### PR TITLE
Remove SDL image usage as well make zlib as a part of application

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,22 +39,17 @@ install:
   - cd %TEMP%
   # Download SDL
   - appveyor DownloadFile https://www.libsdl.org/release/SDL-devel-1.2.15-VC.zip
-  - appveyor DownloadFile https://www.libsdl.org/projects/SDL_image/release/SDL_image-devel-1.2.12-VC.zip
   - appveyor DownloadFile https://www.libsdl.org/projects/SDL_mixer/release/SDL_mixer-devel-1.2.12-VC.zip
   # Extract files
   - 7z x SDL-devel-1.2.15-VC.zip > nul
-  - 7z x SDL_image-devel-1.2.12-VC.zip > nul
   - 7z x SDL_mixer-devel-1.2.12-VC.zip > nul
   # Set up includes
   - copy SDL-1.2.15\include\* %SDL_INCLUDE% > nul
-  - copy SDL_image-1.2.12\include\* %SDL_INCLUDE% > nul
   - copy SDL_mixer-1.2.12\include\* %SDL_INCLUDE% > nul
   # Set up libs
   - copy SDL-1.2.15\lib\x86\* %SDL_LIB_X86% > nul
-  - copy SDL_image-1.2.12\lib\x86\* %SDL_LIB_X86% > nul
   - copy SDL_mixer-1.2.12\lib\x86\* %SDL_LIB_X86% > nul
   - copy SDL-1.2.15\lib\x64\* %SDL_LIB_X64% > nul
-  - copy SDL_image-1.2.12\lib\x64\* %SDL_LIB_X64% > nul
   - copy SDL_mixer-1.2.12\lib\x64\* %SDL_LIB_X64% > nul
     # Download zlib
 #  - appveyor DownloadFile http://zlib.net/zlib128-dll.zip

--- a/fheroes2.vcxproj
+++ b/fheroes2.vcxproj
@@ -78,7 +78,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>../sdl/lib/x86/;../zlib/lib/x86/;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>zlib.lib;SDL.lib;SDL_mixer.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>zlibstatic.lib;SDL.lib;SDL_mixer.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
@@ -93,7 +93,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>../sdl/lib/x64/;../zlib/lib/x64/;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>zlib.lib;SDL.lib;SDL_mixer.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>zlibstatic.lib;SDL.lib;SDL_mixer.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
@@ -111,7 +111,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>../sdl/lib/x86/;../zlib/lib/x86/;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>zlib.lib;SDL.lib;SDL_mixer.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>zlibstatic.lib;SDL.lib;SDL_mixer.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -128,7 +128,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>../sdl/lib/x64/;../zlib/lib/x64/;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>zlib.lib;SDL.lib;SDL_mixer.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>zlibstatic.lib;SDL.lib;SDL_mixer.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
then we don't need zlib dynamic library for Windows