### PR TITLE
Fix number of monsters being displayed in black box

### DIFF
--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -179,8 +179,7 @@ void ArmyBar::RedrawItem(ArmyTroop & troop, const Rect & pos, bool selected, Sur
 	    spmonh.Blit(pos.x + spmonh.x(), pos.y + spmonh.y(), dstsf);
 	}
 
-	if(! use_mini_sprite)
-	{
+    if (use_mini_sprite) {
 	    Surface black(Size(text.w() + 4, text.h()), false);
 	    black.Fill(ColorBlack);
 	    const Point pt(pos.x + pos.w - black.w() - 1, pos.y + pos.h - black.h() - 1);


### PR DESCRIPTION
relates to #15 

![creature_count_fixed](https://user-images.githubusercontent.com/19829520/64613496-d6cb8600-d408-11e9-9ae6-6526e3bacb87.png)
