### PR TITLE
Mask the tavern tile in Necromancer's castle

### DIFF
--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -142,6 +142,13 @@ int Castle::DialogBuyCastle(bool buttons) const
     return info.DialogBuyBuilding(buttons) ? Dialog::OK : Dialog::CANCEL;
 }
 
+static void MaskTavernTile(Point dst_pt, const Point& cur_pt) {
+	dst_pt.x = cur_pt.x + 149;
+	dst_pt.y = cur_pt.y + 157;
+	const Rect buildingMask(dst_pt, 144, 75);
+	AGG::GetICN(ICN::STONEBAK, 0).Blit(buildingMask, dst_pt);
+}
+
 u32 Castle::OpenTown(void)
 {
     Display & display = Display::Get();
@@ -221,10 +228,7 @@ u32 Castle::OpenTown(void)
         buildingTavern.SetPos(cur_pt.x + 149, cur_pt.y + 157);
         buildingTavern.Redraw();
     } else {
-        dst_pt.x = cur_pt.x + 149;
-        dst_pt.y = cur_pt.y + 157;
-        const Rect buildingMask(dst_pt, 144, 75);
-        AGG::GetICN(ICN::STONEBAK, 0).Blit(buildingMask, dst_pt);
+		MaskTavernTile(dst_pt, cur_pt);
     }
 
     // thieves guild

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -23,20 +23,20 @@
 #include <string>
 #include <vector>
 #include "agg.h"
-#include "world.h"
-#include "button.h"
-#include "cursor.h"
-#include "settings.h"
-#include "castle.h"
-#include "dialog.h"
-#include "heroes.h"
-#include "text.h"
-#include "race.h"
-#include "game.h"
-#include "statusbar.h"
-#include "payment.h"
 #include "buildinginfo.h"
+#include "button.h"
+#include "castle.h"
+#include "cursor.h"
+#include "dialog.h"
+#include "game.h"
+#include "heroes.h"
 #include "kingdom.h"
+#include "payment.h"
+#include "race.h"
+#include "settings.h"
+#include "statusbar.h"
+#include "text.h"
+#include "world.h"
 
 int Castle::DialogBuyHero(const Heroes* hero)
 {
@@ -142,11 +142,298 @@ int Castle::DialogBuyCastle(bool buttons) const
     return info.DialogBuyBuilding(buttons) ? Dialog::OK : Dialog::CANCEL;
 }
 
-static void MaskTavernTile(Point dst_pt, const Point& cur_pt) {
+static void MaskTavernTile(Point dst_pt, const Point &cur_pt) {
 	dst_pt.x = cur_pt.x + 149;
 	dst_pt.y = cur_pt.y + 157;
 	const Rect buildingMask(dst_pt, 144, 75);
 	AGG::GetICN(ICN::STONEBAK, 0).Blit(buildingMask, dst_pt);
+}
+
+static BuildingInfo DrawDwelling1(const Castle &ref, const Point &cur_pt) {
+	BuildingInfo dwelling1(ref, DWELLING_MONSTER1);
+	dwelling1.SetPos(cur_pt.x + 5, cur_pt.y + 2);
+	dwelling1.Redraw();
+	return dwelling1;
+}
+
+static BuildingInfo DrawDwelling2(const Castle &ref, const Point &cur_pt) {
+	BuildingInfo dwelling2(ref, DWELLING_MONSTER2);
+	dwelling2.SetPos(cur_pt.x + 149, cur_pt.y + 2);
+	dwelling2.Redraw();
+	return dwelling2;
+}
+
+static BuildingInfo DrawDwelling3(const Castle &ref, const Point &cur_pt) {
+	BuildingInfo dwelling3(ref, DWELLING_MONSTER3);
+	dwelling3.SetPos(cur_pt.x + 293, cur_pt.y + 2);
+	dwelling3.Redraw();
+	return dwelling3;
+}
+
+static BuildingInfo DrawDwelling4(const Castle &ref, const Point &cur_pt) {
+	BuildingInfo dwelling4(ref, DWELLING_MONSTER4);
+	dwelling4.SetPos(cur_pt.x + 5, cur_pt.y + 77);
+	dwelling4.Redraw();
+	return dwelling4;
+}
+
+static BuildingInfo DrawDwelling5(const Castle &ref, const Point &cur_pt) {
+	BuildingInfo dwelling5(ref, DWELLING_MONSTER5);
+	dwelling5.SetPos(cur_pt.x + 149, cur_pt.y + 77);
+	dwelling5.Redraw();
+	return dwelling5;
+}
+
+static BuildingInfo DrawDwelling6(const Castle &ref, const Point &cur_pt) {
+	BuildingInfo dwelling6(ref, DWELLING_MONSTER6);
+	dwelling6.SetPos(cur_pt.x + 293, cur_pt.y + 77);
+	dwelling6.Redraw();
+	return dwelling6;
+}
+
+static BuildingInfo DrawMageGuild(const Castle &ref, const Point &cur_pt) {
+	building_t level = BUILD_NOTHING;
+	switch (ref.GetLevelMageGuild()) {
+	case 0:
+		level = BUILD_MAGEGUILD1;
+		break;
+	case 1:
+		level = BUILD_MAGEGUILD2;
+		break;
+	case 2:
+		level = BUILD_MAGEGUILD3;
+		break;
+	case 3:
+		level = BUILD_MAGEGUILD4;
+		break;
+	default:
+		level = BUILD_MAGEGUILD5;
+		break;
+	}
+	BuildingInfo buildingMageGuild(ref, level);
+	buildingMageGuild.SetPos(cur_pt.x + 5, cur_pt.y + 157);
+	buildingMageGuild.Redraw();
+	return buildingMageGuild;
+}
+
+static BuildingInfo DrawTavern(const Castle &ref, const Point &cur_pt, const Point &dst_pt) {
+	BuildingInfo buildingTavern(ref, BUILD_TAVERN);
+	if (ref.GetRace() != Race::NECR) {
+		buildingTavern.SetPos(cur_pt.x + 149, cur_pt.y + 157);
+		buildingTavern.Redraw();
+	} else {
+		MaskTavernTile(dst_pt, cur_pt);
+	}
+	return buildingTavern;
+}
+
+static BuildingInfo DrawThievesGuild(const Castle &ref, const Point &cur_pt) {
+	BuildingInfo buildingThievesGuild(ref, BUILD_THIEVESGUILD);
+	buildingThievesGuild.SetPos(cur_pt.x + 293, cur_pt.y + 157);
+	buildingThievesGuild.Redraw();
+	return buildingThievesGuild;
+}
+
+static BuildingInfo DrawShipyard(const Castle &ref, const Point &cur_pt) {
+	BuildingInfo buildingShipyard(ref, BUILD_SHIPYARD);
+	buildingShipyard.SetPos(cur_pt.x + 5, cur_pt.y + 232);
+	buildingShipyard.Redraw();
+	return buildingShipyard;
+}
+
+static BuildingInfo DrawStatue(const Castle &ref, const Point &cur_pt) {
+	BuildingInfo buildingStatue(ref, BUILD_STATUE);
+	buildingStatue.SetPos(cur_pt.x + 149, cur_pt.y + 232);
+	buildingStatue.Redraw();
+	return buildingStatue;
+}
+
+static BuildingInfo DrawMarketplace(const Castle &ref, const Point &cur_pt) {
+	BuildingInfo buildingMarketplace(ref, BUILD_MARKETPLACE);
+	buildingMarketplace.SetPos(cur_pt.x + 293, cur_pt.y + 232);
+	buildingMarketplace.Redraw();
+	return buildingMarketplace;
+}
+
+static BuildingInfo DrawWell(const Castle &ref, const Point &cur_pt) {
+	BuildingInfo buildingWell(ref, BUILD_WELL);
+	buildingWell.SetPos(cur_pt.x + 5, cur_pt.y + 307);
+	buildingWell.Redraw();
+	return buildingWell;
+}
+
+static BuildingInfo DrawWel2(const Castle &ref, const Point &cur_pt) {
+	BuildingInfo buildingWel2(ref, BUILD_WEL2);
+	buildingWel2.SetPos(cur_pt.x + 149, cur_pt.y + 307);
+	buildingWel2.Redraw();
+	return buildingWel2;
+}
+
+static BuildingInfo DrawSpec(const Castle &ref, const Point &cur_pt) {
+	BuildingInfo buildingSpec(ref, BUILD_SPEC);
+	buildingSpec.SetPos(cur_pt.x + 293, cur_pt.y + 307);
+	buildingSpec.Redraw();
+	return buildingSpec;
+}
+
+static BuildingInfo DrawLeftTurret(const Castle &ref, const Point &cur_pt) {
+	BuildingInfo buildingLTurret(ref, BUILD_LEFTTURRET);
+	buildingLTurret.SetPos(cur_pt.x + 5, cur_pt.y + 387);
+	buildingLTurret.Redraw();
+	return buildingLTurret;
+}
+
+static BuildingInfo DrawRightTurret(const Castle &ref, const Point &cur_pt) {
+	BuildingInfo buildingRTurret(ref, BUILD_RIGHTTURRET);
+	buildingRTurret.SetPos(cur_pt.x + 149, cur_pt.y + 387);
+	buildingRTurret.Redraw();
+	return buildingRTurret;
+}
+
+static BuildingInfo DrawMoat(const Castle &ref, const Point &cur_pt) {
+	BuildingInfo buildingMoat(ref, BUILD_MOAT);
+	buildingMoat.SetPos(cur_pt.x + 293, cur_pt.y + 387);
+	buildingMoat.Redraw();
+	return buildingMoat;
+}
+
+static BuildingInfo DrawCaptain(const Castle &ref, const Point &cur_pt) {
+	BuildingInfo buildingCaptain(ref, BUILD_CAPTAIN);
+	buildingCaptain.SetPos(cur_pt.x + 444, cur_pt.y + 165);
+	buildingCaptain.Redraw();
+	return buildingCaptain;
+}
+
+static void DrawCombatInfo(const Castle &ref,
+                           const Point& cur_pt,
+						   Point dst_pt,
+						   Text text,
+						   const Sprite& spriteSpreadArmyFormat,
+						   const Sprite& spriteGroupedArmyFormat,
+						   const Rect rectSpreadArmyFormat,
+						   const Rect rectGroupedArmyFormat,
+						   const Point pointSpreadArmyFormat,
+						   const Point pointGroupedArmyFormat,
+						   SpriteMove cursorFormat) {
+	text.Set(_("Attack Skill")+ std::string(" "), Font::SMALL);
+	dst_pt.x = cur_pt.x + 535;
+	dst_pt.y = cur_pt.y + 168;
+	text.Blit(dst_pt);
+	text.Set(GetString(ref.GetCaptain().GetAttack()));
+	dst_pt.x += 90;
+	text.Blit(dst_pt);
+	text.Set(_("Defense Skill")+ std::string(" "));
+	dst_pt.x = cur_pt.x + 535;
+	dst_pt.y += 12;
+	text.Blit(dst_pt);
+	text.Set(GetString(ref.GetCaptain().GetDefense()));
+	dst_pt.x += 90;
+	text.Blit(dst_pt);
+	text.Set(_("Spell Power")+ std::string(" "));
+	dst_pt.x = cur_pt.x + 535;
+	dst_pt.y += 12;
+	text.Blit(dst_pt);
+	text.Set(GetString(ref.GetCaptain().GetPower()));
+	dst_pt.x += 90;
+	text.Blit(dst_pt);
+	text.Set(_("Knowledge")+ std::string(" "));
+	dst_pt.x = cur_pt.x + 535;
+	dst_pt.y += 12;
+	text.Blit(dst_pt);
+	text.Set(GetString(ref.GetCaptain().GetKnowledge()));
+	dst_pt.x += 90;
+	text.Blit(dst_pt);
+	spriteSpreadArmyFormat.Blit(rectSpreadArmyFormat.x, rectSpreadArmyFormat.y);
+	spriteGroupedArmyFormat.Blit(rectGroupedArmyFormat.x,
+			rectGroupedArmyFormat.y);
+	cursorFormat.Move(
+			ref.GetArmy().isSpreadFormat() ?
+					pointSpreadArmyFormat : pointGroupedArmyFormat);
+}
+
+static void ManageStatusInfo(const Castle &ref, const BuildingInfo& dwelling1,
+		const BuildingInfo& dwelling2, const BuildingInfo& dwelling3,
+		const BuildingInfo& dwelling4, const BuildingInfo& dwelling5,
+		const BuildingInfo& dwelling6, const BuildingInfo& buildingMageGuild,
+		const BuildingInfo& buildingTavern,
+		const BuildingInfo& buildingThievesGuild,
+		const BuildingInfo& buildingShipyard,
+		const BuildingInfo& buildingStatue,
+		const BuildingInfo& buildingMarketplace,
+		const BuildingInfo& buildingWell, const BuildingInfo& buildingWel2,
+		const BuildingInfo& buildingSpec, const BuildingInfo& buildingLTurret,
+		const BuildingInfo& buildingRTurret, const BuildingInfo& buildingMoat,
+		const BuildingInfo& buildingCaptain, const Rect& rectHero1,
+		const bool allow_buy_hero1, const std::string& not_allow1_msg,
+		const Rect& rectHero2, const bool allow_buy_hero2,
+		const std::string& not_allow2_msg, const Rect& rectSpreadArmyFormat,
+		const Rect& rectGroupedArmyFormat, LocalEvent& le, StatusBar& statusBar,
+		Heroes* hero1, Heroes* hero2) {
+	// status info
+	if (le.MouseCursor(dwelling1.GetArea()))
+		dwelling1.SetStatusMessage(statusBar);
+	else if (le.MouseCursor(dwelling2.GetArea()))
+		dwelling2.SetStatusMessage(statusBar);
+	else if (le.MouseCursor(dwelling3.GetArea()))
+		dwelling3.SetStatusMessage(statusBar);
+	else if (le.MouseCursor(dwelling4.GetArea()))
+		dwelling4.SetStatusMessage(statusBar);
+	else if (le.MouseCursor(dwelling5.GetArea()))
+		dwelling5.SetStatusMessage(statusBar);
+	else if (le.MouseCursor(dwelling6.GetArea()))
+		dwelling6.SetStatusMessage(statusBar);
+	else if (le.MouseCursor(buildingMageGuild.GetArea()))
+		buildingMageGuild.SetStatusMessage(statusBar);
+	else if ((ref.GetRace() != Race::NECR)
+			&& le.MouseCursor(buildingTavern.GetArea()))
+		buildingTavern.SetStatusMessage(statusBar);
+	else if (le.MouseCursor(buildingThievesGuild.GetArea()))
+		buildingThievesGuild.SetStatusMessage(statusBar);
+	else if (le.MouseCursor(buildingShipyard.GetArea()))
+		buildingShipyard.SetStatusMessage(statusBar);
+	else if (le.MouseCursor(buildingStatue.GetArea()))
+		buildingStatue.SetStatusMessage(statusBar);
+	else if (le.MouseCursor(buildingMarketplace.GetArea()))
+		buildingMarketplace.SetStatusMessage(statusBar);
+	else if (le.MouseCursor(buildingWell.GetArea()))
+		buildingWell.SetStatusMessage(statusBar);
+	else if (le.MouseCursor(buildingWel2.GetArea()))
+		buildingWel2.SetStatusMessage(statusBar);
+	else if (le.MouseCursor(buildingSpec.GetArea()))
+		buildingSpec.SetStatusMessage(statusBar);
+	else if (le.MouseCursor(buildingLTurret.GetArea()))
+		buildingLTurret.SetStatusMessage(statusBar);
+	else if (le.MouseCursor(buildingRTurret.GetArea()))
+		buildingRTurret.SetStatusMessage(statusBar);
+	else if (le.MouseCursor(buildingMoat.GetArea()))
+		buildingMoat.SetStatusMessage(statusBar);
+	else if (le.MouseCursor(buildingCaptain.GetArea()))
+		buildingCaptain.SetStatusMessage(statusBar);
+	else if (hero1 && le.MouseCursor(rectHero1)) {
+		if (!allow_buy_hero1) {
+			statusBar.ShowMessage(not_allow1_msg);
+		} else {
+			std::string str = _("Recruit %{name} the %{race}");
+			StringReplace(str, "%{name}", hero1->GetName());
+			StringReplace(str, "%{race}", Race::String(hero1->GetRace()));
+			statusBar.ShowMessage(str);
+		}
+	} else if (hero2 && le.MouseCursor(rectHero2)) {
+		if (!allow_buy_hero2)
+			statusBar.ShowMessage(not_allow2_msg);
+		else {
+			std::string str = _("Recruit %{name} the %{race}");
+			StringReplace(str, "%{name}", hero2->GetName());
+			StringReplace(str, "%{race}", Race::String(hero2->GetRace()));
+			statusBar.ShowMessage(str);
+		}
+	} else if (le.MouseCursor(rectSpreadArmyFormat))
+		statusBar.ShowMessage(_("Set garrison combat formation to 'Spread'"));
+	else if (le.MouseCursor(rectGroupedArmyFormat))
+		statusBar.ShowMessage(_("Set garrison combat formation to 'Grouped'"));
+	else
+		// clear all
+		statusBar.ShowMessage(_("Castle Options"));
 }
 
 u32 Castle::OpenTown(void)
@@ -160,18 +447,18 @@ u32 Castle::OpenTown(void)
     const Point & cur_pt = background.GetArea();
     Point dst_pt(cur_pt);
 
+    // Display the borders
     AGG::GetICN(ICN::CASLWIND, 0).Blit(dst_pt);
 
     // hide captain options
-    if(!(building & BUILD_CAPTAIN))
-    {
-	dst_pt.x = 530;
-	dst_pt.y = 163;
-	const Rect rect(dst_pt, 110, 84);
-	dst_pt.x += cur_pt.x;
-	dst_pt.y += cur_pt.y;
+    if(!(building & BUILD_CAPTAIN)) {
+        dst_pt.x = 530;
+        dst_pt.y = 163;
+        const Rect rect(dst_pt, 110, 84);
+        dst_pt.x += cur_pt.x;
+        dst_pt.y += cur_pt.y;
 
-	AGG::GetICN(ICN::STONEBAK, 0).Blit(rect, dst_pt);
+        AGG::GetICN(ICN::STONEBAK, 0).Blit(rect, dst_pt);
     }
 
     // draw castle sprite
@@ -183,163 +470,55 @@ u32 Castle::OpenTown(void)
     Text text(GetName(), Font::SMALL);
     text.Blit(cur_pt.x + 536 - text.w() / 2, cur_pt.y + 1);
 
-    //
-    BuildingInfo dwelling1(*this, DWELLING_MONSTER1);
-    dwelling1.SetPos(cur_pt.x + 5, cur_pt.y + 2);
-    dwelling1.Redraw();
-
-    BuildingInfo dwelling2(*this, DWELLING_MONSTER2);
-    dwelling2.SetPos(cur_pt.x + 149, cur_pt.y + 2);
-    dwelling2.Redraw();
-
-    BuildingInfo dwelling3(*this, DWELLING_MONSTER3);
-    dwelling3.SetPos(cur_pt.x + 293, cur_pt.y + 2);
-    dwelling3.Redraw();
-
-    BuildingInfo dwelling4(*this, DWELLING_MONSTER4);
-    dwelling4.SetPos(cur_pt.x + 5, cur_pt.y + 77);
-    dwelling4.Redraw();
-
-    BuildingInfo dwelling5(*this, DWELLING_MONSTER5);
-    dwelling5.SetPos(cur_pt.x + 149, cur_pt.y + 77);
-    dwelling5.Redraw();
-
-    BuildingInfo dwelling6(*this, DWELLING_MONSTER6);
-    dwelling6.SetPos(cur_pt.x + 293, cur_pt.y + 77);
-    dwelling6.Redraw();
-
-    // mage guild
-    building_t level = BUILD_NOTHING;
-    switch(GetLevelMageGuild())
-    {
-	case 0: level = BUILD_MAGEGUILD1; break;
-	case 1: level = BUILD_MAGEGUILD2; break;
-	case 2: level = BUILD_MAGEGUILD3; break;
-	case 3: level = BUILD_MAGEGUILD4; break;
-	default:level = BUILD_MAGEGUILD5; break;
-    }
-    BuildingInfo buildingMageGuild(*this, level);
-    buildingMageGuild.SetPos(cur_pt.x + 5, cur_pt.y + 157);
-    buildingMageGuild.Redraw();
-
-	// tavern
-	BuildingInfo buildingTavern(*this, BUILD_TAVERN);
-    if (GetRace() != Race::NECR) {
-        buildingTavern.SetPos(cur_pt.x + 149, cur_pt.y + 157);
-        buildingTavern.Redraw();
-    } else {
-		MaskTavernTile(dst_pt, cur_pt);
-    }
-
-    // thieves guild
-    BuildingInfo buildingThievesGuild(*this, BUILD_THIEVESGUILD);
-    buildingThievesGuild.SetPos(cur_pt.x + 293, cur_pt.y + 157);
-    buildingThievesGuild.Redraw();
-
-    // shipyard
-    BuildingInfo buildingShipyard(*this, BUILD_SHIPYARD);
-    buildingShipyard.SetPos(cur_pt.x + 5, cur_pt.y + 232);
-    buildingShipyard.Redraw();
-
-    // statue
-    BuildingInfo buildingStatue(*this, BUILD_STATUE);
-    buildingStatue.SetPos(cur_pt.x + 149, cur_pt.y + 232);
-    buildingStatue.Redraw();
-
-    // marketplace
-    BuildingInfo buildingMarketplace(*this, BUILD_MARKETPLACE);
-    buildingMarketplace.SetPos(cur_pt.x + 293, cur_pt.y + 232);
-    buildingMarketplace.Redraw();
-
-    // well
-    BuildingInfo buildingWell(*this, BUILD_WELL);
-    buildingWell.SetPos(cur_pt.x + 5, cur_pt.y + 307);
-    buildingWell.Redraw();
-
-    // wel2
-    BuildingInfo buildingWel2(*this, BUILD_WEL2);
-    buildingWel2.SetPos(cur_pt.x + 149, cur_pt.y + 307);
-    buildingWel2.Redraw();
-
-    // spec
-    BuildingInfo buildingSpec(*this, BUILD_SPEC);
-    buildingSpec.SetPos(cur_pt.x + 293, cur_pt.y + 307);
-    buildingSpec.Redraw();
-
-    // left turret
-    BuildingInfo buildingLTurret(*this, BUILD_LEFTTURRET);
-    buildingLTurret.SetPos(cur_pt.x + 5, cur_pt.y + 387);
-    buildingLTurret.Redraw();
-
-    // right turret
-    BuildingInfo buildingRTurret(*this, BUILD_RIGHTTURRET);
-    buildingRTurret.SetPos(cur_pt.x + 149, cur_pt.y + 387);
-    buildingRTurret.Redraw();
-
-    // moat
-    BuildingInfo buildingMoat(*this, BUILD_MOAT);
-    buildingMoat.SetPos(cur_pt.x + 293, cur_pt.y + 387);
-    buildingMoat.Redraw();
-
-    // captain
-    BuildingInfo buildingCaptain(*this, BUILD_CAPTAIN);
-    buildingCaptain.SetPos(cur_pt.x + 444, cur_pt.y + 165);
-    buildingCaptain.Redraw();
+	BuildingInfo dwelling1 = DrawDwelling1(*this, cur_pt);
+	BuildingInfo dwelling2 = DrawDwelling2(*this, cur_pt);
+	BuildingInfo dwelling3 = DrawDwelling3(*this, cur_pt);
+	BuildingInfo dwelling4 = DrawDwelling4(*this, cur_pt);
+	BuildingInfo dwelling5 = DrawDwelling5(*this, cur_pt);
+	BuildingInfo dwelling6 = DrawDwelling6(*this, cur_pt);
+	BuildingInfo buildingMageGuild = DrawMageGuild(*this, cur_pt);
+	BuildingInfo buildingTavern = DrawTavern(*this, cur_pt, dst_pt);
+	BuildingInfo buildingThievesGuild = DrawThievesGuild(*this, cur_pt);
+	BuildingInfo buildingShipyard = DrawShipyard(*this, cur_pt);
+	BuildingInfo buildingStatue = DrawStatue(*this, cur_pt);
+	BuildingInfo buildingMarketplace = DrawMarketplace(*this, cur_pt);
+	BuildingInfo buildingWell = DrawWell(*this, cur_pt);
+	BuildingInfo buildingWel2 = DrawWel2(*this, cur_pt);
+	BuildingInfo buildingSpec = DrawSpec(*this, cur_pt);
+	BuildingInfo buildingLTurret = DrawLeftTurret(*this, cur_pt);
+	BuildingInfo buildingRTurret = DrawRightTurret(*this, cur_pt);
+	BuildingInfo buildingMoat = DrawMoat(*this, cur_pt);
+	BuildingInfo buildingCaptain = DrawCaptain(*this, cur_pt);
 
     // combat format
-    const Sprite & spriteSpreadArmyFormat = AGG::GetICN(ICN::HSICONS, 9);
-    const Sprite & spriteGroupedArmyFormat = AGG::GetICN(ICN::HSICONS, 10);
-    const Rect rectSpreadArmyFormat(cur_pt.x + 550, cur_pt.y + 220, spriteSpreadArmyFormat.w(), spriteSpreadArmyFormat.h());
-    const Rect rectGroupedArmyFormat(cur_pt.x + 585, cur_pt.y + 220, spriteGroupedArmyFormat.w(), spriteGroupedArmyFormat.h());
-    const std::string descriptionSpreadArmyFormat(_("'Spread' combat formation spreads your armies from the top to the bottom of the battlefield, with at least one empty space between each army."));
-    const std::string descriptionGroupedArmyFormat(_("'Grouped' combat formation bunches your army toget her in the center of your side of the battlefield."));
-    const Point pointSpreadArmyFormat(rectSpreadArmyFormat.x - 1, rectSpreadArmyFormat.y - 1);
-    const Point pointGroupedArmyFormat(rectGroupedArmyFormat.x - 1, rectGroupedArmyFormat.y - 1);
+	const Sprite& spriteSpreadArmyFormat = AGG::GetICN(ICN::HSICONS, 9);
+	const Sprite& spriteGroupedArmyFormat = AGG::GetICN(ICN::HSICONS, 10);
+	const Rect rectSpreadArmyFormat(cur_pt.x + 550, cur_pt.y + 220,
+			spriteSpreadArmyFormat.w(), spriteSpreadArmyFormat.h());
+	const Rect rectGroupedArmyFormat(cur_pt.x + 585, cur_pt.y + 220,
+			spriteGroupedArmyFormat.w(), spriteGroupedArmyFormat.h());
+	const std::string descriptionSpreadArmyFormat(
+			_("'Spread' combat formation spreads your armies from the top to the bottom of the battlefield, with at least one empty space between each army."));
+	const std::string descriptionGroupedArmyFormat(
+			_("'Grouped' combat formation bunches your army toget her in the center of your side of the battlefield."));
+	const Point pointSpreadArmyFormat(rectSpreadArmyFormat.x - 1,
+                                      rectSpreadArmyFormat.y - 1);
+	const Point pointGroupedArmyFormat(rectGroupedArmyFormat.x - 1,
+                                       rectGroupedArmyFormat.y - 1);
+	SpriteMove cursorFormat(AGG::GetICN(ICN::HSICONS, 11));
 
-    SpriteMove cursorFormat(AGG::GetICN(ICN::HSICONS, 11));
-
-    if(isBuild(BUILD_CAPTAIN))
-    {
-	text.Set(_("Attack Skill") + std::string(" "), Font::SMALL);
-	dst_pt.x = cur_pt.x + 535;
-	dst_pt.y = cur_pt.y + 168;
-	text.Blit(dst_pt);
-
-	text.Set(GetString(captain.GetAttack()));
-	dst_pt.x += 90;
-	text.Blit(dst_pt);
-
-	text.Set(_("Defense Skill") + std::string(" "));
-	dst_pt.x = cur_pt.x + 535;
-	dst_pt.y += 12;
-	text.Blit(dst_pt);
-
-	text.Set(GetString(captain.GetDefense()));
-	dst_pt.x += 90;
-	text.Blit(dst_pt);
-
-	text.Set(_("Spell Power") + std::string(" "));
-	dst_pt.x = cur_pt.x + 535;
-	dst_pt.y += 12;
-	text.Blit(dst_pt);
-
-	text.Set(GetString(captain.GetPower()));
-	dst_pt.x += 90;
-	text.Blit(dst_pt);
-
-	text.Set(_("Knowledge") + std::string(" "));
-	dst_pt.x = cur_pt.x + 535;
-	dst_pt.y += 12;
-	text.Blit(dst_pt);
-
-	text.Set(GetString(captain.GetKnowledge()));
-	dst_pt.x += 90;
-	text.Blit(dst_pt);
-
-	spriteSpreadArmyFormat.Blit(rectSpreadArmyFormat.x, rectSpreadArmyFormat.y);
-	spriteGroupedArmyFormat.Blit(rectGroupedArmyFormat.x, rectGroupedArmyFormat.y);
-
-	cursorFormat.Move(army.isSpreadFormat() ? pointSpreadArmyFormat : pointGroupedArmyFormat);
+    if(isBuild(BUILD_CAPTAIN)) {
+		DrawCombatInfo(*this,
+						cur_pt,
+						dst_pt,
+						text,
+						spriteSpreadArmyFormat,
+						spriteGroupedArmyFormat,
+						rectSpreadArmyFormat,
+						rectGroupedArmyFormat,
+						pointSpreadArmyFormat,
+						pointGroupedArmyFormat,
+						cursorFormat);
     }
 
     Kingdom & kingdom = GetKingdom();
@@ -355,36 +534,34 @@ u32 Castle::OpenTown(void)
     dst_pt.x = cur_pt.x + 443;
     dst_pt.y = cur_pt.y + 260;
     const Rect rectHero1(dst_pt, 102, 93);
-    if(hero1)
-    {
-	hero1->PortraitRedraw(dst_pt.x, dst_pt.y, PORT_BIG, display);
+    if(hero1) {
+        hero1->PortraitRedraw(dst_pt.x, dst_pt.y, PORT_BIG, display);
+    } else {
+        display.FillRect(rectHero1, ColorBlack);
     }
-    else
-	display.FillRect(rectHero1, ColorBlack);
+
     // indicator
-    if(!allow_buy_hero1)
-    {
-	dst_pt.x += 83;
-	dst_pt.y += 75;
-	AGG::GetICN(ICN::TOWNWIND, 12).Blit(dst_pt);
+    if(!allow_buy_hero1) {
+        dst_pt.x += 83;
+        dst_pt.y += 75;
+        AGG::GetICN(ICN::TOWNWIND, 12).Blit(dst_pt);
     }
 
     // second hero
     dst_pt.x = cur_pt.x + 443;
     dst_pt.y = cur_pt.y + 362;
     const Rect rectHero2(dst_pt, 102, 94);
-    if(hero2)
-    {
-	hero2->PortraitRedraw(dst_pt.x, dst_pt.y, PORT_BIG, display);
+    if(hero2) {
+        hero2->PortraitRedraw(dst_pt.x, dst_pt.y, PORT_BIG, display);
+    } else {
+        display.FillRect(rectHero2, ColorBlack);
     }
-    else
-	display.FillRect(rectHero2, ColorBlack);
+
     // indicator
-    if(!allow_buy_hero2)
-    {
-	dst_pt.x += 83;
-	dst_pt.y += 75;
-	AGG::GetICN(ICN::TOWNWIND, 12).Blit(dst_pt);
+    if(!allow_buy_hero2) {
+        dst_pt.x += 83;
+        dst_pt.y += 75;
+        AGG::GetICN(ICN::TOWNWIND, 12).Blit(dst_pt);
     }
 
     // bottom bar
@@ -418,7 +595,7 @@ u32 Castle::OpenTown(void)
 
         if(le.MouseClickLeft(buttonExit) || HotKeyCloseWindow) break;
 
-	// click left
+        // click left
         if(le.MouseCursor(dwelling1.GetArea()) && dwelling1.QueueEventProcessing()) return dwelling1();
         else
         if(le.MouseCursor(dwelling2.GetArea()) && dwelling2.QueueEventProcessing()) return dwelling2();
@@ -430,152 +607,83 @@ u32 Castle::OpenTown(void)
         if(le.MouseCursor(dwelling5.GetArea()) && dwelling5.QueueEventProcessing()) return dwelling5();
         else
         if(le.MouseCursor(dwelling6.GetArea()) && dwelling6.QueueEventProcessing()) return dwelling6();
-	else
+        else
         if(le.MouseCursor(buildingMageGuild.GetArea()) && buildingMageGuild.QueueEventProcessing()) return buildingMageGuild();
-	else
+        else
         if(le.MouseCursor(buildingTavern.GetArea()) && buildingTavern.QueueEventProcessing()) return (Race::NECR == race  ? BUILD_SHRINE : BUILD_TAVERN);
-	else
+        else
         if((GetRace() != Race::NECR) && le.MouseCursor(buildingThievesGuild.GetArea()) && buildingThievesGuild.QueueEventProcessing()) return BUILD_THIEVESGUILD;
-	else
+        else
         if(le.MouseCursor(buildingShipyard.GetArea()) && buildingShipyard.QueueEventProcessing()) return BUILD_SHIPYARD;
-	else
+        else
         if(le.MouseCursor(buildingStatue.GetArea()) && buildingStatue.QueueEventProcessing()) return BUILD_STATUE;
-	else
+        else
         if(le.MouseCursor(buildingMarketplace.GetArea()) && buildingMarketplace.QueueEventProcessing()) return BUILD_MARKETPLACE;
-	else
+        else
         if(le.MouseCursor(buildingWell.GetArea()) && buildingWell.QueueEventProcessing()) return BUILD_WELL;
-	else
+        else
         if(le.MouseCursor(buildingWel2.GetArea()) && buildingWel2.QueueEventProcessing()) return BUILD_WEL2;
-	else
+        else
         if(le.MouseCursor(buildingSpec.GetArea()) && buildingSpec.QueueEventProcessing()) return BUILD_SPEC;
-	else
+        else
         if(le.MouseCursor(buildingLTurret.GetArea()) && buildingLTurret.QueueEventProcessing()) return BUILD_LEFTTURRET;
-	else
+        else
         if(le.MouseCursor(buildingRTurret.GetArea()) && buildingRTurret.QueueEventProcessing()) return BUILD_RIGHTTURRET;
-	else
+        else
         if(le.MouseCursor(buildingMoat.GetArea()) && buildingMoat.QueueEventProcessing()) return BUILD_MOAT;
-	else
-	if(le.MouseCursor(buildingCaptain.GetArea()) && buildingCaptain.QueueEventProcessing()) return BUILD_CAPTAIN;
-	else
-	if(hero1 && le.MouseClickLeft(rectHero1) &&
-	    Dialog::OK == DialogBuyHero(hero1))
-        {
+        else
+        if(le.MouseCursor(buildingCaptain.GetArea()) && buildingCaptain.QueueEventProcessing()) return BUILD_CAPTAIN;
+        else
+        if(hero1 && le.MouseClickLeft(rectHero1) &&
+	    Dialog::OK == DialogBuyHero(hero1)) {
     	    RecruitHero(hero1);
 
     	    return BUILD_NOTHING;
-        }
-	else
-	if(hero2 && le.MouseClickLeft(rectHero2) &&
-	    Dialog::OK == DialogBuyHero(hero2))
-        {
-	    RecruitHero(hero2);
+        } else if(hero2 && le.MouseClickLeft(rectHero2) &&
+	    Dialog::OK == DialogBuyHero(hero2)) {
+    	    RecruitHero(hero2);
 
-	    return BUILD_NOTHING;
+    	    return BUILD_NOTHING;
+        } else if(isBuild(BUILD_CAPTAIN)) {
+            if(le.MouseClickLeft(rectSpreadArmyFormat) && ! army.isSpreadFormat()) {
+                cursor.Hide();
+                cursorFormat.Move(pointSpreadArmyFormat);
+                cursor.Show();
+                display.Flip();
+                army.SetSpreadFormat(true);
+    	    } else if(le.MouseClickLeft(rectGroupedArmyFormat) && army.isSpreadFormat()) {
+                cursor.Hide();
+                cursorFormat.Move(pointGroupedArmyFormat);
+                cursor.Show();
+                display.Flip();
+                army.SetSpreadFormat(false);
+    	    }
         }
-	else
-	if(isBuild(BUILD_CAPTAIN))
-	{
-	    if(le.MouseClickLeft(rectSpreadArmyFormat) && ! army.isSpreadFormat())
-    	    {
-        	cursor.Hide();
-        	cursorFormat.Move(pointSpreadArmyFormat);
-        	cursor.Show();
-        	display.Flip();
-        	army.SetSpreadFormat(true);
-    	    }
-	    else
-    	    if(le.MouseClickLeft(rectGroupedArmyFormat) && army.isSpreadFormat())
-    	    {
-        	cursor.Hide();
-        	cursorFormat.Move(pointGroupedArmyFormat);
-        	cursor.Show();
-        	display.Flip();
-        	army.SetSpreadFormat(false);
-    	    }
-	}
 
-	// right
-	if(le.MousePressRight(rectSpreadArmyFormat)) Dialog::Message(_("Spread Formation"), descriptionSpreadArmyFormat, Font::BIG);
-        else
-	if(le.MousePressRight(rectGroupedArmyFormat)) Dialog::Message(_("Grouped Formation"), descriptionGroupedArmyFormat, Font::BIG);
-	else
-	if(hero1 && le.MousePressRight(rectHero1)){ hero1->OpenDialog(true); cursor.Show(); display.Flip(); }
-	else
-	if(hero2 && le.MousePressRight(rectHero2)){ hero2->OpenDialog(true); cursor.Show(); display.Flip(); }
+        // right
+        if(le.MousePressRight(rectSpreadArmyFormat)) {
+            Dialog::Message(_("Spread Formation"), descriptionSpreadArmyFormat, Font::BIG);
+        } else if(le.MousePressRight(rectGroupedArmyFormat)) {
+            Dialog::Message(_("Grouped Formation"), descriptionGroupedArmyFormat, Font::BIG);
+        } else if(hero1 && le.MousePressRight(rectHero1)) {
+            hero1->OpenDialog(true);
+            cursor.Show();
+            display.Flip();
+        } else if(hero2 && le.MousePressRight(rectHero2)) {
+            hero2->OpenDialog(true);
+            cursor.Show();
+            display.Flip();
+        }
 
         // status info
-	if(le.MouseCursor(dwelling1.GetArea())) dwelling1.SetStatusMessage(statusBar);
-	else
-	if(le.MouseCursor(dwelling2.GetArea())) dwelling2.SetStatusMessage(statusBar);
-	else
-	if(le.MouseCursor(dwelling3.GetArea())) dwelling3.SetStatusMessage(statusBar);
-	else
-	if(le.MouseCursor(dwelling4.GetArea())) dwelling4.SetStatusMessage(statusBar);
-	else
-	if(le.MouseCursor(dwelling5.GetArea())) dwelling5.SetStatusMessage(statusBar);
-	else
-	if(le.MouseCursor(dwelling6.GetArea())) dwelling6.SetStatusMessage(statusBar);
-	else
-	if(le.MouseCursor(buildingMageGuild.GetArea())) buildingMageGuild.SetStatusMessage(statusBar);
-	else
-	if((GetRace() != Race::NECR) && le.MouseCursor(buildingTavern.GetArea())) buildingTavern.SetStatusMessage(statusBar);
-	else
-	if(le.MouseCursor(buildingThievesGuild.GetArea())) buildingThievesGuild.SetStatusMessage(statusBar);
-	else
-	if(le.MouseCursor(buildingShipyard.GetArea())) buildingShipyard.SetStatusMessage(statusBar);
-	else
-	if(le.MouseCursor(buildingStatue.GetArea())) buildingStatue.SetStatusMessage(statusBar);
-	else
-	if(le.MouseCursor(buildingMarketplace.GetArea())) buildingMarketplace.SetStatusMessage(statusBar);
-	else
-	if(le.MouseCursor(buildingWell.GetArea())) buildingWell.SetStatusMessage(statusBar);
-	else
-	if(le.MouseCursor(buildingWel2.GetArea())) buildingWel2.SetStatusMessage(statusBar);
-	else
-	if(le.MouseCursor(buildingSpec.GetArea())) buildingSpec.SetStatusMessage(statusBar);
-	else
-	if(le.MouseCursor(buildingLTurret.GetArea())) buildingLTurret.SetStatusMessage(statusBar);
-	else
-	if(le.MouseCursor(buildingRTurret.GetArea())) buildingRTurret.SetStatusMessage(statusBar);
-	else
-	if(le.MouseCursor(buildingMoat.GetArea())) buildingMoat.SetStatusMessage(statusBar);
-	else
-	if(le.MouseCursor(buildingCaptain.GetArea())) buildingCaptain.SetStatusMessage(statusBar);
-	else
-	if(hero1 && le.MouseCursor(rectHero1))
-	{
-	    if(! allow_buy_hero1)
-		statusBar.ShowMessage(not_allow1_msg);
-	    else
-	    {
-		std::string str = _("Recruit %{name} the %{race}");
-		StringReplace(str, "%{name}", hero1->GetName());
-		StringReplace(str, "%{race}", Race::String(hero1->GetRace()));
-	    	statusBar.ShowMessage(str);
-	    }
-	}
-	else
-	if(hero2 && le.MouseCursor(rectHero2))
-	{
-	    if(! allow_buy_hero2)
-		statusBar.ShowMessage(not_allow2_msg);
-	    else
-	    {
-		std::string str = _("Recruit %{name} the %{race}");
-		StringReplace(str, "%{name}", hero2->GetName());
-		StringReplace(str, "%{race}", Race::String(hero2->GetRace()));
-	    	statusBar.ShowMessage(str);
-	    }
-	}
-	else
-	if(le.MouseCursor(rectSpreadArmyFormat))
-	    statusBar.ShowMessage(_("Set garrison combat formation to 'Spread'"));
-	else
-	if(le.MouseCursor(rectGroupedArmyFormat))
-	    statusBar.ShowMessage(_("Set garrison combat formation to 'Grouped'"));
-	else
-	// clear all
-	    statusBar.ShowMessage(_("Castle Options"));
+		ManageStatusInfo(*this, dwelling1, dwelling2, dwelling3, dwelling4, dwelling5,
+				dwelling6, buildingMageGuild, buildingTavern,
+				buildingThievesGuild, buildingShipyard, buildingStatue,
+				buildingMarketplace, buildingWell, buildingWel2, buildingSpec,
+				buildingLTurret, buildingRTurret, buildingMoat, buildingCaptain,
+				rectHero1, allow_buy_hero1, not_allow1_msg, rectHero2,
+				allow_buy_hero2, not_allow2_msg, rectSpreadArmyFormat,
+				rectGroupedArmyFormat, le, statusBar, hero1, hero2);
     }
 
     return BUILD_NOTHING;

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -38,6 +38,311 @@
 #include "text.h"
 #include "world.h"
 
+namespace
+{
+    void MaskTavernTile(Point dst_pt, const Point &cur_pt)
+    {
+        dst_pt.x = cur_pt.x + 149;
+        dst_pt.y = cur_pt.y + 157;
+        const Rect buildingMask(dst_pt, 144, 75);
+        AGG::GetICN(ICN::STONEBAK, 0).Blit(buildingMask, dst_pt);
+    }
+
+    BuildingInfo DrawDwelling1(const Castle &ref, const Point &cur_pt)
+    {
+        BuildingInfo dwelling1(ref, DWELLING_MONSTER1);
+        dwelling1.SetPos(cur_pt.x + 5, cur_pt.y + 2);
+        dwelling1.Redraw();
+        return dwelling1;
+    }
+
+    BuildingInfo DrawDwelling2(const Castle &ref, const Point &cur_pt)
+    {
+        BuildingInfo dwelling2(ref, DWELLING_MONSTER2);
+        dwelling2.SetPos(cur_pt.x + 149, cur_pt.y + 2);
+        dwelling2.Redraw();
+        return dwelling2;
+    }
+
+    BuildingInfo DrawDwelling3(const Castle &ref, const Point &cur_pt)
+    {
+        BuildingInfo dwelling3(ref, DWELLING_MONSTER3);
+        dwelling3.SetPos(cur_pt.x + 293, cur_pt.y + 2);
+        dwelling3.Redraw();
+        return dwelling3;
+    }
+
+    BuildingInfo DrawDwelling4(const Castle &ref, const Point &cur_pt)
+    {
+        BuildingInfo dwelling4(ref, DWELLING_MONSTER4);
+        dwelling4.SetPos(cur_pt.x + 5, cur_pt.y + 77);
+        dwelling4.Redraw();
+        return dwelling4;
+    }
+
+    BuildingInfo DrawDwelling5(const Castle &ref, const Point &cur_pt)
+    {
+        BuildingInfo dwelling5(ref, DWELLING_MONSTER5);
+        dwelling5.SetPos(cur_pt.x + 149, cur_pt.y + 77);
+        dwelling5.Redraw();
+        return dwelling5;
+    }
+
+    BuildingInfo DrawDwelling6(const Castle &ref, const Point &cur_pt)
+    {
+        BuildingInfo dwelling6(ref, DWELLING_MONSTER6);
+        dwelling6.SetPos(cur_pt.x + 293, cur_pt.y + 77);
+        dwelling6.Redraw();
+        return dwelling6;
+    }
+
+    BuildingInfo DrawMageGuild(const Castle &ref, const Point &cur_pt)
+    {
+        building_t level = BUILD_NOTHING;
+        switch (ref.GetLevelMageGuild()) {
+            case 0:
+                level = BUILD_MAGEGUILD1;
+                break;
+            case 1:
+                level = BUILD_MAGEGUILD2;
+                break;
+            case 2:
+                level = BUILD_MAGEGUILD3;
+                break;
+            case 3:
+                level = BUILD_MAGEGUILD4;
+                break;
+            default:
+                level = BUILD_MAGEGUILD5;
+        }
+        BuildingInfo buildingMageGuild(ref, level);
+        buildingMageGuild.SetPos(cur_pt.x + 5, cur_pt.y + 157);
+        buildingMageGuild.Redraw();
+        return buildingMageGuild;
+    }
+
+    BuildingInfo DrawTavern(const Castle &ref, const Point &cur_pt, const Point &dst_pt)
+    {
+        BuildingInfo buildingTavern(ref, BUILD_TAVERN);
+        if (ref.GetRace() != Race::NECR) {
+            buildingTavern.SetPos(cur_pt.x + 149, cur_pt.y + 157);
+            buildingTavern.Redraw();
+        } else {
+            MaskTavernTile(dst_pt, cur_pt);
+        }
+        return buildingTavern;
+    }
+
+    BuildingInfo DrawThievesGuild(const Castle &ref, const Point &cur_pt)
+    {
+        BuildingInfo buildingThievesGuild(ref, BUILD_THIEVESGUILD);
+        buildingThievesGuild.SetPos(cur_pt.x + 293, cur_pt.y + 157);
+        buildingThievesGuild.Redraw();
+        return buildingThievesGuild;
+    }
+
+    BuildingInfo DrawShipyard(const Castle &ref, const Point &cur_pt)
+    {
+        BuildingInfo buildingShipyard(ref, BUILD_SHIPYARD);
+        buildingShipyard.SetPos(cur_pt.x + 5, cur_pt.y + 232);
+        buildingShipyard.Redraw();
+        return buildingShipyard;
+    }
+
+    BuildingInfo DrawStatue(const Castle &ref, const Point &cur_pt)
+    {
+        BuildingInfo buildingStatue(ref, BUILD_STATUE);
+        buildingStatue.SetPos(cur_pt.x + 149, cur_pt.y + 232);
+        buildingStatue.Redraw();
+        return buildingStatue;
+    }
+
+    BuildingInfo DrawMarketplace(const Castle &ref, const Point &cur_pt)
+    {
+        BuildingInfo buildingMarketplace(ref, BUILD_MARKETPLACE);
+        buildingMarketplace.SetPos(cur_pt.x + 293, cur_pt.y + 232);
+        buildingMarketplace.Redraw();
+        return buildingMarketplace;
+    }
+
+    BuildingInfo DrawWell(const Castle &ref, const Point &cur_pt)
+    {
+        BuildingInfo buildingWell(ref, BUILD_WELL);
+        buildingWell.SetPos(cur_pt.x + 5, cur_pt.y + 307);
+        buildingWell.Redraw();
+        return buildingWell;
+    }
+
+    BuildingInfo DrawWel2(const Castle &ref, const Point &cur_pt)
+    {
+        BuildingInfo buildingWel2(ref, BUILD_WEL2);
+        buildingWel2.SetPos(cur_pt.x + 149, cur_pt.y + 307);
+        buildingWel2.Redraw();
+        return buildingWel2;
+    }
+
+    BuildingInfo DrawSpec(const Castle &ref, const Point &cur_pt)
+    {
+        BuildingInfo buildingSpec(ref, BUILD_SPEC);
+        buildingSpec.SetPos(cur_pt.x + 293, cur_pt.y + 307);
+        buildingSpec.Redraw();
+        return buildingSpec;
+    }
+
+    BuildingInfo DrawLeftTurret(const Castle &ref, const Point &cur_pt)
+    {
+        BuildingInfo buildingLTurret(ref, BUILD_LEFTTURRET);
+        buildingLTurret.SetPos(cur_pt.x + 5, cur_pt.y + 387);
+        buildingLTurret.Redraw();
+        return buildingLTurret;
+    }
+
+    BuildingInfo DrawRightTurret(const Castle &ref, const Point &cur_pt)
+    {
+        BuildingInfo buildingRTurret(ref, BUILD_RIGHTTURRET);
+        buildingRTurret.SetPos(cur_pt.x + 149, cur_pt.y + 387);
+        buildingRTurret.Redraw();
+        return buildingRTurret;
+    }
+
+    BuildingInfo DrawMoat(const Castle &ref, const Point &cur_pt)
+    {
+        BuildingInfo buildingMoat(ref, BUILD_MOAT);
+        buildingMoat.SetPos(cur_pt.x + 293, cur_pt.y + 387);
+        buildingMoat.Redraw();
+        return buildingMoat;
+    }
+
+    BuildingInfo DrawCaptain(const Castle &ref, const Point &cur_pt)
+    {
+        BuildingInfo buildingCaptain(ref, BUILD_CAPTAIN);
+        buildingCaptain.SetPos(cur_pt.x + 444, cur_pt.y + 165);
+        buildingCaptain.Redraw();
+        return buildingCaptain;
+    }
+
+    void DrawCombatInfo(const Castle &ref, const Point& cur_pt, Point dst_pt, Text text,
+                        const Sprite& spriteSpreadArmyFormat, const Sprite& spriteGroupedArmyFormat,
+			const Rect rectSpreadArmyFormat, const Rect rectGroupedArmyFormat,
+			const Point pointSpreadArmyFormat, const Point pointGroupedArmyFormat,
+			SpriteMove cursorFormat)
+    {
+        text.Set(_("Attack Skill")+ std::string(" "), Font::SMALL);
+        dst_pt.x = cur_pt.x + 535;
+        dst_pt.y = cur_pt.y + 168;
+        text.Blit(dst_pt);
+        text.Set(GetString(ref.GetCaptain().GetAttack()));
+        dst_pt.x += 90;
+        text.Blit(dst_pt);
+        text.Set(_("Defense Skill")+ std::string(" "));
+        dst_pt.x = cur_pt.x + 535;
+        dst_pt.y += 12;
+        text.Blit(dst_pt);
+        text.Set(GetString(ref.GetCaptain().GetDefense()));
+        dst_pt.x += 90;
+        text.Blit(dst_pt);
+        text.Set(_("Spell Power")+ std::string(" "));
+        dst_pt.x = cur_pt.x + 535;
+        dst_pt.y += 12;
+        text.Blit(dst_pt);
+        text.Set(GetString(ref.GetCaptain().GetPower()));
+        dst_pt.x += 90;
+        text.Blit(dst_pt);
+        text.Set(_("Knowledge")+ std::string(" "));
+        dst_pt.x = cur_pt.x + 535;
+        dst_pt.y += 12;
+        text.Blit(dst_pt);
+        text.Set(GetString(ref.GetCaptain().GetKnowledge()));
+        dst_pt.x += 90;
+        text.Blit(dst_pt);
+        spriteSpreadArmyFormat.Blit(rectSpreadArmyFormat.x, rectSpreadArmyFormat.y);
+        spriteGroupedArmyFormat.Blit(rectGroupedArmyFormat.x, rectGroupedArmyFormat.y);
+        cursorFormat.Move( ref.GetArmy().isSpreadFormat() ? pointSpreadArmyFormat : pointGroupedArmyFormat );
+    }
+
+    void ManageStatusInfo(const Castle &ref, const BuildingInfo& dwelling1,
+                          const BuildingInfo& dwelling2, const BuildingInfo& dwelling3,
+			  const BuildingInfo& dwelling4, const BuildingInfo& dwelling5,
+			  const BuildingInfo& dwelling6, const BuildingInfo& buildingMageGuild,
+			  const BuildingInfo& buildingTavern, const BuildingInfo& buildingThievesGuild,
+			  const BuildingInfo& buildingShipyard, const BuildingInfo& buildingStatue,
+			  const BuildingInfo& buildingMarketplace, const BuildingInfo& buildingWell,
+			  const BuildingInfo& buildingWel2, const BuildingInfo& buildingSpec,
+			  const BuildingInfo& buildingLTurret, const BuildingInfo& buildingRTurret,
+			  const BuildingInfo& buildingMoat, const BuildingInfo& buildingCaptain,
+			  const Rect& rectHero1, const bool allow_buy_hero1,
+			  const std::string& not_allow1_msg, const Rect& rectHero2, const bool allow_buy_hero2,
+			  const std::string& not_allow2_msg, const Rect& rectSpreadArmyFormat,
+			  const Rect& rectGroupedArmyFormat, LocalEvent& le, StatusBar& statusBar,
+			  Heroes* hero1, Heroes* hero2)
+    {
+        // status info
+        if (le.MouseCursor(dwelling1.GetArea()))
+            dwelling1.SetStatusMessage(statusBar);
+        else if (le.MouseCursor(dwelling2.GetArea()))
+            dwelling2.SetStatusMessage(statusBar);
+        else if (le.MouseCursor(dwelling3.GetArea()))
+            dwelling3.SetStatusMessage(statusBar);
+        else if (le.MouseCursor(dwelling4.GetArea()))
+            dwelling4.SetStatusMessage(statusBar);
+        else if (le.MouseCursor(dwelling5.GetArea()))
+            dwelling5.SetStatusMessage(statusBar);
+        else if (le.MouseCursor(dwelling6.GetArea()))
+            dwelling6.SetStatusMessage(statusBar);
+        else if (le.MouseCursor(buildingMageGuild.GetArea()))
+            buildingMageGuild.SetStatusMessage(statusBar);
+        else if ((ref.GetRace() != Race::NECR) && le.MouseCursor(buildingTavern.GetArea()))
+            buildingTavern.SetStatusMessage(statusBar);
+        else if (le.MouseCursor(buildingThievesGuild.GetArea()))
+            buildingThievesGuild.SetStatusMessage(statusBar);
+        else if (le.MouseCursor(buildingShipyard.GetArea()))
+            buildingShipyard.SetStatusMessage(statusBar);
+        else if (le.MouseCursor(buildingStatue.GetArea()))
+            buildingStatue.SetStatusMessage(statusBar);
+        else if (le.MouseCursor(buildingMarketplace.GetArea()))
+            buildingMarketplace.SetStatusMessage(statusBar);
+        else if (le.MouseCursor(buildingWell.GetArea()))
+            buildingWell.SetStatusMessage(statusBar);
+        else if (le.MouseCursor(buildingWel2.GetArea()))
+            buildingWel2.SetStatusMessage(statusBar);
+        else if (le.MouseCursor(buildingSpec.GetArea()))
+            buildingSpec.SetStatusMessage(statusBar);
+        else if (le.MouseCursor(buildingLTurret.GetArea()))
+            buildingLTurret.SetStatusMessage(statusBar);
+        else if (le.MouseCursor(buildingRTurret.GetArea()))
+            buildingRTurret.SetStatusMessage(statusBar);
+        else if (le.MouseCursor(buildingMoat.GetArea()))
+            buildingMoat.SetStatusMessage(statusBar);
+        else if (le.MouseCursor(buildingCaptain.GetArea()))
+            buildingCaptain.SetStatusMessage(statusBar);
+        else if (hero1 && le.MouseCursor(rectHero1)) {
+            if (!allow_buy_hero1) {
+                statusBar.ShowMessage(not_allow1_msg);
+            } else {
+                std::string str = _("Recruit %{name} the %{race}");
+                StringReplace(str, "%{name}", hero1->GetName());
+                StringReplace(str, "%{race}", Race::String(hero1->GetRace()));
+                statusBar.ShowMessage(str);
+            }
+        } else if (hero2 && le.MouseCursor(rectHero2)) {
+            if (!allow_buy_hero2)
+                statusBar.ShowMessage(not_allow2_msg);
+            else {
+                std::string str = _("Recruit %{name} the %{race}");
+                StringReplace(str, "%{name}", hero2->GetName());
+                StringReplace(str, "%{race}", Race::String(hero2->GetRace()));
+                statusBar.ShowMessage(str);
+            }
+        } else if (le.MouseCursor(rectSpreadArmyFormat))
+            statusBar.ShowMessage(_("Set garrison combat formation to 'Spread'"));
+        else if (le.MouseCursor(rectGroupedArmyFormat))
+            statusBar.ShowMessage(_("Set garrison combat formation to 'Grouped'"));
+        else
+            // clear all
+            statusBar.ShowMessage(_("Castle Options"));
+    }
+}
+
 int Castle::DialogBuyHero(const Heroes* hero)
 {
     if(!hero) return Dialog::CANCEL;
@@ -140,300 +445,6 @@ int Castle::DialogBuyCastle(bool buttons) const
 {
     BuildingInfo info(*this, BUILD_CASTLE);
     return info.DialogBuyBuilding(buttons) ? Dialog::OK : Dialog::CANCEL;
-}
-
-static void MaskTavernTile(Point dst_pt, const Point &cur_pt) {
-	dst_pt.x = cur_pt.x + 149;
-	dst_pt.y = cur_pt.y + 157;
-	const Rect buildingMask(dst_pt, 144, 75);
-	AGG::GetICN(ICN::STONEBAK, 0).Blit(buildingMask, dst_pt);
-}
-
-static BuildingInfo DrawDwelling1(const Castle &ref, const Point &cur_pt) {
-	BuildingInfo dwelling1(ref, DWELLING_MONSTER1);
-	dwelling1.SetPos(cur_pt.x + 5, cur_pt.y + 2);
-	dwelling1.Redraw();
-	return dwelling1;
-}
-
-static BuildingInfo DrawDwelling2(const Castle &ref, const Point &cur_pt) {
-	BuildingInfo dwelling2(ref, DWELLING_MONSTER2);
-	dwelling2.SetPos(cur_pt.x + 149, cur_pt.y + 2);
-	dwelling2.Redraw();
-	return dwelling2;
-}
-
-static BuildingInfo DrawDwelling3(const Castle &ref, const Point &cur_pt) {
-	BuildingInfo dwelling3(ref, DWELLING_MONSTER3);
-	dwelling3.SetPos(cur_pt.x + 293, cur_pt.y + 2);
-	dwelling3.Redraw();
-	return dwelling3;
-}
-
-static BuildingInfo DrawDwelling4(const Castle &ref, const Point &cur_pt) {
-	BuildingInfo dwelling4(ref, DWELLING_MONSTER4);
-	dwelling4.SetPos(cur_pt.x + 5, cur_pt.y + 77);
-	dwelling4.Redraw();
-	return dwelling4;
-}
-
-static BuildingInfo DrawDwelling5(const Castle &ref, const Point &cur_pt) {
-	BuildingInfo dwelling5(ref, DWELLING_MONSTER5);
-	dwelling5.SetPos(cur_pt.x + 149, cur_pt.y + 77);
-	dwelling5.Redraw();
-	return dwelling5;
-}
-
-static BuildingInfo DrawDwelling6(const Castle &ref, const Point &cur_pt) {
-	BuildingInfo dwelling6(ref, DWELLING_MONSTER6);
-	dwelling6.SetPos(cur_pt.x + 293, cur_pt.y + 77);
-	dwelling6.Redraw();
-	return dwelling6;
-}
-
-static BuildingInfo DrawMageGuild(const Castle &ref, const Point &cur_pt) {
-	building_t level = BUILD_NOTHING;
-	switch (ref.GetLevelMageGuild()) {
-	case 0:
-		level = BUILD_MAGEGUILD1;
-		break;
-	case 1:
-		level = BUILD_MAGEGUILD2;
-		break;
-	case 2:
-		level = BUILD_MAGEGUILD3;
-		break;
-	case 3:
-		level = BUILD_MAGEGUILD4;
-		break;
-	default:
-		level = BUILD_MAGEGUILD5;
-		break;
-	}
-	BuildingInfo buildingMageGuild(ref, level);
-	buildingMageGuild.SetPos(cur_pt.x + 5, cur_pt.y + 157);
-	buildingMageGuild.Redraw();
-	return buildingMageGuild;
-}
-
-static BuildingInfo DrawTavern(const Castle &ref, const Point &cur_pt, const Point &dst_pt) {
-	BuildingInfo buildingTavern(ref, BUILD_TAVERN);
-	if (ref.GetRace() != Race::NECR) {
-		buildingTavern.SetPos(cur_pt.x + 149, cur_pt.y + 157);
-		buildingTavern.Redraw();
-	} else {
-		MaskTavernTile(dst_pt, cur_pt);
-	}
-	return buildingTavern;
-}
-
-static BuildingInfo DrawThievesGuild(const Castle &ref, const Point &cur_pt) {
-	BuildingInfo buildingThievesGuild(ref, BUILD_THIEVESGUILD);
-	buildingThievesGuild.SetPos(cur_pt.x + 293, cur_pt.y + 157);
-	buildingThievesGuild.Redraw();
-	return buildingThievesGuild;
-}
-
-static BuildingInfo DrawShipyard(const Castle &ref, const Point &cur_pt) {
-	BuildingInfo buildingShipyard(ref, BUILD_SHIPYARD);
-	buildingShipyard.SetPos(cur_pt.x + 5, cur_pt.y + 232);
-	buildingShipyard.Redraw();
-	return buildingShipyard;
-}
-
-static BuildingInfo DrawStatue(const Castle &ref, const Point &cur_pt) {
-	BuildingInfo buildingStatue(ref, BUILD_STATUE);
-	buildingStatue.SetPos(cur_pt.x + 149, cur_pt.y + 232);
-	buildingStatue.Redraw();
-	return buildingStatue;
-}
-
-static BuildingInfo DrawMarketplace(const Castle &ref, const Point &cur_pt) {
-	BuildingInfo buildingMarketplace(ref, BUILD_MARKETPLACE);
-	buildingMarketplace.SetPos(cur_pt.x + 293, cur_pt.y + 232);
-	buildingMarketplace.Redraw();
-	return buildingMarketplace;
-}
-
-static BuildingInfo DrawWell(const Castle &ref, const Point &cur_pt) {
-	BuildingInfo buildingWell(ref, BUILD_WELL);
-	buildingWell.SetPos(cur_pt.x + 5, cur_pt.y + 307);
-	buildingWell.Redraw();
-	return buildingWell;
-}
-
-static BuildingInfo DrawWel2(const Castle &ref, const Point &cur_pt) {
-	BuildingInfo buildingWel2(ref, BUILD_WEL2);
-	buildingWel2.SetPos(cur_pt.x + 149, cur_pt.y + 307);
-	buildingWel2.Redraw();
-	return buildingWel2;
-}
-
-static BuildingInfo DrawSpec(const Castle &ref, const Point &cur_pt) {
-	BuildingInfo buildingSpec(ref, BUILD_SPEC);
-	buildingSpec.SetPos(cur_pt.x + 293, cur_pt.y + 307);
-	buildingSpec.Redraw();
-	return buildingSpec;
-}
-
-static BuildingInfo DrawLeftTurret(const Castle &ref, const Point &cur_pt) {
-	BuildingInfo buildingLTurret(ref, BUILD_LEFTTURRET);
-	buildingLTurret.SetPos(cur_pt.x + 5, cur_pt.y + 387);
-	buildingLTurret.Redraw();
-	return buildingLTurret;
-}
-
-static BuildingInfo DrawRightTurret(const Castle &ref, const Point &cur_pt) {
-	BuildingInfo buildingRTurret(ref, BUILD_RIGHTTURRET);
-	buildingRTurret.SetPos(cur_pt.x + 149, cur_pt.y + 387);
-	buildingRTurret.Redraw();
-	return buildingRTurret;
-}
-
-static BuildingInfo DrawMoat(const Castle &ref, const Point &cur_pt) {
-	BuildingInfo buildingMoat(ref, BUILD_MOAT);
-	buildingMoat.SetPos(cur_pt.x + 293, cur_pt.y + 387);
-	buildingMoat.Redraw();
-	return buildingMoat;
-}
-
-static BuildingInfo DrawCaptain(const Castle &ref, const Point &cur_pt) {
-	BuildingInfo buildingCaptain(ref, BUILD_CAPTAIN);
-	buildingCaptain.SetPos(cur_pt.x + 444, cur_pt.y + 165);
-	buildingCaptain.Redraw();
-	return buildingCaptain;
-}
-
-static void DrawCombatInfo(const Castle &ref,
-                           const Point& cur_pt,
-						   Point dst_pt,
-						   Text text,
-						   const Sprite& spriteSpreadArmyFormat,
-						   const Sprite& spriteGroupedArmyFormat,
-						   const Rect rectSpreadArmyFormat,
-						   const Rect rectGroupedArmyFormat,
-						   const Point pointSpreadArmyFormat,
-						   const Point pointGroupedArmyFormat,
-						   SpriteMove cursorFormat) {
-	text.Set(_("Attack Skill")+ std::string(" "), Font::SMALL);
-	dst_pt.x = cur_pt.x + 535;
-	dst_pt.y = cur_pt.y + 168;
-	text.Blit(dst_pt);
-	text.Set(GetString(ref.GetCaptain().GetAttack()));
-	dst_pt.x += 90;
-	text.Blit(dst_pt);
-	text.Set(_("Defense Skill")+ std::string(" "));
-	dst_pt.x = cur_pt.x + 535;
-	dst_pt.y += 12;
-	text.Blit(dst_pt);
-	text.Set(GetString(ref.GetCaptain().GetDefense()));
-	dst_pt.x += 90;
-	text.Blit(dst_pt);
-	text.Set(_("Spell Power")+ std::string(" "));
-	dst_pt.x = cur_pt.x + 535;
-	dst_pt.y += 12;
-	text.Blit(dst_pt);
-	text.Set(GetString(ref.GetCaptain().GetPower()));
-	dst_pt.x += 90;
-	text.Blit(dst_pt);
-	text.Set(_("Knowledge")+ std::string(" "));
-	dst_pt.x = cur_pt.x + 535;
-	dst_pt.y += 12;
-	text.Blit(dst_pt);
-	text.Set(GetString(ref.GetCaptain().GetKnowledge()));
-	dst_pt.x += 90;
-	text.Blit(dst_pt);
-	spriteSpreadArmyFormat.Blit(rectSpreadArmyFormat.x, rectSpreadArmyFormat.y);
-	spriteGroupedArmyFormat.Blit(rectGroupedArmyFormat.x,
-			rectGroupedArmyFormat.y);
-	cursorFormat.Move(
-			ref.GetArmy().isSpreadFormat() ?
-					pointSpreadArmyFormat : pointGroupedArmyFormat);
-}
-
-static void ManageStatusInfo(const Castle &ref, const BuildingInfo& dwelling1,
-		const BuildingInfo& dwelling2, const BuildingInfo& dwelling3,
-		const BuildingInfo& dwelling4, const BuildingInfo& dwelling5,
-		const BuildingInfo& dwelling6, const BuildingInfo& buildingMageGuild,
-		const BuildingInfo& buildingTavern,
-		const BuildingInfo& buildingThievesGuild,
-		const BuildingInfo& buildingShipyard,
-		const BuildingInfo& buildingStatue,
-		const BuildingInfo& buildingMarketplace,
-		const BuildingInfo& buildingWell, const BuildingInfo& buildingWel2,
-		const BuildingInfo& buildingSpec, const BuildingInfo& buildingLTurret,
-		const BuildingInfo& buildingRTurret, const BuildingInfo& buildingMoat,
-		const BuildingInfo& buildingCaptain, const Rect& rectHero1,
-		const bool allow_buy_hero1, const std::string& not_allow1_msg,
-		const Rect& rectHero2, const bool allow_buy_hero2,
-		const std::string& not_allow2_msg, const Rect& rectSpreadArmyFormat,
-		const Rect& rectGroupedArmyFormat, LocalEvent& le, StatusBar& statusBar,
-		Heroes* hero1, Heroes* hero2) {
-	// status info
-	if (le.MouseCursor(dwelling1.GetArea()))
-		dwelling1.SetStatusMessage(statusBar);
-	else if (le.MouseCursor(dwelling2.GetArea()))
-		dwelling2.SetStatusMessage(statusBar);
-	else if (le.MouseCursor(dwelling3.GetArea()))
-		dwelling3.SetStatusMessage(statusBar);
-	else if (le.MouseCursor(dwelling4.GetArea()))
-		dwelling4.SetStatusMessage(statusBar);
-	else if (le.MouseCursor(dwelling5.GetArea()))
-		dwelling5.SetStatusMessage(statusBar);
-	else if (le.MouseCursor(dwelling6.GetArea()))
-		dwelling6.SetStatusMessage(statusBar);
-	else if (le.MouseCursor(buildingMageGuild.GetArea()))
-		buildingMageGuild.SetStatusMessage(statusBar);
-	else if ((ref.GetRace() != Race::NECR)
-			&& le.MouseCursor(buildingTavern.GetArea()))
-		buildingTavern.SetStatusMessage(statusBar);
-	else if (le.MouseCursor(buildingThievesGuild.GetArea()))
-		buildingThievesGuild.SetStatusMessage(statusBar);
-	else if (le.MouseCursor(buildingShipyard.GetArea()))
-		buildingShipyard.SetStatusMessage(statusBar);
-	else if (le.MouseCursor(buildingStatue.GetArea()))
-		buildingStatue.SetStatusMessage(statusBar);
-	else if (le.MouseCursor(buildingMarketplace.GetArea()))
-		buildingMarketplace.SetStatusMessage(statusBar);
-	else if (le.MouseCursor(buildingWell.GetArea()))
-		buildingWell.SetStatusMessage(statusBar);
-	else if (le.MouseCursor(buildingWel2.GetArea()))
-		buildingWel2.SetStatusMessage(statusBar);
-	else if (le.MouseCursor(buildingSpec.GetArea()))
-		buildingSpec.SetStatusMessage(statusBar);
-	else if (le.MouseCursor(buildingLTurret.GetArea()))
-		buildingLTurret.SetStatusMessage(statusBar);
-	else if (le.MouseCursor(buildingRTurret.GetArea()))
-		buildingRTurret.SetStatusMessage(statusBar);
-	else if (le.MouseCursor(buildingMoat.GetArea()))
-		buildingMoat.SetStatusMessage(statusBar);
-	else if (le.MouseCursor(buildingCaptain.GetArea()))
-		buildingCaptain.SetStatusMessage(statusBar);
-	else if (hero1 && le.MouseCursor(rectHero1)) {
-		if (!allow_buy_hero1) {
-			statusBar.ShowMessage(not_allow1_msg);
-		} else {
-			std::string str = _("Recruit %{name} the %{race}");
-			StringReplace(str, "%{name}", hero1->GetName());
-			StringReplace(str, "%{race}", Race::String(hero1->GetRace()));
-			statusBar.ShowMessage(str);
-		}
-	} else if (hero2 && le.MouseCursor(rectHero2)) {
-		if (!allow_buy_hero2)
-			statusBar.ShowMessage(not_allow2_msg);
-		else {
-			std::string str = _("Recruit %{name} the %{race}");
-			StringReplace(str, "%{name}", hero2->GetName());
-			StringReplace(str, "%{race}", Race::String(hero2->GetRace()));
-			statusBar.ShowMessage(str);
-		}
-	} else if (le.MouseCursor(rectSpreadArmyFormat))
-		statusBar.ShowMessage(_("Set garrison combat formation to 'Spread'"));
-	else if (le.MouseCursor(rectGroupedArmyFormat))
-		statusBar.ShowMessage(_("Set garrison combat formation to 'Grouped'"));
-	else
-		// clear all
-		statusBar.ShowMessage(_("Castle Options"));
 }
 
 u32 Castle::OpenTown(void)

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -156,7 +156,7 @@ u32 Castle::OpenTown(void)
     AGG::GetICN(ICN::CASLWIND, 0).Blit(dst_pt);
 
     // hide captain options
-    if(! (building & BUILD_CAPTAIN))
+    if(!(building & BUILD_CAPTAIN))
     {
 	dst_pt.x = 530;
 	dst_pt.y = 163;
@@ -215,10 +215,17 @@ u32 Castle::OpenTown(void)
     buildingMageGuild.SetPos(cur_pt.x + 5, cur_pt.y + 157);
     buildingMageGuild.Redraw();
 
-    // tavern
-    BuildingInfo buildingTavern(*this, BUILD_TAVERN);
-    buildingTavern.SetPos(cur_pt.x + 149, cur_pt.y + 157);
-    buildingTavern.Redraw();
+	// tavern
+	BuildingInfo buildingTavern(*this, BUILD_TAVERN);
+    if (GetRace() != Race::NECR) {
+        buildingTavern.SetPos(cur_pt.x + 149, cur_pt.y + 157);
+        buildingTavern.Redraw();
+    } else {
+        dst_pt.x = cur_pt.x + 149;
+        dst_pt.y = cur_pt.y + 157;
+        const Rect buildingMask(dst_pt, 144, 75);
+        AGG::GetICN(ICN::STONEBAK, 0).Blit(buildingMask, dst_pt);
+    }
 
     // thieves guild
     BuildingInfo buildingThievesGuild(*this, BUILD_THIEVESGUILD);
@@ -424,7 +431,7 @@ u32 Castle::OpenTown(void)
 	else
         if(le.MouseCursor(buildingTavern.GetArea()) && buildingTavern.QueueEventProcessing()) return (Race::NECR == race  ? BUILD_SHRINE : BUILD_TAVERN);
 	else
-        if(le.MouseCursor(buildingThievesGuild.GetArea()) && buildingThievesGuild.QueueEventProcessing()) return BUILD_THIEVESGUILD;
+        if((GetRace() != Race::NECR) && le.MouseCursor(buildingThievesGuild.GetArea()) && buildingThievesGuild.QueueEventProcessing()) return BUILD_THIEVESGUILD;
 	else
         if(le.MouseCursor(buildingShipyard.GetArea()) && buildingShipyard.QueueEventProcessing()) return BUILD_SHIPYARD;
 	else
@@ -507,7 +514,7 @@ u32 Castle::OpenTown(void)
 	else
 	if(le.MouseCursor(buildingMageGuild.GetArea())) buildingMageGuild.SetStatusMessage(statusBar);
 	else
-	if(le.MouseCursor(buildingTavern.GetArea())) buildingTavern.SetStatusMessage(statusBar);
+	if((GetRace() != Race::NECR) && le.MouseCursor(buildingTavern.GetArea())) buildingTavern.SetStatusMessage(statusBar);
 	else
 	if(le.MouseCursor(buildingThievesGuild.GetArea())) buildingThievesGuild.SetStatusMessage(statusBar);
 	else


### PR DESCRIPTION
So basically the tavern tile is redrawn with a rectangle of the background texture. On top of that the tavern tile events are not managed, just in case it may cause unwanted side-effects.