### PR TITLE
Disabled Continue Movement button

### DIFF
--- a/src/fheroes2/gui/interface_buttons.cpp
+++ b/src/fheroes2/gui/interface_buttons.cpp
@@ -97,6 +97,11 @@ void Interface::ButtonsArea::Redraw(void)
 
     SetButtonStatus();
 
+	Heroes * currentHero = GetFocusHeroes();
+	if (currentHero != nullptr && !currentHero->GetPath().isValid()
+	   || currentHero != nullptr && 0 == currentHero->GetMobilityIndexSprite())
+		buttonMovement.SetDisable(true);
+
 	buttonNextHero.Draw();
 	buttonMovement.Draw();
 	buttonKingdom.Draw();

--- a/src/fheroes2/gui/interface_buttons.cpp
+++ b/src/fheroes2/gui/interface_buttons.cpp
@@ -97,11 +97,6 @@ void Interface::ButtonsArea::Redraw(void)
 
     SetButtonStatus();
 
-	Heroes * currentHero = GetFocusHeroes();
-	if (currentHero != nullptr && !currentHero->GetPath().isValid()
-	   || currentHero != nullptr && 0 == currentHero->GetMobilityIndexSprite())
-		buttonMovement.SetDisable(true);
-
 	buttonNextHero.Draw();
 	buttonMovement.Draw();
 	buttonKingdom.Draw();
@@ -211,5 +206,11 @@ int Interface::ButtonsArea::QueueEventProcessing(void)
 
 void Interface::ButtonsArea::SetButtonStatus()
 {
-    buttonMovement.SetDisable(GetFocusHeroes() == NULL);
+    Heroes * currentHero = GetFocusHeroes();
+    if (currentHero != NULL && !currentHero->GetPath().isValid()
+       || currentHero != NULL && !currentHero->MayStillMove())
+        buttonMovement.SetDisable(true);
+    else
+        buttonMovement.SetDisable(false);
+
 }

--- a/src/fheroes2/gui/interface_buttons.cpp
+++ b/src/fheroes2/gui/interface_buttons.cpp
@@ -212,5 +212,4 @@ void Interface::ButtonsArea::SetButtonStatus()
         buttonMovement.SetDisable(true);
     else
         buttonMovement.SetDisable(false);
-
 }

--- a/src/fheroes2/gui/interface_buttons.cpp
+++ b/src/fheroes2/gui/interface_buttons.cpp
@@ -207,9 +207,6 @@ int Interface::ButtonsArea::QueueEventProcessing(void)
 void Interface::ButtonsArea::SetButtonStatus()
 {
     Heroes * currentHero = GetFocusHeroes();
-    if (currentHero != NULL && !currentHero->GetPath().isValid()
-       || currentHero != NULL && !currentHero->MayStillMove())
-        buttonMovement.SetDisable(true);
-    else
-        buttonMovement.SetDisable(false);
+    const bool isMovementButtonDisabled = (currentHero == NULL) || !currentHero->GetPath().isValid() || !currentHero->MayStillMove();
+    buttonMovement.SetDisable(isMovementButtonDisabled);
 }

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -55,6 +55,8 @@ void Interface::Basic::ShowPathOrStartMoveHero(Heroes* hero, s32 dst_index)
         DEBUG(DBG_GAME, DBG_TRACE, hero->GetName() << ", route: " << path.String());
         gameArea.SetRedraw();
         cursor.SetThemes(GetCursorTileIndex(dst_index));
+        Interface::Basic & I = Interface::Basic::Get();
+        I.buttonsArea.Redraw();
     }
     // start move
     else

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -55,8 +55,7 @@ void Interface::Basic::ShowPathOrStartMoveHero(Heroes* hero, s32 dst_index)
         DEBUG(DBG_GAME, DBG_TRACE, hero->GetName() << ", route: " << path.String());
         gameArea.SetRedraw();
         cursor.SetThemes(GetCursorTileIndex(dst_index));
-        Interface::Basic & I = Interface::Basic::Get();
-        I.buttonsArea.Redraw();
+        Interface::Basic::Get().buttonsArea.Redraw();
     }
     // start move
     else


### PR DESCRIPTION
Disabled Continue Movement button for a hero which doesn't have chosen path. Resolves #107 