### PR TITLE
Display error window if no original data detected

### DIFF
--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -1860,8 +1860,8 @@ bool AGG::Init(void)
     if(! ReadDataDir())
     {
         DEBUG(DBG_ENGINE, DBG_WARN, "data files not found");
-        //ShowError();
-        //return false;
+        ShowError();
+        return false;
     }
 
 #ifdef WITH_TTF


### PR DESCRIPTION
Fixes #11 
Missing maps is already OK.
Error message is there, I don't know why it was disabled. Tested on Linux with SDL 1.2: an error window is displayed and dismissed with a click.