### PR TITLE
Unchecked array access leading to potential corruption

### DIFF
--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -810,11 +810,14 @@ StreamBase & operator<< (StreamBase & msg, const Kingdoms & obj)
 StreamBase & operator>> (StreamBase & msg, Kingdoms & obj)
 {
     u32 kingdomscount;
-    msg >> kingdomscount; // FIXME: check kingdomscount
-
-    for(u32 ii = 0; ii < kingdomscount; ++ii)
+    msg >> kingdomscount; 
+	
+    if (kingdomscount <= KINGDOMMAX)
+    {
+        for(u32 ii = 0; ii < kingdomscount; ++ii)
 	msg >> obj.kingdoms[ii];
-
+    }
+       
     return msg;
 }
 

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -812,7 +812,7 @@ StreamBase & operator>> (StreamBase & msg, Kingdoms & obj)
     u32 kingdomscount = 0;
     msg >> kingdomscount;
 
-    if (kingdomscount < KINGDOMMAX) {
+    if (kingdomscount <= KINGDOMMAX) {
         for (u32 i = 0; i < kingdomscount; ++i)
             msg >> obj.kingdoms[i];
     }

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -809,15 +809,14 @@ StreamBase & operator<< (StreamBase & msg, const Kingdoms & obj)
 
 StreamBase & operator>> (StreamBase & msg, Kingdoms & obj)
 {
-    u32 kingdomscount;
-    msg >> kingdomscount; 
-	
-    if (kingdomscount <= KINGDOMMAX)
-    {
-        for(u32 ii = 0; ii < kingdomscount; ++ii)
-	msg >> obj.kingdoms[ii];
+    u32 kingdomscount = 0;
+    msg >> kingdomscount;
+
+    if (kingdomscount < KINGDOMMAX) {
+        for (u32 i = 0; i < kingdomscount; ++i)
+            msg >> obj.kingdoms[i];
     }
-       
+
     return msg;
 }
 


### PR DESCRIPTION
Check array size before write it to avoid memory corruption
relates to #131 