### PR TITLE
Rename variables to do not hide members of class

### DIFF
--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -229,9 +229,9 @@ const std::string & AGG::File::Name(void) const
 }
 
 /* get FAT element */
-const AGG::FAT & AGG::File::Fat(const std::string & key)
+const AGG::FAT & AGG::File::Fat(const std::string & fileKey)
 {
-    return fat[key];
+    return fat[fileKey];
 }
 
 /* dump FAT */

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1377,9 +1377,9 @@ void Battle::Interface::RedrawPocketControls(void) const
     }
 }
 
-int Battle::Interface::GetBattleCursor(std::string & statusL)
+int Battle::Interface::GetBattleCursor(std::string & heroStatus)
 {
-    statusL.clear();
+    heroStatus.clear();
 
     const Cell* cell = Board::GetCell(index_pos);
 
@@ -1391,19 +1391,19 @@ int Battle::Interface::GetBattleCursor(std::string & statusL)
 	{
 	    if(b_current->GetColor() == b_enemy->GetColor() && !b_enemy->Modes(SP_HYPNOTIZE))
 	    {
-		statusL = _("View %{monster} info.");
-		StringReplace(statusL, "%{monster}", b_enemy->GetMultiName());
+		heroStatus = _("View %{monster} info.");
+		StringReplace(heroStatus, "%{monster}", b_enemy->GetMultiName());
 		return Cursor::WAR_INFO;
 	    }
 	    else
 	    {
 		if(b_current->isArchers() && !b_current->isHandFighting())
 		{
-		    statusL = _("Shoot %{monster}");
-		    statusL.append(" ");
-		    statusL.append(_n("(one shot left)", "(%{count} shots left)", b_current->GetShots()));
-		    StringReplace(statusL, "%{monster}", b_enemy->GetMultiName());
- 		    StringReplace(statusL, "%{count}", b_current->GetShots());
+		    heroStatus = _("Shoot %{monster}");
+		    heroStatus.append(" ");
+		    heroStatus.append(_n("(one shot left)", "(%{count} shots left)", b_current->GetShots()));
+		    StringReplace(heroStatus, "%{monster}", b_enemy->GetMultiName());
+ 		    StringReplace(heroStatus, "%{count}", b_current->GetShots());
 
 		    return arena.GetObstaclesPenalty(*b_current, *b_enemy) ? Cursor::WAR_BROKENARROW : Cursor::WAR_ARROW;
 		}
@@ -1421,8 +1421,8 @@ int Battle::Interface::GetBattleCursor(std::string & statusL)
 			    from == b_current->GetHeadIndex() ||
 			    (b_current->isWide() && from == b_current->GetTailIndex()))
 			{
-			    statusL = _("Attack %{monster}");
-			    StringReplace(statusL, "%{monster}", b_enemy->GetName());
+			    heroStatus = _("Attack %{monster}");
+			    StringReplace(heroStatus, "%{monster}", b_enemy->GetName());
 
 			    return cursor;
 			}
@@ -1433,21 +1433,21 @@ int Battle::Interface::GetBattleCursor(std::string & statusL)
 	else
 	if(cell->isPassable3(*b_current, false) && UNKNOWN != cell->GetDirection())
 	{
-	    statusL = b_current->isFly() ? _("Fly %{monster} here.") : _("Move %{monster} here.");
-	    StringReplace(statusL, "%{monster}", b_current->GetName());
+	    heroStatus = b_current->isFly() ? _("Fly %{monster} here.") : _("Move %{monster} here.");
+	    StringReplace(heroStatus, "%{monster}", b_current->GetName());
 	    return b_current->isFly() ? Cursor::WAR_FLY : Cursor::WAR_MOVE;
 	}
     }
 
-    statusL = _("Turn %{turn}");
-    StringReplace(statusL, "%{turn}", arena.GetCurrentTurn());
+    heroStatus = _("Turn %{turn}");
+    StringReplace(heroStatus, "%{turn}", arena.GetCurrentTurn());
 
     return Cursor::WAR_NONE;
 }
 
-int Battle::Interface::GetBattleSpellCursor(std::string & statusL)
+int Battle::Interface::GetBattleSpellCursor(std::string & heroStatus)
 {
-    statusL.clear();
+    heroStatus.clear();
 
     const Cell* cell = Board::GetCell(index_pos);
     const Spell & spell = humanturn_spell;
@@ -1465,19 +1465,19 @@ int Battle::Interface::GetBattleSpellCursor(std::string & statusL)
 	{
 	    if(!b_stats && cell->isPassable3(*b_current, false))
 	    {
-		statusL = _("Teleport Here");
+		heroStatus = _("Teleport Here");
 		return Cursor::SP_TELEPORT;
 	    }
 
-	    statusL = _("Invalid Teleport Destination");
+	    heroStatus = _("Invalid Teleport Destination");
 	    return Cursor::WAR_NONE;
 	}
 	else
 	if(b_stats && b_stats->AllowApplySpell(spell, b_current->GetCommander()))
 	{
-	    statusL = _("Cast %{spell} on %{monster}");
-	    StringReplace(statusL, "%{spell}", spell.GetName());
-	    StringReplace(statusL, "%{monster}", b_stats->GetName());
+	    heroStatus = _("Cast %{spell} on %{monster}");
+	    StringReplace(heroStatus, "%{spell}", spell.GetName());
+	    StringReplace(heroStatus, "%{monster}", b_stats->GetName());
 	    return GetCursorFromSpell(spell());
     	}
 	else
@@ -1485,13 +1485,13 @@ int Battle::Interface::GetBattleSpellCursor(std::string & statusL)
 	   !spell.isApplyToEnemies() &&
 	   !spell.isApplyToAnyTroops())
 	{
-	    statusL = _("Cast %{spell}");
-	    StringReplace(statusL, "%{spell}", spell.GetName());
+	    heroStatus = _("Cast %{spell}");
+	    StringReplace(heroStatus, "%{spell}", spell.GetName());
 	    return GetCursorFromSpell(spell());
 	}
     }
 
-    statusL = _("Select Spell Target");
+    heroStatus = _("Select Spell Target");
 
     return Cursor::WAR_NONE;
 }
@@ -4248,27 +4248,27 @@ void Battle::PopupDamageInfo::Redraw(int maxw, int maxh)
 	int tw = 5 + (text1.w() > text2.w() ? text1.w() : text2.w());
 	int th = (text1.h() + text2.h());
 
-	const Rect & areaL = GetArea();
-	const Rect & rectL = GetRect();
+	const Rect & battleArea = GetArea();
+	const Rect & battleRect = GetRect();
 	const Rect & pos = cell->GetPos();
 
-	int tx = rectL.x;
-	int ty = rectL.y;
+	int tx = battleRect.x;
+	int ty = battleRect.y;
 
-	if(rectL.x + rectL.w > maxw)
+	if(battleRect.x + battleRect.w > maxw)
 	{
-	    tx = maxw - rectL.w - 5;
+	    tx = maxw - battleRect.w - 5;
 	    ty = pos.y - pos.h;
 	}
 
-	if(rectL.x != tx || rectL.y != ty || areaL.w != tw || areaL.h != th)
+	if(battleRect.x != tx || battleRect.y != ty || battleArea.w != tw || battleArea.h != th)
 	    SetPosition(tx, ty, tw, th);
 
 	const Sprite & sf = AGG::GetICN(ICN::CELLWIN, 1);
 	Dialog::FrameBorder::RenderOther(sf, GetRect());
 
-	text1.Blit(areaL.x, areaL.y);
-	text2.Blit(areaL.x, areaL.y + areaL.h/2);
+	text1.Blit(battleArea.x, battleArea.y);
+	text2.Blit(battleArea.x, battleArea.y + battleArea.h/2);
     }
 }
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1377,9 +1377,9 @@ void Battle::Interface::RedrawPocketControls(void) const
     }
 }
 
-int Battle::Interface::GetBattleCursor(std::string & status)
+int Battle::Interface::GetBattleCursor(std::string & statusL)
 {
-    status.clear();
+    statusL.clear();
 
     const Cell* cell = Board::GetCell(index_pos);
 
@@ -1391,19 +1391,19 @@ int Battle::Interface::GetBattleCursor(std::string & status)
 	{
 	    if(b_current->GetColor() == b_enemy->GetColor() && !b_enemy->Modes(SP_HYPNOTIZE))
 	    {
-		status = _("View %{monster} info.");
-		StringReplace(status, "%{monster}", b_enemy->GetMultiName());
+		statusL = _("View %{monster} info.");
+		StringReplace(statusL, "%{monster}", b_enemy->GetMultiName());
 		return Cursor::WAR_INFO;
 	    }
 	    else
 	    {
 		if(b_current->isArchers() && !b_current->isHandFighting())
 		{
-		    status = _("Shoot %{monster}");
-		    status.append(" ");
-		    status.append(_n("(one shot left)", "(%{count} shots left)", b_current->GetShots()));
-		    StringReplace(status, "%{monster}", b_enemy->GetMultiName());
- 		    StringReplace(status, "%{count}", b_current->GetShots());
+		    statusL = _("Shoot %{monster}");
+		    statusL.append(" ");
+		    statusL.append(_n("(one shot left)", "(%{count} shots left)", b_current->GetShots()));
+		    StringReplace(statusL, "%{monster}", b_enemy->GetMultiName());
+ 		    StringReplace(statusL, "%{count}", b_current->GetShots());
 
 		    return arena.GetObstaclesPenalty(*b_current, *b_enemy) ? Cursor::WAR_BROKENARROW : Cursor::WAR_ARROW;
 		}
@@ -1421,8 +1421,8 @@ int Battle::Interface::GetBattleCursor(std::string & status)
 			    from == b_current->GetHeadIndex() ||
 			    (b_current->isWide() && from == b_current->GetTailIndex()))
 			{
-			    status = _("Attack %{monster}");
-			    StringReplace(status, "%{monster}", b_enemy->GetName());
+			    statusL = _("Attack %{monster}");
+			    StringReplace(statusL, "%{monster}", b_enemy->GetName());
 
 			    return cursor;
 			}
@@ -1433,21 +1433,21 @@ int Battle::Interface::GetBattleCursor(std::string & status)
 	else
 	if(cell->isPassable3(*b_current, false) && UNKNOWN != cell->GetDirection())
 	{
-	    status = b_current->isFly() ? _("Fly %{monster} here.") : _("Move %{monster} here.");
-	    StringReplace(status, "%{monster}", b_current->GetName());
+	    statusL = b_current->isFly() ? _("Fly %{monster} here.") : _("Move %{monster} here.");
+	    StringReplace(statusL, "%{monster}", b_current->GetName());
 	    return b_current->isFly() ? Cursor::WAR_FLY : Cursor::WAR_MOVE;
 	}
     }
 
-    status = _("Turn %{turn}");
-    StringReplace(status, "%{turn}", arena.GetCurrentTurn());
+    statusL = _("Turn %{turn}");
+    StringReplace(statusL, "%{turn}", arena.GetCurrentTurn());
 
     return Cursor::WAR_NONE;
 }
 
-int Battle::Interface::GetBattleSpellCursor(std::string & status)
+int Battle::Interface::GetBattleSpellCursor(std::string & statusL)
 {
-    status.clear();
+    statusL.clear();
 
     const Cell* cell = Board::GetCell(index_pos);
     const Spell & spell = humanturn_spell;
@@ -1465,19 +1465,19 @@ int Battle::Interface::GetBattleSpellCursor(std::string & status)
 	{
 	    if(!b_stats && cell->isPassable3(*b_current, false))
 	    {
-		status = _("Teleport Here");
+		statusL = _("Teleport Here");
 		return Cursor::SP_TELEPORT;
 	    }
 
-	    status = _("Invalid Teleport Destination");
+	    statusL = _("Invalid Teleport Destination");
 	    return Cursor::WAR_NONE;
 	}
 	else
 	if(b_stats && b_stats->AllowApplySpell(spell, b_current->GetCommander()))
 	{
-	    status = _("Cast %{spell} on %{monster}");
-	    StringReplace(status, "%{spell}", spell.GetName());
-	    StringReplace(status, "%{monster}", b_stats->GetName());
+	    statusL = _("Cast %{spell} on %{monster}");
+	    StringReplace(statusL, "%{spell}", spell.GetName());
+	    StringReplace(statusL, "%{monster}", b_stats->GetName());
 	    return GetCursorFromSpell(spell());
     	}
 	else
@@ -1485,13 +1485,13 @@ int Battle::Interface::GetBattleSpellCursor(std::string & status)
 	   !spell.isApplyToEnemies() &&
 	   !spell.isApplyToAnyTroops())
 	{
-	    status = _("Cast %{spell}");
-	    StringReplace(status, "%{spell}", spell.GetName());
+	    statusL = _("Cast %{spell}");
+	    StringReplace(statusL, "%{spell}", spell.GetName());
 	    return GetCursorFromSpell(spell());
 	}
     }
 
-    status = _("Select Spell Target");
+    statusL = _("Select Spell Target");
 
     return Cursor::WAR_NONE;
 }
@@ -4248,27 +4248,27 @@ void Battle::PopupDamageInfo::Redraw(int maxw, int maxh)
 	int tw = 5 + (text1.w() > text2.w() ? text1.w() : text2.w());
 	int th = (text1.h() + text2.h());
 
-	const Rect & area = GetArea();
-	const Rect & rect = GetRect();
+	const Rect & areaL = GetArea();
+	const Rect & rectL = GetRect();
 	const Rect & pos = cell->GetPos();
 
-	int tx = rect.x;
-	int ty = rect.y;
+	int tx = rectL.x;
+	int ty = rectL.y;
 
-	if(rect.x + rect.w > maxw)
+	if(rectL.x + rectL.w > maxw)
 	{
-	    tx = maxw - rect.w - 5;
+	    tx = maxw - rectL.w - 5;
 	    ty = pos.y - pos.h;
 	}
 
-	if(rect.x != tx || rect.y != ty || area.w != tw || area.h != th)
+	if(rectL.x != tx || rectL.y != ty || areaL.w != tw || areaL.h != th)
 	    SetPosition(tx, ty, tw, th);
 
 	const Sprite & sf = AGG::GetICN(ICN::CELLWIN, 1);
 	Dialog::FrameBorder::RenderOther(sf, GetRect());
 
-	text1.Blit(area.x, area.y);
-	text2.Blit(area.x, area.y + area.h/2);
+	text1.Blit(areaL.x, areaL.y);
+	text2.Blit(areaL.x, areaL.y + areaL.h/2);
     }
 }
 

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -1599,7 +1599,7 @@ bool Castle::HaveNearlySea(void) const
 	const s32 index = Maps::GetIndexFromAbsPoint(center.x, center.y + 2);
 	const Maps::Tiles & left = world.GetTiles(index - 1);
 	const Maps::Tiles & right = world.GetTiles(index + 1);
-	const Maps::Tiles & center = world.GetTiles(index);
+	const Maps::Tiles & worldCenter = world.GetTiles(index);
 
 	return left.isWater() || right.isWater() || center.isWater();
     }
@@ -1624,7 +1624,7 @@ bool Castle::PresentBoat(void) const
 	{
 	    const Maps::Tiles & left = world.GetTiles(index - 1);
 	    const Maps::Tiles & right = world.GetTiles(index + 1);
-	    const Maps::Tiles & center = world.GetTiles(index);
+	    const Maps::Tiles & worldCenter = world.GetTiles(index);
 
 	    if(TilePresentBoat(left) || TilePresentBoat(right) || TilePresentBoat(center)) return true;
 	}
@@ -1930,7 +1930,7 @@ bool Castle::BuyBoat(void)
     const s32 index = Maps::GetIndexFromAbsPoint(center.x, center.y + 2);
     Maps::Tiles & left = world.GetTiles(index - 1);
     Maps::Tiles & right = world.GetTiles(index + 1);
-    Maps::Tiles & center = world.GetTiles(index);
+    Maps::Tiles & worldCenter = world.GetTiles(index);
     Kingdom & kingdom = GetKingdom();
 
     if(MP2::OBJ_ZERO == left.GetObject() && left.isWater())

--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -65,20 +65,20 @@ void SettingsListBox::RedrawItem(const u32 & item, s32 ox, s32 oy, bool current)
 	msg.Blit(ox + cell.w() + 5, oy + 4);
 }
 
-void SettingsListBox::RedrawBackground(const Point & top)
+void SettingsListBox::RedrawBackground(const Point & topL)
 {
     const Settings & conf = Settings::Get();
 
     const int window_h = conf.QVGA() ? 224 : 400;
     const int ah = window_h - 54;
 
-    AGG::GetICN(ICN::STONEBAK, 0).Blit(Rect(15, 25, 280, ah), top.x + 15, top.y + 25);
+    AGG::GetICN(ICN::STONEBAK, 0).Blit(Rect(15, 25, 280, ah), topL.x + 15, topL.y + 25);
 
     for(int ii = 1; ii < (window_h / 25); ++ii)
-	AGG::GetICN(ICN::DROPLISL, 11).Blit(top.x + 295, top.y + 35 + (19 * ii));
+	AGG::GetICN(ICN::DROPLISL, 11).Blit(topL.x + 295, topL.y + 35 + (19 * ii));
 
-    AGG::GetICN(ICN::DROPLISL, 10).Blit(top.x + 295, top.y + 46);
-    AGG::GetICN(ICN::DROPLISL, 12).Blit(top.x + 295, top.y + ah - 14);
+    AGG::GetICN(ICN::DROPLISL, 10).Blit(topL.x + 295, topL.y + 46);
+    AGG::GetICN(ICN::DROPLISL, 12).Blit(topL.x + 295, topL.y + ah - 14);
 }
 
 void SettingsListBox::ActionListDoubleClick(u32 & item)

--- a/src/fheroes2/gui/interface_icons.cpp
+++ b/src/fheroes2/gui/interface_icons.cpp
@@ -382,13 +382,13 @@ void Interface::IconsPanel::SetPos(s32 ox, s32 oy)
 
     BorderWindow::SetPosition(ox, oy, 144, iconsCount * ICONS_CURSOR_HEIGHT);
 
-    const Rect & area = GetArea();
+    const Rect & windowArea = GetArea();
 
     heroesIcons.SetIconsCount(iconsCount);
     castleIcons.SetIconsCount(iconsCount);
 
-    heroesIcons.SetPos(area.x, area.y);
-    castleIcons.SetPos(area.x + 72, area.y);
+    heroesIcons.SetPos(windowArea.x, windowArea.y);
+    castleIcons.SetPos(windowArea.x + 72, windowArea.y);
 }
 
 void Interface::IconsPanel::Redraw(void)

--- a/src/fheroes2/gui/interface_radar.cpp
+++ b/src/fheroes2/gui/interface_radar.cpp
@@ -118,7 +118,7 @@ void Interface::Radar::Build(void)
 /* generate mini maps */
 void Interface::Radar::Generate(void)
 {
-    const Size & area = GetArea();
+    const Size & radarArea = GetArea();
     const s32 world_w = world.w();
     const s32 world_h = world.h();
 
@@ -148,29 +148,29 @@ void Interface::Radar::Generate(void)
 	}
     }
 
-    if(spriteArea.GetSize() != area)
+    if(spriteArea.GetSize() != radarArea)
     {
         Size new_sz;
 
         if(world_w < world_h)
         {
-            new_sz.w = (world_w * area.h) / world_h;
-            new_sz.h = area.h;
-            offset.x = (area.w - new_sz.w) / 2;
+            new_sz.w = (world_w * radarArea.h) / world_h;
+            new_sz.h = radarArea.h;
+            offset.x = (radarArea.w - new_sz.w) / 2;
             offset.y = 0;
         }
         else
         if(world_w > world_h)
         {
-            new_sz.w = area.w;
-            new_sz.h = (world_h * area.w) / world_w;
+            new_sz.w = radarArea.w;
+            new_sz.h = (world_h * radarArea.w) / world_w;
             offset.x = 0;
-            offset.y = (area.h - new_sz.h) / 2;
+            offset.y = (radarArea.h - new_sz.h) / 2;
         }
         else
         {
-            new_sz.w = area.w;
-            new_sz.h = area.h;
+            new_sz.w = radarArea.w;
+            new_sz.h = radarArea.h;
         }
 
         spriteArea = spriteArea.RenderScale(new_sz);
@@ -191,7 +191,7 @@ void Interface::Radar::Redraw(void)
 {
     Display & display = Display::Get();
     const Settings & conf = Settings::Get();
-    const Rect & area = GetArea();
+    const Rect & radarArea = GetArea();
 
     if(conf.ExtGameHideInterface() && conf.ShowRadar())
     {
@@ -204,12 +204,12 @@ void Interface::Radar::Redraw(void)
     if(! conf.ExtGameHideInterface() || conf.ShowRadar())
     {
 	if(hide)
-	    AGG::GetICN((conf.ExtGameEvilInterface() ? ICN::HEROLOGE : ICN::HEROLOGO), 0).Blit(area.x, area.y);
+	    AGG::GetICN((conf.ExtGameEvilInterface() ? ICN::HEROLOGE : ICN::HEROLOGO), 0).Blit(radarArea.x, radarArea.y);
 	else
 	{
-	    if(world.w() != world.h()) display.FillRect(area, ColorBlack);
+	    if(world.w() != world.h()) display.FillRect(radarArea, ColorBlack);
 	    cursorArea.Hide();
-	    spriteArea.Blit(area.x + offset.x, area.y + offset.y, display);
+	    spriteArea.Blit(radarArea.x + offset.x, radarArea.y + offset.y, display);
 	    RedrawObjects(Players::FriendColors());
 	    RedrawCursor();
 	}
@@ -236,14 +236,14 @@ int GetChunkSize(float size1, float size2)
 void Interface::Radar::RedrawObjects(int color)
 {
     Display & display = Display::Get();
-    const Rect & area = GetArea();
+    const Rect & radarArea = GetArea();
     const s32 world_w = world.w();
     const s32 world_h = world.h();
-    const int areaw = (offset.x ? area.w - 2 * offset.x : area.w);
-    const int areah = (offset.y ? area.h - 2 * offset.y : area.h);
+    const int areaw = (offset.x ? radarArea.w - 2 * offset.x : radarArea.w);
+    const int areah = (offset.y ? radarArea.h - 2 * offset.y : radarArea.h);
 
-    int stepx = world_w / area.w;
-    int stepy = world_h / area.h;
+    int stepx = world_w / radarArea.w;
+    int stepy = world_h / radarArea.h;
 
     if(0 == stepx) stepx = 1;
     if(0 == stepy) stepy = 1;
@@ -304,8 +304,8 @@ void Interface::Radar::RedrawObjects(int color)
 		}
 	    }
 
-            const int dstx = area.x + offset.x + (xx * areaw) / world_w;
-            const int dsty = area.y + offset.y + (yy * areah) / world_h;
+            const int dstx = radarArea.x + offset.x + (xx * areaw) / world_w;
+            const int dsty = radarArea.y + offset.y + (yy * areah) / world_h;
 
             if(sw > 1)
             {
@@ -326,11 +326,11 @@ void Interface::Radar::RedrawCursor(void)
 
     if(! conf.ExtGameHideInterface() || conf.ShowRadar())
     {
-	const Rect & area = GetArea();
+	const Rect & radarArea = GetArea();
 	const Rect & rectMaps = interface.GetGameArea().GetRectMaps();
 
-	s32 areaw = (offset.x ? area.w - 2 * offset.x : area.w);
-	s32 areah = (offset.y ? area.h - 2 * offset.y : area.h);
+	s32 areaw = (offset.x ? radarArea.w - 2 * offset.x : radarArea.w);
+	s32 areah = (offset.y ? radarArea.h - 2 * offset.y : radarArea.h);
 
         const Size sz((rectMaps.w * areaw) / world.w(),
                         (rectMaps.h * areah) / world.h());
@@ -342,8 +342,8 @@ void Interface::Radar::RedrawCursor(void)
             cursorArea.DrawBorder(AGG::GetPaletteColor(RADARCOLOR), false);
 	}
 
-        cursorArea.Move(area.x + offset.x + (rectMaps.x * areaw) / world.w(),
-            		    area.y + offset.y + (rectMaps.y * areah) / world.h());
+        cursorArea.Move(radarArea.x + offset.x + (rectMaps.x * radarAreaw) / world.w(),
+            		    radarArea.y + offset.y + (rectMaps.y * areah) / world.h());
     }
 }
 
@@ -352,7 +352,7 @@ void Interface::Radar::QueueEventProcessing(void)
     GameArea & gamearea = interface.GetGameArea();
     Settings & conf = Settings::Get();
     LocalEvent & le = LocalEvent::Get();
-    const Rect & area = GetArea();
+    const Rect & radarArea = GetArea();
 
     // move border
     if(conf.ShowRadar() &&
@@ -362,16 +362,16 @@ void Interface::Radar::QueueEventProcessing(void)
     }
     else
     // move cursor
-    if(le.MouseCursor(area))
+    if(le.MouseCursor(radarArea))
     {
 	if(le.MouseClickLeft() || le.MousePressLeft())
 	{
     	    const Point prev(gamearea.GetRectMaps());
     	    const Point & pt = le.GetMouseCursor();
 
-	    if(area & pt)
+	    if(radarArea & pt)
 	    {
-		gamearea.SetCenter((pt.x - area.x) * world.w() / area.w, (pt.y - area.y) * world.h() / area.h);
+		gamearea.SetCenter((pt.x - radarArea.x) * world.w() / area.w, (pt.y - area.y) * world.h() / area.h);
 
     		if(prev != gamearea.GetRectMaps())
     		{
@@ -387,20 +387,20 @@ void Interface::Radar::QueueEventProcessing(void)
 	else
 	if(! conf.QVGA())
 	{
-	    const Rect & area = GetArea();
-	    Size newSize(area.w, area.h);
+	    const Rect & radarArea = GetArea();
+	    Size newSize(radarArea.w, radarArea.h);
 
 	    if(le.MouseWheelUp())
 	    {
-		if(area.w != world.w() ||
-	    		    area.h != world.h())
+		if(radarArea.w != world.w() ||
+	    		    radarArea.h != world.h())
 		    newSize = Size(world.w(), world.h());
 	    }
 	    else
 	    if(le.MouseWheelDn())
 	    {
-		if(area.w != RADARWIDTH ||
-	    		    area.h != RADARWIDTH)
+		if(radarArea.w != RADARWIDTH ||
+	    		    radarArea.h != RADARWIDTH)
 		    newSize = Size(RADARWIDTH, RADARWIDTH);
 	    }
 

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -387,7 +387,7 @@ void Interface::StatusWindow::QueueEventProcessing(void)
     Display & display = Display::Get();
     Cursor & cursor = Cursor::Get();
     LocalEvent & le = LocalEvent::Get();
-    const Rect & area = GetArea();
+    const Rect & gameArea = GetArea();
 
     if(Settings::Get().ShowStatus() &&
 	// move border window
@@ -395,7 +395,7 @@ void Interface::StatusWindow::QueueEventProcessing(void)
     {
     }
     else
-    if(le.MouseClickLeft(area))
+    if(le.MouseClickLeft(gameArea))
     {
         cursor.Hide();
         NextState();

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -492,7 +492,7 @@ void Kingdom::HeroesActionNewPosition(void)
 
 Funds Kingdom::GetIncome(int type /* INCOME_ALL */) const
 {
-    Funds resource;
+    Funds kingdomResource;
 
     if(INCOME_CAPTURED & type)
     {
@@ -501,7 +501,7 @@ Funds Kingdom::GetIncome(int type /* INCOME_ALL */) const
                                     Resource::CRYSTAL, Resource::GEMS, Resource::GOLD, Resource::UNKNOWN };
 
 	for(u32 index = 0; resources[index] != Resource::UNKNOWN; ++index)
-    	    resource += ProfitConditions::FromMine(resources[index]) *
+    	    kingdomResource += ProfitConditions::FromMine(resources[index]) *
                             	    world.CountCapturedMines(resources[index], GetColor());
     }
 
@@ -514,15 +514,15 @@ Funds Kingdom::GetIncome(int type /* INCOME_ALL */) const
     	    const Castle & castle = **it;
 
     	    // castle or town profit
-    	    resource += ProfitConditions::FromBuilding((castle.isCastle() ? BUILD_CASTLE : BUILD_TENT), 0);
+    	    kingdomResource += ProfitConditions::FromBuilding((castle.isCastle() ? BUILD_CASTLE : BUILD_TENT), 0);
 
     	    // statue
     	    if(castle.isBuild(BUILD_STATUE))
-                resource += ProfitConditions::FromBuilding(BUILD_STATUE, 0);
+                kingdomResource += ProfitConditions::FromBuilding(BUILD_STATUE, 0);
 
     	    // dungeon for warlock
 	    if(castle.isBuild(BUILD_SPEC) && Race::WRLK == castle.GetRace())
-                resource += ProfitConditions::FromBuilding(BUILD_SPEC, Race::WRLK);
+                kingdomResource += ProfitConditions::FromBuilding(BUILD_SPEC, Race::WRLK);
 	}
     }
 
@@ -537,13 +537,13 @@ Funds Kingdom::GetIncome(int type /* INCOME_ALL */) const
 	for(u32 index = 0; artifacts[index] != Artifact::UNKNOWN; ++index)
 	    for(KingdomHeroes::const_iterator
 		ith = heroes.begin(); ith != heroes.end(); ++ith)
-    		resource += ProfitConditions::FromArtifact(artifacts[index]) * 
+    		kingdomResource += ProfitConditions::FromArtifact(artifacts[index]) * 
 		    (**ith).GetBagArtifacts().Count(Artifact(artifacts[index]));
 
 	// TAX_LIEN
 	for(KingdomHeroes::const_iterator
 	    ith = heroes.begin(); ith != heroes.end(); ++ith)
-    	    resource -= ProfitConditions::FromArtifact(Artifact::TAX_LIEN) * 
+    	    kingdomResource -= ProfitConditions::FromArtifact(Artifact::TAX_LIEN) * 
 		    (**ith).GetBagArtifacts().Count(Artifact(Artifact::TAX_LIEN));
     }
 
@@ -552,10 +552,10 @@ Funds Kingdom::GetIncome(int type /* INCOME_ALL */) const
 	// estates skill bonus
 	for(KingdomHeroes::const_iterator
 	    ith = heroes.begin(); ith != heroes.end(); ++ith)
-	    resource.gold += (**ith).GetSecondaryValues(Skill::Secondary::ESTATES);
+	    kingdomResource.gold += (**ith).GetSecondaryValues(Skill::Secondary::ESTATES);
     }
 
-    return resource;
+    return kingdomResource;
 }
 
 const Heroes* Kingdom::GetBestHero(void) const

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -902,22 +902,22 @@ bool ArtifactsBar::ActionBarDoubleClick(const Point & cursor, Artifact & art, co
         {
 	    payment_t cost = spell.GetCost();
             u32 answer = 0;
-            std::string msg = _("Do you want to use your knowledge of magical secrets to transcribe the %{spell} Scroll into your spell book?\nThe Scroll will be consumed.\n Spell point: %{sp}");
+            std::string spellMsg = _("Do you want to use your knowledge of magical secrets to transcribe the %{spell} Scroll into your spell book?\nThe Scroll will be consumed.\n Spell point: %{sp}");
 
-            StringReplace(msg, "%{spell}", spell.GetName());
-            StringReplace(msg, "%{sp}", spell.SpellPoint());
+            StringReplace(spellMsg, "%{spell}", spell.GetName());
+            StringReplace(spellMsg, "%{sp}", spell.SpellPoint());
 
 	    if(spell.MovePoint())
             {
-        	msg.append("\n");
-                msg.append("Move point: %{mp}");
-                StringReplace(msg, "%{mp}", spell.MovePoint());
+        	spellMsg.append("\n");
+                spellMsg.append("Move point: %{mp}");
+                StringReplace(spellMsg, "%{mp}", spell.MovePoint());
             }
 
             if(cost.GetValidItemsCount())
-        	answer = Dialog::ResourceInfo("", msg, cost, Dialog::YES|Dialog::NO);
+        	answer = Dialog::ResourceInfo("", spellMsg, cost, Dialog::YES|Dialog::NO);
             else
-        	answer = Dialog::Message("", msg, Font::BIG, Dialog::YES|Dialog::NO);
+        	answer = Dialog::Message("", spellMsg, Font::BIG, Dialog::YES|Dialog::NO);
 
     	    if(answer == Dialog::YES)
 		const_cast<Heroes*>(hero)->TranscribeScroll(art);


### PR DESCRIPTION
I changed the local variable names described in the issue so they wouldn't hide class members. I added context to the names so they are legible.

relates to #158 