### PR TITLE
fix: increase view distance for observation tower

### DIFF
--- a/src/fheroes2/game/game_static.cpp
+++ b/src/fheroes2/game/game_static.cpp
@@ -165,7 +165,7 @@ namespace GameStatic
     u8		whirlpool_lost_percent	= 50;
 
     /* town, castle, heroes, artifact_telescope, object_observation_tower, object_magi_eyes */
-    u8		overview_distance[]	= { 4, 5, 4, 1, 10, 9, 8 };
+    u8		overview_distance[]	= { 4, 5, 4, 1, 20, 9, 8 };
 
     u8		gameover_lost_days	= 7;
 


### PR DESCRIPTION
As I see it, issue #154 has two parts to it:
1. The view distance data for the observation tower is wrong. The value should be increased. I set it to 20, which might be wrong, but it definitely seems to be closer to the answer (see result below).
2. The formula that calculates whether to reveal a tile is incorrect. To reveal a circular area, as in the original game, the vector length should be used, instead of the sum of x and y distances, [here](https://github.com/ihhub/fheroes2/blob/81da835ba4f0403ae8c41c61cace46f69de8b6d2/src/fheroes2/maps/maps.cpp#L318).

This PR addresses the first point. Result:

![image](https://user-images.githubusercontent.com/3101405/66683493-dd535480-ec77-11e9-90e7-feb2d8d230cb.png)
