### PR TITLE
Disable cast a spell for castles

### DIFF
--- a/src/fheroes2/gui/interface_buttons.cpp
+++ b/src/fheroes2/gui/interface_buttons.cpp
@@ -207,6 +207,8 @@ int Interface::ButtonsArea::QueueEventProcessing(void)
 void Interface::ButtonsArea::SetButtonStatus()
 {
     Heroes * currentHero = GetFocusHeroes();
-    const bool isMovementButtonDisabled = (currentHero == NULL) || !currentHero->GetPath().isValid() || !currentHero->MayStillMove();
-    buttonMovement.SetDisable(isMovementButtonDisabled);
+    const bool isMovementButtonDisabled = ( currentHero == NULL ) || !currentHero->GetPath().isValid() || !currentHero->MayStillMove();
+    buttonMovement.SetDisable( isMovementButtonDisabled );
+    const bool isSpellButtonDisabled = ( currentHero == NULL ) || !currentHero->HaveSpellBook();
+    buttonSpell.SetDisable( isSpellButtonDisabled );
 }


### PR DESCRIPTION
Cast a Spell button on main screen must be disabled if castle is selected.

This fixes #147.
