### PR TITLE
Fix font color for creature name

### DIFF
--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -74,7 +74,7 @@ int Dialog::ArmyInfo(const Troop & troop, int flags)
     }
 
     // name
-    text.Set(troop.GetName(), Font::BIG);
+    text.Set( troop.GetName(), Font::YELLOW_BIG );
     dst_pt.x = pos_rt.x + 140 - text.w() / 2;
     dst_pt.y = pos_rt.y + 40;
     text.Blit(dst_pt);

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -80,7 +80,7 @@ int Dialog::ArmyInfo(const Troop & troop, int flags)
     text.Blit(dst_pt);
 
     // count
-    text.Set(GetString(troop.GetCount()));
+    text.Set( GetString(troop.GetCount()), Font::BIG );
     dst_pt.x = pos_rt.x + 140 - text.w() / 2;
     dst_pt.y = pos_rt.y + 225;
     text.Blit(dst_pt);


### PR DESCRIPTION
In the original game font color is yellow, not white.

This fixes #152.