### PR TITLE
Fix application execution after unpacking demo

### DIFF
--- a/script/demo/demo_linux.sh
+++ b/script/demo/demo_linux.sh
@@ -6,5 +6,5 @@ wget https://archive.org/download/HeroesofMightandMagicIITheSuccessionWars_1020/
 unzip h2demo.zip
 rm h2demo.zip
 
-cp -r ./DATA ./../../../
-cp -r ./MAPS ./../../../
+cp -r ./DATA ./../../../data
+cp -r ./MAPS ./../../../maps


### PR DESCRIPTION
Linux filesystem is case-sensitive, so paths which worked for Windows
are unavailable for this OS.