### PR TITLE
Fix shadow for hexes in the battle

### DIFF
--- a/src/engine/surface.cpp
+++ b/src/engine/surface.cpp
@@ -257,6 +257,12 @@ Surface::Surface(const Size & sz, bool amask) : surface(NULL)
     Set(sz.w, sz.h, amask);
 }
 
+Surface::Surface( const Size & sz, u32 bpp, bool amask )
+    : surface( NULL )
+{
+    Set( sz.w, sz.h, bpp, amask );
+}
+
 Surface::Surface(const Size & sz, const SurfaceFormat & fm) : surface(NULL)
 {
     Set(sz.w, sz.h, fm);

--- a/src/engine/surface.h
+++ b/src/engine/surface.h
@@ -71,6 +71,7 @@ class Surface
 public:
     Surface();
     Surface(const Size &, bool amask);
+    Surface( const Size & sz, u32 bpp, bool amask );
     Surface(const Size &, const SurfaceFormat &);
     Surface(const std::string &);
     Surface(const void* pixels, u32 width, u32 height, u32 bytes_per_pixel /* 1, 2, 3, 4 */, bool amask);  /* agg: create raw tile */

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -218,12 +218,9 @@ Surface DrawHexagonShadow(void)
 	h = 52;
     }
 
-    Surface sf(Size(w, h), true);
+    Surface sf( Size( w, h ), 32, true );
     RGBA shadow = RGBA(0, 0, 0, 0x30);
-
     Rect rt(0, l, w, 2 * l);
-    sf.FillRect(rt, shadow);
-
     for(int i = 1; i < w / 2; i += 2)
     {
 	--rt.y;


### PR DESCRIPTION
Shadow which is used to highlight hexes available for unit to move is
displayed incorrectly - it doesn't use alpha channel and overwrites
vertical boundaries of hex.

This fixes #143.