### PR TITLE
Remove third component of app's version

### DIFF
--- a/src/dist/Makefile
+++ b/src/dist/Makefile
@@ -22,13 +22,6 @@ endif
 RES	:=
 ICOFILE	:= ../../image/fheroes2_32x32.ico
 
-ifdef WITH_SVNREV
-ifndef SVNVER
-SVNVER	:= $(shell svnversion ..)
-endif
-CFLAGS	:= $(CFLAGS) -DSVN_REVISION="\"$(SVNVER)\""
-endif
-
 ifdef WITH_ICONS
 RES	:= $(TARGET).res
 endif

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -199,14 +199,7 @@ const settings_t settingsFHeroes2[] =
 std::string Settings::GetVersion(void)
 {
     std::ostringstream os;
-
-    os << static_cast<int>(MAJOR_VERSION) << "." << static_cast<int>(MINOR_VERSION) << "."
-#ifdef SVN_REVISION
-    SVN_REVISION;
-#else
-    "0000";
-#endif
-
+    os << static_cast<int>( MAJOR_VERSION ) << "." << static_cast<int>( MINOR_VERSION );
     return os.str();
 }
 


### PR DESCRIPTION
Third part of the version used to be subversion revision; once the project moved to Git source control version it's no longer required.

This fixes #40.