### PR TITLE
Fix interface buttons in hero dialog

### DIFF
--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -483,23 +483,26 @@ int Castle::OpenDialog(bool readonly, bool fade)
 	    Game::DisableChangeMusic(true);
         Game::OpenHeroesDialog( *heroes.Guard(), false );
 
-            if(selectArmy1.isSelected()) selectArmy1.ResetSelected();
-	    if(selectArmy2.isValid() && selectArmy2.isSelected()) selectArmy2.ResetSelected();
+        if ( selectArmy1.isSelected() )
+            selectArmy1.ResetSelected();
+        if ( selectArmy2.isValid() && selectArmy2.isSelected() )
+            selectArmy2.ResetSelected();
 
-	    need_redraw = true;
-	}
-	else
-	// view hero
-	if(!readonly && heroes.Guest() && le.MouseClickLeft(rectSign2))
-	{
-	    Game::DisableChangeMusic(true);
+        need_redraw = true;
+    }
+    else
+        // view hero
+        if ( !readonly && heroes.Guest() && le.MouseClickLeft( rectSign2 ) ) {
+        Game::DisableChangeMusic( true );
         Game::OpenHeroesDialog( *heroes.Guest(), false );
 
-            if(selectArmy1.isSelected()) selectArmy1.ResetSelected();
-	    if(selectArmy2.isValid() && selectArmy2.isSelected()) selectArmy2.ResetSelected();
+        if ( selectArmy1.isSelected() )
+            selectArmy1.ResetSelected();
+        if ( selectArmy2.isValid() && selectArmy2.isSelected() )
+            selectArmy2.ResetSelected();
 
-	    need_redraw = true;
-	}
+        need_redraw = true;
+    }
 
         // prev castle
 	if(buttonPrevCastle.isEnable() && le.MouseClickLeft(buttonPrevCastle)){ result = Dialog::PREV; break; }

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -481,7 +481,7 @@ int Castle::OpenDialog(bool readonly, bool fade)
 	if(!readonly && heroes.Guard() && le.MouseClickLeft(rectSign1))
 	{
 	    Game::DisableChangeMusic(true);
-	    Game::OpenHeroesDialog(*heroes.Guard());
+        Game::OpenHeroesDialog( *heroes.Guard(), false );
 
             if(selectArmy1.isSelected()) selectArmy1.ResetSelected();
 	    if(selectArmy2.isValid() && selectArmy2.isSelected()) selectArmy2.ResetSelected();
@@ -493,7 +493,7 @@ int Castle::OpenDialog(bool readonly, bool fade)
 	if(!readonly && heroes.Guest() && le.MouseClickLeft(rectSign2))
 	{
 	    Game::DisableChangeMusic(true);
-	    Game::OpenHeroesDialog(*heroes.Guest());
+        Game::OpenHeroesDialog( *heroes.Guest(), false );
 
             if(selectArmy1.isSelected()) selectArmy1.ResetSelected();
 	    if(selectArmy2.isValid() && selectArmy2.isSelected()) selectArmy2.ResetSelected();

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -231,7 +231,7 @@ namespace Game
     void	PlayPickupSound(void);
     void	DisableChangeMusic(bool);
     bool	ChangeMusicDisabled(void);
-    void OpenHeroesDialog( Heroes & hero, bool update_focus = true );
+    void OpenHeroesDialog( Heroes & hero, bool updateFocus = true );
     void	OpenCastleDialog(Castle &);
     std::string GetEncodeString(const std::string &);
 

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -231,7 +231,7 @@ namespace Game
     void	PlayPickupSound(void);
     void	DisableChangeMusic(bool);
     bool	ChangeMusicDisabled(void);
-    void	OpenHeroesDialog(Heroes &);
+    void	OpenHeroesDialog(Heroes & hero, bool update_focus = true);
     void	OpenCastleDialog(Castle &);
     std::string GetEncodeString(const std::string &);
 

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -231,7 +231,7 @@ namespace Game
     void	PlayPickupSound(void);
     void	DisableChangeMusic(bool);
     bool	ChangeMusicDisabled(void);
-    void	OpenHeroesDialog(Heroes & hero, bool update_focus = true);
+    void OpenHeroesDialog( Heroes & hero, bool update_focus = true );
     void	OpenCastleDialog(Castle &);
     std::string GetEncodeString(const std::string &);
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -159,7 +159,7 @@ void Game::OpenCastleDialog(Castle & castle)
 }
 
 /* open heroes wrapper */
-void Game::OpenHeroesDialog( Heroes & hero, bool update_focus )
+void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus )
 {
     const Settings & conf = Settings::Get();
     Kingdom & myKingdom = hero.GetKingdom();
@@ -209,7 +209,7 @@ void Game::OpenHeroesDialog( Heroes & hero, bool update_focus )
 	}
     }
 
-    if ( update_focus ) {
+    if ( updateFocus ) {
         if ( it != myHeroes.end() ) {
             Interface::Basic::Get().SetFocus( *it );
         }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -159,7 +159,7 @@ void Game::OpenCastleDialog(Castle & castle)
 }
 
 /* open heroes wrapper */
-void Game::OpenHeroesDialog(Heroes & hero)
+void Game::OpenHeroesDialog( Heroes & hero, bool update_focus )
 {
     const Settings & conf = Settings::Get();
     Kingdom & myKingdom = hero.GetKingdom();
@@ -209,12 +209,15 @@ void Game::OpenHeroesDialog(Heroes & hero)
 	}
     }
 
-    if(it != myHeroes.end())
-	Interface::Basic::Get().SetFocus(*it);
-    else
-        Interface::Basic::Get().ResetFocus(GameFocus::HEROES);
-
-    Interface::Basic::Get().RedrawFocus();
+    if ( update_focus ) {
+        if ( it != myHeroes.end() ) {
+            Interface::Basic::Get().SetFocus( *it );
+        }
+        else {
+            Interface::Basic::Get().ResetFocus( GameFocus::HEROES );
+        }
+        Interface::Basic::Get().RedrawFocus();
+    }
 }
 
 void ShowNewWeekDialog(void)

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -143,7 +143,7 @@ void StatsHeroesList::ActionListDoubleClick(HeroRow & row, const Point & cursor,
 void StatsHeroesList::ActionListSingleClick(HeroRow & row, const Point & cursor, s32 ox, s32 oy)
 {
     if(row.hero && (Rect(ox + 5, oy + 4, Interface::IconsBar::GetItemWidth(), Interface::IconsBar::GetItemHeight()) & cursor))
-	Game::OpenHeroesDialog(*row.hero);
+        Game::OpenHeroesDialog( *row.hero, false );
 }
 
 void StatsHeroesList::ActionListPressRight(HeroRow & row, const Point & cursor, s32 ox, s32 oy)
@@ -370,7 +370,7 @@ void StatsCastlesList::ActionListSingleClick(CstlRow & row, const Point & cursor
 	    Heroes* hero = row.castle->GetHeroes().GuardFirst();
 	    if(hero)
 	    {
-		Game::OpenHeroesDialog(*hero);
+            Game::OpenHeroesDialog( *hero, false );
 		row.Init(row.castle);
 	    }
 	}

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -371,9 +371,9 @@ void StatsCastlesList::ActionListSingleClick(CstlRow & row, const Point & cursor
 	    if(hero)
 	    {
             Game::OpenHeroesDialog( *hero, false );
-		row.Init(row.castle);
-	    }
-	}
+            row.Init( row.castle );
+        }
+    }
     }
 }
 


### PR DESCRIPTION
Remove image artifacts while being in the castle

When hero's details dialog is opened from inside the castle, after exiting it interface buttons are drawn under the troops panel.

Similar problem is encountered if one opens hero's details dialog from heroes/castles statistics dialog.

This fixes #144.