### PR TITLE
Remove Dismiss button for unhired hero in town

### DIFF
--- a/src/fheroes2/gui/button.cpp
+++ b/src/fheroes2/gui/button.cpp
@@ -60,7 +60,7 @@ bool Button::isDisable(void) const
     return flags & BTN_DISABLE;
 }
 
-bool Button::isVisible( void ) const
+bool Button::isVisible() const
 {
     return flags & BTN_VISIBLE;
 }
@@ -116,9 +116,9 @@ void Button::SetDisable(bool f)
 	flags &= ~(BTN_DISABLE | BTN_PRESSED);
 }
 
-void Button::SetVisible( bool f )
+void Button::SetVisible( bool isVisible )
 {
-    if ( f )
+    if ( isVisible )
         flags |= BTN_VISIBLE;
     else
         flags &= ~BTN_VISIBLE;

--- a/src/fheroes2/gui/button.cpp
+++ b/src/fheroes2/gui/button.cpp
@@ -27,13 +27,13 @@
 #include "dialog.h"
 #include "button.h"
 
-enum { BTN_PRESSED = 0x0080, BTN_DISABLE = 0x0008 };
+enum { BTN_PRESSED = 0x0080, BTN_DISABLE = 0x0008, BTN_VISIBLE = 0x0800};
 
-Button::Button() : flags(0)
+Button::Button() : flags(BTN_VISIBLE)
 {
 }
 
-Button::Button(s32 ox, s32 oy, int icn, u32 index1, u32 index2) : flags(0)
+Button::Button(s32 ox, s32 oy, int icn, u32 index1, u32 index2) : flags(BTN_VISIBLE)
 {
     SetPos(ox, oy);
 
@@ -51,6 +51,11 @@ bool Button::isEnable(void) const
 bool Button::isDisable(void) const
 {
     return flags & BTN_DISABLE;
+}
+
+bool Button::isVisible(void) const
+{
+    return flags & BTN_VISIBLE;
 }
 
 bool Button::isPressed(void) const
@@ -104,6 +109,14 @@ void Button::SetDisable(bool f)
 	flags &= ~(BTN_DISABLE | BTN_PRESSED);
 }
 
+void Button::SetVisible(bool v)
+{
+    if (v)
+        flags |= BTN_VISIBLE;
+    else
+        flags &= ~BTN_VISIBLE;
+}
+
 void Button::Press(void)
 {
     if(isEnable() && isReleased())
@@ -138,6 +151,8 @@ void Button::ReleaseDraw(void)
 
 void Button::Draw(void)
 {
+	if (!this->isVisible())
+		return;
     bool localcursor = false;
     Cursor & cursor = Cursor::Get();
 

--- a/src/fheroes2/gui/button.cpp
+++ b/src/fheroes2/gui/button.cpp
@@ -27,13 +27,20 @@
 #include "dialog.h"
 #include "button.h"
 
-enum { BTN_PRESSED = 0x0080, BTN_DISABLE = 0x0008, BTN_VISIBLE = 0x0800};
+enum
+{
+    BTN_PRESSED = 0x0080,
+    BTN_DISABLE = 0x0008,
+    BTN_VISIBLE = 0x0800
+};
 
-Button::Button() : flags(BTN_VISIBLE)
+Button::Button()
+    : flags( BTN_VISIBLE )
 {
 }
 
-Button::Button(s32 ox, s32 oy, int icn, u32 index1, u32 index2) : flags(BTN_VISIBLE)
+Button::Button( s32 ox, s32 oy, int icn, u32 index1, u32 index2 )
+    : flags( BTN_VISIBLE )
 {
     SetPos(ox, oy);
 
@@ -53,7 +60,7 @@ bool Button::isDisable(void) const
     return flags & BTN_DISABLE;
 }
 
-bool Button::isVisible(void) const
+bool Button::isVisible( void ) const
 {
     return flags & BTN_VISIBLE;
 }
@@ -109,9 +116,9 @@ void Button::SetDisable(bool f)
 	flags &= ~(BTN_DISABLE | BTN_PRESSED);
 }
 
-void Button::SetVisible(bool v)
+void Button::SetVisible( bool f )
 {
-    if (v)
+    if ( f )
         flags |= BTN_VISIBLE;
     else
         flags &= ~BTN_VISIBLE;
@@ -151,8 +158,8 @@ void Button::ReleaseDraw(void)
 
 void Button::Draw(void)
 {
-	if (!this->isVisible())
-		return;
+    if ( !this->isVisible() )
+        return;
     bool localcursor = false;
     Cursor & cursor = Cursor::Get();
 

--- a/src/fheroes2/gui/button.h
+++ b/src/fheroes2/gui/button.h
@@ -35,6 +35,7 @@ public:
 
     bool	isEnable(void) const;
     bool	isDisable(void) const;
+    bool	isVisible(void) const;
     bool	isPressed(void) const;
     bool	isReleased(void) const;
 
@@ -47,6 +48,7 @@ public:
     void	SetSprite(int icn, u32, u32);
     void	SetSprite(const Surface &, const Surface &);
     void	SetDisable(bool);
+    void	SetVisible(bool);
 
     void	Draw(void);
     void	PressDraw(void);

--- a/src/fheroes2/gui/button.h
+++ b/src/fheroes2/gui/button.h
@@ -35,7 +35,7 @@ public:
 
     bool	isEnable(void) const;
     bool	isDisable(void) const;
-    bool	isVisible(void) const;
+    bool isVisible( void ) const;
     bool	isPressed(void) const;
     bool	isReleased(void) const;
 
@@ -48,7 +48,7 @@ public:
     void	SetSprite(int icn, u32, u32);
     void	SetSprite(const Surface &, const Surface &);
     void	SetDisable(bool);
-    void	SetVisible(bool);
+    void SetVisible( bool );
 
     void	Draw(void);
     void	PressDraw(void);

--- a/src/fheroes2/gui/button.h
+++ b/src/fheroes2/gui/button.h
@@ -35,7 +35,7 @@ public:
 
     bool	isEnable(void) const;
     bool	isDisable(void) const;
-    bool isVisible( void ) const;
+    bool isVisible() const;
     bool	isPressed(void) const;
     bool	isReleased(void) const;
 
@@ -48,7 +48,7 @@ public:
     void	SetSprite(int icn, u32, u32);
     void	SetSprite(const Surface &, const Surface &);
     void	SetDisable(bool);
-    void SetVisible( bool );
+    void SetVisible( bool isVisible );
 
     void	Draw(void);
     void	PressDraw(void);

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -201,8 +201,9 @@ int Heroes::OpenDialog(bool readonly, bool fade)
 
     if(inCastle() || readonly || Modes(NOTDISMISS))
     {
-	buttonDismiss.Press();
-	buttonDismiss.SetDisable(true);
+      buttonDismiss.Press();
+      buttonDismiss.SetDisable(true);
+      buttonDismiss.SetVisible(false);
     }
 
     if(readonly || 2 > GetKingdom().GetHeroes().size())
@@ -283,7 +284,7 @@ int Heroes::OpenDialog(bool readonly, bool fade)
     	if(buttonNextHero.isEnable() && le.MouseClickLeft(buttonNextHero)){ return Dialog::NEXT; }
 
     	// dismiss
-    	if(buttonDismiss.isEnable() && le.MouseClickLeft(buttonDismiss) &&
+      if(buttonDismiss.isEnable() && buttonDismiss.isVisible() && le.MouseClickLeft(buttonDismiss) &&
     	      Dialog::YES == Dialog::Message(GetName(), _("Are you sure you want to dismiss this Hero?"), Font::BIG, Dialog::YES | Dialog::NO))
     	    { return Dialog::DISMISS; }
 

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -201,9 +201,9 @@ int Heroes::OpenDialog(bool readonly, bool fade)
 
     if(inCastle() || readonly || Modes(NOTDISMISS))
     {
-      buttonDismiss.Press();
-      buttonDismiss.SetDisable(true);
-      buttonDismiss.SetVisible(false);
+        buttonDismiss.Press();
+        buttonDismiss.SetDisable( true );
+        buttonDismiss.SetVisible( false );
     }
 
     if(readonly || 2 > GetKingdom().GetHeroes().size())
@@ -284,9 +284,10 @@ int Heroes::OpenDialog(bool readonly, bool fade)
     	if(buttonNextHero.isEnable() && le.MouseClickLeft(buttonNextHero)){ return Dialog::NEXT; }
 
     	// dismiss
-      if(buttonDismiss.isEnable() && buttonDismiss.isVisible() && le.MouseClickLeft(buttonDismiss) &&
-    	      Dialog::YES == Dialog::Message(GetName(), _("Are you sure you want to dismiss this Hero?"), Font::BIG, Dialog::YES | Dialog::NO))
-    	    { return Dialog::DISMISS; }
+        if ( buttonDismiss.isEnable() && buttonDismiss.isVisible() && le.MouseClickLeft( buttonDismiss )
+             && Dialog::YES == Dialog::Message( GetName(), _( "Are you sure you want to dismiss this Hero?" ), Font::BIG, Dialog::YES | Dialog::NO ) ) {
+            return Dialog::DISMISS;
+        }
 
         if(le.MouseCursor(moraleIndicator.GetArea())) MoraleIndicator::QueueEventProcessing(moraleIndicator);
         else


### PR DESCRIPTION
- Added visibility for buttons
- set visibility to false for Dismiss button when in town, readonly or NONDISMISS mode