### PR TITLE
make installation scripts readable at completion

### DIFF
--- a/script/demo/demo.bat
+++ b/script/demo/demo.bat
@@ -35,5 +35,8 @@ if not sevenZipPath == "" (
 ) else (
     echo 7z.exe is not found in path. Please unzip files manually.
 )
-echo Press any key to exit...
-pause >nul
+set "isAppveyor=%APPVEYOR_REPO_PROVIDER%"
+if not "%isAppveyor%" == "gitHub" (
+	echo Press any key to exit...
+	pause >nul
+)

--- a/script/demo/demo.bat
+++ b/script/demo/demo.bat
@@ -36,7 +36,7 @@ if not sevenZipPath == "" (
     echo 7z.exe is not found in path. Please unzip files manually.
 )
 
-if not %APPVEYOR_REPO_PROVIDER% == "gitHub" (
+if not "%APPVEYOR_REPO_PROVIDER%" == "gitHub" (
     echo Press any key to exit...
     pause >nul
 )

--- a/script/demo/demo.bat
+++ b/script/demo/demo.bat
@@ -37,6 +37,6 @@ if not sevenZipPath == "" (
 )
 set "isAppveyor=%APPVEYOR_REPO_PROVIDER%"
 if not "%isAppveyor%" == "gitHub" (
-	echo Press any key to exit...
-	pause >nul
+    echo Press any key to exit...
+    pause >nul
 )

--- a/script/demo/demo.bat
+++ b/script/demo/demo.bat
@@ -35,8 +35,8 @@ if not sevenZipPath == "" (
 ) else (
     echo 7z.exe is not found in path. Please unzip files manually.
 )
-set "isAppveyor=%APPVEYOR_REPO_PROVIDER%"
-if not "%isAppveyor%" == "gitHub" (
+
+if not %APPVEYOR_REPO_PROVIDER% == "gitHub" (
     echo Press any key to exit...
     pause >nul
 )

--- a/script/demo/demo.bat
+++ b/script/demo/demo.bat
@@ -35,3 +35,5 @@ if not sevenZipPath == "" (
 ) else (
     echo 7z.exe is not found in path. Please unzip files manually.
 )
+echo Press any key to exit...
+pause >nul

--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -52,5 +52,8 @@ if not sevenZipPath == "" (
 ) else (
     echo "Failed to unzip archives because 7-zip is not installed in system. Please unpack all archives in packages internal folders and manually run setup_packages.bat file after"
 )
-echo Press any key to exit...
-pause >nul
+set "isAppveyor=%APPVEYOR_REPO_PROVIDER%"
+if not "%isAppveyor%" == "gitHub" (
+	echo Press any key to exit...
+	pause >nul
+)

--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -53,7 +53,7 @@ if not sevenZipPath == "" (
     echo "Failed to unzip archives because 7-zip is not installed in system. Please unpack all archives in packages internal folders and manually run setup_packages.bat file after"
 )
 
-if not %APPVEYOR_REPO_PROVIDER% == "gitHub" (
+if not "%APPVEYOR_REPO_PROVIDER%" == "gitHub" (
     echo Press any key to exit...
     pause >nul
 )

--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -52,3 +52,5 @@ if not sevenZipPath == "" (
 ) else (
     echo "Failed to unzip archives because 7-zip is not installed in system. Please unpack all archives in packages internal folders and manually run setup_packages.bat file after"
 )
+echo Press any key to exit...
+pause >nul

--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -52,8 +52,8 @@ if not sevenZipPath == "" (
 ) else (
     echo "Failed to unzip archives because 7-zip is not installed in system. Please unpack all archives in packages internal folders and manually run setup_packages.bat file after"
 )
-set "isAppveyor=%APPVEYOR_REPO_PROVIDER%"
-if not "%isAppveyor%" == "gitHub" (
+
+if not %APPVEYOR_REPO_PROVIDER% == "gitHub" (
     echo Press any key to exit...
     pause >nul
 )

--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -54,6 +54,6 @@ if not sevenZipPath == "" (
 )
 set "isAppveyor=%APPVEYOR_REPO_PROVIDER%"
 if not "%isAppveyor%" == "gitHub" (
-	echo Press any key to exit...
-	pause >nul
+    echo Press any key to exit...
+    pause >nul
 )


### PR DESCRIPTION
If running scripts by double click instead of manually opening cmd- On completion of installation and demo scripts, cmd closes automatically, preventing user from seeing the installation status(whether succeeded or failed at any step)
After the added instructions- both scripts at the completion looks like below screenshots-
![image](https://user-images.githubusercontent.com/6822117/67431741-8e57d880-f602-11e9-84d0-b2b0dc25014a.png)
![image](https://user-images.githubusercontent.com/6822117/67431757-944db980-f602-11e9-9457-4d2ad7e5f188.png)
