### PR TITLE
Make found resources message amount show below resource icon

### DIFF
--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -263,7 +263,7 @@ void Interface::StatusWindow::DrawResourceInfo(int oh) const
     spr.Blit(pos.x + (pos.w - spr.w()) / 2, pos.y + 6 + oh + text.h());
 
     text.Set(GetString(countLastResource), Font::SMALL, pos.w);
-    text.Blit(pos.x + (pos.w - text.w()) / 2, pos.y + 6 + oh + text.h() * 2 + spr.h() + 2);
+    text.Blit(pos.x + (pos.w - text.w()) / 2, pos.y + oh + text.h() * 2 + spr.h() + 8);
 }
 
 void Interface::StatusWindow::DrawArmyInfo(int oh) const

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -263,7 +263,7 @@ void Interface::StatusWindow::DrawResourceInfo(int oh) const
     spr.Blit(pos.x + (pos.w - spr.w()) / 2, pos.y + 6 + oh + text.h());
 
     text.Set(GetString(countLastResource), Font::SMALL, pos.w);
-    text.Blit(pos.x + (pos.w - text.w()) / 2, pos.y + oh + text.h() + spr.h() - 8);
+    text.Blit(pos.x + (pos.w - text.w()) / 2, pos.y + 6 + oh + text.h() * 2 + spr.h() + 2);
 }
 
 void Interface::StatusWindow::DrawArmyInfo(int oh) const


### PR DESCRIPTION
Fixes #204 
Now it looks like this:
![2019-10-27-160612_147x72_scrot](https://user-images.githubusercontent.com/5622899/67639859-d6614e80-f8d3-11e9-9c0f-10155c45f637.png)
