### PR TITLE
Add configuration file into deployment packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
         - sudo apt-get install -y libsdl-mixer1.2-dev
         - sudo apt-get install -y libsdl-image1.2-dev
       before_deploy:
-        - zip fheroes2_linux_sdl1.zip fheroes2 LICENSE script/linux/install_sdl_1.sh script/linux/install_sdl_2.sh script/demo/demo_linux.sh
+        - zip fheroes2_linux_sdl1.zip fheroes2 LICENSE fheroes2.cfg fheroes2.key script/linux/install_sdl_1.sh script/linux/install_sdl_2.sh script/demo/demo_linux.sh
         - export TRAVIS_TAG=fheroes2-linux-sdl1_dev
         - git tag -f $TRAVIS_TAG
       deploy:
@@ -44,7 +44,7 @@ matrix:
         - sudo apt-get install -y libsdl2-image-dev
         - export WITH_SDL2="ON"
       before_deploy:
-        - zip fheroes2_linux_sdl2.zip fheroes2 LICENSE script/linux/install_sdl_1.sh script/linux/install_sdl_2.sh script/demo/demo_linux.sh
+        - zip fheroes2_linux_sdl2.zip fheroes2 LICENSE fheroes2.cfg fheroes2.key script/linux/install_sdl_1.sh script/linux/install_sdl_2.sh script/demo/demo_linux.sh
         - export TRAVIS_TAG=fheroes2-linux-sdl2_dev
         - git tag -f $TRAVIS_TAG
       deploy:
@@ -69,7 +69,7 @@ matrix:
         - brew install gettext
         - export PATH="/usr/local/opt/gettext/bin:$PATH"
       before_deploy:
-        - zip fheroes2_osx_sdl1.zip fheroes2 LICENSE script/macos/install_sdl_1.sh script/macos/install_sdl_2.sh script/demo/demo_macos.sh
+        - zip fheroes2_osx_sdl1.zip fheroes2 LICENSE fheroes2.cfg fheroes2.key script/macos/install_sdl_1.sh script/macos/install_sdl_2.sh script/demo/demo_macos.sh
         - export TRAVIS_TAG=ffheroes2-osx-sdl1_dev
         - git tag -f $TRAVIS_TAG
       deploy:
@@ -95,7 +95,7 @@ matrix:
         - export PATH="/usr/local/opt/gettext/bin:$PATH"
         - export WITH_SDL2="ON"
       before_deploy:
-        - zip fheroes2_osx_sdl2.zip fheroes2 LICENSE script/macos/install_sdl_1.sh script/macos/install_sdl_2.sh script/demo/demo_macos.sh
+        - zip fheroes2_osx_sdl2.zip fheroes2 LICENSE fheroes2.cfg fheroes2.key script/macos/install_sdl_1.sh script/macos/install_sdl_2.sh script/demo/demo_macos.sh
         - export TRAVIS_TAG=fheroes2-osx-sdl2_dev
         - git tag -f $TRAVIS_TAG
       deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ after_build:
   - cmd: cd C:\projects\fheroes2\build\%platform%\%configuration%
   - cmd: 7z a fheroes2_%platform%_%deploy_conf_name%.zip fheroes2.exe SDL*.dll
   - cmd: cd C:\projects\fheroes2
-  - cmd: 7z a build\%platform%\%configuration%\fheroes2_%platform%_%deploy_conf_name%.zip script\demo\demo.bat LICENSE
+  - cmd: 7z a build\%platform%\%configuration%\fheroes2_%platform%_%deploy_conf_name%.zip script\demo\demo.bat LICENSE fheroes2.cfg fheroes2.key
 
 artifacts:
   - path: build\$(platform)\$(configuration)\fheroes2_$(platform)_$(deploy_conf_name).zip


### PR DESCRIPTION
Both `fheroes2.cfg` (default config) and `fheroes2.key` (default key bindings) must present in deploy package.

This closes #193.