### PR TITLE
Do not put all scripts into deployed package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
         - sudo apt-get install -y libsdl-mixer1.2-dev
         - sudo apt-get install -y libsdl-image1.2-dev
       before_deploy:
-        - zip fheroes2_linux_sdl1.zip fheroes2 LICENSE fheroes2.cfg fheroes2.key script/linux/install_sdl_1.sh script/linux/install_sdl_2.sh script/demo/demo_linux.sh
+        - zip fheroes2_linux_sdl1.zip fheroes2 LICENSE fheroes2.cfg fheroes2.key script/linux/install_sdl_1.sh script/demo/demo_linux.sh
         - export TRAVIS_TAG=fheroes2-linux-sdl1_dev
         - git tag -f $TRAVIS_TAG
       deploy:
@@ -44,7 +44,7 @@ matrix:
         - sudo apt-get install -y libsdl2-image-dev
         - export WITH_SDL2="ON"
       before_deploy:
-        - zip fheroes2_linux_sdl2.zip fheroes2 LICENSE fheroes2.cfg fheroes2.key script/linux/install_sdl_1.sh script/linux/install_sdl_2.sh script/demo/demo_linux.sh
+        - zip fheroes2_linux_sdl2.zip fheroes2 LICENSE fheroes2.cfg fheroes2.key script/linux/install_sdl_2.sh script/demo/demo_linux.sh
         - export TRAVIS_TAG=fheroes2-linux-sdl2_dev
         - git tag -f $TRAVIS_TAG
       deploy:
@@ -69,7 +69,7 @@ matrix:
         - brew install gettext
         - export PATH="/usr/local/opt/gettext/bin:$PATH"
       before_deploy:
-        - zip fheroes2_osx_sdl1.zip fheroes2 LICENSE fheroes2.cfg fheroes2.key script/macos/install_sdl_1.sh script/macos/install_sdl_2.sh script/demo/demo_macos.sh
+        - zip fheroes2_osx_sdl1.zip fheroes2 LICENSE fheroes2.cfg fheroes2.key script/macos/install_sdl_1.sh script/demo/demo_macos.sh
         - export TRAVIS_TAG=fheroes2-osx-sdl1_dev
         - git tag -f $TRAVIS_TAG
       deploy:
@@ -95,7 +95,7 @@ matrix:
         - export PATH="/usr/local/opt/gettext/bin:$PATH"
         - export WITH_SDL2="ON"
       before_deploy:
-        - zip fheroes2_osx_sdl2.zip fheroes2 LICENSE fheroes2.cfg fheroes2.key script/macos/install_sdl_1.sh script/macos/install_sdl_2.sh script/demo/demo_macos.sh
+        - zip fheroes2_osx_sdl2.zip fheroes2 LICENSE fheroes2.cfg fheroes2.key script/macos/install_sdl_2.sh script/demo/demo_macos.sh
         - export TRAVIS_TAG=fheroes2-osx-sdl2_dev
         - git tag -f $TRAVIS_TAG
       deploy:


### PR DESCRIPTION
There is not need to put SDL2 script for SDL1 build and vice versa