### PR TITLE
Fix shadows in SDL 2

### DIFF
--- a/src/engine/surface.cpp
+++ b/src/engine/surface.cpp
@@ -39,7 +39,11 @@
 
 namespace
 {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+    u32 default_depth = 32;
+#else
     u32 default_depth = 16;
+#endif
     RGBA default_color_key;
     SDL_Color* pal_colors = NULL;
     u32 pal_nums = 0;


### PR DESCRIPTION
Set default alpha channel depth to 32 bit for SDL 2
relates to #176 

<img width="752" alt="Screenshot 2019-11-13 at 1 45 54 PM" src="https://user-images.githubusercontent.com/19829520/68736582-f5721700-061b-11ea-993f-0d1f1db0d32c.png">
