### PR TITLE
Fix transparency for Spellbook

### DIFF
--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -164,7 +164,7 @@ namespace AGG
 
 Sprite ICNSprite::CreateSprite(bool reflect, bool shadow) const
 {
-    Surface res(first.GetSize(), true);
+    Surface res(first.GetSize(), shadow);
     first.Blit(res);
 
     if(shadow && second.isValid())

--- a/src/fheroes2/agg/sprite.cpp
+++ b/src/fheroes2/agg/sprite.cpp
@@ -27,27 +27,6 @@
 #include "display.h"
 #include "sprite.h"
 
-bool SkipLocalAlpha(int icn)
-{
-    switch(icn)
-    {
-        case ICN::SYSTEM:
-        case ICN::SYSTEME:
-        case ICN::BUYBUILD:
-        case ICN::BUYBUILE:
-        case ICN::BOOK:
-        case ICN::CSPANBKE:
-        case ICN::CPANBKGE:
-        case ICN::CAMPBKGE:
-
-            return true;
-
-        default: break;
-    }
-
-    return false;
-}
-
 Sprite::Sprite()
 {
 }


### PR DESCRIPTION
Spellbook is shown in semi-transparent way on Windows build using SDL1.

This fixes #34.