### PR TITLE
Add WITH_DEBUG macro for debug builds on VS

### DIFF
--- a/VisualStudio/Debug.props
+++ b/VisualStudio/Debug.props
@@ -6,6 +6,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WITH_DEBUG;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
`WITH_DEBUG` must be used for Windows debug builds. Also `_DEBUG` must
be set (it's used in TinyXML).

This fixes #239