### PR TITLE
Fix the crash on starting a new game after loading any save

### DIFF
--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -362,8 +362,8 @@ bool LocalEvent::HandleEvents(bool delay)
 	
 	    // exit
 	    case SDL_QUIT:
-		Error::Except(__FUNCTION__, "SDL_QUIT");
-		return false;
+		// Error::Except(__FUNCTION__, "SDL_QUIT");
+		return false; // try to perform clear exit to catch all memory leaks, for example
 
 	    default:
 		break;

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -330,7 +330,7 @@ std::string System::GetTime(void)
 bool System::IsFile(const std::string & name, bool writable)
 {
 #if defined(_MSC_VER)
-    return writable ? ( 0 == _access(name.c_str(), 06) ) : true;
+    return writable ? ( 0 == _access(name.c_str(), 06) ) : ( 0 == _access(name.c_str(), 04) );
 #elif defined(ANDROID)
     return writable ? 0 == access(name.c_str(), W_OK) : true;
 #else

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -346,7 +346,7 @@ bool System::IsFile(const std::string & name, bool writable)
 bool System::IsDirectory(const std::string & name, bool writable)
 {
 #if defined(_MSC_VER)
-    return writable ? ( 0 == _access(name.c_str(), 06) ) : true;
+    return writable ? ( 0 == _access(name.c_str(), 06) ) : ( 0 == _access(name.c_str(), 00) );
 #elif defined(ANDROID)
     return writable ? 0 == access(name.c_str(), W_OK) : true;
 #else

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -140,8 +140,8 @@ int Game::ScenarioInfo(void)
 
     if ( !resetStartingSettings ) { // verify that current map really exists in map's list
         resetStartingSettings = true;
-        const std::string mapName = conf.CurrentFileInfo().name;
-        const std::string mapFileName = System::GetBasename( conf.CurrentFileInfo().file );
+        const std::string & mapName = conf.CurrentFileInfo().name;
+        const std::string & mapFileName = System::GetBasename( conf.CurrentFileInfo().file );
         for ( MapsFileInfoList::const_iterator mapIter = lists.begin(); mapIter != lists.end(); ++mapIter ) {
             if ( ( mapIter->name == mapName ) && ( System::GetBasename( mapIter->file ) == mapFileName ) ) {
                 if ( mapIter->file != conf.CurrentFileInfo().file )

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -134,13 +134,28 @@ int Game::ScenarioInfo(void)
 	back.Blit(top);
     }
 
-    const bool reset_starting_settings = conf.MapsFile().empty() || ! System::IsFile(conf.MapsFile());
+    bool resetStartingSettings = conf.MapsFile().empty();
     Players & players = conf.GetPlayers();
     Interface::PlayersInfo playersInfo(true, !conf.QVGA(), !conf.QVGA());
 
-    // set first maps settings
-    if(reset_starting_settings)
-	conf.SetCurrentFileInfo(lists.front());
+    if ( !resetStartingSettings ) { // verify that current map really exists in map's list
+        resetStartingSettings = true;
+        const std::string mapName = conf.CurrentFileInfo().name;
+        const std::string mapFileName = System::GetBasename( conf.CurrentFileInfo().file );
+        for ( MapsFileInfoList::const_iterator mapIter = lists.begin(); mapIter != lists.end(); ++mapIter ) {
+            if ( ( mapIter->name == mapName ) && ( System::GetBasename( mapIter->file ) == mapFileName ) ) {
+                if ( mapIter->file != conf.CurrentFileInfo().file )
+                    conf.SetCurrentFileInfo( *mapIter );
+
+                resetStartingSettings = false;
+                break;
+            }
+        }
+    }
+
+    // set first map's settings
+    if ( resetStartingSettings )
+        conf.SetCurrentFileInfo( lists.front() );
 
     playersInfo.UpdateInfo(players, pointOpponentInfo, pointClassInfo);
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -706,8 +706,12 @@ int Interface::Basic::HumanTurn(bool isload)
 
 
     // startgame loop
-    while(Game::CANCEL == res && le.HandleEvents())
+    while(Game::CANCEL == res)
     {
+        if (!le.HandleEvents()) {
+            res = Game::QUITGAME;
+            break;
+        }
 	// for pocketpc: auto hide status if start turn
 	if(autohide_status && Game::AnimateInfrequentDelay(Game::AUTOHIDE_STATUS_DELAY))
 	{

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -706,9 +706,8 @@ int Interface::Basic::HumanTurn(bool isload)
 
 
     // startgame loop
-    while(Game::CANCEL == res)
-    {
-        if (!le.HandleEvents()) {
+    while ( Game::CANCEL == res ) {
+        if ( !le.HandleEvents() ) {
             res = Game::QUITGAME;
             break;
         }

--- a/src/fheroes2/kingdom/world_loadmap.cpp
+++ b/src/fheroes2/kingdom/world_loadmap.cpp
@@ -954,7 +954,7 @@ bool World::LoadMapMP2(const std::string & filename)
     if(!fs.open(filename, "rb"))
     {
 	 DEBUG(DBG_GAME|DBG_ENGINE, DBG_WARN, "file not found " << filename.c_str());
-	 Error::Except(__FUNCTION__, "load maps");
+        return false;
     }
 
     MapsIndexes vec_object; // index maps for OBJ_CASTLE, OBJ_HEROES, OBJ_SIGN, OBJ_BOTTLE, OBJ_EVENT

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -699,7 +699,7 @@ bool PrepareMapsFileInfoList(MapsFileInfoList & lists, bool multi)
 
 StreamBase & Maps::operator<< (StreamBase & msg, const FileInfo & fi)
 {
-    msg << System::GetBasename(fi.file) << fi.name << fi.description <<
+    msg << fi.file << fi.name << fi.description <<
 	fi.size_w << fi.size_h << fi.difficulty << static_cast<u8>(KINGDOMMAX);
 
     for(u32 ii = 0; ii < KINGDOMMAX; ++ii)


### PR DESCRIPTION
This is alternative solution for #249, #250.

The reason game was crashed is that only basename of a file of the map was serialized to savegame file, and on read it was expected to be full path.

It makes sense to store path with dirname cause user can set additional paths to maps in `fheroes.cfg`.

Also, I commented here throwing Cancel exception if game's windows is closed during the game (`SDL_QUIT` event) - it crashes game instead of graceful exit, and prevents any leakdumper (e.g. Address Sanitizer) from dumping actual leaks. As a side effect, there can be freezes on exit in some rare cases, please report them if you find any.