### PR TITLE
Fix crash for configuration file cases

### DIFF
--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -712,7 +712,7 @@ std::vector<u8> StreamFile::getRaw(size_t sz)
 {
     std::vector<u8> v(sz ? sz : sizeg(), 0);
     if ( rw && !v.empty() )
-        SDL_RWread( rw, & v[0], v.size(), 1 );
+        SDL_RWread( rw, &v[0], v.size(), 1 );
     return v;
 }
 

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -711,7 +711,8 @@ void StreamFile::putLE16(u16 val)
 std::vector<u8> StreamFile::getRaw(size_t sz)
 {
     std::vector<u8> v(sz ? sz : sizeg(), 0);
-    if(rw) SDL_RWread(rw, & v[0], v.size(), 1);
+    if ( rw && !v.empty() )
+        SDL_RWread( rw, & v[0], v.size(), 1 );
     return v;
 }
 

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -539,18 +539,16 @@ bool SaveMemToFile(const std::vector<u8> & data, const std::string & file)
 std::vector<u8> LoadFileToMem(const std::string & file)
 {
     std::vector<u8> data;
-    SDL_RWops *rw = SDL_RWFromFile(file.c_str(),"rb");
+    SDL_RWops * rw = SDL_RWFromFile( file.c_str(), "rb" );
 
-    if(rw && SDL_RWseek(rw, 0, RW_SEEK_END) != -1)
-    {
-	data.resize(SDL_RWtell(rw));
-	SDL_RWseek(rw, 0, RW_SEEK_SET);
-	SDL_RWread(rw, & data[0], data.size(), 1);
-	SDL_RWclose(rw);
+    if ( ( rw != NULL ) && ( SDL_RWseek( rw, 0, RW_SEEK_END ) > 0 ) ) {
+        data.resize( SDL_RWtell( rw ) );
+        SDL_RWseek( rw, 0, RW_SEEK_SET );
+        SDL_RWread( rw, &data[0], data.size(), 1 );
+        SDL_RWclose( rw );
     }
-    else
-    {
-	ERROR(SDL_GetError());
+    else {
+        ERROR( SDL_GetError() );
     }
 
     return data;

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -542,11 +542,11 @@ std::vector<u8> LoadFileToMem(const std::string & file)
     SDL_RWops * rw = SDL_RWFromFile( file.c_str(), "rb" );
     if ( rw == NULL )
         ERROR( SDL_GetError() );
-    
+
     const Sint64 length = SDL_RWseek( rw, 0, RW_SEEK_END );
     if ( length < 0 )
         ERROR( SDL_GetError() );
-    
+
     if ( length > 0 ) {
         data.resize( length );
         SDL_RWseek( rw, 0, RW_SEEK_SET );

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -540,16 +540,20 @@ std::vector<u8> LoadFileToMem(const std::string & file)
 {
     std::vector<u8> data;
     SDL_RWops * rw = SDL_RWFromFile( file.c_str(), "rb" );
-
-    if ( ( rw != NULL ) && ( SDL_RWseek( rw, 0, RW_SEEK_END ) > 0 ) ) {
-        data.resize( SDL_RWtell( rw ) );
+    if ( rw == NULL )
+        ERROR( SDL_GetError() );
+    
+    const Sint64 length = SDL_RWseek( rw, 0, RW_SEEK_END );
+    if ( length < 0 )
+        ERROR( SDL_GetError() );
+    
+    if ( length > 0 ) {
+        data.resize( length );
         SDL_RWseek( rw, 0, RW_SEEK_SET );
         SDL_RWread( rw, &data[0], data.size(), 1 );
-        SDL_RWclose( rw );
     }
-    else {
-        ERROR( SDL_GetError() );
-    }
+
+    SDL_RWclose( rw );
 
     return data;
 }

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <fstream>
 
 #include "text.h"
 #include "maps.h"
@@ -524,9 +525,13 @@ bool Settings::Save(const std::string & filename) const
 {
     if(filename.empty()) return false;
 
-    StreamFile fs;
-    if(! fs.open(filename, "wb")) return false;
-    fs << String();
+    std::fstream file;
+    file.open( filename, std::fstream::out | std::fstream::trunc );
+    if ( !file )
+        return false;
+
+    const std::string & data = String();
+    file.write( data.data(), data.size() );
 
     return true;
 }

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -526,7 +526,7 @@ bool Settings::Save(const std::string & filename) const
     if(filename.empty()) return false;
 
     std::fstream file;
-    file.open( filename, std::fstream::out | std::fstream::trunc );
+    file.open( filename.data(), std::fstream::out | std::fstream::trunc );
     if ( !file )
         return false;
 


### PR DESCRIPTION
- load empty configuration file
- load corrupted configuration file

Previous configuration file saving was incorrect because **StreamFile** adds
file size information at the beginning of the file causing a crash while
reading text from it.

relates to #255 