### PR TITLE
Fix signs not displaying any information

### DIFF
--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3022,9 +3022,7 @@ void ActionToEyeMagi(Heroes & hero, u32 obj, s32 dst_index)
 
 void ActionToSphinx(Heroes & hero, u32 obj, s32 dst_index)
 {
-    Maps::Tiles & tile = world.GetTiles(dst_index);
-    MapSphinx* riddle = static_cast<MapSphinx*>(world.GetMapObject(tile.GetObjectUID(obj)));
-
+    MapSphinx * riddle = static_cast<MapSphinx *>( world.GetMapObject( dst_index ) );
     if(riddle && riddle->valid)
     {
 	if(Dialog::YES == Dialog::Message("", _("\"I have a riddle for you,\" the Sphinx says. \"Answer correctly, and you shall be rewarded. Answer incorrectly, and you shall be eaten. Do you accept the challenge?\""), Font::BIG, Dialog::YES|Dialog::NO))
@@ -3072,7 +3070,9 @@ void ActionToSphinx(Heroes & hero, u32 obj, s32 dst_index)
 	}
     }
     else
+    {
 	Dialog::Message(MP2::StringObject(obj), _("You come across a giant Sphinx. The Sphinx remains strangely quiet."), Font::BIG, Dialog::OK);
+    }
 
     DEBUG(DBG_GAME, DBG_INFO, hero.GetName());
 }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1377,7 +1377,7 @@ void ActionToPoorLuckObject(Heroes & hero, u32 obj, s32 dst_index)
 void ActionToSign(Heroes & hero, u32 obj, s32 dst_index)
 {
     PlaySoundWarning;
-    MapSign* sign = static_cast<MapSign*>(world.GetMapObject(dst_index));
+    MapSign * sign = static_cast<MapSign *>( world.GetMapObject( dst_index ) );
     Dialog::Message(_("Sign"), (sign ? sign->message : ""), Font::BIG, Dialog::OK);
     DEBUG(DBG_GAME, DBG_INFO, hero.GetName());
 }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3069,8 +3069,7 @@ void ActionToSphinx(Heroes & hero, u32 obj, s32 dst_index)
 	    }
 	}
     }
-    else
-    {
+    else {
 	Dialog::Message(MP2::StringObject(obj), _("You come across a giant Sphinx. The Sphinx remains strangely quiet."), Font::BIG, Dialog::OK);
     }
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1377,8 +1377,7 @@ void ActionToPoorLuckObject(Heroes & hero, u32 obj, s32 dst_index)
 void ActionToSign(Heroes & hero, u32 obj, s32 dst_index)
 {
     PlaySoundWarning;
-    Maps::Tiles & tile = world.GetTiles(dst_index);
-    MapSign* sign = static_cast<MapSign*>(world.GetMapObject(tile.GetObjectUID(obj)));
+    MapSign* sign = static_cast<MapSign*>(world.GetMapObject(dst_index));
     Dialog::Message(_("Sign"), (sign ? sign->message : ""), Font::BIG, Dialog::OK);
     DEBUG(DBG_GAME, DBG_INFO, hero.GetName());
 }

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -226,6 +226,7 @@ void MapSign::LoadFromMP2(s32 index, StreamBuf st)
     message = st.toString();
 
     SetIndex(index);
+    SetUID(index);
     message = Game::GetEncodeString(message);
     DEBUG(DBG_GAME , DBG_INFO, "sign" << ": " << message);
 }

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -51,6 +51,7 @@ void MapEvent::LoadFromMP2(s32 index, StreamBuf st)
     if(1 == st.get())
     {
 	SetIndex(index);
+	SetUID( index );
 
 	// resource
 	resources.wood = st.getLE32();
@@ -117,6 +118,7 @@ void MapSphinx::LoadFromMP2(s32 index, StreamBuf st)
     if(0 == st.get())
     {
 	SetIndex(index);
+	SetUID( index );
 
 	// resource
 	resources.wood = st.getLE32();

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -226,7 +226,7 @@ void MapSign::LoadFromMP2(s32 index, StreamBuf st)
     message = st.toString();
 
     SetIndex(index);
-    SetUID(index);
+    SetUID( index );
     message = Game::GetEncodeString(message);
     DEBUG(DBG_GAME , DBG_INFO, "sign" << ": " << message);
 }

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -170,7 +170,7 @@ namespace MP2
 	u8	unknown4[15];	// 0
     };
 
-    // origin mp2 sign or buttle
+    // origin mp2 sign or bottle
     struct mp2info_t
     {
 	u8	id;		// 0x01


### PR DESCRIPTION
Signs loaded from a map don't have a uid, so each one overwrote the old one in the `world.map_objects` map.

Using the map object index as uid solves this.

Note: I am not familiar enough with the engine to check for all possible side effects. From my quick play test I did not encounter any.

relates to #235 