### PR TITLE
Cancel dialog by close windows button (#321)

### DIFF
--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -374,7 +374,7 @@ int Castle::OpenDialog( bool readonly, bool fade )
     cursor.Show();
     display.Flip();
 
-    int result = Dialog::ZERO;
+    int result = Dialog::CANCEL;
     bool need_redraw = false;
 
     // dialog menu loop

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -371,5 +371,5 @@ int Heroes::OpenDialog( bool readonly, bool fade )
         }
     }
 
-    return Dialog::ZERO;
+    return Dialog::CANCEL;
 }


### PR DESCRIPTION
Close window button cancel current dialog for castle and heroes. This fixes https://github.com/ihhub/fheroes2/issues/321