### PR TITLE
Add hotkey N to start a new game

### DIFF
--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -124,6 +124,7 @@ namespace Interface
         void EventDebug1( void );
         void EventDebug2( void );
 
+        int EventNewGame( void );
         int EventLoadGame( void );
         int EventAdventureDialog( void );
         int EventFileDialog( void );

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -705,6 +705,10 @@ int Interface::Basic::HumanTurn( bool isload )
                 // next town
                 if ( HotKeyPressEvent( Game::EVENT_NEXTTOWN ) )
                 EventNextTown();
+           else
+                // new game
+                if ( HotKeyPressEvent( Game::EVENT_BUTTON_NEWGAME ) )
+                res = EventNewGame();
             else
                 // save game
                 if ( HotKeyPressEvent( Game::EVENT_SAVEGAME ) )

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -213,9 +213,7 @@ int Interface::Basic::EventFileDialog( void )
 {
     switch ( Dialog::FileOptions() ) {
     case Game::NEWGAME:
-        if ( Dialog::YES == Dialog::Message( "", _( "Are you sure you want to restart? (Your current game will be lost)" ), Font::BIG, Dialog::YES | Dialog::NO ) )
-            return Game::NEWGAME;
-        break;
+        return EventNewGame();
 
     case Game::QUITGAME:
         return Game::QUITGAME;
@@ -298,6 +296,13 @@ void Interface::Basic::EventNextTown( void )
 
         RedrawFocus();
     }
+}
+
+int Interface::Basic::EventNewGame( void )
+{
+    return Dialog::YES == Dialog::Message( "", _( "Are you sure you want to restart? (Your current game will be lost)" ), Font::BIG, Dialog::YES | Dialog::NO )
+               ? Game::NEWGAME
+               : Game::CANCEL;
 }
 
 int Interface::Basic::EventSaveGame( void )


### PR DESCRIPTION
Fixes ihhub#335

Verified by pressing `n` in-game and confirming the _New Game_ dialog appears. Works the same as opening File Options and pressing the _New Game_ button.