### PR TITLE
Remove FIXME

### DIFF
--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -237,7 +237,6 @@ u32 Battle::Force::GetSurrenderCost( void ) const
 
     for ( const_iterator it = begin(); it != end(); ++it )
         if ( ( *it )->isValid() ) {
-            // FIXME: orig: 3 titan = 7500
             payment_t payment = ( *it )->GetCost();
             res += payment.gold;
         }


### PR DESCRIPTION
The FIXME is misleading as surrendering with 3 Titans does cost 7500 gold, which is the same as the original.

_Surrendering with 3 Titans in FHeroes2_
![fheroes2](https://user-images.githubusercontent.com/1855194/79054882-ac4be080-7c16-11ea-866c-a0fc3dd3f528.png)

_Surrendering with 3 Titans in HoMM2_
![homm2](https://user-images.githubusercontent.com/1855194/79054883-afdf6780-7c16-11ea-91de-8e5cbce0280c.png)

Closes ihhub#127.
