### PR TITLE
Remove atexit use for SDL2 deinit functions since that causes segfaul…

### DIFF
--- a/fheroes2.cfg
+++ b/fheroes2.cfg
@@ -46,6 +46,18 @@ music = on
 # fullscreen: on off (F4 switch)
 # fullscreen = off
 #
+# change resolution: on off (Not recommended on modern displays)
+# change resolution = off
+#
+# aspect ratio: on off
+# aspect ratio = on
+#
+# bilinear filter: on off
+# bilinear filter = on
+#
+# wait vsync: on off
+# wait vsync = off
+#
 # debug (0 - 9)
 debug = off
 #

--- a/src/engine/display.cpp
+++ b/src/engine/display.cpp
@@ -29,6 +29,8 @@
 #include "tools.h"
 #include "types.h"
 
+Display *display = NULL;
+
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
 Display::Display()
     : window( NULL )
@@ -364,8 +366,7 @@ void Display::Rise( int delay )
 /* get video display */
 Display & Display::Get( void )
 {
-    static Display inside;
-    return inside;
+    return *display;
 }
 
 bool Display::isDisplay( void ) const

--- a/src/engine/display.h
+++ b/src/engine/display.h
@@ -31,7 +31,6 @@ class Texture;
 class Display : public Surface
 {
 public:
-    
     Display();
     ~Display();
 

--- a/src/engine/display.h
+++ b/src/engine/display.h
@@ -41,7 +41,7 @@ public:
     std::string GetInfo( void ) const;
     Size GetMaxMode( bool enable_rotate ) const;
 
-    void SetVideoMode( int w, int h, bool );
+    void SetVideoMode( int w, int h, bool, bool, bool, bool, bool );
     void SetCaption( const char * );
     void SetIcons( Surface & );
 

--- a/src/engine/display.h
+++ b/src/engine/display.h
@@ -31,6 +31,8 @@ class Texture;
 class Display : public Surface
 {
 public:
+    
+    Display();
     ~Display();
 
     static Display & Get( void );
@@ -66,8 +68,6 @@ protected:
     friend class Texture;
 
     bool isDisplay( void ) const;
-
-    Display();
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
     SDL_Window * window;
@@ -106,6 +106,9 @@ protected:
     SDL_Texture * texture;
     int * counter;
 };
+
+extern Display *display;
+
 #else
 class Texture : public Surface
 {

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -143,7 +143,8 @@ int main( int argc, char ** argv )
                 conf.SetAutoVideoMode();
 
             Display & display = Display::Get();
-            display.SetVideoMode( conf.VideoMode().w, conf.VideoMode().h, conf.FullScreen() );
+            display.SetVideoMode( conf.VideoMode().w, conf.VideoMode().h, conf.FullScreen(),
+                conf.ChangeResolution(), conf.AspectRatio(), conf.BilinearFilter(), conf.WaitVsync() );
             display.HideCursor();
             display.SetCaption( GetCaption().c_str() );
 

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -124,7 +124,6 @@ int main( int argc, char ** argv )
         try
 #endif
         {
-
             SetLangEnvPath( conf );
 
             if ( Mixer::isValid() ) {

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -68,6 +68,8 @@ std::string GetCaption( void )
 
 int main( int argc, char ** argv )
 {
+    display = new Display;
+
     Settings & conf = Settings::Get();
     int test = 0;
 
@@ -122,7 +124,6 @@ int main( int argc, char ** argv )
         try
 #endif
         {
-            std::atexit( SDL::Quit );
 
             SetLangEnvPath( conf );
 
@@ -249,6 +250,9 @@ int main( int argc, char ** argv )
             VERBOSE( std::endl << conf.String() );
         }
 #endif
+    delete(display);
+    SDL::Quit();
+
     return EXIT_SUCCESS;
 }
 

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -68,8 +68,6 @@ std::string GetCaption( void )
 
 int main( int argc, char ** argv )
 {
-    display = new Display;
-
     Settings & conf = Settings::Get();
     int test = 0;
 
@@ -124,6 +122,10 @@ int main( int argc, char ** argv )
         try
 #endif
         {
+#if SDL_VERSION_ATLEAST( 2, 0, 0 )
+            display = new Display;
+#endif
+
             SetLangEnvPath( conf );
 
             if ( Mixer::isValid() ) {
@@ -250,7 +252,9 @@ int main( int argc, char ** argv )
             VERBOSE( std::endl << conf.String() );
         }
 #endif
+#if SDL_VERSION_ATLEAST( 2, 0, 0 )
     delete(display);
+#endif
     SDL::Quit();
 
     return EXIT_SUCCESS;

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -235,7 +235,8 @@ void Game::SetFixVideoMode( void )
     if ( conf.VideoMode().h > max_y )
         fixsize.h = max_y;
 
-    Display::Get().SetVideoMode( fixsize.w, fixsize.h, conf.FullScreen() );
+    Display::Get().SetVideoMode( fixsize.w, fixsize.h, conf.FullScreen(), conf.ChangeResolution(),
+        conf.AspectRatio(), conf.BilinearFilter(), conf.WaitVsync() );
 }
 
 /* play all sound from focus area game */

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -77,10 +77,14 @@ enum
     GLOBAL_SHOWBUTTONS = 0x00000800,
     GLOBAL_SHOWSTATUS = 0x00001000,
 
-    GLOBAL_FONTRENDERBLENDED1 = 0x00020000,
-    GLOBAL_FONTRENDERBLENDED2 = 0x00040000,
-    GLOBAL_FULLSCREEN = 0x00400000,
-    GLOBAL_USESWSURFACE = 0x00800000,
+    GLOBAL_FONTRENDERBLENDED1 = 0x00002000,
+    GLOBAL_FONTRENDERBLENDED2 = 0x00004000,
+    GLOBAL_FULLSCREEN = 0x00008000,
+    GLOBAL_USESWSURFACE = 0x00010000,
+    GLOBAL_CHANGE_RESOLUTION = 0x00020000,
+    GLOBAL_ASPECT_RATIO = 0x00040000,
+    GLOBAL_BILINEAR_FILTER = 0x00080000,
+    GLOBAL_WAIT_VSYNC = 0x00100000,
 
     GLOBAL_SOUND = 0x01000000,
     GLOBAL_MUSIC_EXT = 0x02000000,
@@ -126,6 +130,22 @@ const settings_t settingsGeneral[] = {
     {
         GLOBAL_FULLSCREEN,
         "full screen",
+    },
+    {
+        GLOBAL_CHANGE_RESOLUTION,
+        "change resolution",
+    },
+    {
+        GLOBAL_ASPECT_RATIO,
+        "aspect ratio",
+    },
+    {
+        GLOBAL_BILINEAR_FILTER,
+        "bilinear filter",
+    },
+    {
+        GLOBAL_WAIT_VSYNC,
+        "wait vsync",
     },
     {
         GLOBAL_USEUNICODE,
@@ -846,6 +866,10 @@ std::string Settings::String( void ) const
        << "sound volume = " << static_cast<int>( sound_volume ) << std::endl
        << "music volume = " << static_cast<int>( music_volume ) << std::endl
        << "fullscreen = " << ( opt_global.Modes( GLOBAL_FULLSCREEN ) ? "on" : "off" ) << std::endl
+       << "change resolution = " << ( opt_global.Modes( GLOBAL_CHANGE_RESOLUTION ) ? "on" : "off" ) << std::endl
+       << "aspect ratio = " << ( opt_global.Modes( GLOBAL_ASPECT_RATIO ) ? "on" : "off" ) << std::endl
+       << "bilinear filter = " << ( opt_global.Modes( GLOBAL_BILINEAR_FILTER ) ? "on" : "off" ) << std::endl
+       << "wait vsync = " << ( opt_global.Modes( GLOBAL_WAIT_VSYNC ) ? "on" : "off" ) << std::endl
        << "alt resource = " << ( opt_global.Modes( GLOBAL_ALTRESOURCE ) ? "on" : "off" ) << std::endl
        << "debug = " << ( debug ? "on" : "off" ) << std::endl;
 
@@ -1957,6 +1981,26 @@ u32 Settings::MemoryLimit( void ) const
 bool Settings::FullScreen( void ) const
 {
     return System::isEmbededDevice() || opt_global.Modes( GLOBAL_FULLSCREEN );
+}
+
+bool Settings::ChangeResolution( void ) const
+{
+    return opt_global.Modes( GLOBAL_CHANGE_RESOLUTION );
+}
+
+bool Settings::AspectRatio( void ) const
+{
+    return opt_global.Modes( GLOBAL_ASPECT_RATIO );
+}
+
+bool Settings::BilinearFilter( void ) const
+{
+    return opt_global.Modes( GLOBAL_BILINEAR_FILTER );
+}
+
+bool Settings::WaitVsync( void ) const
+{
+    return opt_global.Modes( GLOBAL_WAIT_VSYNC );
 }
 
 StreamBase & operator<<( StreamBase & msg, const Settings & conf )

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -230,6 +230,10 @@ public:
     void SetPosStatus( const Point & );
 
     bool FullScreen( void ) const;
+    bool ChangeResolution( void ) const;
+    bool AspectRatio( void ) const;
+    bool BilinearFilter( void ) const;
+    bool WaitVsync( void ) const;
     bool QVGA( void ) const;
     bool Sound( void ) const;
     bool Music( void ) const;


### PR DESCRIPTION
…ts in X-less configurations.

Fixes this issue:
https://github.com/ihhub/fheroes2/issues/409