### PR TITLE
Recruit Creature Info window has an incorrect position in higher than default resolution

### DIFF
--- a/src/fheroes2/dialog/dialog_recrut.cpp
+++ b/src/fheroes2/dialog/dialog_recrut.cpp
@@ -458,7 +458,7 @@ void Dialog::DwellingInfo( const Monster & monster, u32 available )
     const payment_t paymentMonster = monster.GetCost();
     const Sprite & box = AGG::GetICN( ICN::RECR2BKG, 0 );
 
-    const SpriteBack back( Rect( ( display.w() - box.w() ) / 2, ( display.h() - box.h() ) / 2 - 16, box.w(), box.h() ) );
+    const SpriteBack back( Rect( ( display.w() - box.w() ) / 2, display.h() / 2 - Display::DEFAULT_HEIGHT / 2 + 16, box.w(), box.h() ) );
     const Rect & pos = back.GetArea();
 
     box.Blit( pos.x, pos.y );

--- a/src/fheroes2/dialog/dialog_recrut.cpp
+++ b/src/fheroes2/dialog/dialog_recrut.cpp
@@ -458,7 +458,7 @@ void Dialog::DwellingInfo( const Monster & monster, u32 available )
     const payment_t paymentMonster = monster.GetCost();
     const Sprite & box = AGG::GetICN( ICN::RECR2BKG, 0 );
 
-    const SpriteBack back( Rect( ( display.w() - box.w() ) / 2, 16, box.w(), box.h() ) );
+    const SpriteBack back( Rect( ( display.w() - box.w() ) / 2, ( display.h() - box.h() ) / 2 - 16, box.w(), box.h() ) );
     const Rect & pos = back.GetArea();
 
     box.Blit( pos.x, pos.y );


### PR DESCRIPTION
Yes I read CONTRIBUTING.md, but I can't resist offering an case insensitive access on *nix systems. You have an script/demo/demo_linux.sh that will dl zip, after extraction data directory named by default as "DATA" and need to rename it manually. Please accept the patch, because different HOMM2 distributives have different naming and manual renaming on *nix is a time wasting.

Fixes: #424 