### PR TITLE
Flying movement animation is shifted during battle

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2696,7 +2696,7 @@ void Battle::Interface::RedrawActionFly( Unit & b, const Position & pos )
     const Rect & pos1 = b.GetRectPosition();
     const Rect & pos2 = Board::GetCell( dst )->GetPos();
 
-    Point pt1( pos1.x + ( b.isReflect() ? 0 : pos1.w ), pos1.y );
+    Point pt1( pos1.x, pos1.y );
     Point pt2( pos2.x, pos2.y );
 
     cursor.SetThemes( Cursor::WAR_NONE );


### PR DESCRIPTION
This is a straightforward fix for #216, tested in both branches.

![fix](https://user-images.githubusercontent.com/1373638/80853396-9c646280-8bfe-11ea-8fb7-1828e1fe0529.png)