### PR TITLE
Fix morale and luck events

### DIFF
--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -55,7 +55,7 @@ void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, s32 dst, in
     }
     else
         attacker.UpdateDirection( board[dst].GetPos() );
-    
+
     // check luck right before the attack
     attacker.SetRandomLuck();
 

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -55,6 +55,9 @@ void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, s32 dst, in
     }
     else
         attacker.UpdateDirection( board[dst].GetPos() );
+    
+    // check luck right before the attack
+    attacker.SetRandomLuck();
 
     TargetsInfo targets = GetTargetsForDamage( attacker, defender, dst );
 

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -337,6 +337,12 @@ void Battle::Arena::TurnTroop( Unit * current_troop )
 
     DEBUG( DBG_BATTLE, DBG_TRACE, current_troop->String( true ) );
 
+    // morale check right before the turn
+    if ( !current_troop->Modes( SP_BLIND | IS_PARALYZE_MAGIC ) ) {
+        if ( current_troop->isAffectedByMorale() )
+            current_troop->SetRandomMorale();
+    }
+
     while ( !end_turn ) {
         // bad morale
         if ( current_troop->Modes( MORALE_BAD ) ) {

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -531,15 +531,6 @@ void Battle::Unit::NewTurn( void )
             mirror = NULL;
         }
     }
-
-    if ( !Modes( SP_BLIND | IS_PARALYZE_MAGIC ) ) {
-        // define morale
-        if ( isAffectedByMorale() )
-            SetRandomMorale();
-
-        // define luck
-        SetRandomLuck();
-    }
 }
 
 u32 Battle::Unit::GetSpeed( bool skip_standing_check ) const

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -414,77 +414,39 @@ s32 Battle::Unit::GetTailIndex( void ) const
 
 void Battle::Unit::SetRandomMorale( void )
 {
-    switch ( GetMorale() ) {
-    case Morale::TREASON:
-        if ( 9 > Rand::Get( 1, 16 ) )
+    s32 morale = GetMorale();
+
+    // Bone dragon affects morale, not luck
+    if ( GetArena()->GetForce( GetArmyColor(), true ).HasMonster( Monster::BONE_DRAGON ) && morale > Morale::TREASON )
+        --morale;
+
+    if ( morale > 0 && Rand::Get( 1, 24 ) <= morale ) {
+        SetModes( MORALE_GOOD );
+    }
+    else if ( morale < 0 && Rand::Get( 1, 12 ) <= -morale ) {
+        if ( GetColor() == Settings::Get().GetPlayers().GetCurrent()->GetColor() ) {
             SetModes( MORALE_BAD );
-        break; // 50%
-    case Morale::AWFUL:
-        if ( 6 > Rand::Get( 1, 15 ) )
+        }
+        // AI is given a cheeky 25% chance to avoid it
+        else if ( Rand::Get( 1, 4 ) != 1 ) {
             SetModes( MORALE_BAD );
-        break; // 30%
-    case Morale::POOR:
-        if ( 2 > Rand::Get( 1, 15 ) )
-            SetModes( MORALE_BAD );
-        break; // 15%
-    case Morale::GOOD:
-        if ( 2 > Rand::Get( 1, 15 ) )
-            SetModes( MORALE_GOOD );
-        break; // 15%
-    case Morale::GREAT:
-        if ( 6 > Rand::Get( 1, 15 ) )
-            SetModes( MORALE_GOOD );
-        break; // 30%
-    case Morale::BLOOD:
-        if ( 9 > Rand::Get( 1, 16 ) )
-            SetModes( MORALE_GOOD );
-        break; // 50%
-    default:
-        break;
+        }
     }
 }
 
 void Battle::Unit::SetRandomLuck( void )
 {
-    s32 f = GetLuck();
+    s32 luck = GetLuck();
+    u32 chance = Rand::Get( 1, 24 );
 
-    // check enemy: have bone dragon
-    if ( GetArena()->GetForce( GetArmyColor(), true ).HasMonster( Monster::BONE_DRAGON ) )
-        --f;
-
-    switch ( f ) {
-    case Luck::CURSED:
-        if ( 9 > Rand::Get( 1, 16 ) )
-            SetModes( LUCK_BAD );
-        break; // 50%
-    case Luck::AWFUL:
-        if ( 6 > Rand::Get( 1, 15 ) )
-            SetModes( LUCK_BAD );
-        break; // 30%
-    case Luck::BAD:
-        if ( 2 > Rand::Get( 1, 15 ) )
-            SetModes( LUCK_BAD );
-        break; // 15%
-    case Luck::GOOD:
-        if ( 2 > Rand::Get( 1, 15 ) )
-            SetModes( LUCK_GOOD );
-        break; // 15%
-    case Luck::GREAT:
-        if ( 6 > Rand::Get( 1, 15 ) )
-            SetModes( LUCK_GOOD );
-        break; // 30%
-    case Luck::IRISH:
-        if ( 9 > Rand::Get( 1, 16 ) )
-            SetModes( LUCK_GOOD );
-        break; // 50%
-    default:
-        break;
+    if ( luck > 0 && chance <= luck ) {
+        SetModes( LUCK_GOOD );
+    }
+    else if ( luck < 0 && chance <= -luck ) {
+        SetModes( LUCK_BAD );
     }
 
-    if ( Modes( SP_BLESS ) && Modes( LUCK_GOOD ) )
-        ResetModes( LUCK_GOOD );
-    else if ( Modes( SP_CURSE ) && Modes( LUCK_BAD ) )
-        ResetModes( LUCK_BAD );
+    // Bless, Curse and Luck do stack
 }
 
 bool Battle::Unit::isFly( void ) const

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -424,10 +424,10 @@ void Battle::Unit::SetRandomMorale( void )
         SetModes( MORALE_GOOD );
     }
     else if ( morale < 0 && Rand::Get( 1, 12 ) <= -morale ) {
-        if ( GetColor() == Settings::Get().GetPlayers().GetCurrent()->GetColor() ) {
+        if ( isControlHuman() ) {
             SetModes( MORALE_BAD );
         }
-        // AI is given a cheeky 25% chance to avoid it
+        // AI is given a cheeky 25% chance to avoid it - because they build armies from random troops
         else if ( Rand::Get( 1, 4 ) != 1 ) {
             SetModes( MORALE_BAD );
         }

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -643,13 +643,13 @@ int Heroes::GetMorale( void ) const
 
 int Heroes::GetMoraleWithModificators( std::string * strs ) const
 {
+    if ( army.AllTroopsIsRace( Race::NECR ) )
+        return Morale::NORMAL;
+
     int result = Morale::NORMAL;
 
     // bonus artifact
     result += GetMoraleModificator( strs );
-
-    if ( army.AllTroopsIsRace( Race::NECR ) )
-        return Morale::NORMAL;
 
     // bonus leadership
     result += Skill::GetLeadershipModifiers( GetLevelSkill( Skill::Secondary::LEADERSHIP ), strs );


### PR DESCRIPTION
The previous ratios were ridiculous; I've set it to original formulas. Fixes #236  and fixes #221 
Now luck can trigger on both double attacks and isn't disabled by the bless.