### PR TITLE
GUI: Fix value input selectors

### DIFF
--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -714,8 +714,6 @@ bool PressIntKey( u32 max, u32 & result )
 
     if ( le.KeyPress( KEY_BACKSPACE ) ) {
         result /= 10;
-        if ( result < 0 )
-            result = 0;
         return true;
     }
     else if ( le.KeyPress() && KEY_0 <= le.KeyValue() && KEY_9 >= le.KeyValue() ) {

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -708,16 +708,14 @@ std::vector<u8> LoadFileToMem( const std::string & file )
     return data;
 }
 
-bool PressIntKey( u32 min, u32 max, u32 & result )
+bool PressIntKey( u32 max, u32 & result )
 {
     LocalEvent & le = LocalEvent::Get();
 
     if ( le.KeyPress( KEY_BACKSPACE ) ) {
-        if ( min < result ) {
-            result /= 10;
-            if ( result < min )
-                result = min;
-        }
+        result /= 10;
+        if ( result < 0 )
+            result = 0;
         return true;
     }
     else if ( le.KeyPress() && KEY_0 <= le.KeyValue() && KEY_9 >= le.KeyValue() ) {

--- a/src/engine/tools.h
+++ b/src/engine/tools.h
@@ -63,7 +63,7 @@ std::string InsertString( const std::string &, size_t, const char * );
 size_t InsertKeySym( std::string &, size_t, KeySym, u16 mod = 0 );
 KeySym KeySymFromChar( char );
 char CharFromKeySym( KeySym, u16 mod = 0 );
-bool PressIntKey( u32 min, u32 max, u32 & result );
+bool PressIntKey( u32 max, u32 & result );
 
 bool SaveMemToFile( const std::vector<u8> &, const std::string & );
 std::vector<u8> LoadFileToMem( const std::string & );

--- a/src/fheroes2/battle/battle_only.cpp
+++ b/src/fheroes2/battle/battle_only.cpp
@@ -610,8 +610,7 @@ void Battle::Only::RedrawBaseInfo( const Point & top )
     std::string message = "%{name1} vs %{name2}";
 
     StringReplace( message, "%{name1}", std::string( Race::String( hero1->GetRace() ) ) + " " + hero1->GetName() );
-    if ( hero2 )
-        StringReplace( message, "%{name2}", ( hero2 ? std::string( Race::String( hero2->GetRace() ) ) + " " + hero2->GetName() : "Monsters" ) );
+    StringReplace( message, "%{name2}", ( hero2 ? std::string( Race::String( hero2->GetRace() ) ) + " " + hero2->GetName() : "Monsters" ) );
 
     Text text( message, Font::BIG );
     text.Blit( top.x + 320 - text.w() / 2, top.y + 26 );

--- a/src/fheroes2/dialog/dialog_recrut.cpp
+++ b/src/fheroes2/dialog/dialog_recrut.cpp
@@ -348,7 +348,7 @@ Troop Dialog::RecruitMonster( const Monster & monster0, u32 available, bool ext 
             redraw = true;
         }
 
-        if ( PressIntKey( 0, max, result ) ) {
+        if ( PressIntKey( max, result ) ) {
             paymentCosts = paymentMonster * result;
             redraw = true;
             maxmin.clear();

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -160,7 +160,7 @@ bool Dialog::SelectCount( const std::string & header, u32 min, u32 max, u32 & cu
     // message loop
     int result = Dialog::ZERO;
     while ( result == Dialog::ZERO && le.HandleEvents() ) {
-        if ( PressIntKey( min, max, cur ) ) {
+        if ( PressIntKey( max, cur ) ) {
             sel.SetCur( cur );
             redraw_count = true;
         }
@@ -385,7 +385,7 @@ int Dialog::ArmySplitTroop( int free_slots, u32 max, u32 & cur, bool savelast )
     // message loop
     int bres = Dialog::ZERO;
     while ( bres == Dialog::ZERO && le.HandleEvents() ) {
-        if ( PressIntKey( min, max, cur ) ) {
+        if ( PressIntKey( max, cur ) ) {
             sel.SetCur( cur );
             redraw_count = true;
         }


### PR DESCRIPTION
Currently it was impossible to enter a number starting from anything else than 1. Since `PressIntKey` handles only one keystroke validation should be done outside. Plus fixed a title string on BattleOnly screen.

![image](https://user-images.githubusercontent.com/1373638/81127785-5fa1af80-8f0d-11ea-9386-f7f861f24628.png)