### PR TITLE
Battle logic: fix Genie special ability

### DIFF
--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -509,9 +509,6 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( Unit & attacker, Unit & 
     }
     // around hydra
     else if ( attacker.GetID() == Monster::HYDRA ) {
-        std::vector<Unit *> v;
-        v.reserve( 8 );
-
         const Indexes around = Board::GetAroundIndexes( attacker );
 
         for ( Indexes::const_iterator it = around.begin(); it != around.end(); ++it ) {

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -481,17 +481,15 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( Unit & attacker, Unit & 
     res.defender = &defender;
     res.damage = attacker.GetDamage( defender );
 
-    // Genie special attack (20%, genie likes number 2)
-    if ( attacker.GetID() == Monster::GENIE && Rand::Get( 1, 5 ) == 2 ) {
-        if ( defender.GetHitPoints() / 2 > res.damage ) {
-            // Replaces the damage, not adding to it
-            res.damage = defender.GetHitPoints() / 2;
+    // Genie special attack
+    if ( attacker.GetID() == Monster::GENIE && Rand::Get( 1, 10 ) == 2 && defender.GetHitPoints() / 2 > res.damage ) {
+        // Replaces the damage, not adding to it
+        res.damage = defender.GetHitPoints() / 2;
 
-            if ( Arena::GetInterface() ) {
-                std::string str( _( "%{name} half the enemy troops!" ) );
-                StringReplace( str, "%{name}", attacker.GetName() );
-                Arena::GetInterface()->SetStatus( str, true );
-            }
+        if ( Arena::GetInterface() ) {
+            std::string str( _( "%{name} half the enemy troops!" ) );
+            StringReplace( str, "%{name}", attacker.GetName() );
+            Arena::GetInterface()->SetStatus( str, true );
         }
     }
     targets.push_back( res );

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -482,7 +482,7 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( Unit & attacker, Unit & 
     res.damage = attacker.GetDamage( defender );
 
     // Genie special attack (20%, genie likes number 2)
-    if ( attacker.GetID() == Monster::GENIE && Rand::Get( 1, 5 ) <= 4 ) {
+    if ( attacker.GetID() == Monster::GENIE && Rand::Get( 1, 5 ) == 2 ) {
         if ( defender.GetHitPoints() / 2 > res.damage ) {
             // Replaces the damage, not adding to it
             res.damage = defender.GetHitPoints() / 2;

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -480,6 +480,20 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( Unit & attacker, Unit & 
     // first target
     res.defender = &defender;
     res.damage = attacker.GetDamage( defender );
+
+    // Genie special attack (20%, genie likes number 2)
+    if ( attacker.GetID() == Monster::GENIE && Rand::Get( 1, 5 ) <= 4 ) {
+        if ( defender.GetHitPoints() / 2 > res.damage ) {
+            // Replaces the damage, not adding to it
+            res.damage = defender.GetHitPoints() / 2;
+
+            if ( Arena::GetInterface() ) {
+                std::string str( _( "%{name} half the enemy troops!" ) );
+                StringReplace( str, "%{name}", attacker.GetName() );
+                Arena::GetInterface()->SetStatus( str, true );
+            }
+        }
+    }
     targets.push_back( res );
 
     // long distance attack
@@ -493,9 +507,8 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( Unit & attacker, Unit & 
             }
         }
     }
-    else
-        // around hydra
-        if ( attacker.GetID() == Monster::HYDRA ) {
+    // around hydra
+    else if ( attacker.GetID() == Monster::HYDRA ) {
         std::vector<Unit *> v;
         v.reserve( 8 );
 
@@ -509,9 +522,8 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( Unit & attacker, Unit & 
             }
         }
     }
-    else
-        // lich cloud damages
-        if ( ( attacker.GetID() == Monster::LICH || attacker.GetID() == Monster::POWER_LICH ) && !attacker.isHandFighting() ) {
+    // lich cloud damages
+    else if ( ( attacker.GetID() == Monster::LICH || attacker.GetID() == Monster::POWER_LICH ) && !attacker.isHandFighting() ) {
         const Indexes around = Board::GetAroundIndexes( defender.GetHeadIndex() );
 
         for ( Indexes::const_iterator it = around.begin(); it != around.end(); ++it ) {

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -38,9 +38,7 @@
 #include "world.h"
 
 namespace Battle
-{
-    u32 genie_enemy_half_percent = 10;
-}
+{}
 
 void Battle::UpdateMonsterAttributes( const std::string & spec )
 {
@@ -52,15 +50,6 @@ void Battle::UpdateMonsterAttributes( const std::string & spec )
     if ( doc.LoadFile( spec.c_str() ) && NULL != ( xml_battle = doc.FirstChildElement( "battle" ) ) ) {
         const TiXmlElement * xml_element;
         int value;
-
-        // genie
-        xml_element = xml_battle->FirstChildElement( "genie" );
-        if ( xml_element ) {
-            xml_element->Attribute( "enemy_half_percent", &value );
-            if ( value > 100 )
-                value = 100;
-            genie_enemy_half_percent = value;
-        }
     }
     else
         VERBOSE( spec << ": " << doc.ErrorDesc() );
@@ -774,24 +763,6 @@ u32 Battle::Unit::ApplyDamage( Unit & enemy, u32 dmg )
 {
     u32 killed = ApplyDamage( dmg );
     u32 resurrect;
-
-    switch ( enemy.GetID() ) {
-    case Monster::GENIE:
-        // 10% half
-        if ( 1 < GetCount() && killed < GetCount() && genie_enemy_half_percent >= Rand::Get( 1, 100 ) ) {
-            killed = ApplyDamage( hp / 2 );
-
-            if ( Arena::GetInterface() ) {
-                std::string str( _( "%{name} half the enemy troops!" ) );
-                StringReplace( str, "%{name}", enemy.GetName() );
-                Arena::GetInterface()->SetStatus( str, true );
-            }
-        }
-        break;
-
-    default:
-        break;
-    }
 
     if ( killed )
         switch ( enemy.GetID() ) {

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -37,9 +37,6 @@
 #include "speed.h"
 #include "world.h"
 
-namespace Battle
-{}
-
 void Battle::UpdateMonsterAttributes( const std::string & spec )
 {
 #ifdef WITH_XML


### PR DESCRIPTION
Self-explanatory title; fixing chance and the effect of special ability. Important to use it before any damage is applied.

Correct chance is pulled from HEROES2W file, it's checking for Genies at 0x04806CC.