### PR TITLE
Music: Loop battle music and switch to main tune when loading

### DIFF
--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -405,7 +405,7 @@ void Battle::Arena::Turns( void )
     DEBUG( DBG_BATTLE, DBG_TRACE, current_turn );
 
     if ( interface && conf.Music() && !Music::isPlaying() )
-        AGG::PlayMusic( MUS::GetBattleRandom(), false );
+        AGG::PlayMusic( MUS::GetBattleRandom() );
 
     army1->NewTurn();
     army2->NewTurn();

--- a/src/fheroes2/game/game_loadgame.cpp
+++ b/src/fheroes2/game/game_loadgame.cpp
@@ -27,6 +27,7 @@
 #include "dialog.h"
 #include "game_io.h"
 #include "gamedefs.h"
+#include "mus.h"
 #include "pocketpc.h"
 #include "settings.h"
 
@@ -101,6 +102,8 @@ int Game::LoadGame( void )
 
 int Game::LoadStandard( void )
 {
+    Mixer::Pause();
+    AGG::PlayMusic( MUS::MAINMENU );
     // cursor
     Cursor & cursor = Cursor::Get();
     cursor.Hide();


### PR DESCRIPTION
Fixes #433 
Fixes #435 

Checked OG to make sure it behaves the same.