### PR TITLE
Fix spell sorting crash and mage guild positioning

### DIFF
--- a/src/fheroes2/castle/castle_mageguild.cpp
+++ b/src/fheroes2/castle/castle_mageguild.cpp
@@ -99,10 +99,10 @@ void RowSpells::Redraw( void )
                 icon.Blit( dst.x + 2 + ( dst.w - icon.w() ) / 2, dst.y + 20 - icon.h() / 2 );
             }
             else {
-                icon.Blit( dst.x + 5 + ( dst.w - icon.w() ) / 2, dst.y + 40 - icon.h() / 2 );
+                icon.Blit( dst.x + 3 + ( dst.w - icon.w() ) / 2, dst.y + 31 - icon.h() / 2 );
 
                 TextBox text( std::string( spell.GetName() ) + " [" + GetString( spell.SpellPoint( NULL ) ) + "]", Font::SMALL, 78 );
-                text.Blit( dst.x + 18, dst.y + 62 );
+                text.Blit( dst.x + 18, dst.y + 55 );
             }
         }
     }

--- a/src/fheroes2/spell/spell_book.cpp
+++ b/src/fheroes2/spell/spell_book.cpp
@@ -51,7 +51,9 @@ void SpellBookRedrawMP( const Point &, u32 );
 
 bool SpellBookSortingSpell( const Spell & spell1, const Spell & spell2 )
 {
-    return ( ( spell1.isCombat() != spell2.isCombat() && spell1.isCombat() ) || ( std::string( spell1.GetName() ) < std::string( spell2.GetName() ) ) );
+    if ( spell1.isCombat() == spell2.isCombat() )
+        return std::string( spell1.GetName() ) < std::string( spell2.GetName() );
+    return spell1.isCombat();
 }
 
 Spell SpellBook::Open( const HeroBase & hero, int filt, bool canselect ) const


### PR DESCRIPTION
Fixes #538 . A bit of pixel pushing here, the core of the problem is that every spell sprite is not centered.

Also fixed spellbook sorting crash which happened if there's adventure spell with name (i.e. Set Water Guardian) previous to the combat spell (i.e. Steelskin).

![rework](https://user-images.githubusercontent.com/1373638/82162457-ae870780-9872-11ea-8367-15c195c9e60f.png)
