### PR TITLE
Fix hero movement at low speeds

### DIFF
--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -140,7 +140,7 @@ void Battle::DialogBattleSettings( void )
 
         if ( le.MouseClickLeft( opt_speed ) ) {
             conf.SetBattleSpeed( conf.BattleSpeed() % 10 + 1 );
-            Game::UpdateBattleSpeed();
+            Game::UpdateGameSpeed();
             cursor.Hide();
             speed_buttom_back.Restore();
             SpeedRedraw( opt_speed );

--- a/src/fheroes2/dialog/dialog_system.cpp
+++ b/src/fheroes2/dialog/dialog_system.cpp
@@ -111,7 +111,7 @@ int Dialog::SystemOptions( void )
             conf.SetHeroesMoveSpeed( conf.HeroesMoveSpeed() % 10 + 1 );
             result |= 0x01;
             redraw = true;
-            Game::UpdateHeroesMoveSpeed();
+            Game::UpdateGameSpeed();
         }
 
         // set ai speed
@@ -119,7 +119,7 @@ int Dialog::SystemOptions( void )
             conf.SetAIMoveSpeed( conf.AIMoveSpeed() % 10 + 1 );
             result |= 0x01;
             redraw = true;
-            Game::UpdateHeroesMoveSpeed();
+            Game::UpdateGameSpeed();
         }
 
         // set scroll speed

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -176,7 +176,6 @@ namespace Game
         CASTLE_AROUND_DELAY,
         CASTLE_BUYHERO_DELAY,
         CASTLE_BUILD_DELAY,
-        HEROES_MOVE_DELAY,
         HEROES_FADE_DELAY,
         HEROES_PICKUP_DELAY,
         PUZZLE_FADE_DELAY,
@@ -206,8 +205,7 @@ namespace Game
     bool AnimateCustomDelay( uint32_t delay );
     bool AnimateInfrequentDelay( int );
     void AnimateResetDelay( int );
-    void UpdateHeroesMoveSpeed( void );
-    void UpdateBattleSpeed( void );
+    void UpdateGameSpeed( void );
     uint32_t ApplyBattleSpeed( uint32_t delay );
     int MainMenu( void );
     int NewGame( void );

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -125,15 +125,15 @@ void Game::UpdateGameSpeed( void )
     delays[CURRENT_HERO_DELAY] = 40 - ( conf.HeroesMoveSpeed() - DEFAULT_SPEED_DELAY ) * 8;
     delays[CURRENT_AI_DELAY] = 40 - ( conf.AIMoveSpeed() - DEFAULT_SPEED_DELAY ) * 8;
 
-    const uint32_t battleSpeed = conf.BattleSpeed();
-    delays[BATTLE_FRAME_DELAY] = 120 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 20;
-    delays[BATTLE_MISSILE_DELAY] = 40 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 7;
-    delays[BATTLE_SPELL_DELAY] = 90 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 17;
-    delays[BATTLE_DISRUPTING_DELAY] = 20 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 3;
-    delays[BATTLE_CATAPULT_DELAY] = 90 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 17;
-    delays[BATTLE_CATAPULT2_DELAY] = 40 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 7;
-    delays[BATTLE_CATAPULT3_DELAY] = 40 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 7;
-    delays[BATTLE_BRIDGE_DELAY] = 90 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 17;
+    const int battleSpeed = conf.BattleSpeed() - DEFAULT_SPEED_DELAY;
+    delays[BATTLE_FRAME_DELAY] = 120 - battleSpeed * 20;
+    delays[BATTLE_MISSILE_DELAY] = 40 - battleSpeed * 7;
+    delays[BATTLE_SPELL_DELAY] = 90 - battleSpeed * 17;
+    delays[BATTLE_DISRUPTING_DELAY] = 20 - battleSpeed * 3;
+    delays[BATTLE_CATAPULT_DELAY] = 90 - battleSpeed * 17;
+    delays[BATTLE_CATAPULT2_DELAY] = 40 - battleSpeed * 7;
+    delays[BATTLE_CATAPULT3_DELAY] = 40 - battleSpeed * 7;
+    delays[BATTLE_BRIDGE_DELAY] = 90 - battleSpeed * 17;
 }
 
 uint32_t Game::ApplyBattleSpeed( uint32_t delay )

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -72,12 +72,11 @@ namespace Game
                           150, // CASTLE_AROUND_DELAY
                           130, // CASTLE_BUYHERO_DELAY
                           130, // CASTLE_BUILD_DELAY
-                          40, // HEROES_MOVE_DELAY
                           40, // HEROES_FADE_DELAY
                           40, // HEROES_PICKUP_DELAY
                           50, // PUZZLE_FADE_DELAY
                           100, // BATTLE_DIALOG_DELAY
-                          80, // BATTLE_FRAME_DELAY
+                          120, // BATTLE_FRAME_DELAY
                           40, // BATTLE_MISSILE_DELAY
                           90, // BATTLE_SPELL_DELAY
                           20, // BATTLE_DISRUPTING_DELAY
@@ -100,8 +99,7 @@ namespace Game
 void Game::AnimateDelaysInitialize( void )
 {
     std::for_each( &delays[0], &delays[LAST_DELAY], std::mem_fun_ref( &TimeDelay::Reset ) );
-    UpdateHeroesMoveSpeed();
-    UpdateBattleSpeed();
+    UpdateGameSpeed();
 }
 
 void Game::AnimateResetDelay( int dl )
@@ -120,60 +118,41 @@ bool Game::AnimateInfrequentDelay( int dl )
     return dl < LAST_DELAY && 0 < delays[dl]() ? delays[dl].Trigger() : true;
 }
 
-void Game::UpdateHeroesMoveSpeed( void )
+void Game::UpdateGameSpeed( void )
 {
     const Settings & conf = Settings::Get();
 
-    const TimeDelay & td_etalon = delays[HEROES_MOVE_DELAY];
-    TimeDelay & td_hero = delays[CURRENT_HERO_DELAY];
-    TimeDelay & td_ai = delays[CURRENT_AI_DELAY];
+    delays[CURRENT_HERO_DELAY] = 30 - ( conf.HeroesMoveSpeed() - DEFAULT_SPEED_DELAY ) * 6;
+    delays[CURRENT_AI_DELAY] = 30 - ( conf.AIMoveSpeed() - DEFAULT_SPEED_DELAY ) * 6;
 
-    const int hr_value = conf.HeroesMoveSpeed() ? ( ( conf.HeroesMoveSpeed() - DEFAULT_SPEED_DELAY ) * td_etalon() ) / DEFAULT_SPEED_DELAY : td_etalon();
+    const uint32_t battleSpeed = conf.BattleSpeed();
+    delays[BATTLE_FRAME_DELAY] = 120 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 15;
+    delays[BATTLE_MISSILE_DELAY] = 40 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 7;
+    delays[BATTLE_SPELL_DELAY] = 90 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 17;
+    delays[BATTLE_DISRUPTING_DELAY] = 20 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 3;
+    delays[BATTLE_CATAPULT_DELAY] = 90 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 17;
+    delays[BATTLE_CATAPULT2_DELAY] = 40 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 7;
+    delays[BATTLE_CATAPULT3_DELAY] = 40 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 7;
+    delays[BATTLE_BRIDGE_DELAY] = 90 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 17;
 
-    const int ai_value = conf.AIMoveSpeed() ? ( ( conf.AIMoveSpeed() - DEFAULT_SPEED_DELAY ) * td_etalon() ) / DEFAULT_SPEED_DELAY : td_etalon();
-
-    if ( conf.HeroesMoveSpeed() == DEFAULT_SPEED_DELAY )
-        td_hero = td_etalon();
-    else
-        td_hero = td_etalon() - hr_value;
-
-    if ( conf.AIMoveSpeed() == DEFAULT_SPEED_DELAY )
-        td_ai = td_etalon();
-    else
-        td_ai = td_etalon() - ai_value;
-}
-
-void Game::UpdateBattleSpeed( void )
-{
-    const Settings & conf = Settings::Get();
-    const int value = 5;
-
-    delays[BATTLE_FRAME_DELAY] = 80 - ( conf.BattleSpeed() - value ) * 15;
-    delays[BATTLE_MISSILE_DELAY] = 40 - ( conf.BattleSpeed() - value ) * 7;
-    delays[BATTLE_SPELL_DELAY] = 90 - ( conf.BattleSpeed() - value ) * 17;
-    delays[BATTLE_DISRUPTING_DELAY] = 20 - ( conf.BattleSpeed() - value ) * 3;
-    delays[BATTLE_CATAPULT_DELAY] = 90 - ( conf.BattleSpeed() - value ) * 17;
-    delays[BATTLE_CATAPULT2_DELAY] = 40 - ( conf.BattleSpeed() - value ) * 7;
-    delays[BATTLE_CATAPULT3_DELAY] = 40 - ( conf.BattleSpeed() - value ) * 7;
-    delays[BATTLE_BRIDGE_DELAY] = 90 - ( conf.BattleSpeed() - value ) * 17;
-
-    if ( 0 < conf.BlitSpeed() ) {
-        const float etalon = 15.0;
-        const float div = conf.BlitSpeed() / etalon;
+    const float currentBlitSpeed = conf.BlitSpeed();
+    const float expectedBlittingSpeed = 15.0;
+    if ( currentBlitSpeed < expectedBlittingSpeed ) {
+        const float adjustment = expectedBlittingSpeed / currentBlitSpeed;
         const int ids[] = {BATTLE_FRAME_DELAY,    BATTLE_MISSILE_DELAY,   BATTLE_SPELL_DELAY,     BATTLE_DISRUPTING_DELAY,
                            BATTLE_CATAPULT_DELAY, BATTLE_CATAPULT2_DELAY, BATTLE_CATAPULT3_DELAY, BATTLE_BRIDGE_DELAY};
 
-        DEBUG( DBG_GAME, DBG_INFO, "set battle speed: " << conf.BattleSpeed() );
+        DEBUG( DBG_GAME, DBG_WARN, "Slow render speed detected: " << currentBlitSpeed << ", adjusting battle delays for speed " << battleSpeed );
         std::ostringstream os;
 
         for ( u32 it = 0; it < ARRAY_COUNT( ids ); ++it ) {
             float tmp = delays[ids[it]]();
-            tmp /= div;
+            tmp /= adjustment;
             delays[ids[it]] = static_cast<int>( tmp );
             os << static_cast<int>( tmp ) << ", ";
         }
 
-        DEBUG( DBG_GAME, DBG_INFO, "set battle delays: " << os.str() );
+        DEBUG( DBG_GAME, DBG_WARN, "set battle delays: " << os.str() );
     }
 }
 

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -134,26 +134,6 @@ void Game::UpdateGameSpeed( void )
     delays[BATTLE_CATAPULT2_DELAY] = 40 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 7;
     delays[BATTLE_CATAPULT3_DELAY] = 40 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 7;
     delays[BATTLE_BRIDGE_DELAY] = 90 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 17;
-
-    const float currentBlitTime = conf.BlitSpeed();
-    const float expectedBlittingSpeed = 15.0;
-    if ( expectedBlittingSpeed < currentBlitTime ) {
-        const float adjustment = currentBlitTime / expectedBlittingSpeed;
-        const int ids[] = {BATTLE_FRAME_DELAY,    BATTLE_MISSILE_DELAY,   BATTLE_SPELL_DELAY,     BATTLE_DISRUPTING_DELAY,
-                           BATTLE_CATAPULT_DELAY, BATTLE_CATAPULT2_DELAY, BATTLE_CATAPULT3_DELAY, BATTLE_BRIDGE_DELAY};
-
-        DEBUG( DBG_GAME, DBG_WARN, "Slow render time detected: " << currentBlitTime << ", adjusting battle delays for speed " << battleSpeed );
-        std::ostringstream os;
-
-        for ( u32 it = 0; it < ARRAY_COUNT( ids ); ++it ) {
-            float tmp = delays[ids[it]]();
-            tmp /= adjustment;
-            delays[ids[it]] = static_cast<int>( tmp );
-            os << static_cast<int>( tmp ) << ", ";
-        }
-
-        DEBUG( DBG_GAME, DBG_WARN, "set battle delays: " << os.str() );
-    }
 }
 
 uint32_t Game::ApplyBattleSpeed( uint32_t delay )

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -90,8 +90,8 @@ namespace Game
                           300, // BATTLE_FLAGS_DELAY
                           800, // BATTLE_POPUP_DELAY
                           300, // AUTOHIDE_STATUS_DELAY
-                          0, // CURRENT_HERO_DELAY
-                          0, // CURRENT_AI_DELAY
+                          40, // CURRENT_HERO_DELAY
+                          40, // CURRENT_AI_DELAY
                           0, // CUSTOM_DELAY
                           0};
 }
@@ -122,11 +122,11 @@ void Game::UpdateGameSpeed( void )
 {
     const Settings & conf = Settings::Get();
 
-    delays[CURRENT_HERO_DELAY] = 30 - ( conf.HeroesMoveSpeed() - DEFAULT_SPEED_DELAY ) * 6;
-    delays[CURRENT_AI_DELAY] = 30 - ( conf.AIMoveSpeed() - DEFAULT_SPEED_DELAY ) * 6;
+    delays[CURRENT_HERO_DELAY] = 40 - ( conf.HeroesMoveSpeed() - DEFAULT_SPEED_DELAY ) * 8;
+    delays[CURRENT_AI_DELAY] = 40 - ( conf.AIMoveSpeed() - DEFAULT_SPEED_DELAY ) * 8;
 
     const uint32_t battleSpeed = conf.BattleSpeed();
-    delays[BATTLE_FRAME_DELAY] = 120 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 15;
+    delays[BATTLE_FRAME_DELAY] = 120 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 20;
     delays[BATTLE_MISSILE_DELAY] = 40 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 7;
     delays[BATTLE_SPELL_DELAY] = 90 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 17;
     delays[BATTLE_DISRUPTING_DELAY] = 20 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 3;
@@ -135,14 +135,14 @@ void Game::UpdateGameSpeed( void )
     delays[BATTLE_CATAPULT3_DELAY] = 40 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 7;
     delays[BATTLE_BRIDGE_DELAY] = 90 - ( battleSpeed - DEFAULT_SPEED_DELAY ) * 17;
 
-    const float currentBlitSpeed = conf.BlitSpeed();
+    const float currentBlitTime = conf.BlitSpeed();
     const float expectedBlittingSpeed = 15.0;
-    if ( currentBlitSpeed < expectedBlittingSpeed ) {
-        const float adjustment = expectedBlittingSpeed / currentBlitSpeed;
+    if ( expectedBlittingSpeed < currentBlitTime ) {
+        const float adjustment = currentBlitTime / expectedBlittingSpeed;
         const int ids[] = {BATTLE_FRAME_DELAY,    BATTLE_MISSILE_DELAY,   BATTLE_SPELL_DELAY,     BATTLE_DISRUPTING_DELAY,
                            BATTLE_CATAPULT_DELAY, BATTLE_CATAPULT2_DELAY, BATTLE_CATAPULT3_DELAY, BATTLE_BRIDGE_DELAY};
 
-        DEBUG( DBG_GAME, DBG_WARN, "Slow render speed detected: " << currentBlitSpeed << ", adjusting battle delays for speed " << battleSpeed );
+        DEBUG( DBG_GAME, DBG_WARN, "Slow render time detected: " << currentBlitTime << ", adjusting battle delays for speed " << battleSpeed );
         std::ostringstream os;
 
         for ( u32 it = 0; it < ARRAY_COUNT( ids ); ++it ) {
@@ -158,5 +158,5 @@ void Game::UpdateGameSpeed( void )
 
 uint32_t Game::ApplyBattleSpeed( uint32_t delay )
 {
-    return static_cast<uint32_t>( 10 - Settings::Get().BattleSpeed() ) * ( delay / DEFAULT_SPEED_DELAY );
+    return static_cast<uint32_t>( 10 - Settings::Get().BattleSpeed() ) * ( delay / ( DEFAULT_SPEED_DELAY ) );
 }

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -138,5 +138,5 @@ void Game::UpdateGameSpeed( void )
 
 uint32_t Game::ApplyBattleSpeed( uint32_t delay )
 {
-    return static_cast<uint32_t>( 10 - Settings::Get().BattleSpeed() ) * ( delay / ( DEFAULT_SPEED_DELAY ) );
+    return static_cast<uint32_t>( 10 - Settings::Get().BattleSpeed() ) * ( delay / DEFAULT_SPEED_DELAY );
 }


### PR DESCRIPTION
Fixes #518 

Refactored a bunch of old code, including BlitSpeed adjustment. I tested in different configs with resulting blit speeds from 5 to 20, however when timing battle rounds in battle_interface.cpp I still seen pretty consistent numbers for each animation. Our event loop will eat those tiny render delays, because of the way it is structured.

Actually this speed adjustment was the reason why animation speed varied so much between SDL1 and SDL2 versions; this annoyed me for while.