### PR TITLE
Fix hero, castle and status army info

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -672,7 +672,7 @@ void Troops::DrawMons32LineWithScoute( s32 cx, s32 cy, u32 width, u32 first, u32
                     if ( compact )
                         text.Blit( cx + monster.w() / 2, cy + 23 );
                     else
-                        text.Blit( cx - text.w() / 2, cy + 28 );
+                        text.Blit( cx - text.w() / 2, cy + 29 );
 
                     cx += chunk;
                     --count;
@@ -1254,8 +1254,8 @@ void Army::DrawMons32LineShort( const Troops & troops, s32 cx, s32 cy, u32 width
 void Army::DrawMonsterLines( const Troops & troops, s32 posX, s32 posY, u32 lineWidth, u32 scout, bool compact )
 {
     const uint32_t count = troops.GetCount();
-    const int offsetX = compact ? 23 : 35;
-    const int offsetY = compact ? 29 : 42;
+    const int offsetX = lineWidth / 6;
+    const int offsetY = compact ? 29 : 50;
 
     if ( count < 4 ) {
         troops.DrawMons32LineWithScoute( posX, posY + offsetY / 2, lineWidth, 0, 0, scout, compact );

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1251,23 +1251,22 @@ void Army::DrawMons32LineShort( const Troops & troops, s32 cx, s32 cy, u32 width
     troops.DrawMons32LineWithScoute( cx, cy, width, first, count, Skill::Level::EXPERT, true );
 }
 
-void Army::DrawMonsterLines( const Troops & troops, s32 posX, s32 posY, u32 scout, bool compact )
+void Army::DrawMonsterLines( const Troops & troops, s32 posX, s32 posY, u32 lineWidth, u32 scout, bool compact )
 {
     const uint32_t count = troops.GetCount();
-    const uint32_t unitWidth = compact ? 46 : 64;
     const int offsetX = compact ? 23 : 35;
-    const int offsetY = compact ? 29 : 44;
+    const int offsetY = compact ? 29 : 42;
 
     if ( count < 4 ) {
-        troops.DrawMons32LineWithScoute( posX, posY + offsetY / 2, unitWidth * 3, 0, 0, scout, compact );
+        troops.DrawMons32LineWithScoute( posX, posY + offsetY / 2, lineWidth, 0, 0, scout, compact );
     }
     else if ( count == 4 ) {
-        troops.DrawMons32LineWithScoute( posX + offsetX, posY, unitWidth * 2, 0, 2, scout, compact );
-        troops.DrawMons32LineWithScoute( posX, posY + offsetY, unitWidth * 2, 2, 2, scout, compact );
+        troops.DrawMons32LineWithScoute( posX + offsetX, posY, lineWidth * 2 / 3, 0, 2, scout, compact );
+        troops.DrawMons32LineWithScoute( posX, posY + offsetY, lineWidth * 2 / 3, 2, 2, scout, compact );
     }
     else {
-        troops.DrawMons32LineWithScoute( posX + offsetX, posY, unitWidth * 2, 0, 2, scout, compact );
-        troops.DrawMons32LineWithScoute( posX, posY + offsetY, unitWidth * 3, 2, 3, scout, compact );
+        troops.DrawMons32LineWithScoute( posX + offsetX, posY, lineWidth * 2 / 3, 0, 2, scout, compact );
+        troops.DrawMons32LineWithScoute( posX, posY + offsetY, lineWidth, 2, 3, scout, compact );
     }
 }
 

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -649,7 +649,7 @@ void Troops::KeepOnlyWeakest( Troops & troops2, bool save_last )
     }
 }
 
-void Troops::DrawMons32LineWithScoute( s32 cx, s32 cy, u32 width, u32 first, u32 count, u32 scoute, bool shorts ) const
+void Troops::DrawMons32LineWithScoute( s32 cx, s32 cy, u32 width, u32 first, u32 count, u32 scoute, bool compact ) const
 {
     if ( isValid() ) {
         if ( 0 == count )
@@ -665,10 +665,14 @@ void Troops::DrawMons32LineWithScoute( s32 cx, s32 cy, u32 width, u32 first, u32
             if ( ( *it )->isValid() ) {
                 if ( 0 == first && count ) {
                     const Sprite & monster = AGG::GetICN( ICN::MONS32, ( *it )->GetSpriteIndex() );
+                    int offsetY = !( compact ) ? 30 - monster.h() : ( monster.h() < 35 ) ? 35 - monster.h() : 0;
 
-                    monster.Blit( cx - monster.w() / 2, cy + 30 - monster.h() );
-                    text.Set( Game::CountScoute( ( *it )->GetCount(), scoute, shorts ) );
-                    text.Blit( cx - text.w() / 2, cy + 28 );
+                    monster.Blit( cx - monster.w() / 2, cy + offsetY );
+                    text.Set( Game::CountScoute( ( *it )->GetCount(), scoute, compact ) );
+                    if ( compact )
+                        text.Blit( cx + monster.w() / 2, cy + 23 );
+                    else
+                        text.Blit( cx - text.w() / 2, cy + 28 );
 
                     cx += chunk;
                     --count;
@@ -1245,6 +1249,26 @@ void Army::DrawMons32Line( const Troops & troops, s32 cx, s32 cy, u32 width, u32
 void Army::DrawMons32LineShort( const Troops & troops, s32 cx, s32 cy, u32 width, u32 first, u32 count )
 {
     troops.DrawMons32LineWithScoute( cx, cy, width, first, count, Skill::Level::EXPERT, true );
+}
+
+void Army::DrawMonsterLines( const Troops & troops, s32 posX, s32 posY, u32 scout, bool compact )
+{
+    const uint32_t count = troops.GetCount();
+    const uint32_t unitWidth = compact ? 46 : 64;
+    const int offsetX = compact ? 23 : 35;
+    const int offsetY = compact ? 29 : 44;
+
+    if ( count < 4 ) {
+        troops.DrawMons32LineWithScoute( posX, posY + offsetY / 2, unitWidth * 3, 0, 0, scout, compact );
+    }
+    else if ( count == 4 ) {
+        troops.DrawMons32LineWithScoute( posX + offsetX, posY, unitWidth * 2, 0, 2, scout, compact );
+        troops.DrawMons32LineWithScoute( posX, posY + offsetY, unitWidth * 2, 2, 2, scout, compact );
+    }
+    else {
+        troops.DrawMons32LineWithScoute( posX + offsetX, posY, unitWidth * 2, 0, 2, scout, compact );
+        troops.DrawMons32LineWithScoute( posX, posY + offsetY, unitWidth * 3, 2, 3, scout, compact );
+    }
 }
 
 JoinCount Army::GetJoinSolution( const Heroes & hero, const Maps::Tiles & tile, const Troop & troop )

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1246,11 +1246,6 @@ void Army::DrawMons32Line( const Troops & troops, s32 cx, s32 cy, u32 width, u32
     troops.DrawMons32LineWithScoute( cx, cy, width, first, count, Skill::Level::EXPERT, false );
 }
 
-void Army::DrawMons32LineShort( const Troops & troops, s32 cx, s32 cy, u32 width, u32 first, u32 count )
-{
-    troops.DrawMons32LineWithScoute( cx, cy, width, first, count, Skill::Level::EXPERT, true );
-}
-
 void Army::DrawMonsterLines( const Troops & troops, s32 posX, s32 posY, u32 lineWidth, u32 scout, bool compact )
 {
     const uint32_t count = troops.GetCount();

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -140,7 +140,7 @@ public:
     static void DrawMons32Line( const Troops &, s32, s32, u32, u32 = 0, u32 = 0 );
     static void DrawMons32LineWithScoute( const Troops &, s32, s32, u32, u32, u32, u32 );
     static void DrawMons32LineShort( const Troops &, s32, s32, u32, u32, u32 );
-    static void DrawMonsterLines( const Troops & troops, s32 posX, s32 posY, u32 scout = 3, bool compact = true );
+    static void DrawMonsterLines( const Troops & troops, s32 posX, s32 posY, u32 lineWidth, u32 scout = 3, bool compact = true );
 
     Army( HeroBase * s = NULL );
     Army( const Maps::Tiles & );

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -140,6 +140,7 @@ public:
     static void DrawMons32Line( const Troops &, s32, s32, u32, u32 = 0, u32 = 0 );
     static void DrawMons32LineWithScoute( const Troops &, s32, s32, u32, u32, u32, u32 );
     static void DrawMons32LineShort( const Troops &, s32, s32, u32, u32, u32 );
+    static void DrawMonsterLines( const Troops & troops, s32 posX, s32 posY, u32 scout = 3, bool compact = true );
 
     Army( HeroBase * s = NULL );
     Army( const Maps::Tiles & );

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -139,8 +139,7 @@ public:
 
     static void DrawMons32Line( const Troops &, s32, s32, u32, u32 = 0, u32 = 0 );
     static void DrawMons32LineWithScoute( const Troops &, s32, s32, u32, u32, u32, u32 );
-    static void DrawMons32LineShort( const Troops &, s32, s32, u32, u32, u32 );
-    static void DrawMonsterLines( const Troops & troops, s32 posX, s32 posY, u32 lineWidth, u32 scout = 3, bool compact = true );
+    static void DrawMonsterLines( const Troops & troops, s32 posX, s32 posY, u32 lineWidth, u32 scout, bool compact = true );
 
     Army( HeroBase * s = NULL );
     Army( const Maps::Tiles & );

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -689,12 +689,10 @@ void Dialog::QuickInfo( const Castle & castle )
     }
     else if ( castle.isFriends( conf.CurrentColor() ) )
         // show all
-        Army::DrawMonsterLines( castle.GetArmy(), cur_rt.x - 5, cur_rt.y + 70, Skill::Level::EXPERT, false );
+        Army::DrawMonsterLines( castle.GetArmy(), cur_rt.x - 5, cur_rt.y + 70, 192, Skill::Level::EXPERT, false );
     else
         // show limited
-        Army::DrawMons32LineWithScoute( castle.GetArmy(), cur_rt.x - 5, cur_rt.y + 100, 192, 0, 0,
-                                        ( from_hero && from_hero->CanScouteTile( castle.GetIndex() ) ? from_hero->GetSecondaryValues( Skill::Secondary::SCOUTING )
-                                                                                                     : Skill::Level::NONE ) );
+        Army::DrawMonsterLines( castle.GetArmy(), cur_rt.x - 5, cur_rt.y + 70, 192, Skill::Level::NONE, false );
 
     cursor.Show();
     display.Flip();
@@ -849,77 +847,74 @@ void Dialog::QuickInfo( const Heroes & hero )
     dst_pt.x = cur_rt.x + ( cur_rt.w + 40 ) / 2;
     r_flag.Blit( dst_pt );
 
-    // attack
-    text.Set( std::string( _( "Attack" ) ) + ":" );
-    dst_pt.x = cur_rt.x + 10;
-    dst_pt.y += port.h();
-    text.Blit( dst_pt );
+    // TODO: check if under effect of View heroes spell; then show enemies too
+    if ( hero.isFriends( conf.CurrentColor() ) ) {
+        // attack
+        text.Set( std::string( _( "Attack" ) ) + ":" );
+        dst_pt.x = cur_rt.x + 10;
+        dst_pt.y += port.h();
+        text.Blit( dst_pt );
 
-    text.Set( GetString( hero.GetAttack() ) );
-    dst_pt.x += 75;
-    text.Blit( dst_pt );
+        text.Set( GetString( hero.GetAttack() ) );
+        dst_pt.x += 75;
+        text.Blit( dst_pt );
 
-    // defense
-    text.Set( std::string( _( "Defense" ) ) + ":" );
-    dst_pt.x = cur_rt.x + 10;
-    dst_pt.y += 12;
-    text.Blit( dst_pt );
+        // defense
+        text.Set( std::string( _( "Defense" ) ) + ":" );
+        dst_pt.x = cur_rt.x + 10;
+        dst_pt.y += 12;
+        text.Blit( dst_pt );
 
-    text.Set( GetString( hero.GetDefense() ) );
-    dst_pt.x += 75;
-    text.Blit( dst_pt );
+        text.Set( GetString( hero.GetDefense() ) );
+        dst_pt.x += 75;
+        text.Blit( dst_pt );
 
-    // power
-    text.Set( std::string( _( "Spell Power" ) ) + ":" );
-    dst_pt.x = cur_rt.x + 10;
-    dst_pt.y += 12;
-    text.Blit( dst_pt );
+        // power
+        text.Set( std::string( _( "Spell Power" ) ) + ":" );
+        dst_pt.x = cur_rt.x + 10;
+        dst_pt.y += 12;
+        text.Blit( dst_pt );
 
-    text.Set( GetString( hero.GetPower() ) );
-    dst_pt.x += 75;
-    text.Blit( dst_pt );
+        text.Set( GetString( hero.GetPower() ) );
+        dst_pt.x += 75;
+        text.Blit( dst_pt );
 
-    // knowledge
-    text.Set( std::string( _( "Knowledge" ) ) + ":" );
-    dst_pt.x = cur_rt.x + 10;
-    dst_pt.y += 12;
-    text.Blit( dst_pt );
+        // knowledge
+        text.Set( std::string( _( "Knowledge" ) ) + ":" );
+        dst_pt.x = cur_rt.x + 10;
+        dst_pt.y += 12;
+        text.Blit( dst_pt );
 
-    text.Set( GetString( hero.GetKnowledge() ) );
-    dst_pt.x += 75;
-    text.Blit( dst_pt );
+        text.Set( GetString( hero.GetKnowledge() ) );
+        dst_pt.x += 75;
+        text.Blit( dst_pt );
 
-    // spell point
-    text.Set( std::string( _( "Spell Points" ) ) + ":" );
-    dst_pt.x = cur_rt.x + 10;
-    dst_pt.y += 12;
-    text.Blit( dst_pt );
+        // spell point
+        text.Set( std::string( _( "Spell Points" ) ) + ":" );
+        dst_pt.x = cur_rt.x + 10;
+        dst_pt.y += 12;
+        text.Blit( dst_pt );
 
-    text.Set( GetString( hero.GetSpellPoints() ) + "/" + GetString( hero.GetMaxSpellPoints() ) );
-    dst_pt.x += 75;
-    text.Blit( dst_pt );
+        text.Set( GetString( hero.GetSpellPoints() ) + "/" + GetString( hero.GetMaxSpellPoints() ) );
+        dst_pt.x += 75;
+        text.Blit( dst_pt );
 
-    // move point
-    text.Set( std::string( _( "Move Points" ) ) + ":" );
-    dst_pt.x = cur_rt.x + 10;
-    dst_pt.y += 12;
-    text.Blit( dst_pt );
+        // move point
+        text.Set( std::string( _( "Move Points" ) ) + ":" );
+        dst_pt.x = cur_rt.x + 10;
+        dst_pt.y += 12;
+        text.Blit( dst_pt );
 
-    text.Set( GetString( hero.GetMobilityIndexSprite() ) + "/" + GetString( hero.GetMovePoints() ) + "/" + GetString( hero.GetMaxMovePoints() ) );
-    dst_pt.x += 75;
-    text.Blit( dst_pt );
+        text.Set( GetString( hero.GetMobilityIndexSprite() ) + "/" + GetString( hero.GetMovePoints() ) + "/" + GetString( hero.GetMaxMovePoints() ) );
+        dst_pt.x += 75;
+        text.Blit( dst_pt );
 
-    // draw monster sprite in one string
-    const Heroes * from_hero = Interface::GetFocusHeroes();
-
-    if ( hero.isFriends( conf.CurrentColor() ) )
-        // show all
         Army::DrawMons32Line( hero.GetArmy(), cur_rt.x - 5, cur_rt.y + 114, 160 );
-    else
+    }
+    else {
         // show limited
-        Army::DrawMons32LineWithScoute( hero.GetArmy(), cur_rt.x - 5, cur_rt.y + 114, 160, 0, 0,
-                                        ( from_hero && from_hero->CanScouteTile( hero.GetIndex() ) ? from_hero->GetSecondaryValues( Skill::Secondary::SCOUTING )
-                                                                                                   : Skill::Level::NONE ) );
+        Army::DrawMonsterLines( hero.GetArmy(), cur_rt.x - 5, cur_rt.y + 70, 160, Skill::Level::NONE, false );
+    }
 
     cursor.Show();
     display.Flip();

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -689,7 +689,7 @@ void Dialog::QuickInfo( const Castle & castle )
     }
     else if ( castle.isFriends( conf.CurrentColor() ) )
         // show all
-        Army::DrawMons32Line( castle.GetArmy(), cur_rt.x - 5, cur_rt.y + 100, 192 );
+        Army::DrawMonsterLines( castle.GetArmy(), cur_rt.x - 5, cur_rt.y + 70, Skill::Level::EXPERT, false );
     else
         // show limited
         Army::DrawMons32LineWithScoute( castle.GetArmy(), cur_rt.x - 5, cur_rt.y + 100, 192, 0, 0,

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -568,7 +568,7 @@ void Dialog::QuickInfo( const Castle & castle )
     SpriteBack back( cur_rt );
     box.Blit( cur_rt.x, cur_rt.y );
 
-    cur_rt = Rect( back.GetPos().x + 28, back.GetPos().y + 8, 178, 140 );
+    cur_rt = Rect( back.GetPos().x + 28, back.GetPos().y + 9, 178, 140 );
     Point dst_pt;
     Text text;
 

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -568,14 +568,14 @@ void Dialog::QuickInfo( const Castle & castle )
     SpriteBack back( cur_rt );
     box.Blit( cur_rt.x, cur_rt.y );
 
-    cur_rt = Rect( back.GetPos().x + 28, back.GetPos().y + 12, 178, 140 );
+    cur_rt = Rect( back.GetPos().x + 28, back.GetPos().y + 8, 178, 140 );
     Point dst_pt;
     Text text;
 
     // castle name
     text.Set( castle.GetName(), Font::SMALL );
     dst_pt.x = cur_rt.x + ( cur_rt.w - text.w() ) / 2;
-    dst_pt.y = cur_rt.y + 5;
+    dst_pt.y = cur_rt.y;
     text.Blit( dst_pt );
 
     u32 index = 0;
@@ -608,7 +608,7 @@ void Dialog::QuickInfo( const Castle & castle )
     const Sprite & sprite = AGG::GetICN( ICN::LOCATORS, index );
 
     dst_pt.x = cur_rt.x + ( cur_rt.w - sprite.w() ) / 2;
-    dst_pt.y += 18;
+    dst_pt.y += 15;
     sprite.Blit( dst_pt );
 
     // color flags
@@ -689,10 +689,10 @@ void Dialog::QuickInfo( const Castle & castle )
     }
     else if ( castle.isFriends( conf.CurrentColor() ) )
         // show all
-        Army::DrawMonsterLines( castle.GetArmy(), cur_rt.x - 5, cur_rt.y + 70, 192, Skill::Level::EXPERT, false );
+        Army::DrawMonsterLines( castle.GetArmy(), cur_rt.x - 5, cur_rt.y + 62, 192, Skill::Level::EXPERT, false );
     else
         // show limited
-        Army::DrawMonsterLines( castle.GetArmy(), cur_rt.x - 5, cur_rt.y + 70, 192, Skill::Level::NONE, false );
+        Army::DrawMonsterLines( castle.GetArmy(), cur_rt.x - 5, cur_rt.y + 62, 192, Skill::Level::NONE, false );
 
     cursor.Show();
     display.Flip();
@@ -909,11 +909,11 @@ void Dialog::QuickInfo( const Heroes & hero )
         dst_pt.x += 75;
         text.Blit( dst_pt );
 
-        Army::DrawMons32Line( hero.GetArmy(), cur_rt.x - 5, cur_rt.y + 114, 160 );
+        Army::DrawMons32Line( hero.GetArmy(), cur_rt.x - 7, cur_rt.y + 116, 160 );
     }
     else {
         // show limited
-        Army::DrawMonsterLines( hero.GetArmy(), cur_rt.x - 5, cur_rt.y + 70, 160, Skill::Level::NONE, false );
+        Army::DrawMonsterLines( hero.GetArmy(), cur_rt.x - 6, cur_rt.y + 60, 160, Skill::Level::NONE, false );
     }
 
     cursor.Show();

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -280,7 +280,7 @@ void Interface::StatusWindow::DrawArmyInfo( int oh ) const
 
     if ( armies ) {
         const Rect & pos = GetArea();
-        Army::DrawMonsterLines( *armies, pos.x, pos.y + 3 + oh, 138 );
+        Army::DrawMonsterLines( *armies, pos.x, pos.y + 3 + oh, 138, Skill::Level::EXPERT );
     }
 }
 

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -280,7 +280,7 @@ void Interface::StatusWindow::DrawArmyInfo( int oh ) const
 
     if ( armies ) {
         const Rect & pos = GetArea();
-        Army::DrawMonsterLines( *armies, pos.x, pos.y + 3 + oh );
+        Army::DrawMonsterLines( *armies, pos.x, pos.y + 3 + oh, 138 );
     }
 }
 

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -280,19 +280,7 @@ void Interface::StatusWindow::DrawArmyInfo( int oh ) const
 
     if ( armies ) {
         const Rect & pos = GetArea();
-        u32 count = armies->GetCount();
-
-        if ( 4 > count ) {
-            Army::DrawMons32LineShort( *armies, pos.x, pos.y + 20 + oh, 144, 0, 0 );
-        }
-        else if ( 5 > count ) {
-            Army::DrawMons32LineShort( *armies, pos.x, pos.y + 15 + oh, 110, 0, 2 );
-            Army::DrawMons32LineShort( *armies, pos.x + 20, pos.y + 30 + oh, 120, 2, 2 );
-        }
-        else {
-            Army::DrawMons32LineShort( *armies, pos.x, pos.y + 15 + oh, 140, 0, 3 );
-            Army::DrawMons32LineShort( *armies, pos.x + 10, pos.y + 30 + oh, 120, 3, 2 );
-        }
+        Army::DrawMonsterLines( *armies, pos.x, pos.y + 3 + oh );
     }
 }
 


### PR DESCRIPTION
Fixes #203 

1. Army in status window (using OG values and text to the side rather than under the icon).
2. Castle window update: shifted top part and re-aligned the troops. Amount of information depend on thief guild level rather than Scouting skill - we can do it later.
3. Hero window rework: hide stats for enemy heroes and align the army accordingly.

![image](https://user-images.githubusercontent.com/1373638/82312809-8f34cb00-9995-11ea-888a-4b73a95d02fc.png)
