### PR TITLE
Fix idling condition check

### DIFF
--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -392,7 +392,7 @@ bool Battle::Force::animateIdleUnits()
         if ( unit.isValid() && !unit.Modes( SP_BLIND | IS_PARALYZE_MAGIC ) ) {
             if ( unit.isIdling() ) {
                 if ( unit.isFinishAnimFrame() ) {
-                    redrawNeeded = redrawNeeded || unit.SwitchAnimation( Monster_Info::STATIC );
+                    redrawNeeded = unit.SwitchAnimation( Monster_Info::STATIC ) || redrawNeeded;
                 }
                 else {
                     unit.IncreaseAnimFrame();
@@ -401,7 +401,7 @@ bool Battle::Force::animateIdleUnits()
             }
             // checkIdleDelay() sets and checks unit's internal timer if we're ready to switch to next one
             else if ( unit.GetAnimationState() == Monster_Info::STATIC && unit.checkIdleDelay() ) {
-                redrawNeeded = redrawNeeded || unit.SwitchAnimation( Monster_Info::IDLE );
+                redrawNeeded = unit.SwitchAnimation( Monster_Info::IDLE ) || redrawNeeded;
             }
         }
     }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4220,7 +4220,8 @@ void Battle::Interface::RedrawBridgeAnimation( bool down )
 bool Battle::Interface::IdleTroopsAnimation( void )
 {
     if ( Battle::AnimateInfrequentDelay( Game::BATTLE_IDLE_DELAY ) ) {
-        return arena.GetForce1().animateIdleUnits() || arena.GetForce2().animateIdleUnits();
+        const bool redrawNeeded = arena.GetForce1().animateIdleUnits();
+        return arena.GetForce2().animateIdleUnits() || redrawNeeded;
     }
 
     return false;


### PR DESCRIPTION
Reminder to myself: code after `||` won't be executed.

Fixes #606 .