### PR TITLE
Fix monster count window position during battle

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1240,12 +1240,24 @@ void Battle::Interface::RedrawTroopCount( const Unit & b ) const
         sx = rt.x + ( rt.w - bar.w() ) / 2;
     }
     else {
-        sy = rt.y + rt.h - bar.h() - 5;
+        const bool isReflected = b.isReflect();
+        const bool isWide = b.isWide();
+        sy = rt.y + rt.h - bar.h() - ( isReflected ? 21 : 9 );
 
-        if ( b.isReflect() )
-            sx = rt.x + 3;
-        else
-            sx = rt.x + rt.w - bar.w() - 3;
+        if ( isReflected ) {
+            if ( isWide )
+                sx = rt.x;
+            else
+                sx = rt.x - bar.w() + 3;
+        }
+        else {
+            if ( isWide ) {
+                sx = rt.x + rt.w - bar.w();
+            }
+            else {
+                sx = rt.x + rt.w - 3;
+            }
+        }
     }
 
     bar.Blit( sx, sy );


### PR DESCRIPTION
relates to #261
relates to #534 

Before we had like this (many monster have overlapped window);
![image](https://user-images.githubusercontent.com/19829520/82801668-4064c500-9eb0-11ea-9ee4-f4198c4cb71b.png)

After the fix:
![image](https://user-images.githubusercontent.com/19829520/82801819-7dc95280-9eb0-11ea-9c5a-21b92cca0cd1.png)

