### PR TITLE
Fix ray spells: ripple effect for disrupting ray and correct drawing

### DIFF
--- a/src/engine/surface.cpp
+++ b/src/engine/surface.cpp
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <iomanip>
 #include <iostream>
+#include <math.h>
 #include <memory>
 #include <sstream>
 
@@ -1113,6 +1114,7 @@ Surface Surface::RenderSepia( void ) const
     return res;
 }
 
+// Returns a warped Sprite. Animation is built with 60 frames in mind.
 Surface Surface::RenderRippleEffect( int frame ) const
 {
     Surface res = GetSurface();

--- a/src/engine/surface.cpp
+++ b/src/engine/surface.cpp
@@ -1121,11 +1121,10 @@ Surface Surface::RenderRippleEffect( int frame ) const
 
     const int height = h();
     const int width = w();
-    const int imageDepth = depth();
 
-    int quadWave = abs( 20 - (int)frame % 40 ) - 10;
-    int effectY = ( frame - 10 ) / 10 + 1;
-    const double xOffset = ( effectY * 0.05 + 0.3 ) * quadWave;
+    const int linearWave = abs( 20 - ( frame + 10 ) % 40 ) - 10;
+    const int progress = 7 - ( frame / 10 );
+    const double xOffset = ( progress * 0.05 + 0.3 ) * linearWave;
 
     for ( int y = 0; y < height; ++y ) {
         double sinYEffect = ( sin( ( y % 62 ) / 20.0 ) - 0.5 ) * 2.0;

--- a/src/engine/surface.cpp
+++ b/src/engine/surface.cpp
@@ -1115,26 +1115,28 @@ Surface Surface::RenderSepia( void ) const
 }
 
 // Returns a warped Sprite. Animation is built with 60 frames in mind.
-Surface Surface::RenderRippleEffect( int frame ) const
+Surface Surface::RenderRippleEffect( int frame, double scaleX, double waveFrequency ) const
 {
-    Surface res = GetSurface();
-
-    res.Lock();
-
     const int height = h();
     const int width = w();
 
-    const int linearWave = abs( 20 - ( frame + 10 ) % 40 ) - 10;
-    const int progress = 7 - ( frame / 10 );
-    const double xOffset = ( progress * 0.05 + 0.3 ) * linearWave;
+    // convert frames to -10...10 range with a period of 40
+    const int linearWave = std::abs( 20 - ( frame + 10 ) % 40 ) - 10;
+    const int progress = 7 - frame / 10;
+
+    const double rippleXModifier = ( progress * scaleX + 0.3 ) * linearWave;
+    const int offsetX = std::abs( rippleXModifier );
+    const uint32_t limitY = waveFrequency * M_PI;
+
+    Surface res = Surface( Size( width + offsetX * 2, height ), true );
+    res.Lock();
 
     for ( int y = 0; y < height; ++y ) {
-        double sinYEffect = ( sin( ( y % 62 ) / 20.0 ) - 0.5 ) * 2.0;
+        // Take top half the sin wave starting at 0 with period set by waveFrequency, result is -1...1
+        const double sinYEffect = std::sin( ( y % limitY ) / waveFrequency ) * 2.0 - 1;
         for ( int x = 0; x < width; ++x ) {
-            const int newX = x + static_cast<int>( xOffset * sinYEffect );
-            if ( newX >= 0 && newX < width ) {
-                res.SetPixel( newX, y, GetPixel( x, y ) );
-            }
+            const int newX = x + static_cast<int>( rippleXModifier * sinYEffect ) + offsetX;
+            res.SetPixel( newX, y, GetPixel( x, y ) );
         }
     }
 

--- a/src/engine/surface.cpp
+++ b/src/engine/surface.cpp
@@ -1113,6 +1113,35 @@ Surface Surface::RenderSepia( void ) const
     return res;
 }
 
+Surface Surface::RenderRippleEffect( int frame ) const
+{
+    Surface res = GetSurface();
+
+    res.Lock();
+
+    const int height = h();
+    const int width = w();
+    const int imageDepth = depth();
+
+    int quadWave = abs( 20 - (int)frame % 40 ) - 10;
+    int effectY = ( frame - 10 ) / 10 + 1;
+    const double xOffset = ( effectY * 0.05 + 0.3 ) * quadWave;
+
+    for ( int y = 0; y < height; ++y ) {
+        double sinYEffect = ( sin( ( y % 62 ) / 20.0 ) - 0.5 ) * 2.0;
+        for ( int x = 0; x < width; ++x ) {
+            const int newX = x + static_cast<int>( xOffset * sinYEffect );
+            if ( newX >= 0 && newX < width ) {
+                res.SetPixel( newX, y, GetPixel( x, y ) );
+            }
+        }
+    }
+
+    res.Unlock();
+
+    return res;
+}
+
 Surface Surface::RenderChangeColor( const RGBA & col1, const RGBA & col2 ) const
 {
     Surface res = GetSurface();

--- a/src/engine/surface.cpp
+++ b/src/engine/surface.cpp
@@ -1125,7 +1125,7 @@ Surface Surface::RenderRippleEffect( int frame, double scaleX, double waveFreque
     const int progress = 7 - frame / 10;
 
     const double rippleXModifier = ( progress * scaleX + 0.3 ) * linearWave;
-    const int offsetX = std::abs( rippleXModifier );
+    const int offsetX = abs( rippleXModifier );
     const uint32_t limitY = waveFrequency * M_PI;
 
     Surface res = Surface( Size( width + offsetX * 2, height ), true );
@@ -1133,7 +1133,7 @@ Surface Surface::RenderRippleEffect( int frame, double scaleX, double waveFreque
 
     for ( int y = 0; y < height; ++y ) {
         // Take top half the sin wave starting at 0 with period set by waveFrequency, result is -1...1
-        const double sinYEffect = std::sin( ( y % limitY ) / waveFrequency ) * 2.0 - 1;
+        const double sinYEffect = sin( ( y % limitY ) / waveFrequency ) * 2.0 - 1;
         for ( int x = 0; x < width; ++x ) {
             const int newX = x + static_cast<int>( rippleXModifier * sinYEffect ) + offsetX;
             res.SetPixel( newX, y, GetPixel( x, y ) );

--- a/src/engine/surface.h
+++ b/src/engine/surface.h
@@ -154,7 +154,7 @@ public:
     Surface RenderContour( const RGBA & ) const;
     Surface RenderGrayScale( void ) const;
     Surface RenderSepia( void ) const;
-    Surface RenderRippleEffect( int frame ) const;
+    Surface RenderRippleEffect( int frame, double scaleX = 0.05, double waveFrequency = 20.0 ) const;
     Surface RenderChangeColor( const RGBA &, const RGBA & ) const;
     Surface RenderChangeColor( const std::map<RGBA, RGBA> & colorPairs ) const;
     Surface RenderSurface( const Rect & srt, const Size & ) const;

--- a/src/engine/surface.h
+++ b/src/engine/surface.h
@@ -154,6 +154,7 @@ public:
     Surface RenderContour( const RGBA & ) const;
     Surface RenderGrayScale( void ) const;
     Surface RenderSepia( void ) const;
+    Surface RenderRippleEffect( int frame ) const;
     Surface RenderChangeColor( const RGBA &, const RGBA & ) const;
     Surface RenderChangeColor( const std::map<RGBA, RGBA> & colorPairs ) const;
     Surface RenderSurface( const Rect & srt, const Size & ) const;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3662,7 +3662,7 @@ void Battle::Interface::RedrawActionDisruptingRaySpell( Unit & target )
     RedrawRaySpell( target, ICN::DISRRAY, M82::DISRUPTR, 24 );
 
     // Part 2 - ripple effect
-    Sprite & unitSprite = AGG::GetICN( target.GetMonsterSprite().icn_file, target.GetFrame(), target.isReflect() );
+    const Sprite & unitSprite = AGG::GetICN( target.GetMonsterSprite().icn_file, target.GetFrame(), target.isReflect() );
     Sprite rippleSprite;
 
     const Unit * old_current = _currentUnit;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3699,8 +3699,8 @@ void Battle::Interface::RedrawActionDisruptingRaySpell( Unit & target )
     _currentUnit = &target;
     _movingPos = Point( 0, 0 );
 
-    uint32_t frame = 10;
-    while ( le.HandleEvents() && frame < 70 ) {
+    uint32_t frame = 0;
+    while ( le.HandleEvents() && frame < 60 ) {
         CheckGlobalEvents( le );
 
         if ( Battle::AnimateInfrequentDelay( Game::BATTLE_DISRUPTING_DELAY ) ) {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3654,6 +3654,7 @@ void Battle::Interface::RedrawActionDisruptingRaySpell( Unit & target )
     Cursor & cursor = Cursor::Get();
     LocalEvent & le = LocalEvent::Get();
 
+    // Casting hero position
     Point startingPos;
     const HeroBase * current_commander = arena.GetCurrentCommander();
 
@@ -3691,26 +3692,26 @@ void Battle::Interface::RedrawActionDisruptingRaySpell( Unit & target )
     }
 
     // Part 2 - ripple effect
-    const Monster::monstersprite_t & msi = target.GetMonsterSprite();
-    Sprite & sprite1 = AGG::GetICN( msi.icn_file, target.GetFrame(), target.isReflect() );
+    Sprite & unitSprite = AGG::GetICN( target.GetMonsterSprite().icn_file, target.GetFrame(), target.isReflect() );
+    Sprite rippleSprite;
 
     const Unit * old_current = _currentUnit;
     _currentUnit = &target;
-    b_current_sprite = &sprite1;
     _movingPos = Point( 0, 0 );
 
-    uint32_t frame = 0;
-    while ( le.HandleEvents() && frame < 30 ) {
+    uint32_t frame = 10;
+    while ( le.HandleEvents() && frame < 70 ) {
         CheckGlobalEvents( le );
 
-        if ( Battle::AnimateInfrequentDelay( Game::BATTLE_SPELL_DELAY ) ) {
+        if ( Battle::AnimateInfrequentDelay( Game::BATTLE_DISRUPTING_DELAY ) ) {
             cursor.Hide();
-            sprite1.SetPos( Point( sprite1.x() + ( ( frame % 2 ) ? -3 : 3 ), sprite1.y() ) );
+            rippleSprite = Sprite( unitSprite.RenderRippleEffect( frame ), unitSprite.GetPos().x, unitSprite.GetPos().y );
+            b_current_sprite = &rippleSprite;
             Redraw();
             cursor.Show();
             display.Flip();
 
-            ++frame;
+            frame += 2;
         }
     }
 

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -226,6 +226,7 @@ namespace Battle
         void RedrawActionResurrectSpell( Unit &, const Spell & );
         void RedrawActionLightningBoltSpell( Unit & );
         void RedrawActionChainLightningSpell( const TargetsInfo & );
+        void RedrawRaySpell( const Unit & target, int spellICN, int spellSound, uint32_t size );
 
         void AnimateUnitWithDelay( Unit & unit, uint32_t delay );
         void RedrawTroopDefaultDelay( Unit & unit );

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -130,7 +130,7 @@ void Game::UpdateGameSpeed( void )
     const double adjustedBattleSpeed = ( 10 - conf.BattleSpeed() ) * battleSpeedAdjustment;
     delays[BATTLE_FRAME_DELAY] = 120 * adjustedBattleSpeed;
     delays[BATTLE_MISSILE_DELAY] = 40 * adjustedBattleSpeed;
-    delays[BATTLE_SPELL_DELAY] = 90 * adjustedBattleSpeed;
+    delays[BATTLE_SPELL_DELAY] = 75 * adjustedBattleSpeed;
     delays[BATTLE_IDLE_DELAY] = 150 * adjustedBattleSpeed;
     delays[BATTLE_DISRUPTING_DELAY] = 25 * adjustedBattleSpeed;
     delays[BATTLE_CATAPULT_DELAY] = 90 * adjustedBattleSpeed;


### PR DESCRIPTION
Fixes #645. 

Ripple function is very magical. We should reuse it later: teleport effect uses similar logic.