### PR TITLE
Fix teleport and luck animation

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3154,10 +3154,10 @@ void Battle::Interface::RedrawActionLuck( Unit & unit )
         cursor.SetThemes( Cursor::WAR_NONE );
         AGG::PlaySound( M82::GOODLUCK );
 
-        while ( le.HandleEvents() && width < luckSprite.w() ) {
+        while ( le.HandleEvents() && Mixer::isPlaying( -1 ) ) {
             CheckGlobalEvents( le );
 
-            if ( Battle::AnimateInfrequentDelay( Game::BATTLE_MISSILE_DELAY ) ) {
+            if ( width < luckSprite.w() && Battle::AnimateInfrequentDelay( Game::BATTLE_MISSILE_DELAY ) ) {
                 cursor.Hide();
                 Redraw();
 
@@ -3179,10 +3179,10 @@ void Battle::Interface::RedrawActionLuck( Unit & unit )
         cursor.SetThemes( Cursor::WAR_NONE );
         AGG::PlaySound( M82::BADLUCK );
 
-        while ( le.HandleEvents() && frameId < 8 ) {
+        while ( le.HandleEvents() && Mixer::isPlaying( -1 ) ) {
             CheckGlobalEvents( le );
 
-            if ( Battle::AnimateInfrequentDelay( Game::BATTLE_MISSILE_DELAY ) ) {
+            if ( frameId < 8 && Battle ::AnimateInfrequentDelay( Game::BATTLE_MISSILE_DELAY ) ) {
                 cursor.Hide();
                 Redraw();
 
@@ -3397,15 +3397,16 @@ void Battle::Interface::RedrawActionTeleportSpell( Unit & target, s32 dst )
     cursor.Hide();
 
     _currentUnit = &target;
+    _movingUnit = &target;
     b_current_sprite = &sprite;
-    b_current_alpha = 250;
+    b_current_alpha = 240;
 
     AGG::PlaySound( M82::TELPTOUT );
 
-    while ( le.HandleEvents() && b_current_alpha > 20 ) {
+    while ( le.HandleEvents() && Mixer::isPlaying( -1 ) ) {
         CheckGlobalEvents( le );
 
-        if ( Battle::AnimateInfrequentDelay( Game::BATTLE_SPELL_DELAY ) ) {
+        if ( b_current_alpha > 0 && Battle ::AnimateInfrequentDelay( Game::BATTLE_SPELL_DELAY ) ) {
             cursor.Hide();
             Redraw();
             cursor.Show();
@@ -3422,10 +3423,10 @@ void Battle::Interface::RedrawActionTeleportSpell( Unit & target, s32 dst )
     target.SetPosition( dst );
     AGG::PlaySound( M82::TELPTIN );
 
-    while ( le.HandleEvents() && b_current_alpha <= 235 ) {
+    while ( le.HandleEvents() && Mixer::isPlaying( -1 ) ) {
         CheckGlobalEvents( le );
 
-        if ( Battle::AnimateInfrequentDelay( Game::BATTLE_SPELL_DELAY ) ) {
+        if ( b_current_alpha <= 235 && Battle ::AnimateInfrequentDelay( Game::BATTLE_SPELL_DELAY ) ) {
             cursor.Hide();
             Redraw();
             cursor.Show();
@@ -3437,6 +3438,7 @@ void Battle::Interface::RedrawActionTeleportSpell( Unit & target, s32 dst )
 
     b_current_alpha = 255;
     _currentUnit = NULL;
+    _movingUnit = NULL;
     b_current_sprite = NULL;
 }
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3406,7 +3406,7 @@ void Battle::Interface::RedrawActionTeleportSpell( Unit & target, s32 dst )
     while ( le.HandleEvents() && Mixer::isPlaying( -1 ) ) {
         CheckGlobalEvents( le );
 
-        if ( b_current_alpha > 0 && Battle ::AnimateInfrequentDelay( Game::BATTLE_SPELL_DELAY ) ) {
+        if ( b_current_alpha > 0 && Battle::AnimateInfrequentDelay( Game::BATTLE_SPELL_DELAY ) ) {
             cursor.Hide();
             Redraw();
             cursor.Show();

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3182,7 +3182,7 @@ void Battle::Interface::RedrawActionLuck( Unit & unit )
         while ( le.HandleEvents() && Mixer::isPlaying( -1 ) ) {
             CheckGlobalEvents( le );
 
-            if ( frameId < 8 && Battle ::AnimateInfrequentDelay( Game::BATTLE_MISSILE_DELAY ) ) {
+            if ( frameId < 8 && Battle::AnimateInfrequentDelay( Game::BATTLE_MISSILE_DELAY ) ) {
                 cursor.Hide();
                 Redraw();
 
@@ -3426,7 +3426,7 @@ void Battle::Interface::RedrawActionTeleportSpell( Unit & target, s32 dst )
     while ( le.HandleEvents() && Mixer::isPlaying( -1 ) ) {
         CheckGlobalEvents( le );
 
-        if ( b_current_alpha <= 235 && Battle ::AnimateInfrequentDelay( Game::BATTLE_SPELL_DELAY ) ) {
+        if ( b_current_alpha <= 235 && Battle::AnimateInfrequentDelay( Game::BATTLE_SPELL_DELAY ) ) {
             cursor.Hide();
             Redraw();
             cursor.Show();


### PR DESCRIPTION
Fixes #636.

Waiting for sound sample before going to the next step. Applied to both luck animations as well as teleport spell. Also fixed alpha and removed troop count on a teleport.

The only problem here is that the sound obviously doesn't scale with the game speed and on higher settings player has to wait a considerate time. On lower settings it's perfect.