### PR TITLE
Fix hero quick info crash

### DIFF
--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -85,7 +85,7 @@ namespace Dialog
     // show info cell maps
     void QuickInfo( const Maps::Tiles & );
     void QuickInfo( const Castle & );
-    void QuickInfo( const Heroes & hero, const Heroes & viewer );
+    void QuickInfo( const Heroes & hero );
     int Message( const std::string &, const std::string &, int ft, int buttons = 0 /* buttons: OK : CANCEL : OK|CANCEL : YES|NO */ );
     void ExtSettings( bool );
     int LevelUpSelectSkill( const std::string &, const std::string &, const Skill::Secondary &, const Skill::Secondary &, Heroes & );

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -706,7 +706,7 @@ void Dialog::QuickInfo( const Castle & castle )
     display.Flip();
 }
 
-void Dialog::QuickInfo( const Heroes & hero, const Heroes & viewer )
+void Dialog::QuickInfo( const Heroes & hero )
 {
     Display & display = Display::Get();
     const Settings & conf = Settings::Get();
@@ -757,8 +757,8 @@ void Dialog::QuickInfo( const Heroes & hero, const Heroes & viewer )
     Text text;
     std::string message;
 
-    const bool isFriend = hero.isFriends( viewer.GetColor() );
-    const bool isUnderIdentifyHeroSpell = viewer.GetKingdom().Modes( Kingdom::IDENTIFYHERO );
+    const bool isFriend = hero.isFriends( conf.CurrentColor() );
+    const bool isUnderIdentifyHeroSpell = world.GetKingdom( conf.CurrentColor() ).Modes( Kingdom::IDENTIFYHERO );
     const bool showFullInfo = isFriend || isUnderIdentifyHeroSpell;
 
     // heroes name

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1085,7 +1085,7 @@ void Interface::Basic::MouseCursorAreaPressRight( s32 index_maps )
             case MP2::OBJ_HEROES: {
                 const Heroes * heroes = tile.GetHeroes();
                 if ( heroes )
-                    Dialog::QuickInfo( *heroes, *hero );
+                    Dialog::QuickInfo( *heroes );
             } break;
 
             default:

--- a/src/fheroes2/gui/interface_icons.cpp
+++ b/src/fheroes2/gui/interface_icons.cpp
@@ -300,7 +300,7 @@ void Interface::HeroesIcons::ActionListPressRight( HEROES & item )
 {
     if ( item ) {
         Cursor::Get().Hide();
-        Dialog::QuickInfo( *item, *item );
+        Dialog::QuickInfo( *item );
     }
 }
 

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -330,7 +330,7 @@ int Heroes::OpenDialog( bool readonly, bool fade )
 
         // right info
         if ( !readonly && le.MousePressRight( portPos ) )
-            Dialog::QuickInfo( *this, *this );
+            Dialog::QuickInfo( *this );
         else if ( le.MousePressRight( rectSpreadArmyFormat ) )
             Dialog::Message( _( "Spread Formation" ), descriptionSpreadArmyFormat, Font::BIG );
         else if ( le.MousePressRight( rectGroupedArmyFormat ) )

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -155,7 +155,7 @@ void StatsHeroesList::ActionListSingleClick( HeroRow & row, const Point & cursor
 void StatsHeroesList::ActionListPressRight( HeroRow & row, const Point & cursor, s32 ox, s32 oy )
 {
     if ( row.hero && ( Rect( ox + 5, oy + 4, Interface::IconsBar::GetItemWidth(), Interface::IconsBar::GetItemHeight() ) & cursor ) )
-        Dialog::QuickInfo( *row.hero, *row.hero );
+        Dialog::QuickInfo( *row.hero );
 }
 
 bool StatsHeroesList::ActionListCursor( HeroRow & row, const Point & cursor, s32 ox, s32 oy )
@@ -380,7 +380,7 @@ void StatsCastlesList::ActionListPressRight( CstlRow & row, const Point & cursor
         else if ( Rect( ox + 82, oy + 19, Interface::IconsBar::GetItemWidth(), Interface::IconsBar::GetItemHeight() ) & cursor ) {
             Heroes * hero = row.castle->GetHeroes().GuardFirst();
             if ( hero )
-                Dialog::QuickInfo( *hero, *hero );
+                Dialog::QuickInfo( *hero );
         }
     }
 }


### PR DESCRIPTION
Easy to reproduce: select a castle instead of the hero and then right click other heroes to view the Quickinfo dialog.