### PR TITLE
Bloodlust effect fix and interaction with petrified units

### DIFF
--- a/src/engine/surface.cpp
+++ b/src/engine/surface.cpp
@@ -195,7 +195,7 @@ RGBA::RGBA()
 #endif
 }
 
-RGBA::RGBA( SDL_Color sdl )
+RGBA::RGBA( const SDL_Color & sdl )
 {
     color.r = sdl.r;
     color.g = sdl.g;

--- a/src/engine/surface.cpp
+++ b/src/engine/surface.cpp
@@ -195,6 +195,18 @@ RGBA::RGBA()
 #endif
 }
 
+RGBA::RGBA( SDL_Color sdl )
+{
+    color.r = sdl.r;
+    color.g = sdl.g;
+    color.b = sdl.b;
+#if SDL_VERSION_ATLEAST( 2, 0, 0 )
+    color.a = sdl.a;
+#else
+    color.unused = 255;
+#endif
+}
+
 RGBA::RGBA( int r, int g, int b, int a )
 {
     color.r = r;

--- a/src/engine/surface.h
+++ b/src/engine/surface.h
@@ -36,7 +36,7 @@ class RGBA
 {
 public:
     RGBA();
-    RGBA( SDL_Color sdl );
+    RGBA( const SDL_Color & sdl );
     RGBA( int r, int g, int b, int a = 255 );
 
     SDL_Color operator()( void ) const

--- a/src/engine/surface.h
+++ b/src/engine/surface.h
@@ -36,6 +36,7 @@ class RGBA
 {
 public:
     RGBA();
+    RGBA( SDL_Color sdl );
     RGBA( int r, int g, int b, int a = 255 );
 
     SDL_Color operator()( void ) const

--- a/src/fheroes2/agg/pal.cpp
+++ b/src/fheroes2/agg/pal.cpp
@@ -166,10 +166,11 @@ namespace PAL
     {
         std::map<RGBA, RGBA> swap;
 
-        if ( type >= STANDARD && type <= MIRROR_IMAGE ) {
-            for ( u32 ii = 0; ii < PALETTE_SIZE; ++ii ) {
-                if ( palmap[type].indexes[ii] != ii ) {
-                    swap[standard_palette[ii]] = palmap[type].colors[ii];
+        if ( type < STANDARD && type > MIRROR_IMAGE ) {
+            const palmap_t & paletteMap = palmap[type];
+            for ( u32 i = 0; i < PALETTE_SIZE; ++i ) {
+                if ( paletteMap.indexes[i] != i ) {
+                    swap[standard_palette[i]] = paletteMap.colors[i];
                 }
             }
         }

--- a/src/fheroes2/agg/pal.cpp
+++ b/src/fheroes2/agg/pal.cpp
@@ -124,19 +124,20 @@ namespace PAL
     struct palmap_t
     {
         int type;
-        std::vector<SDL_Color> * colors;
+        const u8 * indexes;
+        std::vector<SDL_Color> & colors;
     };
 
-    const palmap_t palmap[] = {{STANDARD, &standard_palette},
-                               {YELLOW_TEXT, &yellow_text_palette},
-                               {WHITE_TEXT, &white_text_palette},
-                               {GRAY_TEXT, &gray_text_palette},
-                               {RED, &red_palette},
-                               {GRAY, &gray_palette},
-                               {BROWN, &brown_palette},
-                               {TAN, &tan_palette},
-                               {NO_CYCLE, &no_cycle_palette},
-                               {MIRROR_IMAGE, &mirror_image_palette}};
+    const palmap_t palmap[] = {{STANDARD, no_cycle_table, standard_palette},
+                               {YELLOW_TEXT, yellow_text_table, yellow_text_palette},
+                               {WHITE_TEXT, white_text_table, white_text_palette},
+                               {GRAY_TEXT, gray_text_table, gray_text_palette},
+                               {RED, red_table, red_palette},
+                               {GRAY, gray_table, gray_palette},
+                               {BROWN, brown_table, brown_palette},
+                               {TAN, tan_table, tan_palette},
+                               {NO_CYCLE, no_cycle_table, no_cycle_palette},
+                               {MIRROR_IMAGE, mirror_image_table, mirror_image_palette}};
 
     const palmap_t * current_palette;
 
@@ -159,6 +160,21 @@ namespace PAL
         }
 
         return cycleSet;
+    }
+
+    std::map<RGBA, RGBA> GetPaletteSwapMap( int type )
+    {
+        std::map<RGBA, RGBA> swap;
+
+        if ( type >= STANDARD && type <= MIRROR_IMAGE ) {
+            for ( u32 ii = 0; ii < PALETTE_SIZE; ++ii ) {
+                if ( palmap[type].indexes[ii] != ii ) {
+                    swap[standard_palette[ii]] = palmap[type].colors[ii];
+                }
+            }
+
+        }
+        return swap;
     }
 }
 
@@ -186,14 +202,14 @@ int PAL::CurrentPalette()
 
 RGBA PAL::GetPaletteColor( u8 index )
 {
-    const std::vector<SDL_Color> & colors = *current_palette->colors;
+    const std::vector<SDL_Color> & colors = current_palette->colors;
     return index < colors.size() ? RGBA( colors[index].r, colors[index].g, colors[index].b ) : RGBA( 0, 0, 0 );
 }
 
 void PAL::SwapPalette( int type )
 {
     current_palette = &palmap[type];
-    Surface::SetDefaultPalette( &( *current_palette->colors )[0], static_cast<int>( current_palette->colors->size() ) );
+    Surface::SetDefaultPalette( &( current_palette->colors )[0], static_cast<int>( current_palette->colors.size() ) );
 }
 
 void PAL::InitAllPalettes()

--- a/src/fheroes2/agg/pal.cpp
+++ b/src/fheroes2/agg/pal.cpp
@@ -169,14 +169,14 @@ namespace PAL
         if ( type < STANDARD || type > MIRROR_IMAGE ) {
             return swap;
         }
-        else {
-            const palmap_t & paletteMap = palmap[type];
-            for ( uint32_t i = 0; i < PALETTE_SIZE; ++i ) {
-                if ( paletteMap.indexes[i] != i ) {
-                    swap[standard_palette[i]] = paletteMap.colors[i];
-                }
+
+        const palmap_t & paletteMap = palmap[type];
+        for ( uint32_t i = 0; i < PALETTE_SIZE; ++i ) {
+            if ( paletteMap.indexes[i] != i ) {
+                swap[standard_palette[i]] = paletteMap.colors[i];
             }
         }
+
         return swap;
     }
 }

--- a/src/fheroes2/agg/pal.cpp
+++ b/src/fheroes2/agg/pal.cpp
@@ -172,7 +172,6 @@ namespace PAL
                     swap[standard_palette[ii]] = palmap[type].colors[ii];
                 }
             }
-
         }
         return swap;
     }

--- a/src/fheroes2/agg/pal.cpp
+++ b/src/fheroes2/agg/pal.cpp
@@ -168,7 +168,7 @@ namespace PAL
 
         if ( type < STANDARD && type > MIRROR_IMAGE ) {
             const palmap_t & paletteMap = palmap[type];
-            for ( u32 i = 0; i < PALETTE_SIZE; ++i ) {
+            for ( uint32_t i = 0; i < PALETTE_SIZE; ++i ) {
                 if ( paletteMap.indexes[i] != i ) {
                     swap[standard_palette[i]] = paletteMap.colors[i];
                 }

--- a/src/fheroes2/agg/pal.cpp
+++ b/src/fheroes2/agg/pal.cpp
@@ -168,7 +168,8 @@ namespace PAL
 
         if ( type < STANDARD || type > MIRROR_IMAGE ) {
             return swap;
-        } else {
+        }
+        else {
             const palmap_t & paletteMap = palmap[type];
             for ( uint32_t i = 0; i < PALETTE_SIZE; ++i ) {
                 if ( paletteMap.indexes[i] != i ) {

--- a/src/fheroes2/agg/pal.cpp
+++ b/src/fheroes2/agg/pal.cpp
@@ -166,7 +166,9 @@ namespace PAL
     {
         std::map<RGBA, RGBA> swap;
 
-        if ( type < STANDARD && type > MIRROR_IMAGE ) {
+        if ( type < STANDARD || type > MIRROR_IMAGE ) {
+            return swap;
+        } else {
             const palmap_t & paletteMap = palmap[type];
             for ( uint32_t i = 0; i < PALETTE_SIZE; ++i ) {
                 if ( paletteMap.indexes[i] != i ) {

--- a/src/fheroes2/agg/pal.h
+++ b/src/fheroes2/agg/pal.h
@@ -50,6 +50,7 @@ namespace PAL
     };
 
     const std::vector<CyclingColorSet> & GetCyclingColors();
+    std::map<RGBA, RGBA> GetPaletteSwapMap( int type );
     void CreateStandardPalette();
     void InitAllPalettes();
     void Clear();

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1210,19 +1210,19 @@ void Battle::Interface::RedrawTroopSprite( const Unit & b ) const
         // regular
         spmon1 = AGG::GetICN( msi.icn_file, b.GetFrame(), b.isReflect() );
 
-        // this unit's turn, must be covered with contour
-        if ( _currentUnit == &b ) {
-            if ( b_current_sprite ) {
-                spmon1 = *b_current_sprite;
-                spmon2.Reset();
-            }
-            else {
-                spmon2 = Sprite( b.isReflect() ? b.GetContour( CONTOUR_REFLECT ) : b.GetContour( CONTOUR_MAIN ), 0, 0 );
-            }
-        }
-
         if ( b.hasColorCycling() ) {
             spmon1.ChangeColor( _colorCyclePairs );
+        }
+    }
+
+    // this unit's turn, must be covered with contour
+    if ( _currentUnit == &b ) {
+        if ( b_current_sprite ) {
+            spmon1 = *b_current_sprite;
+            spmon2.Reset();
+        }
+        else {
+            spmon2 = Sprite( b.isReflect() ? b.GetContour( CONTOUR_REFLECT ) : b.GetContour( CONTOUR_MAIN ), 0, 0 );
         }
     }
 
@@ -3579,14 +3579,16 @@ void Battle::Interface::RedrawActionBloodLustSpell( Unit & target )
     _currentUnit = &target;
     b_current_sprite = &mixSprite;
 
-    AGG::PlaySound( M82::BLOODLUS ); // duration is 1900ms
+    const uint32_t bloodlustDelay = 1800 / 20;
+    // duration is 1900ms
+    AGG::PlaySound( M82::BLOODLUS );
 
     uint32_t alpha = 0;
     uint32_t frame = 0;
     while ( le.HandleEvents() && Mixer::isPlaying( -1 ) ) {
         CheckGlobalEvents( le );
 
-        if ( frame < 20 && Battle::AnimateInfrequentDelay( Game::BATTLE_SPELL_DELAY ) ) {
+        if ( frame < 20 && Game::AnimateCustomDelay( bloodlustDelay ) ) {
             cursor.Hide();
             unitSprite.Blit( mixSprite );
             bloodlustEffect.SetAlphaMod( alpha );
@@ -3595,7 +3597,7 @@ void Battle::Interface::RedrawActionBloodLustSpell( Unit & target )
             cursor.Show();
             display.Flip();
 
-            alpha += ( frame < 10 ) ? 15 : -15;
+            alpha += ( frame < 10 ) ? 20 : -20;
             frame++;
         }
     }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1201,28 +1201,25 @@ void Battle::Interface::RedrawTroopSprite( const Unit & b ) const
     const Monster::monstersprite_t & msi = b.GetMonsterSprite();
     Sprite spmon1, spmon2;
 
-    // under medusa's stunning effect
-    if ( b.Modes( SP_STONE ) ) {
-        const Sprite & original = AGG::GetICN( msi.icn_file, b.GetFrame(), b.isReflect() );
-        spmon1 = Sprite( b.isReflect() ? b.GetContour( CONTOUR_REFLECT | CONTOUR_BLACK ) : b.GetContour( CONTOUR_BLACK ), original.x(), original.y() );
+    // regular
+    spmon1 = AGG::GetICN( msi.icn_file, b.GetFrame(), b.isReflect() );
+    
+    // override
+    if ( b_current_sprite && _currentUnit == &b ) {
+        spmon1 = *b_current_sprite;
+        spmon2.Reset();
+    }
+    else if ( b.Modes( SP_STONE ) ) {
+        // under medusa's stunning effect
+        spmon1 = Sprite( b.isReflect() ? b.GetContour( CONTOUR_REFLECT | CONTOUR_BLACK ) : b.GetContour( CONTOUR_BLACK ), spmon1.x(), spmon1.y() );
     }
     else {
-        // regular
-        spmon1 = AGG::GetICN( msi.icn_file, b.GetFrame(), b.isReflect() );
-
+        if ( _currentUnit == &b ) {
+            // this unit's turn, must be covered with contour
+            spmon2 = Sprite( b.isReflect() ? b.GetContour( CONTOUR_REFLECT ) : b.GetContour( CONTOUR_MAIN ), 0, 0 );
+        }
         if ( b.hasColorCycling() ) {
             spmon1.ChangeColor( _colorCyclePairs );
-        }
-    }
-
-    // this unit's turn, must be covered with contour
-    if ( _currentUnit == &b ) {
-        if ( b_current_sprite ) {
-            spmon1 = *b_current_sprite;
-            spmon2.Reset();
-        }
-        else {
-            spmon2 = Sprite( b.isReflect() ? b.GetContour( CONTOUR_REFLECT ) : b.GetContour( CONTOUR_MAIN ), 0, 0 );
         }
     }
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3564,7 +3564,7 @@ void Battle::Interface::RedrawActionBloodLustSpell( Unit & target )
     Cursor & cursor = Cursor::Get();
     LocalEvent & le = LocalEvent::Get();
 
-    std::map<RGBA, RGBA> colorSwap = PAL::GetPaletteSwapMap( PAL::RED );
+    const std::map<RGBA, RGBA> colorSwap = PAL::GetPaletteSwapMap( PAL::RED );
     const Monster::monstersprite_t & msi = target.GetMonsterSprite();
 
     Sprite unitSprite = AGG::GetICN( msi.icn_file, target.GetFrame(), target.isReflect() );
@@ -3599,7 +3599,7 @@ void Battle::Interface::RedrawActionBloodLustSpell( Unit & target )
             display.Flip();
 
             alpha += ( frame < 10 ) ? 20 : -20;
-            frame++;
+            ++frame;
         }
     }
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3568,6 +3568,10 @@ void Battle::Interface::RedrawActionBloodLustSpell( Unit & target )
     const Monster::monstersprite_t & msi = target.GetMonsterSprite();
 
     Sprite unitSprite = AGG::GetICN( msi.icn_file, target.GetFrame(), target.isReflect() );
+    if ( target.Modes( SP_STONE ) ) {
+        unitSprite
+            = Sprite( target.isReflect() ? target.GetContour( CONTOUR_REFLECT | CONTOUR_BLACK ) : target.GetContour( CONTOUR_BLACK ), unitSprite.x(), unitSprite.y() );
+    }
     Surface bloodlustEffect = unitSprite.RenderChangeColor( colorSwap );
     Sprite mixSprite( Surface( unitSprite.GetSize(), true ), unitSprite.x(), unitSprite.y() );
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1203,7 +1203,7 @@ void Battle::Interface::RedrawTroopSprite( const Unit & b ) const
 
     // regular
     spmon1 = AGG::GetICN( msi.icn_file, b.GetFrame(), b.isReflect() );
-    
+
     // override
     if ( b_current_sprite && _currentUnit == &b ) {
         spmon1 = *b_current_sprite;


### PR DESCRIPTION
Fixes #715 . Fixes #613 .

Using palette swap to draw bloodlust effect, blending the two. Made sure bloodlust effect can be displayed over the petrified unit. Also waiting for sound effect to end.