### PR TITLE
Fix monster sprite shift teleport spell

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3429,7 +3429,6 @@ void Battle::Interface::RedrawActionTeleportSpell( Unit & target, s32 dst )
     cursor.Hide();
 
     _currentUnit = &target;
-    _movingUnit = &target;
     b_current_sprite = &sprite;
     b_current_alpha = 240;
 
@@ -3470,7 +3469,6 @@ void Battle::Interface::RedrawActionTeleportSpell( Unit & target, s32 dst )
 
     b_current_alpha = 255;
     _currentUnit = NULL;
-    _movingUnit = NULL;
     b_current_sprite = NULL;
 }
 


### PR DESCRIPTION
A monster does not move during teleportation