### PR TITLE
Castle siege logic fixes

### DIFF
--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -872,7 +872,7 @@ double GetAngle( const Point & start, const Point & target )
     double angle = atan2( -dy, dx ) * 180.0 / M_PI;
     // we only care about two quadrants, normalize
     if ( dx < 0 ) {
-        angle = ( dy < 0 ) ? 180 - angle : -angle - 180;
+        angle = ( dy <= 0 ) ? 180 - angle : -angle - 180;
     }
     return angle;
 }

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -441,10 +441,10 @@ void Battle::Arena::Turns( void )
             }
 
             if ( !tower_moved && current_troop->GetColor() == army2->GetColor() ) {
-                if ( towers[0] && towers[0]->isValid() )
-                    TowerAction( *towers[0] );
                 if ( towers[1] && towers[1]->isValid() )
                     TowerAction( *towers[1] );
+                if ( towers[0] && towers[0]->isValid() )
+                    TowerAction( *towers[0] );
                 if ( towers[2] && towers[2]->isValid() )
                     TowerAction( *towers[2] );
                 tower_moved = true;
@@ -543,7 +543,7 @@ void Battle::Arena::CatapultAction( void )
         values[CAT_WALL4] = GetCastleTargetValue( CAT_WALL4 );
         values[CAT_TOWER1] = GetCastleTargetValue( CAT_TOWER1 );
         values[CAT_TOWER2] = GetCastleTargetValue( CAT_TOWER2 );
-        values[CAT_TOWER3] = GetCastleTargetValue( CAT_TOWER3 );
+        values[CAT_CENTRAL_TOWER] = GetCastleTargetValue( CAT_CENTRAL_TOWER );
         values[CAT_BRIDGE] = GetCastleTargetValue( CAT_BRIDGE );
 
         Command cmd( MSG_BATTLE_CATAPULT );
@@ -829,7 +829,7 @@ void Battle::Arena::SetCastleTargetValue( int target, u32 value )
         if ( towers[2] && towers[2]->isValid() )
             towers[2]->SetDestroy();
         break;
-    case CAT_TOWER3:
+    case CAT_CENTRAL_TOWER:
         if ( towers[1] && towers[1]->isValid() )
             towers[1]->SetDestroy();
         break;
@@ -864,7 +864,7 @@ u32 Battle::Arena::GetCastleTargetValue( int target ) const
         return towers[0] && towers[0]->isValid();
     case CAT_TOWER2:
         return towers[2] && towers[2]->isValid();
-    case CAT_TOWER3:
+    case CAT_CENTRAL_TOWER:
         return towers[1] && towers[1]->isValid();
 
     case CAT_BRIDGE:

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -550,7 +550,7 @@ void Battle::Arena::CatapultAction( void )
 
         while ( shots-- ) {
             int target = catapult->GetTarget( values );
-            u32 damage = catapult->GetDamage( target, GetCastleTargetValue( target ) );
+            u32 damage = std::min( catapult->GetDamage(), values[target] );
             cmd << damage << target;
             values[target] -= damage;
         }

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -54,9 +54,8 @@ Battle::Catapult::Catapult( const HeroBase & hero, bool fortification )
         break;
     }
 
-    u32 acount = hero.HasArtifact( Artifact::BALLISTA );
-    if ( acount )
-        catShots += acount * Artifact( Artifact::BALLISTA ).ExtraValue();
+    if ( hero.HasArtifact( Artifact::BALLISTA ) )
+        catShots += Artifact( Artifact::BALLISTA ).ExtraValue();
 }
 
 u32 Battle::Catapult::GetDamage( int target, u32 value ) const

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -28,26 +28,26 @@
 #include "skill.h"
 
 Battle::Catapult::Catapult( const HeroBase & hero, bool fortification )
-    : cat_shots( 1 )
-    , cat_first( 20 )
-    , cat_miss( true ) /*, cat_fort(fortification) */
+    : catShots( 1 )
+    , doubleDamageChance( 25 )
+    , canMiss( true )
 {
     switch ( hero.GetLevelSkill( Skill::Secondary::BALLISTICS ) ) {
     case Skill::Level::BASIC:
-        cat_first = 40;
-        cat_miss = false;
+        doubleDamageChance = 50;
+        canMiss = false;
         break;
 
     case Skill::Level::ADVANCED:
-        cat_first = 80;
-        cat_shots += 1;
-        cat_miss = false;
+        doubleDamageChance = 50;
+        catShots += 1;
+        canMiss = false;
         break;
 
     case Skill::Level::EXPERT:
-        cat_first = 100;
-        cat_shots += 1;
-        cat_miss = false;
+        doubleDamageChance = 100;
+        catShots += 1;
+        canMiss = false;
         break;
 
     default:
@@ -56,7 +56,7 @@ Battle::Catapult::Catapult( const HeroBase & hero, bool fortification )
 
     u32 acount = hero.HasArtifact( Artifact::BALLISTA );
     if ( acount )
-        cat_shots += acount * Artifact( Artifact::BALLISTA ).ExtraValue();
+        catShots += acount * Artifact( Artifact::BALLISTA ).ExtraValue();
 }
 
 u32 Battle::Catapult::GetDamage( int target, u32 value ) const
@@ -67,9 +67,9 @@ u32 Battle::Catapult::GetDamage( int target, u32 value ) const
     case CAT_WALL3:
     case CAT_WALL4:
         if ( value ) {
-            if ( cat_first == 100 || cat_first >= Rand::Get( 1, 100 ) ) {
-                // value = value;
-                DEBUG( DBG_BATTLE, DBG_TRACE, "from one blow capability" );
+            if ( doubleDamageChance == 100 || doubleDamageChance >= Rand::Get( 1, 100 ) ) {
+                DEBUG( DBG_BATTLE, DBG_TRACE, "Catapult dealt double damage from " << doubleDamageChance );
+                value = 2;
             }
             else
                 value = 1;
@@ -163,8 +163,8 @@ int Battle::Catapult::GetTarget( const std::vector<u32> & values ) const
     }
 
     if ( targets.size() ) {
-        // miss for 30%
-        return cat_miss && 7 > Rand::Get( 1, 20 ) ? CAT_MISS : ( 1 < targets.size() ? *Rand::Get( targets ) : targets.front() );
+        // Miss chance is 25%
+        return canMiss && 6 > Rand::Get( 1, 20 ) ? CAT_MISS : ( 1 < targets.size() ? *Rand::Get( targets ) : targets.front() );
     }
 
     DEBUG( DBG_BATTLE, DBG_TRACE, "target not found.." );

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -58,32 +58,14 @@ Battle::Catapult::Catapult( const HeroBase & hero, bool fortification )
         catShots += Artifact( Artifact::BALLISTA ).ExtraValue();
 }
 
-u32 Battle::Catapult::GetDamage( int target, u32 value ) const
+u32 Battle::Catapult::GetDamage() const
 {
-    switch ( target ) {
-    case CAT_WALL1:
-    case CAT_WALL2:
-    case CAT_WALL3:
-    case CAT_WALL4:
-        if ( value ) {
-            if ( doubleDamageChance == 100 || doubleDamageChance >= Rand::Get( 1, 100 ) ) {
-                DEBUG( DBG_BATTLE, DBG_TRACE, "Catapult dealt double damage from " << doubleDamageChance );
-                value = 2;
-            }
-            else
-                value = 1;
-        }
-        break;
-
-    case CAT_MISS:
-        DEBUG( DBG_BATTLE, DBG_TRACE, "miss!" );
-        break;
-
-    default:
-        break;
+    if ( doubleDamageChance == 100 || doubleDamageChance >= Rand::Get( 1, 100 ) ) {
+        DEBUG( DBG_BATTLE, DBG_TRACE, "Catapult dealt double damage! (" << doubleDamageChance << "% chance)" );
+        return 2;
     }
 
-    return value;
+    return 1;
 }
 
 Point Battle::Catapult::GetTargetPosition( int target )

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -110,7 +110,7 @@ Point Battle::Catapult::GetTargetPosition( int target )
     case CAT_TOWER2:
         res = Point( 430, 300 );
         break;
-    case CAT_TOWER3:
+    case CAT_CENTRAL_TOWER:
         res = Point( 580, 160 );
         break;
     case CAT_BRIDGE:
@@ -158,8 +158,8 @@ int Battle::Catapult::GetTarget( const std::vector<u32> & values ) const
 
     // check general tower
     if ( targets.empty() ) {
-        if ( values[CAT_TOWER3] )
-            targets.push_back( CAT_TOWER3 );
+        if ( values[CAT_CENTRAL_TOWER] )
+            targets.push_back( CAT_CENTRAL_TOWER );
     }
 
     if ( targets.size() ) {

--- a/src/fheroes2/battle/battle_catapult.h
+++ b/src/fheroes2/battle/battle_catapult.h
@@ -54,7 +54,7 @@ namespace Battle
             return catShots;
         }
         int GetTarget( const std::vector<u32> & ) const;
-        u32 GetDamage( int, u32 ) const;
+        u32 GetDamage() const;
 
     private:
         u32 catShots;

--- a/src/fheroes2/battle/battle_catapult.h
+++ b/src/fheroes2/battle/battle_catapult.h
@@ -51,16 +51,15 @@ namespace Battle
 
         u32 GetShots( void ) const
         {
-            return cat_shots;
+            return catShots;
         }
         int GetTarget( const std::vector<u32> & ) const;
         u32 GetDamage( int, u32 ) const;
 
     private:
-        u32 cat_shots;
-        u32 cat_first;
-        bool cat_miss;
-        // bool	cat_fort;
+        u32 catShots;
+        u32 doubleDamageChance;
+        bool canMiss;
     };
 }
 

--- a/src/fheroes2/battle/battle_catapult.h
+++ b/src/fheroes2/battle/battle_catapult.h
@@ -38,7 +38,7 @@ namespace Battle
         CAT_TOWER1 = 5,
         CAT_TOWER2 = 6,
         CAT_BRIDGE = 7,
-        CAT_TOWER3 = 8,
+        CAT_CENTRAL_TOWER = 8,
         CAT_MISS = 9
     };
 


### PR DESCRIPTION
Fixes #747 . Fixes #728 . Fixes #739 

Corrected missile angle when Y distance is 0. 
Corrected ballistics skill effect to replace assumptions with real values.
Corrected tower shooting order/renamed a def to avoid confusion.
Removed artifact effect stacking.
