### PR TITLE
Fix display drawing during mouse movement in SDL 2

### DIFF
--- a/src/engine/display.cpp
+++ b/src/engine/display.cpp
@@ -29,6 +29,11 @@
 #include "tools.h"
 #include "types.h"
 
+namespace
+{
+    SDL::Time redrawTiming; // a special timer to highlight that it's time to redraw a screen (only for SDL 2 as of now)
+}
+
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
 Display::Display()
     : window( NULL )
@@ -157,6 +162,8 @@ Size Display::GetDefaultSize( void )
 void Display::Flip( void )
 {
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
+    redrawTiming.Start(); // TODO: for now it's only for SDL 2 but it should be for everything
+
     SDL_Texture * tx = SDL_CreateTextureFromSurface( renderer, surface );
 
     if ( tx ) {
@@ -459,6 +466,16 @@ Display & Display::Get( void )
 Surface Display::GetSurface( void ) const
 {
     return GetSurface( Rect( Point( 0, 0 ), GetSize() ) );
+}
+
+bool Display::isRedrawRequired()
+{
+#if SDL_VERSION_ATLEAST( 2, 0, 0 )
+    redrawTiming.Stop();
+    return redrawTiming.Get() > 500; // 0.5 second
+#else
+    return false;
+#endif
 }
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )

--- a/src/engine/display.h
+++ b/src/engine/display.h
@@ -73,6 +73,8 @@ public:
 
     bool isMouseFocusActive() const;
 
+    static bool isRedrawRequired(); // in case of no explicit redrawing we must redraw at least once in a second
+
 protected:
     friend class Texture;
 

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -434,6 +434,10 @@ LocalEvent & LocalEvent::Get( void )
 
 bool LocalEvent::HandleEvents( bool delay, bool allowExit )
 {
+    if ( Display::isRedrawRequired() ) {
+        Display::Get().Flip();
+    }
+
     SDL_Event event;
 
     ResetModes( MOUSE_MOTION );

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -127,6 +127,8 @@ int Game::MainMenu( void )
             }
         }
 
+        bool redrawScreen = false;
+
         for ( u32 i = 0; i < ARRAY_COUNT( buttons ); i++ ) {
             buttons[i].wasOver = buttons[i].isOver;
 
@@ -137,17 +139,24 @@ int Game::MainMenu( void )
 
             buttons[i].isOver = le.MouseCursor( buttons[i].button );
 
-            if ( ( !buttons[i].isOver && buttons[i].wasOver ) || ( buttons[i].isOver && !buttons[i].wasOver ) ) {
+            if ( buttons[i].isOver != buttons[i].wasOver ) {
                 u32 frame = buttons[i].frame;
 
                 if ( buttons[i].isOver && !buttons[i].wasOver )
                     frame++;
 
-                cursor.Hide();
+                if ( !redrawScreen ) {
+                    cursor.Hide();
+                    redrawScreen = true;
+                }
                 const Sprite & sprite = AGG::GetICN( ICN::BTNSHNGL, frame );
                 sprite.Blit( sprite.x(), sprite.y() );
-                cursor.Show();
             }
+        }
+
+        if ( redrawScreen ) {
+            cursor.Show();
+            display.Flip();
         }
 
         if ( HotKeyPressEvent( EVENT_BUTTON_NEWGAME ) || le.MouseClickLeft( buttonNewGame ) )

--- a/src/fheroes2/gui/cursor.h
+++ b/src/fheroes2/gui/cursor.h
@@ -24,6 +24,10 @@
 
 #include "gamedefs.h"
 
+#if SDL_VERSION_ATLEAST( 2, 0, 0 )
+#define USE_SDL_CURSOR
+#endif
+
 class Cursor : public SpriteMove
 {
 public:
@@ -140,15 +144,25 @@ public:
     int Themes( void );
     bool SetThemes( int, bool force = false );
     void Show( void );
+    void Hide( void );
+    bool isVisible( void ) const;
 
 private:
     Cursor();
+    ~Cursor();
     void SetOffset( int name, const Point & defaultOffset );
     void Move( s32, s32 );
+
+    void _free();
 
     int theme;
     s32 offset_x;
     s32 offset_y;
+
+#if defined( USE_SDL_CURSOR )
+    SDL_Cursor * _cursorSDL;
+    bool _isVisibleCursor;
+#endif
 };
 
 #endif


### PR DESCRIPTION
relates to #427

After detailed investigation of the problem there are multiple observations:
- the slowdown happens when we refresh screen too fast. The current implementation refreshes screen on the event of mouse move, method `void Cursor::Move( s32 x, s32 y )`. Even if we move the mouse a little we still refresh the whole screen
- after applying most of changes from #515 we still faced a problem of slow response of the main screen due to a fact that screen refresh time now doesn't depend on mouse movement. The problem was related to a problem that we don't call **Flip()** method of Display class.
- we don't update screen if we don't explicitly draw anything. I added a simple implementation to forcefully update the screen in such case every 0.5 second

Hi @shprotru and @idshibanov , I made a separate pull request as it was faster to make changes here instead of changing the existing pull request.