### PR TITLE
Fix World Map drawings and screen jumping during hero movement

### DIFF
--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -337,7 +337,7 @@ void Dialog::QuickInfo( const Maps::Tiles & tile )
     // image box
     const Sprite & box = AGG::GetICN( qwikinfo, 0 );
     const Interface::GameArea & gamearea = Interface::Basic::Get().GetGameArea();
-    const Rect ar( BORDERWIDTH, BORDERWIDTH, gamearea.GetArea().w, gamearea.GetArea().h );
+    const Rect ar( gamearea.GetROI() );
 
     LocalEvent & le = LocalEvent::Get();
     const Point & mp = le.GetMouseCursor();
@@ -533,7 +533,7 @@ void Dialog::QuickInfo( const Castle & castle )
     // image box
     const Sprite & box = AGG::GetICN( qwiktown, 0 );
     const Interface::GameArea & gamearea = Interface::Basic::Get().GetGameArea();
-    const Rect ar( BORDERWIDTH, BORDERWIDTH, gamearea.GetArea().w, gamearea.GetArea().h );
+    const Rect ar( gamearea.GetROI() );
 
     LocalEvent & le = LocalEvent::Get();
     const Point & mp = le.GetMouseCursor();
@@ -719,7 +719,7 @@ void Dialog::QuickInfo( const Heroes & hero )
     // image box
     const Sprite & box = AGG::GetICN( qwikhero, 0 );
     const Interface::GameArea & gamearea = Interface::Basic::Get().GetGameArea();
-    const Rect ar( BORDERWIDTH, BORDERWIDTH, gamearea.GetArea().w, gamearea.GetArea().h );
+    const Rect ar( gamearea.GetROI() );
 
     LocalEvent & le = LocalEvent::Get();
     const Point & mp = le.GetMouseCursor();

--- a/src/fheroes2/game/game_interface.cpp
+++ b/src/fheroes2/game/game_interface.cpp
@@ -231,14 +231,15 @@ s32 Interface::Basic::GetDimensionDoorDestination( s32 from, u32 distance, bool 
     SpriteBack back( Rect( radarArea.x, radarArea.y, radarArea.w, radarArea.h ) );
     viewDoor.Blit( radarArea );
 
-    const Rect & visibleArea = gameArea.GetArea();
+    const Rect & visibleArea = gameArea.GetROI();
     const bool isFadingEnabled = display.w() >= TILEWIDTH * ( distance + 1 ) && display.h() >= TILEWIDTH * ( distance + 1 );
     const Surface & top = display.GetSurface( visibleArea );
     if ( isFadingEnabled ) {
         Surface back( top.GetSize(), false );
         back.Fill( ColorBlack );
-        const Point offset( visibleArea.x + visibleArea.w / 2 - TILEWIDTH * ( distance / 2 ) - TILEWIDTH / 2,
-                            visibleArea.y + visibleArea.h / 2 - TILEWIDTH * ( distance / 2 ) - TILEWIDTH / 2 );
+
+        const Point heroPos( gameArea.GetRelativeTilePosition( Maps::GetPoint( from ) ) );
+        const Point offset( heroPos.x - TILEWIDTH * ( distance / 2 ), heroPos.y - TILEWIDTH * ( distance / 2 ) );
         const Surface middle = display.GetSurface( Rect( offset.x, offset.y, TILEWIDTH * ( distance + 1 ), TILEWIDTH * ( distance + 1 ) ) );
 
         display.InvertedFade( top, back, Point( visibleArea.x, visibleArea.y ), middle, offset, 105, 300 );
@@ -264,15 +265,15 @@ s32 Interface::Basic::GetDimensionDoorDestination( s32 from, u32 distance, bool 
             if ( le.MouseClickLeft( buttonExit ) || HotKeyCloseWindow )
                 break;
         }
-        else if ( gameArea.GetArea() & mp ) {
-            dst = gameArea.GetIndexFromMousePoint( mp );
+        else if ( visibleArea & mp ) {
+            dst = gameArea.GetValidTileIdFromPoint( mp );
 
             bool valid = ( dst >= 0 );
 
             if ( valid ) {
                 const Maps::Tiles & tile = world.GetTiles( dst );
 
-                valid = ( ( gameArea.GetArea() & mp ) && ( !tile.isFog( conf.CurrentColor() ) ) && MP2::isClearGroundObject( tile.GetObject() )
+                valid = ( ( visibleArea & mp ) && ( !tile.isFog( conf.CurrentColor() ) ) && MP2::isClearGroundObject( tile.GetObject() )
                           && water == world.GetTiles( dst ).isWater() && ( distance / 2 ) >= Maps::GetApproximateDistance( from, dst ) );
             }
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -878,7 +878,7 @@ int Interface::Basic::HumanTurn( bool isload )
             res = controlPanel.QueueEventProcessing();
         }
         // cursor over game area
-        else if ( le.MouseCursor( gameArea.GetArea() ) && !gameArea.NeedScroll() ) {
+        else if ( le.MouseCursor( gameArea.GetROI() ) && !gameArea.NeedScroll() ) {
             gameArea.QueueEventProcessing();
         }
 
@@ -936,11 +936,9 @@ int Interface::Basic::HumanTurn( bool isload )
                             Point movement( hero->MovementDirection() );
                             if ( movement != Point() ) { // don't waste resources for no movement
                                 const int moveStep = hero->GetMoveStep();
-                                movement.x *= -moveStep;
-                                movement.y *= -moveStep;
-                                gameArea.SetMapsPos( gameArea.GetMapsPos() + movement );
-                                gameArea.SetCenter( hero->GetCenter() );
-                                ResetFocus( GameFocus::HEROES );
+                                movement.x *= moveStep;
+                                movement.y *= moveStep;
+                                gameArea.ShiftCenter( movement );
                                 RedrawFocus();
                             }
                         }

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -227,7 +227,7 @@ void Interface::Basic::EventSystemDialog( void )
     // change scroll
     if ( 0x10 & changes ) {
         // hardcore reset pos
-        gameArea.SetCenter( 0, 0 );
+        gameArea.SetCenter( Point( 0, 0 ) );
         if ( GetFocusType() != GameFocus::UNSEL )
             gameArea.SetCenter( GetFocusCenter() );
         gameArea.SetRedraw();

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -56,7 +56,7 @@ void Interface::Basic::CalculateHeroPath( Heroes * hero, s32 destinationIdx )
         gameArea.SetRedraw();
 
         LocalEvent & le = LocalEvent::Get();
-        const int32_t cursorIndex = gameArea.GetIndexFromMousePoint( le.GetMouseCursor() );
+        const int32_t cursorIndex = gameArea.GetValidTileIdFromPoint( le.GetMouseCursor() );
         Cursor::Get().SetThemes( GetCursorTileIndex( cursorIndex ) );
         Interface::Basic::Get().buttonsArea.Redraw();
     }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -47,7 +47,7 @@ const Rect & Interface::GameArea::GetROI( void ) const
     return _windowROI;
 }
 
-const Rect Interface::GameArea::GetVisibleTileROI( void ) const
+Rect Interface::GameArea::GetVisibleTileROI( void ) const
 {
     return Rect( _getStartTileId(), _visibleTileCount );
 }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -31,53 +31,35 @@
 #include "settings.h"
 #include "world.h"
 
-#define SCROLL_MAX TILEWIDTH
-
-namespace Game
-{
-    // game_startgame.cpp
-    int GetCursor( s32 );
-    void MouseCursorAreaClickLeft( s32 );
-    void MouseCursorAreaPressRight( s32 );
-}
-
 Interface::GameArea::GameArea( Basic & basic )
     : interface( basic )
-    , oldIndexPos( 0 )
+    , _minLeftOffset( 0 )
+    , _maxLeftOffset( 0 )
+    , _minTopOffset( 0 )
+    , _maxTopOffset( 0 )
+    , _prevIndexPos( 0 )
     , scrollDirection( 0 )
-    , scrollStepX( 32 )
-    , scrollStepY( 32 )
-    , tailX( 0 )
-    , tailY( 0 )
     , updateCursor( false )
-    , borderSizeX( 8 )
-    , borderSizeY( 8 )
 {}
 
-const Rect & Interface::GameArea::GetArea( void ) const
+const Rect & Interface::GameArea::GetROI( void ) const
 {
-    return areaPosition;
+    return _windowROI;
 }
 
-const Point & Interface::GameArea::GetMapsPos( void ) const
+const Rect Interface::GameArea::GetVisibleTileROI( void ) const
 {
-    return rectMapsPosition;
+    return Rect( _getStartTileId(), _visibleTileCount );
 }
 
-void Interface::GameArea::SetMapsPos( const Point & pos )
+void Interface::GameArea::ShiftCenter( const Point & offset )
 {
-    rectMapsPosition = pos;
+    _setCenter( _topLeftTileOffset + _middlePoint() + offset );
 }
 
-const Rect & Interface::GameArea::GetRectMaps( void ) const
-{
-    return rectMaps;
-}
-
-/* fixed src rect image */
 Rect Interface::GameArea::RectFixed( Point & dst, int rw, int rh ) const
 {
-    std::pair<Rect, Point> res = Rect::Fixed4Blit( Rect( dst.x, dst.y, rw, rh ), interface.GetGameArea().GetArea() );
+    std::pair<Rect, Point> res = Rect::Fixed4Blit( Rect( dst.x, dst.y, rw, rh ), interface.GetGameArea().GetROI() );
     dst = res.second;
     return res.first;
 }
@@ -92,55 +74,31 @@ void Interface::GameArea::Build( void )
 
 void Interface::GameArea::SetAreaPosition( s32 x, s32 y, u32 w, u32 h )
 {
-    areaPosition.x = x;
-    areaPosition.y = y;
-    areaPosition.w = w;
-    areaPosition.h = h;
+    _windowROI = Rect( x, y, w, h );
+    const Size worldSize = Size( world.w() * TILEWIDTH, world.h() * TILEWIDTH );
 
-    rectMaps.x = 0;
-    rectMaps.y = 0;
-
-    rectMaps.w = ( areaPosition.w / TILEWIDTH ) + 2;
-    rectMaps.h = ( areaPosition.h / TILEWIDTH ) + 2;
-
-    scrollOffset.x = 0;
-    scrollOffset.y = 0;
-    scrollStepX = Settings::Get().ScrollSpeed();
-    scrollStepY = Settings::Get().ScrollSpeed();
-
-    if ( world.w() < rectMaps.w ) {
-        rectMaps.w = ( areaPosition.w / TILEWIDTH );
-        scrollStepX = SCROLL_MAX;
+    if ( worldSize.w > w ) {
+        _minLeftOffset = -static_cast<int16_t>( w / 2 );
+        _maxLeftOffset = worldSize.w - w / 2;
+    }
+    else {
+        _minLeftOffset = -static_cast<int16_t>( w - worldSize.w ) / 2;
+        _maxLeftOffset = _minLeftOffset;
     }
 
-    if ( world.h() < rectMaps.h ) {
-        rectMaps.h = ( areaPosition.h / TILEWIDTH );
-        scrollStepY = SCROLL_MAX;
+    if ( worldSize.h > h ) {
+        _minTopOffset = -static_cast<int16_t>( h / 2 );
+        _maxTopOffset = worldSize.h - h / 2;
+    }
+    else {
+        _minTopOffset = -static_cast<int16_t>( h - worldSize.h ) / 2;
+        _maxTopOffset = _minTopOffset;
     }
 
-    borderSizeX = rectMaps.w / 2;
-    if ( ( rectMaps.w % 2 ) == 1 )
-        ++borderSizeX;
+    // adding 1 extra tile for both axes in case of drawing tiles partially near sides
+    _visibleTileCount = Size( ( w + TILEWIDTH - 1 ) / TILEWIDTH + 1, ( h + TILEWIDTH - 1 ) / TILEWIDTH + 1 );
 
-    if ( borderSizeX < MIN_BORDER_SIZE )
-        borderSizeX = MIN_BORDER_SIZE;
-    else if ( borderSizeX > SCROLL_MAX )
-        borderSizeX = SCROLL_MAX;
-
-    borderSizeY = rectMaps.h / 2;
-    if ( ( rectMaps.h % 2 ) == 1 )
-        ++borderSizeY;
-
-    if ( borderSizeY < MIN_BORDER_SIZE )
-        borderSizeY = MIN_BORDER_SIZE;
-    else if ( borderSizeY > SCROLL_MAX )
-        borderSizeY = SCROLL_MAX;
-
-    tailX = areaPosition.w - TILEWIDTH * ( areaPosition.w / TILEWIDTH );
-    tailY = areaPosition.h - TILEWIDTH * ( areaPosition.h / TILEWIDTH );
-
-    rectMapsPosition.x = areaPosition.x - scrollOffset.x;
-    rectMapsPosition.y = areaPosition.y - scrollOffset.y;
+    _setCenterToTile( Point( world.w() / 2, world.h() / 2 ) );
 }
 
 void Interface::GameArea::UpdateCyclingPalette( int frame )
@@ -168,26 +126,23 @@ void Interface::GameArea::BlitOnTile( Surface & dst, const Sprite & src, const P
 
 void Interface::GameArea::BlitOnTile( Surface & dst, const Surface & src, s32 ox, s32 oy, const Point & mp ) const
 {
-    Point dstpt( rectMapsPosition.x + TILEWIDTH * ( mp.x - rectMaps.x ) + ox, rectMapsPosition.y + TILEWIDTH * ( mp.y - rectMaps.y ) + oy );
+    Point dstpt = GetRelativeTilePosition( mp ) + Point( ox, oy );
 
-    if ( areaPosition & Rect( dstpt, src.w(), src.h() ) ) {
+    if ( _windowROI & Rect( dstpt, src.w(), src.h() ) ) {
         src.Blit( RectFixed( dstpt, src.w(), src.h() ), dstpt, dst );
     }
 }
 
 void Interface::GameArea::Redraw( Surface & dst, int flag ) const
 {
-    Redraw( dst, flag, Rect( 0, 0, rectMaps.w, rectMaps.h ) );
-}
+    const Rect tileROI = GetVisibleTileROI();
 
-void Interface::GameArea::Redraw( Surface & dst, int flag, const Rect & rt ) const
-{
-    // tile
-    for ( s32 oy = rt.y; oy < rt.y + rt.h; ++oy ) {
-        const s32 offsetY = rectMaps.y + oy;
+    // ground
+    for ( int16_t y = 0; y < tileROI.h; ++y ) {
+        const s32 offsetY = tileROI.y + y;
         bool isEmptyTile = offsetY < 0 || offsetY >= world.h();
-        for ( s32 ox = rt.x; ox < rt.x + rt.w; ++ox ) {
-            const s32 offsetX = rectMaps.x + ox;
+        for ( s32 x = 0; x < tileROI.w; ++x ) {
+            const s32 offsetX = tileROI.x + x;
             if ( isEmptyTile || offsetX < 0 || offsetX >= world.w() )
                 Maps::Tiles::RedrawEmptyTile( dst, Point( offsetX, offsetY ) );
             else
@@ -197,12 +152,12 @@ void Interface::GameArea::Redraw( Surface & dst, int flag, const Rect & rt ) con
 
     // bottom
     if ( flag & LEVEL_BOTTOM ) {
-        for ( s32 oy = rt.y; oy < rt.y + rt.h; ++oy ) {
-            const s32 offsetY = rectMaps.y + oy;
+        for ( int16_t y = 0; y < tileROI.h; ++y ) {
+            const s32 offsetY = tileROI.y + y;
             if ( offsetY < 0 || offsetY >= world.h() )
                 continue;
-            for ( s32 ox = rt.x; ox < rt.x + rt.w; ++ox ) {
-                const s32 offsetX = rectMaps.x + ox;
+            for ( s32 x = 0; x < tileROI.w; ++x ) {
+                const s32 offsetX = tileROI.x + x;
                 if ( offsetX < 0 || offsetX >= world.w() )
                     continue;
                 world.GetTiles( offsetX, offsetY ).RedrawBottom( dst, !( flag & LEVEL_OBJECTS ) );
@@ -217,19 +172,18 @@ void Interface::GameArea::Redraw( Surface & dst, int flag, const Rect & rt ) con
         const Sprite & sprite = AGG::GetICN( MP2::GetICNObject( removalInfo.object ), removalInfo.index );
         sprite.Blit( sprite.x(), sprite.y(), surface );
         surface.SetAlphaMod( removalInfo.alpha, false );
-        const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
         const Point mp = Maps::GetPoint( removalInfo.tile );
-        area.BlitOnTile( dst, surface, 0, 0, mp );
+        BlitOnTile( dst, surface, 0, 0, mp );
     }
 
     // ext object
     if ( flag & LEVEL_OBJECTS ) {
-        for ( s32 oy = rt.y; oy < rt.y + rt.h; ++oy ) {
-            const s32 offsetY = rectMaps.y + oy;
+        for ( int16_t y = 0; y < tileROI.h; ++y ) {
+            const s32 offsetY = tileROI.y + y;
             if ( offsetY < 0 || offsetY >= world.h() )
                 continue;
-            for ( s32 ox = rt.x; ox < rt.x + rt.w; ++ox ) {
-                const s32 offsetX = rectMaps.x + ox;
+            for ( s32 x = 0; x < tileROI.w; ++x ) {
+                const s32 offsetX = tileROI.x + x;
                 if ( offsetX < 0 || offsetX >= world.w() )
                     continue;
                 world.GetTiles( offsetX, offsetY ).RedrawObjects( dst );
@@ -239,12 +193,12 @@ void Interface::GameArea::Redraw( Surface & dst, int flag, const Rect & rt ) con
 
     // top
     if ( flag & LEVEL_TOP ) {
-        for ( s32 oy = rt.y; oy < rt.y + rt.h; ++oy ) {
-            const s32 offsetY = rectMaps.y + oy;
+        for ( int16_t y = 0; y < tileROI.h; ++y ) {
+            const s32 offsetY = tileROI.y + y;
             if ( offsetY < 0 || offsetY >= world.h() )
                 continue;
-            for ( s32 ox = rt.x; ox < rt.x + rt.w; ++ox ) {
-                const s32 offsetX = rectMaps.x + ox;
+            for ( s32 x = 0; x < tileROI.w; ++x ) {
+                const s32 offsetX = tileROI.x + x;
                 if ( offsetX < 0 || offsetX >= world.w() )
                     continue;
                 world.GetTiles( offsetX, offsetY ).RedrawTop( dst );
@@ -253,20 +207,22 @@ void Interface::GameArea::Redraw( Surface & dst, int flag, const Rect & rt ) con
     }
 
     // heroes
-    for ( s32 oy = rt.y; oy < rt.y + rt.h; ++oy ) {
-        const s32 offsetY = rectMaps.y + oy;
+    for ( int16_t y = 0; y < tileROI.h; ++y ) {
+        const s32 offsetY = tileROI.y + y;
         if ( offsetY < 0 || offsetY >= world.h() )
             continue;
-        for ( s32 ox = rt.x; ox < rt.x + rt.w; ++ox ) {
-            const s32 offsetX = rectMaps.x + ox;
+        for ( s32 x = 0; x < tileROI.w; ++x ) {
+            const s32 offsetX = tileROI.x + x;
             if ( offsetX < 0 || offsetX >= world.w() )
                 continue;
             const Maps::Tiles & tile = world.GetTiles( offsetX, offsetY );
 
             if ( tile.GetObject() == MP2::OBJ_HEROES && ( flag & LEVEL_HEROES ) ) {
                 const Heroes * hero = tile.GetHeroes();
-                if ( hero )
-                    hero->Redraw( dst, rectMapsPosition.x + TILEWIDTH * ox, rectMapsPosition.y + TILEWIDTH * oy, true );
+                if ( hero ) {
+                    const Point pos = GetRelativeTilePosition( Point( offsetX, offsetY ) );
+                    hero->Redraw( dst, pos.x, pos.y, true );
+                }
             }
         }
     }
@@ -275,7 +231,6 @@ void Interface::GameArea::Redraw( Surface & dst, int flag, const Rect & rt ) con
     const Heroes * hero = flag & LEVEL_HEROES ? GetFocusHeroes() : NULL;
 
     if ( hero && hero->GetPath().isShow() ) {
-        // s32 from = hero->GetIndex();
         s32 green = hero->GetPath().GetAllowStep();
 
         const bool skipfirst = hero->isEnableMove() && 45 > hero->GetSpriteIndex() && 2 < ( hero->GetSpriteIndex() % 9 );
@@ -292,7 +247,7 @@ void Interface::GameArea::Redraw( Surface & dst, int flag, const Rect & rt ) con
             --green;
 
             // is visible
-            if ( ( Rect( rectMaps.x + rt.x, rectMaps.y + rt.y, rt.w, rt.h ) & mp ) &&
+            if ( ( tileROI & mp ) &&
                  // check skip first?
                  !( it1 == hero->GetPath().begin() && skipfirst ) ) {
                 const u32 index
@@ -313,19 +268,20 @@ void Interface::GameArea::Redraw( Surface & dst, int flag, const Rect & rt ) con
         if ( flag & LEVEL_ALL ) {
             const RGBA col = RGBA( 0x90, 0xA4, 0xE0 );
 
-            for ( s32 oy = rt.y; oy < rt.y + rt.h; ++oy ) {
-                const s32 offsetY = rectMaps.y + oy;
+            for ( int16_t y = 0; y < tileROI.h; ++y ) {
+                const s32 offsetY = tileROI.y + y;
                 if ( offsetY < 0 || offsetY >= world.h() )
                     continue;
-                for ( s32 ox = rt.x; ox < rt.x + rt.w; ++ox ) {
-                    const s32 offsetX = rectMaps.x + ox;
+                for ( s32 x = 0; x < tileROI.w; ++x ) {
+                    const s32 offsetX = tileROI.x + x;
                     if ( offsetX < 0 || offsetX >= world.w() )
                         continue;
-                    const Point dstpt( rectMapsPosition.x + TILEWIDTH * ox, rectMapsPosition.y + TILEWIDTH * oy );
-                    if ( areaPosition & dstpt )
-                        dst.DrawPoint( dstpt, col );
 
-                    world.GetTiles( rectMaps.x + ox, rectMaps.y + oy ).RedrawPassable( dst );
+                    const Point pos = GetRelativeTilePosition( Point( offsetX, offsetY ) );
+                    if ( _windowROI & pos )
+                        dst.DrawPoint( pos, col );
+
+                    world.GetTiles( offsetX, offsetY ).RedrawPassable( dst );
                 }
             }
         }
@@ -336,12 +292,12 @@ void Interface::GameArea::Redraw( Surface & dst, int flag, const Rect & rt ) con
         if ( flag & LEVEL_FOG ) {
         const int colors = Players::FriendColors();
 
-        for ( s32 oy = rt.y; oy < rt.y + rt.h; ++oy ) {
-            const s32 offsetY = rectMaps.y + oy;
+        for ( int16_t y = 0; y < tileROI.h; ++y ) {
+            const s32 offsetY = tileROI.y + y;
             if ( offsetY < 0 || offsetY >= world.h() )
                 continue;
-            for ( s32 ox = rt.x; ox < rt.x + rt.w; ++ox ) {
-                const s32 offsetX = rectMaps.x + ox;
+            for ( s32 x = 0; x < tileROI.w; ++x ) {
+                const s32 offsetX = tileROI.x + x;
                 if ( offsetX < 0 || offsetX >= world.w() )
                     continue;
 
@@ -354,45 +310,26 @@ void Interface::GameArea::Redraw( Surface & dst, int flag, const Rect & rt ) con
     }
 }
 
-/* scroll area */
 void Interface::GameArea::Scroll( void )
 {
+    const int16_t speed = Settings::Get().ScrollSpeed();
+    Point offset;
+
     if ( scrollDirection & SCROLL_LEFT ) {
-        if ( 0 < scrollOffset.x )
-            scrollOffset.x -= scrollStepX;
-        else if ( -borderSizeX < rectMaps.x ) {
-            scrollOffset.x = SCROLL_MAX - scrollStepX;
-            --rectMaps.x;
-        }
+        offset.x = -speed;
     }
     else if ( scrollDirection & SCROLL_RIGHT ) {
-        if ( scrollOffset.x < SCROLL_MAX * 2 - tailX )
-            scrollOffset.x += scrollStepX;
-        else if ( world.w() - rectMaps.w + borderSizeX > rectMaps.x ) {
-            scrollOffset.x = SCROLL_MAX + scrollStepX - tailX;
-            ++rectMaps.x;
-        }
+        offset.x = speed;
     }
 
     if ( scrollDirection & SCROLL_TOP ) {
-        if ( 0 < scrollOffset.y )
-            scrollOffset.y -= scrollStepY;
-        else if ( -borderSizeY < rectMaps.y ) {
-            scrollOffset.y = SCROLL_MAX - scrollStepY;
-            --rectMaps.y;
-        }
+        offset.y = -speed;
     }
     else if ( scrollDirection & SCROLL_BOTTOM ) {
-        if ( scrollOffset.y < SCROLL_MAX * 2 - tailY )
-            scrollOffset.y += scrollStepY;
-        else if ( world.h() - rectMaps.h + borderSizeY > rectMaps.y ) {
-            scrollOffset.y = SCROLL_MAX + scrollStepY - tailY;
-            ++rectMaps.y;
-        }
+        offset.y = speed;
     }
 
-    rectMapsPosition.x = areaPosition.x - scrollOffset.x;
-    rectMapsPosition.y = areaPosition.y - scrollOffset.y;
+    ShiftCenter( offset );
 
     scrollDirection = 0;
 }
@@ -410,52 +347,9 @@ void Interface::GameArea::SetCenter( const Point & pt )
 
 void Interface::GameArea::SetCenter( s32 px, s32 py )
 {
-    Point pos( px - rectMaps.w / 2, py - rectMaps.h / 2 );
+    _setCenterToTile( Point( px, py ) );
 
-    // our of range
-    if ( pos.x < -borderSizeX )
-        pos.x = -borderSizeX;
-    else if ( pos.x > world.w() - rectMaps.w + borderSizeX )
-        pos.x = world.w() - rectMaps.w + borderSizeX;
-
-    if ( pos.y < -borderSizeY )
-        pos.y = -borderSizeY;
-    else if ( pos.y > world.h() - rectMaps.h + borderSizeY )
-        pos.y = world.h() - rectMaps.h + borderSizeY;
-
-    if ( pos.x == rectMaps.x && pos.y == rectMaps.y )
-        return;
-
-    rectMaps.x = pos.x;
-    rectMaps.y = pos.y;
     scrollDirection = 0;
-
-    if ( pos.x == 0 )
-        scrollOffset.x = 0;
-    else if ( pos.x == world.w() - rectMaps.w ) {
-        scrollOffset.x = SCROLL_MAX * 2 - tailX;
-    }
-    else {
-        scrollOffset.x = ( rectMaps.w % 2 == 0 ? SCROLL_MAX + TILEWIDTH / 2 : SCROLL_MAX ) - tailX;
-    }
-
-    if ( pos.y == 0 )
-        scrollOffset.y = 0;
-    else if ( pos.y == world.h() - rectMaps.h ) {
-        scrollOffset.y = SCROLL_MAX * 2 - tailY;
-    }
-    else {
-        scrollOffset.y = ( rectMaps.h % 2 == 0 ? SCROLL_MAX + TILEWIDTH / 2 : SCROLL_MAX ) - tailY;
-    }
-
-    rectMapsPosition.x = areaPosition.x - scrollOffset.x;
-    rectMapsPosition.y = areaPosition.y - scrollOffset.y;
-
-    if ( Display::Get().w() > areaPosition.w )
-        scrollStepX = Settings::Get().ScrollSpeed();
-
-    if ( Display::Get().h() > areaPosition.h )
-        scrollStepY = Settings::Get().ScrollSpeed();
 }
 
 Surface Interface::GameArea::GenerateUltimateArtifactAreaSurface( s32 index )
@@ -466,11 +360,10 @@ Surface Interface::GameArea::GenerateUltimateArtifactAreaSurface( s32 index )
         sf.Set( 448, 448, false );
 
         GameArea & gamearea = Basic::Get().GetGameArea();
-        const Rect origPosition( gamearea.areaPosition );
+        const Rect origPosition( gamearea._windowROI );
         gamearea.SetAreaPosition( 0, 0, sf.w(), sf.h() );
 
-        const Rect & rectMaps = gamearea.GetRectMaps();
-        const Rect & areaPosition = gamearea.GetArea();
+        const Rect & rectMaps = gamearea.GetVisibleTileROI();
         Point pt = Maps::GetPoint( index );
 
         gamearea.SetCenter( pt );
@@ -488,8 +381,10 @@ Surface Interface::GameArea::GenerateUltimateArtifactAreaSurface( s32 index )
                 break;
             }
         const Sprite & marker = AGG::GetICN( ICN::ROUTE, 0 );
-        const Point dst( areaPosition.x + pt.x * TILEWIDTH - gamearea.scrollOffset.x, areaPosition.y + pt.y * TILEWIDTH - gamearea.scrollOffset.y );
-        marker.Blit( dst.x, dst.y + 8, sf );
+        const Point markerPos( gamearea.GetRelativeTilePosition( pt ) - gamearea._middlePoint() - Point( gamearea._windowROI.x, gamearea._windowROI.y )
+                               + Point( sf.w() / 2, sf.h() / 2 ) );
+
+        marker.Blit( markerPos.x, markerPos.y + 8, sf );
 
         sf = ( Settings::Get().ExtGameEvilInterface() ? sf.RenderGrayScale() : sf.RenderSepia() );
 
@@ -538,44 +433,32 @@ int Interface::GameArea::GetScrollCursor( void ) const
 void Interface::GameArea::SetScroll( int direct )
 {
     if ( ( direct & SCROLL_LEFT ) == SCROLL_LEFT ) {
-        if ( -borderSizeX < rectMaps.x || -borderSizeX < scrollOffset.x ) {
+        if ( _topLeftTileOffset.x > _minLeftOffset ) {
             scrollDirection |= direct;
             updateCursor = true;
         }
     }
     else if ( ( direct & SCROLL_RIGHT ) == SCROLL_RIGHT ) {
-        if ( world.w() - rectMaps.w + borderSizeX > rectMaps.x || SCROLL_MAX * 2 > scrollOffset.x ) {
+        if ( _topLeftTileOffset.x < _maxLeftOffset ) {
             scrollDirection |= direct;
             updateCursor = true;
         }
     }
 
     if ( ( direct & SCROLL_TOP ) == SCROLL_TOP ) {
-        if ( -borderSizeY < rectMaps.y || -borderSizeY < scrollOffset.y ) {
+        if ( _topLeftTileOffset.y > _minTopOffset ) {
             scrollDirection |= direct;
             updateCursor = true;
         }
     }
     else if ( ( direct & SCROLL_BOTTOM ) == SCROLL_BOTTOM ) {
-        if ( world.h() - rectMaps.h + borderSizeY > rectMaps.y || SCROLL_MAX * 2 > scrollOffset.y ) {
+        if ( _topLeftTileOffset.y < _maxTopOffset ) {
             scrollDirection |= direct;
             updateCursor = true;
         }
     }
 
     scrollTime.Start();
-}
-
-/* convert area point to index maps */
-s32 Interface::GameArea::GetIndexFromMousePoint( const Point & pt ) const
-{
-    const s32 xPos = rectMaps.x + ( pt.x - rectMapsPosition.x ) / TILEWIDTH;
-    const s32 yPos = rectMaps.y + ( pt.y - rectMapsPosition.y ) / TILEWIDTH;
-
-    if ( xPos < 0 || yPos < 0 || xPos >= world.w() || yPos >= world.h() )
-        return -1;
-
-    return yPos * world.w() + xPos;
 }
 
 void Interface::GameArea::SetUpdateCursor( void )
@@ -591,12 +474,12 @@ void Interface::GameArea::QueueEventProcessing( void )
     LocalEvent & le = LocalEvent::Get();
     const Point & mp = le.GetMouseCursor();
 
-    s32 index = GetIndexFromMousePoint( mp );
+    s32 index = GetValidTileIdFromPoint( mp );
 
     // change cusor if need
-    if ( updateCursor || index != oldIndexPos ) {
+    if ( updateCursor || index != _prevIndexPos ) {
         cursor.SetThemes( interface.GetCursorTileIndex( index ) );
-        oldIndexPos = index;
+        _prevIndexPos = index;
         updateCursor = false;
     }
 
@@ -612,6 +495,7 @@ void Interface::GameArea::QueueEventProcessing( void )
         // drag&drop gamearea: scroll
         if ( conf.ExtPocketDragDropScroll() && le.MousePressLeft() ) {
             Point pt1 = le.GetMouseCursor();
+            const int16_t speed = Settings::Get().ScrollSpeed();
 
             while ( le.HandleEvents() && le.MousePressLeft() ) {
                 const Point & pt2 = le.GetMouseCursor();
@@ -619,8 +503,8 @@ void Interface::GameArea::QueueEventProcessing( void )
                 if ( pt1 != pt2 ) {
                     s32 dx = pt2.x - pt1.x;
                     s32 dy = pt2.y - pt1.y;
-                    s32 d2x = scrollStepX;
-                    s32 d2y = scrollStepY;
+                    s32 d2x = speed;
+                    s32 d2y = speed;
 
                     while ( 1 ) {
                         if ( d2x <= dx ) {
@@ -662,11 +546,74 @@ void Interface::GameArea::QueueEventProcessing( void )
             return;
     }
 
-    const Rect tile_pos( rectMapsPosition.x + ( ( mp.x - rectMapsPosition.x ) / TILEWIDTH ) * TILEWIDTH,
-                         rectMapsPosition.y + ( ( mp.y - rectMapsPosition.y ) / TILEWIDTH ) * TILEWIDTH, TILEWIDTH, TILEWIDTH );
+    const Point tileOffset = _topLeftTileOffset + mp - Point( _windowROI.x, _windowROI. y );
+    const Point tilePos( ( tileOffset.x / TILEWIDTH ) * TILEWIDTH - _topLeftTileOffset.x + _windowROI.x,
+                         ( tileOffset.y / TILEWIDTH ) * TILEWIDTH - _topLeftTileOffset.y + _windowROI.x );
 
-    if ( le.MouseClickLeft( tile_pos ) )
+    const Rect tileROI( tilePos.x, tilePos.y, TILEWIDTH, TILEWIDTH );
+
+    if ( le.MouseClickLeft( tileROI ) )
         interface.MouseCursorAreaClickLeft( index );
-    else if ( le.MousePressRight( tile_pos ) )
+    else if ( le.MousePressRight( tileROI ) )
         interface.MouseCursorAreaPressRight( index );
+}
+
+Point Interface::GameArea::_middlePoint() const
+{
+    return Point( _windowROI.w / 2, _windowROI.h / 2 );
+}
+
+Point Interface::GameArea::_getStartTileId() const
+{
+    const int16_t x = ( _topLeftTileOffset.x < 0 ? ( _topLeftTileOffset.x - TILEWIDTH - 1 ) / TILEWIDTH : _topLeftTileOffset.x / TILEWIDTH );
+    const int16_t y = ( _topLeftTileOffset.y < 0 ? ( _topLeftTileOffset.y - TILEWIDTH - 1 ) / TILEWIDTH : _topLeftTileOffset.y / TILEWIDTH );
+
+    return Point( x, y );
+}
+
+void Interface::GameArea::_setCenterToTile( const Point & tile )
+{
+    _setCenter( Point( tile.x * TILEWIDTH - TILEWIDTH / 2, tile.y * TILEWIDTH - TILEWIDTH / 2 ) );
+}
+
+void Interface::GameArea::_setCenter( const Point & point )
+{
+    int16_t offsetX = point.x - _middlePoint().x;
+    int16_t offsetY = point.y - _middlePoint().y;
+    if ( offsetX < _minLeftOffset )
+        offsetX = _minLeftOffset;
+    else if ( offsetX > _maxLeftOffset )
+        offsetX = _maxLeftOffset;
+
+    if ( offsetY < _minTopOffset )
+        offsetY = _minTopOffset;
+    else if ( offsetY > _maxTopOffset )
+        offsetY = _maxTopOffset;
+
+    _topLeftTileOffset = Point( offsetX, offsetY );
+}
+
+int32_t Interface::GameArea::GetValidTileIdFromPoint( const Point & point ) const
+{
+    const Point offset = _topLeftTileOffset + point - Point( _windowROI.x, _windowROI. y );
+    if ( offset.x < 0 || offset.y < 0 )
+        return -1;
+
+    const int16_t x = offset.x / TILEWIDTH;
+    const int16_t y = offset.y / TILEWIDTH;
+
+    if ( x >= world.w() || y >= world.h() )
+        return -1;
+
+    return y * world.w() + x;
+}
+
+Point Interface::GameArea::GetRelativeTilePosition( const Point & tileId ) const
+{
+    return _getRelativePosition( Point( tileId.x * TILEWIDTH, tileId.y * TILEWIDTH ) );
+}
+
+Point Interface::GameArea::_getRelativePosition( const Point & point ) const
+{
+    return point - _topLeftTileOffset + Point( _windowROI.x, _windowROI. y );
 }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -546,7 +546,7 @@ void Interface::GameArea::QueueEventProcessing( void )
             return;
     }
 
-    const Point tileOffset = _topLeftTileOffset + mp - Point( _windowROI.x, _windowROI. y );
+    const Point tileOffset = _topLeftTileOffset + mp - Point( _windowROI.x, _windowROI.y );
     const Point tilePos( ( tileOffset.x / TILEWIDTH ) * TILEWIDTH - _topLeftTileOffset.x + _windowROI.x,
                          ( tileOffset.y / TILEWIDTH ) * TILEWIDTH - _topLeftTileOffset.y + _windowROI.x );
 
@@ -595,7 +595,7 @@ void Interface::GameArea::_setCenter( const Point & point )
 
 int32_t Interface::GameArea::GetValidTileIdFromPoint( const Point & point ) const
 {
-    const Point offset = _topLeftTileOffset + point - Point( _windowROI.x, _windowROI. y );
+    const Point offset = _topLeftTileOffset + point - Point( _windowROI.x, _windowROI.y );
     if ( offset.x < 0 || offset.y < 0 )
         return -1;
 
@@ -615,5 +615,5 @@ Point Interface::GameArea::GetRelativeTilePosition( const Point & tileId ) const
 
 Point Interface::GameArea::_getRelativePosition( const Point & point ) const
 {
-    return point - _topLeftTileOffset + Point( _windowROI.x, _windowROI. y );
+    return point - _topLeftTileOffset + Point( _windowROI.x, _windowROI.y );
 }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -342,12 +342,7 @@ void Interface::GameArea::SetRedraw( void ) const
 /* scroll area to center point maps */
 void Interface::GameArea::SetCenter( const Point & pt )
 {
-    SetCenter( pt.x, pt.y );
-}
-
-void Interface::GameArea::SetCenter( s32 px, s32 py )
-{
-    _setCenterToTile( Point( px, py ) );
+    _setCenterToTile( pt );
 
     scrollDirection = 0;
 }

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -99,6 +99,7 @@ namespace Interface
         Rect _windowROI; // visible to draw area of World Map in pixels
         Point _topLeftTileOffset; // offset of tiles to be drawn (from here we can find any tile ID)
 
+        // boundaries for World Map
         int16_t _minLeftOffset;
         int16_t _maxLeftOffset;
         int16_t _minTopOffset;
@@ -115,11 +116,11 @@ namespace Interface
 
         SDL::Time scrollTime;
 
-        Point _middlePoint() const;
+        Point _middlePoint() const; // returns middle point of window ROI
         Point _getStartTileId() const;
         void _setCenterToTile( const Point & tile ); // set center to the middle of tile (input is tile ID)
         void _setCenter( const Point & point ); // in pixels
-        Point _getRelativePosition( const Point & point ) const; // return relative to screen position
+        Point _getRelativePosition( const Point & point ) const; // returns relative to screen position
     };
 }
 

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -68,7 +68,6 @@ namespace Interface
         void Scroll( void );
         void SetScroll( int );
 
-        void SetCenter( s32, s32 );
         void SetCenter( const Point & );
         void SetRedraw( void ) const;
 

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -60,7 +60,7 @@ namespace Interface
         void Build( void );
 
         const Rect & GetROI( void ) const; // returns visible Game Area ROI in pixels
-        const Rect GetVisibleTileROI( void ) const;
+        Rect GetVisibleTileROI( void ) const;
         void ShiftCenter( const Point & offset ); // in pixels
 
         int GetScrollCursor( void ) const;

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -59,10 +59,9 @@ namespace Interface
         GameArea( Basic & );
         void Build( void );
 
-        const Rect & GetArea( void ) const;
-        const Point & GetMapsPos( void ) const;
-        void SetMapsPos( const Point & pos ); // do not call this method without caution
-        const Rect & GetRectMaps( void ) const;
+        const Rect & GetROI( void ) const; // returns visible Game Area ROI in pixels
+        const Rect GetVisibleTileROI( void ) const;
+        void ShiftCenter( const Point & offset ); // in pixels
 
         int GetScrollCursor( void ) const;
         bool NeedScroll( void ) const;
@@ -74,7 +73,6 @@ namespace Interface
         void SetRedraw( void ) const;
 
         void Redraw( Surface & dst, int ) const;
-        void Redraw( Surface & dst, int, const Rect & ) const;
 
         void BlitOnTile( Surface &, const Surface &, s32, s32, const Point & ) const;
         void BlitOnTile( Surface &, const Sprite &, const Point & ) const;
@@ -86,39 +84,42 @@ namespace Interface
         void SetUpdateCursor( void );
         void QueueEventProcessing( void );
 
-        s32 GetIndexFromMousePoint( const Point & ) const;
         Rect RectFixed( Point & dst, int rw, int rh ) const;
 
         static Surface GenerateUltimateArtifactAreaSurface( s32 );
+
+        int32_t GetValidTileIdFromPoint( const Point & point ) const; // returns -1 in case of invalid index (out of World Map)
+        Point GetRelativeTilePosition( const Point & tileId ) const; // in relation to screen
 
     private:
         void SetAreaPosition( s32, s32, u32, u32 );
 
         Basic & interface;
 
-        Rect areaPosition;
-        Rect rectMaps;
-        Point rectMapsPosition;
-        Point scrollOffset;
-        s32 oldIndexPos;
+        Rect _windowROI; // visible to draw area of World Map in pixels
+        Point _topLeftTileOffset; // offset of tiles to be drawn (from here we can find any tile ID)
+
+        int16_t _minLeftOffset;
+        int16_t _maxLeftOffset;
+        int16_t _minTopOffset;
+        int16_t _maxTopOffset;
+
+        Size _visibleTileCount; // number of tiles to be drawn on screen
+
+        int32_t _prevIndexPos;
         int scrollDirection;
-        int scrollStepX;
-        int scrollStepY;
-        int tailX;
-        int tailY;
         bool updateCursor;
-        int borderSizeX;
-        int borderSizeY;
 
         std::vector<uint8_t> _customPalette;
         MapObjectSprite _spriteCache;
 
-        enum
-        {
-            MIN_BORDER_SIZE = 8
-        };
-
         SDL::Time scrollTime;
+
+        Point _middlePoint() const;
+        Point _getStartTileId() const;
+        void _setCenterToTile( const Point & tile ); // set center to the middle of tile (input is tile ID)
+        void _setCenter( const Point & point ); // in pixels
+        Point _getRelativePosition( const Point & point ) const; // return relative to screen position
     };
 }
 

--- a/src/fheroes2/gui/interface_radar.cpp
+++ b/src/fheroes2/gui/interface_radar.cpp
@@ -375,7 +375,7 @@ void Interface::Radar::QueueEventProcessing( void )
             const Point & pt = le.GetMouseCursor();
 
             if ( rect & pt ) {
-                gamearea.SetCenter( ( pt.x - rect.x ) * world.w() / rect.w, ( pt.y - rect.y ) * world.h() / rect.h );
+                gamearea.SetCenter( Point( ( pt.x - rect.x ) * world.w() / rect.w, ( pt.y - rect.y ) * world.h() / rect.h ) );
 
                 if ( prev != gamearea.GetVisibleTileROI() ) {
                     Cursor::Get().Hide();

--- a/src/fheroes2/gui/interface_radar.cpp
+++ b/src/fheroes2/gui/interface_radar.cpp
@@ -323,7 +323,7 @@ void Interface::Radar::RedrawCursor( void )
 
     if ( !conf.ExtGameHideInterface() || conf.ShowRadar() ) {
         const Rect & rect = GetArea();
-        const Rect & rectMaps = interface.GetGameArea().GetRectMaps();
+        const Rect & rectMaps = interface.GetGameArea().GetVisibleTileROI();
 
         s32 areaw = ( offset.x ? rect.w - 2 * offset.x : rect.w );
         s32 areah = ( offset.y ? rect.h - 2 * offset.y : rect.h );
@@ -371,13 +371,13 @@ void Interface::Radar::QueueEventProcessing( void )
         // move cursor
         if ( le.MouseCursor( rect ) ) {
         if ( le.MouseClickLeft() || le.MousePressLeft() ) {
-            const Point prev( gamearea.GetRectMaps() );
+            const Point prev( gamearea.GetVisibleTileROI() );
             const Point & pt = le.GetMouseCursor();
 
             if ( rect & pt ) {
                 gamearea.SetCenter( ( pt.x - rect.x ) * world.w() / rect.w, ( pt.y - rect.y ) * world.h() / rect.h );
 
-                if ( prev != gamearea.GetRectMaps() ) {
+                if ( prev != gamearea.GetVisibleTileROI() ) {
                     Cursor::Get().Hide();
                     RedrawCursor();
                     gamearea.SetRedraw();

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -272,7 +272,6 @@ public:
     bool ApplyPenaltyMovement( void );
     bool ActionSpellCast( const Spell & );
 
-    void Redraw( Surface &, bool ) const;
     void Redraw( Surface &, s32, s32, bool ) const;
     void PortraitRedraw( s32, s32, int type, Surface & ) const;
     int GetSpriteIndex( void ) const;

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -374,21 +374,11 @@ bool isNeedStayFrontObject( const Heroes & hero, const Maps::Tiles & next )
     return MP2::isNeedStayFront( next.GetObject() );
 }
 
-void Heroes::Redraw( Surface & dst, bool with_shadow ) const
-{
-    const Point & mp = GetCenter();
-    const Interface::GameArea & gamearea = Interface::Basic::Get().GetGameArea();
-    s32 dx = gamearea.GetMapsPos().x + TILEWIDTH * ( mp.x - gamearea.GetRectMaps().x );
-    s32 dy = gamearea.GetMapsPos().y + TILEWIDTH * ( mp.y - gamearea.GetRectMaps().y );
-
-    Redraw( dst, dx, dy, with_shadow );
-}
-
 void Heroes::Redraw( Surface & dst, s32 dx, s32 dy, bool with_shadow ) const
 {
     const Point & mp = GetCenter();
     const Interface::GameArea & gamearea = Interface::Basic::Get().GetGameArea();
-    if ( !( gamearea.GetRectMaps() & mp ) )
+    if ( !( gamearea.GetVisibleTileROI() & mp ) )
         return;
 
     bool reflect = ReflectSprite( direction );
@@ -743,7 +733,7 @@ void Heroes::FadeOut( void ) const
     const Point & mp = GetCenter();
     const Interface::GameArea & gamearea = Interface::Basic::Get().GetGameArea();
 
-    if ( !( gamearea.GetRectMaps() & mp ) )
+    if ( !( gamearea.GetVisibleTileROI() & mp ) )
         return;
 
     Display & display = Display::Get();
@@ -770,7 +760,7 @@ void Heroes::FadeIn( void ) const
     const Point & mp = GetCenter();
     const Interface::GameArea & gamearea = Interface::Basic::Get().GetGameArea();
 
-    if ( !( gamearea.GetRectMaps() & mp ) )
+    if ( !( gamearea.GetVisibleTileROI() & mp ) )
         return;
 
     Display & display = Display::Get();

--- a/src/fheroes2/kingdom/puzzle.cpp
+++ b/src/fheroes2/kingdom/puzzle.cpp
@@ -180,7 +180,7 @@ void ShowExtendedDialog( const Puzzle & pzl, const Surface & sf )
     Display & display = Display::Get();
     Cursor & cursor = Cursor::Get();
     const Settings & conf = Settings::Get();
-    const Rect & gameArea = Interface::Basic::Get().GetGameArea().GetArea();
+    const Rect & gameArea = Interface::Basic::Get().GetGameArea().GetROI();
 
     Dialog::FrameBorder frameborder( gameArea.x + ( gameArea.w - sf.w() - BORDERWIDTH * 2 ) / 2, gameArea.y + ( gameArea.h - sf.h() - BORDERWIDTH * 2 ) / 2, sf.w(),
                                      sf.h() );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1480,7 +1480,7 @@ void Maps::Tiles::RedrawTile( Surface & dst ) const
     const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
     const Point mp = Maps::GetPoint( GetIndex() );
 
-    if ( area.GetRectMaps() & mp )
+    if ( area.GetVisibleTileROI() & mp )
         area.BlitOnTile( dst, GetTileSurface(), 0, 0, mp );
 }
 
@@ -1488,7 +1488,7 @@ void Maps::Tiles::RedrawEmptyTile( Surface & dst, const Point & mp )
 {
     const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
 
-    if ( area.GetRectMaps() & mp ) {
+    if ( area.GetVisibleTileROI() & mp ) {
         if ( mp.y == -1 && mp.x >= 0 && mp.x < world.w() ) { // top first row
             area.BlitOnTile( dst, AGG::GetTIL( TIL::STON, 20 + ( mp.x % 4 ), 0 ), 0, 0, mp );
         }
@@ -1512,7 +1512,7 @@ void Maps::Tiles::RedrawAddon( Surface & dst, const Addons & addon, bool skipObj
     Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
     const Point mp = Maps::GetPoint( GetIndex() );
 
-    if ( ( area.GetRectMaps() & mp ) && !addon.empty() ) {
+    if ( ( area.GetVisibleTileROI() & mp ) && !addon.empty() ) {
         for ( Addons::const_iterator it = addon.begin(); it != addon.end(); ++it ) {
             // skip
             if ( skipObjs && MP2::isRemoveObject( GetObject() ) && FindObjectConst( GetObject() ) == &( *it ) )
@@ -1563,7 +1563,7 @@ void Maps::Tiles::RedrawPassable( Surface & dst ) const
     const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
     const Point mp = Maps::GetPoint( GetIndex() );
 
-    if ( area.GetRectMaps() & mp ) {
+    if ( area.GetVisibleTileROI() & mp ) {
         if ( 0 == tile_passable || DIRECTION_ALL != tile_passable ) {
             Surface sf = PassableViewSurface( tile_passable );
 
@@ -1602,7 +1602,7 @@ void Maps::Tiles::RedrawMonster( Surface & dst ) const
     const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
     s32 dst_index = -1;
 
-    if ( !( area.GetRectMaps() & mp ) )
+    if ( !( area.GetVisibleTileROI() & mp ) )
         return;
 
     // scan hero around
@@ -1658,7 +1658,7 @@ void Maps::Tiles::RedrawBoat( Surface & dst ) const
     const Point mp = Maps::GetPoint( GetIndex() );
     const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
 
-    if ( area.GetRectMaps() & mp ) {
+    if ( area.GetVisibleTileROI() & mp ) {
         // FIXME: restore direction from Maps::Tiles
         const Sprite & sprite = AGG::GetICN( ICN::BOAT32, 18 );
         area.BlitOnTile( dst, sprite, sprite.x(), TILEWIDTH + sprite.y(), mp );
@@ -1708,7 +1708,7 @@ void Maps::Tiles::RedrawBottom4Hero( Surface & dst ) const
     const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
     const Point mp = Maps::GetPoint( GetIndex() );
 
-    if ( ( area.GetRectMaps() & mp ) && !addons_level1.empty() ) {
+    if ( ( area.GetVisibleTileROI() & mp ) && !addons_level1.empty() ) {
         for ( Addons::const_iterator it = addons_level1.begin(); it != addons_level1.end(); ++it ) {
             if ( !SkipRedrawTileBottom4Hero( *it, tile_passable ) ) {
                 const u8 & object = ( *it ).object;
@@ -1733,7 +1733,7 @@ void Maps::Tiles::RedrawTop( Surface & dst, bool skipObjs ) const
     const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
     const Point mp = Maps::GetPoint( GetIndex() );
 
-    if ( !( area.GetRectMaps() & mp ) )
+    if ( !( area.GetVisibleTileROI() & mp ) )
         return;
 
     // animate objects
@@ -1760,7 +1760,7 @@ void Maps::Tiles::RedrawTop4Hero( Surface & dst, bool skip_ground ) const
     const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
     const Point mp = Maps::GetPoint( GetIndex() );
 
-    if ( ( area.GetRectMaps() & mp ) && !addons_level2.empty() ) {
+    if ( ( area.GetVisibleTileROI() & mp ) && !addons_level2.empty() ) {
         for ( Addons::const_iterator it = addons_level2.begin(); it != addons_level2.end(); ++it ) {
             if ( skip_ground && MP2::isGroundObject( ( *it ).object ) )
                 continue;


### PR DESCRIPTION
- fixed World Map display on huge resolutions. We do not allow to scroll
if there is nothing to scroll
- fixed Dimension Door area for 4K (relates to #893 )
- fixed hero centering (relates to #727 )
- fixed screen jumping for hero's movement (relates to #797)
- fixed pop-up dialog area for no-interface case
- fixed Ultimate Artifact generation on huge resolutions
- fixed missing drawing during scrolling for World Map (relates to #779)