### PR TITLE
Monsters strategic map animation

### DIFF
--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -1986,23 +1986,23 @@ void AGG::RegisterScalableICN( int icnId )
     scalableICNIds.insert( icnId );
 }
 
-bool AGG::ReplaceColors( Surface & surface, const std::vector<uint8_t> & colorMap, int icnId, int icnIndex, bool reflect )
+bool AGG::ReplaceColors( Surface & surface, const std::vector<uint8_t> & colorIndexes, int icnId, int icnIndex, bool reflect )
 {
-    if ( colorMap.size() != PALETTE_SIZE )
+    if ( colorIndexes.size() != PALETTE_SIZE )
         return false;
 
     const std::vector<uint32_t> & rgbColors = PAL::GetRGBColors();
 
-    std::vector<uint32_t> colors( colorMap.size() );
-    for ( size_t i = 0; i < colorMap.size(); ++i )
-        colors[i] = rgbColors[colorMap[i]];
+    std::vector<uint32_t> colors( colorIndexes.size() );
+    for ( size_t i = 0; i < colorIndexes.size(); ++i )
+        colors[i] = rgbColors[colorIndexes[i]];
 
     return ReplaceColors( surface, colors, icnId, icnIndex, reflect );
 }
 
-bool AGG::ReplaceColors( Surface & surface, const std::vector<uint32_t> & colorMap, int icnId, int icnIndex, bool reflect )
+bool AGG::ReplaceColors( Surface & surface, const std::vector<uint32_t> & rgbColors, int icnId, int icnIndex, bool reflect )
 {
-    if ( !surface.isValid() || surface.depth() != 32 || colorMap.size() != PALETTE_SIZE || icnId < 0 || icnIndex < 0 )
+    if ( !surface.isValid() || surface.depth() != 32 || rgbColors.size() != PALETTE_SIZE || icnId < 0 || icnIndex < 0 )
         return false;
 
     std::map<std::pair<int, int>, ICNData>::const_iterator iter = _icnIdVsData.find( std::make_pair( icnId, icnIndex ) );
@@ -2013,7 +2013,7 @@ bool AGG::ReplaceColors( Surface & surface, const std::vector<uint32_t> & colorM
     if ( surface.w() != data.width() || surface.h() != data.height() )
         return false;
 
-    return surface.SetColors( data.get(), colorMap, reflect );
+    return surface.SetColors( data.get(), rgbColors, reflect );
 }
 
 bool AGG::DrawContour( Surface & surface, uint32_t value, int icnId, int incIndex, bool reflect )

--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -279,21 +279,6 @@ namespace AGG
     };
 
     std::map<std::pair<int, int>, ICNData> _icnIdVsData;
-
-    const std::vector<uint32_t> GetRGBColors()
-    {
-        static std::vector<uint32_t> colors;
-        if ( !colors.empty() )
-            return colors;
-
-        colors.resize( PALETTE_SIZE );
-        for ( size_t i = 0u; i < PALETTE_SIZE; ++i ) {
-            const RGBA & rgba = PAL::GetPaletteColor( static_cast<uint8_t>( i ) );
-            colors[i] = rgba.r() + ( rgba.g() << 8 ) + ( rgba.b() << 16 );
-        }
-
-        return colors;
-    }
 }
 
 Sprite ICNSprite::CreateSprite( bool reflect, bool shadow ) const
@@ -2001,12 +1986,26 @@ void AGG::RegisterScalableICN( int icnId )
     scalableICNIds.insert( icnId );
 }
 
-bool AGG::ReplaceColors( Surface & surface, const std::vector<uint8_t> & colorMap, int icnId, int incIndex, bool reflect )
+bool AGG::ReplaceColors( Surface & surface, const std::vector<uint8_t> & colorMap, int icnId, int icnIndex, bool reflect )
 {
-    if ( !surface.isValid() || surface.depth() != 32 || colorMap.size() != PALETTE_SIZE || icnId < 0 || incIndex < 0 )
+    if ( colorMap.size() != PALETTE_SIZE )
         return false;
 
-    std::map<std::pair<int, int>, ICNData>::const_iterator iter = _icnIdVsData.find( std::make_pair( icnId, incIndex ) );
+    const std::vector<uint32_t> & rgbColors = PAL::GetRGBColors();
+
+    std::vector<uint32_t> colors( colorMap.size() );
+    for ( size_t i = 0; i < colorMap.size(); ++i )
+        colors[i] = rgbColors[colorMap[i]];
+
+    return ReplaceColors( surface, colors, icnId, icnIndex, reflect );
+}
+
+bool AGG::ReplaceColors( Surface & surface, const std::vector<uint32_t> & colorMap, int icnId, int icnIndex, bool reflect )
+{
+    if ( !surface.isValid() || surface.depth() != 32 || colorMap.size() != PALETTE_SIZE || icnId < 0 || icnIndex < 0 )
+        return false;
+
+    std::map<std::pair<int, int>, ICNData>::const_iterator iter = _icnIdVsData.find( std::make_pair( icnId, icnIndex ) );
     if ( iter == _icnIdVsData.end() )
         return false;
 
@@ -2014,13 +2013,7 @@ bool AGG::ReplaceColors( Surface & surface, const std::vector<uint8_t> & colorMa
     if ( surface.w() != data.width() || surface.h() != data.height() )
         return false;
 
-    const std::vector<uint32_t> & rgbColors = GetRGBColors();
-
-    std::vector<uint32_t> colors( colorMap.size(), 0 );
-    for ( size_t i = 0; i < colorMap.size(); ++i )
-        colors[i] = rgbColors[colorMap[i]];
-
-    return surface.SetColors( data.get(), colors, reflect );
+    return surface.SetColors( data.get(), colorMap, reflect );
 }
 
 bool AGG::DrawContour( Surface & surface, uint32_t value, int icnId, int incIndex, bool reflect )

--- a/src/fheroes2/agg/agg.h
+++ b/src/fheroes2/agg/agg.h
@@ -81,9 +81,9 @@ namespace AGG
     void RegisterScalableICN( int icnId );
 
     // Replace colors based on indexes provided. Returns true only when the operation was successful.
-    bool ReplaceColors( Surface & surface, const std::vector<uint8_t> & colorMap, int icnId, int incIndex, bool reflect );
-    // Replace colors with the ones provided. Map has to match the palette. Returns true only when the operation was successful.
-    bool ReplaceColors( Surface & surface, const std::vector<uint32_t> & colorReplacement, int icnId, int incIndex, bool reflect );
+    bool ReplaceColors( Surface & surface, const std::vector<uint8_t> & colorIndexes, int icnId, int incIndex, bool reflect );
+    // Replace colors with the ones provided. RGB map has to match the palette. Returns true only if successful.
+    bool ReplaceColors( Surface & surface, const std::vector<uint32_t> & rgbColors, int icnId, int incIndex, bool reflect );
 
     // Returns true in an event of success. Only for 32-bit images
     bool DrawContour( Surface & surface, uint32_t value, int icnId, int incIndex, bool reflect );

--- a/src/fheroes2/agg/agg.h
+++ b/src/fheroes2/agg/agg.h
@@ -80,8 +80,10 @@ namespace AGG
     // Some ICNs need to be rescaled. You have to register their IDs before calling GetICN() function
     void RegisterScalableICN( int icnId );
 
-    // Returns true only when the operation was successful
+    // Replace colors based on indexes provided. Returns true only when the operation was successful.
     bool ReplaceColors( Surface & surface, const std::vector<uint8_t> & colorMap, int icnId, int incIndex, bool reflect );
+    // Replace colors with the ones provided. Map has to match the palette. Returns true only when the operation was successful.
+    bool ReplaceColors( Surface & surface, const std::vector<uint32_t> & colorReplacement, int icnId, int incIndex, bool reflect );
 
     // Returns true in an event of success. Only for 32-bit images
     bool DrawContour( Surface & surface, uint32_t value, int icnId, int incIndex, bool reflect );

--- a/src/fheroes2/agg/pal.cpp
+++ b/src/fheroes2/agg/pal.cpp
@@ -163,6 +163,21 @@ namespace PAL
 
         return cycleSet;
     }
+
+    const std::vector<uint32_t> GetRGBColors()
+    {
+        static std::vector<uint32_t> colors;
+        if ( !colors.empty() )
+            return colors;
+
+        colors.resize( PALETTE_SIZE );
+        for ( size_t i = 0u; i < PALETTE_SIZE; ++i ) {
+            const SDL_Color & rgba = standard_palette[i];
+            colors[i] = rgba.r + ( rgba.g << 8 ) + ( rgba.b << 16 );
+        }
+
+        return colors;
+    }
 }
 
 std::vector<uint8_t> PAL::GetCyclingPalette( int stepId )

--- a/src/fheroes2/agg/pal.cpp
+++ b/src/fheroes2/agg/pal.cpp
@@ -164,7 +164,7 @@ namespace PAL
         return cycleSet;
     }
 
-    const std::vector<uint32_t> GetRGBColors()
+    const std::vector<uint32_t> & GetRGBColors()
     {
         static std::vector<uint32_t> colors;
         if ( !colors.empty() )

--- a/src/fheroes2/agg/pal.h
+++ b/src/fheroes2/agg/pal.h
@@ -58,7 +58,7 @@ namespace PAL
     void SwapPalette( int type );
     RGBA GetPaletteColor( u8 index );
     const std::vector<uint8_t> & GetPalette( int type );
-    const std::vector<uint32_t> GetRGBColors();
+    const std::vector<uint32_t> & GetRGBColors();
     std::vector<uint8_t> CombinePalettes( const std::vector<uint8_t> & first, const std::vector<uint8_t> & second );
     void SetCustomSDLPalette( const std::vector<uint8_t> & indexes );
 }

--- a/src/fheroes2/agg/pal.h
+++ b/src/fheroes2/agg/pal.h
@@ -58,6 +58,7 @@ namespace PAL
     void SwapPalette( int type );
     RGBA GetPaletteColor( u8 index );
     const std::vector<uint8_t> & GetPalette( int type );
+    const std::vector<uint32_t> GetRGBColors();
     std::vector<uint8_t> CombinePalettes( const std::vector<uint8_t> & first, const std::vector<uint8_t> & second );
     void SetCustomSDLPalette( const std::vector<uint8_t> & indexes );
 }

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -262,6 +262,15 @@ bool Troops::HasMonster( const Monster & mons ) const
     return end() != std::find_if( begin(), end(), std::bind2nd( std::mem_fun( &Troop::isMonster ), mons() ) );
 }
 
+bool Troops::hasColorCycling() const
+{
+    for ( const_iterator it = begin(); it != end(); ++it ) {
+        if ( ( *it )->hasColorCycling() )
+            return true;
+    }
+    return false;
+}
+
 bool Troops::AllTroopsIsRace( int race ) const
 {
     for ( const_iterator it = begin(); it != end(); ++it )

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -660,7 +660,11 @@ void Troops::DrawMons32LineWithScoute( s32 cx, s32 cy, u32 width, u32 first, u32
         for ( const_iterator it = begin(); it != end(); ++it )
             if ( ( *it )->isValid() ) {
                 if ( 0 == first && count ) {
-                    const Sprite & monster = AGG::GetICN( ICN::MONS32, ( *it )->GetSpriteIndex() );
+                    const uint32_t spriteIndex = ( *it )->GetSpriteIndex();
+                    Sprite monster = AGG::GetICN( ICN::MONS32, spriteIndex );
+                    if ( ( *it )->hasColorCycling() ) {
+                        AGG::ReplaceColors( monster, PAL::GetCyclingPalette( Game::MapsAnimationFrame() ), ICN::MONS32, spriteIndex, false );
+                    }
                     const int offsetY = !compact ? 30 - monster.h() : ( monster.h() < 35 ) ? 35 - monster.h() : 0;
 
                     monster.Blit( cx - monster.w() / 2, cy + offsetY );

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -268,8 +268,9 @@ u32 Troops::GetCount( void ) const
 
 bool Troops::HasMonster( const Monster & mons ) const
 {
+    const int monsterID = mons();
     for ( const_iterator it = begin(); it != end(); ++it ) {
-        if ( ( *it )->isMonster( mons() ) )
+        if ( ( *it )->isMonster( monsterID ) )
             return true;
     }
     return false;

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -250,7 +250,7 @@ u32 Troops::GetCountMonsters( const Monster & m ) const
 bool Troops::isValid( void ) const
 {
     for ( const_iterator it = begin(); it != end(); ++it ) {
-        if ( ( *it )->isValid( ) )
+        if ( ( *it )->isValid() )
             return true;
     }
     return false;
@@ -269,7 +269,7 @@ u32 Troops::GetCount( void ) const
 bool Troops::HasMonster( const Monster & mons ) const
 {
     for ( const_iterator it = begin(); it != end(); ++it ) {
-        if ( ( *it )->isMonster(mons()) )
+        if ( ( *it )->isMonster( mons() ) )
             return true;
     }
     return false;

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -249,17 +249,30 @@ u32 Troops::GetCountMonsters( const Monster & m ) const
 
 bool Troops::isValid( void ) const
 {
-    return end() != std::find_if( begin(), end(), std::mem_fun( &Troop::isValid ) );
+    for ( const_iterator it = begin(); it != end(); ++it ) {
+        if ( ( *it )->isValid( ) )
+            return true;
+    }
+    return false;
 }
 
 u32 Troops::GetCount( void ) const
 {
-    return std::count_if( begin(), end(), std::mem_fun( &Troop::isValid ) );
+    uint32_t total = 0;
+    for ( const_iterator it = begin(); it != end(); ++it ) {
+        if ( ( *it )->isValid() )
+            ++total;
+    }
+    return total;
 }
 
 bool Troops::HasMonster( const Monster & mons ) const
 {
-    return end() != std::find_if( begin(), end(), std::bind2nd( std::mem_fun( &Troop::isMonster ), mons() ) );
+    for ( const_iterator it = begin(); it != end(); ++it ) {
+        if ( ( *it )->isMonster(mons()) )
+            return true;
+    }
+    return false;
 }
 
 bool Troops::hasColorCycling() const

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -65,6 +65,7 @@ public:
     u32 GetCount( void ) const;
     bool isValid( void ) const;
     bool HasMonster( const Monster & ) const;
+    bool hasColorCycling() const;
 
     bool AllTroopsIsRace( int ) const;
     u32 GetUniqueCount( void ) const;

--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -50,6 +50,7 @@ enum redraw_t
 
 class Castle;
 class Heroes;
+class Army;
 
 namespace Maps
 {
@@ -71,6 +72,7 @@ namespace Interface
 {
     Castle * GetFocusCastle( void );
     Heroes * GetFocusHeroes( void );
+    Army * GetFocusArmy();
     int GetFocusType( void );
     Point GetFocusCenter( void );
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -974,7 +974,7 @@ int Interface::Basic::HumanTurn( bool isload )
             ++frame;
             gameArea.UpdateCyclingPalette( frame );
             gameArea.SetRedraw();
-            
+
             Army * focusArmy = GetFocusArmy();
             if ( focusArmy && focusArmy->hasColorCycling() ) {
                 statusWindow.SetRedraw();

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -974,6 +974,11 @@ int Interface::Basic::HumanTurn( bool isload )
             ++frame;
             gameArea.UpdateCyclingPalette( frame );
             gameArea.SetRedraw();
+            
+            Army * focusArmy = GetFocusArmy();
+            if ( focusArmy && focusArmy->hasColorCycling() ) {
+                statusWindow.SetRedraw();
+            }
         }
 
         if ( Game::AnimateInfrequentDelay( Game::HEROES_PICKUP_DELAY ) ) {

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -174,17 +174,19 @@ Heroes * Interface::GetFocusHeroes( void )
 
 Army * Interface::GetFocusArmy()
 {
-    Army * armyPtr = NULL;
     Player * player = Settings::Get().GetPlayers().GetCurrent();
 
-    if ( player && player->GetFocus().GetHeroes() ) {
-        armyPtr = &player->GetFocus().GetHeroes()->GetArmy();
+    if ( player == NULL )
+        return NULL;
+
+    if ( player->GetFocus().GetHeroes() ) {
+        return &player->GetFocus().GetHeroes()->GetArmy();
     }
-    else if ( player && player->GetFocus().GetCastle() ) {
-        armyPtr = &player->GetFocus().GetCastle()->GetArmy();
+    else if ( player->GetFocus().GetCastle() ) {
+        return &player->GetFocus().GetCastle()->GetArmy();
     }
 
-    return armyPtr;
+    return NULL;
 }
 
 Point Interface::GetFocusCenter( void )

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -172,6 +172,21 @@ Heroes * Interface::GetFocusHeroes( void )
     return player ? player->GetFocus().GetHeroes() : NULL;
 }
 
+Army * Interface::GetFocusArmy()
+{
+    Army * armyPtr = NULL;
+    Player * player = Settings::Get().GetPlayers().GetCurrent();
+
+    if ( player && player->GetFocus().GetHeroes() ) {
+        armyPtr = &player->GetFocus().GetHeroes()->GetArmy();
+    }
+    else if ( player && player->GetFocus().GetCastle() ) {
+        armyPtr = &player->GetFocus().GetCastle()->GetArmy();
+    }
+
+    return armyPtr;
+}
+
 Point Interface::GetFocusCenter( void )
 {
     Player * player = Settings::Get().GetPlayers().GetCurrent();

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -145,24 +145,24 @@ void Interface::GameArea::SetAreaPosition( s32 x, s32 y, u32 w, u32 h )
 
 void Interface::GameArea::UpdateCyclingPalette( int frame )
 {
-    const std::vector<uint8_t> & palette = PAL::GetCyclingPalette( frame );
+    const std::vector<uint8_t> & colorIndexes = PAL::GetCyclingPalette( frame );
     const std::vector<uint32_t> & rgbColors = PAL::GetRGBColors();
 
-    if ( palette.size() == rgbColors.size() ) {
-        PAL::SetCustomSDLPalette( palette );
+    if ( colorIndexes.size() == rgbColors.size() ) {
+        PAL::SetCustomSDLPalette( colorIndexes );
 
-        _customPalette.resize( palette.size() );
-        for ( size_t i = 0; i < palette.size(); ++i )
-            _customPalette[i] = rgbColors[palette[i]];
+        _cyclingRGBPalette.resize( colorIndexes.size() );
+        for ( size_t i = 0; i < colorIndexes.size(); ++i )
+            _cyclingRGBPalette[i] = rgbColors[colorIndexes[i]];
 
         // reset cache as we'll need to re-color tiles
         _spriteCache.clear();
     }
 }
 
-const std::vector<uint32_t> & Interface::GameArea::GetCyclingPalette() const
+const std::vector<uint32_t> & Interface::GameArea::GetCyclingRGBPalette() const
 {
-    return _customPalette;
+    return _cyclingRGBPalette;
 }
 
 MapObjectSprite & Interface::GameArea::GetSpriteCache()

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -145,13 +145,22 @@ void Interface::GameArea::SetAreaPosition( s32 x, s32 y, u32 w, u32 h )
 
 void Interface::GameArea::UpdateCyclingPalette( int frame )
 {
-    _customPalette = PAL::GetCyclingPalette( frame );
-    PAL::SetCustomSDLPalette( _customPalette );
-    // reset cache as we'll need to re-color tiles
-    _spriteCache.clear();
+    const std::vector<uint8_t> & palette = PAL::GetCyclingPalette( frame );
+    const std::vector<uint32_t> & rgbColors = PAL::GetRGBColors();
+
+    if ( palette.size() == rgbColors.size() ) {
+        PAL::SetCustomSDLPalette( palette );
+
+        _customPalette.resize( palette.size() );
+        for ( size_t i = 0; i < palette.size(); ++i )
+            _customPalette[i] = rgbColors[palette[i]];
+
+        // reset cache as we'll need to re-color tiles
+        _spriteCache.clear();
+    }
 }
 
-const std::vector<uint8_t> & Interface::GameArea::GetCyclingPalette() const
+const std::vector<uint32_t> & Interface::GameArea::GetCyclingPalette() const
 {
     return _customPalette;
 }

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -80,7 +80,7 @@ namespace Interface
         void BlitOnTile( Surface &, const Sprite &, const Point & ) const;
 
         void UpdateCyclingPalette( int frame );
-        const std::vector<uint8_t> & GetCyclingPalette() const;
+        const std::vector<uint32_t> & GetCyclingPalette() const;
         MapObjectSprite & GetSpriteCache();
 
         void SetUpdateCursor( void );
@@ -110,7 +110,7 @@ namespace Interface
         int borderSizeX;
         int borderSizeY;
 
-        std::vector<uint8_t> _customPalette;
+        std::vector<uint32_t> _customPalette;
         MapObjectSprite _spriteCache;
 
         enum

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -47,7 +47,7 @@ enum level_t
     LEVEL_ALL = 0xFF
 };
 
-typedef std::map<std::pair<uint8_t, uint8_t>, Sprite> MapObjectSprite;
+typedef std::map<std::pair<int, uint8_t>, Sprite> MapObjectSprite;
 
 namespace Interface
 {

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -80,7 +80,7 @@ namespace Interface
         void BlitOnTile( Surface &, const Sprite &, const Point & ) const;
 
         void UpdateCyclingPalette( int frame );
-        const std::vector<uint32_t> & GetCyclingPalette() const;
+        const std::vector<uint32_t> & GetCyclingRGBPalette() const;
         MapObjectSprite & GetSpriteCache();
 
         void SetUpdateCursor( void );
@@ -110,7 +110,7 @@ namespace Interface
         int borderSizeX;
         int borderSizeY;
 
-        std::vector<uint32_t> _customPalette;
+        std::vector<uint32_t> _cyclingRGBPalette;
         MapObjectSprite _spriteCache;
 
         enum

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -47,7 +47,7 @@ enum level_t
     LEVEL_ALL = 0xFF
 };
 
-typedef std::map<std::pair<int, uint8_t>, Sprite> MapObjectSprite;
+typedef std::map<std::pair<int, uint32_t>, Sprite> MapObjectSprite;
 
 namespace Interface
 {

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -54,7 +54,7 @@
 
 namespace
 {
-    const u8 monster_animation_cicle[] = {0, 1, 2, 1, 0, 3, 4, 5, 4, 3};
+    const u8 monsterAnimationSequence[] = {0, 0, 1, 2, 1, 0, 0, 0, 3, 4, 5, 4, 3, 0, 0};
 
     bool contains( int base, int value )
     {
@@ -1649,7 +1649,7 @@ void Maps::Tiles::RedrawMonster( Surface & dst ) const
         spriteIndex += ( revert ? 8 : 7 );
     }
     else {
-        secondSprite = spriteIndex + 1 + monster_animation_cicle[( Game::MapsAnimationFrame() + mp.x * mp.y ) % ARRAY_COUNT( monster_animation_cicle )];
+        secondSprite = spriteIndex + 1 + monsterAnimationSequence[( Game::MapsAnimationFrame() + mp.x * mp.y ) % ARRAY_COUNT( monsterAnimationSequence )];
     }
 
     RedrawMapObject( dst, ICN::MINIMON, spriteIndex, mp, monster.hasColorCycling(), 16, TILEWIDTH );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1515,7 +1515,7 @@ void Maps::Tiles::RedrawMapObject( Surface & dst, int icn, uint32_t index, const
 
     if ( cycle ) {
         MapObjectSprite & spriteCache = area.GetSpriteCache();
-        const std::pair<int, uint8_t> spriteIndex( icn, index );
+        const std::pair<int, uint32_t> spriteIndex( icn, index );
         MapObjectSprite::iterator cachedSprite = spriteCache.find( spriteIndex );
         if ( cachedSprite != spriteCache.end() ) {
             sprite = cachedSprite->second;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1507,6 +1507,31 @@ void Maps::Tiles::RedrawEmptyTile( Surface & dst, const Point & mp )
     }
 }
 
+// Private drawing function that will cycle colors if told to do so
+void Maps::Tiles::RedrawMapObject( Surface & dst, int icn, uint32_t index, const Point & mapPoint, bool cycle, int offsetX, int offsetY ) const
+{
+    Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
+    Sprite sprite;
+
+    if ( cycle ) {
+        MapObjectSprite & spriteCache = area.GetSpriteCache();
+        const std::pair<int, uint8_t> spriteIndex( icn, index );
+        MapObjectSprite::iterator cachedSprite = spriteCache.find( spriteIndex );
+        if ( cachedSprite != spriteCache.end() ) {
+            sprite = cachedSprite->second;
+        }
+        else {
+            sprite = AGG::GetICN( icn, index );
+            AGG::ReplaceColors( sprite, area.GetCyclingRGBPalette(), icn, index, false );
+            spriteCache[spriteIndex] = sprite;
+        }
+    }
+    else {
+        sprite = AGG::GetICN( icn, index );
+    }
+    area.BlitOnTile( dst, sprite, sprite.x() + offsetX, sprite.y() + offsetY, mapPoint );
+}
+
 void Maps::Tiles::RedrawAddon( Surface & dst, const Addons & addon, bool skipObjs ) const
 {
     Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
@@ -1518,34 +1543,16 @@ void Maps::Tiles::RedrawAddon( Surface & dst, const Addons & addon, bool skipObj
             if ( skipObjs && MP2::isRemoveObject( GetObject() ) && FindObjectConst( GetObject() ) == &( *it ) )
                 continue;
 
-            const u8 & object = ( *it ).object;
             const u8 & index = ( *it ).index;
-            const int icn = MP2::GetICNObject( object );
+            const int icn = MP2::GetICNObject( ( *it ).object );
 
             if ( ICN::UNKNOWN != icn && ICN::MINIHERO != icn && ICN::MONS32 != icn ) {
-                Sprite sprite;
-                if ( TilesAddon::hasColorCycling( *it ) ) {
-                    MapObjectSprite & spriteCache = area.GetSpriteCache();
-                    const std::pair<uint8_t, uint8_t> tileIndex( object, index );
-                    MapObjectSprite::iterator cachedSprite = spriteCache.find( tileIndex );
-                    if ( cachedSprite != spriteCache.end() ) {
-                        sprite = cachedSprite->second;
-                    }
-                    else {
-                        sprite = AGG::GetICN( icn, index );
-                        AGG::ReplaceColors( sprite, area.GetCyclingRGBPalette(), icn, index, false );
-                        spriteCache[tileIndex] = sprite;
-                    }
-                }
-                else {
-                    sprite = AGG::GetICN( icn, index );
-                }
-                area.BlitOnTile( dst, sprite, mp );
+                RedrawMapObject( dst, icn, index, mp, TilesAddon::hasColorCycling( *it ) );
 
-                // possible anime
-                if ( u32 anime_index = ICN::AnimationFrame( icn, index, Game::MapsAnimationFrame(), quantity2 ) ) {
-                    const Sprite & anime_sprite = AGG::GetICN( icn, anime_index );
-                    area.BlitOnTile( dst, anime_sprite, mp );
+                // possible animation
+                if ( u32 anim_index = ICN::AnimationFrame( icn, index, Game::MapsAnimationFrame(), quantity2 ) ) {
+                    const Sprite & animationSprite = AGG::GetICN( icn, anim_index );
+                    area.BlitOnTile( dst, animationSprite, mp );
                 }
             }
         }
@@ -1621,7 +1628,9 @@ void Maps::Tiles::RedrawMonster( Surface & dst ) const
             break;
     }
 
-    const u32 sprite_index = QuantityMonster().GetSpriteIndex();
+    const Monster & monster = QuantityMonster();
+    uint32_t spriteIndex = monster.GetSpriteIndex() * 9;
+    uint32_t secondSprite = MAXU32;
 
     // draw attack sprite
     if ( -1 != dst_index && !conf.ExtWorldOnlyFirstMonsterAttack() ) {
@@ -1637,19 +1646,15 @@ void Maps::Tiles::RedrawMonster( Surface & dst ) const
             break;
         }
 
-        const Sprite & sprite_first = AGG::GetICN( ICN::MINIMON, sprite_index * 9 + ( revert ? 8 : 7 ) );
-        area.BlitOnTile( dst, sprite_first, sprite_first.x() + 16, TILEWIDTH + sprite_first.y(), mp );
+        spriteIndex += ( revert ? 8 : 7 );
     }
     else {
-        // draw first sprite
-        const Sprite & sprite_first = AGG::GetICN( ICN::MINIMON, sprite_index * 9 );
-        area.BlitOnTile( dst, sprite_first, sprite_first.x() + 16, TILEWIDTH + sprite_first.y(), mp );
+        secondSprite = spriteIndex + 1 + monster_animation_cicle[( Game::MapsAnimationFrame() + mp.x * mp.y ) % ARRAY_COUNT( monster_animation_cicle )];
+    }
 
-        // draw second sprite
-        const Sprite & sprite_next
-            = AGG::GetICN( ICN::MINIMON,
-                           sprite_index * 9 + 1 + monster_animation_cicle[( Game::MapsAnimationFrame() + mp.x * mp.y ) % ARRAY_COUNT( monster_animation_cicle )] );
-        area.BlitOnTile( dst, sprite_next, sprite_next.x() + 16, TILEWIDTH + sprite_next.y(), mp );
+    RedrawMapObject( dst, ICN::MINIMON, spriteIndex, mp, monster.hasColorCycling(), 16, TILEWIDTH );
+    if ( secondSprite != MAXU32 ) {
+        RedrawMapObject( dst, ICN::MINIMON, secondSprite, mp, monster.hasColorCycling(), 16, TILEWIDTH );
     }
 }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1533,7 +1533,7 @@ void Maps::Tiles::RedrawAddon( Surface & dst, const Addons & addon, bool skipObj
                     }
                     else {
                         sprite = AGG::GetICN( icn, index );
-                        AGG::ReplaceColors( sprite, area.GetCyclingPalette(), icn, index, false );
+                        AGG::ReplaceColors( sprite, area.GetCyclingRGBPalette(), icn, index, false );
                         spriteCache[tileIndex] = sprite;
                     }
                 }

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -270,6 +270,7 @@ namespace Maps
 
         void RedrawBoat( Surface & ) const;
         void RedrawMonster( Surface & ) const;
+        void RedrawMapObject( Surface & dst, int icn, uint32_t index, const Point & mapPoint, bool cycle = false, int offsetX = 0, int offsetY = 0 ) const;
 
         void QuantitySetVariant( int );
         void QuantitySetExt( int );


### PR DESCRIPTION
Another chapter of our color cycling adventure. Monsters on the map and army in status window now are being animated. Also added a faster `AGG::ReplaceColor` method that we should prefer to use.

In addition added a few standing frames to monster's animation cycle to avoid them fidgeting too much. Related to #744 . I don't want to double the animation delay because it looks smoother right now.