### PR TITLE
Reuse SDL2 texture for display flip

### DIFF
--- a/src/engine/display.cpp
+++ b/src/engine/display.cpp
@@ -187,7 +187,6 @@ void Display::Flip( void )
                 SDL_RenderPresent( renderer );
             }
         }
-
     }
     else {
         ERROR( SDL_GetError() );

--- a/src/engine/display.cpp
+++ b/src/engine/display.cpp
@@ -38,6 +38,7 @@ namespace
 Display::Display()
     : window( NULL )
     , renderer( NULL )
+    , displayTexture( NULL )
     , keepAspectRatio( false )
 {
     _isDisplay = true;
@@ -52,6 +53,11 @@ Display::Display()
 Display::~Display()
 {
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
+    if ( displayTexture ) {
+        SDL_DestroyTexture( displayTexture );
+        displayTexture = NULL;
+    }
+
     if ( renderer ) {
         SDL_DestroyRenderer( renderer );
         renderer = NULL;

--- a/src/engine/display.h
+++ b/src/engine/display.h
@@ -86,6 +86,7 @@ protected:
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
     SDL_Window * window;
     SDL_Renderer * renderer;
+    SDL_Texture * displayTexture;
 #endif
 };
 


### PR DESCRIPTION
Recently Display.Flip() became our biggest bottleneck, slowing down the rest of the game. This is very noticeable when setting hero and AI speed to 9 or 10: you would not see a real speed up because of the amount of flipping. `SDL_CreateTextureFromSurface` is a very expensive call that we should avoid.

Idea here is simple: instead of building a new texture every time we'll overwrite existing one. I finally see comparable hero speed to pre cycling/smooth animation change.

Example of the difference between two calls:
![sdl2_texture](https://user-images.githubusercontent.com/1373638/86540992-1652e980-bed7-11ea-91b6-90999ad1596d.PNG)
