### PR TITLE
Fit the screen to closest resolution in SDL 2

### DIFF
--- a/src/engine/display.cpp
+++ b/src/engine/display.cpp
@@ -96,15 +96,15 @@ void Display::SetVideoMode( int w, int h, bool fullscreen, bool aspect, bool cha
     if ( !keepAspectRatio ) {
         SDL_DisplayMode currentVideoMode;
         SDL_GetCurrentDisplayMode( 0, &currentVideoMode );
-    
+
         currentVideoMode.w = w;
         currentVideoMode.h = h;
-    
+
         SDL_DisplayMode closestVideoMode;
-        SDL_GetClosestDisplayMode( 0, &currentVideoMode, &closestVideoMode );
-    
-        w = closestVideoMode.w;
-        h = closestVideoMode.h;
+        if ( SDL_GetClosestDisplayMode( 0, &currentVideoMode, &closestVideoMode ) != NULL ) {
+            w = closestVideoMode.w;
+            h = closestVideoMode.h;
+        }
     }
 
     if ( displayTexture )

--- a/src/engine/display.cpp
+++ b/src/engine/display.cpp
@@ -93,7 +93,7 @@ void Display::SetVideoMode( int w, int h, bool fullscreen, bool aspect, bool cha
         keepAspectRatio = false;
     }
 
-    if ( !keepAspectRatio ) {
+    if ( !keepAspectRatio ) { // we don't allow random resolutions
         SDL_DisplayMode currentVideoMode;
         SDL_GetCurrentDisplayMode( 0, &currentVideoMode );
 

--- a/src/engine/display.cpp
+++ b/src/engine/display.cpp
@@ -81,12 +81,30 @@ void Display::SetVideoMode( int w, int h, bool fullscreen, bool aspect, bool cha
             flags |= SDL_WINDOW_FULLSCREEN;
         }
         else {
+#if defined( __WIN32__ )
+            flags |= SDL_WINDOW_FULLSCREEN;
+#else
             flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+#endif
         }
         keepAspectRatio = aspect;
     }
     else {
         keepAspectRatio = false;
+    }
+
+    if ( !keepAspectRatio ) {
+        SDL_DisplayMode currentVideoMode;
+        SDL_GetCurrentDisplayMode( 0, &currentVideoMode );
+    
+        currentVideoMode.w = w;
+        currentVideoMode.h = h;
+    
+        SDL_DisplayMode closestVideoMode;
+        SDL_GetClosestDisplayMode( 0, &currentVideoMode, &closestVideoMode );
+    
+        w = closestVideoMode.w;
+        h = closestVideoMode.h;
     }
 
     if ( displayTexture )


### PR DESCRIPTION
don't allow random resolutions
relates to #919 and #921 
also relates to #887 