### PR TITLE
Pathfinding fixes: roads, move cost and display

### DIFF
--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -263,8 +263,8 @@ void Interface::GameArea::Redraw( Surface & dst, int flag ) const
                  !( currentStep == path.begin() && skipfirst ) ) {
                 uint32_t index = 0;
                 if ( pathEnd != nextStep ) {
-                    uint32_t penaltyTo = Maps::Ground::GetPenalty( currentStep->GetFrom(), currentStep->GetDirection(), pathfinding, false );
-                    uint32_t penaltyReverse = Maps::Ground::GetPenalty( currentStep->GetIndex(), Direction::Reflect( currentStep->GetDirection() ), pathfinding, false );
+                    const uint32_t penaltyTo = Maps::Ground::GetPenalty( currentStep->GetFrom(), currentStep->GetDirection(), pathfinding, false );
+                    const uint32_t penaltyReverse = Maps::Ground::GetPenalty( currentStep->GetIndex(), Direction::Reflect( currentStep->GetDirection() ), pathfinding, false );
 
                     index = Route::Path::GetIndexSprite( ( *currentStep ).GetDirection(), ( *nextStep ).GetDirection(), std::min( penaltyTo, penaltyReverse ) );
                 }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -258,9 +258,7 @@ void Interface::GameArea::Redraw( Surface & dst, int flag ) const
             --green;
 
             // is visible
-            if ( ( tileROI & mp ) &&
-                 // check skip first?
-                 !( currentStep == path.begin() && skipfirst ) ) {
+            if ( ( tileROI & mp ) && !( currentStep == path.begin() && skipfirst ) ) {
                 uint32_t index = 0;
                 if ( pathEnd != nextStep ) {
                     const uint32_t penaltyTo = Maps::Ground::GetPenalty( currentStep->GetFrom(), currentStep->GetDirection(), pathfinding, false );

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -264,7 +264,8 @@ void Interface::GameArea::Redraw( Surface & dst, int flag ) const
                 uint32_t index = 0;
                 if ( pathEnd != nextStep ) {
                     const uint32_t penaltyTo = Maps::Ground::GetPenalty( currentStep->GetFrom(), currentStep->GetDirection(), pathfinding, false );
-                    const uint32_t penaltyReverse = Maps::Ground::GetPenalty( currentStep->GetIndex(), Direction::Reflect( currentStep->GetDirection() ), pathfinding, false );
+                    const uint32_t penaltyReverse
+                        = Maps::Ground::GetPenalty( currentStep->GetIndex(), Direction::Reflect( currentStep->GetDirection() ), pathfinding, false );
 
                     index = Route::Path::GetIndexSprite( ( *currentStep ).GetDirection(), ( *nextStep ).GetDirection(), std::min( penaltyTo, penaltyReverse ) );
                 }

--- a/src/fheroes2/heroes/route_pathfind.cpp
+++ b/src/fheroes2/heroes/route_pathfind.cpp
@@ -207,7 +207,7 @@ u32 GetPenaltyFromTo( s32 from, s32 to, int direct, int pathfinding )
 {
     const u32 cost1 = Maps::Ground::GetPenalty( from, direct, pathfinding ); // penalty: for [cur] out
     const u32 cost2 = Maps::Ground::GetPenalty( to, Direction::Reflect( direct ), pathfinding ); // penalty: for [tmp] in
-    return ( cost1 + cost2 ) >> 1;
+    return std::min(cost1, cost2);
 }
 
 uint32_t Route::Path::Find( s32 to, int limit )

--- a/src/fheroes2/heroes/route_pathfind.cpp
+++ b/src/fheroes2/heroes/route_pathfind.cpp
@@ -207,7 +207,7 @@ u32 GetPenaltyFromTo( s32 from, s32 to, int direct, int pathfinding )
 {
     const u32 cost1 = Maps::Ground::GetPenalty( from, direct, pathfinding ); // penalty: for [cur] out
     const u32 cost2 = Maps::Ground::GetPenalty( to, Direction::Reflect( direct ), pathfinding ); // penalty: for [tmp] in
-    return std::min(cost1, cost2);
+    return std::min( cost1, cost2 );
 }
 
 uint32_t Route::Path::Find( s32 to, int limit )

--- a/src/fheroes2/maps/ground.cpp
+++ b/src/fheroes2/maps/ground.cpp
@@ -121,7 +121,7 @@ u32 Maps::Ground::GetPenalty( s32 index, int direct, u32 level, bool diagonalCos
         }
     }
 
-    if ( diagonalCost && direct & ( Direction::TOP_RIGHT | Direction::BOTTOM_RIGHT | Direction::BOTTOM_LEFT | Direction::TOP_LEFT ) )
+    if ( diagonalCost && ( direct & ( Direction::TOP_RIGHT | Direction::BOTTOM_RIGHT | Direction::BOTTOM_LEFT | Direction::TOP_LEFT ) ) )
         result *= 1.5;
 
     return result;

--- a/src/fheroes2/maps/ground.cpp
+++ b/src/fheroes2/maps/ground.cpp
@@ -56,7 +56,7 @@ const char * Maps::Ground::String( int ground )
     return str_ground[8];
 }
 
-u32 Maps::Ground::GetPenalty( s32 index, int direct, u32 level )
+u32 Maps::Ground::GetPenalty( s32 index, int direct, u32 level, bool diagonalCost )
 {
     const Maps::Tiles & tile = world.GetTiles( index );
 
@@ -121,7 +121,7 @@ u32 Maps::Ground::GetPenalty( s32 index, int direct, u32 level )
         }
     }
 
-    if ( direct & ( Direction::TOP_RIGHT | Direction::BOTTOM_RIGHT | Direction::BOTTOM_LEFT | Direction::TOP_LEFT ) )
+    if ( diagonalCost && direct & ( Direction::TOP_RIGHT | Direction::BOTTOM_RIGHT | Direction::BOTTOM_LEFT | Direction::TOP_LEFT ) )
         result *= 1.5;
 
     return result;

--- a/src/fheroes2/maps/ground.cpp
+++ b/src/fheroes2/maps/ground.cpp
@@ -72,56 +72,57 @@ u32 Maps::Ground::GetPenalty( s32 index, int direct, u32 level )
     //    Water   1.00   1.00   1.00   1.00
     //    Road    0.75   0.75   0.75   0.75
 
-    if ( tile.isRoad( direct ) )
-        return 75;
-
     u32 result = 100;
+    if ( tile.isRoad( direct ) ) {
+        result = 75;
+    }
+    else {
+        switch ( tile.GetGround() ) {
+        case DESERT:
+            switch ( level ) {
+            case Skill::Level::EXPERT:
+                break;
+            case Skill::Level::ADVANCED:
+                result += 50;
+                break;
+            case Skill::Level::BASIC:
+                result += 75;
+                break;
+            default:
+                result += 100;
+                break;
+            }
+            break;
 
-    switch ( tile.GetGround() ) {
-    case DESERT:
-        switch ( level ) {
-        case Skill::Level::EXPERT:
+        case SNOW:
+        case SWAMP:
+            switch ( level ) {
+            case Skill::Level::EXPERT:
+                break;
+            case Skill::Level::ADVANCED:
+                result += 25;
+                break;
+            case Skill::Level::BASIC:
+                result += 50;
+                break;
+            default:
+                result += 75;
+                break;
+            }
             break;
-        case Skill::Level::ADVANCED:
-            result += 50;
+
+        case WASTELAND:
+        case BEACH:
+            result += ( Skill::Level::NONE == level ? 25 : 0 );
             break;
-        case Skill::Level::BASIC:
-            result += 75;
-            break;
+
         default:
-            result += 100;
             break;
         }
-        break;
-
-    case SNOW:
-    case SWAMP:
-        switch ( level ) {
-        case Skill::Level::EXPERT:
-            break;
-        case Skill::Level::ADVANCED:
-            result += 25;
-            break;
-        case Skill::Level::BASIC:
-            result += 50;
-            break;
-        default:
-            result += 75;
-            break;
-        }
-        break;
-
-    case WASTELAND:
-    case BEACH:
-        result += ( Skill::Level::NONE == level ? 25 : 0 );
-        break;
-
-    default:
-        break;
     }
 
     if ( direct & ( Direction::TOP_RIGHT | Direction::BOTTOM_RIGHT | Direction::BOTTOM_LEFT | Direction::TOP_LEFT ) )
-        result += result * 55 / 100;
+        result *= 1.5;
 
     return result;
 }

--- a/src/fheroes2/maps/ground.h
+++ b/src/fheroes2/maps/ground.h
@@ -46,7 +46,7 @@ namespace Maps
         };
 
         const char * String( int );
-        u32 GetPenalty( s32, int direction, u32 pathfinding );
+        u32 GetPenalty( s32, int direction, u32 pathfinding, bool diagonalCost = true );
     }
 }
 

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -447,7 +447,8 @@ Maps::Indexes Maps::GetTilesUnderProtection( s32 center )
 u32 Maps::GetApproximateDistance( s32 index1, s32 index2 )
 {
     const Size sz( GetPoint( index1 ) - GetPoint( index2 ) );
-    return std::max( sz.w, sz.h );
+    // diagonal move costs 1.5 as much
+    return std::max( sz.w, sz.h ) + std::min( sz.w, sz.h ) / 2;
 }
 
 void Maps::MinimizeAreaForCastle( const Point & center )

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -403,7 +403,7 @@ bool Maps::TilesAddon::isRoad( int direct ) const
     switch ( MP2::GetICNObject( object ) ) {
     // from sprite road
     case ICN::ROAD:
-        if ( 0 == index || 4 == index || 5 == index || 13 == index || 26 == index )
+        if ( 0 == index || 26 == index || 31 == index )
             return direct & ( Direction::TOP | Direction::BOTTOM );
         else if ( 2 == index || 21 == index || 28 == index )
             return direct & ( Direction::LEFT | Direction::RIGHT );
@@ -413,14 +413,20 @@ bool Maps::TilesAddon::isRoad( int direct ) const
             return direct & ( Direction::TOP_RIGHT | Direction::BOTTOM_LEFT );
         else if ( 3 == index )
             return direct & ( Direction::TOP | Direction::BOTTOM | Direction::LEFT | Direction::RIGHT );
+        else if ( 4 == index )
+            return direct & ( Direction::TOP | Direction::BOTTOM | Direction::TOP_LEFT | Direction::TOP_RIGHT );
+        else if ( 5 == index  )
+            return direct & ( Direction::TOP | Direction::BOTTOM | Direction::TOP_RIGHT );
         else if ( 6 == index )
             return direct & ( Direction::TOP | Direction::BOTTOM | Direction::RIGHT );
         else if ( 7 == index )
             return direct & ( Direction::TOP | Direction::RIGHT );
         else if ( 9 == index )
-            return direct & ( Direction::BOTTOM | Direction::RIGHT );
+            return direct & ( Direction::BOTTOM | Direction::TOP_RIGHT );
         else if ( 12 == index )
-            return direct & ( Direction::BOTTOM | Direction::LEFT );
+            return direct & ( Direction::BOTTOM | Direction::TOP_LEFT );
+        else if ( 13 == index )
+            return direct & ( Direction::TOP | Direction::BOTTOM | Direction::TOP_LEFT );
         else if ( 14 == index )
             return direct & ( Direction::TOP | Direction::BOTTOM | Direction::LEFT );
         else if ( 16 == index )

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -415,7 +415,7 @@ bool Maps::TilesAddon::isRoad( int direct ) const
             return direct & ( Direction::TOP | Direction::BOTTOM | Direction::LEFT | Direction::RIGHT );
         else if ( 4 == index )
             return direct & ( Direction::TOP | Direction::BOTTOM | Direction::TOP_LEFT | Direction::TOP_RIGHT );
-        else if ( 5 == index  )
+        else if ( 5 == index )
             return direct & ( Direction::TOP | Direction::BOTTOM | Direction::TOP_RIGHT );
         else if ( 6 == index )
             return direct & ( Direction::TOP | Direction::BOTTOM | Direction::RIGHT );


### PR DESCRIPTION
Fixes #880 . Fixes #979 .

Fixed diagonal move cost and updated pathfinding heuristic accordingly. Updated road logic/directions so it would recognize them correctly. Updated the path display to show actual move cost, not the one based on terrain.

There's still bugs with impassibility rules over object corners that will be addressed separately. A lot of the logic there is arbitrary as usual.

![image](https://user-images.githubusercontent.com/1373638/87022255-3c60de00-c1a4-11ea-8ed9-5c4f4d017755.png)