### PR TITLE
Fix troop counter position

### DIFF
--- a/src/fheroes2/battle/battle_animation.cpp
+++ b/src/fheroes2/battle/battle_animation.cpp
@@ -480,6 +480,11 @@ Point AnimationReference::getBlindOffset() const
     return _monsterInfo.eyePosition;
 }
 
+int AnimationReference::getTroopCountOffset( bool isReflect ) const
+{
+    return isReflect ? _monsterInfo.troopCountOffsetRight : _monsterInfo.troopCountOffsetLeft;
+}
+
 Point AnimationReference::getProjectileOffset( size_t direction ) const
 {
     if ( _monsterInfo.projectileOffset.size() > direction ) {

--- a/src/fheroes2/battle/battle_animation.h
+++ b/src/fheroes2/battle/battle_animation.h
@@ -114,6 +114,7 @@ public:
     size_t getProjectileID( float angle ) const;
     Point getBlindOffset() const;
     Point getProjectileOffset( size_t direction ) const;
+    int getTroopCountOffset( bool isReflect ) const;
     uint32_t getIdleDelay() const;
 
 protected:

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1325,10 +1325,10 @@ void Battle::Interface::RedrawTroopCount( const Unit & unit )
     const Sprite & bar = AGG::GetICN( ICN::TEXTBAR, GetIndexIndicator( unit ) );
     const bool isReflected = unit.isReflect();
 
-    const int tileInFront = isReflected ? unit.GetHeadIndex() - 1 : unit.GetHeadIndex() + 1;
+    const int tileInFront = Board::GetIndexDirection( unit.GetHeadIndex(), isReflected ? Battle::LEFT : Battle::RIGHT );
 
     s32 sx = rt.x + ( isReflected ? -7 : rt.w - 13 );
-    s32 sy = rt.y + rt.h - bar.h() - ( isReflected ? 23 : 11 );
+    const s32 sy = rt.y + rt.h - bar.h() - ( isReflected ? 23 : 11 );
 
     int xOffset = unit.animation.getTroopCountOffset( isReflected );
     // check if has unit standing in front

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1319,36 +1319,27 @@ void Battle::Interface::RedrawTroopSprite( const Unit & b )
     }
 }
 
-void Battle::Interface::RedrawTroopCount( const Unit & b )
+void Battle::Interface::RedrawTroopCount( const Unit & unit )
 {
-    const Rect & rt = b.GetRectPosition();
-    const Sprite & bar = AGG::GetICN( ICN::TEXTBAR, GetIndexIndicator( b ) );
+    const Rect & rt = unit.GetRectPosition();
+    const Sprite & bar = AGG::GetICN( ICN::TEXTBAR, GetIndexIndicator( unit ) );
+    const bool isReflected = unit.isReflect();
 
-    s32 sx = 0;
-    s32 sy = 0;
+    const int tileInFront = isReflected ? unit.GetHeadIndex() - 1 : unit.GetHeadIndex() + 1;
 
-    const bool isReflected = b.isReflect();
-    const bool isWide = b.isWide();
-    sy = rt.y + rt.h - bar.h() - ( isReflected ? 21 : 9 );
+    s32 sx = rt.x + ( isReflected ? -7 : rt.w - 13 );
+    s32 sy = rt.y + rt.h - bar.h() - ( isReflected ? 23 : 11 );
 
-    if ( isReflected ) {
-        if ( isWide )
-            sx = rt.x;
-        else
-            sx = rt.x - bar.w() + 3;
-    }
-    else {
-        if ( isWide ) {
-            sx = rt.x + rt.w - bar.w();
-        }
-        else {
-            sx = rt.x + rt.w - 3;
-        }
-    }
+    int xOffset = unit.animation.getTroopCountOffset( isReflected );
+    // check if has unit standing in front
+    if ( xOffset > 0 && Board::isValidIndex( tileInFront ) && Board::GetCell( tileInFront )->GetUnit() != NULL )
+        xOffset = 0;
+
+    sx += isReflected ? -xOffset : xOffset;
 
     bar.Blit( sx, sy, _mainSurface );
 
-    Text text( GetStringShort( b.GetCount() ), Font::SMALL );
+    Text text( GetStringShort( unit.GetCount() ), Font::SMALL );
     text.Blit( sx + ( bar.w() - text.w() ) / 2, sy, _mainSurface );
 }
 

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -245,7 +245,7 @@ namespace Battle
         void RedrawOpponentsFlags( void );
         void RedrawArmies( void );
         void RedrawTroopSprite( const Unit & );
-        void RedrawTroopCount( const Unit & );
+        void RedrawTroopCount( const Unit & unit );
 
         void RedrawActionWincesKills( TargetsInfo & targets, Unit * attacker = NULL );
         void RedrawActionArrowSpell( const Unit & );


### PR DESCRIPTION
Fixes #884 .

Corrected general position (both X and Y) applying offsets from original FRM BIN data files. Added additional check if there's unit in front and adjusting x offset accordingly.

![image](https://user-images.githubusercontent.com/1373638/87256104-f040c280-c45d-11ea-8e45-7490b1ad8143.png)
