### PR TITLE
Fix castle initialization, shadows and drawing

### DIFF
--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -954,7 +954,7 @@ struct ICNHeader
         , offsetY( 0 )
         , width( 0 )
         , height( 0 )
-        , type( 0 )
+        , animationFrames( 0 )
         , offsetData( 0 )
     {}
 
@@ -962,7 +962,7 @@ struct ICNHeader
     u16 offsetY;
     u16 width;
     u16 height;
-    u8 type;
+    u8 animationFrames; // used for adventure map animations, this can replace ICN::AnimationFrame
     u32 offsetData;
 };
 
@@ -972,7 +972,7 @@ StreamBuf & operator>>( StreamBuf & st, ICNHeader & icn )
     icn.offsetY = st.getLE16();
     icn.width = st.getLE16();
     icn.height = st.getLE16();
-    icn.type = st.get();
+    icn.animationFrames = st.get();
     icn.offsetData = st.getLE32();
 
     return st;

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -1468,7 +1468,7 @@ bool Castle::BuyBuilding( u32 build )
     switch ( build ) {
     case BUILD_CASTLE:
         building &= ~BUILD_TENT;
-        Maps::UpdateSpritesFromTownToCastle( GetCenter(), race );
+        Maps::UpdateCastleSprite( GetCenter(), race );
         Maps::ClearFog( GetIndex(), Game::GetViewDistance( Game::VIEW_CASTLE ), GetColor() );
         break;
 

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -1468,7 +1468,7 @@ bool Castle::BuyBuilding( u32 build )
     switch ( build ) {
     case BUILD_CASTLE:
         building &= ~BUILD_TENT;
-        Maps::UpdateSpritesFromTownToCastle( GetCenter() );
+        Maps::UpdateSpritesFromTownToCastle( GetCenter(), race );
         Maps::ClearFog( GetIndex(), Game::GetViewDistance( Game::VIEW_CASTLE ), GetColor() );
         break;
 

--- a/src/fheroes2/kingdom/world_loadmap.cpp
+++ b/src/fheroes2/kingdom/world_loadmap.cpp
@@ -1273,7 +1273,7 @@ bool World::LoadMapMP2( const std::string & filename )
                     Castle * castle = GetCastle( Maps::GetPoint( findobject ) );
                     if ( castle ) {
                         castle->LoadFromMP2( StreamBuf( pblock ) );
-                        Maps::UpdateRNDSpriteForCastle( castle->GetCenter(), castle->GetRace(), castle->isCastle() );
+                        Maps::UpdateCastleSprite( castle->GetCenter(), castle->GetRace(), castle->isCastle(), true );
                         Maps::MinimizeAreaForCastle( castle->GetCenter() );
                         map_captureobj.SetColor( tile.GetIndex(), castle->GetColor() );
                     }

--- a/src/fheroes2/kingdom/world_loadmap.cpp
+++ b/src/fheroes2/kingdom/world_loadmap.cpp
@@ -1494,7 +1494,7 @@ void World::PostLoad( void )
             break;
 
         case MP2::OBJ_HEROES: {
-            Maps::TilesAddon * addon = tile.FindAddonICN1( ICN::MINIHERO );
+            Maps::TilesAddon * addon = tile.FindAddonICN( ICN::MINIHERO, 1 );
             // remove event sprite
             if ( addon )
                 tile.Remove( addon->uniq );

--- a/src/fheroes2/kingdom/world_loadmap.cpp
+++ b/src/fheroes2/kingdom/world_loadmap.cpp
@@ -201,7 +201,7 @@ TiXmlElement & operator>>( TiXmlElement & doc, Castle & town )
         u32 kingdom_race = Players::GetPlayerRace( town.GetColor() );
         race = Color::NONE != town.GetColor() && ( Race::ALL & kingdom_race ) ? kingdom_race : Race::Rand();
 
-        Maps::UpdateRNDSpriteForCastle( town.GetCenter(), race, town.isCastle() );
+        Maps::UpdateCastleSprite( town.GetCenter(), race, town.isCastle(), true );
     }
     town.race = race;
 

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -483,7 +483,7 @@ void Maps::UpdateCastleSprite( const Point & center, int race, bool isCastle, bo
 {
     /*
     Castle/Town object image consists of 42 tile sprites:
-    10 base tilea (OBJNTWBA) with 16 shadow tiles on left side (OBJNTWSH) overlayed by 16 town tiles (OBJNTOWN)
+    10 base tiles (OBJNTWBA) with 16 shadow tiles on left side (OBJNTWSH) overlayed by 16 town tiles (OBJNTOWN)
 
     Shadows (OBJNTWSH)  Castle (OBJNTOWN)
                               0

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -24,6 +24,7 @@
 
 #include "difficulty.h"
 #include "game.h"
+#include "icn.h"
 #include "kingdom.h"
 #include "maps.h"
 #include "maps_tiles.h"
@@ -556,44 +557,53 @@ void Maps::UpdateRNDSpriteForCastle( const Point & center, int race, bool castle
     }
 }
 
-void Maps::UpdateSpritesFromTownToCastle( const Point & center )
+void Maps::UpdateSpritesFromTownToCastle( const Point & center, int race )
 {
-    // correct area maps sprites
-    Indexes coords;
-    coords.reserve( 15 );
+    int raceIndex = 0;
+    switch ( race ) {
+    case Race::BARB:
+        raceIndex = 1;
+        break;
+    case Race::SORC:
+        raceIndex = 2;
+        break;
+    case Race::WRLK:
+        raceIndex = 3;
+        break;
+    case Race::WZRD:
+        raceIndex = 4;
+        break;
+    case Race::NECR:
+        raceIndex = 5;
+        break;
+    default:
+        break;
+    }
 
-    // T1
-    coords.push_back( GetIndexFromAbsPoint( center.x - 2, center.y - 2 ) );
-    coords.push_back( GetIndexFromAbsPoint( center.x - 1, center.y - 2 ) );
-    coords.push_back( GetIndexFromAbsPoint( center.x, center.y - 2 ) );
-    coords.push_back( GetIndexFromAbsPoint( center.x + 1, center.y - 2 ) );
-    coords.push_back( GetIndexFromAbsPoint( center.x + 2, center.y - 2 ) );
-    // T2
-    coords.push_back( GetIndexFromAbsPoint( center.x - 2, center.y - 1 ) );
-    coords.push_back( GetIndexFromAbsPoint( center.x - 1, center.y - 1 ) );
-    coords.push_back( GetIndexFromAbsPoint( center.x, center.y - 1 ) );
-    coords.push_back( GetIndexFromAbsPoint( center.x + 1, center.y - 1 ) );
-    coords.push_back( GetIndexFromAbsPoint( center.x + 2, center.y - 1 ) );
-    // B1
-    coords.push_back( GetIndexFromAbsPoint( center.x - 2, center.y ) );
-    coords.push_back( GetIndexFromAbsPoint( center.x - 1, center.y ) );
-    coords.push_back( GetIndexFromAbsPoint( center.x, center.y ) );
-    coords.push_back( GetIndexFromAbsPoint( center.x + 1, center.y ) );
-    coords.push_back( GetIndexFromAbsPoint( center.x + 2, center.y ) );
+    static const int castleCoordinates[16][2] = { { 0, -3 }, { -2, -2 }, { -1, -2 }, { 0, -2 }, { 1, -2 }, { 2, -2 }, { -2, -1 }, { -1, -1 },
+                                                  { 0, -1 }, { 1, -1 },  { 2, -1 },  { -2, 0 }, { -1, 0 }, { 0, 0 },  { 1, 0 },   { 2, 0 } };
+    static const int shadowCoordinates[16][2] = { { -4, -2 }, { -3, -2 }, { -2, -2 }, { -1, -2 }, { -5, -1 }, { -4, -1 }, { -3, -1 }, { -2, -1 },
+                                                  { -1, -1 }, { -4, 0 },  { -3, 0 },  { -2, 0 },  { -1, 0 },  { -3, -1 }, { -2, -1 }, { -1, -1 } };
 
-    // modify all town sprites
-    for ( Indexes::const_iterator it = coords.begin(); it != coords.end(); ++it )
-        if ( isValidAbsIndex( *it ) ) {
-            TilesAddon * addon = world.GetTiles( *it ).FindObject( MP2::OBJ_CASTLE );
-            if ( addon )
-                addon->index -= 16;
+    for ( int index = 0; index < 16; ++index ) {
+        const int townIndex = index + 16 + raceIndex * 32;
+        const int castleTile = GetIndexFromAbsPoint( center.x + castleCoordinates[index][0], center.y + castleCoordinates[index][1] );
+        if ( isValidAbsIndex( castleTile ) ) {
+            Maps::TilesAddon * addon = world.GetTiles( castleTile ).FindAddonICN1( ICN::OBJNTOWN, townIndex );
+            
+            //Maps::TilesAddon * addon = .FindObject( MP2::OBJ_CASTLE, index + 16 );
+            //if ( addon ) {
+            //    addon->index = index;
+            //}
         }
 
-    // T0
-    if ( isValidAbsIndex( GetIndexFromAbsPoint( center.x, center.y - 3 ) && isValidAbsIndex( GetIndexFromAbsPoint( center.x, center.y - 2 ) ) ) ) {
-        TilesAddon * addon = world.GetTiles( GetIndexFromAbsPoint( center.x, center.y - 2 ) ).FindObject( MP2::OBJ_CASTLE );
-        if ( addon )
-            world.GetTiles( GetIndexFromAbsPoint( center.x, center.y - 3 ) ).AddonsPushLevel2( TilesAddon( addon->level, addon->uniq, addon->object, addon->index - 3 ) );
+        const int shadowTile = GetIndexFromAbsPoint( center.x + shadowCoordinates[index][0], center.y + shadowCoordinates[index][1] );
+        if ( isValidAbsIndex( shadowTile ) ) {
+            Maps::TilesAddon * addon = world.GetTiles( shadowTile ).FindObject( MP2::OBJ_CASTLE, index + 16 );
+            if ( addon ) {
+                addon->index = index;
+            }
+        }
     }
 }
 

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -548,7 +548,7 @@ void Maps::UpdateRNDSpriteForCastle( const Point & center, int race, bool castle
 
         const int shadowTile = GetIndexFromAbsPoint( center.x + shadowCoordinates[index][0], center.y + shadowCoordinates[index][1] );
         if ( isValidAbsIndex( shadowTile ) ) {
-            Maps::TilesAddon * addon = world.GetTiles( castleTile ).FindAddonICN( ICN::OBJNTWRD, -1, castleIndex + 16 );
+            Maps::TilesAddon * addon = world.GetTiles( shadowTile ).FindAddonICN( ICN::OBJNTWRD, -1, castleIndex + 32 );
             if ( addon ) {
                 addon->object -= 4; // OBJNTWRD to OBJNTWSH
                 addon->index = addonIndex;

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -539,7 +539,7 @@ void Maps::UpdateRNDSpriteForCastle( const Point & center, int race, bool castle
 
         const int castleTile = GetIndexFromAbsPoint( center.x + castleCoordinates[index][0], center.y + castleCoordinates[index][1] );
         if ( isValidAbsIndex( castleTile ) ) {
-            Maps::TilesAddon * addon = world.GetTiles( castleTile ).FindObject( MP2::OBJ_RNDCASTLE, castleIndex );
+            Maps::TilesAddon * addon = world.GetTiles( castleTile ).FindAddonICN( ICN::OBJNTWRD, -1, castleIndex );
             if ( addon ) {
                 addon->object -= 12; // OBJNTWRD to OBJNTOWN
                 addon->index = addonIndex;
@@ -548,7 +548,7 @@ void Maps::UpdateRNDSpriteForCastle( const Point & center, int race, bool castle
 
         const int shadowTile = GetIndexFromAbsPoint( center.x + shadowCoordinates[index][0], center.y + shadowCoordinates[index][1] );
         if ( isValidAbsIndex( shadowTile ) ) {
-            Maps::TilesAddon * addon = world.GetTiles( shadowTile ).FindObject( MP2::OBJ_RNDCASTLE, castleIndex + 16 );
+            Maps::TilesAddon * addon = world.GetTiles( castleTile ).FindAddonICN( ICN::OBJNTWRD, -1, castleIndex + 16 );
             if ( addon ) {
                 addon->object -= 4; // OBJNTWRD to OBJNTWSH
                 addon->index = addonIndex;
@@ -590,18 +590,22 @@ void Maps::UpdateSpritesFromTownToCastle( const Point & center, int race )
         const int castleTile = GetIndexFromAbsPoint( center.x + castleCoordinates[index][0], center.y + castleCoordinates[index][1] );
         if ( isValidAbsIndex( castleTile ) ) {
             Maps::TilesAddon * addon = world.GetTiles( castleTile ).FindAddonICN1( ICN::OBJNTOWN, townIndex );
-            
-            //Maps::TilesAddon * addon = .FindObject( MP2::OBJ_CASTLE, index + 16 );
-            //if ( addon ) {
-            //    addon->index = index;
-            //}
+            if ( addon == NULL )
+                addon = world.GetTiles( castleTile ).FindAddonICN2( ICN::OBJNTOWN, townIndex );
+
+            if ( addon ) {
+                addon->index -= 16;
+            }
         }
 
         const int shadowTile = GetIndexFromAbsPoint( center.x + shadowCoordinates[index][0], center.y + shadowCoordinates[index][1] );
         if ( isValidAbsIndex( shadowTile ) ) {
-            Maps::TilesAddon * addon = world.GetTiles( shadowTile ).FindObject( MP2::OBJ_CASTLE, index + 16 );
+            Maps::TilesAddon * addon = world.GetTiles( castleTile ).FindAddonICN1( ICN::OBJNTWSH, townIndex );
+            if ( addon == NULL )
+                addon = world.GetTiles( castleTile ).FindAddonICN2( ICN::OBJNTWSH, townIndex );
+
             if ( addon ) {
-                addon->index = index;
+                addon->index -= 16;
             }
         }
     }

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -531,10 +531,10 @@ void Maps::UpdateCastleSprite( const Point & center, int race, bool isCastle, bo
         const int fullTownIndex = index + ( isCastle ? 0 : 16 ) + raceIndex * 32;
         const int lookupID = isRandom ? index + ( isCastle ? 0 : 16 ) : fullTownIndex;
 
-        static const int castleCoordinates[16][2] = { { 0, -3 }, { -2, -2 }, { -1, -2 }, { 0, -2 }, { 1, -2 }, { 2, -2 }, { -2, -1 }, { -1, -1 },
-                                                      { 0, -1 }, { 1, -1 },  { 2, -1 },  { -2, 0 }, { -1, 0 }, { 0, 0 },  { 1, 0 },   { 2, 0 } };
-        static const int shadowCoordinates[16][2] = { { -4, -2 }, { -3, -2 }, { -2, -2 }, { -1, -2 }, { -5, -1 }, { -4, -1 }, { -3, -1 }, { -2, -1 },
-                                                      { -1, -1 }, { -4, 0 },  { -3, 0 },  { -2, 0 },  { -1, 0 },  { -3, -1 }, { -2, -1 }, { -1, -1 } };
+        static const int castleCoordinates[16][2]
+            = {{0, -3}, {-2, -2}, {-1, -2}, {0, -2}, {1, -2}, {2, -2}, {-2, -1}, {-1, -1}, {0, -1}, {1, -1}, {2, -1}, {-2, 0}, {-1, 0}, {0, 0}, {1, 0}, {2, 0}};
+        static const int shadowCoordinates[16][2] = {{-4, -2}, {-3, -2}, {-2, -2}, {-1, -2}, {-5, -1}, {-4, -1}, {-3, -1}, {-2, -1},
+                                                     {-1, -1}, {-4, 0},  {-3, 0},  {-2, 0},  {-1, 0},  {-3, -1}, {-2, -1}, {-1, -1}};
 
         const int castleTile = GetIndexFromAbsPoint( center.x + castleCoordinates[index][0], center.y + castleCoordinates[index][1] );
         if ( isValidAbsIndex( castleTile ) ) {

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -93,8 +93,8 @@ namespace Maps
     void ClearFog( s32, int scoute, int color );
     u32 GetApproximateDistance( s32, s32 );
 
-    void UpdateRNDSpriteForCastle( const Point &, int race, bool castle );
-    void UpdateSpritesFromTownToCastle( const Point & );
+    void UpdateRNDSpriteForCastle( const Point & center, int race, bool castle );
+    void UpdateSpritesFromTownToCastle( const Point & center, int race );
     void MinimizeAreaForCastle( const Point & );
 }
 

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -93,8 +93,7 @@ namespace Maps
     void ClearFog( s32, int scoute, int color );
     u32 GetApproximateDistance( s32, s32 );
 
-    void UpdateRNDSpriteForCastle( const Point & center, int race, bool castle );
-    void UpdateSpritesFromTownToCastle( const Point & center, int race );
+    void UpdateCastleSprite( const Point & center, int race, bool isCastle = false, bool isRandom = false );
     void MinimizeAreaForCastle( const Point & );
 }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1690,6 +1690,7 @@ bool SkipRedrawTileBottom4Hero( const Maps::TilesAddon & ta, int passable )
         case ICN::OBJNWATR:
             return ta.index >= 202 && ta.index <= 225; /* whirlpool */
 
+        case ICN::OBJNTWSH:
         case ICN::OBJNTWBA:
         case ICN::ROAD:
         case ICN::STREAM:

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1795,6 +1795,25 @@ void Maps::Tiles::RedrawTop4Hero( Surface & dst, bool skip_ground ) const
     }
 }
 
+Maps::TilesAddon * Maps::Tiles::FindAddonICN( int icn, int level, int index )
+{
+    if ( level == -1 || level == 1 ) {
+        for ( Addons::iterator it = addons_level1.begin(); it != addons_level1.end(); ++it ) {
+            if ( MP2::GetICNObject( it->object ) == icn && ( index == -1 || index == it->index ) ) {
+                return &( *it );
+            }
+        }
+    }
+    if ( level == -1 || level == 2 ) {
+        for ( Addons::iterator it = addons_level2.begin(); it != addons_level2.end(); ++it ) {
+            if ( MP2::GetICNObject( it->object ) == icn && ( index == -1 || index == it->index ) ) {
+                return &( *it );
+            }
+        }
+    }
+    return NULL;
+}
+
 Maps::TilesAddon * Maps::Tiles::FindAddonICN1( int icn1, int index )
 {
     for ( Addons::iterator it = addons_level1.begin(); it != addons_level1.end(); ++it ) {

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -683,7 +683,7 @@ bool Maps::TilesAddon::isCastle( const TilesAddon & ta )
 bool Maps::TilesAddon::isRandomCastle( const TilesAddon & ta )
 {
     // OBJNTWRD
-    return ( ICN::OBJNTWRD == MP2::GetICNObject( ta.object ) && 32 > ta.index );
+    return ( ICN::OBJNTWRD == MP2::GetICNObject( ta.object ) );
 }
 
 bool Maps::TilesAddon::isRandomMonster( const TilesAddon & ta )
@@ -2019,16 +2019,16 @@ bool Maps::Tiles::isStream( void ) const
     return addons_level1.end() != std::find_if( addons_level1.begin(), addons_level1.end(), TilesAddon::isStream );
 }
 
-Maps::TilesAddon * Maps::Tiles::FindObject( int objs )
+Maps::TilesAddon * Maps::Tiles::FindObject( int objectID, int index )
 {
-    return const_cast<Maps::TilesAddon *>( FindObjectConst( objs ) );
+    return const_cast<Maps::TilesAddon *>( FindObjectConst( objectID, index ) );
 }
 
-const Maps::TilesAddon * Maps::Tiles::FindObjectConst( int objs ) const
+const Maps::TilesAddon * Maps::Tiles::FindObjectConst( int objectID, int index ) const
 {
     Addons::const_iterator it = addons_level1.size() ? addons_level1.begin() : addons_level1.end();
 
-    switch ( objs ) {
+    switch ( objectID ) {
     case MP2::OBJ_CAMPFIRE:
         it = std::find_if( addons_level1.begin(), addons_level1.end(), TilesAddon::isCampFire );
         break;
@@ -2131,10 +2131,16 @@ const Maps::TilesAddon * Maps::Tiles::FindObjectConst( int objs ) const
         break;
 
     case MP2::OBJ_RNDCASTLE:
-        it = std::find_if( addons_level1.begin(), addons_level1.end(), TilesAddon::isRandomCastle );
-        if ( it == addons_level1.end() ) {
-            it = std::find_if( addons_level2.begin(), addons_level2.end(), TilesAddon::isRandomCastle );
-            return addons_level2.end() != it ? &( *it ) : NULL;
+        for ( ; it != addons_level1.end(); ++it ) {
+            if ( it->isRandomCastle( *it ) && it->index == index ) {
+                return &( *it );
+            }
+        }
+
+        for ( Addons::const_iterator lvl2 = addons_level2.begin(); lvl2 != addons_level2.end(); ++lvl2 ) {
+            if ( lvl2->isRandomCastle( *lvl2 ) && lvl2->index == index ) {
+                return &( *lvl2 );
+            }
         }
         break;
 
@@ -2152,7 +2158,7 @@ const Maps::TilesAddon * Maps::Tiles::FindObjectConst( int objs ) const
 
     default:
         if ( addons_level1.size() > 1 )
-            DEBUG( DBG_GAME, DBG_WARN, "FIXME for: " << MP2::StringObject( objs ) );
+            DEBUG( DBG_GAME, DBG_WARN, "FIXME for: " << MP2::StringObject( objectID ) );
         break;
     }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1311,7 +1311,7 @@ void Maps::Tiles::UpdatePassable( void )
         }
 
         // town twba
-        if ( tile_passable && FindAddonICN1( ICN::OBJNTWBA ) && ( mounts2 || trees2 ) ) {
+        if ( tile_passable && FindAddonICN( ICN::OBJNTWBA, 1 ) && ( mounts2 || trees2 ) ) {
             tile_passable = 0;
 #ifdef WITH_DEBUG
             passable_disable = 5;
@@ -1797,38 +1797,18 @@ void Maps::Tiles::RedrawTop4Hero( Surface & dst, bool skip_ground ) const
 
 Maps::TilesAddon * Maps::Tiles::FindAddonICN( int icn, int level, int index )
 {
-    if ( level == -1 || level == 1 ) {
+    if ( level == 1 || level == -1 ) {
         for ( Addons::iterator it = addons_level1.begin(); it != addons_level1.end(); ++it ) {
             if ( MP2::GetICNObject( it->object ) == icn && ( index == -1 || index == it->index ) ) {
                 return &( *it );
             }
         }
     }
-    if ( level == -1 || level == 2 ) {
+    if ( level == 2 || level == -1 ) {
         for ( Addons::iterator it = addons_level2.begin(); it != addons_level2.end(); ++it ) {
             if ( MP2::GetICNObject( it->object ) == icn && ( index == -1 || index == it->index ) ) {
                 return &( *it );
             }
-        }
-    }
-    return NULL;
-}
-
-Maps::TilesAddon * Maps::Tiles::FindAddonICN1( int icn1, int index )
-{
-    for ( Addons::iterator it = addons_level1.begin(); it != addons_level1.end(); ++it ) {
-        if ( MP2::GetICNObject( it->object ) == icn1 && (index == -1 || index == it->index) ) {
-            return &( *it );
-        }
-    }
-    return NULL;
-}
-
-Maps::TilesAddon * Maps::Tiles::FindAddonICN2( int icn2, int index )
-{
-    for ( Addons::iterator it = addons_level2.begin(); it != addons_level2.end(); ++it ) {
-        if ( MP2::GetICNObject( it->object ) == icn2 && ( index == -1 || index == it->index ) ) {
-            return &( *it );
         }
     }
     return NULL;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1795,18 +1795,24 @@ void Maps::Tiles::RedrawTop4Hero( Surface & dst, bool skip_ground ) const
     }
 }
 
-Maps::TilesAddon * Maps::Tiles::FindAddonICN1( int icn1 )
+Maps::TilesAddon * Maps::Tiles::FindAddonICN1( int icn1, int index )
 {
-    Addons::iterator it = std::find_if( addons_level1.begin(), addons_level1.end(), std::bind2nd( std::mem_fun_ref( &Maps::TilesAddon::isICN ), icn1 ) );
-
-    return it != addons_level1.end() ? &( *it ) : NULL;
+    for ( Addons::iterator it = addons_level1.begin(); it != addons_level1.end(); ++it ) {
+        if ( MP2::GetICNObject( it->object ) == icn1 && (index == -1 || index == it->index) ) {
+            return &( *it );
+        }
+    }
+    return NULL;
 }
 
-Maps::TilesAddon * Maps::Tiles::FindAddonICN2( int icn2 )
+Maps::TilesAddon * Maps::Tiles::FindAddonICN2( int icn2, int index )
 {
-    Addons::iterator it = std::find_if( addons_level2.begin(), addons_level2.end(), std::bind2nd( std::mem_fun_ref( &Maps::TilesAddon::isICN ), icn2 ) );
-
-    return it != addons_level2.end() ? &( *it ) : NULL;
+    for ( Addons::iterator it = addons_level2.begin(); it != addons_level2.end(); ++it ) {
+        if ( MP2::GetICNObject( it->object ) == icn2 && ( index == -1 || index == it->index ) ) {
+            return &( *it );
+        }
+    }
+    return NULL;
 }
 
 Maps::TilesAddon * Maps::Tiles::FindAddonLevel1( u32 uniq1 )
@@ -2020,12 +2026,12 @@ bool Maps::Tiles::isStream( void ) const
     return addons_level1.end() != std::find_if( addons_level1.begin(), addons_level1.end(), TilesAddon::isStream );
 }
 
-Maps::TilesAddon * Maps::Tiles::FindObject( int objectID, int index )
+Maps::TilesAddon * Maps::Tiles::FindObject( int objectID )
 {
-    return const_cast<Maps::TilesAddon *>( FindObjectConst( objectID, index ) );
+    return const_cast<Maps::TilesAddon *>( FindObjectConst( objectID ) );
 }
 
-const Maps::TilesAddon * Maps::Tiles::FindObjectConst( int objectID, int index ) const
+const Maps::TilesAddon * Maps::Tiles::FindObjectConst( int objectID ) const
 {
     Addons::const_iterator it = addons_level1.size() ? addons_level1.begin() : addons_level1.end();
 
@@ -2133,13 +2139,13 @@ const Maps::TilesAddon * Maps::Tiles::FindObjectConst( int objectID, int index )
 
     case MP2::OBJ_RNDCASTLE:
         for ( ; it != addons_level1.end(); ++it ) {
-            if ( it->isRandomCastle( *it ) && it->index == index ) {
+            if ( it->isRandomCastle( *it ) ) {
                 return &( *it );
             }
         }
 
         for ( Addons::const_iterator lvl2 = addons_level2.begin(); lvl2 != addons_level2.end(); ++lvl2 ) {
-            if ( lvl2->isRandomCastle( *lvl2 ) && lvl2->index == index ) {
+            if ( lvl2->isRandomCastle( *lvl2 ) ) {
                 return &( *lvl2 );
             }
         }

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -175,14 +175,14 @@ namespace Maps
         bool isStream( void ) const;
         bool GoodForUltimateArtifact( void ) const;
 
-        TilesAddon * FindAddonICN1( int icn1 );
-        TilesAddon * FindAddonICN2( int icn2 );
+        TilesAddon * FindAddonICN1( int icn1, int index = -1 );
+        TilesAddon * FindAddonICN2( int icn2, int index = -1 );
 
         TilesAddon * FindAddonLevel1( u32 uniq1 );
         TilesAddon * FindAddonLevel2( u32 uniq2 );
 
-        TilesAddon * FindObject( int objectID, int index = -1 );
-        const TilesAddon * FindObjectConst( int objectID, int index = -1 ) const;
+        TilesAddon * FindObject( int objectID );
+        const TilesAddon * FindObjectConst( int objectID ) const;
 
         void SetTile( u32 sprite_index, u32 shape /* 0: none, 1 : vert, 2: horz, 3: both */ );
         void SetObject( int object );

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -175,6 +175,7 @@ namespace Maps
         bool isStream( void ) const;
         bool GoodForUltimateArtifact( void ) const;
 
+        TilesAddon * FindAddonICN( int icn1, int level = -1, int index = -1 );
         TilesAddon * FindAddonICN1( int icn1, int index = -1 );
         TilesAddon * FindAddonICN2( int icn2, int index = -1 );
 

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -176,8 +176,6 @@ namespace Maps
         bool GoodForUltimateArtifact( void ) const;
 
         TilesAddon * FindAddonICN( int icn1, int level = -1, int index = -1 );
-        TilesAddon * FindAddonICN1( int icn1, int index = -1 );
-        TilesAddon * FindAddonICN2( int icn2, int index = -1 );
 
         TilesAddon * FindAddonLevel1( u32 uniq1 );
         TilesAddon * FindAddonLevel2( u32 uniq2 );

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -181,8 +181,8 @@ namespace Maps
         TilesAddon * FindAddonLevel1( u32 uniq1 );
         TilesAddon * FindAddonLevel2( u32 uniq2 );
 
-        TilesAddon * FindObject( int );
-        const TilesAddon * FindObjectConst( int ) const;
+        TilesAddon * FindObject( int objectID, int index = -1 );
+        const TilesAddon * FindObjectConst( int objectID, int index = -1 ) const;
 
         void SetTile( u32 sprite_index, u32 shape /* 0: none, 1 : vert, 2: horz, 3: both */ );
         void SetObject( int object );

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -58,7 +58,7 @@ namespace MP2
     struct mp2addon_t
     {
         u16 indexAddon; // zero or next addons_t
-        u8 objectNameN1; // level 1.N. Last bit indicates if object is animated.
+        u8 objectNameN1; // level 1.N. Last bit indicates if object is animated. Second-last controls overlay
         u8 indexNameN1; // level 1.N or 0xFF
         u8 quantityN; // Bitfield containing metadata
         u8 objectNameN2; // level 2.N
@@ -260,12 +260,12 @@ namespace MP2
     };
 
     ///////////////////////////////////////////////////////////////////////////////
-
+    // First bit indicates if you can interact with object
     enum
     {
         OBJ_ZERO = 0x00,
-        OBJ_UNKNW_02 = 0x02,
         OBJN_ALCHEMYLAB = 0x01,
+        OBJ_UNKNW_02 = 0x02,
         OBJ_UNKNW_03 = 0x03,
         OBJN_SKELETON = 0x04,
         OBJN_DAEMONCAVE = 0x05,

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -43,28 +43,28 @@ namespace MP2
         u16 tileIndex; // tile (ocean, grass, snow, swamp, lava, desert, dirt, wasteland, beach)
         u8 objectName1; // level 1.0
         u8 indexName1; // index level 1.0 or 0xFF
-        u8 quantity1; // count
-        u8 quantity2; // count
+        u8 quantity1; // Bitfield, first 3 bits are flags, rest is used as quantity
+        u8 quantity2; // Used as a part of quantity, field size is actually 13 bits. Has most significant bits
         u8 objectName2; // level 2.0
         u8 indexName2; // index level 2.0 or 0xFF
         u8 shape; // shape reflect % 4, 0 none, 1 vertical, 2 horizontal, 3 any
         u8 generalObject; // zero or object
         u16 indexAddon; // zero or index addons_t
-        u32 uniqNumber1; // level 1.0
-        u32 uniqNumber2; // level 2.0
+        u32 uniqNumber1; // Map editor variable: object link
+        u32 uniqNumber2; // Map editor variable: overlay link
     };
 
     // origin mp2 addons tile
     struct mp2addon_t
     {
         u16 indexAddon; // zero or next addons_t
-        u8 objectNameN1; // level 1.N
+        u8 objectNameN1; // level 1.N. Last bit indicates if object is animated.
         u8 indexNameN1; // level 1.N or 0xFF
-        u8 quantityN; //
+        u8 quantityN; // Bitfield containing metadata
         u8 objectNameN2; // level 2.N
         u8 indexNameN2; // level 1.N or 0xFF
-        u32 uniqNumberN1; // level 1.N
-        u32 uniqNumberN2; // level 2.N
+        u32 uniqNumberN1; // Map editor variable: object link
+        u32 uniqNumberN2; // Map editor variable: overlay link
     };
 
     // origin mp2 castle


### PR DESCRIPTION
Fixes #742.

1. Fixed random castle sprites initialization when map is loaded, fool-proofed it from overlap.
2. Found new bug and fixed town to castle upgrade when it is built. This had the same effect as in original bug.
3. Fixed existing shadows bug when it would flicker as hero is moving over it.
4. Corrected shadow sprites (it reused Warlock as default).

Example of bug no.2:
![image](https://user-images.githubusercontent.com/1373638/87399945-24af9e00-c586-11ea-9696-b5f77e45a9d5.png)

Screenshot of "after":
![image](https://user-images.githubusercontent.com/1373638/87400332-a7d0f400-c586-11ea-9b4b-7932b7e1b7f6.png)
