### PR TITLE
Update death logic and animations

### DIFF
--- a/src/fheroes2/battle/battle.h
+++ b/src/fheroes2/battle/battle.h
@@ -88,7 +88,7 @@ namespace Battle
         {}
 
         bool operator==( const TargetInfo & ) const;
-        bool isFinishAnimFrame( void ) const;
+        static bool isFinishAnimFrame( const TargetInfo & );
     };
 
     StreamBase & operator<<( StreamBase &, const TargetInfo & );

--- a/src/fheroes2/battle/battle.h
+++ b/src/fheroes2/battle/battle.h
@@ -88,7 +88,7 @@ namespace Battle
         {}
 
         bool operator==( const TargetInfo & ) const;
-        static bool isFinishAnimFrame( const TargetInfo & );
+        static bool isFinishAnimFrame( const TargetInfo & info );
     };
 
     StreamBase & operator<<( StreamBase &, const TargetInfo & );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2814,9 +2814,15 @@ void Battle::Interface::RedrawActionWincesKills( TargetsInfo & targets, Unit * a
 
     // Set to static animation as attacker might still continue its animation
     for ( TargetsInfo::iterator it = targets.begin(); it != targets.end(); ++it ) {
-        if ( ( *it ).defender ) {
-            if ( it->defender->isFinishAnimFrame() && it->defender->GetAnimationState() == Monster_Info::WNCE ) {
-                it->defender->SwitchAnimation( Monster_Info::STATIC );
+        Unit * unit = ( *it ).defender;
+        if ( unit ) {
+            if ( unit->isFinishAnimFrame() && unit->GetAnimationState() == Monster_Info::WNCE ) {
+                unit->SwitchAnimation( Monster_Info::STATIC );
+            }
+
+            
+            if ( unit->Modes( CAP_MIRRORIMAGE ) || unit->Modes( CAP_SUMMONELEM ) ) {
+                arena.GetGraveyard()->RemoveTroop( *unit );
             }
         }
     }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2688,17 +2688,6 @@ void Battle::Interface::RedrawActionAttackPart2( Unit & attacker, TargetsInfo & 
         status.SetMessage( "", false );
     }
 
-    // restore
-    for ( TargetsInfo::iterator it = targets.begin(); it != targets.end(); ++it )
-        if ( ( *it ).defender ) {
-            TargetInfo & target = *it;
-            if ( !target.defender->isValid() ) {
-                target.defender->SetDeathAnim();
-            }
-            else
-                target.defender->SwitchAnimation( Monster_Info::STATIC );
-        }
-
     _movingUnit = NULL;
 }
 
@@ -3164,6 +3153,7 @@ void Battle::Interface::RedrawActionSpellCastPart2( const Spell & spell, Targets
         u32 damage = 0;
 
         for ( TargetsInfo::const_iterator it = targets.begin(); it != targets.end(); ++it ) {
+            // here  Arena::GetInterface()->RedrawActionRemoveMirrorImage( *this );
             killed += ( *it ).killed;
             damage += ( *it ).damage;
         }
@@ -3190,18 +3180,6 @@ void Battle::Interface::RedrawActionSpellCastPart2( const Spell & spell, Targets
     }
 
     status.SetMessage( " ", false );
-
-    // restore
-    for ( TargetsInfo::iterator it = targets.begin(); it != targets.end(); ++it )
-        if ( ( *it ).defender ) {
-            TargetInfo & target = *it;
-            if ( !target.defender->isValid() ) {
-                target.defender->SetDeathAnim();
-            }
-            else
-                target.defender->SwitchAnimation( Monster_Info::STATIC );
-        }
-
     _movingUnit = NULL;
 }
 
@@ -3352,13 +3330,6 @@ void Battle::Interface::RedrawActionTowerPart2( Tower & tower, TargetInfo & targ
     }
     status.SetMessage( msg, true );
     status.SetMessage( "", false );
-
-    // restore
-    if ( !target.defender->isValid() ) {
-        target.defender->SetDeathAnim();
-    }
-    else
-        target.defender->SwitchAnimation( Monster_Info::STATIC );
 
     _movingUnit = NULL;
 }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -403,9 +403,9 @@ Surface DrawHexagonShadow( int alphaValue )
     return sf;
 }
 
-bool Battle::TargetInfo::isFinishAnimFrame( void ) const
+bool Battle::TargetInfo::isFinishAnimFrame( const TargetInfo & info )
 {
-    return defender && defender->isFinishAnimFrame();
+    return info.defender && info.defender->isFinishAnimFrame();
 }
 
 int Battle::GetCursorFromSpell( int spell )
@@ -2745,7 +2745,7 @@ void Battle::Interface::RedrawActionWincesKills( TargetsInfo & targets, Unit * a
     }
 
     // targets damage animation loop
-    while ( le.HandleEvents() && finish != std::count_if( targets.begin(), targets.end(), std::mem_fun_ref( &TargetInfo::isFinishAnimFrame ) ) ) {
+    while ( le.HandleEvents() && finish != std::count_if( targets.begin(), targets.end(), TargetInfo::isFinishAnimFrame ) ) {
         CheckGlobalEvents( le );
 
         if ( Battle::AnimateInfrequentDelay( Game::BATTLE_FRAME_DELAY ) ) {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1115,7 +1115,7 @@ void Battle::Interface::RedrawArmies( void )
         if ( b && _flyingUnit != b && ii != b->GetTailIndex() ) {
             RedrawTroopSprite( *b );
 
-            if ( _movingUnit != b )
+            if ( _movingUnit != b && b->isValid() )
                 RedrawTroopCount( *b );
         }
     }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1250,11 +1250,8 @@ void Battle::Interface::RedrawTroopSprite( const Unit & b )
             }
         }
 
-        if ( b.hasColorCycling() ) {
-            const bool isUnderAlphaEffect = ( b_current_sprite && spmon1 == *b_current_sprite && _currentUnit && &b == _currentUnit );
-            if ( !isUnderAlphaEffect ) {
-                applyPalettes.push_back( _creaturePalette );
-            }
+        if ( b.hasColorCycling() && b.GetCustomAlpha() == 255 ) {
+            applyPalettes.push_back( _creaturePalette );
         }
 
         if ( b.Modes( CAP_MIRRORIMAGE ) ) {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3156,7 +3156,6 @@ void Battle::Interface::RedrawActionSpellCastPart2( const Spell & spell, Targets
         u32 damage = 0;
 
         for ( TargetsInfo::const_iterator it = targets.begin(); it != targets.end(); ++it ) {
-            // here  Arena::GetInterface()->RedrawActionRemoveMirrorImage( *this );
             killed += ( *it ).killed;
             damage += ( *it ).damage;
         }
@@ -3323,7 +3322,7 @@ void Battle::Interface::RedrawActionTowerPart2( Tower & tower, TargetInfo & targ
     RedrawActionWincesKills( targets );
 
     // draw status for first defender
-    std::string msg = _( "Tower do %{damage} damage." );
+    std::string msg = _( "Tower does %{damage} damage." );
     StringReplace( msg, "%{damage}", target.damage );
     if ( target.killed ) {
         msg.append( " " );
@@ -4141,7 +4140,7 @@ void Battle::Interface::RedrawActionRemoveMirrorImage( std::vector<Unit *> mirro
     while ( le.HandleEvents() && frame > 0 ) {
         CheckGlobalEvents( le );
 
-        if ( Battle::AnimateInfrequentDelay( Game::BATTLE_SPELL_DELAY ) ) {
+        if ( Battle::AnimateInfrequentDelay( Game::BATTLE_FRAME_DELAY ) ) {
             const uint32_t alpha = static_cast<uint32_t>( frame ) * 25;
             for ( std::vector<Unit *>::iterator it = mirrorImages.begin(); it != mirrorImages.end(); ++it ) {
                 if ( *it )
@@ -4153,7 +4152,7 @@ void Battle::Interface::RedrawActionRemoveMirrorImage( std::vector<Unit *> mirro
             --frame;
         }
     }
-    status.SetMessage( _( "Mirror Image ended" ), true );
+    status.SetMessage( _( "The mirror image is destroyed!" ), true );
 }
 
 void Battle::Interface::RedrawTargetsWithFrameAnimation( s32 dst, const TargetsInfo & targets, int icn, int m82 )

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4154,7 +4154,7 @@ void Battle::Interface::RedrawActionRemoveMirrorImage( const std::vector<Unit *>
 
         if ( Battle::AnimateInfrequentDelay( Game::BATTLE_FRAME_DELAY ) ) {
             const uint32_t alpha = static_cast<uint32_t>( frame ) * 25;
-            for ( std::vector<Unit *>::iterator it = mirrorImages.begin(); it != mirrorImages.end(); ++it ) {
+            for ( std::vector<Unit *>::const_iterator it = mirrorImages.begin(); it != mirrorImages.end(); ++it ) {
                 if ( *it )
                     ( *it )->SetCustomAlpha( alpha );
             }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2642,7 +2642,7 @@ void Battle::Interface::RedrawActionAttackPart2( Unit & attacker, TargetsInfo & 
 
     attacker.SwitchAnimation( Monster_Info::STATIC );
 
-    bool isMirror = targets.size() == 1 && targets.front().defender->isModes( CAP_MIRRORIMAGE );
+    const bool isMirror = targets.size() == 1 && targets.front().defender->isModes( CAP_MIRRORIMAGE );
     // draw status for first defender
     if ( !isMirror && targets.size() ) {
         std::string msg = _( "%{attacker} do %{damage} damage." );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4145,7 +4145,7 @@ void Battle::Interface::RedrawActionRemoveMirrorImage( const std::vector<Unit *>
 {
     if ( mirrorImages.empty() ) // nothing to animate
         return;
-    
+
     LocalEvent & le = LocalEvent::Get();
 
     int frame = 10;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4141,8 +4141,11 @@ void Battle::Interface::RedrawActionEarthQuakeSpell( const std::vector<int> & ta
     }
 }
 
-void Battle::Interface::RedrawActionRemoveMirrorImage( std::vector<Unit *> mirrorImages )
+void Battle::Interface::RedrawActionRemoveMirrorImage( const std::vector<Unit *> & mirrorImages )
 {
+    if ( mirrorImages.empty() ) // nothing to animate
+        return;
+    
     LocalEvent & le = LocalEvent::Get();
 
     int frame = 10;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2820,10 +2820,8 @@ void Battle::Interface::RedrawActionWincesKills( TargetsInfo & targets, Unit * a
                 unit->SwitchAnimation( Monster_Info::STATIC );
             }
 
-            
-            if ( unit->Modes( CAP_MIRRORIMAGE ) || unit->Modes( CAP_SUMMONELEM ) ) {
-                arena.GetGraveyard()->RemoveTroop( *unit );
-            }
+            if ( !unit->isValid() )
+                unit->PostKilledAction();
         }
     }
 }

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -215,7 +215,7 @@ namespace Battle
         void RedrawActionSummonElementalSpell( Unit & target );
         void RedrawActionMirrorImageSpell( const Unit &, const Position & );
         void RedrawActionSkipStatus( const Unit & );
-        void RedrawActionRemoveMirrorImage( std::vector<Unit *> mirrorImages );
+        void RedrawActionRemoveMirrorImage( const std::vector<Unit *> & mirrorImages );
         void RedrawBridgeAnimation( bool down );
         void RedrawMissileAnimation( const Point & startPos, const Point & endPos, double angle, uint32_t monsterID );
 

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -212,7 +212,7 @@ namespace Battle
         void RedrawActionCatapult( int );
         void RedrawActionTeleportSpell( Unit &, s32 );
         void RedrawActionEarthQuakeSpell( const std::vector<int> & );
-        void RedrawActionSummonElementalSpell( const Unit & );
+        void RedrawActionSummonElementalSpell( Unit & target );
         void RedrawActionMirrorImageSpell( const Unit &, const Position & );
         void RedrawActionSkipStatus( const Unit & );
         void RedrawActionRemoveMirrorImage( std::vector<Unit *> mirrorImages );
@@ -330,7 +330,6 @@ namespace Battle
         const Unit * _movingUnit;
         const Unit * _flyingUnit;
         const Sprite * b_current_sprite;
-        u32 b_current_alpha;
         Point _movingPos;
         Point _flyingPos;
 

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -215,7 +215,7 @@ namespace Battle
         void RedrawActionSummonElementalSpell( const Unit & );
         void RedrawActionMirrorImageSpell( const Unit &, const Position & );
         void RedrawActionSkipStatus( const Unit & );
-        void RedrawActionRemoveMirrorImage( const Unit & );
+        void RedrawActionRemoveMirrorImage( std::vector<Unit *> mirrorImages );
         void RedrawBridgeAnimation( bool down );
         void RedrawMissileAnimation( const Point & startPos, const Point & endPos, double angle, uint32_t monsterID );
 

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -612,9 +612,6 @@ u32 Battle::Unit::ApplyDamage( u32 dmg )
         }
         hp -= ( dmg >= hp ? hp : dmg );
 
-        if ( !isValid() )
-            PostKilledAction();
-
         return killed;
     }
 
@@ -633,8 +630,10 @@ void Battle::Unit::PostKilledAction( void )
 
     SetModes( TR_MOVED );
 
-    // save troop to graveyard
-    Arena::GetGraveyard()->AddTroop( *this );
+    // save troop to graveyard            
+    if ( !Modes( CAP_MIRRORIMAGE ) && !Modes( CAP_SUMMONELEM ) ) {
+        Arena::GetGraveyard()->AddTroop( *this );
+    }
 
     Cell * head = Board::GetCell( GetHeadIndex() );
     Cell * tail = Board::GetCell( GetTailIndex() );

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -284,6 +284,11 @@ u32 Battle::Unit::GetUID( void ) const
     return uid;
 }
 
+Battle::Unit * Battle::Unit::GetMirror()
+{
+    return mirror;
+}
+
 void Battle::Unit::SetMirror( Unit * ptr )
 {
     mirror = ptr;
@@ -454,8 +459,11 @@ void Battle::Unit::NewTurn( void )
 
         // cancel mirror image
         if ( mode == CAP_MIRROROWNER && mirror ) {
-            if ( Arena::GetInterface() )
-                Arena::GetInterface()->RedrawActionRemoveMirrorImage( *mirror );
+            if ( Arena::GetInterface() ) {
+                std::vector<Unit *> images;
+                images.push_back( mirror );
+                Arena::GetInterface()->RedrawActionRemoveMirrorImage( images );
+            }
 
             mirror->SetCount( 0 );
             mirror = NULL;
@@ -622,8 +630,6 @@ void Battle::Unit::PostKilledAction( void )
 {
     // kill mirror image (master)
     if ( Modes( CAP_MIRROROWNER ) ) {
-        if ( Arena::GetInterface() )
-            Arena::GetInterface()->RedrawActionRemoveMirrorImage( *mirror );
         modes = 0;
         mirror->hp = 0;
         mirror->SetCount( 0 );
@@ -633,8 +639,6 @@ void Battle::Unit::PostKilledAction( void )
     }
     // kill mirror image (slave)
     if ( Modes( CAP_MIRRORIMAGE ) ) {
-        if ( Arena::GetInterface() )
-            Arena::GetInterface()->RedrawActionRemoveMirrorImage( *this );
         mirror->ResetModes( CAP_MIRROROWNER );
         mirror = NULL;
     }
@@ -1656,6 +1660,16 @@ void Battle::Unit::SetDeathAnim()
         SwitchAnimation( Monster_Info::KILL );
     }
     animation.setToLastFrame();
+}
+
+void Battle::Unit::SetCustomAlpha( uint32_t alpha )
+{
+    customAlphaMask = alpha;
+}
+
+uint32_t Battle::Unit::GetCustomAlpha() const
+{
+    return customAlphaMask;
 }
 
 int Battle::Unit::GetFrameCount( void ) const

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -133,6 +133,7 @@ Battle::Unit::Unit( const Troop & t, s32 pos, bool ref )
     , blindanswer( false )
     , animation( id )
     , idleTimer( animation.getIdleDelay() )
+    , customAlphaMask( 255 )
 {
     // set position
     if ( Board::isValidIndex( pos ) ) {

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -596,12 +596,8 @@ u32 Battle::Unit::ApplyDamage( u32 dmg )
 
         // kill mirror image (slave)
         if ( Modes( CAP_MIRRORIMAGE ) ) {
-            if ( Arena::GetInterface() )
-                Arena::GetInterface()->RedrawActionRemoveMirrorImage( *this );
-            mirror->ResetModes( CAP_MIRROROWNER );
             dmg = hp;
             killed = GetCount();
-            mirror = NULL;
         }
 
         DEBUG( DBG_BATTLE, DBG_TRACE, dmg << " to " << String() << " and killed: " << killed );
@@ -627,18 +623,6 @@ u32 Battle::Unit::ApplyDamage( u32 dmg )
 
 void Battle::Unit::PostKilledAction( void )
 {
-    // kill mirror image (master)
-    if ( Modes( CAP_MIRROROWNER ) ) {
-        if ( Arena::GetInterface() )
-            Arena::GetInterface()->RedrawActionRemoveMirrorImage( *mirror );
-        modes = 0;
-        mirror->hp = 0;
-        mirror->SetCount( 0 );
-        mirror->mirror = NULL;
-        mirror = NULL;
-        ResetModes( CAP_MIRROROWNER );
-    }
-
     ResetModes( IS_MAGIC );
     ResetModes( TR_RESPONSED );
     ResetModes( TR_SKIPMOVE );
@@ -650,9 +634,7 @@ void Battle::Unit::PostKilledAction( void )
     SetModes( TR_MOVED );
 
     // save troop to graveyard
-    // skip mirror and summon
-    if ( !Modes( CAP_MIRRORIMAGE ) && !Modes( CAP_SUMMONELEM ) )
-        Arena::GetGraveyard()->AddTroop( *this );
+    Arena::GetGraveyard()->AddTroop( *this );
 
     Cell * head = Board::GetCell( GetHeadIndex() );
     Cell * tail = Board::GetCell( GetTailIndex() );

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -86,6 +86,7 @@ namespace Battle
         u32 GetSpeed( void ) const;
         Surface GetContour( uint8_t colorId ) const;
 
+        Unit * GetMirror();
         void SetMirror( Unit * );
         void SetRandomMorale( void );
         void SetRandomLuck( void );
@@ -156,6 +157,8 @@ namespace Battle
         int GetFrame( void ) const;
         int GetFrameStart( void ) const;
         int GetFrameCount( void ) const;
+        uint32_t GetCustomAlpha() const;
+        void SetCustomAlpha( uint32_t alpha );
 
         Point GetStartMissileOffset( size_t ) const;
 
@@ -213,6 +216,7 @@ namespace Battle
         RandomizedDelay idleTimer;
 
         bool blindanswer;
+        uint32_t customAlphaMask;
     };
 
     StreamBase & operator<<( StreamBase &, const Unit & );


### PR DESCRIPTION
Fixes #792. Fixes #1006 .

- Moved `PostKilledAction` call from `ApplyDamage` to when animations are done.
- Added custom drawing call for fading mirror images.
- Added custom alpha field to every unit that will be used for drawing.
- Removed b_current_alpha global variable and cleaned up the overall logic.