### PR TITLE
Fix battle pointer cursor offset

### DIFF
--- a/src/fheroes2/gui/cursor.cpp
+++ b/src/fheroes2/gui/cursor.cpp
@@ -132,6 +132,7 @@ void Cursor::SetOffset( int name, const Point & defaultOffset )
     switch ( name ) {
     case Cursor::POINTER:
     case Cursor::POINTER2:
+    case Cursor::WAR_POINTER:
     case Cursor::FIGHT:
     case Cursor::FIGHT2:
     case Cursor::FIGHT3:


### PR DESCRIPTION
Fixes #1034 .

This creates perception that battle interface "active areas" are shifted when actually it was a mouse cursor issue.