### PR TITLE
Fix map monster attack and fade animation

### DIFF
--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -184,13 +184,13 @@ void Interface::GameArea::Redraw( Surface & dst, int flag ) const
             const std::pair<int, int> monsterIndicies = Maps::Tiles::GetMonsterSpriteIndices( world.GetTiles( removalInfo.tile ), removalInfo.index );
 
             // base monster sprite
-            if ( monsterIndicies.first != -1 ) {
+            if ( monsterIndicies.first >= 0 ) {
                 Sprite sprite = AGG::GetICN( ICN::MINIMON, monsterIndicies.first );
                 sprite.SetAlphaMod( removalInfo.alpha, false );
                 BlitOnTile( dst, sprite, sprite.x() + 16, sprite.y() + TILEWIDTH, mp );
             }
             // animated monster part
-            if ( monsterIndicies.second != -1 ) {
+            if ( monsterIndicies.second >= 0 ) {
                 Sprite sprite = AGG::GetICN( ICN::MINIMON, monsterIndicies.second );
                 sprite.SetAlphaMod( removalInfo.alpha, false );
                 BlitOnTile( dst, sprite, sprite.x() + 16, sprite.y() + TILEWIDTH, mp );

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -177,12 +177,30 @@ void Interface::GameArea::Redraw( Surface & dst, int flag ) const
     // remove animation
     Game::RemoveAnimation::Info & removalInfo = Game::RemoveAnimation::Get();
     if ( removalInfo.object != MP2::OBJ_ZERO ) {
-        Surface surface( removalInfo.surfaceSize, true );
-        const Sprite & sprite = AGG::GetICN( MP2::GetICNObject( removalInfo.object ), removalInfo.index );
-        sprite.Blit( sprite.x(), sprite.y(), surface );
-        surface.SetAlphaMod( removalInfo.alpha, false );
-        const Point mp = Maps::GetPoint( removalInfo.tile );
-        BlitOnTile( dst, surface, 0, 0, mp );
+        const Point mp = Maps::GetPoint( removalInfo.tile ); 
+        const int icn = MP2::GetICNObject( removalInfo.object );
+
+        if ( icn == ICN::MONS32 ) {
+            const std::pair<int, int> monsterIndicies = Maps::Tiles::GetMonsterSpriteIndices( world.GetTiles( removalInfo.tile ), removalInfo.index );
+
+            // base monster sprite
+            if ( monsterIndicies.first ) {
+                Sprite sprite = AGG::GetICN( ICN::MINIMON, monsterIndicies.first );
+                sprite.SetAlphaMod( removalInfo.alpha, false );
+                BlitOnTile( dst, sprite, sprite.x() + 16, sprite.y() + TILEWIDTH, mp );
+            }
+            // animated monster part
+            if ( monsterIndicies.second ) {
+                Sprite sprite = AGG::GetICN( ICN::MINIMON, monsterIndicies.second );
+                sprite.SetAlphaMod( removalInfo.alpha, false );
+                BlitOnTile( dst, sprite, sprite.x() + 16, sprite.y() + TILEWIDTH, mp );
+            }
+        }
+        else {
+            Sprite sprite = AGG::GetICN( icn, removalInfo.index );
+            sprite.SetAlphaMod( removalInfo.alpha, false );
+            BlitOnTile( dst, sprite, 0, 0, mp );
+        }
     }
 
     // ext object

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -184,13 +184,13 @@ void Interface::GameArea::Redraw( Surface & dst, int flag ) const
             const std::pair<int, int> monsterIndicies = Maps::Tiles::GetMonsterSpriteIndices( world.GetTiles( removalInfo.tile ), removalInfo.index );
 
             // base monster sprite
-            if ( monsterIndicies.first ) {
+            if ( monsterIndicies.first != -1 ) {
                 Sprite sprite = AGG::GetICN( ICN::MINIMON, monsterIndicies.first );
                 sprite.SetAlphaMod( removalInfo.alpha, false );
                 BlitOnTile( dst, sprite, sprite.x() + 16, sprite.y() + TILEWIDTH, mp );
             }
             // animated monster part
-            if ( monsterIndicies.second ) {
+            if ( monsterIndicies.second != -1 ) {
                 Sprite sprite = AGG::GetICN( ICN::MINIMON, monsterIndicies.second );
                 sprite.SetAlphaMod( removalInfo.alpha, false );
                 BlitOnTile( dst, sprite, sprite.x() + 16, sprite.y() + TILEWIDTH, mp );

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -177,7 +177,7 @@ void Interface::GameArea::Redraw( Surface & dst, int flag ) const
     // remove animation
     Game::RemoveAnimation::Info & removalInfo = Game::RemoveAnimation::Get();
     if ( removalInfo.object != MP2::OBJ_ZERO ) {
-        const Point mp = Maps::GetPoint( removalInfo.tile ); 
+        const Point mp = Maps::GetPoint( removalInfo.tile );
         const int icn = MP2::GetICNObject( removalInfo.object );
 
         if ( icn == ICN::MONS32 ) {

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2509,7 +2509,7 @@ void Maps::Tiles::UpdateRNDResourceSprite( Tiles & tile )
     }
 }
 
-std::pair<int, int> Maps::Tiles::GetMonsterSpriteIndices(const Tiles& tile, uint32_t monsterIndex)
+std::pair<int, int> Maps::Tiles::GetMonsterSpriteIndices( const Tiles & tile, uint32_t monsterIndex )
 {
     std::pair<int, int> spriteIndices( -1, -1 );
     const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1610,57 +1610,17 @@ void Maps::Tiles::RedrawObjects( Surface & dst ) const
 
 void Maps::Tiles::RedrawMonster( Surface & dst ) const
 {
-    const Settings & conf = Settings::Get();
     const Point mp = Maps::GetPoint( GetIndex() );
-    const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
-    s32 dst_index = -1;
 
-    if ( !( area.GetVisibleTileROI() & mp ) )
+    if ( !( Interface::Basic::Get().GetGameArea().GetVisibleTileROI() & mp ) )
         return;
 
-    // scan hero around
-    const MapsIndexes & v = ScanAroundObject( GetIndex(), MP2::OBJ_HEROES );
-    for ( MapsIndexes::const_iterator it = v.begin(); it != v.end(); ++it ) {
-        const Tiles & tile = world.GetTiles( *it );
-        dst_index = *it;
-
-        if ( MP2::OBJ_HEROES != mp2_object ||
-             // skip bottom, bottom_right, bottom_left with ground objects
-             ( ( DIRECTION_BOTTOM_ROW & Direction::Get( GetIndex(), *it ) ) && MP2::isGroundObject( tile.GetObject( false ) ) ) ||
-             // skip ground check
-             ( tile.isWater() != isWater() ) )
-            dst_index = -1;
-        else
-            break;
-    }
-
     const Monster & monster = QuantityMonster();
-    uint32_t spriteIndex = monster.GetSpriteIndex() * 9;
-    uint32_t secondSprite = MAXU32;
+    const std::pair<int, int> spriteIndicies = GetMonsterSpriteIndices( *this, monster.GetSpriteIndex() );
 
-    // draw attack sprite
-    if ( -1 != dst_index && !conf.ExtWorldOnlyFirstMonsterAttack() ) {
-        bool revert = false;
-
-        switch ( Direction::Get( GetIndex(), dst_index ) ) {
-        case Direction::TOP_LEFT:
-        case Direction::LEFT:
-        case Direction::BOTTOM_LEFT:
-            revert = true;
-            break;
-        default:
-            break;
-        }
-
-        spriteIndex += ( revert ? 8 : 7 );
-    }
-    else {
-        secondSprite = spriteIndex + 1 + monsterAnimationSequence[( Game::MapsAnimationFrame() + mp.x * mp.y ) % ARRAY_COUNT( monsterAnimationSequence )];
-    }
-
-    RedrawMapObject( dst, ICN::MINIMON, spriteIndex, mp, monster.hasColorCycling(), 16, TILEWIDTH );
-    if ( secondSprite != MAXU32 ) {
-        RedrawMapObject( dst, ICN::MINIMON, secondSprite, mp, monster.hasColorCycling(), 16, TILEWIDTH );
+    RedrawMapObject( dst, ICN::MINIMON, spriteIndicies.first, mp, monster.hasColorCycling(), 16, TILEWIDTH );
+    if ( spriteIndicies.second != -1 ) {
+        RedrawMapObject( dst, ICN::MINIMON, spriteIndicies.second, mp, monster.hasColorCycling(), 16, TILEWIDTH );
     }
 }
 
@@ -2547,6 +2507,48 @@ void Maps::Tiles::UpdateRNDResourceSprite( Tiles & tile )
                 shadow->index = addon->index - 1;
         }
     }
+}
+
+std::pair<int, int> Maps::Tiles::GetMonsterSpriteIndices(const Tiles& tile, uint32_t monsterIndex)
+{
+    std::pair<int, int> spriteIndices( -1, -1 );
+    const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
+    int tileIndex = tile.GetIndex();
+    int attackerIndex = -1;
+
+    // scan hero around
+    const MapsIndexes & v = ScanAroundObject( tileIndex, MP2::OBJ_HEROES );
+    for ( MapsIndexes::const_iterator it = v.begin(); it != v.end(); ++it ) {
+        const Tiles & heroTile = world.GetTiles( *it );
+        attackerIndex = *it;
+
+        if ( tile.isWater() != heroTile.isWater() )
+            attackerIndex = -1;
+        else
+            break;
+    }
+
+    spriteIndices.first = monsterIndex * 9;
+
+    // draw attack sprite
+    if ( attackerIndex != -1 && !Settings::Get().ExtWorldOnlyFirstMonsterAttack() ) {
+        spriteIndices.first += 7;
+
+        switch ( Direction::Get( tileIndex, attackerIndex ) ) {
+        case Direction::TOP_LEFT:
+        case Direction::LEFT:
+        case Direction::BOTTOM_LEFT:
+            spriteIndices.first += 1;
+            break;
+        default:
+            break;
+        }
+    }
+    else {
+        const Point mp = Maps::GetPoint( tileIndex );
+        spriteIndices.second = monsterIndex * 9 + 1 + monsterAnimationSequence[( Game::MapsAnimationFrame() + mp.x * mp.y ) % ARRAY_COUNT( monsterAnimationSequence )];
+    }
+    return spriteIndices;
 }
 
 bool Maps::Tiles::isFog( int colors ) const

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2511,24 +2511,21 @@ void Maps::Tiles::UpdateRNDResourceSprite( Tiles & tile )
 
 std::pair<int, int> Maps::Tiles::GetMonsterSpriteIndices( const Tiles & tile, uint32_t monsterIndex )
 {
-    std::pair<int, int> spriteIndices( -1, -1 );
     const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
-    int tileIndex = tile.GetIndex();
+    const int tileIndex = tile.GetIndex();
     int attackerIndex = -1;
 
     // scan hero around
     const MapsIndexes & v = ScanAroundObject( tileIndex, MP2::OBJ_HEROES );
     for ( MapsIndexes::const_iterator it = v.begin(); it != v.end(); ++it ) {
         const Tiles & heroTile = world.GetTiles( *it );
-        attackerIndex = *it;
-
-        if ( tile.isWater() != heroTile.isWater() )
-            attackerIndex = -1;
-        else
+        if ( tile.isWater() != heroTile.isWater() ) {
+            attackerIndex = *it;
             break;
+        }
     }
 
-    spriteIndices.first = monsterIndex * 9;
+    std::pair<int, int> spriteIndices( monsterIndex * 9, -1 );
 
     // draw attack sprite
     if ( attackerIndex != -1 && !Settings::Get().ExtWorldOnlyFirstMonsterAttack() ) {

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -256,6 +256,7 @@ namespace Maps
         Heroes * GetHeroes( void ) const;
         void SetHeroes( Heroes * );
 
+        static std::pair<int, int> GetMonsterSpriteIndices( const Tiles & tile, uint32_t monsterIndex );
         static void PlaceMonsterOnTile( Tiles &, const Monster &, u32 );
         static void UpdateAbandoneMineSprite( Tiles & );
         static void FixedPreload( Tiles & );


### PR DESCRIPTION
Fixes #936 . Fixes #812 .

There's two ICN files with monster sprites: MONS32 (full one, for UI) and MINIMON (with animation, split in two parts). Wrong sprite cause animation shift because offsets are different.