### PR TITLE
AI hero fade animations

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -884,7 +884,8 @@ namespace AI
                 if ( hero.isFreeman() ) {
                     DEBUG( DBG_GAME, DBG_TRACE, hero.String() + " hero dismissed, teleport action cancelled" );
                     return;
-                } else if ( !other_hero->isFreeman() ) {
+                }
+                else if ( !other_hero->isFreeman() ) {
                     DEBUG( DBG_GAME, DBG_WARN, other_hero->String() + " hero is blocking teleporter exit" );
                     return;
                 }

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -891,14 +891,11 @@ namespace AI
             }
         }
 
-        Interface::Basic & I = Interface::Basic::Get();
-        Interface::GameArea & gameArea = I.GetGameArea();
-
         hero.FadeOut();
         hero.Move2Dest( index_to, true );
         hero.GetPath().Reset();
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors( hero ) ) ) {
-            gameArea.SetCenter( hero.GetCenter() );
+            Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
             hero.FadeIn();
         }
         hero.ActionNewPosition();
@@ -925,7 +922,10 @@ namespace AI
             troop->SetCount( Monster::GetCountFromHitPoints( troop->GetID(), troop->GetHitPoints() - troop->GetHitPoints() * Game::GetWhirlpoolPercent() / 100 ) );
 
         hero.GetPath().Reset();
-        hero.FadeIn();
+        if ( AIHeroesShowAnimation( hero, AIGetAllianceColors( hero ) ) ) {
+            Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
+            hero.FadeIn();
+        }
         hero.ActionNewPosition();
 
         DEBUG( DBG_AI, DBG_INFO, hero.GetName() );

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1468,6 +1468,9 @@ namespace AI
         hero.Move2Dest( dst_index );
         hero.SetMapsObject( MP2::OBJ_ZERO );
         hero.SetShipMaster( true );
+        if ( AIHeroesShowAnimation( hero, AIGetAllianceColors( hero ) ) ) {
+            Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
+        }
         hero.GetPath().Reset();
 
         AI::Get().HeroesClearTask( hero );
@@ -1488,6 +1491,9 @@ namespace AI
         hero.SetShipMaster( false );
         hero.GetPath().Reset();
         hero.FadeIn();
+        if ( AIHeroesShowAnimation( hero, AIGetAllianceColors( hero ) ) ) {
+            Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
+        }
 
         AI::Get().HeroesClearTask( hero );
 

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -87,6 +87,8 @@ namespace AI
     void AIToBoat( Heroes & hero, u32 obj, s32 dst_index );
     void AIToCoast( Heroes & hero, u32 obj, s32 dst_index );
     void AIMeeting( Heroes & hero1, Heroes & hero2 );
+    uint32_t AIGetAllianceColors( const Heroes & hero );
+    bool AIHeroesShowAnimation( const Heroes & hero, uint32_t colors );
 
     int AISelectPrimarySkill( Heroes & hero )
     {
@@ -868,7 +870,7 @@ namespace AI
         hero.ApplyPenaltyMovement();
 
         if ( index_from == index_to ) {
-            DEBUG( DBG_AI, DBG_WARN, "action unsuccessfully..." );
+            DEBUG( DBG_AI, DBG_WARN, "teleport unsuccessfull, can't find exit lith" );
             return;
         }
 
@@ -879,15 +881,26 @@ namespace AI
                 AIToHeroes( hero, MP2::OBJ_STONELIGHTS, index_to );
 
                 // lose battle
-                if ( hero.isFreeman() )
+                if ( hero.isFreeman() ) {
+                    DEBUG( DBG_GAME, DBG_TRACE, hero.String() + " hero dismissed, teleport action cancelled" );
                     return;
-                else if ( !other_hero->isFreeman() )
-                    DEBUG( DBG_GAME, DBG_WARN, "is busy..." );
+                } else if ( !other_hero->isFreeman() ) {
+                    DEBUG( DBG_GAME, DBG_WARN, other_hero->String() + " hero is blocking teleporter exit" );
+                    return;
+                }
             }
         }
 
+        Interface::Basic & I = Interface::Basic::Get();
+        Interface::GameArea & gameArea = I.GetGameArea();
+
+        hero.FadeOut();
         hero.Move2Dest( index_to, true );
         hero.GetPath().Reset();
+        if ( AIHeroesShowAnimation( hero, AIGetAllianceColors( hero ) ) ) {
+            gameArea.SetCenter( hero.GetCenter() );
+            hero.FadeIn();
+        }
         hero.ActionNewPosition();
 
         DEBUG( DBG_AI, DBG_INFO, hero.GetName() );
@@ -903,6 +916,7 @@ namespace AI
             return;
         }
 
+        hero.FadeOut();
         hero.Move2Dest( index_to, true );
 
         Troop * troop = hero.GetArmy().GetWeakestTroop();
@@ -911,6 +925,7 @@ namespace AI
             troop->SetCount( Monster::GetCountFromHitPoints( troop->GetID(), troop->GetHitPoints() - troop->GetHitPoints() * Game::GetWhirlpoolPercent() / 100 ) );
 
         hero.GetPath().Reset();
+        hero.FadeIn();
         hero.ActionNewPosition();
 
         DEBUG( DBG_AI, DBG_INFO, hero.GetName() );
@@ -1447,6 +1462,7 @@ namespace AI
         for ( MapsIndexes::const_iterator it = coasts.begin(); it != coasts.end(); ++it )
             hero.SetVisited( *it );
 
+        hero.FadeOut();
         hero.ResetMovePoints();
         hero.Move2Dest( dst_index );
         hero.SetMapsObject( MP2::OBJ_ZERO );
@@ -1470,6 +1486,7 @@ namespace AI
         from.SetObject( MP2::OBJ_BOAT );
         hero.SetShipMaster( false );
         hero.GetPath().Reset();
+        hero.FadeIn();
 
         AI::Get().HeroesClearTask( hero );
 

--- a/src/fheroes2/kingdom/world.cpp
+++ b/src/fheroes2/kingdom/world.cpp
@@ -621,16 +621,6 @@ const std::string & World::GetRumors( void )
     return *Rand::Get( vec_rumors );
 }
 
-bool TeleportCheckType( s32 index, int type )
-{
-    return world.GetTiles( index ).QuantityTeleportType() == type;
-}
-
-bool TeleportCheckGround( s32 index, bool water )
-{
-    return world.GetTiles( index ).isWater() == water;
-}
-
 MapsIndexes World::GetTeleportEndPoints( s32 center ) const
 {
     MapsIndexes result;

--- a/src/fheroes2/kingdom/world.cpp
+++ b/src/fheroes2/kingdom/world.cpp
@@ -636,25 +636,22 @@ MapsIndexes World::GetTeleportEndPoints( s32 center ) const
     MapsIndexes result;
 
     if ( MP2::OBJ_STONELIGHTS == GetTiles( center ).GetObject( false ) ) {
-        result = Maps::GetObjectPositions( MP2::OBJ_STONELIGHTS, true );
+        MapsIndexes allTeleporters = Maps::GetObjectPositions( MP2::OBJ_STONELIGHTS, true );
 
-        if ( 2 > result.size() ) {
+        if ( 2 > allTeleporters.size() ) {
             DEBUG( DBG_GAME, DBG_WARN, "is empty" );
-            result.clear();
         }
         else {
-            MapsIndexes::iterator itend = result.end();
+            const Maps::Tiles & entrance = GetTiles( center );
+            uint8_t teleportType = entrance.FindObjectConst( MP2::OBJ_STONELIGHTS )->index;
 
-            // remove if not type
-            itend = std::remove_if( result.begin(), itend, std::not1( std::bind2nd( std::ptr_fun( &TeleportCheckType ), GetTiles( center ).QuantityTeleportType() ) ) );
+            for ( MapsIndexes::iterator it = allTeleporters.begin(); it != allTeleporters.end(); ++it ) {
+                const Maps::Tiles & tile = GetTiles( *it );
 
-            // remove if index
-            itend = std::remove( result.begin(), itend, center );
-
-            // remove if not ground
-            itend = std::remove_if( result.begin(), itend, std::not1( std::bind2nd( std::ptr_fun( &TeleportCheckGround ), GetTiles( center ).isWater() ) ) );
-
-            result.resize( std::distance( result.begin(), itend ) );
+                if ( *it != center && tile.FindObjectConst( MP2::OBJ_STONELIGHTS )->index == teleportType && tile.isWater() == entrance.isWater() ) {
+                    result.push_back( *it );
+                }
+            }
         }
     }
 

--- a/src/fheroes2/kingdom/world.cpp
+++ b/src/fheroes2/kingdom/world.cpp
@@ -637,8 +637,8 @@ MapsIndexes World::GetTeleportEndPoints( s32 center ) const
 
             for ( MapsIndexes::iterator it = allTeleporters.begin(); it != allTeleporters.end(); ++it ) {
                 const Maps::Tiles & tile = GetTiles( *it );
-
-                if ( *it != center && tile.FindObjectConst( MP2::OBJ_STONELIGHTS )->index == teleportType && tile.isWater() == entrance.isWater() ) {
+                const Maps::TilesAddon * addon = tile.FindObjectConst( MP2::OBJ_STONELIGHTS );
+                if ( addon && *it != center && addon->index == teleportType && tile.isWater() == entrance.isWater() ) {
                     result.push_back( *it );
                 }
             }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -668,6 +668,12 @@ bool Maps::TilesAddon::isBoat( const TilesAddon & ta )
     return ( ICN::OBJNWAT2 == MP2::GetICNObject( ta.object ) && 0x17 == ta.index );
 }
 
+bool Maps::TilesAddon::isTeleporter( const TilesAddon & ta )
+{
+    // OBJNWAT2
+    return ( ICN::OBJNMUL2 == MP2::GetICNObject( ta.object ) && ( ta.index == 116 || ta.index == 119 || ta.index == 122 ) );
+}
+
 bool Maps::TilesAddon::isMiniHero( const TilesAddon & ta )
 {
     // MINIHERO
@@ -2078,6 +2084,10 @@ const Maps::TilesAddon * Maps::Tiles::FindObjectConst( int objectID ) const
 
     case MP2::OBJ_BOAT:
         it = std::find_if( addons_level1.begin(), addons_level1.end(), TilesAddon::isBoat );
+        break;
+
+    case MP2::OBJ_STONELIGHTS:
+        it = std::find_if( addons_level1.begin(), addons_level1.end(), TilesAddon::isTeleporter );
         break;
 
     case MP2::OBJ_BARRIER:

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -84,6 +84,7 @@ namespace Maps
         static bool isShadow( const TilesAddon & );
         static bool isEvent( const TilesAddon & );
         static bool isBoat( const TilesAddon & );
+        static bool isTeleporter( const TilesAddon & );
         static bool isMiniHero( const TilesAddon & );
         static bool isRandomResource( const TilesAddon & );
         static bool isRandomArtifact( const TilesAddon & );

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -238,7 +238,6 @@ namespace Maps
         void QuantityReset( void );
         bool QuantityIsValid( void ) const;
         void QuantitySetColor( int );
-        int QuantityTeleportType( void ) const;
         int QuantityVariant( void ) const;
         int QuantityExt( void ) const;
         int QuantityColor( void ) const;
@@ -278,7 +277,6 @@ namespace Maps
         void QuantitySetSpell( int );
         void QuantitySetArtifact( int );
         void QuantitySetResource( int, u32 );
-        void QuantitySetTeleportType( int );
 
         int GetQuantity3( void ) const;
         void SetQuantity3( int );

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -358,16 +358,6 @@ int Maps::Tiles::QuantityColor( void ) const
     }
 }
 
-int Maps::Tiles::QuantityTeleportType( void ) const
-{
-    return quantity1;
-}
-
-void Maps::Tiles::QuantitySetTeleportType( int type )
-{
-    quantity1 = type;
-}
-
 Monster Maps::Tiles::QuantityMonster( void ) const
 {
     switch ( GetObject( false ) ) {


### PR DESCRIPTION
Fixes #1007 .

1. Fixed major logic flaw for teleporters - hero would exit at any type of teleporter.
2. Fixed another logic bug - if allied hero blocked the exit hero would still move over.
3. Fade in/fade out and screen centering animation for teleporters, whirlpool and boats.