### PR TITLE
Fix regression introduced in #1106

### DIFF
--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -204,7 +204,7 @@ void Interface::GameArea::Redraw( Surface & dst, int flag ) const
         else {
             Sprite sprite = AGG::GetICN( icn, fadeInfo.index );
             sprite.SetAlphaMod( fadeInfo.alpha, false );
-            BlitOnTile( dst, sprite, 0, 0, mp );
+            BlitOnTile( dst, sprite, sprite.x(), sprite.y(), mp );
         }
     }
 


### PR DESCRIPTION
Caught the oversight causing object remove animation to jump. Test by hero picking up something.