### PR TITLE
Fix infinite morale bug

### DIFF
--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -377,7 +377,8 @@ void Battle::Arena::TurnTroop( Unit * current_troop )
                 end_turn = true;
 
             // good morale
-            if ( !end_turn && !current_troop->Modes( TR_SKIPMOVE ) && current_troop->Modes( TR_MOVED ) && current_troop->Modes( MORALE_GOOD ) && BattleValid() ) {
+            if ( !end_turn && current_troop->isValid() && !current_troop->Modes( TR_SKIPMOVE ) && current_troop->Modes( TR_MOVED ) && current_troop->Modes( MORALE_GOOD )
+                 && BattleValid() ) {
                 actions.push_back( Command( MSG_BATTLE_MORALE, current_troop->GetUID(), true ) );
                 end_turn = false;
             }


### PR DESCRIPTION
Infinite loop (not crash, but almost) is created when AI's dead unit gets a morale event. Checking if unit is valid before pushing second battle action.