### PR TITLE
Remove move penalty for visiting whirlpool/teleport

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -872,7 +872,6 @@ namespace AI
     void AIToTeleports( Heroes & hero, s32 index_from )
     {
         s32 index_to = world.NextTeleport( index_from );
-        hero.ApplyPenaltyMovement();
 
         if ( index_from == index_to ) {
             DEBUG( DBG_AI, DBG_WARN, "teleport unsuccessfull, can't find exit lith" );
@@ -898,7 +897,7 @@ namespace AI
         }
 
         hero.FadeOut();
-        hero.Move2Dest( index_to, true );
+        hero.Move2Dest( index_to, true, true );
         hero.GetPath().Reset();
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors( hero ) ) ) {
             Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
@@ -912,7 +911,6 @@ namespace AI
     void AIToWhirlpools( Heroes & hero, s32 index_from )
     {
         s32 index_to = world.NextWhirlpool( index_from );
-        hero.ApplyPenaltyMovement();
 
         if ( index_from == index_to ) {
             DEBUG( DBG_AI, DBG_WARN, "action unsuccessfully..." );
@@ -920,7 +918,7 @@ namespace AI
         }
 
         hero.FadeOut();
-        hero.Move2Dest( index_to, true );
+        hero.Move2Dest( index_to, true, true );
 
         Troop * troop = hero.GetArmy().GetWeakestTroop();
 

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -918,7 +918,7 @@ namespace AI
         }
 
         hero.FadeOut();
-        hero.Move2Dest( index_to, true, true );  // no action and no penalty
+        hero.Move2Dest( index_to, true, true ); // no action and no penalty
 
         Troop * troop = hero.GetArmy().GetWeakestTroop();
 

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -897,7 +897,7 @@ namespace AI
         }
 
         hero.FadeOut();
-        hero.Move2Dest( index_to, true, true );
+        hero.Move2Dest( index_to, true, true ); // no action and no penalty
         hero.GetPath().Reset();
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors( hero ) ) ) {
             Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
@@ -918,7 +918,7 @@ namespace AI
         }
 
         hero.FadeOut();
-        hero.Move2Dest( index_to, true, true );
+        hero.Move2Dest( index_to, true, true );  // no action and no penalty
 
         Troop * troop = hero.GetArmy().GetWeakestTroop();
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1635,7 +1635,7 @@ void Heroes::Move2Dest( const s32 & dstIndex, bool skipAction /* false */, bool 
         world.GetTiles( GetIndex() ).SetHeroes( NULL );
         SetIndex( dstIndex );
         Scoute();
-        world.GetTiles( dst_index ).SetHeroes( this );
+        world.GetTiles( dstIndex ).SetHeroes( this );
 
         if ( !skipAction )
             ActionNewPosition();

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1629,18 +1629,18 @@ void Heroes::RecalculateMovePoints( void )
         move_point = GetMaxMovePoints() * move_point_scale / 1000;
 }
 
-void Heroes::Move2Dest( const s32 & dst_index, bool skip_action /* false */, bool skip_penalty /* false */ )
+void Heroes::Move2Dest( const s32 & dstIndex, bool skipAction /* false */, bool skipPenalty /* false */ )
 {
-    if ( dst_index != GetIndex() ) {
+    if ( dstIndex != GetIndex() ) {
         world.GetTiles( GetIndex() ).SetHeroes( NULL );
-        SetIndex( dst_index );
+        SetIndex( dstIndex );
         Scoute();
         world.GetTiles( dst_index ).SetHeroes( this );
 
-        if ( !skip_action )
+        if ( !skipAction )
             ActionNewPosition();
 
-        if ( !skip_penalty )
+        if ( !skipPenalty )
             ApplyPenaltyMovement();
     }
 }

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1629,17 +1629,19 @@ void Heroes::RecalculateMovePoints( void )
         move_point = GetMaxMovePoints() * move_point_scale / 1000;
 }
 
-void Heroes::Move2Dest( const s32 & dst_index, bool skip_action /* false */ )
+void Heroes::Move2Dest( const s32 & dst_index, bool skip_action /* false */, bool skip_penalty /* false */ )
 {
     if ( dst_index != GetIndex() ) {
         world.GetTiles( GetIndex() ).SetHeroes( NULL );
         SetIndex( dst_index );
         Scoute();
-        ApplyPenaltyMovement();
         world.GetTiles( dst_index ).SetHeroes( this );
 
         if ( !skip_action )
             ActionNewPosition();
+
+        if ( !skip_penalty )
+            ApplyPenaltyMovement();
     }
 }
 

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -261,7 +261,7 @@ public:
     bool isVisited( const Maps::Tiles &, Visit::type_t = Visit::LOCAL ) const;
 
     bool Move( bool fast = false );
-    void Move2Dest( const s32 &, bool skip_action = false );
+    void Move2Dest( const s32 &, bool skip_action = false, bool skip_penalty = false );
     bool isEnableMove( void ) const;
     bool CanMove( void ) const;
     void SetMove( bool );

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -261,7 +261,7 @@ public:
     bool isVisited( const Maps::Tiles &, Visit::type_t = Visit::LOCAL ) const;
 
     bool Move( bool fast = false );
-    void Move2Dest( const s32 &, bool skip_action = false, bool skip_penalty = false );
+    void Move2Dest( const s32 & destination, bool skipAction = false, bool skipPenalty = false );
     bool isEnableMove( void ) const;
     bool CanMove( void ) const;
     void SetMove( bool );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1889,7 +1889,6 @@ void ActionToAncientLamp( Heroes & hero, u32 obj, s32 dst_index )
 void ActionToTeleports( Heroes & hero, s32 index_from )
 {
     s32 index_to = world.NextTeleport( index_from );
-    hero.ApplyPenaltyMovement();
 
     if ( index_from == index_to ) {
         AGG::PlaySound( M82::RSBRYFZL );
@@ -1917,7 +1916,7 @@ void ActionToTeleports( Heroes & hero, s32 index_from )
 
     Cursor::Get().Hide();
 
-    hero.Move2Dest( index_to, true );
+    hero.Move2Dest( index_to, true, true );
 
     Interface::Basic & I = Interface::Basic::Get();
     I.GetGameArea().SetCenter( hero.GetCenter() );
@@ -1938,7 +1937,6 @@ void ActionToTeleports( Heroes & hero, s32 index_from )
 void ActionToWhirlpools( Heroes & hero, u32 obj, s32 index_from )
 {
     const s32 index_to = world.NextWhirlpool( index_from );
-    hero.ApplyPenaltyMovement();
 
     if ( index_from == index_to ) {
         AGG::PlaySound( M82::RSBRYFZL );
@@ -1952,7 +1950,7 @@ void ActionToWhirlpools( Heroes & hero, u32 obj, s32 index_from )
 
     Cursor::Get().Hide();
 
-    hero.Move2Dest( index_to, true );
+    hero.Move2Dest( index_to, true, true );
 
     Interface::Basic & I = Interface::Basic::Get();
     I.GetGameArea().SetCenter( hero.GetCenter() );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1916,7 +1916,7 @@ void ActionToTeleports( Heroes & hero, s32 index_from )
 
     Cursor::Get().Hide();
 
-    hero.Move2Dest( index_to, true, true );  // no action and no penalty
+    hero.Move2Dest( index_to, true, true ); // no action and no penalty
 
     Interface::Basic & I = Interface::Basic::Get();
     I.GetGameArea().SetCenter( hero.GetCenter() );
@@ -1950,7 +1950,7 @@ void ActionToWhirlpools( Heroes & hero, u32 obj, s32 index_from )
 
     Cursor::Get().Hide();
 
-    hero.Move2Dest( index_to, true, true );  // no action and no penalty
+    hero.Move2Dest( index_to, true, true ); // no action and no penalty
 
     Interface::Basic & I = Interface::Basic::Get();
     I.GetGameArea().SetCenter( hero.GetCenter() );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1916,7 +1916,7 @@ void ActionToTeleports( Heroes & hero, s32 index_from )
 
     Cursor::Get().Hide();
 
-    hero.Move2Dest( index_to, true, true );
+    hero.Move2Dest( index_to, true, true );  // no action and no penalty
 
     Interface::Basic & I = Interface::Basic::Get();
     I.GetGameArea().SetCenter( hero.GetCenter() );
@@ -1950,7 +1950,7 @@ void ActionToWhirlpools( Heroes & hero, u32 obj, s32 index_from )
 
     Cursor::Get().Hide();
 
-    hero.Move2Dest( index_to, true, true );
+    hero.Move2Dest( index_to, true, true );  // no action and no penalty
 
     Interface::Basic & I = Interface::Basic::Get();
     I.GetGameArea().SetCenter( hero.GetCenter() );


### PR DESCRIPTION
Fix for #1053 
In current version when hero step in teleport/whirlpool we have 2 additional movepoint penalties
```
hero.ApplyPenaltyMovement() (WHY???)
hero.Move2Dest() (move hero to location)
```

Not found any functions for **just** move hero to specific location and don't use ```hero.Move2Dest()```
So fastest way is just add additional move points as compensation for ```hero.Move2Dest()```


