### PR TITLE
Don't show start and end position for monster log movement

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2832,9 +2832,14 @@ void Battle::Interface::RedrawActionMove( Unit & unit, const Indexes & path )
 
     Cursor::Get().SetThemes( Cursor::WAR_NONE );
 
+#ifdef DEBUG
     std::string msg = _( "Moved %{monster}: %{src}, %{dst}" );
     StringReplace( msg, "%{monster}", unit.GetName() );
     StringReplace( msg, "%{src}", unit.GetHeadIndex() );
+#else
+    std::string msg = _( "Moved %{monster}" );
+    StringReplace( msg, "%{monster}", unit.GetName() );
+#endif
 
     _currentUnit = NULL;
     _movingUnit = &unit;
@@ -2886,7 +2891,9 @@ void Battle::Interface::RedrawActionMove( Unit & unit, const Indexes & path )
     _currentUnit = NULL;
     unit.SwitchAnimation( Monster_Info::STATIC );
 
+#ifdef DEBUG
     StringReplace( msg, "%{dst}", unit.GetHeadIndex() );
+#endif
     status.SetMessage( msg, true );
 }
 


### PR DESCRIPTION
relates to #1165