### PR TITLE
Fix AI turn crash and battle board cleanup

### DIFF
--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -190,12 +190,20 @@ struct bcell_t
 
 Battle::Indexes Battle::Board::GetAStarPath( const Unit & b, const Position & dst, bool debug )
 {
+    Indexes result;
+    const bool isWide = b.isWide();
+
+    // check if target position is valid
+    if ( !dst.GetHead() || ( isWide && !dst.GetTail() ) ) {
+        ERROR( "Board::GetAStarPath invalid destination for unit " + b.String() );
+        return result;
+    }
+
+    s32 cur = b.GetHeadIndex();
     const Castle * castle = Arena::GetCastle();
     const Bridge * bridge = Arena::GetBridge();
-    const bool isWide = b.isWide();
-    std::map<s32, bcell_t> list;
-    s32 cur = b.GetHeadIndex();
 
+    std::map<s32, bcell_t> list;
     list[cur].prnt = -1;
     list[cur].cost = 0;
     list[cur].open = false;
@@ -243,7 +251,6 @@ Battle::Indexes Battle::Board::GetAStarPath( const Unit & b, const Position & ds
             break;
     }
 
-    Indexes result;
     result.reserve( 15 );
 
     // save path

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -74,8 +74,14 @@ Rect Battle::Board::GetArea( void ) const
 
 void Battle::Board::Reset( void )
 {
-    std::for_each( begin(), end(), std::mem_fun_ref( &Cell::ResetQuality ) );
-    std::for_each( begin(), end(), std::mem_fun_ref( &Cell::ResetDirection ) );
+    for ( iterator it = begin(); it != end(); ++it ) {
+        Unit * unit = it->GetUnit();
+        if ( unit && !unit->isValid() ) {
+            unit->PostKilledAction();
+        }
+        it->ResetDirection();
+        it->ResetQuality();
+    }
 }
 
 void Battle::Board::SetPositionQuality( const Unit & b )

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2816,9 +2816,6 @@ void Battle::Interface::RedrawActionWincesKills( TargetsInfo & targets, Unit * a
             if ( unit->isFinishAnimFrame() && unit->GetAnimationState() == Monster_Info::WNCE ) {
                 unit->SwitchAnimation( Monster_Info::STATIC );
             }
-
-            if ( !unit->isValid() )
-                unit->PostKilledAction();
         }
     }
 }

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1637,11 +1637,11 @@ void Heroes::Move2Dest( const s32 & dstIndex, bool skipAction /* false */, bool 
         Scoute();
         world.GetTiles( dstIndex ).SetHeroes( this );
 
-        if ( !skipAction )
-            ActionNewPosition();
-
         if ( !skipPenalty )
             ApplyPenaltyMovement();
+
+        if ( !skipAction )
+            ActionNewPosition();
     }
 }
 


### PR DESCRIPTION
Fixes #1198 .

Three bugs here, two are regressions.
1. AI hero losing a battle but penalty still applies resulting in nullptr crash
2. Dead units not removed from the battlefield during AI battle causing infinite battle
3. Wide unit is asked to path to impossible position, resulting in a crash