### PR TITLE
Remove some redundant / useless config options

### DIFF
--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1456,15 +1456,7 @@ u32 Battle::Unit::GetMagicResist( const Spell & spell, u32 spower ) const
     if ( spell.isUndeadOnly() && !isUndead() )
         return 100;
 
-    if ( Settings::Get().ExtBattleMagicTroopCanResist() && spell == GetSpellMagic( true ) )
-        return 20;
-
     switch ( GetID() ) {
-    case Monster::ARCHMAGE:
-        if ( Settings::Get().ExtBattleArchmageCanResistBadMagic() && ( spell.isDamage() || spell.isApplyToEnemies() ) )
-            return 20;
-        break;
-
     // 25% unfortunatly
     case Monster::DWARF:
     case Monster::BATTLE_DWARF:

--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -158,13 +158,9 @@ void Dialog::ExtSettings( bool readonly )
     states.reserve( 64 );
 
     states.push_back( Settings::GAME_SAVE_REWRITE_CONFIRM );
-    states.push_back( Settings::GAME_ALSO_CONFIRM_AUTOSAVE );
     states.push_back( Settings::GAME_REMEMBER_LAST_FOCUS );
     states.push_back( Settings::GAME_SHOW_SYSTEM_INFO );
     states.push_back( Settings::GAME_EVIL_INTERFACE );
-    states.push_back( Settings::GAME_BATTLE_SHOW_GRID );
-    states.push_back( Settings::GAME_BATTLE_SHOW_MOUSE_SHADOW );
-    states.push_back( Settings::GAME_BATTLE_SHOW_MOVE_SHADOW );
     states.push_back( Settings::GAME_BATTLE_SHOW_DAMAGE );
 
     if ( !conf.QVGA() ) {
@@ -236,8 +232,6 @@ void Dialog::ExtSettings( bool readonly )
     states.push_back( Settings::BATTLE_SOFT_WAITING );
     states.push_back( Settings::BATTLE_OBJECTS_ARCHERS_PENALTY );
     states.push_back( Settings::BATTLE_MERGE_ARMIES );
-    states.push_back( Settings::BATTLE_ARCHMAGE_RESIST_BAD_SPELL );
-    states.push_back( Settings::BATTLE_MAGIC_TROOP_RESIST );
     states.push_back( Settings::BATTLE_SKIP_INCREASE_DEFENSE );
     states.push_back( Settings::BATTLE_REVERSE_WAIT_ORDER );
 

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -96,7 +96,7 @@ bool Game::Save( const std::string & fn )
     const Settings & conf = Settings::Get();
 
     // ask overwrite?
-    if ( System::IsFile( fn ) && ( ( !autosave && conf.ExtGameRewriteConfirm() ) || ( autosave && Settings::Get().ExtGameAutosaveConfirm() ) )
+    if ( System::IsFile( fn ) && !autosave && conf.ExtGameRewriteConfirm()
          && Dialog::NO == Dialog::Message( "", _( "Are you sure you want to overwrite the save with this name?" ), Font::BIG, Dialog::YES | Dialog::NO ) ) {
         return false;
     }

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -181,10 +181,6 @@ const settings_t settingsFHeroes2[] = {
         _( "game: always confirm for rewrite savefile" ),
     },
     {
-        Settings::GAME_ALSO_CONFIRM_AUTOSAVE,
-        _( "game: also confirm autosave" ),
-    },
-    {
         Settings::GAME_REMEMBER_LAST_FOCUS,
         _( "game: remember last focus" ),
     },
@@ -388,14 +384,6 @@ const settings_t settingsFHeroes2[] = {
     {
         Settings::BATTLE_MERGE_ARMIES,
         _( "battle: merge armies for hero from castle" ),
-    },
-    {
-        Settings::BATTLE_ARCHMAGE_RESIST_BAD_SPELL,
-        _( "battle: archmage can resists (20%) bad spells" ),
-    },
-    {
-        Settings::BATTLE_MAGIC_TROOP_RESIST,
-        _( "battle: magical creature resists (20%) the same magic" ),
     },
     {
         Settings::BATTLE_SKIP_INCREASE_DEFENSE,
@@ -1787,24 +1775,9 @@ bool Settings::ExtBattleMergeArmies( void ) const
     return ExtModes( BATTLE_MERGE_ARMIES );
 }
 
-bool Settings::ExtBattleArchmageCanResistBadMagic( void ) const
-{
-    return ExtModes( BATTLE_ARCHMAGE_RESIST_BAD_SPELL );
-}
-
-bool Settings::ExtBattleMagicTroopCanResist( void ) const
-{
-    return ExtModes( BATTLE_MAGIC_TROOP_RESIST );
-}
-
 bool Settings::ExtGameRewriteConfirm( void ) const
 {
     return ExtModes( GAME_SAVE_REWRITE_CONFIRM );
-}
-
-bool Settings::ExtGameAutosaveConfirm( void ) const
-{
-    return ExtModes( GAME_ALSO_CONFIRM_AUTOSAVE );
 }
 
 bool Settings::ExtPocketHideCursor( void ) const

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -321,7 +321,6 @@ public:
     bool ExtGameRememberLastFocus( void ) const;
     bool ExtGameContinueAfterVictory( void ) const;
     bool ExtGameRewriteConfirm( void ) const;
-    bool ExtGameAutosaveConfirm( void ) const;
     bool ExtGameShowSystemInfo( void ) const;
     bool ExtGameAutosaveBeginOfDay( void ) const;
     bool ExtGameAutosaveOn( void ) const;

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -126,8 +126,7 @@ public:
         GAME_SHOW_SDL_LOGO = 0x10000800,
         GAME_EVIL_INTERFACE = 0x10001000,
         GAME_HIDE_INTERFACE = 0x10002000,
-        GAME_ALSO_CONFIRM_AUTOSAVE = 0x10004000,
-        // UNUSED			= 0x10008000,
+        // UNUSED = 0x10008000,
         GAME_DYNAMIC_INTERFACE = 0x10010000,
         GAME_BATTLE_SHOW_GRID = 0x10020000,
         GAME_BATTLE_SHOW_MOUSE_SHADOW = 0x10040000,
@@ -186,8 +185,6 @@ public:
         WORLD_EXT_OBJECTS_CAPTURED = 0x30004000,
         CASTLE_1HERO_HIRED_EVERY_WEEK = 0x30008000,
 
-        BATTLE_ARCHMAGE_RESIST_BAD_SPELL = 0x40001000,
-        BATTLE_MAGIC_TROOP_RESIST = 0x40002000,
         BATTLE_SHOW_ARMY_ORDER = 0x40004000,
         // UNUSED = 0x40008000,
         BATTLE_SOFT_WAITING = 0x40010000,
@@ -314,8 +311,6 @@ public:
     bool ExtBattleShowDamage( void ) const;
     bool ExtBattleShowBattleOrder( void ) const;
     bool ExtBattleSoftWait( void ) const;
-    bool ExtBattleMagicTroopCanResist( void ) const;
-    bool ExtBattleArchmageCanResistBadMagic( void ) const;
     bool ExtBattleObjectsArchersPenalty( void ) const;
     bool ExtBattleMergeArmies( void ) const;
     bool ExtBattleSkipIncreaseDefense( void ) const;


### PR DESCRIPTION
relates to #1272

These options will be removed completely:
- game: also confirm autosave
- battle: archmage can resists (20%) bad spells
- battle: magical creature resists (20%) the same magic

These options will be removed from configuration page:
- game: battle show grid
- game: battle mouse shadow
- game: battle move shadow