### PR TITLE
Update configuration options

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -475,14 +475,6 @@ namespace AI
             // wins attacker
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
-
-                // disable: auto move hero for AI
-                /*
-                    if(conf.ExtHeroAutoMove2BattleTarget() && !disable_auto_move)
-                    {
-                            hero.Move2Dest(dst_index);
-                    }
-                */
             }
             else
                 // wins defender
@@ -564,15 +556,6 @@ namespace AI
                 castle->Scoute();
                 // allow_enter = true;
             }
-
-            // disable: auto move hero to castle for AI
-            /*
-                if(conf.ExtHeroAutoMove2BattleTarget() && allow_enter)
-                {
-                    hero.Move2Dest(dst_index);
-                    AIToCastle(hero, MP2::OBJ_CASTLE, dst_index);
-                }
-            */
         }
     }
 
@@ -658,15 +641,6 @@ namespace AI
 
             if ( map_troop )
                 world.RemoveMapObject( map_troop );
-
-            // auto move hero
-            // disable: https://sourceforge.net/tracker/index.php?func=detail&aid=3155230&group_id=96859&atid=616180
-            /*
-                if(conf.ExtHeroAutoMove2BattleTarget() && allow_move)
-                {
-                    hero.Move2Dest(dst_index);
-                }
-            */
         }
     }
 

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -111,11 +111,7 @@ void Castle::OpenWell( void )
 
     WellRedrawInfoArea( cur_pt, monsterAnimInfo );
 
-    if ( !conf.ExtCastleAllowBuyFromWell() )
-        buttonMax.disable();
-    else {
-        buttonMax.draw();
-    }
+    buttonMax.draw();
 
     std::vector<u32> alldwellings;
     alldwellings.reserve( 6 );
@@ -141,63 +137,61 @@ void Castle::OpenWell( void )
             break;
 
         // extended version (click - buy dialog monster)
-        if ( conf.ExtCastleAllowBuyFromWell() ) {
-            if ( buttonMax.isEnabled() && le.MouseClickLeft( buttonMax.area() ) ) {
-                dwellings_t results;
-                Funds cur, total;
-                u32 can_recruit;
-                std::string str;
+        if ( buttonMax.isEnabled() && le.MouseClickLeft( buttonMax.area() ) ) {
+            dwellings_t results;
+            Funds cur, total;
+            u32 can_recruit;
+            std::string str;
 
-                for ( std::vector<u32>::const_iterator it = alldwellings.begin(); it != alldwellings.end(); ++it ) {
-                    if ( 0 != ( can_recruit = HowManyRecruitMonster( *this, *it, total, cur ) ) ) {
-                        results.push_back( dwelling_t( *it, can_recruit ) );
-                        total += cur;
-                        const Monster ms( race, GetActualDwelling( *it ) );
-                        str.append( ms.GetPluralName( can_recruit ) );
-                        str.append( " - " );
-                        str.append( GetString( can_recruit ) );
-                        str.append( "\n" );
-                    }
-                }
-
-                if ( str.empty() ) {
-                    bool isCreaturePresent = false;
-                    for ( int i = 0; i < CASTLEMAXMONSTER; ++i ) {
-                        if ( dwelling[i] > 0 ) {
-                            isCreaturePresent = true;
-                            break;
-                        }
-                    }
-                    if ( isCreaturePresent ) {
-                        Dialog::Message( "", _( "Not enough resources to buy monsters." ), Font::BIG, Dialog::OK );
-                    }
-                    else {
-                        Dialog::Message( "", _( "No monsters available for purchase." ), Font::BIG, Dialog::OK );
-                    }
-                }
-                else {
-                    if ( Dialog::YES == Dialog::ResourceInfo( _( "Buy Monsters:" ), str, total, Dialog::YES | Dialog::NO ) ) {
-                        for ( dwellings_t::const_iterator it = results.begin(); it != results.end(); ++it ) {
-                            const dwelling_t & dw = *it;
-                            RecruitMonsterFromDwelling( dw.first, dw.second );
-                        }
-                    }
+            for ( std::vector<u32>::const_iterator it = alldwellings.begin(); it != alldwellings.end(); ++it ) {
+                if ( 0 != ( can_recruit = HowManyRecruitMonster( *this, *it, total, cur ) ) ) {
+                    results.push_back( dwelling_t( *it, can_recruit ) );
+                    total += cur;
+                    const Monster ms( race, GetActualDwelling( *it ) );
+                    str.append( ms.GetPluralName( can_recruit ) );
+                    str.append( " - " );
+                    str.append( GetString( can_recruit ) );
+                    str.append( "\n" );
                 }
             }
 
-            if ( ( building & DWELLING_MONSTER1 ) && le.MouseClickLeft( rectMonster1 ) )
-                RecruitMonster( Dialog::RecruitMonster( Monster( race, DWELLING_MONSTER1 ), dwelling[0], false ) );
-            else if ( ( building & DWELLING_MONSTER2 ) && le.MouseClickLeft( rectMonster2 ) )
-                RecruitMonster( Dialog::RecruitMonster( Monster( race, GetActualDwelling( DWELLING_MONSTER2 ) ), dwelling[1], true ) );
-            else if ( ( building & DWELLING_MONSTER3 ) && le.MouseClickLeft( rectMonster3 ) )
-                RecruitMonster( Dialog::RecruitMonster( Monster( race, GetActualDwelling( DWELLING_MONSTER3 ) ), dwelling[2], true ) );
-            else if ( ( building & DWELLING_MONSTER4 ) && le.MouseClickLeft( rectMonster4 ) )
-                RecruitMonster( Dialog::RecruitMonster( Monster( race, GetActualDwelling( DWELLING_MONSTER4 ) ), dwelling[3], true ) );
-            else if ( ( building & DWELLING_MONSTER5 ) && le.MouseClickLeft( rectMonster5 ) )
-                RecruitMonster( Dialog::RecruitMonster( Monster( race, GetActualDwelling( DWELLING_MONSTER5 ) ), dwelling[4], true ) );
-            else if ( ( building & DWELLING_MONSTER6 ) && le.MouseClickLeft( rectMonster6 ) )
-                RecruitMonster( Dialog::RecruitMonster( Monster( race, GetActualDwelling( DWELLING_MONSTER6 ) ), dwelling[5], true ) );
+            if ( str.empty() ) {
+                bool isCreaturePresent = false;
+                for ( int i = 0; i < CASTLEMAXMONSTER; ++i ) {
+                    if ( dwelling[i] > 0 ) {
+                        isCreaturePresent = true;
+                        break;
+                    }
+                }
+                if ( isCreaturePresent ) {
+                    Dialog::Message( "", _( "Not enough resources to buy monsters." ), Font::BIG, Dialog::OK );
+                }
+                else {
+                    Dialog::Message( "", _( "No monsters available for purchase." ), Font::BIG, Dialog::OK );
+                }
+            }
+            else {
+                if ( Dialog::YES == Dialog::ResourceInfo( _( "Buy Monsters:" ), str, total, Dialog::YES | Dialog::NO ) ) {
+                    for ( dwellings_t::const_iterator it = results.begin(); it != results.end(); ++it ) {
+                        const dwelling_t & dw = *it;
+                        RecruitMonsterFromDwelling( dw.first, dw.second );
+                    }
+                }
+            }
         }
+
+        if ( ( building & DWELLING_MONSTER1 ) && le.MouseClickLeft( rectMonster1 ) )
+            RecruitMonster( Dialog::RecruitMonster( Monster( race, DWELLING_MONSTER1 ), dwelling[0], false ) );
+        else if ( ( building & DWELLING_MONSTER2 ) && le.MouseClickLeft( rectMonster2 ) )
+            RecruitMonster( Dialog::RecruitMonster( Monster( race, GetActualDwelling( DWELLING_MONSTER2 ) ), dwelling[1], true ) );
+        else if ( ( building & DWELLING_MONSTER3 ) && le.MouseClickLeft( rectMonster3 ) )
+            RecruitMonster( Dialog::RecruitMonster( Monster( race, GetActualDwelling( DWELLING_MONSTER3 ) ), dwelling[2], true ) );
+        else if ( ( building & DWELLING_MONSTER4 ) && le.MouseClickLeft( rectMonster4 ) )
+            RecruitMonster( Dialog::RecruitMonster( Monster( race, GetActualDwelling( DWELLING_MONSTER4 ) ), dwelling[3], true ) );
+        else if ( ( building & DWELLING_MONSTER5 ) && le.MouseClickLeft( rectMonster5 ) )
+            RecruitMonster( Dialog::RecruitMonster( Monster( race, GetActualDwelling( DWELLING_MONSTER5 ) ), dwelling[4], true ) );
+        else if ( ( building & DWELLING_MONSTER6 ) && le.MouseClickLeft( rectMonster6 ) )
+            RecruitMonster( Dialog::RecruitMonster( Monster( race, GetActualDwelling( DWELLING_MONSTER6 ) ), dwelling[5], true ) );
 
         if ( Game::AnimateInfrequentDelay( Game::CASTLE_UNIT_DELAY ) ) {
             cursor.Hide();
@@ -221,11 +215,9 @@ void Castle::WellRedrawInfoArea( const Point & cur_pt, const std::vector<RandomM
     Text text;
     Point dst_pt, pt;
 
-    if ( Settings::Get().ExtCastleAllowBuyFromWell() ) {
-        const fheroes2::Sprite & button = fheroes2::AGG::GetICN( ICN::BUYMAX, 0 );
-        Rect src_rt( 0, 461, button.width(), 19 );
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::WELLBKG, 0 ), src_rt.x, src_rt.y, display, cur_pt.x + button.width(), cur_pt.y + 461, src_rt.w, src_rt.h );
-    }
+    const fheroes2::Sprite & button = fheroes2::AGG::GetICN( ICN::BUYMAX, 0 );
+    Rect src_rt( 0, 461, button.width(), 19 );
+    fheroes2::Blit( fheroes2::AGG::GetICN( ICN::WELLBKG, 0 ), src_rt.x, src_rt.y, display, cur_pt.x + button.width(), cur_pt.y + 461, src_rt.w, src_rt.h );
 
     text.Set( _( "Town Population Information and Statistics" ), Font::BIG );
     dst_pt.x = cur_pt.x + 315 - text.w() / 2;

--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -213,13 +213,9 @@ void Dialog::ExtSettings( bool readonly )
     states.push_back( Settings::HEROES_SURRENDERING_GIVE_EXP );
     states.push_back( Settings::HEROES_RECALCULATE_MOVEMENT );
     states.push_back( Settings::HEROES_PATROL_ALLOW_PICKUP );
-    states.push_back( Settings::HEROES_AUTO_MOVE_BATTLE_DST );
     states.push_back( Settings::HEROES_TRANSCRIBING_SCROLLS );
     states.push_back( Settings::HEROES_ALLOW_BANNED_SECSKILLS );
     states.push_back( Settings::HEROES_ARENA_ANY_SKILLS );
-
-    if ( !conf.QVGA() )
-        states.push_back( Settings::CASTLE_ALLOW_BUY_FROM_WELL );
 
     states.push_back( Settings::CASTLE_ALLOW_GUARDIANS );
     states.push_back( Settings::CASTLE_MAGEGUILD_POINTS_TURN );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -770,15 +770,6 @@ void ActionToMonster( Heroes & hero, u32 obj, s32 dst_index )
 
         if ( map_troop )
             world.RemoveMapObject( map_troop );
-
-        // auto move hero
-        // disable: https://sourceforge.net/tracker/index.php?func=detail&aid=3155230&group_id=96859&atid=616180
-        /*
-        if(conf.ExtHeroAutoMove2BattleTarget() && allow_move)
-        {
-            hero.Move2Dest(dst_index);
-        }
-        */
     }
 }
 
@@ -828,11 +819,6 @@ void ActionToHeroes( Heroes & hero, u32 obj, s32 dst_index )
         // wins attacker
         if ( res.AttackerWins() ) {
             hero.IncreaseExperience( res.GetExperienceAttacker() );
-
-            // auto move hero
-            if ( conf.ExtHeroAutoMove2BattleTarget() && !disable_auto_move ) {
-                hero.Move2Dest( dst_index );
-            }
         }
         else
             // wins defender
@@ -918,12 +904,6 @@ void ActionToCastle( Heroes & hero, u32 obj, s32 dst_index )
             castle->Scoute();
             Interface::Basic::Get().SetRedraw( REDRAW_CASTLES );
             allow_enter = true;
-        }
-
-        // auto move hero to castle
-        if ( conf.ExtHeroAutoMove2BattleTarget() && allow_enter ) {
-            hero.Move2Dest( dst_index );
-            ActionToCastle( hero, MP2::OBJ_CASTLE, dst_index );
         }
     }
 }

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -302,10 +302,6 @@ const settings_t settingsFHeroes2[] = {
         _( "world: disable Barrow Mounds" ),
     },
     {
-        Settings::CASTLE_ALLOW_BUY_FROM_WELL,
-        _( "castle: allow buy from well" ),
-    },
-    {
         Settings::CASTLE_ALLOW_GUARDIANS,
         _( "castle: allow guardians" ),
     },
@@ -344,10 +340,6 @@ const settings_t settingsFHeroes2[] = {
     {
         Settings::HEROES_PATROL_ALLOW_PICKUP,
         _( "heroes: allow pickup objects for patrol" ),
-    },
-    {
-        Settings::HEROES_AUTO_MOVE_BATTLE_DST,
-        _( "heroes: after battle move to target cell" ),
     },
     {
         Settings::HEROES_TRANSCRIBING_SCROLLS,
@@ -478,7 +470,6 @@ Settings::Settings()
 {
     ExtSetModes( GAME_SHOW_SDL_LOGO );
     ExtSetModes( GAME_AUTOSAVE_ON );
-    ExtSetModes( CASTLE_ALLOW_BUY_FROM_WELL );
     ExtSetModes( WORLD_SHOW_VISITED_CONTENT );
     ExtSetModes( WORLD_ONLY_FIRST_MONSTER_ATTACK );
 
@@ -1600,11 +1591,6 @@ void Settings::ExtResetModes( u32 f )
     }
 }
 
-bool Settings::ExtCastleAllowBuyFromWell( void ) const
-{
-    return ExtModes( CASTLE_ALLOW_BUY_FROM_WELL );
-}
-
 bool Settings::ExtCastleGuildRestorePointsTurn( void ) const
 {
     return ExtModes( CASTLE_MAGEGUILD_POINTS_TURN );
@@ -1733,11 +1719,6 @@ bool Settings::ExtBattleSkipIncreaseDefense( void ) const
 bool Settings::ExtHeroAllowTranscribingScroll( void ) const
 {
     return ExtModes( HEROES_TRANSCRIBING_SCROLLS );
-}
-
-bool Settings::ExtHeroAutoMove2BattleTarget( void ) const
-{
-    return ExtModes( HEROES_AUTO_MOVE_BATTLE_DST );
 }
 
 bool Settings::ExtBattleShowBattleOrder( void ) const

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -154,13 +154,11 @@ public:
         WORLD_BAN_PLAGUES = 0x20000800,
         UNIONS_ALLOW_HERO_MEETINGS = 0x20001000,
         UNIONS_ALLOW_CASTLE_VISITING = 0x20002000,
-        // UNUSED			= 0x20004000,
-        HEROES_AUTO_MOVE_BATTLE_DST = 0x20008000,
+        // UNUSED = 0x20004000,
         WORLD_BAN_MONTHOF_MONSTERS = 0x20010000,
         HEROES_TRANSCRIBING_SCROLLS = 0x20020000,
         WORLD_NEW_VERSION_WEEKOF = 0x20040000,
         CASTLE_ALLOW_GUARDIANS = 0x20080000,
-        CASTLE_ALLOW_BUY_FROM_WELL = 0x20100000,
         HEROES_LEARN_SPELLS_WITH_DAY = 0x20200000,
         HEROES_ALLOW_BANNED_SECSKILLS = 0x20400000,
         HEROES_COST_DEPENDED_FROM_LEVEL = 0x20800000,
@@ -272,7 +270,6 @@ public:
     bool ExtHeroRecalculateMovement( void ) const;
     bool ExtHeroPatrolAllowPickup( void ) const;
     bool ExtHeroAllowTranscribingScroll( void ) const;
-    bool ExtHeroAutoMove2BattleTarget( void ) const;
     bool ExtHeroAllowBannedSecSkillsUpgrade( void ) const;
     bool ExtHeroArenaCanChoiseAnySkills( void ) const;
     bool ExtUnionsAllowCastleVisiting( void ) const;
@@ -302,7 +299,6 @@ public:
     bool ExtWorldExtObjectsCaptured( void ) const;
     bool ExtWorldGuardianObjectsTwoDefense( void ) const;
     bool ExtWorldDisableBarrowMounds( void ) const;
-    bool ExtCastleAllowBuyFromWell( void ) const;
     bool ExtCastleAllowGuardians( void ) const;
     bool ExtCastleAllowFlash( void ) const;
     bool ExtCastleGuildRestorePointsTurn( void ) const;


### PR DESCRIPTION
relates to #1272

- remove "heroes: after battle move to target cell" option
- make "castle: allow buy from well" always on (practically cannot turn off). This option doesn't change anything but makes an extra addition to the game