### PR TITLE
fix building tools

### DIFF
--- a/src/tools/icn2img.cpp
+++ b/src/tools/icn2img.cpp
@@ -164,10 +164,10 @@ int main( int argc, char ** argv )
         if ( buf.size() ) {
             Surface surf( Size( head.width, head.height ), /*false*/ true ); // accepting transparency
 
-            const RGBA clkey = RGBA( 0xFF, 0, 0xFF ), ColorBlack = RGBA( 0, 0, 0, 0xFF );
+            const RGBA clkey = RGBA( 0xFF, 0, 0xFF );
             surf.Fill( clkey );
             surf.SetColorKey( clkey );
-            surf.Fill( ColorBlack ); // filling with transparent color
+            surf.Fill( RGBA( 0, 0, 0, 0xFF ) ); // filling with transparent color
 
             if ( 0x20 == head.type )
                 SpriteDrawICNv2( surf, buf, debug );

--- a/src/tools/icn2img.cpp
+++ b/src/tools/icn2img.cpp
@@ -164,11 +164,9 @@ int main( int argc, char ** argv )
         if ( buf.size() ) {
             Surface surf( Size( head.width, head.height ), /*false*/ true ); // accepting transparency
 
-            const RGBA clkey = RGBA( 0xFF, 0, 0xFF );
+            const RGBA clkey = RGBA( 0xFF, 0, 0xFF ), ColorBlack = RGBA( 0, 0, 0, 0xFF );
             surf.Fill( clkey );
             surf.SetColorKey( clkey );
-
-            // surf.Fill(0xff, 0xff, 0xff);
             surf.Fill( ColorBlack ); // filling with transparent color
 
             if ( 0x20 == head.type )


### PR DESCRIPTION
Building with option WITH_TOOLS=1 is failed with error:
icn2img.cpp:172:24: error: ‘ColorBlack’ was not declared in this scope

This change fix it.