### PR TITLE
Validate and fix the path if hero was stuck

### DIFF
--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -847,6 +847,9 @@ void Heroes::RescanPathPassable( void )
 
 void Heroes::RescanPath( void )
 {
+    if ( !path.isValid() )
+        path.clear();
+
     if ( path.isValid() ) {
         const Maps::Tiles & tile = world.GetTiles( path.GetDestinationIndex() );
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -180,7 +180,7 @@ void Pathfinder::evaluateMap( int start, uint8_t skill )
         PathfindingNode & currentNode = _cache[currentNodeIdx];
 
         // check if current tile is protected, can move only to adjacent monster
-        if ( !monsters.empty() ) {
+        if ( currentNodeIdx != start && !monsters.empty() ) {
             for ( int monsterIndex : monsters ) {
                 const int direction = Maps::GetDirection( currentNodeIdx, monsterIndex );
 


### PR DESCRIPTION
Fixes #1647 . If stack of monsters was spawned nearby a hero his path could lock up in invalid state.