### PR TITLE
Combat AI: improve target selection

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -302,12 +302,15 @@ namespace AI
                 // Melee unit - Offensive action
                 const double distanceModifier = enemyArmyStrength / STRENGTH_DISTANCE_FACTOR;
                 double maxPriority = distanceModifier * ARENASIZE * -1;
+                double highestStrength = 0;
 
                 for ( const Unit * enemy : enemies ) {
                     // move node pair consists of move hex index and distance
                     std::pair<int, uint32_t> move = arena.CalculateMoveToUnit( *enemy );
+                    const double enemyValue = enemy->GetScoreQuality( currentUnit );
 
-                    if ( move.first != -1 && move.second <= currentUnitMoveRange ) {
+                    if ( move.first != -1 && move.second <= currentUnitMoveRange && highestStrength < enemyValue ) {
+                        highestStrength = enemyValue;
                         target = enemy;
 
                         if ( currentUnit.isFlying() ) {
@@ -336,7 +339,7 @@ namespace AI
                     }
                     else if ( target == NULL ) {
                         // For walking units that don't have a target within reach, pick based on priority
-                        const double unitPriority = enemy->GetScoreQuality( currentUnit ) - move.second * distanceModifier;
+                        const double unitPriority = enemyValue - move.second * distanceModifier;
                         if ( unitPriority > maxPriority ) {
                             maxPriority = unitPriority;
                             targetCell = move.first;

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -307,22 +307,27 @@ namespace AI
                     // move node pair consists of move hex index and distance
                     std::pair<int, uint32_t> move = arena.CalculateMoveToUnit( *enemy );
 
-                    if ( move.second <= currentUnitMoveRange ) {
+                    if ( move.first != -1 && move.second <= currentUnitMoveRange ) {
                         target = enemy;
 
                         if ( currentUnit.isFlying() ) {
-                            // look for valid adjacent tile
+                            // look for valid adjacent hex
                             const Indexes & around = Board::GetAroundIndexes( *target );
+
+                            int validCell = -1;
                             for ( const int cell : around ) {
                                 if ( arena.hexIsPassable( cell ) ) {
-                                    targetCell = cell;
+                                    validCell = cell;
                                     break;
                                 }
                             }
 
                             // it must have one, otherwise ArenaPathfinder is bugged
-                            if ( targetCell == -1 ) {
+                            if ( validCell == -1 ) {
                                 DEBUG( DBG_AI, DBG_WARN, "Flyer path error while targeting enemy " << enemy->GetName() << ". Check pathfinder." );
+                            }
+                            else {
+                                targetCell = validCell;
                             }
                         }
                         else {

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -344,7 +344,6 @@ namespace AI
                             maxPriority = unitPriority;
                             targetCell = move.first;
                         }
-                    
                     }
                 }
 

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -309,7 +309,7 @@ namespace AI
 
                 for ( const Unit * enemy : enemies ) {
                     // move node pair consists of move hex index and distance
-                    std::pair<int, uint32_t> move = arena.CalculateMoveToUnit( *enemy );
+                    const std::pair<int, uint32_t> move = arena.CalculateMoveToUnit( *enemy );
                     const double enemyValue = enemy->GetScoreQuality( currentUnit );
 
                     if ( move.first != -1 && move.second <= currentUnitMoveRange && highestStrength < enemyValue ) {

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -573,6 +573,31 @@ Battle::Indexes Battle::Arena::CalculatePath( const Battle::Unit & unit, int32_t
     return _pathfinder.getPath( indexTo );
 }
 
+std::pair<int, uint32_t> Battle::Arena::CalculateMoveToUnit( const Unit & target )
+{
+    std::pair<int, uint32_t> result = {-1, 0};
+
+    const Position & pos = target.GetPosition();
+    const Cell * head = pos.GetHead();
+    const Cell * tail = pos.GetTail();
+
+    if ( head ) {
+        const ArenaNode & headNode = _pathfinder.getNode( head->GetIndex() );
+        result.first = headNode._from;
+        result.second = headNode._cost;
+    }
+
+    if ( tail ) {
+        const ArenaNode & tailNode = _pathfinder.getNode( tail->GetIndex() );
+        if ( tailNode._cost < result.second ) {
+            result.first = tailNode._from;
+            result.second = tailNode._cost;
+        }
+    }
+
+    return result;
+}
+
 uint32_t Battle::Arena::CalculateMoveDistance( int32_t indexTo )
 {
     return Board::isValidIndex( indexTo ) ? _pathfinder.getDistance( indexTo ) : MAXU16;

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -575,7 +575,7 @@ Battle::Indexes Battle::Arena::CalculatePath( const Battle::Unit & unit, int32_t
 
 std::pair<int, uint32_t> Battle::Arena::CalculateMoveToUnit( const Unit & target )
 {
-    std::pair<int, uint32_t> result = {-1, 0};
+    std::pair<int, uint32_t> result = {-1, MAXU16};
 
     const Position & pos = target.GetPosition();
     const Cell * head = pos.GetHead();
@@ -583,13 +583,15 @@ std::pair<int, uint32_t> Battle::Arena::CalculateMoveToUnit( const Unit & target
 
     if ( head ) {
         const ArenaNode & headNode = _pathfinder.getNode( head->GetIndex() );
-        result.first = headNode._from;
-        result.second = headNode._cost;
+        if ( headNode._from != -1 ) {
+            result.first = headNode._from;
+            result.second = headNode._cost;
+        }
     }
 
     if ( tail ) {
         const ArenaNode & tailNode = _pathfinder.getNode( tail->GetIndex() );
-        if ( tailNode._cost < result.second ) {
+        if ( tailNode._from != -1 && tailNode._cost < result.second ) {
             result.first = tailNode._from;
             result.second = tailNode._cost;
         }

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -102,11 +102,15 @@ namespace Battle
 
         void FadeArena( void ) const;
 
-        Indexes GetPath( const Unit &, const Position & );
-        Indexes CalculatePath( const Unit & unit, int32_t indexTo );
+        // returns pair with move cell index and distance
+        std::pair<int, uint32_t> CalculateMoveToUnit( const Unit & target );
+
         uint32_t CalculateMoveDistance( int32_t indexTo );
         bool hexIsAccessible( int32_t indexTo );
         bool hexIsPassable( int32_t indexTo );
+        Indexes GetPath( const Unit &, const Position & );
+        Indexes CalculatePath( const Unit & unit, int32_t indexTo );
+
         void ApplyAction( Command & );
 
         TargetsInfo GetTargetsForDamage( Unit &, Unit &, s32 );

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -98,6 +98,11 @@ namespace Battle
         }
     }
 
+    const ArenaNode & ArenaPathfinder::getNode( int targetCell ) const
+    {
+        return _cache[targetCell];
+    }
+
     uint32_t ArenaPathfinder::getDistance( int targetCell ) const
     {
         return _cache[targetCell]._cost;
@@ -168,7 +173,7 @@ namespace Battle
                 if ( it->isPassable1( false ) ) {
                     node._isOpen = true;
                     node._from = headIdx;
-                    node._cost = 1;
+                    node._cost = board.GetDistance( headIdx, idx );
                 }
                 else {
                     node._isOpen = false;
@@ -184,7 +189,7 @@ namespace Battle
                         if ( hexIsPassable( cell ) ) {
                             unitNode._isOpen = false;
                             unitNode._from = headIdx;
-                            unitNode._cost = 1;
+                            unitNode._cost = board.GetDistance( headIdx, cell );
                             break;
                         }
                     }

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -168,7 +168,7 @@ namespace Battle
                     = !unitIsWide || ( x < ARENAW - 2 && board.GetCell( idx + 1 )->isPassable1( true ) ) || ( x > 0 && board.GetCell( idx - 1 )->isPassable1( true ) );
 
                 ArenaNode & node = _cache[idx];
-                if ( it->isPassable1( false ) ) {
+                if ( it->isPassable1( true ) ) {
                     node._isOpen = true;
                     node._from = headIdx;
                     node._cost = board.GetDistance( headIdx, idx );
@@ -183,11 +183,12 @@ namespace Battle
                     ArenaNode & unitNode = _cache[unitIdx];
 
                     const Indexes & around = board.GetAroundIndexes( unitIdx );
-                    for ( const int cell : around ) {
-                        if ( hexIsPassable( cell ) ) {
+                    for ( const int cellIdx : around ) {
+                        const Cell * cell = board.GetCell( cellIdx );
+                        if ( hexIsPassable( cellIdx ) ) {
                             unitNode._isOpen = false;
                             unitNode._from = headIdx;
-                            unitNode._cost = board.GetDistance( headIdx, cell );
+                            unitNode._cost = board.GetDistance( headIdx, cellIdx );
                             break;
                         }
                     }

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -47,8 +47,10 @@ namespace Battle
             }
             break;
         case Battle::RIGHT:
-            if ( x < ARENAW - 1 )
+            if ( x < ARENAW - 1 ) {
                 newIndex = fromCell + 1;
+                wideUnitOffset = -1;
+            }
             break;
         case Battle::BOTTOM_RIGHT:
             if ( y < ARENAH - 1 && ( x < ARENAW - 1 || isOddRow ) ) {
@@ -63,8 +65,10 @@ namespace Battle
             }
             break;
         case Battle::LEFT:
-            if ( x > 0 )
+            if ( x > 0 ) {
                 newIndex = fromCell - 1;
+                wideUnitOffset = 1;
+            }
             break;
         default:
             return -1;
@@ -74,7 +78,7 @@ namespace Battle
         if ( newIndex == -1 || !Board::GetCell( newIndex )->isPassable1( false ) )
             return -1;
 
-        if ( isWide && ( x + wideUnitOffset < 0 || x + wideUnitOffset > ARENAW - 1 || !Board::GetCell( newIndex + wideUnitOffset )->isPassable1( true ) ) )
+        if ( isWide && ( x + wideUnitOffset < 0 || x + wideUnitOffset > ARENAW - 1 || !Board::GetCell( newIndex + wideUnitOffset )->isPassable1( false ) ) )
             return -1;
 
         return newIndex;
@@ -203,6 +207,7 @@ namespace Battle
                     if ( newNode != -1 ) {
                         const uint16_t cost = _cache[fromNode]._cost;
                         ArenaNode & node = _cache[newNode];
+
                         if ( Board::GetCell( newNode )->GetUnit() && cost < node._cost ) {
                             node._isOpen = false;
                             node._from = fromNode;

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -123,7 +123,6 @@ namespace Battle
         std::vector<int> path;
 
         int nodeID = targetCell;
-        const ArenaNode & node = _cache[targetCell];
         while ( _cache[nodeID]._cost != 0 ) {
             path.push_back( nodeID );
             nodeID = _cache[nodeID]._from;
@@ -161,7 +160,6 @@ namespace Battle
 
         if ( unit.isFlying() ) {
             const Board & board = *Arena::GetBoard();
-            const int headIdx = unitHead->GetIndex();
 
             for ( Board::const_iterator it = board.begin(); it != board.end(); ++it ) {
                 const int idx = it->GetIndex();

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -115,7 +115,7 @@ namespace Battle
 
     bool ArenaPathfinder::hexIsPassable( int targetCell ) const
     {
-        return ( _cache[targetCell]._cost == 0 || _cache[targetCell]._isOpen ) && _cache[targetCell]._from != -1;
+        return _cache[targetCell]._cost == 0 || ( _cache[targetCell]._isOpen && _cache[targetCell]._from != -1 );
     }
 
     std::vector<int> ArenaPathfinder::getPath( int targetCell ) const
@@ -178,7 +178,8 @@ namespace Battle
                 }
             }
             for ( Board::const_iterator it = board.begin(); it != board.end(); ++it ) {
-                if ( it->GetUnit() ) {
+                const Unit * boardUnit = it->GetUnit();
+                if ( boardUnit && boardUnit->GetUID() != unit.GetUID() ) {
                     const int unitIdx = it->GetIndex();
                     ArenaNode & unitNode = _cache[unitIdx];
 

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -184,12 +184,11 @@ namespace Battle
                     ArenaNode & unitNode = _cache[unitIdx];
 
                     const Indexes & around = board.GetAroundIndexes( unitIdx );
-                    for ( const int cellIdx : around ) {
-                        const Cell * cell = board.GetCell( cellIdx );
-                        if ( hexIsPassable( cellIdx ) ) {
+                    for ( const int cell : around ) {
+                        if ( hexIsPassable( cell ) ) {
                             unitNode._isOpen = false;
                             unitNode._from = headIdx;
-                            unitNode._cost = board.GetDistance( headIdx, cellIdx );
+                            unitNode._cost = board.GetDistance( headIdx, cell );
                             break;
                         }
                     }

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -56,6 +56,7 @@ namespace Battle
         void calculate( const Unit & unit );
         std::vector<int> getPath( int targetCell ) const;
         uint32_t getDistance( int targetCell ) const;
+        const ArenaNode & getNode( int targetCell ) const;
         bool hexIsAccessible( int targetCell ) const;
         bool hexIsPassable( int targetCell ) const;
 


### PR DESCRIPTION
Added strength - distance ratio (inspired by OG logic) to make sure they don't target only the strongest unit.
Added logic handling AI attacking castles.
Updated decision tree to avoid going over target selection twice.
Additional fixes for battle arena pathfinder (mostly for flying units).