### PR TITLE
Fix puzzle and ultimate artifact logic

### DIFF
--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -356,7 +356,7 @@ fheroes2::Image Interface::GameArea::GenerateUltimateArtifactAreaSurface( s32 in
                                + Point( result.width() / 2, result.height() / 2 ) );
 
         fheroes2::Blit( marker, result, markerPos.x, markerPos.y + 8 );
-        fheroes2::ApplyPalette( result, PAL::GetPalette( Settings::Get().ExtGameEvilInterface() ? PAL::GRAY : PAL::BROWN ) );
+        fheroes2::ApplyPalette( result, PAL::GetPalette( PAL::TAN ) );
 
         gamearea.SetAreaPosition( origPosition.x, origPosition.y, origPosition.w, origPosition.h );
     }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -119,7 +119,7 @@ void Interface::GameArea::BlitOnTile( fheroes2::Image & dst, const fheroes2::Ima
     }
 }
 
-void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag ) const
+void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzleDraw ) const
 {
     const Rect tileROI = GetVisibleTileROI();
 
@@ -145,7 +145,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag ) const
 
                 // map object
                 if ( flag & LEVEL_BOTTOM )
-                    tile.RedrawObjects( dst );
+                    tile.RedrawObjects( dst, isPuzzleDraw );
             }
         }
     }
@@ -163,7 +163,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag ) const
             const Maps::Tiles & tile = world.GetTiles( offsetX, offsetY );
 
             // map object
-            if ( flag & LEVEL_OBJECTS )
+            if ( flag & LEVEL_OBJECTS && !isPuzzleDraw )
                 tile.RedrawMonstersAndBoat( dst );
 
             // top
@@ -349,7 +349,7 @@ fheroes2::Image Interface::GameArea::GenerateUltimateArtifactAreaSurface( s32 in
         gamearea.SetCenter( pt );
 
         const Rect & rectMaps = gamearea.GetVisibleTileROI();
-        gamearea.Redraw( result, LEVEL_BOTTOM | LEVEL_TOP );
+        gamearea.Redraw( result, LEVEL_BOTTOM | LEVEL_TOP, true );
 
         const fheroes2::Sprite & marker = fheroes2::AGG::GetICN( ICN::ROUTE, 0 );
         const Point markerPos( gamearea.GetRelativeTilePosition( pt ) - gamearea._middlePoint() - Point( gamearea._windowROI.x, gamearea._windowROI.y )

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -144,7 +144,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag ) const
                     tile.RedrawBottom( dst, !( flag & LEVEL_OBJECTS ) );
 
                 // map object
-                if ( flag & LEVEL_OBJECTS )
+                if ( flag & LEVEL_BOTTOM )
                     tile.RedrawObjects( dst );
             }
         }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -141,7 +141,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag ) const
 
                 // bottom
                 if ( flag & LEVEL_BOTTOM )
-                    tile.RedrawBottom( dst, !( flag & LEVEL_OBJECTS ) );
+                    tile.RedrawBottom( dst );
 
                 // map object
                 if ( flag & LEVEL_BOTTOM )
@@ -345,23 +345,12 @@ fheroes2::Image Interface::GameArea::GenerateUltimateArtifactAreaSurface( s32 in
         const Rect origPosition( gamearea._windowROI );
         gamearea.SetAreaPosition( 0, 0, result.width(), result.height() );
 
-        const Rect & rectMaps = gamearea.GetVisibleTileROI();
         Point pt = Maps::GetPoint( index );
-
         gamearea.SetCenter( pt );
+
+        const Rect & rectMaps = gamearea.GetVisibleTileROI();
         gamearea.Redraw( result, LEVEL_BOTTOM | LEVEL_TOP );
 
-        // blit marker
-        for ( u32 ii = 0; ii < rectMaps.h; ++ii )
-            if ( index < Maps::GetIndexFromAbsPoint( rectMaps.x + rectMaps.w - 1, rectMaps.y + ii ) ) {
-                pt.y = ii;
-                break;
-            }
-        for ( u32 ii = 0; ii < rectMaps.w; ++ii )
-            if ( index == Maps::GetIndexFromAbsPoint( rectMaps.x + ii, rectMaps.y + pt.y ) ) {
-                pt.x = ii;
-                break;
-            }
         const fheroes2::Sprite & marker = fheroes2::AGG::GetICN( ICN::ROUTE, 0 );
         const Point markerPos( gamearea.GetRelativeTilePosition( pt ) - gamearea._middlePoint() - Point( gamearea._windowROI.x, gamearea._windowROI.y )
                                + Point( result.width() / 2, result.height() / 2 ) );

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -141,7 +141,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
 
                 // bottom
                 if ( flag & LEVEL_BOTTOM )
-                    tile.RedrawBottom( dst );
+                    tile.RedrawBottom( dst, isPuzzleDraw );
 
                 // map object
                 if ( flag & LEVEL_BOTTOM )

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -72,7 +72,7 @@ namespace Interface
         void SetCenter( const Point & );
         void SetRedraw( void ) const;
 
-        void Redraw( fheroes2::Image & dst, int ) const;
+        void Redraw( fheroes2::Image & dst, int flag, bool isPuzzleDraw = false ) const;
 
         void BlitOnTile( fheroes2::Image & src, const fheroes2::Image & dst, int32_t ox, int32_t oy, const Point & mp, bool flip = false, uint8_t alpha = 255 ) const;
         void BlitOnTile( fheroes2::Image & src, const fheroes2::Sprite & dst, const Point & mp ) const;

--- a/src/fheroes2/kingdom/puzzle.cpp
+++ b/src/fheroes2/kingdom/puzzle.cpp
@@ -233,7 +233,7 @@ void PuzzlesDraw( const Puzzle & pzl, const fheroes2::Image & sf, s32 dstx, s32 
     int alpha = 250;
     LocalEvent & le = LocalEvent::Get();
 
-    while ( le.HandleEvents() && 0 < alpha ) {
+    while ( le.HandleEvents() && 0 <= alpha ) {
         if ( Game::AnimateInfrequentDelay( Game::PUZZLE_FADE_DELAY ) ) {
             cursor.Hide();
             fheroes2::Blit( sf, display, dstx, dsty );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1444,13 +1444,13 @@ void Maps::Tiles::RedrawPassable( fheroes2::Image & dst ) const
 #endif
 }
 
-void Maps::Tiles::RedrawObjects( fheroes2::Image & dst ) const
+void Maps::Tiles::RedrawObjects( fheroes2::Image & dst, bool isPuzzleDraw ) const
 {
     int object = GetObject();
 
     // monsters and boats will be drawn later, on top of everything else
     // hero object is accepted here since it replaces what was there originally
-    if ( object != MP2::OBJ_BOAT && object != MP2::OBJ_MONSTER ) {
+    if ( object != MP2::OBJ_BOAT && object != MP2::OBJ_MONSTER && ( !isPuzzleDraw || !MP2::isHiddenForPuzzle( objectTileset, objectIndex ) ) ) {
         const int icn = MP2::GetICNObject( objectTileset );
 
         if ( ICN::UNKNOWN != icn ) {

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1394,7 +1394,7 @@ void Maps::Tiles::RedrawEmptyTile( fheroes2::Image & dst, const Point & mp )
     }
 }
 
-void Maps::Tiles::RedrawAddon( fheroes2::Image & dst, const Addons & addon ) const
+void Maps::Tiles::RedrawAddon( fheroes2::Image & dst, const Addons & addon, bool isPuzzleDraw ) const
 {
     Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
     const Point mp = Maps::GetPoint( GetIndex() );
@@ -1404,7 +1404,7 @@ void Maps::Tiles::RedrawAddon( fheroes2::Image & dst, const Addons & addon ) con
             const u8 & index = ( *it ).index;
             const int icn = MP2::GetICNObject( ( *it ).object );
 
-            if ( ICN::UNKNOWN != icn && ICN::MINIHERO != icn && ICN::MONS32 != icn ) {
+            if ( ICN::UNKNOWN != icn && ICN::MINIHERO != icn && ICN::MONS32 != icn && ( !isPuzzleDraw || !MP2::isHiddenForPuzzle( it->object, index ) ) ) {
                 const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icn, index );
                 area.BlitOnTile( dst, sprite, sprite.x(), sprite.y(), mp );
 
@@ -1418,9 +1418,9 @@ void Maps::Tiles::RedrawAddon( fheroes2::Image & dst, const Addons & addon ) con
     }
 }
 
-void Maps::Tiles::RedrawBottom( fheroes2::Image & dst ) const
+void Maps::Tiles::RedrawBottom( fheroes2::Image & dst, bool isPuzzleDraw ) const
 {
-    RedrawAddon( dst, addons_level1 );
+    RedrawAddon( dst, addons_level1, isPuzzleDraw );
 }
 
 void Maps::Tiles::RedrawPassable( fheroes2::Image & dst ) const

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -255,7 +255,7 @@ int Maps::TilesAddon::GetLoyaltyObject( const Maps::TilesAddon & addon )
 
 int Maps::Tiles::GetPassable( uint32_t tileset, uint32_t index )
 {
-    int icn = MP2::GetICNObject( tileset );
+    const int icn = MP2::GetICNObject( tileset );
 
     switch ( icn ) {
     case ICN::MTNSNOW:
@@ -1092,7 +1092,7 @@ bool isImpassableIfOverlayed( uint8_t objectTileset, uint8_t icnIndex )
 
 bool Exclude4LongObject( const Maps::TilesAddon & ta )
 {
-    int icn = MP2::GetICNObject( ta.object );
+    const int icn = MP2::GetICNObject( ta.object );
     return Maps::Tiles::isShadowSprite( ta.object, ta.index ) || icn == ICN::ROAD || icn == ICN::STREAM || ( icn == ICN::OBJNMUL2 && ta.index < 14 );
 }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1394,17 +1394,13 @@ void Maps::Tiles::RedrawEmptyTile( fheroes2::Image & dst, const Point & mp )
     }
 }
 
-void Maps::Tiles::RedrawAddon( fheroes2::Image & dst, const Addons & addon, bool skipObjs ) const
+void Maps::Tiles::RedrawAddon( fheroes2::Image & dst, const Addons & addon ) const
 {
     Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
     const Point mp = Maps::GetPoint( GetIndex() );
 
     if ( ( area.GetVisibleTileROI() & mp ) && !addon.empty() ) {
         for ( Addons::const_iterator it = addon.begin(); it != addon.end(); ++it ) {
-            // skip
-            if ( skipObjs && MP2::isRemoveObject( GetObject() ) )
-                continue;
-
             const u8 & index = ( *it ).index;
             const int icn = MP2::GetICNObject( ( *it ).object );
 
@@ -1422,9 +1418,9 @@ void Maps::Tiles::RedrawAddon( fheroes2::Image & dst, const Addons & addon, bool
     }
 }
 
-void Maps::Tiles::RedrawBottom( fheroes2::Image & dst, bool skipObjs ) const
+void Maps::Tiles::RedrawBottom( fheroes2::Image & dst ) const
 {
-    RedrawAddon( dst, addons_level1, skipObjs );
+    RedrawAddon( dst, addons_level1 );
 }
 
 void Maps::Tiles::RedrawPassable( fheroes2::Image & dst ) const
@@ -1589,7 +1585,7 @@ void Maps::Tiles::RedrawBottom4Hero( fheroes2::Image & dst ) const
     }
 }
 
-void Maps::Tiles::RedrawTop( fheroes2::Image & dst, bool skipObjs ) const
+void Maps::Tiles::RedrawTop( fheroes2::Image & dst ) const
 {
     const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
     const Point mp = Maps::GetPoint( GetIndex() );
@@ -1611,7 +1607,7 @@ void Maps::Tiles::RedrawTop( fheroes2::Image & dst, bool skipObjs ) const
         }
     }
 
-    RedrawAddon( dst, addons_level2, skipObjs );
+    RedrawAddon( dst, addons_level2 );
 }
 
 void Maps::Tiles::RedrawTop4Hero( fheroes2::Image & dst, bool skip_ground ) const

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -499,66 +499,7 @@ bool Maps::TilesAddon::isX_LOC123( const TilesAddon & ta )
 
 bool Maps::TilesAddon::isShadow( const TilesAddon & ta )
 {
-    const int icn = MP2::GetICNObject( ta.object );
-
-    switch ( icn ) {
-    case ICN::MTNDSRT:
-    case ICN::MTNGRAS:
-    case ICN::MTNLAVA:
-    case ICN::MTNMULT:
-    case ICN::MTNSNOW:
-    case ICN::MTNSWMP:
-        return ObjMnts1::isShadow( ta.index );
-
-    case ICN::MTNCRCK:
-    case ICN::MTNDIRT:
-        return ObjMnts2::isShadow( ta.index );
-
-    case ICN::TREDECI:
-    case ICN::TREEVIL:
-    case ICN::TREFALL:
-    case ICN::TREFIR:
-    case ICN::TREJNGL:
-    case ICN::TRESNOW:
-        return ObjTree::isShadow( ta.index );
-
-    case ICN::OBJNCRCK:
-        return ObjCrck::isShadow( ta.index );
-    case ICN::OBJNDIRT:
-        return ObjDirt::isShadow( ta.index );
-    case ICN::OBJNDSRT:
-        return ObjDsrt::isShadow( ta.index );
-    case ICN::OBJNGRA2:
-        return ObjGra2::isShadow( ta.index );
-    case ICN::OBJNGRAS:
-        return ObjGras::isShadow( ta.index );
-    case ICN::OBJNMUL2:
-        return ObjMul2::isShadow( ta.index );
-    case ICN::OBJNMULT:
-        return ObjMult::isShadow( ta.index );
-    case ICN::OBJNSNOW:
-        return ObjSnow::isShadow( ta.index );
-    case ICN::OBJNSWMP:
-        return ObjSwmp::isShadow( ta.index );
-    case ICN::OBJNWAT2:
-        return ObjWat2::isShadow( ta.index );
-    case ICN::OBJNWATR:
-        return ObjWatr::isShadow( ta.index );
-
-    case ICN::OBJNARTI:
-    case ICN::OBJNRSRC:
-        return 0 == ( ta.index % 2 );
-
-    case ICN::OBJNTWRD:
-        return ta.index > 31;
-    case ICN::OBJNTWSH:
-        return true;
-
-    default:
-        break;
-    }
-
-    return false;
+    return Tiles::isShadowSprite( ta.object, ta.index );
 }
 
 bool Maps::TilesAddon::isMounts( const TilesAddon & ta )
@@ -737,6 +678,70 @@ bool Maps::TilesAddon::isTrees( const TilesAddon & ta )
         if ( ta.index == 80 || ( ta.index > 82 && ta.index < 86 ) || ta.index == 87 || ( ta.index > 88 && ta.index < 92 ) )
             return true;
         break;
+
+    default:
+        break;
+    }
+
+    return false;
+}
+
+bool Maps::Tiles::isShadowSprite( uint8_t tileset, uint8_t icnIndex )
+{
+    const int icn = MP2::GetICNObject( tileset );
+
+    switch ( icn ) {
+    case ICN::MTNDSRT:
+    case ICN::MTNGRAS:
+    case ICN::MTNLAVA:
+    case ICN::MTNMULT:
+    case ICN::MTNSNOW:
+    case ICN::MTNSWMP:
+        return ObjMnts1::isShadow( icnIndex );
+
+    case ICN::MTNCRCK:
+    case ICN::MTNDIRT:
+        return ObjMnts2::isShadow( icnIndex );
+
+    case ICN::TREDECI:
+    case ICN::TREEVIL:
+    case ICN::TREFALL:
+    case ICN::TREFIR:
+    case ICN::TREJNGL:
+    case ICN::TRESNOW:
+        return ObjTree::isShadow( icnIndex );
+
+    case ICN::OBJNCRCK:
+        return ObjCrck::isShadow( icnIndex );
+    case ICN::OBJNDIRT:
+        return ObjDirt::isShadow( icnIndex );
+    case ICN::OBJNDSRT:
+        return ObjDsrt::isShadow( icnIndex );
+    case ICN::OBJNGRA2:
+        return ObjGra2::isShadow( icnIndex );
+    case ICN::OBJNGRAS:
+        return ObjGras::isShadow( icnIndex );
+    case ICN::OBJNMUL2:
+        return ObjMul2::isShadow( icnIndex );
+    case ICN::OBJNMULT:
+        return ObjMult::isShadow( icnIndex );
+    case ICN::OBJNSNOW:
+        return ObjSnow::isShadow( icnIndex );
+    case ICN::OBJNSWMP:
+        return ObjSwmp::isShadow( icnIndex );
+    case ICN::OBJNWAT2:
+        return ObjWat2::isShadow( icnIndex );
+    case ICN::OBJNWATR:
+        return ObjWatr::isShadow( icnIndex );
+
+    case ICN::OBJNARTI:
+    case ICN::OBJNRSRC:
+        return 0 == ( icnIndex % 2 );
+
+    case ICN::OBJNTWRD:
+        return icnIndex > 31;
+    case ICN::OBJNTWSH:
+        return true;
 
     default:
         break;
@@ -1778,10 +1783,7 @@ void Maps::Tiles::FixObject( void )
 
 bool Maps::Tiles::GoodForUltimateArtifact( void ) const
 {
-    return !isWater()
-           && ( addons_level1.empty()
-                || addons_level1.size() == static_cast<size_t>( std::count_if( addons_level1.begin(), addons_level1.end(), std::ptr_fun( &TilesAddon::isShadow ) ) ) )
-           && isPassable( Direction::CENTER, false, true );
+    return !isWater() && ( addons_level1.empty() || isShadow() ) && isPassable( Direction::CENTER, false, true );
 }
 
 bool TileIsGround( s32 index, int ground )
@@ -1841,7 +1843,7 @@ bool Maps::Tiles::isStream( void ) const
 
 bool Maps::Tiles::isShadow( void ) const
 {
-    return addons_level1.size() != std::count_if( addons_level1.begin(), addons_level1.end(), TilesAddon::isShadow );
+    return isShadowSprite( objectTileset, objectIndex ) || addons_level1.size() != std::count_if( addons_level1.begin(), addons_level1.end(), TilesAddon::isShadow );
 }
 
 bool Maps::Tiles::hasSpriteAnimation() const

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -163,7 +163,7 @@ namespace Maps
         void RedrawBottom4Hero( fheroes2::Image & ) const;
         void RedrawTop( fheroes2::Image & dst ) const;
         void RedrawTop4Hero( fheroes2::Image &, bool skip_ground ) const;
-        void RedrawObjects( fheroes2::Image & ) const;
+        void RedrawObjects( fheroes2::Image & dst, bool isPuzzleDraw = false ) const;
         void RedrawMonstersAndBoat( fheroes2::Image & ) const;
         void RedrawFogs( fheroes2::Image &, int ) const;
         void RedrawAddon( fheroes2::Image & dst, const Addons & addon ) const;

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -159,14 +159,14 @@ namespace Maps
 
         void RedrawTile( fheroes2::Image & ) const;
         static void RedrawEmptyTile( fheroes2::Image & dst, const Point & mp );
-        void RedrawBottom( fheroes2::Image & dst ) const;
+        void RedrawBottom( fheroes2::Image & dst, bool isPuzzleDraw = false ) const;
         void RedrawBottom4Hero( fheroes2::Image & ) const;
         void RedrawTop( fheroes2::Image & dst ) const;
         void RedrawTop4Hero( fheroes2::Image &, bool skip_ground ) const;
         void RedrawObjects( fheroes2::Image & dst, bool isPuzzleDraw = false ) const;
         void RedrawMonstersAndBoat( fheroes2::Image & ) const;
         void RedrawFogs( fheroes2::Image &, int ) const;
-        void RedrawAddon( fheroes2::Image & dst, const Addons & addon ) const;
+        void RedrawAddon( fheroes2::Image & dst, const Addons & addon, bool isPuzzleDraw = false ) const;
         void RedrawPassable( fheroes2::Image & ) const;
 
         void AddonsPushLevel1( const MP2::mp2tile_t & );

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -159,14 +159,14 @@ namespace Maps
 
         void RedrawTile( fheroes2::Image & ) const;
         static void RedrawEmptyTile( fheroes2::Image & dst, const Point & mp );
-        void RedrawBottom( fheroes2::Image & dst, bool skipObjs = false ) const;
+        void RedrawBottom( fheroes2::Image & dst ) const;
         void RedrawBottom4Hero( fheroes2::Image & ) const;
-        void RedrawTop( fheroes2::Image & dst, bool skipObjs = false ) const;
+        void RedrawTop( fheroes2::Image & dst ) const;
         void RedrawTop4Hero( fheroes2::Image &, bool skip_ground ) const;
         void RedrawObjects( fheroes2::Image & ) const;
         void RedrawMonstersAndBoat( fheroes2::Image & ) const;
         void RedrawFogs( fheroes2::Image &, int ) const;
-        void RedrawAddon( fheroes2::Image & dst, const Addons & addon, bool skipObjs = false ) const;
+        void RedrawAddon( fheroes2::Image & dst, const Addons & addon ) const;
         void RedrawPassable( fheroes2::Image & ) const;
 
         void AddonsPushLevel1( const MP2::mp2tile_t & );

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -68,7 +68,6 @@ namespace Maps
         std::string String( int level ) const;
 
         static bool isStream( const TilesAddon & );
-        static bool isRoad( const TilesAddon & );
         static bool isShadow( const TilesAddon & );
         static bool isRoadObject( const TilesAddon & );
 
@@ -225,6 +224,7 @@ namespace Maps
         Heroes * GetHeroes( void ) const;
         void SetHeroes( Heroes * );
 
+        static bool isShadowSprite( uint8_t tileset, uint8_t icnIndex );
         static void UpdateAbandoneMineLeftSprite( uint8_t & tileset, uint8_t & index, int resource );
         static void UpdateAbandoneMineRightSprite( uint8_t & tileset, uint8_t & index );
         static int GetPassable( uint32_t tileset, uint32_t index );

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -67,7 +67,6 @@ namespace Maps
 
         std::string String( int level ) const;
 
-        static bool isStream( const TilesAddon & );
         static bool isShadow( const TilesAddon & );
         static bool isRoadObject( const TilesAddon & );
 

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -220,6 +220,16 @@ int MP2::GetICNObject( int tileset )
     return ICN::UNKNOWN;
 }
 
+bool MP2::isHiddenForPuzzle( uint8_t tileset, uint8_t index )
+{
+    const int icnID = tileset >> 2;
+    // Values extracted from 64-byte array at 0x004F0B50 offset of HEROES2W file
+    if ( icnID < 22 || icnID == 46 || ( icnID == 56 && index == 140 ) )
+        return true;
+
+    return false;
+}
+
 const char * MP2::StringObject( int object )
 {
     switch ( object ) {

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -539,6 +539,7 @@ namespace MP2
     int GetICNObject( int tileset );
     const char * StringObject( int object );
 
+    bool isHiddenForPuzzle( uint8_t tileset, uint8_t index );
     bool isActionObject( int obj, bool water );
     bool isGroundObject( int obj );
     bool isWaterObject( int obj );

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -1577,9 +1577,10 @@ void World::PostLoad( void )
     }
     else {
         // remove ultimate artifact sprite
-        ultimate_artifact.Set( it->GetIndex(), Artifact::FromMP2IndexSprite( it->GetObjectSpriteIndex() ) );
+        uint8_t objectIndex = it->GetObjectSpriteIndex();
         it->Remove( it->GetObjectUID() );
         it->SetObject( MP2::OBJ_ZERO );
+        ultimate_artifact.Set( it->GetIndex(), Artifact::FromMP2IndexSprite( objectIndex ) );
         ultimate_pos = ( *it ).GetCenter();
     }
 

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -1577,7 +1577,7 @@ void World::PostLoad( void )
     }
     else {
         // remove ultimate artifact sprite
-        uint8_t objectIndex = it->GetObjectSpriteIndex();
+        const uint8_t objectIndex = it->GetObjectSpriteIndex();
         it->Remove( it->GetObjectUID() );
         it->SetObject( MP2::OBJ_ZERO );
         ultimate_artifact.Set( it->GetIndex(), Artifact::FromMP2IndexSprite( objectIndex ) );


### PR DESCRIPTION
Fixes #145 . Fixes #1523 . Fixes #1524 . Fixes #1526 . Fixes #1537 . Fixes #1818 .
Might be fixing #1536 as well, that issue is defined very vaguely.

- Fixed the puzzle map draw, including offset for the center marker.
- Now ignoring selected objects for the puzzle based on data from original game (offset 0x004F0B50)
- Fixed the ultimate artifact position selection.
- Switch the palette used from BROWN to TAN.
- Draw puzzle after map editor object is removed.
- Minor refactor of tile check code.