### PR TITLE
Fix castle shadows and shadow draw priority

### DIFF
--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -628,7 +628,7 @@ void Maps::UpdateCastleSprite( const Point & center, int race, bool isCastle, bo
         static const int castleCoordinates[16][2]
             = {{0, -3}, {-2, -2}, {-1, -2}, {0, -2}, {1, -2}, {2, -2}, {-2, -1}, {-1, -1}, {0, -1}, {1, -1}, {2, -1}, {-2, 0}, {-1, 0}, {0, 0}, {1, 0}, {2, 0}};
         static const int shadowCoordinates[16][2] = {{-4, -2}, {-3, -2}, {-2, -2}, {-1, -2}, {-5, -1}, {-4, -1}, {-3, -1}, {-2, -1},
-                                                     {-1, -1}, {-4, 0},  {-3, 0},  {-2, 0},  {-1, 0},  {-3, -1}, {-2, -1}, {-1, -1}};
+                                                     {-1, -1}, {-4, 0},  {-3, 0},  {-2, 0},  {-1, 0},  {-3, 1}, {-2, 1}, {-1, 1}};
 
         const int castleTile = GetIndexFromAbsPoint( center.x + castleCoordinates[index][0], center.y + castleCoordinates[index][1] );
         if ( isValidAbsIndex( castleTile ) ) {
@@ -650,9 +650,6 @@ void Maps::UpdateCastleSprite( const Point & center, int race, bool isCastle, bo
 
         const int shadowTile = GetIndexFromAbsPoint( center.x + shadowCoordinates[index][0], center.y + shadowCoordinates[index][1] );
         if ( isValidAbsIndex( shadowTile ) ) {
-            const uint8_t originalSet = isRandom ? 38 : 37; // OBJNTWRD or OBJNTWSH
-            const uint8_t tilesetChange = isRandom ? 37 * 4 : 0; // OBJNTWSH
-
             if ( isRandom )
                 world.GetTiles( shadowTile ).ReplaceObjectSprite( castleID, 38, 37 * 4, lookupID + 32, fullTownIndex ); // OBJNTWRD to OBJNTWSH
             else

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -627,8 +627,8 @@ void Maps::UpdateCastleSprite( const Point & center, int race, bool isCastle, bo
 
         static const int castleCoordinates[16][2]
             = {{0, -3}, {-2, -2}, {-1, -2}, {0, -2}, {1, -2}, {2, -2}, {-2, -1}, {-1, -1}, {0, -1}, {1, -1}, {2, -1}, {-2, 0}, {-1, 0}, {0, 0}, {1, 0}, {2, 0}};
-        static const int shadowCoordinates[16][2] = {{-4, -2}, {-3, -2}, {-2, -2}, {-1, -2}, {-5, -1}, {-4, -1}, {-3, -1}, {-2, -1},
-                                                     {-1, -1}, {-4, 0},  {-3, 0},  {-2, 0},  {-1, 0},  {-3, 1}, {-2, 1}, {-1, 1}};
+        static const int shadowCoordinates[16][2]
+            = {{-4, -2}, {-3, -2}, {-2, -2}, {-1, -2}, {-5, -1}, {-4, -1}, {-3, -1}, {-2, -1}, {-1, -1}, {-4, 0}, {-3, 0}, {-2, 0}, {-1, 0}, {-3, 1}, {-2, 1}, {-1, 1}};
 
         const int castleTile = GetIndexFromAbsPoint( center.x + castleCoordinates[index][0], center.y + castleCoordinates[index][1] );
         if ( isValidAbsIndex( castleTile ) ) {

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -624,7 +624,6 @@ void Maps::UpdateCastleSprite( const Point & center, int race, bool isCastle, bo
     for ( int index = 0; index < 16; ++index ) {
         const int fullTownIndex = index + ( isCastle ? 0 : 16 ) + raceIndex * 32;
         const int lookupID = isRandom ? index + ( isCastle ? 0 : 16 ) : fullTownIndex;
-        const uint8_t indexChange = isRandom ? fullTownIndex : -16;
 
         static const int castleCoordinates[16][2]
             = {{0, -3}, {-2, -2}, {-1, -2}, {0, -2}, {1, -2}, {2, -2}, {-2, -1}, {-1, -1}, {0, -1}, {1, -1}, {2, -1}, {-2, 0}, {-1, 0}, {0, 0}, {1, 0}, {2, 0}};
@@ -634,9 +633,11 @@ void Maps::UpdateCastleSprite( const Point & center, int race, bool isCastle, bo
         const int castleTile = GetIndexFromAbsPoint( center.x + castleCoordinates[index][0], center.y + castleCoordinates[index][1] );
         if ( isValidAbsIndex( castleTile ) ) {
             Tiles & tile = world.GetTiles( castleTile );
-            const uint8_t originalSet = isRandom ? 38 : 35; // OBJNTWRD
-            const uint8_t tilesetChange = isRandom ? 35 * 4 : 0; // OBJNTOWN or no change
-            tile.UpdateObjectSprite( castleID, originalSet, tilesetChange, indexChange, isRandom );
+
+            if ( isRandom )
+                tile.ReplaceObjectSprite( castleID, 38, 35 * 4, lookupID, fullTownIndex ); // OBJNTWRD to OBJNTOWN
+            else
+                tile.UpdateObjectSprite( castleID, 35, 35 * 4, -16 ); // no change in tileset
 
             if ( index == 0 ) {
                 TilesAddon * addon = tile.FindAddonLevel2( castleID );
@@ -651,7 +652,11 @@ void Maps::UpdateCastleSprite( const Point & center, int race, bool isCastle, bo
         if ( isValidAbsIndex( shadowTile ) ) {
             const uint8_t originalSet = isRandom ? 38 : 37; // OBJNTWRD or OBJNTWSH
             const uint8_t tilesetChange = isRandom ? 37 * 4 : 0; // OBJNTWSH
-            world.GetTiles( shadowTile ).UpdateObjectSprite( castleID, originalSet, tilesetChange, indexChange, isRandom );
+
+            if ( isRandom )
+                world.GetTiles( shadowTile ).ReplaceObjectSprite( castleID, 38, 37 * 4, lookupID + 32, fullTownIndex ); // OBJNTWRD to OBJNTWSH
+            else
+                world.GetTiles( shadowTile ).UpdateObjectSprite( castleID, 37, 37 * 4, -16 ); // no change in tileset
         }
     }
 }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1299,17 +1299,25 @@ void Maps::Tiles::AddonsPushLevel2( const TilesAddon & ta )
 
 void Maps::Tiles::AddonsSort( void )
 {
+    uint8_t lastLevel = 4;
     Addons::iterator lastObject = addons_level1.end();
     for ( Addons::iterator it = addons_level1.begin(); it != addons_level1.end(); ++it ) {
+        const int icn = MP2::GetICNObject( it->object );
+
+        // force rivers and roads to be lowest priority
+        if ( icn == ICN::STREAM || icn == ICN::ROAD )
+            continue;
+
         // force monster object on top (fix old saves)
-        if ( mp2_object == MP2::OBJ_MONSTER && MP2::GetICNObject( it->object ) == ICN::MONS32 ) {
+        if ( mp2_object == MP2::OBJ_MONSTER && icn == ICN::MONS32 ) {
             lastObject = it;
             break;
         }
         // Level is actually a bitfield, but if 0 then it's an actual "full object"
         // To compare: level 2 is shadow, level 3 is roads/river
-        else if ( it->level % 4 == 0 ) {
+        else if ( ( it->level % 4 ) < lastLevel ) {
             lastObject = it;
+            lastLevel = it->level % 4;
         }
     }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1299,10 +1299,10 @@ void Maps::Tiles::AddonsPushLevel2( const TilesAddon & ta )
 
 void Maps::Tiles::AddonsSort( void )
 {
-    uint8_t lastLevel = 4;
     Addons::iterator lastObject = addons_level1.end();
     for ( Addons::iterator it = addons_level1.begin(); it != addons_level1.end(); ++it ) {
         const int icn = MP2::GetICNObject( it->object );
+        const uint8_t level = it->level % 4;
 
         // force rivers and roads to be lowest priority
         if ( icn == ICN::STREAM || icn == ICN::ROAD )
@@ -1315,9 +1315,8 @@ void Maps::Tiles::AddonsSort( void )
         }
         // Level is actually a bitfield, but if 0 then it's an actual "full object"
         // To compare: level 2 is shadow, level 3 is roads/river
-        else if ( ( it->level % 4 ) < lastLevel ) {
+        else if ( level == 0 || ( lastObject == addons_level1.end() && level == 2 ) ) {
             lastObject = it;
-            lastLevel = it->level % 4;
         }
     }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1302,7 +1302,6 @@ void Maps::Tiles::AddonsSort( void )
     Addons::iterator lastObject = addons_level1.end();
     for ( Addons::iterator it = addons_level1.begin(); it != addons_level1.end(); ++it ) {
         const int icn = MP2::GetICNObject( it->object );
-        const uint8_t level = it->level % 4;
 
         // force rivers and roads to be lowest priority
         if ( icn == ICN::STREAM || icn == ICN::ROAD )
@@ -1315,7 +1314,7 @@ void Maps::Tiles::AddonsSort( void )
         }
         // Level is actually a bitfield, but if 0 then it's an actual "full object"
         // To compare: level 2 is shadow, level 3 is roads/river
-        else if ( level == 0 || ( lastObject == addons_level1.end() && level == 2 ) ) {
+        else if ( it->level % 4 == 0 ) {
             lastObject = it;
         }
     }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2053,24 +2053,45 @@ void Maps::Tiles::Remove( u32 uniqID )
     }
 }
 
-void Maps::Tiles::UpdateObjectSprite( uint32_t uniqID, uint8_t rawTileset, uint8_t newTileset, uint8_t newIndex, bool replace )
+void Maps::Tiles::ReplaceObjectSprite( uint32_t uniqID, uint8_t rawTileset, uint8_t newTileset, uint8_t indexToReplace, uint8_t newIndex )
+{
+    for ( Addons::iterator it = addons_level1.begin(); it != addons_level1.end(); ++it ) {
+        if ( it->uniq == uniqID && ( it->object >> 2 ) == rawTileset && it->index == indexToReplace ) {
+            it->object = newTileset;
+            it->index = newIndex;
+        }
+    }
+    for ( Addons::iterator it2 = addons_level2.begin(); it2 != addons_level2.end(); ++it2 ) {
+        if ( it2->uniq == uniqID && ( it2->object >> 2 ) == rawTileset && it2->index == indexToReplace ) {
+            it2->object = newTileset;
+            it2->index = newIndex;
+        }
+    }
+
+    if ( uniq == uniqID && ( objectTileset >> 2 ) == rawTileset && objectIndex == indexToReplace ) {
+        objectTileset = newTileset;
+        objectIndex = newIndex;
+    }
+}
+
+void Maps::Tiles::UpdateObjectSprite( uint32_t uniqID, uint8_t rawTileset, uint8_t newTileset, uint8_t indexChange )
 {
     for ( Addons::iterator it = addons_level1.begin(); it != addons_level1.end(); ++it ) {
         if ( it->uniq == uniqID && ( it->object >> 2 ) == rawTileset ) {
-            it->object = replace ? newTileset : it->object + newTileset;
-            it->index = replace ? newIndex : it->index + newIndex;
+            it->object = newTileset;
+            it->index = it->index + indexChange;
         }
     }
     for ( Addons::iterator it2 = addons_level2.begin(); it2 != addons_level2.end(); ++it2 ) {
         if ( it2->uniq == uniqID && ( it2->object >> 2 ) == rawTileset ) {
-            it2->object = replace ? newTileset : it2->object + newTileset;
-            it2->index = replace ? newIndex : it2->index + newIndex;
+            it2->object = newTileset;
+            it2->index = it2->index + indexChange;
         }
     }
 
     if ( uniq == uniqID && ( objectTileset >> 2 ) == rawTileset ) {
-        objectTileset = replace ? newTileset : objectTileset + newTileset;
-        objectIndex = replace ? newIndex : objectIndex + newIndex;
+        objectTileset = newTileset;
+        objectIndex = objectIndex + indexChange;
     }
 }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2074,7 +2074,7 @@ void Maps::Tiles::ReplaceObjectSprite( uint32_t uniqID, uint8_t rawTileset, uint
     }
 }
 
-void Maps::Tiles::UpdateObjectSprite( uint32_t uniqID, uint8_t rawTileset, uint8_t newTileset, uint8_t indexChange )
+void Maps::Tiles::UpdateObjectSprite( uint32_t uniqID, uint8_t rawTileset, uint8_t newTileset, int indexChange )
 {
     for ( Addons::iterator it = addons_level1.begin(); it != addons_level1.end(); ++it ) {
         if ( it->uniq == uniqID && ( it->object >> 2 ) == rawTileset ) {
@@ -2091,7 +2091,7 @@ void Maps::Tiles::UpdateObjectSprite( uint32_t uniqID, uint8_t rawTileset, uint8
 
     if ( uniq == uniqID && ( objectTileset >> 2 ) == rawTileset ) {
         objectTileset = newTileset;
-        objectIndex = objectIndex + indexChange;
+        objectIndex += indexChange;
     }
 }
 

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -181,7 +181,7 @@ namespace Maps
         void AddonsSort( void );
         void Remove( u32 uniqID );
         void RemoveObjectSprite( void );
-        void UpdateObjectSprite( uint32_t uniqID, uint8_t rawTileset, uint8_t newTileset, uint8_t indexChange );
+        void UpdateObjectSprite( uint32_t uniqID, uint8_t rawTileset, uint8_t newTileset, int indexChange );
         void ReplaceObjectSprite( uint32_t uniqID, uint8_t rawTileset, uint8_t newTileset, uint8_t indexToReplace, uint8_t newIndex );
 
         std::string String( void ) const;

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -181,7 +181,8 @@ namespace Maps
         void AddonsSort( void );
         void Remove( u32 uniqID );
         void RemoveObjectSprite( void );
-        void UpdateObjectSprite( uint32_t uniqID, uint8_t rawTileset, uint8_t newTileset, uint8_t newIndex, bool replace = true );
+        void UpdateObjectSprite( uint32_t uniqID, uint8_t rawTileset, uint8_t newTileset, uint8_t indexChange );
+        void ReplaceObjectSprite( uint32_t uniqID, uint8_t rawTileset, uint8_t newTileset, uint8_t indexToReplace, uint8_t newIndex );
 
         std::string String( void ) const;
 


### PR DESCRIPTION
Fixes #1635 . Fixes #1288 .

Fixed random castle shadows when new scenario started.
Fixed town to castle upgrade shadows. Works only on new saves because data is already corrupted on the old ones.
Lowered draw priority on roads/rivers so shadows will be put over it.