### PR TITLE
Reset puzzle between games

### DIFF
--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -81,6 +81,7 @@ void Kingdom::clear( void )
     recruits.Reset();
 
     heroes_cond_loss.clear();
+    puzzle_maps.reset();
 }
 
 int Kingdom::GetControl( void ) const


### PR DESCRIPTION
Related to #1526 .

Reset puzzle bitset when Kingdom is cleared (new game, game re-loaded, etc).