### PR TITLE
Remove map editor boat sprite on map load

### DIFF
--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -832,6 +832,7 @@ void Maps::Tiles::QuantityUpdate( void )
             }
     } break;
 
+    case MP2::OBJ_BOAT:
     case MP2::OBJ_EVENT:
         objectTileset = 0;
         objectIndex = 255;


### PR DESCRIPTION
Currently when hero hops into boat added in map editor and sails away game leaves a tiny sprite behind. We have to clean it up on map load.