### PR TITLE
Save neutral army after battle

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -612,16 +612,14 @@ namespace AI
             }
             else {
                 AIBattleLose( hero, res, true );
-                if ( Settings::Get().ExtWorldSaveMonsterBattle() ) {
-                    tile.MonsterSetCount( army.GetCountMonsters( troop() ) );
-                    if ( tile.MonsterJoinConditionFree() )
-                        tile.MonsterSetJoinCondition( Monster::JOIN_CONDITION_MONEY );
+                tile.MonsterSetCount( army.GetCountMonsters( troop() ) );
+                if ( tile.MonsterJoinConditionFree() )
+                    tile.MonsterSetJoinCondition( Monster::JOIN_CONDITION_MONEY );
 
-                    if ( map_troop ) {
-                        map_troop->count = army.GetCountMonsters( troop() );
-                        if ( map_troop->JoinConditionFree() )
-                            map_troop->condition = Monster::JOIN_CONDITION_MONEY;
-                    }
+                if ( map_troop ) {
+                    map_troop->count = army.GetCountMonsters( troop() );
+                    if ( map_troop->JoinConditionFree() )
+                        map_troop->condition = Monster::JOIN_CONDITION_MONEY;
                 }
             }
         }
@@ -776,8 +774,7 @@ namespace AI
                 else {
                     capture = false;
                     AIBattleLose( hero, result, true );
-                    if ( Settings::Get().ExtWorldSaveMonsterBattle() )
-                        tile.MonsterSetCount( army.GetCountMonsters( troop.GetMonster() ) );
+                    tile.MonsterSetCount( army.GetCountMonsters( troop.GetMonster() ) );
                 }
             }
 

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -884,7 +884,7 @@ Army::Army( const Maps::Tiles & t )
             Troop troop = map_troop ? map_troop->QuantityTroop() : t.QuantityTroop();
 
             at( 0 )->Set( troop );
-            ArrangeForBattle( !Settings::Get().ExtWorldSaveMonsterBattle() );
+            ArrangeForBattle( true );
         }
         break;
     }

--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -172,7 +172,6 @@ void Dialog::ExtSettings( bool readonly )
     states.push_back( Settings::GAME_CONTINUE_AFTER_VICTORY );
     states.push_back( Settings::WORLD_SHOW_VISITED_CONTENT );
     states.push_back( Settings::WORLD_ABANDONED_MINE_RANDOM );
-    states.push_back( Settings::WORLD_SAVE_MONSTER_BATTLE );
     states.push_back( Settings::WORLD_ALLOW_SET_GUARDIAN );
     states.push_back( Settings::WORLD_EXT_OBJECTS_CAPTURED );
     states.push_back( Settings::WORLD_NOREQ_FOR_ARTIFACTS );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -735,17 +735,15 @@ void ActionToMonster( Heroes & hero, u32 obj, s32 dst_index )
         }
         else {
             BattleLose( hero, res, true );
-            if ( Settings::Get().ExtWorldSaveMonsterBattle() ) {
-                tile.MonsterSetCount( army.GetCountMonsters( troop() ) );
-                // reset "can join"
-                if ( tile.MonsterJoinConditionFree() )
-                    tile.MonsterSetJoinCondition( Monster::JOIN_CONDITION_MONEY );
+            tile.MonsterSetCount( army.GetCountMonsters( troop() ) );
+            // reset "can join"
+            if ( tile.MonsterJoinConditionFree() )
+                tile.MonsterSetJoinCondition( Monster::JOIN_CONDITION_MONEY );
 
-                if ( map_troop ) {
-                    map_troop->count = army.GetCountMonsters( troop() );
-                    if ( map_troop->JoinConditionFree() )
-                        map_troop->condition = Monster::JOIN_CONDITION_MONEY;
-                }
+            if ( map_troop ) {
+                map_troop->count = army.GetCountMonsters( troop() );
+                if ( map_troop->JoinConditionFree() )
+                    map_troop->condition = Monster::JOIN_CONDITION_MONEY;
             }
         }
     }
@@ -2066,8 +2064,7 @@ void ActionToCaptureObject( Heroes & hero, u32 obj, s32 dst_index )
             else {
                 capture = false;
                 BattleLose( hero, result, true );
-                if ( Settings::Get().ExtWorldSaveMonsterBattle() )
-                    tile.MonsterSetCount( army.GetCountMonsters( mons ) );
+                tile.MonsterSetCount( army.GetCountMonsters( mons ) );
             }
         }
 

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -206,10 +206,6 @@ const settings_t settingsFHeroes2[] = {
         _( "world: abandoned mine random resource" ),
     },
     {
-        Settings::WORLD_SAVE_MONSTER_BATTLE,
-        _( "world: save count monster after battle" ),
-    },
-    {
         Settings::WORLD_ALLOW_SET_GUARDIAN,
         _( "world: allow set guardian to objects" ),
     },
@@ -1626,11 +1622,6 @@ bool Settings::ExtGameRememberLastFocus( void ) const
 bool Settings::ExtWorldAbandonedMineRandom( void ) const
 {
     return ExtModes( WORLD_ABANDONED_MINE_RANDOM );
-}
-
-bool Settings::ExtWorldSaveMonsterBattle( void ) const
-{
-    return ExtModes( WORLD_SAVE_MONSTER_BATTLE );
 }
 
 bool Settings::ExtWorldAllowSetGuardian( void ) const

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -140,7 +140,6 @@ public:
         /* influence on game balance: save to savefile */
         WORLD_SHOW_VISITED_CONTENT = 0x20000001,
         WORLD_ABANDONED_MINE_RANDOM = 0x20000002,
-        WORLD_SAVE_MONSTER_BATTLE = 0x20000004,
         WORLD_ALLOW_SET_GUARDIAN = 0x20000008,
         WORLD_NOREQ_FOR_ARTIFACTS = 0x20000010,
         WORLD_ARTIFACT_CRYSTAL_BALL = 0x20000020,
@@ -274,7 +273,6 @@ public:
     bool ExtWorldShowVisitedContent( void ) const;
     bool ExtWorldScouteExtended( void ) const;
     bool ExtWorldAbandonedMineRandom( void ) const;
-    bool ExtWorldSaveMonsterBattle( void ) const;
     bool ExtWorldAllowSetGuardian( void ) const;
     bool ExtWorldNoRequirementsForArtifacts( void ) const;
     bool ExtWorldArtifactCrystalBall( void ) const;


### PR DESCRIPTION
Fixes #1012 .

Removing "world: save count monster after battle" option from the config. Making sure it saves the armies by default.