### PR TITLE
Update debug option selection

### DIFF
--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -502,31 +502,37 @@ bool Settings::Read( const std::string & filename )
         debug = DBG_ALL_WARN;
         break;
     case 1:
-        debug = DBG_ENGINE_INFO;
-        break;
-    case 2:
-        debug = DBG_ENGINE_INFO | DBG_GAME_INFO;
-        break;
-    case 3:
-        debug = DBG_ENGINE_INFO | DBG_BATTLE_INFO;
-        break;
-    case 4:
-        debug = DBG_ENGINE_INFO | DBG_BATTLE_INFO | DBG_AI_INFO;
-        break;
-    case 5:
         debug = DBG_ALL_INFO;
         break;
+    case 2:
+        debug = DBG_ALL_TRACE;
+        break;
+    case 3:
+        debug = DBG_ENGINE_TRACE;
+        break;
+    case 4:
+        debug = DBG_GAME_INFO | DBG_BATTLE_INFO | DBG_AI_INFO;
+        break;
+    case 5:
+        debug = DBG_GAME_TRACE | DBG_AI_INFO | DBG_BATTLE_INFO;
+        break;
     case 6:
-        debug = DBG_GAME_TRACE;
+        debug = DBG_AI_TRACE | DBG_BATTLE_INFO | DBG_GAME_INFO;
         break;
     case 7:
-        debug = DBG_GAME_TRACE | DBG_AI_TRACE;
+        debug = DBG_BATTLE_TRACE | DBG_AI_INFO | DBG_GAME_INFO;
         break;
     case 8:
-        debug = DBG_BATTLE_TRACE | DBG_AI_TRACE;
+        debug = DBG_DEVEL | DBG_GAME_TRACE;
         break;
     case 9:
-        debug = DBG_ALL_TRACE;
+        debug = DBG_DEVEL | DBG_AI_INFO | DBG_BATTLE_INFO | DBG_GAME_INFO;
+        break;
+    case 10:
+        debug = DBG_DEVEL | DBG_AI_TRACE | DBG_BATTLE_INFO | DBG_GAME_INFO;
+        break;
+    case 11:
+        debug = DBG_DEVEL | DBG_AI_TRACE | DBG_BATTLE_TRACE | DBG_GAME_INFO;
         break;
     default:
         debug = ival;


### PR DESCRIPTION
Existing debug options aren't very useful, a lot of ENGINE logging at the time when engine code is solid.
GAME flags are for in adventure mode events including castle building and map data.
BATTLE for battle arena and all most things that happen during combat.
AI for decisions made during computer's turn (including battles).

Running through new debug options (in fheroes2.cfg file):

- 0-2: Warning/Info/Trace for everything.
- 3: In case you _have to_ debug the engine.
- 4: Standard debugging config without excessive logging.
- 5-7: Tracing Game/AI/Battle individually.
- 8-11: Same tracing options, but with special DBG_DEVEL mode that unlocks extra tools.

If you want to watch AI fight each other use "debug = 7" for example.