### PR TITLE
Fix AI hero recruit crash

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -113,9 +113,12 @@ namespace AI
             heroLimit = 2;
 
         // Step 3. Buy new heroes, adjust roles, sort heroes based on priority or strength
-        if ( heroes.size() < heroLimit && castles.size() ) {
+
+        // GetFirstCastle might return NULL if there's towns with a test
+        Castle * castle = castles.GetFirstCastle();
+
+        if ( castle && heroes.size() < heroLimit ) {
             Recruits & rec = kingdom.GetRecruits();
-            Castle * castle = castles.GetFirstCastle();
 
             // FIXME: Pick appropriate castle to buy hero from
             Heroes * hero = castle->GetHeroes().Guest();

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -114,7 +114,7 @@ namespace AI
 
         // Step 3. Buy new heroes, adjust roles, sort heroes based on priority or strength
 
-        // GetFirstCastle might return NULL if there's towns with a test
+        // GetFirstCastle might return NULL if there's only towns with a tent
         Castle * castle = castles.GetFirstCastle();
 
         if ( castle && heroes.size() < heroLimit ) {


### PR DESCRIPTION
Happens when if player has only towns without castle upgrade (can't buy hero there).