### PR TITLE
Save and restore position of splitters

### DIFF
--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -46,6 +46,8 @@ Kingdom::Kingdom()
     : color( Color::NONE )
     , lost_town_days( 0 )
     , visited_tents_colors( 0 )
+    , prevCastlesSplitterPosition( 0 )
+    , prevHeroesSplitterPosition( 0 )
 {
     heroes_cond_loss.reserve( 4 );
 }

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -189,6 +189,9 @@ private:
     u32 visited_tents_colors;
 
     KingdomHeroes heroes_cond_loss;
+
+    int prevCastlesSplitterPosition;
+    int prevHeroesSplitterPosition;
 };
 
 class Kingdoms

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -339,7 +339,6 @@ StatsCastlesList::StatsCastlesList( const Point & pt, KingdomCastles & castles )
     SetAreaMaxItems( 4 );
     SetAreaItems( Rect( pt.x + 30, pt.y + 17, 594, 344 ) );
 
-
     content.resize( castles.size() );
 
     for ( KingdomCastles::iterator it = castles.begin(); it != castles.end(); ++it )

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -339,6 +339,7 @@ StatsCastlesList::StatsCastlesList( const Point & pt, KingdomCastles & castles )
     SetAreaMaxItems( 4 );
     SetAreaItems( Rect( pt.x + 30, pt.y + 17, 594, 344 ) );
 
+
     content.resize( castles.size() );
 
     for ( KingdomCastles::iterator it = castles.begin(); it != castles.end(); ++it )
@@ -577,7 +578,11 @@ void Kingdom::OverviewDialog( void )
     RedrawFundsInfo( cur_pt, *this );
 
     StatsHeroesList listHeroes( dst_pt, heroes );
+    if ( listHeroes.GetSplitter().Max() > 0 )
+        listHeroes.GetSplitter().MoveIndex( prevHeroesSplitterPosition );
     StatsCastlesList listCastles( dst_pt, castles );
+    if ( listCastles.GetSplitter().Max() > 0 )
+        listCastles.GetSplitter().MoveIndex( prevCastlesSplitterPosition );
 
     // buttons
     dst_pt.x = cur_pt.x + 540;
@@ -664,4 +669,7 @@ void Kingdom::OverviewDialog( void )
             redraw = false;
         }
     }
+
+    prevCastlesSplitterPosition = listCastles.GetSplitter().GetCurrent();
+    prevHeroesSplitterPosition = listHeroes.GetSplitter().GetCurrent();
 }

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -577,11 +577,14 @@ void Kingdom::OverviewDialog( void )
     RedrawFundsInfo( cur_pt, *this );
 
     StatsHeroesList listHeroes( dst_pt, heroes );
-    if ( listHeroes.GetSplitter().Max() > 0 )
-        listHeroes.GetSplitter().MoveIndex( prevHeroesSplitterPosition );
+    Splitter & splitterHeroes = listHeroes.GetSplitter();
+    if ( splitterHeroes.Max() > 0 )
+        splitterHeroes.MoveIndex( prevHeroesSplitterPosition );
+
     StatsCastlesList listCastles( dst_pt, castles );
-    if ( listCastles.GetSplitter().Max() > 0 )
-        listCastles.GetSplitter().MoveIndex( prevCastlesSplitterPosition );
+    Splitter & splitterCastles = listCastles.GetSplitter();
+    if ( splitterCastles.Max() > 0 )
+        splitterCastles.MoveIndex( prevCastlesSplitterPosition );
 
     // buttons
     dst_pt.x = cur_pt.x + 540;
@@ -669,6 +672,6 @@ void Kingdom::OverviewDialog( void )
         }
     }
 
-    prevCastlesSplitterPosition = listCastles.GetSplitter().GetCurrent();
-    prevHeroesSplitterPosition = listHeroes.GetSplitter().GetCurrent();
+    prevCastlesSplitterPosition = splitterCastles.GetCurrent();
+    prevHeroesSplitterPosition = splitterHeroes.GetCurrent();
 }


### PR DESCRIPTION
This change remembers the position of both the "Towns/Castle" and "Heroes" list splitters in the Kingdom Overview dialog and restores them to their previous position when opened.

I tested the change using the [SAV file](https://github.com/ihhub/fheroes2/files/5195265/Full.elementals.zip) from #1609. I ensured both lists properly saved and restored. I also verified that the two players' previous splitter positions were independent of each other.

I used Visual Studio 2019 on Windows 10 x64 + SDL1 + Zlib (not that it should really matter in this case).

Fixes ihhub/fheroes2#1846