### PR TITLE
Add captain portraits in Kingdom Overview

### DIFF
--- a/src/fheroes2/castle/captain.cpp
+++ b/src/fheroes2/castle/captain.cpp
@@ -267,7 +267,7 @@ void Captain::PortraitRedraw( s32 px, s32 py, int type, fheroes2::Image & dstsf 
         return;
 
     const fheroes2::Image & port = GetPortrait( type );
-    if ( PORT_SMALL != type ) { // a normal portait in a castle or in battle
+    if ( PORT_SMALL != type ) { // a normal portrait in a castle or in battle
         fheroes2::Blit( port, dstsf, px, py );
         return;
     }
@@ -288,10 +288,10 @@ void Captain::PortraitRedraw( s32 px, s32 py, int type, fheroes2::Image & dstsf 
     fheroes2::Blit( blueBG, dstsf, px, py );
 
     // portrait
-    fheroes2::Blit( port, dstsf, px + barw + 1, py );
+    fheroes2::Blit( port, dstsf, px + barWidth + 1, py );
 
     // spell points
-    fheroes2::Blit( blueBG, dstsf, px + barw + port.width() + 2, py );
+    fheroes2::Blit( blueBG, dstsf, px + barWidth + port.width() + 2, py );
     const fheroes2::Sprite & mana = fheroes2::AGG::GetICN( ICN::MANA, GetMaxSpellPoints() );
     fheroes2::Blit( mana, dstsf, px + barw + port.width() + 2, py + mana.y() );
 }

--- a/src/fheroes2/castle/captain.cpp
+++ b/src/fheroes2/castle/captain.cpp
@@ -23,6 +23,7 @@
 #include "captain.h"
 #include "agg.h"
 #include "castle.h"
+#include "interface_icons.h"
 #include "luck.h"
 #include "morale.h"
 #include "race.h"
@@ -262,5 +263,39 @@ fheroes2::Image Captain::GetPortrait( int type ) const
 
 void Captain::PortraitRedraw( s32 px, s32 py, int type, fheroes2::Image & dstsf ) const
 {
-    fheroes2::Blit( GetPortrait( type ), dstsf, px, py );
+    if ( !isValid() )
+        return;
+
+    const fheroes2::Image port = GetPortrait( type );
+
+    if ( PORT_SMALL == type ) {
+        const fheroes2::Sprite & mobility = fheroes2::AGG::GetICN( ICN::MOBILITY, 0 );
+        const fheroes2::Sprite & mana = fheroes2::AGG::GetICN( ICN::MANA, GetMaxSpellPoints() );
+
+        const int iconsw = Interface::IconsBar::GetItemWidth();
+        const int iconsh = Interface::IconsBar::GetItemHeight();
+        const int barw = 7;
+
+        fheroes2::Image blackBG( iconsw, iconsh );
+        blackBG.fill( 0 );
+        fheroes2::Image blueBG( barw, iconsh );
+        blueBG.fill( fheroes2::GetColorId( 15, 30, 120 ) );
+
+        // background
+        fheroes2::Blit( blackBG, dstsf, px, py );
+
+        // mobility is always 0
+        fheroes2::Blit( blueBG, dstsf, px, py );
+        fheroes2::Blit( mobility, dstsf, px, py + mobility.y() );
+
+        // portrait
+        fheroes2::Blit( port, dstsf, px + barw + 1, py );
+
+        // mana
+        fheroes2::Blit( blueBG, dstsf, px + barw + port.width() + 2, py );
+        fheroes2::Blit( mana, dstsf, px + barw + port.width() + 2, py + mana.y() );
+    }
+    else {
+        fheroes2::Blit( port, dstsf, px, py );
+    }
 }

--- a/src/fheroes2/castle/captain.cpp
+++ b/src/fheroes2/castle/captain.cpp
@@ -266,19 +266,19 @@ void Captain::PortraitRedraw( s32 px, s32 py, int type, fheroes2::Image & dstsf 
     if ( !isValid() )
         return;
 
-    const fheroes2::Image port = GetPortrait( type );
+    const fheroes2::Image & port = GetPortrait( type );
 
     if ( PORT_SMALL == type ) {
         const fheroes2::Sprite & mobility = fheroes2::AGG::GetICN( ICN::MOBILITY, 0 );
         const fheroes2::Sprite & mana = fheroes2::AGG::GetICN( ICN::MANA, GetMaxSpellPoints() );
 
-        const int iconsw = Interface::IconsBar::GetItemWidth();
-        const int iconsh = Interface::IconsBar::GetItemHeight();
-        const int barw = 7;
+        const int iconWidth = Interface::IconsBar::GetItemWidth();
+        const int iconHeight = Interface::IconsBar::GetItemHeight();
+        const int barWidth = 7;
 
-        fheroes2::Image blackBG( iconsw, iconsh );
+        fheroes2::Image blackBG( iconWidth, iconHeight );
         blackBG.fill( 0 );
-        fheroes2::Image blueBG( barw, iconsh );
+        fheroes2::Image blueBG( barWidth, iconHeight );
         blueBG.fill( fheroes2::GetColorId( 15, 30, 120 ) );
 
         // background

--- a/src/fheroes2/castle/captain.cpp
+++ b/src/fheroes2/castle/captain.cpp
@@ -267,35 +267,31 @@ void Captain::PortraitRedraw( s32 px, s32 py, int type, fheroes2::Image & dstsf 
         return;
 
     const fheroes2::Image & port = GetPortrait( type );
-
-    if ( PORT_SMALL == type ) {
-        const fheroes2::Sprite & mobility = fheroes2::AGG::GetICN( ICN::MOBILITY, 0 );
-        const fheroes2::Sprite & mana = fheroes2::AGG::GetICN( ICN::MANA, GetMaxSpellPoints() );
-
-        const int iconWidth = Interface::IconsBar::GetItemWidth();
-        const int iconHeight = Interface::IconsBar::GetItemHeight();
-        const int barWidth = 7;
-
-        fheroes2::Image blackBG( iconWidth, iconHeight );
-        blackBG.fill( 0 );
-        fheroes2::Image blueBG( barWidth, iconHeight );
-        blueBG.fill( fheroes2::GetColorId( 15, 30, 120 ) );
-
-        // background
-        fheroes2::Blit( blackBG, dstsf, px, py );
-
-        // mobility is always 0
-        fheroes2::Blit( blueBG, dstsf, px, py );
-        fheroes2::Blit( mobility, dstsf, px, py + mobility.y() );
-
-        // portrait
-        fheroes2::Blit( port, dstsf, px + barw + 1, py );
-
-        // mana
-        fheroes2::Blit( blueBG, dstsf, px + barw + port.width() + 2, py );
-        fheroes2::Blit( mana, dstsf, px + barw + port.width() + 2, py + mana.y() );
-    }
-    else {
+    if ( PORT_SMALL != type ) { // a normal portait in a castle or in battle
         fheroes2::Blit( port, dstsf, px, py );
+        return;
     }
+
+    const int iconWidth = Interface::IconsBar::GetItemWidth();
+    const int iconHeight = Interface::IconsBar::GetItemHeight();
+    const int barWidth = 7;
+
+    fheroes2::Image blackBG( iconWidth, iconHeight );
+    blackBG.fill( 0 );
+    fheroes2::Image blueBG( barWidth, iconHeight );
+    blueBG.fill( fheroes2::GetColorId( 15, 30, 120 ) );
+
+    // background
+    fheroes2::Blit( blackBG, dstsf, px, py );
+
+    // mobility is always 0
+    fheroes2::Blit( blueBG, dstsf, px, py );
+
+    // portrait
+    fheroes2::Blit( port, dstsf, px + barw + 1, py );
+
+    // spell points
+    fheroes2::Blit( blueBG, dstsf, px + barw + port.width() + 2, py );
+    const fheroes2::Sprite & mana = fheroes2::AGG::GetICN( ICN::MANA, GetMaxSpellPoints() );
+    fheroes2::Blit( mana, dstsf, px + barw + port.width() + 2, py + mana.y() );
 }

--- a/src/fheroes2/castle/captain.cpp
+++ b/src/fheroes2/castle/captain.cpp
@@ -293,5 +293,5 @@ void Captain::PortraitRedraw( s32 px, s32 py, int type, fheroes2::Image & dstsf 
     // spell points
     fheroes2::Blit( blueBG, dstsf, px + barWidth + port.width() + 2, py );
     const fheroes2::Sprite & mana = fheroes2::AGG::GetICN( ICN::MANA, GetMaxSpellPoints() );
-    fheroes2::Blit( mana, dstsf, px + barw + port.width() + 2, py + mana.y() );
+    fheroes2::Blit( mana, dstsf, px + barWidth + port.width() + 2, py + mana.y() );
 }

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -429,6 +429,9 @@ void StatsCastlesList::RedrawItem( const CstlRow & row, s32 dstx, s32 dsty, bool
             text.Set( hero->StringSkills( "-" ) );
             text.Blit( dstx + 104 - text.w() / 2, dsty + 43 );
         }
+        else {
+            row.castle->GetCaptain().PortraitRedraw( dstx + 82, dsty + 19, PORT_SMALL, fheroes2::Display::instance() );
+        }
 
         text.Set( row.castle->GetName() );
         text.Blit( dstx + 72 - text.w() / 2, dsty + 62 );


### PR DESCRIPTION
### After
![After](https://user-images.githubusercontent.com/1855194/94998021-0782de00-057d-11eb-9cef-1df739e02cd4.png)
_Captain portraits appear after change_

### Before
![Before](https://user-images.githubusercontent.com/1855194/94998023-08b40b00-057d-11eb-954c-5be1c6526fea.png)
_No captain portraits even when Captain present before_

### Unchanged
![](https://user-images.githubusercontent.com/1855194/94998022-081b7480-057d-11eb-8bac-06d9b9922313.png)
_Hero portrait takes precedent_

![No portrait without captain](https://user-images.githubusercontent.com/1855194/94998023-08b40b00-057d-11eb-954c-5be1c6526fea.png)
_No portrait when there is no captain and no hero_



Fixes #1848