### PR TITLE
Strategic AI: better heuristics and boat handling

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -92,7 +92,8 @@ namespace AI
     uint32_t AIGetAllianceColors( const Heroes & hero );
     bool AIHeroesShowAnimation( const Heroes & hero, uint32_t colors );
 
-    const double ARMY_STRENGTH_ADVANTAGE_SMALL = 1.5;
+    const double ARMY_STRENGTH_ADVANTAGE_SMALL = 1.3;
+    const double ARMY_STRENGTH_ADVANTAGE_MEDUIM = 1.5;
     const double ARMY_STRENGTH_ADVANTAGE_LARGE = 1.8;
 
     int AISelectPrimarySkill( Heroes & hero )
@@ -1560,7 +1561,7 @@ namespace AI
                 if ( !hero.isFriends( tile.QuantityColor() ) ) {
                     if ( tile.CaptureObjectIsProtection() ) {
                         Army enemy( tile );
-                        return army.isStrongerThan( enemy, ARMY_STRENGTH_ADVANTAGE_LARGE );
+                        return army.isStrongerThan( enemy, ARMY_STRENGTH_ADVANTAGE_MEDUIM );
                     }
                     else
                         return true;
@@ -1798,7 +1799,7 @@ namespace AI
             break;
 
         case MP2::OBJ_MONSTER:
-            return army.isStrongerThan( Army( tile ), ARMY_STRENGTH_ADVANTAGE_SMALL );
+            return army.isStrongerThan( Army( tile ), ARMY_STRENGTH_ADVANTAGE_MEDUIM );
 
         // sign
         case MP2::OBJ_SIGN:
@@ -1816,7 +1817,7 @@ namespace AI
                     if ( hero.isFriends( castle->GetColor() ) )
                         return false;
                     else
-                        return army.isStrongerThan( castle->GetActualArmy(), castle->isCastle() ? ARMY_STRENGTH_ADVANTAGE_LARGE : ARMY_STRENGTH_ADVANTAGE_SMALL );
+                        return army.isStrongerThan( castle->GetActualArmy(), castle->isCastle() ? ARMY_STRENGTH_ADVANTAGE_LARGE : ARMY_STRENGTH_ADVANTAGE_MEDUIM );
                 }
             }
             break;

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -92,8 +92,8 @@ namespace AI
     uint32_t AIGetAllianceColors( const Heroes & hero );
     bool AIHeroesShowAnimation( const Heroes & hero, uint32_t colors );
 
-    const double ARMY_STRENGTH_ADVANTAGE_SMALL = 1.3;
-    const double ARMY_STRENGTH_ADVANTAGE_LARGE = 1.6;
+    const double ARMY_STRENGTH_ADVANTAGE_SMALL = 1.5;
+    const double ARMY_STRENGTH_ADVANTAGE_LARGE = 1.8;
 
     int AISelectPrimarySkill( Heroes & hero )
     {
@@ -1816,7 +1816,7 @@ namespace AI
                     if ( hero.isFriends( castle->GetColor() ) )
                         return false;
                     else
-                        return army.isStrongerThan( castle->GetActualArmy(), ARMY_STRENGTH_ADVANTAGE_LARGE );
+                        return army.isStrongerThan( castle->GetActualArmy(), castle->isCastle() ? ARMY_STRENGTH_ADVANTAGE_LARGE : ARMY_STRENGTH_ADVANTAGE_SMALL );
                 }
             }
             break;

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1436,6 +1436,8 @@ namespace AI
         for ( MapsIndexes::const_iterator it = coasts.begin(); it != coasts.end(); ++it )
             hero.SetVisited( *it );
 
+        hero.setLastGroundRegion( world.GetTiles( from_index ).GetRegion() );
+
         hero.FadeOut();
         hero.ResetMovePoints();
         hero.Move2Dest( dst_index );
@@ -1524,10 +1526,10 @@ namespace AI
 
         case MP2::OBJ_MAGELLANMAPS:
         case MP2::OBJ_WHIRLPOOL:
+            return hero.isShipMaster() && !hero.isVisited( tile );
+
         case MP2::OBJ_COAST:
-            if ( hero.isShipMaster() )
-                return true;
-            break;
+            return hero.isShipMaster() && !hero.isVisited( tile ) && tile.GetRegion() != hero.lastGroundRegion();
 
         // capture objects
         case MP2::OBJ_SAWMILL:

--- a/src/fheroes2/ai/normal/ai_normal_castle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_castle.cpp
@@ -118,6 +118,10 @@ namespace AI
             return true;
         }
 
+        // Call internally checks if it's valid (space/resources) to buy one
+        if ( castle.GetKingdom().GetFunds() >= PaymentConditions::BuyBoat() * 2 )
+            castle.BuyBoat();
+
         return Build( castle, GetDefensiveStructures( castle.GetRace() ), 10 );
     }
 
@@ -126,8 +130,7 @@ namespace AI
         if ( defensive ) {
             Build( castle, GetDefensiveStructures( castle.GetRace() ) );
 
-            // Implement a smarter monster recruit option
-            castle.RecruitAllMonsters();
+            castle.recruitBestAvailable( castle.GetKingdom().GetFunds() );
         }
         else {
             CastleDevelopment( castle );

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -50,7 +50,7 @@ namespace AI
             return 500.0 * tile.QuantityArtifact().getArtifactValue();
         }
         else if ( MP2::isPickupObject( objectID ) ) {
-            return 300.0;
+            return 400.0;
         }
         else if ( MP2::isHeroUpgradeObject( objectID ) ) {
             return 400.0;
@@ -58,9 +58,13 @@ namespace AI
         else if ( objectID == MP2::OBJ_OBSERVATIONTOWER ) {
             return 400.0;
         }
-        else if ( objectID == MP2::OBJ_COAST || objectID == MP2::OBJ_BOAT ) {
-            // de-prioritize the swimming
-            return -2000.0;
+        else if ( objectID == MP2::OBJ_COAST ) {
+            // de-prioritize the landing
+            return -1500.0;
+        }
+        else if ( objectID == MP2::OBJ_BOAT ) {
+            // de-prioritize the boats even harder
+            return -2500.0;
         }
 
         return 0;

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -93,13 +93,14 @@ namespace AI
 
             mapObjects.emplace_back( idx, objectID );
 
+            const int color = tile.QuantityColor();
             if ( objectID == MP2::OBJ_HEROES ) {
                 const Heroes * enemy = tile.GetHeroes();
                 if ( enemy && !Players::isFriends( color, enemy->GetColor() ) ) {
                     enemyArmies.emplace_back( idx, &enemy->GetArmy() );
                 }
             }
-            else if ( objectID == MP2::OBJ_CASTLE && !Players::isFriends( color, tile.QuantityColor() ) ) {
+            else if ( objectID == MP2::OBJ_CASTLE && color != Color::NONE && !Players::isFriends( color, color ) ) {
                 const Castle * castle = world.GetCastle( Maps::GetPoint( idx ) );
                 if ( castle )
                     enemyArmies.emplace_back( idx, &castle->GetArmy() );

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1259,8 +1259,8 @@ bool Army::isStrongerThan( const Army & target, double safetyRatio ) const
     if ( !target.isValid() )
         return true;
 
-    const double str1 = GetStrength() * safetyRatio;
-    const double str2 = target.GetStrength();
+    const double str1 = GetStrength();
+    const double str2 = target.GetStrength() * safetyRatio;
 
     DEBUG( DBG_GAME, DBG_TRACE, "Comparing troops: " << str1 << " versus " << str2 );
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1236,6 +1236,16 @@ void Heroes::SetShipMaster( bool f )
     f ? SetModes( SHIPMASTER ) : ResetModes( SHIPMASTER );
 }
 
+int Heroes::lastGroundRegion() const
+{
+    return _lastGroundRegion;
+}
+
+void Heroes::setLastGroundRegion( int regionID ) 
+{
+    _lastGroundRegion = regionID;
+}
+
 Skill::SecSkills & Heroes::GetSecondarySkills( void )
 {
     return secondary_skills;

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1241,7 +1241,7 @@ int Heroes::lastGroundRegion() const
     return _lastGroundRegion;
 }
 
-void Heroes::setLastGroundRegion( int regionID ) 
+void Heroes::setLastGroundRegion( int regionID )
 {
     _lastGroundRegion = regionID;
 }

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -284,6 +284,8 @@ public:
 
     bool isShipMaster( void ) const;
     void SetShipMaster( bool );
+    int lastGroundRegion() const;
+    void setLastGroundRegion( int regionID );
 
     u32 GetExperience( void ) const;
     void IncreaseExperience( u32 );
@@ -345,6 +347,8 @@ private:
     int patrol_square;
 
     std::list<IndexObject> visit_object;
+    // persist this value later
+    int _lastGroundRegion = 0;
 
     mutable int _alphaValue;
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -903,6 +903,8 @@ void ActionToBoat( Heroes & hero, u32 obj, s32 dst_index )
     if ( hero.isShipMaster() )
         return;
 
+    hero.setLastGroundRegion( world.GetTiles( hero.GetIndex() ).GetRegion() );
+
     AGG::PlaySound( M82::KILLFADE );
     hero.GetPath().Hide();
     hero.FadeOut();


### PR DESCRIPTION
Adjusted sailing logic to prevent heroes landing back on the same spot.
AI can now buy boats for themselves.
Also adjusted heuristics to make sure AI plays a bit safer.

Finally I can make use of my world region algorithm.