### PR TITLE
Fix heroes movement animation

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1436,12 +1436,19 @@ namespace AI
         for ( MapsIndexes::const_iterator it = coasts.begin(); it != coasts.end(); ++it )
             hero.SetVisited( *it );
 
-        hero.FadeOut();
+        const bool showAnimation = AIHeroesShowAnimation( hero, AIGetAllianceColors( hero ) );
+        const Point & destPos = Maps::GetPoint( dst_index );
+        const Point offset( destPos - hero.GetCenter() );
+
+        if ( showAnimation ) {
+            hero.FadeOut( offset );
+        }
+
         hero.ResetMovePoints();
         hero.Move2Dest( dst_index );
         hero.SetMapsObject( MP2::OBJ_ZERO );
         hero.SetShipMaster( true );
-        if ( AIHeroesShowAnimation( hero, AIGetAllianceColors( hero ) ) ) {
+        if ( showAnimation ) {
             Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
         }
         hero.GetPath().Reset();
@@ -1458,13 +1465,19 @@ namespace AI
 
         Maps::Tiles & from = world.GetTiles( hero.GetIndex() );
 
+        const bool showAnimation = AIHeroesShowAnimation( hero, AIGetAllianceColors( hero ) );
+
+        const Point & destPos = Maps::GetPoint( dst_index );
+        const Point offset( destPos - hero.GetCenter() );
+
         hero.ResetMovePoints();
         hero.Move2Dest( dst_index );
         from.SetObject( MP2::OBJ_BOAT );
         hero.SetShipMaster( false );
         hero.GetPath().Reset();
-        hero.FadeIn();
-        if ( AIHeroesShowAnimation( hero, AIGetAllianceColors( hero ) ) ) {
+
+        if ( showAnimation ) {
+            hero.FadeIn( offset );
             Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
         }
         hero.ActionNewPosition();
@@ -1898,8 +1911,16 @@ namespace AI
             Interface::GameArea & gameArea = I.GetGameArea();
 
             const uint32_t colors = AIGetAllianceColors( hero );
-            const int moveStep = hero.GetMoveStep();
             bool recenterNeeded = true;
+
+            int heroAnimationFrameCount = 0;
+#ifdef WITH_DEBUG
+            const int heroAnimationFrameStep = 2; // debug mode is always slower in few times so at least we speed up a little
+#else
+            const int heroAnimationFrameStep = 1;
+#endif
+            Point heroAnimationOffset;
+            int heroAnimationSpriteId = 0;
 
             while ( LocalEvent::Get().HandleEvents() ) {
                 if ( hero.isFreeman() || !hero.isMoveEnabled() ) {
@@ -1918,16 +1939,42 @@ namespace AI
                         recenterNeeded = false;
                     }
 
-                    if ( !hero.Move() ) {
-                        Point movement( hero.MovementDirection() );
-                        if ( movement != Point() ) { // don't waste resources for no movement
-                            movement.x *= moveStep;
-                            movement.y *= moveStep;
-                            gameArea.ShiftCenter( movement );
+                    bool resetHeroSprite = false;
+                    if ( heroAnimationFrameCount > 0 ) {
+                        gameArea.ShiftCenter( Point( heroAnimationOffset.x * heroAnimationFrameStep, heroAnimationOffset.y * heroAnimationFrameStep ) );
+                        gameArea.SetRedraw();
+                        heroAnimationFrameCount -= heroAnimationFrameStep;
+                        if ( ( heroAnimationFrameCount & 0x3 ) == 0 ) { // % 4
+                            hero.SetSpriteIndex( heroAnimationSpriteId );
+
+                            if ( heroAnimationFrameCount == 0 )
+                                resetHeroSprite = true;
+                            else
+                                ++heroAnimationSpriteId;
                         }
+                        const int offsetStep = ( ( 4 - ( heroAnimationFrameCount & 0x3 ) ) & 0x3 ); // % 4
+                        hero.SetOffset( fheroes2::Point( heroAnimationOffset.x * offsetStep, heroAnimationOffset.y * offsetStep ) );
                     }
-                    else {
-                        gameArea.SetCenter( hero.GetCenter() );
+
+                    if ( heroAnimationFrameCount == 0 ) {
+                        if ( resetHeroSprite ) {
+                            hero.SetSpriteIndex( heroAnimationSpriteId - 1 );
+                        }
+
+                        if ( hero.Move() ) {
+                            gameArea.SetCenter( hero.GetCenter() );
+                        }
+                        else {
+                            Point movement( hero.MovementDirection() );
+                            if ( movement != Point() ) { // don't waste resources for no movement
+                                heroAnimationOffset = movement;
+                                gameArea.ShiftCenter( movement );
+                                heroAnimationFrameCount = 32 - heroAnimationFrameStep;
+                                heroAnimationSpriteId = hero.GetSpriteIndex();
+                                hero.SetSpriteIndex( heroAnimationSpriteId - 1 );
+                                hero.SetOffset( fheroes2::Point( heroAnimationOffset.x, heroAnimationOffset.y ) );
+                            }
+                        }
                     }
 
                     I.Redraw( REDRAW_GAMEAREA );

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -73,7 +73,7 @@ namespace Game
                           130, // CASTLE_BUYHERO_DELAY
                           130, // CASTLE_BUILD_DELAY
                           150, // CASTLE_UNIT_DELAY
-                          40, // HEROES_FADE_DELAY
+                          32, // HEROES_FADE_DELAY
                           40, // HEROES_PICKUP_DELAY
                           50, // PUZZLE_FADE_DELAY
                           75, // BATTLE_DIALOG_DELAY
@@ -92,8 +92,8 @@ namespace Game
                           220, // BATTLE_COLOR_CYCLE_DELAY
                           160, // BATTLE_SELECTED_UNIT_DELAY
                           300, // AUTOHIDE_STATUS_DELAY
-                          40, // CURRENT_HERO_DELAY
-                          40, // CURRENT_AI_DELAY
+                          10, // CURRENT_HERO_DELAY
+                          10, // CURRENT_AI_DELAY
                           0, // CUSTOM_DELAY
                           0};
 }
@@ -129,8 +129,8 @@ void Game::UpdateGameSpeed( void )
     const int heroSpeed = conf.HeroesMoveSpeed() - DEFAULT_SPEED_DELAY;
     const int aiSpeed = conf.AIMoveSpeed() - DEFAULT_SPEED_DELAY;
 
-    delays[CURRENT_HERO_DELAY] = 40 - heroSpeed * 8;
-    delays[CURRENT_AI_DELAY] = 40 - aiSpeed * 8;
+    delays[CURRENT_HERO_DELAY] = 10 - heroSpeed * 2;
+    delays[CURRENT_AI_DELAY] = 10 - aiSpeed * 2;
 
     const double adjustedBattleSpeed = ( 10 - conf.BattleSpeed() ) * battleSpeedAdjustment;
     delays[BATTLE_FRAME_DELAY] = 120 * adjustedBattleSpeed;

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -947,6 +947,16 @@ int Heroes::GetSpriteIndex( void ) const
     return sprite_index;
 }
 
+void Heroes::SetSpriteIndex( int index )
+{
+    sprite_index = index;
+}
+
+void Heroes::SetOffset( const fheroes2::Point & offset )
+{
+    _offset = offset;
+}
+
 bool Heroes::isAction( void ) const
 {
     return Modes( ACTION );

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -275,8 +275,13 @@ public:
     void Redraw( fheroes2::Image &, s32, s32, bool ) const;
     void PortraitRedraw( s32, s32, int type, fheroes2::Image & ) const;
     int GetSpriteIndex( void ) const;
-    void FadeOut( void ) const;
-    void FadeIn( void ) const;
+
+    // These 2 methods must be used only for hero's animation. Please never use them anywhere else!
+    void SetSpriteIndex( int index );
+    void SetOffset( const fheroes2::Point & offset );
+
+    void FadeOut( const Point & offset = Point() ) const;
+    void FadeIn( const Point & offset = Point() ) const;
     void Scoute( void ) const;
     int GetScoute( void ) const;
     int CanScouteTile( s32 ) const;
@@ -298,7 +303,6 @@ public:
 
     static void ScholarAction( Heroes &, Heroes & );
 
-    int GetMoveStep() const;
     Point MovementDirection() const;
 
 private:
@@ -340,6 +344,7 @@ private:
 
     int direction;
     int sprite_index;
+    fheroes2::Point _offset; // used only during hero's movement
 
     Point patrol_center;
     int patrol_square;

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -903,9 +903,12 @@ void ActionToBoat( Heroes & hero, u32 obj, s32 dst_index )
     if ( hero.isShipMaster() )
         return;
 
+    const Point & destPos = Maps::GetPoint( dst_index );
+    const Point offset( destPos - hero.GetCenter() );
+
     AGG::PlaySound( M82::KILLFADE );
     hero.GetPath().Hide();
-    hero.FadeOut();
+    hero.FadeOut( offset );
     hero.ResetMovePoints();
     hero.Move2Dest( dst_index );
     hero.SetMapsObject( MP2::OBJ_ZERO );
@@ -922,13 +925,16 @@ void ActionToCoast( Heroes & hero, u32 obj, s32 dst_index )
 
     Maps::Tiles & from = world.GetTiles( hero.GetIndex() );
 
+    const Point & destPos = Maps::GetPoint( dst_index );
+    const Point offset( destPos - hero.GetCenter() );
+
     hero.ResetMovePoints();
     hero.Move2Dest( dst_index );
     from.SetObject( MP2::OBJ_BOAT );
     hero.SetShipMaster( false );
     AGG::PlaySound( M82::KILLFADE );
     hero.GetPath().Hide();
-    hero.FadeIn();
+    hero.FadeIn( offset );
     hero.GetPath().Reset();
     hero.ActionNewPosition();
 

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -403,7 +403,9 @@ void Heroes::Redraw( fheroes2::Image & dst, s32 dx, s32 dy, bool withShadow ) co
     if ( sprite_index < 45 ) {
         s32 ox = 0;
         s32 oy = 0;
-        const int frame = ( sprite_index % 9 );
+        int frame = ( sprite_index % 9 );
+        if ( frame > 0 )
+            --frame;
 
         switch ( direction ) {
         case Direction::TOP:
@@ -437,6 +439,9 @@ void Heroes::Redraw( fheroes2::Image & dst, s32 dx, s32 dy, bool withShadow ) co
         default:
             break;
         }
+
+        ox += _offset.x;
+        oy += _offset.y;
 
         dst_pt1.x += ox;
         dst_pt1.y += oy;
@@ -747,40 +752,48 @@ void Heroes::AngleStep( int to_direct )
     }
 }
 
-void Heroes::FadeOut( void ) const
+void Heroes::FadeOut( const Point & offset ) const
 {
     const Point & mp = GetCenter();
-    const Interface::GameArea & gamearea = Interface::Basic::Get().GetGameArea();
+    Interface::GameArea & gamearea = Interface::Basic::Get().GetGameArea();
 
     if ( !( gamearea.GetVisibleTileROI() & mp ) )
         return;
 
+    const bool offsetScreen = offset.x != 0 || offset.y != 0;
+
     fheroes2::Display & display = fheroes2::Display::instance();
     LocalEvent & le = LocalEvent::Get();
-    _alphaValue = 250;
+    _alphaValue = 255;
 
     while ( le.HandleEvents() && _alphaValue > 0 ) {
         if ( Game::AnimateInfrequentDelay( Game::HEROES_FADE_DELAY ) ) {
             Cursor::Get().Hide();
 
+            if ( offsetScreen ) {
+                gamearea.ShiftCenter( offset );
+            }
+
             gamearea.Redraw( display, LEVEL_ALL );
 
             Cursor::Get().Show();
             display.render();
-            _alphaValue -= 10;
+            _alphaValue -= 8;
         }
     }
 
     _alphaValue = 255;
 }
 
-void Heroes::FadeIn( void ) const
+void Heroes::FadeIn( const Point & offset ) const
 {
     const Point & mp = GetCenter();
-    const Interface::GameArea & gamearea = Interface::Basic::Get().GetGameArea();
+    Interface::GameArea & gamearea = Interface::Basic::Get().GetGameArea();
 
     if ( !( gamearea.GetVisibleTileROI() & mp ) )
         return;
+
+    const bool offsetScreen = offset.x != 0 || offset.y != 0;
 
     fheroes2::Display & display = fheroes2::Display::instance();
     LocalEvent & le = LocalEvent::Get();
@@ -790,11 +803,15 @@ void Heroes::FadeIn( void ) const
         if ( Game::AnimateInfrequentDelay( Game::HEROES_FADE_DELAY ) ) {
             Cursor::Get().Hide();
 
+            if ( offsetScreen ) {
+                gamearea.ShiftCenter( offset );
+            }
+
             gamearea.Redraw( display, LEVEL_ALL );
 
             Cursor::Get().Show();
             display.render();
-            _alphaValue += 10;
+            _alphaValue += 8;
         }
     }
 
@@ -839,11 +856,6 @@ bool Heroes::Move( bool fast )
     return false;
 }
 
-int Heroes::GetMoveStep() const
-{
-    return HERO_MOVE_STEP;
-}
-
 Point Heroes::MovementDirection() const
 {
     const int32_t from = GetIndex();
@@ -852,7 +864,7 @@ Point Heroes::MovementDirection() const
         return Point();
 
     if ( direction == Direction::TOP ) {
-        if ( sprite_index > 0 && sprite_index < 9 ) {
+        if ( sprite_index > 1 && sprite_index < 9 ) {
             return Point( 0, -1 );
         }
     }

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -764,7 +764,7 @@ void Heroes::FadeOut( const Point & offset ) const
 
     fheroes2::Display & display = fheroes2::Display::instance();
     LocalEvent & le = LocalEvent::Get();
-    _alphaValue = 255;
+    _alphaValue = 255 - 8;
 
     while ( le.HandleEvents() && _alphaValue > 0 ) {
         if ( Game::AnimateInfrequentDelay( Game::HEROES_FADE_DELAY ) ) {
@@ -797,7 +797,7 @@ void Heroes::FadeIn( const Point & offset ) const
 
     fheroes2::Display & display = fheroes2::Display::instance();
     LocalEvent & le = LocalEvent::Get();
-    _alphaValue = 0;
+    _alphaValue = 8;
 
     while ( le.HandleEvents() && _alphaValue < 250 ) {
         if ( Game::AnimateInfrequentDelay( Game::HEROES_FADE_DELAY ) ) {


### PR DESCRIPTION
- make the animation smooth without jumps
- reduce screen offset after visiting objects from 4 pixels to 1 pixel
(relates to #885)
- add animation of boarding boat and offboarding it (relates to #1186)
- make AI slightly faster when they board or unboard ships under fog