### PR TITLE
FreeBSD: iconv build fixes

### DIFF
--- a/src/Makefile.bsd
+++ b/src/Makefile.bsd
@@ -4,5 +4,13 @@ LIBS := $(LIBS) -L/usr/local/lib
 
 ifndef WITHOUT_UNICODE
 CFLAGS := $(CFLAGS) -DWITH_ICONV
+# A bit of might'n'magic required to link against base iconv in presence of
+# libiconv port installed -- the include path most likely already contains
+# LOCALBASE, so force /usr/include/iconv.h inclusion explicitly.
+ifneq (,$(wildcard /usr/include/iconv.h))
+CFLAGS := -include /usr/include/iconv.h -D_LIBICONV_H $(CFLAGS)
 LIBS := $(LIBS)
+else
+LIBS := $(LIBS) -liconv
+endif
 endif

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -808,7 +808,7 @@ std::string EncodeString( const std::string & str, const char * charset )
     char * outbuf1 = new char[outbytesleft];
     char * outbuf2 = outbuf1;
 
-#if defined( __FreeBSD__ ) || defined( __MINGW32__ ) || defined( __MINGW64__ )
+#if defined( __MINGW32__ ) || defined( __MINGW64__ )
     size_t reslen = iconv( cd, &inbuf, &inbytesleft, &outbuf1, &outbytesleft );
 #else
     size_t reslen = iconv( cd, const_cast<char **>( &inbuf ), &inbytesleft, &outbuf1, &outbytesleft );


### PR DESCRIPTION
1. FreeBSD: both base iconv and libiconv follow POSIX prototype

Fix build on FreeBSD requiring the same const_cast as on other platforms.
Base iconv removed the const qualifier back in 2015.

For the record: https://github.com/freebsd/freebsd/commit/b0813ee288f64f677a2cebf7815754b027a8215b

2.  FreeBSD: fix build with both base iconv and libiconv present

Include path most likely contains LOCALBASE, and that will make us
pick up the /usr/local/include/iconv.h, which requires linking
against libiconv (as compared to base iconv being in libc).

Force /usr/include/iconv.h inclusion explicitly if it's present to
fix the build.  The other choice is to always link against libiconv
as it will most likely be already installed due to other dependencies,
but linking against the base one if we can just looks cleaner.