### PR TITLE
Fix monster dwelling unit count

### DIFF
--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -863,9 +863,10 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
         UpdateMonsterInfo( *this );
         break;
 
-        // join dwelling
     case MP2::OBJ_ANCIENTLAMP:
-        MonsterSetCount( QuantityMonster().GetRNDSize( true ) );
+        // Genies in the lamp do not accumulate
+        if ( isFirstLoad )
+            MonsterSetCount( Rand::Get( 1, 5 ) );
         break;
 
     case MP2::OBJ_WATCHTOWER:

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -866,7 +866,7 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
     case MP2::OBJ_ANCIENTLAMP:
         // Genies in the lamp do not accumulate
         if ( isFirstLoad )
-            MonsterSetCount( Rand::Get( 1, 5 ) );
+            MonsterSetCount( Rand::Get( 2, 4 ) );
         break;
 
     case MP2::OBJ_WATCHTOWER:
@@ -1111,7 +1111,7 @@ void Maps::Tiles::UpdateDwellingPopulation( Tiles & tile, bool isFirstLoad )
     }
 
     if ( count ) {
-        tile.MonsterSetCount( troop.GetCount() + count );
+        tile.MonsterSetCount( count );
     }
 }
 


### PR DESCRIPTION
Forgot to change the most significant line cause units to double every week...
Also fixed the base count for genies in a lamp.