### PR TITLE
Fix the clipped boat sprite

### DIFF
--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -142,6 +142,10 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                 // bottom
                 if ( flag & LEVEL_BOTTOM )
                     tile.RedrawBottom( dst, isPuzzleDraw );
+
+                // map object
+                if ( flag & LEVEL_BOTTOM )
+                    tile.RedrawObjects( dst, isPuzzleDraw );
             }
         }
     }
@@ -157,10 +161,6 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                 continue;
 
             const Maps::Tiles & tile = world.GetTiles( offsetX, offsetY );
-
-            // map object
-            if ( flag & LEVEL_BOTTOM )
-                tile.RedrawObjects( dst, isPuzzleDraw );
 
             // map object
             if ( flag & LEVEL_OBJECTS && !isPuzzleDraw )


### PR DESCRIPTION
Objects were drawn in a wrong loop after a recent fix for another issue (shadows).