### PR TITLE
Reset pathfinder cache on a map change

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -956,6 +956,7 @@ int Maps::Tiles::GetObject( bool ignoreObjectUnderHero /* true */ ) const
 void Maps::Tiles::SetObject( int object )
 {
     mp2_object = object;
+    world.resetPathfinder();
 }
 
 void Maps::Tiles::SetTile( u32 sprite_index, u32 shape )

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1047,6 +1047,11 @@ std::list<Route::Step> World::getPath( int from, int to, uint32_t skill, bool ig
     return _pathfinder.buildPath( from, to, skill );
 }
 
+void World::resetPathfinder()
+{
+    _pathfinder.reset();
+}
+
 StreamBase & operator<<( StreamBase & msg, const CapturedObject & obj )
 {
     return msg << obj.objcol << obj.guardians << obj.split;

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -255,6 +255,7 @@ public:
     uint32_t getDistance( int from, int to, uint32_t skill );
     std::list<Route::Step> getPath( int from, int to, uint32_t skill, bool ignoreObjects = true );
     int searchForFog( const Heroes & hero );
+    void resetPathfinder();
 
     void ComputeStaticAnalysis();
     static u32 GetUniq( void );

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -24,9 +24,11 @@
 
 void Pathfinder::reset()
 {
-    _cache.clear();
-    _pathStart = -1;
-    _pathfindingSkill = Skill::Level::NONE;
+    if ( _pathStart != -1 || _pathfindingSkill != Skill::Level::NONE ) {
+        _cache.clear();
+        _pathStart = -1;
+        _pathfindingSkill = Skill::Level::NONE;
+    }
 }
 
 std::list<Route::Step> Pathfinder::buildPath( int from, int target, uint8_t skill )


### PR DESCRIPTION
Bug caused edge cases where you couldn't move on a summoned boat without re-selecting hero.

Any map change should use `Tiles::SetObject` function.