### PR TITLE
Battle AI: fix target adjacency

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -79,6 +79,9 @@ namespace AI
 
             const int spellPower = commander->GetPower();
             for ( const Spell & spell : allSpells ) {
+                if ( !commander->HaveSpellPoints( spell ) )
+                    continue;
+
                 if ( spell.isCombat() && spell.isDamage() && spell.isSingleTarget() ) {
                     const uint32_t totalDamage = spell.Damage() * spellPower;
                     for ( const Unit * enemy : enemies ) {

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -1000,7 +1000,7 @@ Battle::Indexes Battle::Board::GetAdjacentEnemies( const Unit & unit )
 
     if ( y > 0 ) {
         const int topRowIndex = ( y - 1 ) * ARENAW + x - mod;
-        if ( x - mod > 0 )
+        if ( x - mod >= 0 )
             validateAndInsert( topRowIndex );
 
         if ( x < ARENAW - 1 )
@@ -1018,7 +1018,7 @@ Battle::Indexes Battle::Board::GetAdjacentEnemies( const Unit & unit )
 
     if ( y < ARENAH - 1 ) {
         const int bottomRowIndex = ( y + 1 ) * ARENAW + x - mod;
-        if ( x - mod > 0 )
+        if ( x - mod >= 0 )
             validateAndInsert( bottomRowIndex );
 
         if ( x < ARENAW - 1 )


### PR DESCRIPTION
Fix an error in GetAdjacentEnemies that prevented archers finding a unit that was blocking them for melee retaliation.

Also added extra validation to spell selection function to avoid log spamming.