### PR TITLE
Allow to cast a spell with no move points

### DIFF
--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -116,7 +116,7 @@ bool Heroes::ActionSpellCast( const Spell & spell )
 {
     std::string error;
 
-    if ( !CanMove() ) {
+    if ( !CanMove() && ( spell == Spell::DIMENSIONDOOR || spell == Spell::TOWNGATE || spell == Spell::TOWNPORTAL ) ) {
         Dialog::Message( "", _( "Your hero is too tired to cast this spell today. Try again tomorrow." ), Font::BIG, Dialog::OK );
         return false;
     }


### PR DESCRIPTION
only for non-movement spells

relates to #659