### PR TITLE
Battle AI: make it more agressive when dealing with archers

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -158,6 +158,7 @@ namespace AI
             averageAllyDefense += unit.GetDefense();
         }
 
+        const double enemyArcherRatio = enemyShooterStr / enemyArmyStrength;
         // Will be used for better unit strength heuristic
         averageAllyDefense = ( enemiesCount > 0 ) ? averageAllyDefense / enemiesCount : 1;
         averageEnemyAttack = ( enemiesCount > 0 ) ? averageEnemyAttack / enemiesCount : 1;
@@ -189,9 +190,10 @@ namespace AI
                     myShooterStr /= 2;
             }
         }
-        DEBUG( DBG_AI, DBG_TRACE, "Comparing shooters: " << myShooterStr << ", vs enemy " << enemyShooterStr );
 
-        const bool defensiveTactics = defendingCastle || myShooterStr > enemyShooterStr;
+        const bool defensiveTactics = enemyArcherRatio < 0.75 && ( defendingCastle || myShooterStr > enemyShooterStr );
+        DEBUG( DBG_AI, DBG_TRACE, "Tactic " << defensiveTactics << " chosen. Archers: " << myShooterStr << ", vs enemy " << enemyShooterStr << " ratio is " << enemyArcherRatio );
+
         const double attackDistanceModifier = enemyArmyStrength / STRENGTH_DISTANCE_FACTOR;
         const double defenceDistanceModifier = myArmyStrength / STRENGTH_DISTANCE_FACTOR;
 

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -192,7 +192,8 @@ namespace AI
         }
 
         const bool defensiveTactics = enemyArcherRatio < 0.75 && ( defendingCastle || myShooterStr > enemyShooterStr );
-        DEBUG( DBG_AI, DBG_TRACE, "Tactic " << defensiveTactics << " chosen. Archers: " << myShooterStr << ", vs enemy " << enemyShooterStr << " ratio is " << enemyArcherRatio );
+        DEBUG( DBG_AI, DBG_TRACE,
+               "Tactic " << defensiveTactics << " chosen. Archers: " << myShooterStr << ", vs enemy " << enemyShooterStr << " ratio is " << enemyArcherRatio );
 
         const double attackDistanceModifier = enemyArmyStrength / STRENGTH_DISTANCE_FACTOR;
         const double defenceDistanceModifier = myArmyStrength / STRENGTH_DISTANCE_FACTOR;


### PR DESCRIPTION
Happens when AI's enemy has shooters mainly army. Matters especially during castle sieges, should help to reduce the casualties.