### PR TITLE
Strategic AI: fix hero paths

### DIFF
--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -63,6 +63,10 @@ namespace AI
         HERO_CHAMPION = 0x80000000
     };
 
+    const double ARMY_STRENGTH_ADVANTAGE_SMALL = 1.3;
+    const double ARMY_STRENGTH_ADVANTAGE_MEDUIM = 1.5;
+    const double ARMY_STRENGTH_ADVANTAGE_LARGE = 1.8;
+
     class Base
     {
     public:

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -92,10 +92,6 @@ namespace AI
     uint32_t AIGetAllianceColors();
     bool AIHeroesShowAnimation( const Heroes & hero, uint32_t colors );
 
-    const double ARMY_STRENGTH_ADVANTAGE_SMALL = 1.3;
-    const double ARMY_STRENGTH_ADVANTAGE_MEDUIM = 1.5;
-    const double ARMY_STRENGTH_ADVANTAGE_LARGE = 1.8;
-
     int AISelectPrimarySkill( Heroes & hero )
     {
         switch ( hero.GetRace() ) {

--- a/src/fheroes2/ai/normal/ai_normal.cpp
+++ b/src/fheroes2/ai/normal/ai_normal.cpp
@@ -23,6 +23,7 @@
 namespace AI
 {
     Normal::Normal()
+        : _pathfinder( ARMY_STRENGTH_ADVANTAGE_MEDUIM )
     {
         _personality = Rand::Get( AI::WARRIOR, AI::EXPLORER );
     }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -141,9 +141,9 @@ namespace AI
         }
 
         // Remove the object from the list so other heroes won't target it
-        for ( size_t idx = 0; idx < _mapObjects.size(); ++idx ) {
+        for ( size_t idx = 0; idx < _mapObjects.size() && !objectsToErase.empty(); ++idx ) {
             auto it = std::find( objectsToErase.begin(), objectsToErase.end(), _mapObjects[idx].first );
-            if ( it != objectsToErase.end() ) {
+            if ( it != objectsToErase.end() && ( MP2::isCaptureObject( _mapObjects[idx].second ) || MP2::isPickupObject( _mapObjects[idx].second ) ) ) {
                 // this method does not retain the vector order
                 _mapObjects[idx] = _mapObjects.back();
                 _mapObjects.pop_back();

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -131,8 +131,7 @@ namespace AI
             
 
             if ( targetIndex != -1 ) {
-                auto path = _pathfinder.buildPath( targetIndex );
-                hero.GetPath().assign( path.begin(), path.end() );
+                hero.GetPath().setPath( _pathfinder.buildPath( targetIndex ), targetIndex );
                 HeroesMove( hero );
             }
             else {

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -179,7 +179,7 @@ namespace AI
         VecHeroes sortedHeroList = heroes;
         std::sort( sortedHeroList.begin(), sortedHeroList.end(), []( const Heroes * left, const Heroes * right ) {
             if ( left && right )
-                return left->GetArmy().GetStrength() < right->GetArmy().GetStrength();
+                return left->GetArmy().GetStrength() > right->GetArmy().GetStrength();
             return right == NULL;
         } );
 

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -27,9 +27,13 @@
 
 namespace AI
 {
-    bool IsValidKingdomObject( const Maps::Tiles & tile, int objectID, int kingdomColor )
+    bool IsValidKingdomObject( const Kingdom & kingdom, const Maps::Tiles & tile, int objectID )
     {
+        const int kingdomColor = kingdom.GetColor();
         if ( tile.isFog( kingdomColor ) || ( !MP2::isGroundObject( objectID ) && objectID != MP2::OBJ_COAST ) )
+            return false;
+
+        if ( kingdom.isVisited( tile.GetIndex(), objectID ) )
             return false;
 
         // Check castle first to ignore guest hero (tile with both Castle and Hero)
@@ -87,7 +91,7 @@ namespace AI
             const Maps::Tiles & tile = world.GetTiles( idx );
             int objectID = tile.GetObject();
 
-            if ( !IsValidKingdomObject( tile, objectID, color ) )
+            if ( !IsValidKingdomObject( kingdom, tile, objectID ) )
                 continue;
 
             _mapObjects.emplace_back( idx, objectID );

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1119,6 +1119,7 @@ double Army::GetStrength( void ) const
 {
     double res = 0;
     const uint32_t archery = ( commander ) ? commander->GetSecondaryValues( Skill::Secondary::ARCHERY ) : 0;
+    const int armyMorale = GetMorale();
 
     for ( const_iterator it = begin(); it != end(); ++it ) {
         const Troop * troop = *it;
@@ -1130,8 +1131,9 @@ double Army::GetStrength( void ) const
             }
 
             // GetMorale checks if unit is affected by it
-            const int morale = troop->GetMorale();
-            strength *= 1 + ( ( morale < 0 ) ? morale / 12.0 : morale / 24.0 );
+            if ( troop->isAffectedByMorale() )
+                strength *= 1 + ( ( armyMorale < 0 ) ? armyMorale / 12.0 : armyMorale / 24.0 );
+
             strength *= 1 + troop->GetLuck() / 24.0;
 
             res += strength;

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -354,7 +354,7 @@ u32 Troops::GetUniqueCount( void ) const
     std::set<int> monsters;
 
     for ( size_t idx = 0; idx < size(); ++idx ) {
-        const Troop * troop = operator[](idx);
+        const Troop * troop = operator[]( idx );
         if ( troop && troop->isValid() )
             monsters.insert( troop->GetID() );
     }
@@ -750,7 +750,7 @@ Army::~Army()
     clear();
 }
 
-void Army::setFromTile( const Maps::Tiles & tile ) 
+void Army::setFromTile( const Maps::Tiles & tile )
 {
     Reset();
 

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <functional>
 #include <math.h>
+#include <set>
 
 #include "agg.h"
 #include "army.h"
@@ -350,15 +351,13 @@ void Troops::JoinTroops( Troops & troops2 )
 
 u32 Troops::GetUniqueCount( void ) const
 {
-    std::vector<int> monsters;
-    monsters.reserve( size() );
+    std::set<int> monsters;
 
-    for ( const_iterator it = begin(); it != end(); ++it )
-        if ( ( *it )->isValid() )
-            monsters.push_back( ( *it )->GetID() );
-
-    std::sort( monsters.begin(), monsters.end() );
-    monsters.resize( std::distance( monsters.begin(), std::unique( monsters.begin(), monsters.end() ) ) );
+    for ( size_t idx = 0; idx < size(); ++idx ) {
+        const Troop * troop = operator[](idx);
+        if ( troop && troop->isValid() )
+            monsters.insert( troop->GetID() );
+    }
 
     return monsters.size();
 }
@@ -741,10 +740,25 @@ Army::Army( const Maps::Tiles & t )
     for ( u32 ii = 0; ii < ARMYMAXTROOPS; ++ii )
         push_back( new ArmyTroop( this ) );
 
-    if ( MP2::isCaptureObject( t.GetObject() ) )
-        color = t.QuantityColor();
+    setFromTile( t );
+}
 
-    switch ( t.GetObject( false ) ) {
+Army::~Army()
+{
+    for ( iterator it = begin(); it != end(); ++it )
+        delete *it;
+    clear();
+}
+
+void Army::setFromTile( const Maps::Tiles & tile ) 
+{
+    Reset();
+
+    const bool isCaptureObject = MP2::isCaptureObject( tile.GetObject() );
+    if ( isCaptureObject )
+        color = tile.QuantityColor();
+
+    switch ( tile.GetObject( false ) ) {
     case MP2::OBJ_PYRAMID:
         at( 0 )->Set( Monster::ROYAL_MUMMY, 10 );
         at( 1 )->Set( Monster::VAMPIRE_LORD, 10 );
@@ -759,7 +773,7 @@ Army::Army( const Maps::Tiles & t )
         break;
 
     case MP2::OBJ_SHIPWRECK:
-        at( 0 )->Set( Monster::GHOST, t.GetQuantity2() );
+        at( 0 )->Set( Monster::GHOST, tile.GetQuantity2() );
         ArrangeForBattle( false );
         break;
 
@@ -769,7 +783,7 @@ Army::Army( const Maps::Tiles & t )
         break;
 
     case MP2::OBJ_ARTIFACT:
-        switch ( t.QuantityVariant() ) {
+        switch ( tile.QuantityVariant() ) {
         case 6:
             at( 0 )->Set( Monster::ROGUE, 50 );
             break;
@@ -835,8 +849,8 @@ Army::Army( const Maps::Tiles & t )
         break;
 
     default:
-        if ( MP2::isCaptureObject( t.GetObject() ) ) {
-            CapturedObject & co = world.GetCapturedObject( t.GetIndex() );
+        if ( isCaptureObject ) {
+            CapturedObject & co = world.GetCapturedObject( tile.GetIndex() );
             Troop & troop = co.GetTroop();
 
             switch ( co.GetSplit() ) {
@@ -869,23 +883,17 @@ Army::Army( const Maps::Tiles & t )
         }
         else {
             MapMonster * map_troop = NULL;
-            if ( t.GetObject() == MP2::OBJ_MONSTER )
-                map_troop = dynamic_cast<MapMonster *>( world.GetMapObject( t.GetObjectUID() ) );
+            if ( tile.GetObject() == MP2::OBJ_MONSTER )
+                map_troop = dynamic_cast<MapMonster *>( world.GetMapObject( tile.GetObjectUID() ) );
 
-            Troop troop = map_troop ? map_troop->QuantityTroop() : t.QuantityTroop();
+            Troop troop = map_troop ? map_troop->QuantityTroop() : tile.QuantityTroop();
 
             at( 0 )->Set( troop );
-            ArrangeForBattle( true );
+            if ( troop.isValid() )
+                ArrangeForBattle( true );
         }
         break;
     }
-}
-
-Army::~Army()
-{
-    for ( iterator it = begin(); it != end(); ++it )
-        delete *it;
-    clear();
 }
 
 bool Army::isFullHouse( void ) const

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -146,6 +146,7 @@ public:
     ~Army();
 
     void Reset( bool = false ); // reset: soft or hard
+    void setFromTile( const Maps::Tiles & tile );
 
     int GetRace( void ) const;
     int GetColor( void ) const;

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -2376,7 +2376,7 @@ Army & Castle::GetActualArmy( void )
 bool Castle::AllowBuyBoat( void ) const
 {
     // check payment and present other boat
-    return ( HaveNearlySea() && GetKingdom().AllowPayment( PaymentConditions::BuyBoat() ) && !PresentBoat() );
+    return ( HaveNearlySea() && isBuild( BUILD_SHIPYARD ) && GetKingdom().AllowPayment( PaymentConditions::BuyBoat() ) && !PresentBoat() );
 }
 
 bool Castle::BuyBoat( void )

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -49,7 +49,8 @@ void Interface::Basic::CalculateHeroPath( Heroes * hero, s32 destinationIdx )
     if ( destinationIdx == -1 )
         destinationIdx = path.GetDestinedIndex(); // returns -1 at the time of launching new game (because of no path history)
     if ( destinationIdx != -1 ) {
-        DEBUG( DBG_GAME, DBG_TRACE, hero->GetName() << ", distance: " << path.Calculate( destinationIdx ) << ", route: " << path.String() );
+        hero->GetPath().setPath( world.getPath( *hero, destinationIdx ), destinationIdx );
+        DEBUG( DBG_GAME, DBG_TRACE, hero->GetName() << ", distance: " << world.getDistance( *hero, destinationIdx ) << ", route: " << path.String() );
         gameArea.SetRedraw();
 
         LocalEvent & le = LocalEvent::Get();

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -536,11 +536,14 @@ void Heroes::MoveStep( Heroes & hero, s32 indexTo, bool newpos )
         hero.ActionNewPosition();
         path.PopFront();
 
-        // possible hero is die
-        if ( !hero.isFreeman() && indexTo == hero.GetPath().GetDestinationIndex() ) {
-            hero.GetPath().Reset();
+        // possible that hero loses the battle
+        if ( !hero.isFreeman() ) {
             hero.Action( indexTo );
-            hero.SetMove( false );
+
+            if ( indexTo == hero.GetPath().GetDestinationIndex() ) {
+                hero.GetPath().Reset();
+                hero.SetMove( false );
+            }
         }
     }
     else {

--- a/src/fheroes2/heroes/route.cpp
+++ b/src/fheroes2/heroes/route.cpp
@@ -119,14 +119,10 @@ s32 Route::Path::GetDestinedIndex( void ) const
     return dst;
 }
 
-/* return length path */
-uint32_t Route::Path::Calculate( const s32 & destIndex )
+void Route::Path::setPath( const std::list<Route::Step> & path, int32_t destIndex )
 {
+    assign( path.begin(), path.end() );
     dst = destIndex;
-
-    std::list<Step>::operator=( world.getPath( *hero, dst ) );
-
-    return world.getDistance( *hero, dst );
 }
 
 void Route::Path::Reset( void )
@@ -505,10 +501,14 @@ void Route::Path::RescanObstacle( void )
     if ( it != end() && ( *it ).GetIndex() != GetLastIndex() ) {
         size_t size1 = size();
         s32 reduce = ( *it ).GetFrom();
-        Calculate( dst );
+
+        std::list<Step> path = world.getPath( *hero, dst );
+        const bool reducePath = path.size() > size1 * 2;
         // reduce
-        if ( size() > size1 * 2 )
-            Calculate( reduce );
+        if ( reducePath )
+            path = world.getPath( *hero, reduce );
+
+        setPath( path, reducePath ? reduce : dst );
     }
 }
 

--- a/src/fheroes2/heroes/route.h
+++ b/src/fheroes2/heroes/route.h
@@ -76,7 +76,7 @@ namespace Route
         u32 GetFrontPenalty( void ) const;
         u32 GetTotalPenalty( void ) const;
         uint32_t getLastMovePenalty() const;
-        uint32_t Calculate( const s32 & destIndex );
+        void setPath( const std::list<Step> & path, int32_t destIndex );
 
         void Show( void )
         {

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -955,6 +955,29 @@ bool MP2::isHeroUpgradeObject( int obj )
     return false;
 }
 
+bool MP2::isProtectedObject( int obj )
+{
+    switch ( obj ) {
+    case OBJ_MONSTER:
+    case OBJ_ARTIFACT:
+    case OBJ_DERELICTSHIP:
+    case OBJ_SHIPWRECK:
+    case OBJ_GRAVEYARD:
+    case OBJ_PYRAMID:
+    case OBJ_DAEMONCAVE:
+    case OBJ_ABANDONEDMINE:
+    case OBJ_CITYDEAD:
+    case OBJ_TROLLBRIDGE:
+    case OBJ_DRAGONCITY:
+        return true;
+
+    default:
+        break;
+    }
+
+    return isCaptureObject( obj );
+}
+
 bool MP2::isMoveObject( int obj )
 {
     switch ( obj ) {

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -551,6 +551,7 @@ namespace MP2
     bool isRemoveObject( int obj );
     bool isMoveObject( int obj );
     bool isAbandonedMine( int obj );
+    bool isProtectedObject( int obj );
 
     bool isNeedStayFront( int obj );
     bool isClearGroundObject( int obj );

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -19,6 +19,7 @@
  ***************************************************************************/
 
 #include "world_pathfinding.h"
+#include "ai.h"
 #include "ground.h"
 #include "world.h"
 
@@ -301,7 +302,7 @@ void AIWorldPathfinder::processCurrentNode( std::vector<int> & nodesToExplore, i
     bool isProtected = false;
     const MapsIndexes & monsters = Maps::GetTilesUnderProtection( currentNodeIdx );
     for ( auto it = monsters.begin(); it != monsters.end(); ++it ) {
-        if ( Army( world.GetTiles( *it ) ).GetStrength() > _armyStrength ) {
+        if ( Army( world.GetTiles( *it ) ).GetStrength() * _advantage > _armyStrength ) {
             isProtected = true;
             break;
         }

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -298,13 +298,20 @@ void AIWorldPathfinder::processCurrentNode( std::vector<int> & nodesToExplore, i
 {
     const bool isFirstNode = currentNodeIdx == pathStart;
     PathfindingNode & currentNode = _cache[currentNodeIdx];
+
     // find out if current node is protected by a strong army
-    bool isProtected = false;
-    const MapsIndexes & monsters = Maps::GetTilesUnderProtection( currentNodeIdx );
-    for ( auto it = monsters.begin(); it != monsters.end(); ++it ) {
-        if ( Army( world.GetTiles( *it ) ).GetStrength() * _advantage > _armyStrength ) {
-            isProtected = true;
-            break;
+    auto protectionCheck = [this]( int index ) { 
+        return Army( world.GetTiles( index ) ).GetStrength() * _advantage > _armyStrength;
+    };
+
+    bool isProtected = protectionCheck(currentNodeIdx);
+    if ( !isProtected ) {
+        const MapsIndexes & monsters = Maps::GetTilesUnderProtection( currentNodeIdx );
+        for ( auto it = monsters.begin(); it != monsters.end(); ++it ) {
+            isProtected = protectionCheck( *it );
+            if ( isProtected ) {
+                break;
+            }
         }
     }
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -300,8 +300,10 @@ void AIWorldPathfinder::processCurrentNode( std::vector<int> & nodesToExplore, i
     PathfindingNode & currentNode = _cache[currentNodeIdx];
 
     // find out if current node is protected by a strong army
-    auto protectionCheck = [this]( int index ) { 
-        return Army( world.GetTiles( index ) ).GetStrength() * _advantage > _armyStrength;
+    Army currentArmy;
+    auto protectionCheck = [this, &currentArmy]( int index ) {
+        currentArmy.setFromTile( world.GetTiles( index ) );
+        return currentArmy.GetStrength() * _advantage > _armyStrength;
     };
 
     bool isProtected = protectionCheck(currentNodeIdx);

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -300,13 +300,16 @@ void AIWorldPathfinder::processCurrentNode( std::vector<int> & nodesToExplore, i
     PathfindingNode & currentNode = _cache[currentNodeIdx];
 
     // find out if current node is protected by a strong army
-    Army currentArmy;
-    auto protectionCheck = [this, &currentArmy]( int index ) {
-        currentArmy.setFromTile( world.GetTiles( index ) );
-        return currentArmy.GetStrength() * _advantage > _armyStrength;
+    auto protectionCheck = [this]( int index ) {
+        const Maps::Tiles & tile = world.GetTiles( index );
+        if ( MP2::isProtectedObject( tile.GetObject() ) ) {
+            _temporaryArmy.setFromTile( tile );
+            return _temporaryArmy.GetStrength() * _advantage > _armyStrength;
+        }
+        return false;
     };
 
-    bool isProtected = protectionCheck(currentNodeIdx);
+    bool isProtected = protectionCheck( currentNodeIdx );
     if ( !isProtected ) {
         const MapsIndexes & monsters = Maps::GetTilesUnderProtection( currentNodeIdx );
         for ( auto it = monsters.begin(); it != monsters.end(); ++it ) {

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "army.h"
 #include "color.h"
 #include "pathfinding.h"
 #include "route.h"
@@ -86,4 +87,5 @@ private:
     int _currentColor = Color::NONE;
     double _armyStrength = -1;
     double _advantage = 1.0;
+    Army _temporaryArmy; // for internal calculations
 };

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -64,7 +64,9 @@ private:
 class AIWorldPathfinder : public WorldPathfinder
 {
 public:
-    AIWorldPathfinder() {}
+    AIWorldPathfinder( double advantage )
+        : _advantage( advantage )
+    {}
     virtual void reset() override;
 
     void reEvaluateIfNeeded( int start, int color, double armyStrength, uint8_t skill );
@@ -83,4 +85,5 @@ private:
 
     int _currentColor = Color::NONE;
     double _armyStrength = -1;
+    double _advantage = 1.0;
 };


### PR DESCRIPTION
Fixes #1946 .

Fix regression that broke path building on non-debug builds.
Teach AI to collect/capture multiple objects on the same move.
Adjust heuristics to make sure AI doesn't miss important objects.
Optimize common Army functions that slowed down the calculations.
Fixed a bug where AI was able to buy boats in a castle without shipyard.