### PR TITLE
Fix potential infinite loop when AI is stuck on teleporters

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1909,7 +1909,9 @@ namespace AI
 
     void HeroesMove( Heroes & hero )
     {
-        if ( hero.GetPath().isValid() ) {
+        Route::Path & path = hero.GetPath();
+
+        if ( path.isValid() ) {
             hero.SetMove( true );
 
             Cursor & cursor = Cursor::Get();
@@ -1998,6 +2000,10 @@ namespace AI
             }
 
             hero.SetMove( false );
+        }
+        else if ( path.size() && path.GetFrontDirection() == Direction::UNKNOWN ) {
+            if ( MP2::isActionObject( hero.GetMapsObject(), hero.isShipMaster() ) )
+                hero.Action( hero.GetIndex() );
         }
     }
 }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -123,6 +123,7 @@ namespace AI
 
         std::vector<int> objectsToErase;
         while ( hero.MayStillMove() && !hero.Modes( AI::HERO_WAITING | AI::HERO_MOVED ) ) {
+            const int startIndex = hero.GetIndex();
             const int targetIndex = GetPriorityTarget( hero );
 
             if ( targetIndex != -1 ) {
@@ -130,6 +131,12 @@ namespace AI
                 _pathfinder.reEvaluateIfNeeded( hero );
                 hero.GetPath().setPath( _pathfinder.buildPath( targetIndex ), targetIndex );
                 HeroesMove( hero );
+
+                // Check if hero is stuck
+                if ( targetIndex != startIndex && hero.GetIndex() == startIndex ) {
+                    hero.SetModes( AI::HERO_WAITING );
+                    DEBUG( DBG_AI, DBG_WARN, hero.GetName() << " is stuck trying to reach " << targetIndex );
+                }
             }
             else {
                 hero.SetModes( AI::HERO_WAITING );


### PR DESCRIPTION
Allow AI player to start its move with an Action (to teleport for example).

Add a safeguard for similar future issues that would show the warning and end turn.