### PR TITLE
Use original difficulty bonuses for the game

### DIFF
--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -30,6 +30,10 @@ class Castle;
 class HeroBase;
 class Heroes;
 class Kingdom;
+namespace Maps
+{
+    class Tiles;
+}
 namespace Battle
 {
     class Arena;
@@ -74,6 +78,8 @@ namespace AI
         virtual void CastleTurn( Castle & castle, bool defensive = false );
         virtual void BattleTurn( Battle::Arena & arena, const Battle::Unit & unit, Battle::Actions & actions );
         virtual void HeroTurn( Heroes & hero );
+
+        virtual void revealFog( const Maps::Tiles & tile );
 
         virtual void HeroesAdd( const Heroes & hero );
         virtual void HeroesRemove( const Heroes & hero );

--- a/src/fheroes2/ai/ai_base.cpp
+++ b/src/fheroes2/ai/ai_base.cpp
@@ -88,6 +88,8 @@ namespace AI
 
     void Base::HeroesClearTask( const Heroes & ) {}
 
+    void Base::revealFog( const Maps::Tiles & ) {}
+
     std::string Base::HeroesString( const Heroes & )
     {
         return "";

--- a/src/fheroes2/ai/normal/ai_normal.cpp
+++ b/src/fheroes2/ai/normal/ai_normal.cpp
@@ -19,6 +19,7 @@
  ***************************************************************************/
 
 #include "ai_normal.h"
+#include "maps_tiles.h"
 
 namespace AI
 {
@@ -31,5 +32,10 @@ namespace AI
     void Normal::resetPathfinder()
     {
         _pathfinder.reset();
+    }
+
+    void Normal::revealFog( const Maps::Tiles & tile )
+    {
+        _mapObjects.emplace_back( tile.GetIndex(), tile.GetObject() );
     }
 }

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -37,6 +37,8 @@ namespace AI
         void BattleTurn( Battle::Arena & arena, const Battle::Unit & currentUnit, Battle::Actions & actions );
         void HeroTurn( Heroes & hero );
 
+        void revealFog( const Maps::Tiles & tile );
+
         void HeroesActionComplete( Heroes & hero, int index );
         int GetPriorityTarget( const Heroes & hero );
         void resetPathfinder();

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -455,6 +455,9 @@ void Castle::ActionNewWeek( void )
                 if ( ( dwellings1[ii] == DWELLING_MONSTER1 ) && ( building & BUILD_WEL2 ) )
                     growth += GetGrownWel2();
 
+                if ( isControlAI() )
+                    growth *= Difficulty::GetUnitGrowthBonus( Settings::Get().GameDifficulty() );
+
                 // neutral town: half population (normal for begin month)
                 if ( isNeutral && !world.BeginMonth() )
                     growth /= 2;

--- a/src/fheroes2/game/difficulty.cpp
+++ b/src/fheroes2/game/difficulty.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include "difficulty.h"
+#include "resource.h"
 
 const std::string & Difficulty::String( int difficulty )
 {
@@ -43,4 +44,52 @@ const std::string & Difficulty::String( int difficulty )
     }
 
     return str_difficulty[5];
+}
+
+cost_t Difficulty::GetKingdomStartingResources( int difficulty, bool isAIKingdom )
+{
+    static cost_t startingResourcesSet[] = { { 10000, 30, 10, 30, 10, 10, 10 },
+                                             { 7500, 20, 5, 20, 5, 5, 5 },
+                                             { 5000, 10, 2, 10, 2, 2, 2 },
+                                             { 2500, 5, 0, 5, 0, 0, 0 },
+                                             { 0, 0, 0, 0, 0, 0, 0 },
+                                             // ai resource
+                                             { 10000, 30, 10, 30, 10, 10, 10 } };
+
+    if ( isAIKingdom )
+        return startingResourcesSet[5];
+
+    switch ( difficulty ) {
+    case Difficulty::EASY:
+        return startingResourcesSet[0];
+    case Difficulty::NORMAL:
+        return startingResourcesSet[1];
+    case Difficulty::HARD:
+        return startingResourcesSet[2];
+    case Difficulty::EXPERT:
+        return startingResourcesSet[3];
+    case Difficulty::IMPOSSIBLE:
+        return startingResourcesSet[4];
+    default:
+        break;
+    }
+
+    return startingResourcesSet[1];
+}
+
+int Difficulty::GetScoutingBonus( int difficulty )
+{
+    switch ( difficulty ) {
+    case Difficulty::NORMAL:
+        return 1;
+    case Difficulty::HARD:
+        return 2;
+    case Difficulty::EXPERT:
+        return 3;
+    case Difficulty::IMPOSSIBLE:
+        return 4;
+    default:
+        break;
+    }
+    return 0;
 }

--- a/src/fheroes2/game/difficulty.cpp
+++ b/src/fheroes2/game/difficulty.cpp
@@ -93,3 +93,65 @@ int Difficulty::GetScoutingBonus( int difficulty )
     }
     return 0;
 }
+
+double Difficulty::GetGoldIncomeBonus( int difficulty )
+{
+    switch ( difficulty ) {
+    case Difficulty::EASY:
+        return 0.75;
+    case Difficulty::HARD:
+        return 1.29;
+    case Difficulty::EXPERT:
+        return 1.45;
+    case Difficulty::IMPOSSIBLE:
+        return 1.6;
+    default:
+        break;
+    }
+    return 1.0;
+}
+
+double Difficulty::GetUnitGrowthBonus( int difficulty )
+{
+    switch ( difficulty ) {
+    case Difficulty::HARD:
+        return 1.2;
+    case Difficulty::EXPERT:
+        return 1.32;
+    case Difficulty::IMPOSSIBLE:
+        return 1.44;
+    default:
+        break;
+    }
+    return 1.0;
+}
+
+double Difficulty::GetBattleExperienceBonus( int difficulty )
+{
+    switch ( difficulty ) {
+    case Difficulty::NORMAL:
+        return 1.12;
+    case Difficulty::HARD:
+        return 1.24;
+    case Difficulty::EXPERT:
+        return 1.36;
+    case Difficulty::IMPOSSIBLE:
+        return 1.48;
+    default:
+        break;
+    }
+    return 1.0;
+}
+
+int Difficulty::GetHeroMovementBonus( int difficulty )
+{
+    switch ( difficulty ) {
+    case Difficulty::EXPERT:
+        return 75;
+    case Difficulty::IMPOSSIBLE:
+        return 75;
+    default:
+        break;
+    }
+    return 0;
+}

--- a/src/fheroes2/game/difficulty.cpp
+++ b/src/fheroes2/game/difficulty.cpp
@@ -48,13 +48,13 @@ const std::string & Difficulty::String( int difficulty )
 
 cost_t Difficulty::GetKingdomStartingResources( int difficulty, bool isAIKingdom )
 {
-    static cost_t startingResourcesSet[] = { { 10000, 30, 10, 30, 10, 10, 10 },
-                                             { 7500, 20, 5, 20, 5, 5, 5 },
-                                             { 5000, 10, 2, 10, 2, 2, 2 },
-                                             { 2500, 5, 0, 5, 0, 0, 0 },
-                                             { 0, 0, 0, 0, 0, 0, 0 },
-                                             // ai resource
-                                             { 10000, 30, 10, 30, 10, 10, 10 } };
+    static cost_t startingResourcesSet[] = {{10000, 30, 10, 30, 10, 10, 10},
+                                            {7500, 20, 5, 20, 5, 5, 5},
+                                            {5000, 10, 2, 10, 2, 2, 2},
+                                            {2500, 5, 0, 5, 0, 0, 0},
+                                            {0, 0, 0, 0, 0, 0, 0},
+                                            // ai resource
+                                            {10000, 30, 10, 30, 10, 10, 10}};
 
     if ( isAIKingdom )
         return startingResourcesSet[5];

--- a/src/fheroes2/game/difficulty.h
+++ b/src/fheroes2/game/difficulty.h
@@ -24,6 +24,7 @@
 
 #include "gamedefs.h"
 
+struct cost_t;
 namespace Difficulty
 {
     enum
@@ -36,6 +37,9 @@ namespace Difficulty
     };
 
     const std::string & String( int );
+
+    cost_t GetKingdomStartingResources( int difficulty, bool isAIKingdom );
+    int GetScoutingBonus( int difficulty );
 }
 
 #endif

--- a/src/fheroes2/game/difficulty.h
+++ b/src/fheroes2/game/difficulty.h
@@ -40,6 +40,10 @@ namespace Difficulty
 
     cost_t GetKingdomStartingResources( int difficulty, bool isAIKingdom );
     int GetScoutingBonus( int difficulty );
+    double GetGoldIncomeBonus( int difficulty );
+    double GetUnitGrowthBonus( int difficulty );
+    double GetBattleExperienceBonus( int difficulty );
+    int GetHeroMovementBonus( int difficulty );
 }
 
 #endif

--- a/src/fheroes2/game/game_static.cpp
+++ b/src/fheroes2/game/game_static.cpp
@@ -371,26 +371,6 @@ u32 GameStatic::GetGameOverLostDays( void )
     return gameover_lost_days;
 }
 
-cost_t & GameStatic::GetKingdomStartingResource( int df )
-{
-    switch ( df ) {
-    case Difficulty::EASY:
-        return kingdom_starting_resource[0];
-    case Difficulty::NORMAL:
-        return kingdom_starting_resource[1];
-    case Difficulty::HARD:
-        return kingdom_starting_resource[2];
-    case Difficulty::EXPERT:
-        return kingdom_starting_resource[3];
-    case Difficulty::IMPOSSIBLE:
-        return kingdom_starting_resource[4];
-    default:
-        break;
-    }
-
-    return kingdom_starting_resource[5];
-}
-
 u32 GameStatic::GetHeroesRestoreSpellPointsPerDay( void )
 {
     return heroes_spell_points_day;

--- a/src/fheroes2/game/game_static.h
+++ b/src/fheroes2/game/game_static.h
@@ -25,7 +25,6 @@
 
 #include "gamedefs.h"
 
-struct cost_t;
 namespace Skill
 {
     struct stats_t;
@@ -48,7 +47,6 @@ namespace GameStatic
     u32 GetGameOverLostDays( void );
     u32 GetOverViewDistance( u32 );
 
-    cost_t & GetKingdomStartingResource( int difficulty );
     u32 GetKingdomMaxHeroes( void );
 
     u32 GetCastleGrownWell( void );

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -30,6 +30,7 @@
 #include "battle.h"
 #include "castle.h"
 #include "cursor.h"
+#include "difficulty.h"
 #include "direction.h"
 #include "game.h"
 #include "game_interface.h"
@@ -646,6 +647,10 @@ u32 Heroes::GetMaxMovePoints( void ) const
     acount = HasArtifact( Artifact::TRUE_COMPASS_MOBILITY );
     if ( acount )
         point += acount * 500;
+
+    if ( isControlAI() ) {
+        point += Difficulty::GetHeroMovementBonus( Settings::Get().GameDifficulty() );
+    }
 
     return point;
 }

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -540,6 +540,10 @@ Funds Kingdom::GetIncome( int type /* INCOME_ALL */ ) const
             totalIncome.gold += ( **ith ).GetSecondaryValues( Skill::Secondary::ESTATES );
     }
 
+    if ( isControlAI() ) {
+        totalIncome.gold *= Difficulty::GetGoldIncomeBonus( Settings::Get().GameDifficulty() );
+    }
+
     return totalIncome;
 }
 

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -101,7 +101,7 @@ int Kingdom::GetRace( void ) const
 
 void Kingdom::UpdateStartingResource( void )
 {
-    resource = GameStatic::GetKingdomStartingResource( isControlAI() ? 5 : Settings::Get().GameDifficulty() );
+    resource = Difficulty::GetKingdomStartingResources( Settings::Get().GameDifficulty(), isControlAI() );
 }
 
 bool Kingdom::isLoss( void ) const

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 
+#include "ai.h"
 #include "difficulty.h"
 #include "game.h"
 #include "icn.h"
@@ -372,7 +373,8 @@ void Maps::ClearFog( s32 index, int scoute, int color )
         const Settings & conf = Settings::Get();
 
         // AI advantage
-        if ( world.GetKingdom( color ).isControlAI() ) {
+        const bool isAIPlayer = world.GetKingdom( color ).isControlAI();
+        if ( isAIPlayer ) {
             scoute += Difficulty::GetScoutingBonus( conf.GameDifficulty() );
         }
 
@@ -383,8 +385,12 @@ void Maps::ClearFog( s32 index, int scoute, int color )
             for ( s32 x = center.x - scoute; x <= center.x + scoute; ++x ) {
                 const s32 dx = x - center.x;
                 const s32 dy = y - center.y;
-                if ( isValidAbsPoint( x, y ) && revealRadiusSquared >= dx * dx + dy * dy )
-                    world.GetTiles( GetIndexFromAbsPoint( x, y ) ).ClearFog( colors );
+                if ( isValidAbsPoint( x, y ) && revealRadiusSquared >= dx * dx + dy * dy ) {
+                    Maps::Tiles & tile = world.GetTiles( GetIndexFromAbsPoint( x, y ) );
+                    tile.ClearFog( colors );
+                    if ( isAIPlayer )
+                        AI::Get().revealFog( tile );
+                }
             }
         }
     }

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -373,22 +373,7 @@ void Maps::ClearFog( s32 index, int scoute, int color )
 
         // AI advantage
         if ( world.GetKingdom( color ).isControlAI() ) {
-            switch ( conf.GameDifficulty() ) {
-            case Difficulty::NORMAL:
-                scoute += 2;
-                break;
-            case Difficulty::HARD:
-                scoute += 3;
-                break;
-            case Difficulty::EXPERT:
-                scoute += 4;
-                break;
-            case Difficulty::IMPOSSIBLE:
-                scoute += 6;
-                break;
-            default:
-                break;
-            }
+            scoute += Difficulty::GetScoutingBonus( conf.GameDifficulty() );
         }
 
         const int colors = Players::GetPlayerFriends( color );


### PR DESCRIPTION
Fixes #657 .

Moved difficulty-related code into the same namespace.
Added missing bonuses to the appropriate calculations and corrected the existing logic.
Also added an important fix to the AI scouting logic.