### PR TITLE
Fix boat sprite on older saves

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1555,8 +1555,9 @@ void Maps::Tiles::RedrawBoat( fheroes2::Image & dst ) const
     const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
 
     if ( area.GetVisibleTileROI() & mp ) {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::BOAT32, objectIndex % 128 );
-        area.BlitOnTile( dst, sprite, sprite.x(), TILEWIDTH + sprite.y(), mp, ( objectIndex > 128 ) );
+        const uint32_t spriteIndex = ( objectIndex == 255 ) ? 18 : objectIndex;
+        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::BOAT32, spriteIndex % 128 );
+        area.BlitOnTile( dst, sprite, sprite.x(), TILEWIDTH + sprite.y(), mp, ( spriteIndex > 128 ) );
     }
 }
 


### PR DESCRIPTION
Missed this when was implementing #2030 . Without this fallback boats will be invisible (on older savegames) before they are used.