### PR TITLE
fix(world): lighthouse doesn't reveal additional squares

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -794,9 +794,6 @@ namespace AI
                 }
 
                 tile.QuantitySetColor( hero.GetColor() );
-
-                if ( MP2::OBJ_LIGHTHOUSE == obj )
-                    Maps::ClearFog( dst_index, Game::GetViewDistance( Game::VIEW_LIGHT_HOUSE ), hero.GetColor() );
             }
         }
 

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -91,8 +91,7 @@ namespace Game
         VIEW_HEROES = 2,
         VIEW_TELESCOPE = 3,
         VIEW_OBSERVATION_TOWER = 4,
-        VIEW_MAGI_EYES = 5,
-        VIEW_LIGHT_HOUSE = 6
+        VIEW_MAGI_EYES = 5
     };
 
     enum

--- a/src/fheroes2/game/game_static.cpp
+++ b/src/fheroes2/game/game_static.cpp
@@ -229,7 +229,7 @@ namespace GameStatic
     u8 whirlpool_lost_percent = 50;
 
     /* town, castle, heroes, artifact_telescope, object_observation_tower, object_magi_eyes */
-    u8 overview_distance[] = {4, 5, 4, 1, 20, 9, 8};
+    u8 overview_distance[] = {4, 5, 4, 1, 20, 9};
 
     u8 gameover_lost_days = 7;
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2084,9 +2084,6 @@ void ActionToCaptureObject( Heroes & hero, u32 obj, s32 dst_index )
             }
 
             tile.QuantitySetColor( hero.GetColor() );
-
-            if ( MP2::OBJ_LIGHTHOUSE == obj )
-                Maps::ClearFog( dst_index, Game::GetViewDistance( Game::VIEW_LIGHT_HOUSE ), hero.GetColor() );
         }
     }
     else

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -202,10 +202,6 @@ void CapturedObjects::ClearFog( int colors )
                 scoute = 2;
                 break;
 
-            case MP2::OBJ_LIGHTHOUSE:
-                scoute = 4;
-                break; // FIXME: scoute and lighthouse
-
             default:
                 break;
             }


### PR DESCRIPTION
To fix https://github.com/ihhub/fheroes2/issues/132

Is this what's required or should it be like the other structures as `scoute = 2` ?