### PR TITLE
Fix adjacent monsters when removing one

### DIFF
--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -753,9 +753,9 @@ void ActionToMonster( Heroes & hero, u32 obj, s32 dst_index )
     if ( destroy ) {
         AGG::PlaySound( M82::KILLFADE );
         AnimationRemoveObject( tile );
+        tile.RemoveObjectSprite();
         tile.MonsterSetCount( 0 );
         tile.SetObject( MP2::OBJ_ZERO );
-        tile.RemoveObjectSprite();
 
         if ( map_troop )
             world.RemoveMapObject( map_troop );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2137,6 +2137,9 @@ void Maps::Tiles::UpdateObjectSprite( uint32_t uniqID, uint8_t rawTileset, uint8
 void Maps::Tiles::RemoveObjectSprite( void )
 {
     switch ( GetObject() ) {
+    case MP2::OBJ_MONSTER:
+        Remove( uniq );
+        break;
     case MP2::OBJ_JAIL:
         RemoveJailSprite();
         tilePassable = DIRECTION_ALL;


### PR DESCRIPTION
Fixes #2072 .

Should stop the unknown monsters appearing on the map. Wasn't cleared properly when fighting adjacent units.