### PR TITLE
Fix pass image position on the world map

### DIFF
--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -259,7 +259,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                 }
 
                 const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( 0 > green ? ICN::ROUTERED : ICN::ROUTE, index );
-                BlitOnTile( dst, sprite, sprite.x() - 14, sprite.y(), mp );
+                BlitOnTile( dst, sprite, sprite.x() - 12, sprite.y() + 2, mp );
             }
         }
     }


### PR DESCRIPTION
Fix #2075. Fix #1367 .
![2020-10-24_17-06-50](https://user-images.githubusercontent.com/50713566/97093710-5b349480-161c-11eb-8211-317a48dcd4fa.jpg)
