### PR TITLE
Fix boat and hero position

### DIFF
--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -221,7 +221,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
     }
 
     for ( const std::pair<Point, const Heroes *> & hero : heroList ) {
-        hero.second->Redraw( dst, hero.first.x, hero.first.y, true );
+        hero.second->Redraw( dst, hero.first.x, hero.first.y - 1, true );
     }
 
     // route

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -389,6 +389,10 @@ void Heroes::Redraw( fheroes2::Image & dst, s32 dx, s32 dy, bool withShadow ) co
         flagFrameID = isShipMaster() ? 0 : Game::MapsAnimationFrame();
     }
 
+    // boat sprite have to be shifted so it matches other boats
+    if ( isShipMaster() )
+        dy -= 10;
+
     const fheroes2::Sprite & sprite1 = SpriteHero( *this, sprite_index, false );
     const fheroes2::Sprite & sprite2 = SpriteFlag( *this, flagFrameID, false );
     const fheroes2::Sprite & sprite3 = SpriteShad( *this, sprite_index );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1557,7 +1557,7 @@ void Maps::Tiles::RedrawBoat( fheroes2::Image & dst ) const
     if ( area.GetVisibleTileROI() & mp ) {
         const uint32_t spriteIndex = ( objectIndex == 255 ) ? 18 : objectIndex;
         const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::BOAT32, spriteIndex % 128 );
-        area.BlitOnTile( dst, sprite, sprite.x(), TILEWIDTH + sprite.y(), mp, ( spriteIndex > 128 ) );
+        area.BlitOnTile( dst, sprite, sprite.x(), TILEWIDTH + sprite.y() - 11, mp, ( spriteIndex > 128 ) );
     }
 }
 


### PR DESCRIPTION
Fix #1311 . Fix #1349 .

Boats before (notice how hero boat is basically swimming on land):
![image](https://user-images.githubusercontent.com/50713566/97095868-16682800-1633-11eb-9faa-213b7b35f5b8.png)

Boats after:
![image](https://user-images.githubusercontent.com/50713566/97095872-21bb5380-1633-11eb-9c43-4baa900143d5.png)
