### PR TITLE
Army merge logic improvement

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -674,6 +674,7 @@ void Troops::JoinStrongest( Troops & troops2, bool saveLast )
                 std::sort( rightPriority.begin(), rightPriority.end(), Army::WeakestTroop );
             }
             else {
+                // we're done processing if second army units are weaker
                 break;
             }
         }
@@ -687,17 +688,11 @@ void Troops::JoinStrongest( Troops & troops2, bool saveLast )
 
     // save weakest unit to army2 (for heroes)
     if ( saveLast && !troops2.isValid() ) {
-        iterator last = end();
-        for ( auto it = begin(); it != end(); ++it ) {
-            if ( ( *it )->isValid() && ( last == end() || Army::WeakestTroop( *it, *last ) ) ) {
-                last = it;
-            }
-        }
+        Troop * weakest = GetWeakestTroop();
 
-        if ( last != end() ) {
-            Troop & weakest = *( *last );
-            troops2.JoinTroop( weakest, 1 );
-            weakest.SetCount( weakest.GetCount() - 1 );
+        if ( weakest && weakest->isValid() ) {
+            troops2.JoinTroop( *weakest, 1 );
+            weakest->SetCount( weakest->GetCount() - 1 );
         }
     }
 }

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -662,21 +662,20 @@ void Troops::JoinStrongest( Troops & troops2, bool saveLast )
         while ( count < ARMYMAXTROOPS && rightPriority.size() ) {
             JoinTroop( *rightPriority.back() );
             rightPriority.PopBack();
-            count++;
+            ++count;
         }
 
         // 3. Swap weakest and strongest unit until there's no left
         while ( rightPriority.size() ) {
             Troop * weakest = GetWeakestTroop();
 
-            if ( weakest && Army::StrongestTroop( rightPriority.back(), weakest ) ) {
-                Army::SwapTroops( *weakest, *rightPriority.back() );
-                std::sort( rightPriority.begin(), rightPriority.end(), Army::WeakestTroop );
-            }
-            else {
+            if ( !weakest || Army::StrongestTroop( weakest, rightPriority.back() ) ) {
                 // we're done processing if second army units are weaker
                 break;
             }
+
+            Army::SwapTroops( *weakest, *rightPriority.back() );
+            std::sort( rightPriority.begin(), rightPriority.end(), Army::WeakestTroop );
         }
 
         // 4. The rest goes back to second army

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -667,6 +667,7 @@ void Troops::JoinStrongest( Troops & troops2, bool saveLast )
             priority.PopBack();
         }
 
+        // assign stongest to army1, keep unit order
         Assign( priority );
     }
 
@@ -674,10 +675,8 @@ void Troops::JoinStrongest( Troops & troops2, bool saveLast )
     if ( saveLast && !troops2.isValid() ) {
         iterator last = end();
         for ( auto it = begin(); it != end(); ++it ) {
-            if ( ( *it )->isValid() ) {
-                if ( last == end() || Army::WeakestTroop( *it, *last ) ) {
-                    last = it;
-                }
+            if ( ( *it )->isValid() && ( last == end() || Army::WeakestTroop( *it, *last ) ) ) {
+                last = it;
             }
         }
 

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -620,9 +620,8 @@ void Troops::JoinStrongest( Troops & troops2, bool save_last )
     // save half weak of strongest to army2
     if ( save_last && !troops2.isValid() ) {
         Troop & last = *priority.back();
-        u32 count = last.GetCount() / 2;
-        troops2.JoinTroop( last, last.GetCount() - count );
-        last.SetCount( count );
+        troops2.JoinTroop( last, 1 );
+        last.SetCount( last.GetCount() - 1 );
     }
 
     // strongest to army

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -77,6 +77,7 @@ public:
     void JoinTroops( Troops & );
     bool CanJoinTroops( const Troops & ) const;
 
+    void MergeTroops();
     Troops GetOptimized( void ) const;
 
     virtual u32 GetAttack( void ) const;

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -2506,14 +2506,13 @@ void Castle::JoinRNDArmy( void )
 
 void Castle::ActionPreBattle( void )
 {
+    CastleHeroes heroes = world.GetHeroes( *this );
+    Heroes * hero = heroes.GuardFirst();
+    if ( hero && army.isValid() )
+        hero->GetArmy().JoinStrongestFromArmy( army );
+
     if ( isControlAI() )
         AI::Get().CastlePreBattle( *this );
-    else if ( Settings::Get().ExtBattleMergeArmies() ) {
-        CastleHeroes heroes = world.GetHeroes( *this );
-        Heroes * hero = heroes.GuardFirst();
-        if ( hero && army.isValid() )
-            hero->GetArmy().JoinStrongestFromArmy( army );
-    }
 }
 
 void Castle::ActionAfterBattle( bool attacker_wins )

--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -211,7 +211,6 @@ void Dialog::ExtSettings( bool readonly )
     states.push_back( Settings::BATTLE_SHOW_ARMY_ORDER );
     states.push_back( Settings::BATTLE_SOFT_WAITING );
     states.push_back( Settings::BATTLE_OBJECTS_ARCHERS_PENALTY );
-    states.push_back( Settings::BATTLE_MERGE_ARMIES );
     states.push_back( Settings::BATTLE_SKIP_INCREASE_DEFENSE );
     states.push_back( Settings::BATTLE_REVERSE_WAIT_ORDER );
 

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -346,10 +346,6 @@ const settings_t settingsFHeroes2[] = {
         _( "battle: high objects are an obstacle for archers" ),
     },
     {
-        Settings::BATTLE_MERGE_ARMIES,
-        _( "battle: merge armies for hero from castle" ),
-    },
-    {
         Settings::BATTLE_SKIP_INCREASE_DEFENSE,
         _( "battle: skip increase +2 defense" ),
     },
@@ -432,7 +428,6 @@ Settings::Settings()
     , preferably_count_players( 0 )
     , port( DEFAULT_PORT )
 {
-    ExtSetModes( BATTLE_MERGE_ARMIES );
     ExtSetModes( GAME_AUTOSAVE_ON );
     ExtSetModes( WORLD_SHOW_VISITED_CONTENT );
     ExtSetModes( WORLD_ONLY_FIRST_MONSTER_ATTACK );
@@ -1712,11 +1707,6 @@ bool Settings::ExtBattleSoftWait( void ) const
 bool Settings::ExtBattleObjectsArchersPenalty( void ) const
 {
     return ExtModes( BATTLE_OBJECTS_ARCHERS_PENALTY );
-}
-
-bool Settings::ExtBattleMergeArmies( void ) const
-{
-    return ExtModes( BATTLE_MERGE_ARMIES );
 }
 
 bool Settings::ExtGameRewriteConfirm( void ) const

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -179,7 +179,6 @@ public:
         // UNUSED = 0x40008000,
         BATTLE_SOFT_WAITING = 0x40010000,
         BATTLE_REVERSE_WAIT_ORDER = 0x40020000,
-        BATTLE_MERGE_ARMIES = 0x40100000,
         BATTLE_SKIP_INCREASE_DEFENSE = 0x40200000,
         BATTLE_OBJECTS_ARCHERS_PENALTY = 0x42000000,
 
@@ -294,7 +293,6 @@ public:
     bool ExtBattleShowBattleOrder( void ) const;
     bool ExtBattleSoftWait( void ) const;
     bool ExtBattleObjectsArchersPenalty( void ) const;
-    bool ExtBattleMergeArmies( void ) const;
     bool ExtBattleSkipIncreaseDefense( void ) const;
     bool ExtBattleReverseWaitOrder( void ) const;
     bool ExtGameRememberLastFocus( void ) const;


### PR DESCRIPTION
Fixes #2073 . Fixes #1313 . Fixes #1312 .

Removed useless game option "battle: merge armies for hero from castle". Armies merge should work by default now.
Added two enhancements: game will try to avoid merging unit stacks if there's free room and will try to keep original troop positions as long as possible.

`JoinStrongest` is used when any castle is attacked (to merge defending armies if there's a guest hero) and by AI when merging or reinforcing armies.