### PR TITLE
Mixer::isPlaying returns false if music is disabled

### DIFF
--- a/src/engine/audio_mixer.cpp
+++ b/src/engine/audio_mixer.cpp
@@ -442,7 +442,7 @@ u8 Mixer::isPlaying( int chunkNum )
     }
 
     const chunk_t & chunk = chunks[chunkNum];
-    const bool isSilence = ( chunk.volume1 <= 0 ) && ( chunk.volume2 <= 0 );
+    const bool isSilence = ( chunk.volume1 <= 0 ) || ( chunk.volume2 <= 0 );
     return isSilence ? 0 : ( chunk.state & MIX_PLAY );
 }
 

--- a/src/engine/audio_mixer.cpp
+++ b/src/engine/audio_mixer.cpp
@@ -441,7 +441,7 @@ u8 Mixer::isPlaying( int chunkNum )
         return 0;
     }
 
-    const chunk_t chunk = chunks[chunkNum];
+    const chunk_t & chunk = chunks[chunkNum];
     const bool isSilence = ( chunk.volume1 <= 0 ) && ( chunk.volume2 <= 0 );
     return isSilence ? 0 : ( chunk.state & MIX_PLAY );
 }

--- a/src/engine/audio_mixer.cpp
+++ b/src/engine/audio_mixer.cpp
@@ -192,7 +192,8 @@ void Mixer::Reset( void )
 
 u8 Mixer::isPlaying( int channel )
 {
-    return Mix_Playing( channel );
+    const int currentMusicVolume = Mix_VolumeMusic( -1 ); // -1 is used to get current value without modification
+    return ( currentMusicVolume != 0 ) ? Mix_Playing( channel ) : 0;
 }
 
 u8 Mixer::isPaused( int channel )
@@ -433,9 +434,14 @@ void Mixer::Resume( int ch )
     }
 }
 
-u8 Mixer::isPlaying( int ch )
+u8 Mixer::isPlaying( int chunk )
 {
-    return 0 <= ch && ch < static_cast<int>( chunks.size() ) && ( chunks[ch].state & MIX_PLAY );
+    const int currentVolume = Music::Volume( -1 ); // -1 is used to get current value without modification
+    if ( currentVolume == 0 ) {
+        return 0;
+    }
+    const bool isValidChunk = ( 0 <= chunk ) && ( chunk < static_cast<int>( chunks.size() ) );
+    return isValidChunk ? ( chunks[chunk].state & MIX_PLAY ) : 0;
 }
 
 u8 Mixer::isPaused( int ch )

--- a/src/engine/audio_mixer.cpp
+++ b/src/engine/audio_mixer.cpp
@@ -192,8 +192,7 @@ void Mixer::Reset( void )
 
 u8 Mixer::isPlaying( int channel )
 {
-    const int currentMusicVolume = Mix_VolumeMusic( -1 ); // -1 is used to get current value without modification
-    return ( currentMusicVolume != 0 ) ? Mix_Playing( channel ) : 0;
+    return ( Mix_Volume( channel, -1 ) > 0 ) ? Mix_Playing( channel ) : 0;
 }
 
 u8 Mixer::isPaused( int channel )

--- a/src/engine/audio_mixer.cpp
+++ b/src/engine/audio_mixer.cpp
@@ -434,14 +434,16 @@ void Mixer::Resume( int ch )
     }
 }
 
-u8 Mixer::isPlaying( int chunk )
+u8 Mixer::isPlaying( int chunkNum )
 {
-    const int currentVolume = Music::Volume( -1 ); // -1 is used to get current value without modification
-    if ( currentVolume == 0 ) {
+    const bool isValidChunk = ( 0 <= chunkNum ) && ( chunkNum < static_cast<int>( chunks.size() ) );
+    if ( !isValidChunk ) {
         return 0;
     }
-    const bool isValidChunk = ( 0 <= chunk ) && ( chunk < static_cast<int>( chunks.size() ) );
-    return isValidChunk ? ( chunks[chunk].state & MIX_PLAY ) : 0;
+
+    const chunk_t chunk = chunks[chunkNum];
+    const bool isSilence = ( chunk.volume1 <= 0 ) && ( chunk.volume2 <= 0 );
+    return isSilence ? 0 : ( chunk.state & MIX_PLAY );
 }
 
 u8 Mixer::isPaused( int ch )


### PR DESCRIPTION
Hello! 

This is a fix for #756. As suggested, `Mixer::isPlaying` returns 0 if music is disabled