### PR TITLE
Fix mine guardians sprites

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1638,11 +1638,12 @@ void Maps::Tiles::RedrawTop( fheroes2::Image & dst ) const
     if ( !( area.GetVisibleTileROI() & mp ) )
         return;
 
+    const int objectID = GetObject( false );
     // animate objects
-    if ( MP2::OBJ_ABANDONEDMINE == GetObject() ) {
+    if ( objectID == MP2::OBJ_ABANDONEDMINE ) {
         area.BlitOnTile( dst, fheroes2::AGG::GetICN( ICN::OBJNHAUN, Game::MapsAnimationFrame() % 15 ), mp );
     }
-    else if ( MP2::OBJ_MINES == GetObject() ) {
+    else if ( objectID == MP2::OBJ_MINES ) {
         const uint8_t spellID = GetQuantity3();
         if ( spellID == Spell::HAUNT ) {
             area.BlitOnTile( dst, fheroes2::AGG::GetICN( ICN::OBJNHAUN, Game::MapsAnimationFrame() % 15 ), mp );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1648,7 +1648,7 @@ void Maps::Tiles::RedrawTop( fheroes2::Image & dst ) const
             area.BlitOnTile( dst, fheroes2::AGG::GetICN( ICN::OBJNHAUN, Game::MapsAnimationFrame() % 15 ), mp );
         }
         else if ( spellID >= Spell::SETEGUARDIAN && spellID <= Spell::SETWGUARDIAN ) {
-            area.BlitOnTile( dst, fheroes2::AGG::GetICN( ICN::MONS32, Monster( Spell( spellID ) ).GetSpriteIndex() ), TILEWIDTH, 0, mp );
+            area.BlitOnTile( dst, fheroes2::AGG::GetICN( ICN::OBJNXTRA, spellID - Spell::SETEGUARDIAN ), TILEWIDTH, 0, mp );
         }
     }
 

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -117,6 +117,10 @@ int MP2::GetICNObject( int tileset )
     case 38:
         return ICN::OBJNTWRD;
 
+    // mine guardians (elementals)
+    case 39:
+        return ICN::OBJNXTRA;
+
     // water object
     case 40:
         return ICN::OBJNWAT2;


### PR DESCRIPTION
Fixes #1387 . Fixes #1517 .

Select correct image/sprite index.
Show animations when hero is standing on the mine.