### PR TITLE
Do not show teleport animation in some AI cases

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -846,7 +846,6 @@ namespace AI
         if ( path.size() ) {
             const int dest = path.front().GetIndex();
             while ( indexTo != dest ) {
-                std::cout << "Teleporters: fishing for " << dest << " got " << indexTo << std::endl;
                 indexTo = world.NextTeleport( index_from );
                 const Maps::Tiles & tile = world.GetTiles( indexTo );
                 if ( index_from == indexTo || tile.isFog( hero.GetColor() ) || tile.GetObject() == MP2::OBJ_HEROES )

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -121,7 +121,7 @@ namespace Battle
         int currentNode = targetCell;
         while ( currentNode != targetCell && _cache[currentNode]._cost != 0 ) {
             const ArenaNode & node = _cache[currentNode];
-            path.emplace_front( node._from, Board::GetDirection( node._from, currentNode ), 1 );
+            path.emplace_front( currentNode, node._from, Board::GetDirection( node._from, currentNode ), 1 );
             currentNode = node._from;
         }
 

--- a/src/fheroes2/heroes/route.cpp
+++ b/src/fheroes2/heroes/route.cpp
@@ -32,7 +32,7 @@
 
 s32 Route::Step::GetIndex( void ) const
 {
-    return from < 0 ? -1 : Maps::GetDirectionIndex( from, direction );
+    return currentIndex;
 }
 
 s32 Route::Step::GetFrom( void ) const
@@ -546,7 +546,9 @@ StreamBase & Route::operator<<( StreamBase & msg, const Path & path )
 
 StreamBase & Route::operator>>( StreamBase & msg, Step & step )
 {
-    return msg >> step.from >> step.direction >> step.penalty;
+    msg >> step.from >> step.direction >> step.penalty;
+    step.currentIndex = Maps::GetDirectionIndex( step.from, step.direction );
+    return msg;
 }
 
 StreamBase & Route::operator>>( StreamBase & msg, Path & path )

--- a/src/fheroes2/heroes/route.h
+++ b/src/fheroes2/heroes/route.h
@@ -35,12 +35,7 @@ namespace Route
     class Step
     {
     public:
-        Step()
-            : currentIndex( -1 )
-            , from( -1 )
-            , direction( Direction::CENTER )
-            , penalty( 0 )
-        {}
+        Step() {}
         Step( int index, s32 fromIndex, int dir, u32 cost )
             : currentIndex( index )
             , from( fromIndex )
@@ -58,10 +53,10 @@ namespace Route
         friend StreamBase & operator<<( StreamBase &, const Step & );
         friend StreamBase & operator>>( StreamBase &, Step & );
 
-        int currentIndex;
-        s32 from;
-        int direction;
-        uint32_t penalty;
+        int currentIndex = -1;
+        s32 from = -1;
+        int direction = Direction::CENTER;
+        uint32_t penalty = 0;
     };
 
     class Path : public std::list<Step>

--- a/src/fheroes2/heroes/route.h
+++ b/src/fheroes2/heroes/route.h
@@ -36,12 +36,14 @@ namespace Route
     {
     public:
         Step()
-            : from( -1 )
+            : currentIndex( -1 )
+            , from( -1 )
             , direction( Direction::CENTER )
             , penalty( 0 )
         {}
-        Step( s32 index, int dir, u32 cost )
-            : from( index )
+        Step( int index, s32 fromIndex, int dir, u32 cost )
+            : currentIndex( index )
+            , from( fromIndex )
             , direction( dir )
             , penalty( cost )
         {}
@@ -56,9 +58,10 @@ namespace Route
         friend StreamBase & operator<<( StreamBase &, const Step & );
         friend StreamBase & operator>>( StreamBase &, Step & );
 
+        int currentIndex;
         s32 from;
         int direction;
-        u32 penalty;
+        uint32_t penalty;
     };
 
     class Path : public std::list<Step>

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -228,7 +228,7 @@ std::list<Route::Step> PlayerWorldPathfinder::buildPath( int targetIndex ) const
         const PathfindingNode & node = _cache[currentNode];
         const uint32_t cost = ( node._from != -1 ) ? node._cost - _cache[node._from]._cost : node._cost;
 
-        path.emplace_front( node._from, Maps::GetDirection( node._from, currentNode ), cost );
+        path.emplace_front( currentNode, node._from, Maps::GetDirection( node._from, currentNode ), cost );
 
         // Sanity check
         if ( node._from != -1 && _cache[node._from]._from == currentNode ) {
@@ -468,7 +468,7 @@ std::list<Route::Step> AIWorldPathfinder::buildPath( int targetIndex ) const
         const PathfindingNode & node = _cache[currentNode];
         const uint32_t cost = ( node._from != -1 ) ? node._cost - _cache[node._from]._cost : node._cost;
 
-        path.emplace_front( node._from, Maps::GetDirection( node._from, currentNode ), cost );
+        path.emplace_front( currentNode, node._from, Maps::GetDirection( node._from, currentNode ), cost );
 
         // Sanity check
         if ( node._from != -1 && _cache[node._from]._from == currentNode ) {


### PR DESCRIPTION
Do not show teleport animation when AI hasn't reached the intended destination.

Updated Route::Step struct to include additional info, added line for saves compatibility.