### PR TITLE
Fixes for MinGW Build

### DIFF
--- a/src/Makefile.mingw
+++ b/src/Makefile.mingw
@@ -21,7 +21,7 @@ ifdef WITH_ICONS
 export WITH_ICONS=0
 # ifndef WITH_ICONS
 # export WITH_ICONS=1
-# endif
+endif
 # IDICON := 1099
 # CFLAGS := $(CFLAGS) -DID_ICON=$(IDICON)
 # export IDICON

--- a/src/Makefile.mingw
+++ b/src/Makefile.mingw
@@ -1,32 +1,27 @@
-ifndef WITHOUT_MIXER
-LIBS := $(LIBS) -lSDL -lvorbisfile -lvorbis -logg
-endif
+# ifndef WITHOUT_AUDIOCD
+# CFLAGS := $(CFLAGS) -DWITH_AUDIOCD
+# endif
 
-ifndef WITHOUT_IMAGE
-LIBS := $(LIBS) -lSDL -lpng -ljpeg
-endif
-
-ifndef WITHOUT_UNICODE
-CFLAGS := $(CFLAGS) -DWITH_ICONV
-LIBS := $(LIBS) -lfreetype -liconv
-endif
-
-ifndef WITHOUT_AUDIOCD
-CFLAGS := $(CFLAGS) -DWITH_AUDIOCD
-endif
-
-ifndef WITHOUT_NETWORK
-LIBS := $(LIBS) -lwsock32
-endif
-
-ifdef WITH_ICONS
-IDICON := 1099
-CFLAGS := $(CFLAGS) -DID_ICON=$(IDICON)
-export IDICON
-endif
+# ifndef WITHOUT_NETWORK
+# LIBS := $(LIBS) -lwsock32
+# endif
 
 AR := ar
 CXX := g++
 WINDRES := windres
-CFLAGS := $(CFLAGS) -O2 -static
-LIBS := -static -Wl,-Bstatic $(LIBS) -lwinmm -ldxguid
+LIBS := $(LIBS) -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lwinpthread
+# Static winpthread linking https://stackoverflow.com/a/28001261
+
+ifndef WITHOUT_UNICODE
+CFLAGS := $(CFLAGS) -DWITH_ICONV
+LIBS := $(LIBS) -liconv
+endif
+
+ifdef WITH_ICONS
+export WITH_ICONS=0
+# ifndef WITH_ICONS
+# export WITH_ICONS=1
+# endif
+# IDICON := 1099
+# CFLAGS := $(CFLAGS) -DID_ICON=$(IDICON)
+# export IDICON

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -808,11 +808,8 @@ std::string EncodeString( const std::string & str, const char * charset )
     char * outbuf1 = new char[outbytesleft];
     char * outbuf2 = outbuf1;
 
-#if defined( __MINGW32__ ) || defined( __MINGW64__ )
-    size_t reslen = iconv( cd, &inbuf, &inbytesleft, &outbuf1, &outbytesleft );
-#else
     size_t reslen = iconv( cd, const_cast<char **>( &inbuf ), &inbytesleft, &outbuf1, &outbytesleft );
-#endif
+
     iconv_close( cd );
 
     if ( reslen != ( size_t )( -1 ) )


### PR DESCRIPTION
Tested on MinGW64/MSYS2 with both SDL and SDL2 targets.

There is no shell icon, window icon displays just fine.
WSock32 requirement untested, since I never tested network (nor do I know if it's implemented).
Never managed to build with Audio CD support, so that's also commented out.