### PR TITLE
2137 - Fixed Bug: File to Save window, use of the Delete key on the k…

### DIFF
--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -512,12 +512,9 @@ size_t InsertKeySym( std::string & res, size_t pos, KeySym sym, u16 mod )
         }
     } break;
     case KEY_DELETE: {
-        if ( res.size() && pos ) {
-            if ( pos >= res.size() )
-                res.resize( res.size() - 1 );
-            else
+        if ( res.size() ) {
+            if ( pos < res.size() )
                 res.erase( pos, 1 );
-            pos;
         }
     } break;
 

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -511,6 +511,15 @@ size_t InsertKeySym( std::string & res, size_t pos, KeySym sym, u16 mod )
             --pos;
         }
     } break;
+    case KEY_DELETE: {
+        if ( res.size() && pos ) {
+            if ( pos >= res.size() )
+                res.resize( res.size() - 1 );
+            else
+                res.erase( pos, 1 );
+            pos;
+        }
+    } break;
 
     case KEY_LEFT:
         if ( pos )

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -286,7 +286,7 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
                 buttonOk.disable();
             cursor.Hide();
         }
-        else if ( edit_mode && le.KeyPress() && ( !is_limit || KEY_BACKSPACE == le.KeyValue() ) ) {
+        else if ( edit_mode && le.KeyPress() && ( !is_limit || KEY_BACKSPACE == le.KeyValue() || KEY_DELETE == le.KeyValue() ) ) {
             charInsertPos = InsertKeySym( filename, charInsertPos, le.KeyValue(), le.KeyMod() );
             if ( filename.empty() )
                 buttonOk.disable();
@@ -294,7 +294,7 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
                 buttonOk.enable();
             cursor.Hide();
         }
-        if ( le.KeyPress( KEY_DELETE ) && listbox.isSelected() ) {
+        if ( !edit_mode && le.KeyPress( KEY_DELETE ) && listbox.isSelected() ) {
             std::string msg( _( "Are you sure you want to delete file:" ) );
             msg.append( "\n \n" );
             msg.append( System::GetBasename( listbox.GetCurrent().file ) );


### PR DESCRIPTION
Fixed bug #2137 so that in File to Save window the Delete key is now working as expected (when in edit mode the key deletes the character at the current position, when in select mode it starts the delete dialog for an old save game).