### PR TITLE
Fix portraits/hero information display in battle only mode

### DIFF
--- a/src/fheroes2/battle/battle_only.cpp
+++ b/src/fheroes2/battle/battle_only.cpp
@@ -460,16 +460,6 @@ bool Battle::Only::ChangeSettings( void )
 
 void Battle::Only::UpdateHero1( const Point & cur_pt )
 {
-    if ( moraleIndicator1 ) {
-        delete moraleIndicator1;
-        moraleIndicator1 = NULL;
-    }
-
-    if ( luckIndicator1 ) {
-        delete luckIndicator1;
-        luckIndicator1 = NULL;
-    }
-
     if ( primskill_bar1 ) {
         delete primskill_bar1;
         primskill_bar1 = NULL;
@@ -494,11 +484,21 @@ void Battle::Only::UpdateHero1( const Point & cur_pt )
         player1.SetColor( Color::BLUE );
         player1.SetRace( hero1->GetRace() );
 
-        moraleIndicator1 = new MoraleIndicator( *hero1 );
-        moraleIndicator1->SetPos( Point( cur_pt.x + 34, cur_pt.y + 75 ) );
+        if ( moraleIndicator1 == NULL ) {
+            moraleIndicator1 = new MoraleIndicator( *hero1 );
+            moraleIndicator1->SetPos( Point( cur_pt.x + 34, cur_pt.y + 75 ) );
+        }
+        else {
+            moraleIndicator1->SetHero( *hero1 );
+        }
 
-        luckIndicator1 = new LuckIndicator( *hero1 );
-        luckIndicator1->SetPos( Point( cur_pt.x + 34, cur_pt.y + 115 ) );
+        if ( luckIndicator1 == NULL ) {
+            luckIndicator1 = new LuckIndicator( *hero1 );
+            luckIndicator1->SetPos( Point( cur_pt.x + 34, cur_pt.y + 115 ) );
+        }
+        else {
+            luckIndicator1->SetHero( *hero1 );
+        }
 
         primskill_bar1 = new PrimarySkillsBar( hero1, true );
         primskill_bar1->SetColRows( 1, 4 );
@@ -530,16 +530,6 @@ void Battle::Only::UpdateHero1( const Point & cur_pt )
 
 void Battle::Only::UpdateHero2( const Point & cur_pt )
 {
-    if ( moraleIndicator2 ) {
-        delete moraleIndicator2;
-        moraleIndicator2 = NULL;
-    }
-
-    if ( luckIndicator2 ) {
-        delete luckIndicator2;
-        luckIndicator2 = NULL;
-    }
-
     if ( primskill_bar2 ) {
         delete primskill_bar2;
         primskill_bar2 = NULL;
@@ -564,11 +554,21 @@ void Battle::Only::UpdateHero2( const Point & cur_pt )
         player2.SetColor( Color::RED );
         player2.SetRace( hero2->GetRace() );
 
-        moraleIndicator2 = new MoraleIndicator( *hero2 );
-        moraleIndicator2->SetPos( Point( cur_pt.x + 566, cur_pt.y + 75 ) );
+        if ( moraleIndicator2 == NULL ) {
+            moraleIndicator2 = new MoraleIndicator( *hero2 );
+            moraleIndicator2->SetPos( Point( cur_pt.x + 566, cur_pt.y + 75 ) );
+        }
+        else {
+            moraleIndicator2->SetHero( *hero2 );
+        }
 
-        luckIndicator2 = new LuckIndicator( *hero2 );
-        luckIndicator2->SetPos( Point( cur_pt.x + 566, cur_pt.y + 115 ) );
+        if ( luckIndicator2 == NULL ) {
+            luckIndicator2 = new LuckIndicator( *hero2 );
+            luckIndicator2->SetPos( Point( cur_pt.x + 566, cur_pt.y + 115 ) );
+        }
+        else {
+            luckIndicator2->SetHero( *hero2 );
+        }
 
         primskill_bar2 = new PrimarySkillsBar( hero2, true );
         primskill_bar2->SetColRows( 1, 4 );

--- a/src/fheroes2/battle/battle_only.cpp
+++ b/src/fheroes2/battle/battle_only.cpp
@@ -495,10 +495,10 @@ void Battle::Only::UpdateHero1( const Point & cur_pt )
         player1.SetRace( hero1->GetRace() );
 
         moraleIndicator1 = new MoraleIndicator( *hero1 );
-        moraleIndicator1->SetPos( Point( cur_pt.x + 34, cur_pt.y + 75 ), true );
+        moraleIndicator1->SetPos( Point( cur_pt.x + 34, cur_pt.y + 75 ) );
 
         luckIndicator1 = new LuckIndicator( *hero1 );
-        luckIndicator1->SetPos( Point( cur_pt.x + 34, cur_pt.y + 115 ), true );
+        luckIndicator1->SetPos( Point( cur_pt.x + 34, cur_pt.y + 115 ) );
 
         primskill_bar1 = new PrimarySkillsBar( hero1, true );
         primskill_bar1->SetColRows( 1, 4 );
@@ -565,10 +565,10 @@ void Battle::Only::UpdateHero2( const Point & cur_pt )
         player2.SetRace( hero2->GetRace() );
 
         moraleIndicator2 = new MoraleIndicator( *hero2 );
-        moraleIndicator2->SetPos( Point( cur_pt.x + 566, cur_pt.y + 75 ), true );
+        moraleIndicator2->SetPos( Point( cur_pt.x + 566, cur_pt.y + 75 ) );
 
         luckIndicator2 = new LuckIndicator( *hero2 );
-        luckIndicator2->SetPos( Point( cur_pt.x + 566, cur_pt.y + 115 ), true );
+        luckIndicator2->SetPos( Point( cur_pt.x + 566, cur_pt.y + 115 ) );
 
         primskill_bar2 = new PrimarySkillsBar( hero2, true );
         primskill_bar2->SetColRows( 1, 4 );

--- a/src/fheroes2/battle/battle_only.cpp
+++ b/src/fheroes2/battle/battle_only.cpp
@@ -485,19 +485,19 @@ void Battle::Only::UpdateHero1( const Point & cur_pt )
         player1.SetRace( hero1->GetRace() );
 
         if ( moraleIndicator1 == NULL ) {
-            moraleIndicator1 = new MoraleIndicator( *hero1 );
+            moraleIndicator1 = new MoraleIndicator( hero1 );
             moraleIndicator1->SetPos( Point( cur_pt.x + 34, cur_pt.y + 75 ) );
         }
         else {
-            moraleIndicator1->SetHero( *hero1 );
+            moraleIndicator1->SetHero( hero1 );
         }
 
         if ( luckIndicator1 == NULL ) {
-            luckIndicator1 = new LuckIndicator( *hero1 );
+            luckIndicator1 = new LuckIndicator( hero1 );
             luckIndicator1->SetPos( Point( cur_pt.x + 34, cur_pt.y + 115 ) );
         }
         else {
-            luckIndicator1->SetHero( *hero1 );
+            luckIndicator1->SetHero( hero1 );
         }
 
         primskill_bar1 = new PrimarySkillsBar( hero1, true );
@@ -555,19 +555,19 @@ void Battle::Only::UpdateHero2( const Point & cur_pt )
         player2.SetRace( hero2->GetRace() );
 
         if ( moraleIndicator2 == NULL ) {
-            moraleIndicator2 = new MoraleIndicator( *hero2 );
+            moraleIndicator2 = new MoraleIndicator( hero2 );
             moraleIndicator2->SetPos( Point( cur_pt.x + 566, cur_pt.y + 75 ) );
         }
         else {
-            moraleIndicator2->SetHero( *hero2 );
+            moraleIndicator2->SetHero( hero2 );
         }
 
         if ( luckIndicator2 == NULL ) {
-            luckIndicator2 = new LuckIndicator( *hero2 );
+            luckIndicator2 = new LuckIndicator( hero2 );
             luckIndicator2->SetPos( Point( cur_pt.x + 566, cur_pt.y + 115 ) );
         }
         else {
-            luckIndicator2->SetHero( *hero2 );
+            luckIndicator2->SetHero( hero2 );
         }
 
         primskill_bar2 = new PrimarySkillsBar( hero2, true );

--- a/src/fheroes2/dialog/dialog_guardian.cpp
+++ b/src/fheroes2/dialog/dialog_guardian.cpp
@@ -173,13 +173,13 @@ bool Dialog::SetGuardian( Heroes & hero, Troop & troop, CapturedObject & co, boo
     // indicators
     dst_pt.x = area.x + 185;
     dst_pt.y = area.y + 5;
-    MoraleIndicator moraleIndicator( hero );
+    MoraleIndicator moraleIndicator( &hero );
     moraleIndicator.SetPos( dst_pt );
     moraleIndicator.Redraw();
 
     dst_pt.x = area.x + 185;
     dst_pt.y = area.y + 35;
-    LuckIndicator luckIndicator( hero );
+    LuckIndicator luckIndicator( &hero );
     luckIndicator.SetPos( dst_pt );
     luckIndicator.Redraw();
 

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -86,7 +86,7 @@ int Heroes::OpenDialog( bool readonly, bool fade )
     dst_pt.x = cur_pt.x + 514;
     dst_pt.y = cur_pt.y + 35;
 
-    MoraleIndicator moraleIndicator( *this );
+    MoraleIndicator moraleIndicator( this );
     moraleIndicator.SetPos( dst_pt );
     moraleIndicator.Redraw();
 
@@ -94,7 +94,7 @@ int Heroes::OpenDialog( bool readonly, bool fade )
     dst_pt.x = cur_pt.x + 552;
     dst_pt.y = cur_pt.y + 35;
 
-    LuckIndicator luckIndicator( *this );
+    LuckIndicator luckIndicator( this );
     luckIndicator.SetPos( dst_pt );
     luckIndicator.Redraw();
 
@@ -125,12 +125,12 @@ int Heroes::OpenDialog( bool readonly, bool fade )
     cursorFormat.setPosition( cursorFormatPos.x, cursorFormatPos.y );
 
     // experience
-    ExperienceIndicator experienceInfo( *this );
+    ExperienceIndicator experienceInfo( this );
     experienceInfo.SetPos( Point( cur_pt.x + 512, cur_pt.y + 86 ) );
     experienceInfo.Redraw();
 
     // spell points
-    SpellPointsIndicator spellPointsInfo( *this );
+    SpellPointsIndicator spellPointsInfo( this );
     spellPointsInfo.SetPos( Point( cur_pt.x + 550, cur_pt.y + 88 ) );
     spellPointsInfo.Redraw();
 

--- a/src/fheroes2/heroes/heroes_indicator.cpp
+++ b/src/fheroes2/heroes/heroes_indicator.cpp
@@ -74,8 +74,8 @@ const char * LuckString( int luck )
     return NULL;
 }
 
-HeroesIndicator::HeroesIndicator( const Heroes & h )
-    : hero( &h )
+HeroesIndicator::HeroesIndicator( const Heroes * h )
+    : hero( h )
     , back( fheroes2::Display::instance() )
 {
     descriptions.reserve( 256 );
@@ -91,9 +91,9 @@ const std::string & HeroesIndicator::GetDescriptions( void ) const
     return descriptions;
 }
 
-void HeroesIndicator::SetHero( const Heroes & h )
+void HeroesIndicator::SetHero( const Heroes * h )
 {
-    hero = &h;
+    hero = h;
 }
 
 void HeroesIndicator::SetPos( const Point & pt )
@@ -103,7 +103,7 @@ void HeroesIndicator::SetPos( const Point & pt )
     back.update( area.x, area.y, area.w, area.h );
 }
 
-LuckIndicator::LuckIndicator( const Heroes & h )
+LuckIndicator::LuckIndicator( const Heroes * h )
     : HeroesIndicator( h )
     , luck( Luck::NORMAL )
 {
@@ -113,6 +113,9 @@ LuckIndicator::LuckIndicator( const Heroes & h )
 
 void LuckIndicator::Redraw( void )
 {
+    if ( !hero )
+        return;
+
     std::string modificators;
     modificators.reserve( 256 );
     luck = hero->GetLuckWithModificators( &modificators );
@@ -151,7 +154,7 @@ void LuckIndicator::QueueEventProcessing( LuckIndicator & indicator )
         Dialog::Message( LuckString( indicator.luck ), indicator.descriptions, Font::BIG );
 }
 
-MoraleIndicator::MoraleIndicator( const Heroes & h )
+MoraleIndicator::MoraleIndicator( const Heroes * h )
     : HeroesIndicator( h )
     , morale( Morale::NORMAL )
 {
@@ -161,6 +164,9 @@ MoraleIndicator::MoraleIndicator( const Heroes & h )
 
 void MoraleIndicator::Redraw( void )
 {
+    if ( !hero )
+        return;
+
     std::string modificators;
     modificators.reserve( 256 );
     morale = hero->GetMoraleWithModificators( &modificators );
@@ -199,20 +205,25 @@ void MoraleIndicator::QueueEventProcessing( MoraleIndicator & indicator )
         Dialog::Message( MoraleString( indicator.morale ), indicator.descriptions, Font::BIG );
 }
 
-ExperienceIndicator::ExperienceIndicator( const Heroes & h )
+ExperienceIndicator::ExperienceIndicator( const Heroes * h )
     : HeroesIndicator( h )
 {
     area.w = 39;
     area.h = 36;
 
     descriptions = _( "Current experience %{exp1}.\n Next level %{exp2}." );
-    const uint32_t experience = hero->GetExperience();
-    StringReplace( descriptions, "%{exp1}", experience );
-    StringReplace( descriptions, "%{exp2}", hero->GetExperienceFromLevel( hero->GetLevelFromExperience( experience ) ) );
+    if ( hero ) {
+        const uint32_t experience = hero->GetExperience();
+        StringReplace( descriptions, "%{exp1}", experience );
+        StringReplace( descriptions, "%{exp2}", hero->GetExperienceFromLevel( hero->GetLevelFromExperience( experience ) ) );
+    }
 }
 
 void ExperienceIndicator::Redraw( void )
 {
+    if ( !hero )
+        return;
+
     const fheroes2::Sprite & sprite3 = fheroes2::AGG::GetICN( ICN::HSICONS, 1 );
     fheroes2::Blit( sprite3, fheroes2::Display::instance(), area.x, area.y );
 
@@ -231,7 +242,7 @@ void ExperienceIndicator::QueueEventProcessing( void )
     }
 }
 
-SpellPointsIndicator::SpellPointsIndicator( const Heroes & h )
+SpellPointsIndicator::SpellPointsIndicator( const Heroes * h )
     : HeroesIndicator( h )
 {
     area.w = 39;
@@ -239,13 +250,18 @@ SpellPointsIndicator::SpellPointsIndicator( const Heroes & h )
 
     descriptions = _(
         "%{name} currently has %{point} spell points out of a maximum of %{max}. The maximum number of spell points is 10 times your knowledge. It is occasionally possible to have more than your maximum spell points via special events." );
-    StringReplace( descriptions, "%{name}", hero->GetName() );
-    StringReplace( descriptions, "%{point}", hero->GetSpellPoints() );
-    StringReplace( descriptions, "%{max}", hero->GetMaxSpellPoints() );
+    if ( hero ) {
+        StringReplace( descriptions, "%{name}", hero->GetName() );
+        StringReplace( descriptions, "%{point}", hero->GetSpellPoints() );
+        StringReplace( descriptions, "%{max}", hero->GetMaxSpellPoints() );
+    }
 }
 
 void SpellPointsIndicator::Redraw( void )
 {
+    if ( !hero )
+        return;
+
     const fheroes2::Sprite & sprite3 = fheroes2::AGG::GetICN( ICN::HSICONS, 8 );
     fheroes2::Blit( sprite3, fheroes2::Display::instance(), area.x, area.y );
 

--- a/src/fheroes2/heroes/heroes_indicator.cpp
+++ b/src/fheroes2/heroes/heroes_indicator.cpp
@@ -75,7 +75,7 @@ const char * LuckString( int luck )
 }
 
 HeroesIndicator::HeroesIndicator( const Heroes & h )
-    : hero( h )
+    : hero( &h )
     , back( fheroes2::Display::instance() )
 {
     descriptions.reserve( 256 );
@@ -89,6 +89,11 @@ const Rect & HeroesIndicator::GetArea( void ) const
 const std::string & HeroesIndicator::GetDescriptions( void ) const
 {
     return descriptions;
+}
+
+void HeroesIndicator::SetHero( const Heroes & h )
+{
+    hero = &h;
 }
 
 void HeroesIndicator::SetPos( const Point & pt )
@@ -110,7 +115,7 @@ void LuckIndicator::Redraw( void )
 {
     std::string modificators;
     modificators.reserve( 256 );
-    luck = hero.GetLuckWithModificators( &modificators );
+    luck = hero->GetLuckWithModificators( &modificators );
 
     descriptions.clear();
     descriptions.append( Luck::Description( luck ) );
@@ -158,7 +163,7 @@ void MoraleIndicator::Redraw( void )
 {
     std::string modificators;
     modificators.reserve( 256 );
-    morale = hero.GetMoraleWithModificators( &modificators );
+    morale = hero->GetMoraleWithModificators( &modificators );
 
     descriptions.clear();
     descriptions.append( Morale::Description( morale ) );
@@ -201,8 +206,9 @@ ExperienceIndicator::ExperienceIndicator( const Heroes & h )
     area.h = 36;
 
     descriptions = _( "Current experience %{exp1}.\n Next level %{exp2}." );
-    StringReplace( descriptions, "%{exp1}", hero.GetExperience() );
-    StringReplace( descriptions, "%{exp2}", hero.GetExperienceFromLevel( hero.GetLevelFromExperience( hero.GetExperience() ) ) );
+    const uint32_t experience = hero->GetExperience();
+    StringReplace( descriptions, "%{exp1}", experience );
+    StringReplace( descriptions, "%{exp2}", hero->GetExperienceFromLevel( hero->GetLevelFromExperience( experience ) ) );
 }
 
 void ExperienceIndicator::Redraw( void )
@@ -210,7 +216,7 @@ void ExperienceIndicator::Redraw( void )
     const fheroes2::Sprite & sprite3 = fheroes2::AGG::GetICN( ICN::HSICONS, 1 );
     fheroes2::Blit( sprite3, fheroes2::Display::instance(), area.x, area.y );
 
-    Text text( GetString( hero.GetExperience() ), Font::SMALL );
+    Text text( GetString( hero->GetExperience() ), Font::SMALL );
     text.Blit( area.x + 17 - text.w() / 2, area.y + 23 );
 }
 
@@ -220,7 +226,7 @@ void ExperienceIndicator::QueueEventProcessing( void )
 
     if ( le.MouseClickLeft( area ) || le.MousePressRight( area ) ) {
         std::string message = _( "Level %{level}" );
-        StringReplace( message, "%{level}", hero.GetLevel() );
+        StringReplace( message, "%{level}", hero->GetLevel() );
         Dialog::Message( message, descriptions, Font::BIG, ( le.MousePressRight() ? 0 : Dialog::OK ) );
     }
 }
@@ -233,9 +239,9 @@ SpellPointsIndicator::SpellPointsIndicator( const Heroes & h )
 
     descriptions = _(
         "%{name} currently has %{point} spell points out of a maximum of %{max}. The maximum number of spell points is 10 times your knowledge. It is occasionally possible to have more than your maximum spell points via special events." );
-    StringReplace( descriptions, "%{name}", hero.GetName() );
-    StringReplace( descriptions, "%{point}", hero.GetSpellPoints() );
-    StringReplace( descriptions, "%{max}", hero.GetMaxSpellPoints() );
+    StringReplace( descriptions, "%{name}", hero->GetName() );
+    StringReplace( descriptions, "%{point}", hero->GetSpellPoints() );
+    StringReplace( descriptions, "%{max}", hero->GetMaxSpellPoints() );
 }
 
 void SpellPointsIndicator::Redraw( void )
@@ -243,7 +249,7 @@ void SpellPointsIndicator::Redraw( void )
     const fheroes2::Sprite & sprite3 = fheroes2::AGG::GetICN( ICN::HSICONS, 8 );
     fheroes2::Blit( sprite3, fheroes2::Display::instance(), area.x, area.y );
 
-    Text text( GetString( hero.GetSpellPoints() ) + "/" + GetString( hero.GetMaxSpellPoints() ), Font::SMALL );
+    Text text( GetString( hero->GetSpellPoints() ) + "/" + GetString( hero->GetMaxSpellPoints() ), Font::SMALL );
     text.Blit( area.x + sprite3.width() / 2 - text.w() / 2, area.y + 21 );
 }
 

--- a/src/fheroes2/heroes/heroes_indicator.cpp
+++ b/src/fheroes2/heroes/heroes_indicator.cpp
@@ -91,12 +91,11 @@ const std::string & HeroesIndicator::GetDescriptions( void ) const
     return descriptions;
 }
 
-void HeroesIndicator::SetPos( const Point & pt, bool skip_back )
+void HeroesIndicator::SetPos( const Point & pt )
 {
     area.x = pt.x;
     area.y = pt.y;
-    if ( !skip_back )
-        back.update( area.x, area.y, area.w, area.h );
+    back.update( area.x, area.y, area.w, area.h );
 }
 
 LuckIndicator::LuckIndicator( const Heroes & h )

--- a/src/fheroes2/heroes/heroes_indicator.h
+++ b/src/fheroes2/heroes/heroes_indicator.h
@@ -32,7 +32,7 @@ class Heroes;
 class HeroesIndicator
 {
 public:
-    HeroesIndicator( const Heroes * );
+    HeroesIndicator( const Heroes * h = nullptr );
 
     const Rect & GetArea( void ) const;
     const std::string & GetDescriptions( void ) const;

--- a/src/fheroes2/heroes/heroes_indicator.h
+++ b/src/fheroes2/heroes/heroes_indicator.h
@@ -49,7 +49,7 @@ protected:
 class LuckIndicator : public HeroesIndicator
 {
 public:
-    LuckIndicator( const Heroes * );
+    LuckIndicator( const Heroes * h = nullptr );
 
     void Redraw( void );
     static void QueueEventProcessing( LuckIndicator & );
@@ -61,7 +61,7 @@ private:
 class MoraleIndicator : public HeroesIndicator
 {
 public:
-    MoraleIndicator( const Heroes * );
+    MoraleIndicator( const Heroes * h = nullptr );
 
     void Redraw( void );
     static void QueueEventProcessing( MoraleIndicator & );
@@ -73,7 +73,7 @@ private:
 class ExperienceIndicator : public HeroesIndicator
 {
 public:
-    ExperienceIndicator( const Heroes * );
+    ExperienceIndicator( const Heroes * h = nullptr );
 
     void Redraw( void );
     void QueueEventProcessing( void );
@@ -82,7 +82,7 @@ public:
 class SpellPointsIndicator : public HeroesIndicator
 {
 public:
-    SpellPointsIndicator( const Heroes * );
+    SpellPointsIndicator( const Heroes * h = nullptr );
 
     void Redraw( void );
     void QueueEventProcessing( void );

--- a/src/fheroes2/heroes/heroes_indicator.h
+++ b/src/fheroes2/heroes/heroes_indicator.h
@@ -32,12 +32,12 @@ class Heroes;
 class HeroesIndicator
 {
 public:
-    HeroesIndicator( const Heroes & );
+    HeroesIndicator( const Heroes * );
 
     const Rect & GetArea( void ) const;
     const std::string & GetDescriptions( void ) const;
     void SetPos( const Point & );
-    void SetHero( const Heroes & hero );
+    void SetHero( const Heroes * hero );
 
 protected:
     const Heroes * hero;
@@ -49,7 +49,7 @@ protected:
 class LuckIndicator : public HeroesIndicator
 {
 public:
-    LuckIndicator( const Heroes & );
+    LuckIndicator( const Heroes * );
 
     void Redraw( void );
     static void QueueEventProcessing( LuckIndicator & );
@@ -61,7 +61,7 @@ private:
 class MoraleIndicator : public HeroesIndicator
 {
 public:
-    MoraleIndicator( const Heroes & );
+    MoraleIndicator( const Heroes * );
 
     void Redraw( void );
     static void QueueEventProcessing( MoraleIndicator & );
@@ -73,7 +73,7 @@ private:
 class ExperienceIndicator : public HeroesIndicator
 {
 public:
-    ExperienceIndicator( const Heroes & );
+    ExperienceIndicator( const Heroes * );
 
     void Redraw( void );
     void QueueEventProcessing( void );
@@ -82,7 +82,7 @@ public:
 class SpellPointsIndicator : public HeroesIndicator
 {
 public:
-    SpellPointsIndicator( const Heroes & );
+    SpellPointsIndicator( const Heroes * );
 
     void Redraw( void );
     void QueueEventProcessing( void );

--- a/src/fheroes2/heroes/heroes_indicator.h
+++ b/src/fheroes2/heroes/heroes_indicator.h
@@ -37,9 +37,10 @@ public:
     const Rect & GetArea( void ) const;
     const std::string & GetDescriptions( void ) const;
     void SetPos( const Point & );
+    void SetHero( const Heroes & hero );
 
 protected:
-    const Heroes & hero;
+    const Heroes * hero;
     Rect area;
     fheroes2::ImageRestorer back;
     std::string descriptions;

--- a/src/fheroes2/heroes/heroes_indicator.h
+++ b/src/fheroes2/heroes/heroes_indicator.h
@@ -36,7 +36,7 @@ public:
 
     const Rect & GetArea( void ) const;
     const std::string & GetDescriptions( void ) const;
-    void SetPos( const Point &, bool skip_back = false );
+    void SetPos( const Point & );
 
 protected:
     const Heroes & hero;

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -81,25 +81,25 @@ void Heroes::MeetingDialog( Heroes & heroes2 )
 
     dst_pt.x = cur_pt.x + 34;
     dst_pt.y = cur_pt.y + 75;
-    MoraleIndicator moraleIndicator1( *this );
+    MoraleIndicator moraleIndicator1( this );
     moraleIndicator1.SetPos( dst_pt );
     moraleIndicator1.Redraw();
 
     dst_pt.x = cur_pt.x + 34;
     dst_pt.y = cur_pt.y + 115;
-    LuckIndicator luckIndicator1( *this );
+    LuckIndicator luckIndicator1( this );
     luckIndicator1.SetPos( dst_pt );
     luckIndicator1.Redraw();
 
     dst_pt.x = cur_pt.x + 566;
     dst_pt.y = cur_pt.y + 75;
-    MoraleIndicator moraleIndicator2( heroes2 );
+    MoraleIndicator moraleIndicator2( &heroes2 );
     moraleIndicator2.SetPos( dst_pt );
     moraleIndicator2.Redraw();
 
     dst_pt.x = cur_pt.x + 566;
     dst_pt.y = cur_pt.y + 115;
-    LuckIndicator luckIndicator2( heroes2 );
+    LuckIndicator luckIndicator2( &heroes2 );
     luckIndicator2.SetPos( dst_pt );
     luckIndicator2.Redraw();
 


### PR DESCRIPTION
I used battle only mode very frequently for testing.

Morale and luck indicators have image restorer that was overwriting whole display. This caused cases when UI seemed unresponsive (i.e. you change a hero and it still shows the default one).