### PR TITLE
Strategic AI: general improvements

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1400,11 +1400,9 @@ namespace AI
                     hero.GetKingdom().OddFundsResource( payment );
                 }
             }
-            else
-                // 4,5 - need have skill wisard or leadership,
-                if ( 3 < cond && cond < 6 ) {
-                if ( hero.HasSecondarySkill( tile.QuantitySkill().Skill() ) )
-                    result = true;
+            else if ( 3 < cond && cond < 6 ) {
+                // 4,5 - bypass wisdom and leadership requirement
+                result = true;
             }
             else
                 // 6 - 50 rogues, 7 - 1 gin, 8,9,10,11,12,13 - 1 monster level4

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1849,7 +1849,7 @@ namespace AI
             const Castle * castle = world.GetCastle( Maps::GetPoint( index ) );
             if ( castle ) {
                 if ( hero.GetColor() == castle->GetColor() ) {
-                    return NULL == castle->GetHeroes().Guest() && !hero.isVisited( tile );
+                    return castle->GetHeroes().Guest() == NULL;
                 }
                 else {
                     if ( hero.isFriends( castle->GetColor() ) )

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -49,6 +49,8 @@ namespace AI
         void revealFog( const Maps::Tiles & tile );
 
         void HeroesActionComplete( Heroes & hero, int index );
+
+        double getObjectValue( const Heroes & hero, int index, int objectID, double valueToIgnore ) const;
         int getPriorityTarget( const Heroes & hero, int patrolIndex = -1, uint32_t distanceLimit = 0 );
         void resetPathfinder();
 

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -29,9 +29,10 @@ namespace AI
 {
     struct RegionStats
     {
-        int id = -1;
         double highestThreat = -1;
         double averageMonster = -1;
+        int friendlyHeroCount = 0;
+        int monsterCount = 0;
         int fogCount = 0;
         std::vector<IndexObject> validObjects;
     };
@@ -52,7 +53,10 @@ namespace AI
         void resetPathfinder();
 
     private:
+        // following data won't be saved/serialized
+        double _combinedHeroStrength = 0;
         std::vector<IndexObject> _mapObjects;
+        std::vector<RegionStats> _regions;
         AIWorldPathfinder _pathfinder;
     };
 }

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -27,6 +27,15 @@
 
 namespace AI
 {
+    struct RegionStats
+    {
+        int id = -1;
+        double highestThreat = -1;
+        double averageMonster = -1;
+        int fogCount = 0;
+        std::vector<IndexObject> validObjects;
+    };
+
     class Normal : public Base
     {
     public:
@@ -39,7 +48,7 @@ namespace AI
         void revealFog( const Maps::Tiles & tile );
 
         void HeroesActionComplete( Heroes & hero, int index );
-        int GetPriorityTarget( const Heroes & hero, int patrolIndex = -1, uint32_t distanceLimit = 0 );
+        int getPriorityTarget( const Heroes & hero, int patrolIndex = -1, uint32_t distanceLimit = 0 );
         void resetPathfinder();
 
     private:

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -109,7 +109,7 @@ namespace AI
         const int myHeadIndex = currentUnit.GetHeadIndex();
         const uint32_t currentUnitMoveRange = currentUnit.isFlying() ? MAXU16 : currentUnit.GetSpeed();
 
-        DEBUG( DBG_AI, DBG_TRACE, currentUnit.GetName() << " start their turn. Side: " << myColor );
+        DEBUG( DBG_BATTLE, DBG_TRACE, currentUnit.GetName() << " start their turn. Side: " << myColor );
 
         const HeroBase * commander = currentUnit.GetCommander();
         const Force & friendlyForce = arena.GetForce( myColor );
@@ -174,7 +174,7 @@ namespace AI
             double towerStr = getTowerStrength( arena.GetTower( TWR_CENTER ) );
             towerStr += getTowerStrength( arena.GetTower( TWR_LEFT ) );
             towerStr += getTowerStrength( arena.GetTower( TWR_RIGHT ) );
-            DEBUG( DBG_AI, DBG_TRACE, "- Castle strength: " << towerStr );
+            DEBUG( DBG_BATTLE, DBG_TRACE, "- Castle strength: " << towerStr );
 
             if ( myColor == castle->GetColor() ) {
                 defendingCastle = true;
@@ -191,7 +191,7 @@ namespace AI
         }
 
         const bool defensiveTactics = enemyArcherRatio < 0.75 && ( defendingCastle || myShooterStr > enemyShooterStr );
-        DEBUG( DBG_AI, DBG_TRACE,
+        DEBUG( DBG_BATTLE, DBG_TRACE,
                "Tactic " << defensiveTactics << " chosen. Archers: " << myShooterStr << ", vs enemy " << enemyShooterStr << " ratio is " << enemyArcherRatio );
 
         const double attackDistanceModifier = enemyArmyStrength / STRENGTH_DISTANCE_FACTOR;
@@ -254,19 +254,19 @@ namespace AI
                             canOutrunEnemy = false;
                     }
                     else {
-                        DEBUG( DBG_AI, DBG_WARN, "Board::GetAdjacentEnemies returned a cell " << cell << " that does not contain a unit!" );
+                        DEBUG( DBG_BATTLE, DBG_WARN, "Board::GetAdjacentEnemies returned a cell " << cell << " that does not contain a unit!" );
                     }
                 }
 
                 if ( target && targetCell != -1 ) {
                     // attack selected target
-                    DEBUG( DBG_AI, DBG_INFO, currentUnit.GetName() << " archer deciding to fight back: " << bestOutcome );
+                    DEBUG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " archer deciding to fight back: " << bestOutcome );
                     actions.push_back( Battle::Command( MSG_BATTLE_ATTACK, currentUnit.GetUID(), target->GetUID(), targetCell, 0 ) );
                 }
                 else if ( canOutrunEnemy ) {
                     // Kiting enemy
                     // Search for a safe spot unit can move away
-                    DEBUG( DBG_AI, DBG_INFO, currentUnit.GetName() << " archer kiting enemy" );
+                    DEBUG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " archer kiting enemy" );
                 }
                 // Worst case scenario - Skip turn
             }
@@ -280,14 +280,14 @@ namespace AI
                     if ( highestStrength < attackPriority ) {
                         highestStrength = attackPriority;
                         target = enemy;
-                        DEBUG( DBG_AI, DBG_TRACE, "- Set priority on " << enemy->GetName() << " value " << attackPriority );
+                        DEBUG( DBG_BATTLE, DBG_TRACE, "- Set priority on " << enemy->GetName() << " value " << attackPriority );
                     }
                 }
 
                 if ( target ) {
                     actions.push_back( Battle::Command( MSG_BATTLE_ATTACK, currentUnit.GetUID(), target->GetUID(), target->GetHeadIndex(), 0 ) );
 
-                    DEBUG( DBG_AI, DBG_INFO,
+                    DEBUG( DBG_BATTLE, DBG_INFO,
                            currentUnit.GetName() << " archer focusing enemy " << target->GetName() << " threat level: " << target->GetScoreQuality( currentUnit ) );
                 }
             }
@@ -342,7 +342,7 @@ namespace AI
                                 const bool canReach = moveToEnemy.first != -1 && moveToEnemy.second <= currentUnitMoveRange;
                                 const bool hadAnotherTarget = target != NULL;
 
-                                DEBUG( DBG_AI, DBG_TRACE, " - Found enemy, cell " << cell << " threat " << enemyThreat << " distance " << moveToEnemy.second );
+                                DEBUG( DBG_BATTLE, DBG_TRACE, " - Found enemy, cell " << cell << " threat " << enemyThreat << " distance " << moveToEnemy.second );
 
                                 // Composite priority criteria:
                                 // Primary - Enemy is within move range
@@ -355,11 +355,12 @@ namespace AI
                                     target = enemy;
                                     maxArcherValue = archerValue;
                                     maxEnemyThreat = enemyThreat;
-                                    DEBUG( DBG_AI, DBG_TRACE, " - Target selected " << enemy->GetName() << " cell " << targetCell << " archer value " << archerValue );
+                                    DEBUG( DBG_BATTLE, DBG_TRACE,
+                                           " - Target selected " << enemy->GetName() << " cell " << targetCell << " archer value " << archerValue );
                                 }
                             }
                             else {
-                                DEBUG( DBG_AI, DBG_WARN, "Board::GetAdjacentEnemies returned a cell " << cell << " that does not contain a unit!" );
+                                DEBUG( DBG_BATTLE, DBG_WARN, "Board::GetAdjacentEnemies returned a cell " << cell << " that does not contain a unit!" );
                             }
                         }
 
@@ -372,10 +373,10 @@ namespace AI
                 }
 
                 if ( target ) {
-                    DEBUG( DBG_AI, DBG_INFO, currentUnit.GetName() << " defending against " << target->GetName() << " threat level: " << maxEnemyThreat );
+                    DEBUG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " defending against " << target->GetName() << " threat level: " << maxEnemyThreat );
                 }
                 else if ( targetCell != -1 ) {
-                    DEBUG( DBG_AI, DBG_INFO, currentUnit.GetName() << " protecting friendly archer, moving to " << targetCell );
+                    DEBUG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " protecting friendly archer, moving to " << targetCell );
                 }
             }
             else {
@@ -420,12 +421,12 @@ namespace AI
                             targetCell = wallIndex;
                         }
                     }
-                    DEBUG( DBG_AI, DBG_INFO, "Walker unit moving towards castle walls " << currentUnit.GetName() << " cell " << targetCell );
+                    DEBUG( DBG_BATTLE, DBG_INFO, "Walker unit moving towards castle walls " << currentUnit.GetName() << " cell " << targetCell );
                 }
             }
 
             // Melee unit final stage - action target should be determined already, add actions to the queue
-            DEBUG( DBG_AI, DBG_INFO, "Melee phase end, targetCell is " << targetCell );
+            DEBUG( DBG_BATTLE, DBG_INFO, "Melee phase end, targetCell is " << targetCell );
 
             if ( targetCell != -1 ) {
                 if ( myHeadIndex != targetCell )
@@ -433,7 +434,7 @@ namespace AI
 
                 if ( target ) {
                     actions.push_back( Battle::Command( MSG_BATTLE_ATTACK, currentUnit.GetUID(), target->GetUID(), target->GetHeadIndex(), 0 ) );
-                    DEBUG( DBG_AI, DBG_INFO,
+                    DEBUG( DBG_BATTLE, DBG_INFO,
                            currentUnit.GetName() << " melee offense, focus enemy " << target->GetName() << " threat level: " << target->GetScoreQuality( currentUnit ) );
                 }
             }

--- a/src/fheroes2/ai/normal/ai_normal_castle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_castle.cpp
@@ -127,7 +127,7 @@ namespace AI
             return true;
         }
 
-        const size_t neighbourRegions = world.getRegion( world.GetTiles( castle.GetIndex() ).GetRegion() ).getNeighbours().size();
+        const size_t neighbourRegions = world.getRegion( world.GetTiles( castle.GetIndex() ).GetRegion() ).getNeighboursCount();
         const bool islandOrPeninsula = neighbourRegions < 3;
 
         // force building a shipyard, +1 to cost check since we can have 0 neighbours

--- a/src/fheroes2/ai/normal/ai_normal_castle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_castle.cpp
@@ -39,6 +39,14 @@ namespace AI
         {}
     };
 
+    const std::vector<BuildOrder> & GetIncomeStructures( int type )
+    {
+        static const std::vector<BuildOrder> standard = {{BUILD_CASTLE, 1}, {BUILD_STATUE, 1}};
+        static const std::vector<BuildOrder> warlock = {{BUILD_CASTLE, 1}, {BUILD_STATUE, 1}, {BUILD_SPEC, 1}};
+
+        return ( type == Race::WRLK ) ? warlock : standard;
+    }
+
     const std::vector<BuildOrder> & GetDefensiveStructures( int )
     {
         static const std::vector<BuildOrder> defensive
@@ -113,6 +121,10 @@ namespace AI
         if ( !castle.isBuild( BUILD_WELL ) && world.LastDay() ) {
             // return right away - if you can't buy Well you can't buy anything else
             return BuildIfAvailable( castle, BUILD_WELL );
+        }
+
+        if ( Build( castle, GetIncomeStructures( castle.GetRace() ) ) ) {
+            return true;
         }
 
         const size_t neighbourRegions = world.getRegion( world.GetTiles( castle.GetIndex() ).GetRegion() ).getNeighbours().size();

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -51,7 +51,7 @@ namespace AI
             if ( hero.GetColor() == castle->GetColor() )
                 return castle->getVisitValue( hero );
             else
-                return castle->getBuildingValue() * 70.0 + 1250;
+                return castle->getBuildingValue() * 100.0 + 2000;
         }
         else if ( objectID == MP2::OBJ_HEROES ) {
             const Heroes * otherHero = tile.GetHeroes();
@@ -64,33 +64,33 @@ namespace AI
 
                 const double value = hero.getMeetingValue( *otherHero );
                 // limit the max value of friendly hero meeting to 30 tiles
-                return ( value < 200 ) ? valueToIgnore : std::min( value, 3000.0 );
+                return ( value < 200 ) ? valueToIgnore : std::min( value, 6000.0 );
             }
-            return 1700.0;
+            return 5000.0;
         }
         else if ( objectID == MP2::OBJ_MONSTER ) {
-            return 400.0;
+            return 1500.0;
         }
         else if ( objectID == MP2::OBJ_MINES || objectID == MP2::OBJ_SAWMILL || objectID == MP2::OBJ_ALCHEMYLAB ) {
-            return ( tile.QuantityResourceCount().first == Resource::GOLD ) ? 2000.0 : 1000.0;
+            return ( tile.QuantityResourceCount().first == Resource::GOLD ) ? 4000.0 : 2000.0;
         }
         else if ( MP2::isArtifactObject( objectID ) && tile.QuantityArtifact().isValid() ) {
-            return 500.0 * tile.QuantityArtifact().getArtifactValue();
+            return 1250.0 * tile.QuantityArtifact().getArtifactValue();
         }
         else if ( MP2::isPickupObject( objectID ) ) {
-            return 500.0;
+            return 1000.0;
         }
         else if ( objectID == MP2::OBJ_XANADU ) {
-            return 2000.0;
+            return 3000.0;
         }
         else if ( MP2::isHeroUpgradeObject( objectID ) ) {
-            return 400.0;
+            return 750.0;
         }
         else if ( objectID == MP2::OBJ_OBSERVATIONTOWER ) {
-            return world.getRegion( tile.GetRegion() ).getFogRatio( hero.GetColor() ) * 1500;
+            return world.getRegion( tile.GetRegion() ).getFogRatio( hero.GetColor() ) * 3500;
         }
         else if ( objectID == MP2::OBJ_COAST ) {
-            return world.getRegion( tile.GetRegion() ).getObjectCount() * 50.0 - 2000;
+            return world.getRegion( tile.GetRegion() ).getObjectCount() * 100.0 - 3000;
         }
         else if ( objectID == MP2::OBJ_BOAT || objectID == MP2::OBJ_WHIRLPOOL ) {
             // de-prioritize the water movement even harder

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -58,7 +58,8 @@ namespace AI
                 else if ( hero.isVisited( tile ) )
                     value -= suboptimalTaskPenalty;
                 return value;
-            } else {
+            }
+            else {
                 return castle->getBuildingValue() * 150.0 + 3000;
             }
         }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -74,7 +74,7 @@ namespace AI
 
                 const double value = hero.getMeetingValue( *otherHero );
                 // limit the max value of friendly hero meeting to 30 tiles
-                return ( value < 200 ) ? -suboptimalTaskPenalty : std::min( value, 6000.0 );
+                return ( value < 250 ) ? -suboptimalTaskPenalty : std::min( value, 10000.0 );
             }
             return 5000.0;
         }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -59,7 +59,7 @@ namespace AI
                     value -= suboptimalTaskPenalty;
                 return value;
             } else {
-                return castle->getBuildingValue() * 100.0 + 2000;
+                return castle->getBuildingValue() * 150.0 + 3000;
             }
         }
         else if ( objectID == MP2::OBJ_HEROES ) {
@@ -73,7 +73,7 @@ namespace AI
 
                 const double value = hero.getMeetingValue( *otherHero );
                 // limit the max value of friendly hero meeting to 30 tiles
-                return ( value < 200 ) ? valueToIgnore : std::min( value, 6000.0 );
+                return ( value < 200 ) ? -suboptimalTaskPenalty : std::min( value, 6000.0 );
             }
             return 5000.0;
         }
@@ -111,14 +111,14 @@ namespace AI
         }
         else if ( objectID == MP2::OBJ_COAST ) {
             const int objectCount = _regions[tile.GetRegion()].validObjects.size();
-            double value = objectCount * 100.0 - 3500;
+            double value = objectCount * 100.0 - 7500;
             if ( _regions[tile.GetRegion()].friendlyHeroCount )
                 value -= suboptimalTaskPenalty;
             return ( objectCount ) ? value : valueToIgnore;
         }
         else if ( objectID == MP2::OBJ_BOAT || objectID == MP2::OBJ_WHIRLPOOL ) {
             // de-prioritize the water movement even harder
-            return -2500.0;
+            return -3000.0;
         }
 
         return 0;

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -29,8 +29,8 @@
 
 namespace AI
 {
-    const double lowEfficiencyPenalty = 20000.0;
-    const double underThreatPenalty = 40000.0;
+    const double suboptimalTaskPenalty = 20000.0;
+    const double dangerousTaskPenalty = 40000.0;
 
     double ScaleWithDistance( double value, uint32_t distance )
     {

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -144,7 +144,7 @@ namespace AI
                     if ( HeroesValidObject( hero, pair.first ) && std::binary_search( _mapObjects.begin(), _mapObjects.end(), pair ) )
                         value += getObjectValue( hero, pair.first, pair.second, lowestPossibleValue );
                 }
-                auto regionStats = _regions[world.GetTiles( node.first ).GetRegion() - REGION_NODE_FOUND];
+                auto regionStats = _regions[world.GetTiles( node.first ).GetRegion()];
                 if ( hero.GetArmy().GetStrength() < regionStats.highestThreat )
                     value -= dangerousTaskPenalty;
                 value = ScaleWithDistance( value, dist );

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -55,7 +55,8 @@ namespace AI
                 double value = castle->getVisitValue( hero );
                 if ( value < 1000 )
                     return valueToIgnore;
-                else if ( hero.isVisited( tile ) )
+
+                if ( hero.isVisited( tile ) )
                     value -= suboptimalTaskPenalty;
                 return value;
             }
@@ -111,12 +112,13 @@ namespace AI
             return _regions[tile.GetRegion()].fogCount * 150.0;
         }
         else if ( objectID == MP2::OBJ_COAST ) {
-            const int objectCount = _regions[tile.GetRegion()].validObjects.size();
+            const RegionStats & regionStats = _regions[tile.GetRegion()];
+            const int objectCount = regionStats.validObjects.size();
             if ( objectCount < 1 )
                 return valueToIgnore;
 
             double value = objectCount * 100.0 - 7500;
-            if ( _regions[tile.GetRegion()].friendlyHeroCount )
+            if ( regionStats.friendlyHeroCount )
                 value -= suboptimalTaskPenalty;
             return value;
         }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -29,8 +29,8 @@
 
 namespace AI
 {
-    const double suboptimalTaskPenalty = 20000.0;
-    const double dangerousTaskPenalty = 40000.0;
+    const double suboptimalTaskPenalty = 10000.0;
+    const double dangerousTaskPenalty = 20000.0;
 
     double ScaleWithDistance( double value, uint32_t distance )
     {
@@ -95,13 +95,24 @@ namespace AI
         else if ( MP2::isHeroUpgradeObject( objectID ) ) {
             return 500.0;
         }
+        else if ( MP2::isMonsterDwelling( objectID ) ) {
+            return tile.QuantityTroop().GetStrength();
+        }
+        else if ( objectID == MP2::OBJ_STONELITHS ) {
+            const MapsIndexes & list = world.GetTeleportEndPoints( index );
+            for ( int teleportIndex : list ) {
+                if ( world.GetTiles( teleportIndex ).isFog( hero.GetColor() ) )
+                    return 0;
+            }
+            return valueToIgnore;
+        }
         else if ( objectID == MP2::OBJ_OBSERVATIONTOWER ) {
-            return _regions[tile.GetRegion() - REGION_NODE_FOUND].fogCount * 150;
+            return _regions[tile.GetRegion()].fogCount * 150.0;
         }
         else if ( objectID == MP2::OBJ_COAST ) {
-            const int objectCount = _regions[tile.GetRegion() - REGION_NODE_FOUND].validObjects.size();
+            const int objectCount = _regions[tile.GetRegion()].validObjects.size();
             double value = objectCount * 100.0 - 3500;
-            if ( _regions[tile.GetRegion() - REGION_NODE_FOUND].friendlyHeroCount )
+            if ( _regions[tile.GetRegion()].friendlyHeroCount )
                 value -= suboptimalTaskPenalty;
             return ( objectCount ) ? value : valueToIgnore;
         }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -75,7 +75,7 @@ namespace AI
 
                 const double value = hero.getMeetingValue( *otherHero );
                 // limit the max value of friendly hero meeting to 30 tiles
-                return ( value < 250 ) ? -suboptimalTaskPenalty : std::min( value, 10000.0 );
+                return ( value < 250 ) ? valueToIgnore : std::min( value, 10000.0 );
             }
             return 5000.0;
         }

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -63,10 +63,10 @@ namespace AI
                 continue;
 
             const int regionID = tile.GetRegion();
-            if ( regionID - REGION_NODE_FOUND >= _regions.size() )
+            if ( regionID >= _regions.size() )
                 continue;
 
-            RegionStats & stats = _regions[regionID - REGION_NODE_FOUND];
+            RegionStats & stats = _regions[regionID];
             stats.validObjects.emplace_back( idx, objectID );
 
             if ( !tile.isFog( color ) ) {

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -18,6 +18,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <assert.h>
+
 #include "agg.h"
 #include "ai_normal.h"
 #include "game_interface.h"
@@ -64,8 +66,10 @@ namespace AI
                 continue;
 
             const int regionID = tile.GetRegion();
-            if ( regionID >= _regions.size() )
-                continue;
+            if ( regionID >= _regions.size() ) {
+                // shouldn't be possible, assert
+                assert( 0 );
+            }
 
             RegionStats & stats = _regions[regionID];
             stats.validObjects.emplace_back( idx, objectID );

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -221,7 +221,7 @@ namespace AI
         VecHeroes sortedHeroList = heroes;
         std::sort( sortedHeroList.begin(), sortedHeroList.end(), []( const Heroes * left, const Heroes * right ) {
             if ( left && right )
-                return left->GetArmy().GetStrength() < right->GetArmy().GetStrength();
+                return left->GetArmy().GetStrength() > right->GetArmy().GetStrength();
             return right == NULL;
         } );
 

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -65,10 +65,10 @@ namespace AI
             if ( !kingdom.isValidKingdomObject( tile, objectID ) )
                 continue;
 
-            const int regionID = tile.GetRegion();
-            if ( regionID < 0 || regionID >= _regions.size() ) {
+            const uint32_t regionID = tile.GetRegion();
+            if ( regionID >= _regions.size() ) {
                 // shouldn't be possible, assert
-                assert( regionID > 0 && regionID < _regions.size() );
+                assert( regionID < _regions.size() );
                 continue;
             }
 
@@ -192,7 +192,7 @@ namespace AI
                     if ( hero || std::find( castlesInDanger.begin(), castlesInDanger.end(), mapIndex ) != castlesInDanger.end() )
                         continue;
 
-                    const int regionID = world.GetTiles( mapIndex ).GetRegion();
+                    const uint32_t regionID = world.GetTiles( mapIndex ).GetRegion();
                     const int heroCount = _regions[regionID].friendlyHeroCount;
 
                     // don't buy a second hero if castle is on locked island

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -189,6 +189,10 @@ namespace AI
                     const int regionID = world.GetTiles( mapIndex ).GetRegion();
                     const int heroCount = _regions[regionID].friendlyHeroCount;
 
+                    // don't buy a second hero if castle is on locked island
+                    if ( world.getRegion( regionID ).getNeighboursCount() == 0 && heroCount > 0 )
+                        continue;
+
                     if ( recruitmentCastle == NULL || lowestHeroCount > heroCount ) {
                         recruitmentCastle = castle;
                         lowestHeroCount = heroCount;

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -21,6 +21,7 @@
 #include "agg.h"
 #include "ai_normal.h"
 #include "game_interface.h"
+#include "ground.h"
 #include "kingdom.h"
 #include "mus.h"
 #include "world.h"
@@ -138,6 +139,10 @@ namespace AI
                     const Castle * castle = castles[idx];
                     if ( castle ) {
                         const int castleIndex = castle->GetIndex();
+                        // skip precise distance check if army is too far away to be a threat
+                        if ( Maps::GetApproximateDistance( enemy->first, castleIndex ) * Maps::Ground::roadPenalty > threatDistanceLimit )
+                            continue;
+
                         const double defenders = castle->GetArmy().GetStrength();
 
                         const double attackerThreat = attackerStrength - defenders;

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -66,9 +66,10 @@ namespace AI
                 continue;
 
             const int regionID = tile.GetRegion();
-            if ( regionID < 0 && regionID >= _regions.size() ) {
+            if ( regionID < 0 || regionID >= _regions.size() ) {
                 // shouldn't be possible, assert
                 assert( regionID > 0 && regionID < _regions.size() );
+                continue;
             }
 
             RegionStats & stats = _regions[regionID];

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -159,7 +159,7 @@ namespace AI
             }
         }
 
-        size_t heroLimit = Maps::XLARGE > world.w() ? ( Maps::LARGE > world.w() ? 2 : 3 ) : 4;
+        size_t heroLimit = world.w() / Maps::SMALL + 1;
         if ( _personality == EXPLORER )
             heroLimit++;
         if ( slowEarlyGame )
@@ -208,7 +208,7 @@ namespace AI
                     recruit = recruitmentCastle->RecruitHero( firstRecruit );
                 }
 
-                if ( recruit )
+                if ( recruit && !slowEarlyGame )
                     ReinforceHeroInCastle( *recruit, *recruitmentCastle, kingdom.GetFunds() );
             }
         }

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -437,10 +437,22 @@ double Castle::getVisitValue( const Heroes & hero ) const
         }
     }
 
+    // we don't spend actual funds, so make a copy here
+    Funds potentialFunds = GetKingdom().GetFunds();
     Troops reinforcement;
     for ( uint32_t dw = DWELLING_MONSTER6; dw >= DWELLING_MONSTER1; dw >>= 1 ) {
-        if ( isBuild( dw ) )
-            reinforcement.PushBack( Monster( race, GetActualDwelling( dw ) ), getMonstersInDwelling( dw ) );
+        if ( isBuild( dw ) ) {
+            const Monster monster( race, GetActualDwelling( dw ) );
+            const uint32_t available = getMonstersInDwelling( dw );
+
+            uint32_t couldRecruit = potentialFunds.getLowestQuotient( monster.GetCost() );
+            if ( available < couldRecruit )
+                couldRecruit = available;
+
+            potentialFunds -= ( monster.GetCost() * couldRecruit );
+
+            reinforcement.PushBack( monster, couldRecruit );
+        }
     }
 
     return spellValue + hero.GetArmy().getReinforcementValue( reinforcement );

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -2618,6 +2618,15 @@ Castle * VecCastles::GetFirstCastle( void ) const
     return end() != it ? *it : NULL;
 }
 
+void VecCastles::SortByBuildingValue()
+{
+    std::sort( begin(), end(), []( const Castle * left, const Castle * right ) {
+        if ( left && right )
+            return left->getBuildingValue() > right->getBuildingValue();
+        return right == NULL;
+    } );
+}
+
 void VecCastles::ChangeColors( int col1, int col2 )
 {
     for ( iterator it = begin(); it != end(); ++it )

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -288,6 +288,7 @@ struct VecCastles : public std::vector<Castle *>
     Castle * GetFirstCastle( void ) const;
 
     void ChangeColors( int, int );
+    void SortByBuildingValue();
 };
 
 struct AllCastles : public VecCastles

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1294,12 +1294,12 @@ void Heroes::SetShipMaster( bool f )
     f ? SetModes( SHIPMASTER ) : ResetModes( SHIPMASTER );
 }
 
-int Heroes::lastGroundRegion() const
+uint32_t Heroes::lastGroundRegion() const
 {
     return _lastGroundRegion;
 }
 
-void Heroes::setLastGroundRegion( int regionID )
+void Heroes::setLastGroundRegion( uint32_t regionID )
 {
     _lastGroundRegion = regionID;
 }

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -295,8 +295,8 @@ public:
 
     bool isShipMaster( void ) const;
     void SetShipMaster( bool );
-    int lastGroundRegion() const;
-    void setLastGroundRegion( int regionID );
+    uint32_t lastGroundRegion() const;
+    void setLastGroundRegion( uint32_t regionID );
 
     u32 GetExperience( void ) const;
     void IncreaseExperience( u32 );
@@ -365,7 +365,7 @@ private:
 
     std::list<IndexObject> visit_object;
     // persist this value later
-    int _lastGroundRegion = 0;
+    uint32_t _lastGroundRegion = 0;
 
     mutable int _alphaValue;
 

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -360,7 +360,7 @@ void Kingdom::SetVisited( s32 index, int object )
 
 bool Kingdom::isValidKingdomObject( const Maps::Tiles & tile, int objectID ) const
 {
-    if ( tile.isFog( color ) || ( !MP2::isGroundObject( objectID ) && objectID != MP2::OBJ_COAST ) )
+    if ( !MP2::isGroundObject( objectID ) && objectID != MP2::OBJ_COAST )
         return false;
 
     if ( isVisited( tile.GetIndex(), objectID ) )

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1257,12 +1257,12 @@ void Maps::Tiles::UpdatePassable( void )
     }
 }
 
-int Maps::Tiles::GetRegion() const
+uint32_t Maps::Tiles::GetRegion() const
 {
     return _region;
 }
 
-void Maps::Tiles::UpdateRegion( int newRegionID )
+void Maps::Tiles::UpdateRegion( uint32_t newRegionID )
 {
     if ( tilePassable ) {
         _region = newRegionID;

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -148,8 +148,8 @@ namespace Maps
 
         void FixObject( void );
 
-        int GetRegion() const;
-        void UpdateRegion( int newRegionID );
+        uint32_t GetRegion() const;
+        void UpdateRegion( uint32_t newRegionID );
         void UpdatePassable( void );
         void CaptureFlags32( int obj, int col );
 
@@ -283,7 +283,7 @@ namespace Maps
         bool tileIsRoad = false;
 
         // This field does not persist in savegame
-        int _region = 0;
+        uint32_t _region = 0;
 
 #ifdef WITH_DEBUG
         uint8_t impassableTileRule = 0;

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -964,6 +964,40 @@ bool MP2::isHeroUpgradeObject( int obj )
     return false;
 }
 
+bool MP2::isMonsterDwelling( int obj )
+{
+    switch ( obj ) {
+    case OBJ_WATCHTOWER:
+    case OBJ_EXCAVATION:
+    case OBJ_CAVE:
+    case OBJ_TREEHOUSE:
+    case OBJ_ARCHERHOUSE:
+    case OBJ_GOBLINHUT:
+    case OBJ_DWARFCOTT:
+    case OBJ_HALFLINGHOLE:
+    case OBJ_PEASANTHUT:
+    case OBJ_THATCHEDHUT:
+    case OBJ_RUINS:
+    case OBJ_TREECITY:
+    case OBJ_WAGONCAMP:
+    case OBJ_DESERTTENT:
+    case OBJ_WATERALTAR:
+    case OBJ_AIRALTAR:
+    case OBJ_FIREALTAR:
+    case OBJ_EARTHALTAR:
+    case OBJ_BARROWMOUNDS:
+    case OBJ_CITYDEAD:
+    case OBJ_TROLLBRIDGE:
+    case OBJ_DRAGONCITY:
+        return true;
+
+    default:
+        break;
+    }
+
+    return false;
+}
+
 bool MP2::isProtectedObject( int obj )
 {
     switch ( obj ) {

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -548,6 +548,7 @@ namespace MP2
     bool isPickupObject( int obj );
     bool isArtifactObject( int obj );
     bool isHeroUpgradeObject( int obj );
+    bool isMonsterDwelling( int obj );
     bool isRemoveObject( int obj );
     bool isMoveObject( int obj );
     bool isAbandonedMine( int obj );

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -653,9 +653,6 @@ MapsIndexes World::GetTeleportEndPoints( s32 center ) const
             }
         }
     }
-    else {
-        DEBUG( DBG_GAME, DBG_WARN, " can't find teleporters" );
-    }
 
     return result;
 }

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -258,7 +258,8 @@ public:
     MapEvent * GetMapEvent( const Point & );
     MapObjectSimple * GetMapObject( u32 uid );
     void RemoveMapObject( const MapObjectSimple * );
-    const MapRegion & getRegion( size_t id );
+    const MapRegion & getRegion( size_t id ) const;
+    size_t getRegionCount() const;
 
     bool isTileBlocked( int toTile, bool fromWater ) const;
     bool isValidPath( int index, int direction ) const;

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -276,7 +276,8 @@ private:
     void Defaults( void );
     void Reset( void );
     void MonthOfMonstersAction( const Monster & );
-    void PostLoad( void );
+    void ProcessNewMap( void );
+    void PostLoad();
 
 private:
     friend class Radar;
@@ -312,6 +313,7 @@ private:
     MapObjects map_objects;
 
     // This data isn't serialized
+    Maps::Indexes _allTeleporters;
     std::vector<MapRegion> _regions;
     PlayerWorldPathfinder _pathfinder;
 };

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -875,7 +875,7 @@ TiXmlElement & operator>>( TiXmlElement & doc, World & w )
     TiXmlElement * xml_rumors = doc.FirstChildElement( "rumors" );
     if ( xml_rumors )
         *xml_rumors >> w.vec_rumors;
-    w.PostLoad();
+    w.ProcessNewMap();
 
     return doc;
 }
@@ -1400,13 +1400,13 @@ bool World::LoadMapMP2( const std::string & filename )
         }
     }
 
-    PostLoad();
+    ProcessNewMap();
 
     DEBUG( DBG_GAME, DBG_INFO, "end load" );
     return true;
 }
 
-void World::PostLoad( void )
+void World::ProcessNewMap( void )
 {
     // modify other objects
     for ( size_t ii = 0; ii < vec_tiles.size(); ++ii ) {
@@ -1522,11 +1522,7 @@ void World::PostLoad( void )
         }
     }
 
-    // update tile passable
-    std::for_each( vec_tiles.begin(), vec_tiles.end(), std::mem_fun_ref( &Maps::Tiles::UpdatePassable ) );
-
-    resetPathfinder();
-    ComputeStaticAnalysis();
+    PostLoad();
 
     // play with hero
     vec_kingdoms.ApplyPlayWithStartingHero();

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -44,7 +44,7 @@ bool isTileBlockedForArmy( int tileIndex, int color, double armyStrength, bool f
         }
     }
 
-    if ( object == MP2::OBJ_MONSTER )
+    if ( object == MP2::OBJ_MONSTER || ( object == MP2::OBJ_ARTIFACT && tile.QuantityVariant() > 5 ) )
         return Army( tile ).GetStrength() > armyStrength;
 
     return ( fromWater && !toWater && object == MP2::OBJ_COAST );

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -183,7 +183,12 @@ double MapRegion::getFogRatio( int color ) const
     return static_cast<double>( fogCount ) / _nodes.size();
 }
 
-const MapRegion & World::getRegion( size_t id )
+size_t World::getRegionCount() const
+{
+    return _regions.size();
+}
+
+const MapRegion & World::getRegion( size_t id ) const
 {
     // region IDs start from 3
     id -= REGION_NODE_FOUND;

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -138,12 +138,12 @@ namespace
 }
 
 MapRegion::MapRegion( int regionIndex, int mapIndex, bool water, size_t expectedSize )
-    : _id( REGION_NODE_FOUND + regionIndex )
+    : _id( regionIndex )
     , _isWater( water )
 {
     _nodes.reserve( expectedSize );
     _nodes.emplace_back( mapIndex );
-    _nodes[0].type = _id;
+    _nodes[0].type = regionIndex;
 }
 
 std::vector<int> MapRegion::getNeighbours() const
@@ -353,10 +353,10 @@ void World::ComputeStaticAnalysis()
         _regions.emplace_back( baseIDX, 0, false, 0 );
     }
 
-    for ( size_t regionID = 0; regionID < regionCenters.size(); ++regionID ) {
-        const int tileIndex = regionCenters[regionID];
+    for ( const int tileIndex : regionCenters ) {
+        const size_t regionID = _regions.size();
         _regions.emplace_back( static_cast<int>( regionID ), tileIndex, vec_tiles[tileIndex].isWater(), averageRegionSize );
-        data[ConvertExtendedIndex( tileIndex, extendedWidth )].type = REGION_NODE_FOUND + regionID;
+        data[ConvertExtendedIndex( tileIndex, extendedWidth )].type = regionID;
     }
 
     // Step 7. Grow all regions one step at the time so they would compete for space

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -375,7 +375,6 @@ void World::ComputeStaticAnalysis()
     // Step 8. Fill missing data (if there's a small island/lake or unreachable terrain)
     FindMissingRegions( data, Size( width, height ), _regions );
 
-
     // Step 9. Assign regions to the map tiles and finalize the data
     for ( MapRegion & reg : _regions ) {
         if ( reg._id < REGION_NODE_FOUND )

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -375,13 +375,23 @@ void World::ComputeStaticAnalysis()
     // Step 8. Fill missing data (if there's a small island/lake or unreachable terrain)
     FindMissingRegions( data, Size( width, height ), _regions );
 
-    // Assign regions to the map tiles
-    for ( const MapRegion & reg : _regions ) {
+
+    // Step 9. Assign regions to the map tiles and finalize the data
+    for ( MapRegion & reg : _regions ) {
         if ( reg._id < REGION_NODE_FOUND )
             continue;
 
         for ( const MapRegionNode & node : reg._nodes ) {
             vec_tiles[node.index].UpdateRegion( node.type );
+
+            // connect regions through teleporters
+            if ( node.mapObject == MP2::OBJ_STONELITHS ) {
+                const MapsIndexes & exits = GetTeleportEndPoints( node.index );
+                for ( const int exitIndex : exits ) {
+                    // neighbours is a set that will force the uniqness
+                    reg._neighbours.insert( vec_tiles[exitIndex].GetRegion() );
+                }
+            }
         }
     }
 }

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -190,8 +190,6 @@ size_t World::getRegionCount() const
 
 const MapRegion & World::getRegion( size_t id ) const
 {
-    // region IDs start from 3
-    id -= REGION_NODE_FOUND;
     if ( id < _regions.size() )
         return _regions[id];
 
@@ -346,6 +344,10 @@ void World::ComputeStaticAnalysis()
     // Step 6. Initialize regions
     size_t averageRegionSize = ( static_cast<size_t>( width ) * height * 2 ) / regionCenters.size();
     _regions.clear();
+    for ( size_t baseIDX = 0; baseIDX < REGION_NODE_FOUND; ++baseIDX ) {
+        _regions.emplace_back( baseIDX, 0, false, 0 );
+    }
+
 
     for ( size_t regionID = 0; regionID < regionCenters.size(); ++regionID ) {
         const int tileIndex = regionCenters[regionID];
@@ -358,7 +360,7 @@ void World::ComputeStaticAnalysis()
     bool stillRoomToExpand = true;
     while ( stillRoomToExpand ) {
         stillRoomToExpand = false;
-        for ( size_t regionID = 0; regionID < regionCenters.size(); ++regionID ) {
+        for ( size_t regionID = REGION_NODE_FOUND; regionID < regionCenters.size(); ++regionID ) {
             MapRegion & region = _regions[regionID];
             RegionExpansion( data, extendedWidth, region, offsets );
             if ( region._lastProcessedNode != region._nodes.size() )
@@ -371,6 +373,9 @@ void World::ComputeStaticAnalysis()
 
     // Assign regions to the map tiles
     for ( const MapRegion & reg : _regions ) {
+        if ( reg._id < REGION_NODE_FOUND )
+            continue;
+
         for ( const MapRegionNode & node : reg._nodes ) {
             vec_tiles[node.index].UpdateRegion( node.type );
         }

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -185,6 +185,8 @@ double MapRegion::getFogRatio( int color ) const
 
 const MapRegion & World::getRegion( size_t id )
 {
+    // region IDs start from 3
+    id -= REGION_NODE_FOUND;
     if ( id < _regions.size() )
         return _regions[id];
 

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -348,7 +348,6 @@ void World::ComputeStaticAnalysis()
         _regions.emplace_back( baseIDX, 0, false, 0 );
     }
 
-
     for ( size_t regionID = 0; regionID < regionCenters.size(); ++regionID ) {
         const int tileIndex = regionCenters[regionID];
         _regions.emplace_back( static_cast<int>( regionID ), tileIndex, vec_tiles[tileIndex].isWater(), averageRegionSize );

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -355,7 +355,7 @@ void World::ComputeStaticAnalysis()
 
     for ( const int tileIndex : regionCenters ) {
         const size_t regionID = _regions.size();
-        _regions.emplace_back( static_cast<int>( regionID ), tileIndex, vec_tiles[tileIndex].isWater(), averageRegionSize );
+        _regions.emplace_back( regionID, tileIndex, vec_tiles[tileIndex].isWater(), averageRegionSize );
         data[ConvertExtendedIndex( tileIndex, extendedWidth )].type = regionID;
     }
 

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -151,6 +151,11 @@ std::vector<int> MapRegion::getNeighbours() const
     return std::vector<int>( _neighbours.begin(), _neighbours.end() );
 }
 
+size_t MapRegion::getNeighboursCount() const
+{
+    return _neighbours.size();
+}
+
 std::vector<IndexObject> MapRegion::getObjectList() const
 {
     std::vector<IndexObject> result;

--- a/src/fheroes2/world/world_regions.h
+++ b/src/fheroes2/world/world_regions.h
@@ -64,6 +64,7 @@ public:
     MapRegion(){};
     MapRegion( int regionIndex, int mapIndex, bool water, size_t expectedSize );
     std::vector<int> getNeighbours() const;
+    size_t getNeighboursCount() const;
     std::vector<IndexObject> getObjectList() const;
     int getObjectCount() const;
     double getFogRatio( int color ) const;

--- a/src/fheroes2/world/world_regions.h
+++ b/src/fheroes2/world/world_regions.h
@@ -34,7 +34,7 @@ enum
 struct MapRegionNode
 {
     int index = -1;
-    int type = REGION_NODE_BLOCKED;
+    uint32_t type = REGION_NODE_BLOCKED;
     uint16_t mapObject = 0;
     uint16_t passable = 0;
     bool isWater = false;
@@ -55,7 +55,7 @@ struct MapRegionNode
 struct MapRegion
 {
 public:
-    int _id = REGION_NODE_FOUND;
+    uint32_t _id = REGION_NODE_FOUND;
     bool _isWater = false;
     std::set<int> _neighbours;
     std::vector<MapRegionNode> _nodes;


### PR DESCRIPTION
Overall improvements based on feedback and recent testing. Follow-up on #2108 .

- Optimize threat distance calculations. AI turns are twice as fast on average.
- Track map region stats for better decision-making (especially coast landing from boats).
- Improved castle build order (priority on gold income buildings).
- Recruit heroes in castles other than the first one in the list.
- Skip teleports if every exit was already explored.
- Protect high value (based on buildings built) castles first.
- Another round of adjustments to hero object values, heroes are scared of strong enemy armies.
- Move battle-related debugging logs from AI to BATTLE mode.
- Minor refactor of World post load logic (split into two parts: ProcessNewMap and PostLoad).