### PR TITLE
remove obsolete __GNUC__ checks

### DIFF
--- a/src/fheroes2/objects/objdsrt.cpp
+++ b/src/fheroes2/objects/objdsrt.cpp
@@ -29,12 +29,7 @@
 
 int ObjDsrt::GetPassable( u32 index )
 {
-#if ( __GNUC__ == 4 && __GNUC_MINOR__ == 4 )
-    // fixed: array subscript is above array bounds
-    const u8 disabled[] = {61, 89, 90, 91, 92, 93, 125, 126, 255};
-#else
     const u8 disabled[] = {61, 89, 90, 91, 92, 93, 125, 126};
-#endif
     const u8 restricted[] = {3,  6,  9,  12, 14, 15, 17, 18, 20, 21, 22, 24, 26, 28,  30,  31,  32,  34,  36,  39,  40,  42, 45,
                              48, 49, 51, 53, 72, 76, 81, 83, 94, 95, 97, 98, 99, 100, 110, 111, 112, 116, 121, 127, 128, 130};
 

--- a/src/fheroes2/objects/objlava.cpp
+++ b/src/fheroes2/objects/objlava.cpp
@@ -44,12 +44,7 @@ bool ObjLav2::isAction( u32 index )
 
 bool ObjLav2::isShadow( u32 index )
 {
-#if ( __GNUC__ == 4 && __GNUC_MINOR__ == 4 )
-    // fixed: array subscript is above array bounds
-    const u8 shadows[] = {0, 7, 14, 29, 33, 44, 55, 78, 255};
-#else
     const u8 shadows[] = {0, 7, 14, 29, 33, 44, 55, 78};
-#endif
     return ARRAY_COUNT_END( shadows ) != std::find( shadows, ARRAY_COUNT_END( shadows ), index );
 }
 
@@ -94,12 +89,7 @@ bool ObjLava::isAction( u32 index )
 
 bool ObjLava::isShadow( u32 index )
 {
-#if ( __GNUC__ == 4 && __GNUC_MINOR__ == 4 )
-    // fixed: array subscript is above array bounds
-    const u8 shadows[] = {10, 11, 45, 49, 77, 109, 113, 116, 255};
-#else
     const u8 shadows[] = {10, 11, 45, 49, 77, 109, 113, 116};
-#endif
     return ARRAY_COUNT_END( shadows ) != std::find( shadows, ARRAY_COUNT_END( shadows ), index );
 }
 

--- a/src/fheroes2/objects/objmult.cpp
+++ b/src/fheroes2/objects/objmult.cpp
@@ -53,12 +53,7 @@ bool ObjMult::isShadow( u32 index )
 
 int ObjMul2::GetPassable( u32 index )
 {
-#if ( __GNUC__ == 4 && __GNUC_MINOR__ == 4 )
-    // fixed: array subscript is above array bounds
-    const u8 disabled[] = {46, 76, 77, 124, 125, 126, 221, 213, 255};
-#else
     const u8 disabled[] = {46, 76, 77, 124, 125, 126, 221, 213};
-#endif
     const u8 restricted[] = {16, 18, 19, 25, 27, 51, 52, 53, 55, 57, 78, 79, 81, 98, 105, 128, 136, 187, 207, 209, 214, 215, 217};
 
     if ( isShadow( index ) )

--- a/src/fheroes2/objects/objwatr.cpp
+++ b/src/fheroes2/objects/objwatr.cpp
@@ -29,12 +29,7 @@
 
 int ObjWat2::GetPassable( u32 index )
 {
-#if ( __GNUC__ == 4 && __GNUC_MINOR__ == 4 )
-    // fixed: array subscript is above array bounds
-    const u8 disabled[] = {11, 12, 19, 22, 255};
-#else
     const u8 disabled[] = {11, 12, 19, 22};
-#endif
     const u8 restricted[] = {2, 20};
 
     if ( isShadow( index ) )
@@ -51,12 +46,7 @@ int ObjWat2::GetPassable( u32 index )
 
 int ObjWatr::GetPassable( u32 index )
 {
-#if ( __GNUC__ == 4 && __GNUC_MINOR__ == 4 )
-    // fixed: array subscript is above array bounds
-    const u8 disabled[] = {11, 12, 19, 22, 255};
-#else
     const u8 disabled[] = {11, 12, 19, 22};
-#endif
     const u8 restricted[] = {69, 182, 183, 185, 186, 187, 248};
 
     if ( isShadow( index ) )
@@ -79,13 +69,7 @@ bool ObjWatr::isAction( u32 index )
 
 bool ObjWatr::isShadow( u32 index )
 {
-#if ( __GNUC__ == 4 && __GNUC_MINOR__ == 4 )
-    // fixed: array subscript is above array bounds
-    const u8 shadows[] = {12, 38, 52, 55, 118, 166, 188, 240, 255};
-#else
     const u8 shadows[] = {12, 38, 52, 55, 118, 166, 188, 240};
-#endif
-
     return ARRAY_COUNT_END( shadows ) != std::find( shadows, ARRAY_COUNT_END( shadows ), index );
 }
 

--- a/src/fheroes2/objects/objxloc.cpp
+++ b/src/fheroes2/objects/objxloc.cpp
@@ -70,13 +70,7 @@ bool ObjXlc2::isAction( u32 index )
 
 bool ObjXlc2::isShadow( u32 index )
 {
-#if ( __GNUC__ == 4 && __GNUC_MINOR__ == 4 )
-    // fixed: array subscript is above array bounds
-    const u8 shadows[] = {2, 10, 47, 83, 255};
-#else
     const u8 shadows[] = {2, 10, 47, 83};
-#endif
-
     return ARRAY_COUNT_END( shadows ) != std::find( shadows, ARRAY_COUNT_END( shadows ), index );
 }
 


### PR DESCRIPTION
Relates #2162.
This checks are for avoiding old gcc bug. And gcc 4.4 is pre-c++11 compiler.