### PR TITLE
#1084 Upgrade SDL2 to 2.0.12 for Windows platform

### DIFF
--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -12,7 +12,7 @@ powershell -Command "(New-Object Net.WebClient).DownloadFile('https://www.libsdl
 echo downloading packages [3/5]
 powershell -Command "(New-Object Net.WebClient).DownloadFile('https://www.libsdl.org/projects/SDL_mixer/release/SDL_mixer-devel-1.2.12-VC.zip', '..\..\..\packages\sdl_mixer\sdl_mixer.zip')"
 echo downloading packages [4/5]
-powershell -Command "(New-Object Net.WebClient).DownloadFile('https://www.libsdl.org/release/SDL2-devel-2.0.10-VC.zip', '..\..\..\packages\sdl\sdl2.zip')"
+powershell -Command "(New-Object Net.WebClient).DownloadFile('https://www.libsdl.org/release/SDL2-devel-2.0.12-VC.zip', '..\..\..\packages\sdl\sdl2.zip')"
 echo downloading packages [5/5]
 powershell -Command "(New-Object Net.WebClient).DownloadFile('https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.4-VC.zip', '..\..\..\packages\sdl_mixer\sdl_mixer2.zip')"
 

--- a/script/windows/setup_packages.bat
+++ b/script/windows/setup_packages.bat
@@ -14,8 +14,8 @@ if not exist "..\sdl2\lib"     mkdir "..\sdl2\lib"
 
 xcopy /Y /s /Q "sdl\SDL-1.2.15\include"  "..\sdl\include"
 xcopy /Y /s /Q "sdl\SDL-1.2.15\lib"      "..\sdl\lib"
-xcopy /Y /s /Q "sdl\SDL2-2.0.10\include" "..\sdl2\include"
-xcopy /Y /s /Q "sdl\SDL2-2.0.10\lib"     "..\sdl2\lib"
+xcopy /Y /s /Q "sdl\SDL2-2.0.12\include" "..\sdl2\include"
+xcopy /Y /s /Q "sdl\SDL2-2.0.12\lib"     "..\sdl2\lib"
 
 xcopy /Y /s /Q "sdl_mixer\SDL_mixer-1.2.12\include"                "..\sdl\include"
 xcopy /Y /s /Q "sdl_mixer\SDL_mixer-1.2.12\lib\x86\SDL_mixer.dll"  "..\sdl\lib\x86"


### PR DESCRIPTION
Upgrade SDL2 to 2.0.12 for Windows platform. No issues during compilation. Requires manual remove of previous SDL files. No in game issues found so far.