### PR TITLE
Fix map loading typo

### DIFF
--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -316,11 +316,11 @@ u32 Game::GetGameOverScores( void )
     return GetRating() * ( 200 - nk ) / 100;
 }
 
-void Game::ShowLoadMapsText( void )
+void Game::ShowMapLoadingText( void )
 {
     fheroes2::Display & display = fheroes2::Display::instance();
     const fheroes2::Rect pos( 0, display.height() / 2, display.width(), display.height() / 2 );
-    TextBox text( _( "Maps Loading..." ), Font::BIG, pos.width );
+    TextBox text( _( "Map is loading..." ), Font::BIG, pos.width );
 
     // blit test
     display.fill( 0 );

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -246,7 +246,7 @@ namespace Game
     u32 GetViewDistance( u32 );
     u32 GetWhirlpoolPercent( void );
     u32 SelectCountPlayers( void );
-    void ShowLoadMapsText( void );
+    void ShowMapLoadingText( void );
     void PlayPickupSound( void );
     void DisableChangeMusic( bool );
     bool ChangeMusicDisabled( void );

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -132,7 +132,7 @@ bool Game::Load( const std::string & fn )
     DEBUG( DBG_GAME, DBG_INFO, fn );
     Settings & conf = Settings::Get();
     // loading info
-    Game::ShowLoadMapsText();
+    Game::ShowMapLoadingText();
 
     StreamFile fs;
     fs.setbigendian( true );

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -324,7 +324,7 @@ int Game::NewCampain( void )
             players.SetStartGame();
             if ( conf.ExtGameUseFade() )
                 fheroes2::FadeDisplay();
-            Game::ShowLoadMapsText();
+            Game::ShowMapLoadingText();
             conf.SetGameType( Game::TYPE_CAMPAIGN );
 
             if ( !world.LoadMapMP2( campaignMap[0].file ) ) {

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -311,7 +311,7 @@ int Game::ScenarioInfo( void )
         players.SetStartGame();
         if ( conf.ExtGameUseFade() )
             fheroes2::FadeDisplay();
-        Game::ShowLoadMapsText();
+        Game::ShowMapLoadingText();
         // Load maps
         std::string lower = StringLower( conf.MapsFile() );
 


### PR DESCRIPTION
Fixed small typo on map loading screen.

Perhaps someone has missed adding an apostrophe. Like "map's". But generally, it shouldn't also be shorted.