### PR TITLE
Update hero availability pool after hero purchase

### DIFF
--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -964,6 +964,9 @@ Heroes * Castle::RecruitHero( Heroes * hero )
     if ( kingdom.GetLastLostHero() == hero )
         kingdom.ResetLastLostHero();
 
+    // actually update available heroes to recruit
+    kingdom.GetRecruits();
+
     kingdom.OddFundsResource( PaymentConditions::RecruitHero( hero->GetLevel() ) );
 
     // update spell book


### PR DESCRIPTION
Fix for #454 

Update hero availability pool after hero purchase, otherwise the list will be the same until you open castle menu again