### PR TITLE
Added magic book sprite to popup window #2185

### DIFF
--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1198,13 +1198,11 @@ bool Heroes::BuySpellBook( const Castle * castle, int shrine )
 
     const payment_t payment = PaymentConditions::BuySpellBook( shrine );
     Kingdom & kingdom = GetKingdom();
-
     std::string header = _( "To cast spells, you must first buy a spell book for %{gold} gold." );
     StringReplace( header, "%{gold}", payment.gold );
-    
+
     const fheroes2::Sprite & border = fheroes2::AGG::GetICN( ICN::RESOURCE, 7 );
     fheroes2::Image sprite = border;
-
     fheroes2::Blit( fheroes2::AGG::GetICN( ICN::ARTIFACT, Artifact( Artifact::MAGIC_BOOK ).IndexSprite64() ), sprite, 5, 5 );
 
     if ( !kingdom.AllowPayment( payment ) ) {

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1201,22 +1201,22 @@ bool Heroes::BuySpellBook( const Castle * castle, int shrine )
 
     std::string header = _( "To cast spells, you must first buy a spell book for %{gold} gold." );
     StringReplace( header, "%{gold}", payment.gold );
+    
+    const fheroes2::Sprite & border = fheroes2::AGG::GetICN( ICN::RESOURCE, 7 );
+    fheroes2::Image sprite = border;
+
+    fheroes2::Blit( fheroes2::AGG::GetICN( ICN::ARTIFACT, Artifact( Artifact::MAGIC_BOOK ).IndexSprite64() ), sprite, 5, 5 );
 
     if ( !kingdom.AllowPayment( payment ) ) {
         if ( isControlHuman() ) {
             header.append( " " );
             header.append( _( "Unfortunately, you seem to be a little short of cash at the moment." ) );
-            Dialog::Message( GetName(), header, Font::BIG, Dialog::OK );
+            Dialog::SpriteInfo( GetName(), header, sprite, Dialog::OK );
         }
         return false;
     }
 
     if ( isControlHuman() ) {
-        const fheroes2::Sprite & border = fheroes2::AGG::GetICN( ICN::RESOURCE, 7 );
-        fheroes2::Image sprite = border;
-
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::ARTIFACT, Artifact( Artifact::MAGIC_BOOK ).IndexSprite64() ), sprite, 5, 5 );
-
         header.append( " " );
         header.append( _( "Do you wish to buy one?" ) );
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1198,23 +1198,29 @@ bool Heroes::BuySpellBook( const Castle * castle, int shrine )
 
     const payment_t payment = PaymentConditions::BuySpellBook( shrine );
     Kingdom & kingdom = GetKingdom();
+
     std::string header = _( "To cast spells, you must first buy a spell book for %{gold} gold." );
     StringReplace( header, "%{gold}", payment.gold );
 
-    const fheroes2::Sprite & border = fheroes2::AGG::GetICN( ICN::RESOURCE, 7 );
-    fheroes2::Image sprite = border;
-    fheroes2::Blit( fheroes2::AGG::GetICN( ICN::ARTIFACT, Artifact( Artifact::MAGIC_BOOK ).IndexSprite64() ), sprite, 5, 5 );
-
     if ( !kingdom.AllowPayment( payment ) ) {
         if ( isControlHuman() ) {
+            const fheroes2::Sprite & border = fheroes2::AGG::GetICN( ICN::RESOURCE, 7 );
+            fheroes2::Image sprite = border;
+            fheroes2::Blit( fheroes2::AGG::GetICN( ICN::ARTIFACT, Artifact( Artifact::MAGIC_BOOK ).IndexSprite64() ), sprite, 5, 5 );
+
             header.append( " " );
             header.append( _( "Unfortunately, you seem to be a little short of cash at the moment." ) );
-            Dialog::SpriteInfo( GetName(), header, sprite, Dialog::OK );
+            Dialog::SpriteInfo( "", header, sprite, Dialog::OK );
         }
         return false;
     }
 
     if ( isControlHuman() ) {
+        const fheroes2::Sprite & border = fheroes2::AGG::GetICN( ICN::RESOURCE, 7 );
+        fheroes2::Image sprite = border;
+
+        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::ARTIFACT, Artifact( Artifact::MAGIC_BOOK ).IndexSprite64() ), sprite, 5, 5 );
+
         header.append( " " );
         header.append( _( "Do you wish to buy one?" ) );
 


### PR DESCRIPTION
#2185 

This pull request solves an issue that occurs when the player does not enough gold to buy the magic book. As shown in the before/after below, the graphic of the magic book will now be included on the popup window. 

**Before**

![image](https://user-images.githubusercontent.com/36315666/100533186-7708f880-31cf-11eb-9ed7-971a5afd4893.png)



**After**

![image](https://user-images.githubusercontent.com/36315666/100532980-30b29a00-31cd-11eb-98f5-522b5b85fc0d.png)
