### PR TITLE
Remove all destructors in Monster hierarchy

### DIFF
--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -128,14 +128,6 @@ Battle::Unit::Unit( const Troop & t, s32 pos, bool ref )
     }
 }
 
-Battle::Unit::~Unit()
-{
-    // reset summon elemental and mirror image
-    if ( Modes( CAP_SUMMONELEM ) || Modes( CAP_MIRRORIMAGE ) ) {
-        SetCount( 0 );
-    }
-}
-
 void Battle::Unit::SetPosition( s32 pos )
 {
     if ( position.GetHead() )

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -74,7 +74,6 @@ namespace Battle
     {
     public:
         Unit( const Troop &, s32 pos, bool reflect );
-        ~Unit();
 
         bool isModes( u32 ) const;
         bool isBattle( void ) const;

--- a/src/fheroes2/monster/monster.h
+++ b/src/fheroes2/monster/monster.h
@@ -165,7 +165,6 @@ public:
     Monster( int = UNKNOWN );
     Monster( const Spell & );
     Monster( int race, u32 dw );
-    virtual ~Monster() {}
 
     bool operator<( const Monster & ) const;
     bool operator==( const Monster & ) const;


### PR DESCRIPTION
- Destructor of Unit is useless
- Classes in Monster hierarchy never need an explicit destructor
- It allows to remove the base virtual destructor, which is currently
called at each deallocation of Monster object