### PR TITLE
Correct few sprites of mini-monsters

### DIFF
--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -1226,6 +1226,38 @@ namespace fheroes2
                     ApplyPalette( _icnVsSprite[id][i], 2 );
                 }
                 return true;
+            case ICN::MONS32:
+                LoadOriginalICN( id );
+                if ( _icnVsSprite[id].size() > 2 ) { // Ranger's sprite
+                    const Sprite & source = _icnVsSprite[id][1];
+                    Sprite & modified = _icnVsSprite[id][2];
+                    Sprite temp( source.width(), source.height() + 1 );
+                    temp.reset();
+                    Copy( source, 0, 0, temp, 0, 1, source.width(), source.height() );
+                    Blit( modified, 0, 0, temp, 1, 0, modified.width(), modified.height() );
+                    modified = temp;
+                    modified.setPosition( 0, 1 );
+                }
+                if ( _icnVsSprite[id].size() > 4 ) { // Veteran Pikeman's sprite
+                    Sprite & modified = _icnVsSprite[id][4];
+
+                    Sprite temp = _icnVsSprite[id][3];
+                    Blit( modified, 0, 0, temp, 0, 1, modified.width(), modified.height() );
+                    modified = temp;
+                    if ( modified.width() > 8 ) {
+                        modified.image()[7] = 36;
+                        modified.image()[8] = 36;
+                        modified.transform()[7] = 0;
+                        modified.transform()[8] = 0;
+                    }
+                }
+                if ( _icnVsSprite[id].size() > 44 ) { // Archimage's sprite
+                    Sprite & modified = _icnVsSprite[id][44];
+                    Sprite temp = _icnVsSprite[id][43];
+                    Blit( modified, 0, 0, temp, 1, 0, modified.width(), modified.height() );
+                    modified = temp;
+                }
+                return true;
             default:
                 break;
             }

--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -1241,15 +1241,29 @@ namespace fheroes2
                 if ( _icnVsSprite[id].size() > 4 ) { // Veteran Pikeman's sprite
                     Sprite & modified = _icnVsSprite[id][4];
 
-                    Sprite temp = _icnVsSprite[id][3];
+                    Sprite temp( modified.width(), modified.height() + 1 );
+                    temp.reset();
                     Blit( modified, 0, 0, temp, 0, 1, modified.width(), modified.height() );
                     modified = temp;
-                    if ( modified.width() > 8 ) {
-                        modified.image()[7] = 36;
-                        modified.image()[8] = 36;
-                        modified.transform()[7] = 0;
-                        modified.transform()[8] = 0;
-                    }
+                    Fill( modified, 7, 0, 4, 1, 36 );
+                }
+                if ( _icnVsSprite[id].size() > 6 ) { // Master Swordsman's sprite
+                    Sprite & modified = _icnVsSprite[id][6];
+
+                    Sprite temp( modified.width(), modified.height() + 1 );
+                    temp.reset();
+                    Blit( modified, 0, 0, temp, 0, 1, modified.width(), modified.height() );
+                    modified = temp;
+                    Fill( modified, 2, 0, 5, 1, 36 );
+                }
+                if ( _icnVsSprite[id].size() > 8 ) { // Champion's sprite
+                    Sprite & modified = _icnVsSprite[id][8];
+
+                    Sprite temp( modified.width(), modified.height() + 1 );
+                    temp.reset();
+                    Blit( modified, 0, 0, temp, 0, 1, modified.width(), modified.height() );
+                    modified = temp;
+                    Fill( modified, 12, 0, 5, 1, 36 );
                 }
                 if ( _icnVsSprite[id].size() > 44 ) { // Archimage's sprite
                     Sprite & modified = _icnVsSprite[id][44];

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -769,7 +769,7 @@ void Troops::DrawMons32Line( int32_t cx, int32_t cy, uint32_t width, uint32_t fi
                     const fheroes2::Sprite & monster = fheroes2::AGG::GetICN( ICN::MONS32, spriteIndex );
                     const int offsetY = !compact ? 30 - monster.height() : ( monster.height() < 35 ) ? 35 - monster.height() : 0;
 
-                    fheroes2::Blit( monster, fheroes2::Display::instance(), cx - monster.width() / 2, cy + offsetY );
+                    fheroes2::Blit( monster, fheroes2::Display::instance(), cx - monster.width() / 2 + monster.x(), cy + offsetY + monster.y() );
 
                     const std::string countText
                         = isScouteView ? Game::CountScoute( ( *it )->GetCount(), drawPower, compact ) : Game::CountThievesGuild( ( *it )->GetCount(), drawPower );


### PR DESCRIPTION
relates to #1335

Archimage, Ranger, Veteran Pikeman, Master Swordsman and Champion are corrected

These images before and after correction:
![before_mage](https://user-images.githubusercontent.com/19829520/100545978-b3a12680-3299-11eb-8743-53783fe65078.png) ![after_mage](https://user-images.githubusercontent.com/19829520/100545986-c156ac00-3299-11eb-927d-196548ffd71c.png)
![before_ranger](https://user-images.githubusercontent.com/19829520/100545979-b4d25380-3299-11eb-87ff-dc5aafc4658e.png) ![after_ranger](https://user-images.githubusercontent.com/19829520/100545987-c287d900-3299-11eb-9e33-72c86cd3e93b.png)
![before_veteran_pikeman](https://user-images.githubusercontent.com/19829520/100545981-b56aea00-3299-11eb-99c1-bcb38d5d0f99.png) ![after_veteran_pikeman](https://user-images.githubusercontent.com/19829520/100545989-c3206f80-3299-11eb-9f23-f302b5f0b814.png)
![master_swordsman_before](https://user-images.githubusercontent.com/19829520/100547510-fcf57400-32a1-11eb-884e-95289d2605e3.png) ![master_swordsman_after](https://user-images.githubusercontent.com/19829520/100547513-fff06480-32a1-11eb-86ff-8b1476fada88.png)
![champion_before](https://user-images.githubusercontent.com/19829520/100547514-04b51880-32a2-11eb-88b0-5b1ad2a8cdcb.png) ![champion_after](https://user-images.githubusercontent.com/19829520/100547521-07b00900-32a2-11eb-871f-185f837225b0.png)