### PR TITLE
Directions::All now return a reference

### DIFF
--- a/src/fheroes2/heroes/direction.cpp
+++ b/src/fheroes2/heroes/direction.cpp
@@ -200,8 +200,8 @@ int Direction::Reflect( int direct )
     return UNKNOWN;
 }
 
-Directions Direction::All( void )
+const Directions & Direction::All( void )
 {
-    const int directs[] = {TOP_LEFT, TOP, TOP_RIGHT, RIGHT, BOTTOM_RIGHT, BOTTOM, BOTTOM_LEFT, LEFT};
-    return Directions( directs, directs + 8 );
+    static const Directions allDirections = Directions( {TOP_LEFT, TOP, TOP_RIGHT, RIGHT, BOTTOM_RIGHT, BOTTOM, BOTTOM_LEFT, LEFT} );
+    return allDirections;
 }

--- a/src/fheroes2/heroes/direction.h
+++ b/src/fheroes2/heroes/direction.h
@@ -49,7 +49,7 @@ namespace Direction
     int Reflect( int direct );
 
     bool ShortDistanceClockWise( int direct1, int direct2 );
-    Directions All( void );
+    const Directions & All( void );
 }
 
 #define DIRECTION_TOP_ROW ( Direction::TOP_LEFT | Direction::TOP | Direction::TOP_RIGHT )

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -458,7 +458,7 @@ void Heroes::Redraw( fheroes2::Image & dst, s32 dx, s32 dy, bool withShadow ) co
     }
 
     if ( isShipMaster() ) {
-        const Directions directions = Direction::All();
+        const Directions & directions = Direction::All();
         const int filter = DIRECTION_BOTTOM_ROW | Direction::LEFT | Direction::RIGHT;
 
         bool ocean = true;

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -639,7 +639,7 @@ void Maps::UpdateCastleSprite( const Point & center, int race, bool isCastle, bo
 int Maps::TileIsCoast( s32 center, int filter )
 {
     int result = 0;
-    const Directions directions = Direction::All();
+    const Directions & directions = Direction::All();
 
     for ( Directions::const_iterator it = directions.begin(); it != directions.end(); ++it )
         if ( ( *it & filter ) && isValidDirection( center, *it ) && world.GetTiles( GetDirectionIndex( center, *it ) ).isWater() )

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2383,7 +2383,7 @@ void Maps::Tiles::ClearFog( int colors )
 int Maps::Tiles::GetFogDirections( int color ) const
 {
     int around = 0;
-    const Directions directions = Direction::All();
+    const Directions & directions = Direction::All();
 
     for ( Directions::const_iterator it = directions.begin(); it != directions.end(); ++it )
         if ( !Maps::isValidDirection( GetIndex(), *it ) || world.GetTiles( Maps::GetDirectionIndex( GetIndex(), *it ) ).isFog( color ) )

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -117,7 +117,7 @@ void WorldPathfinder::checkWorldSize()
         _cache.clear();
         _cache.resize( worldSize );
 
-        const Directions directions = Direction::All();
+        const Directions & directions = Direction::All();
         _mapOffset.resize( directions.size() );
         for ( size_t i = 0; i < directions.size(); ++i ) {
             _mapOffset[i] = Maps::GetDirectionIndex( 0, directions[i] );
@@ -169,7 +169,7 @@ void WorldPathfinder::processWorldMap( int pathStart )
 
 void WorldPathfinder::checkAdjacentNodes( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx, bool fromWater )
 {
-    const Directions directions = Direction::All();
+    const Directions & directions = Direction::All();
     const PathfindingNode & currentNode = _cache[currentNodeIdx];
 
     for ( size_t i = 0; i < directions.size(); ++i ) {
@@ -362,7 +362,7 @@ int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero )
     reEvaluateIfNeeded( hero );
     const int start = hero.GetIndex();
 
-    const Directions directions = Direction::All();
+    const Directions & directions = Direction::All();
     std::vector<bool> tilesVisited( world.getSize(), false );
     std::vector<int> nodesToExplore;
 
@@ -402,7 +402,7 @@ std::vector<IndexObject> AIWorldPathfinder::getObjectsOnTheWay( int targetIndex,
         return result;
 
     const Kingdom & kingdom = world.GetKingdom( _currentColor );
-    const Directions directions = Direction::All();
+    const Directions & directions = Direction::All();
 
     std::set<int> uniqueIndicies;
     auto validateAndAdd = [&kingdom, &result, &uniqueIndicies]( int index, int object ) {


### PR DESCRIPTION
This avoids a full allocation/copy each time this method is called.
NB : I do'nt know why this method is needed, it can be refactored
so clients don't need a full vector<direction> to access all directions