### PR TITLE
Adjustments to mouse-based splitting

### DIFF
--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -472,7 +472,7 @@ bool ArmyBar::ActionBarDoubleClick( ArmyTroop & troop )
 
 bool ArmyBar::ActionBarPressRight( ArmyTroop & troop )
 {
-    // empty troops - redistribute troops
+    // try to redistribute troops if we have a selected troop
     if ( isSelected() ) {
         ArmyTroop & selectedTroop = *GetSelectedItem();
 


### PR DESCRIPTION
Solves #1289

Implemented logics:
- Allow splitting to another troop of the same stack via right click and mouse drag (cursor)
- Minor adjustment to mouse drag logic so that the dragging doesn't have to start from an empty troop