### PR TITLE
revert mouse drag logic in mouse split logic adjustment PR

### DIFF
--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -265,8 +265,7 @@ bool ArmyBar::ActionBarCursor( ArmyTroop & troop )
     LocalEvent & le = LocalEvent::Get();
     ArmyTroop * troopPress = GetItem( le.GetMousePressLeft() );
 
-    // drag logic will start working as long as the pressed troop is valid
-    if ( troopPress && troopPress->isValid() ) {
+    if ( !troop.isValid() && troopPress && troopPress->isValid() ) {
         while ( le.HandleEvents() && le.MousePressLeft() ) {
             Cursor::Get().Show();
             fheroes2::Display::instance().render();
@@ -274,10 +273,7 @@ bool ArmyBar::ActionBarCursor( ArmyTroop & troop )
         };
         ArmyTroop * troopRelease = GetItem( le.GetMouseReleaseLeft() );
 
-        if ( !troopRelease || troopPress == troopRelease )
-            return false;
-
-        if ( troopPress->GetMonster() == troopRelease->GetMonster() || !troopRelease->isValid() ) {
+        if ( troopRelease && !troopRelease->isValid() ) {
             RedistributeArmy( *troopPress, *troopRelease );
             if ( isSelected() )
                 ResetSelected();


### PR DESCRIPTION
Solves #2368

What this PR does
- Merge, and not try to split units when clicking a troop with the same as the selected unit
- Do NOT attempt to split the unit when selecting a unit and then clicking on an empty troop slot.
- It's still possible to split a unit by clicking the LMB on a unit and then dragging it to an empty troop slot