### PR TITLE
Hero Screen, updated info bar text at bottom of screen when hovering over magic book.

### DIFF
--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -1078,7 +1078,7 @@ bool ArtifactsBar::ActionBarCursor( Artifact & art )
 
         if ( &art == art2 ) {
             if ( art() == Artifact::MAGIC_BOOK )
-                msg = _( "Open book" );
+                msg = _( "View Spells" );
             else if ( art() == Artifact::SPELL_SCROLL && Settings::Get().ExtHeroAllowTranscribingScroll() && hero->CanTranscribeScroll( art ) )
                 msg = _( "Transcribe scroll" );
             else {


### PR DESCRIPTION
Original Issue - #1686

This change simply changes the info bar text on the hero screen when hovering over the magic book from "Open Book" to "View Spells". 

**Before:**
![pasted image 0](https://user-images.githubusercontent.com/36315666/102002085-1e555780-3cc7-11eb-8f47-f54a032ca1e8.png)

**After:**
![pasted image 0 (1)](https://user-images.githubusercontent.com/36315666/102002092-2c0add00-3cc7-11eb-8bcd-f7d5dcdaa389.png)

 
