### PR TITLE
Fix starting unit values

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1290,17 +1290,31 @@ void Army::Reset( bool soft )
         if ( soft ) {
             const Monster mons2( commander->GetRace(), DWELLING_MONSTER2 );
 
-            int mons1Count = round( mons1.GetGrown() * Rand::Get( 8, 12 ) * 0.1 );
-            int mons2Count = round( mons2.GetGrown() * Rand::Get( 4, 6 ) * 0.1 );
-
-            if ( mons1.GetID() == Monster::PEASANT ) {
-                mons1Count += 30;
+            switch ( mons1.GetID() ) {
+            case Monster::PEASANT:
+                JoinTroop( mons1, Rand::Get( 30, 50 ) );
+                break;
+            case Monster::GOBLIN:
+                JoinTroop( mons1, Rand::Get( 15, 25 ) );
+                break;
+            case Monster::SPRITE:
+                JoinTroop( mons1, Rand::Get( 10, 20 ) );
+                break;
+            default:
+                JoinTroop( mons1, Rand::Get( 6, 10 ) );
+                break;
             }
 
-            JoinTroop( mons1, mons1Count );
-
             if ( Rand::Get( 1, 10 ) != 1 ) {
-                JoinTroop( mons2, mons2Count );
+                switch ( mons2.GetID() ) {
+                case Monster::ARCHER:
+                case Monster::ORC:
+                    JoinTroop( mons2, Rand::Get( 3, 5 ) );
+                    break;
+                default:
+                    JoinTroop( mons2, Rand::Get( 2, 4 ) );
+                    break;
+                }
             }
         }
         else {

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1290,17 +1290,17 @@ void Army::Reset( bool soft )
         if ( soft ) {
             const Monster mons2( commander->GetRace(), DWELLING_MONSTER2 );
 
-            switch ( Rand::Get( 1, 3 ) ) {
-            case 1:
-                JoinTroop( mons1, 3 * mons1.GetGrown() );
-                break;
-            case 2:
-                JoinTroop( mons2, mons2.GetGrown() + mons2.GetGrown() / 2 );
-                break;
-            default:
-                JoinTroop( mons1, 2 * mons1.GetGrown() );
-                JoinTroop( mons2, mons2.GetGrown() );
-                break;
+            int mons1Count = round( mons1.GetGrown() * Rand::Get( 8, 12 ) * 0.1 );
+            int mons2Count = round( mons2.GetGrown() * Rand::Get( 4, 6 ) * 0.1 );
+
+            if ( mons1.GetID() == Monster::PEASANT ) {
+                mons1Count += 30;
+            }
+
+            JoinTroop( mons1, mons1Count );
+
+            if ( Rand::Get( 1, 10 ) != 1 ) {
+                JoinTroop( mons2, mons2Count );
             }
         }
         else {


### PR DESCRIPTION
Fixes #1693
Fixes #1265

I generated a lot of starting heroes in the original game and I think I've determined the starting unit quantity formula.

You get 0.8 to 1.2 times the growth rate for tier one units, and 0.4 to 0.6 times the growth rate for tier two units. 10% of the time you get no tier two units. Peasants are an exception, you get an additional +30 modifier to the starting number of peasants.