### PR TITLE
Adjust troop separation dialog position

### DIFF
--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -330,7 +330,7 @@ int Dialog::ArmySplitTroop( int free_slots, u32 max, u32 & cur, bool savelast )
 
     const int defaultYPosition = 160;
     const int boxHeight = free_slots > 2 ? 90 + spacer : 45;
-    const int boxYPosition = defaultYPosition + ( ( display.height() - display.DEFAULT_HEIGHT ) * 0.5f ) - boxHeight;
+    const int boxYPosition = defaultYPosition + ( ( display.height() - display.DEFAULT_HEIGHT ) / 2 ) - boxHeight;
 
     NonFixedFrameBox box( boxHeight, boxYPosition, true );
     SelectValue sel( min, max, cur, 1 );

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -328,9 +328,7 @@ int Dialog::ArmySplitTroop( int free_slots, u32 max, u32 & cur, bool savelast )
     const u32 min = 1;
     const int spacer = 10;
 
-    const int height = display.height();
     const int defaultYPosition = 160;
-
     const int boxHeight = free_slots > 2 ? 90 + spacer : 45;
     const int boxYPosition = defaultYPosition + ( ( display.height() - display.DEFAULT_HEIGHT ) * 0.5f ) - boxHeight;
 

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -332,7 +332,7 @@ int Dialog::ArmySplitTroop( int free_slots, u32 max, u32 & cur, bool savelast )
     const int defaultYPosition = 160;
 
     const int boxHeight = free_slots > 2 ? 90 + spacer : 45;
-    const int boxYPosition = defaultYPosition + ((display.height() - display.DEFAULT_HEIGHT) * 0.5f) - boxHeight;
+    const int boxYPosition = defaultYPosition + ( ( display.height() - display.DEFAULT_HEIGHT ) * 0.5f ) - boxHeight;
 
     NonFixedFrameBox box( boxHeight, boxYPosition, true );
     SelectValue sel( min, max, cur, 1 );

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -328,7 +328,13 @@ int Dialog::ArmySplitTroop( int free_slots, u32 max, u32 & cur, bool savelast )
     const u32 min = 1;
     const int spacer = 10;
 
-    FrameBox box( free_slots > 2 ? 90 + spacer : 45, true );
+    const int height = display.height();
+    const int defaultYPosition = 160;
+
+    const int boxHeight = free_slots > 2 ? 90 + spacer : 45;
+    const int boxYPosition = defaultYPosition + ((display.height() - display.DEFAULT_HEIGHT) * 0.5f) - boxHeight;
+
+    NonFixedFrameBox box( boxHeight, boxYPosition, true );
     SelectValue sel( min, max, cur, 1 );
     Text text;
 


### PR DESCRIPTION
Solves #278

Tested on 640 x 480, 800 x 600 and 1280 x 720 and all of them seems to be consistent with each other. But note that the dialog position is also moved for other situations which are
- Splitting inside a single hero's screen
- Splitting inside a hero meeting

Example images:

These are the results for the new dialog position in a castle.

![Screenshot 2020-12-15 124729](https://user-images.githubusercontent.com/38433056/102176302-b9bb1800-3ed3-11eb-8dcb-d7847f35f00f.jpg)
![Screenshot 2020-12-15 092427](https://user-images.githubusercontent.com/38433056/102176313-bde73580-3ed3-11eb-9387-f3cfa222194e.jpg)

Inside a hero screen

![Screenshot 2020-12-15 125139](https://user-images.githubusercontent.com/38433056/102176629-64333b00-3ed4-11eb-902e-148fb712a0dc.jpg)

Inside a hero meeting screen

![Screenshot 2020-12-15 125122](https://user-images.githubusercontent.com/38433056/102176635-68f7ef00-3ed4-11eb-8599-25377b670bc9.jpg)

@Branikolog Can you check whether this one is positioned good enough for all cases? Thanks in advance!