### PR TITLE
Fix split logics

### DIFF
--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -427,7 +427,6 @@ bool ArmyBar::ActionBarSingleClick( ArmyTroop & destTroop, ArmyTroop & selectedT
             ResetSelected();
             RedistributeArmy( selectedTroop, destTroop );
         }
-
         return false;
     }
 
@@ -436,7 +435,6 @@ bool ArmyBar::ActionBarSingleClick( ArmyTroop & destTroop, ArmyTroop & selectedT
         // move all but one units into the empty destination slot
         destTroop.Set( selectedTroop, selectedTroop.GetCount() - 1 );
         selectedTroop.SetCount( 1 );
-
         return false;
     }
 

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -440,8 +440,6 @@ bool ArmyBar::ActionBarSingleClick( ArmyTroop & destTroop, ArmyTroop & selectedT
         return false;
     }
 
-    const bool isShiftKeyHeld = Game::HotKeyHoldEvent( Game::EVENT_STACKSPLIT_SHIFT );
-
     // destination troop has units and both troops are the same creature type
     if ( !destTroop.isEmpty() && destTroop.GetID() == selectedTroop.GetID() ) {
         if ( selectedTroop.GetArmy()->SaveLastTroop() ) { // this is their army's only troop

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -511,7 +511,7 @@ bool ArmyBar::ActionBarPressRight( ArmyTroop & troop )
     return true;
 }
 
-bool ArmyBar::ActionBarPressRight( ArmyTroop & destTroop, ArmyTroop & selectedTroop )
+bool ArmyBar::ActionBarPressRight( ArmyTroop & destTroop, ArmyTroop & /*selectedTroop*/ )
 {
     if ( destTroop.isValid() && rightClickedItem == NULL )
         Dialog::ArmyInfo( destTroop, 0 );
@@ -552,13 +552,13 @@ bool ArmyBar::ActionBarSingleRightClick( ArmyTroop & destTroop, ArmyTroop & sele
     return true;
 }
 
-bool ArmyBar::ActionBarRightMouseRelease( ArmyTroop & troop )
+bool ArmyBar::ActionBarRightMouseRelease( ArmyTroop & /*troop*/ )
 {
     rightClickedItem = NULL;
     return true;
 }
 
-bool ArmyBar::ActionBarRightMouseRelease( ArmyTroop & destTroop, ArmyTroop & selectedTroop )
+bool ArmyBar::ActionBarRightMouseRelease( ArmyTroop & /*destTroop*/, ArmyTroop & /*selectedTroop*/ )
 {
     rightClickedItem = NULL;
     return true;

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -472,6 +472,9 @@ bool ArmyBar::ActionBarPressRight( ArmyTroop & troop )
     if ( isSelected() ) {
         ArmyTroop & selectedTroop = *GetSelectedItem();
 
+        if ( troop.GetID() == selectedTroop.GetID() )
+            return false;
+
         if ( !troop.isValid() || selectedTroop.GetMonster() == troop.GetMonster() ) {
             ResetSelected();
             RedistributeArmy( selectedTroop, troop );

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -499,7 +499,7 @@ bool ArmyBar::ActionBarDoubleClick( ArmyTroop & troop )
 
 bool ArmyBar::ActionBarPressRight( ArmyTroop & troop )
 {
-    if ( troop.isValid() && rightClickedItem == nullptr ) {
+    if ( troop.isValid() && rightClickedItem == NULL ) {
         ResetSelected();
 
         if ( can_change && !army->SaveLastTroop() )
@@ -513,7 +513,7 @@ bool ArmyBar::ActionBarPressRight( ArmyTroop & troop )
 
 bool ArmyBar::ActionBarPressRight( ArmyTroop & destTroop, ArmyTroop & selectedTroop )
 {
-    if ( destTroop.isValid() && rightClickedItem == nullptr )
+    if ( destTroop.isValid() && rightClickedItem == NULL )
         Dialog::ArmyInfo( destTroop, 0 );
 
     return true;
@@ -554,13 +554,13 @@ bool ArmyBar::ActionBarSingleRightClick( ArmyTroop & destTroop, ArmyTroop & sele
 
 bool ArmyBar::ActionBarRightMouseRelease( ArmyTroop & troop )
 {
-    rightClickedItem = nullptr;
+    rightClickedItem = NULL;
     return true;
 }
 
 bool ArmyBar::ActionBarRightMouseRelease( ArmyTroop & destTroop, ArmyTroop & selectedTroop )
 {
-    rightClickedItem = nullptr;
+    rightClickedItem = NULL;
     return true;
 }
 

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -223,7 +223,6 @@ void ArmyBar::ResetSelected( void )
 {
     Cursor::Get().Hide();
     spcursor.hide();
-    right_clicked_troop = nullptr;
     Interface::ItemsActionBar<ArmyTroop>::ResetSelected();
 }
 
@@ -455,7 +454,7 @@ bool ArmyBar::ActionBarSingleClick( ArmyTroop & destTroop, ArmyTroop & selectedT
         return false;
     }
 
-     // no risk of emptying selected troop's army, swap the troops
+    // no risk of emptying selected troop's army, swap the troops
     Army::SwapTroops( destTroop, selectedTroop );
 
     return false; // reset cursor
@@ -500,27 +499,22 @@ bool ArmyBar::ActionBarDoubleClick( ArmyTroop & troop )
 
 bool ArmyBar::ActionBarPressRight( ArmyTroop & troop )
 {
-    if ( !troop.isValid() || right_clicked_troop != nullptr )
-        return false;
+    if ( troop.isValid() && rightClickedItem == nullptr ) {
+        ResetSelected();
 
-    ResetSelected();
+        if ( can_change && !army->SaveLastTroop() )
+            troop.Reset();
+        else
+            Dialog::ArmyInfo( troop, 0 );
+    }
 
-    if ( can_change && !army->SaveLastTroop() )
-        troop.Reset();
-    else
-        Dialog::ArmyInfo( troop, 0 );
-
-    return false;
+    return true;
 }
 
-bool ArmyBar::ActionBarPressRight( ArmyTroop & troop1, ArmyTroop & troop2 /* selected */ )
+bool ArmyBar::ActionBarPressRight( ArmyTroop & destTroop, ArmyTroop & selectedTroop )
 {
-    ResetSelected();
-
-    if ( troop1.isValid() )
-        Dialog::ArmyInfo( troop1, 0 );
-    else
-        RedistributeArmy( troop2, troop1 );
+    if ( destTroop.isValid() && rightClickedItem == nullptr )
+        Dialog::ArmyInfo( destTroop, 0 );
 
     return true;
 }
@@ -540,7 +534,19 @@ bool ArmyBar::ActionBarSingleRightClick( ArmyTroop & troop )
         ResetSelected();
         RedistributeArmy( selectedTroop, troop );
 
-        right_clicked_troop = &troop;
+        rightClickedItem = &troop;
+    }
+
+    return true;
+}
+
+bool ArmyBar::ActionBarSingleRightClick( ArmyTroop & destTroop, ArmyTroop & selectedTroop )
+{
+    if ( !destTroop.isValid() || destTroop.GetMonster() == selectedTroop.GetMonster() ) {
+        ResetSelected();
+        RedistributeArmy( selectedTroop, destTroop );
+
+        rightClickedItem = &destTroop;
     }
 
     return true;
@@ -548,7 +554,13 @@ bool ArmyBar::ActionBarSingleRightClick( ArmyTroop & troop )
 
 bool ArmyBar::ActionBarRightMouseRelease( ArmyTroop & troop )
 {
-    right_clicked_troop = nullptr;
+    rightClickedItem = nullptr;
+    return true;
+}
+
+bool ArmyBar::ActionBarRightMouseRelease( ArmyTroop & destTroop, ArmyTroop & selectedTroop )
+{
+    rightClickedItem = nullptr;
     return true;
 }
 

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -457,8 +457,9 @@ bool ArmyBar::ActionBarSingleClick( ArmyTroop & destTroop, ArmyTroop & selectedT
         return false;
     }
 
-    // no risk of emptying selected troop's army, swap the troops or split if shift key is held
+     // no risk of emptying selected troop's army, swap the troops
     Army::SwapTroops( destTroop, selectedTroop );
+
     return false; // reset cursor
 }
 

--- a/src/fheroes2/army/army_bar.h
+++ b/src/fheroes2/army/army_bar.h
@@ -51,8 +51,10 @@ public:
     virtual bool ActionBarDoubleClick( ArmyTroop & ) override;
     virtual bool ActionBarPressRight( ArmyTroop & ) override;
     virtual bool ActionBarPressRight( ArmyTroop &, ArmyTroop & ) override;
-    virtual bool ActionBarSingleRightClick( ArmyTroop & ) override;
-    virtual bool ActionBarRightMouseRelease( ArmyTroop & ) override;
+    virtual bool ActionBarSingleRightClick( ArmyTroop & troop ) override;
+    virtual bool ActionBarSingleRightClick( ArmyTroop & destTroop, ArmyTroop & selectedTroop ) override;
+    virtual bool ActionBarRightMouseRelease( ArmyTroop & troop ) override;
+    virtual bool ActionBarRightMouseRelease( ArmyTroop & destTroop, ArmyTroop & selectedTroop ) override;
 
     virtual bool ActionBarCursor( ArmyTroop & ) override;
     virtual bool ActionBarCursor( ArmyTroop &, ArmyTroop & ) override;
@@ -68,7 +70,6 @@ protected:
     bool read_only;
     bool can_change;
     std::string msg;
-    ArmyTroop * right_clicked_troop;
 };
 
 #endif

--- a/src/fheroes2/army/army_bar.h
+++ b/src/fheroes2/army/army_bar.h
@@ -51,6 +51,8 @@ public:
     virtual bool ActionBarDoubleClick( ArmyTroop & ) override;
     virtual bool ActionBarPressRight( ArmyTroop & ) override;
     virtual bool ActionBarPressRight( ArmyTroop &, ArmyTroop & ) override;
+    virtual bool ActionBarSingleRightClick( ArmyTroop & ) override;
+    virtual bool ActionBarRightMouseRelease( ArmyTroop & ) override;
 
     virtual bool ActionBarCursor( ArmyTroop & ) override;
     virtual bool ActionBarCursor( ArmyTroop &, ArmyTroop & ) override;
@@ -66,6 +68,7 @@ protected:
     bool read_only;
     bool can_change;
     std::string msg;
+    ArmyTroop * right_clicked_troop;
 };
 
 #endif

--- a/src/fheroes2/gui/interface_itemsbar.h
+++ b/src/fheroes2/gui/interface_itemsbar.h
@@ -41,7 +41,6 @@ namespace Interface
         typedef std::pair<ItemsIterator, Rect> ItemIterPos;
 
         Items items;
-        Item * rightClickedItem;
 
     public:
         ItemsBar()
@@ -290,6 +289,7 @@ namespace Interface
 
         ItemsIterator topItem;
         ItemIterPos curItemPos;
+        Item * rightClickedItem;
 
     public:
         ItemsActionBar()

--- a/src/fheroes2/gui/interface_itemsbar.h
+++ b/src/fheroes2/gui/interface_itemsbar.h
@@ -337,22 +337,22 @@ namespace Interface
             return false;
         }
 
-        virtual bool ActionBarSingleRightClick( Item & item )
+        virtual bool ActionBarSingleRightClick( Item & )
         {
             return false;
         }
 
-        virtual bool ActionBarSingleRightClick( Item & item, Item & itemOther )
+        virtual bool ActionBarSingleRightClick( Item &, Item & )
         {
             return false;
         }
 
-        virtual bool ActionBarRightMouseRelease( Item & item )
+        virtual bool ActionBarRightMouseRelease( Item & )
         {
             return true;
         }
 
-        virtual bool ActionBarRightMouseRelease( Item & item, Item & itemOther )
+        virtual bool ActionBarRightMouseRelease( Item &, Item & )
         {
             return true;
         }
@@ -480,11 +480,12 @@ namespace Interface
                     return ActionBarSingleRightClick( **iterPos1.first, **iterPos2.first );
                 }
                 else if ( le.MousePressRight( iterPos1.second ) ) {
-                    if ( rightClickedItem == nullptr && other.rightClickedItem != nullptr )
+                    if ( rightClickedItem == NULL && other.rightClickedItem != NULL )
                         rightClickedItem = other.rightClickedItem;
                     return ActionBarPressRight( **iterPos1.first, **iterPos2.first );
                 }
                 else if ( le.MouseReleaseRight( iterPos1.second ) ) {
+                    other.rightClickedItem = NULL;
                     return ActionBarRightMouseRelease( **iterPos1.first, **iterPos2.first );
                 }
             }

--- a/src/fheroes2/gui/interface_itemsbar.h
+++ b/src/fheroes2/gui/interface_itemsbar.h
@@ -382,6 +382,7 @@ namespace Interface
         {
             topItem = ItemsBar<Item>::GetBeginItemIter();
             curItemPos = ItemIterPos( ItemsBar<Item>::items.end(), Rect() );
+            rightClickedItem = NULL;
         }
 
         bool QueueEventProcessing( void )

--- a/src/fheroes2/gui/interface_itemsbar.h
+++ b/src/fheroes2/gui/interface_itemsbar.h
@@ -41,6 +41,7 @@ namespace Interface
         typedef std::pair<ItemsIterator, Rect> ItemIterPos;
 
         Items items;
+        Item * rightClickedItem;
 
     public:
         ItemsBar()
@@ -336,12 +337,22 @@ namespace Interface
             return false;
         }
 
-        virtual bool ActionBarSingleRightClick( Item & )
+        virtual bool ActionBarSingleRightClick( Item & item )
         {
             return false;
         }
 
-        virtual bool ActionBarRightMouseRelease( Item & )
+        virtual bool ActionBarSingleRightClick( Item & item, Item & itemOther ) 
+        {
+            return false;
+        }
+
+        virtual bool ActionBarRightMouseRelease( Item & item )
+        {
+            return true;
+        }
+
+        virtual bool ActionBarRightMouseRelease( Item & item, Item & itemOther ) 
         {
             return true;
         }
@@ -464,9 +475,17 @@ namespace Interface
                     other.ResetSelected();
                     return true;
                 }
-                else if ( le.MousePressRight( iterPos1.second ) ) {
+                else if ( le.MouseClickRight( iterPos1.second ) ) {
                     other.ResetSelected();
+                    return ActionBarSingleRightClick( **iterPos1.first, **iterPos2.first );
+                }
+                else if ( le.MousePressRight( iterPos1.second ) ) {
+                    if ( rightClickedItem == nullptr && other.rightClickedItem != nullptr )
+                        rightClickedItem = other.rightClickedItem;
                     return ActionBarPressRight( **iterPos1.first, **iterPos2.first );
+                }
+                else if ( le.MouseReleaseRight( iterPos1.second ) ) {
+                    return ActionBarRightMouseRelease( **iterPos1.first, **iterPos2.first );
                 }
             }
 

--- a/src/fheroes2/gui/interface_itemsbar.h
+++ b/src/fheroes2/gui/interface_itemsbar.h
@@ -336,6 +336,16 @@ namespace Interface
             return false;
         }
 
+        virtual bool ActionBarSingleRightClick( Item & )
+        {
+            return false;
+        }
+
+        virtual bool ActionBarRightMouseRelease( Item & )
+        {
+            return false;
+        }
+
         // body
         Item * GetSelectedItem( void )
         {
@@ -420,8 +430,14 @@ namespace Interface
                         return true;
                     }
                 }
+                else if ( le.MouseClickRight( iterPos.second ) ) {
+                    return ActionBarSingleRightClick( **iterPos.first );
+                }
                 else if ( le.MousePressRight( iterPos.second ) ) {
                     return ActionBarPressRight( **iterPos.first );
+                }
+                else if ( le.MouseReleaseRight( iterPos.second ) ) {
+                    return ActionBarRightMouseRelease( **iterPos.first );
                 }
             }
 

--- a/src/fheroes2/gui/interface_itemsbar.h
+++ b/src/fheroes2/gui/interface_itemsbar.h
@@ -343,7 +343,7 @@ namespace Interface
 
         virtual bool ActionBarRightMouseRelease( Item & )
         {
-            return false;
+            return true;
         }
 
         // body

--- a/src/fheroes2/gui/interface_itemsbar.h
+++ b/src/fheroes2/gui/interface_itemsbar.h
@@ -342,7 +342,7 @@ namespace Interface
             return false;
         }
 
-        virtual bool ActionBarSingleRightClick( Item & item, Item & itemOther ) 
+        virtual bool ActionBarSingleRightClick( Item & item, Item & itemOther )
         {
             return false;
         }
@@ -352,7 +352,7 @@ namespace Interface
             return true;
         }
 
-        virtual bool ActionBarRightMouseRelease( Item & item, Item & itemOther ) 
+        virtual bool ActionBarRightMouseRelease( Item & item, Item & itemOther )
         {
             return true;
         }


### PR DESCRIPTION
Solves
- #2389 (partially, just the shift part. We probably should discuss how to do the drag logic separately. Seems things get a bit complicated with two army bars)
- #2390
- #2391

For fixing 2391, I added some base functions in `interface_itemsbar.h`, I encountered some issues with the army bar not redrawing properly when `ActionBarRightMouseRelease()` returns false. But I hope by changing the default return value to true (and its subsequent overriden functions returning true as well) we won't get any side effects.