### PR TITLE
Reduce the amount of memory operations for Image class

### DIFF
--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -389,8 +389,7 @@ namespace fheroes2
     {
         _width = image_.width();
         _height = image_.height();
-        _image = image_._image;
-        _transform = image_._transform;
+        _data = image_._data;
         return *this;
     }
 
@@ -402,28 +401,27 @@ namespace fheroes2
 
     uint8_t * Image::image()
     {
-        return _image.data();
+        return _data.data();
     }
 
     const uint8_t * Image::image() const
     {
-        return _image.data();
+        return _data.data();
     }
 
     uint8_t * Image::transform()
     {
-        return _transform.data();
+        return _data.data() + _width * _height;
     }
 
     const uint8_t * Image::transform() const
     {
-        return _transform.data();
+        return _data.data() + _width * _height;
     }
 
     void Image::clear()
     {
-        _image.clear();
-        _transform.clear();
+        _data.clear();
 
         _width = 0;
         _height = 0;
@@ -449,15 +447,15 @@ namespace fheroes2
         _height = height_;
 
         const size_t totalSize = static_cast<size_t>( _width * _height );
-        _image.resize( totalSize );
-        _transform.resize( totalSize );
+        _data.resize( totalSize * 2 );
     }
 
     void Image::reset()
     {
         if ( !empty() ) {
-            std::fill( _image.begin(), _image.end(), 0 );
-            std::fill( _transform.begin(), _transform.end(), 1 ); // skip all data
+            const size_t totalSize = static_cast<size_t>( _width * _height );
+            std::fill( image(), image() + totalSize, 0 );
+            std::fill( transform(), transform() + totalSize, 1 ); // skip all data
         }
     }
 
@@ -466,8 +464,7 @@ namespace fheroes2
         std::swap( _width, image._width );
         std::swap( _height, image._height );
 
-        std::swap( _image, image._image );
-        std::swap( _transform, image._transform );
+        std::swap( _data, image._data );
     }
 
     Sprite::Sprite( int32_t width_, int32_t height_, int32_t x_, int32_t y_ )

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -62,7 +62,7 @@ namespace fheroes2
 
         bool empty() const
         {
-            return _image.empty();
+            return _data.empty();
         }
 
         void reset(); // makes image fully transparent (transform layer is set to 1)
@@ -75,8 +75,7 @@ namespace fheroes2
     private:
         int32_t _width;
         int32_t _height;
-        std::vector<uint8_t> _image;
-        std::vector<uint8_t> _transform;
+        std::vector<uint8_t> _data; // holds 2 image layers
     };
 
     class Sprite : public Image


### PR DESCRIPTION
We are reducing the amount of memory allocations and deallocations by 2
holding both image layers in 1 array. This also gives a better chance of
data caching which potentially lead to faster execution.