### PR TITLE
Refactor for AllCastles

### DIFF
--- a/src/engine/math_base.h
+++ b/src/engine/math_base.h
@@ -80,6 +80,11 @@ namespace fheroes2
             return PointBase2D( value * x, value * y );
         }
 
+        bool operator<( const PointBase2D & point ) const
+        {
+            return x == point.x ? y < point.y : x < point.x;
+        }
+
         _Type x;
         _Type y;
     };

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -323,7 +323,7 @@ public:
 
 private:
     std::vector<Castle *> _castles;
-    std::vector<int8_t> _castleTiles;
+    std::map<fheroes2::Point, size_t> _castleTiles;
 };
 
 StreamBase & operator<<( StreamBase &, const VecCastles & );

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -301,19 +301,29 @@ public:
 
     void AddCastle( Castle * castle );
 
-    Castle * Get( const Point & ) const;
+    Castle * Get( const Point & position ) const;
 
     void Scoute( int ) const;
 
     // begin/end methods so we can iterate through the elements
-    std::vector<Castle *>::const_iterator begin() const;
-    std::vector<Castle *>::const_iterator end() const;
+    std::vector<Castle *>::const_iterator begin() const
+    {
+        return _castles.begin();
+    }
 
-    size_t Size() const;
+    std::vector<Castle *>::const_iterator end() const
+    {
+        return _castles.end();
+    }
+
+    size_t Size() const
+    {
+        return _castles.size();
+    }
 
 private:
-    std::vector<Castle *> castles;
-    std::vector<int8_t> castleTiles;
+    std::vector<Castle *> _castles;
+    std::vector<int8_t> _castleTiles;
 };
 
 StreamBase & operator<<( StreamBase &, const VecCastles & );

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -284,22 +284,36 @@ namespace CastleDialog
 
 struct VecCastles : public std::vector<Castle *>
 {
-    Castle * Get( const Point & ) const;
     Castle * GetFirstCastle( void ) const;
 
     void ChangeColors( int, int );
     void SortByBuildingValue();
 };
 
-struct AllCastles : public VecCastles
+class AllCastles
 {
+public:
     AllCastles();
     ~AllCastles();
 
     void Init( void );
-    void clear( void );
+    void Clear( void );
+
+    void AddCastle( Castle * castle );
+
+    Castle * Get( const Point & ) const;
 
     void Scoute( int ) const;
+
+    // begin/end methods so we can iterate through the elements
+    std::vector<Castle *>::const_iterator begin() const;
+    std::vector<Castle *>::const_iterator end() const;
+
+    size_t Size() const;
+
+private:
+    std::vector<Castle *> castles;
+    std::vector<int8_t> castleTiles;
 };
 
 StreamBase & operator<<( StreamBase &, const VecCastles & );

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -782,10 +782,11 @@ void Kingdoms::AddCondLossHeroes( const AllHeroes & heroes )
 
 void Kingdoms::AddCastles( const AllCastles & castles )
 {
-    for ( auto & castle : castles )
+    for ( const auto & castle : castles ) {
         // skip gray color
         if ( castle->GetColor() )
             GetKingdom( castle->GetColor() ).AddCastle( castle );
+    }
 }
 
 void Kingdoms::AddTributeEvents( CapturedObjects & captureobj, u32 day, int obj )

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -782,10 +782,10 @@ void Kingdoms::AddCondLossHeroes( const AllHeroes & heroes )
 
 void Kingdoms::AddCastles( const AllCastles & castles )
 {
-    for ( AllCastles::const_iterator it = castles.begin(); it != castles.end(); ++it )
+    for ( auto & castle : castles )
         // skip gray color
-        if ( ( *it )->GetColor() )
-            GetKingdom( ( *it )->GetColor() ).AddCastle( *it );
+        if ( castle->GetColor() )
+            GetKingdom( castle->GetColor() ).AddCastle( castle );
 }
 
 void Kingdoms::AddTributeEvents( CapturedObjects & captureobj, u32 day, int obj )

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -36,7 +36,7 @@ class Castle;
 class Heroes;
 struct AllHeroes;
 struct VecHeroes;
-struct AllCastles;
+class AllCastles;
 struct VecCastles;
 struct CapturedObjects;
 

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -279,7 +279,7 @@ void World::Reset( void )
     vec_rumors.clear();
 
     // castles
-    vec_castles.clear();
+    vec_castles.Clear();
 
     // heroes
     vec_heroes.clear();
@@ -557,9 +557,9 @@ void World::NewWeek( void )
                 ( *it ).QuantityUpdate( false );
 
         // update gray towns
-        for ( AllCastles::iterator it = vec_castles.begin(); it != vec_castles.end(); ++it )
-            if ( ( *it )->GetColor() == Color::NONE )
-                ( *it )->ActionNewWeek();
+        for ( auto & castle : vec_castles )
+            if ( castle->GetColor() == Color::NONE )
+                castle->ActionNewWeek();
     }
 
     // add events
@@ -583,9 +583,9 @@ void World::NewMonth( void )
         MonthOfMonstersAction( Monster( week_current.GetMonster() ) );
 
     // update gray towns
-    for ( AllCastles::iterator it = vec_castles.begin(); it != vec_castles.end(); ++it )
-        if ( ( *it )->GetColor() == Color::NONE )
-            ( *it )->ActionNewMonth();
+    for ( auto & castle : vec_castles )
+        if ( castle->GetColor() == Color::NONE )
+            castle->ActionNewMonth();
 }
 
 void World::MonthOfMonstersAction( const Monster & mons )

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -223,7 +223,7 @@ TiXmlElement & operator>>( TiXmlElement & doc, AllCastles & castles )
     for ( ; xml_town; xml_town = xml_town->NextSiblingElement( "town" ) ) {
         Castle * town = new Castle();
         *xml_town >> *town;
-        castles.push_back( town );
+        castles.AddCastle( town );
     }
 
     return doc;
@@ -1089,37 +1089,37 @@ bool World::LoadMapMP2( const std::string & filename )
         switch ( id ) {
         case 0x00: // tower: knight
         case 0x80: // castle: knight
-            vec_castles.push_back( new Castle( cx, cy, Race::KNGT ) );
+            vec_castles.AddCastle( new Castle( cx, cy, Race::KNGT ) );
             break;
 
         case 0x01: // tower: barbarian
         case 0x81: // castle: barbarian
-            vec_castles.push_back( new Castle( cx, cy, Race::BARB ) );
+            vec_castles.AddCastle( new Castle( cx, cy, Race::BARB ) );
             break;
 
         case 0x02: // tower: sorceress
         case 0x82: // castle: sorceress
-            vec_castles.push_back( new Castle( cx, cy, Race::SORC ) );
+            vec_castles.AddCastle( new Castle( cx, cy, Race::SORC ) );
             break;
 
         case 0x03: // tower: warlock
         case 0x83: // castle: warlock
-            vec_castles.push_back( new Castle( cx, cy, Race::WRLK ) );
+            vec_castles.AddCastle( new Castle( cx, cy, Race::WRLK ) );
             break;
 
         case 0x04: // tower: wizard
         case 0x84: // castle: wizard
-            vec_castles.push_back( new Castle( cx, cy, Race::WZRD ) );
+            vec_castles.AddCastle( new Castle( cx, cy, Race::WZRD ) );
             break;
 
         case 0x05: // tower: necromancer
         case 0x85: // castle: necromancer
-            vec_castles.push_back( new Castle( cx, cy, Race::NECR ) );
+            vec_castles.AddCastle( new Castle( cx, cy, Race::NECR ) );
             break;
 
         case 0x06: // tower: random
         case 0x86: // castle: random
-            vec_castles.push_back( new Castle( cx, cy, Race::NONE ) );
+            vec_castles.AddCastle( new Castle( cx, cy, Race::NONE ) );
             break;
 
         default:


### PR DESCRIPTION
- don't inherit from std::vector
- add an extra container to store position of castle sprites, so
that Get() method is in O(1)

This should fix #2385 , but it's mostly a proposal
This adds more a data structure that contains one byte per tile, but even on biggest map size this should be an extra 10KB