### PR TITLE
Add error handling to SDL_GetPrefPath

### DIFF
--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -100,7 +100,7 @@ std::string System::GetHomeDirectory( const std::string & prog )
     std::string res;
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
-    char * path = SDL_GetPrefPath( "", prog.c_str() );
+    const char * path = SDL_GetPrefPath( "", prog.c_str() );
     if ( path ) {
         res = path;
         SDL_free( path );

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -100,7 +100,7 @@ std::string System::GetHomeDirectory( const std::string & prog )
     std::string res;
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
-    const char * path = SDL_GetPrefPath( "", prog.c_str() );
+    char * path = SDL_GetPrefPath( "", prog.c_str() );
     if ( path ) {
         res = path;
         SDL_free( path );

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -101,8 +101,10 @@ std::string System::GetHomeDirectory( const std::string & prog )
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
     char * path = SDL_GetPrefPath( "", prog.c_str() );
-    res = path;
-    SDL_free( path );
+    if ( path ) {
+        res = path;
+        SDL_free( path );
+    }
 #endif
 
     if ( System::GetEnvironment( "HOME" ) )


### PR DESCRIPTION
I found this while porting the game to Nintendo Switch platform, but decided to submit this separately as it's not specific to Switch. If you prefer, I can add Switch-specific changes to the same PR.