### PR TITLE
Fix logic in mouse button press

### DIFF
--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -477,7 +477,6 @@ LocalEvent & LocalEvent::GetClean()
     le.ResetModes( CLICK_LEFT );
     le.ResetModes( CLICK_RIGHT );
     le.ResetModes( CLICK_MIDDLE );
-    le.ResetModes( CLICK_MIDDLE );
     le.ResetModes( KEY_HOLD );
     return le;
 }
@@ -492,6 +491,9 @@ bool LocalEvent::HandleEvents( bool delay, bool allowExit )
 
     ResetModes( MOUSE_MOTION );
     ResetModes( KEY_PRESSED );
+    ResetModes( CLICK_LEFT );
+    ResetModes( CLICK_MIDDLE );
+    ResetModes( CLICK_RIGHT );
 
     mouse_wm = Point();
 
@@ -725,7 +727,7 @@ void LocalEvent::HandleMouseButtonEvent( const SDL_MouseButtonEvent & button )
         default:
             break;
         }
-    else
+    else // mouse button released
         switch ( button.button ) {
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
 #else
@@ -736,6 +738,7 @@ void LocalEvent::HandleMouseButtonEvent( const SDL_MouseButtonEvent & button )
 #endif
 
         case SDL_BUTTON_LEFT:
+            SetModes( CLICK_LEFT );
             mouse_rl = mouse_cu;
 
             // emulate press right
@@ -745,10 +748,12 @@ void LocalEvent::HandleMouseButtonEvent( const SDL_MouseButtonEvent & button )
             break;
 
         case SDL_BUTTON_MIDDLE:
+            SetModes( CLICK_MIDDLE );
             mouse_rm = mouse_cu;
             break;
 
         case SDL_BUTTON_RIGHT:
+            SetModes( CLICK_RIGHT );
             mouse_rr = mouse_cu;
             break;
 

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -287,9 +287,9 @@ private:
         MOUSE_MOTION = 0x0002,
         MOUSE_PRESSED = 0x0004,
         GLOBAL_FILTER = 0x0008,
-        CLICK_LEFT = 0x0010,
-        CLICK_RIGHT = 0x0020,
-        CLICK_MIDDLE = 0x0040,
+        CLICK_LEFT = 0x0010, // either there is a click on left button or it was just released
+        CLICK_RIGHT = 0x0020, // either there is a click on right button or it was just released
+        CLICK_MIDDLE = 0x0040, // either there is a click on middle button or it was just released
         TAP_MODE = 0x0080,
         MOUSE_OFFSET = 0x0100,
         CLOCK_ON = 0x0200,


### PR DESCRIPTION
- CLICK_LEFT and others are used to detect click events
- for a click event, the code checks that we have both CLICK_LEFT and not
MOUSE_PRESSED (to activate on mouse release)
- However CLICK_LEFT was never reset at each frame, so CLICK_LEFT event
is activated forever until it is consumed
- with this commit we reset CLICK_LEFT flag at each frame, and set it
up correctly in the event logic
1) either when there is a mouse pressed event (already there)
2) on the frame where there is a mouse release event