### PR TITLE
Fix default save file name not appearing

### DIFF
--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -243,8 +243,10 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
             listbox.SetCurrent( std::distance( lists.begin(), it ) );
         }
         else {
-            filename.clear();
-            charInsertPos = 0;
+            if ( !editor ) {
+                filename.clear();
+                charInsertPos = 0;
+            }
             listbox.Unselect();
         }
     }


### PR DESCRIPTION
Fixes a bug that appears upon merging the campaign PR - When saving, the default save file name no longer appears if a save with the same name does not exist.

Thanks @dimag0g for the info