### PR TITLE
After AI loses to either castle or other player, center the view on them

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -184,8 +184,7 @@ namespace AI
         }
 
         if ( centerOn != nullptr ) {
-            Interface::GameArea & gamearea = Interface::Basic::Get().GetGameArea();
-            gamearea.SetCenter( *centerOn );
+            Interface::Basic::Get().GetGameArea().SetCenter( *centerOn );
         }
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -167,7 +167,7 @@ namespace AI
         return Skill::Primary::UNKNOWN;
     }
 
-    void AIBattleLose( Heroes & hero, const Battle::Result & res, bool attacker, int color = Color::NONE )
+    void AIBattleLose( Heroes & hero, const Battle::Result & res, bool attacker, int color = Color::NONE, const Point * centerOn = nullptr )
     {
         u32 reason = attacker ? res.AttackerResult() : res.DefenderResult();
 
@@ -181,6 +181,11 @@ namespace AI
                 Dialog::Message( "", msg, Font::BIG, Dialog::OK );
             }
             hero.IncreaseExperience( exp );
+        }
+
+        if ( centerOn != nullptr ) {
+            Interface::GameArea & gamearea = Interface::Basic::Get().GetGameArea();
+            gamearea.SetCenter( *centerOn );
         }
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
@@ -480,7 +485,7 @@ namespace AI
 
             // loss attacker
             if ( !res.AttackerWins() )
-                AIBattleLose( hero, res, true, other_hero->GetColor() );
+                AIBattleLose( hero, res, true, other_hero->GetColor(), &( other_hero->GetCenter() ) );
 
             // wins attacker
             if ( res.AttackerWins() ) {
@@ -539,7 +544,7 @@ namespace AI
 
                 // loss attacker
                 if ( !res.AttackerWins() )
-                    AIBattleLose( hero, res, true, castle->GetColor() );
+                    AIBattleLose( hero, res, true, castle->GetColor(), &( castle->GetCenter() ) );
 
                 // wins attacker
                 if ( res.AttackerWins() ) {


### PR DESCRIPTION
With this, the window doesn't jump around when it turn for the next player
because it will already be centered on the latest hero

Fix for #2507