### PR TITLE
Correct size for spell point and experience point zone in hero window

### DIFF
--- a/src/fheroes2/heroes/heroes_indicator.cpp
+++ b/src/fheroes2/heroes/heroes_indicator.cpp
@@ -216,7 +216,7 @@ void MoraleIndicator::QueueEventProcessing( MoraleIndicator & indicator )
 ExperienceIndicator::ExperienceIndicator( const Heroes * h )
     : HeroesIndicator( h )
 {
-    area.w = 39;
+    area.w = 35;
     area.h = 36;
 
     descriptions = _( "Current experience %{exp1}.\n Next level %{exp2}." );
@@ -253,7 +253,7 @@ void ExperienceIndicator::QueueEventProcessing( void )
 SpellPointsIndicator::SpellPointsIndicator( const Heroes * h )
     : HeroesIndicator( h )
 {
-    area.w = 39;
+    area.w = 35;
     area.h = 36;
 
     descriptions = _(


### PR DESCRIPTION
Fix for #2489