### PR TITLE
Exclude third-party code from SonarCloud analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -22,3 +22,5 @@ sonar.links.homepage=https://github.com/ihhub/fheroes2
 sonar.links.ci=https://travis-ci.org/ihhub/fheroes2
 sonar.links.scm=https://github.com/ihhub/fheroes2
 sonar.links.issue=https://github.com/ihhub/fheroes2/issues
+
+sonar.exclusions=src/thirdparty/**/*


### PR DESCRIPTION
it is not a part of our project