### PR TITLE
Fix scouting bugs + make crystal ball work

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1428,11 +1428,6 @@ bool Army::ArmyStrongerThanEnemy( const Army & army1, const Army & army2 )
     return army1.isStrongerThan( army2 );
 }
 
-void Army::DrawMons32LineWithScoute( const Troops & troops, s32 cx, s32 cy, u32 width, u32 first, u32 count, u32 scoute )
-{
-    troops.DrawMons32Line( cx, cy, width, first, count, scoute, false, true );
-}
-
 /* draw MONS32 sprite in line, first valid = 0, count = 0 */
 void Army::DrawMons32Line( const Troops & troops, s32 cx, s32 cy, u32 width, u32 first, u32 count )
 {

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -147,7 +147,6 @@ public:
     static bool ArmyStrongerThanEnemy( const Army &, const Army & );
 
     static void DrawMons32Line( const Troops &, s32, s32, u32, u32 = 0, u32 = 0 );
-    static void DrawMons32LineWithScoute( const Troops &, s32, s32, u32, u32, u32, u32 );
     static void DrawMonsterLines( const Troops & troops, int32_t posX, int32_t posY, uint32_t lineWidth, uint32_t drawPower, bool compact = true,
                                   bool isScouteView = true );
 

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -86,7 +86,7 @@ std::string ShowGuardiansInfo( const Maps::Tiles & tile, bool isOwned, bool exte
         str.append( _( "guarded by %{count} of %{monster}" ) );
 
         StringReplace( str, "%{monster}", StringLower( troop.GetMultiName() ) );
-        StringReplace( str, "%{count}", Game::CountScoute( troop.GetCount(), isOwned ? Skill::Level::EXPERT : scoutingLevel ) );
+        StringReplace( str, "%{count}", Game::CountScoute( troop.GetCount(), isOwned ? static_cast<int>( Skill::Level::EXPERT ) : scoutingLevel ) );
     }
 
     return str;
@@ -98,7 +98,7 @@ std::string ShowMonsterInfo( const Maps::Tiles & tile, bool isVisibleFromCrystal
 
     if ( isVisibleFromCrystalBall || ( extendedScoutingOption && scoutingLevel > Skill::Level::NONE ) ) {
         std::string str = "%{count} %{monster}";
-        StringReplace( str, "%{count}", Game::CountScoute( troop.GetCount(), isVisibleFromCrystalBall ? Skill::Level::EXPERT : scoutingLevel ) );
+        StringReplace( str, "%{count}", Game::CountScoute( troop.GetCount(), isVisibleFromCrystalBall ? static_cast<int>( Skill::Level::EXPERT ) : scoutingLevel ) );
         StringReplace( str, "%{monster}", StringLower( troop.GetMultiName() ) );
         return str;
     }
@@ -165,7 +165,7 @@ std::string ShowDwellingInfo( const Maps::Tiles & tile, bool owned, bool extende
         const Troop & troop = tile.QuantityTroop();
         if ( troop.isValid() ) {
             str.append( _( "(available: %{count})" ) );
-            StringReplace( str, "%{count}", Game::CountScoute( troop.GetCount(), owned ? Skill::Level::EXPERT : scoutingLevel ) );
+            StringReplace( str, "%{count}", Game::CountScoute( troop.GetCount(), owned ? static_cast<int>( Skill::Level::EXPERT ) : scoutingLevel ) );
         }
         else
             str.append( "(empty)" );
@@ -373,7 +373,7 @@ uint32_t GetHeroScoutingLevelForTile( const Heroes * hero, uint32_t dst )
         }
     }
     else if ( Settings::Get().ExtWorldScouteExtended() ) {
-        int dist = hero->GetScoute();
+        uint32_t dist = static_cast<uint32_t>( hero->GetScoute() );
         if ( hero->Modes( Heroes::VISIONS ) && dist < hero->GetVisionsDistance() )
             dist = hero->GetVisionsDistance();
 
@@ -439,7 +439,7 @@ void Dialog::QuickInfo( const Maps::Tiles & tile )
     const bool isVisibleFromCrystalBall = kingdom.IsTileVisibleFromCrystalBall( tile.GetIndex() );
 
     // This value is only relevant for the "Extended Scouting" option
-    const uint32_t scoutingLevelForTile = isVisibleFromCrystalBall ? Skill::Level::EXPERT : GetHeroScoutingLevelForTile( from_hero, tile.GetIndex() );
+    const uint32_t scoutingLevelForTile = isVisibleFromCrystalBall ? static_cast<int>( Skill::Level::EXPERT ) : GetHeroScoutingLevelForTile( from_hero, tile.GetIndex() );
 
     const bool showVisitedOption = settings.ExtWorldShowVisitedContent();
     const bool extendedScoutingOption = settings.ExtWorldScouteExtended();
@@ -708,7 +708,7 @@ void Dialog::QuickInfo( const Castle & castle, const fheroes2::Point & position 
     const bool isVisibleCrystalBall = kingdom.IsTileVisibleFromCrystalBall( castle.GetIndex() );
     const bool isFriend = castle.isFriends( currentColor );
 
-    uint32_t scoutSkillLevel = thievesGuildCount > Skill::Level::EXPERT ? Skill::Level::EXPERT : thievesGuildCount;
+    uint32_t scoutSkillLevel = thievesGuildCount > Skill::Level::EXPERT ? static_cast<int>( Skill::Level::EXPERT ) : thievesGuildCount;
     if ( isFriend || isVisibleCrystalBall ) {
         scoutSkillLevel = Skill::Level::EXPERT;
     }

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -20,6 +20,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <cassert>
+
 #include "agg.h"
 #include "army.h"
 #include "castle.h"
@@ -57,7 +59,7 @@ std::string GetMinesIncomeString( int type )
     return res;
 }
 
-std::string ShowGuardiansInfo( const Maps::Tiles & tile, int scoute )
+std::string ShowGuardiansInfo( const Maps::Tiles & tile, bool isOwned, bool extendedScoutingOption, uint32_t scoutingLevel )
 {
     std::string str;
     const Troop & troop = tile.QuantityTroop();
@@ -79,24 +81,24 @@ std::string ShowGuardiansInfo( const Maps::Tiles & tile, int scoute )
         str = MP2::StringObject( tile.GetObject() );
     }
 
-    if ( troop.isValid() ) {
+    if ( troop.isValid() && ( isOwned || ( extendedScoutingOption && scoutingLevel > Skill::Level::NONE ) ) ) {
         str.append( "\n" );
         str.append( _( "guarded by %{count} of %{monster}" ) );
 
         StringReplace( str, "%{monster}", StringLower( troop.GetMultiName() ) );
-        StringReplace( str, "%{count}", Game::CountScoute( troop.GetCount(), scoute ) );
+        StringReplace( str, "%{count}", Game::CountScoute( troop.GetCount(), isOwned ? Skill::Level::EXPERT : scoutingLevel ) );
     }
 
     return str;
 }
 
-std::string ShowMonsterInfo( const Maps::Tiles & tile, int scoute )
+std::string ShowMonsterInfo( const Maps::Tiles & tile, bool isVisibleFromCrystalBall, bool extendedScoutingOption, uint32_t scoutingLevel )
 {
     const Troop & troop = tile.QuantityTroop();
 
-    if ( scoute ) {
+    if ( isVisibleFromCrystalBall || ( extendedScoutingOption && scoutingLevel > Skill::Level::NONE ) ) {
         std::string str = "%{count} %{monster}";
-        StringReplace( str, "%{count}", Game::CountScoute( troop.GetCount(), scoute ) );
+        StringReplace( str, "%{count}", Game::CountScoute( troop.GetCount(), isVisibleFromCrystalBall ? Skill::Level::EXPERT : scoutingLevel ) );
         StringReplace( str, "%{monster}", StringLower( troop.GetMultiName() ) );
         return str;
     }
@@ -105,11 +107,11 @@ std::string ShowMonsterInfo( const Maps::Tiles & tile, int scoute )
     }
 }
 
-std::string ShowArtifactInfo( const Maps::Tiles & tile, bool show )
+std::string ShowArtifactInfo( const Maps::Tiles & tile, bool extendedScoutingOption, uint32_t scoutingLevel )
 {
     std::string str = MP2::StringObject( tile.GetObject() );
 
-    if ( show ) {
+    if ( extendedScoutingOption && scoutingLevel > Skill::Level::NONE ) {
         str.append( "\n(" );
         str.append( tile.QuantityArtifact().GetName() );
         str.append( ")" );
@@ -118,35 +120,35 @@ std::string ShowArtifactInfo( const Maps::Tiles & tile, bool show )
     return str;
 }
 
-std::string ShowResourceInfo( const Maps::Tiles & tile, int scoute )
+std::string ShowResourceInfo( const Maps::Tiles & tile, bool extendedScoutingOption, uint32_t scoutingLevel )
 {
     std::string str;
 
     if ( MP2::OBJ_RESOURCE == tile.GetObject() ) {
         str = Resource::String( tile.GetQuantity1() );
-        if ( scoute ) {
+        if ( extendedScoutingOption && scoutingLevel > Skill::Level::NONE ) {
             const ResourceCount & rc = tile.QuantityResourceCount();
             str.append( ": " );
-            str.append( Game::CountScoute( rc.second, scoute ) );
+            str.append( Game::CountScoute( rc.second, scoutingLevel ) );
         }
     }
-    else {
+    else { // Campfire
         str = MP2::StringObject( tile.GetObject() );
-        if ( scoute ) {
+        if ( extendedScoutingOption && scoutingLevel > Skill::Level::NONE ) {
             const Funds & funds = tile.QuantityFunds();
 
             str.append( "\n(" );
             str.append( Resource::String( Resource::GOLD ) );
 
             str.append( ": " );
-            str.append( Game::CountScoute( funds.gold, scoute ) );
+            str.append( Game::CountScoute( funds.gold, scoutingLevel ) );
             str.append( "\n" );
 
             const ResourceCount & rc = tile.QuantityResourceCount();
             str.append( Resource::String( rc.first ) );
 
             str.append( ": " );
-            str.append( Game::CountScoute( rc.second, scoute ) );
+            str.append( Game::CountScoute( rc.second, scoutingLevel ) );
             str.append( ")" );
         }
     }
@@ -154,16 +156,16 @@ std::string ShowResourceInfo( const Maps::Tiles & tile, int scoute )
     return str;
 }
 
-std::string ShowDwellingInfo( const Maps::Tiles & tile, int scoute )
+std::string ShowDwellingInfo( const Maps::Tiles & tile, bool owned, bool extendedScoutingOption, uint32_t scoutingLevel )
 {
     std::string str = MP2::StringObject( tile.GetObject() );
 
-    if ( scoute ) {
+    if ( owned || ( extendedScoutingOption && scoutingLevel > Skill::Level::NONE ) ) {
         str.append( "\n" );
         const Troop & troop = tile.QuantityTroop();
         if ( troop.isValid() ) {
             str.append( _( "(available: %{count})" ) );
-            StringReplace( str, "%{count}", Game::CountScoute( troop.GetCount(), scoute ) );
+            StringReplace( str, "%{count}", Game::CountScoute( troop.GetCount(), owned ? Skill::Level::EXPERT : scoutingLevel ) );
         }
         else
             str.append( "(empty)" );
@@ -172,26 +174,32 @@ std::string ShowDwellingInfo( const Maps::Tiles & tile, int scoute )
     return str;
 }
 
-std::string ShowShrineInfo( const Maps::Tiles & tile, const Heroes * hero, int scoute )
+std::string ShowShrineInfo( const Maps::Tiles & tile, const Heroes * hero, bool showVisitedOption, bool isVisited, bool extendedScoutingOption, uint32_t scoutingLevel )
 {
     std::string str = MP2::StringObject( tile.GetObject() );
-    bool show = false;
 
-    switch ( tile.GetObject() ) {
-    case MP2::OBJ_SHRINE1:
-        show = scoute >= Skill::Level::BASIC;
-        break;
-    case MP2::OBJ_SHRINE2:
-        show = scoute >= Skill::Level::ADVANCED;
-        break;
-    case MP2::OBJ_SHRINE3:
-        show = scoute == Skill::Level::EXPERT;
-        break;
-    default:
-        break;
+    bool showSpellDetails = false;
+
+    if ( showVisitedOption && isVisited ) {
+        showSpellDetails = true;
+    }
+    else if ( extendedScoutingOption ) {
+        switch ( tile.GetObject() ) {
+        case MP2::OBJ_SHRINE1:
+            showSpellDetails = scoutingLevel >= Skill::Level::BASIC;
+            break;
+        case MP2::OBJ_SHRINE2:
+            showSpellDetails = scoutingLevel >= Skill::Level::ADVANCED;
+            break;
+        case MP2::OBJ_SHRINE3:
+            showSpellDetails = scoutingLevel == Skill::Level::EXPERT;
+            break;
+        default:
+            break;
+        }
     }
 
-    if ( show ) {
+    if ( showSpellDetails ) {
         const Spell & spell = tile.QuantitySpell();
         str.append( "\n(" );
         str.append( spell.GetName() );
@@ -206,9 +214,11 @@ std::string ShowShrineInfo( const Maps::Tiles & tile, const Heroes * hero, int s
     return str;
 }
 
-std::string ShowWitchHutInfo( const Maps::Tiles & tile, const Heroes * hero, bool show )
+std::string ShowWitchHutInfo( const Maps::Tiles & tile, const Heroes * hero, bool showVisitedOption, bool isVisited, bool extendedScoutingOption, uint32_t scoutingLevel )
 {
     std::string str = MP2::StringObject( tile.GetObject() );
+
+    const bool show = ( showVisitedOption && isVisited ) || ( extendedScoutingOption && scoutingLevel == Skill::Level::EXPERT );
 
     if ( show ) {
         const Skill::Secondary & skill = tile.QuantitySkill();
@@ -264,10 +274,10 @@ std::string ShowGlobalVisitInfo( const Maps::Tiles & tile, const Kingdom & kingd
     return str;
 }
 
-std::string ShowGlobalVisitInfo( const Maps::Tiles & tile, const Kingdom & kingdom, bool ext )
+std::string ShowGlobalVisitInfo( const Maps::Tiles & tile, const Kingdom & kingdom, bool showVisitedOption )
 {
     std::string str = MP2::StringObject( tile.GetObject() );
-    if ( ext && kingdom.isVisited( tile ) ) {
+    if ( showVisitedOption && kingdom.isVisited( tile ) ) {
         str.append( "\n" );
         str.append( _( "(already visited)" ) );
     }
@@ -289,11 +299,11 @@ std::string ShowBarrierTentInfo( const Maps::Tiles & tile, const Kingdom & kingd
     return str;
 }
 
-std::string ShowGroundInfo( const Maps::Tiles & tile, bool show, const Heroes * hero )
+std::string ShowGroundInfo( const Maps::Tiles & tile, bool showVisitedOption, const Heroes * hero )
 {
     std::string str = tile.isRoad() ? _( "Road" ) : Maps::Ground::String( tile.GetGround() );
 
-    if ( show && hero ) {
+    if ( showVisitedOption && hero ) {
         int dir = Maps::GetDirection( hero->GetIndex(), tile.GetIndex() );
         if ( dir != Direction::UNKNOWN ) {
             uint32_t cost = tile.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( tile, hero->GetLevelSkill( Skill::Secondary::PATHFINDING ) );
@@ -336,6 +346,43 @@ fheroes2::Rect MakeRectQuickInfo( LocalEvent & le, const fheroes2::Sprite & imag
     else { // bottom right
         return fheroes2::Rect( mx - imageBox.width(), my - imageBox.height(), imageBox.width(), imageBox.height() );
     }
+}
+
+uint32_t GetHeroScoutingLevelForTile( const Heroes * hero, uint32_t dst )
+{
+    if ( hero == nullptr ) {
+        return Skill::Level::NONE;
+    }
+
+    const uint32_t scoutingLevel = hero->GetSecondaryValues( Skill::Secondary::SCOUTING );
+    const int tileObject = world.GetTiles( dst ).GetObject();
+
+    // logic for these is handled in other QuickInfo dialogs
+    assert( tileObject != MP2::OBJ_CASTLE );
+    assert( tileObject != MP2::OBJ_HEROES );
+
+    const bool monsterInfo = tileObject == MP2::OBJ_MONSTER;
+
+    // TODO check that this logic is what is really intended, it's only used for extended scouting anyway
+    if ( monsterInfo ) {
+        if ( Maps::GetApproximateDistance( hero->GetIndex(), dst ) <= hero->GetVisionsDistance() ) {
+            return scoutingLevel;
+        }
+        else {
+            return Skill::Level::NONE;
+        }
+    }
+    else if ( Settings::Get().ExtWorldScouteExtended() ) {
+        int dist = hero->GetScoute();
+        if ( hero->Modes( Heroes::VISIONS ) && dist < hero->GetVisionsDistance() )
+            dist = hero->GetVisionsDistance();
+
+        if ( Maps::GetApproximateDistance( hero->GetIndex(), dst ) <= dist )
+            return scoutingLevel;
+        return Skill::Level::NONE;
+    }
+
+    return Skill::Level::NONE;
 }
 
 void Dialog::QuickInfo( const Maps::Tiles & tile )
@@ -388,25 +435,31 @@ void Dialog::QuickInfo( const Maps::Tiles & tile )
 
     const Heroes * from_hero = Interface::GetFocusHeroes();
     const Kingdom & kingdom = world.GetKingdom( settings.CurrentColor() );
-    const int scoute = from_hero ? from_hero->CanScouteTile( tile.GetIndex() ) : 0;
-    const bool show = settings.ExtWorldShowVisitedContent();
+
+    const bool isVisibleFromCrystalBall = kingdom.IsTileVisibleFromCrystalBall( tile.GetIndex() );
+
+    // This value is only relevant for the "Extended Scouting" option
+    const uint32_t scoutingLevelForTile = isVisibleFromCrystalBall ? Skill::Level::EXPERT : GetHeroScoutingLevelForTile( from_hero, tile.GetIndex() );
+
+    const bool showVisitedOption = settings.ExtWorldShowVisitedContent();
+    const bool extendedScoutingOption = settings.ExtWorldScouteExtended();
 
     if ( tile.isFog( settings.CurrentColor() ) )
         name_object = _( "Unchartered Territory" );
     else
         // check guardians mine
         if ( MP2::OBJ_ABANDONEDMINE == objectType || tile.CaptureObjectIsProtection() ) {
-        name_object = ShowGuardiansInfo( tile, ( settings.CurrentColor() == tile.QuantityColor() ? Skill::Level::EXPERT : scoute ) );
+        name_object = ShowGuardiansInfo( tile, settings.CurrentColor() == tile.QuantityColor(), extendedScoutingOption, scoutingLevelForTile );
     }
     else
         switch ( objectType ) {
         case MP2::OBJ_MONSTER:
-            name_object = ShowMonsterInfo( tile, scoute );
+            name_object = ShowMonsterInfo( tile, isVisibleFromCrystalBall, extendedScoutingOption, scoutingLevelForTile );
             break;
 
         case MP2::OBJ_EVENT:
         case MP2::OBJ_ZERO:
-            name_object = ShowGroundInfo( tile, show, from_hero );
+            name_object = ShowGroundInfo( tile, showVisitedOption, from_hero );
             break;
 
         case MP2::OBJ_DERELICTSHIP:
@@ -417,25 +470,25 @@ void Dialog::QuickInfo( const Maps::Tiles & tile )
         case MP2::OBJ_WAGON:
         case MP2::OBJ_SKELETON:
         case MP2::OBJ_LEANTO:
-            name_object = ShowGlobalVisitInfo( tile, kingdom, show );
+            name_object = ShowGlobalVisitInfo( tile, kingdom, showVisitedOption );
             break;
 
         case MP2::OBJ_WINDMILL:
         case MP2::OBJ_WATERWHEEL:
         case MP2::OBJ_MAGICGARDEN:
-            name_object = Settings::Get().ExtWorldExtObjectsCaptured() ? MP2::StringObject( objectType ) : ShowGlobalVisitInfo( tile, kingdom, show );
+            name_object = Settings::Get().ExtWorldExtObjectsCaptured() ? MP2::StringObject( objectType ) : ShowGlobalVisitInfo( tile, kingdom, showVisitedOption );
             break;
 
         case MP2::OBJ_CAMPFIRE:
-            name_object = ShowResourceInfo( tile, scoute );
+            name_object = ShowResourceInfo( tile, extendedScoutingOption, scoutingLevelForTile );
             break;
 
         case MP2::OBJ_RESOURCE:
-            name_object = ShowResourceInfo( tile, scoute );
+            name_object = ShowResourceInfo( tile, extendedScoutingOption, scoutingLevelForTile );
             break;
 
         case MP2::OBJ_ARTIFACT:
-            name_object = ShowArtifactInfo( tile, scoute != 0 );
+            name_object = ShowArtifactInfo( tile, extendedScoutingOption, scoutingLevelForTile );
             break;
 
         case MP2::OBJ_MINES:
@@ -471,7 +524,7 @@ void Dialog::QuickInfo( const Maps::Tiles & tile )
         case MP2::OBJ_DRAGONCITY:
         case MP2::OBJ_CITYDEAD:
         case MP2::OBJ_TROLLBRIDGE:
-            name_object = ShowDwellingInfo( tile, ( kingdom.isVisited( tile ) ? Skill::Level::EXPERT : scoute ) );
+            name_object = ShowDwellingInfo( tile, kingdom.isVisited( tile ), extendedScoutingOption, scoutingLevelForTile );
             break;
 
         case MP2::OBJ_GAZEBO:
@@ -506,11 +559,11 @@ void Dialog::QuickInfo( const Maps::Tiles & tile )
         case MP2::OBJ_SHRINE1:
         case MP2::OBJ_SHRINE2:
         case MP2::OBJ_SHRINE3:
-            name_object = ShowShrineInfo( tile, from_hero, ( show && kingdom.isVisited( tile ) ? Skill::Level::EXPERT : scoute ) );
+            name_object = ShowShrineInfo( tile, from_hero, showVisitedOption, kingdom.isVisited( tile ), extendedScoutingOption, scoutingLevelForTile );
             break;
 
         case MP2::OBJ_WITCHSHUT:
-            name_object = ShowWitchHutInfo( tile, from_hero, ( ( show && kingdom.isVisited( tile ) ) || scoute == Skill::Level::EXPERT ) );
+            name_object = ShowWitchHutInfo( tile, from_hero, showVisitedOption, kingdom.isVisited( tile ), extendedScoutingOption, scoutingLevelForTile );
             break;
 
         case MP2::OBJ_OBELISK:
@@ -649,12 +702,21 @@ void Dialog::QuickInfo( const Castle & castle, const fheroes2::Point & position 
     const Heroes * guardian = castle.GetHeroes().Guard();
 
     const int currentColor = conf.CurrentColor();
-    const int thievesGuildCount = world.GetKingdom( currentColor ).GetCountThievesGuild();
+    const Kingdom & kingdom = world.GetKingdom( currentColor );
+
+    const uint32_t thievesGuildCount = kingdom.GetCountThievesGuild();
+    const bool isVisibleCrystalBall = kingdom.IsTileVisibleFromCrystalBall( castle.GetIndex() );
+    const bool isFriend = castle.isFriends( currentColor );
+
+    uint32_t scoutSkillLevel = thievesGuildCount > Skill::Level::EXPERT ? Skill::Level::EXPERT : thievesGuildCount;
+    if ( isFriend || isVisibleCrystalBall ) {
+        scoutSkillLevel = Skill::Level::EXPERT;
+    }
 
     // draw guardian portrait
     if ( guardian &&
          // my  colors
-         ( castle.GetColor() == currentColor ||
+         ( castle.GetColor() == currentColor || isVisibleCrystalBall ||
            // show guardians (scouting: advanced)
            ( from_hero && Skill::Level::ADVANCED <= from_hero->GetSecondaryValues( Skill::Secondary::SCOUTING ) ) ) ) {
         // heroes name
@@ -673,26 +735,20 @@ void Dialog::QuickInfo( const Castle & castle, const fheroes2::Point & position 
     }
 
     // draw defenders
-    if ( !count ) {
+    if ( count == 0 ) {
         text.Set( _( "None" ) );
         dst_pt.x = cur_rt.x + ( cur_rt.width - text.w() ) / 2;
         dst_pt.y += 45;
         text.Blit( dst_pt.x, dst_pt.y );
     }
-    else if ( castle.isFriends( currentColor ) ) {
-        // show all
-        Army::DrawMonsterLines( castle.GetArmy(), cur_rt.x - 5, cur_rt.y + 62, 192, Skill::Level::EXPERT, true, true );
+    else if ( scoutSkillLevel > Skill::Level::NONE ) {
+        Army::DrawMonsterLines( castle.GetArmy(), cur_rt.x - 5, cur_rt.y + 62, 192, scoutSkillLevel, true, true );
     }
-    // draw enemy castle defenders, dependent on thieves guild count
-    else if ( thievesGuildCount == 0 ) {
+    else {
         text.Set( _( "Unknown" ) );
         dst_pt.x = cur_rt.x + ( cur_rt.width - text.w() ) / 2;
         dst_pt.y += 45;
         text.Blit( dst_pt.x, dst_pt.y );
-    }
-    else {
-        // show limited
-        Army::DrawMonsterLines( castle.GetArmy(), cur_rt.x - 5, cur_rt.y + 62, 192, thievesGuildCount, false, false );
     }
 
     display.render();
@@ -730,9 +786,10 @@ void Dialog::QuickInfo( const Heroes & hero, const fheroes2::Point & position /*
     Text text;
     std::string message;
 
+    const Kingdom & kingdom = world.GetKingdom( conf.CurrentColor() );
     const bool isFriend = hero.isFriends( conf.CurrentColor() );
-    const bool isUnderIdentifyHeroSpell = world.GetKingdom( conf.CurrentColor() ).Modes( Kingdom::IDENTIFYHERO );
-    const bool showFullInfo = isFriend || isUnderIdentifyHeroSpell;
+    const bool isUnderIdentifyHeroSpell = kingdom.Modes( Kingdom::IDENTIFYHERO );
+    const bool showFullInfo = isFriend || isUnderIdentifyHeroSpell || kingdom.IsTileVisibleFromCrystalBall( hero.GetIndex() );
 
     // heroes name
     if ( showFullInfo ) {

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1378,13 +1378,10 @@ uint32_t Heroes::UpdateMovementPoints( const uint32_t movePoints, const int skil
 
 u32 Heroes::GetVisionsDistance( void ) const
 {
-    int dist = Spell( Spell::VISIONS ).ExtraValue();
-    int acount = HasArtifact( Artifact::CRYSTAL_BALL );
-
-    if ( acount )
-        dist = acount * ( Settings::Get().UseAltResource() ? dist * 2 + 2 : 8 );
-
-    return dist;
+    uint32_t crystalBallCount = HasArtifact( Artifact::CRYSTAL_BALL );
+    if ( crystalBallCount < 1 )
+        crystalBallCount = 1;
+    return 8 * crystalBallCount;
 }
 
 int Heroes::GetDirection( void ) const
@@ -1682,50 +1679,6 @@ const Point & Heroes::GetCenterPatrol( void ) const
 int Heroes::GetSquarePatrol( void ) const
 {
     return patrol_square;
-}
-
-int Heroes::CanScouteTile( s32 dst ) const
-{
-    int scouting = GetSecondaryValues( Skill::Secondary::SCOUTING );
-    bool army_info = false;
-
-    switch ( world.GetTiles( dst ).GetObject() ) {
-    case MP2::OBJ_MONSTER:
-    case MP2::OBJ_CASTLE:
-    case MP2::OBJ_HEROES:
-        army_info = true;
-        break;
-
-    default:
-        break;
-    }
-
-    if ( army_info ) {
-        // depends from distance
-        if ( Maps::GetApproximateDistance( GetIndex(), dst ) <= GetVisionsDistance() ) {
-            // check crystal ball
-            return HasArtifact( Artifact::CRYSTAL_BALL ) ? Skill::Level::EXPERT : scouting;
-        }
-        else {
-            // check spell identify hero
-            if ( GetKingdom().Modes( Kingdom::IDENTIFYHERO ) && MP2::OBJ_HEROES == world.GetTiles( dst ).GetObject() )
-                return Skill::Level::EXPERT;
-        }
-    }
-    else {
-        if ( Settings::Get().ExtWorldScouteExtended() ) {
-            // const Maps::Tiles & tile = world.GetTiles(dst);
-
-            u32 dist = GetSecondaryValues( Skill::Secondary::SCOUTING ) ? GetScoute() : 0;
-            if ( Modes( VISIONS ) && dist < GetVisionsDistance() )
-                dist = GetVisionsDistance();
-
-            if ( dist > Maps::GetApproximateDistance( GetIndex(), dst ) )
-                return scouting;
-        }
-    }
-
-    return 0;
 }
 
 void Heroes::MovePointsScaleFixed( void )

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -291,7 +291,6 @@ public:
     void FadeIn( const Point & offset = Point() ) const;
     void Scoute( void ) const;
     int GetScoute( void ) const;
-    int CanScouteTile( s32 ) const;
     u32 GetVisionsDistance( void ) const;
 
     bool isShipMaster( void ) const;

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -818,7 +818,7 @@ bool Kingdom::IsTileVisibleFromCrystalBall( const int32_t dest ) const
 {
     for ( const Heroes * hero : heroes ) {
         if ( hero->HasArtifact( Artifact::CRYSTAL_BALL ) ) {
-            const int crystalBallDistance = hero->GetVisionsDistance();
+            const uint32_t crystalBallDistance = hero->GetVisionsDistance();
             if ( Maps::GetApproximateDistance( hero->GetIndex(), dest ) <= crystalBallDistance ) {
                 return true;
             }

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -813,6 +813,20 @@ void Kingdoms::AddTributeEvents( CapturedObjects & captureobj, u32 day, int obj 
         }
 }
 
+// Check if tile is visible from any crystal ball of any hero
+bool Kingdom::IsTileVisibleFromCrystalBall( const int32_t dest ) const
+{
+    for ( const Heroes * hero : heroes ) {
+        if ( hero->HasArtifact( Artifact::CRYSTAL_BALL ) ) {
+            const int crystalBallDistance = hero->GetVisionsDistance();
+            if ( Maps::GetApproximateDistance( hero->GetIndex(), dest ) <= crystalBallDistance ) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 StreamBase & operator<<( StreamBase & msg, const Kingdom & kingdom )
 {
     return msg << kingdom.modes << kingdom.color << kingdom.resource << kingdom.lost_town_days << kingdom.castles << kingdom.heroes << kingdom.recruits

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -169,6 +169,8 @@ public:
     void UpdateRecruits( void );
     void LossPostActions( void );
 
+    bool IsTileVisibleFromCrystalBall( const int32_t dest ) const;
+
     static u32 GetMaxHeroes( void );
 
 private:


### PR DESCRIPTION
Here's a refactor of quick dialog info: now we have separated variables for scouting level for a given tile, and option settings etc. Previously all was merged into a "scoute" int which caused lots of complicated code

This fixes the following:
- bug where hero with scouting can see army size number even with "extended scouting" option off
- same bug with guarded mines
- #1460
- #1459