### PR TITLE
[Bugfix][2435] Start picking boats from the end

### DIFF
--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -355,6 +355,28 @@ bool ActionSpellIdentifyHero( const Heroes & hero )
     return true;
 }
 
+bool SummonAnyBoat( s32 center, u32 chance, s32 destinationOnWater )
+{
+    const MapsIndexes & boats = Maps::GetObjectPositions( center, MP2::OBJ_BOAT, false );
+    for ( size_t i = boats.size() - 1; i >= 0; --i ) {
+        const s32 boat = boats[i];
+        if ( Maps::isValidAbsIndex( boat ) ) {
+            if ( chance >= Rand::Get( 1, 100 ) ) {
+                Maps::Tiles & boatFile = world.GetTiles( boat );
+                boatFile.RemoveObjectSprite();
+                boatFile.SetObject( MP2::OBJ_ZERO );
+                Game::ObjectFadeAnimation::Info info = Game::ObjectFadeAnimation::Info( MP2::OBJ_BOAT, /* TODO magic number */ 18, destinationOnWater, 0, false );
+                Game::ObjectFadeAnimation::Set( info );
+                return true;
+            }
+            break;
+        }
+    }
+
+    DialogSpellFailed( Spell::SUMMONBOAT );
+    return true;
+}
+
 bool ActionSpellSummonBoat( const Heroes & hero )
 {
     if ( hero.isShipMaster() ) {
@@ -407,23 +429,7 @@ bool ActionSpellSummonBoat( const Heroes & hero )
         break;
     }
 
-    const MapsIndexes & boats = Maps::GetObjectPositions( center, MP2::OBJ_BOAT, false );
-    for ( size_t i = 0; i < boats.size(); ++i ) {
-        const s32 boat = boats[i];
-        if ( Maps::isValidAbsIndex( boat ) ) {
-            if ( Rand::Get( 1, 100 ) <= chance ) {
-                Maps::Tiles & boatFile = world.GetTiles( boat );
-                boatFile.RemoveObjectSprite();
-                boatFile.SetObject( MP2::OBJ_ZERO );
-                Game::ObjectFadeAnimation::Set( Game::ObjectFadeAnimation::Info( MP2::OBJ_BOAT, 18, dst_water, 0, false ) );
-                return true;
-            }
-            break;
-        }
-    }
-
-    DialogSpellFailed( Spell::SUMMONBOAT );
-    return true;
+    return SummonAnyBoat( center, chance, dst_water );
 }
 
 bool ActionSpellDimensionDoor( Heroes & hero )


### PR DESCRIPTION
Hi!

The problem with #2435 is: present boats are sorted by distance, so the first summoned boat will always be the closest hence be summoned again and again. What i suggest is a simple fix - we start iterating from the farthest boat. Also extracted `SummonAnyBoat` function because `ActionSpellSummonBoat` is too big.