### PR TITLE
Fix bugs in Kingdom View

### DIFF
--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -413,7 +413,7 @@ int Castle::OpenDialog( bool readonly )
         // view guardian
         if ( !readonly && heroes.Guard() && le.MouseClickLeft( rectSign1 ) ) {
             Game::DisableChangeMusic( true );
-            Game::OpenHeroesDialog( *heroes.Guard(), false );
+            Game::OpenHeroesDialog( *heroes.Guard(), false, false );
 
             if ( selectArmy1.isSelected() )
                 selectArmy1.ResetSelected();
@@ -426,7 +426,7 @@ int Castle::OpenDialog( bool readonly )
             // view hero
             if ( !readonly && heroes.Guest() && le.MouseClickLeft( rectSign2 ) ) {
             Game::DisableChangeMusic( true );
-            Game::OpenHeroesDialog( *heroes.Guest(), false );
+            Game::OpenHeroesDialog( *heroes.Guest(), false, false );
 
             if ( selectArmy1.isSelected() )
                 selectArmy1.ResetSelected();

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -258,8 +258,8 @@ namespace Game
     void PlayPickupSound( void );
     void DisableChangeMusic( bool );
     bool ChangeMusicDisabled( void );
-    void OpenHeroesDialog( Heroes & hero, bool updateFocus = true );
-    void OpenCastleDialog( Castle & );
+    void OpenHeroesDialog( Heroes & hero, bool updateFocus, bool windowIsGameWorld );
+    void OpenCastleDialog( Castle & castle, bool updateFocus = true );
     std::string GetEncodeString( const std::string & );
     void LoadPlayers( const std::string & mapFileName, Players & players );
     void SavePlayers( const std::string & mapFileName, const Players & players );

--- a/src/fheroes2/game/game_interface.cpp
+++ b/src/fheroes2/game/game_interface.cpp
@@ -166,6 +166,11 @@ void Interface::Basic::SetRedraw( int f )
     redraw |= f;
 }
 
+int Interface::Basic::GetRedrawMask() const
+{
+    return redraw;
+}
+
 void Interface::Basic::Redraw( int force )
 {
     fheroes2::Display & display = fheroes2::Display::instance();

--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -84,6 +84,7 @@ namespace Interface
 
         bool NeedRedraw( void ) const;
         void SetRedraw( int );
+        int GetRedrawMask() const;
         void Redraw( int f = 0 );
 
         const fheroes2::Rect & GetScrollLeft( void ) const;

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -122,7 +122,7 @@ void Game::DialogPlayers( int color, std::string str )
 }
 
 /* open castle wrapper */
-void Game::OpenCastleDialog( Castle & castle )
+void Game::OpenCastleDialog( Castle & castle, bool updateFocus /*= true*/ )
 {
     Mixer::Pause();
 
@@ -158,17 +158,19 @@ void Game::OpenCastleDialog( Castle & castle )
     }
 
     Interface::Basic & basicInterface = Interface::Basic::Get();
-    if ( heroCountBefore < myKingdom.GetHeroes().size() ) {
-        basicInterface.SetFocus( myKingdom.GetHeroes()[heroCountBefore] );
-    }
-    else {
-        basicInterface.SetFocus( *it );
+    if ( updateFocus ) {
+        if ( heroCountBefore < myKingdom.GetHeroes().size() ) {
+            basicInterface.SetFocus( myKingdom.GetHeroes()[heroCountBefore] );
+        }
+        else {
+            basicInterface.SetFocus( *it );
+        }
     }
     basicInterface.RedrawFocus();
 }
 
 /* open heroes wrapper */
-void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus )
+void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, bool windowIsGameWorld )
 {
     const Settings & conf = Settings::Get();
     Kingdom & myKingdom = hero.GetKingdom();
@@ -206,7 +208,10 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus )
                 ( *it )->GetPath().Hide();
                 gameArea.SetRedraw();
 
-                ( *it )->FadeOut();
+                if ( windowIsGameWorld ) {
+                    ( *it )->FadeOut();
+                }
+
                 ( *it )->SetFreeman( 0 );
                 it = myHeroes.begin();
                 updateFocus = true;
@@ -1070,7 +1075,7 @@ void Interface::Basic::MouseCursorAreaClickLeft( const int32_t index_maps )
                 RedrawFocus();
             }
             else
-                Game::OpenHeroesDialog( *to_hero );
+                Game::OpenHeroesDialog( *to_hero, true, true );
         }
     } break;
 

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -424,7 +424,7 @@ void Interface::Basic::EventDefaultAction( void )
             hero->SetMove( true );
         else
             // 3. hero dialog
-            Game::OpenHeroesDialog( *hero );
+            Game::OpenHeroesDialog( *hero, true, true );
     }
     else
         // 4. town dialog
@@ -436,7 +436,7 @@ void Interface::Basic::EventDefaultAction( void )
 void Interface::Basic::EventOpenFocus( void )
 {
     if ( GetFocusHeroes() )
-        Game::OpenHeroesDialog( *GetFocusHeroes() );
+        Game::OpenHeroesDialog( *GetFocusHeroes(), true, true );
     else if ( GetFocusCastle() )
         Game::OpenCastleDialog( *GetFocusCastle() );
 }

--- a/src/fheroes2/gui/interface_icons.cpp
+++ b/src/fheroes2/gui/interface_icons.cpp
@@ -261,7 +261,7 @@ void Interface::HeroesIcons::ActionListDoubleClick( HEROES & item )
                 Game::OpenCastleDialog( *castle );
         }
         else
-            Game::OpenHeroesDialog( *item, false );
+            Game::OpenHeroesDialog( *item, false, true );
     }
 }
 

--- a/src/fheroes2/gui/ui_window.cpp
+++ b/src/fheroes2/gui/ui_window.cpp
@@ -35,7 +35,7 @@ namespace fheroes2
         , _windowArea( _activeArea.x - borderSize, _activeArea.y - borderSize, _activeArea.width + 2 * borderSize, _activeArea.height + 2 * borderSize )
         , _restorer( output, _windowArea.x - borderSize, _windowArea.y, _windowArea.width + borderSize, _windowArea.height + borderSize )
     {
-        _render();
+        render();
     }
 
     StandardWindow::StandardWindow( const int32_t x, const int32_t y, const int32_t width, const int32_t height, Image & output )
@@ -44,10 +44,10 @@ namespace fheroes2
         , _windowArea( _activeArea.x - borderSize, _activeArea.y - borderSize, _activeArea.width + 2 * borderSize, _activeArea.height + 2 * borderSize )
         , _restorer( output, _windowArea.x - borderSize, _windowArea.y, _windowArea.width + borderSize, _windowArea.height + borderSize )
     {
-        _render();
+        render();
     }
 
-    void StandardWindow::_render()
+    void StandardWindow::render()
     {
         const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ( Settings::Get().ExtGameEvilInterface() ? ICN::SURDRBKE : ICN::SURDRBKG ), 0 );
         const fheroes2::Image renderedImage

--- a/src/fheroes2/gui/ui_window.h
+++ b/src/fheroes2/gui/ui_window.h
@@ -36,12 +36,12 @@ namespace fheroes2
             return _activeArea;
         }
 
+        void render();
+
     private:
         Image & _output;
         Rect _activeArea;
         Rect _windowArea;
         ImageRestorer _restorer;
-
-        void _render();
     };
 }

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -49,35 +49,19 @@ struct HeroRow
     std::unique_ptr<SecondarySkillsBar> secskillsBar;
     std::unique_ptr<PrimarySkillsBar> primskillsBar;
 
-    HeroRow()
-        : hero( nullptr )
-    {}
-
-    HeroRow( const HeroRow & )
-        : hero( nullptr )
+    HeroRow( Heroes * ptr )
     {
-        // If this assertion blows up then something is not right. We should not make a copy of this structure.
-        assert( 0 );
+        Init( ptr );
     }
 
-    ~HeroRow()
-    {
-        Clear();
-    }
-
-    void Clear( void )
-    {
-        armyBar.reset();
-        artifactsBar.reset();
-        secskillsBar.reset();
-        primskillsBar.reset();
-    }
+    HeroRow( const HeroRow & ) = delete;
+    HeroRow & operator=( const HeroRow & ) = delete;
+    HeroRow( HeroRow && ) = default;
+    HeroRow & operator=( HeroRow && ) = default;
 
     void Init( Heroes * ptr )
     {
         hero = ptr;
-
-        Clear();
 
         armyBar.reset( new ArmyBar( &hero->GetArmy(), true, false ) );
         armyBar->SetBackground( Size( 41, 53 ), fheroes2::GetColorId( 72, 28, 0 ) );
@@ -126,6 +110,7 @@ public:
 
 private:
     std::vector<HeroRow> content;
+
     void SetContent( KingdomHeroes & heroes );
 };
 
@@ -145,9 +130,10 @@ StatsHeroesList::StatsHeroesList( const Point & pt, KingdomHeroes & heroes )
 
 void StatsHeroesList::SetContent( KingdomHeroes & heroes )
 {
-    content.resize( heroes.size() );
-    for ( KingdomHeroes::iterator it = heroes.begin(); it != heroes.end(); ++it )
-        content[std::distance( heroes.begin(), it )].Init( *it );
+    content.clear();
+    content.reserve( heroes.size() );
+    for ( auto & hero : heroes )
+        content.emplace_back( hero );
     SetListContent( content );
 }
 
@@ -239,20 +225,20 @@ void StatsHeroesList::RedrawItem( const HeroRow & row, s32 dstx, s32 dsty, bool 
         text.Blit( dstx + 195 - text.w(), dsty + 20 );
 
         // primary skills info
-        row.primskillsBar.get()->SetPos( dstx + 56, dsty - 3 );
-        row.primskillsBar.get()->Redraw();
+        row.primskillsBar->SetPos( dstx + 56, dsty - 3 );
+        row.primskillsBar->Redraw();
 
         // secondary skills info
-        row.secskillsBar.get()->SetPos( dstx + 206, dsty + 3 );
-        row.secskillsBar.get()->Redraw();
+        row.secskillsBar->SetPos( dstx + 206, dsty + 3 );
+        row.secskillsBar->Redraw();
 
         // artifacts info
-        row.artifactsBar.get()->SetPos( dstx + 348, dsty + 3 );
-        row.artifactsBar.get()->Redraw();
+        row.artifactsBar->SetPos( dstx + 348, dsty + 3 );
+        row.artifactsBar->Redraw();
 
         // army info
-        row.armyBar.get()->SetPos( dstx - 1, dsty + 30 );
-        row.armyBar.get()->Redraw();
+        row.armyBar->SetPos( dstx - 1, dsty + 30 );
+        row.armyBar->Redraw();
     }
 }
 
@@ -290,34 +276,20 @@ struct CstlRow
     std::unique_ptr<ArmyBar> armyBarGuest;
     std::unique_ptr<DwellingsBar> dwellingsBar;
 
-    CstlRow()
-        : castle( NULL )
-    {}
-
-    CstlRow( const CstlRow & )
-        : castle( NULL )
+    CstlRow( Castle * ptr )
     {
-        // If this assertion blows up then something is not right. We should not make a copy of this structure.
-        assert( 0 );
+        Init( ptr );
     }
 
-    ~CstlRow()
-    {
-        Clear();
-    }
-
-    void Clear()
-    {
-        armyBarGuard.reset();
-        armyBarGuest.reset();
-        dwellingsBar.reset();
-    }
+    CstlRow( const CstlRow & ) = delete;
+    CstlRow & operator=( const CstlRow & ) = delete;
+    CstlRow( CstlRow && ) = default;
+    CstlRow & operator=( CstlRow && ) = default;
 
     void Init( Castle * ptr )
     {
         castle = ptr;
 
-        Clear();
         const uint8_t fill = fheroes2::GetColorId( 40, 12, 0 );
 
         armyBarGuard.reset( new ArmyBar( &castle->GetArmy(), true, false ) );
@@ -334,7 +306,7 @@ struct CstlRow
             armyBarGuest->SetHSpace( -1 );
         }
         else {
-            armyBarGuest = nullptr;
+            armyBarGuest.reset();
         }
 
         dwellingsBar.reset( new DwellingsBar( *castle, Size( 39, 52 ) ) );
@@ -379,10 +351,10 @@ StatsCastlesList::StatsCastlesList( const Point & pt, KingdomCastles & castles )
     SetAreaMaxItems( 4 );
     SetAreaItems( fheroes2::Rect( pt.x + 30, pt.y + 17, 594, 344 ) );
 
-    content.resize( castles.size() );
+    content.reserve( castles.size() );
 
-    for ( KingdomCastles::iterator it = castles.begin(); it != castles.end(); ++it )
-        content[std::distance( castles.begin(), it )].Init( *it );
+    for ( auto & castle : castles )
+        content.emplace_back( castle );
 
     SetListContent( content );
 }

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -692,22 +692,14 @@ void Kingdom::OverviewDialog( void )
         if ( !cursor.isVisible() || redraw ) {
             listCastles.Refresh();
 
-            // check if the heroes list has changed, which requires update of UI size
-            const bool refreshHeroList = listHeroes.Refresh( heroes );
-
-            // check if graphics in main world map window changed, this can happen in several situations:
+            // check if graphics in main world map window should change, this can happen in several situations:
             // - hero dismissed -> hero icon list is updated and world map focus changed
             // - hero hired -> hero icon list is updated
             // So, it's equivalent to check if hero list changed
-            const bool mainWindowChanged = refreshHeroList;
-
-            if ( mainWindowChanged ) {
+            if ( listHeroes.Refresh( heroes ) ) {
                 worldMapRedrawMask |= Interface::Basic::Get().GetRedrawMask();
-                // redraw of the main game window on screen, which will also erase current kingdom window
+                // redraw the main game window on screen, which will also erase current kingdom window
                 Interface::Basic::Get().Redraw();
-            }
-
-            if ( refreshHeroList || mainWindowChanged ) {
                 // redraw Kingdom window from scratch, because it's now invalid
                 background.render();
                 fheroes2::Blit( fheroes2::AGG::GetICN( ICN::OVERBACK, 0 ), display, cur_pt.x, cur_pt.y );

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -49,8 +49,9 @@ struct HeroRow
     std::unique_ptr<SecondarySkillsBar> secskillsBar;
     std::unique_ptr<PrimarySkillsBar> primskillsBar;
 
-    HeroRow( Heroes * ptr )
+    HeroRow( Heroes * ptr = nullptr )
     {
+        assert( ptr != nullptr );
         Init( ptr );
     }
 
@@ -276,8 +277,9 @@ struct CstlRow
     std::unique_ptr<ArmyBar> armyBarGuest;
     std::unique_ptr<DwellingsBar> dwellingsBar;
 
-    CstlRow( Castle * ptr )
+    CstlRow( Castle * ptr = nullptr )
     {
+        assert( ptr != nullptr );
         Init( ptr );
     }
 

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -329,6 +329,9 @@ struct CstlRow
             armyBarGuest->SetColRows( 5, 1 );
             armyBarGuest->SetHSpace( -1 );
         }
+        else {
+            armyBarGuest = nullptr;
+        }
 
         dwellingsBar.reset( new DwellingsBar( *castle, Size( 39, 52 ) ) );
         dwellingsBar->SetColRows( 6, 1 );
@@ -340,6 +343,7 @@ class StatsCastlesList : public Interface::ListBox<CstlRow>
 {
 public:
     StatsCastlesList( const Point & pt, KingdomCastles & );
+    void Refresh();
 
     virtual void RedrawItem( const CstlRow &, s32, s32, bool ) override;
     virtual void RedrawBackground( const Point & ) override;
@@ -517,6 +521,15 @@ void StatsCastlesList::RedrawBackground( const Point & dst )
         fheroes2::Blit( back, display, dst.x + 30, dst.y + 17 + ii * ( back.height() + 4 ) );
         // fix bar
         fheroes2::Blit( fheroes2::AGG::GetICN( ICN::OVERBACK, 0 ), 28, 12, display, dst.x + 28, dst.y + 12 + ii * ( back.height() + 4 ), 599, 6 );
+    }
+}
+
+// Make sure that our list doesn't refer to incorrect castle data after castle window was entered
+// We don't need to change the size of the vector as castles can't be added / removed from this view
+void StatsCastlesList::Refresh()
+{
+    for ( CstlRow & row : content ) {
+        row.Init( row.castle );
     }
 }
 
@@ -699,6 +712,8 @@ void Kingdom::OverviewDialog( void )
             Dialog::ResourceInfo( _( "Income" ), "", GetIncome( INCOME_ALL ), 0 );
 
         if ( !cursor.isVisible() || redraw ) {
+            listCastles.Refresh();
+
             // check if the heroes list has changed, which requires update of UI size
             const bool refreshHeroList = listHeroes.Refresh( heroes );
 


### PR DESCRIPTION
Fix #2302
Fix #2594

The idea is that:
- for castle window, we don't need to update focus when opening the
window through Kingdown window
- for hero window, we already don't update focus, except when dismissing
heroes where this is forced

In order to have an up-to-date UI when a hero is dismissed from the
Kingdom view (ie, correct heroes icon bar and correct world map focus),
what I'm doing is redrawing the main window, then redrawing the
Kingdom UI on top. This ensures that the UI is always correct for all
resolutions

I'm also updating the list element in the Kingdom UI when a hero is
dismissed, otherwise we have bugs because we try to draw the hero army etc for a hero not in our kingdom