### PR TITLE
Fix right mouse split regression

### DIFF
--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -526,10 +526,11 @@ bool ArmyBar::ActionBarRightMouseSingleClick( ArmyTroop & troop )
 
     ArmyTroop & selectedTroop = *GetSelectedItem();
 
-    if ( troop.GetID() == selectedTroop.GetID() )
+    // prevent troop from splitting into its own stack by checking against their pointers
+    if ( &troop == &selectedTroop )
         return false;
 
-    if ( !troop.isValid() || selectedTroop.GetMonster() == troop.GetMonster() ) {
+    if ( !troop.isValid() || selectedTroop.GetID() == troop.GetID() ) {
         ResetSelected();
         RedistributeArmy( selectedTroop, troop, _isTroopInfoVisible );
     }
@@ -539,7 +540,7 @@ bool ArmyBar::ActionBarRightMouseSingleClick( ArmyTroop & troop )
 
 bool ArmyBar::ActionBarRightMouseSingleClick( ArmyTroop & destTroop, ArmyTroop & selectedTroop )
 {
-    if ( !destTroop.isValid() || destTroop.GetMonster() == selectedTroop.GetMonster() ) {
+    if ( !destTroop.isValid() || destTroop.GetID() == selectedTroop.GetID() ) {
         ResetSelected();
         RedistributeArmy( selectedTroop, destTroop, _isTroopInfoVisible );
     }

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -506,6 +506,10 @@ bool ArmyBar::ActionBarLeftMouseRelease( ArmyTroop & /*destTroop*/, ArmyTroop & 
 
 bool ArmyBar::ActionBarRightMouseHold( ArmyTroop & troop )
 {
+    // for this one, prioritize the click before press - aka prioritize split before showing troop info
+    if ( ActionBarRightMouseSingleClick( troop ) )
+        return true;
+
     if ( troop.isValid() && _isTroopInfoVisible ) {
         ResetSelected();
 
@@ -533,9 +537,10 @@ bool ArmyBar::ActionBarRightMouseSingleClick( ArmyTroop & troop )
     if ( !troop.isValid() || selectedTroop.GetID() == troop.GetID() ) {
         ResetSelected();
         RedistributeArmy( selectedTroop, troop, _isTroopInfoVisible );
+        return true;
     }
 
-    return true;
+    return false;
 }
 
 bool ArmyBar::ActionBarRightMouseSingleClick( ArmyTroop & destTroop, ArmyTroop & selectedTroop )

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -31,10 +31,9 @@
 #include "text.h"
 #include "world.h"
 
-void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army* armyTarget, bool & isTroopInfoVisible )
+void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * armyTarget, bool & isTroopInfoVisible )
 {
     const Army * armyFrom = troopFrom.GetArmy();
-    
     bool saveLastTroop = armyFrom->SaveLastTroop() && armyFrom != armyTarget;
 
     if ( troopFrom.GetCount() <= 1 ) {

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -31,49 +31,51 @@
 #include "text.h"
 #include "world.h"
 
-void RedistributeArmy( ArmyTroop & troop1 /* from */, ArmyTroop & troop2 /* to */, bool & isTroopInfoVisible )
+void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army* armyTarget, bool & isTroopInfoVisible )
 {
-    const Army * army1 = troop1.GetArmy();
-    const Army * army2 = troop2.GetArmy();
+    const Army * armyFrom = troopFrom.GetArmy();
+    
+    bool saveLastTroop = armyFrom->SaveLastTroop() && armyFrom != armyTarget;
 
-    bool save_last_troop = army1->SaveLastTroop() && army1 != army2;
-
-    if ( 2 > troop1.GetCount() ) {
-        if ( !save_last_troop || troop2.isValid() ) {
-            Army::SwapTroops( troop1, troop2 );
+    if ( troopFrom.GetCount() <= 1 ) {
+        if ( !saveLastTroop && !troopTarget.isValid() ) {
+            Army::SwapTroops( troopFrom, troopTarget );
             isTroopInfoVisible = false;
+        }
+        else {
+            return;
         }
     }
     else {
-        const u32 free_slots = ( army1 == army2 ? 1 : 0 ) + army2->Size() - army2->GetCount();
-        const u32 max_count = save_last_troop ? troop1.GetCount() - 1 : troop1.GetCount();
-        u32 redistr_count = troop1.GetCount() / 2;
-        const u32 slots = Dialog::ArmySplitTroop( ( free_slots > max_count ? max_count : free_slots ), max_count, redistr_count, save_last_troop );
+        const uint32_t freeSlots = ( armyFrom == armyTarget ? 1 : 0 ) + armyTarget->Size() - armyTarget->GetCount();
+        const uint32_t maxCount = saveLastTroop ? troopFrom.GetCount() - 1 : troopFrom.GetCount();
+        uint32_t redistributeCount = troopFrom.GetCount() / 2;
+        const uint32_t slots = Dialog::ArmySplitTroop( ( freeSlots > maxCount ? maxCount : freeSlots ), maxCount, redistributeCount, saveLastTroop );
 
         switch ( slots ) {
         case 3:
         case 4:
         case 5:
-            if ( save_last_troop ) {
-                const Troop troop( troop1, troop1.GetCount() - 1 );
-                troop1.SetCount( 1 );
-                const_cast<Army *>( army2 )->SplitTroopIntoFreeSlots( troop, slots );
+            if ( saveLastTroop ) {
+                const Troop troop( troopFrom, troopFrom.GetCount() - 1 );
+                troopFrom.SetCount( 1 );
+                armyTarget->SplitTroopIntoFreeSlots( troop, slots );
             }
             else {
-                const Troop troop( troop1 );
-                troop1.Reset();
-                const_cast<Army *>( army2 )->SplitTroopIntoFreeSlots( troop, slots );
+                const Troop troop( troopFrom );
+                troopFrom.Reset();
+                armyTarget->SplitTroopIntoFreeSlots( troop, slots );
             }
             break;
 
         case 2:
             // this logic is used when splitting to a stack with the same unit
-            if ( troop1.GetID() == troop2.GetID() )
-                troop2.SetCount( troop2.GetCount() + redistr_count );
+            if ( troopFrom.GetID() == troopTarget.GetID() )
+                troopTarget.SetCount( troopTarget.GetCount() + redistributeCount );
             else
-                troop2.Set( troop1, redistr_count );
+                troopTarget.Set( troopFrom, redistributeCount );
 
-            troop1.SetCount( troop1.GetCount() - redistr_count );
+            troopFrom.SetCount( troopFrom.GetCount() - redistributeCount );
             break;
 
         default:
@@ -309,7 +311,7 @@ bool ArmyBar::ActionBarLeftMouseSingleClick( ArmyTroop & troop )
             // redistribute when clicked troop is empty or is the same one as the selected troop
             if ( !troop.isValid() || troop.GetID() == selectedTroop->GetID() ) {
                 ResetSelected();
-                RedistributeArmy( *selectedTroop, troop, _isTroopInfoVisible );
+                RedistributeArmy( *selectedTroop, troop, army, _isTroopInfoVisible );
 
                 return false;
             }
@@ -393,7 +395,7 @@ bool ArmyBar::ActionBarLeftMouseSingleClick( ArmyTroop & destTroop, ArmyTroop & 
     if ( Game::HotKeyHoldEvent( Game::EVENT_STACKSPLIT_SHIFT ) ) {
         if ( destTroop.isEmpty() || destTroop.GetID() == selectedTroop.GetID() ) {
             ResetSelected();
-            RedistributeArmy( selectedTroop, destTroop, _isTroopInfoVisible );
+            RedistributeArmy( selectedTroop, destTroop, army, _isTroopInfoVisible );
         }
         return false;
     }
@@ -484,7 +486,7 @@ bool ArmyBar::ActionBarLeftMouseRelease( ArmyTroop & troop )
     ArmyTroop * troopPress = GetItem( le.GetMousePressLeft() );
 
     if ( !troop.isValid() && troopPress && troopPress->isValid() ) {
-        RedistributeArmy( *troopPress, troop, _isTroopInfoVisible );
+        RedistributeArmy( *troopPress, troop, army, _isTroopInfoVisible );
         le.ResetPressLeft();
 
         if ( isSelected() )
@@ -536,7 +538,7 @@ bool ArmyBar::ActionBarRightMouseSingleClick( ArmyTroop & troop )
 
     if ( !troop.isValid() || selectedTroop.GetID() == troop.GetID() ) {
         ResetSelected();
-        RedistributeArmy( selectedTroop, troop, _isTroopInfoVisible );
+        RedistributeArmy( selectedTroop, troop, army, _isTroopInfoVisible );
         return true;
     }
 
@@ -547,10 +549,11 @@ bool ArmyBar::ActionBarRightMouseSingleClick( ArmyTroop & destTroop, ArmyTroop &
 {
     if ( !destTroop.isValid() || destTroop.GetID() == selectedTroop.GetID() ) {
         ResetSelected();
-        RedistributeArmy( selectedTroop, destTroop, _isTroopInfoVisible );
+        RedistributeArmy( selectedTroop, destTroop, army, _isTroopInfoVisible );
+        return true;
     }
 
-    return true;
+    return false;
 }
 
 bool ArmyBar::ActionBarRightMouseRelease( ArmyTroop & /*troop*/ )

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -34,16 +34,15 @@
 void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * armyTarget, bool & isTroopInfoVisible )
 {
     const Army * armyFrom = troopFrom.GetArmy();
-    bool saveLastTroop = armyFrom->SaveLastTroop() && armyFrom != armyTarget;
+    const bool saveLastTroop = armyFrom->SaveLastTroop() && armyFrom != armyTarget;
 
     if ( troopFrom.GetCount() <= 1 ) {
-        if ( !saveLastTroop && !troopTarget.isValid() ) {
-            Army::SwapTroops( troopFrom, troopTarget );
-            isTroopInfoVisible = false;
-        }
-        else {
+        if ( saveLastTroop || troopTarget.isValid() ) {
             return;
         }
+
+        Army::SwapTroops( troopFrom, troopTarget );
+        isTroopInfoVisible = false;
     }
     else {
         const uint32_t freeSlots = ( armyFrom == armyTarget ? 1 : 0 ) + armyTarget->Size() - armyTarget->GetCount();
@@ -507,7 +506,7 @@ bool ArmyBar::ActionBarLeftMouseRelease( ArmyTroop & /*destTroop*/, ArmyTroop & 
 
 bool ArmyBar::ActionBarRightMouseHold( ArmyTroop & troop )
 {
-    // for this one, prioritize the click before press - aka prioritize split before showing troop info
+    // Prioritize the click before press - aka prioritize split before showing troop info
     if ( ActionBarRightMouseSingleClick( troop ) )
         return true;
 


### PR DESCRIPTION
Solves #2392

Current logic
- Fixed right click split regression (at the risk of introducing a coding antipattern)
- When selecting a stack with 1 unit and right-clicking another stack with the same troop type, it will show the right-clicked troop's dialog info
- Ditto above but when right-clicking another stack with a different troop type. I think this one is already as it should be.

The regression issue is due to the press coming before the click so I made the press try to do click logic first. And if the click logic returns true skip the press logic. I am not too sure about this one since it feels like an antipattern to me. For left mouse click we got away with that one because we don't override `LeftMouseHold()` anywhere at the moment.

Also refactors RedistributeArmy so that it's more like the current coding style.