### PR TITLE
optimize audio/rand/serialize include files

### DIFF
--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -28,7 +28,9 @@
 
 #include "agg.h"
 #include "artifact.h"
+#include "audio.h"
 #include "audio_cdrom.h"
+#include "audio_mixer.h"
 #include "audio_music.h"
 #include "dir.h"
 #include "engine.h"

--- a/src/fheroes2/agg/agg.h
+++ b/src/fheroes2/agg/agg.h
@@ -26,8 +26,6 @@
 #include <utility>
 #include <vector>
 
-#include "audio.h"
-#include "audio_mixer.h"
 #include "gamedefs.h"
 #include "icn.h"
 

--- a/src/fheroes2/agg/mus.cpp
+++ b/src/fheroes2/agg/mus.cpp
@@ -28,6 +28,7 @@
 #include "mp2.h"
 #include "mus.h"
 #include "race.h"
+#include "rand.h"
 #include "settings.h"
 
 namespace MUS

--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -24,6 +24,7 @@
 #define H2AI_H
 
 #include "gamedefs.h"
+#include "rand.h"
 
 class Funds;
 class Castle;

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -38,6 +38,7 @@
 #include "morale.h"
 #include "payment.h"
 #include "race.h"
+#include "rand.h"
 #include "screen.h"
 #include "settings.h"
 #include "speed.h"

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -31,6 +31,7 @@
 #include "battle_tower.h"
 #include "battle_troop.h"
 #include "kingdom.h"
+#include "rand.h"
 #include "settings.h"
 #include "spell.h"
 #include "world.h"

--- a/src/fheroes2/battle/battle_animation.cpp
+++ b/src/fheroes2/battle/battle_animation.cpp
@@ -20,6 +20,7 @@
 
 #include "battle_animation.h"
 #include "monster.h"
+#include "rand.h"
 #include "settings.h"
 #include <algorithm>
 

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -27,6 +27,7 @@
 #include "ai.h"
 #include "army.h"
 #include "army_troop.h"
+#include "audio_mixer.h"
 #include "audio_music.h"
 #include "battle_arena.h"
 #include "battle_army.h"

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -29,6 +29,7 @@
 #include "battle_grave.h"
 #include "battle_pathfinding.h"
 #include "gamedefs.h"
+#include "serialize.h"
 #include "spell_storage.h"
 
 #define ARENAW 11

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -33,6 +33,7 @@
 #include "game_static.h"
 #include "ground.h"
 #include "icn.h"
+#include "rand.h"
 #include "settings.h"
 #include "world.h"
 

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -24,6 +24,7 @@
 #include "artifact.h"
 #include "battle_command.h"
 #include "heroes_base.h"
+#include "rand.h"
 #include "settings.h"
 #include "skill.h"
 

--- a/src/fheroes2/battle/battle_cell.h
+++ b/src/fheroes2/battle/battle_cell.h
@@ -24,6 +24,7 @@
 #define H2BATTLE_CELL_H
 
 #include "gamedefs.h"
+#include "serialize.h"
 
 #define CELLW 44
 #define CELLH 52

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 
 #include "agg.h"
+#include "audio_mixer.h"
 #include "battle_arena.h"
 #include "battle_bridge.h"
 #include "battle_catapult.h"
@@ -41,6 +42,7 @@
 #include "pal.h"
 #include "pocketpc.h"
 #include "race.h"
+#include "rand.h"
 #include "settings.h"
 #include "world.h"
 

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -36,6 +36,7 @@
 #include "heroes.h"
 #include "luck.h"
 #include "morale.h"
+#include "rand.h"
 #include "settings.h"
 #include "speed.h"
 #include "world.h"

--- a/src/fheroes2/campaign/campaign_data.h
+++ b/src/fheroes2/campaign/campaign_data.h
@@ -22,6 +22,7 @@
 #define H2CAMPAIGN_DATA_H
 
 #include "gamedefs.h"
+#include "serialize.h"
 
 namespace Campaign
 {

--- a/src/fheroes2/castle/mageguild.cpp
+++ b/src/fheroes2/castle/mageguild.cpp
@@ -25,6 +25,7 @@
 #include "heroes_base.h"
 #include "mageguild.h"
 #include "race.h"
+#include "rand.h"
 #include "settings.h"
 
 Spell GetUniqueCombatSpellCompatibility( const SpellStorage &, int race, int level );

--- a/src/fheroes2/dialog/dialog_system.cpp
+++ b/src/fheroes2/dialog/dialog_system.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include "agg.h"
+#include "audio_mixer.h"
 #include "audio_music.h"
 #include "cursor.h"
 #include "dialog.h"

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -25,6 +25,7 @@
 #include <string>
 
 #include "agg.h"
+#include "audio_mixer.h"
 #include "audio_music.h"
 #include "bin_info.h"
 #include "cursor.h"

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -26,7 +26,7 @@
 #include <map>
 
 #include "agg.h"
-#include "ai.h"
+#include "audio_mixer.h"
 #include "battle.h"
 #include "buildinginfo.h"
 #include "castle.h"
@@ -43,6 +43,7 @@
 #include "mus.h"
 #include "payment.h"
 #include "profit.h"
+#include "rand.h"
 #include "settings.h"
 #include "skill.h"
 #include "spell.h"

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -25,6 +25,7 @@
 #include "game.h"
 #include "game_delays.h"
 #include "gamedefs.h"
+#include "rand.h"
 #include "settings.h"
 
 TimeDelay::TimeDelay( uint32_t dl )

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "agg.h"
+#include "audio_mixer.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "game.h"

--- a/src/fheroes2/game/game_loadgame.cpp
+++ b/src/fheroes2/game/game_loadgame.cpp
@@ -22,6 +22,7 @@
 
 #include "game.h"
 #include "agg.h"
+#include "audio_mixer.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "game_io.h"

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include "agg.h"
+#include "audio_mixer.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "dialog_resolution.h"

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -24,6 +24,7 @@
 
 #include "agg.h"
 #include "assert.h"
+#include "audio_mixer.h"
 #include "audio_music.h"
 #include "campaign_data.h"
 #include "cursor.h"

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -29,6 +29,7 @@
 
 #include "agg.h"
 #include "ai.h"
+#include "audio_mixer.h"
 #include "battle_only.h"
 #include "castle.h"
 #include "cursor.h"

--- a/src/fheroes2/game/game_static.h
+++ b/src/fheroes2/game/game_static.h
@@ -24,6 +24,7 @@
 #define H2GAMESTATIC_H
 
 #include "gamedefs.h"
+#include "serialize.h"
 
 namespace Skill
 {

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "agg.h"
+#include "audio_mixer.h"
 #include "castle.h"
 #include "cursor.h"
 #include "dialog.h"

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -23,6 +23,8 @@
 #ifndef H2INTERFACE_GAMEAREA_H
 #define H2INTERFACE_GAMEAREA_H
 
+#include <map>
+
 #include "gamedefs.h"
 #include "image.h"
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -23,6 +23,7 @@
 #include "agg.h"
 #include "ai.h"
 #include "assert.h"
+#include "audio_mixer.h"
 #include "battle.h"
 #include "castle.h"
 #include "cursor.h"

--- a/src/fheroes2/heroes/heroes_recruits.h
+++ b/src/fheroes2/heroes/heroes_recruits.h
@@ -26,6 +26,7 @@
 #include <utility>
 
 #include "gamedefs.h"
+#include "serialize.h"
 
 class Heroes;
 

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -30,6 +30,7 @@
 #include "kingdom.h"
 #include "m82.h"
 #include "monster.h"
+#include "rand.h"
 #include "settings.h"
 #include "spell.h"
 #include "ui_window.h"

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -29,6 +29,7 @@
 #include "game_static.h"
 #include "heroes.h"
 #include "race.h"
+#include "rand.h"
 #include "settings.h"
 #include "skill.h"
 #include "skill_static.h"

--- a/src/fheroes2/heroes/skill.h
+++ b/src/fheroes2/heroes/skill.h
@@ -26,6 +26,7 @@
 #include <string>
 
 #include "gamedefs.h"
+#include "serialize.h"
 
 void StringAppendModifiers( std::string &, int );
 

--- a/src/fheroes2/kingdom/color.h
+++ b/src/fheroes2/kingdom/color.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "gamedefs.h"
+#include "serialize.h"
 
 namespace BarrierColor
 {

--- a/src/fheroes2/kingdom/puzzle.h
+++ b/src/fheroes2/kingdom/puzzle.h
@@ -26,6 +26,7 @@
 #include <bitset>
 
 #include "gamedefs.h"
+#include "serialize.h"
 
 #define PUZZLETILES 48
 

--- a/src/fheroes2/kingdom/race.cpp
+++ b/src/fheroes2/kingdom/race.cpp
@@ -23,6 +23,7 @@
 #include "race.h"
 #include "engine.h"
 #include "gamedefs.h"
+#include "rand.h"
 
 const std::string & Race::String( int race )
 {

--- a/src/fheroes2/kingdom/week.cpp
+++ b/src/fheroes2/kingdom/week.cpp
@@ -24,6 +24,7 @@
 #include "engine.h"
 #include "game.h"
 #include "gamedefs.h"
+#include "rand.h"
 #include "settings.h"
 #include "world.h"
 

--- a/src/fheroes2/maps/maps_fileinfo.h
+++ b/src/fheroes2/maps/maps_fileinfo.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "gamedefs.h"
+#include "serialize.h"
 
 namespace Maps
 {

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -24,6 +24,7 @@
 #include "difficulty.h"
 #include "maps_tiles.h"
 #include "pairs.h"
+#include "rand.h"
 #include "settings.h"
 #include "skill.h"
 #include "spell.h"

--- a/src/fheroes2/maps/position.h
+++ b/src/fheroes2/maps/position.h
@@ -24,6 +24,7 @@
 #define H2POSITION_H
 
 #include "gamedefs.h"
+#include "serialize.h"
 
 class MapPosition
 {

--- a/src/fheroes2/monster/monster.cpp
+++ b/src/fheroes2/monster/monster.cpp
@@ -36,6 +36,7 @@
 #include "morale.h"
 #include "mp2.h"
 #include "race.h"
+#include "rand.h"
 #include "settings.h"
 #include "speed.h"
 #include "spell.h"

--- a/src/fheroes2/monster/monster.h
+++ b/src/fheroes2/monster/monster.h
@@ -29,6 +29,7 @@
 #include "gamedefs.h"
 #include "monster_info.h"
 #include "payment.h"
+#include "serialize.h"
 
 class Spell;
 

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -31,6 +31,7 @@
 #include "dialog_selectitems.h"
 #include "game.h"
 #include "heroes.h"
+#include "rand.h"
 #include "settings.h"
 #include "spell.h"
 #include "text.h"

--- a/src/fheroes2/resource/artifact.h
+++ b/src/fheroes2/resource/artifact.h
@@ -26,11 +26,11 @@
 
 #include "gamedefs.h"
 #include "interface_itemsbar.h"
+#include "serialize.h"
 #include "ui_tool.h"
 
 class Spell;
 class Heroes;
-class StreamBase;
 
 class Artifact
 {

--- a/src/fheroes2/resource/artifact_ultimate.h
+++ b/src/fheroes2/resource/artifact_ultimate.h
@@ -24,7 +24,6 @@
 #define H2ARTIFACT_ULTIMATE_H
 
 #include "artifact.h"
-#include "gamedefs.h"
 
 class UltimateArtifact : public Artifact
 {

--- a/src/fheroes2/resource/resource.cpp
+++ b/src/fheroes2/resource/resource.cpp
@@ -25,6 +25,7 @@
 #include "image.h"
 #include "mp2.h"
 #include "pairs.h"
+#include "rand.h"
 #include "settings.h"
 #include "text.h"
 #include "world.h"

--- a/src/fheroes2/resource/resource.h
+++ b/src/fheroes2/resource/resource.h
@@ -23,6 +23,7 @@
 #define H2RESOURCE_H
 
 #include "gamedefs.h"
+#include "serialize.h"
 
 struct cost_t
 {

--- a/src/fheroes2/spell/spell.cpp
+++ b/src/fheroes2/spell/spell.cpp
@@ -26,6 +26,7 @@
 #include "game_static.h"
 #include "heroes_base.h"
 #include "race.h"
+#include "rand.h"
 #include "resource.h"
 #include "settings.h"
 

--- a/src/fheroes2/system/gamedefs.h
+++ b/src/fheroes2/system/gamedefs.h
@@ -22,8 +22,6 @@
 #ifndef H2GAMEDEFS_H
 #define H2GAMEDEFS_H
 
-#include "rand.h"
-#include "serialize.h"
 #include "tools.h"
 #include "types.h"
 

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -24,7 +24,6 @@
 #include <functional>
 
 #include "agg.h"
-#include "ai.h"
 #include "artifact.h"
 #include "castle.h"
 #include "difficulty.h"
@@ -39,6 +38,7 @@
 #include "mp2.h"
 #include "pairs.h"
 #include "race.h"
+#include "rand.h"
 #include "resource.h"
 #include "settings.h"
 #include "text.h"

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -21,7 +21,6 @@
 #include <set>
 
 #include "world_pathfinding.h"
-#include "ai.h"
 #include "ground.h"
 #include "world.h"
 


### PR DESCRIPTION
This is a second "include what you use" commit for #2559:

- `serialize.h` is included in headers which define classes using `StreamBuf`
- `rand.h`, `audio.h` and `audio_mixer.h` are included in `.cpp` units which actually use those. As an exception, `rand.h` is included into `ai.h`, since most AI functions use randomizers.