### PR TITLE
AI: fix path selection for hero in patrol

### DIFF
--- a/src/engine/pathfinding.h
+++ b/src/engine/pathfinding.h
@@ -51,7 +51,6 @@ class Pathfinder
 {
 public:
     virtual void reset() = 0;
-    virtual std::list<Route::Step> buildPath( int targetIndex ) const = 0;
 
     virtual uint32_t getDistance( int targetIndex ) const
     {

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -143,18 +143,13 @@ namespace AI
 #endif
 
         // pre-cache the pathfinder
-        if ( heroInPatrolMode ) {
-            _pathfinder.reEvaluateIfNeeded( patrolIndex, hero.GetColor(), heroStrength, hero.GetLevelSkill( Skill::Secondary::PATHFINDING ) );
-        }
-        else {
-            _pathfinder.reEvaluateIfNeeded( hero );
-        }
+        _pathfinder.reEvaluateIfNeeded( hero );
 
         for ( size_t idx = 0; idx < _mapObjects.size(); ++idx ) {
             const IndexObject & node = _mapObjects[idx];
 
             // Skip if hero in patrol mode and object outside of reach
-            if ( heroInPatrolMode && _pathfinder.buildPath( node.first, true ).size() > distanceLimit )
+            if ( heroInPatrolMode && Maps::GetApproximateDistance( node.first, patrolIndex ) > distanceLimit )
                 continue;
 
             if ( HeroesValidObject( hero, node.first ) ) {
@@ -231,7 +226,7 @@ namespace AI
 
             if ( targetIndex != -1 ) {
                 _pathfinder.reEvaluateIfNeeded( hero );
-                hero.GetPath().setPath( _pathfinder.buildPath( targetIndex, false ), targetIndex );
+                hero.GetPath().setPath( _pathfinder.buildPath( targetIndex ), targetIndex );
                 objectsToErase.push_back( hero.GetPath().GetDestinationIndex() );
 
                 HeroesMove( hero );

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -149,7 +149,7 @@ namespace AI
             const IndexObject & node = _mapObjects[idx];
 
             // Skip if hero in patrol mode and object outside of reach
-            if ( heroInPatrolMode && _pathfinder.buildPath( node.first ).size() > distanceLimit )
+            if ( heroInPatrolMode && _pathfinder.buildPath( node.first, true ).size() > distanceLimit )
                 continue;
 
             if ( HeroesValidObject( hero, node.first ) ) {
@@ -226,7 +226,7 @@ namespace AI
 
             if ( targetIndex != -1 ) {
                 _pathfinder.reEvaluateIfNeeded( hero );
-                hero.GetPath().setPath( _pathfinder.buildPath( targetIndex ), targetIndex );
+                hero.GetPath().setPath( _pathfinder.buildPath( targetIndex, false ), targetIndex );
                 objectsToErase.push_back( hero.GetPath().GetDestinationIndex() );
 
                 HeroesMove( hero );

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -143,7 +143,12 @@ namespace AI
 #endif
 
         // pre-cache the pathfinder
-        _pathfinder.reEvaluateIfNeeded( hero );
+        if ( heroInPatrolMode ) {
+            _pathfinder.reEvaluateIfNeeded( patrolIndex, hero.GetColor(), heroStrength, hero.GetLevelSkill( Skill::Secondary::PATHFINDING ) );
+        }
+        else {
+            _pathfinder.reEvaluateIfNeeded( hero );
+        }
 
         for ( size_t idx = 0; idx < _mapObjects.size(); ++idx ) {
             const IndexObject & node = _mapObjects[idx];

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -57,7 +57,7 @@ namespace Battle
         ArenaPathfinder();
         virtual void reset() override;
         void calculate( const Unit & unit );
-        virtual std::list<Route::Step> buildPath( int targetCell ) const override;
+        virtual std::list<Route::Step> buildPath( int targetCell ) const;
         bool hexIsAccessible( int targetCell ) const;
         bool hexIsPassable( int targetCell ) const;
     };

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -57,7 +57,7 @@ namespace Battle
         ArenaPathfinder();
         virtual void reset() override;
         void calculate( const Unit & unit );
-        virtual std::list<Route::Step> buildPath( int targetCell ) const;
+        std::list<Route::Step> buildPath( int targetCell ) const;
         bool hexIsAccessible( int targetCell ) const;
         bool hexIsPassable( int targetCell ) const;
     };

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -454,7 +454,7 @@ std::vector<IndexObject> AIWorldPathfinder::getObjectsOnTheWay( int targetIndex,
     return result;
 }
 
-std::list<Route::Step> AIWorldPathfinder::buildPath( int targetIndex ) const
+std::list<Route::Step> AIWorldPathfinder::buildPath( int targetIndex, bool isPlanningMode ) const
 {
     std::list<Route::Step> path;
     if ( _pathStart == -1 )
@@ -485,8 +485,8 @@ std::list<Route::Step> AIWorldPathfinder::buildPath( int targetIndex ) const
         }
     }
 
-    // Cut the path to the last valid tile
-    if ( lastValidNode != targetIndex ) {
+    // Cut the path to the last valid tile/obstacle if not in planning mode
+    if ( !isPlanningMode && lastValidNode != targetIndex ) {
         path.erase( std::find_if( path.begin(), path.end(), [&lastValidNode]( const Route::Step & step ) { return step.GetFrom() == lastValidNode; } ), path.end() );
     }
 

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -57,7 +57,7 @@ public:
     virtual void reset() override;
 
     void reEvaluateIfNeeded( const Heroes & hero );
-    virtual std::list<Route::Step> buildPath( int targetIndex ) const;
+    std::list<Route::Step> buildPath( int targetIndex ) const;
 
 private:
     void processCurrentNode( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx, bool fromWater ) override;
@@ -81,7 +81,7 @@ public:
     uint32_t getDistance( int start, int targetIndex, int color, double armyStrength, uint8_t skill = Skill::Level::EXPERT );
 
     // Override builds path to the nearest valid object
-    virtual std::list<Route::Step> buildPath( int targetIndex, bool isPlanningMode = false ) const;
+    std::list<Route::Step> buildPath( int targetIndex, bool isPlanningMode = false ) const;
 
     // Faster, but does not re-evaluate the map (expose base class method)
     using Pathfinder::getDistance;

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -57,7 +57,7 @@ public:
     virtual void reset() override;
 
     void reEvaluateIfNeeded( const Heroes & hero );
-    virtual std::list<Route::Step> buildPath( int targetIndex ) const override;
+    virtual std::list<Route::Step> buildPath( int targetIndex ) const;
 
 private:
     void processCurrentNode( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx, bool fromWater ) override;
@@ -81,7 +81,7 @@ public:
     uint32_t getDistance( int start, int targetIndex, int color, double armyStrength, uint8_t skill = Skill::Level::EXPERT );
 
     // Override builds path to the nearest valid object
-    virtual std::list<Route::Step> buildPath( int targetIndex ) const override;
+    virtual std::list<Route::Step> buildPath( int targetIndex, bool isPlanningMode = false ) const;
 
     // Faster, but does not re-evaluate the map (expose base class method)
     using Pathfinder::getDistance;


### PR DESCRIPTION
Fixes #2576 .

Patrol distance comparison was flawed, so AI perceived targets behind teleporter as "closer".

Also includes a fix to avoid hero in patrol mode leaving intended position.