### PR TITLE
AI: avoid disembarking on empty tiles

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -73,7 +73,8 @@ namespace AI
             }
 
             RegionStats & stats = _regions[regionID];
-            stats.validObjects.emplace_back( idx, objectID );
+            if ( objectID != MP2::OBJ_COAST )
+                stats.validObjects.emplace_back( idx, objectID );
 
             if ( !tile.isFog( color ) ) {
                 _mapObjects.emplace_back( idx, objectID );


### PR DESCRIPTION
Related to #2158.

During turn prep it considered coast a valid object, so tiles became "non-empty" islands for AI.