### PR TITLE
Fix object fading animation

### DIFF
--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -75,7 +75,7 @@ namespace Game
 
     namespace ObjectFadeAnimation
     {
-        FadeTask fadeTask = {MP2::OBJ_ZERO, 0, 0, 0, 0, 0, false, false, 0};
+        FadeTask fadeTask;
     }
 }
 

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -218,15 +218,15 @@ void Game::ObjectFadeAnimation::StartFadeTask( uint8_t object, uint32_t fromInde
     const uint32_t alpha = fadeOut ? 255u : 0;
     if ( MP2::OBJ_MONSTER == object ) {
         const auto & spriteIndicies = Maps::Tiles::GetMonsterSpriteIndices( fromTile, fromTile.QuantityMonster().GetSpriteIndex() );
-        fadeTask = {object, spriteIndicies.first, spriteIndicies.second, fromIndex, toIndex, alpha, fadeOut, fadeIn, 0};
+        fadeTask = FadeTask( object, spriteIndicies.first, spriteIndicies.second, fromIndex, toIndex, alpha, fadeOut, fadeIn, 0 );
     }
     else if ( MP2::OBJ_BOAT == object ) {
-        fadeTask = {object, fromTile.GetObjectSpriteIndex(), 0, fromIndex, toIndex, alpha, fadeOut, fadeIn, 0};
+        fadeTask = FadeTask( object, fromTile.GetObjectSpriteIndex(), 0, fromIndex, toIndex, alpha, fadeOut, fadeIn, 0 );
     }
     else {
         const int icn = MP2::GetICNObject( object );
         const uint32_t animationIndex = ICN::AnimationFrame( icn, fromTile.GetObjectSpriteIndex(), Game::MapsAnimationFrame(), fromTile.GetQuantity2() );
-        fadeTask = {object, fromTile.GetObjectSpriteIndex(), animationIndex, fromIndex, toIndex, alpha, fadeOut, fadeIn, fromTile.GetObjectTileset()};
+        fadeTask = FadeTask( object, fromTile.GetObjectSpriteIndex(), animationIndex, fromIndex, toIndex, alpha, fadeOut, fadeIn, fromTile.GetObjectTileset() );
     }
 }
 

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -219,22 +219,26 @@ void Game::SetCurrentMusic( int mus )
 
 void Game::ObjectFadeAnimation::FinishFadeTask()
 {
-    if ( fadeTask.object != MP2::OBJ_ZERO ) {
-        if ( fadeTask.fadeOut ) {
-            Maps::Tiles & tile = world.GetTiles( fadeTask.fromIndex );
-            if ( tile.GetObject() == fadeTask.object ) {
-                tile.RemoveObjectSprite();
-                tile.SetObject( MP2::OBJ_ZERO );
-            }
-        }
-        if ( fadeTask.fadeIn ) {
-            Maps::Tiles & tile = world.GetTiles( fadeTask.toIndex );
-            if ( MP2::OBJ_BOAT == fadeTask.object ) {
-                tile.setBoat( Direction::RIGHT );
-            }
-        }
-        fadeTask.object = MP2::OBJ_ZERO;
+    if ( fadeTask.object == MP2::OBJ_ZERO ) {
+        return;
     }
+
+    if ( fadeTask.fadeOut ) {
+        Maps::Tiles & tile = world.GetTiles( fadeTask.fromIndex );
+        if ( tile.GetObject() == fadeTask.object ) {
+            tile.RemoveObjectSprite();
+            tile.SetObject( MP2::OBJ_ZERO );
+        }
+    }
+
+    if ( fadeTask.fadeIn ) {
+        Maps::Tiles & tile = world.GetTiles( fadeTask.toIndex );
+        if ( MP2::OBJ_BOAT == fadeTask.object ) {
+            tile.setBoat( Direction::RIGHT );
+        }
+    }
+
+    fadeTask.object = MP2::OBJ_ZERO;
 }
 
 void Game::ObjectFadeAnimation::StartFadeTask( uint8_t object, uint32_t fromIndex, uint32_t toIndex, bool fadeOut, bool fadeIn )

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -76,6 +76,30 @@ namespace Game
     namespace ObjectFadeAnimation
     {
         FadeTask fadeTask;
+        FadeTask::FadeTask( uint8_t object_, uint32_t objectIndex_, uint32_t animationIndex_, uint32_t fromIndex_, uint32_t toIndex_, uint32_t alpha_, bool fadeOut_,
+                            bool fadeIn_, uint8_t objectTileset_ )
+            : object( object_ )
+            , objectIndex( objectIndex_ )
+            , animationIndex( animationIndex_ )
+            , fromIndex( fromIndex_ )
+            , toIndex( toIndex_ )
+            , alpha( alpha_ )
+            , fadeOut( fadeOut_ )
+            , fadeIn( fadeIn_ )
+            , objectTileset( objectTileset_ )
+        {}
+        FadeTask::FadeTask()
+            : object( MP2::OBJ_ZERO )
+            , objectIndex( 0 )
+            , animationIndex( 0 )
+            , fromIndex( 0 )
+            , toIndex( 0 )
+            , alpha( 0 )
+            , fadeOut( false )
+            , fadeIn( false )
+            , objectTileset( 0 )
+
+        {}
     }
 }
 

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -226,7 +226,7 @@ void Game::ObjectFadeAnimation::StartFadeTask( uint8_t object, int32_t fromIndex
         fadeTask = std::make_tuple( object, spriteIndicies.first, spriteIndicies.second, fromIndex, toIndex, alpha, fadeOut, fadeIn, 0 );
     }
     else if ( MP2::OBJ_BOAT == object ) {
-        fadeTask = std::make_tuple( object, fromTile.GetObjectSpriteIndex(), -1, fromIndex, toIndex, alpha, fadeOut, fadeIn, 0 );
+        fadeTask = std::make_tuple( object, fromTile.GetObjectSpriteIndex(), 0, fromIndex, toIndex, alpha, fadeOut, fadeIn, 0 );
     }
     else {
         const int icn = MP2::GetICNObject( object );

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -225,7 +225,7 @@ void Game::ObjectFadeAnimation::StartFadeTask( uint8_t object, uint32_t fromInde
     }
     else {
         const int icn = MP2::GetICNObject( object );
-        const auto animationIndex = ICN::AnimationFrame( icn, fromTile.GetObjectSpriteIndex(), Game::MapsAnimationFrame(), fromTile.GetQuantity2() );
+        const uint32_t animationIndex = ICN::AnimationFrame( icn, fromTile.GetObjectSpriteIndex(), Game::MapsAnimationFrame(), fromTile.GetQuantity2() );
         fadeTask = {object, fromTile.GetObjectSpriteIndex(), animationIndex, fromIndex, toIndex, alpha, fadeOut, fadeIn, fromTile.GetObjectTileset()};
     }
 }

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -75,7 +75,7 @@ namespace Game
 
     namespace ObjectFadeAnimation
     {
-        FadeTask fadeTask;
+        FadeTask fadeTask = { MP2::OBJ_ZERO, 0, 0, 0, 0, 0, false, false, 0 };
     }
 }
 
@@ -192,26 +192,21 @@ void Game::SetCurrentMusic( int mus )
 
 void Game::ObjectFadeAnimation::FinishFadeTask()
 {
-    auto & object = std::get<0>( fadeTask );
-    if ( object != MP2::OBJ_ZERO ) {
-        const auto fadeOut = std::get<6>( fadeTask );
-        if ( fadeOut ) {
-            const auto fromIndex = std::get<3>( fadeTask );
-            Maps::Tiles & tile = world.GetTiles( fromIndex );
-            if ( tile.GetObject() == object ) {
+    if ( fadeTask.object != MP2::OBJ_ZERO ) {
+        if ( fadeTask.fadeOut ) {
+            Maps::Tiles & tile = world.GetTiles( fadeTask.fromIndex );
+            if ( tile.GetObject() == fadeTask.object ) {
                 tile.RemoveObjectSprite();
                 tile.SetObject( MP2::OBJ_ZERO );
             }
         }
-        const auto fadeIn = std::get<6>( fadeTask );
-        if ( fadeIn ) {
-            const auto toIndex = std::get<4>( fadeTask );
-            Maps::Tiles & tile = world.GetTiles( toIndex );
-            if ( MP2::OBJ_BOAT == object ) {
+        if ( fadeTask.fadeIn ) {
+            Maps::Tiles & tile = world.GetTiles( fadeTask.toIndex );
+            if ( MP2::OBJ_BOAT == fadeTask.object ) {
                 tile.setBoat( Direction::RIGHT );
             }
         }
-        object = MP2::OBJ_ZERO;
+        fadeTask.object = MP2::OBJ_ZERO;
     }
 }
 
@@ -219,19 +214,19 @@ void Game::ObjectFadeAnimation::StartFadeTask( uint8_t object, uint32_t fromInde
 {
     FinishFadeTask();
 
-    const auto & fromTile = world.GetTiles( fromIndex );
+    const Maps::Tiles & fromTile = world.GetTiles( fromIndex );
     const uint32_t alpha = fadeOut ? 255u : 0;
     if ( MP2::OBJ_MONSTER == object ) {
         const auto & spriteIndicies = Maps::Tiles::GetMonsterSpriteIndices( fromTile, fromTile.QuantityMonster().GetSpriteIndex() );
-        fadeTask = std::make_tuple( object, spriteIndicies.first, spriteIndicies.second, fromIndex, toIndex, alpha, fadeOut, fadeIn, 0 );
+        fadeTask = { object, spriteIndicies.first, spriteIndicies.second, fromIndex, toIndex, alpha, fadeOut, fadeIn, 0 };
     }
     else if ( MP2::OBJ_BOAT == object ) {
-        fadeTask = std::make_tuple( object, fromTile.GetObjectSpriteIndex(), 0, fromIndex, toIndex, alpha, fadeOut, fadeIn, 0 );
+        fadeTask = { object, fromTile.GetObjectSpriteIndex(), 0, fromIndex, toIndex, alpha, fadeOut, fadeIn, 0 };
     }
     else {
         const int icn = MP2::GetICNObject( object );
         const auto animationIndex = ICN::AnimationFrame( icn, fromTile.GetObjectSpriteIndex(), Game::MapsAnimationFrame(), fromTile.GetQuantity2() );
-        fadeTask = std::make_tuple( object, fromTile.GetObjectSpriteIndex(), animationIndex, fromIndex, toIndex, alpha, fadeOut, fadeIn, fromTile.GetObjectTileset() );
+        fadeTask = { object, fromTile.GetObjectSpriteIndex(), animationIndex, fromIndex, toIndex, alpha, fadeOut, fadeIn, fromTile.GetObjectTileset() }; 
     }
 }
 

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -215,7 +215,7 @@ void Game::ObjectFadeAnimation::FinishFadeTask()
     }
 }
 
-void Game::ObjectFadeAnimation::StartFadeTask( uint8_t object, int32_t fromIndex, int32_t toIndex, bool fadeOut, bool fadeIn )
+void Game::ObjectFadeAnimation::StartFadeTask( uint8_t object, uint32_t fromIndex, uint32_t toIndex, bool fadeOut, bool fadeIn )
 {
     FinishFadeTask();
 

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -75,7 +75,6 @@ namespace Game
 
     namespace ObjectFadeAnimation
     {
-        FadeTask fadeTask;
         FadeTask::FadeTask( uint8_t object_, uint32_t objectIndex_, uint32_t animationIndex_, uint32_t fromIndex_, uint32_t toIndex_, uint32_t alpha_, bool fadeOut_,
                             bool fadeIn_, uint8_t objectTileset_ )
             : object( object_ )
@@ -88,6 +87,7 @@ namespace Game
             , fadeIn( fadeIn_ )
             , objectTileset( objectTileset_ )
         {}
+
         FadeTask::FadeTask()
             : object( MP2::OBJ_ZERO )
             , objectIndex( 0 )
@@ -100,6 +100,9 @@ namespace Game
             , objectTileset( 0 )
 
         {}
+
+        // Single instance of FadeTask.
+        FadeTask fadeTask;
     }
 }
 

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -75,7 +75,7 @@ namespace Game
 
     namespace ObjectFadeAnimation
     {
-        FadeTask fadeTask = { MP2::OBJ_ZERO, 0, 0, 0, 0, 0, false, false, 0 };
+        FadeTask fadeTask = {MP2::OBJ_ZERO, 0, 0, 0, 0, 0, false, false, 0};
     }
 }
 
@@ -218,15 +218,15 @@ void Game::ObjectFadeAnimation::StartFadeTask( uint8_t object, uint32_t fromInde
     const uint32_t alpha = fadeOut ? 255u : 0;
     if ( MP2::OBJ_MONSTER == object ) {
         const auto & spriteIndicies = Maps::Tiles::GetMonsterSpriteIndices( fromTile, fromTile.QuantityMonster().GetSpriteIndex() );
-        fadeTask = { object, spriteIndicies.first, spriteIndicies.second, fromIndex, toIndex, alpha, fadeOut, fadeIn, 0 };
+        fadeTask = {object, spriteIndicies.first, spriteIndicies.second, fromIndex, toIndex, alpha, fadeOut, fadeIn, 0};
     }
     else if ( MP2::OBJ_BOAT == object ) {
-        fadeTask = { object, fromTile.GetObjectSpriteIndex(), 0, fromIndex, toIndex, alpha, fadeOut, fadeIn, 0 };
+        fadeTask = {object, fromTile.GetObjectSpriteIndex(), 0, fromIndex, toIndex, alpha, fadeOut, fadeIn, 0};
     }
     else {
         const int icn = MP2::GetICNObject( object );
         const auto animationIndex = ICN::AnimationFrame( icn, fromTile.GetObjectSpriteIndex(), Game::MapsAnimationFrame(), fromTile.GetQuantity2() );
-        fadeTask = { object, fromTile.GetObjectSpriteIndex(), animationIndex, fromIndex, toIndex, alpha, fadeOut, fadeIn, fromTile.GetObjectTileset() }; 
+        fadeTask = {object, fromTile.GetObjectSpriteIndex(), animationIndex, fromIndex, toIndex, alpha, fadeOut, fadeIn, fromTile.GetObjectTileset()};
     }
 }
 

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -26,7 +26,6 @@
 #include <string>
 
 #include "gamedefs.h"
-#include "mp2.h"
 #include "rect.h"
 #include "types.h"
 
@@ -273,31 +272,9 @@ namespace Game
     {
         struct FadeTask
         {
+            FadeTask();
             FadeTask( uint8_t object_, uint32_t objectIndex_, uint32_t animationIndex_, uint32_t fromIndex_, uint32_t toIndex_, uint32_t alpha_, bool fadeOut_,
-                      bool fadeIn_, uint8_t objectTileset_ )
-            {
-                object = object_;
-                objectIndex = objectIndex_;
-                animationIndex = animationIndex_;
-                fromIndex = fromIndex_;
-                toIndex = toIndex_;
-                alpha = alpha_;
-                fadeOut = fadeOut_;
-                fadeIn = fadeIn_;
-                objectTileset = objectTileset_;
-            }
-            FadeTask()
-            {
-                object = MP2::OBJ_ZERO;
-                objectIndex = 0;
-                animationIndex = 0;
-                fromIndex = 0;
-                toIndex = 0;
-                alpha = 0;
-                fadeOut = false;
-                fadeIn = false;
-                objectTileset = 0;
-            }
+                      bool fadeIn_, uint8_t objectTileset_ );
             uint8_t object;
             uint32_t objectIndex;
             uint32_t animationIndex;

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -26,9 +26,9 @@
 #include <string>
 
 #include "gamedefs.h"
+#include "mp2.h"
 #include "rect.h"
 #include "types.h"
-#include "mp2.h"
 
 class Players;
 class Heroes;

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -267,21 +267,10 @@ namespace Game
 
     namespace ObjectFadeAnimation
     {
-        struct Info
-        {
-            Info();
-            Info( u8 object_, u8 index_, s32 tile_, u32 alpha_ = 255u, bool fadeOut = true );
-
-            uint8_t object;
-            uint8_t index;
-            int32_t tile;
-            uint32_t alpha;
-            fheroes2::Size surfaceSize;
-            bool isFadeOut;
-        };
-
-        void Set( const Info & info );
-        Info & Get();
+        using FadeTask = std::tuple<uint8_t, uint32_t, uint32_t, int32_t, int32_t, uint32_t, bool, bool, uint8_t>;
+        FadeTask & GetFadeTask();
+        void StartFadeTask( uint8_t object, int32_t fromTile, int32_t toTile, bool fadeOut, bool fadeIn );
+        void FinishFadeTask();
     }
 
     namespace Editor

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -270,7 +270,7 @@ namespace Game
 
     namespace ObjectFadeAnimation
     {
-        using FadeTask = std::tuple<uint8_t, uint32_t, uint32_t, int32_t, int32_t, uint32_t, bool, bool, uint8_t>;
+        using FadeTask = std::tuple<uint8_t, uint32_t, int32_t, int32_t, int32_t, uint32_t, bool, bool, uint8_t>;
         FadeTask & GetFadeTask();
         void StartFadeTask( uint8_t object, int32_t fromTile, int32_t toTile, bool fadeOut, bool fadeIn );
         void FinishFadeTask();

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -270,9 +270,9 @@ namespace Game
 
     namespace ObjectFadeAnimation
     {
-        using FadeTask = std::tuple<uint8_t, uint32_t, int32_t, int32_t, int32_t, uint32_t, bool, bool, uint8_t>;
+        using FadeTask = std::tuple<uint8_t, uint32_t, int32_t, uint32_t, uint32_t, uint32_t, bool, bool, uint8_t>;
         FadeTask & GetFadeTask();
-        void StartFadeTask( uint8_t object, int32_t fromTile, int32_t toTile, bool fadeOut, bool fadeIn );
+        void StartFadeTask( uint8_t object, uint32_t fromTile, uint32_t toTile, bool fadeOut, bool fadeIn );
         void FinishFadeTask();
     }
 

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -273,15 +273,40 @@ namespace Game
     {
         struct FadeTask
         {
-            uint8_t object = MP2::OBJ_ZERO;
-            uint32_t objectIndex = 0;
-            uint32_t animationIndex = 0;
-            uint32_t fromIndex = 0;
-            uint32_t toIndex = 0;
-            uint32_t alpha = 0;
-            bool fadeOut = false;
-            bool fadeIn = false;
-            uint8_t objectTileset = 0;
+            FadeTask( uint8_t object_, uint32_t objectIndex_, uint32_t animationIndex_, uint32_t fromIndex_, uint32_t toIndex_, uint32_t alpha_, bool fadeOut_,
+                      bool fadeIn_, uint8_t objectTileset_ )
+            {
+                object = object_;
+                objectIndex = objectIndex_;
+                animationIndex = animationIndex_;
+                fromIndex = fromIndex_;
+                toIndex = toIndex_;
+                alpha = alpha_;
+                fadeOut = fadeOut_;
+                fadeIn = fadeIn_;
+                objectTileset = objectTileset_;
+            }
+            FadeTask()
+            {
+                object = MP2::OBJ_ZERO;
+                objectIndex = 0;
+                animationIndex = 0;
+                fromIndex = 0;
+                toIndex = 0;
+                alpha = 0;
+                fadeOut = false;
+                fadeIn = false;
+                objectTileset = 0;
+            }
+            uint8_t object;
+            uint32_t objectIndex;
+            uint32_t animationIndex;
+            uint32_t fromIndex;
+            uint32_t toIndex;
+            uint32_t alpha;
+            bool fadeOut;
+            bool fadeIn;
+            uint8_t objectTileset;
         };
         FadeTask & GetFadeTask();
         void StartFadeTask( uint8_t object, uint32_t fromTile, uint32_t toTile, bool fadeOut, bool fadeIn );

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -28,6 +28,7 @@
 #include "gamedefs.h"
 #include "rect.h"
 #include "types.h"
+#include "mp2.h"
 
 class Players;
 class Heroes;
@@ -272,15 +273,15 @@ namespace Game
     {
         struct FadeTask
         {
-            uint8_t object;
-            uint32_t objectIndex;
-            uint32_t animationIndex;
-            uint32_t fromIndex;
-            uint32_t toIndex;
-            uint32_t alpha;
-            bool fadeOut;
-            bool fadeIn;
-            uint8_t objectTileset;
+            uint8_t object = MP2::OBJ_ZERO;
+            uint32_t objectIndex = 0;
+            uint32_t animationIndex = 0;
+            uint32_t fromIndex = 0;
+            uint32_t toIndex = 0;
+            uint32_t alpha = 0;
+            bool fadeOut = false;
+            bool fadeIn = false;
+            uint8_t objectTileset = 0;
         };
         FadeTask & GetFadeTask();
         void StartFadeTask( uint8_t object, uint32_t fromTile, uint32_t toTile, bool fadeOut, bool fadeIn );

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -273,8 +273,10 @@ namespace Game
         struct FadeTask
         {
             FadeTask();
+
             FadeTask( uint8_t object_, uint32_t objectIndex_, uint32_t animationIndex_, uint32_t fromIndex_, uint32_t toIndex_, uint32_t alpha_, bool fadeOut_,
                       bool fadeIn_, uint8_t objectTileset_ );
+
             uint8_t object;
             uint32_t objectIndex;
             uint32_t animationIndex;
@@ -285,8 +287,11 @@ namespace Game
             bool fadeIn;
             uint8_t objectTileset;
         };
+
         FadeTask & GetFadeTask();
+
         void StartFadeTask( uint8_t object, uint32_t fromTile, uint32_t toTile, bool fadeOut, bool fadeIn );
+
         void FinishFadeTask();
     }
 

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -270,7 +270,18 @@ namespace Game
 
     namespace ObjectFadeAnimation
     {
-        using FadeTask = std::tuple<uint8_t, uint32_t, int32_t, uint32_t, uint32_t, uint32_t, bool, bool, uint8_t>;
+        struct FadeTask
+        {
+            uint8_t object;
+            uint32_t objectIndex;
+            uint32_t animationIndex;
+            uint32_t fromIndex;
+            uint32_t toIndex;
+            uint32_t alpha;
+            bool fadeOut;
+            bool fadeIn;
+            uint8_t objectTileset;
+        };
         FadeTask & GetFadeTask();
         void StartFadeTask( uint8_t object, uint32_t fromTile, uint32_t toTile, bool fadeOut, bool fadeIn );
         void FinishFadeTask();

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <cassert>
 #include <vector>
 
 #ifdef AI
@@ -1022,8 +1023,6 @@ int Interface::Basic::HumanTurn( bool isload )
                             fadeTask.object = MP2::OBJ_ZERO;
                         }
                     }
-
-                    gameArea.SetRedraw();
                 }
                 else if ( fadeTask.fadeIn ) {
                     if ( fadeTask.alpha == 0 ) {
@@ -1041,9 +1040,12 @@ int Interface::Basic::HumanTurn( bool isload )
                         fadeTask.alpha = 255;
                         fadeTask.object = MP2::OBJ_ZERO;
                     }
-
-                    gameArea.SetRedraw();
                 }
+                else {
+                    assert( 0 ); // incorrect fading animation setup!
+                }
+
+                gameArea.SetRedraw();
             }
         }
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1031,7 +1031,7 @@ int Interface::Basic::HumanTurn( bool isload )
                                 tile.setBoat( Direction::RIGHT );
                             }
                         }
-                        if ( fadeTask.alpha < ( 235 ) ) {
+                        if ( fadeTask.alpha < 235 ) {
                             fadeTask.alpha += 20;
                         }
                         else {

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1005,48 +1005,40 @@ int Interface::Basic::HumanTurn( bool isload )
 
         if ( Game::AnimateInfrequentDelay( Game::HEROES_PICKUP_DELAY ) ) {
             auto & fadeTask = Game::ObjectFadeAnimation::GetFadeTask();
-            auto & object = std::get<0>( fadeTask );
-            if ( MP2::OBJ_ZERO != object ) {
-                auto & fadeOut = std::get<6>( fadeTask );
-                if ( fadeOut ) {
-                    auto & alpha = std::get<5>( fadeTask );
-                    if ( alpha > 20 ) {
-                        alpha -= 20;
+            if ( MP2::OBJ_ZERO != fadeTask.object ) {
+                if ( fadeTask.fadeOut ) {
+                    if ( fadeTask.alpha > 20 ) {
+                        fadeTask.alpha -= 20;
                     }
                     else {
-                        fadeOut = false;
-                        alpha = 0;
-                        const auto fromIndex = std::get<3>( fadeTask );
-                        Maps::Tiles & tile = world.GetTiles( fromIndex );
-                        if ( tile.GetObject() == object ) {
+                        fadeTask.fadeOut = false;
+                        fadeTask.alpha = 0;
+                        Maps::Tiles & tile = world.GetTiles( fadeTask.fromIndex );
+                        if ( tile.GetObject() == fadeTask.object ) {
                             tile.RemoveObjectSprite();
                             tile.SetObject( MP2::OBJ_ZERO );
                         }
-                        const auto fadeIn = std::get<7>( fadeTask );
-                        if ( !fadeIn ) {
-                            object = MP2::OBJ_ZERO;
+                        if ( !fadeTask.fadeIn ) {
+                            fadeTask.object = MP2::OBJ_ZERO;
                         }
                     }
                     gameArea.SetRedraw();
                 }
                 else {
-                    auto & fadeIn = std::get<7>( fadeTask );
-                    if ( fadeIn ) {
-                        auto & alpha = std::get<5>( fadeTask );
-                        if ( alpha == 0 ) {
-                            const auto toIndex = std::get<4>( fadeTask );
-                            Maps::Tiles & tile = world.GetTiles( toIndex );
-                            if ( MP2::OBJ_BOAT == object ) {
+                    if ( fadeTask.fadeIn ) {
+                        if ( fadeTask.alpha == 0 ) {
+                            Maps::Tiles & tile = world.GetTiles( fadeTask.toIndex );
+                            if ( MP2::OBJ_BOAT == fadeTask.object ) {
                                 tile.setBoat( Direction::RIGHT );
                             }
                         }
-                        if ( alpha < ( 255 - 20 ) ) {
-                            alpha += 20;
+                        if ( fadeTask.alpha < ( 235 ) ) {
+                            fadeTask.alpha += 20;
                         }
                         else {
-                            fadeIn = false;
-                            alpha = 255;
-                            object = MP2::OBJ_ZERO;
+                            fadeTask.fadeIn = false;
+                            fadeTask.alpha = 255;
+                            fadeTask.object = MP2::OBJ_ZERO;
                         }
                         gameArea.SetRedraw();
                     }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -21,8 +21,8 @@
  ***************************************************************************/
 
 #include <algorithm>
-#include <vector>
 #include <tuple>
+#include <vector>
 
 #ifdef AI
 #undef AI

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1017,30 +1017,32 @@ int Interface::Basic::HumanTurn( bool isload )
                             tile.RemoveObjectSprite();
                             tile.SetObject( MP2::OBJ_ZERO );
                         }
+
                         if ( !fadeTask.fadeIn ) {
                             fadeTask.object = MP2::OBJ_ZERO;
                         }
                     }
+
                     gameArea.SetRedraw();
                 }
-                else {
-                    if ( fadeTask.fadeIn ) {
-                        if ( fadeTask.alpha == 0 ) {
-                            Maps::Tiles & tile = world.GetTiles( fadeTask.toIndex );
-                            if ( MP2::OBJ_BOAT == fadeTask.object ) {
-                                tile.setBoat( Direction::RIGHT );
-                            }
+                else if ( fadeTask.fadeIn ) {
+                    if ( fadeTask.alpha == 0 ) {
+                        Maps::Tiles & tile = world.GetTiles( fadeTask.toIndex );
+                        if ( MP2::OBJ_BOAT == fadeTask.object ) {
+                            tile.setBoat( Direction::RIGHT );
                         }
-                        if ( fadeTask.alpha < 235 ) {
-                            fadeTask.alpha += 20;
-                        }
-                        else {
-                            fadeTask.fadeIn = false;
-                            fadeTask.alpha = 255;
-                            fadeTask.object = MP2::OBJ_ZERO;
-                        }
-                        gameArea.SetRedraw();
                     }
+
+                    if ( fadeTask.alpha < 235 ) {
+                        fadeTask.alpha += 20;
+                    }
+                    else {
+                        fadeTask.fadeIn = false;
+                        fadeTask.alpha = 255;
+                        fadeTask.object = MP2::OBJ_ZERO;
+                    }
+
+                    gameArea.SetRedraw();
                 }
             }
         }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -21,7 +21,6 @@
  ***************************************************************************/
 
 #include <algorithm>
-#include <tuple>
 #include <vector>
 
 #ifdef AI

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -192,6 +192,34 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                 tile.RedrawMonstersAndBoat( dst, tileROI );
             }
         }
+
+        // object fade in/fade out animation for monster and boat only
+        const Game::ObjectFadeAnimation::Info & fadeInfo = Game::ObjectFadeAnimation::Get();
+        if ( fadeInfo.object != MP2::OBJ_ZERO ) {
+            const Point & mp = Maps::GetPoint( fadeInfo.tile );
+            const int icn = MP2::GetICNObject( fadeInfo.object );
+
+            if ( icn == ICN::MONS32 ) {
+                const std::pair<int, int> monsterIndicies = Maps::Tiles::GetMonsterSpriteIndices( world.GetTiles( fadeInfo.tile ), fadeInfo.index );
+
+                // base monster sprite
+                if ( monsterIndicies.first >= 0 ) {
+                    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::MINIMON, monsterIndicies.first );
+                    BlitOnTile( dst, sprite, sprite.x() + 16, sprite.y() + TILEWIDTH, mp, false, fadeInfo.alpha );
+                }
+                // animated monster part
+                if ( monsterIndicies.second >= 0 ) {
+                    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::MINIMON, monsterIndicies.second );
+                    BlitOnTile( dst, sprite, sprite.x() + 16, sprite.y() + TILEWIDTH, mp, false, fadeInfo.alpha );
+                }
+            }
+            else if ( fadeInfo.object == MP2::OBJ_BOAT ) {
+                const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::BOAT32, fadeInfo.index );
+                BlitOnTile( dst, sprite, sprite.x(), sprite.y() + TILEWIDTH - 11, mp, false, fadeInfo.alpha );
+                const fheroes2::Sprite & spriteShadow = fheroes2::AGG::GetICN( ICN::BOATSHAD, fadeInfo.index );
+                BlitOnTile( dst, spriteShadow, spriteShadow.x(), spriteShadow.y() + TILEWIDTH - 11, mp, false, fadeInfo.alpha );
+            }
+        }
     }
 
     // top layer
@@ -230,25 +258,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
         const Point & mp = Maps::GetPoint( fadeInfo.tile );
         const int icn = MP2::GetICNObject( fadeInfo.object );
 
-        if ( icn == ICN::MONS32 ) {
-            const std::pair<int, int> monsterIndicies = Maps::Tiles::GetMonsterSpriteIndices( world.GetTiles( fadeInfo.tile ), fadeInfo.index );
-
-            // base monster sprite
-            if ( monsterIndicies.first >= 0 ) {
-                const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::MINIMON, monsterIndicies.first );
-                BlitOnTile( dst, sprite, sprite.x() + 16, sprite.y() + TILEWIDTH, mp, false, fadeInfo.alpha );
-            }
-            // animated monster part
-            if ( monsterIndicies.second >= 0 ) {
-                const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::MINIMON, monsterIndicies.second );
-                BlitOnTile( dst, sprite, sprite.x() + 16, sprite.y() + TILEWIDTH, mp, false, fadeInfo.alpha );
-            }
-        }
-        else if ( fadeInfo.object == MP2::OBJ_BOAT ) {
-            const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::BOAT32, fadeInfo.index );
-            BlitOnTile( dst, sprite, sprite.x(), sprite.y() + TILEWIDTH - 11, mp, false, fadeInfo.alpha );
-        }
-        else {
+        if ( icn != ICN::MONS32 && fadeInfo.object != MP2::OBJ_BOAT ) {
             const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icn, fadeInfo.index );
             BlitOnTile( dst, sprite, sprite.x(), sprite.y(), mp, false, fadeInfo.alpha );
         }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -199,27 +199,19 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
     }
 
     const auto & fadeTask = Game::ObjectFadeAnimation::GetFadeTask();
-    const auto object = std::get<0>( fadeTask );
-    const auto fadeOut = std::get<6>( fadeTask );
 
     // fade out animation for objects only
-    if ( drawBottom && fadeOut && MP2::OBJ_ZERO != object && MP2::OBJ_BOAT != object && MP2::OBJ_MONSTER != object ) {
-        const auto objectIndex = std::get<1>( fadeTask );
-        const auto animationIndex = std::get<2>( fadeTask );
-        const auto alpha = std::get<5>( fadeTask );
+    if ( drawBottom && fadeTask.fadeOut && MP2::OBJ_ZERO != fadeTask.object && MP2::OBJ_BOAT != fadeTask.object && MP2::OBJ_MONSTER != fadeTask.object ) {
+        const int icn = MP2::GetICNObject( fadeTask.objectTileset );
+        const Point & mp = Maps::GetPoint( fadeTask.fromIndex );
 
-        const auto objectTileset = std::get<8>( fadeTask );
-        const int icn = MP2::GetICNObject( objectTileset );
-        const auto fromIndex = std::get<3>( fadeTask );
-        const Point & mp = Maps::GetPoint( fromIndex );
-
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icn, objectIndex );
-        BlitOnTile( dst, sprite, sprite.x(), sprite.y(), mp, false, alpha );
+        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icn, fadeTask.objectIndex );
+        BlitOnTile( dst, sprite, sprite.x(), sprite.y(), mp, false, fadeTask.alpha );
 
         // possible animation
-        if ( animationIndex ) {
-            const fheroes2::Sprite & animationSprite = fheroes2::AGG::GetICN( icn, animationIndex );
-            BlitOnTile( dst, animationSprite, animationSprite.x(), animationSprite.y(), mp, false, alpha );
+        if ( fadeTask.animationIndex ) {
+            const fheroes2::Sprite & animationSprite = fheroes2::AGG::GetICN( icn, fadeTask.animationIndex );
+            BlitOnTile( dst, animationSprite, animationSprite.x(), animationSprite.y(), mp, false, fadeTask.alpha );
         }
     }
 
@@ -233,19 +225,14 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
         }
 
         // fade out animation for monsters only
-        if ( MP2::OBJ_MONSTER == object && fadeOut ) {
-            const auto fromIndex = std::get<3>( fadeTask );
-            const Point & mp = Maps::GetPoint( fromIndex );
-            const auto objectIndex = std::get<1>( fadeTask );
-            const auto animationIndex = std::get<2>( fadeTask );
-            const auto alpha = std::get<5>( fadeTask );
+        if ( MP2::OBJ_MONSTER == fadeTask.object && fadeTask.fadeOut ) {
+            const Point & mp = Maps::GetPoint( fadeTask.fromIndex );
+            const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::MINIMON, fadeTask.objectIndex );
+            BlitOnTile( dst, sprite, sprite.x() + 16, sprite.y() + TILEWIDTH, mp, false, fadeTask.alpha );
 
-            const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::MINIMON, objectIndex );
-            BlitOnTile( dst, sprite, sprite.x() + 16, sprite.y() + TILEWIDTH, mp, false, alpha );
-
-            if ( animationIndex ) {
-                const fheroes2::Sprite & animatedSprite = fheroes2::AGG::GetICN( ICN::MINIMON, animationIndex );
-                BlitOnTile( dst, animatedSprite, animatedSprite.x() + 16, animatedSprite.y() + TILEWIDTH, mp, false, alpha );
+            if ( fadeTask.animationIndex ) {
+                const fheroes2::Sprite & animatedSprite = fheroes2::AGG::GetICN( ICN::MINIMON, fadeTask.animationIndex );
+                BlitOnTile( dst, animatedSprite, animatedSprite.x() + 16, animatedSprite.y() + TILEWIDTH, mp, false, fadeTask.alpha );
             }
         }
     }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -237,14 +237,14 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
             const auto fromIndex = std::get<3>( fadeTask );
             const Point & mp = Maps::GetPoint( fromIndex );
             const auto objectIndex = std::get<1>( fadeTask );
-            const auto animatedIndex = std::get<2>( fadeTask );
+            const auto animationIndex = std::get<2>( fadeTask );
             const auto alpha = std::get<5>( fadeTask );
 
             const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::MINIMON, objectIndex );
             BlitOnTile( dst, sprite, sprite.x() + 16, sprite.y() + TILEWIDTH, mp, false, alpha );
 
-            if ( animatedIndex != -1 ) {
-                const fheroes2::Sprite & animatedSprite = fheroes2::AGG::GetICN( ICN::MINIMON, animatedIndex );
+            if ( animationIndex ) {
+                const fheroes2::Sprite & animatedSprite = fheroes2::AGG::GetICN( ICN::MINIMON, animationIndex );
                 BlitOnTile( dst, animatedSprite, animatedSprite.x() + 16, animatedSprite.y() + TILEWIDTH, mp, false, alpha );
             }
         }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -309,10 +309,8 @@ void BattleLose( Heroes & hero, const Battle::Result & res, bool attacker, int c
 
 void AnimationRemoveObject( const Maps::Tiles & tile )
 {
-    if ( tile.GetObject() == MP2::OBJ_ZERO )
-        return;
-
-    Game::ObjectFadeAnimation::Set( Game::ObjectFadeAnimation::Info( tile.GetObjectTileset(), tile.GetObjectSpriteIndex(), tile.GetIndex() ) );
+    if ( tile.GetObject() != MP2::OBJ_ZERO )
+        Game::ObjectFadeAnimation::StartFadeTask( tile.GetObject(), tile.GetIndex(), -1, true, false );
 }
 
 void RecruitMonsterFromTile( Heroes & hero, Maps::Tiles & tile, const std::string & msg, const Troop & troop, bool remove )

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -309,8 +309,10 @@ void BattleLose( Heroes & hero, const Battle::Result & res, bool attacker, int c
 
 void AnimationRemoveObject( const Maps::Tiles & tile )
 {
-    if ( tile.GetObject() != MP2::OBJ_ZERO )
-        Game::ObjectFadeAnimation::StartFadeTask( tile.GetObject(), tile.GetIndex(), -1, true, false );
+    if ( tile.GetObject() == MP2::OBJ_ZERO )
+        return;
+
+    Game::ObjectFadeAnimation::StartFadeTask( tile.GetObject(), tile.GetIndex(), -1, true, false );
 }
 
 void RecruitMonsterFromTile( Heroes & hero, Maps::Tiles & tile, const std::string & msg, const Troop & troop, bool remove )

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -391,32 +391,13 @@ bool ActionSpellSummonBoat( const Heroes & hero )
         return false;
     }
 
-    uint32_t chance = 0;
-
-    switch ( hero.GetLevelSkill( Skill::Secondary::WISDOM ) ) {
-    case Skill::Level::BASIC:
-        chance = 50;
-        break;
-    case Skill::Level::ADVANCED:
-        chance = 75;
-        break;
-    case Skill::Level::EXPERT:
-        chance = 100;
-        break;
-    default:
-        chance = 30;
-        break;
-    }
-
-    if ( Rand::Get( 1, 100 ) <= chance ) {
-        const MapsIndexes & boats = Maps::GetObjectPositions( center, MP2::OBJ_BOAT, false );
-        for ( auto it = boats.cbegin(); it != boats.cend(); ++it ) {
-            if ( Maps::isValidAbsIndex( *it ) ) {
-                const uint32_t distance = Maps::GetApproximateDistance( *it, hero.GetIndex() );
-                if ( distance > 3 ) {
-                    Game::ObjectFadeAnimation::StartFadeTask( MP2::OBJ_BOAT, *it, dst_water, true, true );
-                    return true;
-                }
+    const MapsIndexes & boats = Maps::GetObjectPositions( center, MP2::OBJ_BOAT, false );
+    for ( auto it = boats.cbegin(); it != boats.cend(); ++it ) {
+        if ( Maps::isValidAbsIndex( *it ) ) {
+            const uint32_t distance = Maps::GetApproximateDistance( *it, hero.GetIndex() );
+            if ( distance > 1 ) {
+                Game::ObjectFadeAnimation::StartFadeTask( MP2::OBJ_BOAT, *it, dst_water, true, true );
+                return true;
             }
         }
     }

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -56,7 +56,7 @@ bool ActionSpellViewTowns( const Heroes & );
 bool ActionSpellViewHeroes( const Heroes & );
 bool ActionSpellViewAll( const Heroes & );
 bool ActionSpellIdentifyHero( const Heroes & );
-bool ActionSpellSummonBoat( const Heroes & hero );
+bool ActionSpellSummonBoat( const Heroes & );
 bool ActionSpellDimensionDoor( Heroes & );
 bool ActionSpellTownGate( Heroes & );
 bool ActionSpellTownPortal( Heroes & );
@@ -363,11 +363,11 @@ bool ActionSpellSummonBoat( const Heroes & hero )
         return false;
     }
 
-    const int32_t center = hero.GetIndex();
+    const s32 center = hero.GetIndex();
     const Point & centerPoint = Maps::GetPoint( center );
 
     // find water
-    int32_t dst_water = -1;
+    s32 dst_water = -1;
     MapsIndexes freeTiles = Maps::ScanAroundObject( center, MP2::OBJ_ZERO );
     std::sort( freeTiles.begin(), freeTiles.end(), [&centerPoint]( const int32_t left, const int32_t right ) {
         const Point & leftPoint = Maps::GetPoint( left );
@@ -379,7 +379,7 @@ bool ActionSpellSummonBoat( const Heroes & hero )
 
         return ( leftDiffX * leftDiffX + leftDiffY * leftDiffY ) < ( rightDiffX * rightDiffX + rightDiffY * rightDiffY );
     } );
-    for ( auto it = freeTiles.cbegin(); it != freeTiles.cend(); ++it ) {
+    for ( MapsIndexes::const_iterator it = freeTiles.begin(); it != freeTiles.end(); ++it ) {
         if ( world.GetTiles( *it ).isWater() ) {
             dst_water = *it;
             break;
@@ -391,14 +391,32 @@ bool ActionSpellSummonBoat( const Heroes & hero )
         return false;
     }
 
+    u32 chance = 0;
+
+    switch ( hero.GetLevelSkill( Skill::Secondary::WISDOM ) ) {
+    case Skill::Level::BASIC:
+        chance = 50;
+        break;
+    case Skill::Level::ADVANCED:
+        chance = 75;
+        break;
+    case Skill::Level::EXPERT:
+        chance = 100;
+        break;
+    default:
+        chance = 30;
+        break;
+    }
+
     const MapsIndexes & boats = Maps::GetObjectPositions( center, MP2::OBJ_BOAT, false );
-    for ( auto it = boats.cbegin(); it != boats.cend(); ++it ) {
-        if ( Maps::isValidAbsIndex( *it ) ) {
-            const uint32_t distance = Maps::GetApproximateDistance( *it, hero.GetIndex() );
-            if ( distance > 1 ) {
-                Game::ObjectFadeAnimation::StartFadeTask( MP2::OBJ_BOAT, *it, dst_water, true, true );
+    for ( size_t i = 0; i < boats.size(); ++i ) {
+        const s32 boat = boats[i];
+        if ( Maps::isValidAbsIndex( boat ) ) {
+            if ( Rand::Get( 1, 100 ) <= chance ) {
+                Game::ObjectFadeAnimation::StartFadeTask( MP2::OBJ_BOAT, boat, dst_water, true, true );
                 return true;
             }
+            break;
         }
     }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1553,13 +1553,8 @@ void Maps::Tiles::RedrawBoat( fheroes2::Image & dst, const Rect & visibleTileROI
         const uint32_t spriteIndex = ( objectIndex == 255 ) ? 18 : objectIndex;
 
         const auto & fadeTask = Game::ObjectFadeAnimation::GetFadeTask();
-        //const auto object = std::get<0>( fadeTask );
-        //const auto fadeOut = std::get<6>( fadeTask );
-        //const auto from = std::get<3>( fadeTask );
-        //const auto fadeIn = std::get<7>( fadeTask );
-        //const auto to = std::get<4>( fadeTask );
-        const auto alpha
-            = ( MP2::OBJ_BOAT == fadeTask.object && ( ( fadeTask.fadeOut && fadeTask.fromIndex == maps_index ) || ( fadeTask.fadeIn && fadeTask.toIndex == maps_index ) ) )
+        const auto alpha = ( MP2::OBJ_BOAT == fadeTask.object
+                             && ( ( fadeTask.fadeOut && fadeTask.fromIndex == maps_index ) || ( fadeTask.fadeIn && fadeTask.toIndex == maps_index ) ) )
                                ? fadeTask.alpha
                                : 255;
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1549,12 +1549,21 @@ void Maps::Tiles::RedrawBoat( fheroes2::Image & dst, const Rect & visibleTileROI
     if ( visibleTileROI & mp ) {
         const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
         const uint32_t spriteIndex = ( objectIndex == 255 ) ? 18 : objectIndex;
+
+        const auto & fadeTask = Game::ObjectFadeAnimation::GetFadeTask();
+        const auto object = std::get<0>( fadeTask );
+        const auto fadeOut = std::get<6>( fadeTask );
+        const auto from = std::get<3>( fadeTask );
+        const auto fadeIn = std::get<7>( fadeTask );
+        const auto to = std::get<4>( fadeTask );
+        const auto alpha = ( MP2::OBJ_BOAT == object && ( ( fadeOut && from == maps_index ) || ( fadeIn && to == maps_index ) ) ) ? std::get<5>( fadeTask ) : 255;
+
         if ( withShadow ) {
             const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::BOATSHAD, spriteIndex % 128 );
-            area.BlitOnTile( dst, sprite, sprite.x(), TILEWIDTH + sprite.y() - 11, mp, ( spriteIndex > 128 ) );
+            area.BlitOnTile( dst, sprite, sprite.x(), TILEWIDTH + sprite.y() - 11, mp, ( spriteIndex > 128 ), alpha );
         }
         const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::BOAT32, spriteIndex % 128 );
-        area.BlitOnTile( dst, sprite, sprite.x(), TILEWIDTH + sprite.y() - 11, mp, ( spriteIndex > 128 ) );
+        area.BlitOnTile( dst, sprite, sprite.x(), TILEWIDTH + sprite.y() - 11, mp, ( spriteIndex > 128 ), alpha );
     }
 }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1554,9 +1554,9 @@ void Maps::Tiles::RedrawBoat( fheroes2::Image & dst, const Rect & visibleTileROI
 
         const Game::ObjectFadeAnimation::FadeTask & fadeTask = Game::ObjectFadeAnimation::GetFadeTask();
         const uint32_t alpha = ( MP2::OBJ_BOAT == fadeTask.object
-                             && ( ( fadeTask.fadeOut && fadeTask.fromIndex == maps_index ) || ( fadeTask.fadeIn && fadeTask.toIndex == maps_index ) ) )
-                               ? fadeTask.alpha
-                               : 255;
+                                 && ( ( fadeTask.fadeOut && fadeTask.fromIndex == maps_index ) || ( fadeTask.fadeIn && fadeTask.toIndex == maps_index ) ) )
+                                   ? fadeTask.alpha
+                                   : 255;
 
         if ( withShadow ) {
             const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::BOATSHAD, spriteIndex % 128 );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1533,7 +1533,7 @@ void Maps::Tiles::RedrawMonster( fheroes2::Image & dst, const Rect & visibleTile
     const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
 
     const Monster & monster = QuantityMonster();
-    const std::pair<int, int> spriteIndicies = GetMonsterSpriteIndices( *this, monster.GetSpriteIndex() );
+    const std::pair<uint32_t, uint32_t> spriteIndicies = GetMonsterSpriteIndices( *this, monster.GetSpriteIndex() );
 
     const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::MINIMON, spriteIndicies.first );
     area.BlitOnTile( dst, sprite, sprite.x() + 16, sprite.y() + TILEWIDTH, mp );
@@ -1552,8 +1552,8 @@ void Maps::Tiles::RedrawBoat( fheroes2::Image & dst, const Rect & visibleTileROI
         const Interface::GameArea & area = Interface::Basic::Get().GetGameArea();
         const uint32_t spriteIndex = ( objectIndex == 255 ) ? 18 : objectIndex;
 
-        const auto & fadeTask = Game::ObjectFadeAnimation::GetFadeTask();
-        const auto alpha = ( MP2::OBJ_BOAT == fadeTask.object
+        const Game::ObjectFadeAnimation::FadeTask & fadeTask = Game::ObjectFadeAnimation::GetFadeTask();
+        const uint32_t alpha = ( MP2::OBJ_BOAT == fadeTask.object
                              && ( ( fadeTask.fadeOut && fadeTask.fromIndex == maps_index ) || ( fadeTask.fadeIn && fadeTask.toIndex == maps_index ) ) )
                                ? fadeTask.alpha
                                : 255;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1538,7 +1538,7 @@ void Maps::Tiles::RedrawMonster( fheroes2::Image & dst, const Rect & visibleTile
     const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::MINIMON, spriteIndicies.first );
     area.BlitOnTile( dst, sprite, sprite.x() + 16, sprite.y() + TILEWIDTH, mp );
 
-    if ( spriteIndicies.second != -1 ) {
+    if ( spriteIndicies.second ) {
         const fheroes2::Sprite & animatedSprite = fheroes2::AGG::GetICN( ICN::MINIMON, spriteIndicies.second );
         area.BlitOnTile( dst, animatedSprite, animatedSprite.x() + 16, animatedSprite.y() + TILEWIDTH, mp );
     }
@@ -2314,7 +2314,7 @@ void Maps::Tiles::UpdateRNDResourceSprite( Tiles & tile )
     }
 }
 
-std::pair<int, int> Maps::Tiles::GetMonsterSpriteIndices( const Tiles & tile, uint32_t monsterIndex )
+std::pair<uint32_t, uint32_t> Maps::Tiles::GetMonsterSpriteIndices( const Tiles & tile, uint32_t monsterIndex )
 {
     const int tileIndex = tile.GetIndex();
     int attackerIndex = -1;
@@ -2334,7 +2334,7 @@ std::pair<int, int> Maps::Tiles::GetMonsterSpriteIndices( const Tiles & tile, ui
         }
     }
 
-    std::pair<int, int> spriteIndices( monsterIndex * 9, -1 );
+    std::pair<uint32_t, uint32_t> spriteIndices( monsterIndex * 9, 0 );
 
     // draw attack sprite
     if ( attackerIndex != -1 && !Settings::Get().ExtWorldOnlyFirstMonsterAttack() ) {

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1553,12 +1553,15 @@ void Maps::Tiles::RedrawBoat( fheroes2::Image & dst, const Rect & visibleTileROI
         const uint32_t spriteIndex = ( objectIndex == 255 ) ? 18 : objectIndex;
 
         const auto & fadeTask = Game::ObjectFadeAnimation::GetFadeTask();
-        const auto object = std::get<0>( fadeTask );
-        const auto fadeOut = std::get<6>( fadeTask );
-        const auto from = std::get<3>( fadeTask );
-        const auto fadeIn = std::get<7>( fadeTask );
-        const auto to = std::get<4>( fadeTask );
-        const auto alpha = ( MP2::OBJ_BOAT == object && ( ( fadeOut && from == maps_index ) || ( fadeIn && to == maps_index ) ) ) ? std::get<5>( fadeTask ) : 255;
+        //const auto object = std::get<0>( fadeTask );
+        //const auto fadeOut = std::get<6>( fadeTask );
+        //const auto from = std::get<3>( fadeTask );
+        //const auto fadeIn = std::get<7>( fadeTask );
+        //const auto to = std::get<4>( fadeTask );
+        const auto alpha
+            = ( MP2::OBJ_BOAT == fadeTask.object && ( ( fadeTask.fadeOut && fadeTask.fromIndex == maps_index ) || ( fadeTask.fadeIn && fadeTask.toIndex == maps_index ) ) )
+                               ? fadeTask.alpha
+                               : 255;
 
         if ( withShadow ) {
             const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::BOATSHAD, spriteIndex % 128 );

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -265,7 +265,7 @@ namespace Maps
         static void UpdateAbandoneMineRightSprite( uint8_t & tileset, uint8_t & index );
         static int GetPassable( uint32_t tileset, uint32_t index );
         static std::pair<int, int> ColorRaceFromHeroSprite( uint32_t heroSpriteIndex );
-        static std::pair<int, int> GetMonsterSpriteIndices( const Tiles & tile, uint32_t monsterIndex );
+        static std::pair<uint32_t, uint32_t> GetMonsterSpriteIndices( const Tiles & tile, uint32_t monsterIndex );
         static void PlaceMonsterOnTile( Tiles &, const Monster &, u32 );
         static void UpdateAbandoneMineSprite( Tiles & );
         static void FixedPreload( Tiles & );


### PR DESCRIPTION
Should fix #2441 and #2442
Also we should draw animate for monsters and boats only if `drawMonstersAndBoats == true`, also we should draw animate for monsters and boats before redraw top, because boat have long shadow.