### PR TITLE
Add a separate option for displaying terrain penalty.

### DIFF
--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -300,25 +300,27 @@ std::string ShowBarrierTentInfo( const Maps::Tiles & tile, const Kingdom & kingd
     return str;
 }
 
-std::string ShowGroundInfo( const Maps::Tiles & tile, bool showVisitedOption, const Heroes * hero )
+std::string ShowGroundInfo( const Maps::Tiles & tile, bool showVisitedOption, bool showTerrainPenaltyOption, const Heroes * hero )
 {
     std::string str = tile.isRoad() ? _( "Road" ) : Maps::Ground::String( tile.GetGround() );
 
     if ( showVisitedOption && hero ) {
         int dir = Maps::GetDirection( hero->GetIndex(), tile.GetIndex() );
         if ( dir != Direction::UNKNOWN ) {
-            uint32_t cost = tile.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( tile, hero->GetLevelSkill( Skill::Secondary::PATHFINDING ) );
-
             if ( tile.GoodForUltimateArtifact( hero->GetColor() ) ) {
                 str.append( "\n" );
                 str.append( _( "(digging ok)" ) );
             }
+        }
+    }
 
-            if ( cost > 0 ) {
-                str.append( "\n" );
-                str.append( _( "penalty: %{cost}" ) );
-                StringReplace( str, "%{cost}", cost );
-            }
+    if ( showTerrainPenaltyOption && hero ) {
+        uint32_t cost = tile.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( tile, hero->GetLevelSkill( Skill::Secondary::PATHFINDING ) );
+
+        if ( cost > 0 ) {
+            str.append( "\n" );
+            str.append( _( "penalty: %{cost}" ) );
+            StringReplace( str, "%{cost}", cost );
         }
     }
 
@@ -448,6 +450,7 @@ void Dialog::QuickInfo( const Maps::Tiles & tile )
     const uint32_t scoutingLevelForTile = isVisibleFromCrystalBall ? static_cast<int>( Skill::Level::EXPERT ) : GetHeroScoutingLevelForTile( from_hero, tile.GetIndex() );
 
     const bool showVisitedOption = settings.ExtWorldShowVisitedContent();
+    const bool showTerrainPenaltyOption = settings.ExtWorldShowTerrainPenalty();
     const bool extendedScoutingOption = settings.ExtWorldScouteExtended();
 
     if ( tile.isFog( settings.CurrentColor() ) )
@@ -465,7 +468,7 @@ void Dialog::QuickInfo( const Maps::Tiles & tile )
 
         case MP2::OBJ_EVENT:
         case MP2::OBJ_ZERO:
-            name_object = ShowGroundInfo( tile, showVisitedOption, from_hero );
+            name_object = ShowGroundInfo( tile, showVisitedOption, showTerrainPenaltyOption, from_hero );
             break;
 
         case MP2::OBJ_DERELICTSHIP:

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -315,7 +315,7 @@ std::string ShowGroundInfo( const Maps::Tiles & tile, bool showVisitedOption, bo
     }
 
     if ( showTerrainPenaltyOption && hero ) {
-        uint32_t cost = tile.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( tile, hero->GetLevelSkill( Skill::Secondary::PATHFINDING ) );
+        const uint32_t cost = tile.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( tile, hero->GetLevelSkill( Skill::Secondary::PATHFINDING ) );
 
         if ( cost > 0 ) {
             str.append( "\n" );

--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -174,6 +174,7 @@ void Dialog::ExtSettings( bool readonly )
 
     states.push_back( Settings::GAME_CONTINUE_AFTER_VICTORY );
     states.push_back( Settings::WORLD_SHOW_VISITED_CONTENT );
+    states.push_back( Settings::WORLD_SHOW_TERRAIN_PENALTY );
     states.push_back( Settings::WORLD_ABANDONED_MINE_RANDOM );
     states.push_back( Settings::WORLD_ALLOW_SET_GUARDIAN );
     states.push_back( Settings::WORLD_EXT_OBJECTS_CAPTURED );

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -198,6 +198,10 @@ const settings_t settingsFHeroes2[] = {
         _( "world: show visited content from objects" ),
     },
     {
+        Settings::WORLD_SHOW_TERRAIN_PENALTY,
+        _( "world: show terrain penalty" ),
+    },
+    {
         Settings::WORLD_SCOUTING_EXTENDED,
         _( "world: scouting skill show extended content info" ),
     },
@@ -1567,6 +1571,11 @@ bool Settings::ExtCastleAllowGuardians( void ) const
 bool Settings::ExtWorldShowVisitedContent( void ) const
 {
     return ExtModes( WORLD_SHOW_VISITED_CONTENT );
+}
+
+bool Settings::ExtWorldShowTerrainPenalty( void ) const
+{
+    return ExtModes( WORLD_SHOW_TERRAIN_PENALTY );
 }
 
 bool Settings::ExtWorldScouteExtended( void ) const

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -1573,7 +1573,7 @@ bool Settings::ExtWorldShowVisitedContent( void ) const
     return ExtModes( WORLD_SHOW_VISITED_CONTENT );
 }
 
-bool Settings::ExtWorldShowTerrainPenalty( void ) const
+bool Settings::ExtWorldShowTerrainPenalty() const
 {
     return ExtModes( WORLD_SHOW_TERRAIN_PENALTY );
 }

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -149,7 +149,8 @@ public:
         WORLD_BAN_PLAGUES = 0x20000800,
         UNIONS_ALLOW_HERO_MEETINGS = 0x20001000,
         UNIONS_ALLOW_CASTLE_VISITING = 0x20002000,
-        // UNUSED = 0x20004000,
+        WORLD_SHOW_TERRAIN_PENALTY = 0x20004000,
+        // UNUSED = 0x20008000,
         WORLD_BAN_MONTHOF_MONSTERS = 0x20010000,
         HEROES_TRANSCRIBING_SCROLLS = 0x20020000,
         WORLD_NEW_VERSION_WEEKOF = 0x20040000,
@@ -259,6 +260,7 @@ public:
     bool ExtUnionsAllowCastleVisiting( void ) const;
     bool ExtUnionsAllowHeroesMeetings( void ) const;
     bool ExtWorldShowVisitedContent( void ) const;
+    bool ExtWorldShowTerrainPenalty( void ) const;
     bool ExtWorldScouteExtended( void ) const;
     bool ExtWorldAbandonedMineRandom( void ) const;
     bool ExtWorldAllowSetGuardian( void ) const;

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -260,7 +260,7 @@ public:
     bool ExtUnionsAllowCastleVisiting( void ) const;
     bool ExtUnionsAllowHeroesMeetings( void ) const;
     bool ExtWorldShowVisitedContent( void ) const;
-    bool ExtWorldShowTerrainPenalty( void ) const;
+    bool ExtWorldShowTerrainPenalty() const;
     bool ExtWorldScouteExtended( void ) const;
     bool ExtWorldAbandonedMineRandom( void ) const;
     bool ExtWorldAllowSetGuardian( void ) const;


### PR DESCRIPTION
As byproduct the penalty information shown for all empty terrain tiles, not only neighborgoud tiles for currently selected hero.
See #2575 