### PR TITLE
Reset hero direction when recruiting

### DIFF
--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -776,6 +776,7 @@ bool Heroes::Recruit( int cl, const Point & pt )
         SetColor( cl );
         killer_color.SetColor( Color::NONE );
         SetCenter( pt );
+        setDirection( Direction::RIGHT );
         if ( !Modes( SAVE_MP_POINTS ) )
             move_point = GetMaxMovePoints();
         MovePointsScaleFixed();


### PR DESCRIPTION
Fixes #2417

I noticed the method for setting direction does not follow the naming convention - it's used only in few places, so I fixed it as well.