### PR TITLE
Restore cursor theme after HeroDialog or CastleDialog

### DIFF
--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1077,8 +1077,10 @@ void Interface::Basic::MouseCursorAreaClickLeft( const int32_t index_maps )
                 SetFocus( to_hero );
                 RedrawFocus();
             }
-            else
+            else {
                 Game::OpenHeroesDialog( *to_hero, true, true );
+                Cursor::Get().SetThemes( Cursor::HEROES );
+            }
         }
     } break;
 
@@ -1099,6 +1101,7 @@ void Interface::Basic::MouseCursorAreaClickLeft( const int32_t index_maps )
         }
         else {
             Game::OpenCastleDialog( *to_castle );
+            Cursor::Get().SetThemes( Cursor::CASTLE );
         }
     } break;
     case Cursor::FIGHT:


### PR DESCRIPTION
These dialogs implement their own event processing (cursor theme resets
immediately), however after closing those dialogs the other event
queues might not expect changed cursor theme and keep using the dialog
cursor.

This happens in following situation:

1. On the strategic map, hover over your hero (cursor should change to
   "helmet cursor").
2. Enter the Hero Dialog via left-click.
3. Without moving cursor, leave the Hero Dialog using escape key.

The cursor on the strategic map stays as "arrow" cursor set by the dialog
instead of resetting back to the "helmet" cursor.  Consequently, left
click will not open the Hero dialog any more until user moves it to
point to another tile and then back again to point to the hero.

Same bug happens after opening/leaving the Castle dialog.

There are two alternative fixes possible:

- Manually reinitialize cursor state in the end of
  Interface::GameArea::QueueEventProcessing method (but it complicates
  the code without giving much benefit).
- Placing gameArea.SetUpdateCursor() after
  gameArea.QueueEventProcessing() in Interface::Basic::HumanTurn method
  (but it somewhat defeats the purpose of lazily updating the cursor
  theme).