### PR TITLE
Put needed DLLs for x86 Windows build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,9 +46,9 @@ install:
   - cd C:\projects\fheroes2
 
 after_build:
+  - cmd: cd C:\projects\fheroes2\build\%platform%\%configuration%
   - cmd: if "%platform%" == "x86" xcopy /Y /s /Q "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT\msvcp140.dll" "."
   - cmd: if "%platform%" == "x86" xcopy /Y /s /Q "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT\vcruntime140.dll" "."
-  - cmd: cd C:\projects\fheroes2\build\%platform%\%configuration%
   - cmd: 7z a fheroes2_windows_%platform%_%deploy_conf_name%.zip fheroes2.exe SDL*.dll lib*.dll zlib*.dll msvcp*.dll vcruntime*.dll
   - cmd: cd C:\projects\fheroes2
   - cmd: xcopy /Y /s /Q "doc\README.txt" "."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,8 @@ install:
   - cd C:\projects\fheroes2
 
 after_build:
+  - cmd: if "%platform%" == "x86" xcopy /Y /s /Q "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT\msvcp140.dll" "."
+  - cmd: if "%platform%" == "x86" xcopy /Y /s /Q "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT\vcruntime140.dll" "."
   - cmd: cd C:\projects\fheroes2\build\%platform%\%configuration%
   - cmd: 7z a fheroes2_windows_%platform%_%deploy_conf_name%.zip fheroes2.exe SDL*.dll lib*.dll zlib*.dll
   - cmd: cd C:\projects\fheroes2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ after_build:
   - cmd: if "%platform%" == "x86" xcopy /Y /s /Q "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT\msvcp140.dll" "."
   - cmd: if "%platform%" == "x86" xcopy /Y /s /Q "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT\vcruntime140.dll" "."
   - cmd: cd C:\projects\fheroes2\build\%platform%\%configuration%
-  - cmd: 7z a fheroes2_windows_%platform%_%deploy_conf_name%.zip fheroes2.exe SDL*.dll lib*.dll zlib*.dll
+  - cmd: 7z a fheroes2_windows_%platform%_%deploy_conf_name%.zip fheroes2.exe SDL*.dll lib*.dll zlib*.dll msvcp*.dll vcruntime*.dll
   - cmd: cd C:\projects\fheroes2
   - cmd: xcopy /Y /s /Q "doc\README.txt" "."
   - cmd: 7z a build\%platform%\%configuration%\fheroes2_windows_%platform%_%deploy_conf_name%.zip script\demo\demo_windows.bat LICENSE fheroes2.key changelog.txt README.txt


### PR DESCRIPTION
to do not depend on VS Redistributable 2015

close #192