### PR TITLE
Fix extensive memory usage by windows

### DIFF
--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -127,9 +127,16 @@ namespace Dialog
             return area;
         }
 
+        void redraw();
+
     protected:
         std::unique_ptr<fheroes2::ImageRestorer> _restorer;
         fheroes2::Rect area;
+
+    private:
+        fheroes2::Point _position;
+        uint32_t _middleFragmentCount;
+        int32_t _middleFragmentHeight;
     };
 
     class FrameBox : public NonFixedFrameBox

--- a/src/fheroes2/dialog/dialog_frameborder.cpp
+++ b/src/fheroes2/dialog/dialog_frameborder.cpp
@@ -27,12 +27,12 @@
 #include "settings.h"
 
 Dialog::FrameBorder::FrameBorder( int v )
-    : restorer( fheroes2::Display::instance() )
+    : restorer( fheroes2::Display::instance(), 0, 0, 0, 0 )
     , border( v )
 {}
 
 Dialog::FrameBorder::FrameBorder( const Size & sz, const fheroes2::Image & sf )
-    : restorer( fheroes2::Display::instance() )
+    : restorer( fheroes2::Display::instance(), 0, 0, 0, 0 )
     , border( BORDERWIDTH )
 {
     const fheroes2::Display & display = fheroes2::Display::instance();
@@ -42,7 +42,7 @@ Dialog::FrameBorder::FrameBorder( const Size & sz, const fheroes2::Image & sf )
 }
 
 Dialog::FrameBorder::FrameBorder( const Size & sz )
-    : restorer( fheroes2::Display::instance() )
+    : restorer( fheroes2::Display::instance(), 0, 0, 0, 0 )
     , border( BORDERWIDTH )
 {
     const fheroes2::Display & display = fheroes2::Display::instance();
@@ -51,7 +51,7 @@ Dialog::FrameBorder::FrameBorder( const Size & sz )
 }
 
 Dialog::FrameBorder::FrameBorder( s32 posx, s32 posy, u32 encw, u32 ench )
-    : restorer( fheroes2::Display::instance() )
+    : restorer( fheroes2::Display::instance(), 0, 0, 0, 0 )
     , border( BORDERWIDTH )
 {
     SetPosition( posx, posy, encw, ench );


### PR DESCRIPTION
close #2736

Memory usage for interface reduced by 10 MB for 1024 x 768 pixels
resolution. Which means it's faster on slower machines.