### PR TITLE
Optimize AI's troop placement before the battle

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -47,6 +47,7 @@ namespace AI
 
         virtual void revealFog( const Maps::Tiles & tile ) override;
 
+        virtual void HeroesPreBattle( HeroBase & hero ) override;
         virtual void HeroesActionComplete( Heroes & hero ) override;
 
         double getObjectValue( const Heroes & hero, int index, int objectID, double valueToIgnore ) const;

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -106,6 +106,86 @@ namespace AI
         }
     }
 
+    void Normal::HeroesPreBattle( HeroBase & hero )
+    {
+        // Optimize troops placement before the battle
+        Army & army = hero.GetArmy();
+
+        DEBUG( DBG_AI, DBG_TRACE, "Before the battle: " << army.String() );
+
+        std::vector<Troop> archers;
+        std::vector<Troop> others;
+
+        // Validate and pick the troops
+        for ( size_t slot = 0; slot < ARMYMAXTROOPS; ++slot ) {
+            Troop * troop = army.GetTroop( slot );
+            if ( troop && troop->isValid() ) {
+                if ( troop->isArchers() ) {
+                    archers.push_back( *troop );
+                }
+                else {
+                    others.push_back( *troop );
+                }
+            }
+        }
+
+        // Sort troops by tactical priority. For melee:
+        // 1. Faster units first
+        // 2. Flyers first
+        // 3. Finally if unit type and speed is same, compare by strength
+        std::sort( others.begin(), others.end(), []( const Troop & left, const Troop & right ) {
+            if ( left.GetSpeed() == right.GetSpeed() ) {
+                if ( left.isFlying() == right.isFlying() ) {
+                    return left.GetStrength() > right.GetStrength();
+                }
+                return left.isFlying();
+            }
+            return left.GetSpeed() > right.GetSpeed();
+        } );
+
+        // Archers sorted purely by strength.
+        std::sort( archers.begin(), archers.end(), []( const Troop & left, const Troop & right ) { return left.GetStrength() > right.GetStrength(); } );
+
+        std::vector<size_t> slotOrder = {2, 1, 3, 0, 4};
+        switch ( archers.size() ) {
+        case 1:
+            slotOrder = {0, 2, 1, 3, 4};
+            break;
+        case 2:
+            // 1, 5 or 4 -> 3, 2, 5
+            slotOrder = {0, 4, 2, 1, 3};
+            break;
+        case 3:
+            slotOrder = {0, 4, 2, 1, 3};
+            break;
+        case 4:
+            slotOrder = {0, 4, 2, 3, 1};
+            break;
+        case 5:
+            slotOrder = {0, 4, 1, 2, 3};
+            break;
+        default:
+            break;
+        }
+
+        // Re-arrange troops in army
+        army.Clean();
+        for ( size_t slot : slotOrder ) {
+            if ( archers.size() ) {
+                army.GetTroop( slot )->Set( archers.back() );
+                archers.pop_back();
+            }
+            else if ( others.size() ) {
+                army.GetTroop( slot )->Set( others.back() );
+                others.pop_back();
+            }
+            else {
+                break;
+            }
+        }
+        DEBUG( DBG_AI, DBG_TRACE, "After: " << army.String() );
+    }
+
     void Normal::BattleTurn( Arena & arena, const Unit & currentUnit, Actions & actions )
     {
         if ( currentUnit.Modes( SP_BERSERKER ) != 0 ) {

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -111,8 +111,6 @@ namespace AI
         // Optimize troops placement before the battle
         Army & army = hero.GetArmy();
 
-        DEBUG( DBG_AI, DBG_TRACE, "Before the battle: " << army.String() );
-
         std::vector<Troop> archers;
         std::vector<Troop> others;
 
@@ -136,15 +134,15 @@ namespace AI
         std::sort( others.begin(), others.end(), []( const Troop & left, const Troop & right ) {
             if ( left.GetSpeed() == right.GetSpeed() ) {
                 if ( left.isFlying() == right.isFlying() ) {
-                    return left.GetStrength() > right.GetStrength();
+                    return left.GetStrength() < right.GetStrength();
                 }
-                return left.isFlying();
+                return right.isFlying();
             }
-            return left.GetSpeed() > right.GetSpeed();
+            return left.GetSpeed() < right.GetSpeed();
         } );
 
         // Archers sorted purely by strength.
-        std::sort( archers.begin(), archers.end(), []( const Troop & left, const Troop & right ) { return left.GetStrength() > right.GetStrength(); } );
+        std::sort( archers.begin(), archers.end(), []( const Troop & left, const Troop & right ) { return left.GetStrength() < right.GetStrength(); } );
 
         std::vector<size_t> slotOrder = {2, 1, 3, 0, 4};
         switch ( archers.size() ) {
@@ -183,7 +181,6 @@ namespace AI
                 break;
             }
         }
-        DEBUG( DBG_AI, DBG_TRACE, "After: " << army.String() );
     }
 
     void Normal::BattleTurn( Arena & arena, const Unit & currentUnit, Actions & actions )

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -168,12 +168,12 @@ namespace AI
 
         // Re-arrange troops in army
         army.Clean();
-        for ( size_t slot : slotOrder ) {
-            if ( archers.size() ) {
+        for ( const size_t slot : slotOrder ) {
+            if ( !archers.empty() ) {
                 army.GetTroop( slot )->Set( archers.back() );
                 archers.pop_back();
             }
-            else if ( others.size() ) {
+            else if ( !others.empty() ) {
                 army.GetTroop( slot )->Set( others.back() );
                 others.pop_back();
             }

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -566,12 +566,12 @@ void Troops::SortStrongest()
     std::sort( begin(), end(), Army::StrongestTroop );
 }
 
+// Pre-battle arrangement for Monster or Neutral troops
 void Troops::ArrangeForBattle( bool upgrade )
 {
     const Troops & priority = GetOptimized();
 
-    switch ( priority.size() ) {
-    case 1: {
+    if ( priority.size() == 1 ) {
         const Monster & m = *priority.back();
         const u32 count = priority.back()->GetCount();
 
@@ -599,31 +599,9 @@ void Troops::ArrangeForBattle( bool upgrade )
         }
         else
             at( 2 )->Set( m, count );
-        break;
     }
-    case 2: {
-        // TODO: need modify army for 2 troops
+    else {
         Assign( priority );
-        break;
-    }
-    case 3: {
-        // TODO: need modify army for 3 troops
-        Assign( priority );
-        break;
-    }
-    case 4: {
-        // TODO: need modify army for 4 troops
-        Assign( priority );
-        break;
-    }
-    case 5: {
-        // possible change orders monster
-        // store
-        Assign( priority );
-        break;
-    }
-    default:
-        break;
     }
 }
 


### PR DESCRIPTION
Related to #2158.

Based on archer unit count in the army to space them out so they won't be blocked by one unit.