### PR TITLE
Succession Wars full campaign data, excluding the betrayal missions

### DIFF
--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -59,6 +59,36 @@ namespace
             bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::SORC, 1 );
             bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::KNGT, 1 );
             break;
+        case 4:
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::WZRD, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::SORC, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::KNGT, 1 );
+            break;
+        case 5:
+            bonus.emplace_back( Campaign::ScenarioBonusData::SPELL, Spell::MIRRORIMAGE, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::SPELL, Spell::SUMMONEELEMENT, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::SPELL, Spell::RESURRECT, 1 );
+            break;
+        case 6:
+            bonus.emplace_back( Campaign::ScenarioBonusData::ARTIFACT, Artifact::BLACK_PEARL, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::ARTIFACT, Artifact::DRAGON_SWORD, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::ARTIFACT, Artifact::DIVINE_BREASTPLATE, 1 );
+            break;
+        case 7:
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::WZRD, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::SORC, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::KNGT, 1 );
+            break;
+        case 8:
+            bonus.emplace_back( Campaign::ScenarioBonusData::RESOURCES, Resource::CRYSTAL, 20 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::RESOURCES, Resource::GEMS, 20 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::RESOURCES, Resource::MERCURY, 20 );
+            break;
+        case 9:
+            bonus.emplace_back( Campaign::ScenarioBonusData::ARTIFACT, Artifact::TAX_LIEN, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::ARTIFACT, Artifact::HIDEOUS_MASK, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::ARTIFACT, Artifact::FIZBIN_MISFORTUNE, 1 );
+            break;
         }
 
         return bonus;
@@ -89,6 +119,41 @@ namespace
             bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::WRLK, 1 );
             bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::BARB, 1 );
             break;
+        case 4:
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::NECR, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::WRLK, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::BARB, 1 );
+            break;
+        case 5:
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::NECR, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::WRLK, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::BARB, 1 );
+            break;
+        case 6:
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::NECR, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::WRLK, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::BARB, 1 );
+            break;
+        case 7:
+            bonus.emplace_back( Campaign::ScenarioBonusData::SKILL, Skill::Secondary::LOGISTICS, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::ARTIFACT, Artifact::POWER_AXE, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::ARTIFACT, Artifact::WHITE_PEARL, 1 );
+            break;
+        case 8:
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::NECR, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::WRLK, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::STARTING_RACE, Race::BARB, 1 );
+            break;
+        case 9:
+            bonus.emplace_back( Campaign::ScenarioBonusData::ARTIFACT, Artifact::BLACK_PEARL, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::ARTIFACT, Artifact::DRAGON_SWORD, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::ARTIFACT, Artifact::DIVINE_BREASTPLATE, 1 );
+            break;
+        case 10:
+            bonus.emplace_back( Campaign::ScenarioBonusData::ARTIFACT, Artifact::TAX_LIEN, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::ARTIFACT, Artifact::HIDEOUS_MASK, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::ARTIFACT, Artifact::FIZBIN_MISFORTUNE, 1 );
+            break;
         }
 
         return bonus;
@@ -108,13 +173,32 @@ namespace
         return std::vector<Campaign::ScenarioBonusData>();
     }
 
-    const std::string rolandCampaignDescription[] = {_(
-        "Roland needs you to defeat the lords near his castle to begin his war of rebellion against his brother.  They are not allied with each other, so they will spend"
-        " most of their time fighting with one another.  Victory is yours when you have defeated all of their castles and heroes." )};
+    const std::string rolandCampaignDescription[] = {
+        _( "Roland needs you to defeat the lords near his castle to begin his war of rebellion against his brother.  They are not allied with each other, so they will spend"
+           " most of their time fighting with one another.  Victory is yours when you have defeated all of their castles and heroes." ),
+        "The local lords refuse to swear allegiance to Roland, and must be subdued. They are wealthy and powerful, so be prepared for a tough fight. Capture all enemy castles to win.",
+        "Your task is to defend the Dwarves against Archibald's forces. Capture all of the enemy towns and castles to win, and be sure not to lose all of the dwarf towns at once, or the enemy will have won.",
+        "You will face four allied enemies in a straightforward fight for resource and treasure. Capture all of the enemy castles for victory.",
+        "Your enemies are allied against you and start close by, so be ready to come out fighting. You will need to own all four castles in this small valley to win.",
+        "The Sorceress' guild of Noraston has requested Roland's aid against an attack from Archibald's allies. Capture all of the enemy castles to win, and don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy castle on an island in the ocean.)",
+        "Find the Crown before Archibald's heroes find it. Roland will need the Crown for the final battle against Archibald.",
+        "Gather as large an army as possible and capture the enemy castle within 8 weeks. You are opposed by only one enemy, but must travel a long way to get to the enemy castle. Any troops you have in your army at the end of this scenario will be with you in the final battle.",
+        "Three allied enemies stand before you and victory, including Lord Corlagon. Roland is in a castle to the northwest, and you will lose if he falls to the enemy. Remember that capturing Lord Corlagon will ensure that he will not fight against you in the final scenario.",
+        "This is the final battle. Both you and your enemy are armed to the teeth, and all are allied against you. Capture Archibald to end the war!"};
 
-    const std::string archibaldCampaignDescription[] = {_(
-        "King Archibald requires you to defeat the three enemies in this region.  They are not allied with one another, so they will spend most of their energy fighting"
-        " amongst themselves.  You will win when you own all of the enemy castles and there are no more heroes left to fight." )};
+    const std::string archibaldCampaignDescription[] = {
+        _( "King Archibald requires you to defeat the three enemies in this region.  They are not allied with one another, so they will spend most of their energy fighting"
+           " amongst themselves.  You will win when you own all of the enemy castles and there are no more heroes left to fight." ),
+        "You must unify the barbarian tribes of the north by conquering them. As in the previous mission, the enemy is not allied against you, but they have more resources at their disposal. You will win when you own all of the enemy castles and there are no more heroes left to fight.",
+        "Do-gooder wizards have taken the Necromancers' castle. You must retake it to achieve victory. Remember that while you start with a powerful army, you have no castle and must take one within 7 days, or lose this battle. (Hint: The nearest castle is to the southeast.)",
+        "The dwarves need conquering before they can interfere in King Archibald's plans. Roland's forces have more than one hero and many towns to start with, so be ready for attack from multiple directions. You must capture all of the enemy towns and castles to claim victory.",
+        "Your enemies are allied against you and start close by, so be ready to come out fighting. You will need to own all four castles in this small valley to win.",
+        "You must put down a peasant revolt led by Roland's forces. All are allied against you, but you have Lord Corlagon, an experienced hero, to help you. Capture all enemy castles to win.",
+        "There are two enemies allied against you in this mission. Both are well armed and seek to evict you from their island. Avoid them and capture Dragon City to win",
+        "Your orders are to conquer the country lords that have sworn to serve Roland. All of the enemy castles are unified against you. Since you start without a castle, you must hurry to capture one before the end of the week. Capture all enemy castles for victory.",
+        "Find the Crown before Roland's heroes find it. Archibald will need the Crown for the final battle against Roland.",
+        "Gather as large an army as possible and capture the enemy castle within 8 weeks. You are opposed by only one enemy, but must travel a long way to get to the enemy castle. Any troops you have in your army at the end of this scenario will be with you in the final battle.",
+        "This is the final battle. Both you and your enemy are armed to the teeth, and all are allied against you. Capture Roland to win the war, and be sure not to lose Archibald in the fight!"};
 
     void DrawCampaignScenarioIcon( const int icnId, const int iconIdx, const fheroes2::Point & offset, const int posX, const int posY )
     {
@@ -233,13 +317,18 @@ namespace
 
     Campaign::CampaignData GetRolandCampaignData()
     {
-        // TODO: Do all campaign data until CAMPG10.H2C, for now we'll test until mission 4 (in which mission 3 Save The Dwarves is optional)
         std::vector<Campaign::ScenarioData> scenarioDatas;
-        scenarioDatas.reserve( 4 );
+        scenarioDatas.reserve( 10 );
         scenarioDatas.emplace_back( 0, std::vector<int>{1}, getCampaignBonusData( 0, 0 ), std::string( "CAMPG01.H2C" ), rolandCampaignDescription[0] );
-        scenarioDatas.emplace_back( 1, std::vector<int>{2, 3}, getCampaignBonusData( 0, 1 ), std::string( "CAMPG02.H2C" ), rolandCampaignDescription[0] );
-        scenarioDatas.emplace_back( 2, std::vector<int>{3}, getCampaignBonusData( 0, 2 ), std::string( "CAMPG03.H2C" ), rolandCampaignDescription[0] );
-        scenarioDatas.emplace_back( 3, std::vector<int>{4}, getCampaignBonusData( 0, 3 ), std::string( "CAMPG04.H2C" ), rolandCampaignDescription[0] );
+        scenarioDatas.emplace_back( 1, std::vector<int>{2, 3}, getCampaignBonusData( 0, 1 ), std::string( "CAMPG02.H2C" ), rolandCampaignDescription[1] );
+        scenarioDatas.emplace_back( 2, std::vector<int>{3}, getCampaignBonusData( 0, 2 ), std::string( "CAMPG03.H2C" ), rolandCampaignDescription[2] );
+        scenarioDatas.emplace_back( 3, std::vector<int>{4}, getCampaignBonusData( 0, 3 ), std::string( "CAMPG04.H2C" ), rolandCampaignDescription[3] );
+        scenarioDatas.emplace_back( 4, std::vector<int>{5}, getCampaignBonusData( 0, 4 ), std::string( "CAMPG05.H2C" ), rolandCampaignDescription[4] );
+        scenarioDatas.emplace_back( 5, std::vector<int>{6, 7}, getCampaignBonusData( 0, 5 ), std::string( "CAMPG06.H2C" ), rolandCampaignDescription[5] );
+        scenarioDatas.emplace_back( 6, std::vector<int>{8}, getCampaignBonusData( 0, 6 ), std::string( "CAMPG07.H2C" ), rolandCampaignDescription[6] );
+        scenarioDatas.emplace_back( 7, std::vector<int>{8}, getCampaignBonusData( 0, 7 ), std::string( "CAMPG08.H2C" ), rolandCampaignDescription[7] );
+        scenarioDatas.emplace_back( 8, std::vector<int>{9}, getCampaignBonusData( 0, 8 ), std::string( "CAMPG09.H2C" ), rolandCampaignDescription[8] );
+        scenarioDatas.emplace_back( 9, std::vector<int>{}, getCampaignBonusData( 0, 9 ), std::string( "CAMPG10.H2C" ), rolandCampaignDescription[9] );
 
         Campaign::CampaignData campaignData;
         campaignData.setCampaignID( 0 );
@@ -252,13 +341,19 @@ namespace
 
     Campaign::CampaignData GetArchibaldCampaignData()
     {
-        // TODO: Do all campaign data until CAMPE10.H2C
         std::vector<Campaign::ScenarioData> scenarioDatas;
-        scenarioDatas.reserve( 4 );
+        scenarioDatas.reserve( 11 );
         scenarioDatas.emplace_back( 0, std::vector<int>{1}, getCampaignBonusData( 1, 0 ), std::string( "CAMPE01.H2C" ), archibaldCampaignDescription[0] );
-        scenarioDatas.emplace_back( 1, std::vector<int>{2, 3}, getCampaignBonusData( 1, 1 ), std::string( "CAMPE02.H2C" ), archibaldCampaignDescription[0] );
-        scenarioDatas.emplace_back( 2, std::vector<int>{}, getCampaignBonusData( 1, 2 ), std::string( "CAMPE03.H2C" ), archibaldCampaignDescription[0] );
-        scenarioDatas.emplace_back( 3, std::vector<int>{}, getCampaignBonusData( 1, 3 ), std::string( "CAMPE04.H2C" ), archibaldCampaignDescription[0] );
+        scenarioDatas.emplace_back( 1, std::vector<int>{2, 3}, getCampaignBonusData( 1, 1 ), std::string( "CAMPE02.H2C" ), archibaldCampaignDescription[1] );
+        scenarioDatas.emplace_back( 2, std::vector<int>{4}, getCampaignBonusData( 1, 2 ), std::string( "CAMPE03.H2C" ), archibaldCampaignDescription[2] );
+        scenarioDatas.emplace_back( 3, std::vector<int>{4}, getCampaignBonusData( 1, 3 ), std::string( "CAMPE04.H2C" ), archibaldCampaignDescription[3] );
+        scenarioDatas.emplace_back( 4, std::vector<int>{5}, getCampaignBonusData( 1, 4 ), std::string( "CAMPE05.H2C" ), archibaldCampaignDescription[4] );
+        scenarioDatas.emplace_back( 5, std::vector<int>{6, 7}, getCampaignBonusData( 1, 5 ), std::string( "CAMPE06.H2C" ), archibaldCampaignDescription[5] );
+        scenarioDatas.emplace_back( 6, std::vector<int>{7}, getCampaignBonusData( 1, 6 ), std::string( "CAMPE07.H2C" ), archibaldCampaignDescription[6] );
+        scenarioDatas.emplace_back( 7, std::vector<int>{8, 9}, getCampaignBonusData( 1, 7 ), std::string( "CAMPE08.H2C" ), archibaldCampaignDescription[7] );
+        scenarioDatas.emplace_back( 8, std::vector<int>{ 10 }, getCampaignBonusData( 1, 8 ), std::string( "CAMPE09.H2C" ), archibaldCampaignDescription[8] );
+        scenarioDatas.emplace_back( 9, std::vector<int>{ 10 }, getCampaignBonusData( 1, 9 ), std::string( "CAMPE10.H2C" ), archibaldCampaignDescription[9] );
+        scenarioDatas.emplace_back( 10, std::vector<int>{}, getCampaignBonusData( 1, 10 ), std::string( "CAMPE11.H2C" ), archibaldCampaignDescription[10] );
 
         Campaign::CampaignData campaignData;
         campaignData.setCampaignID( 1 );

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -351,8 +351,8 @@ namespace
         scenarioDatas.emplace_back( 5, std::vector<int>{6, 7}, getCampaignBonusData( 1, 5 ), std::string( "CAMPE06.H2C" ), archibaldCampaignDescription[5] );
         scenarioDatas.emplace_back( 6, std::vector<int>{7}, getCampaignBonusData( 1, 6 ), std::string( "CAMPE07.H2C" ), archibaldCampaignDescription[6] );
         scenarioDatas.emplace_back( 7, std::vector<int>{8, 9}, getCampaignBonusData( 1, 7 ), std::string( "CAMPE08.H2C" ), archibaldCampaignDescription[7] );
-        scenarioDatas.emplace_back( 8, std::vector<int>{ 10 }, getCampaignBonusData( 1, 8 ), std::string( "CAMPE09.H2C" ), archibaldCampaignDescription[8] );
-        scenarioDatas.emplace_back( 9, std::vector<int>{ 10 }, getCampaignBonusData( 1, 9 ), std::string( "CAMPE10.H2C" ), archibaldCampaignDescription[9] );
+        scenarioDatas.emplace_back( 8, std::vector<int>{10}, getCampaignBonusData( 1, 8 ), std::string( "CAMPE09.H2C" ), archibaldCampaignDescription[8] );
+        scenarioDatas.emplace_back( 9, std::vector<int>{10}, getCampaignBonusData( 1, 9 ), std::string( "CAMPE10.H2C" ), archibaldCampaignDescription[9] );
         scenarioDatas.emplace_back( 10, std::vector<int>{}, getCampaignBonusData( 1, 10 ), std::string( "CAMPE11.H2C" ), archibaldCampaignDescription[10] );
 
         Campaign::CampaignData campaignData;

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -173,7 +173,7 @@ namespace
         return std::vector<Campaign::ScenarioBonusData>();
     }
 
-    const std::string rolandCampaignDescription[] = {
+    const std::string rolandCampaignDescription[10] = {
         _( "Roland needs you to defeat the lords near his castle to begin his war of rebellion against his brother.  They are not allied with each other, so they will spend"
            " most of their time fighting with one another.  Victory is yours when you have defeated all of their castles and heroes." ),
         "The local lords refuse to swear allegiance to Roland, and must be subdued. They are wealthy and powerful, so be prepared for a tough fight. Capture all enemy castles to win.",
@@ -186,7 +186,7 @@ namespace
         "Three allied enemies stand before you and victory, including Lord Corlagon. Roland is in a castle to the northwest, and you will lose if he falls to the enemy. Remember that capturing Lord Corlagon will ensure that he will not fight against you in the final scenario.",
         "This is the final battle. Both you and your enemy are armed to the teeth, and all are allied against you. Capture Archibald to end the war!"};
 
-    const std::string archibaldCampaignDescription[] = {
+    const std::string archibaldCampaignDescription[11] = {
         _( "King Archibald requires you to defeat the three enemies in this region.  They are not allied with one another, so they will spend most of their energy fighting"
            " amongst themselves.  You will win when you own all of the enemy castles and there are no more heroes left to fight." ),
         "You must unify the barbarian tribes of the north by conquering them. As in the previous mission, the enemy is not allied against you, but they have more resources at their disposal. You will win when you own all of the enemy castles and there are no more heroes left to fight.",

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -176,29 +176,29 @@ namespace
     const std::string rolandCampaignDescription[10] = {
         _( "Roland needs you to defeat the lords near his castle to begin his war of rebellion against his brother.  They are not allied with each other, so they will spend"
            " most of their time fighting with one another.  Victory is yours when you have defeated all of their castles and heroes." ),
-        "The local lords refuse to swear allegiance to Roland, and must be subdued. They are wealthy and powerful, so be prepared for a tough fight. Capture all enemy castles to win.",
-        "Your task is to defend the Dwarves against Archibald's forces. Capture all of the enemy towns and castles to win, and be sure not to lose all of the dwarf towns at once, or the enemy will have won.",
-        "You will face four allied enemies in a straightforward fight for resource and treasure. Capture all of the enemy castles for victory.",
-        "Your enemies are allied against you and start close by, so be ready to come out fighting. You will need to own all four castles in this small valley to win.",
-        "The Sorceress' guild of Noraston has requested Roland's aid against an attack from Archibald's allies. Capture all of the enemy castles to win, and don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy castle on an island in the ocean.)",
-        "Find the Crown before Archibald's heroes find it. Roland will need the Crown for the final battle against Archibald.",
-        "Gather as large an army as possible and capture the enemy castle within 8 weeks. You are opposed by only one enemy, but must travel a long way to get to the enemy castle. Any troops you have in your army at the end of this scenario will be with you in the final battle.",
-        "Three allied enemies stand before you and victory, including Lord Corlagon. Roland is in a castle to the northwest, and you will lose if he falls to the enemy. Remember that capturing Lord Corlagon will ensure that he will not fight against you in the final scenario.",
-        "This is the final battle. Both you and your enemy are armed to the teeth, and all are allied against you. Capture Archibald to end the war!"};
+        _( "The local lords refuse to swear allegiance to Roland, and must be subdued. They are wealthy and powerful, so be prepared for a tough fight. Capture all enemy castles to win." ),
+        _( "Your task is to defend the Dwarves against Archibald's forces. Capture all of the enemy towns and castles to win, and be sure not to lose all of the dwarf towns at once, or the enemy will have won." ),
+        _( "You will face four allied enemies in a straightforward fight for resource and treasure. Capture all of the enemy castles for victory." ),
+        _( "Your enemies are allied against you and start close by, so be ready to come out fighting. You will need to own all four castles in this small valley to win." ),
+        _( "The Sorceress' guild of Noraston has requested Roland's aid against an attack from Archibald's allies. Capture all of the enemy castles to win, and don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy castle on an island in the ocean.)" ),
+        _( "Find the Crown before Archibald's heroes find it. Roland will need the Crown for the final battle against Archibald." ),
+        _( "Gather as large an army as possible and capture the enemy castle within 8 weeks. You are opposed by only one enemy, but must travel a long way to get to the enemy castle. Any troops you have in your army at the end of this scenario will be with you in the final battle." ),
+        _( "Three allied enemies stand before you and victory, including Lord Corlagon. Roland is in a castle to the northwest, and you will lose if he falls to the enemy. Remember that capturing Lord Corlagon will ensure that he will not fight against you in the final scenario." ),
+        _( "This is the final battle. Both you and your enemy are armed to the teeth, and all are allied against you. Capture Archibald to end the war!" )};
 
     const std::string archibaldCampaignDescription[11] = {
         _( "King Archibald requires you to defeat the three enemies in this region.  They are not allied with one another, so they will spend most of their energy fighting"
            " amongst themselves.  You will win when you own all of the enemy castles and there are no more heroes left to fight." ),
-        "You must unify the barbarian tribes of the north by conquering them. As in the previous mission, the enemy is not allied against you, but they have more resources at their disposal. You will win when you own all of the enemy castles and there are no more heroes left to fight.",
-        "Do-gooder wizards have taken the Necromancers' castle. You must retake it to achieve victory. Remember that while you start with a powerful army, you have no castle and must take one within 7 days, or lose this battle. (Hint: The nearest castle is to the southeast.)",
-        "The dwarves need conquering before they can interfere in King Archibald's plans. Roland's forces have more than one hero and many towns to start with, so be ready for attack from multiple directions. You must capture all of the enemy towns and castles to claim victory.",
-        "Your enemies are allied against you and start close by, so be ready to come out fighting. You will need to own all four castles in this small valley to win.",
-        "You must put down a peasant revolt led by Roland's forces. All are allied against you, but you have Lord Corlagon, an experienced hero, to help you. Capture all enemy castles to win.",
-        "There are two enemies allied against you in this mission. Both are well armed and seek to evict you from their island. Avoid them and capture Dragon City to win",
-        "Your orders are to conquer the country lords that have sworn to serve Roland. All of the enemy castles are unified against you. Since you start without a castle, you must hurry to capture one before the end of the week. Capture all enemy castles for victory.",
-        "Find the Crown before Roland's heroes find it. Archibald will need the Crown for the final battle against Roland.",
-        "Gather as large an army as possible and capture the enemy castle within 8 weeks. You are opposed by only one enemy, but must travel a long way to get to the enemy castle. Any troops you have in your army at the end of this scenario will be with you in the final battle.",
-        "This is the final battle. Both you and your enemy are armed to the teeth, and all are allied against you. Capture Roland to win the war, and be sure not to lose Archibald in the fight!"};
+        _( "You must unify the barbarian tribes of the north by conquering them. As in the previous mission, the enemy is not allied against you, but they have more resources at their disposal. You will win when you own all of the enemy castles and there are no more heroes left to fight." ),
+        _( "Do-gooder wizards have taken the Necromancers' castle. You must retake it to achieve victory. Remember that while you start with a powerful army, you have no castle and must take one within 7 days, or lose this battle. (Hint: The nearest castle is to the southeast.)" ),
+        _( "The dwarves need conquering before they can interfere in King Archibald's plans. Roland's forces have more than one hero and many towns to start with, so be ready for attack from multiple directions. You must capture all of the enemy towns and castles to claim victory." ),
+        _( "Your enemies are allied against you and start close by, so be ready to come out fighting. You will need to own all four castles in this small valley to win." ),
+        _( "You must put down a peasant revolt led by Roland's forces. All are allied against you, but you have Lord Corlagon, an experienced hero, to help you. Capture all enemy castles to win." ),
+        _( "There are two enemies allied against you in this mission. Both are well armed and seek to evict you from their island. Avoid them and capture Dragon City to win" ),
+        _( "Your orders are to conquer the country lords that have sworn to serve Roland. All of the enemy castles are unified against you. Since you start without a castle, you must hurry to capture one before the end of the week. Capture all enemy castles for victory." ),
+        _( "Find the Crown before Roland's heroes find it. Archibald will need the Crown for the final battle against Roland." ),
+        _( "Gather as large an army as possible and capture the enemy castle within 8 weeks. You are opposed by only one enemy, but must travel a long way to get to the enemy castle. Any troops you have in your army at the end of this scenario will be with you in the final battle." ),
+        _( "This is the final battle. Both you and your enemy are armed to the teeth, and all are allied against you. Capture Roland to win the war, and be sure not to lose Archibald in the fight!" )};
 
     void DrawCampaignScenarioIcon( const int icnId, const int iconIdx, const fheroes2::Point & offset, const int posX, const int posY )
     {


### PR DESCRIPTION
Solves #2382

The betrayal missions require custom scripting to switch to another campaign and to display the betrayal mission. So it should be a different issue.