### PR TITLE
Removal of the resource.h dependency

### DIFF
--- a/src/fheroes2/game/difficulty.cpp
+++ b/src/fheroes2/game/difficulty.cpp
@@ -21,7 +21,6 @@
  ***************************************************************************/
 
 #include "difficulty.h"
-#include "resource.h"
 
 const std::string & Difficulty::String( int difficulty )
 {
@@ -44,37 +43,6 @@ const std::string & Difficulty::String( int difficulty )
     }
 
     return str_difficulty[5];
-}
-
-cost_t Difficulty::GetKingdomStartingResources( int difficulty, bool isAIKingdom )
-{
-    static cost_t startingResourcesSet[] = {{10000, 30, 10, 30, 10, 10, 10},
-                                            {7500, 20, 5, 20, 5, 5, 5},
-                                            {5000, 10, 2, 10, 2, 2, 2},
-                                            {2500, 5, 0, 5, 0, 0, 0},
-                                            {0, 0, 0, 0, 0, 0, 0},
-                                            // ai resource
-                                            {10000, 30, 10, 30, 10, 10, 10}};
-
-    if ( isAIKingdom )
-        return startingResourcesSet[5];
-
-    switch ( difficulty ) {
-    case Difficulty::EASY:
-        return startingResourcesSet[0];
-    case Difficulty::NORMAL:
-        return startingResourcesSet[1];
-    case Difficulty::HARD:
-        return startingResourcesSet[2];
-    case Difficulty::EXPERT:
-        return startingResourcesSet[3];
-    case Difficulty::IMPOSSIBLE:
-        return startingResourcesSet[4];
-    default:
-        break;
-    }
-
-    return startingResourcesSet[1];
 }
 
 int Difficulty::GetScoutingBonus( int difficulty )

--- a/src/fheroes2/game/difficulty.h
+++ b/src/fheroes2/game/difficulty.h
@@ -38,7 +38,6 @@ namespace Difficulty
 
     const std::string & String( int );
 
-    cost_t GetKingdomStartingResources( int difficulty, bool isAIKingdom );
     int GetScoutingBonus( int difficulty );
     double GetGoldIncomeBonus( int difficulty );
     double GetUnitGrowthBonus( int difficulty );

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -101,7 +101,7 @@ int Kingdom::GetRace( void ) const
 
 void Kingdom::UpdateStartingResource( void )
 {
-    resource = Difficulty::GetKingdomStartingResources( Settings::Get().GameDifficulty(), isControlAI() );
+    resource = GetKingdomStartingResources( Settings::Get().GameDifficulty(), isControlAI() );
 }
 
 bool Kingdom::isLoss( void ) const
@@ -825,6 +825,37 @@ bool Kingdom::IsTileVisibleFromCrystalBall( const int32_t dest ) const
         }
     }
     return false;
+}
+
+cost_t Kingdom::GetKingdomStartingResources( int difficulty, bool isAIKingdom )
+{
+    static cost_t startingResourcesSet[] = { { 10000, 30, 10, 30, 10, 10, 10 },
+                                             { 7500, 20, 5, 20, 5, 5, 5 },
+                                             { 5000, 10, 2, 10, 2, 2, 2 },
+                                             { 2500, 5, 0, 5, 0, 0, 0 },
+                                             { 0, 0, 0, 0, 0, 0, 0 },
+                                             // ai resource
+                                             { 10000, 30, 10, 30, 10, 10, 10 } };
+
+    if ( isAIKingdom )
+        return startingResourcesSet[5];
+
+    switch ( difficulty ) {
+    case Difficulty::EASY:
+        return startingResourcesSet[0];
+    case Difficulty::NORMAL:
+        return startingResourcesSet[1];
+    case Difficulty::HARD:
+        return startingResourcesSet[2];
+    case Difficulty::EXPERT:
+        return startingResourcesSet[3];
+    case Difficulty::IMPOSSIBLE:
+        return startingResourcesSet[4];
+    default:
+        break;
+    }
+
+    return startingResourcesSet[1];
 }
 
 StreamBase & operator<<( StreamBase & msg, const Kingdom & kingdom )

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -170,6 +170,7 @@ public:
     bool IsTileVisibleFromCrystalBall( const int32_t dest ) const;
 
     static u32 GetMaxHeroes( void );
+    static cost_t GetKingdomStartingResources( int difficulty, bool isAIKingdom );
 
 private:
     friend StreamBase & operator<<( StreamBase &, const Kingdom & );


### PR DESCRIPTION
allows to not bring whole world while compile difficulty.cpp which is required for Setting.cpp
Alternative to that PR would be create difficulty_type.h where declare just enum, and use that .h file for settings.cpp