### PR TITLE
Speed up SDL installation via scripts

### DIFF
--- a/script/linux/install_sdl_1.sh
+++ b/script/linux/install_sdl_1.sh
@@ -7,7 +7,4 @@ sudo apt-get remove libsdl2-ttf-dev
 sudo apt-get remove libsdl2-dev
 
 # Install SDL 1.2
-sudo apt-get install -y libsdl1.2-dev
-sudo apt-get install -y libsdl-ttf2.0-dev
-sudo apt-get install -y libsdl-mixer1.2-dev
-sudo apt-get install -y libsdl-image1.2-dev
+sudo apt-get install -y libsdl1.2-dev libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl-image1.2-dev

--- a/script/linux/install_sdl_2.sh
+++ b/script/linux/install_sdl_2.sh
@@ -6,8 +6,8 @@ sudo apt-get remove libsdl-mixer1.2-dev
 sudo apt-get remove libsdl-ttf2.0-dev
 sudo apt-get remove libsdl1.2-dev
 
-# Install SDL 2
-sudo apt-get install -y libsdl2-dev
-sudo apt-get install -y libsdl2-ttf-dev
-sudo apt-get install -y libsdl2-mixer-dev
-sudo apt-get install -y libsdl2-image-dev
+# Install SDL 2 for development (compilation)
+sudo apt-get install -y libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
+
+# Install tools and libraries for compilation 
+sudo apt-get install -y g++ libpng-dev gettext

--- a/script/linux/install_sdl_2.sh
+++ b/script/linux/install_sdl_2.sh
@@ -6,8 +6,5 @@ sudo apt-get remove libsdl-mixer1.2-dev
 sudo apt-get remove libsdl-ttf2.0-dev
 sudo apt-get remove libsdl1.2-dev
 
-# Install SDL 2 for development (compilation)
+# Install SDL 2
 sudo apt-get install -y libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
-
-# Install tools and libraries for compilation 
-sudo apt-get install -y g++ libpng-dev gettext


### PR DESCRIPTION
In Ubuntu and Debian for compilation fheroes2 g++, libpng-dev and gettext should be installed.
Also speed-up installation of libsdl*-dev libraries