### PR TITLE
Nintendo switch logging / path fixes

### DIFF
--- a/src/Makefile.switch
+++ b/src/Makefile.switch
@@ -1,13 +1,9 @@
-PREFIX	= $(DEVKITPRO)/devkitA64/bin/aarch64-none-elf-
-
-CC = $(PREFIX)gcc
-CXX = $(PREFIX)g++
-AR = $(PREFIX)ar
+include $(DEVKITPRO)/libnx/switch_rules
 
 ARCH = -march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -fPIE
-CFLAGS := $(CFLAGS) $(ARCH) -D__SWITCH__
-CXXFLAGS := $(CXXFLAGS) $(ARCH) -D__SWITCH__
+CFLAGS := $(CFLAGS) $(ARCH) -D__SWITCH__ -DCONFIGURE_FHEROES2_DATA=\"//switch/fheroes2\"
+CXXFLAGS := $(CXXFLAGS) $(ARCH) -D__SWITCH__ -DCONFIGURE_FHEROES2_DATA=\"//switch/fheroes2\"
 CFLAGS_TP := $(CFLAGS_TP) $(ARCH)
 CXXFLAGS_TP := $(CXXFLAGS_TP) $(ARCH)
 
-LIBS := $(LIBS) -lSDL2 -lfreetype -lbz2 -lvorbisidec -lmodplug -lmpg123 -lm -lopusfile -logg -lopus -ljpeg -lwebp -specs=$(DEVKITPRO)/libnx/switch.specs
+LIBS := $(LIBS) -lSDL2 -lfreetype -lpng16 -lbz2 -lvorbisidec -lmodplug -lmpg123 -lm -lopusfile -logg -lopus -ljpeg -lwebp -specs=$(DEVKITPRO)/libnx/switch.specs

--- a/src/engine/logging.cpp
+++ b/src/engine/logging.cpp
@@ -24,14 +24,14 @@
 namespace
 {
     int g_debug = DBG_ALL_WARN + DBG_ALL_INFO;
-
-#if defined( __SWITCH__ ) // Platforms which log to file
-    std::ofstream logFile;
-#endif
 }
 
 namespace Logging
 {
+#if defined( __SWITCH__ ) // Platforms which log to file
+    std::ofstream logFile;
+#endif
+
     const char * GetDebugOptionName( const int name )
     {
         if ( name & DBG_ENGINE )

--- a/src/engine/logging.h
+++ b/src/engine/logging.h
@@ -94,10 +94,12 @@ namespace std
 
 #elif defined( __SWITCH__ ) // Platforms which log to file
 #include <fstream>
+
 namespace Logging
 {
     extern std::ofstream logFile;
 }
+
 #define COUT( x )                                                                                                                                                        \
     {                                                                                                                                                                    \
         Logging::logFile << x << std::endl;                                                                                                                              \

--- a/src/engine/logging.h
+++ b/src/engine/logging.h
@@ -94,11 +94,14 @@ namespace std
 
 #elif defined( __SWITCH__ ) // Platforms which log to file
 #include <fstream>
-extern std::ofstream log_file;
+namespace Logging
+{
+    extern std::ofstream logFile;
+}
 #define COUT( x )                                                                                                                                                        \
     {                                                                                                                                                                    \
-        log_file << x << std::endl;                                                                                                                                      \
-        log_file.flush();                                                                                                                                                \
+        Logging::logFile << x << std::endl;                                                                                                                              \
+        Logging::logFile.flush();                                                                                                                                        \
     }
 #else // Default: log to STDERR
 #define COUT( x )                                                                                                                                                        \


### PR DESCRIPTION
Hi @ihhub,

I merged the latest changes into my Nintendo Switch branch. Here are the manual changes I made in the process, which I think belong to the master branch:

- `logFile` variable is made visible in `logging.h` in order to be used in `COUT` macro
- the Switch-specific data path is no longer hardcoded, instead it is passed via `CONFIGURE_FHEROES2_DATA` macro from the Makefile
- Switch-specific Makefile fixes

With these changes, the master branch can be built for Nintendo Switch. The only remaining changes exclusive to my switch branch are:
- custom hardcoded screen resolution (848x480)
- related touchscreen fixes in `localevent.cpp`

I don't think there is a need for such custom resolutions in the master branch, let me know if there is. I could think of a way to implement this in a platform-independent way (e.g. something like `forced resolution = AAxBB` parameter in the config file).