### PR TITLE
Fix wrong controller pointer speed option name and touch coordinates translation

### DIFF
--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1153,10 +1153,8 @@ void LocalEvent::HandleTouchEvent( const SDL_TouchFingerEvent & event )
 
         SetModes( MOUSE_MOTION );
 
-        _emulatedPointerPosX = ( ( screenResolution.width * event.x ) - ( screenResolution.width - windowRect.width - windowRect.x ) )
-                               * ( static_cast<double>( gameSurfaceRes.width ) / windowRect.width );
-        _emulatedPointerPosY = ( ( screenResolution.height * event.y ) - ( screenResolution.height - windowRect.height - windowRect.y ) )
-                               * ( static_cast<double>( gameSurfaceRes.height ) / windowRect.height );
+        _emulatedPointerPosX = ( screenResolution.width * event.x - windowRect.x ) * ( static_cast<double>( gameSurfaceRes.width ) / windowRect.width );
+        _emulatedPointerPosY = ( screenResolution.height * event.y - windowRect.y ) * ( static_cast<double>( gameSurfaceRes.height ) / windowRect.height );
 
         mouse_cu.x = static_cast<int16_t>( _emulatedPointerPosX );
         mouse_cu.y = static_cast<int16_t>( _emulatedPointerPosY );

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -635,8 +635,8 @@ bool Settings::Read( const std::string & filename )
         }
     }
 
-    if ( config.Exists( "controller_pointer_speed" ) ) {
-        _controllerPointerSpeed = config.IntParams( "controller_pointer_speed" );
+    if ( config.Exists( "controller pointer speed" ) ) {
+        _controllerPointerSpeed = config.IntParams( "controller pointer speed" );
         if ( _controllerPointerSpeed > 100 )
             _controllerPointerSpeed = 100;
         else if ( _controllerPointerSpeed < 0 )


### PR DESCRIPTION
Changed config option name for controller pointer speed to `controller pointer speed`.
Also included fix for correct touch coordinate translation for non-centered windows/game areas.