### PR TITLE
Add asynchronous execution of MIDI calls

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,7 @@ endif
 CFLAGS := $(CFLAGS) -fsigned-char
 CXXFLAGS := -std=c++11 $(CFLAGS)
 LDFLAGS := $(LDFLAGS)
-LIBS :=
+LIBS := -pthread
 
 CFLAGS_TP := $(CFLAGS)
 CXXFLAGS_TP := $(CXXFLAGS)

--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -149,8 +149,7 @@ namespace AGG
         AsyncSoundManager()
             : _exitFlag( 0 )
             , _runFlag( 1 )
-        {
-        }
+        {}
 
         ~AsyncSoundManager()
         {
@@ -233,9 +232,10 @@ namespace AGG
 
             _mutex.unlock();
 
-            std::unique_lock < std::mutex > mutexLock( _mutex );
+            std::unique_lock<std::mutex> mutexLock( _mutex );
             _masterNotification.wait( mutexLock, [&] { return _runFlag == 0; } );
         }
+
     private:
         std::unique_ptr<std::thread> _worker;
         std::mutex _mutex;
@@ -243,9 +243,9 @@ namespace AGG
         std::condition_variable _workerNotification;
         std::condition_variable _masterNotification;
 
-        std::queue<std::pair<int, bool>> _musicTasks;
+        std::queue<std::pair<int, bool> > _musicTasks;
         std::queue<int> _soundTasks;
-        std::queue<std::vector<int>> _loopSoundTasks;
+        std::queue<std::vector<int> > _loopSoundTasks;
 
         uint8_t _exitFlag;
         uint8_t _runFlag;
@@ -254,9 +254,9 @@ namespace AGG
         {
             if ( !_worker ) {
                 _runFlag = 1;
-                _worker.reset( new std::thread ( AsyncSoundManager::_workerThread, this ) );
+                _worker.reset( new std::thread( AsyncSoundManager::_workerThread, this ) );
 
-                std::unique_lock < std::mutex > mutexLock( _mutex );
+                std::unique_lock<std::mutex> mutexLock( _mutex );
                 _masterNotification.wait( mutexLock, [&] { return _runFlag == 0; } );
             }
         }
@@ -271,7 +271,7 @@ namespace AGG
             manager->_mutex.unlock();
 
             while ( manager->_exitFlag == 0 ) {
-                std::unique_lock < std::mutex > mutexLock( manager->_mutex );
+                std::unique_lock<std::mutex> mutexLock( manager->_mutex );
                 manager->_workerNotification.wait( mutexLock, [&] { return manager->_runFlag == 1; } );
                 mutexLock.unlock();
 

--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -171,7 +171,7 @@ namespace AGG
         {
             _createThreadIfNeeded();
 
-            _mutex.lock();
+            std::lock_guard<std::mutex> mutexLock( _mutex );
 
             while ( !_musicTasks.empty() ) {
                 _musicTasks.pop();
@@ -180,39 +180,33 @@ namespace AGG
             _musicTasks.emplace( musicId, isLooped );
             _runFlag = 1;
             _workerNotification.notify_all();
-
-            _mutex.unlock();
         }
 
         void pushSound( const int m82Sound )
         {
             _createThreadIfNeeded();
 
-            _mutex.lock();
+            std::lock_guard<std::mutex> mutexLock( _mutex );
 
             _soundTasks.emplace( m82Sound );
             _runFlag = 1;
             _workerNotification.notify_all();
-
-            _mutex.unlock();
         }
 
         void pushLoopSound( const std::vector<int> & vols )
         {
             _createThreadIfNeeded();
 
-            _mutex.lock();
+            std::lock_guard<std::mutex> mutexLock( _mutex );
 
             _loopSoundTasks.emplace( vols );
             _runFlag = 1;
             _workerNotification.notify_all();
-
-            _mutex.unlock();
         }
 
         void sync()
         {
-            _mutex.lock();
+            std::lock_guard<std::mutex> mutexLock( _mutex );
 
             while ( !_musicTasks.empty() ) {
                 _musicTasks.pop();
@@ -225,8 +219,6 @@ namespace AGG
             while ( !_loopSoundTasks.empty() ) {
                 _loopSoundTasks.pop();
             }
-
-            _mutex.unlock();
         }
 
         // This mutex is used to avoid access to global objects and classes related to SDL Mixer.

--- a/src/fheroes2/agg/agg.h
+++ b/src/fheroes2/agg/agg.h
@@ -38,10 +38,10 @@ namespace AGG
 #ifdef WITH_TTF
     u32 GetFontHeight( bool small );
 #endif
-    void LoadLOOPXXSounds( const std::vector<int> & );
-    void PlaySound( int m82 );
-    void PlayMusic( int mus, bool loop = true );
-    void ResetMixer( void );
+    void LoadLOOPXXSounds( const std::vector<int> & vols, bool asyncronizedCall = false );
+    void PlaySound( int m82, bool asyncronizedCall = false );
+    void PlayMusic( int mus, bool loop = true, bool asyncronizedCall = false );
+    void ResetMixer();
 }
 
 namespace fheroes2

--- a/src/fheroes2/ai/ai_base.cpp
+++ b/src/fheroes2/ai/ai_base.cpp
@@ -162,7 +162,7 @@ namespace AI
         }
 
         if ( !Settings::Get().MusicMIDI() )
-            AGG::PlayMusic( MUS::COMPUTER_TURN );
+            AGG::PlayMusic( MUS::COMPUTER_TURN, true, true );
 
         Interface::StatusWindow & status = Interface::Basic::Get().GetStatusWindow();
 

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -457,7 +457,7 @@ namespace AI
             AI::Get().HeroesActionComplete( hero );
 
         // reset if during an action music was stopped
-        AGG::PlayMusic( MUS::COMPUTER_TURN );
+        AGG::PlayMusic( MUS::COMPUTER_TURN, true, true );
     }
 
     void AIToHeroes( Heroes & hero, s32 dst_index )

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -44,7 +44,7 @@ namespace AI
         Interface::StatusWindow & status = Interface::Basic::Get().GetStatusWindow();
         status.RedrawTurnProgress( 0 );
 
-        AGG::PlayMusic( MUS::COMPUTER_TURN );
+        AGG::PlayMusic( MUS::COMPUTER_TURN, true, true );
         KingdomHeroes & heroes = kingdom.GetHeroes();
         KingdomCastles & castles = kingdom.GetCastles();
 

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -419,7 +419,7 @@ void Battle::Arena::Turns( void )
     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, current_turn );
 
     if ( interface && conf.Music() && !Music::isPlaying() )
-        AGG::PlayMusic( MUS::GetBattleRandom() );
+        AGG::PlayMusic( MUS::GetBattleRandom(), true, true );
 
     army1->NewTurn();
     army2->NewTurn();

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -305,7 +305,7 @@ int Castle::OpenDialog( bool readonly )
     buttonNextCastle.draw();
     buttonExit.draw();
 
-    AGG::PlayMusic( MUS::FromRace( race ) );
+    AGG::PlayMusic( MUS::FromRace( race ), true, true );
 
     LocalEvent & le = LocalEvent::Get();
     cursor.Show();

--- a/src/fheroes2/game/game_credits.cpp
+++ b/src/fheroes2/game/game_credits.cpp
@@ -117,7 +117,7 @@ void Game::ShowCredits()
     const fheroes2::Sprite & goblin = fheroes2::AGG::GetICN( ICN::GOBLIN, 27 );
     fheroes2::Blit( goblin, display, screenOffset.x + ( display.DEFAULT_WIDTH - goblin.width() ) / 2, screenOffset.y + ( display.DEFAULT_HEIGHT - goblin.height() ) / 2 );
 
-    AGG::PlayMusic( MUS::VICTORY );
+    AGG::PlayMusic( MUS::VICTORY, true, true );
 
     LocalEvent & le = LocalEvent::Get();
     while ( le.HandleEvents() ) {

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -199,7 +199,7 @@ int Game::HighScores()
 
     cursor.SetThemes( cursor.POINTER );
     Mixer::Pause();
-    AGG::PlayMusic( MUS::MAINMENU );
+    AGG::PlayMusic( MUS::MAINMENU, true, true );
     hgs.Load( stream.str().c_str() );
 
     const fheroes2::Sprite & back = fheroes2::AGG::GetICN( ICN::HSBKG, 0 );

--- a/src/fheroes2/game/game_loadgame.cpp
+++ b/src/fheroes2/game/game_loadgame.cpp
@@ -134,7 +134,7 @@ int Game::LoadMulti( void )
 int Game::LoadGame( void )
 {
     Mixer::Pause();
-    AGG::PlayMusic( MUS::MAINMENU );
+    AGG::PlayMusic( MUS::MAINMENU, true, true );
     fheroes2::Display & display = fheroes2::Display::instance();
 
     Cursor & cursor = Cursor::Get();
@@ -232,7 +232,7 @@ int Game::LoadStandard( void )
 int Game::DisplayLoadGameDialog()
 {
     Mixer::Pause();
-    AGG::PlayMusic( MUS::MAINMENU );
+    AGG::PlayMusic( MUS::MAINMENU, true, true );
     // cursor
     Cursor & cursor = Cursor::Get();
     cursor.SetThemes( cursor.POINTER );

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -45,7 +45,7 @@
 int Game::MainMenu( bool isFirstGameRun )
 {
     Mixer::Pause();
-    AGG::PlayMusic( MUS::MAINMENU );
+    AGG::PlayMusic( MUS::MAINMENU, true, true );
 
     Settings & conf = Settings::Get();
 

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -108,7 +108,7 @@ int Game::NewCampaign()
     campaignSaveData.setCampaignID( chosenCampaign );
     campaignSaveData.setCurrentScenarioID( 0 );
 
-    AGG::PlayMusic( MUS::VICTORY );
+    AGG::PlayMusic( MUS::VICTORY, true, true );
 
     return Game::SELECT_CAMPAIGN_SCENARIO;
 }
@@ -176,7 +176,7 @@ int Game::NewNetwork( void )
 int Game::NewGame( void )
 {
     Mixer::Pause();
-    AGG::PlayMusic( MUS::MAINMENU );
+    AGG::PlayMusic( MUS::MAINMENU, true, true );
     Settings & conf = Settings::Get();
 
     // reset last save name

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -92,7 +92,7 @@ int Game::ScenarioInfo( void )
 {
     Settings & conf = Settings::Get();
 
-    AGG::PlayMusic( MUS::MAINMENU );
+    AGG::PlayMusic( MUS::MAINMENU, true, true );
 
     MapsFileInfoList lists;
     if ( !PrepareMapsFileInfoList( lists, ( conf.IsGameType( Game::TYPE_MULTI ) ) ) ) {

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -650,7 +650,7 @@ int Interface::Basic::HumanTurn( bool isload )
         if ( 1 < world.CountWeek() && world.BeginWeek() ) {
             const int currentMusic = Game::CurrentMusic();
             ShowNewWeekDialog();
-            AGG::PlayMusic( currentMusic, true );
+            AGG::PlayMusic( currentMusic, true, true );
         }
 
         // show event day

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -57,8 +57,8 @@ void Interface::Basic::SetFocus( Heroes * hero )
 
         const int heroIndexPos = hero->GetIndex();
         if ( !Game::ChangeMusicDisabled() && heroIndexPos >= 0 ) {
-            AGG::PlayMusic( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ) );
             Game::EnvironmentSoundMixer();
+            AGG::PlayMusic( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), true, true );
         }
     }
 }
@@ -83,8 +83,8 @@ void Interface::Basic::SetFocus( Castle * castle )
         gameArea.SetCenter( castle->GetCenter() );
         statusWindow.SetState( StatusType::STATUS_FUNDS );
 
-        AGG::PlayMusic( MUS::FromGround( world.GetTiles( castle->GetIndex() ).GetGround() ) );
         Game::EnvironmentSoundMixer();
+        AGG::PlayMusic( MUS::FromGround( world.GetTiles( castle->GetIndex() ).GetGround() ), true, true );
     }
 }
 

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -76,7 +76,7 @@ void PlayWalkSound( int ground )
     }
 
     if ( wav != M82::UNKNOWN )
-        AGG::PlaySound( wav );
+        AGG::PlaySound( wav, true );
 }
 
 bool ReflectSprite( int from )


### PR DESCRIPTION
SDL Mixer can execute tasks only in one thread. In this case some systems face huge delays during gameplay. To avoid such horror we are shooting asynchronous tasks for cases when we don't expect music to be executed immediately.

close #1008 