### PR TITLE
[Bugfix][2822] Sound off when minimized

### DIFF
--- a/src/engine/audio_music.cpp
+++ b/src/engine/audio_music.cpp
@@ -101,8 +101,10 @@ u16 Music::Volume( int16_t vol )
 
 void Music::Pause( void )
 {
-    if ( music )
+    if ( music ) {
+        std::cout << "sdl pausing music" << std::endl;
         Mix_PauseMusic();
+    }
 }
 
 void Music::Resume( void )
@@ -312,10 +314,14 @@ u16 Music::Volume( int16_t vol )
 
 void Music::Pause( void )
 {
-    if ( !System::GetEnvironment( "MUSIC_WRAPPER" ) )
+    if ( !System::GetEnvironment( "MUSIC_WRAPPER" ) ) {
+        std::cout << "reset" << std::endl;
         Reset();
-    else if ( current != musics.end() && ( *current ).isPlay() && !( *current ).isPaused() )
+    }
+    else if ( current != musics.end() && ( *current ).isPlay() && !( *current ).isPaused() ) {
+        std::cout << "pause music" << std::endl;
         ( *current ).Pause();
+    }
 }
 
 void Music::Resume( void )

--- a/src/engine/audio_music.cpp
+++ b/src/engine/audio_music.cpp
@@ -101,10 +101,8 @@ u16 Music::Volume( int16_t vol )
 
 void Music::Pause( void )
 {
-    if ( music ) {
-        std::cout << "sdl pausing music" << std::endl;
+    if ( music )
         Mix_PauseMusic();
-    }
 }
 
 void Music::Resume( void )
@@ -314,14 +312,10 @@ u16 Music::Volume( int16_t vol )
 
 void Music::Pause( void )
 {
-    if ( !System::GetEnvironment( "MUSIC_WRAPPER" ) ) {
-        std::cout << "reset" << std::endl;
+    if ( !System::GetEnvironment( "MUSIC_WRAPPER" ) )
         Reset();
-    }
-    else if ( current != musics.end() && ( *current ).isPlay() && !( *current ).isPaused() ) {
-        std::cout << "pause music" << std::endl;
+    else if ( current != musics.end() && ( *current ).isPlay() && !( *current ).isPaused() )
         ( *current ).Pause();
-    }
 }
 
 void Music::Resume( void )

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -52,6 +52,7 @@ LocalEvent::LocalEvent()
     , _isHiddenWindow( false )
     , _isMusicPaused( false )
     , _isSoundPaused( false )
+    , _musicVolume( 0 )
 {}
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -26,7 +26,6 @@
 #include "error.h"
 #include "pal.h"
 #include "screen.h"
-#include <iostream>
 
 namespace
 {
@@ -993,35 +992,7 @@ bool LocalEvent::HandleEvents( bool delay, bool allowExit )
         switch ( event.type ) {
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
         case SDL_WINDOWEVENT:
-            if ( Mixer::isValid() ) {
-                const int eventId = static_cast<int>( event.window.event );
-                if ( eventId == SDL_WINDOWEVENT_FOCUS_LOST ) { // 7 or 13
-                    std::cout << "focus lost" << std::endl;
-                    _isHiddenWindow = true;
-                    _isMusicPaused = Music::isPaused();
-                    _isSoundPaused = Mixer::isPaused( -1 );
-                    Mixer::Pause();
-                    Music::Pause();
-                    _volume = Music::Volume( 0 );
-                    loop_delay = 100;
-                }
-                else if ( eventId == SDL_WINDOWEVENT_FOCUS_GAINED ) { // or 12
-                    std::cout << "focus gained" << std::endl;
-                    if ( _isHiddenWindow ) {
-                        if ( !_isMusicPaused ) {
-                            Music::Volume( _volume );
-                            Music::Resume();
-                        }
-                        if ( !_isSoundPaused )
-                            Mixer::Resume();
-                        _isHiddenWindow = false;
-                    }
-                    loop_delay = 1;
-                }
-                else {
-                    std::cout << "unhandled window event '" << eventId << "'" << std::endl;
-                }
-            }
+            OnSdl2WindowEvent( event );
             break;
 #else
         case SDL_ACTIVEEVENT:
@@ -1141,6 +1112,33 @@ bool LocalEvent::HandleEvents( bool delay, bool allowExit )
 }
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
+void LocalEvent::OnSdl2WindowEvent( const SDL_Event & event )
+{
+    if ( Mixer::isValid() ) {
+        if ( event.window.event == SDL_WINDOWEVENT_FOCUS_LOST ) {
+            _isHiddenWindow = true;
+            _isMusicPaused = Music::isPaused();
+            _isSoundPaused = Mixer::isPaused( -1 );
+            Mixer::Pause();
+            Music::Pause();
+            _volume = Music::Volume( 0 );
+            loop_delay = 100;
+        }
+        else if ( event.window.event == SDL_WINDOWEVENT_FOCUS_GAINED ) {
+            if ( _isHiddenWindow ) {
+                if ( !_isMusicPaused ) {
+                    Music::Volume( _volume );
+                    Music::Resume();
+                }
+                if ( !_isSoundPaused )
+                    Mixer::Resume();
+                _isHiddenWindow = false;
+            }
+            loop_delay = 1;
+        }
+    }
+}
+
 void LocalEvent::HandleTouchEvent( const SDL_TouchFingerEvent & event )
 {
     if ( event.touchId != 0 )

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -52,7 +52,7 @@ LocalEvent::LocalEvent()
     , _isHiddenWindow( false )
     , _isMusicPaused( false )
     , _isSoundPaused( false )
-    , _volume( 0 )
+    , _musicVolume( 0 )
 {}
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
@@ -1121,13 +1121,13 @@ void LocalEvent::OnSdl2WindowEvent( const SDL_Event & event )
             _isSoundPaused = Mixer::isPaused( -1 );
             Mixer::Pause();
             Music::Pause();
-            _volume = Music::Volume( 0 );
+            _musicVolume = Music::Volume( 0 );
             loop_delay = 100;
         }
         else if ( event.window.event == SDL_WINDOWEVENT_FOCUS_GAINED ) {
             if ( _isHiddenWindow ) {
                 if ( !_isMusicPaused ) {
-                    Music::Volume( _volume );
+                    Music::Volume( _musicVolume );
                     Music::Resume();
                 }
                 if ( !_isSoundPaused )

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1105,11 +1105,7 @@ void LocalEvent::StopSounds()
     _isSoundPaused = Mixer::isPaused( -1 );
     Mixer::Pause();
     Music::Pause();
-
-#if SDL_VERSION_ATLEAST( 2, 0, 0 )
     _musicVolume = Music::Volume( 0 );
-#endif
-
     loop_delay = 100;
 }
 
@@ -1117,9 +1113,7 @@ void LocalEvent::ResumeSounds()
 {
     if ( _isHiddenWindow ) {
         if ( !_isMusicPaused ) {
-#if SDL_VERSION_ATLEAST( 2, 0, 0 )
             Music::Volume( _musicVolume );
-#endif
             Music::Resume();
         }
         if ( !_isSoundPaused )

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1112,8 +1112,8 @@ void LocalEvent::StopSounds()
 void LocalEvent::ResumeSounds()
 {
     if ( _isHiddenWindow ) {
+        Music::Volume( _musicVolume );
         if ( !_isMusicPaused ) {
-            Music::Volume( _musicVolume );
             Music::Resume();
         }
         if ( !_isSoundPaused )

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -52,7 +52,6 @@ LocalEvent::LocalEvent()
     , _isHiddenWindow( false )
     , _isMusicPaused( false )
     , _isSoundPaused( false )
-    , _musicVolume( 0 )
 {}
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -269,6 +269,7 @@ public:
     void OpenController();
     void CloseController();
     void OpenTouchpad();
+    void OnSdl2WindowEvent( const SDL_Event & event );
 #endif
 
     void SetControllerPointerSpeed( const int newSpeed )

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -344,7 +344,9 @@ private:
     bool _isHiddenWindow;
     bool _isMusicPaused;
     bool _isSoundPaused;
+#if SDL_VERSION_ATLEAST( 2, 0, 0 )
     uint16_t _musicVolume;
+#endif
 
     enum
     {

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -343,6 +343,7 @@ private:
     bool _isHiddenWindow;
     bool _isMusicPaused;
     bool _isSoundPaused;
+    u16 _volume;
 
     enum
     {

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -346,9 +346,7 @@ private:
     bool _isHiddenWindow;
     bool _isMusicPaused;
     bool _isSoundPaused;
-#if SDL_VERSION_ATLEAST( 2, 0, 0 )
     uint16_t _musicVolume;
-#endif
 
     enum
     {

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -344,7 +344,7 @@ private:
     bool _isHiddenWindow;
     bool _isMusicPaused;
     bool _isSoundPaused;
-    u16 _volume;
+    uint16_t _musicVolume;
 
     enum
     {

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -269,7 +269,6 @@ public:
     void OpenController();
     void CloseController();
     void OpenTouchpad();
-    void OnSdl2WindowEvent( const SDL_Event & event );
 #endif
 
     void SetControllerPointerSpeed( const int newSpeed )
@@ -285,6 +284,8 @@ private:
     void HandleMouseMotionEvent( const SDL_MouseMotionEvent & );
     void HandleMouseButtonEvent( const SDL_MouseButtonEvent & );
     void HandleKeyboardEvent( const SDL_KeyboardEvent & );
+    void StopSounds();
+    void ResumeSounds();
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
     void HandleMouseWheelEvent( const SDL_MouseWheelEvent & );
@@ -293,6 +294,7 @@ private:
     void HandleControllerButtonEvent( const SDL_ControllerButtonEvent & button );
     void ProcessControllerAxisMotion();
     void HandleTouchEvent( const SDL_TouchFingerEvent & event );
+    void OnSdl2WindowEvent( const SDL_Event & event );
 #else
     static int GlobalFilterEvents( const SDL_Event * );
 #endif


### PR DESCRIPTION
Hello!

This a _partial_ fix for #2822 (MacOS/SDL2/**SDL_Mixer**)

What was done:

1. SDL2 window event handling logic was moved into a separate function (`OnSdl2WindowEvent`) beause `LocalEvent::HandleEvents` is too big and complex;
2. Changed detected events types from window hidden/shown to focus lost/acuired;
3. Unfortunately, SDL_Mixer doesn't pause played music _immediately_. I didn't consider halting and restarting music on focus change because it would restart a song each time - probably not good. Instead, here is a workaround - store current volume, set to zero and restore when focus is aquired