### PR TITLE
Fix Split-related issues, and Implement some new ones

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -776,12 +776,12 @@ void Troops::SplitTroopIntoFreeSlots( const Troop & troop, const Troop & selecte
     uint32_t remainingCount = troop.GetCount() % slots;
     uint32_t remainingSlots = slots;
 
-    auto TryCreateTroopChunk = [&]( iterator it ) {
+    auto TryCreateTroopChunk = [&]( Troop * emptyTroop ) {
         if ( remainingSlots <= 0 )
             return;
 
-        if ( !( *it )->isValid() ) {
-            ( *it )->Set( troop.GetMonster(), remainingCount > 0 ? chunk + 1 : chunk );
+        if ( !emptyTroop->isValid() ) {
+            emptyTroop->Set( troop.GetMonster(), remainingCount > 0 ? chunk + 1 : chunk );
             --remainingSlots;
 
             if ( remainingCount > 0 )
@@ -790,15 +790,16 @@ void Troops::SplitTroopIntoFreeSlots( const Troop & troop, const Troop & selecte
     };
 
     const iterator selectedSlotIterator = std::find( begin(), end(), &selectedSlot );
+    const reverse_iterator selectedSlotReverseIterator = std::find( rbegin(), rend(), &selectedSlot );
 
     // try to create chunks to the right of the selected slot
     for ( iterator it = selectedSlotIterator + 1; it != end(); ++it ) {
-        TryCreateTroopChunk( it );
+        TryCreateTroopChunk( *it );
     }
 
     // this time, try to create chunks to the left of the selected slot
-    for ( iterator it = selectedSlotIterator - 1; it != begin(); --it ) {
-        TryCreateTroopChunk( it );
+    for ( reverse_iterator it = selectedSlotReverseIterator - 1; it != rend(); ++it ) {
+        TryCreateTroopChunk( *it );
     }
 }
 

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -792,6 +792,10 @@ void Troops::SplitTroopIntoFreeSlots( const Troop & troop, const Troop & selecte
     const iterator selectedSlotIterator = std::find( begin(), end(), &selectedSlot );
     const reverse_iterator selectedSlotReverseIterator = std::find( rbegin(), rend(), &selectedSlot );
 
+    // this means the selected slot is actually not part of the army, which is not the intended logic
+    if ( selectedSlotIterator == end() || selectedSlotReverseIterator == rend() )
+        return;
+
     // try to create chunks to the right of the selected slot
     for ( iterator it = selectedSlotIterator + 1; it != end(); ++it ) {
         TryCreateTroopChunk( **it );

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -803,7 +803,7 @@ void Troops::SplitTroopIntoFreeSlots( const Troop & troop, const Troop & selecte
     }
 
     // this time, try to create chunks to the left of the selected slot
-    for ( int i = static_cast<int>( iteratorIndex - 1 ); i >= 0; --i ) {
+    for ( int i = static_cast<int>( iteratorIndex ) - 1; i >= 0; --i ) {
         TryCreateTroopChunk( *GetTroop( i ) );
     }
 }

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -776,12 +776,12 @@ void Troops::SplitTroopIntoFreeSlots( const Troop & troop, const Troop & selecte
     uint32_t remainingCount = troop.GetCount() % slots;
     uint32_t remainingSlots = slots;
 
-    auto TryCreateTroopChunk = [&remainingSlots, &remainingCount, chunk, troop]( Troop & emptyTroop ) {
+    auto TryCreateTroopChunk = [&remainingSlots, &remainingCount, chunk, troop]( Troop & newTroop ) {
         if ( remainingSlots <= 0 )
             return;
 
-        if ( !emptyTroop.isValid() ) {
-            emptyTroop.Set( troop.GetMonster(), remainingCount > 0 ? chunk + 1 : chunk );
+        if ( !newTroop.isValid() ) {
+            newTroop.Set( troop.GetMonster(), remainingCount > 0 ? chunk + 1 : chunk );
             --remainingSlots;
 
             if ( remainingCount > 0 )
@@ -790,20 +790,21 @@ void Troops::SplitTroopIntoFreeSlots( const Troop & troop, const Troop & selecte
     };
 
     const iterator selectedSlotIterator = std::find( begin(), end(), &selectedSlot );
-    const reverse_iterator selectedSlotReverseIterator = std::find( rbegin(), rend(), &selectedSlot );
 
     // this means the selected slot is actually not part of the army, which is not the intended logic
-    if ( selectedSlotIterator == end() || selectedSlotReverseIterator == rend() )
+    if ( selectedSlotIterator == end() )
         return;
 
+    const size_t iteratorIndex = selectedSlotIterator - begin();
+
     // try to create chunks to the right of the selected slot
-    for ( iterator it = selectedSlotIterator + 1; it != end(); ++it ) {
-        TryCreateTroopChunk( **it );
+    for ( size_t i = iteratorIndex + 1; i < Size(); ++i ) {
+        TryCreateTroopChunk( *GetTroop( i ) );
     }
 
     // this time, try to create chunks to the left of the selected slot
-    for ( reverse_iterator it = selectedSlotReverseIterator - 1; it != rend(); ++it ) {
-        TryCreateTroopChunk( **it );
+    for ( int i = static_cast<int>( iteratorIndex - 1 ); i >= 0; --i ) {
+        TryCreateTroopChunk( *GetTroop( i ) );
     }
 }
 

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -776,12 +776,12 @@ void Troops::SplitTroopIntoFreeSlots( const Troop & troop, const Troop & selecte
     uint32_t remainingCount = troop.GetCount() % slots;
     uint32_t remainingSlots = slots;
 
-    auto TryCreateTroopChunk = [&]( Troop * emptyTroop ) {
+    auto TryCreateTroopChunk = [&remainingSlots, &remainingCount, chunk, troop]( Troop & emptyTroop ) {
         if ( remainingSlots <= 0 )
             return;
 
-        if ( !emptyTroop->isValid() ) {
-            emptyTroop->Set( troop.GetMonster(), remainingCount > 0 ? chunk + 1 : chunk );
+        if ( !emptyTroop.isValid() ) {
+            emptyTroop.Set( troop.GetMonster(), remainingCount > 0 ? chunk + 1 : chunk );
             --remainingSlots;
 
             if ( remainingCount > 0 )
@@ -794,12 +794,12 @@ void Troops::SplitTroopIntoFreeSlots( const Troop & troop, const Troop & selecte
 
     // try to create chunks to the right of the selected slot
     for ( iterator it = selectedSlotIterator + 1; it != end(); ++it ) {
-        TryCreateTroopChunk( *it );
+        TryCreateTroopChunk( **it );
     }
 
     // this time, try to create chunks to the left of the selected slot
     for ( reverse_iterator it = selectedSlotReverseIterator - 1; it != rend(); ++it ) {
-        TryCreateTroopChunk( *it );
+        TryCreateTroopChunk( **it );
     }
 }
 

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -106,7 +106,7 @@ public:
     void KeepOnlyWeakest( Troops &, bool );
 
     void DrawMons32Line( int32_t, int32_t, uint32_t, uint32_t, uint32_t, uint32_t, bool, bool ) const;
-    void SplitTroopIntoFreeSlots( const Troop &, u32 slots );
+    void SplitTroopIntoFreeSlots( const Troop & troop, const Troop & selectedSlot, const uint32_t slots );
     void AssignToFirstFreeSlot( const Troop &, const uint32_t splitCount );
     void JoinAllTroopsOfType( const Troop & targetTroop );
 };

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -45,7 +45,11 @@ void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * ar
         isTroopInfoVisible = false;
     }
     else {
-        const uint32_t freeSlots = 1 + armyTarget->Size() - armyTarget->GetCount();
+        uint32_t freeSlots = 1 + armyTarget->Size() - armyTarget->GetCount();
+
+        if ( troopFrom.GetID() == troopTarget.GetID() )
+            ++freeSlots;
+
         const uint32_t maxCount = saveLastTroop ? troopFrom.GetCount() - 1 : troopFrom.GetCount();
         uint32_t redistributeCount = troopFrom.GetCount() / 2;
         bool useFastSplit = false;
@@ -66,21 +70,23 @@ void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * ar
             troopFrom.SetCount( troopFromCount - redistributeCount );
         }
         else {
-            int targetArmyTroopCount = troopFrom.GetCount();
+            uint32_t totalSplitTroopCount = troopFrom.GetCount();
 
-            if ( armyFrom != armyTarget )
-                targetArmyTroopCount -= targetArmyTroopCount / slots;
+            if ( troopFrom.GetID() == troopTarget.GetID() ) {
+                totalSplitTroopCount += troopTarget.GetCount();
+                troopTarget.Reset();
+            }
 
             if ( armyFrom == armyTarget ) {
-                const Troop troop( troopFrom, troopFromCount );
+                const Troop troop( troopFrom, totalSplitTroopCount );
                 troopFrom.Reset();
                 armyTarget->SplitTroopIntoFreeSlots( troop, slots );
             }
             else {
-                const uint32_t remainingTroops = ( troopFromCount + slots - 1 ) / slots;
+                const uint32_t remainingTroops = ( totalSplitTroopCount + slots - 1 ) / slots;
 
                 troopFrom.SetCount( remainingTroops );
-                armyTarget->SplitTroopIntoFreeSlots( Troop( troopFrom, troopFromCount - remainingTroops ), slots - 1 );
+                armyTarget->SplitTroopIntoFreeSlots( Troop( troopFrom, totalSplitTroopCount - remainingTroops ), slots - 1 );
             }
         }
     }

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -77,7 +77,7 @@ void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * ar
                 armyTarget->SplitTroopIntoFreeSlots( troop, slots );
             }
             else {
-                const uint32_t remainingTroops = (troopFromCount + slots - 1) / slots;
+                const uint32_t remainingTroops = ( troopFromCount + slots - 1 ) / slots;
 
                 troopFrom.SetCount( remainingTroops );
                 armyTarget->SplitTroopIntoFreeSlots( Troop( troopFrom, troopFromCount - remainingTroops ), slots - 1 );

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -353,7 +353,7 @@ bool ArmyBar::ActionBarLeftMouseSingleClick( ArmyTroop & troop )
     else if ( troop.isValid() ) {
         if ( !read_only ) // select
         {
-            if ( IsSplitHotkeyUsed(troop, _army ))
+            if ( IsSplitHotkeyUsed( troop, _army ) )
                 return false;
 
             Cursor::Get().Hide();

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -77,10 +77,7 @@ void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * ar
                 armyTarget->SplitTroopIntoFreeSlots( troop, slots );
             }
             else {
-                int remainingTroops = troopFromCount / slots;
-
-                if ( troopFromCount % slots != 0 )
-                    remainingTroops++;
+                const uint32_t remainingTroops = (troopFromCount + slots - 1) / slots;
 
                 troopFrom.SetCount( remainingTroops );
                 armyTarget->SplitTroopIntoFreeSlots( Troop( troopFrom, troopFromCount - remainingTroops ), slots - 1 );

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -73,7 +73,7 @@ void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * ar
             troopFrom.SetCount( totalSplitTroopCount - redistributeCount );
         }
         else {
-            if ( isSameTroopType ) 
+            if ( isSameTroopType )
                 totalSplitTroopCount += troopTarget.GetCount();
 
             const uint32_t troopFromSplitCount = ( totalSplitTroopCount + slots - 1 ) / slots;
@@ -88,7 +88,7 @@ void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * ar
 
             totalSplitTroopCount -= troopFromSplitCount;
             totalSplitTroopCount -= troopTargetSplitCount;
-            armyTarget->SplitTroopIntoFreeSlots( Troop( troopFrom, totalSplitTroopCount ), slots - 2);
+            armyTarget->SplitTroopIntoFreeSlots( Troop( troopFrom, totalSplitTroopCount ), slots - 2 );
         }
     }
 }

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -102,6 +102,24 @@ void RedistributeTroopEvenly( ArmyTroop & troopFrom, Army * armyTarget )
     RedistributeTroopToFirstFreeSlot( troopFrom, armyTarget, troopFrom.GetCount() / 2 );
 }
 
+bool IsSplitHotkeyUsed( ArmyTroop & troopFrom, Army * armyTarget )
+{
+    if ( Game::HotKeyHoldEvent( Game::EVENT_STACKSPLIT_CTRL ) ) {
+        RedistributeTroopByOne( troopFrom, armyTarget );
+        return true;
+    }
+    else if ( Game::HotKeyHoldEvent( Game::EVENT_JOINSTACKS ) ) {
+        armyTarget->JoinAllTroopsOfType( troopFrom );
+        return true;
+    }
+    else if ( Game::HotKeyHoldEvent( Game::EVENT_STACKSPLIT_SHIFT ) ) {
+        RedistributeTroopEvenly( troopFrom, armyTarget );
+        return true;
+    }
+
+    return false;
+}
+
 ArmyBar::ArmyBar( Army * ptr, bool mini, bool ro, bool change /* false */ )
     : spcursor( fheroes2::AGG::GetICN( ICN::STRIP, 1 ) )
     , _army( nullptr )
@@ -335,20 +353,8 @@ bool ArmyBar::ActionBarLeftMouseSingleClick( ArmyTroop & troop )
     else if ( troop.isValid() ) {
         if ( !read_only ) // select
         {
-            if ( Game::HotKeyHoldEvent( Game::EVENT_STACKSPLIT_CTRL ) ) {
-                RedistributeTroopByOne( troop, _army );
-                //selectedTroop->Reset();
+            if ( IsSplitHotkeyUsed(troop, _army ))
                 return false;
-            }
-            else if ( Game::HotKeyHoldEvent( Game::EVENT_JOINSTACKS ) ) {
-                _army->JoinAllTroopsOfType( troop );
-                //selectedTroop->Reset();
-                return false;
-            }
-            else if ( Game::HotKeyHoldEvent( Game::EVENT_STACKSPLIT_SHIFT ) ) {
-                RedistributeTroopEvenly( troop, _army );
-                return false;
-            }
 
             Cursor::Get().Hide();
             spcursor.hide();
@@ -442,15 +448,9 @@ bool ArmyBar::ActionBarLeftMouseSingleClick( ArmyTroop & destTroop, ArmyTroop & 
 
 bool ArmyBar::ActionBarLeftMouseDoubleClick( ArmyTroop & troop )
 {
-    if ( troop.isValid() && !read_only ) {
-        if ( Game::HotKeyHoldEvent( Game::EVENT_STACKSPLIT_CTRL ) ) {
-            RedistributeTroopByOne( troop, _army );
-            return false;
-        }
-        else if ( Game::HotKeyHoldEvent( Game::EVENT_JOINSTACKS ) ) {
-            _army->JoinAllTroopsOfType( troop );
-            return false;
-        }
+    if ( troop.isValid() && !read_only && IsSplitHotkeyUsed( troop, _army ) ) {
+        ResetSelected();
+        return false;
     }
 
     const ArmyTroop * troop2 = GetSelectedItem();

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -88,7 +88,7 @@ void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * ar
 
             totalSplitTroopCount -= troopFromSplitCount;
             totalSplitTroopCount -= troopTargetSplitCount;
-            armyTarget->SplitTroopIntoFreeSlots( Troop( troopFrom, totalSplitTroopCount ), slots - 2 );
+            armyTarget->SplitTroopIntoFreeSlots( Troop( troopFrom, totalSplitTroopCount ), troopTarget, slots - 2 );
         }
     }
 }

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -331,8 +331,8 @@ bool ArmyBar::ActionBarLeftMouseSingleClick( ArmyTroop & troop )
         if ( selectedTroop && selectedTroop->isValid() && Game::HotKeyHoldEvent( Game::EVENT_STACKSPLIT_SHIFT ) ) {
             // redistribute when clicked troop is empty or is the same one as the selected troop
             if ( !troop.isValid() || troop.GetID() == selectedTroop->GetID() ) {
-                ResetSelected();
                 RedistributeArmy( *selectedTroop, troop, _army, _isTroopInfoVisible );
+                ResetSelected();
 
                 return false;
             }
@@ -409,8 +409,8 @@ bool ArmyBar::ActionBarLeftMouseSingleClick( ArmyTroop & destTroop, ArmyTroop & 
 {
     if ( Game::HotKeyHoldEvent( Game::EVENT_STACKSPLIT_SHIFT ) ) {
         if ( destTroop.isEmpty() || destTroop.GetID() == selectedTroop.GetID() ) {
-            ResetSelected();
             RedistributeArmy( selectedTroop, destTroop, _army, _isTroopInfoVisible );
+            ResetSelected();
         }
         return false;
     }
@@ -546,8 +546,9 @@ bool ArmyBar::ActionBarRightMouseSingleClick( ArmyTroop & troop )
         return false;
 
     if ( !troop.isValid() || selectedTroop.GetID() == troop.GetID() ) {
-        ResetSelected();
         RedistributeArmy( selectedTroop, troop, _army, _isTroopInfoVisible );
+        ResetSelected();
+
         return true;
     }
 
@@ -557,8 +558,9 @@ bool ArmyBar::ActionBarRightMouseSingleClick( ArmyTroop & troop )
 bool ArmyBar::ActionBarRightMouseSingleClick( ArmyTroop & destTroop, ArmyTroop & selectedTroop )
 {
     if ( !destTroop.isValid() || destTroop.GetID() == selectedTroop.GetID() ) {
-        ResetSelected();
         RedistributeArmy( selectedTroop, destTroop, _army, _isTroopInfoVisible );
+        ResetSelected();
+
         return true;
     }
 

--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -108,7 +108,7 @@ namespace Dialog
     int ArmyInfo( const Troop & troop, int flags, bool isReflected = false );
     int ArmyJoinFree( const Troop &, Heroes & );
     int ArmyJoinWithCost( const Troop &, u32 join, u32 gold, Heroes & );
-    int ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistributeMax, const bool saveLastTroop, uint32_t & redistributeCount, bool & useRedistribute );
+    int ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistributeMax, const bool saveLastTroop, uint32_t & redistributeCount, bool & useFastSplit );
     void Marketplace( bool fromTradingPost = false );
     void MakeGiftResource( void );
     int BuyBoat( bool enable );

--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -108,7 +108,7 @@ namespace Dialog
     int ArmyInfo( const Troop & troop, int flags, bool isReflected = false );
     int ArmyJoinFree( const Troop &, Heroes & );
     int ArmyJoinWithCost( const Troop &, u32 join, u32 gold, Heroes & );
-    int ArmySplitTroop( int free_slots, u32 max, u32 &, bool );
+    int ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistributeMax, const bool saveLastTroop, uint32_t & redistributeCount, bool & useRedistribute );
     void Marketplace( bool fromTradingPost = false );
     void MakeGiftResource( void );
     int BuyBoat( bool enable );

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -352,7 +352,7 @@ int Dialog::ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistribut
 
     for ( uint32_t i = 0; i < freeSlots - 1; ++i ) {
         sprites[i] = fheroes2::AGG::GetICN( ICN::REQUESTS, spriteIconIdx++ );
-        const float spriteWidth = sprites[i].width() * ( i - minus );
+        const int spriteWidth = static_cast<int>(sprites[i].width() * ( i - minus ));
         const int deltaXWidth = deltaXStart + i * deltaX;
         vrts[i] = fheroes2::Rect( center + spriteWidth + deltaXWidth, pos.y + 95, sprites[i].width(), sprites[i].height() );
     }

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -344,24 +344,24 @@ int Dialog::ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistribut
     sel.Redraw();
 
     fheroes2::MovableSprite ssp;
-
-    std::vector<fheroes2::Sprite> sprites( freeSlots - 1 );
     std::vector<fheroes2::Rect> vrts( freeSlots - 1 );
 
-    int spriteIconIdx = 21;
-    const int deltaX = 10;
-    const int deltaXStart = ( freeSlots - 2 ) * -5;
-
-    for ( uint32_t i = 0; i < freeSlots - 1; ++i ) {
-        sprites[i] = fheroes2::AGG::GetICN( ICN::REQUESTS, spriteIconIdx );
-        ++spriteIconIdx;
-
-        const int spriteWidth = sprites[i].width();
-        const int offset = spriteWidth * ( i - freeSlots / 2 ) + spriteWidth / 2;
-        vrts[i] = fheroes2::Rect( center + offset + deltaXStart + i * deltaX, pos.y + 95, spriteWidth, sprites[i].height() );
-    }
-
     if ( freeSlots > 1 ) {
+        std::vector<fheroes2::Sprite> sprites( freeSlots - 1 );
+
+        int spriteIconIdx = 21;
+        const int deltaX = 10;
+        const int deltaXStart = static_cast<int>( freeSlots - 2 ) * -5;
+
+        for ( uint32_t i = 0; i < freeSlots - 1; ++i ) {
+            sprites[i] = fheroes2::AGG::GetICN( ICN::REQUESTS, spriteIconIdx );
+            ++spriteIconIdx;
+
+            const int spriteWidth = sprites[i].width();
+            const int offset = spriteWidth * ( i - freeSlots / 2 ) + spriteWidth / 2;
+            vrts[i] = fheroes2::Rect( center + offset + deltaXStart + i * deltaX, pos.y + 95, spriteWidth, sprites[i].height() );
+        }
+
         text.Set( _( "Fast separation into slots:" ), Font::BIG );
         text.Blit( center - text.w() / 2, pos.y + 65 );
 

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -345,8 +345,8 @@ int Dialog::ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistribut
 
     fheroes2::MovableSprite ssp;
 
-    std::vector<fheroes2::Sprite> sprites( freeSlots );
-    std::vector<fheroes2::Rect> vrts( freeSlots );
+    std::vector<fheroes2::Sprite> sprites( freeSlots - 1 );
+    std::vector<fheroes2::Rect> vrts( freeSlots - 1 );
 
     int spriteIconIdx = 21;
     const int deltaX = 10;
@@ -358,10 +358,10 @@ int Dialog::ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistribut
 
         const int spriteWidth = sprites[i].width();
         const int offset = spriteWidth * ( i - freeSlots / 2 ) + spriteWidth / 2;
-        vrts[i] = fheroes2::Rect( center + offset + deltaXStart + i * deltaX, pos.y + 95, sprites[i].width(), sprites[i].height() );
+        vrts[i] = fheroes2::Rect( center + offset + deltaXStart + i * deltaX, pos.y + 95, spriteWidth, sprites[i].height() );
     }
 
-    if ( !sprites.empty() ) {
+    if ( freeSlots > 1 ) {
         text.Set( _( "Fast separation into slots:" ), Font::BIG );
         text.Blit( center - text.w() / 2, pos.y + 65 );
 

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -369,10 +369,12 @@ int Dialog::ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistribut
             fheroes2::Blit( sprites[i], display, vrts[i].x, vrts[i].y );
         }
 
-        ssp.hide();
         ssp.resize( sprites[0].width(), sprites[0].height() );
         ssp.reset();
+
         fheroes2::DrawBorder( ssp, 214 );
+        ssp.setPosition( vrts[0].x, vrts[0].y );
+        ssp.show();
     }
 
     fheroes2::ButtonGroup btnGroups( box.GetArea(), Dialog::OK | Dialog::CANCEL );

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -312,7 +312,7 @@ bool Dialog::InputString( const std::string & header, std::string & res )
     return !res.empty();
 }
 
-int Dialog::ArmySplitTroop( int free_slots, u32 max, u32 & cur, bool savelast )
+int Dialog::ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistributeMax, const bool savelastTroop, uint32_t & redistributeCount, bool & useFastSplit )
 {
     fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -324,11 +324,11 @@ int Dialog::ArmySplitTroop( int free_slots, u32 max, u32 & cur, bool savelast )
     const int spacer = 10;
 
     const int defaultYPosition = 160;
-    const int boxHeight = free_slots > 2 ? 90 + spacer : 45;
+    const int boxHeight = 90 + spacer;
     const int boxYPosition = defaultYPosition + ( ( display.height() - display.DEFAULT_HEIGHT ) / 2 ) - boxHeight;
 
     NonFixedFrameBox box( boxHeight, boxYPosition, true );
-    SelectValue sel( min, max, cur, 1 );
+    SelectValue sel( min, redistributeMax, redistributeCount, 1 );
     Text text;
 
     const fheroes2::Rect & pos = box.GetArea();
@@ -341,55 +341,37 @@ int Dialog::ArmySplitTroop( int free_slots, u32 max, u32 & cur, bool savelast )
     sel.Redraw();
 
     fheroes2::MovableSprite ssp;
+    fheroes2::Sprite sp2;
     fheroes2::Sprite sp3;
     fheroes2::Sprite sp4;
     fheroes2::Sprite sp5;
 
-    std::vector<fheroes2::Rect> vrts( 3 );
+    std::vector<fheroes2::Sprite> sprites(freeSlots);
+    std::vector<fheroes2::Rect> vrts( freeSlots );
+    const bool isEven = freeSlots % 2 == 0;
+    const int deltaX = 10;
 
-    fheroes2::Rect & rt3 = vrts[0];
-    fheroes2::Rect & rt4 = vrts[1];
-    fheroes2::Rect & rt5 = vrts[2];
+    float minus = 0.5 * (freeSlots - 1);
+    int spriteIconIdx = 21;
+    int deltaXStart = ( freeSlots - 2 ) * -5;
 
-    switch ( free_slots ) {
-    case 0:
-        break;
-
-    case 3:
-        sp3 = fheroes2::AGG::GetICN( ICN::REQUESTS, 22 );
-        rt3 = fheroes2::Rect( center - sp3.width() / 2, pos.y + 95, sp3.width(), sp3.height() );
-        break;
-
-    case 4:
-        sp3 = fheroes2::AGG::GetICN( ICN::REQUESTS, 22 );
-        sp4 = fheroes2::AGG::GetICN( ICN::REQUESTS, 23 );
-        rt3 = fheroes2::Rect( center - 5 - sp3.width(), pos.y + 95, sp3.width(), sp3.height() );
-        rt4 = fheroes2::Rect( center + 5, pos.y + 95, sp4.width(), sp4.height() );
-        break;
-
-    case 5:
-        sp3 = fheroes2::AGG::GetICN( ICN::REQUESTS, 22 );
-        sp4 = fheroes2::AGG::GetICN( ICN::REQUESTS, 23 );
-        sp5 = fheroes2::AGG::GetICN( ICN::REQUESTS, 24 );
-        rt3 = fheroes2::Rect( center - sp3.width() / 2 - 10 - sp3.width(), pos.y + 95, sp3.width(), sp3.height() );
-        rt4 = fheroes2::Rect( center - sp4.width() / 2, pos.y + 95, sp4.width(), sp4.height() );
-        rt5 = fheroes2::Rect( center + sp5.width() / 2 + 10, pos.y + 95, sp5.width(), sp5.height() );
-        break;
+    for ( int i = 0; i < freeSlots - 1; ++i ) {
+        sprites[i] = fheroes2::AGG::GetICN( ICN::REQUESTS, spriteIconIdx++ );
+        const int spriteWidth = sprites[i].width() * ( i - minus );
+        const int deltaXWidth = deltaXStart + i * deltaX;
+        vrts[i] = fheroes2::Rect( center + spriteWidth + deltaXWidth, pos.y + 95, sprites[i].width(), sprites[i].height() );
     }
 
-    if ( !sp3.empty() ) {
+    if ( !sprites.empty() ) {
         text.Set( _( "Fast separation into slots:" ), Font::BIG );
         text.Blit( center - text.w() / 2, pos.y + 65 );
 
-        fheroes2::Blit( sp3, display, rt3.x, rt3.y );
-
-        if ( !sp4.empty() )
-            fheroes2::Blit( sp4, display, rt4.x, rt4.y );
-        if ( !sp5.empty() )
-            fheroes2::Blit( sp5, display, rt5.x, rt5.y );
+        for ( int i = 0; i < freeSlots - 1; ++i ) {
+            fheroes2::Blit( sprites[i], display, vrts[i].x, vrts[i].y );
+        }
 
         ssp.hide();
-        ssp.resize( sp3.width(), sp3.height() );
+        ssp.resize( sprites[0].width(), sprites[0].height() );
         ssp.reset();
         fheroes2::DrawBorder( ssp, 214 );
     }
@@ -397,7 +379,7 @@ int Dialog::ArmySplitTroop( int free_slots, u32 max, u32 & cur, bool savelast )
     fheroes2::ButtonGroup btnGroups( box.GetArea(), Dialog::OK | Dialog::CANCEL );
     btnGroups.draw();
 
-    const uint32_t maximumAcceptedValue = savelast ? max : max - 1;
+    const uint32_t maximumAcceptedValue = savelastTroop ? redistributeMax : redistributeMax - 1;
 
     const fheroes2::Point minMaxButtonOffset( pos.x + 165, pos.y + 30 );
     fheroes2::ButtonSprite buttonMax( minMaxButtonOffset.x, minMaxButtonOffset.y );
@@ -409,7 +391,7 @@ int Dialog::ArmySplitTroop( int free_slots, u32 max, u32 & cur, bool savelast )
     buttonMin.setSprite( fheroes2::Crop( fheroes2::AGG::GetICN( ICN::BTNMIN, 0 ), buttonArea.x, buttonArea.y, buttonArea.w, buttonArea.h ),
                          fheroes2::Crop( fheroes2::AGG::GetICN( ICN::BTNMIN, 1 ), buttonArea.x, buttonArea.y, buttonArea.w, buttonArea.h ) );
 
-    SwitchMaxMinButtons( buttonMin, buttonMax, cur, maximumAcceptedValue );
+    SwitchMaxMinButtons( buttonMin, buttonMax, redistributeCount, maximumAcceptedValue );
 
     LocalEvent & le = LocalEvent::Get();
 
@@ -425,19 +407,19 @@ int Dialog::ArmySplitTroop( int free_slots, u32 max, u32 & cur, bool savelast )
         if ( buttonMin.isVisible() )
             le.MousePressLeft( buttonMin.area() ) ? buttonMin.drawOnPress() : buttonMin.drawOnRelease();
 
-        if ( PressIntKey( max, cur ) ) {
-            sel.SetCur( cur );
+        if ( PressIntKey( redistributeMax, redistributeCount ) ) {
+            sel.SetCur( redistributeCount );
             redraw_count = true;
         }
         else if ( buttonMax.isVisible() && le.MouseClickLeft( buttonMax.area() ) ) {
             le.MousePressLeft( buttonMax.area() ) ? buttonMax.drawOnPress() : buttonMax.drawOnRelease();
-            cur = maximumAcceptedValue;
+            redistributeCount = maximumAcceptedValue;
             sel.SetCur( maximumAcceptedValue );
             redraw_count = true;
         }
         else if ( buttonMin.isVisible() && le.MouseClickLeft( buttonMin.area() ) ) {
             le.MousePressLeft( buttonMin.area() ) ? buttonMin.drawOnPress() : buttonMin.drawOnRelease();
-            cur = min;
+            redistributeCount = min;
             sel.SetCur( min );
             redraw_count = true;
         }
@@ -456,7 +438,7 @@ int Dialog::ArmySplitTroop( int free_slots, u32 max, u32 & cur, bool savelast )
             }
 
         if ( redraw_count ) {
-            SwitchMaxMinButtons( buttonMin, buttonMax, cur, maximumAcceptedValue );
+            SwitchMaxMinButtons( buttonMin, buttonMax, redistributeCount, maximumAcceptedValue );
             cursor.Hide();
             if ( !ssp.empty() )
                 ssp.hide();
@@ -479,20 +461,24 @@ int Dialog::ArmySplitTroop( int free_slots, u32 max, u32 & cur, bool savelast )
     int result = 0;
 
     if ( bres == Dialog::OK ) {
-        cur = sel();
+        redistributeCount = sel();
 
         if ( !ssp.isHidden() ) {
             const fheroes2::Rect rt( ssp.x(), ssp.y(), ssp.width(), ssp.height() );
 
-            if ( rt == rt3 )
-                result = 3;
-            else if ( rt == rt4 )
-                result = 4;
-            else if ( rt == rt5 )
-                result = 5;
+            for ( int i = 0; i < freeSlots - 1; ++i ) {
+                if ( rt == vrts[i] ) {
+                    result = i + 2;
+                    break;
+                }
+            }
+
+            useFastSplit = true;
         }
-        else
+        else {
             result = 2;
+            useFastSplit = false;
+        }
     }
 
     return result;

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -344,16 +344,15 @@ int Dialog::ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistribut
 
     std::vector<fheroes2::Sprite> sprites( freeSlots );
     std::vector<fheroes2::Rect> vrts( freeSlots );
-    const bool isEven = freeSlots % 2 == 0;
     const int deltaX = 10;
 
     float minus = 0.5 * ( freeSlots - 1 );
     int spriteIconIdx = 21;
     int deltaXStart = ( freeSlots - 2 ) * -5;
 
-    for ( int i = 0; i < freeSlots - 1; ++i ) {
+    for ( uint32_t i = 0; i < freeSlots - 1; ++i ) {
         sprites[i] = fheroes2::AGG::GetICN( ICN::REQUESTS, spriteIconIdx++ );
-        const int spriteWidth = sprites[i].width() * ( i - minus );
+        const float spriteWidth = sprites[i].width() * ( i - minus );
         const int deltaXWidth = deltaXStart + i * deltaX;
         vrts[i] = fheroes2::Rect( center + spriteWidth + deltaXWidth, pos.y + 95, sprites[i].width(), sprites[i].height() );
     }
@@ -362,7 +361,7 @@ int Dialog::ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistribut
         text.Set( _( "Fast separation into slots:" ), Font::BIG );
         text.Blit( center - text.w() / 2, pos.y + 65 );
 
-        for ( int i = 0; i < freeSlots - 1; ++i ) {
+        for ( uint32_t i = 0; i < freeSlots - 1; ++i ) {
             fheroes2::Blit( sprites[i], display, vrts[i].x, vrts[i].y );
         }
 
@@ -462,7 +461,7 @@ int Dialog::ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistribut
         if ( !ssp.isHidden() ) {
             const fheroes2::Rect rt( ssp.x(), ssp.y(), ssp.width(), ssp.height() );
 
-            for ( int i = 0; i < freeSlots - 1; ++i ) {
+            for ( uint32_t i = 0; i < freeSlots - 1; ++i ) {
                 if ( rt == vrts[i] ) {
                     result = i + 2;
                     break;

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -346,13 +346,13 @@ int Dialog::ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistribut
     std::vector<fheroes2::Rect> vrts( freeSlots );
     const int deltaX = 10;
 
-    float minus = 0.5 * ( freeSlots - 1 );
+    float spriteWidthStart = -0.5f * ( freeSlots - 1 );
     int spriteIconIdx = 21;
     int deltaXStart = ( freeSlots - 2 ) * -5;
 
     for ( uint32_t i = 0; i < freeSlots - 1; ++i ) {
         sprites[i] = fheroes2::AGG::GetICN( ICN::REQUESTS, spriteIconIdx++ );
-        const int spriteWidth = static_cast<int>( sprites[i].width() * ( i - minus ) );
+        const int spriteWidth = static_cast<int>( sprites[i].width() * ( i + spriteWidthStart ) );
         const int deltaXWidth = deltaXStart + i * deltaX;
         vrts[i] = fheroes2::Rect( center + spriteWidth + deltaXWidth, pos.y + 95, sprites[i].width(), sprites[i].height() );
     }

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -324,7 +324,7 @@ int Dialog::ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistribut
     const int spacer = 10;
 
     const int defaultYPosition = 160;
-    const int boxHeight = 90 + spacer;
+    const int boxHeight = freeSlots > 1 ? 90 + spacer : 45;
     const int boxYPosition = defaultYPosition + ( ( display.height() - display.DEFAULT_HEIGHT ) / 2 ) - boxHeight;
 
     NonFixedFrameBox box( boxHeight, boxYPosition, true );
@@ -341,17 +341,13 @@ int Dialog::ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistribut
     sel.Redraw();
 
     fheroes2::MovableSprite ssp;
-    fheroes2::Sprite sp2;
-    fheroes2::Sprite sp3;
-    fheroes2::Sprite sp4;
-    fheroes2::Sprite sp5;
 
-    std::vector<fheroes2::Sprite> sprites(freeSlots);
+    std::vector<fheroes2::Sprite> sprites( freeSlots );
     std::vector<fheroes2::Rect> vrts( freeSlots );
     const bool isEven = freeSlots % 2 == 0;
     const int deltaX = 10;
 
-    float minus = 0.5 * (freeSlots - 1);
+    float minus = 0.5 * ( freeSlots - 1 );
     int spriteIconIdx = 21;
     int deltaXStart = ( freeSlots - 2 ) * -5;
 

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -352,7 +352,7 @@ int Dialog::ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistribut
 
     for ( uint32_t i = 0; i < freeSlots - 1; ++i ) {
         sprites[i] = fheroes2::AGG::GetICN( ICN::REQUESTS, spriteIconIdx++ );
-        const int spriteWidth = static_cast<int>(sprites[i].width() * ( i - minus ));
+        const int spriteWidth = static_cast<int>( sprites[i].width() * ( i - minus ) );
         const int deltaXWidth = deltaXStart + i * deltaX;
         vrts[i] = fheroes2::Rect( center + spriteWidth + deltaXWidth, pos.y + 95, sprites[i].width(), sprites[i].height() );
     }

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -373,8 +373,11 @@ int Dialog::ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistribut
         ssp.reset();
 
         fheroes2::DrawBorder( ssp, 214 );
-        ssp.setPosition( vrts[0].x, vrts[0].y );
-        ssp.show();
+
+        if ( useFastSplit ) {
+            ssp.setPosition( vrts[0].x, vrts[0].y );
+            ssp.show();
+        }
     }
 
     fheroes2::ButtonGroup btnGroups( box.GetArea(), Dialog::OK | Dialog::CANCEL );

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -28,6 +28,7 @@
 #include "settings.h"
 #include "text.h"
 #include "ui_button.h"
+#include <cassert>
 
 namespace
 {
@@ -314,6 +315,8 @@ bool Dialog::InputString( const std::string & header, std::string & res )
 
 int Dialog::ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistributeMax, const bool savelastTroop, uint32_t & redistributeCount, bool & useFastSplit )
 {
+    assert( freeSlots > 0 );
+
     fheroes2::Display & display = fheroes2::Display::instance();
 
     // cursor
@@ -344,17 +347,18 @@ int Dialog::ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistribut
 
     std::vector<fheroes2::Sprite> sprites( freeSlots );
     std::vector<fheroes2::Rect> vrts( freeSlots );
-    const int deltaX = 10;
 
-    float spriteWidthStart = -0.5f * ( freeSlots - 1 );
     int spriteIconIdx = 21;
-    int deltaXStart = ( freeSlots - 2 ) * -5;
+    const int deltaX = 10;
+    const int deltaXStart = ( freeSlots - 2 ) * -5;
 
     for ( uint32_t i = 0; i < freeSlots - 1; ++i ) {
-        sprites[i] = fheroes2::AGG::GetICN( ICN::REQUESTS, spriteIconIdx++ );
-        const int spriteWidth = static_cast<int>( sprites[i].width() * ( i + spriteWidthStart ) );
-        const int deltaXWidth = deltaXStart + i * deltaX;
-        vrts[i] = fheroes2::Rect( center + spriteWidth + deltaXWidth, pos.y + 95, sprites[i].width(), sprites[i].height() );
+        sprites[i] = fheroes2::AGG::GetICN( ICN::REQUESTS, spriteIconIdx );
+        ++spriteIconIdx;
+
+        const int spriteWidth = sprites[i].width();
+        const int offset = spriteWidth * ( i - freeSlots / 2 ) + spriteWidth / 2;
+        vrts[i] = fheroes2::Rect( center + offset + deltaXStart + i * deltaX, pos.y + 95, sprites[i].width(), sprites[i].height() );
     }
 
     if ( !sprites.empty() ) {


### PR DESCRIPTION
Solves
- #2823 -> Stacks remain highlighted when splitting, and the highlight will be gone after the splitting or otherwise
- #2824 -> Shift hotkey for splitting when clicking a stack similar to how ctrl and alt hotkeys
- #2679 -> Cancel highlighted troop after ctrl/alt/shift split hotkeys are used
- #2671 -> The `2` option for fast splitting in the split window. For cross-army splitting, this will bring all troops of the splitted stack into the other army

Edit for 2671 -> The original stack will stay, also allow to split up to 6 different stacks including its own if doing cross-army fast splits.