### PR TITLE
AI: do not chase after faster units

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -458,8 +458,10 @@ namespace AI
             if ( target.unit == nullptr ) {
                 // move node pair consists of move hex index and distance
                 const std::pair<int, uint32_t> move = arena.CalculateMoveToUnit( *enemy );
+                // Do not chase after faster units that might kite away and avoid engagement
+                const uint32_t distance = ( !enemy->isArchers() && isUnitFaster( *enemy, currentUnit ) ) ? move.second + ARENAW + ARENAH : move.second;
 
-                const double unitPriority = enemy->GetScoreQuality( currentUnit ) - move.second * attackDistanceModifier;
+                const double unitPriority = enemy->GetScoreQuality( currentUnit ) - distance * attackDistanceModifier;
                 if ( unitPriority > maxPriority ) {
                     maxPriority = unitPriority;
                     target.cell = move.first;


### PR DESCRIPTION
Fixes #2727 .

Very straightforward fix. Situation happens only when AI's melee units are on the offense action. Increased distance penalty rather than ignoring faster units to deal with archers first. Flyers are always "faster" than walkers.