### PR TITLE
AI wide units pathfding and moat logic

### DIFF
--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -71,20 +71,6 @@ namespace
     }
 }
 
-namespace Battle
-{
-    bool IsLeftDirection( const int32_t startCellId, const int32_t endCellId, const bool prevLeftDirection )
-    {
-        const int startX = startCellId % ARENAW;
-        const int endX = endCellId % ARENAW;
-
-        if ( prevLeftDirection )
-            return endX <= startX;
-        else
-            return endX < startX;
-    }
-}
-
 Battle::Board::Board()
 {
     reserve( ARENASIZE );
@@ -587,6 +573,18 @@ bool Battle::Board::isReflectDirection( int d )
 
     return false;
 }
+
+bool Battle::Board::IsLeftDirection( const int32_t startCellId, const int32_t endCellId, const bool prevLeftDirection )
+{
+    const int startX = startCellId % ARENAW;
+    const int endX = endCellId % ARENAW;
+
+    if ( prevLeftDirection )
+        return endX <= startX;
+    else
+        return endX < startX;
+}
+
 
 bool Battle::Board::isNegativeDistance( s32 index1, s32 index2 )
 {

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -585,7 +585,6 @@ bool Battle::Board::IsLeftDirection( const int32_t startCellId, const int32_t en
         return endX < startX;
 }
 
-
 bool Battle::Board::isNegativeDistance( s32 index1, s32 index2 )
 {
     return ( index1 % ARENAW ) - ( index2 % ARENAW ) < 0;

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -79,6 +79,7 @@ namespace Battle
         static bool isImpassableIndex( s32 );
         static bool isOutOfWallsIndex( s32 );
         static bool isReflectDirection( int );
+        static bool IsLeftDirection( const int32_t startCellId, const int32_t endCellId, const bool prevLeftDirection );
         static bool isNegativeDistance( s32 index1, s32 index2 );
         static int GetReflectDirection( int );
         static int GetDirection( s32, s32 );

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -38,14 +38,16 @@ namespace Battle
     struct ArenaNode : public PathfindingNode
     {
         bool _isOpen = true;
+        bool _isLeftDirection = false;
 
         // ArenaNode uses different default values
         ArenaNode()
             : PathfindingNode( -1, MAX_MOVE_COST, 0 )
         {}
-        ArenaNode( int node, uint16_t cost, bool isOpen )
+        ArenaNode( int node, uint16_t cost, bool isOpen, bool isLeftDirection )
             : PathfindingNode( node, cost, 0 )
             , _isOpen( isOpen )
+            , _isLeftDirection( isLeftDirection )
         {}
         // Override the base version of the call to use proper values
         virtual void resetNode() override;


### PR DESCRIPTION
Fixes #2753 .

Refactored battle pathfinding to resolve long outstanding bugs. This PR should fix issues when AI's wide walker unit (such as Boar or Wolf) skips a turn because it couldn't find a path. Also it should account for moat penalty during castle sieges.