### PR TITLE
Pathfinder should know that moat consumes all remaining movement

### DIFF
--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -237,6 +237,7 @@ Battle::Indexes Battle::Board::GetAStarPath( const Unit & unit, const Position &
     const Castle * castle = Arena::GetCastle();
     const bool isPassableBridge = bridge == nullptr || bridge->isPassable( unit.GetColor() );
     const bool isMoatBuilt = castle && castle->isBuild( BUILD_MOAT );
+    const int32_t moatPenalty = unit.GetSpeed() * 100;
 
     std::map<int32_t, CellNode> cellMap;
     cellMap[currentCellId].parentCellId = -1;
@@ -272,7 +273,7 @@ Battle::Indexes Battle::Board::GetAStarPath( const Unit & unit, const Position &
 
                     int32_t cost = 100 * ( Board::GetDistance( cellId, targetHeadCellId ) + Board::GetDistance( tailCellId, targetTailCellId ) );
                     if ( isMoatBuilt && Board::isMoatIndex( cellId ) )
-                        cost += 100;
+                        cost += std::max(moatPenalty - currentCellNode.cost, 100);
 
                     // Turn back. No movement at all.
                     if ( isLeftDirection != currentCellNode.leftDirection )

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -273,7 +273,7 @@ Battle::Indexes Battle::Board::GetAStarPath( const Unit & unit, const Position &
 
                     int32_t cost = 100 * ( Board::GetDistance( cellId, targetHeadCellId ) + Board::GetDistance( tailCellId, targetTailCellId ) );
                     if ( isMoatBuilt && Board::isMoatIndex( cellId ) )
-                        cost += std::max(moatPenalty - currentCellNode.cost, 100);
+                        cost += std::max( moatPenalty - currentCellNode.cost, 100 );
 
                     // Turn back. No movement at all.
                     if ( isLeftDirection != currentCellNode.leftDirection )

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -164,8 +164,7 @@ namespace Battle
                     const bool isLeftDirection = unitIsWide && Board::IsLeftDirection( fromNode, newNode, previousNode._isLeftDirection );
                     const Cell * tailCell = unitIsWide ? Board::GetCell( isLeftDirection ? newNode + 1 : newNode - 1 ) : nullptr;
 
-                    if ( headCell->isPassable1( false ) && ( !tailCell || tailCell->isPassable1( false ) )
-                         && ( isPassableBridge || !Board::isBridgeIndex( newNode ) ) ) {
+                    if ( headCell->isPassable1( false ) && ( !tailCell || tailCell->isPassable1( false ) ) && ( isPassableBridge || !Board::isBridgeIndex( newNode ) ) ) {
                         const uint32_t cost = _cache[fromNode]._cost;
                         ArenaNode & node = _cache[newNode];
 

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -90,6 +90,7 @@ namespace Battle
 
         const bool isPassableBridge = bridge == nullptr || bridge->isPassable( unit.GetColor() );
         const bool isMoatBuilt = castle && castle->isBuild( BUILD_MOAT );
+        const uint32_t moatPenalty = unit.GetSpeed();
 
         // Initialize the starting cells
         const int32_t headIdx = unitHead->GetIndex();
@@ -168,10 +169,10 @@ namespace Battle
                         const uint32_t cost = _cache[fromNode]._cost;
                         ArenaNode & node = _cache[newNode];
 
-                        uint32_t additionalCost = ( isMoatBuilt && Board::isMoatIndex( newNode ) ) ? 2 : 1;
-                        // Turn back. No movement at all.
-                        if ( isLeftDirection != previousNode._isLeftDirection )
-                            additionalCost = 0;
+                        // Check if we're turning back. No movement at all.
+                        uint32_t additionalCost = ( isLeftDirection != previousNode._isLeftDirection ) ? 0 : 1;
+                        if ( isMoatBuilt && Board::isMoatIndex( newNode ) )
+                            additionalCost += std::max( moatPenalty - previousNode._cost, 1u );
 
                         if ( headCell->GetUnit() && cost < node._cost ) {
                             node._isOpen = false;

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -162,9 +162,9 @@ namespace Battle
                     const Cell * headCell = Board::GetCell( newNode );
 
                     const bool isLeftDirection = unitIsWide && Board::IsLeftDirection( fromNode, newNode, previousNode._isLeftDirection );
-                    const int32_t tailCellId = isLeftDirection ? newNode + 1 : newNode - 1;
+                    const Cell * tailCell = unitIsWide ? Board::GetCell( isLeftDirection ? newNode + 1 : newNode - 1 ) : nullptr;
 
-                    if ( headCell->isPassable1( false ) && ( !unitIsWide || Board::GetCell( tailCellId )->isPassable1( false ) )
+                    if ( headCell->isPassable1( false ) && ( !tailCell || tailCell->isPassable1( false ) )
                          && ( isPassableBridge || !Board::isBridgeIndex( newNode ) ) ) {
                         const uint32_t cost = _cache[fromNode]._cost;
                         ArenaNode & node = _cache[newNode];

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -171,8 +171,11 @@ namespace Battle
 
                         // Check if we're turning back. No movement at all.
                         uint32_t additionalCost = ( isLeftDirection != previousNode._isLeftDirection ) ? 0 : 1;
-                        if ( isMoatBuilt && Board::isMoatIndex( newNode ) )
-                            additionalCost += std::max( moatPenalty - previousNode._cost, 1u );
+
+                        // Moat penalty consumes all remaining movement. Be careful when dealing with unsigned values
+                        if ( isMoatBuilt && Board::isMoatIndex( newNode ) ) {
+                            additionalCost += ( moatPenalty > previousNode._cost ) ? moatPenalty - previousNode._cost : 1u;
+                        }
 
                         if ( headCell->GetUnit() && cost < node._cost ) {
                             node._isOpen = false;


### PR DESCRIPTION
Fixes #2737 . Fixes #2871 .

Self-explanatory solution. `std::max` safeguard covers us from situations when cost is higher than unit can move in a turn.