### PR TITLE
Optimize army placement during AI turn only

### DIFF
--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -32,6 +32,7 @@ class Castle;
 class HeroBase;
 class Heroes;
 class Kingdom;
+class Army;
 struct VecHeroes;
 namespace Maps
 {
@@ -75,8 +76,8 @@ namespace AI
 
         virtual void HeroesAdd( const Heroes & hero );
         virtual void HeroesRemove( const Heroes & hero );
-        virtual void HeroesPreBattle( HeroBase & hero );
-        virtual void HeroesAfterBattle( HeroBase & hero );
+        virtual void HeroesPreBattle( HeroBase & hero, bool isAttacking );
+        virtual void HeroesAfterBattle( HeroBase & hero, bool wasAttacking );
         virtual void HeroesPostLoad( Heroes & hero );
         virtual bool HeroesCanMove( const Heroes & hero );
         virtual bool HeroesGetTask( Heroes & hero );
@@ -124,6 +125,7 @@ namespace AI
     bool BuildIfEnoughResources( Castle & castle, int building, uint32_t minimumMultiplicator );
     uint32_t GetResourceMultiplier( const Castle & castle, uint32_t min, uint32_t max );
     void ReinforceHeroInCastle( Heroes & hero, Castle & castle, const Funds & budget );
+    void OptimizeTroopsOrder( Army & hero );
 
     StreamBase & operator<<( StreamBase &, const AI::Base & );
     StreamBase & operator>>( StreamBase &, AI::Base & );

--- a/src/fheroes2/ai/ai_base.cpp
+++ b/src/fheroes2/ai/ai_base.cpp
@@ -81,9 +81,9 @@ namespace AI
 
     void Base::HeroesRemove( const Heroes & ) {}
 
-    void Base::HeroesPreBattle( HeroBase & ) {}
+    void Base::HeroesPreBattle( HeroBase &, bool ) {}
 
-    void Base::HeroesAfterBattle( HeroBase & ) {}
+    void Base::HeroesAfterBattle( HeroBase &, bool ) {}
 
     void Base::HeroesActionNewPosition( Heroes & ) {}
 

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -84,7 +84,7 @@ namespace AI
 
         virtual void revealFog( const Maps::Tiles & tile ) override;
 
-        virtual void HeroesPreBattle( HeroBase & hero ) override;
+        virtual void HeroesPreBattle( HeroBase & hero, bool isAttacking ) override;
         virtual void HeroesActionComplete( Heroes & hero ) override;
 
         double getObjectValue( const Heroes & hero, int index, int objectID, double valueToIgnore ) const;

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -43,79 +43,10 @@ namespace AI
     const double STRENGTH_DISTANCE_FACTOR = 5.0;
     const std::vector<int> underWallsIndicies = {7, 28, 49, 72, 95};
 
-    void Normal::HeroesPreBattle( HeroBase & hero )
+    void Normal::HeroesPreBattle( HeroBase & hero, bool isAttacking )
     {
-        // Optimize troops placement before the battle
-        Army & army = hero.GetArmy();
-
-        std::vector<Troop> archers;
-        std::vector<Troop> others;
-
-        // Validate and pick the troops
-        for ( size_t slot = 0; slot < ARMYMAXTROOPS; ++slot ) {
-            Troop * troop = army.GetTroop( slot );
-            if ( troop && troop->isValid() ) {
-                if ( troop->isArchers() ) {
-                    archers.push_back( *troop );
-                }
-                else {
-                    others.push_back( *troop );
-                }
-            }
-        }
-
-        // Sort troops by tactical priority. For melee:
-        // 1. Faster units first
-        // 2. Flyers first
-        // 3. Finally if unit type and speed is same, compare by strength
-        std::sort( others.begin(), others.end(), []( const Troop & left, const Troop & right ) {
-            if ( left.GetSpeed() == right.GetSpeed() ) {
-                if ( left.isFlying() == right.isFlying() ) {
-                    return left.GetStrength() < right.GetStrength();
-                }
-                return right.isFlying();
-            }
-            return left.GetSpeed() < right.GetSpeed();
-        } );
-
-        // Archers sorted purely by strength.
-        std::sort( archers.begin(), archers.end(), []( const Troop & left, const Troop & right ) { return left.GetStrength() < right.GetStrength(); } );
-
-        std::vector<size_t> slotOrder = {2, 1, 3, 0, 4};
-        switch ( archers.size() ) {
-        case 1:
-            slotOrder = {0, 2, 1, 3, 4};
-            break;
-        case 2:
-            slotOrder = {0, 4, 2, 1, 3};
-            break;
-        case 3:
-            slotOrder = {0, 4, 2, 1, 3};
-            break;
-        case 4:
-            slotOrder = {0, 4, 2, 3, 1};
-            break;
-        case 5:
-            slotOrder = {0, 4, 1, 2, 3};
-            break;
-        default:
-            break;
-        }
-
-        // Re-arrange troops in army
-        army.Clean();
-        for ( const size_t slot : slotOrder ) {
-            if ( !archers.empty() ) {
-                army.GetTroop( slot )->Set( archers.back() );
-                archers.pop_back();
-            }
-            else if ( !others.empty() ) {
-                army.GetTroop( slot )->Set( others.back() );
-                others.pop_back();
-            }
-            else {
-                break;
-            }
+        if ( isAttacking ) {
+            OptimizeTroopsOrder( hero.GetArmy() );
         }
     }
 

--- a/src/fheroes2/ai/normal/ai_normal_castle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_castle.cpp
@@ -152,6 +152,7 @@ namespace AI
             Build( castle, GetDefensiveStructures( castle.GetRace() ) );
 
             castle.recruitBestAvailable( castle.GetKingdom().GetFunds() );
+            OptimizeTroopsOrder( castle.GetArmy() );
         }
         else {
             CastleDevelopment( castle );

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -68,7 +68,7 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, s32 mapsindex )
         if ( army1.GetCommander()->isCaptain() )
             army1.GetCommander()->ActionPreBattle();
         else if ( army1.isControlAI() )
-            AI::Get().HeroesPreBattle( *army1.GetCommander() );
+            AI::Get().HeroesPreBattle( *army1.GetCommander(), true );
         else
             army1.GetCommander()->ActionPreBattle();
     }
@@ -78,7 +78,7 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, s32 mapsindex )
         if ( army2.GetCommander()->isCaptain() )
             army2.GetCommander()->ActionPreBattle();
         else if ( army2.isControlAI() )
-            AI::Get().HeroesPreBattle( *army2.GetCommander() );
+            AI::Get().HeroesPreBattle( *army2.GetCommander(), false );
         else
             army2.GetCommander()->ActionPreBattle();
     }
@@ -142,7 +142,7 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, s32 mapsindex )
     // after battle army1
     if ( army1.GetCommander() ) {
         if ( army1.isControlAI() )
-            AI::Get().HeroesAfterBattle( *army1.GetCommander() );
+            AI::Get().HeroesAfterBattle( *army1.GetCommander(), true );
         else
             army1.GetCommander()->ActionAfterBattle();
     }
@@ -150,7 +150,7 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, s32 mapsindex )
     // after battle army2
     if ( army2.GetCommander() ) {
         if ( army2.isControlAI() )
-            AI::Get().HeroesAfterBattle( *army2.GetCommander() );
+            AI::Get().HeroesAfterBattle( *army2.GetCommander(), false );
         else
             army2.GetCommander()->ActionAfterBattle();
     }


### PR DESCRIPTION
Fixes #2863 .

Added a bool argument to PreBattle/PostBattle hooks that determines if we can actually shift the troops. Also moved code to `ai_common.cpp` and added optimization call on couple other events to compensate.