### PR TITLE
AI: improve retreat condition

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -50,9 +50,9 @@ namespace AI
 
         // decision-making helpers
         bool isUnitFaster( const Battle::Unit & currentUnit, const Battle::Unit & target ) const;
-        bool isHeroWorthSaving( const Heroes * hero ) const;
+        bool isHeroWorthSaving( const Heroes & hero ) const;
         bool isCommanderCanSpellcast( const Battle::Arena & arena, const HeroBase * commander ) const;
-        bool checkRetreatCondition( double myArmy, double enemy ) const;
+        bool checkRetreatCondition( const Heroes & hero, double myArmy, double enemy ) const;
 
     private:
         // to be exposed later once every BattlePlanner will be re-initialized at combat start

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -52,7 +52,7 @@ namespace AI
         bool isUnitFaster( const Battle::Unit & currentUnit, const Battle::Unit & target ) const;
         bool isHeroWorthSaving( const Heroes & hero ) const;
         bool isCommanderCanSpellcast( const Battle::Arena & arena, const HeroBase * commander ) const;
-        bool checkRetreatCondition( const Heroes & hero, double myArmy, double enemy ) const;
+        bool checkRetreatCondition( const Heroes & hero ) const;
 
     private:
         // to be exposed later once every BattlePlanner will be re-initialized at combat start

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -71,6 +71,7 @@ namespace AI
         int _highestDamageExpected = 0;
         bool _attackingCastle = false;
         bool _defendingCastle = false;
+        bool _considerRetreat = false;
     };
 
     class Normal : public Base

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -250,7 +250,6 @@ namespace AI
         }
 
         uint32_t initialUnitCount = 0;
-        bool lostUnit = false;
         for ( Unit * unitPtr : friendlyForce ) {
             // Do not check isValid() here to handle dead troops
             if ( !unitPtr )

--- a/src/fheroes2/game/difficulty.cpp
+++ b/src/fheroes2/game/difficulty.cpp
@@ -123,3 +123,19 @@ int Difficulty::GetHeroMovementBonus( int difficulty )
     }
     return 0;
 }
+
+double Difficulty::GetAIRetreatRatio( int difficulty )
+{
+    switch ( difficulty ) {
+    case Difficulty::NORMAL:
+        return 100.0 / 7.5;
+    case Difficulty::HARD: // fall-through
+    case Difficulty::EXPERT:
+        return 100.0 / 8.5;
+    case Difficulty::IMPOSSIBLE:
+        return 100.0 / 10.0;
+    default:
+        break;
+    }
+    return 100.0 / 6.0;
+}

--- a/src/fheroes2/game/difficulty.h
+++ b/src/fheroes2/game/difficulty.h
@@ -43,6 +43,7 @@ namespace Difficulty
     double GetUnitGrowthBonus( int difficulty );
     double GetBattleExperienceBonus( int difficulty );
     int GetHeroMovementBonus( int difficulty );
+    double GetAIRetreatRatio( int difficulty );
 }
 
 #endif


### PR DESCRIPTION
Now AI should be less likely to retreat early: checking if unit stack was lost or army was small in the first place. Also army power ratio now depends on game difficulty (Easy AI should rarely run).