### PR TITLE
Make MouseRelease* events one-shot to fix excessive FPS issue

### DIFF
--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -300,14 +300,14 @@ private:
     {
         KEY_PRESSED = 0x0001,
         MOUSE_MOTION = 0x0002,
-        MOUSE_PRESSED = 0x0004,
+        MOUSE_PRESSED = 0x0004, // mouse button is currently pressed
         GLOBAL_FILTER = 0x0008,
-        CLICK_LEFT = 0x0010, // either there is a click on left button or it was just released
-        CLICK_RIGHT = 0x0020, // either there is a click on right button or it was just released
-        CLICK_MIDDLE = 0x0040, // either there is a click on middle button or it was just released
-        UNUSED_1 = 0x0080,
+        MOUSE_RELEASED = 0x0010, // mouse button has just been released
+        MOUSE_CLICKED = 0x0020, // mouse button has been clicked
+        UNUSED_1 = 0x0040,
+        UNUSED_2 = 0x0080,
         MOUSE_OFFSET = 0x0100,
-        UNUSED_2 = 0x0200,
+        UNUSED_3 = 0x0200,
         MOUSE_WHEEL = 0x0400,
         KEY_HOLD = 0x0800
     };


### PR DESCRIPTION
Related to #2842

At the moment, MouseRelease* events (used by drag&drop logic in ArmyBar) are not one-shot events, this leads to excessive FPS issues after clicking on creature stack in this bar. In this patch I suggest the somewhat naive approach to this issue. Also I'm not sure that these events should be one-shot by design (and some other part of the code does not count on the fact that they are NOT one-shot events), so may be some different, more complex approach is needed here.