### PR TITLE
Preserve unit direction in battle if it moves strictly vertically

### DIFF
--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -187,7 +187,7 @@ void Battle::Unit::UpdateDirection( void )
 
 bool Battle::Unit::UpdateDirection( const Rect & pos )
 {
-    bool need = position.GetRect().x > pos.x;
+    bool need = position.GetRect().x == pos.x ? reflect : position.GetRect().x > pos.x;
 
     if ( need != reflect ) {
         SetReflection( need );


### PR DESCRIPTION
fix #2724