### PR TITLE
Don't give an extra day of life to a player without castles

### DIFF
--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -72,7 +72,7 @@ void Kingdom::clear( void )
 
     color = Color::NONE;
     visited_tents_colors = 0;
-    lost_town_days = Game::GetLostTownDays() + 1;
+    lost_town_days = Game::GetLostTownDays();
 
     heroes.clear();
     castles.clear();
@@ -281,7 +281,7 @@ void Kingdom::AddCastle( const Castle * castle )
         AI::Get().CastleAdd( *castle );
     }
 
-    lost_town_days = Game::GetLostTownDays() + 1;
+    lost_town_days = Game::GetLostTownDays();
 }
 
 void Kingdom::RemoveCastle( const Castle * castle )


### PR DESCRIPTION
fix #2647

It seems that players now have an extra day of life, and I don't know why. Any ideas? Maybe this is necessary for some in-game mechanics?