### PR TITLE
Fix the pathfinding near monsters (HoMM3-style)

### DIFF
--- a/src/fheroes2/heroes/direction.cpp
+++ b/src/fheroes2/heroes/direction.cpp
@@ -199,6 +199,34 @@ int Direction::Reflect( int direct )
     return UNKNOWN;
 }
 
+int Direction::Adjacent( int direct )
+{
+    switch ( direct ) {
+    case TOP_LEFT:
+        return DIRECTION_TOP_LEFT_CORNER;
+    case TOP:
+        return DIRECTION_TOP_ROW;
+    case TOP_RIGHT:
+        return DIRECTION_TOP_RIGHT_CORNER;
+    case RIGHT:
+        return DIRECTION_RIGHT_COL;
+    case BOTTOM_RIGHT:
+        return DIRECTION_BOTTOM_RIGHT_CORNER;
+    case BOTTOM:
+        return DIRECTION_BOTTOM_ROW;
+    case BOTTOM_LEFT:
+        return DIRECTION_BOTTOM_LEFT_CORNER;
+    case LEFT:
+        return DIRECTION_LEFT_COL;
+    case CENTER:
+        return DIRECTION_AROUND;
+    default:
+        break;
+    }
+
+    return UNKNOWN;
+}
+
 const Directions & Direction::All( void )
 {
     static const Directions allDirections = Directions( {TOP_LEFT, TOP, TOP_RIGHT, RIGHT, BOTTOM_RIGHT, BOTTOM, BOTTOM_LEFT, LEFT} );

--- a/src/fheroes2/heroes/direction.h
+++ b/src/fheroes2/heroes/direction.h
@@ -47,6 +47,7 @@ namespace Direction
     bool isDiagonal( int direction );
 
     int Reflect( int direct );
+    int Adjacent( int direct );
 
     bool ShortDistanceClockWise( int direct1, int direct2 );
     const Directions & All( void );

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -41,7 +41,7 @@ public:
 
 protected:
     void processWorldMap( int pathStart );
-    void checkAdjacentNodes( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx, bool fromWater );
+    void checkAdjacentNodes( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx, int excludedDirections, bool fromWater );
 
     // This method defines pathfinding rules. This has to be implemented by the derived class.
     virtual void processCurrentNode( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx, bool fromWater ) = 0;


### PR DESCRIPTION
fix #2888

The idea here is to allow the hero to only either fight or retreat if there is a monster on the adjacent cell. Hero can not pass by the monster via adjacent cell or pass through the monster, as it happening now. This is the first approach, may be it should be done in some other manner, so this is a subject for discussion. We need here experts in the original HoMM II game :)