### PR TITLE
Fix the pathfinding near monsters (OG-style)

### DIFF
--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -259,6 +259,11 @@ std::list<Route::Step> PlayerWorldPathfinder::buildPath( int targetIndex ) const
 // Follows regular (for user's interface) passability rules
 void PlayerWorldPathfinder::processCurrentNode( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx, bool fromWater )
 {
+    // if current tile contains a monster, skip it
+    if ( world.GetTiles( currentNodeIdx ).GetObject() == MP2::OBJ_MONSTER ) {
+        return;
+    }
+
     const MapsIndexes & monsters = Maps::GetTilesUnderProtection( currentNodeIdx );
 
     // check if current tile is protected, can move only to adjacent monster


### PR DESCRIPTION
fix #2888

Alternative approach to #2910 - just don't apply (flawed) logic with restrictions on the passage of protected cells. This should work OG-style: hero can pass by the monster via adjacent cell (and will be attacked by one of the monsters guarding the cell), but not pass through the monster, as it happening now.