### PR TITLE
Don't open the hero screen in readonly mode if it was opened from the meeting screen

### DIFF
--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -420,7 +420,14 @@ void Heroes::MeetingDialog( Heroes & heroes2 )
         }
 
         if ( le.MouseClickLeft( hero1Area ) ) {
-            OpenDialog( true, true );
+            const bool noDismiss = Modes( Heroes::NOTDISMISS );
+
+            SetModes( Heroes::NOTDISMISS );
+            OpenDialog( false, true );
+
+            if ( !noDismiss ) {
+                ResetModes( Heroes::NOTDISMISS );
+            }
 
             armyCountBackgroundRestorer.restore();
             selectArtifacts1.ResetSelected();
@@ -433,7 +440,14 @@ void Heroes::MeetingDialog( Heroes & heroes2 )
             display.render();
         }
         else if ( le.MouseClickLeft( hero2Area ) ) {
-            heroes2.OpenDialog( true, true );
+            const bool noDismiss = heroes2.Modes( Heroes::NOTDISMISS );
+
+            heroes2.SetModes( Heroes::NOTDISMISS );
+            heroes2.OpenDialog( false, true );
+
+            if ( !noDismiss ) {
+                heroes2.ResetModes( Heroes::NOTDISMISS );
+            }
 
             armyCountBackgroundRestorer.restore();
             selectArtifacts2.ResetSelected();


### PR DESCRIPTION
fix #2681

Companion PR of #2920.
