### PR TITLE
AI: predict double cell attacks in combat

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -158,7 +158,7 @@ namespace AI
 
                 if ( target.unit ) {
                     actions.emplace_back( MSG_BATTLE_ATTACK, currentUnit.GetUID(), target.unit->GetUID(),
-                                          Board::GetOptimalAttackTarget( target.unit->GetPosition(), target.cell ), 0 );
+                                          Board::OptimalAttackTarget( target.unit->GetPosition(), target.cell ), 0 );
                     DEBUG_LOG( DBG_BATTLE, DBG_INFO,
                                currentUnit.GetName() << " melee offense, focus enemy " << target.unit->GetName()
                                                      << " threat level: " << target.unit->GetScoreQuality( currentUnit ) );

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -58,7 +58,6 @@ namespace AI
 
         const bool isDoubleCell = attacker.isDoubleCellAttack();
         const uint32_t currentUnitMoveRange = attacker.GetMoveRange();
-        const double baseQuality = defender.GetScoreQuality( attacker );
 
         const Indexes & around = Board::GetAroundIndexes( defender );
         for ( const int cell : around ) {
@@ -67,7 +66,7 @@ namespace AI
                 continue;
 
             const int cellQuality = Board::GetCell( cell )->GetQuality();
-            const double attackValue = isDoubleCell ? Board::DoubleCellAttackValue( attacker, defender, cell ) + baseQuality : baseQuality;
+            const double attackValue = Board::OptimalAttackValue( attacker, defender, cell );
 
             // Pick target if either position is improved or unit is higher value at the same position quality
             if ( outcome.positionValue < cellQuality || ( outcome.attackValue < attackValue && std::fabs( outcome.positionValue - cellQuality ) < 0.001 ) ) {
@@ -192,7 +191,7 @@ namespace AI
 
                 if ( target.unit ) {
                     actions.emplace_back( MSG_BATTLE_ATTACK, currentUnit.GetUID(), target.unit->GetUID(),
-                                          Board::OptimalAttackTarget( target.unit->GetPosition(), target.cell ), 0 );
+                                          Board::OptimalAttackTarget( currentUnit, *target.unit, target.cell ), 0 );
                     DEBUG_LOG( DBG_BATTLE, DBG_INFO,
                                currentUnit.GetName() << " melee offense, focus enemy " << target.unit->GetName()
                                                      << " threat level: " << target.unit->GetScoreQuality( currentUnit ) );
@@ -468,7 +467,6 @@ namespace AI
 
         const double defenceDistanceModifier = _myArmyStrength / STRENGTH_DISTANCE_FACTOR;
 
-
         // 1. Check if there's a target within our half of the battlefield
         double attackHighestValue = -_enemyArmyStrength;
         double attackPositionValue = -_enemyArmyStrength;
@@ -523,8 +521,8 @@ namespace AI
                 // Secondary - Archer unit value
                 // Tertiary - Enemy unit threat
                 if ( ( canReach != hadAnotherTarget && canReach )
-                        || ( canReach == hadAnotherTarget
-                            && ( maxArcherValue < archerValue || ( std::fabs( maxArcherValue - archerValue ) < 0.001 && maxEnemyThreat < outcome.attackValue ) ) ) ) {
+                     || ( canReach == hadAnotherTarget
+                          && ( maxArcherValue < archerValue || ( std::fabs( maxArcherValue - archerValue ) < 0.001 && maxEnemyThreat < outcome.attackValue ) ) ) ) {
                     target.cell = outcome.fromIndex;
                     target.unit = enemy;
                     maxArcherValue = archerValue;

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -56,7 +56,6 @@ namespace AI
     {
         MeleeAttackOutcome outcome;
 
-        const bool isDoubleCell = attacker.isDoubleCellAttack();
         const uint32_t currentUnitMoveRange = attacker.GetMoveRange();
 
         const Indexes & around = Board::GetAroundIndexes( defender );
@@ -395,9 +394,6 @@ namespace AI
         BattleTargetPair target;
         const Units enemies( arena.GetForce( _myColor, true ), true );
 
-        const bool isDoubleHex = currentUnit.isDoubleCellAttack();
-        const uint32_t currentUnitMoveRange = currentUnit.GetMoveRange();
-
         double attackHighestValue = -_enemyArmyStrength;
         double attackPositionValue = -_enemyArmyStrength;
 
@@ -462,7 +458,6 @@ namespace AI
         const Units friendly( arena.GetForce( _myColor ), true );
         const Units enemies( arena.GetForce( _myColor, true ), true );
 
-        const uint32_t currentUnitMoveRange = currentUnit.GetMoveRange();
         const int myHeadIndex = currentUnit.GetHeadIndex();
 
         const double defenceDistanceModifier = _myArmyStrength / STRENGTH_DISTANCE_FACTOR;

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -45,6 +45,40 @@ namespace AI
     const double STRENGTH_DISTANCE_FACTOR = 5.0;
     const std::vector<int> underWallsIndicies = {7, 28, 49, 72, 95};
 
+    struct MeleeAttackOutcome
+    {
+        int32_t fromIndex = -1;
+        double attackValue = -INT32_MAX;
+        double positionValue = -INT32_MAX;
+    };
+
+    MeleeAttackOutcome BestAttackOutcome( const Arena & arena, const Unit & attacker, const Unit & defender )
+    {
+        MeleeAttackOutcome outcome;
+
+        const bool isDoubleCell = attacker.isDoubleCellAttack();
+        const uint32_t currentUnitMoveRange = attacker.GetMoveRange();
+        const double baseQuality = defender.GetScoreQuality( attacker );
+
+        const Indexes & around = Board::GetAroundIndexes( defender );
+        for ( const int cell : around ) {
+            // Check if we can reach the target and pick best position to attack from
+            if ( !arena.hexIsPassable( cell ) || arena.CalculateMoveDistance( cell ) > currentUnitMoveRange )
+                continue;
+
+            const int cellQuality = Board::GetCell( cell )->GetQuality();
+            const double attackValue = isDoubleCell ? Board::DoubleCellAttackValue( attacker, defender, cell ) + baseQuality : baseQuality;
+
+            // Pick target if either position is improved or unit is higher value at the same position quality
+            if ( outcome.positionValue < cellQuality || ( outcome.attackValue < attackValue && std::fabs( outcome.positionValue - cellQuality ) < 0.001 ) ) {
+                outcome.attackValue = attackValue;
+                outcome.positionValue = cellQuality;
+                outcome.fromIndex = cell;
+            }
+        }
+        return outcome;
+    }
+
     void Normal::HeroesPreBattle( HeroBase & hero, bool isAttacking )
     {
         if ( isAttacking ) {
@@ -364,35 +398,27 @@ namespace AI
 
         const bool isDoubleHex = currentUnit.isDoubleCellAttack();
         const uint32_t currentUnitMoveRange = currentUnit.GetMoveRange();
-        const double attackDistanceModifier = _enemyArmyStrength / STRENGTH_DISTANCE_FACTOR;
 
-        double maxMovePriority = attackDistanceModifier * ARENASIZE * -1;
         double attackHighestValue = -_enemyArmyStrength;
         double attackPositionValue = -_enemyArmyStrength;
 
         for ( const Unit * enemy : enemies ) {
-            const double quality = enemy->GetScoreQuality( currentUnit );
-
-            const Indexes & around = Board::GetAroundIndexes( *enemy );
-            for ( const int cell : around ) {
-                // Check if we can reach the target and pick best position to attack from
-                if ( !arena.hexIsPassable( cell ) || arena.CalculateMoveDistance( cell ) > currentUnitMoveRange )
-                    continue;
-
-                const int cellQuality = Board::GetCell( cell )->GetQuality();
-                const double attackValue = isDoubleHex ? Board::DoubleCellAttackValue( currentUnit, *enemy, cell ) + quality : quality;
-
-                // Pick target if either position is improved or unit is higher value at the same position quality
-                if ( attackPositionValue < cellQuality || ( attackHighestValue < attackValue && std::fabs( attackPositionValue - cellQuality ) < 0.001 ) ) {
-                    attackHighestValue = quality;
-                    attackPositionValue = cellQuality;
-                    target.unit = enemy;
-                    target.cell = cell;
-                }
+            const MeleeAttackOutcome & outcome = BestAttackOutcome( arena, currentUnit, *enemy );
+            if ( outcome.positionValue > attackPositionValue
+                 || ( outcome.attackValue > attackHighestValue && std::fabs( attackPositionValue - outcome.positionValue ) < 0.001 ) ) {
+                attackHighestValue = outcome.attackValue;
+                attackPositionValue = outcome.positionValue;
+                target.cell = outcome.fromIndex;
+                target.unit = enemy;
             }
+        }
 
-            // For walking units that don't have a target within reach, pick based on distance priority
-            if ( target.unit == nullptr ) {
+        // For walking units that don't have a target within reach, pick based on distance priority
+        if ( target.unit == nullptr ) {
+            const double attackDistanceModifier = _enemyArmyStrength / STRENGTH_DISTANCE_FACTOR;
+            double maxMovePriority = attackDistanceModifier * ARENASIZE * -1;
+
+            for ( const Unit * enemy : enemies ) {
                 // move node pair consists of move hex index and distance
                 const std::pair<int, uint32_t> move = arena.CalculateMoveToUnit( *enemy );
                 // Do not chase after faster units that might kite away and avoid engagement
@@ -404,9 +430,9 @@ namespace AI
                     target.cell = move.first;
                 }
             }
-            else {
-                DEBUG_LOG( DBG_BATTLE, DBG_TRACE, currentUnit.GetName() << " is attacking " << target.unit->GetName() << " at " << target.cell );
-            }
+        }
+        else {
+            DEBUG_LOG( DBG_BATTLE, DBG_TRACE, currentUnit.GetName() << " is attacking " << target.unit->GetName() << " at " << target.cell );
         }
 
         // Walkers: move closer to the castle walls during siege
@@ -440,78 +466,77 @@ namespace AI
         const uint32_t currentUnitMoveRange = currentUnit.GetMoveRange();
         const int myHeadIndex = currentUnit.GetHeadIndex();
 
-        const double attackDistanceModifier = _enemyArmyStrength / STRENGTH_DISTANCE_FACTOR;
         const double defenceDistanceModifier = _myArmyStrength / STRENGTH_DISTANCE_FACTOR;
 
-        double maxArcherValue = defenceDistanceModifier * ARENASIZE * -1;
-        double maxEnemyValue = attackDistanceModifier * ARENASIZE * -1;
-        double maxEnemyThreat = 0;
 
         // 1. Check if there's a target within our half of the battlefield
+        double attackHighestValue = -_enemyArmyStrength;
+        double attackPositionValue = -_enemyArmyStrength;
         for ( const Unit * enemy : enemies ) {
-            const std::pair<int, uint32_t> move = arena.CalculateMoveToUnit( *enemy );
+            const MeleeAttackOutcome & outcome = BestAttackOutcome( arena, currentUnit, *enemy );
 
             // Allow to move only within our half of the battlefield. If in castle make sure to stay inside.
-            const bool isSafeToMove = ( !_defendingCastle && move.second <= ARENAW / 2 ) || ( _defendingCastle && Board::isCastleIndex( move.first ) );
+            if ( ( !_defendingCastle && arena.CalculateMoveDistance( outcome.fromIndex ) <= ARENAW / 2 )
+                 || ( _defendingCastle && Board::isCastleIndex( outcome.fromIndex ) ) )
+                continue;
 
-            if ( move.first != -1 && isSafeToMove ) {
-                const double enemyValue = enemy->GetScoreQuality( currentUnit ) - move.second * attackDistanceModifier;
-
-                // Pick highest value unit if there's multiple
-                if ( maxEnemyValue < enemyValue ) {
-                    maxEnemyValue = enemyValue;
-                    target.unit = enemy;
-                    target.cell = move.first;
-                }
+            if ( outcome.positionValue > attackPositionValue
+                 || ( outcome.attackValue > attackHighestValue && std::fabs( attackPositionValue - outcome.positionValue ) < 0.001 ) ) {
+                attackHighestValue = outcome.attackValue;
+                attackPositionValue = outcome.positionValue;
+                target.cell = outcome.fromIndex;
+                target.unit = enemy;
             }
         }
 
         // 2. Check if our archer units are under threat - overwrite target and protect
+        double maxArcherValue = defenceDistanceModifier * ARENASIZE * -1;
+        double maxEnemyThreat = -_enemyArmyStrength;
         for ( const Unit * unitToDefend : friendly ) {
-            if ( unitToDefend->GetUID() != currentUnit.GetUID() && unitToDefend->isArchers() ) {
-                const int headIndexToDefend = unitToDefend->GetHeadIndex();
-                const std::pair<int, uint32_t> move = arena.CalculateMoveToUnit( *unitToDefend );
-                const uint32_t distanceToUnit = ( move.first != -1 ) ? move.second : Board::GetDistance( myHeadIndex, headIndexToDefend );
-                const double archerValue = unitToDefend->GetStrength() - distanceToUnit * defenceDistanceModifier;
+            if ( unitToDefend->GetUID() == currentUnit.GetUID() || !unitToDefend->isArchers() ) {
+                continue;
+            }
 
-                DEBUG_LOG( DBG_AI, DBG_TRACE, unitToDefend->GetName() << " archer value " << archerValue << " distance: " << distanceToUnit );
+            const std::pair<int, uint32_t> move = arena.CalculateMoveToUnit( *unitToDefend );
+            const uint32_t distanceToUnit = ( move.first != -1 ) ? move.second : Board::GetDistance( myHeadIndex, unitToDefend->GetHeadIndex() );
+            const double archerValue = unitToDefend->GetStrength() - distanceToUnit * defenceDistanceModifier;
 
-                // 3. Search for enemy units blocking our archers within range move
-                const Indexes & adjacentEnemies = Board::GetAdjacentEnemies( *unitToDefend );
-                for ( const int cell : adjacentEnemies ) {
-                    const Unit * enemy = Board::GetCell( cell )->GetUnit();
-                    if ( enemy ) {
-                        const double enemyThreat = enemy->GetScoreQuality( currentUnit );
-                        const std::pair<int, uint32_t> moveToEnemy = arena.CalculateMoveToUnit( *enemy );
-                        const bool canReach = moveToEnemy.first != -1 && moveToEnemy.second <= currentUnitMoveRange;
-                        const bool hadAnotherTarget = target.unit != NULL;
+            DEBUG_LOG( DBG_AI, DBG_TRACE, unitToDefend->GetName() << " archer value " << archerValue << " distance: " << distanceToUnit );
 
-                        DEBUG_LOG( DBG_BATTLE, DBG_TRACE, " - Found enemy, cell " << cell << " threat " << enemyThreat << " distance " << moveToEnemy.second );
-
-                        // Composite priority criteria:
-                        // Primary - Enemy is within move range
-                        // Secondary - Archer unit value
-                        // Tertiary - Enemy unit threat
-                        if ( ( canReach != hadAnotherTarget && canReach )
-                             || ( canReach == hadAnotherTarget
-                                  && ( maxArcherValue < archerValue || ( std::fabs( maxArcherValue - archerValue ) < 0.001 && maxEnemyThreat < enemyThreat ) ) ) ) {
-                            target.cell = moveToEnemy.first;
-                            target.unit = enemy;
-                            maxArcherValue = archerValue;
-                            maxEnemyThreat = enemyThreat;
-                            DEBUG_LOG( DBG_BATTLE, DBG_TRACE, " - Target selected " << enemy->GetName() << " cell " << target.cell << " archer value " << archerValue );
-                        }
-                    }
-                    else {
-                        DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Board::GetAdjacentEnemies returned a cell " << cell << " that does not contain a unit!" );
-                    }
+            // 3. Search for enemy units blocking our archers within range move
+            const Indexes & adjacentEnemies = Board::GetAdjacentEnemies( *unitToDefend );
+            for ( const int cell : adjacentEnemies ) {
+                const Unit * enemy = Board::GetCell( cell )->GetUnit();
+                if ( !enemy ) {
+                    DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Board::GetAdjacentEnemies returned a cell " << cell << " that does not contain a unit!" );
+                    continue;
                 }
 
-                // 4. No enemies found anywhere - move in closer to the friendly ranged unit
-                if ( !target.unit && maxArcherValue < archerValue ) {
-                    target.cell = move.first;
+                const MeleeAttackOutcome & outcome = BestAttackOutcome( arena, currentUnit, *enemy );
+                const bool canReach = outcome.fromIndex != -1;
+                const bool hadAnotherTarget = target.unit != NULL;
+
+                DEBUG_LOG( DBG_BATTLE, DBG_TRACE, " - Found enemy, cell " << cell << " threat " << outcome.attackValue );
+
+                // Composite priority criteria:
+                // Primary - Enemy is within move range
+                // Secondary - Archer unit value
+                // Tertiary - Enemy unit threat
+                if ( ( canReach != hadAnotherTarget && canReach )
+                        || ( canReach == hadAnotherTarget
+                            && ( maxArcherValue < archerValue || ( std::fabs( maxArcherValue - archerValue ) < 0.001 && maxEnemyThreat < outcome.attackValue ) ) ) ) {
+                    target.cell = outcome.fromIndex;
+                    target.unit = enemy;
                     maxArcherValue = archerValue;
+                    maxEnemyThreat = outcome.attackValue;
+                    DEBUG_LOG( DBG_BATTLE, DBG_TRACE, " - Target selected " << enemy->GetName() << " cell " << target.cell << " archer value " << archerValue );
                 }
+            }
+
+            // 4. No enemies found anywhere - move in closer to the friendly ranged unit
+            if ( !target.unit && maxArcherValue < archerValue ) {
+                target.cell = move.first;
+                maxArcherValue = archerValue;
             }
         }
 

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -43,17 +43,7 @@ namespace AI
     // Usual distance between units at the start of the battle is 10-14 tiles
     // 20% of maximum value lost for every tile travelled to make sure 4 tiles difference matters
     const double STRENGTH_DISTANCE_FACTOR = 5.0;
-    const std::vector<int> underWallsIndicies = {7, 28, 49, 72, 95};
-
-    int32_t correctAttackTarget( const Position & target, const int32_t from )
-    {
-        const Cell * tail = target.GetTail();
-        if ( tail && Board::isNearIndexes( from, tail->GetIndex() ) ) {
-            return tail->GetIndex();
-        }
-        const Cell * head = target.GetHead();
-        return head ? head->GetIndex() : -1;
-    }
+    const std::vector<int> underWallsIndicies = { 7, 28, 49, 72, 95 };
 
     void Normal::HeroesPreBattle( HeroBase & hero, bool isAttacking )
     {
@@ -167,8 +157,8 @@ namespace AI
                     actions.emplace_back( MSG_BATTLE_MOVE, currentUnit.GetUID(), target.cell );
 
                 if ( target.unit ) {
-                    actions.emplace_back( MSG_BATTLE_ATTACK, currentUnit.GetUID(), target.unit->GetUID(), correctAttackTarget( target.unit->GetPosition(), target.cell ),
-                                          0 );
+                    actions.emplace_back( MSG_BATTLE_ATTACK, currentUnit.GetUID(), target.unit->GetUID(),
+                                          Board::GetOptimalAttackTarget( target.unit->GetPosition(), target.cell ), 0 );
                     DEBUG_LOG( DBG_BATTLE, DBG_INFO,
                                currentUnit.GetName() << " melee offense, focus enemy " << target.unit->GetName()
                                                      << " threat level: " << target.unit->GetScoreQuality( currentUnit ) );

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -604,17 +604,17 @@ std::pair<int, uint32_t> Battle::Arena::CalculateMoveToUnit( const Unit & target
     return result;
 }
 
-uint32_t Battle::Arena::CalculateMoveDistance( int32_t indexTo )
+uint32_t Battle::Arena::CalculateMoveDistance( int32_t indexTo ) const
 {
     return Board::isValidIndex( indexTo ) ? _pathfinder.getDistance( indexTo ) : MAXU16;
 }
 
-bool Battle::Arena::hexIsAccessible( int32_t indexTo )
+bool Battle::Arena::hexIsAccessible( int32_t indexTo ) const
 {
     return Board::isValidIndex( indexTo ) && _pathfinder.hexIsAccessible( indexTo );
 }
 
-bool Battle::Arena::hexIsPassable( int32_t indexTo )
+bool Battle::Arena::hexIsPassable( int32_t indexTo ) const
 {
     return Board::isValidIndex( indexTo ) && _pathfinder.hexIsPassable( indexTo );
 }

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -105,9 +105,9 @@ namespace Battle
         // returns pair with move cell index and distance
         std::pair<int, uint32_t> CalculateMoveToUnit( const Unit & target );
 
-        uint32_t CalculateMoveDistance( int32_t indexTo );
-        bool hexIsAccessible( int32_t indexTo );
-        bool hexIsPassable( int32_t indexTo );
+        uint32_t CalculateMoveDistance( int32_t indexTo ) const;
+        bool hexIsAccessible( int32_t indexTo ) const;
+        bool hexIsPassable( int32_t indexTo ) const;
         Indexes getAllAvailableMoves( uint32_t moveRange ) const;
         Indexes GetPath( const Unit &, const Position & );
 

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -111,7 +111,6 @@ void Battle::Board::SetPositionQuality( const Unit & b )
 {
     Arena * arena = GetArena();
     Units enemies( arena->GetForce( b.GetCurrentColor(), true ), true );
-    const bool isDoubleCell = b.isDoubleCellAttack();
 
     // Make sure archers are first here, so melee unit's score won't be double counted
     enemies.SortArchers();

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -130,7 +130,7 @@ void Battle::Board::SetPositionQuality( const Unit & b )
                 continue;
 
             const int32_t quality = cell2->GetQuality();
-            const int32_t attackValue = isDoubleCell ? DoubleHexAttackValue( b, *unit, index ) + targetValue : targetValue;
+            const int32_t attackValue = isDoubleCell ? DoubleCellAttackValue( b, *unit, index ) + targetValue : targetValue;
 
             // Only sum up quality score if it's archers; otherwise just pick the highest
             if ( unit->isArchers() )
@@ -535,7 +535,7 @@ int32_t Battle::Board::OptimalAttackTarget( const Position & target, const int32
     return head ? head->GetIndex() : -1;
 }
 
-int32_t Battle::Board::DoubleHexAttackValue( const Unit & attacker, const Unit & target, const int32_t from )
+int32_t Battle::Board::DoubleCellAttackValue( const Unit & attacker, const Unit & target, const int32_t from )
 {
     const int32_t targetCell = OptimalAttackTarget( target.GetPosition(), from );
     const Cell * behind = GetCell( targetCell, GetDirection( from, targetCell ) );

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -526,7 +526,7 @@ int32_t Battle::Board::DoubleCellAttackValue( const Unit & attacker, const Unit 
 {
     const Cell * behind = GetCell( targetCell, GetDirection( from, targetCell ) );
     const Unit * secondaryTarget = ( behind ) ? behind->GetUnit() : nullptr;
-    if ( secondaryTarget && secondaryTarget->GetUID() != target.GetUID() ) {
+    if ( secondaryTarget && secondaryTarget->GetUID() != target.GetUID() && secondaryTarget->GetUID() != attacker.GetUID() ) {
         return secondaryTarget->GetScoreQuality( attacker );
     }
     return 0;
@@ -540,7 +540,7 @@ int32_t Battle::Board::OptimalAttackTarget( const Unit & attacker, const Unit & 
     // isNearIndexes should return false if we pass in invalid tail index (-1)
     if ( isNearIndexes( from, tailIndex ) ) {
         if ( attacker.isDoubleCellAttack() && isNearIndexes( from, headIndex )
-             && DoubleCellAttackValue( attacker, target, headIndex, from ) > DoubleCellAttackValue( attacker, target, tailIndex, from ) ) {
+             && DoubleCellAttackValue( attacker, target, from, headIndex ) > DoubleCellAttackValue( attacker, target, from, tailIndex ) ) {
             // Special case when attacking wide unit from the middle cell and could turn around
             return headIndex;
         }
@@ -553,7 +553,7 @@ int32_t Battle::Board::OptimalAttackValue( const Unit & attacker, const Unit & t
 {
     if ( attacker.isDoubleCellAttack() ) {
         const int32_t targetCell = OptimalAttackTarget( attacker, target, from );
-        return target.GetScoreQuality( attacker ) + DoubleCellAttackValue( attacker, target, targetCell, from );
+        return target.GetScoreQuality( attacker ) + DoubleCellAttackValue( attacker, target, from, targetCell );
     }
     return target.GetScoreQuality( attacker );
 }

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -111,27 +111,39 @@ void Battle::Board::SetPositionQuality( const Unit & b )
 {
     Arena * arena = GetArena();
     Units enemies( arena->GetForce( b.GetCurrentColor(), true ), true );
+    const bool isDoubleCell = b.isDoubleCellAttack();
 
     // Make sure archers are first here, so melee unit's score won't be double counted
     enemies.SortArchers();
 
-    for ( Units::const_iterator it1 = enemies.begin(); it1 != enemies.end(); ++it1 ) {
-        const Unit * unit = *it1;
-
+    for ( const Unit * unit : enemies ) {
         if ( unit && unit->isValid() ) {
-            const s32 unitStrength = unit->GetScoreQuality( b );
+            const int32_t targetValue = unit->GetScoreQuality( b );
             const Indexes around = GetAroundIndexes( *unit );
 
-            for ( Indexes::const_iterator it2 = around.begin(); it2 != around.end(); ++it2 ) {
-                Cell * cell2 = GetCell( *it2 );
-                if ( cell2 && cell2->isPassable3( b, false ) ) {
-                    const s32 quality = cell2->GetQuality();
-                    // Only sum up quality score if it's archers; otherwise just pick the strongest
-                    if ( unit->isArchers() )
-                        cell2->SetQuality( quality + unitStrength );
-                    else if ( unitStrength > quality )
-                        cell2->SetQuality( unitStrength );
+            for ( const int32_t index : around ) {
+                Cell * cell2 = GetCell( index );
+                if ( !cell2 || !cell2->isPassable3( b, false ) )
+                    continue;
+
+                const int32_t quality = cell2->GetQuality();
+
+                // Check what's in the cell behind for double attack
+                int32_t attackValue = targetValue;
+                if ( isDoubleCell ) {
+                    const int32_t targetCell = GetOptimalAttackTarget( unit->GetPosition(), index );
+                    const Cell * behind = GetCell( targetCell, GetDirection( index, targetCell ) );
+                    const Unit * secondaryTarget = ( behind ) ? behind->GetUnit() : nullptr;
+                    if ( secondaryTarget && secondaryTarget->GetUID() != unit->GetUID() ) {
+                        attackValue += secondaryTarget->GetScoreQuality( b );
+                    }
                 }
+
+                // Only sum up quality score if it's archers; otherwise just pick the highest
+                if ( unit->isArchers() )
+                    cell2->SetQuality( quality + attackValue );
+                else if ( attackValue > quality )
+                    cell2->SetQuality( attackValue );
             }
         }
     }
@@ -518,6 +530,17 @@ std::vector<Battle::Unit *> Battle::Board::GetNearestTroops( const Unit * startU
     }
 
     return units;
+}
+
+int32_t Battle::Board::GetOptimalAttackTarget( const Position & target, const int32_t from )
+{
+    const Cell * tail = target.GetTail();
+    if ( tail && Board::isNearIndexes( from, tail->GetIndex() ) ) {
+        // todo - check 2hex attack
+        return tail->GetIndex();
+    }
+    const Cell * head = target.GetHead();
+    return head ? head->GetIndex() : -1;
 }
 
 int Battle::Board::GetDirection( s32 index1, s32 index2 )

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -82,7 +82,8 @@ namespace Battle
         static bool isNegativeDistance( s32 index1, s32 index2 );
         static int GetReflectDirection( int );
         static int GetDirection( s32, s32 );
-        static int32_t GetOptimalAttackTarget( const Position & target, const int32_t from );
+        static int32_t OptimalAttackTarget( const Position & target, const int32_t from );
+        static int32_t DoubleHexAttackValue( const Unit & attacker, const Unit & target, const int32_t from );
         static uint32_t GetDistance( s32, s32 );
         static bool isValidDirection( s32, int );
         static s32 GetIndexDirection( s32, int );

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -82,6 +82,7 @@ namespace Battle
         static bool isNegativeDistance( s32 index1, s32 index2 );
         static int GetReflectDirection( int );
         static int GetDirection( s32, s32 );
+        static int32_t GetOptimalAttackTarget( const Position & target, const int32_t from );
         static uint32_t GetDistance( s32, s32 );
         static bool isValidDirection( s32, int );
         static s32 GetIndexDirection( s32, int );

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -82,8 +82,9 @@ namespace Battle
         static bool isNegativeDistance( s32 index1, s32 index2 );
         static int GetReflectDirection( int );
         static int GetDirection( s32, s32 );
-        static int32_t OptimalAttackTarget( const Position & target, const int32_t from );
-        static int32_t DoubleCellAttackValue( const Unit & attacker, const Unit & target, const int32_t from );
+        static int32_t DoubleCellAttackValue( const Unit & attacker, const Unit & target, const int32_t from, const int32_t targetCell );
+        static int32_t OptimalAttackTarget( const Unit & attacker, const Unit & target, const int32_t from );
+        static int32_t OptimalAttackValue( const Unit & attacker, const Unit & target, const int32_t from );
         static uint32_t GetDistance( s32, s32 );
         static bool isValidDirection( s32, int );
         static s32 GetIndexDirection( s32, int );

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -83,7 +83,7 @@ namespace Battle
         static int GetReflectDirection( int );
         static int GetDirection( s32, s32 );
         static int32_t OptimalAttackTarget( const Position & target, const int32_t from );
-        static int32_t DoubleHexAttackValue( const Unit & attacker, const Unit & target, const int32_t from );
+        static int32_t DoubleCellAttackValue( const Unit & attacker, const Unit & target, const int32_t from );
         static uint32_t GetDistance( s32, s32 );
         static bool isValidDirection( s32, int );
         static s32 GetIndexDirection( s32, int );

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -56,10 +56,10 @@ namespace Battle
     bool ArenaPathfinder::hexIsPassable( int targetCell ) const
     {
         const size_t index = static_cast<size_t>( targetCell );
-        return index < _cache.size() && nodeIsAccessible( _cache[index] );
+        return index < _cache.size() && nodeIsPassable( _cache[index] );
     }
 
-    bool ArenaPathfinder::nodeIsAccessible( const ArenaNode & node ) const
+    bool ArenaPathfinder::nodeIsPassable( const ArenaNode & node ) const
     {
         return node._cost == 0 || ( node._isOpen && node._from != -1 );
     }
@@ -71,7 +71,7 @@ namespace Battle
 
         for ( size_t index = 0; index < _cache.size(); ++index ) {
             const ArenaNode & node = _cache[index];
-            if ( nodeIsAccessible( node ) && node._cost <= moveRange ) {
+            if ( nodeIsPassable( node ) && node._cost <= moveRange ) {
                 result.push_back( index );
             }
         }

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -65,6 +65,6 @@ namespace Battle
         Indexes getAllAvailableMoves( uint32_t moveRange ) const;
 
     private:
-        bool nodeIsAccessible( const ArenaNode & node ) const;
+        bool nodeIsPassable( const ArenaNode & node ) const;
     };
 }

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1120,8 +1120,13 @@ s32 Battle::Unit::GetScoreQuality( const Unit & defender ) const
     if ( attacker.Modes( SP_BLIND ) || attacker.Modes( IS_PARALYZE_MAGIC ) )
         attackerThreat = 0;
     // Negative value of units that changed the side
-    if ( attacker.Modes( SP_BERSERKER ) || attacker.Modes( SP_HYPNOTIZE ) )
+    if ( attacker.Modes( SP_BERSERKER ) || attacker.Modes( SP_HYPNOTIZE ) ) {
         attackerThreat *= -1;
+    }
+    // Heavy penalty for hiting our own units
+    else if ( attacker.GetArmyColor() == defender.GetArmyColor() ) {
+        attackerThreat *= -2;
+    }
 
     // Avoid effectiveness scaling if we're dealing with archers
     if ( !attackerIsArchers || defender.isArchers() )

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1116,24 +1116,25 @@ s32 Battle::Unit::GetScoreQuality( const Unit & defender ) const
     // force big priority on mirror images as they get destroyed in 1 hit
     if ( attacker.Modes( CAP_MIRRORIMAGE ) )
         attackerThreat *= 10;
-    // Ignore disabled units
-    if ( attacker.Modes( SP_BLIND ) || attacker.Modes( IS_PARALYZE_MAGIC ) )
-        attackerThreat = 0;
+
     // Negative value of units that changed the side
     if ( attacker.Modes( SP_BERSERKER ) || attacker.Modes( SP_HYPNOTIZE ) ) {
         attackerThreat *= -1;
     }
-    // Heavy penalty for hiting our own units
+    // Otherwise heavy penalty for hiting our own units
     else if ( attacker.GetArmyColor() == defender.GetArmyColor() ) {
         attackerThreat *= -2;
+    }
+    // Finally ignore disabled units (if belong to the enemy)
+    else if ( attacker.Modes( SP_BLIND ) || attacker.Modes( IS_PARALYZE_MAGIC ) ) {
+        attackerThreat = 0;
     }
 
     // Avoid effectiveness scaling if we're dealing with archers
     if ( !attackerIsArchers || defender.isArchers() )
         attackerThreat *= attackerPowerLost;
 
-    const int score = static_cast<int>( attackerThreat * 10 );
-    return ( score == 0 ) ? 1 : score;
+    return static_cast<int>( attackerThreat * 100 );
 }
 
 u32 Battle::Unit::GetHitPoints( void ) const


### PR DESCRIPTION
Fixes #2735 .

Considerate refactor of melee target selection code for both offensive and defensive modes:
Split quality calculations into target and position heuristics.
Added a few helper methods to evaluate potential double cell attacks.
Added logic to determine best attack angle.

We will need another round of AI testing after all recent changes.