### PR TITLE
Fix ArenaPathfinder backwards move logic

### DIFF
--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -260,7 +260,7 @@ std::list<Route::Step> PlayerWorldPathfinder::buildPath( int targetIndex ) const
 void PlayerWorldPathfinder::processCurrentNode( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx, bool fromWater )
 {
     // if current tile contains a monster, skip it
-    if ( world.GetTiles( currentNodeIdx ).GetObject() == MP2::OBJ_MONSTER ) {
+    if ( _cache[currentNodeIdx]._objectID == MP2::OBJ_MONSTER ) {
         return;
     }
 


### PR DESCRIPTION
Related to #2932 .

Fixed an issue when pathfinder wouldn't for wide unit to move backwards in a straight line (through a bridge for example). Also improved moat penalty calculation and added extra tail check to mirror changes in linked Bridge PR.