### PR TITLE
Reset blind upon taking any damage

### DIFF
--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -241,6 +241,10 @@ void Battle::Arena::ApplyActionAttack( Command & cmd )
         const bool handfighting = Unit::isHandFighting( *b1, *b2 );
         // check position
         if ( b1->isArchers() || handfighting ) {
+            if ( b2->Modes( SP_BLIND ) ) {
+                b2->SetBlindAnswer( true );
+            }
+
             // attack
             BattleProcess( *b1, *b2, dst, dir );
 
@@ -249,6 +253,7 @@ void Battle::Arena::ApplyActionAttack( Command & cmd )
                 if ( handfighting && !b1->ignoreRetaliation() && b2->AllowResponse() ) {
                     BattleProcess( *b2, *b1 );
                     b2->SetResponse();
+                    b2->SetBlindAnswer( false );
                 }
 
                 // twice attack

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -238,10 +238,6 @@ void Battle::Arena::ApplyActionAttack( Command & cmd )
     if ( b1 && b1->isValid() && b2 && b2->isValid() && ( b1->GetCurrentColor() != b2->GetColor() ) ) {
         DEBUG_LOG( DBG_BATTLE, DBG_TRACE, b1->String() << " to " << b2->String() );
 
-        // reset blind
-        if ( b2->Modes( SP_BLIND ) )
-            b2->ResetBlind();
-
         const bool handfighting = Unit::isHandFighting( *b1, *b2 );
         // check position
         if ( b1->isArchers() || handfighting ) {
@@ -820,9 +816,6 @@ void Battle::Arena::ApplyActionTower( Command & cmd )
         target.killed = b2->ApplyDamage( *tower, target.damage );
         if ( interface )
             interface->RedrawActionTowerPart2( *tower, target );
-
-        if ( b2->Modes( SP_BLIND ) )
-            b2->ResetBlind();
     }
     else {
         DEBUG_LOG( DBG_BATTLE, DBG_WARN,

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -241,9 +241,8 @@ void Battle::Arena::ApplyActionAttack( Command & cmd )
         const bool handfighting = Unit::isHandFighting( *b1, *b2 );
         // check position
         if ( b1->isArchers() || handfighting ) {
-            if ( b2->Modes( SP_BLIND ) ) {
+            if ( b2->Modes( SP_BLIND ) )
                 b2->SetBlindAnswer( true );
-            }
 
             // attack
             BattleProcess( *b1, *b2, dst, dir );
@@ -253,8 +252,8 @@ void Battle::Arena::ApplyActionAttack( Command & cmd )
                 if ( handfighting && !b1->ignoreRetaliation() && b2->AllowResponse() ) {
                     BattleProcess( *b2, *b1 );
                     b2->SetResponse();
-                    b2->SetBlindAnswer( false );
                 }
+                b2->SetBlindAnswer( false );
 
                 // twice attack
                 if ( b1->isValid() && b1->isTwiceAttack() && !b1->Modes( SP_BLIND | IS_PARALYZE_MAGIC ) ) {

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1225,6 +1225,7 @@ void Battle::Unit::SpellModesAction( const Spell & spell, u32 duration, const He
 
     case Spell::BLIND:
         SetModes( SP_BLIND );
+        blindanswer = false;
         affected.AddMode( SP_BLIND, duration );
         break;
 

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -524,7 +524,7 @@ u32 Battle::Unit::CalculateDamageUnit( const Unit & enemy, double dmg ) const
     }
 
     // after blind
-    if ( Modes( SP_BLIND ) )
+    if ( blindanswer )
         dmg /= 2;
 
     // stone cap.
@@ -730,7 +730,6 @@ u32 Battle::Unit::ApplyDamage( Unit & enemy, u32 dmg )
 
     // blind
     if ( Modes( SP_BLIND ) ) {
-        blindanswer = true;
         ResetBlind();
     }
 
@@ -960,14 +959,7 @@ StreamBase & Battle::operator>>( StreamBase & msg, Unit & b )
 
 bool Battle::Unit::AllowResponse( void ) const
 {
-    if ( !Modes( IS_PARALYZE_MAGIC ) ) {
-        if ( Modes( SP_BLIND ) )
-            return blindanswer;
-        else if ( isAlwaysRetaliating() || !Modes( TR_RESPONSED ) )
-            return true;
-    }
-
-    return false;
+    return !Modes( IS_PARALYZE_MAGIC ) && ( isAlwaysRetaliating() || !Modes( TR_RESPONSED ) );
 }
 
 void Battle::Unit::SetResponse( void )
@@ -1014,6 +1006,11 @@ void Battle::Unit::ResetBlind( void )
         ResetModes( SP_BLIND );
         affected.RemoveMode( SP_BLIND );
     }
+}
+
+void Battle::Unit::SetBlindAnswer( bool value )
+{
+    blindanswer = value;
 }
 
 u32 Battle::Unit::GetAttack( void ) const
@@ -1228,7 +1225,6 @@ void Battle::Unit::SpellModesAction( const Spell & spell, u32 duration, const He
 
     case Spell::BLIND:
         SetModes( SP_BLIND );
-        blindanswer = false;
         affected.AddMode( SP_BLIND, duration );
         break;
 

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -731,6 +731,7 @@ u32 Battle::Unit::ApplyDamage( Unit & enemy, u32 dmg )
     // blind
     if ( Modes( SP_BLIND ) ) {
         blindanswer = true;
+        ResetBlind();
     }
 
     return killed;

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -142,6 +142,7 @@ namespace Battle
         bool isUnderSpellEffect( const Spell & spell ) const;
         void PostAttackAction( Unit & );
         void ResetBlind( void );
+        void SetBlindAnswer( bool value );
         void SpellModesAction( const Spell &, u32, const HeroBase * );
         void SpellApplyDamage( const Spell &, u32, const HeroBase *, TargetInfo & );
         void SpellRestoreAction( const Spell &, u32, const HeroBase * );


### PR DESCRIPTION
Fixes #2936 .

Before blind was reset during attack action, now it's when unit receives damage. Tested with hydras, castle towers and mass spells.