### PR TITLE
Fix interaction with the castle bridge for flying units

### DIFF
--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -301,6 +301,18 @@ void Battle::Arena::ApplyActionMove( Command & cmd )
                                << ")" );
 
         if ( b->isFlying() ) {
+            const int32_t dstTail = b->isWide() ? pos1.GetTail()->GetIndex() : -1;
+
+            // open the bridge if the unit should land on it
+            if ( bridge ) {
+                if ( bridge->NeedDown( *b, dst ) ) {
+                    bridge->Action( *b, dst );
+                }
+                else if ( b->isWide() && bridge->NeedDown( *b, dstTail ) ) {
+                    bridge->Action( *b, dstTail );
+                }
+            }
+
             b->UpdateDirection( pos1.GetRect() );
             if ( b->isReflect() != pos1.isReflect() )
                 pos1.Swap();

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -458,7 +458,7 @@ void Battle::Arena::Turns( void )
         }
 
         // set bridge passable
-        if ( bridge && bridge->isValid() && !bridge->isDown() )
+        if ( bridge )
             bridge->SetPassable( *current_troop );
 
         // turn troop
@@ -473,7 +473,7 @@ void Battle::Arena::Turns( void )
             current_color = current_troop->GetArmyColor();
 
             // set bridge passable
-            if ( bridge && bridge->isValid() && !bridge->isDown() )
+            if ( bridge )
                 bridge->SetPassable( *current_troop );
 
             // turn troop

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -187,9 +187,9 @@ void Battle::Board::SetScanPassability( const Unit & unit )
         const Bridge * bridge = Arena::GetBridge();
         const bool isPassableBridge = bridge == nullptr || bridge->isPassable( unit );
 
-        for ( iterator it = begin(); it != end(); ++it ) {
-            if ( ( *it ).isPassable3( unit, false ) && ( isPassableBridge || !Board::isBridgeIndex( it - begin(), unit ) ) ) {
-                ( *it ).SetDirection( CENTER );
+        for ( std::size_t i = 0; i < size(); i++ ) {
+            if ( at( i ).isPassable3( unit, false ) && ( isPassableBridge || !Board::isBridgeIndex( i, unit ) ) ) {
+                at( i ).SetDirection( CENTER );
             }
         }
     }

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -73,8 +73,8 @@ namespace Battle
         static bool isNearIndexes( s32, s32 );
         static bool isValidIndex( s32 );
         static bool isCastleIndex( s32 );
-        static bool isMoatIndex( s32, const Unit & );
-        static bool isBridgeIndex( s32, const Unit & );
+        static bool isMoatIndex( s32 index, const Unit & b );
+        static bool isBridgeIndex( s32 index, const Unit & b );
         static bool isImpassableIndex( s32 );
         static bool isOutOfWallsIndex( s32 );
         static bool isReflectDirection( int );

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -73,8 +73,8 @@ namespace Battle
         static bool isNearIndexes( s32, s32 );
         static bool isValidIndex( s32 );
         static bool isCastleIndex( s32 );
-        static bool isMoatIndex( s32, int );
-        static bool isBridgeIndex( s32, int );
+        static bool isMoatIndex( s32, const Unit & );
+        static bool isBridgeIndex( s32, const Unit & );
         static bool isImpassableIndex( s32 );
         static bool isOutOfWallsIndex( s32 );
         static bool isReflectDirection( int );

--- a/src/fheroes2/battle/battle_bridge.cpp
+++ b/src/fheroes2/battle/battle_bridge.cpp
@@ -93,19 +93,20 @@ bool Battle::Bridge::NeedDown( const Unit & b, s32 dstPos ) const
 
 bool Battle::Bridge::isPassable( const Unit & b ) const
 {
-    // yes if bridge is lowered, or unit belongs to the castle and there are no any troops (alive or dead) on or under the bridge
+    // yes if bridge is lowered (or destroyed), or unit belongs to the castle and there are no any troops (alive or dead) on or under the bridge
     return isDown() || ( b.GetColor() == Arena::GetCastle()->GetColor() && !isBridgeOccupied() );
 }
 
 void Battle::Bridge::SetDestroy( void )
 {
     destroy = true;
+
     Board::GetCell( GATES_CELL )->SetObject( 0 );
 }
 
 void Battle::Bridge::SetPassable( const Unit & b )
 {
-    if ( Board::isCastleIndex( b.GetHeadIndex() ) || b.GetColor() == Arena::GetCastle()->GetColor() ) {
+    if ( isPassable( b ) ) {
         Board::GetCell( GATES_CELL )->SetObject( 0 );
     }
     else {

--- a/src/fheroes2/battle/battle_bridge.cpp
+++ b/src/fheroes2/battle/battle_bridge.cpp
@@ -73,12 +73,10 @@ bool Battle::Bridge::NeedDown( const Unit & b, s32 dstPos ) const
         return false;
 
     if ( b.isFlying() ) {
-        if ( dstPos == GATES_CELL ) {
-            return true;
-        }
+        return dstPos == GATES_CELL;
     }
     else {
-        const s32 prevPos = b.GetHeadIndex();
+        const int32_t prevPos = b.GetHeadIndex();
 
         if ( dstPos == GATES_CELL && ( prevPos == CELL_AFTER_GATES || prevPos == BELOW_BRIDGE_CELL || prevPos == ABOVE_BRIDGE_CELL ) ) {
             return true;

--- a/src/fheroes2/battle/battle_bridge.cpp
+++ b/src/fheroes2/battle/battle_bridge.cpp
@@ -68,30 +68,33 @@ bool Battle::Bridge::isBridgeOccupied( void ) const
 
 bool Battle::Bridge::NeedDown( const Unit & b, s32 dstPos ) const
 {
-    // no if bridge is destroyed or already lowered or there are any troops (alive or dead) on or under the bridge
-    if ( !isValid() || isDown() || isBridgeOccupied() )
+    // no if bridge is destroyed or already lowered or unit does not belong to the castle or there are any troops (alive or dead) on or under the bridge
+    if ( !isValid() || isDown() || b.GetColor() != Arena::GetCastle()->GetColor() || isBridgeOccupied() )
         return false;
 
-    const s32 prevPos = b.GetHeadIndex();
-
-    if ( dstPos == GATES_CELL ) {
-        if ( prevPos == CELL_AFTER_GATES )
+    if ( b.isFlying() ) {
+        if ( dstPos == GATES_CELL ) {
             return true;
-        if ( ( prevPos == BELOW_BRIDGE_CELL || prevPos == ABOVE_BRIDGE_CELL ) && b.GetColor() == Arena::GetCastle()->GetColor() )
-            return true;
+        }
     }
-    else if ( dstPos == MOAT_CELL ) {
-        if ( prevPos != GATES_CELL && b.GetColor() == Arena::GetCastle()->GetColor() )
+    else {
+        const s32 prevPos = b.GetHeadIndex();
+
+        if ( dstPos == GATES_CELL && ( prevPos == CELL_AFTER_GATES || prevPos == BELOW_BRIDGE_CELL || prevPos == ABOVE_BRIDGE_CELL ) ) {
             return true;
+        }
+        else if ( dstPos == MOAT_CELL && prevPos != GATES_CELL ) {
+            return true;
+        }
     }
 
     return false;
 }
 
-bool Battle::Bridge::isPassable( int color ) const
+bool Battle::Bridge::isPassable( const Unit & b ) const
 {
-    // yes if bridge is lowered, or color belongs to the castle and there are no any troops (alive or dead) on or under the bridge
-    return isDown() || ( color == Arena::GetCastle()->GetColor() && !isBridgeOccupied() );
+    // yes if bridge is lowered, or unit belongs to the castle and there are no any troops (alive or dead) on or under the bridge
+    return isDown() || ( b.GetColor() == Arena::GetCastle()->GetColor() && !isBridgeOccupied() );
 }
 
 void Battle::Bridge::SetDestroy( void )

--- a/src/fheroes2/battle/battle_bridge.h
+++ b/src/fheroes2/battle/battle_bridge.h
@@ -42,7 +42,7 @@ namespace Battle
 
         bool AllowUp( void ) const;
         bool NeedDown( const Unit &, s32 ) const;
-        bool isPassable( int ) const;
+        bool isPassable( const Unit & ) const;
         bool isValid( void ) const;
         bool isDestroy( void ) const;
         bool isDown( void ) const;

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -109,7 +109,7 @@ namespace Battle
         const Bridge * bridge = Arena::GetBridge();
         const Castle * castle = Arena::GetCastle();
 
-        const bool isPassableBridge = bridge == nullptr || bridge->isPassable( unit.GetColor() );
+        const bool isPassableBridge = bridge == nullptr || bridge->isPassable( unit );
         const bool isMoatBuilt = castle && castle->isBuild( BUILD_MOAT );
         const uint32_t moatPenalty = unit.GetSpeed();
 
@@ -136,7 +136,7 @@ namespace Battle
                 ArenaNode & node = _cache[idx];
 
                 // isPassable3 checks if there's space for unit tail (for wide units)
-                if ( it->isPassable3( unit, false ) ) {
+                if ( it->isPassable3( unit, false ) && ( isPassableBridge || !Board::isBridgeIndex( it - board.begin(), unit ) ) ) {
                     node._isOpen = true;
                     node._from = pathStart;
                     node._cost = Battle::Board::GetDistance( pathStart, idx );
@@ -192,7 +192,7 @@ namespace Battle
 
                     // Special case: headCell is *allowed* to have another unit in it, that's why we check isPassable1( false ) instead of isPassable4
                     if ( headCell->isPassable1( false ) && ( !tailCell || tailCell->isPassable1( true ) )
-                         && ( isPassableBridge || !Board::isBridgeIndex( newNode, unit.GetColor() ) ) ) {
+                         && ( isPassableBridge || !Board::isBridgeIndex( newNode, unit ) ) ) {
                         const uint32_t cost = previousNode._cost;
                         ArenaNode & node = _cache[newNode];
 
@@ -202,7 +202,7 @@ namespace Battle
                             additionalCost = 0;
                         }
                         // Moat penalty consumes all remaining movement. Be careful when dealing with unsigned values.
-                        else if ( isMoatBuilt && ( Board::isMoatIndex( newNode, unit.GetColor() ) || Board::isMoatIndex( newTailIndex, unit.GetColor() ) )
+                        else if ( isMoatBuilt && ( Board::isMoatIndex( newNode, unit ) || Board::isMoatIndex( newTailIndex, unit ) )
                                   && moatPenalty > previousNode._cost ) {
                             additionalCost = moatPenalty - cost;
                         }

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1049,7 +1049,7 @@ u32 Battle::Unit::GetDefense( void ) const
     // check moat
     const Castle * castle = Arena::GetCastle();
 
-    if ( castle && castle->isBuild( BUILD_MOAT ) && ( Board::isMoatIndex( GetHeadIndex(), GetColor() ) || Board::isMoatIndex( GetTailIndex(), GetColor() ) ) ) {
+    if ( castle && castle->isBuild( BUILD_MOAT ) && ( Board::isMoatIndex( GetHeadIndex(), *this ) || Board::isMoatIndex( GetTailIndex(), *this ) ) ) {
         const uint32_t step = GameStatic::GetBattleMoatReduceDefense();
 
         if ( step >= res )


### PR DESCRIPTION
In the original game, flying unit could not land on the gates cell, even if gates are already open or destroyed:

![OG](https://user-images.githubusercontent.com/32623900/111154773-a2f49200-85a4-11eb-96fe-dfc7484a96a1.jpg)

At the moment, in fheroes2 flying units don't interact with gates and bridge in any way, what leads to situations like this:

<img width="639" alt="Phoenixes fail" src="https://user-images.githubusercontent.com/32623900/111155041-fb2b9400-85a4-11eb-88ca-f7064e11b09c.png">

In this PR I propose some changes that will cause flying units to interact with the bridge like everyone else - the bridge should be lowered first to allow landing on the gates cell:

<img width="639" alt="Phoenixes OK" src="https://user-images.githubusercontent.com/32623900/111158330-f79a0c00-85a8-11eb-8c11-d00f438a0efa.png">
