### PR TITLE
Refine battle pathfinding using a recursive greedy depth-limited approach

### DIFF
--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -596,7 +596,7 @@ void Battle::Arena::CatapultAction( void )
 
 Battle::Indexes Battle::Arena::GetPath( const Unit & b, const Position & dst ) const
 {
-    Indexes result = board.GetAStarPath( b, dst );
+    Indexes result = board.GetPath( b, dst );
 
     if ( !result.empty() && IS_DEBUG( DBG_BATTLE, DBG_TRACE ) ) {
         std::stringstream ss;

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -253,9 +253,7 @@ bool Battle::Board::GetPathForUnit( const Unit & unit, const Position & destinat
 
     // Scan the available cells recursively in ascending order of distance
     for ( const auto & cellCost : cellCosts ) {
-        int32_t cellId;
-
-        std::tie( std::ignore, cellId ) = cellCost;
+        const int32_t cellId = cellCost.second;
 
         // Mark the cell as visited for further steps
         visitedCells.at( cellId ) = true;
@@ -335,9 +333,7 @@ bool Battle::Board::GetPathForWideUnit( const Unit & unit, const Position & dest
 
     // Scan the available cells recursively in ascending order of distance
     for ( const auto & cellCost : cellCosts ) {
-        int32_t headCellId;
-
-        std::tie( std::ignore, headCellId ) = cellCost;
+        const int32_t headCellId = cellCost.second;
 
         // Mark the cell as visited for further steps
         visitedCells.at( headCellId ) = true;

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -204,261 +204,200 @@ void Battle::Board::SetScanPassability( const Unit & unit )
 
         // Set passable cells.
         for ( Indexes::const_iterator it = indexes.begin(); it != indexes.end(); ++it )
-            GetAStarPath( unit, Position::GetCorrect( unit, *it ), false );
+            GetPath( unit, Position::GetCorrect( unit, *it ), false );
     }
 }
 
-struct CellNode
+bool Battle::Board::GetPathForUnit( const Unit & unit, const Position & destination, const uint32_t remainingSteps, const int32_t currentCellId,
+                                    std::vector<bool> & visitedCells, Indexes & result ) const
 {
-    int32_t cost;
-    int32_t parentCellId;
-    bool open;
-    bool leftDirection; // this is used for a wide unit movement to know the current position of tail
+    if ( remainingSteps == 0 ) {
+        return false;
+    }
 
-    CellNode()
-        : cost( MAXU16 )
-        , parentCellId( -1 )
-        , open( true )
-        , leftDirection( false )
-    {}
-};
+    const Castle * castle = Arena::GetCastle();
+    const bool isMoatBuilt = castle && castle->isBuild( BUILD_MOAT );
 
-Battle::Indexes Battle::Board::GetAStarPath( const Unit & unit, const Position & destination, const bool debug ) const
+    const int32_t dstCellId = destination.GetHead()->GetIndex();
+
+    // Upper distance limit
+    if ( Board::GetDistance( currentCellId, dstCellId ) > remainingSteps ) {
+        return false;
+    }
+
+    std::multimap<uint32_t, int32_t> cellCosts;
+
+    for ( const int32_t cellId : GetAroundIndexes( currentCellId ) ) {
+        const Cell & cell = at( cellId );
+
+        // Ignore already visited or impassable cell
+        if ( visitedCells.at( cellId ) || !cell.isPassable4( unit, at( currentCellId ) ) ) {
+            continue;
+        }
+
+        // Unit is already at its destination
+        if ( cellId == dstCellId ) {
+            result.push_back( cellId );
+
+            return true;
+        }
+
+        // Unit steps into the moat, do not let it pass through the moat
+        if ( isMoatBuilt && Board::isMoatIndex( cellId, unit ) ) {
+            continue;
+        }
+
+        // Calculate the distance from the cell in question to the destination, sort cells by distance
+        cellCosts.emplace( Board::GetDistance( cellId, dstCellId ), cellId );
+    }
+
+    // Scan the available cells recursively in ascending order of distance
+    for ( const auto & cellCost : cellCosts ) {
+        int32_t cellId;
+
+        std::tie( std::ignore, cellId ) = cellCost;
+
+        // Mark the cell as visited for further steps
+        visitedCells.at( cellId ) = true;
+
+        if ( GetPathForUnit( unit, destination, remainingSteps - 1, cellId, visitedCells, result ) ) {
+            result.push_back( cellId );
+
+            return true;
+        }
+
+        // Unmark the cell as visited
+        visitedCells.at( cellId ) = false;
+    }
+
+    return false;
+}
+
+bool Battle::Board::GetPathForWideUnit( const Unit & unit, const Position & destination, const uint32_t remainingSteps, const int32_t currentHeadCellId,
+                                        const int32_t prevHeadCellId, std::vector<bool> & visitedCells, Indexes & result ) const
+{
+    if ( remainingSteps == 0 ) {
+        return false;
+    }
+
+    const Castle * castle = Arena::GetCastle();
+    const bool isMoatBuilt = castle && castle->isBuild( BUILD_MOAT );
+
+    const int32_t dstHeadCellId = destination.GetHead()->GetIndex();
+    const int32_t dstTailCellId = destination.GetTail()->GetIndex();
+
+    const bool isCurrentLeftDirection = prevHeadCellId < 0 ? unit.isReflect() : ( ( GetDirection( prevHeadCellId, currentHeadCellId ) & LEFT_SIDE ) != 0 );
+    const int32_t currentTailCellId = isCurrentLeftDirection ? currentHeadCellId + 1 : currentHeadCellId - 1;
+
+    // Upper distance limit
+    if ( Board::GetDistance( currentHeadCellId, dstHeadCellId ) > remainingSteps && Board::GetDistance( currentTailCellId, dstHeadCellId ) > remainingSteps ) {
+        return false;
+    }
+
+    std::multimap<uint32_t, int32_t> cellCosts;
+
+    for ( const int32_t headCellId : GetMoveWideIndexes( currentHeadCellId, isCurrentLeftDirection ) ) {
+        const Cell & cell = at( headCellId );
+
+        // Ignore already visited or impassable cell
+        if ( visitedCells.at( headCellId ) || !cell.isPassable4( unit, at( currentHeadCellId ) ) ) {
+            continue;
+        }
+
+        const int32_t tailCellId = ( GetDirection( currentHeadCellId, headCellId ) & LEFT_SIDE ) ? headCellId + 1 : headCellId - 1;
+
+        // Unit is already at its destination
+        if ( ( headCellId == dstHeadCellId && tailCellId == dstTailCellId ) || ( headCellId == dstTailCellId && tailCellId == dstHeadCellId ) ) {
+            result.push_back( headCellId );
+
+            return true;
+        }
+
+        // Unit steps into the moat
+        if ( isMoatBuilt && ( Board::isMoatIndex( headCellId, unit ) || Board::isMoatIndex( tailCellId, unit ) ) ) {
+            // Moat is a part of the unit's destination
+            if ( headCellId == dstHeadCellId ) {
+                result.push_back( headCellId );
+
+                return true;
+            }
+
+            // In the moat it is only allowed to turn back, do not let the unit pass through the moat
+            if ( ( tailCellId != currentHeadCellId || !Board::isMoatIndex( tailCellId, unit ) )
+                 && ( headCellId != currentTailCellId || !Board::isMoatIndex( headCellId, unit ) ) ) {
+                continue;
+            }
+        }
+
+        // Calculate the distance from the cell in question to the destination, sort cells by distance
+        cellCosts.emplace( Board::GetDistance( headCellId, dstHeadCellId ) + Board::GetDistance( tailCellId, dstTailCellId ), headCellId );
+    }
+
+    // Scan the available cells recursively in ascending order of distance
+    for ( const auto & cellCost : cellCosts ) {
+        int32_t headCellId;
+
+        std::tie( std::ignore, headCellId ) = cellCost;
+
+        // Mark the cell as visited for further steps
+        visitedCells.at( headCellId ) = true;
+
+        // Turning back is not a movement
+        const uint32_t steps = headCellId == currentTailCellId ? remainingSteps : remainingSteps - 1;
+
+        if ( GetPathForWideUnit( unit, destination, steps, headCellId, currentHeadCellId, visitedCells, result ) ) {
+            result.push_back( headCellId );
+
+            return true;
+        }
+
+        // Unmark the cell as visited
+        visitedCells.at( headCellId ) = false;
+    }
+
+    return false;
+}
+
+Battle::Indexes Battle::Board::GetPath( const Unit & unit, const Position & destination, const bool debug ) const
 {
     Indexes result;
+
     const bool isWideUnit = unit.isWide();
 
-    // check if target position is valid
+    // Check if destination is valid
     if ( !destination.GetHead() || ( isWideUnit && !destination.GetTail() ) ) {
-        ERROR_LOG( "Board::GetAStarPath invalid destination for unit " + unit.String() );
+        ERROR_LOG( "Board::GetPath invalid destination for unit " + unit.String() );
         return result;
     }
 
-    const int32_t startCellId = unit.GetHeadIndex();
-    int32_t currentCellId = startCellId;
+    result.reserve( 15 );
 
-    const Bridge * bridge = Arena::GetBridge();
-    const Castle * castle = Arena::GetCastle();
-    const bool isPassableBridge = bridge == nullptr || bridge->isPassable( unit );
-    const bool isMoatBuilt = castle && castle->isBuild( BUILD_MOAT );
-
-    std::map<int32_t, CellNode> cellMap;
-    cellMap[currentCellId].parentCellId = -1;
-    cellMap[currentCellId].cost = 0;
-    cellMap[currentCellId].open = false;
-    cellMap[currentCellId].leftDirection = unit.isReflect(); // used only for wide (2-hex) creatures
-
-    bool reachedDestination = true;
-
-    const int32_t targetHeadCellId = destination.GetHead()->GetIndex();
-    const int32_t targetTailCellId = isWideUnit ? destination.GetTail()->GetIndex() : targetHeadCellId;
+    std::vector<bool> visitedCells( ARENASIZE, false );
 
     if ( isWideUnit ) {
-        int32_t currentTailCellId = unit.isReflect() ? currentCellId + 1 : currentCellId - 1;
-
-        while ( !( currentCellId == targetHeadCellId && currentTailCellId == targetTailCellId )
-                && !( currentCellId == targetTailCellId && currentTailCellId == targetHeadCellId ) ) {
-            const Cell & center = at( currentCellId );
-
-            CellNode & currentCellNode = cellMap[currentCellId];
-            Indexes aroundCellIds;
-
-            if ( currentCellNode.parentCellId < 0 )
-                aroundCellIds = GetMoveWideIndexes( currentCellId, unit.isReflect() );
-            else
-                aroundCellIds = GetMoveWideIndexes( currentCellId, ( RIGHT_SIDE & GetDirection( currentCellId, currentCellNode.parentCellId ) ) != 0 );
-
-            for ( const int32_t cellId : aroundCellIds ) {
-                const Cell & cell = at( cellId );
-
-                if ( cell.isPassable4( unit, center ) && ( isPassableBridge || !Board::isBridgeIndex( cellId, unit ) ) ) {
-                    const bool isLeftDirection = IsLeftDirection( currentCellId, cellId, currentCellNode.leftDirection );
-                    const int32_t tailCellId = isLeftDirection ? cellId + 1 : cellId - 1;
-
-                    int32_t cost = Board::GetDistance( cellId, targetHeadCellId ) + Board::GetDistance( tailCellId, targetTailCellId );
-
-                    // Turn back. No movement at all.
-                    if ( isLeftDirection != currentCellNode.leftDirection ) {
-                        cost = 0;
-                    }
-                    // Moat penalty. Not applied if one of the target cells is located in the moat.
-                    else if ( isMoatBuilt && cellId != targetHeadCellId && cellId != targetTailCellId ) {
-                        // Don't apply the moat penalty to the unit's tail if the head cell was also in the moat at the previous stage.
-                        if ( Board::isMoatIndex( cellId, unit ) || ( Board::isMoatIndex( tailCellId, unit ) && !Board::isMoatIndex( currentCellId, unit ) ) ) {
-                            cost += ARENASIZE;
-                        }
-                    }
-
-                    if ( cellMap[cellId].parentCellId < 0 ) {
-                        // It is a new cell (node).
-                        cellMap[cellId].parentCellId = currentCellId;
-                        cellMap[cellId].cost = cost + currentCellNode.cost;
-                        cellMap[cellId].leftDirection = isLeftDirection;
-                    }
-                    else if ( cellMap[cellId].cost > cost + currentCellNode.cost ) {
-                        // Found a better path. Update the existing node.
-                        cellMap[cellId].parentCellId = currentCellId;
-                        cellMap[cellId].cost = cost + currentCellNode.cost;
-                        cellMap[cellId].leftDirection = isLeftDirection;
-                    }
-                }
-            }
-
-            currentCellNode.open = false;
-            int32_t cost = MAXU16;
-
-            const int32_t prevCellId = currentCellId;
-
-            // Find unused nodes by minimum cost.
-            for ( std::map<int32_t, CellNode>::const_iterator cellInfoIt = cellMap.begin(); cellInfoIt != cellMap.end(); ++cellInfoIt ) {
-                const CellNode & cellNode = cellInfoIt->second;
-                if ( cellNode.open && cost > cellNode.cost ) {
-                    currentCellId = cellInfoIt->first;
-                    cost = cellNode.cost;
-                }
-            }
-
-            // Find alternative path if there is any.
-            for ( std::map<int32_t, CellNode>::const_iterator cellInfoIt = cellMap.begin(); cellInfoIt != cellMap.end(); ++cellInfoIt ) {
-                const CellNode & cellNode = cellInfoIt->second;
-                if ( cellNode.open && cost == cellNode.cost && cellInfoIt->first != currentCellId && cellNode.parentCellId == prevCellId ) {
-                    currentCellId = cellInfoIt->first;
-                    break;
-                }
-            }
-
-            if ( MAXU16 == cost ) {
-                reachedDestination = false;
-                break;
-            }
-
-            currentTailCellId = IsLeftDirection( prevCellId, currentCellId, currentCellNode.leftDirection ) ? currentCellId + 1 : currentCellId - 1;
-        }
+        GetPathForWideUnit( unit, destination, unit.GetSpeed(), unit.GetHeadIndex(), -1, visitedCells, result );
     }
     else {
-        while ( currentCellId != targetHeadCellId ) {
-            const Cell & center = at( currentCellId );
-            const Indexes aroundCellIds = GetAroundIndexes( currentCellId );
-
-            for ( const int32_t cellId : aroundCellIds ) {
-                const Cell & cell = at( cellId );
-
-                if ( cellMap[cellId].open && cell.isPassable4( unit, center ) && ( isPassableBridge || !Board::isBridgeIndex( cellId, unit ) ) ) {
-                    int32_t cost = Board::GetDistance( cellId, targetHeadCellId );
-
-                    // Moat penalty. Not applied if the target cell is located in the moat.
-                    if ( isMoatBuilt && Board::isMoatIndex( cellId, unit ) && cellId != targetHeadCellId ) {
-                        cost += ARENASIZE;
-                    }
-
-                    if ( cellMap[cellId].parentCellId < 0 ) {
-                        // It is a new cell (node).
-                        cellMap[cellId].parentCellId = currentCellId;
-                        cellMap[cellId].cost = cost + cellMap[currentCellId].cost;
-                    }
-                    else if ( cellMap[cellId].cost > cost + cellMap[currentCellId].cost ) {
-                        // Found a better path. Update the existing node.
-                        cellMap[cellId].parentCellId = currentCellId;
-                        cellMap[cellId].cost = cost + cellMap[currentCellId].cost;
-                    }
-                }
-            }
-
-            cellMap[currentCellId].open = false;
-            int32_t cost = MAXU16;
-
-            // Find unused nodes by minimum cost.
-            for ( std::map<int32_t, CellNode>::const_iterator cellInfoIt = cellMap.begin(); cellInfoIt != cellMap.end(); ++cellInfoIt ) {
-                const CellNode & cellNode = cellInfoIt->second;
-                if ( cellNode.open && cost > cellNode.cost ) {
-                    currentCellId = cellInfoIt->first;
-                    cost = cellNode.cost;
-                }
-            }
-
-            if ( MAXU16 == cost ) {
-                reachedDestination = false;
-                break;
-            }
-        }
+        GetPathForUnit( unit, destination, unit.GetSpeed(), unit.GetHeadIndex(), visitedCells, result );
     }
 
-    // save path
-    if ( reachedDestination ) {
-        result.reserve( 15 );
-        while ( currentCellId != startCellId && isValidIndex( currentCellId ) ) {
-            if ( isWideUnit && !isValidDirection( currentCellId, cellMap[currentCellId].leftDirection ? RIGHT : LEFT ) )
-                break;
-
-            result.push_back( currentCellId );
-            currentCellId = cellMap[currentCellId].parentCellId;
-        }
-
+    if ( !result.empty() ) {
         std::reverse( result.begin(), result.end() );
 
-        // Correct wide creature position.
-        if ( isWideUnit && !result.empty() ) {
-            const int32_t prev = 1 < result.size() ? result[result.size() - 2] : startCellId;
+        // Set direction info for cells
+        for ( std::size_t i = 0; i < result.size(); i++ ) {
+            const int32_t cellId = result[i];
 
-            if ( result.back() == targetHeadCellId ) {
-                const int side = RIGHT == GetDirection( targetHeadCellId, targetTailCellId ) ? RIGHT_SIDE : LEFT_SIDE;
+            Cell * cell = GetCell( cellId );
 
-                if ( !( side & GetDirection( targetHeadCellId, prev ) ) ) {
-                    result.push_back( targetTailCellId );
-                }
-            }
-            else if ( result.back() == targetTailCellId ) {
-                const int side = RIGHT == GetDirection( targetHeadCellId, targetTailCellId ) ? LEFT_SIDE : RIGHT_SIDE;
-
-                if ( !( side & GetDirection( targetTailCellId, prev ) ) ) {
-                    result.push_back( targetHeadCellId );
-                }
-            }
-        }
-
-        if ( isWideUnit ) {
-            uint32_t cellToMoveLeft = unit.GetSpeed();
-            bool prevIsLeftDirection = unit.isReflect();
-            for ( size_t i = 0; i < result.size(); ++i ) {
-                if ( prevIsLeftDirection == cellMap[result[i]].leftDirection ) {
-                    --cellToMoveLeft;
-                    if ( cellToMoveLeft == 0 ) {
-                        result.resize( i + 1 );
-                        break;
-                    }
-                }
-                else {
-                    prevIsLeftDirection = cellMap[result[i]].leftDirection;
-                }
-            }
-        }
-        else {
-            if ( result.size() > unit.GetSpeed() )
-                result.resize( unit.GetSpeed() );
-        }
-
-        // Skip moat position.
-        if ( isMoatBuilt ) {
-            for ( size_t i = 0; i < result.size(); ++i ) {
-                if ( isWideUnit && result[i] == unit.GetTailIndex() )
-                    continue;
-
-                if ( Board::isMoatIndex( result[i], unit ) ) {
-                    result.resize( i + 1 );
-                    break;
-                }
-            }
-        }
-
-        // set passable info
-        for ( Indexes::iterator it = result.begin(); it != result.end(); ++it ) {
-            Cell * cell = GetCell( *it );
             assert( cell != nullptr );
-            cell->SetDirection( cell->GetDirection() | GetDirection( *it, it == result.begin() ? startCellId : *( it - 1 ) ) );
+
+            cell->SetDirection( cell->GetDirection() | GetDirection( cellId, i == 0 ? unit.GetHeadIndex() : result[i - 1] ) );
 
             if ( isWideUnit ) {
-                const int32_t head = *it;
-                const int32_t prev = it != result.begin() ? *( it - 1 ) : startCellId;
+                const int32_t head = cellId;
+                const int32_t prev = i == 0 ? unit.GetHeadIndex() : result[i - 1];
+
                 Cell * tail = GetCell( head, LEFT_SIDE & GetDirection( head, prev ) ? LEFT : RIGHT );
 
                 if ( tail && UNKNOWN == tail->GetDirection() )
@@ -470,7 +409,8 @@ Battle::Indexes Battle::Board::GetAStarPath( const Unit & unit, const Position &
     if ( debug && result.empty() ) {
         DEBUG_LOG( DBG_BATTLE, DBG_WARN,
                    "Path is not found for " << unit.String() << ", destination: "
-                                            << "(head cell ID: " << targetHeadCellId << ", tail cell ID: " << ( isWideUnit ? targetTailCellId : -1 ) << ")" );
+                                            << "(head cell ID: " << destination.GetHead()->GetIndex()
+                                            << ", tail cell ID: " << ( isWideUnit ? destination.GetTail()->GetIndex() : -1 ) << ")" );
     }
 
     return result;

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -117,6 +117,7 @@ namespace Battle
                              std::vector<bool> & visitedCells, Indexes & result ) const;
         bool GetPathForWideUnit( const Unit & unit, const Position & destination, const uint32_t remainingSteps, const int32_t currentHeadCellId,
                                  const int32_t prevHeadCellId, std::vector<bool> & visitedCells, Indexes & result ) const;
+        void StraightenPathForUnit( const int32_t currentCellId, Indexes & path ) const;
     };
 }
 

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -57,7 +57,7 @@ namespace Battle
 
         s32 GetIndexAbsPosition( const fheroes2::Point & ) const;
         std::vector<Unit *> GetNearestTroops( const Unit * startUnit, const std::vector<Unit *> & blackList );
-        Indexes GetAStarPath( const Unit & unit, const Position & destination, const bool debug = true ) const;
+        Indexes GetPath( const Unit & unit, const Position & destination, const bool debug = true ) const;
 
         void SetEnemyQuality( const Unit & ) const;
         void SetPositionQuality( const Unit & ) const;
@@ -112,6 +112,11 @@ namespace Battle
 
     private:
         void SetCobjObject( const int icn, const int32_t dst );
+
+        bool GetPathForUnit( const Unit & unit, const Position & destination, const uint32_t remainingSteps, const int32_t currentCellId,
+                             std::vector<bool> & visitedCells, Indexes & result ) const;
+        bool GetPathForWideUnit( const Unit & unit, const Position & destination, const uint32_t remainingSteps, const int32_t currentHeadCellId,
+                                 const int32_t prevHeadCellId, std::vector<bool> & visitedCells, Indexes & result ) const;
     };
 }
 


### PR DESCRIPTION
Hi all,

I don't know if it's really worth it (considering the new (Dijkstra's based?) pathfinding engine from battle_pathfinding.cpp), but here is my proposal of greedy (in the sense of making the locally optimal choice at each stage) recursive pathfinding algorithm as a possible temporary replacement for old GetAStarPath(). This algorithm may be suboptimal in some situations, but it is simple and (at first sight) it shows much better results than old (in my opinion, weird or incorrectly implemented A* based) pathfinding algorithm, especially in the case of wide units.

Anyway, there is definitely one useful commit in this PR that fixes Board::GetDistance() function. Previous implementation gave incorrect results in a number of cases.

fix #2951