### PR TITLE
Rewrite player switching in multiplayer dialog

### DIFF
--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -134,6 +134,7 @@ void Game::LoadPlayers( const std::string & mapFileName, Players & players )
         player->SetRace( p.GetRace() );
         player->SetControl( p.GetControl() );
         player->SetFriends( p.GetFriends() );
+        player->SetName( p.GetName() );
         players.push_back( player );
         Players::Set( Color::GetIndex( p.GetColor() ), player );
     }
@@ -153,6 +154,7 @@ void Game::SavePlayers( const std::string & mapFileName, const Players & players
         player.SetRace( p->GetRace() );
         player.SetControl( p->GetControl() );
         player.SetFriends( p->GetFriends() );
+        player.SetName( p->GetName() );
         savedPlayers.push_back( player );
     }
 }

--- a/src/fheroes2/gui/player_info.cpp
+++ b/src/fheroes2/gui/player_info.cpp
@@ -379,7 +379,7 @@ bool Interface::PlayersInfo::QueueEventProcessing( void )
             }
         }
         else
-            // change players
+            // swap players
             if ( show_swap && NULL != ( player = GetFromOpponentChangeClick( le.GetMouseCursor() ) ) ) {
             iterator it = std::find_if( begin(), end(), [player]( const PlayerInfo & pi ) { return pi.player == player; } );
             if ( it != end() && ( it + 1 ) != end() ) {
@@ -388,8 +388,7 @@ bool Interface::PlayersInfo::QueueEventProcessing( void )
                 Players::iterator it2 = std::find_if( players.begin(), players.end(), [&it]( const Player * p ) { return p == ( *( it + 1 ) ).player; } );
 
                 if ( it1 != players.end() && it2 != players.end() ) {
-                    std::swap( ( *it ).player, ( *( it + 1 ) ).player );
-                    std::swap( *it1, *it2 );
+                    SwapPlayers( **it1, **it2 );
                 }
             }
             else

--- a/src/fheroes2/gui/player_info.cpp
+++ b/src/fheroes2/gui/player_info.cpp
@@ -298,17 +298,15 @@ bool Interface::PlayersInfo::QueueEventProcessing( void )
                 _( "Opponents" ),
                 _( "This lets you change player starting positions and colors. A particular color will always start in a particular location. Some positions may only be played by a computer player or only by a human player." ),
                 Font::BIG );
-        else
-            // class
-            if ( NULL != ( player = GetFromClassClick( le.GetMouseCursor() ) ) )
+        // class
+        else if ( NULL != ( player = GetFromClassClick( le.GetMouseCursor() ) ) )
             Dialog::Message(
                 _( "Class" ),
                 _( "This lets you change the class of a player. Classes are not always changeable. Depending on the scenario, a player may receive additional towns and/or heroes not of their primary alignment." ),
                 Font::BIG );
     }
-    else
-    // if(le.MouseClickLeft())
-    {
+    // le.MouseClickLeft()
+    else {
         // select opponent
         if ( NULL != ( player = GetFromOpponentClick( le.GetMouseCursor() ) ) ) {
             const Maps::FileInfo & fi = conf.CurrentFileInfo();
@@ -337,9 +335,8 @@ bool Interface::PlayersInfo::QueueEventProcessing( void )
                 }
             }
         }
-        else
-            // modify name
-            if ( show_name && NULL != ( player = GetFromOpponentNameClick( le.GetMouseCursor() ) ) ) {
+        // modify name
+        else if ( show_name && NULL != ( player = GetFromOpponentNameClick( le.GetMouseCursor() ) ) ) {
             std::string res;
             std::string str = _( "%{color} player" );
             StringReplace( str, "%{color}", Color::String( player->GetColor() ) );
@@ -347,9 +344,8 @@ bool Interface::PlayersInfo::QueueEventProcessing( void )
             if ( Dialog::InputString( str, res ) && !res.empty() )
                 player->SetName( res );
         }
-        else
-            // select class
-            if ( NULL != ( player = GetFromClassClick( le.GetMouseCursor() ) ) ) {
+        // select class
+        else if ( NULL != ( player = GetFromClassClick( le.GetMouseCursor() ) ) ) {
             if ( conf.AllowChangeRace( player->GetColor() ) ) {
                 switch ( player->GetRace() ) {
                 case Race::KNGT:
@@ -378,9 +374,8 @@ bool Interface::PlayersInfo::QueueEventProcessing( void )
                 }
             }
         }
-        else
-            // swap players
-            if ( show_swap && NULL != ( player = GetFromOpponentChangeClick( le.GetMouseCursor() ) ) ) {
+        // swap players
+        else if ( show_swap && NULL != ( player = GetFromOpponentChangeClick( le.GetMouseCursor() ) ) ) {
             iterator it = std::find_if( begin(), end(), [player]( const PlayerInfo & pi ) { return pi.player == player; } );
             if ( it != end() && ( it + 1 ) != end() ) {
                 Players & players = conf.GetPlayers();

--- a/src/fheroes2/gui/player_info.h
+++ b/src/fheroes2/gui/player_info.h
@@ -43,6 +43,7 @@ namespace Interface
         PlayersInfo( bool /* show name */, bool /* show race */, bool /* show swap button */ );
 
         void UpdateInfo( Players &, const Point & opponents, const Point & classes );
+        bool SwapPlayers( Player & player1, Player & player2 ) const;
 
         Player * GetFromOpponentClick( const Point & pt );
         Player * GetFromOpponentNameClick( const Point & pt );

--- a/src/fheroes2/system/players.cpp
+++ b/src/fheroes2/system/players.cpp
@@ -89,7 +89,12 @@ Player::Player( int col )
     , id( World::GetUniq() )
     , _ai( std::make_shared<AI::Normal>() )
 {
-    name = Color::String( color );
+    name = GetDefaultName();
+}
+
+std::string Player::GetDefaultName() const
+{
+    return Color::String( color );
 }
 
 const std::string & Player::GetName( void ) const

--- a/src/fheroes2/system/players.h
+++ b/src/fheroes2/system/players.h
@@ -128,9 +128,12 @@ public:
     int GetRace( void ) const;
     int GetFriends( void ) const;
     int GetID( void ) const;
+
+    std::string GetDefaultName() const;
+    const std::string & GetName( void ) const;
+
     std::string GetPersonalityString() const;
 
-    const std::string & GetName( void ) const;
     Focus & GetFocus( void );
     const Focus & GetFocus( void ) const;
 


### PR DESCRIPTION
fix #2378

Please note that this PR also implements an ability to swap player names & classes in multiplayer mode even if players aren't supposed to be humans. For example, we cannot swap GOOD and BAD players here:

<img width="418" alt="Switch failed" src="https://user-images.githubusercontent.com/32623900/112165894-36127500-8c00-11eb-80be-cffded142933.png">

But we are able to swap BAD and UGLY:

<img width="417" alt="Switch OK" src="https://user-images.githubusercontent.com/32623900/112165994-49bddb80-8c00-11eb-8c53-830d6520c014.png">

I also changed the logic of the swap buttons on the bottom of the dialog window. Previously, they used to swap absolutely everything, including color (?!). Now they work exactly the same way as using mouse. If this is an unwanted change, I can roll it back.