### PR TITLE
Show the surrender dialog even if there is not enough gold to surrender

### DIFF
--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -699,7 +699,7 @@ int Battle::Arena::DialogBattleHero( const HeroBase & hero, bool buttons ) const
     return result;
 }
 
-bool Battle::DialogBattleSurrender( const HeroBase & hero, u32 cost, const Kingdom & kingdom )
+bool Battle::DialogBattleSurrender( const HeroBase & hero, u32 cost, Kingdom & kingdom )
 {
     if ( kingdom.GetColor() == hero.GetColor() ) // this is weird. You're surrending to yourself!
         return false;
@@ -799,12 +799,17 @@ bool Battle::DialogBattleSurrender( const HeroBase & hero, u32 cost, const Kingd
             result = true;
 
         if ( btnMarket.isEnabled() && le.MouseClickLeft( btnMarket.area() ) ) {
-            Dialog::Marketplace( false );
+            Dialog::Marketplace( kingdom, false );
 
             if ( kingdom.AllowPayment( payment_t( Resource::GOLD, cost ) ) ) {
-                btnAccept.release();
                 btnAccept.enable();
             }
+            else {
+                btnAccept.disable();
+            }
+
+            btnAccept.draw();
+            display.render();
         }
 
         // exit

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4828,11 +4828,9 @@ void Battle::Interface::ProcessingHeroDialogResult( int res, Actions & a )
 
             if ( enemy ) {
                 const s32 cost = arena.GetCurrentForce().GetSurrenderCost();
-                const Kingdom & kingdom = world.GetKingdom( arena.GetCurrentColor() );
+                Kingdom & kingdom = world.GetKingdom( arena.GetCurrentColor() );
 
-                if ( !kingdom.AllowPayment( Funds( Resource::GOLD, cost ) ) )
-                    Dialog::Message( "", _( "You don't have enough gold!" ), Font::BIG, Dialog::OK );
-                else if ( DialogBattleSurrender( *enemy, cost, kingdom ) ) {
+                if ( DialogBattleSurrender( *enemy, cost, kingdom ) ) {
                     a.push_back( Command( MSG_BATTLE_SURRENDER ) );
                     a.push_back( Command( MSG_BATTLE_END_TURN, _currentUnit->GetUID() ) );
                     humanturn_exit = true;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -57,7 +57,7 @@ namespace Battle
     struct Result;
 
     void DialogBattleSettings( void );
-    bool DialogBattleSurrender( const HeroBase & hero, u32 cost, const Kingdom & kingdom );
+    bool DialogBattleSurrender( const HeroBase & hero, u32 cost, Kingdom & kingdom );
 
     enum HeroAnimation
     {

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -560,7 +560,7 @@ int Castle::OpenDialog( bool readonly )
 
                             case BUILD_MARKETPLACE: {
                                 fheroes2::ButtonRestorer exitRestorer( buttonExit );
-                                Dialog::Marketplace();
+                                Dialog::Marketplace( world.GetKingdom( GetColor() ), false );
                                 need_redraw = true;
                                 break;
                             }

--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -34,6 +34,7 @@
 #define BOXAREA_WIDTH 244
 
 class Castle;
+class Kingdom;
 class Heroes;
 class Artifact;
 class Spell;
@@ -109,8 +110,8 @@ namespace Dialog
     int ArmyJoinFree( const Troop &, Heroes & );
     int ArmyJoinWithCost( const Troop &, u32 join, u32 gold, Heroes & );
     int ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistributeMax, const bool saveLastTroop, uint32_t & redistributeCount, bool & useFastSplit );
-    void Marketplace( bool fromTradingPost = false );
-    void MakeGiftResource( void );
+    void Marketplace( Kingdom & kingdom, bool fromTradingPost );
+    void MakeGiftResource( Kingdom & kingdom );
     int BuyBoat( bool enable );
     void ThievesGuild( bool oracle );
     void GameInfo( void );

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -713,7 +713,7 @@ int Dialog::ArmyJoinWithCost( const Troop & troop, u32 join, u32 gold, Heroes & 
 
     fheroes2::ButtonSprite btnHeroes( buttonArmyPos.x, buttonArmyPos.y, armyButtonReleasedBack, armyButtonPressedBack );
 
-    const Kingdom & kingdom = hero.GetKingdom();
+    Kingdom & kingdom = hero.GetKingdom();
 
     Rect btnMarketArea = btnMarket.area();
     Rect btnHeroesArea = btnHeroes.area();
@@ -774,7 +774,7 @@ int Dialog::ArmyJoinWithCost( const Troop & troop, u32 join, u32 gold, Heroes & 
         result = btnGroup.processEvents();
 
         if ( btnMarket.isEnabled() && le.MouseClickLeft( btnMarketArea ) ) {
-            Marketplace( false );
+            Marketplace( kingdom, false );
         }
         else if ( btnHeroes.isEnabled() && le.MouseClickLeft( btnHeroesArea ) ) {
             hero.OpenDialog( false, false );

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -57,8 +57,8 @@ struct SelectRecipientsColors
     int recipients;
     std::vector<fheroes2::Rect> positions;
 
-    SelectRecipientsColors( const Point & pos )
-        : colors( Settings::Get().GetPlayers().GetColors() & ~Settings::Get().GetPlayers().current_color )
+    SelectRecipientsColors( const Point & pos, int senderColor )
+        : colors( Settings::Get().GetPlayers().GetColors() & ~senderColor )
         , recipients( 0 )
     {
         positions.reserve( colors.size() );
@@ -199,12 +199,11 @@ struct ResourceBar
     }
 };
 
-void Dialog::MakeGiftResource( void )
+void Dialog::MakeGiftResource( Kingdom & kingdom )
 {
     Cursor & cursor = Cursor::Get();
     fheroes2::Display & display = fheroes2::Display::instance();
     LocalEvent & le = LocalEvent::Get();
-    const Settings & conf = Settings::Get();
 
     cursor.Hide();
     cursor.SetThemes( cursor.POINTER );
@@ -212,16 +211,14 @@ void Dialog::MakeGiftResource( void )
     const fheroes2::StandardWindow frameborder( 320, 224 );
     const Rect box( frameborder.activeArea() );
 
-    Kingdom & myKingdom = world.GetKingdom( conf.CurrentColor() );
-
-    Funds funds1( myKingdom.GetFunds() );
+    Funds funds1( kingdom.GetFunds() );
     Funds funds2;
     Text text;
 
     text.Set( "Select Recipients" );
     text.Blit( box.x + ( box.w - text.w() ) / 2, box.y + 5 );
 
-    SelectRecipientsColors selector( Point( box.x + 65, box.y + 28 ) );
+    SelectRecipientsColors selector( Point( box.x + 65, box.y + 28 ), kingdom.GetColor() );
     selector.Redraw();
 
     text.Set( "Your Funds" );
@@ -257,7 +254,7 @@ void Dialog::MakeGiftResource( void )
                 btnGroups.button( 0 ).enable();
 
             if ( count != new_count ) {
-                funds1 = myKingdom.GetFunds();
+                funds1 = kingdom.GetFunds();
                 funds2.Reset();
                 info1.Redraw();
                 info2.Redraw();
@@ -295,7 +292,7 @@ void Dialog::MakeGiftResource( void )
         event.subsequent = 0;
         event.colors = selector.recipients;
         event.message = "Gift from %{name}";
-        const Player * player = Settings::Get().GetPlayers().GetCurrent();
+        const Player * player = Settings::Get().GetPlayers().Get( kingdom.GetColor() );
         if ( player )
             StringReplace( event.message, "%{name}", player->GetName() );
 
@@ -303,6 +300,6 @@ void Dialog::MakeGiftResource( void )
 
         if ( 1 < count )
             funds2 *= count;
-        myKingdom.OddFundsResource( funds2 );
+        kingdom.OddFundsResource( funds2 );
     }
 }

--- a/src/fheroes2/dialog/dialog_marketplace.cpp
+++ b/src/fheroes2/dialog/dialog_marketplace.cpp
@@ -306,7 +306,7 @@ void TradeWindowGUI::RedrawInfoBuySell( u32 count_sell, u32 count_buy, u32 max_s
     _scrollbar.show();
 }
 
-void Dialog::Marketplace( bool fromTradingPost )
+void Dialog::Marketplace( Kingdom & kingdom, bool fromTradingPost )
 {
     fheroes2::Display & display = fheroes2::Display::instance();
     const int tradpost = Settings::Get().ExtGameEvilInterface() ? ICN::TRADPOSE : ICN::TRADPOST;
@@ -329,8 +329,6 @@ void Dialog::Marketplace( bool fromTradingPost )
     text.Blit( dst_pt.x, dst_pt.y );
 
     TradeWindowGUI gui( pos_rt );
-
-    Kingdom & kingdom = world.GetKingdom( Settings::Get().CurrentColor() );
 
     const std::string & header_from = _( "Your Resources" );
 
@@ -421,7 +419,7 @@ void Dialog::Marketplace( bool fromTradingPost )
 
         if ( buttonGift.isEnabled() && le.MouseClickLeft( buttonGift.area() ) ) {
             cursor.Hide();
-            Dialog::MakeGiftResource();
+            Dialog::MakeGiftResource( kingdom );
             fundsFrom = kingdom.GetFunds();
             RedrawFromResource( pt1, fundsFrom );
             cursor.Show();

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1424,9 +1424,8 @@ void ActionToMagicWell( Heroes & hero, s32 dst_index )
 
 void ActionToTradingPost( const Heroes & hero )
 {
-    Dialog::Marketplace( true );
+    Dialog::Marketplace( hero.GetKingdom(), true );
 
-    (void)hero;
     DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() );
 }
 


### PR DESCRIPTION
fix #2191

Hi @ihhub I will be grateful for the idea how to remove/update "Not enough gold" message properly, without redrawing the entire dialog window :) So far I've just removed it.