### PR TITLE
Don't hide mouse cursor if the Skill Info dialog called from the Level Up dialog contains OK button

### DIFF
--- a/src/fheroes2/dialog/dialog_levelup.cpp
+++ b/src/fheroes2/dialog/dialog_levelup.cpp
@@ -209,16 +209,10 @@ int DialogSelectSecondary( const std::string & name, const std::string & primary
         }
 
         if ( le.MouseClickLeft( rect_image1 ) ) {
-            cursor.Hide();
             Dialog::SecondarySkillInfo( sec1, hero );
-            cursor.Show();
-            display.render();
         }
         else if ( le.MouseClickLeft( rect_image2 ) ) {
-            cursor.Hide();
             Dialog::SecondarySkillInfo( sec2, hero );
-            cursor.Show();
-            display.render();
         }
 
         if ( le.MousePressRight( rect_image1 ) ) {


### PR DESCRIPTION
Fix an issue (not mentioned in Issues though, or I wasn't able to find it) where the mouse cursor remains hidden if the Secondary Skill Info dialog was called from the Level Up dialog by left-clicking on the skill icon.