### PR TITLE
Fix game crash when trying to save/autosave a loaded game with vanquished human-controlled player

### DIFF
--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -261,6 +261,12 @@ void Kingdom::RemoveHeroes( const Heroes * hero )
         if ( heroes.size() )
             heroes.erase( std::find( heroes.begin(), heroes.end(), hero ) );
 
+        Player * player = Settings::Get().GetPlayers().Get( GetColor() );
+
+        if ( player && player->GetFocus().GetHeroes() == hero ) {
+            player->GetFocus().Reset();
+        }
+
         AI::Get().HeroesRemove( *hero );
     }
 
@@ -289,6 +295,12 @@ void Kingdom::RemoveCastle( const Castle * castle )
     if ( castle ) {
         if ( castles.size() )
             castles.erase( std::find( castles.begin(), castles.end(), castle ) );
+
+        Player * player = Settings::Get().GetPlayers().Get( GetColor() );
+
+        if ( player && player->GetFocus().GetCastle() == castle ) {
+            player->GetFocus().Reset();
+        }
 
         AI::Get().CastleRemove( *castle );
     }


### PR DESCRIPTION
Steps to reproduce the issue:

1. Load the game from attached save file;
2. Skip the moves until the blue player will be attacked by AI. Surrender the castle and let the player lose;
3. Save the game;
4. Load the game from the save file you just made;
5. Try to save a game or just skip the move (with autosave enabled);
6. Game crashed.

The reason for the crash is that vanquished player's focus never reset, despite the fact that it doesn't have heroes or castles anymore, so the focus info is saved and loaded incorrectly. Perhaps it's better to fix it in some other way, but I propose to do it this way.

[Slugfest_Before_Attack.zip](https://github.com/ihhub/fheroes2/files/6212358/Slugfest_Before_Attack.zip)