### PR TITLE
Unneeded redraw

### DIFF
--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -581,12 +581,14 @@ void Heroes::Redraw( fheroes2::Image & dst, int32_t dx, int32_t dy, const Rect &
 
     if ( 45 > GetSpriteIndex() ) {
         if ( Direction::BOTTOM != direction && Direction::TOP != direction && Maps::isValidDirection( centerIndex, direction ) ) {
-            if ( Maps::isValidDirection( Maps::GetDirectionIndex( centerIndex, direction ), Direction::BOTTOM ) ) {
+            if ( Direction::BOTTOM_LEFT != direction && Direction::BOTTOM_RIGHT != direction
+                 && Maps::isValidDirection( Maps::GetDirectionIndex( centerIndex, direction ), Direction::BOTTOM ) ) {
                 const Maps::Tiles & tile_dir_bottom = world.GetTiles( Maps::GetDirectionIndex( Maps::GetDirectionIndex( centerIndex, direction ), Direction::BOTTOM ) );
                 tile_dir_bottom.RedrawBottom4Hero( dst, visibleTileROI, gamearea );
                 tile_dir_bottom.RedrawTop( dst, visibleTileROI, gamearea );
             }
-            if ( Maps::isValidDirection( Maps::GetDirectionIndex( centerIndex, direction ), Direction::TOP ) ) {
+            if ( Direction::TOP_LEFT != direction && Direction::TOP_RIGHT != direction
+                 && Maps::isValidDirection( Maps::GetDirectionIndex( centerIndex, direction ), Direction::TOP ) ) {
                 const Maps::Tiles & tile_dir_top = world.GetTiles( Maps::GetDirectionIndex( Maps::GetDirectionIndex( centerIndex, direction ), Direction::TOP ) );
                 tile_dir_top.RedrawTop4Hero( dst, visibleTileROI, skipGround, gamearea );
             }

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -602,12 +602,8 @@ void Heroes::Redraw( fheroes2::Image & dst, int32_t dx, int32_t dy, const Rect &
         }
     }
 
-    if ( Maps::isValidDirection( centerIndex, direction ) ) {
-        if ( Direction::TOP == direction )
-            world.GetTiles( Maps::GetDirectionIndex( centerIndex, direction ) ).RedrawTop4Hero( dst, visibleTileROI, skipGround, gamearea );
-        else
-            world.GetTiles( Maps::GetDirectionIndex( centerIndex, direction ) ).RedrawTop( dst, visibleTileROI, gamearea );
-    }
+    if ( Direction::BOTTOM != direction && Direction::TOP != direction && Maps::isValidDirection( centerIndex, direction ) )
+        world.GetTiles( Maps::GetDirectionIndex( centerIndex, direction ) ).RedrawTop( dst, visibleTileROI, gamearea );
 }
 
 void Heroes::MoveStep( Heroes & hero, s32 indexTo, bool newpos )


### PR DESCRIPTION
Prevent redrawing tile which far away from hero
before
![3](https://user-images.githubusercontent.com/24250224/112693707-24480080-8e92-11eb-9d50-23084d6919e3.jpg)
after
![4](https://user-images.githubusercontent.com/24250224/112693720-28741e00-8e92-11eb-9f75-924dfbf8e7e5.jpg)
