### PR TITLE
Reformat installation instruction and add Gentoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,7 @@ RPM based distributions like Fedora/Red Hat use the commands `sudo yum install S
 openSUSE supports the One-Click-Install via `SDL_mixer.ymp` file in `script/linux`. 
 
 ### Gentoo
-If you have Gentoo, in addition to basic distribution you need to run following commands
-```
-emerge --ask media-libs/sdl2-mixer media-libs/sdl2-ttf
-```
+If you have Gentoo, in addition to basic distribution you need to run following command `emerge --ask media-libs/sdl2-mixer media-libs/sdl2-ttf`.
 
 Compilation
 ---------------------------

--- a/README.md
+++ b/README.md
@@ -25,8 +25,30 @@ You are required to have at least a demo version of Heroes of Might and Magic 2 
 
 MacOS and Linux
 --------------------------
-Unix OSes need an explicit installation of SDL packages. Please go to `script/macos` or `script/linux` directory depending on your OS package and run **install_sdl_1.sh** or **install_sdl_2.sh** file. For Arch based Linux distributions use the command `sudo pacman -S sdl sdl_mixer` instead. RPM based distributions like Fedora/Red Hat use the commands `sudo yum/dnf install SDL*`. openSUSE supports the One-Click-Install via `SDL_mixer.ymp` file in `script/linux`. For MacOS we highly recommend to use SDL 2 as latest versions of MacOS do not fully support SDL 1.
+## Mac OS
+Please go to `script/macos` and run **install_sdl_1.sh** or **install_sdl_2.sh** file. For MacOS we highly recommend to use SDL 2 as latest versions of MacOS do not fully support SDL 1.
 
+## Debian-based
+Please go to `script/linux` directory and run **install_sdl_1.sh** or **install_sdl_2.sh** file.
+
+## Arch
+
+For Arch based Linux distributions use the command `sudo pacman -S sdl sdl_mixer`.
+
+## RedHat-based
+
+RPM based distributions like Fedora/Red Hat use the commands `sudo yum install SDL*` or `sudo dnf install SDL*`.
+
+## OpenSUSE
+openSUSE supports the One-Click-Install via `SDL_mixer.ymp` file in `script/linux`. 
+
+## Gentoo
+
+If you have Gentoo, in addition to basic distribution you need to run following commands
+```
+emerge --ask sdl-mixer
+emerge --ask sdl-ttf
+```
 
 Compilation
 ---------------------------

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ openSUSE supports the One-Click-Install via `SDL_mixer.ymp` file in `script/linu
 ## Gentoo
 If you have Gentoo, in addition to basic distribution you need to run following commands
 ```
-emerge --ask media-libs/sdl-mixer media-libs/sdl-ttf
+emerge --ask media-libs/sdl2-mixer media-libs/sdl2-ttf
 ```
 
 Compilation

--- a/README.md
+++ b/README.md
@@ -32,22 +32,18 @@ Please go to `script/macos` and run **install_sdl_1.sh** or **install_sdl_2.sh**
 Please go to `script/linux` directory and run **install_sdl_1.sh** or **install_sdl_2.sh** file.
 
 ## Arch
-
 For Arch based Linux distributions use the command `sudo pacman -S sdl sdl_mixer`.
 
 ## RedHat-based
-
 RPM based distributions like Fedora/Red Hat use the commands `sudo yum install SDL*` or `sudo dnf install SDL*`.
 
 ## OpenSUSE
 openSUSE supports the One-Click-Install via `SDL_mixer.ymp` file in `script/linux`. 
 
 ## Gentoo
-
 If you have Gentoo, in addition to basic distribution you need to run following commands
 ```
-emerge --ask sdl-mixer
-emerge --ask sdl-ttf
+emerge --ask media-libs/sdl-mixer media-libs/sdl-ttf
 ```
 
 Compilation

--- a/README.md
+++ b/README.md
@@ -23,24 +23,22 @@ Requirements
 ---------------------------
 You are required to have at least a demo version of Heroes of Might and Magic 2 game to be able to play it. Please use one of our scripts to download the demo version of the original game. A script comes with the compiled game.
 
-MacOS and Linux
---------------------------
-## Mac OS
+### Mac OS
 Please go to `script/macos` and run **install_sdl_1.sh** or **install_sdl_2.sh** file. For MacOS we highly recommend to use SDL 2 as latest versions of MacOS do not fully support SDL 1.
 
-## Debian-based
+### Debian-based
 Please go to `script/linux` directory and run **install_sdl_1.sh** or **install_sdl_2.sh** file.
 
-## Arch
+### Arch
 For Arch based Linux distributions use the command `sudo pacman -S sdl sdl_mixer`.
 
-## RedHat-based
+### RedHat-based
 RPM based distributions like Fedora/Red Hat use the commands `sudo yum install SDL*` or `sudo dnf install SDL*`.
 
-## OpenSUSE
+### OpenSUSE
 openSUSE supports the One-Click-Install via `SDL_mixer.ymp` file in `script/linux`. 
 
-## Gentoo
+### Gentoo
 If you have Gentoo, in addition to basic distribution you need to run following commands
 ```
 emerge --ask media-libs/sdl2-mixer media-libs/sdl2-ttf


### PR DESCRIPTION
I extract each platform as separate section, so that block would be easier to read.
Also add instructions how to compile application on Gentoo.