### PR TITLE
Fix blind spell

### DIFF
--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -241,8 +241,7 @@ void Battle::Arena::ApplyActionAttack( Command & cmd )
         const bool handfighting = Unit::isHandFighting( *b1, *b2 );
         // check position
         if ( b1->isArchers() || handfighting ) {
-            if ( b2->Modes( SP_BLIND ) )
-                b2->SetBlindAnswer( true );
+            b2->SetBlindAnswer( b2->Modes( SP_BLIND ) );
 
             // attack
             BattleProcess( *b1, *b2, dst, dir );

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -959,7 +959,7 @@ StreamBase & Battle::operator>>( StreamBase & msg, Unit & b )
 
 bool Battle::Unit::AllowResponse( void ) const
 {
-    return !Modes( IS_PARALYZE_MAGIC ) && !Modes( SP_HYPNOTIZE ) && ( isAlwaysRetaliating() || !Modes( TR_RESPONSED ) );
+    return ( !Modes( SP_BLIND ) || blindanswer ) && !Modes( IS_PARALYZE_MAGIC ) && !Modes( SP_HYPNOTIZE ) && ( isAlwaysRetaliating() || !Modes( TR_RESPONSED ) );
 }
 
 void Battle::Unit::SetResponse( void )


### PR DESCRIPTION
fix #3032

Additionally fix potentially reduced retaliation damage if unit was killed while blinded and then resurrected.