### PR TITLE
Archers shouldn't lose shots when attacking in melee

### DIFF
--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -970,7 +970,7 @@ void Battle::Unit::SetResponse( void )
 void Battle::Unit::PostAttackAction()
 {
     // decrease shots
-    if ( isArchers() ) {
+    if ( isArchers() && !isHandFighting() ) {
         // check ammo cart artifact
         const HeroBase * hero = GetCommander();
         if ( !hero || !hero->HasArtifact( Artifact::AMMO_CART ) )


### PR DESCRIPTION
Self-explanatory fix. Melee attacks include retaliation. Found the bug while testing.