### PR TITLE
Respect initial order of units (from top to bottom) when determining the order of unit moves in battle

### DIFF
--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -147,14 +147,14 @@ void Battle::Units::SortSlowest( bool f )
 {
     SlowestUnits CompareFunc( f );
 
-    std::sort( begin(), end(), CompareFunc );
+    std::stable_sort( begin(), end(), CompareFunc );
 }
 
 void Battle::Units::SortFastest( bool f )
 {
     FastestUnits CompareFunc( f );
 
-    std::sort( begin(), end(), CompareFunc );
+    std::stable_sort( begin(), end(), CompareFunc );
 }
 
 void Battle::Units::SortStrongest( void )

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -307,6 +307,9 @@ void Battle::Force::UpdateOrderUnits( const Force & army1, const Force & army2, 
             units2.SortFastest( true );
         }
         else {
+            std::reverse( units1.begin(), units1.end() );
+            std::reverse( units2.begin(), units2.end() );
+
             units1.SortSlowest( true );
             units2.SortSlowest( true );
         }
@@ -326,6 +329,9 @@ Battle::Unit * Battle::Force::GetCurrentUnit( const Force & army1, const Force &
         units2.SortFastest( false );
     }
     else {
+        std::reverse( units1.begin(), units1.end() );
+        std::reverse( units2.begin(), units2.end() );
+
         units1.SortSlowest( false );
         units2.SortSlowest( false );
     }

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -73,7 +73,6 @@ namespace Battle
         void NewTurn( void );
         void SyncArmyCount( bool checkResurrected );
 
-        static Unit * GetCurrentUnit( const Force &, const Force &, Unit * last, Units * all, bool part1 );
         static Unit * GetCurrentUnit( const Force &, const Force &, const Unit * last, bool part1 );
         static void UpdateOrderUnits( const Force &, const Force &, Units & );
 


### PR DESCRIPTION
fix #1609

Also rework a little "soft wait" battle mode to make it more HoMM3-like: units move in the exact reverse order after waiting (if possible, summoned creatures can somewhat break this on the turn on which they was summoned).