### PR TITLE
AI: estimate hero spell strength

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -105,6 +105,7 @@ namespace AI
         double _myShooterStr = 0;
         double _enemyShooterStr = 0;
         double _enemyAverageSpeed = 0;
+        double _enemySpellStrength = 0;
         int _highestDamageExpected = 0;
         bool _attackingCastle = false;
         bool _defendingCastle = false;

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -215,6 +215,7 @@ namespace AI
         _myShooterStr = 0;
         _enemyShooterStr = 0;
         _enemyAverageSpeed = 0;
+        _enemySpellStrength = 0;
         _highestDamageExpected = 0;
         _considerRetreat = false;
 

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -78,19 +78,6 @@ namespace AI
         return outcome;
     }
 
-    double CalculateSpellcastStrength( const HeroBase * commander )
-    {
-        if ( !commander || commander->GetSpells().empty() )
-            return 0.0;
-
-        static const double AVERAGE_SPELL_DAMAGE = 20.0;
-        static const uint32_t AVERAGE_SPELL_COST = 6;
-
-        // Use integer division here to force strength to be 0 if not enough SP to cast one spell; limit to 10
-        const uint32_t castCount = std::min( commander->GetSpellPoints() / AVERAGE_SPELL_COST, 10u );
-        return commander->GetPower() * AVERAGE_SPELL_DAMAGE * castCount;
-    }
-
     void Normal::HeroesPreBattle( HeroBase & hero, bool isAttacking )
     {
         if ( isAttacking ) {
@@ -318,9 +305,14 @@ namespace AI
         }
 
         // Calculate each hero spell strength and add it to shooter values after castle modifiers were applied
-        _myShooterStr += CalculateSpellcastStrength( _commander );
-        _enemySpellStrength = CalculateSpellcastStrength( arena.GetCommander( _myColor, true ) );
-        _enemyShooterStr += _enemySpellStrength;
+        if ( _commander && _myShooterStr > 1 ) {
+            _myShooterStr += _commander->GetSpellcastStrength();
+        }
+        const HeroBase * enemyCommander = arena.GetCommander( _myColor, true );
+        if ( enemyCommander ) {
+            _enemySpellStrength = enemyCommander->GetSpellcastStrength();
+            _enemyShooterStr += _enemySpellStrength;
+        }
 
         // When we have in 10 times stronger army than the enemy we could consider it as an overpowered and we most likely will win.
         const bool myOverpoweredArmy = _myArmyStrength > _enemyArmyStrength * 10;

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -87,7 +87,7 @@ namespace AI
         static const uint32_t AVERAGE_SPELL_COST = 6;
 
         // Use integer division here to force strength to be 0 if not enough SP to cast one spell; limit to 10
-        const uint32_t castCount = std::max( commander->GetSpellPoints() / AVERAGE_SPELL_COST, 10u );
+        const uint32_t castCount = std::min( commander->GetSpellPoints() / AVERAGE_SPELL_COST, 10u );
         return commander->GetPower() * AVERAGE_SPELL_DAMAGE * castCount;
     }
 

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -78,6 +78,19 @@ namespace AI
         return outcome;
     }
 
+    double CalculateSpellcastStrength( const HeroBase * commander )
+    {
+        if ( !commander || commander->GetSpells().empty() )
+            return 0.0;
+
+        static const double AVERAGE_SPELL_DAMAGE = 20.0;
+        static const uint32_t AVERAGE_SPELL_COST = 6;
+
+        // Use integer division here to force strength to be 0 if not enough SP to cast one spell; limit to 10
+        const uint32_t castCount = std::max( commander->GetSpellPoints() / AVERAGE_SPELL_COST, 10u );
+        return commander->GetPower() * AVERAGE_SPELL_DAMAGE * castCount;
+    }
+
     void Normal::HeroesPreBattle( HeroBase & hero, bool isAttacking )
     {
         if ( isAttacking ) {
@@ -303,6 +316,11 @@ namespace AI
                     _myShooterStr /= 2;
             }
         }
+
+        // Calculate each hero spell strength and add it to shooter values after castle modifiers were applied
+        _myShooterStr += CalculateSpellcastStrength( _commander );
+        _enemySpellStrength = CalculateSpellcastStrength( arena.GetCommander( _myColor, true ) );
+        _enemyShooterStr += _enemySpellStrength;
 
         // When we have in 10 times stronger army than the enemy we could consider it as an overpowered and we most likely will win.
         const bool myOverpoweredArmy = _myArmyStrength > _enemyArmyStrength * 10;

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -305,6 +305,7 @@ namespace AI
             }
         }
 
+        // TODO: replace this hacky code for archers
         // Calculate each hero spell strength and add it to shooter values after castle modifiers were applied
         if ( _commander && _myShooterStr > 1 ) {
             _myShooterStr += _commander->GetSpellcastStrength();

--- a/src/fheroes2/ai/normal/ai_normal_spell.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_spell.cpp
@@ -93,7 +93,10 @@ namespace AI
                 checkSelectBestSpell( spell, spellEffectValue( spell, enemies ) );
             }
         }
-        DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "Best spell " << Spell( bestSpell.spellID ).GetName() << ", value is " << bestHeuristic );
+
+        if ( bestSpell.spellID != -1 ) {
+            DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "Best spell " << Spell( bestSpell.spellID ).GetName() << ", value is " << bestHeuristic );
+        }
 
         return bestSpell;
     }
@@ -386,7 +389,7 @@ namespace AI
         const Force & friendlyForce = arena.GetForce( _myColor );
 
         for ( const Unit * unit : friendlyForce ) {
-            if ( !unit || !unit->AllowApplySpell( spell, _commander ) )
+            if ( !unit || !unit->AllowApplySpell( spell, _commander ) || arena.GetBoard()->GetCell( unit->GetHeadIndex() )->GetUnit() )
                 continue;
 
             uint32_t missingHP = unit->GetMissingHitPoints();

--- a/src/fheroes2/ai/normal/ai_normal_spell.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_spell.cpp
@@ -379,9 +379,8 @@ namespace AI
     SpellcastOutcome BattlePlanner::spellResurrectValue( const Spell & spell, Battle::Arena & arena ) const
     {
         SpellcastOutcome bestOutcome;
-        uint32_t hpRestored = spell.Resurrect() * _commander->GetPower();
-        if ( _commander->HasArtifact( Artifact::ANKH ) )
-            hpRestored *= 2;
+        const uint32_t ankhModifier = _commander->HasArtifact( Artifact::ANKH ) ? 2 : 1;
+        const uint32_t hpRestored = spell.Resurrect() * _commander->GetPower() * ankhModifier;
 
         // Get friendly units list including the invalid and dead ones
         const Force & friendlyForce = arena.GetForce( _myColor );
@@ -390,10 +389,10 @@ namespace AI
             if ( !unit || !unit->AllowApplySpell( spell, _commander ) )
                 continue;
 
-            const uint32_t missingHP = unit->GetMissingHitPoints();
-            hpRestored = ( missingHP < hpRestored ) ? missingHP : hpRestored;
+            uint32_t missingHP = unit->GetMissingHitPoints();
+            missingHP = ( missingHP < hpRestored ) ? missingHP : hpRestored;
 
-            double spellValue = hpRestored * unit->GetMonsterStrength() / unit->Monster::GetHitPoints();
+            double spellValue = missingHP * unit->GetMonsterStrength() / unit->Monster::GetHitPoints();
 
             // if we are winning battle; permanent resurrect bonus
             if ( _myArmyStrength > _enemyArmyStrength && spell.GetID() != Spell::RESURRECT ) {

--- a/src/fheroes2/ai/normal/ai_normal_spell.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_spell.cpp
@@ -29,10 +29,13 @@
 
 using namespace Battle;
 
+namespace
+{
+    const double antimagicLowLimit = 200.0;
+}
+
 namespace AI
 {
-    const double ANTIMAGIC_LOW_LIMIT = 200.0;
-
     double ReduceEffectivenessByDistance( const Unit & unit )
     {
         // Reduce spell effectiveness if unit already crossed the battlefield
@@ -280,7 +283,7 @@ namespace AI
         else if ( target.Modes( SP_CURSE ) && ( spellID == Spell::BLESS || spellID == Spell::MASSBLESS ) ) {
             ratio *= 2;
         }
-        else if ( spellID == Spell::ANTIMAGIC && !target.Modes( IS_GOOD_MAGIC ) && _enemySpellStrength > ANTIMAGIC_LOW_LIMIT ) {
+        else if ( spellID == Spell::ANTIMAGIC && !target.Modes( IS_GOOD_MAGIC ) && _enemySpellStrength > antimagicLowLimit ) {
             double ratioLimit = 0.9;
 
             const std::vector<Spell> & spellList = _commander->GetSpells();
@@ -291,8 +294,9 @@ namespace AI
                     break;
                 }
             }
-            // 0...3000 spell strength (20 power * 200 SP) scales from 0.0 to 0.9 ratio
-            ratio = std::min( _enemySpellStrength / ANTIMAGIC_LOW_LIMIT * 0.06, ratioLimit );
+            // With 20 spell power and 200 spell points _enemySpellStrength will be 3000.0 (anything over is ignored here)
+            // Then convert 0...3000 range into 0.0 to 0.9 ratio and clamp it
+            ratio = std::min( _enemySpellStrength / antimagicLowLimit * 0.06, ratioLimit );
 
             if ( target.Modes( IS_BAD_MAGIC ) ) {
                 ratio *= 2;

--- a/src/fheroes2/ai/normal/ai_normal_spell.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_spell.cpp
@@ -291,7 +291,7 @@ namespace AI
                     break;
                 }
             }
-            // 0...3000 spell strength (15 power * max knowledge) scales from 0.0 to 0.9 ratio
+            // 0...3000 spell strength (20 power * 200 SP) scales from 0.0 to 0.9 ratio
             ratio = std::min( _enemySpellStrength / ANTIMAGIC_LOW_LIMIT * 0.06, ratioLimit );
 
             if ( target.Modes( IS_BAD_MAGIC ) ) {

--- a/src/fheroes2/ai/normal/ai_normal_spell.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_spell.cpp
@@ -112,8 +112,15 @@ namespace AI
             // If we're retreating we don't care about partial damage, only actual units killed
             if ( retreating )
                 return unit->GetMonsterStrength() * unit->HowManyWillKilled( damage );
+
             // Otherwise calculate amount of strength lost (% of unit times total strength)
-            return std::min( static_cast<double>( damage ) / unit->GetHitPoints(), 1.0 ) * unit->GetStrength();
+            double unitPercentageLost = std::min( static_cast<double>( damage ) / unit->GetHitPoints(), 1.0 );
+
+            // Penalty for waking up disabled unit (if you kill only 30%, rest 70% is your penalty)
+            if ( unit->Modes( SP_BLIND | SP_PARALYZE | SP_STONE ) ) {
+                unitPercentageLost += unitPercentageLost - 1.0;
+            }
+            return unitPercentageLost * unit->GetStrength();
         };
 
         if ( spell.isSingleTarget() ) {

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1244,7 +1244,7 @@ u32 Army::GetDefense( void ) const
 
 double Army::GetStrength( void ) const
 {
-    double res = 0;
+    double result = ( commander ) ? commander->GetSpellcastStrength() : 0;
     const uint32_t archery = ( commander ) ? commander->GetSecondaryValues( Skill::Secondary::ARCHERY ) : 0;
     // Hero bonus calculation is slow, cache it
     const int bonusAttack = ( commander ? commander->GetAttack() : 0 );
@@ -1267,14 +1267,11 @@ double Army::GetStrength( void ) const
 
             strength *= 1 + armyLuck / 24.0;
 
-            res += strength;
+            result += strength;
         }
     }
 
-    // hero spell STR
-    // composition
-
-    return res;
+    return result;
 }
 
 double Army::getReinforcementValue( const Troops & reinforcement ) const

--- a/src/fheroes2/heroes/heroes_base.cpp
+++ b/src/fheroes2/heroes/heroes_base.cpp
@@ -382,9 +382,8 @@ double HeroBase::GetSpellcastStrength() const
     if ( GetSpells().empty() )
         return 0.0;
 
-    static const double AVERAGE_SPELL_DAMAGE = 15.0;
-
-    return GetPower() * sqrt( GetSpellPoints() / 2 ) * AVERAGE_SPELL_DAMAGE;
+    // Benchmark for strength is 20 power * 20 knowledge (200 spell points) is 3000.0
+    return GetPower() * sqrt( GetSpellPoints() / 2 ) * 15.0;
 }
 
 bool HeroBase::CanCastSpell( const Spell & spell, std::string * res ) const

--- a/src/fheroes2/heroes/heroes_base.cpp
+++ b/src/fheroes2/heroes/heroes_base.cpp
@@ -377,6 +377,16 @@ int HeroBase::GetLuckModificator( std::string * strs ) const
     return result;
 }
 
+double HeroBase::GetSpellcastStrength() const
+{
+    if ( GetSpells().empty() )
+        return 0.0;
+
+    static const double AVERAGE_SPELL_DAMAGE = 15.0;
+
+    return GetPower() * sqrt( GetSpellPoints() / 2 ) * AVERAGE_SPELL_DAMAGE;
+}
+
 bool HeroBase::CanCastSpell( const Spell & spell, std::string * res ) const
 {
     const Kingdom & kingdom = world.GetKingdom( GetColor() );

--- a/src/fheroes2/heroes/heroes_base.h
+++ b/src/fheroes2/heroes/heroes_base.h
@@ -99,6 +99,7 @@ public:
     int GetKnowledgeModificator( std::string * = NULL ) const;
     int GetMoraleModificator( std::string * = NULL ) const;
     int GetLuckModificator( std::string * = NULL ) const;
+    double GetSpellcastStrength() const;
 
     u32 GetSpellPoints( void ) const;
     bool HaveSpellPoints( const Spell & ) const;


### PR DESCRIPTION
Follow-up on recent spell changes.

Added a method to estimate hero spell casting strength. Using new value to better asses who to attack on strategic map plus in-battle heuristics. AI should avoid using Antimagic altogether if there's no hero or spell threat.

Also including a few behavior fixes to prevent sub-optimal spell casting. Avoid using mind influence and damage spells on blind targets as well as resurrect on tiles blocked by another unit. Summon spell value should account for hero's attack and defense bonus.