### PR TITLE
Force units into empty slots first during merge

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -317,7 +317,7 @@ bool Troops::JoinTroop( const Monster & mons, uint32_t count, bool emptySlotFirs
 
         iterator it = emptySlotFirst ? std::find_if( begin(), end(), findEmptySlot ) : std::find_if( begin(), end(), findMonster );
         if ( it == end() ) {
-            iterator it = emptySlotFirst ? std::find_if( begin(), end(), findMonster ) : std::find_if( begin(), end(), findEmptySlot );
+            it = emptySlotFirst ? std::find_if( begin(), end(), findMonster ) : std::find_if( begin(), end(), findEmptySlot );
         }
 
         if ( it != end() ) {

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -309,12 +309,16 @@ bool Troops::CanJoinTroop( const Monster & mons ) const
     return it != end();
 }
 
-bool Troops::JoinTroop( const Monster & mons, u32 count )
+bool Troops::JoinTroop( const Monster & mons, uint32_t count, bool emptySlotFirst )
 {
     if ( mons.isValid() && count ) {
-        iterator it = std::find_if( begin(), end(), [&mons]( const Troop * troop ) { return troop->isMonster( mons.GetID() ); } );
-        if ( it == end() )
-            it = std::find_if( begin(), end(), []( const Troop * troop ) { return !troop->isValid(); } );
+        auto findEmptySlot = []( const Troop * troop ) { return !troop->isValid(); };
+        auto findMonster = [&mons]( const Troop * troop ) { return troop->isMonster( mons.GetID() ); };
+
+        iterator it = emptySlotFirst ? std::find_if( begin(), end(), findEmptySlot ) : std::find_if( begin(), end(), findMonster );
+        if ( it == end() ) {
+            iterator it = emptySlotFirst ? std::find_if( begin(), end(), findMonster ) : std::find_if( begin(), end(), findEmptySlot );
+        }
 
         if ( it != end() ) {
             if ( ( *it )->isValid() )
@@ -636,7 +640,7 @@ void Troops::JoinStrongest( Troops & troops2, bool saveLast )
     // there's still unmerged units left and there's empty room for them
     for ( size_t slot = 0; slot < troops2.size(); ++slot ) {
         Troop * rightTroop = troops2[slot];
-        if ( rightTroop && rightTroop->isValid() && JoinTroop( *rightTroop ) ) {
+        if ( rightTroop && JoinTroop( rightTroop->GetMonster(), rightTroop->GetCount(), true ) ) {
             rightTroop->Reset();
         }
     }

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -74,7 +74,7 @@ public:
     u32 GetUniqueCount( void ) const;
 
     bool JoinTroop( const Troop & );
-    bool JoinTroop( const Monster &, u32 );
+    bool JoinTroop( const Monster & mons, uint32_t count, bool emptySlotFirst = false );
     bool CanJoinTroop( const Monster & ) const;
 
     void JoinTroops( Troops & );


### PR DESCRIPTION
Fixes #2418 .

`JoinTroop` method merged matching troops first; now we can pick the condition.