### PR TITLE
AI: fast units should try to get the first strike

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -99,10 +99,8 @@ namespace AI
                     }
                     else if ( dist <= range + 1 ) {
                         cellThreatLevel += enemy->GetScoreQuality( currentUnit );
-                        std::cout << moveIndex << " and " << enemy->GetHeadIndex() << " dist: " << Board::GetDistance( moveIndex, enemy->GetHeadIndex() );
                     }
                 }
-                std::cout << "Cell " << moveIndex << " threat: " << cellThreatLevel << std::endl;
 
                 if ( cellThreatLevel < lowestThreat ) {
                     lowestThreat = cellThreatLevel;
@@ -470,19 +468,10 @@ namespace AI
                 const double unitPriority = enemy->GetScoreQuality( currentUnit ) - distance * attackDistanceModifier;
                 if ( unitPriority > maxMovePriority ) {
                     maxMovePriority = unitPriority;
+                    target.cell = FindLowestThreatMove( arena.CalculateTwoTurnPath( move.first, currentUnitMoveRange ), currentUnit, enemies, true );
 
-                    if ( move.second < currentUnitMoveRange * 2 ) {
-                        auto path = arena.CalculateTwoTurnPath( move.first, currentUnitMoveRange );
-                        target.cell = FindLowestThreatMove( path, currentUnit, enemies, true );
-
+                    if ( target.cell != move.first ) {
                         DEBUG_LOG( DBG_BATTLE, DBG_INFO, "Going after target " << enemy->GetName() << " stopping at " << target.cell );
-                        for ( auto idx : path ) {
-                            std::cout << idx << " ";
-                        }
-                        std::cout << std::endl;
-                    }
-                    else {
-                        target.cell = move.first;
                     }
                 }
             }

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -468,10 +468,14 @@ namespace AI
                 const double unitPriority = enemy->GetScoreQuality( currentUnit ) - distance * attackDistanceModifier;
                 if ( unitPriority > maxMovePriority ) {
                     maxMovePriority = unitPriority;
-                    target.cell = FindLowestThreatMove( arena.CalculateTwoTurnPath( move.first, currentUnitMoveRange ), currentUnit, enemies, true );
 
-                    if ( target.cell != move.first ) {
-                        DEBUG_LOG( DBG_BATTLE, DBG_INFO, "Going after target " << enemy->GetName() << " stopping at " << target.cell );
+                    const Indexes & path = arena.CalculateTwoTurnPath( move.first, currentUnitMoveRange );
+                    if ( !path.empty() ) {
+                        target.cell = FindLowestThreatMove( path, currentUnit, enemies, true );
+                        DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "Going after target " << enemy->GetName() << " stopping at " << target.cell );
+                    }
+                    else {
+                        target.cell = move.first;
                     }
                 }
             }

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -579,9 +579,9 @@ Battle::Indexes Battle::Arena::GetPath( const Unit & b, const Position & dst )
 }
 
 
-Battle::Indexes Battle::Arena::getCurrentUnitPath( int32_t indexTo, uint32_t slicingRange ) const
+Battle::Indexes Battle::Arena::CalculateTwoTurnPath( int32_t indexTo, uint32_t movementRange ) const
 {
-    return _pathfinder.buildPath( indexTo, slicingRange );
+    return _pathfinder.buildNextTurnPath( indexTo, movementRange );
 }
 
 std::pair<int, uint32_t> Battle::Arena::CalculateMoveToUnit( const Unit & target )

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -578,15 +578,14 @@ Battle::Indexes Battle::Arena::GetPath( const Unit & b, const Position & dst )
     return result;
 }
 
-
-Battle::Indexes Battle::Arena::CalculateTwoTurnPath( int32_t indexTo, uint32_t movementRange ) const
+Battle::Indexes Battle::Arena::CalculateTwoMoveOverlap( int32_t indexTo, uint32_t movementRange ) const
 {
-    return _pathfinder.buildNextTurnPath( indexTo, movementRange );
+    return _pathfinder.findTwoMovesOverlap( indexTo, movementRange );
 }
 
 std::pair<int, uint32_t> Battle::Arena::CalculateMoveToUnit( const Unit & target )
 {
-    std::pair<int, uint32_t> result = {-1, MAXU16};
+    std::pair<int, uint32_t> result = { -1, MAXU16 };
 
     const Position & pos = target.GetPosition();
     const Cell * head = pos.GetHead();

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -578,6 +578,12 @@ Battle::Indexes Battle::Arena::GetPath( const Unit & b, const Position & dst )
     return result;
 }
 
+
+Battle::Indexes Battle::Arena::getCurrentUnitPath( int32_t indexTo, uint32_t slicingRange ) const
+{
+    return _pathfinder.buildPath( indexTo, slicingRange );
+}
+
 std::pair<int, uint32_t> Battle::Arena::CalculateMoveToUnit( const Unit & target )
 {
     std::pair<int, uint32_t> result = {-1, MAXU16};

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -109,7 +109,7 @@ namespace Battle
         bool hexIsAccessible( int32_t indexTo ) const;
         bool hexIsPassable( int32_t indexTo ) const;
         Indexes getAllAvailableMoves( uint32_t moveRange ) const;
-        Indexes getCurrentUnitPath( int32_t indexTo, uint32_t slicingRange = 0 ) const;
+        Indexes CalculateTwoTurnPath( int32_t indexTo, uint32_t movementRange = 0 ) const;
         Indexes GetPath( const Unit &, const Position & );
 
         void ApplyAction( Command & );

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -109,6 +109,7 @@ namespace Battle
         bool hexIsAccessible( int32_t indexTo ) const;
         bool hexIsPassable( int32_t indexTo ) const;
         Indexes getAllAvailableMoves( uint32_t moveRange ) const;
+        Indexes getCurrentUnitPath( int32_t indexTo, uint32_t slicingRange = 0 ) const;
         Indexes GetPath( const Unit &, const Position & );
 
         void ApplyAction( Command & );

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -109,7 +109,7 @@ namespace Battle
         bool hexIsAccessible( int32_t indexTo ) const;
         bool hexIsPassable( int32_t indexTo ) const;
         Indexes getAllAvailableMoves( uint32_t moveRange ) const;
-        Indexes CalculateTwoTurnPath( int32_t indexTo, uint32_t movementRange = 0 ) const;
+        Indexes CalculateTwoMoveOverlap( int32_t indexTo, uint32_t movementRange = 0 ) const;
         Indexes GetPath( const Unit &, const Position & );
 
         void ApplyAction( Command & );

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -103,10 +103,8 @@ namespace Battle
             return path;
 
         const uint32_t pathCost = _cache[targetCell]._cost;
-        if ( pathCost >= movementRange * 2 ) {
-            path.push_back( targetCell );
+        if ( pathCost >= movementRange * 2 )
             return path;
-        }
 
         int currentNode = targetCell;
         uint32_t nodeCost = pathCost;

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -103,6 +103,11 @@ namespace Battle
             return path;
 
         const uint32_t pathCost = _cache[targetCell]._cost;
+        if ( pathCost >= movementRange * 2 ) {
+            path.push_back( targetCell );
+            return path;
+        }
+
         int currentNode = targetCell;
         uint32_t nodeCost = pathCost;
 
@@ -119,7 +124,6 @@ namespace Battle
             if ( movementRange > 0 && !path.empty() && pathCost - nodeCost >= movementRange )
                 break;
         }
-        std::reverse( path.begin(), path.end() );
 
         return path;
     }

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -82,10 +82,12 @@ namespace Battle
     Indexes ArenaPathfinder::buildPath( int targetCell ) const
     {
         Indexes path;
-        if ( targetCell < 0 || targetCell > _cache.size() )
+
+        size_t target = static_cast<size_t>( targetCell );
+        if ( target >= _cache.size() )
             return path;
 
-        int currentNode = targetCell;
+        int currentNode = target;
         while ( !_start.contains( currentNode ) && _cache[currentNode]._cost != 0 ) {
             const ArenaNode & node = _cache[currentNode];
             path.push_back( currentNode );

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -83,12 +83,11 @@ namespace Battle
     {
         Indexes path;
 
-        size_t target = static_cast<size_t>( targetCell );
-        if ( target >= _cache.size() )
+        if ( static_cast<size_t>( targetCell ) >= _cache.size() )
             return path;
 
-        int currentNode = target;
-        while ( !_start.contains( currentNode ) && _cache[currentNode]._cost != 0 ) {
+        int currentNode = targetCell;
+        while ( _cache[currentNode]._cost != 0 && !_start.contains( currentNode ) ) {
             const ArenaNode & node = _cache[currentNode];
             path.push_back( currentNode );
             currentNode = node._from;
@@ -101,18 +100,17 @@ namespace Battle
     Indexes ArenaPathfinder::findTwoMovesOverlap( int targetCell, uint32_t movementRange ) const
     {
         Indexes path;
-        const size_t target = static_cast<size_t>( targetCell );
-        if ( target >= _cache.size() )
+        if ( static_cast<size_t>( targetCell ) >= _cache.size() )
             return path;
 
-        const uint32_t pathCost = _cache[target]._cost;
+        const uint32_t pathCost = _cache[targetCell]._cost;
         if ( pathCost >= movementRange * 2 )
             return path;
 
-        int currentNode = target;
+        int currentNode = targetCell;
         uint32_t nodeCost = pathCost;
 
-        while ( !_start.contains( currentNode ) && nodeCost != 0 ) {
+        while ( nodeCost != 0 && !_start.contains( currentNode ) ) {
             const ArenaNode & node = _cache[currentNode];
             // Upper limit
             if ( movementRange == 0 || node._cost <= movementRange ) {

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -43,6 +43,7 @@ namespace Battle
 
     void ArenaPathfinder::reset()
     {
+        _start.Set( -1, false, false );
         for ( size_t i = 0; i < _cache.size(); ++i ) {
             _cache[i].resetNode();
         }
@@ -78,16 +79,30 @@ namespace Battle
         return result;
     }
 
-    std::list<Route::Step> ArenaPathfinder::buildPath( int targetCell ) const
+    Indexes ArenaPathfinder::buildPath( int targetCell, uint32_t slicingRange ) const
     {
-        std::list<Route::Step> path;
+        Indexes path;
+        if ( targetCell < 0 || targetCell > _cache.size() )
+            return path;
 
+        const uint32_t pathCost = _cache[targetCell]._cost;
         int currentNode = targetCell;
-        while ( currentNode != targetCell && _cache[currentNode]._cost != 0 ) {
+        uint32_t nodeCost = pathCost;
+
+        while ( !_start.contains( currentNode ) && nodeCost != 0 ) {
             const ArenaNode & node = _cache[currentNode];
-            path.emplace_front( currentNode, node._from, Board::GetDirection( node._from, currentNode ), 1 );
+            // Upper limit
+            if ( slicingRange == 0 || node._cost <= slicingRange ) {
+                path.push_back( currentNode );
+            }
             currentNode = node._from;
+            nodeCost = _cache[currentNode]._cost;
+
+            // Lower limit
+            if ( slicingRange > 0 && pathCost - nodeCost >= slicingRange )
+                break;
         }
+        std::reverse( path.begin(), path.end() );
 
         return path;
     }
@@ -98,9 +113,9 @@ namespace Battle
 
         const bool unitIsWide = unit.isWide();
 
-        const Position & startPosition = unit.GetPosition();
-        const Cell * unitHead = startPosition.GetHead();
-        const Cell * unitTail = startPosition.GetTail();
+        _start = unit.GetPosition();
+        const Cell * unitHead = _start.GetHead();
+        const Cell * unitTail = _start.GetTail();
         if ( !unitHead || ( unitIsWide && !unitTail ) ) {
             DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Pathfinder: Invalid unit is passed in! " << unit.GetName() );
             return;
@@ -188,7 +203,7 @@ namespace Battle
                     const bool isLeftDirection = unitIsWide && Board::IsLeftDirection( fromNode, newNode, previousNode._isLeftDirection );
 
                     const int32_t newTailIndex = isLeftDirection ? newNode + 1 : newNode - 1;
-                    const Cell * tailCell = ( unitIsWide && !startPosition.contains( newTailIndex ) ) ? Board::GetCell( newTailIndex ) : nullptr;
+                    const Cell * tailCell = ( unitIsWide && !_start.contains( newTailIndex ) ) ? Board::GetCell( newTailIndex ) : nullptr;
 
                     // Special case: headCell is *allowed* to have another unit in it, that's why we check isPassable1( false ) instead of isPassable4
                     if ( headCell->isPassable1( false ) && ( !tailCell || tailCell->isPassable1( true ) )

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -79,7 +79,24 @@ namespace Battle
         return result;
     }
 
-    Indexes ArenaPathfinder::buildPath( int targetCell, uint32_t slicingRange ) const
+    Indexes ArenaPathfinder::buildPath( int targetCell ) const
+    {
+        Indexes path;
+        if ( targetCell < 0 || targetCell > _cache.size() )
+            return path;
+
+        int currentNode = targetCell;
+        while ( !_start.contains( currentNode ) && _cache[currentNode]._cost != 0 ) {
+            const ArenaNode & node = _cache[currentNode];
+            path.push_back( currentNode );
+            currentNode = node._from;
+        }
+        std::reverse( path.begin(), path.end() );
+
+        return path;
+    }
+
+    Indexes ArenaPathfinder::buildNextTurnPath( int targetCell, uint32_t movementRange ) const
     {
         Indexes path;
         if ( targetCell < 0 || targetCell > _cache.size() )
@@ -92,14 +109,14 @@ namespace Battle
         while ( !_start.contains( currentNode ) && nodeCost != 0 ) {
             const ArenaNode & node = _cache[currentNode];
             // Upper limit
-            if ( slicingRange == 0 || node._cost <= slicingRange ) {
+            if ( movementRange == 0 || node._cost <= movementRange ) {
                 path.push_back( currentNode );
             }
             currentNode = node._from;
             nodeCost = _cache[currentNode]._cost;
 
             // Lower limit
-            if ( slicingRange > 0 && pathCost - nodeCost >= slicingRange )
+            if ( movementRange > 0 && !path.empty() && pathCost - nodeCost >= movementRange )
                 break;
         }
         std::reverse( path.begin(), path.end() );

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -96,17 +96,18 @@ namespace Battle
         return path;
     }
 
-    Indexes ArenaPathfinder::buildNextTurnPath( int targetCell, uint32_t movementRange ) const
+    Indexes ArenaPathfinder::findTwoMovesOverlap( int targetCell, uint32_t movementRange ) const
     {
         Indexes path;
-        if ( targetCell < 0 || targetCell > _cache.size() )
+        const size_t target = static_cast<size_t>( targetCell );
+        if ( target >= _cache.size() )
             return path;
 
-        const uint32_t pathCost = _cache[targetCell]._cost;
+        const uint32_t pathCost = _cache[target]._cost;
         if ( pathCost >= movementRange * 2 )
             return path;
 
-        int currentNode = targetCell;
+        int currentNode = target;
         uint32_t nodeCost = pathCost;
 
         while ( !_start.contains( currentNode ) && nodeCost != 0 ) {
@@ -122,6 +123,7 @@ namespace Battle
             if ( movementRange > 0 && !path.empty() && pathCost - nodeCost >= movementRange )
                 break;
         }
+        std::reverse( path.begin(), path.end() );
 
         return path;
     }

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -60,7 +60,7 @@ namespace Battle
         virtual void reset() override;
         void calculate( const Unit & unit );
         Indexes buildPath( int targetCell ) const;
-        Indexes buildNextTurnPath( int targetCell, uint32_t movementRange ) const;
+        Indexes findTwoMovesOverlap( int targetCell, uint32_t movementRange ) const;
         bool hexIsAccessible( int targetCell ) const;
         bool hexIsPassable( int targetCell ) const;
         Indexes getAllAvailableMoves( uint32_t moveRange ) const;

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -59,12 +59,14 @@ namespace Battle
         ArenaPathfinder();
         virtual void reset() override;
         void calculate( const Unit & unit );
-        std::list<Route::Step> buildPath( int targetCell ) const;
+        Indexes buildPath( int targetCell, uint32_t slicingRange = 0 ) const;
         bool hexIsAccessible( int targetCell ) const;
         bool hexIsPassable( int targetCell ) const;
         Indexes getAllAvailableMoves( uint32_t moveRange ) const;
 
     private:
         bool nodeIsPassable( const ArenaNode & node ) const;
+
+        Position _start;
     };
 }

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -59,7 +59,8 @@ namespace Battle
         ArenaPathfinder();
         virtual void reset() override;
         void calculate( const Unit & unit );
-        Indexes buildPath( int targetCell, uint32_t slicingRange = 0 ) const;
+        Indexes buildPath( int targetCell ) const;
+        Indexes buildNextTurnPath( int targetCell, uint32_t movementRange ) const;
         bool hexIsAccessible( int targetCell ) const;
         bool hexIsPassable( int targetCell ) const;
         Indexes getAllAvailableMoves( uint32_t moveRange ) const;


### PR DESCRIPTION
Related to #2954 .

Applied only for melee units in offense mode where there isn't a target within reach already. Also cleaned up attack outcome comparison logic.