### PR TITLE
Implement the "faster monster of opposite army goes first" logic in the battle mode

### DIFF
--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -194,8 +194,9 @@ Battle::Arena::Arena( Army & a1, Army & a2, s32 index, bool local )
     : army1( NULL )
     , army2( NULL )
     , armies_order( NULL )
+    , current_color( Color::NONE )
+    , preferredColor( -1 ) // be aware of unknown color
     , castle( NULL )
-    , current_color( 0 )
     , catapult( NULL )
     , bridge( NULL )
     , interface( NULL )
@@ -331,41 +332,41 @@ Battle::Arena::~Arena()
     arena = nullptr;
 }
 
-void Battle::Arena::TurnTroop( Unit * current_troop )
+void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
 {
     Actions actions;
     end_turn = false;
-    const bool isImmovable = current_troop->Modes( SP_BLIND | IS_PARALYZE_MAGIC );
+    const bool isImmovable = troop->Modes( SP_BLIND | IS_PARALYZE_MAGIC );
 
-    DEBUG_LOG( DBG_BATTLE, DBG_TRACE, current_troop->String( true ) );
+    DEBUG_LOG( DBG_BATTLE, DBG_TRACE, troop->String( true ) );
 
     // morale check right before the turn
     if ( !isImmovable ) {
-        if ( current_troop->isAffectedByMorale() )
-            current_troop->SetRandomMorale();
+        if ( troop->isAffectedByMorale() )
+            troop->SetRandomMorale();
     }
 
     while ( !end_turn ) {
-        if ( !current_troop->isValid() ) { // looks like the unit died
+        if ( !troop->isValid() ) { // looks like the unit died
             end_turn = true;
         }
-        else if ( current_troop->Modes( MORALE_BAD ) ) { // bad morale
-            actions.push_back( Command( MSG_BATTLE_MORALE, current_troop->GetUID(), false ) );
+        else if ( troop->Modes( MORALE_BAD ) ) { // bad morale
+            actions.push_back( Command( MSG_BATTLE_MORALE, troop->GetUID(), false ) );
             end_turn = true;
         }
         else {
             // re-calculate possible paths in case unit moved or it's a new turn
-            _pathfinder.calculate( *current_troop );
+            _pathfinder.calculate( *troop );
 
             // turn opponents
-            if ( current_troop->isControlRemote() )
-                RemoteTurn( *current_troop, actions );
+            if ( troop->isControlRemote() )
+                RemoteTurn( *troop, actions );
             else {
-                if ( ( current_troop->GetCurrentControl() & CONTROL_AI ) || ( current_troop->GetCurrentColor() & auto_battle ) ) {
-                    AI::Get().BattleTurn( *this, *current_troop, actions );
+                if ( ( troop->GetCurrentControl() & CONTROL_AI ) || ( troop->GetCurrentColor() & auto_battle ) ) {
+                    AI::Get().BattleTurn( *this, *troop, actions );
                 }
                 else {
-                    HumanTurn( *current_troop, actions );
+                    HumanTurn( *troop, actions );
                 }
             }
         }
@@ -376,9 +377,10 @@ void Battle::Arena::TurnTroop( Unit * current_troop )
             ApplyAction( actions.front() );
             actions.pop_front();
 
-            // rescan orders
-            if ( armies_order )
-                Force::UpdateOrderUnits( *army1, *army2, *armies_order );
+            if ( armies_order ) {
+                // some spell could kill someone or affect the speed of some unit, update units order
+                Force::UpdateOrderUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+            }
 
             // check end battle
             if ( !BattleValid() ) {
@@ -387,14 +389,14 @@ void Battle::Arena::TurnTroop( Unit * current_troop )
             }
 
             // good morale
-            if ( !end_turn && current_troop->isValid() && !current_troop->Modes( TR_SKIPMOVE ) && current_troop->Modes( TR_MOVED ) && current_troop->Modes( MORALE_GOOD )
+            if ( !end_turn && troop->isValid() && !troop->Modes( TR_SKIPMOVE ) && troop->Modes( TR_MOVED ) && troop->Modes( MORALE_GOOD )
                  && !isImmovable ) {
-                actions.push_back( Command( MSG_BATTLE_MORALE, current_troop->GetUID(), true ) );
+                actions.push_back( Command( MSG_BATTLE_MORALE, troop->GetUID(), true ) );
                 end_turn = false;
             }
         }
 
-        if ( current_troop->Modes( TR_SKIPMOVE | TR_MOVED ) )
+        if ( troop->Modes( TR_SKIPMOVE | TR_MOVED ) )
             end_turn = true;
 
         board.Reset();
@@ -412,10 +414,11 @@ bool Battle::Arena::BattleValid( void ) const
 
 void Battle::Arena::Turns( void )
 {
-    const Settings & conf = Settings::Get();
-
     ++current_turn;
+
     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, current_turn );
+
+    const Settings & conf = Settings::Get();
 
     if ( interface && conf.Music() && !Music::isPlaying() )
         AGG::PlayMusic( MUS::GetBattleRandom(), true, true );
@@ -423,61 +426,116 @@ void Battle::Arena::Turns( void )
     army1->NewTurn();
     army2->NewTurn();
 
-    bool tower_moved = false;
-    bool catapult_moved = false;
+    // order history on the current turn
+    Units orderHistory;
 
-    Unit * current_troop = NULL;
+    if ( armies_order ) {
+        orderHistory.reserve( 25 );
 
-    // rescan orders
-    if ( armies_order )
-        Force::UpdateOrderUnits( *army1, *army2, *armies_order );
-
-    while ( BattleValid() && NULL != ( current_troop = Force::GetCurrentUnit( *army1, *army2, current_troop, true ) ) ) {
-        current_color = current_troop->GetCurrentOrArmyColor();
-
-        // first turn: castle and catapult action
-        if ( castle ) {
-            if ( !catapult_moved && current_troop->GetColor() == army1->GetColor() ) {
-                CatapultAction();
-                catapult_moved = true;
-            }
-
-            if ( !tower_moved && current_troop->GetColor() == army2->GetColor() ) {
-                if ( towers[1] && towers[1]->isValid() )
-                    TowerAction( *towers[1] );
-                if ( towers[0] && towers[0]->isValid() )
-                    TowerAction( *towers[0] );
-                if ( towers[2] && towers[2]->isValid() )
-                    TowerAction( *towers[2] );
-                tower_moved = true;
-
-                // check dead last army from towers
-                if ( !BattleValid() )
-                    break;
-            }
-        }
-
-        // set bridge passable
-        if ( bridge )
-            bridge->SetPassable( *current_troop );
-
-        // turn troop
-        TurnTroop( current_troop );
+        // build initial units order
+        Force::UpdateOrderUnits( *army1, *army2, nullptr, preferredColor, orderHistory, *armies_order );
     }
 
-    current_troop = NULL;
+    {
+        bool tower_moved = false;
+        bool catapult_moved = false;
 
-    // can skip move ?
-    if ( Settings::Get().ExtBattleSoftWait() ) {
-        while ( BattleValid() && NULL != ( current_troop = Force::GetCurrentUnit( *army1, *army2, current_troop, false ) ) ) {
-            current_color = current_troop->GetCurrentOrArmyColor();
+        Unit * troop = nullptr;
+
+        while ( BattleValid() && ( troop = Force::GetCurrentUnit( *army1, *army2, true, preferredColor ) ) != nullptr ) {
+            current_color = troop->GetCurrentOrArmyColor();
+
+            // switch preferred color for the next unit
+            preferredColor = troop->GetArmyColor() == army1->GetColor() ? army2->GetColor() : army1->GetColor();
+
+            if ( armies_order ) {
+                // add unit to the order history
+                orderHistory.push_back( troop );
+
+                // update units order
+                Force::UpdateOrderUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+            }
+
+            // first turn: castle and catapult action
+            if ( castle ) {
+                if ( !catapult_moved && troop->GetColor() == army1->GetColor() ) {
+                    CatapultAction();
+                    catapult_moved = true;
+                }
+
+                if ( !tower_moved && troop->GetColor() == army2->GetColor() ) {
+                    if ( towers[1] && towers[1]->isValid() ) {
+                        TowerAction( *towers[1] );
+
+                        if ( armies_order ) {
+                            // tower could kill someone, update units order
+                            Force::UpdateOrderUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+                        }
+                    }
+                    if ( towers[0] && towers[0]->isValid() ) {
+                        TowerAction( *towers[0] );
+
+                        if ( armies_order ) {
+                            // tower could kill someone, update units order
+                            Force::UpdateOrderUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+                        }
+                    }
+                    if ( towers[2] && towers[2]->isValid() ) {
+                        TowerAction( *towers[2] );
+
+                        if ( armies_order ) {
+                            // tower could kill someone, update units order
+                            Force::UpdateOrderUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+                        }
+                    }
+                    tower_moved = true;
+
+                    // check dead last army from towers
+                    if ( !BattleValid() )
+                        break;
+                }
+            }
 
             // set bridge passable
             if ( bridge )
-                bridge->SetPassable( *current_troop );
+                bridge->SetPassable( *troop );
 
             // turn troop
-            TurnTroop( current_troop );
+            TurnTroop( troop, orderHistory );
+
+            if ( armies_order ) {
+                // if unit hasn't finished its turn yet, then remove it from the order history
+                if ( troop->Modes( TR_SKIPMOVE ) && !troop->Modes( TR_MOVED ) ) {
+                    orderHistory.pop_back();
+                }
+            }
+        }
+    }
+
+    // can skip move ?
+    if ( Settings::Get().ExtBattleSoftWait() ) {
+        Unit * troop = nullptr;
+
+        while ( BattleValid() && ( troop = Force::GetCurrentUnit( *army1, *army2, false, preferredColor ) ) != nullptr ) {
+            current_color = troop->GetCurrentOrArmyColor();
+
+            // switch preferred color for the next unit
+            preferredColor = troop->GetArmyColor() == army1->GetColor() ? army2->GetColor() : army1->GetColor();
+
+            if ( armies_order ) {
+                // add unit to the order history
+                orderHistory.push_back( troop );
+
+                // update units order
+                Force::UpdateOrderUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+            }
+
+            // set bridge passable
+            if ( bridge )
+                bridge->SetPassable( *troop );
+
+            // turn troop
+            TurnTroop( troop, orderHistory );
         }
     }
 

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -373,7 +373,7 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
             }
         }
 
-        bool troopHasAlreadySkippedMove = troop->Modes( TR_SKIPMOVE );
+        const bool troopHasAlreadySkippedMove = troop->Modes( TR_SKIPMOVE );
 
         // apply task
         while ( actions.size() ) {

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -160,7 +160,7 @@ namespace Battle
         void RemoteTurn( const Unit &, Actions & );
         void HumanTurn( const Unit &, Actions & );
 
-        void TurnTroop( Unit * );
+        void TurnTroop( Unit * troop, const Units & orderHistory );
         void TowerAction( const Tower & );
 
         void SetCastleTargetValue( int, u32 );
@@ -192,8 +192,10 @@ namespace Battle
         Force * army2;
         Units * armies_order;
 
-        const Castle * castle;
         int current_color;
+        int preferredColor; // preferred color for the next unit in the battle queue
+
+        const Castle * castle;
 
         Tower * towers[3];
         Catapult * catapult;

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -32,38 +32,38 @@
 
 namespace Battle
 {
-    bool AllowPart1( const Unit * b, bool f )
+    bool AllowPart1( const Unit * b )
     {
-        return ( f ? !b->Modes( TR_SKIPMOVE ) || b->Modes( TR_HARDSKIP ) : !b->Modes( TR_SKIPMOVE ) ) && Speed::STANDING != b->GetSpeed( f );
+        return !b->Modes( TR_SKIPMOVE ) && b->GetSpeed() > Speed::STANDING;
     }
 
-    bool AllowPart2( const Unit * b, bool f )
+    bool AllowPart2( const Unit * b )
     {
-        return ( f ? b->Modes( TR_SKIPMOVE ) && !b->Modes( TR_HARDSKIP ) : b->Modes( TR_SKIPMOVE ) ) && Speed::STANDING != b->GetSpeed( f );
+        return b->Modes( TR_SKIPMOVE ) && b->GetSpeed() > Speed::STANDING;
     }
 
     Unit * ForceGetCurrentUnitPart( Units & units1, Units & units2, bool part1, bool units1_first, bool orders_mode )
     {
-        Units::iterator it1 = part1 ? std::find_if( units1.begin(), units1.end(), [orders_mode]( const Unit * v ) { return AllowPart1( v, orders_mode ); } )
-                                    : std::find_if( units1.begin(), units1.end(), [orders_mode]( const Unit * v ) { return AllowPart2( v, orders_mode ); } );
-        Units::iterator it2 = part1 ? std::find_if( units2.begin(), units2.end(), [orders_mode]( const Unit * v ) { return AllowPart1( v, orders_mode ); } )
-                                    : std::find_if( units2.begin(), units2.end(), [orders_mode]( const Unit * v ) { return AllowPart2( v, orders_mode ); } );
+        Units::iterator it1 = part1 ? std::find_if( units1.begin(), units1.end(), []( const Unit * v ) { return AllowPart1( v ); } )
+                                    : std::find_if( units1.begin(), units1.end(), []( const Unit * v ) { return AllowPart2( v ); } );
+        Units::iterator it2 = part1 ? std::find_if( units2.begin(), units2.end(), []( const Unit * v ) { return AllowPart1( v ); } )
+                                    : std::find_if( units2.begin(), units2.end(), []( const Unit * v ) { return AllowPart2( v ); } );
         Unit * result = NULL;
 
         if ( it1 != units1.end() && it2 != units2.end() ) {
-            if ( ( *it1 )->GetSpeed( orders_mode ) == ( *it2 )->GetSpeed( orders_mode ) ) {
+            if ( ( *it1 )->GetSpeed() == ( *it2 )->GetSpeed() ) {
                 result = units1_first ? *it1 : *it2;
             }
             else if ( part1 || Settings::Get().ExtBattleReverseWaitOrder() ) {
-                if ( ( *it1 )->GetSpeed( orders_mode ) > ( *it2 )->GetSpeed( orders_mode ) )
+                if ( ( *it1 )->GetSpeed() > ( *it2 )->GetSpeed() )
                     result = *it1;
-                else if ( ( *it2 )->GetSpeed( orders_mode ) > ( *it1 )->GetSpeed( orders_mode ) )
+                else if ( ( *it2 )->GetSpeed() > ( *it1 )->GetSpeed() )
                     result = *it2;
             }
             else {
-                if ( ( *it1 )->GetSpeed( orders_mode ) < ( *it2 )->GetSpeed( orders_mode ) )
+                if ( ( *it1 )->GetSpeed() < ( *it2 )->GetSpeed() )
                     result = *it1;
-                else if ( ( *it2 )->GetSpeed( orders_mode ) < ( *it1 )->GetSpeed( orders_mode ) )
+                else if ( ( *it2 )->GetSpeed() < ( *it1 )->GetSpeed() )
                     result = *it2;
             }
         }
@@ -115,46 +115,14 @@ Battle::Units & Battle::Units::operator=( const Units & units )
     return *this;
 }
 
-struct FastestUnits
+void Battle::Units::SortSlowest()
 {
-    bool f;
-
-    FastestUnits( bool v )
-        : f( v )
-    {}
-
-    bool operator()( const Battle::Unit * t1, const Battle::Unit * t2 )
-    {
-        return t1->GetSpeed( f ) > t2->GetSpeed( f );
-    }
-};
-
-struct SlowestUnits
-{
-    bool f;
-
-    SlowestUnits( bool v )
-        : f( v )
-    {}
-
-    bool operator()( const Battle::Unit * t1, const Battle::Unit * t2 )
-    {
-        return t1->GetSpeed( f ) < t2->GetSpeed( f );
-    }
-};
-
-void Battle::Units::SortSlowest( bool f )
-{
-    SlowestUnits CompareFunc( f );
-
-    std::stable_sort( begin(), end(), CompareFunc );
+    std::stable_sort( begin(), end(), Army::SlowestTroop );
 }
 
-void Battle::Units::SortFastest( bool f )
+void Battle::Units::SortFastest()
 {
-    FastestUnits CompareFunc( f );
-
-    std::stable_sort( begin(), end(), CompareFunc );
+    std::stable_sort( begin(), end(), Army::FastestTroop );
 }
 
 void Battle::Units::SortStrongest( void )
@@ -277,25 +245,27 @@ void Battle::Force::NewTurn( void )
     std::for_each( begin(), end(), []( Unit * unit ) { unit->NewTurn(); } );
 }
 
-bool isUnitFirst( const Battle::Unit * last, bool part1, int army2_color )
-{
-    return ( !last && part1 ) || ( last && army2_color == last->GetColor() );
-}
-
-void Battle::Force::UpdateOrderUnits( const Force & army1, const Force & army2, Units & orders )
+void Battle::Force::UpdateOrderUnits( const Force & army1, const Force & army2, const Unit * activeUnit, int preferredColor, const Units & orderHistory, Units & orders )
 {
     orders.clear();
-    Unit * last = NULL;
+    orders.insert( orders.end(), orderHistory.begin(), orderHistory.end() );
 
-    if ( 1 ) {
+    {
         Units units1( army1, true );
         Units units2( army2, true );
 
-        units1.SortFastest( true );
-        units2.SortFastest( true );
+        units1.SortFastest();
+        units2.SortFastest();
 
-        while ( NULL != ( last = ForceGetCurrentUnitPart( units1, units2, true, isUnitFirst( last, true, army2.GetColor() ), true ) ) )
-            orders.push_back( last );
+        Unit * unit = nullptr;
+
+        while ( ( unit = ForceGetCurrentUnitPart( units1, units2, true, preferredColor != army2.GetColor(), true ) ) != nullptr ) {
+            if ( unit != activeUnit && unit->isValid() ) {
+                preferredColor = unit->GetArmyColor() == army1.GetColor() ? army2.GetColor() : army1.GetColor();
+
+                orders.push_back( unit );
+            }
+        }
     }
 
     if ( Settings::Get().ExtBattleSoftWait() ) {
@@ -303,42 +273,49 @@ void Battle::Force::UpdateOrderUnits( const Force & army1, const Force & army2, 
         Units units2( army2, true );
 
         if ( Settings::Get().ExtBattleReverseWaitOrder() ) {
-            units1.SortFastest( true );
-            units2.SortFastest( true );
+            units1.SortFastest();
+            units2.SortFastest();
         }
         else {
             std::reverse( units1.begin(), units1.end() );
             std::reverse( units2.begin(), units2.end() );
 
-            units1.SortSlowest( true );
-            units2.SortSlowest( true );
+            units1.SortSlowest();
+            units2.SortSlowest();
         }
 
-        while ( NULL != ( last = ForceGetCurrentUnitPart( units1, units2, false, isUnitFirst( last, false, army2.GetColor() ), true ) ) )
-            orders.push_back( last );
+        Unit * unit = nullptr;
+
+        while ( ( unit = ForceGetCurrentUnitPart( units1, units2, false, preferredColor != army2.GetColor(), true ) ) != nullptr ) {
+            if ( unit != activeUnit && unit->isValid() ) {
+                preferredColor = unit->GetArmyColor() == army1.GetColor() ? army2.GetColor() : army1.GetColor();
+
+                orders.push_back( unit );
+            }
+        }
     }
 }
 
-Battle::Unit * Battle::Force::GetCurrentUnit( const Force & army1, const Force & army2, const Unit * last, bool part1 )
+Battle::Unit * Battle::Force::GetCurrentUnit( const Force & army1, const Force & army2, bool part1, int preferredColor )
 {
     Units units1( army1, true );
     Units units2( army2, true );
 
     if ( part1 || Settings::Get().ExtBattleReverseWaitOrder() ) {
-        units1.SortFastest( false );
-        units2.SortFastest( false );
+        units1.SortFastest();
+        units2.SortFastest();
     }
     else {
         std::reverse( units1.begin(), units1.end() );
         std::reverse( units2.begin(), units2.end() );
 
-        units1.SortSlowest( false );
-        units2.SortSlowest( false );
+        units1.SortSlowest();
+        units2.SortSlowest();
     }
 
-    Unit * result = ForceGetCurrentUnitPart( units1, units2, part1, isUnitFirst( last, part1, army2.GetColor() ), false );
+    Unit * result = ForceGetCurrentUnitPart( units1, units2, part1, preferredColor != army2.GetColor(), false );
 
-    return result && result->isValid() && result->GetSpeed() > Speed::STANDING ? result : NULL;
+    return result && result->isValid() ? result : nullptr;
 }
 
 StreamBase & Battle::operator<<( StreamBase & msg, const Force & f )

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -43,8 +43,8 @@ namespace Battle
         Unit * FindMode( u32 );
         Unit * FindUID( u32 );
 
-        void SortSlowest( bool );
-        void SortFastest( bool );
+        void SortSlowest();
+        void SortFastest();
         void SortStrongest( void );
         void SortWeakest( void );
         void SortArchers();
@@ -73,8 +73,8 @@ namespace Battle
         void NewTurn( void );
         void SyncArmyCount( bool checkResurrected );
 
-        static Unit * GetCurrentUnit( const Force &, const Force &, const Unit * last, bool part1 );
-        static void UpdateOrderUnits( const Force &, const Force &, Units & );
+        static Unit * GetCurrentUnit( const Force & army1, const Force & army2, bool part1, int preferredColor );
+        static void UpdateOrderUnits( const Force & army1, const Force & army2, const Unit * activeUnit, int preferredColor, const Units & orderHistory, Units & orders );
 
     private:
         Army & army;


### PR DESCRIPTION
fix #395

As usual: needs to be thoroughly tested in different situations, with AI and human-controlled players, with and without soft wait option (with and without reverse wait order), with and without "show army order option" and so on.