### PR TITLE
Update Display class capabilities

### DIFF
--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1166,12 +1166,6 @@ namespace fheroes2
         _disableTransformLayer();
     }
 
-    Display::~Display()
-    {
-        delete _cursor;
-        delete _engine;
-    }
-
     void Display::resize( int32_t width_, int32_t height_ )
     {
         if ( width() > 0 && height() > 0 && width_ == width() && height_ == height() ) // nothing to resize
@@ -1277,6 +1271,24 @@ namespace fheroes2
         currentPalette = ( palette == NULL ) ? PALPAlette() : palette;
 
         _engine->updatePalette( StandardPaletteIndexes() );
+    }
+
+    void Display::setEngine( std::unique_ptr<BaseRenderEngine> && engine )
+    {
+        assert( engine.get() != nullptr );
+        if ( engine.get() == nullptr ) {
+            return;
+        }
+        std::swap( engine, _engine );
+    }
+
+    void Display::setCursor( std::unique_ptr<Cursor> && cursor )
+    {
+        assert( cursor.get() != nullptr );
+        if ( cursor.get() == nullptr ) {
+            return;
+        }
+        std::swap( cursor, _cursor );
     }
 
     bool Cursor::isFocusActive() const

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1273,7 +1273,7 @@ namespace fheroes2
         _engine->updatePalette( StandardPaletteIndexes() );
     }
 
-    void Display::setEngine( std::unique_ptr<BaseRenderEngine> && engine )
+    void Display::setEngine( std::unique_ptr<BaseRenderEngine> & engine )
     {
         assert( engine.get() != nullptr );
         if ( engine.get() == nullptr ) {
@@ -1282,7 +1282,7 @@ namespace fheroes2
         std::swap( engine, _engine );
     }
 
-    void Display::setCursor( std::unique_ptr<Cursor> && cursor )
+    void Display::setCursor( std::unique_ptr<Cursor> & cursor )
     {
         assert( cursor.get() != nullptr );
         if ( cursor.get() == nullptr ) {

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -128,8 +128,8 @@ namespace fheroes2
         friend BaseRenderEngine & engine();
         friend Cursor & cursor();
 
-        void setEngine( std::unique_ptr<BaseRenderEngine> && engine );
-        void setCursor( std::unique_ptr<Cursor> && cursor );
+        void setEngine( std::unique_ptr<BaseRenderEngine> & engine );
+        void setCursor( std::unique_ptr<Cursor> & cursor );
 
     private:
         std::unique_ptr<BaseRenderEngine> _engine;

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -21,6 +21,8 @@
 
 #include "image.h"
 
+#include <memory>
+
 namespace fheroes2
 {
     class Cursor;
@@ -31,7 +33,7 @@ namespace fheroes2
     public:
         friend class Cursor;
         friend class Display;
-        virtual ~BaseRenderEngine() {}
+        virtual ~BaseRenderEngine() = default;
 
         virtual void toggleFullScreen()
         {
@@ -92,7 +94,8 @@ namespace fheroes2
     {
     public:
         friend class BaseRenderEngine;
-        enum
+
+        enum : int32_t
         {
             DEFAULT_WIDTH = 640,
             DEFAULT_HEIGHT = 480
@@ -100,9 +103,9 @@ namespace fheroes2
 
         static Display & instance();
 
-        virtual ~Display();
+        virtual ~Display() = default;
 
-        void render(); // render the image on screen
+        void render(); // render full image on screen
 
         virtual void resize( int32_t width_, int32_t height_ ) override;
         bool isDefaultSize() const;
@@ -120,14 +123,17 @@ namespace fheroes2
 
         // Change whole color representation on the screen. Make sure that palette exists all the time!!!
         // NULL input parameters means to set to default value
-        void changePalette( const uint8_t * palette = NULL );
+        void changePalette( const uint8_t * palette = nullptr );
 
         friend BaseRenderEngine & engine();
         friend Cursor & cursor();
 
+        void setEngine( std::unique_ptr<BaseRenderEngine> && engine );
+        void setCursor( std::unique_ptr<Cursor> && cursor );
+
     private:
-        BaseRenderEngine * _engine;
-        Cursor * _cursor;
+        std::unique_ptr<BaseRenderEngine> _engine;
+        std::unique_ptr<Cursor> _cursor;
         PreRenderProcessing _preprocessing;
         PostRenderProcessing _postprocessing;
 
@@ -144,7 +150,7 @@ namespace fheroes2
     {
     public:
         friend Display;
-        virtual ~Cursor() {}
+        virtual ~Cursor() = default;
 
         void show( const bool enable )
         {


### PR DESCRIPTION
relates to #3046

Using move semantics prevents potential memory leaks as well as saves previous objects which we can reuse later.