### PR TITLE
Don't allow the player to scroll world map while hero is moving

### DIFF
--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -176,6 +176,7 @@ namespace Game
     enum
     {
         SCROLL_DELAY,
+        SCROLL_START_DELAY,
         MAIN_MENU_DELAY,
         MAPS_DELAY,
         CASTLE_TAVERN_DELAY,

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -67,7 +67,7 @@ namespace Game
     static const double battleSpeedAdjustment = 1.0 / static_cast<double>( 10 - DEFAULT_BATTLE_SPEED );
 
     TimeDelay delays[] = { 20, // SCROLL_DELAY
-                           500, // SCROLL_START_DELAY
+                           250, // SCROLL_START_DELAY
                            250, // MAIN_MENU_DELAY
                            250, // MAPS_DELAY
                            200, // CASTLE_TAVERN_DELAY

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -66,37 +66,37 @@ namespace Game
 
     static const double battleSpeedAdjustment = 1.0 / static_cast<double>( 10 - DEFAULT_BATTLE_SPEED );
 
-    TimeDelay delays[] = {20, // SCROLL_DELAY
-                          500, // SCROLL_START_DELAY
-                          250, // MAIN_MENU_DELAY
-                          250, // MAPS_DELAY
-                          200, // CASTLE_TAVERN_DELAY
-                          200, // CASTLE_AROUND_DELAY
-                          130, // CASTLE_BUYHERO_DELAY
-                          130, // CASTLE_BUILD_DELAY
-                          150, // CASTLE_UNIT_DELAY
-                          32, // HEROES_FADE_DELAY
-                          40, // HEROES_PICKUP_DELAY
-                          50, // PUZZLE_FADE_DELAY
-                          75, // BATTLE_DIALOG_DELAY
-                          120, // BATTLE_FRAME_DELAY
-                          40, // BATTLE_MISSILE_DELAY
-                          90, // BATTLE_SPELL_DELAY
-                          20, // BATTLE_DISRUPTING_DELAY
-                          90, // BATTLE_CATAPULT_DELAY  // catapult
-                          40, // BATTLE_CATAPULT2_DELAY // boulder
-                          40, // BATTLE_CATAPULT3_DELAY // cloud
-                          90, // BATTLE_BRIDGE_DELAY
-                          150, // BATTLE_IDLE_DELAY
-                          350, // BATTLE_OPPONENTS_DELAY
-                          250, // BATTLE_FLAGS_DELAY
-                          800, // BATTLE_POPUP_DELAY
-                          220, // BATTLE_COLOR_CYCLE_DELAY
-                          160, // BATTLE_SELECTED_UNIT_DELAY
-                          10, // CURRENT_HERO_DELAY
-                          10, // CURRENT_AI_DELAY
-                          0, // CUSTOM_DELAY
-                          0};
+    TimeDelay delays[] = { 20, // SCROLL_DELAY
+                           500, // SCROLL_START_DELAY
+                           250, // MAIN_MENU_DELAY
+                           250, // MAPS_DELAY
+                           200, // CASTLE_TAVERN_DELAY
+                           200, // CASTLE_AROUND_DELAY
+                           130, // CASTLE_BUYHERO_DELAY
+                           130, // CASTLE_BUILD_DELAY
+                           150, // CASTLE_UNIT_DELAY
+                           32, // HEROES_FADE_DELAY
+                           40, // HEROES_PICKUP_DELAY
+                           50, // PUZZLE_FADE_DELAY
+                           75, // BATTLE_DIALOG_DELAY
+                           120, // BATTLE_FRAME_DELAY
+                           40, // BATTLE_MISSILE_DELAY
+                           90, // BATTLE_SPELL_DELAY
+                           20, // BATTLE_DISRUPTING_DELAY
+                           90, // BATTLE_CATAPULT_DELAY  // catapult
+                           40, // BATTLE_CATAPULT2_DELAY // boulder
+                           40, // BATTLE_CATAPULT3_DELAY // cloud
+                           90, // BATTLE_BRIDGE_DELAY
+                           150, // BATTLE_IDLE_DELAY
+                           350, // BATTLE_OPPONENTS_DELAY
+                           250, // BATTLE_FLAGS_DELAY
+                           800, // BATTLE_POPUP_DELAY
+                           220, // BATTLE_COLOR_CYCLE_DELAY
+                           160, // BATTLE_SELECTED_UNIT_DELAY
+                           10, // CURRENT_HERO_DELAY
+                           10, // CURRENT_AI_DELAY
+                           0, // CUSTOM_DELAY
+                           0 };
 
     int humanHeroMultiplier = 1;
     int aiHeroMultiplier = 1;

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -67,6 +67,7 @@ namespace Game
     static const double battleSpeedAdjustment = 1.0 / static_cast<double>( 10 - DEFAULT_BATTLE_SPEED );
 
     TimeDelay delays[] = {20, // SCROLL_DELAY
+                          500, // SCROLL_START_DELAY
                           250, // MAIN_MENU_DELAY
                           250, // MAPS_DELAY
                           200, // CASTLE_TAVERN_DELAY

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -67,7 +67,7 @@ namespace Game
     static const double battleSpeedAdjustment = 1.0 / static_cast<double>( 10 - DEFAULT_BATTLE_SPEED );
 
     TimeDelay delays[] = { 20, // SCROLL_DELAY
-                           250, // SCROLL_START_DELAY
+                           20, // SCROLL_START_DELAY
                            250, // MAIN_MENU_DELAY
                            250, // MAPS_DELAY
                            200, // CASTLE_TAVERN_DELAY

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1019,8 +1019,6 @@ int Interface::Basic::HumanTurn( bool isload )
                 cursor.Show();
 
                 display.render();
-
-                continue;
             }
         }
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -821,6 +821,10 @@ int Interface::Basic::HumanTurn( bool isload )
                 EventOpenFocus();
         }
 
+        if ( res != Game::CANCEL ) {
+            break;
+        }
+
         if ( fheroes2::cursor().isFocusActive() ) {
             int scrollPosition = SCROLL_NONE;
             if ( le.MouseCursor( GetScrollLeft() ) )
@@ -859,12 +863,7 @@ int Interface::Basic::HumanTurn( bool isload )
         else if ( ( !isHiddenInterface || conf.ShowButtons() ) && le.MouseCursor( buttonsArea.GetRect() ) ) {
             if ( Cursor::POINTER != cursor.Themes() )
                 cursor.SetThemes( Cursor::POINTER );
-
-            const int eventProcRes = buttonsArea.QueueEventProcessing();
-            if ( eventProcRes != Game::CANCEL ) {
-                res = eventProcRes;
-            }
-
+            res = buttonsArea.QueueEventProcessing();
             isCursorOverButtons = true;
         }
         // cursor over status area
@@ -877,11 +876,7 @@ int Interface::Basic::HumanTurn( bool isload )
         else if ( isHiddenInterface && conf.ShowControlPanel() && le.MouseCursor( controlPanel.GetArea() ) ) {
             if ( Cursor::POINTER != cursor.Themes() )
                 cursor.SetThemes( Cursor::POINTER );
-
-            const int eventProcRes = controlPanel.QueueEventProcessing();
-            if ( eventProcRes != Game::CANCEL ) {
-                res = eventProcRes;
-            }
+            res = controlPanel.QueueEventProcessing();
         }
         // cursor over game area
         else if ( le.MouseCursor( gameArea.GetROI() ) && !gameArea.NeedScroll() ) {
@@ -895,6 +890,10 @@ int Interface::Basic::HumanTurn( bool isload )
 
         if ( prevIsCursorOverButtons && !isCursorOverButtons ) {
             buttonsArea.ResetButtons();
+        }
+
+        if ( res != Game::CANCEL ) {
+            break;
         }
 
         // fast scroll
@@ -989,10 +988,7 @@ int Interface::Basic::HumanTurn( bool isload )
 
                         if ( hero->isAction() ) {
                             // check game over
-                            const int gameOverRes = gameResult.LocalCheckGameOver();
-                            if ( gameOverRes != Game::CANCEL ) {
-                                res = gameOverRes;
-                            }
+                            res = gameResult.LocalCheckGameOver();
 
                             hero->ResetAction();
                         }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -692,6 +692,9 @@ int Interface::Basic::HumanTurn( bool isload )
     if ( !conf.ExtWorldOnlyFirstMonsterAttack() )
         myKingdom.HeroesActionNewPosition();
 
+    int fastScrollRepeatCount = 0;
+    const int fastScrollStartThreshold = 2;
+
     bool isMovingHero = false;
     bool stopHero = false;
 
@@ -819,6 +822,7 @@ int Interface::Basic::HumanTurn( bool isload )
 
         if ( fheroes2::cursor().isFocusActive() ) {
             int scrollPosition = SCROLL_NONE;
+
             if ( le.MouseCursor( GetScrollLeft() ) )
                 scrollPosition |= SCROLL_LEFT;
             else if ( le.MouseCursor( GetScrollRight() ) )
@@ -827,8 +831,24 @@ int Interface::Basic::HumanTurn( bool isload )
                 scrollPosition |= SCROLL_TOP;
             else if ( le.MouseCursor( GetScrollBottom() ) )
                 scrollPosition |= SCROLL_BOTTOM;
-            if ( scrollPosition != SCROLL_NONE )
-                gameArea.SetScroll( scrollPosition );
+
+            if ( scrollPosition != SCROLL_NONE ) {
+                if ( Game::AnimateInfrequentDelay( Game::SCROLL_START_DELAY ) ) {
+                    if ( fastScrollRepeatCount < fastScrollStartThreshold ) {
+                        ++fastScrollRepeatCount;
+                    }
+                }
+
+                if ( fastScrollRepeatCount >= fastScrollStartThreshold ) {
+                    gameArea.SetScroll( scrollPosition );
+                }
+            }
+            else {
+                fastScrollRepeatCount = 0;
+            }
+        }
+        else {
+            fastScrollRepeatCount = 0;
         }
 
         const fheroes2::Rect displayArea( 0, 0, display.width(), display.height() );

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -724,6 +724,7 @@ int Interface::Basic::HumanTurn( bool isload )
 
         // hot keys
         if ( le.KeyPress() ) {
+            // stop moving hero first if needed
             if ( isMovingHero )
                 stopHero = true;
             // exit dialog
@@ -843,9 +844,17 @@ int Interface::Basic::HumanTurn( bool isload )
         const bool isHiddenInterface = conf.ExtGameHideInterface();
         const bool prevIsCursorOverButtons = isCursorOverButtons;
         isCursorOverButtons = false;
-        // Stop moving hero first
-        if ( isMovingHero && ( le.MouseClickLeft( displayArea ) || le.MousePressRight( displayArea ) ) ) {
-            stopHero = true;
+
+        if ( isMovingHero ) {
+            // hero is moving, set the appropriate cursor
+            if ( cursor.Themes() != Cursor::WAIT ) {
+                cursor.SetThemes( Cursor::WAIT );
+            }
+
+            // stop moving hero if needed
+            if ( le.MouseClickLeft( displayArea ) || le.MousePressRight( displayArea ) ) {
+                stopHero = true;
+            }
         }
         // cursor over radar
         else if ( ( !isHiddenInterface || conf.ShowRadar() ) && le.MouseCursor( radar.GetRect() ) ) {
@@ -929,11 +938,10 @@ int Interface::Basic::HumanTurn( bool isload )
                             RedrawFocus();
 
                             if ( stopHero ) {
-                                hero->SetMove( false );
                                 stopHero = false;
-                            }
 
-                            gameArea.SetUpdateCursor();
+                                hero->SetMove( false );
+                            }
                         }
                         else {
                             Point movement( hero->MovementDirection() );
@@ -968,9 +976,10 @@ int Interface::Basic::HumanTurn( bool isload )
                     else {
                         isMovingHero = false;
                         stopHero = false;
+
                         hero->SetMove( false );
-                        if ( Cursor::WAIT == cursor.Themes() )
-                            gameArea.SetUpdateCursor();
+
+                        gameArea.SetUpdateCursor();
                     }
                 }
             }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1003,8 +1003,6 @@ int Interface::Basic::HumanTurn( bool isload )
         // fast scroll
         if ( gameArea.NeedScroll() && !isMovingHero ) {
             if ( Game::AnimateInfrequentDelay( Game::SCROLL_DELAY ) ) {
-                cursor.Hide();
-
                 if ( le.MouseCursor( GetScrollLeft() ) || le.MouseCursor( GetScrollRight() ) || le.MouseCursor( GetScrollTop() )
                      || le.MouseCursor( GetScrollBottom() ) ) {
                     cursor.SetThemes( gameArea.GetScrollCursor() );
@@ -1014,11 +1012,6 @@ int Interface::Basic::HumanTurn( bool isload )
 
                 gameArea.SetRedraw();
                 radar.SetRedraw();
-                Redraw();
-
-                cursor.Show();
-
-                display.render();
             }
         }
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -692,9 +692,6 @@ int Interface::Basic::HumanTurn( bool isload )
     if ( !conf.ExtWorldOnlyFirstMonsterAttack() )
         myKingdom.HeroesActionNewPosition();
 
-    int fastScrollRepeatCount = 0;
-    const int fastScrollStartThreshold = 2;
-
     bool isMovingHero = false;
     bool stopHero = false;
 
@@ -986,12 +983,6 @@ int Interface::Basic::HumanTurn( bool isload )
         // fast scroll
         if ( gameArea.NeedScroll() && !isMovingHero ) {
             if ( Game::AnimateInfrequentDelay( Game::SCROLL_DELAY ) ) {
-                if ( fastScrollRepeatCount < fastScrollStartThreshold ) {
-                    ++fastScrollRepeatCount;
-
-                    continue;
-                }
-
                 cursor.Hide();
 
                 if ( le.MouseCursor( GetScrollLeft() ) || le.MouseCursor( GetScrollRight() ) || le.MouseCursor( GetScrollTop() )
@@ -1011,9 +1002,6 @@ int Interface::Basic::HumanTurn( bool isload )
 
                 continue;
             }
-        }
-        else {
-            fastScrollRepeatCount = 0;
         }
 
         // slow maps objects animation

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -693,8 +693,7 @@ int Interface::Basic::HumanTurn( bool isload )
         myKingdom.HeroesActionNewPosition();
 
     int fastScrollRepeatCount = 0;
-    const int fastScrollThreshold = 2;
-    bool isOngoingFastScrollEvent = false;
+    const int fastScrollStartThreshold = 2;
 
     bool isMovingHero = false;
     bool stopHero = false;
@@ -716,11 +715,6 @@ int Interface::Basic::HumanTurn( bool isload )
                 continue;
             }
         }
-
-        if ( !isOngoingFastScrollEvent )
-            fastScrollRepeatCount = 0;
-
-        isOngoingFastScrollEvent = false;
 
         // hot keys
         if ( le.KeyPress() ) {
@@ -991,28 +985,35 @@ int Interface::Basic::HumanTurn( bool isload )
 
         // fast scroll
         if ( gameArea.NeedScroll() && !isMovingHero ) {
-            isOngoingFastScrollEvent = true;
-
             if ( Game::AnimateInfrequentDelay( Game::SCROLL_DELAY ) ) {
-                ++fastScrollRepeatCount;
-                if ( fastScrollRepeatCount < fastScrollThreshold )
+                if ( fastScrollRepeatCount < fastScrollStartThreshold ) {
+                    ++fastScrollRepeatCount;
+
                     continue;
+                }
 
                 cursor.Hide();
 
-                if ( le.MouseCursor( GetScrollLeft() ) || le.MouseCursor( GetScrollRight() ) || le.MouseCursor( GetScrollTop() ) || le.MouseCursor( GetScrollBottom() ) )
+                if ( le.MouseCursor( GetScrollLeft() ) || le.MouseCursor( GetScrollRight() ) || le.MouseCursor( GetScrollTop() )
+                     || le.MouseCursor( GetScrollBottom() ) ) {
                     cursor.SetThemes( gameArea.GetScrollCursor() );
+                }
 
                 gameArea.Scroll();
 
                 gameArea.SetRedraw();
                 radar.SetRedraw();
                 Redraw();
+
                 cursor.Show();
+
                 display.render();
 
                 continue;
             }
+        }
+        else {
+            fastScrollRepeatCount = 0;
         }
 
         // slow maps objects animation

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -86,8 +86,6 @@ void Interface::Basic::ShowPathOrStartMoveHero( Heroes * hero, s32 destinationId
         RedrawFocus();
 
         hero->SetMove( true );
-
-        Cursor::Get().SetThemes( Cursor::WAIT );
     }
 }
 


### PR DESCRIPTION
fix #1159

Also fixes an issue when cursor isn't turned into Cursor::WAIT when hotkey is used to start the hero's movement.