### PR TITLE
Fix logic in Maps::Tiles::isShadow()

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1887,7 +1887,8 @@ bool Maps::Tiles::isStream( void ) const
 bool Maps::Tiles::isShadow( void ) const
 {
     return isShadowSprite( objectTileset, objectIndex )
-           && addons_level1.size() != static_cast<size_t>( std::count_if( addons_level1.begin(), addons_level1.end(), TilesAddon::isShadow ) );
+           || ( !addons_level1.empty()
+                && addons_level1.size() == static_cast<size_t>( std::count_if( addons_level1.begin(), addons_level1.end(), TilesAddon::isShadow ) ) );
 }
 
 bool Maps::Tiles::hasSpriteAnimation() const


### PR DESCRIPTION
Fix for the digging issue in #3058.

It looks like there is inverted logic in this function: there should be a shadow either if we have shadow sprite in this tile or if all addons for this tile are shadows. Am I right?