### PR TITLE
Fix ultimate artifact digging logic

### DIFF
--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -305,9 +305,13 @@ std::string ShowGroundInfo( const Maps::Tiles & tile, const bool showTerrainPena
         str = Maps::Ground::String( tile.GetGround() );
     }
 
+    str.append( "\n \n" );
+
     if ( tile.GoodForUltimateArtifact() ) {
-        str.append( "\n \n" );
         str.append( _( "(digging ok)" ) );
+    }
+    else {
+        str.append( _( "(no digging)" ) );
     }
 
     if ( showTerrainPenaltyOption && hero ) {

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1825,7 +1825,15 @@ void Maps::Tiles::FixObject( void )
 
 bool Maps::Tiles::GoodForUltimateArtifact() const
 {
-    return !isWater() && ( ( addons_level1.empty() && objectTileset == 0 ) || isShadow() ) && isPassable( Direction::CENTER, false, true, 0 );
+    if ( isWater() || !isPassable( Direction::CENTER, false, true, 0 ) ) {
+        return false;
+    }
+
+    if ( objectTileset == 0 || isShadowSprite( objectTileset, objectIndex ) ) {
+        return addons_level1.size() == static_cast<size_t>( std::count_if( addons_level1.begin(), addons_level1.end(), TilesAddon::isShadow ) );
+    }
+
+    return false;
 }
 
 bool Maps::Tiles::validateWaterRules( bool fromWater ) const


### PR DESCRIPTION
Fixes digging problem from #3058

fix #2317
fix #2733

I think logic of `Maps::Tiles::GoodForUltimateArtifact()` should be like this, but I may be wrong.

Also I have some doubts regarding logic of `Maps::Tiles::isShadow()` (now it returns `true` if there is a shadow sprite in this tile AND there is at least one non-shadow tile addon, why such logic?). Needs a review from someone familiar with map tiles and passability mechanics. `isShadow()` is not used anymore in `GoodForUltimateArtifact()`, but it is still used in `Maps::Tiles::UpdatePassable()`.