### PR TITLE
Reset the spell on tile when AI-controlled hero has successfully captured an object

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -788,6 +788,7 @@ namespace AI
 
                 if ( result.AttackerWins() ) {
                     hero.IncreaseExperience( result.GetExperienceAttacker() );
+                    tile.SetQuantity3( 0 );
                 }
                 else {
                     capture = false;


### PR DESCRIPTION
fix #3114