### PR TITLE
Zero-initialize _data in Image::resize(), don't leave _data dangling in Image::operator=()

### DIFF
--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -441,6 +441,9 @@ namespace fheroes2
             if ( image_._data != nullptr ) {
                 _data = new uint8_t[static_cast<size_t>( _width * _height * 2 )];
             }
+            else {
+                _data = nullptr;
+            }
         }
 
         if ( image_._data != nullptr ) {
@@ -506,6 +509,8 @@ namespace fheroes2
 
         const size_t totalSize = static_cast<size_t>( _width * _height );
         _data = new uint8_t[totalSize * 2];
+        // TODO: remove this, Image should be able to work with uninitialized data
+        std::fill( _data, _data + totalSize * 2, 0 );
     }
 
     void Image::reset()

--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -724,6 +724,8 @@ DwellingsBar::DwellingsBar( Castle & cstl, const fheroes2::Size & sz )
     : castle( cstl )
     , backsf( sz.width, sz.height )
 {
+    backsf.reset();
+
     for ( u32 dw = DWELLING_MONSTER1; dw <= DWELLING_MONSTER6; dw <<= 1 )
         content.emplace_back( castle, dw );
 


### PR DESCRIPTION
fix #3145

std::vector::resize() performs value-initialization (zero-initialization for primitive types) of new members, while new[] doesn't. Also I wonder, why not use std::unique_ptr<T[]> for _data instead of raw pointer? There is no overhead in terms of memory usage, but there will be no room for dangling references.