### PR TITLE
Enable triggering of positive morale event after soft wait

### DIFF
--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -399,15 +399,14 @@ void Battle::Arena::ApplyActionSkip( Command & cmd )
     Battle::Unit * battle = GetTroopUID( uid );
     if ( battle && battle->isValid() ) {
         if ( !battle->Modes( TR_MOVED ) ) {
-            if ( hard ) {
+            if ( hard || battle->Modes( TR_SKIPMOVE ) ) {
                 battle->SetModes( TR_HARDSKIP );
-                battle->SetModes( TR_SKIPMOVE );
                 battle->SetModes( TR_MOVED );
                 if ( Settings::Get().ExtBattleSkipIncreaseDefense() )
                     battle->SetModes( TR_DEFENSED );
             }
-            else
-                battle->SetModes( battle->Modes( TR_SKIPMOVE ) ? TR_MOVED : TR_SKIPMOVE );
+
+            battle->SetModes( TR_SKIPMOVE );
 
             if ( interface )
                 interface->RedrawActionSkipStatus( *battle );

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -393,9 +393,10 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
             }
 
             // good morale
-            if ( !end_turn && troop->isValid() && !troop->Modes( TR_SKIPMOVE ) && troop->Modes( TR_MOVED ) && troop->Modes( MORALE_GOOD ) && !isImmovable ) {
-                actions.push_back( Command( MSG_BATTLE_MORALE, troop->GetUID(), true ) );
-                end_turn = false;
+            if ( !end_turn && troop->isValid() && troop->Modes( TR_MOVED ) && troop->Modes( MORALE_GOOD ) && !isImmovable ) {
+                if ( troopHasAlreadySkippedMove ? !troop->Modes( TR_HARDSKIP ) : !troop->Modes( TR_SKIPMOVE ) ) {
+                    actions.push_back( Command( MSG_BATTLE_MORALE, troop->GetUID(), true ) );
+                }
             }
         }
 

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -352,7 +352,8 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
         if ( !troop->isValid() ) { // looks like the unit died
             end_turn = true;
         }
-        else if ( troop->Modes( MORALE_BAD ) ) { // bad morale
+        else if ( troop->Modes( MORALE_BAD ) && !troop->Modes( TR_SKIPMOVE ) ) {
+            // bad morale, happens only if the unit wasn't waiting for a turn
             actions.push_back( Command( MSG_BATTLE_MORALE, troop->GetUID(), false ) );
             end_turn = true;
         }

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -396,7 +396,7 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
             // good morale
             if ( !end_turn && troop->isValid() && troop->Modes( TR_MOVED ) && troop->Modes( MORALE_GOOD ) && !isImmovable ) {
                 if ( troopHasAlreadySkippedMove ? !troop->Modes( TR_HARDSKIP ) : !troop->Modes( TR_SKIPMOVE ) ) {
-                    actions.push_back( Command( MSG_BATTLE_MORALE, troop->GetUID(), true ) );
+                    actions.emplace_back( MSG_BATTLE_MORALE, troop->GetUID(), true );
                 }
             }
         }

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -393,11 +393,11 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
                 break;
             }
 
+            const bool troopSkipsMove = troopHasAlreadySkippedMove ? troop->Modes( TR_HARDSKIP ) : troop->Modes( TR_SKIPMOVE );
+
             // good morale
-            if ( !end_turn && troop->isValid() && troop->Modes( TR_MOVED ) && troop->Modes( MORALE_GOOD ) && !isImmovable ) {
-                if ( troopHasAlreadySkippedMove ? !troop->Modes( TR_HARDSKIP ) : !troop->Modes( TR_SKIPMOVE ) ) {
-                    actions.emplace_back( MSG_BATTLE_MORALE, troop->GetUID(), true );
-                }
+            if ( !end_turn && troop->isValid() && troop->Modes( TR_MOVED ) && troop->Modes( MORALE_GOOD ) && !isImmovable && !troopSkipsMove ) {
+                actions.emplace_back( MSG_BATTLE_MORALE, troop->GetUID(), true );
             }
         }
 

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -423,13 +423,13 @@ void Battle::Unit::NewTurn( void )
 
     ResetModes( TR_RESPONSED );
     ResetModes( TR_MOVED );
-    ResetModes( TR_SKIPMOVE );
     ResetModes( TR_HARDSKIP );
+    ResetModes( TR_SKIPMOVE );
     ResetModes( TR_DEFENSED );
-    ResetModes( MORALE_BAD );
-    ResetModes( MORALE_GOOD );
-    ResetModes( LUCK_BAD );
     ResetModes( LUCK_GOOD );
+    ResetModes( LUCK_BAD );
+    ResetModes( MORALE_GOOD );
+    ResetModes( MORALE_BAD );
 
     // decrease spell duration
     affected.DecreaseDuration();
@@ -663,13 +663,15 @@ void Battle::Unit::PostKilledAction( void )
         mirror = NULL;
     }
 
-    ResetModes( IS_MAGIC );
     ResetModes( TR_RESPONSED );
+    ResetModes( TR_HARDSKIP );
     ResetModes( TR_SKIPMOVE );
+    ResetModes( TR_DEFENSED );
     ResetModes( LUCK_GOOD );
     ResetModes( LUCK_BAD );
     ResetModes( MORALE_GOOD );
     ResetModes( MORALE_BAD );
+    ResetModes( IS_MAGIC );
 
     SetModes( TR_MOVED );
 


### PR DESCRIPTION
As @Branikolog [rightly pointed out](https://github.com/ihhub/fheroes2/pull/3095#issuecomment-816917628), at this time troops after waiting can't get a positive morale event, just a negative one, and this doesn't look fair. This PR is called to correct this injustice.

Also, although it may seem that pressing the wait button again is the same as skipping turn, it's actually not quite the same thing, which I think is also not quite right. This PR removes those subtle differences.