### PR TITLE
Partially migrate Linux builds from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/linux_pull_request.yml
+++ b/.github/workflows/linux_pull_request.yml
@@ -1,0 +1,36 @@
+name: Linux
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  sdl1:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
+    - name: install SDL 1
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libsdl1.2-dev libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl-image1.2-dev gettext
+    - name: compile
+      run: make -j 2
+      env:
+        FHEROES2_SDL1: "ON"
+        FHEROES2_STRICT_COMPILATION: "ON"
+  sdl2:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
+    - name: install SDL 2
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev gettext
+    - name: compile
+      run: make -j 2
+      env:
+        FHEROES2_STRICT_COMPILATION: "ON"

--- a/.github/workflows/linux_pull_request.yml
+++ b/.github/workflows/linux_pull_request.yml
@@ -34,3 +34,29 @@ jobs:
       run: make -j 2
       env:
         FHEROES2_STRICT_COMPILATION: "ON"
+  psv-sdl2:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
+    - name: install libs
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libgcc1 gettext
+    - name: setup Vita SDK
+      run: |
+        git clone https://github.com/vitasdk/vdpm
+        cd vdpm
+        export PATH=$VITASDK/bin:$PATH
+        ./bootstrap-vitasdk.sh
+        ./install-all.sh
+      env:
+        VITASDK: "/usr/local/vitasdk"
+    - name: compile
+      run: |
+        export PATH=$VITASDK/bin:$PATH
+        make -f Makefile.vita -j 2
+      env:
+        FHEROES2_STRICT_COMPILATION: "ON"
+        VITASDK: "/usr/local/vitasdk"

--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -62,3 +62,44 @@ jobs:
         allowUpdates: true
         prerelease: true
         replacesArtifacts: true
+  psv-sdl2:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
+    - name: install libs
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libgcc1 gettext
+    - name: setup Vita SDK
+      run: |
+        git clone https://github.com/vitasdk/vdpm
+        cd vdpm
+        export PATH=$VITASDK/bin:$PATH
+        ./bootstrap-vitasdk.sh
+        ./install-all.sh
+      env:
+        VITASDK: "/usr/local/vitasdk"
+    - name: compile
+      run: |
+        export PATH=$VITASDK/bin:$PATH
+        make -f Makefile.vita -j 2
+      env:
+        FHEROES2_STRICT_COMPILATION: "ON"
+        VITASDK: "/usr/local/vitasdk"
+    - name: create package
+      run: |
+        cp doc/README.txt .
+        cp doc/README_PSV.md .
+        zip fheroes2_psv_sdl2.zip fheroes2.vpk LICENSE fheroes2.key changelog.txt README.txt README_PSV.md
+    - uses: ncipollo/release-action@v1
+      with:
+        artifacts: fheroes2_psv_sdl2.zip
+        body: ${{ github.event.commits[0].message }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: PS Vita build with SDL 2.0 support (latest commit)
+        tag: fheroes2-psv-sdl2_dev
+        allowUpdates: true
+        prerelease: true
+        replacesArtifacts: true

--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -1,0 +1,64 @@
+name: Linux (release)
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  sdl1:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
+    - name: install SDL 1
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libsdl1.2-dev libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl-image1.2-dev gettext
+    - name: compile
+      run: make -j 2
+      env:
+        FHEROES2_SDL1: "ON"
+        FHEROES2_STRICT_COMPILATION: "ON"
+    - name: create package
+      run: |
+        cp doc/README.txt .
+        zip fheroes2_ubuntu_sdl1.zip fheroes2 LICENSE fheroes2.key script/linux/install_sdl_1.sh script/demo/demo_linux.sh changelog.txt README.txt
+    - uses: ncipollo/release-action@v1
+      with:
+        artifacts: fheroes2_ubuntu_sdl1.zip
+        body: ${{ github.event.commits[0].message }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: Ubuntu (Linux) build with SDL 1.2 support (latest commit)
+        tag: fheroes2-linux-sdl1_dev
+        allowUpdates: true
+        prerelease: true
+        replacesArtifacts: true
+  sdl2:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
+    - name: install SDL 2
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev gettext
+    - name: compile
+      run: make -j 2
+      env:
+        FHEROES2_STRICT_COMPILATION: "ON"
+    - name: create package
+      run: |
+        cp doc/README.txt .
+        zip fheroes2_ubuntu_sdl2.zip fheroes2 LICENSE fheroes2.key script/linux/install_sdl_2.sh script/demo/demo_linux.sh changelog.txt README.txt
+    - uses: ncipollo/release-action@v1
+      with:
+        artifacts: fheroes2_ubuntu_sdl2.zip
+        body: ${{ github.event.commits[0].message }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: Ubuntu (Linux) build with SDL 2.0 support (latest commit)
+        tag: fheroes2-linux-sdl2_dev
+        allowUpdates: true
+        prerelease: true
+        replacesArtifacts: true

--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: ncipollo/release-action@v1
       with:
         artifacts: fheroes2_macos10_15_sdl1.zip
-        body: Compiled version of ${{ github.sha }} commit
+        body: ${{ github.event.commits[0].message }}
         token: ${{ secrets.GITHUB_TOKEN }}
         name: MacOS build with SDL 1 support (latest commit)
         tag: fheroes2-osx-sdl1_dev
@@ -55,7 +55,7 @@ jobs:
     - uses: ncipollo/release-action@v1
       with:
         artifacts: fheroes2_macos10_15_sdl2.zip
-        body: Compiled version of ${{ github.sha }} commit
+        body: ${{ github.event.commits[0].message }}
         token: ${{ secrets.GITHUB_TOKEN }}
         name: MacOS build with SDL 2 support (latest commit)
         tag: fheroes2-osx-sdl2_dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,50 +31,6 @@ matrix:
         # file to see the specific configuration
         - sonar-scanner -Dsonar.cfamily.build-wrapper-output=bw-output
     - os: linux
-      name: "Ubuntu (Linux) with SDL 1.2"
-      before_install:
-        - sudo apt-get update
-        - sudo apt-get install -y libsdl1.2-dev libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl-image1.2-dev
-        - export FHEROES2_SDL1="ON" FHEROES2_STRICT_COMPILATION="ON"
-      before_deploy:
-        - cp doc/README.txt .
-        - zip fheroes2_ubuntu_sdl1.zip fheroes2 LICENSE fheroes2.key script/linux/install_sdl_1.sh script/demo/demo_linux.sh changelog.txt README.txt
-        - export TRAVIS_TAG=fheroes2-linux-sdl1_dev
-        - git tag -f $TRAVIS_TAG
-      deploy:
-        provider: releases
-        api_key: "$GITHUB_OAUTH_TOKEN"
-        file: "fheroes2_ubuntu_sdl1.zip"
-        name: Ubuntu (Linux) build with SDL 1.2 support (latest commit)
-        body: Compiled version of $TRAVIS_COMMIT commit
-        prerelease: true
-        overwrite: true
-        skip_cleanup: true
-        on:
-          branch: master
-    - os: linux
-      name: "Ubuntu (Linux) with SDL 2.0"
-      before_install:
-        - sudo apt-get update
-        - sudo apt-get install -y libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
-        - export FHEROES2_STRICT_COMPILATION="ON"
-      before_deploy:
-        - cp doc/README.txt .
-        - zip fheroes2_ubuntu_sdl2.zip fheroes2 LICENSE fheroes2.key script/linux/install_sdl_2.sh script/demo/demo_linux.sh changelog.txt README.txt
-        - export TRAVIS_TAG=fheroes2-linux-sdl2_dev
-        - git tag -f $TRAVIS_TAG
-      deploy:
-        provider: releases
-        api_key: "$GITHUB_OAUTH_TOKEN"
-        file: "fheroes2_ubuntu_sdl2.zip"
-        name: Ubuntu (Linux) build with SDL 2.0 support (latest commit)
-        body: Compiled version of $TRAVIS_COMMIT commit
-        prerelease: true
-        overwrite: true
-        skip_cleanup: true
-        on:
-          branch: master
-    - os: linux
       arch: arm64
       name: "Ubuntu (Linux) ARM with SDL 1.2"
       before_install:
@@ -114,38 +70,6 @@ matrix:
         api_key: "$GITHUB_OAUTH_TOKEN"
         file: "fheroes2_ubuntu_arm_sdl2.zip"
         name: Ubuntu (Linux) ARM build with SDL 2.0 support (latest commit)
-        body: Compiled version of $TRAVIS_COMMIT commit
-        prerelease: true
-        overwrite: true
-        skip_cleanup: true
-        on:
-          branch: master
-    - os: linux
-      name: "PSV with SDL 2.0"
-      before_install:
-        - sudo apt-get install libgcc1
-        - git clone https://github.com/vitasdk/vdpm
-        - cd vdpm
-        - export VITASDK=/usr/local/vitasdk
-        - export PATH=$VITASDK/bin:$PATH # add vitasdk tool to $PATH
-        - ./bootstrap-vitasdk.sh
-        - ./install-all.sh
-        - cd ..
-        - export FHEROES2_STRICT_COMPILATION="ON"
-      script:
-        - |
-          make -f Makefile.vita -j 2
-      before_deploy:
-        - cp doc/README.txt .
-        - cp doc/README_PSV.md .
-        - zip fheroes2_psv_sdl2.zip fheroes2.vpk LICENSE fheroes2.key changelog.txt README.txt README_PSV.md
-        - export TRAVIS_TAG=fheroes2-psv-sdl2_dev
-        - git tag -f $TRAVIS_TAG
-      deploy:
-        provider: releases
-        api_key: "$GITHUB_OAUTH_TOKEN"
-        file: "fheroes2_psv_sdl2.zip"
-        name: PS Vita build with SDL 2.0 support (latest commit)
         body: Compiled version of $TRAVIS_COMMIT commit
         prerelease: true
         overwrite: true


### PR DESCRIPTION
Recently I noticed that recent snapshot builds are not available for Linux anymore, latest available build is for commit from May 2020. This PR is intended to partially solve this problem (test builds and snapshot builds for x86 and PSV at least). Also it implements more readable description for macOS builds.