### PR TITLE
Display correct message when capturing abandoned mine

### DIFF
--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2055,6 +2055,7 @@ void ActionToCaptureObject( Heroes & hero, u32 obj, s32 dst_index )
         body = _( "You gain control of a sawmill. It will provide you with %{count} units of wood per day." );
         break;
 
+    case MP2::OBJ_ABANDONEDMINE:
     case MP2::OBJ_MINES: {
         resource = tile.QuantityResourceCount().first;
         header = Maps::GetMinesName( resource );
@@ -2079,10 +2080,6 @@ void ActionToCaptureObject( Heroes & hero, u32 obj, s32 dst_index )
             break;
         }
     } break;
-
-    case MP2::OBJ_ABANDONEDMINE:
-        body = _( "You beat the Ghosts and are able to restore the mine to production." );
-        break;
 
     case MP2::OBJ_LIGHTHOUSE:
         header = MP2::StringObject( obj );


### PR DESCRIPTION
fix for #1368

In this commit, the message displayed when capturing a mine is changed.
Previously, it said the Ghosts were beaten and the mine was restored.
Now, the message says the type of mine captured and the amount of
resources generated per day.