### PR TITLE
Force the scan-build workflow to fail if any bugs found

### DIFF
--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -18,7 +18,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev gettext clang-tools
     - name: compile
-      run: scan-build -v make -j 2
+      run: scan-build --status-bugs -v make -j 2
       env:
         WITHOUT_XML: "ON"
         FHEROES2_STRICT_COMPILATION: "ON"

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -267,6 +267,8 @@ void Kingdom::RemoveHeroes( const Heroes * hero )
             player->GetFocus().Reset();
         }
 
+        assert( hero != nullptr );
+
         AI::Get().HeroesRemove( *hero );
     }
 
@@ -301,6 +303,8 @@ void Kingdom::RemoveCastle( const Castle * castle )
         if ( player && player->GetFocus().GetCastle() == castle ) {
             player->GetFocus().Reset();
         }
+
+        assert( castle != nullptr );
 
         AI::Get().CastleRemove( *castle );
     }


### PR DESCRIPTION
As far as I noticed, currently the scan-build workflow doesn't fail if any bugs are found. This PR fixes this. Also it fixes the following false-positives (reported also by SonarCloud):

https://sonarcloud.io/project/issues?id=ihhub_fheroes2&open=AXhxYwUmQocKC9FrtX__&resolved=false&rules=cpp%3AS2259&types=BUG
https://sonarcloud.io/project/issues?id=ihhub_fheroes2&open=AXhxYwUmQocKC9FrtYAA&resolved=false&rules=cpp%3AS2259&types=BUG

As far as I can tell, there is no way that `hero` and `castle` can somehow become `nullptr` here, so I added `assert()` calls to convince scan-build of this.