### PR TITLE
Fix saving scroll speed in the game config file

### DIFF
--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -764,7 +764,27 @@ std::string Settings::String( void ) const
     os << "battle speed = " << battle_speed << std::endl;
 
     os << std::endl << "# scroll speed: 1 - 4" << std::endl;
-    os << "scroll speed = " << scroll_speed << std::endl;
+    os << "scroll speed = ";
+
+    switch ( scroll_speed ) {
+    case SCROLL_SLOW:
+        os << 1;
+        break;
+    case SCROLL_NORMAL:
+        os << 2;
+        break;
+    case SCROLL_FAST1:
+        os << 3;
+        break;
+    case SCROLL_FAST2:
+        os << 4;
+        break;
+    default:
+        os << 2;
+        break;
+    }
+
+    os << std::endl;
 
     os << std::endl << "# show battle grid: on off" << std::endl;
     os << "battle grid = " << ( opt_global.Modes( GLOBAL_BATTLE_SHOW_GRID ) ? "on" : "off" ) << std::endl;


### PR DESCRIPTION
Currently in Settings::Read() scroll speed is expected in range 1-4, but in Settings::String() it is saved "as is" (4-32).