### PR TITLE
Fix redrawing some objects near hero

### DIFF
--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -667,13 +667,19 @@ void Heroes::RedrawTop( fheroes2::Image & dst, const Rect & visibleTileROI, cons
     }
 
     if ( _redrawIndex.topOnBottom != -1 ) {
-        world.GetTiles( _redrawIndex.topOnBottom ).RedrawTop( dst, visibleTileROI, area );
+        const Maps::Tiles & tileBottom = world.GetTiles( _redrawIndex.topOnBottom );
+        tileBottom.RedrawTop( dst, visibleTileROI, area );
+        tileBottom.RedrawTopFromBottom( dst, visibleTileROI, area );
     }
     if ( _redrawIndex.topOnDirection != -1 ) {
-        world.GetTiles( _redrawIndex.topOnDirection ).RedrawTop( dst, visibleTileROI, area );
+        const Maps::Tiles & tileDirection = world.GetTiles( _redrawIndex.topOnDirection );
+        tileDirection.RedrawTop( dst, visibleTileROI, area );
+        tileDirection.RedrawTopFromBottom( dst, visibleTileROI, area );
     }
     if ( _redrawIndex.topOnDirectionBottom != -1 ) {
-        world.GetTiles( _redrawIndex.topOnDirectionBottom ).RedrawTop( dst, visibleTileROI, area );
+        const Maps::Tiles & tileDirectionBottom = world.GetTiles( _redrawIndex.topOnDirectionBottom );
+        tileDirectionBottom.RedrawTop( dst, visibleTileROI, area );
+        tileDirectionBottom.RedrawTopFromBottom( dst, visibleTileROI, area );
     }
 }
 

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -669,17 +669,17 @@ void Heroes::RedrawTop( fheroes2::Image & dst, const Rect & visibleTileROI, cons
     if ( _redrawIndex.topOnBottom != -1 ) {
         const Maps::Tiles & tileBottom = world.GetTiles( _redrawIndex.topOnBottom );
         tileBottom.RedrawTop( dst, visibleTileROI, area );
-        tileBottom.RedrawTopFromBottom( dst, visibleTileROI, area );
+        tileBottom.RedrawTopFromBottom( dst, area );
     }
     if ( _redrawIndex.topOnDirection != -1 ) {
         const Maps::Tiles & tileDirection = world.GetTiles( _redrawIndex.topOnDirection );
         tileDirection.RedrawTop( dst, visibleTileROI, area );
-        tileDirection.RedrawTopFromBottom( dst, visibleTileROI, area );
+        tileDirection.RedrawTopFromBottom( dst, area );
     }
     if ( _redrawIndex.topOnDirectionBottom != -1 ) {
         const Maps::Tiles & tileDirectionBottom = world.GetTiles( _redrawIndex.topOnDirectionBottom );
         tileDirectionBottom.RedrawTop( dst, visibleTileROI, area );
-        tileDirectionBottom.RedrawTopFromBottom( dst, visibleTileROI, area );
+        tileDirectionBottom.RedrawTopFromBottom( dst, area );
     }
 }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1671,6 +1671,21 @@ void Maps::Tiles::RedrawTop( fheroes2::Image & dst, const Rect & visibleTileROI,
     RedrawAddon( dst, addons_level2, visibleTileROI, false, area );
 }
 
+void Maps::Tiles::RedrawTopFromBottom( fheroes2::Image & dst, const Rect & visibleTileROI, const Interface::GameArea & area ) const
+{
+    if ( !Maps::isValidDirection( maps_index, Direction::BOTTOM ) ) {
+        return;
+    }
+    const Maps::Tiles & tile = world.GetTiles( Maps::GetDirectionIndex( maps_index, Direction::BOTTOM ) );
+    const Point mp = Maps::GetPoint( tile.GetIndex() );
+    for ( const Maps::TilesAddon & addon : tile.addons_level2 ) {
+        const int icn = MP2::GetICNObject( addon.object );
+        if ( icn == ICN::FLAG32 ) {
+            area.BlitOnTile( dst, fheroes2::AGG::GetICN( icn, addon.index ), mp );
+        }
+    }
+}
+
 void Maps::Tiles::RedrawTop4Hero( fheroes2::Image & dst, const Rect & visibleTileROI, bool skip_ground, const Interface::GameArea & area ) const
 {
     const Point mp = Maps::GetPoint( GetIndex() );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1671,7 +1671,7 @@ void Maps::Tiles::RedrawTop( fheroes2::Image & dst, const Rect & visibleTileROI,
     RedrawAddon( dst, addons_level2, visibleTileROI, false, area );
 }
 
-void Maps::Tiles::RedrawTopFromBottom( fheroes2::Image & dst, const Rect & visibleTileROI, const Interface::GameArea & area ) const
+void Maps::Tiles::RedrawTopFromBottom( fheroes2::Image & dst, const Interface::GameArea & area ) const
 {
     if ( !Maps::isValidDirection( maps_index, Direction::BOTTOM ) ) {
         return;

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -200,7 +200,7 @@ namespace Maps
         void RedrawBottom( fheroes2::Image & dst, const Rect & visibleTileROI, bool isPuzzleDraw, const Interface::GameArea & area ) const;
         void RedrawBottom4Hero( fheroes2::Image & dst, const Rect & visibleTileROI, const Interface::GameArea & area ) const;
         void RedrawTop( fheroes2::Image & dst, const Rect & visibleTileROI, const Interface::GameArea & area ) const;
-        void RedrawTopFromBottom( fheroes2::Image & dst, const Rect & visibleTileROI, const Interface::GameArea & area ) const;
+        void RedrawTopFromBottom( fheroes2::Image & dst, const Interface::GameArea & area ) const;
         void RedrawTop4Hero( fheroes2::Image & dst, const Rect & visibleTileROI, bool skip_ground, const Interface::GameArea & area ) const;
         void RedrawObjects( fheroes2::Image & dst, bool isPuzzleDraw, const Interface::GameArea & area ) const;
         void RedrawBoat( fheroes2::Image & dst, const Rect & visibleTileROI, const Interface::GameArea & area ) const;

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -200,6 +200,7 @@ namespace Maps
         void RedrawBottom( fheroes2::Image & dst, const Rect & visibleTileROI, bool isPuzzleDraw, const Interface::GameArea & area ) const;
         void RedrawBottom4Hero( fheroes2::Image & dst, const Rect & visibleTileROI, const Interface::GameArea & area ) const;
         void RedrawTop( fheroes2::Image & dst, const Rect & visibleTileROI, const Interface::GameArea & area ) const;
+        void RedrawTopFromBottom( fheroes2::Image & dst, const Rect & visibleTileROI, const Interface::GameArea & area ) const;
         void RedrawTop4Hero( fheroes2::Image & dst, const Rect & visibleTileROI, bool skip_ground, const Interface::GameArea & area ) const;
         void RedrawObjects( fheroes2::Image & dst, bool isPuzzleDraw, const Interface::GameArea & area ) const;
         void RedrawBoat( fheroes2::Image & dst, const Rect & visibleTileROI, const Interface::GameArea & area ) const;


### PR DESCRIPTION
If we redraw top objects on tile near hero, we should also redraw some top objets below this tile.
Before
![h2](https://user-images.githubusercontent.com/24250224/114781270-21e61180-9d81-11eb-995b-64587210079e.jpg)
After
![h1](https://user-images.githubusercontent.com/24250224/114781284-27435c00-9d81-11eb-8c9b-c8849aa80481.jpg)