### PR TITLE
Code cleanup

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -416,34 +416,6 @@ double Troops::GetStrength() const
     return strength;
 }
 
-u32 Troops::GetAttack( void ) const
-{
-    u32 res = 0;
-    u32 count = 0;
-
-    for ( const_iterator it = begin(); it != end(); ++it )
-        if ( ( *it )->isValid() ) {
-            res += static_cast<Monster *>( *it )->GetAttack();
-            ++count;
-        }
-
-    return count ? res / count : 0;
-}
-
-u32 Troops::GetDefense( void ) const
-{
-    u32 res = 0;
-    u32 count = 0;
-
-    for ( const_iterator it = begin(); it != end(); ++it )
-        if ( ( *it )->isValid() ) {
-            res += static_cast<Monster *>( *it )->GetDefense();
-            ++count;
-        }
-
-    return count ? res / count : 0;
-}
-
 u32 Troops::GetHitPoints( void ) const
 {
     u32 res = 0;
@@ -453,34 +425,6 @@ u32 Troops::GetHitPoints( void ) const
             res += ( *it )->GetHitPoints();
 
     return res;
-}
-
-u32 Troops::GetDamageMin( void ) const
-{
-    u32 res = 0;
-    u32 count = 0;
-
-    for ( const_iterator it = begin(); it != end(); ++it )
-        if ( ( *it )->isValid() ) {
-            res += ( *it )->GetDamageMin();
-            ++count;
-        }
-
-    return count ? res / count : 0;
-}
-
-u32 Troops::GetDamageMax( void ) const
-{
-    u32 res = 0;
-    u32 count = 0;
-
-    for ( const_iterator it = begin(); it != end(); ++it )
-        if ( ( *it )->isValid() ) {
-            res += ( *it )->GetDamageMax();
-            ++count;
-        }
-
-    return count ? res / count : 0;
 }
 
 void Troops::Clean( void )
@@ -1037,26 +981,6 @@ void Army::SetColor( int cl )
     color = cl;
 }
 
-int Army::GetRace( void ) const
-{
-    std::vector<int> races;
-    races.reserve( size() );
-
-    for ( const_iterator it = begin(); it != end(); ++it )
-        if ( ( *it )->isValid() )
-            races.push_back( ( *it )->GetRace() );
-
-    std::sort( races.begin(), races.end() );
-    races.resize( std::distance( races.begin(), std::unique( races.begin(), races.end() ) ) );
-
-    if ( races.empty() ) {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, "empty" );
-        return Race::NONE;
-    }
-
-    return 1 < races.size() ? Race::MULT : races[0];
-}
-
 int Army::GetLuck( void ) const
 {
     const HeroBase * currentCommander = GetCommander();
@@ -1207,34 +1131,6 @@ int Army::GetMoraleModificator( std::string * strs ) const
     }
 
     return result;
-}
-
-u32 Army::GetAttack( void ) const
-{
-    u32 res = 0;
-    u32 count = 0;
-
-    for ( const_iterator it = begin(); it != end(); ++it )
-        if ( ( *it )->isValid() ) {
-            res += ( *it )->GetAttack();
-            ++count;
-        }
-
-    return count ? res / count : 0;
-}
-
-u32 Army::GetDefense( void ) const
-{
-    u32 res = 0;
-    u32 count = 0;
-
-    for ( const_iterator it = begin(); it != end(); ++it )
-        if ( ( *it )->isValid() ) {
-            res += ( *it )->GetDefense();
-            ++count;
-        }
-
-    return count ? res / count : 0;
 }
 
 double Army::GetStrength( void ) const

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -86,13 +86,9 @@ public:
     void MergeTroops();
     Troops GetOptimized( void ) const;
 
-    virtual u32 GetAttack( void ) const;
-    virtual u32 GetDefense( void ) const;
     virtual double GetStrength() const;
 
     u32 GetHitPoints( void ) const;
-    u32 GetDamageMin( void ) const;
-    u32 GetDamageMax( void ) const;
 
     void Clean( void );
     void UpgradeTroops( const Castle & );
@@ -158,11 +154,8 @@ public:
     void Reset( bool = false ); // reset: soft or hard
     void setFromTile( const Maps::Tiles & tile );
 
-    int GetRace( void ) const;
     int GetColor( void ) const;
     int GetControl( void ) const override;
-    u32 GetAttack( void ) const override;
-    u32 GetDefense( void ) const override;
 
     double GetStrength() const override;
     double getReinforcementValue( const Troops & reinforcement ) const;

--- a/src/fheroes2/battle/battle.h
+++ b/src/fheroes2/battle/battle.h
@@ -66,9 +66,6 @@ namespace Battle
         u32 GetExperienceDefender( void ) const;
     };
 
-    StreamBase & operator<<( StreamBase &, const Result & );
-    StreamBase & operator>>( StreamBase &, Result & );
-
     Result Loader( Army &, Army &, s32 );
 
     struct TargetInfo
@@ -89,16 +86,10 @@ namespace Battle
         static bool isFinishAnimFrame( const TargetInfo & info );
     };
 
-    StreamBase & operator<<( StreamBase &, const TargetInfo & );
-    StreamBase & operator>>( StreamBase &, TargetInfo & );
-
     struct TargetsInfo : public std::vector<TargetInfo>
     {
         TargetsInfo() = default;
     };
-
-    StreamBase & operator<<( StreamBase &, const TargetsInfo & );
-    StreamBase & operator>>( StreamBase &, TargetsInfo & );
 
     enum MonsterState : uint32_t
     {

--- a/src/fheroes2/battle/battle_animation.cpp
+++ b/src/fheroes2/battle/battle_animation.cpp
@@ -96,23 +96,12 @@ int AnimationSequence::firstFrame() const
     return isValid() ? _seq.front() : 0;
 }
 
-void AnimationSequence::setToLastFrame()
-{
-    if ( isValid() )
-        _currentFrame = _seq.size() - 1;
-}
-
 double AnimationSequence::movementProgress() const
 {
     if ( _seq.size() > 1 )
         return static_cast<double>( _currentFrame ) / ( static_cast<double>( animationLength() ) );
 
     return 0;
-}
-
-bool AnimationSequence::isFirstFrame() const
-{
-    return _currentFrame == 0;
 }
 
 bool AnimationSequence::isLastFrame() const
@@ -123,69 +112,6 @@ bool AnimationSequence::isLastFrame() const
 bool AnimationSequence::isValid() const
 {
     return !_seq.empty();
-}
-
-TimedSequence::TimedSequence( const std::vector<int> & seq, uint32_t duration )
-    : AnimationSequence( seq )
-    , _currentTime( 0 )
-    , _duration( duration )
-{}
-
-int TimedSequence::playAnimation( uint32_t delta, bool loop )
-{
-    _currentTime += delta;
-    if ( _currentTime > _duration ) {
-        _currentTime = loop ? _currentTime % _duration : _duration;
-    }
-
-    _currentFrame = getFrameID( _currentTime );
-    return getFrame();
-}
-
-int TimedSequence::restartAnimation()
-{
-    _currentTime = 0;
-    _currentFrame = 0;
-    return getFrame();
-}
-
-int TimedSequence::getFrameAt( uint32_t time ) const
-{
-    return isValid() ? _seq[getFrameID( time )] : 0;
-}
-
-size_t TimedSequence::getFrameID( uint32_t time ) const
-{
-    // isValid makes sure duration and length is not 0
-    if ( isValid() ) {
-        const size_t frame = static_cast<size_t>( time / ( _duration / static_cast<double>( animationLength() ) ) );
-        // check if time >= duration
-        return ( frame < animationLength() ) ? frame : animationLength() - 1;
-    }
-    return 0;
-}
-
-uint32_t TimedSequence::getCurrentTime() const
-{
-    return _currentTime;
-}
-
-uint32_t TimedSequence::getDuration() const
-{
-    return _duration;
-}
-
-double TimedSequence::movementProgress() const
-{
-    if ( isValid() )
-        return static_cast<double>( _currentTime ) / static_cast<double>( _duration );
-
-    return 0;
-}
-
-bool TimedSequence::isValid() const
-{
-    return !_seq.empty() && _currentTime <= _duration && _duration > 0;
 }
 
 AnimationReference::AnimationReference()
@@ -439,11 +365,6 @@ std::vector<int> AnimationReference::getAnimationOffset( int animState ) const
     return offset;
 }
 
-AnimationSequence AnimationReference::getAnimationSequence( int animState ) const
-{
-    return AnimationSequence( getAnimationVector( animState ) );
-}
-
 uint32_t AnimationReference::getMoveSpeed() const
 {
     return _monsterInfo.moveSpeed;
@@ -457,11 +378,6 @@ uint32_t AnimationReference::getFlightSpeed() const
 uint32_t AnimationReference::getShootingSpeed() const
 {
     return _monsterInfo.shootSpeed;
-}
-
-size_t AnimationReference::getProjectileID( const double angle ) const
-{
-    return _monsterInfo.getProjectileID( angle );
 }
 
 fheroes2::Point AnimationReference::getBlindOffset() const
@@ -566,19 +482,9 @@ int AnimationState::firstFrame() const
     return _currentSequence.firstFrame();
 }
 
-void AnimationState::setToLastFrame()
-{
-    return _currentSequence.setToLastFrame();
-}
-
 double AnimationState::movementProgress() const
 {
     return _currentSequence.movementProgress();
-}
-
-bool AnimationState::isFirstFrame() const
-{
-    return _currentSequence.isFirstFrame();
 }
 
 bool AnimationState::isLastFrame() const

--- a/src/fheroes2/battle/battle_animation.h
+++ b/src/fheroes2/battle/battle_animation.h
@@ -59,41 +59,17 @@ public:
 
     int playAnimation( bool loop = false );
     virtual int restartAnimation();
-    void setToLastFrame();
 
     int getFrame() const;
     int firstFrame() const;
     size_t animationLength() const;
     virtual double movementProgress() const;
-    bool isFirstFrame() const;
     bool isLastFrame() const;
     virtual bool isValid() const;
 
 protected:
     std::vector<int> _seq;
     size_t _currentFrame;
-};
-
-class TimedSequence : public AnimationSequence
-{
-public:
-    TimedSequence( const std::vector<int> & seq, uint32_t duration );
-
-    int playAnimation( uint32_t delta, bool loop = false );
-    virtual int restartAnimation();
-
-    int getFrameAt( uint32_t time ) const;
-    uint32_t getCurrentTime() const;
-    uint32_t getDuration() const;
-    virtual double movementProgress() const;
-    virtual bool isValid() const;
-
-private:
-    uint32_t _currentTime;
-    uint32_t _duration;
-
-    // Private function: make sure object is valid before calling this
-    size_t getFrameID( uint32_t time ) const;
 };
 
 class AnimationReference
@@ -106,11 +82,9 @@ public:
 
     const std::vector<int> & getAnimationVector( int animState ) const;
     std::vector<int> getAnimationOffset( int animState ) const;
-    AnimationSequence getAnimationSequence( int animState ) const;
     uint32_t getMoveSpeed() const;
     uint32_t getFlightSpeed() const;
     uint32_t getShootingSpeed() const;
-    size_t getProjectileID( const double angle ) const;
     fheroes2::Point getBlindOffset() const;
     fheroes2::Point getProjectileOffset( size_t direction ) const;
     int getTroopCountOffset( bool isReflect ) const;
@@ -149,13 +123,11 @@ public:
     // pass-down methods
     int playAnimation( bool loop = false );
     int restartAnimation();
-    void setToLastFrame();
 
     int getFrame() const;
     int firstFrame() const;
     size_t animationLength() const;
     double movementProgress() const;
-    bool isFirstFrame() const;
     bool isLastFrame() const;
     bool isValid() const;
 

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -101,45 +101,6 @@ int GetCovr( int ground )
     return covrs.empty() ? ICN::UNKNOWN : Rand::Get( covrs );
 }
 
-StreamBase & Battle::operator<<( StreamBase & msg, const TargetInfo & t )
-{
-    return msg << ( t.defender ? t.defender->GetUID() : static_cast<u32>( 0 ) ) << t.damage << t.killed << t.resist;
-}
-
-StreamBase & Battle::operator>>( StreamBase & msg, TargetInfo & t )
-{
-    u32 uid = 0;
-
-    msg >> uid >> t.damage >> t.killed >> t.resist;
-
-    t.defender = uid ? GetArena()->GetTroopUID( uid ) : NULL;
-
-    return msg;
-}
-
-StreamBase & Battle::operator<<( StreamBase & msg, const TargetsInfo & ts )
-{
-    msg << static_cast<u32>( ts.size() );
-
-    for ( TargetsInfo::const_iterator it = ts.begin(); it != ts.end(); ++it )
-        msg << *it;
-
-    return msg;
-}
-
-StreamBase & Battle::operator>>( StreamBase & msg, TargetsInfo & ts )
-{
-    u32 size = 0;
-
-    msg >> size;
-    ts.resize( size );
-
-    for ( TargetsInfo::iterator it = ts.begin(); it != ts.end(); ++it )
-        msg >> *it;
-
-    return msg;
-}
-
 bool Battle::TargetInfo::operator==( const TargetInfo & ta ) const
 {
     return defender == ta.defender;
@@ -690,11 +651,6 @@ uint32_t Battle::Arena::CalculateMoveDistance( int32_t indexTo ) const
     return Board::isValidIndex( indexTo ) ? _pathfinder.getDistance( indexTo ) : MAXU16;
 }
 
-bool Battle::Arena::hexIsAccessible( int32_t indexTo ) const
-{
-    return Board::isValidIndex( indexTo ) && _pathfinder.hexIsAccessible( indexTo );
-}
-
 bool Battle::Arena::hexIsPassable( int32_t indexTo ) const
 {
     return Board::isValidIndex( indexTo ) && _pathfinder.hexIsPassable( indexTo );
@@ -1079,45 +1035,6 @@ std::vector<int> Battle::Arena::GetCastleTargets( void ) const
         targets.push_back( CAT_TOWER2 );
 
     return targets;
-}
-
-StreamBase & Battle::operator<<( StreamBase & msg, const Arena & a )
-{
-    msg << a.current_turn << a.board << *a.army1 << *a.army2;
-
-    const HeroBase * hero1 = a.army1->GetCommander();
-    const HeroBase * hero2 = a.army2->GetCommander();
-
-    if ( hero1 )
-        msg << hero1->GetType() << *hero1;
-    else
-        msg << static_cast<int>( HeroBase::UNDEFINED );
-
-    if ( hero2 )
-        msg << hero2->GetType() << *hero2;
-    else
-        msg << static_cast<int>( HeroBase::UNDEFINED );
-
-    return msg;
-}
-
-StreamBase & Battle::operator>>( StreamBase & msg, Arena & a )
-{
-    msg >> a.current_turn >> a.board >> *a.army1 >> *a.army2;
-
-    int type;
-    HeroBase * hero1 = a.army1->GetCommander();
-    HeroBase * hero2 = a.army2->GetCommander();
-
-    msg >> type;
-    if ( hero1 && type == hero1->GetType() )
-        msg >> *hero1;
-
-    msg >> type;
-    if ( hero2 && type == hero2->GetType() )
-        msg >> *hero2;
-
-    return msg;
 }
 
 const HeroBase * Battle::Arena::GetCommander( int color, bool invert ) const

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -53,8 +53,6 @@ namespace Battle
 
     class Actions : public std::list<Command>
     {
-    public:
-        bool HaveCommand( u32 ) const;
     };
 
     class Arena
@@ -107,7 +105,6 @@ namespace Battle
         std::pair<int, uint32_t> CalculateMoveToUnit( const Unit & target ) const;
 
         uint32_t CalculateMoveDistance( int32_t indexTo ) const;
-        bool hexIsAccessible( int32_t indexTo ) const;
         bool hexIsPassable( int32_t indexTo ) const;
         Indexes getAllAvailableMoves( uint32_t moveRange ) const;
         Indexes CalculateTwoMoveOverlap( int32_t indexTo, uint32_t movementRange = 0 ) const;
@@ -155,9 +152,6 @@ namespace Battle
 
         Arena( const Arena && ) = delete;
         Arena & operator=( const Arena && ) = delete;
-
-        friend StreamBase & operator<<( StreamBase &, const Arena & );
-        friend StreamBase & operator>>( StreamBase &, Arena & );
 
         void RemoteTurn( const Unit &, Actions & );
         void HumanTurn( const Unit &, Actions & );
@@ -233,8 +227,6 @@ namespace Battle
     };
 
     Arena * GetArena( void );
-    StreamBase & operator<<( StreamBase &, const Arena & );
-    StreamBase & operator>>( StreamBase &, Arena & );
 }
 
 #endif

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -107,16 +107,6 @@ void Battle::Units::SortFastest()
     std::stable_sort( begin(), end(), Army::FastestTroop );
 }
 
-void Battle::Units::SortStrongest( void )
-{
-    std::sort( begin(), end(), Army::StrongestTroop );
-}
-
-void Battle::Units::SortWeakest( void )
-{
-    std::sort( begin(), end(), Army::WeakestTroop );
-}
-
 void Battle::Units::SortArchers( void )
 {
     std::sort( begin(), end(), []( const Troop * t1, const Troop * t2 ) { return t1->isArchers() && !t2->isArchers(); } );
@@ -298,33 +288,6 @@ Battle::Unit * Battle::Force::GetCurrentUnit( const Force & army1, const Force &
     Unit * result = ForceGetCurrentUnitPart( units1, units2, part1, preferredColor != army2.GetColor(), false );
 
     return result && result->isValid() ? result : nullptr;
-}
-
-StreamBase & Battle::operator<<( StreamBase & msg, const Force & f )
-{
-    msg << static_cast<const BitModes &>( f ) << static_cast<u32>( f.size() );
-
-    for ( Force::const_iterator it = f.begin(); it != f.end(); ++it )
-        msg << ( *it )->GetUID() << **it;
-
-    return msg;
-}
-
-StreamBase & Battle::operator>>( StreamBase & msg, Force & f )
-{
-    u32 size = 0;
-    u32 uid = 0;
-
-    msg >> static_cast<BitModes &>( f ) >> size;
-
-    for ( u32 ii = 0; ii < size; ++ii ) {
-        msg >> uid;
-        Unit * b = f.FindUID( uid );
-        if ( b )
-            msg >> *b;
-    }
-
-    return msg;
 }
 
 Troops Battle::Force::GetKilledTroops( void ) const

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -44,8 +44,6 @@ namespace Battle
 
         void SortSlowest();
         void SortFastest();
-        void SortStrongest( void );
-        void SortWeakest( void );
         void SortArchers();
     };
 
@@ -83,9 +81,6 @@ namespace Battle
         Army & army;
         std::vector<u32> uids;
     };
-
-    StreamBase & operator<<( StreamBase &, const Force & );
-    StreamBase & operator>>( StreamBase &, Force & );
 }
 
 #endif

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -84,17 +84,6 @@ void Battle::Board::SetArea( const fheroes2::Rect & area )
         ( *it ).SetArea( area );
 }
 
-fheroes2::Rect Battle::Board::GetArea( void ) const
-{
-    std::vector<fheroes2::Rect> rects;
-    rects.reserve( size() );
-
-    for ( const_iterator it = begin(); it != end(); ++it )
-        rects.push_back( ( *it ).GetPos() );
-
-    return GetBoundaryRect( rects );
-}
-
 void Battle::Board::Reset( void )
 {
     for ( iterator it = begin(); it != end(); ++it ) {

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -52,7 +52,6 @@ namespace Battle
 
         void Reset( void );
 
-        fheroes2::Rect GetArea( void ) const;
         void SetArea( const fheroes2::Rect & );
 
         s32 GetIndexAbsPosition( const fheroes2::Point & ) const;

--- a/src/fheroes2/battle/battle_cell.cpp
+++ b/src/fheroes2/battle/battle_cell.cpp
@@ -114,23 +114,10 @@ bool Battle::Position::isReflect( void ) const
     return first && second && first->GetIndex() < second->GetIndex();
 }
 
-bool Battle::Position::isValid( void ) const
-{
-    return first && ( !second || ( ( LEFT | RIGHT ) & Board::GetDirection( first->GetIndex(), second->GetIndex() ) ) );
-}
-
 bool Battle::Position::contains( int cellIndex ) const
 {
     return ( first && first->GetIndex() == cellIndex ) || ( second && second->GetIndex() == cellIndex );
 }
-
-Battle::Cell::Cell()
-    : index( 0 )
-    , object( 0 )
-    , direction( UNKNOWN )
-    , quality( 0 )
-    , troop( NULL )
-{}
 
 Battle::Cell::Cell( int32_t ii )
     : index( ii )
@@ -305,17 +292,4 @@ void Battle::Cell::ResetQuality( void )
 void Battle::Cell::ResetDirection( void )
 {
     direction = UNKNOWN;
-}
-
-StreamBase & Battle::operator<<( StreamBase & msg, const Cell & c )
-{
-    return msg << c.index << c.object << c.direction << c.quality << ( c.troop ? c.troop->GetUID() : static_cast<u32>( 0 ) );
-}
-
-StreamBase & Battle::operator>>( StreamBase & msg, Cell & c )
-{
-    u32 uid = 0;
-    msg >> c.index >> c.object >> c.direction >> c.quality >> uid;
-    c.troop = GetArena()->GetTroopUID( uid );
-    return msg;
 }

--- a/src/fheroes2/battle/battle_cell.h
+++ b/src/fheroes2/battle/battle_cell.h
@@ -52,7 +52,6 @@ namespace Battle
     class Cell
     {
     public:
-        Cell();
         explicit Cell( int32_t );
 
         void ResetQuality( void );
@@ -81,9 +80,6 @@ namespace Battle
         void SetUnit( Unit * );
 
     private:
-        friend StreamBase & operator<<( StreamBase &, const Cell & );
-        friend StreamBase & operator>>( StreamBase &, Cell & );
-
         s32 index;
         fheroes2::Rect pos;
         int object;
@@ -92,9 +88,6 @@ namespace Battle
         Unit * troop;
         fheroes2::Point coord[7];
     };
-
-    StreamBase & operator<<( StreamBase &, const Cell & );
-    StreamBase & operator>>( StreamBase &, Cell & );
 
     class Position : protected std::pair<Cell *, Cell *>
     {
@@ -106,7 +99,6 @@ namespace Battle
         void Set( s32 head, bool wide, bool reflect );
         void Swap( void );
         bool isReflect( void ) const;
-        bool isValid( void ) const;
         bool contains( int cellIndex ) const;
 
         static Position GetCorrect( const Unit &, s32 );

--- a/src/fheroes2/battle/battle_command.cpp
+++ b/src/fheroes2/battle/battle_command.cpp
@@ -26,11 +26,6 @@
 #include "battle_command.h"
 #include "spell.h"
 
-bool Battle::Actions::HaveCommand( u32 cmd ) const
-{
-    return end() != std::find_if( begin(), end(), [cmd]( const Battle::Command & v ) { return v.isType( cmd ); } );
-}
-
 Battle::Command::Command( int cmd )
     : type( cmd )
 {}

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -615,11 +615,6 @@ Battle::OpponentSprite::OpponentSprite( const fheroes2::Rect & area, const HeroB
     pos.height = sprite.height();
 }
 
-int Battle::OpponentSprite::GetColor( void ) const
-{
-    return base ? base->GetColor() : 0;
-}
-
 const HeroBase * Battle::OpponentSprite::GetHero( void ) const
 {
     return base;
@@ -644,11 +639,6 @@ void Battle::OpponentSprite::SetAnimation( int rule )
 bool Battle::OpponentSprite::isFinishFrame( void ) const
 {
     return _currentAnim.isLastFrame();
-}
-
-bool Battle::OpponentSprite::isStartFrame( void ) const
-{
-    return _currentAnim.isFirstFrame();
 }
 
 const fheroes2::Rect & Battle::OpponentSprite::GetArea( void ) const
@@ -2539,26 +2529,6 @@ void Battle::Interface::ButtonSkipAction( Actions & a )
         a.push_back( Command( MSG_BATTLE_SKIP, _currentUnit->GetUID(), true ) );
         humanturn_exit = true;
     }
-}
-
-int Battle::Interface::GetAllowSwordDirection( u32 index )
-{
-    int res = 0;
-
-    if ( _currentUnit ) {
-        const Indexes around = Board::GetAroundIndexes( index );
-
-        for ( Indexes::const_iterator it = around.begin(); it != around.end(); ++it ) {
-            const s32 from = *it;
-
-            if ( UNKNOWN != Board::GetCell( from )->GetDirection() || from == _currentUnit->GetHeadIndex()
-                 || ( _currentUnit->isWide() && from == _currentUnit->GetTailIndex() ) ) {
-                res |= Board::GetDirection( index, from );
-            }
-        }
-    }
-
-    return res;
 }
 
 void Battle::Interface::MousePressRightBoardAction( u32 /*themes*/, const Cell & cell ) const

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -97,8 +97,6 @@ namespace Battle
         void SetAnimation( int rule );
         void IncreaseAnimFrame( bool loop = false );
         bool isFinishFrame( void ) const;
-        bool isStartFrame( void ) const;
-        int GetColor( void ) const;
         const HeroBase * GetHero( void ) const;
         fheroes2::Point Offset() const;
 
@@ -298,7 +296,6 @@ namespace Battle
 
         int GetBattleCursor( std::string & ) const;
         int GetBattleSpellCursor( std::string & ) const;
-        int GetAllowSwordDirection( u32 );
 
         Arena & arena;
         Dialog::FrameBorder border;

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -385,13 +385,3 @@ bool Battle::Result::DefenderWins( void ) const
 {
     return ( army2 & RESULT_WINS ) != 0;
 }
-
-StreamBase & Battle::operator<<( StreamBase & msg, const Result & res )
-{
-    return msg << res.army1 << res.army2 << res.exp1 << res.exp2 << res.killed;
-}
-
-StreamBase & Battle::operator>>( StreamBase & msg, Result & res )
-{
-    return msg >> res.army1 >> res.army2 >> res.exp1 >> res.exp2 >> res.killed;
-}

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -40,10 +40,6 @@
 #include "speed.h"
 #include "world.h"
 
-Battle::ModeDuration::ModeDuration()
-    : std::pair<u32, u32>( 0, 0 )
-{}
-
 Battle::ModeDuration::ModeDuration( u32 mode, u32 duration )
     : std::pair<u32, u32>( mode, duration )
 {}
@@ -973,50 +969,6 @@ std::string Battle::Unit::String( bool more ) const
     return ss.str();
 }
 
-StreamBase & Battle::operator<<( StreamBase & msg, const ModesAffected & v )
-{
-    msg << static_cast<u32>( v.size() );
-
-    for ( size_t ii = 0; ii < v.size(); ++ii )
-        msg << v[ii].first << v[ii].second;
-
-    return msg;
-}
-
-StreamBase & Battle::operator>>( StreamBase & msg, ModesAffected & v )
-{
-    u32 size = 0;
-    msg >> size;
-    v.clear();
-
-    for ( size_t ii = 0; ii < size; ++ii ) {
-        ModeDuration md;
-        msg >> md.first >> md.second;
-        v.push_back( md );
-    }
-
-    return msg;
-}
-
-StreamBase & Battle::operator<<( StreamBase & msg, const Unit & b )
-{
-    return msg << b.modes << b.id << b.count << b.uid << b.hp << b.count0 << b.dead << b.shots << b.disruptingray << b.reflect << b.GetHeadIndex()
-               << ( b.mirror ? b.mirror->GetUID() : static_cast<u32>( 0 ) ) << b.affected << b.blindanswer;
-}
-
-StreamBase & Battle::operator>>( StreamBase & msg, Unit & b )
-{
-    s32 head = -1;
-    u32 uid = 0;
-
-    msg >> b.modes >> b.id >> b.count >> b.uid >> b.hp >> b.count0 >> b.dead >> b.shots >> b.disruptingray >> b.reflect >> head >> uid >> b.affected >> b.blindanswer;
-
-    b.position.Set( head, b.isWide(), b.isReflect() );
-    b.mirror = GetArena()->GetTroopUID( uid );
-
-    return msg;
-}
-
 bool Battle::Unit::AllowResponse( void ) const
 {
     return ( !Modes( SP_BLIND ) || blindanswer ) && !Modes( IS_PARALYZE_MAGIC ) && !Modes( SP_HYPNOTIZE ) && ( isAlwaysRetaliating() || !Modes( TR_RESPONSED ) );
@@ -1752,22 +1704,9 @@ bool Battle::Unit::isHaveDamage( void ) const
     return hp < count0 * Monster::GetHitPoints();
 }
 
-int Battle::Unit::GetFrameStart( void ) const
-{
-    return animation.firstFrame();
-}
-
 int Battle::Unit::GetFrame( void ) const
 {
     return animation.getFrame();
-}
-
-void Battle::Unit::SetDeathAnim()
-{
-    if ( animation.getCurrentState() != Monster_Info::KILL ) {
-        SwitchAnimation( Monster_Info::KILL );
-    }
-    animation.setToLastFrame();
 }
 
 void Battle::Unit::SetCustomAlpha( uint32_t alpha )
@@ -1785,25 +1724,9 @@ void Battle::Unit::IncreaseAnimFrame( bool loop )
     animation.playAnimation( loop );
 }
 
-bool Battle::Unit::isStartAnimFrame( void ) const
-{
-    return animation.isFirstFrame();
-}
-
 bool Battle::Unit::isFinishAnimFrame( void ) const
 {
     return animation.isLastFrame();
-}
-
-AnimationSequence Battle::Unit::GetFrameState( int state ) const
-{
-    // Can't return a reference here - it will be destroyed
-    return animation.getAnimationSequence( state );
-}
-
-const AnimationState & Battle::Unit::GetFrameState( void ) const
-{
-    return animation;
 }
 
 bool Battle::Unit::SwitchAnimation( int rule, bool reverse )
@@ -1889,11 +1812,6 @@ int Battle::Unit::M82Expl( void ) const
     }
 
     return M82::UNKNOWN;
-}
-
-int Battle::Unit::ICNFile( void ) const
-{
-    return GetMonsterSprite().icn_file;
 }
 
 fheroes2::Rect Battle::Unit::GetRectPosition() const

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -40,7 +40,6 @@ namespace Battle
 {
     struct ModeDuration : public std::pair<u32, u32>
     {
-        ModeDuration();
         ModeDuration( u32, u32 );
 
         bool isMode( u32 ) const;
@@ -59,9 +58,6 @@ namespace Battle
 
         u32 FindZeroDuration( void ) const;
     };
-
-    StreamBase & operator<<( StreamBase &, const ModesAffected & );
-    StreamBase & operator>>( StreamBase &, ModesAffected & );
 
     enum
     {
@@ -157,14 +153,9 @@ namespace Battle
 
         bool SwitchAnimation( int rule, bool reverse = false );
         bool SwitchAnimation( const std::vector<int> & animationList, bool reverse = false );
-        const AnimationState & GetFrameState( void ) const;
-        AnimationSequence GetFrameState( int ) const;
-        void SetDeathAnim();
         void IncreaseAnimFrame( bool loop = false );
-        bool isStartAnimFrame( void ) const;
         bool isFinishAnimFrame( void ) const;
         int GetFrame( void ) const;
-        int GetFrameStart( void ) const;
         uint32_t GetCustomAlpha() const;
         void SetCustomAlpha( uint32_t alpha );
 
@@ -175,8 +166,6 @@ namespace Battle
         int M82Move( void ) const;
         int M82Wnce( void ) const;
         int M82Expl( void ) const;
-
-        int ICNFile( void ) const;
 
         fheroes2::Point GetBackPoint( void ) const;
         fheroes2::Point GetCenterPoint() const;
@@ -205,9 +194,6 @@ namespace Battle
         AnimationState animation;
 
     private:
-        friend StreamBase & operator<<( StreamBase &, const Unit & );
-        friend StreamBase & operator>>( StreamBase &, Unit & );
-
         u32 uid;
         u32 hp;
         u32 count0;
@@ -224,9 +210,6 @@ namespace Battle
         bool blindanswer;
         uint32_t customAlphaMask;
     };
-
-    StreamBase & operator<<( StreamBase &, const Unit & );
-    StreamBase & operator>>( StreamBase &, Unit & );
 }
 
 #endif

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -131,18 +131,6 @@ void WorldPathfinder::checkWorldSize()
     }
 }
 
-bool WorldPathfinder::isBlockedByObject( int target, bool fromWater ) const
-{
-    int currentNode = target;
-    while ( currentNode != _pathStart && currentNode != -1 ) {
-        if ( world.isTileBlocked( currentNode, fromWater ) ) {
-            return true;
-        }
-        currentNode = _cache[currentNode]._from;
-    }
-    return false;
-}
-
 uint32_t WorldPathfinder::getMovementPenalty( int from, int target, int direction, uint8_t skill ) const
 {
     const Maps::Tiles & tileTo = world.GetTiles( target );
@@ -503,12 +491,6 @@ std::list<Route::Step> AIWorldPathfinder::buildPath( int targetIndex, bool isPla
     }
 
     return path;
-}
-
-uint32_t AIWorldPathfinder::getDistance( const Heroes & hero, int targetIndex )
-{
-    reEvaluateIfNeeded( hero );
-    return _cache[targetIndex]._cost;
 }
 
 uint32_t AIWorldPathfinder::getDistance( int start, int targetIndex, int color, double armyStrength, uint8_t skill )

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -36,7 +36,6 @@ public:
     virtual void checkWorldSize();
 
     // Shared helper methods
-    bool isBlockedByObject( int target, bool fromWater = false ) const;
     uint32_t getMovementPenalty( int start, int target, int direction, uint8_t skill = Skill::Level::EXPERT ) const;
 
 protected:
@@ -78,7 +77,6 @@ public:
     void reEvaluateIfNeeded( const Heroes & hero );
     int getFogDiscoveryTile( const Heroes & hero );
     std::vector<IndexObject> getObjectsOnTheWay( int targetIndex, bool checkAdjacent = false );
-    uint32_t getDistance( const Heroes & hero, int targetIndex );
 
     // Used for non-hero armies, like castles or monsters
     uint32_t getDistance( int start, int targetIndex, int color, double armyStrength, uint8_t skill = Skill::Level::EXPERT );

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -144,18 +144,6 @@ size_t MapRegion::getNeighboursCount() const
     return _neighbours.size();
 }
 
-std::vector<IndexObject> MapRegion::getObjectList() const
-{
-    std::vector<IndexObject> result;
-
-    for ( const MapRegionNode & node : _nodes ) {
-        if ( node.mapObject != 0 ) {
-            result.emplace_back( node.index, node.mapObject );
-        }
-    }
-    return result;
-}
-
 size_t World::getRegionCount() const
 {
     return _regions.size();

--- a/src/fheroes2/world/world_regions.h
+++ b/src/fheroes2/world/world_regions.h
@@ -60,6 +60,4 @@ public:
     MapRegion( int regionIndex, int mapIndex, bool water, size_t expectedSize );
 
     size_t getNeighboursCount() const;
-
-    std::vector<IndexObject> getObjectList() const;
 };


### PR DESCRIPTION
* Remove unused code
* Get the virtual methods in order
* Make methods const if possible
* Add missing copy constructors and assignment operators (mostly =deleted), as well as destructors (=default)
* Use =default constructors and destructors instead of empty ({})
* Use explicit keyword to disable converting constructors where possible
* Make function parameters reference-to-const where possible