### PR TITLE
WIP: Remove ghost animation for abandoned mines

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1644,7 +1644,7 @@ void Maps::Tiles::RedrawTop( fheroes2::Image & dst, const Rect & visibleTileROI,
 
     const int objectID = GetObject( false );
     // animate objects
-    if ( objectID == MP2::OBJ_ABANDONEDMINE ) {
+    if ( objectID == MP2::OBJ_ABANDONEDMINE && GetQuantity3() == Spell::HAUNT ) {
         area.BlitOnTile( dst, fheroes2::AGG::GetICN( ICN::OBJNHAUN, Game::MapsAnimationFrame() % 15 ), mp );
     }
     else if ( objectID == MP2::OBJ_MINES ) {


### PR DESCRIPTION
fix #2008

In this commit, the ghost animation for abandoned mines was removed.
This helps differentiate between abandoned mines and haunted mines.