### PR TITLE
Fix intermittent M82::KILLFADE sound after eliminating a group of monsters

### DIFF
--- a/src/fheroes2/agg/agg.h
+++ b/src/fheroes2/agg/agg.h
@@ -38,7 +38,8 @@ namespace AGG
     uint32_t GetFontHeight( bool small );
 #endif
     void LoadLOOPXXSounds( const std::vector<int> & vols, bool asyncronizedCall = false );
-    void PlaySound( int m82, bool asyncronizedCall = false );
+    // Returns the mixer channel number if asyncronizedCall is false and playback was started, -1 otherwise
+    int PlaySound( int m82, bool asyncronizedCall = false );
     void PlayMusic( int mus, bool loop = true, bool asyncronizedCall = false );
     void ResetMixer();
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -779,8 +779,10 @@ void ActionToMonster( Heroes & hero, int obj, s32 dst_index )
         Game::ObjectFadeAnimation::PerformFadeTask();
 
         if ( ch >= 0 ) {
+            LocalEvent & le = LocalEvent::Get();
+
             // wait for the M82::KILLFADE to finish playing
-            while ( LocalEvent::Get().HandleEvents() && Mixer::isPlaying( ch ) )
+            while ( le.HandleEvents() && Mixer::isPlaying( ch ) )
                 ;
         }
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -768,7 +768,7 @@ void ActionToMonster( Heroes & hero, int obj, s32 dst_index )
         destroy = true;
 
     if ( destroy ) {
-        AGG::PlaySound( M82::KILLFADE );
+        const int ch = AGG::PlaySound( M82::KILLFADE );
 
         Game::ObjectFadeAnimation::PrepareFadeTask( tile.GetObject(), tile.GetIndex(), -1, true, false );
 
@@ -777,6 +777,12 @@ void ActionToMonster( Heroes & hero, int obj, s32 dst_index )
         tile.SetObject( MP2::OBJ_ZERO );
 
         Game::ObjectFadeAnimation::PerformFadeTask();
+
+        if ( ch >= 0 ) {
+            // wait for the M82::KILLFADE to finish playing
+            while ( LocalEvent::Get().HandleEvents() && Mixer::isPlaying( ch ) )
+                ;
+        }
 
         if ( map_troop )
             world.RemoveMapObject( map_troop );


### PR DESCRIPTION
fix #3129

Alternative approach to #3133. For the record: I tried to use AGG::PlaySound() with asyncronizedCall=true, it doesn't help (at least on my macOS), there is still a brief pause in playback after completion of the FadeTask.