### PR TITLE
Use XDG directories

### DIFF
--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -66,31 +66,29 @@
 #if !defined( __LINUX__ )
 namespace
 {
-
-std::string GetHomeDirectory( const std::string & prog )
-{
+    std::string GetHomeDirectory( const std::string & prog )
+    {
 #if defined( FHEROES2_VITA )
-    return "ux0:data/fheroes2";
+        return "ux0:data/fheroes2";
 #endif
 
-    std::string res;
+        std::string res;
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
-    char * path = SDL_GetPrefPath( "", prog.c_str() );
-    if ( path ) {
-        res = path;
-        SDL_free( path );
-    }
+        char * path = SDL_GetPrefPath( "", prog.c_str() );
+        if ( path ) {
+            res = path;
+            SDL_free( path );
+        }
 #endif
 
-    if ( System::GetEnvironment( "HOME" ) )
-        res = System::ConcatePath( System::GetEnvironment( "HOME" ), std::string( "." ).append( prog ) );
-    else if ( System::GetEnvironment( "APPDATA" ) )
-        res = System::ConcatePath( System::GetEnvironment( "APPDATA" ), prog );
+        if ( System::GetEnvironment( "HOME" ) )
+            res = System::ConcatePath( System::GetEnvironment( "HOME" ), std::string( "." ).append( prog ) );
+        else if ( System::GetEnvironment( "APPDATA" ) )
+            res = System::ConcatePath( System::GetEnvironment( "APPDATA" ), prog );
 
-    return res;
-}
-
+        return res;
+    }
 }
 #endif
 
@@ -127,7 +125,7 @@ std::string System::GetConfigDirectory( const std::string & prog )
         }
     }
 #else
-    res = GetHomeDirectory(prog);
+    res = GetHomeDirectory( prog );
 #endif
     return res;
 }
@@ -147,7 +145,7 @@ std::string System::GetDataDirectory( const std::string & prog )
         }
     }
 #else
-    res = GetHomeDirectory(prog);
+    res = GetHomeDirectory( prog );
 #endif
     return res;
 }

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -124,7 +124,7 @@ std::string System::GetConfigDirectory( const std::string & prog )
         return System::ConcatePath( System::ConcatePath( homeEnv, ".config" ), prog );
     }
 
-    return {};
+    return std::string();
 #else
     return GetHomeDirectory( prog );
 #endif
@@ -143,7 +143,7 @@ std::string System::GetDataDirectory( const std::string & prog )
         return System::ConcatePath( System::ConcatePath( homeEnv, ".local/share" ), prog );
     }
 
-    return {};
+    return std::string();
 #else
     return GetHomeDirectory( prog );
 #endif

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -83,9 +83,10 @@ namespace
 #endif
 
         if ( System::GetEnvironment( "HOME" ) )
-            res = System::ConcatePath( System::GetEnvironment( "HOME" ), std::string( "." ).append( prog ) );
-        else if ( System::GetEnvironment( "APPDATA" ) )
-            res = System::ConcatePath( System::GetEnvironment( "APPDATA" ), prog );
+            return System::ConcatePath( System::GetEnvironment( "HOME" ), std::string( "." ).append( prog ) );
+
+        if ( System::GetEnvironment( "APPDATA" ) )
+            return System::ConcatePath( System::GetEnvironment( "APPDATA" ), prog );
 
         return res;
     }
@@ -112,42 +113,40 @@ std::string System::ConcatePath( const std::string & str1, const std::string & s
 
 std::string System::GetConfigDirectory( const std::string & prog )
 {
-    std::string res;
 #if defined( __LINUX__ )
-    auto config_env = System::GetEnvironment( "XDG_CONFIG_HOME" );
-    if ( config_env ) {
-        res = System::ConcatePath( config_env, prog );
+    const char * configEnv = System::GetEnvironment( "XDG_CONFIG_HOME" );
+    if ( configEnv ) {
+        return System::ConcatePath( configEnv, prog );
     }
-    else {
-        auto home_env = System::GetEnvironment( "HOME" );
-        if ( home_env ) {
-            res = System::ConcatePath( System::ConcatePath( home_env, ".config" ), prog );
-        }
+
+    const char * homeEnv = System::GetEnvironment( "HOME" );
+    if ( homeEnv ) {
+        return System::ConcatePath( System::ConcatePath( homeEnv, ".config" ), prog );
     }
+
+    return {};
 #else
-    res = GetHomeDirectory( prog );
+    return GetHomeDirectory( prog );
 #endif
-    return res;
 }
 
 std::string System::GetDataDirectory( const std::string & prog )
 {
-    std::string res;
 #if defined( __LINUX__ )
-    auto data_env = System::GetEnvironment( "XDG_DATA_HOME" );
-    if ( data_env ) {
-        res = System::ConcatePath( data_env, prog );
+    const char * dataEnv = System::GetEnvironment( "XDG_DATA_HOME" );
+    if ( dataEnv ) {
+        return System::ConcatePath( dataEnv, prog );
     }
-    else {
-        auto home_env = System::GetEnvironment( "HOME" );
-        if ( home_env ) {
-            res = System::ConcatePath( System::ConcatePath( home_env, ".local/share" ), prog );
-        }
+
+    const char * homeEnv = System::GetEnvironment( "HOME" );
+    if ( homeEnv ) {
+        return System::ConcatePath( System::ConcatePath( homeEnv, ".local/share" ), prog );
     }
+
+    return {};
 #else
-    res = GetHomeDirectory( prog );
+    return GetHomeDirectory( prog );
 #endif
-    return res;
 }
 
 ListDirs System::GetDataDirectories( const std::string & prog )

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -72,8 +72,13 @@ namespace
         return "ux0:data/fheroes2";
 #endif
 
-        std::string res;
+        if ( System::GetEnvironment( "HOME" ) )
+            return System::ConcatePath( System::GetEnvironment( "HOME" ), std::string( "." ).append( prog ) );
 
+        if ( System::GetEnvironment( "APPDATA" ) )
+            return System::ConcatePath( System::GetEnvironment( "APPDATA" ), prog );
+
+        std::string res;
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
         char * path = SDL_GetPrefPath( "", prog.c_str() );
         if ( path ) {
@@ -81,13 +86,6 @@ namespace
             SDL_free( path );
         }
 #endif
-
-        if ( System::GetEnvironment( "HOME" ) )
-            return System::ConcatePath( System::GetEnvironment( "HOME" ), std::string( "." ).append( prog ) );
-
-        if ( System::GetEnvironment( "APPDATA" ) )
-            return System::ConcatePath( System::GetEnvironment( "APPDATA" ), prog );
-
         return res;
     }
 }

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -34,8 +34,8 @@ namespace System
     std::string ConcatePath( const std::string &, const std::string & );
     ListDirs GetDataDirectories( const std::string & );
     ListFiles GetListFiles( const std::string &, const std::string &, const std::string & );
-    std::string GetConfigDirectory( const std::string & );
-    std::string GetDataDirectory( const std::string & );
+    std::string GetConfigDirectory( const std::string & prog );
+    std::string GetDataDirectory( const std::string & prog );
 
     std::string GetDirname( const std::string & );
     std::string GetBasename( const std::string & );

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -34,7 +34,8 @@ namespace System
     std::string ConcatePath( const std::string &, const std::string & );
     ListDirs GetDataDirectories( const std::string & );
     ListFiles GetListFiles( const std::string &, const std::string &, const std::string & );
-    std::string GetHomeDirectory( const std::string & );
+    std::string GetConfigDirectory( const std::string & );
+    std::string GetDataDirectory( const std::string & );
 
     std::string GetDirname( const std::string & );
     std::string GetBasename( const std::string & );

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -95,7 +95,7 @@ namespace
     {
         const std::string config_dir = System::GetConfigDirectory( "fheroes2" );
 
-        if ( !config_dir.empty() && !System::IsDirectory( config_dir )) {
+        if ( !config_dir.empty() && !System::IsDirectory( config_dir ) ) {
             System::MakeDirectory( config_dir );
         }
     }

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -107,15 +107,11 @@ namespace
         if ( dataDir.empty() )
             return;
 
-        const std::string dataMaps = System::ConcatePath( dataDir, "maps" );
         const std::string dataFiles = System::ConcatePath( dataDir, "files" );
         const std::string dataFilesSave = System::ConcatePath( dataFiles, "save" );
 
         if ( !System::IsDirectory( dataDir ) )
             System::MakeDirectory( dataDir );
-
-        if ( System::IsDirectory( dataDir, true ) && !System::IsDirectory( dataMaps ) )
-            System::MakeDirectory( dataMaps );
 
         if ( System::IsDirectory( dataDir, true ) && !System::IsDirectory( dataFiles ) )
             System::MakeDirectory( dataFiles );

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -91,27 +91,37 @@ namespace
             conf.Save( configurationFileName );
     }
 
-    void InitHomeDir()
+    void InitConfigDir()
     {
-        const std::string home = System::GetHomeDirectory( "fheroes2" );
+        const std::string config_dir = System::GetConfigDirectory( "fheroes2" );
 
-        if ( !home.empty() ) {
-            const std::string home_maps = System::ConcatePath( home, "maps" );
-            const std::string home_files = System::ConcatePath( home, "files" );
-            const std::string home_files_save = System::ConcatePath( home_files, "save" );
-
-            if ( !System::IsDirectory( home ) )
-                System::MakeDirectory( home );
-
-            if ( System::IsDirectory( home, true ) && !System::IsDirectory( home_maps ) )
-                System::MakeDirectory( home_maps );
-
-            if ( System::IsDirectory( home, true ) && !System::IsDirectory( home_files ) )
-                System::MakeDirectory( home_files );
-
-            if ( System::IsDirectory( home_files, true ) && !System::IsDirectory( home_files_save ) )
-                System::MakeDirectory( home_files_save );
+        if ( !config_dir.empty() && !System::IsDirectory( config_dir )) {
+            System::MakeDirectory( config_dir );
         }
+    }
+
+    void InitDataDir()
+    {
+        const std::string data_dir = System::GetDataDirectory( "fheroes2" );
+
+        if ( data_dir.empty() )
+            return;
+
+        const std::string data_maps = System::ConcatePath( data_dir, "maps" );
+        const std::string data_files = System::ConcatePath( data_dir, "files" );
+        const std::string data_files_save = System::ConcatePath( data_files, "save" );
+
+        if ( !System::IsDirectory( data_dir ) )
+            System::MakeDirectory( data_dir );
+
+        if ( System::IsDirectory( data_dir, true ) && !System::IsDirectory( data_maps ) )
+            System::MakeDirectory( data_maps );
+
+        if ( System::IsDirectory( data_dir, true ) && !System::IsDirectory( data_files ) )
+            System::MakeDirectory( data_files );
+
+        if ( System::IsDirectory( data_files, true ) && !System::IsDirectory( data_files_save ) )
+            System::MakeDirectory( data_files_save );
     }
 
     void SetTimidityEnvPath()
@@ -162,7 +172,8 @@ int main( int argc, char ** argv )
     Settings & conf = Settings::Get();
     conf.SetProgramPath( argv[0] );
 
-    InitHomeDir();
+    InitConfigDir();
+    InitDataDir();
     ReadConfigs();
 
     // getopt

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -93,35 +93,35 @@ namespace
 
     void InitConfigDir()
     {
-        const std::string config_dir = System::GetConfigDirectory( "fheroes2" );
+        const std::string configDir = System::GetConfigDirectory( "fheroes2" );
 
-        if ( !config_dir.empty() && !System::IsDirectory( config_dir ) ) {
-            System::MakeDirectory( config_dir );
+        if ( !configDir.empty() && !System::IsDirectory( configDir ) ) {
+            System::MakeDirectory( configDir );
         }
     }
 
     void InitDataDir()
     {
-        const std::string data_dir = System::GetDataDirectory( "fheroes2" );
+        const std::string dataDir = System::GetDataDirectory( "fheroes2" );
 
-        if ( data_dir.empty() )
+        if ( dataDir.empty() )
             return;
 
-        const std::string data_maps = System::ConcatePath( data_dir, "maps" );
-        const std::string data_files = System::ConcatePath( data_dir, "files" );
-        const std::string data_files_save = System::ConcatePath( data_files, "save" );
+        const std::string dataMaps = System::ConcatePath( dataDir, "maps" );
+        const std::string dataFiles = System::ConcatePath( dataDir, "files" );
+        const std::string dataFilesSave = System::ConcatePath( dataFiles, "save" );
 
-        if ( !System::IsDirectory( data_dir ) )
-            System::MakeDirectory( data_dir );
+        if ( !System::IsDirectory( dataDir ) )
+            System::MakeDirectory( dataDir );
 
-        if ( System::IsDirectory( data_dir, true ) && !System::IsDirectory( data_maps ) )
-            System::MakeDirectory( data_maps );
+        if ( System::IsDirectory( dataDir, true ) && !System::IsDirectory( dataMaps ) )
+            System::MakeDirectory( dataMaps );
 
-        if ( System::IsDirectory( data_dir, true ) && !System::IsDirectory( data_files ) )
-            System::MakeDirectory( data_files );
+        if ( System::IsDirectory( dataDir, true ) && !System::IsDirectory( dataFiles ) )
+            System::MakeDirectory( dataFiles );
 
-        if ( System::IsDirectory( data_files, true ) && !System::IsDirectory( data_files_save ) )
-            System::MakeDirectory( data_files_save );
+        if ( System::IsDirectory( dataFiles, true ) && !System::IsDirectory( dataFilesSave ) )
+            System::MakeDirectory( dataFilesSave );
     }
 
     void SetTimidityEnvPath()

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -331,8 +331,7 @@ bool Game::LoadSAV2FileInfo( const std::string & fn, Maps::FileInfo & finfo )
 
 std::string Game::GetSaveDir()
 {
-    const char * dir = "save";
-    return Settings::GetWriteableDir( dir );
+    return System::ConcatePath( System::ConcatePath( System::GetDataDirectory( "fheroes2" ), "files" ), "save" );
 }
 
 std::string Game::GetSaveFileExtension()

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -894,7 +894,7 @@ ListDirs Settings::GetRootDirs()
 
     // from user data
     const std::string & data = System::GetDataDirectory( "fheroes2" );
-    if ( !data.empty() && (std::find(dirs.cbegin(), dirs.cend(), data) == dirs.cend()))
+    if ( !data.empty() && ( std::find( dirs.cbegin(), dirs.cend(), data ) == dirs.cend() ) )
         dirs.push_back( data );
 
     fheroes2::AddOSSpecificDirectories( dirs );

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -659,7 +659,8 @@ bool Settings::Save( const std::string & filename ) const
     const std::string vitaFilename = "ux0:data/fheroes2/" + filename;
     file.open( vitaFilename.data(), std::fstream::out | std::fstream::trunc );
 #else
-    file.open( filename.data(), std::fstream::out | std::fstream::trunc );
+    const std::string cfgFilename = System::ConcatePath( System::GetConfigDirectory( "fheroes2" ), filename );
+    file.open( cfgFilename.data(), std::fstream::out | std::fstream::trunc );
 #endif
     if ( !file )
         return false;
@@ -886,10 +887,15 @@ ListDirs Settings::GetRootDirs()
     // from dirname
     dirs.push_back( System::GetDirname( Settings::Get().path_program ) );
 
-    // from HOME
-    const std::string & home = System::GetHomeDirectory( "fheroes2" );
-    if ( !home.empty() )
-        dirs.push_back( home );
+    // from user config
+    const std::string & config = System::GetConfigDirectory( "fheroes2" );
+    if ( !config.empty() )
+        dirs.push_back( config );
+
+    // from user data
+    const std::string & data = System::GetDataDirectory( "fheroes2" );
+    if ( !data.empty() && (std::find(dirs.cbegin(), dirs.cend(), data) == dirs.cend()))
+        dirs.push_back( data );
 
     fheroes2::AddOSSpecificDirectories( dirs );
 
@@ -1781,7 +1787,7 @@ void Settings::SetPosStatus( const fheroes2::Point & pt )
 
 void Settings::BinarySave() const
 {
-    const std::string fname = System::ConcatePath( GetWriteableDir( "save" ), "fheroes2.bin" );
+    const std::string fname = System::ConcatePath( System::GetConfigDirectory( "fheroes2" ), "fheroes2.bin" );
 
     StreamFile fs;
     fs.setbigendian( true );
@@ -1793,7 +1799,7 @@ void Settings::BinarySave() const
 
 void Settings::BinaryLoad()
 {
-    std::string fname = System::ConcatePath( GetWriteableDir( "save" ), "fheroes2.bin" );
+    std::string fname = System::ConcatePath( System::GetConfigDirectory( "fheroes2" ), "fheroes2.bin" );
 
     if ( !System::IsFile( fname ) )
         fname = GetLastFile( "", "fheroes2.bin" );


### PR DESCRIPTION
Use `$XDG_CONFIG_HOME/fheroes2`on Linux (`~/.config/fheroes2` by default) for `fheroes2.bin`, `fheroes2.cfg`.
Use `$XDG_DATA_HOME/fheroes2` on Linux (`~/.local/share/fheroes2` by default) for `data`, `files/save`, `maps`.
On other platforms use directory returned by `GetHomeDirectory`.
Close #2860.
Close #3118.