### PR TITLE
Display correct message when capturing abandoned mine

### DIFF
--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2055,8 +2055,15 @@ void ActionToCaptureObject( Heroes & hero, u32 obj, s32 dst_index )
         body = _( "You gain control of a sawmill. It will provide you with %{count} units of wood per day." );
         break;
 
+    case MP2::OBJ_ABANDONEDMINE:
     case MP2::OBJ_MINES: {
-        resource = tile.QuantityResourceCount().first;
+
+		if ( obj == MP2::OBJ_ABANDONEDMINE && tile.GetQuantity3() != Spell::HAUNT ) {
+            body = _( "You beat the Ghosts and are able to restore the mine to production." );
+            break;
+		}
+
+		resource = tile.QuantityResourceCount().first;
         header = Maps::GetMinesName( resource );
 
         switch ( resource ) {
@@ -2080,9 +2087,7 @@ void ActionToCaptureObject( Heroes & hero, u32 obj, s32 dst_index )
         }
     } break;
 
-    case MP2::OBJ_ABANDONEDMINE:
-        body = _( "You beat the Ghosts and are able to restore the mine to production." );
-        break;
+
 
     case MP2::OBJ_LIGHTHOUSE:
         header = MP2::StringObject( obj );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2057,13 +2057,12 @@ void ActionToCaptureObject( Heroes & hero, u32 obj, s32 dst_index )
 
     case MP2::OBJ_ABANDONEDMINE:
     case MP2::OBJ_MINES: {
-
-		if ( obj == MP2::OBJ_ABANDONEDMINE && tile.GetQuantity3() != Spell::HAUNT ) {
+        if ( obj == MP2::OBJ_ABANDONEDMINE && tile.GetQuantity3() != Spell::HAUNT ) {
             body = _( "You beat the Ghosts and are able to restore the mine to production." );
             break;
-		}
+        }
 
-		resource = tile.QuantityResourceCount().first;
+        resource = tile.QuantityResourceCount().first;
         header = Maps::GetMinesName( resource );
 
         switch ( resource ) {
@@ -2086,8 +2085,6 @@ void ActionToCaptureObject( Heroes & hero, u32 obj, s32 dst_index )
             break;
         }
     } break;
-
-
 
     case MP2::OBJ_LIGHTHOUSE:
         header = MP2::StringObject( obj );


### PR DESCRIPTION
fix for #1368

In this commit, the message displayed when capturing a mine is changed.
Haunted mines now display what resource they provide.
Abandoned mines display the correct message that the ghosts have been beaten.