### PR TITLE
Fix issue with incorrect rendering of spells in spellbook

### DIFF
--- a/src/fheroes2/spell/spell_book.cpp
+++ b/src/fheroes2/spell/spell_book.cpp
@@ -445,16 +445,15 @@ void SpellBookRedrawLists( const SpellStorage & spells, Rects & coords, const si
 void SpellBookRedrawSpells( const SpellStorage & spells, Rects & coords, const size_t index, int32_t px, int32_t py, const HeroBase & hero, bool isRight )
 {
     const uint32_t heroSpellPoints = hero.GetSpellPoints();
-    SpellStorage tmpSpells = spells;
-    std::sort( tmpSpells.begin(), tmpSpells.end() );
+
     for ( int32_t i = 0; i < spellsPerPage; ++i ) {
-        if ( tmpSpells.size() <= index + i )
+        if ( spells.size() <= index + i )
             return;
 
         const int32_t ox = 84 + 81 * ( i & 1 );
         const int32_t oy = 71 + 78 * ( i >> 1 ) - ( ( i + isRight ) % 2 ) * 5;
 
-        const Spell & spell = tmpSpells[i + index];
+        const Spell & spell = spells[i + index];
         const std::string & spellName = spell.GetName();
         const uint32_t spellCost = spell.SpellPoint( &hero );
         const bool isAvailable = heroSpellPoints >= spellCost;

--- a/src/fheroes2/spell/spell_book.cpp
+++ b/src/fheroes2/spell/spell_book.cpp
@@ -43,11 +43,6 @@ namespace
     const fheroes2::Point bookmarkAdvOffset( 266, 269 );
     const fheroes2::Point bookmarkCombatoOffset( 299, 276 );
     const fheroes2::Point bookmarkCloseOffset( 416, 280 );
-
-    bool SpellBookSortingSpell( const Spell & spell1, const Spell & spell2 )
-    {
-        return strcmp( spell1.GetName(), spell2.GetName() ) < 0;
-    }
 }
 
 void SpellBookRedrawLists( const SpellStorage &, Rects &, size_t, const fheroes2::Point &, u32, SpellBook::Filter only, const HeroBase & hero );
@@ -327,8 +322,8 @@ void SpellBook::Edit( const HeroBase & hero )
             }
             else {
                 Spell spell = Dialog::SelectSpell();
-                displayedSpells.Append( spell );
                 Append( spell );
+                displayedSpells = SetFilter( Filter::ALL, &hero );
                 redraw = true;
             }
         }
@@ -386,7 +381,7 @@ SpellStorage SpellBook::SetFilter( const Filter filter, const HeroBase * hero ) 
     }
 
     // sorting results
-    std::sort( res.begin(), res.end(), SpellBookSortingSpell );
+    std::sort( res.begin(), res.end() );
 
     return res;
 }


### PR DESCRIPTION
There is currently an issue with spells in the spellbook: when you click on some spell, some other spell is in fact selected. How to reproduce:

1. Run fheroes2 and load the attached savefile;
2. Press on "Cast an adventure spell" button;
3. Press and hold the right mouse button on "View Mines" and "Summon Boat" spells.

![View Mines](https://user-images.githubusercontent.com/32623900/115138635-06eff780-a036-11eb-8be3-94520f982263.png)
![Summon Boat](https://user-images.githubusercontent.com/32623900/115138638-0b1c1500-a036-11eb-961c-24d9762ed821.png)

This PR is intended to fix this issue.

[Broken_Alliance_Boat.zip](https://github.com/ihhub/fheroes2/files/6330742/Broken_Alliance_Boat.zip)