### PR TITLE
Run cmake_build.yml workflow only on master branch

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -1,6 +1,10 @@
 name: Build with CMake
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
I just noticed that cmake_build.yml workflow is launched on ANY branch. Thus, when @ihhub makes a pull request from some branch in this repository, all cmake workflows run in two instances - one on push in that branch, and another one on pull request to master. This PR is intended to fix this. However, if this behavior is intentional, I'll close it.