### PR TITLE
ResizeToShortName(): properly handle filenames with dots

### DIFF
--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -139,7 +139,7 @@ void FileInfoListBox::ActionListSingleClick( Maps::FileInfo & )
 std::string ResizeToShortName( const std::string & str )
 {
     std::string res = System::GetBasename( str );
-    size_t it = res.find( '.' );
+    size_t it = res.rfind( '.' );
     if ( std::string::npos != it )
         res.resize( it );
     return res;


### PR DESCRIPTION
At the moment, there is no way to load a savefile with a name containing dots.