### PR TITLE
Allow switching heroes in hero dialog if it was opened from meeting dialog

### DIFF
--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -597,7 +597,7 @@ int Dialog::ArmyJoinFree( const Troop & troop, Heroes & hero )
         result = btnGroup.processEvents();
 
         if ( btnHeroes.isEnabled() && le.MouseClickLeft( btnHeroes.area() ) ) {
-            hero.OpenDialog( false, false );
+            hero.OpenDialog( false, false, true, true );
 
             if ( hero.GetArmy().GetCount() < hero.GetArmy().Size() ) {
                 btnGroup.button( 0 ).enable();
@@ -781,7 +781,7 @@ int Dialog::ArmyJoinWithCost( const Troop & troop, u32 join, u32 gold, Heroes & 
             needRedraw = true;
         }
         else if ( btnHeroes.isEnabled() && le.MouseClickLeft( btnHeroesArea ) ) {
-            hero.OpenDialog( false, false );
+            hero.OpenDialog( false, false, true, true );
 
             needRedraw = true;
         }

--- a/src/fheroes2/dialog/dialog_levelup.cpp
+++ b/src/fheroes2/dialog/dialog_levelup.cpp
@@ -198,13 +198,8 @@ int DialogSelectSecondary( const std::string & name, const std::string & primary
         else if ( le.MouseClickLeft( button_learn2.area() ) || Game::HotKeyPressEvent( Game::EVENT_DEFAULT_RIGHT ) )
             return sec2.Skill();
         else if ( le.MouseClickLeft( button_hero.area() ) || Game::HotKeyPressEvent( Game::EVENT_DEFAULT_READY ) ) {
-            const bool noDismiss = hero.Modes( Heroes::NOTDISMISS );
-            hero.SetModes( Heroes::NOTDISMISS );
-            hero.OpenDialog( false, true );
+            hero.OpenDialog( false, true, true, true );
 
-            if ( !noDismiss ) {
-                hero.ResetModes( Heroes::NOTDISMISS );
-            }
             cursor.Show();
             display.render();
         }

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -263,7 +263,7 @@ namespace Game
     void PlayPickupSound( void );
     void DisableChangeMusic( bool );
     bool ChangeMusicDisabled( void );
-    void OpenHeroesDialog( Heroes & hero, bool updateFocus, bool windowIsGameWorld );
+    void OpenHeroesDialog( Heroes & hero, bool updateFocus, bool windowIsGameWorld, bool disableDismiss = false );
     void OpenCastleDialog( Castle & castle, bool updateFocus = true );
     std::string GetEncodeString( const std::string & );
     // Returns the difficulty level based on the type of game.

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -181,7 +181,7 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /*= true*/ )
 }
 
 /* open heroes wrapper */
-void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, bool windowIsGameWorld )
+void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, bool windowIsGameWorld, bool disableDismiss /* = false */ )
 {
     const Settings & conf = Settings::Get();
     Kingdom & myKingdom = hero.GetKingdom();
@@ -196,7 +196,7 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, bool windowIsGameW
         int result = Dialog::ZERO;
 
         while ( Dialog::CANCEL != result ) {
-            result = ( *it )->OpenDialog( false, needFade );
+            result = ( *it )->OpenDialog( false, needFade, disableDismiss );
             if ( needFade )
                 needFade = false;
 

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -270,7 +270,7 @@ public:
     int GetMobilityIndexSprite( void ) const;
     int GetManaIndexSprite( void ) const;
 
-    int OpenDialog( bool readonly = false, bool fade = false );
+    int OpenDialog( bool readonly = false, bool fade = false, bool disableDismiss = false, bool disableSwitch = false );
     void MeetingDialog( Heroes & );
 
     bool Recruit( int col, const Point & pt );

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -207,7 +207,7 @@ int Heroes::OpenDialog( bool readonly /* = false */, bool fade /* = false */, bo
     if ( inCastle() || readonly || disableDismiss || Modes( NOTDISMISS ) ) {
         buttonDismiss.disable();
 
-        if ( readonly ) {
+        if ( readonly || disableDismiss ) {
             buttonDismiss.hide();
         }
     }
@@ -357,8 +357,13 @@ int Heroes::OpenDialog( bool readonly /* = false */, bool fade /* = false */, bo
         else if ( le.MouseCursor( buttonExit.area() ) )
             message = _( "Exit Hero Screen" );
         else if ( buttonDismiss.isVisible() && le.MouseCursor( buttonDismiss.area() ) ) {
-            if ( Modes( NOTDISMISS ) ) {
-                message = _( "Dismissal is disabled, see game info" );
+            if ( inCastle() ) {
+                message = _( "You cannot dismiss a hero in a castle" );
+            }
+            else if ( Modes( NOTDISMISS ) ) {
+                message = _( "Dismissal of %{name} the %{race} is prohibited by scenario" );
+                StringReplace( message, "%{name}", name );
+                StringReplace( message, "%{race}", Race::String( race ) );
             }
             else if ( buttonDismiss.isEnabled() ) {
                 message = _( "Dismiss %{name} the %{race}" );

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -43,8 +43,7 @@
 #include "ui_window.h"
 #include "world.h"
 
-/* readonly: false, fade: false */
-int Heroes::OpenDialog( bool readonly, bool fade )
+int Heroes::OpenDialog( bool readonly /* = false */, bool fade /* = false */, bool disableDismiss /* = false */, bool disableSwitch /* = false */ )
 {
     fheroes2::Display & display = fheroes2::Display::instance();
     Cursor & cursor = Cursor::Get();
@@ -205,13 +204,15 @@ int Heroes::OpenDialog( bool readonly, bool fade )
 
     LocalEvent & le = LocalEvent::GetClean();
 
-    if ( inCastle() || readonly || Modes( NOTDISMISS ) ) {
+    if ( inCastle() || readonly || disableDismiss || Modes( NOTDISMISS ) ) {
         buttonDismiss.disable();
-        if ( readonly )
+
+        if ( inCastle() || readonly || disableDismiss ) {
             buttonDismiss.hide();
+        }
     }
 
-    if ( readonly || 2 > GetKingdom().GetHeroes().size() ) {
+    if ( readonly || disableSwitch || 2 > GetKingdom().GetHeroes().size() ) {
         buttonNextHero.disable();
         buttonPrevHero.disable();
     }

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -207,7 +207,7 @@ int Heroes::OpenDialog( bool readonly /* = false */, bool fade /* = false */, bo
     if ( inCastle() || readonly || disableDismiss || Modes( NOTDISMISS ) ) {
         buttonDismiss.disable();
 
-        if ( inCastle() || readonly || disableDismiss ) {
+        if ( readonly ) {
             buttonDismiss.hide();
         }
     }
@@ -356,16 +356,14 @@ int Heroes::OpenDialog( bool readonly /* = false */, bool fade /* = false */, bo
             message = _( "Set army combat formation to 'Grouped'" );
         else if ( le.MouseCursor( buttonExit.area() ) )
             message = _( "Exit Hero Screen" );
-        else if ( le.MouseCursor( buttonDismiss.area() ) ) {
-            if ( buttonDismiss.isVisible() ) {
-                if ( Modes( NOTDISMISS ) ) {
-                    message = "Dismiss disabled, see game info";
-                }
-                else {
-                    message = _( "Dismiss %{name} the %{race}" );
-                    StringReplace( message, "%{name}", name );
-                    StringReplace( message, "%{race}", Race::String( race ) );
-                }
+        else if ( buttonDismiss.isVisible() && le.MouseCursor( buttonDismiss.area() ) ) {
+            if ( Modes( NOTDISMISS ) ) {
+                message = _( "Dismissal is disabled, see game info" );
+            }
+            else if ( buttonDismiss.isEnabled() ) {
+                message = _( "Dismiss %{name} the %{race}" );
+                StringReplace( message, "%{name}", name );
+                StringReplace( message, "%{race}", Race::String( race ) );
             }
         }
         else if ( buttonPrevHero.isEnabled() && le.MouseCursor( buttonPrevHero.area() ) )

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -496,14 +496,7 @@ void Heroes::MeetingDialog( Heroes & heroes2 )
         }
 
         if ( le.MouseClickLeft( hero1Area ) ) {
-            const bool noDismiss = Modes( Heroes::NOTDISMISS );
-
-            SetModes( Heroes::NOTDISMISS );
-            OpenDialog( false, true );
-
-            if ( !noDismiss ) {
-                ResetModes( Heroes::NOTDISMISS );
-            }
+            Game::OpenHeroesDialog( *this, false, false, true );
 
             armyCountBackgroundRestorer.restore();
             selectArtifacts1.ResetSelected();
@@ -516,14 +509,7 @@ void Heroes::MeetingDialog( Heroes & heroes2 )
             display.render();
         }
         else if ( le.MouseClickLeft( hero2Area ) ) {
-            const bool noDismiss = heroes2.Modes( Heroes::NOTDISMISS );
-
-            heroes2.SetModes( Heroes::NOTDISMISS );
-            heroes2.OpenDialog( false, true );
-
-            if ( !noDismiss ) {
-                heroes2.ResetModes( Heroes::NOTDISMISS );
-            }
+            Game::OpenHeroesDialog( heroes2, false, false, true );
 
             armyCountBackgroundRestorer.restore();
             selectArtifacts2.ResetSelected();


### PR DESCRIPTION
fix #3262

Also make dismiss button behavior more OG-like - in OG it is disabled only if this specific hero can't be dismissed due to map scenario, and is hidden in other cases.