### PR TITLE
Fix Interface::ListBox::GetFromPosition()

### DIFF
--- a/src/fheroes2/gui/interface_list.h
+++ b/src/fheroes2/gui/interface_list.h
@@ -202,7 +202,7 @@ namespace Interface
             if ( _topId + id >= _size() ) // out of items
                 return NULL;
 
-            return &( *content )[id];
+            return &( *content )[_topId + id];
         }
 
         void SetCurrent( size_t posId )


### PR DESCRIPTION
At the moment, scenario selection window shows incorrect information about victory and loss conditions. How to reproduce:

1. Run the game, press "New Game", choose "STANDARD GAME";
2. Press "SELECT" button;
3. Scroll the list of available scenarios, press and hold right mouse button on victory and loss conditions of various scenarios.

![Invalid Victory Condition](https://user-images.githubusercontent.com/32623900/115930872-de7f5780-a492-11eb-8bf3-9330c74ddf23.png)
![Invalid Loss Condition](https://user-images.githubusercontent.com/32623900/115930883-e2ab7500-a492-11eb-8fc4-5f1aba2b232b.png)

This PR is intended to fix this.