### PR TITLE
Don't take Mage Guild level into account when calculating count of archers in castle towers

### DIFF
--- a/src/fheroes2/battle/battle_tower.cpp
+++ b/src/fheroes2/battle/battle_tower.cpp
@@ -33,7 +33,6 @@ Battle::Tower::Tower( const Castle & castle, int twr )
     , valid( true )
 {
     count += castle.CountBuildings();
-    count += castle.GetLevelMageGuild() - 1;
 
     if ( count > 20 )
         count = 20;


### PR DESCRIPTION
fix #3294