### PR TITLE
Fix rendering of "Not enough gold" text in Dialog::ArmyJoinWithCost()

### DIFF
--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -727,6 +727,7 @@ int Dialog::ArmyJoinWithCost( const Troop & troop, u32 join, u32 gold, Heroes & 
     else {
         std::string msg = _( "Not enough gold (%{gold})" );
         StringReplace( msg, "%{gold}", gold - kingdom.GetFunds().Get( Resource::GOLD ) );
+        tsNotEnoughGold.SetText( msg, Font::SMALL );
         tsNotEnoughGold.Show();
         btnMarket.enable();
         btnMarket.draw();


### PR DESCRIPTION
fix #3304