### PR TITLE
Save Completed Campaign Scenario to file

### DIFF
--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -32,7 +32,6 @@
 #include "icn.h"
 #include "race.h"
 #include "settings.h"
-#include "system.h"
 #include "text.h"
 #include "world.h"
 

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -28,9 +28,11 @@
 #include "cursor.h"
 #include "dialog.h"
 #include "game.h"
+#include "game_io.h"
 #include "icn.h"
 #include "race.h"
 #include "settings.h"
+#include "system.h"
 #include "text.h"
 #include "world.h"
 
@@ -432,6 +434,8 @@ int Game::CompleteCampaignScenario()
 
     const int lastCompletedScenarioID = saveData.getLastCompletedScenarioID();
     const Campaign::CampaignData & campaignData = GetCampaignData( saveData.getCampaignID() );
+
+    Game::SaveCompletedCampaignScenario();
 
     // TODO: do proper calc based on all scenarios cleared?
     if ( campaignData.isLastScenario( lastCompletedScenarioID ) )

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -126,16 +126,6 @@ bool Game::AutoSave()
     return Game::Save( System::ConcatePath( GetSaveDir(), "AUTOSAVE" + GetSaveFileExtension() ) );
 }
 
-bool Game::SaveCompletedCampaignScenario()
-{
-    const std::string & name = Settings::Get().CurrentFileInfo().name;
-
-    std::string base = name.empty() ? _( "newgame" ) : name;
-    std::replace_if( base.begin(), base.end(), ::isspace, '_' );
-
-    return Save( System::ConcatePath( Game::GetSaveDir(), base ) + _( "_Complete" ) + Game::GetSaveFileExtension() );
-}
-
 bool Game::Save( const std::string & fn )
 {
     DEBUG_LOG( DBG_GAME, DBG_INFO, fn );
@@ -382,4 +372,14 @@ std::string Game::GetSaveFileExtension( const int gameType )
         return ".savh";
 
     return ".savm";
+}
+
+bool Game::SaveCompletedCampaignScenario()
+{
+    const std::string & name = Settings::Get().CurrentFileInfo().name;
+
+    std::string base = name.empty() ? _( "newgame" ) : name;
+    std::replace_if( base.begin(), base.end(), ::isspace, '_' );
+
+    return Save( System::ConcatePath( Game::GetSaveDir(), base ) + _( "_Complete" ) + Game::GetSaveFileExtension() );
 }

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -130,13 +130,10 @@ bool Game::SaveCompletedCampaignScenario()
 {
     const std::string & name = Settings::Get().CurrentFileInfo().name;
 
-    std::string base = name.size() ? name : "newgame";
-    base.resize( std::distance( base.begin(), std::find_if( base.begin(), base.end(), ::ispunct ) ) );
+    std::string base = name.size() ? name : _( "newgame" );
     std::replace_if( base.begin(), base.end(), ::isspace, '_' );
-    std::ostringstream os;
 
-    os << System::ConcatePath( Game::GetSaveDir(), base ) << "_Complete" << Game::GetSaveFileExtension();
-    return Game::Save( os.str() );
+    return Save( System::ConcatePath( Game::GetSaveDir(), base ) + _( "_Complete" ) + Game::GetSaveFileExtension() );
 }
 
 bool Game::Save( const std::string & fn )

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -126,6 +126,19 @@ bool Game::AutoSave()
     return Game::Save( System::ConcatePath( GetSaveDir(), "AUTOSAVE" + GetSaveFileExtension() ) );
 }
 
+bool Game::SaveCompletedCampaignScenario()
+{
+    const std::string & name = Settings::Get().CurrentFileInfo().name;
+
+    std::string base = name.size() ? name : "newgame";
+    base.resize( std::distance( base.begin(), std::find_if( base.begin(), base.end(), ::ispunct ) ) );
+    std::replace_if( base.begin(), base.end(), ::isspace, '_' );
+    std::ostringstream os;
+
+    os << System::ConcatePath( Game::GetSaveDir(), base ) << "_Complete" << Game::GetSaveFileExtension();
+    return Game::Save( os.str() );
+}
+
 bool Game::Save( const std::string & fn )
 {
     DEBUG_LOG( DBG_GAME, DBG_INFO, fn );

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -130,7 +130,7 @@ bool Game::SaveCompletedCampaignScenario()
 {
     const std::string & name = Settings::Get().CurrentFileInfo().name;
 
-    std::string base = name.size() ? name : _( "newgame" );
+    std::string base = name.empty() ? _( "newgame" ) : name;
     std::replace_if( base.begin(), base.end(), ::isspace, '_' );
 
     return Save( System::ConcatePath( Game::GetSaveDir(), base ) + _( "_Complete" ) + Game::GetSaveFileExtension() );

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -378,8 +378,8 @@ bool Game::SaveCompletedCampaignScenario()
 {
     const std::string & name = Settings::Get().CurrentFileInfo().name;
 
-    std::string base = name.empty() ? _( "newgame" ) : name;
+    std::string base = name.empty() ? "newgame" : name;
     std::replace_if( base.begin(), base.end(), ::isspace, '_' );
 
-    return Save( System::ConcatePath( Game::GetSaveDir(), base ) + _( "_Complete" ) + Game::GetSaveFileExtension() );
+    return Save( System::ConcatePath( Game::GetSaveDir(), base ) + "_Complete" + Game::GetSaveFileExtension() );
 }

--- a/src/fheroes2/game/game_io.h
+++ b/src/fheroes2/game/game_io.h
@@ -30,11 +30,12 @@ namespace Maps
 
 namespace Game
 {
-    bool SaveCompletedCampaignScenario();
     bool AutoSave();
     bool Save( const std::string & );
     bool Load( const std::string & );
     bool LoadSAV2FileInfo( const std::string &, Maps::FileInfo & );
+
+    bool SaveCompletedCampaignScenario();
 }
 
 #endif

--- a/src/fheroes2/game/game_io.h
+++ b/src/fheroes2/game/game_io.h
@@ -30,6 +30,7 @@ namespace Maps
 
 namespace Game
 {
+    bool SaveCompletedCampaignScenario();
     bool AutoSave();
     bool Save( const std::string & );
     bool Load( const std::string & );


### PR DESCRIPTION
While testing campaign awards, @Branikolog remarked that in the OG, when we complete a campaign scenario the OG creates a save file which will immediately lead you to the campaign scenario selection window (or probably the credits, if it's the last one).

I'm pretty sure this will have merge conflicts with the big campaign award PR, so when either of the PRs are merged I will resolve the conflicts asap.

Example: Good_1_Complete