### PR TITLE
Fix catapult miss animation: show this animation near the actual target object

### DIFF
--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -865,9 +865,9 @@ void Battle::Arena::ApplyActionCatapult( Command & cmd )
         u32 shots = cmd.GetValue();
 
         while ( shots-- ) {
-            int target = cmd.GetValue();
-            u32 damage = cmd.GetValue();
-            bool hit = cmd.GetValue() != 0;
+            const int target = cmd.GetValue();
+            const uint32_t damage = cmd.GetValue();
+            const bool hit = cmd.GetValue() != 0;
 
             if ( target ) {
                 if ( interface ) {

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -865,14 +865,20 @@ void Battle::Arena::ApplyActionCatapult( Command & cmd )
         u32 shots = cmd.GetValue();
 
         while ( shots-- ) {
-            u32 target = cmd.GetValue();
+            int target = cmd.GetValue();
             u32 damage = cmd.GetValue();
+            bool hit = cmd.GetValue() != 0;
 
             if ( target ) {
-                if ( interface )
-                    interface->RedrawActionCatapult( target );
-                SetCastleTargetValue( target, GetCastleTargetValue( target ) - damage );
-                DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "target: " << target );
+                if ( interface ) {
+                    interface->RedrawActionCatapult( target, hit );
+                }
+
+                if ( hit ) {
+                    SetCastleTargetValue( target, GetCastleTargetValue( target ) - damage );
+                }
+
+                DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "target: " << target << ", damage: " << damage << ", hit: " << hit );
             }
         }
     }

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -608,7 +608,7 @@ void Battle::Arena::CatapultAction( void )
 {
     if ( catapult ) {
         u32 shots = catapult->GetShots();
-        std::vector<u32> values( CAT_MISS + 1, 0 );
+        std::vector<u32> values( CAT_CENTRAL_TOWER + 1, 0 );
 
         values[CAT_WALL1] = GetCastleTargetValue( CAT_WALL1 );
         values[CAT_WALL2] = GetCastleTargetValue( CAT_WALL2 );
@@ -616,8 +616,8 @@ void Battle::Arena::CatapultAction( void )
         values[CAT_WALL4] = GetCastleTargetValue( CAT_WALL4 );
         values[CAT_TOWER1] = GetCastleTargetValue( CAT_TOWER1 );
         values[CAT_TOWER2] = GetCastleTargetValue( CAT_TOWER2 );
-        values[CAT_CENTRAL_TOWER] = GetCastleTargetValue( CAT_CENTRAL_TOWER );
         values[CAT_BRIDGE] = GetCastleTargetValue( CAT_BRIDGE );
+        values[CAT_CENTRAL_TOWER] = GetCastleTargetValue( CAT_CENTRAL_TOWER );
 
         Command cmd( MSG_BATTLE_CATAPULT );
 
@@ -626,8 +626,13 @@ void Battle::Arena::CatapultAction( void )
         while ( shots-- ) {
             int target = catapult->GetTarget( values );
             u32 damage = std::min( catapult->GetDamage(), values[target] );
-            cmd << target << damage;
-            values[target] -= damage;
+            bool hit = catapult->GetHitOrMiss();
+
+            cmd << target << damage << ( hit ? 1 : 0 );
+
+            if ( hit ) {
+                values[target] -= damage;
+            }
         }
 
         // preserve the order of shots - command arguments will be extracted in reverse order

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -624,9 +624,9 @@ void Battle::Arena::CatapultAction( void )
         cmd << shots;
 
         while ( shots-- ) {
-            int target = catapult->GetTarget( values );
-            u32 damage = std::min( catapult->GetDamage(), values[target] );
-            bool hit = catapult->GetHitOrMiss();
+            const int target = catapult->GetTarget( values );
+            const uint32_t damage = std::min( catapult->GetDamage(), values[target] );
+            const bool hit = catapult->IsNextShotHit();
 
             cmd << target << damage << ( hit ? 1 : 0 );
 

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -69,7 +69,7 @@ u32 Battle::Catapult::GetDamage() const
     return 1;
 }
 
-Point Battle::Catapult::GetTargetPosition( int target )
+Point Battle::Catapult::GetTargetPosition( int target, bool hit )
 {
     Point res;
 
@@ -92,16 +92,12 @@ Point Battle::Catapult::GetTargetPosition( int target )
     case CAT_TOWER2:
         res = Point( 430, 300 );
         break;
-    case CAT_CENTRAL_TOWER:
-        res = Point( 580, 160 );
-        break;
     case CAT_BRIDGE:
         res = Point( 400, 195 );
         break;
-    case CAT_MISS:
-        res = Point( 610, 320 );
+    case CAT_CENTRAL_TOWER:
+        res = hit ? Point( 580, 160 ) : Point( 610, 320 );
         break;
-
     default:
         break;
     }
@@ -145,16 +141,16 @@ int Battle::Catapult::GetTarget( const std::vector<u32> & values ) const
     }
 
     if ( !targets.empty() ) {
-        // Miss chance is 25%
-        if ( canMiss && 6 > Rand::Get( 1, 20 ) ) {
-            return static_cast<int>( CAT_MISS );
-        }
-        else {
-            return Rand::Get( targets );
-        }
+        return Rand::Get( targets );
     }
 
     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "target not found.." );
 
     return 0;
+}
+
+bool Battle::Catapult::GetHitOrMiss() const
+{
+    // Miss chance is 25%
+    return !( canMiss && Rand::Get( 1, 20 ) < 6 );
 }

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -75,25 +75,25 @@ Point Battle::Catapult::GetTargetPosition( int target, bool hit )
 
     switch ( target ) {
     case CAT_WALL1:
-        res = Point( 475, 45 );
+        res = hit ? Point( 475, 45 ) : Point( 495, 105 );
         break;
     case CAT_WALL2:
-        res = Point( 420, 115 );
+        res = hit ? Point( 420, 115 ) : Point( 460, 175 );
         break;
     case CAT_WALL3:
-        res = Point( 415, 280 );
+        res = hit ? Point( 415, 280 ) : Point( 455, 280 );
         break;
     case CAT_WALL4:
-        res = Point( 490, 390 );
+        res = hit ? Point( 490, 390 ) : Point( 530, 390 );
         break;
     case CAT_TOWER1:
-        res = Point( 430, 40 );
+        res = hit ? Point( 430, 40 ) : Point( 490, 120 );
         break;
     case CAT_TOWER2:
-        res = Point( 430, 300 );
+        res = hit ? Point( 430, 300 ) : Point( 490, 340 );
         break;
     case CAT_BRIDGE:
-        res = Point( 400, 195 );
+        res = hit ? Point( 400, 195 ) : Point( 450, 235 );
         break;
     case CAT_CENTRAL_TOWER:
         res = hit ? Point( 580, 160 ) : Point( 610, 320 );

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -149,7 +149,7 @@ int Battle::Catapult::GetTarget( const std::vector<u32> & values ) const
     return 0;
 }
 
-bool Battle::Catapult::GetHitOrMiss() const
+bool Battle::Catapult::IsNextShotHit() const
 {
     // Miss chance is 25%
     return !( canMiss && Rand::Get( 1, 20 ) < 6 );

--- a/src/fheroes2/battle/battle_catapult.h
+++ b/src/fheroes2/battle/battle_catapult.h
@@ -55,7 +55,7 @@ namespace Battle
 
         int GetTarget( const std::vector<u32> & ) const;
         u32 GetDamage() const;
-        bool GetHitOrMiss() const;
+        bool IsNextShotHit() const;
 
     private:
         u32 catShots;

--- a/src/fheroes2/battle/battle_catapult.h
+++ b/src/fheroes2/battle/battle_catapult.h
@@ -38,8 +38,7 @@ namespace Battle
         CAT_TOWER1 = 5,
         CAT_TOWER2 = 6,
         CAT_BRIDGE = 7,
-        CAT_CENTRAL_TOWER = 8,
-        CAT_MISS = 9
+        CAT_CENTRAL_TOWER = 8
     };
 
     class Catapult
@@ -47,14 +46,16 @@ namespace Battle
     public:
         explicit Catapult( const HeroBase & hero );
 
-        static Point GetTargetPosition( int );
+        static Point GetTargetPosition( int target, bool hit );
 
         u32 GetShots( void ) const
         {
             return catShots;
         }
+
         int GetTarget( const std::vector<u32> & ) const;
         u32 GetDamage() const;
+        bool GetHitOrMiss() const;
 
     private:
         u32 catShots;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3653,7 +3653,7 @@ void Battle::Interface::RedrawActionTowerPart2( const Tower & tower, const Targe
     _movingUnit = NULL;
 }
 
-void Battle::Interface::RedrawActionCatapult( int target )
+void Battle::Interface::RedrawActionCatapult( int target, bool hit )
 {
     LocalEvent & le = LocalEvent::Get();
 
@@ -3674,7 +3674,7 @@ void Battle::Interface::RedrawActionCatapult( int target )
 
     // boulder animation
     Point pt1( 90, 220 );
-    Point pt2 = Catapult::GetTargetPosition( target );
+    Point pt2 = Catapult::GetTargetPosition( target, hit );
     Point max( 300, 20 );
 
     pt1.x += area.x;
@@ -3701,9 +3701,10 @@ void Battle::Interface::RedrawActionCatapult( int target )
         }
     }
 
-    // clod
+    // draw cloud
+    const int icn = hit ? ICN::LICHCLOD : ICN::SMALCLOD;
     uint32_t frame = 0;
-    int icn = target == CAT_MISS ? ICN::SMALCLOD : ICN::LICHCLOD;
+
     AGG::PlaySound( M82::CATSND02 );
 
     while ( le.HandleEvents() && frame < fheroes2::AGG::GetICNCount( icn ) ) {
@@ -4463,8 +4464,9 @@ void Battle::Interface::RedrawActionEarthQuakeSpell( const std::vector<int> & ta
     }
 
     // draw cloud
+    const int icn = ICN::LICHCLOD;
     frame = 0;
-    int icn = ICN::LICHCLOD;
+
     AGG::PlaySound( M82::CATSND02 );
 
     while ( le.HandleEvents() && frame < fheroes2::AGG::GetICNCount( icn ) ) {
@@ -4474,7 +4476,7 @@ void Battle::Interface::RedrawActionEarthQuakeSpell( const std::vector<int> & ta
             RedrawPartialStart();
 
             for ( std::vector<int>::const_iterator it = targets.begin(); it != targets.end(); ++it ) {
-                Point pt2 = Catapult::GetTargetPosition( *it );
+                Point pt2 = Catapult::GetTargetPosition( *it, true );
 
                 pt2.x += area.x;
                 pt2.y += area.y;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -220,7 +220,7 @@ namespace Battle
         void RedrawActionLuck( const Unit & );
         void RedrawActionTowerPart1( const Tower &, const Unit & );
         void RedrawActionTowerPart2( const Tower &, const TargetInfo & );
-        void RedrawActionCatapult( int );
+        void RedrawActionCatapult( int target, bool hit );
         void RedrawActionTeleportSpell( Unit &, s32 );
         void RedrawActionEarthQuakeSpell( const std::vector<int> & );
         void RedrawActionSummonElementalSpell( Unit & target );


### PR DESCRIPTION
fix #3127