### PR TITLE
Disable cursor software emulation for touchpad

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -57,11 +57,14 @@ bool SDL::Init( const uint32_t system )
 
     if ( SDL_INIT_AUDIO & system )
         Mixer::Init();
+
+#if defined( FHEROES2_VITA ) || defined( __SWITCH__ )
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
     if ( SDL_INIT_GAMECONTROLLER & system ) {
         LocalEvent::Get().OpenController();
     }
     LocalEvent::Get().OpenTouchpad();
+#endif
 #endif
 #ifdef WITH_AUDIOCD
     if ( SDL_INIT_CDROM & system )

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -234,6 +234,7 @@ LocalEvent::LocalEvent()
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
 void LocalEvent::OpenController()
 {
+#if defined( FHEROES2_VITA ) || defined( __SWITCH__ )
     for ( int i = 0; i < SDL_NumJoysticks(); ++i ) {
         if ( SDL_IsGameController( i ) ) {
             _gameController = SDL_GameControllerOpen( i );
@@ -243,14 +244,17 @@ void LocalEvent::OpenController()
             }
         }
     }
+#endif
 }
 
 void LocalEvent::CloseController()
 {
+#if defined( FHEROES2_VITA ) || defined( __SWITCH__ )
     if ( SDL_GameControllerGetAttached( _gameController ) ) {
         SDL_GameControllerClose( _gameController );
         _gameController = nullptr;
     }
+#endif
 }
 
 void LocalEvent::OpenTouchpad()

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -255,6 +255,7 @@ void LocalEvent::CloseController()
 
 void LocalEvent::OpenTouchpad()
 {
+#if defined( FHEROES2_VITA ) || defined( __SWITCH__ )
     const int touchNumber = SDL_GetNumTouchDevices();
     if ( touchNumber > 0 ) {
         _touchpadAvailable = true;
@@ -263,6 +264,7 @@ void LocalEvent::OpenTouchpad()
         SDL_SetHint( SDL_HINT_TOUCH_MOUSE_EVENTS, "0" );
 #endif
     }
+#endif
 }
 #endif
 


### PR DESCRIPTION
relates to #2749

Software emulation should be done only on game consoles