### PR TITLE
Disable controller on non console platforms

### DIFF
--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1153,8 +1153,6 @@ bool LocalEvent::HandleEvents( bool delay, bool allowExit )
         case SDL_MOUSEWHEEL:
             HandleMouseWheelEvent( event.wheel );
             break;
-
-#if defined( FHEROES2_VITA ) || defined( __SWITCH__ )
         case SDL_CONTROLLERDEVICEREMOVED:
             if ( _gameController != nullptr ) {
                 const SDL_GameController * removedController = SDL_GameControllerFromInstanceID( event.jdevice.which );
@@ -1182,8 +1180,6 @@ bool LocalEvent::HandleEvents( bool delay, bool allowExit )
         case SDL_CONTROLLERBUTTONUP:
             HandleControllerButtonEvent( event.cbutton );
             break;
-#endif
-
         case SDL_FINGERDOWN:
         case SDL_FINGERUP:
         case SDL_FINGERMOTION:

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -255,7 +255,7 @@ void LocalEvent::CloseController()
 
 void LocalEvent::OpenTouchpad()
 {
-#if defined( FHEROES2_VITA ) || defined ( __SWITCH__ )
+#if defined( FHEROES2_VITA ) || defined( __SWITCH__ )
     const int touchNumber = SDL_GetNumTouchDevices();
     if ( touchNumber > 0 ) {
         _touchpadAvailable = true;
@@ -1843,7 +1843,7 @@ void LocalEvent::SetStateDefaults( void )
     SetState( SDL_SYSWMEVENT, false );
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
-#if defined( FHEROES2_VITA ) || defined ( __SWITCH__ )
+#if defined( FHEROES2_VITA ) || defined( __SWITCH__ )
     SetState( SDL_FINGERDOWN, true );
     SetState( SDL_FINGERUP, true );
     SetState( SDL_FINGERMOTION, true );

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1842,6 +1842,7 @@ void LocalEvent::SetStateDefaults( void )
     SetState( SDL_JOYHATMOTION, false );
     SetState( SDL_SYSWMEVENT, false );
 
+#if SDL_VERSION_ATLEAST( 2, 0, 0 )
 #if defined( FHEROES2_VITA ) || defined ( __SWITCH__ )
     SetState( SDL_FINGERDOWN, true );
     SetState( SDL_FINGERUP, true );
@@ -1850,6 +1851,7 @@ void LocalEvent::SetStateDefaults( void )
     SetState( SDL_FINGERDOWN, false );
     SetState( SDL_FINGERUP, false );
     SetState( SDL_FINGERMOTION, false );
+#endif
 #endif
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -255,6 +255,7 @@ void LocalEvent::CloseController()
 
 void LocalEvent::OpenTouchpad()
 {
+#if defined( FHEROES2_VITA ) || defined ( __SWITCH__ )
     const int touchNumber = SDL_GetNumTouchDevices();
     if ( touchNumber > 0 ) {
         _touchpadAvailable = true;
@@ -263,6 +264,7 @@ void LocalEvent::OpenTouchpad()
         SDL_SetHint( SDL_HINT_TOUCH_MOUSE_EVENTS, "0" );
 #endif
     }
+#endif
 }
 #endif
 
@@ -1839,6 +1841,16 @@ void LocalEvent::SetStateDefaults( void )
     SetState( SDL_JOYBALLMOTION, false );
     SetState( SDL_JOYHATMOTION, false );
     SetState( SDL_SYSWMEVENT, false );
+
+#if defined( FHEROES2_VITA ) || defined ( __SWITCH__ )
+    SetState( SDL_FINGERDOWN, true );
+    SetState( SDL_FINGERUP, true );
+    SetState( SDL_FINGERMOTION, true );
+#else
+    SetState( SDL_FINGERDOWN, false );
+    SetState( SDL_FINGERUP, false );
+    SetState( SDL_FINGERMOTION, false );
+#endif
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
     SetState( SDL_WINDOWEVENT, true );

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -143,7 +143,7 @@ int main( int argc, char ** argv )
 
     u32 subsystem = INIT_VIDEO;
 
-#if defined( FHEROES2_VITA ) || defined (__SWITCH__)
+#if defined( FHEROES2_VITA ) || defined ( __SWITCH__ )
     subsystem |= INIT_GAMECONTROLLER;
 #endif
 

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -143,7 +143,7 @@ int main( int argc, char ** argv )
 
     u32 subsystem = INIT_VIDEO;
 
-#if defined( FHEROES2_VITA ) || defined ( __SWITCH__ )
+#if defined( FHEROES2_VITA ) || defined( __SWITCH__ )
     subsystem |= INIT_GAMECONTROLLER;
 #endif
 

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -143,7 +143,7 @@ int main( int argc, char ** argv )
 
     u32 subsystem = INIT_VIDEO;
 
-#if SDL_VERSION_ATLEAST( 2, 0, 0 )
+#if defined( FHEROES2_VITA ) || defined (__SWITCH__)
     subsystem |= INIT_GAMECONTROLLER;
 #endif
 


### PR DESCRIPTION
Just don't init it on anything else than Switch/Vita
Tested with Xbone One X controller on Linux