### PR TITLE
Reset current music from the previous turn in the beginning of a new human turn

### DIFF
--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -641,6 +641,9 @@ int Interface::Basic::HumanTurn( bool isload )
 
     GameOver::Result & gameResult = GameOver::Result::Get();
 
+    // current music will be set along with the focus, reset music from the previous turn
+    Game::SetCurrentMusic( MUS::UNKNOWN );
+
     // set focus
     if ( conf.ExtGameRememberLastFocus() ) {
         if ( GetFocusHeroes() != nullptr )


### PR DESCRIPTION
Related to #3244: https://github.com/ihhub/fheroes2/issues/3244#issuecomment-828855227