### PR TITLE
Fix issue when troop info window isn't shown after moving a single unit between army bars using drag&drop

### DIFF
--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -292,7 +292,6 @@ bool ArmyBar::ActionBarCursor( ArmyTroop & troop )
 
     if ( isSelected() ) {
         const ArmyTroop * troop2 = GetSelectedItem();
-
         assert( troop2 != nullptr );
 
         if ( &troop == troop2 ) {
@@ -360,7 +359,6 @@ bool ArmyBar::ActionBarLeftMouseSingleClick( ArmyTroop & troop )
         }
 
         ArmyTroop * selectedTroop = GetSelectedItem();
-
         assert( selectedTroop != nullptr );
 
         const bool isSameTroopType = troop.GetID() == selectedTroop->GetID();
@@ -509,7 +507,6 @@ bool ArmyBar::ActionBarLeftMouseDoubleClick( ArmyTroop & troop )
     }
 
     const ArmyTroop * troop2 = GetSelectedItem();
-
     assert( troop2 != nullptr );
 
     if ( &troop == troop2 ) {
@@ -603,7 +600,6 @@ bool ArmyBar::ActionBarRightMouseSingleClick( ArmyTroop & troop )
 {
     if ( AbleToRedistributeArmyOnRightMouseSingleClick( troop ) ) {
         ArmyTroop * selectedTroop = GetSelectedItem();
-
         assert( selectedTroop != nullptr );
 
         RedistributeArmy( *selectedTroop, troop, _army );
@@ -655,7 +651,6 @@ bool ArmyBar::AbleToRedistributeArmyOnRightMouseSingleClick( const ArmyTroop & t
     }
 
     const ArmyTroop * selectedTroop = GetSelectedItem();
-
     assert( selectedTroop != nullptr );
 
     // prevent troop from splitting into its own stack by checking against their pointers
@@ -664,9 +659,5 @@ bool ArmyBar::AbleToRedistributeArmyOnRightMouseSingleClick( const ArmyTroop & t
     }
 
     // we can redistribute troops either to an empty slot or to a slot containing the same creatures
-    if ( !troop.isValid() || selectedTroop->GetID() == troop.GetID() ) {
-        return true;
-    }
-
-    return false;
+    return !troop.isValid() || selectedTroop->GetID() == troop.GetID();
 }

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -32,6 +32,8 @@
 #include "text.h"
 #include "world.h"
 
+#include <cassert>
+
 void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * armyTarget )
 {
     const Army * armyFrom = troopFrom.GetArmy();
@@ -291,6 +293,8 @@ bool ArmyBar::ActionBarCursor( ArmyTroop & troop )
     if ( isSelected() ) {
         const ArmyTroop * troop2 = GetSelectedItem();
 
+        assert( troop2 != nullptr );
+
         if ( &troop == troop2 ) {
             msg = _( "View %{name}" );
             StringReplace( msg, "%{name}", troop.GetName() );
@@ -357,8 +361,7 @@ bool ArmyBar::ActionBarLeftMouseSingleClick( ArmyTroop & troop )
 
         ArmyTroop * selectedTroop = GetSelectedItem();
 
-        if ( !selectedTroop )
-            return false;
+        assert( selectedTroop != nullptr );
 
         const bool isSameTroopType = troop.GetID() == selectedTroop->GetID();
 
@@ -507,6 +510,8 @@ bool ArmyBar::ActionBarLeftMouseDoubleClick( ArmyTroop & troop )
 
     const ArmyTroop * troop2 = GetSelectedItem();
 
+    assert( troop2 != nullptr );
+
     if ( &troop == troop2 ) {
         int flags = ( read_only || _army->SaveLastTroop() ? Dialog::READONLY | Dialog::BUTTONS : Dialog::BUTTONS );
         const Castle * castle = _army->inCastle();
@@ -597,9 +602,11 @@ bool ArmyBar::ActionBarRightMouseHold( ArmyTroop & troop )
 bool ArmyBar::ActionBarRightMouseSingleClick( ArmyTroop & troop )
 {
     if ( AbleToRedistributeArmyOnRightMouseSingleClick( troop ) ) {
-        ArmyTroop & selectedTroop = *GetSelectedItem();
+        ArmyTroop * selectedTroop = GetSelectedItem();
 
-        RedistributeArmy( selectedTroop, troop, _army );
+        assert( selectedTroop != nullptr );
+
+        RedistributeArmy( *selectedTroop, troop, _army );
         ResetSelected();
 
         return true;
@@ -647,15 +654,17 @@ bool ArmyBar::AbleToRedistributeArmyOnRightMouseSingleClick( const ArmyTroop & t
         return false;
     }
 
-    const ArmyTroop & selectedTroop = *GetSelectedItem();
+    const ArmyTroop * selectedTroop = GetSelectedItem();
+
+    assert( selectedTroop != nullptr );
 
     // prevent troop from splitting into its own stack by checking against their pointers
-    if ( &troop == &selectedTroop ) {
+    if ( &troop == selectedTroop ) {
         return false;
     }
 
     // we can redistribute troops either to an empty slot or to a slot containing the same creatures
-    if ( !troop.isValid() || selectedTroop.GetID() == troop.GetID() ) {
+    if ( !troop.isValid() || selectedTroop->GetID() == troop.GetID() ) {
         return true;
     }
 

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -32,7 +32,7 @@
 #include "text.h"
 #include "world.h"
 
-void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * armyTarget, bool & isTroopInfoVisible )
+void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * armyTarget )
 {
     const Army * armyFrom = troopFrom.GetArmy();
     const bool saveLastTroop = armyFrom->SaveLastTroop() && armyFrom != armyTarget;
@@ -50,7 +50,6 @@ void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * ar
         // or else just move the source troop around
         else if ( !troopTarget.isValid() ) {
             Army::SwapTroops( troopFrom, troopTarget );
-            isTroopInfoVisible = false;
         }
     }
     else {
@@ -149,7 +148,6 @@ ArmyBar::ArmyBar( Army * ptr, bool mini, bool ro, bool change /* false */ )
     , use_mini_sprite( mini )
     , read_only( ro )
     , can_change( change )
-    , _isTroopInfoVisible( true )
 {
     if ( use_mini_sprite )
         SetBackground( fheroes2::Size( 43, 43 ), fheroes2::GetColorId( 0, 45, 0 ) );
@@ -273,7 +271,6 @@ void ArmyBar::RedrawItem( ArmyTroop & troop, const fheroes2::Rect & pos, bool se
 void ArmyBar::ResetSelected( void )
 {
     spcursor.hide();
-    _isTroopInfoVisible = true;
     Interface::ItemsActionBar<ArmyTroop>::ResetSelected();
 }
 
@@ -367,7 +364,7 @@ bool ArmyBar::ActionBarLeftMouseSingleClick( ArmyTroop & troop )
 
         // prioritize standard split via shift hotkey
         if ( ( !troop.isValid() || isSameTroopType ) && Game::HotKeyHoldEvent( Game::EVENT_STACKSPLIT_SHIFT ) ) {
-            RedistributeArmy( *selectedTroop, troop, _army, _isTroopInfoVisible );
+            RedistributeArmy( *selectedTroop, troop, _army );
             ResetSelected();
         }
         else if ( selectedTroop && isSameTroopType ) {
@@ -455,7 +452,7 @@ bool ArmyBar::ActionBarLeftMouseSingleClick( ArmyTroop & destTroop, ArmyTroop & 
     // this will ensure that clicking on a different troop type while shift key is pressed will not show the split dialogue, which can be ambiguous
     if ( Game::HotKeyHoldEvent( Game::EVENT_STACKSPLIT_SHIFT ) ) {
         if ( destTroop.isEmpty() || isSameTroopType ) {
-            RedistributeArmy( selectedTroop, destTroop, _army, _isTroopInfoVisible );
+            RedistributeArmy( selectedTroop, destTroop, _army );
             ResetSelected();
         }
         return false;
@@ -553,7 +550,7 @@ bool ArmyBar::ActionBarLeftMouseRelease( ArmyTroop & troop )
         const bool isTroopPressValid = troopPress && troopPress->isValid();
 
         if ( isTroopPressValid && ( !troop.isValid() || troop.GetID() == troopPress->GetID() ) ) {
-            RedistributeArmy( *troopPress, troop, _army, _isTroopInfoVisible );
+            RedistributeArmy( *troopPress, troop, _army );
             le.ResetPressLeft();
 
             if ( isSelected() )
@@ -561,7 +558,6 @@ bool ArmyBar::ActionBarLeftMouseRelease( ArmyTroop & troop )
         }
     }
 
-    _isTroopInfoVisible = true;
     return true;
 }
 
@@ -572,11 +568,10 @@ bool ArmyBar::ActionBarLeftMouseRelease( ArmyTroop & destTroop, ArmyTroop & sele
 
     // cross-army drag split
     if ( selectedTroop.isValid() && ( !destTroop.isValid() || selectedTroop.GetID() == destTroop.GetID() ) ) {
-        RedistributeArmy( selectedTroop, destTroop, _army, _isTroopInfoVisible );
+        RedistributeArmy( selectedTroop, destTroop, _army );
         return true;
     }
 
-    _isTroopInfoVisible = true;
     return false;
 }
 
@@ -586,7 +581,7 @@ bool ArmyBar::ActionBarRightMouseHold( ArmyTroop & troop )
     if ( ActionBarRightMouseSingleClick( troop ) )
         return true;
 
-    if ( troop.isValid() && _isTroopInfoVisible ) {
+    if ( troop.isValid() ) {
         ResetSelected();
 
         if ( can_change && !_army->SaveLastTroop() )
@@ -615,7 +610,7 @@ bool ArmyBar::ActionBarRightMouseSingleClick( ArmyTroop & troop )
         return false;
 
     if ( !troop.isValid() || selectedTroop.GetID() == troop.GetID() ) {
-        RedistributeArmy( selectedTroop, troop, _army, _isTroopInfoVisible );
+        RedistributeArmy( selectedTroop, troop, _army );
         ResetSelected();
 
         return true;
@@ -627,24 +622,12 @@ bool ArmyBar::ActionBarRightMouseSingleClick( ArmyTroop & troop )
 bool ArmyBar::ActionBarRightMouseSingleClick( ArmyTroop & destTroop, ArmyTroop & selectedTroop )
 {
     if ( !destTroop.isValid() || destTroop.GetID() == selectedTroop.GetID() ) {
-        RedistributeArmy( selectedTroop, destTroop, _army, _isTroopInfoVisible );
+        RedistributeArmy( selectedTroop, destTroop, _army );
         ResetSelected();
 
         return true;
     }
 
-    return true;
-}
-
-bool ArmyBar::ActionBarRightMouseRelease( ArmyTroop & /*troop*/ )
-{
-    _isTroopInfoVisible = true;
-    return true;
-}
-
-bool ArmyBar::ActionBarRightMouseRelease( ArmyTroop & /*destTroop*/, ArmyTroop & /*selectedTroop*/ )
-{
-    _isTroopInfoVisible = true;
     return true;
 }
 

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -613,8 +613,6 @@ bool ArmyBar::ActionBarRightMouseSingleClick( ArmyTroop & destTroop, ArmyTroop &
     if ( !destTroop.isValid() || destTroop.GetID() == selectedTroop.GetID() ) {
         RedistributeArmy( selectedTroop, destTroop, _army );
         ResetSelected();
-
-        return true;
     }
 
     return true;

--- a/src/fheroes2/army/army_bar.h
+++ b/src/fheroes2/army/army_bar.h
@@ -65,6 +65,8 @@ protected:
     fheroes2::MovableSprite spcursor;
 
 private:
+    bool AbleToRedistributeArmyOnRightMouseSingleClick( const ArmyTroop & troop );
+
     Army * _army;
     fheroes2::Image backsf;
     bool use_mini_sprite;

--- a/src/fheroes2/army/army_bar.h
+++ b/src/fheroes2/army/army_bar.h
@@ -54,8 +54,6 @@ public:
     bool ActionBarRightMouseHold( ArmyTroop & troop ) override;
     bool ActionBarRightMouseSingleClick( ArmyTroop & troop ) override;
     bool ActionBarRightMouseSingleClick( ArmyTroop & destTroop, ArmyTroop & selectedTroop ) override;
-    bool ActionBarRightMouseRelease( ArmyTroop & troop ) override;
-    bool ActionBarRightMouseRelease( ArmyTroop & destTroop, ArmyTroop & selectedTroop ) override;
 
     bool ActionBarCursor( ArmyTroop & ) override;
     bool ActionBarCursor( ArmyTroop &, ArmyTroop & ) override;
@@ -72,7 +70,6 @@ private:
     bool use_mini_sprite;
     bool read_only;
     bool can_change;
-    bool _isTroopInfoVisible;
     std::string msg;
 };
 


### PR DESCRIPTION
There is a bug that prevents to view troop info after moving a single unit between army bars. How to reproduce:

1. Run the game and load attached savefile;
2. Enter the Burlock castle (Sorceress);
3. Move the single black dragon from Roxana's army (the rightmost stack) to garrison using drag&drop;
4. Try to view troop info for this black dragon using right mouse button. You will not be able to do this.

The same issue is observed when drag&drop is used to move a single unit between meeting heroes. The proposed patch is intended to fix this.

[Army_Troop_Info_Bug.zip](https://github.com/ihhub/fheroes2/files/6446493/Army_Troop_Info_Bug.zip)