### PR TITLE
Fix bug with mouse cursor not visible after left-clicking on hero's secondary skill in Kingdom Overview

### DIFF
--- a/src/fheroes2/dialog/dialog_skillinfo.cpp
+++ b/src/fheroes2/dialog/dialog_skillinfo.cpp
@@ -45,6 +45,10 @@ void Dialog::SecondarySkillInfo( const std::string & header, const std::string &
     // cursor
     Cursor & cursor = Cursor::Get();
 
+    const bool savedCursorVisibility = cursor.isVisible();
+    const int savedCursorTheme = cursor.Themes();
+
+    cursor.Hide();
     cursor.SetThemes( cursor.POINTER );
 
     TextBox box1( header, Font::YELLOW_BIG, BOXAREA_WIDTH );
@@ -94,8 +98,11 @@ void Dialog::SecondarySkillInfo( const std::string & header, const std::string &
         button.reset( new fheroes2::Button( pt.x, pt.y, system, 1, 2 ) );
     }
 
-    if ( button )
+    if ( button ) {
         button->draw();
+
+        cursor.Show();
+    }
 
     display.render();
 
@@ -118,6 +125,13 @@ void Dialog::SecondarySkillInfo( const std::string & header, const std::string &
         if ( HotKeyCloseWindow ) {
             break;
         }
+    }
+
+    cursor.Hide();
+    cursor.SetThemes( savedCursorTheme );
+
+    if ( savedCursorVisibility ) {
+        cursor.Show();
     }
 }
 


### PR DESCRIPTION
There is a bug: mouse cursor not visible after left-clicking on hero's secondary skill in Kingdom Overview. How to reproduce:

1. Run the game and start any new game with starting hero;
2. Open the Kingdom Overview screen and left-click on any secondary skill of the starting hero;
3. Secondary skill overview dialog is opened, but no cursor is visible on the screen.

This PR is intended to fix this issue.

There is a big mess with cursors in game, they are controlled by hand in an arbitrary way, often contradictory. Need to think about how to better organize this...