### PR TITLE
Add correct support of The Price of Loyalty add-on

### DIFF
--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -333,7 +333,7 @@ bool AGG::ReadDataDir( void )
         }
     }
 
-    conf.SetPriceLoyaltyVersion( heroes2x_agg.isGood() );
+    conf.EnablePriceOfLoyaltySupport( heroes2x_agg.isGood() );
 
     return heroes2_agg.isGood();
 }

--- a/src/fheroes2/agg/icn.cpp
+++ b/src/fheroes2/agg/icn.cpp
@@ -1410,7 +1410,7 @@ u32 ICN::AnimationFrame( int icn, u32 start, u32 ticket, bool quantity )
     // extra objects for loyalty version
     case X_LOC1:
 
-        if ( Settings::Get().PriceLoyaltyVersion() )
+        if ( Settings::Get().isPriceOfLoyaltySupported() )
             switch ( start ) {
             // alchemist tower
             case 0x04:
@@ -1435,7 +1435,7 @@ u32 ICN::AnimationFrame( int icn, u32 start, u32 ticket, bool quantity )
     // extra objects for loyalty version
     case X_LOC2:
 
-        if ( Settings::Get().PriceLoyaltyVersion() )
+        if ( Settings::Get().isPriceOfLoyaltySupported() )
             switch ( start ) {
             // mermaid
             case 0x0A:
@@ -1460,7 +1460,7 @@ u32 ICN::AnimationFrame( int icn, u32 start, u32 ticket, bool quantity )
     // extra objects for loyalty version
     case X_LOC3:
 
-        if ( Settings::Get().PriceLoyaltyVersion() )
+        if ( Settings::Get().isPriceOfLoyaltySupported() )
             switch ( start ) {
             // hut magi
             case 0x00:

--- a/src/fheroes2/campaign/campaign_savedata.cpp
+++ b/src/fheroes2/campaign/campaign_savedata.cpp
@@ -122,7 +122,7 @@ namespace Campaign
     {
         const int loadVersion = Game::GetLoadVersion();
 
-        if ( loadVersion >= FORMAT_VERSION_090_RELEASE && loadVersion < FORMAT_VERSION_093_RELEASE ) {
+        if ( loadVersion < FORMAT_VERSION_093_RELEASE ) {
             std::vector<std::string> tempOldObtainedCampaignAwards;
             msg >> tempOldObtainedCampaignAwards;
         }

--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -313,7 +313,7 @@ BuildingInfo::BuildingInfo( const Castle & c, building_t b )
     building = castle.isBuild( b ) ? castle.GetUpgradeBuilding( b ) : b;
 
     if ( BUILD_TAVERN == building && Race::NECR == castle.GetRace() )
-        building = Settings::Get().PriceLoyaltyVersion() ? BUILD_SHRINE : BUILD_TAVERN;
+        building = ( Settings::Get().isCurrentMapPriceOfLoyalty() ) ? BUILD_SHRINE : BUILD_NOTHING;
 
     bcond = castle.CheckBuyBuilding( building );
 
@@ -447,7 +447,7 @@ void BuildingInfo::Redraw( void ) const
         }
 
         // build image
-        if ( BUILD_DISABLE == bcond && BUILD_TAVERN == building ) { // skip necromancer's tavern
+        if ( BUILD_NOTHING == building ) { // skip necromancer's tavern
             fheroes2::Blit( fheroes2::AGG::GetICN( ICN::CASLXTRA, 0 ), display, area.x, area.y );
             return;
         }
@@ -511,6 +511,10 @@ bool BuildingInfo::QueueEventProcessing( fheroes2::ButtonBase & exitButton ) con
 
 bool BuildingInfo::DialogBuyBuilding( bool buttons ) const
 {
+    if ( building == BUILD_NOTHING ) {
+        return false;
+    }
+
     fheroes2::Display & display = fheroes2::Display::instance();
 
     const int system = ( Settings::Get().ExtGameEvilInterface() ? ICN::SYSTEME : ICN::SYSTEM );
@@ -653,16 +657,16 @@ std::string BuildingInfo::GetConditionDescription( void ) const
     switch ( bcond ) {
     case NOT_TODAY:
     case NEED_CASTLE:
-        res = GetBuildConditionDescription( bcond );
-        break;
+        return GetBuildConditionDescription( bcond );
 
     case BUILD_DISABLE:
         if ( building == BUILD_SHIPYARD ) {
             res = _( "Cannot build %{name} because castle is too far from water." );
             StringReplace( res, "%{name}", Castle::GetStringBuilding( BUILD_SHIPYARD, castle.GetRace() ) );
         }
-        else
+        else {
             res = "disable build.";
+        }
         break;
 
     case LACK_RESOURCES:
@@ -694,6 +698,10 @@ std::string BuildingInfo::GetConditionDescription( void ) const
 
 void BuildingInfo::SetStatusMessage( StatusBar & bar ) const
 {
+    if ( building == BUILD_NOTHING ) {
+        return;
+    }
+
     std::string str;
 
     switch ( bcond ) {

--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -447,7 +447,7 @@ void BuildingInfo::Redraw( void ) const
         }
 
         // build image
-        if ( BUILD_NOTHING == building ) { // skip necromancer's tavern
+        if ( BUILD_NOTHING == building ) {
             fheroes2::Blit( fheroes2::AGG::GetICN( ICN::CASLXTRA, 0 ), display, area.x, area.y );
             return;
         }
@@ -702,8 +702,6 @@ void BuildingInfo::SetStatusMessage( StatusBar & bar ) const
         return;
     }
 
-    std::string str;
-
     switch ( bcond ) {
     case NOT_TODAY:
     case ALREADY_BUILT:
@@ -712,14 +710,12 @@ void BuildingInfo::SetStatusMessage( StatusBar & bar ) const
     case LACK_RESOURCES:
     case REQUIRES_BUILD:
     case ALLOW_BUILD:
-        str = GetConditionDescription();
+        bar.ShowMessage( GetConditionDescription() );
         break;
 
     default:
         break;
     }
-
-    bar.ShowMessage( str );
 }
 
 DwellingItem::DwellingItem( const Castle & castle, u32 dw )

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -325,7 +325,7 @@ void Castle::PostLoad( void )
     // remove tavern from necromancer castle
     if ( Race::NECR == race && ( building & BUILD_TAVERN ) ) {
         building &= ~BUILD_TAVERN;
-        if ( Settings::Get().PriceLoyaltyVersion() )
+        if ( Settings::Get().isCurrentMapPriceOfLoyalty() )
             building |= BUILD_SHRINE;
     }
 
@@ -358,7 +358,7 @@ bool Castle::isCapital( void ) const
 
 u32 Castle::CountBuildings( void ) const
 {
-    const u32 tavern = ( race == Race::NECR ? ( Settings::Get().PriceLoyaltyVersion() ? BUILD_SHRINE : BUILD_NOTHING ) : BUILD_TAVERN );
+    const u32 tavern = ( race == Race::NECR ? ( Settings::Get().isCurrentMapPriceOfLoyalty() ? BUILD_SHRINE : BUILD_NOTHING ) : BUILD_TAVERN );
 
     return CountBits( building
                       & ( BUILD_THIEVESGUILD | tavern | BUILD_SHIPYARD | BUILD_WELL | BUILD_STATUE | BUILD_LEFTTURRET | BUILD_RIGHTTURRET | BUILD_MARKETPLACE | BUILD_WEL2
@@ -1428,7 +1428,7 @@ int Castle::CheckBuyBuilding( u32 build ) const
             return BUILD_DISABLE;
         break;
     case BUILD_SHRINE:
-        if ( Race::NECR != GetRace() || !Settings::Get().PriceLoyaltyVersion() )
+        if ( Race::NECR != GetRace() || !Settings::Get().isCurrentMapPriceOfLoyalty() )
             return BUILD_DISABLE;
         break;
     case BUILD_TAVERN:

--- a/src/fheroes2/castle/castle_building.cpp
+++ b/src/fheroes2/castle/castle_building.cpp
@@ -1033,7 +1033,7 @@ void CastlePackOrdersBuildings( const Castle & castle, std::vector<building_t> &
         break;
     case Race::NECR:
         ordersBuildings.push_back( BUILD_SPEC );
-        if ( Settings::Get().PriceLoyaltyVersion() )
+        if ( Settings::Get().isCurrentMapPriceOfLoyalty() )
             ordersBuildings.push_back( BUILD_SHRINE );
         ordersBuildings.push_back( BUILD_TENT );
         ordersBuildings.push_back( BUILD_CASTLE );

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -227,7 +227,7 @@ u32 Castle::OpenTown( void )
     buildingMageGuild.Redraw();
 
     // tavern
-    const bool isSkipTavernInteraction = ( Race::NECR == race ) && !Settings::Get().PriceLoyaltyVersion();
+    const bool isSkipTavernInteraction = ( Race::NECR == race ) && !Settings::Get().isCurrentMapPriceOfLoyalty();
     BuildingInfo buildingTavern( *this, BUILD_TAVERN );
     buildingTavern.SetPos( cur_pt.x + 149, cur_pt.y + 157 );
     buildingTavern.Redraw();

--- a/src/fheroes2/dialog/dialog_system.cpp
+++ b/src/fheroes2/dialog/dialog_system.cpp
@@ -134,7 +134,7 @@ int Dialog::SystemOptions( void )
         if ( le.MouseClickLeft( rect3 ) ) {
             int type = conf.MusicType() + 1;
             // If there's no expansion files we skip this option
-            if ( type == MUSIC_MIDI_EXPANSION && !conf.PriceLoyaltyVersion() )
+            if ( type == MUSIC_MIDI_EXPANSION && !conf.isPriceOfLoyaltySupported() )
                 ++type;
             if ( type == MUSIC_EXTERNAL && !externalMusicSupported )
                 ++type;

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -83,9 +83,9 @@ namespace Game
 #endif
         }
 
-        int gameType;
         uint16_t status;
         Maps::FileInfo info;
+        int gameType;
         const int _saveFileVersion;
     };
 

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -51,9 +51,7 @@ namespace
 
 namespace Game
 {
-    // This was default structure prior 0.9 version so all save files were under the same category. We added a game type format which is stored
-    // in HeaderSAV structure. By default all old saves are under single-player save type.
-    struct HeaderSAVBase
+    struct HeaderSAV
     {
         enum
         {
@@ -61,19 +59,23 @@ namespace Game
             IS_LOYALTY = 0x4000
         };
 
-        HeaderSAVBase()
+        HeaderSAV( const int saveFileVersion )
             : status( 0 )
+            , gameType( 0 )
+            , _saveFileVersion( saveFileVersion )
         {}
 
-        HeaderSAVBase( const Maps::FileInfo & fi, const bool loyalty )
+        HeaderSAV( const Maps::FileInfo & fi, const int gameType_, const int saveFileVersion )
             : status( 0 )
             , info( fi )
+            , gameType( gameType_ )
+            , _saveFileVersion( saveFileVersion )
         {
             time_t rawtime;
             std::time( &rawtime );
             info.localtime = rawtime;
 
-            if ( loyalty )
+            if ( fi._version == GameVersion::PRICE_OF_LOYALTY )
                 status |= IS_LOYALTY;
 
 #ifdef WITH_ZLIB
@@ -81,33 +83,10 @@ namespace Game
 #endif
         }
 
+        int gameType;
         uint16_t status;
         Maps::FileInfo info;
-
-        friend StreamBase & operator<<( StreamBase & msg, const HeaderSAVBase & hdr )
-        {
-            return msg << hdr.status << hdr.info;
-        }
-
-        friend StreamBase & operator>>( StreamBase & msg, HeaderSAVBase & hdr )
-        {
-            return msg >> hdr.status >> hdr.info;
-        }
-    };
-
-    struct HeaderSAV : HeaderSAVBase
-    {
-        HeaderSAV()
-            : HeaderSAVBase()
-            , gameType( 0 )
-        {}
-
-        HeaderSAV( const Maps::FileInfo & fi, const bool loyalty, const int gameType_ )
-            : HeaderSAVBase( fi, loyalty )
-            , gameType( gameType_ )
-        {}
-
-        int gameType;
+        const int _saveFileVersion;
     };
 
     StreamBase & operator<<( StreamBase & msg, const HeaderSAV & hdr )
@@ -117,7 +96,16 @@ namespace Game
 
     StreamBase & operator>>( StreamBase & msg, HeaderSAV & hdr )
     {
-        return msg >> hdr.status >> hdr.info >> hdr.gameType;
+        if ( hdr._saveFileVersion < FORMAT_VERSION_094_RELEASE ) {
+            msg >> hdr.status >> hdr.info >> hdr.gameType;
+        }
+        else {
+            msg >> hdr.status >> hdr.info;
+            msg >> hdr.info._version;
+            msg >> hdr.gameType;
+        }
+
+        return msg;
     }
 }
 
@@ -146,7 +134,7 @@ bool Game::Save( const std::string & fn )
 
     // raw info content
     fs << static_cast<uint8_t>( SAV2ID3 >> 8 ) << static_cast<uint8_t>( SAV2ID3 & 0xFF ) << std::to_string( loadver ) << loadver
-       << HeaderSAV( conf.CurrentFileInfo(), conf.PriceLoyaltyVersion(), conf.GameType() );
+       << HeaderSAV( conf.CurrentFileInfo(), conf.GameType(), CURRENT_FORMAT_VERSION );
     fs.close();
 
     ZStreamFile fz;
@@ -199,18 +187,9 @@ bool Game::Load( const std::string & fn )
         return false;
 
     int fileGameType = Game::TYPE_STANDARD;
-    HeaderSAVBase header;
-    // starting from 0.8.4, headers also include gameType
-    if ( binver >= FORMAT_VERSION_084_RELEASE ) {
-        HeaderSAV currentFormatHeader;
-        fs >> currentFormatHeader;
-
-        header = currentFormatHeader;
-        fileGameType = currentFormatHeader.gameType;
-    }
-    else {
-        fs >> header;
-    }
+    HeaderSAV header( binver );
+    fs >> header;
+    fileGameType = header.gameType;
 
     size_t offset = fs.tell();
     fs.close();
@@ -235,7 +214,7 @@ bool Game::Load( const std::string & fn )
         return false;
     }
 
-    if ( ( header.status & HeaderSAV::IS_LOYALTY ) && !conf.PriceLoyaltyVersion() )
+    if ( ( header.status & HeaderSAV::IS_LOYALTY ) && !conf.isPriceOfLoyaltySupported() )
         Dialog::Message( "Warning", _( "This file is saved in the \"Price Loyalty\" version.\nSome items may be unavailable." ), Font::BIG, Dialog::OK );
 
     // SaveMemToFile(std::vector<u8>(fz.data(), fz.data() + fz.size()), "gdata.bin");
@@ -256,7 +235,7 @@ bool Game::Load( const std::string & fn )
     u16 end_check = 0;
 
     fz >> World::Get() >> conf;
-    if ( ( conf.GameType() & Game::TYPE_CAMPAIGN ) != 0 && Game::GetLoadVersion() == FORMAT_VERSION_084_RELEASE ) {
+    if ( ( conf.GameType() & Game::TYPE_CAMPAIGN ) != 0 ) {
         fz >> Campaign::CampaignSaveData::Get();
     }
 
@@ -269,7 +248,7 @@ bool Game::Load( const std::string & fn )
         Dialog::Message( "Warning!", warningMessage, Font::BIG, Dialog::OK );
     }
 
-    if ( fileGameType & Game::TYPE_CAMPAIGN && binver >= FORMAT_VERSION_090_RELEASE )
+    if ( fileGameType & Game::TYPE_CAMPAIGN )
         fz >> Campaign::CampaignSaveData::Get();
 
     fz >> end_check;
@@ -321,18 +300,9 @@ bool Game::LoadSAV2FileInfo( const std::string & fn, Maps::FileInfo & finfo )
         return false;
 
     int fileGameType = Game::TYPE_STANDARD;
-    HeaderSAVBase header;
-    // starting from 0.9.0, headers also include gameType
-    if ( binver >= FORMAT_VERSION_084_RELEASE ) {
-        HeaderSAV currentFormatHeader;
-        fs >> currentFormatHeader;
-
-        header = currentFormatHeader;
-        fileGameType = currentFormatHeader.gameType;
-    }
-    else {
-        fs >> header;
-    }
+    HeaderSAV header( binver );
+    fs >> header;
+    fileGameType = header.gameType;
 
     if ( ( Settings::Get().GameType() & fileGameType ) == 0 )
         return false;

--- a/src/fheroes2/game/game_io.h
+++ b/src/fheroes2/game/game_io.h
@@ -25,7 +25,7 @@
 
 namespace Maps
 {
-    class FileInfo;
+    struct FileInfo;
 }
 
 namespace Game

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -254,11 +254,11 @@ void Heroes::LoadFromMP2( s32 map_index, int cl, int rc, StreamBuf st )
         }
 
         // fixed race for custom portrait (after level up)
-        if ( _race != rc )
-            _race = rc;
+        _race = rc;
     }
-    else
+    else {
         st.skip( 1 );
+    }
 
     // 3 artifacts
     PickupArtifact( Artifact( st.get() ) );
@@ -274,7 +274,7 @@ void Heroes::LoadFromMP2( s32 map_index, int cl, int rc, StreamBuf st )
     if ( experience == 0 )
         experience = GetStartingXp();
 
-    bool custom_secskill = ( st.get() != 0 );
+    const bool custom_secskill = ( st.get() != 0 );
 
     // custom skill
     if ( custom_secskill ) {
@@ -294,8 +294,9 @@ void Heroes::LoadFromMP2( s32 map_index, int cl, int rc, StreamBuf st )
             if ( ( *it ).isValid() )
                 secondary_skills.AddSkill( *it );
     }
-    else
+    else {
         st.skip( 16 );
+    }
 
     // unknown
     st.skip( 1 );
@@ -305,8 +306,9 @@ void Heroes::LoadFromMP2( s32 map_index, int cl, int rc, StreamBuf st )
         SetModes( NOTDEFAULTS );
         name = Game::GetEncodeString( st.toString( 13 ) );
     }
-    else
+    else {
         st.skip( 13 );
+    }
 
     // patrol
     if ( st.get() ) {
@@ -1775,7 +1777,7 @@ void AllHeroes::Init( void )
     push_back( new Heroes( Heroes::BAX, Race::NECR, 5 ) );
 
     // loyalty version
-    if ( Settings::Get().PriceLoyaltyVersion() ) {
+    if ( Settings::Get().isCurrentMapPriceOfLoyalty() ) {
         push_back( new Heroes( Heroes::SOLMYR, Race::WZRD, 5 ) );
         push_back( new Heroes( Heroes::DAINWIN, Race::WRLK, 5 ) );
         push_back( new Heroes( Heroes::MOG, Race::NECR, 5 ) );

--- a/src/fheroes2/maps/maps_fileinfo.h
+++ b/src/fheroes2/maps/maps_fileinfo.h
@@ -27,11 +27,16 @@
 #include "gamedefs.h"
 #include "serialize.h"
 
+enum class GameVersion : int
+{
+    SUCCESSION_WARS = 0,
+    PRICE_OF_LOYALTY = 1
+};
+
 namespace Maps
 {
-    class FileInfo
+    struct FileInfo
     {
-    public:
         FileInfo();
         FileInfo( const FileInfo & );
 
@@ -103,11 +108,15 @@ namespace Maps
         u32 localtime;
 
         bool with_heroes;
+
+        GameVersion _version;
     };
 
     StreamBase & operator<<( StreamBase &, const FileInfo & );
     StreamBase & operator>>( StreamBase &, FileInfo & );
 }
+
+StreamBase & operator>>( StreamBase & stream, GameVersion & version );
 
 using MapsFileInfoList = std::vector<Maps::FileInfo>;
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2093,7 +2093,7 @@ void Maps::Tiles::FixedPreload( Tiles & tile )
     }
 
     // fix price loyalty objects.
-    if ( Settings::Get().PriceLoyaltyVersion() )
+    if ( Settings::Get().isPriceOfLoyaltySupported() )
         switch ( tile.GetObject() ) {
         case MP2::OBJ_UNKNW_79:
         case MP2::OBJ_UNKNW_7A:

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -205,19 +205,19 @@ int MP2::GetICNObject( int tileset )
 
     // extra objects for loyalty version
     case 61:
-        if ( Settings::Get().PriceLoyaltyVersion() )
+        if ( Settings::Get().isPriceOfLoyaltySupported() )
             return ICN::X_LOC1;
         break;
 
     // extra objects for loyalty version
     case 62:
-        if ( Settings::Get().PriceLoyaltyVersion() )
+        if ( Settings::Get().isPriceOfLoyaltySupported() )
             return ICN::X_LOC2;
         break;
 
     // extra objects for loyalty version
     case 63:
-        if ( Settings::Get().PriceLoyaltyVersion() )
+        if ( Settings::Get().isPriceOfLoyaltySupported() )
             return ICN::X_LOC3;
         break;
 
@@ -835,7 +835,7 @@ bool MP2::isWaterObject( int obj )
     }
 
     // price loyalty: editor allow place other objects
-    return Settings::Get().PriceLoyaltyVersion() ? isGroundObject( obj ) : false;
+    return Settings::Get().isPriceOfLoyaltySupported() ? isGroundObject( obj ) : false;
 }
 
 bool MP2::isGroundObject( int obj )

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -541,7 +541,7 @@ int Artifact::Level( void ) const
     case SPADE_NECROMANCY:
     case HEART_FIRE:
     case HEART_ICE:
-        return Settings::Get().PriceLoyaltyVersion() ? ART_LOYALTY | LoyaltyLevel() : ART_LOYALTY;
+        return Settings::Get().isCurrentMapPriceOfLoyalty() ? ART_LOYALTY | LoyaltyLevel() : ART_LOYALTY;
 
     default:
         break;
@@ -638,7 +638,6 @@ int Artifact::Rand( level_t lvl )
         if ( ( lvl & Artifact( art ).Level() ) && !( artifacts[art].bits & ART_DISABLED ) && !( artifacts[art].bits & ART_RNDUSED ) )
             v.push_back( art );
 
-    //
     if ( v.empty() ) {
         for ( u32 art = ULTIMATE_BOOK; art < UNKNOWN; ++art )
             if ( ( lvl & Artifact( art ).Level() ) && !( artifacts[art].bits & ART_DISABLED ) )
@@ -655,7 +654,7 @@ Artifact Artifact::FromMP2IndexSprite( u32 index )
 {
     if ( 0xA2 > index )
         return Artifact( ( index - 1 ) / 2 );
-    else if ( Settings::Get().PriceLoyaltyVersion() && 0xAB < index && 0xCE > index )
+    else if ( Settings::Get().isPriceOfLoyaltySupported() && 0xAB < index && 0xCE > index )
         return Artifact( ( index - 1 ) / 2 );
     else if ( 0xA3 == index )
         return Artifact( Rand( ART_LEVEL123 ) );

--- a/src/fheroes2/system/players.h
+++ b/src/fheroes2/system/players.h
@@ -32,7 +32,7 @@
 
 namespace Maps
 {
-    class FileInfo;
+    struct FileInfo;
 }
 
 namespace AI

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -293,7 +293,7 @@ namespace
             _( "game: offer to continue the game afer victory condition" ),
         },
 
-        {0, NULL},
+        { 0, NULL },
     };
 
     const char * GetGeneralSettingDescription( int settingId )

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -33,284 +33,286 @@
 #include "tinyconfig.h"
 #include "version.h"
 
-enum
+namespace
 {
-    // ??? = 0x00000001,
-    // ??? = 0x00000002,
-    GLOBAL_PRICELOYALTY = 0x00000004,
-
-    // GLOBAL_POCKETPC = 0x00000008,
-    GLOBAL_DEDICATEDSERVER = 0x00000010,
-    GLOBAL_LOCALCLIENT = 0x00000020,
-
-    GLOBAL_SHOWCPANEL = 0x00000040,
-    GLOBAL_SHOWRADAR = 0x00000080,
-    GLOBAL_SHOWICONS = 0x00000100,
-    GLOBAL_SHOWBUTTONS = 0x00000200,
-    GLOBAL_SHOWSTATUS = 0x00000400,
-
-    GLOBAL_FULLSCREEN = 0x00008000,
-    GLOBAL_USESWSURFACE = 0x00010000,
-
-    GLOBAL_SOUND = 0x00020000,
-    GLOBAL_MUSIC_EXT = 0x00040000,
-    GLOBAL_MUSIC_CD = 0x00080000,
-    GLOBAL_MUSIC_MIDI = 0x00100000,
-
-    GLOBAL_USEUNICODE = 0x00200000,
-    GLOBAL_ALTRESOURCE = 0x00400000,
-
-    GLOBAL_BATTLE_SHOW_GRID = 0x00800000,
-    GLOBAL_BATTLE_SHOW_MOUSE_SHADOW = 0x01000000,
-    GLOBAL_BATTLE_SHOW_MOVE_SHADOW = 0x02000000,
-    GLOBAL_BATTLE_AUTO_RESOLVE = 0x04000000,
-    GLOBAL_BATTLE_AUTO_SPELLCAST = 0x08000000,
-
-    GLOBAL_MUSIC = GLOBAL_MUSIC_CD | GLOBAL_MUSIC_EXT | GLOBAL_MUSIC_MIDI
-};
-
-struct settings_t
-{
-    u32 id;
-    const char * str;
-
-    bool operator==( u32 i ) const
+    enum
     {
-        return id && id == i;
+        // UNUSED = 0x00000001,
+        // UNUSED = 0x00000002,
+        GLOBAL_PRICELOYALTY = 0x00000004,
+
+        // UNUSED = 0x00000008,
+        GLOBAL_DEDICATEDSERVER = 0x00000010,
+        GLOBAL_LOCALCLIENT = 0x00000020,
+
+        GLOBAL_SHOWCPANEL = 0x00000040,
+        GLOBAL_SHOWRADAR = 0x00000080,
+        GLOBAL_SHOWICONS = 0x00000100,
+        GLOBAL_SHOWBUTTONS = 0x00000200,
+        GLOBAL_SHOWSTATUS = 0x00000400,
+
+        GLOBAL_FULLSCREEN = 0x00008000,
+        GLOBAL_USESWSURFACE = 0x00010000,
+
+        GLOBAL_SOUND = 0x00020000,
+        GLOBAL_MUSIC_EXT = 0x00040000,
+        GLOBAL_MUSIC_CD = 0x00080000,
+        GLOBAL_MUSIC_MIDI = 0x00100000,
+
+        GLOBAL_USEUNICODE = 0x00200000,
+        GLOBAL_ALTRESOURCE = 0x00400000,
+
+        GLOBAL_BATTLE_SHOW_GRID = 0x00800000,
+        GLOBAL_BATTLE_SHOW_MOUSE_SHADOW = 0x01000000,
+        GLOBAL_BATTLE_SHOW_MOVE_SHADOW = 0x02000000,
+        GLOBAL_BATTLE_AUTO_RESOLVE = 0x04000000,
+        GLOBAL_BATTLE_AUTO_SPELLCAST = 0x08000000,
+
+        GLOBAL_MUSIC = GLOBAL_MUSIC_CD | GLOBAL_MUSIC_EXT | GLOBAL_MUSIC_MIDI
+    };
+
+    struct settings_t
+    {
+        u32 id;
+        const char * str;
+
+        bool operator==( u32 i ) const
+        {
+            return id && id == i;
+        }
+    };
+
+    // external settings
+    const settings_t settingsGeneral[] = {
+        {
+            GLOBAL_SOUND,
+            "sound",
+        },
+        {
+            GLOBAL_MUSIC_MIDI,
+            "music",
+        },
+        {
+            GLOBAL_FULLSCREEN,
+            "fullscreen",
+        },
+        {
+            GLOBAL_USEUNICODE,
+            "unicode",
+        },
+        {
+            GLOBAL_ALTRESOURCE,
+            "alt resource",
+        },
+        {
+            GLOBAL_USESWSURFACE,
+            "use swsurface only",
+        },
+        {
+            0,
+            NULL,
+        },
+    };
+
+    // internal settings
+    const settings_t settingsFHeroes2[] = {
+        {
+            Settings::GAME_SAVE_REWRITE_CONFIRM,
+            _( "game: always confirm for rewrite savefile" ),
+        },
+        {
+            Settings::GAME_REMEMBER_LAST_FOCUS,
+            _( "game: remember last focus" ),
+        },
+        {
+            Settings::GAME_BATTLE_SHOW_DAMAGE,
+            _( "battle: show damage info" ),
+        },
+        {
+            Settings::WORLD_SHOW_VISITED_CONTENT,
+            _( "world: show visited content from objects" ),
+        },
+        {
+            Settings::WORLD_SHOW_TERRAIN_PENALTY,
+            _( "world: show terrain penalty" ),
+        },
+        {
+            Settings::WORLD_SCOUTING_EXTENDED,
+            _( "world: scouting skill show extended content info" ),
+        },
+        {
+            Settings::WORLD_ALLOW_SET_GUARDIAN,
+            _( "world: allow set guardian to objects" ),
+        },
+        {
+            Settings::WORLD_ONLY_FIRST_MONSTER_ATTACK,
+            _( "world: only the first monster will attack (H2 bug)." ),
+        },
+        {
+            Settings::WORLD_EYE_EAGLE_AS_SCHOLAR,
+            _( "world: Eagle Eye also works like Scholar in H3." ),
+        },
+        {
+            Settings::WORLD_BAN_WEEKOF,
+            _( "world: ban for WeekOf/MonthOf Monsters" ),
+        },
+        {
+            Settings::WORLD_BAN_PLAGUES,
+            _( "world: ban plagues months" ),
+        },
+        {
+            Settings::WORLD_BAN_MONTHOF_MONSTERS,
+            _( "world: Months Of Monsters do not place creatures on map" ),
+        },
+        {
+            Settings::WORLD_ARTIFACT_CRYSTAL_BALL,
+            _( "world: Crystal Ball also added Identify Hero and Visions spells" ),
+        },
+        {
+            Settings::WORLD_STARTHERO_LOSSCOND4HUMANS,
+            _( "world: Starting heroes as Loss Conditions for Human Players" ),
+        },
+        {
+            Settings::WORLD_1HERO_HIRED_EVERY_WEEK,
+            _( "world: Only 1 hero can be hired by the one player every week" ),
+        },
+        {
+            Settings::CASTLE_1HERO_HIRED_EVERY_WEEK,
+            _( "world: Each castle allows one hero to be recruited every week" ),
+        },
+        {
+            Settings::WORLD_SCALE_NEUTRAL_ARMIES,
+            _( "world: Neutral armies scale with game difficulty" ),
+        },
+        {
+            Settings::WORLD_USE_UNIQUE_ARTIFACTS_ML,
+            _( "world: use unique artifacts for morale/luck" ),
+        },
+        {
+            Settings::WORLD_USE_UNIQUE_ARTIFACTS_RS,
+            _( "world: use unique artifacts for resource affecting" ),
+        },
+        {
+            Settings::WORLD_USE_UNIQUE_ARTIFACTS_PS,
+            _( "world: use unique artifacts for primary skills" ),
+        },
+        {
+            Settings::WORLD_USE_UNIQUE_ARTIFACTS_SS,
+            _( "world: use unique artifacts for secondary skills" ),
+        },
+        {
+            Settings::WORLD_EXT_OBJECTS_CAPTURED,
+            _( "world: Wind/Water Mills and Magic Garden can be captured" ),
+        },
+        {
+            Settings::WORLD_DISABLE_BARROW_MOUNDS,
+            _( "world: disable Barrow Mounds" ),
+        },
+        {
+            Settings::CASTLE_ALLOW_GUARDIANS,
+            _( "castle: allow guardians" ),
+        },
+        {
+            Settings::CASTLE_MAGEGUILD_POINTS_TURN,
+            _( "castle: higher mage guilds regenerate more spell points/turn (20/40/60/80/100%)" ),
+        },
+        {
+            Settings::HEROES_BUY_BOOK_FROM_SHRINES,
+            _( "heroes: allow buy a spellbook from Shrines" ),
+        },
+        {
+            Settings::HEROES_COST_DEPENDED_FROM_LEVEL,
+            _( "heroes: recruit cost to be dependent on hero level" ),
+        },
+        {
+            Settings::HEROES_REMEMBER_POINTS_RETREAT,
+            _( "heroes: remember move points for retreat/surrender result" ),
+        },
+        {
+            Settings::HEROES_TRANSCRIBING_SCROLLS,
+            _( "heroes: allow transcribing scrolls (needs: Eye Eagle skill)" ),
+        },
+        {
+            Settings::HEROES_ARENA_ANY_SKILLS,
+            _( "heroes: in Arena can choose any of primary skills" ),
+        },
+        {
+            Settings::UNIONS_ALLOW_HERO_MEETINGS,
+            _( "unions: allow meeting heroes" ),
+        },
+        {
+            Settings::UNIONS_ALLOW_CASTLE_VISITING,
+            _( "unions: allow castle visiting" ),
+        },
+        {
+            Settings::BATTLE_SHOW_ARMY_ORDER,
+            _( "battle: show army order" ),
+        },
+        {
+            Settings::BATTLE_SOFT_WAITING,
+            _( "battle: soft wait troop" ),
+        },
+        {
+            Settings::BATTLE_SKIP_INCREASE_DEFENSE,
+            _( "battle: skip increase +2 defense" ),
+        },
+        {
+            Settings::BATTLE_REVERSE_WAIT_ORDER,
+            _( "battle: reverse wait order (fast, average, slow)" ),
+        },
+        {
+            Settings::GAME_SHOW_SYSTEM_INFO,
+            _( "game: show system info" ),
+        },
+        {
+            Settings::GAME_AUTOSAVE_ON,
+            _( "game: autosave on" ),
+        },
+        {
+            Settings::GAME_AUTOSAVE_BEGIN_DAY,
+            _( "game: autosave will be made at the beginning of the day" ),
+        },
+        {
+            Settings::GAME_USE_FADE,
+            _( "game: use fade" ),
+        },
+        {
+            Settings::GAME_EVIL_INTERFACE,
+            _( "game: use evil interface" ),
+        },
+        {
+            Settings::GAME_DYNAMIC_INTERFACE,
+            _( "game: also use dynamic interface for castles" ),
+        },
+        {
+            Settings::GAME_HIDE_INTERFACE,
+            _( "game: hide interface" ),
+        },
+        {
+            Settings::GAME_CONTINUE_AFTER_VICTORY,
+            _( "game: offer to continue the game afer victory condition" ),
+        },
+
+        {0, NULL},
+    };
+
+    const char * GetGeneralSettingDescription( int settingId )
+    {
+        const settings_t * ptr = settingsGeneral;
+        while ( ptr->id != 0 ) {
+            if ( ptr->id == static_cast<uint32_t>( settingId ) )
+                return ptr->str;
+            ++ptr;
+        }
+        return NULL;
     }
-};
-
-// external settings
-const settings_t settingsGeneral[] = {
-    {
-        GLOBAL_SOUND,
-        "sound",
-    },
-    {
-        GLOBAL_MUSIC_MIDI,
-        "music",
-    },
-    {
-        GLOBAL_FULLSCREEN,
-        "fullscreen",
-    },
-    {
-        GLOBAL_USEUNICODE,
-        "unicode",
-    },
-    {
-        GLOBAL_ALTRESOURCE,
-        "alt resource",
-    },
-    {
-        GLOBAL_USESWSURFACE,
-        "use swsurface only",
-    },
-    {
-        0,
-        NULL,
-    },
-};
-
-const char * GetGeneralSettingDescription( int settingId )
-{
-    const settings_t * ptr = settingsGeneral;
-    while ( ptr->id != 0 ) {
-        if ( ptr->id == static_cast<uint32_t>( settingId ) )
-            return ptr->str;
-        ++ptr;
-    }
-    return NULL;
 }
 
-// internal settings
-const settings_t settingsFHeroes2[] = {
-    {
-        Settings::GAME_SAVE_REWRITE_CONFIRM,
-        _( "game: always confirm for rewrite savefile" ),
-    },
-    {
-        Settings::GAME_REMEMBER_LAST_FOCUS,
-        _( "game: remember last focus" ),
-    },
-    {
-        Settings::GAME_BATTLE_SHOW_DAMAGE,
-        _( "battle: show damage info" ),
-    },
-    {
-        Settings::WORLD_SHOW_VISITED_CONTENT,
-        _( "world: show visited content from objects" ),
-    },
-    {
-        Settings::WORLD_SHOW_TERRAIN_PENALTY,
-        _( "world: show terrain penalty" ),
-    },
-    {
-        Settings::WORLD_SCOUTING_EXTENDED,
-        _( "world: scouting skill show extended content info" ),
-    },
-    {
-        Settings::WORLD_ALLOW_SET_GUARDIAN,
-        _( "world: allow set guardian to objects" ),
-    },
-    {
-        Settings::WORLD_ONLY_FIRST_MONSTER_ATTACK,
-        _( "world: only the first monster will attack (H2 bug)." ),
-    },
-    {
-        Settings::WORLD_EYE_EAGLE_AS_SCHOLAR,
-        _( "world: Eagle Eye also works like Scholar in H3." ),
-    },
-    {
-        Settings::WORLD_BAN_WEEKOF,
-        _( "world: ban for WeekOf/MonthOf Monsters" ),
-    },
-    {
-        Settings::WORLD_BAN_PLAGUES,
-        _( "world: ban plagues months" ),
-    },
-    {
-        Settings::WORLD_BAN_MONTHOF_MONSTERS,
-        _( "world: Months Of Monsters do not place creatures on map" ),
-    },
-    {
-        Settings::WORLD_ARTIFACT_CRYSTAL_BALL,
-        _( "world: Crystal Ball also added Identify Hero and Visions spells" ),
-    },
-    {
-        Settings::WORLD_STARTHERO_LOSSCOND4HUMANS,
-        _( "world: Starting heroes as Loss Conditions for Human Players" ),
-    },
-    {
-        Settings::WORLD_1HERO_HIRED_EVERY_WEEK,
-        _( "world: Only 1 hero can be hired by the one player every week" ),
-    },
-    {
-        Settings::CASTLE_1HERO_HIRED_EVERY_WEEK,
-        _( "world: Each castle allows one hero to be recruited every week" ),
-    },
-    {
-        Settings::WORLD_SCALE_NEUTRAL_ARMIES,
-        _( "world: Neutral armies scale with game difficulty" ),
-    },
-    {
-        Settings::WORLD_USE_UNIQUE_ARTIFACTS_ML,
-        _( "world: use unique artifacts for morale/luck" ),
-    },
-    {
-        Settings::WORLD_USE_UNIQUE_ARTIFACTS_RS,
-        _( "world: use unique artifacts for resource affecting" ),
-    },
-    {
-        Settings::WORLD_USE_UNIQUE_ARTIFACTS_PS,
-        _( "world: use unique artifacts for primary skills" ),
-    },
-    {
-        Settings::WORLD_USE_UNIQUE_ARTIFACTS_SS,
-        _( "world: use unique artifacts for secondary skills" ),
-    },
-    {
-        Settings::WORLD_EXT_OBJECTS_CAPTURED,
-        _( "world: Wind/Water Mills and Magic Garden can be captured" ),
-    },
-    {
-        Settings::WORLD_DISABLE_BARROW_MOUNDS,
-        _( "world: disable Barrow Mounds" ),
-    },
-    {
-        Settings::CASTLE_ALLOW_GUARDIANS,
-        _( "castle: allow guardians" ),
-    },
-    {
-        Settings::CASTLE_MAGEGUILD_POINTS_TURN,
-        _( "castle: higher mage guilds regenerate more spell points/turn (20/40/60/80/100%)" ),
-    },
-    {
-        Settings::HEROES_BUY_BOOK_FROM_SHRINES,
-        _( "heroes: allow buy a spellbook from Shrines" ),
-    },
-    {
-        Settings::HEROES_COST_DEPENDED_FROM_LEVEL,
-        _( "heroes: recruit cost to be dependent on hero level" ),
-    },
-    {
-        Settings::HEROES_REMEMBER_POINTS_RETREAT,
-        _( "heroes: remember move points for retreat/surrender result" ),
-    },
-    {
-        Settings::HEROES_TRANSCRIBING_SCROLLS,
-        _( "heroes: allow transcribing scrolls (needs: Eye Eagle skill)" ),
-    },
-    {
-        Settings::HEROES_ARENA_ANY_SKILLS,
-        _( "heroes: in Arena can choose any of primary skills" ),
-    },
-    {
-        Settings::UNIONS_ALLOW_HERO_MEETINGS,
-        _( "unions: allow meeting heroes" ),
-    },
-    {
-        Settings::UNIONS_ALLOW_CASTLE_VISITING,
-        _( "unions: allow castle visiting" ),
-    },
-    {
-        Settings::BATTLE_SHOW_ARMY_ORDER,
-        _( "battle: show army order" ),
-    },
-    {
-        Settings::BATTLE_SOFT_WAITING,
-        _( "battle: soft wait troop" ),
-    },
-    {
-        Settings::BATTLE_SKIP_INCREASE_DEFENSE,
-        _( "battle: skip increase +2 defense" ),
-    },
-    {
-        Settings::BATTLE_REVERSE_WAIT_ORDER,
-        _( "battle: reverse wait order (fast, average, slow)" ),
-    },
-    {
-        Settings::GAME_SHOW_SYSTEM_INFO,
-        _( "game: show system info" ),
-    },
-    {
-        Settings::GAME_AUTOSAVE_ON,
-        _( "game: autosave on" ),
-    },
-    {
-        Settings::GAME_AUTOSAVE_BEGIN_DAY,
-        _( "game: autosave will be made at the beginning of the day" ),
-    },
-    {
-        Settings::GAME_USE_FADE,
-        _( "game: use fade" ),
-    },
-    {
-        Settings::GAME_EVIL_INTERFACE,
-        _( "game: use evil interface" ),
-    },
-    {
-        Settings::GAME_DYNAMIC_INTERFACE,
-        _( "game: also use dynamic interface for castles" ),
-    },
-    {
-        Settings::GAME_HIDE_INTERFACE,
-        _( "game: hide interface" ),
-    },
-    {
-        Settings::GAME_CONTINUE_AFTER_VICTORY,
-        _( "game: offer to continue the game afer victory condition" ),
-    },
-
-    {0, NULL},
-};
-
-std::string Settings::GetVersion( void )
+std::string Settings::GetVersion()
 {
     return std::to_string( MAJOR_VERSION ) + '.' + std::to_string( MINOR_VERSION ) + '.' + std::to_string( INTERMEDIATE_VERSION );
 }
 
-/* constructor */
 Settings::Settings()
     : debug( 0 )
     , video_mode( fheroes2::Size( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT ) )
@@ -340,13 +342,14 @@ Settings::Settings()
     opt_global.SetModes( GLOBAL_SHOWSTATUS );
     opt_global.SetModes( GLOBAL_MUSIC_EXT );
     opt_global.SetModes( GLOBAL_SOUND );
-    // Set expansion version by default - turn off if heroes2x.agg not found
-    opt_global.SetModes( GLOBAL_PRICELOYALTY );
 
     opt_global.SetModes( GLOBAL_BATTLE_SHOW_GRID );
     opt_global.SetModes( GLOBAL_BATTLE_SHOW_MOUSE_SHADOW );
     opt_global.SetModes( GLOBAL_BATTLE_SHOW_MOVE_SHADOW );
     opt_global.SetModes( GLOBAL_BATTLE_AUTO_SPELLCAST );
+
+    // The Price of Loyalty is not supported by default.
+    EnablePriceOfLoyaltySupport( false );
 }
 
 Settings::~Settings()
@@ -355,7 +358,7 @@ Settings::~Settings()
         BinarySave();
 }
 
-Settings & Settings::Get( void )
+Settings & Settings::Get()
 {
     static Settings conf;
 
@@ -480,7 +483,7 @@ bool Settings::Read( const std::string & filename )
         else if ( sval == "expansion" ) {
             opt_global.ResetModes( GLOBAL_MUSIC );
             opt_global.SetModes( GLOBAL_MUSIC_MIDI );
-            if ( PriceLoyaltyVersion() )
+            if ( isPriceOfLoyaltySupported() )
                 _musicType = MUSIC_MIDI_EXPANSION;
         }
         else if ( sval == "cd" ) {
@@ -639,7 +642,7 @@ bool Settings::Read( const std::string & filename )
     return true;
 }
 
-void Settings::PostLoad( void )
+void Settings::PostLoad()
 {
     if ( ExtModes( GAME_HIDE_INTERFACE ) ) {
         opt_global.SetModes( GLOBAL_SHOWCPANEL );
@@ -671,7 +674,7 @@ bool Settings::Save( const std::string & filename ) const
     return true;
 }
 
-std::string Settings::String( void ) const
+std::string Settings::String() const
 {
     std::ostringstream os;
     std::string musicType;
@@ -800,43 +803,48 @@ void Settings::SetCurrentFileInfo( const Maps::FileInfo & fi )
     preferably_count_players = 0;
 }
 
-const Maps::FileInfo & Settings::CurrentFileInfo( void ) const
+const Maps::FileInfo & Settings::CurrentFileInfo() const
 {
     return current_maps_file;
 }
 
+bool Settings::isCurrentMapPriceOfLoyalty() const
+{
+    return current_maps_file._version == GameVersion::PRICE_OF_LOYALTY;
+}
+
 /* return debug */
-int Settings::Debug( void ) const
+int Settings::Debug() const
 {
     return debug;
 }
 
 /* return game difficulty */
-int Settings::GameDifficulty( void ) const
+int Settings::GameDifficulty() const
 {
     return game_difficulty;
 }
 
-int Settings::CurrentColor( void ) const
+int Settings::CurrentColor() const
 {
     return players.current_color;
 }
 
-const std::string & Settings::SelectVideoDriver( void ) const
+const std::string & Settings::SelectVideoDriver() const
 {
     return video_driver;
 }
 
 /* return fontname */
-const std::string & Settings::FontsNormal( void ) const
+const std::string & Settings::FontsNormal() const
 {
     return font_normal;
 }
-const std::string & Settings::FontsSmall( void ) const
+const std::string & Settings::FontsSmall() const
 {
     return font_small;
 }
-const std::string & Settings::ForceLang( void ) const
+const std::string & Settings::ForceLang() const
 {
     return force_lang;
 }
@@ -844,15 +852,15 @@ const std::string & Settings::loadedFileLanguage() const
 {
     return _loadedFileLanguage;
 }
-const std::string & Settings::MapsCharset( void ) const
+const std::string & Settings::MapsCharset() const
 {
     return maps_charset;
 }
-int Settings::FontsNormalSize( void ) const
+int Settings::FontsNormalSize() const
 {
     return size_normal;
 }
-int Settings::FontsSmallSize( void ) const
+int Settings::FontsSmallSize() const
 {
     return size_small;
 }
@@ -934,7 +942,7 @@ std::string Settings::GetLastFile( const std::string & prefix, const std::string
     return files.empty() ? name : files.back();
 }
 
-std::string Settings::GetLangDir( void )
+std::string Settings::GetLangDir()
 {
 #ifdef CONFIGURE_FHEROES2_LOCALEDIR
     return std::string( CONFIGURE_FHEROES2_LOCALEDIR );
@@ -981,47 +989,47 @@ std::string Settings::GetWriteableDir( const char * subdir )
     return "";
 }
 
-bool Settings::MusicExt( void ) const
+bool Settings::MusicExt() const
 {
     return opt_global.Modes( GLOBAL_MUSIC_EXT );
 }
-bool Settings::MusicMIDI( void ) const
+bool Settings::MusicMIDI() const
 {
     return opt_global.Modes( GLOBAL_MUSIC_MIDI );
 }
-bool Settings::MusicCD( void ) const
+bool Settings::MusicCD() const
 {
     return opt_global.Modes( GLOBAL_MUSIC_CD );
 }
 
 /* return sound */
-bool Settings::Sound( void ) const
+bool Settings::Sound() const
 {
     return opt_global.Modes( GLOBAL_SOUND );
 }
 
 /* return music */
-bool Settings::Music( void ) const
+bool Settings::Music() const
 {
     return opt_global.Modes( GLOBAL_MUSIC );
 }
 
 /* return move speed */
-int Settings::HeroesMoveSpeed( void ) const
+int Settings::HeroesMoveSpeed() const
 {
     return heroes_speed;
 }
-int Settings::AIMoveSpeed( void ) const
+int Settings::AIMoveSpeed() const
 {
     return ai_speed;
 }
-int Settings::BattleSpeed( void ) const
+int Settings::BattleSpeed() const
 {
     return battle_speed;
 }
 
 /* return scroll speed */
-int Settings::ScrollSpeed( void ) const
+int Settings::ScrollSpeed() const
 {
     return scroll_speed;
 }
@@ -1114,75 +1122,75 @@ void Settings::SetScrollSpeed( int speed )
     }
 }
 
-bool Settings::UseAltResource( void ) const
+bool Settings::UseAltResource() const
 {
     return opt_global.Modes( GLOBAL_ALTRESOURCE );
 }
 
-bool Settings::PriceLoyaltyVersion( void ) const
+bool Settings::isPriceOfLoyaltySupported() const
 {
     return opt_global.Modes( GLOBAL_PRICELOYALTY );
 }
 
-bool Settings::LoadedGameVersion( void ) const
+bool Settings::LoadedGameVersion() const
 {
     // 0x80 value should be same as in Game::TYPE_LOADFILE enumeration value
     // This constant not used here, to not drag dependency on the game.h and game.cpp in compilation target.
     return ( game_type & 0x80 ) != 0;
 }
 
-bool Settings::ShowControlPanel( void ) const
+bool Settings::ShowControlPanel() const
 {
     return opt_global.Modes( GLOBAL_SHOWCPANEL );
 }
 
-bool Settings::ShowRadar( void ) const
+bool Settings::ShowRadar() const
 {
     return opt_global.Modes( GLOBAL_SHOWRADAR );
 }
 
-bool Settings::ShowIcons( void ) const
+bool Settings::ShowIcons() const
 {
     return opt_global.Modes( GLOBAL_SHOWICONS );
 }
 
-bool Settings::ShowButtons( void ) const
+bool Settings::ShowButtons() const
 {
     return opt_global.Modes( GLOBAL_SHOWBUTTONS );
 }
 
-bool Settings::ShowStatus( void ) const
+bool Settings::ShowStatus() const
 {
     return opt_global.Modes( GLOBAL_SHOWSTATUS );
 }
 
 /* unicode support */
-bool Settings::Unicode( void ) const
+bool Settings::Unicode() const
 {
     return opt_global.Modes( GLOBAL_USEUNICODE );
 }
 
-bool Settings::BattleShowGrid( void ) const
+bool Settings::BattleShowGrid() const
 {
     return opt_global.Modes( GLOBAL_BATTLE_SHOW_GRID );
 }
 
-bool Settings::BattleShowMouseShadow( void ) const
+bool Settings::BattleShowMouseShadow() const
 {
     return opt_global.Modes( GLOBAL_BATTLE_SHOW_MOUSE_SHADOW );
 }
 
-bool Settings::BattleShowMoveShadow( void ) const
+bool Settings::BattleShowMoveShadow() const
 {
     return opt_global.Modes( GLOBAL_BATTLE_SHOW_MOVE_SHADOW );
 }
 
-bool Settings::BattleAutoResolve( void ) const
+bool Settings::BattleAutoResolve() const
 {
     return opt_global.Modes( GLOBAL_BATTLE_AUTO_RESOLVE );
 }
 
-bool Settings::BattleAutoSpellcast( void ) const
+bool Settings::BattleAutoSpellcast() const
 {
     return opt_global.Modes( GLOBAL_BATTLE_AUTO_SPELLCAST );
 }
@@ -1210,11 +1218,11 @@ void Settings::SetCurrentColor( int color )
     players.current_color = color;
 }
 
-int Settings::SoundVolume( void ) const
+int Settings::SoundVolume() const
 {
     return sound_volume;
 }
-int Settings::MusicVolume( void ) const
+int Settings::MusicVolume() const
 {
     return music_volume;
 }
@@ -1247,7 +1255,7 @@ bool Settings::IsGameType( int f ) const
     return ( game_type & f ) != 0;
 }
 
-int Settings::GameType( void ) const
+int Settings::GameType() const
 {
     return game_type;
 }
@@ -1258,12 +1266,12 @@ void Settings::SetGameType( int type )
     game_type = type;
 }
 
-const Players & Settings::GetPlayers( void ) const
+const Players & Settings::GetPlayers() const
 {
     return players;
 }
 
-Players & Settings::GetPlayers( void )
+Players & Settings::GetPlayers()
 {
     return players;
 }
@@ -1273,22 +1281,22 @@ void Settings::SetPreferablyCountPlayers( int c )
     preferably_count_players = 6 < c ? 6 : c;
 }
 
-int Settings::PreferablyCountPlayers( void ) const
+int Settings::PreferablyCountPlayers() const
 {
     return preferably_count_players;
 }
 
-const std::string & Settings::MapsFile( void ) const
+const std::string & Settings::MapsFile() const
 {
     return current_maps_file.file;
 }
 
-const std::string & Settings::MapsName( void ) const
+const std::string & Settings::MapsName() const
 {
     return current_maps_file.name;
 }
 
-const std::string & Settings::MapsDescription( void ) const
+const std::string & Settings::MapsDescription() const
 {
     return current_maps_file.description;
 }
@@ -1298,12 +1306,12 @@ const std::string & Settings::externalMusicCommand() const
     return _externalMusicCommand;
 }
 
-int Settings::MapsDifficulty( void ) const
+int Settings::MapsDifficulty() const
 {
     return current_maps_file.difficulty;
 }
 
-fheroes2::Size Settings::MapsSize( void ) const
+fheroes2::Size Settings::MapsSize() const
 {
     return fheroes2::Size( current_maps_file.size_w, current_maps_file.size_h );
 }
@@ -1313,52 +1321,52 @@ bool Settings::AllowChangeRace( int f ) const
     return ( current_maps_file.rnd_races & f ) != 0;
 }
 
-bool Settings::GameStartWithHeroes( void ) const
+bool Settings::GameStartWithHeroes() const
 {
     return current_maps_file.with_heroes;
 }
 
-int Settings::ConditionWins( void ) const
+int Settings::ConditionWins() const
 {
     return current_maps_file.ConditionWins();
 }
 
-int Settings::ConditionLoss( void ) const
+int Settings::ConditionLoss() const
 {
     return current_maps_file.ConditionLoss();
 }
 
-bool Settings::WinsCompAlsoWins( void ) const
+bool Settings::WinsCompAlsoWins() const
 {
     return current_maps_file.WinsCompAlsoWins();
 }
 
-int Settings::WinsFindArtifactID( void ) const
+int Settings::WinsFindArtifactID() const
 {
     return current_maps_file.WinsFindArtifactID();
 }
 
-bool Settings::WinsFindUltimateArtifact( void ) const
+bool Settings::WinsFindUltimateArtifact() const
 {
     return current_maps_file.WinsFindUltimateArtifact();
 }
 
-u32 Settings::WinsAccumulateGold( void ) const
+u32 Settings::WinsAccumulateGold() const
 {
     return current_maps_file.WinsAccumulateGold();
 }
 
-fheroes2::Point Settings::WinsMapsPositionObject( void ) const
+fheroes2::Point Settings::WinsMapsPositionObject() const
 {
     return current_maps_file.WinsMapsPositionObject();
 }
 
-fheroes2::Point Settings::LossMapsPositionObject( void ) const
+fheroes2::Point Settings::LossMapsPositionObject() const
 {
     return current_maps_file.LossMapsPositionObject();
 }
 
-u32 Settings::LossCountDays( void ) const
+u32 Settings::LossCountDays() const
 {
     return current_maps_file.LossCountDays();
 }
@@ -1373,7 +1381,7 @@ void Settings::SetUnicode( bool f )
     f ? opt_global.SetModes( GLOBAL_USEUNICODE ) : opt_global.ResetModes( GLOBAL_USEUNICODE );
 }
 
-void Settings::SetPriceLoyaltyVersion( bool set )
+void Settings::EnablePriceOfLoyaltySupport( const bool set )
 {
     if ( set ) {
         opt_global.SetModes( GLOBAL_PRICELOYALTY );
@@ -1410,12 +1418,12 @@ void Settings::SetBattleMouseShaded( bool f )
     f ? opt_global.SetModes( GLOBAL_BATTLE_SHOW_MOUSE_SHADOW ) : opt_global.ResetModes( GLOBAL_BATTLE_SHOW_MOUSE_SHADOW );
 }
 
-void Settings::ResetSound( void )
+void Settings::ResetSound()
 {
     opt_global.ResetModes( GLOBAL_SOUND );
 }
 
-void Settings::ResetMusic( void )
+void Settings::ResetMusic()
 {
     opt_global.ResetModes( GLOBAL_MUSIC );
 }
@@ -1517,17 +1525,17 @@ void Settings::ExtResetModes( u32 f )
     }
 }
 
-bool Settings::ExtCastleGuildRestorePointsTurn( void ) const
+bool Settings::ExtCastleGuildRestorePointsTurn() const
 {
     return ExtModes( CASTLE_MAGEGUILD_POINTS_TURN );
 }
 
-bool Settings::ExtCastleAllowGuardians( void ) const
+bool Settings::ExtCastleAllowGuardians() const
 {
     return ExtModes( CASTLE_ALLOW_GUARDIANS );
 }
 
-bool Settings::ExtWorldShowVisitedContent( void ) const
+bool Settings::ExtWorldShowVisitedContent() const
 {
     return ExtModes( WORLD_SHOW_VISITED_CONTENT );
 }
@@ -1537,222 +1545,222 @@ bool Settings::ExtWorldShowTerrainPenalty() const
     return ExtModes( WORLD_SHOW_TERRAIN_PENALTY );
 }
 
-bool Settings::ExtWorldScouteExtended( void ) const
+bool Settings::ExtWorldScouteExtended() const
 {
     return ExtModes( WORLD_SCOUTING_EXTENDED );
 }
 
-bool Settings::ExtGameRememberLastFocus( void ) const
+bool Settings::ExtGameRememberLastFocus() const
 {
     return ExtModes( GAME_REMEMBER_LAST_FOCUS );
 }
 
-bool Settings::ExtWorldAllowSetGuardian( void ) const
+bool Settings::ExtWorldAllowSetGuardian() const
 {
     return ExtModes( WORLD_ALLOW_SET_GUARDIAN );
 }
 
-bool Settings::ExtWorldArtifactCrystalBall( void ) const
+bool Settings::ExtWorldArtifactCrystalBall() const
 {
     return ExtModes( WORLD_ARTIFACT_CRYSTAL_BALL );
 }
 
-bool Settings::ExtWorldOnlyFirstMonsterAttack( void ) const
+bool Settings::ExtWorldOnlyFirstMonsterAttack() const
 {
     return ExtModes( WORLD_ONLY_FIRST_MONSTER_ATTACK );
 }
 
-bool Settings::ExtWorldEyeEagleAsScholar( void ) const
+bool Settings::ExtWorldEyeEagleAsScholar() const
 {
     return ExtModes( WORLD_EYE_EAGLE_AS_SCHOLAR );
 }
 
-bool Settings::ExtHeroBuySpellBookFromShrine( void ) const
+bool Settings::ExtHeroBuySpellBookFromShrine() const
 {
     return ExtModes( HEROES_BUY_BOOK_FROM_SHRINES );
 }
 
-bool Settings::ExtHeroRecruitCostDependedFromLevel( void ) const
+bool Settings::ExtHeroRecruitCostDependedFromLevel() const
 {
     return ExtModes( HEROES_COST_DEPENDED_FROM_LEVEL );
 }
 
-bool Settings::ExtHeroRememberPointsForRetreating( void ) const
+bool Settings::ExtHeroRememberPointsForRetreating() const
 {
     return ExtModes( HEROES_REMEMBER_POINTS_RETREAT );
 }
 
-bool Settings::ExtUnionsAllowCastleVisiting( void ) const
+bool Settings::ExtUnionsAllowCastleVisiting() const
 {
     return ExtModes( UNIONS_ALLOW_CASTLE_VISITING );
 }
 
-bool Settings::ExtUnionsAllowHeroesMeetings( void ) const
+bool Settings::ExtUnionsAllowHeroesMeetings() const
 {
     return ExtModes( UNIONS_ALLOW_HERO_MEETINGS );
 }
 
-bool Settings::ExtBattleShowDamage( void ) const
+bool Settings::ExtBattleShowDamage() const
 {
     return ExtModes( GAME_BATTLE_SHOW_DAMAGE );
 }
 
-bool Settings::ExtBattleSkipIncreaseDefense( void ) const
+bool Settings::ExtBattleSkipIncreaseDefense() const
 {
     return ExtModes( BATTLE_SKIP_INCREASE_DEFENSE );
 }
 
-bool Settings::ExtHeroAllowTranscribingScroll( void ) const
+bool Settings::ExtHeroAllowTranscribingScroll() const
 {
     return ExtModes( HEROES_TRANSCRIBING_SCROLLS );
 }
 
-bool Settings::ExtBattleShowBattleOrder( void ) const
+bool Settings::ExtBattleShowBattleOrder() const
 {
     return ExtModes( BATTLE_SHOW_ARMY_ORDER );
 }
 
-bool Settings::ExtBattleSoftWait( void ) const
+bool Settings::ExtBattleSoftWait() const
 {
     return ExtModes( BATTLE_SOFT_WAITING );
 }
 
-bool Settings::ExtGameRewriteConfirm( void ) const
+bool Settings::ExtGameRewriteConfirm() const
 {
     return ExtModes( GAME_SAVE_REWRITE_CONFIRM );
 }
 
-bool Settings::ExtGameShowSystemInfo( void ) const
+bool Settings::ExtGameShowSystemInfo() const
 {
     return ExtModes( GAME_SHOW_SYSTEM_INFO );
 }
 
-bool Settings::ExtGameAutosaveBeginOfDay( void ) const
+bool Settings::ExtGameAutosaveBeginOfDay() const
 {
     return ExtModes( GAME_AUTOSAVE_BEGIN_DAY );
 }
 
-bool Settings::ExtGameAutosaveOn( void ) const
+bool Settings::ExtGameAutosaveOn() const
 {
     return ExtModes( GAME_AUTOSAVE_ON );
 }
 
-bool Settings::ExtGameUseFade( void ) const
+bool Settings::ExtGameUseFade() const
 {
     return video_mode == fheroes2::Size( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT ) && ExtModes( GAME_USE_FADE );
 }
 
-bool Settings::ExtGameEvilInterface( void ) const
+bool Settings::ExtGameEvilInterface() const
 {
     return ExtModes( GAME_EVIL_INTERFACE );
 }
 
-bool Settings::ExtGameDynamicInterface( void ) const
+bool Settings::ExtGameDynamicInterface() const
 {
     return ExtModes( GAME_DYNAMIC_INTERFACE );
 }
 
-bool Settings::ExtGameHideInterface( void ) const
+bool Settings::ExtGameHideInterface() const
 {
     return ExtModes( GAME_HIDE_INTERFACE );
 }
 
-bool Settings::ExtWorldBanWeekOf( void ) const
+bool Settings::ExtWorldBanWeekOf() const
 {
     return ExtModes( WORLD_BAN_WEEKOF );
 }
 
-bool Settings::ExtWorldBanMonthOfMonsters( void ) const
+bool Settings::ExtWorldBanMonthOfMonsters() const
 {
     return ExtModes( WORLD_BAN_MONTHOF_MONSTERS );
 }
 
-bool Settings::ExtWorldBanPlagues( void ) const
+bool Settings::ExtWorldBanPlagues() const
 {
     return ExtModes( WORLD_BAN_PLAGUES );
 }
 
-bool Settings::ExtBattleReverseWaitOrder( void ) const
+bool Settings::ExtBattleReverseWaitOrder() const
 {
     return ExtModes( BATTLE_REVERSE_WAIT_ORDER );
 }
 
-bool Settings::ExtWorldStartHeroLossCond4Humans( void ) const
+bool Settings::ExtWorldStartHeroLossCond4Humans() const
 {
     return ExtModes( WORLD_STARTHERO_LOSSCOND4HUMANS );
 }
 
-bool Settings::ExtWorldOneHeroHiredEveryWeek( void ) const
+bool Settings::ExtWorldOneHeroHiredEveryWeek() const
 {
     return ExtModes( WORLD_1HERO_HIRED_EVERY_WEEK );
 }
 
-bool Settings::ExtCastleOneHeroHiredEveryWeek( void ) const
+bool Settings::ExtCastleOneHeroHiredEveryWeek() const
 {
     return ExtModes( CASTLE_1HERO_HIRED_EVERY_WEEK );
 }
 
-bool Settings::ExtWorldNeutralArmyDifficultyScaling( void ) const
+bool Settings::ExtWorldNeutralArmyDifficultyScaling() const
 {
     return ExtModes( WORLD_SCALE_NEUTRAL_ARMIES );
 }
 
-bool Settings::ExtWorldUseUniqueArtifactsML( void ) const
+bool Settings::ExtWorldUseUniqueArtifactsML() const
 {
     return ExtModes( WORLD_USE_UNIQUE_ARTIFACTS_ML );
 }
 
-bool Settings::ExtWorldUseUniqueArtifactsRS( void ) const
+bool Settings::ExtWorldUseUniqueArtifactsRS() const
 {
     return ExtModes( WORLD_USE_UNIQUE_ARTIFACTS_RS );
 }
 
-bool Settings::ExtWorldUseUniqueArtifactsPS( void ) const
+bool Settings::ExtWorldUseUniqueArtifactsPS() const
 {
     return ExtModes( WORLD_USE_UNIQUE_ARTIFACTS_PS );
 }
 
-bool Settings::ExtWorldUseUniqueArtifactsSS( void ) const
+bool Settings::ExtWorldUseUniqueArtifactsSS() const
 {
     return ExtModes( WORLD_USE_UNIQUE_ARTIFACTS_SS );
 }
 
-bool Settings::ExtHeroArenaCanChoiseAnySkills( void ) const
+bool Settings::ExtHeroArenaCanChoiseAnySkills() const
 {
     return ExtModes( HEROES_ARENA_ANY_SKILLS );
 }
 
-bool Settings::ExtWorldExtObjectsCaptured( void ) const
+bool Settings::ExtWorldExtObjectsCaptured() const
 {
     return ExtModes( WORLD_EXT_OBJECTS_CAPTURED );
 }
 
-bool Settings::ExtWorldDisableBarrowMounds( void ) const
+bool Settings::ExtWorldDisableBarrowMounds() const
 {
     return ExtModes( WORLD_DISABLE_BARROW_MOUNDS );
 }
 
-bool Settings::ExtGameContinueAfterVictory( void ) const
+bool Settings::ExtGameContinueAfterVictory() const
 {
     return ExtModes( GAME_CONTINUE_AFTER_VICTORY );
 }
 
-const fheroes2::Point & Settings::PosRadar( void ) const
+const fheroes2::Point & Settings::PosRadar() const
 {
     return pos_radr;
 }
 
-const fheroes2::Point & Settings::PosButtons( void ) const
+const fheroes2::Point & Settings::PosButtons() const
 {
     return pos_bttn;
 }
 
-const fheroes2::Point & Settings::PosIcons( void ) const
+const fheroes2::Point & Settings::PosIcons() const
 {
     return pos_icon;
 }
 
-const fheroes2::Point & Settings::PosStatus( void ) const
+const fheroes2::Point & Settings::PosStatus() const
 {
     return pos_stat;
 }
@@ -1777,7 +1785,7 @@ void Settings::SetPosStatus( const fheroes2::Point & pt )
     pos_stat = pt;
 }
 
-void Settings::BinarySave( void ) const
+void Settings::BinarySave() const
 {
     const std::string fname = System::ConcatePath( GetWriteableDir( "save" ), "fheroes2.bin" );
 
@@ -1789,7 +1797,7 @@ void Settings::BinarySave( void ) const
     }
 }
 
-void Settings::BinaryLoad( void )
+void Settings::BinaryLoad()
 {
     std::string fname = System::ConcatePath( GetWriteableDir( "save" ), "fheroes2.bin" );
 
@@ -1806,7 +1814,7 @@ void Settings::BinaryLoad( void )
     }
 }
 
-bool Settings::FullScreen( void ) const
+bool Settings::FullScreen() const
 {
     return System::isEmbededDevice() || opt_global.Modes( GLOBAL_FULLSCREEN );
 }

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -32,10 +32,12 @@
 #include "maps_fileinfo.h"
 #include "players.h"
 
-#define FORMAT_VERSION_094_RELEASE 9400 // TODO: once this version becomes minimal supported please remove game version handling in HeaderSAV class and FileInfo structure.
+#define FORMAT_VERSION_094_RELEASE 9400
 #define FORMAT_VERSION_093_RELEASE 9300
 #define FORMAT_VERSION_091_RELEASE 9100
 #define FORMAT_VERSION_090_RELEASE 9001
+
+// TODO: once FORMAT_VERSION_094_RELEASE version becomes minimal supported please remove game version handling in HeaderSAV class and FileInfo structure.
 #define LAST_SUPPORTED_FORMAT_VERSION FORMAT_VERSION_090_RELEASE
 
 #define CURRENT_FORMAT_VERSION FORMAT_VERSION_094_RELEASE // TODO: update this value for a new release

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -32,13 +32,13 @@
 #include "maps_fileinfo.h"
 #include "players.h"
 
+#define FORMAT_VERSION_094_RELEASE 9400 // TODO: once this version becomes minimal supported please remove game version handling in HeaderSAV class and FileInfo structure.
 #define FORMAT_VERSION_093_RELEASE 9300
 #define FORMAT_VERSION_091_RELEASE 9100
 #define FORMAT_VERSION_090_RELEASE 9001
-#define FORMAT_VERSION_084_RELEASE 9000
-#define LAST_SUPPORTED_FORMAT_VERSION FORMAT_VERSION_084_RELEASE
+#define LAST_SUPPORTED_FORMAT_VERSION FORMAT_VERSION_090_RELEASE
 
-#define CURRENT_FORMAT_VERSION FORMAT_VERSION_093_RELEASE // TODO: update this value for a new release
+#define CURRENT_FORMAT_VERSION FORMAT_VERSION_094_RELEASE // TODO: update this value for a new release
 
 enum
 {
@@ -122,32 +122,34 @@ public:
 
     Settings & operator=( const Settings & ) = delete;
 
-    static Settings & Get( void );
+    static Settings & Get();
 
     bool Read( const std::string & );
     bool Save( const std::string & ) const;
 
-    std::string String( void ) const;
+    std::string String() const;
     void SetCurrentFileInfo( const Maps::FileInfo & );
-    const Maps::FileInfo & CurrentFileInfo( void ) const;
+    const Maps::FileInfo & CurrentFileInfo() const;
 
-    int Debug( void ) const;
-    int HeroesMoveSpeed( void ) const;
-    int AIMoveSpeed( void ) const;
-    int BattleSpeed( void ) const;
-    int ScrollSpeed( void ) const;
+    bool isCurrentMapPriceOfLoyalty() const;
 
-    const std::string & SelectVideoDriver( void ) const;
+    int Debug() const;
+    int HeroesMoveSpeed() const;
+    int AIMoveSpeed() const;
+    int BattleSpeed() const;
+    int ScrollSpeed() const;
 
-    int GameDifficulty( void ) const;
+    const std::string & SelectVideoDriver() const;
 
-    const std::string & MapsCharset( void ) const;
-    const std::string & ForceLang( void ) const;
+    int GameDifficulty() const;
+
+    const std::string & MapsCharset() const;
+    const std::string & ForceLang() const;
     const std::string & loadedFileLanguage() const;
-    const std::string & FontsNormal( void ) const;
-    const std::string & FontsSmall( void ) const;
-    int FontsNormalSize( void ) const;
-    int FontsSmallSize( void ) const;
+    const std::string & FontsNormal() const;
+    const std::string & FontsSmall() const;
+    int FontsNormalSize() const;
+    int FontsSmallSize() const;
 
     const fheroes2::Point & PosRadar() const;
     const fheroes2::Point & PosButtons() const;
@@ -159,28 +161,28 @@ public:
     void SetPosIcons( const fheroes2::Point & );
     void SetPosStatus( const fheroes2::Point & );
 
-    bool FullScreen( void ) const;
-    bool Sound( void ) const;
-    bool Music( void ) const;
-    bool ShowControlPanel( void ) const;
-    bool ShowRadar( void ) const;
-    bool ShowIcons( void ) const;
-    bool ShowButtons( void ) const;
-    bool ShowStatus( void ) const;
-    bool Unicode( void ) const;
-    bool BattleShowGrid( void ) const;
-    bool BattleShowMouseShadow( void ) const;
-    bool BattleShowMoveShadow( void ) const;
+    bool FullScreen() const;
+    bool Sound() const;
+    bool Music() const;
+    bool ShowControlPanel() const;
+    bool ShowRadar() const;
+    bool ShowIcons() const;
+    bool ShowButtons() const;
+    bool ShowStatus() const;
+    bool Unicode() const;
+    bool BattleShowGrid() const;
+    bool BattleShowMouseShadow() const;
+    bool BattleShowMoveShadow() const;
     bool BattleAutoResolve() const;
     bool BattleAutoSpellcast() const;
-    bool UseAltResource( void ) const;
-    bool PriceLoyaltyVersion( void ) const;
-    bool LoadedGameVersion( void ) const;
-    bool MusicExt( void ) const;
-    bool MusicMIDI( void ) const;
-    bool MusicCD( void ) const;
-    void BinarySave( void ) const;
-    void BinaryLoad( void );
+    bool UseAltResource() const;
+    bool isPriceOfLoyaltySupported() const;
+    bool LoadedGameVersion() const;
+    bool MusicExt() const;
+    bool MusicMIDI() const;
+    bool MusicCD() const;
+    void BinarySave() const;
+    void BinaryLoad();
 
     bool CanChangeInGame( u32 ) const;
     bool ExtModes( u32 ) const;
@@ -188,56 +190,56 @@ public:
     void ExtResetModes( u32 );
     const char * ExtName( u32 ) const;
 
-    bool ExtHeroBuySpellBookFromShrine( void ) const;
-    bool ExtHeroRecruitCostDependedFromLevel( void ) const;
-    bool ExtHeroRememberPointsForRetreating( void ) const;
-    bool ExtHeroAllowTranscribingScroll( void ) const;
-    bool ExtHeroArenaCanChoiseAnySkills( void ) const;
-    bool ExtUnionsAllowCastleVisiting( void ) const;
-    bool ExtUnionsAllowHeroesMeetings( void ) const;
-    bool ExtWorldShowVisitedContent( void ) const;
+    bool ExtHeroBuySpellBookFromShrine() const;
+    bool ExtHeroRecruitCostDependedFromLevel() const;
+    bool ExtHeroRememberPointsForRetreating() const;
+    bool ExtHeroAllowTranscribingScroll() const;
+    bool ExtHeroArenaCanChoiseAnySkills() const;
+    bool ExtUnionsAllowCastleVisiting() const;
+    bool ExtUnionsAllowHeroesMeetings() const;
+    bool ExtWorldShowVisitedContent() const;
     bool ExtWorldShowTerrainPenalty() const;
-    bool ExtWorldScouteExtended( void ) const;
-    bool ExtWorldAllowSetGuardian( void ) const;
-    bool ExtWorldArtifactCrystalBall( void ) const;
-    bool ExtWorldOnlyFirstMonsterAttack( void ) const;
-    bool ExtWorldEyeEagleAsScholar( void ) const;
-    bool ExtWorldBanMonthOfMonsters( void ) const;
-    bool ExtWorldBanWeekOf( void ) const;
-    bool ExtWorldBanPlagues( void ) const;
-    bool ExtWorldStartHeroLossCond4Humans( void ) const;
-    bool ExtWorldOneHeroHiredEveryWeek( void ) const;
-    bool ExtWorldNeutralArmyDifficultyScaling( void ) const;
-    bool ExtWorldUseUniqueArtifactsML( void ) const;
-    bool ExtWorldUseUniqueArtifactsRS( void ) const;
-    bool ExtWorldUseUniqueArtifactsPS( void ) const;
-    bool ExtWorldUseUniqueArtifactsSS( void ) const;
-    bool ExtWorldExtObjectsCaptured( void ) const;
-    bool ExtWorldDisableBarrowMounds( void ) const;
-    bool ExtCastleAllowGuardians( void ) const;
-    bool ExtCastleGuildRestorePointsTurn( void ) const;
-    bool ExtCastleOneHeroHiredEveryWeek( void ) const;
-    bool ExtBattleShowDamage( void ) const;
-    bool ExtBattleShowBattleOrder( void ) const;
-    bool ExtBattleSoftWait( void ) const;
-    bool ExtBattleSkipIncreaseDefense( void ) const;
-    bool ExtBattleReverseWaitOrder( void ) const;
-    bool ExtGameRememberLastFocus( void ) const;
-    bool ExtGameContinueAfterVictory( void ) const;
-    bool ExtGameRewriteConfirm( void ) const;
-    bool ExtGameShowSystemInfo( void ) const;
-    bool ExtGameAutosaveBeginOfDay( void ) const;
-    bool ExtGameAutosaveOn( void ) const;
-    bool ExtGameUseFade( void ) const;
-    bool ExtGameEvilInterface( void ) const;
-    bool ExtGameDynamicInterface( void ) const;
-    bool ExtGameHideInterface( void ) const;
+    bool ExtWorldScouteExtended() const;
+    bool ExtWorldAllowSetGuardian() const;
+    bool ExtWorldArtifactCrystalBall() const;
+    bool ExtWorldOnlyFirstMonsterAttack() const;
+    bool ExtWorldEyeEagleAsScholar() const;
+    bool ExtWorldBanMonthOfMonsters() const;
+    bool ExtWorldBanWeekOf() const;
+    bool ExtWorldBanPlagues() const;
+    bool ExtWorldStartHeroLossCond4Humans() const;
+    bool ExtWorldOneHeroHiredEveryWeek() const;
+    bool ExtWorldNeutralArmyDifficultyScaling() const;
+    bool ExtWorldUseUniqueArtifactsML() const;
+    bool ExtWorldUseUniqueArtifactsRS() const;
+    bool ExtWorldUseUniqueArtifactsPS() const;
+    bool ExtWorldUseUniqueArtifactsSS() const;
+    bool ExtWorldExtObjectsCaptured() const;
+    bool ExtWorldDisableBarrowMounds() const;
+    bool ExtCastleAllowGuardians() const;
+    bool ExtCastleGuildRestorePointsTurn() const;
+    bool ExtCastleOneHeroHiredEveryWeek() const;
+    bool ExtBattleShowDamage() const;
+    bool ExtBattleShowBattleOrder() const;
+    bool ExtBattleSoftWait() const;
+    bool ExtBattleSkipIncreaseDefense() const;
+    bool ExtBattleReverseWaitOrder() const;
+    bool ExtGameRememberLastFocus() const;
+    bool ExtGameContinueAfterVictory() const;
+    bool ExtGameRewriteConfirm() const;
+    bool ExtGameShowSystemInfo() const;
+    bool ExtGameAutosaveBeginOfDay() const;
+    bool ExtGameAutosaveOn() const;
+    bool ExtGameUseFade() const;
+    bool ExtGameEvilInterface() const;
+    bool ExtGameDynamicInterface() const;
+    bool ExtGameHideInterface() const;
 
     const fheroes2::Size & VideoMode() const;
 
     void SetDebug( int );
     void SetUnicode( bool );
-    void SetPriceLoyaltyVersion( bool set = true );
+    void EnablePriceOfLoyaltySupport( const bool set );
     void SetGameDifficulty( int );
     void SetEvilInterface( bool );
     void SetHideInterface( bool );
@@ -260,73 +262,73 @@ public:
     void SetSoundVolume( int v );
     void SetMusicVolume( int v );
     void SetMusicType( int v );
-    void ResetSound( void );
-    void ResetMusic( void );
+    void ResetSound();
+    void ResetMusic();
 
-    int SoundVolume( void ) const;
-    int MusicVolume( void ) const;
+    int SoundVolume() const;
+    int MusicVolume() const;
     MusicSource MusicType() const;
 
     bool IsGameType( int type ) const;
-    int GameType( void ) const;
+    int GameType() const;
     void SetGameType( int );
 
-    Players & GetPlayers( void );
-    const Players & GetPlayers( void ) const;
+    Players & GetPlayers();
+    const Players & GetPlayers() const;
 
-    int CurrentColor( void ) const;
+    int CurrentColor() const;
     void SetCurrentColor( int );
-    int PreferablyCountPlayers( void ) const;
+    int PreferablyCountPlayers() const;
     void SetPreferablyCountPlayers( int );
 
     // from maps info
     bool AllowChangeRace( int ) const;
-    const std::string & MapsFile( void ) const;
-    const std::string & MapsName( void ) const;
-    const std::string & MapsDescription( void ) const;
+    const std::string & MapsFile() const;
+    const std::string & MapsName() const;
+    const std::string & MapsDescription() const;
     const std::string & externalMusicCommand() const;
-    int MapsDifficulty( void ) const;
-    fheroes2::Size MapsSize( void ) const;
-    bool GameStartWithHeroes( void ) const;
-    int ConditionWins( void ) const;
-    int ConditionLoss( void ) const;
-    bool WinsCompAlsoWins( void ) const;
-    int WinsFindArtifactID( void ) const;
-    bool WinsFindUltimateArtifact( void ) const;
-    u32 WinsAccumulateGold( void ) const;
-    fheroes2::Point WinsMapsPositionObject( void ) const;
-    fheroes2::Point LossMapsPositionObject( void ) const;
-    u32 LossCountDays( void ) const;
+    int MapsDifficulty() const;
+    fheroes2::Size MapsSize() const;
+    bool GameStartWithHeroes() const;
+    int ConditionWins() const;
+    int ConditionLoss() const;
+    bool WinsCompAlsoWins() const;
+    int WinsFindArtifactID() const;
+    bool WinsFindUltimateArtifact() const;
+    u32 WinsAccumulateGold() const;
+    fheroes2::Point WinsMapsPositionObject() const;
+    fheroes2::Point LossMapsPositionObject() const;
+    u32 LossCountDays() const;
     int controllerPointerSpeed() const;
 
-    std::string GetProgramPath( void ) const
+    std::string GetProgramPath() const
     {
         return path_program;
     }
     void SetProgramPath( const char * );
 
-    static std::string GetVersion( void );
+    static std::string GetVersion();
 
     static ListFiles GetListFiles( const std::string & prefix, const std::string & filter );
-    static ListDirs GetRootDirs( void );
+    static ListDirs GetRootDirs();
     static std::string GetLastFile( const std::string & prefix, const std::string & name );
     static std::string GetWriteableDir( const char * );
-    static std::string GetLangDir( void );
+    static std::string GetLangDir();
 
     static ListFiles FindFiles( const std::string & directory, const std::string & fileName );
 
     // deprecated
-    const std::string & GetDataParams( void ) const
+    const std::string & GetDataParams() const
     {
         return data_params;
     }
-    ListDirs GetMapsParams( void ) const
+    ListDirs GetMapsParams() const
     {
         return maps_params;
     }
 
 protected:
-    void PostLoad( void );
+    void PostLoad();
 
 private:
     friend StreamBase & operator<<( StreamBase &, const Settings & );

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -639,7 +639,7 @@ void World::MonthOfMonstersAction( const Monster & mons )
     }
 
     const int32_t area = 12;
-    const int32_t maxc = ( w() / area ) * ( h() / area );
+    const int32_t maxc = ( width / area ) * ( height / area );
     Rand::Shuffle( tiles );
     if ( tiles.size() > static_cast<size_t>( maxc ) )
         tiles.resize( maxc );


### PR DESCRIPTION
- new saves will have a flag indicating about the original (The Succession Wars) map version or the add-on (The Price of Loyalty)
- all old saves will be considered as using the original map (The Succession Wars). It could lead to some issues with add-on related maps but we have to do this
- remove support of save files older than 0.9.1
- some code cleanup (I'm sorry I can't look at so many voids) and small code optimizations

close #1759 
close #3158 