### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/src/engine/endian_h2.h
+++ b/src/engine/endian_h2.h
@@ -24,7 +24,7 @@
 #if defined( __linux__ )
 #include <endian.h>
 
-#elif defined( __FreeBSD__ )
+#elif defined( __FreeBSD__ ) || defined( __OpenBSD__ )
 #include <sys/endian.h>
 
 #elif defined( _WIN32 ) || defined( _WIN64 )


### PR DESCRIPTION
This trivial patch allows us to build a working version of the application for OpenBSD. No additional code changes were required, everything works as expected. Thank you in advance.