### PR TITLE
Fix sound mute in background on MacOS with SDL1

### DIFF
--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1137,9 +1137,8 @@ bool LocalEvent::HandleEvents( bool delay, bool allowExit )
             break;
 #else
         case SDL_ACTIVEEVENT:
-            if ( event.active.state & SDL_APPACTIVE ) {
+            if ( event.active.state & SDL_APPINPUTFOCUS ) {
                 if ( Mixer::isValid() ) {
-                    // iconify
                     if ( 0 == event.active.gain ) {
                         StopSounds();
                     }


### PR DESCRIPTION
Related to #3415

On MacOS, `SDL_APPACTIVE` doesn't work properly: it is coming only when app is minimized (`gain == 0`), but not when app is activated back (`gain == 1`), not to mention the fact that, according to the documentation, it doesn't come when window simply sent to background without minimizing.