### PR TITLE
Fix next hero choose logic

### DIFF
--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -139,7 +139,7 @@ void Interface::Basic::EventNextHero( void )
             ++it;
             if ( it == myHeroes.end() )
                 it = myHeroes.begin();
-            if ( ( *it )->MayStillMove() ) {
+            if ( ( *it )->MayStillMove( false ) ) {
                 SetFocus( *it );
                 CalculateHeroPath( *it, -1 );
                 break;
@@ -147,11 +147,10 @@ void Interface::Basic::EventNextHero( void )
         } while ( it != currentHero );
     }
     else {
-        const size_t heroesCount = myHeroes.size();
-        for ( size_t i = 0; i < heroesCount; ++i ) {
-            if ( myHeroes[i]->MayStillMove() ) {
-                SetFocus( myHeroes[i] );
-                CalculateHeroPath( myHeroes[i], -1 );
+        for ( Heroes * hero : myHeroes ) {
+            if ( hero->MayStillMove( false ) ) {
+                SetFocus( hero );
+                CalculateHeroPath( hero, -1 );
                 break;
             }
         }

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -139,7 +139,7 @@ void Interface::Basic::EventNextHero( void )
             ++it;
             if ( it == myHeroes.end() )
                 it = myHeroes.begin();
-            if ( ( *it )->MayStillMove( false ) ) {
+            if ( ( *it )->MayStillMove( true ) ) {
                 SetFocus( *it );
                 CalculateHeroPath( *it, -1 );
                 break;
@@ -148,7 +148,7 @@ void Interface::Basic::EventNextHero( void )
     }
     else {
         for ( Heroes * hero : myHeroes ) {
-            if ( hero->MayStillMove( false ) ) {
+            if ( hero->MayStillMove( true ) ) {
                 SetFocus( hero );
                 CalculateHeroPath( hero, -1 );
                 break;

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1410,12 +1410,17 @@ void Heroes::ResetMovePoints( void )
     move_point = 0;
 }
 
-bool Heroes::MayStillMove( void ) const
+bool Heroes::MayStillMove( bool isConsiderMovePoints ) const
 {
-    if ( Modes( SLEEPER | GUARDIAN ) || isFreeman() )
+    if ( Modes( SLEEPER | GUARDIAN ) || isFreeman() ) {
         return false;
+    }
 
-    return path.isValid() ? ( move_point >= path.getLastMovePenalty() ) : CanMove();
+    if ( path.isValid() ) {
+        const uint32_t threshold = isConsiderMovePoints ? path.getLastMovePenalty() : 0;
+        return move_point > threshold;
+    }
+    return CanMove();
 }
 
 bool Heroes::MayCastAdventureSpells() const

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1410,15 +1410,15 @@ void Heroes::ResetMovePoints( void )
     move_point = 0;
 }
 
-bool Heroes::MayStillMove( bool isConsiderMovePoints ) const
+bool Heroes::MayStillMove( const bool isConsiderMovePoints ) const
 {
     if ( Modes( SLEEPER | GUARDIAN ) || isFreeman() ) {
         return false;
     }
 
     if ( path.isValid() ) {
-        const uint32_t threshold = isConsiderMovePoints ? path.getLastMovePenalty() : 0;
-        return move_point > threshold;
+        const uint32_t threshold = isConsiderMovePoints ? path.getLastMovePenalty() : 1;
+        return move_point >= threshold;
     }
     return CanMove();
 }

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1410,15 +1410,14 @@ void Heroes::ResetMovePoints( void )
     move_point = 0;
 }
 
-bool Heroes::MayStillMove( const bool isConsiderMovePoints ) const
+bool Heroes::MayStillMove( const bool ignorePath ) const
 {
     if ( Modes( SLEEPER | GUARDIAN ) || isFreeman() ) {
         return false;
     }
 
-    if ( path.isValid() ) {
-        const uint32_t threshold = isConsiderMovePoints ? path.getLastMovePenalty() : 1;
-        return move_point >= threshold;
+    if ( path.isValid() && !ignorePath ) {
+        return move_point >= path.getLastMovePenalty();
     }
     return CanMove();
 }

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -251,7 +251,7 @@ public:
 
     u32 GetMovePoints( void ) const;
     void IncreaseMovePoints( u32 );
-    bool MayStillMove( void ) const;
+    bool MayStillMove( bool isConsiderMovePoints = true ) const;
     void ResetMovePoints( void );
     void MovePointsScaleFixed( void );
 

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -251,7 +251,7 @@ public:
 
     u32 GetMovePoints( void ) const;
     void IncreaseMovePoints( u32 );
-    bool MayStillMove( const bool isConsiderMovePoints = true ) const;
+    bool MayStillMove( const bool ignorePath = true ) const;
     void ResetMovePoints( void );
     void MovePointsScaleFixed( void );
 

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -251,7 +251,7 @@ public:
 
     u32 GetMovePoints( void ) const;
     void IncreaseMovePoints( u32 );
-    bool MayStillMove( bool isConsiderMovePoints = true ) const;
+    bool MayStillMove( const bool isConsiderMovePoints = true ) const;
     void ResetMovePoints( void );
     void MovePointsScaleFixed( void );
 


### PR DESCRIPTION
Fixes #3364
A hero with non-zero move points can be chosen as next even if movement is not possible on predetermined path