### PR TITLE
Fix crash on non-PoL maps because the heroes vector isn't full

### DIFF
--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1790,10 +1790,18 @@ void AllHeroes::Init( void )
         push_back( new Heroes( Heroes::MARTINE, Race::SORC, 5 ) );
         push_back( new Heroes( Heroes::JARKONAS, Race::BARB, 5 ) );
     }
+    else {
+        // for non-PoL maps, just add unknown heroes instead in place of the PoL-specific ones
+        for ( int i = Heroes::SOLMYR; i < Heroes::JARKONAS; ++i )
+            push_back( new Heroes( Heroes::UNKNOWN, Race::KNGT ) );
+    }
 
     // devel
     if ( IS_DEVEL() ) {
         push_back( new Heroes( Heroes::DEBUG_HERO, Race::WRLK ) );
+    }
+    else {
+        push_back( new Heroes( Heroes::UNKNOWN, Race::KNGT ) );
     }
 
     push_back( new Heroes( Heroes::UNKNOWN, Race::KNGT ) );


### PR DESCRIPTION
Some PRs ago I made changes to `heroes.cpp` in which I didn't add PoL-exclusive heroes in non-PoL maps. Unfortunately this causes a crash on development builds where debug hero is used.

So I'll be re-adding unknown heroes in place of the PoL-specific ones for non PoL maps. Alternatively, we could use a std::find_if lambda when heroID == DebugHero but I think the current solution is more consistent with the rest of the code so far.