### PR TITLE
Unveil the fog on instant hero's movement (for example, via Stone Lith)

### DIFF
--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1599,6 +1599,7 @@ void Heroes::Move2Dest( const int32_t dstIndex )
     if ( dstIndex != GetIndex() ) {
         world.GetTiles( GetIndex() ).SetHeroes( NULL );
         SetIndex( dstIndex );
+        Scoute( dstIndex );
         world.GetTiles( dstIndex ).SetHeroes( this );
     }
 }


### PR DESCRIPTION
fix #3448