### PR TITLE
Fix heroes blocked in front of player's castle for Debug Mode

### DIFF
--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1795,7 +1795,7 @@ void AllHeroes::Init( void )
     }
     else {
         // for non-PoL maps, just add unknown heroes instead in place of the PoL-specific ones
-        for ( int i = Heroes::SOLMYR; i < Heroes::JARKONAS; ++i )
+        for ( int i = Heroes::SOLMYR; i <= Heroes::JARKONAS; ++i )
             push_back( new Heroes( Heroes::UNKNOWN, Race::KNGT ) );
     }
 


### PR DESCRIPTION
Closes #3460 

This was another regression from #3436 that was supposed to fix a regression. 

In the previous PR, we didn't make an unknown hero to replace Jarkonas for non-PoL maps and so, when we are looking for debug hero we get an unknown instead. And that "unknown" is invisible and blocks the road in front of the castle.