### PR TITLE
Add Campaign scenario Allies for Player

### DIFF
--- a/src/fheroes2/campaign/campaign_data.cpp
+++ b/src/fheroes2/campaign/campaign_data.cpp
@@ -125,7 +125,8 @@ namespace
         // NOTE: In Roland's Campaign, scenario 8 is drawn above scenario 7, so we emplace_back scenario 8 first
         scenarioDatas.emplace_back( 7, std::vector<int>{ 8 }, Campaign::ScenarioBonusData::getCampaignBonusData( 0, 7 ), "CAMPG08.H2C", rolandCampaignDescription[7] );
         scenarioDatas.emplace_back( 6, std::vector<int>{ 8 }, Campaign::ScenarioBonusData::getCampaignBonusData( 0, 6 ), "CAMPG07.H2C", rolandCampaignDescription[6] );
-        scenarioDatas.emplace_back( 8, std::vector<int>{ 9 }, Campaign::ScenarioBonusData::getCampaignBonusData( 0, 8 ), "CAMPG09.H2C", rolandCampaignDescription[8] );
+        scenarioDatas.emplace_back( 8, std::vector<int>{ 9 }, Campaign::ScenarioBonusData::getCampaignBonusData( 0, 8 ), "CAMPG09.H2C", rolandCampaignDescription[8],
+                                    Campaign::ScenarioVictoryCondition::WINS_SIDE, Campaign::ScenarioLossCondition::STANDARD, Color::YELLOW );
         scenarioDatas.emplace_back( 9, std::vector<int>{}, Campaign::ScenarioBonusData::getCampaignBonusData( 0, 9 ), "CAMPG10.H2C", rolandCampaignDescription[9] );
 
         Campaign::CampaignData campaignData;

--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -249,7 +249,8 @@ namespace Campaign
     }
 
     ScenarioData::ScenarioData( int scenarioID, const std::vector<int> & nextMaps, const std::vector<ScenarioBonusData> & bonuses, const std::string & fileName,
-                                const std::string & description, const ScenarioVictoryCondition victoryCondition, const ScenarioLossCondition lossCondition, const int allyColors )
+                                const std::string & description, const ScenarioVictoryCondition victoryCondition, const ScenarioLossCondition lossCondition,
+                                const int allyColors )
         : _scenarioID( scenarioID )
         , _nextMaps( nextMaps )
         , _bonuses( bonuses )

--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -249,7 +249,7 @@ namespace Campaign
     }
 
     ScenarioData::ScenarioData( int scenarioID, const std::vector<int> & nextMaps, const std::vector<ScenarioBonusData> & bonuses, const std::string & fileName,
-                                const std::string & description, const ScenarioVictoryCondition victoryCondition, const ScenarioLossCondition lossCondition )
+                                const std::string & description, const ScenarioVictoryCondition victoryCondition, const ScenarioLossCondition lossCondition, const int allyColors )
         : _scenarioID( scenarioID )
         , _nextMaps( nextMaps )
         , _bonuses( bonuses )
@@ -257,6 +257,7 @@ namespace Campaign
         , _description( description )
         , _victoryCondition( victoryCondition )
         , _lossCondition( lossCondition )
+        , _allyColors( allyColors )
     {}
 
     bool Campaign::ScenarioData::isMapFilePresent() const

--- a/src/fheroes2/campaign/campaign_scenariodata.h
+++ b/src/fheroes2/campaign/campaign_scenariodata.h
@@ -21,6 +21,7 @@
 #ifndef H2CAMPAIGN_SCENARIODATA_H
 #define H2CAMPAIGN_SCENARIODATA_H
 
+#include "color.h"
 #include "maps_fileinfo.h"
 
 namespace Campaign
@@ -47,7 +48,8 @@ namespace Campaign
     enum class ScenarioVictoryCondition : int
     {
         STANDARD = 0, // standard map's defined victory condition
-        CAPTURE_DRAGON_CITY = 1
+        CAPTURE_DRAGON_CITY = 1,
+        WINS_SIDE = 2 // necessary to override roland ch9's win condition where it was WINS_ALL
     };
 
     enum class ScenarioLossCondition : int
@@ -90,7 +92,7 @@ namespace Campaign
         ScenarioData() = delete;
         ScenarioData( int scenarioID, const std::vector<int> & nextMaps, const std::vector<Campaign::ScenarioBonusData> & bonuses, const std::string & fileName,
                       const std::string & description, const ScenarioVictoryCondition victoryCondition = ScenarioVictoryCondition::STANDARD,
-                      const ScenarioLossCondition lossCondition = ScenarioLossCondition::STANDARD );
+                      const ScenarioLossCondition lossCondition = ScenarioLossCondition::STANDARD, const int allyColors = Color::NONE );
 
         const std::vector<int> & getNextMaps() const
         {
@@ -127,6 +129,11 @@ namespace Campaign
             return _lossCondition;
         }
 
+        int getAllyColors() const
+        {
+            return _allyColors;
+        }
+
         bool isMapFilePresent() const;
         Maps::FileInfo loadMap() const;
 
@@ -138,6 +145,7 @@ namespace Campaign
         std::string _description; // at least for campaign maps, the description isn't obtained from the map's description, so we have to write one manually
         ScenarioVictoryCondition _victoryCondition;
         ScenarioLossCondition _lossCondition;
+        int _allyColors;
     };
 }
 

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -455,7 +455,7 @@ fheroes2::GameMode Game::SelectCampaignScenario()
                     break;
                 }
             }
-            
+
             players.SetStartGame();
             if ( conf.ExtGameUseFade() )
                 fheroes2::FadeDisplay();

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -444,6 +444,18 @@ fheroes2::GameMode Game::SelectCampaignScenario()
                 SetScenarioBonus( scenarioBonus );
 
             Players & players = conf.GetPlayers();
+
+            for ( Players::const_iterator it = players.begin(); it != players.end(); ++it ) {
+                if ( !*it )
+                    continue;
+
+                Player & player = ( **it );
+                if ( player.isControlHuman() ) {
+                    player.SetFriends( scenario.getAllyColors() | player.GetColor() );
+                    break;
+                }
+            }
+            
             players.SetStartGame();
             if ( conf.ExtGameUseFade() )
                 fheroes2::FadeDisplay();

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1022,6 +1022,9 @@ int World::CheckKingdomWins( const Kingdom & kingdom ) const
                     return GameOver::COND_NONE;
                 }
             }
+            else if ( victoryCondition == Campaign::ScenarioVictoryCondition::WINS_SIDE && KingdomIsWins( kingdom, GameOver::WINS_SIDE ) ) {
+                return GameOver::WINS_SIDE;
+            }
         }
     }
 


### PR DESCRIPTION
Needed for Roland Campaign Chapter 9 so that we'd be allied to Roland (Yellow).

Also, I have to override the map's victory condition since that map was returning WINS_ALL. The loss condition (Lose Roland) remains correct though.

Question: Do we have to do this for enemies too?