### PR TITLE
Set proper difficulty level for campaign scenario

### DIFF
--- a/src/fheroes2/game/difficulty.h
+++ b/src/fheroes2/game/difficulty.h
@@ -26,7 +26,7 @@
 
 namespace Difficulty
 {
-    enum
+    enum DifficultyLevel : int
     {
         EASY,
         NORMAL,

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -113,7 +113,9 @@ namespace Game
 // Returns the difficulty level based on the type of game.
 int Game::getDifficulty()
 {
-    return ( Settings::Get().isCampaignGameType() ? Difficulty::NORMAL : Settings::Get().GameDifficulty() );
+    Settings & configuration = Settings::Get();
+
+    return ( configuration.isCampaignGameType() ? configuration.CurrentFileInfo().difficulty : configuration.GameDifficulty() );
 }
 
 void Game::LoadPlayers( const std::string & mapFileName, Players & players )


### PR DESCRIPTION
close #3501

The only scenario which has difficult diffuculty is the second map for
both campaigns