### PR TITLE
Implement Artifact Set Data and use it in Campaign Awards

### DIFF
--- a/src/fheroes2/campaign/campaign_data.cpp
+++ b/src/fheroes2/campaign/campaign_data.cpp
@@ -101,9 +101,13 @@ namespace
             obtainableAwards.emplace_back( 3, Campaign::CampaignAwardData::TYPE_GET_ARTIFACT, Artifact::HELMET_ANDURAN );
             break;
         case 6:
-            // will assemble Battle Garb of Anduran along with the previous anduran set pieces
+            // Will assemble Battle Garb of Anduran along with the previous anduran set pieces
+            // If we get all the parts, we'll obtain the Battle Garb award while removing the awards for the individual parts
             obtainableAwards.emplace_back( 4, Campaign::CampaignAwardData::TYPE_GET_ARTIFACT, Artifact::SWORD_ANDURAN );
-            obtainableAwards.emplace_back( 5, Campaign::CampaignAwardData::TYPE_DEFEAT_ENEMY_HERO, Heroes::DAINWIN );
+            obtainableAwards.emplace_back( 5, Campaign::CampaignAwardData::TYPE_GET_ARTIFACT, Artifact::BATTLE_GARB );
+
+            // seems that Kraeger is a custom name for Dainwin in this case
+            obtainableAwards.emplace_back( 6, Campaign::CampaignAwardData::TYPE_DEFEAT_ENEMY_HERO, Heroes::DAINWIN, _( "Kraeger defeated" ) );
             break;
         }
 

--- a/src/fheroes2/campaign/campaign_savedata.cpp
+++ b/src/fheroes2/campaign/campaign_savedata.cpp
@@ -50,6 +50,11 @@ namespace Campaign
         _obtainedCampaignAwards.emplace_back( awardID );
     }
 
+    void CampaignSaveData::removeCampaignAward( const int awardID ) 
+    {
+        _obtainedCampaignAwards.erase( std::remove( _obtainedCampaignAwards.begin(), _obtainedCampaignAwards.end(), awardID ), _obtainedCampaignAwards.end() );
+    }
+
     void CampaignSaveData::setCurrentScenarioBonus( const ScenarioBonusData & bonus )
     {
         _currentScenarioBonus = bonus;

--- a/src/fheroes2/campaign/campaign_savedata.h
+++ b/src/fheroes2/campaign/campaign_savedata.h
@@ -80,6 +80,7 @@ namespace Campaign
         void setCarryOverTroops( const Troops & troops );
         void reset();
         void addDaysPassed( const uint32_t days );
+        void removeCampaignAward( const int awardID );
 
         static CampaignSaveData & Get();
 

--- a/src/fheroes2/resource/artifact.h
+++ b/src/fheroes2/resource/artifact.h
@@ -210,6 +210,23 @@ StreamBase & operator<<( StreamBase &, const Artifact & );
 StreamBase & operator>>( StreamBase &, Artifact & );
 u32 GoldInsteadArtifact( int );
 
+class ArtifactSetData
+{
+public:
+    ArtifactSetData() = default;
+    ArtifactSetData( const uint32_t artifactID, const std::vector<uint32_t> & artifactPartIDs );
+    bool isPartOfSet( const uint32_t artifactID ) const;
+    bool isCombinationResult( const uint32_t artifactID ) const;
+    size_t getNumberOfParts() const;
+
+    static const ArtifactSetData * tryGetArtifactSetData( const uint32_t artifactID );
+    static const uint32_t tryFormArtifactSet( const std::vector<uint32_t> & artifactPartIDs );
+
+private:
+    uint32_t _artifactID;
+    std::vector<uint32_t> _artifactPartIDs;
+};
+
 class BagArtifacts : public std::vector<Artifact>
 {
 public:


### PR DESCRIPTION
Currently we only have the Battle Garb of Anduran as an artifact set in the base game (I think). In this PR I'd like to make a solution where we can easily create new artifact sets.

Also, artifact sets will be taken into account for obtained campaign awards. The logic to add awards for artifacts that are not part of any set or are artifact parts remain the same. However, artifacts that are the result of a combination have to be checked first. If all the parts of said artifact are present, we'll add the campaign award and remove the awards for the individual parts.

I think this is less than ideal but it is what it is when we are saving just the award ID instead of the entire award data.