### PR TITLE
Support PoL heroes & artifacts in "battle only" mode

### DIFF
--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -316,7 +316,7 @@ Artifact Dialog::SelectArtifact( int cur )
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    std::vector<int> artifacts( static_cast<int>( Artifact::UNKNOWN ), Artifact::UNKNOWN );
+    std::vector<int> artifacts( static_cast<int>( Settings::Get().isCurrentMapPriceOfLoyalty() ? Artifact::UNKNOWN : Artifact::SPELL_SCROLL ), Artifact::UNKNOWN );
 
     for ( size_t i = 0; i < artifacts.size(); ++i )
         artifacts[i] = static_cast<int>( i ); // safe to do this as the number of artifacts can't be more than 2 billion
@@ -404,7 +404,7 @@ int Dialog::SelectHeroes( int cur )
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    std::vector<int> heroes( static_cast<int>( Heroes::DEBUG_HERO ), Heroes::UNKNOWN );
+    std::vector<int> heroes( static_cast<int>( Settings::Get().isCurrentMapPriceOfLoyalty() ? Heroes::DEBUG_HERO : Heroes::SOLMYR ), Heroes::UNKNOWN );
 
     for ( size_t i = 0; i < heroes.size(); ++i )
         heroes[i] = static_cast<int>( i ); // safe to do this as the heroes of spells can't be more than 2 billion

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -300,12 +300,26 @@ void World::Reset( void )
 void World::NewMaps( int32_t sw, int32_t sh )
 {
     Reset();
+
+    width = sw;
+    height = sh;
+
+    Maps::FileInfo fi;
+
+    fi.size_w = static_cast<uint16_t>( width );
+    fi.size_h = static_cast<uint16_t>( height );
+
+    Settings & conf = Settings::Get();
+
+    if ( conf.isPriceOfLoyaltySupported() ) {
+        fi._version = GameVersion::PRICE_OF_LOYALTY;
+    }
+
+    conf.SetCurrentFileInfo( fi );
+
     Defaults();
 
-    fheroes2::Size::width = sw;
-    fheroes2::Size::height = sh;
-
-    vec_tiles.resize( static_cast<size_t>( fheroes2::Size::width ) * fheroes2::Size::height );
+    vec_tiles.resize( static_cast<size_t>( width ) * height );
 
     // init all tiles
     for ( size_t i = 0; i < vec_tiles.size(); ++i ) {
@@ -326,13 +340,6 @@ void World::NewMaps( int32_t sw, int32_t sh )
 
         vec_tiles[i].Init( static_cast<int32_t>( i ), mp2tile );
     }
-
-    // reset current maps info
-    Maps::FileInfo fi;
-    fi.size_w = static_cast<uint16_t>( width );
-    fi.size_h = static_cast<uint16_t>( height );
-
-    Settings::Get().SetCurrentFileInfo( fi );
 }
 
 void World::InitKingdoms( void )


### PR DESCRIPTION
Currently heroes from PoL cannot be used in "battle only" mode (they turn into Heroes::UNKNOWN) and I suppose that there may be also issues with artifacts from PoL if this addon is not available on player's machine.

Need a review from someone who is familiar with PoL addon mechanics to make sure that I do the right things here and didn't forget anything. PoL doesn't add new secondary skills, spells or monsters, right?