### PR TITLE
Clear the hidden mode for the hero's path after moving through Whirlpool

### DIFF
--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2017,6 +2017,7 @@ void ActionToWhirlpools( Heroes & hero, s32 index_from )
     WhirlpoolTroopLooseEffect( hero );
 
     hero.GetPath().Reset();
+    hero.GetPath().Show(); // Reset method sets Hero's path to hidden mode with non empty path, we have to set it back
     hero.ActionNewPosition();
 
     DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() );


### PR DESCRIPTION
fix #3564