### PR TITLE
Remove "world: only the first monster will attack (H2 bug)" option

### DIFF
--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -165,7 +165,6 @@ void Dialog::ExtSettings( bool readonly )
     states.push_back( Settings::WORLD_EXT_OBJECTS_CAPTURED );
     states.push_back( Settings::WORLD_SCOUTING_EXTENDED );
     states.push_back( Settings::WORLD_ARTIFACT_CRYSTAL_BALL );
-    states.push_back( Settings::WORLD_ONLY_FIRST_MONSTER_ATTACK );
     states.push_back( Settings::WORLD_EYE_EAGLE_AS_SCHOLAR );
     states.push_back( Settings::WORLD_BAN_WEEKOF );
     states.push_back( Settings::WORLD_BAN_PLAGUES );

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -688,10 +688,6 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
         res = ShowWarningLostTownsDialog();
     }
 
-    // check around actions (and skip for h2 orig, bug?)
-    if ( !conf.ExtWorldOnlyFirstMonsterAttack() )
-        myKingdom.HeroesActionNewPosition();
-
     int fastScrollRepeatCount = 0;
     const int fastScrollStartThreshold = 2;
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1542,7 +1542,6 @@ void RedrawGameAreaAndHeroAttackMonster( Heroes & hero, s32 dst )
 
 void Heroes::ActionNewPosition( void )
 {
-    const Settings & conf = Settings::Get();
     // check around monster
     MapsIndexes targets = Maps::GetTilesUnderProtection( GetIndex() );
 
@@ -1556,15 +1555,13 @@ void Heroes::ActionNewPosition( void )
         if ( it != targets.end() ) {
             RedrawGameAreaAndHeroAttackMonster( *this, *it );
             targets.erase( it );
-            if ( conf.ExtWorldOnlyFirstMonsterAttack() )
-                skip_battle = true;
+            skip_battle = true;
         }
 
         // other around targets
         for ( it = targets.begin(); it != targets.end() && !isFreeman() && !skip_battle; ++it ) {
             RedrawGameAreaAndHeroAttackMonster( *this, *it );
-            if ( conf.ExtWorldOnlyFirstMonsterAttack() )
-                skip_battle = true;
+            skip_battle = true;
         }
     }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2359,7 +2359,7 @@ std::pair<uint32_t, uint32_t> Maps::Tiles::GetMonsterSpriteIndices( const Tiles 
     std::pair<uint32_t, uint32_t> spriteIndices( monsterIndex * 9, 0 );
 
     // draw attack sprite
-    if ( attackerIndex != -1 && !Settings::Get().ExtWorldOnlyFirstMonsterAttack() ) {
+    if ( attackerIndex != -1 ) {
         spriteIndices.first += 7;
 
         switch ( Maps::GetDirection( tileIndex, attackerIndex ) ) {

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -145,10 +145,6 @@ namespace
             _( "world: allow set guardian to objects" ),
         },
         {
-            Settings::WORLD_ONLY_FIRST_MONSTER_ATTACK,
-            _( "world: only the first monster will attack (H2 bug)." ),
-        },
-        {
             Settings::WORLD_EYE_EAGLE_AS_SCHOLAR,
             _( "world: Eagle Eye also works like Scholar in H3." ),
         },
@@ -330,7 +326,6 @@ Settings::Settings()
 {
     ExtSetModes( GAME_AUTOSAVE_ON );
     ExtSetModes( WORLD_SHOW_VISITED_CONTENT );
-    ExtSetModes( WORLD_ONLY_FIRST_MONSTER_ATTACK );
 
     opt_global.SetModes( GLOBAL_FIRST_RUN );
     opt_global.SetModes( GLOBAL_SHOWRADAR );
@@ -1572,11 +1567,6 @@ bool Settings::ExtWorldAllowSetGuardian() const
 bool Settings::ExtWorldArtifactCrystalBall() const
 {
     return ExtModes( WORLD_ARTIFACT_CRYSTAL_BALL );
-}
-
-bool Settings::ExtWorldOnlyFirstMonsterAttack() const
-{
-    return ExtModes( WORLD_ONLY_FIRST_MONSTER_ATTACK );
 }
 
 bool Settings::ExtWorldEyeEagleAsScholar() const

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -82,7 +82,7 @@ public:
         WORLD_ALLOW_SET_GUARDIAN = 0x20000008,
         WORLD_ARTIFACT_CRYSTAL_BALL = 0x20000020,
         WORLD_SCOUTING_EXTENDED = 0x20000040,
-        WORLD_ONLY_FIRST_MONSTER_ATTACK = 0x20000080,
+        // UNUSED = 0x20000080,
         WORLD_EYE_EAGLE_AS_SCHOLAR = 0x20000100,
         HEROES_BUY_BOOK_FROM_SHRINES = 0x20000200,
         WORLD_BAN_WEEKOF = 0x20000400,
@@ -206,7 +206,6 @@ public:
     bool ExtWorldScouteExtended() const;
     bool ExtWorldAllowSetGuardian() const;
     bool ExtWorldArtifactCrystalBall() const;
-    bool ExtWorldOnlyFirstMonsterAttack() const;
     bool ExtWorldEyeEagleAsScholar() const;
     bool ExtWorldBanMonthOfMonsters() const;
     bool ExtWorldBanWeekOf() const;


### PR DESCRIPTION
relates to #1272

This option must be always enabled.