### PR TITLE
Fix attacking monster sprite behavior

### DIFF
--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -367,6 +367,9 @@ public:
 
     fheroes2::Point MovementDirection() const;
 
+    int GetAttackedMonsterTileIndex() const;
+    void SetAttackedMonsterTileIndex( int idx );
+
 private:
     friend StreamBase & operator<<( StreamBase &, const Heroes & );
     friend StreamBase & operator>>( StreamBase &, Heroes & );
@@ -426,6 +429,8 @@ private:
     RedrawIndex _redrawIndex;
 
     mutable int _alphaValue;
+
+    int _attackedMonsterTileIndex; // used only when hero attacks a group of wandering monsters
 
     enum
     {

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -364,6 +364,13 @@ void Heroes::Action( int tileIndex, bool isDestination )
     if ( GetKingdom().isControlAI() )
         return AI::HeroesAction( *this, tileIndex, isDestination );
 
+    // immediately center the map on the hero to avoid subsequent minor screen movements
+    Interface::Basic & I = Interface::Basic::Get();
+
+    I.GetGameArea().SetCenter( GetCenter() );
+    I.GetGameArea().SetRedraw();
+    I.Redraw();
+
     Maps::Tiles & tile = world.GetTiles( tileIndex );
     const int object = ( tileIndex == GetIndex() ? tile.GetObject( false ) : tile.GetObject() );
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -684,17 +684,13 @@ void Heroes::Action( int tileIndex, bool isDestination )
 
 void ActionToMonster( Heroes & hero, int obj, s32 dst_index )
 {
-    bool destroy = false;
     Maps::Tiles & tile = world.GetTiles( dst_index );
-    MapMonster * map_troop = NULL;
-    if ( tile.GetObject() == obj )
-        map_troop = dynamic_cast<MapMonster *>( world.GetMapObject( tile.GetObjectUID() ) );
-
+    MapMonster * map_troop = tile.GetObject() == obj ? dynamic_cast<MapMonster *>( world.GetMapObject( tile.GetObjectUID() ) ) : nullptr;
     Troop troop = map_troop ? map_troop->QuantityTroop() : tile.QuantityTroop();
 
-    JoinCount join = Army::GetJoinSolution( hero, tile, troop );
+    Interface::Basic & I = Interface::Basic::Get();
 
-    const Interface::StatusWindow & statusWindow = Interface::Basic::Get().GetStatusWindow();
+    JoinCount join = Army::GetJoinSolution( hero, tile, troop );
 
     // free join
     if ( JOIN_FREE == join.first ) {
@@ -702,71 +698,88 @@ void ActionToMonster( Heroes & hero, int obj, s32 dst_index )
 
         if ( Dialog::YES == Dialog::ArmyJoinFree( troop, hero ) ) {
             hero.GetArmy().JoinTroop( troop );
-            statusWindow.SetRedraw();
+
+            I.GetStatusWindow().SetRedraw();
         }
         else {
             Dialog::Message( "", _( "Insulted by your refusal of their offer, the monsters attack!" ), Font::BIG, Dialog::OK );
+
             join.first = JOIN_NONE;
         }
     }
-    else
-        // join with cost
-        if ( JOIN_COST == join.first ) {
+    // join with cost
+    else if ( JOIN_COST == join.first ) {
         const u32 gold = troop.GetCost().gold;
+
         if ( Dialog::YES == Dialog::ArmyJoinWithCost( troop, join.second, gold, hero ) ) {
             DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " join monster " << troop.GetName() << ", count: " << join.second << ", cost: " << gold );
 
             hero.GetArmy().JoinTroop( troop(), join.second );
             hero.GetKingdom().OddFundsResource( Funds( Resource::GOLD, gold ) );
-            statusWindow.SetRedraw();
+
+            I.GetStatusWindow().SetRedraw();
         }
         else {
             Dialog::Message( "", _( "Insulted by your refusal of their offer, the monsters attack!" ), Font::BIG, Dialog::OK );
+
             join.first = JOIN_NONE;
         }
     }
-    else
-        // flee
-        if ( JOIN_FLEE == join.first ) {
+    // flee
+    else if ( JOIN_FLEE == join.first ) {
         std::string message = _( "The %{monster}, awed by the power of your forces, begin to scatter.\nDo you wish to pursue and engage them?" );
         StringReplace( message, "%{monster}", StringLower( troop.GetMultiName() ) );
 
-        if ( Dialog::Message( "", message, Font::BIG, Dialog::YES | Dialog::NO ) == Dialog::NO )
-            destroy = true;
-        else
-            join.first = 0;
+        if ( Dialog::Message( "", message, Font::BIG, Dialog::YES | Dialog::NO ) == Dialog::YES ) {
+            join.first = JOIN_NONE;
+        }
     }
 
-    // bool allow_move = false;
+    bool destroy = false;
 
     // fight
     if ( JOIN_NONE == join.first ) {
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " attack monster " << troop.GetName() );
+
+        // set the hero's attacked monster tile index and immediately redraw game area to show an attacking sprite for this monster
+        hero.SetAttackedMonsterTileIndex( dst_index );
+
+        I.GetGameArea().SetRedraw();
+        I.Redraw();
+
         Army army( tile );
+
         Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
         if ( res.AttackerWins() ) {
             hero.IncreaseExperience( res.GetExperienceAttacker() );
+
             destroy = true;
-            // allow_move = true;
         }
         else {
             BattleLose( hero, res, true );
+
             tile.MonsterSetCount( army.GetCountMonsters( troop() ) );
-            // reset "can join"
-            if ( tile.MonsterJoinConditionFree() )
+
+            // reset join condition
+            if ( tile.MonsterJoinConditionFree() ) {
                 tile.MonsterSetJoinCondition( Monster::JOIN_CONDITION_MONEY );
+            }
 
             if ( map_troop ) {
                 map_troop->count = army.GetCountMonsters( troop() );
-                if ( map_troop->JoinConditionFree() )
+
+                // reset join condition
+                if ( map_troop->JoinConditionFree() ) {
                     map_troop->condition = Monster::JOIN_CONDITION_MONEY;
+                }
             }
         }
     }
-    // unknown
-    else
+    // just remove group of monsters
+    else {
         destroy = true;
+    }
 
     if ( destroy ) {
         AGG::PlaySound( M82::KILLFADE );
@@ -779,9 +792,13 @@ void ActionToMonster( Heroes & hero, int obj, s32 dst_index )
 
         Game::ObjectFadeAnimation::PerformFadeTask();
 
-        if ( map_troop )
+        if ( map_troop ) {
             world.RemoveMapObject( map_troop );
+        }
     }
+
+    // clear the hero's attacked monster tile index
+    hero.SetAttackedMonsterTileIndex( -1 );
 }
 
 void ActionToHeroes( Heroes & hero, s32 dst_index )

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -364,13 +364,6 @@ void Heroes::Action( int tileIndex, bool isDestination )
     if ( GetKingdom().isControlAI() )
         return AI::HeroesAction( *this, tileIndex, isDestination );
 
-    // immediately center the map on the hero to avoid subsequent minor screen movements
-    Interface::Basic & I = Interface::Basic::Get();
-
-    I.GetGameArea().SetCenter( GetCenter() );
-    I.GetGameArea().SetRedraw();
-    I.Redraw();
-
     Maps::Tiles & tile = world.GetTiles( tileIndex );
     const int object = ( tileIndex == GetIndex() ? tile.GetObject( false ) : tile.GetObject() );
 
@@ -382,9 +375,18 @@ void Heroes::Action( int tileIndex, bool isDestination )
         SetModes( ACTION );
     }
 
-    /* new format map only */
+    // new format map only
     ListActions * list = world.GetListActions( tileIndex );
     bool cancel_default = false;
+
+    if ( MP2::isActionObject( object, isShipMaster() ) || list ) {
+        // most likely there will be some action, immediately center the map on the hero to avoid subsequent minor screen movements
+        Interface::Basic & I = Interface::Basic::Get();
+
+        I.GetGameArea().SetCenter( GetCenter() );
+        I.GetGameArea().SetRedraw();
+        I.Redraw();
+    }
 
     if ( list ) {
         for ( ListActions::const_iterator it = list->begin(); it != list->end(); ++it ) {

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -384,7 +384,8 @@ void Heroes::Action( int tileIndex, bool isDestination )
         Interface::Basic & I = Interface::Basic::Get();
 
         I.GetGameArea().SetCenter( GetCenter() );
-        I.GetGameArea().SetRedraw();
+
+        I.SetRedraw( Interface::REDRAW_GAMEAREA | Interface::REDRAW_RADAR );
         I.Redraw();
     }
 
@@ -753,7 +754,7 @@ void ActionToMonster( Heroes & hero, int obj, s32 dst_index )
         // set the hero's attacked monster tile index and immediately redraw game area to show an attacking sprite for this monster
         hero.SetAttackedMonsterTileIndex( dst_index );
 
-        I.GetGameArea().SetRedraw();
+        I.SetRedraw( Interface::REDRAW_GAMEAREA );
         I.Redraw();
 
         Army army( tile );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -379,7 +379,7 @@ void Heroes::Action( int tileIndex, bool isDestination )
     ListActions * list = world.GetListActions( tileIndex );
     bool cancel_default = false;
 
-    if ( MP2::isActionObject( object, isShipMaster() ) || list ) {
+    if ( Modes( ACTION ) || list ) {
         // most likely there will be some action, immediately center the map on the hero to avoid subsequent minor screen movements
         Interface::Basic & I = Interface::Basic::Get();
 

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -88,7 +88,7 @@ struct ComparsionDistance
     int32_t center;
 };
 
-Maps::Indexes MapsIndexesFilteredObject( const Maps::Indexes & indexes, const int obj, const bool ignoreHeroes = true )
+Maps::Indexes Maps::MapsIndexesFilteredObject( const Maps::Indexes & indexes, const int obj, const bool ignoreHeroes /* = true */ )
 {
     Maps::Indexes result;
     for ( size_t idx = 0; idx < indexes.size(); ++idx ) {
@@ -99,7 +99,7 @@ Maps::Indexes MapsIndexesFilteredObject( const Maps::Indexes & indexes, const in
     return result;
 }
 
-Maps::Indexes MapsIndexesObject( const int obj, const bool ignoreHeroes = true )
+Maps::Indexes Maps::MapsIndexesObject( const int obj, const bool ignoreHeroes /* = true */ )
 {
     Maps::Indexes result;
     const int32_t size = static_cast<int32_t>( world.getSize() );

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -44,6 +44,9 @@ namespace Maps
 
     using Indexes = MapsIndexes;
 
+    Indexes MapsIndexesFilteredObject( const Indexes & indexes, const int obj, const bool ignoreHeroes = true );
+    Indexes MapsIndexesObject( const int obj, const bool ignoreHeroes = true );
+
     const char * SizeString( int size );
     const char * GetMinesName( int res );
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <iomanip>
 #include <iostream>
@@ -2341,24 +2342,23 @@ std::pair<uint32_t, uint32_t> Maps::Tiles::GetMonsterSpriteIndices( const Tiles 
     const int tileIndex = tile._index;
     int attackerIndex = -1;
 
-    // scan hero around
-    const MapsIndexes & v = ScanAroundObject( tileIndex, MP2::OBJ_HEROES );
-    for ( MapsIndexes::const_iterator it = v.begin(); it != v.end(); ++it ) {
-        const Tiles & heroTile = world.GetTiles( *it );
-        const Heroes * hero = heroTile.GetHeroes();
-        if ( hero == NULL ) { // not a hero? How can it be?!
-            continue;
-        }
+    // scan for a hero around
+    const MapsIndexes aroundIndexes = Maps::GetAroundIndexes( tileIndex );
 
-        if ( tile.isWater() == heroTile.isWater() ) {
-            attackerIndex = *it;
+    for ( const int32_t idx : Maps::MapsIndexesFilteredObject( aroundIndexes, MP2::OBJ_HEROES, false ) ) {
+        const Heroes * hero = world.GetTiles( idx ).GetHeroes();
+        assert( hero != nullptr );
+
+        // hero is going to attack monsters on this tile
+        if ( hero->GetAttackedMonsterTileIndex() == tileIndex ) {
+            attackerIndex = idx;
             break;
         }
     }
 
     std::pair<uint32_t, uint32_t> spriteIndices( monsterIndex * 9, 0 );
 
-    // draw attack sprite
+    // draw an attacking sprite if there is an attacking hero nearby
     if ( attackerIndex != -1 ) {
         spriteIndices.first += 7;
 


### PR DESCRIPTION
In original game, sprite of a monster attacked by hero (or attacking hero) changed before battle to the "attacking" sprite. This was the case in fheroes2 too if "world: only the first monster will attack (H2 bug)" option wasn't enabled. Recently this option was removed, so I decided to make this "attacking" sprite work again (and properly).

fix #1142 (sprite change logic was fixed)
fix #885 (still should fix that! 😛)
fix #2537 
fix #2377 