### PR TITLE
Castle screen, Creature separation window, the sentence "Fast separation into slots:" and the graphic "2" are not displayed when there are only 2 creatures in the starting slot during the distribution between the hero's army and the garrison

### DIFF
--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -32,7 +32,6 @@
 #include "world.h"
 
 #include <cassert>
-#include <iostream>
 
 void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * armyTarget )
 {

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -57,7 +57,6 @@ void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * ar
     else {
         uint32_t freeSlots = static_cast<uint32_t>( 1 + armyTarget->Size() - armyTarget->GetCount() );
 
-
         if ( isSameTroopType )
             ++freeSlots;
 

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -60,7 +60,7 @@ void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * ar
             ++freeSlots;
 
         const uint32_t maxCount = saveLastTroop ? troopFrom.GetCount() - 1 : troopFrom.GetCount();
-        uint32_t redistributeCount = isSameTroopType - 1 ? 1 : troopFrom.GetCount() / 2;
+        uint32_t redistributeCount = isSameTroopType ? 1 : troopFrom.GetCount() / 2;
 
         // if splitting to the same troop type, use this bool to turn off fast split option at the beginning of the dialog
         bool useFastSplit = !isSameTroopType;

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -32,6 +32,7 @@
 #include "world.h"
 
 #include <cassert>
+#include <iostream>
 
 void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * armyTarget )
 {
@@ -56,10 +57,11 @@ void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * ar
     else {
         uint32_t freeSlots = static_cast<uint32_t>( 1 + armyTarget->Size() - armyTarget->GetCount() );
 
+
         if ( isSameTroopType )
             ++freeSlots;
 
-        const uint32_t maxCount = saveLastTroop ? troopFrom.GetCount() - 1 : troopFrom.GetCount();
+        const uint32_t maxCount = troopFrom.GetCount();
         uint32_t redistributeCount = isSameTroopType ? 1 : troopFrom.GetCount() / 2;
 
         // if splitting to the same troop type, use this bool to turn off fast split option at the beginning of the dialog

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -59,8 +59,8 @@ void RedistributeArmy( ArmyTroop & troopFrom, ArmyTroop & troopTarget, Army * ar
         if ( isSameTroopType )
             ++freeSlots;
 
-        const uint32_t maxCount = troopFrom.GetCount();
-        uint32_t redistributeCount = isSameTroopType ? 1 : troopFrom.GetCount() / 2;
+        const uint32_t maxCount = saveLastTroop ? troopFrom.GetCount() - 1 : troopFrom.GetCount();
+        uint32_t redistributeCount = isSameTroopType - 1 ? 1 : troopFrom.GetCount() / 2;
 
         // if splitting to the same troop type, use this bool to turn off fast split option at the beginning of the dialog
         bool useFastSplit = !isSameTroopType;

--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -110,7 +110,7 @@ namespace Dialog
     int ArmyInfo( const Troop & troop, int flags, bool isReflected = false );
     int ArmyJoinFree( const Troop &, Heroes & );
     int ArmyJoinWithCost( const Troop &, u32 join, u32 gold, Heroes & );
-    int ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistributeMax, const bool saveLastTroop, uint32_t & redistributeCount, bool & useFastSplit );
+    int ArmySplitTroop( uint32_t freeSlots, const uint32_t redistributeMax, const bool saveLastTroop, uint32_t & redistributeCount, bool & useFastSplit );
     void Marketplace( Kingdom & kingdom, bool fromTradingPost );
     void MakeGiftResource( Kingdom & kingdom );
     int BuyBoat( bool enable );

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -300,8 +300,11 @@ bool Dialog::InputString( const std::string & header, std::string & res, const s
     return !res.empty();
 }
 
-int Dialog::ArmySplitTroop( const uint32_t freeSlots, const uint32_t redistributeMax, const bool savelastTroop, uint32_t & redistributeCount, bool & useFastSplit )
+int Dialog::ArmySplitTroop( uint32_t freeSlots, const uint32_t redistributeMax, const bool savelastTroop, uint32_t & redistributeCount, bool & useFastSplit )
 {
+    if ( savelastTroop )
+        ++freeSlots;
+
     assert( freeSlots > 0 );
 
     fheroes2::Display & display = fheroes2::Display::instance();


### PR DESCRIPTION
fix #3621 