### PR TITLE
Prefer per-user config file over global one

### DIFF
--- a/src/engine/dir.cpp
+++ b/src/engine/dir.cpp
@@ -168,16 +168,3 @@ void ListDirs::Append( const std::list<std::string> & dirs )
 {
     insert( end(), dirs.begin(), dirs.end() );
 }
-
-namespace fheroes2
-{
-    void AddOSSpecificDirectories( ListDirs & dirs )
-    {
-#if defined( FHEROES2_VITA )
-        dirs.emplace_back( "ux0:app/FHOMM0002" );
-        dirs.emplace_back( "ux0:data/fheroes2" );
-#else
-        (void)dirs;
-#endif
-    }
-}

--- a/src/engine/dir.h
+++ b/src/engine/dir.h
@@ -39,9 +39,4 @@ struct ListDirs : public std::list<std::string>
     void Append( const std::list<std::string> & );
 };
 
-namespace fheroes2
-{
-    void AddOSSpecificDirectories( ListDirs & dirs );
-}
-
 #endif

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -109,6 +109,17 @@ std::string System::ConcatePath( const std::string & str1, const std::string & s
     return std::string( str1 + SEPARATOR + str2 );
 }
 
+ListDirs System::GetOSSpecificDirectories()
+{
+    ListDirs dirs;
+
+#if defined( FHEROES2_VITA )
+    dirs.emplace_back( "ux0:app/FHOMM0002" );
+#endif
+
+    return dirs;
+}
+
 std::string System::GetConfigDirectory( const std::string & prog )
 {
 #if defined( __LINUX__ )

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -147,61 +147,6 @@ std::string System::GetDataDirectory( const std::string & prog )
 #endif
 }
 
-ListDirs System::GetDataDirectories( const std::string & prog )
-{
-    ListDirs dirs;
-
-#if defined( ANDROID )
-    const char * internal = SDL_AndroidGetInternalStoragePath();
-    if ( internal )
-        dirs.push_back( System::ConcatePath( internal, prog ) );
-
-    if ( SDL_ANDROID_EXTERNAL_STORAGE_READ && SDL_AndroidGetExternalStorageState() ) {
-        const char * external = SDL_AndroidGetExternalStoragePath();
-        if ( external )
-            dirs.push_back( System::ConcatePath( external, prog ) );
-    }
-
-    dirs.push_back( System::ConcatePath( "/storage/sdcard0", prog ) );
-    dirs.push_back( System::ConcatePath( "/storage/sdcard1", prog ) );
-#else
-    (void)prog;
-#endif
-
-    return dirs;
-}
-
-ListFiles System::GetListFiles( const std::string & prog, const std::string & prefix, const std::string & filter )
-{
-    ListFiles res;
-
-#if defined( ANDROID )
-    VERBOSE_LOG( prefix << ", " << filter );
-
-    // check assets
-    StreamFile sf;
-    if ( sf.open( "assets.list", "rb" ) ) {
-        std::list<std::string> rows = StringSplit( GetString( sf.getRaw( sf.size() ) ), "\n" );
-        for ( std::list<std::string>::const_iterator it = rows.begin(); it != rows.end(); ++it )
-            if ( prefix.empty() || ( ( prefix.size() <= ( *it ).size() && 0 == prefix.compare( ( *it ).substr( 0, prefix.size() ) ) ) ) ) {
-                if ( filter.empty() || ( 0 == filter.compare( ( *it ).substr( ( *it ).size() - filter.size(), filter.size() ) ) ) )
-                    res.push_back( *it );
-            }
-    }
-
-    ListDirs dirs = GetDataDirectories( prog );
-
-    for ( ListDirs::const_iterator it = dirs.begin(); it != dirs.end(); ++it ) {
-        res.ReadDir( prefix.size() ? System::ConcatePath( *it, prefix ) : *it, filter, false );
-    }
-#else
-    (void)prog;
-    (void)prefix;
-    (void)filter;
-#endif
-    return res;
-}
-
 std::string System::GetDirname( const std::string & str )
 {
     if ( str.size() ) {

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -32,6 +32,8 @@ namespace System
 
     int MakeDirectory( const std::string & );
     std::string ConcatePath( const std::string &, const std::string & );
+
+    ListDirs GetOSSpecificDirectories();
     std::string GetConfigDirectory( const std::string & prog );
     std::string GetDataDirectory( const std::string & prog );
 

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -32,8 +32,6 @@ namespace System
 
     int MakeDirectory( const std::string & );
     std::string ConcatePath( const std::string &, const std::string & );
-    ListDirs GetDataDirectories( const std::string & );
-    ListFiles GetListFiles( const std::string &, const std::string &, const std::string & );
     std::string GetConfigDirectory( const std::string & prog );
     std::string GetDataDirectory( const std::string & prog );
 

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -72,23 +72,19 @@ namespace
     void ReadConfigs()
     {
         Settings & conf = Settings::Get();
-        const ListFiles & files = Settings::GetListFiles( "", configurationFileName );
 
-        bool isValidConfigurationFile = false;
-        for ( ListFiles::const_iterator it = files.begin(); it != files.end(); ++it ) {
-            if ( System::IsFile( *it ) && conf.Read( *it ) ) {
-                isValidConfigurationFile = true;
-                const std::string & externalCommand = conf.externalMusicCommand();
-                if ( !externalCommand.empty() )
-                    Music::SetExtCommand( externalCommand );
+        const std::string confFile = Settings::GetLastFile( "", configurationFileName );
 
-                LocalEvent::Get().SetControllerPointerSpeed( conf.controllerPointerSpeed() );
-                break;
-            }
+        if ( System::IsFile( confFile ) && conf.Read( confFile ) ) {
+            const std::string & externalCommand = conf.externalMusicCommand();
+            if ( !externalCommand.empty() )
+                Music::SetExtCommand( externalCommand );
+
+            LocalEvent::Get().SetControllerPointerSpeed( conf.controllerPointerSpeed() );
         }
-
-        if ( !isValidConfigurationFile )
+        else {
             conf.Save( configurationFileName );
+        }
     }
 
     void InitConfigDir()

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -884,20 +884,21 @@ ListDirs Settings::GetRootDirs()
     if ( System::GetEnvironment( "FHEROES2_DATA" ) )
         dirs.push_back( System::GetEnvironment( "FHEROES2_DATA" ) );
 
-    // from dirname
+    // from app path
     dirs.push_back( System::GetDirname( Settings::Get().path_program ) );
 
-    // from user config
+    // os-specific directories
+    dirs.splice( dirs.end(), System::GetOSSpecificDirectories() );
+
+    // user config directory
     const std::string & config = System::GetConfigDirectory( "fheroes2" );
     if ( !config.empty() )
         dirs.push_back( config );
 
-    // from user data
+    // user data directory (may be the same as user config directory, so check this to avoid unnecessary work)
     const std::string & data = System::GetDataDirectory( "fheroes2" );
     if ( !data.empty() && ( std::find( dirs.cbegin(), dirs.cend(), data ) == dirs.cend() ) )
         dirs.push_back( data );
-
-    fheroes2::AddOSSpecificDirectories( dirs );
 
     return dirs;
 }

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -965,35 +965,6 @@ std::string Settings::GetLangDir()
     return "";
 }
 
-std::string Settings::GetWriteableDir( const char * subdir )
-{
-    ListDirs dirs = GetRootDirs();
-    dirs.Append( System::GetDataDirectories( "fheroes2" ) );
-
-    for ( ListDirs::const_iterator it = dirs.begin(); it != dirs.end(); ++it ) {
-        std::string dir_files = System::ConcatePath( *it, "files" );
-
-        // create files
-        if ( System::IsDirectory( *it, true ) && !System::IsDirectory( dir_files, true ) )
-            System::MakeDirectory( dir_files );
-
-        // create subdir
-        if ( System::IsDirectory( dir_files, true ) ) {
-            std::string dir_subdir = System::ConcatePath( dir_files, subdir );
-
-            if ( !System::IsDirectory( dir_subdir, true ) )
-                System::MakeDirectory( dir_subdir );
-
-            if ( System::IsDirectory( dir_subdir, true ) )
-                return dir_subdir;
-        }
-    }
-
-    DEBUG_LOG( DBG_GAME, DBG_WARN, "writable directory not found" );
-
-    return "";
-}
-
 bool Settings::MusicExt() const
 {
     return opt_global.Modes( GLOBAL_MUSIC_EXT );

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -918,8 +918,6 @@ ListFiles Settings::GetListFiles( const std::string & prefix, const std::string 
             res.ReadDir( path, filter, false );
     }
 
-    res.Append( System::GetListFiles( "fheroes2", prefix, filter ) );
-
     return res;
 }
 

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -315,7 +315,6 @@ public:
     static ListFiles GetListFiles( const std::string & prefix, const std::string & filter );
     static ListDirs GetRootDirs();
     static std::string GetLastFile( const std::string & prefix, const std::string & name );
-    static std::string GetWriteableDir( const char * );
     static std::string GetLangDir();
 
     static ListFiles FindFiles( const std::string & directory, const std::string & fileName );


### PR DESCRIPTION
fix #3636

It seems that there is already a ready-made mechanism for such situations - `Settings::GetLastFile()`, it is already used for `fheroes2.key` as well. As I understand, the order of search will be the following:

1. List of the matching files is created by scanning directories in the following order: directory from $FHEROES2_DATA env var first, then app's directory, then user config directory, then user data directory, then OS specific directories (like "ux0:..." on PS Vita);
2. The **last** file is taken from this list. If there is no matching files, just file name is taken, which effectively means "file with this name in current directory".

Need to test this on consoles too - to not break anything.