### PR TITLE
Adding gettext to the list of installed packages

### DIFF
--- a/script/linux/install_sdl_1.sh
+++ b/script/linux/install_sdl_1.sh
@@ -6,5 +6,5 @@ sudo apt-get remove libsdl2-mixer-dev
 sudo apt-get remove libsdl2-ttf-dev
 sudo apt-get remove libsdl2-dev
 
-# Install SDL 1.2
-sudo apt-get install -y libsdl1.2-dev libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl-image1.2-dev
+# Install SDL 1.2 and other dependencies
+sudo apt-get install -y libsdl1.2-dev libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl-image1.2-dev gettext

--- a/script/linux/install_sdl_2.sh
+++ b/script/linux/install_sdl_2.sh
@@ -6,5 +6,5 @@ sudo apt-get remove libsdl-mixer1.2-dev
 sudo apt-get remove libsdl-ttf2.0-dev
 sudo apt-get remove libsdl1.2-dev
 
-# Install SDL 2
-sudo apt-get install -y libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
+# Install SDL 2 and other dependencies
+sudo apt-get install -y libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev gettext


### PR DESCRIPTION
In [compilation instructions for Linux](https://github.com/ihhub/fheroes2#macos-and-linux) it's implied that you just need to run **install_sdl_2.sh** or **install_sdl_1.sh** to install dependencies (no other steps are present).

However both of these files are missing **gettext** package so if you follow the instruction, your compilation will fail.