### PR TITLE
Windows installer: always rewrite fheroes2.exe regardless of version number

### DIFF
--- a/script/windows/fheroes2.iss
+++ b/script/windows/fheroes2.iss
@@ -21,7 +21,7 @@ ArchitecturesInstallIn64BitMode=x64
 #endif
 
 [Files]
-Source: "{#BuildDir}\{#AppName}.exe"; DestDir: "{app}"
+Source: "{#BuildDir}\{#AppName}.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#BuildDir}\lib*.dll"; DestDir: "{app}"
 Source: "{#BuildDir}\SDL*.dll"; DestDir: "{app}"
 #if DeployConfName == 'SDL2'


### PR DESCRIPTION
Currently you will be not able to update fheroes2 to the latest pre-release build using Windows installer, because versions of files doesn't change from build to build. May be build versioning via AppVeyor (#3651) would be a better alternative, this is a subject for a discussion.