### PR TITLE
More gamepad hotkeys added

### DIFF
--- a/doc/README_PSV.md
+++ b/doc/README_PSV.md
@@ -27,9 +27,13 @@ make -f Makefile.vita
 
 ## Controls
 - Left analog stick - Pointer movement
-- X button - Left mouse button
-- O button - Right mouse button
 - D-Pad / Right analog stick - Map scrolling
+- × - Left mouse button
+- ○ - Right mouse button
+- □ - End turn
+- △ - Open spellbook
+- L1 - Next hero
+- R1 - Next castle
 - SELECT - System menu
 - START - Enter
 

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1434,8 +1434,23 @@ void LocalEvent::HandleControllerButtonEvent( const SDL_ControllerButtonEvent & 
             _dpadScrollActive = false;
         }
 
-        if ( button.button == SDL_CONTROLLER_BUTTON_LEFTSHOULDER || button.button == SDL_CONTROLLER_BUTTON_RIGHTSHOULDER ) {
+#if defined( FHEROES2_VITA )
+        if ( dpadInputActive && ( button.button == SDL_CONTROLLER_BUTTON_LEFTSHOULDER || button.button == SDL_CONTROLLER_BUTTON_RIGHTSHOULDER ) ) {
             key_value = KEY_SHIFT;
+            return;
+        }
+#endif
+        if ( button.button == SDL_CONTROLLER_BUTTON_LEFTSHOULDER ) {
+            key_value = KEY_h;
+        }
+        else if ( button.button == SDL_CONTROLLER_BUTTON_RIGHTSHOULDER ) {
+            key_value = KEY_t;
+        }
+        else if ( button.button == SDL_CONTROLLER_BUTTON_X ) {
+            key_value = KEY_e;
+        }
+        else if ( button.button == SDL_CONTROLLER_BUTTON_Y ) {
+            key_value = KEY_c;
         }
         else if ( button.button == SDL_CONTROLLER_BUTTON_BACK ) {
             key_value = KEY_f;


### PR DESCRIPTION
Added more key mappings for gamepad on Vita and Switch (switching between heroes/castles, end turn and the last one to open a spell book).