### PR TITLE
Fix issue when abandoned mine becomes OBJ_ZERO when captured by AI-controlled hero

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -849,7 +849,7 @@ namespace AI
                 // update abandone mine
                 if ( obj == MP2::OBJ_ABANDONEDMINE ) {
                     Maps::Tiles::UpdateAbandoneMineSprite( tile );
-                    tile.SetHeroes( &hero );
+                    hero.SetMapsObject( MP2::OBJ_MINES );
                 }
 
                 tile.QuantitySetColor( hero.GetColor() );


### PR DESCRIPTION
fix #3632

While hero is on tile, tile object is set to `MP2::OBJ_HEROES`, and hero saves original tile object into its `save_maps_object` property, so when tile object changes, we need update this property. `Maps::Tiles::UpdateAbandoneMineSprite()` doesn't update tile object by itself, so `SetHeroes()` for this tile will not help, we need to explicitly call `SetMapsObject()` method of a hero on that tile. Tile object will be updated automatically once hero will leave that tile.