### PR TITLE
Don't let nearby monsters automatically attack hero if he moved to this tile using Stone Lith, Whirlpool or Dimension Door

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -948,7 +948,7 @@ namespace AI
             Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
             hero.FadeIn();
         }
-        hero.ActionNewPosition();
+        hero.ActionNewPosition( false );
 
         DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() );
     }
@@ -974,7 +974,7 @@ namespace AI
             Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
             hero.FadeIn();
         }
-        hero.ActionNewPosition();
+        hero.ActionNewPosition( false );
 
         DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() );
     }
@@ -1584,7 +1584,7 @@ namespace AI
             Interface::Basic::Get().GetGameArea().SetCenter( prevPosition );
             hero.FadeIn( fheroes2::Point( offset.x * Game::AIHeroAnimSkip(), offset.y * Game::AIHeroAnimSkip() ) );
         }
-        hero.ActionNewPosition();
+        hero.ActionNewPosition( true );
 
         AI::Get().HeroesClearTask( hero );
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1515,24 +1515,26 @@ void Heroes::SetMapsObject( int obj )
 
 void Heroes::ActionPreBattle( void ) {}
 
-void Heroes::ActionNewPosition( void )
+void Heroes::ActionNewPosition( const bool allowMonsterAttack )
 {
-    // scan for monsters around
-    const MapsIndexes targets = Maps::GetTilesUnderProtection( GetIndex() );
+    if ( allowMonsterAttack ) {
+        // scan for monsters around
+        const MapsIndexes targets = Maps::GetTilesUnderProtection( GetIndex() );
 
-    if ( !targets.empty() ) {
-        SetMove( false );
-        GetPath().Hide();
+        if ( !targets.empty() ) {
+            SetMove( false );
+            GetPath().Hide();
 
-        // first fight the monsters on the destination tile (if any)
-        MapsIndexes::const_iterator it = std::find( targets.begin(), targets.end(), GetPath().GetDestinedIndex() );
+            // first fight the monsters on the destination tile (if any)
+            MapsIndexes::const_iterator it = std::find( targets.begin(), targets.end(), GetPath().GetDestinedIndex() );
 
-        if ( it != targets.end() ) {
-            Action( *it, true );
-        }
-        // otherwise fight the monsters on the first adjacent tile
-        else {
-            Action( targets.front(), true );
+            if ( it != targets.end() ) {
+                Action( *it, true );
+            }
+            // otherwise fight the monsters on the first adjacent tile
+            else {
+                Action( targets.front(), true );
+            }
         }
     }
 

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -319,7 +319,7 @@ public:
     bool isAction( void ) const;
     void ResetAction( void );
     void Action( int tileIndex, bool isDestination );
-    void ActionNewPosition( void );
+    void ActionNewPosition( const bool allowMonsterAttack );
     void ApplyPenaltyMovement( uint32_t penalty );
     bool ActionSpellCast( const Spell & );
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -988,7 +988,7 @@ void ActionToCoast( Heroes & hero, s32 dst_index )
     hero.GetPath().Hide();
     hero.FadeIn( fheroes2::Point( offset.x * Game::HumanHeroAnimSkip(), offset.y * Game::HumanHeroAnimSkip() ) );
     hero.GetPath().Reset();
-    hero.ActionNewPosition();
+    hero.ActionNewPosition( true );
 
     DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() );
 }
@@ -2005,7 +2005,7 @@ void ActionToTeleports( Heroes & hero, s32 index_from )
 
     hero.GetPath().Reset();
     hero.GetPath().Show(); // Reset method sets Hero's path to hidden mode with non empty path, we have to set it back
-    hero.ActionNewPosition();
+    hero.ActionNewPosition( false );
 
     DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() );
 }
@@ -2039,7 +2039,7 @@ void ActionToWhirlpools( Heroes & hero, s32 index_from )
 
     hero.GetPath().Reset();
     hero.GetPath().Show(); // Reset method sets Hero's path to hidden mode with non empty path, we have to set it back
-    hero.ActionNewPosition();
+    hero.ActionNewPosition( false );
 
     DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() );
 }

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -721,7 +721,7 @@ void Heroes::MoveStep( Heroes & hero, s32 indexTo, bool newpos )
     hero.ApplyPenaltyMovement( path.GetFrontPenalty() );
     if ( newpos ) {
         hero.Move2Dest( indexTo );
-        hero.ActionNewPosition();
+        hero.ActionNewPosition( true );
         path.PopFront();
 
         // possible that hero loses the battle

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -438,9 +438,7 @@ bool ActionSpellDimensionDoor( Heroes & hero )
         hero.FadeIn();
         hero.GetPath().Reset();
         hero.GetPath().Show(); // Reset method sets Hero's path to hidden mode with non empty path, we have to set it back
-
-        // No action is being made. Uncomment this code if the logic will be changed
-        // hero.ActionNewPosition();
+        hero.ActionNewPosition( false );
 
         I.ResetFocus( GameFocus::HEROES );
 

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -605,13 +605,6 @@ u32 Kingdom::GetMaxHeroes( void )
     return GameStatic::GetKingdomMaxHeroes();
 }
 
-void Kingdom::HeroesActionNewPosition() const
-{
-    // Heroes::ActionNewPosition: can remove elements from heroes vector.
-    KingdomHeroes heroes2( heroes );
-    std::for_each( heroes2.begin(), heroes2.end(), []( Heroes * hero ) { hero->ActionNewPosition( true ); } );
-}
-
 Funds Kingdom::GetIncome( int type /* INCOME_ALL */ ) const
 {
     Funds totalIncome;

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -609,7 +609,7 @@ void Kingdom::HeroesActionNewPosition() const
 {
     // Heroes::ActionNewPosition: can remove elements from heroes vector.
     KingdomHeroes heroes2( heroes );
-    std::for_each( heroes2.begin(), heroes2.end(), []( Heroes * hero ) { hero->ActionNewPosition(); } );
+    std::for_each( heroes2.begin(), heroes2.end(), []( Heroes * hero ) { hero->ActionNewPosition( true ); } );
 }
 
 Funds Kingdom::GetIncome( int type /* INCOME_ALL */ ) const

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -144,7 +144,6 @@ public:
     void AddHeroes( Heroes * );
     void RemoveHeroes( const Heroes * );
     void ApplyPlayWithStartingHero( void );
-    void HeroesActionNewPosition() const;
 
     void AddCastle( const Castle * );
     void RemoveCastle( const Castle * );


### PR DESCRIPTION
fix #717
fix #1183 (sort of, hero should not attack creatures when moving using the Dimension Door)