### PR TITLE
Fix build with older Xcode versions

### DIFF
--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -23,6 +23,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 
 namespace

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <cstdlib>
 
 #include "localevent.h"
 #include "audio_mixer.h"

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -24,6 +24,7 @@
 #include <cctype>
 #include <climits>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <iomanip>

--- a/src/fheroes2/agg/bin_info.cpp
+++ b/src/fheroes2/agg/bin_info.cpp
@@ -25,6 +25,7 @@
 #include "monster.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <iostream>
 
 namespace Bin_Info

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -36,6 +36,7 @@
 #include "speed.h"
 
 #include <cassert>
+#include <cmath>
 
 using namespace Battle;
 

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdlib>
 #include <functional>
 #include <iterator>
 #include <set>

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <cstdlib>
 
 #include "agg.h"
 #include "agg_image.h"

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -20,6 +20,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <cstdlib>
+
 #include "agg_image.h"
 #include "army.h"
 #include "castle.h"

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstdlib>
 #include <map>
 
 #include "agg.h"

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -25,6 +25,8 @@
 #include "text.h"
 
 #include <chrono>
+#include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <deque>

--- a/src/fheroes2/heroes/heroes_indicator.cpp
+++ b/src/fheroes2/heroes/heroes_indicator.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include <cmath>
+#include <cstdlib>
 
 #include "agg_image.h"
 #include "dialog.h"

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <cstdlib>
 #include <numeric>
 
 #include "ai.h"

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstdlib>
 #include <iomanip>
 #include <iostream>
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -18,6 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <cmath>
 #include <set>
 
 #include "ground.h"


### PR DESCRIPTION
Issues caught by MacPorts buildbot:

1. `#include <cstdlib>` is required for `std::abs()` with int argument and `std::div()`: [buildbot log](https://build.macports.org/builders/ports-10.10_x86_64-builder/builds/145739/steps/install-port/logs/stdio)
