### PR TITLE
Adventure map, Alchemist's Tower, Sphere of Negation should not be considered a cursed artifact

### DIFF
--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -330,7 +330,6 @@ bool Artifact::isAlchemistRemove( void ) const
     case HEART_FIRE:
     case HEART_ICE:
     case BROACH_SHIELDING:
-    case SPHERE_NEGATION:
         return true;
     }
 


### PR DESCRIPTION
Fix for #3682