### PR TITLE
Heroes::setVisitedForAllies(): set object as visited for this hero's kingdom as well, not just for allied kingdoms

### DIFF
--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -874,9 +874,7 @@ void Heroes::setVisitedForAllies( const int32_t tileIndex ) const
     // Set visited to all allies as well.
     const Colors friendColors( Players::GetPlayerFriends( GetColor() ) );
     for ( const int friendColor : friendColors ) {
-        if ( friendColor != GetColor() ) {
-            world.GetKingdom( friendColor ).SetVisited( tileIndex, objectId );
-        }
+        world.GetKingdom( friendColor ).SetVisited( tileIndex, objectId );
     }
 }
 


### PR DESCRIPTION
fix #3680

It looks like this method is intended to mark object as visited for hero's kingdom too, but currently it is not the case.