### PR TITLE
Don't consider Sphere of Negation as cursed artifact when visiting the Alchemist's Tower

### DIFF
--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -330,7 +330,6 @@ bool Artifact::isAlchemistRemove( void ) const
     case HEART_FIRE:
     case HEART_ICE:
     case BROACH_SHIELDING:
-    case SPHERE_NEGATION:
         return true;
     }
 


### PR DESCRIPTION
fix #3682