### PR TITLE
AI improvements

### DIFF
--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -64,10 +64,16 @@ namespace AI
         }
 
         Army & heroArmy = hero.GetArmy();
+        const double armyStrength = heroArmy.GetStrength();
+
         heroArmy.UpgradeTroops( castle );
         castle.recruitBestAvailable( budget );
         heroArmy.JoinStrongestFromArmy( castle.GetArmy() );
         OptimizeTroopsOrder( heroArmy );
+
+        if ( std::fabs( armyStrength - heroArmy.GetStrength() ) > 0.001 ) {
+            hero.unmarkHeroMeeting();
+        }
     }
 
     void OptimizeTroopsOrder( Army & army )

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1734,13 +1734,14 @@ namespace AI
         case MP2::OBJ_SHRINE3: {
             const Spell & spell = tile.QuantitySpell();
             assert( spell.isValid() );
-            if ( !spell.isValid() || !hero.HaveSpellBook() || hero.HaveSpell( spell ) ||
-                ( 3 == spell.Level() && Skill::Level::NONE == hero.GetLevelSkill( Skill::Secondary::WISDOM ) ) ) {
+            if ( !spell.isValid() || !hero.HaveSpellBook() || hero.HaveSpell( spell )
+                 || ( 3 == spell.Level() && Skill::Level::NONE == hero.GetLevelSkill( Skill::Secondary::WISDOM ) ) ) {
                 return false;
             }
 
-            if ( hero.isObjectTypeVisited( obj, Visit::GLOBAL ) && ( spell == Spell::VIEWALL || spell == Spell::VIEWARTIFACTS || spell == Spell::VIEWHEROES ||
-                spell == Spell::VIEWMINES || spell == Spell::VIEWRESOURCES || spell == Spell::VIEWTOWNS || spell == Spell::IDENTIFYHERO || spell == Spell::VISIONS ) ) {
+            if ( hero.isObjectTypeVisited( obj, Visit::GLOBAL )
+                 && ( spell == Spell::VIEWALL || spell == Spell::VIEWARTIFACTS || spell == Spell::VIEWHEROES || spell == Spell::VIEWMINES || spell == Spell::VIEWRESOURCES
+                      || spell == Spell::VIEWTOWNS || spell == Spell::IDENTIFYHERO || spell == Spell::VISIONS ) ) {
                 // AI never uses View spells.
                 return false;
             }
@@ -1885,7 +1886,7 @@ namespace AI
             }
             break;
 
-        // case MP2::OBJ_PYRAMID:
+            // case MP2::OBJ_PYRAMID:
 
         case MP2::OBJ_DAEMONCAVE:
             if ( tile.QuantityIsValid() && 4 != tile.QuantityVariant() )

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -701,6 +701,8 @@ namespace AI
             if ( map_troop )
                 world.RemoveMapObject( map_troop );
         }
+
+        hero.unmarkHeroMeeting();
     }
 
     void AIToPickupResource( Heroes & hero, int obj, s32 dst_index )
@@ -741,8 +743,8 @@ namespace AI
 
             if ( gold ) {
                 const u32 expr = gold > 500 ? gold - 500 : 500;
-                // select gold or exp
-                if ( Rand::Get( 1 ) ) {
+                // Only 10% chance of choosing experience. Make AI rich!
+                if ( Rand::Get( 1, 10 ) == 1 ) {
                     gold = 0;
                     hero.IncreaseExperience( expr );
                 }
@@ -872,7 +874,7 @@ namespace AI
 
     void AIToSign( Heroes & hero, s32 dst_index )
     {
-        hero.SetVisited( dst_index, Visit::LOCAL );
+        hero.SetVisited( dst_index, Visit::GLOBAL );
         DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() );
     }
 
@@ -1079,7 +1081,9 @@ namespace AI
              // check valid level spell and wisdom skill
              !( 3 == spell_level && Skill::Level::NONE == hero.GetLevelSkill( Skill::Secondary::WISDOM ) ) ) {
             hero.AppendSpellToBook( spell );
-            hero.SetVisited( dst_index );
+
+            // All heroes will know which spell is here.
+            hero.SetVisited( dst_index, Visit::GLOBAL );
         }
         DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() );
     }
@@ -1343,8 +1347,10 @@ namespace AI
         Maps::Tiles & tile = world.GetTiles( dst_index );
         const Troop & troop = tile.QuantityTroop();
 
-        if ( troop.isValid() && hero.GetArmy().JoinTroop( troop ) )
+        if ( troop.isValid() && hero.GetArmy().JoinTroop( troop ) ) {
             tile.MonsterSetCount( 0 );
+            hero.unmarkHeroMeeting();
+        }
 
         DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() );
     }
@@ -1367,6 +1373,8 @@ namespace AI
                     tile.RemoveObjectSprite();
                     tile.setAsEmpty();
                 }
+
+                hero.unmarkHeroMeeting();
             }
         }
 
@@ -1387,6 +1395,8 @@ namespace AI
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
                 tile.QuantitySetColor( hero.GetColor() );
                 tile.SetObjectPassable( true );
+
+                hero.unmarkHeroMeeting();
             }
             else {
                 AIBattleLose( hero, res, true, Color::NONE );
@@ -1619,26 +1629,18 @@ namespace AI
         const Army & army = hero.GetArmy();
         const Kingdom & kingdom = hero.GetKingdom();
 
-        // check other
         switch ( obj ) {
-        // water object
         case MP2::OBJ_SHIPWRECKSURVIROR:
         case MP2::OBJ_WATERCHEST:
         case MP2::OBJ_FLOTSAM:
         case MP2::OBJ_BOTTLE:
-            if ( hero.isShipMaster() )
-                return true;
-            break;
+            return hero.isShipMaster();
 
         case MP2::OBJ_BUOY:
-            if ( !hero.isObjectTypeVisited( obj ) && Morale::BLOOD > hero.GetMorale() )
-                return true;
-            break;
+            return !hero.isObjectTypeVisited( obj ) && hero.GetMorale() < Morale::BLOOD;
 
         case MP2::OBJ_MERMAID:
-            if ( !hero.isObjectTypeVisited( obj ) && Luck::IRISH > hero.GetLuck() )
-                return true;
-            break;
+            return !hero.isObjectTypeVisited( obj ) && hero.GetLuck() < Luck::IRISH;
 
         case MP2::OBJ_SIRENS:
             return false;
@@ -1650,7 +1652,6 @@ namespace AI
         case MP2::OBJ_COAST:
             return hero.isShipMaster() && !hero.isVisited( tile ) && tile.GetRegion() != hero.lastGroundRegion();
 
-        // capture objects
         case MP2::OBJ_SAWMILL:
         case MP2::OBJ_MINES:
         case MP2::OBJ_ALCHEMYLAB:
@@ -1664,13 +1665,10 @@ namespace AI
             }
             break;
 
-        // pickup object
         case MP2::OBJ_WAGON:
         case MP2::OBJ_LEANTO:
         case MP2::OBJ_SKELETON:
-            if ( tile.QuantityIsValid() )
-                return true;
-            break;
+            return tile.QuantityIsValid();
 
         case MP2::OBJ_MAGICGARDEN:
         case MP2::OBJ_WATERWHEEL:
@@ -1687,13 +1685,10 @@ namespace AI
                 return true;
             break;
 
-        // pickup resource
         case MP2::OBJ_RESOURCE:
         case MP2::OBJ_CAMPFIRE:
         case MP2::OBJ_TREASURECHEST:
-            if ( !hero.isShipMaster() )
-                return true;
-            break;
+            return !hero.isShipMaster();
 
         case MP2::OBJ_ARTIFACT: {
             const u32 variants = tile.QuantityVariant();
@@ -1724,56 +1719,50 @@ namespace AI
                 return true;
         }
 
-        // increase view
         case MP2::OBJ_OBSERVATIONTOWER:
-        // obelisk
         case MP2::OBJ_OBELISK:
-            if ( !hero.isVisited( tile, Visit::GLOBAL ) )
-                return true;
-            break;
+            return !hero.isVisited( tile, Visit::GLOBAL );
 
         case MP2::OBJ_BARRIER:
-            if ( kingdom.IsVisitTravelersTent( tile.QuantityColor() ) )
-                return true;
-            break;
+            return kingdom.IsVisitTravelersTent( tile.QuantityColor() );
 
         case MP2::OBJ_TRAVELLERTENT:
-            if ( !kingdom.IsVisitTravelersTent( tile.QuantityColor() ) )
-                return true;
-            break;
+            return !kingdom.IsVisitTravelersTent( tile.QuantityColor() );
 
-            // new spell
         case MP2::OBJ_SHRINE1:
         case MP2::OBJ_SHRINE2:
         case MP2::OBJ_SHRINE3: {
             const Spell & spell = tile.QuantitySpell();
-            if ( spell.isValid() &&
-                 // check spell book
-                 hero.HaveSpellBook() && !hero.HaveSpell( spell ) &&
-                 // check valid level spell and wisdom skill
-                 !( 3 == spell.Level() && Skill::Level::NONE == hero.GetLevelSkill( Skill::Secondary::WISDOM ) ) )
-                return true;
-        } break;
+            assert( spell.isValid() );
+            if ( !spell.isValid() || !hero.HaveSpellBook() || hero.HaveSpell( spell ) ||
+                ( 3 == spell.Level() && Skill::Level::NONE == hero.GetLevelSkill( Skill::Secondary::WISDOM ) ) ) {
+                return false;
+            }
 
-            // primary skill
+            if ( hero.isObjectTypeVisited( obj, Visit::GLOBAL ) && ( spell == Spell::VIEWALL || spell == Spell::VIEWARTIFACTS || spell == Spell::VIEWHEROES ||
+                spell == Spell::VIEWMINES || spell == Spell::VIEWRESOURCES || spell == Spell::VIEWTOWNS || spell == Spell::IDENTIFYHERO || spell == Spell::VISIONS ) ) {
+                // AI never uses View spells.
+                return false;
+            }
+            return true;
+        }
+
+        // primary skill
         case MP2::OBJ_FORT:
         case MP2::OBJ_MERCENARYCAMP:
         case MP2::OBJ_DOCTORHUT:
         case MP2::OBJ_STANDINGSTONES:
         // exp
         case MP2::OBJ_GAZEBO:
-            if ( !hero.isVisited( tile ) )
-                return true;
-            break;
+            return !hero.isVisited( tile );
 
         // sec skill
         case MP2::OBJ_WITCHSHUT: {
             const Skill::Secondary & skill = tile.QuantitySkill();
 
             // check skill
-            if ( skill.isValid() && !hero.HasMaxSecondarySkill() && !hero.HasSecondarySkill( skill.Skill() ) )
-                return true;
-        } break;
+            return skill.isValid() && !hero.HasMaxSecondarySkill() && !hero.HasSecondarySkill( skill.Skill() );
+        }
 
         case MP2::OBJ_TREEKNOWLEDGE:
             if ( !hero.isVisited( tile ) ) {
@@ -1787,27 +1776,19 @@ namespace AI
         case MP2::OBJ_FOUNTAIN:
         case MP2::OBJ_FAERIERING:
         case MP2::OBJ_IDOL:
-            if ( !hero.isObjectTypeVisited( obj ) && Luck::IRISH > hero.GetLuck() )
-                return true;
-            break;
+            return !hero.isObjectTypeVisited( obj ) && hero.GetLuck() < Luck::IRISH;
 
         // good morale
         case MP2::OBJ_OASIS:
         case MP2::OBJ_TEMPLE:
         case MP2::OBJ_WATERINGHOLE:
-            if ( !hero.isObjectTypeVisited( obj ) && Morale::BLOOD > hero.GetMorale() )
-                return true;
-            break;
+            return !hero.isObjectTypeVisited( obj ) && hero.GetMorale() < Morale::BLOOD;
 
         case MP2::OBJ_MAGICWELL:
-            if ( !hero.isVisited( tile ) && hero.GetMaxSpellPoints() != hero.GetSpellPoints() )
-                return true;
-            break;
+            return !hero.isVisited( tile ) && hero.HaveSpellBook() && hero.GetSpellPoints() < hero.GetMaxSpellPoints();
 
         case MP2::OBJ_ARTESIANSPRING:
-            if ( !hero.isVisited( tile ) && 2 * hero.GetMaxSpellPoints() > hero.GetSpellPoints() )
-                return true;
-            break;
+            return !hero.isVisited( tile ) && hero.HaveSpellBook() && hero.GetSpellPoints() < 2 * hero.GetMaxSpellPoints();
 
         case MP2::OBJ_XANADU: {
             const u32 level1 = hero.GetLevelSkill( Skill::Secondary::DIPLOMACY );
@@ -1829,12 +1810,15 @@ namespace AI
         case MP2::OBJ_GOBLINHUT:
         case MP2::OBJ_DWARFCOTT:
         case MP2::OBJ_HALFLINGHOLE:
-        case MP2::OBJ_PEASANTHUT:
         case MP2::OBJ_THATCHEDHUT: {
             const Troop & troop = tile.QuantityTroop();
-            if ( troop.isValid() && ( army.HasMonster( troop() ) || ( !army.isFullHouse() ) ) )
-                return true;
-            break;
+            return troop.isValid() && ( army.HasMonster( troop() ) || ( !army.isFullHouse() ) );
+        }
+
+        case MP2::OBJ_PEASANTHUT: {
+            // Peasants are special monsters. They're the weakest! Think twice before getting them.
+            const Troop & troop = tile.QuantityTroop();
+            return troop.isValid() && ( army.HasMonster( troop() ) || ( !army.isFullHouse() && army.GetStrength() < troop.GetStrength() * 10 ) );
         }
 
         // recruit army
@@ -1848,11 +1832,9 @@ namespace AI
         case MP2::OBJ_EARTHALTAR:
         case MP2::OBJ_BARROWMOUNDS: {
             const Troop & troop = tile.QuantityTroop();
-            const payment_t paymentCosts = troop.GetCost();
+            const payment_t & paymentCosts = troop.GetCost();
 
-            if ( troop.isValid() && kingdom.AllowPayment( paymentCosts ) && ( army.HasMonster( troop() ) || !army.isFullHouse() ) )
-                return true;
-            break;
+            return troop.isValid() && kingdom.AllowPayment( paymentCosts ) && ( army.HasMonster( troop() ) || !army.isFullHouse() );
         }
 
         // recruit army (battle)
@@ -1864,46 +1846,34 @@ namespace AI
             }
             else {
                 const Troop & troop = tile.QuantityTroop();
-                const payment_t paymentCosts = troop.GetCost();
+                const payment_t & paymentCosts = troop.GetCost();
 
-                if ( troop.isValid() && kingdom.AllowPayment( paymentCosts ) && ( army.HasMonster( troop() ) || ( !army.isFullHouse() ) ) )
-                    return true;
+                return troop.isValid() && kingdom.AllowPayment( paymentCosts ) && ( army.HasMonster( troop() ) || ( !army.isFullHouse() ) );
             }
-            break;
         }
 
         // recruit genie
         case MP2::OBJ_ANCIENTLAMP: {
             const Troop & troop = tile.QuantityTroop();
-            const payment_t paymentCosts = troop.GetCost();
+            const payment_t & paymentCosts = troop.GetCost();
 
-            if ( troop.isValid() && kingdom.AllowPayment( paymentCosts ) && ( army.HasMonster( troop() ) || ( !army.isFullHouse() ) ) )
-                return true;
-            break;
+            return troop.isValid() && kingdom.AllowPayment( paymentCosts ) && ( army.HasMonster( troop() ) || ( !army.isFullHouse() ) );
         }
 
         // upgrade army
         case MP2::OBJ_HILLFORT:
-            if ( army.HasMonster( Monster::DWARF ) || army.HasMonster( Monster::ORC ) || army.HasMonster( Monster::OGRE ) )
-                return true;
-            break;
+            return army.HasMonster( Monster::DWARF ) || army.HasMonster( Monster::ORC ) || army.HasMonster( Monster::OGRE );
 
-            // upgrade army
+        // upgrade army
         case MP2::OBJ_FREEMANFOUNDRY:
-            if ( army.HasMonster( Monster::PIKEMAN ) || army.HasMonster( Monster::SWORDSMAN ) || army.HasMonster( Monster::IRON_GOLEM ) )
-                return true;
-            break;
+            return army.HasMonster( Monster::PIKEMAN ) || army.HasMonster( Monster::SWORDSMAN ) || army.HasMonster( Monster::IRON_GOLEM );
 
         // loyalty obj
         case MP2::OBJ_STABLES:
-            if ( army.HasMonster( Monster::CAVALRY ) || !hero.isVisited( tile ) )
-                return true;
-            break;
+            return army.HasMonster( Monster::CAVALRY ) || !hero.isVisited( tile );
 
         case MP2::OBJ_ARENA:
-            if ( !hero.isVisited( tile ) )
-                return true;
-            break;
+            return !hero.isVisited( tile );
 
         // poor morale obj
         case MP2::OBJ_SHIPWRECK:
@@ -1915,7 +1885,7 @@ namespace AI
             }
             break;
 
-            // case MP2::OBJ_PYRAMID:
+        // case MP2::OBJ_PYRAMID:
 
         case MP2::OBJ_DAEMONCAVE:
             if ( tile.QuantityIsValid() && 4 != tile.QuantityVariant() )
@@ -1925,11 +1895,9 @@ namespace AI
         case MP2::OBJ_MONSTER:
             return army.isStrongerThan( Army( tile ), ARMY_STRENGTH_ADVANTAGE_MEDUIM );
 
-        // sign
         case MP2::OBJ_SIGN:
-            if ( !hero.isVisited( tile ) )
-                return true;
-            break;
+            // AI has no brains to process anything from sign messages.
+            return false;
 
         case MP2::OBJ_HEROES: {
             const Heroes * hero2 = tile.GetHeroes();

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -129,7 +129,7 @@ namespace AI
         void HeroesPreBattle( HeroBase & hero, bool isAttacking ) override;
         void HeroesActionComplete( Heroes & hero ) override;
 
-        double getObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distance ) const;
+        double getObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         int getPriorityTarget( const Heroes & hero, double & maxPriority, int patrolIndex = -1, uint32_t distanceLimit = 0 );
         void resetPathfinder() override;
 

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -129,7 +129,7 @@ namespace AI
         void HeroesPreBattle( HeroBase & hero, bool isAttacking ) override;
         void HeroesActionComplete( Heroes & hero ) override;
 
-        double getObjectValue( const Heroes & hero, int index, int objectID, double valueToIgnore ) const;
+        double getObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distance ) const;
         int getPriorityTarget( const Heroes & hero, double & maxPriority, int patrolIndex = -1, uint32_t distanceLimit = 0 );
         void resetPathfinder() override;
 

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -107,7 +107,7 @@ namespace AI
         return value - ( distance * std::log10( distance ) );
     }
 
-    double Normal::getObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distance ) const
+    double Normal::getObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const
     {
         // In the future these hardcoded values could be configured by the mod
         // 1 tile distance is 100.0 value approximately
@@ -258,7 +258,7 @@ namespace AI
         }
         else if ( objectID == MP2::OBJ_STABLES ) {
             const int daysActive = DAYOFWEEK - world.GetDay() + 1;
-            double movementBonus = daysActive * 400.0 - 2.0 * distance;
+            double movementBonus = daysActive * 400.0 - 2.0 * distanceToObject;
             if ( movementBonus < 0 ) {
                 // Looks like this is too far away.
                 movementBonus = 0;
@@ -289,10 +289,10 @@ namespace AI
             return 1000;
         }
         else if ( objectID == MP2::OBJ_OASIS ) {
-            return std::max( 800.0 - 2.0 * distance, 0.0 );
+            return std::max( 800.0 - 2.0 * distanceToObject, 0.0 );
         }
         else if ( objectID == MP2::OBJ_WATERINGHOLE ) {
-            return std::max( 400.0 - 2.0 * distance, 0.0 );
+            return std::max( 400.0 - 2.0 * distanceToObject, 0.0 );
         }
 
         // TODO: add support for all possible objects.

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -260,7 +260,7 @@ namespace AI
             const int daysActive = DAYOFWEEK - world.GetDay() + 1;
             double movementBonus = daysActive * 400.0 - 2.0 * distance;
             if ( movementBonus < 0 ) {
-                // Looks like this 
+                // Looks like this is too far away.
                 movementBonus = 0;
             }
 
@@ -272,25 +272,26 @@ namespace AI
             const double upgradeSwordsmanValue = Monster( Monster::MASTER_SWORDSMAN ).GetMonsterStrength() - Monster( Monster::SWORDSMAN ).GetMonsterStrength();
             const double upgradeGolemValue = Monster( Monster::STEEL_GOLEM ).GetMonsterStrength() - Monster( Monster::IRON_GOLEM ).GetMonsterStrength();
 
-            return upgradePikemanValue * hero.GetArmy().GetCountMonsters( Monster::PIKEMAN ) + upgradeSwordsmanValue * hero.GetArmy().GetCountMonsters( Monster::SWORDSMAN ) +
-                upgradeGolemValue * hero.GetArmy().GetCountMonsters( Monster::IRON_GOLEM );
+            return upgradePikemanValue * hero.GetArmy().GetCountMonsters( Monster::PIKEMAN )
+                   + upgradeSwordsmanValue * hero.GetArmy().GetCountMonsters( Monster::SWORDSMAN )
+                   + upgradeGolemValue * hero.GetArmy().GetCountMonsters( Monster::IRON_GOLEM );
         }
         else if ( objectID == MP2::OBJ_HILLFORT ) {
             const double upgradeDwarfValue = Monster( Monster::BATTLE_DWARF ).GetMonsterStrength() - Monster( Monster::DWARF ).GetMonsterStrength();
             const double upgradeOrcValue = Monster( Monster::ORC_CHIEF ).GetMonsterStrength() - Monster( Monster::ORC ).GetMonsterStrength();
             const double upgradeOgreValue = Monster( Monster::OGRE_LORD ).GetMonsterStrength() - Monster( Monster::OGRE ).GetMonsterStrength();
 
-            return upgradeDwarfValue * hero.GetArmy().GetCountMonsters( Monster::DWARF ) + upgradeOrcValue * hero.GetArmy().GetCountMonsters( Monster::ORC ) +
-                upgradeOgreValue * hero.GetArmy().GetCountMonsters( Monster::OGRE );
+            return upgradeDwarfValue * hero.GetArmy().GetCountMonsters( Monster::DWARF ) + upgradeOrcValue * hero.GetArmy().GetCountMonsters( Monster::ORC )
+                   + upgradeOgreValue * hero.GetArmy().GetCountMonsters( Monster::OGRE );
         }
         else if ( objectID == MP2::OBJ_TRAVELLERTENT ) {
             // Most likely it'll lead to opening more land.
             return 1000;
         }
-        else if ( objectID == MP2::OBJ_OASIS) {
+        else if ( objectID == MP2::OBJ_OASIS ) {
             return std::max( 800.0 - 2.0 * distance, 0.0 );
         }
-        else if ( objectID == MP2::OBJ_WATERINGHOLE) {
+        else if ( objectID == MP2::OBJ_WATERINGHOLE ) {
             return std::max( 400.0 - 2.0 * distance, 0.0 );
         }
 

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -73,14 +73,14 @@ namespace
             , _ignoreValue( ignoreValue )
         {}
 
-        double value( const std::pair<int, int> & objectInfo )
+        double value( const std::pair<int, int> & objectInfo, const uint32_t distance )
         {
             auto iter = _objectValue.find( objectInfo );
             if ( iter != _objectValue.end() ) {
                 return iter->second;
             }
 
-            const double value = _ai.getObjectValue( _hero, objectInfo.first, objectInfo.second, _ignoreValue );
+            const double value = _ai.getObjectValue( _hero, objectInfo.first, _ignoreValue, distance );
 
             _objectValue[objectInfo] = value;
             return value;
@@ -107,11 +107,12 @@ namespace AI
         return value - ( distance * std::log10( distance ) );
     }
 
-    double Normal::getObjectValue( const Heroes & hero, int index, int objectID, double valueToIgnore ) const
+    double Normal::getObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distance ) const
     {
         // In the future these hardcoded values could be configured by the mod
         // 1 tile distance is 100.0 value approximately
         const Maps::Tiles & tile = world.GetTiles( index );
+        const int objectID = tile.GetObject();
 
         if ( objectID == MP2::OBJ_CASTLE ) {
             const Castle * castle = world.GetCastle( Maps::GetPoint( index ) );
@@ -133,8 +134,10 @@ namespace AI
         }
         else if ( objectID == MP2::OBJ_HEROES ) {
             const Heroes * otherHero = tile.GetHeroes();
-            if ( !otherHero )
+            assert( otherHero );
+            if ( !otherHero ) {
                 return valueToIgnore;
+            }
 
             if ( hero.GetColor() == otherHero->GetColor() ) {
                 if ( hero.getStatsValue() + 2 > otherHero->getStatsValue() )
@@ -197,7 +200,11 @@ namespace AI
                 // Nothing to uncover.
                 return -dangerousTaskPenalty;
             }
-            return fogCountToUncover * 100.0;
+            return fogCountToUncover;
+        }
+        else if ( objectID == MP2::OBJ_MAGELLANMAPS ) {
+            // Very valuable object.
+            return 5000;
         }
         else if ( objectID == MP2::OBJ_COAST ) {
             const RegionStats & regionStats = _regions[tile.GetRegion()];
@@ -249,6 +256,45 @@ namespace AI
                 return 250;
             }
         }
+        else if ( objectID == MP2::OBJ_STABLES ) {
+            const int daysActive = DAYOFWEEK - world.GetDay() + 1;
+            double movementBonus = daysActive * 400.0 - 2.0 * distance;
+            if ( movementBonus < 0 ) {
+                // Looks like this 
+                movementBonus = 0;
+            }
+
+            const double upgradeValue = Monster( Monster::CHAMPION ).GetMonsterStrength() - Monster( Monster::CAVALRY ).GetMonsterStrength();
+            return movementBonus + upgradeValue * hero.GetArmy().GetCountMonsters( Monster::CAVALRY );
+        }
+        else if ( objectID == MP2::OBJ_FREEMANFOUNDRY ) {
+            const double upgradePikemanValue = Monster( Monster::VETERAN_PIKEMAN ).GetMonsterStrength() - Monster( Monster::PIKEMAN ).GetMonsterStrength();
+            const double upgradeSwordsmanValue = Monster( Monster::MASTER_SWORDSMAN ).GetMonsterStrength() - Monster( Monster::SWORDSMAN ).GetMonsterStrength();
+            const double upgradeGolemValue = Monster( Monster::STEEL_GOLEM ).GetMonsterStrength() - Monster( Monster::IRON_GOLEM ).GetMonsterStrength();
+
+            return upgradePikemanValue * hero.GetArmy().GetCountMonsters( Monster::PIKEMAN ) + upgradeSwordsmanValue * hero.GetArmy().GetCountMonsters( Monster::SWORDSMAN ) +
+                upgradeGolemValue * hero.GetArmy().GetCountMonsters( Monster::IRON_GOLEM );
+        }
+        else if ( objectID == MP2::OBJ_HILLFORT ) {
+            const double upgradeDwarfValue = Monster( Monster::BATTLE_DWARF ).GetMonsterStrength() - Monster( Monster::DWARF ).GetMonsterStrength();
+            const double upgradeOrcValue = Monster( Monster::ORC_CHIEF ).GetMonsterStrength() - Monster( Monster::ORC ).GetMonsterStrength();
+            const double upgradeOgreValue = Monster( Monster::OGRE_LORD ).GetMonsterStrength() - Monster( Monster::OGRE ).GetMonsterStrength();
+
+            return upgradeDwarfValue * hero.GetArmy().GetCountMonsters( Monster::DWARF ) + upgradeOrcValue * hero.GetArmy().GetCountMonsters( Monster::ORC ) +
+                upgradeOgreValue * hero.GetArmy().GetCountMonsters( Monster::OGRE );
+        }
+        else if ( objectID == MP2::OBJ_TRAVELLERTENT ) {
+            // Most likely it'll lead to opening more land.
+            return 1000;
+        }
+        else if ( objectID == MP2::OBJ_OASIS) {
+            return std::max( 800.0 - 2.0 * distance, 0.0 );
+        }
+        else if ( objectID == MP2::OBJ_WATERINGHOLE) {
+            return std::max( 400.0 - 2.0 * distance, 0.0 );
+        }
+
+        // TODO: add support for all possible objects.
 
         return 0;
     }
@@ -285,12 +331,17 @@ namespace AI
                 if ( dist == 0 )
                     continue;
 
-                double value = valueStorage.value( node );
+                double value = valueStorage.value( node, dist );
 
                 const std::vector<IndexObject> & list = _pathfinder.getObjectsOnTheWay( node.first );
                 for ( const IndexObject & pair : list ) {
-                    if ( objectValidator.isValid( pair.first ) && std::binary_search( _mapObjects.begin(), _mapObjects.end(), pair ) )
-                        value += valueStorage.value( pair );
+                    if ( objectValidator.isValid( pair.first ) && std::binary_search( _mapObjects.begin(), _mapObjects.end(), pair ) ) {
+                        const double extraValue = valueStorage.value( pair, 0 ); // object is on the way, we don't loose any movement points.
+                        if ( extraValue > 0 ) {
+                            // There is no need to reduce the quality of the object even if the path has others.
+                            value += extraValue;
+                        }
+                    }
                 }
                 const RegionStats & regionStats = _regions[world.GetTiles( node.first ).GetRegion()];
                 if ( heroStrength < regionStats.highestThreat )

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -584,7 +584,7 @@ u32 Heroes::GetMaxMovePoints( void ) const
 
         // visited object
         if ( isObjectTypeVisited( MP2::OBJ_STABLES ) )
-            point += 500;
+            point += 400;
     }
 
     acount = HasArtifact( Artifact::TRUE_COMPASS_MOBILITY );
@@ -721,10 +721,6 @@ void Heroes::ActionNewDay( void )
     move_point = GetMaxMovePoints();
     MovePointsScaleFixed();
 
-    // stables visited?
-    if ( isObjectTypeVisited( MP2::OBJ_STABLES ) )
-        move_point += 400;
-
     // remove day visit object
     visit_object.remove_if( Visit::isDayLife );
 
@@ -832,7 +828,6 @@ Castle * Heroes::inCastle( void )
     return castle && castle->GetHeroes() == this ? castle : NULL;
 }
 
-/* is visited cell */
 bool Heroes::isVisited( const Maps::Tiles & tile, Visit::type_t type ) const
 {
     const int32_t index = tile.GetIndex();
@@ -844,7 +839,6 @@ bool Heroes::isVisited( const Maps::Tiles & tile, Visit::type_t type ) const
     return visit_object.end() != std::find( visit_object.begin(), visit_object.end(), IndexObject( index, object ) );
 }
 
-/* return true if object visited */
 bool Heroes::isObjectTypeVisited( int object, Visit::type_t type ) const
 {
     if ( Visit::GLOBAL == type )
@@ -911,6 +905,19 @@ void Heroes::markHeroMeeting( int heroID )
 {
     if ( heroID < UNKNOWN && !hasMetWithHero( heroID ) )
         visit_object.push_front( IndexObject( heroID, MP2::OBJ_HEROES ) );
+}
+
+void Heroes::unmarkHeroMeeting()
+{
+    const KingdomHeroes & heroes = GetKingdom().GetHeroes();
+    for ( Heroes * hero : heroes ) {
+        if ( hero == nullptr || hero == this ) {
+            continue;
+        }
+
+        hero->visit_object.remove( IndexObject( hid, MP2::OBJ_HEROES ) );
+        visit_object.remove( IndexObject( hero->hid, MP2::OBJ_HEROES ) );
+    }
 }
 
 bool Heroes::hasMetWithHero( int heroID ) const

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -308,8 +308,11 @@ public:
     void SetVisitedWideTile( s32, int object, Visit::type_t = Visit::LOCAL );
     bool isObjectTypeVisited( int object, Visit::type_t = Visit::LOCAL ) const;
     bool isVisited( const Maps::Tiles &, Visit::type_t = Visit::LOCAL ) const;
+
+    // These methods are used only for AI.
     bool hasMetWithHero( int heroID ) const;
     void markHeroMeeting( int heroID );
+    void unmarkHeroMeeting();
 
     bool Move( bool fast = false );
     void Move2Dest( const int32_t destination );

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -380,8 +380,22 @@ int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero )
     for ( size_t lastProcessedNode = 0; lastProcessedNode < nodesToExplore.size(); ++lastProcessedNode ) {
         const int currentNodeIdx = nodesToExplore[lastProcessedNode];
 
-        if ( start != currentNodeIdx && Maps::getFogTileCountToBeRevealed( currentNodeIdx, scouteValue, _currentColor ) > 0 ) {
-            return currentNodeIdx;
+        if ( start != currentNodeIdx ) {
+            int32_t maxTilesToReveal = Maps::getFogTileCountToBeRevealed( currentNodeIdx, scouteValue, _currentColor );
+            if ( maxTilesToReveal > 0 ) {
+                // Found a tile where we can reveal fog. Check for other tiles in the queue to find the one with the highest value.
+                int bestIndex = currentNodeIdx;
+                for ( ; lastProcessedNode < nodesToExplore.size(); ++lastProcessedNode ) {
+                    const int nodeIdx = nodesToExplore[lastProcessedNode];
+                    const int32_t tilesToReveal = Maps::getFogTileCountToBeRevealed( nodeIdx, scouteValue, _currentColor );
+                    if ( maxTilesToReveal < tilesToReveal ) {
+                        maxTilesToReveal = tilesToReveal;
+                        bestIndex = nodeIdx;
+                    }
+                }
+
+                return bestIndex;
+            }
         }
 
         for ( size_t i = 0; i < directions.size(); ++i ) {


### PR DESCRIPTION
- improve fog revealing algorithm for AI
- fix Stables movement bonus
- fix AI heroes interaction between each other (reset meeting flag if a hero updates an army)
- a chance to choose experience from treasure boxes reduced from 50% to 10%
- AI heroes don't visit signs anymore
- AI don't visit shrines for useless spells
- fix some incorrect situations of missing hero meeting or attacking another one
- improve Magellan Maps object value
- improve some other objects values

close #3417
close #3413 
close #3381 