### PR TITLE
Fix WITHOUT_ZLIB build option

### DIFF
--- a/.github/workflows/linux_pull_request.yml
+++ b/.github/workflows/linux_pull_request.yml
@@ -14,6 +14,8 @@ jobs:
           env: { FHEROES2_SDL1: "ON", FHEROES2_STRICT_COMPILATION: "ON" }
         - name: debug
           env: { FHEROES2_SDL1: "ON", FHEROES2_STRICT_COMPILATION: "ON", DEBUG: "ON" }
+        - name: without_zlib
+          env: { FHEROES2_SDL1: "ON", FHEROES2_STRICT_COMPILATION: "ON", WITHOUT_ZLIB: "ON" }
     name: sdl1 ${{ matrix.name }}
     steps:
     - uses: actions/checkout@v2
@@ -35,6 +37,8 @@ jobs:
           env: { FHEROES2_STRICT_COMPILATION: "ON" }
         - name: debug
           env: { FHEROES2_STRICT_COMPILATION: "ON", DEBUG: "ON" }
+        - name: without_zlib
+          env: { FHEROES2_STRICT_COMPILATION: "ON", WITHOUT_ZLIB: "ON" }
     name: sdl2 ${{ matrix.name }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux_pull_request.yml
+++ b/.github/workflows/linux_pull_request.yml
@@ -14,8 +14,6 @@ jobs:
           env: { FHEROES2_SDL1: "ON", FHEROES2_STRICT_COMPILATION: "ON" }
         - name: debug
           env: { FHEROES2_SDL1: "ON", FHEROES2_STRICT_COMPILATION: "ON", DEBUG: "ON" }
-        - name: without_zlib
-          env: { FHEROES2_SDL1: "ON", FHEROES2_STRICT_COMPILATION: "ON", WITHOUT_ZLIB: "ON" }
     name: sdl1 ${{ matrix.name }}
     steps:
     - uses: actions/checkout@v2
@@ -37,8 +35,6 @@ jobs:
           env: { FHEROES2_STRICT_COMPILATION: "ON" }
         - name: debug
           env: { FHEROES2_STRICT_COMPILATION: "ON", DEBUG: "ON" }
-        - name: without_zlib
-          env: { FHEROES2_STRICT_COMPILATION: "ON", WITHOUT_ZLIB: "ON" }
     name: sdl2 ${{ matrix.name }}
     steps:
     - uses: actions/checkout@v2

--- a/src/engine/zzlib.cpp
+++ b/src/engine/zzlib.cpp
@@ -113,12 +113,12 @@ fheroes2::Image CreateImageFromZlib( int32_t width, int32_t height, const uint8_
 
 #endif // WITH_ZLIB
 
-ZStreamFile::ZStreamFile( bool compressed )
+ZStreamFile::ZStreamFile( bool compressIfSupported )
     : StreamBuf()
-    , _compressed( compressed )
+    , _compressIfSupported( compressIfSupported )
 {
 #ifndef WITH_ZLIB
-    (void)_compressed; // Silence the "private field is not used" compiler warning
+    (void)_compressIfSupported; // Silence the "private field is not used" compiler warning
 #endif
 }
 
@@ -131,7 +131,7 @@ bool ZStreamFile::read( const std::string & fn, size_t offset /* = 0 */ )
         if ( offset )
             sf.seek( offset );
 #ifdef WITH_ZLIB
-        if ( _compressed ) {
+        if ( _compressIfSupported ) {
             const u32 size0 = sf.get32(); // raw size
             if ( size0 == 0 ) {
                 return false;
@@ -170,7 +170,7 @@ bool ZStreamFile::write( const std::string & fn, bool append /* = false */ ) con
 
     if ( sf.open( fn, append ? "ab" : "wb" ) ) {
 #ifdef WITH_ZLIB
-        if ( _compressed ) {
+        if ( _compressIfSupported ) {
             std::vector<u8> zip = zlibCompress( data(), size() );
 
             if ( !zip.empty() ) {

--- a/src/engine/zzlib.cpp
+++ b/src/engine/zzlib.cpp
@@ -20,15 +20,18 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifdef WITH_ZLIB
 #include <cstring>
 #include <sstream>
+
+#ifdef WITH_ZLIB
 #include <zlib.h>
+#endif
 
 #include "logging.h"
 #include "zzlib.h"
 
-std::vector<u8> zlibDecompress( const u8 * src, size_t srcsz, size_t realsz )
+#ifdef WITH_ZLIB
+std::vector<u8> zlibDecompress( const u8 * src, size_t srcsz, size_t realsz /* = 0 */ )
 {
     std::vector<u8> res;
 
@@ -79,6 +82,7 @@ std::vector<u8> zlibCompress( const u8 * src, size_t srcsz )
 
     return res;
 }
+#endif
 
 bool ZStreamFile::read( const std::string & fn, size_t offset )
 {
@@ -108,7 +112,7 @@ bool ZStreamFile::read( const std::string & fn, size_t offset )
             return false;
         }
         std::vector<u8> raw = sf.getRaw( size0 );
-        putRaw( &raw[0], raw.size() );
+        putRaw( reinterpret_cast<char *>( &raw[0] ), raw.size() );
         seek( 0 );
 #endif
         return !fail();
@@ -134,13 +138,14 @@ bool ZStreamFile::write( const std::string & fn, bool append ) const
         }
 #else
         sf.put32( size() );
-        sf.putRaw( data(), size() );
+        sf.putRaw( reinterpret_cast<const char *>( data() ), size() );
         return !sf.fail();
 #endif
     }
     return false;
 }
 
+#ifdef WITH_ZLIB
 fheroes2::Image CreateImageFromZlib( int32_t width, int32_t height, const uint8_t * imageData, size_t imageSize, bool doubleLayer )
 {
     if ( imageData == NULL || imageSize == 0 || width <= 0 || height <= 0 )
@@ -167,5 +172,4 @@ fheroes2::Image CreateImageFromZlib( int32_t width, int32_t height, const uint8_
     }
     return out;
 }
-
 #endif

--- a/src/engine/zzlib.cpp
+++ b/src/engine/zzlib.cpp
@@ -183,7 +183,7 @@ bool ZStreamFile::write( const std::string & fn, bool append /* = false */ ) con
         }
         else {
 #endif
-            sf.put32( size() );
+            sf.put32( static_cast<uint32_t>( size() ) );
             sf.putRaw( reinterpret_cast<const char *>( data() ), size() );
             return !sf.fail();
 #ifdef WITH_ZLIB

--- a/src/engine/zzlib.h
+++ b/src/engine/zzlib.h
@@ -33,6 +33,8 @@
 #ifdef WITH_ZLIB
 std::vector<u8> zlibCompress( const u8 *, size_t srcsz );
 std::vector<u8> zlibDecompress( const u8 *, size_t srcsz, size_t realsz = 0 );
+
+fheroes2::Image CreateImageFromZlib( int32_t width, int32_t height, const uint8_t * imageData, size_t imageSize, bool doubleLayer );
 #endif
 
 class ZStreamFile : public StreamBuf
@@ -43,9 +45,5 @@ public:
     bool read( const std::string &, size_t offset = 0 );
     bool write( const std::string &, bool append = false ) const;
 };
-
-#ifdef WITH_ZLIB
-fheroes2::Image CreateImageFromZlib( int32_t width, int32_t height, const uint8_t * imageData, size_t imageSize, bool doubleLayer );
-#endif
 
 #endif

--- a/src/engine/zzlib.h
+++ b/src/engine/zzlib.h
@@ -40,10 +40,13 @@ fheroes2::Image CreateImageFromZlib( int32_t width, int32_t height, const uint8_
 class ZStreamFile : public StreamBuf
 {
 public:
-    ZStreamFile() = default;
+    ZStreamFile( bool compressed );
 
     bool read( const std::string &, size_t offset = 0 );
     bool write( const std::string &, bool append = false ) const;
+
+private:
+    bool _compressed;
 };
 
 #endif

--- a/src/engine/zzlib.h
+++ b/src/engine/zzlib.h
@@ -23,8 +23,6 @@
 #ifndef H2ZLIB_H
 #define H2ZLIB_H
 
-#ifdef WITH_ZLIB
-
 #include <iostream>
 #include <vector>
 
@@ -32,9 +30,9 @@
 #include "serialize.h"
 #include "types.h"
 
+#ifdef WITH_ZLIB
 std::vector<u8> zlibCompress( const u8 *, size_t srcsz );
 std::vector<u8> zlibDecompress( const u8 *, size_t srcsz, size_t realsz = 0 );
-
 #endif
 
 class ZStreamFile : public StreamBuf
@@ -46,12 +44,8 @@ public:
     bool write( const std::string &, bool append = false ) const;
 };
 
+#ifdef WITH_ZLIB
 fheroes2::Image CreateImageFromZlib( int32_t width, int32_t height, const uint8_t * imageData, size_t imageSize, bool doubleLayer );
-
-class ImageZlib : public fheroes2::Image
-{
-    ImageZlib( int32_t width, int32_t height, const uint8_t * data, size_t size );
-    ~ImageZlib() override = default;
-};
+#endif
 
 #endif

--- a/src/engine/zzlib.h
+++ b/src/engine/zzlib.h
@@ -40,13 +40,13 @@ fheroes2::Image CreateImageFromZlib( int32_t width, int32_t height, const uint8_
 class ZStreamFile : public StreamBuf
 {
 public:
-    ZStreamFile( bool compressed );
+    ZStreamFile( const bool compressIfSupported );
 
     bool read( const std::string &, size_t offset = 0 );
     bool write( const std::string &, bool append = false ) const;
 
 private:
-    bool _compressed;
+    const bool _compressIfSupported;
 };
 
 #endif

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -100,7 +100,7 @@ private:
 
 bool HGSData::Load( const std::string & fn )
 {
-    ZStreamFile hdata;
+    ZStreamFile hdata( true );
     if ( !hdata.read( fn ) )
         return false;
 
@@ -119,7 +119,7 @@ bool HGSData::Load( const std::string & fn )
 
 bool HGSData::Save( const std::string & fn ) const
 {
-    ZStreamFile hdata;
+    ZStreamFile hdata( true );
     hdata.setbigendian( true );
     hdata << static_cast<u16>( HGS_ID ) << list;
     if ( hdata.fail() || !hdata.write( fn ) )

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -136,7 +136,7 @@ bool Game::Save( const std::string & fn )
        << HeaderSAV( conf.CurrentFileInfo(), conf.GameType(), CURRENT_FORMAT_VERSION );
     fs.close();
 
-    ZStreamFile fz;
+    ZStreamFile fz( true );
     fz.setbigendian( true );
 
     // zip game data content
@@ -206,7 +206,7 @@ fheroes2::GameMode Game::Load( const std::string & fn )
     }
 #endif
 
-    ZStreamFile fz;
+    ZStreamFile fz( ( header.status & HeaderSAV::IS_COMPRESS ) == HeaderSAV::IS_COMPRESS );
     fz.setbigendian( true );
 
     if ( !fz.read( fn, offset ) ) {


### PR DESCRIPTION
fix #3691

Unfortunately, currently there is no proper header in HGSData, so we still not able to load uncompressed highscores on WITH_ZLIB builds.