### PR TITLE
code cleanup: Don't use else after return

### DIFF
--- a/src/engine/logging.cpp
+++ b/src/engine/logging.cpp
@@ -36,17 +36,17 @@ namespace Logging
     {
         if ( name & DBG_ENGINE )
             return "DBG_ENGINE";
-        else if ( name & DBG_GAME )
+        if ( name & DBG_GAME )
             return "DBG_GAME";
-        else if ( name & DBG_BATTLE )
+        if ( name & DBG_BATTLE )
             return "DBG_BATTLE";
-        else if ( name & DBG_AI )
+        if ( name & DBG_AI )
             return "DBG_AI";
-        else if ( name & DBG_NETWORK )
+        if ( name & DBG_NETWORK )
             return "DBG_NETWORK";
-        else if ( name & DBG_OTHER )
+        if ( name & DBG_OTHER )
             return "DBG_OTHER";
-        else if ( name & DBG_DEVEL )
+        if ( name & DBG_DEVEL )
             return "DBG_DEVEL";
 
         return "";

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -367,8 +367,8 @@ namespace
         {
             if ( _emulation )
                 return fheroes2::Cursor::isVisible();
-            else
-                return fheroes2::Cursor::isVisible() && ( SDL_ShowCursor( SDL_QUERY ) == SDL_ENABLE );
+
+            return fheroes2::Cursor::isVisible() && ( SDL_ShowCursor( SDL_QUERY ) == SDL_ENABLE );
         }
 
         void update( const fheroes2::Image & image, int32_t offsetX, int32_t offsetY ) override

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -365,10 +365,7 @@ namespace
 
         bool isVisible() const override
         {
-            if ( _emulation )
-                return fheroes2::Cursor::isVisible();
-
-            return fheroes2::Cursor::isVisible() && ( SDL_ShowCursor( SDL_QUERY ) == SDL_ENABLE );
+            return fheroes2::Cursor::isVisible() && ( _emulation || ( SDL_ShowCursor( SDL_QUERY ) == SDL_ENABLE ) );
         }
 
         void update( const fheroes2::Image & image, int32_t offsetX, int32_t offsetY ) override

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -402,8 +402,8 @@ u8 StreamBuf::get8()
 {
     if ( sizeg() )
         return *itget++;
-    else
-        return 0u;
+
+    return 0u;
 }
 
 u16 StreamBuf::getBE16()

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -400,10 +400,7 @@ void StreamBuf::put8( char v )
 
 u8 StreamBuf::get8()
 {
-    if ( sizeg() )
-        return *itget++;
-
-    return 0u;
+    return sizeg() ? *itget++ : 0u;
 }
 
 u16 StreamBuf::getBE16()

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -117,32 +117,29 @@ struct mofile
 
         if ( !sf.open( file, "rb" ) )
             return false;
-        else {
-            size_t size = sf.size();
-            u32 id = 0;
-            sf >> id;
 
-            if ( 0x950412de != id ) {
-                ERROR_LOG( "incorrect mo id: " << GetHexString( id ) );
-                return false;
-            }
-            else {
-                u16 major, minor;
-                sf >> major >> minor;
+        size_t size = sf.size();
+        u32 id = 0;
+        sf >> id;
 
-                if ( 0 != major ) {
-                    ERROR_LOG( "incorrect major version: " << GetHexString( major, 4 ) );
-                    return false;
-                }
-                else {
-                    sf >> count >> offset_strings1 >> offset_strings2 >> hash_size >> hash_offset;
-
-                    sf.seek( 0 );
-                    buf = sf.toStreamBuf( size );
-                    sf.close();
-                }
-            }
+        if ( 0x950412de != id ) {
+            ERROR_LOG( "incorrect mo id: " << GetHexString( id ) );
+            return false;
         }
+
+        u16 major, minor;
+        sf >> major >> minor;
+
+        if ( 0 != major ) {
+            ERROR_LOG( "incorrect major version: " << GetHexString( major, 4 ) );
+            return false;
+        }
+
+        sf >> count >> offset_strings1 >> offset_strings2 >> hash_size >> hash_offset;
+
+        sf.seek( 0 );
+        buf = sf.toStreamBuf( size );
+        sf.close();
 
         // parse encoding and plural forms
         if ( count ) {

--- a/src/engine/xmi2mid.cpp
+++ b/src/engine/xmi2mid.cpp
@@ -365,57 +365,57 @@ struct MidiEvents : std::vector<MidiChunk>
                     // stop parsing
                     break;
                 }
-                else
-                    switch ( *ptr >> 4 ) {
-                    // metadata
-                    case 0x0F: {
-                        ptr++; // skip 0xFF
-                        const uint8_t metaType = *( ptr++ );
-                        const uint8_t metaLength = *( ptr++ );
-                        emplace_back( delta, 0xFF, metaType, ptr, metaLength );
-                        // Tempo switch
-                        if ( metaType == 0x51 && metaLength == 3 ) {
-                            // 24bit big endian
-                            trackTempo = ( ( ( *ptr << 8 ) | *( ptr + 1 ) ) << 8 ) | *( ptr + 2 );
-                        }
-                        ptr += metaLength;
-                    } break;
 
-                    // key pressure
-                    case 0x0A:
-                    // control change
-                    case 0x0B:
-                    // pitch bend
-                    case 0x0E: {
-                        emplace_back( delta, *ptr, *( ptr + 1 ), *( ptr + 2 ) );
-                        ptr += 3;
-                    } break;
-
-                    // XMI events doesn't have note off events
-                    // note on
-                    case 0x09: {
-                        emplace_back( delta, *ptr, *( ptr + 1 ), *( ptr + 2 ) );
-                        const XMI_Time duration = readXMITime( ptr + 3 );
-                        // note off
-                        emplace_back( delta + duration.first, *ptr - 0x10, *( ptr + 1 ), 0x7F );
-                        ptr += 3 + duration.second;
-                    } break;
-
-                    // program change
-                    case 0x0C:
-                    // channel aftertouch
-                    case 0x0D: {
-                        emplace_back( delta, *ptr, *( ptr + 1 ) );
-                        ptr += 2;
-                    } break;
-
-                    // unused command
-                    default:
-                        emplace_back( 0, 0xFF, 0x2F, 0 );
-                        ERROR_LOG( "unknown st: 0x" << std::setw( 2 ) << std::setfill( '0' ) << std::hex << static_cast<int>( *ptr )
-                                                    << ", ln: " << static_cast<int>( &t.evnt[0] + t.evnt.size() - ptr ) );
-                        break;
+                switch ( *ptr >> 4 ) {
+                // metadata
+                case 0x0F: {
+                    ptr++; // skip 0xFF
+                    const uint8_t metaType = *( ptr++ );
+                    const uint8_t metaLength = *( ptr++ );
+                    emplace_back( delta, 0xFF, metaType, ptr, metaLength );
+                    // Tempo switch
+                    if ( metaType == 0x51 && metaLength == 3 ) {
+                        // 24bit big endian
+                        trackTempo = ( ( ( *ptr << 8 ) | *( ptr + 1 ) ) << 8 ) | *( ptr + 2 );
                     }
+                    ptr += metaLength;
+                } break;
+
+                // key pressure
+                case 0x0A:
+                // control change
+                case 0x0B:
+                // pitch bend
+                case 0x0E: {
+                    emplace_back( delta, *ptr, *( ptr + 1 ), *( ptr + 2 ) );
+                    ptr += 3;
+                } break;
+
+                // XMI events doesn't have note off events
+                // note on
+                case 0x09: {
+                    emplace_back( delta, *ptr, *( ptr + 1 ), *( ptr + 2 ) );
+                    const XMI_Time duration = readXMITime( ptr + 3 );
+                    // note off
+                    emplace_back( delta + duration.first, *ptr - 0x10, *( ptr + 1 ), 0x7F );
+                    ptr += 3 + duration.second;
+                } break;
+
+                // program change
+                case 0x0C:
+                // channel aftertouch
+                case 0x0D: {
+                    emplace_back( delta, *ptr, *( ptr + 1 ) );
+                    ptr += 2;
+                } break;
+
+                // unused command
+                default:
+                    emplace_back( 0, 0xFF, 0x2F, 0 );
+                    ERROR_LOG( "unknown st: 0x" << std::setw( 2 ) << std::setfill( '0' ) << std::hex << static_cast<int>( *ptr )
+                                                << ", ln: " << static_cast<int>( &t.evnt[0] + t.evnt.size() - ptr ) );
+                    break;
+                }
             }
         }
 

--- a/src/fheroes2/agg/bin_info.cpp
+++ b/src/fheroes2/agg/bin_info.cpp
@@ -309,16 +309,14 @@ namespace Bin_Info
         if ( mapIterator != _animMap.end() ) {
             return mapIterator->second;
         }
-        else {
-            const MonsterAnimInfo info( monsterID, AGG::LoadBINFRM( Bin_Info::GetFilename( monsterID ) ) );
-            if ( info.isValid() ) {
-                _animMap[monsterID] = info;
-                return info;
-            }
-            else {
-                DEBUG_LOG( DBG_ENGINE, DBG_WARN, "missing BIN FRM data: " << Bin_Info::GetFilename( monsterID ) << ", index: " << monsterID );
-            }
+
+        const MonsterAnimInfo info( monsterID, AGG::LoadBINFRM( Bin_Info::GetFilename( monsterID ) ) );
+        if ( info.isValid() ) {
+            _animMap[monsterID] = info;
+            return info;
         }
+
+        DEBUG_LOG( DBG_ENGINE, DBG_WARN, "missing BIN FRM data: " << Bin_Info::GetFilename( monsterID ) << ", index: " << monsterID );
         return MonsterAnimInfo();
     }
 

--- a/src/fheroes2/battle/battle_animation.cpp
+++ b/src/fheroes2/battle/battle_animation.cpp
@@ -422,9 +422,8 @@ bool AnimationState::switchAnimation( int animState, bool reverse )
         _currentSequence.restartAnimation();
         return true;
     }
-    else {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, " AnimationState switched to invalid anim " << animState << " length " << _currentSequence.animationLength() );
-    }
+
+    DEBUG_LOG( DBG_GAME, DBG_WARN, " AnimationState switched to invalid anim " << animState << " length " << _currentSequence.animationLength() );
     return false;
 }
 
@@ -448,9 +447,8 @@ bool AnimationState::switchAnimation( const std::vector<int> & animationList, bo
         _currentSequence.restartAnimation();
         return true;
     }
-    else {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, " AnimationState switched to invalid anim list of length " << animationList.size() );
-    }
+
+    DEBUG_LOG( DBG_GAME, DBG_WARN, " AnimationState switched to invalid anim list of length " << animationList.size() );
     return false;
 }
 

--- a/src/fheroes2/battle/battle_cell.cpp
+++ b/src/fheroes2/battle/battle_cell.cpp
@@ -230,6 +230,12 @@ void Battle::Cell::SetUnit( Unit * val )
     troop = val;
 }
 
+bool Battle::Cell::isPassable( const Unit & b, int dir ) const
+{
+    const Cell * cell = Board::GetCell( index, dir );
+    return cell && ( cell->isPassable1( true ) || cell->index == b.GetTailIndex() || cell->index == b.GetHeadIndex() );
+}
+
 bool Battle::Cell::isPassable4( const Unit & b, const Cell & from ) const
 {
     if ( b.isWide() ) {
@@ -262,20 +268,18 @@ bool Battle::Cell::isPassable3( const Unit & b, bool check_reflect ) const
     if ( index == b.GetHeadIndex() || index == b.GetTailIndex() )
         return true;
 
-    if ( b.isWide() ) {
-        if ( check_reflect ) {
-            const Cell * cell = Board::GetCell( index, b.isReflect() ? RIGHT : LEFT );
-            return cell && ( cell->isPassable1( true ) || cell->index == b.GetTailIndex() || cell->index == b.GetHeadIndex() ) && isPassable1( true );
-        }
+    if ( !b.isWide() )
+        return isPassable1( true );
 
-        const Cell * left = Board::GetCell( index, LEFT );
-        const Cell * right = Board::GetCell( index, RIGHT );
-        return ( ( left && ( left->isPassable1( true ) || left->index == b.GetTailIndex() || left->index == b.GetHeadIndex() ) )
-                 || ( right && ( right->isPassable1( true ) || right->index == b.GetTailIndex() || right->index == b.GetHeadIndex() ) ) )
-               && isPassable1( true );
+    bool passableWide;
+    if ( check_reflect ) {
+        passableWide = isPassable( b, b.isReflect() ? RIGHT : LEFT );
+    }
+    else {
+        passableWide = isPassable( b, LEFT ) || isPassable( b, RIGHT );
     }
 
-    return isPassable1( true );
+    return passableWide && isPassable1( true );
 }
 
 bool Battle::Cell::isPassable1( bool check_troop ) const

--- a/src/fheroes2/battle/battle_cell.cpp
+++ b/src/fheroes2/battle/battle_cell.cpp
@@ -154,17 +154,17 @@ Battle::direction_t Battle::Cell::GetTriangleDirection( const fheroes2::Point & 
 
     if ( pt == coord[0] )
         return CENTER;
-    else if ( inABC( pt, coord[0], coord[1], coord[2] ) )
+    if ( inABC( pt, coord[0], coord[1], coord[2] ) )
         return TOP_LEFT;
-    else if ( inABC( pt, coord[0], coord[2], coord[3] ) )
+    if ( inABC( pt, coord[0], coord[2], coord[3] ) )
         return TOP_RIGHT;
-    else if ( inABC( pt, coord[0], coord[3], coord[4] ) )
+    if ( inABC( pt, coord[0], coord[3], coord[4] ) )
         return RIGHT;
-    else if ( inABC( pt, coord[0], coord[4], coord[5] ) )
+    if ( inABC( pt, coord[0], coord[4], coord[5] ) )
         return BOTTOM_RIGHT;
-    else if ( inABC( pt, coord[0], coord[5], coord[6] ) )
+    if ( inABC( pt, coord[0], coord[5], coord[6] ) )
         return BOTTOM_LEFT;
-    else if ( inABC( pt, coord[0], coord[1], coord[6] ) )
+    if ( inABC( pt, coord[0], coord[1], coord[6] ) )
         return LEFT;
 
     return UNKNOWN;
@@ -267,13 +267,12 @@ bool Battle::Cell::isPassable3( const Unit & b, bool check_reflect ) const
             const Cell * cell = Board::GetCell( index, b.isReflect() ? RIGHT : LEFT );
             return cell && ( cell->isPassable1( true ) || cell->index == b.GetTailIndex() || cell->index == b.GetHeadIndex() ) && isPassable1( true );
         }
-        else {
-            const Cell * left = Board::GetCell( index, LEFT );
-            const Cell * right = Board::GetCell( index, RIGHT );
-            return ( ( left && ( left->isPassable1( true ) || left->index == b.GetTailIndex() || left->index == b.GetHeadIndex() ) )
-                     || ( right && ( right->isPassable1( true ) || right->index == b.GetTailIndex() || right->index == b.GetHeadIndex() ) ) )
-                   && isPassable1( true );
-        }
+
+        const Cell * left = Board::GetCell( index, LEFT );
+        const Cell * right = Board::GetCell( index, RIGHT );
+        return ( ( left && ( left->isPassable1( true ) || left->index == b.GetTailIndex() || left->index == b.GetHeadIndex() ) )
+                 || ( right && ( right->isPassable1( true ) || right->index == b.GetTailIndex() || right->index == b.GetHeadIndex() ) ) )
+               && isPassable1( true );
     }
 
     return isPassable1( true );

--- a/src/fheroes2/battle/battle_cell.h
+++ b/src/fheroes2/battle/battle_cell.h
@@ -79,6 +79,8 @@ namespace Battle
         void SetUnit( Unit * );
 
     private:
+        bool isPassable( const Unit & b, int direction ) const;
+
         s32 index;
         fheroes2::Rect pos;
         int object;

--- a/src/fheroes2/gui/text.cpp
+++ b/src/fheroes2/gui/text.cpp
@@ -40,6 +40,16 @@ namespace
     {
         return font == Font::WHITE_LARGE;
     }
+
+    int getFontWidth( int font )
+    {
+        if ( isSmallFont( font ) )
+            return 4;
+        if ( isLargeFont( font ) )
+            return 12;
+
+        return 6;
+    }
 }
 
 TextInterface::TextInterface( int ft )
@@ -73,16 +83,10 @@ size_t TextAscii::Size( void ) const
 
 int TextAscii::CharWidth( const uint8_t character, const int ft )
 {
-    if ( character < 0x21 || character > fheroes2::AGG::ASCIILastSupportedCharacter( ft ) ) {
-        if ( isSmallFont( ft ) )
-            return 4;
-        if ( isLargeFont( ft ) )
-            return 12;
+    if ( 0x21 <= character && character <= fheroes2::AGG::ASCIILastSupportedCharacter( ft ) )
+        return fheroes2::AGG::GetLetter( character, ft ).width();
 
-        return 6;
-    }
-
-    return fheroes2::AGG::GetLetter( character, ft ).width();
+    return getFontWidth( ft );
 }
 
 int TextAscii::FontHeight( const int f )
@@ -253,15 +257,10 @@ size_t TextUnicode::Size( void ) const
 
 int TextUnicode::CharWidth( int c, int f )
 {
-    if ( c < 0x0021 ) {
-        if ( isSmallFont( f ) )
-            return 4;
-        if ( isLargeFont( f ) )
-            return 12;
-        return 6;
-    }
+    if ( c >= 0x0021 )
+        return fheroes2::AGG::GetUnicodeLetter( c, f ).width();
 
-    return fheroes2::AGG::GetUnicodeLetter( c, f ).width();
+    return getFontWidth( f );
 }
 
 int TextUnicode::CharHeight( int f )

--- a/src/fheroes2/gui/text.cpp
+++ b/src/fheroes2/gui/text.cpp
@@ -76,24 +76,23 @@ int TextAscii::CharWidth( const uint8_t character, const int ft )
     if ( character < 0x21 || character > fheroes2::AGG::ASCIILastSupportedCharacter( ft ) ) {
         if ( isSmallFont( ft ) )
             return 4;
-        else if ( isLargeFont( ft ) )
+        if ( isLargeFont( ft ) )
             return 12;
-        else
-            return 6;
+
+        return 6;
     }
-    else {
-        return fheroes2::AGG::GetLetter( character, ft ).width();
-    }
+
+    return fheroes2::AGG::GetLetter( character, ft ).width();
 }
 
 int TextAscii::FontHeight( const int f )
 {
     if ( isSmallFont( f ) )
         return 8 + 2 + 1;
-    else if ( isLargeFont( f ) )
+    if ( isLargeFont( f ) )
         return 26 + 6 + 1;
-    else
-        return 13 + 3 + 1;
+
+    return 13 + 3 + 1;
 }
 
 int TextAscii::w( size_t s, size_t c ) const
@@ -257,14 +256,12 @@ int TextUnicode::CharWidth( int c, int f )
     if ( c < 0x0021 ) {
         if ( isSmallFont( f ) )
             return 4;
-        else if ( isLargeFont( f ) )
+        if ( isLargeFont( f ) )
             return 12;
-        else
-            return 6;
+        return 6;
     }
-    else {
-        return fheroes2::AGG::GetUnicodeLetter( c, f ).width();
-    }
+
+    return fheroes2::AGG::GetUnicodeLetter( c, f ).width();
 }
 
 int TextUnicode::CharHeight( int f )
@@ -305,7 +302,7 @@ int TextUnicode::h( int width ) const
 {
     if ( message.empty() )
         return 0;
-    else if ( 0 == width || w() <= width )
+    if ( 0 == width || w() <= width )
         return CharHeight( font );
 
     int res = 0;
@@ -485,7 +482,6 @@ u32 Text::width( const std::string & str, int ft, u32 start, u32 count )
             TextUnicode text( str, ft );
             return text.w( start, count );
         }
-        else
 #endif
         {
             TextAscii text( str, ft );
@@ -503,7 +499,6 @@ u32 Text::height( const std::string & str, int ft, u32 width )
             TextUnicode text( str, ft );
             return text.h( width );
         }
-        else
 #endif
         {
             TextAscii text( str, ft );

--- a/src/fheroes2/objects/mounts.cpp
+++ b/src/fheroes2/objects/mounts.cpp
@@ -38,9 +38,9 @@ int ObjMnts1::GetPassable( int icn, u32 index )
 
     if ( isShadow( index ) )
         return DIRECTION_ALL;
-    else
-        // fix: disable passable: invalid top sprite
-        if ( icn == ICN::MTNGRAS && ( 25 == index || 43 == index || 44 == index || 53 == index || 54 == index || 78 == index ) )
+
+    // fix: disable passable: invalid top sprite
+    if ( icn == ICN::MTNGRAS && ( 25 == index || 43 == index || 44 == index || 53 == index || 54 == index || 78 == index ) )
         return 0;
 
     return std::end( disabled2 ) != std::find( disabled2, std::end( disabled2 ), index ) ? 0 : DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW;

--- a/src/fheroes2/objects/objcrck.cpp
+++ b/src/fheroes2/objects/objcrck.cpp
@@ -35,9 +35,9 @@ int ObjCrck::GetPassable( u32 index )
 
     if ( isShadow( index ) )
         return DIRECTION_ALL;
-    else if ( 184 == index )
+    if ( 184 == index )
         return Direction::CENTER | Direction::BOTTOM_RIGHT | DIRECTION_TOP_ROW;
-    else if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
+    if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
         return 0;
 
     return std::end( restricted ) != std::find( restricted, std::end( restricted ), index ) ? DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW : DIRECTION_ALL;

--- a/src/fheroes2/objects/objdirt.cpp
+++ b/src/fheroes2/objects/objdirt.cpp
@@ -35,7 +35,7 @@ int ObjDirt::GetPassable( u32 index )
 
     if ( isShadow( index ) )
         return DIRECTION_ALL;
-    else if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
+    if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
         return 0;
 
     return std::end( restricted ) != std::find( restricted, std::end( restricted ), index ) ? DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW : DIRECTION_ALL;

--- a/src/fheroes2/objects/objdsrt.cpp
+++ b/src/fheroes2/objects/objdsrt.cpp
@@ -35,7 +35,7 @@ int ObjDsrt::GetPassable( u32 index )
 
     if ( isShadow( index ) )
         return DIRECTION_ALL;
-    else if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
+    if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
         return 0;
 
     return std::end( restricted ) != std::find( restricted, std::end( restricted ), index ) ? DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW : DIRECTION_ALL;

--- a/src/fheroes2/objects/objgras.cpp
+++ b/src/fheroes2/objects/objgras.cpp
@@ -38,7 +38,7 @@ int ObjGras::GetPassable( u32 index )
 
     if ( isShadow( index ) )
         return DIRECTION_ALL;
-    else if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
+    if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
         return 0;
 
     return std::end( restricted ) != std::find( restricted, std::end( restricted ), index ) ? DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW : DIRECTION_ALL;
@@ -60,7 +60,7 @@ int ObjGra2::GetPassable( u32 index )
     const u8 restricted[] = {2, 3, 6, 8, 22, 59};
     if ( isShadow( index ) )
         return DIRECTION_ALL;
-    else if ( isAction( index ) )
+    if ( isAction( index ) )
         return 0;
 
     return std::end( restricted ) != std::find( restricted, std::end( restricted ), index ) ? DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW : DIRECTION_ALL;

--- a/src/fheroes2/objects/objlava.cpp
+++ b/src/fheroes2/objects/objlava.cpp
@@ -31,7 +31,7 @@ int ObjLav2::GetPassable( u32 index )
 {
     if ( isShadow( index ) )
         return DIRECTION_ALL;
-    else if ( isAction( index ) )
+    if ( isAction( index ) )
         return 0;
 
     return DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW;
@@ -52,7 +52,7 @@ int ObjLav3::GetPassable( u32 index )
 {
     if ( isShadow( index ) )
         return DIRECTION_ALL;
-    else if ( isAction( index ) )
+    if ( isAction( index ) )
         return 0;
 
     return DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW;

--- a/src/fheroes2/objects/objmult.cpp
+++ b/src/fheroes2/objects/objmult.cpp
@@ -33,7 +33,7 @@ int ObjMult::GetPassable( u32 index )
 
     if ( isShadow( index ) )
         return DIRECTION_ALL;
-    else if ( isAction( index ) )
+    if ( isAction( index ) )
         return 0;
 
     return std::end( restricted ) != std::find( restricted, std::end( restricted ), index ) ? DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW : DIRECTION_ALL;
@@ -58,7 +58,7 @@ int ObjMul2::GetPassable( u32 index )
 
     if ( isShadow( index ) )
         return DIRECTION_ALL;
-    else if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
+    if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
         return 0;
 
     return std::end( restricted ) != std::find( restricted, std::end( restricted ), index ) ? DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW : DIRECTION_ALL;

--- a/src/fheroes2/objects/objsnow.cpp
+++ b/src/fheroes2/objects/objsnow.cpp
@@ -35,7 +35,7 @@ int ObjSnow::GetPassable( u32 index )
 
     if ( isShadow( index ) )
         return DIRECTION_ALL;
-    else if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
+    if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
         return 0;
 
     return std::end( restricted ) != std::find( restricted, std::end( restricted ), index ) ? DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW : DIRECTION_ALL;

--- a/src/fheroes2/objects/objswmp.cpp
+++ b/src/fheroes2/objects/objswmp.cpp
@@ -36,7 +36,7 @@ int ObjSwmp::GetPassable( u32 index )
 
     if ( isShadow( index ) )
         return DIRECTION_ALL;
-    else if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
+    if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
         return 0;
 
     return std::end( restricted ) != std::find( restricted, std::end( restricted ), index ) ? DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW : DIRECTION_ALL;

--- a/src/fheroes2/objects/objtown.cpp
+++ b/src/fheroes2/objects/objtown.cpp
@@ -52,8 +52,9 @@ int ObjTwba::GetPassable( u32 index0 )
         return 0;
     }
 
-    // 7, 17, 27, 37, 47, 57, 67, 77
     int result = DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW;
+
+    // 7, 17, 27, 37, 47, 57, 67, 77
     if ( index == 7 )
         result |= Direction::TOP;
 

--- a/src/fheroes2/objects/objtown.cpp
+++ b/src/fheroes2/objects/objtown.cpp
@@ -32,9 +32,9 @@ int ObjTown::GetPassable( u32 index0 )
     // 13, 29, 45, 61, 77, 93, 109, 125, 141, 157, 173, 189
     if ( 13 == index || 29 == index )
         return Direction::CENTER | Direction::BOTTOM;
-    else
-        // town/castle
-        if ( ( 5 < index && index < 13 ) || ( 13 < index && index < 16 ) || ( 21 < index && index < 29 ) || ( 29 < index ) )
+
+    // town/castle
+    if ( ( 5 < index && index < 13 ) || ( 13 < index && index < 16 ) || ( 21 < index && index < 29 ) || ( 29 < index ) )
         return 0;
 
     return DIRECTION_ALL;
@@ -48,16 +48,16 @@ int ObjTwba::GetPassable( u32 index0 )
     if ( index == 2 ) {
         return Direction::CENTER | Direction::BOTTOM;
     }
-    else if ( index < 5 ) {
+    if ( index < 5 ) {
         return 0;
     }
-    else {
-        // 7, 17, 27, 37, 47, 57, 67, 77
-        if ( index == 7 )
-            return DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW | Direction::TOP;
-        else
-            return DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW;
-    }
+
+    // 7, 17, 27, 37, 47, 57, 67, 77
+    int result = DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW;
+    if ( index == 7 )
+        result |= Direction::TOP;
+
+    return result;
 }
 
 bool ObjTown::isAction( u32 index )

--- a/src/fheroes2/objects/objwatr.cpp
+++ b/src/fheroes2/objects/objwatr.cpp
@@ -34,11 +34,11 @@ int ObjWat2::GetPassable( u32 index )
 
     if ( isShadow( index ) )
         return DIRECTION_ALL;
-    else if ( 10 == index )
+    if ( 10 == index )
         return Direction::CENTER | Direction::TOP | Direction::LEFT | Direction::TOP_LEFT;
-    else if ( 22 == index )
+    if ( 22 == index )
         return DIRECTION_CENTER_ROW | Direction::BOTTOM | Direction::BOTTOM_LEFT;
-    else if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
+    if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
         return 0;
 
     return std::end( restricted ) != std::find( restricted, std::end( restricted ), index ) ? DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW : DIRECTION_ALL;
@@ -51,7 +51,7 @@ int ObjWatr::GetPassable( u32 index )
 
     if ( isShadow( index ) )
         return DIRECTION_ALL;
-    else if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
+    if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
         return 0;
 
     return std::end( restricted ) != std::find( restricted, std::end( restricted ), index ) ? DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW : DIRECTION_ALL;

--- a/src/fheroes2/objects/objxloc.cpp
+++ b/src/fheroes2/objects/objxloc.cpp
@@ -33,7 +33,7 @@ int ObjXlc1::GetPassable( u32 index )
 
     if ( isShadow( index ) )
         return DIRECTION_ALL;
-    else if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
+    if ( isAction( index ) || std::end( disabled ) != std::find( disabled, std::end( disabled ), index ) )
         return 0;
 
     return std::end( restricted ) != std::find( restricted, std::end( restricted ), index ) ? DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW : DIRECTION_ALL;
@@ -57,7 +57,7 @@ int ObjXlc2::GetPassable( u32 index )
 
     if ( isShadow( index ) )
         return DIRECTION_ALL;
-    else if ( isAction( index ) || ( 110 < index && index < 136 ) )
+    if ( isAction( index ) || ( 110 < index && index < 136 ) )
         return 0;
 
     return std::end( restricted ) != std::find( restricted, std::end( restricted ), index ) ? DIRECTION_CENTER_ROW | DIRECTION_BOTTOM_ROW : DIRECTION_ALL;
@@ -78,7 +78,7 @@ int ObjXlc3::GetPassable( u32 index )
 {
     if ( isShadow( index ) )
         return DIRECTION_ALL;
-    else if ( isAction( index ) )
+    if ( isAction( index ) )
         return 0;
 
     return DIRECTION_ALL;


### PR DESCRIPTION
Fix clang-tidy [readability-else-after-return](https://releases.llvm.org/11.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-else-after-return.html) warnings. Flattens code a little bit.