### PR TITLE
Remove "battle: skip increase +2 defense" option

### DIFF
--- a/src/fheroes2/battle/battle.h
+++ b/src/fheroes2/battle/battle.h
@@ -108,7 +108,7 @@ namespace Battle
         CAP_MIRROROWNER = 0x00004000,
         CAP_MIRRORIMAGE = 0x00008000,
 
-        TR_DEFENSED = 0x00010000,
+        // UNUSED = 0x00010000,
 
         SP_BLOODLUST = 0x00020000,
         SP_BLESS = 0x00040000,

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -413,8 +413,6 @@ void Battle::Arena::ApplyActionSkip( Command & cmd )
             if ( hard || battle->Modes( TR_SKIPMOVE ) ) {
                 battle->SetModes( TR_HARDSKIP );
                 battle->SetModes( TR_MOVED );
-                if ( Settings::Get().ExtBattleSkipIncreaseDefense() )
-                    battle->SetModes( TR_DEFENSED );
             }
 
             battle->SetModes( TR_SKIPMOVE );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2670,8 +2670,6 @@ void Battle::Interface::RedrawActionSkipStatus( const Unit & attacker )
     std::string msg;
     if ( attacker.Modes( TR_HARDSKIP ) ) {
         msg = _( "%{name} skipping turn" );
-        if ( Settings::Get().ExtBattleSkipIncreaseDefense() )
-            msg.append( _( ", and get +2 defense" ) );
     }
     else {
         msg = _( "%{name} waiting turn" );

--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -192,7 +192,6 @@ void Dialog::ExtSettings( bool readonly )
 
     states.push_back( Settings::BATTLE_SHOW_ARMY_ORDER );
     states.push_back( Settings::BATTLE_SOFT_WAITING );
-    states.push_back( Settings::BATTLE_SKIP_INCREASE_DEFENSE );
     states.push_back( Settings::BATTLE_REVERSE_WAIT_ORDER );
 
     std::sort( states.begin(), states.end(),

--- a/src/fheroes2/monster/monster_info.h
+++ b/src/fheroes2/monster/monster_info.h
@@ -80,7 +80,7 @@ namespace fheroes2
             , value( 0 )
         {}
 
-        explicit MonsterAbility( const MonsterAbilityType type_, const int percentage_, const int value_ )
+        explicit MonsterAbility( const MonsterAbilityType type_, const uint32_t percentage_, const uint32_t value_ )
             : type( type_ )
             , percentage( percentage_ )
             , value( value_ )
@@ -93,9 +93,9 @@ namespace fheroes2
 
         MonsterAbilityType type;
 
-        int percentage;
+        uint32_t percentage;
 
-        int value;
+        uint32_t value;
     };
 
     struct MonsterWeakness
@@ -106,7 +106,7 @@ namespace fheroes2
             , value( 0 )
         {}
 
-        explicit MonsterWeakness( const MonsterWeaknessType type_, const int percentage_, const int value_ )
+        explicit MonsterWeakness( const MonsterWeaknessType type_, const uint32_t percentage_, const uint32_t value_ )
             : type( type_ )
             , percentage( percentage_ )
             , value( value_ )
@@ -119,9 +119,9 @@ namespace fheroes2
 
         MonsterWeaknessType type;
 
-        int percentage;
+        uint32_t percentage;
 
-        int value;
+        uint32_t value;
     };
 
     struct MonsterBattleStats

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -249,10 +249,6 @@ namespace
             _( "battle: soft wait troop" ),
         },
         {
-            Settings::BATTLE_SKIP_INCREASE_DEFENSE,
-            _( "battle: skip increase +2 defense" ),
-        },
-        {
             Settings::BATTLE_REVERSE_WAIT_ORDER,
             _( "battle: reverse wait order (fast, average, slow)" ),
         },
@@ -1596,11 +1592,6 @@ bool Settings::ExtUnionsAllowHeroesMeetings() const
 bool Settings::ExtBattleShowDamage() const
 {
     return ExtModes( GAME_BATTLE_SHOW_DAMAGE );
-}
-
-bool Settings::ExtBattleSkipIncreaseDefense() const
-{
-    return ExtModes( BATTLE_SKIP_INCREASE_DEFENSE );
 }
 
 bool Settings::ExtHeroAllowTranscribingScroll() const

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -113,8 +113,7 @@ public:
         BATTLE_SHOW_ARMY_ORDER = 0x40004000,
         // UNUSED = 0x40008000,
         BATTLE_SOFT_WAITING = 0x40010000,
-        BATTLE_REVERSE_WAIT_ORDER = 0x40020000,
-        BATTLE_SKIP_INCREASE_DEFENSE = 0x40200000
+        BATTLE_REVERSE_WAIT_ORDER = 0x40020000
     };
 
     Settings( const Settings & ) = delete;
@@ -225,7 +224,6 @@ public:
     bool ExtBattleShowDamage() const;
     bool ExtBattleShowBattleOrder() const;
     bool ExtBattleSoftWait() const;
-    bool ExtBattleSkipIncreaseDefense() const;
     bool ExtBattleReverseWaitOrder() const;
     bool ExtGameRememberLastFocus() const;
     bool ExtGameContinueAfterVictory() const;


### PR DESCRIPTION
There is no solid explanation why this value was chosen.

Plus a small code cleanup.

relates to #1272