### PR TITLE
Remove "world: use unique artifacts for morale/luck" option

### DIFF
--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -173,7 +173,6 @@ void Dialog::ExtSettings( bool readonly )
     states.push_back( Settings::WORLD_1HERO_HIRED_EVERY_WEEK );
     states.push_back( Settings::CASTLE_1HERO_HIRED_EVERY_WEEK );
     states.push_back( Settings::WORLD_SCALE_NEUTRAL_ARMIES );
-    states.push_back( Settings::WORLD_USE_UNIQUE_ARTIFACTS_ML );
     states.push_back( Settings::WORLD_USE_UNIQUE_ARTIFACTS_RS );
     states.push_back( Settings::WORLD_USE_UNIQUE_ARTIFACTS_PS );
     states.push_back( Settings::WORLD_USE_UNIQUE_ARTIFACTS_SS );

--- a/src/fheroes2/heroes/heroes_base.cpp
+++ b/src/fheroes2/heroes/heroes_base.cpp
@@ -268,9 +268,9 @@ u32 HeroBase::HasArtifact( const Artifact & art ) const
     bool unique = true;
 
     switch ( art.Type() ) {
-    case 1:
-        unique = Settings::Get().ExtWorldUseUniqueArtifactsML();
-        break; /* morale/luck arts. */
+    case 1: // morale/luck arifacts
+        unique = true;
+        break; 
     case 2:
         unique = Settings::Get().ExtWorldUseUniqueArtifactsRS();
         break; /* resource affecting arts. */
@@ -284,7 +284,12 @@ u32 HeroBase::HasArtifact( const Artifact & art ) const
         break;
     }
 
-    return !unique ? bag_artifacts.Count( art ) : ( bag_artifacts.isPresentArtifact( art ) ? 1 : 0 );
+    if ( unique ) {
+        return bag_artifacts.isPresentArtifact( art ) ? 1 : 0;
+    }
+    else {
+        return bag_artifacts.Count( art );
+    }
 }
 
 int HeroBase::GetAttackModificator( std::string * strs ) const

--- a/src/fheroes2/heroes/heroes_base.cpp
+++ b/src/fheroes2/heroes/heroes_base.cpp
@@ -270,7 +270,7 @@ u32 HeroBase::HasArtifact( const Artifact & art ) const
     switch ( art.Type() ) {
     case 1: // morale/luck arifacts
         unique = true;
-        break; 
+        break;
     case 2:
         unique = Settings::Get().ExtWorldUseUniqueArtifactsRS();
         break; /* resource affecting arts. */

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -181,10 +181,6 @@ namespace
             _( "world: Neutral armies scale with game difficulty" ),
         },
         {
-            Settings::WORLD_USE_UNIQUE_ARTIFACTS_ML,
-            _( "world: use unique artifacts for morale/luck" ),
-        },
-        {
             Settings::WORLD_USE_UNIQUE_ARTIFACTS_RS,
             _( "world: use unique artifacts for resource affecting" ),
         },
@@ -1682,11 +1678,6 @@ bool Settings::ExtCastleOneHeroHiredEveryWeek() const
 bool Settings::ExtWorldNeutralArmyDifficultyScaling() const
 {
     return ExtModes( WORLD_SCALE_NEUTRAL_ARMIES );
-}
-
-bool Settings::ExtWorldUseUniqueArtifactsML() const
-{
-    return ExtModes( WORLD_USE_UNIQUE_ARTIFACTS_ML );
 }
 
 bool Settings::ExtWorldUseUniqueArtifactsRS() const

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -102,7 +102,7 @@ public:
         WORLD_1HERO_HIRED_EVERY_WEEK = 0x30000010,
         WORLD_SCALE_NEUTRAL_ARMIES = 0x30000020,
         HEROES_ARENA_ANY_SKILLS = 0x30000080,
-        WORLD_USE_UNIQUE_ARTIFACTS_ML = 0x30000100,
+        // UNUSED = 0x30000100,
         WORLD_USE_UNIQUE_ARTIFACTS_RS = 0x30000200,
         WORLD_USE_UNIQUE_ARTIFACTS_PS = 0x30000400,
         WORLD_USE_UNIQUE_ARTIFACTS_SS = 0x30000800,
@@ -212,7 +212,6 @@ public:
     bool ExtWorldStartHeroLossCond4Humans() const;
     bool ExtWorldOneHeroHiredEveryWeek() const;
     bool ExtWorldNeutralArmyDifficultyScaling() const;
-    bool ExtWorldUseUniqueArtifactsML() const;
     bool ExtWorldUseUniqueArtifactsRS() const;
     bool ExtWorldUseUniqueArtifactsPS() const;
     bool ExtWorldUseUniqueArtifactsSS() const;


### PR DESCRIPTION
close #1300

This option should be always enabled to have the same behavior as in the original game