### PR TITLE
Remove required spellpoints from scroll in Mage Guild

### DIFF
--- a/src/fheroes2/castle/castle_mageguild.cpp
+++ b/src/fheroes2/castle/castle_mageguild.cpp
@@ -111,7 +111,7 @@ void RowSpells::Redraw( void )
             const fheroes2::Sprite & icon = fheroes2::AGG::GetICN( ICN::SPELLS, spell.IndexSprite() );
             fheroes2::Blit( icon, display, dst.x + 3 + ( dst.width - icon.width() ) / 2, dst.y + 31 - icon.height() / 2 );
 
-            TextBox text( std::string( spell.GetName() ) + " [" + std::to_string( spell.SpellPoint( nullptr ) ) + "]", Font::SMALL, 78 );
+            TextBox text( spell.GetName(), Font::SMALL, 78 );
             text.Blit( dst.x + 18, dst.y + 55 );
         }
     }

--- a/src/fheroes2/dialog/dialog_spellinfo.cpp
+++ b/src/fheroes2/dialog/dialog_spellinfo.cpp
@@ -67,7 +67,7 @@ void Dialog::SpellInfo( const std::string & header, const std::string & message,
 
     TextBox box1( header, Font::YELLOW_BIG, BOXAREA_WIDTH );
     TextBox box2( message, Font::BIG, BOXAREA_WIDTH );
-    Text text( spell.GetName(), Font::SMALL );
+    Text text( std::string( spell.GetName() ) + " [" + std::to_string( spell.SpellPoint( nullptr ) ) + "]", Font::SMALL );
 
     const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::SPELLS, spell.IndexSprite() );
     const int spacer = 10;


### PR DESCRIPTION
Add them to spell info dialog.
Fixes #633.