### PR TITLE
Update translation files and fix in-game translation function

### DIFF
--- a/files/lang/Makefile
+++ b/files/lang/Makefile
@@ -2,11 +2,17 @@
 # makefile
 #
 
+# TODO: remove the iconv/konwert line once unicode support is there
+# `-iconv -c -f utf-8 -t ascii $< > $<.tmp` simply removes all non-ASCII characters
+# Most non-ASCII characters can be converted to ASCII with `iconv -f utf-8 -t ascii//TRANSLIT -o $<.tmp $<`
+# Russian alphabet can be transliterated on Debian with `konwert UTF8-ascii/1 -o $<.tmp $<`
+
 all: $(patsubst %.po, %.mo, $(wildcard *.po))
 
 %.mo: %.po
-	msgmerge -U $< fheroes2.pot
-	msgfmt $< -o $@
+	msgmerge -U --no-location $< fheroes2.pot
+	-iconv -c -f utf-8 -t ascii $< > $<.tmp
+	msgfmt $<.tmp -o $@
 
 clean:
-	rm -f *.mo
+	rm -f *.mo *.tmp

--- a/files/lang/cs.po
+++ b/files/lang/cs.po
@@ -7,91 +7,53 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-10-23 10:54+0900\n"
+"POT-Creation-Date: 2021-07-01 15:11+0200\n"
 "PO-Revision-Date: 2009-08-10 08:45+0000\n"
 "Last-Translator: Vojtěch Trefný <vojtech.trefny@gmail.com>\n"
 "Language-Team: Czech <cs@li.org>\n"
+"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: cs\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Launchpad-Export-Date: 2010-05-27 09:12+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: ../fheroes2/ai/ai_action.cpp:157 ../fheroes2/heroes/heroes_action.cpp:248
-msgid "Hero %{name} also got a %{count} experience."
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:221 ../fheroes2/resource/artifact.cpp:968
-msgid "View %{name}"
-msgstr "Zobrazit %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:227 ../fheroes2/army/army_bar.cpp:310
-msgid "Move or right click to redistribute %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:233 ../fheroes2/army/army_bar.cpp:301
-msgid "Combine %{name} armies"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:238 ../fheroes2/army/army_bar.cpp:292
-#: ../fheroes2/resource/artifact.cpp:980
-#: ../fheroes2/resource/artifact.cpp:1002
-msgid "Exchange %{name2} with %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:246 ../fheroes2/resource/artifact.cpp:988
-msgid "Select %{name}"
-msgstr "Vybrat %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:298 ../fheroes2/army/army_bar.cpp:307
-msgid "Cannot move last troop"
-msgstr ""
-
-#: ../fheroes2/army/army.cpp:85
 msgid ""
 "A few\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:86
 msgid ""
 "Several\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:87
 msgid ""
 "A pack of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:88
 msgid ""
 "Lots of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:89
 msgid ""
 "A horde of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:90
 msgid ""
 "A throng of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:91
 msgid ""
 "A swarm of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:92
 msgid ""
 "Zounds of\n"
 "%{monster}"
@@ -99,7 +61,6 @@ msgstr ""
 "Mračna\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:93
 msgid ""
 "A legion of\n"
 "%{monster}"
@@ -107,224 +68,216 @@ msgstr ""
 "Legie\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Few"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Several"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Pack"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Lots"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Horde"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Throng"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Swarm"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Zounds"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Legion"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:925
 msgid "All %{race} troops +1"
 msgstr "Všechny %{race} jednotky +1"
 
-#: ../fheroes2/army/army.cpp:936
-msgid "Entire unit is undead, so morale does not apply."
-msgstr ""
-
-#: ../fheroes2/army/army.cpp:946
 msgid "Troops of 3 alignments -1"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:954
 msgid "Troops of 4 alignments -2"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:962
 msgid "Troops of 5 alignments -3"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:976
 msgid "Some undead in groups -1"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:752
+msgid "View %{name}"
+msgstr "Zobrazit %{name}"
+
+msgid "Move or right click to redistribute %{name}"
+msgstr ""
+
+msgid "Combine %{name} armies"
+msgstr ""
+
+msgid "Exchange %{name2} with %{name}"
+msgstr ""
+
+msgid "Select %{name}"
+msgstr "Vybrat %{name}"
+
+msgid "Cannot move last troop"
+msgstr ""
+
+msgid "%{name} half the enemy troops!"
+msgstr ""
+
 msgid "Set auto battle off"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:757
 msgid "Set auto battle on"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:864
 msgid "spell failed!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:705
 msgid ""
 "The Sphere of Negation artifact is in effect for this battle, disabling all "
 "combat spells."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:714
 msgid "You have already cast a spell this round."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:720
-#: ../fheroes2/battle/battle_arena.cpp:768
 msgid "That spell will affect no one!"
 msgstr "Toto kouzlo nebude na nikoho učinkovat!"
 
-#: ../fheroes2/battle/battle_arena.cpp:739
 msgid "You may only summon one type of elemental per combat."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:745
 msgid "There is no open space adjacent to your hero to summon an Elemental to."
 msgstr ""
 
-#: ../fheroes2/battle/battle_board.cpp:968
 msgid ""
 "The Moat reduces by -%{count} the defense skill of any unit and slows to "
 "half movement rate."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:50
-msgid "speed: %{speed}"
+msgid "Speed"
+msgstr "Rychlost"
+
+msgid "Speed: %{speed}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:165
+msgid "Auto Spell Casting"
+msgstr ""
+
+msgid "Grid"
+msgstr ""
+
+msgid "Shadow Movement"
+msgstr ""
+
+msgid "Shadow Cursor"
+msgstr ""
+
+msgid "On"
+msgstr ""
+
+#, fuzzy
+msgid "Off"
+msgstr "off"
+
 msgid "The enemy has surrendered!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:168
 msgid "The enemy has fled!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:170
-#: ../fheroes2/battle/battle_dialogs.cpp:256
 msgid "A glorious victory!"
 msgstr "Slavné vítězství!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:175
-msgid "For valor in combat, %{name} receives %{exp} experience"
+msgid "For valor in combat, %{name} receives %{exp} experience."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:184
 msgid "The cowardly %{name} flees from battle."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:191
 msgid "%{name} surrenders to the enemy, and departs in shame."
 msgstr "%{name} se vzdal nepříteli a odchází v hanbě."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:197
 msgid "Your force suffer a bitter defeat, and %{name} abandons your cause."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:249
 msgid "Your force suffer a bitter defeat."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:296
 msgid "Battlefield Casualties"
 msgstr "Ztráty"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:300
 msgid "Attacker"
 msgstr "Útočník"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:312
 msgid "Defender"
 msgstr "Obránce"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:394
+msgid "You have captured an enemy artifact!"
+msgstr ""
+
+msgid "Necromancy!"
+msgstr ""
+
+msgid ""
+"Practicing the dark arts of necromancy, you are able to raise %{count} of "
+"the enemy's dead to return under your service as %{monster}."
+msgstr ""
+
 msgid "%{name} the %{race}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:401
-#: ../fheroes2/castle/castle_well.cpp:311
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:194
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:834
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Attack"
 msgstr "Útok"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:406
-#: ../fheroes2/castle/castle_well.cpp:317
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:206
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:844
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Defense"
 msgstr "Obrana"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:411
-#: ../fheroes2/castle/castle_town.cpp:310
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:854
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:142
-#: ../fheroes2/heroes/heroes_meeting.cpp:292
 msgid "Spell Power"
 msgstr "Síla kouzel"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:416
-#: ../fheroes2/castle/castle_town.cpp:319
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:864
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:147
-#: ../fheroes2/heroes/heroes_meeting.cpp:296 ../fheroes2/heroes/skill.cpp:151
 msgid "Knowledge"
 msgstr "Znalosti"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:421
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:276
 msgid "Morale"
 msgstr "Morálka"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:426
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:286 ../fheroes2/heroes/skill.cpp:338
 msgid "Luck"
 msgstr "Štěstí"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:431
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:874
-#: ../fheroes2/heroes/heroes_indicator.cpp:247
 msgid "Spell Points"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
-#: ../fheroes2/gui/interface_buttons.cpp:189
+msgid "Hero's Options"
+msgstr ""
+
 msgid "Cast Spell"
 msgstr "Seslat kouzlo"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
-msgid ""
-"Cast a magical spell. You may only cast one spell per combat round. The "
-"round is reset when every creature has had a turn"
-msgstr ""
-
-#: ../fheroes2/battle/battle_dialogs.cpp:488
 msgid "Retreat"
 msgstr "Ústup"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:488
+msgid "Surrender"
+msgstr "Vzdát se"
+
+msgid "Cancel"
+msgstr "Zrušit"
+
+msgid "Hero Screen"
+msgstr ""
+
+msgid ""
+"Cast a magical spell. You may only cast one spell per combat round. The "
+"round is reset when every creature has had a turn."
+msgstr ""
+
 msgid ""
 "Retreat your hero, abandoning your creatures. Your hero will be available "
 "for you to recruit again, however, the hero will have only a novice hero's "
@@ -333,11 +286,6 @@ msgstr ""
 "Hrdina ustoupí a opustí své bojovníky. Hrdina bude dostupný pro opětovné "
 "najmutí. Hrdina bude mít pouze minimální armádu."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:491
-msgid "Surrender"
-msgstr "Vzdát se"
-
-#: ../fheroes2/battle/battle_dialogs.cpp:491
 msgid ""
 "Surrendering costs gold. However if you pay the ransom, the hero and all of "
 "his or her surviving creatures will be available to recruit again."
@@ -345,716 +293,971 @@ msgstr ""
 "Kapitulace stojí zlato. Pokud ale zaplatíš výkupné, hrdina a celá přeživší "
 "armáda bude k dispozici k opětovnému najmutí."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:166
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:227
-msgid "Cancel"
-msgstr "Zrušit"
+msgid "Open Hero Screen to view full information about the hero."
+msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
 msgid "Return to the battle."
 msgstr "Zpět do bitvy."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:549
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:438
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:497
 msgid "Not enough gold (%{gold})"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:564
 msgid "%{name} states:"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:569
 msgid ""
-"I will accept your surrender and grant you and your troops safe passage for "
-"the price of %{price} gold."
+"\"I will accept your surrender and grant you and your troops safe passage "
+"for the price of %{price} gold.\""
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:613
-#: ../fheroes2/battle/battle_interface.cpp:1401
 msgid "View %{monster} info."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1409
 #, fuzzy
 msgid "Shoot %{monster}"
 msgstr ""
 "Mračna\n"
 "%{monster}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1431
 msgid "Attack %{monster}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Fly %{monster} here."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Move %{monster} here."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1449
-#: ../fheroes2/battle/battle_interface.cpp:1538
 msgid "Turn %{turn}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1475
 msgid "Teleport Here"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1479
 msgid "Invalid Teleport Destination"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1485
 msgid "Cast %{spell} on %{monster}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1495
 msgid "Cast %{spell}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1501
 msgid "Select Spell Target"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1674
-msgid "Spell cast"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:1686
 #, fuzzy
 msgid "View Ballista Info"
 msgstr "Zobrazit informace o %{name}."
 
-#: ../fheroes2/battle/battle_interface.cpp:1699
-#: ../fheroes2/battle/battle_tower.cpp:53
 msgid "Ballista"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1712
 msgid "Auto combat"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1719
 msgid "Customize system options."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1727
 #, fuzzy
 msgid "Wait this unit"
 msgstr "Přeskočit tuto jednotku"
 
-#: ../fheroes2/battle/battle_interface.cpp:1734
 msgid "Skip this unit"
 msgstr "Přeskočit tuto jednotku"
 
-#: ../fheroes2/battle/battle_interface.cpp:1742
-#: ../fheroes2/battle/battle_interface.cpp:1774
-msgid "Hero's Options"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:1753
-#: ../fheroes2/battle/battle_interface.cpp:1785
 msgid "View Opposing Hero"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Hide logs"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Show logs"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1878
 msgid "%{color} cast spell: %{spell}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2202
 msgid "%{name} skipping turn"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2203
-msgid ", and get +2 defense"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:2206
 msgid "%{name} waiting turn"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2343
 msgid "%{attacker} do %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2497
 msgid "Moved %{monster}: %{src}, %{dst}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2612
+#, fuzzy
+msgid "Moved %{monster}"
+msgstr ""
+"Mračna\n"
+"%{monster}"
+
 msgid "The %{name} resist the spell!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2625
 msgid "%{name} casts %{spell} on the %{troop}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2630
 msgid "%{name} casts %{spell}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2751
-msgid "The %{spell} spell does %{damage} damage to all undead creatures."
-msgstr ""
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to one undead creature."
+msgstr "%{spell} způsobil %{value} škod."
 
-#: ../fheroes2/battle/battle_interface.cpp:2754
-msgid "The %{spell} spell does %{damage} damage to all living creatures."
-msgstr ""
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to all undead creatures."
+msgstr "%{spell} způsobil %{value} škod."
 
-#: ../fheroes2/battle/battle_interface.cpp:2756
+#, fuzzy
+msgid "The %{spell} does %{damage} damage, %{count} creatures perish."
+msgstr "%{spell} způsobil %{value} škod."
+
 msgid "The %{spell} does %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2797
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to one living creature."
+msgstr "%{spell} způsobil %{value} škod."
+
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to all living creatures."
+msgstr "%{spell} způsobil %{value} škod."
+
 msgid "The Unicorns attack blinds the %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2798
 msgid "The Medusas gaze turns the %{name} to stone!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2800
 msgid "The Mummies' curse falls upon the %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2801
 msgid "The %{name} are paralyzed by the Cyclopes!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2802
 msgid "The Archmagi dispel all good spells on your %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2820
-msgid "Good luck shines on the  %{attacker}"
+msgid "Good luck shines on the %{attacker}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2872
 msgid "Bad luck descends on the %{attacker}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2884
 msgid "High morale enables the %{monster} to attack again."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2891
 msgid "Low morale causes the %{monster} to freeze in panic."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2944
-msgid "Tower do %{damage} damage."
-msgstr ""
+#, fuzzy
+msgid "%{tower} does %{damage} damage."
+msgstr "%{tower} způsobila %{dmg} škod."
 
-#: ../fheroes2/battle/battle_interface.cpp:3257
 msgid "MirrorImage created"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:3798
-msgid "MirrorImage ended"
+msgid "The mirror image is destroyed!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4089
 msgid "Break auto battle?"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4138
 msgid "No spells to cast."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4147
 msgid "Are you sure you want to retreat?"
 msgstr "Jsi si jist, že chceš utéct?"
 
-#: ../fheroes2/battle/battle_interface.cpp:4155
 #, fuzzy
 msgid "Retreat disabled"
 msgstr "Ústup"
 
-#: ../fheroes2/battle/battle_interface.cpp:4169
-msgid "You don't have enough gold!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:4180
 #, fuzzy
 msgid "Surrender disabled"
 msgstr "Vzdát se"
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{min} - %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{min} - %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_main.cpp:190
-msgid "You have captured an enemy artifact!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_main.cpp:241
 msgid ""
-"Through eagle-eyed observation, %{name} is able to learn the magic spell %"
-"{spell}."
+"Through eagle-eyed observation, %{name} is able to learn the magic spell "
+"%{spell}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_main.cpp:280
-msgid ""
-"Practicing the dark arts of necromancy, you are able to raise %{count} of "
-"the enemy's dead to return under your service as %{monster}"
-msgstr ""
-
-#: ../fheroes2/battle/battle_tower.cpp:47 ../fheroes2/castle/castle.cpp:466
 msgid "Left Turret"
 msgstr "Levá věž"
 
-#: ../fheroes2/battle/battle_tower.cpp:48 ../fheroes2/castle/castle.cpp:467
 msgid "Right Turret"
 msgstr "Pravá věž"
 
-#: ../fheroes2/battle/battle_tower.cpp:115
 msgid "The %{name} fires with the strength of %{count} Archers"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:116
 msgid "each with a +%{attack} bonus to their attack skill."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:863
-msgid "%{name} half the enemy troops!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_troop.cpp:950
 msgid ""
 "The %{artifact} artifact is in effect for this battle, disabling %{spell} "
 "spell."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:1598
 msgid "%{count} %{name} rise(s) from the dead!"
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:258
+#, fuzzy
+msgid "Sorceress Guild"
+msgstr "Cech zlodějů"
+
+msgid "Necromancer Guild"
+msgstr ""
+
+msgid "Dragon Alliance"
+msgstr ""
+
+msgid "Elven Alliance"
+msgstr ""
+
+msgid "Wayward Son"
+msgstr ""
+
+msgid "Uncle Ivan"
+msgstr ""
+
+msgid "Force of Arms"
+msgstr ""
+
+#, fuzzy
+msgid "Annexation"
+msgstr "animace"
+
+msgid "Save the Dwarves"
+msgstr ""
+
+msgid "Carator Mines"
+msgstr ""
+
+msgid "Turning Point"
+msgstr ""
+
+msgid "The Gauntlet"
+msgstr ""
+
+msgid "The Crown"
+msgstr ""
+
+msgid "Corlagon's Defense"
+msgstr ""
+
+msgid "Final Justice"
+msgstr ""
+
+msgid "First Blood"
+msgstr ""
+
+msgid "Barbarian Wars"
+msgstr ""
+
+msgid "Necromancers"
+msgstr ""
+
+msgid "Slay the Dwarves"
+msgstr ""
+
+msgid "Rebellion"
+msgstr ""
+
+msgid "Dragon Master"
+msgstr ""
+
+msgid "Country Lords"
+msgstr ""
+
+msgid "Greater Glory"
+msgstr ""
+
+msgid "Apocalypse"
+msgstr ""
+
+msgid "Uprising"
+msgstr ""
+
+msgid "Island of Chaos"
+msgstr ""
+
+msgid "Arrow's Flight"
+msgstr ""
+
+msgid "The Abyss"
+msgstr ""
+
+msgid "The Giant's Pass"
+msgstr ""
+
+msgid "Aurora Borealis"
+msgstr ""
+
+msgid "Betrayal's End"
+msgstr ""
+
+msgid "Corruption's Heart"
+msgstr ""
+
+msgid "Conquer and Unify"
+msgstr ""
+
+msgid "Border Towns"
+msgstr ""
+
+msgid "The Wayward Son"
+msgstr ""
+
+msgid "Crazy Uncle Ivan"
+msgstr ""
+
+msgid "The Southern War"
+msgstr ""
+
+msgid "Ivory Gates"
+msgstr ""
+
+msgid "The Elven Lands"
+msgstr ""
+
+msgid "The Epic Battle"
+msgstr ""
+
+msgid "The Shrouded Isles"
+msgstr ""
+
+msgid "The Eternal Scrolls"
+msgstr ""
+
+msgid "Power's End"
+msgstr ""
+
+msgid "Fount of Wizardry"
+msgstr ""
+
+msgid "Stranded"
+msgstr ""
+
+msgid "Pirate Isles"
+msgstr ""
+
+msgid "King and Country"
+msgstr ""
+
+msgid "Blood is Thicker"
+msgstr ""
+
+msgid ""
+"Roland needs you to defeat the lords near his castle to begin his war of "
+"rebellion against his brother.  They are not allied with each other, so they "
+"will spend most of their time fighting with one another.  Victory is yours "
+"when you have defeated all of their castles and heroes."
+msgstr ""
+
+msgid ""
+"The local lords refuse to swear allegiance to Roland, and must be subdued. "
+"They are wealthy and powerful, so be prepared for a tough fight. Capture all "
+"enemy castles to win."
+msgstr ""
+
+msgid ""
+"Your task is to defend the Dwarves against Archibald's forces. Capture all "
+"of the enemy towns and castles to win, and be sure not to lose all of the "
+"dwarf towns at once, or the enemy will have won."
+msgstr ""
+
+msgid ""
+"You will face four allied enemies in a straightforward fight for resource "
+"and treasure. Capture all of the enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Your enemies are allied against you and start close by, so be ready to come "
+"out fighting. You will need to own all four castles in this small valley to "
+"win."
+msgstr ""
+
+msgid ""
+"The Sorceress' guild of Noraston has requested Roland's aid against an "
+"attack from Archibald's allies. Capture all of the enemy castles to win, and "
+"don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy "
+"castle on an island in the ocean.)"
+msgstr ""
+
+msgid ""
+"Gather as large an army as possible and capture the enemy castle within 8 "
+"weeks. You are opposed by only one enemy, but must travel a long way to get "
+"to the enemy castle. Any troops you have in your army at the end of this "
+"scenario will be with you in the final battle."
+msgstr ""
+
+msgid ""
+"Find the Crown before Archibald's heroes find it. Roland will need the Crown "
+"for the final battle against Archibald."
+msgstr ""
+
+msgid ""
+"Three allied enemies stand before you and victory, including Lord Corlagon. "
+"Roland is in a castle to the northwest, and you will lose if he falls to the "
+"enemy. Remember that capturing Lord Corlagon will ensure that he will not "
+"fight against you in the final scenario."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Archibald to end the war!"
+msgstr ""
+
+msgid ""
+"King Archibald requires you to defeat the three enemies in this region.  "
+"They are not allied with one another, so they will spend most of their "
+"energy fighting amongst themselves.  You will win when you own all of the "
+"enemy castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"You must unify the barbarian tribes of the north by conquering them. As in "
+"the previous mission, the enemy is not allied against you, but they have "
+"more resources at their disposal. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"Do-gooder wizards have taken the Necromancers' castle. You must retake it to "
+"achieve victory. Remember that while you start with a powerful army, you "
+"have no castle and must take one within 7 days, or lose this battle. (Hint: "
+"The nearest castle is to the southeast.)"
+msgstr ""
+
+msgid ""
+"The dwarves need conquering before they can interfere in King Archibald's "
+"plans. Roland's forces have more than one hero and many towns to start with, "
+"so be ready for attack from multiple directions. You must capture all of the "
+"enemy towns and castles to claim victory."
+msgstr ""
+
+msgid ""
+"You must put down a peasant revolt led by Roland's forces. All are allied "
+"against you, but you have Lord Corlagon, an experienced hero, to help you. "
+"Capture all enemy castles to win."
+msgstr ""
+
+msgid ""
+"There are two enemies allied against you in this mission. Both are well "
+"armed and seek to evict you from their island. Avoid them and capture Dragon "
+"City to win"
+msgstr ""
+
+msgid ""
+"Your orders are to conquer the country lords that have sworn to serve "
+"Roland. All of the enemy castles are unified against you. Since you start "
+"without a castle, you must hurry to capture one before the end of the week. "
+"Capture all enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Find the Crown before Roland's heroes find it. Archibald will need the Crown "
+"for the final battle against Roland."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Roland to win the war, and be sure "
+"not to lose Archibald in the fight!"
+msgstr ""
+
+msgid ""
+"Subdue the unruly local lords in order to provide the Empire with facilities "
+"to operate in this region."
+msgstr ""
+
+msgid ""
+"Eliminate all oposition in this area. Then the first piece of the artifact "
+"will be yours."
+msgstr ""
+
+msgid ""
+"The sorceresses to the northeast are rebelling! For the good of the empire "
+"you must quash their feeble uprising on your way to the mountains."
+msgstr ""
+
+msgid ""
+"Having prepared for your arrival, Kraeger has arranged for a force of "
+"necromancers to thwart your quest. You must capture the castle of Scabsdale "
+"before the first day of the third week, or the Necromancers will be too "
+"strong for you."
+msgstr ""
+
+msgid ""
+"The barbarian despot in this area is, as yet, ignorant of your presence. "
+"Quickly, build up your forces before you are discovered and attacked! Secure "
+"the region by subduing all enemy forces."
+msgstr ""
+
+msgid ""
+"The Empire is weak in this region. You will be unable to completely subdue "
+"all forces in this area, so take what you can before reprisal strikes. "
+"Remember, your true goal is to claim the Helmet of Anduran."
+msgstr ""
+
+msgid "For the good of the Empire, eliminate Kraeger."
+msgstr ""
+
+msgid ""
+"At last, you have the opportunity and the facilities to rid the Empire of "
+"the necromancer's evil. Eradicate them completely, and you will be sung as a "
+"hero for all time."
+msgstr ""
+
+msgid ""
+"Conquer and unite all the enemy tribes. Don't lose the hero Jarkonas, the "
+"forefather of all descendants."
+msgstr ""
+
+msgid ""
+"Your rival, the Kingdom of Harondale, is attacking weak towns on your "
+"border! Recover from their first strike and crush them completely!"
+msgstr ""
+
+msgid ""
+"Find your wayward son Joseph who is rumored to be living in the desolate "
+"lands. Do it before the first day of the third month or it will be of no "
+"help to your family."
+msgstr ""
+
+msgid ""
+"Rescue your crazy uncle Ivan. Find him before the first day of the fourth "
+"month or it will be no help to your kingdom."
+msgstr ""
+
+msgid ""
+"Destroy the barbarians who are attacking the southern border of your "
+"kingdom! Recover your fallen towns, and then invade the jungle kingdom. "
+"Leave no enemy standing."
+msgstr ""
+
+msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
+msgstr ""
+
+msgid ""
+"Gain the favor of the elves. They will not allow trees to be chopped down, "
+"so they will send you wood every 2 weeks. You must complete your mission "
+"before the first day of the seventh month, or the kingdom will surely fall."
+msgstr ""
+
+msgid ""
+"This is the final battle against your rival kingdom of Harondale. Eliminate "
+"everyone, and don't lose the hero Jarkonas VI."
+msgstr ""
+
+msgid ""
+"Your mission is to vanquish the warring mages in the magical Shrouded Isles. "
+"The completion of this task will give you a fighting chance against your "
+"rivals."
+msgstr ""
+
+msgid ""
+"The location of the great library has been dicovered! You must make your way "
+"to it, and reclaim the city of Chronos in which it lies."
+msgstr ""
+
+msgid ""
+"Find the Orb of negation, which is said to be buried in this land. There are "
+"clues inscribed on stone obelisks which will help lead you to your price. "
+"Find the orb before the first day of the sixth month, or your rivals will "
+"surely have gotten to the fount before you."
+msgstr ""
+
+msgid ""
+"You must take control of the castle of Magic, where the fount of wizardry "
+"lies. Do this and your victory will be supreme."
+msgstr ""
+
+msgid ""
+"Capture the town on the island off the southeast shore in order to construct "
+"a boat and travel back towards the mainland. Do not lose the hero Gallavant."
+msgstr ""
+
+msgid ""
+"Find and defeat Martine, the pirate leader, who resides in Pirates Cove. Do "
+"not lose Gallavant or your quest will be over."
+msgstr ""
+
+msgid ""
+"Eliminate all the other forces who oppose the rule of Lord Alberon. "
+"Gallavant must not die."
+msgstr ""
+
+msgid ""
+"Overthrow the entrenched monarchy of Lord Alberon, and claim all the land in "
+"your name. Gallavant must not die."
+msgstr ""
+
+msgid " bane"
+msgstr ""
+
+msgid " alliance"
+msgstr ""
+
+msgid "Carry-over forces"
+msgstr ""
+
+msgid " bonus"
+msgstr ""
+
+msgid " defeated"
+msgstr ""
+
+msgid "Thunder Mace"
+msgstr ""
+
+msgid "Minor Scroll"
+msgstr ""
+
+msgid "Dragon Sword"
+msgstr ""
+
+#, fuzzy
+msgid "Breastplate"
+msgstr "Tržiště"
+
+msgid "Fibzin Medal"
+msgstr ""
+
+msgid "Mage's ring"
+msgstr ""
+
+#, fuzzy
+msgid "Defender Helm"
+msgstr "Obránce"
+
+msgid "Power Axe"
+msgstr ""
+
+msgid "Summon Earth"
+msgstr ""
+
 msgid "The %{building} produces %{monster}."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:505
 msgid "Requires:"
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:597
 msgid "Cannot build. Already built here this turn."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:601
 msgid "For this action it is necessary first to build a castle."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:623
 msgid "Cannot build %{name} because castle is too far from water."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:631
-msgid "Cannot afford %{name}"
-msgstr ""
-
-#: ../fheroes2/castle/buildinginfo.cpp:636
-msgid "%{name} is already built"
-msgstr "%{name} je již postaven."
-
-#: ../fheroes2/castle/buildinginfo.cpp:641
-msgid "Cannot build %{name}"
+#, fuzzy
+msgid "Cannot afford %{name}."
 msgstr "Není možné postavit %{name}"
 
-#: ../fheroes2/castle/buildinginfo.cpp:646
-msgid "Build %{name}"
+#, fuzzy
+msgid "%{name} is already built."
+msgstr "%{name} je již postaven."
+
+#, fuzzy
+msgid "Cannot build %{name}."
+msgstr "Není možné postavit %{name}"
+
+#, fuzzy
+msgid "Build %{name}."
 msgstr "Postavit %{name}"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Thieves' Guild"
 msgstr "Cech zlodějů"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Tavern"
 msgstr "Taverna"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Shipyard"
 msgstr "Loděnice"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Well"
 msgstr "Studna"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Statue"
 msgstr "Socha"
 
-#: ../fheroes2/castle/castle.cpp:467
-#: ../fheroes2/dialog/dialog_marketplace.cpp:212
 msgid "Marketplace"
 msgstr "Tržiště"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Moat"
 msgstr "Příkop"
 
-#: ../fheroes2/castle/castle.cpp:467 ../fheroes2/maps/mp2.cpp:391
 msgid "Castle"
 msgstr "Hrad"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Tent"
 msgstr "Stan"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Captain's Quarters"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Mage Guild, Level 1"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 2"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 3"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 4"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 5"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Farm"
 msgstr "Farma"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Garbage Heap"
 msgstr "Halda hnoje"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Crystal Garden"
 msgstr "Křišťálová zahrada"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Waterfall"
 msgstr "Vodopád"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Orchard"
 msgstr "Ovocný sad"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Skull Pile"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Fortifications"
 msgstr "Opevnění"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Coliseum"
 msgstr "Koloseum"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Rainbow"
 msgstr "Duha"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Dungeon"
 msgstr "Kobka"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Library"
 msgstr "Knihovna"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Storm"
 msgstr "Bouře"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:498
 msgid "Thatched Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Treehouse"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:441
 msgid "Cave"
 msgstr "Jeskyně"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Habitat"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:431
 msgid "Excavation"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:477
 msgid "Archery Range"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Stick Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Cottage"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Crypt"
 msgstr "Krypta"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Pen"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/maps/mp2.cpp:371
 msgid "Graveyard"
 msgstr "Hřbitov"
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Blacksmith"
 msgstr "Kovárna"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Den"
 msgstr "Doupě"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Nest"
 msgstr "Hnízdo"
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Foundry"
 msgstr "Slévárna"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:480
-#: ../fheroes2/castle/castle.cpp:487 ../fheroes2/maps/mp2.cpp:427
-#: ../fheroes2/resource/maps_text.cpp:521
 msgid "Pyramid"
 msgstr "Pyramida"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Armory"
 msgstr "Zbrojnice"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Adobe"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Stonehenge"
 msgstr "Stonehenge"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Maze"
 msgstr "Labyrint"
 
-#: ../fheroes2/castle/castle.cpp:478 ../fheroes2/castle/castle.cpp:485
 msgid "Cliff Nest"
 msgstr "Útes"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Mansion"
 msgstr "Zámek"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Jousting Arena"
 msgstr "Turnajové pole"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Bridge"
 msgstr "Most"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
 msgid "Fenced Meadow"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Swamp"
 msgstr "Bažina"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Ivory Tower"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Mausoleum"
 msgstr "Mauzoleum"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cathedral"
 msgstr "Katedrála"
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Red Tower"
 msgstr "Červená věž"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Green Tower"
 msgstr "Zelená věž"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cloud Castle"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Laboratory"
 msgstr "Laboratoř"
 
-#: ../fheroes2/castle/castle.cpp:483 ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Archery Range"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Stick Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Cottage"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Graveyard"
 msgstr "Rozšířit Hřbitov"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Blacksmith"
 msgstr "Rozšířit Kovárna"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Foundry"
 msgstr "Rozšířit Slevárna"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Pyramid"
 msgstr "Rozšířit Pyramida"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Armory"
 msgstr "Rozšířit Zbrojnice"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Adobe"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Stonehenge"
 msgstr "Rozšířit Stonehenge"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Maze"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Mansion"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Jousting Arena"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Bridge"
 msgstr "Rozšířit Most"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Ivory Tower"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Mausoleum"
 msgstr "Rozšířit Mauzoleum"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cathedral"
 msgstr "Rozšířit Katedrála"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cloud Castle"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:488
 msgid "Black Tower"
 msgstr "Černá věž"
 
-#: ../fheroes2/castle/castle.cpp:490
 msgid "Shrine"
 msgstr "Svatyně"
 
-#: ../fheroes2/castle/castle.cpp:552
+#, fuzzy
 msgid ""
 "The Thieves' Guild provides information on enemy players. Thieves' Guilds "
-"can also provide scouting information on enemy towns."
+"can also provide scouting information on enemy towns. Additional Guilds "
+"provide more information."
 msgstr ""
 "Cech zlodějů poskytuje informace o nepřátelích. Může také poskytovat "
 "špionážní informace o nepřátelských městech."
 
-#: ../fheroes2/castle/castle.cpp:553
 msgid "The Tavern increases morale for troops defending the castle."
 msgstr "Taverna zvyšuje morálku jednotek bránících hrad."
 
-#: ../fheroes2/castle/castle.cpp:554
 msgid "The Shipyard allows ships to be built."
 msgstr "Loděnice umožňuje stavbu lodí."
 
-#: ../fheroes2/castle/castle.cpp:555
 msgid ""
 "The Well increases the growth rate of all dwellings by %{count} creatures "
 "per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:556
 msgid "The Statue increases your town's income by %{count} per day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:557
 msgid "The Left Turret provides extra firepower during castle combat."
 msgstr "Levá věž zvyšuje palebnou sílu při obraně hradu."
 
-#: ../fheroes2/castle/castle.cpp:558
 msgid "The Right Turret provides extra firepower during castle combat."
 msgstr "Levá věž zvyšuje palebnou sílu při obraně hradu."
 
-#: ../fheroes2/castle/castle.cpp:559
 msgid ""
 "The Marketplace can be used to convert one type of resource into another. "
 "The more marketplaces you control, the better the exchange rate."
@@ -1062,7 +1265,6 @@ msgstr ""
 "Tržiště slouží ke směně surovin navzájem. Čím více tržišť kontrolujete, tím "
 "lepší je směnný kurz."
 
-#: ../fheroes2/castle/castle.cpp:560
 msgid ""
 "The Moat slows attacking units. Any unit entering the moat must end its turn "
 "there and becomes more vulnerable to attack."
@@ -1070,402 +1272,359 @@ msgstr ""
 "Příkop zpomaluje útočící jednotky. Jakákoli jednotka zde musí ukončit pohyb "
 "a je zranitelnější při útoku."
 
-#: ../fheroes2/castle/castle.cpp:561
 msgid ""
 "The Castle improves town defense and increases income to %{count} gold per "
 "day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:562
 msgid ""
 "The Tent provides workers to build a castle, provided the materials and the "
 "gold are available."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:563
 msgid ""
 "The Captain's Quarters provides a captain to assist in the castle's defense "
 "when no hero is present."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:564
 msgid ""
 "The Mage Guild allows heroes to learn spells and replenish their spell "
 "points."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:567
 msgid "The Farm increases production of Peasants by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:568
 msgid "The Garbage Heap increases production of Goblins by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:569
 msgid ""
 "The Crystal Garden increases production of Sprites by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:570
 msgid "The Waterfall increases production of Centaurs by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:571
 msgid "The Orchard increases production of Halflings by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:572
 msgid "The Skull Pile increases production of Skeletons by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:575
 msgid ""
 "The Fortifications increase the toughness of the walls, increasing the "
 "number of turns it takes to knock them down."
 msgstr "Opevnění zvyšuje odolnost zdí - zvyšuje počet kol než budou zničeny."
 
-#: ../fheroes2/castle/castle.cpp:576
 msgid ""
 "The Coliseum provides inspiring spectacles to defending troops, raising "
 "their morale by two during combat."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:577
 msgid "The Rainbow increases the luck of the defending units by two."
 msgstr "Duha zvyšuje štěstí bránících jednotek o dvě."
 
-#: ../fheroes2/castle/castle.cpp:578
 msgid "The Dungeon increases the income of the town by %{count} / day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:579
 msgid ""
 "The Library increases the number of spells in the Guild by one for each "
 "level of the guild."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:580
 msgid "The Storm adds +2 to the power of spells of a defending spell caster."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:582
 msgid ""
 "The Shrine increases the necromancy skill of all your necromancers by 10 "
 "percent."
 msgstr ""
 "Svatyně zvyšuje úroveň nekromacie o 10 procent u všech vašich nekromatnů."
 
-#: ../fheroes2/castle/castle.cpp:632
 msgid "Cannot recruit - you already recruit hero in current week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:645
 msgid "Cannot recruit - guest to guard automove error."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:651
 msgid "Cannot recruit - you already have a Hero in this town."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:659
 msgid "Cannot recruit - you have too many Heroes."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:665
 msgid "Cannot afford a Hero"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:756
 msgid "There is no room in the garrison for this army."
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:272
+msgid "Recruit %{name}"
+msgstr ""
+
 msgid "Month: %{month}, Week: %{week}, Day: %{day}"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:393
-#: ../fheroes2/castle/castle_dialog.cpp:396
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:387
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:186
-msgid "Income:"
+#, fuzzy
+msgid "Income"
 msgstr "Příjem:"
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 msgid "Join Error"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 msgid "Army is full"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
+msgid ""
+"You must purchase a spell book to use the mage guild, but you currently have "
+"no room for a spell book. Try giving one of your artifacts to another hero."
+msgstr ""
+
 msgid "Town"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
 msgid "This town may not be upgraded to a castle."
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit castle"
+#, fuzzy
+msgid "Exit Castle"
 msgstr "Opustit hrad"
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit town"
+#, fuzzy
+msgid "Exit Town"
 msgstr "Opustit město"
 
-#: ../fheroes2/castle/castle_dialog.cpp:730
-msgid "Show income"
-msgstr ""
+#, fuzzy
+msgid "Show Income"
+msgstr "Příjem:"
 
-#: ../fheroes2/castle/castle_dialog.cpp:734
 msgid "Show previous town"
 msgstr "Zobrazit předchozí město"
 
-#: ../fheroes2/castle/castle_dialog.cpp:738
 msgid "Show next town"
 msgstr "Zobrazit následující město"
 
-#: ../fheroes2/castle/castle_dialog.cpp:741
 #, fuzzy
 msgid "Swap Heroes"
 msgstr "Hrdinové"
 
-#: ../fheroes2/castle/castle_dialog.cpp:744
 #, fuzzy
 msgid "Meeting Heroes"
 msgstr "Hrdinové"
 
-#: ../fheroes2/castle/castle_dialog.cpp:749
 msgid "View Hero"
 msgstr "Zobrazit hrdinu"
 
-#: ../fheroes2/castle/castle_mageguild.cpp:150
+msgid "The above spells are available here."
+msgstr ""
+
 msgid "The above spells have been added to your book."
 msgstr ""
 
-#: ../fheroes2/castle/castle_tavern.cpp:39
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:748
 msgid "A generous tip for the barkeep yields the following rumor:"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:54
 msgid "Recruit Hero"
 msgstr "Najmout hrdinu"
 
-#: ../fheroes2/castle/castle_town.cpp:59
-msgid "%{name} is a level %{value} %{race}"
+#, fuzzy
+msgid "%{name} is a level %{value} %{race} "
+msgstr "%{name} %{does} %{value} škod."
+
+msgid "with %{count} artifacts."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with %{count} artifacts"
+msgid "with 1 artifact."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with one artifact"
+msgid "without artifacts."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:283
-#: ../fheroes2/heroes/heroes_dialog.cpp:108
 msgid ""
 "'Spread' combat formation spreads your armies from the top to the bottom of "
 "the battlefield, with at least one empty space between each army."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:284
 msgid ""
 "'Grouped' combat formation bunches your army toget her in the center of your "
 "side of the battlefield."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:292
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:132
-#: ../fheroes2/heroes/heroes_meeting.cpp:284
 msgid "Attack Skill"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:301
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:137
-#: ../fheroes2/heroes/heroes_meeting.cpp:288
 msgid "Defense Skill"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:487
-#: ../fheroes2/heroes/heroes_dialog.cpp:334
 msgid "Spread Formation"
 msgstr "Rozvinutá formace"
 
-#: ../fheroes2/castle/castle_town.cpp:489
-#: ../fheroes2/heroes/heroes_dialog.cpp:337
 msgid "Grouped Formation"
 msgstr "Seskupená formace"
 
-#: ../fheroes2/castle/castle_town.cpp:540
-#: ../fheroes2/castle/castle_town.cpp:553
 msgid "Recruit %{name} the %{race}"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:561
 msgid "Set garrison combat formation to 'Spread'"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:564
 msgid "Set garrison combat formation to 'Grouped'"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:567
+#, fuzzy
+msgid "Exit Castle Options"
+msgstr "Nastavení systému"
+
 msgid "Castle Options"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:158
-msgid "Buy Monsters:"
+msgid "Not enough resources to buy monsters."
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:221
+msgid "No monsters available for purchase."
+msgstr ""
+
+msgid "Buy Monsters"
+msgstr ""
+
 msgid "Town Population Information and Statistics"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:323
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:231
 msgid "Damage"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:329
 msgid "HP"
 msgstr "HP"
 
-#: ../fheroes2/castle/castle_well.cpp:335
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:266
-msgid "Speed"
-msgstr "Rychlost"
-
-#: ../fheroes2/castle/castle_well.cpp:351
 msgid "Growth"
 msgstr "Růst"
 
-#: ../fheroes2/castle/castle_well.cpp:355
 msgid "week"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:361
-#: ../fheroes2/kingdom/kingdom_overview.cpp:479
 msgid "Available"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:89
 msgid "View the entire world."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:90
 msgid "View the obelisk puzzle."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:91
 msgid "View information on the scenario you are currently playing."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:92
 msgid "Dig for the Ultimate Artifact."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:93
 msgid "Exit this menu without doing anything."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_arena.cpp:48
+msgid "Arena"
+msgstr ""
+
 msgid ""
 "You enter the arena and face a pack of vicious lions. You handily defeat "
 "them, to the wild cheers of the crowd.  Impressed by your skill, the aged "
 "trainer of gladiators agrees to train you in a skill of your choice."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:154
-msgid ""
-"Your troops can be upgraded, but it will cost you %{ratio} times the "
-"difference in cost for each troop, rounded up to next highest number. Do you "
-"wish to upgrade them?"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:155
 msgid ""
 "Your troops can be upgraded, but it will cost you dearly. Do you wish to "
 "upgrade them?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:166
 msgid "Are you sure you want to dismiss this army?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots Left"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:244
 msgid "Hit Points"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:255
 msgid "Hit Points Left"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:379
+#, fuzzy
+msgid "Followers"
+msgstr "Síla kouzel"
+
 msgid ""
-"The creature is swayed by your diplomatic tongue, and offers to join your "
+"A group of %{monster} with a desire for greater glory wish to join you.\n"
+"Do you accept?"
+msgstr ""
+
+msgid ""
+"The %{monster} is swayed by your diplomatic tongue, and offers to join your "
 "army for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:382
 msgid ""
 "The creatures are swayed by your diplomatic\n"
 "tongue, and make you an offer:\n"
 " \n"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:385
 msgid ""
 "%{offer} of the %{total} %{monster} will join your army, and the rest will "
 "leave you alone, for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:387
 msgid ""
 "All %{offer} of the %{monster} will join your army for the sum of %{gold} "
 "gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:401
 msgid "(Rate: %{percent})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:451
-msgid ""
-"Not room in\n"
-"the garrison"
+msgid "No room in"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:48
+msgid "the garrison"
+msgstr ""
+
 msgid "Build a new ship:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:63
 msgid "Resource cost:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:40
-msgid "For the QVGA version is not available."
+msgid "Load Game"
+msgstr "Načíst hru"
+
+msgid "No save files to load."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:62
+msgid "New Game"
+msgstr "Nová hra"
+
+msgid "Start a single or multi-player game."
+msgstr ""
+
+msgid "Load a previously saved game."
+msgstr ""
+
+#, fuzzy
+msgid "Save Game"
+msgstr "Nová hra"
+
+msgid "Save the current game."
+msgstr ""
+
+msgid "Quit"
+msgstr "Ukončit"
+
+msgid "Quit out of Free Heroes of Might and Magic II."
+msgstr ""
+
 msgid ""
 "Map\n"
 "Difficulty"
@@ -1473,7 +1632,6 @@ msgstr ""
 "Mapa\n"
 "Obtížnost"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:65
 msgid ""
 "Game\n"
 "Difficulty"
@@ -1481,1193 +1639,1324 @@ msgstr ""
 "Hra\n"
 "Obtížnost"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:68
 msgid "Rating"
 msgstr "Hodnocení"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:71
 msgid "Map Size"
 msgstr "Velikost mapy"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:89
-#: ../fheroes2/system/players.cpp:691
 msgid "Opponents"
 msgstr "Protivníci"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:92
-#: ../fheroes2/system/players.cpp:695
 msgid "Class"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:100
 msgid ""
 "Victory\n"
 "Conditions"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:106
 msgid ""
 "Loss\n"
 "Conditions"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:167
 msgid "You cannot select %{resource}!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:173
 msgid "Select count %{resource}:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:200
 msgid "Set Guardian"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:236
-#: ../fheroes2/dialog/dialog_guardian.cpp:292
 msgid "Your army too big!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:34
-#: ../fheroes2/dialog/dialog_levelup.cpp:44
-#: ../fheroes2/dialog/dialog_levelup.cpp:73
 msgid "%{name} has gained a level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:36
-#: ../fheroes2/dialog/dialog_levelup.cpp:46
-#: ../fheroes2/dialog/dialog_levelup.cpp:75
-msgid "%{skill} Skill +1"
-msgstr ""
+#, fuzzy
+msgid "%{skill} +1"
+msgstr "Zobrazit informace o %{name}."
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:51
 msgid "You have learned %{skill}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:93
 msgid "You may learn either:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:96
 msgid "or"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:66
 msgid ""
 "Please inspect our fine wares. If you feel like offering a trade, click on "
 "the items you wish to trade with and for."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:104
 msgid ""
 "You have received quite a bargain. I expect to make no profit on the deal. "
 "Can I interest you in any of my other wares?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:130
 msgid "I can offer you %{count} for 1 unit of %{resfrom}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:136
 msgid "I can offer you 1 unit of %{resto} for %{count} units of %{resfrom}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:164
 msgid "Qty to trade"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:235
+msgid "Trading Post"
+msgstr ""
+
 msgid "Your Resources"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:257
 msgid "Available Trades"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:573
 msgid "n/a"
 msgstr "n/a"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:77
-msgid "guarded by %{count} of %{monster}"
+msgid "guarded by %{count} %{monster}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:149
 msgid "(available: %{count})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:181
 msgid "already learned"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:205
 msgid "already knows this skill"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:212
 msgid "already has max skills"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:260
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:276
 msgid "(already visited)"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
 msgid "(not visited)"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:296
+msgid "Road"
+msgstr ""
+
+msgid "(digging ok)"
+msgstr ""
+
+msgid "(no digging)"
+msgstr ""
+
 msgid "penalty: %{cost}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:382
-msgid "Unchartered Territory"
+msgid "Uncharted Territory"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:635
 msgid "Defenders:"
 msgstr "Obránci:"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:674
-#: ../fheroes2/heroes/heroes_indicator.cpp:125
-#: ../fheroes2/heroes/heroes_indicator.cpp:171
 msgid "None"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:756
-msgid "%{name} ( Level %{level} )"
+msgid "Unknown"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:884
+msgid "%{name} (Level %{level})"
+msgstr ""
+
 msgid "Move Points"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:40
-#: ../fheroes2/dialog/dialog_recrut.cpp:579
 msgid "Available: %{count}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:101
-msgid "Cost per troop:"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:107
-#: ../fheroes2/dialog/dialog_recrut.cpp:506
-msgid "Recruit %{name}"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:210
 msgid "Number to buy:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:314
 msgid "How many troops to move?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:358
 msgid "Fast separation into slots:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:180
 msgid "File to Save:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:186
 msgid "File to Load:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:302
 msgid "Are you sure you want to delete file:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:305
 msgid "Warning!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:144
-msgid "Maps Difficulty:"
+#, fuzzy
+msgid "Map difficulty:"
+msgstr ""
+"Mapa\n"
+"Obtížnost"
+
+msgid "No maps exist at that size"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
 msgid "Small Maps"
 msgstr "Malé mapy"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
-msgid "View only maps of size small (36x36)."
+#, fuzzy
+msgid "View only maps of size small (36 x 36)."
 msgstr "Zobrazí pouze mapy velikosti \"malá\" (36x36)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
 msgid "Medium Maps"
 msgstr "Střední mapy."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
-msgid "View only maps of size medium (72x72)."
+#, fuzzy
+msgid "View only maps of size medium (72 x 72)."
 msgstr "Zobrazí pouze mapy velikosti \"střední\" (72x72)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
 msgid "Large Maps"
 msgstr "Velké mapy"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
-msgid "View only maps of size large (108x108)."
+#, fuzzy
+msgid "View only maps of size large (108 x 108)."
 msgstr "Zobrazí pouze mapy velikosti \"velká\" (108x108)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
 msgid "Extra Large Maps"
 msgstr "Velmi velké mapy"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
-msgid "View only maps of size extra large (144x144)."
+#, fuzzy
+msgid "View only maps of size extra large (144 x 144)."
 msgstr "Zobrazí pouze mapy velikosti \"velmi velká\" (144x144)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "All Maps"
 msgstr "Všechny mapy"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "View all maps, regardless of size."
 msgstr "Zobrazí všechny mapě nezávisle na velikosti."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
 msgid "Players Icon"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
 msgid ""
-"Indicates how many players total are in the EditScenario. Any positions not "
+"Indicates how many players total are in the scenario. Any positions not "
 "occupied by humans will be occupied by computer players."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
 msgid "Size Icon"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
 msgid ""
-"Indicates whether the maps is small (36x36), medium (72x72), large "
-"(108x108), or extra large (144x144)."
+"Indicates whether the map\n"
+"is small (36 x 36), medium\n"
+"(72 x 72), large (108 x 108),\n"
+"or extra large (144 x 144)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "Selected Name"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "The name of the currently selected map."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid "Selected Map Difficulty"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid ""
 "The map difficulty of the currently selected map.  The map difficulty is "
-"determined by the EditScenario designer. More difficult maps might include "
-"more or stronger enemies, fewer resources, or other special conditions "
-"making things tougher for the human player."
+"determined by the scenario designer. More difficult maps might include more "
+"or stronger enemies, fewer resources, or other special conditions making "
+"things tougher for the human player."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "Selected Description"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "The description of the currently selected map."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
-msgid "OK"
-msgstr "OK"
+msgid "Okay"
+msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
 msgid "Accept the choice made."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:364
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose all your heroes and towns."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:365
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific town."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:366
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific hero."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:367
 msgid "Run out of time. Fail to win by a certain point."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:370
 msgid "Loss Condition"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:379
 msgid "Defeat all enemy heroes and towns."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:380
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Capture a specific town."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:381
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat a specific hero."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:382
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Find a specific artifact."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:383
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Your side defeats the opposing side."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:384
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Accumulate a large amount of gold."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:387
 msgid "Victory Condition"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:48
-#: ../fheroes2/heroes/heroes_action.cpp:134
 msgid "one"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:51
-#: ../fheroes2/heroes/heroes_action.cpp:135
 msgid "two"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:187
-msgid "sound"
-msgstr "zvuk"
-
-#: ../fheroes2/dialog/dialog_system.cpp:192
-#: ../fheroes2/dialog/dialog_system.cpp:205
-#: ../fheroes2/dialog/dialog_system.cpp:228
-#: ../fheroes2/dialog/dialog_system.cpp:242
-msgid "off"
-msgstr "off"
-
-#: ../fheroes2/dialog/dialog_system.cpp:200
-msgid "music"
+#, fuzzy
+msgid "Music"
 msgstr "hudba"
 
-#: ../fheroes2/dialog/dialog_system.cpp:223
-msgid "hero speed"
+msgid "Toggle ambient music level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:237
+msgid "Effects"
+msgstr ""
+
+msgid "Toggle foreground sounds level."
+msgstr ""
+
+msgid "Music Type"
+msgstr ""
+
+msgid "Change the type of music."
+msgstr ""
+
 #, fuzzy
-msgid "ai speed"
+msgid "Hero Speed"
 msgstr "Rychlost"
 
-#: ../fheroes2/dialog/dialog_system.cpp:251
-msgid "scroll speed"
+msgid "Change the speed at which your heroes move on the main screen."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:262
-#: ../fheroes2/dialog/dialog_system.cpp:276
+#, fuzzy
+msgid "Enemy Speed"
+msgstr "Rychlost"
+
+msgid ""
+"Sets the speed that A.I. heroes move at.  You can also elect not to view A."
+"I. movement at all."
+msgstr ""
+
+msgid "Scroll Speed"
+msgstr ""
+
+msgid "Sets the speed at which you scroll the window."
+msgstr ""
+
+#, fuzzy
+msgid "Interface Type"
+msgstr "Rozhraní"
+
+msgid "Toggle the type of interface you want to use."
+msgstr ""
+
 msgid "Interface"
 msgstr "Rozhraní"
 
-#: ../fheroes2/dialog/dialog_system.cpp:265
+msgid "Toggle interface visibility."
+msgstr ""
+
+msgid "Battles"
+msgstr ""
+
+msgid "Toggle instant battle mode."
+msgstr ""
+
+msgid "OK"
+msgstr "OK"
+
+#, fuzzy
+msgid "Exit this menu."
+msgstr "Přeskočit tuto jednotku"
+
+msgid "off"
+msgstr "off"
+
+msgid "MIDI"
+msgstr ""
+
+#, fuzzy
+msgid "MIDI Expansion"
+msgstr "Zámek"
+
+msgid "CD Stereo"
+msgstr ""
+
+msgid "External"
+msgstr ""
+
+msgid "Jump"
+msgstr ""
+
+msgid "Don't Show"
+msgstr ""
+
 msgid "Evil"
 msgstr "Zlý"
 
-#: ../fheroes2/dialog/dialog_system.cpp:267
 msgid "Good"
 msgstr "Dobrý"
 
-#: ../fheroes2/dialog/dialog_system.cpp:281
 #, fuzzy
 msgid "Hide"
 msgstr "Horda"
 
-#: ../fheroes2/dialog/dialog_system.cpp:287
 #, fuzzy
 msgid "Show"
 msgstr "Sníh"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:285
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:96
+msgid "Auto Resolve"
+msgstr ""
+
+msgid "Auto, No Spells"
+msgstr ""
+
+msgid "Manual"
+msgstr ""
+
+msgid "Att."
+msgstr ""
+
+msgid "Def."
+msgstr ""
+
+msgid "Power"
+msgstr ""
+
+#, fuzzy
+msgid "Knowl"
+msgstr "Znalosti"
+
+msgid "Human"
+msgstr ""
+
 msgid "1st"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:286
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:97
 msgid "2nd"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:98
 msgid "3rd"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:288
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:99
 msgid "4th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:289
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:100
 msgid "5th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:290
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:101
 msgid "6th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:305
-msgid "Thieves' Guild: Player RanKings"
+msgid "Oracle: Player Rankings"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:315
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:114
+#, fuzzy
+msgid "Thieves' Guild: Player Rankings"
+msgstr "Cech zlodějů"
+
 msgid "Number of Towns:"
 msgstr "Počet měst:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:324
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:123
 msgid "Number of Castles:"
 msgstr "Počet hradů:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:333
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:132
 msgid "Number of Heroes:"
 msgstr "Počet hrdinů:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:342
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:141
 msgid "Gold in Treasury:"
 msgstr "Zlato v pokladici:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:351
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:150
 msgid "Wood & Ore:"
 msgstr "Dřevo & Ruda:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:360
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:159
 msgid "Gems, Cr, Slf & Mer:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:369
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:168
 msgid "Obelisks Found:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:378
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:177
+#, fuzzy
+msgid "Artifacts:"
+msgstr "Artefakt"
+
 msgid "Total Army Strength:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:408
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:211
+msgid "Income:"
+msgstr "Příjem:"
+
 msgid "Best Hero:"
 msgstr "Nejlepší hrdina:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:417
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:220
 msgid "Best Hero Stats:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:426
 msgid "Personality:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:435
 msgid "Best Monster:"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Easy"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Normal"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Hard"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Expert"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Impossible"
 msgstr ""
 
-#: ../fheroes2/game/game.cpp:314
-msgid "Maps Loading..."
+msgid "Map is loading..."
 msgstr ""
 
-#: ../fheroes2/game/game_highscores.cpp:239
-#: ../fheroes2/game/game_highscores.cpp:242
+msgid "and more..."
+msgstr ""
+
+msgid "Campaign Scenario loading failure"
+msgstr ""
+
+msgid "Please make sure that campaign files are correct and present."
+msgstr ""
+
 msgid "Unknown Hero"
 msgstr ""
 
-#: ../fheroes2/game/game_highscores.cpp:240
 msgid "Your Name"
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:95
-msgid "Are you sure you want to overwrite the save with this name?"
+msgid ""
+"Invalid file game type. Please ensure that you are running the latest type "
+"of save files."
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:191
 msgid ""
-"This file is saved in the \"Price Loyalty\" version.\n"
+"This file is saved in the \"The Price of Loyalty\" version.\n"
 "Some items may be unavailable."
 msgstr ""
 
-#: ../fheroes2/game/game_mainmenu.cpp:157
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:95
-msgid "Quit"
-msgstr "Ukončit"
-
-#: ../fheroes2/game/game_mainmenu.cpp:157
-msgid "Quit Heroes of Might and Magic and return to the operating system."
-msgstr "Ukončí Heroes of Might and Magic a vrátí se do operačního systému."
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:79
-msgid "Load Game"
-msgstr "Načíst hru"
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-msgid "Load a previously saved game."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:91
-msgid "Credits"
-msgstr "Autoři"
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-msgid "View the credits screen."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:87
-msgid "High Scores"
-msgstr "Nejlepší výsledky"
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-msgid "View the high score screen."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:75
-msgid "New Game"
-msgstr "Nová hra"
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-msgid "Start a single or multi-player game."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid "Host"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid ""
-"The host sets up the game options. There can only be one host per network "
-"game."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid "Guest"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid ""
-"The guest waits for the host to set up the game, then is automatically added "
-"in. There can be multiple guests for TCP/IP games."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-msgid "Cancel back to the main menu."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:214
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:154
-msgid "Standard Game"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:214
-msgid "A single player game playing out a single map."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:216
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:162
-msgid "Multi-Player Game"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:216
-msgid ""
-"A multi-player game, with several human players completing against each "
-"other on a single map."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:217
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:83
-msgid "Settings"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:217
-msgid "FHeroes2 game settings."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:271
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:219
 msgid "Hot Seat"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:271
 msgid ""
 "Play a Hot Seat game, where 2 to 4 players play around the same computer, "
 "switching into the 'Hot Seat' when it is their turn."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:279
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:223
+msgid "Cancel back to the main menu."
+msgstr ""
+
 msgid "Network"
 msgstr "Síť"
 
-#: ../fheroes2/game/game_newgame.cpp:279
 msgid ""
 "Play a network game, where 2 players use their own computers connected "
 "through a LAN (Local Area Network)."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:343
+msgid "Standard Game"
+msgstr ""
+
+msgid "A single player game playing out a single map."
+msgstr ""
+
+msgid "Campaign Game"
+msgstr ""
+
+msgid "A single player game playing through a series of maps."
+msgstr ""
+
+msgid "Multi-Player Game"
+msgstr ""
+
+msgid ""
+"A multi-player game, with several human players completing against each "
+"other on a single map."
+msgstr ""
+
+msgid "Greetings!"
+msgstr ""
+
+msgid ""
+"Welcome to Free Heroes of Might and Magic II! Before starting the game "
+"please choose game resolution."
+msgstr ""
+
+msgid "Please Remember"
+msgstr ""
+
+msgid "You can always change game resolution by clicking on the "
+msgstr ""
+
+msgid "door"
+msgstr ""
+
+msgid ""
+" on the left side of main menu.\n"
+"\n"
+"To switch between windowed and full screen modes\n"
+"press "
+msgstr ""
+
+msgid "F4"
+msgstr ""
+
+msgid ""
+" key on the keyboard.\n"
+"\n"
+"Enjoy the game!"
+msgstr ""
+
+msgid "Quit Heroes of Might and Magic and return to the operating system."
+msgstr "Ukončí Heroes of Might and Magic a vrátí se do operačního systému."
+
+msgid "Credits"
+msgstr "Autoři"
+
+msgid "View the credits screen."
+msgstr ""
+
+msgid "High Scores"
+msgstr "Nejlepší výsledky"
+
+msgid "View the high score screen."
+msgstr ""
+
+msgid "Select Game Resolution"
+msgstr ""
+
+msgid "Change resolution of the game."
+msgstr ""
+
+msgid "Original Campaign"
+msgstr ""
+
+msgid ""
+"Either Roland's or Archibald's campaign from the original Heroes of Might "
+"and Magic II."
+msgstr ""
+
+msgid "Expansion Campaign"
+msgstr ""
+
+msgid "One of the four new campaigns from the Price of Loyalty expansion set."
+msgstr ""
+
+msgid "Host"
+msgstr ""
+
+msgid ""
+"The host sets up the game options. There can only be one host per network "
+"game."
+msgstr ""
+
+msgid "Guest"
+msgstr ""
+
+msgid ""
+"The guest waits for the host to set up the game, then is automatically added "
+"in. There can be multiple guests for TCP/IP games."
+msgstr ""
+
+msgid "Battle Only"
+msgstr ""
+
+msgid "Setup and play a battle without loading any map."
+msgstr ""
+
+msgid "Settings"
+msgstr ""
+
+msgid "Experimental game settings."
+msgstr ""
+
 msgid "2 Players"
 msgstr "2 hráči"
 
-#: ../fheroes2/game/game_newgame.cpp:343
 msgid ""
 "Play with 2 human players, and optionally, up, to 4 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid "3 Players"
 msgstr "3 hráči"
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid ""
 "Play with 3 human players, and optionally, up, to 3 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid "4 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid ""
 "Play with 4 human players, and optionally, up, to 2 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid "5 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid ""
 "Play with 5 human players, and optionally, up, to 1 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "6 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "Play with 6 human players."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat all enemy heroes and capture all enemy towns and castles."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Run out of time. (Fail to win by a certain point.)"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the castle '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the town '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:83
 msgid "Defeat the hero '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:91
 msgid "Find the ultimate artifact"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:95
 msgid "Find the '%{name}' artifact"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:102
 msgid "Accumulate %{count} gold"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:106
 msgid ""
 ", or you may win by defeating all enemy heroes and capturing all enemy towns "
 "and castles."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the castle '%{name}'."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the town '%{name}'."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:126 ../fheroes2/game/game_over.cpp:145
 msgid "Lose the hero: %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:133
 msgid "Fail to win by the end of month %{month}, week %{week}, day %{day}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:145
 msgid "Lose the heroes: %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:167
 msgid ""
 "You captured %{name}!\n"
 "You are victorious."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:175
 msgid ""
 "You have captured the enemy hero %{name}!\n"
 "Your quest is complete."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:183
 msgid ""
 "You have found the %{name}.\n"
 "Your quest is complete."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:195
 msgid ""
 "The enemy is beaten.\n"
 "Your side has triumphed!"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:200
 msgid ""
 "You have built up over %{count} gold in your treasury.\n"
 "All enemies bow before your wealth and power."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:222
 msgid ""
 "The enemy has found the %{name}.\n"
 "Your quest is a failure."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:230
 msgid ""
 "%{color} has fallen!\n"
 "All is lost."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:237
 msgid ""
 "The enemy has built up over %{count} gold in his treasury.\n"
 "You must bow done in defeat before his wealth and power."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:243
 msgid "You have been eliminated from the game!!!"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:248
 msgid ""
 "The enemy has captured %{name}!\n"
 "They are triumphant."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:257 ../fheroes2/game/game_over.cpp:264
 msgid ""
 "You have lost the hero %{name}.\n"
 "Your quest is over."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:272
 msgid ""
 "You have failed to complete your quest in time.\n"
 "All is lost."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:320
-msgid "%{color} has been vanquished!"
+msgid "%{color} player has been vanquished!"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "Warning"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "No maps available!"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Scenario"
 msgstr "Scénář"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Click here to select which scenario to play."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid "Game Difficulty"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid ""
 "This lets you change the starting difficulty at which you will play. Higher "
 "difficulty levels start you of with fewer resources, and at the higher "
 "settings, give extra resources to the computer."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid "Difficulty Rating"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid ""
 "The difficulty rating reflects a combination of various settings for your "
 "game. This number will be applied to your final score."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
 msgid "Click to accept these settings and start a new game."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
 msgid "Click to return to the main menu."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:342
 msgid "Scenario:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:350
 msgid "Game Difficulty:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:354
 msgid "Opponents:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:358
 msgid "Class:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:384
 msgid "Rating %{rating}%"
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:226
 msgid "Astrologers proclaim Month of the %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:226
 msgid "Astrologers proclaim Week of the %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:240
 msgid "After regular growth, population of %{monster} is doubled!"
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:252
 msgid " All populations are halved."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:254
 msgid " All dwellings increase population."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:283
 msgid ""
 "%{color} player, your heroes abandon you, and you are banished from this "
 "land."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:290
 msgid ""
 "%{color} player, this is your last day to capture a town, or you will be "
 "banished from this land."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:295
 msgid ""
 "%{color} player, you only have %{day} days left to capture a town, or you "
 "will be banished from this land."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:584
-msgid "%{color} player's turn"
+msgid "%{color} player's turn."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:995
 msgid ""
 "%{color} player, you have lost your last town. If you do not conquer another "
 "town in next week, you will be eliminated."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Next Hero"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Select the next Hero."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue Movement"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue the Hero's movement along the current path."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "Kingdom Summary"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "View a Summary of your Kingdom."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:189
 msgid "Cast an adventure spell."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End Turn"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End your turn and left the computer take its turn."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Adventure Options"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Bring up the adventure options menu."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "File Options"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "Bring up the file options menu, alloving you to load menu, save etc."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "System Options"
 msgstr "Nastavení systému"
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "Bring up the system options menu, alloving you to customize your game."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:175
 msgid ""
 "One or more heroes may still move, are you sure you want to end your turn?"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:212
-msgid "Are you sure you want to restart? (Your current game will be lost)"
-msgstr ""
-
-#: ../fheroes2/gui/interface_events.cpp:276
 msgid "Are you sure you want to quit?"
 msgstr "Opravdu chcete skončit?"
 
-#: ../fheroes2/gui/interface_events.cpp:308
+#, fuzzy
+msgid "Are you sure you want to restart? (Your current game will be lost.)"
+msgstr "Jsi si jist, že chceš utéct?"
+
+msgid "Are you sure you want to overwrite the save with this name?"
+msgstr ""
+
 msgid "Game saved successfully."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:314
-msgid ""
-"Are you sure you want to load a new game? (Your current game will be lost)"
+msgid "There was an issue during saving."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:353
+msgid ""
+"Are you sure you want to load a new game? (Your current game will be lost.)"
+msgstr ""
+
 msgid "Try looking on land!!!"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:368
 msgid ""
-"After spending many hours digging here, you have uncovered the %{artifact}"
+"After spending many hours digging here, you have uncovered the %{artifact}."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:370
 msgid "Congratulations!"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:384
 msgid "Nothing here. Where could it be?"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:395
 msgid "Try searching on clear ground."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:399
 msgid "Digging for artifacts requires a whole day, try again tomorrow."
 msgstr ""
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "World Map"
 msgstr ""
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "A miniature view of the known world. Left click to move viewing area."
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:216
 msgid "Month: %{month} Week: %{week}"
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:222
-#: ../fheroes2/kingdom/kingdom_overview.cpp:569
 msgid "Day: %{day}"
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:257
 msgid ""
 "You find a small\n"
 "quantity of %{resource}."
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:407
 msgid "Status Window"
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:407
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date."
+msgstr ""
+
 msgid ""
 "This window provides information on the status of your hero or kingdom, and "
 "shows the date. Left click here to cycle throungh these windows."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:112
+msgid "Necroman"
+msgstr ""
+
+msgid ""
+"This lets you change player starting positions and colors. A particular "
+"color will always start in a particular location. Some positions may only be "
+"played by a computer player or only by a human player."
+msgstr ""
+
+msgid ""
+"This lets you change the class of a player. Classes are not always "
+"changeable. Depending on the scenario, a player may receive additional towns "
+"and/or heroes not of their primary alignment."
+msgstr ""
+
+msgid "%{color} player"
+msgstr ""
+
+#, fuzzy
+msgid "View %{skill} Info"
+msgstr "Zobrazit informace o %{name}."
+
+msgid "Lord Kilburn"
+msgstr ""
+
+msgid "Sir Gallant"
+msgstr ""
+
+msgid "Ector"
+msgstr ""
+
+msgid "Gwenneth"
+msgstr ""
+
+msgid "Tyro"
+msgstr ""
+
+msgid "Ambrose"
+msgstr ""
+
+msgid "Ruby"
+msgstr ""
+
+msgid "Maximus"
+msgstr ""
+
+msgid "Dimitry"
+msgstr ""
+
+msgid "Thundax"
+msgstr ""
+
+msgid "Fineous"
+msgstr ""
+
+msgid "Jojosh"
+msgstr ""
+
+msgid "Crag Hack"
+msgstr ""
+
+msgid "Jezebel"
+msgstr ""
+
+msgid "Jaclyn"
+msgstr ""
+
+msgid "Ergon"
+msgstr ""
+
+msgid "Tsabu"
+msgstr ""
+
+msgid "Atlas"
+msgstr ""
+
+msgid "Astra"
+msgstr ""
+
+msgid "Natasha"
+msgstr ""
+
+msgid "Troyan"
+msgstr ""
+
+msgid "Vatawna"
+msgstr ""
+
+msgid "Rebecca"
+msgstr ""
+
+msgid "Gem"
+msgstr ""
+
+msgid "Ariel"
+msgstr ""
+
+msgid "Carlawn"
+msgstr ""
+
+msgid "Luna"
+msgstr ""
+
+msgid "Arie"
+msgstr ""
+
+msgid "Alamar"
+msgstr ""
+
+msgid "Vesper"
+msgstr ""
+
+msgid "Crodo"
+msgstr ""
+
+msgid "Barok"
+msgstr ""
+
+msgid "Kastore"
+msgstr ""
+
+msgid "Agar"
+msgstr ""
+
+msgid "Falagar"
+msgstr ""
+
+msgid "Wrathmont"
+msgstr ""
+
+msgid "Myra"
+msgstr ""
+
+msgid "Flint"
+msgstr ""
+
+msgid "Dawn"
+msgstr ""
+
+msgid "Halon"
+msgstr ""
+
+msgid "Myrini"
+msgstr ""
+
+msgid "Wilfrey"
+msgstr ""
+
+msgid "Sarakin"
+msgstr ""
+
+msgid "Kalindra"
+msgstr ""
+
+msgid "Mandigal"
+msgstr ""
+
+msgid "Zom"
+msgstr ""
+
+msgid "Darlana"
+msgstr ""
+
+msgid "Zam"
+msgstr ""
+
+msgid "Ranloo"
+msgstr ""
+
+msgid "Charity"
+msgstr ""
+
+msgid "Rialdo"
+msgstr ""
+
+msgid "Roxana"
+msgstr ""
+
+msgid "Sandro"
+msgstr ""
+
+msgid "Celia"
+msgstr ""
+
+msgid "Roland"
+msgstr ""
+
+msgid "Lord Corlagon"
+msgstr ""
+
+msgid "Sister Eliza"
+msgstr ""
+
+msgid "Archibald"
+msgstr ""
+
+msgid "Lord Halton"
+msgstr ""
+
+msgid "Brother Brax"
+msgstr ""
+
+msgid "Solmyr"
+msgstr ""
+
+msgid "Dainwin"
+msgstr ""
+
+msgid "Mog"
+msgstr ""
+
+msgid "Joseph"
+msgstr ""
+
+msgid "Gallavant"
+msgstr ""
+
+msgid "Elderian"
+msgstr ""
+
+msgid "Ceallach"
+msgstr ""
+
+msgid "Drakonia"
+msgstr ""
+
+msgid "Martine"
+msgstr ""
+
+msgid "Jarkonas"
+msgstr ""
+
+msgid "%{object} robber"
+msgstr ""
+
+msgid "%{object} raided"
+msgstr ""
+
+msgid "You cannot pick up this artifact, you already have a full load!"
+msgstr ""
+
+msgid "The three Anduran artifacts magically combine into one."
+msgstr ""
+
+msgid "To cast spells, you must first buy a spell book for %{gold} gold."
+msgstr ""
+
+msgid "Unfortunately, you seem to be a little short of cash at the moment."
+msgstr ""
+
+msgid "Do you wish to buy one?"
+msgstr ""
+
 msgid "%{count} / day"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:331
-#: ../fheroes2/heroes/heroes_action.cpp:2199
 msgid "You are unable to recruit at this time, your ranks are full."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:599
-msgid ""
-"A group of %{monster} with a desire for greater glory wish to join you.\n"
-"Do you accept?"
+msgid "A whirlpool engulfs your ship."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:609
-#: ../fheroes2/heroes/heroes_action.cpp:630
+msgid "Some of your army has fallen overboard."
+msgstr ""
+
 msgid "Insulted by your refusal of their offer, the monsters attack!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:638
 msgid ""
 "The %{monster}, awed by the power of your forces, begin to scatter.\n"
 "Do you wish to pursue and engage them?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:934
 msgid "Ransacking an enemy camp, you discover a hidden cache of treasures."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:966
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with these resources, "
 "come back next week for more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:967
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there are no resources currently available. Please try "
 "again next week.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:972
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with this gold, come "
 "back next week for more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:973
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there is no gold currently available. Please try again "
 "next week.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:979
 msgid ""
 "You've found an abandoned lean-to.\n"
 "Poking about, you discover some resources hidden nearby."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:980
 msgid "The lean-to is long abandoned. There is nothing of value here."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:985
 msgid ""
 "You catch a leprechaun foolishly sleeping amidst a cluster of magic "
 "mushrooms.\n"
@@ -2675,177 +2964,143 @@ msgid ""
 "precious things."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:986
 msgid ""
 "You've found a magic garden, the kind of place that leprechauns and faeries "
 "like to cavort in, but there is no one here today.\n"
 "Perhaps you should try again next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1023
 msgid "You come upon the remains of an unfortunate adventurer."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1034
 #, fuzzy
 msgid "Treasure"
 msgstr "Poklady"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1041
 msgid "Searching through the tattered clothing, you find %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1052
 msgid "Searching through the tattered clothing, you find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1064
 msgid ""
 "You come across an old wagon left by a trader who didn't quite make it to "
 "safe terrain."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1075
-#: ../fheroes2/heroes/heroes_action.cpp:1103
 msgid "Unfortunately, others have found it first, and the wagon is empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1082
 msgid "Searching inside, you find the %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1093
 msgid "Inside, you find some of the wagon's cargo still intact."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1123
 msgid "You search through the flotsam, and find some wood and some gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1124
 msgid "You search through the flotsam, and find some wood."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1130
 msgid "You search through the flotsam, but find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1151
 msgid "Shrine of the 1st Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1152
 msgid ""
 "You come across a small shrine attended by a group of novice acolytes.\n"
-"In exchange for your protection, they agree to teach you a simple spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a simple spell - "
+"'%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1155
 msgid "Shrine of the 2nd Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1156
 msgid ""
 "You come across an ornate shrine attended by a group of rotund friars.\n"
-"In exchange for your protection, they agree to teach you a spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a spell - "
+"'%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1159
 msgid "Shrine of the 3rd Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1160
 msgid ""
 "You come across a lavish shrine attended by a group of high priests.\n"
 "In exchange for your protection, they agree to teach you a sophisticated "
 "spell - '%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1173
 msgid ""
 "\n"
 "Unfortunately, you have no Magic Book to record the spell with."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1184
 msgid ""
 "\n"
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1192
 msgid ""
 "\n"
 "Unfortunately, you already have knowledge of this spell, so there is nothing "
 "more for them to teach you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1215
 msgid ""
-"You approach the hut and observe a witch inside studying an ancient tome on %"
-"{skill}.\n"
+"You approach the hut and observe a witch inside studying an ancient tome on "
+"%{skill}.\n"
 " \n"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1222
 msgid ""
 "As you approach, she turns and focuses her one glass eye on you.\n"
 "\"You already know everything you deserve to learn!\" the witch screeches. "
 "\"NOW GET OUT OF MY HOUSE!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1229
 msgid ""
 "As you approach, she turns and speaks.\n"
 "\"You already know that which I would teach you. I can help you no further.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1236
 msgid ""
 "An ancient and immortal witch living in a hut with bird's legs for stilts "
 "teaches you %{skill} for her own inscrutable purposes."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1255
 msgid "You drink from the enchanted fountain, but nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1256
 msgid "As you drink the sweet water, you gain luck for your next battle."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1260
 msgid "You enter the faerie ring, but nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1261
 msgid ""
 "Upon entering the mystical faerie ring, your army gains luck for its next "
 "battle."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1265
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "It is supposed to grant luck to visitors, but since the stars are already "
 "smiling upon you, it does nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1266
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "Kissing it is supposed to be lucky, so you do. The stone is very cold to the "
 "touch."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1270
 msgid "The mermaids silently entice you to return later and be blessed again."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1271
 msgid ""
 "The magical, soothing beauty of the Mermaids reaches you and your crew.\n"
 "Just for a moment, you forget your worries and bask in the beauty of the "
@@ -2853,7 +3108,6 @@ msgid ""
 "The mermaids charms bless you with increased luck for your next combat."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1303
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "You are tempted to search it for treasure, but all the old stories warn of "
@@ -2861,470 +3115,375 @@ msgid ""
 "Will you search?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1304
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "Routine exploration reveals that the pyramid is completely empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1329
 msgid "Unfortunately, you have no Magic Book to record the spell with."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1333
 msgid ""
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1337
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
 "telling the secret of the spell."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1374 ../fheroes2/maps/mp2.cpp:469
 msgid "Sign"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1385
 msgid ""
 "A drink at the well is supposed to restore your spell points, but you are "
 "already at maximum."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1392
 msgid "A second drink at the well in one day will not help you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1399
 msgid "A drink from the well has restored your spell points to maximum."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1424
 msgid ""
 "\"I'm sorry sir,\" The leader of the soldiers says, \"but you already know "
 "everything we have to teach.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1425
 msgid "The soldiers living in the fort teach you a few new defensive tricks."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1430
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. \"You're too "
 "advanced for us,\" the mercenary captain says. \"We can teach nothing more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1431
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. The mercenaries "
 "welcome you and your troops and invite you to train with them."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1436
 msgid "\"Go 'way!\", the witch doctor barks, \"you know all I know.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1437
 msgid ""
 "An Orcish witch doctor living in the hut deepens your knowledge of magic by "
 "showing you how to cast stones, read portents, and decipher the intricacies "
 "of chicken entrails."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1442
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, the Druids turn you away, indicating they have nothing "
 "new to teach you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1443
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, they teach you new ways to cast spells."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1479
 msgid ""
 "You tentatively approach the burial ground of ancient warriors. Do you want "
 "to search the graves?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1480
 msgid ""
 "Upon defeating the Zombies you spend several hours searching the graves and "
 "find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1481
-msgid "Upon defeating the zomies you search the graves and find something!"
+msgid "Upon defeating the Zombies you search the graves and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1484
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the shipwreck?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1485
 msgid ""
 "Upon defeating the Ghosts you spend several hours sifting through the debris "
 "and find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1486
 msgid ""
 "Upon defeating the Ghosts you sift through the debris and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1489
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the ship?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1490
 msgid ""
 "Upon defeating the Skeletons you spend several hours sifting through the "
 "debris and find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1491
 msgid ""
 "Upon defeating the Skeletons you sift through the debris and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1564
 msgid "Your men spot a navigational buoy, confirming that you are on course."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1565
 msgid ""
 "Your men spot a navigational buoy, confirming that you are on course and "
 "increasing their morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1569
 msgid ""
 "The drink at the oasis is refreshing, but offers no further benefit. The "
 "oasis might help again if you fought a battle first."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1570
 msgid ""
 "A drink at the oasis fills your troops with strength and lifts their "
 "spirits.  You can travel a bit further today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1575
 msgid ""
 "The drink at the watering hole is refreshing, but offers no further benefit. "
 "The watering hole might help again if you fought a battle first."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1576
 msgid ""
 "A drink at the watering hole fills your troops with strength and lifts their "
 "spirits. You can travel a bit further today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1581
 msgid ""
 "It doesn't help to pray twice before a battle. Come back after you've fought."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1582
 msgid "A visit and a prayer at the temple raises the morale of your troops."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1622
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"I am sorry, my liege, I "
 "have taught you all I can.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1623
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"My liege, I will teach "
 "you all that I know to aid you in your travels.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1662
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
 "ocean. Grateful, he says, \"I would give you an artifact as a reward, but "
 "you're all full.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1669
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
-"ocean. Grateful, he rewards you for your act of kindness by giving you the %"
-"{art}."
+"ocean. Grateful, he rewards you for your act of kindness by giving you the "
+"%{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1688 ../fheroes2/heroes/heroes.cpp:941
-msgid "You have no room to carry another artifact!"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:1704
 msgid "A leprechaun offers you the %{art} for the small price of %{gold} Gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1709
 msgid ""
-"A leprechaun offers you the %{art} for the small price of %{gold} Gold and %"
-"{count} %{res}."
+"A leprechaun offers you the %{art} for the small price of %{gold} Gold and "
+"%{count} %{res}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1718
 msgid "Do you wish to buy this artifact?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1731
 msgid ""
 "You try to pay the leprechaun, but realize that you can't afford it. The "
 "leprechaun stamps his foot and ignores you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1735
 msgid ""
 "Insulted by your refusal of his generous offer, the leprechaun stamps his "
 "foot and ignores you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1746
-#: ../fheroes2/heroes/heroes_action.cpp:1821
 msgid "You've found the artifact: "
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1756
 msgid ""
 "You've found the humble dwelling of a withered hermit. The hermit tells you "
 "that he is willing to give the %{art} to the first wise person he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1759
 msgid ""
 "You've come across the spartan quarters of a retired soldier. The soldier "
 "tells you that he is willing to pass on the %{art} to the first true leader "
 "he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1780
 msgid ""
 "You come upon an ancient artifact. As you reach for it, a pack of Rogues "
 "leap out of the brush to guard their stolen loot."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1783
 msgid ""
 "Through a clearing you observe an ancient artifact. Unfortunately, it's "
 "guarded by a nearby %{monster}. Do you want to fight the %{monster} for the "
 "artifact?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1798
 msgid "Victorious, you take your prize, the %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1810
 msgid ""
 "Discretion is the better part of valor, and you decide to avoid this fight "
 "for today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1866
-#: ../fheroes2/heroes/heroes_action.cpp:1881
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold pieces."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1872
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold and the %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1888
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it, "
 "only to find it empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1898
 msgid ""
 "After scouring the area, you fall upon a hidden treasure cache. You may take "
 "the gold or distribute the gold to the peasants for experience. Do you wish "
 "to keep the gold?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1912
 msgid ""
-"After scouring the area, you fall upon a hidden chest, containing the %"
-"{gold} gold pieces."
+"After scouring the area, you fall upon a hidden chest, containing the "
+"%{gold} gold pieces."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1918
 msgid ""
 "After scouring the area, you fall upon a hidden chest, containing the "
 "ancient artifact %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1942
 msgid ""
 "You stumble upon a dented and tarnished lamp lodged deep in the earth. Do "
 "you wish to rub the lamp?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "A whirlpool engulfs your ship."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "Some of your army has fallen overboard."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2045
 msgid ""
 "You come upon an abandoned gold mine. The mine appears to be haunted. Do you "
 "wish to enter?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2064
 msgid ""
 "You have taken control of the local Alchemist shop. It will provide you with "
 "%{count} unit of Mercury per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2070
 msgid ""
 "You gain control of a sawmill. It will provide you with %{count} units of "
 "wood per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2081
+msgid "You beat the Ghosts and are able to restore the mine to production."
+msgstr ""
+
 msgid ""
 "You gain control of an ore mine. It will provide you with %{count} units of "
 "ore per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2083
 msgid ""
 "You gain control of a sulfur mine. It will provide you with %{count} unit of "
 "sulfur per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2085
 msgid ""
 "You gain control of a crystal mine. It will provide you with %{count} unit "
 "of crystal per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2087
 msgid ""
 "You gain control of a gem mine. It will provide you with %{count} unit of "
 "gems per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2089
 msgid ""
 "You gain control of a gold mine. It will provide you with %{count} gold per "
 "day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2096
-msgid "You beat the Ghosts and are able to restore the mine to production."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2101
 msgid ""
 "The lighthouse is now under your control, and all of your ships will now "
 "move further each turn."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2105
 msgid "You gain control of a %{name}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2188
 msgid ""
 "A group of %{monster} with a desire for greater glory wish to join you. Do "
 "you accept?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2215
 msgid "As you approach the dwelling, you notice that there is no one here."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2232
 msgid ""
 "You search the ruins, but the Medusas that used to live here are gone. "
 "Perhaps there will be more next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2233
 msgid ""
 "You've found some Medusas living in the ruins. They are willing to join your "
 "army for a price. Do you want to recruit Medusas?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2238
 msgid ""
 "You've found a Sprite Tree City. Unfortunately, none of the Sprites living "
 "there wish to join an army. Maybe next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2239
 msgid ""
 "Some of the Sprites living in the tree city are willing to join your army "
 "for a price. Do you want to recruit Sprites?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2244
 msgid ""
 "A colorful Rogues' wagon stands empty here. Perhaps more Rogues will be here "
 "later."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2245
 msgid ""
 "Distant sounds of music and laughter draw you to a colorful wagon housing "
 "Rogues. Do you wish to have any Rogues join your army?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2250
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. The "
 "tents are unoccupied. Perhaps more Nomads will be here later."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2251
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. Do you "
 "wish to have any Nomads join you during your travels?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2256
 msgid "The pit of mud bubbles for a minute and then lies still."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2257
 msgid ""
 "As you approach the bubbling pit of mud, creatures begin to climb out and "
 "position themselves around it. In unison they say: \"Mother Earth would like "
 "to offer you a few of her troops. Do you want to recruit Earth Elementals?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2261
 msgid "You enter the structure of white stone pillars, and find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2262
 msgid ""
 "White stone pillars support a roof that rises up to the sky. As you enter "
 "the structure, the dead air of the outside gives way to a whirling gust that "
@@ -3334,192 +3493,159 @@ msgid ""
 "air?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2266
 msgid "No Fire Elementals approach you from the lava pool."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2267
 msgid ""
 "Beneath a structure that serves to hold in heat, Fire Elementals move about "
 "in a fiery pool of molten lava. A group of them approach you and offer their "
 "services. Would you like to recruit Fire Elementals?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2271
 msgid "A face forms in the water for a moment, and then is gone."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2272
 msgid ""
 "Crystalline structures cast shadows over a small reflective pool of water. "
 "You peer into the pool, and a face that is not your own peers back. It asks: "
 "\"Would you like to call upon the powers of water?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2276
 msgid "This burial site is deathly still."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2277
 msgid ""
 "Restless spirits of long dead warriors seeking their final resting place "
 "offer to join you in hopes of finding peace. Do you wish to recruit ghosts?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2313
 msgid ""
 "The City of the Dead is empty of life, and empty of unlife as well. Perhaps "
 "some undead will move in next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2314
 msgid ""
 "Some Liches living here are willing to join your army for a price. Do you "
 "want to recruit Liches?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2315
 msgid ""
 "You've found the ruins of an ancient city, now inhabited solely by the "
 "undead. Will you search?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2316
 msgid ""
 "Some of the surviving Liches are impressed by your victory over their "
 "fellows, and offer to join you for a price. Do you want to recruit Liches?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2320
 msgid ""
 "You've found one of those bridges that Trolls are so fond of living under, "
 "but there are none here. Perhaps there will be some next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2321
 msgid ""
 "Some Trolls living under a bridge are willing to join your army, but for a "
 "price. Do you want to recruit Trolls?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2322
 msgid "Trolls living under the bridge challenge you. Will you fight them?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2323
 msgid ""
 "A few Trolls remain, cowering under the bridge. They approach you and offer "
 "to join your forces as mercenaries. Do you want to buy any Trolls?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2327
 msgid ""
 "The Dragon city has no Dragons willing to join you this week. Perhaps a "
 "Dragon will become available next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2328
 msgid ""
 "The Dragon city is willing to offer some Dragons for your army for a price. "
 "Do you wish to recruit Dragons?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2329
 msgid ""
 "You stand before the Dragon City, a place off-limits to mere humans. Do you "
 "wish to violate this rule and challenge the Dragons to a fight?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2330
 msgid ""
 "Having defeated the Dragon champions, the city's leaders agree to supply "
 "some Dragons to your army for a price. Do you wish to recruit Dragons?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2389
 msgid "From the observation tower, you are able to see distant lands."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2401
 msgid ""
 "The spring only refills once a week, and someone's already been here this "
 "week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2407
 msgid ""
 "A drink at the spring is supposed to give you twice your normal spell "
 "points, but you are already at that level."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2418
 msgid ""
 "A drink from the spring fills your blood with magic! You have twice your "
 "normal spell points in reserve."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2437
 msgid ""
 "Recognizing you, the butler refuses to admit you. \"The master,\" he says, "
 "\"will not see the same student twice.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2457
 msgid ""
 "The butler admits you to see the master of the house. He trains you in the "
 "four skills a hero should know."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2467
 msgid ""
 "The butler opens the door and looks you up and down. \"You are neither "
 "famous nor diplomatic enough to be admitted to see my master,\" he sniffs. "
 "\"Come back when you think yourself worthy.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2510
 msgid ""
 "All of the %{monsters} you have in your army have been trained by the battle "
 "masters of the fort. Your army now contains %{monsters2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2513
 msgid ""
-"An unusual alliance of Orcs, Ogres, and Dwarves offer to train (upgrade) any "
+"An unusual alliance of Ogres, Orcs, and Dwarves offer to train (upgrade) any "
 "such troops brought to them. Unfortunately, you have none with you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2524
 msgid "All of your %{monsters} have been upgraded into %{monsters2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2527
 msgid ""
 "A blacksmith working at the foundry offers to convert all Pikemen and "
 "Swordsmen's weapons brought to him from iron to steel. He also says that he "
-"knows a process that will convert Iron Golems into Steel Golems.  "
+"knows a process that will convert Iron Golems into Steel Golems. "
 "Unfortunately, you have none of these troops in your army, so he can't help "
 "you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2585
 msgid ""
 "A retired captain living on this refurbished fishing platform offers to sell "
 "you maps of the sea he made in his younger days for 1,000 gold. Do you wish "
 "to buy the maps?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2598
 msgid ""
 "The captain sighs. \"You don't have enough money, eh?  You can't expect me "
 "to give my maps away for free!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2632
 msgid "You find %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2655
 msgid ""
 "You come upon an obelisk made from a type of stone you have never seen "
 "before. Staring at it intensely, the smooth surface suddenly changes to an "
@@ -3527,56 +3653,51 @@ msgid ""
 "copy down the piece and the inscription vanishes as abruptly as it appeared."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2659
 msgid "You have already been to this obelisk."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2671
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"It is good to see "
 "you, my student. I hope my teachings have helped you.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2683
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"Ahh, an "
 "adventurer! Allow me to teach you a little of what I have learned over the "
 "ages.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2692
 msgid "Upon your approach, the tree opens its eyes in delight."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2694
 msgid ""
 "\"Ahh, an adventurer! I will be happy to teach you a little of what I have "
 "learned over the ages for a mere %{count} %{res}.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2696
 msgid "(Just bury it around my roots.)"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2703
 msgid "Tears brim in the eyes of the tree."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2705
 msgid "\"I need %{count} %{res}.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2707
 msgid "it whispers. (sniff) \"Well, come back when you can pay me.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2737
+msgid ""
+"Nestled among the trees sits a blind seer. After explaining the intent of "
+"your journey, the seer activates his crystal ball, allowing you to see the "
+"strengths and weaknesses of your opponents."
+msgstr ""
+
 msgid ""
 "The entrance to the cave is dark, and a foul, sulfurous smell issues from "
 "the cave mouth. Will you enter?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2749
 msgid ""
 "You find a powerful and grotesque Demon in the cave. \"Today,\" it rasps, "
 "\"you will fight and surely die. But I will give you a choice of deaths. You "
@@ -3584,71 +3705,59 @@ msgid ""
 "servants?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2759
 msgid ""
 "Upon defeating the daemon's servants, you find a hidden cache with %{count} "
 "gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2774
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and receive %{exp} experience points."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2784
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and find the %{art} in the back of the cave."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2794
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
-"battle, you slay the monster and receive %{exp) experience points and %"
-"{count} gold."
+"battle, you slay the monster and receive %{exp} experience points and "
+"%{count} gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2809
 msgid ""
 "The Demon leaps upon you and has its claws at your throat before you can "
 "even draw your sword. \"Your life is mine,\" it says. \"I will sell it back "
 "to you for %{count} gold.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2810
 msgid ""
 "Seeing that you do not have %{count} gold, the demon slashes you with its "
 "claws, and the last thing you see is a red haze."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2835
 msgid "Except for evidence of a terrible battle, the cave is empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2860
 msgid "For %{gold} gold, the alchemist will remove it for you. Do you pay?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2871
 msgid ""
 "You hear a voice from behind the locked door, \"You don't have enough gold "
 "to pay for my services.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2874
 msgid ""
 "You hear a voice from high above in the tower, \"Go away! I can't help you!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2886
 msgid ""
 "The head groom approaches you and speaks, \"You already have a fine horse, "
 "and have no inexperienced cavalry which might make use of our trained war "
 "horses.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2889
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, his "
@@ -3657,7 +3766,6 @@ msgid ""
 "mounted soldiers, but you have none we can help.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2892
 msgid ""
 "The head groom speaks to you, \"That is a fine looking horse you have. I am "
 "afraid we can give you no better, but the horses your cavalry are riding "
@@ -3665,7 +3773,6 @@ msgid ""
 "would aid your riders greatly. I insist you take them.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2895
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, he will "
@@ -3673,17 +3780,14 @@ msgid ""
 "mounted soldiers, their horses look shoddy and weak.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2922
 msgid "The Arena guards turn you away."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2939
 msgid ""
 "As the sirens sing their eerie song, your small, determined army manages to "
 "overcome the urge to dive headlong into the sea."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2944
 msgid ""
 "You have your crew stop up their ears with wax before the sirens' eerie song "
 "has any chance of luring them to a watery grave. An eerie wailing song "
@@ -3692,57 +3796,52 @@ msgid ""
 "for the visit, and gain %{exp} experience."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2964
 msgid ""
 "In a dazzling display of daring, you break into the local jail and free the "
 "hero imprisoned there, who, in return, pledges loyalty to your cause."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2980
 msgid ""
 "You already have %{count} heroes, and regretfully must leave the prisoner in "
 "this jail to languish in agony for untold days."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2991
 msgid ""
 "You enter a rickety hut and talk to the magician who lives there. He tells "
 "you of places near and far which may aid you in your journeys."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3004
 msgid "This eye seems to be intently studying its surroundings."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3015
 msgid ""
 "\"I have a riddle for you,\" the Sphinx says. \"Answer correctly, and you "
 "shall be rewarded. Answer incorrectly, and you shall be eaten. Do you accept "
 "the challenge?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3017
-msgid "The Sphinx asks you the following riddle: %{riddle}. Your answer?"
+msgid ""
+"The Sphinx asks you the following riddle:\n"
+" \n"
+"'%{riddle}'\n"
+" \n"
+"Your answer?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3025
 msgid ""
 "Looking somewhat disappointed, the Sphinx sighs. You've answered my riddle "
 "so here's your reward. Now begone."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3052
 msgid ""
 "\"You guessed incorrectly,\" the Sphinx says, smiling. The Sphinx swipes at "
 "you with a paw, knocking you to the ground. Another blow makes the world go "
 "black, and you know no more."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3060
 msgid "You come across a giant Sphinx. The Sphinx remains strangely quiet."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3073
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -3750,7 +3849,6 @@ msgid ""
 "As you speak the magic word, the glowing barrier dissolves into nothingness."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3083
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -3758,7 +3856,6 @@ msgid ""
 "You speak, and nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3093
 msgid ""
 "You enter the tent and see an old woman gazing into a magic gem. She looks "
 "up and says,\n"
@@ -3766,422 +3863,85 @@ msgid ""
 "oracle taught me his skill. I have the answer you seek.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_base.cpp:401
 msgid ""
 "That spell costs %{mana} mana. You only have %{point} mana, so you can't "
 "cast the spell."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Lord Kilburn"
+msgid "%{name} the %{race} (Level %{level})"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Sir Gallanth"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ector"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Gwenneth"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Tyro"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ambrose"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ruby"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Maximus"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Dimitry"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Thundax"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Fineous"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jojosh"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Crag Hack"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jezebel"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jaclyn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Ergon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Tsabu"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Atlas"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Astra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Natasha"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Troyan"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Vatawna"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Rebecca"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Gem"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Ariel"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Carlawn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Luna"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Arie"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61 ../fheroes2/resource/maps_text.cpp:59
-msgid "Alamar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Vesper"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Crodo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Barok"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Kastore"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Agar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Falagar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Wrathmont"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Flint"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Dawn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Halon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myrini"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Wilfrey"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Sarakin"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63 ../fheroes2/resource/maps_text.cpp:377
-msgid "Kalindra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Mandigal"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zom"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Darlana"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zam"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Ranloo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Charity"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Rialdo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Roxana"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65 ../fheroes2/resource/maps_text.cpp:557
-msgid "Sandro"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Celia"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:552
-msgid "Roland"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Lord Corlagon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Sister Eliza"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:88
-msgid "Archibald"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:403
-msgid "Lord Halton"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Brother Bax"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Solmyr"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:194
-msgid "Dainwin"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Mog"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:760
-msgid "Uncle Ivan"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:373
-msgid "Joseph"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:285
-msgid "Gallavant"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Elderian"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:179
-msgid "Ceallach"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:229
-msgid "Drakonia"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:422
-msgid "Martine"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:370
-msgid "Jarkonas"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:940
-msgid ""
-"You must purchase a spell book to use the mage guild, but you currently have "
-"no room for a spell book. Try giving one of your artifacts to another hero."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:950
-msgid "The three Anduran artifacts magically combine into one."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1056
-msgid "To cast spells, you must first buy a spell book for %{gold} gold."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1064
-msgid "Unfortunately, you seem to be a little short of cash at the moment."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1078
-msgid "Do you wish to buy one?"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:72
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:55
-msgid "%{name} the %{race} ( Level %{level} )"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:118
 msgid ""
 "'Grouped' combat formation bunches your army together in the center of your "
 "side of the battlefield."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:161
 msgid "Are you sure you want to dismiss this Hero?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:341
 #, fuzzy
 msgid "View Stats"
 msgstr "Hrdinové"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:344
-msgid "View Morale Info"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:347
-msgid "View Luck Info"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:350
 msgid "View Experience Info"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:353
 msgid "View Spell Points Info"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:356
 msgid "Set army combat formation to 'Spread'"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:359
 msgid "Set army combat formation to 'Grouped'"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:362
-msgid "Exit hero"
+msgid "Exit Hero Screen"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:369
-msgid "Dismiss hero"
+msgid "You cannot dismiss a hero in a castle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:373
-msgid "Show prev heroes"
+msgid "Dismissal of %{name} the %{race} is prohibited by scenario"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:376
-msgid "Show next heroes"
+msgid "Dismiss %{name} the %{race}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:379
-msgid "Hero Screen"
+#, fuzzy
+msgid "Show previous hero"
+msgstr "Zobrazit předchozí město"
+
+#, fuzzy
+msgid "Show next hero"
+msgstr "Zobrazit následující město"
+
+#, fuzzy
+msgid "Blood Morale"
+msgstr "Morálka"
+
+msgid "%{morale} Morale"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:39
-msgid "Bad Morale"
+msgid "%{luck} Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:42
-msgid "Neutral Morale"
+msgid "Current Luck Modifiers:"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:47
-msgid "Good Morale"
+msgid "Current Morale Modifiers:"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:61
-msgid "Bad Luck"
+msgid "Entire army is undead, so morale does not apply."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:64
-msgid "Neutral Luck"
+msgid ""
+"Current experience %{exp1}.\n"
+" Next level %{exp2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:69
-msgid "Good Luck"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:113
-#: ../fheroes2/heroes/heroes_indicator.cpp:159
-#: ../fheroes2/heroes/skill.cpp:197
-msgid "Current Modifiers:"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:195
-msgid "Current experience %{exp1} Next level %{exp2}."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:215
 msgid "Level %{level}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:226
 msgid ""
 "%{name} currently has %{point} spell points out of a maximum of %{max}. The "
 "maximum number of spell points is 10 times your knowledge. It is "
@@ -4189,2538 +3949,1449 @@ msgid ""
 "special events."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:65
 msgid "%{name1} meets %{name2}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:396
-#: ../fheroes2/heroes/heroes_meeting.cpp:406
 msgid " and "
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:414
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:417
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:420
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches %"
-"{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches "
+"%{spells2} to %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:431
 msgid "Scholar Ability"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:83 ../fheroes2/spell/spell.cpp:109
 msgid "Town Portal"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:86
 msgid "Select town to port to."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:106
 msgid "Your hero is too tired to cast this spell today. Try again tomorrow."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:187
 msgid "%{spell} failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:236
+msgid "This spell is already in use."
+msgstr ""
+
 msgid "Enemy heroes are now fully identifiable."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:362
-#: ../fheroes2/heroes/heroes_spell.cpp:386
-msgid "No available towns. Spell Failed!!!"
+msgid "This spell cannot be used on a boat."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:459
-msgid "I fear these creatures are in the mood for a fight."
+msgid "This spell can be casted only nearby water."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:463
-msgid "The creatures are willing to join us!"
+msgid ""
+"No available towns.\n"
+"Spell Failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:468
-msgid "All the creatures will join us..."
+msgid ""
+"Nearest town occupied.\n"
+"Spell Failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:480
-msgid "These weak creatures will surely flee before us."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_spell.cpp:489
 msgid ""
 "You must be within %{count} spaces of a monster for the Visions spell to "
 "work."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:506
+msgid "I fear these creatures are in the mood for a fight."
+msgstr ""
+
+msgid "The creatures are willing to join us!"
+msgstr ""
+
+msgid "All the creatures will join us..."
+msgstr ""
+
+msgid "These weak creatures will surely flee before us."
+msgstr ""
+
 msgid ""
 "You must be standing on the entrance to a mine (sawmills and alchemists "
 "don't count) to cast this spell."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:151
-msgid "Power"
-msgstr ""
-
-#: ../fheroes2/heroes/skill.cpp:172
 msgid "Your attack skill is a bonus added to each creature's attack skill."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:177
 msgid "Your defense skill is a bonus added to each creature's defense skill."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:182
 msgid "Your spell power determines the length or power of a spell."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:187
 msgid ""
 "Your knowledge determines how many spell points your hero may have. Under "
-"normal cirumstances, a hero is limited to 10 spell points per level of "
+"normal circumstances, a hero is limited to 10 spell points per level of "
 "knowledge."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
+msgid "Current Modifiers:"
+msgstr ""
+
 msgid "skill|Basic"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
 msgid "skill|Advanced"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
 #, fuzzy
 msgid "skill|Expert"
 msgstr "Expert"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Basic Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Advanced Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Expert Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Basic Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Advanced Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
 #, fuzzy
 msgid "Expert Archery"
 msgstr "Expert"
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Basic Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Advanced Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Expert Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Basic Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Advanced Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Expert Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Basic Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Advanced Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Expert Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Basic Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Advanced Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Expert Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Basic Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Advanced Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Expert Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Basic Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Advanced Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
 #, fuzzy
 msgid "Expert Wisdom"
 msgstr "Expert"
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Basic Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Advanced Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Expert Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Basic Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Advanced Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
 #, fuzzy
 msgid "Expert Luck"
 msgstr "Expert"
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Basic Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Advanced Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Expert Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Basic Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Advanced Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Expert Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Basic Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Advanced Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Expert Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Basic Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Advanced Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 #, fuzzy
 msgid "Expert Estates"
 msgstr "Expert"
 
-#: ../fheroes2/heroes/skill.cpp:406
-msgid "Allows you to negotiate with monsters who are weaker than your group."
+msgid " allows you to negotiate with monsters who are weaker than your group."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:421
-msgid "Allows your hero to learn third level spells."
+msgid "All of the creatures may offer to join you."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:423
-msgid "Allows your hero to learn fourth level spells."
+msgid " allows your hero to learn third level spells."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:425
-msgid "Allows your hero to learn fifth level spells."
+msgid " allows your hero to learn fourth level spells."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:440
+msgid " allows your hero to learn fifth level spells."
+msgstr ""
+
 msgid ""
-"Gives your hero's catapult shots a greater chance to hit and do damage to "
+" gives your hero's catapult shots a greater chance to hit and do damage to "
 "castle walls."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:442
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot has a greater chance "
-"to hit and do damage to castle walls."
+" gives your hero's catapult an extra shot, and each shot has a greater "
+"chance to hit and do damage to castle walls."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:444
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot automatically "
+" gives your hero's catapult an extra shot, and each shot automatically "
 "destroys any wall, except a fortified wall in a Knight town."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:858 ../fheroes2/heroes/skill.cpp:959
-#, fuzzy
-msgid "View %{skill} Info"
-msgstr "Zobrazit informace o %{name}."
-
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:108
 msgid "Blue"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:111
 msgid "Green"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:114
 msgid "Red"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32
 msgid "Yellow"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:112
 msgid "Orange"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:113
 msgid "Purple"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:107
 msgid "Aqua"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:109
 msgid "Brown"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:110 ../fheroes2/resource/resource.cpp:283
 msgid "Gold"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:238
 #, fuzzy
 msgid "Hero/Stats"
 msgstr "Hrdinové"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:241
 #, fuzzy
 msgid "Skills"
 msgstr "Přeskočit"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:244
 #, fuzzy
 msgid "Artifacts"
 msgstr "Artefakt"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:473
 #, fuzzy
 msgid "Town/Castle"
 msgstr "Hrad"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:476
 msgid "Garrison"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:566
 #, fuzzy
 msgid "Gold Per Day:"
 msgstr "Zlato v pokladici:"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Cursed"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Awful"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Bad"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Normal"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Good"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Great"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Irish"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:48
 msgid ""
 "Bad luck sometimes falls on your armies in combat, causing their attacks to "
 "only do half damage."
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:49
 msgid ""
 "Neutral luck means your armies will never get lucky or unlucky attacks on "
 "the enemy."
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:50
 msgid ""
 "Good luck sometimes lets your armies get lucky attacks (double strength) in "
 "combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Treason"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Awful"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Poor"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Normal"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Good"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Great"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Blood!"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:48
 msgid "Bad morale may cause your armies to freeze in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:49
 msgid ""
 "Neutral morale means your armies will never be blessed with extra attacks or "
 "freeze in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:50
 msgid "Good morale may give your armies extra attacks in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Knight"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Barbarian"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Sorceress"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Warlock"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Wizard"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Necromancer"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Multi"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Standing"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Crawling"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Very Slow"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Slow"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Average"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Very Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Ultra Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Blazing"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Instant"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:32
 msgid "week|PLAGUE"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Ant"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Grasshopper"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Dragonfly"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Spider"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Butterfly"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Bumblebee"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Locust"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Earthworm"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Hornet"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Beetle"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Squirrel"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Rabbit"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Gopher"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Badger"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Eagle"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Weasel"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Raven"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Mongoose"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Aardvark"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Lizard"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Tortoise"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Hedgehog"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Condor"
 msgstr ""
 
-#: ../fheroes2/kingdom/world_loadmap.cpp:1424
-msgid "The ultimate artifact is really the %{name}"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1428
-msgid "The ultimate artifact may be found in the %{name} regions of the world."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1433
-msgid "north-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1436
-msgid "north"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1438
-msgid "north-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1444
-#, fuzzy
-msgid "west"
-msgstr "Hnízdo"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1447
-#, fuzzy
-msgid "center"
-msgstr "Stan"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1449
-#, fuzzy
-msgid "east"
-msgstr "Hnízdo"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1454
-msgid "south-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1457
-#, fuzzy
-msgid "south"
-msgstr "zvuk"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1459
-msgid "south-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1463
-msgid "The truth is out there."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1464
-msgid "The dark side is stronger."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1465
-msgid "The end of the world is near."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1466
-msgid "The bones of Lord Slayer are buried in the foundation of the arena."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1467
-msgid "A Black Dragon will take out a Titan any day of the week."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1468
-msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1470
-msgid ""
-"You can load the newest version of game from a site:\n"
-" http://sf.net/projects/fheroes2"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1471
-msgid "This game is now in beta development version. ;)"
-msgstr ""
-
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Desert"
 msgstr "Poušť"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Snow"
 msgstr "Sníh"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Wasteland"
 msgstr "Pustina"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Beach"
 msgstr "Pláž"
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Lava"
 msgstr "Láva"
 
-#: ../fheroes2/maps/ground.cpp:31 ../fheroes2/resource/maps_text.cpp:210
 msgid "Dirt"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Grass"
 msgstr "Tráva"
 
-#: ../fheroes2/maps/ground.cpp:31
-msgid "Water"
-msgstr "Voda"
+msgid "Ocean"
+msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Small"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Medium"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Large"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Extra Large"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Custom Size"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:122
 msgid "Ore Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:123
 msgid "Sulfur Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:124
 msgid "Crystal Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:125
 msgid "Gems Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:126
 msgid "Gold Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:130
 msgid "Mine"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:365
 msgid "Alchemist Lab"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:367
 msgid "Daemon Cave"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:369
 msgid "Faerie Ring"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:373 ../fheroes2/resource/maps_text.cpp:217
 msgid "Dragon City"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:375
-msgid "Light House"
+msgid "Lighthouse"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:377
 msgid "Water Wheel"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:379
 msgid "Mines"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:381
 msgid "Obelisk"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:383
 msgid "Oasis"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:385
 msgid "Sawmill"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:387
 msgid "Oracle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:389
 msgid "Desert Tent"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:393
 msgid "Wagon Camp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:395
 msgid "Windmill"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:397
 msgid "Random Town"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:399
 msgid "Random Castle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:401
 msgid "Watch Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:403
 msgid "Tree City"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:405
 msgid "Tree House"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:407
 msgid "Ruins"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:409
 msgid "Fort"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:411
-msgid "Trading Post"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:413
 msgid "Abandoned Mine"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:415
 msgid "Tree of Knowledge"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:417
 msgid "Witch Doctor's Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:419
 msgid "Temple"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:421
 msgid "Hill Fort"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:423
 msgid "Halfling Hole"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:425
 msgid "Mercenary Camp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:429
 msgid "City of the Dead"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:433
 msgid "Sphinx"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:435
 msgid "Troll Bridge"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:437
 msgid "Witch Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:439
 msgid "Xanadu"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:443
 msgid "Magellan Maps"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:445
 msgid "Derelict Ship"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:447
-msgid "Ship Wreck"
+msgid "Shipwreck"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:449
 msgid "Observation Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:451
-msgid "Freeman Foundry"
+msgid "Freeman's Foundry"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:453
 msgid "Watering Hole"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:455
 msgid "Artesian Spring"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:457
 msgid "Gazebo"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:459
 msgid "Archer's House"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:461
 msgid "Peasant Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:463
 msgid "Dwarf Cottage"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:465
 msgid "Stone Liths"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:467
 msgid "Magic Well"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:468
 msgid "Heroes"
 msgstr "Hrdinové"
 
-#: ../fheroes2/maps/mp2.cpp:470 ../fheroes2/maps/mp2.cpp:488
-msgid "Shrub"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:471
 msgid "Nothing Special"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:472
 msgid "Tar Pit"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:473
-msgid "Coast"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:474
 msgid "Mound"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:475
 msgid "Dune"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:476
 msgid "Stump"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:477
 msgid "Cactus"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:478
 msgid "Trees"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:479
 msgid "Dead Tree"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:480
 msgid "Mountains"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:481
 msgid "Volcano"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:482
 msgid "Rock"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:483
 msgid "Flowers"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:484
 msgid "Water Lake"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:485
 msgid "Mandrake"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:486
 msgid "Crater"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:487
 msgid "Lava Pool"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:489
+msgid "Shrub"
+msgstr ""
+
 msgid "Buoy"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:491 ../fheroes2/monster/monster.cpp:116
 msgid "Skeleton"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:492
 msgid "Treasure Chest"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:493
 msgid "Sea Chest"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:494
 msgid "Campfire"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:495
 msgid "Fountain"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:496
 msgid "Genie Lamp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:497
 msgid "Goblin Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:499
 msgid "Monster"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:500
 msgid "Resource"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:501
 msgid "Whirlpool"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:502
 msgid "Artifact"
 msgstr "Artefakt"
 
-#: ../fheroes2/maps/mp2.cpp:503
 msgid "Boat"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:510
 msgid "Standing Stones"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:514
 msgid "Idol"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:515
 msgid "Shrine of the First Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:516
 msgid "Shrine of the Second Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:517
 msgid "Shrine of the Third Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:518
 msgid "Wagon"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:519
 msgid "Lean To"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:520
 msgid "Flotsam"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:521
 msgid "Shipwreck Survivor"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:522
 msgid "Bottle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:523
 msgid "Magic Garden"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:529
 msgid "Jail"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:531
 msgid "Traveller's Tent"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:532
 msgid "Barrier"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:535
 msgid "Fire Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:537
 msgid "Air Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:539
 msgid "Earth Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:541
 msgid "Water Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:543
 msgid "Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:545
-msgid "Arena"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:547
 msgid "Stables"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:549
 msgid "Alchemist's Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:551
 msgid "Hut of the Magi"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:553
 msgid "Eye of the Magi"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:555
 msgid "Mermaid"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:557
 msgid "Sirens"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:558
 msgid "Reefs"
 msgstr ""
 
-#: ../fheroes2/monster/monster.cpp:59
-msgid "Peasant"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:59 ../fheroes2/resource/maps_text.cpp:501
-msgid "Peasants"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Archer"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Archers"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Ranger"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Rangers"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Pikeman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Pikemen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Veteran Pikeman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Veteran Pikemen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Swordsman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Swordsmen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Master Swordsman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Master Swordsmen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Cavalry"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Cavalries"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Champion"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Champions"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Paladin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Paladins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:69
-msgid "Crusader"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:69
-msgid "Crusaders"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Goblin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Goblins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orc"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orcs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chief"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chiefs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Wolf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Wolves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogre"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogres"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Ogre Lord"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Ogre Lords"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "Troll"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "Trolls"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "War Troll"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "War Trolls"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:80
-msgid "Cyclops"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:80
-msgid "Cyclopes"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Sprite"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Sprites"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Dwarf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Dwarves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Battle Dwarf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Battle Dwarves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druid"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druids"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druid"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druids"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorn"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorns"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:91
-msgid "Phoenix"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:91
-msgid "Phoenixes"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaur"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaurs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyle"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyles"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaur"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaurs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur King"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur Kings"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydra"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydras"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halfling"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halflings"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boar"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boars"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golem"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golems"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golem"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golems"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Roc"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Rocs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Mage"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Magi"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmage"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmagi"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:112
-msgid "Giant"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:112 ../fheroes2/resource/maps_text.cpp:293
-msgid "Giants"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titan"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titans"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:116
-msgid "Skeletons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummy"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummy"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampire"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampires"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lord"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lords"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Lich"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Liches"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Lich"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Liches"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogue"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogues"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomad"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomads"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghost"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghosts"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusa"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusas"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elementals"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:694
-msgid "buy"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:158
-msgid "Campaign Game"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "Error"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "This release is compiled without network support."
-msgstr ""
-
-#: ../fheroes2/resource/artifact.cpp:51
 msgid "Ultimate Book of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:51 ../fheroes2/resource/artifact.cpp:77
-#: ../fheroes2/resource/artifact.cpp:78 ../fheroes2/resource/artifact.cpp:79
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "The %{name} increases your knowledge by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:52
 msgid "Ultimate Sword of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:52 ../fheroes2/resource/artifact.cpp:68
-#: ../fheroes2/resource/artifact.cpp:71 ../fheroes2/resource/artifact.cpp:74
-#: ../fheroes2/resource/artifact.cpp:75 ../fheroes2/resource/artifact.cpp:149
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "The %{name} increases your attack skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:53
 msgid "Ultimate Cloak of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:53 ../fheroes2/resource/artifact.cpp:70
-#: ../fheroes2/resource/artifact.cpp:73 ../fheroes2/resource/artifact.cpp:76
 msgid "The %{name} increases your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:54
 msgid "Ultimate Wand of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:54 ../fheroes2/resource/artifact.cpp:59
-#: ../fheroes2/resource/artifact.cpp:60 ../fheroes2/resource/artifact.cpp:61
-#: ../fheroes2/resource/artifact.cpp:62 ../fheroes2/resource/artifact.cpp:148
 msgid "The %{name} increases your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:55
 msgid "Ultimate Shield"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:55 ../fheroes2/resource/artifact.cpp:128
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "The %{name} increases your attack and defense skills by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:56
 msgid "Ultimate Staff"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:56 ../fheroes2/resource/artifact.cpp:130
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "The %{name} increases your spell power and knowledge by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "Ultimate Crown"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "The %{name} increases each of your basic skills by %{count} points."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "Golden Goose"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "The %{name} brings in an income of %{count} gold per turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:59
 msgid "Arcane Necklace of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:60
 msgid "Caster's Bracelet of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:61
 msgid "Mage's Ring of Power"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:62
 msgid "Witch's Broach of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:63
 msgid "Medal of Valor"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:63 ../fheroes2/resource/artifact.cpp:64
-#: ../fheroes2/resource/artifact.cpp:65 ../fheroes2/resource/artifact.cpp:66
 msgid "The %{name} increases your morale."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:64
 msgid "Medal of Courage"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:65
 msgid "Medal of Honor"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:66
 msgid "Medal of Distinction"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "Fizbin of Misfortune"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "The %{name} greatly decreases your morale by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:68
 msgid "Thunder Mace of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "Armored Gauntlets of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "The %{name} increase your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:70
 msgid "Defender Helm of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:71
 msgid "Giant Flail of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "Ballista of Quickness"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "The %{name} lets your catapult fire twice per combat round."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:73
 msgid "Stealth Shield of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:74
 msgid "Dragon Sword of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:75
 msgid "Power Axe of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:76
 msgid "Divine Breastplate of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:77
 msgid "Minor Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:78
 msgid "Major Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:79
 msgid "Superior Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "Foremost Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:81
 msgid "Endless Sack of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:81 ../fheroes2/resource/artifact.cpp:82
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "The %{name} provides you with %{count} gold per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:82
 msgid "Endless Bag of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "Endless Purse of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:84
 msgid "Nomad Boots of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:84 ../fheroes2/resource/artifact.cpp:85
 msgid "The %{name} increase your movement on land."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:85
 msgid "Traveler's Boots of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:86
 msgid "Lucky Rabbit's Foot"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:86 ../fheroes2/resource/artifact.cpp:87
-#: ../fheroes2/resource/artifact.cpp:88 ../fheroes2/resource/artifact.cpp:89
 #, fuzzy
 msgid "The %{name} increases your luck in combat."
 msgstr "Pomník zvyšuje příjem města o 250 za den."
 
-#: ../fheroes2/resource/artifact.cpp:87
 msgid "Golden Horseshoe"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:88
 msgid "Gambler's Lucky Coin"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:89
 msgid "Four-Leaf Clover"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "True Compass of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "The %{name} increases your movement on land and sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "Sailor's Astrolabe of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:91
 #, fuzzy
 msgid "The %{name} increases your movement on sea."
 msgstr "Pomník zvyšuje příjem města o 250 za den."
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "Evil Eye"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "The %{name} reduces the casting cost of curse spells by half."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "Enchanted Hourglass"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "The %{name} extends the duration of all your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "Gold Watch"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "The %{name} doubles the effectiveness of your hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "Skullcap"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "The %{name} halves the casting cost of all mind influencing spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "Ice Cloak"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "The %{name} halves all damage your troops take from cold spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "Fire Cloak"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "The %{name} halves all damage your troops take from fire spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "Lightning Helm"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "The %{name} halves all damage your troops take from lightning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid "Evercold Icicle"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid ""
 "The %{name} causes your cold spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid "Everhot Lava Rock"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid ""
 "The %{name} causes your fire spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid "Lightning Rod"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid ""
 "The %{name} causes your lightning spells to do %{count} percent more damage "
 "to enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "Snake-Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "The %{name} halves the casting cost of all your bless spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid "Ankh"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid ""
 "The %{name} doubles the effectiveness of all your resurrect and animate "
 "spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "Book of Elements"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "The %{name} doubles the effectiveness of all your summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "Elemental Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "The %{name} halves the casting cost of all summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "Holy Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "The %{name} makes all your troops immune to curse spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "Pendant of Free Will"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "The %{name} makes all your troops immune to hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "Pendant of Life"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "The %{name} makes all your troops immune to death spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "Serenity Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "The %{name} makes all your troops immune to berserk spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "Seeing-eye Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "The %{name} makes all your troops immune to blindness spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "Kinetic Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "The %{name} makes all your troops immune to paralyze spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "Pendant of Death"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "The %{name} makes all your troops immune to holy spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "Wand of Negation"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "The %{name} protects your troops from the Dispel Magic spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid "Golden Bow"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid ""
 "The %{name} eliminates the %{count} percent penalty for your troops shooting "
-"past obstacles. (e.g. castle walls)"
+"past obstacles (e.g. castle walls)."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid "Telescope"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid ""
 "The %{name} increases the amount of terrain your hero reveals when "
 "adventuring by %{count} extra square."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid "Statesman's Quill"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid ""
 "The %{name} reduces the cost of surrender to %{count} percent of the total "
 "cost of troops you have in your army."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "Wizard's Hat"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "The %{name} increases the duration of your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "Power Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "The %{name} returns %{count} extra power points/turn to your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "Ammo Cart"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "The %{name} provides endless ammunition for all your troops that shoot."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "Tax Lien"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "The %{name} costs you %{count} gold pieces/turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "Hideous Mask"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "The %{name} prevents all 'wandering' armies from joining your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "Endless Pouch of Sulfur"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "The %{name} provides %{count} unit of sulfur per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "Endless Vial of Mercury"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "The %{name} provides %{count} unit of mercury per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "Endless Pouch of Gems"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "The %{name} provides %{count} unit of gems per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "Endless Cord of Wood"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "The %{name} provides %{count} unit of wood per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "Endless Cart of Ore"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "The %{name} provides %{count} unit of ore per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "Endless Pouch of Crystal"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "The %{name} provides %{count} unit of crystal/day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:128
 msgid "Spiked Helm"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "Spiked Shield"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:130
 msgid "White Pearl"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "Black Pearl"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "Magic Book"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "The %{name} enables you to cast spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "Spell Scroll"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid "Arm of the Martyr"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid ""
 "The %{name} increases your spell power by %{count} but adds the undead "
 "morale penalty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "Breastplate of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "The %{name} increases your defense by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid "Broach of Shielding"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid ""
 "The %{name} provides %{count} percent protection from Armageddon and "
 "Elemental Storm, but decreases spell power by 2."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid "Battle Garb of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid ""
 "The %{name} combines the powers of the three Anduran artifacts.  It provides "
 "maximum luck and morale for your troops and gives you the Town Portal spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid "Crystal Ball"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid ""
 "The %{name} lets you get more specific information about monsters, enemy "
 "heroes, and castles nearby the hero who holds it."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid "Heart of Fire"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid ""
 "The %{name} provides %{count} percent protection from fire, but doubles the "
 "damage taken from cold."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid "Heart of Ice"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid ""
 "The %{name} provides %{count} percent protection from cold, but doubles the "
 "damage taken from fire."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:148
 msgid "Helmet of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:149
 msgid "Holy Hammer"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "Legendary Scepter"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "The %{name} adds %{count} points to all attributes."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "Masthead"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "The %{name} boosts your luck and morale by %{count} each in sea combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "Sphere of Negation"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "The %{name} disables all spell casting, for both sides, in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "Staff of Wizardry"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "The %{name} boosts your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "Sword Breaker"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "The %{name} increases your defense by %{count} and attack by 1."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "Sword of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "Spade of Necromancy"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "The %{name} gives you increased necromancy skill."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:638
 msgid ""
 "You find an elaborate aontainer which housesan old vellum scroll. The runes "
 "on the container are very old, and the artistry with whitch it was put "
@@ -6728,7 +5399,6 @@ msgid ""
 "magical power."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:639
 msgid ""
 "One of the less intelligent members of your party picks up an arm off of the "
 "ground. Despite its missing a body, it is still moving. Your troops find the "
@@ -6737,7 +5407,6 @@ msgid ""
 "making."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:640
 msgid ""
 "You come upon a sign. It reads: \"Here lies the body of Anduran. Bow and "
 "swear fealty, and you shall be rewarded.\" You decide to do as it says. As "
@@ -6745,21 +5414,18 @@ msgid ""
 "that you are suddenly wearing a gleaming, ornate breastplate."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:641
 msgid ""
 "A kindly Sorceress thinks that your army's defenses could use a magical "
 "boost. She offers to enchant the Broach that you wear on your cloak, and you "
 "accept."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:642
 msgid ""
 "Out of pity for a poor peasant, you purchase a chest of old junk they are "
 "hawking for too much gold. Later, as you search through it, you find it "
 "contains the 3 pieces of the legendary battle garb of Anduran!"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:643
 msgid ""
 "You come upon a caravan of gypsies who are feasting and fortifying their "
 "bodies with mead. They call you forward and say \"If you prove that you can "
@@ -6768,7 +5434,6 @@ msgid ""
 "Crystal Ball."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:644
 msgid ""
 "You enter a recently burned glade and come upon a Fire Elemental sitting "
 "atop a rock. It looks up, its flaming face contorted in a look of severe "
@@ -6776,7 +5441,6 @@ msgid ""
 "it, but it passes right through them and sears itself into your chest."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:645
 msgid ""
 "Suddenly, a biting coldness engulfs your body. You seize up, falling from "
 "your horse. The pain subsides, but you still feel as if your chest is "
@@ -6785,7 +5449,6 @@ msgid ""
 "woods and disappear."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:646
 msgid ""
 "You spy a gleaming object poking up out of the ground. You send a member of "
 "your party over to investigate. He comes back with a golden helmet in his "
@@ -6793,7 +5456,6 @@ msgid ""
 "only man who was known to wear solid gold armor."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:647
 msgid ""
 "You come upon a battle where a Paladin has been mortally wounded by a group "
 "of Zombies. He asks you to take his hammer and finish what he started.  As "
@@ -6801,7 +5463,6 @@ msgid ""
 "Zombies lie dead, the hammer dripping with blood. You strap it to your belt."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:648
 msgid ""
 "Upon cresting a small hill, you come upon a ridiculous looking sight. A "
 "Sprite is attempting to carry a Scepter that is almost as big as it is. "
@@ -6810,7 +5471,6 @@ msgid ""
 "flying anyway.\""
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:649
 msgid ""
 "An old seaman tells you a tale of an enchanted masthead that he used in his "
 "youth to rally his crew during times of trouble. He then hands you a faded "
@@ -6818,14 +5478,12 @@ msgid ""
 "underneath a nearby dock."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:650
 msgid ""
 "You stop to help a Peasant catch a runaway mare. To show his gratitude, he "
 "hands you a tiny sphere. As soon as you grasp it, you feel the magical "
 "energy drain from your limbs..."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:651
 msgid ""
 "While out scaring up game, your troops find a mysterious staff levitating "
 "about three feet off of the ground. They hand it to you, and you notice an "
@@ -6833,13 +5491,11 @@ msgid ""
 "words, and you'll win every fight.\""
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:652
 msgid ""
 "A former Captain of the Guard admires your quest and gives you the enchanted "
 "Sword Breaker that he relied on during his tour of duty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:653
 msgid ""
 "A Troll stops you and says: \"Pay me 5,000 gold, or the Sword of Anduran "
 "will slay you where you stand.\" You refuse. The troll grabs the sword "
@@ -6848,4465 +5504,83 @@ msgid ""
 "sharp objects."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:654
 msgid ""
 "A dirty shovel has been thrust into a dirt mound nearby. Upon investigation, "
 "you discover it to be the enchanted shovel of the Gravediggers, long thought "
 "lost by mortals."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:896
 msgid ""
-"Do you want to use your knowledge of magical secrets to transcribe the %"
-"{spell} Scroll into your spell book?\n"
-"The Scroll will be consumed.\n"
-" Spell point: %{sp}"
+"Do you want to use your knowledge of magical secrets to transcribe the "
+"%{spell} Scroll into your Magic Book?\n"
+"The Spell Scroll will be consumed.\n"
+" Cost in spell points: %{sp}"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:960
-msgid "Open book"
+msgid "Transcribe Spell Scroll"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:965
-msgid "Transcribe scroll"
-msgstr ""
+#, fuzzy
+msgid "View Spells"
+msgstr "Hrdinové"
 
-#: ../fheroes2/resource/artifact.cpp:975
-#: ../fheroes2/resource/artifact.cpp:1008
+#, fuzzy
+msgid "View %{name} Info"
+msgstr "Zobrazit %{name}"
+
 #, fuzzy
 msgid "Move %{name}"
 msgstr "Zobrazit %{name}"
 
-#: ../fheroes2/resource/artifact.cpp:998
 msgid "Cannot move artifact"
 msgstr ""
 
-#: ../fheroes2/resource/maps_text.cpp:15
-msgid ""
-"425 bottles of beer on the wall, 425 bottles of beer! If one of those "
-"bottles should happen to fall, there'll be..."
+msgid "This item can't be traded."
 msgstr ""
 
-#: ../fheroes2/resource/maps_text.cpp:16
-msgid "A balanced scenario with lots of resources and land to explore."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:17
-msgid ""
-"A bandit army of gorgons jump you without warning.  they stone your entire "
-"army demand 500 gold before they will release your comrads.  Realizing that "
-"it is much cheeper to pay then rebuild your army you part with the gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:18
-msgid "Abandon All Hope!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:19
-msgid "Abandon All Hope Ye That Enter Here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:20
-msgid "A bit of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:21
-msgid "A bit of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:22
-msgid "A bit of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:23
-msgid ""
-"Above you looms the ancient Ice Palace.  Dimly remembered myth speaks of a "
-"Prince who rejected the advances of the Winter Goddess, and thus he and his "
-"domain were cursed to remain shrouded in ice, hidden in a forgotten corner "
-"of the world.  It is said that he can only be rescued by a hero who is both "
-"clever and bold.  Are you that one?  Do you dare enter this frozen domain?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:24
-msgid "A cache of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:25
-msgid "A cache of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:26
-msgid "A cache of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:27
-msgid "A cache of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:28
-msgid "A cache of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:29
-msgid ""
-"A chance to end a bitter war has finally arrived as a new resource-laden "
-"land has been discovered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:30
-msgid "A chunk of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:31
-msgid "A chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:32
-msgid "A couple of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:33
-msgid "\"Act of Desperation\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:34
-msgid ""
-"A desert isle rich in resources rewards the quick.  Just be sure to watch "
-"your back!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:35
-msgid "A dolphin playfully jumps into the air."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:36
-msgid ""
-"A Dragon, A Cyclops, or an Undead. King of the Centaurs, His name is ....?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:37
-msgid "A flight of dragons circles overhead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:38
-msgid "A flock of seagulls circle overhead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:39
-msgid "A friendly dolphin splashes alongside the ship."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:40
-msgid ""
-"After a long search of the island, I have discovered that there is no way "
-"for me to escape without help.  I can not steal a ship from one of the "
-"coastal castles, and I dare not venture into the desert unless I wish to "
-"become Dragon food.  Should anyone find this, I beg of you, please send a "
-"ship and get me off this cursed island!  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:41
-msgid ""
-"After centuries of friendship, the Wizards have suddenly decided to stop "
-"sharing their Library with the rest of the world.  This can't be good!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:42
-msgid ""
-"After many years of peace, you discover that your sworn enemy from across "
-"the sea has chosen to invade your homeland by raising up the ocean floor to "
-"bridge the distance! You must not let them gain a foothold on this "
-"continent, in fact, your King has ordered you to establish a foothold on "
-"theirs!  To make matters worse, two of your OWN towns have thrown in their "
-"lots with the enemy..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:43
-msgid ""
-"After you return from a scouting trip, your Seneschal hurries to greet you.  "
-"\"My Lord, in your absence I signed an agreement in your name with a Master "
-"Merchant.  If we supply him with the resources he needs, through trading, he "
-"can return the resources to us in a week or so, plus some additional ones."
-"\"  The Seneschal eyes you anxiously.  You hesitate, then nod slowly, "
-"\"Good, we can use more resources>\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:44
-msgid "A ghostly pirate ship appears and sails on by."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:45
-msgid ""
-"A Gift from your King, and a note that reads \"Use these resources wisely, "
-"It's all we have left\"."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:46
-msgid ""
-"A gift of gold, m'lord, from the people of Enroth, to the people of Enroth.  "
-"Good luck, and may God save true King Roland!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:47
-msgid "A glint by a tree catches your eye..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:48
-msgid "A gold cache!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:49
-msgid "A gold chunk!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:50
-msgid "A gold nugget!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:51
-msgid ""
-"A great Black dragon stands before you. It speaks in a suprisingly soft "
-"voice, saying, \"The elves believe they have sent another hero to reclaim "
-"their prize. I believe they have sent me another meal.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:52
-msgid ""
-"A group of peasant farmers approaches you, \"We are in dire need of your "
-"assistance.  Our castle to the north has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:53
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance.  Our castle to the east has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:54
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance. Our castle to the east has been overrun and our Lord killed. "
-"Please help us regain our homes! There are still women and children there! "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:55
-msgid ""
-"A group of peasant farmers approach you, We are in dire need of your "
-"assistance.  Our castle to the northeast has been overrun and our Lord "
-"killed.  Please help us regain our homes!  There are still women and "
-"children there!  Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:56
-msgid "A handful of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:57
-msgid ""
-"Ah, you stumble across something buried in the sand.  As you dig it up you "
-"discover a small pile of gems and crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:58
-msgid ""
-"A Knight and Necromancer team up against the Barbarian and Sorceress. (Blue "
-"and Green vs Red and Yellow)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:60
-msgid ""
-"A large contingent of the king's guard approaches you.  \"Ahh, we have "
-"finally caught up to you.  The king requires tribute from all of his vassals "
-"and you have been negligent far too long.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:61
-msgid ""
-"A large map with lots of resources and treasure. Exploration and victory "
-"will require many heroes."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:62
-msgid "A legion of peasants stands between you and this unclaimed island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:63
-msgid "Algary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:64
-msgid "A little bit closer..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:65
-msgid "All mines are grouped by type. Trade is your only hope."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:66
-msgid "A lump of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:67
-msgid "A lump of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:68
-msgid "A lump of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:69
-msgid ""
-"A man appears from behind the sand dune. \"At last,\" he says, \"Someone has "
-"come to rescue me! I am forever grateful. Alas all I have to offer you in "
-"return are these souvenirs from my wrecked ship.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:70
-msgid ""
-"A man is laying on the ground, near death. He looks to you and speaks, "
-"\"Please help my companions! Please... they can't...cough...get away from..."
-"cough...the drag...\" With that, he dies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:71
-msgid ""
-"A merchant caravan arrives, bringing gold and supplies, however, no one can "
-"seem to remember where they came from.  You silently praise this anonymous "
-"benefactor and continue your duties."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:72
-msgid "a mirror"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:73
-msgid "An albatross flies ahead of the ship for a while"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:74
-msgid "Anduran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:75
-msgid ""
-"An enemy from across the sea has seized half your towns.  Can you put aside "
-"your own feud with your brother to fight this common enemy?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:76
-msgid "\"Annexation\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:77
-msgid ""
-"An old elf is sitting on a rock in a glen, pounding on the shackles on his "
-"feet with a stone. You help him remove them and ask him his tale. \"I'm a "
-"deserter from Drakonia's army. She has enslaved all the elves to support her "
-"madness. She must be stopped.\" Then he slips into the woods without a "
-"sound, leaving behind just his cloak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:78
-msgid "Antioch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:79
-msgid "A piece of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:80
-msgid "A pile of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:81
-msgid "A pile of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:82
-msgid "A pile of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:83
-msgid ""
-"A plague of undead is upon us. Who will unite the living against the dead?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:84
-msgid "\"Apocalypse\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:85
-msgid "A quantity of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:86
-msgid "A quantity of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:87
-msgid "A quantity of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:89
-msgid ""
-"Archibald has also sent an army to find the Crown, you must find it first or "
-"all is lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:90
-msgid "Archibald is hiding at the end of the river."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:91
-msgid ""
-"A resource rich valley keeps the Wizard and the Necromancer apart. Your "
-"opponent's army will arrive in 3 months so hurry."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:92
-msgid "Arm of the Crusader"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:93
-msgid "Arm of the Cyclops"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:94
-msgid "Arm of the Dragon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:95
-msgid "Arm of the Phoenix"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:96
-msgid "Arm of the Titan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:97
-msgid "Arr' Here be pirates gold buried."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:98
-msgid "A shipment of wood has arrived from your kingdom!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:99
-msgid ""
-"A splash in the seaweed alerts you to a mermaid waving in a friendly manner. "
-"\"Oh, I thought you were Ahab.\" She is surprised, but quickly composes "
-"herself. \"Well, if you meet him, give him these treasures I have collected."
-"\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:100
-msgid "Assassins tried to kill our ally."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:101
-msgid "Astircaer"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:102
-msgid ""
-"A stranded Wizard with only a small force must conquer an entire continent "
-"of hostile forces."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:103
-msgid ""
-"A supply ship has arrived from the homeland!  You send word home that all is "
-"well."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:104
-msgid ""
-"As you approach the barrier, you see the old elf you helped free. This time, "
-"however, you see that he is wearing a cape of fine weave, and a wooden crown "
-"is on his head. He sees your forces, and says \"Take this sword, and with "
-"it, strike down Drakonia and help free my people.\" The old elf then strides "
-"regally into the woods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:105
-msgid ""
-"As you approach the gates of the Ice Palace, one of your troops points in "
-"terror.  You watch in awe as great slabs of ice separate from the castle "
-"walls with loud cracking reports and crash to the ground.  Soon the ice is "
-"gone and the sun begins to peak through the gloom.  The deathly silence that "
-"must have ruled these lands for centuries ends as birds begin to sing.  From "
-"inside you hear the sounds of life."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:106
-msgid ""
-"As you approach the tent, the leader of the nomads comes out to greet you. "
-"He says, \"It was prophecied many years ago that a great hero would come to "
-"greet us in our sacred valley, and we would prosper afterwords. Now it has "
-"come to pass, and we offer you these gifts as tokens of our thanks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:107
-msgid ""
-"As you approach,  you hear whispered mentions of \"the wild barbarian who "
-"passed this way months before\". One of the villagers approaches you and "
-"hands you an object, saying \"The wild one dropped this. You must be his "
-"kin. Therefore I give it to you. But beware! Many in the village will not be "
-"as friendly as I.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:108
-msgid ""
-"As you break your fast your sage rushes in, \"Good news, my lord!  I have "
-"translated the message.  Two great heroes were imprisoned many years ago.  "
-"They lie sleeping - still guarded by magic barriers and monsters.  My lord, "
-"they lie nearby- in between our ally and us.  If we could free them, they "
-"would surely aid us against our enemies!  The password to the first magic "
-"barrier can be learned at the Aqua Traveller's Tent.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:109
-msgid ""
-"As you enter the small clearing, you see a familiar figure talking to a "
-"group of halflings and soldiers. You stay awhile and listen to his speech. "
-"\"The time to throw off these chains of tyranny is now! We must strike at "
-"the heart of her empire, and destroy the evil that she has brought to our "
-"land.\" As the old elf finishes speaking, he gets up from his mossy seat and "
-"once again, blends into the woods with incredible grace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:110
-msgid ""
-"As you lay down to nap after a long battle, you notice a lucky four-leaf "
-"clover."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:111
-msgid ""
-"As you make  your way through the last of the golemn debris, a group of "
-"halflings runs towards you carrying fruit and flowers. \"Thank you so much!"
-"\" Their leader exclaims, \"We've been trapped in here for ever! Come by our "
-"homes, we'll pack up and go with you!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:112
-msgid ""
-"As you make your way to the shrine, some very thin and hollow-eyed men come "
-"out of the flower patch and stare at you.  Seeing that you want the gold, "
-"one of them says to you \"Hey, man, if you're, like, so lusty for earthly "
-"wealth, then, like, have this too.\" You graciously take what they have "
-"offered and back out of the clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:113
-msgid ""
-"As you prepare your lands to fight the onslaught from the South, a curious "
-"message appears on your table in the Great Hall of your Castle.  Written in "
-"some ancient language, none but your sage can make any sense of it.  She "
-"promises to have the words deciphered by tomorrow..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:114
-msgid "A three hour tour, a three hour tour..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:115
-msgid ""
-"A tiny gnome points to a chunk of crystal you otherwise would have "
-"overlooked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:116
-msgid "Atlantium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:117
-msgid ""
-"At last, the king is dead.  For years you have planned his demise, but now "
-"it is done, and there is no heir to take his place, though the Knights to "
-"the south believe that they are the rightful successors.  A wealth in wood "
-"(to the south) and ore (in the northern mountains) provides you with trade "
-"goods, and your isolation has allowed you to prepare your forces of darkness "
-"for this day.  Go, now, and fulfill your destiny!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:118
-msgid ""
-"At the base of the mountain you see something that glitters.   You discover "
-"an ancient pile of offerings to the gods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:119
-msgid "Avalon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:120
-msgid "Avone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:121
-msgid ""
-"A wild magic has allowed a bridge to form between two lands...  Your one "
-"hope is to capture castle \"Black Fang\"."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:122
-msgid "Barbarian's castle lies to the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:123
-msgid ""
-"Barbarians from the north threaten all civilization. Can you repel the "
-"hordes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:124
-msgid "\"Barbarian Wars\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:125
-msgid "Barrowton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:126
-msgid "Basenji"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:127
-msgid "Bayside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:128
-msgid "Baywatch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:129
-msgid ""
-"Because the Darkscale Valley is so barren, the Emperor will be sending wood "
-"to you every week. Use it wisely, for it is all you shall have."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:130
-msgid ""
-"Before questing for the orb of negation, you must first crush the local "
-"opposition. After the Sorceresses are removed from the earth, go east where "
-"legend says the orb lies.  You may expect a convoy of supplies in a week or "
-"so to aid your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:131
-msgid ""
-"Before you may pass, the spirit guardian of this valley demands tribute."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:132
-msgid "Being held...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:133
-msgid "Beltway"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:134
-msgid "\"Betrayal!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:135
-msgid "Beware -- Entering Hyrda Country"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:136
-msgid "Beware for whom the bell trolls."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:137
-msgid "Beware of Pirates!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:138
-msgid "Beware of thieves!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:139
-msgid "Beware of traps ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:140
-msgid "Beware of Warlocks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:141
-msgid "Beware the deadly swamps!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:142
-msgid "Beware the Domain of Dragons"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:143
-msgid "Beware the Dragon Leader"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:144
-msgid "Beware the edge of the world!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:145
-msgid "Beware the moors and stick to the roads."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:146
-msgid "Beware the rocks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:147
-msgid "Beware the sirens!!!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:148
-msgid "Beware the sirens!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:149
-msgid "Beware the whiporwill..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:150
-msgid "Beware, the whirlpool may not take you into a friendly embrace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:151
-msgid "Beyond here be Dragons!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:152
-msgid "Beyond the door, there be Dragons. BEWARE!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:153
-msgid "Big Oak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:154
-msgid "Blackburn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:155
-msgid "Blackfang"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:156
-msgid "Black Fang"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:157
-msgid "Black Oak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:158
-msgid "Blackridge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:159
-msgid "Blacksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:160
-msgid "Black Vein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:161
-msgid "Blackwind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:162
-msgid "Bloodreign"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:163
-msgid "Boats my be needed to access some parts of this peninsula."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:164
-msgid "Boats Sold Here            Inquire Within"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:165
-msgid "BoneVille"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:166
-msgid "Borderlands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:167
-msgid "Bridge out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:168
-msgid "Bridge Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:169
-msgid "Brindamoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:170
-msgid "Broken Alliance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:171
-msgid "Brownston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:172
-msgid "Buried Treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:173
-msgid "Burlock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:174
-msgid "Burton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:175
-msgid ""
-"Capture the necromancer's dreaded castle \"Death Gate\" and free the land "
-"from the undead plague."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:176
-msgid ""
-"Capture the town on the island off the southeast shore in order to construct "
-"a boat and travel back towards the mainland."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:177
-msgid "\"Carator Mines\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:178
-msgid "Cathcart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:180
-msgid "Chandler"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:181
-msgid "Chilton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:182
-msgid "Chronos"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:183
-msgid "Come and...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:184
-msgid ""
-"Compared to the rest of the villages in this land, this village seems grand, "
-"but in any other land it would seem poor. From here you can see the tall "
-"spires of the Warlock's tower of Dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:185
-msgid "Complete"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:186
-msgid "Condemned!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:187
-msgid ""
-"Congratulations! After navigating the treacherous coast, you have "
-"established trade between the north and south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:188
-msgid "Corackston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:189
-msgid "Corlagon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:190
-msgid "\"Country Lords\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:191
-msgid "Crossroads"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:192
-msgid "Crossroads North"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:193
-msgid "Crossroads South"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:195
-msgid "Danger a whirlpool destroyed my ship."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:196
-msgid "Danger, Dragons abound!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:197
-msgid "DANGER!  QUICKSAND!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:198
-msgid "Danger! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:199
-msgid "Danger - Turn Back Now"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:200
-msgid "Dark clouds loom overhead as you enter this valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:201
-msgid "Dead Pine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:202
-msgid ""
-"Dear Diary,                           I found a mermaid today.  She was "
-"floating in a patch of seaweed next to a rock.  A very friendly sort of "
-"creature too!  Gave me all sorts of lovely gems and jewelry!  She said to "
-"come back again sometime for more of the sea riches.  Wow. Ahab"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:203
-msgid "Deathgate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:204
-msgid "DeathGate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:205
-msgid "Decisions"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:206
-msgid "\"Defender\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:207
-msgid ""
-"Destroy the Barbarians who are attacking the southern border of your "
-"kingdom! Recover your towns and then invade the jungle kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:208
-msgid ""
-"Detour! Mountain pass to the East has been known to have avalanches! For "
-"your own safety, follow the road South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:209
-msgid "Detour! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:211
-msgid "DirtWater"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:212
-msgid "Dominion"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:213
-msgid "Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:214
-msgid "Do not remove coins from fountain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:215
-msgid "Dragadune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:216
-msgid "Dragonburg"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:218
-msgid "Dragon City lies beyond the Scorpion Hills."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:219
-msgid "Dragon Hill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:220
-msgid "\"Dragon Master\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:221
-msgid "Dragon Rider"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:222
-msgid "Dragons Everywhere!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:223
-msgid "Dragon's Eye"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:224
-msgid "Dragontooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:225
-msgid "Dragon Town"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:226
-msgid "Dragonville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:227
-msgid "Dragon Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:228
-msgid "Dragon Watch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:230
-msgid "Drakoran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:231
-msgid "Dwarfhall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:232
-msgid "Dwarfhall, Domain of the dwarf King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:233
-msgid "Dwarf Hall, domain of the dwarf King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:234
-msgid "Eatio"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:235
-msgid "Edgewood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:236
-msgid "Elk's Head"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:237
-msgid "Elowyn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:238
-msgid "Enroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:239
-msgid "Entering high in the desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:240
-msgid "Entering Praires of the Middlelands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:241
-msgid "Entering the desert high"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:242
-msgid "Entering the high desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:243
-msgid "Entering the higher desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:244
-msgid "Entering the Valley of Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:245
-msgid "Erliquin"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:246
-msgid "Evil Igor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:247
-msgid "Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:248
-msgid "Fantasy Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:249
-msgid "Farlien"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:250
-msgid ""
-"Federal express, when it absolutely positively has to be there turn one."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:251
-msgid "fedx comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:252
-msgid "Fedx for comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:253
-msgid "Fenton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:254
-msgid "Fetid Elm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:255
-msgid ""
-"Final message from Overlord. \"The royal executioners are on their way. My "
-"gold, the land or your head- it's your choice.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:256
-msgid "Find and defeat the Pirate Leader!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:257
-msgid "Find and destroy the evil beings who rule the wastelands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:258
-msgid "Find the center island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:259
-msgid ""
-"Find the Ultimate Artifact and be proclaimed King, or smash the opposition "
-"and take control."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:260
-msgid ""
-"Find Your Wayward Son who is rumored to be living in the desolate lands. Do "
-"it within 8 weeks or it will be of no help to your family."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:261
-msgid "Fire King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:262
-msgid "\"First Blood\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:263
-msgid "Five heroes vie for control of a familiar land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:264
-msgid "Fool's Gold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:265
-msgid ""
-"For a total of 400,000 gold your opponents will become \"loyal\" subjects, "
-"otherwise... let them eat cake!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:266
-msgid ""
-"For centuries, the Wizards of the North have maintained a vast library for "
-"all the world to share.  Now, however, they have closed their doors, and "
-"issued declarations of war to each of the other rulers of the land.  To make "
-"matters worse, rather than ally with you to face the Wizards, each of the "
-"others have decided to go forth on their own in an effort to conquer this "
-"land for themselves!  Prepare your forces, commander, for you now stand "
-"alone."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:267
-msgid "\"Force of Arms\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:268
-msgid ""
-"For decades you have studied, learned, and allowed yourself to be ruled by "
-"that pitiful excuse for a king, knowing that one day the time would come for "
-"you to sit on the throne.  That time is now, for the king is dead and "
-"without an heir.  You have the advantage of isolation from the rest of the "
-"kingdom, but beware the miles of coastline that could leave you vulnerable "
-"to attack.  Go, now, and wipe your enemies from this land!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:269
-msgid "Forder Oaks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:270
-msgid "Forestria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:271
-msgid "For Honor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:272
-msgid ""
-"For information about Ye Rich lands to the south, speak to Alponse at the "
-"Golden Goose Tavern. Excellent views, plentiful water."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:273
-msgid "Forsaken Lands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:274
-msgid "For sale."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:275
-msgid "Fortress Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:276
-msgid ""
-"For years, you have existed peacefully in the Forest of Dreams, knowing that "
-"your king was the kindest and strongest ruler the land had seen in "
-"centuries.  Now, however, his reign is at an end, and there is no heir to "
-"succeed him.  You realize that a power struggle is coming, and that you must "
-"brace yourself for war, and prevent those who would harm this land from "
-"coming into power!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:277
-msgid ""
-"For years, you've been able to keep your subjects \"appeased.\"  Now "
-"however, you discover not only that your entire kingdom has turned against "
-"you, but most of your outer towns have fallen to the different factions.  To "
-"make matters worse, all your gold suddenly seems to be missing from the "
-"treasury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:278
-msgid "Fountainhead"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:279
-msgid "Four kingdoms race to capture the island of Sharkania."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:280
-msgid "Four lakes have castles, three have treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:281
-msgid "Four players must work together to assault the Wizards' Stronghold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:282
-msgid "Frozenpeak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:283
-msgid "Full House"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:284
-msgid ""
-"Gain the aid of the elves. They will not allow trees to be chopped down, so "
-"we will send you wood every 2 weeks. You have 7 months!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:286
-msgid "Galveston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:287
-msgid "Garamok"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:288
-msgid "Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:289
-msgid "Gate to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:290
-msgid "Gate to The Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:291
-msgid "Gaurdian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:292
-msgid "Gavonshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:294
-msgid "Glastonbury"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:295
-msgid "Go away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:296
-msgid "GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:297
-msgid "Goblin Island"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:298
-msgid "Goblin King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:299
-msgid "Go Home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:300
-msgid "Go north to find the lost gold-mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:301
-msgid "Good vs. Evil"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:302
-msgid "Gorgomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:303
-msgid "\"Greater Glory\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:304
-msgid "Greed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:305
-msgid "Green bonus stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:306
-msgid "Green gets stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:307
-msgid "Greenroot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:308
-msgid "Green's Allowance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:309
-msgid "Green's Groceries"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:310
-msgid "green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:311
-msgid "Green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:312
-msgid "Greywind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:313
-msgid "Grim"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:314
-msgid "Grrr, Blazzer, Grrupt. Be gone with you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:315
-msgid "Guardian War"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:316
-msgid "Gungtooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:317
-msgid "Hail Unicorns!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:318
-msgid "Hampshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:319
-msgid "Have fun storming the castle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:320
-msgid "Havenwood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:321
-msgid "Hawkins"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:322
-msgid "Help!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:323
-msgid "Help me...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:324
-msgid ""
-"Help peasant farmers regain their castle and land, else they'll take your "
-"crops."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:325
-msgid "Hero's Hall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:326
-msgid ""
-"High in the snowy crags, you meet an old witch who, in return for a trinket "
-"of yours, gives you a powerful magical object she used to use as a footstool "
-"before she was exiled into the mountains by her own townspeople."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:327
-msgid "Hillstone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:328
-msgid "Hilltop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:329
-msgid "Hilltown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:330
-msgid "Horizon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:331
-msgid "Hot Spot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:332
-msgid "Hungry dragons await.  Welcome, food."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:333
-msgid "Hurry, no time to wait.  This way to the dock."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:334
-msgid "Hurry up! Few days are left before the enemy's army arrives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:335
-msgid "I am...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:336
-msgid ""
-"I am one of the few remaining survivors of the wrecked pleasure ship, "
-"Exhorbitance. I think we'll all be dead of hunger soon, for we are out of "
-"caviar. We ate the chef yesterday."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:337
-msgid "Ibn Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:338
-msgid "Ice Palace"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:339
-msgid "Ice Prince"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:340
-msgid "Icy lands ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:341
-msgid "I didn't do it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:342
-msgid ""
-"If three heroes could dig six holes in three days, how long would it take "
-"six heroes to dig twelve holes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:343
-msgid "If you free a hero, they may help..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:344
-msgid ""
-"If you value your lives, for God's sake, Don't go through this whirlpool!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:345
-msgid "Income for Yellow."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:346
-msgid "In the hole you find a chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:347
-msgid "In the stream you find an old compass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:348
-msgid "In this glen live some very naughty halflings. Stay Away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:349
-msgid ""
-"In two more weeks, if you have not located Joseph, your kingdom will surely "
-"lose its current battle with Harondale."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:350
-msgid "I see you, you see me."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:351
-msgid "Is it something I said? Go back and I will forget the whole thing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:352
-msgid "IslandHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:353
-msgid "Island of the Elves"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:354
-msgid "Island of the meek"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:355
-msgid "Island of Wolcott"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:356
-msgid "Isle Maze"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:357
-msgid "Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:358
-msgid ""
-"It has become apparent that if all your enemies were eliminated, you would "
-"have all the time you need to find the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:359
-msgid ""
-"It is obvious that the mage that once was here had won many battles!  There, "
-"upon his hand, is a most powerful ring!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:360
-msgid ""
-"It is rumored that a bridge of land used to exist between the two "
-"continents, but that a wild magic caused it to sink into the sea, taking "
-"with it all those who used to inhabit it.  To try to raise this bridge is to "
-"invite a curse upon the world!  The spirits of the dead will haunt us all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:361
-msgid ""
-"It is said that King Zealot found the gods' artifact once and it let him "
-"rule for 100 years."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:362
-msgid ""
-"It looks like there used to be an ore mine here but all you see now is a "
-"hole in the ground and some minerals scattered around."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:363
-msgid ""
-"It's a battle for supremacy as the Blue and Green heroes take on Red and "
-"Orange in team competition!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:364
-msgid "It's windy at the top.  Defend, Divide, and Conquer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:365
-msgid "IvanHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:366
-msgid "Ivan lives in the desert."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:367
-msgid "Ivory Gates"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:368
-msgid ""
-"I, Wilgatus, besiege you - do not fight me for I am all powerful and will "
-"destroy you if you persue me.  I will demonstrate my power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:369
-msgid "I Would Go That Way If I Were You."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:371
-msgid "Jarkonas VI"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:372
-msgid "Jolly Roger was here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:374
-msgid "Jungomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:375
-msgid "Just 30 days left!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:376
-msgid "Just ONE week left!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:378
-msgid "Kastor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:379
-msgid "Keep going south"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:380
-msgid "Keep Off The Grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:381
-msgid "Keep Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:382
-msgid "King John"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:383
-msgid "King of Death"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:384
-msgid "Knight's Trail."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:385
-msgid "Knight stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:386
-msgid "Lakeside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:387
-msgid "Land's Edge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:388
-msgid "Land teleporters will get you to your destination sooner."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:389
-msgid "Lankershire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:390
-msgid "Lavalor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:391
-msgid "Like, Stuff And Junk?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:392
-msgid ""
-"Living on the outskirts of the kingdom, you are considered an unwelcome "
-"outcast by the other leaders of the realm, though you always showed your "
-"support for the king.  Now, however, the king is dead, and many of those who "
-"spoke out againt him seek to seize his throne for themselves.  You have a "
-"vast desert at your back, rich with gems, and the advantage that many do not "
-"consider you a threat.  Go, now, and show them how wrong they are!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:393
-msgid "Lladner Dock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:394
-msgid ""
-"Log go up... Log go down... Log go up... Log go down...  OOoohhhhhhhh........"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:395
-msgid "Lombard"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:396
-msgid "Long live Roland the true King!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:397
-msgid "Long live Roland the true King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:398
-msgid "Look before you leap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:399
-msgid "Look out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:400
-msgid "Lord Alberon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:401
-msgid ""
-"Lord Alberon calls you into his war room. He says, \"I am glad you have "
-"chosen to remain loyal to me, but this war is a terrible one for my kingdom. "
-"Already, the sorceress' towns to the Northeast have become unsure about "
-"their loyalties, and will not pledge allegiance to either side. This is hard "
-"on our cities as most of the wood in the land comes from these towns. We "
-"will need to recover their sawmills and take their towns by force.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:402
-msgid "Lord Haart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:404
-msgid "Lord Kreager"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:405
-msgid ""
-"Lord, messages have begun pouring in from our spies in the other island "
-"courts.  They have learned of a new volcanic island with vast amounts of "
-"reasources.  Your Majesty, with these new reasources we could put an end to "
-"a century of war between the islands, and reunite them under your rightful "
-"rule."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:406
-msgid "Lost Continent"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:407
-msgid "Lost Gold- Mine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:408
-msgid "Lost Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:409
-msgid "Lost Relic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:410
-msgid "Maelstrom of Deceit"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:411
-msgid "Maelstrom of Misery"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:412
-msgid "Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:413
-msgid "Magic Three"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:414
-msgid ""
-"Many dust plumes rise from the floor of this small valley. You see various "
-"bands of nomads roaming about, and in the distant, the bright flames of "
-"their camp."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:415
-msgid ""
-"Many guardians stand between you and your enemies, but anybody can sneak "
-"through the back door!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:416
-msgid "Many that have gone through this door have never returned."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:417
-msgid ""
-"Many years ago, a couple of mages had a \"duel\" that forever changed the "
-"lake at the center of this continent.  Hearty adventurers might find "
-"interesting treasure there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:418
-msgid ""
-"Many years ago, a falling star crashed near here.  Only now the area is safe "
-"enough to explore.  Rumor has it a castle exist where the star fell."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:419
-msgid ""
-"Many years ago, your father, the King, died in a freak hunting accident.  "
-"Since then, you and your brother have jointly ruled his kingdom, but both of "
-"you have been seeking a way to seize the throne for yourself.  You got your "
-"wish.  Attackers from across the sea have captured more than half your towns "
-"and castles, effectively dividing the continent in two.  Now is the time to "
-"repel these invaders and do away with your brother once and for all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:420
-msgid "Marco"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:421
-msgid "Marsh Home"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:423
-msgid "Mayland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:424
-msgid "Meramec"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:425
-msgid "Message from Archibald. \" Do not dare to return without my Crown.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:426
-msgid ""
-"Message from Archibald. \" General, thank you for bringing me this lovely "
-"gift. I have decided to participate directly in the capture of my brother "
-"Roland. Since your military advice has taken us this far, I will follow your "
-"orders to the letter.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:427
-msgid "Message from Overlord. \"STILL WAITING FOR MY GOLD!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:428
-msgid "Message from Overlord. \"WHERE'S MY GOLD?\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:429
-msgid ""
-"Message from Roland. \"General, circumstances permit me to take a hand in "
-"the events of this final conflict. I have your spoils of war with me and I "
-"will follow your advice explicitly.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:430
-msgid ""
-"Message from Roland.  \"General, I have sent most of our troops and material "
-"ahead to the region of the final conflict with Archibald.  Unfortunately, "
-"Lord Corlagon has cut us off from the rest of our army.  I will be awaiting "
-"your victory in a castle across the west river.  I should be safe from "
-"attack.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:431
-msgid ""
-"Message from Roland. \" We cannot hope to defeat Archibald without the "
-"Crown, I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:432
-msgid "Middle Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:433
-msgid "Middleton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:434
-msgid "Middletown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:435
-msgid "Might vs. Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:436
-msgid "Mineral Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:437
-msgid "Mirkosov"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:438
-msgid "mirror"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:439
-msgid "Money For Red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:440
-msgid "MONEY, MONEY, MONEY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:441
-msgid "Morale becomes even lower as the endless cliffs move past."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:442
-msgid ""
-"More water than land, you'll still spend lots of time on foot as you search "
-"a literal horde of islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:443
-msgid "Mountain king"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:444
-msgid "Mountainview"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:445
-msgid "Mr Ed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:446
-msgid "Mr. Yellow's Income"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:447
-msgid "Murray's resort Isle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:448
-msgid ""
-"Mutiny!  The crew has dumped off my precious cargo into the sea!  Thank "
-"goodness it floats - when I've rid of them, I'll come back to pick it up!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:449
-msgid ""
-"My leige, our scouts report three other lords are attacking from the south. "
-"They work in conjuction with each other to eliminate us! We must keep this "
-"castle and remove the threat of the enemy. We wish you luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:450
-msgid ""
-"My leige, we have established a foothold (which we cannot afford to lose) "
-"and all of our Heroes have joined us. The king has made us the offer to "
-"purchase this land for 200,000 gold or we may take it by force. The local "
-"lords have been fighting and each wants to be the one that defeats us. Now "
-"all the local armies have arrived on the beach, creating a state of complete "
-"Pandemonium!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:451
-msgid "My Treasure Is Buried Beneath Three Palm Trees"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:452
-msgid "\"Necromancers!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:453
-msgid "New Dawn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:454
-msgid "New Enemies"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:455
-msgid "New Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:456
-msgid "Nightshadow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:457
-msgid "No Description"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:458
-msgid "No Fishing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:459
-msgid "No gems, crystal, or mercury for red."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:460
-msgid ""
-"None of the four leaders like being stuck in a land that has only one season."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:461
-msgid "NO, Not That Way. This Way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:462
-msgid "No one has ever made it out of the deadly swamps alive!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:463
-msgid "Noraston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:464
-msgid "North Road"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:465
-msgid "North vs. South"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:466
-msgid "No stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:467
-msgid "No sulfer fer Yella."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:468
-msgid "No swimming."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:469
-msgid "Notice- Those who put messages in bottles will be tortured."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:470
-msgid "No Trespassing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:471
-msgid "No tresspath...  No tree...  No thresh...  GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:472
-msgid "Now leaving Swamplands of the Eternial"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:473
-msgid "Obsidian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:474
-msgid "Of the necromancers...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:475
-msgid "Ogrehild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:476
-msgid "Olympus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:477
-msgid ""
-"One of the seers in your castle comes to you in the morning with urgent "
-"news. Your one time comrade, the wizard Joseph, and his armies have been "
-"imprisoned in a jail nearby. His power would surely aid you in your quest to "
-"reclaim the library, you think to yourself. Perhaps there is a way to rescue "
-"him..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:478
-msgid ""
-"One of your aides reports that the Castle of Farlien is located on the "
-"northeast spur of this island, and is a stronghold for the enemy. He urges "
-"you to take it out as soon as possible, and then move onto other islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:479
-msgid ""
-"One of your \"allies\" has joined Archibald.  You now face an opponent with "
-"three castles to your one.  Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:480
-msgid ""
-"One of your \"Allies\" has joined Roland. You are now facing three castles, "
-"all belonging to the enemy. Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:481
-msgid "One of your loyal goblins has brought you an armload of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:482
-msgid ""
-"One of your loyal subjects, a fairy tells you where to find a cache of "
-"mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:483
-msgid ""
-"One of your scouts reports a tiny cave nearby. Upon investigating, you "
-"discover a small cache of goods. In the dirt by them is etched 'Ivan'."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:484
-msgid ""
-"One of your troops stubs its paw on something buried here.  After a few "
-"hours of digging you unearth a cache of treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:485
-msgid "Only a month remains in which to find Joseph."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:486
-msgid "On quite days, Nubbie the sea monster can be seen!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:487
-msgid "Orange stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:488
-msgid "Orcville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:489
-msgid "Ostoroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:490
-msgid "Other than the dragons, the elves don't have any enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:491
-msgid "Our ally was greatly weakened when his resources were plundered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:492
-msgid "\"Our Finest Hour\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:493
-msgid "Our reinforcements were lost in a storm, we salvaged all we could!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:494
-msgid ""
-"Our spies have discovered that the barbarian hordes are now receiving "
-"support from kraeger! You must hurry and find the third piece before your "
-"forces here are crushed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:495
-msgid "Overlord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:496
-msgid "Pandemonium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:497
-msgid "Paper can gain you what wood and sail cannot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:498
-msgid "Password found by Crystals to the South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:499
-msgid "Peacekeeper"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:500
-msgid "\"Peasants!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:502
-msgid "Peasantsville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:503
-msgid "Perenor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:504
-msgid "Pet Cemetary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:505
-msgid "Pick one of four Knights in this large and inhospitable land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:506
-msgid "Pig's Eye"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:507
-msgid "Pinehurst"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:508
-msgid "Pirate Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:509
-msgid "Pirate's Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:510
-msgid "Pirate Utopia"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:511
-msgid "Pirites strike and take the gold from you holds."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:512
-msgid "Pixie"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:513
-msgid ""
-"Play the Knight or Barbarian in an alliance in this classic duel against the "
-"four spell casters. (Blue and Green vs Red)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:514
-msgid "Please...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:515
-msgid ""
-"Plenty of resources and lots of ground to cover. Watch out for Orange and "
-"Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:516
-msgid "Portals"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:517
-msgid "Portsmith"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:518
-msgid "POSION - DO NOT DRINK"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:519
-msgid "Powerful magic lies southwest of here in the Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:520
-msgid "Prisoner on...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:522
-msgid "Quick Silver"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:523
-msgid "Raste"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:524
-msgid "Realm of the Undead.  Fresh blood welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:525
-msgid "Red bonus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:526
-msgid "Red player sympathizes with the undead cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:527
-msgid "Red's Connection"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:528
-msgid "Redshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:529
-msgid "Red's Lunch Money"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:530
-msgid "Red's Rubles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:531
-msgid "Red stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:532
-msgid ""
-"Regrettably, you have no castle with which to begin your assault. "
-"Fortunately, however, Kraeger's forces are weak here in the south, and you "
-"have bribed a rebel necromancer to aid you in the beginning of your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:533
-msgid "Reinforcements have arrived, Gold from the homelands!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:534
-msgid ""
-"Remains of a long since dead wizard have attracted an ancient artifact.  "
-"This artifact has now attached itself to you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:535
-msgid ""
-"Remember, you're searching for the Ultimate Artifact... don't get distracted!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:536
-msgid ""
-"Rendall Koski was here. 1997.  Northampton, Massachusetts There is a "
-"powerful artifact in the southeastern corner of the world.  Go for it, "
-"explorer!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:537
-msgid ""
-"Reports from your spies tell of enemies on the march.  As you rush to the "
-"castle courtyard to prepare your armies, you are intercepted by your "
-"Chaplain.  \"My Lord, I have received word that we should send what Heroes "
-"we can to the Isle of Knowledge.   The Scholars there have agreed to teach "
-"them so they will be strong for the battles ahead of us.\"  You thank the "
-"Chaplain for the information and head thoughtfully into the courtyard."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:538
-msgid ""
-"Rescue your crazy Uncle Ivan. Find him within 4 months or it will be no help "
-"to your kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:539
-msgid "Restricted Area, Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:540
-msgid "Rest stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:541
-msgid "Retake the Castle of Ivory Gates."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:542
-msgid "Revolution"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:543
-msgid "Right thinking - he who takes the riskes deserves the rewards."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:544
-msgid "River Crossing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:545
-msgid "Road Ends"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:546
-msgid "Road to Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:547
-msgid "Road to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:548
-msgid "Robbers have looted your treasury and you have lost valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:549
-msgid "Robbers have looted your treasury, stealing valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:550
-msgid "Roc Haven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:551
-msgid "Rogar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:553
-msgid "Roscomon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:554
-msgid "Rotten Birch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:555
-msgid ""
-"Rumors abound and your faithful hero Sandro is now highly regarded by the "
-"masses. Should Sandro desert you, all will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:556
-msgid "Sandcaster"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:558
-msgid "Sands of Time"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:559
-msgid "Sansobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:560
-msgid "\"Save the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:561
-msgid "Scabsdale"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:562
-msgid "Scorched Earth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:563
-msgid ""
-"Scouts have reported a town to the North.  They have also heard some "
-"disturbing news.  Their seems to be a war raging in this area."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:564
-msgid ""
-"Scouts report the enemy's stronghold lies to the Southwest. Our swift "
-"arrival has caught them by surprise. If you move quickly their resistance "
-"will be minimal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:565
-msgid ""
-"Scouts report the notorious necromancer \"Wyrm\" has been sighted to the "
-"northeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:566
-msgid "Scummy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:567
-msgid ""
-"Searching in the dust of this abandoned campsite, you find a magic scroll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:568
-msgid "Seasons Change"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:569
-msgid "Secret Mountain Pass"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:570
-msgid ""
-"Seek out the Ultimate Artifact to be victorious in this strangely shaped "
-"land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:571
-msgid ""
-"Seek the great library, for only with the guidance of the musty tomes therin "
-"will you find the means to reveal and bind the fount to your will."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:572
-msgid "Seven Lakes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:573
-msgid "Sharkania"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:574
-msgid "Sheltemburg"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:575
-msgid "Sherman"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:576
-msgid "Shipwrecked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:577
-msgid ""
-"Should this message ever reach home, please know that this has become a "
-"hostile place since the King's death.  No less than six factions are at war "
-"with each other, each seeking to be the King's successor.  Beware especially "
-"of the Barbarians and the Necromancers who control the north, their regions "
-"are easily defended and they have a wealth of gold and gems.  Do not venture "
-"to this land without a sizeable force.  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:578
-msgid "Sirein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:579
-msgid ""
-"Six factions have established a foothold on a huge, unexplored continent.  "
-"Can you eliminate the other five?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:580
-msgid ""
-"Six heroes with large armies prepare to slug it out for total domination!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:581
-msgid "Skirmish"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:582
-msgid "\"Slay the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:583
-msgid "Slippery when wet."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:584
-msgid "Slugfest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:585
-msgid ""
-"Snagged on a thorny bush, you discover a scrap of cloth. The design on it "
-"looks like the coat of arms of Ivan's house!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:586
-msgid "Snowdrop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:587
-msgid "Somebody has stuffed a pile of gems in the ditch!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:588
-msgid "Some crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:589
-msgid "Some gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:590
-msgid ""
-"Someone has stolen 100 wood and 77 ore from you. Ah, that's nothing. Let's "
-"keep going."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:591
-msgid ""
-"Someone has stolen gold and resources from  the palace treasury!  You "
-"suspect your enemies, but you can't know for certain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:592
-msgid "Someone is playing a pan flute around here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:593
-msgid ""
-"Someone notices a piece of parchment lying behind a clump of grass. You pick "
-"it up. It looks to be a page from a journal, and it reads, \"...made it past "
-"the first guardians. Hopefully will reach the ancient desert city soon. Only "
-"hope my forces are strong enough to survive...\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:594
-msgid "Some ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:595
-msgid "Some sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:596
-msgid ""
-"Some unlucky adventurers have been captured and imprisoned in these lands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:597
-msgid "Sorceress Forest.  Show respect for nature!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:598
-msgid "Sorpigal"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:599
-msgid "South Mill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:600
-msgid "So you think you're smart?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:601
-msgid "Spector"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:602
-msgid "Spell Casters"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:603
-msgid ""
-"Spies report Roland has sent a hero to search for the Crown. If he finds it "
-"first, all is lost!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:604
-msgid "Spirit City"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:605
-msgid "Spy Tower - see what your competition is doing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:606
-msgid "Stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:607
-msgid ""
-"Start with five castles!  How could you lose!?  Oh yeah, everyone else "
-"starts with five, too."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:608
-msgid "Stick to the road!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:609
-msgid "Stromgild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:610
-msgid "Stromhild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:611
-msgid "Stronghold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:612
-msgid "Stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:613
-msgid "Stuff for Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:614
-msgid "Stuff For Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:615
-msgid "Subbaculcha"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:616
-msgid "Sundune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:617
-msgid "Surf and Turf"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:618
-msgid "Swimming near the kelp is a pod of dolphins."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:619
-msgid "Tacma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:620
-msgid "Tchudes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:621
-msgid "Teleporters"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:622
-msgid "Terra Firma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:623
-msgid "Terrain Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:624
-msgid ""
-"The alliance has crumbled and all are at war. Lots of resources but little "
-"time to prepare."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:625
-msgid ""
-"The ancient King Zealot had the artifact of the gods and then hid it in his "
-"old age so that it could not be used by others."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:626
-msgid "The Back Door"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:627
-msgid ""
-"The Barbarian's lands are being invaded. Are you strong enough to resist the "
-"invasion?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:628
-msgid ""
-"The castle of Drakonran in the east has been taken by the barbarians! Two "
-"other towns to the west have also been taken, but the barbarian armies were "
-"fairly decimated in the process."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:629
-msgid "The center island is rumored to harbor great spells."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:630
-msgid "The Citadel"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:631
-msgid "The cities of the plains."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:632
-msgid "The Clearing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:633
-msgid ""
-"The convoy has at long last arrived. Regretably, it has been beset by "
-"bandits on its journey here, and has far less supplies than we had hoped. "
-"Make your way south, for our spies have found rich mines there."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:634
-msgid ""
-"The convoy should have been here by now! Let us hope that it is safe and "
-"still on its way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:635
-msgid ""
-"The country lords have allied and pooled their resources into one command. "
-"Not only have they massed their forces in the north, but they have sent a "
-"knight to the west to steal your supplies. Scouts report a castle to the "
-"east that would be ideal as a base of operations."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:636
-msgid "The crew are unworthy!  I am not going down with the ship! -The Captain"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:637
-msgid "\"The Crown\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:638
-msgid ""
-"The day you have feared has finally arrived.  The king, who you have "
-"faithfully served, has died, leaving no heir to his throne.  As his captain, "
-"you feel that this job should now be yours, but several factions even now "
-"are preparing for conquest.  You are at the center of the trade routes, "
-"having the sea to the south and the great forest to the north.  Go, now, "
-"Commander, and claim what is rightfully yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:639
-msgid ""
-"The diplomats who were sent here ahead of you report that the elves will "
-"only cooperate with you if you will recover the golden bow for them. It was "
-"stolen by their enemies, the Dragons and hidden behind magic barriers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:640
-msgid "The Eastern Town."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:641
-msgid "The edge of the world is your edge.  But prepare to be prepared."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:642
-msgid "The Emerald Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:643
-msgid "The Enchanted Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:644
-msgid "The End of the World is Nigh!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:645
-msgid "The End of the World is Nigh"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:646
-msgid ""
-"The Epic battle against Your Rival! Eliminate everything! Total Warfare! "
-"Don't Lose your first hero!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:647
-msgid ""
-"The Fire King is an ally to the dragons, and will help a friend of theirs."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:648
-msgid "The First One To Take Astircaer Wins!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:649
-msgid ""
-"The first piece of the artifact now lies in the hands of the Unholy Order of "
-"Warlocks. You must annihilate them, and their allies to the north. They will "
-"surely give us what we seek in exchange for their feeble lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:650
-msgid ""
-"The Fortune of Infamous Uae was buried on one of these islands. She died "
-"without ever revealing it.  Find it before the other cutthroats."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:651
-msgid "The four factions race to capture a mystical castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:652
-msgid ""
-"The four spell casters face off with substantial starting armies. Can the "
-"crusaders keep the peace?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:653
-msgid "\"The Gauntlet\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:654
-msgid ""
-"The Gods have given you 6 months to prove yourself. Good or Evil - who shall "
-"prevail? (Blue,Green and Red vs Yellow, Orange and Purple)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:655
-msgid ""
-"The gods have granted this world a great artifact, to find it means victory."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:656
-msgid "The Gods themselves will aid us in this War."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:657
-msgid "The Gold Traveller's Tent is near the Aqua Taveller's Tent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:658
-msgid "The guardians of Dragon Isle reside in the jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:659
-msgid "The Ice Prince stands frozen in some forgotten corner of the world."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:660
-msgid "The island...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:661
-msgid "The Island of Lost Reason"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:662
-msgid "The islands have much wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:663
-msgid "The Isle of Armoria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:664
-msgid "The key to success is rubbing enough lamps."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:665
-msgid ""
-"The King has declared you his hier apparent and champion. You must seek out "
-"and destroy your common enemy, Wilgatus and his Castle, Mirkosov, the source "
-"of his power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:666
-msgid ""
-"The King is dead, his kingdom has been shattered, and six leaders seek to "
-"seize power for themselves."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:667
-msgid "The Kingly Wastes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:668
-msgid "The Kings Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:669
-msgid ""
-"The King will sell you this land for 200,000 gold or you can take it by "
-"force. The choice is yours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:670
-msgid "The land of Heroes II."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:671
-msgid "The Lost Castle of the Ancients"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:672
-msgid ""
-"The mage wars have caused a great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:673
-msgid ""
-"The mage wars have caused great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:674
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trade.  "
-"Plus a little gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:675
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trading.  "
-"Plus a little more gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:676
-msgid ""
-"The Master Merchant arrives at your Castle.  He tells you tall tales of "
-"travel, full of outrageous lies.  He also gives you, your share of the "
-"profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:677
-msgid ""
-"The Master Merchant arrives back at your Castle.  He tells you tall tales of "
-"faraway places full of outrageous lies.  He also gives you, your share of "
-"the profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:678
-msgid "The Medusas have the password and they can be found just to the west."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:679
-msgid "The more there is the less you see."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:680
-msgid "The North Road to Roland's castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:681
-msgid ""
-"The note in this bottle has become mostly indecipherable. All you can make "
-"out are references to deadly pirates, and hidden gold mines."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:682
-msgid "The Other Side"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:683
-msgid ""
-"The Overlord has given you 4 months to conquer this land or deliver to him "
-"the sum of 150,000 gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:684
-msgid ""
-"The people on the Isle of Knowledge are taking up a collection to aid us."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:685
-msgid "The Proving Grounds"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:686
-msgid "The Queen's Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:687
-msgid "The Realm of Air is barred, but you may appeal here for help."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:688
-msgid ""
-"There are remnants of a mighty battle fought here, not too long ago. It "
-"looks as if whoever came this way may have made this their final stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:689
-msgid ""
-"There are three enemy castles to the north. Capture them in the name of "
-"Roland the true king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:690
-msgid ""
-"The Red Tide of War rolls North.  Stopping the flood seems hopeless.  Yet, "
-"Honor demands you and your ally die trying."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:691
-msgid "There is hidden treasure north of the Green Lord's Ore Mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:692
-msgid "There is hidden treasure south of the Blue Lord's Sawmill."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:693
-msgid "There's a warm wind blowing from the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:694
-msgid "There's a Wizard living in the north who is behind this peasant revolt."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:695
-msgid "The Retreat of the Alchemist Doctor Yu"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:696
-msgid ""
-"There used to be a mine here, but it has long since run out of ore.  You are "
-"only able to scavenge 5 units of ore from the old site."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:697
-msgid "There was a shipreck in the far east waters recently."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:698
-msgid "The River Styx"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:699
-msgid "The roars of several dragons echo from the towers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:700
-msgid "The Rock Store."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:701
-msgid "The Royal Gardens."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:702
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:703
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you defend against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:704
-msgid "These doors are a risk the likes of which you do not know."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:705
-msgid "These lands are beholden to Lord Kraeger."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:706
-msgid ""
-"These lands are desolate and for the most part devoid of resources. Not even "
-"the bravest heroes dare to venture into them, and plants are rare and "
-"precious here. Who knows what else awaits?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:707
-msgid ""
-"The Southern Witch is biding her time.  She will strike when your armies are "
-"weak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:708
-msgid "the stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:709
-msgid "The Table in the Great Hall of the Castle is Haunted."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:710
-msgid ""
-"The third piece of the artifact is somewhere to the north, that much we "
-"know. We are still unsure of its exact location, but our spies are out "
-"gathering information. The forces in this area are too strong to be "
-"completely subjugated, so take what you can and hold on to it tightly."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:711
-msgid ""
-"The troops have sworn their allegiance, but should lose a battle they will "
-"lose faith and our cause will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:712
-msgid "The Valley of Aruk."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:713
-msgid ""
-"The Valley of Magic holds many surprises.  You discover an old pair of boots "
-"sticking out of the sand."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:714
-msgid "The Valley of Tresures"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:715
-msgid "The Wasteland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:716
-msgid "The way of magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:717
-msgid "The way of might"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:718
-msgid "The way of numbers"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:719
-msgid "The western town."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:720
-msgid "The winds howl in mourning around the shipwreck."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:721
-msgid "The wizard has an island in the southeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:722
-msgid ""
-"The Wizards who have captured the Necromancers' town have wasted no time in "
-"building defenses designed to stop you, and their last castle has just been "
-"completed. Fortunately only a Captain of the Guard and a small garrison are "
-"currently present.  If you hurry, you should be able to capture the castle "
-"before they have a chance to reinforce it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:723
-msgid "The wood has arrived."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:724
-msgid "The writing on this sign is too faded to read."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:725
-msgid "The Yellow Lord has the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:726
-msgid ""
-"The Yellow Lord is a hothead who will attack before his allies can send him "
-"aid."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:727
-msgid "They say there's mermaids in these waters..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:728
-msgid ""
-"This area is rich in resources. Explore, but beware, a castle left "
-"undefended will quickly fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:729
-msgid ""
-"This area must be secured for the sake of the Empire. Our spies have "
-"reported a discord between The kingdom of the knights to the north, and that "
-"of the oppressive sorceresses to the northeast. Perhaps this feud can be "
-"exploited for our gain..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:730
-msgid "This bottle is empty."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:731
-msgid ""
-"This is the last week you have to find the rebel wizard Joseph! Good Luck in "
-"your quest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:732
-msgid ""
-"This land and all others are now under the sole ownership of Ibn Fadlan, the "
-"Undead King. Any disregard for his magesty's soverign rule is to be punished "
-"by death most horrendous."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:733
-msgid ""
-"This land has been claimed by the nation of Neroli. Interlopers are "
-"UNWELCOME."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:734
-msgid ""
-"This rugged land will have rivals fighting the terrain as well as each other."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:735
-msgid ""
-"This rundown village looks like it was once the epicenter of an enormous, "
-"but now ruined, city. Under a pile of rubble you find an object which looks "
-"like it has lain there for ages."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:736
-msgid ""
-"This spot overlooks an old quarry.  This was one of the only places in the "
-"world where ore could be taken right out of the ground.  Unfortunately the "
-"jungle has reclaimed the quarry and it is unusable.  You collect the last of "
-"the ore and depart."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:737
-msgid ""
-"This twisted maze of sorceress towns has three factions struggling for sole "
-"control.  Use your resources wisely!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:738
-msgid ""
-"This village appears to be in little better shape than the first one you "
-"saw. As you approach the village an old man hands you a slip of paper, with "
-"the following message, \"Joseph lives in the town of IslandHome.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:739
-msgid ""
-"This village is in extremely poor shape. There is no chance of getting more "
-"than some of the lesser creatures here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:740
-msgid "This way to the Necromancer Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:741
-msgid "Those who seek knowledge are welcome to the city of Chronos."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:742
-msgid ""
-"Three Warlocks in the land of Dragons. Lose thy home and all will be lost. "
-"Conquer thy enemies and the land shall forever be yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:743
-msgid "Timberhill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:744
-msgid "Time for a refreshing drink."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:745
-msgid "Time is running out! The enemy's reinforcements are almost here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:746
-msgid "To pass you must pay troll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:747
-msgid "TreeHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:748
-msgid "Trespassers will be EATEN!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:749
-msgid "Trilobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:750
-msgid "Troy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:751
-msgid "Tundara"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:752
-msgid "Turn back, friend, while you still can!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:753
-msgid "Turn Back Now!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:754
-msgid "Turn Back Now or all will be LOST!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:755
-msgid "Turn Back or DIE!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:756
-msgid "Turn Back or else!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:757
-msgid "Turn back, you fool."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:758
-msgid "\"Turning Point\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:759
-msgid ""
-"Uae was the scurviest, pirate ye'd never wanta see. In all her years of "
-"murdering and thieving she amassed so much ill-gotten booty that she "
-"couldn't carry it around in her galleon.  Besides, even the meanest can't "
-"stay awake all the time.  Legend tells that she hid it so well, she was "
-"thinking that she just might forget where it was.  So she left clues around "
-"the islands, carved in stone.  Well, she's dead now.  It's up to you to "
-"recover her legacy."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:761
-msgid "Uncle Leo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:762
-msgid "Uncle Milty"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:763
-msgid "Undead Armies"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:764
-msgid "Unholy Alliance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:765
-msgid "Unite the Tribes. Don't lose your main hero, the first Descendant."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:766
-msgid "Valley of Death"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:767
-msgid "Valley Of The Damned"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:768
-msgid "Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:769
-msgid "Vaultius"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:770
-msgid "Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:771
-msgid "Vikings!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:772
-msgid "Viper's Nest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:773
-msgid "Vulcania"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:774
-msgid "Warrior Knight"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:775
-msgid "Wastelands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:776
-msgid "Watch out for Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:777
-msgid "Waystop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:778
-msgid ""
-"\"We are at the edge of the world!\"  they scream.  \"What are we doing here?"
-"\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:779
-msgid "Weddington"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:780
-msgid "Weed Patch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:781
-msgid ""
-"We found a weakness my lord. Capture castle Black Fang and victory is ours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:782
-msgid ""
-"We have just learned that the artifact is on an island north of this "
-"continent. However, there does not appear to be any means to get there. Stay "
-"very alert for any possible way across the narrow channel."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:783
-msgid ""
-"Welcome back general.  Have you finished the conquest of the northern "
-"lands?  What? you still have not finished your mission!  Get back there and "
-"teach those rebels a lesson!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:784
-msgid "Welcome to Li'l Alctatraz! Vistors NOT welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:785
-msgid ""
-"Welcome to Power Island. He who controls this Isle controls the Seven Lakes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:786
-msgid "Welcome to the Sandbar."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:787
-msgid "Welcome to the sandy Isle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:788
-msgid "Welcome to the sorceress' guild."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:789
-msgid "Welcome to the Spiral Isles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:790
-msgid ""
-"Welcome to the wounderous Kitisland range.  Eruptions each day, beware of "
-"dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:791
-msgid "Welcome to Windfall Island!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:792
-msgid "Welcome to your DOOM!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:793
-msgid "We'll join you - for the right price."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:794
-msgid ""
-"Well placed bribes have won you a stronghold near the warring Barbarians. Be "
-"advised that given their proximity an unguarded castle is an open invitation "
-"to defeat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:795
-msgid "Westfork"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:796
-msgid "Westmoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:797
-msgid "We told you not to drink!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:798
-msgid "What are you doing here?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:799
-msgid "What cannot be seen but only heard, and will not speak until spoken to?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:800
-msgid "What everyday word is most often pronounced incorrectly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:801
-msgid "What goes up and down but never moves?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:802
-msgid ""
-"What good fortune!  You've discovered a long-abandoned settlement.  To your "
-"surprise, you discover that the previous inhabitants left some of their "
-"resources behind when they departed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:803
-msgid "What is always coming but never arrives?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:804
-msgid "What is the Sum of all Numbers from 1 to 200?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:805
-msgid "What is time spent poorly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:806
-msgid "What's another word for pirate treasure?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:807
-msgid "What's behind door number one?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:808
-msgid "What's this? A pile of gems?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:809
-msgid "What's this? Someone has left a pile of wood here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:810
-msgid ""
-"What team won Super Bowl XXI and Super Bowl XXV?  (Hint... a Wizard might "
-"have these troops in his army)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:811
-msgid "What turns everything around but does not move?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:812
-msgid ""
-"What walks in the morning on four legs, two in the afternoon and three in "
-"the evening?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:813
-msgid "What?  What's this?  Something at the bottom of this pool..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:814
-msgid "When you're ready, take the teleport to the Island's Hot Spot!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:815
-msgid ""
-"When you think yourself invincible, walk through this gate.  Even then, "
-"prepare to meet your bitter end."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:816
-msgid "Where am I?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:817
-msgid "While away seeking the Ultimate Artifact, Kastor's kingdom is invaded!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:818
-msgid ""
-"While traveling a mesenger meets you on the road.  His message tells of a "
-"new ally from an island far to the south.  This ally can not offer forces to "
-"your battle but has agreed to send some support in the form of gold and "
-"crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:819
-msgid "Whiteshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:820
-msgid "Whittingham"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:821
-msgid "Who am I?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:822
-msgid ""
-"Who am I?...  Where am I?...  Oh no! My Ship!  Well it's consigned to the "
-"ghosts of my dead crew now, at least I still have my lucky rabbits foot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:823
-msgid "Who is the true King?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:824
-msgid ""
-"\"Why have we come this way?\"  asks the first mate.  You have no answer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:825
-msgid "Wicked Warlock Way"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:826
-msgid "Wilasher"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:827
-msgid "Wildabar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:828
-msgid "Wilgatus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:829
-msgid "Willow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:830
-msgid "Windfall Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:831
-msgid "Winterkill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:832
-msgid "Winterlands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:833
-msgid "Witch Hunt"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:834
-msgid ""
-"With the year long eruption of Mt. Kitisland, your three worst enemies now "
-"have a ground bridge to your eastern contenent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:835
-msgid "Wizardwood.  Magicians welcome!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:836
-msgid "Woodhaven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:837
-msgid "Wood's Lord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:838
-msgid "Woodstock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:839
-msgid "Woodville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:840
-msgid "Wormed Ash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:841
-msgid "Wow, somebody has left a pile of wood here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:842
-msgid "Wyrm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:843
-msgid "Xabran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:844
-msgid "Yellow gets some stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:845
-msgid "Yellow's Steady Cash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:846
-msgid "Yellow stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:847
-msgid "Yellow's Yarbols"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:848
-msgid "Ye old fish liver oil."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:849
-msgid "Yorksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:850
-msgid ""
-"You and your ally's families were given custody of The Isle of Knowledge.  "
-"Other Lords feel the time has come for new guardians..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:851
-msgid "You are a fool to come here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:852
-msgid "You are fighting on the side of your king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:853
-msgid "You are fighting on the side of your sister!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:854
-msgid "You are now entering the domain of Prince Roland. Have a nice day."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:855
-msgid "You are now entering the domain of Prince Roland. Have a pleasant stay."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:856
-msgid ""
-"You bribe the entrance guards of this dingy prison camp. They agree to look "
-"the other way for a little while."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:857
-msgid ""
-"You can only reach your enemies via teleporters, but each jump is a leap of "
-"faith."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:858
-msgid ""
-"You cautiously ride through the trees, looking out for enemy assaults, when "
-"suddenly, the old elf is beside you. \"Your quest is almost at an end, my "
-"friend. All that remains is for you to lay seige to these last few castles. "
-"The fate of my people rests upon your final battles here. May the gods be "
-"with you as well.\"  He turns to leave, but you ask him his name before he "
-"is gone. Over his shoulder, as he is leaving he says \"I am Ilthanis, king "
-"of the elves.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:859
-msgid ""
-"You come across the dead remains of what was appearantly a powerful wizard!  "
-"You wonder if it's safe to continue."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:860
-msgid ""
-"You face three opponents in this scenario. Capture their castles and their "
-"heroes to prove your worthiness to Archibald."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:861
-msgid ""
-"You find a beautiful helm buried in the lava.  As you move to put it on your "
-"head it turns into the Hideous mask and now you realize that no creature "
-"will join you."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:862
-msgid ""
-"You find a gleaming gold medalion buried in the  snow.  As you move to put "
-"it on it changes to the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:863
-msgid ""
-"You find an old signpost in the midst of a thicket that reads \"Warlock "
-"Wood, West.  Barbarian Fields, East.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:864
-msgid ""
-"You find a note in the bottle! It reads, \"My ship has been wrecked by the "
-"notorious pirates in this area! I am stranded on a small and barren island. "
-"Please, I beg you to come and rescue me!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:865
-msgid "You found something!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:866
-msgid "You found Treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:867
-msgid ""
-"You have been ordered here to claim this land in the name of your King and "
-"recover any riches that you might find.  However, five other Kings and "
-"Queens have also sent their heroes to this land, so you must watch out for "
-"them as well as the natives!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:868
-msgid "You have found what someone else has lost..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:869
-msgid ""
-"You have hired a barbarian of great power to aid you in this, your last "
-"quest. His origins are unknown to you, but you sense strong nobility beneath "
-"the furs and dirt that cover him. In addition, the famous explorer, Marco "
-"the wizard, is rumored to have wrecked his ship in this new land. Finding "
-"him would prove to be a much needed boon to your cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:870
-msgid ""
-"You have just 8 weeks  to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:871
-msgid ""
-"You have just 8 weeks to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:872
-msgid ""
-"You have received a message from Archibald. \"General, these peasants "
-"deserve punishment. Put them to the sword and let Corlagon have his way with "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:873
-msgid ""
-"You have received a message from Archibald.  \" HOW DARE YOU BETRAY ME! I "
-"will see your head on the block alongside your new master's once I have won."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:874
-msgid ""
-"You have received a message from Roland. \" I am shocked! I had thought "
-"better of you, but I was terribly wrong. Now you'll have to live with your "
-"dark decision for the rest of your life.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:875
-msgid "You have recieved a shipment of supplies from your kingdom!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:876
-msgid ""
-"You have recieved a shipment of supplies from your kingdom! There is a note "
-"attached, \"These are all we could afford to send you from our treasuries, "
-"as the war with Harondale is taxing us greatly. We will send more in two "
-"weeks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:877
-msgid ""
-"You have six months to destroy the Necromancer Stronghold in the heart of "
-"the valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:878
-msgid ""
-"You have washed up on the beach after being shipwrecked. Your goal is to "
-"find a way home."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:879
-msgid ""
-"You hear a low rumble, look up and see an avalanche!  You dive onto a large "
-"patch of grass to avoid it.  While dusting yourself off, you consider "
-"yourself quite lucky to be alive.  Luckier still to find a Four-Leaf Clover "
-"stuck on your nose."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:880
-msgid ""
-"You hear a rumor from a peasant who lives in the town of Waystop. He says, "
-"\"The pirates control most of the sulfur mines in this area. They use it for "
-"the cannons on their bigger boats. If you want a mine, you'll have to defeat "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:881
-msgid "You hear melodic strains of elvish music as you enter this clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:882
-msgid ""
-"You must, like, forsake your earthly wealth and, like, join us on the island "
-"of the lotus eaters."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:883
-msgid ""
-"You must search the world for your mortal enemy, Wilgatus.  Can you find him "
-"before its too late?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:884
-msgid ""
-"You notice some runes hastily scrawled into a rock by your feet, They look "
-"like the initials of Uncle Ivan!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:885
-msgid ""
-"You notice that mines and resources in the elvish lands are few, and you "
-"send word to your kingdom that you will need extra supplies. They should "
-"respond within a fortnight."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:886
-msgid ""
-"Your advance scouts come riding back to you with the following news. They "
-"believe they have found signs that Uncle Ivan was in this general area, and "
-"that he made his way to the north many months ago. Also they say there is a "
-"town nearby and many resources to the east."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:887
-msgid ""
-"Your advisor approaches you, \"My liege, something must be done about these "
-"peasants! They still refuse to work.  At this rate you won't have anything "
-"to put in your daughter's dowry!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:888
-msgid ""
-"Your advisor approaches you smiling greatly, \"My liege! The peasants are "
-"making money in the market, and are finally paying taxes!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:889
-msgid ""
-"Your advisor approaches you with a long face, \"My liege, the peasant's "
-"numbers are growing steadily.  All they do is take, take, take! We are "
-"beginning to suffer dearly because of them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:890
-msgid ""
-"Your advisor approaches you with some startling information, \"My liege, the "
-"peasants are draining us. They do nothing, and take everything! We must get "
-"them home. Your own citizens are beginning to suffer!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:891
-msgid ""
-"Your arrival here was a surprise to those sworn to guard Dragon Isle, and "
-"you were able to quickly capture one of their castles.  Use caution, though, "
-"for two other guardians remain in this jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:892
-msgid ""
-"Your castle, founded inside the center of a mile wide crater, is besieged by "
-"those who desire your mineral wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:893
-msgid "Your castle is the last outpost in the area, Don't lose it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:894
-msgid "Your crew begins to grumble."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:895
-msgid ""
-"Your crew seriously entertains thoughts of mutiny.  Your nights are "
-"sleepless."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:896
-msgid "You're almost there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:897
-msgid "You, recieve word that you have been robbed."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:898
-msgid "You're getting colder."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:899
-msgid "You're getting warmer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:900
-msgid ""
-"You're here! Oh, thank you thank you thank you! I'm in the jail east of the "
-"castle. Please hurry!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:901
-msgid ""
-"Your expedition has taken a turn for the worse... you now have no way to get "
-"home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:902
-msgid ""
-"Your forces are thinly spread in an effort to defend all the dwarf towns "
-"(which may not be transformed into castles). Consolidate your forces and "
-"smite the enemy before the towns fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:903
-msgid ""
-"Your horse stumbles and throws you from the saddle.  When you awaken you "
-"find that you have hit your head on the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:904
-msgid ""
-"Your isolation from the rest of the kingdom has largely kept you out of the "
-"political struggles, but now with the king's death, and lack of an heir, you "
-"see a golden opportunity to seize the throne for yourself.  Just remember "
-"that you have relied largely on trade for several key resources, especially "
-"sulfur, but with a little planning this land can be yours.  Go, now, and "
-"show these peasants how to rule!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:905
-msgid "Your king has sent supplies to aid the war effort."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:906
-msgid ""
-"Your opponents are allied against you and each is twice as powerful as his "
-"predecessor! Is it possible to win?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:907
-msgid ""
-"Your Queen sent you here to explore this newly discovered territory, but a "
-"freak storm scattered your fleet and left you stranded.  You gather the "
-"survivors and form a small settlement, naming it New Vertigo.  This place is "
-"your home now, and survival is your highest priority, but remember, if you "
-"are captured or killed, it's over!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:908
-msgid ""
-"Your rival, the kingdom of Harondale, is attacking your weak border towns! "
-"Recover from their first strike and crush them completely."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:909
-msgid ""
-"Your Scouts report talking to a young knight, a squire to the two sleeping "
-"heroes.  The squire is trapped by the Aqua Magic Barriers and a group of "
-"fallen Paladins.  He says the two heroes, Dainwin and Ceallach, have "
-"awakened but are still trapped by a Gold Magical Barrier and asks your aid "
-"in freeing them."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:910
-msgid ""
-"Your Scouts report that the Aqua Traveller's Tent is located along The North "
-"Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:911
-msgid ""
-"Your scouts return with grim news.  The natives of this land are currently "
-"at war with each other, and they like outsiders even less than they like "
-"each other!  Congratulations, Commander, you're at war!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:912
-msgid ""
-"Your sister calls you before her altar in the morning. \"I have important "
-"news,\" she says, \"The barbarian kingdoms which border this land have "
-"agreed to lend us some of their castles and warriors in return for a share "
-"of the spoils. I hope victory comes swiftly, but your presence gives me "
-"strength to stand until whatever end awaits.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:913
-msgid "Your subjects contribute to your war effort!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:914
-msgid ""
-"Your town is undefended and your heroes are scattered.  Do you attack or "
-"defend?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:915
-msgid ""
-"Your treasury has been looted by robbers and you have lost valuable "
-"resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:916
-msgid "Your troops begin to wonder about your sanity."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:917
-msgid ""
-"You run aground on the rocks and have to use some wood to fix your boat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:918
-msgid ""
-"You see a family of refugees making their way from the beach. You ask them "
-"about their plight and they tell you that they are from a once great city "
-"called Moss Side. They tell you that the castle was destroyed in a great "
-"conflagration, and they fled for fear of their lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:919
-msgid ""
-"You see an old man bringing water towards the stables. Recognizing him as "
-"the mystic, you attempt to thank him for his gift with some gold. He "
-"refuses, but says to you instead, \"There are riddles guarding the source of "
-"the fount's power, and the dragons know the answers. Make your way through "
-"their lair, and you shall know victory.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:920
-msgid ""
-"You see an old mystic perched on a rock. You walk towards him to see if he "
-"has any words for you on your quest, and he says \"First I see you as a "
-"great conquerer of the lands of men. Secondly, I see you as a mighty ruler "
-"of vast armies, well loved by your troops. Thirdly, I see you as a slayer of "
-"legions of dragons, your body bathed in their fire. Lastly, I see you "
-"standing on the shores of the fount, unable to cross.\" Then the Mystic "
-"fades away."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:921
-msgid "You see something that could just be the elusive Nubbie!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:922
-msgid ""
-"You see the mast of ancient ship here.  On further investigation you find "
-"that the ships holds are full of gems.  The hours pass as your crue "
-"liberates the treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:923
-msgid ""
-"You see the remains of a burned out sawmill here.  All you can salvage is "
-"some ofwood left for scrap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:924
-msgid ""
-"You see the remains of an old sawmill, but it is obvious that you will not "
-"be able to make it work again."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:925
-msgid ""
-"You see the remains of an old sawmill just to realize that it will no longer "
-"produce.  You gather the ramains and move on."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:926
-msgid ""
-"You send this letter back to the king,\"A month has passed and we have not "
-"discovered the wizard Joseph. I only hope that we are able to locate him in "
-"time to aid us in our struggle.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:927
-msgid "You should turn back."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:928
-msgid ""
-"You stumble upon an old man who proclaims you Lord of the Realm, hands you "
-"his boots and wonders into the mountains mumbling something about being late "
-"for an important date."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:929
-msgid ""
-"You stumple across three small rocks piled on top of each other and decide "
-"to dig undernear them.  There you find an old weather-beaten bag of gems."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:930
-msgid "You uncover a compass in the grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:931
-msgid "You've been warned!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:932
-msgid ""
-"You've received a message from Roland. \"In the absence of a strong leader, "
-"the local lords have fallen to fighting. Uniting this area is critical to "
-"our cause, so we must not fail.  Leaving your castle undefended in this "
-"highly contested region will surely lead to defeat. I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:933
-msgid ""
-"You've received a message from the guild. \"Thank God you've arrived! We're "
-"under seige from two enemies from the north and one from across the sea. "
-"Please save us, you're our only hope.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:934
-msgid ""
-"You've ruled with an iron fist (and an army of undead), but now your kingdom "
-"has turned against you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:935
-msgid ""
-"You've saved a group of miners from the dragons.  One of them approaches "
-"you, \"Thank you so much for saving us!  We found this sulfer and sword in "
-"the mine, then those dragons chased us!  I don't know how much longer we "
-"could survive!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:936
-msgid ""
-"You will clash quickly on this small head-to-head map, so stay on your toes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:937
-msgid ""
-"You will need a stronger army than that, mortal, to step through this portal."
-msgstr ""
-
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Wood"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Mercury"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Ore"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Sulfur"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Crystal"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Gems"
 msgstr ""
 
-#: ../fheroes2/spell/spell_book.cpp:61 ../fheroes2/spell/spell_book.cpp:79
-msgid "No spell to cast."
-msgstr ""
-
-#: ../fheroes2/spell/spell_book.cpp:138
-msgid "Your hero has %{point} spell points remaining"
-msgstr ""
-
-#: ../fheroes2/spell/spell.cpp:50
 msgid "Fireball"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:50
 msgid ""
 "Causes a giant fireball to strike the selected area, damaging all nearby "
 "creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid "Fireblast"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid ""
 "An improved version of fireball, fireblast affects two hexes around the "
 "center point of the spell, rather than one."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Lightning Bolt"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Causes a bolt of electrical energy to strike the selected creature."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid "Chain Lightning"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid ""
 "Causes a bolt of electrical energy to strike a selected creature, then "
 "strike the nearest creature with half damage, then strike the NEXT nearest "
@@ -11314,821 +5588,621 @@ msgid ""
 "harmful.  Warning:  This spell can hit your own creatures!"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid "Teleport"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid ""
 "Teleports the creature you select to any open position on the battlefield."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid "Cure"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid ""
-"Removes all negative spells cast upon one of your units, and restores up to %"
-"{count} HP per level of spell power."
+"Removes all negative spells cast upon one of your units, and restores up to "
+"%{count} HP per level of spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid "Mass Cure"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid ""
-"Removes all negative spells cast upon your forces, and restores up to %"
-"{count} HP per level of spell power, per creature."
+"Removes all negative spells cast upon your forces, and restores up to "
+"%{count} HP per level of spell power, per creature."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrect"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrects creatures from a damaged or dead unit until end of combat."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrect True"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrects creatures from a damaged or dead unit permanently."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Haste"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Increases the speed of any creature by %{count}."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Mass Haste"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Increases the speed of all of your creatures by %{count}."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "spell|Slow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "Slows target to half movement rate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Mass Slow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Slows all enemies to half movement rate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:64
-msgid "Blind "
+msgid "spell|Blind"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:64
 msgid "Clouds the affected creatures' eyes, preventing them from moving."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Bless"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Causes the selected creatures to inflict maximum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Mass Bless"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Causes all of your units to inflict maximum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Stoneskin"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Magically increases the defense skill of the selected creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid "Steelskin"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid ""
 "Increases the defense skill of the targeted creatures.  This is an improved "
 "version of Stoneskin."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Curse"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Causes the selected creatures to inflict minimum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Mass Curse"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Causes all enemy troops to inflict minimum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Holy Word"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Damages all undead in the battle."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid "Holy Shout"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid ""
 "Damages all undead in the battle.  This is an improved version of Holy Word."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Anti-Magic"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Prevents harmful magic against the selected creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Dispel Magic"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Removes all magic spells from a single target."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Mass Dispel"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Removes all magic spells from all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Magic Arrow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Causes a magic arrow to strike the selected target."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Berserker"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Causes a creature to attack its nearest neighbor."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid "Armageddon"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid ""
 "Holy terror strikes the battlefield, causing severe damage to all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Elemental Storm"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Magical elements pour down on the battlefield, damaging all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid "Meteor Shower"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid ""
 "A rain of rocks strikes an area of the battlefield, damaging all nearby "
 "creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "Paralyze"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "The targeted creatures are paralyzed, unable to move or retaliate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid "Hypnotize"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid ""
-"Brings a single enemy unit under your control for one combat round if its "
-"hits are less than %{count} times the caster's spell power."
+"Brings a single enemy unit under your control if its hits are less than "
+"%{count} times the caster's spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Cold Ray"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Drains body heat from a single enemy unit."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid "Cold Ring"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid ""
 "Drains body heat from all units surrounding the center point, but not "
 "including the center point."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Disrupting Ray"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Reduces the defense rating of an enemy unit by three."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Death Ripple"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Damages all living (non-undead) units in the battle."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid "Death Wave"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid ""
 "Damages all living (non-undead) units in the battle.  This spell is an "
 "improved version of Death Ripple."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Dragon Slayer"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Greatly increases a unit's attack skill vs. Dragons."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Blood Lust"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Increases a unit's attack skill."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Animate Dead"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Resurrects creatures from a damaged or dead undead unit permanently."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid "Mirror Image"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid ""
 "Creates an illusionary unit that duplicates one of your existing units.  "
 "This illusionary unit does the same damages as the original, but will vanish "
 "if it takes any damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Shield"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Halves damage received from ranged attacks for a single unit."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Mass Shield"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Halves damage received from ranged attacks for all of your units."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summon Earth Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summons Earth Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summon Air Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summons Air Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summon Fire Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summons Fire Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summon Water Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summons Water Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Earthquake"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Damages castle walls."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "View Mines"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "Causes all mines across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "View Resources"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "Causes all resources across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "View Artifacts"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "Causes all artifacts across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "View Towns"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "Causes all towns and castles across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "View Heroes"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "Causes all Heroes across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "View All"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "Causes the entire land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Identify Hero"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Allows the caster to view detailed information on enemy Heroes."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid "Summon Boat"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid ""
 "Summons the nearest unoccupied, friendly boat to an adjacent shore "
 "location.  A friendly boat is one which you just built or were the most "
 "recent player to occupy."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Dimension Door"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Allows the caster to magically transport to a nearby location."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Town Gate"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Returns the caster to any town or castle currently owned."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:109
 msgid ""
 "Returns the hero to the town or castle of choice, provided it is controlled "
 "by you."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid "Visions"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid ""
 "Visions predicts the likely outcome of an encounter with a neutral army camp."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid "Haunt"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid ""
 "Haunts a mine you control with Ghosts.  This mine stops producing "
 "resources.  (If I can't keep it, nobody will!)"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Set Earth Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Sets Earth Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Set Air Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Sets Air Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Set Fire Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Sets Fire Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Set Water Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Sets Water Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:665
-msgid "Necroman"
+msgid "No spell to cast."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:691
-msgid ""
-"This lets you change player starting positions and colors. A particular "
-"color will always start in a particular location. Some positions may only be "
-"played by a computer player or only by a human player."
+msgid "Your hero has %{point} spell points remaining."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:695
-msgid ""
-"This lets you change the class of a player. Classes are not always "
-"changeable. Depending on the scenario, a player may receive additional towns "
-"and/or heroes not of their primary alignment."
+msgid "View Adventure Spells"
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:734
-msgid "%{color} player"
-msgstr ""
+#, fuzzy
+msgid "View Combat Spells"
+msgstr "Seslat kouzlo"
 
-#: ../fheroes2/system/settings.cpp:126
+#, fuzzy
+msgid "View previous page"
+msgstr "Zobrazit předchozí město"
+
+#, fuzzy
+msgid "View next page"
+msgstr "Zobrazit %{name}"
+
+#, fuzzy
+msgid "Close Spellbook"
+msgstr "Seslat kouzlo"
+
+#, fuzzy
+msgid "View %{spell}"
+msgstr "Zobrazit %{name}"
+
 msgid "game: always confirm for rewrite savefile"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:127
-msgid "game: also confirm autosave"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:128
 msgid "game: remember last focus"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:129
-msgid "game: battle show grid"
+msgid "battle: show damage info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:130
-msgid "game: battle mouse shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:131
-msgid "game: battle move shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:132
-msgid "game: battle show damage info"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:133
-msgid "game: castle flash building"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:134
 msgid "world: show visited content from objects"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:135
+msgid "world: show terrain penalty"
+msgstr ""
+
 msgid "world: scouting skill show extended content info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:136
-msgid "world: abandoned mine random resource"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:137
-msgid "world: save count monster after battle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:138
 msgid "world: allow set guardian to objects"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:139
-msgid "world: guardian objects gets +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:140
-msgid "world: no in-built requirements or guardians for placed artifacts"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:141
-msgid "world: only the first monster will attack (H2 bug)."
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:142
 msgid "world: Eagle Eye also works like Scholar in H3."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:143
 msgid "world: ban for WeekOf/MonthOf Monsters"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:144
-msgid "world: new version WeekOf (+growth)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:145
 msgid "world: ban plagues months"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:146
 msgid "world: Months Of Monsters do not place creatures on map"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:147
 msgid "world: Crystal Ball also added Identify Hero and Visions spells"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:148
-msgid "world: Artesian Springs have two separately visitable squares (h3 ver)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:149
 msgid "world: Starting heroes as Loss Conditions for Human Players"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:150
 msgid "world: Only 1 hero can be hired by the one player every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:151
-msgid "world: each castle allows one hero to be recruited every week"
+msgid "world: Each castle allows one hero to be recruited every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:152
-msgid "world: Outer creature dwellings should accumulate units"
+msgid "world: Neutral armies scale with game difficulty"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:153
-msgid "world: use unique artifacts for morale/luck"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:154
 msgid "world: use unique artifacts for resource affecting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:155
 msgid "world: use unique artifacts for primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:156
 msgid "world: use unique artifacts for secondary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:157
 msgid "world: Wind/Water Mills and Magic Garden can be captured"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:158
 msgid "world: disable Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:159
-msgid "castle: allow buy from well"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:160
 msgid "castle: allow guardians"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:161
 msgid ""
 "castle: higher mage guilds regenerate more spell points/turn "
 "(20/40/60/80/100%)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:162
-msgid "castle: allow recruits special/expansion heroes"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:163
 msgid "heroes: allow buy a spellbook from Shrines"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:164
-msgid "heroes: learn new spells with day"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:165
 msgid "heroes: recruit cost to be dependent on hero level"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:166
-msgid "heroes: remember MP/SP for retreat/surrender result"
+msgid "heroes: remember move points for retreat/surrender result"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:167
-msgid "heroes: surrendering gives some experience"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:168
-msgid "heroes: recalculate movement points after creatures movement"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:169
-msgid "heroes: allow pickup objects for patrol"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:170
-msgid "heroes: after battle move to target cell"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:171
 msgid "heroes: allow transcribing scrolls (needs: Eye Eagle skill)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:172
-msgid "heroes: allow banned sec. skills upgrade"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:173
 msgid "heroes: in Arena can choose any of primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:174
 msgid "unions: allow meeting heroes"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:175
 msgid "unions: allow castle visiting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:176
+msgid "battle: show army order"
+msgstr ""
+
 msgid "battle: soft wait troop"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:177
-msgid "battle: high objects are an obstacle for archers"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:178
-msgid "battle: merge armies for hero from castle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:179
-msgid "battle: archmage can resists (20%) bad spells"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:180
-msgid "battle: magical creature resists (20%) the same magic"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:181
-msgid "battle: skip increase +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:182
 msgid "battle: reverse wait order (fast, average, slow)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:183
 msgid "game: show system info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:184
 msgid "game: autosave on"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:185
 msgid "game: autosave will be made at the beginning of the day"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:186
 msgid "game: use fade"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:187
-msgid "game: show SDL logo"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:188
 msgid "game: use evil interface"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:189
-msgid "game: also use dynamic interface for castles"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:190
 msgid "game: hide interface"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:191
 msgid "game: offer to continue the game afer victory condition"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:192
-msgid "pocketpc: hide cursor"
+msgid "The ultimate artifact is really the %{name}."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:193
-msgid "pocketpc: tap mode"
+msgid "The ultimate artifact may be found in the %{name} regions of the world."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:194
-msgid "pocketpc: drag&drop gamearea as scroll"
+msgid "north-west"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:195
-msgid "pocketpc: low memory"
+msgid "north"
 msgstr ""
+
+msgid "north-east"
+msgstr ""
+
+#, fuzzy
+msgid "west"
+msgstr "Hnízdo"
+
+#, fuzzy
+msgid "center"
+msgstr "Stan"
+
+#, fuzzy
+msgid "east"
+msgstr "Hnízdo"
+
+msgid "south-west"
+msgstr ""
+
+#, fuzzy
+msgid "south"
+msgstr "zvuk"
+
+msgid "south-east"
+msgstr ""
+
+msgid "The truth is out there."
+msgstr ""
+
+msgid "The dark side is stronger."
+msgstr ""
+
+msgid "The end of the world is near."
+msgstr ""
+
+msgid "The bones of Lord Slayer are buried in the foundation of the arena."
+msgstr ""
+
+msgid "A Black Dragon will take out a Titan any day of the week."
+msgstr ""
+
+msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
+msgstr ""
+
+msgid "An unknown force is being ressurected..."
+msgstr ""
+
+msgid ""
+"Check the newest version of game at\n"
+"https://github.com/ihhub/\n"
+"fheroes2/releases"
+msgstr ""
+
+#~ msgid "sound"
+#~ msgstr "zvuk"
+
+#, fuzzy
+#~ msgid "ai speed"
+#~ msgstr "Rychlost"
+
+#~ msgid "Water"
+#~ msgstr "Voda"
 
 #, fuzzy
 #~ msgid "one creature perishes."
@@ -12161,9 +6235,6 @@ msgstr ""
 
 #~ msgid "Empty"
 #~ msgstr "Prázdný"
-
-#~ msgid "animation"
-#~ msgstr "animace"
 
 #~ msgid "Legion"
 #~ msgstr "Legie"
@@ -12228,9 +6299,6 @@ msgstr ""
 #~ msgid "Low morale causes the %{name} to freeze in panic."
 #~ msgstr "Nízká morálka způsobila, že %{name} ztuhl strachem."
 
-#~ msgid "%{tower} does %{dmg} damage."
-#~ msgstr "%{tower} způsobila %{dmg} škod."
-
 #~ msgid "High morale enables the %{name} to attack again."
 #~ msgstr "Díky vysoké morálce může %{name} znovu zaútočit."
 
@@ -12252,17 +6320,11 @@ msgstr ""
 #~ msgid "perishes"
 #~ msgstr "zemřel"
 
-#~ msgid "%{name} %{does} %{value} damage."
-#~ msgstr "%{name} %{does} %{value} škod."
-
 #~ msgid "Auto Combat"
 #~ msgstr "Automatický boj"
 
 #~ msgid "do"
 #~ msgstr "způsobit"
-
-#~ msgid "The %{spell} does %{value} damage."
-#~ msgstr "%{spell} způsobil %{value} škod."
 
 #~ msgid "Allows the computer to fight out the battle for you."
 #~ msgstr "Dovolí počítači vybojovat bitvu za vás."

--- a/files/lang/es.po
+++ b/files/lang/es.po
@@ -7,49 +7,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-10-23 10:54+0900\n"
+"POT-Creation-Date: 2021-07-01 15:11+0200\n"
 "PO-Revision-Date: 2013-06-03 16:38+0000\n"
 "Last-Translator: elhoir <jfarroyo82@hotmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Launchpad-Export-Date: 2013-10-09 02:01+0000\n"
 "X-Generator: Launchpad (build 16799)\n"
 
-#: ../fheroes2/ai/ai_action.cpp:157 ../fheroes2/heroes/heroes_action.cpp:248
-msgid "Hero %{name} also got a %{count} experience."
-msgstr "El héroe %{name} también obtubo %{count} de experiencia."
-
-#: ../fheroes2/army/army_bar.cpp:221 ../fheroes2/resource/artifact.cpp:968
-msgid "View %{name}"
-msgstr "Ver %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:227 ../fheroes2/army/army_bar.cpp:310
-msgid "Move or right click to redistribute %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:233 ../fheroes2/army/army_bar.cpp:301
-msgid "Combine %{name} armies"
-msgstr "Combinar los ejércitos de %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:238 ../fheroes2/army/army_bar.cpp:292
-#: ../fheroes2/resource/artifact.cpp:980
-#: ../fheroes2/resource/artifact.cpp:1002
-msgid "Exchange %{name2} with %{name}"
-msgstr "Intercambiar %{name2} por %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:246 ../fheroes2/resource/artifact.cpp:988
-msgid "Select %{name}"
-msgstr "Seleccionar %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:298 ../fheroes2/army/army_bar.cpp:307
-msgid "Cannot move last troop"
-msgstr ""
-
-#: ../fheroes2/army/army.cpp:85
 msgid ""
 "A few\n"
 "%{monster}"
@@ -57,7 +26,6 @@ msgstr ""
 "Unos pocos\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:86
 msgid ""
 "Several\n"
 "%{monster}"
@@ -65,7 +33,6 @@ msgstr ""
 "Varios\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:87
 msgid ""
 "A pack of\n"
 "%{monster}"
@@ -73,7 +40,6 @@ msgstr ""
 "Algunos\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:88
 msgid ""
 "Lots of\n"
 "%{monster}"
@@ -81,7 +47,6 @@ msgstr ""
 "Muchos\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:89
 msgid ""
 "A horde of\n"
 "%{monster}"
@@ -89,7 +54,6 @@ msgstr ""
 "Una horda de\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:90
 msgid ""
 "A throng of\n"
 "%{monster}"
@@ -97,7 +61,6 @@ msgstr ""
 "Una muchedumbre de\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:91
 msgid ""
 "A swarm of\n"
 "%{monster}"
@@ -105,7 +68,6 @@ msgstr ""
 "Un enjambre de\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:92
 msgid ""
 "Zounds of\n"
 "%{monster}"
@@ -113,7 +75,6 @@ msgstr ""
 "Demasiados\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:93
 msgid ""
 "A legion of\n"
 "%{monster}"
@@ -121,79 +82,78 @@ msgstr ""
 "Una legión\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Few"
 msgstr "ejército|Pocos"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Several"
 msgstr "ejército|Unos cuantos"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Pack"
 msgstr "ejército|Grupo"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Lots"
 msgstr "ejército|Muchos"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Horde"
 msgstr "ejército|Horda"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Throng"
 msgstr "ejército|Muchedumbre"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Swarm"
 msgstr "ejército|Enjambre"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Zounds"
 msgstr "ejército|Demasiados"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Legion"
 msgstr "ejército|Legión"
 
-#: ../fheroes2/army/army.cpp:925
 msgid "All %{race} troops +1"
 msgstr "Toda la tropa %{race +1"
 
-#: ../fheroes2/army/army.cpp:936
-msgid "Entire unit is undead, so morale does not apply."
-msgstr "No hay ningún muerto en la unidad, así que su moral está intacta"
-
-#: ../fheroes2/army/army.cpp:946
 msgid "Troops of 3 alignments -1"
 msgstr "Tropas de 3 líneas -1"
 
-#: ../fheroes2/army/army.cpp:954
 msgid "Troops of 4 alignments -2"
 msgstr "Tropas de 4 líneas -2"
 
-#: ../fheroes2/army/army.cpp:962
 msgid "Troops of 5 alignments -3"
 msgstr "Tropas de 5 líneas -3"
 
-#: ../fheroes2/army/army.cpp:976
 msgid "Some undead in groups -1"
 msgstr "Tienes algunos caídos en tu ejercito -1"
 
-#: ../fheroes2/battle/battle_action.cpp:752
+msgid "View %{name}"
+msgstr "Ver %{name}"
+
+msgid "Move or right click to redistribute %{name}"
+msgstr ""
+
+msgid "Combine %{name} armies"
+msgstr "Combinar los ejércitos de %{name}"
+
+msgid "Exchange %{name2} with %{name}"
+msgstr "Intercambiar %{name2} por %{name}"
+
+msgid "Select %{name}"
+msgstr "Seleccionar %{name}"
+
+msgid "Cannot move last troop"
+msgstr ""
+
+msgid "%{name} half the enemy troops!"
+msgstr "%{name} mitad de las tropas enemigas!"
+
 msgid "Set auto battle off"
 msgstr "Desactivar combate automático"
 
-#: ../fheroes2/battle/battle_action.cpp:757
 msgid "Set auto battle on"
 msgstr "Activar combate automático"
 
-#: ../fheroes2/battle/battle_action.cpp:864
 msgid "spell failed!"
 msgstr "¡Hechizo fallido!"
 
-#: ../fheroes2/battle/battle_arena.cpp:705
 msgid ""
 "The Sphere of Negation artifact is in effect for this battle, disabling all "
 "combat spells."
@@ -201,150 +161,153 @@ msgstr ""
 "El artefacto Esfera de la Negación está afectando a esta batalla, "
 "deshabilitando todos los hechizos de combate."
 
-#: ../fheroes2/battle/battle_arena.cpp:714
 msgid "You have already cast a spell this round."
 msgstr "Ya has lanzado un hechizo en este turno."
 
-#: ../fheroes2/battle/battle_arena.cpp:720
-#: ../fheroes2/battle/battle_arena.cpp:768
 msgid "That spell will affect no one!"
 msgstr "¡El hechizo no afectará a nadie!"
 
-#: ../fheroes2/battle/battle_arena.cpp:739
 msgid "You may only summon one type of elemental per combat."
 msgstr "Solo puedes convocar un tipo de elemental por combate."
 
-#: ../fheroes2/battle/battle_arena.cpp:745
 msgid "There is no open space adjacent to your hero to summon an Elemental to."
 msgstr ""
 "No hay un espacio libre adyacente a tu héroe para convocar un Elemental."
 
-#: ../fheroes2/battle/battle_board.cpp:968
 msgid ""
 "The Moat reduces by -%{count} the defense skill of any unit and slows to "
 "half movement rate."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:50
-msgid "speed: %{speed}"
+msgid "Speed"
+msgstr "Velocidad"
+
+#, fuzzy
+msgid "Speed: %{speed}"
 msgstr "velocidad: %{speed}"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:165
+#, fuzzy
+msgid "Auto Spell Casting"
+msgstr "Conjuradores"
+
+msgid "Grid"
+msgstr ""
+
+#, fuzzy
+msgid "Shadow Movement"
+msgstr "Continuar movimento"
+
+msgid "Shadow Cursor"
+msgstr ""
+
+msgid "On"
+msgstr ""
+
+#, fuzzy
+msgid "Off"
+msgstr "apagado"
+
 msgid "The enemy has surrendered!"
 msgstr "¡El enemigo se ha rendido!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:168
 msgid "The enemy has fled!"
 msgstr "¡El enemigo ha huido!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:170
-#: ../fheroes2/battle/battle_dialogs.cpp:256
 msgid "A glorious victory!"
 msgstr "¡Una gloriosa victoria!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:175
-msgid "For valor in combat, %{name} receives %{exp} experience"
+#, fuzzy
+msgid "For valor in combat, %{name} receives %{exp} experience."
 msgstr "Por valor en el combate, %{name} recibe %{exp} experiencia"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:184
 msgid "The cowardly %{name} flees from battle."
 msgstr "El cobarde %{name} huye de la batalla."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:191
 msgid "%{name} surrenders to the enemy, and departs in shame."
 msgstr "%{name} se rinde al enemigo, marchandose avergonzado."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:197
 msgid "Your force suffer a bitter defeat, and %{name} abandons your cause."
 msgstr "Tus fuerzas sufren una amarga derrota, y  %{name} abandona tu causa."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:249
 msgid "Your force suffer a bitter defeat."
 msgstr "Tus fuerzas sufren una amarga derrota."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:296
 msgid "Battlefield Casualties"
 msgstr "Bajas en el campo de batalla."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:300
 msgid "Attacker"
 msgstr "Agresor"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:312
 msgid "Defender"
 msgstr "Defensor"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:394
+msgid "You have captured an enemy artifact!"
+msgstr "¡Has capturado un artefacto enemigo!"
+
+#, fuzzy
+msgid "Necromancy!"
+msgstr "Nigromancia"
+
+#, fuzzy
+msgid ""
+"Practicing the dark arts of necromancy, you are able to raise %{count} of "
+"the enemy's dead to return under your service as %{monster}."
+msgstr ""
+"Practicando las oscuras artes de la nigromancia, eres capaz de alzar "
+"%{count} de los enemigos muertos para que vuelvan bajo tu servicio como "
+"%{monster}"
+
 msgid "%{name} the %{race}"
 msgstr "%{name} el %{race}"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:401
-#: ../fheroes2/castle/castle_well.cpp:311
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:194
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:834
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Attack"
 msgstr "Ataque"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:406
-#: ../fheroes2/castle/castle_well.cpp:317
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:206
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:844
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Defense"
 msgstr "Defensa"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:411
-#: ../fheroes2/castle/castle_town.cpp:310
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:854
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:142
-#: ../fheroes2/heroes/heroes_meeting.cpp:292
 msgid "Spell Power"
 msgstr "Pot. de Hech."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:416
-#: ../fheroes2/castle/castle_town.cpp:319
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:864
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:147
-#: ../fheroes2/heroes/heroes_meeting.cpp:296 ../fheroes2/heroes/skill.cpp:151
 msgid "Knowledge"
 msgstr "Conocimiento"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:421
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:276
 msgid "Morale"
 msgstr "Moral"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:426
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:286 ../fheroes2/heroes/skill.cpp:338
 msgid "Luck"
 msgstr "Suerte"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:431
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:874
-#: ../fheroes2/heroes/heroes_indicator.cpp:247
 msgid "Spell Points"
 msgstr "Maná"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
-#: ../fheroes2/gui/interface_buttons.cpp:189
+msgid "Hero's Options"
+msgstr "Opciones del héroe"
+
 msgid "Cast Spell"
 msgstr "Lanzar hechizo"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
+msgid "Retreat"
+msgstr "Retirarse"
+
+msgid "Surrender"
+msgstr "Rendirse"
+
+msgid "Cancel"
+msgstr "Cancelar"
+
+msgid "Hero Screen"
+msgstr "Pantalla de Héroe"
+
+#, fuzzy
 msgid ""
 "Cast a magical spell. You may only cast one spell per combat round. The "
-"round is reset when every creature has had a turn"
+"round is reset when every creature has had a turn."
 msgstr ""
 "Lanza un hechizo mágico. Solo se puede lanzar un hechizo por ronda de "
 "combate. La ronda de combate vuelve a comenzar cuando todas las criaturas "
 "han tenido un turno."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:488
-msgid "Retreat"
-msgstr "Retirarse"
-
-#: ../fheroes2/battle/battle_dialogs.cpp:488
 msgid ""
 "Retreat your hero, abandoning your creatures. Your hero will be available "
 "for you to recruit again, however, the hero will have only a novice hero's "
@@ -354,11 +317,6 @@ msgstr ""
 "para que lo reclutes, sin embargo, el héroe tendrá los reclutas de un novato "
 "(como cualquier otro héroe)."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:491
-msgid "Surrender"
-msgstr "Rendirse"
-
-#: ../fheroes2/battle/battle_dialogs.cpp:491
 msgid ""
 "Surrendering costs gold. However if you pay the ransom, the hero and all of "
 "his or her surviving creatures will be available to recruit again."
@@ -366,318 +324,238 @@ msgstr ""
 "Rendirse cuesta oro. Sin embargo, si pagas el rescate, el héroe y todas sus "
 "criaturas supervivientes estarán disponibles para ser reclutadas otra vez."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:166
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:227
-msgid "Cancel"
-msgstr "Cancelar"
+#, fuzzy
+msgid "Open Hero Screen to view full information about the hero."
+msgstr "Permite al lanzador ver información detallada de los héroes enemigos."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
 msgid "Return to the battle."
 msgstr "Volver a la batalla."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:549
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:438
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:497
 msgid "Not enough gold (%{gold})"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:564
 msgid "%{name} states:"
 msgstr "Estado de %{name}:"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:569
+#, fuzzy
 msgid ""
-"I will accept your surrender and grant you and your troops safe passage for "
-"the price of %{price} gold."
+"\"I will accept your surrender and grant you and your troops safe passage "
+"for the price of %{price} gold.\""
 msgstr ""
 "Aceptaré tu rendición y daré salvoconducto a ti y tus tropas por %{price} "
 "monedas de oro."
 
-#: ../fheroes2/battle/battle_interface.cpp:613
-#: ../fheroes2/battle/battle_interface.cpp:1401
 msgid "View %{monster} info."
 msgstr "Ver información de %{monster}."
 
-#: ../fheroes2/battle/battle_interface.cpp:1409
 #, fuzzy
 msgid "Shoot %{monster}"
 msgstr ""
 "Muchos\n"
 "%{monster}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1431
 msgid "Attack %{monster}"
 msgstr "Atacar a %{monster}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Fly %{monster} here."
 msgstr "%{monster} vuela aquí."
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Move %{monster} here."
 msgstr "Mover a %{monster} aquí."
 
-#: ../fheroes2/battle/battle_interface.cpp:1449
-#: ../fheroes2/battle/battle_interface.cpp:1538
 msgid "Turn %{turn}"
 msgstr "Turno %{turn}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1475
 msgid "Teleport Here"
 msgstr "Teletransportar aquí"
 
-#: ../fheroes2/battle/battle_interface.cpp:1479
 msgid "Invalid Teleport Destination"
 msgstr "Destino de teletransporte inválido"
 
-#: ../fheroes2/battle/battle_interface.cpp:1485
 msgid "Cast %{spell} on %{monster}"
 msgstr "Lanzar %{spell} sobre %{monster}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1495
 msgid "Cast %{spell}"
 msgstr "Lanzar %{spell}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1501
 msgid "Select Spell Target"
 msgstr "Seleccionar objetivo del hechizo"
 
-#: ../fheroes2/battle/battle_interface.cpp:1674
-msgid "Spell cast"
-msgstr "Lanzar hechizo"
-
-#: ../fheroes2/battle/battle_interface.cpp:1686
 msgid "View Ballista Info"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1699
-#: ../fheroes2/battle/battle_tower.cpp:53
 msgid "Ballista"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1712
 msgid "Auto combat"
 msgstr "Combate automático"
 
-#: ../fheroes2/battle/battle_interface.cpp:1719
 msgid "Customize system options."
 msgstr "Personalizar opciones del sistema."
 
-#: ../fheroes2/battle/battle_interface.cpp:1727
 msgid "Wait this unit"
 msgstr "Esta unidad espera"
 
-#: ../fheroes2/battle/battle_interface.cpp:1734
 msgid "Skip this unit"
 msgstr "Saltar el turno de esta unidad."
 
-#: ../fheroes2/battle/battle_interface.cpp:1742
-#: ../fheroes2/battle/battle_interface.cpp:1774
-msgid "Hero's Options"
-msgstr "Opciones del héroe"
-
-#: ../fheroes2/battle/battle_interface.cpp:1753
-#: ../fheroes2/battle/battle_interface.cpp:1785
 msgid "View Opposing Hero"
 msgstr "Ver el Heroe Contrario"
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Hide logs"
 msgstr "Ocultar registro"
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Show logs"
 msgstr "Mostrar registros"
 
-#: ../fheroes2/battle/battle_interface.cpp:1878
 msgid "%{color} cast spell: %{spell}"
 msgstr "%{color} lanzó el hechizo: %{spell}"
 
-#: ../fheroes2/battle/battle_interface.cpp:2202
 msgid "%{name} skipping turn"
 msgstr "%{name} pasa turno"
 
-#: ../fheroes2/battle/battle_interface.cpp:2203
-msgid ", and get +2 defense"
-msgstr ", y consigue +2 a la defensa"
-
-#: ../fheroes2/battle/battle_interface.cpp:2206
 msgid "%{name} waiting turn"
 msgstr "%{name} esperando turno"
 
-#: ../fheroes2/battle/battle_interface.cpp:2343
 msgid "%{attacker} do %{damage} damage."
 msgstr "%{attacker} hace %{damage} de daño."
 
-#: ../fheroes2/battle/battle_interface.cpp:2497
 msgid "Moved %{monster}: %{src}, %{dst}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2612
+#, fuzzy
+msgid "Moved %{monster}"
+msgstr "Mover a %{monster} aquí."
+
 msgid "The %{name} resist the spell!"
 msgstr "¡El %{name} resiste el hechizo!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2625
 msgid "%{name} casts %{spell} on the %{troop}."
 msgstr "%{name} lanza %{spell} sobre %{troop}."
 
-#: ../fheroes2/battle/battle_interface.cpp:2630
 msgid "%{name} casts %{spell}."
 msgstr "%{name} lanza %{spell}."
 
-#: ../fheroes2/battle/battle_interface.cpp:2751
-msgid "The %{spell} spell does %{damage} damage to all undead creatures."
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to one undead creature."
 msgstr ""
 "El hechizo %{spell} hace %{damage} puntos de daño a todas las criaturas "
 "nomuertas."
 
-#: ../fheroes2/battle/battle_interface.cpp:2754
-msgid "The %{spell} spell does %{damage} damage to all living creatures."
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to all undead creatures."
+msgstr ""
+"El hechizo %{spell} hace %{damage} puntos de daño a todas las criaturas "
+"nomuertas."
+
+#, fuzzy
+msgid "The %{spell} does %{damage} damage, %{count} creatures perish."
+msgstr ""
+"El hechizo %{spell} hace %{damage} puntos de daño a todas las criaturas "
+"nomuertas."
+
+msgid "The %{spell} does %{damage} damage."
+msgstr "%{spell} hacen %{damage} de daño."
+
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to one living creature."
 msgstr ""
 "El hechizo %{spell} hace %{damage} puntos de daño a todas las criaturas "
 "vivas."
 
-#: ../fheroes2/battle/battle_interface.cpp:2756
-msgid "The %{spell} does %{damage} damage."
-msgstr "%{spell} hacen %{damage} de daño."
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to all living creatures."
+msgstr ""
+"El hechizo %{spell} hace %{damage} puntos de daño a todas las criaturas "
+"vivas."
 
-#: ../fheroes2/battle/battle_interface.cpp:2797
 msgid "The Unicorns attack blinds the %{name}!"
 msgstr "¡El ataque del Unicornio ciega a %{name}!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2798
 msgid "The Medusas gaze turns the %{name} to stone!"
 msgstr "¡La mirada de la Medusa convierte a %{name} en piedra!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2800
 msgid "The Mummies' curse falls upon the %{name}!"
 msgstr "¡La maldición de la Momia cae sobre %{name}!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2801
 msgid "The %{name} are paralyzed by the Cyclopes!"
 msgstr "¡El %{name} es paralizado por los Cíclopes!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2802
 msgid "The Archmagi dispel all good spells on your %{name}!"
 msgstr "¡El Archimago dispersó todos los hechizos buenos en tu %{name}!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2820
-msgid "Good luck shines on the  %{attacker}"
+#, fuzzy
+msgid "Good luck shines on the %{attacker}"
 msgstr "La buena suerte brilla sobre %{attacker}"
 
-#: ../fheroes2/battle/battle_interface.cpp:2872
 msgid "Bad luck descends on the %{attacker}"
 msgstr "La mala suerte desciende sobre %{attacker}"
 
-#: ../fheroes2/battle/battle_interface.cpp:2884
 msgid "High morale enables the %{monster} to attack again."
 msgstr "La alta moral permite a %{monster} atacar otra vez."
 
-#: ../fheroes2/battle/battle_interface.cpp:2891
 msgid "Low morale causes the %{monster} to freeze in panic."
 msgstr "La baja moral provoca que %{monster} se paralice por el pánico."
 
-#: ../fheroes2/battle/battle_interface.cpp:2944
-msgid "Tower do %{damage} damage."
+#, fuzzy
+msgid "%{tower} does %{damage} damage."
 msgstr "La torre ha causado %{damage} de daño."
 
-#: ../fheroes2/battle/battle_interface.cpp:3257
 msgid "MirrorImage created"
 msgstr "Reflejo creado"
 
-#: ../fheroes2/battle/battle_interface.cpp:3798
-msgid "MirrorImage ended"
-msgstr "Reflejo terminado"
+msgid "The mirror image is destroyed!"
+msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4089
 #, fuzzy
 msgid "Break auto battle?"
 msgstr "Activar combate automático"
 
-#: ../fheroes2/battle/battle_interface.cpp:4138
 msgid "No spells to cast."
 msgstr "Sin hechizos que lanzar."
 
-#: ../fheroes2/battle/battle_interface.cpp:4147
 msgid "Are you sure you want to retreat?"
 msgstr "¿Estas seguro que quieres retirarte?"
 
-#: ../fheroes2/battle/battle_interface.cpp:4155
 #, fuzzy
 msgid "Retreat disabled"
 msgstr "Retirarse"
 
-#: ../fheroes2/battle/battle_interface.cpp:4169
-msgid "You don't have enough gold!"
-msgstr "¡Tu no tienes suficiente oro!"
-
-#: ../fheroes2/battle/battle_interface.cpp:4180
 #, fuzzy
 msgid "Surrender disabled"
 msgstr "Rendirse"
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{max}"
 msgstr "Daño: %{max}"
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{min} - %{max}"
 msgstr "Daño: %{min} - %{max}"
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{max}"
 msgstr "Mueren: %{max}"
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{min} - %{max}"
 msgstr "Mueren: %{min} - %{max}"
 
-#: ../fheroes2/battle/battle_main.cpp:190
-msgid "You have captured an enemy artifact!"
-msgstr "¡Has capturado un artefacto enemigo!"
-
-#: ../fheroes2/battle/battle_main.cpp:241
 msgid ""
-"Through eagle-eyed observation, %{name} is able to learn the magic spell %"
-"{spell}."
+"Through eagle-eyed observation, %{name} is able to learn the magic spell "
+"%{spell}."
 msgstr ""
 "Mediante la observación del ojo de halcón, %{name} es capaz de aprender el "
 "hechizo mágico %{spell}."
 
-#: ../fheroes2/battle/battle_main.cpp:280
-msgid ""
-"Practicing the dark arts of necromancy, you are able to raise %{count} of "
-"the enemy's dead to return under your service as %{monster}"
-msgstr ""
-"Practicando las oscuras artes de la nigromancia, eres capaz de alzar %"
-"{count} de los enemigos muertos para que vuelvan bajo tu servicio como %"
-"{monster}"
-
-#: ../fheroes2/battle/battle_tower.cpp:47 ../fheroes2/castle/castle.cpp:466
 msgid "Left Turret"
 msgstr "Torreón Izquierdo"
 
-#: ../fheroes2/battle/battle_tower.cpp:48 ../fheroes2/castle/castle.cpp:467
 msgid "Right Turret"
 msgstr "Torreón Derecho"
 
-#: ../fheroes2/battle/battle_tower.cpp:115
 msgid "The %{name} fires with the strength of %{count} Archers"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:116
 msgid "each with a +%{attack} bonus to their attack skill."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:863
-msgid "%{name} half the enemy troops!"
-msgstr "%{name} mitad de las tropas enemigas!"
-
-#: ../fheroes2/battle/battle_troop.cpp:950
 msgid ""
 "The %{artifact} artifact is in effect for this battle, disabling %{spell} "
 "spell."
@@ -685,394 +563,795 @@ msgstr ""
 "El artefacto %{artifact} está en efecto por esta batalla, deshabilitando el "
 "hechizo %{spell}."
 
-#: ../fheroes2/battle/battle_troop.cpp:1598
 msgid "%{count} %{name} rise(s) from the dead!"
 msgstr "¡%{count} %{name} se eleva(n) de la muerte!"
 
-#: ../fheroes2/castle/buildinginfo.cpp:258
+#, fuzzy
+msgid "Sorceress Guild"
+msgstr "Hechicera"
+
+#, fuzzy
+msgid "Necromancer Guild"
+msgstr "Nigromante"
+
+#, fuzzy
+msgid "Dragon Alliance"
+msgstr "Alianza Rota"
+
+#, fuzzy
+msgid "Elven Alliance"
+msgstr "Alianza Rota"
+
+msgid "Wayward Son"
+msgstr ""
+
+msgid "Uncle Ivan"
+msgstr "Uncle Ivan"
+
+#, fuzzy
+msgid "Force of Arms"
+msgstr "\"La Fuerza de las Armas\""
+
+#, fuzzy
+msgid "Annexation"
+msgstr "\"Anexión\""
+
+#, fuzzy
+msgid "Save the Dwarves"
+msgstr "\"Salva a los Enanos\""
+
+#, fuzzy
+msgid "Carator Mines"
+msgstr "\"Minas Carator\""
+
+#, fuzzy
+msgid "Turning Point"
+msgstr "\"Punto de retorno\""
+
+#, fuzzy
+msgid "The Gauntlet"
+msgstr "\"El Guantelete\""
+
+#, fuzzy
+msgid "The Crown"
+msgstr "\"La Corona\""
+
+#, fuzzy
+msgid "Corlagon's Defense"
+msgstr "Corlagon"
+
+msgid "Final Justice"
+msgstr ""
+
+#, fuzzy
+msgid "First Blood"
+msgstr "\"Primera Sangre\""
+
+#, fuzzy
+msgid "Barbarian Wars"
+msgstr "\"Guerras Barbaras\""
+
+#, fuzzy
+msgid "Necromancers"
+msgstr "Nigromante"
+
+#, fuzzy
+msgid "Slay the Dwarves"
+msgstr "\"Da muerte a los Enanos\""
+
+msgid "Rebellion"
+msgstr ""
+
+#, fuzzy
+msgid "Dragon Master"
+msgstr "\"Maestro Dragón\""
+
+#, fuzzy
+msgid "Country Lords"
+msgstr "\"Señores del Pais\""
+
+#, fuzzy
+msgid "Greater Glory"
+msgstr "\"Gloria Mayor\""
+
+#, fuzzy
+msgid "Apocalypse"
+msgstr "\"Apocalipsis\""
+
+msgid "Uprising"
+msgstr ""
+
+#, fuzzy
+msgid "Island of Chaos"
+msgstr "Isla de los Elfos"
+
+msgid "Arrow's Flight"
+msgstr ""
+
+msgid "The Abyss"
+msgstr ""
+
+#, fuzzy
+msgid "The Giant's Pass"
+msgstr "Los yermos reales"
+
+msgid "Aurora Borealis"
+msgstr ""
+
+#, fuzzy
+msgid "Betrayal's End"
+msgstr "\"¡Traición!\""
+
+#, fuzzy
+msgid "Corruption's Heart"
+msgstr "Alojamiento del Capitán"
+
+msgid "Conquer and Unify"
+msgstr ""
+
+#, fuzzy
+msgid "Border Towns"
+msgstr "Tierras fronterizas"
+
+msgid "The Wayward Son"
+msgstr ""
+
+#, fuzzy
+msgid "Crazy Uncle Ivan"
+msgstr "Uncle Ivan"
+
+#, fuzzy
+msgid "The Southern War"
+msgstr "El Otro Lado"
+
+msgid "Ivory Gates"
+msgstr "Puertas de Marfil"
+
+#, fuzzy
+msgid "The Elven Lands"
+msgstr "Siete Lagos"
+
+msgid "The Epic Battle"
+msgstr ""
+
+#, fuzzy
+msgid "The Shrouded Isles"
+msgstr "La Isla Esmeralda"
+
+#, fuzzy
+msgid "The Eternal Scrolls"
+msgstr "La Isla Esmeralda"
+
+#, fuzzy
+msgid "Power's End"
+msgstr "Anillo de Poder"
+
+#, fuzzy
+msgid "Fount of Wizardry"
+msgstr "El Cayado de Brujería"
+
+msgid "Stranded"
+msgstr ""
+
+#, fuzzy
+msgid "Pirate Isles"
+msgstr "Ensenada Pirata"
+
+msgid "King and Country"
+msgstr ""
+
+msgid "Blood is Thicker"
+msgstr ""
+
+msgid ""
+"Roland needs you to defeat the lords near his castle to begin his war of "
+"rebellion against his brother.  They are not allied with each other, so they "
+"will spend most of their time fighting with one another.  Victory is yours "
+"when you have defeated all of their castles and heroes."
+msgstr ""
+
+msgid ""
+"The local lords refuse to swear allegiance to Roland, and must be subdued. "
+"They are wealthy and powerful, so be prepared for a tough fight. Capture all "
+"enemy castles to win."
+msgstr ""
+
+msgid ""
+"Your task is to defend the Dwarves against Archibald's forces. Capture all "
+"of the enemy towns and castles to win, and be sure not to lose all of the "
+"dwarf towns at once, or the enemy will have won."
+msgstr ""
+
+msgid ""
+"You will face four allied enemies in a straightforward fight for resource "
+"and treasure. Capture all of the enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Your enemies are allied against you and start close by, so be ready to come "
+"out fighting. You will need to own all four castles in this small valley to "
+"win."
+msgstr ""
+
+msgid ""
+"The Sorceress' guild of Noraston has requested Roland's aid against an "
+"attack from Archibald's allies. Capture all of the enemy castles to win, and "
+"don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy "
+"castle on an island in the ocean.)"
+msgstr ""
+
+msgid ""
+"Gather as large an army as possible and capture the enemy castle within 8 "
+"weeks. You are opposed by only one enemy, but must travel a long way to get "
+"to the enemy castle. Any troops you have in your army at the end of this "
+"scenario will be with you in the final battle."
+msgstr ""
+
+msgid ""
+"Find the Crown before Archibald's heroes find it. Roland will need the Crown "
+"for the final battle against Archibald."
+msgstr ""
+
+msgid ""
+"Three allied enemies stand before you and victory, including Lord Corlagon. "
+"Roland is in a castle to the northwest, and you will lose if he falls to the "
+"enemy. Remember that capturing Lord Corlagon will ensure that he will not "
+"fight against you in the final scenario."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Archibald to end the war!"
+msgstr ""
+
+msgid ""
+"King Archibald requires you to defeat the three enemies in this region.  "
+"They are not allied with one another, so they will spend most of their "
+"energy fighting amongst themselves.  You will win when you own all of the "
+"enemy castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"You must unify the barbarian tribes of the north by conquering them. As in "
+"the previous mission, the enemy is not allied against you, but they have "
+"more resources at their disposal. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"Do-gooder wizards have taken the Necromancers' castle. You must retake it to "
+"achieve victory. Remember that while you start with a powerful army, you "
+"have no castle and must take one within 7 days, or lose this battle. (Hint: "
+"The nearest castle is to the southeast.)"
+msgstr ""
+
+msgid ""
+"The dwarves need conquering before they can interfere in King Archibald's "
+"plans. Roland's forces have more than one hero and many towns to start with, "
+"so be ready for attack from multiple directions. You must capture all of the "
+"enemy towns and castles to claim victory."
+msgstr ""
+
+msgid ""
+"You must put down a peasant revolt led by Roland's forces. All are allied "
+"against you, but you have Lord Corlagon, an experienced hero, to help you. "
+"Capture all enemy castles to win."
+msgstr ""
+
+msgid ""
+"There are two enemies allied against you in this mission. Both are well "
+"armed and seek to evict you from their island. Avoid them and capture Dragon "
+"City to win"
+msgstr ""
+
+msgid ""
+"Your orders are to conquer the country lords that have sworn to serve "
+"Roland. All of the enemy castles are unified against you. Since you start "
+"without a castle, you must hurry to capture one before the end of the week. "
+"Capture all enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Find the Crown before Roland's heroes find it. Archibald will need the Crown "
+"for the final battle against Roland."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Roland to win the war, and be sure "
+"not to lose Archibald in the fight!"
+msgstr ""
+
+msgid ""
+"Subdue the unruly local lords in order to provide the Empire with facilities "
+"to operate in this region."
+msgstr ""
+
+msgid ""
+"Eliminate all oposition in this area. Then the first piece of the artifact "
+"will be yours."
+msgstr ""
+
+msgid ""
+"The sorceresses to the northeast are rebelling! For the good of the empire "
+"you must quash their feeble uprising on your way to the mountains."
+msgstr ""
+
+msgid ""
+"Having prepared for your arrival, Kraeger has arranged for a force of "
+"necromancers to thwart your quest. You must capture the castle of Scabsdale "
+"before the first day of the third week, or the Necromancers will be too "
+"strong for you."
+msgstr ""
+
+msgid ""
+"The barbarian despot in this area is, as yet, ignorant of your presence. "
+"Quickly, build up your forces before you are discovered and attacked! Secure "
+"the region by subduing all enemy forces."
+msgstr ""
+
+msgid ""
+"The Empire is weak in this region. You will be unable to completely subdue "
+"all forces in this area, so take what you can before reprisal strikes. "
+"Remember, your true goal is to claim the Helmet of Anduran."
+msgstr ""
+
+msgid "For the good of the Empire, eliminate Kraeger."
+msgstr ""
+
+msgid ""
+"At last, you have the opportunity and the facilities to rid the Empire of "
+"the necromancer's evil. Eradicate them completely, and you will be sung as a "
+"hero for all time."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Conquer and unite all the enemy tribes. Don't lose the hero Jarkonas, the "
+"forefather of all descendants."
+msgstr ""
+"Une las Tribus. No pierdas a tu héroe principal, el primer Descendiente."
+
+msgid ""
+"Your rival, the Kingdom of Harondale, is attacking weak towns on your "
+"border! Recover from their first strike and crush them completely!"
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Find your wayward son Joseph who is rumored to be living in the desolate "
+"lands. Do it before the first day of the third month or it will be of no "
+"help to your family."
+msgstr ""
+"Encuentra a tu caprichoso hijo, del que se rumorea que vive en las tierras "
+"desoladas. Házlo en menos de 8 semanas o no será de ninguna ayuda para tu "
+"familia."
+
+#, fuzzy
+msgid ""
+"Rescue your crazy uncle Ivan. Find him before the first day of the fourth "
+"month or it will be no help to your kingdom."
+msgstr ""
+"Rescata a tu loco Tío Iván. Encuéntrale en 4 meses o no habrá ayuda para tu "
+"reino."
+
+#, fuzzy
+msgid ""
+"Destroy the barbarians who are attacking the southern border of your "
+"kingdom! Recover your fallen towns, and then invade the jungle kingdom. "
+"Leave no enemy standing."
+msgstr ""
+"¡Destruye a los Bárbaros que están atacando la frontera sur de tu reino! "
+"Recupera tus ciudades y entonces invade el reino jungla."
+
+#, fuzzy
+msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
+msgstr "Reconquista el Castillo de las Puertas de Marfil."
+
+#, fuzzy
+msgid ""
+"Gain the favor of the elves. They will not allow trees to be chopped down, "
+"so they will send you wood every 2 weeks. You must complete your mission "
+"before the first day of the seventh month, or the kingdom will surely fall."
+msgstr ""
+"Consigue la ayuda de los elfos. No permitirán que se talen árboles, así que "
+"te enviaremos madera cada 2 semanas. ¡Tienes 7 meses!"
+
+msgid ""
+"This is the final battle against your rival kingdom of Harondale. Eliminate "
+"everyone, and don't lose the hero Jarkonas VI."
+msgstr ""
+
+msgid ""
+"Your mission is to vanquish the warring mages in the magical Shrouded Isles. "
+"The completion of this task will give you a fighting chance against your "
+"rivals."
+msgstr ""
+
+msgid ""
+"The location of the great library has been dicovered! You must make your way "
+"to it, and reclaim the city of Chronos in which it lies."
+msgstr ""
+
+msgid ""
+"Find the Orb of negation, which is said to be buried in this land. There are "
+"clues inscribed on stone obelisks which will help lead you to your price. "
+"Find the orb before the first day of the sixth month, or your rivals will "
+"surely have gotten to the fount before you."
+msgstr ""
+
+msgid ""
+"You must take control of the castle of Magic, where the fount of wizardry "
+"lies. Do this and your victory will be supreme."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Capture the town on the island off the southeast shore in order to construct "
+"a boat and travel back towards the mainland. Do not lose the hero Gallavant."
+msgstr ""
+"Captura la ciudad de la isla en la costa sureste para construir un barco y "
+"navegar de vuelta al continente."
+
+msgid ""
+"Find and defeat Martine, the pirate leader, who resides in Pirates Cove. Do "
+"not lose Gallavant or your quest will be over."
+msgstr ""
+
+msgid ""
+"Eliminate all the other forces who oppose the rule of Lord Alberon. "
+"Gallavant must not die."
+msgstr ""
+
+msgid ""
+"Overthrow the entrenched monarchy of Lord Alberon, and claim all the land in "
+"your name. Gallavant must not die."
+msgstr ""
+
+msgid " bane"
+msgstr ""
+
+#, fuzzy
+msgid " alliance"
+msgstr "Alianza Rota"
+
+msgid "Carry-over forces"
+msgstr ""
+
+#, fuzzy
+msgid " bonus"
+msgstr "Bonificación del Rojo"
+
+msgid " defeated"
+msgstr ""
+
+#, fuzzy
+msgid "Thunder Mace"
+msgstr "Maza del Trueno de Dominio"
+
+#, fuzzy
+msgid "Minor Scroll"
+msgstr "Pergamino Menor de Conocimiento"
+
+#, fuzzy
+msgid "Dragon Sword"
+msgstr "Matadragones"
+
+#, fuzzy
+msgid "Breastplate"
+msgstr "Peto de Anduran"
+
+msgid "Fibzin Medal"
+msgstr ""
+
+#, fuzzy
+msgid "Mage's ring"
+msgstr "Anillo del Mago del Poder"
+
+#, fuzzy
+msgid "Defender Helm"
+msgstr "Defensor"
+
+#, fuzzy
+msgid "Power Axe"
+msgstr "Poder"
+
+#, fuzzy
+msgid "Summon Earth"
+msgstr "LLamar Barco"
+
 msgid "The %{building} produces %{monster}."
 msgstr "Produce: %{monster}."
 
-#: ../fheroes2/castle/buildinginfo.cpp:505
 msgid "Requires:"
 msgstr "Requiere:"
 
-#: ../fheroes2/castle/buildinginfo.cpp:597
 msgid "Cannot build. Already built here this turn."
 msgstr "No se puede construir. Ya se construyo en este turno."
 
-#: ../fheroes2/castle/buildinginfo.cpp:601
 msgid "For this action it is necessary first to build a castle."
 msgstr "Para realizar esa acción primero es necesario construir un castillo."
 
-#: ../fheroes2/castle/buildinginfo.cpp:623
 msgid "Cannot build %{name} because castle is too far from water."
 msgstr ""
 "No se puede construir %{name} porque el castillo está demasiado lejos del "
 "agua."
 
-#: ../fheroes2/castle/buildinginfo.cpp:631
-msgid "Cannot afford %{name}"
+#, fuzzy
+msgid "Cannot afford %{name}."
 msgstr "No se puede pagar el %{name}"
 
-#: ../fheroes2/castle/buildinginfo.cpp:636
-msgid "%{name} is already built"
+#, fuzzy
+msgid "%{name} is already built."
 msgstr "El %{name} ya está construido"
 
-#: ../fheroes2/castle/buildinginfo.cpp:641
-msgid "Cannot build %{name}"
+#, fuzzy
+msgid "Cannot build %{name}."
 msgstr "No se puede construir %{name}"
 
-#: ../fheroes2/castle/buildinginfo.cpp:646
-msgid "Build %{name}"
+#, fuzzy
+msgid "Build %{name}."
 msgstr "Construir %{name}"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Thieves' Guild"
 msgstr "Gremio de Ladrones"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Tavern"
 msgstr "Taverna"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Shipyard"
 msgstr "Astillero"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Well"
 msgstr "Pozo"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Statue"
 msgstr "Estatua"
 
-#: ../fheroes2/castle/castle.cpp:467
-#: ../fheroes2/dialog/dialog_marketplace.cpp:212
 msgid "Marketplace"
 msgstr "Mercado"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Moat"
 msgstr "Foso"
 
-#: ../fheroes2/castle/castle.cpp:467 ../fheroes2/maps/mp2.cpp:391
 msgid "Castle"
 msgstr "Castillo"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Tent"
 msgstr "Tienda"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Captain's Quarters"
 msgstr "Alojamiento del Capitán"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Mage Guild, Level 1"
 msgstr "Torre Mágica, Nivel 1"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 2"
 msgstr "Torre Mágica, Nivel 2"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 3"
 msgstr "Torre Mágica, Nivel 3"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 4"
 msgstr "Torre Mágica, Nivel 4"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 5"
 msgstr "Torre Mágica, Nivel 5"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Farm"
 msgstr "Granja"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Garbage Heap"
 msgstr "Vertedero"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Crystal Garden"
 msgstr "Jardín de Cristales"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Waterfall"
 msgstr "Cascada"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Orchard"
 msgstr "Huerta"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Skull Pile"
 msgstr "Pila de Calaveras"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Fortifications"
 msgstr "Fortificación"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Coliseum"
 msgstr "Coliseo"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Rainbow"
 msgstr "Arcoíris"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Dungeon"
 msgstr "Mazmorra"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Library"
 msgstr "Biblioteca"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Storm"
 msgstr "Tormenta"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:498
 msgid "Thatched Hut"
 msgstr "Cobertizo"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Hut"
 msgstr "Choza"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Treehouse"
 msgstr "Casa en los Árboles"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:441
 msgid "Cave"
 msgstr "Cueva"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Habitat"
 msgstr "Hábitat"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:431
 msgid "Excavation"
 msgstr "Excavación"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:477
 msgid "Archery Range"
 msgstr "Campo de Tiro"
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Stick Hut"
 msgstr "Chamizo"
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Cottage"
 msgstr "Casa de Campo"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Crypt"
 msgstr "Cripta"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Pen"
 msgstr "Corral"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/maps/mp2.cpp:371
 msgid "Graveyard"
 msgstr "Cementerio"
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Blacksmith"
 msgstr "Herrero"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Den"
 msgstr "Lobera"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Nest"
 msgstr "Nido"
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Foundry"
 msgstr "Fundición"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:480
-#: ../fheroes2/castle/castle.cpp:487 ../fheroes2/maps/mp2.cpp:427
-#: ../fheroes2/resource/maps_text.cpp:521
 msgid "Pyramid"
 msgstr "Pirámide"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Armory"
 msgstr "Armería"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Adobe"
 msgstr "Adobe"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Stonehenge"
 msgstr "Stonehenge"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Maze"
 msgstr "Laberinto"
 
-#: ../fheroes2/castle/castle.cpp:478 ../fheroes2/castle/castle.cpp:485
 msgid "Cliff Nest"
 msgstr "Nido del acantilado"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Mansion"
 msgstr "Mansión"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Jousting Arena"
 msgstr "Campo de Justa"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Bridge"
 msgstr "Puente"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
 msgid "Fenced Meadow"
 msgstr "Prado Vallado"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Swamp"
 msgstr "Ciénaga"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Ivory Tower"
 msgstr "Torre de Marfil"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Mausoleum"
 msgstr "Mausoleo"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cathedral"
 msgstr "Catedral"
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Red Tower"
 msgstr "Torre Roja"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Green Tower"
 msgstr "Torre Verde"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cloud Castle"
 msgstr "Castillo de las Nubes"
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Laboratory"
 msgstr "Laboratorio"
 
-#: ../fheroes2/castle/castle.cpp:483 ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Archery Range"
 msgstr "Mej. Campo de Tiro"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Stick Hut"
 msgstr "Mej. Chamizo"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Cottage"
 msgstr "Casa de Campo Mejorada"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Graveyard"
 msgstr "Cementerio Mejorado"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Blacksmith"
 msgstr "Herrería Mejorada"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Foundry"
 msgstr "Fundición Mejorada"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Pyramid"
 msgstr "Pirámide Mejorada"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Armory"
 msgstr "Armería Mejorada"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Adobe"
 msgstr "Adobe Mejorado"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Stonehenge"
 msgstr "Mej. Mejorado"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Maze"
 msgstr "Laberinto Mejorado"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Mansion"
 msgstr "Mansión Mejorada"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Jousting Arena"
 msgstr "Mej. Campo de Justa"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Bridge"
 msgstr "Puente Mejorado"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Ivory Tower"
 msgstr "Torre de Marfil Mejorada"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Mausoleum"
 msgstr "Mausoleo Mejorado"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cathedral"
 msgstr "Catedral Mejorada"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cloud Castle"
 msgstr "Castillo de las Nubes Mejorado"
 
-#: ../fheroes2/castle/castle.cpp:488
 msgid "Black Tower"
 msgstr "Torre Negra"
 
-#: ../fheroes2/castle/castle.cpp:490
 msgid "Shrine"
 msgstr "Santuario"
 
-#: ../fheroes2/castle/castle.cpp:552
+#, fuzzy
 msgid ""
 "The Thieves' Guild provides information on enemy players. Thieves' Guilds "
-"can also provide scouting information on enemy towns."
+"can also provide scouting information on enemy towns. Additional Guilds "
+"provide more information."
 msgstr ""
 "El Gremio de los Ladrones ofrece información sobre los héroes enemigos y sus "
 "cuidades."
 
-#: ../fheroes2/castle/castle.cpp:553
 msgid "The Tavern increases morale for troops defending the castle."
 msgstr ""
 "La Taberna incrementa la moral de las tropas miestras defiendes el castillo."
 
-#: ../fheroes2/castle/castle.cpp:554
 msgid "The Shipyard allows ships to be built."
 msgstr "El Astillero permite construir barcos."
 
-#: ../fheroes2/castle/castle.cpp:555
 msgid ""
 "The Well increases the growth rate of all dwellings by %{count} creatures "
 "per week."
@@ -1080,24 +1359,20 @@ msgstr ""
 "El Pozo incrementa el ritmo de crecimiento de todas las moradas en %{count} "
 "criaturas por semana."
 
-#: ../fheroes2/castle/castle.cpp:556
 msgid "The Statue increases your town's income by %{count} per day."
 msgstr ""
 "La Estatua incrementa los ingresos de tus ciudades en %{count} por día."
 
-#: ../fheroes2/castle/castle.cpp:557
 msgid "The Left Turret provides extra firepower during castle combat."
 msgstr ""
 "El Torreón Izquierdo proporciona un disparo extra durante el asalto al "
 "castillo."
 
-#: ../fheroes2/castle/castle.cpp:558
 msgid "The Right Turret provides extra firepower during castle combat."
 msgstr ""
 "El Torreón Derecho proporciona un disparo extra durante el asalto al "
 "castillo."
 
-#: ../fheroes2/castle/castle.cpp:559
 msgid ""
 "The Marketplace can be used to convert one type of resource into another. "
 "The more marketplaces you control, the better the exchange rate."
@@ -1105,7 +1380,6 @@ msgstr ""
 "El Mercado puede ser usado para convertir uno de los tipos de recursos en "
 "otro. Cuantos más mercados controles, mejor será el precio de intercambio."
 
-#: ../fheroes2/castle/castle.cpp:560
 msgid ""
 "The Moat slows attacking units. Any unit entering the moat must end its turn "
 "there and becomes more vulnerable to attack."
@@ -1113,15 +1387,13 @@ msgstr ""
 "El Foso ralentiza a las unidades atacantes. Cualquier unidad que entre en el "
 "foso terminará su turno y será más vulnerable a los ataques."
 
-#: ../fheroes2/castle/castle.cpp:561
 msgid ""
 "The Castle improves town defense and increases income to %{count} gold per "
 "day."
 msgstr ""
-"El Castillo mejora las defensas de la ciudad e incrementa los ingresos en %"
-"{count} de oro al día."
+"El Castillo mejora las defensas de la ciudad e incrementa los ingresos en "
+"%{count} de oro al día."
 
-#: ../fheroes2/castle/castle.cpp:562
 msgid ""
 "The Tent provides workers to build a castle, provided the materials and the "
 "gold are available."
@@ -1129,7 +1401,6 @@ msgstr ""
 "La Tienda provee de trabajadores para construir un castillo, con la "
 "condición de que estén disponibles los materiales y el oro."
 
-#: ../fheroes2/castle/castle.cpp:563
 msgid ""
 "The Captain's Quarters provides a captain to assist in the castle's defense "
 "when no hero is present."
@@ -1137,7 +1408,6 @@ msgstr ""
 "El Alojamiento del Capitán provee un capitán para que asista en la defensa "
 "del castillo cuando no hay un héroe presente."
 
-#: ../fheroes2/castle/castle.cpp:564
 msgid ""
 "The Mage Guild allows heroes to learn spells and replenish their spell "
 "points."
@@ -1145,40 +1415,33 @@ msgstr ""
 "La Torre Mágica permite aprender hechizos y restablecer los puntos de Maná a "
 "los héroes visitantes."
 
-#: ../fheroes2/castle/castle.cpp:567
 msgid "The Farm increases production of Peasants by %{count} per week."
 msgstr ""
 "La Granja incrementa la producción de Campesinos en %{count} por semana."
 
-#: ../fheroes2/castle/castle.cpp:568
 msgid "The Garbage Heap increases production of Goblins by %{count} per week."
 msgstr ""
 "El Montón de Basura incrementa la producción de Globlins en %{count} por "
 "semana."
 
-#: ../fheroes2/castle/castle.cpp:569
 msgid ""
 "The Crystal Garden increases production of Sprites by %{count} per week."
 msgstr ""
 "El Jardín de Cristales incrementa la producción de Hadas en %{count} por "
 "semana."
 
-#: ../fheroes2/castle/castle.cpp:570
 msgid "The Waterfall increases production of Centaurs by %{count} per week."
 msgstr ""
 "La Cascada incrementa la producción de Centauros en %{count} por semana."
 
-#: ../fheroes2/castle/castle.cpp:571
 msgid "The Orchard increases production of Halflings by %{count} per week."
 msgstr "El Huerto incrementa la producción de Medianos en %{count} por semana."
 
-#: ../fheroes2/castle/castle.cpp:572
 msgid "The Skull Pile increases production of Skeletons by %{count} per week."
 msgstr ""
 "La Pila de Calaberas incrementa la producción de Esqueletos en %{count} por "
 "semana."
 
-#: ../fheroes2/castle/castle.cpp:575
 msgid ""
 "The Fortifications increase the toughness of the walls, increasing the "
 "number of turns it takes to knock them down."
@@ -1186,7 +1449,6 @@ msgstr ""
 "La Fortificación incrementa la dureza de los muros, incrementa el número de "
 "turnos que se tarda en derribar el muro."
 
-#: ../fheroes2/castle/castle.cpp:576
 msgid ""
 "The Coliseum provides inspiring spectacles to defending troops, raising "
 "their morale by two during combat."
@@ -1194,147 +1456,133 @@ msgstr ""
 "El Coliseo provee de inspiradores espectaculos a las tropas defensoras, "
 "aumentando la moral en 2 durante el combate."
 
-#: ../fheroes2/castle/castle.cpp:577
 msgid "The Rainbow increases the luck of the defending units by two."
 msgstr "El Arcoíris incrementa la suerte de las unidades defensoras en 2."
 
-#: ../fheroes2/castle/castle.cpp:578
 msgid "The Dungeon increases the income of the town by %{count} / day."
 msgstr "La Mazmorra incrementa los ingresos de la ciudad en %{count} por día."
 
-#: ../fheroes2/castle/castle.cpp:579
 msgid ""
 "The Library increases the number of spells in the Guild by one for each "
 "level of the guild."
 msgstr ""
 "La Biblioteca proporciona un hechizo extra en cada nivel de la Torre Mágica."
 
-#: ../fheroes2/castle/castle.cpp:580
 msgid "The Storm adds +2 to the power of spells of a defending spell caster."
 msgstr ""
 "La Tormenta añade +2 al poder de hechizo del lanzador de hechizos defensor."
 
-#: ../fheroes2/castle/castle.cpp:582
 msgid ""
 "The Shrine increases the necromancy skill of all your necromancers by 10 "
 "percent."
 msgstr "El Santuario incrementa la habilidad de nigromancia."
 
-#: ../fheroes2/castle/castle.cpp:632
 msgid "Cannot recruit - you already recruit hero in current week."
 msgstr "No se puede reclutar - Ya has reclutado un héroe esta semana"
 
-#: ../fheroes2/castle/castle.cpp:645
 #, fuzzy
 msgid "Cannot recruit - guest to guard automove error."
 msgstr "No puedes reclutar, tienes demasiados Héroes."
 
-#: ../fheroes2/castle/castle.cpp:651
 msgid "Cannot recruit - you already have a Hero in this town."
 msgstr "No puedes reclutar, ya tienes un Héroe en esta ciudad."
 
-#: ../fheroes2/castle/castle.cpp:659
 msgid "Cannot recruit - you have too many Heroes."
 msgstr "No puedes reclutar, tienes demasiados Héroes."
 
-#: ../fheroes2/castle/castle.cpp:665
 msgid "Cannot afford a Hero"
 msgstr "No puedes costearte reclutar un Héroe."
 
-#: ../fheroes2/castle/castle.cpp:756
 msgid "There is no room in the garrison for this army."
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:272
+msgid "Recruit %{name}"
+msgstr "Recluta %{name}"
+
 msgid "Month: %{month}, Week: %{week}, Day: %{day}"
 msgstr "Mes: %{month}, Semana: %{week}, Día: %{day}"
 
-#: ../fheroes2/castle/castle_dialog.cpp:393
-#: ../fheroes2/castle/castle_dialog.cpp:396
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:387
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:186
-msgid "Income:"
+#, fuzzy
+msgid "Income"
 msgstr "Ingresos:"
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 #, fuzzy
 msgid "Join Error"
 msgstr "Error"
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 msgid "Army is full"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
+msgid ""
+"You must purchase a spell book to use the mage guild, but you currently have "
+"no room for a spell book. Try giving one of your artifacts to another hero."
+msgstr ""
+"Debes compra un libro de hechizos para usar el gremio de magos, pero "
+"actualmente no tienes espacio para un libro de hechizos. Prueba dando uno de "
+"tus artefactos a otro héroe."
+
 msgid "Town"
 msgstr "Pueblo"
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
 msgid "This town may not be upgraded to a castle."
 msgstr "Este pueblo no se puede actualizar a castillo."
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit castle"
+#, fuzzy
+msgid "Exit Castle"
 msgstr "Salir del castillo"
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit town"
+#, fuzzy
+msgid "Exit Town"
 msgstr "Salir de la ciudad"
 
-#: ../fheroes2/castle/castle_dialog.cpp:730
 #, fuzzy
-msgid "Show income"
+msgid "Show Income"
 msgstr "Mostrar registros"
 
-#: ../fheroes2/castle/castle_dialog.cpp:734
 msgid "Show previous town"
 msgstr "Ver ciudad anterior"
 
-#: ../fheroes2/castle/castle_dialog.cpp:738
 msgid "Show next town"
 msgstr "Ver ciudad siguiente"
 
-#: ../fheroes2/castle/castle_dialog.cpp:741
 msgid "Swap Heroes"
 msgstr "Intercambiar Héroes"
 
-#: ../fheroes2/castle/castle_dialog.cpp:744
 msgid "Meeting Heroes"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:749
 msgid "View Hero"
 msgstr "Ver Heroe"
 
-#: ../fheroes2/castle/castle_mageguild.cpp:150
+#, fuzzy
+msgid "The above spells are available here."
+msgstr "Los hechizos anteriores han sido añadidos a tu Libro de Hechizos."
+
 msgid "The above spells have been added to your book."
 msgstr "Los hechizos anteriores han sido añadidos a tu Libro de Hechizos."
 
-#: ../fheroes2/castle/castle_tavern.cpp:39
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:748
 msgid "A generous tip for the barkeep yields the following rumor:"
 msgstr "Una generosa propina para el camarero te cede el siguiente rumor:"
 
-#: ../fheroes2/castle/castle_town.cpp:54
 msgid "Recruit Hero"
 msgstr "Reclutar Heroe"
 
-#: ../fheroes2/castle/castle_town.cpp:59
-msgid "%{name} is a level %{value} %{race}"
+#, fuzzy
+msgid "%{name} is a level %{value} %{race} "
 msgstr "%{name} es un nivel %{value} %{race}"
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with %{count} artifacts"
+#, fuzzy
+msgid "with %{count} artifacts."
 msgstr " con %{count} artefactos"
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with one artifact"
+#, fuzzy
+msgid "with 1 artifact."
 msgstr " con un artefacto"
 
-#: ../fheroes2/castle/castle_town.cpp:283
-#: ../fheroes2/heroes/heroes_dialog.cpp:108
+#, fuzzy
+msgid "without artifacts."
+msgstr " con %{count} artefactos"
+
 msgid ""
 "'Spread' combat formation spreads your armies from the top to the bottom of "
 "the battlefield, with at least one empty space between each army."
@@ -1343,7 +1591,6 @@ msgstr ""
 "superior a la inferior del campo de batalla con al menos un espacio vacio "
 "entre unidades."
 
-#: ../fheroes2/castle/castle_town.cpp:284
 msgid ""
 "'Grouped' combat formation bunches your army toget her in the center of your "
 "side of the battlefield."
@@ -1351,101 +1598,80 @@ msgstr ""
 "La formación 'Agrupada' de combate aglutina tu ejercito en el centro de tu "
 "flanco del campo de batalla."
 
-#: ../fheroes2/castle/castle_town.cpp:292
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:132
-#: ../fheroes2/heroes/heroes_meeting.cpp:284
 msgid "Attack Skill"
 msgstr "Ataque"
 
-#: ../fheroes2/castle/castle_town.cpp:301
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:137
-#: ../fheroes2/heroes/heroes_meeting.cpp:288
 msgid "Defense Skill"
 msgstr "Defensa"
 
-#: ../fheroes2/castle/castle_town.cpp:487
-#: ../fheroes2/heroes/heroes_dialog.cpp:334
 msgid "Spread Formation"
 msgstr "Formación Desplegada"
 
-#: ../fheroes2/castle/castle_town.cpp:489
-#: ../fheroes2/heroes/heroes_dialog.cpp:337
 msgid "Grouped Formation"
 msgstr "Formación Agrupada"
 
-#: ../fheroes2/castle/castle_town.cpp:540
-#: ../fheroes2/castle/castle_town.cpp:553
 msgid "Recruit %{name} the %{race}"
 msgstr "Reclutar a %{name} el %{race}"
 
-#: ../fheroes2/castle/castle_town.cpp:561
 msgid "Set garrison combat formation to 'Spread'"
 msgstr "Ordena a la guarnición formación Desplegada de combate."
 
-#: ../fheroes2/castle/castle_town.cpp:564
 msgid "Set garrison combat formation to 'Grouped'"
 msgstr "Ordena a la guarnición formación Agrupada de combate."
 
-#: ../fheroes2/castle/castle_town.cpp:567
+#, fuzzy
+msgid "Exit Castle Options"
+msgstr "Opciones del castillo"
+
 msgid "Castle Options"
 msgstr "Opciones del castillo"
 
-#: ../fheroes2/castle/castle_well.cpp:158
-msgid "Buy Monsters:"
+msgid "Not enough resources to buy monsters."
+msgstr ""
+
+msgid "No monsters available for purchase."
+msgstr ""
+
+#, fuzzy
+msgid "Buy Monsters"
 msgstr "Comprar Monstruos:"
 
-#: ../fheroes2/castle/castle_well.cpp:221
 msgid "Town Population Information and Statistics"
 msgstr "Población y estadísticas de la ciudad"
 
-#: ../fheroes2/castle/castle_well.cpp:323
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:231
 msgid "Damage"
 msgstr "Daño"
 
-#: ../fheroes2/castle/castle_well.cpp:329
 msgid "HP"
 msgstr "Daño (puntos)"
 
-#: ../fheroes2/castle/castle_well.cpp:335
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:266
-msgid "Speed"
-msgstr "Velocidad"
-
-#: ../fheroes2/castle/castle_well.cpp:351
 msgid "Growth"
 msgstr "Crecimiento"
 
-#: ../fheroes2/castle/castle_well.cpp:355
 msgid "week"
 msgstr "semana"
 
-#: ../fheroes2/castle/castle_well.cpp:361
-#: ../fheroes2/kingdom/kingdom_overview.cpp:479
 msgid "Available"
 msgstr "Disponible"
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:89
 msgid "View the entire world."
 msgstr "Ver el mundo entero."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:90
 msgid "View the obelisk puzzle."
 msgstr "Ver el puzzle del Obelisco"
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:91
 msgid "View information on the scenario you are currently playing."
 msgstr "Ver información del escenario que estás jugando actualmente."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:92
 msgid "Dig for the Ultimate Artifact."
 msgstr "Cavar buscando el Artefacto Definitivo."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:93
 msgid "Exit this menu without doing anything."
 msgstr "Cerrar este menú sin hacer cambios"
 
-#: ../fheroes2/dialog/dialog_arena.cpp:48
+msgid "Arena"
+msgstr "Arena"
+
 msgid ""
 "You enter the arena and face a pack of vicious lions. You handily defeat "
 "them, to the wild cheers of the crowd.  Impressed by your skill, the aged "
@@ -1456,45 +1682,41 @@ msgstr ""
 "veterano entrenador de gladiadores acepta adiestrarte en la habilidad que "
 "prefieras."
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:154
-msgid ""
-"Your troops can be upgraded, but it will cost you %{ratio} times the "
-"difference in cost for each troop, rounded up to next highest number. Do you "
-"wish to upgrade them?"
-msgstr ""
-"Tus tropas pueden mejorarse, pero te costará %{ratio} veces la diferencia en "
-"coste para cada tropa, redondeando al alza. ¿Quieres actualizarlas?"
-
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:155
 msgid ""
 "Your troops can be upgraded, but it will cost you dearly. Do you wish to "
 "upgrade them?"
 msgstr ""
 "Tus tropas pueden ser mejoradas, pero te saldrá caro. ¿Quieres actualizarlas?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:166
 msgid "Are you sure you want to dismiss this army?"
 msgstr "¿Estás seguro de que desea descartar este ejército?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots Left"
 msgstr "Disparos restantes"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots"
 msgstr "Disparos"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:244
 msgid "Hit Points"
 msgstr "Puntos de daño"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:255
 msgid "Hit Points Left"
 msgstr "Vida Restante"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:379
+#, fuzzy
+msgid "Followers"
+msgstr "Flores"
+
 msgid ""
-"The creature is swayed by your diplomatic tongue, and offers to join your "
+"A group of %{monster} with a desire for greater glory wish to join you.\n"
+"Do you accept?"
+msgstr ""
+"Un grupo de %{monster} con ansia de gloria desea unirse a tus tropas. "
+"¿Aceptas?"
+
+#, fuzzy
+msgid ""
+"The %{monster} is swayed by your diplomatic tongue, and offers to join your "
 "army for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
@@ -1502,7 +1724,6 @@ msgstr ""
 "ejercito por la suma de %{gold}  de oro.\n"
 "¿Aceptas?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:382
 msgid ""
 "The creatures are swayed by your diplomatic\n"
 "tongue, and make you an offer:\n"
@@ -1512,7 +1733,6 @@ msgstr ""
 "te hacen una oferta:\n"
 " \n"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:385
 msgid ""
 "%{offer} of the %{total} %{monster} will join your army, and the rest will "
 "leave you alone, for the sum of %{gold} gold.\n"
@@ -1521,39 +1741,60 @@ msgstr ""
 "%{offer} %{monster} del total se unirán a tu ejercito y el resto te dejará "
 "continuar, por la módica cantidad de %{gold} piezas de oro. ¿Aceptas?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:387
 msgid ""
 "All %{offer} of the %{monster} will join your army for the sum of %{gold} "
 "gold.\n"
 "Do you accept?"
 msgstr ""
-"Todos los %{monster} (%{offer}) se unirán a tu ejercito por la cantidad de %"
-"{gold} de oro.\n"
+"Todos los %{monster} (%{offer}) se unirán a tu ejercito por la cantidad de "
+"%{gold} de oro.\n"
 "¿Acepta?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:401
 msgid "(Rate: %{percent})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:451
-msgid ""
-"Not room in\n"
-"the garrison"
+msgid "No room in"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:48
+#, fuzzy
+msgid "the garrison"
+msgstr "las escaleras"
+
 msgid "Build a new ship:"
 msgstr "Construir un nuevo barco:"
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:63
 msgid "Resource cost:"
 msgstr "Coste del recurso:"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:40
-msgid "For the QVGA version is not available."
-msgstr "Para la versión QVGA no está disponible."
+msgid "Load Game"
+msgstr "Cargar juego"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:62
+#, fuzzy
+msgid "No save files to load."
+msgstr "Sin hechizos que lanzar."
+
+msgid "New Game"
+msgstr "Nueva partida"
+
+msgid "Start a single or multi-player game."
+msgstr "Comenzar una partida simple o multijugador"
+
+msgid "Load a previously saved game."
+msgstr "Cargar una partida previamente grabada."
+
+#, fuzzy
+msgid "Save Game"
+msgstr "Nueva partida"
+
+msgid "Save the current game."
+msgstr ""
+
+msgid "Quit"
+msgstr "Salir"
+
+msgid "Quit out of Free Heroes of Might and Magic II."
+msgstr ""
+
 msgid ""
 "Map\n"
 "Difficulty"
@@ -1561,7 +1802,6 @@ msgstr ""
 "Nivel\n"
 "del Mapa"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:65
 msgid ""
 "Game\n"
 "Difficulty"
@@ -1569,25 +1809,18 @@ msgstr ""
 "Dificultad\n"
 "del juego"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:68
 msgid "Rating"
 msgstr "Nivel"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:71
 msgid "Map Size"
 msgstr "Tamaño del Mapa"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:89
-#: ../fheroes2/system/players.cpp:691
 msgid "Opponents"
 msgstr "Contrincantes"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:92
-#: ../fheroes2/system/players.cpp:695
 msgid "Class"
 msgstr "Raza"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:100
 msgid ""
 "Victory\n"
 "Conditions"
@@ -1595,7 +1828,6 @@ msgstr ""
 "Condiciones\n"
 "de victoria"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:106
 msgid ""
 "Loss\n"
 "Conditions"
@@ -1603,48 +1835,34 @@ msgstr ""
 "Condiciones\n"
 "de derrota"
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:167
 msgid "You cannot select %{resource}!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:173
 msgid "Select count %{resource}:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:200
 msgid "Set Guardian"
 msgstr "Establecer Guardián"
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:236
-#: ../fheroes2/dialog/dialog_guardian.cpp:292
 msgid "Your army too big!"
 msgstr "¡Tu ejército es demasiado grande!"
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:34
-#: ../fheroes2/dialog/dialog_levelup.cpp:44
-#: ../fheroes2/dialog/dialog_levelup.cpp:73
 msgid "%{name} has gained a level."
 msgstr "%{name} ha ganado un nivel."
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:36
-#: ../fheroes2/dialog/dialog_levelup.cpp:46
-#: ../fheroes2/dialog/dialog_levelup.cpp:75
-msgid "%{skill} Skill +1"
+#, fuzzy
+msgid "%{skill} +1"
 msgstr "La habilidad %{skill} obtiene +1"
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:51
 msgid "You have learned %{skill}."
 msgstr "Has aprendido %{skill}."
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:93
 msgid "You may learn either:"
 msgstr "Puedes aprender:"
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:96
 msgid "or"
 msgstr "o"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:66
 msgid ""
 "Please inspect our fine wares. If you feel like offering a trade, click on "
 "the items you wish to trade with and for."
@@ -1652,7 +1870,6 @@ msgstr ""
 "Por favor ojea nuestros magníficos puestos. Si te apetece comerciar, haz "
 "click en los artículos que deseas cambiar y obtener."
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:104
 msgid ""
 "You have received quite a bargain. I expect to make no profit on the deal. "
 "Can I interest you in any of my other wares?"
@@ -1660,219 +1877,187 @@ msgstr ""
 "Te llevas una ganga, creo que no ganaré nada con el trato. ¿Hay algo que te "
 "pueda ofrecer de cualquiera de mis otros puestos ?"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:130
 msgid "I can offer you %{count} for 1 unit of %{resfrom}."
 msgstr "Te puedo ofrecer %{count} por 1 unidad de  %{resfrom}."
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:136
 msgid "I can offer you 1 unit of %{resto} for %{count} units of %{resfrom}."
 msgstr ""
 "Te puedo ofrecer 1 unidad de %{resto} por %{count} unidades de %{resfrom}"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:164
 msgid "Qty to trade"
 msgstr "Cantidad a comerciar"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:235
+msgid "Trading Post"
+msgstr "Mercadillo"
+
 msgid "Your Resources"
 msgstr "Tus recursos"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:257
 msgid "Available Trades"
 msgstr "Tratos Disponibles"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:573
 msgid "n/a"
 msgstr "No disponible"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:77
-msgid "guarded by %{count} of %{monster}"
+#, fuzzy
+msgid "guarded by %{count} %{monster}"
 msgstr "protegido por %{count} %{monster}"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:149
 msgid "(available: %{count})"
 msgstr "(disponibles: %{count})"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:181
 msgid "already learned"
 msgstr "ya se ha aprendido"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:205
 msgid "already knows this skill"
 msgstr "ya conoce esta habilidad"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:212
 msgid "already has max skills"
 msgstr "ya tiene las habilidades al máximo"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:260
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:276
 msgid "(already visited)"
 msgstr "(ya visitado)"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
 msgid "(not visited)"
 msgstr "(no visitado)"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:296
+#, fuzzy
+msgid "Road"
+msgstr "Fin del camino"
+
+msgid "(digging ok)"
+msgstr ""
+
+msgid "(no digging)"
+msgstr ""
+
 msgid "penalty: %{cost}"
 msgstr "Penalización: %{cost}"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:382
-msgid "Unchartered Territory"
+#, fuzzy
+msgid "Uncharted Territory"
 msgstr "Territorio Virgen"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:635
 msgid "Defenders:"
 msgstr "Defensores:"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:674
-#: ../fheroes2/heroes/heroes_indicator.cpp:125
-#: ../fheroes2/heroes/heroes_indicator.cpp:171
 msgid "None"
 msgstr "Ninguna"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:756
-msgid "%{name} ( Level %{level} )"
+msgid "Unknown"
+msgstr ""
+
+#, fuzzy
+msgid "%{name} (Level %{level})"
 msgstr "%{name} ( Nivel %{level} )"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:884
 msgid "Move Points"
 msgstr "Puntos de movimiento"
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:40
-#: ../fheroes2/dialog/dialog_recrut.cpp:579
 msgid "Available: %{count}"
 msgstr "Disponible: %{count}"
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:101
-msgid "Cost per troop:"
-msgstr "Coste por tropa:"
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:107
-#: ../fheroes2/dialog/dialog_recrut.cpp:506
-msgid "Recruit %{name}"
-msgstr "Recluta %{name}"
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:210
 msgid "Number to buy:"
 msgstr "NÚMERO"
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:314
 msgid "How many troops to move?"
 msgstr "¿Cuántas tropas deseas mover?"
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:358
 msgid "Fast separation into slots:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:180
 msgid "File to Save:"
 msgstr "Archivo a Guardar:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:186
 msgid "File to Load:"
 msgstr "Archivo a Cargar:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:302
 msgid "Are you sure you want to delete file:"
 msgstr "Estas seguro de que quieres eliminar el archivo:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:305
 msgid "Warning!"
 msgstr "¡Advertencia!"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:144
-msgid "Maps Difficulty:"
+#, fuzzy
+msgid "Map difficulty:"
 msgstr "Nivel del mapa."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
+msgid "No maps exist at that size"
+msgstr ""
+
 msgid "Small Maps"
 msgstr "Mapas pequeños"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
-msgid "View only maps of size small (36x36)."
+#, fuzzy
+msgid "View only maps of size small (36 x 36)."
 msgstr "Ver sólo mapas pequeños (36x36)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
 msgid "Medium Maps"
 msgstr "Mapas medianos"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
-msgid "View only maps of size medium (72x72)."
+#, fuzzy
+msgid "View only maps of size medium (72 x 72)."
 msgstr "Ver sólo mapas medianos (72x72)"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
 msgid "Large Maps"
 msgstr "Mapas grandes"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
-msgid "View only maps of size large (108x108)."
+#, fuzzy
+msgid "View only maps of size large (108 x 108)."
 msgstr "Ver sólo mapas grandes (108x108)"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
 msgid "Extra Large Maps"
 msgstr "Mapas extra grandes"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
-msgid "View only maps of size extra large (144x144)."
+#, fuzzy
+msgid "View only maps of size extra large (144 x 144)."
 msgstr "Ver sólo mapas extra grandes (144x144)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "All Maps"
 msgstr "Todos los mapas"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "View all maps, regardless of size."
 msgstr "Ver todos los mapas, independientemente de su tamaño"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
 msgid "Players Icon"
 msgstr "Icono de los jugadores"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
+#, fuzzy
 msgid ""
-"Indicates how many players total are in the EditScenario. Any positions not "
+"Indicates how many players total are in the scenario. Any positions not "
 "occupied by humans will be occupied by computer players."
 msgstr ""
 "Indica cuantos jugadores hay en total en el editor de escenario. Cualquier "
 "posición no ocupada por humanos, será ocupada por jugadores virtuales."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
 msgid "Size Icon"
 msgstr "Icono del tamaño"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
+#, fuzzy
 msgid ""
-"Indicates whether the maps is small (36x36), medium (72x72), large "
-"(108x108), or extra large (144x144)."
+"Indicates whether the map\n"
+"is small (36 x 36), medium\n"
+"(72 x 72), large (108 x 108),\n"
+"or extra large (144 x 144)."
 msgstr ""
 "Indica si los mapas son pequeños (36x36), medianos (72x72), grandes "
 "(108x108) o extra grandes (144x144)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "Selected Name"
 msgstr "Nombre elegido"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "The name of the currently selected map."
 msgstr "El nombre del mapa actualmente seleccionado."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid "Selected Map Difficulty"
 msgstr "Dificultad del mapa elegido"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
+#, fuzzy
 msgid ""
 "The map difficulty of the currently selected map.  The map difficulty is "
-"determined by the EditScenario designer. More difficult maps might include "
-"more or stronger enemies, fewer resources, or other special conditions "
-"making things tougher for the human player."
+"determined by the scenario designer. More difficult maps might include more "
+"or stronger enemies, fewer resources, or other special conditions making "
+"things tougher for the human player."
 msgstr ""
 "La dificultad de mapa del mapa seleccionado actualmente. La dificultad de "
 "mapa se determina por el diseñador EdiScenario. Los mapas más difíciles "
@@ -1880,323 +2065,420 @@ msgstr ""
 "algunas otras condiciones que vuelvan las cosas más duras para el jugador "
 "humano."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "Selected Description"
 msgstr "Descripción seleccionada"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "The description of the currently selected map."
 msgstr "La descripción del mapa actualmente elegido"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
-msgid "OK"
-msgstr "OK"
+msgid "Okay"
+msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
 msgid "Accept the choice made."
 msgstr "Aceptar la elección realizada."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:364
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose all your heroes and towns."
 msgstr "Perder todos tus héroes y ciudades."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:365
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific town."
 msgstr "Perder una ciudad específica."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:366
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific hero."
 msgstr "Perder un héroe específico."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:367
 msgid "Run out of time. Fail to win by a certain point."
 msgstr "Se acaba el tiempo. No conseguir ganar llegado un punto determinado."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:370
 msgid "Loss Condition"
 msgstr "Condiciones de derrota"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:379
 msgid "Defeat all enemy heroes and towns."
 msgstr "Derrota a todos los heroes enemígos y sus ciudades."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:380
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Capture a specific town."
 msgstr "Capturar una ciudad específica."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:381
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat a specific hero."
 msgstr "Derrotar un héroe específico."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:382
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Find a specific artifact."
 msgstr "Encontrar un artefacto específico."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:383
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Your side defeats the opposing side."
 msgstr "Tu bando derrota al bando contrario."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:384
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Accumulate a large amount of gold."
 msgstr "Acumular una gran cantidad de dinero."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:387
 msgid "Victory Condition"
 msgstr "Condiciones de victoria"
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:48
-#: ../fheroes2/heroes/heroes_action.cpp:134
 msgid "one"
 msgstr "uno"
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:51
-#: ../fheroes2/heroes/heroes_action.cpp:135
 msgid "two"
 msgstr "dos"
 
-#: ../fheroes2/dialog/dialog_system.cpp:187
-msgid "sound"
-msgstr "sonido"
-
-#: ../fheroes2/dialog/dialog_system.cpp:192
-#: ../fheroes2/dialog/dialog_system.cpp:205
-#: ../fheroes2/dialog/dialog_system.cpp:228
-#: ../fheroes2/dialog/dialog_system.cpp:242
-msgid "off"
-msgstr "apagado"
-
-#: ../fheroes2/dialog/dialog_system.cpp:200
-msgid "music"
+#, fuzzy
+msgid "Music"
 msgstr "música"
 
-#: ../fheroes2/dialog/dialog_system.cpp:223
-msgid "hero speed"
+msgid "Toggle ambient music level."
+msgstr ""
+
+msgid "Effects"
+msgstr ""
+
+msgid "Toggle foreground sounds level."
+msgstr ""
+
+msgid "Music Type"
+msgstr ""
+
+msgid "Change the type of music."
+msgstr ""
+
+#, fuzzy
+msgid "Hero Speed"
 msgstr "Velocidad del héroe"
 
-#: ../fheroes2/dialog/dialog_system.cpp:237
-msgid "ai speed"
-msgstr "velocidad de la IA"
+msgid "Change the speed at which your heroes move on the main screen."
+msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:251
-msgid "scroll speed"
+#, fuzzy
+msgid "Enemy Speed"
+msgstr "Velocidad"
+
+msgid ""
+"Sets the speed that A.I. heroes move at.  You can also elect not to view A."
+"I. movement at all."
+msgstr ""
+
+#, fuzzy
+msgid "Scroll Speed"
 msgstr "Velocidad de desplazamiento"
 
-#: ../fheroes2/dialog/dialog_system.cpp:262
-#: ../fheroes2/dialog/dialog_system.cpp:276
+msgid "Sets the speed at which you scroll the window."
+msgstr ""
+
+#, fuzzy
+msgid "Interface Type"
+msgstr "Interfaz"
+
+msgid "Toggle the type of interface you want to use."
+msgstr ""
+
 msgid "Interface"
 msgstr "Interfaz"
 
-#: ../fheroes2/dialog/dialog_system.cpp:265
+msgid "Toggle interface visibility."
+msgstr ""
+
+#, fuzzy
+msgid "Battles"
+msgstr "Botella"
+
+msgid "Toggle instant battle mode."
+msgstr ""
+
+msgid "OK"
+msgstr "OK"
+
+#, fuzzy
+msgid "Exit this menu."
+msgstr "Esta unidad espera"
+
+msgid "off"
+msgstr "apagado"
+
+msgid "MIDI"
+msgstr ""
+
+#, fuzzy
+msgid "MIDI Expansion"
+msgstr "Mansión"
+
+msgid "CD Stereo"
+msgstr ""
+
+msgid "External"
+msgstr ""
+
+msgid "Jump"
+msgstr ""
+
+msgid "Don't Show"
+msgstr ""
+
 msgid "Evil"
 msgstr "Mal"
 
-#: ../fheroes2/dialog/dialog_system.cpp:267
 msgid "Good"
 msgstr "Bien"
 
-#: ../fheroes2/dialog/dialog_system.cpp:281
 msgid "Hide"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:287
 msgid "Show"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:285
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:96
+msgid "Auto Resolve"
+msgstr ""
+
+msgid "Auto, No Spells"
+msgstr ""
+
+msgid "Manual"
+msgstr ""
+
+msgid "Att."
+msgstr ""
+
+msgid "Def."
+msgstr ""
+
+msgid "Power"
+msgstr "Poder"
+
+#, fuzzy
+msgid "Knowl"
+msgstr "Conocimiento"
+
+msgid "Human"
+msgstr ""
+
 msgid "1st"
 msgstr "1º"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:286
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:97
 msgid "2nd"
 msgstr "2º"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:98
 msgid "3rd"
 msgstr "3º"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:288
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:99
 msgid "4th"
 msgstr "4º"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:289
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:100
 msgid "5th"
 msgstr "5º"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:290
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:101
 msgid "6th"
 msgstr "6º"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:305
-msgid "Thieves' Guild: Player RanKings"
+#, fuzzy
+msgid "Oracle: Player Rankings"
 msgstr "Gremio de ladrones: Clasificación de jugadores"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:315
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:114
+#, fuzzy
+msgid "Thieves' Guild: Player Rankings"
+msgstr "Gremio de ladrones: Clasificación de jugadores"
+
 msgid "Number of Towns:"
 msgstr "Número de ciudades:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:324
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:123
 msgid "Number of Castles:"
 msgstr "Número de castillos:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:333
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:132
 msgid "Number of Heroes:"
 msgstr "Número de héroes:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:342
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:141
 msgid "Gold in Treasury:"
 msgstr "Fondos de oro"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:351
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:150
 msgid "Wood & Ore:"
 msgstr "Madera y hierro"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:360
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:159
 msgid "Gems, Cr, Slf & Mer:"
 msgstr "Gem, Crist, Azuf y Merc"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:369
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:168
 msgid "Obelisks Found:"
 msgstr "Obeliscos encontrados:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:378
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:177
+#, fuzzy
+msgid "Artifacts:"
+msgstr "Artefactos"
+
 msgid "Total Army Strength:"
 msgstr "Fuerza total del ejercito:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:408
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:211
+msgid "Income:"
+msgstr "Ingresos:"
+
 msgid "Best Hero:"
 msgstr "Mejor héroe:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:417
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:220
 msgid "Best Hero Stats:"
 msgstr "Estadísticas (mejor héroe):"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:426
 msgid "Personality:"
 msgstr "Personalidad:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:435
 msgid "Best Monster:"
 msgstr "Mejor monstruo:"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Easy"
 msgstr "Fácil"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Normal"
 msgstr "Normal"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Hard"
 msgstr "Difícil"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Expert"
 msgstr "Experto"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Impossible"
 msgstr "Imposible"
 
-#: ../fheroes2/game/game.cpp:314
-msgid "Maps Loading..."
+#, fuzzy
+msgid "Map is loading..."
 msgstr "Cargando mapas..."
 
-#: ../fheroes2/game/game_highscores.cpp:239
-#: ../fheroes2/game/game_highscores.cpp:242
+msgid "and more..."
+msgstr ""
+
+msgid "Campaign Scenario loading failure"
+msgstr ""
+
+msgid "Please make sure that campaign files are correct and present."
+msgstr ""
+
 msgid "Unknown Hero"
 msgstr ""
 
-#: ../fheroes2/game/game_highscores.cpp:240
 msgid "Your Name"
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:95
-msgid "Are you sure you want to overwrite the save with this name?"
-msgstr ""
-"¿Estás seguro de que quieres sobreescribir el guardado con este nombre?"
-
-#: ../fheroes2/game/game_io.cpp:191
 msgid ""
-"This file is saved in the \"Price Loyalty\" version.\n"
+"Invalid file game type. Please ensure that you are running the latest type "
+"of save files."
+msgstr ""
+
+msgid ""
+"This file is saved in the \"The Price of Loyalty\" version.\n"
 "Some items may be unavailable."
 msgstr ""
 
-#: ../fheroes2/game/game_mainmenu.cpp:157
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:95
-msgid "Quit"
-msgstr "Salir"
+msgid "Hot Seat"
+msgstr "Asiento caliente."
 
-#: ../fheroes2/game/game_mainmenu.cpp:157
+msgid ""
+"Play a Hot Seat game, where 2 to 4 players play around the same computer, "
+"switching into the 'Hot Seat' when it is their turn."
+msgstr ""
+"Juega una partida de \"Asiento caliente\" donde de 2 a 4 jugadores juegan en "
+"el mismo PC por turnos."
+
+msgid "Cancel back to the main menu."
+msgstr "Cancelar y volver al menú principal."
+
+msgid "Network"
+msgstr "Red"
+
+msgid ""
+"Play a network game, where 2 players use their own computers connected "
+"through a LAN (Local Area Network)."
+msgstr ""
+"Jugar una partida de red donde 2 jugadores usan sus propios PCs conectados "
+"en una LAN. (Red de Área Local)."
+
+msgid "Standard Game"
+msgstr "Juego estandar"
+
+msgid "A single player game playing out a single map."
+msgstr "Un solo jugador jugando un único mapa."
+
+msgid "Campaign Game"
+msgstr "Partida de Campaña."
+
+#, fuzzy
+msgid "A single player game playing through a series of maps."
+msgstr "Un solo jugador jugando un único mapa."
+
+msgid "Multi-Player Game"
+msgstr "Juego multi-jugador"
+
+msgid ""
+"A multi-player game, with several human players completing against each "
+"other on a single map."
+msgstr ""
+"Una partida multijugador con varios jugadores humanos compitiendo entre "
+"ellos en un mapa."
+
+#, fuzzy
+msgid "Greetings!"
+msgstr "Ajustes"
+
+msgid ""
+"Welcome to Free Heroes of Might and Magic II! Before starting the game "
+"please choose game resolution."
+msgstr ""
+
+msgid "Please Remember"
+msgstr ""
+
+msgid "You can always change game resolution by clicking on the "
+msgstr ""
+
+msgid "door"
+msgstr ""
+
+msgid ""
+" on the left side of main menu.\n"
+"\n"
+"To switch between windowed and full screen modes\n"
+"press "
+msgstr ""
+
+msgid "F4"
+msgstr ""
+
+msgid ""
+" key on the keyboard.\n"
+"\n"
+"Enjoy the game!"
+msgstr ""
+
 msgid "Quit Heroes of Might and Magic and return to the operating system."
 msgstr "Salir del juego y volver al sistema operativo."
 
-#: ../fheroes2/game/game_mainmenu.cpp:159
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:79
-msgid "Load Game"
-msgstr "Cargar juego"
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-msgid "Load a previously saved game."
-msgstr "Cargar una partida previamente grabada."
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:91
 msgid "Credits"
 msgstr "Creditos"
 
-#: ../fheroes2/game/game_mainmenu.cpp:161
 msgid "View the credits screen."
 msgstr "Ver la pantalla de créditos"
 
-#: ../fheroes2/game/game_mainmenu.cpp:163
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:87
 msgid "High Scores"
 msgstr "Puntuaciones más altas"
 
-#: ../fheroes2/game/game_mainmenu.cpp:163
 msgid "View the high score screen."
 msgstr "Ver la pantalla de puntuaciones más altas"
 
-#: ../fheroes2/game/game_mainmenu.cpp:165
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:75
-msgid "New Game"
-msgstr "Nueva partida"
+#, fuzzy
+msgid "Select Game Resolution"
+msgstr "Descripción seleccionada"
 
-#: ../fheroes2/game/game_mainmenu.cpp:165
-msgid "Start a single or multi-player game."
-msgstr "Comenzar una partida simple o multijugador"
+msgid "Change resolution of the game."
+msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:127
+msgid "Original Campaign"
+msgstr ""
+
+msgid ""
+"Either Roland's or Archibald's campaign from the original Heroes of Might "
+"and Magic II."
+msgstr ""
+
+msgid "Expansion Campaign"
+msgstr ""
+
+msgid "One of the four new campaigns from the Price of Loyalty expansion set."
+msgstr ""
+
 msgid "Host"
 msgstr "Anfitrión"
 
-#: ../fheroes2/game/game_newgame.cpp:127
 msgid ""
 "The host sets up the game options. There can only be one host per network "
 "game."
@@ -2204,11 +2486,9 @@ msgstr ""
 "El anfitrión establece las opciones de la partida. Solo puede haber un "
 "anfitrión por partida en red."
 
-#: ../fheroes2/game/game_newgame.cpp:128
 msgid "Guest"
 msgstr "Invitado"
 
-#: ../fheroes2/game/game_newgame.cpp:128
 msgid ""
 "The guest waits for the host to set up the game, then is automatically added "
 "in. There can be multiple guests for TCP/IP games."
@@ -2217,73 +2497,23 @@ msgstr ""
 "añadido automáticamente en ella. Pueden haber varios invitados en las "
 "partidas TCP/IP."
 
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-msgid "Cancel back to the main menu."
-msgstr "Cancelar y volver al menú principal."
+#, fuzzy
+msgid "Battle Only"
+msgstr "Enano de Combate"
 
-#: ../fheroes2/game/game_newgame.cpp:214
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:154
-msgid "Standard Game"
-msgstr "Juego estandar"
-
-#: ../fheroes2/game/game_newgame.cpp:214
-msgid "A single player game playing out a single map."
-msgstr "Un solo jugador jugando un único mapa."
-
-#: ../fheroes2/game/game_newgame.cpp:216
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:162
-msgid "Multi-Player Game"
-msgstr "Juego multi-jugador"
-
-#: ../fheroes2/game/game_newgame.cpp:216
-msgid ""
-"A multi-player game, with several human players completing against each "
-"other on a single map."
+msgid "Setup and play a battle without loading any map."
 msgstr ""
-"Una partida multijugador con varios jugadores humanos compitiendo entre "
-"ellos en un mapa."
 
-#: ../fheroes2/game/game_newgame.cpp:217
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:83
 msgid "Settings"
 msgstr "Ajustes"
 
-#: ../fheroes2/game/game_newgame.cpp:217
-msgid "FHeroes2 game settings."
+#, fuzzy
+msgid "Experimental game settings."
 msgstr "Configuración del juego FHeroes2"
 
-#: ../fheroes2/game/game_newgame.cpp:271
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:219
-msgid "Hot Seat"
-msgstr "Asiento caliente."
-
-#: ../fheroes2/game/game_newgame.cpp:271
-msgid ""
-"Play a Hot Seat game, where 2 to 4 players play around the same computer, "
-"switching into the 'Hot Seat' when it is their turn."
-msgstr ""
-"Juega una partida de \"Asiento caliente\" donde de 2 a 4 jugadores juegan en "
-"el mismo PC por turnos."
-
-#: ../fheroes2/game/game_newgame.cpp:279
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:223
-msgid "Network"
-msgstr "Red"
-
-#: ../fheroes2/game/game_newgame.cpp:279
-msgid ""
-"Play a network game, where 2 players use their own computers connected "
-"through a LAN (Local Area Network)."
-msgstr ""
-"Jugar una partida de red donde 2 jugadores usan sus propios PCs conectados "
-"en una LAN. (Red de Área Local)."
-
-#: ../fheroes2/game/game_newgame.cpp:343
 msgid "2 Players"
 msgstr "2 jugadores"
 
-#: ../fheroes2/game/game_newgame.cpp:343
 msgid ""
 "Play with 2 human players, and optionally, up, to 4 additional computer "
 "players."
@@ -2291,11 +2521,9 @@ msgstr ""
 "Jugar con 2 jugadores humanos y opcionalmente, hasta con 4 jugadores "
 "virtuales."
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid "3 Players"
 msgstr "3 Jugadores"
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid ""
 "Play with 3 human players, and optionally, up, to 3 additional computer "
 "players."
@@ -2303,22 +2531,18 @@ msgstr ""
 "Jugar con 3 jugadores humanos y, opcionalmente, hasta con 3 jugadores "
 "virtuales."
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid "4 Players"
 msgstr "4 Jugadores"
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid ""
 "Play with 4 human players, and optionally, up, to 2 additional computer "
 "players."
 msgstr ""
 "Jugar con 4 jugadores humanos y ,opcionalmente, hasta 2 jugadores virtuales."
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid "5 Players"
 msgstr "5 Jugadores"
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid ""
 "Play with 5 human players, and optionally, up, to 1 additional computer "
 "players."
@@ -2326,47 +2550,36 @@ msgstr ""
 "Jugar con 5 jugadores humanos y, opcionalmente, con un jugador virtual "
 "adicional."
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "6 Players"
 msgstr "6 Jugadores"
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "Play with 6 human players."
 msgstr "Jugar con 6 jugadores humanos."
 
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat all enemy heroes and capture all enemy towns and castles."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Run out of time. (Fail to win by a certain point.)"
 msgstr "Agotarse el tiempo. (Fracasando sin ganar por alguna condición.)"
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the castle '%{name}'"
 msgstr "Captura el castillo de '%{name}'"
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the town '%{name}'"
 msgstr "Captura la ciudad de '%{name}'"
 
-#: ../fheroes2/game/game_over.cpp:83
 msgid "Defeat the hero '%{name}'"
 msgstr "Derrota el héroe '%{name}"
 
-#: ../fheroes2/game/game_over.cpp:91
 msgid "Find the ultimate artifact"
 msgstr "Encuentra el artefacto definitivo"
 
-#: ../fheroes2/game/game_over.cpp:95
 msgid "Find the '%{name}' artifact"
 msgstr "Encuentra el artefacto '%{name}"
 
-#: ../fheroes2/game/game_over.cpp:102
 msgid "Accumulate %{count} gold"
 msgstr "Acumula %{count} oro"
 
-#: ../fheroes2/game/game_over.cpp:106
 msgid ""
 ", or you may win by defeating all enemy heroes and capturing all enemy towns "
 "and castles."
@@ -2374,29 +2587,23 @@ msgstr ""
 ", o puedes ganar derrotando a todos los héroes enemigos y capturando todas "
 "las ciudades y castillos enemigos."
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the castle '%{name}'."
 msgstr "Pierde el castillo '%{name}'."
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the town '%{name}'."
 msgstr "Pierde la ciudad de '%{name}'."
 
-#: ../fheroes2/game/game_over.cpp:126 ../fheroes2/game/game_over.cpp:145
 msgid "Lose the hero: %{name}."
 msgstr "Pierdes el héroe: %{name}."
 
-#: ../fheroes2/game/game_over.cpp:133
 msgid "Fail to win by the end of month %{month}, week %{week}, day %{day}."
 msgstr ""
-"No consigas ganar para el final del mes &{month}, semana %{semana}, día %"
-"{day}."
+"No consigas ganar para el final del mes &{month}, semana %{semana}, día "
+"%{day}."
 
-#: ../fheroes2/game/game_over.cpp:145
 msgid "Lose the heroes: %{name}."
 msgstr "Piérdes los Héroes: %{name}."
 
-#: ../fheroes2/game/game_over.cpp:167
 msgid ""
 "You captured %{name}!\n"
 "You are victorious."
@@ -2404,7 +2611,6 @@ msgstr ""
 "¡Capturas %{name}!\n"
 "Eres el vencedor."
 
-#: ../fheroes2/game/game_over.cpp:175
 msgid ""
 "You have captured the enemy hero %{name}!\n"
 "Your quest is complete."
@@ -2412,7 +2618,6 @@ msgstr ""
 "¡Has capturado al héroe enemigo (%{name})!\n"
 "Tu búsqueda está completada."
 
-#: ../fheroes2/game/game_over.cpp:183
 msgid ""
 "You have found the %{name}.\n"
 "Your quest is complete."
@@ -2420,7 +2625,6 @@ msgstr ""
 "Has encontrado %{name}.\n"
 "Tu búsqueda ha concluido."
 
-#: ../fheroes2/game/game_over.cpp:195
 msgid ""
 "The enemy is beaten.\n"
 "Your side has triumphed!"
@@ -2428,7 +2632,6 @@ msgstr ""
 "Tu enemigo esta derrotado.\n"
 "¡Tu bando ha triunfado!"
 
-#: ../fheroes2/game/game_over.cpp:200
 msgid ""
 "You have built up over %{count} gold in your treasury.\n"
 "All enemies bow before your wealth and power."
@@ -2436,7 +2639,6 @@ msgstr ""
 "Has recaudado por encima de %{count} de oro en tu tesoro.\n"
 "Todos los enemigos te reverencia ante tu riqueza y poder."
 
-#: ../fheroes2/game/game_over.cpp:222
 msgid ""
 "The enemy has found the %{name}.\n"
 "Your quest is a failure."
@@ -2444,7 +2646,6 @@ msgstr ""
 "El enemigo ha encontrado %{name}.\n"
 "Tu búsqueda ha fallado."
 
-#: ../fheroes2/game/game_over.cpp:230
 msgid ""
 "%{color} has fallen!\n"
 "All is lost."
@@ -2452,7 +2653,6 @@ msgstr ""
 "¡%{color} ha sido eliminado!\n"
 "Todo está perdido."
 
-#: ../fheroes2/game/game_over.cpp:237
 msgid ""
 "The enemy has built up over %{count} gold in his treasury.\n"
 "You must bow done in defeat before his wealth and power."
@@ -2460,11 +2660,9 @@ msgstr ""
 "El enemigo a recaudado más de %{count} de oro en su tesoro.\n"
 "Debes inclinarte derrotado ante su riqueza y poder."
 
-#: ../fheroes2/game/game_over.cpp:243
 msgid "You have been eliminated from the game!!!"
 msgstr "¡¡¡Has sido eliminado del juego!!!"
 
-#: ../fheroes2/game/game_over.cpp:248
 msgid ""
 "The enemy has captured %{name}!\n"
 "They are triumphant."
@@ -2472,7 +2670,6 @@ msgstr ""
 "¡El enemigo ha capturado %{name}!\n"
 "Son los triunfadores."
 
-#: ../fheroes2/game/game_over.cpp:257 ../fheroes2/game/game_over.cpp:264
 msgid ""
 "You have lost the hero %{name}.\n"
 "Your quest is over."
@@ -2480,7 +2677,6 @@ msgstr ""
 "Has perdido al héroe %{name}.\n"
 "Tu búsqueda ha terminado."
 
-#: ../fheroes2/game/game_over.cpp:272
 msgid ""
 "You have failed to complete your quest in time.\n"
 "All is lost."
@@ -2488,33 +2684,25 @@ msgstr ""
 "Has fallado en completar tu búsqueda a tiempo.\n"
 "Todo está perdido."
 
-#: ../fheroes2/game/game_over.cpp:320
-msgid "%{color} has been vanquished!"
+#, fuzzy
+msgid "%{color} player has been vanquished!"
 msgstr "¡%{color} ha sido derrotado!"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "Warning"
 msgstr "Advertencia"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "No maps available!"
 msgstr "¡Ningún mapa disponible!"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Scenario"
 msgstr "Escenario"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Click here to select which scenario to play."
 msgstr "Haga clic aquí para seleccionar el escenario donde jugar."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid "Game Difficulty"
 msgstr "Dificultad del juego"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid ""
 "This lets you change the starting difficulty at which you will play. Higher "
 "difficulty levels start you of with fewer resources, and at the higher "
@@ -2524,11 +2712,9 @@ msgstr ""
 "nivel de dificultad comienzas con menos recursos, cuanto más alta la "
 "configuración más recursos extra recibe el jugador virtual."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid "Difficulty Rating"
 msgstr "Nivel de Dificultad."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid ""
 "The difficulty rating reflects a combination of various settings for your "
 "game. This number will be applied to your final score."
@@ -2536,63 +2722,49 @@ msgstr ""
 "El Nivel de Dificultad refleja la combinación de varias configuraciones del "
 "juego. Este número se aplicará a tu puntuación final."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
 msgid "Click to accept these settings and start a new game."
 msgstr ""
 "Haz clic para aceptar estas configuraciones y empezar una nueva partida."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
 msgid "Click to return to the main menu."
 msgstr "Haz clic para volver al menú principal"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:342
 msgid "Scenario:"
 msgstr "Escenario:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:350
 msgid "Game Difficulty:"
 msgstr "Dificultad del juego:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:354
 msgid "Opponents:"
 msgstr "Contrincantes:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:358
 msgid "Class:"
 msgstr "Raza"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:384
 msgid "Rating %{rating}%"
 msgstr "Nivel %{rating}%"
 
-#: ../fheroes2/game/game_startgame.cpp:226
 msgid "Astrologers proclaim Month of the %{name}."
 msgstr "Los Astrólogos proclaman el Mes de  %{name}."
 
-#: ../fheroes2/game/game_startgame.cpp:226
 msgid "Astrologers proclaim Week of the %{name}."
 msgstr "Los Astrólogos proclaman la Semana de  %{name}."
 
-#: ../fheroes2/game/game_startgame.cpp:240
 msgid "After regular growth, population of %{monster} is doubled!"
 msgstr "Por el crecimiento normal, ¡La población de {monster} se ha doblado!"
 
-#: ../fheroes2/game/game_startgame.cpp:252
 msgid " All populations are halved."
 msgstr " El crecimiento de las poblaciones se reduce a la mitad."
 
-#: ../fheroes2/game/game_startgame.cpp:254
 msgid " All dwellings increase population."
 msgstr " Todas las moradas aumentan su población."
 
-#: ../fheroes2/game/game_startgame.cpp:283
 msgid ""
 "%{color} player, your heroes abandon you, and you are banished from this "
 "land."
 msgstr ""
 "Jugador %{color}, tus héroes te abandonan y eres desterrado de estas tierras."
 
-#: ../fheroes2/game/game_startgame.cpp:290
 msgid ""
 "%{color} player, this is your last day to capture a town, or you will be "
 "banished from this land."
@@ -2600,7 +2772,6 @@ msgstr ""
 "Jugador %{color}, éste es tu último día para capturar una ciudad o serás "
 "desterrado de estas tierras."
 
-#: ../fheroes2/game/game_startgame.cpp:295
 msgid ""
 "%{color} player, you only have %{day} days left to capture a town, or you "
 "will be banished from this land."
@@ -2608,11 +2779,10 @@ msgstr ""
 "Jugador %{color}, sólo te quedan %{day} días para capturar una ciudad o "
 "serás desterrado de estas tierras."
 
-#: ../fheroes2/game/game_startgame.cpp:584
-msgid "%{color} player's turn"
+#, fuzzy
+msgid "%{color} player's turn."
 msgstr "Turno del jugador %{color}"
 
-#: ../fheroes2/game/game_startgame.cpp:995
 msgid ""
 "%{color} player, you have lost your last town. If you do not conquer another "
 "town in next week, you will be eliminated."
@@ -2620,141 +2790,119 @@ msgstr ""
 "Jugador %{color}, has perdido tu última ciudad. Si no conquistas ótra la "
 "próxima semana serás eliminado."
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Next Hero"
 msgstr "Siguiente Héroe"
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Select the next Hero."
 msgstr "Seleccione el siguiente Héroe"
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue Movement"
 msgstr "Continuar movimento"
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue the Hero's movement along the current path."
 msgstr "Continuar el movimento de tu héroe por el sendero actual."
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "Kingdom Summary"
 msgstr "Resumen del reino"
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "View a Summary of your Kingdom."
 msgstr "Ver un resumen de tu reino"
 
-#: ../fheroes2/gui/interface_buttons.cpp:189
 msgid "Cast an adventure spell."
 msgstr "Lanzar un hechizo tipo aventura."
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End Turn"
 msgstr "Finalizar  el turno."
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End your turn and left the computer take its turn."
 msgstr "Finalizar tu turno y pasárselo al jugador virtual."
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Adventure Options"
 msgstr "Opciones de la Aventura"
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Bring up the adventure options menu."
 msgstr "Desplegar el menú de opciones de aventura."
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "File Options"
 msgstr "Opciones de archivo"
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "Bring up the file options menu, alloving you to load menu, save etc."
 msgstr ""
 "Desplegar el menú de opciones de archivo, permiéndote cargar, grabar etc."
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "System Options"
 msgstr "Opciones del Sistema"
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "Bring up the system options menu, alloving you to customize your game."
 msgstr ""
 "Desplegar el menú de opciones de sistema, permitiéndote personalizar tu "
 "partida."
 
-#: ../fheroes2/gui/interface_events.cpp:175
 msgid ""
 "One or more heroes may still move, are you sure you want to end your turn?"
 msgstr ""
 "Uno o más de tus héroes todavía tiene posibilidad de movimiento. ¿Seguro que "
 "quieres terminar tu turno?"
 
-#: ../fheroes2/gui/interface_events.cpp:212
-msgid "Are you sure you want to restart? (Your current game will be lost)"
-msgstr "¿Estás seguro que quieres reiniciar? (Tu partida actual se perderá)"
-
-#: ../fheroes2/gui/interface_events.cpp:276
 msgid "Are you sure you want to quit?"
 msgstr "¿Estás seguro que deseas salir?"
 
-#: ../fheroes2/gui/interface_events.cpp:308
+#, fuzzy
+msgid "Are you sure you want to restart? (Your current game will be lost.)"
+msgstr "¿Estás seguro que quieres reiniciar? (Tu partida actual se perderá)"
+
+msgid "Are you sure you want to overwrite the save with this name?"
+msgstr ""
+"¿Estás seguro de que quieres sobreescribir el guardado con este nombre?"
+
 msgid "Game saved successfully."
 msgstr "Partida grabada con éxito."
 
-#: ../fheroes2/gui/interface_events.cpp:314
+msgid "There was an issue during saving."
+msgstr ""
+
+#, fuzzy
 msgid ""
-"Are you sure you want to load a new game? (Your current game will be lost)"
+"Are you sure you want to load a new game? (Your current game will be lost.)"
 msgstr ""
 "¿Estás seguro de que quieres cargar una nueva partida? (Tu partida actual se "
 "perderá)"
 
-#: ../fheroes2/gui/interface_events.cpp:353
 msgid "Try looking on land!!!"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:368
+#, fuzzy
 msgid ""
-"After spending many hours digging here, you have uncovered the %{artifact}"
+"After spending many hours digging here, you have uncovered the %{artifact}."
 msgstr ""
 "Desoyñes de muchas horas cabando aquí, al fin has desenterrado %{artifact}"
 
-#: ../fheroes2/gui/interface_events.cpp:370
 msgid "Congratulations!"
 msgstr "¡Enhorabuena!"
 
-#: ../fheroes2/gui/interface_events.cpp:384
 msgid "Nothing here. Where could it be?"
 msgstr "No hay nada aquí. ¿Dónde puede estar?"
 
-#: ../fheroes2/gui/interface_events.cpp:395
 msgid "Try searching on clear ground."
 msgstr "Prueba buscando en terreno despejado"
 
-#: ../fheroes2/gui/interface_events.cpp:399
 msgid "Digging for artifacts requires a whole day, try again tomorrow."
 msgstr "Excavar artefactos requiere un día entero, inténtalo mañana."
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "World Map"
 msgstr "Mapa del mundo"
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "A miniature view of the known world. Left click to move viewing area."
 msgstr ""
 "Una vista en minatura del mundo explorado. Cliquea con el botón izquierdo "
 "para ver dicha área."
 
-#: ../fheroes2/gui/interface_status.cpp:216
 msgid "Month: %{month} Week: %{week}"
 msgstr "Mes: %{month} Semana: %{week}"
 
-#: ../fheroes2/gui/interface_status.cpp:222
-#: ../fheroes2/kingdom/kingdom_overview.cpp:569
 msgid "Day: %{day}"
 msgstr "Día: %{day}"
 
-#: ../fheroes2/gui/interface_status.cpp:257
 msgid ""
 "You find a small\n"
 "quantity of %{resource}."
@@ -2762,11 +2910,18 @@ msgstr ""
 "Encuentras una pequeña\n"
 "cantidad de %{resource}."
 
-#: ../fheroes2/gui/interface_status.cpp:407
 msgid "Status Window"
 msgstr "Ventana de estado"
 
-#: ../fheroes2/gui/interface_status.cpp:407
+#, fuzzy
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date."
+msgstr ""
+"Esta ventana muestra información de la situación de tu héroe o reino y "
+"muestra la fecha. Cliquea en el botón izquierdo para alternar entre las "
+"ventanas."
+
 msgid ""
 "This window provides information on the status of your hero or kingdom, and "
 "shows the date. Left click here to cycle throungh these windows."
@@ -2775,29 +2930,285 @@ msgstr ""
 "muestra la fecha. Cliquea en el botón izquierdo para alternar entre las "
 "ventanas."
 
-#: ../fheroes2/heroes/heroes_action.cpp:112
+msgid "Necroman"
+msgstr "Nigromante."
+
+msgid ""
+"This lets you change player starting positions and colors. A particular "
+"color will always start in a particular location. Some positions may only be "
+"played by a computer player or only by a human player."
+msgstr ""
+"Te permite cambiar las posición inicial y los colores. Cada color siempre "
+"comenzará en una situación precisa. Algunas posiciones sólo puede ser "
+"jugadas por un jugador humano o uno virtual."
+
+msgid ""
+"This lets you change the class of a player. Classes are not always "
+"changeable. Depending on the scenario, a player may receive additional towns "
+"and/or heroes not of their primary alignment."
+msgstr ""
+"Te permite cambiar la raza de un jugador. No siempre se pueden cambiar las "
+"razas. Dependiendo del escenario, un jugador puede recibir ciudades y/o "
+"héroes adicionales no pertenecientes a su primer alineamiento."
+
+msgid "%{color} player"
+msgstr "%{color} jugador"
+
+msgid "View %{skill} Info"
+msgstr "Ver información de %{skill}"
+
+msgid "Lord Kilburn"
+msgstr "Lord Kilburn"
+
+#, fuzzy
+msgid "Sir Gallant"
+msgstr "Sir Gallanth"
+
+msgid "Ector"
+msgstr "Ector"
+
+msgid "Gwenneth"
+msgstr "Gwenneth"
+
+msgid "Tyro"
+msgstr "Tyro"
+
+msgid "Ambrose"
+msgstr "Ambrose"
+
+msgid "Ruby"
+msgstr "Ruby"
+
+msgid "Maximus"
+msgstr "Maximus"
+
+msgid "Dimitry"
+msgstr "Dimitry"
+
+msgid "Thundax"
+msgstr "Thundax"
+
+msgid "Fineous"
+msgstr "Fineous"
+
+msgid "Jojosh"
+msgstr "Jojosh"
+
+msgid "Crag Hack"
+msgstr "Crag Hack"
+
+msgid "Jezebel"
+msgstr "Jezebel"
+
+msgid "Jaclyn"
+msgstr "Jaclyn"
+
+msgid "Ergon"
+msgstr "Ergon"
+
+msgid "Tsabu"
+msgstr "Tsabu"
+
+msgid "Atlas"
+msgstr "Atlas"
+
+msgid "Astra"
+msgstr "Astra"
+
+msgid "Natasha"
+msgstr "Natasha"
+
+msgid "Troyan"
+msgstr "Troyan"
+
+msgid "Vatawna"
+msgstr "Vatawna"
+
+msgid "Rebecca"
+msgstr "Rebecca"
+
+msgid "Gem"
+msgstr "Gem"
+
+msgid "Ariel"
+msgstr "Ariel"
+
+msgid "Carlawn"
+msgstr "Carlawn"
+
+msgid "Luna"
+msgstr "Luna"
+
+msgid "Arie"
+msgstr "Arie"
+
+msgid "Alamar"
+msgstr "Alamar"
+
+msgid "Vesper"
+msgstr "Vesper"
+
+msgid "Crodo"
+msgstr "Crodo"
+
+msgid "Barok"
+msgstr "Barok"
+
+msgid "Kastore"
+msgstr "Katore"
+
+msgid "Agar"
+msgstr "Agar"
+
+msgid "Falagar"
+msgstr "Falagar"
+
+msgid "Wrathmont"
+msgstr "Wrathmont"
+
+msgid "Myra"
+msgstr "Myra"
+
+msgid "Flint"
+msgstr "Flint"
+
+msgid "Dawn"
+msgstr "Dawn"
+
+msgid "Halon"
+msgstr "Halon"
+
+msgid "Myrini"
+msgstr "Myrini"
+
+msgid "Wilfrey"
+msgstr "Wilfrey"
+
+msgid "Sarakin"
+msgstr "Sarakin"
+
+msgid "Kalindra"
+msgstr "Kalindra"
+
+msgid "Mandigal"
+msgstr "Mandigal"
+
+msgid "Zom"
+msgstr "Zom"
+
+msgid "Darlana"
+msgstr "Darlana"
+
+msgid "Zam"
+msgstr "Zam"
+
+msgid "Ranloo"
+msgstr "Ranloo"
+
+msgid "Charity"
+msgstr "Charity"
+
+msgid "Rialdo"
+msgstr "Rialdo"
+
+msgid "Roxana"
+msgstr "Roxana"
+
+msgid "Sandro"
+msgstr "Sandro"
+
+msgid "Celia"
+msgstr "Celia"
+
+msgid "Roland"
+msgstr "Roland"
+
+msgid "Lord Corlagon"
+msgstr "Lord Corlagon"
+
+msgid "Sister Eliza"
+msgstr "Hermana Eliza"
+
+msgid "Archibald"
+msgstr "Archibald"
+
+msgid "Lord Halton"
+msgstr "Lord Halton"
+
+#, fuzzy
+msgid "Brother Brax"
+msgstr "Hermano Bax"
+
+msgid "Solmyr"
+msgstr "Solmyr"
+
+msgid "Dainwin"
+msgstr "Dainwin"
+
+msgid "Mog"
+msgstr "Mog"
+
+msgid "Joseph"
+msgstr "Joseph"
+
+msgid "Gallavant"
+msgstr "Gallavant"
+
+msgid "Elderian"
+msgstr "Elderian"
+
+msgid "Ceallach"
+msgstr "Ceallach"
+
+msgid "Drakonia"
+msgstr "Drakonia"
+
+msgid "Martine"
+msgstr "Martine"
+
+msgid "Jarkonas"
+msgstr "Jarkonas"
+
+msgid "%{object} robber"
+msgstr ""
+
+msgid "%{object} raided"
+msgstr ""
+
+msgid "You cannot pick up this artifact, you already have a full load!"
+msgstr ""
+
+msgid "The three Anduran artifacts magically combine into one."
+msgstr "Los tres artefactos mágicos de Anduran combinados en uno."
+
+msgid "To cast spells, you must first buy a spell book for %{gold} gold."
+msgstr ""
+"Para lanzar hechizos primero has de comprar un libro de hechizos por %{gold} "
+"monedas de oro."
+
+msgid "Unfortunately, you seem to be a little short of cash at the moment."
+msgstr ""
+"Desafortunadamente, parece que andas un poco justo de dinero en estos "
+"momentos."
+
+msgid "Do you wish to buy one?"
+msgstr "¿Quiéres comprar uno?"
+
 msgid "%{count} / day"
 msgstr "%{count} / día"
 
-#: ../fheroes2/heroes/heroes_action.cpp:331
-#: ../fheroes2/heroes/heroes_action.cpp:2199
 msgid "You are unable to recruit at this time, your ranks are full."
 msgstr "Eres incapaz de reclutar ahora mismo, tus filas están completas."
 
-#: ../fheroes2/heroes/heroes_action.cpp:599
-msgid ""
-"A group of %{monster} with a desire for greater glory wish to join you.\n"
-"Do you accept?"
-msgstr ""
-"Un grupo de %{monster} con ansia de gloria desea unirse a tus tropas. "
-"¿Aceptas?"
+msgid "A whirlpool engulfs your ship."
+msgstr "Un remolino engulle tu nave."
 
-#: ../fheroes2/heroes/heroes_action.cpp:609
-#: ../fheroes2/heroes/heroes_action.cpp:630
+msgid "Some of your army has fallen overboard."
+msgstr "Parte de tu ejército ha caído por la borda."
+
 msgid "Insulted by your refusal of their offer, the monsters attack!"
 msgstr "¡Insultados por la negativa a su oferta, los monstruos te atacan!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:638
 msgid ""
 "The %{monster}, awed by the power of your forces, begin to scatter.\n"
 "Do you wish to pursue and engage them?"
@@ -2805,12 +3216,10 @@ msgstr ""
 "Ante la superioridad de tus fuerzas el enemigo comienza a dispersarse.\n"
 "¿Deseas proceder a su persecución y entablar combate?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:934
 msgid "Ransacking an enemy camp, you discover a hidden cache of treasures."
 msgstr ""
 "Saqueando un campamento enemigo descubres un depósito oculto con tesoros."
 
-#: ../fheroes2/heroes/heroes_action.cpp:966
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with these resources, "
@@ -2820,7 +3229,6 @@ msgstr ""
 "\"Mi Señor, he estado trabajando muy duro para proporcionarte estos "
 "recursos, vuelve la próxima semana a por más.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:967
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there are no resources currently available. Please try "
@@ -2830,7 +3238,6 @@ msgstr ""
 "\"Mi Señor, lo siento, pero no hay recursos disponibles en este momento. Por "
 "favor, vuelve a intentarlo la próxima semana.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:972
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with this gold, come "
@@ -2840,7 +3247,6 @@ msgstr ""
 "\"Mi Señor, he estado trabajando muy duro para proporcionarte este oro, "
 "vuelve la próxima semana a por más.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:973
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there is no gold currently available. Please try again "
@@ -2850,7 +3256,6 @@ msgstr ""
 "\"Mi Señor, lo siento, no hay oro disponible en este momento. Por favor, "
 "vuelve a intentarlo la próxima semana.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:979
 msgid ""
 "You've found an abandoned lean-to.\n"
 "Poking about, you discover some resources hidden nearby."
@@ -2858,11 +3263,9 @@ msgstr ""
 "Has encontrado un alpendre abandonado.\n"
 "Dando una vuelta a su alrededor, descubres cerca algunos recursos ocultos."
 
-#: ../fheroes2/heroes/heroes_action.cpp:980
 msgid "The lean-to is long abandoned. There is nothing of value here."
 msgstr "El alpendre hace tiempo que fue abandonado. No hay nada de valor aquí."
 
-#: ../fheroes2/heroes/heroes_action.cpp:985
 msgid ""
 "You catch a leprechaun foolishly sleeping amidst a cluster of magic "
 "mushrooms.\n"
@@ -2873,7 +3276,6 @@ msgstr ""
 "A cambio de su libertad, te guía a una pequeña olla llena de objetos "
 "preciosos."
 
-#: ../fheroes2/heroes/heroes_action.cpp:986
 msgid ""
 "You've found a magic garden, the kind of place that leprechauns and faeries "
 "like to cavort in, but there is no one here today.\n"
@@ -2883,88 +3285,70 @@ msgstr ""
 "leprechauns y hadas, pero no hay ninguno hoy aquí.\n"
 "A lo mejor debieras de intentarlo de nuevo la próxima semana."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1023
 msgid "You come upon the remains of an unfortunate adventurer."
 msgstr "Te topas con los restos de un desafortunado aventurero."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1034
 msgid "Treasure"
 msgstr "Tesoro"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1041
 msgid "Searching through the tattered clothing, you find %{artifact}."
 msgstr "Mientras buscabas entre las ropas sucias, encontraste %{artifact}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1052
 msgid "Searching through the tattered clothing, you find nothing."
 msgstr "Mientras buscabas entre las ropas sucias, encontraste %{artifact}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1064
 msgid ""
 "You come across an old wagon left by a trader who didn't quite make it to "
 "safe terrain."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1075
-#: ../fheroes2/heroes/heroes_action.cpp:1103
 msgid "Unfortunately, others have found it first, and the wagon is empty."
 msgstr ""
 "Desafortunadamente, otros han estado aquí antes, y el vagón está vacío."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1082
 msgid "Searching inside, you find the %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1093
 msgid "Inside, you find some of the wagon's cargo still intact."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1123
 msgid "You search through the flotsam, and find some wood and some gold."
 msgstr ""
 "Buscas entre los restos del naufragio y encuentras algo de de madera y oro."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1124
 msgid "You search through the flotsam, and find some wood."
 msgstr "Buscas entre los restos del naufragio y encuentras algo de madera."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1130
 msgid "You search through the flotsam, but find nothing."
 msgstr "Buscas entre los restos del naufragio pero no encuentras nada."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1151
 msgid "Shrine of the 1st Circle"
 msgstr "Capilla del Primer Círculo"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1152
 msgid ""
 "You come across a small shrine attended by a group of novice acolytes.\n"
-"In exchange for your protection, they agree to teach you a simple spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a simple spell - "
+"'%{spell}'."
 msgstr ""
 "Te encuentras con un pequeño santuario atendido por un grupo de acólitos "
-"novicios. A cambio de tu protección aceptan enseñarte un hechizo sencillo: '%"
-"{spell}'."
+"novicios. A cambio de tu protección aceptan enseñarte un hechizo sencillo: "
+"'%{spell}'."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1155
 msgid "Shrine of the 2nd Circle"
 msgstr "Altar del Segundo Círculo"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1156
 msgid ""
 "You come across an ornate shrine attended by a group of rotund friars.\n"
-"In exchange for your protection, they agree to teach you a spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a spell - "
+"'%{spell}'."
 msgstr ""
 "Te encuentras con un santuario ornamentado atendido por un grupo de "
 "voluminosos frailes. A cambio de tu protección aceptan enseñarte un hechizo: "
 "'%{spell}'."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1159
 msgid "Shrine of the 3rd Circle"
 msgstr "Altar del Tercer Círculo"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1160
 msgid ""
 "You come across a lavish shrine attended by a group of high priests.\n"
 "In exchange for your protection, they agree to teach you a sophisticated "
@@ -2974,7 +3358,6 @@ msgstr ""
 "sacerdotes. A cambio de tu protección aceptan enseñarte un sofisticado "
 "hechizo: '%{spell}'."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1173
 msgid ""
 "\n"
 "Unfortunately, you have no Magic Book to record the spell with."
@@ -2983,7 +3366,6 @@ msgstr ""
 "Desafortunadamente, no tienes un Libro de Hechizos donde registrar este "
 "hechizo."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1184
 msgid ""
 "\n"
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
@@ -2993,7 +3375,6 @@ msgstr ""
 "Desafortunadamente, no tienes la sabiduría necesaria para comprender el "
 "hechizo, y eres incapaz de aprenderlo."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1192
 msgid ""
 "\n"
 "Unfortunately, you already have knowledge of this spell, so there is nothing "
@@ -3003,17 +3384,15 @@ msgstr ""
 "Desafortunadamente, ya conocías ese hechizo, así que no hay nada más que te "
 "pueda enseñar."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1215
 msgid ""
-"You approach the hut and observe a witch inside studying an ancient tome on %"
-"{skill}.\n"
+"You approach the hut and observe a witch inside studying an ancient tome on "
+"%{skill}.\n"
 " \n"
 msgstr ""
 "Te aproximas a la cabaña y observas dentro a una bruja estudiando un antiguo "
 "tomo de %{skill}.\n"
 " \n"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1222
 msgid ""
 "As you approach, she turns and focuses her one glass eye on you.\n"
 "\"You already know everything you deserve to learn!\" the witch screeches. "
@@ -3023,7 +3402,6 @@ msgstr ""
 "\"¡Ya sabes todo lo que merecías aprender!\" chilla la bruja. \"¡AHORA, "
 "FUERA DE MI CASA!\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1229
 msgid ""
 "As you approach, she turns and speaks.\n"
 "\"You already know that which I would teach you. I can help you no further.\""
@@ -3031,7 +3409,6 @@ msgstr ""
 "Al aproximarte, ella se gira y habla.\n"
 "\"Ya sabes lo que yo te enseñaría. Ya no puedo ayudarte más.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1236
 msgid ""
 "An ancient and immortal witch living in a hut with bird's legs for stilts "
 "teaches you %{skill} for her own inscrutable purposes."
@@ -3039,20 +3416,16 @@ msgstr ""
 "Una antigua e inmortal bruja que vive en una cabaña rodeada de zancos de "
 "aves te enseña %{skill}, para sus inescrutables propósitos."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1255
 msgid "You drink from the enchanted fountain, but nothing happens."
 msgstr "Bebes de una fuente encantada pero nada sucede."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1256
 msgid "As you drink the sweet water, you gain luck for your next battle."
 msgstr ""
 "Mientras bebes la dulce agua adquieres suerte para tu siguiente batalla."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1260
 msgid "You enter the faerie ring, but nothing happens."
 msgstr "Entras en el anillo místico de hadas pero nada sucede."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1261
 msgid ""
 "Upon entering the mystical faerie ring, your army gains luck for its next "
 "battle."
@@ -3060,7 +3433,6 @@ msgstr ""
 "Justo al entrar el anillo místico de las hadas tu ejército adquiere suerte "
 "para su próxima batalla"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1265
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "It is supposed to grant luck to visitors, but since the stars are already "
@@ -3070,7 +3442,6 @@ msgstr ""
 "Se supone que otorga suerte a los visitantes, pero dado que las estrellas ya "
 "te sonríen, no ocurre nada."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1266
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "Kissing it is supposed to be lucky, so you do. The stone is very cold to the "
@@ -3080,13 +3451,11 @@ msgstr ""
 "Besarlo se supone que da suerte, así que lo haces. La piedra esta muy fría "
 "al tacto."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1270
 msgid "The mermaids silently entice you to return later and be blessed again."
 msgstr ""
 "Las sirenas en silencio te engatusan para volver más tarde y ser bendecido "
 "de nuevo."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1271
 msgid ""
 "The magical, soothing beauty of the Mermaids reaches you and your crew.\n"
 "Just for a moment, you forget your worries and bask in the beauty of the "
@@ -3099,7 +3468,6 @@ msgstr ""
 "Los encantos de las Sirenas te bendicen e incrementan tu suerte para el "
 "próximo combate."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1303
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "You are tempted to search it for treasure, but all the old stories warn of "
@@ -3111,7 +3479,6 @@ msgstr ""
 "las espantosas maldiciones y los guardianes nomuertos.\n"
 "¿Vas a buscar?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1304
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "Routine exploration reveals that the pyramid is completely empty."
@@ -3119,12 +3486,10 @@ msgstr ""
 "Te aproximas a la pirámide de un antiguo y gran rey.\n"
 "Exploraciones rutinarias te indican que la pirámide está completamente vacía."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1329
 msgid "Unfortunately, you have no Magic Book to record the spell with."
 msgstr ""
 "Desafortunamente, no posees Libro de Hechizos donde registrar este hechizo."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1333
 msgid ""
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
@@ -3132,7 +3497,6 @@ msgstr ""
 "Desafortunadamente, no tienes el conocimiento necesario para comprender el "
 "hechizo y no eres capaz de aprenderlo."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1337
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
 "telling the secret of the spell."
@@ -3140,25 +3504,20 @@ msgstr ""
 "Al derrotar a los monstruos, descrifras un antiguo  jeroglífico de la pared "
 "que explica el secreto del hechizo."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1374 ../fheroes2/maps/mp2.cpp:469
 msgid "Sign"
 msgstr "Señal"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1385
 msgid ""
 "A drink at the well is supposed to restore your spell points, but you are "
 "already at maximum."
 msgstr "Al beber pozo se restablece tu Maná, pero ya estás al máximo."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1392
 msgid "A second drink at the well in one day will not help you."
 msgstr "Beber dos veces del pozo en el mismo día no te ayudará."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1399
 msgid "A drink from the well has restored your spell points to maximum."
 msgstr "Al beber del pozo se han restablecido tus puntos de Maná al máximo."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1424
 msgid ""
 "\"I'm sorry sir,\" The leader of the soldiers says, \"but you already know "
 "everything we have to teach.\""
@@ -3166,13 +3525,11 @@ msgstr ""
 "\"Lo siento\" dice el lider de los solados, \"pero ya has sabeis todo lo que "
 "nosotros podemos enserñarte\"."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1425
 msgid "The soldiers living in the fort teach you a few new defensive tricks."
 msgstr ""
 "Los soldados que viven en el fuerte te enseñan algunos trucos defensivos "
 "nuevos."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1430
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. \"You're too "
 "advanced for us,\" the mercenary captain says. \"We can teach nothing more.\""
@@ -3181,7 +3538,6 @@ msgstr ""
 "\"Eres demasiado avanzado para nosotros\", dice el capitán de los "
 "mercenarios. \"No podemos enseñarte nada más\"."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1431
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. The mercenaries "
 "welcome you and your troops and invite you to train with them."
@@ -3190,11 +3546,9 @@ msgstr ""
 "Los mercenarios te dan la bienvenida a ti y a tus tropas y os invitan a "
 "entrenar con ellos."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1436
 msgid "\"Go 'way!\", the witch doctor barks, \"you know all I know.\""
 msgstr "¡Vete! grita el curandero, \"sabes todo lo que yo sé\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1437
 msgid ""
 "An Orcish witch doctor living in the hut deepens your knowledge of magic by "
 "showing you how to cast stones, read portents, and decipher the intricacies "
@@ -3204,7 +3558,6 @@ msgstr ""
 "magia enseñándote a: invocar piedras, leer augurios y descifrar las "
 "complejidades en las entrañas de los pollos."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1442
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, the Druids turn you away, indicating they have nothing "
@@ -3214,7 +3567,6 @@ msgstr ""
 "edificios de piedra. Los Druidas te apartan silenciosamente, indicando que "
 "no tienen nada nuevo que enseñarte."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1443
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, they teach you new ways to cast spells."
@@ -3223,7 +3575,6 @@ msgstr ""
 "edificios de piedra. Silenciosamente te enseñan nuevas formas de lanzar "
 "hechizos."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1479
 msgid ""
 "You tentatively approach the burial ground of ancient warriors. Do you want "
 "to search the graves?"
@@ -3231,7 +3582,6 @@ msgstr ""
 "Tímidamente te aproximas al cementerio de antiguos guerreros. ¿Deseas buscar "
 "en las tumbas?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1480
 msgid ""
 "Upon defeating the Zombies you spend several hours searching the graves and "
 "find nothing. Such a despicable act reduces your army's morale."
@@ -3239,12 +3589,11 @@ msgstr ""
 "Después derrotar a los zombis y pasar varias horas buscando en las tumbas "
 "sin premio, la moral de tu ejercito se reduce por un hecho tan despreciable."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1481
-msgid "Upon defeating the zomies you search the graves and find something!"
+#, fuzzy
+msgid "Upon defeating the Zombies you search the graves and find something!"
 msgstr ""
 "¡Después de derrotar a los zombis entras en las tumbas y encuentras algo!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1484
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the shipwreck?"
@@ -3252,7 +3601,6 @@ msgstr ""
 "El casco putrefacto de una gran nave pirata chirría de manera inquietante "
 "contra las rocas.¿Deseas buscar entre los restos del naufragio?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1485
 msgid ""
 "Upon defeating the Ghosts you spend several hours sifting through the debris "
 "and find nothing. Such a despicable act reduces your army's morale."
@@ -3260,12 +3608,10 @@ msgstr ""
 "Después de derrotar a los fantamas y pasar varias horas tamizando sus restos "
 "sin premio la moral de tu ejercito se reduce por un acto tan despreciable"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1486
 msgid ""
 "Upon defeating the Ghosts you sift through the debris and find something!"
 msgstr "¡Despúes de derrotar a los fantasmas tamizas sus restos sin premio!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1489
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the ship?"
@@ -3273,7 +3619,6 @@ msgstr ""
 "El casco putrefacto de una gran nave pirata chirría inquietantemente contra "
 "las rocas. ¿Deseas buscar en la nave?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1490
 msgid ""
 "Upon defeating the Skeletons you spend several hours sifting through the "
 "debris and find nothing. Such a despicable act reduces your army's morale."
@@ -3281,19 +3626,16 @@ msgstr ""
 "Después de derrotar a los esqueletos y pasar varias horas tamizando sus "
 "restos sin premio la moral de tu ejército baja por tan despreciable acto."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1491
 msgid ""
 "Upon defeating the Skeletons you sift through the debris and find something!"
 msgstr ""
 "!Después de derrotar a los esqueletos tamizas sus restos y encuentras algo!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1564
 msgid "Your men spot a navigational buoy, confirming that you are on course."
 msgstr ""
 "Tus hombres descubren una boya de navegación, confirmando que estás en la "
 "ruta correcta."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1565
 msgid ""
 "Your men spot a navigational buoy, confirming that you are on course and "
 "increasing their morale."
@@ -3301,7 +3643,6 @@ msgstr ""
 "Tus hombres descubren una boya de navegación, confirmando que estás en la "
 "ruta correcta e incrementa su moral."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1569
 msgid ""
 "The drink at the oasis is refreshing, but offers no further benefit. The "
 "oasis might help again if you fought a battle first."
@@ -3309,7 +3650,6 @@ msgstr ""
 "Beber en el oasis es refrescante, pero no ofrece ningún beneficio adicional. "
 "El oasis te podrá ayudar otra vez si primero has luchado en una batalla."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1570
 msgid ""
 "A drink at the oasis fills your troops with strength and lifts their "
 "spirits.  You can travel a bit further today."
@@ -3317,7 +3657,6 @@ msgstr ""
 "Al beber en el oasis se restablecen las fuerzas de tus tropas y se elevan "
 "sus espíritus. Puedes viajar un poco más hoy."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1575
 msgid ""
 "The drink at the watering hole is refreshing, but offers no further benefit. "
 "The watering hole might help again if you fought a battle first."
@@ -3326,7 +3665,6 @@ msgstr ""
 "otros beneficios. La grieta te podría ayudar de nuevo si antes luchas en "
 "batalla."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1576
 msgid ""
 "A drink at the watering hole fills your troops with strength and lifts their "
 "spirits. You can travel a bit further today."
@@ -3334,18 +3672,15 @@ msgstr ""
 "Beber por esta grieta de la que fluye agua restablece las fuerzas de tus "
 "tropas y eleva sus espíritus. Puedes viajar un poco más hoy."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1581
 msgid ""
 "It doesn't help to pray twice before a battle. Come back after you've fought."
 msgstr ""
 "No ayuda rezar dos veces antes de una batalla. Regresa después de que hayas "
 "luchado."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1582
 msgid "A visit and a prayer at the temple raises the morale of your troops."
 msgstr "Una visita y una oración en el templo aumenta la moral de tus tropas."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1622
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"I am sorry, my liege, I "
 "have taught you all I can.\""
@@ -3353,7 +3688,6 @@ msgstr ""
 "Un anciano caballero aparece en los peldaños del cenador. \"Lo siento os he "
 "enseñado todo lo que puedo\"."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1623
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"My liege, I will teach "
 "you all that I know to aid you in your travels.\""
@@ -3361,7 +3695,6 @@ msgstr ""
 "Un anciano caballero aparece en los peldaños del cenador. \"Os enseñaré todo "
 "lo que sé para ayudaros en vuestros viajes\"."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1662
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
 "ocean. Grateful, he says, \"I would give you an artifact as a reward, but "
@@ -3371,39 +3704,30 @@ msgstr ""
 "océano olvidado. Agradecido, él dice, \"Yo te daría un artefacto como "
 "recompensa, pero no tienes espacio\"."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1669
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
-"ocean. Grateful, he rewards you for your act of kindness by giving you the %"
-"{art}."
+"ocean. Grateful, he rewards you for your act of kindness by giving you the "
+"%{art}."
 msgstr ""
 "Arrastras a un superviviente de un naufragio, salvándolo de una muerte "
 "segura en un océano sin compasión. Agradecido, te recompensa por tu acto de "
 "bondad con %{art}"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1688 ../fheroes2/heroes/heroes.cpp:941
-msgid "You have no room to carry another artifact!"
-msgstr "¡No tienes espacio para llevar otro artefacto!"
-
-#: ../fheroes2/heroes/heroes_action.cpp:1704
 msgid "A leprechaun offers you the %{art} for the small price of %{gold} Gold."
 msgstr ""
 "Un Leprechaun te ofrece %{art} por el pequeño precio de %{gold} piezas de "
 "Oro."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1709
 msgid ""
-"A leprechaun offers you the %{art} for the small price of %{gold} Gold and %"
-"{count} %{res}."
+"A leprechaun offers you the %{art} for the small price of %{gold} Gold and "
+"%{count} %{res}."
 msgstr ""
-"Un Leprechaun te ofrece %{art} por el precio de %{gold} piezas de Oro y %"
-"{count} %{res}."
+"Un Leprechaun te ofrece %{art} por el precio de %{gold} piezas de Oro y "
+"%{count} %{res}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1718
 msgid "Do you wish to buy this artifact?"
 msgstr "¿Deseas comprar este artefacto?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1731
 msgid ""
 "You try to pay the leprechaun, but realize that you can't afford it. The "
 "leprechaun stamps his foot and ignores you."
@@ -3411,7 +3735,6 @@ msgstr ""
 "Intentas pagar al leprechaun, pero te das cuenta de que no te lo puedes "
 "permitir. El leprechaun patea el suelo y te ignora."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1735
 msgid ""
 "Insulted by your refusal of his generous offer, the leprechaun stamps his "
 "foot and ignores you."
@@ -3419,12 +3742,9 @@ msgstr ""
 "Insultado por el rechazo de su generosa oferta, el Leprechaun te da una "
 "patada y te ignora."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1746
-#: ../fheroes2/heroes/heroes_action.cpp:1821
 msgid "You've found the artifact: "
 msgstr "Has encontrado el artefacto: "
 
-#: ../fheroes2/heroes/heroes_action.cpp:1756
 msgid ""
 "You've found the humble dwelling of a withered hermit. The hermit tells you "
 "that he is willing to give the %{art} to the first wise person he meets."
@@ -3433,7 +3753,6 @@ msgstr ""
 "que está dispuesto a darle el %{art} a la primera persona sabia que se "
 "encuentre."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1759
 msgid ""
 "You've come across the spartan quarters of a retired soldier. The soldier "
 "tells you that he is willing to pass on the %{art} to the first true leader "
@@ -3442,7 +3761,6 @@ msgstr ""
 "Llegas a la espartana morada de un soldado retirado. El soldado te dice que "
 "está dispuesto a darle el %{art} al primer líder auténtico que se encuentre."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1780
 msgid ""
 "You come upon an ancient artifact. As you reach for it, a pack of Rogues "
 "leap out of the brush to guard their stolen loot."
@@ -3450,7 +3768,6 @@ msgstr ""
 "Te encuentras un artefacto antiguo. Al ir a recogerlo, un grupo de Pícaros "
 "saltan de entre la maleza para proteger su botín."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1783
 msgid ""
 "Through a clearing you observe an ancient artifact. Unfortunately, it's "
 "guarded by a nearby %{monster}. Do you want to fight the %{monster} for the "
@@ -3460,11 +3777,9 @@ msgstr ""
 "está guardado por un %{monster} cercano. ¿Quiers combatir el %{monster} por "
 "el artefacto?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1798
 msgid "Victorious, you take your prize, the %{art}."
 msgstr "Victorioso, tomas tu premio: %{art}"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1810
 msgid ""
 "Discretion is the better part of valor, and you decide to avoid this fight "
 "for today."
@@ -3472,8 +3787,6 @@ msgstr ""
 "La madurez es la mejor parte del valor, así pues decides evitar esta lucha "
 "hoy."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1866
-#: ../fheroes2/heroes/heroes_action.cpp:1881
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold pieces."
@@ -3481,7 +3794,6 @@ msgstr ""
 "Después de varias horas intentando sacar el cofre del mar, lo abres y "
 "encentras %{gold} piezas de oro."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1872
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold and the %{art}."
@@ -3489,7 +3801,6 @@ msgstr ""
 "Después de pasar horas intentando sacar el cofre del mar, lo abres y "
 "encuentras %{gold} piezas de oro y %{art}"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1888
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it, "
 "only to find it empty."
@@ -3497,7 +3808,6 @@ msgstr ""
 "Después de pasar horas intentando sacar el cofre del mar, lo abres y resulta "
 "estar vacío."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1898
 msgid ""
 "After scouring the area, you fall upon a hidden treasure cache. You may take "
 "the gold or distribute the gold to the peasants for experience. Do you wish "
@@ -3507,15 +3817,13 @@ msgstr ""
 "quedarte con el oro o distribuirlo entre los campesinos a cambio de "
 "experiencia. ¿Deseas quedarte con el oro?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1912
 msgid ""
-"After scouring the area, you fall upon a hidden chest, containing the %"
-"{gold} gold pieces."
+"After scouring the area, you fall upon a hidden chest, containing the "
+"%{gold} gold pieces."
 msgstr ""
 "Después de dar una batida por el área, das con un cofre escondido que "
 "contiene %{gold} piezas de oro."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1918
 msgid ""
 "After scouring the area, you fall upon a hidden chest, containing the "
 "ancient artifact %{art}."
@@ -3523,7 +3831,6 @@ msgstr ""
 "Después de dar una batida por el área, das con un cofre escondido que "
 "contiene un antiguo artefacto: %{art}"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1942
 msgid ""
 "You stumble upon a dented and tarnished lamp lodged deep in the earth. Do "
 "you wish to rub the lamp?"
@@ -3531,15 +3838,6 @@ msgstr ""
 "Te tropiezas con una lámpara abollada que está depositada en lo profundo de "
 "la tierra. ¿Deseas frotar la lámpara?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "A whirlpool engulfs your ship."
-msgstr "Un remolino engulle tu nave."
-
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "Some of your army has fallen overboard."
-msgstr "Parte de tu ejército ha caído por la borda."
-
-#: ../fheroes2/heroes/heroes_action.cpp:2045
 msgid ""
 "You come upon an abandoned gold mine. The mine appears to be haunted. Do you "
 "wish to enter?"
@@ -3547,15 +3845,13 @@ msgstr ""
 "Llegas a una mina de oro abandonada. La mina parece estar embrujada. "
 "¿Quieres entrar en ella?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2064
 msgid ""
 "You have taken control of the local Alchemist shop. It will provide you with "
 "%{count} unit of Mercury per day."
 msgstr ""
-"Has tomado el control de la casa del Alquimista local. Te proveerá con %"
-"{count} unidades de mercurio al día."
+"Has tomado el control de la casa del Alquimista local. Te proveerá con "
+"%{count} unidades de mercurio al día."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2070
 msgid ""
 "You gain control of a sawmill. It will provide you with %{count} units of "
 "wood per day."
@@ -3563,7 +3859,11 @@ msgstr ""
 "Has tomado el control de un aserradero. Te proveerá con %{count} unidades de "
 "madera al día."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2081
+msgid "You beat the Ghosts and are able to restore the mine to production."
+msgstr ""
+"Derrotas a los Fantasmas y eres capaz de restablecer la producción de la "
+"mina."
+
 msgid ""
 "You gain control of an ore mine. It will provide you with %{count} units of "
 "ore per day."
@@ -3571,7 +3871,6 @@ msgstr ""
 "Has tomado el control de una mina de mineral. Te proveerá con %{count} "
 "unidades de mineral al día."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2083
 msgid ""
 "You gain control of a sulfur mine. It will provide you with %{count} unit of "
 "sulfur per day."
@@ -3579,7 +3878,6 @@ msgstr ""
 "Has tomado el control de una mina de azufre. Te proveerá con %{count} "
 "unidades de azufre al día."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2085
 msgid ""
 "You gain control of a crystal mine. It will provide you with %{count} unit "
 "of crystal per day."
@@ -3587,7 +3885,6 @@ msgstr ""
 "Has tomado el control de una mina de cristal. Te proveerá con %{count} "
 "unidades de cristal al día."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2087
 msgid ""
 "You gain control of a gem mine. It will provide you with %{count} unit of "
 "gems per day."
@@ -3595,7 +3892,6 @@ msgstr ""
 "Has tomado el control de una mina de gemas. Te proveerá con %{count} "
 "unidades de gemas al día."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2089
 msgid ""
 "You gain control of a gold mine. It will provide you with %{count} gold per "
 "day."
@@ -3603,13 +3899,6 @@ msgstr ""
 "Has tomado el control de una mina de oro. Te proveerá con %{count} unidades "
 "de oro al día."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2096
-msgid "You beat the Ghosts and are able to restore the mine to production."
-msgstr ""
-"Derrotas a los Fantasmas y eres capaz de restablecer la producción de la "
-"mina."
-
-#: ../fheroes2/heroes/heroes_action.cpp:2101
 msgid ""
 "The lighthouse is now under your control, and all of your ships will now "
 "move further each turn."
@@ -3617,11 +3906,9 @@ msgstr ""
 "El faro está ahora bajo tu control, todos tus barcos podrán recorrer mayor "
 "distancia por turno."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2105
 msgid "You gain control of a %{name}."
 msgstr "Tomas control de %{name}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2188
 msgid ""
 "A group of %{monster} with a desire for greater glory wish to join you. Do "
 "you accept?"
@@ -3629,11 +3916,9 @@ msgstr ""
 "Un grupo de %{monster} con ansias de gloria desea unirse a tus tropas. "
 "¿Aceptas?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2215
 msgid "As you approach the dwelling, you notice that there is no one here."
 msgstr "Al aproximarte a la morada te percatas de que ya no hay nadie allí."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2232
 msgid ""
 "You search the ruins, but the Medusas that used to live here are gone. "
 "Perhaps there will be more next week."
@@ -3641,7 +3926,6 @@ msgstr ""
 "Buscas en las ruinas, pero las Medusas que solían vivir aquí se han ido. "
 "Quizás habrá más la próxima semana."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2233
 msgid ""
 "You've found some Medusas living in the ruins. They are willing to join your "
 "army for a price. Do you want to recruit Medusas?"
@@ -3649,7 +3933,6 @@ msgstr ""
 "Has encontrado algunas Medusas viviendo en las Ruinas. Están deseosas de "
 "servir como mercenarias por un buen precio. ¿Deseas reclutar Medusas?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2238
 msgid ""
 "You've found a Sprite Tree City. Unfortunately, none of the Sprites living "
 "there wish to join an army. Maybe next week."
@@ -3657,7 +3940,6 @@ msgstr ""
 "Has encontrado la Ciudad de los Árboles de las Hadas. Desafortunadamente "
 "ninguna desea unirse a tu ejército. Quizás la próxima semana."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2239
 msgid ""
 "Some of the Sprites living in the tree city are willing to join your army "
 "for a price. Do you want to recruit Sprites?"
@@ -3665,7 +3947,6 @@ msgstr ""
 "Alguna de las Hadas que viven en la ciudad están deseosas de unirse como "
 "mercenarias a tu ejército por un precio. ¿Quieres reclutar Hadas?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2244
 msgid ""
 "A colorful Rogues' wagon stands empty here. Perhaps more Rogues will be here "
 "later."
@@ -3673,7 +3954,6 @@ msgstr ""
 "Un colorido vagón de Bandidos se encuentra vacio ahora mismo. Quizás estarán "
 "aquí más tarde."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2245
 msgid ""
 "Distant sounds of music and laughter draw you to a colorful wagon housing "
 "Rogues. Do you wish to have any Rogues join your army?"
@@ -3681,7 +3961,6 @@ msgstr ""
 "Sonidos de música y risas distantes te guían a una colorida caravana de "
 "Bandidos. ¿Quieres que se una algún Bandido a tu ejército?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2250
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. The "
 "tents are unoccupied. Perhaps more Nomads will be here later."
@@ -3689,7 +3968,6 @@ msgstr ""
 "Te intriga un grupo de destartaladas tiendas, que se mueven con el viento. "
 "Las tiendas están vacías. Quizás haya mas Nómadas mas adelante."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2251
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. Do you "
 "wish to have any Nomads join you during your travels?"
@@ -3697,11 +3975,9 @@ msgstr ""
 "Te intriga un grupo de destartaladas tiendas, que se mueven con el viento. "
 "¿Quieres que algún Nómada te acompañe durante tus viajes?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2256
 msgid "The pit of mud bubbles for a minute and then lies still."
 msgstr "La fosa de barro burbujea por un minuto y entonces permanece en calma."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2257
 msgid ""
 "As you approach the bubbling pit of mud, creatures begin to climb out and "
 "position themselves around it. In unison they say: \"Mother Earth would like "
@@ -3711,12 +3987,10 @@ msgstr ""
 "y te rodean. Dicen al unísono: \"La Madre Tierra le gustaría ofrecerte "
 "algunas de sus tropas. ¿Quieres reclutar Elementales de la Tierra?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2261
 msgid "You enter the structure of white stone pillars, and find nothing."
 msgstr ""
 "Entras en la estructura de blancos pilares de piedra y no encuentras nada."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2262
 msgid ""
 "White stone pillars support a roof that rises up to the sky. As you enter "
 "the structure, the dead air of the outside gives way to a whirling gust that "
@@ -3732,11 +4006,9 @@ msgstr ""
 "considerarse un susurro. ¿Por qué has venido?, ¿Estás aquí para invocar a "
 "las fuerzas del Aire?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2266
 msgid "No Fire Elementals approach you from the lava pool."
 msgstr "Ningun Elemental del Fuego se aproxima a ti desde el charco de lava."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2267
 msgid ""
 "Beneath a structure that serves to hold in heat, Fire Elementals move about "
 "in a fiery pool of molten lava. A group of them approach you and offer their "
@@ -3747,11 +4019,9 @@ msgstr ""
 "se aproxima a ti y te ofrece sus servicios. ¿Te gustaría reclutar "
 "Elementales de Fuego?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2271
 msgid "A face forms in the water for a moment, and then is gone."
 msgstr "Una cara se forma en el agua por un momento y entonces se va."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2272
 msgid ""
 "Crystalline structures cast shadows over a small reflective pool of water. "
 "You peer into the pool, and a face that is not your own peers back. It asks: "
@@ -3761,11 +4031,9 @@ msgstr ""
 "de agua. Miras con detenimiento la charca y una cara que no es la tuya te "
 "devuelve la mirada. Dice: \"¿Te gustaría invocar los poderes del agua?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2276
 msgid "This burial site is deathly still."
 msgstr "En este lugar de enterramiento se respira una quietud de muerte."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2277
 msgid ""
 "Restless spirits of long dead warriors seeking their final resting place "
 "offer to join you in hopes of finding peace. Do you wish to recruit ghosts?"
@@ -3774,7 +4042,6 @@ msgstr ""
 "lugar de definitivo descanso, ofrecen incorporase a tus fuezas con la "
 "esperanza de encontrar la paz. ¿Deseas reclutar Fantasmas?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2313
 msgid ""
 "The City of the Dead is empty of life, and empty of unlife as well. Perhaps "
 "some undead will move in next week."
@@ -3782,7 +4049,6 @@ msgstr ""
 "La Ciudad de los Muertos está vacía de vida y de muertos vivientes también. "
 "Quizás algunos nomuertos vendrán la próxima semana."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2314
 msgid ""
 "Some Liches living here are willing to join your army for a price. Do you "
 "want to recruit Liches?"
@@ -3790,7 +4056,6 @@ msgstr ""
 "Algunos Liches que moran aquí están deseando unirse a tu ejército por una "
 "buena suma. ¿Quieres reclutar Liches?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2315
 msgid ""
 "You've found the ruins of an ancient city, now inhabited solely by the "
 "undead. Will you search?"
@@ -3798,7 +4063,6 @@ msgstr ""
 "Has encontrado las ruinas de una antigua ciudad, ahora habitada sólamente "
 "por nomuertos. ¿Quieres investigar?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2316
 msgid ""
 "Some of the surviving Liches are impressed by your victory over their "
 "fellows, and offer to join you for a price. Do you want to recruit Liches?"
@@ -3806,7 +4070,6 @@ msgstr ""
 "Algunas Liches, impresionadas por tu victoria sobre sus camaradas, se "
 "ofrecen como mercenarias. ¿Quieres reclutar liches?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2320
 msgid ""
 "You've found one of those bridges that Trolls are so fond of living under, "
 "but there are none here. Perhaps there will be some next week."
@@ -3814,7 +4077,6 @@ msgstr ""
 "Has encontrado uno de esos puentes debajo de los cuales los Trolls están tan "
 "a gusto viviendo. Quizás la próxima semana habrá algunos."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2321
 msgid ""
 "Some Trolls living under a bridge are willing to join your army, but for a "
 "price. Do you want to recruit Trolls?"
@@ -3822,12 +4084,10 @@ msgstr ""
 "Algunos Trolls que viven bajo un puente están deseosos de unirse a tu "
 "ejercitgo por un precio. ¿Quieres reclutar Trolls?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2322
 msgid "Trolls living under the bridge challenge you. Will you fight them?"
 msgstr ""
 "Los Trolls que viven bajo el puente te desafían. ¿Lucharás contra ellos?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2323
 msgid ""
 "A few Trolls remain, cowering under the bridge. They approach you and offer "
 "to join your forces as mercenaries. Do you want to buy any Trolls?"
@@ -3836,7 +4096,6 @@ msgstr ""
 "ofrecen unirse a tus fuerzas como mercenarios. ¿Quieres reclutar algunos "
 "Trolls?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2327
 msgid ""
 "The Dragon city has no Dragons willing to join you this week. Perhaps a "
 "Dragon will become available next week."
@@ -3844,7 +4103,6 @@ msgstr ""
 "En la Ciudad del Dragón no hay ningún Dragón que desee unirse a tus filas "
 "esta semana. Quizás un dragón estará disponible la próxima semana."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2328
 msgid ""
 "The Dragon city is willing to offer some Dragons for your army for a price. "
 "Do you wish to recruit Dragons?"
@@ -3852,7 +4110,6 @@ msgstr ""
 "La Ciudad del Dragón está deseando ofrecer algunos Dragones a tu ejercito "
 "por un precio. ¿Deseas reclutar Dragones?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2329
 msgid ""
 "You stand before the Dragon City, a place off-limits to mere humans. Do you "
 "wish to violate this rule and challenge the Dragons to a fight?"
@@ -3860,7 +4117,6 @@ msgstr ""
 "Estás ante la Ciudad del Dragón, un lugar fuera de los límites de los "
 "humanos. ¿Deseas romper esta norma y desafiar a los Dragones en combate?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2330
 msgid ""
 "Having defeated the Dragon champions, the city's leaders agree to supply "
 "some Dragons to your army for a price. Do you wish to recruit Dragons?"
@@ -3869,11 +4125,9 @@ msgstr ""
 "accede a sumistrar algunos Dragones a tu ejército por un precio. ¿Deseas "
 "reclutar Dragones?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2389
 msgid "From the observation tower, you are able to see distant lands."
 msgstr "Desde la torre de observación, puedes ver tierras lejanas."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2401
 msgid ""
 "The spring only refills once a week, and someone's already been here this "
 "week."
@@ -3881,7 +4135,6 @@ msgstr ""
 "El manaltial sólo se rellena una vez a la semana y alguien ya ha estado aquí "
 "esta semana."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2407
 msgid ""
 "A drink at the spring is supposed to give you twice your normal spell "
 "points, but you are already at that level."
@@ -3889,7 +4142,6 @@ msgstr ""
 "Al beber del manantial se duplican tus puntos normales de Maná, pero ya "
 "estás a ese nivel."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2418
 msgid ""
 "A drink from the spring fills your blood with magic! You have twice your "
 "normal spell points in reserve."
@@ -3897,7 +4149,6 @@ msgstr ""
 "¡Beber del manantial colma tu sangre con magia! Duplicas la reserva de tus "
 "puntos normales de Maná."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2437
 msgid ""
 "Recognizing you, the butler refuses to admit you. \"The master,\" he says, "
 "\"will not see the same student twice.\""
@@ -3905,7 +4156,6 @@ msgstr ""
 "El mayordomo te reconoce y rechaza admitirte. \"El Maestro\" dice, \"no "
 "atenderá al mismo estudiante dos veces\"."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2457
 msgid ""
 "The butler admits you to see the master of the house. He trains you in the "
 "four skills a hero should know."
@@ -3913,7 +4163,6 @@ msgstr ""
 "El Mayordomo permite que veas al Maestro de la Casa. Él te adiestra en las "
 "cuatro habilidades que todo héroe debería conocer."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2467
 msgid ""
 "The butler opens the door and looks you up and down. \"You are neither "
 "famous nor diplomatic enough to be admitted to see my master,\" he sniffs. "
@@ -3923,7 +4172,6 @@ msgstr ""
 "famoso ni suficientemente letrado para llegar a ver a mi maestro\" dice con "
 "desdén. \"Vuelve cuando te consideres suficientemente válido\"."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2510
 msgid ""
 "All of the %{monsters} you have in your army have been trained by the battle "
 "masters of the fort. Your army now contains %{monsters2}."
@@ -3931,24 +4179,23 @@ msgstr ""
 "Tus %{mosters} han sido entrenados por los Maestros en Batalla del fuerte. "
 "Tus ejército ahora cuenta con %{monsters2}"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2513
+#, fuzzy
 msgid ""
-"An unusual alliance of Orcs, Ogres, and Dwarves offer to train (upgrade) any "
+"An unusual alliance of Ogres, Orcs, and Dwarves offer to train (upgrade) any "
 "such troops brought to them. Unfortunately, you have none with you."
 msgstr ""
 "Una inusual alianza entre Orcos, Ogros y Enanos te ofrece mejorar ese clase "
 "de tropas si se las traes. Desafortunadamente no tienes ninguno de ellos "
 "contigo."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2524
 msgid "All of your %{monsters} have been upgraded into %{monsters2}."
 msgstr "Tus %{monsters} han mejorado a %{monsters2}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2527
+#, fuzzy
 msgid ""
 "A blacksmith working at the foundry offers to convert all Pikemen and "
 "Swordsmen's weapons brought to him from iron to steel. He also says that he "
-"knows a process that will convert Iron Golems into Steel Golems.  "
+"knows a process that will convert Iron Golems into Steel Golems. "
 "Unfortunately, you have none of these troops in your army, so he can't help "
 "you."
 msgstr ""
@@ -3957,7 +4204,6 @@ msgstr ""
 "convertirá Golems en Golems de Acero. Desafortunadamente no tienes esas "
 "tropas en tu ejército, por lo tanto no puede ayudarte."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2585
 msgid ""
 "A retired captain living on this refurbished fishing platform offers to sell "
 "you maps of the sea he made in his younger days for 1,000 gold. Do you wish "
@@ -3967,7 +4213,6 @@ msgstr ""
 "mapas marítimos que hizo en sus días de juventud por 1.000 piezas de Oro. "
 "¿Deseas comprar los mapas?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2598
 msgid ""
 "The captain sighs. \"You don't have enough money, eh?  You can't expect me "
 "to give my maps away for free!\""
@@ -3975,11 +4220,9 @@ msgstr ""
 "El Capitán suspira: \"No tienes suficiente dinero, ¿eh? No esperarás que te "
 "ofrezca mis mapas gratis."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2632
 msgid "You find %{artifact}."
 msgstr "Encuentras: %{artifact}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2655
 msgid ""
 "You come upon an obelisk made from a type of stone you have never seen "
 "before. Staring at it intensely, the smooth surface suddenly changes to an "
@@ -3992,11 +4235,9 @@ msgstr ""
 "Rápidamente lo copias y la inscripción se esfuma tan abruptamente como "
 "apareció."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2659
 msgid "You have already been to this obelisk."
 msgstr "Ya has habias estado en este obelisco."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2671
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"It is good to see "
 "you, my student. I hope my teachings have helped you.\""
@@ -4004,7 +4245,6 @@ msgstr ""
 "Al aproximarte, el Árbol abre sus ojos con deleite. \"Es bueno verte de "
 "nuevo, alumno mío. Espero que mis enseñanzas te hayan ayudado.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2683
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"Ahh, an "
 "adventurer! Allow me to teach you a little of what I have learned over the "
@@ -4013,33 +4253,32 @@ msgstr ""
 "Al aproximarte, el Árbol abre sus ojos con deleite. \"Ahh, ¡un aventurero! "
 "Permíteme enseñarte un poco de lo que aprendido con los años.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2692
 msgid "Upon your approach, the tree opens its eyes in delight."
 msgstr "Al aproximarte, el Árbol abre sus ojos con deleite."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2694
 msgid ""
 "\"Ahh, an adventurer! I will be happy to teach you a little of what I have "
 "learned over the ages for a mere %{count} %{res}.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2696
 msgid "(Just bury it around my roots.)"
 msgstr "(Simplemente entierra lo que te pido alredor de mis raices.)"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2703
 msgid "Tears brim in the eyes of the tree."
 msgstr "Las lágrimas colman los ojos del Árbol."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2705
 msgid "\"I need %{count} %{res}.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2707
 msgid "it whispers. (sniff) \"Well, come back when you can pay me.\""
 msgstr "Suspira .. sniff, \"Bien, regresa cuando puedas pagarme.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2737
+msgid ""
+"Nestled among the trees sits a blind seer. After explaining the intent of "
+"your journey, the seer activates his crystal ball, allowing you to see the "
+"strengths and weaknesses of your opponents."
+msgstr ""
+
 msgid ""
 "The entrance to the cave is dark, and a foul, sulfurous smell issues from "
 "the cave mouth. Will you enter?"
@@ -4047,7 +4286,6 @@ msgstr ""
 "La entrada a la Cueva es oscura, un hediondo y sufuroso olor sale de la boca "
 "de la cueva. ¿Entrarás?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2749
 msgid ""
 "You find a powerful and grotesque Demon in the cave. \"Today,\" it rasps, "
 "\"you will fight and surely die. But I will give you a choice of deaths. You "
@@ -4059,19 +4297,16 @@ msgstr ""
 "puedes luchar contra mi o contra mis sirvientes. ¿Prefieres luchar contra "
 "mis sirvientes?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2759
 msgid ""
 "Upon defeating the daemon's servants, you find a hidden cache with %{count} "
 "gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2774
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and receive %{exp} experience points."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2784
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and find the %{art} in the back of the cave."
@@ -4080,48 +4315,44 @@ msgstr ""
 "batalla, das muerte al monstruo y encuentras %{art} in la parte posterior de "
 "la cueva."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2794
+#, fuzzy
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
-"battle, you slay the monster and receive %{exp) experience points and %"
-"{count} gold."
+"battle, you slay the monster and receive %{exp} experience points and "
+"%{count} gold."
 msgstr ""
+"¡El Demonio grita su desafío y ataca! Después de una pequeña y desesperada "
+"batalla, das muerte al monstruo y encuentras %{art} in la parte posterior de "
+"la cueva."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2809
 msgid ""
 "The Demon leaps upon you and has its claws at your throat before you can "
 "even draw your sword. \"Your life is mine,\" it says. \"I will sell it back "
 "to you for %{count} gold.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2810
 msgid ""
 "Seeing that you do not have %{count} gold, the demon slashes you with its "
 "claws, and the last thing you see is a red haze."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2835
 msgid "Except for evidence of a terrible battle, the cave is empty."
 msgstr "Excepto por la evidencia de una terrible batalla, la Cueva está vacía."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2860
 msgid "For %{gold} gold, the alchemist will remove it for you. Do you pay?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2871
 msgid ""
 "You hear a voice from behind the locked door, \"You don't have enough gold "
 "to pay for my services.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2874
 msgid ""
 "You hear a voice from high above in the tower, \"Go away! I can't help you!\""
 msgstr ""
 "Oyes una voz que proviene de lo alto de la torre, \"¡Vete, no puedo ayudarte!"
 "\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2886
 msgid ""
 "The head groom approaches you and speaks, \"You already have a fine horse, "
 "and have no inexperienced cavalry which might make use of our trained war "
@@ -4131,7 +4362,6 @@ msgstr ""
 "caballería con experiencia lo que evitará hacer uso de nuestros caballos de "
 "batalla entrenados."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2889
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, his "
@@ -4146,7 +4376,6 @@ msgstr ""
 "beneficiar a tus solados montados, pero no tienes ninguno así que no te "
 "podemos ayudar\"."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2892
 msgid ""
 "The head groom speaks to you, \"That is a fine looking horse you have. I am "
 "afraid we can give you no better, but the horses your cavalry are riding "
@@ -4158,7 +4387,6 @@ msgstr ""
 "no ser de raza. Hemos entrenado muchos caballos de batalla lo cual ayudará a "
 "tus jinetes mucho. Insisto en que te los lleves."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2895
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, he will "
@@ -4170,11 +4398,9 @@ msgstr ""
 "cansará en una semana. Deberíais permitirme daros mejores caballos para tus "
 "soldados montados, puesto que sus caballos parecen debiluchos."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2922
 msgid "The Arena guards turn you away."
 msgstr "Los Guardas de la Arena te apartan."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2939
 msgid ""
 "As the sirens sing their eerie song, your small, determined army manages to "
 "overcome the urge to dive headlong into the sea."
@@ -4183,7 +4409,6 @@ msgstr ""
 "ejercito empieza a pensar en dejarse llevar por el impulso de tirarse de "
 "cabeza al mar."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2944
 msgid ""
 "You have your crew stop up their ears with wax before the sirens' eerie song "
 "has any chance of luring them to a watery grave. An eerie wailing song "
@@ -4198,7 +4423,6 @@ msgstr ""
 "donde se ahogan. Ahora estas prevenido de su localización, y ganas %{exp} de "
 "experiencia."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2964
 msgid ""
 "In a dazzling display of daring, you break into the local jail and free the "
 "hero imprisoned there, who, in return, pledges loyalty to your cause."
@@ -4207,7 +4431,6 @@ msgstr ""
 "liberas el héroe que está prisionero allí, quien, a cambio, jura lealtad a "
 "tu causa."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2980
 msgid ""
 "You already have %{count} heroes, and regretfully must leave the prisoner in "
 "this jail to languish in agony for untold days."
@@ -4215,7 +4438,6 @@ msgstr ""
 "Ya tienes %{count} héroes, y lamentablemente debes dejar al prisionero en su "
 "cárcel languideciendo de agonía por incontables días."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2991
 msgid ""
 "You enter a rickety hut and talk to the magician who lives there. He tells "
 "you of places near and far which may aid you in your journeys."
@@ -4223,11 +4445,9 @@ msgstr ""
 "Entras en una desvencijada cabaña y hablas con el mago que vive allí. El te "
 "habla de lugares cercanos y lejanos que te pueden ayudar en tus viajes."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3004
 msgid "This eye seems to be intently studying its surroundings."
 msgstr "Este ojo parece estar atentamente estudiando los alrededores."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3015
 msgid ""
 "\"I have a riddle for you,\" the Sphinx says. \"Answer correctly, and you "
 "shall be rewarded. Answer incorrectly, and you shall be eaten. Do you accept "
@@ -4236,12 +4456,16 @@ msgstr ""
 "\"Tengo un acertijo para ti\" dice la Esfinge. \"Contesta correctamente y "
 "serás recompensado. Falla y serás engullido.\" ¿Aceptas el Desafío?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:3017
-msgid "The Sphinx asks you the following riddle: %{riddle}. Your answer?"
+#, fuzzy
+msgid ""
+"The Sphinx asks you the following riddle:\n"
+" \n"
+"'%{riddle}'\n"
+" \n"
+"Your answer?"
 msgstr ""
 "La Esfinge te pregunta el siguiente acertijo: %{riddle}. ¿Tú respuesta?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:3025
 msgid ""
 "Looking somewhat disappointed, the Sphinx sighs. You've answered my riddle "
 "so here's your reward. Now begone."
@@ -4249,7 +4473,6 @@ msgstr ""
 "Pareciendo en cierto modo decepcionada, la Esfinge suspira. Has acertado mi "
 "acertijo, por lo tanto aquí está tu recompensa. Ahora vete."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3052
 msgid ""
 "\"You guessed incorrectly,\" the Sphinx says, smiling. The Sphinx swipes at "
 "you with a paw, knocking you to the ground. Another blow makes the world go "
@@ -4259,13 +4482,11 @@ msgstr ""
 "tirándote al suelo. Otro soplido hace retrodecer al mundo y no sabes nada "
 "más."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3060
 msgid "You come across a giant Sphinx. The Sphinx remains strangely quiet."
 msgstr ""
 "Te topas con una Esfinge Gigante. La Esfinge permanece extrañamente "
 "tranquila."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3073
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -4277,7 +4498,6 @@ msgstr ""
 "En cuanto dices la palabra mágica, la brillante barrera se disuelve en la "
 "nada."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3083
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -4288,7 +4508,6 @@ msgstr ""
 "el arco dicen, \"Di la clave y podrás pasar\".\n"
 "Hablas, pero no ocurre nada."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3093
 msgid ""
 "You enter the tent and see an old woman gazing into a magic gem. She looks "
 "up and says,\n"
@@ -4300,333 +4519,17 @@ msgstr ""
 "\"En mis viajes, he aprendido mucho del camino de la magia arcana. Un gran "
 "oráculo me paso sus habilidades. Tengo la respuesta que buscas.\""
 
-#: ../fheroes2/heroes/heroes_base.cpp:401
 msgid ""
 "That spell costs %{mana} mana. You only have %{point} mana, so you can't "
 "cast the spell."
 msgstr ""
-"No puedes usar ese hechizo. Cuesta %{mana} puntos de Maná y sólo tienes &"
-"{point}."
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Lord Kilburn"
-msgstr "Lord Kilburn"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Sir Gallanth"
-msgstr "Sir Gallanth"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ector"
-msgstr "Ector"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Gwenneth"
-msgstr "Gwenneth"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Tyro"
-msgstr "Tyro"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ambrose"
-msgstr "Ambrose"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ruby"
-msgstr "Ruby"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Maximus"
-msgstr "Maximus"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Dimitry"
-msgstr "Dimitry"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Thundax"
-msgstr "Thundax"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Fineous"
-msgstr "Fineous"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jojosh"
-msgstr "Jojosh"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Crag Hack"
-msgstr "Crag Hack"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jezebel"
-msgstr "Jezebel"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jaclyn"
-msgstr "Jaclyn"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Ergon"
-msgstr "Ergon"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Tsabu"
-msgstr "Tsabu"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Atlas"
-msgstr "Atlas"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Astra"
-msgstr "Astra"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Natasha"
-msgstr "Natasha"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Troyan"
-msgstr "Troyan"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Vatawna"
-msgstr "Vatawna"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Rebecca"
-msgstr "Rebecca"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Gem"
-msgstr "Gem"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Ariel"
-msgstr "Ariel"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Carlawn"
-msgstr "Carlawn"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Luna"
-msgstr "Luna"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Arie"
-msgstr "Arie"
-
-#: ../fheroes2/heroes/heroes.cpp:61 ../fheroes2/resource/maps_text.cpp:59
-msgid "Alamar"
-msgstr "Alamar"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Vesper"
-msgstr "Vesper"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Crodo"
-msgstr "Crodo"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Barok"
-msgstr "Barok"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Kastore"
-msgstr "Katore"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Agar"
-msgstr "Agar"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Falagar"
-msgstr "Falagar"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Wrathmont"
-msgstr "Wrathmont"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myra"
-msgstr "Myra"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Flint"
-msgstr "Flint"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Dawn"
-msgstr "Dawn"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Halon"
-msgstr "Halon"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myrini"
-msgstr "Myrini"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Wilfrey"
-msgstr "Wilfrey"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Sarakin"
-msgstr "Sarakin"
-
-#: ../fheroes2/heroes/heroes.cpp:63 ../fheroes2/resource/maps_text.cpp:377
-msgid "Kalindra"
-msgstr "Kalindra"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Mandigal"
-msgstr "Mandigal"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zom"
-msgstr "Zom"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Darlana"
-msgstr "Darlana"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zam"
-msgstr "Zam"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Ranloo"
-msgstr "Ranloo"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Charity"
-msgstr "Charity"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Rialdo"
-msgstr "Rialdo"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Roxana"
-msgstr "Roxana"
-
-#: ../fheroes2/heroes/heroes.cpp:65 ../fheroes2/resource/maps_text.cpp:557
-msgid "Sandro"
-msgstr "Sandro"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Celia"
-msgstr "Celia"
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:552
-msgid "Roland"
-msgstr "Roland"
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Lord Corlagon"
-msgstr "Lord Corlagon"
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Sister Eliza"
-msgstr "Hermana Eliza"
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:88
-msgid "Archibald"
-msgstr "Archibald"
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:403
-msgid "Lord Halton"
-msgstr "Lord Halton"
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Brother Bax"
-msgstr "Hermano Bax"
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Solmyr"
-msgstr "Solmyr"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:194
-msgid "Dainwin"
-msgstr "Dainwin"
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Mog"
-msgstr "Mog"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:760
-msgid "Uncle Ivan"
-msgstr "Uncle Ivan"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:373
-msgid "Joseph"
-msgstr "Joseph"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:285
-msgid "Gallavant"
-msgstr "Gallavant"
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Elderian"
-msgstr "Elderian"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:179
-msgid "Ceallach"
-msgstr "Ceallach"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:229
-msgid "Drakonia"
-msgstr "Drakonia"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:422
-msgid "Martine"
-msgstr "Martine"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:370
-msgid "Jarkonas"
-msgstr "Jarkonas"
-
-#: ../fheroes2/heroes/heroes.cpp:940
-msgid ""
-"You must purchase a spell book to use the mage guild, but you currently have "
-"no room for a spell book. Try giving one of your artifacts to another hero."
-msgstr ""
-"Debes compra un libro de hechizos para usar el gremio de magos, pero "
-"actualmente no tienes espacio para un libro de hechizos. Prueba dando uno de "
-"tus artefactos a otro héroe."
-
-#: ../fheroes2/heroes/heroes.cpp:950
-msgid "The three Anduran artifacts magically combine into one."
-msgstr "Los tres artefactos mágicos de Anduran combinados en uno."
-
-#: ../fheroes2/heroes/heroes.cpp:1056
-msgid "To cast spells, you must first buy a spell book for %{gold} gold."
-msgstr ""
-"Para lanzar hechizos primero has de comprar un libro de hechizos por %{gold} "
-"monedas de oro."
-
-#: ../fheroes2/heroes/heroes.cpp:1064
-msgid "Unfortunately, you seem to be a little short of cash at the moment."
-msgstr ""
-"Desafortunadamente, parece que andas un poco justo de dinero en estos "
-"momentos."
-
-#: ../fheroes2/heroes/heroes.cpp:1078
-msgid "Do you wish to buy one?"
-msgstr "¿Quiéres comprar uno?"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:72
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:55
-msgid "%{name} the %{race} ( Level %{level} )"
+"No puedes usar ese hechizo. Cuesta %{mana} puntos de Maná y sólo tienes "
+"&{point}."
+
+#, fuzzy
+msgid "%{name} the %{race} (Level %{level})"
 msgstr "%{name}, %{race} ( Nivel %{level} )"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:118
 msgid ""
 "'Grouped' combat formation bunches your army together in the center of your "
 "side of the battlefield."
@@ -4634,99 +4537,79 @@ msgstr ""
 "La formación 'Agrupada' de combate aglutina tu ejercito en el centro de tu "
 "lado del campo de batalla."
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:161
 msgid "Are you sure you want to dismiss this Hero?"
 msgstr "¿Estas seguro que quieres despedir este Héroe?"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:341
 #, fuzzy
 msgid "View Stats"
 msgstr "Ver Artefactos"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:344
-msgid "View Morale Info"
-msgstr "Ver Información sobre Moral"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:347
-msgid "View Luck Info"
-msgstr "Ver información sobre Suerte"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:350
 msgid "View Experience Info"
 msgstr "Ver información sobre Experiencia"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:353
 msgid "View Spell Points Info"
 msgstr "Ver información sobre Maná."
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:356
 msgid "Set army combat formation to 'Spread'"
 msgstr "Ordenar al ejercito formación Desplegada."
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:359
 msgid "Set army combat formation to 'Grouped'"
 msgstr "Ordenar al ejercito formación Agrupada"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:362
-msgid "Exit hero"
-msgstr "Salir de la pantalla de Héroe."
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:369
-msgid "Dismiss hero"
-msgstr "Descartar Héroe"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:373
-msgid "Show prev heroes"
-msgstr "Mostrar Héroes previos."
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:376
-msgid "Show next heroes"
-msgstr "Mostrar Héroes siguientes."
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:379
-msgid "Hero Screen"
+#, fuzzy
+msgid "Exit Hero Screen"
 msgstr "Pantalla de Héroe"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:39
-msgid "Bad Morale"
-msgstr "Mala Moral"
+msgid "You cannot dismiss a hero in a castle"
+msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:42
-msgid "Neutral Morale"
-msgstr "Moral Neutral"
+msgid "Dismissal of %{name} the %{race} is prohibited by scenario"
+msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:47
-msgid "Good Morale"
+#, fuzzy
+msgid "Dismiss %{name} the %{race}"
+msgstr "%{name} el %{race}"
+
+#, fuzzy
+msgid "Show previous hero"
+msgstr "Ver ciudad anterior"
+
+#, fuzzy
+msgid "Show next hero"
+msgstr "Mostrar Héroes siguientes."
+
+#, fuzzy
+msgid "Blood Morale"
 msgstr "Buena Moral"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:61
-msgid "Bad Luck"
-msgstr "Mala Suerte"
+#, fuzzy
+msgid "%{morale} Morale"
+msgstr "moral|Normal"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:64
-msgid "Neutral Luck"
-msgstr "Suerte Neutral"
+msgid "%{luck} Luck"
+msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:69
-msgid "Good Luck"
-msgstr "Buena Suerte"
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:113
-#: ../fheroes2/heroes/heroes_indicator.cpp:159
-#: ../fheroes2/heroes/skill.cpp:197
-msgid "Current Modifiers:"
+#, fuzzy
+msgid "Current Luck Modifiers:"
 msgstr "Modificadores actuales:"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:195
-msgid "Current experience %{exp1} Next level %{exp2}."
+#, fuzzy
+msgid "Current Morale Modifiers:"
+msgstr "Modificadores actuales:"
+
+#, fuzzy
+msgid "Entire army is undead, so morale does not apply."
+msgstr "No hay ningún muerto en la unidad, así que su moral está intacta"
+
+#, fuzzy
+msgid ""
+"Current experience %{exp1}.\n"
+" Next level %{exp2}."
 msgstr "Experiencia actual: %{exp1} Siguiente nivel a: %{exp2}."
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:215
 msgid "Level %{level}"
 msgstr "Nivel %{level}"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:226
 msgid ""
 "%{name} currently has %{point} spell points out of a maximum of %{max}. The "
 "maximum number of spell points is 10 times your knowledge. It is "
@@ -4738,88 +4621,76 @@ msgstr ""
 "es posible sobrepasar el máximo de puntos de Maná mediante eventos "
 "especiales."
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:65
 msgid "%{name1} meets %{name2}"
 msgstr "%{name1} se reune con %{name2}"
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:396
-#: ../fheroes2/heroes/heroes_meeting.cpp:406
 msgid " and "
 msgstr " y "
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:414
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
 msgstr ""
 "%{teacher}, cuyo %{scholar} %{level} conoce muchos secretos mágicos, aprende "
 "%{spells1} de %{learner}, y enseña %{spells2} a %{learner}."
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:417
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}."
 msgstr ""
 "%{teacher}, cuyo %{scholar} %{level} conoce muchos secretos mágicos, aprende "
 "%{spells1} de %{learner}."
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:420
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches %"
-"{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches "
+"%{spells2} to %{learner}."
 msgstr ""
-"%{teacher}, cuyo %{scholar} %{level} conoce muchos secretos mágicos, enseña %"
-"{spells1} a %{learner}."
+"%{teacher}, cuyo %{scholar} %{level} conoce muchos secretos mágicos, enseña "
+"%{spells1} a %{learner}."
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:431
 msgid "Scholar Ability"
 msgstr "Habilidad de Erudito"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:83 ../fheroes2/spell/spell.cpp:109
 msgid "Town Portal"
 msgstr "Portal de la Ciudad"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:86
 msgid "Select town to port to."
 msgstr "Seleccione la ciudad a la que transportarse."
 
-#: ../fheroes2/heroes/heroes_spell.cpp:106
 msgid "Your hero is too tired to cast this spell today. Try again tomorrow."
 msgstr ""
 "Tu héroe está demasiado cansado como para conjurar este hechizo hoy. Prueba "
 "de nuevo mañana."
 
-#: ../fheroes2/heroes/heroes_spell.cpp:187
 #, fuzzy
 msgid "%{spell} failed!!!"
 msgstr "¡Hechizo fallido!"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:236
+msgid "This spell is already in use."
+msgstr ""
+
 msgid "Enemy heroes are now fully identifiable."
 msgstr "Ahora se identifica totalmente a los héroes enemigos."
 
-#: ../fheroes2/heroes/heroes_spell.cpp:362
-#: ../fheroes2/heroes/heroes_spell.cpp:386
-msgid "No available towns. Spell Failed!!!"
+#, fuzzy
+msgid "This spell cannot be used on a boat."
+msgstr "Este pueblo no se puede actualizar a castillo."
+
+msgid "This spell can be casted only nearby water."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"No available towns.\n"
+"Spell Failed!!!"
 msgstr "No hay disponible ninguna ciudad. ¡¡¡ Hechizo fallido!!!"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:459
-msgid "I fear these creatures are in the mood for a fight."
-msgstr "Me temo que esas criaturas tienen ganas de luchar."
+#, fuzzy
+msgid ""
+"Nearest town occupied.\n"
+"Spell Failed!!!"
+msgstr "No hay disponible ninguna ciudad. ¡¡¡ Hechizo fallido!!!"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:463
-msgid "The creatures are willing to join us!"
-msgstr "¡Las criaturas quieren unirse a nosotros!"
-
-#: ../fheroes2/heroes/heroes_spell.cpp:468
-msgid "All the creatures will join us..."
-msgstr "Todas las criaturas se nos unirán..."
-
-#: ../fheroes2/heroes/heroes_spell.cpp:480
-msgid "These weak creatures will surely flee before us."
-msgstr "Esas débiles criaturas seguramente huirán nada más vernos."
-
-#: ../fheroes2/heroes/heroes_spell.cpp:489
 msgid ""
 "You must be within %{count} spaces of a monster for the Visions spell to "
 "work."
@@ -4827,7 +4698,18 @@ msgstr ""
 "Debes estar a %{count} casillas  de un monstruo para que el hechizo Visiones "
 "funcione."
 
-#: ../fheroes2/heroes/heroes_spell.cpp:506
+msgid "I fear these creatures are in the mood for a fight."
+msgstr "Me temo que esas criaturas tienen ganas de luchar."
+
+msgid "The creatures are willing to join us!"
+msgstr "¡Las criaturas quieren unirse a nosotros!"
+
+msgid "All the creatures will join us..."
+msgstr "Todas las criaturas se nos unirán..."
+
+msgid "These weak creatures will surely flee before us."
+msgstr "Esas débiles criaturas seguramente huirán nada más vernos."
+
 msgid ""
 "You must be standing on the entrance to a mine (sawmills and alchemists "
 "don't count) to cast this spell."
@@ -4835,400 +4717,317 @@ msgstr ""
 "Has de estar en la entrada de una mina para lanzar este hechizo (las "
 "serrerías y las casas de alquimia no cuentan)."
 
-#: ../fheroes2/heroes/skill.cpp:151
-msgid "Power"
-msgstr "Poder"
-
-#: ../fheroes2/heroes/skill.cpp:172
 msgid "Your attack skill is a bonus added to each creature's attack skill."
 msgstr ""
 "Tu habilidad de ataque es una bonificación añadida a cada habilidad de "
 "ataque de cada criatura."
 
-#: ../fheroes2/heroes/skill.cpp:177
 msgid "Your defense skill is a bonus added to each creature's defense skill."
 msgstr ""
 "Tu habilidad de defensa es un bonificación añadida a cada habilidad de "
 "defensa de cada criatura."
 
-#: ../fheroes2/heroes/skill.cpp:182
 msgid "Your spell power determines the length or power of a spell."
 msgstr ""
 "Tu Potencia de hechizo determina la longitud o el poder de los hechizos."
 
-#: ../fheroes2/heroes/skill.cpp:187
+#, fuzzy
 msgid ""
 "Your knowledge determines how many spell points your hero may have. Under "
-"normal cirumstances, a hero is limited to 10 spell points per level of "
+"normal circumstances, a hero is limited to 10 spell points per level of "
 "knowledge."
 msgstr ""
 "El conocimiento determina el número máximo de puntos de Maná que tu héroe "
 "puede alcanzar. Bajo circunstancias normales, un héroe está limitado a 10 "
 "puntos de Maná por nivel de conocimiento."
 
-#: ../fheroes2/heroes/skill.cpp:214
+msgid "Current Modifiers:"
+msgstr "Modificadores actuales:"
+
 msgid "skill|Basic"
 msgstr "habilidad|Básica"
 
-#: ../fheroes2/heroes/skill.cpp:214
 msgid "skill|Advanced"
 msgstr "habilidad|Avanzada"
 
-#: ../fheroes2/heroes/skill.cpp:214
 msgid "skill|Expert"
 msgstr "habilidad|Experta"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Pathfinding"
 msgstr "Orientación"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Archery"
 msgstr "Puntería"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Logistics"
 msgstr "Logística"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Scouting"
 msgstr "Exploración"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Diplomacy"
 msgstr "Diplomacia"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Navigation"
 msgstr "Navegación"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Leadership"
 msgstr "Liderazgo"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Wisdom"
 msgstr "Sabiduría"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Mysticism"
 msgstr "Misticismo"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Ballistics"
 msgstr "Balística"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Eagle Eye"
 msgstr "Ojo de Águila"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Necromancy"
 msgstr "Nigromancia"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Estates"
 msgstr "Patrimonio"
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Basic Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Advanced Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Expert Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Basic Archery"
 msgstr "Tiro con Arco Básico"
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Advanced Archery"
 msgstr "Tiro con Arco Avanzado"
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Expert Archery"
 msgstr "Tiro con Arco Experto"
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Basic Logistics"
 msgstr "Logística Básica"
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Advanced Logistics"
 msgstr "Logística Avanzada"
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Expert Logistics"
 msgstr "Logística Experta"
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Basic Scouting"
 msgstr "Exploración Básica"
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Advanced Scouting"
 msgstr "Exploración Avanzada"
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Expert Scouting"
 msgstr "Exploración Experta"
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Basic Diplomacy"
 msgstr "Diplomacia Básica"
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Advanced Diplomacy"
 msgstr "Diplomacia Avanzada"
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Expert Diplomacy"
 msgstr "Diplomacia Experta"
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Basic Navigation"
 msgstr "Navegación Básica"
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Advanced Navigation"
 msgstr "Navegación Avanzada"
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Expert Navigation"
 msgstr "Navegación Experta"
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Basic Leadership"
 msgstr "Liderazgo Básico"
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Advanced Leadership"
 msgstr "Liderazgo Avanzado"
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Expert Leadership"
 msgstr "Liderazgo Experto"
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Basic Wisdom"
 msgstr "Sabiduría Básica"
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Advanced Wisdom"
 msgstr "Sabiduría Avanzada"
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Expert Wisdom"
 msgstr "Sabiduría Experta"
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Basic Mysticism"
 msgstr "Misticismo Básico"
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Advanced Mysticism"
 msgstr "Misticismo Avanzado"
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Expert Mysticism"
 msgstr "Misticismo Experto"
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Basic Luck"
 msgstr "Suerte Básica"
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Advanced Luck"
 msgstr "Suerte Avanzada"
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Expert Luck"
 msgstr "Suerte Experta"
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Basic Ballistics"
 msgstr "Balística Básica"
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Advanced Ballistics"
 msgstr "Balística Avanzada"
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Expert Ballistics"
 msgstr "Balística Experta"
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Basic Eagle Eye"
 msgstr "Ojo de águila básico"
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Advanced Eagle Eye"
 msgstr "Ojo de águila avanzado"
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Expert Eagle Eye"
 msgstr "Ojo de águila experto"
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Basic Necromancy"
 msgstr "Necromancia Básica"
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Advanced Necromancy"
 msgstr "Necromancia Avanzada"
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Expert Necromancy"
 msgstr "Necromancia Experta"
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Basic Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Advanced Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Expert Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:406
-msgid "Allows you to negotiate with monsters who are weaker than your group."
+#, fuzzy
+msgid " allows you to negotiate with monsters who are weaker than your group."
 msgstr "Te permite negociar con monstruos que sean más débiles que tu grupo."
 
-#: ../fheroes2/heroes/skill.cpp:421
-msgid "Allows your hero to learn third level spells."
+#, fuzzy
+msgid "All of the creatures may offer to join you."
+msgstr "Todas las criaturas se nos unirán..."
+
+#, fuzzy
+msgid " allows your hero to learn third level spells."
 msgstr "Permite a tu héroe aprender hechizos de tercer nivel."
 
-#: ../fheroes2/heroes/skill.cpp:423
-msgid "Allows your hero to learn fourth level spells."
+#, fuzzy
+msgid " allows your hero to learn fourth level spells."
 msgstr "Permite a tu héroe aprender hechizos de cuarto nivel."
 
-#: ../fheroes2/heroes/skill.cpp:425
-msgid "Allows your hero to learn fifth level spells."
+#, fuzzy
+msgid " allows your hero to learn fifth level spells."
 msgstr "Permite a tu héroe aprender hechizos de quinto nivel."
 
-#: ../fheroes2/heroes/skill.cpp:440
+#, fuzzy
 msgid ""
-"Gives your hero's catapult shots a greater chance to hit and do damage to "
+" gives your hero's catapult shots a greater chance to hit and do damage to "
 "castle walls."
 msgstr ""
 "Le otorga a los disparos de las catapultas de tu héroe mayores "
 "probabilidades de dañar las murallas de los castillos."
 
-#: ../fheroes2/heroes/skill.cpp:442
+#, fuzzy
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot has a greater chance "
-"to hit and do damage to castle walls."
+" gives your hero's catapult an extra shot, and each shot has a greater "
+"chance to hit and do damage to castle walls."
 msgstr ""
 "Le otorga a la catapulta de tu héroe un disparo adicional y cada disparo "
 "tiene mayores opciones de golpear y dañar las murallas de los castillos."
 
-#: ../fheroes2/heroes/skill.cpp:444
+#, fuzzy
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot automatically "
+" gives your hero's catapult an extra shot, and each shot automatically "
 "destroys any wall, except a fortified wall in a Knight town."
 msgstr ""
+"Le otorga a la catapulta de tu héroe un disparo adicional y cada disparo "
+"tiene mayores opciones de golpear y dañar las murallas de los castillos."
 
-#: ../fheroes2/heroes/skill.cpp:858 ../fheroes2/heroes/skill.cpp:959
-msgid "View %{skill} Info"
-msgstr "Ver información de %{skill}"
-
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:108
 msgid "Blue"
 msgstr "Azul"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:111
 msgid "Green"
 msgstr "Verde"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:114
 msgid "Red"
 msgstr "Rojo"
 
-#: ../fheroes2/kingdom/color.cpp:32
 msgid "Yellow"
 msgstr "Amarillo"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:112
 msgid "Orange"
 msgstr "Naranja"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:113
 msgid "Purple"
 msgstr "Morado"
 
-#: ../fheroes2/kingdom/color.cpp:107
 msgid "Aqua"
 msgstr "Agua"
 
-#: ../fheroes2/kingdom/color.cpp:109
 msgid "Brown"
 msgstr "Marrón"
 
-#: ../fheroes2/kingdom/color.cpp:110 ../fheroes2/resource/resource.cpp:283
 msgid "Gold"
 msgstr "Oro"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:238
 msgid "Hero/Stats"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:241
 msgid "Skills"
 msgstr "Experiencia"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:244
 msgid "Artifacts"
 msgstr "Artefactos"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:473
 msgid "Town/Castle"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:476
 msgid "Garrison"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:566
 msgid "Gold Per Day:"
 msgstr "Oro por día:"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Cursed"
 msgstr "suerte|Maldito"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Awful"
 msgstr "suerte|Horrible"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Bad"
 msgstr "suerte|Malo"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Normal"
 msgstr "suerte|Normal"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Good"
 msgstr "suerte|bueno"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Great"
 msgstr "suerte|Grande"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Irish"
 msgstr "suerte|Irlandés"
 
-#: ../fheroes2/kingdom/luck.cpp:48
 msgid ""
 "Bad luck sometimes falls on your armies in combat, causing their attacks to "
 "only do half damage."
@@ -5236,7 +5035,6 @@ msgstr ""
 "La Mala suerte cae a veces en combate sobre tus tropas dividiendo por 2 el "
 "daño de sus ataques."
 
-#: ../fheroes2/kingdom/luck.cpp:49
 msgid ""
 "Neutral luck means your armies will never get lucky or unlucky attacks on "
 "the enemy."
@@ -5244,7 +5042,6 @@ msgstr ""
 "Con Suerte Neutral tus ejércitos nunca lograrán ataques afortunados o "
 "desafortunados."
 
-#: ../fheroes2/kingdom/luck.cpp:50
 msgid ""
 "Good luck sometimes lets your armies get lucky attacks (double strength) in "
 "combat."
@@ -5252,39 +5049,30 @@ msgstr ""
 "Con Buena Suerte a veces tus tropas consegirán ataques afortunados "
 "duplicando su daño."
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Treason"
 msgstr "moral|Traición"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Awful"
 msgstr "moral|Horrible"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Poor"
 msgstr "moral|Pobre"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Normal"
 msgstr "moral|Normal"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Good"
 msgstr "moral|Bueno"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Great"
 msgstr "moral|Grande"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Blood!"
 msgstr "moral|¡Sangre!"
 
-#: ../fheroes2/kingdom/morale.cpp:48
 msgid "Bad morale may cause your armies to freeze in combat."
 msgstr "Con Baja Moral tus tropas puede paralizarse en combate."
 
-#: ../fheroes2/kingdom/morale.cpp:49
 msgid ""
 "Neutral morale means your armies will never be blessed with extra attacks or "
 "freeze in combat."
@@ -5292,2076 +5080,1029 @@ msgstr ""
 "Con Moral Neutral tus tropas no serán bendecidas con ataques adicionales ni "
 "se petrificarán en combate."
 
-#: ../fheroes2/kingdom/morale.cpp:50
 msgid "Good morale may give your armies extra attacks in combat."
 msgstr "Con Moral Alta tus tropas podrán lograr ataques extra en combate."
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Knight"
 msgstr "Caballero"
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Barbarian"
 msgstr "Bárbaro"
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Sorceress"
 msgstr "Hechicera"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Warlock"
 msgstr "Brujo"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Wizard"
 msgstr "Mago"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Necromancer"
 msgstr "Nigromante"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Multi"
 msgstr "Multi"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Standing"
 msgstr "velocidad|Fijo"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Crawling"
 msgstr "velocidad|Arrastrando"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Very Slow"
 msgstr "velocidad|Muy lento"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Slow"
 msgstr "velocidad|Lento"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Average"
 msgstr "velocidad|Media"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Fast"
 msgstr "velocidad|Rápido"
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Very Fast"
 msgstr "velocidad|Muy rápido"
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Ultra Fast"
 msgstr "velocidad|Ultra rápido"
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Blazing"
 msgstr "velocidad|fugaz"
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Instant"
 msgstr "velocidad|Instantáneo"
 
-#: ../fheroes2/kingdom/week.cpp:32
 msgid "week|PLAGUE"
 msgstr "semana|PLAGA"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Ant"
 msgstr "semana|Hormiga"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Grasshopper"
 msgstr "semana|Saltamontes"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Dragonfly"
 msgstr "semana|Libélula"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Spider"
 msgstr "semana|Araña"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Butterfly"
 msgstr "semana|Mariposa"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Bumblebee"
 msgstr "semana|Abejorro"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Locust"
 msgstr "semana|Langosta"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Earthworm"
 msgstr "semana|Gusano"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Hornet"
 msgstr "semana|Avispa"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Beetle"
 msgstr "semana|Escarabajo"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Squirrel"
 msgstr "semana|Ardilla"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Rabbit"
 msgstr "semana|Conejo"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Gopher"
 msgstr "semana|Tuza"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Badger"
 msgstr "semana|Tejón"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Eagle"
 msgstr "semana|Águila"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Weasel"
 msgstr "semana|Comadreja"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Raven"
 msgstr "semana|Cuervo"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Mongoose"
 msgstr "semana|Mangosta"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Aardvark"
 msgstr "semana|Oso hormiguero"
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Lizard"
 msgstr "semana|Lagarto"
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Tortoise"
 msgstr "semana|Tortuga"
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Hedgehog"
 msgstr "semana|Puercoespín"
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Condor"
 msgstr "semana|Cóndor"
 
-#: ../fheroes2/kingdom/world_loadmap.cpp:1424
-#, fuzzy
-msgid "The ultimate artifact is really the %{name}"
-msgstr "¡La maldición de la Momia cae sobre %{name}!"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1428
-msgid "The ultimate artifact may be found in the %{name} regions of the world."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1433
-msgid "north-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1436
-#, fuzzy
-msgid "north"
-msgstr "Enroth"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1438
-msgid "north-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1444
-#, fuzzy
-msgid "west"
-msgstr "Nido"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1447
-#, fuzzy
-msgid "center"
-msgstr "Monstruo"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1449
-#, fuzzy
-msgid "east"
-msgstr "Nido"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1454
-msgid "south-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1457
-#, fuzzy
-msgid "south"
-msgstr "Ostoroth"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1459
-msgid "south-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1463
-msgid "The truth is out there."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1464
-msgid "The dark side is stronger."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1465
-#, fuzzy
-msgid "The end of the world is near."
-msgstr "El fin del mundo está cerca"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1466
-msgid "The bones of Lord Slayer are buried in the foundation of the arena."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1467
-msgid "A Black Dragon will take out a Titan any day of the week."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1468
-msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1470
-msgid ""
-"You can load the newest version of game from a site:\n"
-" http://sf.net/projects/fheroes2"
-msgstr ""
-"Puedes descargar la última versión del juego desde el sítio:\n"
-"http://sf.net/projects/fheroes2"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1471
-msgid "This game is now in beta development version. ;)"
-msgstr "Este juego está en fase Beta de desarrollo."
-
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Desert"
 msgstr "Desierto"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Snow"
 msgstr "Nieve"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Wasteland"
 msgstr "Paraje baldio"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Beach"
 msgstr "Playa"
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Lava"
 msgstr "Zona Volcánica"
 
-#: ../fheroes2/maps/ground.cpp:31 ../fheroes2/resource/maps_text.cpp:210
 msgid "Dirt"
 msgstr "Terreno arcilloso"
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Grass"
 msgstr "Pastos"
 
-#: ../fheroes2/maps/ground.cpp:31
-msgid "Water"
-msgstr "Agua"
+msgid "Ocean"
+msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Small"
 msgstr "mapas|Pequeño"
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Medium"
 msgstr "mapas|Mediano"
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Large"
 msgstr "mapas|Grande"
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Extra Large"
 msgstr "mapas|Extra grande"
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Custom Size"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:122
 msgid "Ore Mine"
 msgstr "MIna de Hierro."
 
-#: ../fheroes2/maps/maps.cpp:123
 msgid "Sulfur Mine"
 msgstr "Mina de Azufre."
 
-#: ../fheroes2/maps/maps.cpp:124
 msgid "Crystal Mine"
 msgstr "Mina de Cristal."
 
-#: ../fheroes2/maps/maps.cpp:125
 msgid "Gems Mine"
 msgstr "MIna de Gemas."
 
-#: ../fheroes2/maps/maps.cpp:126
 msgid "Gold Mine"
 msgstr "MIna de Oro."
 
-#: ../fheroes2/maps/maps.cpp:130
 msgid "Mine"
 msgstr "Mina"
 
-#: ../fheroes2/maps/mp2.cpp:365
 msgid "Alchemist Lab"
 msgstr "Alquimista"
 
-#: ../fheroes2/maps/mp2.cpp:367
 msgid "Daemon Cave"
 msgstr "Cueva del Demonio"
 
-#: ../fheroes2/maps/mp2.cpp:369
 msgid "Faerie Ring"
 msgstr "Anillo del Hada"
 
-#: ../fheroes2/maps/mp2.cpp:373 ../fheroes2/resource/maps_text.cpp:217
 msgid "Dragon City"
 msgstr "Ciudad Dragón"
 
-#: ../fheroes2/maps/mp2.cpp:375
-msgid "Light House"
+#, fuzzy
+msgid "Lighthouse"
 msgstr "Faro"
 
-#: ../fheroes2/maps/mp2.cpp:377
 msgid "Water Wheel"
 msgstr "Molino de Agua"
 
-#: ../fheroes2/maps/mp2.cpp:379
 msgid "Mines"
 msgstr "Minas"
 
-#: ../fheroes2/maps/mp2.cpp:381
 msgid "Obelisk"
 msgstr "Obelisco"
 
-#: ../fheroes2/maps/mp2.cpp:383
 msgid "Oasis"
 msgstr "Oasis"
 
-#: ../fheroes2/maps/mp2.cpp:385
 msgid "Sawmill"
 msgstr "Aserradero"
 
-#: ../fheroes2/maps/mp2.cpp:387
 msgid "Oracle"
 msgstr "Oráculo"
 
-#: ../fheroes2/maps/mp2.cpp:389
 msgid "Desert Tent"
 msgstr "Tienda del Desierto"
 
-#: ../fheroes2/maps/mp2.cpp:393
 msgid "Wagon Camp"
 msgstr "Carromato"
 
-#: ../fheroes2/maps/mp2.cpp:395
 msgid "Windmill"
 msgstr "Molino de Viento"
 
-#: ../fheroes2/maps/mp2.cpp:397
 msgid "Random Town"
 msgstr "Cualquier torre"
 
-#: ../fheroes2/maps/mp2.cpp:399
 msgid "Random Castle"
 msgstr "Cualquier castillo"
 
-#: ../fheroes2/maps/mp2.cpp:401
 msgid "Watch Tower"
 msgstr "Torre de Vigilancia"
 
-#: ../fheroes2/maps/mp2.cpp:403
 msgid "Tree City"
 msgstr "Ciudad del Árbol"
 
-#: ../fheroes2/maps/mp2.cpp:405
 msgid "Tree House"
 msgstr "Casa de Árbol"
 
-#: ../fheroes2/maps/mp2.cpp:407
 msgid "Ruins"
 msgstr "Ruinas"
 
-#: ../fheroes2/maps/mp2.cpp:409
 msgid "Fort"
 msgstr "Fortaleza"
 
-#: ../fheroes2/maps/mp2.cpp:411
-msgid "Trading Post"
-msgstr "Mercadillo"
-
-#: ../fheroes2/maps/mp2.cpp:413
 msgid "Abandoned Mine"
 msgstr "Mina Abandonada"
 
-#: ../fheroes2/maps/mp2.cpp:415
 msgid "Tree of Knowledge"
 msgstr "Árbol del conocimiento"
 
-#: ../fheroes2/maps/mp2.cpp:417
 msgid "Witch Doctor's Hut"
 msgstr "Cabaña de la Bruja"
 
-#: ../fheroes2/maps/mp2.cpp:419
 msgid "Temple"
 msgstr "Templo"
 
-#: ../fheroes2/maps/mp2.cpp:421
 msgid "Hill Fort"
 msgstr "Fuerte de la Colina"
 
-#: ../fheroes2/maps/mp2.cpp:423
 msgid "Halfling Hole"
 msgstr "Hoyo de los Medianos"
 
-#: ../fheroes2/maps/mp2.cpp:425
 msgid "Mercenary Camp"
 msgstr "Campamento Mercenario"
 
-#: ../fheroes2/maps/mp2.cpp:429
 msgid "City of the Dead"
 msgstr "Ciudad de la muerte"
 
-#: ../fheroes2/maps/mp2.cpp:433
 msgid "Sphinx"
 msgstr "Esfinge"
 
-#: ../fheroes2/maps/mp2.cpp:435
 msgid "Troll Bridge"
 msgstr "Puente de los Trolls"
 
-#: ../fheroes2/maps/mp2.cpp:437
 msgid "Witch Hut"
 msgstr "Choza de brujas"
 
-#: ../fheroes2/maps/mp2.cpp:439
 msgid "Xanadu"
 msgstr "Xanadu"
 
-#: ../fheroes2/maps/mp2.cpp:443
 msgid "Magellan Maps"
 msgstr "Mapas de Magallanes"
 
-#: ../fheroes2/maps/mp2.cpp:445
 msgid "Derelict Ship"
 msgstr "Barco Abandonado"
 
-#: ../fheroes2/maps/mp2.cpp:447
-msgid "Ship Wreck"
-msgstr "Naufragio"
+#, fuzzy
+msgid "Shipwreck"
+msgstr "¡Naufragio!"
 
-#: ../fheroes2/maps/mp2.cpp:449
 msgid "Observation Tower"
 msgstr "Torre de observación"
 
-#: ../fheroes2/maps/mp2.cpp:451
-msgid "Freeman Foundry"
+#, fuzzy
+msgid "Freeman's Foundry"
 msgstr "Fundición"
 
-#: ../fheroes2/maps/mp2.cpp:453
 msgid "Watering Hole"
 msgstr "Gotera."
 
-#: ../fheroes2/maps/mp2.cpp:455
 msgid "Artesian Spring"
 msgstr "Pozo Artesiano"
 
-#: ../fheroes2/maps/mp2.cpp:457
 msgid "Gazebo"
 msgstr "Cenador"
 
-#: ../fheroes2/maps/mp2.cpp:459
 msgid "Archer's House"
 msgstr "Casa del Arquero"
 
-#: ../fheroes2/maps/mp2.cpp:461
 msgid "Peasant Hut"
 msgstr "Cabaña de Campesinos"
 
-#: ../fheroes2/maps/mp2.cpp:463
 msgid "Dwarf Cottage"
 msgstr "Casita de Enanos"
 
-#: ../fheroes2/maps/mp2.cpp:465
 msgid "Stone Liths"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:467
 msgid "Magic Well"
 msgstr "Pozo Mágico"
 
-#: ../fheroes2/maps/mp2.cpp:468
 msgid "Heroes"
 msgstr "Héroes"
 
-#: ../fheroes2/maps/mp2.cpp:470 ../fheroes2/maps/mp2.cpp:488
-msgid "Shrub"
-msgstr "Arbusto"
-
-#: ../fheroes2/maps/mp2.cpp:471
 msgid "Nothing Special"
 msgstr "Nada especial"
 
-#: ../fheroes2/maps/mp2.cpp:472
 msgid "Tar Pit"
 msgstr "Fosa de Alquitrán"
 
-#: ../fheroes2/maps/mp2.cpp:473
-msgid "Coast"
-msgstr "Costa"
-
-#: ../fheroes2/maps/mp2.cpp:474
 msgid "Mound"
 msgstr "Montón"
 
-#: ../fheroes2/maps/mp2.cpp:475
 msgid "Dune"
 msgstr "Duna"
 
-#: ../fheroes2/maps/mp2.cpp:476
 msgid "Stump"
 msgstr "Cepa"
 
-#: ../fheroes2/maps/mp2.cpp:477
 msgid "Cactus"
 msgstr "Cactus"
 
-#: ../fheroes2/maps/mp2.cpp:478
 msgid "Trees"
 msgstr "Árboles"
 
-#: ../fheroes2/maps/mp2.cpp:479
 msgid "Dead Tree"
 msgstr "Árbol muerto"
 
-#: ../fheroes2/maps/mp2.cpp:480
 msgid "Mountains"
 msgstr "Montañas"
 
-#: ../fheroes2/maps/mp2.cpp:481
 msgid "Volcano"
 msgstr "Volcán"
 
-#: ../fheroes2/maps/mp2.cpp:482
 msgid "Rock"
 msgstr "Roca"
 
-#: ../fheroes2/maps/mp2.cpp:483
 msgid "Flowers"
 msgstr "Flores"
 
-#: ../fheroes2/maps/mp2.cpp:484
 msgid "Water Lake"
 msgstr "Lago"
 
-#: ../fheroes2/maps/mp2.cpp:485
 msgid "Mandrake"
 msgstr "Mandrágora"
 
-#: ../fheroes2/maps/mp2.cpp:486
 msgid "Crater"
 msgstr "Cráter"
 
-#: ../fheroes2/maps/mp2.cpp:487
 msgid "Lava Pool"
 msgstr "Charca de Lava"
 
-#: ../fheroes2/maps/mp2.cpp:489
+msgid "Shrub"
+msgstr "Arbusto"
+
 msgid "Buoy"
 msgstr "Boya"
 
-#: ../fheroes2/maps/mp2.cpp:491 ../fheroes2/monster/monster.cpp:116
 #, fuzzy
 msgid "Skeleton"
 msgstr "Esqueleto"
 
-#: ../fheroes2/maps/mp2.cpp:492
 msgid "Treasure Chest"
 msgstr "Cofre del Tesoro"
 
-#: ../fheroes2/maps/mp2.cpp:493
 msgid "Sea Chest"
 msgstr "Cofre Marino"
 
-#: ../fheroes2/maps/mp2.cpp:494
 msgid "Campfire"
 msgstr "Hoguera"
 
-#: ../fheroes2/maps/mp2.cpp:495
 msgid "Fountain"
 msgstr "Fuente"
 
-#: ../fheroes2/maps/mp2.cpp:496
 msgid "Genie Lamp"
 msgstr "Lampara del Genio"
 
-#: ../fheroes2/maps/mp2.cpp:497
 msgid "Goblin Hut"
 msgstr "Palloza"
 
-#: ../fheroes2/maps/mp2.cpp:499
 msgid "Monster"
 msgstr "Monstruo"
 
-#: ../fheroes2/maps/mp2.cpp:500
 msgid "Resource"
 msgstr "Recursos"
 
-#: ../fheroes2/maps/mp2.cpp:501
 msgid "Whirlpool"
 msgstr "Remolino"
 
-#: ../fheroes2/maps/mp2.cpp:502
 msgid "Artifact"
 msgstr "Artefacto"
 
-#: ../fheroes2/maps/mp2.cpp:503
 msgid "Boat"
 msgstr "Bote"
 
-#: ../fheroes2/maps/mp2.cpp:510
 msgid "Standing Stones"
 msgstr "Círculo Lítico"
 
-#: ../fheroes2/maps/mp2.cpp:514
 msgid "Idol"
 msgstr "Ídolo"
 
-#: ../fheroes2/maps/mp2.cpp:515
 msgid "Shrine of the First Circle"
 msgstr "Capilla del Primer Círculo"
 
-#: ../fheroes2/maps/mp2.cpp:516
 msgid "Shrine of the Second Circle"
 msgstr "Capilla del Segundo Círculo"
 
-#: ../fheroes2/maps/mp2.cpp:517
 msgid "Shrine of the Third Circle"
 msgstr "Capilla del Tercer Círculo"
 
-#: ../fheroes2/maps/mp2.cpp:518
 msgid "Wagon"
 msgstr "Vagón"
 
-#: ../fheroes2/maps/mp2.cpp:519
 msgid "Lean To"
 msgstr "Apoyar"
 
-#: ../fheroes2/maps/mp2.cpp:520
 msgid "Flotsam"
 msgstr "Restos de un naufragio"
 
-#: ../fheroes2/maps/mp2.cpp:521
 msgid "Shipwreck Survivor"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:522
 msgid "Bottle"
 msgstr "Botella"
 
-#: ../fheroes2/maps/mp2.cpp:523
 msgid "Magic Garden"
 msgstr "Jardín mágico"
 
-#: ../fheroes2/maps/mp2.cpp:529
 msgid "Jail"
 msgstr "Cárcel"
 
-#: ../fheroes2/maps/mp2.cpp:531
 msgid "Traveller's Tent"
 msgstr "Tienda del Viajero"
 
-#: ../fheroes2/maps/mp2.cpp:532
 msgid "Barrier"
 msgstr "Barrera"
 
-#: ../fheroes2/maps/mp2.cpp:535
 msgid "Fire Summoning Altar"
 msgstr "Altar del Fuego"
 
-#: ../fheroes2/maps/mp2.cpp:537
 msgid "Air Summoning Altar"
 msgstr "Altar del Aire"
 
-#: ../fheroes2/maps/mp2.cpp:539
 msgid "Earth Summoning Altar"
 msgstr "Altar de la Tierra"
 
-#: ../fheroes2/maps/mp2.cpp:541
 msgid "Water Summoning Altar"
 msgstr "Altar del Agua"
 
-#: ../fheroes2/maps/mp2.cpp:543
 msgid "Barrow Mounds"
 msgstr "Montículo de la Carretilla"
 
-#: ../fheroes2/maps/mp2.cpp:545
-msgid "Arena"
-msgstr "Arena"
-
-#: ../fheroes2/maps/mp2.cpp:547
 msgid "Stables"
 msgstr "Establos"
 
-#: ../fheroes2/maps/mp2.cpp:549
 msgid "Alchemist's Tower"
 msgstr "Torre del Alquimista."
 
-#: ../fheroes2/maps/mp2.cpp:551
 msgid "Hut of the Magi"
 msgstr "Cabaña del los Magos"
 
-#: ../fheroes2/maps/mp2.cpp:553
 msgid "Eye of the Magi"
 msgstr "Ojo de los Magos"
 
-#: ../fheroes2/maps/mp2.cpp:555
 msgid "Mermaid"
 msgstr "Sirena"
 
-#: ../fheroes2/maps/mp2.cpp:557
 msgid "Sirens"
 msgstr "Sirenas"
 
-#: ../fheroes2/maps/mp2.cpp:558
 msgid "Reefs"
 msgstr "Arrecifes"
 
-#: ../fheroes2/monster/monster.cpp:59
-#, fuzzy
-msgid "Peasant"
-msgstr "Campesino"
-
-#: ../fheroes2/monster/monster.cpp:59 ../fheroes2/resource/maps_text.cpp:501
-msgid "Peasants"
-msgstr "Campesinos"
-
-#: ../fheroes2/monster/monster.cpp:60
-#, fuzzy
-msgid "Archer"
-msgstr "Arquero"
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Archers"
-msgstr "Arqueros"
-
-#: ../fheroes2/monster/monster.cpp:61
-#, fuzzy
-msgid "Ranger"
-msgstr "Montaraz"
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Rangers"
-msgstr "Arqueros Expertos"
-
-#: ../fheroes2/monster/monster.cpp:62
-#, fuzzy
-msgid "Pikeman"
-msgstr "Piquero"
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Pikemen"
-msgstr "Piqueros"
-
-#: ../fheroes2/monster/monster.cpp:63
-#, fuzzy
-msgid "Veteran Pikeman"
-msgstr "Piquero veterano"
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Veteran Pikemen"
-msgstr "Alabarderos"
-
-#: ../fheroes2/monster/monster.cpp:64
-#, fuzzy
-msgid "Swordsman"
-msgstr "Espadachín"
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Swordsmen"
-msgstr "Espadachín"
-
-#: ../fheroes2/monster/monster.cpp:65
-#, fuzzy
-msgid "Master Swordsman"
-msgstr "Maestro Espadachín"
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Master Swordsmen"
-msgstr "Maestros Espadachines"
-
-#: ../fheroes2/monster/monster.cpp:66
-#, fuzzy
-msgid "Cavalry"
-msgstr "Caballería"
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Cavalries"
-msgstr "Caballerías"
-
-#: ../fheroes2/monster/monster.cpp:67
-#, fuzzy
-msgid "Champion"
-msgstr "Campeón"
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Champions"
-msgstr "Caballeros"
-
-#: ../fheroes2/monster/monster.cpp:68
-#, fuzzy
-msgid "Paladin"
-msgstr "Paladín"
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Paladins"
-msgstr "Paladines"
-
-#: ../fheroes2/monster/monster.cpp:69
-#, fuzzy
-msgid "Crusader"
-msgstr "Cruzado"
-
-#: ../fheroes2/monster/monster.cpp:69
-msgid "Crusaders"
-msgstr "Cruzados"
-
-#: ../fheroes2/monster/monster.cpp:72
-#, fuzzy
-msgid "Goblin"
-msgstr "Trasgo"
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Goblins"
-msgstr "Trasgos"
-
-#: ../fheroes2/monster/monster.cpp:73
-#, fuzzy
-msgid "Orc"
-msgstr "Orco"
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orcs"
-msgstr "Orcos"
-
-#: ../fheroes2/monster/monster.cpp:74
-#, fuzzy
-msgid "Orc Chief"
-msgstr "Jefe Orco"
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chiefs"
-msgstr "Jefes Orcos"
-
-#: ../fheroes2/monster/monster.cpp:75
-#, fuzzy
-msgid "Wolf"
-msgstr "Lobo"
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Wolves"
-msgstr "Lobos"
-
-#: ../fheroes2/monster/monster.cpp:76
-#, fuzzy
-msgid "Ogre"
-msgstr "Ogro"
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogres"
-msgstr "Ogros"
-
-#: ../fheroes2/monster/monster.cpp:77
-#, fuzzy
-msgid "Ogre Lord"
-msgstr "Ogro de Combate"
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Ogre Lords"
-msgstr "Ogros de Combate"
-
-#: ../fheroes2/monster/monster.cpp:78
-#, fuzzy
-msgid "Troll"
-msgstr "Troll"
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "Trolls"
-msgstr "Trolls"
-
-#: ../fheroes2/monster/monster.cpp:79
-#, fuzzy
-msgid "War Troll"
-msgstr "Trol de Guerra"
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "War Trolls"
-msgstr "Troll de Guerra"
-
-#: ../fheroes2/monster/monster.cpp:80
-#, fuzzy
-msgid "Cyclops"
-msgstr "Cíclope"
-
-#: ../fheroes2/monster/monster.cpp:80
-msgid "Cyclopes"
-msgstr "Cíclopes"
-
-#: ../fheroes2/monster/monster.cpp:83
-#, fuzzy
-msgid "Sprite"
-msgstr "Hada"
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Sprites"
-msgstr "Hadas"
-
-#: ../fheroes2/monster/monster.cpp:84
-#, fuzzy
-msgid "Dwarf"
-msgstr "Enano"
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Dwarves"
-msgstr "Enanos"
-
-#: ../fheroes2/monster/monster.cpp:85
-#, fuzzy
-msgid "Battle Dwarf"
-msgstr "Enano de Combate"
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Battle Dwarves"
-msgstr "Enanos de Combate"
-
-#: ../fheroes2/monster/monster.cpp:86
-#, fuzzy
-msgid "Elf"
-msgstr "Elfo"
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elves"
-msgstr "Elfos"
-
-#: ../fheroes2/monster/monster.cpp:87
-#, fuzzy
-msgid "Grand Elf"
-msgstr "Gran Elfo"
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elves"
-msgstr "Grandes Elfos"
-
-#: ../fheroes2/monster/monster.cpp:88
-#, fuzzy
-msgid "Druid"
-msgstr "Druida"
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druids"
-msgstr "Druidas"
-
-#: ../fheroes2/monster/monster.cpp:89
-#, fuzzy
-msgid "Greater Druid"
-msgstr "Gran Druida"
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druids"
-msgstr "Grandes Druidas"
-
-#: ../fheroes2/monster/monster.cpp:90
-#, fuzzy
-msgid "Unicorn"
-msgstr "Unicornio"
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorns"
-msgstr "Unicornios"
-
-#: ../fheroes2/monster/monster.cpp:91
-#, fuzzy
-msgid "Phoenix"
-msgstr "Fénix"
-
-#: ../fheroes2/monster/monster.cpp:91
-#, fuzzy
-msgid "Phoenixes"
-msgstr "Fénix"
-
-#: ../fheroes2/monster/monster.cpp:94
-#, fuzzy
-msgid "Centaur"
-msgstr "Centauro"
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaurs"
-msgstr "Centauros"
-
-#: ../fheroes2/monster/monster.cpp:95
-#, fuzzy
-msgid "Gargoyle"
-msgstr "Gárgola"
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyles"
-msgstr "Gárgolas"
-
-#: ../fheroes2/monster/monster.cpp:96
-#, fuzzy
-msgid "Griffin"
-msgstr "Grifo"
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffins"
-msgstr "Grifos"
-
-#: ../fheroes2/monster/monster.cpp:97
-#, fuzzy
-msgid "Minotaur"
-msgstr "Minotauro"
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaurs"
-msgstr "Minotauros"
-
-#: ../fheroes2/monster/monster.cpp:98
-#, fuzzy
-msgid "Minotaur King"
-msgstr "Minotauro Rey"
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur Kings"
-msgstr "Minotauros Reyes"
-
-#: ../fheroes2/monster/monster.cpp:99
-#, fuzzy
-msgid "Hydra"
-msgstr "Hidra"
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydras"
-msgstr "Hidras"
-
-#: ../fheroes2/monster/monster.cpp:100
-#, fuzzy
-msgid "Green Dragon"
-msgstr "Dragón Verde"
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragons"
-msgstr "Dragones Verdes"
-
-#: ../fheroes2/monster/monster.cpp:101
-#, fuzzy
-msgid "Red Dragon"
-msgstr "Dragón rojo"
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragons"
-msgstr "Dragones Rojos"
-
-#: ../fheroes2/monster/monster.cpp:102
-#, fuzzy
-msgid "Black Dragon"
-msgstr "Dragón Negro"
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragons"
-msgstr "Dragones Negros"
-
-#: ../fheroes2/monster/monster.cpp:105
-#, fuzzy
-msgid "Halfling"
-msgstr "Mediano"
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halflings"
-msgstr "Medianos"
-
-#: ../fheroes2/monster/monster.cpp:106
-#, fuzzy
-msgid "Boar"
-msgstr "Jabalí"
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boars"
-msgstr "Jabalíes"
-
-#: ../fheroes2/monster/monster.cpp:107
-#, fuzzy
-msgid "Iron Golem"
-msgstr "Golem de Hierro"
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golems"
-msgstr "Golems de Hierro"
-
-#: ../fheroes2/monster/monster.cpp:108
-#, fuzzy
-msgid "Steel Golem"
-msgstr "Golem de Acero"
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golems"
-msgstr "Golems de Acero"
-
-#: ../fheroes2/monster/monster.cpp:109
-#, fuzzy
-msgid "Roc"
-msgstr "Roc"
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Rocs"
-msgstr "Rocs"
-
-#: ../fheroes2/monster/monster.cpp:110
-#, fuzzy
-msgid "Mage"
-msgstr "Mago"
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Magi"
-msgstr "Magos"
-
-#: ../fheroes2/monster/monster.cpp:111
-#, fuzzy
-msgid "Archmage"
-msgstr "Archimago"
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmagi"
-msgstr "Archimagos"
-
-#: ../fheroes2/monster/monster.cpp:112
-#, fuzzy
-msgid "Giant"
-msgstr "Gigante"
-
-#: ../fheroes2/monster/monster.cpp:112 ../fheroes2/resource/maps_text.cpp:293
-msgid "Giants"
-msgstr "Gigantes"
-
-#: ../fheroes2/monster/monster.cpp:113
-#, fuzzy
-msgid "Titan"
-msgstr "Titán"
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titans"
-msgstr "Titanes"
-
-#: ../fheroes2/monster/monster.cpp:116
-msgid "Skeletons"
-msgstr "Esqueletos"
-
-#: ../fheroes2/monster/monster.cpp:117
-#, fuzzy
-msgid "Zombie"
-msgstr "Zombi"
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombies"
-msgstr "Zombis"
-
-#: ../fheroes2/monster/monster.cpp:118
-#, fuzzy
-msgid "Mutant Zombie"
-msgstr "Zombi Mutante"
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombies"
-msgstr "Zombis Mutantes"
-
-#: ../fheroes2/monster/monster.cpp:119
-#, fuzzy
-msgid "Mummy"
-msgstr "Momia"
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummies"
-msgstr "Momia"
-
-#: ../fheroes2/monster/monster.cpp:120
-#, fuzzy
-msgid "Royal Mummy"
-msgstr "Momia Real"
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummies"
-msgstr "Momias Reales"
-
-#: ../fheroes2/monster/monster.cpp:121
-#, fuzzy
-msgid "Vampire"
-msgstr "Vampiro"
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampires"
-msgstr "Vampiros"
-
-#: ../fheroes2/monster/monster.cpp:122
-#, fuzzy
-msgid "Vampire Lord"
-msgstr "Maestro Vampiro"
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lords"
-msgstr "Maestros Vampiros"
-
-#: ../fheroes2/monster/monster.cpp:123
-#, fuzzy
-msgid "Lich"
-msgstr "Liche"
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Liches"
-msgstr "Liches"
-
-#: ../fheroes2/monster/monster.cpp:124
-#, fuzzy
-msgid "Power Lich"
-msgstr "Gran Liche"
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Liches"
-msgstr "Grandes Liches"
-
-#: ../fheroes2/monster/monster.cpp:125
-#, fuzzy
-msgid "Bone Dragon"
-msgstr "Dragón de Hueso"
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragons"
-msgstr "Dragones de Hueso"
-
-#: ../fheroes2/monster/monster.cpp:128
-#, fuzzy
-msgid "Rogue"
-msgstr "Bandido"
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogues"
-msgstr "Bandidos"
-
-#: ../fheroes2/monster/monster.cpp:129
-#, fuzzy
-msgid "Nomad"
-msgstr "Nómada"
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomads"
-msgstr "Nómadas"
-
-#: ../fheroes2/monster/monster.cpp:130
-#, fuzzy
-msgid "Ghost"
-msgstr "Fantasma"
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghosts"
-msgstr "Fantasmas"
-
-#: ../fheroes2/monster/monster.cpp:131
-#, fuzzy
-msgid "Genie"
-msgstr "Genio"
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genies"
-msgstr "Genios"
-
-#: ../fheroes2/monster/monster.cpp:132
-#, fuzzy
-msgid "Medusa"
-msgstr "Medusa"
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusas"
-msgstr "Medusa"
-
-#: ../fheroes2/monster/monster.cpp:133
-#, fuzzy
-msgid "Earth Elemental"
-msgstr "Elemental de la Tierra"
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elementals"
-msgstr "Elementales de la Tierra"
-
-#: ../fheroes2/monster/monster.cpp:134
-#, fuzzy
-msgid "Air Elemental"
-msgstr "Elemental del Aire"
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elementals"
-msgstr "Elementales del Aire"
-
-#: ../fheroes2/monster/monster.cpp:135
-#, fuzzy
-msgid "Fire Elemental"
-msgstr "Elemental del Fuego"
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elementals"
-msgstr "Elementales del Fuego"
-
-#: ../fheroes2/monster/monster.cpp:136
-#, fuzzy
-msgid "Water Elemental"
-msgstr "Elemental del Agua"
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elementals"
-msgstr "Elementales del Agua"
-
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:694
-msgid "buy"
-msgstr "comprar"
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:158
-msgid "Campaign Game"
-msgstr "Partida de Campaña."
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "Error"
-msgstr "Error"
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "This release is compiled without network support."
-msgstr "Esta versión está compilada sin soporte para red."
-
-#: ../fheroes2/resource/artifact.cpp:51
 msgid "Ultimate Book of Knowledge"
 msgstr "Libro Definitivo del Conocimiento"
 
-#: ../fheroes2/resource/artifact.cpp:51 ../fheroes2/resource/artifact.cpp:77
-#: ../fheroes2/resource/artifact.cpp:78 ../fheroes2/resource/artifact.cpp:79
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "The %{name} increases your knowledge by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:52
 msgid "Ultimate Sword of Dominion"
 msgstr "Espada Final de la Dominación"
 
-#: ../fheroes2/resource/artifact.cpp:52 ../fheroes2/resource/artifact.cpp:68
-#: ../fheroes2/resource/artifact.cpp:71 ../fheroes2/resource/artifact.cpp:74
-#: ../fheroes2/resource/artifact.cpp:75 ../fheroes2/resource/artifact.cpp:149
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "The %{name} increases your attack skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:53
 msgid "Ultimate Cloak of Protection"
 msgstr "Capa Final de la Protección"
 
-#: ../fheroes2/resource/artifact.cpp:53 ../fheroes2/resource/artifact.cpp:70
-#: ../fheroes2/resource/artifact.cpp:73 ../fheroes2/resource/artifact.cpp:76
 msgid "The %{name} increases your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:54
 msgid "Ultimate Wand of Magic"
 msgstr "Varíta Final de la Magia"
 
-#: ../fheroes2/resource/artifact.cpp:54 ../fheroes2/resource/artifact.cpp:59
-#: ../fheroes2/resource/artifact.cpp:60 ../fheroes2/resource/artifact.cpp:61
-#: ../fheroes2/resource/artifact.cpp:62 ../fheroes2/resource/artifact.cpp:148
 msgid "The %{name} increases your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:55
 msgid "Ultimate Shield"
 msgstr "El Escudo Supremo"
 
-#: ../fheroes2/resource/artifact.cpp:55 ../fheroes2/resource/artifact.cpp:128
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "The %{name} increases your attack and defense skills by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:56
 msgid "Ultimate Staff"
 msgstr "El Cayado Supremo"
 
-#: ../fheroes2/resource/artifact.cpp:56 ../fheroes2/resource/artifact.cpp:130
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "The %{name} increases your spell power and knowledge by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "Ultimate Crown"
 msgstr "La Corona Suprema"
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "The %{name} increases each of your basic skills by %{count} points."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "Golden Goose"
 msgstr "Ganso Dorado"
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "The %{name} brings in an income of %{count} gold per turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:59
 msgid "Arcane Necklace of Magic"
 msgstr "Collar Arcano de la Magia"
 
-#: ../fheroes2/resource/artifact.cpp:60
 msgid "Caster's Bracelet of Magic"
 msgstr "Brazalete del Lanzador de la Magia"
 
-#: ../fheroes2/resource/artifact.cpp:61
 msgid "Mage's Ring of Power"
 msgstr "Anillo del Mago del Poder"
 
-#: ../fheroes2/resource/artifact.cpp:62
 msgid "Witch's Broach of Magic"
 msgstr "Broche de Bruja de la Magia"
 
-#: ../fheroes2/resource/artifact.cpp:63
 msgid "Medal of Valor"
 msgstr "La Medalla de Valor"
 
-#: ../fheroes2/resource/artifact.cpp:63 ../fheroes2/resource/artifact.cpp:64
-#: ../fheroes2/resource/artifact.cpp:65 ../fheroes2/resource/artifact.cpp:66
 msgid "The %{name} increases your morale."
 msgstr "El %{nombre} incrementa tu moral."
 
-#: ../fheroes2/resource/artifact.cpp:64
 msgid "Medal of Courage"
 msgstr "La Medalla de Coraje"
 
-#: ../fheroes2/resource/artifact.cpp:65
 msgid "Medal of Honor"
 msgstr "La Medalla de Honor."
 
-#: ../fheroes2/resource/artifact.cpp:66
 msgid "Medal of Distinction"
 msgstr "La Medalla de Distinción."
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "Fizbin of Misfortune"
 msgstr "El Fizbin de la Mala Suerte"
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "The %{name} greatly decreases your morale by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:68
 msgid "Thunder Mace of Dominion"
 msgstr "Maza del Trueno de Dominio"
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "Armored Gauntlets of Protection"
 msgstr "Guanteletes Blindados de Protección"
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "The %{name} increase your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:70
 msgid "Defender Helm of Protection"
 msgstr "Timón Defensor de la Protección"
 
-#: ../fheroes2/resource/artifact.cpp:71
 msgid "Giant Flail of Dominion"
 msgstr "Mayal Gigante de la Dominación"
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "Ballista of Quickness"
 msgstr "Ballesta de Rapidez"
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "The %{name} lets your catapult fire twice per combat round."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:73
 msgid "Stealth Shield of Protection"
 msgstr "Escudo Sigiloso de la Protección"
 
-#: ../fheroes2/resource/artifact.cpp:74
 msgid "Dragon Sword of Dominion"
 msgstr "Espada Dragón de la Dominación"
 
-#: ../fheroes2/resource/artifact.cpp:75
 msgid "Power Axe of Dominion"
 msgstr "Hacha Poderosa de la Dominación"
 
-#: ../fheroes2/resource/artifact.cpp:76
 msgid "Divine Breastplate of Protection"
 msgstr "Coraza  Divina de Protección"
 
-#: ../fheroes2/resource/artifact.cpp:77
 msgid "Minor Scroll of Knowledge"
 msgstr "Pergamino Menor de Conocimiento"
 
-#: ../fheroes2/resource/artifact.cpp:78
 msgid "Major Scroll of Knowledge"
 msgstr "Rollo Mayor del Conocimiento"
 
-#: ../fheroes2/resource/artifact.cpp:79
 msgid "Superior Scroll of Knowledge"
 msgstr "Rollo Superior del Conocimiento"
 
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "Foremost Scroll of Knowledge"
 msgstr "Principal Pergamino de Conocimiento"
 
-#: ../fheroes2/resource/artifact.cpp:81
 msgid "Endless Sack of Gold"
 msgstr "La Saca inagotable de Oro."
 
-#: ../fheroes2/resource/artifact.cpp:81 ../fheroes2/resource/artifact.cpp:82
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "The %{name} provides you with %{count} gold per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:82
 msgid "Endless Bag of Gold"
 msgstr "La Bolsa inagotable de Oro."
 
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "Endless Purse of Gold"
 msgstr "La Cartera inagotable de Oro."
 
-#: ../fheroes2/resource/artifact.cpp:84
 msgid "Nomad Boots of Mobility"
 msgstr "Las Botas Nómadas de la Movilidad"
 
-#: ../fheroes2/resource/artifact.cpp:84 ../fheroes2/resource/artifact.cpp:85
 msgid "The %{name} increase your movement on land."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:85
 msgid "Traveler's Boots of Mobility"
 msgstr "Botas de Viajero de la Movilidad"
 
-#: ../fheroes2/resource/artifact.cpp:86
 msgid "Lucky Rabbit's Foot"
 msgstr "Pata de Conejo de la Suerte"
 
-#: ../fheroes2/resource/artifact.cpp:86 ../fheroes2/resource/artifact.cpp:87
-#: ../fheroes2/resource/artifact.cpp:88 ../fheroes2/resource/artifact.cpp:89
 msgid "The %{name} increases your luck in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:87
 msgid "Golden Horseshoe"
 msgstr "La Herradura Dorada."
 
-#: ../fheroes2/resource/artifact.cpp:88
 msgid "Gambler's Lucky Coin"
 msgstr "Moneda de la Suerte del Jugador"
 
-#: ../fheroes2/resource/artifact.cpp:89
 msgid "Four-Leaf Clover"
 msgstr "Trebol de 4 Hojas"
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "True Compass of Mobility"
 msgstr "Brújula de la Verdera Movilidad"
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "The %{name} increases your movement on land and sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "Sailor's Astrolabe of Mobility"
 msgstr "Astrolabio del Marinero  de la Movilidad"
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "The %{name} increases your movement on sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "Evil Eye"
 msgstr "Ojo Maligno"
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "The %{name} reduces the casting cost of curse spells by half."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "Enchanted Hourglass"
 msgstr "Reloj de Arena Encantado"
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "The %{name} extends the duration of all your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "Gold Watch"
 msgstr "Reloj de Oro"
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "The %{name} doubles the effectiveness of your hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "Skullcap"
 msgstr "Casco de Cráneo"
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "The %{name} halves the casting cost of all mind influencing spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "Ice Cloak"
 msgstr "Capa de Hielo"
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "The %{name} halves all damage your troops take from cold spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "Fire Cloak"
 msgstr "Capa de Fuego"
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "The %{name} halves all damage your troops take from fire spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "Lightning Helm"
 msgstr "Casco Relampagueante"
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "The %{name} halves all damage your troops take from lightning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid "Evercold Icicle"
 msgstr "Carámbano del Frío Eterno"
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid ""
 "The %{name} causes your cold spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid "Everhot Lava Rock"
 msgstr "Roca de Lava del Calor Eterno"
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid ""
 "The %{name} causes your fire spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid "Lightning Rod"
 msgstr "Vara Relampagueante"
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid ""
 "The %{name} causes your lightning spells to do %{count} percent more damage "
 "to enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "Snake-Ring"
 msgstr "Anillo-Serpiente"
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "The %{name} halves the casting cost of all your bless spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid "Ankh"
 msgstr "Llave de la Vida"
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid ""
 "The %{name} doubles the effectiveness of all your resurrect and animate "
 "spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "Book of Elements"
 msgstr "Libro de los Elementos"
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "The %{name} doubles the effectiveness of all your summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "Elemental Ring"
 msgstr "Anillo Elemental"
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "The %{name} halves the casting cost of all summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "Holy Pendant"
 msgstr "Colgante Sagrado"
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "The %{name} makes all your troops immune to curse spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "Pendant of Free Will"
 msgstr "Colgante de la Voluntad Libre"
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "The %{name} makes all your troops immune to hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "Pendant of Life"
 msgstr "Colgante de la Vida"
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "The %{name} makes all your troops immune to death spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "Serenity Pendant"
 msgstr "Colgane de la Serenidad"
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "The %{name} makes all your troops immune to berserk spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "Seeing-eye Pendant"
 msgstr "Colgante Visionario"
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "The %{name} makes all your troops immune to blindness spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "Kinetic Pendant"
 msgstr "Colgante Cinético"
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "The %{name} makes all your troops immune to paralyze spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "Pendant of Death"
 msgstr "Colgante de la Muerte"
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "The %{name} makes all your troops immune to holy spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "Wand of Negation"
 msgstr "Varita de la Negación"
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "The %{name} protects your troops from the Dispel Magic spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid "Golden Bow"
 msgstr "El Arco Dorado."
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid ""
 "The %{name} eliminates the %{count} percent penalty for your troops shooting "
-"past obstacles. (e.g. castle walls)"
+"past obstacles (e.g. castle walls)."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid "Telescope"
 msgstr "Telescopio"
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid ""
 "The %{name} increases the amount of terrain your hero reveals when "
 "adventuring by %{count} extra square."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid "Statesman's Quill"
 msgstr "Pluma de Estadista"
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid ""
 "The %{name} reduces the cost of surrender to %{count} percent of the total "
 "cost of troops you have in your army."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "Wizard's Hat"
 msgstr "Sombrero de Mago"
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "The %{name} increases the duration of your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "Power Ring"
 msgstr "Anillo de Poder"
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "The %{name} returns %{count} extra power points/turn to your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "Ammo Cart"
 msgstr "Carro de Munición"
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "The %{name} provides endless ammunition for all your troops that shoot."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "Tax Lien"
 msgstr "La Tasa de Embargo."
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "The %{name} costs you %{count} gold pieces/turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "Hideous Mask"
 msgstr "Máscara Horrenda"
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "The %{name} prevents all 'wandering' armies from joining your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "Endless Pouch of Sulfur"
 msgstr "Bolsa Inagotable de Sulfuro"
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "The %{name} provides %{count} unit of sulfur per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "Endless Vial of Mercury"
 msgstr "Frasco Inagotable de Mercurio"
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "The %{name} provides %{count} unit of mercury per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "Endless Pouch of Gems"
 msgstr "Bolsa Inagotable de Gemas"
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "The %{name} provides %{count} unit of gems per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "Endless Cord of Wood"
 msgstr "Cuerda Interminable de Madera"
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "The %{name} provides %{count} unit of wood per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "Endless Cart of Ore"
 msgstr "Carro de Piedra Inagotable"
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "The %{name} provides %{count} unit of ore per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "Endless Pouch of Crystal"
 msgstr "Bolsa Inagotable de Cristal"
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "The %{name} provides %{count} unit of crystal/day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:128
 msgid "Spiked Helm"
 msgstr "Casco Picudo"
 
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "Spiked Shield"
 msgstr "Escudo Picudo"
 
-#: ../fheroes2/resource/artifact.cpp:130
 msgid "White Pearl"
 msgstr "Perla Blanca"
 
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "Black Pearl"
 msgstr "Perla Negra"
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "Magic Book"
 msgstr "Libro de Hechizos"
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "The %{name} enables you to cast spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "Spell Scroll"
 msgstr "Pegamino del Hechizo"
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid "Arm of the Martyr"
 msgstr "Brazo del Martir"
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid ""
 "The %{name} increases your spell power by %{count} but adds the undead "
 "morale penalty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "Breastplate of Anduran"
 msgstr "Peto de Anduran"
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "The %{name} increases your defense by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid "Broach of Shielding"
 msgstr "Mención de Protección"
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid ""
 "The %{name} provides %{count} percent protection from Armageddon and "
 "Elemental Storm, but decreases spell power by 2."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid "Battle Garb of Anduran"
 msgstr "Traje de Batalla de Anduran"
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid ""
 "The %{name} combines the powers of the three Anduran artifacts.  It provides "
 "maximum luck and morale for your troops and gives you the Town Portal spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid "Crystal Ball"
 msgstr "Bola de Cristal"
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid ""
 "The %{name} lets you get more specific information about monsters, enemy "
 "heroes, and castles nearby the hero who holds it."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid "Heart of Fire"
 msgstr "Corazón de Fuego"
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid ""
 "The %{name} provides %{count} percent protection from fire, but doubles the "
 "damage taken from cold."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid "Heart of Ice"
 msgstr "Corazón de Hielo"
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid ""
 "The %{name} provides %{count} percent protection from cold, but doubles the "
 "damage taken from fire."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:148
 msgid "Helmet of Anduran"
 msgstr "Casco de Anduran"
 
-#: ../fheroes2/resource/artifact.cpp:149
 msgid "Holy Hammer"
 msgstr "Martillo Sagrado"
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "Legendary Scepter"
 msgstr "El Cetro Legendario"
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "The %{name} adds %{count} points to all attributes."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "Masthead"
 msgstr "El Mástil"
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "The %{name} boosts your luck and morale by %{count} each in sea combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "Sphere of Negation"
 msgstr "La Esfera de la Negación"
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "The %{name} disables all spell casting, for both sides, in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "Staff of Wizardry"
 msgstr "El Cayado de Brujería"
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "The %{name} boosts your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "Sword Breaker"
 msgstr "El Quebranta Espadas"
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "The %{name} increases your defense by %{count} and attack by 1."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "Sword of Anduran"
 msgstr "La Espada de Anduran"
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "Spade of Necromancy"
 msgstr "Pica de Nigromancia"
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "The %{name} gives you increased necromancy skill."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:638
 msgid ""
 "You find an elaborate aontainer which housesan old vellum scroll. The runes "
 "on the container are very old, and the artistry with whitch it was put "
@@ -7373,7 +6114,6 @@ msgstr ""
 "impresionante. Al sacar el pergamino de la caja sientes cómo el poder mágico "
 "te envuelve."
 
-#: ../fheroes2/resource/artifact.cpp:639
 msgid ""
 "One of the less intelligent members of your party picks up an arm off of the "
 "ground. Despite its missing a body, it is still moving. Your troops find the "
@@ -7386,7 +6126,6 @@ msgstr ""
 "encuentran el brazo repulsivo, pero no puedes dejarlo: parece que posee "
 "algún tipo de poder mágico que influye en tu capacidad de decisión."
 
-#: ../fheroes2/resource/artifact.cpp:640
 msgid ""
 "You come upon a sign. It reads: \"Here lies the body of Anduran. Bow and "
 "swear fealty, and you shall be rewarded.\" You decide to do as it says. As "
@@ -7398,7 +6137,6 @@ msgstr ""
 "dice. Al levantarte, sientes frío contra la piel. Al mirar hacia abajo, ves "
 "que de repente estás llevando una brillante y ornada coraza."
 
-#: ../fheroes2/resource/artifact.cpp:641
 msgid ""
 "A kindly Sorceress thinks that your army's defenses could use a magical "
 "boost. She offers to enchant the Broach that you wear on your cloak, and you "
@@ -7408,7 +6146,6 @@ msgstr ""
 "bien un plus mágico. Se ofrece para encantar el Broche de tu capa, y tú "
 "aceptas."
 
-#: ../fheroes2/resource/artifact.cpp:642
 msgid ""
 "Out of pity for a poor peasant, you purchase a chest of old junk they are "
 "hawking for too much gold. Later, as you search through it, you find it "
@@ -7419,7 +6156,6 @@ msgstr ""
 "revisando su contenido, ¡encuentras en su interior las tres piezas del "
 "legendario traje de combate de Anduran!"
 
-#: ../fheroes2/resource/artifact.cpp:643
 msgid ""
 "You come upon a caravan of gypsies who are feasting and fortifying their "
 "bodies with mead. They call you forward and say \"If you prove that you can "
@@ -7433,7 +6169,6 @@ msgstr ""
 "tienes ni idea, pero aún así lo intentas. Se ríen a carcajadas, pero admiran "
 "tu coraje, y te regalan una Bola de Cristal."
 
-#: ../fheroes2/resource/artifact.cpp:644
 msgid ""
 "You enter a recently burned glade and come upon a Fire Elemental sitting "
 "atop a rock. It looks up, its flaming face contorted in a look of severe "
@@ -7446,7 +6181,6 @@ msgstr ""
 "brillante. Te cubres con las manos, pero las atraviesa, y te quema, "
 "incrustándose en tu pecho."
 
-#: ../fheroes2/resource/artifact.cpp:645
 msgid ""
 "Suddenly, a biting coldness engulfs your body. You seize up, falling from "
 "your horse. The pain subsides, but you still feel as if your chest is "
@@ -7460,7 +6194,6 @@ msgstr ""
 "sonora carcajada. Te das la vuelta justo a tiempo para ver a un Gigante de "
 "Hielo huyendo hacia los bosques hasta desaparecer."
 
-#: ../fheroes2/resource/artifact.cpp:646
 msgid ""
 "You spy a gleaming object poking up out of the ground. You send a member of "
 "your party over to investigate. He comes back with a golden helmet in his "
@@ -7472,7 +6205,6 @@ msgstr ""
 "de que debe de ser el casco del legendario Anduran, el único hombre que haya "
 "llevado una armadura de oro macizo."
 
-#: ../fheroes2/resource/artifact.cpp:647
 msgid ""
 "You come upon a battle where a Paladin has been mortally wounded by a group "
 "of Zombies. He asks you to take his hammer and finish what he started.  As "
@@ -7485,7 +6217,6 @@ msgstr ""
 "en un borrón. Los zombies yacen muertos, y el martillo gotea su sangre. Lo "
 "enganchas a tu cinturón."
 
-#: ../fheroes2/resource/artifact.cpp:648
 msgid ""
 "Upon cresting a small hill, you come upon a ridiculous looking sight. A "
 "Sprite is attempting to carry a Scepter that is almost as big as it is. "
@@ -7499,7 +6230,6 @@ msgstr ""
 "te mira y te responde: \"¿Crees que es divertido? Vale. Puedes llevártelo. "
 "De cualquier modo, prefiero volar.\""
 
-#: ../fheroes2/resource/artifact.cpp:649
 msgid ""
 "An old seaman tells you a tale of an enchanted masthead that he used in his "
 "youth to rally his crew during times of trouble. He then hands you a faded "
@@ -7511,7 +6241,6 @@ msgstr ""
 "mapa borroso que muestra dónde lo escondió. Después de un buen rato "
 "explorando, lo encuentras escondido debajo de un embarcadero cercano."
 
-#: ../fheroes2/resource/artifact.cpp:650
 msgid ""
 "You stop to help a Peasant catch a runaway mare. To show his gratitude, he "
 "hands you a tiny sphere. As soon as you grasp it, you feel the magical "
@@ -7521,7 +6250,6 @@ msgstr ""
 "escapada. En muestra de gratitud, te entrega una esfera diminuta. Tan pronto "
 "como la coges, sientes la energía mágica fluir de tus miembros..."
 
-#: ../fheroes2/resource/artifact.cpp:651
 msgid ""
 "While out scaring up game, your troops find a mysterious staff levitating "
 "about three feet off of the ground. They hand it to you, and you notice an "
@@ -7533,7 +6261,6 @@ msgstr ""
 "una inscripción en él. Se lee: \"Cerebro mejor que musculo y la magia vence "
 "a la fuerza. Considera mis palabras, y ganarás todas las batallas\"."
 
-#: ../fheroes2/resource/artifact.cpp:652
 msgid ""
 "A former Captain of the Guard admires your quest and gives you the enchanted "
 "Sword Breaker that he relied on during his tour of duty."
@@ -7542,7 +6269,6 @@ msgstr ""
 "Rompedora de Espadas encantada en la que confiaba durante sus años de "
 "servicio."
 
-#: ../fheroes2/resource/artifact.cpp:653
 msgid ""
 "A Troll stops you and says: \"Pay me 5,000 gold, or the Sword of Anduran "
 "will slay you where you stand.\" You refuse. The troll grabs the sword "
@@ -7556,7 +6282,6 @@ msgstr ""
 "espada, das gracias por los trolls medio idiotas que tienden a agarrar el "
 "extremo incorrecto de los objetos afilados."
 
-#: ../fheroes2/resource/artifact.cpp:654
 msgid ""
 "A dirty shovel has been thrust into a dirt mound nearby. Upon investigation, "
 "you discover it to be the enchanted shovel of the Gravediggers, long thought "
@@ -7566,5089 +6291,60 @@ msgstr ""
 "investigarla, descubres que es la pala encantada de los Enterradores, que se "
 "creía perdida hacía tiempo por los mortales."
 
-#: ../fheroes2/resource/artifact.cpp:896
+#, fuzzy
 msgid ""
-"Do you want to use your knowledge of magical secrets to transcribe the %"
-"{spell} Scroll into your spell book?\n"
-"The Scroll will be consumed.\n"
-" Spell point: %{sp}"
+"Do you want to use your knowledge of magical secrets to transcribe the "
+"%{spell} Scroll into your Magic Book?\n"
+"The Spell Scroll will be consumed.\n"
+" Cost in spell points: %{sp}"
 msgstr ""
 "¿Quieres usar tu conocimiento en los secretos de la mágia para transcribir "
 "el Pergamino %{spell} en tu libro de hechizos?\n"
 "El Pergamino será consumido.\n"
 " Maná: %{sp}"
 
-#: ../fheroes2/resource/artifact.cpp:960
-msgid "Open book"
-msgstr ""
+#, fuzzy
+msgid "Transcribe Spell Scroll"
+msgstr "Pegamino del Hechizo"
 
-#: ../fheroes2/resource/artifact.cpp:965
-msgid "Transcribe scroll"
-msgstr ""
+#, fuzzy
+msgid "View Spells"
+msgstr "Ver Todo"
 
-#: ../fheroes2/resource/artifact.cpp:975
-#: ../fheroes2/resource/artifact.cpp:1008
+#, fuzzy
+msgid "View %{name} Info"
+msgstr "Ver %{name}"
+
 msgid "Move %{name}"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:998
 msgid "Cannot move artifact"
 msgstr ""
 
-#: ../fheroes2/resource/maps_text.cpp:15
-msgid ""
-"425 bottles of beer on the wall, 425 bottles of beer! If one of those "
-"bottles should happen to fall, there'll be..."
+msgid "This item can't be traded."
 msgstr ""
-"425 botellas de cerveza sobre el muro, ¡425 botellas de cerveza! Si una de "
-"las botellas llegara a caer, habría que ..."
 
-#: ../fheroes2/resource/maps_text.cpp:16
-msgid "A balanced scenario with lots of resources and land to explore."
-msgstr ""
-"Un escenario equilibrado con gran cantidad de recursos y terriorios para "
-"explorar."
-
-#: ../fheroes2/resource/maps_text.cpp:17
-msgid ""
-"A bandit army of gorgons jump you without warning.  they stone your entire "
-"army demand 500 gold before they will release your comrads.  Realizing that "
-"it is much cheeper to pay then rebuild your army you part with the gold."
-msgstr ""
-"Un ejercito de bandidas gorgonas te asalta sin ningún aviso.  Y petrifican "
-"tu ejercito entero demandando 500 de oro antes de liberar a tus camaradas. "
-"Alegando que es más barato pagar que reconstruir tu ejercito por tu cuenta "
-"con ese oro."
-
-#: ../fheroes2/resource/maps_text.cpp:18
-msgid "Abandon All Hope!"
-msgstr "¡Abandona toda esperanza!"
-
-#: ../fheroes2/resource/maps_text.cpp:19
-msgid "Abandon All Hope Ye That Enter Here"
-msgstr "!Abandonad toda esperanza aquellos que entréis aquí!"
-
-#: ../fheroes2/resource/maps_text.cpp:20
-msgid "A bit of crystal!"
-msgstr "Un poco de cristal."
-
-#: ../fheroes2/resource/maps_text.cpp:21
-msgid "A bit of mercury!"
-msgstr "¡Un poco de mercurio!"
-
-#: ../fheroes2/resource/maps_text.cpp:22
-msgid "A bit of sulfur!"
-msgstr "¡Un poco de azufre!"
-
-#: ../fheroes2/resource/maps_text.cpp:23
-msgid ""
-"Above you looms the ancient Ice Palace.  Dimly remembered myth speaks of a "
-"Prince who rejected the advances of the Winter Goddess, and thus he and his "
-"domain were cursed to remain shrouded in ice, hidden in a forgotten corner "
-"of the world.  It is said that he can only be rescued by a hero who is both "
-"clever and bold.  Are you that one?  Do you dare enter this frozen domain?"
-msgstr ""
-"Sobre ti se avecina el antiguo Palacio de Hielo. El mito, borrosamente "
-"recordado, habla de un Príncipe que rechazó los avances de la Diosa del "
-"Invierto. De este modo él y su dominio fueron maldecidos a permanecer "
-"envueltos en hielo ocultos en una olvidada esquina del mundo. Se dice que él "
-"sólo puede ser rescatado por un héroe que sea tanto listo como audaz. ¿Eres "
-"tú ese héroe?, ¿Te atreves a entrar en este dominio helado?"
-
-#: ../fheroes2/resource/maps_text.cpp:24
-msgid "A cache of crystal!"
-msgstr "¡Un alijo de crital!"
-
-#: ../fheroes2/resource/maps_text.cpp:25
-msgid "A cache of gems!"
-msgstr "¡Un alijo de gemas!"
-
-#: ../fheroes2/resource/maps_text.cpp:26
-msgid "A cache of gold!"
-msgstr "¡Un alijo de oro!"
-
-#: ../fheroes2/resource/maps_text.cpp:27
-msgid "A cache of mercury!"
-msgstr "¡Un alijo de mercurio!"
-
-#: ../fheroes2/resource/maps_text.cpp:28
-msgid "A cache of sulfur!"
-msgstr "¡Un alijo de azufre!"
-
-#: ../fheroes2/resource/maps_text.cpp:29
-msgid ""
-"A chance to end a bitter war has finally arrived as a new resource-laden "
-"land has been discovered."
-msgstr ""
-"Una oportunidad para finalizar esta amarga querra se ha presentado "
-"finalmente puesto que un nuevo territorio repleto de recursos ha sido "
-"descubierto."
-
-#: ../fheroes2/resource/maps_text.cpp:30
-msgid "A chunk of gold!"
-msgstr "¡Una buena cantidad de oro!"
-
-#: ../fheroes2/resource/maps_text.cpp:31
-msgid "A chunk of ore!"
-msgstr "¡Una buena mena de hierro!"
-
-#: ../fheroes2/resource/maps_text.cpp:32
-msgid "A couple of gems!"
-msgstr "¡Un par de gemas!"
-
-#: ../fheroes2/resource/maps_text.cpp:33
-msgid "\"Act of Desperation\""
-msgstr "\"Acto de desesperación\""
-
-#: ../fheroes2/resource/maps_text.cpp:34
-msgid ""
-"A desert isle rich in resources rewards the quick.  Just be sure to watch "
-"your back!"
-msgstr ""
-"Una isla desierta rica en recursos recompensa la rapidez. ¡Asegúrate de "
-"vigilar tu espalda!"
-
-#: ../fheroes2/resource/maps_text.cpp:35
-msgid "A dolphin playfully jumps into the air."
-msgstr "Un delfín alegremente da un brinco en el aire."
-
-#: ../fheroes2/resource/maps_text.cpp:36
-msgid ""
-"A Dragon, A Cyclops, or an Undead. King of the Centaurs, His name is ....?"
-msgstr ""
-"Un dragón, un Cíclope o un Nomuerto. Rey de los Centauros, ¿Su nombre es ...?"
-
-#: ../fheroes2/resource/maps_text.cpp:37
-msgid "A flight of dragons circles overhead."
-msgstr "Una bandada de dragones sobrevuela en círculo."
-
-#: ../fheroes2/resource/maps_text.cpp:38
-msgid "A flock of seagulls circle overhead."
-msgstr "Una bandada de gaviotas sobrevuelta en círculo."
-
-#: ../fheroes2/resource/maps_text.cpp:39
-msgid "A friendly dolphin splashes alongside the ship."
-msgstr "Un delfín amistoso chapotea alredor del barco."
-
-#: ../fheroes2/resource/maps_text.cpp:40
-msgid ""
-"After a long search of the island, I have discovered that there is no way "
-"for me to escape without help.  I can not steal a ship from one of the "
-"coastal castles, and I dare not venture into the desert unless I wish to "
-"become Dragon food.  Should anyone find this, I beg of you, please send a "
-"ship and get me off this cursed island!  -Sir Christian"
-msgstr ""
-"Después de una larga busqueda por la isla, me he dado cuenta de que no hay "
-"manera de escaparse sin ayuda. No puedo robar un barco de los castillos de "
-"la costa y no me atrevo a aventurarme en el desierto; a no ser que desee "
-"convertirme en comida de dragón. Si alguien encuentra esto, te ruego, "
-"envíame un barco y sácame de esta isla maldita! - Sir Christian."
-
-#: ../fheroes2/resource/maps_text.cpp:41
-msgid ""
-"After centuries of friendship, the Wizards have suddenly decided to stop "
-"sharing their Library with the rest of the world.  This can't be good!"
-msgstr ""
-"Después de siglos de amistad, los Magos deciden dejar de compartir su "
-"Biblioteca con el resto del mundo. ¡Esto no puede ser bueno!"
-
-#: ../fheroes2/resource/maps_text.cpp:42
-msgid ""
-"After many years of peace, you discover that your sworn enemy from across "
-"the sea has chosen to invade your homeland by raising up the ocean floor to "
-"bridge the distance! You must not let them gain a foothold on this "
-"continent, in fact, your King has ordered you to establish a foothold on "
-"theirs!  To make matters worse, two of your OWN towns have thrown in their "
-"lots with the enemy..."
-msgstr ""
-"Tras muchos años de paz, descubres que tu enemigo jurado de allende los "
-"mares ha elegido invadir tu patria elevando el fondo del océano y cubrir así "
-"la distancia. No debes permitirle poner el pie en este continente, de hecho, "
-"¡tu Rey te ha ordenado invadir el suyo! Para empeorar las cosas, dos de tus "
-"propias ciudades se han pasado al enemigo..."
-
-#: ../fheroes2/resource/maps_text.cpp:43
-msgid ""
-"After you return from a scouting trip, your Seneschal hurries to greet you.  "
-"\"My Lord, in your absence I signed an agreement in your name with a Master "
-"Merchant.  If we supply him with the resources he needs, through trading, he "
-"can return the resources to us in a week or so, plus some additional ones."
-"\"  The Seneschal eyes you anxiously.  You hesitate, then nod slowly, "
-"\"Good, we can use more resources>\""
-msgstr ""
-"Al volver de una partida de exploración, tu Senescal se apresura a "
-"encontrarte. \"Mi Señor, en vuestra ausencia he firmado un acuerdo en "
-"vuestro nombre con un Mercader Maestro. Si le proporcionamos los recursos "
-"que necesita, a través del comercio, nos puede devolver dichos recursos en "
-"una semana o así, además de algunos otros adicionales\". El Senescal te mira "
-"con ansiedad. Tú dudas, y luego asientes lentamente, \"Bien, podemos usar "
-"más recursos\""
-
-#: ../fheroes2/resource/maps_text.cpp:44
-msgid "A ghostly pirate ship appears and sails on by."
-msgstr "Aparece un barco fantasma y pasa de largo."
-
-#: ../fheroes2/resource/maps_text.cpp:45
-msgid ""
-"A Gift from your King, and a note that reads \"Use these resources wisely, "
-"It's all we have left\"."
-msgstr ""
-"Un presente de tu Rey y una nota que dice: \"Usa estos recursos sabiamente, "
-"es todo lo que me queda\"."
-
-#: ../fheroes2/resource/maps_text.cpp:46
-msgid ""
-"A gift of gold, m'lord, from the people of Enroth, to the people of Enroth.  "
-"Good luck, and may God save true King Roland!"
-msgstr ""
-"Un presente de oro, Señor, de las gentes de Enroth para las gentes de "
-"Enroth. ¡Buena suerte y que Dios guarde al verdadero Rey Roland!"
-
-#: ../fheroes2/resource/maps_text.cpp:47
-msgid "A glint by a tree catches your eye..."
-msgstr "Un destello en un árbol te llama la atención..."
-
-#: ../fheroes2/resource/maps_text.cpp:48
-msgid "A gold cache!"
-msgstr "Un alijo de oro."
-
-#: ../fheroes2/resource/maps_text.cpp:49
-msgid "A gold chunk!"
-msgstr "¡Un poco de oro!"
-
-#: ../fheroes2/resource/maps_text.cpp:50
-msgid "A gold nugget!"
-msgstr "¡Unas pepitas de oro!"
-
-#: ../fheroes2/resource/maps_text.cpp:51
-msgid ""
-"A great Black dragon stands before you. It speaks in a suprisingly soft "
-"voice, saying, \"The elves believe they have sent another hero to reclaim "
-"their prize. I believe they have sent me another meal.\""
-msgstr ""
-"Un fantástico Dragón negro está de pie delante tuyo. Habla con una "
-"sorprendentemente suave voz, diciendo, \"Los elfos creen que han mandado a "
-"otro héroe para reclamar su recompensa. Yo creo que me han enviado otra "
-"comida.\""
-
-#: ../fheroes2/resource/maps_text.cpp:52
-msgid ""
-"A group of peasant farmers approaches you, \"We are in dire need of your "
-"assistance.  Our castle to the north has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-"Un grupo de campesinos se te acerca, \"Necesitamos vuestra ayuda. Nuestro "
-"castillo, al norte, ha sido ocupado y nuestro Señor, asesinado. Por favor, "
-"¡ayudadnos a recuperar nuestros hogares! ¡Aún hay mujeres y niños allí! "
-"¡Tomad lo que tenemos para ayudar!\""
-
-#: ../fheroes2/resource/maps_text.cpp:53
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance.  Our castle to the east has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-"Un grupo de campesinos se te acerca, \"Necesitamos vuestra ayuda. Nuestro "
-"castillo, al este, ha sido ocupado y nuestro Señor, asesinado. Por favor, "
-"¡ayudadnos a recuperar nuestros hogares! ¡Aún hay mujeres y niños allí! "
-"¡Tomad lo que tenemos para ayudar!\""
-
-#: ../fheroes2/resource/maps_text.cpp:54
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance. Our castle to the east has been overrun and our Lord killed. "
-"Please help us regain our homes! There are still women and children there! "
-"Take what we have to help!\""
-msgstr ""
-"Un grupo de campesinos se te acerca, \"Necesitamos vuestra ayuda. Nuestro "
-"castillo, al este, ha sido ocupado y nuestro Señor, asesinado. Por favor, "
-"¡ayudadnos a recuperar nuestros hogares! ¡Aún hay mujeres y niños allí! "
-"¡Tomad lo que tenemos para ayudar!\""
-
-#: ../fheroes2/resource/maps_text.cpp:55
-msgid ""
-"A group of peasant farmers approach you, We are in dire need of your "
-"assistance.  Our castle to the northeast has been overrun and our Lord "
-"killed.  Please help us regain our homes!  There are still women and "
-"children there!  Take what we have to help!\""
-msgstr ""
-"Un grupo de campesinos se te acerca, \"Necesitamos vuestra ayuda. Nuestro "
-"castillo, al noreste, ha sido ocupado y nuestro Señor, asesinado. Por favor, "
-"¡ayudadnos a recuperar nuestros hogares! ¡Aún hay mujeres y niños allí! "
-"¡Tomad lo que tenemos para ayudar!\""
-
-#: ../fheroes2/resource/maps_text.cpp:56
-msgid "A handful of gems!"
-msgstr "¡Un puñado de gemas!"
-
-#: ../fheroes2/resource/maps_text.cpp:57
-msgid ""
-"Ah, you stumble across something buried in the sand.  As you dig it up you "
-"discover a small pile of gems and crystal."
-msgstr ""
-"Ah, tropiezas con algo semienterrado en la arena. Al desenterrarlo descubres "
-"una pequeña pila de gemas y cristal."
-
-#: ../fheroes2/resource/maps_text.cpp:58
-msgid ""
-"A Knight and Necromancer team up against the Barbarian and Sorceress. (Blue "
-"and Green vs Red and Yellow)"
-msgstr ""
-"Un Caballero y un Necromante unen sus fuerzas contra el Bárbaro y la "
-"Hechicera. (Azul y Verde vs Rojo y Amarillo)"
-
-#: ../fheroes2/resource/maps_text.cpp:60
-msgid ""
-"A large contingent of the king's guard approaches you.  \"Ahh, we have "
-"finally caught up to you.  The king requires tribute from all of his vassals "
-"and you have been negligent far too long.\""
-msgstr ""
-"Se te acerca un gran contingente de la guardia del rey. \"Ah, al final os "
-"alcanzamos. El rey exige tributo de todos sus vasallos, y vos habéis sido "
-"negligente por demasiado tiempo.\""
-
-#: ../fheroes2/resource/maps_text.cpp:61
-msgid ""
-"A large map with lots of resources and treasure. Exploration and victory "
-"will require many heroes."
-msgstr ""
-"Un mapa grande con muchos recursos y tesoros. La exploración y la victoria "
-"requerirán muchos héroes."
-
-#: ../fheroes2/resource/maps_text.cpp:62
-msgid "A legion of peasants stands between you and this unclaimed island."
-msgstr ""
-"Una legión de campesinos es el único obstaculo entre tú y esta tierra no "
-"reclamada."
-
-#: ../fheroes2/resource/maps_text.cpp:63
-msgid "Algary"
-msgstr "Algary"
-
-#: ../fheroes2/resource/maps_text.cpp:64
-msgid "A little bit closer..."
-msgstr "Un poco más cerca ..."
-
-#: ../fheroes2/resource/maps_text.cpp:65
-msgid "All mines are grouped by type. Trade is your only hope."
-msgstr ""
-"Todas las minas están agrupadas por tipo. El comercio es tu única esperanza."
-
-#: ../fheroes2/resource/maps_text.cpp:66
-msgid "A lump of crystal!"
-msgstr "¡Un trozo de cristal!"
-
-#: ../fheroes2/resource/maps_text.cpp:67
-msgid "A lump of gold!"
-msgstr "¡Un trozo de oro!"
-
-#: ../fheroes2/resource/maps_text.cpp:68
-msgid "A lump of mercury!"
-msgstr "¡Un trozo de mercurio!"
-
-#: ../fheroes2/resource/maps_text.cpp:69
-msgid ""
-"A man appears from behind the sand dune. \"At last,\" he says, \"Someone has "
-"come to rescue me! I am forever grateful. Alas all I have to offer you in "
-"return are these souvenirs from my wrecked ship.\""
-msgstr ""
-"Un hombre aparece por detrás de la duna. Dice: \"¡Por fin alguien ha venido "
-"a rescatarme! estaré siempre en deuda contigo. Ay, todo lo que tengo para "
-"ofrecerte a cambio son estos objetos de mi barco siniestrado\"."
-
-#: ../fheroes2/resource/maps_text.cpp:70
-msgid ""
-"A man is laying on the ground, near death. He looks to you and speaks, "
-"\"Please help my companions! Please... they can't...cough...get away from..."
-"cough...the drag...\" With that, he dies."
-msgstr ""
-"Un hombre permanece tumbado en el suelo moribundo. Justo antes de morir te "
-"mira y dicer: \"por favor, ayuda a mis compañeros, por favor ... ellos no "
-"pueden  ... huir de ... el avance."
-
-#: ../fheroes2/resource/maps_text.cpp:71
-msgid ""
-"A merchant caravan arrives, bringing gold and supplies, however, no one can "
-"seem to remember where they came from.  You silently praise this anonymous "
-"benefactor and continue your duties."
-msgstr ""
-"Una caravana mercante llega trayendo oro y suministros. Sin embargo, nadie "
-"puede parecer recordar de dónde vienen. En silencio alabas a este anónimo "
-"benefactor y continúas con tus deberes."
-
-#: ../fheroes2/resource/maps_text.cpp:72
-msgid "a mirror"
-msgstr "un espejo"
-
-#: ../fheroes2/resource/maps_text.cpp:73
-msgid "An albatross flies ahead of the ship for a while"
-msgstr "Un albatros sobrevuela el barco por un momento."
-
-#: ../fheroes2/resource/maps_text.cpp:74
-msgid "Anduran"
-msgstr "Anduran"
-
-#: ../fheroes2/resource/maps_text.cpp:75
-msgid ""
-"An enemy from across the sea has seized half your towns.  Can you put aside "
-"your own feud with your brother to fight this common enemy?"
-msgstr ""
-"Un enemigo de allende los mares ha conquistado la mitad de tus ciudades. "
-"¿Puedes dejar a un lado la enemistad con tu hermano para enfrentar a este "
-"enemigo común?"
-
-#: ../fheroes2/resource/maps_text.cpp:76
-msgid "\"Annexation\""
-msgstr "\"Anexión\""
-
-#: ../fheroes2/resource/maps_text.cpp:77
-msgid ""
-"An old elf is sitting on a rock in a glen, pounding on the shackles on his "
-"feet with a stone. You help him remove them and ask him his tale. \"I'm a "
-"deserter from Drakonia's army. She has enslaved all the elves to support her "
-"madness. She must be stopped.\" Then he slips into the woods without a "
-"sound, leaving behind just his cloak."
-msgstr ""
-"Un elfo anciano está sentado sobre una roca en una cañada, golpeando los "
-"grilletes de sus pies con una piedra. Le ayudas a quitárselos y le preguntas "
-"por su historia. \"Soy un desertor del ejercito de Drakonia. Ella ha "
-"esclavizado a todos los elfos para mantener su locura. Debe ser detenida\". "
-"Entonces se desliza hacia el interior del bosque sin hacer ningún sonido, "
-"dejando tras de sí solamente su capa."
-
-#: ../fheroes2/resource/maps_text.cpp:78
-msgid "Antioch"
-msgstr "Antioch"
-
-#: ../fheroes2/resource/maps_text.cpp:79
-msgid "A piece of crystal!"
-msgstr "¡Un poco de cristal!"
-
-#: ../fheroes2/resource/maps_text.cpp:80
-msgid "A pile of crystal!"
-msgstr "¡Una pila de Cristal!"
-
-#: ../fheroes2/resource/maps_text.cpp:81
-msgid "A pile of gems!"
-msgstr "¡Una pila de Gemas!"
-
-#: ../fheroes2/resource/maps_text.cpp:82
-msgid "A pile of gold!"
-msgstr "¡Una pila de Oro!"
-
-#: ../fheroes2/resource/maps_text.cpp:83
-msgid ""
-"A plague of undead is upon us. Who will unite the living against the dead?"
-msgstr ""
-"Una plaga de nomuertos está sobre nosotros ¿Quién unirá a los vivos contra "
-"los muertos?"
-
-#: ../fheroes2/resource/maps_text.cpp:84
-msgid "\"Apocalypse\""
-msgstr "\"Apocalipsis\""
-
-#: ../fheroes2/resource/maps_text.cpp:85
-msgid "A quantity of crystal!"
-msgstr "¡Algo de cristal!"
-
-#: ../fheroes2/resource/maps_text.cpp:86
-msgid "A quantity of mercury!"
-msgstr "¡Algo de mercurio!"
-
-#: ../fheroes2/resource/maps_text.cpp:87
-msgid "A quantity of sulfur!"
-msgstr "¡Algo de azufre!"
-
-#: ../fheroes2/resource/maps_text.cpp:89
-msgid ""
-"Archibald has also sent an army to find the Crown, you must find it first or "
-"all is lost."
-msgstr ""
-"Archibald también ha enviado un ejército para hallar la corona, debes "
-"encontrarla antes o todo estará perdido."
-
-#: ../fheroes2/resource/maps_text.cpp:90
-msgid "Archibald is hiding at the end of the river."
-msgstr "Archibald se esconde al final del río."
-
-#: ../fheroes2/resource/maps_text.cpp:91
-msgid ""
-"A resource rich valley keeps the Wizard and the Necromancer apart. Your "
-"opponent's army will arrive in 3 months so hurry."
-msgstr ""
-"Un valle rico en recursos mantiene separados al Mago y al Necromante. El "
-"ejército de tus enemigos llegará en 3 meses, así que apresúrate."
-
-#: ../fheroes2/resource/maps_text.cpp:92
-msgid "Arm of the Crusader"
-msgstr "Arma de Cruzado"
-
-#: ../fheroes2/resource/maps_text.cpp:93
-msgid "Arm of the Cyclops"
-msgstr "Arma de Cíclope"
-
-#: ../fheroes2/resource/maps_text.cpp:94
-msgid "Arm of the Dragon"
-msgstr "Arma de Dragón"
-
-#: ../fheroes2/resource/maps_text.cpp:95
-msgid "Arm of the Phoenix"
-msgstr "Arma de Fénix"
-
-#: ../fheroes2/resource/maps_text.cpp:96
-msgid "Arm of the Titan"
-msgstr "Arma de Titán"
-
-#: ../fheroes2/resource/maps_text.cpp:97
-msgid "Arr' Here be pirates gold buried."
-msgstr "Arrg, aquí esta enterrado el oro de los piratas."
-
-#: ../fheroes2/resource/maps_text.cpp:98
-msgid "A shipment of wood has arrived from your kingdom!"
-msgstr "¡Un cargamento de madera ha llegado desde tu Reino!"
-
-#: ../fheroes2/resource/maps_text.cpp:99
-msgid ""
-"A splash in the seaweed alerts you to a mermaid waving in a friendly manner. "
-"\"Oh, I thought you were Ahab.\" She is surprised, but quickly composes "
-"herself. \"Well, if you meet him, give him these treasures I have collected."
-"\""
-msgstr ""
-"Un chapoteo entre las algas te llama la atención, y ves a una sirena "
-"saludando de manera amistosa. \"Oh, pensé que eras Ahab.\" Ella se muestra "
-"sorprendida, pero rápidamente recupera la compostura. \"Bien, si te lo "
-"encuentras, dale estos tesoros que he recogido.\""
-
-#: ../fheroes2/resource/maps_text.cpp:100
-msgid "Assassins tried to kill our ally."
-msgstr "Unos asesinos intentaron asesinar a nuestro aliado."
-
-#: ../fheroes2/resource/maps_text.cpp:101
-msgid "Astircaer"
-msgstr "Astircaer"
-
-#: ../fheroes2/resource/maps_text.cpp:102
-msgid ""
-"A stranded Wizard with only a small force must conquer an entire continent "
-"of hostile forces."
-msgstr ""
-"Un Mago abandonado con unas fuerzas pequeñas debe conquistar un continente "
-"entero repleto de fuerzas enemigas."
-
-#: ../fheroes2/resource/maps_text.cpp:103
-msgid ""
-"A supply ship has arrived from the homeland!  You send word home that all is "
-"well."
-msgstr ""
-"Un barco de suministros ha llegado desde la patria. Das aviso de que todo "
-"está correcto."
-
-#: ../fheroes2/resource/maps_text.cpp:104
-msgid ""
-"As you approach the barrier, you see the old elf you helped free. This time, "
-"however, you see that he is wearing a cape of fine weave, and a wooden crown "
-"is on his head. He sees your forces, and says \"Take this sword, and with "
-"it, strike down Drakonia and help free my people.\" The old elf then strides "
-"regally into the woods."
-msgstr ""
-"Al acercarte a la barrera, ves al viejo elfo al que ayudaste a liberarse. "
-"Esta vez, en cambio, ves que viste una capa de fino tejido, y luce una "
-"corona de madera en su cabeza. Al ver tus fuerzas, te dice: \"Toma esta "
-"espada, y con ella, golpea Drakonia y libera a mi gente.\" El viejo elfo "
-"regresa, majestuosamente, al interior del bosque."
-
-#: ../fheroes2/resource/maps_text.cpp:105
-msgid ""
-"As you approach the gates of the Ice Palace, one of your troops points in "
-"terror.  You watch in awe as great slabs of ice separate from the castle "
-"walls with loud cracking reports and crash to the ground.  Soon the ice is "
-"gone and the sun begins to peak through the gloom.  The deathly silence that "
-"must have ruled these lands for centuries ends as birds begin to sing.  From "
-"inside you hear the sounds of life."
-msgstr ""
-"Al acercarte a las puertas del Palacio de Hielo, uno de tus hombres señala "
-"aterrorizado. Observas, asombrado, cómo enormes losas de hielo se separan de "
-"los muros del castillo con un ruido ensordecedor, y se estrellan contra el "
-"suelo. En poco tiempo ha desaparecido el hielo, y el sol comienza a "
-"despuntar a través de la penumbra. El mortal silencio que ha dominado estas "
-"tierras durante siglos finaliza al comenzar a cantar los pájaros. Desde "
-"dentro oyes los sonidos de la vida."
-
-#: ../fheroes2/resource/maps_text.cpp:106
-msgid ""
-"As you approach the tent, the leader of the nomads comes out to greet you. "
-"He says, \"It was prophecied many years ago that a great hero would come to "
-"greet us in our sacred valley, and we would prosper afterwords. Now it has "
-"come to pass, and we offer you these gifts as tokens of our thanks.\""
-msgstr ""
-"Al acercarte a la tienda, el líder de los nómadas sale a recibirte. Te dice "
-"\"Hace muchos años se profetizó que un gran héroe llegaría para encontrarnos "
-"en nuestro valle sagrado, y que prosperaríamos tras ello. Ahora esto ha "
-"sucedido, y te ofrecemos estos regalos como muestra de nuestra gratitud\"."
-
-#: ../fheroes2/resource/maps_text.cpp:107
-msgid ""
-"As you approach,  you hear whispered mentions of \"the wild barbarian who "
-"passed this way months before\". One of the villagers approaches you and "
-"hands you an object, saying \"The wild one dropped this. You must be his "
-"kin. Therefore I give it to you. But beware! Many in the village will not be "
-"as friendly as I.\""
-msgstr ""
-"Al acercarte, oyes susurros que mencionan al \"bárbaro salvaje que pasó por "
-"este camino meses atrás\". Uno de los habitantes del pueblo se te acerca y "
-"te da un objeto, diciendo \"El salvaje dejó caer esto. Tú debes ser de su "
-"calaña. Por eso, te lo entrego. Pero cuidado. Muchos en el pueblo no serán "
-"tan amistosos como yo.\""
-
-#: ../fheroes2/resource/maps_text.cpp:108
-msgid ""
-"As you break your fast your sage rushes in, \"Good news, my lord!  I have "
-"translated the message.  Two great heroes were imprisoned many years ago.  "
-"They lie sleeping - still guarded by magic barriers and monsters.  My lord, "
-"they lie nearby- in between our ally and us.  If we could free them, they "
-"would surely aid us against our enemies!  The password to the first magic "
-"barrier can be learned at the Aqua Traveller's Tent.\""
-msgstr ""
-"Mientras estás desayunando, tu consejero entra apresuradamente, \"¡Buenas "
-"noticias, mi señor! He traducido el mensaje. Dos grandes héroes fueron "
-"apresados hace muchos años. Aún duermen - guardados por barreras mágicas y "
-"monstruos. Mi señor, están cerca, entre nuestro aliado y nosotros. Si "
-"puiéramos liberarlos, seguramente nos ayudarían contra nuestros enemigos. La "
-"contraseña para la primera barrera mágica puede aprenderse en la Tienda de "
-"Agua del Viajero.\""
-
-#: ../fheroes2/resource/maps_text.cpp:109
-msgid ""
-"As you enter the small clearing, you see a familiar figure talking to a "
-"group of halflings and soldiers. You stay awhile and listen to his speech. "
-"\"The time to throw off these chains of tyranny is now! We must strike at "
-"the heart of her empire, and destroy the evil that she has brought to our "
-"land.\" As the old elf finishes speaking, he gets up from his mossy seat and "
-"once again, blends into the woods with incredible grace."
-msgstr ""
-"Mientras entras en el pequeño descampado ves una figura familiar que comanda "
-"un grupo de Medianos y soldados. Te alejas mientras y escuchas su "
-"conversación: \"El tiempo de romper estas cadenas de tiranía ha llegado\". "
-"\"Debemos atacar el corazón del Imperio y destruir el mal que ha traido a "
-"nuestra tierra\". Cuando el anciano elfo acaba su discurso se levanta del "
-"asiento y de nuevo se camufla en el bosque con increible habilidad."
-
-#: ../fheroes2/resource/maps_text.cpp:110
-msgid ""
-"As you lay down to nap after a long battle, you notice a lucky four-leaf "
-"clover."
-msgstr ""
-"Al ir a descansar después de una larga batalal, encuentras un trébol de la "
-"suerte de cuatro hojas."
-
-#: ../fheroes2/resource/maps_text.cpp:111
-msgid ""
-"As you make  your way through the last of the golemn debris, a group of "
-"halflings runs towards you carrying fruit and flowers. \"Thank you so much!"
-"\" Their leader exclaims, \"We've been trapped in here for ever! Come by our "
-"homes, we'll pack up and go with you!\""
-msgstr ""
-"Al abrirte paso a través de los restos del gólem, un grupo de medianos corre "
-"hacia ti trayendo flores y frutas. \"¡Muchas gracias!\" Su líder exclama: "
-"\"¡Hemos estado atrapados aquí por siempre! ¡Pásate por nuestros hogares, "
-"recogeremos nuestras cosas e iremos contigo!\""
-
-#: ../fheroes2/resource/maps_text.cpp:112
-msgid ""
-"As you make your way to the shrine, some very thin and hollow-eyed men come "
-"out of the flower patch and stare at you.  Seeing that you want the gold, "
-"one of them says to you \"Hey, man, if you're, like, so lusty for earthly "
-"wealth, then, like, have this too.\" You graciously take what they have "
-"offered and back out of the clearing."
-msgstr ""
-"Al abrirte camino hasta el altar, un hombre muy flaco y ojeroso sale de "
-"entre las flores y te mira fijamente. Viendo que quieres el oro, uno de "
-"ellos te dice \"Eh, hombre, si estás tan ansioso por las riquezas "
-"terrenales, entonces ten también esto.\" Agradecido, tomas lo que te ofrecen "
-"y sales del claro."
-
-#: ../fheroes2/resource/maps_text.cpp:113
-msgid ""
-"As you prepare your lands to fight the onslaught from the South, a curious "
-"message appears on your table in the Great Hall of your Castle.  Written in "
-"some ancient language, none but your sage can make any sense of it.  She "
-"promises to have the words deciphered by tomorrow..."
-msgstr ""
-"Mientras preparas tus tierras para combatir la invasión del Sur, aparece un "
-"curioso mensaje en la mesa del Gran Salón de tu Castillo. Escrito en algún "
-"lenguaje antiguo, sólo tu [SAGE] sabio sabe encontrarle sentido. Te promete "
-"tener las palabras descifradas para mañana..."
-
-#: ../fheroes2/resource/maps_text.cpp:114
-msgid "A three hour tour, a three hour tour..."
-msgstr "Un recorrido de tres horas, un recorrido de tres horas..."
-
-#: ../fheroes2/resource/maps_text.cpp:115
-msgid ""
-"A tiny gnome points to a chunk of crystal you otherwise would have "
-"overlooked!"
-msgstr ""
-"Un gnomo diminuto te señala un trozo de cristal que de otro modo hubieras "
-"pasado por alto."
-
-#: ../fheroes2/resource/maps_text.cpp:116
-msgid "Atlantium"
-msgstr "Atlantium"
-
-#: ../fheroes2/resource/maps_text.cpp:117
-msgid ""
-"At last, the king is dead.  For years you have planned his demise, but now "
-"it is done, and there is no heir to take his place, though the Knights to "
-"the south believe that they are the rightful successors.  A wealth in wood "
-"(to the south) and ore (in the northern mountains) provides you with trade "
-"goods, and your isolation has allowed you to prepare your forces of darkness "
-"for this day.  Go, now, and fulfill your destiny!"
-msgstr ""
-"Por fin, el rey ha muerto. Durante años planeaste su fallecimiento, pero "
-"ahora lo has conseguido, y no hay heredero que ocupe su lugar, aunque los "
-"Caballeros del sur creen que ellos son sus sucesores legítimos. La abundante "
-"madera (al sur) y mineral (en las montañas del norte) te proporcionan bienes "
-"de comercio, y tu aislamiento te ha permitido preparar tus fuerzas de "
-"oscuridad para este día. ¡Ve ahora, y cumple tu destino!"
-
-#: ../fheroes2/resource/maps_text.cpp:118
-msgid ""
-"At the base of the mountain you see something that glitters.   You discover "
-"an ancient pile of offerings to the gods."
-msgstr ""
-"Ves algo que brilla en la base de la montaña. Descubres una antigua pila de "
-"ofrendas a los Dioses."
-
-#: ../fheroes2/resource/maps_text.cpp:119
-msgid "Avalon"
-msgstr "Avalon"
-
-#: ../fheroes2/resource/maps_text.cpp:120
-msgid "Avone"
-msgstr "Avone"
-
-#: ../fheroes2/resource/maps_text.cpp:121
-msgid ""
-"A wild magic has allowed a bridge to form between two lands...  Your one "
-"hope is to capture castle \"Black Fang\"."
-msgstr ""
-"Una magia salvaje ha permitido que se formara un puente entre dos tierras... "
-"Tu única esperanza es capturar el castillo \"Colmillo Negro\"."
-
-#: ../fheroes2/resource/maps_text.cpp:122
-msgid "Barbarian's castle lies to the south."
-msgstr "El castillo de los bárbaros se encuentra al sur."
-
-#: ../fheroes2/resource/maps_text.cpp:123
-msgid ""
-"Barbarians from the north threaten all civilization. Can you repel the "
-"hordes?"
-msgstr ""
-"Bárbaros del norte amenazan toda civilización. ¿Puedes repeler sus hordas?"
-
-#: ../fheroes2/resource/maps_text.cpp:124
-msgid "\"Barbarian Wars\""
-msgstr "\"Guerras Barbaras\""
-
-#: ../fheroes2/resource/maps_text.cpp:125
-msgid "Barrowton"
-msgstr "Barrowton"
-
-#: ../fheroes2/resource/maps_text.cpp:126
-msgid "Basenji"
-msgstr "Basenji"
-
-#: ../fheroes2/resource/maps_text.cpp:127
-msgid "Bayside"
-msgstr "Junto a la bahía"
-
-#: ../fheroes2/resource/maps_text.cpp:128
-msgid "Baywatch"
-msgstr "Vigilantes de la playa"
-
-#: ../fheroes2/resource/maps_text.cpp:129
-msgid ""
-"Because the Darkscale Valley is so barren, the Emperor will be sending wood "
-"to you every week. Use it wisely, for it is all you shall have."
-msgstr ""
-"Al ser el Valle Escamaoscura tan desolado el Emperador te enviará madera "
-"cada semana. Úsala con sabiduría, pues es toda la que tendrás."
-
-#: ../fheroes2/resource/maps_text.cpp:130
-msgid ""
-"Before questing for the orb of negation, you must first crush the local "
-"opposition. After the Sorceresses are removed from the earth, go east where "
-"legend says the orb lies.  You may expect a convoy of supplies in a week or "
-"so to aid your conquest."
-msgstr ""
-"Antes de partir en busca de el Orbe de Negación, primero debes aplastar la "
-"oposición local. Una vez que las Hechiceras hayan sido eliminadas de la faz "
-"de la Tierra, dirígete al este, donde dice la leyenda que se encuentra el "
-"orbe. Puedes esperar que un convoy con suministros llegue en cosa de una "
-"semana para ayudarte con tu conquista."
-
-#: ../fheroes2/resource/maps_text.cpp:131
-msgid ""
-"Before you may pass, the spirit guardian of this valley demands tribute."
-msgstr ""
-"Antes de dejarte pasar, el espíritu guardián de este valle demanda tributo."
-
-#: ../fheroes2/resource/maps_text.cpp:132
-msgid "Being held...."
-msgstr "Ser retenido..."
-
-#: ../fheroes2/resource/maps_text.cpp:133
-msgid "Beltway"
-msgstr "Beltway"
-
-#: ../fheroes2/resource/maps_text.cpp:134
-msgid "\"Betrayal!\""
-msgstr "\"¡Traición!\""
-
-#: ../fheroes2/resource/maps_text.cpp:135
-msgid "Beware -- Entering Hyrda Country"
-msgstr "Precaución -- Está entrando en el País de Hyrda"
-
-#: ../fheroes2/resource/maps_text.cpp:136
-msgid "Beware for whom the bell trolls."
-msgstr "Cuidado con por quién trolean las campanas."
-
-#: ../fheroes2/resource/maps_text.cpp:137
-msgid "Beware of Pirates!"
-msgstr "¡Cuidado con los Piratas!"
-
-#: ../fheroes2/resource/maps_text.cpp:138
-msgid "Beware of thieves!"
-msgstr "¡Cuidado con los ladrones!"
-
-#: ../fheroes2/resource/maps_text.cpp:139
-msgid "Beware of traps ahead."
-msgstr "Cuidado con las trampas."
-
-#: ../fheroes2/resource/maps_text.cpp:140
-msgid "Beware of Warlocks"
-msgstr "¡Cuidado con los hechiceros!"
-
-#: ../fheroes2/resource/maps_text.cpp:141
-msgid "Beware the deadly swamps!"
-msgstr "¡Cuidado con los pantanos mortíferos!"
-
-#: ../fheroes2/resource/maps_text.cpp:142
-msgid "Beware the Domain of Dragons"
-msgstr "Cuidado con el Dominio de los Dragones"
-
-#: ../fheroes2/resource/maps_text.cpp:143
-msgid "Beware the Dragon Leader"
-msgstr "Cuidado cno el Líder Dragon"
-
-#: ../fheroes2/resource/maps_text.cpp:144
-msgid "Beware the edge of the world!"
-msgstr "¡Cuidado con el borde del mundo!"
-
-#: ../fheroes2/resource/maps_text.cpp:145
-msgid "Beware the moors and stick to the roads."
-msgstr "Cuidado con los páramos y manténte en las carreteras."
-
-#: ../fheroes2/resource/maps_text.cpp:146
-msgid "Beware the rocks"
-msgstr "Cuidado con las rocas"
-
-#: ../fheroes2/resource/maps_text.cpp:147
-msgid "Beware the sirens!!!"
-msgstr "¡¡Cuidado con las sirenas!!"
-
-#: ../fheroes2/resource/maps_text.cpp:148
-msgid "Beware the sirens!"
-msgstr "¡Cuidado con las sirenas!"
-
-#: ../fheroes2/resource/maps_text.cpp:149
-msgid "Beware the whiporwill..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:150
-msgid "Beware, the whirlpool may not take you into a friendly embrace."
-msgstr "Cuidado, el torbellino puede que no te dé un abrazo amigable."
-
-#: ../fheroes2/resource/maps_text.cpp:151
-msgid "Beyond here be Dragons!"
-msgstr "¡Más allá de aqui estan los dragones!"
-
-#: ../fheroes2/resource/maps_text.cpp:152
-msgid "Beyond the door, there be Dragons. BEWARE!"
-msgstr "Más allá de la puerta hay Dragones. ¡CUIDADO!"
-
-#: ../fheroes2/resource/maps_text.cpp:153
-msgid "Big Oak"
-msgstr "Roble Grande"
-
-#: ../fheroes2/resource/maps_text.cpp:154
-msgid "Blackburn"
-msgstr "Blackburn"
-
-#: ../fheroes2/resource/maps_text.cpp:155
-msgid "Blackfang"
-msgstr "Colmillonegro"
-
-#: ../fheroes2/resource/maps_text.cpp:156
-msgid "Black Fang"
-msgstr "Comillo Negro"
-
-#: ../fheroes2/resource/maps_text.cpp:157
-msgid "Black Oak"
-msgstr "Roble Negro"
-
-#: ../fheroes2/resource/maps_text.cpp:158
-msgid "Blackridge"
-msgstr "Crestanegra"
-
-#: ../fheroes2/resource/maps_text.cpp:159
-msgid "Blacksford"
-msgstr "Vadonegro"
-
-#: ../fheroes2/resource/maps_text.cpp:160
-msgid "Black Vein"
-msgstr "Vena Negra"
-
-#: ../fheroes2/resource/maps_text.cpp:161
-msgid "Blackwind"
-msgstr "Vientonegro"
-
-#: ../fheroes2/resource/maps_text.cpp:162
-msgid "Bloodreign"
-msgstr "Reinosangriento"
-
-#: ../fheroes2/resource/maps_text.cpp:163
-msgid "Boats my be needed to access some parts of this peninsula."
-msgstr "Se necesitarán botes para acceder a algunas partes de esta península."
-
-#: ../fheroes2/resource/maps_text.cpp:164
-msgid "Boats Sold Here            Inquire Within"
-msgstr "Se venden botes. Razón aquí."
-
-#: ../fheroes2/resource/maps_text.cpp:165
-msgid "BoneVille"
-msgstr "VillaHuesos"
-
-#: ../fheroes2/resource/maps_text.cpp:166
-msgid "Borderlands"
-msgstr "Tierras fronterizas"
-
-#: ../fheroes2/resource/maps_text.cpp:167
-msgid "Bridge out!"
-msgstr "¡Puente ausente!"
-
-#: ../fheroes2/resource/maps_text.cpp:168
-msgid "Bridge Out!"
-msgstr "¡Puente fuera!"
-
-#: ../fheroes2/resource/maps_text.cpp:169
-msgid "Brindamoor"
-msgstr "Brindamoor"
-
-#: ../fheroes2/resource/maps_text.cpp:170
-msgid "Broken Alliance"
-msgstr "Alianza Rota"
-
-#: ../fheroes2/resource/maps_text.cpp:171
-msgid "Brownston"
-msgstr "Brownston"
-
-#: ../fheroes2/resource/maps_text.cpp:172
-msgid "Buried Treasure!"
-msgstr "¡Tesoro enterrado!"
-
-#: ../fheroes2/resource/maps_text.cpp:173
-msgid "Burlock"
-msgstr "Burlock"
-
-#: ../fheroes2/resource/maps_text.cpp:174
-msgid "Burton"
-msgstr "Burton"
-
-#: ../fheroes2/resource/maps_text.cpp:175
-msgid ""
-"Capture the necromancer's dreaded castle \"Death Gate\" and free the land "
-"from the undead plague."
-msgstr ""
-"Captura el temido castillo del necromante \"Puerta de la Muerte\" y libera "
-"la tierra de la plaga de no-muertos."
-
-#: ../fheroes2/resource/maps_text.cpp:176
-msgid ""
-"Capture the town on the island off the southeast shore in order to construct "
-"a boat and travel back towards the mainland."
-msgstr ""
-"Captura la ciudad de la isla en la costa sureste para construir un barco y "
-"navegar de vuelta al continente."
-
-#: ../fheroes2/resource/maps_text.cpp:177
-msgid "\"Carator Mines\""
-msgstr "\"Minas Carator\""
-
-#: ../fheroes2/resource/maps_text.cpp:178
-msgid "Cathcart"
-msgstr "Cathcart"
-
-#: ../fheroes2/resource/maps_text.cpp:180
-msgid "Chandler"
-msgstr "Chandler"
-
-#: ../fheroes2/resource/maps_text.cpp:181
-msgid "Chilton"
-msgstr "Chilton"
-
-#: ../fheroes2/resource/maps_text.cpp:182
-msgid "Chronos"
-msgstr "Chronos"
-
-#: ../fheroes2/resource/maps_text.cpp:183
-msgid "Come and...."
-msgstr "Ven y..."
-
-#: ../fheroes2/resource/maps_text.cpp:184
-msgid ""
-"Compared to the rest of the villages in this land, this village seems grand, "
-"but in any other land it would seem poor. From here you can see the tall "
-"spires of the Warlock's tower of Dragons."
-msgstr ""
-"Comparada con el resto de los pueblos de esta tierra, este pueblo parece "
-"grande, pero en cualquier otra parte se le consideraría pobre. Desde aquí "
-"puedes ver las altas espiras de la torre de Dragones del Hechicero."
-
-#: ../fheroes2/resource/maps_text.cpp:185
-msgid "Complete"
-msgstr "Completo"
-
-#: ../fheroes2/resource/maps_text.cpp:186
-msgid "Condemned!"
-msgstr "¡Condenado!"
-
-#: ../fheroes2/resource/maps_text.cpp:187
-msgid ""
-"Congratulations! After navigating the treacherous coast, you have "
-"established trade between the north and south."
-msgstr ""
-"¡Enhorabuena! Después de navegar por la traicionera costa, has establecido "
-"rutas de comercio entre el norte y el sur."
-
-#: ../fheroes2/resource/maps_text.cpp:188
-msgid "Corackston"
-msgstr "Corackston"
-
-#: ../fheroes2/resource/maps_text.cpp:189
-msgid "Corlagon"
-msgstr "Corlagon"
-
-#: ../fheroes2/resource/maps_text.cpp:190
-msgid "\"Country Lords\""
-msgstr "\"Señores del Pais\""
-
-#: ../fheroes2/resource/maps_text.cpp:191
-msgid "Crossroads"
-msgstr "Encrucijada"
-
-#: ../fheroes2/resource/maps_text.cpp:192
-msgid "Crossroads North"
-msgstr "Encrucijada Norte"
-
-#: ../fheroes2/resource/maps_text.cpp:193
-msgid "Crossroads South"
-msgstr "Encrucijada Sur"
-
-#: ../fheroes2/resource/maps_text.cpp:195
-msgid "Danger a whirlpool destroyed my ship."
-msgstr "Peligro, un remolino destruyó mi barco."
-
-#: ../fheroes2/resource/maps_text.cpp:196
-msgid "Danger, Dragons abound!"
-msgstr "¡Peligro, abundancia de Dragones!"
-
-#: ../fheroes2/resource/maps_text.cpp:197
-msgid "DANGER!  QUICKSAND!"
-msgstr "¡PELIGRO! ¡ARENAS MOVEDIZAS!"
-
-#: ../fheroes2/resource/maps_text.cpp:198
-msgid "Danger! Troll bridge ahead!"
-msgstr "¡Peligro! ¡Puente de troll delante!"
-
-#: ../fheroes2/resource/maps_text.cpp:199
-msgid "Danger - Turn Back Now"
-msgstr "Peligro - Vuelve Atrás Ahora"
-
-#: ../fheroes2/resource/maps_text.cpp:200
-msgid "Dark clouds loom overhead as you enter this valley."
-msgstr "Oscuras nubes se ciernen sobre tu cabeza al entrar en este valle."
-
-#: ../fheroes2/resource/maps_text.cpp:201
-msgid "Dead Pine"
-msgstr "Pino Muerto"
-
-#: ../fheroes2/resource/maps_text.cpp:202
-msgid ""
-"Dear Diary,                           I found a mermaid today.  She was "
-"floating in a patch of seaweed next to a rock.  A very friendly sort of "
-"creature too!  Gave me all sorts of lovely gems and jewelry!  She said to "
-"come back again sometime for more of the sea riches.  Wow. Ahab"
-msgstr ""
-"Querido Diario: hoy he encontrado una sirena. Estaba flotando en un bancal "
-"de algas, junto a una roca. ¡Es una criatura muy amistosa! ¡Me entregó todo "
-"tipo de gemas y joyería! Ella dijo que volviera más tarde a por más riquezas "
-"del mar. Vaya. Ahab"
-
-#: ../fheroes2/resource/maps_text.cpp:203
-msgid "Deathgate"
-msgstr "Puerta de la muerte"
-
-#: ../fheroes2/resource/maps_text.cpp:204
-msgid "DeathGate"
-msgstr "Puerta de la Muerte"
-
-#: ../fheroes2/resource/maps_text.cpp:205
-msgid "Decisions"
-msgstr "Decisiones"
-
-#: ../fheroes2/resource/maps_text.cpp:206
-msgid "\"Defender\""
-msgstr "\"Defensor\""
-
-#: ../fheroes2/resource/maps_text.cpp:207
-msgid ""
-"Destroy the Barbarians who are attacking the southern border of your "
-"kingdom! Recover your towns and then invade the jungle kingdom."
-msgstr ""
-"¡Destruye a los Bárbaros que están atacando la frontera sur de tu reino! "
-"Recupera tus ciudades y entonces invade el reino jungla."
-
-#: ../fheroes2/resource/maps_text.cpp:208
-msgid ""
-"Detour! Mountain pass to the East has been known to have avalanches! For "
-"your own safety, follow the road South."
-msgstr ""
-"¡Desvío! El paso de montaña al Este es conocido por sus avalanchas. Por tu "
-"propia seguridad, sigue la carretera al Sur."
-
-#: ../fheroes2/resource/maps_text.cpp:209
-msgid "Detour! Troll bridge ahead!"
-msgstr "¡Desvio! ¡Puente de troll delante!"
-
-#: ../fheroes2/resource/maps_text.cpp:211
-msgid "DirtWater"
-msgstr "Aguasucia"
-
-#: ../fheroes2/resource/maps_text.cpp:212
-msgid "Dominion"
-msgstr "Dominio"
-
-#: ../fheroes2/resource/maps_text.cpp:213
-msgid "Do Not Enter!"
-msgstr "¡No Entrar!"
-
-#: ../fheroes2/resource/maps_text.cpp:214
-msgid "Do not remove coins from fountain."
-msgstr "No se lleven las monedas de la fuente."
-
-#: ../fheroes2/resource/maps_text.cpp:215
-msgid "Dragadune"
-msgstr "Dragadune"
-
-#: ../fheroes2/resource/maps_text.cpp:216
-msgid "Dragonburg"
-msgstr "Dragomburgo"
-
-#: ../fheroes2/resource/maps_text.cpp:218
-msgid "Dragon City lies beyond the Scorpion Hills."
-msgstr "Ciudad Dragón se encuentra más allá de las Colinas Escorpión."
-
-#: ../fheroes2/resource/maps_text.cpp:219
-msgid "Dragon Hill"
-msgstr "Colina del Dragón"
-
-#: ../fheroes2/resource/maps_text.cpp:220
-msgid "\"Dragon Master\""
-msgstr "\"Maestro Dragón\""
-
-#: ../fheroes2/resource/maps_text.cpp:221
-msgid "Dragon Rider"
-msgstr "Jinete de Dragones"
-
-#: ../fheroes2/resource/maps_text.cpp:222
-msgid "Dragons Everywhere!"
-msgstr "¡Dragones por todos lados!"
-
-#: ../fheroes2/resource/maps_text.cpp:223
-msgid "Dragon's Eye"
-msgstr "Ojo de Dragón"
-
-#: ../fheroes2/resource/maps_text.cpp:224
-msgid "Dragontooth"
-msgstr "Diente de Dragón"
-
-#: ../fheroes2/resource/maps_text.cpp:225
-msgid "Dragon Town"
-msgstr "Ciudad Dragón"
-
-#: ../fheroes2/resource/maps_text.cpp:226
-msgid "Dragonville"
-msgstr "Pueblo Dragón"
-
-#: ../fheroes2/resource/maps_text.cpp:227
-msgid "Dragon Wars"
-msgstr "Guerras Dragón"
-
-#: ../fheroes2/resource/maps_text.cpp:228
-msgid "Dragon Watch"
-msgstr "Guardian Dragón"
-
-#: ../fheroes2/resource/maps_text.cpp:230
-msgid "Drakoran"
-msgstr "Drakoran"
-
-#: ../fheroes2/resource/maps_text.cpp:231
-msgid "Dwarfhall"
-msgstr "Dwarfhall"
-
-#: ../fheroes2/resource/maps_text.cpp:232
-msgid "Dwarfhall, Domain of the dwarf King."
-msgstr "Dwarfhall, Dominio del Rey Enano."
-
-#: ../fheroes2/resource/maps_text.cpp:233
-msgid "Dwarf Hall, domain of the dwarf King."
-msgstr "Camara Enana, dominio del Rey enano."
-
-#: ../fheroes2/resource/maps_text.cpp:234
-msgid "Eatio"
-msgstr "Eatio"
-
-#: ../fheroes2/resource/maps_text.cpp:235
-msgid "Edgewood"
-msgstr "Edgewood"
-
-#: ../fheroes2/resource/maps_text.cpp:236
-msgid "Elk's Head"
-msgstr "Cabeza de Alce"
-
-#: ../fheroes2/resource/maps_text.cpp:237
-msgid "Elowyn"
-msgstr "Elowyn"
-
-#: ../fheroes2/resource/maps_text.cpp:238
-msgid "Enroth"
-msgstr "Enroth"
-
-#: ../fheroes2/resource/maps_text.cpp:239
-msgid "Entering high in the desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:240
-msgid "Entering Praires of the Middlelands"
-msgstr "Entrando en las Praderas de las Tierras Medias"
-
-#: ../fheroes2/resource/maps_text.cpp:241
-msgid "Entering the desert high"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:242
-msgid "Entering the high desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:243
-msgid "Entering the higher desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:244
-msgid "Entering the Valley of Magic"
-msgstr "Entrando en el Valle de la Magia"
-
-#: ../fheroes2/resource/maps_text.cpp:245
-msgid "Erliquin"
-msgstr "Erliquin"
-
-#: ../fheroes2/resource/maps_text.cpp:246
-msgid "Evil Igor"
-msgstr "Malvado Igor"
-
-#: ../fheroes2/resource/maps_text.cpp:247
-msgid "Fadlan"
-msgstr "Fadlan"
-
-#: ../fheroes2/resource/maps_text.cpp:248
-msgid "Fantasy Island."
-msgstr "Isla de Fantasía."
-
-#: ../fheroes2/resource/maps_text.cpp:249
-msgid "Farlien"
-msgstr "Farlien"
-
-#: ../fheroes2/resource/maps_text.cpp:250
-msgid ""
-"Federal express, when it absolutely positively has to be there turn one."
-msgstr ""
-"Federal Express, cuando absolutamente y positivamente tiene que estar allí "
-"en el turno uno."
-
-#: ../fheroes2/resource/maps_text.cpp:251
-msgid "fedx comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:252
-msgid "Fedx for comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:253
-msgid "Fenton"
-msgstr "Fenton"
-
-#: ../fheroes2/resource/maps_text.cpp:254
-msgid "Fetid Elm"
-msgstr "Olmo Fétido"
-
-#: ../fheroes2/resource/maps_text.cpp:255
-msgid ""
-"Final message from Overlord. \"The royal executioners are on their way. My "
-"gold, the land or your head- it's your choice.\""
-msgstr ""
-"Mensaje final del Jefe Supremo: \"Los ejecutores reales están en camino. Mi "
-"oro, la tierra o vuestra cabeza - vos elegís.\""
-
-#: ../fheroes2/resource/maps_text.cpp:256
-msgid "Find and defeat the Pirate Leader!"
-msgstr "¡Busca y derrota al Líder Pirata!"
-
-#: ../fheroes2/resource/maps_text.cpp:257
-msgid "Find and destroy the evil beings who rule the wastelands."
-msgstr "Busca y destruye a las malvadas criaturas que gobiernan los páramos."
-
-#: ../fheroes2/resource/maps_text.cpp:258
-msgid "Find the center island."
-msgstr "Encuentra la isla central."
-
-#: ../fheroes2/resource/maps_text.cpp:259
-msgid ""
-"Find the Ultimate Artifact and be proclaimed King, or smash the opposition "
-"and take control."
-msgstr ""
-"Encuentra el Artefacto Definitivo y sé proclamado Rey, o aplasta la oposción "
-"y toma el control."
-
-#: ../fheroes2/resource/maps_text.cpp:260
-msgid ""
-"Find Your Wayward Son who is rumored to be living in the desolate lands. Do "
-"it within 8 weeks or it will be of no help to your family."
-msgstr ""
-"Encuentra a tu caprichoso hijo, del que se rumorea que vive en las tierras "
-"desoladas. Házlo en menos de 8 semanas o no será de ninguna ayuda para tu "
-"familia."
-
-#: ../fheroes2/resource/maps_text.cpp:261
-msgid "Fire King"
-msgstr "Rey de Fuego"
-
-#: ../fheroes2/resource/maps_text.cpp:262
-msgid "\"First Blood\""
-msgstr "\"Primera Sangre\""
-
-#: ../fheroes2/resource/maps_text.cpp:263
-msgid "Five heroes vie for control of a familiar land."
-msgstr "Cinco héroes rivalizan por controlar una tierra familiar."
-
-#: ../fheroes2/resource/maps_text.cpp:264
-msgid "Fool's Gold"
-msgstr "El Oro de los Necios"
-
-#: ../fheroes2/resource/maps_text.cpp:265
-msgid ""
-"For a total of 400,000 gold your opponents will become \"loyal\" subjects, "
-"otherwise... let them eat cake!"
-msgstr ""
-"Por un total de 400.000 de oro, tus oponentes se volverán sujetos \"leales"
-"\", si no... ¡Qué coman pasteles!"
-
-#: ../fheroes2/resource/maps_text.cpp:266
-msgid ""
-"For centuries, the Wizards of the North have maintained a vast library for "
-"all the world to share.  Now, however, they have closed their doors, and "
-"issued declarations of war to each of the other rulers of the land.  To make "
-"matters worse, rather than ally with you to face the Wizards, each of the "
-"others have decided to go forth on their own in an effort to conquer this "
-"land for themselves!  Prepare your forces, commander, for you now stand "
-"alone."
-msgstr ""
-"Durante siglos, los Magos del Norte han mantenido una enorme biblioteca para "
-"compartirla con el mundo. Ahora, sin embargo, han cerrado sus puertas, y han "
-"enviado declaraciones de guerra a cada uno de los otros señores de la "
-"tierra. Para empeorar las cosas, en lugar de aliarse contigo para enfrentar "
-"a los Magos, cada uno de los otros ha decidido ir por su cuenta, ¡en un "
-"intento de conquistar esta tierra para sí mismos! Prepara tus fuerzas, "
-"comandante, pues ahora estás solo."
-
-#: ../fheroes2/resource/maps_text.cpp:267
-msgid "\"Force of Arms\""
-msgstr "\"La Fuerza de las Armas\""
-
-#: ../fheroes2/resource/maps_text.cpp:268
-msgid ""
-"For decades you have studied, learned, and allowed yourself to be ruled by "
-"that pitiful excuse for a king, knowing that one day the time would come for "
-"you to sit on the throne.  That time is now, for the king is dead and "
-"without an heir.  You have the advantage of isolation from the rest of the "
-"kingdom, but beware the miles of coastline that could leave you vulnerable "
-"to attack.  Go, now, and wipe your enemies from this land!"
-msgstr ""
-"Durante décadas has estudiado, aprendido, y permitido a esa patética excusa "
-"de Rey gobernarte, sabedor de que un tiempo llegaría en el que serías tú "
-"quien se sentaría en el trono. Ese tiempo ha llegado, pues el rey ha muerto "
-"sin heredero. Tienes la ventaja del aislamiento del resto del reino, pero "
-"cuidado con las millas de costa que podrían dejarte vulnerable al ataque. "
-"¡Ve ahora, y barre de esta tierra a tus enemigos!"
-
-#: ../fheroes2/resource/maps_text.cpp:269
-msgid "Forder Oaks"
-msgstr "Forder Oaks"
-
-#: ../fheroes2/resource/maps_text.cpp:270
-msgid "Forestria"
-msgstr "Forestria"
-
-#: ../fheroes2/resource/maps_text.cpp:271
-msgid "For Honor"
-msgstr "Por Honor"
-
-#: ../fheroes2/resource/maps_text.cpp:272
-msgid ""
-"For information about Ye Rich lands to the south, speak to Alponse at the "
-"Golden Goose Tavern. Excellent views, plentiful water."
-msgstr ""
-"Para obtener información acerca de las Ricas tierras al sur, habla con "
-"Alponse en la Taberna del Ganso Dorado. Excelentes vistas, abundante agua."
-
-#: ../fheroes2/resource/maps_text.cpp:273
-msgid "Forsaken Lands"
-msgstr "Tierras Olvidadas"
-
-#: ../fheroes2/resource/maps_text.cpp:274
-msgid "For sale."
-msgstr "Se vende."
-
-#: ../fheroes2/resource/maps_text.cpp:275
-msgid "Fortress Isle"
-msgstr "Isla Fortaleza"
-
-#: ../fheroes2/resource/maps_text.cpp:276
-msgid ""
-"For years, you have existed peacefully in the Forest of Dreams, knowing that "
-"your king was the kindest and strongest ruler the land had seen in "
-"centuries.  Now, however, his reign is at an end, and there is no heir to "
-"succeed him.  You realize that a power struggle is coming, and that you must "
-"brace yourself for war, and prevent those who would harm this land from "
-"coming into power!"
-msgstr ""
-"Durante años, has vivido en paz en el Bosque de los Sueños, sabiendo que tu "
-"rey era el más amable y poderoso gobernante que la tierra hubiera visto en "
-"siglos. Ahora, sin embargo, su reinado finaliza, y no hay heredero que le "
-"suceda. Eres consciente de que se acerca una lucha por el poder, y que debes "
-"aprestarte al combate, para prevenir que los que dañarían esta tierra "
-"lleguen al poder."
-
-#: ../fheroes2/resource/maps_text.cpp:277
-msgid ""
-"For years, you've been able to keep your subjects \"appeased.\"  Now "
-"however, you discover not only that your entire kingdom has turned against "
-"you, but most of your outer towns have fallen to the different factions.  To "
-"make matters worse, all your gold suddenly seems to be missing from the "
-"treasury!"
-msgstr ""
-"Durante años has sido capaz de mantener a tus súbditos \"complacidos\". Sin "
-"embargo, ahora descubres no sólo que todo tu reino se ha vuelto contra ti, "
-"sino que tus ciudades más lejanas han caído a manos de distintas facciones. "
-"Para empeorar las cosas, ¡parece que ha desaparecido todo tu oro del tesoro!"
-
-#: ../fheroes2/resource/maps_text.cpp:278
-msgid "Fountainhead"
-msgstr "Cabezafuente"
-
-#: ../fheroes2/resource/maps_text.cpp:279
-msgid "Four kingdoms race to capture the island of Sharkania."
-msgstr "Cuatro reinos compiten para capturar la isla de Sharkania."
-
-#: ../fheroes2/resource/maps_text.cpp:280
-msgid "Four lakes have castles, three have treasure."
-msgstr "Cuatro lagos tienen castillos, tres tienen tesoros."
-
-#: ../fheroes2/resource/maps_text.cpp:281
-msgid "Four players must work together to assault the Wizards' Stronghold."
-msgstr ""
-"Para asaltar la Fortaleza de los Magos han de trabajar juntos cuatro "
-"jugadores."
-
-#: ../fheroes2/resource/maps_text.cpp:282
-msgid "Frozenpeak"
-msgstr "Picohelado"
-
-#: ../fheroes2/resource/maps_text.cpp:283
-msgid "Full House"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:284
-msgid ""
-"Gain the aid of the elves. They will not allow trees to be chopped down, so "
-"we will send you wood every 2 weeks. You have 7 months!"
-msgstr ""
-"Consigue la ayuda de los elfos. No permitirán que se talen árboles, así que "
-"te enviaremos madera cada 2 semanas. ¡Tienes 7 meses!"
-
-#: ../fheroes2/resource/maps_text.cpp:286
-msgid "Galveston"
-msgstr "Galveston"
-
-#: ../fheroes2/resource/maps_text.cpp:287
-msgid "Garamok"
-msgstr "Garamok"
-
-#: ../fheroes2/resource/maps_text.cpp:288
-msgid "Gate"
-msgstr "Puerta"
-
-#: ../fheroes2/resource/maps_text.cpp:289
-msgid "Gate to the Isle of Knowledge"
-msgstr "Puerta a la Isla del Conocimiento"
-
-#: ../fheroes2/resource/maps_text.cpp:290
-msgid "Gate to The Isle of Knowledge"
-msgstr "Puerta a La Isla del Conocimiento"
-
-#: ../fheroes2/resource/maps_text.cpp:291
-msgid "Gaurdian"
-msgstr "Guardián"
-
-#: ../fheroes2/resource/maps_text.cpp:292
-msgid "Gavonshire"
-msgstr "Gavonshire"
-
-#: ../fheroes2/resource/maps_text.cpp:294
-msgid "Glastonbury"
-msgstr "Glastonbury"
-
-#: ../fheroes2/resource/maps_text.cpp:295
-msgid "Go away!"
-msgstr "¡Largo!"
-
-#: ../fheroes2/resource/maps_text.cpp:296
-msgid "GO AWAY!"
-msgstr "¡LARGO!"
-
-#: ../fheroes2/resource/maps_text.cpp:297
-msgid "Goblin Island"
-msgstr "Isla Goblin"
-
-#: ../fheroes2/resource/maps_text.cpp:298
-msgid "Goblin King"
-msgstr "Rey Goblin"
-
-#: ../fheroes2/resource/maps_text.cpp:299
-msgid "Go Home!"
-msgstr "¡Vete a casa!"
-
-#: ../fheroes2/resource/maps_text.cpp:300
-msgid "Go north to find the lost gold-mine."
-msgstr "Dirígete al norte para encontrar la mina de oro perdida."
-
-#: ../fheroes2/resource/maps_text.cpp:301
-msgid "Good vs. Evil"
-msgstr "Bien vs. Mal"
-
-#: ../fheroes2/resource/maps_text.cpp:302
-msgid "Gorgomar"
-msgstr "Gorgomar"
-
-#: ../fheroes2/resource/maps_text.cpp:303
-msgid "\"Greater Glory\""
-msgstr "\"Gloria Mayor\""
-
-#: ../fheroes2/resource/maps_text.cpp:304
-msgid "Greed"
-msgstr "Codicia"
-
-#: ../fheroes2/resource/maps_text.cpp:305
-msgid "Green bonus stuff"
-msgstr "Bonificación del verde"
-
-#: ../fheroes2/resource/maps_text.cpp:306
-msgid "Green gets stuff"
-msgstr "El verde obtiene cosas"
-
-#: ../fheroes2/resource/maps_text.cpp:307
-msgid "Greenroot"
-msgstr "Raízverde"
-
-#: ../fheroes2/resource/maps_text.cpp:308
-msgid "Green's Allowance"
-msgstr "Complemento del Verde"
-
-#: ../fheroes2/resource/maps_text.cpp:309
-msgid "Green's Groceries"
-msgstr "Provisiones del Verde"
-
-#: ../fheroes2/resource/maps_text.cpp:310
-msgid "green stuff"
-msgstr "cosa verde"
-
-#: ../fheroes2/resource/maps_text.cpp:311
-msgid "Green stuff"
-msgstr "Cosa verde"
-
-#: ../fheroes2/resource/maps_text.cpp:312
-msgid "Greywind"
-msgstr "Vientogris"
-
-#: ../fheroes2/resource/maps_text.cpp:313
-msgid "Grim"
-msgstr "Siniestro"
-
-#: ../fheroes2/resource/maps_text.cpp:314
-msgid "Grrr, Blazzer, Grrupt. Be gone with you!"
-msgstr "Grrr, Blazzer, Grrupt. ¡Se ha ido contigo!"
-
-#: ../fheroes2/resource/maps_text.cpp:315
-msgid "Guardian War"
-msgstr "Guerra de Guardianes"
-
-#: ../fheroes2/resource/maps_text.cpp:316
-msgid "Gungtooth"
-msgstr "Gungtooth"
-
-#: ../fheroes2/resource/maps_text.cpp:317
-msgid "Hail Unicorns!"
-msgstr "¡Hurra por los Unicornios!"
-
-#: ../fheroes2/resource/maps_text.cpp:318
-msgid "Hampshire"
-msgstr "Hampshire"
-
-#: ../fheroes2/resource/maps_text.cpp:319
-msgid "Have fun storming the castle!"
-msgstr "¡Diviértete asaltando el castillo!"
-
-#: ../fheroes2/resource/maps_text.cpp:320
-msgid "Havenwood"
-msgstr "Havenwood"
-
-#: ../fheroes2/resource/maps_text.cpp:321
-msgid "Hawkins"
-msgstr "Hawkins"
-
-#: ../fheroes2/resource/maps_text.cpp:322
-msgid "Help!"
-msgstr "¡Ayuda!"
-
-#: ../fheroes2/resource/maps_text.cpp:323
-msgid "Help me...."
-msgstr "Ayúdame..."
-
-#: ../fheroes2/resource/maps_text.cpp:324
-msgid ""
-"Help peasant farmers regain their castle and land, else they'll take your "
-"crops."
-msgstr ""
-"Ayuda a los campesinos a recuperar su castillo y sus tierras, o de otro modo "
-"tomarán tus cosechas."
-
-#: ../fheroes2/resource/maps_text.cpp:325
-msgid "Hero's Hall"
-msgstr "Salón de los Héroes"
-
-#: ../fheroes2/resource/maps_text.cpp:326
-msgid ""
-"High in the snowy crags, you meet an old witch who, in return for a trinket "
-"of yours, gives you a powerful magical object she used to use as a footstool "
-"before she was exiled into the mountains by her own townspeople."
-msgstr ""
-"En lo alto de los riscos nevados te encuentras con una vieja bruja, que a "
-"cambio de un pendiente, te da un poderoso objeto mágico que solía usar como "
-"escabel antes de ser exiliada a las montañas por sus propios vecinos."
-
-#: ../fheroes2/resource/maps_text.cpp:327
-msgid "Hillstone"
-msgstr "Colinapedregosa"
-
-#: ../fheroes2/resource/maps_text.cpp:328
-msgid "Hilltop"
-msgstr "Cumbre"
-
-#: ../fheroes2/resource/maps_text.cpp:329
-msgid "Hilltown"
-msgstr "Hilltown"
-
-#: ../fheroes2/resource/maps_text.cpp:330
-msgid "Horizon"
-msgstr "Horizonte"
-
-#: ../fheroes2/resource/maps_text.cpp:331
-msgid "Hot Spot"
-msgstr "Punto Caliente"
-
-#: ../fheroes2/resource/maps_text.cpp:332
-msgid "Hungry dragons await.  Welcome, food."
-msgstr "Dragones hambrientos esperan. Bienvenida, comida."
-
-#: ../fheroes2/resource/maps_text.cpp:333
-msgid "Hurry, no time to wait.  This way to the dock."
-msgstr "Apresúrate, no hay tiempo para esperar. Al muelle."
-
-#: ../fheroes2/resource/maps_text.cpp:334
-msgid "Hurry up! Few days are left before the enemy's army arrives."
-msgstr "¡Date prisa! Quedan pocos días para que el ejercito enemigo llegue."
-
-#: ../fheroes2/resource/maps_text.cpp:335
-msgid "I am...."
-msgstr "Yo soy..."
-
-#: ../fheroes2/resource/maps_text.cpp:336
-msgid ""
-"I am one of the few remaining survivors of the wrecked pleasure ship, "
-"Exhorbitance. I think we'll all be dead of hunger soon, for we are out of "
-"caviar. We ate the chef yesterday."
-msgstr ""
-"Soy uno de los pocos supervivientes del naufragio del crucero de placer "
-"Exhorbitance. Creo que pronto moriremos de hambre, pues se nos ha acabado el "
-"caviar. Ayer nos comimos al chef."
-
-#: ../fheroes2/resource/maps_text.cpp:337
-msgid "Ibn Fadlan"
-msgstr "Ibn Fadlan"
-
-#: ../fheroes2/resource/maps_text.cpp:338
-msgid "Ice Palace"
-msgstr "Palacio de Hielo"
-
-#: ../fheroes2/resource/maps_text.cpp:339
-msgid "Ice Prince"
-msgstr "Príncipe de Hielo"
-
-#: ../fheroes2/resource/maps_text.cpp:340
-msgid "Icy lands ahead."
-msgstr "Tierras heladas más adelante."
-
-#: ../fheroes2/resource/maps_text.cpp:341
-msgid "I didn't do it!"
-msgstr "¡Yo no he sido!"
-
-#: ../fheroes2/resource/maps_text.cpp:342
-msgid ""
-"If three heroes could dig six holes in three days, how long would it take "
-"six heroes to dig twelve holes?"
-msgstr ""
-"Si tres héroes pueden cavar seis hoyos en tres días, ¿cuánto le llevará a "
-"seis héroes cavar doce hoyos?"
-
-#: ../fheroes2/resource/maps_text.cpp:343
-msgid "If you free a hero, they may help..."
-msgstr "Si liberaras a un héroe, ellos tal vez ayudarían..."
-
-#: ../fheroes2/resource/maps_text.cpp:344
-msgid ""
-"If you value your lives, for God's sake, Don't go through this whirlpool!"
-msgstr ""
-"Si teneis aprecio a la vida, por el amor de Dios, ¡no atraveseis este "
-"remolino!"
-
-#: ../fheroes2/resource/maps_text.cpp:345
-msgid "Income for Yellow."
-msgstr "Ingresos para el Amarillo"
-
-#: ../fheroes2/resource/maps_text.cpp:346
-msgid "In the hole you find a chunk of ore!"
-msgstr "¡Encuentras una mena de mineral en el agujero!"
-
-#: ../fheroes2/resource/maps_text.cpp:347
-msgid "In the stream you find an old compass!"
-msgstr "¡Encuentras una brújula en la corriente!"
-
-#: ../fheroes2/resource/maps_text.cpp:348
-msgid "In this glen live some very naughty halflings. Stay Away!"
-msgstr "En esta cañada vivlen algunos traviesos Medianos. ¡Aléjate!"
-
-#: ../fheroes2/resource/maps_text.cpp:349
-msgid ""
-"In two more weeks, if you have not located Joseph, your kingdom will surely "
-"lose its current battle with Harondale."
-msgstr ""
-"Si en dos semanas no has localizado a Joseph, tu reino perderá con seguridad "
-"su batalla en curso con Harondale."
-
-#: ../fheroes2/resource/maps_text.cpp:350
-msgid "I see you, you see me."
-msgstr "Te veo, me ves."
-
-#: ../fheroes2/resource/maps_text.cpp:351
-msgid "Is it something I said? Go back and I will forget the whole thing."
-msgstr "¿Es algo que dije? Vuelve atrás y olvidaré todo el asunto."
-
-#: ../fheroes2/resource/maps_text.cpp:352
-msgid "IslandHome"
-msgstr "IslaHogar"
-
-#: ../fheroes2/resource/maps_text.cpp:353
-msgid "Island of the Elves"
-msgstr "Isla de los Elfos"
-
-#: ../fheroes2/resource/maps_text.cpp:354
-msgid "Island of the meek"
-msgstr "Isla de los mansos"
-
-#: ../fheroes2/resource/maps_text.cpp:355
-msgid "Island of Wolcott"
-msgstr "Isla de Wolcott"
-
-#: ../fheroes2/resource/maps_text.cpp:356
-msgid "Isle Maze"
-msgstr "Isla Laberinto"
-
-#: ../fheroes2/resource/maps_text.cpp:357
-msgid "Isle of Knowledge"
-msgstr "Isla de Conocimiento"
-
-#: ../fheroes2/resource/maps_text.cpp:358
-msgid ""
-"It has become apparent that if all your enemies were eliminated, you would "
-"have all the time you need to find the Ultimate Artifact."
-msgstr ""
-"Es bastante claro que si todos tus enemigos fueran eliminados, tendrías todo "
-"el tiempo que necesitas para encontrar el Artefacto Definitivo."
-
-#: ../fheroes2/resource/maps_text.cpp:359
-msgid ""
-"It is obvious that the mage that once was here had won many battles!  There, "
-"upon his hand, is a most powerful ring!"
-msgstr ""
-"¡Es obvio que el mago que estuvo una vez aquí ganó muchas batallas! Ahí, en "
-"su mano, ¡hay un poderoso anillo!"
-
-#: ../fheroes2/resource/maps_text.cpp:360
-msgid ""
-"It is rumored that a bridge of land used to exist between the two "
-"continents, but that a wild magic caused it to sink into the sea, taking "
-"with it all those who used to inhabit it.  To try to raise this bridge is to "
-"invite a curse upon the world!  The spirits of the dead will haunt us all!"
-msgstr ""
-"Se rumorea que solía haber un puente de tierra entre los dos continentes, "
-"pero que una magia salvaje lo hizo hundirse en el mar, llevándose consigo a "
-"todos los que vivían allí. ¡Intentar levantar este puente es atraer una "
-"maldición sobre el mundo! ¡Los espíritus de los muertos nos atormentarán a "
-"todos!"
-
-#: ../fheroes2/resource/maps_text.cpp:361
-msgid ""
-"It is said that King Zealot found the gods' artifact once and it let him "
-"rule for 100 years."
-msgstr ""
-"Se dice que el Rey Fanático encontró el artefacto de los dioses, y éste le "
-"permitió gobernar por 100 años."
-
-#: ../fheroes2/resource/maps_text.cpp:362
-msgid ""
-"It looks like there used to be an ore mine here but all you see now is a "
-"hole in the ground and some minerals scattered around."
-msgstr ""
-"Parece que aquí había una mina de mineral, pero todo lo que ves ahora es un "
-"agujero en la tierra y algunos minerales desperdigados."
-
-#: ../fheroes2/resource/maps_text.cpp:363
-msgid ""
-"It's a battle for supremacy as the Blue and Green heroes take on Red and "
-"Orange in team competition!"
-msgstr ""
-"¡Es una batalla por la supremacía donde los heroes Azul y Verde se enfrentan "
-"a los heroes Rojo y Naranja en una competición por equipos!"
-
-#: ../fheroes2/resource/maps_text.cpp:364
-msgid "It's windy at the top.  Defend, Divide, and Conquer."
-msgstr "Hace viento en la cima. Defiende, Divide, y Conquista."
-
-#: ../fheroes2/resource/maps_text.cpp:365
-msgid "IvanHome"
-msgstr "CasaIván"
-
-#: ../fheroes2/resource/maps_text.cpp:366
-msgid "Ivan lives in the desert."
-msgstr "Ivan vive en el desierto."
-
-#: ../fheroes2/resource/maps_text.cpp:367
-msgid "Ivory Gates"
-msgstr "Puertas de Marfil"
-
-#: ../fheroes2/resource/maps_text.cpp:368
-msgid ""
-"I, Wilgatus, besiege you - do not fight me for I am all powerful and will "
-"destroy you if you persue me.  I will demonstrate my power."
-msgstr ""
-"Yo, Wilgatus, te acecho - no luches contra mí, pues soy poderoso y te "
-"destruiré si me persigues. Te demostraré mi poder."
-
-#: ../fheroes2/resource/maps_text.cpp:369
-msgid "I Would Go That Way If I Were You."
-msgstr "Yo en tu lugar iría por ese camino."
-
-#: ../fheroes2/resource/maps_text.cpp:371
-msgid "Jarkonas VI"
-msgstr "Jarkonas VI"
-
-#: ../fheroes2/resource/maps_text.cpp:372
-msgid "Jolly Roger was here"
-msgstr "Jolly Roger estuvo aquí"
-
-#: ../fheroes2/resource/maps_text.cpp:374
-msgid "Jungomar"
-msgstr "Jungomar"
-
-#: ../fheroes2/resource/maps_text.cpp:375
-msgid "Just 30 days left!"
-msgstr "¡Sólo te quedan 30 días!"
-
-#: ../fheroes2/resource/maps_text.cpp:376
-msgid "Just ONE week left!"
-msgstr "¡Sólo te queda 1 semana!"
-
-#: ../fheroes2/resource/maps_text.cpp:378
-msgid "Kastor"
-msgstr "Kastor"
-
-#: ../fheroes2/resource/maps_text.cpp:379
-msgid "Keep going south"
-msgstr "Sigue hacia el sur"
-
-#: ../fheroes2/resource/maps_text.cpp:380
-msgid "Keep Off The Grass!"
-msgstr "¡Prohibido pisar la hierba!"
-
-#: ../fheroes2/resource/maps_text.cpp:381
-msgid "Keep Out!"
-msgstr "¡Largo!"
-
-#: ../fheroes2/resource/maps_text.cpp:382
-msgid "King John"
-msgstr "Rey John"
-
-#: ../fheroes2/resource/maps_text.cpp:383
-msgid "King of Death"
-msgstr "Rey de la Muerte"
-
-#: ../fheroes2/resource/maps_text.cpp:384
-msgid "Knight's Trail."
-msgstr "La Pista del Caballero."
-
-#: ../fheroes2/resource/maps_text.cpp:385
-msgid "Knight stuff"
-msgstr "Cosas del caballero"
-
-#: ../fheroes2/resource/maps_text.cpp:386
-msgid "Lakeside"
-msgstr "Lakeside"
-
-#: ../fheroes2/resource/maps_text.cpp:387
-msgid "Land's Edge"
-msgstr "El Borde de la Tierra"
-
-#: ../fheroes2/resource/maps_text.cpp:388
-msgid "Land teleporters will get you to your destination sooner."
-msgstr "Los teleportadores terrestres te llevarán más pronto a tu destino."
-
-#: ../fheroes2/resource/maps_text.cpp:389
-msgid "Lankershire"
-msgstr "Lankershire"
-
-#: ../fheroes2/resource/maps_text.cpp:390
-msgid "Lavalor"
-msgstr "Lavalor"
-
-#: ../fheroes2/resource/maps_text.cpp:391
-msgid "Like, Stuff And Junk?"
-msgstr "¿Quiere, Cosas y Trastos?"
-
-#: ../fheroes2/resource/maps_text.cpp:392
-msgid ""
-"Living on the outskirts of the kingdom, you are considered an unwelcome "
-"outcast by the other leaders of the realm, though you always showed your "
-"support for the king.  Now, however, the king is dead, and many of those who "
-"spoke out againt him seek to seize his throne for themselves.  You have a "
-"vast desert at your back, rich with gems, and the advantage that many do not "
-"consider you a threat.  Go, now, and show them how wrong they are!"
-msgstr ""
-"Al vivir en las afueras del reino, eres considerado como un paria por los "
-"otros líderes del reino, aunque siempre has mostrado tu apoyo al rey. Sin "
-"embargo, ahora el rey está muerto, y muchos de los que hablaban en su contra "
-"buscan ocupar el trono. Tienes un vasto desierto a tu espalda, rico en "
-"gemas, y la ventaja de que muchos no te consideran una amenaza. Ve ahora, y "
-"¡muéstrales cuánto se equivocan!"
-
-#: ../fheroes2/resource/maps_text.cpp:393
-msgid "Lladner Dock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:394
-msgid ""
-"Log go up... Log go down... Log go up... Log go down...  OOoohhhhhhhh........"
-msgstr ""
-"Tronco sube... Tronco baja... Tronco sube... Tronco baja... "
-"OOoohhhhhhhh........."
-
-#: ../fheroes2/resource/maps_text.cpp:395
-msgid "Lombard"
-msgstr "Lombardo"
-
-#: ../fheroes2/resource/maps_text.cpp:396
-msgid "Long live Roland the true King!"
-msgstr "¡Larga vida a Roland, el auténtico Rey!"
-
-#: ../fheroes2/resource/maps_text.cpp:397
-msgid "Long live Roland the true King."
-msgstr "Larga vida a Roland, el auténtico Rey."
-
-#: ../fheroes2/resource/maps_text.cpp:398
-msgid "Look before you leap."
-msgstr "Mira antes de saltar."
-
-#: ../fheroes2/resource/maps_text.cpp:399
-msgid "Look out!"
-msgstr "¡Cuidado!"
-
-#: ../fheroes2/resource/maps_text.cpp:400
-msgid "Lord Alberon"
-msgstr "Lord Alberon"
-
-#: ../fheroes2/resource/maps_text.cpp:401
-msgid ""
-"Lord Alberon calls you into his war room. He says, \"I am glad you have "
-"chosen to remain loyal to me, but this war is a terrible one for my kingdom. "
-"Already, the sorceress' towns to the Northeast have become unsure about "
-"their loyalties, and will not pledge allegiance to either side. This is hard "
-"on our cities as most of the wood in the land comes from these towns. We "
-"will need to recover their sawmills and take their towns by force.\""
-msgstr ""
-"Lord Alberon te convoca a su gabinete de guerra. Te dice, \"Estoy orgulloso "
-"de que hayas elegido mantenerte leal a mí, pero esta guerra está siendo "
-"terrible para mi reino. Las ciudades de la hechicera al noreste dudan acerca "
-"de su lealtad, y no rendirán pleitesía a ningún bando. Esto va a ser duro "
-"para nuestras ciudades, pues la mayoría de la madera proviene de esas "
-"ciudades. Necesitamos recuperar sus aserraderos y tomar sus ciudades por la "
-"fuerza.\""
-
-#: ../fheroes2/resource/maps_text.cpp:402
-msgid "Lord Haart"
-msgstr "Lord Haart"
-
-#: ../fheroes2/resource/maps_text.cpp:404
-msgid "Lord Kreager"
-msgstr "Lord Kreager"
-
-#: ../fheroes2/resource/maps_text.cpp:405
-msgid ""
-"Lord, messages have begun pouring in from our spies in the other island "
-"courts.  They have learned of a new volcanic island with vast amounts of "
-"reasources.  Your Majesty, with these new reasources we could put an end to "
-"a century of war between the islands, and reunite them under your rightful "
-"rule."
-msgstr ""
-"Señor, nos están llegando mensajes de nuestros espías en las cortes de las "
-"otras islas. Han tenido conocimiento de una nueva isla volcánica con un "
-"cantidad enorme de recursos. Su Majestad, con esos nuevos recursos podríamos "
-"poner fin a un siglo de guerra entre las islas, y reunirlas bajo vuestro "
-"justo dominio."
-
-#: ../fheroes2/resource/maps_text.cpp:406
-msgid "Lost Continent"
-msgstr "Continente Perdido"
-
-#: ../fheroes2/resource/maps_text.cpp:407
-msgid "Lost Gold- Mine"
-msgstr "Mina de oro perdida"
-
-#: ../fheroes2/resource/maps_text.cpp:408
-msgid "Lost Island."
-msgstr "Isla Perdida"
-
-#: ../fheroes2/resource/maps_text.cpp:409
-msgid "Lost Relic"
-msgstr "Reliquia Perdida"
-
-#: ../fheroes2/resource/maps_text.cpp:410
-msgid "Maelstrom of Deceit"
-msgstr "Vortice del Engaño"
-
-#: ../fheroes2/resource/maps_text.cpp:411
-msgid "Maelstrom of Misery"
-msgstr "Vortice de la Miseria"
-
-#: ../fheroes2/resource/maps_text.cpp:412
-msgid "Magic"
-msgstr "Magia"
-
-#: ../fheroes2/resource/maps_text.cpp:413
-msgid "Magic Three"
-msgstr "Árbol Mágico"
-
-#: ../fheroes2/resource/maps_text.cpp:414
-msgid ""
-"Many dust plumes rise from the floor of this small valley. You see various "
-"bands of nomads roaming about, and in the distant, the bright flames of "
-"their camp."
-msgstr ""
-"Se alzan muchos penachos de polvo desde el suelo de este pequeño valle. Ves "
-"varios grupos de nómadas vagando, y en la distancia, las brillantes hogueras "
-"de su campamento."
-
-#: ../fheroes2/resource/maps_text.cpp:415
-msgid ""
-"Many guardians stand between you and your enemies, but anybody can sneak "
-"through the back door!"
-msgstr ""
-"Hay muchos guardias entre ti y tus enemigos, ¡pero cualquiera podría entrar "
-"a escondidas por la puerta trasera!"
-
-#: ../fheroes2/resource/maps_text.cpp:416
-msgid "Many that have gone through this door have never returned."
-msgstr "Muchos de los que han franqueado esta puerte nunca regresaron."
-
-#: ../fheroes2/resource/maps_text.cpp:417
-msgid ""
-"Many years ago, a couple of mages had a \"duel\" that forever changed the "
-"lake at the center of this continent.  Hearty adventurers might find "
-"interesting treasure there!"
-msgstr ""
-"Hace muchos años, unos cuantos magos mantuvieron un \"duelo\" que cambió por "
-"siempre el lago del centro de este continente. Los aventureros más osados "
-"podrían encontrar tesoros interesantes aquí."
-
-#: ../fheroes2/resource/maps_text.cpp:418
-msgid ""
-"Many years ago, a falling star crashed near here.  Only now the area is safe "
-"enough to explore.  Rumor has it a castle exist where the star fell."
-msgstr ""
-"Hace muchos años cayó una estrella cerca de aquí. Sólo ahora es seguro "
-"explorar la zona. Se rumorea que existe un castillo donde cayó la estrella."
-
-#: ../fheroes2/resource/maps_text.cpp:419
-msgid ""
-"Many years ago, your father, the King, died in a freak hunting accident.  "
-"Since then, you and your brother have jointly ruled his kingdom, but both of "
-"you have been seeking a way to seize the throne for yourself.  You got your "
-"wish.  Attackers from across the sea have captured more than half your towns "
-"and castles, effectively dividing the continent in two.  Now is the time to "
-"repel these invaders and do away with your brother once and for all!"
-msgstr ""
-"Hace muchos años, tu padre, el Rey, murió en un extraño accidente de caza. "
-"Desde entonces, tu hermano y tú habéis gobernado conjuntamente el reino, "
-"pero los dos habéis estado buscando la manera de conseguir el trono para sí. "
-"Conseguiste tu deseo. Atacantes de más allá del mar han capturado más de la "
-"mitad de tus ciudades y castillos, dividiendo efectivamente el continente en "
-"dos. ¡Ahora es el momento de repeler a los invasores y acabar con tu hermano "
-"de una vez por todas!"
-
-#: ../fheroes2/resource/maps_text.cpp:420
-msgid "Marco"
-msgstr "Marco"
-
-#: ../fheroes2/resource/maps_text.cpp:421
-msgid "Marsh Home"
-msgstr "Hogar del Pantano"
-
-#: ../fheroes2/resource/maps_text.cpp:423
-msgid "Mayland"
-msgstr "Mayland"
-
-#: ../fheroes2/resource/maps_text.cpp:424
-msgid "Meramec"
-msgstr "Meramec"
-
-#: ../fheroes2/resource/maps_text.cpp:425
-msgid "Message from Archibald. \" Do not dare to return without my Crown.\""
-msgstr "Mensaje de Archibald. \"No te atrevas a volver sin mi Corona.\""
-
-#: ../fheroes2/resource/maps_text.cpp:426
-msgid ""
-"Message from Archibald. \" General, thank you for bringing me this lovely "
-"gift. I have decided to participate directly in the capture of my brother "
-"Roland. Since your military advice has taken us this far, I will follow your "
-"orders to the letter.\""
-msgstr ""
-"Mensaje de Archibald. \" General, gracias por traerme este adorable regalo. "
-"He decidido participar directamente en la captura de mi hermano Roland. Dado "
-"que vuestro consejo militar nos ha llevado tan lejos, seguiré vuestras "
-"órdenes al pie de la letra.\""
-
-#: ../fheroes2/resource/maps_text.cpp:427
-msgid "Message from Overlord. \"STILL WAITING FOR MY GOLD!\""
-msgstr "Mensaje del Jefe Supremo. \"¡SIGO ESPERANDO MI ORO!\""
-
-#: ../fheroes2/resource/maps_text.cpp:428
-msgid "Message from Overlord. \"WHERE'S MY GOLD?\""
-msgstr "Mensaje del Jefe Supremo. \"¿DÓNDE ESTÁ MI ORO?\""
-
-#: ../fheroes2/resource/maps_text.cpp:429
-msgid ""
-"Message from Roland. \"General, circumstances permit me to take a hand in "
-"the events of this final conflict. I have your spoils of war with me and I "
-"will follow your advice explicitly.\""
-msgstr ""
-"Mensaje de Roland. \"General, las circunstancias me permiten echar una mano "
-"en los eventos de este conflicto final. Tengo vuestro botín de guerra "
-"conmigo, y seguiré vuestro consejo al pie de la letra.\""
-
-#: ../fheroes2/resource/maps_text.cpp:430
-msgid ""
-"Message from Roland.  \"General, I have sent most of our troops and material "
-"ahead to the region of the final conflict with Archibald.  Unfortunately, "
-"Lord Corlagon has cut us off from the rest of our army.  I will be awaiting "
-"your victory in a castle across the west river.  I should be safe from "
-"attack.\""
-msgstr ""
-"Mensaje de Roland. \"General, he enviado a la mayor parte de nuestras tropas "
-"y materiales adelante, a la región del conflicto final con Archibald. "
-"Desafortunadamente, Lord Corlagon nos ha aislado del resto de nuestro "
-"ejército. Estaré esperando vuestra victoria en un castillo al oeste del río. "
-"Debería de estar a salvo de ataques.\""
-
-#: ../fheroes2/resource/maps_text.cpp:431
-msgid ""
-"Message from Roland. \" We cannot hope to defeat Archibald without the "
-"Crown, I'm counting on you.\""
-msgstr ""
-"Mensaje de Roland: \"No podemos esperar derrotar a Archibald sin la Corona. "
-"Cuento con vos.\""
-
-#: ../fheroes2/resource/maps_text.cpp:432
-msgid "Middle Gate"
-msgstr "Puerta Media"
-
-#: ../fheroes2/resource/maps_text.cpp:433
-msgid "Middleton"
-msgstr "Middleton"
-
-#: ../fheroes2/resource/maps_text.cpp:434
-msgid "Middletown"
-msgstr "Middletown"
-
-#: ../fheroes2/resource/maps_text.cpp:435
-msgid "Might vs. Magic"
-msgstr "Poder vs. Magia"
-
-#: ../fheroes2/resource/maps_text.cpp:436
-msgid "Mineral Wars"
-msgstr "Guerras de Minerales"
-
-#: ../fheroes2/resource/maps_text.cpp:437
-msgid "Mirkosov"
-msgstr "Mirkosov"
-
-#: ../fheroes2/resource/maps_text.cpp:438
-msgid "mirror"
-msgstr "espejo"
-
-#: ../fheroes2/resource/maps_text.cpp:439
-msgid "Money For Red"
-msgstr "Dinero para el Rojo"
-
-#: ../fheroes2/resource/maps_text.cpp:440
-msgid "MONEY, MONEY, MONEY!"
-msgstr "¡DINERO, DINERO, DINERO!"
-
-#: ../fheroes2/resource/maps_text.cpp:441
-msgid "Morale becomes even lower as the endless cliffs move past."
-msgstr "La moral baja aún más a medida que los riscos sin fin pasan."
-
-#: ../fheroes2/resource/maps_text.cpp:442
-msgid ""
-"More water than land, you'll still spend lots of time on foot as you search "
-"a literal horde of islands."
-msgstr ""
-"Más agua que tierra, aún pasarás un montón de tiempo a pie buscando por, "
-"literalmente, una horda de islas."
-
-#: ../fheroes2/resource/maps_text.cpp:443
-msgid "Mountain king"
-msgstr "Rey de la montaña"
-
-#: ../fheroes2/resource/maps_text.cpp:444
-msgid "Mountainview"
-msgstr "Vistamontaña"
-
-#: ../fheroes2/resource/maps_text.cpp:445
-msgid "Mr Ed"
-msgstr "Sr. Ed"
-
-#: ../fheroes2/resource/maps_text.cpp:446
-msgid "Mr. Yellow's Income"
-msgstr "Ingresos del Sr. Amarillo"
-
-#: ../fheroes2/resource/maps_text.cpp:447
-msgid "Murray's resort Isle!"
-msgstr "La isla de vacaciones de Murray"
-
-#: ../fheroes2/resource/maps_text.cpp:448
-msgid ""
-"Mutiny!  The crew has dumped off my precious cargo into the sea!  Thank "
-"goodness it floats - when I've rid of them, I'll come back to pick it up!"
-msgstr ""
-"¡Motín! ¡La tripulación ha lanzado mi preciosa carga por la borda! Gracias a "
-"Dios, flota - cuando me haya ocupado de ellos, ¡volveré a recogerla!"
-
-#: ../fheroes2/resource/maps_text.cpp:449
-msgid ""
-"My leige, our scouts report three other lords are attacking from the south. "
-"They work in conjuction with each other to eliminate us! We must keep this "
-"castle and remove the threat of the enemy. We wish you luck!"
-msgstr ""
-"Mi señor, nuestros exploradores nos informan de que otros tres señores están "
-"atacando desde el sur. Trabajan en conjunción los unos con los otros para "
-"eliminarnos. Debemos mantener este castillo, y eliminar la amenaza del "
-"enemigo. ¡Os deseamos suerte!"
-
-#: ../fheroes2/resource/maps_text.cpp:450
-msgid ""
-"My leige, we have established a foothold (which we cannot afford to lose) "
-"and all of our Heroes have joined us. The king has made us the offer to "
-"purchase this land for 200,000 gold or we may take it by force. The local "
-"lords have been fighting and each wants to be the one that defeats us. Now "
-"all the local armies have arrived on the beach, creating a state of complete "
-"Pandemonium!"
-msgstr ""
-"Mi señor, hemos establecido una avanzadilla (que no podemos permitirnos "
-"perder) y todos nuestros Héroes se nos han unido. El rey nos ha ofrecido "
-"esta tierra por 200,000 piezas de oro, o podemos tomarla por la fuerza. Los "
-"señores locales han estado luchando y todos quieren ser el que nos derrote. "
-"Todos los ejércitos locales han llegado a la playa, creando un completo "
-"pandemonio."
-
-#: ../fheroes2/resource/maps_text.cpp:451
-msgid "My Treasure Is Buried Beneath Three Palm Trees"
-msgstr "Mi tesoro está enterrado bajo tres palmeras"
-
-#: ../fheroes2/resource/maps_text.cpp:452
-msgid "\"Necromancers!\""
-msgstr "\"¡Necromantes!\""
-
-#: ../fheroes2/resource/maps_text.cpp:453
-msgid "New Dawn"
-msgstr "Nuevo Amanecer"
-
-#: ../fheroes2/resource/maps_text.cpp:454
-msgid "New Enemies"
-msgstr "Nuevos Enemigos"
-
-#: ../fheroes2/resource/maps_text.cpp:455
-msgid "New Vertigo"
-msgstr "Nuevo Vértigo"
-
-#: ../fheroes2/resource/maps_text.cpp:456
-msgid "Nightshadow"
-msgstr "Sombranocturna"
-
-#: ../fheroes2/resource/maps_text.cpp:457
-msgid "No Description"
-msgstr "Sin Descripción"
-
-#: ../fheroes2/resource/maps_text.cpp:458
-msgid "No Fishing!"
-msgstr "¡Prohibido pescar!"
-
-#: ../fheroes2/resource/maps_text.cpp:459
-msgid "No gems, crystal, or mercury for red."
-msgstr "Sin gemas, cristal, o mercurio para el rojo."
-
-#: ../fheroes2/resource/maps_text.cpp:460
-msgid ""
-"None of the four leaders like being stuck in a land that has only one season."
-msgstr ""
-"A ninguno de los cuatro líderes le gusta estar atascado en una tierra en la "
-"que sólo hay una estación."
-
-#: ../fheroes2/resource/maps_text.cpp:461
-msgid "NO, Not That Way. This Way."
-msgstr "NO, No Por Ese Camino. Por este camino."
-
-#: ../fheroes2/resource/maps_text.cpp:462
-msgid "No one has ever made it out of the deadly swamps alive!"
-msgstr "¡Nadie ha salido con vida de los mortíferos pantanos!"
-
-#: ../fheroes2/resource/maps_text.cpp:463
-msgid "Noraston"
-msgstr "Noraston"
-
-#: ../fheroes2/resource/maps_text.cpp:464
-msgid "North Road"
-msgstr "Carretera Norte"
-
-#: ../fheroes2/resource/maps_text.cpp:465
-msgid "North vs. South"
-msgstr "Norte vs. Sur"
-
-#: ../fheroes2/resource/maps_text.cpp:466
-msgid "No stuff for red"
-msgstr "Sin cosas para el rojo"
-
-#: ../fheroes2/resource/maps_text.cpp:467
-msgid "No sulfer fer Yella."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:468
-msgid "No swimming."
-msgstr "Prohibido nadar."
-
-#: ../fheroes2/resource/maps_text.cpp:469
-msgid "Notice- Those who put messages in bottles will be tortured."
-msgstr "Aviso: los que pongan mensajes en botellas serán torturados."
-
-#: ../fheroes2/resource/maps_text.cpp:470
-msgid "No Trespassing"
-msgstr "Prohibido el paso"
-
-#: ../fheroes2/resource/maps_text.cpp:471
-msgid "No tresspath...  No tree...  No thresh...  GO AWAY!"
-msgstr "Prohibido el pazo... prohibido el paxo... prohibido el pa... ¡FUERA!"
-
-#: ../fheroes2/resource/maps_text.cpp:472
-msgid "Now leaving Swamplands of the Eternial"
-msgstr "Está usted dejando los Pantanos del Eterno"
-
-#: ../fheroes2/resource/maps_text.cpp:473
-msgid "Obsidian"
-msgstr "Obsidiana"
-
-#: ../fheroes2/resource/maps_text.cpp:474
-msgid "Of the necromancers...."
-msgstr "De los necromantes..."
-
-#: ../fheroes2/resource/maps_text.cpp:475
-msgid "Ogrehild"
-msgstr "Ogrehild"
-
-#: ../fheroes2/resource/maps_text.cpp:476
-msgid "Olympus"
-msgstr "Olimpo"
-
-#: ../fheroes2/resource/maps_text.cpp:477
-msgid ""
-"One of the seers in your castle comes to you in the morning with urgent "
-"news. Your one time comrade, the wizard Joseph, and his armies have been "
-"imprisoned in a jail nearby. His power would surely aid you in your quest to "
-"reclaim the library, you think to yourself. Perhaps there is a way to rescue "
-"him..."
-msgstr ""
-"Uno de los videntes de tu castillo viene a verte por la mañana con noticias "
-"urgentes. Tu antiguo camarada, el mago Joseph, junto a sus ejércitos,  han "
-"sido aprisionados en una cárcel cercana. Su poder seguramente te ayudaría en "
-"tu misión de reclamar la biblioteca, piensas para ti. Tal vez haya alguna "
-"forma de rescatarle..."
-
-#: ../fheroes2/resource/maps_text.cpp:478
-msgid ""
-"One of your aides reports that the Castle of Farlien is located on the "
-"northeast spur of this island, and is a stronghold for the enemy. He urges "
-"you to take it out as soon as possible, and then move onto other islands."
-msgstr ""
-"Uno de tus ayudantes te informa de que el Castillo de Farlien se encuentra "
-"en el espolón noreste de la isla, y que es un bastión del enemigo. Te urge a "
-"tomarlo tan pronto como sea posible, y seguir a continuación a las otras "
-"islas."
-
-#: ../fheroes2/resource/maps_text.cpp:479
-msgid ""
-"One of your \"allies\" has joined Archibald.  You now face an opponent with "
-"three castles to your one.  Good luck!"
-msgstr ""
-"Uno de tus \"aliados\" se ha unido a Archibald. Ahora te enfrentas a un "
-"oponente con tres castillos, por el único tuyo. ¡Buena suerte!"
-
-#: ../fheroes2/resource/maps_text.cpp:480
-msgid ""
-"One of your \"Allies\" has joined Roland. You are now facing three castles, "
-"all belonging to the enemy. Good luck!"
-msgstr ""
-"Uno de tus \"Aliados\" se ha unido a Roland. Ahora te enfrentas a tres "
-"castillos, todos pertenecientes al enemigo. ¡Buena suerte!Un"
-
-#: ../fheroes2/resource/maps_text.cpp:481
-msgid "One of your loyal goblins has brought you an armload of crystal!"
-msgstr "¡Uno de tus leales goblins te ha traído una brazada de cristales!"
-
-#: ../fheroes2/resource/maps_text.cpp:482
-msgid ""
-"One of your loyal subjects, a fairy tells you where to find a cache of "
-"mercury!"
-msgstr ""
-"¡Uno de tus leales súbditos, un hada, te dice dónde encontrar una buena "
-"cantidad de mercurio!"
-
-#: ../fheroes2/resource/maps_text.cpp:483
-msgid ""
-"One of your scouts reports a tiny cave nearby. Upon investigating, you "
-"discover a small cache of goods. In the dirt by them is etched 'Ivan'."
-msgstr ""
-"Uno de tus esploradores te informa de la existencia de una pequeña cueva en "
-"los alrededores. Tras investigar, descubres un escondrijo con varias cosas. "
-"En la tierra, a su lado, está escrito \"Ivan\"."
-
-#: ../fheroes2/resource/maps_text.cpp:484
-msgid ""
-"One of your troops stubs its paw on something buried here.  After a few "
-"hours of digging you unearth a cache of treasure!"
-msgstr ""
-"Una de tus tropas tropieza con algo medio enterrado. Después de unas cuantas "
-"horas de excavación, desentierras un escondite de tesoros."
-
-#: ../fheroes2/resource/maps_text.cpp:485
-msgid "Only a month remains in which to find Joseph."
-msgstr "Sólo queda un mes para encontrar a Joseph."
-
-#: ../fheroes2/resource/maps_text.cpp:486
-msgid "On quite days, Nubbie the sea monster can be seen!"
-msgstr "¡Puede verse bastantes días a Nubbie el monstruo marino!"
-
-#: ../fheroes2/resource/maps_text.cpp:487
-msgid "Orange stuff"
-msgstr "Cosas del Naranja"
-
-#: ../fheroes2/resource/maps_text.cpp:488
-msgid "Orcville"
-msgstr "Villaorcos"
-
-#: ../fheroes2/resource/maps_text.cpp:489
-msgid "Ostoroth"
-msgstr "Ostoroth"
-
-#: ../fheroes2/resource/maps_text.cpp:490
-msgid "Other than the dragons, the elves don't have any enemies."
-msgstr "Aparte de los dragones, los elfos no tienen enemigos."
-
-#: ../fheroes2/resource/maps_text.cpp:491
-msgid "Our ally was greatly weakened when his resources were plundered."
-msgstr ""
-"Nuestro aliado fue muy debilitado cuando sus recursos fueron saqueados."
-
-#: ../fheroes2/resource/maps_text.cpp:492
-msgid "\"Our Finest Hour\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:493
-msgid "Our reinforcements were lost in a storm, we salvaged all we could!"
-msgstr ""
-"Nuestros refuerzos se perdieron en una tormenta, salvamos todo lo que "
-"pudimos."
-
-#: ../fheroes2/resource/maps_text.cpp:494
-msgid ""
-"Our spies have discovered that the barbarian hordes are now receiving "
-"support from kraeger! You must hurry and find the third piece before your "
-"forces here are crushed!"
-msgstr ""
-"Nuestros espías han descubierto que las hordas bárbaras reciben apoyo de "
-"Kraeger. ¡Debes apresurarte y encontrar la tercera pieza antes de que tus "
-"fuerzas aquí sean aplastadas!"
-
-#: ../fheroes2/resource/maps_text.cpp:495
-msgid "Overlord"
-msgstr "Señor"
-
-#: ../fheroes2/resource/maps_text.cpp:496
-msgid "Pandemonium"
-msgstr "Pandemonium"
-
-#: ../fheroes2/resource/maps_text.cpp:497
-msgid "Paper can gain you what wood and sail cannot."
-msgstr "El papel te puede dar lo que la madera y las velas no te han dado."
-
-#: ../fheroes2/resource/maps_text.cpp:498
-msgid "Password found by Crystals to the South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:499
-msgid "Peacekeeper"
-msgstr "Pacificador"
-
-#: ../fheroes2/resource/maps_text.cpp:500
-msgid "\"Peasants!\""
-msgstr "\"¡Campesinos!\""
-
-#: ../fheroes2/resource/maps_text.cpp:502
-msgid "Peasantsville"
-msgstr "Villacampesinos"
-
-#: ../fheroes2/resource/maps_text.cpp:503
-msgid "Perenor"
-msgstr "Perenor"
-
-#: ../fheroes2/resource/maps_text.cpp:504
-msgid "Pet Cemetary"
-msgstr "Cementerio de Animales"
-
-#: ../fheroes2/resource/maps_text.cpp:505
-msgid "Pick one of four Knights in this large and inhospitable land."
-msgstr ""
-"Elige uno de entre cuatro Caballeros en esta inhóspita y enorme tierra."
-
-#: ../fheroes2/resource/maps_text.cpp:506
-msgid "Pig's Eye"
-msgstr "Ojo de Cerdo"
-
-#: ../fheroes2/resource/maps_text.cpp:507
-msgid "Pinehurst"
-msgstr "Pinehurst"
-
-#: ../fheroes2/resource/maps_text.cpp:508
-msgid "Pirate Cove"
-msgstr "Ensenada Pirata"
-
-#: ../fheroes2/resource/maps_text.cpp:509
-msgid "Pirate's Cove"
-msgstr "Ensenada del Pirata"
-
-#: ../fheroes2/resource/maps_text.cpp:510
-msgid "Pirate Utopia"
-msgstr "Utopía pirata"
-
-#: ../fheroes2/resource/maps_text.cpp:511
-msgid "Pirites strike and take the gold from you holds."
-msgstr "Te atacan piratas y se llevan el oro de tus bodegas."
-
-#: ../fheroes2/resource/maps_text.cpp:512
-msgid "Pixie"
-msgstr "Duendecillo"
-
-#: ../fheroes2/resource/maps_text.cpp:513
-msgid ""
-"Play the Knight or Barbarian in an alliance in this classic duel against the "
-"four spell casters. (Blue and Green vs Red)"
-msgstr ""
-"Juega con el Caballero o con el Bárbaro en una alianza en este duelo clásico "
-"contra los cuatro lanzadores de hechizoc (Azul y Verde vs Rojo)"
-
-#: ../fheroes2/resource/maps_text.cpp:514
-msgid "Please...."
-msgstr "Por favor..."
-
-#: ../fheroes2/resource/maps_text.cpp:515
-msgid ""
-"Plenty of resources and lots of ground to cover. Watch out for Orange and "
-"Purple!"
-msgstr ""
-"Muchos recursos y un montón de tierra que cubrir. ¡Cuidado con los Naranjas "
-"y los Púrpura!"
-
-#: ../fheroes2/resource/maps_text.cpp:516
-msgid "Portals"
-msgstr "Portales"
-
-#: ../fheroes2/resource/maps_text.cpp:517
-msgid "Portsmith"
-msgstr "Portsmith"
-
-#: ../fheroes2/resource/maps_text.cpp:518
-msgid "POSION - DO NOT DRINK"
-msgstr "VENENO - NO BEBER"
-
-#: ../fheroes2/resource/maps_text.cpp:519
-msgid "Powerful magic lies southwest of here in the Valley of the Kings."
-msgstr ""
-"Una magia poderosa se halla al suroeste de aquí, en el Valle de los Reyes."
-
-#: ../fheroes2/resource/maps_text.cpp:520
-msgid "Prisoner on...."
-msgstr "Prisionero en..."
-
-#: ../fheroes2/resource/maps_text.cpp:522
-msgid "Quick Silver"
-msgstr "Mercurio"
-
-#: ../fheroes2/resource/maps_text.cpp:523
-msgid "Raste"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:524
-msgid "Realm of the Undead.  Fresh blood welcome."
-msgstr "Dominios de los No-Muertos. Sangre fresca bienvenida."
-
-#: ../fheroes2/resource/maps_text.cpp:525
-msgid "Red bonus"
-msgstr "Bonificación del Rojo"
-
-#: ../fheroes2/resource/maps_text.cpp:526
-msgid "Red player sympathizes with the undead cause."
-msgstr "El jugador rojo simpatiza con la causa de los no-muertos."
-
-#: ../fheroes2/resource/maps_text.cpp:527
-msgid "Red's Connection"
-msgstr "Conexiones del Rojo"
-
-#: ../fheroes2/resource/maps_text.cpp:528
-msgid "Redshield"
-msgstr "Escudorrojo"
-
-#: ../fheroes2/resource/maps_text.cpp:529
-msgid "Red's Lunch Money"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:530
-msgid "Red's Rubles"
-msgstr "Rublos del Rojo"
-
-#: ../fheroes2/resource/maps_text.cpp:531
-msgid "Red stuff"
-msgstr "Cosas del Rojo"
-
-#: ../fheroes2/resource/maps_text.cpp:532
-msgid ""
-"Regrettably, you have no castle with which to begin your assault. "
-"Fortunately, however, Kraeger's forces are weak here in the south, and you "
-"have bribed a rebel necromancer to aid you in the beginning of your conquest."
-msgstr ""
-"Lamentablemente, no tienes ningún castillo con el que comenzar tu asalto. "
-"Por suerte, las fuerzas de Kraeger son débiles aquí, en el sur, y has "
-"sobornado a un necromante rebelde para que te ayude en los comienzos de tus "
-"conquistas."
-
-#: ../fheroes2/resource/maps_text.cpp:533
-msgid "Reinforcements have arrived, Gold from the homelands!"
-msgstr "Han llegado refuerzos, ¡oro desde casa!"
-
-#: ../fheroes2/resource/maps_text.cpp:534
-msgid ""
-"Remains of a long since dead wizard have attracted an ancient artifact.  "
-"This artifact has now attached itself to you!"
-msgstr ""
-"Los restos de un mago muerto hace mucho han atraído un artefacto antiguo. "
-"¡El artefacto se ha vinculado ahora a ti!"
-
-#: ../fheroes2/resource/maps_text.cpp:535
-msgid ""
-"Remember, you're searching for the Ultimate Artifact... don't get distracted!"
-msgstr ""
-"Recuerda que estás buscando el Artefacto Definitivo... ¡No te distraigas!"
-
-#: ../fheroes2/resource/maps_text.cpp:536
-msgid ""
-"Rendall Koski was here. 1997.  Northampton, Massachusetts There is a "
-"powerful artifact in the southeastern corner of the world.  Go for it, "
-"explorer!"
-msgstr ""
-"Rendall Koski estuvo aquí. 1997. Northampton, Massachusetts. Hay un poderoso "
-"artefacto en la esquina sureste del mundo. ¡Ve por él, explorador!"
-
-#: ../fheroes2/resource/maps_text.cpp:537
-msgid ""
-"Reports from your spies tell of enemies on the march.  As you rush to the "
-"castle courtyard to prepare your armies, you are intercepted by your "
-"Chaplain.  \"My Lord, I have received word that we should send what Heroes "
-"we can to the Isle of Knowledge.   The Scholars there have agreed to teach "
-"them so they will be strong for the battles ahead of us.\"  You thank the "
-"Chaplain for the information and head thoughtfully into the courtyard."
-msgstr ""
-"Recibes informes de tus espías que advierten de enemigos en marcha. Al "
-"apresurarte al patio del castillo para preparar tus ejércitos, te intercepta "
-"tu Capellán. \"Mi señor, he recibido noticias que aconsejan enviar los "
-"Héroes que podamos a la Isla del Conocimiento. Los eruditos de allí están de "
-"acuerdo en enseñarles, con lo que serán fuertes en las batallas que nos "
-"esperan.\" Le das las gracias al Capellá por la información, y de diriges "
-"pensativo al patio."
-
-#: ../fheroes2/resource/maps_text.cpp:538
-msgid ""
-"Rescue your crazy Uncle Ivan. Find him within 4 months or it will be no help "
-"to your kingdom."
-msgstr ""
-"Rescata a tu loco Tío Iván. Encuéntrale en 4 meses o no habrá ayuda para tu "
-"reino."
-
-#: ../fheroes2/resource/maps_text.cpp:539
-msgid "Restricted Area, Do Not Enter!"
-msgstr "¡Área restringida, prohibido el paso!"
-
-#: ../fheroes2/resource/maps_text.cpp:540
-msgid "Rest stop."
-msgstr "Parada de descanso."
-
-#: ../fheroes2/resource/maps_text.cpp:541
-msgid "Retake the Castle of Ivory Gates."
-msgstr "Reconquista el Castillo de las Puertas de Marfil."
-
-#: ../fheroes2/resource/maps_text.cpp:542
-msgid "Revolution"
-msgstr "Revolución"
-
-#: ../fheroes2/resource/maps_text.cpp:543
-msgid "Right thinking - he who takes the riskes deserves the rewards."
-msgstr "Lo correcto - quien asuma los riesgos se merece las recompensas."
-
-#: ../fheroes2/resource/maps_text.cpp:544
-msgid "River Crossing"
-msgstr "Vado"
-
-#: ../fheroes2/resource/maps_text.cpp:545
-msgid "Road Ends"
-msgstr "Fin del camino"
-
-#: ../fheroes2/resource/maps_text.cpp:546
-msgid "Road to Isle of Knowledge"
-msgstr "Carretera a la Isla del Conocimiento"
-
-#: ../fheroes2/resource/maps_text.cpp:547
-msgid "Road to the Isle of Knowledge"
-msgstr "Camino a la Isla del Conocimiento"
-
-#: ../fheroes2/resource/maps_text.cpp:548
-msgid "Robbers have looted your treasury and you have lost valuable resources."
-msgstr "Algún ladrón ha saqueado tu tesoro y has perdido valiosos recursos."
-
-#: ../fheroes2/resource/maps_text.cpp:549
-msgid "Robbers have looted your treasury, stealing valuable resources."
-msgstr "Los ladrones han saqueado tu tesoro, robando valiosos recursos."
-
-#: ../fheroes2/resource/maps_text.cpp:550
-msgid "Roc Haven"
-msgstr "Roc Haven"
-
-#: ../fheroes2/resource/maps_text.cpp:551
-msgid "Rogar"
-msgstr "Rogar"
-
-#: ../fheroes2/resource/maps_text.cpp:553
-msgid "Roscomon"
-msgstr "Roscomon"
-
-#: ../fheroes2/resource/maps_text.cpp:554
-msgid "Rotten Birch"
-msgstr "Abedul Podrido"
-
-#: ../fheroes2/resource/maps_text.cpp:555
-msgid ""
-"Rumors abound and your faithful hero Sandro is now highly regarded by the "
-"masses. Should Sandro desert you, all will be lost."
-msgstr ""
-"Los rumores abundan y tu leal héroe Sandro es aclamado por las masas. En "
-"caso de que Sandro desertara, todo se perdería."
-
-#: ../fheroes2/resource/maps_text.cpp:556
-msgid "Sandcaster"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:558
-msgid "Sands of Time"
-msgstr "Arenas del Tiempo"
-
-#: ../fheroes2/resource/maps_text.cpp:559
-msgid "Sansobar"
-msgstr "Sansobar"
-
-#: ../fheroes2/resource/maps_text.cpp:560
-msgid "\"Save the Dwarves\""
-msgstr "\"Salva a los Enanos\""
-
-#: ../fheroes2/resource/maps_text.cpp:561
-msgid "Scabsdale"
-msgstr "Scabsdale"
-
-#: ../fheroes2/resource/maps_text.cpp:562
-msgid "Scorched Earth"
-msgstr "Tierras flageladas"
-
-#: ../fheroes2/resource/maps_text.cpp:563
-msgid ""
-"Scouts have reported a town to the North.  They have also heard some "
-"disturbing news.  Their seems to be a war raging in this area."
-msgstr ""
-"Los exploradores informan de que hay una ciudad al Norte. También han oído "
-"noticias inquietantes. Parece que hay una guerra en curso en este área."
-
-#: ../fheroes2/resource/maps_text.cpp:564
-msgid ""
-"Scouts report the enemy's stronghold lies to the Southwest. Our swift "
-"arrival has caught them by surprise. If you move quickly their resistance "
-"will be minimal."
-msgstr ""
-"Los exploradores informan de que el bastión enemigo se encuentra al "
-"Suroeste. Nuestra rápida llegada los ha cogido por sorpresa. Si te mueves "
-"rápidamente su resistencia será mínima."
-
-#: ../fheroes2/resource/maps_text.cpp:565
-msgid ""
-"Scouts report the notorious necromancer \"Wyrm\" has been sighted to the "
-"northeast."
-msgstr ""
-"Los exploradores informan de que el notorio necromante \"Wyrm\" ha sido "
-"visto al noreste."
-
-#: ../fheroes2/resource/maps_text.cpp:566
-msgid "Scummy"
-msgstr "Espumoso"
-
-#: ../fheroes2/resource/maps_text.cpp:567
-msgid ""
-"Searching in the dust of this abandoned campsite, you find a magic scroll."
-msgstr ""
-"Rebuscando en el polvo de este sitio de acampada abandonado, encuentras un "
-"pergamino mágico."
-
-#: ../fheroes2/resource/maps_text.cpp:568
-msgid "Seasons Change"
-msgstr "Cambio de Estaciones"
-
-#: ../fheroes2/resource/maps_text.cpp:569
-msgid "Secret Mountain Pass"
-msgstr "Paso Secreto de Montaña"
-
-#: ../fheroes2/resource/maps_text.cpp:570
-msgid ""
-"Seek out the Ultimate Artifact to be victorious in this strangely shaped "
-"land."
-msgstr ""
-"Busca el Artefacto Definitivo para obtener la victoria en esta tierra con "
-"formas raras."
-
-#: ../fheroes2/resource/maps_text.cpp:571
-msgid ""
-"Seek the great library, for only with the guidance of the musty tomes therin "
-"will you find the means to reveal and bind the fount to your will."
-msgstr ""
-"Busca la gran bilioteca, pues sólo con la guía de sus mohosos tomos "
-"encontrarás la manera de revelar y vincular la fuente a tu voluntad."
-
-#: ../fheroes2/resource/maps_text.cpp:572
-msgid "Seven Lakes"
-msgstr "Siete Lagos"
-
-#: ../fheroes2/resource/maps_text.cpp:573
-msgid "Sharkania"
-msgstr "Sharkania"
-
-#: ../fheroes2/resource/maps_text.cpp:574
-msgid "Sheltemburg"
-msgstr "Sheltemburg"
-
-#: ../fheroes2/resource/maps_text.cpp:575
-msgid "Sherman"
-msgstr "Sherman"
-
-#: ../fheroes2/resource/maps_text.cpp:576
-msgid "Shipwrecked!"
-msgstr "¡Naufragio!"
-
-#: ../fheroes2/resource/maps_text.cpp:577
-msgid ""
-"Should this message ever reach home, please know that this has become a "
-"hostile place since the King's death.  No less than six factions are at war "
-"with each other, each seeking to be the King's successor.  Beware especially "
-"of the Barbarians and the Necromancers who control the north, their regions "
-"are easily defended and they have a wealth of gold and gems.  Do not venture "
-"to this land without a sizeable force.  -Sir Christian"
-msgstr ""
-"En caso de que este mensaje llegue alguna vez a casa, por favor, has de "
-"saber que este se ha convertido en un lugar hostil desde la muerte del Rey. "
-"Al menos seis facciones están en guerra con las demás, cada cual buscando "
-"ser la sucesora del Rey. Cuidado especialmente con los Bárbaros y los "
-"Necromantes que controlan el norte, sus regiones se defienden fácilmente y "
-"tienen grandes riquezas en forma de oro y gemas. No te aventures en esa "
-"tierra sin unas fuerzas considerables. -Sir Christian"
-
-#: ../fheroes2/resource/maps_text.cpp:578
-msgid "Sirein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:579
-msgid ""
-"Six factions have established a foothold on a huge, unexplored continent.  "
-"Can you eliminate the other five?"
-msgstr ""
-"Seis facciones han establecido una cabeza de playa en un enorme e "
-"inexplorado continente. ¿Puedes eliminar a las otras cinco?"
-
-#: ../fheroes2/resource/maps_text.cpp:580
-msgid ""
-"Six heroes with large armies prepare to slug it out for total domination!"
-msgstr ""
-"¡Seis héroes con grandes ejércitos se preparan para combatir por la "
-"dominación total!"
-
-#: ../fheroes2/resource/maps_text.cpp:581
-msgid "Skirmish"
-msgstr "Escaramuza"
-
-#: ../fheroes2/resource/maps_text.cpp:582
-msgid "\"Slay the Dwarves\""
-msgstr "\"Da muerte a los Enanos\""
-
-#: ../fheroes2/resource/maps_text.cpp:583
-msgid "Slippery when wet."
-msgstr "Resbaladizo cuando está húmedo."
-
-#: ../fheroes2/resource/maps_text.cpp:584
-msgid "Slugfest"
-msgstr "Slugfest"
-
-#: ../fheroes2/resource/maps_text.cpp:585
-msgid ""
-"Snagged on a thorny bush, you discover a scrap of cloth. The design on it "
-"looks like the coat of arms of Ivan's house!"
-msgstr ""
-"Descubres un trozo de tela, enganchado en un arbusto espinoso. El diseño que "
-"tiene parece el escudo de armas de la casa de Iván."
-
-#: ../fheroes2/resource/maps_text.cpp:586
-msgid "Snowdrop"
-msgstr "Copo de nieve"
-
-#: ../fheroes2/resource/maps_text.cpp:587
-msgid "Somebody has stuffed a pile of gems in the ditch!"
-msgstr "¡Alguien ha metido un montón de gemas en la zanja!"
-
-#: ../fheroes2/resource/maps_text.cpp:588
-msgid "Some crystal!"
-msgstr "¡Algunos cristales!"
-
-#: ../fheroes2/resource/maps_text.cpp:589
-msgid "Some gems!"
-msgstr "¡Algunas gemas!"
-
-#: ../fheroes2/resource/maps_text.cpp:590
-msgid ""
-"Someone has stolen 100 wood and 77 ore from you. Ah, that's nothing. Let's "
-"keep going."
-msgstr ""
-"Alguien te ha robado 100 de madera y 77 de mineral. Ah, eso no es nada. "
-"Prosigamos."
-
-#: ../fheroes2/resource/maps_text.cpp:591
-msgid ""
-"Someone has stolen gold and resources from  the palace treasury!  You "
-"suspect your enemies, but you can't know for certain."
-msgstr ""
-"Alguien ha robado oro y recursos del tesoro de palacio. Sospechas de tus "
-"enemigos, pero no puedes saberlo con certeza."
-
-#: ../fheroes2/resource/maps_text.cpp:592
-msgid "Someone is playing a pan flute around here."
-msgstr "Alguien está tocando una flauta cerca de aquí."
-
-#: ../fheroes2/resource/maps_text.cpp:593
-msgid ""
-"Someone notices a piece of parchment lying behind a clump of grass. You pick "
-"it up. It looks to be a page from a journal, and it reads, \"...made it past "
-"the first guardians. Hopefully will reach the ancient desert city soon. Only "
-"hope my forces are strong enough to survive...\""
-msgstr ""
-"Alguien se encuentra con un trozo de pergamino, tirado entre unas hierbas. "
-"Lo recoges. Parece ser una página de un diario, y en ella se lee \"...hemos "
-"pasado los primeros guardias. Con suerte, pronto llegaremos a la antigua "
-"ciudad del desierto. Sólo espero tener fuerzas suficientes para sobrevivir..."
-"\""
-
-#: ../fheroes2/resource/maps_text.cpp:594
-msgid "Some ore!"
-msgstr "¡Algunos minerales!"
-
-#: ../fheroes2/resource/maps_text.cpp:595
-msgid "Some sulfur!"
-msgstr "¡Algo de azufre!"
-
-#: ../fheroes2/resource/maps_text.cpp:596
-msgid ""
-"Some unlucky adventurers have been captured and imprisoned in these lands."
-msgstr ""
-"Algunos desdichados aventureros han sido capturados y encerrados en estas "
-"tierras."
-
-#: ../fheroes2/resource/maps_text.cpp:597
-msgid "Sorceress Forest.  Show respect for nature!"
-msgstr "Bosque de Hechiceras. ¡Muestra respeto por la naturaleza!"
-
-#: ../fheroes2/resource/maps_text.cpp:598
-msgid "Sorpigal"
-msgstr "Sorpigal"
-
-#: ../fheroes2/resource/maps_text.cpp:599
-msgid "South Mill"
-msgstr "Molino Sur"
-
-#: ../fheroes2/resource/maps_text.cpp:600
-msgid "So you think you're smart?"
-msgstr "¿Te crees listo?"
-
-#: ../fheroes2/resource/maps_text.cpp:601
-msgid "Spector"
-msgstr "Spector"
-
-#: ../fheroes2/resource/maps_text.cpp:602
-msgid "Spell Casters"
-msgstr "Conjuradores"
-
-#: ../fheroes2/resource/maps_text.cpp:603
-msgid ""
-"Spies report Roland has sent a hero to search for the Crown. If he finds it "
-"first, all is lost!"
-msgstr ""
-"Los espías informan de Roland ha enviado un héroe en busca de la Corona. ¡Si "
-"él la encuentra primero, todo se habrá perdido!"
-
-#: ../fheroes2/resource/maps_text.cpp:604
-msgid "Spirit City"
-msgstr "Ciudad espíritu"
-
-#: ../fheroes2/resource/maps_text.cpp:605
-msgid "Spy Tower - see what your competition is doing!"
-msgstr "Torre Espía - ¡ve lo que está haciendo tu competencia!"
-
-#: ../fheroes2/resource/maps_text.cpp:606
-msgid "Stairs"
-msgstr "Escaleras"
-
-#: ../fheroes2/resource/maps_text.cpp:607
-msgid ""
-"Start with five castles!  How could you lose!?  Oh yeah, everyone else "
-"starts with five, too."
-msgstr ""
-"¡Comienzas con cinco castillos! ¿Cómo podrías perder? Ah, sí, todos los "
-"demás comienzan también con cinco castillos."
-
-#: ../fheroes2/resource/maps_text.cpp:608
-msgid "Stick to the road!"
-msgstr "¡Sigue la carretera!"
-
-#: ../fheroes2/resource/maps_text.cpp:609
-msgid "Stromgild"
-msgstr "Stromgild"
-
-#: ../fheroes2/resource/maps_text.cpp:610
-msgid "Stromhild"
-msgstr "Stromhild"
-
-#: ../fheroes2/resource/maps_text.cpp:611
-msgid "Stronghold"
-msgstr "Bastión"
-
-#: ../fheroes2/resource/maps_text.cpp:612
-msgid "Stuff for red"
-msgstr "Cosas para el rojo"
-
-#: ../fheroes2/resource/maps_text.cpp:613
-msgid "Stuff for Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:614
-msgid "Stuff For Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:615
-msgid "Subbaculcha"
-msgstr "Subbaculcha"
-
-#: ../fheroes2/resource/maps_text.cpp:616
-msgid "Sundune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:617
-msgid "Surf and Turf"
-msgstr "Tierra y Mar."
-
-#: ../fheroes2/resource/maps_text.cpp:618
-msgid "Swimming near the kelp is a pod of dolphins."
-msgstr "Hay un grupo de delfines nadando junto a las algas."
-
-#: ../fheroes2/resource/maps_text.cpp:619
-msgid "Tacma"
-msgstr "Tacma"
-
-#: ../fheroes2/resource/maps_text.cpp:620
-msgid "Tchudes"
-msgstr "Tchudes"
-
-#: ../fheroes2/resource/maps_text.cpp:621
-msgid "Teleporters"
-msgstr "Teleportadores"
-
-#: ../fheroes2/resource/maps_text.cpp:622
-msgid "Terra Firma"
-msgstr "Terra Firma"
-
-#: ../fheroes2/resource/maps_text.cpp:623
-msgid "Terrain Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:624
-msgid ""
-"The alliance has crumbled and all are at war. Lots of resources but little "
-"time to prepare."
-msgstr ""
-"La alianza se ha roto y todos están en guerra. Hay muchos recursos pero poco "
-"tiempo para prepararse."
-
-#: ../fheroes2/resource/maps_text.cpp:625
-msgid ""
-"The ancient King Zealot had the artifact of the gods and then hid it in his "
-"old age so that it could not be used by others."
-msgstr ""
-"El antiguo Rey Fanático tenía el artefacto de los dioses, y lo escondió en "
-"sus últimos días de tal modo que no pudiera ser usado por otros."
-
-#: ../fheroes2/resource/maps_text.cpp:626
-msgid "The Back Door"
-msgstr "La Puerta Trasera"
-
-#: ../fheroes2/resource/maps_text.cpp:627
-msgid ""
-"The Barbarian's lands are being invaded. Are you strong enough to resist the "
-"invasion?"
-msgstr ""
-"Las tierras de los Bárbaros están siendo invadidas. ¿Eres lo suficientemente "
-"fuerte como para resistir la invasión?"
-
-#: ../fheroes2/resource/maps_text.cpp:628
-msgid ""
-"The castle of Drakonran in the east has been taken by the barbarians! Two "
-"other towns to the west have also been taken, but the barbarian armies were "
-"fairly decimated in the process."
-msgstr ""
-"El castillo de Drakonran al este ha caído en manos de los bárbaros. También "
-"han tomado otras dos ciudades al oeste, pero los ejércitos bárbaros "
-"sufrieron grandes bajas en el proceso."
-
-#: ../fheroes2/resource/maps_text.cpp:629
-msgid "The center island is rumored to harbor great spells."
-msgstr "Se rumorea que la isla central concentra grandes hechizos."
-
-#: ../fheroes2/resource/maps_text.cpp:630
-msgid "The Citadel"
-msgstr "La Ciudadela"
-
-#: ../fheroes2/resource/maps_text.cpp:631
-msgid "The cities of the plains."
-msgstr "Las ciudades de las planicies."
-
-#: ../fheroes2/resource/maps_text.cpp:632
-msgid "The Clearing"
-msgstr "La limpieza"
-
-#: ../fheroes2/resource/maps_text.cpp:633
-msgid ""
-"The convoy has at long last arrived. Regretably, it has been beset by "
-"bandits on its journey here, and has far less supplies than we had hoped. "
-"Make your way south, for our spies have found rich mines there."
-msgstr ""
-"Al fin ha llegado el convoy. Lamentablemente, ha sido hostigado por bandidos "
-"durante el camino, y tiene muchos menos recursos de los que esperábamos. "
-"Ábrete camino hacia el sur, pues nuestros espías han encontrado ricas minas "
-"allí."
-
-#: ../fheroes2/resource/maps_text.cpp:634
-msgid ""
-"The convoy should have been here by now! Let us hope that it is safe and "
-"still on its way."
-msgstr ""
-"¡Ya debiera de haber llegado el convoy! Esperemos que esté a salvo y aún en "
-"marcha."
-
-#: ../fheroes2/resource/maps_text.cpp:635
-msgid ""
-"The country lords have allied and pooled their resources into one command. "
-"Not only have they massed their forces in the north, but they have sent a "
-"knight to the west to steal your supplies. Scouts report a castle to the "
-"east that would be ideal as a base of operations."
-msgstr ""
-"Los Señores se han aliado y reunido sus recursos bajo un mismo mando. No "
-"sólo han aglutinado sus fuerzas en el norte, sino que también han enviado un "
-"caballero al oeste para robar tus suministros. Los exploradores informan de "
-"que hay un castillo al este que sería ideal como base de operaciones."
-
-#: ../fheroes2/resource/maps_text.cpp:636
-msgid "The crew are unworthy!  I am not going down with the ship! -The Captain"
-msgstr ""
-"¡La tripulación es indigna! ¡No me voy a hundir con el barco! - El Capitán"
-
-#: ../fheroes2/resource/maps_text.cpp:637
-msgid "\"The Crown\""
-msgstr "\"La Corona\""
-
-#: ../fheroes2/resource/maps_text.cpp:638
-msgid ""
-"The day you have feared has finally arrived.  The king, who you have "
-"faithfully served, has died, leaving no heir to his throne.  As his captain, "
-"you feel that this job should now be yours, but several factions even now "
-"are preparing for conquest.  You are at the center of the trade routes, "
-"having the sea to the south and the great forest to the north.  Go, now, "
-"Commander, and claim what is rightfully yours!"
-msgstr ""
-"El día que tanto temías ha llegado al fin. El rey, a quien serviste con "
-"lealtad, ha muerto, sin dejar heredero alguno al trono. Como su capitán, "
-"piensas que este trabajo debiera de ser tuyo, pero varias facciones se están "
-"preparando ahora mismo para conquistar. Estás en el centro de las rutas "
-"comerciales, tienes el mar al sur y el gran bosque al norte. Ve ahora, "
-"Comandante, y reclama lo que es tuyo por derecho."
-
-#: ../fheroes2/resource/maps_text.cpp:639
-msgid ""
-"The diplomats who were sent here ahead of you report that the elves will "
-"only cooperate with you if you will recover the golden bow for them. It was "
-"stolen by their enemies, the Dragons and hidden behind magic barriers."
-msgstr ""
-"Los diplomáticos que se enviaron antes de ti te informan de que los elfos "
-"sólo cooperarán si les recuperas el arco dorado. Fue robado por sus "
-"enemigos, los Dragones, y escondido tras barreras mágicas."
-
-#: ../fheroes2/resource/maps_text.cpp:640
-msgid "The Eastern Town."
-msgstr "La ciudad oriental"
-
-#: ../fheroes2/resource/maps_text.cpp:641
-msgid "The edge of the world is your edge.  But prepare to be prepared."
-msgstr "El borde del mundo es tu frontera. Pero prepárate para prepararte."
-
-#: ../fheroes2/resource/maps_text.cpp:642
-msgid "The Emerald Isle"
-msgstr "La Isla Esmeralda"
-
-#: ../fheroes2/resource/maps_text.cpp:643
-msgid "The Enchanted Forest."
-msgstr "El Bosque Encantado"
-
-#: ../fheroes2/resource/maps_text.cpp:644
-msgid "The End of the World is Nigh!"
-msgstr "¡El fin del mundo está cerca!"
-
-#: ../fheroes2/resource/maps_text.cpp:645
-msgid "The End of the World is Nigh"
-msgstr "El fin del mundo está cerca"
-
-#: ../fheroes2/resource/maps_text.cpp:646
-msgid ""
-"The Epic battle against Your Rival! Eliminate everything! Total Warfare! "
-"Don't Lose your first hero!"
-msgstr ""
-"¡La batalla Épica contra Tu Rival! ¡Elimina todo! ¡Guerra Total! ¡No pierdas "
-"a tu primer héroe!"
-
-#: ../fheroes2/resource/maps_text.cpp:647
-msgid ""
-"The Fire King is an ally to the dragons, and will help a friend of theirs."
-msgstr "El Rey de Fuego es aliado de los dragones, y ayudarán a un amigo suyo."
-
-#: ../fheroes2/resource/maps_text.cpp:648
-msgid "The First One To Take Astircaer Wins!"
-msgstr "¡El primero en capturar Astircaer gana!"
-
-#: ../fheroes2/resource/maps_text.cpp:649
-msgid ""
-"The first piece of the artifact now lies in the hands of the Unholy Order of "
-"Warlocks. You must annihilate them, and their allies to the north. They will "
-"surely give us what we seek in exchange for their feeble lives."
-msgstr ""
-"El primer fragmento del artefacto se encuentra ahora en las manos de la "
-"Impía Orden de Brujos. Debes aniquilarlos, a ellos y a sus aliados del "
-"norte. Seguramente nos darán lo que buscamos a cambio de sus patéticas vidas."
-
-#: ../fheroes2/resource/maps_text.cpp:650
-msgid ""
-"The Fortune of Infamous Uae was buried on one of these islands. She died "
-"without ever revealing it.  Find it before the other cutthroats."
-msgstr ""
-"La Fortuna de la Infame Uae fue enterrada en una de estas islas. Ella murió "
-"sin reverlársela a nadie. Encuéntrala antes que los otros asesinos."
-
-#: ../fheroes2/resource/maps_text.cpp:651
-msgid "The four factions race to capture a mystical castle."
-msgstr "Las cuatro facciones se apresuran a capturar un castillo místico."
-
-#: ../fheroes2/resource/maps_text.cpp:652
-msgid ""
-"The four spell casters face off with substantial starting armies. Can the "
-"crusaders keep the peace?"
-msgstr ""
-"Los cuatro conjuradores se enfrentan con ejércitos iniciales importantes. "
-"¿Pueden mantener el ritmo los cruzados?"
-
-#: ../fheroes2/resource/maps_text.cpp:653
-msgid "\"The Gauntlet\""
-msgstr "\"El Guantelete\""
-
-#: ../fheroes2/resource/maps_text.cpp:654
-msgid ""
-"The Gods have given you 6 months to prove yourself. Good or Evil - who shall "
-"prevail? (Blue,Green and Red vs Yellow, Orange and Purple)"
-msgstr ""
-"Los Dioses te han dado 6 meses para ponerte a prueba. Bien o Mal - ¿Quién "
-"prevalecerá? (Azul, Verde y Rojo vs. Amarillo, Naranja y Púrpura)"
-
-#: ../fheroes2/resource/maps_text.cpp:655
-msgid ""
-"The gods have granted this world a great artifact, to find it means victory."
-msgstr ""
-"Los dioses han otorgado a este mundo un gran artefacto, encontrarlo "
-"significa la victoria."
-
-#: ../fheroes2/resource/maps_text.cpp:656
-msgid "The Gods themselves will aid us in this War."
-msgstr "Los Dioses en persona nos ayudarán en esta Guerra."
-
-#: ../fheroes2/resource/maps_text.cpp:657
-msgid "The Gold Traveller's Tent is near the Aqua Taveller's Tent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:658
-msgid "The guardians of Dragon Isle reside in the jungle."
-msgstr "Los guardianes de la Isla Dragón residen en la jungla."
-
-#: ../fheroes2/resource/maps_text.cpp:659
-msgid "The Ice Prince stands frozen in some forgotten corner of the world."
-msgstr ""
-"El Príncipe del Hielo está congelado en algún rincón olvidado del mundo."
-
-#: ../fheroes2/resource/maps_text.cpp:660
-msgid "The island...."
-msgstr "La isla..."
-
-#: ../fheroes2/resource/maps_text.cpp:661
-msgid "The Island of Lost Reason"
-msgstr "La Isla de la Razón Perdida"
-
-#: ../fheroes2/resource/maps_text.cpp:662
-msgid "The islands have much wealth."
-msgstr "Las islas tienen muchas riquezas."
-
-#: ../fheroes2/resource/maps_text.cpp:663
-msgid "The Isle of Armoria"
-msgstr "La Isla de Armoria"
-
-#: ../fheroes2/resource/maps_text.cpp:664
-msgid "The key to success is rubbing enough lamps."
-msgstr "El secreto del éxito es frotar las suficientes lámparas."
-
-#: ../fheroes2/resource/maps_text.cpp:665
-msgid ""
-"The King has declared you his hier apparent and champion. You must seek out "
-"and destroy your common enemy, Wilgatus and his Castle, Mirkosov, the source "
-"of his power."
-msgstr ""
-"El Rey te ha declarado su heredero y campeón. Debes de buscar y destruir a "
-"nuestro enemigo común, Wilgatus, y su castillo, Mirkosov, la fuente de su "
-"poder."
-
-#: ../fheroes2/resource/maps_text.cpp:666
-msgid ""
-"The King is dead, his kingdom has been shattered, and six leaders seek to "
-"seize power for themselves."
-msgstr ""
-"El Rey ha muerto, su reino se ha hecho pedazos, y seis líderes buscan el "
-"poder para sí."
-
-#: ../fheroes2/resource/maps_text.cpp:667
-msgid "The Kingly Wastes"
-msgstr "Los yermos reales"
-
-#: ../fheroes2/resource/maps_text.cpp:668
-msgid "The Kings Road."
-msgstr "La Carretera del Rey"
-
-#: ../fheroes2/resource/maps_text.cpp:669
-msgid ""
-"The King will sell you this land for 200,000 gold or you can take it by "
-"force. The choice is yours."
-msgstr ""
-"El Rey te venderá esta tierra por 200,000 piezas de oro, o puedes tomarla "
-"por la fuerza. La elección es vuestra."
-
-#: ../fheroes2/resource/maps_text.cpp:670
-msgid "The land of Heroes II."
-msgstr "La tierra de Heroes II."
-
-#: ../fheroes2/resource/maps_text.cpp:671
-msgid "The Lost Castle of the Ancients"
-msgstr "El Castillo Perdido de los Antiguos"
-
-#: ../fheroes2/resource/maps_text.cpp:672
-msgid ""
-"The mage wars have caused a great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-"Las guerras de los magos han causado grandes desórdenes. La isla se ha "
-"convertido en un vórtice central de poder mágico. Cuidado a todos los que "
-"entren aquí."
-
-#: ../fheroes2/resource/maps_text.cpp:673
-msgid ""
-"The mage wars have caused great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-"Las guerras de los magos han causado grandes desórdenes. La isla se ha "
-"convertido en un vórtice central de poder mágico. Cuidado a todos los que "
-"entren aquí."
-
-#: ../fheroes2/resource/maps_text.cpp:674
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trade.  "
-"Plus a little gold for expenses..."
-msgstr ""
-"Llega el maestro mercader y se lleva los recursos necesarios para comerciar. "
-"Y un poco de oro más para gastos..."
-
-#: ../fheroes2/resource/maps_text.cpp:675
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trading.  "
-"Plus a little more gold for expenses..."
-msgstr ""
-"Llega el maestro mercader y se lleva los recursos necesarios para comerciar. "
-"Y algo más de oro para gastos..."
-
-#: ../fheroes2/resource/maps_text.cpp:676
-msgid ""
-"The Master Merchant arrives at your Castle.  He tells you tall tales of "
-"travel, full of outrageous lies.  He also gives you, your share of the "
-"profits..."
-msgstr ""
-"El maestro mercader llega a tu castillo. Te cuenta grandes historias de "
-"viajes, llenas de escandalosas mentiras. También te da tu parte de las "
-"ganancias..."
-
-#: ../fheroes2/resource/maps_text.cpp:677
-msgid ""
-"The Master Merchant arrives back at your Castle.  He tells you tall tales of "
-"faraway places full of outrageous lies.  He also gives you, your share of "
-"the profits..."
-msgstr ""
-"El maestro mercader vuelve a tu castillo. Te cuenta grandes historias sobre "
-"lugares lejanos llenas de escandalosas mentiras."
-
-#: ../fheroes2/resource/maps_text.cpp:678
-msgid "The Medusas have the password and they can be found just to the west."
-msgstr "Las Medusas tienen la contraseña y se las puede encontrar al oeste."
-
-#: ../fheroes2/resource/maps_text.cpp:679
-msgid "The more there is the less you see."
-msgstr "Mientras más hay menos ves."
-
-#: ../fheroes2/resource/maps_text.cpp:680
-msgid "The North Road to Roland's castle."
-msgstr "La Carretera Norte al castillo de Roland."
-
-#: ../fheroes2/resource/maps_text.cpp:681
-msgid ""
-"The note in this bottle has become mostly indecipherable. All you can make "
-"out are references to deadly pirates, and hidden gold mines."
-msgstr ""
-"La nota de la botella está prácticamente indescifrable. Todo lo que puedes "
-"interpretar hace referencia a piratas mortales, y minas de oro ocultas."
-
-#: ../fheroes2/resource/maps_text.cpp:682
-msgid "The Other Side"
-msgstr "El Otro Lado"
-
-#: ../fheroes2/resource/maps_text.cpp:683
-msgid ""
-"The Overlord has given you 4 months to conquer this land or deliver to him "
-"the sum of 150,000 gold."
-msgstr ""
-"El Jefe Supremo te ha dado cuatro meses para conquistar esta tierra, o "
-"enviarle la suma de 150,000 piezas de oro."
-
-#: ../fheroes2/resource/maps_text.cpp:684
-msgid ""
-"The people on the Isle of Knowledge are taking up a collection to aid us."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:685
-msgid "The Proving Grounds"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:686
-msgid "The Queen's Road."
-msgstr "El Camino de la Reina."
-
-#: ../fheroes2/resource/maps_text.cpp:687
-msgid "The Realm of Air is barred, but you may appeal here for help."
-msgstr "El Reino del Aire está prohibido, pero puedes buscar ayuda aquí."
-
-#: ../fheroes2/resource/maps_text.cpp:688
-msgid ""
-"There are remnants of a mighty battle fought here, not too long ago. It "
-"looks as if whoever came this way may have made this their final stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:689
-msgid ""
-"There are three enemy castles to the north. Capture them in the name of "
-"Roland the true king!"
-msgstr ""
-"Hay tres castillos enemigos al norte. ¡Captúralos en nombre de Roland, el "
-"rey verdadero!"
-
-#: ../fheroes2/resource/maps_text.cpp:690
-msgid ""
-"The Red Tide of War rolls North.  Stopping the flood seems hopeless.  Yet, "
-"Honor demands you and your ally die trying."
-msgstr ""
-"La Marea Roja de la Guerra avanza hacia el Norte. Tratar de detener la "
-"avalancha parece imposible. Aún así, el honor exige que tú y tua aliado "
-"mueran intentándolo."
-
-#: ../fheroes2/resource/maps_text.cpp:691
-msgid "There is hidden treasure north of the Green Lord's Ore Mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:692
-msgid "There is hidden treasure south of the Blue Lord's Sawmill."
-msgstr "Hay tesoros escondidos al sur de la Serrería del Señor Azul."
-
-#: ../fheroes2/resource/maps_text.cpp:693
-msgid "There's a warm wind blowing from the south."
-msgstr "Sopla un viento cálido del sur."
-
-#: ../fheroes2/resource/maps_text.cpp:694
-msgid "There's a Wizard living in the north who is behind this peasant revolt."
-msgstr ""
-"Hay un Mago que vive en el norte que está detrás de esta revuelta de "
-"campesinos."
-
-#: ../fheroes2/resource/maps_text.cpp:695
-msgid "The Retreat of the Alchemist Doctor Yu"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:696
-msgid ""
-"There used to be a mine here, but it has long since run out of ore.  You are "
-"only able to scavenge 5 units of ore from the old site."
-msgstr ""
-"Aquí solía haber una mina, pero hace tiempo que está agotada. Apenas eres "
-"capaz de conseguir 5 unidades de mineral de el viejo lugar."
-
-#: ../fheroes2/resource/maps_text.cpp:697
-msgid "There was a shipreck in the far east waters recently."
-msgstr "Hubo un naufragio en aguas orientales hace poco."
-
-#: ../fheroes2/resource/maps_text.cpp:698
-msgid "The River Styx"
-msgstr "El Río Estigio"
-
-#: ../fheroes2/resource/maps_text.cpp:699
-msgid "The roars of several dragons echo from the towers."
-msgstr "El eco de los rugidos de varios dragones retumba desde las torres."
-
-#: ../fheroes2/resource/maps_text.cpp:700
-msgid "The Rock Store."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:701
-msgid "The Royal Gardens."
-msgstr "Los Jardines Reales."
-
-#: ../fheroes2/resource/maps_text.cpp:702
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you against your enemies."
-msgstr ""
-"Los Eruditos, Sacerdotes y Sacerdotisas de la isla te han dado lo que han "
-"podido para ayudarte contra tus enemigos."
-
-#: ../fheroes2/resource/maps_text.cpp:703
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you defend against your enemies."
-msgstr ""
-"Los Eruditos, Sacerdotes y Sacerdotisas de la isla te han dado lo que han "
-"podido para ayudarte a defenderte de tus enemigos."
-
-#: ../fheroes2/resource/maps_text.cpp:704
-msgid "These doors are a risk the likes of which you do not know."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:705
-msgid "These lands are beholden to Lord Kraeger."
-msgstr "Estas tierras son vigiladas por Lord Kraeger."
-
-#: ../fheroes2/resource/maps_text.cpp:706
-msgid ""
-"These lands are desolate and for the most part devoid of resources. Not even "
-"the bravest heroes dare to venture into them, and plants are rare and "
-"precious here. Who knows what else awaits?"
-msgstr ""
-"Estas tierras están desiertas y en general carecen de recursos. Ni siquiera "
-"los héroes más valientes se atreven a adentrarse en ellas, además las "
-"plantas son escasas aquí. ¿Quién sabe qué mas aguarda?"
-
-#: ../fheroes2/resource/maps_text.cpp:707
-msgid ""
-"The Southern Witch is biding her time.  She will strike when your armies are "
-"weak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:708
-msgid "the stairs"
-msgstr "las escaleras"
-
-#: ../fheroes2/resource/maps_text.cpp:709
-msgid "The Table in the Great Hall of the Castle is Haunted."
-msgstr "La Mesa del Gran Salón del Castillo está Embrujada."
-
-#: ../fheroes2/resource/maps_text.cpp:710
-msgid ""
-"The third piece of the artifact is somewhere to the north, that much we "
-"know. We are still unsure of its exact location, but our spies are out "
-"gathering information. The forces in this area are too strong to be "
-"completely subjugated, so take what you can and hold on to it tightly."
-msgstr ""
-"Por lo que sabemos, la tercera pieza del artefacto está en algún lugar al "
-"norte. Aún no sabemos su ubicación exacta, pero nuestros espías están "
-"reuniendo información. Las fuerzas en el área son demasiado fuertes para ser "
-"completamente sometidas, así que coge lo que puedas y agárralo fuerte."
-
-#: ../fheroes2/resource/maps_text.cpp:711
-msgid ""
-"The troops have sworn their allegiance, but should lose a battle they will "
-"lose faith and our cause will be lost."
-msgstr ""
-"Las tropas nos han jurado lealtad, pero en caso de que perdieran una "
-"batalla, también perderían la fe y nuestra causa se perdería."
-
-#: ../fheroes2/resource/maps_text.cpp:712
-msgid "The Valley of Aruk."
-msgstr "El Valle de Aruk."
-
-#: ../fheroes2/resource/maps_text.cpp:713
-msgid ""
-"The Valley of Magic holds many surprises.  You discover an old pair of boots "
-"sticking out of the sand."
-msgstr ""
-"El Valle de la Magia esconde muchas sorpresas. Descubres un viejo par de "
-"botas sobresaliendo de la arena."
-
-#: ../fheroes2/resource/maps_text.cpp:714
-msgid "The Valley of Tresures"
-msgstr "El Valle de los Tesoros"
-
-#: ../fheroes2/resource/maps_text.cpp:715
-msgid "The Wasteland"
-msgstr "El Yermo"
-
-#: ../fheroes2/resource/maps_text.cpp:716
-msgid "The way of magic"
-msgstr "El camino de la mágia"
-
-#: ../fheroes2/resource/maps_text.cpp:717
-msgid "The way of might"
-msgstr "El camino del poder"
-
-#: ../fheroes2/resource/maps_text.cpp:718
-msgid "The way of numbers"
-msgstr "El camino de los números"
-
-#: ../fheroes2/resource/maps_text.cpp:719
-msgid "The western town."
-msgstr "Oeste de la ciudad"
-
-#: ../fheroes2/resource/maps_text.cpp:720
-msgid "The winds howl in mourning around the shipwreck."
-msgstr "El viento aúlla un lamento en torno al pecio."
-
-#: ../fheroes2/resource/maps_text.cpp:721
-msgid "The wizard has an island in the southeast."
-msgstr "El mago tiene una isla al sureste."
-
-#: ../fheroes2/resource/maps_text.cpp:722
-msgid ""
-"The Wizards who have captured the Necromancers' town have wasted no time in "
-"building defenses designed to stop you, and their last castle has just been "
-"completed. Fortunately only a Captain of the Guard and a small garrison are "
-"currently present.  If you hurry, you should be able to capture the castle "
-"before they have a chance to reinforce it!"
-msgstr ""
-"Los Magos que capturaron la ciudad del Necromante no han perdido el tiempo "
-"para construir defensas destinadas a detenerte, y su último castillo acaba "
-"de completarse. Afortunadamente sólo están presentes ahora mismo un Capitán "
-"de la Guardia y una pequeña guarnición. Si te apresuras, debieras de poder "
-"capturar el castillo antes de que tengan oportunidad de enviar refuerzos."
-
-#: ../fheroes2/resource/maps_text.cpp:723
-msgid "The wood has arrived."
-msgstr "Ha llegado la madera."
-
-#: ../fheroes2/resource/maps_text.cpp:724
-msgid "The writing on this sign is too faded to read."
-msgstr "Esta señal está demasiado desgastada como para leerse."
-
-#: ../fheroes2/resource/maps_text.cpp:725
-msgid "The Yellow Lord has the Ultimate Artifact."
-msgstr "El Señor Amarillo tiene en su poder el Artefacto Definitivo."
-
-#: ../fheroes2/resource/maps_text.cpp:726
-msgid ""
-"The Yellow Lord is a hothead who will attack before his allies can send him "
-"aid."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:727
-msgid "They say there's mermaids in these waters..."
-msgstr "Dicen que hay sirenas en esas aguas..."
-
-#: ../fheroes2/resource/maps_text.cpp:728
-msgid ""
-"This area is rich in resources. Explore, but beware, a castle left "
-"undefended will quickly fall."
-msgstr ""
-"Este área es rica en recursos. Explórala pero ten cuidado, un castillo no "
-"defendido caerá rapidaménte."
-
-#: ../fheroes2/resource/maps_text.cpp:729
-msgid ""
-"This area must be secured for the sake of the Empire. Our spies have "
-"reported a discord between The kingdom of the knights to the north, and that "
-"of the oppressive sorceresses to the northeast. Perhaps this feud can be "
-"exploited for our gain..."
-msgstr ""
-"Esta área debe ser segura por el bien del Imperio. Nuestros espías han "
-"informado de un desacuerdo entre El Reino de los caballeros del norte, y la "
-"opresiva hechicera del noreste. Quizás esta contienda pueda ser explotada "
-"para nuestro beneficio..."
-
-#: ../fheroes2/resource/maps_text.cpp:730
-msgid "This bottle is empty."
-msgstr "La botella está vacía."
-
-#: ../fheroes2/resource/maps_text.cpp:731
-msgid ""
-"This is the last week you have to find the rebel wizard Joseph! Good Luck in "
-"your quest."
-msgstr ""
-"Esta es la última semana que tienes para encontrar al mago rebelde Joseph. "
-"Buena suerte en tu búsqueda."
-
-#: ../fheroes2/resource/maps_text.cpp:732
-msgid ""
-"This land and all others are now under the sole ownership of Ibn Fadlan, the "
-"Undead King. Any disregard for his magesty's soverign rule is to be punished "
-"by death most horrendous."
-msgstr ""
-"Esta tierra y todas las demás están ahora bajo la única propiedad de Ibn "
-"Fadlan, el Rey No-muerto. Cualquier descuido a la soberanía de su majestad "
-"será castigado con la más horrenda de las muertes."
-
-#: ../fheroes2/resource/maps_text.cpp:733
-msgid ""
-"This land has been claimed by the nation of Neroli. Interlopers are "
-"UNWELCOME."
-msgstr ""
-"Esta tierra ha sido reclamada por la nación de Neroli. Los intrusos NO SON "
-"BIENVENIDOS."
-
-#: ../fheroes2/resource/maps_text.cpp:734
-msgid ""
-"This rugged land will have rivals fighting the terrain as well as each other."
-msgstr ""
-"Esta áspera tierra tendrá rivales luchando tanto con el terreno como contra "
-"los demás."
-
-#: ../fheroes2/resource/maps_text.cpp:735
-msgid ""
-"This rundown village looks like it was once the epicenter of an enormous, "
-"but now ruined, city. Under a pile of rubble you find an object which looks "
-"like it has lain there for ages."
-msgstr ""
-"Este pueblo parece que una vez fue el centro de una ciudad enorme, pero hoy "
-"en día arruinada. Bajo un montón de escombros encuentras un objeto que "
-"parece haber estado allí por siglos."
-
-#: ../fheroes2/resource/maps_text.cpp:736
-msgid ""
-"This spot overlooks an old quarry.  This was one of the only places in the "
-"world where ore could be taken right out of the ground.  Unfortunately the "
-"jungle has reclaimed the quarry and it is unusable.  You collect the last of "
-"the ore and depart."
-msgstr ""
-"Desde este lugar se domina una vieja guarnición. Este era uno de los pocos "
-"lugares del mundo en los que se podían extraer minerales directamente de la "
-"tierra. Desafortunadamente, la selva ha reclamado la guarnición y es "
-"inutilizable. Recoges el resto de minerales que queda, y partes."
-
-#: ../fheroes2/resource/maps_text.cpp:737
-msgid ""
-"This twisted maze of sorceress towns has three factions struggling for sole "
-"control.  Use your resources wisely!"
-msgstr ""
-"Este laberinto retorcido de ciudades de hechiceras tiene tres facciones "
-"luchando por la supremación. ¡Usa con sabiduría tus recursos!"
-
-#: ../fheroes2/resource/maps_text.cpp:738
-msgid ""
-"This village appears to be in little better shape than the first one you "
-"saw. As you approach the village an old man hands you a slip of paper, with "
-"the following message, \"Joseph lives in the town of IslandHome.\""
-msgstr ""
-"El poblado parece estar en mejor forma que el primero que vistes. A medida "
-"que te acercas al poblado y anciano te entrega un trozo de papel con el "
-"siguiente mensaje, \"Joseph vive en la ciudad de IslandHome\"."
-
-#: ../fheroes2/resource/maps_text.cpp:739
-msgid ""
-"This village is in extremely poor shape. There is no chance of getting more "
-"than some of the lesser creatures here."
-msgstr ""
-"Esta aldea está en pésimo estado. No hay ninguna oportunidad de encontrar "
-"aquí más que algunas criaturas menores."
-
-#: ../fheroes2/resource/maps_text.cpp:740
-msgid "This way to the Necromancer Forest."
-msgstr "Al Bosque del Necromante."
-
-#: ../fheroes2/resource/maps_text.cpp:741
-msgid "Those who seek knowledge are welcome to the city of Chronos."
-msgstr ""
-"Sean bienvenidos a la ciudad de Chronos aquellos que buscan conocimiento."
-
-#: ../fheroes2/resource/maps_text.cpp:742
-msgid ""
-"Three Warlocks in the land of Dragons. Lose thy home and all will be lost. "
-"Conquer thy enemies and the land shall forever be yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:743
-msgid "Timberhill"
-msgstr "Timberhill"
-
-#: ../fheroes2/resource/maps_text.cpp:744
-msgid "Time for a refreshing drink."
-msgstr "Hora de una bebida refrescante."
-
-#: ../fheroes2/resource/maps_text.cpp:745
-msgid "Time is running out! The enemy's reinforcements are almost here."
-msgstr "¡Se acaba el tiempo! Los refuerzos del enemigo casi están aquí."
-
-#: ../fheroes2/resource/maps_text.cpp:746
-msgid "To pass you must pay troll."
-msgstr "Para pasar debes pagar al trol."
-
-#: ../fheroes2/resource/maps_text.cpp:747
-msgid "TreeHome"
-msgstr "Casa del árbol"
-
-#: ../fheroes2/resource/maps_text.cpp:748
-msgid "Trespassers will be EATEN!"
-msgstr "¡Los intrusos serán DEVORADOS!"
-
-#: ../fheroes2/resource/maps_text.cpp:749
-msgid "Trilobar"
-msgstr "Trilobar"
-
-#: ../fheroes2/resource/maps_text.cpp:750
-msgid "Troy"
-msgstr "Troya"
-
-#: ../fheroes2/resource/maps_text.cpp:751
-msgid "Tundara"
-msgstr "Tundara"
-
-#: ../fheroes2/resource/maps_text.cpp:752
-msgid "Turn back, friend, while you still can!"
-msgstr "¡Da la vuelta, amigo, mientras puedas!"
-
-#: ../fheroes2/resource/maps_text.cpp:753
-msgid "Turn Back Now!"
-msgstr "¡Da la vuelta ya!"
-
-#: ../fheroes2/resource/maps_text.cpp:754
-msgid "Turn Back Now or all will be LOST!"
-msgstr "¡Da la vuelta ya o todo se habrá perdido!"
-
-#: ../fheroes2/resource/maps_text.cpp:755
-msgid "Turn Back or DIE!"
-msgstr "¡Da la vuelta o MUERE!"
-
-#: ../fheroes2/resource/maps_text.cpp:756
-msgid "Turn Back or else!"
-msgstr "Retírate"
-
-#: ../fheroes2/resource/maps_text.cpp:757
-msgid "Turn back, you fool."
-msgstr "Da la vuelta, idiota."
-
-#: ../fheroes2/resource/maps_text.cpp:758
-msgid "\"Turning Point\""
-msgstr "\"Punto de retorno\""
-
-#: ../fheroes2/resource/maps_text.cpp:759
-msgid ""
-"Uae was the scurviest, pirate ye'd never wanta see. In all her years of "
-"murdering and thieving she amassed so much ill-gotten booty that she "
-"couldn't carry it around in her galleon.  Besides, even the meanest can't "
-"stay awake all the time.  Legend tells that she hid it so well, she was "
-"thinking that she just might forget where it was.  So she left clues around "
-"the islands, carved in stone.  Well, she's dead now.  It's up to you to "
-"recover her legacy."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:761
-msgid "Uncle Leo"
-msgstr "Tío Leo"
-
-#: ../fheroes2/resource/maps_text.cpp:762
-msgid "Uncle Milty"
-msgstr "Tío Milty"
-
-#: ../fheroes2/resource/maps_text.cpp:763
-msgid "Undead Armies"
-msgstr "Ejércitos No-muertos"
-
-#: ../fheroes2/resource/maps_text.cpp:764
-msgid "Unholy Alliance"
-msgstr "Alianza Impía"
-
-#: ../fheroes2/resource/maps_text.cpp:765
-msgid "Unite the Tribes. Don't lose your main hero, the first Descendant."
-msgstr ""
-"Une las Tribus. No pierdas a tu héroe principal, el primer Descendiente."
-
-#: ../fheroes2/resource/maps_text.cpp:766
-msgid "Valley of Death"
-msgstr "Valle de la Muerte"
-
-#: ../fheroes2/resource/maps_text.cpp:767
-msgid "Valley Of The Damned"
-msgstr "Valle de los Condenados"
-
-#: ../fheroes2/resource/maps_text.cpp:768
-msgid "Valley of the Kings."
-msgstr "Valle de los Reyes."
-
-#: ../fheroes2/resource/maps_text.cpp:769
-msgid "Vaultius"
-msgstr "Vaultius"
-
-#: ../fheroes2/resource/maps_text.cpp:770
-msgid "Vertigo"
-msgstr "Vértigo"
-
-#: ../fheroes2/resource/maps_text.cpp:771
-msgid "Vikings!"
-msgstr "¡Vikingos!"
-
-#: ../fheroes2/resource/maps_text.cpp:772
-msgid "Viper's Nest"
-msgstr "Nido de Víboras"
-
-#: ../fheroes2/resource/maps_text.cpp:773
-msgid "Vulcania"
-msgstr "Vulcania"
-
-#: ../fheroes2/resource/maps_text.cpp:774
-msgid "Warrior Knight"
-msgstr "Caballero Guerrero"
-
-#: ../fheroes2/resource/maps_text.cpp:775
-msgid "Wastelands"
-msgstr "Yermos"
-
-#: ../fheroes2/resource/maps_text.cpp:776
-msgid "Watch out for Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:777
-msgid "Waystop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:778
-msgid ""
-"\"We are at the edge of the world!\"  they scream.  \"What are we doing here?"
-"\""
-msgstr ""
-"\"¡Estamos en el borde del mundo!\", gritan. \"¿Qué estamos haciendo aquí?\""
-
-#: ../fheroes2/resource/maps_text.cpp:779
-msgid "Weddington"
-msgstr "Weddington"
-
-#: ../fheroes2/resource/maps_text.cpp:780
-msgid "Weed Patch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:781
-msgid ""
-"We found a weakness my lord. Capture castle Black Fang and victory is ours."
-msgstr ""
-"Encontramos un punto débil, mi Señor. Capturad el castillo Colmillo Negro y "
-"la victoria será nuestra."
-
-#: ../fheroes2/resource/maps_text.cpp:782
-msgid ""
-"We have just learned that the artifact is on an island north of this "
-"continent. However, there does not appear to be any means to get there. Stay "
-"very alert for any possible way across the narrow channel."
-msgstr ""
-"Acabamos de enterarnos de que el artefacto está en una isla al norte de este "
-"continente. Sin embargo, no parece haber manera de llegar allí. Mantente "
-"alerta por si hubiera alguna manera de cruzar el estrecho canal."
-
-#: ../fheroes2/resource/maps_text.cpp:783
-msgid ""
-"Welcome back general.  Have you finished the conquest of the northern "
-"lands?  What? you still have not finished your mission!  Get back there and "
-"teach those rebels a lesson!"
-msgstr ""
-"Bienvenido de vuelta, general. ¿Habéis completado la conquista de las "
-"tierras del norte? ¿Qué? ¡Aún no habéis terminado vuestra misión! ¡Regresad, "
-"y dad a esos rebeldes una lección!"
-
-#: ../fheroes2/resource/maps_text.cpp:784
-msgid "Welcome to Li'l Alctatraz! Vistors NOT welcome."
-msgstr "Bienvenidos a la Pequeña Alctatraz. Los visitantes NO son bienvenidos."
-
-#: ../fheroes2/resource/maps_text.cpp:785
-msgid ""
-"Welcome to Power Island. He who controls this Isle controls the Seven Lakes!"
-msgstr ""
-"Bienvenido a la Isla del Poder. ¡Quien controle esta Isla controlará los "
-"Siete Lagos!"
-
-#: ../fheroes2/resource/maps_text.cpp:786
-msgid "Welcome to the Sandbar."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:787
-msgid "Welcome to the sandy Isle."
-msgstr "Bienvenidos a la Isla Arenosa."
-
-#: ../fheroes2/resource/maps_text.cpp:788
-msgid "Welcome to the sorceress' guild."
-msgstr "Bienvenido al gremio de hechiceras."
-
-#: ../fheroes2/resource/maps_text.cpp:789
-msgid "Welcome to the Spiral Isles"
-msgstr "Bienvenido a las Islas Espirales"
-
-#: ../fheroes2/resource/maps_text.cpp:790
-msgid ""
-"Welcome to the wounderous Kitisland range.  Eruptions each day, beware of "
-"dragons."
-msgstr ""
-"Bienvenido a la maravillosa cordillera de Kitisland. Erupciones diarias, "
-"cuidado con los dragones."
-
-#: ../fheroes2/resource/maps_text.cpp:791
-msgid "Welcome to Windfall Island!"
-msgstr "¡Bienvenido a la Windfall Island!"
-
-#: ../fheroes2/resource/maps_text.cpp:792
-msgid "Welcome to your DOOM!"
-msgstr "¡Bienvenido a tu MUERTE!"
-
-#: ../fheroes2/resource/maps_text.cpp:793
-msgid "We'll join you - for the right price."
-msgstr "Nos uniremos a ti - por el precio justo."
-
-#: ../fheroes2/resource/maps_text.cpp:794
-msgid ""
-"Well placed bribes have won you a stronghold near the warring Barbarians. Be "
-"advised that given their proximity an unguarded castle is an open invitation "
-"to defeat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:795
-msgid "Westfork"
-msgstr "Westfork"
-
-#: ../fheroes2/resource/maps_text.cpp:796
-msgid "Westmoor"
-msgstr "Westmoor"
-
-#: ../fheroes2/resource/maps_text.cpp:797
-msgid "We told you not to drink!"
-msgstr "¡Te dijimos que no bebieras!"
-
-#: ../fheroes2/resource/maps_text.cpp:798
-msgid "What are you doing here?"
-msgstr "¿Qué estás haciendo aquí?"
-
-#: ../fheroes2/resource/maps_text.cpp:799
-msgid "What cannot be seen but only heard, and will not speak until spoken to?"
-msgstr "¿Qué no puede verse sino oírse, y no hablará hasta que se le hable?"
-
-#: ../fheroes2/resource/maps_text.cpp:800
-msgid "What everyday word is most often pronounced incorrectly?"
-msgstr "¿Qué palabra cotidiana se pronuncia de forma incorrecta más a menudo?"
-
-#: ../fheroes2/resource/maps_text.cpp:801
-msgid "What goes up and down but never moves?"
-msgstr "¿Qué va arriba y abajo pero nunca se mueve?"
-
-#: ../fheroes2/resource/maps_text.cpp:802
-msgid ""
-"What good fortune!  You've discovered a long-abandoned settlement.  To your "
-"surprise, you discover that the previous inhabitants left some of their "
-"resources behind when they departed!"
-msgstr ""
-"¡Qué buena fortuna! Has descubierto un asentamiento abandonado hace mucho "
-"tiempo. Para tu sorpresa, descubres que los habitantes anteriores dejaron "
-"atrás algunos de sus recursos cuando se fueron."
-
-#: ../fheroes2/resource/maps_text.cpp:803
-msgid "What is always coming but never arrives?"
-msgstr "¿Qué está viniendo siempre, pero nunca llega?"
-
-#: ../fheroes2/resource/maps_text.cpp:804
-msgid "What is the Sum of all Numbers from 1 to 200?"
-msgstr "¿Cuál es la suma de todos los números de 1 a 200?"
-
-#: ../fheroes2/resource/maps_text.cpp:805
-msgid "What is time spent poorly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:806
-msgid "What's another word for pirate treasure?"
-msgstr "¿Otra palabra para tesoro pirata?"
-
-#: ../fheroes2/resource/maps_text.cpp:807
-msgid "What's behind door number one?"
-msgstr "¿Qué hay detrás de la puerta número uno?"
-
-#: ../fheroes2/resource/maps_text.cpp:808
-msgid "What's this? A pile of gems?"
-msgstr "¿Qué es esto? ¿Una montaña de gemas?"
-
-#: ../fheroes2/resource/maps_text.cpp:809
-msgid "What's this? Someone has left a pile of wood here!"
-msgstr "¿Qué es esto? ¡Alguien ha dejado una pila de madera aquí!"
-
-#: ../fheroes2/resource/maps_text.cpp:810
-msgid ""
-"What team won Super Bowl XXI and Super Bowl XXV?  (Hint... a Wizard might "
-"have these troops in his army)"
-msgstr ""
-"¿Qué equipo ganó la XXI y la XXV Super Bowl? (Pista... un mago podría tener "
-"estas tropas en su ejército)"
-
-#: ../fheroes2/resource/maps_text.cpp:811
-msgid "What turns everything around but does not move?"
-msgstr "¿Qué cambia todo a su alrededor pero no se mueve?"
-
-#: ../fheroes2/resource/maps_text.cpp:812
-msgid ""
-"What walks in the morning on four legs, two in the afternoon and three in "
-"the evening?"
-msgstr ""
-"¿Qué camina por la mañana a cuatro patas, sobre dos por la tarde, y a tres "
-"de noche?"
-
-#: ../fheroes2/resource/maps_text.cpp:813
-msgid "What?  What's this?  Something at the bottom of this pool..."
-msgstr "¿Qué? ¿Qué es eso? Hay algo en el fondo de este estanque..."
-
-#: ../fheroes2/resource/maps_text.cpp:814
-msgid "When you're ready, take the teleport to the Island's Hot Spot!"
-msgstr ""
-"Cuando estés listo, ¡usa el teletransporte y ve al Punto Caliente de la Isla!"
-
-#: ../fheroes2/resource/maps_text.cpp:815
-msgid ""
-"When you think yourself invincible, walk through this gate.  Even then, "
-"prepare to meet your bitter end."
-msgstr ""
-"Cuando creas que eres invencible, cruza esta puerta. Incluso entonces, "
-"prepárate para encontrarte con tu amargo final."
-
-#: ../fheroes2/resource/maps_text.cpp:816
-msgid "Where am I?"
-msgstr "¿Dónde estoy?"
-
-#: ../fheroes2/resource/maps_text.cpp:817
-msgid "While away seeking the Ultimate Artifact, Kastor's kingdom is invaded!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:818
-msgid ""
-"While traveling a mesenger meets you on the road.  His message tells of a "
-"new ally from an island far to the south.  This ally can not offer forces to "
-"your battle but has agreed to send some support in the form of gold and "
-"crystal."
-msgstr ""
-"Mientras viajas te cruzas con un mensajero en el camino. Su mensaje trata de "
-"un nuevo aliado proveniente de una isla al sur. Este aliado no puede ofrecer "
-"fuerzas para tu batellón pero se compromete a enviar ayuda en forma de oro y "
-"cristales."
-
-#: ../fheroes2/resource/maps_text.cpp:819
-msgid "Whiteshield"
-msgstr "Escudoblanco"
-
-#: ../fheroes2/resource/maps_text.cpp:820
-msgid "Whittingham"
-msgstr "Whittingham"
-
-#: ../fheroes2/resource/maps_text.cpp:821
-msgid "Who am I?"
-msgstr "¿Quién soy?"
-
-#: ../fheroes2/resource/maps_text.cpp:822
-msgid ""
-"Who am I?...  Where am I?...  Oh no! My Ship!  Well it's consigned to the "
-"ghosts of my dead crew now, at least I still have my lucky rabbits foot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:823
-msgid "Who is the true King?"
-msgstr "¿Quién es el Rey verdadero?"
-
-#: ../fheroes2/resource/maps_text.cpp:824
-msgid ""
-"\"Why have we come this way?\"  asks the first mate.  You have no answer."
-msgstr ""
-"\"¿Por qué hemos venido por aquí?\" pregunta el primer amigo. No tienes "
-"contestación."
-
-#: ../fheroes2/resource/maps_text.cpp:825
-msgid "Wicked Warlock Way"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:826
-msgid "Wilasher"
-msgstr "Wilasher"
-
-#: ../fheroes2/resource/maps_text.cpp:827
-msgid "Wildabar"
-msgstr "Wildabar"
-
-#: ../fheroes2/resource/maps_text.cpp:828
-msgid "Wilgatus"
-msgstr "Wilgatus"
-
-#: ../fheroes2/resource/maps_text.cpp:829
-msgid "Willow"
-msgstr "Sauce"
-
-#: ../fheroes2/resource/maps_text.cpp:830
-msgid "Windfall Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:831
-msgid "Winterkill"
-msgstr "Winterkill"
-
-#: ../fheroes2/resource/maps_text.cpp:832
-msgid "Winterlands"
-msgstr "Winterlands"
-
-#: ../fheroes2/resource/maps_text.cpp:833
-msgid "Witch Hunt"
-msgstr "Caza de Brujas"
-
-#: ../fheroes2/resource/maps_text.cpp:834
-msgid ""
-"With the year long eruption of Mt. Kitisland, your three worst enemies now "
-"have a ground bridge to your eastern contenent."
-msgstr ""
-"Con la erupción de un año del Monte Kitisland, tus tres peores enemigos "
-"tienen ahora un puente de roca hasta tu continente oriental."
-
-#: ../fheroes2/resource/maps_text.cpp:835
-msgid "Wizardwood.  Magicians welcome!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:836
-msgid "Woodhaven"
-msgstr "Woodhaven"
-
-#: ../fheroes2/resource/maps_text.cpp:837
-msgid "Wood's Lord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:838
-msgid "Woodstock"
-msgstr "Woodstock"
-
-#: ../fheroes2/resource/maps_text.cpp:839
-msgid "Woodville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:840
-msgid "Wormed Ash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:841
-msgid "Wow, somebody has left a pile of wood here!"
-msgstr "¡Vaya!, ¡alguien ha dejado una pila de madera aquí!"
-
-#: ../fheroes2/resource/maps_text.cpp:842
-msgid "Wyrm"
-msgstr "Wyrm"
-
-#: ../fheroes2/resource/maps_text.cpp:843
-msgid "Xabran"
-msgstr "Xabran"
-
-#: ../fheroes2/resource/maps_text.cpp:844
-msgid "Yellow gets some stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:845
-msgid "Yellow's Steady Cash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:846
-msgid "Yellow stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:847
-msgid "Yellow's Yarbols"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:848
-msgid "Ye old fish liver oil."
-msgstr "Aceite de hígado de bacalao."
-
-#: ../fheroes2/resource/maps_text.cpp:849
-msgid "Yorksford"
-msgstr "Yorksford"
-
-#: ../fheroes2/resource/maps_text.cpp:850
-msgid ""
-"You and your ally's families were given custody of The Isle of Knowledge.  "
-"Other Lords feel the time has come for new guardians..."
-msgstr ""
-"A tu familia y la de tus aliados se le dio en custodia la Isla del "
-"Conocimiento. Otros Señores piensan que ha llegado la hora de que tenga "
-"nuevos guardianes..."
-
-#: ../fheroes2/resource/maps_text.cpp:851
-msgid "You are a fool to come here!"
-msgstr "¡Eres un necio por haber venido aquí!"
-
-#: ../fheroes2/resource/maps_text.cpp:852
-msgid "You are fighting on the side of your king!"
-msgstr "¡Estás luchando en el bando de tu rey!"
-
-#: ../fheroes2/resource/maps_text.cpp:853
-msgid "You are fighting on the side of your sister!"
-msgstr "¡Estás luchando en el bando de tu hermana!"
-
-#: ../fheroes2/resource/maps_text.cpp:854
-msgid "You are now entering the domain of Prince Roland. Have a nice day."
-msgstr ""
-"Está usted entrando en los dominios del Príncipe Roland. Que tenga un buen "
-"día."
-
-#: ../fheroes2/resource/maps_text.cpp:855
-msgid "You are now entering the domain of Prince Roland. Have a pleasant stay."
-msgstr ""
-"Está usted entrando en los dominios del Príncipe Roland. Que tenga una "
-"estancia agradable."
-
-#: ../fheroes2/resource/maps_text.cpp:856
-msgid ""
-"You bribe the entrance guards of this dingy prison camp. They agree to look "
-"the other way for a little while."
-msgstr ""
-"Sobornas a los guardias de la entrada de este sucio campo de prisioneros. "
-"Están de acuerdo en mirar para otro lado durante un rato."
-
-#: ../fheroes2/resource/maps_text.cpp:857
-msgid ""
-"You can only reach your enemies via teleporters, but each jump is a leap of "
-"faith."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:858
-msgid ""
-"You cautiously ride through the trees, looking out for enemy assaults, when "
-"suddenly, the old elf is beside you. \"Your quest is almost at an end, my "
-"friend. All that remains is for you to lay seige to these last few castles. "
-"The fate of my people rests upon your final battles here. May the gods be "
-"with you as well.\"  He turns to leave, but you ask him his name before he "
-"is gone. Over his shoulder, as he is leaving he says \"I am Ilthanis, king "
-"of the elves.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:859
-msgid ""
-"You come across the dead remains of what was appearantly a powerful wizard!  "
-"You wonder if it's safe to continue."
-msgstr ""
-"Te encuentras con los restos de lo que aparentemente fue un poderoso mago. "
-"Te planteas si es seguro seguir adelante."
-
-#: ../fheroes2/resource/maps_text.cpp:860
-msgid ""
-"You face three opponents in this scenario. Capture their castles and their "
-"heroes to prove your worthiness to Archibald."
-msgstr ""
-"Te enfrentas a tres oponentes en este escenario. Captura sus castillos y sus "
-"héroes para probar tu valía ante Archibald."
-
-#: ../fheroes2/resource/maps_text.cpp:861
-msgid ""
-"You find a beautiful helm buried in the lava.  As you move to put it on your "
-"head it turns into the Hideous mask and now you realize that no creature "
-"will join you."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:862
-msgid ""
-"You find a gleaming gold medalion buried in the  snow.  As you move to put "
-"it on it changes to the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:863
-msgid ""
-"You find an old signpost in the midst of a thicket that reads \"Warlock "
-"Wood, West.  Barbarian Fields, East.\""
-msgstr ""
-"Encuentras en medio de la espesura una señal que lee \"Bosque de los Brujos, "
-"al Oeste. Campos de los Bárbaros, Este.\""
-
-#: ../fheroes2/resource/maps_text.cpp:864
-msgid ""
-"You find a note in the bottle! It reads, \"My ship has been wrecked by the "
-"notorious pirates in this area! I am stranded on a small and barren island. "
-"Please, I beg you to come and rescue me!\""
-msgstr ""
-"¡Encuentras una nota en la botella! En ella se lee: \"Mi barco ha sido "
-"hundido por los famosos piratas de este área. Estoy perdido en una pequeña "
-"isla. ¡Por favor, te ruego que vengas y me rescates!"
-
-#: ../fheroes2/resource/maps_text.cpp:865
-msgid "You found something!"
-msgstr "¡Has encontrado algo!"
-
-#: ../fheroes2/resource/maps_text.cpp:866
-msgid "You found Treasure!"
-msgstr "¡Has encontrado Tesoros!"
-
-#: ../fheroes2/resource/maps_text.cpp:867
-msgid ""
-"You have been ordered here to claim this land in the name of your King and "
-"recover any riches that you might find.  However, five other Kings and "
-"Queens have also sent their heroes to this land, so you must watch out for "
-"them as well as the natives!"
-msgstr ""
-"Has sido enviado aquí para reclamar esta tierra en nombre de tu Rey, y "
-"obtener cualquier riqueza que pudieras encontrar. Sin embargo, otros cinco "
-"Reyes y Reinas han enviado también a sus héroes a esta tierra, así que debes "
-"de vigilar tanto a ellos como a los nativos."
-
-#: ../fheroes2/resource/maps_text.cpp:868
-msgid "You have found what someone else has lost..."
-msgstr "Has encontrado lo que alguien perdió..."
-
-#: ../fheroes2/resource/maps_text.cpp:869
-msgid ""
-"You have hired a barbarian of great power to aid you in this, your last "
-"quest. His origins are unknown to you, but you sense strong nobility beneath "
-"the furs and dirt that cover him. In addition, the famous explorer, Marco "
-"the wizard, is rumored to have wrecked his ship in this new land. Finding "
-"him would prove to be a much needed boon to your cause."
-msgstr ""
-"Has contratado a un poderoso bárbaro para que te ayude con ésta, tu última "
-"búsqueda. Sus orígenes te son desconocidos, pero eres capaz de sentir la "
-"fuerte nobleza bajo las pieles y la suciedad que le cubren. Además, Marco el "
-"Mago, el famoso explorador, naufragó frente a estas tierras. Encontrarle "
-"sería una bendición para tu causa."
-
-#: ../fheroes2/resource/maps_text.cpp:870
-msgid ""
-"You have just 8 weeks  to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-"Sólo dispones de 8 semanas para formar tu ejército y conquistar una ciudad "
-"del otro lado del lejano rio. Hay tres caminos a seguir, ¿cuál escojerás?"
-
-#: ../fheroes2/resource/maps_text.cpp:871
-msgid ""
-"You have just 8 weeks to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-"Sólo dispones de 8 semanas para formar tu ejército y conquistar una ciudad "
-"del otro lado del lejano rio. Hay tres caminos a seguir, ¿cuál escojerás?"
-
-#: ../fheroes2/resource/maps_text.cpp:872
-msgid ""
-"You have received a message from Archibald. \"General, these peasants "
-"deserve punishment. Put them to the sword and let Corlagon have his way with "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:873
-msgid ""
-"You have received a message from Archibald.  \" HOW DARE YOU BETRAY ME! I "
-"will see your head on the block alongside your new master's once I have won."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:874
-msgid ""
-"You have received a message from Roland. \" I am shocked! I had thought "
-"better of you, but I was terribly wrong. Now you'll have to live with your "
-"dark decision for the rest of your life.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:875
-msgid "You have recieved a shipment of supplies from your kingdom!"
-msgstr "¡Has recibido un cargamento con suministris desde tu reino!"
-
-#: ../fheroes2/resource/maps_text.cpp:876
-msgid ""
-"You have recieved a shipment of supplies from your kingdom! There is a note "
-"attached, \"These are all we could afford to send you from our treasuries, "
-"as the war with Harondale is taxing us greatly. We will send more in two "
-"weeks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:877
-msgid ""
-"You have six months to destroy the Necromancer Stronghold in the heart of "
-"the valley."
-msgstr ""
-"Tienes seis meses para destruir la Fortaleza del Necromante, en el corazón "
-"de este valle."
-
-#: ../fheroes2/resource/maps_text.cpp:878
-msgid ""
-"You have washed up on the beach after being shipwrecked. Your goal is to "
-"find a way home."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:879
-msgid ""
-"You hear a low rumble, look up and see an avalanche!  You dive onto a large "
-"patch of grass to avoid it.  While dusting yourself off, you consider "
-"yourself quite lucky to be alive.  Luckier still to find a Four-Leaf Clover "
-"stuck on your nose."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:880
-msgid ""
-"You hear a rumor from a peasant who lives in the town of Waystop. He says, "
-"\"The pirates control most of the sulfur mines in this area. They use it for "
-"the cannons on their bigger boats. If you want a mine, you'll have to defeat "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:881
-msgid "You hear melodic strains of elvish music as you enter this clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:882
-msgid ""
-"You must, like, forsake your earthly wealth and, like, join us on the island "
-"of the lotus eaters."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:883
-msgid ""
-"You must search the world for your mortal enemy, Wilgatus.  Can you find him "
-"before its too late?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:884
-msgid ""
-"You notice some runes hastily scrawled into a rock by your feet, They look "
-"like the initials of Uncle Ivan!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:885
-msgid ""
-"You notice that mines and resources in the elvish lands are few, and you "
-"send word to your kingdom that you will need extra supplies. They should "
-"respond within a fortnight."
-msgstr ""
-"Te das cuenta de que las minas y los recursos de las tierras elfas son "
-"escasos, y envías un mensaje a tu reino de que necesitarás recursos extra. "
-"Debieran de responderte en una quincena."
-
-#: ../fheroes2/resource/maps_text.cpp:886
-msgid ""
-"Your advance scouts come riding back to you with the following news. They "
-"believe they have found signs that Uncle Ivan was in this general area, and "
-"that he made his way to the north many months ago. Also they say there is a "
-"town nearby and many resources to the east."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:887
-msgid ""
-"Your advisor approaches you, \"My liege, something must be done about these "
-"peasants! They still refuse to work.  At this rate you won't have anything "
-"to put in your daughter's dowry!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:888
-msgid ""
-"Your advisor approaches you smiling greatly, \"My liege! The peasants are "
-"making money in the market, and are finally paying taxes!\""
-msgstr ""
-"Tu consejero se acerca, sonriendo ampliamente: \"¡Mi Señor! Los campesinos "
-"están haciendo dinero en el mercado, y !por fin están pagando impuestos!\""
-
-#: ../fheroes2/resource/maps_text.cpp:889
-msgid ""
-"Your advisor approaches you with a long face, \"My liege, the peasant's "
-"numbers are growing steadily.  All they do is take, take, take! We are "
-"beginning to suffer dearly because of them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:890
-msgid ""
-"Your advisor approaches you with some startling information, \"My liege, the "
-"peasants are draining us. They do nothing, and take everything! We must get "
-"them home. Your own citizens are beginning to suffer!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:891
-msgid ""
-"Your arrival here was a surprise to those sworn to guard Dragon Isle, and "
-"you were able to quickly capture one of their castles.  Use caution, though, "
-"for two other guardians remain in this jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:892
-msgid ""
-"Your castle, founded inside the center of a mile wide crater, is besieged by "
-"those who desire your mineral wealth."
-msgstr ""
-"Tu castillo, fundado en el interior del centro de un cráter de más de una "
-"milla de ancho, está siendo asediado por aquellos que ansían tu riqueza "
-"mineral."
-
-#: ../fheroes2/resource/maps_text.cpp:893
-msgid "Your castle is the last outpost in the area, Don't lose it!"
-msgstr "¡Tu castillo es el ultimo bastión de la zona, no lo pierdas!"
-
-#: ../fheroes2/resource/maps_text.cpp:894
-msgid "Your crew begins to grumble."
-msgstr "Tu equipo empieza a quejarse."
-
-#: ../fheroes2/resource/maps_text.cpp:895
-msgid ""
-"Your crew seriously entertains thoughts of mutiny.  Your nights are "
-"sleepless."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:896
-msgid "You're almost there!"
-msgstr "¡Ya casi ha terminado!"
-
-#: ../fheroes2/resource/maps_text.cpp:897
-msgid "You, recieve word that you have been robbed."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:898
-msgid "You're getting colder."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:899
-msgid "You're getting warmer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:900
-msgid ""
-"You're here! Oh, thank you thank you thank you! I'm in the jail east of the "
-"castle. Please hurry!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:901
-msgid ""
-"Your expedition has taken a turn for the worse... you now have no way to get "
-"home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:902
-msgid ""
-"Your forces are thinly spread in an effort to defend all the dwarf towns "
-"(which may not be transformed into castles). Consolidate your forces and "
-"smite the enemy before the towns fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:903
-msgid ""
-"Your horse stumbles and throws you from the saddle.  When you awaken you "
-"find that you have hit your head on the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:904
-msgid ""
-"Your isolation from the rest of the kingdom has largely kept you out of the "
-"political struggles, but now with the king's death, and lack of an heir, you "
-"see a golden opportunity to seize the throne for yourself.  Just remember "
-"that you have relied largely on trade for several key resources, especially "
-"sulfur, but with a little planning this land can be yours.  Go, now, and "
-"show these peasants how to rule!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:905
-msgid "Your king has sent supplies to aid the war effort."
-msgstr "Su rey ha enviado suministros para ayudar en la guerra."
-
-#: ../fheroes2/resource/maps_text.cpp:906
-msgid ""
-"Your opponents are allied against you and each is twice as powerful as his "
-"predecessor! Is it possible to win?"
-msgstr ""
-"Tus oponentes se han aliado contra ti, ¡y cada uno es el doble de poderoso "
-"que su predecesor! ¿Es posible vencer?"
-
-#: ../fheroes2/resource/maps_text.cpp:907
-msgid ""
-"Your Queen sent you here to explore this newly discovered territory, but a "
-"freak storm scattered your fleet and left you stranded.  You gather the "
-"survivors and form a small settlement, naming it New Vertigo.  This place is "
-"your home now, and survival is your highest priority, but remember, if you "
-"are captured or killed, it's over!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:908
-msgid ""
-"Your rival, the kingdom of Harondale, is attacking your weak border towns! "
-"Recover from their first strike and crush them completely."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:909
-msgid ""
-"Your Scouts report talking to a young knight, a squire to the two sleeping "
-"heroes.  The squire is trapped by the Aqua Magic Barriers and a group of "
-"fallen Paladins.  He says the two heroes, Dainwin and Ceallach, have "
-"awakened but are still trapped by a Gold Magical Barrier and asks your aid "
-"in freeing them."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:910
-msgid ""
-"Your Scouts report that the Aqua Traveller's Tent is located along The North "
-"Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:911
-msgid ""
-"Your scouts return with grim news.  The natives of this land are currently "
-"at war with each other, and they like outsiders even less than they like "
-"each other!  Congratulations, Commander, you're at war!"
-msgstr ""
-"Tus exploradores regresan con noticias horrendas. Los nativos de estas "
-"tierras están actualmente en guerra los unos con los otros, y los "
-"extranjeros les gustan aún menos. ¡Enhorabuena, Comandante, estás en guerra!"
-
-#: ../fheroes2/resource/maps_text.cpp:912
-msgid ""
-"Your sister calls you before her altar in the morning. \"I have important "
-"news,\" she says, \"The barbarian kingdoms which border this land have "
-"agreed to lend us some of their castles and warriors in return for a share "
-"of the spoils. I hope victory comes swiftly, but your presence gives me "
-"strength to stand until whatever end awaits.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:913
-msgid "Your subjects contribute to your war effort!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:914
-msgid ""
-"Your town is undefended and your heroes are scattered.  Do you attack or "
-"defend?"
-msgstr ""
-"Tu ciudad no tiene defensa y tus héroes están desperdigados. ¿Atacas o "
-"defiendes?"
-
-#: ../fheroes2/resource/maps_text.cpp:915
-msgid ""
-"Your treasury has been looted by robbers and you have lost valuable "
-"resources."
-msgstr ""
-"Tu tesoro ha sido saqueado por ladrones y has perdido valiosos recursos."
-
-#: ../fheroes2/resource/maps_text.cpp:916
-msgid "Your troops begin to wonder about your sanity."
-msgstr "Tus tropas empiezan a preguntarse acerca de su cordura."
-
-#: ../fheroes2/resource/maps_text.cpp:917
-msgid ""
-"You run aground on the rocks and have to use some wood to fix your boat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:918
-msgid ""
-"You see a family of refugees making their way from the beach. You ask them "
-"about their plight and they tell you that they are from a once great city "
-"called Moss Side. They tell you that the castle was destroyed in a great "
-"conflagration, and they fled for fear of their lives."
-msgstr ""
-"Ves a una familia de refugiados abriéndose camino desde la playa. Les "
-"preguntas por su situación, y te dicen que son de una ciudad que fue grande "
-"llamada Moss Side. También te cuentan que el castillo fue destruido en una "
-"gran conflagración, y que huyeron al temer por sus vidas."
-
-#: ../fheroes2/resource/maps_text.cpp:919
-msgid ""
-"You see an old man bringing water towards the stables. Recognizing him as "
-"the mystic, you attempt to thank him for his gift with some gold. He "
-"refuses, but says to you instead, \"There are riddles guarding the source of "
-"the fount's power, and the dragons know the answers. Make your way through "
-"their lair, and you shall know victory.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:920
-msgid ""
-"You see an old mystic perched on a rock. You walk towards him to see if he "
-"has any words for you on your quest, and he says \"First I see you as a "
-"great conquerer of the lands of men. Secondly, I see you as a mighty ruler "
-"of vast armies, well loved by your troops. Thirdly, I see you as a slayer of "
-"legions of dragons, your body bathed in their fire. Lastly, I see you "
-"standing on the shores of the fount, unable to cross.\" Then the Mystic "
-"fades away."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:921
-msgid "You see something that could just be the elusive Nubbie!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:922
-msgid ""
-"You see the mast of ancient ship here.  On further investigation you find "
-"that the ships holds are full of gems.  The hours pass as your crue "
-"liberates the treasure."
-msgstr ""
-"Ves el mástil de un navío antiguo. Tras investigar más, encuentras las "
-"bodegas del barco repletas de gemas. Pasan las horas mientras tus hombres "
-"liberan el tesoro."
-
-#: ../fheroes2/resource/maps_text.cpp:923
-msgid ""
-"You see the remains of a burned out sawmill here.  All you can salvage is "
-"some ofwood left for scrap."
-msgstr ""
-"Ves los restos calcinados de un aserradero. Lo único que puedes recuperar es "
-"algo de madera."
-
-#: ../fheroes2/resource/maps_text.cpp:924
-msgid ""
-"You see the remains of an old sawmill, but it is obvious that you will not "
-"be able to make it work again."
-msgstr ""
-"Ves los restos de un viejo aserradero, pero es obvio que no podrás ponerlo "
-"en marcha de nuevo."
-
-#: ../fheroes2/resource/maps_text.cpp:925
-msgid ""
-"You see the remains of an old sawmill just to realize that it will no longer "
-"produce.  You gather the ramains and move on."
-msgstr ""
-"Ves los restos de un viejo aserradero, sólo para darte cuenta de que no "
-"volverá a producir. Recoges los restos y sigues tu camino."
-
-#: ../fheroes2/resource/maps_text.cpp:926
-msgid ""
-"You send this letter back to the king,\"A month has passed and we have not "
-"discovered the wizard Joseph. I only hope that we are able to locate him in "
-"time to aid us in our struggle.\""
-msgstr ""
-"Envías esta carta de vuelta al rey, \"Ha pasado un mes y no hemos "
-"descubierto al mago Joseph. Sólo espero que seamos capaces de encontrarlo a "
-"tiempo para que nos ayude en nuestra lucha.\""
-
-#: ../fheroes2/resource/maps_text.cpp:927
-msgid "You should turn back."
-msgstr "Deberías volver."
-
-#: ../fheroes2/resource/maps_text.cpp:928
-msgid ""
-"You stumble upon an old man who proclaims you Lord of the Realm, hands you "
-"his boots and wonders into the mountains mumbling something about being late "
-"for an important date."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:929
-msgid ""
-"You stumple across three small rocks piled on top of each other and decide "
-"to dig undernear them.  There you find an old weather-beaten bag of gems."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:930
-msgid "You uncover a compass in the grass!"
-msgstr "¡Has descubierto una brújula en el cesped!"
-
-#: ../fheroes2/resource/maps_text.cpp:931
-msgid "You've been warned!"
-msgstr "¡Se te ha advertido!"
-
-#: ../fheroes2/resource/maps_text.cpp:932
-msgid ""
-"You've received a message from Roland. \"In the absence of a strong leader, "
-"the local lords have fallen to fighting. Uniting this area is critical to "
-"our cause, so we must not fail.  Leaving your castle undefended in this "
-"highly contested region will surely lead to defeat. I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:933
-msgid ""
-"You've received a message from the guild. \"Thank God you've arrived! We're "
-"under seige from two enemies from the north and one from across the sea. "
-"Please save us, you're our only hope.\""
-msgstr ""
-"Has recibido un mensaje del gremio. \"¡Gracias a Dios que has llegado! "
-"Estamos bajo asedio de dos enemigos del norte y uno de más allá del mar. Por "
-"favor, sálvanos, ¡eres nuestra única esperanza.\""
-
-#: ../fheroes2/resource/maps_text.cpp:934
-msgid ""
-"You've ruled with an iron fist (and an army of undead), but now your kingdom "
-"has turned against you!"
-msgstr ""
-"Has gobernado con puño de hierro (y un ejército de no-muertos), ¡pero ahora "
-"tu reino se ha vuelto contra ti!"
-
-#: ../fheroes2/resource/maps_text.cpp:935
-msgid ""
-"You've saved a group of miners from the dragons.  One of them approaches "
-"you, \"Thank you so much for saving us!  We found this sulfer and sword in "
-"the mine, then those dragons chased us!  I don't know how much longer we "
-"could survive!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:936
-msgid ""
-"You will clash quickly on this small head-to-head map, so stay on your toes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:937
-msgid ""
-"You will need a stronger army than that, mortal, to step through this portal."
-msgstr ""
-"Necesitarás un ejército más fuerte que ese, mortal, para cruzar este portal."
-
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Wood"
 msgstr "Madera"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Mercury"
 msgstr "Mercurio"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Ore"
 msgstr "Hierro"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Sulfur"
 msgstr "Azufre"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Crystal"
 msgstr "Cristal"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Gems"
 msgstr "Gemas"
 
-#: ../fheroes2/spell/spell_book.cpp:61 ../fheroes2/spell/spell_book.cpp:79
-msgid "No spell to cast."
-msgstr "No hay hechizo que lanzar."
-
-#: ../fheroes2/spell/spell_book.cpp:138
-msgid "Your hero has %{point} spell points remaining"
-msgstr "Tú héroe tiene todavía %{point} puntos de Maná."
-
-#: ../fheroes2/spell/spell.cpp:50
 msgid "Fireball"
 msgstr "Bola de Fuego"
 
-#: ../fheroes2/spell/spell.cpp:50
 msgid ""
 "Causes a giant fireball to strike the selected area, damaging all nearby "
 "creatures."
@@ -12656,11 +6352,9 @@ msgstr ""
 "Origina una Bola de Fuego gigante dañándo las criaturas del area "
 "seleccionada."
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid "Fireblast"
 msgstr "Explosión"
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid ""
 "An improved version of fireball, fireblast affects two hexes around the "
 "center point of the spell, rather than one."
@@ -12668,19 +6362,15 @@ msgstr ""
 "Una versión mejorada de Bola de Fuego, Explosión afecta a dos cuadrados "
 "alrededor del punto central del Hechizo, en vez de uno."
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Lightning Bolt"
 msgstr "Rayo"
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Causes a bolt of electrical energy to strike the selected creature."
 msgstr "Hace que un rayo de energía alcance a la criatura seleccionada."
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid "Chain Lightning"
 msgstr "Cadena de Rayos"
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid ""
 "Causes a bolt of electrical energy to strike a selected creature, then "
 "strike the nearest creature with half damage, then strike the NEXT nearest "
@@ -12693,130 +6383,103 @@ msgstr ""
 "demasiado debil para ser dañino. ADVERTENCIA: Este hechizo puede alcanzar a "
 "tus propias criaturas."
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid "Teleport"
 msgstr "Teletransporte"
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid ""
 "Teleports the creature you select to any open position on the battlefield."
 msgstr ""
 "Teletransporta la critatura seleccionada a cualquier punto desocupado del "
 "campo de batalla."
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid "Cure"
 msgstr "Cura"
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid ""
-"Removes all negative spells cast upon one of your units, and restores up to %"
-"{count} HP per level of spell power."
+"Removes all negative spells cast upon one of your units, and restores up to "
+"%{count} HP per level of spell power."
 msgstr ""
 "Quita todos los hechizos negativos que afecten a tus unidades, y restaura "
 "hasta %{count} puntos de vida por nivel del hechizo."
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid "Mass Cure"
 msgstr "Curar en Masas"
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid ""
-"Removes all negative spells cast upon your forces, and restores up to %"
-"{count} HP per level of spell power, per creature."
+"Removes all negative spells cast upon your forces, and restores up to "
+"%{count} HP per level of spell power, per creature."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrect"
 msgstr "Resurrección"
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrects creatures from a damaged or dead unit until end of combat."
 msgstr ""
 "Devuelve a la vida las criaturas de una unidad dañada o muerta hasta el "
 "final de combate."
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrect True"
 msgstr "Resurrección Verdadera"
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrects creatures from a damaged or dead unit permanently."
 msgstr ""
 "Devuelve permanentemente a la vida las unidades de una criatura muerta o "
 "dañana."
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Haste"
 msgstr "Prisa"
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Increases the speed of any creature by %{count}."
 msgstr "Aumenta la velocidad de cualquier criatura en %{count}."
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Mass Haste"
 msgstr "Prisa en Masas"
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Increases the speed of all of your creatures by %{count}."
 msgstr "Aumenta la velocidad de todas tus criaturas en %{count}."
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "spell|Slow"
 msgstr "hechizo|ralentizar"
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "Slows target to half movement rate."
 msgstr "Ralentiza el objetivo a la mitad del movimiento."
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Mass Slow"
 msgstr "Ralentizar en Masas"
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Slows all enemies to half movement rate."
 msgstr "Ralentiza a todos los enemigas a la mitad del movimiento."
 
-#: ../fheroes2/spell/spell.cpp:64
-msgid "Blind "
-msgstr "Ceguera "
+#, fuzzy
+msgid "spell|Blind"
+msgstr "hechizo|ralentizar"
 
-#: ../fheroes2/spell/spell.cpp:64
 msgid "Clouds the affected creatures' eyes, preventing them from moving."
 msgstr "Cubre los ojos de la criatura afectada, previniendo que se mueva."
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Bless"
 msgstr "Bendecir"
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Causes the selected creatures to inflict maximum damage."
 msgstr "Hace que las criaturas seleccionadas inflijan daños máximos."
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Mass Bless"
 msgstr "Bendición en Masa"
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Causes all of your units to inflict maximum damage."
 msgstr "Hace que todas tus unidades inflijan daños máximos."
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Stoneskin"
 msgstr "Piel de Roca"
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Magically increases the defense skill of the selected creatures."
 msgstr ""
 "Magicamente incrementa la habilidad de Defensa de las criaturas "
 "seleccionadas."
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid "Steelskin"
 msgstr "Piel de Acero"
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid ""
 "Increases the defense skill of the targeted creatures.  This is an improved "
 "version of Stoneskin."
@@ -12824,109 +6487,85 @@ msgstr ""
 "Incrementa la habilidad de Defensa de las criaturas seleccionadas. Ésta es "
 "una versión mejorada de Piel de Roca."
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Curse"
 msgstr "Maldición"
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Causes the selected creatures to inflict minimum damage."
 msgstr "Hace que las criaturas seleccionadas inflijan daños mínimos."
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Mass Curse"
 msgstr "Maldición en Masa."
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Causes all enemy troops to inflict minimum damage."
 msgstr "Hace que todas las tropas enemigas inflijan daños mínimos."
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Holy Word"
 msgstr "Palabra Sagrada"
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Damages all undead in the battle."
 msgstr "Daña a todos los Nomuertos en combate."
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid "Holy Shout"
 msgstr "Grito Sagrado"
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid ""
 "Damages all undead in the battle.  This is an improved version of Holy Word."
 msgstr ""
 "Daña a todos los nomuertos en la batalla. Es una versión mejorada de la "
 "Palabra Sagrada."
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Anti-Magic"
 msgstr "Anti-Magia"
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Prevents harmful magic against the selected creatures."
 msgstr "Previene de magia perjudicial contra la criatura seleccionada."
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Dispel Magic"
 msgstr "Disipar"
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Removes all magic spells from a single target."
 msgstr ""
 "Elimina todos los hechizos mágicos que afectan a la criatura que se "
 "selecciona."
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Mass Dispel"
 msgstr "Disipar en Masa"
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Removes all magic spells from all creatures."
 msgstr "Elimina todos los hechizos mágicos que afectan a todas las criaturas."
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Magic Arrow"
 msgstr "Flecha Mágica"
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Causes a magic arrow to strike the selected target."
 msgstr "Hace que una flecha mágica alcance al objetivo seleccionado."
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Berserker"
 msgstr "Berserker"
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Causes a creature to attack its nearest neighbor."
 msgstr "Hace que una criatura ataque a su vecino más cercano."
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid "Armageddon"
 msgstr "Armagedón"
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid ""
 "Holy terror strikes the battlefield, causing severe damage to all creatures."
 msgstr ""
 "El terror sagrado ataca el campo de batalla, causando daños severos a todas "
 "las criaturas."
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Elemental Storm"
 msgstr "LLuvia de Meteoritos"
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Magical elements pour down on the battlefield, damaging all creatures."
 msgstr ""
 "Elementos mágicos caen sobre el campo de batalla, dañando a todas las "
 "criaturas."
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid "Meteor Shower"
 msgstr "Lluvia de Meteoritos"
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid ""
 "A rain of rocks strikes an area of the battlefield, damaging all nearby "
 "creatures."
@@ -12934,39 +6573,31 @@ msgstr ""
 "Una lluvia de piedras se abate sobre el campo de batalla, dañando a todas "
 "criaturas cercanas."
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "Paralyze"
 msgstr "Paralizar"
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "The targeted creatures are paralyzed, unable to move or retaliate."
 msgstr ""
 "Las criaturas seleccionadas quedan paralizadas y no se pueden mover ni "
 "contratacar."
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid "Hypnotize"
 msgstr "Hipnotizar"
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid ""
-"Brings a single enemy unit under your control for one combat round if its "
-"hits are less than %{count} times the caster's spell power."
+"Brings a single enemy unit under your control if its hits are less than "
+"%{count} times the caster's spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Cold Ray"
 msgstr "Rayo Frío"
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Drains body heat from a single enemy unit."
 msgstr "Absorbe el calor del cuerpo de una sola unidad enemiga."
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid "Cold Ring"
 msgstr "Anillo Frío"
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid ""
 "Drains body heat from all units surrounding the center point, but not "
 "including the center point."
@@ -12974,27 +6605,21 @@ msgstr ""
 "Absorbe el calor del cuerdo de todas las unidades alrededor del punto "
 "central, pero sin incluir dicho punto."
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Disrupting Ray"
 msgstr "Rayo Pertubador"
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Reduces the defense rating of an enemy unit by three."
 msgstr "Reduce la defensa de una unidad enemiga en 3."
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Death Ripple"
 msgstr "Onda de la Muerte"
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Damages all living (non-undead) units in the battle."
 msgstr "Daña todas las unidades Vivientes (no Nomuertas) en la batalla."
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid "Death Wave"
 msgstr "Ola de la Muerte"
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid ""
 "Damages all living (non-undead) units in the battle.  This spell is an "
 "improved version of Death Ripple."
@@ -13002,37 +6627,29 @@ msgstr ""
 "Daña todas las unidades Vivientes (no Nomuertas) en la batalla. Es una "
 "versión mejorada de Onda de la Muerte."
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Dragon Slayer"
 msgstr "Matadragones"
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Greatly increases a unit's attack skill vs. Dragons."
 msgstr "Incrementa enormente tu habilidad de ataque contra Dragones."
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Blood Lust"
 msgstr "Ansia de Sangre"
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Increases a unit's attack skill."
 msgstr "Incrementa la habilidad de ataque de una unidad."
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Animate Dead"
 msgstr "Animar Muertos"
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Resurrects creatures from a damaged or dead undead unit permanently."
 msgstr ""
 "Devuelve permanentemente a la vida las unidades muertas o dañadas de una "
 "criatura Nomuerta."
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid "Mirror Image"
 msgstr "Doble Imagen"
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid ""
 "Creates an illusionary unit that duplicates one of your existing units.  "
 "This illusionary unit does the same damages as the original, but will vanish "
@@ -13042,126 +6659,96 @@ msgstr ""
 "causará los mismos daños que la original, pero se esfumará si recibe algún "
 "daño."
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Shield"
 msgstr "Escudo"
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Halves damage received from ranged attacks for a single unit."
 msgstr ""
 "Reduce a la midad los daños recibidos en ataques a distancia por una unidad."
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Mass Shield"
 msgstr "Escudo en Masa"
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Halves damage received from ranged attacks for all of your units."
 msgstr ""
 "Reduce a la midad los daños recibidos en ataques a distancia por todas tus "
 "unidades."
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summon Earth Elemental"
 msgstr "LLamar al Elemental de la Tierra"
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summons Earth Elementals to fight for your army."
 msgstr "Llama a los Elementales de la Tierra para luchar en tu ejercito."
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summon Air Elemental"
 msgstr "LLamar al Elemental del Aire"
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summons Air Elementals to fight for your army."
 msgstr "LLama a los Elementales del Aire para combatir en tu ejercito."
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summon Fire Elemental"
 msgstr "LLamar al Elemental del Fuego"
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summons Fire Elementals to fight for your army."
 msgstr "LLama a los Elementales del Fuego para luchar en tu ejercito."
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summon Water Elemental"
 msgstr "LLamar Elemental del Agua."
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summons Water Elementals to fight for your army."
 msgstr "LLama a los Elementales del Agua para luchar en tu ejercito."
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Earthquake"
 msgstr "Terremoto"
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Damages castle walls."
 msgstr "Daña los muros del castillo."
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "View Mines"
 msgstr "Ver minas"
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "Causes all mines across the land to become visible."
 msgstr "Hace que todas las minas del territorio sean visibles."
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "View Resources"
 msgstr "Ver Recursos"
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "Causes all resources across the land to become visible."
 msgstr "Hace que todos los recursos del territorio sean visibles."
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "View Artifacts"
 msgstr "Ver Artefactos"
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "Causes all artifacts across the land to become visible."
 msgstr "Hace que todos los Artefactos del territorio sean visibles."
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "View Towns"
 msgstr "Ver Ciudades"
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "Causes all towns and castles across the land to become visible."
 msgstr "Hace que todas las ciudades y castillos del territorio sean visibles."
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "View Heroes"
 msgstr "Ver Heroes"
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "Causes all Heroes across the land to become visible."
 msgstr "Hace que todos los Héroes del territorio sean visibles."
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "View All"
 msgstr "Ver Todo"
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "Causes the entire land to become visible."
 msgstr "Hace que todo el territorio sea visible."
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Identify Hero"
 msgstr "Identificar Héroe"
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Allows the caster to view detailed information on enemy Heroes."
 msgstr "Permite al lanzador ver información detallada de los héroes enemigos."
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid "Summon Boat"
 msgstr "LLamar Barco"
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid ""
 "Summons the nearest unoccupied, friendly boat to an adjacent shore "
 "location.  A friendly boat is one which you just built or were the most "
@@ -13170,25 +6757,20 @@ msgstr ""
 "LLama a un barco amigo desocupado al punto de costa más cercano. Un barco "
 "amigo es aquel que has contruido o has sido el último jugador en ocupar."
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Dimension Door"
 msgstr "Puerta Dimensional"
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Allows the caster to magically transport to a nearby location."
 msgstr ""
 "Permite al lanzador del hechizo ser magicamente transportado a un punto "
 "cercano."
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Town Gate"
 msgstr "Puerta de la Ciudad"
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Returns the caster to any town or castle currently owned."
 msgstr "LLeva al Héroe a cualquier ciudad o castillo que posea."
 
-#: ../fheroes2/spell/spell.cpp:109
 msgid ""
 "Returns the hero to the town or castle of choice, provided it is controlled "
 "by you."
@@ -13196,22 +6778,18 @@ msgstr ""
 "Devuelve al héroe que lanza este hechizo a cualquier ciudad o castillo, "
 "siempre que sea controlado por él."
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid "Visions"
 msgstr "Visiones"
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid ""
 "Visions predicts the likely outcome of an encounter with a neutral army camp."
 msgstr ""
 "Visiones predice el resultado problable de un encuentro con un ejército "
 "neutral."
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid "Haunt"
 msgstr "Encantar"
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid ""
 "Haunts a mine you control with Ghosts.  This mine stops producing "
 "resources.  (If I can't keep it, nobody will!)"
@@ -13219,349 +6797,4458 @@ msgstr ""
 "Encanta una mina que controlas con Fantasmas. La mina no podrá producir "
 "recursos para nadie."
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Set Earth Guardian"
 msgstr "Establecer guardian de la Tierra"
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Sets Earth Elementals to guard a mine against enemy armies."
 msgstr "Ordena a los Elementales de la Tierra que protejan una mina."
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Set Air Guardian"
 msgstr "Establecer guardian del aire"
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Sets Air Elementals to guard a mine against enemy armies."
 msgstr "Ordena a los Elementales del Aire que protejan una mina."
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Set Fire Guardian"
 msgstr "Establecer guardia del fuego"
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Sets Fire Elementals to guard a mine against enemy armies."
 msgstr ""
 "Ordenar a los Elementales del Fuego proteger una mina frente a los ejercitos "
 "enemigos."
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Set Water Guardian"
 msgstr "Establecer guardia del agua"
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Sets Water Elementals to guard a mine against enemy armies."
 msgstr "Ordenar que los Elementales del Agua protejan una mina."
 
-#: ../fheroes2/system/players.cpp:665
-msgid "Necroman"
-msgstr "Nigromante."
+msgid "No spell to cast."
+msgstr "No hay hechizo que lanzar."
 
-#: ../fheroes2/system/players.cpp:691
-msgid ""
-"This lets you change player starting positions and colors. A particular "
-"color will always start in a particular location. Some positions may only be "
-"played by a computer player or only by a human player."
-msgstr ""
-"Te permite cambiar las posición inicial y los colores. Cada color siempre "
-"comenzará en una situación precisa. Algunas posiciones sólo puede ser "
-"jugadas por un jugador humano o uno virtual."
+#, fuzzy
+msgid "Your hero has %{point} spell points remaining."
+msgstr "Tú héroe tiene todavía %{point} puntos de Maná."
 
-#: ../fheroes2/system/players.cpp:695
-msgid ""
-"This lets you change the class of a player. Classes are not always "
-"changeable. Depending on the scenario, a player may receive additional towns "
-"and/or heroes not of their primary alignment."
-msgstr ""
-"Te permite cambiar la raza de un jugador. No siempre se pueden cambiar las "
-"razas. Dependiendo del escenario, un jugador puede recibir ciudades y/o "
-"héroes adicionales no pertenecientes a su primer alineamiento."
+#, fuzzy
+msgid "View Adventure Spells"
+msgstr "Opciones de la Aventura"
 
-#: ../fheroes2/system/players.cpp:734
-msgid "%{color} player"
-msgstr "%{color} jugador"
+#, fuzzy
+msgid "View Combat Spells"
+msgstr "Lanzar hechizo"
 
-#: ../fheroes2/system/settings.cpp:126
+#, fuzzy
+msgid "View previous page"
+msgstr "Ver ciudad anterior"
+
+#, fuzzy
+msgid "View next page"
+msgstr "Ver %{name}"
+
+#, fuzzy
+msgid "Close Spellbook"
+msgstr "Lanzar hechizo"
+
+#, fuzzy
+msgid "View %{spell}"
+msgstr "Ver %{name}"
+
 msgid "game: always confirm for rewrite savefile"
 msgstr "juego: siempre confirmar al sobreescribir una paritda guardada"
 
-#: ../fheroes2/system/settings.cpp:127
-msgid "game: also confirm autosave"
-msgstr "juego: también confirmar el autoguardado"
-
-#: ../fheroes2/system/settings.cpp:128
 msgid "game: remember last focus"
 msgstr "juego: recordar el último foco."
 
-#: ../fheroes2/system/settings.cpp:129
-msgid "game: battle show grid"
-msgstr ""
+#, fuzzy
+msgid "battle: show damage info"
+msgstr "juego: mostrar información del sistema"
 
-#: ../fheroes2/system/settings.cpp:130
-msgid "game: battle mouse shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:131
-msgid "game: battle move shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:132
-msgid "game: battle show damage info"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:133
-msgid "game: castle flash building"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:134
 msgid "world: show visited content from objects"
 msgstr "mundo: ver contenido de objetos visitados"
 
-#: ../fheroes2/system/settings.cpp:135
+msgid "world: show terrain penalty"
+msgstr ""
+
 msgid "world: scouting skill show extended content info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:136
-msgid "world: abandoned mine random resource"
-msgstr "mundo: mina abandonada con recursos aleatorios"
-
-#: ../fheroes2/system/settings.cpp:137
-msgid "world: save count monster after battle"
-msgstr "mundo: guardar cantidad de monstruos después de la batalla"
-
-#: ../fheroes2/system/settings.cpp:138
 msgid "world: allow set guardian to objects"
 msgstr "mundo: permitir establecer guardianes en objetos"
 
-#: ../fheroes2/system/settings.cpp:139
-msgid "world: guardian objects gets +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:140
-msgid "world: no in-built requirements or guardians for placed artifacts"
-msgstr "mundo: sin requisitos in-situ o guardianes para artefactos ubicados"
-
-#: ../fheroes2/system/settings.cpp:141
-msgid "world: only the first monster will attack (H2 bug)."
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:142
 msgid "world: Eagle Eye also works like Scholar in H3."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:143
 msgid "world: ban for WeekOf/MonthOf Monsters"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:144
-msgid "world: new version WeekOf (+growth)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:145
 msgid "world: ban plagues months"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:146
 msgid "world: Months Of Monsters do not place creatures on map"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:147
 msgid "world: Crystal Ball also added Identify Hero and Visions spells"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:148
-msgid "world: Artesian Springs have two separately visitable squares (h3 ver)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:149
 msgid "world: Starting heroes as Loss Conditions for Human Players"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:150
 msgid "world: Only 1 hero can be hired by the one player every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:151
-msgid "world: each castle allows one hero to be recruited every week"
+msgid "world: Each castle allows one hero to be recruited every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:152
-msgid "world: Outer creature dwellings should accumulate units"
+msgid "world: Neutral armies scale with game difficulty"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:153
-msgid "world: use unique artifacts for morale/luck"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:154
 msgid "world: use unique artifacts for resource affecting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:155
 msgid "world: use unique artifacts for primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:156
 msgid "world: use unique artifacts for secondary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:157
 msgid "world: Wind/Water Mills and Magic Garden can be captured"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:158
 msgid "world: disable Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:159
-msgid "castle: allow buy from well"
-msgstr "castillo: permitir comprar desde el pozo"
-
-#: ../fheroes2/system/settings.cpp:160
 msgid "castle: allow guardians"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:161
 msgid ""
 "castle: higher mage guilds regenerate more spell points/turn "
 "(20/40/60/80/100%)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:162
-msgid "castle: allow recruits special/expansion heroes"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:163
 msgid "heroes: allow buy a spellbook from Shrines"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:164
-msgid "heroes: learn new spells with day"
-msgstr "Los héroes: aprenden nuevos hechizos día a día."
-
-#: ../fheroes2/system/settings.cpp:165
 msgid "heroes: recruit cost to be dependent on hero level"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:166
-msgid "heroes: remember MP/SP for retreat/surrender result"
+msgid "heroes: remember move points for retreat/surrender result"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:167
-msgid "heroes: surrendering gives some experience"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:168
-msgid "heroes: recalculate movement points after creatures movement"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:169
-msgid "heroes: allow pickup objects for patrol"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:170
-msgid "heroes: after battle move to target cell"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:171
 msgid "heroes: allow transcribing scrolls (needs: Eye Eagle skill)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:172
-msgid "heroes: allow banned sec. skills upgrade"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:173
 msgid "heroes: in Arena can choose any of primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:174
 msgid "unions: allow meeting heroes"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:175
 msgid "unions: allow castle visiting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:176
+#, fuzzy
+msgid "battle: show army order"
+msgstr "batalla: espera de tropa fluido"
+
 msgid "battle: soft wait troop"
 msgstr "batalla: espera de tropa fluido"
 
-#: ../fheroes2/system/settings.cpp:177
-msgid "battle: high objects are an obstacle for archers"
-msgstr "batalla: objetos altos son un obstáculo para arqueros"
-
-#: ../fheroes2/system/settings.cpp:178
-msgid "battle: merge armies for hero from castle"
-msgstr "batalla: fusionar ejércitos para el héroe desde el castillo"
-
-#: ../fheroes2/system/settings.cpp:179
-msgid "battle: archmage can resists (20%) bad spells"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:180
-msgid "battle: magical creature resists (20%) the same magic"
-msgstr "batalla: criatura mágica resiste (20%) la misma magia"
-
-#: ../fheroes2/system/settings.cpp:181
-msgid "battle: skip increase +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:182
 msgid "battle: reverse wait order (fast, average, slow)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:183
 msgid "game: show system info"
 msgstr "juego: mostrar información del sistema"
 
-#: ../fheroes2/system/settings.cpp:184
 msgid "game: autosave on"
 msgstr "juego: autoguardado activado"
 
-#: ../fheroes2/system/settings.cpp:185
 msgid "game: autosave will be made at the beginning of the day"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:186
 msgid "game: use fade"
 msgstr "juego: usar difuminado"
 
-#: ../fheroes2/system/settings.cpp:187
-msgid "game: show SDL logo"
-msgstr "juego: mostrar logo de SDL"
-
-#: ../fheroes2/system/settings.cpp:188
 msgid "game: use evil interface"
 msgstr "juego: usar interfaz maligna"
 
-#: ../fheroes2/system/settings.cpp:189
-msgid "game: also use dynamic interface for castles"
-msgstr "juego: también usar interfaz dinámica para castillos"
-
-#: ../fheroes2/system/settings.cpp:190
 msgid "game: hide interface"
 msgstr "juego: ocultar interfaz"
 
-#: ../fheroes2/system/settings.cpp:191
 msgid "game: offer to continue the game afer victory condition"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:192
-msgid "pocketpc: hide cursor"
-msgstr "pocketpc: ocultar cursor"
+#, fuzzy
+msgid "The ultimate artifact is really the %{name}."
+msgstr "¡La maldición de la Momia cae sobre %{name}!"
 
-#: ../fheroes2/system/settings.cpp:193
-msgid "pocketpc: tap mode"
-msgstr "pocketpc: modo de pulsación"
-
-#: ../fheroes2/system/settings.cpp:194
-msgid "pocketpc: drag&drop gamearea as scroll"
+msgid "The ultimate artifact may be found in the %{name} regions of the world."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:195
-msgid "pocketpc: low memory"
-msgstr "tap: poca memoria"
+msgid "north-west"
+msgstr ""
+
+#, fuzzy
+msgid "north"
+msgstr "Enroth"
+
+msgid "north-east"
+msgstr ""
+
+#, fuzzy
+msgid "west"
+msgstr "Nido"
+
+#, fuzzy
+msgid "center"
+msgstr "Monstruo"
+
+#, fuzzy
+msgid "east"
+msgstr "Nido"
+
+msgid "south-west"
+msgstr ""
+
+#, fuzzy
+msgid "south"
+msgstr "Ostoroth"
+
+msgid "south-east"
+msgstr ""
+
+msgid "The truth is out there."
+msgstr ""
+
+msgid "The dark side is stronger."
+msgstr ""
+
+#, fuzzy
+msgid "The end of the world is near."
+msgstr "El fin del mundo está cerca"
+
+msgid "The bones of Lord Slayer are buried in the foundation of the arena."
+msgstr ""
+
+msgid "A Black Dragon will take out a Titan any day of the week."
+msgstr ""
+
+msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
+msgstr ""
+
+msgid "An unknown force is being ressurected..."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Check the newest version of game at\n"
+"https://github.com/ihhub/\n"
+"fheroes2/releases"
+msgstr ""
+"Puedes descargar la última versión del juego desde el sítio:\n"
+"http://sf.net/projects/fheroes2"
+
+#~ msgid "Hero %{name} also got a %{count} experience."
+#~ msgstr "El héroe %{name} también obtubo %{count} de experiencia."
+
+#~ msgid "Spell cast"
+#~ msgstr "Lanzar hechizo"
+
+#~ msgid ", and get +2 defense"
+#~ msgstr ", y consigue +2 a la defensa"
+
+#~ msgid "MirrorImage ended"
+#~ msgstr "Reflejo terminado"
+
+#~ msgid "You don't have enough gold!"
+#~ msgstr "¡Tu no tienes suficiente oro!"
+
+#~ msgid ""
+#~ "Your troops can be upgraded, but it will cost you %{ratio} times the "
+#~ "difference in cost for each troop, rounded up to next highest number. Do "
+#~ "you wish to upgrade them?"
+#~ msgstr ""
+#~ "Tus tropas pueden mejorarse, pero te costará %{ratio} veces la diferencia "
+#~ "en coste para cada tropa, redondeando al alza. ¿Quieres actualizarlas?"
+
+#~ msgid "For the QVGA version is not available."
+#~ msgstr "Para la versión QVGA no está disponible."
+
+#~ msgid "Cost per troop:"
+#~ msgstr "Coste por tropa:"
+
+#~ msgid "sound"
+#~ msgstr "sonido"
+
+#~ msgid "ai speed"
+#~ msgstr "velocidad de la IA"
+
+#~ msgid "You have no room to carry another artifact!"
+#~ msgstr "¡No tienes espacio para llevar otro artefacto!"
+
+#~ msgid "View Morale Info"
+#~ msgstr "Ver Información sobre Moral"
+
+#~ msgid "View Luck Info"
+#~ msgstr "Ver información sobre Suerte"
+
+#~ msgid "Exit hero"
+#~ msgstr "Salir de la pantalla de Héroe."
+
+#~ msgid "Dismiss hero"
+#~ msgstr "Descartar Héroe"
+
+#~ msgid "Show prev heroes"
+#~ msgstr "Mostrar Héroes previos."
+
+#~ msgid "Bad Morale"
+#~ msgstr "Mala Moral"
+
+#~ msgid "Neutral Morale"
+#~ msgstr "Moral Neutral"
+
+#~ msgid "Bad Luck"
+#~ msgstr "Mala Suerte"
+
+#~ msgid "Neutral Luck"
+#~ msgstr "Suerte Neutral"
+
+#~ msgid "Good Luck"
+#~ msgstr "Buena Suerte"
+
+#~ msgid "This game is now in beta development version. ;)"
+#~ msgstr "Este juego está en fase Beta de desarrollo."
+
+#~ msgid "Water"
+#~ msgstr "Agua"
+
+#~ msgid "Ship Wreck"
+#~ msgstr "Naufragio"
+
+#~ msgid "Coast"
+#~ msgstr "Costa"
+
+#, fuzzy
+#~ msgid "Peasant"
+#~ msgstr "Campesino"
+
+#~ msgid "Peasants"
+#~ msgstr "Campesinos"
+
+#, fuzzy
+#~ msgid "Archer"
+#~ msgstr "Arquero"
+
+#~ msgid "Archers"
+#~ msgstr "Arqueros"
+
+#, fuzzy
+#~ msgid "Ranger"
+#~ msgstr "Montaraz"
+
+#~ msgid "Rangers"
+#~ msgstr "Arqueros Expertos"
+
+#, fuzzy
+#~ msgid "Pikeman"
+#~ msgstr "Piquero"
+
+#~ msgid "Pikemen"
+#~ msgstr "Piqueros"
+
+#, fuzzy
+#~ msgid "Veteran Pikeman"
+#~ msgstr "Piquero veterano"
+
+#~ msgid "Veteran Pikemen"
+#~ msgstr "Alabarderos"
+
+#, fuzzy
+#~ msgid "Swordsman"
+#~ msgstr "Espadachín"
+
+#~ msgid "Swordsmen"
+#~ msgstr "Espadachín"
+
+#, fuzzy
+#~ msgid "Master Swordsman"
+#~ msgstr "Maestro Espadachín"
+
+#~ msgid "Master Swordsmen"
+#~ msgstr "Maestros Espadachines"
+
+#, fuzzy
+#~ msgid "Cavalry"
+#~ msgstr "Caballería"
+
+#~ msgid "Cavalries"
+#~ msgstr "Caballerías"
+
+#, fuzzy
+#~ msgid "Champion"
+#~ msgstr "Campeón"
+
+#~ msgid "Champions"
+#~ msgstr "Caballeros"
+
+#, fuzzy
+#~ msgid "Paladin"
+#~ msgstr "Paladín"
+
+#~ msgid "Paladins"
+#~ msgstr "Paladines"
+
+#, fuzzy
+#~ msgid "Crusader"
+#~ msgstr "Cruzado"
+
+#~ msgid "Crusaders"
+#~ msgstr "Cruzados"
+
+#, fuzzy
+#~ msgid "Goblin"
+#~ msgstr "Trasgo"
+
+#~ msgid "Goblins"
+#~ msgstr "Trasgos"
+
+#, fuzzy
+#~ msgid "Orc"
+#~ msgstr "Orco"
+
+#~ msgid "Orcs"
+#~ msgstr "Orcos"
+
+#, fuzzy
+#~ msgid "Orc Chief"
+#~ msgstr "Jefe Orco"
+
+#~ msgid "Orc Chiefs"
+#~ msgstr "Jefes Orcos"
+
+#, fuzzy
+#~ msgid "Wolf"
+#~ msgstr "Lobo"
+
+#~ msgid "Wolves"
+#~ msgstr "Lobos"
+
+#, fuzzy
+#~ msgid "Ogre"
+#~ msgstr "Ogro"
+
+#~ msgid "Ogres"
+#~ msgstr "Ogros"
+
+#, fuzzy
+#~ msgid "Ogre Lord"
+#~ msgstr "Ogro de Combate"
+
+#~ msgid "Ogre Lords"
+#~ msgstr "Ogros de Combate"
+
+#, fuzzy
+#~ msgid "Troll"
+#~ msgstr "Troll"
+
+#~ msgid "Trolls"
+#~ msgstr "Trolls"
+
+#, fuzzy
+#~ msgid "War Troll"
+#~ msgstr "Trol de Guerra"
+
+#~ msgid "War Trolls"
+#~ msgstr "Troll de Guerra"
+
+#, fuzzy
+#~ msgid "Cyclops"
+#~ msgstr "Cíclope"
+
+#~ msgid "Cyclopes"
+#~ msgstr "Cíclopes"
+
+#, fuzzy
+#~ msgid "Sprite"
+#~ msgstr "Hada"
+
+#~ msgid "Sprites"
+#~ msgstr "Hadas"
+
+#, fuzzy
+#~ msgid "Dwarf"
+#~ msgstr "Enano"
+
+#~ msgid "Dwarves"
+#~ msgstr "Enanos"
+
+#~ msgid "Battle Dwarves"
+#~ msgstr "Enanos de Combate"
+
+#, fuzzy
+#~ msgid "Elf"
+#~ msgstr "Elfo"
+
+#~ msgid "Elves"
+#~ msgstr "Elfos"
+
+#, fuzzy
+#~ msgid "Grand Elf"
+#~ msgstr "Gran Elfo"
+
+#~ msgid "Grand Elves"
+#~ msgstr "Grandes Elfos"
+
+#, fuzzy
+#~ msgid "Druid"
+#~ msgstr "Druida"
+
+#~ msgid "Druids"
+#~ msgstr "Druidas"
+
+#, fuzzy
+#~ msgid "Greater Druid"
+#~ msgstr "Gran Druida"
+
+#~ msgid "Greater Druids"
+#~ msgstr "Grandes Druidas"
+
+#, fuzzy
+#~ msgid "Unicorn"
+#~ msgstr "Unicornio"
+
+#~ msgid "Unicorns"
+#~ msgstr "Unicornios"
+
+#, fuzzy
+#~ msgid "Phoenix"
+#~ msgstr "Fénix"
+
+#, fuzzy
+#~ msgid "Phoenixes"
+#~ msgstr "Fénix"
+
+#, fuzzy
+#~ msgid "Centaur"
+#~ msgstr "Centauro"
+
+#~ msgid "Centaurs"
+#~ msgstr "Centauros"
+
+#, fuzzy
+#~ msgid "Gargoyle"
+#~ msgstr "Gárgola"
+
+#~ msgid "Gargoyles"
+#~ msgstr "Gárgolas"
+
+#, fuzzy
+#~ msgid "Griffin"
+#~ msgstr "Grifo"
+
+#~ msgid "Griffins"
+#~ msgstr "Grifos"
+
+#, fuzzy
+#~ msgid "Minotaur"
+#~ msgstr "Minotauro"
+
+#~ msgid "Minotaurs"
+#~ msgstr "Minotauros"
+
+#, fuzzy
+#~ msgid "Minotaur King"
+#~ msgstr "Minotauro Rey"
+
+#~ msgid "Minotaur Kings"
+#~ msgstr "Minotauros Reyes"
+
+#, fuzzy
+#~ msgid "Hydra"
+#~ msgstr "Hidra"
+
+#~ msgid "Hydras"
+#~ msgstr "Hidras"
+
+#, fuzzy
+#~ msgid "Green Dragon"
+#~ msgstr "Dragón Verde"
+
+#~ msgid "Green Dragons"
+#~ msgstr "Dragones Verdes"
+
+#, fuzzy
+#~ msgid "Red Dragon"
+#~ msgstr "Dragón rojo"
+
+#~ msgid "Red Dragons"
+#~ msgstr "Dragones Rojos"
+
+#, fuzzy
+#~ msgid "Black Dragon"
+#~ msgstr "Dragón Negro"
+
+#~ msgid "Black Dragons"
+#~ msgstr "Dragones Negros"
+
+#, fuzzy
+#~ msgid "Halfling"
+#~ msgstr "Mediano"
+
+#~ msgid "Halflings"
+#~ msgstr "Medianos"
+
+#, fuzzy
+#~ msgid "Boar"
+#~ msgstr "Jabalí"
+
+#~ msgid "Boars"
+#~ msgstr "Jabalíes"
+
+#, fuzzy
+#~ msgid "Iron Golem"
+#~ msgstr "Golem de Hierro"
+
+#~ msgid "Iron Golems"
+#~ msgstr "Golems de Hierro"
+
+#, fuzzy
+#~ msgid "Steel Golem"
+#~ msgstr "Golem de Acero"
+
+#~ msgid "Steel Golems"
+#~ msgstr "Golems de Acero"
+
+#, fuzzy
+#~ msgid "Roc"
+#~ msgstr "Roc"
+
+#~ msgid "Rocs"
+#~ msgstr "Rocs"
+
+#, fuzzy
+#~ msgid "Mage"
+#~ msgstr "Mago"
+
+#~ msgid "Magi"
+#~ msgstr "Magos"
+
+#, fuzzy
+#~ msgid "Archmage"
+#~ msgstr "Archimago"
+
+#~ msgid "Archmagi"
+#~ msgstr "Archimagos"
+
+#, fuzzy
+#~ msgid "Giant"
+#~ msgstr "Gigante"
+
+#~ msgid "Giants"
+#~ msgstr "Gigantes"
+
+#, fuzzy
+#~ msgid "Titan"
+#~ msgstr "Titán"
+
+#~ msgid "Titans"
+#~ msgstr "Titanes"
+
+#~ msgid "Skeletons"
+#~ msgstr "Esqueletos"
+
+#, fuzzy
+#~ msgid "Zombie"
+#~ msgstr "Zombi"
+
+#~ msgid "Zombies"
+#~ msgstr "Zombis"
+
+#, fuzzy
+#~ msgid "Mutant Zombie"
+#~ msgstr "Zombi Mutante"
+
+#~ msgid "Mutant Zombies"
+#~ msgstr "Zombis Mutantes"
+
+#, fuzzy
+#~ msgid "Mummy"
+#~ msgstr "Momia"
+
+#~ msgid "Mummies"
+#~ msgstr "Momia"
+
+#, fuzzy
+#~ msgid "Royal Mummy"
+#~ msgstr "Momia Real"
+
+#~ msgid "Royal Mummies"
+#~ msgstr "Momias Reales"
+
+#, fuzzy
+#~ msgid "Vampire"
+#~ msgstr "Vampiro"
+
+#~ msgid "Vampires"
+#~ msgstr "Vampiros"
+
+#, fuzzy
+#~ msgid "Vampire Lord"
+#~ msgstr "Maestro Vampiro"
+
+#~ msgid "Vampire Lords"
+#~ msgstr "Maestros Vampiros"
+
+#, fuzzy
+#~ msgid "Lich"
+#~ msgstr "Liche"
+
+#~ msgid "Liches"
+#~ msgstr "Liches"
+
+#, fuzzy
+#~ msgid "Power Lich"
+#~ msgstr "Gran Liche"
+
+#~ msgid "Power Liches"
+#~ msgstr "Grandes Liches"
+
+#, fuzzy
+#~ msgid "Bone Dragon"
+#~ msgstr "Dragón de Hueso"
+
+#~ msgid "Bone Dragons"
+#~ msgstr "Dragones de Hueso"
+
+#, fuzzy
+#~ msgid "Rogue"
+#~ msgstr "Bandido"
+
+#~ msgid "Rogues"
+#~ msgstr "Bandidos"
+
+#, fuzzy
+#~ msgid "Nomad"
+#~ msgstr "Nómada"
+
+#~ msgid "Nomads"
+#~ msgstr "Nómadas"
+
+#, fuzzy
+#~ msgid "Ghost"
+#~ msgstr "Fantasma"
+
+#~ msgid "Ghosts"
+#~ msgstr "Fantasmas"
+
+#, fuzzy
+#~ msgid "Genie"
+#~ msgstr "Genio"
+
+#~ msgid "Genies"
+#~ msgstr "Genios"
+
+#, fuzzy
+#~ msgid "Medusa"
+#~ msgstr "Medusa"
+
+#~ msgid "Medusas"
+#~ msgstr "Medusa"
+
+#, fuzzy
+#~ msgid "Earth Elemental"
+#~ msgstr "Elemental de la Tierra"
+
+#~ msgid "Earth Elementals"
+#~ msgstr "Elementales de la Tierra"
+
+#, fuzzy
+#~ msgid "Air Elemental"
+#~ msgstr "Elemental del Aire"
+
+#~ msgid "Air Elementals"
+#~ msgstr "Elementales del Aire"
+
+#, fuzzy
+#~ msgid "Fire Elemental"
+#~ msgstr "Elemental del Fuego"
+
+#~ msgid "Fire Elementals"
+#~ msgstr "Elementales del Fuego"
+
+#, fuzzy
+#~ msgid "Water Elemental"
+#~ msgstr "Elemental del Agua"
+
+#~ msgid "Water Elementals"
+#~ msgstr "Elementales del Agua"
+
+#~ msgid "buy"
+#~ msgstr "comprar"
+
+#~ msgid "Error"
+#~ msgstr "Error"
+
+#~ msgid "This release is compiled without network support."
+#~ msgstr "Esta versión está compilada sin soporte para red."
+
+#~ msgid ""
+#~ "425 bottles of beer on the wall, 425 bottles of beer! If one of those "
+#~ "bottles should happen to fall, there'll be..."
+#~ msgstr ""
+#~ "425 botellas de cerveza sobre el muro, ¡425 botellas de cerveza! Si una "
+#~ "de las botellas llegara a caer, habría que ..."
+
+#~ msgid "A balanced scenario with lots of resources and land to explore."
+#~ msgstr ""
+#~ "Un escenario equilibrado con gran cantidad de recursos y terriorios para "
+#~ "explorar."
+
+#~ msgid ""
+#~ "A bandit army of gorgons jump you without warning.  they stone your "
+#~ "entire army demand 500 gold before they will release your comrads.  "
+#~ "Realizing that it is much cheeper to pay then rebuild your army you part "
+#~ "with the gold."
+#~ msgstr ""
+#~ "Un ejercito de bandidas gorgonas te asalta sin ningún aviso.  Y "
+#~ "petrifican tu ejercito entero demandando 500 de oro antes de liberar a "
+#~ "tus camaradas. Alegando que es más barato pagar que reconstruir tu "
+#~ "ejercito por tu cuenta con ese oro."
+
+#~ msgid "Abandon All Hope!"
+#~ msgstr "¡Abandona toda esperanza!"
+
+#~ msgid "Abandon All Hope Ye That Enter Here"
+#~ msgstr "!Abandonad toda esperanza aquellos que entréis aquí!"
+
+#~ msgid "A bit of crystal!"
+#~ msgstr "Un poco de cristal."
+
+#~ msgid "A bit of mercury!"
+#~ msgstr "¡Un poco de mercurio!"
+
+#~ msgid "A bit of sulfur!"
+#~ msgstr "¡Un poco de azufre!"
+
+#~ msgid ""
+#~ "Above you looms the ancient Ice Palace.  Dimly remembered myth speaks of "
+#~ "a Prince who rejected the advances of the Winter Goddess, and thus he and "
+#~ "his domain were cursed to remain shrouded in ice, hidden in a forgotten "
+#~ "corner of the world.  It is said that he can only be rescued by a hero "
+#~ "who is both clever and bold.  Are you that one?  Do you dare enter this "
+#~ "frozen domain?"
+#~ msgstr ""
+#~ "Sobre ti se avecina el antiguo Palacio de Hielo. El mito, borrosamente "
+#~ "recordado, habla de un Príncipe que rechazó los avances de la Diosa del "
+#~ "Invierto. De este modo él y su dominio fueron maldecidos a permanecer "
+#~ "envueltos en hielo ocultos en una olvidada esquina del mundo. Se dice que "
+#~ "él sólo puede ser rescatado por un héroe que sea tanto listo como audaz. "
+#~ "¿Eres tú ese héroe?, ¿Te atreves a entrar en este dominio helado?"
+
+#~ msgid "A cache of crystal!"
+#~ msgstr "¡Un alijo de crital!"
+
+#~ msgid "A cache of gems!"
+#~ msgstr "¡Un alijo de gemas!"
+
+#~ msgid "A cache of gold!"
+#~ msgstr "¡Un alijo de oro!"
+
+#~ msgid "A cache of mercury!"
+#~ msgstr "¡Un alijo de mercurio!"
+
+#~ msgid "A cache of sulfur!"
+#~ msgstr "¡Un alijo de azufre!"
+
+#~ msgid ""
+#~ "A chance to end a bitter war has finally arrived as a new resource-laden "
+#~ "land has been discovered."
+#~ msgstr ""
+#~ "Una oportunidad para finalizar esta amarga querra se ha presentado "
+#~ "finalmente puesto que un nuevo territorio repleto de recursos ha sido "
+#~ "descubierto."
+
+#~ msgid "A chunk of gold!"
+#~ msgstr "¡Una buena cantidad de oro!"
+
+#~ msgid "A chunk of ore!"
+#~ msgstr "¡Una buena mena de hierro!"
+
+#~ msgid "A couple of gems!"
+#~ msgstr "¡Un par de gemas!"
+
+#~ msgid "\"Act of Desperation\""
+#~ msgstr "\"Acto de desesperación\""
+
+#~ msgid ""
+#~ "A desert isle rich in resources rewards the quick.  Just be sure to watch "
+#~ "your back!"
+#~ msgstr ""
+#~ "Una isla desierta rica en recursos recompensa la rapidez. ¡Asegúrate de "
+#~ "vigilar tu espalda!"
+
+#~ msgid "A dolphin playfully jumps into the air."
+#~ msgstr "Un delfín alegremente da un brinco en el aire."
+
+#~ msgid ""
+#~ "A Dragon, A Cyclops, or an Undead. King of the Centaurs, His name is ....?"
+#~ msgstr ""
+#~ "Un dragón, un Cíclope o un Nomuerto. Rey de los Centauros, ¿Su nombre "
+#~ "es ...?"
+
+#~ msgid "A flight of dragons circles overhead."
+#~ msgstr "Una bandada de dragones sobrevuela en círculo."
+
+#~ msgid "A flock of seagulls circle overhead."
+#~ msgstr "Una bandada de gaviotas sobrevuelta en círculo."
+
+#~ msgid "A friendly dolphin splashes alongside the ship."
+#~ msgstr "Un delfín amistoso chapotea alredor del barco."
+
+#~ msgid ""
+#~ "After a long search of the island, I have discovered that there is no way "
+#~ "for me to escape without help.  I can not steal a ship from one of the "
+#~ "coastal castles, and I dare not venture into the desert unless I wish to "
+#~ "become Dragon food.  Should anyone find this, I beg of you, please send a "
+#~ "ship and get me off this cursed island!  -Sir Christian"
+#~ msgstr ""
+#~ "Después de una larga busqueda por la isla, me he dado cuenta de que no "
+#~ "hay manera de escaparse sin ayuda. No puedo robar un barco de los "
+#~ "castillos de la costa y no me atrevo a aventurarme en el desierto; a no "
+#~ "ser que desee convertirme en comida de dragón. Si alguien encuentra esto, "
+#~ "te ruego, envíame un barco y sácame de esta isla maldita! - Sir Christian."
+
+#~ msgid ""
+#~ "After centuries of friendship, the Wizards have suddenly decided to stop "
+#~ "sharing their Library with the rest of the world.  This can't be good!"
+#~ msgstr ""
+#~ "Después de siglos de amistad, los Magos deciden dejar de compartir su "
+#~ "Biblioteca con el resto del mundo. ¡Esto no puede ser bueno!"
+
+#~ msgid ""
+#~ "After many years of peace, you discover that your sworn enemy from across "
+#~ "the sea has chosen to invade your homeland by raising up the ocean floor "
+#~ "to bridge the distance! You must not let them gain a foothold on this "
+#~ "continent, in fact, your King has ordered you to establish a foothold on "
+#~ "theirs!  To make matters worse, two of your OWN towns have thrown in "
+#~ "their lots with the enemy..."
+#~ msgstr ""
+#~ "Tras muchos años de paz, descubres que tu enemigo jurado de allende los "
+#~ "mares ha elegido invadir tu patria elevando el fondo del océano y cubrir "
+#~ "así la distancia. No debes permitirle poner el pie en este continente, de "
+#~ "hecho, ¡tu Rey te ha ordenado invadir el suyo! Para empeorar las cosas, "
+#~ "dos de tus propias ciudades se han pasado al enemigo..."
+
+#~ msgid ""
+#~ "After you return from a scouting trip, your Seneschal hurries to greet "
+#~ "you.  \"My Lord, in your absence I signed an agreement in your name with "
+#~ "a Master Merchant.  If we supply him with the resources he needs, through "
+#~ "trading, he can return the resources to us in a week or so, plus some "
+#~ "additional ones.\"  The Seneschal eyes you anxiously.  You hesitate, then "
+#~ "nod slowly, \"Good, we can use more resources>\""
+#~ msgstr ""
+#~ "Al volver de una partida de exploración, tu Senescal se apresura a "
+#~ "encontrarte. \"Mi Señor, en vuestra ausencia he firmado un acuerdo en "
+#~ "vuestro nombre con un Mercader Maestro. Si le proporcionamos los recursos "
+#~ "que necesita, a través del comercio, nos puede devolver dichos recursos "
+#~ "en una semana o así, además de algunos otros adicionales\". El Senescal "
+#~ "te mira con ansiedad. Tú dudas, y luego asientes lentamente, \"Bien, "
+#~ "podemos usar más recursos\""
+
+#~ msgid "A ghostly pirate ship appears and sails on by."
+#~ msgstr "Aparece un barco fantasma y pasa de largo."
+
+#~ msgid ""
+#~ "A Gift from your King, and a note that reads \"Use these resources "
+#~ "wisely, It's all we have left\"."
+#~ msgstr ""
+#~ "Un presente de tu Rey y una nota que dice: \"Usa estos recursos "
+#~ "sabiamente, es todo lo que me queda\"."
+
+#~ msgid ""
+#~ "A gift of gold, m'lord, from the people of Enroth, to the people of "
+#~ "Enroth.  Good luck, and may God save true King Roland!"
+#~ msgstr ""
+#~ "Un presente de oro, Señor, de las gentes de Enroth para las gentes de "
+#~ "Enroth. ¡Buena suerte y que Dios guarde al verdadero Rey Roland!"
+
+#~ msgid "A glint by a tree catches your eye..."
+#~ msgstr "Un destello en un árbol te llama la atención..."
+
+#~ msgid "A gold cache!"
+#~ msgstr "Un alijo de oro."
+
+#~ msgid "A gold chunk!"
+#~ msgstr "¡Un poco de oro!"
+
+#~ msgid "A gold nugget!"
+#~ msgstr "¡Unas pepitas de oro!"
+
+#~ msgid ""
+#~ "A great Black dragon stands before you. It speaks in a suprisingly soft "
+#~ "voice, saying, \"The elves believe they have sent another hero to reclaim "
+#~ "their prize. I believe they have sent me another meal.\""
+#~ msgstr ""
+#~ "Un fantástico Dragón negro está de pie delante tuyo. Habla con una "
+#~ "sorprendentemente suave voz, diciendo, \"Los elfos creen que han mandado "
+#~ "a otro héroe para reclamar su recompensa. Yo creo que me han enviado otra "
+#~ "comida.\""
+
+#~ msgid ""
+#~ "A group of peasant farmers approaches you, \"We are in dire need of your "
+#~ "assistance.  Our castle to the north has been overrun and our Lord "
+#~ "killed.  Please help us regain our homes!  There are still women and "
+#~ "children there!  Take what we have to help!\""
+#~ msgstr ""
+#~ "Un grupo de campesinos se te acerca, \"Necesitamos vuestra ayuda. Nuestro "
+#~ "castillo, al norte, ha sido ocupado y nuestro Señor, asesinado. Por "
+#~ "favor, ¡ayudadnos a recuperar nuestros hogares! ¡Aún hay mujeres y niños "
+#~ "allí! ¡Tomad lo que tenemos para ayudar!\""
+
+#~ msgid ""
+#~ "A group of peasant farmers approach you, \"We are in dire need of your "
+#~ "assistance.  Our castle to the east has been overrun and our Lord "
+#~ "killed.  Please help us regain our homes!  There are still women and "
+#~ "children there!  Take what we have to help!\""
+#~ msgstr ""
+#~ "Un grupo de campesinos se te acerca, \"Necesitamos vuestra ayuda. Nuestro "
+#~ "castillo, al este, ha sido ocupado y nuestro Señor, asesinado. Por favor, "
+#~ "¡ayudadnos a recuperar nuestros hogares! ¡Aún hay mujeres y niños allí! "
+#~ "¡Tomad lo que tenemos para ayudar!\""
+
+#~ msgid ""
+#~ "A group of peasant farmers approach you, \"We are in dire need of your "
+#~ "assistance. Our castle to the east has been overrun and our Lord killed. "
+#~ "Please help us regain our homes! There are still women and children "
+#~ "there! Take what we have to help!\""
+#~ msgstr ""
+#~ "Un grupo de campesinos se te acerca, \"Necesitamos vuestra ayuda. Nuestro "
+#~ "castillo, al este, ha sido ocupado y nuestro Señor, asesinado. Por favor, "
+#~ "¡ayudadnos a recuperar nuestros hogares! ¡Aún hay mujeres y niños allí! "
+#~ "¡Tomad lo que tenemos para ayudar!\""
+
+#~ msgid ""
+#~ "A group of peasant farmers approach you, We are in dire need of your "
+#~ "assistance.  Our castle to the northeast has been overrun and our Lord "
+#~ "killed.  Please help us regain our homes!  There are still women and "
+#~ "children there!  Take what we have to help!\""
+#~ msgstr ""
+#~ "Un grupo de campesinos se te acerca, \"Necesitamos vuestra ayuda. Nuestro "
+#~ "castillo, al noreste, ha sido ocupado y nuestro Señor, asesinado. Por "
+#~ "favor, ¡ayudadnos a recuperar nuestros hogares! ¡Aún hay mujeres y niños "
+#~ "allí! ¡Tomad lo que tenemos para ayudar!\""
+
+#~ msgid "A handful of gems!"
+#~ msgstr "¡Un puñado de gemas!"
+
+#~ msgid ""
+#~ "Ah, you stumble across something buried in the sand.  As you dig it up "
+#~ "you discover a small pile of gems and crystal."
+#~ msgstr ""
+#~ "Ah, tropiezas con algo semienterrado en la arena. Al desenterrarlo "
+#~ "descubres una pequeña pila de gemas y cristal."
+
+#~ msgid ""
+#~ "A Knight and Necromancer team up against the Barbarian and Sorceress. "
+#~ "(Blue and Green vs Red and Yellow)"
+#~ msgstr ""
+#~ "Un Caballero y un Necromante unen sus fuerzas contra el Bárbaro y la "
+#~ "Hechicera. (Azul y Verde vs Rojo y Amarillo)"
+
+#~ msgid ""
+#~ "A large contingent of the king's guard approaches you.  \"Ahh, we have "
+#~ "finally caught up to you.  The king requires tribute from all of his "
+#~ "vassals and you have been negligent far too long.\""
+#~ msgstr ""
+#~ "Se te acerca un gran contingente de la guardia del rey. \"Ah, al final os "
+#~ "alcanzamos. El rey exige tributo de todos sus vasallos, y vos habéis sido "
+#~ "negligente por demasiado tiempo.\""
+
+#~ msgid ""
+#~ "A large map with lots of resources and treasure. Exploration and victory "
+#~ "will require many heroes."
+#~ msgstr ""
+#~ "Un mapa grande con muchos recursos y tesoros. La exploración y la "
+#~ "victoria requerirán muchos héroes."
+
+#~ msgid "A legion of peasants stands between you and this unclaimed island."
+#~ msgstr ""
+#~ "Una legión de campesinos es el único obstaculo entre tú y esta tierra no "
+#~ "reclamada."
+
+#~ msgid "Algary"
+#~ msgstr "Algary"
+
+#~ msgid "A little bit closer..."
+#~ msgstr "Un poco más cerca ..."
+
+#~ msgid "All mines are grouped by type. Trade is your only hope."
+#~ msgstr ""
+#~ "Todas las minas están agrupadas por tipo. El comercio es tu única "
+#~ "esperanza."
+
+#~ msgid "A lump of crystal!"
+#~ msgstr "¡Un trozo de cristal!"
+
+#~ msgid "A lump of gold!"
+#~ msgstr "¡Un trozo de oro!"
+
+#~ msgid "A lump of mercury!"
+#~ msgstr "¡Un trozo de mercurio!"
+
+#~ msgid ""
+#~ "A man appears from behind the sand dune. \"At last,\" he says, \"Someone "
+#~ "has come to rescue me! I am forever grateful. Alas all I have to offer "
+#~ "you in return are these souvenirs from my wrecked ship.\""
+#~ msgstr ""
+#~ "Un hombre aparece por detrás de la duna. Dice: \"¡Por fin alguien ha "
+#~ "venido a rescatarme! estaré siempre en deuda contigo. Ay, todo lo que "
+#~ "tengo para ofrecerte a cambio son estos objetos de mi barco siniestrado\"."
+
+#~ msgid ""
+#~ "A man is laying on the ground, near death. He looks to you and speaks, "
+#~ "\"Please help my companions! Please... they can't...cough...get away "
+#~ "from...cough...the drag...\" With that, he dies."
+#~ msgstr ""
+#~ "Un hombre permanece tumbado en el suelo moribundo. Justo antes de morir "
+#~ "te mira y dicer: \"por favor, ayuda a mis compañeros, por favor ... ellos "
+#~ "no pueden  ... huir de ... el avance."
+
+#~ msgid ""
+#~ "A merchant caravan arrives, bringing gold and supplies, however, no one "
+#~ "can seem to remember where they came from.  You silently praise this "
+#~ "anonymous benefactor and continue your duties."
+#~ msgstr ""
+#~ "Una caravana mercante llega trayendo oro y suministros. Sin embargo, "
+#~ "nadie puede parecer recordar de dónde vienen. En silencio alabas a este "
+#~ "anónimo benefactor y continúas con tus deberes."
+
+#~ msgid "a mirror"
+#~ msgstr "un espejo"
+
+#~ msgid "An albatross flies ahead of the ship for a while"
+#~ msgstr "Un albatros sobrevuela el barco por un momento."
+
+#~ msgid "Anduran"
+#~ msgstr "Anduran"
+
+#~ msgid ""
+#~ "An enemy from across the sea has seized half your towns.  Can you put "
+#~ "aside your own feud with your brother to fight this common enemy?"
+#~ msgstr ""
+#~ "Un enemigo de allende los mares ha conquistado la mitad de tus ciudades. "
+#~ "¿Puedes dejar a un lado la enemistad con tu hermano para enfrentar a este "
+#~ "enemigo común?"
+
+#~ msgid ""
+#~ "An old elf is sitting on a rock in a glen, pounding on the shackles on "
+#~ "his feet with a stone. You help him remove them and ask him his tale. "
+#~ "\"I'm a deserter from Drakonia's army. She has enslaved all the elves to "
+#~ "support her madness. She must be stopped.\" Then he slips into the woods "
+#~ "without a sound, leaving behind just his cloak."
+#~ msgstr ""
+#~ "Un elfo anciano está sentado sobre una roca en una cañada, golpeando los "
+#~ "grilletes de sus pies con una piedra. Le ayudas a quitárselos y le "
+#~ "preguntas por su historia. \"Soy un desertor del ejercito de Drakonia. "
+#~ "Ella ha esclavizado a todos los elfos para mantener su locura. Debe ser "
+#~ "detenida\". Entonces se desliza hacia el interior del bosque sin hacer "
+#~ "ningún sonido, dejando tras de sí solamente su capa."
+
+#~ msgid "Antioch"
+#~ msgstr "Antioch"
+
+#~ msgid "A piece of crystal!"
+#~ msgstr "¡Un poco de cristal!"
+
+#~ msgid "A pile of crystal!"
+#~ msgstr "¡Una pila de Cristal!"
+
+#~ msgid "A pile of gems!"
+#~ msgstr "¡Una pila de Gemas!"
+
+#~ msgid "A pile of gold!"
+#~ msgstr "¡Una pila de Oro!"
+
+#~ msgid ""
+#~ "A plague of undead is upon us. Who will unite the living against the dead?"
+#~ msgstr ""
+#~ "Una plaga de nomuertos está sobre nosotros ¿Quién unirá a los vivos "
+#~ "contra los muertos?"
+
+#~ msgid "A quantity of crystal!"
+#~ msgstr "¡Algo de cristal!"
+
+#~ msgid "A quantity of mercury!"
+#~ msgstr "¡Algo de mercurio!"
+
+#~ msgid "A quantity of sulfur!"
+#~ msgstr "¡Algo de azufre!"
+
+#~ msgid ""
+#~ "Archibald has also sent an army to find the Crown, you must find it first "
+#~ "or all is lost."
+#~ msgstr ""
+#~ "Archibald también ha enviado un ejército para hallar la corona, debes "
+#~ "encontrarla antes o todo estará perdido."
+
+#~ msgid "Archibald is hiding at the end of the river."
+#~ msgstr "Archibald se esconde al final del río."
+
+#~ msgid ""
+#~ "A resource rich valley keeps the Wizard and the Necromancer apart. Your "
+#~ "opponent's army will arrive in 3 months so hurry."
+#~ msgstr ""
+#~ "Un valle rico en recursos mantiene separados al Mago y al Necromante. El "
+#~ "ejército de tus enemigos llegará en 3 meses, así que apresúrate."
+
+#~ msgid "Arm of the Crusader"
+#~ msgstr "Arma de Cruzado"
+
+#~ msgid "Arm of the Cyclops"
+#~ msgstr "Arma de Cíclope"
+
+#~ msgid "Arm of the Dragon"
+#~ msgstr "Arma de Dragón"
+
+#~ msgid "Arm of the Phoenix"
+#~ msgstr "Arma de Fénix"
+
+#~ msgid "Arm of the Titan"
+#~ msgstr "Arma de Titán"
+
+#~ msgid "Arr' Here be pirates gold buried."
+#~ msgstr "Arrg, aquí esta enterrado el oro de los piratas."
+
+#~ msgid "A shipment of wood has arrived from your kingdom!"
+#~ msgstr "¡Un cargamento de madera ha llegado desde tu Reino!"
+
+#~ msgid ""
+#~ "A splash in the seaweed alerts you to a mermaid waving in a friendly "
+#~ "manner. \"Oh, I thought you were Ahab.\" She is surprised, but quickly "
+#~ "composes herself. \"Well, if you meet him, give him these treasures I "
+#~ "have collected.\""
+#~ msgstr ""
+#~ "Un chapoteo entre las algas te llama la atención, y ves a una sirena "
+#~ "saludando de manera amistosa. \"Oh, pensé que eras Ahab.\" Ella se "
+#~ "muestra sorprendida, pero rápidamente recupera la compostura. \"Bien, si "
+#~ "te lo encuentras, dale estos tesoros que he recogido.\""
+
+#~ msgid "Assassins tried to kill our ally."
+#~ msgstr "Unos asesinos intentaron asesinar a nuestro aliado."
+
+#~ msgid "Astircaer"
+#~ msgstr "Astircaer"
+
+#~ msgid ""
+#~ "A stranded Wizard with only a small force must conquer an entire "
+#~ "continent of hostile forces."
+#~ msgstr ""
+#~ "Un Mago abandonado con unas fuerzas pequeñas debe conquistar un "
+#~ "continente entero repleto de fuerzas enemigas."
+
+#~ msgid ""
+#~ "A supply ship has arrived from the homeland!  You send word home that all "
+#~ "is well."
+#~ msgstr ""
+#~ "Un barco de suministros ha llegado desde la patria. Das aviso de que todo "
+#~ "está correcto."
+
+#~ msgid ""
+#~ "As you approach the barrier, you see the old elf you helped free. This "
+#~ "time, however, you see that he is wearing a cape of fine weave, and a "
+#~ "wooden crown is on his head. He sees your forces, and says \"Take this "
+#~ "sword, and with it, strike down Drakonia and help free my people.\" The "
+#~ "old elf then strides regally into the woods."
+#~ msgstr ""
+#~ "Al acercarte a la barrera, ves al viejo elfo al que ayudaste a liberarse. "
+#~ "Esta vez, en cambio, ves que viste una capa de fino tejido, y luce una "
+#~ "corona de madera en su cabeza. Al ver tus fuerzas, te dice: \"Toma esta "
+#~ "espada, y con ella, golpea Drakonia y libera a mi gente.\" El viejo elfo "
+#~ "regresa, majestuosamente, al interior del bosque."
+
+#~ msgid ""
+#~ "As you approach the gates of the Ice Palace, one of your troops points in "
+#~ "terror.  You watch in awe as great slabs of ice separate from the castle "
+#~ "walls with loud cracking reports and crash to the ground.  Soon the ice "
+#~ "is gone and the sun begins to peak through the gloom.  The deathly "
+#~ "silence that must have ruled these lands for centuries ends as birds "
+#~ "begin to sing.  From inside you hear the sounds of life."
+#~ msgstr ""
+#~ "Al acercarte a las puertas del Palacio de Hielo, uno de tus hombres "
+#~ "señala aterrorizado. Observas, asombrado, cómo enormes losas de hielo se "
+#~ "separan de los muros del castillo con un ruido ensordecedor, y se "
+#~ "estrellan contra el suelo. En poco tiempo ha desaparecido el hielo, y el "
+#~ "sol comienza a despuntar a través de la penumbra. El mortal silencio que "
+#~ "ha dominado estas tierras durante siglos finaliza al comenzar a cantar "
+#~ "los pájaros. Desde dentro oyes los sonidos de la vida."
+
+#~ msgid ""
+#~ "As you approach the tent, the leader of the nomads comes out to greet "
+#~ "you. He says, \"It was prophecied many years ago that a great hero would "
+#~ "come to greet us in our sacred valley, and we would prosper afterwords. "
+#~ "Now it has come to pass, and we offer you these gifts as tokens of our "
+#~ "thanks.\""
+#~ msgstr ""
+#~ "Al acercarte a la tienda, el líder de los nómadas sale a recibirte. Te "
+#~ "dice \"Hace muchos años se profetizó que un gran héroe llegaría para "
+#~ "encontrarnos en nuestro valle sagrado, y que prosperaríamos tras ello. "
+#~ "Ahora esto ha sucedido, y te ofrecemos estos regalos como muestra de "
+#~ "nuestra gratitud\"."
+
+#~ msgid ""
+#~ "As you approach,  you hear whispered mentions of \"the wild barbarian who "
+#~ "passed this way months before\". One of the villagers approaches you and "
+#~ "hands you an object, saying \"The wild one dropped this. You must be his "
+#~ "kin. Therefore I give it to you. But beware! Many in the village will not "
+#~ "be as friendly as I.\""
+#~ msgstr ""
+#~ "Al acercarte, oyes susurros que mencionan al \"bárbaro salvaje que pasó "
+#~ "por este camino meses atrás\". Uno de los habitantes del pueblo se te "
+#~ "acerca y te da un objeto, diciendo \"El salvaje dejó caer esto. Tú debes "
+#~ "ser de su calaña. Por eso, te lo entrego. Pero cuidado. Muchos en el "
+#~ "pueblo no serán tan amistosos como yo.\""
+
+#~ msgid ""
+#~ "As you break your fast your sage rushes in, \"Good news, my lord!  I have "
+#~ "translated the message.  Two great heroes were imprisoned many years "
+#~ "ago.  They lie sleeping - still guarded by magic barriers and monsters.  "
+#~ "My lord, they lie nearby- in between our ally and us.  If we could free "
+#~ "them, they would surely aid us against our enemies!  The password to the "
+#~ "first magic barrier can be learned at the Aqua Traveller's Tent.\""
+#~ msgstr ""
+#~ "Mientras estás desayunando, tu consejero entra apresuradamente, \"¡Buenas "
+#~ "noticias, mi señor! He traducido el mensaje. Dos grandes héroes fueron "
+#~ "apresados hace muchos años. Aún duermen - guardados por barreras mágicas "
+#~ "y monstruos. Mi señor, están cerca, entre nuestro aliado y nosotros. Si "
+#~ "puiéramos liberarlos, seguramente nos ayudarían contra nuestros enemigos. "
+#~ "La contraseña para la primera barrera mágica puede aprenderse en la "
+#~ "Tienda de Agua del Viajero.\""
+
+#~ msgid ""
+#~ "As you enter the small clearing, you see a familiar figure talking to a "
+#~ "group of halflings and soldiers. You stay awhile and listen to his "
+#~ "speech. \"The time to throw off these chains of tyranny is now! We must "
+#~ "strike at the heart of her empire, and destroy the evil that she has "
+#~ "brought to our land.\" As the old elf finishes speaking, he gets up from "
+#~ "his mossy seat and once again, blends into the woods with incredible "
+#~ "grace."
+#~ msgstr ""
+#~ "Mientras entras en el pequeño descampado ves una figura familiar que "
+#~ "comanda un grupo de Medianos y soldados. Te alejas mientras y escuchas su "
+#~ "conversación: \"El tiempo de romper estas cadenas de tiranía ha llegado"
+#~ "\". \"Debemos atacar el corazón del Imperio y destruir el mal que ha "
+#~ "traido a nuestra tierra\". Cuando el anciano elfo acaba su discurso se "
+#~ "levanta del asiento y de nuevo se camufla en el bosque con increible "
+#~ "habilidad."
+
+#~ msgid ""
+#~ "As you lay down to nap after a long battle, you notice a lucky four-leaf "
+#~ "clover."
+#~ msgstr ""
+#~ "Al ir a descansar después de una larga batalal, encuentras un trébol de "
+#~ "la suerte de cuatro hojas."
+
+#~ msgid ""
+#~ "As you make  your way through the last of the golemn debris, a group of "
+#~ "halflings runs towards you carrying fruit and flowers. \"Thank you so "
+#~ "much!\" Their leader exclaims, \"We've been trapped in here for ever! "
+#~ "Come by our homes, we'll pack up and go with you!\""
+#~ msgstr ""
+#~ "Al abrirte paso a través de los restos del gólem, un grupo de medianos "
+#~ "corre hacia ti trayendo flores y frutas. \"¡Muchas gracias!\" Su líder "
+#~ "exclama: \"¡Hemos estado atrapados aquí por siempre! ¡Pásate por nuestros "
+#~ "hogares, recogeremos nuestras cosas e iremos contigo!\""
+
+#~ msgid ""
+#~ "As you make your way to the shrine, some very thin and hollow-eyed men "
+#~ "come out of the flower patch and stare at you.  Seeing that you want the "
+#~ "gold, one of them says to you \"Hey, man, if you're, like, so lusty for "
+#~ "earthly wealth, then, like, have this too.\" You graciously take what "
+#~ "they have offered and back out of the clearing."
+#~ msgstr ""
+#~ "Al abrirte camino hasta el altar, un hombre muy flaco y ojeroso sale de "
+#~ "entre las flores y te mira fijamente. Viendo que quieres el oro, uno de "
+#~ "ellos te dice \"Eh, hombre, si estás tan ansioso por las riquezas "
+#~ "terrenales, entonces ten también esto.\" Agradecido, tomas lo que te "
+#~ "ofrecen y sales del claro."
+
+#~ msgid ""
+#~ "As you prepare your lands to fight the onslaught from the South, a "
+#~ "curious message appears on your table in the Great Hall of your Castle.  "
+#~ "Written in some ancient language, none but your sage can make any sense "
+#~ "of it.  She promises to have the words deciphered by tomorrow..."
+#~ msgstr ""
+#~ "Mientras preparas tus tierras para combatir la invasión del Sur, aparece "
+#~ "un curioso mensaje en la mesa del Gran Salón de tu Castillo. Escrito en "
+#~ "algún lenguaje antiguo, sólo tu [SAGE] sabio sabe encontrarle sentido. Te "
+#~ "promete tener las palabras descifradas para mañana..."
+
+#~ msgid "A three hour tour, a three hour tour..."
+#~ msgstr "Un recorrido de tres horas, un recorrido de tres horas..."
+
+#~ msgid ""
+#~ "A tiny gnome points to a chunk of crystal you otherwise would have "
+#~ "overlooked!"
+#~ msgstr ""
+#~ "Un gnomo diminuto te señala un trozo de cristal que de otro modo hubieras "
+#~ "pasado por alto."
+
+#~ msgid "Atlantium"
+#~ msgstr "Atlantium"
+
+#~ msgid ""
+#~ "At last, the king is dead.  For years you have planned his demise, but "
+#~ "now it is done, and there is no heir to take his place, though the "
+#~ "Knights to the south believe that they are the rightful successors.  A "
+#~ "wealth in wood (to the south) and ore (in the northern mountains) "
+#~ "provides you with trade goods, and your isolation has allowed you to "
+#~ "prepare your forces of darkness for this day.  Go, now, and fulfill your "
+#~ "destiny!"
+#~ msgstr ""
+#~ "Por fin, el rey ha muerto. Durante años planeaste su fallecimiento, pero "
+#~ "ahora lo has conseguido, y no hay heredero que ocupe su lugar, aunque los "
+#~ "Caballeros del sur creen que ellos son sus sucesores legítimos. La "
+#~ "abundante madera (al sur) y mineral (en las montañas del norte) te "
+#~ "proporcionan bienes de comercio, y tu aislamiento te ha permitido "
+#~ "preparar tus fuerzas de oscuridad para este día. ¡Ve ahora, y cumple tu "
+#~ "destino!"
+
+#~ msgid ""
+#~ "At the base of the mountain you see something that glitters.   You "
+#~ "discover an ancient pile of offerings to the gods."
+#~ msgstr ""
+#~ "Ves algo que brilla en la base de la montaña. Descubres una antigua pila "
+#~ "de ofrendas a los Dioses."
+
+#~ msgid "Avalon"
+#~ msgstr "Avalon"
+
+#~ msgid "Avone"
+#~ msgstr "Avone"
+
+#~ msgid ""
+#~ "A wild magic has allowed a bridge to form between two lands...  Your one "
+#~ "hope is to capture castle \"Black Fang\"."
+#~ msgstr ""
+#~ "Una magia salvaje ha permitido que se formara un puente entre dos "
+#~ "tierras... Tu única esperanza es capturar el castillo \"Colmillo Negro\"."
+
+#~ msgid "Barbarian's castle lies to the south."
+#~ msgstr "El castillo de los bárbaros se encuentra al sur."
+
+#~ msgid ""
+#~ "Barbarians from the north threaten all civilization. Can you repel the "
+#~ "hordes?"
+#~ msgstr ""
+#~ "Bárbaros del norte amenazan toda civilización. ¿Puedes repeler sus hordas?"
+
+#~ msgid "Barrowton"
+#~ msgstr "Barrowton"
+
+#~ msgid "Basenji"
+#~ msgstr "Basenji"
+
+#~ msgid "Bayside"
+#~ msgstr "Junto a la bahía"
+
+#~ msgid "Baywatch"
+#~ msgstr "Vigilantes de la playa"
+
+#~ msgid ""
+#~ "Because the Darkscale Valley is so barren, the Emperor will be sending "
+#~ "wood to you every week. Use it wisely, for it is all you shall have."
+#~ msgstr ""
+#~ "Al ser el Valle Escamaoscura tan desolado el Emperador te enviará madera "
+#~ "cada semana. Úsala con sabiduría, pues es toda la que tendrás."
+
+#~ msgid ""
+#~ "Before questing for the orb of negation, you must first crush the local "
+#~ "opposition. After the Sorceresses are removed from the earth, go east "
+#~ "where legend says the orb lies.  You may expect a convoy of supplies in a "
+#~ "week or so to aid your conquest."
+#~ msgstr ""
+#~ "Antes de partir en busca de el Orbe de Negación, primero debes aplastar "
+#~ "la oposición local. Una vez que las Hechiceras hayan sido eliminadas de "
+#~ "la faz de la Tierra, dirígete al este, donde dice la leyenda que se "
+#~ "encuentra el orbe. Puedes esperar que un convoy con suministros llegue en "
+#~ "cosa de una semana para ayudarte con tu conquista."
+
+#~ msgid ""
+#~ "Before you may pass, the spirit guardian of this valley demands tribute."
+#~ msgstr ""
+#~ "Antes de dejarte pasar, el espíritu guardián de este valle demanda "
+#~ "tributo."
+
+#~ msgid "Being held...."
+#~ msgstr "Ser retenido..."
+
+#~ msgid "Beltway"
+#~ msgstr "Beltway"
+
+#~ msgid "Beware -- Entering Hyrda Country"
+#~ msgstr "Precaución -- Está entrando en el País de Hyrda"
+
+#~ msgid "Beware for whom the bell trolls."
+#~ msgstr "Cuidado con por quién trolean las campanas."
+
+#~ msgid "Beware of Pirates!"
+#~ msgstr "¡Cuidado con los Piratas!"
+
+#~ msgid "Beware of thieves!"
+#~ msgstr "¡Cuidado con los ladrones!"
+
+#~ msgid "Beware of traps ahead."
+#~ msgstr "Cuidado con las trampas."
+
+#~ msgid "Beware of Warlocks"
+#~ msgstr "¡Cuidado con los hechiceros!"
+
+#~ msgid "Beware the deadly swamps!"
+#~ msgstr "¡Cuidado con los pantanos mortíferos!"
+
+#~ msgid "Beware the Domain of Dragons"
+#~ msgstr "Cuidado con el Dominio de los Dragones"
+
+#~ msgid "Beware the Dragon Leader"
+#~ msgstr "Cuidado cno el Líder Dragon"
+
+#~ msgid "Beware the edge of the world!"
+#~ msgstr "¡Cuidado con el borde del mundo!"
+
+#~ msgid "Beware the moors and stick to the roads."
+#~ msgstr "Cuidado con los páramos y manténte en las carreteras."
+
+#~ msgid "Beware the rocks"
+#~ msgstr "Cuidado con las rocas"
+
+#~ msgid "Beware the sirens!!!"
+#~ msgstr "¡¡Cuidado con las sirenas!!"
+
+#~ msgid "Beware the sirens!"
+#~ msgstr "¡Cuidado con las sirenas!"
+
+#~ msgid "Beware, the whirlpool may not take you into a friendly embrace."
+#~ msgstr "Cuidado, el torbellino puede que no te dé un abrazo amigable."
+
+#~ msgid "Beyond here be Dragons!"
+#~ msgstr "¡Más allá de aqui estan los dragones!"
+
+#~ msgid "Beyond the door, there be Dragons. BEWARE!"
+#~ msgstr "Más allá de la puerta hay Dragones. ¡CUIDADO!"
+
+#~ msgid "Big Oak"
+#~ msgstr "Roble Grande"
+
+#~ msgid "Blackburn"
+#~ msgstr "Blackburn"
+
+#~ msgid "Blackfang"
+#~ msgstr "Colmillonegro"
+
+#~ msgid "Black Fang"
+#~ msgstr "Comillo Negro"
+
+#~ msgid "Black Oak"
+#~ msgstr "Roble Negro"
+
+#~ msgid "Blackridge"
+#~ msgstr "Crestanegra"
+
+#~ msgid "Blacksford"
+#~ msgstr "Vadonegro"
+
+#~ msgid "Black Vein"
+#~ msgstr "Vena Negra"
+
+#~ msgid "Blackwind"
+#~ msgstr "Vientonegro"
+
+#~ msgid "Bloodreign"
+#~ msgstr "Reinosangriento"
+
+#~ msgid "Boats my be needed to access some parts of this peninsula."
+#~ msgstr ""
+#~ "Se necesitarán botes para acceder a algunas partes de esta península."
+
+#~ msgid "Boats Sold Here            Inquire Within"
+#~ msgstr "Se venden botes. Razón aquí."
+
+#~ msgid "BoneVille"
+#~ msgstr "VillaHuesos"
+
+#~ msgid "Bridge out!"
+#~ msgstr "¡Puente ausente!"
+
+#~ msgid "Bridge Out!"
+#~ msgstr "¡Puente fuera!"
+
+#~ msgid "Brindamoor"
+#~ msgstr "Brindamoor"
+
+#~ msgid "Brownston"
+#~ msgstr "Brownston"
+
+#~ msgid "Buried Treasure!"
+#~ msgstr "¡Tesoro enterrado!"
+
+#~ msgid "Burlock"
+#~ msgstr "Burlock"
+
+#~ msgid "Burton"
+#~ msgstr "Burton"
+
+#~ msgid ""
+#~ "Capture the necromancer's dreaded castle \"Death Gate\" and free the land "
+#~ "from the undead plague."
+#~ msgstr ""
+#~ "Captura el temido castillo del necromante \"Puerta de la Muerte\" y "
+#~ "libera la tierra de la plaga de no-muertos."
+
+#~ msgid "Cathcart"
+#~ msgstr "Cathcart"
+
+#~ msgid "Chandler"
+#~ msgstr "Chandler"
+
+#~ msgid "Chilton"
+#~ msgstr "Chilton"
+
+#~ msgid "Chronos"
+#~ msgstr "Chronos"
+
+#~ msgid "Come and...."
+#~ msgstr "Ven y..."
+
+#~ msgid ""
+#~ "Compared to the rest of the villages in this land, this village seems "
+#~ "grand, but in any other land it would seem poor. From here you can see "
+#~ "the tall spires of the Warlock's tower of Dragons."
+#~ msgstr ""
+#~ "Comparada con el resto de los pueblos de esta tierra, este pueblo parece "
+#~ "grande, pero en cualquier otra parte se le consideraría pobre. Desde aquí "
+#~ "puedes ver las altas espiras de la torre de Dragones del Hechicero."
+
+#~ msgid "Complete"
+#~ msgstr "Completo"
+
+#~ msgid "Condemned!"
+#~ msgstr "¡Condenado!"
+
+#~ msgid ""
+#~ "Congratulations! After navigating the treacherous coast, you have "
+#~ "established trade between the north and south."
+#~ msgstr ""
+#~ "¡Enhorabuena! Después de navegar por la traicionera costa, has "
+#~ "establecido rutas de comercio entre el norte y el sur."
+
+#~ msgid "Corackston"
+#~ msgstr "Corackston"
+
+#~ msgid "Crossroads"
+#~ msgstr "Encrucijada"
+
+#~ msgid "Crossroads North"
+#~ msgstr "Encrucijada Norte"
+
+#~ msgid "Crossroads South"
+#~ msgstr "Encrucijada Sur"
+
+#~ msgid "Danger a whirlpool destroyed my ship."
+#~ msgstr "Peligro, un remolino destruyó mi barco."
+
+#~ msgid "Danger, Dragons abound!"
+#~ msgstr "¡Peligro, abundancia de Dragones!"
+
+#~ msgid "DANGER!  QUICKSAND!"
+#~ msgstr "¡PELIGRO! ¡ARENAS MOVEDIZAS!"
+
+#~ msgid "Danger! Troll bridge ahead!"
+#~ msgstr "¡Peligro! ¡Puente de troll delante!"
+
+#~ msgid "Danger - Turn Back Now"
+#~ msgstr "Peligro - Vuelve Atrás Ahora"
+
+#~ msgid "Dark clouds loom overhead as you enter this valley."
+#~ msgstr "Oscuras nubes se ciernen sobre tu cabeza al entrar en este valle."
+
+#~ msgid "Dead Pine"
+#~ msgstr "Pino Muerto"
+
+#~ msgid ""
+#~ "Dear Diary,                           I found a mermaid today.  She was "
+#~ "floating in a patch of seaweed next to a rock.  A very friendly sort of "
+#~ "creature too!  Gave me all sorts of lovely gems and jewelry!  She said to "
+#~ "come back again sometime for more of the sea riches.  Wow. Ahab"
+#~ msgstr ""
+#~ "Querido Diario: hoy he encontrado una sirena. Estaba flotando en un "
+#~ "bancal de algas, junto a una roca. ¡Es una criatura muy amistosa! ¡Me "
+#~ "entregó todo tipo de gemas y joyería! Ella dijo que volviera más tarde a "
+#~ "por más riquezas del mar. Vaya. Ahab"
+
+#~ msgid "Deathgate"
+#~ msgstr "Puerta de la muerte"
+
+#~ msgid "DeathGate"
+#~ msgstr "Puerta de la Muerte"
+
+#~ msgid "Decisions"
+#~ msgstr "Decisiones"
+
+#~ msgid "\"Defender\""
+#~ msgstr "\"Defensor\""
+
+#~ msgid ""
+#~ "Detour! Mountain pass to the East has been known to have avalanches! For "
+#~ "your own safety, follow the road South."
+#~ msgstr ""
+#~ "¡Desvío! El paso de montaña al Este es conocido por sus avalanchas. Por "
+#~ "tu propia seguridad, sigue la carretera al Sur."
+
+#~ msgid "Detour! Troll bridge ahead!"
+#~ msgstr "¡Desvio! ¡Puente de troll delante!"
+
+#~ msgid "DirtWater"
+#~ msgstr "Aguasucia"
+
+#~ msgid "Dominion"
+#~ msgstr "Dominio"
+
+#~ msgid "Do Not Enter!"
+#~ msgstr "¡No Entrar!"
+
+#~ msgid "Do not remove coins from fountain."
+#~ msgstr "No se lleven las monedas de la fuente."
+
+#~ msgid "Dragadune"
+#~ msgstr "Dragadune"
+
+#~ msgid "Dragonburg"
+#~ msgstr "Dragomburgo"
+
+#~ msgid "Dragon City lies beyond the Scorpion Hills."
+#~ msgstr "Ciudad Dragón se encuentra más allá de las Colinas Escorpión."
+
+#~ msgid "Dragon Hill"
+#~ msgstr "Colina del Dragón"
+
+#~ msgid "Dragon Rider"
+#~ msgstr "Jinete de Dragones"
+
+#~ msgid "Dragons Everywhere!"
+#~ msgstr "¡Dragones por todos lados!"
+
+#~ msgid "Dragon's Eye"
+#~ msgstr "Ojo de Dragón"
+
+#~ msgid "Dragontooth"
+#~ msgstr "Diente de Dragón"
+
+#~ msgid "Dragon Town"
+#~ msgstr "Ciudad Dragón"
+
+#~ msgid "Dragonville"
+#~ msgstr "Pueblo Dragón"
+
+#~ msgid "Dragon Wars"
+#~ msgstr "Guerras Dragón"
+
+#~ msgid "Dragon Watch"
+#~ msgstr "Guardian Dragón"
+
+#~ msgid "Drakoran"
+#~ msgstr "Drakoran"
+
+#~ msgid "Dwarfhall"
+#~ msgstr "Dwarfhall"
+
+#~ msgid "Dwarfhall, Domain of the dwarf King."
+#~ msgstr "Dwarfhall, Dominio del Rey Enano."
+
+#~ msgid "Dwarf Hall, domain of the dwarf King."
+#~ msgstr "Camara Enana, dominio del Rey enano."
+
+#~ msgid "Eatio"
+#~ msgstr "Eatio"
+
+#~ msgid "Edgewood"
+#~ msgstr "Edgewood"
+
+#~ msgid "Elk's Head"
+#~ msgstr "Cabeza de Alce"
+
+#~ msgid "Elowyn"
+#~ msgstr "Elowyn"
+
+#~ msgid "Enroth"
+#~ msgstr "Enroth"
+
+#~ msgid "Entering Praires of the Middlelands"
+#~ msgstr "Entrando en las Praderas de las Tierras Medias"
+
+#~ msgid "Entering the Valley of Magic"
+#~ msgstr "Entrando en el Valle de la Magia"
+
+#~ msgid "Erliquin"
+#~ msgstr "Erliquin"
+
+#~ msgid "Evil Igor"
+#~ msgstr "Malvado Igor"
+
+#~ msgid "Fadlan"
+#~ msgstr "Fadlan"
+
+#~ msgid "Fantasy Island."
+#~ msgstr "Isla de Fantasía."
+
+#~ msgid "Farlien"
+#~ msgstr "Farlien"
+
+#~ msgid ""
+#~ "Federal express, when it absolutely positively has to be there turn one."
+#~ msgstr ""
+#~ "Federal Express, cuando absolutamente y positivamente tiene que estar "
+#~ "allí en el turno uno."
+
+#~ msgid "Fenton"
+#~ msgstr "Fenton"
+
+#~ msgid "Fetid Elm"
+#~ msgstr "Olmo Fétido"
+
+#~ msgid ""
+#~ "Final message from Overlord. \"The royal executioners are on their way. "
+#~ "My gold, the land or your head- it's your choice.\""
+#~ msgstr ""
+#~ "Mensaje final del Jefe Supremo: \"Los ejecutores reales están en camino. "
+#~ "Mi oro, la tierra o vuestra cabeza - vos elegís.\""
+
+#~ msgid "Find and defeat the Pirate Leader!"
+#~ msgstr "¡Busca y derrota al Líder Pirata!"
+
+#~ msgid "Find and destroy the evil beings who rule the wastelands."
+#~ msgstr ""
+#~ "Busca y destruye a las malvadas criaturas que gobiernan los páramos."
+
+#~ msgid "Find the center island."
+#~ msgstr "Encuentra la isla central."
+
+#~ msgid ""
+#~ "Find the Ultimate Artifact and be proclaimed King, or smash the "
+#~ "opposition and take control."
+#~ msgstr ""
+#~ "Encuentra el Artefacto Definitivo y sé proclamado Rey, o aplasta la "
+#~ "oposción y toma el control."
+
+#~ msgid "Fire King"
+#~ msgstr "Rey de Fuego"
+
+#~ msgid "Five heroes vie for control of a familiar land."
+#~ msgstr "Cinco héroes rivalizan por controlar una tierra familiar."
+
+#~ msgid "Fool's Gold"
+#~ msgstr "El Oro de los Necios"
+
+#~ msgid ""
+#~ "For a total of 400,000 gold your opponents will become \"loyal\" "
+#~ "subjects, otherwise... let them eat cake!"
+#~ msgstr ""
+#~ "Por un total de 400.000 de oro, tus oponentes se volverán sujetos \"leales"
+#~ "\", si no... ¡Qué coman pasteles!"
+
+#~ msgid ""
+#~ "For centuries, the Wizards of the North have maintained a vast library "
+#~ "for all the world to share.  Now, however, they have closed their doors, "
+#~ "and issued declarations of war to each of the other rulers of the land.  "
+#~ "To make matters worse, rather than ally with you to face the Wizards, "
+#~ "each of the others have decided to go forth on their own in an effort to "
+#~ "conquer this land for themselves!  Prepare your forces, commander, for "
+#~ "you now stand alone."
+#~ msgstr ""
+#~ "Durante siglos, los Magos del Norte han mantenido una enorme biblioteca "
+#~ "para compartirla con el mundo. Ahora, sin embargo, han cerrado sus "
+#~ "puertas, y han enviado declaraciones de guerra a cada uno de los otros "
+#~ "señores de la tierra. Para empeorar las cosas, en lugar de aliarse "
+#~ "contigo para enfrentar a los Magos, cada uno de los otros ha decidido ir "
+#~ "por su cuenta, ¡en un intento de conquistar esta tierra para sí mismos! "
+#~ "Prepara tus fuerzas, comandante, pues ahora estás solo."
+
+#~ msgid ""
+#~ "For decades you have studied, learned, and allowed yourself to be ruled "
+#~ "by that pitiful excuse for a king, knowing that one day the time would "
+#~ "come for you to sit on the throne.  That time is now, for the king is "
+#~ "dead and without an heir.  You have the advantage of isolation from the "
+#~ "rest of the kingdom, but beware the miles of coastline that could leave "
+#~ "you vulnerable to attack.  Go, now, and wipe your enemies from this land!"
+#~ msgstr ""
+#~ "Durante décadas has estudiado, aprendido, y permitido a esa patética "
+#~ "excusa de Rey gobernarte, sabedor de que un tiempo llegaría en el que "
+#~ "serías tú quien se sentaría en el trono. Ese tiempo ha llegado, pues el "
+#~ "rey ha muerto sin heredero. Tienes la ventaja del aislamiento del resto "
+#~ "del reino, pero cuidado con las millas de costa que podrían dejarte "
+#~ "vulnerable al ataque. ¡Ve ahora, y barre de esta tierra a tus enemigos!"
+
+#~ msgid "Forder Oaks"
+#~ msgstr "Forder Oaks"
+
+#~ msgid "Forestria"
+#~ msgstr "Forestria"
+
+#~ msgid "For Honor"
+#~ msgstr "Por Honor"
+
+#~ msgid ""
+#~ "For information about Ye Rich lands to the south, speak to Alponse at the "
+#~ "Golden Goose Tavern. Excellent views, plentiful water."
+#~ msgstr ""
+#~ "Para obtener información acerca de las Ricas tierras al sur, habla con "
+#~ "Alponse en la Taberna del Ganso Dorado. Excelentes vistas, abundante agua."
+
+#~ msgid "Forsaken Lands"
+#~ msgstr "Tierras Olvidadas"
+
+#~ msgid "For sale."
+#~ msgstr "Se vende."
+
+#~ msgid "Fortress Isle"
+#~ msgstr "Isla Fortaleza"
+
+#~ msgid ""
+#~ "For years, you have existed peacefully in the Forest of Dreams, knowing "
+#~ "that your king was the kindest and strongest ruler the land had seen in "
+#~ "centuries.  Now, however, his reign is at an end, and there is no heir to "
+#~ "succeed him.  You realize that a power struggle is coming, and that you "
+#~ "must brace yourself for war, and prevent those who would harm this land "
+#~ "from coming into power!"
+#~ msgstr ""
+#~ "Durante años, has vivido en paz en el Bosque de los Sueños, sabiendo que "
+#~ "tu rey era el más amable y poderoso gobernante que la tierra hubiera "
+#~ "visto en siglos. Ahora, sin embargo, su reinado finaliza, y no hay "
+#~ "heredero que le suceda. Eres consciente de que se acerca una lucha por el "
+#~ "poder, y que debes aprestarte al combate, para prevenir que los que "
+#~ "dañarían esta tierra lleguen al poder."
+
+#~ msgid ""
+#~ "For years, you've been able to keep your subjects \"appeased.\"  Now "
+#~ "however, you discover not only that your entire kingdom has turned "
+#~ "against you, but most of your outer towns have fallen to the different "
+#~ "factions.  To make matters worse, all your gold suddenly seems to be "
+#~ "missing from the treasury!"
+#~ msgstr ""
+#~ "Durante años has sido capaz de mantener a tus súbditos \"complacidos\". "
+#~ "Sin embargo, ahora descubres no sólo que todo tu reino se ha vuelto "
+#~ "contra ti, sino que tus ciudades más lejanas han caído a manos de "
+#~ "distintas facciones. Para empeorar las cosas, ¡parece que ha desaparecido "
+#~ "todo tu oro del tesoro!"
+
+#~ msgid "Fountainhead"
+#~ msgstr "Cabezafuente"
+
+#~ msgid "Four kingdoms race to capture the island of Sharkania."
+#~ msgstr "Cuatro reinos compiten para capturar la isla de Sharkania."
+
+#~ msgid "Four lakes have castles, three have treasure."
+#~ msgstr "Cuatro lagos tienen castillos, tres tienen tesoros."
+
+#~ msgid "Four players must work together to assault the Wizards' Stronghold."
+#~ msgstr ""
+#~ "Para asaltar la Fortaleza de los Magos han de trabajar juntos cuatro "
+#~ "jugadores."
+
+#~ msgid "Frozenpeak"
+#~ msgstr "Picohelado"
+
+#~ msgid "Galveston"
+#~ msgstr "Galveston"
+
+#~ msgid "Garamok"
+#~ msgstr "Garamok"
+
+#~ msgid "Gate"
+#~ msgstr "Puerta"
+
+#~ msgid "Gate to the Isle of Knowledge"
+#~ msgstr "Puerta a la Isla del Conocimiento"
+
+#~ msgid "Gate to The Isle of Knowledge"
+#~ msgstr "Puerta a La Isla del Conocimiento"
+
+#~ msgid "Gaurdian"
+#~ msgstr "Guardián"
+
+#~ msgid "Gavonshire"
+#~ msgstr "Gavonshire"
+
+#~ msgid "Glastonbury"
+#~ msgstr "Glastonbury"
+
+#~ msgid "Go away!"
+#~ msgstr "¡Largo!"
+
+#~ msgid "GO AWAY!"
+#~ msgstr "¡LARGO!"
+
+#~ msgid "Goblin Island"
+#~ msgstr "Isla Goblin"
+
+#~ msgid "Goblin King"
+#~ msgstr "Rey Goblin"
+
+#~ msgid "Go Home!"
+#~ msgstr "¡Vete a casa!"
+
+#~ msgid "Go north to find the lost gold-mine."
+#~ msgstr "Dirígete al norte para encontrar la mina de oro perdida."
+
+#~ msgid "Good vs. Evil"
+#~ msgstr "Bien vs. Mal"
+
+#~ msgid "Gorgomar"
+#~ msgstr "Gorgomar"
+
+#~ msgid "Greed"
+#~ msgstr "Codicia"
+
+#~ msgid "Green bonus stuff"
+#~ msgstr "Bonificación del verde"
+
+#~ msgid "Green gets stuff"
+#~ msgstr "El verde obtiene cosas"
+
+#~ msgid "Greenroot"
+#~ msgstr "Raízverde"
+
+#~ msgid "Green's Allowance"
+#~ msgstr "Complemento del Verde"
+
+#~ msgid "Green's Groceries"
+#~ msgstr "Provisiones del Verde"
+
+#~ msgid "green stuff"
+#~ msgstr "cosa verde"
+
+#~ msgid "Green stuff"
+#~ msgstr "Cosa verde"
+
+#~ msgid "Greywind"
+#~ msgstr "Vientogris"
+
+#~ msgid "Grim"
+#~ msgstr "Siniestro"
+
+#~ msgid "Grrr, Blazzer, Grrupt. Be gone with you!"
+#~ msgstr "Grrr, Blazzer, Grrupt. ¡Se ha ido contigo!"
+
+#~ msgid "Guardian War"
+#~ msgstr "Guerra de Guardianes"
+
+#~ msgid "Gungtooth"
+#~ msgstr "Gungtooth"
+
+#~ msgid "Hail Unicorns!"
+#~ msgstr "¡Hurra por los Unicornios!"
+
+#~ msgid "Hampshire"
+#~ msgstr "Hampshire"
+
+#~ msgid "Have fun storming the castle!"
+#~ msgstr "¡Diviértete asaltando el castillo!"
+
+#~ msgid "Havenwood"
+#~ msgstr "Havenwood"
+
+#~ msgid "Hawkins"
+#~ msgstr "Hawkins"
+
+#~ msgid "Help!"
+#~ msgstr "¡Ayuda!"
+
+#~ msgid "Help me...."
+#~ msgstr "Ayúdame..."
+
+#~ msgid ""
+#~ "Help peasant farmers regain their castle and land, else they'll take your "
+#~ "crops."
+#~ msgstr ""
+#~ "Ayuda a los campesinos a recuperar su castillo y sus tierras, o de otro "
+#~ "modo tomarán tus cosechas."
+
+#~ msgid "Hero's Hall"
+#~ msgstr "Salón de los Héroes"
+
+#~ msgid ""
+#~ "High in the snowy crags, you meet an old witch who, in return for a "
+#~ "trinket of yours, gives you a powerful magical object she used to use as "
+#~ "a footstool before she was exiled into the mountains by her own "
+#~ "townspeople."
+#~ msgstr ""
+#~ "En lo alto de los riscos nevados te encuentras con una vieja bruja, que a "
+#~ "cambio de un pendiente, te da un poderoso objeto mágico que solía usar "
+#~ "como escabel antes de ser exiliada a las montañas por sus propios vecinos."
+
+#~ msgid "Hillstone"
+#~ msgstr "Colinapedregosa"
+
+#~ msgid "Hilltop"
+#~ msgstr "Cumbre"
+
+#~ msgid "Hilltown"
+#~ msgstr "Hilltown"
+
+#~ msgid "Horizon"
+#~ msgstr "Horizonte"
+
+#~ msgid "Hot Spot"
+#~ msgstr "Punto Caliente"
+
+#~ msgid "Hungry dragons await.  Welcome, food."
+#~ msgstr "Dragones hambrientos esperan. Bienvenida, comida."
+
+#~ msgid "Hurry, no time to wait.  This way to the dock."
+#~ msgstr "Apresúrate, no hay tiempo para esperar. Al muelle."
+
+#~ msgid "Hurry up! Few days are left before the enemy's army arrives."
+#~ msgstr "¡Date prisa! Quedan pocos días para que el ejercito enemigo llegue."
+
+#~ msgid "I am...."
+#~ msgstr "Yo soy..."
+
+#~ msgid ""
+#~ "I am one of the few remaining survivors of the wrecked pleasure ship, "
+#~ "Exhorbitance. I think we'll all be dead of hunger soon, for we are out of "
+#~ "caviar. We ate the chef yesterday."
+#~ msgstr ""
+#~ "Soy uno de los pocos supervivientes del naufragio del crucero de placer "
+#~ "Exhorbitance. Creo que pronto moriremos de hambre, pues se nos ha acabado "
+#~ "el caviar. Ayer nos comimos al chef."
+
+#~ msgid "Ibn Fadlan"
+#~ msgstr "Ibn Fadlan"
+
+#~ msgid "Ice Palace"
+#~ msgstr "Palacio de Hielo"
+
+#~ msgid "Ice Prince"
+#~ msgstr "Príncipe de Hielo"
+
+#~ msgid "Icy lands ahead."
+#~ msgstr "Tierras heladas más adelante."
+
+#~ msgid "I didn't do it!"
+#~ msgstr "¡Yo no he sido!"
+
+#~ msgid ""
+#~ "If three heroes could dig six holes in three days, how long would it take "
+#~ "six heroes to dig twelve holes?"
+#~ msgstr ""
+#~ "Si tres héroes pueden cavar seis hoyos en tres días, ¿cuánto le llevará a "
+#~ "seis héroes cavar doce hoyos?"
+
+#~ msgid "If you free a hero, they may help..."
+#~ msgstr "Si liberaras a un héroe, ellos tal vez ayudarían..."
+
+#~ msgid ""
+#~ "If you value your lives, for God's sake, Don't go through this whirlpool!"
+#~ msgstr ""
+#~ "Si teneis aprecio a la vida, por el amor de Dios, ¡no atraveseis este "
+#~ "remolino!"
+
+#~ msgid "Income for Yellow."
+#~ msgstr "Ingresos para el Amarillo"
+
+#~ msgid "In the hole you find a chunk of ore!"
+#~ msgstr "¡Encuentras una mena de mineral en el agujero!"
+
+#~ msgid "In the stream you find an old compass!"
+#~ msgstr "¡Encuentras una brújula en la corriente!"
+
+#~ msgid "In this glen live some very naughty halflings. Stay Away!"
+#~ msgstr "En esta cañada vivlen algunos traviesos Medianos. ¡Aléjate!"
+
+#~ msgid ""
+#~ "In two more weeks, if you have not located Joseph, your kingdom will "
+#~ "surely lose its current battle with Harondale."
+#~ msgstr ""
+#~ "Si en dos semanas no has localizado a Joseph, tu reino perderá con "
+#~ "seguridad su batalla en curso con Harondale."
+
+#~ msgid "I see you, you see me."
+#~ msgstr "Te veo, me ves."
+
+#~ msgid "Is it something I said? Go back and I will forget the whole thing."
+#~ msgstr "¿Es algo que dije? Vuelve atrás y olvidaré todo el asunto."
+
+#~ msgid "IslandHome"
+#~ msgstr "IslaHogar"
+
+#~ msgid "Island of the meek"
+#~ msgstr "Isla de los mansos"
+
+#~ msgid "Island of Wolcott"
+#~ msgstr "Isla de Wolcott"
+
+#~ msgid "Isle Maze"
+#~ msgstr "Isla Laberinto"
+
+#~ msgid "Isle of Knowledge"
+#~ msgstr "Isla de Conocimiento"
+
+#~ msgid ""
+#~ "It has become apparent that if all your enemies were eliminated, you "
+#~ "would have all the time you need to find the Ultimate Artifact."
+#~ msgstr ""
+#~ "Es bastante claro que si todos tus enemigos fueran eliminados, tendrías "
+#~ "todo el tiempo que necesitas para encontrar el Artefacto Definitivo."
+
+#~ msgid ""
+#~ "It is obvious that the mage that once was here had won many battles!  "
+#~ "There, upon his hand, is a most powerful ring!"
+#~ msgstr ""
+#~ "¡Es obvio que el mago que estuvo una vez aquí ganó muchas batallas! Ahí, "
+#~ "en su mano, ¡hay un poderoso anillo!"
+
+#~ msgid ""
+#~ "It is rumored that a bridge of land used to exist between the two "
+#~ "continents, but that a wild magic caused it to sink into the sea, taking "
+#~ "with it all those who used to inhabit it.  To try to raise this bridge is "
+#~ "to invite a curse upon the world!  The spirits of the dead will haunt us "
+#~ "all!"
+#~ msgstr ""
+#~ "Se rumorea que solía haber un puente de tierra entre los dos continentes, "
+#~ "pero que una magia salvaje lo hizo hundirse en el mar, llevándose consigo "
+#~ "a todos los que vivían allí. ¡Intentar levantar este puente es atraer una "
+#~ "maldición sobre el mundo! ¡Los espíritus de los muertos nos atormentarán "
+#~ "a todos!"
+
+#~ msgid ""
+#~ "It is said that King Zealot found the gods' artifact once and it let him "
+#~ "rule for 100 years."
+#~ msgstr ""
+#~ "Se dice que el Rey Fanático encontró el artefacto de los dioses, y éste "
+#~ "le permitió gobernar por 100 años."
+
+#~ msgid ""
+#~ "It looks like there used to be an ore mine here but all you see now is a "
+#~ "hole in the ground and some minerals scattered around."
+#~ msgstr ""
+#~ "Parece que aquí había una mina de mineral, pero todo lo que ves ahora es "
+#~ "un agujero en la tierra y algunos minerales desperdigados."
+
+#~ msgid ""
+#~ "It's a battle for supremacy as the Blue and Green heroes take on Red and "
+#~ "Orange in team competition!"
+#~ msgstr ""
+#~ "¡Es una batalla por la supremacía donde los heroes Azul y Verde se "
+#~ "enfrentan a los heroes Rojo y Naranja en una competición por equipos!"
+
+#~ msgid "It's windy at the top.  Defend, Divide, and Conquer."
+#~ msgstr "Hace viento en la cima. Defiende, Divide, y Conquista."
+
+#~ msgid "IvanHome"
+#~ msgstr "CasaIván"
+
+#~ msgid "Ivan lives in the desert."
+#~ msgstr "Ivan vive en el desierto."
+
+#~ msgid ""
+#~ "I, Wilgatus, besiege you - do not fight me for I am all powerful and will "
+#~ "destroy you if you persue me.  I will demonstrate my power."
+#~ msgstr ""
+#~ "Yo, Wilgatus, te acecho - no luches contra mí, pues soy poderoso y te "
+#~ "destruiré si me persigues. Te demostraré mi poder."
+
+#~ msgid "I Would Go That Way If I Were You."
+#~ msgstr "Yo en tu lugar iría por ese camino."
+
+#~ msgid "Jarkonas VI"
+#~ msgstr "Jarkonas VI"
+
+#~ msgid "Jolly Roger was here"
+#~ msgstr "Jolly Roger estuvo aquí"
+
+#~ msgid "Jungomar"
+#~ msgstr "Jungomar"
+
+#~ msgid "Just 30 days left!"
+#~ msgstr "¡Sólo te quedan 30 días!"
+
+#~ msgid "Just ONE week left!"
+#~ msgstr "¡Sólo te queda 1 semana!"
+
+#~ msgid "Kastor"
+#~ msgstr "Kastor"
+
+#~ msgid "Keep going south"
+#~ msgstr "Sigue hacia el sur"
+
+#~ msgid "Keep Off The Grass!"
+#~ msgstr "¡Prohibido pisar la hierba!"
+
+#~ msgid "Keep Out!"
+#~ msgstr "¡Largo!"
+
+#~ msgid "King John"
+#~ msgstr "Rey John"
+
+#~ msgid "King of Death"
+#~ msgstr "Rey de la Muerte"
+
+#~ msgid "Knight's Trail."
+#~ msgstr "La Pista del Caballero."
+
+#~ msgid "Knight stuff"
+#~ msgstr "Cosas del caballero"
+
+#~ msgid "Lakeside"
+#~ msgstr "Lakeside"
+
+#~ msgid "Land's Edge"
+#~ msgstr "El Borde de la Tierra"
+
+#~ msgid "Land teleporters will get you to your destination sooner."
+#~ msgstr "Los teleportadores terrestres te llevarán más pronto a tu destino."
+
+#~ msgid "Lankershire"
+#~ msgstr "Lankershire"
+
+#~ msgid "Lavalor"
+#~ msgstr "Lavalor"
+
+#~ msgid "Like, Stuff And Junk?"
+#~ msgstr "¿Quiere, Cosas y Trastos?"
+
+#~ msgid ""
+#~ "Living on the outskirts of the kingdom, you are considered an unwelcome "
+#~ "outcast by the other leaders of the realm, though you always showed your "
+#~ "support for the king.  Now, however, the king is dead, and many of those "
+#~ "who spoke out againt him seek to seize his throne for themselves.  You "
+#~ "have a vast desert at your back, rich with gems, and the advantage that "
+#~ "many do not consider you a threat.  Go, now, and show them how wrong they "
+#~ "are!"
+#~ msgstr ""
+#~ "Al vivir en las afueras del reino, eres considerado como un paria por los "
+#~ "otros líderes del reino, aunque siempre has mostrado tu apoyo al rey. Sin "
+#~ "embargo, ahora el rey está muerto, y muchos de los que hablaban en su "
+#~ "contra buscan ocupar el trono. Tienes un vasto desierto a tu espalda, "
+#~ "rico en gemas, y la ventaja de que muchos no te consideran una amenaza. "
+#~ "Ve ahora, y ¡muéstrales cuánto se equivocan!"
+
+#~ msgid ""
+#~ "Log go up... Log go down... Log go up... Log go down...  "
+#~ "OOoohhhhhhhh........"
+#~ msgstr ""
+#~ "Tronco sube... Tronco baja... Tronco sube... Tronco baja... "
+#~ "OOoohhhhhhhh........."
+
+#~ msgid "Lombard"
+#~ msgstr "Lombardo"
+
+#~ msgid "Long live Roland the true King!"
+#~ msgstr "¡Larga vida a Roland, el auténtico Rey!"
+
+#~ msgid "Long live Roland the true King."
+#~ msgstr "Larga vida a Roland, el auténtico Rey."
+
+#~ msgid "Look before you leap."
+#~ msgstr "Mira antes de saltar."
+
+#~ msgid "Look out!"
+#~ msgstr "¡Cuidado!"
+
+#~ msgid "Lord Alberon"
+#~ msgstr "Lord Alberon"
+
+#~ msgid ""
+#~ "Lord Alberon calls you into his war room. He says, \"I am glad you have "
+#~ "chosen to remain loyal to me, but this war is a terrible one for my "
+#~ "kingdom. Already, the sorceress' towns to the Northeast have become "
+#~ "unsure about their loyalties, and will not pledge allegiance to either "
+#~ "side. This is hard on our cities as most of the wood in the land comes "
+#~ "from these towns. We will need to recover their sawmills and take their "
+#~ "towns by force.\""
+#~ msgstr ""
+#~ "Lord Alberon te convoca a su gabinete de guerra. Te dice, \"Estoy "
+#~ "orgulloso de que hayas elegido mantenerte leal a mí, pero esta guerra "
+#~ "está siendo terrible para mi reino. Las ciudades de la hechicera al "
+#~ "noreste dudan acerca de su lealtad, y no rendirán pleitesía a ningún "
+#~ "bando. Esto va a ser duro para nuestras ciudades, pues la mayoría de la "
+#~ "madera proviene de esas ciudades. Necesitamos recuperar sus aserraderos y "
+#~ "tomar sus ciudades por la fuerza.\""
+
+#~ msgid "Lord Haart"
+#~ msgstr "Lord Haart"
+
+#~ msgid "Lord Kreager"
+#~ msgstr "Lord Kreager"
+
+#~ msgid ""
+#~ "Lord, messages have begun pouring in from our spies in the other island "
+#~ "courts.  They have learned of a new volcanic island with vast amounts of "
+#~ "reasources.  Your Majesty, with these new reasources we could put an end "
+#~ "to a century of war between the islands, and reunite them under your "
+#~ "rightful rule."
+#~ msgstr ""
+#~ "Señor, nos están llegando mensajes de nuestros espías en las cortes de "
+#~ "las otras islas. Han tenido conocimiento de una nueva isla volcánica con "
+#~ "un cantidad enorme de recursos. Su Majestad, con esos nuevos recursos "
+#~ "podríamos poner fin a un siglo de guerra entre las islas, y reunirlas "
+#~ "bajo vuestro justo dominio."
+
+#~ msgid "Lost Continent"
+#~ msgstr "Continente Perdido"
+
+#~ msgid "Lost Gold- Mine"
+#~ msgstr "Mina de oro perdida"
+
+#~ msgid "Lost Island."
+#~ msgstr "Isla Perdida"
+
+#~ msgid "Lost Relic"
+#~ msgstr "Reliquia Perdida"
+
+#~ msgid "Maelstrom of Deceit"
+#~ msgstr "Vortice del Engaño"
+
+#~ msgid "Maelstrom of Misery"
+#~ msgstr "Vortice de la Miseria"
+
+#~ msgid "Magic"
+#~ msgstr "Magia"
+
+#~ msgid "Magic Three"
+#~ msgstr "Árbol Mágico"
+
+#~ msgid ""
+#~ "Many dust plumes rise from the floor of this small valley. You see "
+#~ "various bands of nomads roaming about, and in the distant, the bright "
+#~ "flames of their camp."
+#~ msgstr ""
+#~ "Se alzan muchos penachos de polvo desde el suelo de este pequeño valle. "
+#~ "Ves varios grupos de nómadas vagando, y en la distancia, las brillantes "
+#~ "hogueras de su campamento."
+
+#~ msgid ""
+#~ "Many guardians stand between you and your enemies, but anybody can sneak "
+#~ "through the back door!"
+#~ msgstr ""
+#~ "Hay muchos guardias entre ti y tus enemigos, ¡pero cualquiera podría "
+#~ "entrar a escondidas por la puerta trasera!"
+
+#~ msgid "Many that have gone through this door have never returned."
+#~ msgstr "Muchos de los que han franqueado esta puerte nunca regresaron."
+
+#~ msgid ""
+#~ "Many years ago, a couple of mages had a \"duel\" that forever changed the "
+#~ "lake at the center of this continent.  Hearty adventurers might find "
+#~ "interesting treasure there!"
+#~ msgstr ""
+#~ "Hace muchos años, unos cuantos magos mantuvieron un \"duelo\" que cambió "
+#~ "por siempre el lago del centro de este continente. Los aventureros más "
+#~ "osados podrían encontrar tesoros interesantes aquí."
+
+#~ msgid ""
+#~ "Many years ago, a falling star crashed near here.  Only now the area is "
+#~ "safe enough to explore.  Rumor has it a castle exist where the star fell."
+#~ msgstr ""
+#~ "Hace muchos años cayó una estrella cerca de aquí. Sólo ahora es seguro "
+#~ "explorar la zona. Se rumorea que existe un castillo donde cayó la "
+#~ "estrella."
+
+#~ msgid ""
+#~ "Many years ago, your father, the King, died in a freak hunting accident.  "
+#~ "Since then, you and your brother have jointly ruled his kingdom, but both "
+#~ "of you have been seeking a way to seize the throne for yourself.  You got "
+#~ "your wish.  Attackers from across the sea have captured more than half "
+#~ "your towns and castles, effectively dividing the continent in two.  Now "
+#~ "is the time to repel these invaders and do away with your brother once "
+#~ "and for all!"
+#~ msgstr ""
+#~ "Hace muchos años, tu padre, el Rey, murió en un extraño accidente de "
+#~ "caza. Desde entonces, tu hermano y tú habéis gobernado conjuntamente el "
+#~ "reino, pero los dos habéis estado buscando la manera de conseguir el "
+#~ "trono para sí. Conseguiste tu deseo. Atacantes de más allá del mar han "
+#~ "capturado más de la mitad de tus ciudades y castillos, dividiendo "
+#~ "efectivamente el continente en dos. ¡Ahora es el momento de repeler a los "
+#~ "invasores y acabar con tu hermano de una vez por todas!"
+
+#~ msgid "Marco"
+#~ msgstr "Marco"
+
+#~ msgid "Marsh Home"
+#~ msgstr "Hogar del Pantano"
+
+#~ msgid "Mayland"
+#~ msgstr "Mayland"
+
+#~ msgid "Meramec"
+#~ msgstr "Meramec"
+
+#~ msgid "Message from Archibald. \" Do not dare to return without my Crown.\""
+#~ msgstr "Mensaje de Archibald. \"No te atrevas a volver sin mi Corona.\""
+
+#~ msgid ""
+#~ "Message from Archibald. \" General, thank you for bringing me this lovely "
+#~ "gift. I have decided to participate directly in the capture of my brother "
+#~ "Roland. Since your military advice has taken us this far, I will follow "
+#~ "your orders to the letter.\""
+#~ msgstr ""
+#~ "Mensaje de Archibald. \" General, gracias por traerme este adorable "
+#~ "regalo. He decidido participar directamente en la captura de mi hermano "
+#~ "Roland. Dado que vuestro consejo militar nos ha llevado tan lejos, "
+#~ "seguiré vuestras órdenes al pie de la letra.\""
+
+#~ msgid "Message from Overlord. \"STILL WAITING FOR MY GOLD!\""
+#~ msgstr "Mensaje del Jefe Supremo. \"¡SIGO ESPERANDO MI ORO!\""
+
+#~ msgid "Message from Overlord. \"WHERE'S MY GOLD?\""
+#~ msgstr "Mensaje del Jefe Supremo. \"¿DÓNDE ESTÁ MI ORO?\""
+
+#~ msgid ""
+#~ "Message from Roland. \"General, circumstances permit me to take a hand in "
+#~ "the events of this final conflict. I have your spoils of war with me and "
+#~ "I will follow your advice explicitly.\""
+#~ msgstr ""
+#~ "Mensaje de Roland. \"General, las circunstancias me permiten echar una "
+#~ "mano en los eventos de este conflicto final. Tengo vuestro botín de "
+#~ "guerra conmigo, y seguiré vuestro consejo al pie de la letra.\""
+
+#~ msgid ""
+#~ "Message from Roland.  \"General, I have sent most of our troops and "
+#~ "material ahead to the region of the final conflict with Archibald.  "
+#~ "Unfortunately, Lord Corlagon has cut us off from the rest of our army.  I "
+#~ "will be awaiting your victory in a castle across the west river.  I "
+#~ "should be safe from attack.\""
+#~ msgstr ""
+#~ "Mensaje de Roland. \"General, he enviado a la mayor parte de nuestras "
+#~ "tropas y materiales adelante, a la región del conflicto final con "
+#~ "Archibald. Desafortunadamente, Lord Corlagon nos ha aislado del resto de "
+#~ "nuestro ejército. Estaré esperando vuestra victoria en un castillo al "
+#~ "oeste del río. Debería de estar a salvo de ataques.\""
+
+#~ msgid ""
+#~ "Message from Roland. \" We cannot hope to defeat Archibald without the "
+#~ "Crown, I'm counting on you.\""
+#~ msgstr ""
+#~ "Mensaje de Roland: \"No podemos esperar derrotar a Archibald sin la "
+#~ "Corona. Cuento con vos.\""
+
+#~ msgid "Middle Gate"
+#~ msgstr "Puerta Media"
+
+#~ msgid "Middleton"
+#~ msgstr "Middleton"
+
+#~ msgid "Middletown"
+#~ msgstr "Middletown"
+
+#~ msgid "Might vs. Magic"
+#~ msgstr "Poder vs. Magia"
+
+#~ msgid "Mineral Wars"
+#~ msgstr "Guerras de Minerales"
+
+#~ msgid "Mirkosov"
+#~ msgstr "Mirkosov"
+
+#~ msgid "mirror"
+#~ msgstr "espejo"
+
+#~ msgid "Money For Red"
+#~ msgstr "Dinero para el Rojo"
+
+#~ msgid "MONEY, MONEY, MONEY!"
+#~ msgstr "¡DINERO, DINERO, DINERO!"
+
+#~ msgid "Morale becomes even lower as the endless cliffs move past."
+#~ msgstr "La moral baja aún más a medida que los riscos sin fin pasan."
+
+#~ msgid ""
+#~ "More water than land, you'll still spend lots of time on foot as you "
+#~ "search a literal horde of islands."
+#~ msgstr ""
+#~ "Más agua que tierra, aún pasarás un montón de tiempo a pie buscando por, "
+#~ "literalmente, una horda de islas."
+
+#~ msgid "Mountain king"
+#~ msgstr "Rey de la montaña"
+
+#~ msgid "Mountainview"
+#~ msgstr "Vistamontaña"
+
+#~ msgid "Mr Ed"
+#~ msgstr "Sr. Ed"
+
+#~ msgid "Mr. Yellow's Income"
+#~ msgstr "Ingresos del Sr. Amarillo"
+
+#~ msgid "Murray's resort Isle!"
+#~ msgstr "La isla de vacaciones de Murray"
+
+#~ msgid ""
+#~ "Mutiny!  The crew has dumped off my precious cargo into the sea!  Thank "
+#~ "goodness it floats - when I've rid of them, I'll come back to pick it up!"
+#~ msgstr ""
+#~ "¡Motín! ¡La tripulación ha lanzado mi preciosa carga por la borda! "
+#~ "Gracias a Dios, flota - cuando me haya ocupado de ellos, ¡volveré a "
+#~ "recogerla!"
+
+#~ msgid ""
+#~ "My leige, our scouts report three other lords are attacking from the "
+#~ "south. They work in conjuction with each other to eliminate us! We must "
+#~ "keep this castle and remove the threat of the enemy. We wish you luck!"
+#~ msgstr ""
+#~ "Mi señor, nuestros exploradores nos informan de que otros tres señores "
+#~ "están atacando desde el sur. Trabajan en conjunción los unos con los "
+#~ "otros para eliminarnos. Debemos mantener este castillo, y eliminar la "
+#~ "amenaza del enemigo. ¡Os deseamos suerte!"
+
+#~ msgid ""
+#~ "My leige, we have established a foothold (which we cannot afford to lose) "
+#~ "and all of our Heroes have joined us. The king has made us the offer to "
+#~ "purchase this land for 200,000 gold or we may take it by force. The local "
+#~ "lords have been fighting and each wants to be the one that defeats us. "
+#~ "Now all the local armies have arrived on the beach, creating a state of "
+#~ "complete Pandemonium!"
+#~ msgstr ""
+#~ "Mi señor, hemos establecido una avanzadilla (que no podemos permitirnos "
+#~ "perder) y todos nuestros Héroes se nos han unido. El rey nos ha ofrecido "
+#~ "esta tierra por 200,000 piezas de oro, o podemos tomarla por la fuerza. "
+#~ "Los señores locales han estado luchando y todos quieren ser el que nos "
+#~ "derrote. Todos los ejércitos locales han llegado a la playa, creando un "
+#~ "completo pandemonio."
+
+#~ msgid "My Treasure Is Buried Beneath Three Palm Trees"
+#~ msgstr "Mi tesoro está enterrado bajo tres palmeras"
+
+#~ msgid "\"Necromancers!\""
+#~ msgstr "\"¡Necromantes!\""
+
+#~ msgid "New Dawn"
+#~ msgstr "Nuevo Amanecer"
+
+#~ msgid "New Enemies"
+#~ msgstr "Nuevos Enemigos"
+
+#~ msgid "New Vertigo"
+#~ msgstr "Nuevo Vértigo"
+
+#~ msgid "Nightshadow"
+#~ msgstr "Sombranocturna"
+
+#~ msgid "No Description"
+#~ msgstr "Sin Descripción"
+
+#~ msgid "No Fishing!"
+#~ msgstr "¡Prohibido pescar!"
+
+#~ msgid "No gems, crystal, or mercury for red."
+#~ msgstr "Sin gemas, cristal, o mercurio para el rojo."
+
+#~ msgid ""
+#~ "None of the four leaders like being stuck in a land that has only one "
+#~ "season."
+#~ msgstr ""
+#~ "A ninguno de los cuatro líderes le gusta estar atascado en una tierra en "
+#~ "la que sólo hay una estación."
+
+#~ msgid "NO, Not That Way. This Way."
+#~ msgstr "NO, No Por Ese Camino. Por este camino."
+
+#~ msgid "No one has ever made it out of the deadly swamps alive!"
+#~ msgstr "¡Nadie ha salido con vida de los mortíferos pantanos!"
+
+#~ msgid "Noraston"
+#~ msgstr "Noraston"
+
+#~ msgid "North Road"
+#~ msgstr "Carretera Norte"
+
+#~ msgid "North vs. South"
+#~ msgstr "Norte vs. Sur"
+
+#~ msgid "No stuff for red"
+#~ msgstr "Sin cosas para el rojo"
+
+#~ msgid "No swimming."
+#~ msgstr "Prohibido nadar."
+
+#~ msgid "Notice- Those who put messages in bottles will be tortured."
+#~ msgstr "Aviso: los que pongan mensajes en botellas serán torturados."
+
+#~ msgid "No Trespassing"
+#~ msgstr "Prohibido el paso"
+
+#~ msgid "No tresspath...  No tree...  No thresh...  GO AWAY!"
+#~ msgstr ""
+#~ "Prohibido el pazo... prohibido el paxo... prohibido el pa... ¡FUERA!"
+
+#~ msgid "Now leaving Swamplands of the Eternial"
+#~ msgstr "Está usted dejando los Pantanos del Eterno"
+
+#~ msgid "Obsidian"
+#~ msgstr "Obsidiana"
+
+#~ msgid "Of the necromancers...."
+#~ msgstr "De los necromantes..."
+
+#~ msgid "Ogrehild"
+#~ msgstr "Ogrehild"
+
+#~ msgid "Olympus"
+#~ msgstr "Olimpo"
+
+#~ msgid ""
+#~ "One of the seers in your castle comes to you in the morning with urgent "
+#~ "news. Your one time comrade, the wizard Joseph, and his armies have been "
+#~ "imprisoned in a jail nearby. His power would surely aid you in your quest "
+#~ "to reclaim the library, you think to yourself. Perhaps there is a way to "
+#~ "rescue him..."
+#~ msgstr ""
+#~ "Uno de los videntes de tu castillo viene a verte por la mañana con "
+#~ "noticias urgentes. Tu antiguo camarada, el mago Joseph, junto a sus "
+#~ "ejércitos,  han sido aprisionados en una cárcel cercana. Su poder "
+#~ "seguramente te ayudaría en tu misión de reclamar la biblioteca, piensas "
+#~ "para ti. Tal vez haya alguna forma de rescatarle..."
+
+#~ msgid ""
+#~ "One of your aides reports that the Castle of Farlien is located on the "
+#~ "northeast spur of this island, and is a stronghold for the enemy. He "
+#~ "urges you to take it out as soon as possible, and then move onto other "
+#~ "islands."
+#~ msgstr ""
+#~ "Uno de tus ayudantes te informa de que el Castillo de Farlien se "
+#~ "encuentra en el espolón noreste de la isla, y que es un bastión del "
+#~ "enemigo. Te urge a tomarlo tan pronto como sea posible, y seguir a "
+#~ "continuación a las otras islas."
+
+#~ msgid ""
+#~ "One of your \"allies\" has joined Archibald.  You now face an opponent "
+#~ "with three castles to your one.  Good luck!"
+#~ msgstr ""
+#~ "Uno de tus \"aliados\" se ha unido a Archibald. Ahora te enfrentas a un "
+#~ "oponente con tres castillos, por el único tuyo. ¡Buena suerte!"
+
+#~ msgid ""
+#~ "One of your \"Allies\" has joined Roland. You are now facing three "
+#~ "castles, all belonging to the enemy. Good luck!"
+#~ msgstr ""
+#~ "Uno de tus \"Aliados\" se ha unido a Roland. Ahora te enfrentas a tres "
+#~ "castillos, todos pertenecientes al enemigo. ¡Buena suerte!Un"
+
+#~ msgid "One of your loyal goblins has brought you an armload of crystal!"
+#~ msgstr "¡Uno de tus leales goblins te ha traído una brazada de cristales!"
+
+#~ msgid ""
+#~ "One of your loyal subjects, a fairy tells you where to find a cache of "
+#~ "mercury!"
+#~ msgstr ""
+#~ "¡Uno de tus leales súbditos, un hada, te dice dónde encontrar una buena "
+#~ "cantidad de mercurio!"
+
+#~ msgid ""
+#~ "One of your scouts reports a tiny cave nearby. Upon investigating, you "
+#~ "discover a small cache of goods. In the dirt by them is etched 'Ivan'."
+#~ msgstr ""
+#~ "Uno de tus esploradores te informa de la existencia de una pequeña cueva "
+#~ "en los alrededores. Tras investigar, descubres un escondrijo con varias "
+#~ "cosas. En la tierra, a su lado, está escrito \"Ivan\"."
+
+#~ msgid ""
+#~ "One of your troops stubs its paw on something buried here.  After a few "
+#~ "hours of digging you unearth a cache of treasure!"
+#~ msgstr ""
+#~ "Una de tus tropas tropieza con algo medio enterrado. Después de unas "
+#~ "cuantas horas de excavación, desentierras un escondite de tesoros."
+
+#~ msgid "Only a month remains in which to find Joseph."
+#~ msgstr "Sólo queda un mes para encontrar a Joseph."
+
+#~ msgid "On quite days, Nubbie the sea monster can be seen!"
+#~ msgstr "¡Puede verse bastantes días a Nubbie el monstruo marino!"
+
+#~ msgid "Orange stuff"
+#~ msgstr "Cosas del Naranja"
+
+#~ msgid "Orcville"
+#~ msgstr "Villaorcos"
+
+#~ msgid "Ostoroth"
+#~ msgstr "Ostoroth"
+
+#~ msgid "Other than the dragons, the elves don't have any enemies."
+#~ msgstr "Aparte de los dragones, los elfos no tienen enemigos."
+
+#~ msgid "Our ally was greatly weakened when his resources were plundered."
+#~ msgstr ""
+#~ "Nuestro aliado fue muy debilitado cuando sus recursos fueron saqueados."
+
+#~ msgid "Our reinforcements were lost in a storm, we salvaged all we could!"
+#~ msgstr ""
+#~ "Nuestros refuerzos se perdieron en una tormenta, salvamos todo lo que "
+#~ "pudimos."
+
+#~ msgid ""
+#~ "Our spies have discovered that the barbarian hordes are now receiving "
+#~ "support from kraeger! You must hurry and find the third piece before your "
+#~ "forces here are crushed!"
+#~ msgstr ""
+#~ "Nuestros espías han descubierto que las hordas bárbaras reciben apoyo de "
+#~ "Kraeger. ¡Debes apresurarte y encontrar la tercera pieza antes de que tus "
+#~ "fuerzas aquí sean aplastadas!"
+
+#~ msgid "Overlord"
+#~ msgstr "Señor"
+
+#~ msgid "Pandemonium"
+#~ msgstr "Pandemonium"
+
+#~ msgid "Paper can gain you what wood and sail cannot."
+#~ msgstr "El papel te puede dar lo que la madera y las velas no te han dado."
+
+#~ msgid "Peacekeeper"
+#~ msgstr "Pacificador"
+
+#~ msgid "\"Peasants!\""
+#~ msgstr "\"¡Campesinos!\""
+
+#~ msgid "Peasantsville"
+#~ msgstr "Villacampesinos"
+
+#~ msgid "Perenor"
+#~ msgstr "Perenor"
+
+#~ msgid "Pet Cemetary"
+#~ msgstr "Cementerio de Animales"
+
+#~ msgid "Pick one of four Knights in this large and inhospitable land."
+#~ msgstr ""
+#~ "Elige uno de entre cuatro Caballeros en esta inhóspita y enorme tierra."
+
+#~ msgid "Pig's Eye"
+#~ msgstr "Ojo de Cerdo"
+
+#~ msgid "Pinehurst"
+#~ msgstr "Pinehurst"
+
+#~ msgid "Pirate's Cove"
+#~ msgstr "Ensenada del Pirata"
+
+#~ msgid "Pirate Utopia"
+#~ msgstr "Utopía pirata"
+
+#~ msgid "Pirites strike and take the gold from you holds."
+#~ msgstr "Te atacan piratas y se llevan el oro de tus bodegas."
+
+#~ msgid "Pixie"
+#~ msgstr "Duendecillo"
+
+#~ msgid ""
+#~ "Play the Knight or Barbarian in an alliance in this classic duel against "
+#~ "the four spell casters. (Blue and Green vs Red)"
+#~ msgstr ""
+#~ "Juega con el Caballero o con el Bárbaro en una alianza en este duelo "
+#~ "clásico contra los cuatro lanzadores de hechizoc (Azul y Verde vs Rojo)"
+
+#~ msgid "Please...."
+#~ msgstr "Por favor..."
+
+#~ msgid ""
+#~ "Plenty of resources and lots of ground to cover. Watch out for Orange and "
+#~ "Purple!"
+#~ msgstr ""
+#~ "Muchos recursos y un montón de tierra que cubrir. ¡Cuidado con los "
+#~ "Naranjas y los Púrpura!"
+
+#~ msgid "Portals"
+#~ msgstr "Portales"
+
+#~ msgid "Portsmith"
+#~ msgstr "Portsmith"
+
+#~ msgid "POSION - DO NOT DRINK"
+#~ msgstr "VENENO - NO BEBER"
+
+#~ msgid "Powerful magic lies southwest of here in the Valley of the Kings."
+#~ msgstr ""
+#~ "Una magia poderosa se halla al suroeste de aquí, en el Valle de los Reyes."
+
+#~ msgid "Prisoner on...."
+#~ msgstr "Prisionero en..."
+
+#~ msgid "Quick Silver"
+#~ msgstr "Mercurio"
+
+#~ msgid "Realm of the Undead.  Fresh blood welcome."
+#~ msgstr "Dominios de los No-Muertos. Sangre fresca bienvenida."
+
+#~ msgid "Red player sympathizes with the undead cause."
+#~ msgstr "El jugador rojo simpatiza con la causa de los no-muertos."
+
+#~ msgid "Red's Connection"
+#~ msgstr "Conexiones del Rojo"
+
+#~ msgid "Redshield"
+#~ msgstr "Escudorrojo"
+
+#~ msgid "Red's Rubles"
+#~ msgstr "Rublos del Rojo"
+
+#~ msgid "Red stuff"
+#~ msgstr "Cosas del Rojo"
+
+#~ msgid ""
+#~ "Regrettably, you have no castle with which to begin your assault. "
+#~ "Fortunately, however, Kraeger's forces are weak here in the south, and "
+#~ "you have bribed a rebel necromancer to aid you in the beginning of your "
+#~ "conquest."
+#~ msgstr ""
+#~ "Lamentablemente, no tienes ningún castillo con el que comenzar tu asalto. "
+#~ "Por suerte, las fuerzas de Kraeger son débiles aquí, en el sur, y has "
+#~ "sobornado a un necromante rebelde para que te ayude en los comienzos de "
+#~ "tus conquistas."
+
+#~ msgid "Reinforcements have arrived, Gold from the homelands!"
+#~ msgstr "Han llegado refuerzos, ¡oro desde casa!"
+
+#~ msgid ""
+#~ "Remains of a long since dead wizard have attracted an ancient artifact.  "
+#~ "This artifact has now attached itself to you!"
+#~ msgstr ""
+#~ "Los restos de un mago muerto hace mucho han atraído un artefacto antiguo. "
+#~ "¡El artefacto se ha vinculado ahora a ti!"
+
+#~ msgid ""
+#~ "Remember, you're searching for the Ultimate Artifact... don't get "
+#~ "distracted!"
+#~ msgstr ""
+#~ "Recuerda que estás buscando el Artefacto Definitivo... ¡No te distraigas!"
+
+#~ msgid ""
+#~ "Rendall Koski was here. 1997.  Northampton, Massachusetts There is a "
+#~ "powerful artifact in the southeastern corner of the world.  Go for it, "
+#~ "explorer!"
+#~ msgstr ""
+#~ "Rendall Koski estuvo aquí. 1997. Northampton, Massachusetts. Hay un "
+#~ "poderoso artefacto en la esquina sureste del mundo. ¡Ve por él, "
+#~ "explorador!"
+
+#~ msgid ""
+#~ "Reports from your spies tell of enemies on the march.  As you rush to the "
+#~ "castle courtyard to prepare your armies, you are intercepted by your "
+#~ "Chaplain.  \"My Lord, I have received word that we should send what "
+#~ "Heroes we can to the Isle of Knowledge.   The Scholars there have agreed "
+#~ "to teach them so they will be strong for the battles ahead of us.\"  You "
+#~ "thank the Chaplain for the information and head thoughtfully into the "
+#~ "courtyard."
+#~ msgstr ""
+#~ "Recibes informes de tus espías que advierten de enemigos en marcha. Al "
+#~ "apresurarte al patio del castillo para preparar tus ejércitos, te "
+#~ "intercepta tu Capellán. \"Mi señor, he recibido noticias que aconsejan "
+#~ "enviar los Héroes que podamos a la Isla del Conocimiento. Los eruditos de "
+#~ "allí están de acuerdo en enseñarles, con lo que serán fuertes en las "
+#~ "batallas que nos esperan.\" Le das las gracias al Capellá por la "
+#~ "información, y de diriges pensativo al patio."
+
+#~ msgid "Restricted Area, Do Not Enter!"
+#~ msgstr "¡Área restringida, prohibido el paso!"
+
+#~ msgid "Rest stop."
+#~ msgstr "Parada de descanso."
+
+#~ msgid "Revolution"
+#~ msgstr "Revolución"
+
+#~ msgid "Right thinking - he who takes the riskes deserves the rewards."
+#~ msgstr "Lo correcto - quien asuma los riesgos se merece las recompensas."
+
+#~ msgid "River Crossing"
+#~ msgstr "Vado"
+
+#~ msgid "Road to Isle of Knowledge"
+#~ msgstr "Carretera a la Isla del Conocimiento"
+
+#~ msgid "Road to the Isle of Knowledge"
+#~ msgstr "Camino a la Isla del Conocimiento"
+
+#~ msgid ""
+#~ "Robbers have looted your treasury and you have lost valuable resources."
+#~ msgstr "Algún ladrón ha saqueado tu tesoro y has perdido valiosos recursos."
+
+#~ msgid "Robbers have looted your treasury, stealing valuable resources."
+#~ msgstr "Los ladrones han saqueado tu tesoro, robando valiosos recursos."
+
+#~ msgid "Roc Haven"
+#~ msgstr "Roc Haven"
+
+#~ msgid "Rogar"
+#~ msgstr "Rogar"
+
+#~ msgid "Roscomon"
+#~ msgstr "Roscomon"
+
+#~ msgid "Rotten Birch"
+#~ msgstr "Abedul Podrido"
+
+#~ msgid ""
+#~ "Rumors abound and your faithful hero Sandro is now highly regarded by the "
+#~ "masses. Should Sandro desert you, all will be lost."
+#~ msgstr ""
+#~ "Los rumores abundan y tu leal héroe Sandro es aclamado por las masas. En "
+#~ "caso de que Sandro desertara, todo se perdería."
+
+#~ msgid "Sands of Time"
+#~ msgstr "Arenas del Tiempo"
+
+#~ msgid "Sansobar"
+#~ msgstr "Sansobar"
+
+#~ msgid "Scabsdale"
+#~ msgstr "Scabsdale"
+
+#~ msgid "Scorched Earth"
+#~ msgstr "Tierras flageladas"
+
+#~ msgid ""
+#~ "Scouts have reported a town to the North.  They have also heard some "
+#~ "disturbing news.  Their seems to be a war raging in this area."
+#~ msgstr ""
+#~ "Los exploradores informan de que hay una ciudad al Norte. También han "
+#~ "oído noticias inquietantes. Parece que hay una guerra en curso en este "
+#~ "área."
+
+#~ msgid ""
+#~ "Scouts report the enemy's stronghold lies to the Southwest. Our swift "
+#~ "arrival has caught them by surprise. If you move quickly their resistance "
+#~ "will be minimal."
+#~ msgstr ""
+#~ "Los exploradores informan de que el bastión enemigo se encuentra al "
+#~ "Suroeste. Nuestra rápida llegada los ha cogido por sorpresa. Si te mueves "
+#~ "rápidamente su resistencia será mínima."
+
+#~ msgid ""
+#~ "Scouts report the notorious necromancer \"Wyrm\" has been sighted to the "
+#~ "northeast."
+#~ msgstr ""
+#~ "Los exploradores informan de que el notorio necromante \"Wyrm\" ha sido "
+#~ "visto al noreste."
+
+#~ msgid "Scummy"
+#~ msgstr "Espumoso"
+
+#~ msgid ""
+#~ "Searching in the dust of this abandoned campsite, you find a magic scroll."
+#~ msgstr ""
+#~ "Rebuscando en el polvo de este sitio de acampada abandonado, encuentras "
+#~ "un pergamino mágico."
+
+#~ msgid "Seasons Change"
+#~ msgstr "Cambio de Estaciones"
+
+#~ msgid "Secret Mountain Pass"
+#~ msgstr "Paso Secreto de Montaña"
+
+#~ msgid ""
+#~ "Seek out the Ultimate Artifact to be victorious in this strangely shaped "
+#~ "land."
+#~ msgstr ""
+#~ "Busca el Artefacto Definitivo para obtener la victoria en esta tierra con "
+#~ "formas raras."
+
+#~ msgid ""
+#~ "Seek the great library, for only with the guidance of the musty tomes "
+#~ "therin will you find the means to reveal and bind the fount to your will."
+#~ msgstr ""
+#~ "Busca la gran bilioteca, pues sólo con la guía de sus mohosos tomos "
+#~ "encontrarás la manera de revelar y vincular la fuente a tu voluntad."
+
+#~ msgid "Sharkania"
+#~ msgstr "Sharkania"
+
+#~ msgid "Sheltemburg"
+#~ msgstr "Sheltemburg"
+
+#~ msgid "Sherman"
+#~ msgstr "Sherman"
+
+#~ msgid ""
+#~ "Should this message ever reach home, please know that this has become a "
+#~ "hostile place since the King's death.  No less than six factions are at "
+#~ "war with each other, each seeking to be the King's successor.  Beware "
+#~ "especially of the Barbarians and the Necromancers who control the north, "
+#~ "their regions are easily defended and they have a wealth of gold and "
+#~ "gems.  Do not venture to this land without a sizeable force.  -Sir "
+#~ "Christian"
+#~ msgstr ""
+#~ "En caso de que este mensaje llegue alguna vez a casa, por favor, has de "
+#~ "saber que este se ha convertido en un lugar hostil desde la muerte del "
+#~ "Rey. Al menos seis facciones están en guerra con las demás, cada cual "
+#~ "buscando ser la sucesora del Rey. Cuidado especialmente con los Bárbaros "
+#~ "y los Necromantes que controlan el norte, sus regiones se defienden "
+#~ "fácilmente y tienen grandes riquezas en forma de oro y gemas. No te "
+#~ "aventures en esa tierra sin unas fuerzas considerables. -Sir Christian"
+
+#~ msgid ""
+#~ "Six factions have established a foothold on a huge, unexplored "
+#~ "continent.  Can you eliminate the other five?"
+#~ msgstr ""
+#~ "Seis facciones han establecido una cabeza de playa en un enorme e "
+#~ "inexplorado continente. ¿Puedes eliminar a las otras cinco?"
+
+#~ msgid ""
+#~ "Six heroes with large armies prepare to slug it out for total domination!"
+#~ msgstr ""
+#~ "¡Seis héroes con grandes ejércitos se preparan para combatir por la "
+#~ "dominación total!"
+
+#~ msgid "Skirmish"
+#~ msgstr "Escaramuza"
+
+#~ msgid "Slippery when wet."
+#~ msgstr "Resbaladizo cuando está húmedo."
+
+#~ msgid "Slugfest"
+#~ msgstr "Slugfest"
+
+#~ msgid ""
+#~ "Snagged on a thorny bush, you discover a scrap of cloth. The design on it "
+#~ "looks like the coat of arms of Ivan's house!"
+#~ msgstr ""
+#~ "Descubres un trozo de tela, enganchado en un arbusto espinoso. El diseño "
+#~ "que tiene parece el escudo de armas de la casa de Iván."
+
+#~ msgid "Snowdrop"
+#~ msgstr "Copo de nieve"
+
+#~ msgid "Somebody has stuffed a pile of gems in the ditch!"
+#~ msgstr "¡Alguien ha metido un montón de gemas en la zanja!"
+
+#~ msgid "Some crystal!"
+#~ msgstr "¡Algunos cristales!"
+
+#~ msgid "Some gems!"
+#~ msgstr "¡Algunas gemas!"
+
+#~ msgid ""
+#~ "Someone has stolen 100 wood and 77 ore from you. Ah, that's nothing. "
+#~ "Let's keep going."
+#~ msgstr ""
+#~ "Alguien te ha robado 100 de madera y 77 de mineral. Ah, eso no es nada. "
+#~ "Prosigamos."
+
+#~ msgid ""
+#~ "Someone has stolen gold and resources from  the palace treasury!  You "
+#~ "suspect your enemies, but you can't know for certain."
+#~ msgstr ""
+#~ "Alguien ha robado oro y recursos del tesoro de palacio. Sospechas de tus "
+#~ "enemigos, pero no puedes saberlo con certeza."
+
+#~ msgid "Someone is playing a pan flute around here."
+#~ msgstr "Alguien está tocando una flauta cerca de aquí."
+
+#~ msgid ""
+#~ "Someone notices a piece of parchment lying behind a clump of grass. You "
+#~ "pick it up. It looks to be a page from a journal, and it reads, \"...made "
+#~ "it past the first guardians. Hopefully will reach the ancient desert city "
+#~ "soon. Only hope my forces are strong enough to survive...\""
+#~ msgstr ""
+#~ "Alguien se encuentra con un trozo de pergamino, tirado entre unas "
+#~ "hierbas. Lo recoges. Parece ser una página de un diario, y en ella se lee "
+#~ "\"...hemos pasado los primeros guardias. Con suerte, pronto llegaremos a "
+#~ "la antigua ciudad del desierto. Sólo espero tener fuerzas suficientes "
+#~ "para sobrevivir...\""
+
+#~ msgid "Some ore!"
+#~ msgstr "¡Algunos minerales!"
+
+#~ msgid "Some sulfur!"
+#~ msgstr "¡Algo de azufre!"
+
+#~ msgid ""
+#~ "Some unlucky adventurers have been captured and imprisoned in these lands."
+#~ msgstr ""
+#~ "Algunos desdichados aventureros han sido capturados y encerrados en estas "
+#~ "tierras."
+
+#~ msgid "Sorceress Forest.  Show respect for nature!"
+#~ msgstr "Bosque de Hechiceras. ¡Muestra respeto por la naturaleza!"
+
+#~ msgid "Sorpigal"
+#~ msgstr "Sorpigal"
+
+#~ msgid "South Mill"
+#~ msgstr "Molino Sur"
+
+#~ msgid "So you think you're smart?"
+#~ msgstr "¿Te crees listo?"
+
+#~ msgid "Spector"
+#~ msgstr "Spector"
+
+#~ msgid ""
+#~ "Spies report Roland has sent a hero to search for the Crown. If he finds "
+#~ "it first, all is lost!"
+#~ msgstr ""
+#~ "Los espías informan de Roland ha enviado un héroe en busca de la Corona. "
+#~ "¡Si él la encuentra primero, todo se habrá perdido!"
+
+#~ msgid "Spirit City"
+#~ msgstr "Ciudad espíritu"
+
+#~ msgid "Spy Tower - see what your competition is doing!"
+#~ msgstr "Torre Espía - ¡ve lo que está haciendo tu competencia!"
+
+#~ msgid "Stairs"
+#~ msgstr "Escaleras"
+
+#~ msgid ""
+#~ "Start with five castles!  How could you lose!?  Oh yeah, everyone else "
+#~ "starts with five, too."
+#~ msgstr ""
+#~ "¡Comienzas con cinco castillos! ¿Cómo podrías perder? Ah, sí, todos los "
+#~ "demás comienzan también con cinco castillos."
+
+#~ msgid "Stick to the road!"
+#~ msgstr "¡Sigue la carretera!"
+
+#~ msgid "Stromgild"
+#~ msgstr "Stromgild"
+
+#~ msgid "Stromhild"
+#~ msgstr "Stromhild"
+
+#~ msgid "Stronghold"
+#~ msgstr "Bastión"
+
+#~ msgid "Stuff for red"
+#~ msgstr "Cosas para el rojo"
+
+#~ msgid "Subbaculcha"
+#~ msgstr "Subbaculcha"
+
+#~ msgid "Surf and Turf"
+#~ msgstr "Tierra y Mar."
+
+#~ msgid "Swimming near the kelp is a pod of dolphins."
+#~ msgstr "Hay un grupo de delfines nadando junto a las algas."
+
+#~ msgid "Tacma"
+#~ msgstr "Tacma"
+
+#~ msgid "Tchudes"
+#~ msgstr "Tchudes"
+
+#~ msgid "Teleporters"
+#~ msgstr "Teleportadores"
+
+#~ msgid "Terra Firma"
+#~ msgstr "Terra Firma"
+
+#~ msgid ""
+#~ "The alliance has crumbled and all are at war. Lots of resources but "
+#~ "little time to prepare."
+#~ msgstr ""
+#~ "La alianza se ha roto y todos están en guerra. Hay muchos recursos pero "
+#~ "poco tiempo para prepararse."
+
+#~ msgid ""
+#~ "The ancient King Zealot had the artifact of the gods and then hid it in "
+#~ "his old age so that it could not be used by others."
+#~ msgstr ""
+#~ "El antiguo Rey Fanático tenía el artefacto de los dioses, y lo escondió "
+#~ "en sus últimos días de tal modo que no pudiera ser usado por otros."
+
+#~ msgid "The Back Door"
+#~ msgstr "La Puerta Trasera"
+
+#~ msgid ""
+#~ "The Barbarian's lands are being invaded. Are you strong enough to resist "
+#~ "the invasion?"
+#~ msgstr ""
+#~ "Las tierras de los Bárbaros están siendo invadidas. ¿Eres lo "
+#~ "suficientemente fuerte como para resistir la invasión?"
+
+#~ msgid ""
+#~ "The castle of Drakonran in the east has been taken by the barbarians! Two "
+#~ "other towns to the west have also been taken, but the barbarian armies "
+#~ "were fairly decimated in the process."
+#~ msgstr ""
+#~ "El castillo de Drakonran al este ha caído en manos de los bárbaros. "
+#~ "También han tomado otras dos ciudades al oeste, pero los ejércitos "
+#~ "bárbaros sufrieron grandes bajas en el proceso."
+
+#~ msgid "The center island is rumored to harbor great spells."
+#~ msgstr "Se rumorea que la isla central concentra grandes hechizos."
+
+#~ msgid "The Citadel"
+#~ msgstr "La Ciudadela"
+
+#~ msgid "The cities of the plains."
+#~ msgstr "Las ciudades de las planicies."
+
+#~ msgid "The Clearing"
+#~ msgstr "La limpieza"
+
+#~ msgid ""
+#~ "The convoy has at long last arrived. Regretably, it has been beset by "
+#~ "bandits on its journey here, and has far less supplies than we had hoped. "
+#~ "Make your way south, for our spies have found rich mines there."
+#~ msgstr ""
+#~ "Al fin ha llegado el convoy. Lamentablemente, ha sido hostigado por "
+#~ "bandidos durante el camino, y tiene muchos menos recursos de los que "
+#~ "esperábamos. Ábrete camino hacia el sur, pues nuestros espías han "
+#~ "encontrado ricas minas allí."
+
+#~ msgid ""
+#~ "The convoy should have been here by now! Let us hope that it is safe and "
+#~ "still on its way."
+#~ msgstr ""
+#~ "¡Ya debiera de haber llegado el convoy! Esperemos que esté a salvo y aún "
+#~ "en marcha."
+
+#~ msgid ""
+#~ "The country lords have allied and pooled their resources into one "
+#~ "command. Not only have they massed their forces in the north, but they "
+#~ "have sent a knight to the west to steal your supplies. Scouts report a "
+#~ "castle to the east that would be ideal as a base of operations."
+#~ msgstr ""
+#~ "Los Señores se han aliado y reunido sus recursos bajo un mismo mando. No "
+#~ "sólo han aglutinado sus fuerzas en el norte, sino que también han enviado "
+#~ "un caballero al oeste para robar tus suministros. Los exploradores "
+#~ "informan de que hay un castillo al este que sería ideal como base de "
+#~ "operaciones."
+
+#~ msgid ""
+#~ "The crew are unworthy!  I am not going down with the ship! -The Captain"
+#~ msgstr ""
+#~ "¡La tripulación es indigna! ¡No me voy a hundir con el barco! - El Capitán"
+
+#~ msgid ""
+#~ "The day you have feared has finally arrived.  The king, who you have "
+#~ "faithfully served, has died, leaving no heir to his throne.  As his "
+#~ "captain, you feel that this job should now be yours, but several factions "
+#~ "even now are preparing for conquest.  You are at the center of the trade "
+#~ "routes, having the sea to the south and the great forest to the north.  "
+#~ "Go, now, Commander, and claim what is rightfully yours!"
+#~ msgstr ""
+#~ "El día que tanto temías ha llegado al fin. El rey, a quien serviste con "
+#~ "lealtad, ha muerto, sin dejar heredero alguno al trono. Como su capitán, "
+#~ "piensas que este trabajo debiera de ser tuyo, pero varias facciones se "
+#~ "están preparando ahora mismo para conquistar. Estás en el centro de las "
+#~ "rutas comerciales, tienes el mar al sur y el gran bosque al norte. Ve "
+#~ "ahora, Comandante, y reclama lo que es tuyo por derecho."
+
+#~ msgid ""
+#~ "The diplomats who were sent here ahead of you report that the elves will "
+#~ "only cooperate with you if you will recover the golden bow for them. It "
+#~ "was stolen by their enemies, the Dragons and hidden behind magic barriers."
+#~ msgstr ""
+#~ "Los diplomáticos que se enviaron antes de ti te informan de que los elfos "
+#~ "sólo cooperarán si les recuperas el arco dorado. Fue robado por sus "
+#~ "enemigos, los Dragones, y escondido tras barreras mágicas."
+
+#~ msgid "The Eastern Town."
+#~ msgstr "La ciudad oriental"
+
+#~ msgid "The edge of the world is your edge.  But prepare to be prepared."
+#~ msgstr "El borde del mundo es tu frontera. Pero prepárate para prepararte."
+
+#~ msgid "The Enchanted Forest."
+#~ msgstr "El Bosque Encantado"
+
+#~ msgid "The End of the World is Nigh!"
+#~ msgstr "¡El fin del mundo está cerca!"
+
+#~ msgid "The End of the World is Nigh"
+#~ msgstr "El fin del mundo está cerca"
+
+#~ msgid ""
+#~ "The Epic battle against Your Rival! Eliminate everything! Total Warfare! "
+#~ "Don't Lose your first hero!"
+#~ msgstr ""
+#~ "¡La batalla Épica contra Tu Rival! ¡Elimina todo! ¡Guerra Total! ¡No "
+#~ "pierdas a tu primer héroe!"
+
+#~ msgid ""
+#~ "The Fire King is an ally to the dragons, and will help a friend of theirs."
+#~ msgstr ""
+#~ "El Rey de Fuego es aliado de los dragones, y ayudarán a un amigo suyo."
+
+#~ msgid "The First One To Take Astircaer Wins!"
+#~ msgstr "¡El primero en capturar Astircaer gana!"
+
+#~ msgid ""
+#~ "The first piece of the artifact now lies in the hands of the Unholy Order "
+#~ "of Warlocks. You must annihilate them, and their allies to the north. "
+#~ "They will surely give us what we seek in exchange for their feeble lives."
+#~ msgstr ""
+#~ "El primer fragmento del artefacto se encuentra ahora en las manos de la "
+#~ "Impía Orden de Brujos. Debes aniquilarlos, a ellos y a sus aliados del "
+#~ "norte. Seguramente nos darán lo que buscamos a cambio de sus patéticas "
+#~ "vidas."
+
+#~ msgid ""
+#~ "The Fortune of Infamous Uae was buried on one of these islands. She died "
+#~ "without ever revealing it.  Find it before the other cutthroats."
+#~ msgstr ""
+#~ "La Fortuna de la Infame Uae fue enterrada en una de estas islas. Ella "
+#~ "murió sin reverlársela a nadie. Encuéntrala antes que los otros asesinos."
+
+#~ msgid "The four factions race to capture a mystical castle."
+#~ msgstr "Las cuatro facciones se apresuran a capturar un castillo místico."
+
+#~ msgid ""
+#~ "The four spell casters face off with substantial starting armies. Can the "
+#~ "crusaders keep the peace?"
+#~ msgstr ""
+#~ "Los cuatro conjuradores se enfrentan con ejércitos iniciales importantes. "
+#~ "¿Pueden mantener el ritmo los cruzados?"
+
+#~ msgid ""
+#~ "The Gods have given you 6 months to prove yourself. Good or Evil - who "
+#~ "shall prevail? (Blue,Green and Red vs Yellow, Orange and Purple)"
+#~ msgstr ""
+#~ "Los Dioses te han dado 6 meses para ponerte a prueba. Bien o Mal - ¿Quién "
+#~ "prevalecerá? (Azul, Verde y Rojo vs. Amarillo, Naranja y Púrpura)"
+
+#~ msgid ""
+#~ "The gods have granted this world a great artifact, to find it means "
+#~ "victory."
+#~ msgstr ""
+#~ "Los dioses han otorgado a este mundo un gran artefacto, encontrarlo "
+#~ "significa la victoria."
+
+#~ msgid "The Gods themselves will aid us in this War."
+#~ msgstr "Los Dioses en persona nos ayudarán en esta Guerra."
+
+#~ msgid "The guardians of Dragon Isle reside in the jungle."
+#~ msgstr "Los guardianes de la Isla Dragón residen en la jungla."
+
+#~ msgid "The Ice Prince stands frozen in some forgotten corner of the world."
+#~ msgstr ""
+#~ "El Príncipe del Hielo está congelado en algún rincón olvidado del mundo."
+
+#~ msgid "The island...."
+#~ msgstr "La isla..."
+
+#~ msgid "The Island of Lost Reason"
+#~ msgstr "La Isla de la Razón Perdida"
+
+#~ msgid "The islands have much wealth."
+#~ msgstr "Las islas tienen muchas riquezas."
+
+#~ msgid "The Isle of Armoria"
+#~ msgstr "La Isla de Armoria"
+
+#~ msgid "The key to success is rubbing enough lamps."
+#~ msgstr "El secreto del éxito es frotar las suficientes lámparas."
+
+#~ msgid ""
+#~ "The King has declared you his hier apparent and champion. You must seek "
+#~ "out and destroy your common enemy, Wilgatus and his Castle, Mirkosov, the "
+#~ "source of his power."
+#~ msgstr ""
+#~ "El Rey te ha declarado su heredero y campeón. Debes de buscar y destruir "
+#~ "a nuestro enemigo común, Wilgatus, y su castillo, Mirkosov, la fuente de "
+#~ "su poder."
+
+#~ msgid ""
+#~ "The King is dead, his kingdom has been shattered, and six leaders seek to "
+#~ "seize power for themselves."
+#~ msgstr ""
+#~ "El Rey ha muerto, su reino se ha hecho pedazos, y seis líderes buscan el "
+#~ "poder para sí."
+
+#~ msgid "The Kings Road."
+#~ msgstr "La Carretera del Rey"
+
+#~ msgid ""
+#~ "The King will sell you this land for 200,000 gold or you can take it by "
+#~ "force. The choice is yours."
+#~ msgstr ""
+#~ "El Rey te venderá esta tierra por 200,000 piezas de oro, o puedes tomarla "
+#~ "por la fuerza. La elección es vuestra."
+
+#~ msgid "The land of Heroes II."
+#~ msgstr "La tierra de Heroes II."
+
+#~ msgid "The Lost Castle of the Ancients"
+#~ msgstr "El Castillo Perdido de los Antiguos"
+
+#~ msgid ""
+#~ "The mage wars have caused a great turmoil.  This island has become a "
+#~ "central flux of magical power.  Be wary all those that enter upon here."
+#~ msgstr ""
+#~ "Las guerras de los magos han causado grandes desórdenes. La isla se ha "
+#~ "convertido en un vórtice central de poder mágico. Cuidado a todos los que "
+#~ "entren aquí."
+
+#~ msgid ""
+#~ "The mage wars have caused great turmoil.  This island has become a "
+#~ "central flux of magical power.  Be wary all those that enter upon here."
+#~ msgstr ""
+#~ "Las guerras de los magos han causado grandes desórdenes. La isla se ha "
+#~ "convertido en un vórtice central de poder mágico. Cuidado a todos los que "
+#~ "entren aquí."
+
+#~ msgid ""
+#~ "The Master Merchant arrives and takes the resources he needs for trade.  "
+#~ "Plus a little gold for expenses..."
+#~ msgstr ""
+#~ "Llega el maestro mercader y se lleva los recursos necesarios para "
+#~ "comerciar. Y un poco de oro más para gastos..."
+
+#~ msgid ""
+#~ "The Master Merchant arrives and takes the resources he needs for "
+#~ "trading.  Plus a little more gold for expenses..."
+#~ msgstr ""
+#~ "Llega el maestro mercader y se lleva los recursos necesarios para "
+#~ "comerciar. Y algo más de oro para gastos..."
+
+#~ msgid ""
+#~ "The Master Merchant arrives at your Castle.  He tells you tall tales of "
+#~ "travel, full of outrageous lies.  He also gives you, your share of the "
+#~ "profits..."
+#~ msgstr ""
+#~ "El maestro mercader llega a tu castillo. Te cuenta grandes historias de "
+#~ "viajes, llenas de escandalosas mentiras. También te da tu parte de las "
+#~ "ganancias..."
+
+#~ msgid ""
+#~ "The Master Merchant arrives back at your Castle.  He tells you tall tales "
+#~ "of faraway places full of outrageous lies.  He also gives you, your share "
+#~ "of the profits..."
+#~ msgstr ""
+#~ "El maestro mercader vuelve a tu castillo. Te cuenta grandes historias "
+#~ "sobre lugares lejanos llenas de escandalosas mentiras."
+
+#~ msgid ""
+#~ "The Medusas have the password and they can be found just to the west."
+#~ msgstr "Las Medusas tienen la contraseña y se las puede encontrar al oeste."
+
+#~ msgid "The more there is the less you see."
+#~ msgstr "Mientras más hay menos ves."
+
+#~ msgid "The North Road to Roland's castle."
+#~ msgstr "La Carretera Norte al castillo de Roland."
+
+#~ msgid ""
+#~ "The note in this bottle has become mostly indecipherable. All you can "
+#~ "make out are references to deadly pirates, and hidden gold mines."
+#~ msgstr ""
+#~ "La nota de la botella está prácticamente indescifrable. Todo lo que "
+#~ "puedes interpretar hace referencia a piratas mortales, y minas de oro "
+#~ "ocultas."
+
+#~ msgid ""
+#~ "The Overlord has given you 4 months to conquer this land or deliver to "
+#~ "him the sum of 150,000 gold."
+#~ msgstr ""
+#~ "El Jefe Supremo te ha dado cuatro meses para conquistar esta tierra, o "
+#~ "enviarle la suma de 150,000 piezas de oro."
+
+#~ msgid "The Queen's Road."
+#~ msgstr "El Camino de la Reina."
+
+#~ msgid "The Realm of Air is barred, but you may appeal here for help."
+#~ msgstr "El Reino del Aire está prohibido, pero puedes buscar ayuda aquí."
+
+#~ msgid ""
+#~ "There are three enemy castles to the north. Capture them in the name of "
+#~ "Roland the true king!"
+#~ msgstr ""
+#~ "Hay tres castillos enemigos al norte. ¡Captúralos en nombre de Roland, el "
+#~ "rey verdadero!"
+
+#~ msgid ""
+#~ "The Red Tide of War rolls North.  Stopping the flood seems hopeless.  "
+#~ "Yet, Honor demands you and your ally die trying."
+#~ msgstr ""
+#~ "La Marea Roja de la Guerra avanza hacia el Norte. Tratar de detener la "
+#~ "avalancha parece imposible. Aún así, el honor exige que tú y tua aliado "
+#~ "mueran intentándolo."
+
+#~ msgid "There is hidden treasure south of the Blue Lord's Sawmill."
+#~ msgstr "Hay tesoros escondidos al sur de la Serrería del Señor Azul."
+
+#~ msgid "There's a warm wind blowing from the south."
+#~ msgstr "Sopla un viento cálido del sur."
+
+#~ msgid ""
+#~ "There's a Wizard living in the north who is behind this peasant revolt."
+#~ msgstr ""
+#~ "Hay un Mago que vive en el norte que está detrás de esta revuelta de "
+#~ "campesinos."
+
+#~ msgid ""
+#~ "There used to be a mine here, but it has long since run out of ore.  You "
+#~ "are only able to scavenge 5 units of ore from the old site."
+#~ msgstr ""
+#~ "Aquí solía haber una mina, pero hace tiempo que está agotada. Apenas eres "
+#~ "capaz de conseguir 5 unidades de mineral de el viejo lugar."
+
+#~ msgid "There was a shipreck in the far east waters recently."
+#~ msgstr "Hubo un naufragio en aguas orientales hace poco."
+
+#~ msgid "The River Styx"
+#~ msgstr "El Río Estigio"
+
+#~ msgid "The roars of several dragons echo from the towers."
+#~ msgstr "El eco de los rugidos de varios dragones retumba desde las torres."
+
+#~ msgid "The Royal Gardens."
+#~ msgstr "Los Jardines Reales."
+
+#~ msgid ""
+#~ "The Scholars, Priests, and Priestesses of the Isle have given you what "
+#~ "they can to help you against your enemies."
+#~ msgstr ""
+#~ "Los Eruditos, Sacerdotes y Sacerdotisas de la isla te han dado lo que han "
+#~ "podido para ayudarte contra tus enemigos."
+
+#~ msgid ""
+#~ "The Scholars, Priests, and Priestesses of the Isle have given you what "
+#~ "they can to help you defend against your enemies."
+#~ msgstr ""
+#~ "Los Eruditos, Sacerdotes y Sacerdotisas de la isla te han dado lo que han "
+#~ "podido para ayudarte a defenderte de tus enemigos."
+
+#~ msgid "These lands are beholden to Lord Kraeger."
+#~ msgstr "Estas tierras son vigiladas por Lord Kraeger."
+
+#~ msgid ""
+#~ "These lands are desolate and for the most part devoid of resources. Not "
+#~ "even the bravest heroes dare to venture into them, and plants are rare "
+#~ "and precious here. Who knows what else awaits?"
+#~ msgstr ""
+#~ "Estas tierras están desiertas y en general carecen de recursos. Ni "
+#~ "siquiera los héroes más valientes se atreven a adentrarse en ellas, "
+#~ "además las plantas son escasas aquí. ¿Quién sabe qué mas aguarda?"
+
+#~ msgid "The Table in the Great Hall of the Castle is Haunted."
+#~ msgstr "La Mesa del Gran Salón del Castillo está Embrujada."
+
+#~ msgid ""
+#~ "The third piece of the artifact is somewhere to the north, that much we "
+#~ "know. We are still unsure of its exact location, but our spies are out "
+#~ "gathering information. The forces in this area are too strong to be "
+#~ "completely subjugated, so take what you can and hold on to it tightly."
+#~ msgstr ""
+#~ "Por lo que sabemos, la tercera pieza del artefacto está en algún lugar al "
+#~ "norte. Aún no sabemos su ubicación exacta, pero nuestros espías están "
+#~ "reuniendo información. Las fuerzas en el área son demasiado fuertes para "
+#~ "ser completamente sometidas, así que coge lo que puedas y agárralo fuerte."
+
+#~ msgid ""
+#~ "The troops have sworn their allegiance, but should lose a battle they "
+#~ "will lose faith and our cause will be lost."
+#~ msgstr ""
+#~ "Las tropas nos han jurado lealtad, pero en caso de que perdieran una "
+#~ "batalla, también perderían la fe y nuestra causa se perdería."
+
+#~ msgid "The Valley of Aruk."
+#~ msgstr "El Valle de Aruk."
+
+#~ msgid ""
+#~ "The Valley of Magic holds many surprises.  You discover an old pair of "
+#~ "boots sticking out of the sand."
+#~ msgstr ""
+#~ "El Valle de la Magia esconde muchas sorpresas. Descubres un viejo par de "
+#~ "botas sobresaliendo de la arena."
+
+#~ msgid "The Valley of Tresures"
+#~ msgstr "El Valle de los Tesoros"
+
+#~ msgid "The Wasteland"
+#~ msgstr "El Yermo"
+
+#~ msgid "The way of magic"
+#~ msgstr "El camino de la mágia"
+
+#~ msgid "The way of might"
+#~ msgstr "El camino del poder"
+
+#~ msgid "The way of numbers"
+#~ msgstr "El camino de los números"
+
+#~ msgid "The western town."
+#~ msgstr "Oeste de la ciudad"
+
+#~ msgid "The winds howl in mourning around the shipwreck."
+#~ msgstr "El viento aúlla un lamento en torno al pecio."
+
+#~ msgid "The wizard has an island in the southeast."
+#~ msgstr "El mago tiene una isla al sureste."
+
+#~ msgid ""
+#~ "The Wizards who have captured the Necromancers' town have wasted no time "
+#~ "in building defenses designed to stop you, and their last castle has just "
+#~ "been completed. Fortunately only a Captain of the Guard and a small "
+#~ "garrison are currently present.  If you hurry, you should be able to "
+#~ "capture the castle before they have a chance to reinforce it!"
+#~ msgstr ""
+#~ "Los Magos que capturaron la ciudad del Necromante no han perdido el "
+#~ "tiempo para construir defensas destinadas a detenerte, y su último "
+#~ "castillo acaba de completarse. Afortunadamente sólo están presentes ahora "
+#~ "mismo un Capitán de la Guardia y una pequeña guarnición. Si te apresuras, "
+#~ "debieras de poder capturar el castillo antes de que tengan oportunidad de "
+#~ "enviar refuerzos."
+
+#~ msgid "The wood has arrived."
+#~ msgstr "Ha llegado la madera."
+
+#~ msgid "The writing on this sign is too faded to read."
+#~ msgstr "Esta señal está demasiado desgastada como para leerse."
+
+#~ msgid "The Yellow Lord has the Ultimate Artifact."
+#~ msgstr "El Señor Amarillo tiene en su poder el Artefacto Definitivo."
+
+#~ msgid "They say there's mermaids in these waters..."
+#~ msgstr "Dicen que hay sirenas en esas aguas..."
+
+#~ msgid ""
+#~ "This area is rich in resources. Explore, but beware, a castle left "
+#~ "undefended will quickly fall."
+#~ msgstr ""
+#~ "Este área es rica en recursos. Explórala pero ten cuidado, un castillo no "
+#~ "defendido caerá rapidaménte."
+
+#~ msgid ""
+#~ "This area must be secured for the sake of the Empire. Our spies have "
+#~ "reported a discord between The kingdom of the knights to the north, and "
+#~ "that of the oppressive sorceresses to the northeast. Perhaps this feud "
+#~ "can be exploited for our gain..."
+#~ msgstr ""
+#~ "Esta área debe ser segura por el bien del Imperio. Nuestros espías han "
+#~ "informado de un desacuerdo entre El Reino de los caballeros del norte, y "
+#~ "la opresiva hechicera del noreste. Quizás esta contienda pueda ser "
+#~ "explotada para nuestro beneficio..."
+
+#~ msgid "This bottle is empty."
+#~ msgstr "La botella está vacía."
+
+#~ msgid ""
+#~ "This is the last week you have to find the rebel wizard Joseph! Good Luck "
+#~ "in your quest."
+#~ msgstr ""
+#~ "Esta es la última semana que tienes para encontrar al mago rebelde "
+#~ "Joseph. Buena suerte en tu búsqueda."
+
+#~ msgid ""
+#~ "This land and all others are now under the sole ownership of Ibn Fadlan, "
+#~ "the Undead King. Any disregard for his magesty's soverign rule is to be "
+#~ "punished by death most horrendous."
+#~ msgstr ""
+#~ "Esta tierra y todas las demás están ahora bajo la única propiedad de Ibn "
+#~ "Fadlan, el Rey No-muerto. Cualquier descuido a la soberanía de su "
+#~ "majestad será castigado con la más horrenda de las muertes."
+
+#~ msgid ""
+#~ "This land has been claimed by the nation of Neroli. Interlopers are "
+#~ "UNWELCOME."
+#~ msgstr ""
+#~ "Esta tierra ha sido reclamada por la nación de Neroli. Los intrusos NO "
+#~ "SON BIENVENIDOS."
+
+#~ msgid ""
+#~ "This rugged land will have rivals fighting the terrain as well as each "
+#~ "other."
+#~ msgstr ""
+#~ "Esta áspera tierra tendrá rivales luchando tanto con el terreno como "
+#~ "contra los demás."
+
+#~ msgid ""
+#~ "This rundown village looks like it was once the epicenter of an enormous, "
+#~ "but now ruined, city. Under a pile of rubble you find an object which "
+#~ "looks like it has lain there for ages."
+#~ msgstr ""
+#~ "Este pueblo parece que una vez fue el centro de una ciudad enorme, pero "
+#~ "hoy en día arruinada. Bajo un montón de escombros encuentras un objeto "
+#~ "que parece haber estado allí por siglos."
+
+#~ msgid ""
+#~ "This spot overlooks an old quarry.  This was one of the only places in "
+#~ "the world where ore could be taken right out of the ground.  "
+#~ "Unfortunately the jungle has reclaimed the quarry and it is unusable.  "
+#~ "You collect the last of the ore and depart."
+#~ msgstr ""
+#~ "Desde este lugar se domina una vieja guarnición. Este era uno de los "
+#~ "pocos lugares del mundo en los que se podían extraer minerales "
+#~ "directamente de la tierra. Desafortunadamente, la selva ha reclamado la "
+#~ "guarnición y es inutilizable. Recoges el resto de minerales que queda, y "
+#~ "partes."
+
+#~ msgid ""
+#~ "This twisted maze of sorceress towns has three factions struggling for "
+#~ "sole control.  Use your resources wisely!"
+#~ msgstr ""
+#~ "Este laberinto retorcido de ciudades de hechiceras tiene tres facciones "
+#~ "luchando por la supremación. ¡Usa con sabiduría tus recursos!"
+
+#~ msgid ""
+#~ "This village appears to be in little better shape than the first one you "
+#~ "saw. As you approach the village an old man hands you a slip of paper, "
+#~ "with the following message, \"Joseph lives in the town of IslandHome.\""
+#~ msgstr ""
+#~ "El poblado parece estar en mejor forma que el primero que vistes. A "
+#~ "medida que te acercas al poblado y anciano te entrega un trozo de papel "
+#~ "con el siguiente mensaje, \"Joseph vive en la ciudad de IslandHome\"."
+
+#~ msgid ""
+#~ "This village is in extremely poor shape. There is no chance of getting "
+#~ "more than some of the lesser creatures here."
+#~ msgstr ""
+#~ "Esta aldea está en pésimo estado. No hay ninguna oportunidad de encontrar "
+#~ "aquí más que algunas criaturas menores."
+
+#~ msgid "This way to the Necromancer Forest."
+#~ msgstr "Al Bosque del Necromante."
+
+#~ msgid "Those who seek knowledge are welcome to the city of Chronos."
+#~ msgstr ""
+#~ "Sean bienvenidos a la ciudad de Chronos aquellos que buscan conocimiento."
+
+#~ msgid "Timberhill"
+#~ msgstr "Timberhill"
+
+#~ msgid "Time for a refreshing drink."
+#~ msgstr "Hora de una bebida refrescante."
+
+#~ msgid "Time is running out! The enemy's reinforcements are almost here."
+#~ msgstr "¡Se acaba el tiempo! Los refuerzos del enemigo casi están aquí."
+
+#~ msgid "To pass you must pay troll."
+#~ msgstr "Para pasar debes pagar al trol."
+
+#~ msgid "TreeHome"
+#~ msgstr "Casa del árbol"
+
+#~ msgid "Trespassers will be EATEN!"
+#~ msgstr "¡Los intrusos serán DEVORADOS!"
+
+#~ msgid "Trilobar"
+#~ msgstr "Trilobar"
+
+#~ msgid "Troy"
+#~ msgstr "Troya"
+
+#~ msgid "Tundara"
+#~ msgstr "Tundara"
+
+#~ msgid "Turn back, friend, while you still can!"
+#~ msgstr "¡Da la vuelta, amigo, mientras puedas!"
+
+#~ msgid "Turn Back Now!"
+#~ msgstr "¡Da la vuelta ya!"
+
+#~ msgid "Turn Back Now or all will be LOST!"
+#~ msgstr "¡Da la vuelta ya o todo se habrá perdido!"
+
+#~ msgid "Turn Back or DIE!"
+#~ msgstr "¡Da la vuelta o MUERE!"
+
+#~ msgid "Turn Back or else!"
+#~ msgstr "Retírate"
+
+#~ msgid "Turn back, you fool."
+#~ msgstr "Da la vuelta, idiota."
+
+#~ msgid "Uncle Leo"
+#~ msgstr "Tío Leo"
+
+#~ msgid "Uncle Milty"
+#~ msgstr "Tío Milty"
+
+#~ msgid "Undead Armies"
+#~ msgstr "Ejércitos No-muertos"
+
+#~ msgid "Unholy Alliance"
+#~ msgstr "Alianza Impía"
+
+#~ msgid "Valley of Death"
+#~ msgstr "Valle de la Muerte"
+
+#~ msgid "Valley Of The Damned"
+#~ msgstr "Valle de los Condenados"
+
+#~ msgid "Valley of the Kings."
+#~ msgstr "Valle de los Reyes."
+
+#~ msgid "Vaultius"
+#~ msgstr "Vaultius"
+
+#~ msgid "Vertigo"
+#~ msgstr "Vértigo"
+
+#~ msgid "Vikings!"
+#~ msgstr "¡Vikingos!"
+
+#~ msgid "Viper's Nest"
+#~ msgstr "Nido de Víboras"
+
+#~ msgid "Vulcania"
+#~ msgstr "Vulcania"
+
+#~ msgid "Warrior Knight"
+#~ msgstr "Caballero Guerrero"
+
+#~ msgid "Wastelands"
+#~ msgstr "Yermos"
+
+#~ msgid ""
+#~ "\"We are at the edge of the world!\"  they scream.  \"What are we doing "
+#~ "here?\""
+#~ msgstr ""
+#~ "\"¡Estamos en el borde del mundo!\", gritan. \"¿Qué estamos haciendo aquí?"
+#~ "\""
+
+#~ msgid "Weddington"
+#~ msgstr "Weddington"
+
+#~ msgid ""
+#~ "We found a weakness my lord. Capture castle Black Fang and victory is "
+#~ "ours."
+#~ msgstr ""
+#~ "Encontramos un punto débil, mi Señor. Capturad el castillo Colmillo Negro "
+#~ "y la victoria será nuestra."
+
+#~ msgid ""
+#~ "We have just learned that the artifact is on an island north of this "
+#~ "continent. However, there does not appear to be any means to get there. "
+#~ "Stay very alert for any possible way across the narrow channel."
+#~ msgstr ""
+#~ "Acabamos de enterarnos de que el artefacto está en una isla al norte de "
+#~ "este continente. Sin embargo, no parece haber manera de llegar allí. "
+#~ "Mantente alerta por si hubiera alguna manera de cruzar el estrecho canal."
+
+#~ msgid ""
+#~ "Welcome back general.  Have you finished the conquest of the northern "
+#~ "lands?  What? you still have not finished your mission!  Get back there "
+#~ "and teach those rebels a lesson!"
+#~ msgstr ""
+#~ "Bienvenido de vuelta, general. ¿Habéis completado la conquista de las "
+#~ "tierras del norte? ¿Qué? ¡Aún no habéis terminado vuestra misión! "
+#~ "¡Regresad, y dad a esos rebeldes una lección!"
+
+#~ msgid "Welcome to Li'l Alctatraz! Vistors NOT welcome."
+#~ msgstr ""
+#~ "Bienvenidos a la Pequeña Alctatraz. Los visitantes NO son bienvenidos."
+
+#~ msgid ""
+#~ "Welcome to Power Island. He who controls this Isle controls the Seven "
+#~ "Lakes!"
+#~ msgstr ""
+#~ "Bienvenido a la Isla del Poder. ¡Quien controle esta Isla controlará los "
+#~ "Siete Lagos!"
+
+#~ msgid "Welcome to the sandy Isle."
+#~ msgstr "Bienvenidos a la Isla Arenosa."
+
+#~ msgid "Welcome to the sorceress' guild."
+#~ msgstr "Bienvenido al gremio de hechiceras."
+
+#~ msgid "Welcome to the Spiral Isles"
+#~ msgstr "Bienvenido a las Islas Espirales"
+
+#~ msgid ""
+#~ "Welcome to the wounderous Kitisland range.  Eruptions each day, beware of "
+#~ "dragons."
+#~ msgstr ""
+#~ "Bienvenido a la maravillosa cordillera de Kitisland. Erupciones diarias, "
+#~ "cuidado con los dragones."
+
+#~ msgid "Welcome to Windfall Island!"
+#~ msgstr "¡Bienvenido a la Windfall Island!"
+
+#~ msgid "Welcome to your DOOM!"
+#~ msgstr "¡Bienvenido a tu MUERTE!"
+
+#~ msgid "We'll join you - for the right price."
+#~ msgstr "Nos uniremos a ti - por el precio justo."
+
+#~ msgid "Westfork"
+#~ msgstr "Westfork"
+
+#~ msgid "Westmoor"
+#~ msgstr "Westmoor"
+
+#~ msgid "We told you not to drink!"
+#~ msgstr "¡Te dijimos que no bebieras!"
+
+#~ msgid "What are you doing here?"
+#~ msgstr "¿Qué estás haciendo aquí?"
+
+#~ msgid ""
+#~ "What cannot be seen but only heard, and will not speak until spoken to?"
+#~ msgstr "¿Qué no puede verse sino oírse, y no hablará hasta que se le hable?"
+
+#~ msgid "What everyday word is most often pronounced incorrectly?"
+#~ msgstr ""
+#~ "¿Qué palabra cotidiana se pronuncia de forma incorrecta más a menudo?"
+
+#~ msgid "What goes up and down but never moves?"
+#~ msgstr "¿Qué va arriba y abajo pero nunca se mueve?"
+
+#~ msgid ""
+#~ "What good fortune!  You've discovered a long-abandoned settlement.  To "
+#~ "your surprise, you discover that the previous inhabitants left some of "
+#~ "their resources behind when they departed!"
+#~ msgstr ""
+#~ "¡Qué buena fortuna! Has descubierto un asentamiento abandonado hace mucho "
+#~ "tiempo. Para tu sorpresa, descubres que los habitantes anteriores dejaron "
+#~ "atrás algunos de sus recursos cuando se fueron."
+
+#~ msgid "What is always coming but never arrives?"
+#~ msgstr "¿Qué está viniendo siempre, pero nunca llega?"
+
+#~ msgid "What is the Sum of all Numbers from 1 to 200?"
+#~ msgstr "¿Cuál es la suma de todos los números de 1 a 200?"
+
+#~ msgid "What's another word for pirate treasure?"
+#~ msgstr "¿Otra palabra para tesoro pirata?"
+
+#~ msgid "What's behind door number one?"
+#~ msgstr "¿Qué hay detrás de la puerta número uno?"
+
+#~ msgid "What's this? A pile of gems?"
+#~ msgstr "¿Qué es esto? ¿Una montaña de gemas?"
+
+#~ msgid "What's this? Someone has left a pile of wood here!"
+#~ msgstr "¿Qué es esto? ¡Alguien ha dejado una pila de madera aquí!"
+
+#~ msgid ""
+#~ "What team won Super Bowl XXI and Super Bowl XXV?  (Hint... a Wizard might "
+#~ "have these troops in his army)"
+#~ msgstr ""
+#~ "¿Qué equipo ganó la XXI y la XXV Super Bowl? (Pista... un mago podría "
+#~ "tener estas tropas en su ejército)"
+
+#~ msgid "What turns everything around but does not move?"
+#~ msgstr "¿Qué cambia todo a su alrededor pero no se mueve?"
+
+#~ msgid ""
+#~ "What walks in the morning on four legs, two in the afternoon and three in "
+#~ "the evening?"
+#~ msgstr ""
+#~ "¿Qué camina por la mañana a cuatro patas, sobre dos por la tarde, y a "
+#~ "tres de noche?"
+
+#~ msgid "What?  What's this?  Something at the bottom of this pool..."
+#~ msgstr "¿Qué? ¿Qué es eso? Hay algo en el fondo de este estanque..."
+
+#~ msgid "When you're ready, take the teleport to the Island's Hot Spot!"
+#~ msgstr ""
+#~ "Cuando estés listo, ¡usa el teletransporte y ve al Punto Caliente de la "
+#~ "Isla!"
+
+#~ msgid ""
+#~ "When you think yourself invincible, walk through this gate.  Even then, "
+#~ "prepare to meet your bitter end."
+#~ msgstr ""
+#~ "Cuando creas que eres invencible, cruza esta puerta. Incluso entonces, "
+#~ "prepárate para encontrarte con tu amargo final."
+
+#~ msgid "Where am I?"
+#~ msgstr "¿Dónde estoy?"
+
+#~ msgid ""
+#~ "While traveling a mesenger meets you on the road.  His message tells of a "
+#~ "new ally from an island far to the south.  This ally can not offer forces "
+#~ "to your battle but has agreed to send some support in the form of gold "
+#~ "and crystal."
+#~ msgstr ""
+#~ "Mientras viajas te cruzas con un mensajero en el camino. Su mensaje trata "
+#~ "de un nuevo aliado proveniente de una isla al sur. Este aliado no puede "
+#~ "ofrecer fuerzas para tu batellón pero se compromete a enviar ayuda en "
+#~ "forma de oro y cristales."
+
+#~ msgid "Whiteshield"
+#~ msgstr "Escudoblanco"
+
+#~ msgid "Whittingham"
+#~ msgstr "Whittingham"
+
+#~ msgid "Who am I?"
+#~ msgstr "¿Quién soy?"
+
+#~ msgid "Who is the true King?"
+#~ msgstr "¿Quién es el Rey verdadero?"
+
+#~ msgid ""
+#~ "\"Why have we come this way?\"  asks the first mate.  You have no answer."
+#~ msgstr ""
+#~ "\"¿Por qué hemos venido por aquí?\" pregunta el primer amigo. No tienes "
+#~ "contestación."
+
+#~ msgid "Wilasher"
+#~ msgstr "Wilasher"
+
+#~ msgid "Wildabar"
+#~ msgstr "Wildabar"
+
+#~ msgid "Wilgatus"
+#~ msgstr "Wilgatus"
+
+#~ msgid "Willow"
+#~ msgstr "Sauce"
+
+#~ msgid "Winterkill"
+#~ msgstr "Winterkill"
+
+#~ msgid "Winterlands"
+#~ msgstr "Winterlands"
+
+#~ msgid "Witch Hunt"
+#~ msgstr "Caza de Brujas"
+
+#~ msgid ""
+#~ "With the year long eruption of Mt. Kitisland, your three worst enemies "
+#~ "now have a ground bridge to your eastern contenent."
+#~ msgstr ""
+#~ "Con la erupción de un año del Monte Kitisland, tus tres peores enemigos "
+#~ "tienen ahora un puente de roca hasta tu continente oriental."
+
+#~ msgid "Woodhaven"
+#~ msgstr "Woodhaven"
+
+#~ msgid "Woodstock"
+#~ msgstr "Woodstock"
+
+#~ msgid "Wow, somebody has left a pile of wood here!"
+#~ msgstr "¡Vaya!, ¡alguien ha dejado una pila de madera aquí!"
+
+#~ msgid "Wyrm"
+#~ msgstr "Wyrm"
+
+#~ msgid "Xabran"
+#~ msgstr "Xabran"
+
+#~ msgid "Ye old fish liver oil."
+#~ msgstr "Aceite de hígado de bacalao."
+
+#~ msgid "Yorksford"
+#~ msgstr "Yorksford"
+
+#~ msgid ""
+#~ "You and your ally's families were given custody of The Isle of "
+#~ "Knowledge.  Other Lords feel the time has come for new guardians..."
+#~ msgstr ""
+#~ "A tu familia y la de tus aliados se le dio en custodia la Isla del "
+#~ "Conocimiento. Otros Señores piensan que ha llegado la hora de que tenga "
+#~ "nuevos guardianes..."
+
+#~ msgid "You are a fool to come here!"
+#~ msgstr "¡Eres un necio por haber venido aquí!"
+
+#~ msgid "You are fighting on the side of your king!"
+#~ msgstr "¡Estás luchando en el bando de tu rey!"
+
+#~ msgid "You are fighting on the side of your sister!"
+#~ msgstr "¡Estás luchando en el bando de tu hermana!"
+
+#~ msgid "You are now entering the domain of Prince Roland. Have a nice day."
+#~ msgstr ""
+#~ "Está usted entrando en los dominios del Príncipe Roland. Que tenga un "
+#~ "buen día."
+
+#~ msgid ""
+#~ "You are now entering the domain of Prince Roland. Have a pleasant stay."
+#~ msgstr ""
+#~ "Está usted entrando en los dominios del Príncipe Roland. Que tenga una "
+#~ "estancia agradable."
+
+#~ msgid ""
+#~ "You bribe the entrance guards of this dingy prison camp. They agree to "
+#~ "look the other way for a little while."
+#~ msgstr ""
+#~ "Sobornas a los guardias de la entrada de este sucio campo de prisioneros. "
+#~ "Están de acuerdo en mirar para otro lado durante un rato."
+
+#~ msgid ""
+#~ "You come across the dead remains of what was appearantly a powerful "
+#~ "wizard!  You wonder if it's safe to continue."
+#~ msgstr ""
+#~ "Te encuentras con los restos de lo que aparentemente fue un poderoso "
+#~ "mago. Te planteas si es seguro seguir adelante."
+
+#~ msgid ""
+#~ "You face three opponents in this scenario. Capture their castles and "
+#~ "their heroes to prove your worthiness to Archibald."
+#~ msgstr ""
+#~ "Te enfrentas a tres oponentes en este escenario. Captura sus castillos y "
+#~ "sus héroes para probar tu valía ante Archibald."
+
+#~ msgid ""
+#~ "You find an old signpost in the midst of a thicket that reads \"Warlock "
+#~ "Wood, West.  Barbarian Fields, East.\""
+#~ msgstr ""
+#~ "Encuentras en medio de la espesura una señal que lee \"Bosque de los "
+#~ "Brujos, al Oeste. Campos de los Bárbaros, Este.\""
+
+#~ msgid ""
+#~ "You find a note in the bottle! It reads, \"My ship has been wrecked by "
+#~ "the notorious pirates in this area! I am stranded on a small and barren "
+#~ "island. Please, I beg you to come and rescue me!\""
+#~ msgstr ""
+#~ "¡Encuentras una nota en la botella! En ella se lee: \"Mi barco ha sido "
+#~ "hundido por los famosos piratas de este área. Estoy perdido en una "
+#~ "pequeña isla. ¡Por favor, te ruego que vengas y me rescates!"
+
+#~ msgid "You found something!"
+#~ msgstr "¡Has encontrado algo!"
+
+#~ msgid "You found Treasure!"
+#~ msgstr "¡Has encontrado Tesoros!"
+
+#~ msgid ""
+#~ "You have been ordered here to claim this land in the name of your King "
+#~ "and recover any riches that you might find.  However, five other Kings "
+#~ "and Queens have also sent their heroes to this land, so you must watch "
+#~ "out for them as well as the natives!"
+#~ msgstr ""
+#~ "Has sido enviado aquí para reclamar esta tierra en nombre de tu Rey, y "
+#~ "obtener cualquier riqueza que pudieras encontrar. Sin embargo, otros "
+#~ "cinco Reyes y Reinas han enviado también a sus héroes a esta tierra, así "
+#~ "que debes de vigilar tanto a ellos como a los nativos."
+
+#~ msgid "You have found what someone else has lost..."
+#~ msgstr "Has encontrado lo que alguien perdió..."
+
+#~ msgid ""
+#~ "You have hired a barbarian of great power to aid you in this, your last "
+#~ "quest. His origins are unknown to you, but you sense strong nobility "
+#~ "beneath the furs and dirt that cover him. In addition, the famous "
+#~ "explorer, Marco the wizard, is rumored to have wrecked his ship in this "
+#~ "new land. Finding him would prove to be a much needed boon to your cause."
+#~ msgstr ""
+#~ "Has contratado a un poderoso bárbaro para que te ayude con ésta, tu "
+#~ "última búsqueda. Sus orígenes te son desconocidos, pero eres capaz de "
+#~ "sentir la fuerte nobleza bajo las pieles y la suciedad que le cubren. "
+#~ "Además, Marco el Mago, el famoso explorador, naufragó frente a estas "
+#~ "tierras. Encontrarle sería una bendición para tu causa."
+
+#~ msgid ""
+#~ "You have just 8 weeks  to build your army and conquer a town on the other "
+#~ "side of a distant river.  There are three paths to take, which will you "
+#~ "choose?"
+#~ msgstr ""
+#~ "Sólo dispones de 8 semanas para formar tu ejército y conquistar una "
+#~ "ciudad del otro lado del lejano rio. Hay tres caminos a seguir, ¿cuál "
+#~ "escojerás?"
+
+#~ msgid ""
+#~ "You have just 8 weeks to build your army and conquer a town on the other "
+#~ "side of a distant river.  There are three paths to take, which will you "
+#~ "choose?"
+#~ msgstr ""
+#~ "Sólo dispones de 8 semanas para formar tu ejército y conquistar una "
+#~ "ciudad del otro lado del lejano rio. Hay tres caminos a seguir, ¿cuál "
+#~ "escojerás?"
+
+#~ msgid "You have recieved a shipment of supplies from your kingdom!"
+#~ msgstr "¡Has recibido un cargamento con suministris desde tu reino!"
+
+#~ msgid ""
+#~ "You have six months to destroy the Necromancer Stronghold in the heart of "
+#~ "the valley."
+#~ msgstr ""
+#~ "Tienes seis meses para destruir la Fortaleza del Necromante, en el "
+#~ "corazón de este valle."
+
+#~ msgid ""
+#~ "You notice that mines and resources in the elvish lands are few, and you "
+#~ "send word to your kingdom that you will need extra supplies. They should "
+#~ "respond within a fortnight."
+#~ msgstr ""
+#~ "Te das cuenta de que las minas y los recursos de las tierras elfas son "
+#~ "escasos, y envías un mensaje a tu reino de que necesitarás recursos "
+#~ "extra. Debieran de responderte en una quincena."
+
+#~ msgid ""
+#~ "Your advisor approaches you smiling greatly, \"My liege! The peasants are "
+#~ "making money in the market, and are finally paying taxes!\""
+#~ msgstr ""
+#~ "Tu consejero se acerca, sonriendo ampliamente: \"¡Mi Señor! Los "
+#~ "campesinos están haciendo dinero en el mercado, y !por fin están pagando "
+#~ "impuestos!\""
+
+#~ msgid ""
+#~ "Your castle, founded inside the center of a mile wide crater, is besieged "
+#~ "by those who desire your mineral wealth."
+#~ msgstr ""
+#~ "Tu castillo, fundado en el interior del centro de un cráter de más de una "
+#~ "milla de ancho, está siendo asediado por aquellos que ansían tu riqueza "
+#~ "mineral."
+
+#~ msgid "Your castle is the last outpost in the area, Don't lose it!"
+#~ msgstr "¡Tu castillo es el ultimo bastión de la zona, no lo pierdas!"
+
+#~ msgid "Your crew begins to grumble."
+#~ msgstr "Tu equipo empieza a quejarse."
+
+#~ msgid "You're almost there!"
+#~ msgstr "¡Ya casi ha terminado!"
+
+#~ msgid "Your king has sent supplies to aid the war effort."
+#~ msgstr "Su rey ha enviado suministros para ayudar en la guerra."
+
+#~ msgid ""
+#~ "Your opponents are allied against you and each is twice as powerful as "
+#~ "his predecessor! Is it possible to win?"
+#~ msgstr ""
+#~ "Tus oponentes se han aliado contra ti, ¡y cada uno es el doble de "
+#~ "poderoso que su predecesor! ¿Es posible vencer?"
+
+#~ msgid ""
+#~ "Your scouts return with grim news.  The natives of this land are "
+#~ "currently at war with each other, and they like outsiders even less than "
+#~ "they like each other!  Congratulations, Commander, you're at war!"
+#~ msgstr ""
+#~ "Tus exploradores regresan con noticias horrendas. Los nativos de estas "
+#~ "tierras están actualmente en guerra los unos con los otros, y los "
+#~ "extranjeros les gustan aún menos. ¡Enhorabuena, Comandante, estás en "
+#~ "guerra!"
+
+#~ msgid ""
+#~ "Your town is undefended and your heroes are scattered.  Do you attack or "
+#~ "defend?"
+#~ msgstr ""
+#~ "Tu ciudad no tiene defensa y tus héroes están desperdigados. ¿Atacas o "
+#~ "defiendes?"
+
+#~ msgid ""
+#~ "Your treasury has been looted by robbers and you have lost valuable "
+#~ "resources."
+#~ msgstr ""
+#~ "Tu tesoro ha sido saqueado por ladrones y has perdido valiosos recursos."
+
+#~ msgid "Your troops begin to wonder about your sanity."
+#~ msgstr "Tus tropas empiezan a preguntarse acerca de su cordura."
+
+#~ msgid ""
+#~ "You see a family of refugees making their way from the beach. You ask "
+#~ "them about their plight and they tell you that they are from a once great "
+#~ "city called Moss Side. They tell you that the castle was destroyed in a "
+#~ "great conflagration, and they fled for fear of their lives."
+#~ msgstr ""
+#~ "Ves a una familia de refugiados abriéndose camino desde la playa. Les "
+#~ "preguntas por su situación, y te dicen que son de una ciudad que fue "
+#~ "grande llamada Moss Side. También te cuentan que el castillo fue "
+#~ "destruido en una gran conflagración, y que huyeron al temer por sus vidas."
+
+#~ msgid ""
+#~ "You see the mast of ancient ship here.  On further investigation you find "
+#~ "that the ships holds are full of gems.  The hours pass as your crue "
+#~ "liberates the treasure."
+#~ msgstr ""
+#~ "Ves el mástil de un navío antiguo. Tras investigar más, encuentras las "
+#~ "bodegas del barco repletas de gemas. Pasan las horas mientras tus hombres "
+#~ "liberan el tesoro."
+
+#~ msgid ""
+#~ "You see the remains of a burned out sawmill here.  All you can salvage is "
+#~ "some ofwood left for scrap."
+#~ msgstr ""
+#~ "Ves los restos calcinados de un aserradero. Lo único que puedes recuperar "
+#~ "es algo de madera."
+
+#~ msgid ""
+#~ "You see the remains of an old sawmill, but it is obvious that you will "
+#~ "not be able to make it work again."
+#~ msgstr ""
+#~ "Ves los restos de un viejo aserradero, pero es obvio que no podrás "
+#~ "ponerlo en marcha de nuevo."
+
+#~ msgid ""
+#~ "You see the remains of an old sawmill just to realize that it will no "
+#~ "longer produce.  You gather the ramains and move on."
+#~ msgstr ""
+#~ "Ves los restos de un viejo aserradero, sólo para darte cuenta de que no "
+#~ "volverá a producir. Recoges los restos y sigues tu camino."
+
+#~ msgid ""
+#~ "You send this letter back to the king,\"A month has passed and we have "
+#~ "not discovered the wizard Joseph. I only hope that we are able to locate "
+#~ "him in time to aid us in our struggle.\""
+#~ msgstr ""
+#~ "Envías esta carta de vuelta al rey, \"Ha pasado un mes y no hemos "
+#~ "descubierto al mago Joseph. Sólo espero que seamos capaces de encontrarlo "
+#~ "a tiempo para que nos ayude en nuestra lucha.\""
+
+#~ msgid "You should turn back."
+#~ msgstr "Deberías volver."
+
+#~ msgid "You uncover a compass in the grass!"
+#~ msgstr "¡Has descubierto una brújula en el cesped!"
+
+#~ msgid "You've been warned!"
+#~ msgstr "¡Se te ha advertido!"
+
+#~ msgid ""
+#~ "You've received a message from the guild. \"Thank God you've arrived! "
+#~ "We're under seige from two enemies from the north and one from across the "
+#~ "sea. Please save us, you're our only hope.\""
+#~ msgstr ""
+#~ "Has recibido un mensaje del gremio. \"¡Gracias a Dios que has llegado! "
+#~ "Estamos bajo asedio de dos enemigos del norte y uno de más allá del mar. "
+#~ "Por favor, sálvanos, ¡eres nuestra única esperanza.\""
+
+#~ msgid ""
+#~ "You've ruled with an iron fist (and an army of undead), but now your "
+#~ "kingdom has turned against you!"
+#~ msgstr ""
+#~ "Has gobernado con puño de hierro (y un ejército de no-muertos), ¡pero "
+#~ "ahora tu reino se ha vuelto contra ti!"
+
+#~ msgid ""
+#~ "You will need a stronger army than that, mortal, to step through this "
+#~ "portal."
+#~ msgstr ""
+#~ "Necesitarás un ejército más fuerte que ese, mortal, para cruzar este "
+#~ "portal."
+
+#~ msgid "Blind "
+#~ msgstr "Ceguera "
+
+#~ msgid "game: also confirm autosave"
+#~ msgstr "juego: también confirmar el autoguardado"
+
+#~ msgid "world: abandoned mine random resource"
+#~ msgstr "mundo: mina abandonada con recursos aleatorios"
+
+#~ msgid "world: save count monster after battle"
+#~ msgstr "mundo: guardar cantidad de monstruos después de la batalla"
+
+#~ msgid "world: no in-built requirements or guardians for placed artifacts"
+#~ msgstr "mundo: sin requisitos in-situ o guardianes para artefactos ubicados"
+
+#~ msgid "castle: allow buy from well"
+#~ msgstr "castillo: permitir comprar desde el pozo"
+
+#~ msgid "heroes: learn new spells with day"
+#~ msgstr "Los héroes: aprenden nuevos hechizos día a día."
+
+#~ msgid "battle: high objects are an obstacle for archers"
+#~ msgstr "batalla: objetos altos son un obstáculo para arqueros"
+
+#~ msgid "battle: merge armies for hero from castle"
+#~ msgstr "batalla: fusionar ejércitos para el héroe desde el castillo"
+
+#~ msgid "battle: magical creature resists (20%) the same magic"
+#~ msgstr "batalla: criatura mágica resiste (20%) la misma magia"
+
+#~ msgid "game: show SDL logo"
+#~ msgstr "juego: mostrar logo de SDL"
+
+#~ msgid "game: also use dynamic interface for castles"
+#~ msgstr "juego: también usar interfaz dinámica para castillos"
+
+#~ msgid "pocketpc: hide cursor"
+#~ msgstr "pocketpc: ocultar cursor"
+
+#~ msgid "pocketpc: tap mode"
+#~ msgstr "pocketpc: modo de pulsación"
+
+#~ msgid "pocketpc: low memory"
+#~ msgstr "tap: poca memoria"
 
 #~ msgid "one creature perishes."
 #~ msgid_plural "%{count} creatures perish."
@@ -13801,11 +11488,11 @@ msgstr "tap: poca memoria"
 #~ msgid_plural ""
 #~ "Reduces the movement penalty for rough terrain by %{count} percent."
 #~ msgstr[0] ""
-#~ "Reduce la penalización al movimiento debida a terreno agreste en un %"
-#~ "{count} por ciento."
+#~ "Reduce la penalización al movimiento debida a terreno agreste en un "
+#~ "%{count} por ciento."
 #~ msgstr[1] ""
-#~ "Reduce la penalización al movimiento debida a terreno agreste en un %"
-#~ "{count} por ciento."
+#~ "Reduce la penalización al movimiento debida a terreno agreste en un "
+#~ "%{count} por ciento."
 
 #~ msgid "Stone"
 #~ msgstr "Piedra"

--- a/files/lang/fheroes2.pot
+++ b/files/lang/fheroes2.pot
@@ -8,1514 +8,2183 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-22 09:48+0800\n"
+"POT-Creation-Date: 2021-07-01 15:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../fheroes2/ai/ai_action.cpp:157 ../fheroes2/heroes/heroes_action.cpp:248
-msgid "Hero %{name} also got a %{count} experience."
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:221 ../fheroes2/resource/artifact.cpp:977
-msgid "View %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:227 ../fheroes2/army/army_bar.cpp:310
-msgid "Move or right click to redistribute %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:233 ../fheroes2/army/army_bar.cpp:301
-msgid "Combine %{name} armies"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:238 ../fheroes2/army/army_bar.cpp:292
-#: ../fheroes2/resource/artifact.cpp:989
-#: ../fheroes2/resource/artifact.cpp:1011
-msgid "Exchange %{name2} with %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:246 ../fheroes2/resource/artifact.cpp:997
-msgid "Select %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:298 ../fheroes2/army/army_bar.cpp:307
-msgid "Cannot move last troop"
-msgstr ""
-
-#: ../fheroes2/army/army.cpp:85
+#: ../fheroes2/army/army.cpp:93
 msgid ""
 "A few\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:86
+#: ../fheroes2/army/army.cpp:96
 msgid ""
 "Several\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:87
+#: ../fheroes2/army/army.cpp:99
 msgid ""
 "A pack of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:88
+#: ../fheroes2/army/army.cpp:102
 msgid ""
 "Lots of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:89
+#: ../fheroes2/army/army.cpp:105
 msgid ""
 "A horde of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:90
+#: ../fheroes2/army/army.cpp:108
 msgid ""
 "A throng of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:91
+#: ../fheroes2/army/army.cpp:111
 msgid ""
 "A swarm of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:92
+#: ../fheroes2/army/army.cpp:114
 msgid ""
 "Zounds of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:93
+#: ../fheroes2/army/army.cpp:117
 msgid ""
 "A legion of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
+#: ../fheroes2/army/army.cpp:127
 msgid "army|Few"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
+#: ../fheroes2/army/army.cpp:127
 msgid "army|Several"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
+#: ../fheroes2/army/army.cpp:127
 msgid "army|Pack"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
+#: ../fheroes2/army/army.cpp:127
 msgid "army|Lots"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
+#: ../fheroes2/army/army.cpp:127
 msgid "army|Horde"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
+#: ../fheroes2/army/army.cpp:128
 msgid "army|Throng"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
+#: ../fheroes2/army/army.cpp:128
 msgid "army|Swarm"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
+#: ../fheroes2/army/army.cpp:128
 msgid "army|Zounds"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
+#: ../fheroes2/army/army.cpp:128
 msgid "army|Legion"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:928
+#: ../fheroes2/army/army.cpp:1100
 msgid "All %{race} troops +1"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:939
-msgid "Entire unit is undead, so morale does not apply."
-msgstr ""
-
-#: ../fheroes2/army/army.cpp:949
+#: ../fheroes2/army/army.cpp:1114
 msgid "Troops of 3 alignments -1"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:957
+#: ../fheroes2/army/army.cpp:1121
 msgid "Troops of 4 alignments -2"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:965
+#: ../fheroes2/army/army.cpp:1128
 msgid "Troops of 5 alignments -3"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:979
+#: ../fheroes2/army/army.cpp:1140
 msgid "Some undead in groups -1"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:752
+#: ../fheroes2/army/army_bar.cpp:300
+msgid "View %{name}"
+msgstr ""
+
+#: ../fheroes2/army/army_bar.cpp:305 ../fheroes2/army/army_bar.cpp:349
+msgid "Move or right click to redistribute %{name}"
+msgstr ""
+
+#: ../fheroes2/army/army_bar.cpp:311 ../fheroes2/army/army_bar.cpp:342
+msgid "Combine %{name} armies"
+msgstr ""
+
+#: ../fheroes2/army/army_bar.cpp:316 ../fheroes2/army/army_bar.cpp:335
+#: ../fheroes2/resource/artifact.cpp:1094
+#: ../fheroes2/resource/artifact.cpp:1118
+msgid "Exchange %{name2} with %{name}"
+msgstr ""
+
+#: ../fheroes2/army/army_bar.cpp:322 ../fheroes2/resource/artifact.cpp:1105
+msgid "Select %{name}"
+msgstr ""
+
+#: ../fheroes2/army/army_bar.cpp:340 ../fheroes2/army/army_bar.cpp:347
+msgid "Cannot move last troop"
+msgstr ""
+
+#: ../fheroes2/battle/battle_action.cpp:577
+msgid "%{name} half the enemy troops!"
+msgstr ""
+
+#: ../fheroes2/battle/battle_action.cpp:903
 msgid "Set auto battle off"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:757
+#: ../fheroes2/battle/battle_action.cpp:908
 msgid "Set auto battle on"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:864
+#: ../fheroes2/battle/battle_action.cpp:1034
 msgid "spell failed!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:705
+#: ../fheroes2/battle/battle_arena.cpp:805
 msgid ""
 "The Sphere of Negation artifact is in effect for this battle, disabling all "
 "combat spells."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:714
+#: ../fheroes2/battle/battle_arena.cpp:813
 msgid "You have already cast a spell this round."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:720
-#: ../fheroes2/battle/battle_arena.cpp:768
+#: ../fheroes2/battle/battle_arena.cpp:818
+#: ../fheroes2/battle/battle_arena.cpp:870
 msgid "That spell will affect no one!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:739
+#: ../fheroes2/battle/battle_arena.cpp:847
 msgid "You may only summon one type of elemental per combat."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:745
+#: ../fheroes2/battle/battle_arena.cpp:852
 msgid "There is no open space adjacent to your hero to summon an Elemental to."
 msgstr ""
 
-#: ../fheroes2/battle/battle_board.cpp:968
+#: ../fheroes2/battle/battle_board.cpp:1186
 msgid ""
 "The Moat reduces by -%{count} the defense skill of any unit and slows to "
 "half movement rate."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:50
-msgid "speed: %{speed}"
-msgstr ""
-
 #: ../fheroes2/battle/battle_dialogs.cpp:165
-msgid "The enemy has surrendered!"
+#: ../fheroes2/castle/castle_well.cpp:323
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:307
+msgid "Speed"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:168
-msgid "The enemy has fled!"
+#: ../fheroes2/battle/battle_dialogs.cpp:169
+msgid "Speed: %{speed}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:170
-#: ../fheroes2/battle/battle_dialogs.cpp:256
-msgid "A glorious victory!"
+#: ../fheroes2/battle/battle_dialogs.cpp:177
+msgid "Auto Spell Casting"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:175
-msgid "For valor in combat, %{name} receives %{exp} experience"
+#: ../fheroes2/battle/battle_dialogs.cpp:178
+msgid "Grid"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:184
-msgid "The cowardly %{name} flees from battle."
+#: ../fheroes2/battle/battle_dialogs.cpp:179
+msgid "Shadow Movement"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:191
-msgid "%{name} surrenders to the enemy, and departs in shame."
+#: ../fheroes2/battle/battle_dialogs.cpp:180
+msgid "Shadow Cursor"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:197
-msgid "Your force suffer a bitter defeat, and %{name} abandons your cause."
+#: ../fheroes2/battle/battle_dialogs.cpp:196
+msgid "On"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:249
-msgid "Your force suffer a bitter defeat."
+#: ../fheroes2/battle/battle_dialogs.cpp:196
+msgid "Off"
 msgstr ""
 
 #: ../fheroes2/battle/battle_dialogs.cpp:296
-msgid "Battlefield Casualties"
+msgid "The enemy has surrendered!"
+msgstr ""
+
+#: ../fheroes2/battle/battle_dialogs.cpp:298
+msgid "The enemy has fled!"
 msgstr ""
 
 #: ../fheroes2/battle/battle_dialogs.cpp:300
-msgid "Attacker"
+#: ../fheroes2/battle/battle_dialogs.cpp:380
+msgid "A glorious victory!"
+msgstr ""
+
+#: ../fheroes2/battle/battle_dialogs.cpp:303
+msgid "For valor in combat, %{name} receives %{exp} experience."
 msgstr ""
 
 #: ../fheroes2/battle/battle_dialogs.cpp:312
+msgid "The cowardly %{name} flees from battle."
+msgstr ""
+
+#: ../fheroes2/battle/battle_dialogs.cpp:317
+msgid "%{name} surrenders to the enemy, and departs in shame."
+msgstr ""
+
+#: ../fheroes2/battle/battle_dialogs.cpp:324
+msgid "Your force suffer a bitter defeat, and %{name} abandons your cause."
+msgstr ""
+
+#: ../fheroes2/battle/battle_dialogs.cpp:374
+msgid "Your force suffer a bitter defeat."
+msgstr ""
+
+#: ../fheroes2/battle/battle_dialogs.cpp:428
+msgid "Battlefield Casualties"
+msgstr ""
+
+#: ../fheroes2/battle/battle_dialogs.cpp:432
+msgid "Attacker"
+msgstr ""
+
+#: ../fheroes2/battle/battle_dialogs.cpp:443
+#: ../fheroes2/campaign/campaign_data.cpp:151
 msgid "Defender"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:394
+#: ../fheroes2/battle/battle_dialogs.cpp:526
+msgid "You have captured an enemy artifact!"
+msgstr ""
+
+#: ../fheroes2/battle/battle_dialogs.cpp:605
+msgid "Necromancy!"
+msgstr ""
+
+#: ../fheroes2/battle/battle_dialogs.cpp:609
+msgid ""
+"Practicing the dark arts of necromancy, you are able to raise %{count} of "
+"the enemy's dead to return under your service as %{monster}."
+msgstr ""
+
+#: ../fheroes2/battle/battle_dialogs.cpp:690
 msgid "%{name} the %{race}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:401
-#: ../fheroes2/castle/castle_well.cpp:311
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:194
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:834
-#: ../fheroes2/heroes/skill.cpp:151
+#: ../fheroes2/battle/battle_dialogs.cpp:697
+#: ../fheroes2/castle/castle_well.cpp:299
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:914
 msgid "Attack"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:406
-#: ../fheroes2/castle/castle_well.cpp:317
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:206
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:844
-#: ../fheroes2/heroes/skill.cpp:151
+#: ../fheroes2/battle/battle_dialogs.cpp:702
+#: ../fheroes2/castle/castle_well.cpp:305
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:924
 msgid "Defense"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:411
-#: ../fheroes2/castle/castle_town.cpp:310
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:854
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:142
-#: ../fheroes2/heroes/heroes_meeting.cpp:292
+#: ../fheroes2/battle/battle_dialogs.cpp:707
+#: ../fheroes2/castle/castle_town.cpp:322
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:934
+#: ../fheroes2/dialog/dialog_skillinfo.cpp:146
+#: ../fheroes2/gui/skill_bar.cpp:293 ../fheroes2/heroes/skill.cpp:148
 msgid "Spell Power"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:416
-#: ../fheroes2/castle/castle_town.cpp:319
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:864
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:147
-#: ../fheroes2/heroes/heroes_meeting.cpp:296 ../fheroes2/heroes/skill.cpp:151
+#: ../fheroes2/battle/battle_dialogs.cpp:712
+#: ../fheroes2/castle/castle_town.cpp:331
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:944
+#: ../fheroes2/dialog/dialog_skillinfo.cpp:151
+#: ../fheroes2/gui/skill_bar.cpp:297 ../fheroes2/heroes/skill.cpp:148
 msgid "Knowledge"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:421
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:276
+#: ../fheroes2/battle/battle_dialogs.cpp:717
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:317
 msgid "Morale"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:426
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:286 ../fheroes2/heroes/skill.cpp:338
+#: ../fheroes2/battle/battle_dialogs.cpp:722
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:327 ../fheroes2/heroes/skill.cpp:364
 msgid "Luck"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:431
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:874
-#: ../fheroes2/heroes/heroes_indicator.cpp:247
+#: ../fheroes2/battle/battle_dialogs.cpp:727
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:954
+#: ../fheroes2/heroes/heroes_indicator.cpp:253
 msgid "Spell Points"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
+#: ../fheroes2/battle/battle_dialogs.cpp:756
+#: ../fheroes2/battle/battle_dialogs.cpp:782
+#: ../fheroes2/battle/battle_interface.cpp:2288
+#: ../fheroes2/battle/battle_interface.cpp:2314
+msgid "Hero's Options"
+msgstr ""
+
+#: ../fheroes2/battle/battle_dialogs.cpp:767
+#: ../fheroes2/battle/battle_dialogs.cpp:804
 #: ../fheroes2/gui/interface_buttons.cpp:189
 msgid "Cast Spell"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
-msgid ""
-"Cast a magical spell. You may only cast one spell per combat round. The "
-"round is reset when every creature has had a turn"
-msgstr ""
-
-#: ../fheroes2/battle/battle_dialogs.cpp:488
+#: ../fheroes2/battle/battle_dialogs.cpp:770
+#: ../fheroes2/battle/battle_dialogs.cpp:810
 msgid "Retreat"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:488
+#: ../fheroes2/battle/battle_dialogs.cpp:773
+#: ../fheroes2/battle/battle_dialogs.cpp:816
+msgid "Surrender"
+msgstr ""
+
+#: ../fheroes2/battle/battle_dialogs.cpp:776
+#: ../fheroes2/battle/battle_dialogs.cpp:824
+#: ../fheroes2/dialog/dialog_file.cpp:119
+#: ../fheroes2/game/game_loadgame.cpp:114
+#: ../fheroes2/game/game_loadgame.cpp:222 ../fheroes2/game/game_newgame.cpp:146
+#: ../fheroes2/game/game_newgame.cpp:311 ../fheroes2/game/game_newgame.cpp:399
+#: ../fheroes2/game/game_newgame.cpp:445 ../fheroes2/game/game_newgame.cpp:522
+#: ../fheroes2/game/game_scenarioinfo.cpp:306
+msgid "Cancel"
+msgstr ""
+
+#: ../fheroes2/battle/battle_dialogs.cpp:779
+#: ../fheroes2/battle/battle_dialogs.cpp:821
+#: ../fheroes2/heroes/heroes_dialog.cpp:369
+msgid "Hero Screen"
+msgstr ""
+
+#: ../fheroes2/battle/battle_dialogs.cpp:805
+msgid ""
+"Cast a magical spell. You may only cast one spell per combat round. The "
+"round is reset when every creature has had a turn."
+msgstr ""
+
+#: ../fheroes2/battle/battle_dialogs.cpp:811
 msgid ""
 "Retreat your hero, abandoning your creatures. Your hero will be available "
 "for you to recruit again, however, the hero will have only a novice hero's "
 "forces."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:491
-msgid "Surrender"
-msgstr ""
-
-#: ../fheroes2/battle/battle_dialogs.cpp:491
+#: ../fheroes2/battle/battle_dialogs.cpp:817
 msgid ""
 "Surrendering costs gold. However if you pay the ransom, the hero and all of "
 "his or her surviving creatures will be available to recruit again."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:166
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:227
-msgid "Cancel"
+#: ../fheroes2/battle/battle_dialogs.cpp:821
+msgid "Open Hero Screen to view full information about the hero."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
+#: ../fheroes2/battle/battle_dialogs.cpp:824
 msgid "Return to the battle."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:549
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:515
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:574
+#: ../fheroes2/battle/battle_dialogs.cpp:902
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:736
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:817
 msgid "Not enough gold (%{gold})"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:564
+#: ../fheroes2/battle/battle_dialogs.cpp:916
 msgid "%{name} states:"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:569
+#: ../fheroes2/battle/battle_dialogs.cpp:921
 msgid ""
-"I will accept your surrender and grant you and your troops safe passage for "
-"the price of %{price} gold."
+"\"I will accept your surrender and grant you and your troops safe passage "
+"for the price of %{price} gold.\""
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:613
-#: ../fheroes2/battle/battle_interface.cpp:1401
+#: ../fheroes2/battle/battle_interface.cpp:807
+#: ../fheroes2/battle/battle_interface.cpp:2008
 msgid "View %{monster} info."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1409
+#: ../fheroes2/battle/battle_interface.cpp:2014
 msgid "Shoot %{monster}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1431
+#: ../fheroes2/battle/battle_interface.cpp:2032
 msgid "Attack %{monster}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
+#: ../fheroes2/battle/battle_interface.cpp:2042
 msgid "Fly %{monster} here."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
+#: ../fheroes2/battle/battle_interface.cpp:2042
 msgid "Move %{monster} here."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1449
-#: ../fheroes2/battle/battle_interface.cpp:1538
+#: ../fheroes2/battle/battle_interface.cpp:2048
+#: ../fheroes2/battle/battle_interface.cpp:2729
 msgid "Turn %{turn}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1475
+#: ../fheroes2/battle/battle_interface.cpp:2082
 msgid "Teleport Here"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1479
+#: ../fheroes2/battle/battle_interface.cpp:2086
 msgid "Invalid Teleport Destination"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1485
+#: ../fheroes2/battle/battle_interface.cpp:2090
 msgid "Cast %{spell} on %{monster}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1495
+#: ../fheroes2/battle/battle_interface.cpp:2096
 msgid "Cast %{spell}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1501
+#: ../fheroes2/battle/battle_interface.cpp:2102
 msgid "Select Spell Target"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1674
-msgid "Spell cast"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:1686
+#: ../fheroes2/battle/battle_interface.cpp:2247
 msgid "View Ballista Info"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1699
-#: ../fheroes2/battle/battle_tower.cpp:53
+#: ../fheroes2/battle/battle_interface.cpp:2258
+#: ../fheroes2/battle/battle_tower.cpp:61
 msgid "Ballista"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1712
+#: ../fheroes2/battle/battle_interface.cpp:2267
 msgid "Auto combat"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1719
+#: ../fheroes2/battle/battle_interface.cpp:2272
 msgid "Customize system options."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1727
+#: ../fheroes2/battle/battle_interface.cpp:2277
 msgid "Wait this unit"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1734
+#: ../fheroes2/battle/battle_interface.cpp:2282
 msgid "Skip this unit"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1742
-#: ../fheroes2/battle/battle_interface.cpp:1774
-msgid "Hero's Options"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:1753
-#: ../fheroes2/battle/battle_interface.cpp:1785
+#: ../fheroes2/battle/battle_interface.cpp:2297
+#: ../fheroes2/battle/battle_interface.cpp:2323
 msgid "View Opposing Hero"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
+#: ../fheroes2/battle/battle_interface.cpp:2370
 msgid "Hide logs"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
+#: ../fheroes2/battle/battle_interface.cpp:2370
 msgid "Show logs"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1878
+#: ../fheroes2/battle/battle_interface.cpp:2408
 msgid "%{color} cast spell: %{spell}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2202
+#: ../fheroes2/battle/battle_interface.cpp:2673
 msgid "%{name} skipping turn"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2203
-msgid ", and get +2 defense"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:2206
+#: ../fheroes2/battle/battle_interface.cpp:2676
 msgid "%{name} waiting turn"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2343
+#: ../fheroes2/battle/battle_interface.cpp:2832
 msgid "%{attacker} do %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2497
+#: ../fheroes2/battle/battle_interface.cpp:2997
+#: ../fheroes2/battle/battle_interface.cpp:3080
 msgid "Moved %{monster}: %{src}, %{dst}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2612
+#: ../fheroes2/battle/battle_interface.cpp:3001
+msgid "Moved %{monster}"
+msgstr ""
+
+#: ../fheroes2/battle/battle_interface.cpp:3174
 msgid "The %{name} resist the spell!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2625
+#: ../fheroes2/battle/battle_interface.cpp:3187
 msgid "%{name} casts %{spell} on the %{troop}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2630
+#: ../fheroes2/battle/battle_interface.cpp:3191
 msgid "%{name} casts %{spell}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2751
-msgid "The %{spell} spell does %{damage} damage to all undead creatures."
+#: ../fheroes2/battle/battle_interface.cpp:3394
+msgid "The %{spell} does %{damage} damage to one undead creature."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2754
-msgid "The %{spell} spell does %{damage} damage to all living creatures."
+#: ../fheroes2/battle/battle_interface.cpp:3406
+msgid "The %{spell} does %{damage} damage to all undead creatures."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2756
+#: ../fheroes2/battle/battle_interface.cpp:3412
+#: ../fheroes2/battle/battle_interface.cpp:3444
+msgid "The %{spell} does %{damage} damage, %{count} creatures perish."
+msgstr ""
+
+#: ../fheroes2/battle/battle_interface.cpp:3416
+#: ../fheroes2/battle/battle_interface.cpp:3448
+#: ../fheroes2/battle/battle_interface.cpp:3457
 msgid "The %{spell} does %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2797
+#: ../fheroes2/battle/battle_interface.cpp:3426
+msgid "The %{spell} does %{damage} damage to one living creature."
+msgstr ""
+
+#: ../fheroes2/battle/battle_interface.cpp:3438
+msgid "The %{spell} does %{damage} damage to all living creatures."
+msgstr ""
+
+#: ../fheroes2/battle/battle_interface.cpp:3481
 msgid "The Unicorns attack blinds the %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2798
+#: ../fheroes2/battle/battle_interface.cpp:3484
 msgid "The Medusas gaze turns the %{name} to stone!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2800
+#: ../fheroes2/battle/battle_interface.cpp:3488
 msgid "The Mummies' curse falls upon the %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2801
+#: ../fheroes2/battle/battle_interface.cpp:3491
 msgid "The %{name} are paralyzed by the Cyclopes!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2802
+#: ../fheroes2/battle/battle_interface.cpp:3494
 msgid "The Archmagi dispel all good spells on your %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2820
-msgid "Good luck shines on the  %{attacker}"
+#: ../fheroes2/battle/battle_interface.cpp:3516
+msgid "Good luck shines on the %{attacker}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2872
+#: ../fheroes2/battle/battle_interface.cpp:3516
 msgid "Bad luck descends on the %{attacker}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2884
+#: ../fheroes2/battle/battle_interface.cpp:3584
 msgid "High morale enables the %{monster} to attack again."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2891
+#: ../fheroes2/battle/battle_interface.cpp:3590
 msgid "Low morale causes the %{monster} to freeze in panic."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2944
-msgid "Tower do %{damage} damage."
+#: ../fheroes2/battle/battle_interface.cpp:3622
+msgid "%{tower} does %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:3257
+#: ../fheroes2/battle/battle_interface.cpp:3829
 msgid "MirrorImage created"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:3798
-msgid "MirrorImage ended"
+#: ../fheroes2/battle/battle_interface.cpp:4506
+msgid "The mirror image is destroyed!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4089
+#: ../fheroes2/battle/battle_interface.cpp:4791
 msgid "Break auto battle?"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4138
+#: ../fheroes2/battle/battle_interface.cpp:4835
 msgid "No spells to cast."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4147
+#: ../fheroes2/battle/battle_interface.cpp:4842
 msgid "Are you sure you want to retreat?"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4155
+#: ../fheroes2/battle/battle_interface.cpp:4849
 msgid "Retreat disabled"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4169
-msgid "You don't have enough gold!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:4180
+#: ../fheroes2/battle/battle_interface.cpp:4869
 msgid "Surrender disabled"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
+#: ../fheroes2/battle/battle_interface.cpp:4922
 msgid "Damage: %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
+#: ../fheroes2/battle/battle_interface.cpp:4922
 msgid "Damage: %{min} - %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
+#: ../fheroes2/battle/battle_interface.cpp:4937
 msgid "Perish: %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
+#: ../fheroes2/battle/battle_interface.cpp:4937
 msgid "Perish: %{min} - %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_main.cpp:190
-msgid "You have captured an enemy artifact!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_main.cpp:241
+#: ../fheroes2/battle/battle_main.cpp:305
 msgid ""
-"Through eagle-eyed observation, %{name} is able to learn the magic spell %"
-"{spell}."
+"Through eagle-eyed observation, %{name} is able to learn the magic spell "
+"%{spell}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_main.cpp:280
-msgid ""
-"Practicing the dark arts of necromancy, you are able to raise %{count} of "
-"the enemy's dead to return under your service as %{monster}"
-msgstr ""
-
-#: ../fheroes2/battle/battle_tower.cpp:47 ../fheroes2/castle/castle.cpp:466
+#: ../fheroes2/battle/battle_tower.cpp:53 ../fheroes2/castle/castle.cpp:661
 msgid "Left Turret"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:48 ../fheroes2/castle/castle.cpp:467
+#: ../fheroes2/battle/battle_tower.cpp:55 ../fheroes2/castle/castle.cpp:662
 msgid "Right Turret"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:115
+#: ../fheroes2/battle/battle_tower.cpp:123
 msgid "The %{name} fires with the strength of %{count} Archers"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:116
+#: ../fheroes2/battle/battle_tower.cpp:124
 msgid "each with a +%{attack} bonus to their attack skill."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:863
-msgid "%{name} half the enemy troops!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_troop.cpp:950
+#: ../fheroes2/battle/battle_troop.cpp:797
 msgid ""
 "The %{artifact} artifact is in effect for this battle, disabling %{spell} "
 "spell."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:1598
+#: ../fheroes2/battle/battle_troop.cpp:1488
 msgid "%{count} %{name} rise(s) from the dead!"
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:258
+#: ../fheroes2/campaign/campaign_data.cpp:44
+msgid "Sorceress Guild"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:66
+msgid "Necromancer Guild"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:73
+msgid "Dragon Alliance"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:95
+#: ../fheroes2/campaign/campaign_data.cpp:142
+msgid "Elven Alliance"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:133
+msgid "Wayward Son"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:136 ../fheroes2/heroes/heroes.cpp:85
+msgid "Uncle Ivan"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:150
+msgid "Force of Arms"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:150
+msgid "Annexation"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:150
+msgid "Save the Dwarves"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:150
+msgid "Carator Mines"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:150
+#: ../fheroes2/campaign/campaign_data.cpp:154
+msgid "Turning Point"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:151
+msgid "The Gauntlet"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:151
+#: ../fheroes2/campaign/campaign_data.cpp:155
+msgid "The Crown"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:151
+msgid "Corlagon's Defense"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:151
+msgid "Final Justice"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:154
+msgid "First Blood"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:154
+msgid "Barbarian Wars"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:154
+msgid "Necromancers"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:154
+msgid "Slay the Dwarves"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:154
+msgid "Rebellion"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:155
+msgid "Dragon Master"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:155
+msgid "Country Lords"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:155
+msgid "Greater Glory"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:155
+msgid "Apocalypse"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:157
+msgid "Uprising"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:157
+msgid "Island of Chaos"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:157
+msgid "Arrow's Flight"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:157
+msgid "The Abyss"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:158
+msgid "The Giant's Pass"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:158
+msgid "Aurora Borealis"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:158
+msgid "Betrayal's End"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:158
+msgid "Corruption's Heart"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:160
+msgid "Conquer and Unify"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:160
+msgid "Border Towns"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:160
+msgid "The Wayward Son"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:160
+msgid "Crazy Uncle Ivan"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:161
+msgid "The Southern War"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:161
+msgid "Ivory Gates"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:161
+msgid "The Elven Lands"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:161
+msgid "The Epic Battle"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:163
+msgid "The Shrouded Isles"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:163
+msgid "The Eternal Scrolls"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:163
+msgid "Power's End"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:163
+msgid "Fount of Wizardry"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:165
+msgid "Stranded"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:165
+msgid "Pirate Isles"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:165
+msgid "King and Country"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:165
+msgid "Blood is Thicker"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:168
+msgid ""
+"Roland needs you to defeat the lords near his castle to begin his war of "
+"rebellion against his brother.  They are not allied with each other, so they "
+"will spend most of their time fighting with one another.  Victory is yours "
+"when you have defeated all of their castles and heroes."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:170
+msgid ""
+"The local lords refuse to swear allegiance to Roland, and must be subdued. "
+"They are wealthy and powerful, so be prepared for a tough fight. Capture all "
+"enemy castles to win."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:171
+msgid ""
+"Your task is to defend the Dwarves against Archibald's forces. Capture all "
+"of the enemy towns and castles to win, and be sure not to lose all of the "
+"dwarf towns at once, or the enemy will have won."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:172
+msgid ""
+"You will face four allied enemies in a straightforward fight for resource "
+"and treasure. Capture all of the enemy castles for victory."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:173
+#: ../fheroes2/campaign/campaign_data.cpp:186
+msgid ""
+"Your enemies are allied against you and start close by, so be ready to come "
+"out fighting. You will need to own all four castles in this small valley to "
+"win."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:174
+msgid ""
+"The Sorceress' guild of Noraston has requested Roland's aid against an "
+"attack from Archibald's allies. Capture all of the enemy castles to win, and "
+"don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy "
+"castle on an island in the ocean.)"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:175
+#: ../fheroes2/campaign/campaign_data.cpp:191
+msgid ""
+"Gather as large an army as possible and capture the enemy castle within 8 "
+"weeks. You are opposed by only one enemy, but must travel a long way to get "
+"to the enemy castle. Any troops you have in your army at the end of this "
+"scenario will be with you in the final battle."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:176
+msgid ""
+"Find the Crown before Archibald's heroes find it. Roland will need the Crown "
+"for the final battle against Archibald."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:177
+msgid ""
+"Three allied enemies stand before you and victory, including Lord Corlagon. "
+"Roland is in a castle to the northwest, and you will lose if he falls to the "
+"enemy. Remember that capturing Lord Corlagon will ensure that he will not "
+"fight against you in the final scenario."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:178
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Archibald to end the war!"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:181
+msgid ""
+"King Archibald requires you to defeat the three enemies in this region.  "
+"They are not allied with one another, so they will spend most of their "
+"energy fighting amongst themselves.  You will win when you own all of the "
+"enemy castles and there are no more heroes left to fight."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:183
+msgid ""
+"You must unify the barbarian tribes of the north by conquering them. As in "
+"the previous mission, the enemy is not allied against you, but they have "
+"more resources at their disposal. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:184
+msgid ""
+"Do-gooder wizards have taken the Necromancers' castle. You must retake it to "
+"achieve victory. Remember that while you start with a powerful army, you "
+"have no castle and must take one within 7 days, or lose this battle. (Hint: "
+"The nearest castle is to the southeast.)"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:185
+msgid ""
+"The dwarves need conquering before they can interfere in King Archibald's "
+"plans. Roland's forces have more than one hero and many towns to start with, "
+"so be ready for attack from multiple directions. You must capture all of the "
+"enemy towns and castles to claim victory."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:187
+msgid ""
+"You must put down a peasant revolt led by Roland's forces. All are allied "
+"against you, but you have Lord Corlagon, an experienced hero, to help you. "
+"Capture all enemy castles to win."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:188
+msgid ""
+"There are two enemies allied against you in this mission. Both are well "
+"armed and seek to evict you from their island. Avoid them and capture Dragon "
+"City to win"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:189
+msgid ""
+"Your orders are to conquer the country lords that have sworn to serve "
+"Roland. All of the enemy castles are unified against you. Since you start "
+"without a castle, you must hurry to capture one before the end of the week. "
+"Capture all enemy castles for victory."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:190
+msgid ""
+"Find the Crown before Roland's heroes find it. Archibald will need the Crown "
+"for the final battle against Roland."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:192
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Roland to win the war, and be sure "
+"not to lose Archibald in the fight!"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:195
+msgid ""
+"Subdue the unruly local lords in order to provide the Empire with facilities "
+"to operate in this region."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:196
+msgid ""
+"Eliminate all oposition in this area. Then the first piece of the artifact "
+"will be yours."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:197
+msgid ""
+"The sorceresses to the northeast are rebelling! For the good of the empire "
+"you must quash their feeble uprising on your way to the mountains."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:198
+msgid ""
+"Having prepared for your arrival, Kraeger has arranged for a force of "
+"necromancers to thwart your quest. You must capture the castle of Scabsdale "
+"before the first day of the third week, or the Necromancers will be too "
+"strong for you."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:199
+msgid ""
+"The barbarian despot in this area is, as yet, ignorant of your presence. "
+"Quickly, build up your forces before you are discovered and attacked! Secure "
+"the region by subduing all enemy forces."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:200
+msgid ""
+"The Empire is weak in this region. You will be unable to completely subdue "
+"all forces in this area, so take what you can before reprisal strikes. "
+"Remember, your true goal is to claim the Helmet of Anduran."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:201
+msgid "For the good of the Empire, eliminate Kraeger."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:202
+msgid ""
+"At last, you have the opportunity and the facilities to rid the Empire of "
+"the necromancer's evil. Eradicate them completely, and you will be sung as a "
+"hero for all time."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:205
+msgid ""
+"Conquer and unite all the enemy tribes. Don't lose the hero Jarkonas, the "
+"forefather of all descendants."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:206
+msgid ""
+"Your rival, the Kingdom of Harondale, is attacking weak towns on your "
+"border! Recover from their first strike and crush them completely!"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:207
+msgid ""
+"Find your wayward son Joseph who is rumored to be living in the desolate "
+"lands. Do it before the first day of the third month or it will be of no "
+"help to your family."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:208
+msgid ""
+"Rescue your crazy uncle Ivan. Find him before the first day of the fourth "
+"month or it will be no help to your kingdom."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:209
+msgid ""
+"Destroy the barbarians who are attacking the southern border of your "
+"kingdom! Recover your fallen towns, and then invade the jungle kingdom. "
+"Leave no enemy standing."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:210
+msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:211
+msgid ""
+"Gain the favor of the elves. They will not allow trees to be chopped down, "
+"so they will send you wood every 2 weeks. You must complete your mission "
+"before the first day of the seventh month, or the kingdom will surely fall."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:212
+msgid ""
+"This is the final battle against your rival kingdom of Harondale. Eliminate "
+"everyone, and don't lose the hero Jarkonas VI."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:215
+msgid ""
+"Your mission is to vanquish the warring mages in the magical Shrouded Isles. "
+"The completion of this task will give you a fighting chance against your "
+"rivals."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:216
+msgid ""
+"The location of the great library has been dicovered! You must make your way "
+"to it, and reclaim the city of Chronos in which it lies."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:217
+msgid ""
+"Find the Orb of negation, which is said to be buried in this land. There are "
+"clues inscribed on stone obelisks which will help lead you to your price. "
+"Find the orb before the first day of the sixth month, or your rivals will "
+"surely have gotten to the fount before you."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:218
+msgid ""
+"You must take control of the castle of Magic, where the fount of wizardry "
+"lies. Do this and your victory will be supreme."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:221
+msgid ""
+"Capture the town on the island off the southeast shore in order to construct "
+"a boat and travel back towards the mainland. Do not lose the hero Gallavant."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:222
+msgid ""
+"Find and defeat Martine, the pirate leader, who resides in Pirates Cove. Do "
+"not lose Gallavant or your quest will be over."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:223
+msgid ""
+"Eliminate all the other forces who oppose the rule of Lord Alberon. "
+"Gallavant must not die."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:224
+msgid ""
+"Overthrow the entrenched monarchy of Lord Alberon, and claim all the land in "
+"your name. Gallavant must not die."
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:692
+msgid " bane"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:694
+msgid " alliance"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:698
+msgid "Carry-over forces"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:700
+msgid " bonus"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_data.cpp:706
+msgid " defeated"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_scenariodata.cpp:346
+msgid "Thunder Mace"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_scenariodata.cpp:348
+msgid "Minor Scroll"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_scenariodata.cpp:350
+msgid "Dragon Sword"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_scenariodata.cpp:352
+msgid "Breastplate"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_scenariodata.cpp:354
+msgid "Fibzin Medal"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_scenariodata.cpp:356
+msgid "Mage's ring"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_scenariodata.cpp:358
+msgid "Defender Helm"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_scenariodata.cpp:360
+msgid "Power Axe"
+msgstr ""
+
+#: ../fheroes2/campaign/campaign_scenariodata.cpp:370
+msgid "Summon Earth"
+msgstr ""
+
+#: ../fheroes2/castle/buildinginfo.cpp:279
 msgid "The %{building} produces %{monster}."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:505
+#: ../fheroes2/castle/buildinginfo.cpp:508
 msgid "Requires:"
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:597
+#: ../fheroes2/castle/buildinginfo.cpp:595
 msgid "Cannot build. Already built here this turn."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:601
+#: ../fheroes2/castle/buildinginfo.cpp:598
 msgid "For this action it is necessary first to build a castle."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:623
+#: ../fheroes2/castle/buildinginfo.cpp:618
 msgid "Cannot build %{name} because castle is too far from water."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:631
-msgid "Cannot afford %{name}"
+#: ../fheroes2/castle/buildinginfo.cpp:627
+msgid "Cannot afford %{name}."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:636
-msgid "%{name} is already built"
+#: ../fheroes2/castle/buildinginfo.cpp:632
+msgid "%{name} is already built."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:641
-msgid "Cannot build %{name}"
+#: ../fheroes2/castle/buildinginfo.cpp:637
+msgid "Cannot build %{name}."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:646
-msgid "Build %{name}"
+#: ../fheroes2/castle/buildinginfo.cpp:642
+msgid "Build %{name}."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:466
+#: ../fheroes2/castle/castle.cpp:656
 msgid "Thieves' Guild"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:466
+#: ../fheroes2/castle/castle.cpp:657
 msgid "Tavern"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:466
+#: ../fheroes2/castle/castle.cpp:658
 msgid "Shipyard"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:466
+#: ../fheroes2/castle/castle.cpp:659
 msgid "Well"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:466
+#: ../fheroes2/castle/castle.cpp:660
 msgid "Statue"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467
-#: ../fheroes2/dialog/dialog_marketplace.cpp:212
+#: ../fheroes2/castle/castle.cpp:663
+#: ../fheroes2/dialog/dialog_marketplace.cpp:310
 msgid "Marketplace"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467
+#: ../fheroes2/castle/castle.cpp:664
 msgid "Moat"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467 ../fheroes2/maps/mp2.cpp:391
+#: ../fheroes2/castle/castle.cpp:665 ../fheroes2/maps/mp2.cpp:288
 msgid "Castle"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467
+#: ../fheroes2/castle/castle.cpp:666
 msgid "Tent"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467
+#: ../fheroes2/castle/castle.cpp:667
 msgid "Captain's Quarters"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467
+#: ../fheroes2/castle/castle.cpp:668
 msgid "Mage Guild, Level 1"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:468
+#: ../fheroes2/castle/castle.cpp:669
 msgid "Mage Guild, Level 2"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:468
+#: ../fheroes2/castle/castle.cpp:670
 msgid "Mage Guild, Level 3"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:468
+#: ../fheroes2/castle/castle.cpp:671
 msgid "Mage Guild, Level 4"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:468
+#: ../fheroes2/castle/castle.cpp:672
 msgid "Mage Guild, Level 5"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
+#: ../fheroes2/castle/castle.cpp:675
 msgid "Farm"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
+#: ../fheroes2/castle/castle.cpp:675
 msgid "Garbage Heap"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
+#: ../fheroes2/castle/castle.cpp:675
 msgid "Crystal Garden"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
+#: ../fheroes2/castle/castle.cpp:675
 msgid "Waterfall"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
+#: ../fheroes2/castle/castle.cpp:675
 msgid "Orchard"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
+#: ../fheroes2/castle/castle.cpp:675
 msgid "Skull Pile"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
+#: ../fheroes2/castle/castle.cpp:677
 msgid "Fortifications"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
+#: ../fheroes2/castle/castle.cpp:677
 msgid "Coliseum"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
+#: ../fheroes2/castle/castle.cpp:677
 msgid "Rainbow"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
+#: ../fheroes2/castle/castle.cpp:677
 msgid "Dungeon"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
+#: ../fheroes2/castle/castle.cpp:677
 msgid "Library"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
+#: ../fheroes2/castle/castle.cpp:677
 msgid "Storm"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:498
+#: ../fheroes2/castle/castle.cpp:679 ../fheroes2/maps/mp2.cpp:462
 msgid "Thatched Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475
+#: ../fheroes2/castle/castle.cpp:679
 msgid "Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475
+#: ../fheroes2/castle/castle.cpp:679
 msgid "Treehouse"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:441
+#: ../fheroes2/castle/castle.cpp:679 ../fheroes2/maps/mp2.cpp:363
 msgid "Cave"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475
+#: ../fheroes2/castle/castle.cpp:679
 msgid "Habitat"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:431
+#: ../fheroes2/castle/castle.cpp:679 ../fheroes2/maps/mp2.cpp:348
 msgid "Excavation"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:477
+#: ../fheroes2/castle/castle.cpp:680 ../fheroes2/castle/castle.cpp:681
 msgid "Archery Range"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476
+#: ../fheroes2/castle/castle.cpp:680
 msgid "Stick Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476
+#: ../fheroes2/castle/castle.cpp:680
 msgid "Cottage"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
+#: ../fheroes2/castle/castle.cpp:680 ../fheroes2/castle/castle.cpp:689
 msgid "Crypt"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
+#: ../fheroes2/castle/castle.cpp:680 ../fheroes2/castle/castle.cpp:690
 msgid "Pen"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/maps/mp2.cpp:371
+#: ../fheroes2/castle/castle.cpp:680 ../fheroes2/maps/mp2.cpp:258
 msgid "Graveyard"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477
+#: ../fheroes2/castle/castle.cpp:681
 msgid "Blacksmith"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
+#: ../fheroes2/castle/castle.cpp:681 ../fheroes2/castle/castle.cpp:693
 msgid "Den"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
+#: ../fheroes2/castle/castle.cpp:681 ../fheroes2/castle/castle.cpp:695
 msgid "Nest"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477
+#: ../fheroes2/castle/castle.cpp:681
 msgid "Foundry"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:480
-#: ../fheroes2/castle/castle.cpp:487 ../fheroes2/maps/mp2.cpp:427
-#: ../fheroes2/resource/maps_text.cpp:521
+#: ../fheroes2/castle/castle.cpp:681 ../fheroes2/castle/castle.cpp:684
+#: ../fheroes2/castle/castle.cpp:711 ../fheroes2/maps/mp2.cpp:342
 msgid "Pyramid"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
+#: ../fheroes2/castle/castle.cpp:682
 msgid "Armory"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
+#: ../fheroes2/castle/castle.cpp:682
 msgid "Adobe"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
+#: ../fheroes2/castle/castle.cpp:682
 msgid "Stonehenge"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
+#: ../fheroes2/castle/castle.cpp:682
 msgid "Maze"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478 ../fheroes2/castle/castle.cpp:485
+#: ../fheroes2/castle/castle.cpp:682 ../fheroes2/castle/castle.cpp:702
 msgid "Cliff Nest"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
+#: ../fheroes2/castle/castle.cpp:682
 msgid "Mansion"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479
+#: ../fheroes2/castle/castle.cpp:683
 msgid "Jousting Arena"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479
+#: ../fheroes2/castle/castle.cpp:683
 msgid "Bridge"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
+#: ../fheroes2/castle/castle.cpp:683 ../fheroes2/castle/castle.cpp:706
 msgid "Fenced Meadow"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
+#: ../fheroes2/castle/castle.cpp:683 ../fheroes2/castle/castle.cpp:707
 #: ../fheroes2/maps/ground.cpp:30
 msgid "Swamp"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479
+#: ../fheroes2/castle/castle.cpp:683
 msgid "Ivory Tower"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479
+#: ../fheroes2/castle/castle.cpp:683
 msgid "Mausoleum"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480
+#: ../fheroes2/castle/castle.cpp:684
 msgid "Cathedral"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
+#: ../fheroes2/castle/castle.cpp:684 ../fheroes2/castle/castle.cpp:712
+#: ../fheroes2/castle/castle.cpp:713
 msgid "Red Tower"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480
+#: ../fheroes2/castle/castle.cpp:684
 msgid "Green Tower"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480
+#: ../fheroes2/castle/castle.cpp:684
 msgid "Cloud Castle"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
+#: ../fheroes2/castle/castle.cpp:684 ../fheroes2/castle/castle.cpp:715
 msgid "Laboratory"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:483 ../fheroes2/castle/castle.cpp:484
+#: ../fheroes2/castle/castle.cpp:686 ../fheroes2/castle/castle.cpp:694
 msgid "Upg. Archery Range"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:483
+#: ../fheroes2/castle/castle.cpp:687
 msgid "Upg. Stick Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:483
+#: ../fheroes2/castle/castle.cpp:688
 msgid "Upg. Cottage"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:483
+#: ../fheroes2/castle/castle.cpp:691
 msgid "Upg. Graveyard"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:484
+#: ../fheroes2/castle/castle.cpp:692
 msgid "Upg. Blacksmith"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:484
+#: ../fheroes2/castle/castle.cpp:696
 msgid "Upg. Foundry"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:484
+#: ../fheroes2/castle/castle.cpp:697
 msgid "Upg. Pyramid"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
+#: ../fheroes2/castle/castle.cpp:698
 msgid "Upg. Armory"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
+#: ../fheroes2/castle/castle.cpp:699
 msgid "Upg. Adobe"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
+#: ../fheroes2/castle/castle.cpp:700
 msgid "Upg. Stonehenge"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
+#: ../fheroes2/castle/castle.cpp:701
 msgid "Upg. Maze"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
+#: ../fheroes2/castle/castle.cpp:703
 msgid "Upg. Mansion"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:486
+#: ../fheroes2/castle/castle.cpp:704
 msgid "Upg. Jousting Arena"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:486
+#: ../fheroes2/castle/castle.cpp:705
 msgid "Upg. Bridge"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:486
+#: ../fheroes2/castle/castle.cpp:708
 msgid "Upg. Ivory Tower"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:486
+#: ../fheroes2/castle/castle.cpp:709
 msgid "Upg. Mausoleum"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:487
+#: ../fheroes2/castle/castle.cpp:710
 msgid "Upg. Cathedral"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:487
+#: ../fheroes2/castle/castle.cpp:714
 msgid "Upg. Cloud Castle"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:488
+#: ../fheroes2/castle/castle.cpp:719
 msgid "Black Tower"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:490
+#: ../fheroes2/castle/castle.cpp:723
 msgid "Shrine"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:552
+#: ../fheroes2/castle/castle.cpp:829
 msgid ""
 "The Thieves' Guild provides information on enemy players. Thieves' Guilds "
-"can also provide scouting information on enemy towns."
+"can also provide scouting information on enemy towns. Additional Guilds "
+"provide more information."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:553
+#: ../fheroes2/castle/castle.cpp:830
 msgid "The Tavern increases morale for troops defending the castle."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:554
+#: ../fheroes2/castle/castle.cpp:831
 msgid "The Shipyard allows ships to be built."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:555
+#: ../fheroes2/castle/castle.cpp:832
 msgid ""
 "The Well increases the growth rate of all dwellings by %{count} creatures "
 "per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:556
+#: ../fheroes2/castle/castle.cpp:833
 msgid "The Statue increases your town's income by %{count} per day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:557
+#: ../fheroes2/castle/castle.cpp:834
 msgid "The Left Turret provides extra firepower during castle combat."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:558
+#: ../fheroes2/castle/castle.cpp:835
 msgid "The Right Turret provides extra firepower during castle combat."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:559
+#: ../fheroes2/castle/castle.cpp:836
 msgid ""
 "The Marketplace can be used to convert one type of resource into another. "
 "The more marketplaces you control, the better the exchange rate."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:560
+#: ../fheroes2/castle/castle.cpp:837
 msgid ""
 "The Moat slows attacking units. Any unit entering the moat must end its turn "
 "there and becomes more vulnerable to attack."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:561
+#: ../fheroes2/castle/castle.cpp:838
 msgid ""
 "The Castle improves town defense and increases income to %{count} gold per "
 "day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:562
+#: ../fheroes2/castle/castle.cpp:839
 msgid ""
 "The Tent provides workers to build a castle, provided the materials and the "
 "gold are available."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:563
+#: ../fheroes2/castle/castle.cpp:840
 msgid ""
 "The Captain's Quarters provides a captain to assist in the castle's defense "
 "when no hero is present."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:564
+#: ../fheroes2/castle/castle.cpp:841
 msgid ""
 "The Mage Guild allows heroes to learn spells and replenish their spell "
 "points."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:567
+#: ../fheroes2/castle/castle.cpp:844
 msgid "The Farm increases production of Peasants by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:568
+#: ../fheroes2/castle/castle.cpp:845
 msgid "The Garbage Heap increases production of Goblins by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:569
+#: ../fheroes2/castle/castle.cpp:846
 msgid ""
 "The Crystal Garden increases production of Sprites by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:570
+#: ../fheroes2/castle/castle.cpp:847
 msgid "The Waterfall increases production of Centaurs by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:571
+#: ../fheroes2/castle/castle.cpp:848
 msgid "The Orchard increases production of Halflings by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:572
+#: ../fheroes2/castle/castle.cpp:849
 msgid "The Skull Pile increases production of Skeletons by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:575
+#: ../fheroes2/castle/castle.cpp:851
 msgid ""
 "The Fortifications increase the toughness of the walls, increasing the "
 "number of turns it takes to knock them down."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:576
+#: ../fheroes2/castle/castle.cpp:852
 msgid ""
 "The Coliseum provides inspiring spectacles to defending troops, raising "
 "their morale by two during combat."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:577
+#: ../fheroes2/castle/castle.cpp:853
 msgid "The Rainbow increases the luck of the defending units by two."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:578
+#: ../fheroes2/castle/castle.cpp:854
 msgid "The Dungeon increases the income of the town by %{count} / day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:579
+#: ../fheroes2/castle/castle.cpp:855
 msgid ""
 "The Library increases the number of spells in the Guild by one for each "
 "level of the guild."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:580
+#: ../fheroes2/castle/castle.cpp:856
 msgid "The Storm adds +2 to the power of spells of a defending spell caster."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:582
+#: ../fheroes2/castle/castle.cpp:858
 msgid ""
 "The Shrine increases the necromancy skill of all your necromancers by 10 "
 "percent."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:632
+#: ../fheroes2/castle/castle.cpp:936
 msgid "Cannot recruit - you already recruit hero in current week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:645
+#: ../fheroes2/castle/castle.cpp:947
 msgid "Cannot recruit - guest to guard automove error."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:651
+#: ../fheroes2/castle/castle.cpp:953
 msgid "Cannot recruit - you already have a Hero in this town."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:659
+#: ../fheroes2/castle/castle.cpp:960
 msgid "Cannot recruit - you have too many Heroes."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:665
+#: ../fheroes2/castle/castle.cpp:966
 msgid "Cannot afford a Hero"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:756
+#: ../fheroes2/castle/castle.cpp:1073
 msgid "There is no room in the garrison for this army."
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:272
+#: ../fheroes2/castle/castle.cpp:2921 ../fheroes2/dialog/dialog_recrut.cpp:82
+msgid "Recruit %{name}"
+msgstr ""
+
+#: ../fheroes2/castle/castle_dialog.cpp:133
 msgid "Month: %{month}, Week: %{week}, Day: %{day}"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:393
-#: ../fheroes2/castle/castle_dialog.cpp:396
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:388
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:186
-msgid "Income:"
+#: ../fheroes2/castle/castle_dialog.cpp:261
+#: ../fheroes2/castle/castle_dialog.cpp:264
+#: ../fheroes2/castle/castle_town.cpp:430
+#: ../fheroes2/castle/castle_town.cpp:433
+#: ../fheroes2/dialog/dialog_marketplace.cpp:452
+#: ../fheroes2/kingdom/kingdom_overview.cpp:679
+#: ../fheroes2/kingdom/kingdom_overview.cpp:681
+msgid "Income"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
+#: ../fheroes2/castle/castle_dialog.cpp:296
 msgid "Join Error"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
+#: ../fheroes2/castle/castle_dialog.cpp:296
 msgid "Army is full"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
+#: ../fheroes2/castle/castle_dialog.cpp:424 ../fheroes2/heroes/heroes.cpp:978
+msgid ""
+"You must purchase a spell book to use the mage guild, but you currently have "
+"no room for a spell book. Try giving one of your artifacts to another hero."
+msgstr ""
+
+#: ../fheroes2/castle/castle_dialog.cpp:493
 msgid "Town"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
+#: ../fheroes2/castle/castle_dialog.cpp:493
 msgid "This town may not be upgraded to a castle."
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit castle"
+#: ../fheroes2/castle/castle_dialog.cpp:592
+msgid "Exit Castle"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit town"
+#: ../fheroes2/castle/castle_dialog.cpp:592
+msgid "Exit Town"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:730
-msgid "Show income"
+#: ../fheroes2/castle/castle_dialog.cpp:594
+#: ../fheroes2/castle/castle_town.cpp:586
+msgid "Show Income"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:734
+#: ../fheroes2/castle/castle_dialog.cpp:598
 msgid "Show previous town"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:738
+#: ../fheroes2/castle/castle_dialog.cpp:602
 msgid "Show next town"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:741
+#: ../fheroes2/castle/castle_dialog.cpp:604
 msgid "Swap Heroes"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:744
+#: ../fheroes2/castle/castle_dialog.cpp:606
 msgid "Meeting Heroes"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:749
+#: ../fheroes2/castle/castle_dialog.cpp:610
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:623
+#: ../fheroes2/dialog/dialog_levelup.cpp:218
 msgid "View Hero"
 msgstr ""
 
-#: ../fheroes2/castle/castle_mageguild.cpp:150
+#: ../fheroes2/castle/castle_mageguild.cpp:160
+msgid "The above spells are available here."
+msgstr ""
+
+#: ../fheroes2/castle/castle_mageguild.cpp:162
 msgid "The above spells have been added to your book."
 msgstr ""
 
-#: ../fheroes2/castle/castle_tavern.cpp:39
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:748
+#: ../fheroes2/castle/castle_tavern.cpp:38
 msgid "A generous tip for the barkeep yields the following rumor:"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:54
+#: ../fheroes2/castle/castle_town.cpp:58
 msgid "Recruit Hero"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:59
-msgid "%{name} is a level %{value} %{race}"
+#: ../fheroes2/castle/castle_town.cpp:64
+msgid "%{name} is a level %{value} %{race} "
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with %{count} artifacts"
+#: ../fheroes2/castle/castle_town.cpp:67
+msgid "with %{count} artifacts."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with one artifact"
+#: ../fheroes2/castle/castle_town.cpp:67
+msgid "with 1 artifact."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:283
-#: ../fheroes2/heroes/heroes_dialog.cpp:108
+#: ../fheroes2/castle/castle_town.cpp:70
+msgid "without artifacts."
+msgstr ""
+
+#: ../fheroes2/castle/castle_town.cpp:296
+#: ../fheroes2/heroes/heroes_dialog.cpp:109
 msgid ""
 "'Spread' combat formation spreads your armies from the top to the bottom of "
 "the battlefield, with at least one empty space between each army."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:284
+#: ../fheroes2/castle/castle_town.cpp:297
 msgid ""
 "'Grouped' combat formation bunches your army toget her in the center of your "
 "side of the battlefield."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:292
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:132
-#: ../fheroes2/heroes/heroes_meeting.cpp:284
+#: ../fheroes2/castle/castle_town.cpp:304
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:236
+#: ../fheroes2/dialog/dialog_skillinfo.cpp:136
+#: ../fheroes2/gui/skill_bar.cpp:285 ../fheroes2/heroes/skill.cpp:148
 msgid "Attack Skill"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:301
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:137
-#: ../fheroes2/heroes/heroes_meeting.cpp:288
+#: ../fheroes2/castle/castle_town.cpp:313
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:249
+#: ../fheroes2/dialog/dialog_skillinfo.cpp:141
+#: ../fheroes2/gui/skill_bar.cpp:289 ../fheroes2/heroes/skill.cpp:148
 msgid "Defense Skill"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:487
-#: ../fheroes2/heroes/heroes_dialog.cpp:334
+#: ../fheroes2/castle/castle_town.cpp:508
+#: ../fheroes2/heroes/heroes_dialog.cpp:325
 msgid "Spread Formation"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:489
-#: ../fheroes2/heroes/heroes_dialog.cpp:337
+#: ../fheroes2/castle/castle_town.cpp:510
+#: ../fheroes2/heroes/heroes_dialog.cpp:327
 msgid "Grouped Formation"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:540
-#: ../fheroes2/castle/castle_town.cpp:553
+#: ../fheroes2/castle/castle_town.cpp:563
+#: ../fheroes2/castle/castle_town.cpp:573
 msgid "Recruit %{name} the %{race}"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:561
+#: ../fheroes2/castle/castle_town.cpp:580
 msgid "Set garrison combat formation to 'Spread'"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:564
+#: ../fheroes2/castle/castle_town.cpp:582
 msgid "Set garrison combat formation to 'Grouped'"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:567
+#: ../fheroes2/castle/castle_town.cpp:584
+msgid "Exit Castle Options"
+msgstr ""
+
+#: ../fheroes2/castle/castle_town.cpp:589
 msgid "Castle Options"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:158
-msgid "Buy Monsters:"
+#: ../fheroes2/castle/castle_well.cpp:163
+msgid "Not enough resources to buy monsters."
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:221
+#: ../fheroes2/castle/castle_well.cpp:166
+msgid "No monsters available for purchase."
+msgstr ""
+
+#: ../fheroes2/castle/castle_well.cpp:169
+msgid "Buy Monsters"
+msgstr ""
+
+#: ../fheroes2/castle/castle_well.cpp:214
 msgid "Town Population Information and Statistics"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:323
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:231
+#: ../fheroes2/castle/castle_well.cpp:311
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:273
 msgid "Damage"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:329
+#: ../fheroes2/castle/castle_well.cpp:317
 msgid "HP"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:335
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:266
-msgid "Speed"
-msgstr ""
-
-#: ../fheroes2/castle/castle_well.cpp:351
+#: ../fheroes2/castle/castle_well.cpp:339
 msgid "Growth"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:355
+#: ../fheroes2/castle/castle_well.cpp:343
 msgid "week"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:361
-#: ../fheroes2/kingdom/kingdom_overview.cpp:479
+#: ../fheroes2/castle/castle_well.cpp:349
+#: ../fheroes2/kingdom/kingdom_overview.cpp:481
 msgid "Available"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:89
+#: ../fheroes2/dialog/dialog_adventure.cpp:104
 msgid "View the entire world."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:90
+#: ../fheroes2/dialog/dialog_adventure.cpp:106
 msgid "View the obelisk puzzle."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:91
+#: ../fheroes2/dialog/dialog_adventure.cpp:108
 msgid "View information on the scenario you are currently playing."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:92
+#: ../fheroes2/dialog/dialog_adventure.cpp:110
 msgid "Dig for the Ultimate Artifact."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:93
+#: ../fheroes2/dialog/dialog_adventure.cpp:112
+#: ../fheroes2/dialog/dialog_file.cpp:119
 msgid "Exit this menu without doing anything."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_arena.cpp:48
+#: ../fheroes2/dialog/dialog_arena.cpp:48 ../fheroes2/maps/mp2.cpp:546
+msgid "Arena"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_arena.cpp:51
 msgid ""
 "You enter the arena and face a pack of vicious lions. You handily defeat "
 "them, to the wild cheers of the crowd.  Impressed by your skill, the aged "
 "trainer of gladiators agrees to train you in a skill of your choice."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:154
-msgid ""
-"Your troops can be upgraded, but it will cost you %{ratio} times the "
-"difference in cost for each troop, rounded up to next highest number. Do you "
-"wish to upgrade them?"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:155
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:178
 msgid ""
 "Your troops can be upgraded, but it will cost you dearly. Do you wish to "
 "upgrade them?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:166
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:188
 msgid "Are you sure you want to dismiss this army?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:260
 msgid "Shots Left"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:260
 msgid "Shots"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:244
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:286
 msgid "Hit Points"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:255
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:296
 msgid "Hit Points Left"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:376
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:549
+msgid "Followers"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:551
 msgid ""
 "A group of %{monster} with a desire for greater glory wish to join you.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:456
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:641
 msgid ""
-"The creature is swayed by your diplomatic tongue, and offers to join your "
+"The %{monster} is swayed by your diplomatic tongue, and offers to join your "
 "army for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:459
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:644
 msgid ""
 "The creatures are swayed by your diplomatic\n"
 "tongue, and make you an offer:\n"
 " \n"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:462
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:647
 msgid ""
 "%{offer} of the %{total} %{monster} will join your army, and the rest will "
 "leave you alone, for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:464
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:649
 msgid ""
 "All %{offer} of the %{monster} will join your army for the sum of %{gold} "
 "gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:478
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:663
 msgid "(Rate: %{percent})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:528
-msgid ""
-"Not room in\n"
-"the garrison"
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:745
+msgid "No room in"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:48
+#: ../fheroes2/dialog/dialog_armyinfo.cpp:748
+msgid "the garrison"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_buyboat.cpp:46
 msgid "Build a new ship:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:63
+#: ../fheroes2/dialog/dialog_buyboat.cpp:59
 msgid "Resource cost:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:40
-msgid "For the QVGA version is not available."
+#: ../fheroes2/dialog/dialog_file.cpp:85 ../fheroes2/dialog/dialog_file.cpp:110
+#: ../fheroes2/game/game_loadgame.cpp:97 ../fheroes2/game/game_loadgame.cpp:122
+#: ../fheroes2/game/game_loadgame.cpp:192
+#: ../fheroes2/game/game_loadgame.cpp:200
+#: ../fheroes2/game/game_mainmenu.cpp:311
+msgid "Load Game"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:62
+#: ../fheroes2/dialog/dialog_file.cpp:85 ../fheroes2/game/game_loadgame.cpp:97
+#: ../fheroes2/game/game_loadgame.cpp:122
+#: ../fheroes2/game/game_loadgame.cpp:192
+#: ../fheroes2/game/game_loadgame.cpp:200
+msgid "No save files to load."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_file.cpp:107
+#: ../fheroes2/game/game_mainmenu.cpp:317
+msgid "New Game"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_file.cpp:107
+#: ../fheroes2/game/game_mainmenu.cpp:317
+msgid "Start a single or multi-player game."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_file.cpp:110
+#: ../fheroes2/game/game_mainmenu.cpp:311
+msgid "Load a previously saved game."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_file.cpp:113
+msgid "Save Game"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_file.cpp:113
+msgid "Save the current game."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_file.cpp:116
+#: ../fheroes2/game/game_mainmenu.cpp:309
+msgid "Quit"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_file.cpp:116
+msgid "Quit out of Free Heroes of Might and Magic II."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_gameinfo.cpp:56
 msgid ""
 "Map\n"
 "Difficulty"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:65
+#: ../fheroes2/dialog/dialog_gameinfo.cpp:59
 msgid ""
 "Game\n"
 "Difficulty"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:68
+#: ../fheroes2/dialog/dialog_gameinfo.cpp:62
 msgid "Rating"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:71
+#: ../fheroes2/dialog/dialog_gameinfo.cpp:65
 msgid "Map Size"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:89
-#: ../fheroes2/system/players.cpp:691
+#: ../fheroes2/dialog/dialog_gameinfo.cpp:83
+#: ../fheroes2/gui/player_info.cpp:296
 msgid "Opponents"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:92
-#: ../fheroes2/system/players.cpp:695
+#: ../fheroes2/dialog/dialog_gameinfo.cpp:86
+#: ../fheroes2/gui/player_info.cpp:302
 msgid "Class"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:100
+#: ../fheroes2/dialog/dialog_gameinfo.cpp:94
 msgid ""
 "Victory\n"
 "Conditions"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:106
+#: ../fheroes2/dialog/dialog_gameinfo.cpp:100
 msgid ""
 "Loss\n"
 "Conditions"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:167
+#: ../fheroes2/dialog/dialog_giftresources.cpp:176
 msgid "You cannot select %{resource}!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:173
+#: ../fheroes2/dialog/dialog_giftresources.cpp:181
 msgid "Select count %{resource}:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:200
+#: ../fheroes2/dialog/dialog_guardian.cpp:202
 msgid "Set Guardian"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:236
-#: ../fheroes2/dialog/dialog_guardian.cpp:292
+#: ../fheroes2/dialog/dialog_guardian.cpp:233
+#: ../fheroes2/dialog/dialog_guardian.cpp:277
 msgid "Your army too big!"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_levelup.cpp:34
-#: ../fheroes2/dialog/dialog_levelup.cpp:44
-#: ../fheroes2/dialog/dialog_levelup.cpp:73
-msgid "%{name} has gained a level."
 msgstr ""
 
 #: ../fheroes2/dialog/dialog_levelup.cpp:36
 #: ../fheroes2/dialog/dialog_levelup.cpp:46
-#: ../fheroes2/dialog/dialog_levelup.cpp:75
-msgid "%{skill} Skill +1"
+#: ../fheroes2/dialog/dialog_levelup.cpp:77
+msgid "%{name} has gained a level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:51
+#: ../fheroes2/dialog/dialog_levelup.cpp:38
+#: ../fheroes2/dialog/dialog_levelup.cpp:48
+#: ../fheroes2/dialog/dialog_levelup.cpp:79
+msgid "%{skill} +1"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_levelup.cpp:53
 msgid "You have learned %{skill}."
 msgstr ""
 
@@ -1527,905 +2196,1107 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:66
+#: ../fheroes2/dialog/dialog_marketplace.cpp:155
 msgid ""
 "Please inspect our fine wares. If you feel like offering a trade, click on "
 "the items you wish to trade with and for."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:104
+#: ../fheroes2/dialog/dialog_marketplace.cpp:205
 msgid ""
 "You have received quite a bargain. I expect to make no profit on the deal. "
 "Can I interest you in any of my other wares?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:130
+#: ../fheroes2/dialog/dialog_marketplace.cpp:229
 msgid "I can offer you %{count} for 1 unit of %{resfrom}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:136
+#: ../fheroes2/dialog/dialog_marketplace.cpp:234
 msgid "I can offer you 1 unit of %{resto} for %{count} units of %{resfrom}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:164
+#: ../fheroes2/dialog/dialog_marketplace.cpp:262
 msgid "Qty to trade"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:235
+#: ../fheroes2/dialog/dialog_marketplace.cpp:310 ../fheroes2/maps/mp2.cpp:318
+msgid "Trading Post"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_marketplace.cpp:329
 msgid "Your Resources"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:257
+#: ../fheroes2/dialog/dialog_marketplace.cpp:351
 msgid "Available Trades"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:573
+#: ../fheroes2/dialog/dialog_marketplace.cpp:629
 msgid "n/a"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:77
-msgid "guarded by %{count} of %{monster}"
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:93
+msgid "guarded by %{count} %{monster}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:149
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:186
 msgid "(available: %{count})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:181
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:228
 msgid "already learned"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:205
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:251
 msgid "already knows this skill"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:212
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:256
 msgid "already has max skills"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:260
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:276
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:270
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:281
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:293
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:307
 msgid "(already visited)"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:270
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:281
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:293
 msgid "(not visited)"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:296
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:322
+msgid "Road"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:331
+msgid "(digging ok)"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:334
+msgid "(no digging)"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:341
 msgid "penalty: %{cost}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:382
-msgid "Unchartered Territory"
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:500
+msgid "Uncharted Territory"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:635
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:755
 msgid "Defenders:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:674
-#: ../fheroes2/heroes/heroes_indicator.cpp:125
-#: ../fheroes2/heroes/heroes_indicator.cpp:171
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:765
+#: ../fheroes2/heroes/heroes_indicator.cpp:109
+#: ../fheroes2/heroes/heroes_indicator.cpp:152
 msgid "None"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:756
-msgid "%{name} ( Level %{level} )"
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:779
+msgid "Unknown"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:884
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:826
+msgid "%{name} (Level %{level})"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_quickinfo.cpp:964
 msgid "Move Points"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:40
-#: ../fheroes2/dialog/dialog_recrut.cpp:579
+#: ../fheroes2/dialog/dialog_recrut.cpp:168
 msgid "Available: %{count}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:101
-msgid "Cost per troop:"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:107
-#: ../fheroes2/dialog/dialog_recrut.cpp:506
-msgid "Recruit %{name}"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:210
+#: ../fheroes2/dialog/dialog_recrut.cpp:182
 msgid "Number to buy:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:314
+#: ../fheroes2/dialog/dialog_selectcount.cpp:330
 msgid "How many troops to move?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:358
+#: ../fheroes2/dialog/dialog_selectcount.cpp:355
 msgid "Fast separation into slots:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:180
+#: ../fheroes2/dialog/dialog_selectfile.cpp:208
 msgid "File to Save:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:186
+#: ../fheroes2/dialog/dialog_selectfile.cpp:214
 msgid "File to Load:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:302
+#: ../fheroes2/dialog/dialog_selectfile.cpp:333
 msgid "Are you sure you want to delete file:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:305
+#: ../fheroes2/dialog/dialog_selectfile.cpp:336
 msgid "Warning!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:144
-msgid "Maps Difficulty:"
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:149
+msgid "Map difficulty:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:295
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:307
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:319
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:331
+msgid "No maps exist at that size"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:350
 msgid "Small Maps"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
-msgid "View only maps of size small (36x36)."
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:350
+msgid "View only maps of size small (36 x 36)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:352
 msgid "Medium Maps"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
-msgid "View only maps of size medium (72x72)."
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:352
+msgid "View only maps of size medium (72 x 72)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:354
 msgid "Large Maps"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
-msgid "View only maps of size large (108x108)."
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:354
+msgid "View only maps of size large (108 x 108)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:356
 msgid "Extra Large Maps"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
-msgid "View only maps of size extra large (144x144)."
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:356
+msgid "View only maps of size extra large (144 x 144)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:358
 msgid "All Maps"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:358
 msgid "View all maps, regardless of size."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:360
 msgid "Players Icon"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:361
 msgid ""
-"Indicates how many players total are in the EditScenario. Any positions not "
+"Indicates how many players total are in the scenario. Any positions not "
 "occupied by humans will be occupied by computer players."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:364
 msgid "Size Icon"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
-msgid ""
-"Indicates whether the maps is small (36x36), medium (72x72), large "
-"(108x108), or extra large (144x144)."
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
-msgid "Selected Name"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
-msgid "The name of the currently selected map."
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
-msgid "Selected Map Difficulty"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
-msgid ""
-"The map difficulty of the currently selected map.  The map difficulty is "
-"determined by the EditScenario designer. More difficult maps might include "
-"more or stronger enemies, fewer resources, or other special conditions "
-"making things tougher for the human player."
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
-msgid "Selected Description"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
-msgid "The description of the currently selected map."
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
-msgid "OK"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
-msgid "Accept the choice made."
-msgstr ""
-
 #: ../fheroes2/dialog/dialog_selectscenario.cpp:364
-#: ../fheroes2/game/game_over.cpp:38
-msgid "Lose all your heroes and towns."
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:365
-#: ../fheroes2/game/game_over.cpp:38
-msgid "Lose a specific town."
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:366
-#: ../fheroes2/game/game_over.cpp:38
-msgid "Lose a specific hero."
+msgid ""
+"Indicates whether the map\n"
+"is small (36 x 36), medium\n"
+"(72 x 72), large (108 x 108),\n"
+"or extra large (144 x 144)."
 msgstr ""
 
 #: ../fheroes2/dialog/dialog_selectscenario.cpp:367
-msgid "Run out of time. Fail to win by a certain point."
+msgid "Selected Name"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:370
-msgid "Loss Condition"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:379
-msgid "Defeat all enemy heroes and towns."
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:380
-#: ../fheroes2/game/game_over.cpp:37
-msgid "Capture a specific town."
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:381
-#: ../fheroes2/game/game_over.cpp:37
-msgid "Defeat a specific hero."
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:382
-#: ../fheroes2/game/game_over.cpp:37
-msgid "Find a specific artifact."
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:383
-#: ../fheroes2/game/game_over.cpp:37
-msgid "Your side defeats the opposing side."
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:367
+msgid "The name of the currently selected map."
 msgstr ""
 
 #: ../fheroes2/dialog/dialog_selectscenario.cpp:384
-#: ../fheroes2/game/game_over.cpp:37
+msgid "Selected Map Difficulty"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:385
+msgid ""
+"The map difficulty of the currently selected map.  The map difficulty is "
+"determined by the scenario designer. More difficult maps might include more "
+"or stronger enemies, fewer resources, or other special conditions making "
+"things tougher for the human player."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:388
+msgid "Selected Description"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:388
+msgid "The description of the currently selected map."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:390
+msgid "Okay"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:390
+msgid "Accept the choice made."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:415
+#: ../fheroes2/game/game_over.cpp:49
+msgid "Lose all your heroes and towns."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:418
+#: ../fheroes2/game/game_over.cpp:50
+msgid "Lose a specific town."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:421
+#: ../fheroes2/game/game_over.cpp:51
+msgid "Lose a specific hero."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:424
+msgid "Run out of time. Fail to win by a certain point."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:429
+msgid "Loss Condition"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:438
+msgid "Defeat all enemy heroes and towns."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:441
+#: ../fheroes2/game/game_over.cpp:44
+msgid "Capture a specific town."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:444
+#: ../fheroes2/game/game_over.cpp:45
+msgid "Defeat a specific hero."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:447
+#: ../fheroes2/game/game_over.cpp:46
+msgid "Find a specific artifact."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:450
+#: ../fheroes2/game/game_over.cpp:47
+msgid "Your side defeats the opposing side."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:453
+#: ../fheroes2/game/game_over.cpp:48
 msgid "Accumulate a large amount of gold."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:387
+#: ../fheroes2/dialog/dialog_selectscenario.cpp:458
 msgid "Victory Condition"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:48
-#: ../fheroes2/heroes/heroes_action.cpp:134
+#: ../fheroes2/dialog/dialog_spellinfo.cpp:52
+#: ../fheroes2/heroes/heroes_action.cpp:150
 msgid "one"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:51
-#: ../fheroes2/heroes/heroes_action.cpp:135
+#: ../fheroes2/dialog/dialog_spellinfo.cpp:54
+#: ../fheroes2/heroes/heroes_action.cpp:153
 msgid "two"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:187
-msgid "sound"
+#: ../fheroes2/dialog/dialog_system.cpp:209
+#: ../fheroes2/dialog/dialog_system.cpp:259
+msgid "Music"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:192
-#: ../fheroes2/dialog/dialog_system.cpp:205
-#: ../fheroes2/dialog/dialog_system.cpp:228
-#: ../fheroes2/dialog/dialog_system.cpp:242
-msgid "off"
+#: ../fheroes2/dialog/dialog_system.cpp:209
+msgid "Toggle ambient music level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:200
-msgid "music"
+#: ../fheroes2/dialog/dialog_system.cpp:211
+#: ../fheroes2/dialog/dialog_system.cpp:274
+msgid "Effects"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:211
+msgid "Toggle foreground sounds level."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:213
+#: ../fheroes2/dialog/dialog_system.cpp:290
+msgid "Music Type"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:213
+msgid "Change the type of music."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:215
+#: ../fheroes2/dialog/dialog_system.cpp:315
+msgid "Hero Speed"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:215
+msgid "Change the speed at which your heroes move on the main screen."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:217
+#: ../fheroes2/dialog/dialog_system.cpp:335
+msgid "Enemy Speed"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:217
+msgid ""
+"Sets the speed that A.I. heroes move at.  You can also elect not to view A."
+"I. movement at all."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:219
+#: ../fheroes2/dialog/dialog_system.cpp:357
+msgid "Scroll Speed"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:219
+msgid "Sets the speed at which you scroll the window."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:221
+#: ../fheroes2/dialog/dialog_system.cpp:371
+msgid "Interface Type"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:221
+msgid "Toggle the type of interface you want to use."
 msgstr ""
 
 #: ../fheroes2/dialog/dialog_system.cpp:223
-msgid "hero speed"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_system.cpp:237
-msgid "ai speed"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_system.cpp:251
-msgid "scroll speed"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_system.cpp:262
-#: ../fheroes2/dialog/dialog_system.cpp:276
+#: ../fheroes2/dialog/dialog_system.cpp:386
 msgid "Interface"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:265
+#: ../fheroes2/dialog/dialog_system.cpp:223
+msgid "Toggle interface visibility."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:225
+#: ../fheroes2/dialog/dialog_system.cpp:404
+msgid "Battles"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:225
+msgid "Toggle instant battle mode."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:227
+#: ../fheroes2/game/game_scenarioinfo.cpp:304
+msgid "OK"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:227
+msgid "Exit this menu."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:266
+#: ../fheroes2/dialog/dialog_system.cpp:281
+msgid "off"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:295
+msgid "MIDI"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:298
+msgid "MIDI Expansion"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:301
+msgid "CD Stereo"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:304
+msgid "External"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:320
+#: ../fheroes2/dialog/dialog_system.cpp:343
+msgid "Jump"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:340
+msgid "Don't Show"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:376
 msgid "Evil"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:267
+#: ../fheroes2/dialog/dialog_system.cpp:378
 msgid "Good"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:281
+#: ../fheroes2/dialog/dialog_system.cpp:392
 msgid "Hide"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:287
+#: ../fheroes2/dialog/dialog_system.cpp:397
 msgid "Show"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:286
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:96
+#: ../fheroes2/dialog/dialog_system.cpp:410
+msgid "Auto Resolve"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:410
+msgid "Auto, No Spells"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_system.cpp:416
+msgid "Manual"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:243
+msgid "Att."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:247
+msgid "Def."
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:251
+msgid "Power"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:255
+msgid "Knowl"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:266
+msgid "Human"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:312
 msgid "1st"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:97
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:315
 msgid "2nd"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:288
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:98
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:318
 msgid "3rd"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:289
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:99
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:321
 msgid "4th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:290
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:100
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:324
 msgid "5th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:291
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:101
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:327
 msgid "6th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:306
-msgid "Thieves' Guild: Player RanKings"
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:344
+msgid "Oracle: Player Rankings"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:316
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:114
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:344
+msgid "Thieves' Guild: Player Rankings"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:354
 msgid "Number of Towns:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:325
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:123
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:363
 msgid "Number of Castles:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:334
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:132
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:372
 msgid "Number of Heroes:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:343
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:141
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:381
 msgid "Gold in Treasury:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:352
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:150
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:391
 msgid "Wood & Ore:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:361
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:159
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:401
 msgid "Gems, Cr, Slf & Mer:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:370
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:168
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:411
 msgid "Obelisks Found:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:379
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:177
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:421
+msgid "Artifacts:"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:432
 msgid "Total Army Strength:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:409
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:211
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:442
+msgid "Income:"
+msgstr ""
+
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:462
 msgid "Best Hero:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:418
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:220
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:472
 msgid "Best Hero Stats:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:427
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:482
 msgid "Personality:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:436
+#: ../fheroes2/dialog/dialog_thievesguild.cpp:492
 msgid "Best Monster:"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
+#: ../fheroes2/game/difficulty.cpp:29
 msgid "difficulty|Easy"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
+#: ../fheroes2/game/difficulty.cpp:29
 msgid "difficulty|Normal"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
+#: ../fheroes2/game/difficulty.cpp:29
 msgid "difficulty|Hard"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
+#: ../fheroes2/game/difficulty.cpp:29
 msgid "difficulty|Expert"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
+#: ../fheroes2/game/difficulty.cpp:29
 msgid "difficulty|Impossible"
 msgstr ""
 
-#: ../fheroes2/game/game.cpp:314
-msgid "Maps Loading..."
+#: ../fheroes2/game/game.cpp:468
+msgid "Map is loading..."
 msgstr ""
 
-#: ../fheroes2/game/game_highscores.cpp:239
-#: ../fheroes2/game/game_highscores.cpp:242
+#: ../fheroes2/game/game_campaign.cpp:210
+msgid "and more..."
+msgstr ""
+
+#: ../fheroes2/game/game_campaign.cpp:633
+msgid "Campaign Scenario loading failure"
+msgstr ""
+
+#: ../fheroes2/game/game_campaign.cpp:633
+msgid "Please make sure that campaign files are correct and present."
+msgstr ""
+
+#: ../fheroes2/game/game_highscores.cpp:231
+#: ../fheroes2/game/game_highscores.cpp:234
 msgid "Unknown Hero"
 msgstr ""
 
-#: ../fheroes2/game/game_highscores.cpp:240
+#: ../fheroes2/game/game_highscores.cpp:232
 msgid "Your Name"
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:95
-msgid "Are you sure you want to overwrite the save with this name?"
+#: ../fheroes2/game/game_io.cpp:190
+msgid ""
+"Invalid file game type. Please ensure that you are running the latest type "
+"of save files."
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:191
+#: ../fheroes2/game/game_io.cpp:203
 msgid ""
-"This file is saved in the \"Price Loyalty\" version.\n"
+"This file is saved in the \"The Price of Loyalty\" version.\n"
 "Some items may be unavailable."
 msgstr ""
 
-#: ../fheroes2/game/game_mainmenu.cpp:157
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:95
-msgid "Quit"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:157
-msgid "Quit Heroes of Might and Magic and return to the operating system."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:79
-msgid "Load Game"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-msgid "Load a previously saved game."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:91
-msgid "Credits"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-msgid "View the credits screen."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:87
-msgid "High Scores"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-msgid "View the high score screen."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:75
-msgid "New Game"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-msgid "Start a single or multi-player game."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid "Host"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid ""
-"The host sets up the game options. There can only be one host per network "
-"game."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid "Guest"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid ""
-"The guest waits for the host to set up the game, then is automatically added "
-"in. There can be multiple guests for TCP/IP games."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-msgid "Cancel back to the main menu."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:214
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:154
-msgid "Standard Game"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:214
-msgid "A single player game playing out a single map."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:216
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:162
-msgid "Multi-Player Game"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:216
-msgid ""
-"A multi-player game, with several human players completing against each "
-"other on a single map."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:217
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:83
-msgid "Settings"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:217
-msgid "FHeroes2 game settings."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:271
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:219
+#: ../fheroes2/game/game_loadgame.cpp:109 ../fheroes2/game/game_newgame.cpp:441
 msgid "Hot Seat"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:271
+#: ../fheroes2/game/game_loadgame.cpp:110 ../fheroes2/game/game_newgame.cpp:442
 msgid ""
 "Play a Hot Seat game, where 2 to 4 players play around the same computer, "
 "switching into the 'Hot Seat' when it is their turn."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:279
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:223
+#: ../fheroes2/game/game_loadgame.cpp:114
+#: ../fheroes2/game/game_loadgame.cpp:222 ../fheroes2/game/game_newgame.cpp:146
+#: ../fheroes2/game/game_newgame.cpp:311 ../fheroes2/game/game_newgame.cpp:399
+#: ../fheroes2/game/game_newgame.cpp:445 ../fheroes2/game/game_newgame.cpp:522
+msgid "Cancel back to the main menu."
+msgstr ""
+
+#: ../fheroes2/game/game_loadgame.cpp:130 ../fheroes2/game/game_newgame.cpp:453
 msgid "Network"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:279
+#: ../fheroes2/game/game_loadgame.cpp:130 ../fheroes2/game/game_newgame.cpp:453
 msgid ""
 "Play a network game, where 2 players use their own computers connected "
 "through a LAN (Local Area Network)."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:343
+#: ../fheroes2/game/game_loadgame.cpp:213 ../fheroes2/game/game_newgame.cpp:389
+msgid "Standard Game"
+msgstr ""
+
+#: ../fheroes2/game/game_loadgame.cpp:213 ../fheroes2/game/game_newgame.cpp:389
+msgid "A single player game playing out a single map."
+msgstr ""
+
+#: ../fheroes2/game/game_loadgame.cpp:216 ../fheroes2/game/game_newgame.cpp:391
+msgid "Campaign Game"
+msgstr ""
+
+#: ../fheroes2/game/game_loadgame.cpp:216 ../fheroes2/game/game_newgame.cpp:391
+msgid "A single player game playing through a series of maps."
+msgstr ""
+
+#: ../fheroes2/game/game_loadgame.cpp:219 ../fheroes2/game/game_newgame.cpp:393
+msgid "Multi-Player Game"
+msgstr ""
+
+#: ../fheroes2/game/game_loadgame.cpp:219 ../fheroes2/game/game_newgame.cpp:393
+msgid ""
+"A multi-player game, with several human players completing against each "
+"other on a single map."
+msgstr ""
+
+#: ../fheroes2/game/game_mainmenu.cpp:171
+msgid "Greetings!"
+msgstr ""
+
+#: ../fheroes2/game/game_mainmenu.cpp:171
+msgid ""
+"Welcome to Free Heroes of Might and Magic II! Before starting the game "
+"please choose game resolution."
+msgstr ""
+
+#: ../fheroes2/game/game_mainmenu.cpp:179
+msgid "Please Remember"
+msgstr ""
+
+#: ../fheroes2/game/game_mainmenu.cpp:182
+msgid "You can always change game resolution by clicking on the "
+msgstr ""
+
+#: ../fheroes2/game/game_mainmenu.cpp:183
+msgid "door"
+msgstr ""
+
+#: ../fheroes2/game/game_mainmenu.cpp:184
+msgid ""
+" on the left side of main menu.\n"
+"\n"
+"To switch between windowed and full screen modes\n"
+"press "
+msgstr ""
+
+#: ../fheroes2/game/game_mainmenu.cpp:186
+msgid "F4"
+msgstr ""
+
+#: ../fheroes2/game/game_mainmenu.cpp:187
+msgid ""
+" key on the keyboard.\n"
+"\n"
+"Enjoy the game!"
+msgstr ""
+
+#: ../fheroes2/game/game_mainmenu.cpp:309
+msgid "Quit Heroes of Might and Magic and return to the operating system."
+msgstr ""
+
+#: ../fheroes2/game/game_mainmenu.cpp:313
+msgid "Credits"
+msgstr ""
+
+#: ../fheroes2/game/game_mainmenu.cpp:313
+msgid "View the credits screen."
+msgstr ""
+
+#: ../fheroes2/game/game_mainmenu.cpp:315
+msgid "High Scores"
+msgstr ""
+
+#: ../fheroes2/game/game_mainmenu.cpp:315
+msgid "View the high score screen."
+msgstr ""
+
+#: ../fheroes2/game/game_mainmenu.cpp:319
+msgid "Select Game Resolution"
+msgstr ""
+
+#: ../fheroes2/game/game_mainmenu.cpp:319
+msgid "Change resolution of the game."
+msgstr ""
+
+#: ../fheroes2/game/game_newgame.cpp:140
+msgid "Original Campaign"
+msgstr ""
+
+#: ../fheroes2/game/game_newgame.cpp:140
+msgid ""
+"Either Roland's or Archibald's campaign from the original Heroes of Might "
+"and Magic II."
+msgstr ""
+
+#: ../fheroes2/game/game_newgame.cpp:143
+msgid "Expansion Campaign"
+msgstr ""
+
+#: ../fheroes2/game/game_newgame.cpp:143
+msgid "One of the four new campaigns from the Price of Loyalty expansion set."
+msgstr ""
+
+#: ../fheroes2/game/game_newgame.cpp:305
+msgid "Host"
+msgstr ""
+
+#: ../fheroes2/game/game_newgame.cpp:305
+msgid ""
+"The host sets up the game options. There can only be one host per network "
+"game."
+msgstr ""
+
+#: ../fheroes2/game/game_newgame.cpp:307
+msgid "Guest"
+msgstr ""
+
+#: ../fheroes2/game/game_newgame.cpp:308
+msgid ""
+"The guest waits for the host to set up the game, then is automatically added "
+"in. There can be multiple guests for TCP/IP games."
+msgstr ""
+
+#: ../fheroes2/game/game_newgame.cpp:395
+msgid "Battle Only"
+msgstr ""
+
+#: ../fheroes2/game/game_newgame.cpp:395
+msgid "Setup and play a battle without loading any map."
+msgstr ""
+
+#: ../fheroes2/game/game_newgame.cpp:397
+msgid "Settings"
+msgstr ""
+
+#: ../fheroes2/game/game_newgame.cpp:397
+msgid "Experimental game settings."
+msgstr ""
+
+#: ../fheroes2/game/game_newgame.cpp:512
 msgid "2 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:343
+#: ../fheroes2/game/game_newgame.cpp:512
 msgid ""
 "Play with 2 human players, and optionally, up, to 4 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:344
+#: ../fheroes2/game/game_newgame.cpp:514
 msgid "3 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:344
+#: ../fheroes2/game/game_newgame.cpp:514
 msgid ""
 "Play with 3 human players, and optionally, up, to 3 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:345
+#: ../fheroes2/game/game_newgame.cpp:516
 msgid "4 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:345
+#: ../fheroes2/game/game_newgame.cpp:516
 msgid ""
 "Play with 4 human players, and optionally, up, to 2 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:346
+#: ../fheroes2/game/game_newgame.cpp:518
 msgid "5 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:346
+#: ../fheroes2/game/game_newgame.cpp:518
 msgid ""
 "Play with 5 human players, and optionally, up, to 1 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:347
+#: ../fheroes2/game/game_newgame.cpp:520
 msgid "6 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:347
+#: ../fheroes2/game/game_newgame.cpp:520
 msgid "Play with 6 human players."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:37
+#: ../fheroes2/game/game_over.cpp:43
 msgid "Defeat all enemy heroes and capture all enemy towns and castles."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:38
+#: ../fheroes2/game/game_over.cpp:52
 msgid "Run out of time. (Fail to win by a certain point.)"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:73
+#: ../fheroes2/game/game_over.cpp:94
 msgid "Capture the castle '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:73
+#: ../fheroes2/game/game_over.cpp:94
 msgid "Capture the town '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:83
+#: ../fheroes2/game/game_over.cpp:102
 msgid "Defeat the hero '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:91
+#: ../fheroes2/game/game_over.cpp:108
 msgid "Find the ultimate artifact"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:95
+#: ../fheroes2/game/game_over.cpp:111
 msgid "Find the '%{name}' artifact"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:102
+#: ../fheroes2/game/game_over.cpp:116
 msgid "Accumulate %{count} gold"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:106
+#: ../fheroes2/game/game_over.cpp:121
 msgid ""
 ", or you may win by defeating all enemy heroes and capturing all enemy towns "
 "and castles."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:116
+#: ../fheroes2/game/game_over.cpp:128
 msgid "Lose the castle '%{name}'."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:116
+#: ../fheroes2/game/game_over.cpp:128
 msgid "Lose the town '%{name}'."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:126 ../fheroes2/game/game_over.cpp:145
+#: ../fheroes2/game/game_over.cpp:135 ../fheroes2/game/game_over.cpp:154
 msgid "Lose the hero: %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:133
+#: ../fheroes2/game/game_over.cpp:140
 msgid "Fail to win by the end of month %{month}, week %{week}, day %{day}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:145
+#: ../fheroes2/game/game_over.cpp:154
 msgid "Lose the heroes: %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:167
+#: ../fheroes2/game/game_over.cpp:174
 msgid ""
 "You captured %{name}!\n"
 "You are victorious."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:175
+#: ../fheroes2/game/game_over.cpp:181
 msgid ""
 "You have captured the enemy hero %{name}!\n"
 "Your quest is complete."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:183
+#: ../fheroes2/game/game_over.cpp:189
 msgid ""
 "You have found the %{name}.\n"
 "Your quest is complete."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:195
+#: ../fheroes2/game/game_over.cpp:200
 msgid ""
 "The enemy is beaten.\n"
 "Your side has triumphed!"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:200
+#: ../fheroes2/game/game_over.cpp:204
 msgid ""
 "You have built up over %{count} gold in your treasury.\n"
 "All enemies bow before your wealth and power."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:222
+#: ../fheroes2/game/game_over.cpp:226
 msgid ""
 "The enemy has found the %{name}.\n"
 "Your quest is a failure."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:230
+#: ../fheroes2/game/game_over.cpp:233
 msgid ""
 "%{color} has fallen!\n"
 "All is lost."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:237
+#: ../fheroes2/game/game_over.cpp:239
 msgid ""
 "The enemy has built up over %{count} gold in his treasury.\n"
 "You must bow done in defeat before his wealth and power."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:243
+#: ../fheroes2/game/game_over.cpp:245
 msgid "You have been eliminated from the game!!!"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:248
+#: ../fheroes2/game/game_over.cpp:249
 msgid ""
 "The enemy has captured %{name}!\n"
 "They are triumphant."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:257 ../fheroes2/game/game_over.cpp:264
+#: ../fheroes2/game/game_over.cpp:258 ../fheroes2/game/game_over.cpp:265
 msgid ""
 "You have lost the hero %{name}.\n"
 "Your quest is over."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:272
+#: ../fheroes2/game/game_over.cpp:275
 msgid ""
 "You have failed to complete your quest in time.\n"
 "All is lost."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:320
-msgid "%{color} has been vanquished!"
+#: ../fheroes2/game/game_over.cpp:331
+msgid "%{color} player has been vanquished!"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
+#: ../fheroes2/game/game_scenarioinfo.cpp:102
 msgid "Warning"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
+#: ../fheroes2/game/game_scenarioinfo.cpp:102
 msgid "No maps available!"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
+#: ../fheroes2/game/game_scenarioinfo.cpp:293
 msgid "Scenario"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
+#: ../fheroes2/game/game_scenarioinfo.cpp:293
 msgid "Click here to select which scenario to play."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
+#: ../fheroes2/game/game_scenarioinfo.cpp:296
 msgid "Game Difficulty"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
+#: ../fheroes2/game/game_scenarioinfo.cpp:297
 msgid ""
 "This lets you change the starting difficulty at which you will play. Higher "
 "difficulty levels start you of with fewer resources, and at the higher "
 "settings, give extra resources to the computer."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
+#: ../fheroes2/game/game_scenarioinfo.cpp:300
 msgid "Difficulty Rating"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
+#: ../fheroes2/game/game_scenarioinfo.cpp:301
 msgid ""
 "The difficulty rating reflects a combination of various settings for your "
 "game. This number will be applied to your final score."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
+#: ../fheroes2/game/game_scenarioinfo.cpp:304
 msgid "Click to accept these settings and start a new game."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
+#: ../fheroes2/game/game_scenarioinfo.cpp:306
 msgid "Click to return to the main menu."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:342
+#: ../fheroes2/game/game_scenarioinfo.cpp:368
 msgid "Scenario:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:350
+#: ../fheroes2/game/game_scenarioinfo.cpp:376
 msgid "Game Difficulty:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:354
+#: ../fheroes2/game/game_scenarioinfo.cpp:380
 msgid "Opponents:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:358
+#: ../fheroes2/game/game_scenarioinfo.cpp:384
 msgid "Class:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:384
+#: ../fheroes2/game/game_scenarioinfo.cpp:403
 msgid "Rating %{rating}%"
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:226
+#: ../fheroes2/game/game_startgame.cpp:293
 msgid "Astrologers proclaim Month of the %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:226
+#: ../fheroes2/game/game_startgame.cpp:293
 msgid "Astrologers proclaim Week of the %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:240
+#: ../fheroes2/game/game_startgame.cpp:304
 msgid "After regular growth, population of %{monster} is doubled!"
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:252
+#: ../fheroes2/game/game_startgame.cpp:316
 msgid " All populations are halved."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:254
+#: ../fheroes2/game/game_startgame.cpp:318
 msgid " All dwellings increase population."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:283
+#: ../fheroes2/game/game_startgame.cpp:341
 msgid ""
 "%{color} player, your heroes abandon you, and you are banished from this "
 "land."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:290
+#: ../fheroes2/game/game_startgame.cpp:346
 msgid ""
 "%{color} player, this is your last day to capture a town, or you will be "
 "banished from this land."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:295
+#: ../fheroes2/game/game_startgame.cpp:349
 msgid ""
 "%{color} player, you only have %{day} days left to capture a town, or you "
 "will be banished from this land."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:584
-msgid "%{color} player's turn"
+#: ../fheroes2/game/game_startgame.cpp:613
+msgid "%{color} player's turn."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:995
+#: ../fheroes2/game/game_startgame.cpp:1068
 msgid ""
 "%{color} player, you have lost your last town. If you do not conquer another "
 "town in next week, you will be eliminated."
@@ -2491,149 +3362,508 @@ msgstr ""
 msgid "Bring up the system options menu, alloving you to customize your game."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:175
+#: ../fheroes2/gui/interface_events.cpp:204
 msgid ""
 "One or more heroes may still move, are you sure you want to end your turn?"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:212
-msgid "Are you sure you want to restart? (Your current game will be lost)"
-msgstr ""
-
-#: ../fheroes2/gui/interface_events.cpp:276
+#: ../fheroes2/gui/interface_events.cpp:269
 msgid "Are you sure you want to quit?"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:308
+#: ../fheroes2/gui/interface_events.cpp:297
+msgid "Are you sure you want to restart? (Your current game will be lost.)"
+msgstr ""
+
+#: ../fheroes2/gui/interface_events.cpp:313
+msgid "Are you sure you want to overwrite the save with this name?"
+msgstr ""
+
+#: ../fheroes2/gui/interface_events.cpp:318
 msgid "Game saved successfully."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:314
-msgid ""
-"Are you sure you want to load a new game? (Your current game will be lost)"
+#: ../fheroes2/gui/interface_events.cpp:321
+msgid "There was an issue during saving."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:353
+#: ../fheroes2/gui/interface_events.cpp:329
+msgid ""
+"Are you sure you want to load a new game? (Your current game will be lost.)"
+msgstr ""
+
+#: ../fheroes2/gui/interface_events.cpp:366
 msgid "Try looking on land!!!"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:368
+#: ../fheroes2/gui/interface_events.cpp:377
 msgid ""
-"After spending many hours digging here, you have uncovered the %{artifact}"
+"After spending many hours digging here, you have uncovered the %{artifact}."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:370
+#: ../fheroes2/gui/interface_events.cpp:379
 msgid "Congratulations!"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:384
+#: ../fheroes2/gui/interface_events.cpp:392
 msgid "Nothing here. Where could it be?"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:395
+#: ../fheroes2/gui/interface_events.cpp:401
 msgid "Try searching on clear ground."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:399
+#: ../fheroes2/gui/interface_events.cpp:404
 msgid "Digging for artifacts requires a whole day, try again tomorrow."
 msgstr ""
 
-#: ../fheroes2/gui/interface_radar.cpp:387
+#: ../fheroes2/gui/interface_radar.cpp:437
+#: ../fheroes2/gui/interface_radar.cpp:477
 msgid "World Map"
 msgstr ""
 
-#: ../fheroes2/gui/interface_radar.cpp:387
+#: ../fheroes2/gui/interface_radar.cpp:437
+#: ../fheroes2/gui/interface_radar.cpp:477
 msgid "A miniature view of the known world. Left click to move viewing area."
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:216
+#: ../fheroes2/gui/interface_status.cpp:271
 msgid "Month: %{month} Week: %{week}"
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:222
-#: ../fheroes2/kingdom/kingdom_overview.cpp:569
+#: ../fheroes2/gui/interface_status.cpp:277
+#: ../fheroes2/kingdom/kingdom_overview.cpp:575
 msgid "Day: %{day}"
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:257
+#: ../fheroes2/gui/interface_status.cpp:311
 msgid ""
 "You find a small\n"
 "quantity of %{resource}."
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:407
+#: ../fheroes2/gui/interface_status.cpp:448
+#: ../fheroes2/gui/interface_status.cpp:452
 msgid "Status Window"
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:407
+#: ../fheroes2/gui/interface_status.cpp:448
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date."
+msgstr ""
+
+#: ../fheroes2/gui/interface_status.cpp:453
 msgid ""
 "This window provides information on the status of your hero or kingdom, and "
 "shows the date. Left click here to cycle throungh these windows."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:112
+#: ../fheroes2/gui/player_info.cpp:269
+msgid "Necroman"
+msgstr ""
+
+#: ../fheroes2/gui/player_info.cpp:297
+msgid ""
+"This lets you change player starting positions and colors. A particular "
+"color will always start in a particular location. Some positions may only be "
+"played by a computer player or only by a human player."
+msgstr ""
+
+#: ../fheroes2/gui/player_info.cpp:303
+msgid ""
+"This lets you change the class of a player. Classes are not always "
+"changeable. Depending on the scenario, a player may receive additional towns "
+"and/or heroes not of their primary alignment."
+msgstr ""
+
+#: ../fheroes2/gui/player_info.cpp:339
+msgid "%{color} player"
+msgstr ""
+
+#: ../fheroes2/gui/skill_bar.cpp:170 ../fheroes2/gui/skill_bar.cpp:264
+msgid "View %{skill} Info"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:71
+msgid "Lord Kilburn"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:71
+msgid "Sir Gallant"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:71
+msgid "Ector"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:71
+msgid "Gwenneth"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:71
+msgid "Tyro"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:71
+msgid "Ambrose"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:71
+msgid "Ruby"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:71
+msgid "Maximus"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:71
+msgid "Dimitry"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:73
+msgid "Thundax"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:73
+msgid "Fineous"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:73
+msgid "Jojosh"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:73
+msgid "Crag Hack"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:73
+msgid "Jezebel"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:73
+msgid "Jaclyn"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:73
+msgid "Ergon"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:73
+msgid "Tsabu"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:73
+msgid "Atlas"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:75
+msgid "Astra"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:75
+msgid "Natasha"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:75
+msgid "Troyan"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:75
+msgid "Vatawna"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:75
+msgid "Rebecca"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:75
+msgid "Gem"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:75
+msgid "Ariel"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:75
+msgid "Carlawn"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:75
+msgid "Luna"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:77
+msgid "Arie"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:77
+msgid "Alamar"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:77
+msgid "Vesper"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:77
+msgid "Crodo"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:77
+msgid "Barok"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:77
+msgid "Kastore"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:77
+msgid "Agar"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:77
+msgid "Falagar"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:77
+msgid "Wrathmont"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:79
+msgid "Myra"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:79
+msgid "Flint"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:79
+msgid "Dawn"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:79
+msgid "Halon"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:79
+msgid "Myrini"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:79
+msgid "Wilfrey"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:79
+msgid "Sarakin"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:79
+msgid "Kalindra"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:79
+msgid "Mandigal"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:81
+msgid "Zom"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:81
+msgid "Darlana"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:81
+msgid "Zam"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:81
+msgid "Ranloo"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:81
+msgid "Charity"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:81
+msgid "Rialdo"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:81
+msgid "Roxana"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:81
+msgid "Sandro"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:81
+msgid "Celia"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:83
+msgid "Roland"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:83
+msgid "Lord Corlagon"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:83
+msgid "Sister Eliza"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:83
+msgid "Archibald"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:83
+msgid "Lord Halton"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:83
+msgid "Brother Brax"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:85
+msgid "Solmyr"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:85
+msgid "Dainwin"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:85
+msgid "Mog"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:85
+msgid "Joseph"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:85
+msgid "Gallavant"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:85
+msgid "Elderian"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:85
+msgid "Ceallach"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:85
+msgid "Drakonia"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:86
+msgid "Martine"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:86
+msgid "Jarkonas"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:110
+msgid "%{object} robber"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:116
+msgid "%{object} raided"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:980 ../fheroes2/heroes/heroes_action.cpp:1705
+msgid "You cannot pick up this artifact, you already have a full load!"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:989 ../fheroes2/heroes/heroes_meeting.cpp:455
+msgid "The three Anduran artifacts magically combine into one."
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:1139
+msgid "To cast spells, you must first buy a spell book for %{gold} gold."
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:1149
+msgid "Unfortunately, you seem to be a little short of cash at the moment."
+msgstr ""
+
+#: ../fheroes2/heroes/heroes.cpp:1162
+msgid "Do you wish to buy one?"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes_action.cpp:115
 msgid "%{count} / day"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:331
-#: ../fheroes2/heroes/heroes_action.cpp:2214
+#: ../fheroes2/heroes/heroes_action.cpp:306
+#: ../fheroes2/heroes/heroes_action.cpp:2163
 msgid "You are unable to recruit at this time, your ranks are full."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:607
-#: ../fheroes2/heroes/heroes_action.cpp:628
+#: ../fheroes2/heroes/heroes_action.cpp:350
+msgid "A whirlpool engulfs your ship."
+msgstr ""
+
+#: ../fheroes2/heroes/heroes_action.cpp:350
+msgid "Some of your army has fallen overboard."
+msgstr ""
+
+#: ../fheroes2/heroes/heroes_action.cpp:714
+#: ../fheroes2/heroes/heroes_action.cpp:732
 msgid "Insulted by your refusal of their offer, the monsters attack!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:636
+#: ../fheroes2/heroes/heroes_action.cpp:739
 msgid ""
 "The %{monster}, awed by the power of your forces, begin to scatter.\n"
 "Do you wish to pursue and engage them?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:939
+#: ../fheroes2/heroes/heroes_action.cpp:994
 msgid "Ransacking an enemy camp, you discover a hidden cache of treasures."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:974
+#: ../fheroes2/heroes/heroes_action.cpp:1033
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with these resources, "
 "come back next week for more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:975
+#: ../fheroes2/heroes/heroes_action.cpp:1034
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there are no resources currently available. Please try "
 "again next week.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:980
+#: ../fheroes2/heroes/heroes_action.cpp:1039
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with this gold, come "
 "back next week for more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:981
+#: ../fheroes2/heroes/heroes_action.cpp:1040
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there is no gold currently available. Please try again "
 "next week.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:987
+#: ../fheroes2/heroes/heroes_action.cpp:1045
 msgid ""
 "You've found an abandoned lean-to.\n"
 "Poking about, you discover some resources hidden nearby."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:988
+#: ../fheroes2/heroes/heroes_action.cpp:1046
 msgid "The lean-to is long abandoned. There is nothing of value here."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:993
+#: ../fheroes2/heroes/heroes_action.cpp:1052
 msgid ""
 "You catch a leprechaun foolishly sleeping amidst a cluster of magic "
 "mushrooms.\n"
@@ -2641,176 +3871,176 @@ msgid ""
 "precious things."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:994
+#: ../fheroes2/heroes/heroes_action.cpp:1054
 msgid ""
 "You've found a magic garden, the kind of place that leprechauns and faeries "
 "like to cavort in, but there is no one here today.\n"
 "Perhaps you should try again next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1030
+#: ../fheroes2/heroes/heroes_action.cpp:1088
 msgid "You come upon the remains of an unfortunate adventurer."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1041
+#: ../fheroes2/heroes/heroes_action.cpp:1097
 msgid "Treasure"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1048
+#: ../fheroes2/heroes/heroes_action.cpp:1103
 msgid "Searching through the tattered clothing, you find %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1059
+#: ../fheroes2/heroes/heroes_action.cpp:1113
 msgid "Searching through the tattered clothing, you find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1071
+#: ../fheroes2/heroes/heroes_action.cpp:1125
 msgid ""
 "You come across an old wagon left by a trader who didn't quite make it to "
 "safe terrain."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1082
-#: ../fheroes2/heroes/heroes_action.cpp:1110
+#: ../fheroes2/heroes/heroes_action.cpp:1133
+#: ../fheroes2/heroes/heroes_action.cpp:1158
 msgid "Unfortunately, others have found it first, and the wagon is empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1089
+#: ../fheroes2/heroes/heroes_action.cpp:1139
 msgid "Searching inside, you find the %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1100
+#: ../fheroes2/heroes/heroes_action.cpp:1149
 msgid "Inside, you find some of the wagon's cargo still intact."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1130
+#: ../fheroes2/heroes/heroes_action.cpp:1174
 msgid "You search through the flotsam, and find some wood and some gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1131
+#: ../fheroes2/heroes/heroes_action.cpp:1175
 msgid "You search through the flotsam, and find some wood."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1137
+#: ../fheroes2/heroes/heroes_action.cpp:1180
 msgid "You search through the flotsam, but find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1158
+#: ../fheroes2/heroes/heroes_action.cpp:1206
 msgid "Shrine of the 1st Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1159
+#: ../fheroes2/heroes/heroes_action.cpp:1208
 msgid ""
 "You come across a small shrine attended by a group of novice acolytes.\n"
-"In exchange for your protection, they agree to teach you a simple spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a simple spell - "
+"'%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1162
+#: ../fheroes2/heroes/heroes_action.cpp:1211
 msgid "Shrine of the 2nd Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1163
+#: ../fheroes2/heroes/heroes_action.cpp:1213
 msgid ""
 "You come across an ornate shrine attended by a group of rotund friars.\n"
-"In exchange for your protection, they agree to teach you a spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a spell - "
+"'%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1166
+#: ../fheroes2/heroes/heroes_action.cpp:1216
 msgid "Shrine of the 3rd Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1167
+#: ../fheroes2/heroes/heroes_action.cpp:1218
 msgid ""
 "You come across a lavish shrine attended by a group of high priests.\n"
 "In exchange for your protection, they agree to teach you a sophisticated "
 "spell - '%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1180
+#: ../fheroes2/heroes/heroes_action.cpp:1229
 msgid ""
 "\n"
 "Unfortunately, you have no Magic Book to record the spell with."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1191
+#: ../fheroes2/heroes/heroes_action.cpp:1237
 msgid ""
 "\n"
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1199
+#: ../fheroes2/heroes/heroes_action.cpp:1243
 msgid ""
 "\n"
 "Unfortunately, you already have knowledge of this spell, so there is nothing "
 "more for them to teach you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1222
+#: ../fheroes2/heroes/heroes_action.cpp:1264
 msgid ""
-"You approach the hut and observe a witch inside studying an ancient tome on %"
-"{skill}.\n"
+"You approach the hut and observe a witch inside studying an ancient tome on "
+"%{skill}.\n"
 " \n"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1229
+#: ../fheroes2/heroes/heroes_action.cpp:1271
 msgid ""
 "As you approach, she turns and focuses her one glass eye on you.\n"
 "\"You already know everything you deserve to learn!\" the witch screeches. "
 "\"NOW GET OUT OF MY HOUSE!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1236
+#: ../fheroes2/heroes/heroes_action.cpp:1277
 msgid ""
 "As you approach, she turns and speaks.\n"
 "\"You already know that which I would teach you. I can help you no further.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1243
+#: ../fheroes2/heroes/heroes_action.cpp:1283
 msgid ""
 "An ancient and immortal witch living in a hut with bird's legs for stilts "
 "teaches you %{skill} for her own inscrutable purposes."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1262
+#: ../fheroes2/heroes/heroes_action.cpp:1300
 msgid "You drink from the enchanted fountain, but nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1263
+#: ../fheroes2/heroes/heroes_action.cpp:1300
 msgid "As you drink the sweet water, you gain luck for your next battle."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1267
+#: ../fheroes2/heroes/heroes_action.cpp:1304
 msgid "You enter the faerie ring, but nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1268
+#: ../fheroes2/heroes/heroes_action.cpp:1304
 msgid ""
 "Upon entering the mystical faerie ring, your army gains luck for its next "
 "battle."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1272
+#: ../fheroes2/heroes/heroes_action.cpp:1309
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "It is supposed to grant luck to visitors, but since the stars are already "
 "smiling upon you, it does nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1273
+#: ../fheroes2/heroes/heroes_action.cpp:1310
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "Kissing it is supposed to be lucky, so you do. The stone is very cold to the "
 "touch."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1277
+#: ../fheroes2/heroes/heroes_action.cpp:1315
 msgid "The mermaids silently entice you to return later and be blessed again."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1278
+#: ../fheroes2/heroes/heroes_action.cpp:1317
 msgid ""
 "The magical, soothing beauty of the Mermaids reaches you and your crew.\n"
 "Just for a moment, you forget your worries and bask in the beauty of the "
@@ -2818,7 +4048,7 @@ msgid ""
 "The mermaids charms bless you with increased luck for your next combat."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1310
+#: ../fheroes2/heroes/heroes_action.cpp:1347
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "You are tempted to search it for treasure, but all the old stories warn of "
@@ -2826,470 +4056,458 @@ msgid ""
 "Will you search?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1311
+#: ../fheroes2/heroes/heroes_action.cpp:1348
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "Routine exploration reveals that the pyramid is completely empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1336
+#: ../fheroes2/heroes/heroes_action.cpp:1367
 msgid "Unfortunately, you have no Magic Book to record the spell with."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1340
+#: ../fheroes2/heroes/heroes_action.cpp:1371
 msgid ""
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1344
+#: ../fheroes2/heroes/heroes_action.cpp:1374
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
 "telling the secret of the spell."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1382 ../fheroes2/maps/mp2.cpp:469
+#: ../fheroes2/heroes/heroes_action.cpp:1407 ../fheroes2/maps/mp2.cpp:406
 msgid "Sign"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1393
+#: ../fheroes2/heroes/heroes_action.cpp:1418
 msgid ""
 "A drink at the well is supposed to restore your spell points, but you are "
 "already at maximum."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1400
+#: ../fheroes2/heroes/heroes_action.cpp:1424
 msgid "A second drink at the well in one day will not help you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1407
+#: ../fheroes2/heroes/heroes_action.cpp:1429
 msgid "A drink from the well has restored your spell points to maximum."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1432
+#: ../fheroes2/heroes/heroes_action.cpp:1453
 msgid ""
 "\"I'm sorry sir,\" The leader of the soldiers says, \"but you already know "
 "everything we have to teach.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1433
+#: ../fheroes2/heroes/heroes_action.cpp:1454
 msgid "The soldiers living in the fort teach you a few new defensive tricks."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1438
+#: ../fheroes2/heroes/heroes_action.cpp:1460
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. \"You're too "
 "advanced for us,\" the mercenary captain says. \"We can teach nothing more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1439
+#: ../fheroes2/heroes/heroes_action.cpp:1461
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. The mercenaries "
 "welcome you and your troops and invite you to train with them."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1444
+#: ../fheroes2/heroes/heroes_action.cpp:1467
 msgid "\"Go 'way!\", the witch doctor barks, \"you know all I know.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1445
+#: ../fheroes2/heroes/heroes_action.cpp:1469
 msgid ""
 "An Orcish witch doctor living in the hut deepens your knowledge of magic by "
 "showing you how to cast stones, read portents, and decipher the intricacies "
 "of chicken entrails."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1450
+#: ../fheroes2/heroes/heroes_action.cpp:1475
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, the Druids turn you away, indicating they have nothing "
 "new to teach you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1451
+#: ../fheroes2/heroes/heroes_action.cpp:1476
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, they teach you new ways to cast spells."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1487
+#: ../fheroes2/heroes/heroes_action.cpp:1508
 msgid ""
 "You tentatively approach the burial ground of ancient warriors. Do you want "
 "to search the graves?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1488
+#: ../fheroes2/heroes/heroes_action.cpp:1509
 msgid ""
 "Upon defeating the Zombies you spend several hours searching the graves and "
 "find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1489
-msgid "Upon defeating the zomies you search the graves and find something!"
+#: ../fheroes2/heroes/heroes_action.cpp:1510
+msgid "Upon defeating the Zombies you search the graves and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1492
+#: ../fheroes2/heroes/heroes_action.cpp:1513
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the shipwreck?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1493
+#: ../fheroes2/heroes/heroes_action.cpp:1514
 msgid ""
 "Upon defeating the Ghosts you spend several hours sifting through the debris "
 "and find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1494
+#: ../fheroes2/heroes/heroes_action.cpp:1515
 msgid ""
 "Upon defeating the Ghosts you sift through the debris and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1497
+#: ../fheroes2/heroes/heroes_action.cpp:1518
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the ship?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1498
+#: ../fheroes2/heroes/heroes_action.cpp:1519
 msgid ""
 "Upon defeating the Skeletons you spend several hours sifting through the "
 "debris and find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1499
+#: ../fheroes2/heroes/heroes_action.cpp:1520
 msgid ""
 "Upon defeating the Skeletons you sift through the debris and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1572
+#: ../fheroes2/heroes/heroes_action.cpp:1582
 msgid "Your men spot a navigational buoy, confirming that you are on course."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1573
+#: ../fheroes2/heroes/heroes_action.cpp:1583
 msgid ""
 "Your men spot a navigational buoy, confirming that you are on course and "
 "increasing their morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1577
+#: ../fheroes2/heroes/heroes_action.cpp:1587
 msgid ""
 "The drink at the oasis is refreshing, but offers no further benefit. The "
 "oasis might help again if you fought a battle first."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1578
+#: ../fheroes2/heroes/heroes_action.cpp:1588
 msgid ""
 "A drink at the oasis fills your troops with strength and lifts their "
 "spirits.  You can travel a bit further today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1583
+#: ../fheroes2/heroes/heroes_action.cpp:1594
 msgid ""
 "The drink at the watering hole is refreshing, but offers no further benefit. "
 "The watering hole might help again if you fought a battle first."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1584
+#: ../fheroes2/heroes/heroes_action.cpp:1595
 msgid ""
 "A drink at the watering hole fills your troops with strength and lifts their "
 "spirits. You can travel a bit further today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1589
+#: ../fheroes2/heroes/heroes_action.cpp:1600
 msgid ""
 "It doesn't help to pray twice before a battle. Come back after you've fought."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1590
+#: ../fheroes2/heroes/heroes_action.cpp:1601
 msgid "A visit and a prayer at the temple raises the morale of your troops."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1630
+#: ../fheroes2/heroes/heroes_action.cpp:1637
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"I am sorry, my liege, I "
 "have taught you all I can.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1631
+#: ../fheroes2/heroes/heroes_action.cpp:1638
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"My liege, I will teach "
 "you all that I know to aid you in your travels.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1670
+#: ../fheroes2/heroes/heroes_action.cpp:1675
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
 "ocean. Grateful, he says, \"I would give you an artifact as a reward, but "
 "you're all full.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1677
+#: ../fheroes2/heroes/heroes_action.cpp:1682
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
-"ocean. Grateful, he rewards you for your act of kindness by giving you the %"
-"{art}."
+"ocean. Grateful, he rewards you for your act of kindness by giving you the "
+"%{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1697 ../fheroes2/heroes/heroes.cpp:944
-msgid "You have no room to carry another artifact!"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:1719
+#: ../fheroes2/heroes/heroes_action.cpp:1718
 msgid "A leprechaun offers you the %{art} for the small price of %{gold} Gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1724
+#: ../fheroes2/heroes/heroes_action.cpp:1722
 msgid ""
-"A leprechaun offers you the %{art} for the small price of %{gold} Gold and %"
-"{count} %{res}."
+"A leprechaun offers you the %{art} for the small price of %{gold} Gold and "
+"%{count} %{res}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1733
+#: ../fheroes2/heroes/heroes_action.cpp:1731
 msgid "Do you wish to buy this artifact?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1746
+#: ../fheroes2/heroes/heroes_action.cpp:1740
 msgid ""
 "You try to pay the leprechaun, but realize that you can't afford it. The "
 "leprechaun stamps his foot and ignores you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1750
+#: ../fheroes2/heroes/heroes_action.cpp:1745
 msgid ""
 "Insulted by your refusal of his generous offer, the leprechaun stamps his "
 "foot and ignores you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1761
-#: ../fheroes2/heroes/heroes_action.cpp:1836
+#: ../fheroes2/heroes/heroes_action.cpp:1753
+#: ../fheroes2/heroes/heroes_action.cpp:1815
 msgid "You've found the artifact: "
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1771
+#: ../fheroes2/heroes/heroes_action.cpp:1761
 msgid ""
 "You've found the humble dwelling of a withered hermit. The hermit tells you "
 "that he is willing to give the %{art} to the first wise person he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1774
+#: ../fheroes2/heroes/heroes_action.cpp:1764
 msgid ""
 "You've come across the spartan quarters of a retired soldier. The soldier "
 "tells you that he is willing to pass on the %{art} to the first true leader "
 "he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1795
+#: ../fheroes2/heroes/heroes_action.cpp:1782
 msgid ""
 "You come upon an ancient artifact. As you reach for it, a pack of Rogues "
 "leap out of the brush to guard their stolen loot."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1798
+#: ../fheroes2/heroes/heroes_action.cpp:1786
 msgid ""
 "Through a clearing you observe an ancient artifact. Unfortunately, it's "
 "guarded by a nearby %{monster}. Do you want to fight the %{monster} for the "
 "artifact?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1813
+#: ../fheroes2/heroes/heroes_action.cpp:1799
 msgid "Victorious, you take your prize, the %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1825
+#: ../fheroes2/heroes/heroes_action.cpp:1808
 msgid ""
 "Discretion is the better part of valor, and you decide to avoid this fight "
 "for today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1881
-#: ../fheroes2/heroes/heroes_action.cpp:1896
+#: ../fheroes2/heroes/heroes_action.cpp:1855
+#: ../fheroes2/heroes/heroes_action.cpp:1868
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold pieces."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1887
+#: ../fheroes2/heroes/heroes_action.cpp:1860
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold and the %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1903
+#: ../fheroes2/heroes/heroes_action.cpp:1874
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it, "
 "only to find it empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1913
+#: ../fheroes2/heroes/heroes_action.cpp:1883
 msgid ""
 "After scouring the area, you fall upon a hidden treasure cache. You may take "
 "the gold or distribute the gold to the peasants for experience. Do you wish "
 "to keep the gold?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1927
+#: ../fheroes2/heroes/heroes_action.cpp:1893
 msgid ""
-"After scouring the area, you fall upon a hidden chest, containing the %"
-"{gold} gold pieces."
+"After scouring the area, you fall upon a hidden chest, containing the "
+"%{gold} gold pieces."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1933
+#: ../fheroes2/heroes/heroes_action.cpp:1898
 msgid ""
 "After scouring the area, you fall upon a hidden chest, containing the "
 "ancient artifact %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1957
+#: ../fheroes2/heroes/heroes_action.cpp:1928
 msgid ""
 "You stumble upon a dented and tarnished lamp lodged deep in the earth. Do "
 "you wish to rub the lamp?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2045
-msgid "A whirlpool engulfs your ship."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2045
-msgid "Some of your army has fallen overboard."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2060
+#: ../fheroes2/heroes/heroes_action.cpp:2018
 msgid ""
 "You come upon an abandoned gold mine. The mine appears to be haunted. Do you "
 "wish to enter?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2079
+#: ../fheroes2/heroes/heroes_action.cpp:2036
 msgid ""
 "You have taken control of the local Alchemist shop. It will provide you with "
 "%{count} unit of Mercury per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2085
+#: ../fheroes2/heroes/heroes_action.cpp:2042
 msgid ""
 "You gain control of a sawmill. It will provide you with %{count} units of "
 "wood per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2096
+#: ../fheroes2/heroes/heroes_action.cpp:2048
+msgid "You beat the Ghosts and are able to restore the mine to production."
+msgstr ""
+
+#: ../fheroes2/heroes/heroes_action.cpp:2057
 msgid ""
 "You gain control of an ore mine. It will provide you with %{count} units of "
 "ore per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2098
+#: ../fheroes2/heroes/heroes_action.cpp:2060
 msgid ""
 "You gain control of a sulfur mine. It will provide you with %{count} unit of "
 "sulfur per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2100
+#: ../fheroes2/heroes/heroes_action.cpp:2063
 msgid ""
 "You gain control of a crystal mine. It will provide you with %{count} unit "
 "of crystal per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2102
+#: ../fheroes2/heroes/heroes_action.cpp:2066
 msgid ""
 "You gain control of a gem mine. It will provide you with %{count} unit of "
 "gems per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2104
+#: ../fheroes2/heroes/heroes_action.cpp:2069
 msgid ""
 "You gain control of a gold mine. It will provide you with %{count} gold per "
 "day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2111
-msgid "You beat the Ghosts and are able to restore the mine to production."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2116
+#: ../fheroes2/heroes/heroes_action.cpp:2078
 msgid ""
 "The lighthouse is now under your control, and all of your ships will now "
 "move further each turn."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2120
+#: ../fheroes2/heroes/heroes_action.cpp:2082
 msgid "You gain control of a %{name}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2203
+#: ../fheroes2/heroes/heroes_action.cpp:2153
 msgid ""
 "A group of %{monster} with a desire for greater glory wish to join you. Do "
 "you accept?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2230
+#: ../fheroes2/heroes/heroes_action.cpp:2174
 msgid "As you approach the dwelling, you notice that there is no one here."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2247
+#: ../fheroes2/heroes/heroes_action.cpp:2190
 msgid ""
 "You search the ruins, but the Medusas that used to live here are gone. "
 "Perhaps there will be more next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2248
+#: ../fheroes2/heroes/heroes_action.cpp:2191
 msgid ""
 "You've found some Medusas living in the ruins. They are willing to join your "
 "army for a price. Do you want to recruit Medusas?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2253
+#: ../fheroes2/heroes/heroes_action.cpp:2195
 msgid ""
 "You've found a Sprite Tree City. Unfortunately, none of the Sprites living "
 "there wish to join an army. Maybe next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2254
+#: ../fheroes2/heroes/heroes_action.cpp:2196
 msgid ""
 "Some of the Sprites living in the tree city are willing to join your army "
 "for a price. Do you want to recruit Sprites?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2259
+#: ../fheroes2/heroes/heroes_action.cpp:2200
 msgid ""
 "A colorful Rogues' wagon stands empty here. Perhaps more Rogues will be here "
 "later."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2260
+#: ../fheroes2/heroes/heroes_action.cpp:2201
 msgid ""
 "Distant sounds of music and laughter draw you to a colorful wagon housing "
 "Rogues. Do you wish to have any Rogues join your army?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2265
+#: ../fheroes2/heroes/heroes_action.cpp:2205
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. The "
 "tents are unoccupied. Perhaps more Nomads will be here later."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2266
+#: ../fheroes2/heroes/heroes_action.cpp:2206
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. Do you "
 "wish to have any Nomads join you during your travels?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2271
+#: ../fheroes2/heroes/heroes_action.cpp:2210
 msgid "The pit of mud bubbles for a minute and then lies still."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2272
+#: ../fheroes2/heroes/heroes_action.cpp:2212
 msgid ""
 "As you approach the bubbling pit of mud, creatures begin to climb out and "
 "position themselves around it. In unison they say: \"Mother Earth would like "
 "to offer you a few of her troops. Do you want to recruit Earth Elementals?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2276
+#: ../fheroes2/heroes/heroes_action.cpp:2216
 msgid "You enter the structure of white stone pillars, and find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2277
+#: ../fheroes2/heroes/heroes_action.cpp:2218
 msgid ""
 "White stone pillars support a roof that rises up to the sky. As you enter "
 "the structure, the dead air of the outside gives way to a whirling gust that "
@@ -3299,192 +4517,192 @@ msgid ""
 "air?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2281
+#: ../fheroes2/heroes/heroes_action.cpp:2222
 msgid "No Fire Elementals approach you from the lava pool."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2282
+#: ../fheroes2/heroes/heroes_action.cpp:2224
 msgid ""
 "Beneath a structure that serves to hold in heat, Fire Elementals move about "
 "in a fiery pool of molten lava. A group of them approach you and offer their "
 "services. Would you like to recruit Fire Elementals?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2286
+#: ../fheroes2/heroes/heroes_action.cpp:2228
 msgid "A face forms in the water for a moment, and then is gone."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2287
+#: ../fheroes2/heroes/heroes_action.cpp:2230
 msgid ""
 "Crystalline structures cast shadows over a small reflective pool of water. "
 "You peer into the pool, and a face that is not your own peers back. It asks: "
 "\"Would you like to call upon the powers of water?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2291
+#: ../fheroes2/heroes/heroes_action.cpp:2234
 msgid "This burial site is deathly still."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2292
+#: ../fheroes2/heroes/heroes_action.cpp:2236
 msgid ""
 "Restless spirits of long dead warriors seeking their final resting place "
 "offer to join you in hopes of finding peace. Do you wish to recruit ghosts?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2328
+#: ../fheroes2/heroes/heroes_action.cpp:2266
 msgid ""
 "The City of the Dead is empty of life, and empty of unlife as well. Perhaps "
 "some undead will move in next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2329
+#: ../fheroes2/heroes/heroes_action.cpp:2267
 msgid ""
 "Some Liches living here are willing to join your army for a price. Do you "
 "want to recruit Liches?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2330
+#: ../fheroes2/heroes/heroes_action.cpp:2268
 msgid ""
 "You've found the ruins of an ancient city, now inhabited solely by the "
 "undead. Will you search?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2331
+#: ../fheroes2/heroes/heroes_action.cpp:2270
 msgid ""
 "Some of the surviving Liches are impressed by your victory over their "
 "fellows, and offer to join you for a price. Do you want to recruit Liches?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2335
+#: ../fheroes2/heroes/heroes_action.cpp:2273
 msgid ""
 "You've found one of those bridges that Trolls are so fond of living under, "
 "but there are none here. Perhaps there will be some next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2336
+#: ../fheroes2/heroes/heroes_action.cpp:2274
 msgid ""
 "Some Trolls living under a bridge are willing to join your army, but for a "
 "price. Do you want to recruit Trolls?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2337
+#: ../fheroes2/heroes/heroes_action.cpp:2275
 msgid "Trolls living under the bridge challenge you. Will you fight them?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2338
+#: ../fheroes2/heroes/heroes_action.cpp:2276
 msgid ""
 "A few Trolls remain, cowering under the bridge. They approach you and offer "
 "to join your forces as mercenaries. Do you want to buy any Trolls?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2342
+#: ../fheroes2/heroes/heroes_action.cpp:2279
 msgid ""
 "The Dragon city has no Dragons willing to join you this week. Perhaps a "
 "Dragon will become available next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2343
+#: ../fheroes2/heroes/heroes_action.cpp:2280
 msgid ""
 "The Dragon city is willing to offer some Dragons for your army for a price. "
 "Do you wish to recruit Dragons?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2344
+#: ../fheroes2/heroes/heroes_action.cpp:2281
 msgid ""
 "You stand before the Dragon City, a place off-limits to mere humans. Do you "
 "wish to violate this rule and challenge the Dragons to a fight?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2345
+#: ../fheroes2/heroes/heroes_action.cpp:2282
 msgid ""
 "Having defeated the Dragon champions, the city's leaders agree to supply "
 "some Dragons to your army for a price. Do you wish to recruit Dragons?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2404
+#: ../fheroes2/heroes/heroes_action.cpp:2331
 msgid "From the observation tower, you are able to see distant lands."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2416
+#: ../fheroes2/heroes/heroes_action.cpp:2341
 msgid ""
 "The spring only refills once a week, and someone's already been here this "
 "week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2422
+#: ../fheroes2/heroes/heroes_action.cpp:2344
 msgid ""
 "A drink at the spring is supposed to give you twice your normal spell "
 "points, but you are already at that level."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2433
+#: ../fheroes2/heroes/heroes_action.cpp:2356
 msgid ""
 "A drink from the spring fills your blood with magic! You have twice your "
 "normal spell points in reserve."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2452
+#: ../fheroes2/heroes/heroes_action.cpp:2370
 msgid ""
 "Recognizing you, the butler refuses to admit you. \"The master,\" he says, "
 "\"will not see the same student twice.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2472
+#: ../fheroes2/heroes/heroes_action.cpp:2395
 msgid ""
 "The butler admits you to see the master of the house. He trains you in the "
 "four skills a hero should know."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2482
+#: ../fheroes2/heroes/heroes_action.cpp:2406
 msgid ""
 "The butler opens the door and looks you up and down. \"You are neither "
 "famous nor diplomatic enough to be admitted to see my master,\" he sniffs. "
 "\"Come back when you think yourself worthy.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2525
+#: ../fheroes2/heroes/heroes_action.cpp:2449
 msgid ""
 "All of the %{monsters} you have in your army have been trained by the battle "
 "masters of the fort. Your army now contains %{monsters2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2528
+#: ../fheroes2/heroes/heroes_action.cpp:2450
 msgid ""
-"An unusual alliance of Orcs, Ogres, and Dwarves offer to train (upgrade) any "
+"An unusual alliance of Ogres, Orcs, and Dwarves offer to train (upgrade) any "
 "such troops brought to them. Unfortunately, you have none with you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2539
+#: ../fheroes2/heroes/heroes_action.cpp:2456
 msgid "All of your %{monsters} have been upgraded into %{monsters2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2542
+#: ../fheroes2/heroes/heroes_action.cpp:2458
 msgid ""
 "A blacksmith working at the foundry offers to convert all Pikemen and "
 "Swordsmen's weapons brought to him from iron to steel. He also says that he "
-"knows a process that will convert Iron Golems into Steel Golems.  "
+"knows a process that will convert Iron Golems into Steel Golems. "
 "Unfortunately, you have none of these troops in your army, so he can't help "
 "you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2600
+#: ../fheroes2/heroes/heroes_action.cpp:2566
 msgid ""
 "A retired captain living on this refurbished fishing platform offers to sell "
 "you maps of the sea he made in his younger days for 1,000 gold. Do you wish "
 "to buy the maps?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2613
+#: ../fheroes2/heroes/heroes_action.cpp:2577
 msgid ""
 "The captain sighs. \"You don't have enough money, eh?  You can't expect me "
 "to give my maps away for free!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2644
+#: ../fheroes2/heroes/heroes_action.cpp:2603
 msgid "You find %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2670
+#: ../fheroes2/heroes/heroes_action.cpp:2629
 msgid ""
 "You come upon an obelisk made from a type of stone you have never seen "
 "before. Staring at it intensely, the smooth surface suddenly changes to an "
@@ -3492,56 +4710,63 @@ msgid ""
 "copy down the piece and the inscription vanishes as abruptly as it appeared."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2674
+#: ../fheroes2/heroes/heroes_action.cpp:2634
 msgid "You have already been to this obelisk."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2686
+#: ../fheroes2/heroes/heroes_action.cpp:2645
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"It is good to see "
 "you, my student. I hope my teachings have helped you.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2698
+#: ../fheroes2/heroes/heroes_action.cpp:2657
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"Ahh, an "
 "adventurer! Allow me to teach you a little of what I have learned over the "
 "ages.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2707
+#: ../fheroes2/heroes/heroes_action.cpp:2664
 msgid "Upon your approach, the tree opens its eyes in delight."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2709
+#: ../fheroes2/heroes/heroes_action.cpp:2666
 msgid ""
 "\"Ahh, an adventurer! I will be happy to teach you a little of what I have "
 "learned over the ages for a mere %{count} %{res}.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2711
+#: ../fheroes2/heroes/heroes_action.cpp:2668
 msgid "(Just bury it around my roots.)"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2718
+#: ../fheroes2/heroes/heroes_action.cpp:2674
 msgid "Tears brim in the eyes of the tree."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2720
+#: ../fheroes2/heroes/heroes_action.cpp:2676
 msgid "\"I need %{count} %{res}.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2722
+#: ../fheroes2/heroes/heroes_action.cpp:2678
 msgid "it whispers. (sniff) \"Well, come back when you can pay me.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2752
+#: ../fheroes2/heroes/heroes_action.cpp:2699
+msgid ""
+"Nestled among the trees sits a blind seer. After explaining the intent of "
+"your journey, the seer activates his crystal ball, allowing you to see the "
+"strengths and weaknesses of your opponents."
+msgstr ""
+
+#: ../fheroes2/heroes/heroes_action.cpp:2714
 msgid ""
 "The entrance to the cave is dark, and a foul, sulfurous smell issues from "
 "the cave mouth. Will you enter?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2764
+#: ../fheroes2/heroes/heroes_action.cpp:2729
 msgid ""
 "You find a powerful and grotesque Demon in the cave. \"Today,\" it rasps, "
 "\"you will fight and surely die. But I will give you a choice of deaths. You "
@@ -3549,71 +4774,71 @@ msgid ""
 "servants?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2774
+#: ../fheroes2/heroes/heroes_action.cpp:2738
 msgid ""
 "Upon defeating the daemon's servants, you find a hidden cache with %{count} "
 "gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2789
+#: ../fheroes2/heroes/heroes_action.cpp:2750
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and receive %{exp} experience points."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2799
+#: ../fheroes2/heroes/heroes_action.cpp:2759
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and find the %{art} in the back of the cave."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2809
+#: ../fheroes2/heroes/heroes_action.cpp:2769
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
-"battle, you slay the monster and receive %{exp) experience points and %"
-"{count} gold."
+"battle, you slay the monster and receive %{exp} experience points and "
+"%{count} gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2824
+#: ../fheroes2/heroes/heroes_action.cpp:2783
 msgid ""
 "The Demon leaps upon you and has its claws at your throat before you can "
 "even draw your sword. \"Your life is mine,\" it says. \"I will sell it back "
 "to you for %{count} gold.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2825
+#: ../fheroes2/heroes/heroes_action.cpp:2784
 msgid ""
 "Seeing that you do not have %{count} gold, the demon slashes you with its "
 "claws, and the last thing you see is a red haze."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2850
+#: ../fheroes2/heroes/heroes_action.cpp:2806
 msgid "Except for evidence of a terrible battle, the cave is empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2875
+#: ../fheroes2/heroes/heroes_action.cpp:2833
 msgid "For %{gold} gold, the alchemist will remove it for you. Do you pay?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2886
+#: ../fheroes2/heroes/heroes_action.cpp:2848
 msgid ""
 "You hear a voice from behind the locked door, \"You don't have enough gold "
 "to pay for my services.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2889
+#: ../fheroes2/heroes/heroes_action.cpp:2851
 msgid ""
 "You hear a voice from high above in the tower, \"Go away! I can't help you!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2901
+#: ../fheroes2/heroes/heroes_action.cpp:2865
 msgid ""
 "The head groom approaches you and speaks, \"You already have a fine horse, "
 "and have no inexperienced cavalry which might make use of our trained war "
 "horses.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2904
+#: ../fheroes2/heroes/heroes_action.cpp:2868
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, his "
@@ -3622,7 +4847,7 @@ msgid ""
 "mounted soldiers, but you have none we can help.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2907
+#: ../fheroes2/heroes/heroes_action.cpp:2871
 msgid ""
 "The head groom speaks to you, \"That is a fine looking horse you have. I am "
 "afraid we can give you no better, but the horses your cavalry are riding "
@@ -3630,7 +4855,7 @@ msgid ""
 "would aid your riders greatly. I insist you take them.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2910
+#: ../fheroes2/heroes/heroes_action.cpp:2874
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, he will "
@@ -3638,17 +4863,17 @@ msgid ""
 "mounted soldiers, their horses look shoddy and weak.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2937
+#: ../fheroes2/heroes/heroes_action.cpp:2894
 msgid "The Arena guards turn you away."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2954
+#: ../fheroes2/heroes/heroes_action.cpp:2909
 msgid ""
 "As the sirens sing their eerie song, your small, determined army manages to "
 "overcome the urge to dive headlong into the sea."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2959
+#: ../fheroes2/heroes/heroes_action.cpp:2915
 msgid ""
 "You have your crew stop up their ears with wax before the sirens' eerie song "
 "has any chance of luring them to a watery grave. An eerie wailing song "
@@ -3657,57 +4882,62 @@ msgid ""
 "for the visit, and gain %{exp} experience."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2979
+#: ../fheroes2/heroes/heroes_action.cpp:2936
 msgid ""
 "In a dazzling display of daring, you break into the local jail and free the "
 "hero imprisoned there, who, in return, pledges loyalty to your cause."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2995
+#: ../fheroes2/heroes/heroes_action.cpp:2954
 msgid ""
 "You already have %{count} heroes, and regretfully must leave the prisoner in "
 "this jail to languish in agony for untold days."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3006
+#: ../fheroes2/heroes/heroes_action.cpp:2965
 msgid ""
 "You enter a rickety hut and talk to the magician who lives there. He tells "
 "you of places near and far which may aid you in your journeys."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3019
+#: ../fheroes2/heroes/heroes_action.cpp:2999
 msgid "This eye seems to be intently studying its surroundings."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3031
+#: ../fheroes2/heroes/heroes_action.cpp:3014
 msgid ""
 "\"I have a riddle for you,\" the Sphinx says. \"Answer correctly, and you "
 "shall be rewarded. Answer incorrectly, and you shall be eaten. Do you accept "
 "the challenge?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3033
-msgid "The Sphinx asks you the following riddle: %{riddle}. Your answer?"
+#: ../fheroes2/heroes/heroes_action.cpp:3016
+msgid ""
+"The Sphinx asks you the following riddle:\n"
+" \n"
+"'%{riddle}'\n"
+" \n"
+"Your answer?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3041
+#: ../fheroes2/heroes/heroes_action.cpp:3023
 msgid ""
 "Looking somewhat disappointed, the Sphinx sighs. You've answered my riddle "
 "so here's your reward. Now begone."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3068
+#: ../fheroes2/heroes/heroes_action.cpp:3050
 msgid ""
 "\"You guessed incorrectly,\" the Sphinx says, smiling. The Sphinx swipes at "
 "you with a paw, knocking you to the ground. Another blow makes the world go "
 "black, and you know no more."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3076
+#: ../fheroes2/heroes/heroes_action.cpp:3059
 msgid "You come across a giant Sphinx. The Sphinx remains strangely quiet."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3089
+#: ../fheroes2/heroes/heroes_action.cpp:3073
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -3715,7 +4945,7 @@ msgid ""
 "As you speak the magic word, the glowing barrier dissolves into nothingness."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3099
+#: ../fheroes2/heroes/heroes_action.cpp:3096
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -3723,7 +4953,7 @@ msgid ""
 "You speak, and nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3109
+#: ../fheroes2/heroes/heroes_action.cpp:3108
 msgid ""
 "You enter the tent and see an old woman gazing into a magic gem. She looks "
 "up and says,\n"
@@ -3731,421 +4961,105 @@ msgid ""
 "oracle taught me his skill. I have the answer you seek.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_base.cpp:401
+#: ../fheroes2/heroes/heroes_base.cpp:433
 msgid ""
 "That spell costs %{mana} mana. You only have %{point} mana, so you can't "
 "cast the spell."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Lord Kilburn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Sir Gallanth"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ector"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Gwenneth"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Tyro"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ambrose"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ruby"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Maximus"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Dimitry"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Thundax"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Fineous"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jojosh"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Crag Hack"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jezebel"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jaclyn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Ergon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Tsabu"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Atlas"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Astra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Natasha"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Troyan"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Vatawna"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Rebecca"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Gem"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Ariel"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Carlawn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Luna"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Arie"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61 ../fheroes2/resource/maps_text.cpp:59
-msgid "Alamar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Vesper"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Crodo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Barok"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Kastore"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Agar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Falagar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Wrathmont"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Flint"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Dawn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Halon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myrini"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Wilfrey"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Sarakin"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63 ../fheroes2/resource/maps_text.cpp:377
-msgid "Kalindra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Mandigal"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zom"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Darlana"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zam"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Ranloo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Charity"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Rialdo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Roxana"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65 ../fheroes2/resource/maps_text.cpp:557
-msgid "Sandro"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Celia"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:552
-msgid "Roland"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Lord Corlagon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Sister Eliza"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:88
-msgid "Archibald"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:403
-msgid "Lord Halton"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Brother Bax"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Solmyr"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:194
-msgid "Dainwin"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Mog"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:760
-msgid "Uncle Ivan"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:373
-msgid "Joseph"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:285
-msgid "Gallavant"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Elderian"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:179
-msgid "Ceallach"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:229
-msgid "Drakonia"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:422
-msgid "Martine"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:370
-msgid "Jarkonas"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:943
-msgid ""
-"You must purchase a spell book to use the mage guild, but you currently have "
-"no room for a spell book. Try giving one of your artifacts to another hero."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:953
-msgid "The three Anduran artifacts magically combine into one."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1059
-msgid "To cast spells, you must first buy a spell book for %{gold} gold."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1067
-msgid "Unfortunately, you seem to be a little short of cash at the moment."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1081
-msgid "Do you wish to buy one?"
-msgstr ""
-
 #: ../fheroes2/heroes/heroes_dialog.cpp:72
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:55
-msgid "%{name} the %{race} ( Level %{level} )"
+msgid "%{name} the %{race} (Level %{level})"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:118
+#: ../fheroes2/heroes/heroes_dialog.cpp:119
 msgid ""
 "'Grouped' combat formation bunches your army together in the center of your "
 "side of the battlefield."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:161
+#: ../fheroes2/heroes/heroes_dialog.cpp:290
 msgid "Are you sure you want to dismiss this Hero?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:341
+#: ../fheroes2/heroes/heroes_dialog.cpp:331
 msgid "View Stats"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:344
-msgid "View Morale Info"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:347
-msgid "View Luck Info"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:350
+#: ../fheroes2/heroes/heroes_dialog.cpp:339
 msgid "View Experience Info"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:353
+#: ../fheroes2/heroes/heroes_dialog.cpp:341
 msgid "View Spell Points Info"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:356
+#: ../fheroes2/heroes/heroes_dialog.cpp:343
 msgid "Set army combat formation to 'Spread'"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:359
+#: ../fheroes2/heroes/heroes_dialog.cpp:345
 msgid "Set army combat formation to 'Grouped'"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:362
-msgid "Exit hero"
+#: ../fheroes2/heroes/heroes_dialog.cpp:347
+msgid "Exit Hero Screen"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:369
-msgid "Dismiss hero"
+#: ../fheroes2/heroes/heroes_dialog.cpp:350
+msgid "You cannot dismiss a hero in a castle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:373
-msgid "Show prev heroes"
+#: ../fheroes2/heroes/heroes_dialog.cpp:353
+msgid "Dismissal of %{name} the %{race} is prohibited by scenario"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:376
-msgid "Show next heroes"
+#: ../fheroes2/heroes/heroes_dialog.cpp:358
+msgid "Dismiss %{name} the %{race}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:379
-msgid "Hero Screen"
+#: ../fheroes2/heroes/heroes_dialog.cpp:364
+msgid "Show previous hero"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:39
-msgid "Bad Morale"
+#: ../fheroes2/heroes/heroes_dialog.cpp:366
+msgid "Show next hero"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:42
-msgid "Neutral Morale"
+#: ../fheroes2/heroes/heroes_indicator.cpp:38
+msgid "Blood Morale"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes_indicator.cpp:40
+msgid "%{morale} Morale"
 msgstr ""
 
 #: ../fheroes2/heroes/heroes_indicator.cpp:47
-msgid "Good Morale"
+msgid "%{luck} Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:61
-msgid "Bad Luck"
+#: ../fheroes2/heroes/heroes_indicator.cpp:97
+msgid "Current Luck Modifiers:"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:64
-msgid "Neutral Luck"
+#: ../fheroes2/heroes/heroes_indicator.cpp:148
+msgid "Current Morale Modifiers:"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:69
-msgid "Good Luck"
+#: ../fheroes2/heroes/heroes_indicator.cpp:158
+msgid "Entire army is undead, so morale does not apply."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:113
-#: ../fheroes2/heroes/heroes_indicator.cpp:159
-#: ../fheroes2/heroes/skill.cpp:197
-msgid "Current Modifiers:"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:195
-msgid "Current experience %{exp1} Next level %{exp2}."
+#: ../fheroes2/heroes/heroes_indicator.cpp:190
+msgid ""
+"Current experience %{exp1}.\n"
+" Next level %{exp2}."
 msgstr ""
 
 #: ../fheroes2/heroes/heroes_indicator.cpp:215
 msgid "Level %{level}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:226
+#: ../fheroes2/heroes/heroes_indicator.cpp:228
 msgid ""
 "%{name} currently has %{point} spell points out of a maximum of %{max}. The "
 "maximum number of spell points is 10 times your knowledge. It is "
@@ -4153,484 +5067,504 @@ msgid ""
 "special events."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:65
+#: ../fheroes2/heroes/heroes_meeting.cpp:254
 msgid "%{name1} meets %{name2}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:396
-#: ../fheroes2/heroes/heroes_meeting.cpp:406
+#: ../fheroes2/heroes/heroes_meeting.cpp:673
+#: ../fheroes2/heroes/heroes_meeting.cpp:681
 msgid " and "
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:414
+#: ../fheroes2/heroes/heroes_meeting.cpp:687
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:417
+#: ../fheroes2/heroes/heroes_meeting.cpp:689
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:420
+#: ../fheroes2/heroes/heroes_meeting.cpp:691
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches %"
-"{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches "
+"%{spells2} to %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:431
+#: ../fheroes2/heroes/heroes_meeting.cpp:701
 msgid "Scholar Ability"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:83 ../fheroes2/spell/spell.cpp:109
+#: ../fheroes2/heroes/heroes_spell.cpp:133 ../fheroes2/spell/spell.cpp:119
 msgid "Town Portal"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:86
+#: ../fheroes2/heroes/heroes_spell.cpp:136
 msgid "Select town to port to."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:106
+#: ../fheroes2/heroes/heroes_spell.cpp:187
 msgid "Your hero is too tired to cast this spell today. Try again tomorrow."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:187
+#: ../fheroes2/heroes/heroes_spell.cpp:302
 msgid "%{spell} failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:236
+#: ../fheroes2/heroes/heroes_spell.cpp:346
+msgid "This spell is already in use."
+msgstr ""
+
+#: ../fheroes2/heroes/heroes_spell.cpp:351
 msgid "Enemy heroes are now fully identifiable."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:362
-#: ../fheroes2/heroes/heroes_spell.cpp:386
-msgid "No available towns. Spell Failed!!!"
+#: ../fheroes2/heroes/heroes_spell.cpp:359
+msgid "This spell cannot be used on a boat."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:458
-msgid "I fear these creatures are in the mood for a fight."
+#: ../fheroes2/heroes/heroes_spell.cpp:388
+msgid "This spell can be casted only nearby water."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:462
-msgid "The creatures are willing to join us!"
+#: ../fheroes2/heroes/heroes_spell.cpp:480
+#: ../fheroes2/heroes/heroes_spell.cpp:509
+msgid ""
+"No available towns.\n"
+"Spell Failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:467
-msgid "All the creatures will join us..."
+#: ../fheroes2/heroes/heroes_spell.cpp:484
+msgid ""
+"Nearest town occupied.\n"
+"Spell Failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:479
-msgid "These weak creatures will surely flee before us."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_spell.cpp:488
+#: ../fheroes2/heroes/heroes_spell.cpp:567
 msgid ""
 "You must be within %{count} spaces of a monster for the Visions spell to "
 "work."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:505
+#: ../fheroes2/heroes/heroes_spell.cpp:587
+msgid "I fear these creatures are in the mood for a fight."
+msgstr ""
+
+#: ../fheroes2/heroes/heroes_spell.cpp:591
+msgid "The creatures are willing to join us!"
+msgstr ""
+
+#: ../fheroes2/heroes/heroes_spell.cpp:596
+msgid "All the creatures will join us..."
+msgstr ""
+
+#: ../fheroes2/heroes/heroes_spell.cpp:607
+msgid "These weak creatures will surely flee before us."
+msgstr ""
+
+#: ../fheroes2/heroes/heroes_spell.cpp:624
 msgid ""
 "You must be standing on the entrance to a mine (sawmills and alchemists "
 "don't count) to cast this spell."
-msgstr ""
-
-#: ../fheroes2/heroes/skill.cpp:151
-msgid "Power"
 msgstr ""
 
 #: ../fheroes2/heroes/skill.cpp:172
 msgid "Your attack skill is a bonus added to each creature's attack skill."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:177
+#: ../fheroes2/heroes/skill.cpp:178
 msgid "Your defense skill is a bonus added to each creature's defense skill."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:182
+#: ../fheroes2/heroes/skill.cpp:184
 msgid "Your spell power determines the length or power of a spell."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:187
+#: ../fheroes2/heroes/skill.cpp:191
 msgid ""
 "Your knowledge determines how many spell points your hero may have. Under "
-"normal cirumstances, a hero is limited to 10 spell points per level of "
+"normal circumstances, a hero is limited to 10 spell points per level of "
 "knowledge."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
+#: ../fheroes2/heroes/skill.cpp:202
+msgid "Current Modifiers:"
+msgstr ""
+
+#: ../fheroes2/heroes/skill.cpp:212
 msgid "skill|Basic"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
+#: ../fheroes2/heroes/skill.cpp:212
 msgid "skill|Advanced"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
+#: ../fheroes2/heroes/skill.cpp:212
 msgid "skill|Expert"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
+#: ../fheroes2/heroes/skill.cpp:363
 msgid "Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
+#: ../fheroes2/heroes/skill.cpp:363
 msgid "Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
+#: ../fheroes2/heroes/skill.cpp:363
 msgid "Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
+#: ../fheroes2/heroes/skill.cpp:363
 msgid "Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
+#: ../fheroes2/heroes/skill.cpp:363
 msgid "Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
+#: ../fheroes2/heroes/skill.cpp:363
 msgid "Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
+#: ../fheroes2/heroes/skill.cpp:363
 msgid "Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
+#: ../fheroes2/heroes/skill.cpp:363
 msgid "Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
+#: ../fheroes2/heroes/skill.cpp:364
 msgid "Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
+#: ../fheroes2/heroes/skill.cpp:364
 msgid "Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
+#: ../fheroes2/heroes/skill.cpp:364
 msgid "Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
+#: ../fheroes2/heroes/skill.cpp:364
 msgid "Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
+#: ../fheroes2/heroes/skill.cpp:364
 msgid "Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
+#: ../fheroes2/heroes/skill.cpp:406
 msgid "Basic Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
+#: ../fheroes2/heroes/skill.cpp:406
 msgid "Advanced Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
+#: ../fheroes2/heroes/skill.cpp:406
 msgid "Expert Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
+#: ../fheroes2/heroes/skill.cpp:406
 msgid "Basic Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
+#: ../fheroes2/heroes/skill.cpp:406
 msgid "Advanced Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
+#: ../fheroes2/heroes/skill.cpp:407
 msgid "Expert Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:369
+#: ../fheroes2/heroes/skill.cpp:407
 msgid "Basic Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:369
+#: ../fheroes2/heroes/skill.cpp:407
 msgid "Advanced Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:369
+#: ../fheroes2/heroes/skill.cpp:407
 msgid "Expert Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
+#: ../fheroes2/heroes/skill.cpp:407
 msgid "Basic Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
+#: ../fheroes2/heroes/skill.cpp:408
 msgid "Advanced Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
+#: ../fheroes2/heroes/skill.cpp:408
 msgid "Expert Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
+#: ../fheroes2/heroes/skill.cpp:408
 msgid "Basic Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
+#: ../fheroes2/heroes/skill.cpp:408
 msgid "Advanced Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
+#: ../fheroes2/heroes/skill.cpp:408
 msgid "Expert Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:372
+#: ../fheroes2/heroes/skill.cpp:409
 msgid "Basic Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:372
+#: ../fheroes2/heroes/skill.cpp:409
 msgid "Advanced Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:372
+#: ../fheroes2/heroes/skill.cpp:409
 msgid "Expert Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
+#: ../fheroes2/heroes/skill.cpp:409
 msgid "Basic Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
+#: ../fheroes2/heroes/skill.cpp:409
 msgid "Advanced Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
+#: ../fheroes2/heroes/skill.cpp:410
 msgid "Expert Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
+#: ../fheroes2/heroes/skill.cpp:410
 msgid "Basic Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
+#: ../fheroes2/heroes/skill.cpp:410
 msgid "Advanced Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
+#: ../fheroes2/heroes/skill.cpp:410
 msgid "Expert Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
+#: ../fheroes2/heroes/skill.cpp:410
 msgid "Basic Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
+#: ../fheroes2/heroes/skill.cpp:411
 msgid "Advanced Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
+#: ../fheroes2/heroes/skill.cpp:411
 msgid "Expert Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
+#: ../fheroes2/heroes/skill.cpp:411
 msgid "Basic Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
+#: ../fheroes2/heroes/skill.cpp:411
 msgid "Advanced Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
+#: ../fheroes2/heroes/skill.cpp:411
 msgid "Expert Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:377
+#: ../fheroes2/heroes/skill.cpp:412
 msgid "Basic Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:377
+#: ../fheroes2/heroes/skill.cpp:412
 msgid "Advanced Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:377
+#: ../fheroes2/heroes/skill.cpp:412
 msgid "Expert Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
+#: ../fheroes2/heroes/skill.cpp:412
 msgid "Basic Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
+#: ../fheroes2/heroes/skill.cpp:412
 msgid "Advanced Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
+#: ../fheroes2/heroes/skill.cpp:413
 msgid "Expert Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
+#: ../fheroes2/heroes/skill.cpp:413
 msgid "Basic Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
+#: ../fheroes2/heroes/skill.cpp:413
 msgid "Advanced Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
+#: ../fheroes2/heroes/skill.cpp:413
 msgid "Expert Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
+#: ../fheroes2/heroes/skill.cpp:413
 msgid "Basic Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
+#: ../fheroes2/heroes/skill.cpp:414
 msgid "Advanced Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
+#: ../fheroes2/heroes/skill.cpp:414
 msgid "Expert Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:406
-msgid "Allows you to negotiate with monsters who are weaker than your group."
+#: ../fheroes2/heroes/skill.cpp:463
+msgid " allows you to negotiate with monsters who are weaker than your group."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:421
-msgid "Allows your hero to learn third level spells."
+#: ../fheroes2/heroes/skill.cpp:472
+msgid "All of the creatures may offer to join you."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:423
-msgid "Allows your hero to learn fourth level spells."
+#: ../fheroes2/heroes/skill.cpp:492
+msgid " allows your hero to learn third level spells."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:425
-msgid "Allows your hero to learn fifth level spells."
+#: ../fheroes2/heroes/skill.cpp:495
+msgid " allows your hero to learn fourth level spells."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:440
+#: ../fheroes2/heroes/skill.cpp:498
+msgid " allows your hero to learn fifth level spells."
+msgstr ""
+
+#: ../fheroes2/heroes/skill.cpp:519
 msgid ""
-"Gives your hero's catapult shots a greater chance to hit and do damage to "
+" gives your hero's catapult shots a greater chance to hit and do damage to "
 "castle walls."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:442
+#: ../fheroes2/heroes/skill.cpp:522
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot has a greater chance "
-"to hit and do damage to castle walls."
+" gives your hero's catapult an extra shot, and each shot has a greater "
+"chance to hit and do damage to castle walls."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:444
+#: ../fheroes2/heroes/skill.cpp:525
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot automatically "
+" gives your hero's catapult an extra shot, and each shot automatically "
 "destroys any wall, except a fortified wall in a Knight town."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:876 ../fheroes2/heroes/skill.cpp:977
-msgid "View %{skill} Info"
-msgstr ""
-
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:108
+#: ../fheroes2/kingdom/color.cpp:33 ../fheroes2/kingdom/color.cpp:124
 msgid "Blue"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:111
+#: ../fheroes2/kingdom/color.cpp:33 ../fheroes2/kingdom/color.cpp:130
 msgid "Green"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:114
+#: ../fheroes2/kingdom/color.cpp:33 ../fheroes2/kingdom/color.cpp:136
 msgid "Red"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32
+#: ../fheroes2/kingdom/color.cpp:33
 msgid "Yellow"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:112
+#: ../fheroes2/kingdom/color.cpp:33 ../fheroes2/kingdom/color.cpp:132
 msgid "Orange"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:113
+#: ../fheroes2/kingdom/color.cpp:33 ../fheroes2/kingdom/color.cpp:134
 msgid "Purple"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:107
+#: ../fheroes2/kingdom/color.cpp:122
 msgid "Aqua"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:109
+#: ../fheroes2/kingdom/color.cpp:126
 msgid "Brown"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:110 ../fheroes2/resource/resource.cpp:283
+#: ../fheroes2/kingdom/color.cpp:128 ../fheroes2/resource/resource.cpp:323
 msgid "Gold"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:238
+#: ../fheroes2/kingdom/kingdom_overview.cpp:250
 msgid "Hero/Stats"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:241
+#: ../fheroes2/kingdom/kingdom_overview.cpp:253
 msgid "Skills"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:244
+#: ../fheroes2/kingdom/kingdom_overview.cpp:256
 msgid "Artifacts"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:473
+#: ../fheroes2/kingdom/kingdom_overview.cpp:475
 msgid "Town/Castle"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:476
+#: ../fheroes2/kingdom/kingdom_overview.cpp:478
 msgid "Garrison"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:566
+#: ../fheroes2/kingdom/kingdom_overview.cpp:572
 msgid "Gold Per Day:"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
+#: ../fheroes2/kingdom/luck.cpp:29
 msgid "luck|Cursed"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
+#: ../fheroes2/kingdom/luck.cpp:29
 msgid "luck|Awful"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
+#: ../fheroes2/kingdom/luck.cpp:29
 msgid "luck|Bad"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
+#: ../fheroes2/kingdom/luck.cpp:29
 msgid "luck|Normal"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
+#: ../fheroes2/kingdom/luck.cpp:29
 msgid "luck|Good"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
+#: ../fheroes2/kingdom/luck.cpp:29
 msgid "luck|Great"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
+#: ../fheroes2/kingdom/luck.cpp:29
 msgid "luck|Irish"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:48
+#: ../fheroes2/kingdom/luck.cpp:55
 msgid ""
 "Bad luck sometimes falls on your armies in combat, causing their attacks to "
 "only do half damage."
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:49
+#: ../fheroes2/kingdom/luck.cpp:56
 msgid ""
 "Neutral luck means your armies will never get lucky or unlucky attacks on "
 "the enemy."
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:50
+#: ../fheroes2/kingdom/luck.cpp:57
 msgid ""
 "Good luck sometimes lets your armies get lucky attacks (double strength) in "
 "combat."
@@ -4652,41 +5586,41 @@ msgstr ""
 msgid "morale|Normal"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
+#: ../fheroes2/kingdom/morale.cpp:29
 msgid "morale|Good"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
+#: ../fheroes2/kingdom/morale.cpp:29
 msgid "morale|Great"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
+#: ../fheroes2/kingdom/morale.cpp:29
 msgid "morale|Blood!"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:48
+#: ../fheroes2/kingdom/morale.cpp:55
 msgid "Bad morale may cause your armies to freeze in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:49
+#: ../fheroes2/kingdom/morale.cpp:56
 msgid ""
 "Neutral morale means your armies will never be blessed with extra attacks or "
 "freeze in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:50
+#: ../fheroes2/kingdom/morale.cpp:57
 msgid "Good morale may give your armies extra attacks in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
+#: ../fheroes2/kingdom/race.cpp:30
 msgid "Knight"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
+#: ../fheroes2/kingdom/race.cpp:30
 msgid "Barbarian"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
+#: ../fheroes2/kingdom/race.cpp:30
 msgid "Sorceress"
 msgstr ""
 
@@ -4706,27 +5640,27 @@ msgstr ""
 msgid "Multi"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
+#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Standing"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
+#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Crawling"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
+#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Very Slow"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
+#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Slow"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
+#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Average"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
+#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Fast"
 msgstr ""
 
@@ -4734,15 +5668,15 @@ msgstr ""
 msgid "speed|Very Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
+#: ../fheroes2/kingdom/speed.cpp:30
 msgid "speed|Ultra Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
+#: ../fheroes2/kingdom/speed.cpp:30
 msgid "speed|Blazing"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
+#: ../fheroes2/kingdom/speed.cpp:30
 msgid "speed|Instant"
 msgstr ""
 
@@ -4754,170 +5688,92 @@ msgstr ""
 msgid "week|Ant"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
+#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Grasshopper"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
+#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Dragonfly"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
+#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Spider"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
+#: ../fheroes2/kingdom/week.cpp:37
 msgid "week|Butterfly"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
+#: ../fheroes2/kingdom/week.cpp:38
 msgid "week|Bumblebee"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
+#: ../fheroes2/kingdom/week.cpp:39
 msgid "week|Locust"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
+#: ../fheroes2/kingdom/week.cpp:40
 msgid "week|Earthworm"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
+#: ../fheroes2/kingdom/week.cpp:41
 msgid "week|Hornet"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
+#: ../fheroes2/kingdom/week.cpp:42
 msgid "week|Beetle"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
+#: ../fheroes2/kingdom/week.cpp:43
 msgid "week|Squirrel"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
+#: ../fheroes2/kingdom/week.cpp:44
 msgid "week|Rabbit"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
+#: ../fheroes2/kingdom/week.cpp:45
 msgid "week|Gopher"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
+#: ../fheroes2/kingdom/week.cpp:46
 msgid "week|Badger"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
+#: ../fheroes2/kingdom/week.cpp:47
 msgid "week|Eagle"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
+#: ../fheroes2/kingdom/week.cpp:48
 msgid "week|Weasel"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
+#: ../fheroes2/kingdom/week.cpp:49
 msgid "week|Raven"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
+#: ../fheroes2/kingdom/week.cpp:50
 msgid "week|Mongoose"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
+#: ../fheroes2/kingdom/week.cpp:51
 msgid "week|Aardvark"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
+#: ../fheroes2/kingdom/week.cpp:52
 msgid "week|Lizard"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
+#: ../fheroes2/kingdom/week.cpp:53
 msgid "week|Tortoise"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
+#: ../fheroes2/kingdom/week.cpp:54
 msgid "week|Hedgehog"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
+#: ../fheroes2/kingdom/week.cpp:55
 msgid "week|Condor"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1620
-msgid "The ultimate artifact is really the %{name}"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1624
-msgid "The ultimate artifact may be found in the %{name} regions of the world."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1629
-msgid "north-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1632
-msgid "north"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1634
-msgid "north-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1640
-msgid "west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1643
-msgid "center"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1645
-msgid "east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1650
-msgid "south-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1653
-msgid "south"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1655
-msgid "south-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1659
-msgid "The truth is out there."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1660
-msgid "The dark side is stronger."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1661
-msgid "The end of the world is near."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1662
-msgid "The bones of Lord Slayer are buried in the foundation of the arena."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1663
-msgid "A Black Dragon will take out a Titan any day of the week."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1664
-msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1666
-msgid ""
-"You can load the newest version of game from a site:\n"
-" http://sf.net/projects/fheroes2"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1667
-msgid "This game is now in beta development version. ;)"
 msgstr ""
 
 #: ../fheroes2/maps/ground.cpp:30
@@ -4932,455 +5788,447 @@ msgstr ""
 msgid "Wasteland"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:30
+#: ../fheroes2/maps/ground.cpp:30 ../fheroes2/maps/mp2.cpp:413
 msgid "Beach"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:31
+#: ../fheroes2/maps/ground.cpp:30
 msgid "Lava"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:31 ../fheroes2/resource/maps_text.cpp:210
+#: ../fheroes2/maps/ground.cpp:30
 msgid "Dirt"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:31
+#: ../fheroes2/maps/ground.cpp:30
 msgid "Grass"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:31
-msgid "Water"
-msgstr ""
-
-#: ../fheroes2/maps/maps.cpp:104
-msgid "maps|Small"
-msgstr ""
-
-#: ../fheroes2/maps/maps.cpp:104
-msgid "maps|Medium"
-msgstr ""
-
-#: ../fheroes2/maps/maps.cpp:104
-msgid "maps|Large"
-msgstr ""
-
-#: ../fheroes2/maps/maps.cpp:104
-msgid "maps|Extra Large"
-msgstr ""
-
-#: ../fheroes2/maps/maps.cpp:104
-msgid "maps|Custom Size"
-msgstr ""
-
-#: ../fheroes2/maps/maps.cpp:122
-msgid "Ore Mine"
-msgstr ""
-
-#: ../fheroes2/maps/maps.cpp:123
-msgid "Sulfur Mine"
-msgstr ""
-
-#: ../fheroes2/maps/maps.cpp:124
-msgid "Crystal Mine"
+#: ../fheroes2/maps/ground.cpp:30
+msgid "Ocean"
 msgstr ""
 
 #: ../fheroes2/maps/maps.cpp:125
+msgid "maps|Small"
+msgstr ""
+
+#: ../fheroes2/maps/maps.cpp:125
+msgid "maps|Medium"
+msgstr ""
+
+#: ../fheroes2/maps/maps.cpp:125
+msgid "maps|Large"
+msgstr ""
+
+#: ../fheroes2/maps/maps.cpp:125
+msgid "maps|Extra Large"
+msgstr ""
+
+#: ../fheroes2/maps/maps.cpp:125
+msgid "maps|Custom Size"
+msgstr ""
+
+#: ../fheroes2/maps/maps.cpp:147
+msgid "Ore Mine"
+msgstr ""
+
+#: ../fheroes2/maps/maps.cpp:149
+msgid "Sulfur Mine"
+msgstr ""
+
+#: ../fheroes2/maps/maps.cpp:151
+msgid "Crystal Mine"
+msgstr ""
+
+#: ../fheroes2/maps/maps.cpp:153
 msgid "Gems Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:126
+#: ../fheroes2/maps/maps.cpp:155
 msgid "Gold Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:130
+#: ../fheroes2/maps/maps.cpp:160
 msgid "Mine"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:365
+#: ../fheroes2/maps/mp2.cpp:249
 msgid "Alchemist Lab"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:367
+#: ../fheroes2/maps/mp2.cpp:252
 msgid "Daemon Cave"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:369
+#: ../fheroes2/maps/mp2.cpp:255
 msgid "Faerie Ring"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:373 ../fheroes2/resource/maps_text.cpp:217
+#: ../fheroes2/maps/mp2.cpp:261
 msgid "Dragon City"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:375
-msgid "Light House"
+#: ../fheroes2/maps/mp2.cpp:264
+msgid "Lighthouse"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:377
+#: ../fheroes2/maps/mp2.cpp:267
 msgid "Water Wheel"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:379
+#: ../fheroes2/maps/mp2.cpp:270
 msgid "Mines"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:381
+#: ../fheroes2/maps/mp2.cpp:273
 msgid "Obelisk"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:383
+#: ../fheroes2/maps/mp2.cpp:276
 msgid "Oasis"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:385
+#: ../fheroes2/maps/mp2.cpp:279
 msgid "Sawmill"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:387
+#: ../fheroes2/maps/mp2.cpp:282
 msgid "Oracle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:389
+#: ../fheroes2/maps/mp2.cpp:285
 msgid "Desert Tent"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:393
+#: ../fheroes2/maps/mp2.cpp:291
 msgid "Wagon Camp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:395
+#: ../fheroes2/maps/mp2.cpp:294
 msgid "Windmill"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:397
+#: ../fheroes2/maps/mp2.cpp:297
 msgid "Random Town"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:399
+#: ../fheroes2/maps/mp2.cpp:300
 msgid "Random Castle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:401
+#: ../fheroes2/maps/mp2.cpp:303
 msgid "Watch Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:403
+#: ../fheroes2/maps/mp2.cpp:306
 msgid "Tree City"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:405
+#: ../fheroes2/maps/mp2.cpp:309
 msgid "Tree House"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:407
+#: ../fheroes2/maps/mp2.cpp:312
 msgid "Ruins"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:409
+#: ../fheroes2/maps/mp2.cpp:315
 msgid "Fort"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:411
-msgid "Trading Post"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:413
+#: ../fheroes2/maps/mp2.cpp:321
 msgid "Abandoned Mine"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:415
+#: ../fheroes2/maps/mp2.cpp:324
 msgid "Tree of Knowledge"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:417
+#: ../fheroes2/maps/mp2.cpp:327
 msgid "Witch Doctor's Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:419
+#: ../fheroes2/maps/mp2.cpp:330
 msgid "Temple"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:421
+#: ../fheroes2/maps/mp2.cpp:333
 msgid "Hill Fort"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:423
+#: ../fheroes2/maps/mp2.cpp:336
 msgid "Halfling Hole"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:425
+#: ../fheroes2/maps/mp2.cpp:339
 msgid "Mercenary Camp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:429
+#: ../fheroes2/maps/mp2.cpp:345
 msgid "City of the Dead"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:433
+#: ../fheroes2/maps/mp2.cpp:351
 msgid "Sphinx"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:435
+#: ../fheroes2/maps/mp2.cpp:354
 msgid "Troll Bridge"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:437
+#: ../fheroes2/maps/mp2.cpp:357
 msgid "Witch Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:439
+#: ../fheroes2/maps/mp2.cpp:360
 msgid "Xanadu"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:443
+#: ../fheroes2/maps/mp2.cpp:366
 msgid "Magellan Maps"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:445
+#: ../fheroes2/maps/mp2.cpp:369
 msgid "Derelict Ship"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:447
-msgid "Ship Wreck"
+#: ../fheroes2/maps/mp2.cpp:372
+msgid "Shipwreck"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:449
+#: ../fheroes2/maps/mp2.cpp:375
 msgid "Observation Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:451
-msgid "Freeman Foundry"
+#: ../fheroes2/maps/mp2.cpp:378
+msgid "Freeman's Foundry"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:453
+#: ../fheroes2/maps/mp2.cpp:381
 msgid "Watering Hole"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:455
+#: ../fheroes2/maps/mp2.cpp:384
 msgid "Artesian Spring"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:457
+#: ../fheroes2/maps/mp2.cpp:387
 msgid "Gazebo"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:459
+#: ../fheroes2/maps/mp2.cpp:390
 msgid "Archer's House"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:461
+#: ../fheroes2/maps/mp2.cpp:393
 msgid "Peasant Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:463
+#: ../fheroes2/maps/mp2.cpp:396
 msgid "Dwarf Cottage"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:465
+#: ../fheroes2/maps/mp2.cpp:399
 msgid "Stone Liths"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:467
+#: ../fheroes2/maps/mp2.cpp:402
 msgid "Magic Well"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:468
+#: ../fheroes2/maps/mp2.cpp:404
 msgid "Heroes"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:470 ../fheroes2/maps/mp2.cpp:488
-msgid "Shrub"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:471
+#: ../fheroes2/maps/mp2.cpp:409
 msgid "Nothing Special"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:472
+#: ../fheroes2/maps/mp2.cpp:411
 msgid "Tar Pit"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:473
-msgid "Coast"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:474
+#: ../fheroes2/maps/mp2.cpp:415
 msgid "Mound"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:475
+#: ../fheroes2/maps/mp2.cpp:417
 msgid "Dune"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:476
+#: ../fheroes2/maps/mp2.cpp:419
 msgid "Stump"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:477
+#: ../fheroes2/maps/mp2.cpp:421
 msgid "Cactus"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:478
+#: ../fheroes2/maps/mp2.cpp:423
 msgid "Trees"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:479
+#: ../fheroes2/maps/mp2.cpp:425
 msgid "Dead Tree"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:480
+#: ../fheroes2/maps/mp2.cpp:427
 msgid "Mountains"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:481
+#: ../fheroes2/maps/mp2.cpp:429
 msgid "Volcano"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:482
+#: ../fheroes2/maps/mp2.cpp:431
 msgid "Rock"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:483
+#: ../fheroes2/maps/mp2.cpp:433
 msgid "Flowers"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:484
+#: ../fheroes2/maps/mp2.cpp:435
 msgid "Water Lake"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:485
+#: ../fheroes2/maps/mp2.cpp:437
 msgid "Mandrake"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:486
+#: ../fheroes2/maps/mp2.cpp:439
 msgid "Crater"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:487
+#: ../fheroes2/maps/mp2.cpp:441
 msgid "Lava Pool"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:489
+#: ../fheroes2/maps/mp2.cpp:443
+msgid "Shrub"
+msgstr ""
+
+#: ../fheroes2/maps/mp2.cpp:445
 msgid "Buoy"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:491 ../fheroes2/monster/monster.cpp:116
+#: ../fheroes2/maps/mp2.cpp:448
 msgid "Skeleton"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:492
+#: ../fheroes2/maps/mp2.cpp:450
 msgid "Treasure Chest"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:493
+#: ../fheroes2/maps/mp2.cpp:452
 msgid "Sea Chest"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:494
+#: ../fheroes2/maps/mp2.cpp:454
 msgid "Campfire"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:495
+#: ../fheroes2/maps/mp2.cpp:456
 msgid "Fountain"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:496
+#: ../fheroes2/maps/mp2.cpp:458
 msgid "Genie Lamp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:497
+#: ../fheroes2/maps/mp2.cpp:460
 msgid "Goblin Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:499
+#: ../fheroes2/maps/mp2.cpp:464
 msgid "Monster"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:500
+#: ../fheroes2/maps/mp2.cpp:466
 msgid "Resource"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:501
+#: ../fheroes2/maps/mp2.cpp:468
 msgid "Whirlpool"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:502
+#: ../fheroes2/maps/mp2.cpp:470
 msgid "Artifact"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:503
+#: ../fheroes2/maps/mp2.cpp:472
 msgid "Boat"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:510
+#: ../fheroes2/maps/mp2.cpp:486
 msgid "Standing Stones"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:514
+#: ../fheroes2/maps/mp2.cpp:494
 msgid "Idol"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:515
+#: ../fheroes2/maps/mp2.cpp:496
 msgid "Shrine of the First Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:516
+#: ../fheroes2/maps/mp2.cpp:498
 msgid "Shrine of the Second Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:517
+#: ../fheroes2/maps/mp2.cpp:500
 msgid "Shrine of the Third Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:518
+#: ../fheroes2/maps/mp2.cpp:502
 msgid "Wagon"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:519
+#: ../fheroes2/maps/mp2.cpp:504
 msgid "Lean To"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:520
+#: ../fheroes2/maps/mp2.cpp:506
 msgid "Flotsam"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:521
+#: ../fheroes2/maps/mp2.cpp:508
 msgid "Shipwreck Survivor"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:522
+#: ../fheroes2/maps/mp2.cpp:510
 msgid "Bottle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:523
+#: ../fheroes2/maps/mp2.cpp:512
 msgid "Magic Garden"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:529
+#: ../fheroes2/maps/mp2.cpp:522
 msgid "Jail"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:531
+#: ../fheroes2/maps/mp2.cpp:525
 msgid "Traveller's Tent"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:532
+#: ../fheroes2/maps/mp2.cpp:527
 msgid "Barrier"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:535
+#: ../fheroes2/maps/mp2.cpp:531
 msgid "Fire Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:537
+#: ../fheroes2/maps/mp2.cpp:534
 msgid "Air Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:539
+#: ../fheroes2/maps/mp2.cpp:537
 msgid "Earth Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:541
+#: ../fheroes2/maps/mp2.cpp:540
 msgid "Water Summoning Altar"
 msgstr ""
 
@@ -5388,1286 +6236,742 @@ msgstr ""
 msgid "Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:545
-msgid "Arena"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:547
+#: ../fheroes2/maps/mp2.cpp:549
 msgid "Stables"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:549
+#: ../fheroes2/maps/mp2.cpp:552
 msgid "Alchemist's Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:551
+#: ../fheroes2/maps/mp2.cpp:555
 msgid "Hut of the Magi"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:553
+#: ../fheroes2/maps/mp2.cpp:558
 msgid "Eye of the Magi"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:555
+#: ../fheroes2/maps/mp2.cpp:561
 msgid "Mermaid"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:557
+#: ../fheroes2/maps/mp2.cpp:564
 msgid "Sirens"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:558
+#: ../fheroes2/maps/mp2.cpp:566
 msgid "Reefs"
 msgstr ""
 
-#: ../fheroes2/monster/monster.cpp:59
-msgid "Peasant"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:59 ../fheroes2/resource/maps_text.cpp:501
-msgid "Peasants"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Archer"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Archers"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Ranger"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Rangers"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Pikeman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Pikemen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Veteran Pikeman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Veteran Pikemen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Swordsman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Swordsmen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Master Swordsman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Master Swordsmen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Cavalry"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Cavalries"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Champion"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Champions"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Paladin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Paladins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:69
-msgid "Crusader"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:69
-msgid "Crusaders"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Goblin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Goblins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orc"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orcs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chief"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chiefs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Wolf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Wolves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogre"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogres"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Ogre Lord"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Ogre Lords"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "Troll"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "Trolls"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "War Troll"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "War Trolls"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:80
-msgid "Cyclops"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:80
-msgid "Cyclopes"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Sprite"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Sprites"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Dwarf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Dwarves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Battle Dwarf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Battle Dwarves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druid"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druids"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druid"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druids"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorn"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorns"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:91
-msgid "Phoenix"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:91
-msgid "Phoenixes"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaur"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaurs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyle"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyles"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaur"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaurs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur King"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur Kings"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydra"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydras"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halfling"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halflings"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boar"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boars"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golem"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golems"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golem"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golems"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Roc"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Rocs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Mage"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Magi"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmage"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmagi"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:112
-msgid "Giant"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:112 ../fheroes2/resource/maps_text.cpp:293
-msgid "Giants"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titan"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titans"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:116
-msgid "Skeletons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummy"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummy"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampire"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampires"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lord"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lords"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Lich"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Liches"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Lich"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Liches"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogue"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogues"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomad"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomads"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghost"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghosts"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusa"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusas"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elementals"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:694
-msgid "buy"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:158
-msgid "Campaign Game"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "Error"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "This release is compiled without network support."
-msgstr ""
-
-#: ../fheroes2/resource/artifact.cpp:51
+#: ../fheroes2/resource/artifact.cpp:65
 msgid "Ultimate Book of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:51 ../fheroes2/resource/artifact.cpp:77
-#: ../fheroes2/resource/artifact.cpp:78 ../fheroes2/resource/artifact.cpp:79
-#: ../fheroes2/resource/artifact.cpp:80
+#: ../fheroes2/resource/artifact.cpp:65 ../fheroes2/resource/artifact.cpp:91
+#: ../fheroes2/resource/artifact.cpp:92 ../fheroes2/resource/artifact.cpp:93
+#: ../fheroes2/resource/artifact.cpp:94
 msgid "The %{name} increases your knowledge by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:52
+#: ../fheroes2/resource/artifact.cpp:66
 msgid "Ultimate Sword of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:52 ../fheroes2/resource/artifact.cpp:68
-#: ../fheroes2/resource/artifact.cpp:71 ../fheroes2/resource/artifact.cpp:74
-#: ../fheroes2/resource/artifact.cpp:75 ../fheroes2/resource/artifact.cpp:149
-#: ../fheroes2/resource/artifact.cpp:155
+#: ../fheroes2/resource/artifact.cpp:66 ../fheroes2/resource/artifact.cpp:82
+#: ../fheroes2/resource/artifact.cpp:85 ../fheroes2/resource/artifact.cpp:88
+#: ../fheroes2/resource/artifact.cpp:89 ../fheroes2/resource/artifact.cpp:165
+#: ../fheroes2/resource/artifact.cpp:171
 msgid "The %{name} increases your attack skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:53
+#: ../fheroes2/resource/artifact.cpp:67
 msgid "Ultimate Cloak of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:53 ../fheroes2/resource/artifact.cpp:70
-#: ../fheroes2/resource/artifact.cpp:73 ../fheroes2/resource/artifact.cpp:76
+#: ../fheroes2/resource/artifact.cpp:67 ../fheroes2/resource/artifact.cpp:84
+#: ../fheroes2/resource/artifact.cpp:87 ../fheroes2/resource/artifact.cpp:90
 msgid "The %{name} increases your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:54
+#: ../fheroes2/resource/artifact.cpp:68
 msgid "Ultimate Wand of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:54 ../fheroes2/resource/artifact.cpp:59
-#: ../fheroes2/resource/artifact.cpp:60 ../fheroes2/resource/artifact.cpp:61
-#: ../fheroes2/resource/artifact.cpp:62 ../fheroes2/resource/artifact.cpp:148
+#: ../fheroes2/resource/artifact.cpp:68 ../fheroes2/resource/artifact.cpp:73
+#: ../fheroes2/resource/artifact.cpp:74 ../fheroes2/resource/artifact.cpp:75
+#: ../fheroes2/resource/artifact.cpp:76 ../fheroes2/resource/artifact.cpp:164
 msgid "The %{name} increases your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:55
+#: ../fheroes2/resource/artifact.cpp:69
 msgid "Ultimate Shield"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:55 ../fheroes2/resource/artifact.cpp:128
-#: ../fheroes2/resource/artifact.cpp:129
+#: ../fheroes2/resource/artifact.cpp:69 ../fheroes2/resource/artifact.cpp:142
+#: ../fheroes2/resource/artifact.cpp:143
 msgid "The %{name} increases your attack and defense skills by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:56
+#: ../fheroes2/resource/artifact.cpp:70
 msgid "Ultimate Staff"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:56 ../fheroes2/resource/artifact.cpp:130
-#: ../fheroes2/resource/artifact.cpp:131
+#: ../fheroes2/resource/artifact.cpp:70 ../fheroes2/resource/artifact.cpp:144
+#: ../fheroes2/resource/artifact.cpp:145
 msgid "The %{name} increases your spell power and knowledge by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:57
+#: ../fheroes2/resource/artifact.cpp:71
 msgid "Ultimate Crown"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:57
+#: ../fheroes2/resource/artifact.cpp:71
 msgid "The %{name} increases each of your basic skills by %{count} points."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:58
+#: ../fheroes2/resource/artifact.cpp:72
 msgid "Golden Goose"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:58
+#: ../fheroes2/resource/artifact.cpp:72
 msgid "The %{name} brings in an income of %{count} gold per turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:59
+#: ../fheroes2/resource/artifact.cpp:73
 msgid "Arcane Necklace of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:60
+#: ../fheroes2/resource/artifact.cpp:74
 msgid "Caster's Bracelet of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:61
+#: ../fheroes2/resource/artifact.cpp:75
 msgid "Mage's Ring of Power"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:62
+#: ../fheroes2/resource/artifact.cpp:76
 msgid "Witch's Broach of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:63
+#: ../fheroes2/resource/artifact.cpp:77
 msgid "Medal of Valor"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:63 ../fheroes2/resource/artifact.cpp:64
-#: ../fheroes2/resource/artifact.cpp:65 ../fheroes2/resource/artifact.cpp:66
+#: ../fheroes2/resource/artifact.cpp:77 ../fheroes2/resource/artifact.cpp:78
+#: ../fheroes2/resource/artifact.cpp:79 ../fheroes2/resource/artifact.cpp:80
 msgid "The %{name} increases your morale."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:64
+#: ../fheroes2/resource/artifact.cpp:78
 msgid "Medal of Courage"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:65
+#: ../fheroes2/resource/artifact.cpp:79
 msgid "Medal of Honor"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:66
+#: ../fheroes2/resource/artifact.cpp:80
 msgid "Medal of Distinction"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:67
+#: ../fheroes2/resource/artifact.cpp:81
 msgid "Fizbin of Misfortune"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:67
+#: ../fheroes2/resource/artifact.cpp:81
 msgid "The %{name} greatly decreases your morale by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:68
+#: ../fheroes2/resource/artifact.cpp:82
 msgid "Thunder Mace of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:69
+#: ../fheroes2/resource/artifact.cpp:83
 msgid "Armored Gauntlets of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:69
+#: ../fheroes2/resource/artifact.cpp:83
 msgid "The %{name} increase your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:70
+#: ../fheroes2/resource/artifact.cpp:84
 msgid "Defender Helm of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:71
+#: ../fheroes2/resource/artifact.cpp:85
 msgid "Giant Flail of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:72
+#: ../fheroes2/resource/artifact.cpp:86
 msgid "Ballista of Quickness"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:72
+#: ../fheroes2/resource/artifact.cpp:86
 msgid "The %{name} lets your catapult fire twice per combat round."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:73
+#: ../fheroes2/resource/artifact.cpp:87
 msgid "Stealth Shield of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:74
+#: ../fheroes2/resource/artifact.cpp:88
 msgid "Dragon Sword of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:75
+#: ../fheroes2/resource/artifact.cpp:89
 msgid "Power Axe of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:76
+#: ../fheroes2/resource/artifact.cpp:90
 msgid "Divine Breastplate of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:77
+#: ../fheroes2/resource/artifact.cpp:91
 msgid "Minor Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:78
+#: ../fheroes2/resource/artifact.cpp:92
 msgid "Major Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:79
+#: ../fheroes2/resource/artifact.cpp:93
 msgid "Superior Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:80
+#: ../fheroes2/resource/artifact.cpp:94
 msgid "Foremost Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:81
+#: ../fheroes2/resource/artifact.cpp:95
 msgid "Endless Sack of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:81 ../fheroes2/resource/artifact.cpp:82
-#: ../fheroes2/resource/artifact.cpp:83
+#: ../fheroes2/resource/artifact.cpp:95 ../fheroes2/resource/artifact.cpp:96
+#: ../fheroes2/resource/artifact.cpp:97
 msgid "The %{name} provides you with %{count} gold per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:82
+#: ../fheroes2/resource/artifact.cpp:96
 msgid "Endless Bag of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:83
+#: ../fheroes2/resource/artifact.cpp:97
 msgid "Endless Purse of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:84
+#: ../fheroes2/resource/artifact.cpp:98
 msgid "Nomad Boots of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:84 ../fheroes2/resource/artifact.cpp:85
+#: ../fheroes2/resource/artifact.cpp:98 ../fheroes2/resource/artifact.cpp:99
 msgid "The %{name} increase your movement on land."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:85
+#: ../fheroes2/resource/artifact.cpp:99
 msgid "Traveler's Boots of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:86
+#: ../fheroes2/resource/artifact.cpp:100
 msgid "Lucky Rabbit's Foot"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:86 ../fheroes2/resource/artifact.cpp:87
-#: ../fheroes2/resource/artifact.cpp:88 ../fheroes2/resource/artifact.cpp:89
+#: ../fheroes2/resource/artifact.cpp:100 ../fheroes2/resource/artifact.cpp:101
+#: ../fheroes2/resource/artifact.cpp:102 ../fheroes2/resource/artifact.cpp:103
 msgid "The %{name} increases your luck in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:87
+#: ../fheroes2/resource/artifact.cpp:101
 msgid "Golden Horseshoe"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:88
+#: ../fheroes2/resource/artifact.cpp:102
 msgid "Gambler's Lucky Coin"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:89
+#: ../fheroes2/resource/artifact.cpp:103
 msgid "Four-Leaf Clover"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:90
+#: ../fheroes2/resource/artifact.cpp:104
 msgid "True Compass of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:90
+#: ../fheroes2/resource/artifact.cpp:104
 msgid "The %{name} increases your movement on land and sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:91
+#: ../fheroes2/resource/artifact.cpp:105
 msgid "Sailor's Astrolabe of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:91
+#: ../fheroes2/resource/artifact.cpp:105
 msgid "The %{name} increases your movement on sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:92
+#: ../fheroes2/resource/artifact.cpp:106
 msgid "Evil Eye"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:92
+#: ../fheroes2/resource/artifact.cpp:106
 msgid "The %{name} reduces the casting cost of curse spells by half."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:93
+#: ../fheroes2/resource/artifact.cpp:107
 msgid "Enchanted Hourglass"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:93
+#: ../fheroes2/resource/artifact.cpp:107
 msgid "The %{name} extends the duration of all your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:94
+#: ../fheroes2/resource/artifact.cpp:108
 msgid "Gold Watch"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:94
+#: ../fheroes2/resource/artifact.cpp:108
 msgid "The %{name} doubles the effectiveness of your hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
+#: ../fheroes2/resource/artifact.cpp:109
 msgid "Skullcap"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
+#: ../fheroes2/resource/artifact.cpp:109
 msgid "The %{name} halves the casting cost of all mind influencing spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:96
+#: ../fheroes2/resource/artifact.cpp:110
 msgid "Ice Cloak"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:96
+#: ../fheroes2/resource/artifact.cpp:110
 msgid "The %{name} halves all damage your troops take from cold spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:97
+#: ../fheroes2/resource/artifact.cpp:111
 msgid "Fire Cloak"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:97
+#: ../fheroes2/resource/artifact.cpp:111
 msgid "The %{name} halves all damage your troops take from fire spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:98
+#: ../fheroes2/resource/artifact.cpp:112
 msgid "Lightning Helm"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:98
+#: ../fheroes2/resource/artifact.cpp:112
 msgid "The %{name} halves all damage your troops take from lightning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
+#: ../fheroes2/resource/artifact.cpp:113
 msgid "Evercold Icicle"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
+#: ../fheroes2/resource/artifact.cpp:113
 msgid ""
 "The %{name} causes your cold spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
+#: ../fheroes2/resource/artifact.cpp:114
 msgid "Everhot Lava Rock"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
+#: ../fheroes2/resource/artifact.cpp:114
 msgid ""
 "The %{name} causes your fire spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:101
+#: ../fheroes2/resource/artifact.cpp:115
 msgid "Lightning Rod"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:101
+#: ../fheroes2/resource/artifact.cpp:115
 msgid ""
 "The %{name} causes your lightning spells to do %{count} percent more damage "
 "to enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:102
+#: ../fheroes2/resource/artifact.cpp:116
 msgid "Snake-Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:102
+#: ../fheroes2/resource/artifact.cpp:116
 msgid "The %{name} halves the casting cost of all your bless spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:103
+#: ../fheroes2/resource/artifact.cpp:117
 msgid "Ankh"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:103
+#: ../fheroes2/resource/artifact.cpp:117
 msgid ""
 "The %{name} doubles the effectiveness of all your resurrect and animate "
 "spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:104
+#: ../fheroes2/resource/artifact.cpp:118
 msgid "Book of Elements"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:104
+#: ../fheroes2/resource/artifact.cpp:118
 msgid "The %{name} doubles the effectiveness of all your summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:105
+#: ../fheroes2/resource/artifact.cpp:119
 msgid "Elemental Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:105
+#: ../fheroes2/resource/artifact.cpp:119
 msgid "The %{name} halves the casting cost of all summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
+#: ../fheroes2/resource/artifact.cpp:120
 msgid "Holy Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
+#: ../fheroes2/resource/artifact.cpp:120
 msgid "The %{name} makes all your troops immune to curse spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
+#: ../fheroes2/resource/artifact.cpp:121
 msgid "Pendant of Free Will"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
+#: ../fheroes2/resource/artifact.cpp:121
 msgid "The %{name} makes all your troops immune to hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:108
+#: ../fheroes2/resource/artifact.cpp:122
 msgid "Pendant of Life"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:108
+#: ../fheroes2/resource/artifact.cpp:122
 msgid "The %{name} makes all your troops immune to death spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
+#: ../fheroes2/resource/artifact.cpp:123
 msgid "Serenity Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
+#: ../fheroes2/resource/artifact.cpp:123
 msgid "The %{name} makes all your troops immune to berserk spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
+#: ../fheroes2/resource/artifact.cpp:124
 msgid "Seeing-eye Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
+#: ../fheroes2/resource/artifact.cpp:124
 msgid "The %{name} makes all your troops immune to blindness spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
+#: ../fheroes2/resource/artifact.cpp:125
 msgid "Kinetic Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
+#: ../fheroes2/resource/artifact.cpp:125
 msgid "The %{name} makes all your troops immune to paralyze spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
+#: ../fheroes2/resource/artifact.cpp:126
 msgid "Pendant of Death"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
+#: ../fheroes2/resource/artifact.cpp:126
 msgid "The %{name} makes all your troops immune to holy spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
+#: ../fheroes2/resource/artifact.cpp:127
 msgid "Wand of Negation"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
+#: ../fheroes2/resource/artifact.cpp:127
 msgid "The %{name} protects your troops from the Dispel Magic spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:114
+#: ../fheroes2/resource/artifact.cpp:128
 msgid "Golden Bow"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:114
+#: ../fheroes2/resource/artifact.cpp:128
 msgid ""
 "The %{name} eliminates the %{count} percent penalty for your troops shooting "
-"past obstacles. (e.g. castle walls)"
+"past obstacles (e.g. castle walls)."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:115
+#: ../fheroes2/resource/artifact.cpp:129
 msgid "Telescope"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:115
+#: ../fheroes2/resource/artifact.cpp:129
 msgid ""
 "The %{name} increases the amount of terrain your hero reveals when "
 "adventuring by %{count} extra square."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:116
+#: ../fheroes2/resource/artifact.cpp:130
 msgid "Statesman's Quill"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:116
+#: ../fheroes2/resource/artifact.cpp:130
 msgid ""
 "The %{name} reduces the cost of surrender to %{count} percent of the total "
 "cost of troops you have in your army."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:117
+#: ../fheroes2/resource/artifact.cpp:131
 msgid "Wizard's Hat"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:117
+#: ../fheroes2/resource/artifact.cpp:131
 msgid "The %{name} increases the duration of your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
+#: ../fheroes2/resource/artifact.cpp:132
 msgid "Power Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
+#: ../fheroes2/resource/artifact.cpp:132
 msgid "The %{name} returns %{count} extra power points/turn to your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
+#: ../fheroes2/resource/artifact.cpp:133
 msgid "Ammo Cart"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
+#: ../fheroes2/resource/artifact.cpp:133
 msgid "The %{name} provides endless ammunition for all your troops that shoot."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
+#: ../fheroes2/resource/artifact.cpp:134
 msgid "Tax Lien"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
+#: ../fheroes2/resource/artifact.cpp:134
 msgid "The %{name} costs you %{count} gold pieces/turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:121
+#: ../fheroes2/resource/artifact.cpp:135
 msgid "Hideous Mask"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:121
+#: ../fheroes2/resource/artifact.cpp:135
 msgid "The %{name} prevents all 'wandering' armies from joining your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:122
+#: ../fheroes2/resource/artifact.cpp:136
 msgid "Endless Pouch of Sulfur"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:122
+#: ../fheroes2/resource/artifact.cpp:136
 msgid "The %{name} provides %{count} unit of sulfur per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:123
+#: ../fheroes2/resource/artifact.cpp:137
 msgid "Endless Vial of Mercury"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:123
+#: ../fheroes2/resource/artifact.cpp:137
 msgid "The %{name} provides %{count} unit of mercury per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:124
+#: ../fheroes2/resource/artifact.cpp:138
 msgid "Endless Pouch of Gems"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:124
+#: ../fheroes2/resource/artifact.cpp:138
 msgid "The %{name} provides %{count} unit of gems per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:125
+#: ../fheroes2/resource/artifact.cpp:139
 msgid "Endless Cord of Wood"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:125
+#: ../fheroes2/resource/artifact.cpp:139
 msgid "The %{name} provides %{count} unit of wood per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:126
+#: ../fheroes2/resource/artifact.cpp:140
 msgid "Endless Cart of Ore"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:126
+#: ../fheroes2/resource/artifact.cpp:140
 msgid "The %{name} provides %{count} unit of ore per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:127
+#: ../fheroes2/resource/artifact.cpp:141
 msgid "Endless Pouch of Crystal"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:127
+#: ../fheroes2/resource/artifact.cpp:141
 msgid "The %{name} provides %{count} unit of crystal/day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:128
+#: ../fheroes2/resource/artifact.cpp:142
 msgid "Spiked Helm"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:129
+#: ../fheroes2/resource/artifact.cpp:143
 msgid "Spiked Shield"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:130
+#: ../fheroes2/resource/artifact.cpp:144
 msgid "White Pearl"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:131
+#: ../fheroes2/resource/artifact.cpp:145
 msgid "Black Pearl"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:133
+#: ../fheroes2/resource/artifact.cpp:147
 msgid "Magic Book"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:133
+#: ../fheroes2/resource/artifact.cpp:147
 msgid "The %{name} enables you to cast spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:140
+#: ../fheroes2/resource/artifact.cpp:154
 msgid "Spell Scroll"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:140
+#: ../fheroes2/resource/artifact.cpp:154
 msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
+#: ../fheroes2/resource/artifact.cpp:155
 msgid "Arm of the Martyr"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
+#: ../fheroes2/resource/artifact.cpp:155
 msgid ""
 "The %{name} increases your spell power by %{count} but adds the undead "
 "morale penalty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:142
+#: ../fheroes2/resource/artifact.cpp:156
 msgid "Breastplate of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:142
+#: ../fheroes2/resource/artifact.cpp:156
 msgid "The %{name} increases your defense by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
+#: ../fheroes2/resource/artifact.cpp:157
 msgid "Broach of Shielding"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
+#: ../fheroes2/resource/artifact.cpp:158
 msgid ""
 "The %{name} provides %{count} percent protection from Armageddon and "
 "Elemental Storm, but decreases spell power by 2."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
+#: ../fheroes2/resource/artifact.cpp:159
 msgid "Battle Garb of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
+#: ../fheroes2/resource/artifact.cpp:160
 msgid ""
 "The %{name} combines the powers of the three Anduran artifacts.  It provides "
 "maximum luck and morale for your troops and gives you the Town Portal spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:145
+#: ../fheroes2/resource/artifact.cpp:161
 msgid "Crystal Ball"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:145
+#: ../fheroes2/resource/artifact.cpp:161
 msgid ""
 "The %{name} lets you get more specific information about monsters, enemy "
 "heroes, and castles nearby the hero who holds it."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:146
+#: ../fheroes2/resource/artifact.cpp:162
 msgid "Heart of Fire"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:146
+#: ../fheroes2/resource/artifact.cpp:162
 msgid ""
 "The %{name} provides %{count} percent protection from fire, but doubles the "
 "damage taken from cold."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:147
+#: ../fheroes2/resource/artifact.cpp:163
 msgid "Heart of Ice"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:147
+#: ../fheroes2/resource/artifact.cpp:163
 msgid ""
 "The %{name} provides %{count} percent protection from cold, but doubles the "
 "damage taken from fire."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:148
+#: ../fheroes2/resource/artifact.cpp:164
 msgid "Helmet of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:149
+#: ../fheroes2/resource/artifact.cpp:165
 msgid "Holy Hammer"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:150
+#: ../fheroes2/resource/artifact.cpp:166
 msgid "Legendary Scepter"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:150
+#: ../fheroes2/resource/artifact.cpp:166
 msgid "The %{name} adds %{count} points to all attributes."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
+#: ../fheroes2/resource/artifact.cpp:167
 msgid "Masthead"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
+#: ../fheroes2/resource/artifact.cpp:167
 msgid "The %{name} boosts your luck and morale by %{count} each in sea combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
+#: ../fheroes2/resource/artifact.cpp:168
 msgid "Sphere of Negation"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
+#: ../fheroes2/resource/artifact.cpp:168
 msgid "The %{name} disables all spell casting, for both sides, in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
+#: ../fheroes2/resource/artifact.cpp:169
 msgid "Staff of Wizardry"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
+#: ../fheroes2/resource/artifact.cpp:169
 msgid "The %{name} boosts your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
+#: ../fheroes2/resource/artifact.cpp:170
 msgid "Sword Breaker"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
+#: ../fheroes2/resource/artifact.cpp:170
 msgid "The %{name} increases your defense by %{count} and attack by 1."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:155
+#: ../fheroes2/resource/artifact.cpp:171
 msgid "Sword of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:156
+#: ../fheroes2/resource/artifact.cpp:172
 msgid "Spade of Necromancy"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:156
+#: ../fheroes2/resource/artifact.cpp:172
 msgid "The %{name} gives you increased necromancy skill."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:638
+#: ../fheroes2/resource/artifact.cpp:646
 msgid ""
 "You find an elaborate aontainer which housesan old vellum scroll. The runes "
 "on the container are very old, and the artistry with whitch it was put "
@@ -6675,7 +6979,7 @@ msgid ""
 "magical power."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:639
+#: ../fheroes2/resource/artifact.cpp:649
 msgid ""
 "One of the less intelligent members of your party picks up an arm off of the "
 "ground. Despite its missing a body, it is still moving. Your troops find the "
@@ -6684,7 +6988,7 @@ msgid ""
 "making."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:640
+#: ../fheroes2/resource/artifact.cpp:652
 msgid ""
 "You come upon a sign. It reads: \"Here lies the body of Anduran. Bow and "
 "swear fealty, and you shall be rewarded.\" You decide to do as it says. As "
@@ -6692,21 +6996,21 @@ msgid ""
 "that you are suddenly wearing a gleaming, ornate breastplate."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:641
+#: ../fheroes2/resource/artifact.cpp:655
 msgid ""
 "A kindly Sorceress thinks that your army's defenses could use a magical "
 "boost. She offers to enchant the Broach that you wear on your cloak, and you "
 "accept."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:642
+#: ../fheroes2/resource/artifact.cpp:658
 msgid ""
 "Out of pity for a poor peasant, you purchase a chest of old junk they are "
 "hawking for too much gold. Later, as you search through it, you find it "
 "contains the 3 pieces of the legendary battle garb of Anduran!"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:643
+#: ../fheroes2/resource/artifact.cpp:661
 msgid ""
 "You come upon a caravan of gypsies who are feasting and fortifying their "
 "bodies with mead. They call you forward and say \"If you prove that you can "
@@ -6715,7 +7019,7 @@ msgid ""
 "Crystal Ball."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:644
+#: ../fheroes2/resource/artifact.cpp:664
 msgid ""
 "You enter a recently burned glade and come upon a Fire Elemental sitting "
 "atop a rock. It looks up, its flaming face contorted in a look of severe "
@@ -6723,7 +7027,7 @@ msgid ""
 "it, but it passes right through them and sears itself into your chest."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:645
+#: ../fheroes2/resource/artifact.cpp:667
 msgid ""
 "Suddenly, a biting coldness engulfs your body. You seize up, falling from "
 "your horse. The pain subsides, but you still feel as if your chest is "
@@ -6732,7 +7036,7 @@ msgid ""
 "woods and disappear."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:646
+#: ../fheroes2/resource/artifact.cpp:670
 msgid ""
 "You spy a gleaming object poking up out of the ground. You send a member of "
 "your party over to investigate. He comes back with a golden helmet in his "
@@ -6740,7 +7044,7 @@ msgid ""
 "only man who was known to wear solid gold armor."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:647
+#: ../fheroes2/resource/artifact.cpp:673
 msgid ""
 "You come upon a battle where a Paladin has been mortally wounded by a group "
 "of Zombies. He asks you to take his hammer and finish what he started.  As "
@@ -6748,7 +7052,7 @@ msgid ""
 "Zombies lie dead, the hammer dripping with blood. You strap it to your belt."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:648
+#: ../fheroes2/resource/artifact.cpp:676
 msgid ""
 "Upon cresting a small hill, you come upon a ridiculous looking sight. A "
 "Sprite is attempting to carry a Scepter that is almost as big as it is. "
@@ -6757,7 +7061,7 @@ msgid ""
 "flying anyway.\""
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:649
+#: ../fheroes2/resource/artifact.cpp:679
 msgid ""
 "An old seaman tells you a tale of an enchanted masthead that he used in his "
 "youth to rally his crew during times of trouble. He then hands you a faded "
@@ -6765,14 +7069,14 @@ msgid ""
 "underneath a nearby dock."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:650
+#: ../fheroes2/resource/artifact.cpp:682
 msgid ""
 "You stop to help a Peasant catch a runaway mare. To show his gratitude, he "
 "hands you a tiny sphere. As soon as you grasp it, you feel the magical "
 "energy drain from your limbs..."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:651
+#: ../fheroes2/resource/artifact.cpp:685
 msgid ""
 "While out scaring up game, your troops find a mysterious staff levitating "
 "about three feet off of the ground. They hand it to you, and you notice an "
@@ -6780,13 +7084,13 @@ msgid ""
 "words, and you'll win every fight.\""
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:652
+#: ../fheroes2/resource/artifact.cpp:687
 msgid ""
 "A former Captain of the Guard admires your quest and gives you the enchanted "
 "Sword Breaker that he relied on during his tour of duty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:653
+#: ../fheroes2/resource/artifact.cpp:690
 msgid ""
 "A Troll stops you and says: \"Pay me 5,000 gold, or the Sword of Anduran "
 "will slay you where you stand.\" You refuse. The troll grabs the sword "
@@ -6795,4464 +7099,106 @@ msgid ""
 "sharp objects."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:654
+#: ../fheroes2/resource/artifact.cpp:693
 msgid ""
 "A dirty shovel has been thrust into a dirt mound nearby. Upon investigation, "
 "you discover it to be the enchanted shovel of the Gravediggers, long thought "
 "lost by mortals."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:905
+#: ../fheroes2/resource/artifact.cpp:1011
 msgid ""
-"Do you want to use your knowledge of magical secrets to transcribe the %"
-"{spell} Scroll into your spell book?\n"
-"The Scroll will be consumed.\n"
-" Spell point: %{sp}"
+"Do you want to use your knowledge of magical secrets to transcribe the "
+"%{spell} Scroll into your Magic Book?\n"
+"The Spell Scroll will be consumed.\n"
+" Cost in spell points: %{sp}"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:969
-msgid "Open book"
+#: ../fheroes2/resource/artifact.cpp:1022
+#: ../fheroes2/resource/artifact.cpp:1077
+msgid "Transcribe Spell Scroll"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:974
-msgid "Transcribe scroll"
+#: ../fheroes2/resource/artifact.cpp:1075
+#: ../fheroes2/resource/artifact.cpp:1102 ../fheroes2/spell/spell_book.cpp:336
+msgid "View Spells"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:984
-#: ../fheroes2/resource/artifact.cpp:1017
+#: ../fheroes2/resource/artifact.cpp:1079
+msgid "View %{name} Info"
+msgstr ""
+
+#: ../fheroes2/resource/artifact.cpp:1085
+#: ../fheroes2/resource/artifact.cpp:1123
 msgid "Move %{name}"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:1007
+#: ../fheroes2/resource/artifact.cpp:1091
+#: ../fheroes2/resource/artifact.cpp:1116
 msgid "Cannot move artifact"
 msgstr ""
 
-#: ../fheroes2/resource/maps_text.cpp:15
-msgid ""
-"425 bottles of beer on the wall, 425 bottles of beer! If one of those "
-"bottles should happen to fall, there'll be..."
+#: ../fheroes2/resource/artifact.cpp:1155
+msgid "This item can't be traded."
 msgstr ""
 
-#: ../fheroes2/resource/maps_text.cpp:16
-msgid "A balanced scenario with lots of resources and land to explore."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:17
-msgid ""
-"A bandit army of gorgons jump you without warning.  they stone your entire "
-"army demand 500 gold before they will release your comrads.  Realizing that "
-"it is much cheeper to pay then rebuild your army you part with the gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:18
-msgid "Abandon All Hope!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:19
-msgid "Abandon All Hope Ye That Enter Here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:20
-msgid "A bit of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:21
-msgid "A bit of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:22
-msgid "A bit of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:23
-msgid ""
-"Above you looms the ancient Ice Palace.  Dimly remembered myth speaks of a "
-"Prince who rejected the advances of the Winter Goddess, and thus he and his "
-"domain were cursed to remain shrouded in ice, hidden in a forgotten corner "
-"of the world.  It is said that he can only be rescued by a hero who is both "
-"clever and bold.  Are you that one?  Do you dare enter this frozen domain?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:24
-msgid "A cache of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:25
-msgid "A cache of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:26
-msgid "A cache of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:27
-msgid "A cache of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:28
-msgid "A cache of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:29
-msgid ""
-"A chance to end a bitter war has finally arrived as a new resource-laden "
-"land has been discovered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:30
-msgid "A chunk of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:31
-msgid "A chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:32
-msgid "A couple of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:33
-msgid "\"Act of Desperation\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:34
-msgid ""
-"A desert isle rich in resources rewards the quick.  Just be sure to watch "
-"your back!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:35
-msgid "A dolphin playfully jumps into the air."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:36
-msgid ""
-"A Dragon, A Cyclops, or an Undead. King of the Centaurs, His name is ....?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:37
-msgid "A flight of dragons circles overhead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:38
-msgid "A flock of seagulls circle overhead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:39
-msgid "A friendly dolphin splashes alongside the ship."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:40
-msgid ""
-"After a long search of the island, I have discovered that there is no way "
-"for me to escape without help.  I can not steal a ship from one of the "
-"coastal castles, and I dare not venture into the desert unless I wish to "
-"become Dragon food.  Should anyone find this, I beg of you, please send a "
-"ship and get me off this cursed island!  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:41
-msgid ""
-"After centuries of friendship, the Wizards have suddenly decided to stop "
-"sharing their Library with the rest of the world.  This can't be good!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:42
-msgid ""
-"After many years of peace, you discover that your sworn enemy from across "
-"the sea has chosen to invade your homeland by raising up the ocean floor to "
-"bridge the distance! You must not let them gain a foothold on this "
-"continent, in fact, your King has ordered you to establish a foothold on "
-"theirs!  To make matters worse, two of your OWN towns have thrown in their "
-"lots with the enemy..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:43
-msgid ""
-"After you return from a scouting trip, your Seneschal hurries to greet you.  "
-"\"My Lord, in your absence I signed an agreement in your name with a Master "
-"Merchant.  If we supply him with the resources he needs, through trading, he "
-"can return the resources to us in a week or so, plus some additional ones."
-"\"  The Seneschal eyes you anxiously.  You hesitate, then nod slowly, "
-"\"Good, we can use more resources>\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:44
-msgid "A ghostly pirate ship appears and sails on by."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:45
-msgid ""
-"A Gift from your King, and a note that reads \"Use these resources wisely, "
-"It's all we have left\"."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:46
-msgid ""
-"A gift of gold, m'lord, from the people of Enroth, to the people of Enroth.  "
-"Good luck, and may God save true King Roland!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:47
-msgid "A glint by a tree catches your eye..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:48
-msgid "A gold cache!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:49
-msgid "A gold chunk!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:50
-msgid "A gold nugget!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:51
-msgid ""
-"A great Black dragon stands before you. It speaks in a suprisingly soft "
-"voice, saying, \"The elves believe they have sent another hero to reclaim "
-"their prize. I believe they have sent me another meal.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:52
-msgid ""
-"A group of peasant farmers approaches you, \"We are in dire need of your "
-"assistance.  Our castle to the north has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:53
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance.  Our castle to the east has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:54
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance. Our castle to the east has been overrun and our Lord killed. "
-"Please help us regain our homes! There are still women and children there! "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:55
-msgid ""
-"A group of peasant farmers approach you, We are in dire need of your "
-"assistance.  Our castle to the northeast has been overrun and our Lord "
-"killed.  Please help us regain our homes!  There are still women and "
-"children there!  Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:56
-msgid "A handful of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:57
-msgid ""
-"Ah, you stumble across something buried in the sand.  As you dig it up you "
-"discover a small pile of gems and crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:58
-msgid ""
-"A Knight and Necromancer team up against the Barbarian and Sorceress. (Blue "
-"and Green vs Red and Yellow)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:60
-msgid ""
-"A large contingent of the king's guard approaches you.  \"Ahh, we have "
-"finally caught up to you.  The king requires tribute from all of his vassals "
-"and you have been negligent far too long.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:61
-msgid ""
-"A large map with lots of resources and treasure. Exploration and victory "
-"will require many heroes."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:62
-msgid "A legion of peasants stands between you and this unclaimed island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:63
-msgid "Algary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:64
-msgid "A little bit closer..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:65
-msgid "All mines are grouped by type. Trade is your only hope."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:66
-msgid "A lump of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:67
-msgid "A lump of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:68
-msgid "A lump of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:69
-msgid ""
-"A man appears from behind the sand dune. \"At last,\" he says, \"Someone has "
-"come to rescue me! I am forever grateful. Alas all I have to offer you in "
-"return are these souvenirs from my wrecked ship.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:70
-msgid ""
-"A man is laying on the ground, near death. He looks to you and speaks, "
-"\"Please help my companions! Please... they can't...cough...get away from..."
-"cough...the drag...\" With that, he dies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:71
-msgid ""
-"A merchant caravan arrives, bringing gold and supplies, however, no one can "
-"seem to remember where they came from.  You silently praise this anonymous "
-"benefactor and continue your duties."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:72
-msgid "a mirror"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:73
-msgid "An albatross flies ahead of the ship for a while"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:74
-msgid "Anduran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:75
-msgid ""
-"An enemy from across the sea has seized half your towns.  Can you put aside "
-"your own feud with your brother to fight this common enemy?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:76
-msgid "\"Annexation\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:77
-msgid ""
-"An old elf is sitting on a rock in a glen, pounding on the shackles on his "
-"feet with a stone. You help him remove them and ask him his tale. \"I'm a "
-"deserter from Drakonia's army. She has enslaved all the elves to support her "
-"madness. She must be stopped.\" Then he slips into the woods without a "
-"sound, leaving behind just his cloak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:78
-msgid "Antioch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:79
-msgid "A piece of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:80
-msgid "A pile of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:81
-msgid "A pile of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:82
-msgid "A pile of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:83
-msgid ""
-"A plague of undead is upon us. Who will unite the living against the dead?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:84
-msgid "\"Apocalypse\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:85
-msgid "A quantity of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:86
-msgid "A quantity of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:87
-msgid "A quantity of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:89
-msgid ""
-"Archibald has also sent an army to find the Crown, you must find it first or "
-"all is lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:90
-msgid "Archibald is hiding at the end of the river."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:91
-msgid ""
-"A resource rich valley keeps the Wizard and the Necromancer apart. Your "
-"opponent's army will arrive in 3 months so hurry."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:92
-msgid "Arm of the Crusader"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:93
-msgid "Arm of the Cyclops"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:94
-msgid "Arm of the Dragon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:95
-msgid "Arm of the Phoenix"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:96
-msgid "Arm of the Titan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:97
-msgid "Arr' Here be pirates gold buried."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:98
-msgid "A shipment of wood has arrived from your kingdom!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:99
-msgid ""
-"A splash in the seaweed alerts you to a mermaid waving in a friendly manner. "
-"\"Oh, I thought you were Ahab.\" She is surprised, but quickly composes "
-"herself. \"Well, if you meet him, give him these treasures I have collected."
-"\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:100
-msgid "Assassins tried to kill our ally."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:101
-msgid "Astircaer"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:102
-msgid ""
-"A stranded Wizard with only a small force must conquer an entire continent "
-"of hostile forces."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:103
-msgid ""
-"A supply ship has arrived from the homeland!  You send word home that all is "
-"well."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:104
-msgid ""
-"As you approach the barrier, you see the old elf you helped free. This time, "
-"however, you see that he is wearing a cape of fine weave, and a wooden crown "
-"is on his head. He sees your forces, and says \"Take this sword, and with "
-"it, strike down Drakonia and help free my people.\" The old elf then strides "
-"regally into the woods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:105
-msgid ""
-"As you approach the gates of the Ice Palace, one of your troops points in "
-"terror.  You watch in awe as great slabs of ice separate from the castle "
-"walls with loud cracking reports and crash to the ground.  Soon the ice is "
-"gone and the sun begins to peak through the gloom.  The deathly silence that "
-"must have ruled these lands for centuries ends as birds begin to sing.  From "
-"inside you hear the sounds of life."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:106
-msgid ""
-"As you approach the tent, the leader of the nomads comes out to greet you. "
-"He says, \"It was prophecied many years ago that a great hero would come to "
-"greet us in our sacred valley, and we would prosper afterwords. Now it has "
-"come to pass, and we offer you these gifts as tokens of our thanks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:107
-msgid ""
-"As you approach,  you hear whispered mentions of \"the wild barbarian who "
-"passed this way months before\". One of the villagers approaches you and "
-"hands you an object, saying \"The wild one dropped this. You must be his "
-"kin. Therefore I give it to you. But beware! Many in the village will not be "
-"as friendly as I.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:108
-msgid ""
-"As you break your fast your sage rushes in, \"Good news, my lord!  I have "
-"translated the message.  Two great heroes were imprisoned many years ago.  "
-"They lie sleeping - still guarded by magic barriers and monsters.  My lord, "
-"they lie nearby- in between our ally and us.  If we could free them, they "
-"would surely aid us against our enemies!  The password to the first magic "
-"barrier can be learned at the Aqua Traveller's Tent.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:109
-msgid ""
-"As you enter the small clearing, you see a familiar figure talking to a "
-"group of halflings and soldiers. You stay awhile and listen to his speech. "
-"\"The time to throw off these chains of tyranny is now! We must strike at "
-"the heart of her empire, and destroy the evil that she has brought to our "
-"land.\" As the old elf finishes speaking, he gets up from his mossy seat and "
-"once again, blends into the woods with incredible grace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:110
-msgid ""
-"As you lay down to nap after a long battle, you notice a lucky four-leaf "
-"clover."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:111
-msgid ""
-"As you make  your way through the last of the golemn debris, a group of "
-"halflings runs towards you carrying fruit and flowers. \"Thank you so much!"
-"\" Their leader exclaims, \"We've been trapped in here for ever! Come by our "
-"homes, we'll pack up and go with you!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:112
-msgid ""
-"As you make your way to the shrine, some very thin and hollow-eyed men come "
-"out of the flower patch and stare at you.  Seeing that you want the gold, "
-"one of them says to you \"Hey, man, if you're, like, so lusty for earthly "
-"wealth, then, like, have this too.\" You graciously take what they have "
-"offered and back out of the clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:113
-msgid ""
-"As you prepare your lands to fight the onslaught from the South, a curious "
-"message appears on your table in the Great Hall of your Castle.  Written in "
-"some ancient language, none but your sage can make any sense of it.  She "
-"promises to have the words deciphered by tomorrow..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:114
-msgid "A three hour tour, a three hour tour..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:115
-msgid ""
-"A tiny gnome points to a chunk of crystal you otherwise would have "
-"overlooked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:116
-msgid "Atlantium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:117
-msgid ""
-"At last, the king is dead.  For years you have planned his demise, but now "
-"it is done, and there is no heir to take his place, though the Knights to "
-"the south believe that they are the rightful successors.  A wealth in wood "
-"(to the south) and ore (in the northern mountains) provides you with trade "
-"goods, and your isolation has allowed you to prepare your forces of darkness "
-"for this day.  Go, now, and fulfill your destiny!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:118
-msgid ""
-"At the base of the mountain you see something that glitters.   You discover "
-"an ancient pile of offerings to the gods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:119
-msgid "Avalon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:120
-msgid "Avone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:121
-msgid ""
-"A wild magic has allowed a bridge to form between two lands...  Your one "
-"hope is to capture castle \"Black Fang\"."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:122
-msgid "Barbarian's castle lies to the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:123
-msgid ""
-"Barbarians from the north threaten all civilization. Can you repel the "
-"hordes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:124
-msgid "\"Barbarian Wars\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:125
-msgid "Barrowton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:126
-msgid "Basenji"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:127
-msgid "Bayside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:128
-msgid "Baywatch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:129
-msgid ""
-"Because the Darkscale Valley is so barren, the Emperor will be sending wood "
-"to you every week. Use it wisely, for it is all you shall have."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:130
-msgid ""
-"Before questing for the orb of negation, you must first crush the local "
-"opposition. After the Sorceresses are removed from the earth, go east where "
-"legend says the orb lies.  You may expect a convoy of supplies in a week or "
-"so to aid your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:131
-msgid ""
-"Before you may pass, the spirit guardian of this valley demands tribute."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:132
-msgid "Being held...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:133
-msgid "Beltway"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:134
-msgid "\"Betrayal!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:135
-msgid "Beware -- Entering Hyrda Country"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:136
-msgid "Beware for whom the bell trolls."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:137
-msgid "Beware of Pirates!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:138
-msgid "Beware of thieves!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:139
-msgid "Beware of traps ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:140
-msgid "Beware of Warlocks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:141
-msgid "Beware the deadly swamps!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:142
-msgid "Beware the Domain of Dragons"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:143
-msgid "Beware the Dragon Leader"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:144
-msgid "Beware the edge of the world!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:145
-msgid "Beware the moors and stick to the roads."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:146
-msgid "Beware the rocks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:147
-msgid "Beware the sirens!!!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:148
-msgid "Beware the sirens!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:149
-msgid "Beware the whiporwill..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:150
-msgid "Beware, the whirlpool may not take you into a friendly embrace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:151
-msgid "Beyond here be Dragons!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:152
-msgid "Beyond the door, there be Dragons. BEWARE!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:153
-msgid "Big Oak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:154
-msgid "Blackburn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:155
-msgid "Blackfang"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:156
-msgid "Black Fang"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:157
-msgid "Black Oak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:158
-msgid "Blackridge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:159
-msgid "Blacksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:160
-msgid "Black Vein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:161
-msgid "Blackwind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:162
-msgid "Bloodreign"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:163
-msgid "Boats my be needed to access some parts of this peninsula."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:164
-msgid "Boats Sold Here            Inquire Within"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:165
-msgid "BoneVille"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:166
-msgid "Borderlands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:167
-msgid "Bridge out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:168
-msgid "Bridge Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:169
-msgid "Brindamoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:170
-msgid "Broken Alliance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:171
-msgid "Brownston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:172
-msgid "Buried Treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:173
-msgid "Burlock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:174
-msgid "Burton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:175
-msgid ""
-"Capture the necromancer's dreaded castle \"Death Gate\" and free the land "
-"from the undead plague."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:176
-msgid ""
-"Capture the town on the island off the southeast shore in order to construct "
-"a boat and travel back towards the mainland."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:177
-msgid "\"Carator Mines\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:178
-msgid "Cathcart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:180
-msgid "Chandler"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:181
-msgid "Chilton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:182
-msgid "Chronos"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:183
-msgid "Come and...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:184
-msgid ""
-"Compared to the rest of the villages in this land, this village seems grand, "
-"but in any other land it would seem poor. From here you can see the tall "
-"spires of the Warlock's tower of Dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:185
-msgid "Complete"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:186
-msgid "Condemned!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:187
-msgid ""
-"Congratulations! After navigating the treacherous coast, you have "
-"established trade between the north and south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:188
-msgid "Corackston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:189
-msgid "Corlagon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:190
-msgid "\"Country Lords\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:191
-msgid "Crossroads"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:192
-msgid "Crossroads North"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:193
-msgid "Crossroads South"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:195
-msgid "Danger a whirlpool destroyed my ship."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:196
-msgid "Danger, Dragons abound!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:197
-msgid "DANGER!  QUICKSAND!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:198
-msgid "Danger! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:199
-msgid "Danger - Turn Back Now"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:200
-msgid "Dark clouds loom overhead as you enter this valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:201
-msgid "Dead Pine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:202
-msgid ""
-"Dear Diary,                           I found a mermaid today.  She was "
-"floating in a patch of seaweed next to a rock.  A very friendly sort of "
-"creature too!  Gave me all sorts of lovely gems and jewelry!  She said to "
-"come back again sometime for more of the sea riches.  Wow. Ahab"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:203
-msgid "Deathgate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:204
-msgid "DeathGate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:205
-msgid "Decisions"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:206
-msgid "\"Defender\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:207
-msgid ""
-"Destroy the Barbarians who are attacking the southern border of your "
-"kingdom! Recover your towns and then invade the jungle kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:208
-msgid ""
-"Detour! Mountain pass to the East has been known to have avalanches! For "
-"your own safety, follow the road South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:209
-msgid "Detour! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:211
-msgid "DirtWater"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:212
-msgid "Dominion"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:213
-msgid "Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:214
-msgid "Do not remove coins from fountain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:215
-msgid "Dragadune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:216
-msgid "Dragonburg"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:218
-msgid "Dragon City lies beyond the Scorpion Hills."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:219
-msgid "Dragon Hill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:220
-msgid "\"Dragon Master\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:221
-msgid "Dragon Rider"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:222
-msgid "Dragons Everywhere!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:223
-msgid "Dragon's Eye"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:224
-msgid "Dragontooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:225
-msgid "Dragon Town"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:226
-msgid "Dragonville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:227
-msgid "Dragon Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:228
-msgid "Dragon Watch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:230
-msgid "Drakoran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:231
-msgid "Dwarfhall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:232
-msgid "Dwarfhall, Domain of the dwarf King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:233
-msgid "Dwarf Hall, domain of the dwarf King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:234
-msgid "Eatio"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:235
-msgid "Edgewood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:236
-msgid "Elk's Head"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:237
-msgid "Elowyn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:238
-msgid "Enroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:239
-msgid "Entering high in the desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:240
-msgid "Entering Praires of the Middlelands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:241
-msgid "Entering the desert high"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:242
-msgid "Entering the high desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:243
-msgid "Entering the higher desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:244
-msgid "Entering the Valley of Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:245
-msgid "Erliquin"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:246
-msgid "Evil Igor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:247
-msgid "Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:248
-msgid "Fantasy Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:249
-msgid "Farlien"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:250
-msgid ""
-"Federal express, when it absolutely positively has to be there turn one."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:251
-msgid "fedx comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:252
-msgid "Fedx for comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:253
-msgid "Fenton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:254
-msgid "Fetid Elm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:255
-msgid ""
-"Final message from Overlord. \"The royal executioners are on their way. My "
-"gold, the land or your head- it's your choice.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:256
-msgid "Find and defeat the Pirate Leader!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:257
-msgid "Find and destroy the evil beings who rule the wastelands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:258
-msgid "Find the center island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:259
-msgid ""
-"Find the Ultimate Artifact and be proclaimed King, or smash the opposition "
-"and take control."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:260
-msgid ""
-"Find Your Wayward Son who is rumored to be living in the desolate lands. Do "
-"it within 8 weeks or it will be of no help to your family."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:261
-msgid "Fire King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:262
-msgid "\"First Blood\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:263
-msgid "Five heroes vie for control of a familiar land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:264
-msgid "Fool's Gold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:265
-msgid ""
-"For a total of 400,000 gold your opponents will become \"loyal\" subjects, "
-"otherwise... let them eat cake!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:266
-msgid ""
-"For centuries, the Wizards of the North have maintained a vast library for "
-"all the world to share.  Now, however, they have closed their doors, and "
-"issued declarations of war to each of the other rulers of the land.  To make "
-"matters worse, rather than ally with you to face the Wizards, each of the "
-"others have decided to go forth on their own in an effort to conquer this "
-"land for themselves!  Prepare your forces, commander, for you now stand "
-"alone."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:267
-msgid "\"Force of Arms\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:268
-msgid ""
-"For decades you have studied, learned, and allowed yourself to be ruled by "
-"that pitiful excuse for a king, knowing that one day the time would come for "
-"you to sit on the throne.  That time is now, for the king is dead and "
-"without an heir.  You have the advantage of isolation from the rest of the "
-"kingdom, but beware the miles of coastline that could leave you vulnerable "
-"to attack.  Go, now, and wipe your enemies from this land!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:269
-msgid "Forder Oaks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:270
-msgid "Forestria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:271
-msgid "For Honor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:272
-msgid ""
-"For information about Ye Rich lands to the south, speak to Alponse at the "
-"Golden Goose Tavern. Excellent views, plentiful water."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:273
-msgid "Forsaken Lands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:274
-msgid "For sale."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:275
-msgid "Fortress Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:276
-msgid ""
-"For years, you have existed peacefully in the Forest of Dreams, knowing that "
-"your king was the kindest and strongest ruler the land had seen in "
-"centuries.  Now, however, his reign is at an end, and there is no heir to "
-"succeed him.  You realize that a power struggle is coming, and that you must "
-"brace yourself for war, and prevent those who would harm this land from "
-"coming into power!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:277
-msgid ""
-"For years, you've been able to keep your subjects \"appeased.\"  Now "
-"however, you discover not only that your entire kingdom has turned against "
-"you, but most of your outer towns have fallen to the different factions.  To "
-"make matters worse, all your gold suddenly seems to be missing from the "
-"treasury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:278
-msgid "Fountainhead"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:279
-msgid "Four kingdoms race to capture the island of Sharkania."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:280
-msgid "Four lakes have castles, three have treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:281
-msgid "Four players must work together to assault the Wizards' Stronghold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:282
-msgid "Frozenpeak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:283
-msgid "Full House"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:284
-msgid ""
-"Gain the aid of the elves. They will not allow trees to be chopped down, so "
-"we will send you wood every 2 weeks. You have 7 months!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:286
-msgid "Galveston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:287
-msgid "Garamok"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:288
-msgid "Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:289
-msgid "Gate to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:290
-msgid "Gate to The Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:291
-msgid "Gaurdian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:292
-msgid "Gavonshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:294
-msgid "Glastonbury"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:295
-msgid "Go away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:296
-msgid "GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:297
-msgid "Goblin Island"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:298
-msgid "Goblin King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:299
-msgid "Go Home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:300
-msgid "Go north to find the lost gold-mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:301
-msgid "Good vs. Evil"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:302
-msgid "Gorgomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:303
-msgid "\"Greater Glory\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:304
-msgid "Greed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:305
-msgid "Green bonus stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:306
-msgid "Green gets stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:307
-msgid "Greenroot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:308
-msgid "Green's Allowance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:309
-msgid "Green's Groceries"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:310
-msgid "green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:311
-msgid "Green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:312
-msgid "Greywind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:313
-msgid "Grim"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:314
-msgid "Grrr, Blazzer, Grrupt. Be gone with you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:315
-msgid "Guardian War"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:316
-msgid "Gungtooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:317
-msgid "Hail Unicorns!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:318
-msgid "Hampshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:319
-msgid "Have fun storming the castle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:320
-msgid "Havenwood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:321
-msgid "Hawkins"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:322
-msgid "Help!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:323
-msgid "Help me...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:324
-msgid ""
-"Help peasant farmers regain their castle and land, else they'll take your "
-"crops."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:325
-msgid "Hero's Hall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:326
-msgid ""
-"High in the snowy crags, you meet an old witch who, in return for a trinket "
-"of yours, gives you a powerful magical object she used to use as a footstool "
-"before she was exiled into the mountains by her own townspeople."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:327
-msgid "Hillstone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:328
-msgid "Hilltop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:329
-msgid "Hilltown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:330
-msgid "Horizon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:331
-msgid "Hot Spot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:332
-msgid "Hungry dragons await.  Welcome, food."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:333
-msgid "Hurry, no time to wait.  This way to the dock."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:334
-msgid "Hurry up! Few days are left before the enemy's army arrives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:335
-msgid "I am...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:336
-msgid ""
-"I am one of the few remaining survivors of the wrecked pleasure ship, "
-"Exhorbitance. I think we'll all be dead of hunger soon, for we are out of "
-"caviar. We ate the chef yesterday."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:337
-msgid "Ibn Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:338
-msgid "Ice Palace"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:339
-msgid "Ice Prince"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:340
-msgid "Icy lands ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:341
-msgid "I didn't do it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:342
-msgid ""
-"If three heroes could dig six holes in three days, how long would it take "
-"six heroes to dig twelve holes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:343
-msgid "If you free a hero, they may help..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:344
-msgid ""
-"If you value your lives, for God's sake, Don't go through this whirlpool!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:345
-msgid "Income for Yellow."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:346
-msgid "In the hole you find a chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:347
-msgid "In the stream you find an old compass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:348
-msgid "In this glen live some very naughty halflings. Stay Away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:349
-msgid ""
-"In two more weeks, if you have not located Joseph, your kingdom will surely "
-"lose its current battle with Harondale."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:350
-msgid "I see you, you see me."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:351
-msgid "Is it something I said? Go back and I will forget the whole thing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:352
-msgid "IslandHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:353
-msgid "Island of the Elves"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:354
-msgid "Island of the meek"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:355
-msgid "Island of Wolcott"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:356
-msgid "Isle Maze"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:357
-msgid "Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:358
-msgid ""
-"It has become apparent that if all your enemies were eliminated, you would "
-"have all the time you need to find the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:359
-msgid ""
-"It is obvious that the mage that once was here had won many battles!  There, "
-"upon his hand, is a most powerful ring!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:360
-msgid ""
-"It is rumored that a bridge of land used to exist between the two "
-"continents, but that a wild magic caused it to sink into the sea, taking "
-"with it all those who used to inhabit it.  To try to raise this bridge is to "
-"invite a curse upon the world!  The spirits of the dead will haunt us all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:361
-msgid ""
-"It is said that King Zealot found the gods' artifact once and it let him "
-"rule for 100 years."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:362
-msgid ""
-"It looks like there used to be an ore mine here but all you see now is a "
-"hole in the ground and some minerals scattered around."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:363
-msgid ""
-"It's a battle for supremacy as the Blue and Green heroes take on Red and "
-"Orange in team competition!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:364
-msgid "It's windy at the top.  Defend, Divide, and Conquer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:365
-msgid "IvanHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:366
-msgid "Ivan lives in the desert."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:367
-msgid "Ivory Gates"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:368
-msgid ""
-"I, Wilgatus, besiege you - do not fight me for I am all powerful and will "
-"destroy you if you persue me.  I will demonstrate my power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:369
-msgid "I Would Go That Way If I Were You."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:371
-msgid "Jarkonas VI"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:372
-msgid "Jolly Roger was here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:374
-msgid "Jungomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:375
-msgid "Just 30 days left!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:376
-msgid "Just ONE week left!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:378
-msgid "Kastor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:379
-msgid "Keep going south"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:380
-msgid "Keep Off The Grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:381
-msgid "Keep Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:382
-msgid "King John"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:383
-msgid "King of Death"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:384
-msgid "Knight's Trail."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:385
-msgid "Knight stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:386
-msgid "Lakeside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:387
-msgid "Land's Edge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:388
-msgid "Land teleporters will get you to your destination sooner."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:389
-msgid "Lankershire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:390
-msgid "Lavalor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:391
-msgid "Like, Stuff And Junk?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:392
-msgid ""
-"Living on the outskirts of the kingdom, you are considered an unwelcome "
-"outcast by the other leaders of the realm, though you always showed your "
-"support for the king.  Now, however, the king is dead, and many of those who "
-"spoke out againt him seek to seize his throne for themselves.  You have a "
-"vast desert at your back, rich with gems, and the advantage that many do not "
-"consider you a threat.  Go, now, and show them how wrong they are!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:393
-msgid "Lladner Dock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:394
-msgid ""
-"Log go up... Log go down... Log go up... Log go down...  OOoohhhhhhhh........"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:395
-msgid "Lombard"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:396
-msgid "Long live Roland the true King!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:397
-msgid "Long live Roland the true King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:398
-msgid "Look before you leap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:399
-msgid "Look out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:400
-msgid "Lord Alberon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:401
-msgid ""
-"Lord Alberon calls you into his war room. He says, \"I am glad you have "
-"chosen to remain loyal to me, but this war is a terrible one for my kingdom. "
-"Already, the sorceress' towns to the Northeast have become unsure about "
-"their loyalties, and will not pledge allegiance to either side. This is hard "
-"on our cities as most of the wood in the land comes from these towns. We "
-"will need to recover their sawmills and take their towns by force.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:402
-msgid "Lord Haart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:404
-msgid "Lord Kreager"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:405
-msgid ""
-"Lord, messages have begun pouring in from our spies in the other island "
-"courts.  They have learned of a new volcanic island with vast amounts of "
-"reasources.  Your Majesty, with these new reasources we could put an end to "
-"a century of war between the islands, and reunite them under your rightful "
-"rule."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:406
-msgid "Lost Continent"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:407
-msgid "Lost Gold- Mine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:408
-msgid "Lost Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:409
-msgid "Lost Relic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:410
-msgid "Maelstrom of Deceit"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:411
-msgid "Maelstrom of Misery"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:412
-msgid "Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:413
-msgid "Magic Three"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:414
-msgid ""
-"Many dust plumes rise from the floor of this small valley. You see various "
-"bands of nomads roaming about, and in the distant, the bright flames of "
-"their camp."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:415
-msgid ""
-"Many guardians stand between you and your enemies, but anybody can sneak "
-"through the back door!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:416
-msgid "Many that have gone through this door have never returned."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:417
-msgid ""
-"Many years ago, a couple of mages had a \"duel\" that forever changed the "
-"lake at the center of this continent.  Hearty adventurers might find "
-"interesting treasure there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:418
-msgid ""
-"Many years ago, a falling star crashed near here.  Only now the area is safe "
-"enough to explore.  Rumor has it a castle exist where the star fell."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:419
-msgid ""
-"Many years ago, your father, the King, died in a freak hunting accident.  "
-"Since then, you and your brother have jointly ruled his kingdom, but both of "
-"you have been seeking a way to seize the throne for yourself.  You got your "
-"wish.  Attackers from across the sea have captured more than half your towns "
-"and castles, effectively dividing the continent in two.  Now is the time to "
-"repel these invaders and do away with your brother once and for all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:420
-msgid "Marco"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:421
-msgid "Marsh Home"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:423
-msgid "Mayland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:424
-msgid "Meramec"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:425
-msgid "Message from Archibald. \" Do not dare to return without my Crown.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:426
-msgid ""
-"Message from Archibald. \" General, thank you for bringing me this lovely "
-"gift. I have decided to participate directly in the capture of my brother "
-"Roland. Since your military advice has taken us this far, I will follow your "
-"orders to the letter.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:427
-msgid "Message from Overlord. \"STILL WAITING FOR MY GOLD!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:428
-msgid "Message from Overlord. \"WHERE'S MY GOLD?\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:429
-msgid ""
-"Message from Roland. \"General, circumstances permit me to take a hand in "
-"the events of this final conflict. I have your spoils of war with me and I "
-"will follow your advice explicitly.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:430
-msgid ""
-"Message from Roland.  \"General, I have sent most of our troops and material "
-"ahead to the region of the final conflict with Archibald.  Unfortunately, "
-"Lord Corlagon has cut us off from the rest of our army.  I will be awaiting "
-"your victory in a castle across the west river.  I should be safe from "
-"attack.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:431
-msgid ""
-"Message from Roland. \" We cannot hope to defeat Archibald without the "
-"Crown, I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:432
-msgid "Middle Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:433
-msgid "Middleton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:434
-msgid "Middletown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:435
-msgid "Might vs. Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:436
-msgid "Mineral Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:437
-msgid "Mirkosov"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:438
-msgid "mirror"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:439
-msgid "Money For Red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:440
-msgid "MONEY, MONEY, MONEY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:441
-msgid "Morale becomes even lower as the endless cliffs move past."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:442
-msgid ""
-"More water than land, you'll still spend lots of time on foot as you search "
-"a literal horde of islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:443
-msgid "Mountain king"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:444
-msgid "Mountainview"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:445
-msgid "Mr Ed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:446
-msgid "Mr. Yellow's Income"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:447
-msgid "Murray's resort Isle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:448
-msgid ""
-"Mutiny!  The crew has dumped off my precious cargo into the sea!  Thank "
-"goodness it floats - when I've rid of them, I'll come back to pick it up!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:449
-msgid ""
-"My leige, our scouts report three other lords are attacking from the south. "
-"They work in conjuction with each other to eliminate us! We must keep this "
-"castle and remove the threat of the enemy. We wish you luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:450
-msgid ""
-"My leige, we have established a foothold (which we cannot afford to lose) "
-"and all of our Heroes have joined us. The king has made us the offer to "
-"purchase this land for 200,000 gold or we may take it by force. The local "
-"lords have been fighting and each wants to be the one that defeats us. Now "
-"all the local armies have arrived on the beach, creating a state of complete "
-"Pandemonium!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:451
-msgid "My Treasure Is Buried Beneath Three Palm Trees"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:452
-msgid "\"Necromancers!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:453
-msgid "New Dawn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:454
-msgid "New Enemies"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:455
-msgid "New Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:456
-msgid "Nightshadow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:457
-msgid "No Description"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:458
-msgid "No Fishing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:459
-msgid "No gems, crystal, or mercury for red."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:460
-msgid ""
-"None of the four leaders like being stuck in a land that has only one season."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:461
-msgid "NO, Not That Way. This Way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:462
-msgid "No one has ever made it out of the deadly swamps alive!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:463
-msgid "Noraston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:464
-msgid "North Road"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:465
-msgid "North vs. South"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:466
-msgid "No stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:467
-msgid "No sulfer fer Yella."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:468
-msgid "No swimming."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:469
-msgid "Notice- Those who put messages in bottles will be tortured."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:470
-msgid "No Trespassing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:471
-msgid "No tresspath...  No tree...  No thresh...  GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:472
-msgid "Now leaving Swamplands of the Eternial"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:473
-msgid "Obsidian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:474
-msgid "Of the necromancers...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:475
-msgid "Ogrehild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:476
-msgid "Olympus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:477
-msgid ""
-"One of the seers in your castle comes to you in the morning with urgent "
-"news. Your one time comrade, the wizard Joseph, and his armies have been "
-"imprisoned in a jail nearby. His power would surely aid you in your quest to "
-"reclaim the library, you think to yourself. Perhaps there is a way to rescue "
-"him..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:478
-msgid ""
-"One of your aides reports that the Castle of Farlien is located on the "
-"northeast spur of this island, and is a stronghold for the enemy. He urges "
-"you to take it out as soon as possible, and then move onto other islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:479
-msgid ""
-"One of your \"allies\" has joined Archibald.  You now face an opponent with "
-"three castles to your one.  Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:480
-msgid ""
-"One of your \"Allies\" has joined Roland. You are now facing three castles, "
-"all belonging to the enemy. Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:481
-msgid "One of your loyal goblins has brought you an armload of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:482
-msgid ""
-"One of your loyal subjects, a fairy tells you where to find a cache of "
-"mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:483
-msgid ""
-"One of your scouts reports a tiny cave nearby. Upon investigating, you "
-"discover a small cache of goods. In the dirt by them is etched 'Ivan'."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:484
-msgid ""
-"One of your troops stubs its paw on something buried here.  After a few "
-"hours of digging you unearth a cache of treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:485
-msgid "Only a month remains in which to find Joseph."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:486
-msgid "On quite days, Nubbie the sea monster can be seen!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:487
-msgid "Orange stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:488
-msgid "Orcville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:489
-msgid "Ostoroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:490
-msgid "Other than the dragons, the elves don't have any enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:491
-msgid "Our ally was greatly weakened when his resources were plundered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:492
-msgid "\"Our Finest Hour\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:493
-msgid "Our reinforcements were lost in a storm, we salvaged all we could!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:494
-msgid ""
-"Our spies have discovered that the barbarian hordes are now receiving "
-"support from kraeger! You must hurry and find the third piece before your "
-"forces here are crushed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:495
-msgid "Overlord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:496
-msgid "Pandemonium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:497
-msgid "Paper can gain you what wood and sail cannot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:498
-msgid "Password found by Crystals to the South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:499
-msgid "Peacekeeper"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:500
-msgid "\"Peasants!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:502
-msgid "Peasantsville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:503
-msgid "Perenor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:504
-msgid "Pet Cemetary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:505
-msgid "Pick one of four Knights in this large and inhospitable land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:506
-msgid "Pig's Eye"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:507
-msgid "Pinehurst"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:508
-msgid "Pirate Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:509
-msgid "Pirate's Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:510
-msgid "Pirate Utopia"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:511
-msgid "Pirites strike and take the gold from you holds."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:512
-msgid "Pixie"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:513
-msgid ""
-"Play the Knight or Barbarian in an alliance in this classic duel against the "
-"four spell casters. (Blue and Green vs Red)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:514
-msgid "Please...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:515
-msgid ""
-"Plenty of resources and lots of ground to cover. Watch out for Orange and "
-"Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:516
-msgid "Portals"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:517
-msgid "Portsmith"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:518
-msgid "POSION - DO NOT DRINK"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:519
-msgid "Powerful magic lies southwest of here in the Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:520
-msgid "Prisoner on...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:522
-msgid "Quick Silver"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:523
-msgid "Raste"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:524
-msgid "Realm of the Undead.  Fresh blood welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:525
-msgid "Red bonus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:526
-msgid "Red player sympathizes with the undead cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:527
-msgid "Red's Connection"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:528
-msgid "Redshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:529
-msgid "Red's Lunch Money"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:530
-msgid "Red's Rubles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:531
-msgid "Red stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:532
-msgid ""
-"Regrettably, you have no castle with which to begin your assault. "
-"Fortunately, however, Kraeger's forces are weak here in the south, and you "
-"have bribed a rebel necromancer to aid you in the beginning of your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:533
-msgid "Reinforcements have arrived, Gold from the homelands!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:534
-msgid ""
-"Remains of a long since dead wizard have attracted an ancient artifact.  "
-"This artifact has now attached itself to you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:535
-msgid ""
-"Remember, you're searching for the Ultimate Artifact... don't get distracted!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:536
-msgid ""
-"Rendall Koski was here. 1997.  Northampton, Massachusetts There is a "
-"powerful artifact in the southeastern corner of the world.  Go for it, "
-"explorer!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:537
-msgid ""
-"Reports from your spies tell of enemies on the march.  As you rush to the "
-"castle courtyard to prepare your armies, you are intercepted by your "
-"Chaplain.  \"My Lord, I have received word that we should send what Heroes "
-"we can to the Isle of Knowledge.   The Scholars there have agreed to teach "
-"them so they will be strong for the battles ahead of us.\"  You thank the "
-"Chaplain for the information and head thoughtfully into the courtyard."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:538
-msgid ""
-"Rescue your crazy Uncle Ivan. Find him within 4 months or it will be no help "
-"to your kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:539
-msgid "Restricted Area, Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:540
-msgid "Rest stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:541
-msgid "Retake the Castle of Ivory Gates."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:542
-msgid "Revolution"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:543
-msgid "Right thinking - he who takes the riskes deserves the rewards."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:544
-msgid "River Crossing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:545
-msgid "Road Ends"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:546
-msgid "Road to Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:547
-msgid "Road to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:548
-msgid "Robbers have looted your treasury and you have lost valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:549
-msgid "Robbers have looted your treasury, stealing valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:550
-msgid "Roc Haven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:551
-msgid "Rogar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:553
-msgid "Roscomon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:554
-msgid "Rotten Birch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:555
-msgid ""
-"Rumors abound and your faithful hero Sandro is now highly regarded by the "
-"masses. Should Sandro desert you, all will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:556
-msgid "Sandcaster"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:558
-msgid "Sands of Time"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:559
-msgid "Sansobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:560
-msgid "\"Save the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:561
-msgid "Scabsdale"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:562
-msgid "Scorched Earth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:563
-msgid ""
-"Scouts have reported a town to the North.  They have also heard some "
-"disturbing news.  Their seems to be a war raging in this area."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:564
-msgid ""
-"Scouts report the enemy's stronghold lies to the Southwest. Our swift "
-"arrival has caught them by surprise. If you move quickly their resistance "
-"will be minimal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:565
-msgid ""
-"Scouts report the notorious necromancer \"Wyrm\" has been sighted to the "
-"northeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:566
-msgid "Scummy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:567
-msgid ""
-"Searching in the dust of this abandoned campsite, you find a magic scroll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:568
-msgid "Seasons Change"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:569
-msgid "Secret Mountain Pass"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:570
-msgid ""
-"Seek out the Ultimate Artifact to be victorious in this strangely shaped "
-"land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:571
-msgid ""
-"Seek the great library, for only with the guidance of the musty tomes therin "
-"will you find the means to reveal and bind the fount to your will."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:572
-msgid "Seven Lakes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:573
-msgid "Sharkania"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:574
-msgid "Sheltemburg"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:575
-msgid "Sherman"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:576
-msgid "Shipwrecked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:577
-msgid ""
-"Should this message ever reach home, please know that this has become a "
-"hostile place since the King's death.  No less than six factions are at war "
-"with each other, each seeking to be the King's successor.  Beware especially "
-"of the Barbarians and the Necromancers who control the north, their regions "
-"are easily defended and they have a wealth of gold and gems.  Do not venture "
-"to this land without a sizeable force.  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:578
-msgid "Sirein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:579
-msgid ""
-"Six factions have established a foothold on a huge, unexplored continent.  "
-"Can you eliminate the other five?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:580
-msgid ""
-"Six heroes with large armies prepare to slug it out for total domination!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:581
-msgid "Skirmish"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:582
-msgid "\"Slay the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:583
-msgid "Slippery when wet."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:584
-msgid "Slugfest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:585
-msgid ""
-"Snagged on a thorny bush, you discover a scrap of cloth. The design on it "
-"looks like the coat of arms of Ivan's house!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:586
-msgid "Snowdrop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:587
-msgid "Somebody has stuffed a pile of gems in the ditch!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:588
-msgid "Some crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:589
-msgid "Some gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:590
-msgid ""
-"Someone has stolen 100 wood and 77 ore from you. Ah, that's nothing. Let's "
-"keep going."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:591
-msgid ""
-"Someone has stolen gold and resources from  the palace treasury!  You "
-"suspect your enemies, but you can't know for certain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:592
-msgid "Someone is playing a pan flute around here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:593
-msgid ""
-"Someone notices a piece of parchment lying behind a clump of grass. You pick "
-"it up. It looks to be a page from a journal, and it reads, \"...made it past "
-"the first guardians. Hopefully will reach the ancient desert city soon. Only "
-"hope my forces are strong enough to survive...\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:594
-msgid "Some ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:595
-msgid "Some sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:596
-msgid ""
-"Some unlucky adventurers have been captured and imprisoned in these lands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:597
-msgid "Sorceress Forest.  Show respect for nature!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:598
-msgid "Sorpigal"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:599
-msgid "South Mill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:600
-msgid "So you think you're smart?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:601
-msgid "Spector"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:602
-msgid "Spell Casters"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:603
-msgid ""
-"Spies report Roland has sent a hero to search for the Crown. If he finds it "
-"first, all is lost!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:604
-msgid "Spirit City"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:605
-msgid "Spy Tower - see what your competition is doing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:606
-msgid "Stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:607
-msgid ""
-"Start with five castles!  How could you lose!?  Oh yeah, everyone else "
-"starts with five, too."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:608
-msgid "Stick to the road!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:609
-msgid "Stromgild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:610
-msgid "Stromhild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:611
-msgid "Stronghold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:612
-msgid "Stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:613
-msgid "Stuff for Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:614
-msgid "Stuff For Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:615
-msgid "Subbaculcha"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:616
-msgid "Sundune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:617
-msgid "Surf and Turf"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:618
-msgid "Swimming near the kelp is a pod of dolphins."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:619
-msgid "Tacma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:620
-msgid "Tchudes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:621
-msgid "Teleporters"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:622
-msgid "Terra Firma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:623
-msgid "Terrain Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:624
-msgid ""
-"The alliance has crumbled and all are at war. Lots of resources but little "
-"time to prepare."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:625
-msgid ""
-"The ancient King Zealot had the artifact of the gods and then hid it in his "
-"old age so that it could not be used by others."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:626
-msgid "The Back Door"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:627
-msgid ""
-"The Barbarian's lands are being invaded. Are you strong enough to resist the "
-"invasion?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:628
-msgid ""
-"The castle of Drakonran in the east has been taken by the barbarians! Two "
-"other towns to the west have also been taken, but the barbarian armies were "
-"fairly decimated in the process."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:629
-msgid "The center island is rumored to harbor great spells."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:630
-msgid "The Citadel"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:631
-msgid "The cities of the plains."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:632
-msgid "The Clearing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:633
-msgid ""
-"The convoy has at long last arrived. Regretably, it has been beset by "
-"bandits on its journey here, and has far less supplies than we had hoped. "
-"Make your way south, for our spies have found rich mines there."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:634
-msgid ""
-"The convoy should have been here by now! Let us hope that it is safe and "
-"still on its way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:635
-msgid ""
-"The country lords have allied and pooled their resources into one command. "
-"Not only have they massed their forces in the north, but they have sent a "
-"knight to the west to steal your supplies. Scouts report a castle to the "
-"east that would be ideal as a base of operations."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:636
-msgid "The crew are unworthy!  I am not going down with the ship! -The Captain"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:637
-msgid "\"The Crown\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:638
-msgid ""
-"The day you have feared has finally arrived.  The king, who you have "
-"faithfully served, has died, leaving no heir to his throne.  As his captain, "
-"you feel that this job should now be yours, but several factions even now "
-"are preparing for conquest.  You are at the center of the trade routes, "
-"having the sea to the south and the great forest to the north.  Go, now, "
-"Commander, and claim what is rightfully yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:639
-msgid ""
-"The diplomats who were sent here ahead of you report that the elves will "
-"only cooperate with you if you will recover the golden bow for them. It was "
-"stolen by their enemies, the Dragons and hidden behind magic barriers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:640
-msgid "The Eastern Town."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:641
-msgid "The edge of the world is your edge.  But prepare to be prepared."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:642
-msgid "The Emerald Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:643
-msgid "The Enchanted Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:644
-msgid "The End of the World is Nigh!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:645
-msgid "The End of the World is Nigh"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:646
-msgid ""
-"The Epic battle against Your Rival! Eliminate everything! Total Warfare! "
-"Don't Lose your first hero!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:647
-msgid ""
-"The Fire King is an ally to the dragons, and will help a friend of theirs."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:648
-msgid "The First One To Take Astircaer Wins!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:649
-msgid ""
-"The first piece of the artifact now lies in the hands of the Unholy Order of "
-"Warlocks. You must annihilate them, and their allies to the north. They will "
-"surely give us what we seek in exchange for their feeble lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:650
-msgid ""
-"The Fortune of Infamous Uae was buried on one of these islands. She died "
-"without ever revealing it.  Find it before the other cutthroats."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:651
-msgid "The four factions race to capture a mystical castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:652
-msgid ""
-"The four spell casters face off with substantial starting armies. Can the "
-"crusaders keep the peace?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:653
-msgid "\"The Gauntlet\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:654
-msgid ""
-"The Gods have given you 6 months to prove yourself. Good or Evil - who shall "
-"prevail? (Blue,Green and Red vs Yellow, Orange and Purple)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:655
-msgid ""
-"The gods have granted this world a great artifact, to find it means victory."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:656
-msgid "The Gods themselves will aid us in this War."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:657
-msgid "The Gold Traveller's Tent is near the Aqua Taveller's Tent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:658
-msgid "The guardians of Dragon Isle reside in the jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:659
-msgid "The Ice Prince stands frozen in some forgotten corner of the world."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:660
-msgid "The island...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:661
-msgid "The Island of Lost Reason"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:662
-msgid "The islands have much wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:663
-msgid "The Isle of Armoria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:664
-msgid "The key to success is rubbing enough lamps."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:665
-msgid ""
-"The King has declared you his hier apparent and champion. You must seek out "
-"and destroy your common enemy, Wilgatus and his Castle, Mirkosov, the source "
-"of his power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:666
-msgid ""
-"The King is dead, his kingdom has been shattered, and six leaders seek to "
-"seize power for themselves."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:667
-msgid "The Kingly Wastes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:668
-msgid "The Kings Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:669
-msgid ""
-"The King will sell you this land for 200,000 gold or you can take it by "
-"force. The choice is yours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:670
-msgid "The land of Heroes II."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:671
-msgid "The Lost Castle of the Ancients"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:672
-msgid ""
-"The mage wars have caused a great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:673
-msgid ""
-"The mage wars have caused great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:674
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trade.  "
-"Plus a little gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:675
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trading.  "
-"Plus a little more gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:676
-msgid ""
-"The Master Merchant arrives at your Castle.  He tells you tall tales of "
-"travel, full of outrageous lies.  He also gives you, your share of the "
-"profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:677
-msgid ""
-"The Master Merchant arrives back at your Castle.  He tells you tall tales of "
-"faraway places full of outrageous lies.  He also gives you, your share of "
-"the profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:678
-msgid "The Medusas have the password and they can be found just to the west."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:679
-msgid "The more there is the less you see."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:680
-msgid "The North Road to Roland's castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:681
-msgid ""
-"The note in this bottle has become mostly indecipherable. All you can make "
-"out are references to deadly pirates, and hidden gold mines."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:682
-msgid "The Other Side"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:683
-msgid ""
-"The Overlord has given you 4 months to conquer this land or deliver to him "
-"the sum of 150,000 gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:684
-msgid ""
-"The people on the Isle of Knowledge are taking up a collection to aid us."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:685
-msgid "The Proving Grounds"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:686
-msgid "The Queen's Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:687
-msgid "The Realm of Air is barred, but you may appeal here for help."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:688
-msgid ""
-"There are remnants of a mighty battle fought here, not too long ago. It "
-"looks as if whoever came this way may have made this their final stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:689
-msgid ""
-"There are three enemy castles to the north. Capture them in the name of "
-"Roland the true king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:690
-msgid ""
-"The Red Tide of War rolls North.  Stopping the flood seems hopeless.  Yet, "
-"Honor demands you and your ally die trying."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:691
-msgid "There is hidden treasure north of the Green Lord's Ore Mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:692
-msgid "There is hidden treasure south of the Blue Lord's Sawmill."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:693
-msgid "There's a warm wind blowing from the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:694
-msgid "There's a Wizard living in the north who is behind this peasant revolt."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:695
-msgid "The Retreat of the Alchemist Doctor Yu"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:696
-msgid ""
-"There used to be a mine here, but it has long since run out of ore.  You are "
-"only able to scavenge 5 units of ore from the old site."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:697
-msgid "There was a shipreck in the far east waters recently."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:698
-msgid "The River Styx"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:699
-msgid "The roars of several dragons echo from the towers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:700
-msgid "The Rock Store."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:701
-msgid "The Royal Gardens."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:702
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:703
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you defend against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:704
-msgid "These doors are a risk the likes of which you do not know."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:705
-msgid "These lands are beholden to Lord Kraeger."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:706
-msgid ""
-"These lands are desolate and for the most part devoid of resources. Not even "
-"the bravest heroes dare to venture into them, and plants are rare and "
-"precious here. Who knows what else awaits?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:707
-msgid ""
-"The Southern Witch is biding her time.  She will strike when your armies are "
-"weak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:708
-msgid "the stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:709
-msgid "The Table in the Great Hall of the Castle is Haunted."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:710
-msgid ""
-"The third piece of the artifact is somewhere to the north, that much we "
-"know. We are still unsure of its exact location, but our spies are out "
-"gathering information. The forces in this area are too strong to be "
-"completely subjugated, so take what you can and hold on to it tightly."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:711
-msgid ""
-"The troops have sworn their allegiance, but should lose a battle they will "
-"lose faith and our cause will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:712
-msgid "The Valley of Aruk."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:713
-msgid ""
-"The Valley of Magic holds many surprises.  You discover an old pair of boots "
-"sticking out of the sand."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:714
-msgid "The Valley of Tresures"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:715
-msgid "The Wasteland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:716
-msgid "The way of magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:717
-msgid "The way of might"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:718
-msgid "The way of numbers"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:719
-msgid "The western town."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:720
-msgid "The winds howl in mourning around the shipwreck."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:721
-msgid "The wizard has an island in the southeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:722
-msgid ""
-"The Wizards who have captured the Necromancers' town have wasted no time in "
-"building defenses designed to stop you, and their last castle has just been "
-"completed. Fortunately only a Captain of the Guard and a small garrison are "
-"currently present.  If you hurry, you should be able to capture the castle "
-"before they have a chance to reinforce it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:723
-msgid "The wood has arrived."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:724
-msgid "The writing on this sign is too faded to read."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:725
-msgid "The Yellow Lord has the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:726
-msgid ""
-"The Yellow Lord is a hothead who will attack before his allies can send him "
-"aid."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:727
-msgid "They say there's mermaids in these waters..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:728
-msgid ""
-"This area is rich in resources. Explore, but beware, a castle left "
-"undefended will quickly fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:729
-msgid ""
-"This area must be secured for the sake of the Empire. Our spies have "
-"reported a discord between The kingdom of the knights to the north, and that "
-"of the oppressive sorceresses to the northeast. Perhaps this feud can be "
-"exploited for our gain..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:730
-msgid "This bottle is empty."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:731
-msgid ""
-"This is the last week you have to find the rebel wizard Joseph! Good Luck in "
-"your quest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:732
-msgid ""
-"This land and all others are now under the sole ownership of Ibn Fadlan, the "
-"Undead King. Any disregard for his magesty's soverign rule is to be punished "
-"by death most horrendous."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:733
-msgid ""
-"This land has been claimed by the nation of Neroli. Interlopers are "
-"UNWELCOME."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:734
-msgid ""
-"This rugged land will have rivals fighting the terrain as well as each other."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:735
-msgid ""
-"This rundown village looks like it was once the epicenter of an enormous, "
-"but now ruined, city. Under a pile of rubble you find an object which looks "
-"like it has lain there for ages."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:736
-msgid ""
-"This spot overlooks an old quarry.  This was one of the only places in the "
-"world where ore could be taken right out of the ground.  Unfortunately the "
-"jungle has reclaimed the quarry and it is unusable.  You collect the last of "
-"the ore and depart."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:737
-msgid ""
-"This twisted maze of sorceress towns has three factions struggling for sole "
-"control.  Use your resources wisely!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:738
-msgid ""
-"This village appears to be in little better shape than the first one you "
-"saw. As you approach the village an old man hands you a slip of paper, with "
-"the following message, \"Joseph lives in the town of IslandHome.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:739
-msgid ""
-"This village is in extremely poor shape. There is no chance of getting more "
-"than some of the lesser creatures here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:740
-msgid "This way to the Necromancer Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:741
-msgid "Those who seek knowledge are welcome to the city of Chronos."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:742
-msgid ""
-"Three Warlocks in the land of Dragons. Lose thy home and all will be lost. "
-"Conquer thy enemies and the land shall forever be yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:743
-msgid "Timberhill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:744
-msgid "Time for a refreshing drink."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:745
-msgid "Time is running out! The enemy's reinforcements are almost here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:746
-msgid "To pass you must pay troll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:747
-msgid "TreeHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:748
-msgid "Trespassers will be EATEN!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:749
-msgid "Trilobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:750
-msgid "Troy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:751
-msgid "Tundara"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:752
-msgid "Turn back, friend, while you still can!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:753
-msgid "Turn Back Now!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:754
-msgid "Turn Back Now or all will be LOST!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:755
-msgid "Turn Back or DIE!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:756
-msgid "Turn Back or else!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:757
-msgid "Turn back, you fool."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:758
-msgid "\"Turning Point\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:759
-msgid ""
-"Uae was the scurviest, pirate ye'd never wanta see. In all her years of "
-"murdering and thieving she amassed so much ill-gotten booty that she "
-"couldn't carry it around in her galleon.  Besides, even the meanest can't "
-"stay awake all the time.  Legend tells that she hid it so well, she was "
-"thinking that she just might forget where it was.  So she left clues around "
-"the islands, carved in stone.  Well, she's dead now.  It's up to you to "
-"recover her legacy."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:761
-msgid "Uncle Leo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:762
-msgid "Uncle Milty"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:763
-msgid "Undead Armies"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:764
-msgid "Unholy Alliance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:765
-msgid "Unite the Tribes. Don't lose your main hero, the first Descendant."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:766
-msgid "Valley of Death"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:767
-msgid "Valley Of The Damned"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:768
-msgid "Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:769
-msgid "Vaultius"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:770
-msgid "Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:771
-msgid "Vikings!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:772
-msgid "Viper's Nest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:773
-msgid "Vulcania"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:774
-msgid "Warrior Knight"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:775
-msgid "Wastelands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:776
-msgid "Watch out for Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:777
-msgid "Waystop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:778
-msgid ""
-"\"We are at the edge of the world!\"  they scream.  \"What are we doing here?"
-"\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:779
-msgid "Weddington"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:780
-msgid "Weed Patch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:781
-msgid ""
-"We found a weakness my lord. Capture castle Black Fang and victory is ours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:782
-msgid ""
-"We have just learned that the artifact is on an island north of this "
-"continent. However, there does not appear to be any means to get there. Stay "
-"very alert for any possible way across the narrow channel."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:783
-msgid ""
-"Welcome back general.  Have you finished the conquest of the northern "
-"lands?  What? you still have not finished your mission!  Get back there and "
-"teach those rebels a lesson!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:784
-msgid "Welcome to Li'l Alctatraz! Vistors NOT welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:785
-msgid ""
-"Welcome to Power Island. He who controls this Isle controls the Seven Lakes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:786
-msgid "Welcome to the Sandbar."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:787
-msgid "Welcome to the sandy Isle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:788
-msgid "Welcome to the sorceress' guild."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:789
-msgid "Welcome to the Spiral Isles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:790
-msgid ""
-"Welcome to the wounderous Kitisland range.  Eruptions each day, beware of "
-"dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:791
-msgid "Welcome to Windfall Island!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:792
-msgid "Welcome to your DOOM!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:793
-msgid "We'll join you - for the right price."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:794
-msgid ""
-"Well placed bribes have won you a stronghold near the warring Barbarians. Be "
-"advised that given their proximity an unguarded castle is an open invitation "
-"to defeat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:795
-msgid "Westfork"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:796
-msgid "Westmoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:797
-msgid "We told you not to drink!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:798
-msgid "What are you doing here?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:799
-msgid "What cannot be seen but only heard, and will not speak until spoken to?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:800
-msgid "What everyday word is most often pronounced incorrectly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:801
-msgid "What goes up and down but never moves?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:802
-msgid ""
-"What good fortune!  You've discovered a long-abandoned settlement.  To your "
-"surprise, you discover that the previous inhabitants left some of their "
-"resources behind when they departed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:803
-msgid "What is always coming but never arrives?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:804
-msgid "What is the Sum of all Numbers from 1 to 200?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:805
-msgid "What is time spent poorly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:806
-msgid "What's another word for pirate treasure?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:807
-msgid "What's behind door number one?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:808
-msgid "What's this? A pile of gems?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:809
-msgid "What's this? Someone has left a pile of wood here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:810
-msgid ""
-"What team won Super Bowl XXI and Super Bowl XXV?  (Hint... a Wizard might "
-"have these troops in his army)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:811
-msgid "What turns everything around but does not move?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:812
-msgid ""
-"What walks in the morning on four legs, two in the afternoon and three in "
-"the evening?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:813
-msgid "What?  What's this?  Something at the bottom of this pool..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:814
-msgid "When you're ready, take the teleport to the Island's Hot Spot!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:815
-msgid ""
-"When you think yourself invincible, walk through this gate.  Even then, "
-"prepare to meet your bitter end."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:816
-msgid "Where am I?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:817
-msgid "While away seeking the Ultimate Artifact, Kastor's kingdom is invaded!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:818
-msgid ""
-"While traveling a mesenger meets you on the road.  His message tells of a "
-"new ally from an island far to the south.  This ally can not offer forces to "
-"your battle but has agreed to send some support in the form of gold and "
-"crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:819
-msgid "Whiteshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:820
-msgid "Whittingham"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:821
-msgid "Who am I?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:822
-msgid ""
-"Who am I?...  Where am I?...  Oh no! My Ship!  Well it's consigned to the "
-"ghosts of my dead crew now, at least I still have my lucky rabbits foot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:823
-msgid "Who is the true King?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:824
-msgid ""
-"\"Why have we come this way?\"  asks the first mate.  You have no answer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:825
-msgid "Wicked Warlock Way"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:826
-msgid "Wilasher"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:827
-msgid "Wildabar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:828
-msgid "Wilgatus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:829
-msgid "Willow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:830
-msgid "Windfall Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:831
-msgid "Winterkill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:832
-msgid "Winterlands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:833
-msgid "Witch Hunt"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:834
-msgid ""
-"With the year long eruption of Mt. Kitisland, your three worst enemies now "
-"have a ground bridge to your eastern contenent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:835
-msgid "Wizardwood.  Magicians welcome!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:836
-msgid "Woodhaven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:837
-msgid "Wood's Lord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:838
-msgid "Woodstock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:839
-msgid "Woodville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:840
-msgid "Wormed Ash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:841
-msgid "Wow, somebody has left a pile of wood here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:842
-msgid "Wyrm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:843
-msgid "Xabran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:844
-msgid "Yellow gets some stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:845
-msgid "Yellow's Steady Cash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:846
-msgid "Yellow stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:847
-msgid "Yellow's Yarbols"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:848
-msgid "Ye old fish liver oil."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:849
-msgid "Yorksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:850
-msgid ""
-"You and your ally's families were given custody of The Isle of Knowledge.  "
-"Other Lords feel the time has come for new guardians..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:851
-msgid "You are a fool to come here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:852
-msgid "You are fighting on the side of your king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:853
-msgid "You are fighting on the side of your sister!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:854
-msgid "You are now entering the domain of Prince Roland. Have a nice day."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:855
-msgid "You are now entering the domain of Prince Roland. Have a pleasant stay."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:856
-msgid ""
-"You bribe the entrance guards of this dingy prison camp. They agree to look "
-"the other way for a little while."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:857
-msgid ""
-"You can only reach your enemies via teleporters, but each jump is a leap of "
-"faith."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:858
-msgid ""
-"You cautiously ride through the trees, looking out for enemy assaults, when "
-"suddenly, the old elf is beside you. \"Your quest is almost at an end, my "
-"friend. All that remains is for you to lay seige to these last few castles. "
-"The fate of my people rests upon your final battles here. May the gods be "
-"with you as well.\"  He turns to leave, but you ask him his name before he "
-"is gone. Over his shoulder, as he is leaving he says \"I am Ilthanis, king "
-"of the elves.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:859
-msgid ""
-"You come across the dead remains of what was appearantly a powerful wizard!  "
-"You wonder if it's safe to continue."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:860
-msgid ""
-"You face three opponents in this scenario. Capture their castles and their "
-"heroes to prove your worthiness to Archibald."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:861
-msgid ""
-"You find a beautiful helm buried in the lava.  As you move to put it on your "
-"head it turns into the Hideous mask and now you realize that no creature "
-"will join you."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:862
-msgid ""
-"You find a gleaming gold medalion buried in the  snow.  As you move to put "
-"it on it changes to the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:863
-msgid ""
-"You find an old signpost in the midst of a thicket that reads \"Warlock "
-"Wood, West.  Barbarian Fields, East.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:864
-msgid ""
-"You find a note in the bottle! It reads, \"My ship has been wrecked by the "
-"notorious pirates in this area! I am stranded on a small and barren island. "
-"Please, I beg you to come and rescue me!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:865
-msgid "You found something!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:866
-msgid "You found Treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:867
-msgid ""
-"You have been ordered here to claim this land in the name of your King and "
-"recover any riches that you might find.  However, five other Kings and "
-"Queens have also sent their heroes to this land, so you must watch out for "
-"them as well as the natives!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:868
-msgid "You have found what someone else has lost..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:869
-msgid ""
-"You have hired a barbarian of great power to aid you in this, your last "
-"quest. His origins are unknown to you, but you sense strong nobility beneath "
-"the furs and dirt that cover him. In addition, the famous explorer, Marco "
-"the wizard, is rumored to have wrecked his ship in this new land. Finding "
-"him would prove to be a much needed boon to your cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:870
-msgid ""
-"You have just 8 weeks  to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:871
-msgid ""
-"You have just 8 weeks to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:872
-msgid ""
-"You have received a message from Archibald. \"General, these peasants "
-"deserve punishment. Put them to the sword and let Corlagon have his way with "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:873
-msgid ""
-"You have received a message from Archibald.  \" HOW DARE YOU BETRAY ME! I "
-"will see your head on the block alongside your new master's once I have won."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:874
-msgid ""
-"You have received a message from Roland. \" I am shocked! I had thought "
-"better of you, but I was terribly wrong. Now you'll have to live with your "
-"dark decision for the rest of your life.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:875
-msgid "You have recieved a shipment of supplies from your kingdom!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:876
-msgid ""
-"You have recieved a shipment of supplies from your kingdom! There is a note "
-"attached, \"These are all we could afford to send you from our treasuries, "
-"as the war with Harondale is taxing us greatly. We will send more in two "
-"weeks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:877
-msgid ""
-"You have six months to destroy the Necromancer Stronghold in the heart of "
-"the valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:878
-msgid ""
-"You have washed up on the beach after being shipwrecked. Your goal is to "
-"find a way home."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:879
-msgid ""
-"You hear a low rumble, look up and see an avalanche!  You dive onto a large "
-"patch of grass to avoid it.  While dusting yourself off, you consider "
-"yourself quite lucky to be alive.  Luckier still to find a Four-Leaf Clover "
-"stuck on your nose."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:880
-msgid ""
-"You hear a rumor from a peasant who lives in the town of Waystop. He says, "
-"\"The pirates control most of the sulfur mines in this area. They use it for "
-"the cannons on their bigger boats. If you want a mine, you'll have to defeat "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:881
-msgid "You hear melodic strains of elvish music as you enter this clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:882
-msgid ""
-"You must, like, forsake your earthly wealth and, like, join us on the island "
-"of the lotus eaters."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:883
-msgid ""
-"You must search the world for your mortal enemy, Wilgatus.  Can you find him "
-"before its too late?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:884
-msgid ""
-"You notice some runes hastily scrawled into a rock by your feet, They look "
-"like the initials of Uncle Ivan!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:885
-msgid ""
-"You notice that mines and resources in the elvish lands are few, and you "
-"send word to your kingdom that you will need extra supplies. They should "
-"respond within a fortnight."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:886
-msgid ""
-"Your advance scouts come riding back to you with the following news. They "
-"believe they have found signs that Uncle Ivan was in this general area, and "
-"that he made his way to the north many months ago. Also they say there is a "
-"town nearby and many resources to the east."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:887
-msgid ""
-"Your advisor approaches you, \"My liege, something must be done about these "
-"peasants! They still refuse to work.  At this rate you won't have anything "
-"to put in your daughter's dowry!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:888
-msgid ""
-"Your advisor approaches you smiling greatly, \"My liege! The peasants are "
-"making money in the market, and are finally paying taxes!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:889
-msgid ""
-"Your advisor approaches you with a long face, \"My liege, the peasant's "
-"numbers are growing steadily.  All they do is take, take, take! We are "
-"beginning to suffer dearly because of them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:890
-msgid ""
-"Your advisor approaches you with some startling information, \"My liege, the "
-"peasants are draining us. They do nothing, and take everything! We must get "
-"them home. Your own citizens are beginning to suffer!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:891
-msgid ""
-"Your arrival here was a surprise to those sworn to guard Dragon Isle, and "
-"you were able to quickly capture one of their castles.  Use caution, though, "
-"for two other guardians remain in this jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:892
-msgid ""
-"Your castle, founded inside the center of a mile wide crater, is besieged by "
-"those who desire your mineral wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:893
-msgid "Your castle is the last outpost in the area, Don't lose it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:894
-msgid "Your crew begins to grumble."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:895
-msgid ""
-"Your crew seriously entertains thoughts of mutiny.  Your nights are "
-"sleepless."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:896
-msgid "You're almost there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:897
-msgid "You, recieve word that you have been robbed."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:898
-msgid "You're getting colder."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:899
-msgid "You're getting warmer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:900
-msgid ""
-"You're here! Oh, thank you thank you thank you! I'm in the jail east of the "
-"castle. Please hurry!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:901
-msgid ""
-"Your expedition has taken a turn for the worse... you now have no way to get "
-"home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:902
-msgid ""
-"Your forces are thinly spread in an effort to defend all the dwarf towns "
-"(which may not be transformed into castles). Consolidate your forces and "
-"smite the enemy before the towns fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:903
-msgid ""
-"Your horse stumbles and throws you from the saddle.  When you awaken you "
-"find that you have hit your head on the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:904
-msgid ""
-"Your isolation from the rest of the kingdom has largely kept you out of the "
-"political struggles, but now with the king's death, and lack of an heir, you "
-"see a golden opportunity to seize the throne for yourself.  Just remember "
-"that you have relied largely on trade for several key resources, especially "
-"sulfur, but with a little planning this land can be yours.  Go, now, and "
-"show these peasants how to rule!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:905
-msgid "Your king has sent supplies to aid the war effort."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:906
-msgid ""
-"Your opponents are allied against you and each is twice as powerful as his "
-"predecessor! Is it possible to win?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:907
-msgid ""
-"Your Queen sent you here to explore this newly discovered territory, but a "
-"freak storm scattered your fleet and left you stranded.  You gather the "
-"survivors and form a small settlement, naming it New Vertigo.  This place is "
-"your home now, and survival is your highest priority, but remember, if you "
-"are captured or killed, it's over!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:908
-msgid ""
-"Your rival, the kingdom of Harondale, is attacking your weak border towns! "
-"Recover from their first strike and crush them completely."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:909
-msgid ""
-"Your Scouts report talking to a young knight, a squire to the two sleeping "
-"heroes.  The squire is trapped by the Aqua Magic Barriers and a group of "
-"fallen Paladins.  He says the two heroes, Dainwin and Ceallach, have "
-"awakened but are still trapped by a Gold Magical Barrier and asks your aid "
-"in freeing them."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:910
-msgid ""
-"Your Scouts report that the Aqua Traveller's Tent is located along The North "
-"Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:911
-msgid ""
-"Your scouts return with grim news.  The natives of this land are currently "
-"at war with each other, and they like outsiders even less than they like "
-"each other!  Congratulations, Commander, you're at war!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:912
-msgid ""
-"Your sister calls you before her altar in the morning. \"I have important "
-"news,\" she says, \"The barbarian kingdoms which border this land have "
-"agreed to lend us some of their castles and warriors in return for a share "
-"of the spoils. I hope victory comes swiftly, but your presence gives me "
-"strength to stand until whatever end awaits.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:913
-msgid "Your subjects contribute to your war effort!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:914
-msgid ""
-"Your town is undefended and your heroes are scattered.  Do you attack or "
-"defend?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:915
-msgid ""
-"Your treasury has been looted by robbers and you have lost valuable "
-"resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:916
-msgid "Your troops begin to wonder about your sanity."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:917
-msgid ""
-"You run aground on the rocks and have to use some wood to fix your boat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:918
-msgid ""
-"You see a family of refugees making their way from the beach. You ask them "
-"about their plight and they tell you that they are from a once great city "
-"called Moss Side. They tell you that the castle was destroyed in a great "
-"conflagration, and they fled for fear of their lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:919
-msgid ""
-"You see an old man bringing water towards the stables. Recognizing him as "
-"the mystic, you attempt to thank him for his gift with some gold. He "
-"refuses, but says to you instead, \"There are riddles guarding the source of "
-"the fount's power, and the dragons know the answers. Make your way through "
-"their lair, and you shall know victory.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:920
-msgid ""
-"You see an old mystic perched on a rock. You walk towards him to see if he "
-"has any words for you on your quest, and he says \"First I see you as a "
-"great conquerer of the lands of men. Secondly, I see you as a mighty ruler "
-"of vast armies, well loved by your troops. Thirdly, I see you as a slayer of "
-"legions of dragons, your body bathed in their fire. Lastly, I see you "
-"standing on the shores of the fount, unable to cross.\" Then the Mystic "
-"fades away."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:921
-msgid "You see something that could just be the elusive Nubbie!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:922
-msgid ""
-"You see the mast of ancient ship here.  On further investigation you find "
-"that the ships holds are full of gems.  The hours pass as your crue "
-"liberates the treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:923
-msgid ""
-"You see the remains of a burned out sawmill here.  All you can salvage is "
-"some ofwood left for scrap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:924
-msgid ""
-"You see the remains of an old sawmill, but it is obvious that you will not "
-"be able to make it work again."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:925
-msgid ""
-"You see the remains of an old sawmill just to realize that it will no longer "
-"produce.  You gather the ramains and move on."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:926
-msgid ""
-"You send this letter back to the king,\"A month has passed and we have not "
-"discovered the wizard Joseph. I only hope that we are able to locate him in "
-"time to aid us in our struggle.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:927
-msgid "You should turn back."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:928
-msgid ""
-"You stumble upon an old man who proclaims you Lord of the Realm, hands you "
-"his boots and wonders into the mountains mumbling something about being late "
-"for an important date."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:929
-msgid ""
-"You stumple across three small rocks piled on top of each other and decide "
-"to dig undernear them.  There you find an old weather-beaten bag of gems."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:930
-msgid "You uncover a compass in the grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:931
-msgid "You've been warned!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:932
-msgid ""
-"You've received a message from Roland. \"In the absence of a strong leader, "
-"the local lords have fallen to fighting. Uniting this area is critical to "
-"our cause, so we must not fail.  Leaving your castle undefended in this "
-"highly contested region will surely lead to defeat. I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:933
-msgid ""
-"You've received a message from the guild. \"Thank God you've arrived! We're "
-"under seige from two enemies from the north and one from across the sea. "
-"Please save us, you're our only hope.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:934
-msgid ""
-"You've ruled with an iron fist (and an army of undead), but now your kingdom "
-"has turned against you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:935
-msgid ""
-"You've saved a group of miners from the dragons.  One of them approaches "
-"you, \"Thank you so much for saving us!  We found this sulfer and sword in "
-"the mine, then those dragons chased us!  I don't know how much longer we "
-"could survive!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:936
-msgid ""
-"You will clash quickly on this small head-to-head map, so stay on your toes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:937
-msgid ""
-"You will need a stronger army than that, mortal, to step through this portal."
-msgstr ""
-
-#: ../fheroes2/resource/resource.cpp:283
+#: ../fheroes2/resource/resource.cpp:323
 msgid "Wood"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
+#: ../fheroes2/resource/resource.cpp:323
 msgid "Mercury"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
+#: ../fheroes2/resource/resource.cpp:323
 msgid "Ore"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
+#: ../fheroes2/resource/resource.cpp:323
 msgid "Sulfur"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
+#: ../fheroes2/resource/resource.cpp:323
 msgid "Crystal"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
+#: ../fheroes2/resource/resource.cpp:323
 msgid "Gems"
 msgstr ""
 
-#: ../fheroes2/spell/spell_book.cpp:61 ../fheroes2/spell/spell_book.cpp:79
-msgid "No spell to cast."
-msgstr ""
-
-#: ../fheroes2/spell/spell_book.cpp:138
-msgid "Your hero has %{point} spell points remaining"
-msgstr ""
-
-#: ../fheroes2/spell/spell.cpp:50
+#: ../fheroes2/spell/spell.cpp:54
 msgid "Fireball"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:50
+#: ../fheroes2/spell/spell.cpp:54
 msgid ""
 "Causes a giant fireball to strike the selected area, damaging all nearby "
 "creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:51
+#: ../fheroes2/spell/spell.cpp:55
 msgid "Fireblast"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:51
+#: ../fheroes2/spell/spell.cpp:56
 msgid ""
 "An improved version of fireball, fireblast affects two hexes around the "
 "center point of the spell, rather than one."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:52
+#: ../fheroes2/spell/spell.cpp:57
 msgid "Lightning Bolt"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:52
+#: ../fheroes2/spell/spell.cpp:57
 msgid "Causes a bolt of electrical energy to strike the selected creature."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:53
+#: ../fheroes2/spell/spell.cpp:58
 msgid "Chain Lightning"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:53
+#: ../fheroes2/spell/spell.cpp:59
 msgid ""
 "Causes a bolt of electrical energy to strike a selected creature, then "
 "strike the nearest creature with half damage, then strike the NEXT nearest "
@@ -11260,818 +7206,790 @@ msgid ""
 "harmful.  Warning:  This spell can hit your own creatures!"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:54
+#: ../fheroes2/spell/spell.cpp:60
 msgid "Teleport"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:54
+#: ../fheroes2/spell/spell.cpp:60
 msgid ""
 "Teleports the creature you select to any open position on the battlefield."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:55
+#: ../fheroes2/spell/spell.cpp:61
 msgid "Cure"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:55
+#: ../fheroes2/spell/spell.cpp:61
 msgid ""
-"Removes all negative spells cast upon one of your units, and restores up to %"
-"{count} HP per level of spell power."
+"Removes all negative spells cast upon one of your units, and restores up to "
+"%{count} HP per level of spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:56
+#: ../fheroes2/spell/spell.cpp:62
 msgid "Mass Cure"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:56
+#: ../fheroes2/spell/spell.cpp:63
 msgid ""
-"Removes all negative spells cast upon your forces, and restores up to %"
-"{count} HP per level of spell power, per creature."
+"Removes all negative spells cast upon your forces, and restores up to "
+"%{count} HP per level of spell power, per creature."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:57
+#: ../fheroes2/spell/spell.cpp:64
 msgid "Resurrect"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:57
+#: ../fheroes2/spell/spell.cpp:64
 msgid "Resurrects creatures from a damaged or dead unit until end of combat."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:58
+#: ../fheroes2/spell/spell.cpp:65
 msgid "Resurrect True"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:58
+#: ../fheroes2/spell/spell.cpp:65
 msgid "Resurrects creatures from a damaged or dead unit permanently."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:59
+#: ../fheroes2/spell/spell.cpp:66
 msgid "Haste"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:59
+#: ../fheroes2/spell/spell.cpp:66
 msgid "Increases the speed of any creature by %{count}."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:60
+#: ../fheroes2/spell/spell.cpp:67
 msgid "Mass Haste"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:60
+#: ../fheroes2/spell/spell.cpp:67
 msgid "Increases the speed of all of your creatures by %{count}."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:61
+#: ../fheroes2/spell/spell.cpp:68
 msgid "spell|Slow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:61
+#: ../fheroes2/spell/spell.cpp:68
 msgid "Slows target to half movement rate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:62
+#: ../fheroes2/spell/spell.cpp:69
 msgid "Mass Slow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:62
+#: ../fheroes2/spell/spell.cpp:69
 msgid "Slows all enemies to half movement rate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:64
-msgid "Blind "
+#: ../fheroes2/spell/spell.cpp:71
+msgid "spell|Blind"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:64
+#: ../fheroes2/spell/spell.cpp:71
 msgid "Clouds the affected creatures' eyes, preventing them from moving."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:65
+#: ../fheroes2/spell/spell.cpp:72
 msgid "Bless"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:65
+#: ../fheroes2/spell/spell.cpp:72
 msgid "Causes the selected creatures to inflict maximum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:66
+#: ../fheroes2/spell/spell.cpp:73
 msgid "Mass Bless"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:66
+#: ../fheroes2/spell/spell.cpp:73
 msgid "Causes all of your units to inflict maximum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:67
+#: ../fheroes2/spell/spell.cpp:74
 msgid "Stoneskin"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:67
+#: ../fheroes2/spell/spell.cpp:74
 msgid "Magically increases the defense skill of the selected creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:68
+#: ../fheroes2/spell/spell.cpp:75
 msgid "Steelskin"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:68
+#: ../fheroes2/spell/spell.cpp:75
 msgid ""
 "Increases the defense skill of the targeted creatures.  This is an improved "
 "version of Stoneskin."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:69
+#: ../fheroes2/spell/spell.cpp:76
 msgid "Curse"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:69
+#: ../fheroes2/spell/spell.cpp:76
 msgid "Causes the selected creatures to inflict minimum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:70
+#: ../fheroes2/spell/spell.cpp:77
 msgid "Mass Curse"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:70
+#: ../fheroes2/spell/spell.cpp:77
 msgid "Causes all enemy troops to inflict minimum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:71
+#: ../fheroes2/spell/spell.cpp:78
 msgid "Holy Word"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:71
+#: ../fheroes2/spell/spell.cpp:78
 msgid "Damages all undead in the battle."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:72
+#: ../fheroes2/spell/spell.cpp:79
 msgid "Holy Shout"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:72
+#: ../fheroes2/spell/spell.cpp:79
 msgid ""
 "Damages all undead in the battle.  This is an improved version of Holy Word."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:73
+#: ../fheroes2/spell/spell.cpp:80
 msgid "Anti-Magic"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:73
+#: ../fheroes2/spell/spell.cpp:80
 msgid "Prevents harmful magic against the selected creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:74
+#: ../fheroes2/spell/spell.cpp:81
 msgid "Dispel Magic"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:74
+#: ../fheroes2/spell/spell.cpp:81
 msgid "Removes all magic spells from a single target."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:75
+#: ../fheroes2/spell/spell.cpp:82
 msgid "Mass Dispel"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:75
+#: ../fheroes2/spell/spell.cpp:82
 msgid "Removes all magic spells from all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:76
+#: ../fheroes2/spell/spell.cpp:83
 msgid "Magic Arrow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:76
+#: ../fheroes2/spell/spell.cpp:83
 msgid "Causes a magic arrow to strike the selected target."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:77
+#: ../fheroes2/spell/spell.cpp:84
 msgid "Berserker"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:77
+#: ../fheroes2/spell/spell.cpp:84
 msgid "Causes a creature to attack its nearest neighbor."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:78
+#: ../fheroes2/spell/spell.cpp:85
 msgid "Armageddon"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:78
+#: ../fheroes2/spell/spell.cpp:85
 msgid ""
 "Holy terror strikes the battlefield, causing severe damage to all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:79
+#: ../fheroes2/spell/spell.cpp:86
 msgid "Elemental Storm"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:79
+#: ../fheroes2/spell/spell.cpp:86
 msgid "Magical elements pour down on the battlefield, damaging all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:80
+#: ../fheroes2/spell/spell.cpp:87
 msgid "Meteor Shower"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:80
+#: ../fheroes2/spell/spell.cpp:87
 msgid ""
 "A rain of rocks strikes an area of the battlefield, damaging all nearby "
 "creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:81
+#: ../fheroes2/spell/spell.cpp:88
 msgid "Paralyze"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:81
+#: ../fheroes2/spell/spell.cpp:88
 msgid "The targeted creatures are paralyzed, unable to move or retaliate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:82
+#: ../fheroes2/spell/spell.cpp:89
 msgid "Hypnotize"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:82
+#: ../fheroes2/spell/spell.cpp:90
 msgid ""
-"Brings a single enemy unit under your control for one combat round if its "
-"hits are less than %{count} times the caster's spell power."
+"Brings a single enemy unit under your control if its hits are less than "
+"%{count} times the caster's spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:83
+#: ../fheroes2/spell/spell.cpp:91
 msgid "Cold Ray"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:83
+#: ../fheroes2/spell/spell.cpp:91
 msgid "Drains body heat from a single enemy unit."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:84
+#: ../fheroes2/spell/spell.cpp:92
 msgid "Cold Ring"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:84
+#: ../fheroes2/spell/spell.cpp:92
 msgid ""
 "Drains body heat from all units surrounding the center point, but not "
 "including the center point."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:85
+#: ../fheroes2/spell/spell.cpp:93
 msgid "Disrupting Ray"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:85
+#: ../fheroes2/spell/spell.cpp:93
 msgid "Reduces the defense rating of an enemy unit by three."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:86
+#: ../fheroes2/spell/spell.cpp:94
 msgid "Death Ripple"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:86
+#: ../fheroes2/spell/spell.cpp:94
 msgid "Damages all living (non-undead) units in the battle."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:87
+#: ../fheroes2/spell/spell.cpp:95
 msgid "Death Wave"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:87
+#: ../fheroes2/spell/spell.cpp:95
 msgid ""
 "Damages all living (non-undead) units in the battle.  This spell is an "
 "improved version of Death Ripple."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:88
+#: ../fheroes2/spell/spell.cpp:96
 msgid "Dragon Slayer"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:88
+#: ../fheroes2/spell/spell.cpp:96
 msgid "Greatly increases a unit's attack skill vs. Dragons."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:89
+#: ../fheroes2/spell/spell.cpp:97
 msgid "Blood Lust"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:89
+#: ../fheroes2/spell/spell.cpp:97
 msgid "Increases a unit's attack skill."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:90
+#: ../fheroes2/spell/spell.cpp:98
 msgid "Animate Dead"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:90
+#: ../fheroes2/spell/spell.cpp:98
 msgid "Resurrects creatures from a damaged or dead undead unit permanently."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:91
+#: ../fheroes2/spell/spell.cpp:99
 msgid "Mirror Image"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:91
+#: ../fheroes2/spell/spell.cpp:100
 msgid ""
 "Creates an illusionary unit that duplicates one of your existing units.  "
 "This illusionary unit does the same damages as the original, but will vanish "
 "if it takes any damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:92
+#: ../fheroes2/spell/spell.cpp:101
 msgid "Shield"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:92
+#: ../fheroes2/spell/spell.cpp:101
 msgid "Halves damage received from ranged attacks for a single unit."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:93
+#: ../fheroes2/spell/spell.cpp:102
 msgid "Mass Shield"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:93
+#: ../fheroes2/spell/spell.cpp:102
 msgid "Halves damage received from ranged attacks for all of your units."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:94
+#: ../fheroes2/spell/spell.cpp:103
 msgid "Summon Earth Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:94
+#: ../fheroes2/spell/spell.cpp:103
 msgid "Summons Earth Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:95
+#: ../fheroes2/spell/spell.cpp:104
 msgid "Summon Air Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:95
+#: ../fheroes2/spell/spell.cpp:104
 msgid "Summons Air Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:96
+#: ../fheroes2/spell/spell.cpp:105
 msgid "Summon Fire Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:96
+#: ../fheroes2/spell/spell.cpp:105
 msgid "Summons Fire Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:97
+#: ../fheroes2/spell/spell.cpp:106
 msgid "Summon Water Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:97
+#: ../fheroes2/spell/spell.cpp:106
 msgid "Summons Water Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:98
+#: ../fheroes2/spell/spell.cpp:107
 msgid "Earthquake"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:98
+#: ../fheroes2/spell/spell.cpp:107
 msgid "Damages castle walls."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:99
+#: ../fheroes2/spell/spell.cpp:108
 msgid "View Mines"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:99
+#: ../fheroes2/spell/spell.cpp:108
 msgid "Causes all mines across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:100
+#: ../fheroes2/spell/spell.cpp:109
 msgid "View Resources"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:100
+#: ../fheroes2/spell/spell.cpp:109
 msgid "Causes all resources across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:101
+#: ../fheroes2/spell/spell.cpp:110
 msgid "View Artifacts"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:101
+#: ../fheroes2/spell/spell.cpp:110
 msgid "Causes all artifacts across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:102
+#: ../fheroes2/spell/spell.cpp:111
 msgid "View Towns"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:102
+#: ../fheroes2/spell/spell.cpp:111
 msgid "Causes all towns and castles across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:103
+#: ../fheroes2/spell/spell.cpp:112
 msgid "View Heroes"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:103
+#: ../fheroes2/spell/spell.cpp:112
 msgid "Causes all Heroes across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:104
+#: ../fheroes2/spell/spell.cpp:113
 msgid "View All"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:104
+#: ../fheroes2/spell/spell.cpp:113
 msgid "Causes the entire land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:105
+#: ../fheroes2/spell/spell.cpp:114
 msgid "Identify Hero"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:105
+#: ../fheroes2/spell/spell.cpp:114
 msgid "Allows the caster to view detailed information on enemy Heroes."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:106
+#: ../fheroes2/spell/spell.cpp:115
 msgid "Summon Boat"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:106
+#: ../fheroes2/spell/spell.cpp:116
 msgid ""
 "Summons the nearest unoccupied, friendly boat to an adjacent shore "
 "location.  A friendly boat is one which you just built or were the most "
 "recent player to occupy."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:107
+#: ../fheroes2/spell/spell.cpp:117
 msgid "Dimension Door"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:107
+#: ../fheroes2/spell/spell.cpp:117
 msgid "Allows the caster to magically transport to a nearby location."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:108
+#: ../fheroes2/spell/spell.cpp:118
 msgid "Town Gate"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:108
+#: ../fheroes2/spell/spell.cpp:118
 msgid "Returns the caster to any town or castle currently owned."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:109
+#: ../fheroes2/spell/spell.cpp:119
 msgid ""
 "Returns the hero to the town or castle of choice, provided it is controlled "
 "by you."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:110
+#: ../fheroes2/spell/spell.cpp:120
 msgid "Visions"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:110
+#: ../fheroes2/spell/spell.cpp:120
 msgid ""
 "Visions predicts the likely outcome of an encounter with a neutral army camp."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:111
+#: ../fheroes2/spell/spell.cpp:121
 msgid "Haunt"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:111
+#: ../fheroes2/spell/spell.cpp:121
 msgid ""
 "Haunts a mine you control with Ghosts.  This mine stops producing "
 "resources.  (If I can't keep it, nobody will!)"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:112
+#: ../fheroes2/spell/spell.cpp:122
 msgid "Set Earth Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:112
+#: ../fheroes2/spell/spell.cpp:122
 msgid "Sets Earth Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:113
+#: ../fheroes2/spell/spell.cpp:123
 msgid "Set Air Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:113
+#: ../fheroes2/spell/spell.cpp:123
 msgid "Sets Air Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:114
+#: ../fheroes2/spell/spell.cpp:124
 msgid "Set Fire Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:114
+#: ../fheroes2/spell/spell.cpp:124
 msgid "Sets Fire Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:115
+#: ../fheroes2/spell/spell.cpp:125
 msgid "Set Water Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:115
+#: ../fheroes2/spell/spell.cpp:125
 msgid "Sets Water Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:665
-msgid "Necroman"
+#: ../fheroes2/spell/spell_book.cpp:169 ../fheroes2/spell/spell_book.cpp:177
+msgid "No spell to cast."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:691
-msgid ""
-"This lets you change player starting positions and colors. A particular "
-"color will always start in a particular location. Some positions may only be "
-"played by a computer player or only by a human player."
+#: ../fheroes2/spell/spell_book.cpp:234 ../fheroes2/spell/spell_book.cpp:251
+#: ../fheroes2/spell/spell_book.cpp:301
+msgid "Your hero has %{point} spell points remaining."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:695
-msgid ""
-"This lets you change the class of a player. Classes are not always "
-"changeable. Depending on the scenario, a player may receive additional towns "
-"and/or heroes not of their primary alignment."
+#: ../fheroes2/spell/spell_book.cpp:256 ../fheroes2/spell/spell_book.cpp:306
+#: ../fheroes2/spell/spell_book.cpp:333
+msgid "View Adventure Spells"
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:734
-msgid "%{color} player"
+#: ../fheroes2/spell/spell_book.cpp:260 ../fheroes2/spell/spell_book.cpp:309
+#: ../fheroes2/spell/spell_book.cpp:330
+msgid "View Combat Spells"
+msgstr ""
+
+#: ../fheroes2/spell/spell_book.cpp:264 ../fheroes2/spell/spell_book.cpp:312
+msgid "View previous page"
+msgstr ""
+
+#: ../fheroes2/spell/spell_book.cpp:267 ../fheroes2/spell/spell_book.cpp:315
+msgid "View next page"
+msgstr ""
+
+#: ../fheroes2/spell/spell_book.cpp:318
+msgid "Close Spellbook"
+msgstr ""
+
+#: ../fheroes2/spell/spell_book.cpp:325
+msgid "View %{spell}"
 msgstr ""
 
 #: ../fheroes2/system/settings.cpp:126
 msgid "game: always confirm for rewrite savefile"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:127
-msgid "game: also confirm autosave"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:128
+#: ../fheroes2/system/settings.cpp:130
 msgid "game: remember last focus"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:129
-msgid "game: battle show grid"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:130
-msgid "game: battle mouse shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:131
-msgid "game: battle move shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:132
-msgid "game: battle show damage info"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:133
-msgid "game: castle flash building"
-msgstr ""
-
 #: ../fheroes2/system/settings.cpp:134
-msgid "world: show visited content from objects"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:135
-msgid "world: scouting skill show extended content info"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:136
-msgid "world: abandoned mine random resource"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:137
-msgid "world: save count monster after battle"
+msgid "battle: show damage info"
 msgstr ""
 
 #: ../fheroes2/system/settings.cpp:138
-msgid "world: allow set guardian to objects"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:139
-msgid "world: guardian objects gets +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:140
-msgid "world: no in-built requirements or guardians for placed artifacts"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:141
-msgid "world: only the first monster will attack (H2 bug)."
+msgid "world: show visited content from objects"
 msgstr ""
 
 #: ../fheroes2/system/settings.cpp:142
-msgid "world: Eagle Eye also works like Scholar in H3."
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:143
-msgid "world: ban for WeekOf/MonthOf Monsters"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:144
-msgid "world: new version WeekOf (+growth)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:145
-msgid "world: ban plagues months"
+msgid "world: show terrain penalty"
 msgstr ""
 
 #: ../fheroes2/system/settings.cpp:146
-msgid "world: Months Of Monsters do not place creatures on map"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:147
-msgid "world: Crystal Ball also added Identify Hero and Visions spells"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:148
-msgid "world: Artesian Springs have two separately visitable squares (h3 ver)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:149
-msgid "world: Starting heroes as Loss Conditions for Human Players"
+msgid "world: scouting skill show extended content info"
 msgstr ""
 
 #: ../fheroes2/system/settings.cpp:150
-msgid "world: Only 1 hero can be hired by the one player every week"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:151
-msgid "world: each castle allows one hero to be recruited every week"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:152
-msgid "world: Outer creature dwellings should accumulate units"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:153
-msgid "world: use unique artifacts for morale/luck"
+msgid "world: allow set guardian to objects"
 msgstr ""
 
 #: ../fheroes2/system/settings.cpp:154
-msgid "world: use unique artifacts for resource affecting"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:155
-msgid "world: use unique artifacts for primary skills"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:156
-msgid "world: use unique artifacts for secondary skills"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:157
-msgid "world: Wind/Water Mills and Magic Garden can be captured"
+msgid "world: Eagle Eye also works like Scholar in H3."
 msgstr ""
 
 #: ../fheroes2/system/settings.cpp:158
+msgid "world: ban for WeekOf/MonthOf Monsters"
+msgstr ""
+
+#: ../fheroes2/system/settings.cpp:162
+msgid "world: ban plagues months"
+msgstr ""
+
+#: ../fheroes2/system/settings.cpp:166
+msgid "world: Months Of Monsters do not place creatures on map"
+msgstr ""
+
+#: ../fheroes2/system/settings.cpp:170
+msgid "world: Crystal Ball also added Identify Hero and Visions spells"
+msgstr ""
+
+#: ../fheroes2/system/settings.cpp:174
+msgid "world: Starting heroes as Loss Conditions for Human Players"
+msgstr ""
+
+#: ../fheroes2/system/settings.cpp:178
+msgid "world: Only 1 hero can be hired by the one player every week"
+msgstr ""
+
+#: ../fheroes2/system/settings.cpp:182
+msgid "world: Each castle allows one hero to be recruited every week"
+msgstr ""
+
+#: ../fheroes2/system/settings.cpp:186
+msgid "world: Neutral armies scale with game difficulty"
+msgstr ""
+
+#: ../fheroes2/system/settings.cpp:190
+msgid "world: use unique artifacts for resource affecting"
+msgstr ""
+
+#: ../fheroes2/system/settings.cpp:194
+msgid "world: use unique artifacts for primary skills"
+msgstr ""
+
+#: ../fheroes2/system/settings.cpp:198
+msgid "world: use unique artifacts for secondary skills"
+msgstr ""
+
+#: ../fheroes2/system/settings.cpp:202
+msgid "world: Wind/Water Mills and Magic Garden can be captured"
+msgstr ""
+
+#: ../fheroes2/system/settings.cpp:206
 msgid "world: disable Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:159
-msgid "castle: allow buy from well"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:160
+#: ../fheroes2/system/settings.cpp:210
 msgid "castle: allow guardians"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:161
+#: ../fheroes2/system/settings.cpp:214
 msgid ""
 "castle: higher mage guilds regenerate more spell points/turn "
 "(20/40/60/80/100%)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:162
-msgid "castle: allow recruits special/expansion heroes"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:163
+#: ../fheroes2/system/settings.cpp:218
 msgid "heroes: allow buy a spellbook from Shrines"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:164
-msgid "heroes: learn new spells with day"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:165
+#: ../fheroes2/system/settings.cpp:222
 msgid "heroes: recruit cost to be dependent on hero level"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:166
-msgid "heroes: remember MP/SP for retreat/surrender result"
+#: ../fheroes2/system/settings.cpp:226
+msgid "heroes: remember move points for retreat/surrender result"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:167
-msgid "heroes: surrendering gives some experience"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:168
-msgid "heroes: recalculate movement points after creatures movement"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:169
-msgid "heroes: allow pickup objects for patrol"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:170
-msgid "heroes: after battle move to target cell"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:171
+#: ../fheroes2/system/settings.cpp:230
 msgid "heroes: allow transcribing scrolls (needs: Eye Eagle skill)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:172
-msgid "heroes: allow banned sec. skills upgrade"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:173
+#: ../fheroes2/system/settings.cpp:234
 msgid "heroes: in Arena can choose any of primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:174
+#: ../fheroes2/system/settings.cpp:238
 msgid "unions: allow meeting heroes"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:175
+#: ../fheroes2/system/settings.cpp:242
 msgid "unions: allow castle visiting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:176
+#: ../fheroes2/system/settings.cpp:246
+msgid "battle: show army order"
+msgstr ""
+
+#: ../fheroes2/system/settings.cpp:250
 msgid "battle: soft wait troop"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:177
-msgid "battle: high objects are an obstacle for archers"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:178
-msgid "battle: merge armies for hero from castle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:179
-msgid "battle: archmage can resists (20%) bad spells"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:180
-msgid "battle: magical creature resists (20%) the same magic"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:181
-msgid "battle: skip increase +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:182
+#: ../fheroes2/system/settings.cpp:254
 msgid "battle: reverse wait order (fast, average, slow)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:183
+#: ../fheroes2/system/settings.cpp:258
 msgid "game: show system info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:184
+#: ../fheroes2/system/settings.cpp:262
 msgid "game: autosave on"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:185
+#: ../fheroes2/system/settings.cpp:266
 msgid "game: autosave will be made at the beginning of the day"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:186
+#: ../fheroes2/system/settings.cpp:270
 msgid "game: use fade"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:187
-msgid "game: show SDL logo"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:188
+#: ../fheroes2/system/settings.cpp:274
 msgid "game: use evil interface"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:189
-msgid "game: also use dynamic interface for castles"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:190
+#: ../fheroes2/system/settings.cpp:278
 msgid "game: hide interface"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:191
+#: ../fheroes2/system/settings.cpp:282
 msgid "game: offer to continue the game afer victory condition"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:192
-msgid "pocketpc: hide cursor"
+#: ../fheroes2/world/world_loadmap.cpp:742
+msgid "The ultimate artifact is really the %{name}."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:193
-msgid "pocketpc: tap mode"
+#: ../fheroes2/world/world_loadmap.cpp:745
+msgid "The ultimate artifact may be found in the %{name} regions of the world."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:194
-msgid "pocketpc: drag&drop gamearea as scroll"
+#: ../fheroes2/world/world_loadmap.cpp:749
+msgid "north-west"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:195
-msgid "pocketpc: low memory"
+#: ../fheroes2/world/world_loadmap.cpp:751
+msgid "north"
+msgstr ""
+
+#: ../fheroes2/world/world_loadmap.cpp:753
+msgid "north-east"
+msgstr ""
+
+#: ../fheroes2/world/world_loadmap.cpp:757
+msgid "west"
+msgstr ""
+
+#: ../fheroes2/world/world_loadmap.cpp:759
+msgid "center"
+msgstr ""
+
+#: ../fheroes2/world/world_loadmap.cpp:761
+msgid "east"
+msgstr ""
+
+#: ../fheroes2/world/world_loadmap.cpp:765
+msgid "south-west"
+msgstr ""
+
+#: ../fheroes2/world/world_loadmap.cpp:767
+msgid "south"
+msgstr ""
+
+#: ../fheroes2/world/world_loadmap.cpp:769
+msgid "south-east"
+msgstr ""
+
+#: ../fheroes2/world/world_loadmap.cpp:772
+msgid "The truth is out there."
+msgstr ""
+
+#: ../fheroes2/world/world_loadmap.cpp:773
+msgid "The dark side is stronger."
+msgstr ""
+
+#: ../fheroes2/world/world_loadmap.cpp:774
+msgid "The end of the world is near."
+msgstr ""
+
+#: ../fheroes2/world/world_loadmap.cpp:775
+msgid "The bones of Lord Slayer are buried in the foundation of the arena."
+msgstr ""
+
+#: ../fheroes2/world/world_loadmap.cpp:776
+msgid "A Black Dragon will take out a Titan any day of the week."
+msgstr ""
+
+#: ../fheroes2/world/world_loadmap.cpp:777
+msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
+msgstr ""
+
+#: ../fheroes2/world/world_loadmap.cpp:778
+msgid "An unknown force is being ressurected..."
+msgstr ""
+
+#: ../fheroes2/world/world_loadmap.cpp:780
+msgid ""
+"Check the newest version of game at\n"
+"https://github.com/ihhub/\n"
+"fheroes2/releases"
 msgstr ""

--- a/files/lang/fr.po
+++ b/files/lang/fr.po
@@ -7,50 +7,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-10-23 10:54+0900\n"
+"POT-Creation-Date: 2021-07-01 15:11+0200\n"
 "PO-Revision-Date: 2009-11-29 01:03+0000\n"
 "Last-Translator: Sorkin <Unknown>\n"
 "Language-Team: French <fr@li.org>\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Launchpad-Export-Date: 2010-05-27 09:12+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: ../fheroes2/ai/ai_action.cpp:157 ../fheroes2/heroes/heroes_action.cpp:248
-msgid "Hero %{name} also got a %{count} experience."
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:221 ../fheroes2/resource/artifact.cpp:968
-msgid "View %{name}"
-msgstr "voir %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:227 ../fheroes2/army/army_bar.cpp:310
-msgid "Move or right click to redistribute %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:233 ../fheroes2/army/army_bar.cpp:301
-msgid "Combine %{name} armies"
-msgstr "Fusionner les armées de %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:238 ../fheroes2/army/army_bar.cpp:292
-#: ../fheroes2/resource/artifact.cpp:980
-#: ../fheroes2/resource/artifact.cpp:1002
-msgid "Exchange %{name2} with %{name}"
-msgstr "Echanger %{name2} avec %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:246 ../fheroes2/resource/artifact.cpp:988
-msgid "Select %{name}"
-msgstr "Selectionner %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:298 ../fheroes2/army/army_bar.cpp:307
-#, fuzzy
-msgid "Cannot move last troop"
-msgstr "Impossible de déplacer la dernière armée dans la garnison"
-
-#: ../fheroes2/army/army.cpp:85
 msgid ""
 "A few\n"
 "%{monster}"
@@ -58,7 +26,6 @@ msgstr ""
 "Peu\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:86
 msgid ""
 "Several\n"
 "%{monster}"
@@ -66,7 +33,6 @@ msgstr ""
 "Beaucoup\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:87
 msgid ""
 "A pack of\n"
 "%{monster}"
@@ -74,7 +40,6 @@ msgstr ""
 "un bon paquet\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:88
 msgid ""
 "Lots of\n"
 "%{monster}"
@@ -82,7 +47,6 @@ msgstr ""
 "Beaucoup de\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:89
 msgid ""
 "A horde of\n"
 "%{monster}"
@@ -90,7 +54,6 @@ msgstr ""
 "une horde de \n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:90
 msgid ""
 "A throng of\n"
 "%{monster}"
@@ -98,7 +61,6 @@ msgstr ""
 "Une foule de \n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:91
 msgid ""
 "A swarm of\n"
 "%{monster}"
@@ -106,7 +68,6 @@ msgstr ""
 "un essaim de \n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:92
 msgid ""
 "Zounds of\n"
 "%{monster}"
@@ -114,7 +75,6 @@ msgstr ""
 "Pléthore de \n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:93
 msgid ""
 "A legion of\n"
 "%{monster}"
@@ -122,226 +82,222 @@ msgstr ""
 "Une légion de\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Few"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Several"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Pack"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Lots"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Horde"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Throng"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Swarm"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Zounds"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Legion"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:925
 msgid "All %{race} troops +1"
 msgstr "+1 pour toutes les troupes %{race}"
 
-#: ../fheroes2/army/army.cpp:936
-msgid "Entire unit is undead, so morale does not apply."
-msgstr ""
-
-#: ../fheroes2/army/army.cpp:946
 msgid "Troops of 3 alignments -1"
 msgstr "Troupes de 3 alignements -1"
 
-#: ../fheroes2/army/army.cpp:954
 msgid "Troops of 4 alignments -2"
 msgstr "Troupes de 4 alignements -2"
 
-#: ../fheroes2/army/army.cpp:962
 msgid "Troops of 5 alignments -3"
 msgstr "Troupes de 5 alignements -3"
 
-#: ../fheroes2/army/army.cpp:976
 msgid "Some undead in groups -1"
 msgstr "Morts vivants dans les groupes -1"
 
-#: ../fheroes2/battle/battle_action.cpp:752
+msgid "View %{name}"
+msgstr "voir %{name}"
+
+msgid "Move or right click to redistribute %{name}"
+msgstr ""
+
+msgid "Combine %{name} armies"
+msgstr "Fusionner les armées de %{name}"
+
+msgid "Exchange %{name2} with %{name}"
+msgstr "Echanger %{name2} avec %{name}"
+
+msgid "Select %{name}"
+msgstr "Selectionner %{name}"
+
+#, fuzzy
+msgid "Cannot move last troop"
+msgstr "Impossible de déplacer la dernière armée dans la garnison"
+
+msgid "%{name} half the enemy troops!"
+msgstr ""
+
 msgid "Set auto battle off"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:757
 msgid "Set auto battle on"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:864
 msgid "spell failed!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:705
 msgid ""
 "The Sphere of Negation artifact is in effect for this battle, disabling all "
 "combat spells."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:714
 msgid "You have already cast a spell this round."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:720
-#: ../fheroes2/battle/battle_arena.cpp:768
 msgid "That spell will affect no one!"
 msgstr "Ce sort n'affectera personne!"
 
-#: ../fheroes2/battle/battle_arena.cpp:739
 msgid "You may only summon one type of elemental per combat."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:745
 msgid "There is no open space adjacent to your hero to summon an Elemental to."
 msgstr ""
 
-#: ../fheroes2/battle/battle_board.cpp:968
 msgid ""
 "The Moat reduces by -%{count} the defense skill of any unit and slows to "
 "half movement rate."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:50
-msgid "speed: %{speed}"
+msgid "Speed"
+msgstr "Vitesse"
+
+msgid "Speed: %{speed}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:165
+msgid "Auto Spell Casting"
+msgstr ""
+
+msgid "Grid"
+msgstr ""
+
+msgid "Shadow Movement"
+msgstr ""
+
+msgid "Shadow Cursor"
+msgstr ""
+
+msgid "On"
+msgstr ""
+
+#, fuzzy
+msgid "Off"
+msgstr "coupé"
+
 msgid "The enemy has surrendered!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:168
 msgid "The enemy has fled!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:170
-#: ../fheroes2/battle/battle_dialogs.cpp:256
 msgid "A glorious victory!"
 msgstr "Une victoire pleine de gloire!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:175
-msgid "For valor in combat, %{name} receives %{exp} experience"
+msgid "For valor in combat, %{name} receives %{exp} experience."
 msgstr ""
+"Pour avoir prouvé sa valeur au combat, %{name} reçoit %{exp} point(s) "
+"d'experience."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:184
 msgid "The cowardly %{name} flees from battle."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:191
 msgid "%{name} surrenders to the enemy, and departs in shame."
 msgstr "%{name} se rend à l'ennemi et part couvert de honte."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:197
 msgid "Your force suffer a bitter defeat, and %{name} abandons your cause."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:249
 msgid "Your force suffer a bitter defeat."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:296
 msgid "Battlefield Casualties"
 msgstr "Blessures reçues au champ de bataille"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:300
 msgid "Attacker"
 msgstr "Attaquant"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:312
 msgid "Defender"
 msgstr "Défenseur"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:394
+msgid "You have captured an enemy artifact!"
+msgstr "Vous avez capturé un artéfact ennemi!"
+
+msgid "Necromancy!"
+msgstr ""
+
+msgid ""
+"Practicing the dark arts of necromancy, you are able to raise %{count} of "
+"the enemy's dead to return under your service as %{monster}."
+msgstr ""
+
 msgid "%{name} the %{race}"
 msgstr "%{name} le %{race}"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:401
-#: ../fheroes2/castle/castle_well.cpp:311
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:194
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:834
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Attack"
 msgstr "Attaque"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:406
-#: ../fheroes2/castle/castle_well.cpp:317
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:206
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:844
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Defense"
 msgstr "Défense"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:411
-#: ../fheroes2/castle/castle_town.cpp:310
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:854
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:142
-#: ../fheroes2/heroes/heroes_meeting.cpp:292
 msgid "Spell Power"
 msgstr "Pouvoir d'invocation"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:416
-#: ../fheroes2/castle/castle_town.cpp:319
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:864
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:147
-#: ../fheroes2/heroes/heroes_meeting.cpp:296 ../fheroes2/heroes/skill.cpp:151
 msgid "Knowledge"
 msgstr "Connaissance"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:421
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:276
 msgid "Morale"
 msgstr "Morale"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:426
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:286 ../fheroes2/heroes/skill.cpp:338
 msgid "Luck"
 msgstr "Chance"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:431
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:874
-#: ../fheroes2/heroes/heroes_indicator.cpp:247
 msgid "Spell Points"
 msgstr "Points de sortilège"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
-#: ../fheroes2/gui/interface_buttons.cpp:189
+msgid "Hero's Options"
+msgstr "Options du héro"
+
 msgid "Cast Spell"
 msgstr "Lancer un sortilège"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
+msgid "Retreat"
+msgstr "Sonner la retraite"
+
+msgid "Surrender"
+msgstr "Prisonnier"
+
+msgid "Cancel"
+msgstr "Annuler"
+
+msgid "Hero Screen"
+msgstr ""
+
+#, fuzzy
 msgid ""
 "Cast a magical spell. You may only cast one spell per combat round. The "
-"round is reset when every creature has had a turn"
+"round is reset when every creature has had a turn."
 msgstr ""
 "Lance un sortilège. Vous pouvez seulement en lancer un par tour pendant le "
 "combat. Le tour se termine lorsque chauqe créature a effectuée une action"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:488
-msgid "Retreat"
-msgstr "Sonner la retraite"
-
-#: ../fheroes2/battle/battle_dialogs.cpp:488
 msgid ""
 "Retreat your hero, abandoning your creatures. Your hero will be available "
 "for you to recruit again, however, the hero will have only a novice hero's "
@@ -351,11 +307,6 @@ msgstr ""
 "sera ensuite capable de recruter de nouveau, mais ne disposera que des "
 "forces d'un héro novice."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:491
-msgid "Surrender"
-msgstr "Prisonnier"
-
-#: ../fheroes2/battle/battle_dialogs.cpp:491
 msgid ""
 "Surrendering costs gold. However if you pay the ransom, the hero and all of "
 "his or her surviving creatures will be available to recruit again."
@@ -363,724 +314,981 @@ msgstr ""
 "Se constituer prisonnier coûte de l'or. Toutefois, si vous payez la rançon, "
 "le héro et toutes les créatures survivantes pourront recruter de nouveau."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:166
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:227
-msgid "Cancel"
-msgstr "Annuler"
+msgid "Open Hero Screen to view full information about the hero."
+msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
 msgid "Return to the battle."
 msgstr "Retourner a la bataille."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:549
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:438
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:497
 msgid "Not enough gold (%{gold})"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:564
 msgid "%{name} states:"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:569
 msgid ""
-"I will accept your surrender and grant you and your troops safe passage for "
-"the price of %{price} gold."
+"\"I will accept your surrender and grant you and your troops safe passage "
+"for the price of %{price} gold.\""
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:613
-#: ../fheroes2/battle/battle_interface.cpp:1401
 msgid "View %{monster} info."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1409
 #, fuzzy
 msgid "Shoot %{monster}"
 msgstr ""
 "Beaucoup de\n"
 "%{monster}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1431
 msgid "Attack %{monster}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Fly %{monster} here."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Move %{monster} here."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1449
-#: ../fheroes2/battle/battle_interface.cpp:1538
 msgid "Turn %{turn}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1475
 msgid "Teleport Here"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1479
 msgid "Invalid Teleport Destination"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1485
 msgid "Cast %{spell} on %{monster}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1495
 msgid "Cast %{spell}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1501
 msgid "Select Spell Target"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1674
-msgid "Spell cast"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:1686
 #, fuzzy
 msgid "View Ballista Info"
 msgstr "voir les infos de %{name} info."
 
-#: ../fheroes2/battle/battle_interface.cpp:1699
-#: ../fheroes2/battle/battle_tower.cpp:53
 msgid "Ballista"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1712
 msgid "Auto combat"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1719
 msgid "Customize system options."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1727
 #, fuzzy
 msgid "Wait this unit"
 msgstr "Passer cette unité"
 
-#: ../fheroes2/battle/battle_interface.cpp:1734
 msgid "Skip this unit"
 msgstr "Passer cette unité"
 
-#: ../fheroes2/battle/battle_interface.cpp:1742
-#: ../fheroes2/battle/battle_interface.cpp:1774
-msgid "Hero's Options"
-msgstr "Options du héro"
-
-#: ../fheroes2/battle/battle_interface.cpp:1753
-#: ../fheroes2/battle/battle_interface.cpp:1785
 msgid "View Opposing Hero"
 msgstr "Voir le héro adverse"
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Hide logs"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Show logs"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1878
 msgid "%{color} cast spell: %{spell}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2202
 msgid "%{name} skipping turn"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2203
-msgid ", and get +2 defense"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:2206
 msgid "%{name} waiting turn"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2343
 msgid "%{attacker} do %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2497
 msgid "Moved %{monster}: %{src}, %{dst}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2612
+#, fuzzy
+msgid "Moved %{monster}"
+msgstr ""
+"Beaucoup de\n"
+"%{monster}"
+
 msgid "The %{name} resist the spell!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2625
 msgid "%{name} casts %{spell} on the %{troop}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2630
 msgid "%{name} casts %{spell}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2751
-msgid "The %{spell} spell does %{damage} damage to all undead creatures."
-msgstr ""
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to one undead creature."
+msgstr "%{spell} fait %{value} dommage(s) à %{name}."
 
-#: ../fheroes2/battle/battle_interface.cpp:2754
-msgid "The %{spell} spell does %{damage} damage to all living creatures."
-msgstr ""
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to all undead creatures."
+msgstr "%{spell} fait %{value} dommage(s) à %{name}."
 
-#: ../fheroes2/battle/battle_interface.cpp:2756
+#, fuzzy
+msgid "The %{spell} does %{damage} damage, %{count} creatures perish."
+msgstr "%{spell} fait %{value} dommage(s) à %{name}."
+
 msgid "The %{spell} does %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2797
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to one living creature."
+msgstr "%{spell} fait %{value} dommage(s) à %{name}."
+
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to all living creatures."
+msgstr "%{spell} fait %{value} dommage(s) à %{name}."
+
 msgid "The Unicorns attack blinds the %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2798
 msgid "The Medusas gaze turns the %{name} to stone!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2800
 msgid "The Mummies' curse falls upon the %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2801
 msgid "The %{name} are paralyzed by the Cyclopes!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2802
 msgid "The Archmagi dispel all good spells on your %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2820
-msgid "Good luck shines on the  %{attacker}"
+msgid "Good luck shines on the %{attacker}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2872
 msgid "Bad luck descends on the %{attacker}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2884
 msgid "High morale enables the %{monster} to attack again."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2891
 msgid "Low morale causes the %{monster} to freeze in panic."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2944
-msgid "Tower do %{damage} damage."
-msgstr ""
+#, fuzzy
+msgid "%{tower} does %{damage} damage."
+msgstr "%{tower} a causé %{dmg} dommage(s)."
 
-#: ../fheroes2/battle/battle_interface.cpp:3257
 msgid "MirrorImage created"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:3798
-msgid "MirrorImage ended"
+msgid "The mirror image is destroyed!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4089
 msgid "Break auto battle?"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4138
 msgid "No spells to cast."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4147
 msgid "Are you sure you want to retreat?"
 msgstr "Êtes vous sur de vouloir sonner la retraite?"
 
-#: ../fheroes2/battle/battle_interface.cpp:4155
 #, fuzzy
 msgid "Retreat disabled"
 msgstr "Sonner la retraite"
 
-#: ../fheroes2/battle/battle_interface.cpp:4169
-msgid "You don't have enough gold!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:4180
 #, fuzzy
 msgid "Surrender disabled"
 msgstr "Prisonnier"
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 #, fuzzy
 msgid "Damage: %{max}"
 msgstr "Dommage"
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{min} - %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 #, fuzzy
 msgid "Perish: %{max}"
 msgstr "Dommage"
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{min} - %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_main.cpp:190
-msgid "You have captured an enemy artifact!"
-msgstr "Vous avez capturé un artéfact ennemi!"
-
-#: ../fheroes2/battle/battle_main.cpp:241
 msgid ""
-"Through eagle-eyed observation, %{name} is able to learn the magic spell %"
-"{spell}."
+"Through eagle-eyed observation, %{name} is able to learn the magic spell "
+"%{spell}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_main.cpp:280
-msgid ""
-"Practicing the dark arts of necromancy, you are able to raise %{count} of "
-"the enemy's dead to return under your service as %{monster}"
-msgstr ""
-
-#: ../fheroes2/battle/battle_tower.cpp:47 ../fheroes2/castle/castle.cpp:466
 msgid "Left Turret"
 msgstr "Tourelle gauche"
 
-#: ../fheroes2/battle/battle_tower.cpp:48 ../fheroes2/castle/castle.cpp:467
 msgid "Right Turret"
 msgstr "Tourelle droite"
 
-#: ../fheroes2/battle/battle_tower.cpp:115
 msgid "The %{name} fires with the strength of %{count} Archers"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:116
 msgid "each with a +%{attack} bonus to their attack skill."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:863
-msgid "%{name} half the enemy troops!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_troop.cpp:950
 msgid ""
 "The %{artifact} artifact is in effect for this battle, disabling %{spell} "
 "spell."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:1598
 msgid "%{count} %{name} rise(s) from the dead!"
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:258
+#, fuzzy
+msgid "Sorceress Guild"
+msgstr "Guilde des voleurs"
+
+msgid "Necromancer Guild"
+msgstr ""
+
+msgid "Dragon Alliance"
+msgstr ""
+
+msgid "Elven Alliance"
+msgstr ""
+
+msgid "Wayward Son"
+msgstr ""
+
+msgid "Uncle Ivan"
+msgstr ""
+
+msgid "Force of Arms"
+msgstr ""
+
+#, fuzzy
+msgid "Annexation"
+msgstr "animation"
+
+msgid "Save the Dwarves"
+msgstr ""
+
+msgid "Carator Mines"
+msgstr ""
+
+#, fuzzy
+msgid "Turning Point"
+msgstr "Points de vie"
+
+msgid "The Gauntlet"
+msgstr ""
+
+msgid "The Crown"
+msgstr ""
+
+msgid "Corlagon's Defense"
+msgstr ""
+
+msgid "Final Justice"
+msgstr ""
+
+msgid "First Blood"
+msgstr ""
+
+msgid "Barbarian Wars"
+msgstr ""
+
+msgid "Necromancers"
+msgstr ""
+
+msgid "Slay the Dwarves"
+msgstr ""
+
+msgid "Rebellion"
+msgstr ""
+
+msgid "Dragon Master"
+msgstr ""
+
+msgid "Country Lords"
+msgstr ""
+
+msgid "Greater Glory"
+msgstr ""
+
+msgid "Apocalypse"
+msgstr ""
+
+msgid "Uprising"
+msgstr ""
+
+msgid "Island of Chaos"
+msgstr ""
+
+msgid "Arrow's Flight"
+msgstr ""
+
+msgid "The Abyss"
+msgstr ""
+
+msgid "The Giant's Pass"
+msgstr ""
+
+msgid "Aurora Borealis"
+msgstr ""
+
+msgid "Betrayal's End"
+msgstr ""
+
+#, fuzzy
+msgid "Corruption's Heart"
+msgstr "Quartiers du capitaine"
+
+msgid "Conquer and Unify"
+msgstr ""
+
+msgid "Border Towns"
+msgstr ""
+
+msgid "The Wayward Son"
+msgstr ""
+
+msgid "Crazy Uncle Ivan"
+msgstr ""
+
+msgid "The Southern War"
+msgstr ""
+
+msgid "Ivory Gates"
+msgstr ""
+
+msgid "The Elven Lands"
+msgstr ""
+
+msgid "The Epic Battle"
+msgstr ""
+
+msgid "The Shrouded Isles"
+msgstr ""
+
+msgid "The Eternal Scrolls"
+msgstr ""
+
+msgid "Power's End"
+msgstr ""
+
+msgid "Fount of Wizardry"
+msgstr ""
+
+msgid "Stranded"
+msgstr ""
+
+msgid "Pirate Isles"
+msgstr ""
+
+msgid "King and Country"
+msgstr ""
+
+msgid "Blood is Thicker"
+msgstr ""
+
+msgid ""
+"Roland needs you to defeat the lords near his castle to begin his war of "
+"rebellion against his brother.  They are not allied with each other, so they "
+"will spend most of their time fighting with one another.  Victory is yours "
+"when you have defeated all of their castles and heroes."
+msgstr ""
+
+msgid ""
+"The local lords refuse to swear allegiance to Roland, and must be subdued. "
+"They are wealthy and powerful, so be prepared for a tough fight. Capture all "
+"enemy castles to win."
+msgstr ""
+
+msgid ""
+"Your task is to defend the Dwarves against Archibald's forces. Capture all "
+"of the enemy towns and castles to win, and be sure not to lose all of the "
+"dwarf towns at once, or the enemy will have won."
+msgstr ""
+
+msgid ""
+"You will face four allied enemies in a straightforward fight for resource "
+"and treasure. Capture all of the enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Your enemies are allied against you and start close by, so be ready to come "
+"out fighting. You will need to own all four castles in this small valley to "
+"win."
+msgstr ""
+
+msgid ""
+"The Sorceress' guild of Noraston has requested Roland's aid against an "
+"attack from Archibald's allies. Capture all of the enemy castles to win, and "
+"don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy "
+"castle on an island in the ocean.)"
+msgstr ""
+
+msgid ""
+"Gather as large an army as possible and capture the enemy castle within 8 "
+"weeks. You are opposed by only one enemy, but must travel a long way to get "
+"to the enemy castle. Any troops you have in your army at the end of this "
+"scenario will be with you in the final battle."
+msgstr ""
+
+msgid ""
+"Find the Crown before Archibald's heroes find it. Roland will need the Crown "
+"for the final battle against Archibald."
+msgstr ""
+
+msgid ""
+"Three allied enemies stand before you and victory, including Lord Corlagon. "
+"Roland is in a castle to the northwest, and you will lose if he falls to the "
+"enemy. Remember that capturing Lord Corlagon will ensure that he will not "
+"fight against you in the final scenario."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Archibald to end the war!"
+msgstr ""
+
+msgid ""
+"King Archibald requires you to defeat the three enemies in this region.  "
+"They are not allied with one another, so they will spend most of their "
+"energy fighting amongst themselves.  You will win when you own all of the "
+"enemy castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"You must unify the barbarian tribes of the north by conquering them. As in "
+"the previous mission, the enemy is not allied against you, but they have "
+"more resources at their disposal. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"Do-gooder wizards have taken the Necromancers' castle. You must retake it to "
+"achieve victory. Remember that while you start with a powerful army, you "
+"have no castle and must take one within 7 days, or lose this battle. (Hint: "
+"The nearest castle is to the southeast.)"
+msgstr ""
+
+msgid ""
+"The dwarves need conquering before they can interfere in King Archibald's "
+"plans. Roland's forces have more than one hero and many towns to start with, "
+"so be ready for attack from multiple directions. You must capture all of the "
+"enemy towns and castles to claim victory."
+msgstr ""
+
+msgid ""
+"You must put down a peasant revolt led by Roland's forces. All are allied "
+"against you, but you have Lord Corlagon, an experienced hero, to help you. "
+"Capture all enemy castles to win."
+msgstr ""
+
+msgid ""
+"There are two enemies allied against you in this mission. Both are well "
+"armed and seek to evict you from their island. Avoid them and capture Dragon "
+"City to win"
+msgstr ""
+
+msgid ""
+"Your orders are to conquer the country lords that have sworn to serve "
+"Roland. All of the enemy castles are unified against you. Since you start "
+"without a castle, you must hurry to capture one before the end of the week. "
+"Capture all enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Find the Crown before Roland's heroes find it. Archibald will need the Crown "
+"for the final battle against Roland."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Roland to win the war, and be sure "
+"not to lose Archibald in the fight!"
+msgstr ""
+
+msgid ""
+"Subdue the unruly local lords in order to provide the Empire with facilities "
+"to operate in this region."
+msgstr ""
+
+msgid ""
+"Eliminate all oposition in this area. Then the first piece of the artifact "
+"will be yours."
+msgstr ""
+
+msgid ""
+"The sorceresses to the northeast are rebelling! For the good of the empire "
+"you must quash their feeble uprising on your way to the mountains."
+msgstr ""
+
+msgid ""
+"Having prepared for your arrival, Kraeger has arranged for a force of "
+"necromancers to thwart your quest. You must capture the castle of Scabsdale "
+"before the first day of the third week, or the Necromancers will be too "
+"strong for you."
+msgstr ""
+
+msgid ""
+"The barbarian despot in this area is, as yet, ignorant of your presence. "
+"Quickly, build up your forces before you are discovered and attacked! Secure "
+"the region by subduing all enemy forces."
+msgstr ""
+
+msgid ""
+"The Empire is weak in this region. You will be unable to completely subdue "
+"all forces in this area, so take what you can before reprisal strikes. "
+"Remember, your true goal is to claim the Helmet of Anduran."
+msgstr ""
+
+msgid "For the good of the Empire, eliminate Kraeger."
+msgstr ""
+
+msgid ""
+"At last, you have the opportunity and the facilities to rid the Empire of "
+"the necromancer's evil. Eradicate them completely, and you will be sung as a "
+"hero for all time."
+msgstr ""
+
+msgid ""
+"Conquer and unite all the enemy tribes. Don't lose the hero Jarkonas, the "
+"forefather of all descendants."
+msgstr ""
+
+msgid ""
+"Your rival, the Kingdom of Harondale, is attacking weak towns on your "
+"border! Recover from their first strike and crush them completely!"
+msgstr ""
+
+msgid ""
+"Find your wayward son Joseph who is rumored to be living in the desolate "
+"lands. Do it before the first day of the third month or it will be of no "
+"help to your family."
+msgstr ""
+
+msgid ""
+"Rescue your crazy uncle Ivan. Find him before the first day of the fourth "
+"month or it will be no help to your kingdom."
+msgstr ""
+
+msgid ""
+"Destroy the barbarians who are attacking the southern border of your "
+"kingdom! Recover your fallen towns, and then invade the jungle kingdom. "
+"Leave no enemy standing."
+msgstr ""
+
+msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
+msgstr ""
+
+msgid ""
+"Gain the favor of the elves. They will not allow trees to be chopped down, "
+"so they will send you wood every 2 weeks. You must complete your mission "
+"before the first day of the seventh month, or the kingdom will surely fall."
+msgstr ""
+
+msgid ""
+"This is the final battle against your rival kingdom of Harondale. Eliminate "
+"everyone, and don't lose the hero Jarkonas VI."
+msgstr ""
+
+msgid ""
+"Your mission is to vanquish the warring mages in the magical Shrouded Isles. "
+"The completion of this task will give you a fighting chance against your "
+"rivals."
+msgstr ""
+
+msgid ""
+"The location of the great library has been dicovered! You must make your way "
+"to it, and reclaim the city of Chronos in which it lies."
+msgstr ""
+
+msgid ""
+"Find the Orb of negation, which is said to be buried in this land. There are "
+"clues inscribed on stone obelisks which will help lead you to your price. "
+"Find the orb before the first day of the sixth month, or your rivals will "
+"surely have gotten to the fount before you."
+msgstr ""
+
+msgid ""
+"You must take control of the castle of Magic, where the fount of wizardry "
+"lies. Do this and your victory will be supreme."
+msgstr ""
+
+msgid ""
+"Capture the town on the island off the southeast shore in order to construct "
+"a boat and travel back towards the mainland. Do not lose the hero Gallavant."
+msgstr ""
+
+msgid ""
+"Find and defeat Martine, the pirate leader, who resides in Pirates Cove. Do "
+"not lose Gallavant or your quest will be over."
+msgstr ""
+
+msgid ""
+"Eliminate all the other forces who oppose the rule of Lord Alberon. "
+"Gallavant must not die."
+msgstr ""
+
+msgid ""
+"Overthrow the entrenched monarchy of Lord Alberon, and claim all the land in "
+"your name. Gallavant must not die."
+msgstr ""
+
+msgid " bane"
+msgstr ""
+
+msgid " alliance"
+msgstr ""
+
+msgid "Carry-over forces"
+msgstr ""
+
+msgid " bonus"
+msgstr ""
+
+msgid " defeated"
+msgstr ""
+
+msgid "Thunder Mace"
+msgstr ""
+
+msgid "Minor Scroll"
+msgstr ""
+
+msgid "Dragon Sword"
+msgstr ""
+
+#, fuzzy
+msgid "Breastplate"
+msgstr "Place du marché"
+
+msgid "Fibzin Medal"
+msgstr ""
+
+msgid "Mage's ring"
+msgstr ""
+
+#, fuzzy
+msgid "Defender Helm"
+msgstr "Défenseur"
+
+msgid "Power Axe"
+msgstr ""
+
+msgid "Summon Earth"
+msgstr ""
+
 msgid "The %{building} produces %{monster}."
 msgstr "%{building} produit des %{monster}."
 
-#: ../fheroes2/castle/buildinginfo.cpp:505
 msgid "Requires:"
 msgstr "Nécessite :"
 
-#: ../fheroes2/castle/buildinginfo.cpp:597
 msgid "Cannot build. Already built here this turn."
 msgstr ""
 "Construction impossible. Une construction a déjà été faite ici ce tour."
 
-#: ../fheroes2/castle/buildinginfo.cpp:601
 msgid "For this action it is necessary first to build a castle."
 msgstr "Pour effectuer cette action il faut d'abord construire un château."
 
-#: ../fheroes2/castle/buildinginfo.cpp:623
 msgid "Cannot build %{name} because castle is too far from water."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:631
-msgid "Cannot afford %{name}"
+#, fuzzy
+msgid "Cannot afford %{name}."
 msgstr "Impossible d'acheter %{name}"
 
-#: ../fheroes2/castle/buildinginfo.cpp:636
-msgid "%{name} is already built"
+#, fuzzy
+msgid "%{name} is already built."
 msgstr "%{name} est déjà construit(e)"
 
-#: ../fheroes2/castle/buildinginfo.cpp:641
-msgid "Cannot build %{name}"
+#, fuzzy
+msgid "Cannot build %{name}."
 msgstr "Impossible de construire %{name}"
 
-#: ../fheroes2/castle/buildinginfo.cpp:646
-msgid "Build %{name}"
+#, fuzzy
+msgid "Build %{name}."
 msgstr "Construire %{name}"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Thieves' Guild"
 msgstr "Guilde des voleurs"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Tavern"
 msgstr "Taverne"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Shipyard"
 msgstr "Chantier naval"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Well"
 msgstr "Puit"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Statue"
 msgstr "Statue"
 
-#: ../fheroes2/castle/castle.cpp:467
-#: ../fheroes2/dialog/dialog_marketplace.cpp:212
 msgid "Marketplace"
 msgstr "Place du marché"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Moat"
 msgstr "Douves"
 
-#: ../fheroes2/castle/castle.cpp:467 ../fheroes2/maps/mp2.cpp:391
 msgid "Castle"
 msgstr "Chateau"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Tent"
 msgstr "Tente"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Captain's Quarters"
 msgstr "Quartiers du capitaine"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Mage Guild, Level 1"
 msgstr "Guide des Mages, niveau 1"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 2"
 msgstr "Guide des Mages, niveau 2"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 3"
 msgstr "Guide des Mages, niveau 3"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 4"
 msgstr "Guide des Mages, niveau 4"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 5"
 msgstr "Guide des Mages, niveau 5"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Farm"
 msgstr "Ferme"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Garbage Heap"
 msgstr "Tas de déchets"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Crystal Garden"
 msgstr "Jardin de Cristal"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Waterfall"
 msgstr "Chute d'eau"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Orchard"
 msgstr "Verger"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Skull Pile"
 msgstr "Tas d'ossements"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Fortifications"
 msgstr "Fortifications"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Coliseum"
 msgstr "Colisée"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Rainbow"
 msgstr "Arc en ciel"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Dungeon"
 msgstr "Donjon"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Library"
 msgstr "Bibliothèque"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Storm"
 msgstr "Tempête"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:498
 msgid "Thatched Hut"
 msgstr "Chaumière"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Hut"
 msgstr "Hutte"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Treehouse"
 msgstr "Cabane dans les arbres"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:441
 msgid "Cave"
 msgstr "Grotte"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Habitat"
 msgstr "Habitation"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:431
 msgid "Excavation"
 msgstr "Fouille"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:477
 msgid "Archery Range"
 msgstr "Archerie"
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Stick Hut"
 msgstr "Cabane de bois"
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Cottage"
 msgstr "Cottage"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Crypt"
 msgstr "Crypte"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Pen"
 msgstr "Taule"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/maps/mp2.cpp:371
 msgid "Graveyard"
 msgstr "Cimetière"
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Blacksmith"
 msgstr "Forgeron"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Den"
 msgstr "Antre"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Nest"
 msgstr "Nid"
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Foundry"
 msgstr "Fonderie"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:480
-#: ../fheroes2/castle/castle.cpp:487 ../fheroes2/maps/mp2.cpp:427
-#: ../fheroes2/resource/maps_text.cpp:521
 msgid "Pyramid"
 msgstr "Pyramide"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Armory"
 msgstr "Armurerie"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Adobe"
 msgstr "Pisé"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Stonehenge"
 msgstr "Stonehenge"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Maze"
 msgstr "Dédale"
 
-#: ../fheroes2/castle/castle.cpp:478 ../fheroes2/castle/castle.cpp:485
 msgid "Cliff Nest"
 msgstr "Falaise des Rocks"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Mansion"
 msgstr "Manoir"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Jousting Arena"
 msgstr "Arène de joute"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Bridge"
 msgstr "Pont"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
 msgid "Fenced Meadow"
 msgstr "Prairie clôturée"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Swamp"
 msgstr "Marais"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Ivory Tower"
 msgstr "Tour d'ivoire"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Mausoleum"
 msgstr "Mausolée"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cathedral"
 msgstr "Cathédrale"
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Red Tower"
 msgstr "Tour rouge"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Green Tower"
 msgstr "Tour verte"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cloud Castle"
 msgstr "Château des Nuages"
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Laboratory"
 msgstr "Laboratoire"
 
-#: ../fheroes2/castle/castle.cpp:483 ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Archery Range"
 msgstr "Améliorer Archerie"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Stick Hut"
 msgstr "Améliorer cabane de bois"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Cottage"
 msgstr "Améliorer cottage"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Graveyard"
 msgstr "Améliorer Cimetière"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Blacksmith"
 msgstr "Améliorer forge"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Foundry"
 msgstr "Améliorer fonderie"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Pyramid"
 msgstr "Améliorer pyramide"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Armory"
 msgstr "Améliorer  armuerie"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Adobe"
 msgstr "Améliorer pisé"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Stonehenge"
 msgstr "Améliorer monument de pierres"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Maze"
 msgstr "Améliorer dédale"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Mansion"
 msgstr "Améliorer manoir"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Jousting Arena"
 msgstr "Améliorer arène de joutes"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Bridge"
 msgstr "Améliorer pont"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Ivory Tower"
 msgstr "Améliorer tour d'ivoire"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Mausoleum"
 msgstr "Améliorer mausolée"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cathedral"
 msgstr "Améliorer cathédrale"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cloud Castle"
 msgstr "Améliorer château des nuages"
 
-#: ../fheroes2/castle/castle.cpp:488
 msgid "Black Tower"
 msgstr "Tour noire"
 
-#: ../fheroes2/castle/castle.cpp:490
 msgid "Shrine"
 msgstr "Lieu saint"
 
-#: ../fheroes2/castle/castle.cpp:552
+#, fuzzy
 msgid ""
 "The Thieves' Guild provides information on enemy players. Thieves' Guilds "
-"can also provide scouting information on enemy towns."
+"can also provide scouting information on enemy towns. Additional Guilds "
+"provide more information."
 msgstr ""
 "La guilde des voleurs fournit des informations sur les joueurs ennemies. Les "
 "guildes de voleurs peuvent aussi effectuer des missions d'infiltrations dans "
 "les villes ennemies"
 
-#: ../fheroes2/castle/castle.cpp:553
 msgid "The Tavern increases morale for troops defending the castle."
 msgstr "La taverne permet d'augmenter le moral des défenseurs du château."
 
-#: ../fheroes2/castle/castle.cpp:554
 msgid "The Shipyard allows ships to be built."
 msgstr "Le chantier naval permet la construction de navires."
 
-#: ../fheroes2/castle/castle.cpp:555
 msgid ""
 "The Well increases the growth rate of all dwellings by %{count} creatures "
 "per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:556
 msgid "The Statue increases your town's income by %{count} per day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:557
 msgid "The Left Turret provides extra firepower during castle combat."
 msgstr ""
 "la tourelle gauche fournit une puissance de feu supplémentaire lors de "
 "combat de châteaux."
 
-#: ../fheroes2/castle/castle.cpp:558
 msgid "The Right Turret provides extra firepower during castle combat."
 msgstr ""
 "la tourelle droite fournit une puissance de feu supplémentaire lors de "
 "combat de châteaux."
 
-#: ../fheroes2/castle/castle.cpp:559
 msgid ""
 "The Marketplace can be used to convert one type of resource into another. "
 "The more marketplaces you control, the better the exchange rate."
@@ -1089,7 +1297,6 @@ msgstr ""
 "un autre. Plus vous contrôlez de places de marchés, plus le taux de change "
 "est favorable."
 
-#: ../fheroes2/castle/castle.cpp:560
 msgid ""
 "The Moat slows attacking units. Any unit entering the moat must end its turn "
 "there and becomes more vulnerable to attack."
@@ -1097,13 +1304,11 @@ msgstr ""
 "Les douves ralentissent les attaques d'unités. Chaque unité qui entre dans "
 "les douves y termine son tour et devient plus vulnérable aux attaques."
 
-#: ../fheroes2/castle/castle.cpp:561
 msgid ""
 "The Castle improves town defense and increases income to %{count} gold per "
 "day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:562
 msgid ""
 "The Tent provides workers to build a castle, provided the materials and the "
 "gold are available."
@@ -1111,7 +1316,6 @@ msgstr ""
 "La tente permet aux travailleurs de construire un château, si les matériaux "
 "et l'or sont disponibles."
 
-#: ../fheroes2/castle/castle.cpp:563
 msgid ""
 "The Captain's Quarters provides a captain to assist in the castle's defense "
 "when no hero is present."
@@ -1119,7 +1323,6 @@ msgstr ""
 "les quartiers du capitaine permettent au capitaine d'assurer une aide à la "
 "défense du château lorsqu'un héro est absent."
 
-#: ../fheroes2/castle/castle.cpp:564
 msgid ""
 "The Mage Guild allows heroes to learn spells and replenish their spell "
 "points."
@@ -1127,32 +1330,25 @@ msgstr ""
 "La guilde des Mages permet aux héros d'apprendre des sortilèges et de "
 "restaurer les points de sorts."
 
-#: ../fheroes2/castle/castle.cpp:567
 msgid "The Farm increases production of Peasants by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:568
 msgid "The Garbage Heap increases production of Goblins by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:569
 msgid ""
 "The Crystal Garden increases production of Sprites by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:570
 msgid "The Waterfall increases production of Centaurs by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:571
 msgid "The Orchard increases production of Halflings by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:572
 msgid "The Skull Pile increases production of Skeletons by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:575
 msgid ""
 "The Fortifications increase the toughness of the walls, increasing the "
 "number of turns it takes to knock them down."
@@ -1160,7 +1356,6 @@ msgstr ""
 "Les fortifications augmentent la résistance des murs, augmentant le nombre "
 "de tours nécessaire pour les réduire en cendres."
 
-#: ../fheroes2/castle/castle.cpp:576
 msgid ""
 "The Coliseum provides inspiring spectacles to defending troops, raising "
 "their morale by two during combat."
@@ -1168,15 +1363,12 @@ msgstr ""
 "Le colisée fournit aux troupes de défenses des spectacles motivants, "
 "augmentant leur moral de deux pendant le combat."
 
-#: ../fheroes2/castle/castle.cpp:577
 msgid "The Rainbow increases the luck of the defending units by two."
 msgstr "L'arc en ciel augmente la chance des unités de défenses de deux."
 
-#: ../fheroes2/castle/castle.cpp:578
 msgid "The Dungeon increases the income of the town by %{count} / day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:579
 msgid ""
 "The Library increases the number of spells in the Guild by one for each "
 "level of the guild."
@@ -1184,12 +1376,10 @@ msgstr ""
 "La bibliothèque augmente le nombre de sorts de la guilde d'un pour chaque "
 "niveau de la guilde."
 
-#: ../fheroes2/castle/castle.cpp:580
 msgid "The Storm adds +2 to the power of spells of a defending spell caster."
 msgstr ""
 "La tempête ajoute +2 à la puissance des sortilèges d'un sorcier qui défend."
 
-#: ../fheroes2/castle/castle.cpp:582
 msgid ""
 "The Shrine increases the necromancy skill of all your necromancers by 10 "
 "percent."
@@ -1197,122 +1387,109 @@ msgstr ""
 "Le lieu saint augmente la puissance de nécromancie de tous les nécromanciens "
 "de 10 pour cents."
 
-#: ../fheroes2/castle/castle.cpp:632
 #, fuzzy
 msgid "Cannot recruit - you already recruit hero in current week."
 msgstr "Impossible de recruter - vous avez déjà une héro dans cette ville."
 
-#: ../fheroes2/castle/castle.cpp:645
 #, fuzzy
 msgid "Cannot recruit - guest to guard automove error."
 msgstr "Impossible de recruter - vous avez trop de héros."
 
-#: ../fheroes2/castle/castle.cpp:651
 msgid "Cannot recruit - you already have a Hero in this town."
 msgstr "Impossible de recruter - vous avez déjà une héro dans cette ville."
 
-#: ../fheroes2/castle/castle.cpp:659
 msgid "Cannot recruit - you have too many Heroes."
 msgstr "Impossible de recruter - vous avez trop de héros."
 
-#: ../fheroes2/castle/castle.cpp:665
 msgid "Cannot afford a Hero"
 msgstr "Imopssible de s'offrir un héro"
 
-#: ../fheroes2/castle/castle.cpp:756
 msgid "There is no room in the garrison for this army."
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:272
+msgid "Recruit %{name}"
+msgstr "Recruter %{name}"
+
 msgid "Month: %{month}, Week: %{week}, Day: %{day}"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:393
-#: ../fheroes2/castle/castle_dialog.cpp:396
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:387
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:186
-msgid "Income:"
+#, fuzzy
+msgid "Income"
 msgstr "Rentrées d'argent :"
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 msgid "Join Error"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 msgid "Army is full"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
+msgid ""
+"You must purchase a spell book to use the mage guild, but you currently have "
+"no room for a spell book. Try giving one of your artifacts to another hero."
+msgstr ""
+
 msgid "Town"
 msgstr "Ville"
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
 msgid "This town may not be upgraded to a castle."
 msgstr "Cette ville ne peut pas être améliorée en château."
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit castle"
+#, fuzzy
+msgid "Exit Castle"
 msgstr "Sortie du château"
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit town"
+#, fuzzy
+msgid "Exit Town"
 msgstr "Sortie de la ville"
 
-#: ../fheroes2/castle/castle_dialog.cpp:730
-msgid "Show income"
-msgstr ""
+#, fuzzy
+msgid "Show Income"
+msgstr "Rentrées d'argent :"
 
-#: ../fheroes2/castle/castle_dialog.cpp:734
 msgid "Show previous town"
 msgstr "Montrer la ville précédente"
 
-#: ../fheroes2/castle/castle_dialog.cpp:738
 msgid "Show next town"
 msgstr "Montrer la ville suivante"
 
-#: ../fheroes2/castle/castle_dialog.cpp:741
 #, fuzzy
 msgid "Swap Heroes"
 msgstr "Héros"
 
-#: ../fheroes2/castle/castle_dialog.cpp:744
 #, fuzzy
 msgid "Meeting Heroes"
 msgstr "Héros"
 
-#: ../fheroes2/castle/castle_dialog.cpp:749
 msgid "View Hero"
 msgstr "Voir le Héro"
 
-#: ../fheroes2/castle/castle_mageguild.cpp:150
+#, fuzzy
+msgid "The above spells are available here."
+msgstr "Les sorts ci-dessus ont été ajoutés à votre livre."
+
 msgid "The above spells have been added to your book."
 msgstr "Les sorts ci-dessus ont été ajoutés à votre livre."
 
-#: ../fheroes2/castle/castle_tavern.cpp:39
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:748
 msgid "A generous tip for the barkeep yields the following rumor:"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:54
 msgid "Recruit Hero"
 msgstr "Recruter un héro"
 
-#: ../fheroes2/castle/castle_town.cpp:59
-msgid "%{name} is a level %{value} %{race}"
+#, fuzzy
+msgid "%{name} is a level %{value} %{race} "
+msgstr "%{name} est niveau %{value} %{race} avec %{count} artefacts."
+
+msgid "with %{count} artifacts."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with %{count} artifacts"
+#, fuzzy
+msgid "with 1 artifact."
+msgstr "Impossible de déplacer la dernière armée dans la garnison"
+
+msgid "without artifacts."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with one artifact"
-msgstr ""
-
-#: ../fheroes2/castle/castle_town.cpp:283
-#: ../fheroes2/heroes/heroes_dialog.cpp:108
 msgid ""
 "'Spread' combat formation spreads your armies from the top to the bottom of "
 "the battlefield, with at least one empty space between each army."
@@ -1320,7 +1497,6 @@ msgstr ""
 "La formation de combat 'Déploiement' propage vos armées du haut vers le bas "
 "du champ de bataille, avec au moins un espace vide entre chaque armée."
 
-#: ../fheroes2/castle/castle_town.cpp:284
 msgid ""
 "'Grouped' combat formation bunches your army toget her in the center of your "
 "side of the battlefield."
@@ -1328,102 +1504,80 @@ msgstr ""
 "La formation de combat 'Groupé' regroupe votre armée au centre du champ de "
 "bataille, de votre coté."
 
-#: ../fheroes2/castle/castle_town.cpp:292
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:132
-#: ../fheroes2/heroes/heroes_meeting.cpp:284
 msgid "Attack Skill"
 msgstr "Puissance d'attaque"
 
-#: ../fheroes2/castle/castle_town.cpp:301
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:137
-#: ../fheroes2/heroes/heroes_meeting.cpp:288
 msgid "Defense Skill"
 msgstr "Puissance de défense"
 
-#: ../fheroes2/castle/castle_town.cpp:487
-#: ../fheroes2/heroes/heroes_dialog.cpp:334
 msgid "Spread Formation"
 msgstr "Formation Déploiement"
 
-#: ../fheroes2/castle/castle_town.cpp:489
-#: ../fheroes2/heroes/heroes_dialog.cpp:337
 msgid "Grouped Formation"
 msgstr "Formation Groupée"
 
-#: ../fheroes2/castle/castle_town.cpp:540
-#: ../fheroes2/castle/castle_town.cpp:553
 msgid "Recruit %{name} the %{race}"
 msgstr "Recrutement de %{name} le %{race}"
 
-#: ../fheroes2/castle/castle_town.cpp:561
 msgid "Set garrison combat formation to 'Spread'"
 msgstr "Utiliser la formation de combat 'Déploiement' pour la garnison"
 
-#: ../fheroes2/castle/castle_town.cpp:564
 msgid "Set garrison combat formation to 'Grouped'"
 msgstr "Utiliser la formation de combat 'Déploiement' pour la garnison"
 
-#: ../fheroes2/castle/castle_town.cpp:567
+#, fuzzy
+msgid "Exit Castle Options"
+msgstr "Options du chateau"
+
 msgid "Castle Options"
 msgstr "Options du chateau"
 
-#: ../fheroes2/castle/castle_well.cpp:158
+msgid "Not enough resources to buy monsters."
+msgstr ""
+
+msgid "No monsters available for purchase."
+msgstr ""
+
 #, fuzzy
-msgid "Buy Monsters:"
+msgid "Buy Monsters"
 msgstr "Meilleur monstre :"
 
-#: ../fheroes2/castle/castle_well.cpp:221
 msgid "Town Population Information and Statistics"
 msgstr "Information et statistiques sur la population de la ville"
 
-#: ../fheroes2/castle/castle_well.cpp:323
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:231
 msgid "Damage"
 msgstr "Dommage"
 
-#: ../fheroes2/castle/castle_well.cpp:329
 msgid "HP"
 msgstr "PV"
 
-#: ../fheroes2/castle/castle_well.cpp:335
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:266
-msgid "Speed"
-msgstr "Vitesse"
-
-#: ../fheroes2/castle/castle_well.cpp:351
 msgid "Growth"
 msgstr "Croissance"
 
-#: ../fheroes2/castle/castle_well.cpp:355
 msgid "week"
 msgstr "semaine"
 
-#: ../fheroes2/castle/castle_well.cpp:361
-#: ../fheroes2/kingdom/kingdom_overview.cpp:479
 msgid "Available"
 msgstr "Disponible"
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:89
 msgid "View the entire world."
 msgstr "Voir le monde entier."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:90
 msgid "View the obelisk puzzle."
 msgstr "Voir le puzzle de l'obélisque."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:91
 msgid "View information on the scenario you are currently playing."
 msgstr "Voir les informations du scénario de la partie actuelle."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:92
 msgid "Dig for the Ultimate Artifact."
 msgstr "Creuser pour l'Artefact Ultime"
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:93
 msgid "Exit this menu without doing anything."
 msgstr "Sortir de ce menu sans modification."
 
-#: ../fheroes2/dialog/dialog_arena.cpp:48
+msgid "Arena"
+msgstr ""
+
 msgid ""
 "You enter the arena and face a pack of vicious lions. You handily defeat "
 "them, to the wild cheers of the crowd.  Impressed by your skill, the aged "
@@ -1434,90 +1588,102 @@ msgstr ""
 "la foule. Impressionné par votre talent, l'entraineur des gladiateurs vous "
 "offre la possibilité d'améliorer un talent de votre choix."
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:154
-msgid ""
-"Your troops can be upgraded, but it will cost you %{ratio} times the "
-"difference in cost for each troop, rounded up to next highest number. Do you "
-"wish to upgrade them?"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:155
 msgid ""
 "Your troops can be upgraded, but it will cost you dearly. Do you wish to "
 "upgrade them?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:166
 msgid "Are you sure you want to dismiss this army?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots Left"
 msgstr "Tirs restants"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots"
 msgstr "Tirs"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:244
 msgid "Hit Points"
 msgstr "Points de vie"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:255
 msgid "Hit Points Left"
 msgstr "Points de vie restants"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:379
+#, fuzzy
+msgid "Followers"
+msgstr "Pouvoir d'invocation"
+
 msgid ""
-"The creature is swayed by your diplomatic tongue, and offers to join your "
+"A group of %{monster} with a desire for greater glory wish to join you.\n"
+"Do you accept?"
+msgstr ""
+
+msgid ""
+"The %{monster} is swayed by your diplomatic tongue, and offers to join your "
 "army for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:382
 msgid ""
 "The creatures are swayed by your diplomatic\n"
 "tongue, and make you an offer:\n"
 " \n"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:385
 msgid ""
 "%{offer} of the %{total} %{monster} will join your army, and the rest will "
 "leave you alone, for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:387
 msgid ""
 "All %{offer} of the %{monster} will join your army for the sum of %{gold} "
 "gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:401
 msgid "(Rate: %{percent})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:451
-msgid ""
-"Not room in\n"
-"the garrison"
+msgid "No room in"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:48
+msgid "the garrison"
+msgstr ""
+
 msgid "Build a new ship:"
 msgstr "Construire un nouveau navire :"
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:63
 msgid "Resource cost:"
 msgstr "Coût en ressources :"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:40
-msgid "For the QVGA version is not available."
+msgid "Load Game"
+msgstr "Charger une partie"
+
+msgid "No save files to load."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:62
+msgid "New Game"
+msgstr "Nouvelle partie"
+
+msgid "Start a single or multi-player game."
+msgstr "Démarrer un jeu solo ou multijoueur"
+
+msgid "Load a previously saved game."
+msgstr "CHarger une partie sauvegardée"
+
+#, fuzzy
+msgid "Save Game"
+msgstr "Nouvelle partie"
+
+msgid "Save the current game."
+msgstr ""
+
+msgid "Quit"
+msgstr "Quitter"
+
+msgid "Quit out of Free Heroes of Might and Magic II."
+msgstr ""
+
 msgid ""
 "Map\n"
 "Difficulty"
@@ -1525,7 +1691,6 @@ msgstr ""
 "Carte\n"
 "Difficulté"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:65
 msgid ""
 "Game\n"
 "Difficulty"
@@ -1533,25 +1698,18 @@ msgstr ""
 "Jeu\n"
 "Difficulté"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:68
 msgid "Rating"
 msgstr "Classement"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:71
 msgid "Map Size"
 msgstr "Taille de la carte"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:89
-#: ../fheroes2/system/players.cpp:691
 msgid "Opponents"
 msgstr "Opposants"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:92
-#: ../fheroes2/system/players.cpp:695
 msgid "Class"
 msgstr "Classe"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:100
 msgid ""
 "Victory\n"
 "Conditions"
@@ -1559,7 +1717,6 @@ msgstr ""
 "Victoire\n"
 "Conditions"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:106
 msgid ""
 "Loss\n"
 "Conditions"
@@ -1567,48 +1724,34 @@ msgstr ""
 "Défaite\n"
 "Conditions"
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:167
 msgid "You cannot select %{resource}!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:173
 msgid "Select count %{resource}:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:200
 msgid "Set Guardian"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:236
-#: ../fheroes2/dialog/dialog_guardian.cpp:292
 msgid "Your army too big!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:34
-#: ../fheroes2/dialog/dialog_levelup.cpp:44
-#: ../fheroes2/dialog/dialog_levelup.cpp:73
 msgid "%{name} has gained a level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:36
-#: ../fheroes2/dialog/dialog_levelup.cpp:46
-#: ../fheroes2/dialog/dialog_levelup.cpp:75
-msgid "%{skill} Skill +1"
-msgstr ""
+#, fuzzy
+msgid "%{skill} +1"
+msgstr "voir les infos de %{name} info."
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:51
 msgid "You have learned %{skill}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:93
 msgid "You may learn either:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:96
 msgid "or"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:66
 msgid ""
 "Please inspect our fine wares. If you feel like offering a trade, click on "
 "the items you wish to trade with and for."
@@ -1616,728 +1759,705 @@ msgstr ""
 "Regardez nos belles marchandises. Si vous souhaitez faire affaire, cliquez "
 "sur les objets que vous souhaitez échanger."
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:104
 msgid ""
 "You have received quite a bargain. I expect to make no profit on the deal. "
 "Can I interest you in any of my other wares?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:130
 msgid "I can offer you %{count} for 1 unit of %{resfrom}."
 msgstr "Je peux vous offrir %{count} pour une unité de %{resfrom}."
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:136
 msgid "I can offer you 1 unit of %{resto} for %{count} units of %{resfrom}."
 msgstr ""
 "Je peux vous offrir 1 unité de %{resto} pour %{count} unités de %{resfrom}."
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:164
 msgid "Qty to trade"
 msgstr "Qté à échanger"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:235
+msgid "Trading Post"
+msgstr ""
+
 msgid "Your Resources"
 msgstr "Vos ressources"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:257
 msgid "Available Trades"
 msgstr "Echanges disponibles"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:573
 msgid "n/a"
 msgstr "n/a"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:77
-msgid "guarded by %{count} of %{monster}"
+msgid "guarded by %{count} %{monster}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:149
 msgid "(available: %{count})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:181
 msgid "already learned"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:205
 msgid "already knows this skill"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:212
 msgid "already has max skills"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:260
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:276
 msgid "(already visited)"
 msgstr "(déjà visité)"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
 msgid "(not visited)"
 msgstr "(pas visité)"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:296
+#, fuzzy
+msgid "Road"
+msgstr "Mode Routes"
+
+msgid "(digging ok)"
+msgstr ""
+
+msgid "(no digging)"
+msgstr ""
+
 msgid "penalty: %{cost}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:382
-msgid "Unchartered Territory"
+msgid "Uncharted Territory"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:635
 msgid "Defenders:"
 msgstr "Defenseurs :"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:674
-#: ../fheroes2/heroes/heroes_indicator.cpp:125
-#: ../fheroes2/heroes/heroes_indicator.cpp:171
 msgid "None"
 msgstr "Aucun"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:756
+msgid "Unknown"
+msgstr ""
+
 #, fuzzy
-msgid "%{name} ( Level %{level} )"
+msgid "%{name} (Level %{level})"
 msgstr "%{name} le %{race}"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:884
 #, fuzzy
 msgid "Move Points"
 msgstr "Points de sortilège"
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:40
-#: ../fheroes2/dialog/dialog_recrut.cpp:579
 msgid "Available: %{count}"
 msgstr "Disponible: %{count}"
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:101
-msgid "Cost per troop:"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:107
-#: ../fheroes2/dialog/dialog_recrut.cpp:506
-msgid "Recruit %{name}"
-msgstr "Recruter %{name}"
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:210
 msgid "Number to buy:"
 msgstr "Nombre à acheter :"
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:314
 msgid "How many troops to move?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:358
 msgid "Fast separation into slots:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:180
 msgid "File to Save:"
 msgstr "Fichier à sauvegarder :"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:186
 msgid "File to Load:"
 msgstr "Fichier à charger :"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:302
 msgid "Are you sure you want to delete file:"
 msgstr "Êtes vous sur de vouloir effacer le fichier :"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:305
 msgid "Warning!"
 msgstr "Attention!"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:144
-msgid "Maps Difficulty:"
+#, fuzzy
+msgid "Map difficulty:"
 msgstr "Difficulté des cartes :"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
+msgid "No maps exist at that size"
+msgstr ""
+
 msgid "Small Maps"
 msgstr "Petite cartes"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
-msgid "View only maps of size small (36x36)."
+#, fuzzy
+msgid "View only maps of size small (36 x 36)."
 msgstr "Voir seulement les cartes de petite taille (36x36)"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
 msgid "Medium Maps"
 msgstr "Cartes moyennes"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
-msgid "View only maps of size medium (72x72)."
+#, fuzzy
+msgid "View only maps of size medium (72 x 72)."
 msgstr "Voir seulement les cartes de taille moyenne (72x72)"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
 msgid "Large Maps"
 msgstr "Grandes cartes"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
-msgid "View only maps of size large (108x108)."
+#, fuzzy
+msgid "View only maps of size large (108 x 108)."
 msgstr "Voir seulement les grandes cartes (108x108)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
 msgid "Extra Large Maps"
 msgstr "Très grandes cartes"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
-msgid "View only maps of size extra large (144x144)."
+#, fuzzy
+msgid "View only maps of size extra large (144 x 144)."
 msgstr "Voir seulement les très grandes cartes (144x144)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "All Maps"
 msgstr "Toutes les cartes"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "View all maps, regardless of size."
 msgstr "Voir toutes les cartes, sans tenir compte de leur taille."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
 msgid "Players Icon"
 msgstr "Icônes des joueurs"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
+#, fuzzy
 msgid ""
-"Indicates how many players total are in the EditScenario. Any positions not "
+"Indicates how many players total are in the scenario. Any positions not "
 "occupied by humans will be occupied by computer players."
 msgstr ""
 "Indique combien de joueurs au total sont dans le scenario. Toute position "
 "non occupée par un humain sera occupée par l'ordinateur."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
 msgid "Size Icon"
 msgstr "Taille de l'icône"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
+#, fuzzy
 msgid ""
-"Indicates whether the maps is small (36x36), medium (72x72), large "
-"(108x108), or extra large (144x144)."
+"Indicates whether the map\n"
+"is small (36 x 36), medium\n"
+"(72 x 72), large (108 x 108),\n"
+"or extra large (144 x 144)."
 msgstr ""
 "Indique si la map est petite (36x36), moyenne (72x72), large (108x108) ou "
 "extra large (144x144)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "Selected Name"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "The name of the currently selected map."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid "Selected Map Difficulty"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid ""
 "The map difficulty of the currently selected map.  The map difficulty is "
-"determined by the EditScenario designer. More difficult maps might include "
-"more or stronger enemies, fewer resources, or other special conditions "
-"making things tougher for the human player."
+"determined by the scenario designer. More difficult maps might include more "
+"or stronger enemies, fewer resources, or other special conditions making "
+"things tougher for the human player."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "Selected Description"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "The description of the currently selected map."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
-msgid "OK"
-msgstr "OK"
+msgid "Okay"
+msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
 msgid "Accept the choice made."
 msgstr "Confirmez le choix."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:364
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose all your heroes and towns."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:365
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific town."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:366
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific hero."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:367
 msgid "Run out of time. Fail to win by a certain point."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:370
 msgid "Loss Condition"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:379
 msgid "Defeat all enemy heroes and towns."
 msgstr "Détruisez tous les héros et villes ennemis"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:380
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Capture a specific town."
 msgstr "Capturez une ville spécifique"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:381
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat a specific hero."
 msgstr "Détruisez un héros spécifique"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:382
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Find a specific artifact."
 msgstr "Trouvez un artefact spécifique"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:383
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Your side defeats the opposing side."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:384
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Accumulate a large amount of gold."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:387
 msgid "Victory Condition"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:48
-#: ../fheroes2/heroes/heroes_action.cpp:134
 msgid "one"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:51
-#: ../fheroes2/heroes/heroes_action.cpp:135
 msgid "two"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:187
-msgid "sound"
-msgstr "son"
-
-#: ../fheroes2/dialog/dialog_system.cpp:192
-#: ../fheroes2/dialog/dialog_system.cpp:205
-#: ../fheroes2/dialog/dialog_system.cpp:228
-#: ../fheroes2/dialog/dialog_system.cpp:242
-msgid "off"
-msgstr "coupé"
-
-#: ../fheroes2/dialog/dialog_system.cpp:200
-msgid "music"
+#, fuzzy
+msgid "Music"
 msgstr "musique"
 
-#: ../fheroes2/dialog/dialog_system.cpp:223
-msgid "hero speed"
+msgid "Toggle ambient music level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:237
+msgid "Effects"
+msgstr ""
+
+msgid "Toggle foreground sounds level."
+msgstr ""
+
+msgid "Music Type"
+msgstr ""
+
+msgid "Change the type of music."
+msgstr ""
+
 #, fuzzy
-msgid "ai speed"
+msgid "Hero Speed"
 msgstr "Vitesse"
 
-#: ../fheroes2/dialog/dialog_system.cpp:251
-msgid "scroll speed"
+msgid "Change the speed at which your heroes move on the main screen."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:262
-#: ../fheroes2/dialog/dialog_system.cpp:276
+#, fuzzy
+msgid "Enemy Speed"
+msgstr "Vitesse"
+
+msgid ""
+"Sets the speed that A.I. heroes move at.  You can also elect not to view A."
+"I. movement at all."
+msgstr ""
+
+msgid "Scroll Speed"
+msgstr ""
+
+msgid "Sets the speed at which you scroll the window."
+msgstr ""
+
+#, fuzzy
+msgid "Interface Type"
+msgstr "Interface"
+
+msgid "Toggle the type of interface you want to use."
+msgstr ""
+
 msgid "Interface"
 msgstr "Interface"
 
-#: ../fheroes2/dialog/dialog_system.cpp:265
+msgid "Toggle interface visibility."
+msgstr ""
+
+msgid "Battles"
+msgstr ""
+
+msgid "Toggle instant battle mode."
+msgstr ""
+
+msgid "OK"
+msgstr "OK"
+
+#, fuzzy
+msgid "Exit this menu."
+msgstr "Passer cette unité"
+
+msgid "off"
+msgstr "coupé"
+
+msgid "MIDI"
+msgstr ""
+
+#, fuzzy
+msgid "MIDI Expansion"
+msgstr "Manoir"
+
+msgid "CD Stereo"
+msgstr ""
+
+msgid "External"
+msgstr ""
+
+msgid "Jump"
+msgstr ""
+
+msgid "Don't Show"
+msgstr ""
+
 msgid "Evil"
 msgstr "Mal"
 
-#: ../fheroes2/dialog/dialog_system.cpp:267
 msgid "Good"
 msgstr "Bien"
 
-#: ../fheroes2/dialog/dialog_system.cpp:281
 #, fuzzy
 msgid "Hide"
 msgstr "Horde"
 
-#: ../fheroes2/dialog/dialog_system.cpp:287
 #, fuzzy
 msgid "Show"
 msgstr "Neige"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:285
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:96
+msgid "Auto Resolve"
+msgstr ""
+
+msgid "Auto, No Spells"
+msgstr ""
+
+msgid "Manual"
+msgstr ""
+
+msgid "Att."
+msgstr ""
+
+msgid "Def."
+msgstr ""
+
+msgid "Power"
+msgstr ""
+
+#, fuzzy
+msgid "Knowl"
+msgstr "Connaissance"
+
+msgid "Human"
+msgstr ""
+
 msgid "1st"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:286
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:97
 msgid "2nd"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:98
 msgid "3rd"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:288
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:99
 msgid "4th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:289
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:100
 msgid "5th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:290
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:101
 msgid "6th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:305
-msgid "Thieves' Guild: Player RanKings"
+msgid "Oracle: Player Rankings"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:315
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:114
+#, fuzzy
+msgid "Thieves' Guild: Player Rankings"
+msgstr "Guilde des voleurs"
+
 msgid "Number of Towns:"
 msgstr "Nombre de villes :"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:324
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:123
 msgid "Number of Castles:"
 msgstr "Nombre de châteaux :"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:333
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:132
 msgid "Number of Heroes:"
 msgstr "Nombre de Héros :"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:342
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:141
 msgid "Gold in Treasury:"
 msgstr "Or disponible dans la trésorerie :"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:351
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:150
 msgid "Wood & Ore:"
 msgstr "Bois et minerais :"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:360
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:159
 msgid "Gems, Cr, Slf & Mer:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:369
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:168
 msgid "Obelisks Found:"
 msgstr "Obélisques trouvés :"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:378
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:177
+#, fuzzy
+msgid "Artifacts:"
+msgstr "Artéfact"
+
 msgid "Total Army Strength:"
 msgstr "Force totale de l'armée :"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:408
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:211
+msgid "Income:"
+msgstr "Rentrées d'argent :"
+
 msgid "Best Hero:"
 msgstr "Meilleur Héro :"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:417
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:220
 msgid "Best Hero Stats:"
 msgstr "Stats du meilleur Héro :"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:426
 msgid "Personality:"
 msgstr "Personnalité:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:435
 msgid "Best Monster:"
 msgstr "Meilleur monstre :"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Easy"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Normal"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Hard"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Expert"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Impossible"
 msgstr ""
 
-#: ../fheroes2/game/game.cpp:314
-msgid "Maps Loading..."
+#, fuzzy
+msgid "Map is loading..."
 msgstr "Chargement des cartes..."
 
-#: ../fheroes2/game/game_highscores.cpp:239
-#: ../fheroes2/game/game_highscores.cpp:242
+msgid "and more..."
+msgstr ""
+
+msgid "Campaign Scenario loading failure"
+msgstr ""
+
+msgid "Please make sure that campaign files are correct and present."
+msgstr ""
+
 msgid "Unknown Hero"
 msgstr ""
 
-#: ../fheroes2/game/game_highscores.cpp:240
 msgid "Your Name"
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:95
-msgid "Are you sure you want to overwrite the save with this name?"
+msgid ""
+"Invalid file game type. Please ensure that you are running the latest type "
+"of save files."
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:191
 msgid ""
-"This file is saved in the \"Price Loyalty\" version.\n"
+"This file is saved in the \"The Price of Loyalty\" version.\n"
 "Some items may be unavailable."
 msgstr ""
 
-#: ../fheroes2/game/game_mainmenu.cpp:157
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:95
-msgid "Quit"
-msgstr "Quitter"
-
-#: ../fheroes2/game/game_mainmenu.cpp:157
-msgid "Quit Heroes of Might and Magic and return to the operating system."
-msgstr ""
-"Quitter Heroes of Might and Magic et retourner au système d'exploitation."
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:79
-msgid "Load Game"
-msgstr "Charger une partie"
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-msgid "Load a previously saved game."
-msgstr "CHarger une partie sauvegardée"
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:91
-msgid "Credits"
-msgstr "Crédits"
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-msgid "View the credits screen."
-msgstr "Voir l'écran des crédits"
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:87
-msgid "High Scores"
-msgstr "Meilleurs scores"
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-msgid "View the high score screen."
-msgstr "Voir l'écran des meilleurs scores"
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:75
-msgid "New Game"
-msgstr "Nouvelle partie"
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-msgid "Start a single or multi-player game."
-msgstr "Démarrer un jeu solo ou multijoueur"
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid "Host"
-msgstr "Hôte"
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid ""
-"The host sets up the game options. There can only be one host per network "
-"game."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid "Guest"
-msgstr "Invité"
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid ""
-"The guest waits for the host to set up the game, then is automatically added "
-"in. There can be multiple guests for TCP/IP games."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-msgid "Cancel back to the main menu."
-msgstr "Annuler et revenir au menu principal."
-
-#: ../fheroes2/game/game_newgame.cpp:214
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:154
-msgid "Standard Game"
-msgstr "Jeu standard"
-
-#: ../fheroes2/game/game_newgame.cpp:214
-msgid "A single player game playing out a single map."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:216
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:162
-msgid "Multi-Player Game"
-msgstr "Jeu Multi-joueur"
-
-#: ../fheroes2/game/game_newgame.cpp:216
-msgid ""
-"A multi-player game, with several human players completing against each "
-"other on a single map."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:217
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:83
-msgid "Settings"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:217
-msgid "FHeroes2 game settings."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:271
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:219
 msgid "Hot Seat"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:271
 msgid ""
 "Play a Hot Seat game, where 2 to 4 players play around the same computer, "
 "switching into the 'Hot Seat' when it is their turn."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:279
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:223
+msgid "Cancel back to the main menu."
+msgstr "Annuler et revenir au menu principal."
+
 msgid "Network"
 msgstr "Réseau"
 
-#: ../fheroes2/game/game_newgame.cpp:279
 msgid ""
 "Play a network game, where 2 players use their own computers connected "
 "through a LAN (Local Area Network)."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:343
+msgid "Standard Game"
+msgstr "Jeu standard"
+
+msgid "A single player game playing out a single map."
+msgstr ""
+
+msgid "Campaign Game"
+msgstr "Mode Campagne"
+
+msgid "A single player game playing through a series of maps."
+msgstr ""
+
+msgid "Multi-Player Game"
+msgstr "Jeu Multi-joueur"
+
+msgid ""
+"A multi-player game, with several human players completing against each "
+"other on a single map."
+msgstr ""
+
+msgid "Greetings!"
+msgstr ""
+
+msgid ""
+"Welcome to Free Heroes of Might and Magic II! Before starting the game "
+"please choose game resolution."
+msgstr ""
+
+msgid "Please Remember"
+msgstr ""
+
+msgid "You can always change game resolution by clicking on the "
+msgstr ""
+
+msgid "door"
+msgstr ""
+
+msgid ""
+" on the left side of main menu.\n"
+"\n"
+"To switch between windowed and full screen modes\n"
+"press "
+msgstr ""
+
+msgid "F4"
+msgstr ""
+
+msgid ""
+" key on the keyboard.\n"
+"\n"
+"Enjoy the game!"
+msgstr ""
+
+msgid "Quit Heroes of Might and Magic and return to the operating system."
+msgstr ""
+"Quitter Heroes of Might and Magic et retourner au système d'exploitation."
+
+msgid "Credits"
+msgstr "Crédits"
+
+msgid "View the credits screen."
+msgstr "Voir l'écran des crédits"
+
+msgid "High Scores"
+msgstr "Meilleurs scores"
+
+msgid "View the high score screen."
+msgstr "Voir l'écran des meilleurs scores"
+
+msgid "Select Game Resolution"
+msgstr ""
+
+msgid "Change resolution of the game."
+msgstr ""
+
+msgid "Original Campaign"
+msgstr ""
+
+msgid ""
+"Either Roland's or Archibald's campaign from the original Heroes of Might "
+"and Magic II."
+msgstr ""
+
+msgid "Expansion Campaign"
+msgstr ""
+
+msgid "One of the four new campaigns from the Price of Loyalty expansion set."
+msgstr ""
+
+msgid "Host"
+msgstr "Hôte"
+
+msgid ""
+"The host sets up the game options. There can only be one host per network "
+"game."
+msgstr ""
+
+msgid "Guest"
+msgstr "Invité"
+
+msgid ""
+"The guest waits for the host to set up the game, then is automatically added "
+"in. There can be multiple guests for TCP/IP games."
+msgstr ""
+
+msgid "Battle Only"
+msgstr ""
+
+msgid "Setup and play a battle without loading any map."
+msgstr ""
+
+msgid "Settings"
+msgstr ""
+
+msgid "Experimental game settings."
+msgstr ""
+
 msgid "2 Players"
 msgstr "2 Joueurs"
 
-#: ../fheroes2/game/game_newgame.cpp:343
 msgid ""
 "Play with 2 human players, and optionally, up, to 4 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid "3 Players"
 msgstr "3 Joueurs"
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid ""
 "Play with 3 human players, and optionally, up, to 3 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid "4 Players"
 msgstr "4 Joueurs"
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid ""
 "Play with 4 human players, and optionally, up, to 2 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid "5 Players"
 msgstr "5 Joueurs"
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid ""
 "Play with 5 human players, and optionally, up, to 1 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "6 Players"
 msgstr "6 Joueurs"
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "Play with 6 human players."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:37
 #, fuzzy
 msgid "Defeat all enemy heroes and capture all enemy towns and castles."
 msgstr "Détruisez tous les héros et villes ennemis"
 
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Run out of time. (Fail to win by a certain point.)"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the castle '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the town '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:83
 msgid "Defeat the hero '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:91
 msgid "Find the ultimate artifact"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:95
 msgid "Find the '%{name}' artifact"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:102
 msgid "Accumulate %{count} gold"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:106
 msgid ""
 ", or you may win by defeating all enemy heroes and capturing all enemy towns "
 "and castles."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the castle '%{name}'."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the town '%{name}'."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:126 ../fheroes2/game/game_over.cpp:145
 msgid "Lose the hero: %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:133
 msgid "Fail to win by the end of month %{month}, week %{week}, day %{day}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:145
 msgid "Lose the heroes: %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:167
 msgid ""
 "You captured %{name}!\n"
 "You are victorious."
@@ -2345,7 +2465,6 @@ msgstr ""
 "Vous avez capturé %{name} !\n"
 "Vous êtes victorieux."
 
-#: ../fheroes2/game/game_over.cpp:175
 msgid ""
 "You have captured the enemy hero %{name}!\n"
 "Your quest is complete."
@@ -2353,7 +2472,6 @@ msgstr ""
 "Vous avez capturé le héros ennemi %{name} !\n"
 "Votre quête est terminée."
 
-#: ../fheroes2/game/game_over.cpp:183
 msgid ""
 "You have found the %{name}.\n"
 "Your quest is complete."
@@ -2361,386 +2479,567 @@ msgstr ""
 "Vous avez trouvé le %{name}.\n"
 "Votre quête est terminée."
 
-#: ../fheroes2/game/game_over.cpp:195
 msgid ""
 "The enemy is beaten.\n"
 "Your side has triumphed!"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:200
 msgid ""
 "You have built up over %{count} gold in your treasury.\n"
 "All enemies bow before your wealth and power."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:222
 msgid ""
 "The enemy has found the %{name}.\n"
 "Your quest is a failure."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:230
 msgid ""
 "%{color} has fallen!\n"
 "All is lost."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:237
 msgid ""
 "The enemy has built up over %{count} gold in his treasury.\n"
 "You must bow done in defeat before his wealth and power."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:243
 msgid "You have been eliminated from the game!!!"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:248
 msgid ""
 "The enemy has captured %{name}!\n"
 "They are triumphant."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:257 ../fheroes2/game/game_over.cpp:264
 msgid ""
 "You have lost the hero %{name}.\n"
 "Your quest is over."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:272
 msgid ""
 "You have failed to complete your quest in time.\n"
 "All is lost."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:320
-msgid "%{color} has been vanquished!"
+msgid "%{color} player has been vanquished!"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "Warning"
 msgstr "Attention"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "No maps available!"
 msgstr "Pas de carte disponible!"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Scenario"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Click here to select which scenario to play."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid "Game Difficulty"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid ""
 "This lets you change the starting difficulty at which you will play. Higher "
 "difficulty levels start you of with fewer resources, and at the higher "
 "settings, give extra resources to the computer."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid "Difficulty Rating"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid ""
 "The difficulty rating reflects a combination of various settings for your "
 "game. This number will be applied to your final score."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
 msgid "Click to accept these settings and start a new game."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
 msgid "Click to return to the main menu."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:342
 msgid "Scenario:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:350
 msgid "Game Difficulty:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:354
 msgid "Opponents:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:358
 msgid "Class:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:384
 msgid "Rating %{rating}%"
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:226
 msgid "Astrologers proclaim Month of the %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:226
 msgid "Astrologers proclaim Week of the %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:240
 msgid "After regular growth, population of %{monster} is doubled!"
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:252
 msgid " All populations are halved."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:254
 msgid " All dwellings increase population."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:283
 msgid ""
 "%{color} player, your heroes abandon you, and you are banished from this "
 "land."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:290
 msgid ""
 "%{color} player, this is your last day to capture a town, or you will be "
 "banished from this land."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:295
 msgid ""
 "%{color} player, you only have %{day} days left to capture a town, or you "
 "will be banished from this land."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:584
-msgid "%{color} player's turn"
+msgid "%{color} player's turn."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:995
 msgid ""
 "%{color} player, you have lost your last town. If you do not conquer another "
 "town in next week, you will be eliminated."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Next Hero"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Select the next Hero."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue Movement"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue the Hero's movement along the current path."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "Kingdom Summary"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "View a Summary of your Kingdom."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:189
 msgid "Cast an adventure spell."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End Turn"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End your turn and left the computer take its turn."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Adventure Options"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Bring up the adventure options menu."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "File Options"
 msgstr "Fichier d'options"
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "Bring up the file options menu, alloving you to load menu, save etc."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "System Options"
 msgstr "Options du système"
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "Bring up the system options menu, alloving you to customize your game."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:175
 msgid ""
 "One or more heroes may still move, are you sure you want to end your turn?"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:212
-msgid "Are you sure you want to restart? (Your current game will be lost)"
-msgstr ""
-
-#: ../fheroes2/gui/interface_events.cpp:276
 msgid "Are you sure you want to quit?"
 msgstr "Êtes vous sur de vouloir quitter?"
 
-#: ../fheroes2/gui/interface_events.cpp:308
+#, fuzzy
+msgid "Are you sure you want to restart? (Your current game will be lost.)"
+msgstr "Êtes vous sur de vouloir sonner la retraite?"
+
+msgid "Are you sure you want to overwrite the save with this name?"
+msgstr ""
+
 msgid "Game saved successfully."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:314
-msgid ""
-"Are you sure you want to load a new game? (Your current game will be lost)"
+msgid "There was an issue during saving."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:353
+#, fuzzy
+msgid ""
+"Are you sure you want to load a new game? (Your current game will be lost.)"
+msgstr "Êtes vous sur de vouloir effacer le fichier :"
+
 msgid "Try looking on land!!!"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:368
 msgid ""
-"After spending many hours digging here, you have uncovered the %{artifact}"
+"After spending many hours digging here, you have uncovered the %{artifact}."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:370
 msgid "Congratulations!"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:384
 msgid "Nothing here. Where could it be?"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:395
 msgid "Try searching on clear ground."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:399
 msgid "Digging for artifacts requires a whole day, try again tomorrow."
 msgstr ""
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "World Map"
 msgstr ""
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "A miniature view of the known world. Left click to move viewing area."
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:216
 msgid "Month: %{month} Week: %{week}"
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:222
-#: ../fheroes2/kingdom/kingdom_overview.cpp:569
 msgid "Day: %{day}"
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:257
 msgid ""
 "You find a small\n"
 "quantity of %{resource}."
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:407
 msgid "Status Window"
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:407
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date."
+msgstr ""
+
 msgid ""
 "This window provides information on the status of your hero or kingdom, and "
 "shows the date. Left click here to cycle throungh these windows."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:112
+msgid "Necroman"
+msgstr ""
+
+msgid ""
+"This lets you change player starting positions and colors. A particular "
+"color will always start in a particular location. Some positions may only be "
+"played by a computer player or only by a human player."
+msgstr ""
+
+msgid ""
+"This lets you change the class of a player. Classes are not always "
+"changeable. Depending on the scenario, a player may receive additional towns "
+"and/or heroes not of their primary alignment."
+msgstr ""
+
+msgid "%{color} player"
+msgstr ""
+
+#, fuzzy
+msgid "View %{skill} Info"
+msgstr "voir les infos de %{name} info."
+
+msgid "Lord Kilburn"
+msgstr ""
+
+msgid "Sir Gallant"
+msgstr ""
+
+msgid "Ector"
+msgstr ""
+
+msgid "Gwenneth"
+msgstr ""
+
+msgid "Tyro"
+msgstr ""
+
+msgid "Ambrose"
+msgstr ""
+
+msgid "Ruby"
+msgstr ""
+
+msgid "Maximus"
+msgstr ""
+
+msgid "Dimitry"
+msgstr ""
+
+msgid "Thundax"
+msgstr ""
+
+msgid "Fineous"
+msgstr ""
+
+msgid "Jojosh"
+msgstr ""
+
+msgid "Crag Hack"
+msgstr ""
+
+msgid "Jezebel"
+msgstr ""
+
+msgid "Jaclyn"
+msgstr ""
+
+msgid "Ergon"
+msgstr ""
+
+msgid "Tsabu"
+msgstr ""
+
+msgid "Atlas"
+msgstr ""
+
+msgid "Astra"
+msgstr ""
+
+msgid "Natasha"
+msgstr ""
+
+msgid "Troyan"
+msgstr ""
+
+msgid "Vatawna"
+msgstr ""
+
+msgid "Rebecca"
+msgstr ""
+
+msgid "Gem"
+msgstr ""
+
+msgid "Ariel"
+msgstr ""
+
+msgid "Carlawn"
+msgstr ""
+
+msgid "Luna"
+msgstr ""
+
+msgid "Arie"
+msgstr ""
+
+msgid "Alamar"
+msgstr ""
+
+msgid "Vesper"
+msgstr ""
+
+msgid "Crodo"
+msgstr ""
+
+msgid "Barok"
+msgstr ""
+
+msgid "Kastore"
+msgstr ""
+
+msgid "Agar"
+msgstr ""
+
+msgid "Falagar"
+msgstr ""
+
+msgid "Wrathmont"
+msgstr ""
+
+msgid "Myra"
+msgstr ""
+
+msgid "Flint"
+msgstr ""
+
+msgid "Dawn"
+msgstr ""
+
+msgid "Halon"
+msgstr ""
+
+msgid "Myrini"
+msgstr ""
+
+msgid "Wilfrey"
+msgstr ""
+
+msgid "Sarakin"
+msgstr ""
+
+msgid "Kalindra"
+msgstr ""
+
+msgid "Mandigal"
+msgstr ""
+
+msgid "Zom"
+msgstr ""
+
+msgid "Darlana"
+msgstr ""
+
+msgid "Zam"
+msgstr ""
+
+msgid "Ranloo"
+msgstr ""
+
+msgid "Charity"
+msgstr ""
+
+msgid "Rialdo"
+msgstr ""
+
+msgid "Roxana"
+msgstr ""
+
+msgid "Sandro"
+msgstr ""
+
+msgid "Celia"
+msgstr ""
+
+msgid "Roland"
+msgstr ""
+
+msgid "Lord Corlagon"
+msgstr ""
+
+msgid "Sister Eliza"
+msgstr ""
+
+msgid "Archibald"
+msgstr ""
+
+msgid "Lord Halton"
+msgstr ""
+
+msgid "Brother Brax"
+msgstr ""
+
+msgid "Solmyr"
+msgstr ""
+
+msgid "Dainwin"
+msgstr ""
+
+msgid "Mog"
+msgstr ""
+
+msgid "Joseph"
+msgstr ""
+
+msgid "Gallavant"
+msgstr ""
+
+msgid "Elderian"
+msgstr ""
+
+msgid "Ceallach"
+msgstr ""
+
+msgid "Drakonia"
+msgstr ""
+
+msgid "Martine"
+msgstr ""
+
+msgid "Jarkonas"
+msgstr ""
+
+msgid "%{object} robber"
+msgstr ""
+
+msgid "%{object} raided"
+msgstr ""
+
+msgid "You cannot pick up this artifact, you already have a full load!"
+msgstr ""
+
+msgid "The three Anduran artifacts magically combine into one."
+msgstr ""
+
+msgid "To cast spells, you must first buy a spell book for %{gold} gold."
+msgstr ""
+
+msgid "Unfortunately, you seem to be a little short of cash at the moment."
+msgstr ""
+
+msgid "Do you wish to buy one?"
+msgstr ""
+
 msgid "%{count} / day"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:331
-#: ../fheroes2/heroes/heroes_action.cpp:2199
 msgid "You are unable to recruit at this time, your ranks are full."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:599
-msgid ""
-"A group of %{monster} with a desire for greater glory wish to join you.\n"
-"Do you accept?"
+msgid "A whirlpool engulfs your ship."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:609
-#: ../fheroes2/heroes/heroes_action.cpp:630
+msgid "Some of your army has fallen overboard."
+msgstr ""
+
 msgid "Insulted by your refusal of their offer, the monsters attack!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:638
 msgid ""
 "The %{monster}, awed by the power of your forces, begin to scatter.\n"
 "Do you wish to pursue and engage them?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:934
 msgid "Ransacking an enemy camp, you discover a hidden cache of treasures."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:966
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with these resources, "
 "come back next week for more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:967
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there are no resources currently available. Please try "
 "again next week.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:972
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with this gold, come "
 "back next week for more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:973
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there is no gold currently available. Please try again "
 "next week.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:979
 msgid ""
 "You've found an abandoned lean-to.\n"
 "Poking about, you discover some resources hidden nearby."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:980
 msgid "The lean-to is long abandoned. There is nothing of value here."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:985
 msgid ""
 "You catch a leprechaun foolishly sleeping amidst a cluster of magic "
 "mushrooms.\n"
@@ -2748,177 +3047,143 @@ msgid ""
 "precious things."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:986
 msgid ""
 "You've found a magic garden, the kind of place that leprechauns and faeries "
 "like to cavort in, but there is no one here today.\n"
 "Perhaps you should try again next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1023
 msgid "You come upon the remains of an unfortunate adventurer."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1034
 #, fuzzy
 msgid "Treasure"
 msgstr "Trésors"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1041
 msgid "Searching through the tattered clothing, you find %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1052
 msgid "Searching through the tattered clothing, you find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1064
 msgid ""
 "You come across an old wagon left by a trader who didn't quite make it to "
 "safe terrain."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1075
-#: ../fheroes2/heroes/heroes_action.cpp:1103
 msgid "Unfortunately, others have found it first, and the wagon is empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1082
 msgid "Searching inside, you find the %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1093
 msgid "Inside, you find some of the wagon's cargo still intact."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1123
 msgid "You search through the flotsam, and find some wood and some gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1124
 msgid "You search through the flotsam, and find some wood."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1130
 msgid "You search through the flotsam, but find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1151
 msgid "Shrine of the 1st Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1152
 msgid ""
 "You come across a small shrine attended by a group of novice acolytes.\n"
-"In exchange for your protection, they agree to teach you a simple spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a simple spell - "
+"'%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1155
 msgid "Shrine of the 2nd Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1156
 msgid ""
 "You come across an ornate shrine attended by a group of rotund friars.\n"
-"In exchange for your protection, they agree to teach you a spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a spell - "
+"'%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1159
 msgid "Shrine of the 3rd Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1160
 msgid ""
 "You come across a lavish shrine attended by a group of high priests.\n"
 "In exchange for your protection, they agree to teach you a sophisticated "
 "spell - '%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1173
 msgid ""
 "\n"
 "Unfortunately, you have no Magic Book to record the spell with."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1184
 msgid ""
 "\n"
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1192
 msgid ""
 "\n"
 "Unfortunately, you already have knowledge of this spell, so there is nothing "
 "more for them to teach you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1215
 msgid ""
-"You approach the hut and observe a witch inside studying an ancient tome on %"
-"{skill}.\n"
+"You approach the hut and observe a witch inside studying an ancient tome on "
+"%{skill}.\n"
 " \n"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1222
 msgid ""
 "As you approach, she turns and focuses her one glass eye on you.\n"
 "\"You already know everything you deserve to learn!\" the witch screeches. "
 "\"NOW GET OUT OF MY HOUSE!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1229
 msgid ""
 "As you approach, she turns and speaks.\n"
 "\"You already know that which I would teach you. I can help you no further.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1236
 msgid ""
 "An ancient and immortal witch living in a hut with bird's legs for stilts "
 "teaches you %{skill} for her own inscrutable purposes."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1255
 msgid "You drink from the enchanted fountain, but nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1256
 msgid "As you drink the sweet water, you gain luck for your next battle."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1260
 msgid "You enter the faerie ring, but nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1261
 msgid ""
 "Upon entering the mystical faerie ring, your army gains luck for its next "
 "battle."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1265
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "It is supposed to grant luck to visitors, but since the stars are already "
 "smiling upon you, it does nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1266
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "Kissing it is supposed to be lucky, so you do. The stone is very cold to the "
 "touch."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1270
 msgid "The mermaids silently entice you to return later and be blessed again."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1271
 msgid ""
 "The magical, soothing beauty of the Mermaids reaches you and your crew.\n"
 "Just for a moment, you forget your worries and bask in the beauty of the "
@@ -2926,7 +3191,6 @@ msgid ""
 "The mermaids charms bless you with increased luck for your next combat."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1303
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "You are tempted to search it for treasure, but all the old stories warn of "
@@ -2934,470 +3198,375 @@ msgid ""
 "Will you search?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1304
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "Routine exploration reveals that the pyramid is completely empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1329
 msgid "Unfortunately, you have no Magic Book to record the spell with."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1333
 msgid ""
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1337
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
 "telling the secret of the spell."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1374 ../fheroes2/maps/mp2.cpp:469
 msgid "Sign"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1385
 msgid ""
 "A drink at the well is supposed to restore your spell points, but you are "
 "already at maximum."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1392
 msgid "A second drink at the well in one day will not help you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1399
 msgid "A drink from the well has restored your spell points to maximum."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1424
 msgid ""
 "\"I'm sorry sir,\" The leader of the soldiers says, \"but you already know "
 "everything we have to teach.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1425
 msgid "The soldiers living in the fort teach you a few new defensive tricks."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1430
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. \"You're too "
 "advanced for us,\" the mercenary captain says. \"We can teach nothing more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1431
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. The mercenaries "
 "welcome you and your troops and invite you to train with them."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1436
 msgid "\"Go 'way!\", the witch doctor barks, \"you know all I know.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1437
 msgid ""
 "An Orcish witch doctor living in the hut deepens your knowledge of magic by "
 "showing you how to cast stones, read portents, and decipher the intricacies "
 "of chicken entrails."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1442
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, the Druids turn you away, indicating they have nothing "
 "new to teach you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1443
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, they teach you new ways to cast spells."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1479
 msgid ""
 "You tentatively approach the burial ground of ancient warriors. Do you want "
 "to search the graves?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1480
 msgid ""
 "Upon defeating the Zombies you spend several hours searching the graves and "
 "find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1481
-msgid "Upon defeating the zomies you search the graves and find something!"
+msgid "Upon defeating the Zombies you search the graves and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1484
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the shipwreck?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1485
 msgid ""
 "Upon defeating the Ghosts you spend several hours sifting through the debris "
 "and find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1486
 msgid ""
 "Upon defeating the Ghosts you sift through the debris and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1489
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the ship?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1490
 msgid ""
 "Upon defeating the Skeletons you spend several hours sifting through the "
 "debris and find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1491
 msgid ""
 "Upon defeating the Skeletons you sift through the debris and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1564
 msgid "Your men spot a navigational buoy, confirming that you are on course."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1565
 msgid ""
 "Your men spot a navigational buoy, confirming that you are on course and "
 "increasing their morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1569
 msgid ""
 "The drink at the oasis is refreshing, but offers no further benefit. The "
 "oasis might help again if you fought a battle first."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1570
 msgid ""
 "A drink at the oasis fills your troops with strength and lifts their "
 "spirits.  You can travel a bit further today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1575
 msgid ""
 "The drink at the watering hole is refreshing, but offers no further benefit. "
 "The watering hole might help again if you fought a battle first."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1576
 msgid ""
 "A drink at the watering hole fills your troops with strength and lifts their "
 "spirits. You can travel a bit further today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1581
 msgid ""
 "It doesn't help to pray twice before a battle. Come back after you've fought."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1582
 msgid "A visit and a prayer at the temple raises the morale of your troops."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1622
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"I am sorry, my liege, I "
 "have taught you all I can.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1623
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"My liege, I will teach "
 "you all that I know to aid you in your travels.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1662
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
 "ocean. Grateful, he says, \"I would give you an artifact as a reward, but "
 "you're all full.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1669
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
-"ocean. Grateful, he rewards you for your act of kindness by giving you the %"
-"{art}."
+"ocean. Grateful, he rewards you for your act of kindness by giving you the "
+"%{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1688 ../fheroes2/heroes/heroes.cpp:941
-msgid "You have no room to carry another artifact!"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:1704
 msgid "A leprechaun offers you the %{art} for the small price of %{gold} Gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1709
 msgid ""
-"A leprechaun offers you the %{art} for the small price of %{gold} Gold and %"
-"{count} %{res}."
+"A leprechaun offers you the %{art} for the small price of %{gold} Gold and "
+"%{count} %{res}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1718
 msgid "Do you wish to buy this artifact?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1731
 msgid ""
 "You try to pay the leprechaun, but realize that you can't afford it. The "
 "leprechaun stamps his foot and ignores you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1735
 msgid ""
 "Insulted by your refusal of his generous offer, the leprechaun stamps his "
 "foot and ignores you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1746
-#: ../fheroes2/heroes/heroes_action.cpp:1821
 msgid "You've found the artifact: "
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1756
 msgid ""
 "You've found the humble dwelling of a withered hermit. The hermit tells you "
 "that he is willing to give the %{art} to the first wise person he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1759
 msgid ""
 "You've come across the spartan quarters of a retired soldier. The soldier "
 "tells you that he is willing to pass on the %{art} to the first true leader "
 "he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1780
 msgid ""
 "You come upon an ancient artifact. As you reach for it, a pack of Rogues "
 "leap out of the brush to guard their stolen loot."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1783
 msgid ""
 "Through a clearing you observe an ancient artifact. Unfortunately, it's "
 "guarded by a nearby %{monster}. Do you want to fight the %{monster} for the "
 "artifact?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1798
 msgid "Victorious, you take your prize, the %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1810
 msgid ""
 "Discretion is the better part of valor, and you decide to avoid this fight "
 "for today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1866
-#: ../fheroes2/heroes/heroes_action.cpp:1881
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold pieces."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1872
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold and the %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1888
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it, "
 "only to find it empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1898
 msgid ""
 "After scouring the area, you fall upon a hidden treasure cache. You may take "
 "the gold or distribute the gold to the peasants for experience. Do you wish "
 "to keep the gold?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1912
 msgid ""
-"After scouring the area, you fall upon a hidden chest, containing the %"
-"{gold} gold pieces."
+"After scouring the area, you fall upon a hidden chest, containing the "
+"%{gold} gold pieces."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1918
 msgid ""
 "After scouring the area, you fall upon a hidden chest, containing the "
 "ancient artifact %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1942
 msgid ""
 "You stumble upon a dented and tarnished lamp lodged deep in the earth. Do "
 "you wish to rub the lamp?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "A whirlpool engulfs your ship."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "Some of your army has fallen overboard."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2045
 msgid ""
 "You come upon an abandoned gold mine. The mine appears to be haunted. Do you "
 "wish to enter?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2064
 msgid ""
 "You have taken control of the local Alchemist shop. It will provide you with "
 "%{count} unit of Mercury per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2070
 msgid ""
 "You gain control of a sawmill. It will provide you with %{count} units of "
 "wood per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2081
+msgid "You beat the Ghosts and are able to restore the mine to production."
+msgstr ""
+
 msgid ""
 "You gain control of an ore mine. It will provide you with %{count} units of "
 "ore per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2083
 msgid ""
 "You gain control of a sulfur mine. It will provide you with %{count} unit of "
 "sulfur per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2085
 msgid ""
 "You gain control of a crystal mine. It will provide you with %{count} unit "
 "of crystal per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2087
 msgid ""
 "You gain control of a gem mine. It will provide you with %{count} unit of "
 "gems per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2089
 msgid ""
 "You gain control of a gold mine. It will provide you with %{count} gold per "
 "day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2096
-msgid "You beat the Ghosts and are able to restore the mine to production."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2101
 msgid ""
 "The lighthouse is now under your control, and all of your ships will now "
 "move further each turn."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2105
 msgid "You gain control of a %{name}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2188
 msgid ""
 "A group of %{monster} with a desire for greater glory wish to join you. Do "
 "you accept?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2215
 msgid "As you approach the dwelling, you notice that there is no one here."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2232
 msgid ""
 "You search the ruins, but the Medusas that used to live here are gone. "
 "Perhaps there will be more next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2233
 msgid ""
 "You've found some Medusas living in the ruins. They are willing to join your "
 "army for a price. Do you want to recruit Medusas?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2238
 msgid ""
 "You've found a Sprite Tree City. Unfortunately, none of the Sprites living "
 "there wish to join an army. Maybe next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2239
 msgid ""
 "Some of the Sprites living in the tree city are willing to join your army "
 "for a price. Do you want to recruit Sprites?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2244
 msgid ""
 "A colorful Rogues' wagon stands empty here. Perhaps more Rogues will be here "
 "later."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2245
 msgid ""
 "Distant sounds of music and laughter draw you to a colorful wagon housing "
 "Rogues. Do you wish to have any Rogues join your army?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2250
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. The "
 "tents are unoccupied. Perhaps more Nomads will be here later."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2251
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. Do you "
 "wish to have any Nomads join you during your travels?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2256
 msgid "The pit of mud bubbles for a minute and then lies still."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2257
 msgid ""
 "As you approach the bubbling pit of mud, creatures begin to climb out and "
 "position themselves around it. In unison they say: \"Mother Earth would like "
 "to offer you a few of her troops. Do you want to recruit Earth Elementals?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2261
 msgid "You enter the structure of white stone pillars, and find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2262
 msgid ""
 "White stone pillars support a roof that rises up to the sky. As you enter "
 "the structure, the dead air of the outside gives way to a whirling gust that "
@@ -3407,192 +3576,159 @@ msgid ""
 "air?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2266
 msgid "No Fire Elementals approach you from the lava pool."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2267
 msgid ""
 "Beneath a structure that serves to hold in heat, Fire Elementals move about "
 "in a fiery pool of molten lava. A group of them approach you and offer their "
 "services. Would you like to recruit Fire Elementals?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2271
 msgid "A face forms in the water for a moment, and then is gone."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2272
 msgid ""
 "Crystalline structures cast shadows over a small reflective pool of water. "
 "You peer into the pool, and a face that is not your own peers back. It asks: "
 "\"Would you like to call upon the powers of water?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2276
 msgid "This burial site is deathly still."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2277
 msgid ""
 "Restless spirits of long dead warriors seeking their final resting place "
 "offer to join you in hopes of finding peace. Do you wish to recruit ghosts?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2313
 msgid ""
 "The City of the Dead is empty of life, and empty of unlife as well. Perhaps "
 "some undead will move in next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2314
 msgid ""
 "Some Liches living here are willing to join your army for a price. Do you "
 "want to recruit Liches?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2315
 msgid ""
 "You've found the ruins of an ancient city, now inhabited solely by the "
 "undead. Will you search?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2316
 msgid ""
 "Some of the surviving Liches are impressed by your victory over their "
 "fellows, and offer to join you for a price. Do you want to recruit Liches?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2320
 msgid ""
 "You've found one of those bridges that Trolls are so fond of living under, "
 "but there are none here. Perhaps there will be some next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2321
 msgid ""
 "Some Trolls living under a bridge are willing to join your army, but for a "
 "price. Do you want to recruit Trolls?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2322
 msgid "Trolls living under the bridge challenge you. Will you fight them?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2323
 msgid ""
 "A few Trolls remain, cowering under the bridge. They approach you and offer "
 "to join your forces as mercenaries. Do you want to buy any Trolls?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2327
 msgid ""
 "The Dragon city has no Dragons willing to join you this week. Perhaps a "
 "Dragon will become available next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2328
 msgid ""
 "The Dragon city is willing to offer some Dragons for your army for a price. "
 "Do you wish to recruit Dragons?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2329
 msgid ""
 "You stand before the Dragon City, a place off-limits to mere humans. Do you "
 "wish to violate this rule and challenge the Dragons to a fight?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2330
 msgid ""
 "Having defeated the Dragon champions, the city's leaders agree to supply "
 "some Dragons to your army for a price. Do you wish to recruit Dragons?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2389
 msgid "From the observation tower, you are able to see distant lands."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2401
 msgid ""
 "The spring only refills once a week, and someone's already been here this "
 "week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2407
 msgid ""
 "A drink at the spring is supposed to give you twice your normal spell "
 "points, but you are already at that level."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2418
 msgid ""
 "A drink from the spring fills your blood with magic! You have twice your "
 "normal spell points in reserve."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2437
 msgid ""
 "Recognizing you, the butler refuses to admit you. \"The master,\" he says, "
 "\"will not see the same student twice.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2457
 msgid ""
 "The butler admits you to see the master of the house. He trains you in the "
 "four skills a hero should know."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2467
 msgid ""
 "The butler opens the door and looks you up and down. \"You are neither "
 "famous nor diplomatic enough to be admitted to see my master,\" he sniffs. "
 "\"Come back when you think yourself worthy.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2510
 msgid ""
 "All of the %{monsters} you have in your army have been trained by the battle "
 "masters of the fort. Your army now contains %{monsters2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2513
 msgid ""
-"An unusual alliance of Orcs, Ogres, and Dwarves offer to train (upgrade) any "
+"An unusual alliance of Ogres, Orcs, and Dwarves offer to train (upgrade) any "
 "such troops brought to them. Unfortunately, you have none with you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2524
 msgid "All of your %{monsters} have been upgraded into %{monsters2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2527
 msgid ""
 "A blacksmith working at the foundry offers to convert all Pikemen and "
 "Swordsmen's weapons brought to him from iron to steel. He also says that he "
-"knows a process that will convert Iron Golems into Steel Golems.  "
+"knows a process that will convert Iron Golems into Steel Golems. "
 "Unfortunately, you have none of these troops in your army, so he can't help "
 "you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2585
 msgid ""
 "A retired captain living on this refurbished fishing platform offers to sell "
 "you maps of the sea he made in his younger days for 1,000 gold. Do you wish "
 "to buy the maps?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2598
 msgid ""
 "The captain sighs. \"You don't have enough money, eh?  You can't expect me "
 "to give my maps away for free!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2632
 msgid "You find %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2655
 msgid ""
 "You come upon an obelisk made from a type of stone you have never seen "
 "before. Staring at it intensely, the smooth surface suddenly changes to an "
@@ -3600,56 +3736,51 @@ msgid ""
 "copy down the piece and the inscription vanishes as abruptly as it appeared."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2659
 msgid "You have already been to this obelisk."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2671
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"It is good to see "
 "you, my student. I hope my teachings have helped you.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2683
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"Ahh, an "
 "adventurer! Allow me to teach you a little of what I have learned over the "
 "ages.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2692
 msgid "Upon your approach, the tree opens its eyes in delight."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2694
 msgid ""
 "\"Ahh, an adventurer! I will be happy to teach you a little of what I have "
 "learned over the ages for a mere %{count} %{res}.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2696
 msgid "(Just bury it around my roots.)"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2703
 msgid "Tears brim in the eyes of the tree."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2705
 msgid "\"I need %{count} %{res}.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2707
 msgid "it whispers. (sniff) \"Well, come back when you can pay me.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2737
+msgid ""
+"Nestled among the trees sits a blind seer. After explaining the intent of "
+"your journey, the seer activates his crystal ball, allowing you to see the "
+"strengths and weaknesses of your opponents."
+msgstr ""
+
 msgid ""
 "The entrance to the cave is dark, and a foul, sulfurous smell issues from "
 "the cave mouth. Will you enter?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2749
 msgid ""
 "You find a powerful and grotesque Demon in the cave. \"Today,\" it rasps, "
 "\"you will fight and surely die. But I will give you a choice of deaths. You "
@@ -3657,71 +3788,59 @@ msgid ""
 "servants?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2759
 msgid ""
 "Upon defeating the daemon's servants, you find a hidden cache with %{count} "
 "gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2774
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and receive %{exp} experience points."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2784
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and find the %{art} in the back of the cave."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2794
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
-"battle, you slay the monster and receive %{exp) experience points and %"
-"{count} gold."
+"battle, you slay the monster and receive %{exp} experience points and "
+"%{count} gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2809
 msgid ""
 "The Demon leaps upon you and has its claws at your throat before you can "
 "even draw your sword. \"Your life is mine,\" it says. \"I will sell it back "
 "to you for %{count} gold.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2810
 msgid ""
 "Seeing that you do not have %{count} gold, the demon slashes you with its "
 "claws, and the last thing you see is a red haze."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2835
 msgid "Except for evidence of a terrible battle, the cave is empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2860
 msgid "For %{gold} gold, the alchemist will remove it for you. Do you pay?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2871
 msgid ""
 "You hear a voice from behind the locked door, \"You don't have enough gold "
 "to pay for my services.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2874
 msgid ""
 "You hear a voice from high above in the tower, \"Go away! I can't help you!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2886
 msgid ""
 "The head groom approaches you and speaks, \"You already have a fine horse, "
 "and have no inexperienced cavalry which might make use of our trained war "
 "horses.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2889
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, his "
@@ -3730,7 +3849,6 @@ msgid ""
 "mounted soldiers, but you have none we can help.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2892
 msgid ""
 "The head groom speaks to you, \"That is a fine looking horse you have. I am "
 "afraid we can give you no better, but the horses your cavalry are riding "
@@ -3738,7 +3856,6 @@ msgid ""
 "would aid your riders greatly. I insist you take them.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2895
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, he will "
@@ -3746,17 +3863,14 @@ msgid ""
 "mounted soldiers, their horses look shoddy and weak.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2922
 msgid "The Arena guards turn you away."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2939
 msgid ""
 "As the sirens sing their eerie song, your small, determined army manages to "
 "overcome the urge to dive headlong into the sea."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2944
 msgid ""
 "You have your crew stop up their ears with wax before the sirens' eerie song "
 "has any chance of luring them to a watery grave. An eerie wailing song "
@@ -3765,57 +3879,52 @@ msgid ""
 "for the visit, and gain %{exp} experience."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2964
 msgid ""
 "In a dazzling display of daring, you break into the local jail and free the "
 "hero imprisoned there, who, in return, pledges loyalty to your cause."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2980
 msgid ""
 "You already have %{count} heroes, and regretfully must leave the prisoner in "
 "this jail to languish in agony for untold days."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2991
 msgid ""
 "You enter a rickety hut and talk to the magician who lives there. He tells "
 "you of places near and far which may aid you in your journeys."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3004
 msgid "This eye seems to be intently studying its surroundings."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3015
 msgid ""
 "\"I have a riddle for you,\" the Sphinx says. \"Answer correctly, and you "
 "shall be rewarded. Answer incorrectly, and you shall be eaten. Do you accept "
 "the challenge?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3017
-msgid "The Sphinx asks you the following riddle: %{riddle}. Your answer?"
+msgid ""
+"The Sphinx asks you the following riddle:\n"
+" \n"
+"'%{riddle}'\n"
+" \n"
+"Your answer?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3025
 msgid ""
 "Looking somewhat disappointed, the Sphinx sighs. You've answered my riddle "
 "so here's your reward. Now begone."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3052
 msgid ""
 "\"You guessed incorrectly,\" the Sphinx says, smiling. The Sphinx swipes at "
 "you with a paw, knocking you to the ground. Another blow makes the world go "
 "black, and you know no more."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3060
 msgid "You come across a giant Sphinx. The Sphinx remains strangely quiet."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3073
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -3823,7 +3932,6 @@ msgid ""
 "As you speak the magic word, the glowing barrier dissolves into nothingness."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3083
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -3831,7 +3939,6 @@ msgid ""
 "You speak, and nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3093
 msgid ""
 "You enter the tent and see an old woman gazing into a magic gem. She looks "
 "up and says,\n"
@@ -3839,422 +3946,87 @@ msgid ""
 "oracle taught me his skill. I have the answer you seek.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_base.cpp:401
 msgid ""
 "That spell costs %{mana} mana. You only have %{point} mana, so you can't "
 "cast the spell."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Lord Kilburn"
-msgstr ""
+#, fuzzy
+msgid "%{name} the %{race} (Level %{level})"
+msgstr "%{name} le %{race}"
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Sir Gallanth"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ector"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Gwenneth"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Tyro"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ambrose"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ruby"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Maximus"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Dimitry"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Thundax"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Fineous"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jojosh"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Crag Hack"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jezebel"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jaclyn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Ergon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Tsabu"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Atlas"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Astra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Natasha"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Troyan"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Vatawna"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Rebecca"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Gem"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Ariel"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Carlawn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Luna"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Arie"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61 ../fheroes2/resource/maps_text.cpp:59
-msgid "Alamar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Vesper"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Crodo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Barok"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Kastore"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Agar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Falagar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Wrathmont"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Flint"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Dawn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Halon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myrini"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Wilfrey"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Sarakin"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63 ../fheroes2/resource/maps_text.cpp:377
-msgid "Kalindra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Mandigal"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zom"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Darlana"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zam"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Ranloo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Charity"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Rialdo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Roxana"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65 ../fheroes2/resource/maps_text.cpp:557
-msgid "Sandro"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Celia"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:552
-msgid "Roland"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Lord Corlagon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Sister Eliza"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:88
-msgid "Archibald"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:403
-msgid "Lord Halton"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Brother Bax"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Solmyr"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:194
-msgid "Dainwin"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Mog"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:760
-msgid "Uncle Ivan"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:373
-msgid "Joseph"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:285
-msgid "Gallavant"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Elderian"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:179
-msgid "Ceallach"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:229
-msgid "Drakonia"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:422
-msgid "Martine"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:370
-msgid "Jarkonas"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:940
-msgid ""
-"You must purchase a spell book to use the mage guild, but you currently have "
-"no room for a spell book. Try giving one of your artifacts to another hero."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:950
-msgid "The three Anduran artifacts magically combine into one."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1056
-msgid "To cast spells, you must first buy a spell book for %{gold} gold."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1064
-msgid "Unfortunately, you seem to be a little short of cash at the moment."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1078
-msgid "Do you wish to buy one?"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:72
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:55
-msgid "%{name} the %{race} ( Level %{level} )"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:118
 msgid ""
 "'Grouped' combat formation bunches your army together in the center of your "
 "side of the battlefield."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:161
 msgid "Are you sure you want to dismiss this Hero?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:341
 #, fuzzy
 msgid "View Stats"
 msgstr "Stats du meilleur Héro :"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:344
-msgid "View Morale Info"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:347
-msgid "View Luck Info"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:350
 msgid "View Experience Info"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:353
 msgid "View Spell Points Info"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:356
 msgid "Set army combat formation to 'Spread'"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:359
 msgid "Set army combat formation to 'Grouped'"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:362
-msgid "Exit hero"
+msgid "Exit Hero Screen"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:369
-msgid "Dismiss hero"
+msgid "You cannot dismiss a hero in a castle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:373
-msgid "Show prev heroes"
+msgid "Dismissal of %{name} the %{race} is prohibited by scenario"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:376
-msgid "Show next heroes"
+#, fuzzy
+msgid "Dismiss %{name} the %{race}"
+msgstr "%{name} le %{race}"
+
+#, fuzzy
+msgid "Show previous hero"
+msgstr "Montrer la ville précédente"
+
+#, fuzzy
+msgid "Show next hero"
+msgstr "Montrer la ville suivante"
+
+#, fuzzy
+msgid "Blood Morale"
+msgstr "Morale"
+
+msgid "%{morale} Morale"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:379
-msgid "Hero Screen"
+msgid "%{luck} Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:39
-msgid "Bad Morale"
+msgid "Current Luck Modifiers:"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:42
-msgid "Neutral Morale"
+msgid "Current Morale Modifiers:"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:47
-msgid "Good Morale"
+msgid "Entire army is undead, so morale does not apply."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:61
-msgid "Bad Luck"
+msgid ""
+"Current experience %{exp1}.\n"
+" Next level %{exp2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:64
-msgid "Neutral Luck"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:69
-msgid "Good Luck"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:113
-#: ../fheroes2/heroes/heroes_indicator.cpp:159
-#: ../fheroes2/heroes/skill.cpp:197
-msgid "Current Modifiers:"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:195
-msgid "Current experience %{exp1} Next level %{exp2}."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:215
 msgid "Level %{level}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:226
 msgid ""
 "%{name} currently has %{point} spell points out of a maximum of %{max}. The "
 "maximum number of spell points is 10 times your knowledge. It is "
@@ -4262,2540 +4034,1452 @@ msgid ""
 "special events."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:65
 msgid "%{name1} meets %{name2}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:396
-#: ../fheroes2/heroes/heroes_meeting.cpp:406
 msgid " and "
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:414
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:417
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:420
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches %"
-"{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches "
+"%{spells2} to %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:431
 msgid "Scholar Ability"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:83 ../fheroes2/spell/spell.cpp:109
 msgid "Town Portal"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:86
 msgid "Select town to port to."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:106
 msgid "Your hero is too tired to cast this spell today. Try again tomorrow."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:187
 msgid "%{spell} failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:236
+msgid "This spell is already in use."
+msgstr ""
+
 msgid "Enemy heroes are now fully identifiable."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:362
-#: ../fheroes2/heroes/heroes_spell.cpp:386
-msgid "No available towns. Spell Failed!!!"
+#, fuzzy
+msgid "This spell cannot be used on a boat."
+msgstr "Cette ville ne peut pas être améliorée en château."
+
+msgid "This spell can be casted only nearby water."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:459
-msgid "I fear these creatures are in the mood for a fight."
+msgid ""
+"No available towns.\n"
+"Spell Failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:463
-msgid "The creatures are willing to join us!"
+msgid ""
+"Nearest town occupied.\n"
+"Spell Failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:468
-msgid "All the creatures will join us..."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_spell.cpp:480
-msgid "These weak creatures will surely flee before us."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_spell.cpp:489
 msgid ""
 "You must be within %{count} spaces of a monster for the Visions spell to "
 "work."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:506
+msgid "I fear these creatures are in the mood for a fight."
+msgstr ""
+
+msgid "The creatures are willing to join us!"
+msgstr ""
+
+msgid "All the creatures will join us..."
+msgstr ""
+
+msgid "These weak creatures will surely flee before us."
+msgstr ""
+
 msgid ""
 "You must be standing on the entrance to a mine (sawmills and alchemists "
 "don't count) to cast this spell."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:151
-msgid "Power"
-msgstr ""
-
-#: ../fheroes2/heroes/skill.cpp:172
 msgid "Your attack skill is a bonus added to each creature's attack skill."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:177
 msgid "Your defense skill is a bonus added to each creature's defense skill."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:182
 msgid "Your spell power determines the length or power of a spell."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:187
 msgid ""
 "Your knowledge determines how many spell points your hero may have. Under "
-"normal cirumstances, a hero is limited to 10 spell points per level of "
+"normal circumstances, a hero is limited to 10 spell points per level of "
 "knowledge."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
+msgid "Current Modifiers:"
+msgstr ""
+
 msgid "skill|Basic"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
 msgid "skill|Advanced"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
 #, fuzzy
 msgid "skill|Expert"
 msgstr "Expert"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Basic Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Advanced Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Expert Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Basic Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Advanced Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
 #, fuzzy
 msgid "Expert Archery"
 msgstr "Expert"
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Basic Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Advanced Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Expert Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Basic Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Advanced Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Expert Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Basic Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Advanced Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Expert Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:372
 #, fuzzy
 msgid "Basic Navigation"
 msgstr "Fouille"
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Advanced Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:372
 #, fuzzy
 msgid "Expert Navigation"
 msgstr "Fouille"
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Basic Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Advanced Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Expert Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Basic Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Advanced Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
 #, fuzzy
 msgid "Expert Wisdom"
 msgstr "Expert"
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Basic Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Advanced Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Expert Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Basic Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Advanced Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
 #, fuzzy
 msgid "Expert Luck"
 msgstr "Expert"
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Basic Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Advanced Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Expert Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Basic Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Advanced Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Expert Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Basic Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Advanced Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Expert Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Basic Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Advanced Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 #, fuzzy
 msgid "Expert Estates"
 msgstr "Expert"
 
-#: ../fheroes2/heroes/skill.cpp:406
-msgid "Allows you to negotiate with monsters who are weaker than your group."
+msgid " allows you to negotiate with monsters who are weaker than your group."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:421
-msgid "Allows your hero to learn third level spells."
+msgid "All of the creatures may offer to join you."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:423
-msgid "Allows your hero to learn fourth level spells."
+msgid " allows your hero to learn third level spells."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:425
-msgid "Allows your hero to learn fifth level spells."
+msgid " allows your hero to learn fourth level spells."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:440
+msgid " allows your hero to learn fifth level spells."
+msgstr ""
+
 msgid ""
-"Gives your hero's catapult shots a greater chance to hit and do damage to "
+" gives your hero's catapult shots a greater chance to hit and do damage to "
 "castle walls."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:442
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot has a greater chance "
-"to hit and do damage to castle walls."
+" gives your hero's catapult an extra shot, and each shot has a greater "
+"chance to hit and do damage to castle walls."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:444
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot automatically "
+" gives your hero's catapult an extra shot, and each shot automatically "
 "destroys any wall, except a fortified wall in a Knight town."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:858 ../fheroes2/heroes/skill.cpp:959
-#, fuzzy
-msgid "View %{skill} Info"
-msgstr "voir les infos de %{name} info."
-
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:108
 msgid "Blue"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:111
 msgid "Green"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:114
 msgid "Red"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32
 msgid "Yellow"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:112
 msgid "Orange"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:113
 msgid "Purple"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:107
 msgid "Aqua"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:109
 msgid "Brown"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:110 ../fheroes2/resource/resource.cpp:283
 msgid "Gold"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:238
 #, fuzzy
 msgid "Hero/Stats"
 msgstr "Stats du meilleur Héro :"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:241
 #, fuzzy
 msgid "Skills"
 msgstr "Passer"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:244
 #, fuzzy
 msgid "Artifacts"
 msgstr "Artéfact"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:473
 #, fuzzy
 msgid "Town/Castle"
 msgstr "Chateau"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:476
 msgid "Garrison"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:566
 #, fuzzy
 msgid "Gold Per Day:"
 msgstr "Or disponible dans la trésorerie :"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Cursed"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Awful"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Bad"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Normal"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Good"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Great"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Irish"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:48
 msgid ""
 "Bad luck sometimes falls on your armies in combat, causing their attacks to "
 "only do half damage."
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:49
 msgid ""
 "Neutral luck means your armies will never get lucky or unlucky attacks on "
 "the enemy."
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:50
 msgid ""
 "Good luck sometimes lets your armies get lucky attacks (double strength) in "
 "combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Treason"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Awful"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Poor"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Normal"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Good"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Great"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Blood!"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:48
 msgid "Bad morale may cause your armies to freeze in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:49
 msgid ""
 "Neutral morale means your armies will never be blessed with extra attacks or "
 "freeze in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:50
 msgid "Good morale may give your armies extra attacks in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Knight"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Barbarian"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Sorceress"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Warlock"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Wizard"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Necromancer"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Multi"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Standing"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Crawling"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Very Slow"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Slow"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Average"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Very Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Ultra Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Blazing"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Instant"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:32
 msgid "week|PLAGUE"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Ant"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Grasshopper"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Dragonfly"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Spider"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Butterfly"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Bumblebee"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Locust"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Earthworm"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Hornet"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Beetle"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Squirrel"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Rabbit"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Gopher"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Badger"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Eagle"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Weasel"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Raven"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Mongoose"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Aardvark"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Lizard"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Tortoise"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Hedgehog"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Condor"
 msgstr ""
 
-#: ../fheroes2/kingdom/world_loadmap.cpp:1424
-msgid "The ultimate artifact is really the %{name}"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1428
-msgid "The ultimate artifact may be found in the %{name} regions of the world."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1433
-msgid "north-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1436
-msgid "north"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1438
-msgid "north-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1444
-#, fuzzy
-msgid "west"
-msgstr "Nid"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1447
-#, fuzzy
-msgid "center"
-msgstr "Tente"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1449
-#, fuzzy
-msgid "east"
-msgstr "Nid"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1454
-msgid "south-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1457
-#, fuzzy
-msgid "south"
-msgstr "son"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1459
-msgid "south-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1463
-msgid "The truth is out there."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1464
-msgid "The dark side is stronger."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1465
-msgid "The end of the world is near."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1466
-msgid "The bones of Lord Slayer are buried in the foundation of the arena."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1467
-msgid "A Black Dragon will take out a Titan any day of the week."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1468
-msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1470
-msgid ""
-"You can load the newest version of game from a site:\n"
-" http://sf.net/projects/fheroes2"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1471
-msgid "This game is now in beta development version. ;)"
-msgstr ""
-
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Desert"
 msgstr "Désert"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Snow"
 msgstr "Neige"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Wasteland"
 msgstr "Terrain vague"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Beach"
 msgstr "Plage"
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Lava"
 msgstr "Lave"
 
-#: ../fheroes2/maps/ground.cpp:31 ../fheroes2/resource/maps_text.cpp:210
 msgid "Dirt"
 msgstr "Boue"
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Grass"
 msgstr "Herbe"
 
-#: ../fheroes2/maps/ground.cpp:31
-msgid "Water"
-msgstr "Eau"
+msgid "Ocean"
+msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Small"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Medium"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Large"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Extra Large"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Custom Size"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:122
 msgid "Ore Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:123
 msgid "Sulfur Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:124
 msgid "Crystal Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:125
 msgid "Gems Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:126
 msgid "Gold Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:130
 msgid "Mine"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:365
 msgid "Alchemist Lab"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:367
 msgid "Daemon Cave"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:369
 msgid "Faerie Ring"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:373 ../fheroes2/resource/maps_text.cpp:217
 msgid "Dragon City"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:375
-msgid "Light House"
+msgid "Lighthouse"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:377
 msgid "Water Wheel"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:379
 msgid "Mines"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:381
 msgid "Obelisk"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:383
 msgid "Oasis"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:385
 msgid "Sawmill"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:387
 msgid "Oracle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:389
 msgid "Desert Tent"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:393
 msgid "Wagon Camp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:395
 msgid "Windmill"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:397
 msgid "Random Town"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:399
 msgid "Random Castle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:401
 msgid "Watch Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:403
 msgid "Tree City"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:405
 msgid "Tree House"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:407
 msgid "Ruins"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:409
 msgid "Fort"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:411
-msgid "Trading Post"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:413
 msgid "Abandoned Mine"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:415
 msgid "Tree of Knowledge"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:417
 msgid "Witch Doctor's Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:419
 msgid "Temple"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:421
 msgid "Hill Fort"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:423
 msgid "Halfling Hole"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:425
 msgid "Mercenary Camp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:429
 msgid "City of the Dead"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:433
 msgid "Sphinx"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:435
 msgid "Troll Bridge"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:437
 msgid "Witch Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:439
 msgid "Xanadu"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:443
 msgid "Magellan Maps"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:445
 msgid "Derelict Ship"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:447
-msgid "Ship Wreck"
+msgid "Shipwreck"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:449
 msgid "Observation Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:451
-msgid "Freeman Foundry"
+msgid "Freeman's Foundry"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:453
 msgid "Watering Hole"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:455
 msgid "Artesian Spring"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:457
 msgid "Gazebo"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:459
 msgid "Archer's House"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:461
 msgid "Peasant Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:463
 msgid "Dwarf Cottage"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:465
 msgid "Stone Liths"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:467
 msgid "Magic Well"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:468
 msgid "Heroes"
 msgstr "Héros"
 
-#: ../fheroes2/maps/mp2.cpp:470 ../fheroes2/maps/mp2.cpp:488
-msgid "Shrub"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:471
 msgid "Nothing Special"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:472
 msgid "Tar Pit"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:473
-msgid "Coast"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:474
 msgid "Mound"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:475
 msgid "Dune"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:476
 msgid "Stump"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:477
 msgid "Cactus"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:478
 msgid "Trees"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:479
 msgid "Dead Tree"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:480
 msgid "Mountains"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:481
 msgid "Volcano"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:482
 msgid "Rock"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:483
 msgid "Flowers"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:484
 msgid "Water Lake"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:485
 msgid "Mandrake"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:486
 msgid "Crater"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:487
 msgid "Lava Pool"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:489
+msgid "Shrub"
+msgstr ""
+
 msgid "Buoy"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:491 ../fheroes2/monster/monster.cpp:116
 msgid "Skeleton"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:492
 msgid "Treasure Chest"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:493
 msgid "Sea Chest"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:494
 msgid "Campfire"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:495
 msgid "Fountain"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:496
 msgid "Genie Lamp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:497
 msgid "Goblin Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:499
 msgid "Monster"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:500
 msgid "Resource"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:501
 msgid "Whirlpool"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:502
 msgid "Artifact"
 msgstr "Artéfact"
 
-#: ../fheroes2/maps/mp2.cpp:503
 msgid "Boat"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:510
 msgid "Standing Stones"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:514
 msgid "Idol"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:515
 msgid "Shrine of the First Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:516
 msgid "Shrine of the Second Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:517
 msgid "Shrine of the Third Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:518
 msgid "Wagon"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:519
 msgid "Lean To"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:520
 msgid "Flotsam"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:521
 msgid "Shipwreck Survivor"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:522
 msgid "Bottle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:523
 msgid "Magic Garden"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:529
 msgid "Jail"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:531
 msgid "Traveller's Tent"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:532
 msgid "Barrier"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:535
 msgid "Fire Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:537
 msgid "Air Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:539
 msgid "Earth Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:541
 msgid "Water Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:543
 msgid "Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:545
-msgid "Arena"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:547
 msgid "Stables"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:549
 msgid "Alchemist's Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:551
 msgid "Hut of the Magi"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:553
 msgid "Eye of the Magi"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:555
 msgid "Mermaid"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:557
 msgid "Sirens"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:558
 msgid "Reefs"
 msgstr ""
 
-#: ../fheroes2/monster/monster.cpp:59
-msgid "Peasant"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:59 ../fheroes2/resource/maps_text.cpp:501
-msgid "Peasants"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Archer"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Archers"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Ranger"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Rangers"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Pikeman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Pikemen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Veteran Pikeman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Veteran Pikemen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Swordsman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Swordsmen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Master Swordsman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Master Swordsmen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Cavalry"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Cavalries"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Champion"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Champions"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Paladin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Paladins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:69
-msgid "Crusader"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:69
-msgid "Crusaders"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Goblin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Goblins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orc"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orcs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chief"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chiefs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Wolf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Wolves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogre"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogres"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Ogre Lord"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Ogre Lords"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "Troll"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "Trolls"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "War Troll"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "War Trolls"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:80
-msgid "Cyclops"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:80
-msgid "Cyclopes"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Sprite"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Sprites"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Dwarf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Dwarves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Battle Dwarf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Battle Dwarves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druid"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druids"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druid"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druids"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorn"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorns"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:91
-msgid "Phoenix"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:91
-msgid "Phoenixes"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaur"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaurs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyle"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyles"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaur"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaurs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur King"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur Kings"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydra"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydras"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halfling"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halflings"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boar"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boars"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golem"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golems"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golem"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golems"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Roc"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Rocs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Mage"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Magi"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmage"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmagi"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:112
-msgid "Giant"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:112 ../fheroes2/resource/maps_text.cpp:293
-msgid "Giants"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titan"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titans"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:116
-msgid "Skeletons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummy"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummy"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampire"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampires"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lord"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lords"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Lich"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Liches"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Lich"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Liches"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogue"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogues"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomad"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomads"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghost"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghosts"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusa"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusas"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elementals"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:694
-msgid "buy"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:158
-msgid "Campaign Game"
-msgstr "Mode Campagne"
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "Error"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "This release is compiled without network support."
-msgstr ""
-
-#: ../fheroes2/resource/artifact.cpp:51
 msgid "Ultimate Book of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:51 ../fheroes2/resource/artifact.cpp:77
-#: ../fheroes2/resource/artifact.cpp:78 ../fheroes2/resource/artifact.cpp:79
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "The %{name} increases your knowledge by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:52
 msgid "Ultimate Sword of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:52 ../fheroes2/resource/artifact.cpp:68
-#: ../fheroes2/resource/artifact.cpp:71 ../fheroes2/resource/artifact.cpp:74
-#: ../fheroes2/resource/artifact.cpp:75 ../fheroes2/resource/artifact.cpp:149
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "The %{name} increases your attack skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:53
 msgid "Ultimate Cloak of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:53 ../fheroes2/resource/artifact.cpp:70
-#: ../fheroes2/resource/artifact.cpp:73 ../fheroes2/resource/artifact.cpp:76
 msgid "The %{name} increases your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:54
 msgid "Ultimate Wand of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:54 ../fheroes2/resource/artifact.cpp:59
-#: ../fheroes2/resource/artifact.cpp:60 ../fheroes2/resource/artifact.cpp:61
-#: ../fheroes2/resource/artifact.cpp:62 ../fheroes2/resource/artifact.cpp:148
 msgid "The %{name} increases your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:55
 msgid "Ultimate Shield"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:55 ../fheroes2/resource/artifact.cpp:128
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "The %{name} increases your attack and defense skills by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:56
 msgid "Ultimate Staff"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:56 ../fheroes2/resource/artifact.cpp:130
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "The %{name} increases your spell power and knowledge by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "Ultimate Crown"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "The %{name} increases each of your basic skills by %{count} points."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "Golden Goose"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "The %{name} brings in an income of %{count} gold per turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:59
 msgid "Arcane Necklace of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:60
 msgid "Caster's Bracelet of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:61
 msgid "Mage's Ring of Power"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:62
 msgid "Witch's Broach of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:63
 msgid "Medal of Valor"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:63 ../fheroes2/resource/artifact.cpp:64
-#: ../fheroes2/resource/artifact.cpp:65 ../fheroes2/resource/artifact.cpp:66
 msgid "The %{name} increases your morale."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:64
 msgid "Medal of Courage"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:65
 msgid "Medal of Honor"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:66
 msgid "Medal of Distinction"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "Fizbin of Misfortune"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "The %{name} greatly decreases your morale by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:68
 msgid "Thunder Mace of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "Armored Gauntlets of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "The %{name} increase your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:70
 msgid "Defender Helm of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:71
 msgid "Giant Flail of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "Ballista of Quickness"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "The %{name} lets your catapult fire twice per combat round."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:73
 msgid "Stealth Shield of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:74
 msgid "Dragon Sword of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:75
 msgid "Power Axe of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:76
 msgid "Divine Breastplate of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:77
 msgid "Minor Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:78
 msgid "Major Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:79
 msgid "Superior Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "Foremost Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:81
 msgid "Endless Sack of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:81 ../fheroes2/resource/artifact.cpp:82
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "The %{name} provides you with %{count} gold per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:82
 msgid "Endless Bag of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "Endless Purse of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:84
 msgid "Nomad Boots of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:84 ../fheroes2/resource/artifact.cpp:85
 msgid "The %{name} increase your movement on land."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:85
 msgid "Traveler's Boots of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:86
 msgid "Lucky Rabbit's Foot"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:86 ../fheroes2/resource/artifact.cpp:87
-#: ../fheroes2/resource/artifact.cpp:88 ../fheroes2/resource/artifact.cpp:89
 #, fuzzy
 msgid "The %{name} increases your luck in combat."
 msgstr "La statue augmente les recettes de votre ville de 250 par jour."
 
-#: ../fheroes2/resource/artifact.cpp:87
 msgid "Golden Horseshoe"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:88
 msgid "Gambler's Lucky Coin"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:89
 msgid "Four-Leaf Clover"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "True Compass of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "The %{name} increases your movement on land and sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "Sailor's Astrolabe of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:91
 #, fuzzy
 msgid "The %{name} increases your movement on sea."
 msgstr "La statue augmente les recettes de votre ville de 250 par jour."
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "Evil Eye"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "The %{name} reduces the casting cost of curse spells by half."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "Enchanted Hourglass"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "The %{name} extends the duration of all your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "Gold Watch"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "The %{name} doubles the effectiveness of your hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "Skullcap"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "The %{name} halves the casting cost of all mind influencing spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "Ice Cloak"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "The %{name} halves all damage your troops take from cold spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "Fire Cloak"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "The %{name} halves all damage your troops take from fire spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "Lightning Helm"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "The %{name} halves all damage your troops take from lightning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid "Evercold Icicle"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid ""
 "The %{name} causes your cold spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid "Everhot Lava Rock"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid ""
 "The %{name} causes your fire spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid "Lightning Rod"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid ""
 "The %{name} causes your lightning spells to do %{count} percent more damage "
 "to enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "Snake-Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "The %{name} halves the casting cost of all your bless spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid "Ankh"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid ""
 "The %{name} doubles the effectiveness of all your resurrect and animate "
 "spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "Book of Elements"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "The %{name} doubles the effectiveness of all your summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "Elemental Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "The %{name} halves the casting cost of all summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "Holy Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "The %{name} makes all your troops immune to curse spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "Pendant of Free Will"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "The %{name} makes all your troops immune to hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "Pendant of Life"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "The %{name} makes all your troops immune to death spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "Serenity Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "The %{name} makes all your troops immune to berserk spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "Seeing-eye Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "The %{name} makes all your troops immune to blindness spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "Kinetic Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "The %{name} makes all your troops immune to paralyze spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "Pendant of Death"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "The %{name} makes all your troops immune to holy spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "Wand of Negation"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "The %{name} protects your troops from the Dispel Magic spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid "Golden Bow"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid ""
 "The %{name} eliminates the %{count} percent penalty for your troops shooting "
-"past obstacles. (e.g. castle walls)"
+"past obstacles (e.g. castle walls)."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid "Telescope"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid ""
 "The %{name} increases the amount of terrain your hero reveals when "
 "adventuring by %{count} extra square."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid "Statesman's Quill"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid ""
 "The %{name} reduces the cost of surrender to %{count} percent of the total "
 "cost of troops you have in your army."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "Wizard's Hat"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "The %{name} increases the duration of your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "Power Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "The %{name} returns %{count} extra power points/turn to your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "Ammo Cart"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "The %{name} provides endless ammunition for all your troops that shoot."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "Tax Lien"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "The %{name} costs you %{count} gold pieces/turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "Hideous Mask"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "The %{name} prevents all 'wandering' armies from joining your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "Endless Pouch of Sulfur"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "The %{name} provides %{count} unit of sulfur per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "Endless Vial of Mercury"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "The %{name} provides %{count} unit of mercury per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "Endless Pouch of Gems"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "The %{name} provides %{count} unit of gems per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "Endless Cord of Wood"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "The %{name} provides %{count} unit of wood per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "Endless Cart of Ore"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "The %{name} provides %{count} unit of ore per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "Endless Pouch of Crystal"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "The %{name} provides %{count} unit of crystal/day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:128
 msgid "Spiked Helm"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "Spiked Shield"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:130
 msgid "White Pearl"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "Black Pearl"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "Magic Book"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "The %{name} enables you to cast spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "Spell Scroll"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid "Arm of the Martyr"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid ""
 "The %{name} increases your spell power by %{count} but adds the undead "
 "morale penalty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "Breastplate of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "The %{name} increases your defense by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid "Broach of Shielding"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid ""
 "The %{name} provides %{count} percent protection from Armageddon and "
 "Elemental Storm, but decreases spell power by 2."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid "Battle Garb of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid ""
 "The %{name} combines the powers of the three Anduran artifacts.  It provides "
 "maximum luck and morale for your troops and gives you the Town Portal spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid "Crystal Ball"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid ""
 "The %{name} lets you get more specific information about monsters, enemy "
 "heroes, and castles nearby the hero who holds it."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid "Heart of Fire"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid ""
 "The %{name} provides %{count} percent protection from fire, but doubles the "
 "damage taken from cold."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid "Heart of Ice"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid ""
 "The %{name} provides %{count} percent protection from cold, but doubles the "
 "damage taken from fire."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:148
 msgid "Helmet of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:149
 msgid "Holy Hammer"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "Legendary Scepter"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "The %{name} adds %{count} points to all attributes."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "Masthead"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "The %{name} boosts your luck and morale by %{count} each in sea combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "Sphere of Negation"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "The %{name} disables all spell casting, for both sides, in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "Staff of Wizardry"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "The %{name} boosts your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "Sword Breaker"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "The %{name} increases your defense by %{count} and attack by 1."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "Sword of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "Spade of Necromancy"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "The %{name} gives you increased necromancy skill."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:638
 msgid ""
 "You find an elaborate aontainer which housesan old vellum scroll. The runes "
 "on the container are very old, and the artistry with whitch it was put "
@@ -6803,7 +5487,6 @@ msgid ""
 "magical power."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:639
 msgid ""
 "One of the less intelligent members of your party picks up an arm off of the "
 "ground. Despite its missing a body, it is still moving. Your troops find the "
@@ -6812,7 +5495,6 @@ msgid ""
 "making."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:640
 msgid ""
 "You come upon a sign. It reads: \"Here lies the body of Anduran. Bow and "
 "swear fealty, and you shall be rewarded.\" You decide to do as it says. As "
@@ -6820,21 +5502,18 @@ msgid ""
 "that you are suddenly wearing a gleaming, ornate breastplate."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:641
 msgid ""
 "A kindly Sorceress thinks that your army's defenses could use a magical "
 "boost. She offers to enchant the Broach that you wear on your cloak, and you "
 "accept."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:642
 msgid ""
 "Out of pity for a poor peasant, you purchase a chest of old junk they are "
 "hawking for too much gold. Later, as you search through it, you find it "
 "contains the 3 pieces of the legendary battle garb of Anduran!"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:643
 msgid ""
 "You come upon a caravan of gypsies who are feasting and fortifying their "
 "bodies with mead. They call you forward and say \"If you prove that you can "
@@ -6843,7 +5522,6 @@ msgid ""
 "Crystal Ball."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:644
 msgid ""
 "You enter a recently burned glade and come upon a Fire Elemental sitting "
 "atop a rock. It looks up, its flaming face contorted in a look of severe "
@@ -6851,7 +5529,6 @@ msgid ""
 "it, but it passes right through them and sears itself into your chest."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:645
 msgid ""
 "Suddenly, a biting coldness engulfs your body. You seize up, falling from "
 "your horse. The pain subsides, but you still feel as if your chest is "
@@ -6860,7 +5537,6 @@ msgid ""
 "woods and disappear."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:646
 msgid ""
 "You spy a gleaming object poking up out of the ground. You send a member of "
 "your party over to investigate. He comes back with a golden helmet in his "
@@ -6868,7 +5544,6 @@ msgid ""
 "only man who was known to wear solid gold armor."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:647
 msgid ""
 "You come upon a battle where a Paladin has been mortally wounded by a group "
 "of Zombies. He asks you to take his hammer and finish what he started.  As "
@@ -6876,7 +5551,6 @@ msgid ""
 "Zombies lie dead, the hammer dripping with blood. You strap it to your belt."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:648
 msgid ""
 "Upon cresting a small hill, you come upon a ridiculous looking sight. A "
 "Sprite is attempting to carry a Scepter that is almost as big as it is. "
@@ -6885,7 +5559,6 @@ msgid ""
 "flying anyway.\""
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:649
 msgid ""
 "An old seaman tells you a tale of an enchanted masthead that he used in his "
 "youth to rally his crew during times of trouble. He then hands you a faded "
@@ -6893,14 +5566,12 @@ msgid ""
 "underneath a nearby dock."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:650
 msgid ""
 "You stop to help a Peasant catch a runaway mare. To show his gratitude, he "
 "hands you a tiny sphere. As soon as you grasp it, you feel the magical "
 "energy drain from your limbs..."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:651
 msgid ""
 "While out scaring up game, your troops find a mysterious staff levitating "
 "about three feet off of the ground. They hand it to you, and you notice an "
@@ -6908,13 +5579,11 @@ msgid ""
 "words, and you'll win every fight.\""
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:652
 msgid ""
 "A former Captain of the Guard admires your quest and gives you the enchanted "
 "Sword Breaker that he relied on during his tour of duty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:653
 msgid ""
 "A Troll stops you and says: \"Pay me 5,000 gold, or the Sword of Anduran "
 "will slay you where you stand.\" You refuse. The troll grabs the sword "
@@ -6923,4466 +5592,84 @@ msgid ""
 "sharp objects."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:654
 msgid ""
 "A dirty shovel has been thrust into a dirt mound nearby. Upon investigation, "
 "you discover it to be the enchanted shovel of the Gravediggers, long thought "
 "lost by mortals."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:896
 msgid ""
-"Do you want to use your knowledge of magical secrets to transcribe the %"
-"{spell} Scroll into your spell book?\n"
-"The Scroll will be consumed.\n"
-" Spell point: %{sp}"
+"Do you want to use your knowledge of magical secrets to transcribe the "
+"%{spell} Scroll into your Magic Book?\n"
+"The Spell Scroll will be consumed.\n"
+" Cost in spell points: %{sp}"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:960
-msgid "Open book"
+msgid "Transcribe Spell Scroll"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:965
-msgid "Transcribe scroll"
-msgstr ""
+#, fuzzy
+msgid "View Spells"
+msgstr "Stats du meilleur Héro :"
 
-#: ../fheroes2/resource/artifact.cpp:975
-#: ../fheroes2/resource/artifact.cpp:1008
+#, fuzzy
+msgid "View %{name} Info"
+msgstr "voir %{name}"
+
 #, fuzzy
 msgid "Move %{name}"
 msgstr "voir %{name}"
 
-#: ../fheroes2/resource/artifact.cpp:998
 #, fuzzy
 msgid "Cannot move artifact"
 msgstr "Impossible de déplacer la dernière armée dans la garnison"
 
-#: ../fheroes2/resource/maps_text.cpp:15
-msgid ""
-"425 bottles of beer on the wall, 425 bottles of beer! If one of those "
-"bottles should happen to fall, there'll be..."
+msgid "This item can't be traded."
 msgstr ""
 
-#: ../fheroes2/resource/maps_text.cpp:16
-msgid "A balanced scenario with lots of resources and land to explore."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:17
-msgid ""
-"A bandit army of gorgons jump you without warning.  they stone your entire "
-"army demand 500 gold before they will release your comrads.  Realizing that "
-"it is much cheeper to pay then rebuild your army you part with the gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:18
-msgid "Abandon All Hope!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:19
-msgid "Abandon All Hope Ye That Enter Here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:20
-msgid "A bit of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:21
-msgid "A bit of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:22
-msgid "A bit of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:23
-msgid ""
-"Above you looms the ancient Ice Palace.  Dimly remembered myth speaks of a "
-"Prince who rejected the advances of the Winter Goddess, and thus he and his "
-"domain were cursed to remain shrouded in ice, hidden in a forgotten corner "
-"of the world.  It is said that he can only be rescued by a hero who is both "
-"clever and bold.  Are you that one?  Do you dare enter this frozen domain?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:24
-msgid "A cache of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:25
-msgid "A cache of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:26
-msgid "A cache of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:27
-msgid "A cache of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:28
-msgid "A cache of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:29
-msgid ""
-"A chance to end a bitter war has finally arrived as a new resource-laden "
-"land has been discovered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:30
-msgid "A chunk of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:31
-msgid "A chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:32
-msgid "A couple of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:33
-msgid "\"Act of Desperation\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:34
-msgid ""
-"A desert isle rich in resources rewards the quick.  Just be sure to watch "
-"your back!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:35
-msgid "A dolphin playfully jumps into the air."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:36
-msgid ""
-"A Dragon, A Cyclops, or an Undead. King of the Centaurs, His name is ....?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:37
-msgid "A flight of dragons circles overhead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:38
-msgid "A flock of seagulls circle overhead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:39
-msgid "A friendly dolphin splashes alongside the ship."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:40
-msgid ""
-"After a long search of the island, I have discovered that there is no way "
-"for me to escape without help.  I can not steal a ship from one of the "
-"coastal castles, and I dare not venture into the desert unless I wish to "
-"become Dragon food.  Should anyone find this, I beg of you, please send a "
-"ship and get me off this cursed island!  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:41
-msgid ""
-"After centuries of friendship, the Wizards have suddenly decided to stop "
-"sharing their Library with the rest of the world.  This can't be good!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:42
-msgid ""
-"After many years of peace, you discover that your sworn enemy from across "
-"the sea has chosen to invade your homeland by raising up the ocean floor to "
-"bridge the distance! You must not let them gain a foothold on this "
-"continent, in fact, your King has ordered you to establish a foothold on "
-"theirs!  To make matters worse, two of your OWN towns have thrown in their "
-"lots with the enemy..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:43
-msgid ""
-"After you return from a scouting trip, your Seneschal hurries to greet you.  "
-"\"My Lord, in your absence I signed an agreement in your name with a Master "
-"Merchant.  If we supply him with the resources he needs, through trading, he "
-"can return the resources to us in a week or so, plus some additional ones."
-"\"  The Seneschal eyes you anxiously.  You hesitate, then nod slowly, "
-"\"Good, we can use more resources>\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:44
-msgid "A ghostly pirate ship appears and sails on by."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:45
-msgid ""
-"A Gift from your King, and a note that reads \"Use these resources wisely, "
-"It's all we have left\"."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:46
-msgid ""
-"A gift of gold, m'lord, from the people of Enroth, to the people of Enroth.  "
-"Good luck, and may God save true King Roland!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:47
-msgid "A glint by a tree catches your eye..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:48
-msgid "A gold cache!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:49
-msgid "A gold chunk!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:50
-msgid "A gold nugget!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:51
-msgid ""
-"A great Black dragon stands before you. It speaks in a suprisingly soft "
-"voice, saying, \"The elves believe they have sent another hero to reclaim "
-"their prize. I believe they have sent me another meal.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:52
-msgid ""
-"A group of peasant farmers approaches you, \"We are in dire need of your "
-"assistance.  Our castle to the north has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:53
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance.  Our castle to the east has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:54
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance. Our castle to the east has been overrun and our Lord killed. "
-"Please help us regain our homes! There are still women and children there! "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:55
-msgid ""
-"A group of peasant farmers approach you, We are in dire need of your "
-"assistance.  Our castle to the northeast has been overrun and our Lord "
-"killed.  Please help us regain our homes!  There are still women and "
-"children there!  Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:56
-msgid "A handful of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:57
-msgid ""
-"Ah, you stumble across something buried in the sand.  As you dig it up you "
-"discover a small pile of gems and crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:58
-msgid ""
-"A Knight and Necromancer team up against the Barbarian and Sorceress. (Blue "
-"and Green vs Red and Yellow)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:60
-msgid ""
-"A large contingent of the king's guard approaches you.  \"Ahh, we have "
-"finally caught up to you.  The king requires tribute from all of his vassals "
-"and you have been negligent far too long.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:61
-msgid ""
-"A large map with lots of resources and treasure. Exploration and victory "
-"will require many heroes."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:62
-msgid "A legion of peasants stands between you and this unclaimed island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:63
-msgid "Algary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:64
-msgid "A little bit closer..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:65
-msgid "All mines are grouped by type. Trade is your only hope."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:66
-msgid "A lump of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:67
-msgid "A lump of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:68
-msgid "A lump of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:69
-msgid ""
-"A man appears from behind the sand dune. \"At last,\" he says, \"Someone has "
-"come to rescue me! I am forever grateful. Alas all I have to offer you in "
-"return are these souvenirs from my wrecked ship.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:70
-msgid ""
-"A man is laying on the ground, near death. He looks to you and speaks, "
-"\"Please help my companions! Please... they can't...cough...get away from..."
-"cough...the drag...\" With that, he dies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:71
-msgid ""
-"A merchant caravan arrives, bringing gold and supplies, however, no one can "
-"seem to remember where they came from.  You silently praise this anonymous "
-"benefactor and continue your duties."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:72
-msgid "a mirror"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:73
-msgid "An albatross flies ahead of the ship for a while"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:74
-msgid "Anduran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:75
-msgid ""
-"An enemy from across the sea has seized half your towns.  Can you put aside "
-"your own feud with your brother to fight this common enemy?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:76
-msgid "\"Annexation\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:77
-msgid ""
-"An old elf is sitting on a rock in a glen, pounding on the shackles on his "
-"feet with a stone. You help him remove them and ask him his tale. \"I'm a "
-"deserter from Drakonia's army. She has enslaved all the elves to support her "
-"madness. She must be stopped.\" Then he slips into the woods without a "
-"sound, leaving behind just his cloak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:78
-msgid "Antioch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:79
-msgid "A piece of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:80
-msgid "A pile of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:81
-msgid "A pile of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:82
-msgid "A pile of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:83
-msgid ""
-"A plague of undead is upon us. Who will unite the living against the dead?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:84
-msgid "\"Apocalypse\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:85
-msgid "A quantity of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:86
-msgid "A quantity of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:87
-msgid "A quantity of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:89
-msgid ""
-"Archibald has also sent an army to find the Crown, you must find it first or "
-"all is lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:90
-msgid "Archibald is hiding at the end of the river."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:91
-msgid ""
-"A resource rich valley keeps the Wizard and the Necromancer apart. Your "
-"opponent's army will arrive in 3 months so hurry."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:92
-msgid "Arm of the Crusader"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:93
-msgid "Arm of the Cyclops"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:94
-msgid "Arm of the Dragon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:95
-msgid "Arm of the Phoenix"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:96
-msgid "Arm of the Titan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:97
-msgid "Arr' Here be pirates gold buried."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:98
-msgid "A shipment of wood has arrived from your kingdom!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:99
-msgid ""
-"A splash in the seaweed alerts you to a mermaid waving in a friendly manner. "
-"\"Oh, I thought you were Ahab.\" She is surprised, but quickly composes "
-"herself. \"Well, if you meet him, give him these treasures I have collected."
-"\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:100
-msgid "Assassins tried to kill our ally."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:101
-msgid "Astircaer"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:102
-msgid ""
-"A stranded Wizard with only a small force must conquer an entire continent "
-"of hostile forces."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:103
-msgid ""
-"A supply ship has arrived from the homeland!  You send word home that all is "
-"well."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:104
-msgid ""
-"As you approach the barrier, you see the old elf you helped free. This time, "
-"however, you see that he is wearing a cape of fine weave, and a wooden crown "
-"is on his head. He sees your forces, and says \"Take this sword, and with "
-"it, strike down Drakonia and help free my people.\" The old elf then strides "
-"regally into the woods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:105
-msgid ""
-"As you approach the gates of the Ice Palace, one of your troops points in "
-"terror.  You watch in awe as great slabs of ice separate from the castle "
-"walls with loud cracking reports and crash to the ground.  Soon the ice is "
-"gone and the sun begins to peak through the gloom.  The deathly silence that "
-"must have ruled these lands for centuries ends as birds begin to sing.  From "
-"inside you hear the sounds of life."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:106
-msgid ""
-"As you approach the tent, the leader of the nomads comes out to greet you. "
-"He says, \"It was prophecied many years ago that a great hero would come to "
-"greet us in our sacred valley, and we would prosper afterwords. Now it has "
-"come to pass, and we offer you these gifts as tokens of our thanks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:107
-msgid ""
-"As you approach,  you hear whispered mentions of \"the wild barbarian who "
-"passed this way months before\". One of the villagers approaches you and "
-"hands you an object, saying \"The wild one dropped this. You must be his "
-"kin. Therefore I give it to you. But beware! Many in the village will not be "
-"as friendly as I.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:108
-msgid ""
-"As you break your fast your sage rushes in, \"Good news, my lord!  I have "
-"translated the message.  Two great heroes were imprisoned many years ago.  "
-"They lie sleeping - still guarded by magic barriers and monsters.  My lord, "
-"they lie nearby- in between our ally and us.  If we could free them, they "
-"would surely aid us against our enemies!  The password to the first magic "
-"barrier can be learned at the Aqua Traveller's Tent.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:109
-msgid ""
-"As you enter the small clearing, you see a familiar figure talking to a "
-"group of halflings and soldiers. You stay awhile and listen to his speech. "
-"\"The time to throw off these chains of tyranny is now! We must strike at "
-"the heart of her empire, and destroy the evil that she has brought to our "
-"land.\" As the old elf finishes speaking, he gets up from his mossy seat and "
-"once again, blends into the woods with incredible grace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:110
-msgid ""
-"As you lay down to nap after a long battle, you notice a lucky four-leaf "
-"clover."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:111
-msgid ""
-"As you make  your way through the last of the golemn debris, a group of "
-"halflings runs towards you carrying fruit and flowers. \"Thank you so much!"
-"\" Their leader exclaims, \"We've been trapped in here for ever! Come by our "
-"homes, we'll pack up and go with you!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:112
-msgid ""
-"As you make your way to the shrine, some very thin and hollow-eyed men come "
-"out of the flower patch and stare at you.  Seeing that you want the gold, "
-"one of them says to you \"Hey, man, if you're, like, so lusty for earthly "
-"wealth, then, like, have this too.\" You graciously take what they have "
-"offered and back out of the clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:113
-msgid ""
-"As you prepare your lands to fight the onslaught from the South, a curious "
-"message appears on your table in the Great Hall of your Castle.  Written in "
-"some ancient language, none but your sage can make any sense of it.  She "
-"promises to have the words deciphered by tomorrow..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:114
-msgid "A three hour tour, a three hour tour..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:115
-msgid ""
-"A tiny gnome points to a chunk of crystal you otherwise would have "
-"overlooked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:116
-msgid "Atlantium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:117
-msgid ""
-"At last, the king is dead.  For years you have planned his demise, but now "
-"it is done, and there is no heir to take his place, though the Knights to "
-"the south believe that they are the rightful successors.  A wealth in wood "
-"(to the south) and ore (in the northern mountains) provides you with trade "
-"goods, and your isolation has allowed you to prepare your forces of darkness "
-"for this day.  Go, now, and fulfill your destiny!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:118
-msgid ""
-"At the base of the mountain you see something that glitters.   You discover "
-"an ancient pile of offerings to the gods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:119
-msgid "Avalon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:120
-msgid "Avone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:121
-msgid ""
-"A wild magic has allowed a bridge to form between two lands...  Your one "
-"hope is to capture castle \"Black Fang\"."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:122
-msgid "Barbarian's castle lies to the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:123
-msgid ""
-"Barbarians from the north threaten all civilization. Can you repel the "
-"hordes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:124
-msgid "\"Barbarian Wars\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:125
-msgid "Barrowton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:126
-msgid "Basenji"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:127
-msgid "Bayside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:128
-msgid "Baywatch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:129
-msgid ""
-"Because the Darkscale Valley is so barren, the Emperor will be sending wood "
-"to you every week. Use it wisely, for it is all you shall have."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:130
-msgid ""
-"Before questing for the orb of negation, you must first crush the local "
-"opposition. After the Sorceresses are removed from the earth, go east where "
-"legend says the orb lies.  You may expect a convoy of supplies in a week or "
-"so to aid your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:131
-msgid ""
-"Before you may pass, the spirit guardian of this valley demands tribute."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:132
-msgid "Being held...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:133
-msgid "Beltway"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:134
-msgid "\"Betrayal!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:135
-msgid "Beware -- Entering Hyrda Country"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:136
-msgid "Beware for whom the bell trolls."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:137
-msgid "Beware of Pirates!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:138
-msgid "Beware of thieves!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:139
-msgid "Beware of traps ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:140
-msgid "Beware of Warlocks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:141
-msgid "Beware the deadly swamps!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:142
-msgid "Beware the Domain of Dragons"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:143
-msgid "Beware the Dragon Leader"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:144
-msgid "Beware the edge of the world!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:145
-msgid "Beware the moors and stick to the roads."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:146
-msgid "Beware the rocks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:147
-msgid "Beware the sirens!!!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:148
-msgid "Beware the sirens!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:149
-msgid "Beware the whiporwill..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:150
-msgid "Beware, the whirlpool may not take you into a friendly embrace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:151
-msgid "Beyond here be Dragons!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:152
-msgid "Beyond the door, there be Dragons. BEWARE!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:153
-msgid "Big Oak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:154
-msgid "Blackburn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:155
-msgid "Blackfang"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:156
-msgid "Black Fang"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:157
-msgid "Black Oak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:158
-msgid "Blackridge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:159
-msgid "Blacksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:160
-msgid "Black Vein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:161
-msgid "Blackwind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:162
-msgid "Bloodreign"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:163
-msgid "Boats my be needed to access some parts of this peninsula."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:164
-msgid "Boats Sold Here            Inquire Within"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:165
-msgid "BoneVille"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:166
-msgid "Borderlands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:167
-msgid "Bridge out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:168
-msgid "Bridge Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:169
-msgid "Brindamoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:170
-msgid "Broken Alliance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:171
-msgid "Brownston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:172
-msgid "Buried Treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:173
-msgid "Burlock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:174
-msgid "Burton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:175
-msgid ""
-"Capture the necromancer's dreaded castle \"Death Gate\" and free the land "
-"from the undead plague."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:176
-msgid ""
-"Capture the town on the island off the southeast shore in order to construct "
-"a boat and travel back towards the mainland."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:177
-msgid "\"Carator Mines\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:178
-msgid "Cathcart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:180
-msgid "Chandler"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:181
-msgid "Chilton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:182
-msgid "Chronos"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:183
-msgid "Come and...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:184
-msgid ""
-"Compared to the rest of the villages in this land, this village seems grand, "
-"but in any other land it would seem poor. From here you can see the tall "
-"spires of the Warlock's tower of Dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:185
-msgid "Complete"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:186
-msgid "Condemned!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:187
-msgid ""
-"Congratulations! After navigating the treacherous coast, you have "
-"established trade between the north and south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:188
-msgid "Corackston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:189
-msgid "Corlagon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:190
-msgid "\"Country Lords\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:191
-msgid "Crossroads"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:192
-msgid "Crossroads North"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:193
-msgid "Crossroads South"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:195
-msgid "Danger a whirlpool destroyed my ship."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:196
-msgid "Danger, Dragons abound!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:197
-msgid "DANGER!  QUICKSAND!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:198
-msgid "Danger! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:199
-msgid "Danger - Turn Back Now"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:200
-msgid "Dark clouds loom overhead as you enter this valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:201
-msgid "Dead Pine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:202
-msgid ""
-"Dear Diary,                           I found a mermaid today.  She was "
-"floating in a patch of seaweed next to a rock.  A very friendly sort of "
-"creature too!  Gave me all sorts of lovely gems and jewelry!  She said to "
-"come back again sometime for more of the sea riches.  Wow. Ahab"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:203
-msgid "Deathgate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:204
-msgid "DeathGate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:205
-msgid "Decisions"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:206
-msgid "\"Defender\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:207
-msgid ""
-"Destroy the Barbarians who are attacking the southern border of your "
-"kingdom! Recover your towns and then invade the jungle kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:208
-msgid ""
-"Detour! Mountain pass to the East has been known to have avalanches! For "
-"your own safety, follow the road South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:209
-msgid "Detour! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:211
-msgid "DirtWater"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:212
-msgid "Dominion"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:213
-msgid "Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:214
-msgid "Do not remove coins from fountain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:215
-msgid "Dragadune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:216
-msgid "Dragonburg"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:218
-msgid "Dragon City lies beyond the Scorpion Hills."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:219
-msgid "Dragon Hill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:220
-msgid "\"Dragon Master\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:221
-msgid "Dragon Rider"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:222
-msgid "Dragons Everywhere!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:223
-msgid "Dragon's Eye"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:224
-msgid "Dragontooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:225
-msgid "Dragon Town"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:226
-msgid "Dragonville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:227
-msgid "Dragon Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:228
-msgid "Dragon Watch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:230
-msgid "Drakoran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:231
-msgid "Dwarfhall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:232
-msgid "Dwarfhall, Domain of the dwarf King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:233
-msgid "Dwarf Hall, domain of the dwarf King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:234
-msgid "Eatio"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:235
-msgid "Edgewood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:236
-msgid "Elk's Head"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:237
-msgid "Elowyn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:238
-msgid "Enroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:239
-msgid "Entering high in the desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:240
-msgid "Entering Praires of the Middlelands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:241
-msgid "Entering the desert high"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:242
-msgid "Entering the high desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:243
-msgid "Entering the higher desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:244
-msgid "Entering the Valley of Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:245
-msgid "Erliquin"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:246
-msgid "Evil Igor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:247
-msgid "Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:248
-msgid "Fantasy Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:249
-msgid "Farlien"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:250
-msgid ""
-"Federal express, when it absolutely positively has to be there turn one."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:251
-msgid "fedx comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:252
-msgid "Fedx for comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:253
-msgid "Fenton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:254
-msgid "Fetid Elm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:255
-msgid ""
-"Final message from Overlord. \"The royal executioners are on their way. My "
-"gold, the land or your head- it's your choice.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:256
-msgid "Find and defeat the Pirate Leader!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:257
-msgid "Find and destroy the evil beings who rule the wastelands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:258
-msgid "Find the center island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:259
-msgid ""
-"Find the Ultimate Artifact and be proclaimed King, or smash the opposition "
-"and take control."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:260
-msgid ""
-"Find Your Wayward Son who is rumored to be living in the desolate lands. Do "
-"it within 8 weeks or it will be of no help to your family."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:261
-msgid "Fire King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:262
-msgid "\"First Blood\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:263
-msgid "Five heroes vie for control of a familiar land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:264
-msgid "Fool's Gold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:265
-msgid ""
-"For a total of 400,000 gold your opponents will become \"loyal\" subjects, "
-"otherwise... let them eat cake!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:266
-msgid ""
-"For centuries, the Wizards of the North have maintained a vast library for "
-"all the world to share.  Now, however, they have closed their doors, and "
-"issued declarations of war to each of the other rulers of the land.  To make "
-"matters worse, rather than ally with you to face the Wizards, each of the "
-"others have decided to go forth on their own in an effort to conquer this "
-"land for themselves!  Prepare your forces, commander, for you now stand "
-"alone."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:267
-msgid "\"Force of Arms\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:268
-msgid ""
-"For decades you have studied, learned, and allowed yourself to be ruled by "
-"that pitiful excuse for a king, knowing that one day the time would come for "
-"you to sit on the throne.  That time is now, for the king is dead and "
-"without an heir.  You have the advantage of isolation from the rest of the "
-"kingdom, but beware the miles of coastline that could leave you vulnerable "
-"to attack.  Go, now, and wipe your enemies from this land!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:269
-msgid "Forder Oaks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:270
-msgid "Forestria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:271
-msgid "For Honor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:272
-msgid ""
-"For information about Ye Rich lands to the south, speak to Alponse at the "
-"Golden Goose Tavern. Excellent views, plentiful water."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:273
-msgid "Forsaken Lands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:274
-msgid "For sale."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:275
-msgid "Fortress Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:276
-msgid ""
-"For years, you have existed peacefully in the Forest of Dreams, knowing that "
-"your king was the kindest and strongest ruler the land had seen in "
-"centuries.  Now, however, his reign is at an end, and there is no heir to "
-"succeed him.  You realize that a power struggle is coming, and that you must "
-"brace yourself for war, and prevent those who would harm this land from "
-"coming into power!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:277
-msgid ""
-"For years, you've been able to keep your subjects \"appeased.\"  Now "
-"however, you discover not only that your entire kingdom has turned against "
-"you, but most of your outer towns have fallen to the different factions.  To "
-"make matters worse, all your gold suddenly seems to be missing from the "
-"treasury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:278
-msgid "Fountainhead"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:279
-msgid "Four kingdoms race to capture the island of Sharkania."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:280
-msgid "Four lakes have castles, three have treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:281
-msgid "Four players must work together to assault the Wizards' Stronghold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:282
-msgid "Frozenpeak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:283
-msgid "Full House"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:284
-msgid ""
-"Gain the aid of the elves. They will not allow trees to be chopped down, so "
-"we will send you wood every 2 weeks. You have 7 months!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:286
-msgid "Galveston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:287
-msgid "Garamok"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:288
-msgid "Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:289
-msgid "Gate to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:290
-msgid "Gate to The Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:291
-msgid "Gaurdian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:292
-msgid "Gavonshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:294
-msgid "Glastonbury"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:295
-msgid "Go away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:296
-msgid "GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:297
-msgid "Goblin Island"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:298
-msgid "Goblin King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:299
-msgid "Go Home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:300
-msgid "Go north to find the lost gold-mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:301
-msgid "Good vs. Evil"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:302
-msgid "Gorgomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:303
-msgid "\"Greater Glory\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:304
-msgid "Greed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:305
-msgid "Green bonus stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:306
-msgid "Green gets stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:307
-msgid "Greenroot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:308
-msgid "Green's Allowance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:309
-msgid "Green's Groceries"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:310
-msgid "green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:311
-msgid "Green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:312
-msgid "Greywind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:313
-msgid "Grim"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:314
-msgid "Grrr, Blazzer, Grrupt. Be gone with you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:315
-msgid "Guardian War"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:316
-msgid "Gungtooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:317
-msgid "Hail Unicorns!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:318
-msgid "Hampshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:319
-msgid "Have fun storming the castle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:320
-msgid "Havenwood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:321
-msgid "Hawkins"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:322
-msgid "Help!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:323
-msgid "Help me...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:324
-msgid ""
-"Help peasant farmers regain their castle and land, else they'll take your "
-"crops."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:325
-msgid "Hero's Hall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:326
-msgid ""
-"High in the snowy crags, you meet an old witch who, in return for a trinket "
-"of yours, gives you a powerful magical object she used to use as a footstool "
-"before she was exiled into the mountains by her own townspeople."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:327
-msgid "Hillstone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:328
-msgid "Hilltop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:329
-msgid "Hilltown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:330
-msgid "Horizon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:331
-msgid "Hot Spot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:332
-msgid "Hungry dragons await.  Welcome, food."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:333
-msgid "Hurry, no time to wait.  This way to the dock."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:334
-msgid "Hurry up! Few days are left before the enemy's army arrives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:335
-msgid "I am...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:336
-msgid ""
-"I am one of the few remaining survivors of the wrecked pleasure ship, "
-"Exhorbitance. I think we'll all be dead of hunger soon, for we are out of "
-"caviar. We ate the chef yesterday."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:337
-msgid "Ibn Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:338
-msgid "Ice Palace"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:339
-msgid "Ice Prince"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:340
-msgid "Icy lands ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:341
-msgid "I didn't do it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:342
-msgid ""
-"If three heroes could dig six holes in three days, how long would it take "
-"six heroes to dig twelve holes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:343
-msgid "If you free a hero, they may help..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:344
-msgid ""
-"If you value your lives, for God's sake, Don't go through this whirlpool!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:345
-msgid "Income for Yellow."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:346
-msgid "In the hole you find a chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:347
-msgid "In the stream you find an old compass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:348
-msgid "In this glen live some very naughty halflings. Stay Away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:349
-msgid ""
-"In two more weeks, if you have not located Joseph, your kingdom will surely "
-"lose its current battle with Harondale."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:350
-msgid "I see you, you see me."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:351
-msgid "Is it something I said? Go back and I will forget the whole thing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:352
-msgid "IslandHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:353
-msgid "Island of the Elves"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:354
-msgid "Island of the meek"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:355
-msgid "Island of Wolcott"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:356
-msgid "Isle Maze"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:357
-msgid "Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:358
-msgid ""
-"It has become apparent that if all your enemies were eliminated, you would "
-"have all the time you need to find the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:359
-msgid ""
-"It is obvious that the mage that once was here had won many battles!  There, "
-"upon his hand, is a most powerful ring!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:360
-msgid ""
-"It is rumored that a bridge of land used to exist between the two "
-"continents, but that a wild magic caused it to sink into the sea, taking "
-"with it all those who used to inhabit it.  To try to raise this bridge is to "
-"invite a curse upon the world!  The spirits of the dead will haunt us all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:361
-msgid ""
-"It is said that King Zealot found the gods' artifact once and it let him "
-"rule for 100 years."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:362
-msgid ""
-"It looks like there used to be an ore mine here but all you see now is a "
-"hole in the ground and some minerals scattered around."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:363
-msgid ""
-"It's a battle for supremacy as the Blue and Green heroes take on Red and "
-"Orange in team competition!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:364
-msgid "It's windy at the top.  Defend, Divide, and Conquer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:365
-msgid "IvanHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:366
-msgid "Ivan lives in the desert."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:367
-msgid "Ivory Gates"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:368
-msgid ""
-"I, Wilgatus, besiege you - do not fight me for I am all powerful and will "
-"destroy you if you persue me.  I will demonstrate my power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:369
-msgid "I Would Go That Way If I Were You."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:371
-msgid "Jarkonas VI"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:372
-msgid "Jolly Roger was here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:374
-msgid "Jungomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:375
-msgid "Just 30 days left!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:376
-msgid "Just ONE week left!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:378
-msgid "Kastor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:379
-msgid "Keep going south"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:380
-msgid "Keep Off The Grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:381
-msgid "Keep Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:382
-msgid "King John"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:383
-msgid "King of Death"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:384
-msgid "Knight's Trail."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:385
-msgid "Knight stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:386
-msgid "Lakeside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:387
-msgid "Land's Edge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:388
-msgid "Land teleporters will get you to your destination sooner."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:389
-msgid "Lankershire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:390
-msgid "Lavalor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:391
-msgid "Like, Stuff And Junk?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:392
-msgid ""
-"Living on the outskirts of the kingdom, you are considered an unwelcome "
-"outcast by the other leaders of the realm, though you always showed your "
-"support for the king.  Now, however, the king is dead, and many of those who "
-"spoke out againt him seek to seize his throne for themselves.  You have a "
-"vast desert at your back, rich with gems, and the advantage that many do not "
-"consider you a threat.  Go, now, and show them how wrong they are!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:393
-msgid "Lladner Dock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:394
-msgid ""
-"Log go up... Log go down... Log go up... Log go down...  OOoohhhhhhhh........"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:395
-msgid "Lombard"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:396
-msgid "Long live Roland the true King!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:397
-msgid "Long live Roland the true King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:398
-msgid "Look before you leap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:399
-msgid "Look out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:400
-msgid "Lord Alberon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:401
-msgid ""
-"Lord Alberon calls you into his war room. He says, \"I am glad you have "
-"chosen to remain loyal to me, but this war is a terrible one for my kingdom. "
-"Already, the sorceress' towns to the Northeast have become unsure about "
-"their loyalties, and will not pledge allegiance to either side. This is hard "
-"on our cities as most of the wood in the land comes from these towns. We "
-"will need to recover their sawmills and take their towns by force.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:402
-msgid "Lord Haart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:404
-msgid "Lord Kreager"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:405
-msgid ""
-"Lord, messages have begun pouring in from our spies in the other island "
-"courts.  They have learned of a new volcanic island with vast amounts of "
-"reasources.  Your Majesty, with these new reasources we could put an end to "
-"a century of war between the islands, and reunite them under your rightful "
-"rule."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:406
-msgid "Lost Continent"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:407
-msgid "Lost Gold- Mine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:408
-msgid "Lost Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:409
-msgid "Lost Relic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:410
-msgid "Maelstrom of Deceit"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:411
-msgid "Maelstrom of Misery"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:412
-msgid "Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:413
-msgid "Magic Three"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:414
-msgid ""
-"Many dust plumes rise from the floor of this small valley. You see various "
-"bands of nomads roaming about, and in the distant, the bright flames of "
-"their camp."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:415
-msgid ""
-"Many guardians stand between you and your enemies, but anybody can sneak "
-"through the back door!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:416
-msgid "Many that have gone through this door have never returned."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:417
-msgid ""
-"Many years ago, a couple of mages had a \"duel\" that forever changed the "
-"lake at the center of this continent.  Hearty adventurers might find "
-"interesting treasure there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:418
-msgid ""
-"Many years ago, a falling star crashed near here.  Only now the area is safe "
-"enough to explore.  Rumor has it a castle exist where the star fell."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:419
-msgid ""
-"Many years ago, your father, the King, died in a freak hunting accident.  "
-"Since then, you and your brother have jointly ruled his kingdom, but both of "
-"you have been seeking a way to seize the throne for yourself.  You got your "
-"wish.  Attackers from across the sea have captured more than half your towns "
-"and castles, effectively dividing the continent in two.  Now is the time to "
-"repel these invaders and do away with your brother once and for all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:420
-msgid "Marco"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:421
-msgid "Marsh Home"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:423
-msgid "Mayland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:424
-msgid "Meramec"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:425
-msgid "Message from Archibald. \" Do not dare to return without my Crown.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:426
-msgid ""
-"Message from Archibald. \" General, thank you for bringing me this lovely "
-"gift. I have decided to participate directly in the capture of my brother "
-"Roland. Since your military advice has taken us this far, I will follow your "
-"orders to the letter.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:427
-msgid "Message from Overlord. \"STILL WAITING FOR MY GOLD!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:428
-msgid "Message from Overlord. \"WHERE'S MY GOLD?\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:429
-msgid ""
-"Message from Roland. \"General, circumstances permit me to take a hand in "
-"the events of this final conflict. I have your spoils of war with me and I "
-"will follow your advice explicitly.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:430
-msgid ""
-"Message from Roland.  \"General, I have sent most of our troops and material "
-"ahead to the region of the final conflict with Archibald.  Unfortunately, "
-"Lord Corlagon has cut us off from the rest of our army.  I will be awaiting "
-"your victory in a castle across the west river.  I should be safe from "
-"attack.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:431
-msgid ""
-"Message from Roland. \" We cannot hope to defeat Archibald without the "
-"Crown, I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:432
-msgid "Middle Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:433
-msgid "Middleton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:434
-msgid "Middletown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:435
-msgid "Might vs. Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:436
-msgid "Mineral Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:437
-msgid "Mirkosov"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:438
-msgid "mirror"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:439
-msgid "Money For Red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:440
-msgid "MONEY, MONEY, MONEY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:441
-msgid "Morale becomes even lower as the endless cliffs move past."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:442
-msgid ""
-"More water than land, you'll still spend lots of time on foot as you search "
-"a literal horde of islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:443
-msgid "Mountain king"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:444
-msgid "Mountainview"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:445
-msgid "Mr Ed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:446
-msgid "Mr. Yellow's Income"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:447
-msgid "Murray's resort Isle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:448
-msgid ""
-"Mutiny!  The crew has dumped off my precious cargo into the sea!  Thank "
-"goodness it floats - when I've rid of them, I'll come back to pick it up!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:449
-msgid ""
-"My leige, our scouts report three other lords are attacking from the south. "
-"They work in conjuction with each other to eliminate us! We must keep this "
-"castle and remove the threat of the enemy. We wish you luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:450
-msgid ""
-"My leige, we have established a foothold (which we cannot afford to lose) "
-"and all of our Heroes have joined us. The king has made us the offer to "
-"purchase this land for 200,000 gold or we may take it by force. The local "
-"lords have been fighting and each wants to be the one that defeats us. Now "
-"all the local armies have arrived on the beach, creating a state of complete "
-"Pandemonium!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:451
-msgid "My Treasure Is Buried Beneath Three Palm Trees"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:452
-msgid "\"Necromancers!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:453
-msgid "New Dawn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:454
-msgid "New Enemies"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:455
-msgid "New Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:456
-msgid "Nightshadow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:457
-msgid "No Description"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:458
-msgid "No Fishing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:459
-msgid "No gems, crystal, or mercury for red."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:460
-msgid ""
-"None of the four leaders like being stuck in a land that has only one season."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:461
-msgid "NO, Not That Way. This Way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:462
-msgid "No one has ever made it out of the deadly swamps alive!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:463
-msgid "Noraston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:464
-msgid "North Road"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:465
-msgid "North vs. South"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:466
-msgid "No stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:467
-msgid "No sulfer fer Yella."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:468
-msgid "No swimming."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:469
-msgid "Notice- Those who put messages in bottles will be tortured."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:470
-msgid "No Trespassing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:471
-msgid "No tresspath...  No tree...  No thresh...  GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:472
-msgid "Now leaving Swamplands of the Eternial"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:473
-msgid "Obsidian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:474
-msgid "Of the necromancers...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:475
-msgid "Ogrehild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:476
-msgid "Olympus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:477
-msgid ""
-"One of the seers in your castle comes to you in the morning with urgent "
-"news. Your one time comrade, the wizard Joseph, and his armies have been "
-"imprisoned in a jail nearby. His power would surely aid you in your quest to "
-"reclaim the library, you think to yourself. Perhaps there is a way to rescue "
-"him..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:478
-msgid ""
-"One of your aides reports that the Castle of Farlien is located on the "
-"northeast spur of this island, and is a stronghold for the enemy. He urges "
-"you to take it out as soon as possible, and then move onto other islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:479
-msgid ""
-"One of your \"allies\" has joined Archibald.  You now face an opponent with "
-"three castles to your one.  Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:480
-msgid ""
-"One of your \"Allies\" has joined Roland. You are now facing three castles, "
-"all belonging to the enemy. Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:481
-msgid "One of your loyal goblins has brought you an armload of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:482
-msgid ""
-"One of your loyal subjects, a fairy tells you where to find a cache of "
-"mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:483
-msgid ""
-"One of your scouts reports a tiny cave nearby. Upon investigating, you "
-"discover a small cache of goods. In the dirt by them is etched 'Ivan'."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:484
-msgid ""
-"One of your troops stubs its paw on something buried here.  After a few "
-"hours of digging you unearth a cache of treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:485
-msgid "Only a month remains in which to find Joseph."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:486
-msgid "On quite days, Nubbie the sea monster can be seen!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:487
-msgid "Orange stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:488
-msgid "Orcville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:489
-msgid "Ostoroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:490
-msgid "Other than the dragons, the elves don't have any enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:491
-msgid "Our ally was greatly weakened when his resources were plundered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:492
-msgid "\"Our Finest Hour\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:493
-msgid "Our reinforcements were lost in a storm, we salvaged all we could!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:494
-msgid ""
-"Our spies have discovered that the barbarian hordes are now receiving "
-"support from kraeger! You must hurry and find the third piece before your "
-"forces here are crushed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:495
-msgid "Overlord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:496
-msgid "Pandemonium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:497
-msgid "Paper can gain you what wood and sail cannot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:498
-msgid "Password found by Crystals to the South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:499
-msgid "Peacekeeper"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:500
-msgid "\"Peasants!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:502
-msgid "Peasantsville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:503
-msgid "Perenor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:504
-msgid "Pet Cemetary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:505
-msgid "Pick one of four Knights in this large and inhospitable land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:506
-msgid "Pig's Eye"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:507
-msgid "Pinehurst"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:508
-msgid "Pirate Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:509
-msgid "Pirate's Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:510
-msgid "Pirate Utopia"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:511
-msgid "Pirites strike and take the gold from you holds."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:512
-msgid "Pixie"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:513
-msgid ""
-"Play the Knight or Barbarian in an alliance in this classic duel against the "
-"four spell casters. (Blue and Green vs Red)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:514
-msgid "Please...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:515
-msgid ""
-"Plenty of resources and lots of ground to cover. Watch out for Orange and "
-"Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:516
-msgid "Portals"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:517
-msgid "Portsmith"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:518
-msgid "POSION - DO NOT DRINK"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:519
-msgid "Powerful magic lies southwest of here in the Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:520
-msgid "Prisoner on...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:522
-msgid "Quick Silver"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:523
-msgid "Raste"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:524
-msgid "Realm of the Undead.  Fresh blood welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:525
-msgid "Red bonus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:526
-msgid "Red player sympathizes with the undead cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:527
-msgid "Red's Connection"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:528
-msgid "Redshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:529
-msgid "Red's Lunch Money"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:530
-msgid "Red's Rubles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:531
-msgid "Red stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:532
-msgid ""
-"Regrettably, you have no castle with which to begin your assault. "
-"Fortunately, however, Kraeger's forces are weak here in the south, and you "
-"have bribed a rebel necromancer to aid you in the beginning of your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:533
-msgid "Reinforcements have arrived, Gold from the homelands!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:534
-msgid ""
-"Remains of a long since dead wizard have attracted an ancient artifact.  "
-"This artifact has now attached itself to you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:535
-msgid ""
-"Remember, you're searching for the Ultimate Artifact... don't get distracted!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:536
-msgid ""
-"Rendall Koski was here. 1997.  Northampton, Massachusetts There is a "
-"powerful artifact in the southeastern corner of the world.  Go for it, "
-"explorer!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:537
-msgid ""
-"Reports from your spies tell of enemies on the march.  As you rush to the "
-"castle courtyard to prepare your armies, you are intercepted by your "
-"Chaplain.  \"My Lord, I have received word that we should send what Heroes "
-"we can to the Isle of Knowledge.   The Scholars there have agreed to teach "
-"them so they will be strong for the battles ahead of us.\"  You thank the "
-"Chaplain for the information and head thoughtfully into the courtyard."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:538
-msgid ""
-"Rescue your crazy Uncle Ivan. Find him within 4 months or it will be no help "
-"to your kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:539
-msgid "Restricted Area, Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:540
-msgid "Rest stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:541
-msgid "Retake the Castle of Ivory Gates."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:542
-msgid "Revolution"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:543
-msgid "Right thinking - he who takes the riskes deserves the rewards."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:544
-msgid "River Crossing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:545
-msgid "Road Ends"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:546
-msgid "Road to Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:547
-msgid "Road to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:548
-msgid "Robbers have looted your treasury and you have lost valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:549
-msgid "Robbers have looted your treasury, stealing valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:550
-msgid "Roc Haven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:551
-msgid "Rogar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:553
-msgid "Roscomon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:554
-msgid "Rotten Birch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:555
-msgid ""
-"Rumors abound and your faithful hero Sandro is now highly regarded by the "
-"masses. Should Sandro desert you, all will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:556
-msgid "Sandcaster"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:558
-msgid "Sands of Time"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:559
-msgid "Sansobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:560
-msgid "\"Save the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:561
-msgid "Scabsdale"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:562
-msgid "Scorched Earth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:563
-msgid ""
-"Scouts have reported a town to the North.  They have also heard some "
-"disturbing news.  Their seems to be a war raging in this area."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:564
-msgid ""
-"Scouts report the enemy's stronghold lies to the Southwest. Our swift "
-"arrival has caught them by surprise. If you move quickly their resistance "
-"will be minimal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:565
-msgid ""
-"Scouts report the notorious necromancer \"Wyrm\" has been sighted to the "
-"northeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:566
-msgid "Scummy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:567
-msgid ""
-"Searching in the dust of this abandoned campsite, you find a magic scroll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:568
-msgid "Seasons Change"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:569
-msgid "Secret Mountain Pass"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:570
-msgid ""
-"Seek out the Ultimate Artifact to be victorious in this strangely shaped "
-"land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:571
-msgid ""
-"Seek the great library, for only with the guidance of the musty tomes therin "
-"will you find the means to reveal and bind the fount to your will."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:572
-msgid "Seven Lakes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:573
-msgid "Sharkania"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:574
-msgid "Sheltemburg"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:575
-msgid "Sherman"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:576
-msgid "Shipwrecked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:577
-msgid ""
-"Should this message ever reach home, please know that this has become a "
-"hostile place since the King's death.  No less than six factions are at war "
-"with each other, each seeking to be the King's successor.  Beware especially "
-"of the Barbarians and the Necromancers who control the north, their regions "
-"are easily defended and they have a wealth of gold and gems.  Do not venture "
-"to this land without a sizeable force.  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:578
-msgid "Sirein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:579
-msgid ""
-"Six factions have established a foothold on a huge, unexplored continent.  "
-"Can you eliminate the other five?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:580
-msgid ""
-"Six heroes with large armies prepare to slug it out for total domination!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:581
-msgid "Skirmish"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:582
-msgid "\"Slay the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:583
-msgid "Slippery when wet."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:584
-msgid "Slugfest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:585
-msgid ""
-"Snagged on a thorny bush, you discover a scrap of cloth. The design on it "
-"looks like the coat of arms of Ivan's house!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:586
-msgid "Snowdrop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:587
-msgid "Somebody has stuffed a pile of gems in the ditch!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:588
-msgid "Some crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:589
-msgid "Some gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:590
-msgid ""
-"Someone has stolen 100 wood and 77 ore from you. Ah, that's nothing. Let's "
-"keep going."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:591
-msgid ""
-"Someone has stolen gold and resources from  the palace treasury!  You "
-"suspect your enemies, but you can't know for certain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:592
-msgid "Someone is playing a pan flute around here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:593
-msgid ""
-"Someone notices a piece of parchment lying behind a clump of grass. You pick "
-"it up. It looks to be a page from a journal, and it reads, \"...made it past "
-"the first guardians. Hopefully will reach the ancient desert city soon. Only "
-"hope my forces are strong enough to survive...\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:594
-msgid "Some ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:595
-msgid "Some sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:596
-msgid ""
-"Some unlucky adventurers have been captured and imprisoned in these lands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:597
-msgid "Sorceress Forest.  Show respect for nature!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:598
-msgid "Sorpigal"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:599
-msgid "South Mill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:600
-msgid "So you think you're smart?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:601
-msgid "Spector"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:602
-msgid "Spell Casters"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:603
-msgid ""
-"Spies report Roland has sent a hero to search for the Crown. If he finds it "
-"first, all is lost!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:604
-msgid "Spirit City"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:605
-msgid "Spy Tower - see what your competition is doing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:606
-msgid "Stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:607
-msgid ""
-"Start with five castles!  How could you lose!?  Oh yeah, everyone else "
-"starts with five, too."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:608
-msgid "Stick to the road!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:609
-msgid "Stromgild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:610
-msgid "Stromhild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:611
-msgid "Stronghold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:612
-msgid "Stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:613
-msgid "Stuff for Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:614
-msgid "Stuff For Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:615
-msgid "Subbaculcha"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:616
-msgid "Sundune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:617
-msgid "Surf and Turf"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:618
-msgid "Swimming near the kelp is a pod of dolphins."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:619
-msgid "Tacma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:620
-msgid "Tchudes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:621
-msgid "Teleporters"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:622
-msgid "Terra Firma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:623
-msgid "Terrain Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:624
-msgid ""
-"The alliance has crumbled and all are at war. Lots of resources but little "
-"time to prepare."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:625
-msgid ""
-"The ancient King Zealot had the artifact of the gods and then hid it in his "
-"old age so that it could not be used by others."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:626
-msgid "The Back Door"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:627
-msgid ""
-"The Barbarian's lands are being invaded. Are you strong enough to resist the "
-"invasion?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:628
-msgid ""
-"The castle of Drakonran in the east has been taken by the barbarians! Two "
-"other towns to the west have also been taken, but the barbarian armies were "
-"fairly decimated in the process."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:629
-msgid "The center island is rumored to harbor great spells."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:630
-msgid "The Citadel"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:631
-msgid "The cities of the plains."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:632
-msgid "The Clearing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:633
-msgid ""
-"The convoy has at long last arrived. Regretably, it has been beset by "
-"bandits on its journey here, and has far less supplies than we had hoped. "
-"Make your way south, for our spies have found rich mines there."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:634
-msgid ""
-"The convoy should have been here by now! Let us hope that it is safe and "
-"still on its way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:635
-msgid ""
-"The country lords have allied and pooled their resources into one command. "
-"Not only have they massed their forces in the north, but they have sent a "
-"knight to the west to steal your supplies. Scouts report a castle to the "
-"east that would be ideal as a base of operations."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:636
-msgid "The crew are unworthy!  I am not going down with the ship! -The Captain"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:637
-msgid "\"The Crown\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:638
-msgid ""
-"The day you have feared has finally arrived.  The king, who you have "
-"faithfully served, has died, leaving no heir to his throne.  As his captain, "
-"you feel that this job should now be yours, but several factions even now "
-"are preparing for conquest.  You are at the center of the trade routes, "
-"having the sea to the south and the great forest to the north.  Go, now, "
-"Commander, and claim what is rightfully yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:639
-msgid ""
-"The diplomats who were sent here ahead of you report that the elves will "
-"only cooperate with you if you will recover the golden bow for them. It was "
-"stolen by their enemies, the Dragons and hidden behind magic barriers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:640
-msgid "The Eastern Town."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:641
-msgid "The edge of the world is your edge.  But prepare to be prepared."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:642
-msgid "The Emerald Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:643
-msgid "The Enchanted Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:644
-msgid "The End of the World is Nigh!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:645
-msgid "The End of the World is Nigh"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:646
-msgid ""
-"The Epic battle against Your Rival! Eliminate everything! Total Warfare! "
-"Don't Lose your first hero!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:647
-msgid ""
-"The Fire King is an ally to the dragons, and will help a friend of theirs."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:648
-msgid "The First One To Take Astircaer Wins!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:649
-msgid ""
-"The first piece of the artifact now lies in the hands of the Unholy Order of "
-"Warlocks. You must annihilate them, and their allies to the north. They will "
-"surely give us what we seek in exchange for their feeble lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:650
-msgid ""
-"The Fortune of Infamous Uae was buried on one of these islands. She died "
-"without ever revealing it.  Find it before the other cutthroats."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:651
-msgid "The four factions race to capture a mystical castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:652
-msgid ""
-"The four spell casters face off with substantial starting armies. Can the "
-"crusaders keep the peace?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:653
-msgid "\"The Gauntlet\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:654
-msgid ""
-"The Gods have given you 6 months to prove yourself. Good or Evil - who shall "
-"prevail? (Blue,Green and Red vs Yellow, Orange and Purple)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:655
-msgid ""
-"The gods have granted this world a great artifact, to find it means victory."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:656
-msgid "The Gods themselves will aid us in this War."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:657
-msgid "The Gold Traveller's Tent is near the Aqua Taveller's Tent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:658
-msgid "The guardians of Dragon Isle reside in the jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:659
-msgid "The Ice Prince stands frozen in some forgotten corner of the world."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:660
-msgid "The island...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:661
-msgid "The Island of Lost Reason"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:662
-msgid "The islands have much wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:663
-msgid "The Isle of Armoria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:664
-msgid "The key to success is rubbing enough lamps."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:665
-msgid ""
-"The King has declared you his hier apparent and champion. You must seek out "
-"and destroy your common enemy, Wilgatus and his Castle, Mirkosov, the source "
-"of his power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:666
-msgid ""
-"The King is dead, his kingdom has been shattered, and six leaders seek to "
-"seize power for themselves."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:667
-msgid "The Kingly Wastes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:668
-msgid "The Kings Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:669
-msgid ""
-"The King will sell you this land for 200,000 gold or you can take it by "
-"force. The choice is yours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:670
-msgid "The land of Heroes II."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:671
-msgid "The Lost Castle of the Ancients"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:672
-msgid ""
-"The mage wars have caused a great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:673
-msgid ""
-"The mage wars have caused great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:674
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trade.  "
-"Plus a little gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:675
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trading.  "
-"Plus a little more gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:676
-msgid ""
-"The Master Merchant arrives at your Castle.  He tells you tall tales of "
-"travel, full of outrageous lies.  He also gives you, your share of the "
-"profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:677
-msgid ""
-"The Master Merchant arrives back at your Castle.  He tells you tall tales of "
-"faraway places full of outrageous lies.  He also gives you, your share of "
-"the profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:678
-msgid "The Medusas have the password and they can be found just to the west."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:679
-msgid "The more there is the less you see."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:680
-msgid "The North Road to Roland's castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:681
-msgid ""
-"The note in this bottle has become mostly indecipherable. All you can make "
-"out are references to deadly pirates, and hidden gold mines."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:682
-msgid "The Other Side"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:683
-msgid ""
-"The Overlord has given you 4 months to conquer this land or deliver to him "
-"the sum of 150,000 gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:684
-msgid ""
-"The people on the Isle of Knowledge are taking up a collection to aid us."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:685
-msgid "The Proving Grounds"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:686
-msgid "The Queen's Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:687
-msgid "The Realm of Air is barred, but you may appeal here for help."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:688
-msgid ""
-"There are remnants of a mighty battle fought here, not too long ago. It "
-"looks as if whoever came this way may have made this their final stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:689
-msgid ""
-"There are three enemy castles to the north. Capture them in the name of "
-"Roland the true king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:690
-msgid ""
-"The Red Tide of War rolls North.  Stopping the flood seems hopeless.  Yet, "
-"Honor demands you and your ally die trying."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:691
-msgid "There is hidden treasure north of the Green Lord's Ore Mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:692
-msgid "There is hidden treasure south of the Blue Lord's Sawmill."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:693
-msgid "There's a warm wind blowing from the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:694
-msgid "There's a Wizard living in the north who is behind this peasant revolt."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:695
-msgid "The Retreat of the Alchemist Doctor Yu"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:696
-msgid ""
-"There used to be a mine here, but it has long since run out of ore.  You are "
-"only able to scavenge 5 units of ore from the old site."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:697
-msgid "There was a shipreck in the far east waters recently."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:698
-msgid "The River Styx"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:699
-msgid "The roars of several dragons echo from the towers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:700
-msgid "The Rock Store."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:701
-msgid "The Royal Gardens."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:702
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:703
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you defend against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:704
-msgid "These doors are a risk the likes of which you do not know."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:705
-msgid "These lands are beholden to Lord Kraeger."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:706
-msgid ""
-"These lands are desolate and for the most part devoid of resources. Not even "
-"the bravest heroes dare to venture into them, and plants are rare and "
-"precious here. Who knows what else awaits?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:707
-msgid ""
-"The Southern Witch is biding her time.  She will strike when your armies are "
-"weak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:708
-msgid "the stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:709
-msgid "The Table in the Great Hall of the Castle is Haunted."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:710
-msgid ""
-"The third piece of the artifact is somewhere to the north, that much we "
-"know. We are still unsure of its exact location, but our spies are out "
-"gathering information. The forces in this area are too strong to be "
-"completely subjugated, so take what you can and hold on to it tightly."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:711
-msgid ""
-"The troops have sworn their allegiance, but should lose a battle they will "
-"lose faith and our cause will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:712
-msgid "The Valley of Aruk."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:713
-msgid ""
-"The Valley of Magic holds many surprises.  You discover an old pair of boots "
-"sticking out of the sand."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:714
-msgid "The Valley of Tresures"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:715
-msgid "The Wasteland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:716
-msgid "The way of magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:717
-msgid "The way of might"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:718
-msgid "The way of numbers"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:719
-msgid "The western town."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:720
-msgid "The winds howl in mourning around the shipwreck."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:721
-msgid "The wizard has an island in the southeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:722
-msgid ""
-"The Wizards who have captured the Necromancers' town have wasted no time in "
-"building defenses designed to stop you, and their last castle has just been "
-"completed. Fortunately only a Captain of the Guard and a small garrison are "
-"currently present.  If you hurry, you should be able to capture the castle "
-"before they have a chance to reinforce it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:723
-msgid "The wood has arrived."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:724
-msgid "The writing on this sign is too faded to read."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:725
-msgid "The Yellow Lord has the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:726
-msgid ""
-"The Yellow Lord is a hothead who will attack before his allies can send him "
-"aid."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:727
-msgid "They say there's mermaids in these waters..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:728
-msgid ""
-"This area is rich in resources. Explore, but beware, a castle left "
-"undefended will quickly fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:729
-msgid ""
-"This area must be secured for the sake of the Empire. Our spies have "
-"reported a discord between The kingdom of the knights to the north, and that "
-"of the oppressive sorceresses to the northeast. Perhaps this feud can be "
-"exploited for our gain..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:730
-msgid "This bottle is empty."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:731
-msgid ""
-"This is the last week you have to find the rebel wizard Joseph! Good Luck in "
-"your quest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:732
-msgid ""
-"This land and all others are now under the sole ownership of Ibn Fadlan, the "
-"Undead King. Any disregard for his magesty's soverign rule is to be punished "
-"by death most horrendous."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:733
-msgid ""
-"This land has been claimed by the nation of Neroli. Interlopers are "
-"UNWELCOME."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:734
-msgid ""
-"This rugged land will have rivals fighting the terrain as well as each other."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:735
-msgid ""
-"This rundown village looks like it was once the epicenter of an enormous, "
-"but now ruined, city. Under a pile of rubble you find an object which looks "
-"like it has lain there for ages."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:736
-msgid ""
-"This spot overlooks an old quarry.  This was one of the only places in the "
-"world where ore could be taken right out of the ground.  Unfortunately the "
-"jungle has reclaimed the quarry and it is unusable.  You collect the last of "
-"the ore and depart."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:737
-msgid ""
-"This twisted maze of sorceress towns has three factions struggling for sole "
-"control.  Use your resources wisely!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:738
-msgid ""
-"This village appears to be in little better shape than the first one you "
-"saw. As you approach the village an old man hands you a slip of paper, with "
-"the following message, \"Joseph lives in the town of IslandHome.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:739
-msgid ""
-"This village is in extremely poor shape. There is no chance of getting more "
-"than some of the lesser creatures here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:740
-msgid "This way to the Necromancer Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:741
-msgid "Those who seek knowledge are welcome to the city of Chronos."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:742
-msgid ""
-"Three Warlocks in the land of Dragons. Lose thy home and all will be lost. "
-"Conquer thy enemies and the land shall forever be yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:743
-msgid "Timberhill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:744
-msgid "Time for a refreshing drink."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:745
-msgid "Time is running out! The enemy's reinforcements are almost here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:746
-msgid "To pass you must pay troll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:747
-msgid "TreeHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:748
-msgid "Trespassers will be EATEN!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:749
-msgid "Trilobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:750
-msgid "Troy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:751
-msgid "Tundara"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:752
-msgid "Turn back, friend, while you still can!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:753
-msgid "Turn Back Now!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:754
-msgid "Turn Back Now or all will be LOST!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:755
-msgid "Turn Back or DIE!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:756
-msgid "Turn Back or else!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:757
-msgid "Turn back, you fool."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:758
-msgid "\"Turning Point\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:759
-msgid ""
-"Uae was the scurviest, pirate ye'd never wanta see. In all her years of "
-"murdering and thieving she amassed so much ill-gotten booty that she "
-"couldn't carry it around in her galleon.  Besides, even the meanest can't "
-"stay awake all the time.  Legend tells that she hid it so well, she was "
-"thinking that she just might forget where it was.  So she left clues around "
-"the islands, carved in stone.  Well, she's dead now.  It's up to you to "
-"recover her legacy."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:761
-msgid "Uncle Leo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:762
-msgid "Uncle Milty"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:763
-msgid "Undead Armies"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:764
-msgid "Unholy Alliance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:765
-msgid "Unite the Tribes. Don't lose your main hero, the first Descendant."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:766
-msgid "Valley of Death"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:767
-msgid "Valley Of The Damned"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:768
-msgid "Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:769
-msgid "Vaultius"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:770
-msgid "Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:771
-msgid "Vikings!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:772
-msgid "Viper's Nest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:773
-msgid "Vulcania"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:774
-msgid "Warrior Knight"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:775
-msgid "Wastelands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:776
-msgid "Watch out for Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:777
-msgid "Waystop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:778
-msgid ""
-"\"We are at the edge of the world!\"  they scream.  \"What are we doing here?"
-"\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:779
-msgid "Weddington"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:780
-msgid "Weed Patch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:781
-msgid ""
-"We found a weakness my lord. Capture castle Black Fang and victory is ours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:782
-msgid ""
-"We have just learned that the artifact is on an island north of this "
-"continent. However, there does not appear to be any means to get there. Stay "
-"very alert for any possible way across the narrow channel."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:783
-msgid ""
-"Welcome back general.  Have you finished the conquest of the northern "
-"lands?  What? you still have not finished your mission!  Get back there and "
-"teach those rebels a lesson!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:784
-msgid "Welcome to Li'l Alctatraz! Vistors NOT welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:785
-msgid ""
-"Welcome to Power Island. He who controls this Isle controls the Seven Lakes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:786
-msgid "Welcome to the Sandbar."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:787
-msgid "Welcome to the sandy Isle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:788
-msgid "Welcome to the sorceress' guild."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:789
-msgid "Welcome to the Spiral Isles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:790
-msgid ""
-"Welcome to the wounderous Kitisland range.  Eruptions each day, beware of "
-"dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:791
-msgid "Welcome to Windfall Island!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:792
-msgid "Welcome to your DOOM!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:793
-msgid "We'll join you - for the right price."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:794
-msgid ""
-"Well placed bribes have won you a stronghold near the warring Barbarians. Be "
-"advised that given their proximity an unguarded castle is an open invitation "
-"to defeat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:795
-msgid "Westfork"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:796
-msgid "Westmoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:797
-msgid "We told you not to drink!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:798
-msgid "What are you doing here?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:799
-msgid "What cannot be seen but only heard, and will not speak until spoken to?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:800
-msgid "What everyday word is most often pronounced incorrectly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:801
-msgid "What goes up and down but never moves?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:802
-msgid ""
-"What good fortune!  You've discovered a long-abandoned settlement.  To your "
-"surprise, you discover that the previous inhabitants left some of their "
-"resources behind when they departed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:803
-msgid "What is always coming but never arrives?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:804
-msgid "What is the Sum of all Numbers from 1 to 200?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:805
-msgid "What is time spent poorly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:806
-msgid "What's another word for pirate treasure?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:807
-msgid "What's behind door number one?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:808
-msgid "What's this? A pile of gems?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:809
-msgid "What's this? Someone has left a pile of wood here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:810
-msgid ""
-"What team won Super Bowl XXI and Super Bowl XXV?  (Hint... a Wizard might "
-"have these troops in his army)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:811
-msgid "What turns everything around but does not move?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:812
-msgid ""
-"What walks in the morning on four legs, two in the afternoon and three in "
-"the evening?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:813
-msgid "What?  What's this?  Something at the bottom of this pool..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:814
-msgid "When you're ready, take the teleport to the Island's Hot Spot!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:815
-msgid ""
-"When you think yourself invincible, walk through this gate.  Even then, "
-"prepare to meet your bitter end."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:816
-msgid "Where am I?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:817
-msgid "While away seeking the Ultimate Artifact, Kastor's kingdom is invaded!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:818
-msgid ""
-"While traveling a mesenger meets you on the road.  His message tells of a "
-"new ally from an island far to the south.  This ally can not offer forces to "
-"your battle but has agreed to send some support in the form of gold and "
-"crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:819
-msgid "Whiteshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:820
-msgid "Whittingham"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:821
-msgid "Who am I?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:822
-msgid ""
-"Who am I?...  Where am I?...  Oh no! My Ship!  Well it's consigned to the "
-"ghosts of my dead crew now, at least I still have my lucky rabbits foot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:823
-msgid "Who is the true King?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:824
-msgid ""
-"\"Why have we come this way?\"  asks the first mate.  You have no answer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:825
-msgid "Wicked Warlock Way"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:826
-msgid "Wilasher"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:827
-msgid "Wildabar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:828
-msgid "Wilgatus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:829
-msgid "Willow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:830
-msgid "Windfall Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:831
-msgid "Winterkill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:832
-msgid "Winterlands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:833
-msgid "Witch Hunt"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:834
-msgid ""
-"With the year long eruption of Mt. Kitisland, your three worst enemies now "
-"have a ground bridge to your eastern contenent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:835
-msgid "Wizardwood.  Magicians welcome!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:836
-msgid "Woodhaven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:837
-msgid "Wood's Lord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:838
-msgid "Woodstock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:839
-msgid "Woodville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:840
-msgid "Wormed Ash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:841
-msgid "Wow, somebody has left a pile of wood here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:842
-msgid "Wyrm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:843
-msgid "Xabran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:844
-msgid "Yellow gets some stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:845
-msgid "Yellow's Steady Cash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:846
-msgid "Yellow stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:847
-msgid "Yellow's Yarbols"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:848
-msgid "Ye old fish liver oil."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:849
-msgid "Yorksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:850
-msgid ""
-"You and your ally's families were given custody of The Isle of Knowledge.  "
-"Other Lords feel the time has come for new guardians..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:851
-msgid "You are a fool to come here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:852
-msgid "You are fighting on the side of your king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:853
-msgid "You are fighting on the side of your sister!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:854
-msgid "You are now entering the domain of Prince Roland. Have a nice day."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:855
-msgid "You are now entering the domain of Prince Roland. Have a pleasant stay."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:856
-msgid ""
-"You bribe the entrance guards of this dingy prison camp. They agree to look "
-"the other way for a little while."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:857
-msgid ""
-"You can only reach your enemies via teleporters, but each jump is a leap of "
-"faith."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:858
-msgid ""
-"You cautiously ride through the trees, looking out for enemy assaults, when "
-"suddenly, the old elf is beside you. \"Your quest is almost at an end, my "
-"friend. All that remains is for you to lay seige to these last few castles. "
-"The fate of my people rests upon your final battles here. May the gods be "
-"with you as well.\"  He turns to leave, but you ask him his name before he "
-"is gone. Over his shoulder, as he is leaving he says \"I am Ilthanis, king "
-"of the elves.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:859
-msgid ""
-"You come across the dead remains of what was appearantly a powerful wizard!  "
-"You wonder if it's safe to continue."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:860
-msgid ""
-"You face three opponents in this scenario. Capture their castles and their "
-"heroes to prove your worthiness to Archibald."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:861
-msgid ""
-"You find a beautiful helm buried in the lava.  As you move to put it on your "
-"head it turns into the Hideous mask and now you realize that no creature "
-"will join you."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:862
-msgid ""
-"You find a gleaming gold medalion buried in the  snow.  As you move to put "
-"it on it changes to the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:863
-msgid ""
-"You find an old signpost in the midst of a thicket that reads \"Warlock "
-"Wood, West.  Barbarian Fields, East.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:864
-msgid ""
-"You find a note in the bottle! It reads, \"My ship has been wrecked by the "
-"notorious pirates in this area! I am stranded on a small and barren island. "
-"Please, I beg you to come and rescue me!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:865
-msgid "You found something!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:866
-msgid "You found Treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:867
-msgid ""
-"You have been ordered here to claim this land in the name of your King and "
-"recover any riches that you might find.  However, five other Kings and "
-"Queens have also sent their heroes to this land, so you must watch out for "
-"them as well as the natives!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:868
-msgid "You have found what someone else has lost..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:869
-msgid ""
-"You have hired a barbarian of great power to aid you in this, your last "
-"quest. His origins are unknown to you, but you sense strong nobility beneath "
-"the furs and dirt that cover him. In addition, the famous explorer, Marco "
-"the wizard, is rumored to have wrecked his ship in this new land. Finding "
-"him would prove to be a much needed boon to your cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:870
-msgid ""
-"You have just 8 weeks  to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:871
-msgid ""
-"You have just 8 weeks to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:872
-msgid ""
-"You have received a message from Archibald. \"General, these peasants "
-"deserve punishment. Put them to the sword and let Corlagon have his way with "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:873
-msgid ""
-"You have received a message from Archibald.  \" HOW DARE YOU BETRAY ME! I "
-"will see your head on the block alongside your new master's once I have won."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:874
-msgid ""
-"You have received a message from Roland. \" I am shocked! I had thought "
-"better of you, but I was terribly wrong. Now you'll have to live with your "
-"dark decision for the rest of your life.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:875
-msgid "You have recieved a shipment of supplies from your kingdom!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:876
-msgid ""
-"You have recieved a shipment of supplies from your kingdom! There is a note "
-"attached, \"These are all we could afford to send you from our treasuries, "
-"as the war with Harondale is taxing us greatly. We will send more in two "
-"weeks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:877
-msgid ""
-"You have six months to destroy the Necromancer Stronghold in the heart of "
-"the valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:878
-msgid ""
-"You have washed up on the beach after being shipwrecked. Your goal is to "
-"find a way home."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:879
-msgid ""
-"You hear a low rumble, look up and see an avalanche!  You dive onto a large "
-"patch of grass to avoid it.  While dusting yourself off, you consider "
-"yourself quite lucky to be alive.  Luckier still to find a Four-Leaf Clover "
-"stuck on your nose."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:880
-msgid ""
-"You hear a rumor from a peasant who lives in the town of Waystop. He says, "
-"\"The pirates control most of the sulfur mines in this area. They use it for "
-"the cannons on their bigger boats. If you want a mine, you'll have to defeat "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:881
-msgid "You hear melodic strains of elvish music as you enter this clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:882
-msgid ""
-"You must, like, forsake your earthly wealth and, like, join us on the island "
-"of the lotus eaters."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:883
-msgid ""
-"You must search the world for your mortal enemy, Wilgatus.  Can you find him "
-"before its too late?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:884
-msgid ""
-"You notice some runes hastily scrawled into a rock by your feet, They look "
-"like the initials of Uncle Ivan!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:885
-msgid ""
-"You notice that mines and resources in the elvish lands are few, and you "
-"send word to your kingdom that you will need extra supplies. They should "
-"respond within a fortnight."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:886
-msgid ""
-"Your advance scouts come riding back to you with the following news. They "
-"believe they have found signs that Uncle Ivan was in this general area, and "
-"that he made his way to the north many months ago. Also they say there is a "
-"town nearby and many resources to the east."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:887
-msgid ""
-"Your advisor approaches you, \"My liege, something must be done about these "
-"peasants! They still refuse to work.  At this rate you won't have anything "
-"to put in your daughter's dowry!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:888
-msgid ""
-"Your advisor approaches you smiling greatly, \"My liege! The peasants are "
-"making money in the market, and are finally paying taxes!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:889
-msgid ""
-"Your advisor approaches you with a long face, \"My liege, the peasant's "
-"numbers are growing steadily.  All they do is take, take, take! We are "
-"beginning to suffer dearly because of them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:890
-msgid ""
-"Your advisor approaches you with some startling information, \"My liege, the "
-"peasants are draining us. They do nothing, and take everything! We must get "
-"them home. Your own citizens are beginning to suffer!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:891
-msgid ""
-"Your arrival here was a surprise to those sworn to guard Dragon Isle, and "
-"you were able to quickly capture one of their castles.  Use caution, though, "
-"for two other guardians remain in this jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:892
-msgid ""
-"Your castle, founded inside the center of a mile wide crater, is besieged by "
-"those who desire your mineral wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:893
-msgid "Your castle is the last outpost in the area, Don't lose it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:894
-msgid "Your crew begins to grumble."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:895
-msgid ""
-"Your crew seriously entertains thoughts of mutiny.  Your nights are "
-"sleepless."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:896
-msgid "You're almost there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:897
-msgid "You, recieve word that you have been robbed."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:898
-msgid "You're getting colder."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:899
-msgid "You're getting warmer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:900
-msgid ""
-"You're here! Oh, thank you thank you thank you! I'm in the jail east of the "
-"castle. Please hurry!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:901
-msgid ""
-"Your expedition has taken a turn for the worse... you now have no way to get "
-"home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:902
-msgid ""
-"Your forces are thinly spread in an effort to defend all the dwarf towns "
-"(which may not be transformed into castles). Consolidate your forces and "
-"smite the enemy before the towns fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:903
-msgid ""
-"Your horse stumbles and throws you from the saddle.  When you awaken you "
-"find that you have hit your head on the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:904
-msgid ""
-"Your isolation from the rest of the kingdom has largely kept you out of the "
-"political struggles, but now with the king's death, and lack of an heir, you "
-"see a golden opportunity to seize the throne for yourself.  Just remember "
-"that you have relied largely on trade for several key resources, especially "
-"sulfur, but with a little planning this land can be yours.  Go, now, and "
-"show these peasants how to rule!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:905
-msgid "Your king has sent supplies to aid the war effort."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:906
-msgid ""
-"Your opponents are allied against you and each is twice as powerful as his "
-"predecessor! Is it possible to win?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:907
-msgid ""
-"Your Queen sent you here to explore this newly discovered territory, but a "
-"freak storm scattered your fleet and left you stranded.  You gather the "
-"survivors and form a small settlement, naming it New Vertigo.  This place is "
-"your home now, and survival is your highest priority, but remember, if you "
-"are captured or killed, it's over!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:908
-msgid ""
-"Your rival, the kingdom of Harondale, is attacking your weak border towns! "
-"Recover from their first strike and crush them completely."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:909
-msgid ""
-"Your Scouts report talking to a young knight, a squire to the two sleeping "
-"heroes.  The squire is trapped by the Aqua Magic Barriers and a group of "
-"fallen Paladins.  He says the two heroes, Dainwin and Ceallach, have "
-"awakened but are still trapped by a Gold Magical Barrier and asks your aid "
-"in freeing them."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:910
-msgid ""
-"Your Scouts report that the Aqua Traveller's Tent is located along The North "
-"Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:911
-msgid ""
-"Your scouts return with grim news.  The natives of this land are currently "
-"at war with each other, and they like outsiders even less than they like "
-"each other!  Congratulations, Commander, you're at war!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:912
-msgid ""
-"Your sister calls you before her altar in the morning. \"I have important "
-"news,\" she says, \"The barbarian kingdoms which border this land have "
-"agreed to lend us some of their castles and warriors in return for a share "
-"of the spoils. I hope victory comes swiftly, but your presence gives me "
-"strength to stand until whatever end awaits.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:913
-msgid "Your subjects contribute to your war effort!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:914
-msgid ""
-"Your town is undefended and your heroes are scattered.  Do you attack or "
-"defend?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:915
-msgid ""
-"Your treasury has been looted by robbers and you have lost valuable "
-"resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:916
-msgid "Your troops begin to wonder about your sanity."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:917
-msgid ""
-"You run aground on the rocks and have to use some wood to fix your boat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:918
-msgid ""
-"You see a family of refugees making their way from the beach. You ask them "
-"about their plight and they tell you that they are from a once great city "
-"called Moss Side. They tell you that the castle was destroyed in a great "
-"conflagration, and they fled for fear of their lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:919
-msgid ""
-"You see an old man bringing water towards the stables. Recognizing him as "
-"the mystic, you attempt to thank him for his gift with some gold. He "
-"refuses, but says to you instead, \"There are riddles guarding the source of "
-"the fount's power, and the dragons know the answers. Make your way through "
-"their lair, and you shall know victory.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:920
-msgid ""
-"You see an old mystic perched on a rock. You walk towards him to see if he "
-"has any words for you on your quest, and he says \"First I see you as a "
-"great conquerer of the lands of men. Secondly, I see you as a mighty ruler "
-"of vast armies, well loved by your troops. Thirdly, I see you as a slayer of "
-"legions of dragons, your body bathed in their fire. Lastly, I see you "
-"standing on the shores of the fount, unable to cross.\" Then the Mystic "
-"fades away."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:921
-msgid "You see something that could just be the elusive Nubbie!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:922
-msgid ""
-"You see the mast of ancient ship here.  On further investigation you find "
-"that the ships holds are full of gems.  The hours pass as your crue "
-"liberates the treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:923
-msgid ""
-"You see the remains of a burned out sawmill here.  All you can salvage is "
-"some ofwood left for scrap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:924
-msgid ""
-"You see the remains of an old sawmill, but it is obvious that you will not "
-"be able to make it work again."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:925
-msgid ""
-"You see the remains of an old sawmill just to realize that it will no longer "
-"produce.  You gather the ramains and move on."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:926
-msgid ""
-"You send this letter back to the king,\"A month has passed and we have not "
-"discovered the wizard Joseph. I only hope that we are able to locate him in "
-"time to aid us in our struggle.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:927
-msgid "You should turn back."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:928
-msgid ""
-"You stumble upon an old man who proclaims you Lord of the Realm, hands you "
-"his boots and wonders into the mountains mumbling something about being late "
-"for an important date."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:929
-msgid ""
-"You stumple across three small rocks piled on top of each other and decide "
-"to dig undernear them.  There you find an old weather-beaten bag of gems."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:930
-msgid "You uncover a compass in the grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:931
-msgid "You've been warned!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:932
-msgid ""
-"You've received a message from Roland. \"In the absence of a strong leader, "
-"the local lords have fallen to fighting. Uniting this area is critical to "
-"our cause, so we must not fail.  Leaving your castle undefended in this "
-"highly contested region will surely lead to defeat. I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:933
-msgid ""
-"You've received a message from the guild. \"Thank God you've arrived! We're "
-"under seige from two enemies from the north and one from across the sea. "
-"Please save us, you're our only hope.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:934
-msgid ""
-"You've ruled with an iron fist (and an army of undead), but now your kingdom "
-"has turned against you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:935
-msgid ""
-"You've saved a group of miners from the dragons.  One of them approaches "
-"you, \"Thank you so much for saving us!  We found this sulfer and sword in "
-"the mine, then those dragons chased us!  I don't know how much longer we "
-"could survive!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:936
-msgid ""
-"You will clash quickly on this small head-to-head map, so stay on your toes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:937
-msgid ""
-"You will need a stronger army than that, mortal, to step through this portal."
-msgstr ""
-
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Wood"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Mercury"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Ore"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Sulfur"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Crystal"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Gems"
 msgstr ""
 
-#: ../fheroes2/spell/spell_book.cpp:61 ../fheroes2/spell/spell_book.cpp:79
-msgid "No spell to cast."
-msgstr ""
-
-#: ../fheroes2/spell/spell_book.cpp:138
-msgid "Your hero has %{point} spell points remaining"
-msgstr ""
-
-#: ../fheroes2/spell/spell.cpp:50
 msgid "Fireball"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:50
 msgid ""
 "Causes a giant fireball to strike the selected area, damaging all nearby "
 "creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid "Fireblast"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid ""
 "An improved version of fireball, fireblast affects two hexes around the "
 "center point of the spell, rather than one."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Lightning Bolt"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Causes a bolt of electrical energy to strike the selected creature."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid "Chain Lightning"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid ""
 "Causes a bolt of electrical energy to strike a selected creature, then "
 "strike the nearest creature with half damage, then strike the NEXT nearest "
@@ -11390,821 +5677,621 @@ msgid ""
 "harmful.  Warning:  This spell can hit your own creatures!"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid "Teleport"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid ""
 "Teleports the creature you select to any open position on the battlefield."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid "Cure"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid ""
-"Removes all negative spells cast upon one of your units, and restores up to %"
-"{count} HP per level of spell power."
+"Removes all negative spells cast upon one of your units, and restores up to "
+"%{count} HP per level of spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid "Mass Cure"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid ""
-"Removes all negative spells cast upon your forces, and restores up to %"
-"{count} HP per level of spell power, per creature."
+"Removes all negative spells cast upon your forces, and restores up to "
+"%{count} HP per level of spell power, per creature."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrect"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrects creatures from a damaged or dead unit until end of combat."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrect True"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrects creatures from a damaged or dead unit permanently."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Haste"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Increases the speed of any creature by %{count}."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Mass Haste"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Increases the speed of all of your creatures by %{count}."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "spell|Slow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "Slows target to half movement rate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Mass Slow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Slows all enemies to half movement rate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:64
-msgid "Blind "
+msgid "spell|Blind"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:64
 msgid "Clouds the affected creatures' eyes, preventing them from moving."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Bless"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Causes the selected creatures to inflict maximum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Mass Bless"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Causes all of your units to inflict maximum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Stoneskin"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Magically increases the defense skill of the selected creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid "Steelskin"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid ""
 "Increases the defense skill of the targeted creatures.  This is an improved "
 "version of Stoneskin."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Curse"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Causes the selected creatures to inflict minimum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Mass Curse"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Causes all enemy troops to inflict minimum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Holy Word"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Damages all undead in the battle."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid "Holy Shout"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid ""
 "Damages all undead in the battle.  This is an improved version of Holy Word."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Anti-Magic"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Prevents harmful magic against the selected creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Dispel Magic"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Removes all magic spells from a single target."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Mass Dispel"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Removes all magic spells from all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Magic Arrow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Causes a magic arrow to strike the selected target."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Berserker"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Causes a creature to attack its nearest neighbor."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid "Armageddon"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid ""
 "Holy terror strikes the battlefield, causing severe damage to all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Elemental Storm"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Magical elements pour down on the battlefield, damaging all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid "Meteor Shower"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid ""
 "A rain of rocks strikes an area of the battlefield, damaging all nearby "
 "creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "Paralyze"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "The targeted creatures are paralyzed, unable to move or retaliate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid "Hypnotize"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid ""
-"Brings a single enemy unit under your control for one combat round if its "
-"hits are less than %{count} times the caster's spell power."
+"Brings a single enemy unit under your control if its hits are less than "
+"%{count} times the caster's spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Cold Ray"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Drains body heat from a single enemy unit."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid "Cold Ring"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid ""
 "Drains body heat from all units surrounding the center point, but not "
 "including the center point."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Disrupting Ray"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Reduces the defense rating of an enemy unit by three."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Death Ripple"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Damages all living (non-undead) units in the battle."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid "Death Wave"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid ""
 "Damages all living (non-undead) units in the battle.  This spell is an "
 "improved version of Death Ripple."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Dragon Slayer"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Greatly increases a unit's attack skill vs. Dragons."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Blood Lust"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Increases a unit's attack skill."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Animate Dead"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Resurrects creatures from a damaged or dead undead unit permanently."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid "Mirror Image"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid ""
 "Creates an illusionary unit that duplicates one of your existing units.  "
 "This illusionary unit does the same damages as the original, but will vanish "
 "if it takes any damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Shield"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Halves damage received from ranged attacks for a single unit."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Mass Shield"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Halves damage received from ranged attacks for all of your units."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summon Earth Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summons Earth Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summon Air Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summons Air Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summon Fire Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summons Fire Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summon Water Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summons Water Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Earthquake"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Damages castle walls."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "View Mines"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "Causes all mines across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "View Resources"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "Causes all resources across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "View Artifacts"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "Causes all artifacts across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "View Towns"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "Causes all towns and castles across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "View Heroes"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "Causes all Heroes across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "View All"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "Causes the entire land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Identify Hero"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Allows the caster to view detailed information on enemy Heroes."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid "Summon Boat"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid ""
 "Summons the nearest unoccupied, friendly boat to an adjacent shore "
 "location.  A friendly boat is one which you just built or were the most "
 "recent player to occupy."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Dimension Door"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Allows the caster to magically transport to a nearby location."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Town Gate"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Returns the caster to any town or castle currently owned."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:109
 msgid ""
 "Returns the hero to the town or castle of choice, provided it is controlled "
 "by you."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid "Visions"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid ""
 "Visions predicts the likely outcome of an encounter with a neutral army camp."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid "Haunt"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid ""
 "Haunts a mine you control with Ghosts.  This mine stops producing "
 "resources.  (If I can't keep it, nobody will!)"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Set Earth Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Sets Earth Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Set Air Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Sets Air Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Set Fire Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Sets Fire Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Set Water Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Sets Water Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:665
-msgid "Necroman"
+msgid "No spell to cast."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:691
-msgid ""
-"This lets you change player starting positions and colors. A particular "
-"color will always start in a particular location. Some positions may only be "
-"played by a computer player or only by a human player."
+msgid "Your hero has %{point} spell points remaining."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:695
-msgid ""
-"This lets you change the class of a player. Classes are not always "
-"changeable. Depending on the scenario, a player may receive additional towns "
-"and/or heroes not of their primary alignment."
+msgid "View Adventure Spells"
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:734
-msgid "%{color} player"
-msgstr ""
+#, fuzzy
+msgid "View Combat Spells"
+msgstr "Lancer un sortilège"
 
-#: ../fheroes2/system/settings.cpp:126
+#, fuzzy
+msgid "View previous page"
+msgstr "Montrer la ville précédente"
+
+#, fuzzy
+msgid "View next page"
+msgstr "voir %{name}"
+
+#, fuzzy
+msgid "Close Spellbook"
+msgstr "Lancer un sortilège"
+
+#, fuzzy
+msgid "View %{spell}"
+msgstr "voir %{name}"
+
 msgid "game: always confirm for rewrite savefile"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:127
-msgid "game: also confirm autosave"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:128
 msgid "game: remember last focus"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:129
-msgid "game: battle show grid"
+msgid "battle: show damage info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:130
-msgid "game: battle mouse shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:131
-msgid "game: battle move shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:132
-msgid "game: battle show damage info"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:133
-msgid "game: castle flash building"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:134
 msgid "world: show visited content from objects"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:135
+msgid "world: show terrain penalty"
+msgstr ""
+
 msgid "world: scouting skill show extended content info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:136
-msgid "world: abandoned mine random resource"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:137
-msgid "world: save count monster after battle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:138
 msgid "world: allow set guardian to objects"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:139
-msgid "world: guardian objects gets +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:140
-msgid "world: no in-built requirements or guardians for placed artifacts"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:141
-msgid "world: only the first monster will attack (H2 bug)."
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:142
 msgid "world: Eagle Eye also works like Scholar in H3."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:143
 msgid "world: ban for WeekOf/MonthOf Monsters"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:144
-msgid "world: new version WeekOf (+growth)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:145
 msgid "world: ban plagues months"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:146
 msgid "world: Months Of Monsters do not place creatures on map"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:147
 msgid "world: Crystal Ball also added Identify Hero and Visions spells"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:148
-msgid "world: Artesian Springs have two separately visitable squares (h3 ver)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:149
 msgid "world: Starting heroes as Loss Conditions for Human Players"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:150
 msgid "world: Only 1 hero can be hired by the one player every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:151
-msgid "world: each castle allows one hero to be recruited every week"
+msgid "world: Each castle allows one hero to be recruited every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:152
-msgid "world: Outer creature dwellings should accumulate units"
+msgid "world: Neutral armies scale with game difficulty"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:153
-msgid "world: use unique artifacts for morale/luck"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:154
 msgid "world: use unique artifacts for resource affecting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:155
 msgid "world: use unique artifacts for primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:156
 msgid "world: use unique artifacts for secondary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:157
 msgid "world: Wind/Water Mills and Magic Garden can be captured"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:158
 msgid "world: disable Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:159
-msgid "castle: allow buy from well"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:160
 msgid "castle: allow guardians"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:161
 msgid ""
 "castle: higher mage guilds regenerate more spell points/turn "
 "(20/40/60/80/100%)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:162
-msgid "castle: allow recruits special/expansion heroes"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:163
 msgid "heroes: allow buy a spellbook from Shrines"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:164
-msgid "heroes: learn new spells with day"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:165
 msgid "heroes: recruit cost to be dependent on hero level"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:166
-msgid "heroes: remember MP/SP for retreat/surrender result"
+msgid "heroes: remember move points for retreat/surrender result"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:167
-msgid "heroes: surrendering gives some experience"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:168
-msgid "heroes: recalculate movement points after creatures movement"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:169
-msgid "heroes: allow pickup objects for patrol"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:170
-msgid "heroes: after battle move to target cell"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:171
 msgid "heroes: allow transcribing scrolls (needs: Eye Eagle skill)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:172
-msgid "heroes: allow banned sec. skills upgrade"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:173
 msgid "heroes: in Arena can choose any of primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:174
 msgid "unions: allow meeting heroes"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:175
 msgid "unions: allow castle visiting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:176
+msgid "battle: show army order"
+msgstr ""
+
 msgid "battle: soft wait troop"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:177
-msgid "battle: high objects are an obstacle for archers"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:178
-msgid "battle: merge armies for hero from castle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:179
-msgid "battle: archmage can resists (20%) bad spells"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:180
-msgid "battle: magical creature resists (20%) the same magic"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:181
-msgid "battle: skip increase +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:182
 msgid "battle: reverse wait order (fast, average, slow)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:183
 msgid "game: show system info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:184
 msgid "game: autosave on"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:185
 msgid "game: autosave will be made at the beginning of the day"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:186
 msgid "game: use fade"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:187
-msgid "game: show SDL logo"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:188
 msgid "game: use evil interface"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:189
-msgid "game: also use dynamic interface for castles"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:190
 msgid "game: hide interface"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:191
 msgid "game: offer to continue the game afer victory condition"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:192
-msgid "pocketpc: hide cursor"
+msgid "The ultimate artifact is really the %{name}."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:193
-msgid "pocketpc: tap mode"
+msgid "The ultimate artifact may be found in the %{name} regions of the world."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:194
-msgid "pocketpc: drag&drop gamearea as scroll"
+msgid "north-west"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:195
-msgid "pocketpc: low memory"
+msgid "north"
 msgstr ""
+
+msgid "north-east"
+msgstr ""
+
+#, fuzzy
+msgid "west"
+msgstr "Nid"
+
+#, fuzzy
+msgid "center"
+msgstr "Tente"
+
+#, fuzzy
+msgid "east"
+msgstr "Nid"
+
+msgid "south-west"
+msgstr ""
+
+#, fuzzy
+msgid "south"
+msgstr "son"
+
+msgid "south-east"
+msgstr ""
+
+msgid "The truth is out there."
+msgstr ""
+
+msgid "The dark side is stronger."
+msgstr ""
+
+msgid "The end of the world is near."
+msgstr ""
+
+msgid "The bones of Lord Slayer are buried in the foundation of the arena."
+msgstr ""
+
+msgid "A Black Dragon will take out a Titan any day of the week."
+msgstr ""
+
+msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
+msgstr ""
+
+msgid "An unknown force is being ressurected..."
+msgstr ""
+
+msgid ""
+"Check the newest version of game at\n"
+"https://github.com/ihhub/\n"
+"fheroes2/releases"
+msgstr ""
+
+#~ msgid "sound"
+#~ msgstr "son"
+
+#, fuzzy
+#~ msgid "ai speed"
+#~ msgstr "Vitesse"
+
+#~ msgid "Water"
+#~ msgstr "Eau"
 
 #, fuzzy
 #~ msgid "Shoot %{monster} (%{count} shot(s) left)"
@@ -12297,9 +6384,6 @@ msgstr ""
 #~ msgid "Used for special editing of monsters, heroes and towns."
 #~ msgstr "Permet l'édition des monstres, des héros et des villes."
 
-#~ msgid "Road Mode"
-#~ msgstr "Mode Routes"
-
 #~ msgid "Allows you to draw roads by clicking and dragging."
 #~ msgstr ""
 #~ "Vous permet de dessiner des routes en cliquant et en faisant glisser la "
@@ -12331,9 +6415,6 @@ msgstr ""
 
 #~ msgid "You may learn either %{level1} %{skill1} or %{level2} %{skill2}."
 #~ msgstr "Vous pouvez apprendre  %{level1} %{skill1} ou %{level2} %{skill2}."
-
-#~ msgid "animation"
-#~ msgstr "animation"
 
 #~ msgid ""
 #~ "Create a map that is 36 squares wide by 36 squares high. (For reference, "
@@ -12384,11 +6465,6 @@ msgstr ""
 #~ msgid "Legion"
 #~ msgstr "Légion"
 
-#~ msgid "For valor in combat, %{name} receives %{exp} experience."
-#~ msgstr ""
-#~ "Pour avoir prouvé sa valeur au combat, %{name} reçoit %{exp} point(s) "
-#~ "d'experience."
-
 #~ msgid "Your forces suffer a bitter defeat, and %{name} abandons your cause."
 #~ msgstr ""
 #~ "Vos forces ont subit une amère défaite, %{name} abandonne votre cause."
@@ -12397,9 +6473,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Vos forces sont en plein désarroi, %{name} le couard mouille ses chausses "
 #~ "de terreur."
-
-#~ msgid "%{tower} does %{dmg} damage."
-#~ msgstr "%{tower} a causé %{dmg} dommage(s)."
 
 #~ msgid "High morale enables the %{name} to attack again."
 #~ msgstr "le moral au beau fixe a permis à %{name} d'attaquer de nouveau."
@@ -12434,9 +6507,6 @@ msgstr ""
 
 #~ msgid "does"
 #~ msgstr "fait"
-
-#~ msgid "The %{spell} does %{value} damage to the %{name}."
-#~ msgstr "%{spell} fait %{value} dommage(s) à %{name}."
 
 #~ msgid "The %{spell} does %{value} damage."
 #~ msgstr "%{spell} fait %{value} dommage(s)."
@@ -12513,9 +6583,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Impossible de construire %{name} car le château se trouve trop loin de "
 #~ "l'eau"
-
-#~ msgid "%{name} is a level %{value} %{race} with %{count} artifacts."
-#~ msgstr "%{name} est niveau %{value} %{race} avec %{count} artefacts."
 
 #~ msgid "Victory Condition Icon"
 #~ msgstr "Icône de condition de victoire"

--- a/files/lang/hu.po
+++ b/files/lang/hu.po
@@ -7,50 +7,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-10-23 10:54+0900\n"
+"POT-Creation-Date: 2021-07-01 15:11+0200\n"
 "PO-Revision-Date: 2010-05-25 19:30+0000\n"
 "Last-Translator: Lévai Tamás <leai@t-online.hu>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
+"Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hu\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Launchpad-Export-Date: 2011-06-02 03:12+0000\n"
 "X-Generator: Launchpad (build 13144)\n"
 
-#: ../fheroes2/ai/ai_action.cpp:157 ../fheroes2/heroes/heroes_action.cpp:248
-msgid "Hero %{name} also got a %{count} experience."
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:221 ../fheroes2/resource/artifact.cpp:968
-msgid "View %{name}"
-msgstr "%{name} mutatása"
-
-#: ../fheroes2/army/army_bar.cpp:227 ../fheroes2/army/army_bar.cpp:310
-msgid "Move or right click to redistribute %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:233 ../fheroes2/army/army_bar.cpp:301
-msgid "Combine %{name} armies"
-msgstr "%{name} seregek egyesítése"
-
-#: ../fheroes2/army/army_bar.cpp:238 ../fheroes2/army/army_bar.cpp:292
-#: ../fheroes2/resource/artifact.cpp:980
-#: ../fheroes2/resource/artifact.cpp:1002
-msgid "Exchange %{name2} with %{name}"
-msgstr "%{name2} és %{name} cseréje"
-
-#: ../fheroes2/army/army_bar.cpp:246 ../fheroes2/resource/artifact.cpp:988
-msgid "Select %{name}"
-msgstr "%{name} kiválasztása"
-
-#: ../fheroes2/army/army_bar.cpp:298 ../fheroes2/army/army_bar.cpp:307
-#, fuzzy
-msgid "Cannot move last troop"
-msgstr "A sereg utolsó egységét nem lehet áthelyezni."
-
-#: ../fheroes2/army/army.cpp:85
 msgid ""
 "A few\n"
 "%{monster}"
@@ -58,7 +26,6 @@ msgstr ""
 "Kevés\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:86
 msgid ""
 "Several\n"
 "%{monster}"
@@ -66,7 +33,6 @@ msgstr ""
 "Néhány\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:87
 msgid ""
 "A pack of\n"
 "%{monster}"
@@ -74,7 +40,6 @@ msgstr ""
 "Csapat\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:88
 msgid ""
 "Lots of\n"
 "%{monster}"
@@ -82,7 +47,6 @@ msgstr ""
 "Sok\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:89
 msgid ""
 "A horde of\n"
 "%{monster}"
@@ -90,7 +54,6 @@ msgstr ""
 "Hordányi\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:90
 msgid ""
 "A throng of\n"
 "%{monster}"
@@ -98,7 +61,6 @@ msgstr ""
 "Seregnyi\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:91
 msgid ""
 "A swarm of\n"
 "%{monster}"
@@ -106,7 +68,6 @@ msgstr ""
 "Több száz\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:92
 msgid ""
 "Zounds of\n"
 "%{monster}"
@@ -114,7 +75,6 @@ msgstr ""
 "Ezrednyi\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:93
 msgid ""
 "A legion of\n"
 "%{monster}"
@@ -122,226 +82,226 @@ msgstr ""
 "Légiónyi\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Few"
 msgstr "sereg| Kevés (1-4)"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Several"
 msgstr "sereg| Számos (5-9)"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Pack"
 msgstr "sereg| Csoport (10-19)"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Lots"
 msgstr "sereg| Sok (20-49)"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Horde"
 msgstr "sereg| Horda (50-99)"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Throng"
 msgstr "sereg| Tömeg (100-199)"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Swarm"
 msgstr "sereg| Több száz (200-499)"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Zounds"
 msgstr "sereg| Ezrednyi (500-999)"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Legion"
 msgstr "sereg| Légió (1000-)"
 
-#: ../fheroes2/army/army.cpp:925
 msgid "All %{race} troops +1"
 msgstr "Minden %{race} csapat +1"
 
-#: ../fheroes2/army/army.cpp:936
-msgid "Entire unit is undead, so morale does not apply."
-msgstr "A csapat minden tagja élőhalott, így a morál nem hat rájuk."
-
-#: ../fheroes2/army/army.cpp:946
 msgid "Troops of 3 alignments -1"
 msgstr "3 faj csapatai -1"
 
-#: ../fheroes2/army/army.cpp:954
 msgid "Troops of 4 alignments -2"
 msgstr "4 faj csapatai -2"
 
-#: ../fheroes2/army/army.cpp:962
 msgid "Troops of 5 alignments -3"
 msgstr "5 faj csapatai -3"
 
-#: ../fheroes2/army/army.cpp:976
 msgid "Some undead in groups -1"
 msgstr "Élőhalottak a seregben -1"
 
-#: ../fheroes2/battle/battle_action.cpp:752
+msgid "View %{name}"
+msgstr "%{name} mutatása"
+
+msgid "Move or right click to redistribute %{name}"
+msgstr ""
+
+msgid "Combine %{name} armies"
+msgstr "%{name} seregek egyesítése"
+
+msgid "Exchange %{name2} with %{name}"
+msgstr "%{name2} és %{name} cseréje"
+
+msgid "Select %{name}"
+msgstr "%{name} kiválasztása"
+
+#, fuzzy
+msgid "Cannot move last troop"
+msgstr "A sereg utolsó egységét nem lehet áthelyezni."
+
+msgid "%{name} half the enemy troops!"
+msgstr ""
+
 msgid "Set auto battle off"
 msgstr "Automata harc kikapcsolása"
 
-#: ../fheroes2/battle/battle_action.cpp:757
 msgid "Set auto battle on"
 msgstr "Automata harc bekapcsolása"
 
-#: ../fheroes2/battle/battle_action.cpp:864
 msgid "spell failed!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:705
 msgid ""
 "The Sphere of Negation artifact is in effect for this battle, disabling all "
 "combat spells."
 msgstr "A Tagadás Gömbje varázstárgy hatására a csatában nem lehet varázsolni."
 
-#: ../fheroes2/battle/battle_arena.cpp:714
 msgid "You have already cast a spell this round."
 msgstr "Te már használtál varázslatot ebben a körben."
 
-#: ../fheroes2/battle/battle_arena.cpp:720
-#: ../fheroes2/battle/battle_arena.cpp:768
 msgid "That spell will affect no one!"
 msgstr "Ez a varázslat nem fog senkire se hatni!"
 
-#: ../fheroes2/battle/battle_arena.cpp:739
 msgid "You may only summon one type of elemental per combat."
 msgstr "Csak egy típusú elementált idézhetsz meg egy csatában."
 
-#: ../fheroes2/battle/battle_arena.cpp:745
 msgid "There is no open space adjacent to your hero to summon an Elemental to."
 msgstr "Nincs szabad helye a hősödnek, egy újabb Elementál idézésére."
 
-#: ../fheroes2/battle/battle_board.cpp:968
 msgid ""
 "The Moat reduces by -%{count} the defense skill of any unit and slows to "
 "half movement rate."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:50
-msgid "speed: %{speed}"
+msgid "Speed"
+msgstr "Sebesség"
+
+msgid "Speed: %{speed}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:165
+#, fuzzy
+msgid "Auto Spell Casting"
+msgstr "Varázslás"
+
+msgid "Grid"
+msgstr ""
+
+#, fuzzy
+msgid "Shadow Movement"
+msgstr "Mozgás folytatása"
+
+msgid "Shadow Cursor"
+msgstr ""
+
+msgid "On"
+msgstr ""
+
+#, fuzzy
+msgid "Off"
+msgstr "ki"
+
 msgid "The enemy has surrendered!"
 msgstr "Az ellenség feladta!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:168
 msgid "The enemy has fled!"
 msgstr "Az ellenség elmenekült!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:170
-#: ../fheroes2/battle/battle_dialogs.cpp:256
 msgid "A glorious victory!"
 msgstr "Dicsőséges győzelem!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:175
-msgid "For valor in combat, %{name} receives %{exp} experience"
-msgstr ""
+msgid "For valor in combat, %{name} receives %{exp} experience."
+msgstr "Vitézségéért %{name} %{exp} tapasztalati pontot kap."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:184
 msgid "The cowardly %{name} flees from battle."
 msgstr "A gyáva %{name} elmenekül a csatából."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:191
 msgid "%{name} surrenders to the enemy, and departs in shame."
 msgstr "%{name} megadja magát az ellenségnek, és szégyenben elvonul."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:197
 msgid "Your force suffer a bitter defeat, and %{name} abandons your cause."
 msgstr "Sereged vereséget szenvedett, és ezért a %{name} hős elhagy."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:249
 msgid "Your force suffer a bitter defeat."
 msgstr "A sereged vereséget szenvedett."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:296
 msgid "Battlefield Casualties"
 msgstr "Harctéri veszteségek"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:300
 msgid "Attacker"
 msgstr "Támadó"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:312
 msgid "Defender"
 msgstr "Védekező"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:394
+msgid "You have captured an enemy artifact!"
+msgstr "Megszereztél egy tárgyat az ellenségtől!"
+
+#, fuzzy
+msgid "Necromancy!"
+msgstr "Nekromancia"
+
+#, fuzzy
+msgid ""
+"Practicing the dark arts of necromancy, you are able to raise %{count} of "
+"the enemy's dead to return under your service as %{monster}."
+msgstr ""
+"A szellemidézés tudományának köszönhetően képes vagy az ellenség seregében "
+"elhullott lényekből %{count} %{monster} lényt feltámasztani ."
+
 msgid "%{name} the %{race}"
 msgstr "%{name} a %{race}"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:401
-#: ../fheroes2/castle/castle_well.cpp:311
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:194
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:834
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Attack"
 msgstr "Támadás"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:406
-#: ../fheroes2/castle/castle_well.cpp:317
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:206
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:844
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Defense"
 msgstr "Védekezés"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:411
-#: ../fheroes2/castle/castle_town.cpp:310
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:854
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:142
-#: ../fheroes2/heroes/heroes_meeting.cpp:292
 msgid "Spell Power"
 msgstr "Varázserő"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:416
-#: ../fheroes2/castle/castle_town.cpp:319
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:864
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:147
-#: ../fheroes2/heroes/heroes_meeting.cpp:296 ../fheroes2/heroes/skill.cpp:151
 msgid "Knowledge"
 msgstr "Tudás"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:421
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:276
 msgid "Morale"
 msgstr "Morál"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:426
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:286 ../fheroes2/heroes/skill.cpp:338
 msgid "Luck"
 msgstr "Szerencse"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:431
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:874
-#: ../fheroes2/heroes/heroes_indicator.cpp:247
 msgid "Spell Points"
 msgstr "Varázspontok"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
-#: ../fheroes2/gui/interface_buttons.cpp:189
+msgid "Hero's Options"
+msgstr "Hős opciói"
+
 msgid "Cast Spell"
 msgstr "Varázslás"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
+msgid "Retreat"
+msgstr "Visszavonulás"
+
+msgid "Surrender"
+msgstr "Feladás"
+
+msgid "Cancel"
+msgstr "Mégsem"
+
+msgid "Hero Screen"
+msgstr ""
+
+#, fuzzy
 msgid ""
 "Cast a magical spell. You may only cast one spell per combat round. The "
-"round is reset when every creature has had a turn"
+"round is reset when every creature has had a turn."
 msgstr ""
 "Varázslat idézés. A harc során körönként egyszer varázsolhatsz. A kör az "
 "összes egység lépése után indul újra."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:488
-msgid "Retreat"
-msgstr "Visszavonulás"
-
-#: ../fheroes2/battle/battle_dialogs.cpp:488
 msgid ""
 "Retreat your hero, abandoning your creatures. Your hero will be available "
 "for you to recruit again, however, the hero will have only a novice hero's "
@@ -350,11 +310,6 @@ msgstr ""
 "A visszavonuló hősöd, elhagyja a lényeidet. A hőst újra toborozhatod, habár "
 "a hősnek csak újonc serege lesz."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:491
-msgid "Surrender"
-msgstr "Feladás"
-
-#: ../fheroes2/battle/battle_dialogs.cpp:491
 msgid ""
 "Surrendering costs gold. However if you pay the ransom, the hero and all of "
 "his or her surviving creatures will be available to recruit again."
@@ -362,315 +317,231 @@ msgstr ""
 "A megadás aranyba kerül., Ha megfizeted a váltságdíjat, akkor a hőst és az "
 "összes túlélő lényét újra toborozhatod."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:166
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:227
-msgid "Cancel"
-msgstr "Mégsem"
+#, fuzzy
+msgid "Open Hero Screen to view full information about the hero."
+msgstr "Részletes információkat ad az ellenséges hősökről."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
 msgid "Return to the battle."
 msgstr "Visszatérés a csatába"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:549
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:438
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:497
 msgid "Not enough gold (%{gold})"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:564
 msgid "%{name} states:"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:569
 #, fuzzy
 msgid ""
-"I will accept your surrender and grant you and your troops safe passage for "
-"the price of %{price} gold."
+"\"I will accept your surrender and grant you and your troops safe passage "
+"for the price of %{price} gold.\""
 msgstr ""
 "Efogadom a megadásodat és gatantálom, hogy %{price} aranyért cserébe a "
 "csapatod szabadon távozhat."
 
-#: ../fheroes2/battle/battle_interface.cpp:613
-#: ../fheroes2/battle/battle_interface.cpp:1401
 msgid "View %{monster} info."
 msgstr "Megmutatja %{monster} információját."
 
-#: ../fheroes2/battle/battle_interface.cpp:1409
 #, fuzzy
 msgid "Shoot %{monster}"
 msgstr "%{monster} kiválasztása"
 
-#: ../fheroes2/battle/battle_interface.cpp:1431
 msgid "Attack %{monster}"
 msgstr "%{monster} támad"
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Fly %{monster} here."
 msgstr "A %{monster} ide repül."
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Move %{monster} here."
 msgstr "A %{monster} ide menjen."
 
-#: ../fheroes2/battle/battle_interface.cpp:1449
-#: ../fheroes2/battle/battle_interface.cpp:1538
 msgid "Turn %{turn}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1475
 msgid "Teleport Here"
 msgstr "Teleportálás Ide"
 
-#: ../fheroes2/battle/battle_interface.cpp:1479
 msgid "Invalid Teleport Destination"
 msgstr "Helytelen Teleport Cél"
 
-#: ../fheroes2/battle/battle_interface.cpp:1485
 msgid "Cast %{spell} on %{monster}"
 msgstr "%{spell} varázslat idézése a(z) %{monster} lényre"
 
-#: ../fheroes2/battle/battle_interface.cpp:1495
 msgid "Cast %{spell}"
 msgstr "Varázsolj %{spell}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1501
 msgid "Select Spell Target"
 msgstr "Varázslat célpontjának választása."
 
-#: ../fheroes2/battle/battle_interface.cpp:1674
-msgid "Spell cast"
-msgstr "Varázslás"
-
-#: ../fheroes2/battle/battle_interface.cpp:1686
 #, fuzzy
 msgid "View Ballista Info"
 msgstr "Morál információ"
 
-#: ../fheroes2/battle/battle_interface.cpp:1699
-#: ../fheroes2/battle/battle_tower.cpp:53
 msgid "Ballista"
 msgstr "Dobógép"
 
-#: ../fheroes2/battle/battle_interface.cpp:1712
 msgid "Auto combat"
 msgstr "Automatikus harc"
 
-#: ../fheroes2/battle/battle_interface.cpp:1719
 msgid "Customize system options."
 msgstr "Rendszerbeállítások testreszabása"
 
-#: ../fheroes2/battle/battle_interface.cpp:1727
 msgid "Wait this unit"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1734
 msgid "Skip this unit"
 msgstr "Egység kihagyása"
 
-#: ../fheroes2/battle/battle_interface.cpp:1742
-#: ../fheroes2/battle/battle_interface.cpp:1774
-msgid "Hero's Options"
-msgstr "Hős opciói"
-
-#: ../fheroes2/battle/battle_interface.cpp:1753
-#: ../fheroes2/battle/battle_interface.cpp:1785
 msgid "View Opposing Hero"
 msgstr "Ellenséges hős megmutatása"
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Hide logs"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Show logs"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1878
 msgid "%{color} cast spell: %{spell}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2202
 msgid "%{name} skipping turn"
 msgstr "%{name} kör kihagyása"
 
-#: ../fheroes2/battle/battle_interface.cpp:2203
-msgid ", and get +2 defense"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:2206
 msgid "%{name} waiting turn"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2343
 msgid "%{attacker} do %{damage} damage."
 msgstr "A %{attacker} %{damage} sebzett."
 
-#: ../fheroes2/battle/battle_interface.cpp:2497
 #, fuzzy
 msgid "Moved %{monster}: %{src}, %{dst}"
 msgstr "A %{monster} ide menjen."
 
-#: ../fheroes2/battle/battle_interface.cpp:2612
+#, fuzzy
+msgid "Moved %{monster}"
+msgstr "A %{monster} ide menjen."
+
 msgid "The %{name} resist the spell!"
 msgstr "A %{name} ellenáll a varázslatnak!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2625
 msgid "%{name} casts %{spell} on the %{troop}."
 msgstr "%{name}  %{spell} -t varázsol a %{troop} -re."
 
-#: ../fheroes2/battle/battle_interface.cpp:2630
 msgid "%{name} casts %{spell}."
 msgstr "%{name} %{spell} -t  varázsol."
 
-#: ../fheroes2/battle/battle_interface.cpp:2751
-msgid "The %{spell} spell does %{damage} damage to all undead creatures."
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to one undead creature."
 msgstr ""
 "A %{spell} varázslat %{damage} sebzést okoz valamennyi élőhalott lénynek.."
 
-#: ../fheroes2/battle/battle_interface.cpp:2754
-msgid "The %{spell} spell does %{damage} damage to all living creatures."
-msgstr "A %{spell} varázslat %{damage} sebzést okoz valamennyi élő lénynek.."
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to all undead creatures."
+msgstr ""
+"A %{spell} varázslat %{damage} sebzést okoz valamennyi élőhalott lénynek.."
 
-#: ../fheroes2/battle/battle_interface.cpp:2756
+#, fuzzy
+msgid "The %{spell} does %{damage} damage, %{count} creatures perish."
+msgstr ""
+"A %{spell} varázslat %{damage} sebzést okoz valamennyi élőhalott lénynek.."
+
 msgid "The %{spell} does %{damage} damage."
 msgstr "The %{spell} varázslat %{damage} sebzést okoz."
 
-#: ../fheroes2/battle/battle_interface.cpp:2797
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to one living creature."
+msgstr "A %{spell} varázslat %{damage} sebzést okoz valamennyi élő lénynek.."
+
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to all living creatures."
+msgstr "A %{spell} varázslat %{damage} sebzést okoz valamennyi élő lénynek.."
+
 msgid "The Unicorns attack blinds the %{name}!"
 msgstr "Az Unikornis megvakítja a(z) %{name}!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2798
 msgid "The Medusas gaze turns the %{name} to stone!"
 msgstr "A Medúza szeme kővé változtatta a(z) %{name} lényt!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2800
 msgid "The Mummies' curse falls upon the %{name}!"
 msgstr "A Múmiák átka lesújt a(z) %{name}!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2801
 msgid "The %{name} are paralyzed by the Cyclopes!"
 msgstr "A Küklopsz lebénítja a(z) %{name} lényt!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2802
 msgid "The Archmagi dispel all good spells on your %{name}!"
 msgstr "A főmágus eloszlatja az összes pozitív varázslatot a %{name} lényről!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2820
-msgid "Good luck shines on the  %{attacker}"
+#, fuzzy
+msgid "Good luck shines on the %{attacker}"
 msgstr "A Jó szerencse regyog a  %{attacker}"
 
-#: ../fheroes2/battle/battle_interface.cpp:2872
 msgid "Bad luck descends on the %{attacker}"
 msgstr "A %{attacker} lénynek balszerencséje van."
 
-#: ../fheroes2/battle/battle_interface.cpp:2884
 msgid "High morale enables the %{monster} to attack again."
 msgstr "A jó morál következtében a(z) %{monster} újra támadhat."
 
-#: ../fheroes2/battle/battle_interface.cpp:2891
 msgid "Low morale causes the %{monster} to freeze in panic."
 msgstr "Az alacsony morál miatt a(z) %{monster} pánikba esett."
 
-#: ../fheroes2/battle/battle_interface.cpp:2944
-msgid "Tower do %{damage} damage."
-msgstr "A torony %{damage} sebzést okoz."
+#, fuzzy
+msgid "%{tower} does %{damage} damage."
+msgstr "%{tower} sebzése %{dmg}"
 
-#: ../fheroes2/battle/battle_interface.cpp:3257
 msgid "MirrorImage created"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:3798
-msgid "MirrorImage ended"
+msgid "The mirror image is destroyed!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4089
 #, fuzzy
 msgid "Break auto battle?"
 msgstr "Automata harc bekapcsolása"
 
-#: ../fheroes2/battle/battle_interface.cpp:4138
 msgid "No spells to cast."
 msgstr "Nincsenek varázslatai."
 
-#: ../fheroes2/battle/battle_interface.cpp:4147
 msgid "Are you sure you want to retreat?"
 msgstr "Biztos, hogy vissza akarsz vonulni?"
 
-#: ../fheroes2/battle/battle_interface.cpp:4155
 #, fuzzy
 msgid "Retreat disabled"
 msgstr "Visszavonulás"
 
-#: ../fheroes2/battle/battle_interface.cpp:4169
-msgid "You don't have enough gold!"
-msgstr "Nincs elég aranyod!"
-
-#: ../fheroes2/battle/battle_interface.cpp:4180
 #, fuzzy
 msgid "Surrender disabled"
 msgstr "Feladás"
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{min} - %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{min} - %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_main.cpp:190
-msgid "You have captured an enemy artifact!"
-msgstr "Megszereztél egy tárgyat az ellenségtől!"
-
-#: ../fheroes2/battle/battle_main.cpp:241
 msgid ""
-"Through eagle-eyed observation, %{name} is able to learn the magic spell %"
-"{spell}."
+"Through eagle-eyed observation, %{name} is able to learn the magic spell "
+"%{spell}."
 msgstr ""
 "A sasszemű megfigyelés következtében %{name} az alábbi varázslatot tanulja "
 "meg: %{spell}."
 
-#: ../fheroes2/battle/battle_main.cpp:280
-msgid ""
-"Practicing the dark arts of necromancy, you are able to raise %{count} of "
-"the enemy's dead to return under your service as %{monster}"
-msgstr ""
-"A szellemidézés tudományának köszönhetően képes vagy az ellenség seregében "
-"elhullott lényekből %{count} %{monster} lényt feltámasztani ."
-
-#: ../fheroes2/battle/battle_tower.cpp:47 ../fheroes2/castle/castle.cpp:466
 msgid "Left Turret"
 msgstr "Bal torony"
 
-#: ../fheroes2/battle/battle_tower.cpp:48 ../fheroes2/castle/castle.cpp:467
 msgid "Right Turret"
 msgstr "Jobb torony"
 
-#: ../fheroes2/battle/battle_tower.cpp:115
 msgid "The %{name} fires with the strength of %{count} Archers"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:116
 msgid "each with a +%{attack} bonus to their attack skill."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:863
-msgid "%{name} half the enemy troops!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_troop.cpp:950
 msgid ""
 "The %{artifact} artifact is in effect for this battle, disabling %{spell} "
 "spell."
@@ -678,409 +549,776 @@ msgstr ""
 "A(z) %{artifact} varázstárgy hatása miatt a %{spell} varázslat nem "
 "használható a csatában."
 
-#: ../fheroes2/battle/battle_troop.cpp:1598
 msgid "%{count} %{name} rise(s) from the dead!"
 msgstr "%{count} %{name} lényt feltámasztották a halálból!"
 
-#: ../fheroes2/castle/buildinginfo.cpp:258
+#, fuzzy
+msgid "Sorceress Guild"
+msgstr "Varázslónő"
+
+#, fuzzy
+msgid "Necromancer Guild"
+msgstr "Hullamágus"
+
+#, fuzzy
+msgid "Dragon Alliance"
+msgstr "Sárkányölő"
+
+msgid "Elven Alliance"
+msgstr ""
+
+msgid "Wayward Son"
+msgstr ""
+
+msgid "Uncle Ivan"
+msgstr "Uncle nagybácsi"
+
+#, fuzzy
+msgid "Force of Arms"
+msgstr "\"Karok Ereje\""
+
+#, fuzzy
+msgid "Annexation"
+msgstr "animáció"
+
+#, fuzzy
+msgid "Save the Dwarves"
+msgstr "Törp harcos"
+
+#, fuzzy
+msgid "Carator Mines"
+msgstr "Kristálybánya"
+
+#, fuzzy
+msgid "Turning Point"
+msgstr "Fordulópont"
+
+msgid "The Gauntlet"
+msgstr ""
+
+#, fuzzy
+msgid "The Crown"
+msgstr "\"Korona\""
+
+#, fuzzy
+msgid "Corlagon's Defense"
+msgstr "Sárkány Szem"
+
+msgid "Final Justice"
+msgstr ""
+
+#, fuzzy
+msgid "First Blood"
+msgstr "\"Első vérig\""
+
+#, fuzzy
+msgid "Barbarian Wars"
+msgstr "Barbár"
+
+#, fuzzy
+msgid "Necromancers"
+msgstr "Hullamágus"
+
+#, fuzzy
+msgid "Slay the Dwarves"
+msgstr "Törp harcos"
+
+msgid "Rebellion"
+msgstr ""
+
+#, fuzzy
+msgid "Dragon Master"
+msgstr "\"Sárkánymester\""
+
+#, fuzzy
+msgid "Country Lords"
+msgstr "Ogre Nagyúr"
+
+#, fuzzy
+msgid "Greater Glory"
+msgstr "Nemes Druida"
+
+msgid "Apocalypse"
+msgstr ""
+
+msgid "Uprising"
+msgstr ""
+
+msgid "Island of Chaos"
+msgstr ""
+
+msgid "Arrow's Flight"
+msgstr ""
+
+msgid "The Abyss"
+msgstr ""
+
+msgid "The Giant's Pass"
+msgstr ""
+
+msgid "Aurora Borealis"
+msgstr ""
+
+#, fuzzy
+msgid "Betrayal's End"
+msgstr "\"Árulás!'"
+
+#, fuzzy
+msgid "Corruption's Heart"
+msgstr "Kapitány Őrház"
+
+msgid "Conquer and Unify"
+msgstr ""
+
+#, fuzzy
+msgid "Border Towns"
+msgstr "Városok mutatása"
+
+msgid "The Wayward Son"
+msgstr ""
+
+#, fuzzy
+msgid "Crazy Uncle Ivan"
+msgstr "Uncle nagybácsi"
+
+msgid "The Southern War"
+msgstr ""
+
+msgid "Ivory Gates"
+msgstr "Ivory Gates"
+
+msgid "The Elven Lands"
+msgstr ""
+
+msgid "The Epic Battle"
+msgstr ""
+
+#, fuzzy
+msgid "The Shrouded Isles"
+msgstr "Emerald-sziget"
+
+#, fuzzy
+msgid "The Eternal Scrolls"
+msgstr "Emerald-sziget"
+
+#, fuzzy
+msgid "Power's End"
+msgstr "Hatalom gyűrűje"
+
+#, fuzzy
+msgid "Fount of Wizardry"
+msgstr "Varázsjogar"
+
+msgid "Stranded"
+msgstr ""
+
+msgid "Pirate Isles"
+msgstr ""
+
+msgid "King and Country"
+msgstr ""
+
+msgid "Blood is Thicker"
+msgstr ""
+
+msgid ""
+"Roland needs you to defeat the lords near his castle to begin his war of "
+"rebellion against his brother.  They are not allied with each other, so they "
+"will spend most of their time fighting with one another.  Victory is yours "
+"when you have defeated all of their castles and heroes."
+msgstr ""
+
+msgid ""
+"The local lords refuse to swear allegiance to Roland, and must be subdued. "
+"They are wealthy and powerful, so be prepared for a tough fight. Capture all "
+"enemy castles to win."
+msgstr ""
+
+msgid ""
+"Your task is to defend the Dwarves against Archibald's forces. Capture all "
+"of the enemy towns and castles to win, and be sure not to lose all of the "
+"dwarf towns at once, or the enemy will have won."
+msgstr ""
+
+msgid ""
+"You will face four allied enemies in a straightforward fight for resource "
+"and treasure. Capture all of the enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Your enemies are allied against you and start close by, so be ready to come "
+"out fighting. You will need to own all four castles in this small valley to "
+"win."
+msgstr ""
+
+msgid ""
+"The Sorceress' guild of Noraston has requested Roland's aid against an "
+"attack from Archibald's allies. Capture all of the enemy castles to win, and "
+"don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy "
+"castle on an island in the ocean.)"
+msgstr ""
+
+msgid ""
+"Gather as large an army as possible and capture the enemy castle within 8 "
+"weeks. You are opposed by only one enemy, but must travel a long way to get "
+"to the enemy castle. Any troops you have in your army at the end of this "
+"scenario will be with you in the final battle."
+msgstr ""
+
+msgid ""
+"Find the Crown before Archibald's heroes find it. Roland will need the Crown "
+"for the final battle against Archibald."
+msgstr ""
+
+msgid ""
+"Three allied enemies stand before you and victory, including Lord Corlagon. "
+"Roland is in a castle to the northwest, and you will lose if he falls to the "
+"enemy. Remember that capturing Lord Corlagon will ensure that he will not "
+"fight against you in the final scenario."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Archibald to end the war!"
+msgstr ""
+
+msgid ""
+"King Archibald requires you to defeat the three enemies in this region.  "
+"They are not allied with one another, so they will spend most of their "
+"energy fighting amongst themselves.  You will win when you own all of the "
+"enemy castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"You must unify the barbarian tribes of the north by conquering them. As in "
+"the previous mission, the enemy is not allied against you, but they have "
+"more resources at their disposal. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"Do-gooder wizards have taken the Necromancers' castle. You must retake it to "
+"achieve victory. Remember that while you start with a powerful army, you "
+"have no castle and must take one within 7 days, or lose this battle. (Hint: "
+"The nearest castle is to the southeast.)"
+msgstr ""
+
+msgid ""
+"The dwarves need conquering before they can interfere in King Archibald's "
+"plans. Roland's forces have more than one hero and many towns to start with, "
+"so be ready for attack from multiple directions. You must capture all of the "
+"enemy towns and castles to claim victory."
+msgstr ""
+
+msgid ""
+"You must put down a peasant revolt led by Roland's forces. All are allied "
+"against you, but you have Lord Corlagon, an experienced hero, to help you. "
+"Capture all enemy castles to win."
+msgstr ""
+
+msgid ""
+"There are two enemies allied against you in this mission. Both are well "
+"armed and seek to evict you from their island. Avoid them and capture Dragon "
+"City to win"
+msgstr ""
+
+msgid ""
+"Your orders are to conquer the country lords that have sworn to serve "
+"Roland. All of the enemy castles are unified against you. Since you start "
+"without a castle, you must hurry to capture one before the end of the week. "
+"Capture all enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Find the Crown before Roland's heroes find it. Archibald will need the Crown "
+"for the final battle against Roland."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Roland to win the war, and be sure "
+"not to lose Archibald in the fight!"
+msgstr ""
+
+msgid ""
+"Subdue the unruly local lords in order to provide the Empire with facilities "
+"to operate in this region."
+msgstr ""
+
+msgid ""
+"Eliminate all oposition in this area. Then the first piece of the artifact "
+"will be yours."
+msgstr ""
+
+msgid ""
+"The sorceresses to the northeast are rebelling! For the good of the empire "
+"you must quash their feeble uprising on your way to the mountains."
+msgstr ""
+
+msgid ""
+"Having prepared for your arrival, Kraeger has arranged for a force of "
+"necromancers to thwart your quest. You must capture the castle of Scabsdale "
+"before the first day of the third week, or the Necromancers will be too "
+"strong for you."
+msgstr ""
+
+msgid ""
+"The barbarian despot in this area is, as yet, ignorant of your presence. "
+"Quickly, build up your forces before you are discovered and attacked! Secure "
+"the region by subduing all enemy forces."
+msgstr ""
+
+msgid ""
+"The Empire is weak in this region. You will be unable to completely subdue "
+"all forces in this area, so take what you can before reprisal strikes. "
+"Remember, your true goal is to claim the Helmet of Anduran."
+msgstr ""
+
+msgid "For the good of the Empire, eliminate Kraeger."
+msgstr ""
+
+msgid ""
+"At last, you have the opportunity and the facilities to rid the Empire of "
+"the necromancer's evil. Eradicate them completely, and you will be sung as a "
+"hero for all time."
+msgstr ""
+
+msgid ""
+"Conquer and unite all the enemy tribes. Don't lose the hero Jarkonas, the "
+"forefather of all descendants."
+msgstr ""
+
+msgid ""
+"Your rival, the Kingdom of Harondale, is attacking weak towns on your "
+"border! Recover from their first strike and crush them completely!"
+msgstr ""
+
+msgid ""
+"Find your wayward son Joseph who is rumored to be living in the desolate "
+"lands. Do it before the first day of the third month or it will be of no "
+"help to your family."
+msgstr ""
+
+msgid ""
+"Rescue your crazy uncle Ivan. Find him before the first day of the fourth "
+"month or it will be no help to your kingdom."
+msgstr ""
+
+msgid ""
+"Destroy the barbarians who are attacking the southern border of your "
+"kingdom! Recover your fallen towns, and then invade the jungle kingdom. "
+"Leave no enemy standing."
+msgstr ""
+
+msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
+msgstr ""
+
+msgid ""
+"Gain the favor of the elves. They will not allow trees to be chopped down, "
+"so they will send you wood every 2 weeks. You must complete your mission "
+"before the first day of the seventh month, or the kingdom will surely fall."
+msgstr ""
+
+msgid ""
+"This is the final battle against your rival kingdom of Harondale. Eliminate "
+"everyone, and don't lose the hero Jarkonas VI."
+msgstr ""
+
+msgid ""
+"Your mission is to vanquish the warring mages in the magical Shrouded Isles. "
+"The completion of this task will give you a fighting chance against your "
+"rivals."
+msgstr ""
+
+msgid ""
+"The location of the great library has been dicovered! You must make your way "
+"to it, and reclaim the city of Chronos in which it lies."
+msgstr ""
+
+msgid ""
+"Find the Orb of negation, which is said to be buried in this land. There are "
+"clues inscribed on stone obelisks which will help lead you to your price. "
+"Find the orb before the first day of the sixth month, or your rivals will "
+"surely have gotten to the fount before you."
+msgstr ""
+
+msgid ""
+"You must take control of the castle of Magic, where the fount of wizardry "
+"lies. Do this and your victory will be supreme."
+msgstr ""
+
+msgid ""
+"Capture the town on the island off the southeast shore in order to construct "
+"a boat and travel back towards the mainland. Do not lose the hero Gallavant."
+msgstr ""
+
+msgid ""
+"Find and defeat Martine, the pirate leader, who resides in Pirates Cove. Do "
+"not lose Gallavant or your quest will be over."
+msgstr ""
+
+msgid ""
+"Eliminate all the other forces who oppose the rule of Lord Alberon. "
+"Gallavant must not die."
+msgstr ""
+
+msgid ""
+"Overthrow the entrenched monarchy of Lord Alberon, and claim all the land in "
+"your name. Gallavant must not die."
+msgstr ""
+
+msgid " bane"
+msgstr ""
+
+msgid " alliance"
+msgstr ""
+
+msgid "Carry-over forces"
+msgstr ""
+
+#, fuzzy
+msgid " bonus"
+msgstr "bónusz a pirosnak"
+
+msgid " defeated"
+msgstr ""
+
+#, fuzzy
+msgid "Thunder Mace"
+msgstr "Hatalom Mennydörgő Buzogánya"
+
+msgid "Minor Scroll"
+msgstr "Kis Pergamentekercs"
+
+msgid "Dragon Sword"
+msgstr "Sárkánykard"
+
+#, fuzzy
+msgid "Breastplate"
+msgstr "Anduran Mellvértje"
+
+msgid "Fibzin Medal"
+msgstr ""
+
+#, fuzzy
+msgid "Mage's ring"
+msgstr "Varázsgyűrű"
+
+#, fuzzy
+msgid "Defender Helm"
+msgstr "Védekező"
+
+#, fuzzy
+msgid "Power Axe"
+msgstr "Erő"
+
+#, fuzzy
+msgid "Summon Earth"
+msgstr "Hajó idézése"
+
 msgid "The %{building} produces %{monster}."
 msgstr "A(z) %{building} %{monster}-t termel."
 
-#: ../fheroes2/castle/buildinginfo.cpp:505
 msgid "Requires:"
 msgstr "Szükséges:"
 
-#: ../fheroes2/castle/buildinginfo.cpp:597
 msgid "Cannot build. Already built here this turn."
 msgstr "Nem építhető. Már építettél ide ebben körben."
 
-#: ../fheroes2/castle/buildinginfo.cpp:601
 msgid "For this action it is necessary first to build a castle."
 msgstr "Ehhez a művelethez először a kastélyt fel kell építeni."
 
-#: ../fheroes2/castle/buildinginfo.cpp:623
 msgid "Cannot build %{name} because castle is too far from water."
 msgstr "Nem lehet %{name} építeni, mert a vár túl messze van a víztől."
 
-#: ../fheroes2/castle/buildinginfo.cpp:631
-msgid "Cannot afford %{name}"
-msgstr ""
+#, fuzzy
+msgid "Cannot afford %{name}."
+msgstr "Nem vásárolható meg a Hős"
 
-#: ../fheroes2/castle/buildinginfo.cpp:636
-msgid "%{name} is already built"
+#, fuzzy
+msgid "%{name} is already built."
 msgstr "%{name} már felépült"
 
-#: ../fheroes2/castle/buildinginfo.cpp:641
-msgid "Cannot build %{name}"
+#, fuzzy
+msgid "Cannot build %{name}."
 msgstr "%{name}-t nem lehet építeni."
 
-#: ../fheroes2/castle/buildinginfo.cpp:646
-msgid "Build %{name}"
+#, fuzzy
+msgid "Build %{name}."
 msgstr "%{name} építése"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Thieves' Guild"
 msgstr "Tolvajcéh"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Tavern"
 msgstr "Fogadó"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Shipyard"
 msgstr "Hajógyár"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Well"
 msgstr "Kút"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Statue"
 msgstr "Szobor"
 
-#: ../fheroes2/castle/castle.cpp:467
-#: ../fheroes2/dialog/dialog_marketplace.cpp:212
 msgid "Marketplace"
 msgstr "Piactér"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Moat"
 msgstr "Várárok"
 
-#: ../fheroes2/castle/castle.cpp:467 ../fheroes2/maps/mp2.cpp:391
 msgid "Castle"
 msgstr "Kastély"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Tent"
 msgstr "Sátor"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Captain's Quarters"
 msgstr "Kapitány Őrház"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Mage Guild, Level 1"
 msgstr "Varázstorony, 1. szint"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 2"
 msgstr "Varázstorony, 2. szint"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 3"
 msgstr "Varázstorony, 3. szint"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 4"
 msgstr "Varázstorony, 4. szint"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 5"
 msgstr "Varázstorony, 5. szint"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Farm"
 msgstr "Tanya"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Garbage Heap"
 msgstr "Szemétdomb"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Crystal Garden"
 msgstr "Kristálykert"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Waterfall"
 msgstr "Vízesés"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Orchard"
 msgstr "Gyümölcsöskert"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Skull Pile"
 msgstr "Csonthalom"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Fortifications"
 msgstr "Erődítmények"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Coliseum"
 msgstr "Kolosszeum"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Rainbow"
 msgstr "Szivárvány"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Dungeon"
 msgstr "Kazamata"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Library"
 msgstr "Könyvtár"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Storm"
 msgstr "Vihar"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:498
 msgid "Thatched Hut"
 msgstr "Nádkunyhó"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Hut"
 msgstr "Kunyhó"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Treehouse"
 msgstr "Faház"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:441
 msgid "Cave"
 msgstr "Barlang"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Habitat"
 msgstr "Hobbit-lak"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:431
 msgid "Excavation"
 msgstr "Ásatás"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:477
 msgid "Archery Range"
 msgstr "Íjászpálya"
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Stick Hut"
 msgstr "Fakunyhó"
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Cottage"
 msgstr "Törpe kunyhó"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Crypt"
 msgstr "Kripta"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Pen"
 msgstr "Akol"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/maps/mp2.cpp:371
 msgid "Graveyard"
 msgstr "Sírkert"
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Blacksmith"
 msgstr "Kovácsműhely"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Den"
 msgstr "Barlang"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Nest"
 msgstr "Fészek"
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Foundry"
 msgstr "Öntöde"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:480
-#: ../fheroes2/castle/castle.cpp:487 ../fheroes2/maps/mp2.cpp:427
-#: ../fheroes2/resource/maps_text.cpp:521
 msgid "Pyramid"
 msgstr "Piramis"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Armory"
 msgstr "Fegyverkovács"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Adobe"
 msgstr "Vályogház"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Stonehenge"
 msgstr "Kőkör"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Maze"
 msgstr "Útvesztő"
 
-#: ../fheroes2/castle/castle.cpp:478 ../fheroes2/castle/castle.cpp:485
 msgid "Cliff Nest"
 msgstr "Sziklafészek"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Mansion"
 msgstr "Kúria"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Jousting Arena"
 msgstr "Lovarda"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Bridge"
 msgstr "Híd"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
 msgid "Fenced Meadow"
 msgstr "Legelő"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Swamp"
 msgstr "Mocsár"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Ivory Tower"
 msgstr "Elefántcsont torony"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Mausoleum"
 msgstr "Mauzóleum"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cathedral"
 msgstr "Katedrális"
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Red Tower"
 msgstr "Vörös torony"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Green Tower"
 msgstr "Zöld torony"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cloud Castle"
 msgstr "Fellegvár"
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Laboratory"
 msgstr "Laboratórium"
 
-#: ../fheroes2/castle/castle.cpp:483 ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Archery Range"
 msgstr "Fejlesztett íjászpálya"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Stick Hut"
 msgstr "Fejlesztett Fakunyhó"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Cottage"
 msgstr "Fejlesztett törpe kunyhó"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Graveyard"
 msgstr "Fejlesztett sírkert"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Blacksmith"
 msgstr "Fejlesztett kovácsműhely"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Foundry"
 msgstr "Fejlesztett Öntöde"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Pyramid"
 msgstr "Fejlesztett piramis"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Armory"
 msgstr "Fejlesztett fegyverkovács"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Adobe"
 msgstr "Fejlesztett vályogház"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Stonehenge"
 msgstr "Fejlesztett kőkör"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Maze"
 msgstr "Fejlesztett útvesztő"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Mansion"
 msgstr "Fejlesztett kúria"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Jousting Arena"
 msgstr "Fejlesztett lovarda"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Bridge"
 msgstr "Fejlesztett híd"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Ivory Tower"
 msgstr "Fejlesztett elefántcsont torony"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Mausoleum"
 msgstr "Fejlesztett mauzóleum"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cathedral"
 msgstr "Fejlesztett katedrális"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cloud Castle"
 msgstr "Fejlesztett fellegvár"
 
-#: ../fheroes2/castle/castle.cpp:488
 msgid "Black Tower"
 msgstr "Fekete torony"
 
-#: ../fheroes2/castle/castle.cpp:490
 msgid "Shrine"
 msgstr "Szentély"
 
-#: ../fheroes2/castle/castle.cpp:552
+#, fuzzy
 msgid ""
 "The Thieves' Guild provides information on enemy players. Thieves' Guilds "
-"can also provide scouting information on enemy towns."
+"can also provide scouting information on enemy towns. Additional Guilds "
+"provide more information."
 msgstr ""
 "A Tolvajcéh tagjai hasznos információkkal tudnak szolgálni az ellenfelekről, "
 "illetve kémkedhetnek az ellenséges városokban."
 
-#: ../fheroes2/castle/castle.cpp:553
 msgid "The Tavern increases morale for troops defending the castle."
 msgstr "A Fogadó növeli a kastélyt védő katonák morálját."
 
-#: ../fheroes2/castle/castle.cpp:554
 msgid "The Shipyard allows ships to be built."
 msgstr "A Hajógyárban építhetsz hajókat."
 
-#: ../fheroes2/castle/castle.cpp:555
 msgid ""
 "The Well increases the growth rate of all dwellings by %{count} creatures "
 "per week."
 msgstr "A Kút hetente %{count}-vel növeli az összes lény szaporulatát."
 
-#: ../fheroes2/castle/castle.cpp:556
 msgid "The Statue increases your town's income by %{count} per day."
 msgstr "A Szobor naponta %{count}-nel növeli a város bevételét."
 
-#: ../fheroes2/castle/castle.cpp:557
 msgid "The Left Turret provides extra firepower during castle combat."
 msgstr "A Bal Torony megnöveli a kastélyod tűzerejét ostrom idején."
 
-#: ../fheroes2/castle/castle.cpp:558
 msgid "The Right Turret provides extra firepower during castle combat."
 msgstr "A Jobb Torony megnöveli a kastélyod tűzerejét ostrom idején."
 
-#: ../fheroes2/castle/castle.cpp:559
 msgid ""
 "The Marketplace can be used to convert one type of resource into another. "
 "The more marketplaces you control, the better the exchange rate."
@@ -1088,7 +1326,6 @@ msgstr ""
 "A Piactéren vásárolhatsz és eladhatsz nyersanyagokat. Több Piactér "
 "birtoklása javítja az átváltási arányt."
 
-#: ../fheroes2/castle/castle.cpp:560
 msgid ""
 "The Moat slows attacking units. Any unit entering the moat must end its turn "
 "there and becomes more vulnerable to attack."
@@ -1096,7 +1333,6 @@ msgstr ""
 "A Vizesárok lassítja a támadó egységeket. Minden egység, aki belelép az "
 "árokba, ott be kell fejezze a körét és sebezhetőbbé válik."
 
-#: ../fheroes2/castle/castle.cpp:561
 msgid ""
 "The Castle improves town defense and increases income to %{count} gold per "
 "day."
@@ -1104,13 +1340,11 @@ msgstr ""
 "A Kastély fejleszti a város védelmét és növeli naponta %{count} arannyal a "
 "bevételét."
 
-#: ../fheroes2/castle/castle.cpp:562
 msgid ""
 "The Tent provides workers to build a castle, provided the materials and the "
 "gold are available."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:563
 msgid ""
 "The Captain's Quarters provides a captain to assist in the castle's defense "
 "when no hero is present."
@@ -1118,7 +1352,6 @@ msgstr ""
 "A Kapitány Őrház egy kapitányt biztosít, aki segít a város védelmében, "
 "amikor nincs hős a várban."
 
-#: ../fheroes2/castle/castle.cpp:564
 msgid ""
 "The Mage Guild allows heroes to learn spells and replenish their spell "
 "points."
@@ -1126,33 +1359,26 @@ msgstr ""
 "A Varázstorony lehetővé teszi varázslatok megtanulását és a varázspontok "
 "feltöltését."
 
-#: ../fheroes2/castle/castle.cpp:567
 msgid "The Farm increases production of Peasants by %{count} per week."
 msgstr "A Farm növeli a Jobbágyok termelődését hetente %{count}-vel."
 
-#: ../fheroes2/castle/castle.cpp:568
 msgid "The Garbage Heap increases production of Goblins by %{count} per week."
 msgstr "A Szemétdomb növeli a Goblinok termelődését hetente %{count}-cal."
 
-#: ../fheroes2/castle/castle.cpp:569
 msgid ""
 "The Crystal Garden increases production of Sprites by %{count} per week."
 msgstr "A Kristály Kert növeli a Tündérek termelődését hetente %{count}-cal."
 
-#: ../fheroes2/castle/castle.cpp:570
 msgid "The Waterfall increases production of Centaurs by %{count} per week."
 msgstr "A Vízesés növeli a Kentaurok termelődését hetente %{count}-cal."
 
-#: ../fheroes2/castle/castle.cpp:571
 msgid "The Orchard increases production of Halflings by %{count} per week."
 msgstr ""
 "A Gyümölcsöskert növeli a Félszeretek termelődését hetente %{count}-cal."
 
-#: ../fheroes2/castle/castle.cpp:572
 msgid "The Skull Pile increases production of Skeletons by %{count} per week."
 msgstr "A Koponya Halom növeli a Csontvázak termelődését hetente %{count}-cal."
 
-#: ../fheroes2/castle/castle.cpp:575
 msgid ""
 "The Fortifications increase the toughness of the walls, increasing the "
 "number of turns it takes to knock them down."
@@ -1160,7 +1386,6 @@ msgstr ""
 "Az Erődítmények növelik a várfalak védelmét, melynek hatására több lövéssel "
 "lehet lerombolni őket."
 
-#: ../fheroes2/castle/castle.cpp:576
 msgid ""
 "The Coliseum provides inspiring spectacles to defending troops, raising "
 "their morale by two during combat."
@@ -1168,15 +1393,12 @@ msgstr ""
 "A Kolosszeum látványa lelkesíti a védőket., ezért a moráljuk kettővel nő a "
 "csata idejére."
 
-#: ../fheroes2/castle/castle.cpp:577
 msgid "The Rainbow increases the luck of the defending units by two."
 msgstr "A Szivárvány növeli a védőegységek szerencséjét 2-vel."
 
-#: ../fheroes2/castle/castle.cpp:578
 msgid "The Dungeon increases the income of the town by %{count} / day."
 msgstr "A Várbörtön naponta %{count} arannyal növeli a város bevételét."
 
-#: ../fheroes2/castle/castle.cpp:579
 msgid ""
 "The Library increases the number of spells in the Guild by one for each "
 "level of the guild."
@@ -1184,134 +1406,124 @@ msgstr ""
 "A könyvtár növeli a varázstorony varázslatainak számát 1-gyel mindegyik "
 "szinten."
 
-#: ../fheroes2/castle/castle.cpp:580
 msgid "The Storm adds +2 to the power of spells of a defending spell caster."
 msgstr "A Vihar növeli a védő varázserejét 2-vel."
 
-#: ../fheroes2/castle/castle.cpp:582
 msgid ""
 "The Shrine increases the necromancy skill of all your necromancers by 10 "
 "percent."
 msgstr ""
 "A Szentély növeli az összes nekromantád nekromancia képességét 10%-kal."
 
-#: ../fheroes2/castle/castle.cpp:632
 #, fuzzy
 msgid "Cannot recruit - you already recruit hero in current week."
 msgstr "Nem lehet tobrozni - van már hősöd ebben a városban.."
 
-#: ../fheroes2/castle/castle.cpp:645
 #, fuzzy
 msgid "Cannot recruit - guest to guard automove error."
 msgstr "Nem lehet tobrozni - túl sok hősöd van."
 
-#: ../fheroes2/castle/castle.cpp:651
 msgid "Cannot recruit - you already have a Hero in this town."
 msgstr "Nem lehet tobrozni - van már hősöd ebben a városban.."
 
-#: ../fheroes2/castle/castle.cpp:659
 msgid "Cannot recruit - you have too many Heroes."
 msgstr "Nem lehet tobrozni - túl sok hősöd van."
 
-#: ../fheroes2/castle/castle.cpp:665
 msgid "Cannot afford a Hero"
 msgstr "Nem vásárolható meg a Hős"
 
-#: ../fheroes2/castle/castle.cpp:756
 msgid "There is no room in the garrison for this army."
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:272
+msgid "Recruit %{name}"
+msgstr "%{name} toborzása"
+
 msgid "Month: %{month}, Week: %{week}, Day: %{day}"
 msgstr "Hónap: %{month}, Hét: %{week}, Nap: %{day}"
 
-#: ../fheroes2/castle/castle_dialog.cpp:393
-#: ../fheroes2/castle/castle_dialog.cpp:396
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:387
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:186
-msgid "Income:"
+#, fuzzy
+msgid "Income"
 msgstr "Jövedelem:"
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 #, fuzzy
 msgid "Join Error"
 msgstr "Hiba"
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 msgid "Army is full"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
+msgid ""
+"You must purchase a spell book to use the mage guild, but you currently have "
+"no room for a spell book. Try giving one of your artifacts to another hero."
+msgstr ""
+"Hogy használd a varázstoronyban lévő varázslatokat, szükséged van "
+"varázskönyvre, de nincs szabad hely a könyv számára. Próbálj meg egy "
+"varázstárgyat átadni egy másik hősnek."
+
 msgid "Town"
 msgstr "Város"
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
 msgid "This town may not be upgraded to a castle."
 msgstr "Ezt a várost nem lehet kastéllyá fejleszteni."
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit castle"
+#, fuzzy
+msgid "Exit Castle"
 msgstr "Kastély elhagyása"
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit town"
+#, fuzzy
+msgid "Exit Town"
 msgstr "Város elhagyása"
 
-#: ../fheroes2/castle/castle_dialog.cpp:730
-msgid "Show income"
-msgstr ""
+#, fuzzy
+msgid "Show Income"
+msgstr "Jövedelem:"
 
-#: ../fheroes2/castle/castle_dialog.cpp:734
 msgid "Show previous town"
 msgstr "Előző város mutatása"
 
-#: ../fheroes2/castle/castle_dialog.cpp:738
 msgid "Show next town"
 msgstr "Következő város mutatása"
 
-#: ../fheroes2/castle/castle_dialog.cpp:741
 #, fuzzy
 msgid "Swap Heroes"
 msgstr "Hősök mutatása"
 
-#: ../fheroes2/castle/castle_dialog.cpp:744
 #, fuzzy
 msgid "Meeting Heroes"
 msgstr "Hősök mutatása"
 
-#: ../fheroes2/castle/castle_dialog.cpp:749
 msgid "View Hero"
 msgstr "Hős mutatása"
 
-#: ../fheroes2/castle/castle_mageguild.cpp:150
+#, fuzzy
+msgid "The above spells are available here."
+msgstr "Az említett varázslatok beíródtak a varázskönyvedbe."
+
 msgid "The above spells have been added to your book."
 msgstr "Az említett varázslatok beíródtak a varázskönyvedbe."
 
-#: ../fheroes2/castle/castle_tavern.cpp:39
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:748
 msgid "A generous tip for the barkeep yields the following rumor:"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:54
 msgid "Recruit Hero"
 msgstr "Hős toborzása"
 
-#: ../fheroes2/castle/castle_town.cpp:59
-msgid "%{name} is a level %{value} %{race}"
+#, fuzzy
+msgid "%{name} is a level %{value} %{race} "
 msgstr "%{name} %{value} szintű %{race}"
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with %{count} artifacts"
+#, fuzzy
+msgid "with %{count} artifacts."
 msgstr " %{count} varázstárggyal"
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with one artifact"
+#, fuzzy
+msgid "with 1 artifact."
 msgstr " egy varázstárggyal"
 
-#: ../fheroes2/castle/castle_town.cpp:283
-#: ../fheroes2/heroes/heroes_dialog.cpp:108
+#, fuzzy
+msgid "without artifacts."
+msgstr " %{count} varázstárggyal"
+
 msgid ""
 "'Spread' combat formation spreads your armies from the top to the bottom of "
 "the battlefield, with at least one empty space between each army."
@@ -1319,7 +1531,6 @@ msgstr ""
 "'Laza' csataalakzatban az egységeid szétszóródva helyezkednek el a harcmező "
 "egyik oldalán (legalább 1 üres hely van közöttük)."
 
-#: ../fheroes2/castle/castle_town.cpp:284
 msgid ""
 "'Grouped' combat formation bunches your army toget her in the center of your "
 "side of the battlefield."
@@ -1327,115 +1538,86 @@ msgstr ""
 "'Szoros' csataalakzatban az egységeid szorosan egymás mellett helyezkednek "
 "el a harcmező oldalának közepén."
 
-#: ../fheroes2/castle/castle_town.cpp:292
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:132
-#: ../fheroes2/heroes/heroes_meeting.cpp:284
 msgid "Attack Skill"
 msgstr "Támadóerő"
 
-#: ../fheroes2/castle/castle_town.cpp:301
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:137
-#: ../fheroes2/heroes/heroes_meeting.cpp:288
 msgid "Defense Skill"
 msgstr "Védőerő"
 
-#: ../fheroes2/castle/castle_town.cpp:487
-#: ../fheroes2/heroes/heroes_dialog.cpp:334
 msgid "Spread Formation"
 msgstr "Laza felállás"
 
-#: ../fheroes2/castle/castle_town.cpp:489
-#: ../fheroes2/heroes/heroes_dialog.cpp:337
 msgid "Grouped Formation"
 msgstr "Szoros felállás"
 
-#: ../fheroes2/castle/castle_town.cpp:540
-#: ../fheroes2/castle/castle_town.cpp:553
 msgid "Recruit %{name} the %{race}"
 msgstr "%{name} a %{race} toborzása"
 
-#: ../fheroes2/castle/castle_town.cpp:561
 msgid "Set garrison combat formation to 'Spread'"
 msgstr "A helyőrség csataalakzata legyen 'Laza'."
 
-#: ../fheroes2/castle/castle_town.cpp:564
 msgid "Set garrison combat formation to 'Grouped'"
 msgstr "A helyőrség csataalakzata legyen 'Szoros'."
 
-#: ../fheroes2/castle/castle_town.cpp:567
+#, fuzzy
+msgid "Exit Castle Options"
+msgstr "Kastély beállítások"
+
 msgid "Castle Options"
 msgstr "Kastély beállítások"
 
-#: ../fheroes2/castle/castle_well.cpp:158
-msgid "Buy Monsters:"
+msgid "Not enough resources to buy monsters."
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:221
+msgid "No monsters available for purchase."
+msgstr ""
+
+#, fuzzy
+msgid "Buy Monsters"
+msgstr "Szörnyek"
+
 msgid "Town Population Information and Statistics"
 msgstr "A város lakosságának adatai és statisztikái"
 
-#: ../fheroes2/castle/castle_well.cpp:323
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:231
 msgid "Damage"
 msgstr "Sebzés"
 
-#: ../fheroes2/castle/castle_well.cpp:329
 msgid "HP"
 msgstr "ÉP"
 
-#: ../fheroes2/castle/castle_well.cpp:335
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:266
-msgid "Speed"
-msgstr "Sebesség"
-
-#: ../fheroes2/castle/castle_well.cpp:351
 msgid "Growth"
 msgstr "Szaporulat"
 
-#: ../fheroes2/castle/castle_well.cpp:355
 msgid "week"
 msgstr "hét"
 
-#: ../fheroes2/castle/castle_well.cpp:361
-#: ../fheroes2/kingdom/kingdom_overview.cpp:479
 msgid "Available"
 msgstr "Rendelkezésre áll"
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:89
 msgid "View the entire world."
 msgstr "Az egész világ mutatása."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:90
 msgid "View the obelisk puzzle."
 msgstr "Az obeliszk puzzle mutatása."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:91
 msgid "View information on the scenario you are currently playing."
 msgstr "Nézd meg az éppen játszott küldetés információit."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:92
 msgid "Dig for the Ultimate Artifact."
 msgstr "A Szent Varázstárgy kiásása."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:93
 msgid "Exit this menu without doing anything."
 msgstr "Kilépés ebből a menüből, bármilyen cselekvés nélkül."
 
-#: ../fheroes2/dialog/dialog_arena.cpp:48
+msgid "Arena"
+msgstr "Aréna"
+
 msgid ""
 "You enter the arena and face a pack of vicious lions. You handily defeat "
 "them, to the wild cheers of the crowd.  Impressed by your skill, the aged "
 "trainer of gladiators agrees to train you in a skill of your choice."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:154
-msgid ""
-"Your troops can be upgraded, but it will cost you %{ratio} times the "
-"difference in cost for each troop, rounded up to next highest number. Do you "
-"wish to upgrade them?"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:155
 msgid ""
 "Your troops can be upgraded, but it will cost you dearly. Do you wish to "
 "upgrade them?"
@@ -1443,34 +1625,42 @@ msgstr ""
 "Felfejlesztheted a csoportot, de ez többe kerül. Fel szeretnéd fejleszteni "
 "őket?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:166
 msgid "Are you sure you want to dismiss this army?"
 msgstr "Biztos vagy benne hogy feloszlatod ezt a sereget?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots Left"
 msgstr "Maradék lövések"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots"
 msgstr "Lövések"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:244
 msgid "Hit Points"
 msgstr "Életerő-pontok"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:255
 msgid "Hit Points Left"
 msgstr "Maradék életerő-pontok"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:379
+#, fuzzy
+msgid "Followers"
+msgstr "Virágok"
+
 msgid ""
-"The creature is swayed by your diplomatic tongue, and offers to join your "
+"A group of %{monster} with a desire for greater glory wish to join you.\n"
+"Do you accept?"
+msgstr ""
+"Egy  %{monster} csoportja a nagyobb dicsőség reményében csatlakozna hozzád.\n"
+"Elfogadod őket?"
+
+#, fuzzy
+msgid ""
+"The %{monster} is swayed by your diplomatic tongue, and offers to join your "
 "army for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
+"%{offer} %{monster} mindegyike csatlakozna hozzád összesen %{gold} "
+"aranyért.\n"
+"Elfogadod az ajánlatukat?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:382
 msgid ""
 "The creatures are swayed by your diplomatic\n"
 "tongue, and make you an offer:\n"
@@ -1480,7 +1670,6 @@ msgstr ""
 "egy ajánlattal állnak elő:\n"
 " \n"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:385
 msgid ""
 "%{offer} of the %{total} %{monster} will join your army, and the rest will "
 "leave you alone, for the sum of %{gold} gold.\n"
@@ -1490,7 +1679,6 @@ msgstr ""
 "aranyért. A többiek pedig elhagynának.\n"
 "Elfogadod az ajánlatot?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:387
 msgid ""
 "All %{offer} of the %{monster} will join your army for the sum of %{gold} "
 "gold.\n"
@@ -1500,30 +1688,52 @@ msgstr ""
 "aranyért.\n"
 "Elfogadod az ajánlatukat?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:401
 #, fuzzy
 msgid "(Rate: %{percent})"
 msgstr "(elérhető: %{count})"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:451
-msgid ""
-"Not room in\n"
-"the garrison"
+msgid "No room in"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:48
+#, fuzzy
+msgid "the garrison"
+msgstr "Helyőrség"
+
 msgid "Build a new ship:"
 msgstr "Új hajó építése:"
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:63
 msgid "Resource cost:"
 msgstr "Fejlesztési költség:"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:40
-msgid "For the QVGA version is not available."
-msgstr "A QVGA verzió nam alkalmazható."
+msgid "Load Game"
+msgstr "Játék betöltése"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:62
+#, fuzzy
+msgid "No save files to load."
+msgstr "Nincsenek varázslatai."
+
+msgid "New Game"
+msgstr "Új játék"
+
+msgid "Start a single or multi-player game."
+msgstr "Egy- vagy többszemélyes játék indítása"
+
+msgid "Load a previously saved game."
+msgstr "Mentett játék betöltése."
+
+#, fuzzy
+msgid "Save Game"
+msgstr "Új játék"
+
+msgid "Save the current game."
+msgstr ""
+
+msgid "Quit"
+msgstr "Kilépés"
+
+msgid "Quit out of Free Heroes of Might and Magic II."
+msgstr ""
+
 msgid ""
 "Map\n"
 "Difficulty"
@@ -1531,7 +1741,6 @@ msgstr ""
 "Térkép\n"
 "Nehézség"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:65
 msgid ""
 "Game\n"
 "Difficulty"
@@ -1539,25 +1748,18 @@ msgstr ""
 "Játék\n"
 "Nehézség"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:68
 msgid "Rating"
 msgstr "Besorolás"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:71
 msgid "Map Size"
 msgstr "Térkép mérete"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:89
-#: ../fheroes2/system/players.cpp:691
 msgid "Opponents"
 msgstr "Ellenfelek"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:92
-#: ../fheroes2/system/players.cpp:695
 msgid "Class"
 msgstr "Osztály"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:100
 msgid ""
 "Victory\n"
 "Conditions"
@@ -1565,7 +1767,6 @@ msgstr ""
 "Győzelmi\n"
 "Feltételek"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:106
 msgid ""
 "Loss\n"
 "Conditions"
@@ -1573,601 +1774,642 @@ msgstr ""
 "Vesztési\n"
 "Feltételek"
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:167
 msgid "You cannot select %{resource}!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:173
 #, fuzzy
 msgid "Select count %{resource}:"
 msgstr "%{monster} kiválasztása"
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:200
 msgid "Set Guardian"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:236
-#: ../fheroes2/dialog/dialog_guardian.cpp:292
 msgid "Your army too big!"
 msgstr "A sereged túl nagy!"
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:34
-#: ../fheroes2/dialog/dialog_levelup.cpp:44
-#: ../fheroes2/dialog/dialog_levelup.cpp:73
 msgid "%{name} has gained a level."
 msgstr "%{name} következő szintre lépett."
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:36
-#: ../fheroes2/dialog/dialog_levelup.cpp:46
-#: ../fheroes2/dialog/dialog_levelup.cpp:75
-msgid "%{skill} Skill +1"
-msgstr ""
+#, fuzzy
+msgid "%{skill} +1"
+msgstr "%{level} %{skill} információ"
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:51
 msgid "You have learned %{skill}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:93
 msgid "You may learn either:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:96
 #, fuzzy
 msgid "or"
 msgstr "Erőd"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:66
 msgid ""
 "Please inspect our fine wares. If you feel like offering a trade, click on "
 "the items you wish to trade with and for."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:104
 msgid ""
 "You have received quite a bargain. I expect to make no profit on the deal. "
 "Can I interest you in any of my other wares?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:130
 msgid "I can offer you %{count} for 1 unit of %{resfrom}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:136
 msgid "I can offer you 1 unit of %{resto} for %{count} units of %{resfrom}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:164
 msgid "Qty to trade"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:235
+msgid "Trading Post"
+msgstr "Kereskedelmi Állomás"
+
 msgid "Your Resources"
 msgstr "Erőforrásaid"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:257
 msgid "Available Trades"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:573
 msgid "n/a"
 msgstr "n/a"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:77
-msgid "guarded by %{count} of %{monster}"
+#, fuzzy
+msgid "guarded by %{count} %{monster}"
 msgstr "%{count} %{monster} őrzi."
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:149
 msgid "(available: %{count})"
 msgstr "(elérhető: %{count})"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:181
 msgid "already learned"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:205
 msgid "already knows this skill"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:212
 msgid "already has max skills"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:260
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:276
 msgid "(already visited)"
 msgstr "(már meglátogatott)"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
 msgid "(not visited)"
 msgstr "(nem látogatott)"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:296
+#, fuzzy
+msgid "Road"
+msgstr "Út Mód"
+
+msgid "(digging ok)"
+msgstr ""
+
+msgid "(no digging)"
+msgstr ""
+
 msgid "penalty: %{cost}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:382
-msgid "Unchartered Territory"
+#, fuzzy
+msgid "Uncharted Territory"
 msgstr "Felderítettlen Terület"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:635
 msgid "Defenders:"
 msgstr "Védők:"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:674
-#: ../fheroes2/heroes/heroes_indicator.cpp:125
-#: ../fheroes2/heroes/heroes_indicator.cpp:171
 msgid "None"
 msgstr "Nincs"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:756
 #, fuzzy
-msgid "%{name} ( Level %{level} )"
+msgid "Unknown"
+msgstr "Ismeretlen"
+
+#, fuzzy
+msgid "%{name} (Level %{level})"
 msgstr "%{level} szint"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:884
 msgid "Move Points"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:40
-#: ../fheroes2/dialog/dialog_recrut.cpp:579
 msgid "Available: %{count}"
 msgstr "Használható: %{count}"
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:101
-msgid "Cost per troop:"
-msgstr "Sereg ára:"
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:107
-#: ../fheroes2/dialog/dialog_recrut.cpp:506
-msgid "Recruit %{name}"
-msgstr "%{name} toborzása"
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:210
 msgid "Number to buy:"
 msgstr "Vétel (db):"
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:314
 msgid "How many troops to move?"
 msgstr "Hány egységet mozgat?"
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:358
 msgid "Fast separation into slots:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:180
 msgid "File to Save:"
 msgstr "Mentés:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:186
 msgid "File to Load:"
 msgstr "Betöltés:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:302
 msgid "Are you sure you want to delete file:"
 msgstr "Biztos benne hogy törli a fájlt:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:305
 msgid "Warning!"
 msgstr "Figyelem!"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:144
-msgid "Maps Difficulty:"
+#, fuzzy
+msgid "Map difficulty:"
 msgstr "Térkép nehézsége:"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
+msgid "No maps exist at that size"
+msgstr ""
+
 msgid "Small Maps"
 msgstr "Kicsi térképek"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
-msgid "View only maps of size small (36x36)."
+#, fuzzy
+msgid "View only maps of size small (36 x 36)."
 msgstr "Csak a kicsi térképek (36x36) mutatása."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
 msgid "Medium Maps"
 msgstr "Közepes térképek"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
-msgid "View only maps of size medium (72x72)."
+#, fuzzy
+msgid "View only maps of size medium (72 x 72)."
 msgstr "Csak a közepes térképek (72x72) mutatása."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
 msgid "Large Maps"
 msgstr "Nagy térképek"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
-msgid "View only maps of size large (108x108)."
+#, fuzzy
+msgid "View only maps of size large (108 x 108)."
 msgstr "Csak a nagy térképek (108x108) mutatása."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
 msgid "Extra Large Maps"
 msgstr "Hatalmas térképek"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
-msgid "View only maps of size extra large (144x144)."
+#, fuzzy
+msgid "View only maps of size extra large (144 x 144)."
 msgstr "Csak a hatalmas térképek (144x144) mutatása."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "All Maps"
 msgstr "Összes térkép"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "View all maps, regardless of size."
 msgstr "Összes térkép mutatása, mérettől függetlenül."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
 msgid "Players Icon"
 msgstr "Játékos ikon"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
 msgid ""
-"Indicates how many players total are in the EditScenario. Any positions not "
+"Indicates how many players total are in the scenario. Any positions not "
 "occupied by humans will be occupied by computer players."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
 msgid "Size Icon"
 msgstr "Ikon méret"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
 msgid ""
-"Indicates whether the maps is small (36x36), medium (72x72), large "
-"(108x108), or extra large (144x144)."
+"Indicates whether the map\n"
+"is small (36 x 36), medium\n"
+"(72 x 72), large (108 x 108),\n"
+"or extra large (144 x 144)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "Selected Name"
 msgstr "Kiválasztott Név"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "The name of the currently selected map."
 msgstr "A kiválasztott térkép neve"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid "Selected Map Difficulty"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid ""
 "The map difficulty of the currently selected map.  The map difficulty is "
-"determined by the EditScenario designer. More difficult maps might include "
-"more or stronger enemies, fewer resources, or other special conditions "
-"making things tougher for the human player."
+"determined by the scenario designer. More difficult maps might include more "
+"or stronger enemies, fewer resources, or other special conditions making "
+"things tougher for the human player."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "Selected Description"
 msgstr "Kiválasztott Leírás"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "The description of the currently selected map."
 msgstr "A kiválasztott térkép leírása"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
-msgid "OK"
-msgstr "Ok"
+msgid "Okay"
+msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
 msgid "Accept the choice made."
 msgstr "A választás elfogadása."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:364
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose all your heroes and towns."
 msgstr "Összes hős és város elvesztése"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:365
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific town."
 msgstr "Meghatározott város elvesztése"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:366
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific hero."
 msgstr "Meghatározott hős elvesztése"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:367
 msgid "Run out of time. Fail to win by a certain point."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:370
 msgid "Loss Condition"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:379
 msgid "Defeat all enemy heroes and towns."
 msgstr "Az ellenfelek összes hősének és városának elpusztítása."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:380
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Capture a specific town."
 msgstr "Meghatározott város elfoglalása."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:381
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat a specific hero."
 msgstr "Megadott hős elpusztítása."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:382
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Find a specific artifact."
 msgstr "Találj meg egy Különleges Varázstárgyat."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:383
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Your side defeats the opposing side."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:384
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Accumulate a large amount of gold."
 msgstr "Gyűjts össze egy nagyobb mennyiségű aranyat."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:387
 msgid "Victory Condition"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:48
-#: ../fheroes2/heroes/heroes_action.cpp:134
 msgid "one"
 msgstr "egy"
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:51
-#: ../fheroes2/heroes/heroes_action.cpp:135
 msgid "two"
 msgstr "kettő"
 
-#: ../fheroes2/dialog/dialog_system.cpp:187
-msgid "sound"
-msgstr "hang"
-
-#: ../fheroes2/dialog/dialog_system.cpp:192
-#: ../fheroes2/dialog/dialog_system.cpp:205
-#: ../fheroes2/dialog/dialog_system.cpp:228
-#: ../fheroes2/dialog/dialog_system.cpp:242
-msgid "off"
-msgstr "ki"
-
-#: ../fheroes2/dialog/dialog_system.cpp:200
-msgid "music"
+#, fuzzy
+msgid "Music"
 msgstr "zene"
 
-#: ../fheroes2/dialog/dialog_system.cpp:223
-msgid "hero speed"
+msgid "Toggle ambient music level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:237
-msgid "ai speed"
+msgid "Effects"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:251
-msgid "scroll speed"
+msgid "Toggle foreground sounds level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:262
-#: ../fheroes2/dialog/dialog_system.cpp:276
+msgid "Music Type"
+msgstr ""
+
+msgid "Change the type of music."
+msgstr ""
+
+#, fuzzy
+msgid "Hero Speed"
+msgstr "Sebesség"
+
+msgid "Change the speed at which your heroes move on the main screen."
+msgstr ""
+
+#, fuzzy
+msgid "Enemy Speed"
+msgstr "Sebesség"
+
+msgid ""
+"Sets the speed that A.I. heroes move at.  You can also elect not to view A."
+"I. movement at all."
+msgstr ""
+
+msgid "Scroll Speed"
+msgstr ""
+
+msgid "Sets the speed at which you scroll the window."
+msgstr ""
+
+#, fuzzy
+msgid "Interface Type"
+msgstr "Kezelőfelület"
+
+msgid "Toggle the type of interface you want to use."
+msgstr ""
+
 msgid "Interface"
 msgstr "Kezelőfelület"
 
-#: ../fheroes2/dialog/dialog_system.cpp:265
+msgid "Toggle interface visibility."
+msgstr ""
+
+#, fuzzy
+msgid "Battles"
+msgstr "Üveg"
+
+msgid "Toggle instant battle mode."
+msgstr ""
+
+msgid "OK"
+msgstr "Ok"
+
+msgid "Exit this menu."
+msgstr ""
+
+msgid "off"
+msgstr "ki"
+
+msgid "MIDI"
+msgstr ""
+
+#, fuzzy
+msgid "MIDI Expansion"
+msgstr "Kúria"
+
+msgid "CD Stereo"
+msgstr ""
+
+msgid "External"
+msgstr ""
+
+msgid "Jump"
+msgstr ""
+
+msgid "Don't Show"
+msgstr ""
+
 msgid "Evil"
 msgstr "Gonosz"
 
-#: ../fheroes2/dialog/dialog_system.cpp:267
 msgid "Good"
 msgstr "Jó"
 
-#: ../fheroes2/dialog/dialog_system.cpp:281
 #, fuzzy
 msgid "Hide"
 msgstr "50-99"
 
-#: ../fheroes2/dialog/dialog_system.cpp:287
 #, fuzzy
 msgid "Show"
 msgstr "Hó"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:285
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:96
+msgid "Auto Resolve"
+msgstr ""
+
+msgid "Auto, No Spells"
+msgstr ""
+
+msgid "Manual"
+msgstr ""
+
+msgid "Att."
+msgstr ""
+
+msgid "Def."
+msgstr ""
+
+msgid "Power"
+msgstr "Erő"
+
+#, fuzzy
+msgid "Knowl"
+msgstr "Tudás"
+
+msgid "Human"
+msgstr ""
+
 msgid "1st"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:286
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:97
 msgid "2nd"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:98
 msgid "3rd"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:288
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:99
 msgid "4th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:289
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:100
 msgid "5th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:290
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:101
 msgid "6th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:305
-msgid "Thieves' Guild: Player RanKings"
+#, fuzzy
+msgid "Oracle: Player Rankings"
 msgstr "Tolvajcéh: Játékos ranglista"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:315
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:114
+#, fuzzy
+msgid "Thieves' Guild: Player Rankings"
+msgstr "Tolvajcéh: Játékos ranglista"
+
 msgid "Number of Towns:"
 msgstr "Városok száma:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:324
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:123
 msgid "Number of Castles:"
 msgstr "Kastélyok száma:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:333
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:132
 msgid "Number of Heroes:"
 msgstr "Hősök száma:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:342
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:141
 msgid "Gold in Treasury:"
 msgstr "Arany a kincstárban:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:351
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:150
 msgid "Wood & Ore:"
 msgstr "Fa és érc:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:360
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:159
 msgid "Gems, Cr, Slf & Mer:"
 msgstr "Dr, Kr, S és Hg"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:369
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:168
 msgid "Obelisks Found:"
 msgstr "Látogatott obeliszkek száma:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:378
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:177
+#, fuzzy
+msgid "Artifacts:"
+msgstr "Varázstárgy"
+
 msgid "Total Army Strength:"
 msgstr "Sereg összereje:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:408
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:211
+msgid "Income:"
+msgstr "Jövedelem:"
+
 msgid "Best Hero:"
 msgstr "Legjobb hős:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:417
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:220
 msgid "Best Hero Stats:"
 msgstr "Legjobb hős statisztikái:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:426
 msgid "Personality:"
 msgstr "Személyiség:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:435
 msgid "Best Monster:"
 msgstr "Legjobb szörny:"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Easy"
 msgstr "nehézség | Könnyű"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Normal"
 msgstr "nehézség | Normál"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Hard"
 msgstr "nehézség | Nehéz"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Expert"
 msgstr "nehézség | Szakértő"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Impossible"
 msgstr "nehézség | Lehetetlen"
 
-#: ../fheroes2/game/game.cpp:314
-msgid "Maps Loading..."
+#, fuzzy
+msgid "Map is loading..."
 msgstr "Térképek töltése..."
 
-#: ../fheroes2/game/game_highscores.cpp:239
-#: ../fheroes2/game/game_highscores.cpp:242
+msgid "and more..."
+msgstr ""
+
+msgid "Campaign Scenario loading failure"
+msgstr ""
+
+msgid "Please make sure that campaign files are correct and present."
+msgstr ""
+
 #, fuzzy
 msgid "Unknown Hero"
 msgstr "Ismeretlen"
 
-#: ../fheroes2/game/game_highscores.cpp:240
 msgid "Your Name"
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:95
-msgid "Are you sure you want to overwrite the save with this name?"
-msgstr "Biztosan felülírod a mentést ezzel a névvel?"
-
-#: ../fheroes2/game/game_io.cpp:191
 msgid ""
-"This file is saved in the \"Price Loyalty\" version.\n"
+"Invalid file game type. Please ensure that you are running the latest type "
+"of save files."
+msgstr ""
+
+msgid ""
+"This file is saved in the \"The Price of Loyalty\" version.\n"
 "Some items may be unavailable."
 msgstr ""
 
-#: ../fheroes2/game/game_mainmenu.cpp:157
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:95
-msgid "Quit"
-msgstr "Kilépés"
+msgid "Hot Seat"
+msgstr ""
 
-#: ../fheroes2/game/game_mainmenu.cpp:157
+msgid ""
+"Play a Hot Seat game, where 2 to 4 players play around the same computer, "
+"switching into the 'Hot Seat' when it is their turn."
+msgstr ""
+
+msgid "Cancel back to the main menu."
+msgstr "Vissza a főmenübe"
+
+msgid "Network"
+msgstr "Hálózati játék"
+
+msgid ""
+"Play a network game, where 2 players use their own computers connected "
+"through a LAN (Local Area Network)."
+msgstr ""
+"A hálózati játékban 2 játékos játszik a saját számítógépéről helyi "
+"hálózat(LAN) segítségével."
+
+msgid "Standard Game"
+msgstr "Szimpla játék"
+
+msgid "A single player game playing out a single map."
+msgstr "Egyjátékos mód egy pályán."
+
+msgid "Campaign Game"
+msgstr "Hadjárat"
+
+msgid "A single player game playing through a series of maps."
+msgstr "Egyjátékos mód egy csomó pályán át."
+
+msgid "Multi-Player Game"
+msgstr "Többjátékos mód"
+
+msgid ""
+"A multi-player game, with several human players completing against each "
+"other on a single map."
+msgstr ""
+"A többjátékos módban több emberi játékos vesz részt, hogy legyőzze a másikat "
+"egy pályán."
+
+#, fuzzy
+msgid "Greetings!"
+msgstr "Beállítások"
+
+msgid ""
+"Welcome to Free Heroes of Might and Magic II! Before starting the game "
+"please choose game resolution."
+msgstr ""
+
+msgid "Please Remember"
+msgstr ""
+
+msgid "You can always change game resolution by clicking on the "
+msgstr ""
+
+msgid "door"
+msgstr ""
+
+msgid ""
+" on the left side of main menu.\n"
+"\n"
+"To switch between windowed and full screen modes\n"
+"press "
+msgstr ""
+
+msgid "F4"
+msgstr ""
+
+msgid ""
+" key on the keyboard.\n"
+"\n"
+"Enjoy the game!"
+msgstr ""
+
 msgid "Quit Heroes of Might and Magic and return to the operating system."
 msgstr "Kilépés a játékból és visszatérés az operációs rendszerhez."
 
-#: ../fheroes2/game/game_mainmenu.cpp:159
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:79
-msgid "Load Game"
-msgstr "Játék betöltése"
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-msgid "Load a previously saved game."
-msgstr "Mentett játék betöltése."
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:91
 msgid "Credits"
 msgstr "Készítők"
 
-#: ../fheroes2/game/game_mainmenu.cpp:161
 msgid "View the credits screen."
 msgstr "Készítők listájának megjelenítése."
 
-#: ../fheroes2/game/game_mainmenu.cpp:163
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:87
 msgid "High Scores"
 msgstr "Dicsőségtábla"
 
-#: ../fheroes2/game/game_mainmenu.cpp:163
 msgid "View the high score screen."
 msgstr "Dicsőségtábla megjelenítése."
 
-#: ../fheroes2/game/game_mainmenu.cpp:165
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:75
-msgid "New Game"
-msgstr "Új játék"
+#, fuzzy
+msgid "Select Game Resolution"
+msgstr "Kiválasztott Leírás"
 
-#: ../fheroes2/game/game_mainmenu.cpp:165
-msgid "Start a single or multi-player game."
-msgstr "Egy- vagy többszemélyes játék indítása"
+msgid "Change resolution of the game."
+msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:127
+msgid "Original Campaign"
+msgstr ""
+
+msgid ""
+"Either Roland's or Archibald's campaign from the original Heroes of Might "
+"and Magic II."
+msgstr ""
+
+msgid "Expansion Campaign"
+msgstr ""
+
+msgid "One of the four new campaigns from the Price of Loyalty expansion set."
+msgstr ""
+
 msgid "Host"
 msgstr "Kiszolgáló"
 
-#: ../fheroes2/game/game_newgame.cpp:127
 msgid ""
 "The host sets up the game options. There can only be one host per network "
 "game."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:128
 msgid "Guest"
 msgstr "Vendég"
 
-#: ../fheroes2/game/game_newgame.cpp:128
 msgid ""
 "The guest waits for the host to set up the game, then is automatically added "
 "in. There can be multiple guests for TCP/IP games."
@@ -2176,174 +2418,103 @@ msgstr ""
 "automatikusan látható lesz. Több vendég is lehet egyszerre egy hálózati "
 "játszmában."
 
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-msgid "Cancel back to the main menu."
-msgstr "Vissza a főmenübe"
+#, fuzzy
+msgid "Battle Only"
+msgstr "Harci Törpe"
 
-#: ../fheroes2/game/game_newgame.cpp:214
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:154
-msgid "Standard Game"
-msgstr "Szimpla játék"
-
-#: ../fheroes2/game/game_newgame.cpp:214
-msgid "A single player game playing out a single map."
-msgstr "Egyjátékos mód egy pályán."
-
-#: ../fheroes2/game/game_newgame.cpp:216
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:162
-msgid "Multi-Player Game"
-msgstr "Többjátékos mód"
-
-#: ../fheroes2/game/game_newgame.cpp:216
-msgid ""
-"A multi-player game, with several human players completing against each "
-"other on a single map."
+msgid "Setup and play a battle without loading any map."
 msgstr ""
-"A többjátékos módban több emberi játékos vesz részt, hogy legyőzze a másikat "
-"egy pályán."
 
-#: ../fheroes2/game/game_newgame.cpp:217
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:83
 msgid "Settings"
 msgstr "Beállítások"
 
-#: ../fheroes2/game/game_newgame.cpp:217
-msgid "FHeroes2 game settings."
+#, fuzzy
+msgid "Experimental game settings."
 msgstr "FHeroes2 játék beállítások."
 
-#: ../fheroes2/game/game_newgame.cpp:271
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:219
-msgid "Hot Seat"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:271
-msgid ""
-"Play a Hot Seat game, where 2 to 4 players play around the same computer, "
-"switching into the 'Hot Seat' when it is their turn."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:279
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:223
-msgid "Network"
-msgstr "Hálózati játék"
-
-#: ../fheroes2/game/game_newgame.cpp:279
-msgid ""
-"Play a network game, where 2 players use their own computers connected "
-"through a LAN (Local Area Network)."
-msgstr ""
-"A hálózati játékban 2 játékos játszik a saját számítógépéről helyi hálózat"
-"(LAN) segítségével."
-
-#: ../fheroes2/game/game_newgame.cpp:343
 msgid "2 Players"
 msgstr "2 játékos"
 
-#: ../fheroes2/game/game_newgame.cpp:343
 msgid ""
 "Play with 2 human players, and optionally, up, to 4 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid "3 Players"
 msgstr "3 játékos"
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid ""
 "Play with 3 human players, and optionally, up, to 3 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid "4 Players"
 msgstr "4 játékos"
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid ""
 "Play with 4 human players, and optionally, up, to 2 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid "5 Players"
 msgstr "5 játékos"
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid ""
 "Play with 5 human players, and optionally, up, to 1 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "6 Players"
 msgstr "6 játékos"
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "Play with 6 human players."
 msgstr "Játsz 6 ember játékossal."
 
-#: ../fheroes2/game/game_over.cpp:37
 #, fuzzy
 msgid "Defeat all enemy heroes and capture all enemy towns and castles."
 msgstr "Az ellenfelek összes hősének és városának elpusztítása."
 
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Run out of time. (Fail to win by a certain point.)"
 msgstr "Az idő lejárt. (Nem sikerült nyernie egyes pontokban.)"
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the castle '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the town '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:83
 msgid "Defeat the hero '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:91
 msgid "Find the ultimate artifact"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:95
 msgid "Find the '%{name}' artifact"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:102
 msgid "Accumulate %{count} gold"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:106
 msgid ""
 ", or you may win by defeating all enemy heroes and capturing all enemy towns "
 "and castles."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the castle '%{name}'."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the town '%{name}'."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:126 ../fheroes2/game/game_over.cpp:145
 msgid "Lose the hero: %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:133
 msgid "Fail to win by the end of month %{month}, week %{week}, day %{day}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:145
 msgid "Lose the heroes: %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:167
 msgid ""
 "You captured %{name}!\n"
 "You are victorious."
@@ -2351,7 +2522,6 @@ msgstr ""
 "Elfoglaltad %{name}-t!\n"
 "Győztél."
 
-#: ../fheroes2/game/game_over.cpp:175
 msgid ""
 "You have captured the enemy hero %{name}!\n"
 "Your quest is complete."
@@ -2359,7 +2529,6 @@ msgstr ""
 "Elkaptad az ellenséges %{name} hőst!\n"
 "Küldetés teljesítve."
 
-#: ../fheroes2/game/game_over.cpp:183
 msgid ""
 "You have found the %{name}.\n"
 "Your quest is complete."
@@ -2367,7 +2536,6 @@ msgstr ""
 "Megtaláltad a  %{name}-t.\n"
 "Küldetés teljesítve."
 
-#: ../fheroes2/game/game_over.cpp:195
 msgid ""
 "The enemy is beaten.\n"
 "Your side has triumphed!"
@@ -2375,7 +2543,6 @@ msgstr ""
 "Az ellenség elbukott.\n"
 "Győztél!"
 
-#: ../fheroes2/game/game_over.cpp:200
 msgid ""
 "You have built up over %{count} gold in your treasury.\n"
 "All enemies bow before your wealth and power."
@@ -2383,7 +2550,6 @@ msgstr ""
 "Sikerült %{count} aranyat felhalmoznod a kincstáradban.\n"
 "Az összes ellenfeled fejet hajt elötted."
 
-#: ../fheroes2/game/game_over.cpp:222
 msgid ""
 "The enemy has found the %{name}.\n"
 "Your quest is a failure."
@@ -2391,7 +2557,6 @@ msgstr ""
 "Az ellenség megtalálta %{name}.\n"
 "A küldetésed kudarcba fulladt."
 
-#: ../fheroes2/game/game_over.cpp:230
 msgid ""
 "%{color} has fallen!\n"
 "All is lost."
@@ -2399,17 +2564,14 @@ msgstr ""
 "%{color} elbukott!\n"
 "Minden elveszett."
 
-#: ../fheroes2/game/game_over.cpp:237
 msgid ""
 "The enemy has built up over %{count} gold in his treasury.\n"
 "You must bow done in defeat before his wealth and power."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:243
 msgid "You have been eliminated from the game!!!"
 msgstr "Kiestél a játékból!"
 
-#: ../fheroes2/game/game_over.cpp:248
 msgid ""
 "The enemy has captured %{name}!\n"
 "They are triumphant."
@@ -2417,7 +2579,6 @@ msgstr ""
 "Az ellenfél elfoglalta %{name}!\n"
 "Ők győztek.."
 
-#: ../fheroes2/game/game_over.cpp:257 ../fheroes2/game/game_over.cpp:264
 msgid ""
 "You have lost the hero %{name}.\n"
 "Your quest is over."
@@ -2425,7 +2586,6 @@ msgstr ""
 "Elvestítetted a %{name Hőst}.\n"
 "A küldetésed elbukott.."
 
-#: ../fheroes2/game/game_over.cpp:272
 msgid ""
 "You have failed to complete your quest in time.\n"
 "All is lost."
@@ -2433,106 +2593,82 @@ msgstr ""
 "Nem tudtad időben teljesíteni a küldetésed.\n"
 "Minden elveszett."
 
-#: ../fheroes2/game/game_over.cpp:320
-msgid "%{color} has been vanquished!"
+#, fuzzy
+msgid "%{color} player has been vanquished!"
 msgstr "%{color} kiesett!"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "Warning"
 msgstr "Figyelmeztetés"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "No maps available!"
 msgstr "Nincs használható térkép!"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Scenario"
 msgstr "Küldetés"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Click here to select which scenario to play."
 msgstr "Kattints ide, hogy kiválaszd melyik Küldetéssel játszol."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid "Game Difficulty"
 msgstr "Játék nehézsége"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid ""
 "This lets you change the starting difficulty at which you will play. Higher "
 "difficulty levels start you of with fewer resources, and at the higher "
 "settings, give extra resources to the computer."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid "Difficulty Rating"
 msgstr "Nehézség besorolás"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid ""
 "The difficulty rating reflects a combination of various settings for your "
 "game. This number will be applied to your final score."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
 msgid "Click to accept these settings and start a new game."
 msgstr "Kattints a beállítások elfogadásához és új játék indításához."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
 msgid "Click to return to the main menu."
 msgstr "Kattints a főmenübe való visszatéréshez."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:342
 msgid "Scenario:"
 msgstr "Küldetés:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:350
 msgid "Game Difficulty:"
 msgstr "Játék nehézsége:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:354
 msgid "Opponents:"
 msgstr "Ellenfelek:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:358
 msgid "Class:"
 msgstr "Osztály:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:384
 msgid "Rating %{rating}%"
 msgstr "Besorolás: %{rating}%"
 
-#: ../fheroes2/game/game_startgame.cpp:226
 #, fuzzy
 msgid "Astrologers proclaim Month of the %{name}."
 msgstr "Az Asztrológusok kihírdették a %{name} havát."
 
-#: ../fheroes2/game/game_startgame.cpp:226
 #, fuzzy
 msgid "Astrologers proclaim Week of the %{name}."
 msgstr "Az Asztrológusok kihírdették a %{name} hetét."
 
-#: ../fheroes2/game/game_startgame.cpp:240
 msgid "After regular growth, population of %{monster} is doubled!"
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:252
 msgid " All populations are halved."
 msgstr " Minden populáció megfeleződött."
 
-#: ../fheroes2/game/game_startgame.cpp:254
 msgid " All dwellings increase population."
 msgstr " Mindegyik toborzóhelynek nőtt a termelése."
 
-#: ../fheroes2/game/game_startgame.cpp:283
 msgid ""
 "%{color} player, your heroes abandon you, and you are banished from this "
 "land."
 msgstr "%{color} játékos, a hőseid elhagytak és száműztek erről a földről."
 
-#: ../fheroes2/game/game_startgame.cpp:290
 msgid ""
 "%{color} player, this is your last day to capture a town, or you will be "
 "banished from this land."
@@ -2540,7 +2676,6 @@ msgstr ""
 "%{color} játékos, ez az utolsó napod, hogy elfoglalj egy várost vagy "
 "száműznek erről a földről."
 
-#: ../fheroes2/game/game_startgame.cpp:295
 msgid ""
 "%{color} player, you only have %{day} days left to capture a town, or you "
 "will be banished from this land."
@@ -2548,11 +2683,10 @@ msgstr ""
 "%{color} játékos, már csak %{day} napod maradt, hogy elfoglalj egy város, "
 "vagy száműznek erről a földről."
 
-#: ../fheroes2/game/game_startgame.cpp:584
-msgid "%{color} player's turn"
+#, fuzzy
+msgid "%{color} player's turn."
 msgstr "%{color} játékos köre"
 
-#: ../fheroes2/game/game_startgame.cpp:995
 msgid ""
 "%{color} player, you have lost your last town. If you do not conquer another "
 "town in next week, you will be eliminated."
@@ -2560,138 +2694,114 @@ msgstr ""
 "Kedves %{color} játékos, elvesztetted az utolsó városod is, ha nem szerzel "
 "egy másik várost a következő héten, akkor elbuktad a játékot."
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Next Hero"
 msgstr "Következő hős"
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Select the next Hero."
 msgstr "Következő hős kiválasztása."
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue Movement"
 msgstr "Mozgás folytatása"
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue the Hero's movement along the current path."
 msgstr "Folytatódik a hős menete a jelenlegi úton."
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "Kingdom Summary"
 msgstr "Királyság összesítése"
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "View a Summary of your Kingdom."
 msgstr "Királyságod összesítésének megjelenítése."
 
-#: ../fheroes2/gui/interface_buttons.cpp:189
 msgid "Cast an adventure spell."
 msgstr "Kalandozó varázslat elsütése"
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End Turn"
 msgstr "A kör befejezése"
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End your turn and left the computer take its turn."
 msgstr "Befejezi a kört és a számítógép lép."
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Adventure Options"
 msgstr "Kaland Opciók"
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Bring up the adventure options menu."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "File Options"
 msgstr "Fájlbeállítások"
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "Bring up the file options menu, alloving you to load menu, save etc."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "System Options"
 msgstr "Rendszerbeállítások"
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "Bring up the system options menu, alloving you to customize your game."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:175
 msgid ""
 "One or more heroes may still move, are you sure you want to end your turn?"
 msgstr ""
 "Egy vagy több hős még mozoghat, biztos hogy vagy benne hogy be akarod "
 "fejezni a kört?"
 
-#: ../fheroes2/gui/interface_events.cpp:212
-msgid "Are you sure you want to restart? (Your current game will be lost)"
-msgstr "Biztos vagy benne hogy újrakezded? (A jelenlegi játékod el fog veszni)"
-
-#: ../fheroes2/gui/interface_events.cpp:276
 msgid "Are you sure you want to quit?"
 msgstr "Biztosan ki szeretne lépni?"
 
-#: ../fheroes2/gui/interface_events.cpp:308
+#, fuzzy
+msgid "Are you sure you want to restart? (Your current game will be lost.)"
+msgstr "Biztos vagy benne hogy újrakezded? (A jelenlegi játékod el fog veszni)"
+
+msgid "Are you sure you want to overwrite the save with this name?"
+msgstr "Biztosan felülírod a mentést ezzel a névvel?"
+
 msgid "Game saved successfully."
 msgstr "A játék sikeresen mentve."
 
-#: ../fheroes2/gui/interface_events.cpp:314
+msgid "There was an issue during saving."
+msgstr ""
+
+#, fuzzy
 msgid ""
-"Are you sure you want to load a new game? (Your current game will be lost)"
+"Are you sure you want to load a new game? (Your current game will be lost.)"
 msgstr ""
 "Biztos hogy benne hogy új játékot töltesz be? (A jelenlegi játékod el fog "
 "veszni)"
 
-#: ../fheroes2/gui/interface_events.cpp:353
 msgid "Try looking on land!!!"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:368
 #, fuzzy
 msgid ""
-"After spending many hours digging here, you have uncovered the %{artifact}"
+"After spending many hours digging here, you have uncovered the %{artifact}."
 msgstr "Több órányi ásás után, megtalálatad a "
 
-#: ../fheroes2/gui/interface_events.cpp:370
 msgid "Congratulations!"
 msgstr "Gratulálunk!"
 
-#: ../fheroes2/gui/interface_events.cpp:384
 msgid "Nothing here. Where could it be?"
 msgstr "Itt nincs semmi, hol lehet?"
 
-#: ../fheroes2/gui/interface_events.cpp:395
 msgid "Try searching on clear ground."
 msgstr "Keress tiszta területet."
 
-#: ../fheroes2/gui/interface_events.cpp:399
 msgid "Digging for artifacts requires a whole day, try again tomorrow."
 msgstr "Egész nap a varázstárgy után kutattál, holnap próbáld újra."
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "World Map"
 msgstr "Világtérkép"
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "A miniature view of the known world. Left click to move viewing area."
 msgstr ""
 "Az ismert világ kicsinyített mása. Bal kattintással mozgathatod a látható "
 "területet."
 
-#: ../fheroes2/gui/interface_status.cpp:216
 msgid "Month: %{month} Week: %{week}"
 msgstr "Hónap: %{month} Hét: %{week}"
 
-#: ../fheroes2/gui/interface_status.cpp:222
-#: ../fheroes2/kingdom/kingdom_overview.cpp:569
 msgid "Day: %{day}"
 msgstr "Nap: %{day}"
 
-#: ../fheroes2/gui/interface_status.cpp:257
 msgid ""
 "You find a small\n"
 "quantity of %{resource}."
@@ -2699,39 +2809,291 @@ msgstr ""
 "Találtál\n"
 "egy kis %{resource}-t."
 
-#: ../fheroes2/gui/interface_status.cpp:407
 msgid "Status Window"
 msgstr "Állapotjelző ablak"
 
-#: ../fheroes2/gui/interface_status.cpp:407
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date."
+msgstr ""
+
 msgid ""
 "This window provides information on the status of your hero or kingdom, and "
 "shows the date. Left click here to cycle throungh these windows."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:112
+msgid "Necroman"
+msgstr "Nekromanta"
+
+msgid ""
+"This lets you change player starting positions and colors. A particular "
+"color will always start in a particular location. Some positions may only be "
+"played by a computer player or only by a human player."
+msgstr ""
+
+msgid ""
+"This lets you change the class of a player. Classes are not always "
+"changeable. Depending on the scenario, a player may receive additional towns "
+"and/or heroes not of their primary alignment."
+msgstr ""
+
+#, fuzzy
+msgid "%{color} player"
+msgstr "%{color} játékos köre"
+
+#, fuzzy
+msgid "View %{skill} Info"
+msgstr "%{level} %{skill} információ"
+
+msgid "Lord Kilburn"
+msgstr "Lord Kilburn"
+
+#, fuzzy
+msgid "Sir Gallant"
+msgstr "Sir Gallanth"
+
+msgid "Ector"
+msgstr "Ector"
+
+msgid "Gwenneth"
+msgstr ""
+
+msgid "Tyro"
+msgstr "Tyro"
+
+msgid "Ambrose"
+msgstr "Ambrose"
+
+msgid "Ruby"
+msgstr "Ruby"
+
+msgid "Maximus"
+msgstr "Maximus"
+
+msgid "Dimitry"
+msgstr "Dimitry"
+
+msgid "Thundax"
+msgstr "Thundax"
+
+msgid "Fineous"
+msgstr "Fineous"
+
+msgid "Jojosh"
+msgstr "Jojosh"
+
+msgid "Crag Hack"
+msgstr "Crag Hack"
+
+msgid "Jezebel"
+msgstr "Jezebel"
+
+msgid "Jaclyn"
+msgstr "Jaclyn"
+
+msgid "Ergon"
+msgstr "Ergon"
+
+msgid "Tsabu"
+msgstr "Tsabu"
+
+msgid "Atlas"
+msgstr "Atlas"
+
+msgid "Astra"
+msgstr "Astra"
+
+msgid "Natasha"
+msgstr "Natasha"
+
+msgid "Troyan"
+msgstr "Troyan"
+
+msgid "Vatawna"
+msgstr "Vatawna"
+
+msgid "Rebecca"
+msgstr "Rebecca"
+
+msgid "Gem"
+msgstr "Gem"
+
+msgid "Ariel"
+msgstr "Ariel"
+
+msgid "Carlawn"
+msgstr "Carlawn"
+
+msgid "Luna"
+msgstr "Luna"
+
+msgid "Arie"
+msgstr "Arie"
+
+msgid "Alamar"
+msgstr "Alamar"
+
+msgid "Vesper"
+msgstr "Vesper"
+
+msgid "Crodo"
+msgstr "Crodo"
+
+msgid "Barok"
+msgstr "Barok"
+
+msgid "Kastore"
+msgstr "Kastore"
+
+msgid "Agar"
+msgstr "Agar"
+
+msgid "Falagar"
+msgstr "Falagar"
+
+msgid "Wrathmont"
+msgstr "Wrathmont"
+
+msgid "Myra"
+msgstr "Myra"
+
+msgid "Flint"
+msgstr "Flint"
+
+msgid "Dawn"
+msgstr "Dawn"
+
+msgid "Halon"
+msgstr "Halon"
+
+msgid "Myrini"
+msgstr "Myrini"
+
+msgid "Wilfrey"
+msgstr "Wilfrey"
+
+msgid "Sarakin"
+msgstr "Sarakin"
+
+msgid "Kalindra"
+msgstr "Kalindra"
+
+msgid "Mandigal"
+msgstr "Mandigal"
+
+msgid "Zom"
+msgstr "Zom"
+
+msgid "Darlana"
+msgstr "Darlana"
+
+msgid "Zam"
+msgstr "Zam"
+
+msgid "Ranloo"
+msgstr "Ranloo"
+
+msgid "Charity"
+msgstr "Charity"
+
+msgid "Rialdo"
+msgstr "Rialdo"
+
+msgid "Roxana"
+msgstr "Roxana"
+
+msgid "Sandro"
+msgstr "Sandro"
+
+msgid "Celia"
+msgstr "Celia"
+
+msgid "Roland"
+msgstr "Roland"
+
+msgid "Lord Corlagon"
+msgstr "Lord Corlagon"
+
+msgid "Sister Eliza"
+msgstr "Eliza nővér"
+
+msgid "Archibald"
+msgstr "Archibald"
+
+msgid "Lord Halton"
+msgstr "Lord Halton"
+
+#, fuzzy
+msgid "Brother Brax"
+msgstr "Bax atya"
+
+msgid "Solmyr"
+msgstr "Solmyr"
+
+msgid "Dainwin"
+msgstr "Dainwin"
+
+msgid "Mog"
+msgstr "Mog"
+
+msgid "Joseph"
+msgstr "Joseph"
+
+msgid "Gallavant"
+msgstr "Gallavant"
+
+msgid "Elderian"
+msgstr "Elderian"
+
+msgid "Ceallach"
+msgstr "Ceallach"
+
+msgid "Drakonia"
+msgstr "Drakonia"
+
+msgid "Martine"
+msgstr "Martine"
+
+msgid "Jarkonas"
+msgstr "Jarkonas"
+
+msgid "%{object} robber"
+msgstr ""
+
+msgid "%{object} raided"
+msgstr ""
+
+msgid "You cannot pick up this artifact, you already have a full load!"
+msgstr ""
+
+msgid "The three Anduran artifacts magically combine into one."
+msgstr ""
+
+msgid "To cast spells, you must first buy a spell book for %{gold} gold."
+msgstr ""
+"Hogy varázsolhass, először vásárolnod kell %{gold} aranyért varázskönyvet."
+
+msgid "Unfortunately, you seem to be a little short of cash at the moment."
+msgstr "Sajnos, nincs elég aranyad."
+
+msgid "Do you wish to buy one?"
+msgstr "Szeretnél venni egyet?"
+
 msgid "%{count} / day"
 msgstr "%{count} / nap"
 
-#: ../fheroes2/heroes/heroes_action.cpp:331
-#: ../fheroes2/heroes/heroes_action.cpp:2199
 msgid "You are unable to recruit at this time, your ranks are full."
 msgstr "Most nem tudsz toborozni, a csapatod tele van."
 
-#: ../fheroes2/heroes/heroes_action.cpp:599
-msgid ""
-"A group of %{monster} with a desire for greater glory wish to join you.\n"
-"Do you accept?"
-msgstr ""
-"Egy  %{monster} csoportja a nagyobb dicsőség reményében csatlakozna hozzád.\n"
-"Elfogadod őket?"
+msgid "A whirlpool engulfs your ship."
+msgstr "Egy örvény elnyeli a hajód."
 
-#: ../fheroes2/heroes/heroes_action.cpp:609
-#: ../fheroes2/heroes/heroes_action.cpp:630
+msgid "Some of your army has fallen overboard."
+msgstr "A csapatod néhány tagja a tengerbe esett."
+
 msgid "Insulted by your refusal of their offer, the monsters attack!"
 msgstr "Visszautasítottad az ajánlatukat, ezért megtámadnak!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:638
 msgid ""
 "The %{monster}, awed by the power of your forces, begin to scatter.\n"
 "Do you wish to pursue and engage them?"
@@ -2739,11 +3101,9 @@ msgstr ""
 "A(z) %{monster} félnek a csapatod erejétől és megpróbálnak elmenekülni.\n"
 "Akarod üldözni és megtámadni őket?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:934
 msgid "Ransacking an enemy camp, you discover a hidden cache of treasures."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:966
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with these resources, "
@@ -2753,7 +3113,6 @@ msgstr ""
 "\"Uram, keményen dolgoztam, hogy ezeket a nyersanyagokat neked adjam, Gyere "
 "vissza a következő héten továbbiakért."
 
-#: ../fheroes2/heroes/heroes_action.cpp:967
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there are no resources currently available. Please try "
@@ -2763,7 +3122,6 @@ msgstr ""
 "\"Uram, elnézést, de jelenleg nincsen nyersanyagom. Próbálja meg jövő héten."
 "\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:972
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with this gold, come "
@@ -2773,7 +3131,6 @@ msgstr ""
 "\"Uram, keményen dolgoztam, hogy ennyi aranyat tudjak neked adni, Gyere "
 "vissza a következő héten továbbiakért.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:973
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there is no gold currently available. Please try again "
@@ -2782,17 +3139,14 @@ msgstr ""
 "A malom gazdája azt mondja:\n"
 "\"Uram, elnézést, de jelenleg nincsen aranyam. Próbálja meg jövő héten.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:979
 msgid ""
 "You've found an abandoned lean-to.\n"
 "Poking about, you discover some resources hidden nearby."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:980
 msgid "The lean-to is long abandoned. There is nothing of value here."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:985
 msgid ""
 "You catch a leprechaun foolishly sleeping amidst a cluster of magic "
 "mushrooms.\n"
@@ -2800,32 +3154,26 @@ msgid ""
 "precious things."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:986
 msgid ""
 "You've found a magic garden, the kind of place that leprechauns and faeries "
 "like to cavort in, but there is no one here today.\n"
 "Perhaps you should try again next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1023
 msgid "You come upon the remains of an unfortunate adventurer."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1034
 #, fuzzy
 msgid "Treasure"
 msgstr "Kincsek"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1041
 msgid "Searching through the tattered clothing, you find %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1052
 #, fuzzy
 msgid "Searching through the tattered clothing, you find nothing."
 msgstr "Átkutatod az uszadékot, de semmit sem találsz."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1064
 #, fuzzy
 msgid ""
 "You come across an old wagon left by a trader who didn't quite make it to "
@@ -2835,8 +3183,6 @@ msgstr ""
 "tudta megvédeni.\n"
 "Átkutatod, és egy %{artifact} varázstárgyat találsz rajta."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1075
-#: ../fheroes2/heroes/heroes_action.cpp:1103
 #, fuzzy
 msgid "Unfortunately, others have found it first, and the wagon is empty."
 msgstr ""
@@ -2844,61 +3190,49 @@ msgstr ""
 "tudta megvédeni.\n"
 "Sajnos, valaki hamarabb rátalált, és a szekér üres."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1082
 #, fuzzy
 msgid "Searching inside, you find the %{artifact}."
 msgstr "Megtaláltad a %{artifact}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1093
 msgid "Inside, you find some of the wagon's cargo still intact."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1123
 msgid "You search through the flotsam, and find some wood and some gold."
 msgstr "Átkutatod az uszadékot, és találsz egy kevés fát és aranyat."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1124
 msgid "You search through the flotsam, and find some wood."
 msgstr "Átkutatod az uszadékot, és találsz egy kevés fát."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1130
 msgid "You search through the flotsam, but find nothing."
 msgstr "Átkutatod az uszadékot, de semmit sem találsz."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1151
 msgid "Shrine of the 1st Circle"
 msgstr "1. Kör Szentélye"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1152
 msgid ""
 "You come across a small shrine attended by a group of novice acolytes.\n"
-"In exchange for your protection, they agree to teach you a simple spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a simple spell - "
+"'%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1155
 msgid "Shrine of the 2nd Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1156
 msgid ""
 "You come across an ornate shrine attended by a group of rotund friars.\n"
-"In exchange for your protection, they agree to teach you a spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a spell - "
+"'%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1159
 msgid "Shrine of the 3rd Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1160
 msgid ""
 "You come across a lavish shrine attended by a group of high priests.\n"
 "In exchange for your protection, they agree to teach you a sophisticated "
 "spell - '%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1173
 msgid ""
 "\n"
 "Unfortunately, you have no Magic Book to record the spell with."
@@ -2906,7 +3240,6 @@ msgstr ""
 "\n"
 "Szerencsétlenségedre, nincs varázskönyved, amibe a varázslatot beírhatnád."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1184
 msgid ""
 "\n"
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
@@ -2916,24 +3249,21 @@ msgstr ""
 "Sajnos nem elegendő a bölcsességed, hogy megértsd a varázslatot, így nem "
 "vagy képes azt megtanulni."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1192
 msgid ""
 "\n"
 "Unfortunately, you already have knowledge of this spell, so there is nothing "
 "more for them to teach you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1215
 msgid ""
-"You approach the hut and observe a witch inside studying an ancient tome on %"
-"{skill}.\n"
+"You approach the hut and observe a witch inside studying an ancient tome on "
+"%{skill}.\n"
 " \n"
 msgstr ""
 "A kunyhóhoz érve meglátsz egy öreg banyát, aki egy %{skill}-könyvet "
 "olvasgat.\n"
 " \n"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1222
 msgid ""
 "As you approach, she turns and focuses her one glass eye on you.\n"
 "\"You already know everything you deserve to learn!\" the witch screeches. "
@@ -2942,7 +3272,6 @@ msgstr ""
 "Amint észrevesz, elkezd téged bámulni az egy szem üvegszemével.\n"
 "Rádkiabál: \"Te már mindent tudsz, amit kiérdemeltél! KIFELÉ A HÁZAMBÓL!\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1229
 msgid ""
 "As you approach, she turns and speaks.\n"
 "\"You already know that which I would teach you. I can help you no further.\""
@@ -2950,7 +3279,6 @@ msgstr ""
 "Ahogy közeledsz megfordul és ezt mondja:\n"
 "\"Te már tudod azt amit én tanítani tudnék neked, Másban nem segíthetek.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1236
 msgid ""
 "An ancient and immortal witch living in a hut with bird's legs for stilts "
 "teaches you %{skill} for her own inscrutable purposes."
@@ -2958,20 +3286,16 @@ msgstr ""
 "Egy vénséges, halhatatlan boszorkány lakik a cölöpkunyhóban, aki "
 "kifürkészhetetlen okok miatt megtanít téged a %{skill} képzettségre,"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1255
 msgid "You drink from the enchanted fountain, but nothing happens."
 msgstr "Iszol az elvarázsolt kútból, de dem történik semmi."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1256
 msgid "As you drink the sweet water, you gain luck for your next battle."
 msgstr ""
 "Ha iszol az édesvízből, akkor a következő csatádhoz szerencsét szerzel."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1260
 msgid "You enter the faerie ring, but nothing happens."
 msgstr "Belépsz a körbe, de semmi nem történik."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1261
 msgid ""
 "Upon entering the mystical faerie ring, your army gains luck for its next "
 "battle."
@@ -2979,7 +3303,6 @@ msgstr ""
 "Ahogy belépsz a misztikus körbe, a sereged szerencsét nyer a következő "
 "csatáig."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1265
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "It is supposed to grant luck to visitors, but since the stars are already "
@@ -2989,7 +3312,6 @@ msgstr ""
 "Azt mondják, szerencsét hoz a látogatónak, azonban a szerencse már "
 "rádmosolygott, ezért nem történik semmi."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1266
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "Kissing it is supposed to be lucky, so you do. The stone is very cold to the "
@@ -2999,11 +3321,9 @@ msgstr ""
 "Azt mondják, ha megcsókolják, szerencsét hoz - így is teszel. A kő nagyon "
 "hideg."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1270
 msgid "The mermaids silently entice you to return later and be blessed again."
 msgstr "A sellők csábítanak, hogy később jöjj vissza és újra megáldanak."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1271
 msgid ""
 "The magical, soothing beauty of the Mermaids reaches you and your crew.\n"
 "Just for a moment, you forget your worries and bask in the beauty of the "
@@ -3011,7 +3331,6 @@ msgid ""
 "The mermaids charms bless you with increased luck for your next combat."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1303
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "You are tempted to search it for treasure, but all the old stories warn of "
@@ -3019,18 +3338,15 @@ msgid ""
 "Will you search?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1304
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "Routine exploration reveals that the pyramid is completely empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1329
 msgid "Unfortunately, you have no Magic Book to record the spell with."
 msgstr ""
 "Szerencsétlenségedre, nincs varázskönyved, amibe a varázslatot beírhatnád."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1333
 msgid ""
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
@@ -3038,32 +3354,26 @@ msgstr ""
 "Szerencsétlenségedre, nem vagy elég bölcs, hogy megértsd a varázslatot, nem "
 "hogy megtanuld..."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1337
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
 "telling the secret of the spell."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1374 ../fheroes2/maps/mp2.cpp:469
 msgid "Sign"
 msgstr "Jel"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1385
 msgid ""
 "A drink at the well is supposed to restore your spell points, but you are "
 "already at maximum."
 msgstr ""
 "A kútból történő ivás feltöltené a varázspontodat, de már  maximumon van."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1392
 msgid "A second drink at the well in one day will not help you."
 msgstr "Egy napon belüli második ivás nem hat rád."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1399
 msgid "A drink from the well has restored your spell points to maximum."
 msgstr "A kútból történő ivás feltölti a varázspontodat."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1424
 msgid ""
 "\"I'm sorry sir,\" The leader of the soldiers says, \"but you already know "
 "everything we have to teach.\""
@@ -3071,38 +3381,32 @@ msgstr ""
 "\"Sajnálom Uram,\" - mondja a katonák vezetője - \"de Ön már mindent tud, "
 "amit mi megtaníthatnánk...\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1425
 msgid "The soldiers living in the fort teach you a few new defensive tricks."
 msgstr ""
 "Az erődítményben állomásozó katonák tanítanak neked néhány új védelmi "
 "trükköt."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1430
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. \"You're too "
 "advanced for us,\" the mercenary captain says. \"We can teach nothing more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1431
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. The mercenaries "
 "welcome you and your troops and invite you to train with them."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1436
 msgid "\"Go 'way!\", the witch doctor barks, \"you know all I know.\""
 msgstr ""
 "\"Takarodj innen!\" - rivall rád az vajákos - \"Nem tudok neked újat mondani!"
 "\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1437
 msgid ""
 "An Orcish witch doctor living in the hut deepens your knowledge of magic by "
 "showing you how to cast stones, read portents, and decipher the intricacies "
 "of chicken entrails."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1442
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, the Druids turn you away, indicating they have nothing "
@@ -3111,7 +3415,6 @@ msgstr ""
 "Druidák egy csoportjára bukkansz, akik furcsa kőépítményükben imádkoznak. A "
 "Druidák elküldenek azzal, hogy nem tudnak neked semmi újat tanítani."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1443
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, they teach you new ways to cast spells."
@@ -3119,13 +3422,11 @@ msgstr ""
 "Druidák egy csoportjára bukkansz, akik furcsa kőépítményükben imádkoznak. Új "
 "dolgokat tanítanak meg neked a varázslás terén."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1479
 msgid ""
 "You tentatively approach the burial ground of ancient warriors. Do you want "
 "to search the graves?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1480
 msgid ""
 "Upon defeating the Zombies you spend several hours searching the graves and "
 "find nothing. Such a despicable act reduces your army's morale."
@@ -3133,55 +3434,46 @@ msgstr ""
 "Miután legyőzted a Zombikat órákat töltöttél el a sírok átkutatásával de nem "
 "találtál semmit. Csökkent a csapatod morálja ."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1481
-msgid "Upon defeating the zomies you search the graves and find something!"
+#, fuzzy
+msgid "Upon defeating the Zombies you search the graves and find something!"
 msgstr "Miután legyőzted a zombikat átkutattad a sírokat és találtál valamit!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1484
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the shipwreck?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1485
 msgid ""
 "Upon defeating the Ghosts you spend several hours sifting through the debris "
 "and find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1486
 msgid ""
 "Upon defeating the Ghosts you sift through the debris and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1489
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the ship?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1490
 msgid ""
 "Upon defeating the Skeletons you spend several hours sifting through the "
 "debris and find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1491
 msgid ""
 "Upon defeating the Skeletons you sift through the debris and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1564
 msgid "Your men spot a navigational buoy, confirming that you are on course."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1565
 msgid ""
 "Your men spot a navigational buoy, confirming that you are on course and "
 "increasing their morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1569
 msgid ""
 "The drink at the oasis is refreshing, but offers no further benefit. The "
 "oasis might help again if you fought a battle first."
@@ -3189,7 +3481,6 @@ msgstr ""
 "Ha iszol az oázisban, akkor felfrissülsz, de más nem történik. Csak az első "
 "csatádban segít."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1570
 msgid ""
 "A drink at the oasis fills your troops with strength and lifts their "
 "spirits.  You can travel a bit further today."
@@ -3197,7 +3488,6 @@ msgstr ""
 "Ha iszol az oázisban, akkor az egységeid ereje és hangulata feltöltődik. "
 "Ezért ma egy kicsit tovább tudsz haladni."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1575
 msgid ""
 "The drink at the watering hole is refreshing, but offers no further benefit. "
 "The watering hole might help again if you fought a battle first."
@@ -3205,7 +3495,6 @@ msgstr ""
 "Ha iszol a vizesgödörnél, akkor felfrissülsz, de más nem történik. Csak az "
 "első csatádban segít."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1576
 msgid ""
 "A drink at the watering hole fills your troops with strength and lifts their "
 "spirits. You can travel a bit further today."
@@ -3213,17 +3502,14 @@ msgstr ""
 "Ha iszol a vizesgödörnél, akkor az egységeid ereje és hangulata feltöltődik. "
 "Ezért ma egy kicsit tovább tudsz haladni."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1581
 msgid ""
 "It doesn't help to pray twice before a battle. Come back after you've fought."
 msgstr ""
 "Az nem segít, ha többször imádkozol csata előtt, gyere vissza harc után!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1582
 msgid "A visit and a prayer at the temple raises the morale of your troops."
 msgstr "Egy látogatás és egy imádság a templomban niveli a csapataid morálját."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1622
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"I am sorry, my liege, I "
 "have taught you all I can.\""
@@ -3231,7 +3517,6 @@ msgstr ""
 "Egy öreg lovag jelenik meg a kilátó lépcsőin. \"Bocsánat, Uram, mindenre "
 "megtanítottam Önt, amit én tudok.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1623
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"My liege, I will teach "
 "you all that I know to aid you in your travels.\""
@@ -3239,7 +3524,6 @@ msgstr ""
 "Egy öreg lovag jelenik meg a kilátó lépcsőin. \"Uram, mindenre meg akarom "
 "Önt tanítani, amit én tudok, hogy segítsem az utazását.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1662
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
 "ocean. Grateful, he says, \"I would give you an artifact as a reward, but "
@@ -3249,106 +3533,84 @@ msgstr ""
 "cserébe azt mondja: \"Jutalmul adnék neked egy varázstárgyat, de tele van a "
 "hátizsákod.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1669
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
-"ocean. Grateful, he rewards you for your act of kindness by giving you the %"
-"{art}."
+"ocean. Grateful, he rewards you for your act of kindness by giving you the "
+"%{art}."
 msgstr ""
 "Megmentesz egy hajótöröttet az óceán halálosan ölelő karjából. Jótettedért "
 "cserébe megjutalmaz egy %{art} varázstárggyal."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1688 ../fheroes2/heroes/heroes.cpp:941
-msgid "You have no room to carry another artifact!"
-msgstr "Nincs hely, hogy eltedd a varázstárgyat."
-
-#: ../fheroes2/heroes/heroes_action.cpp:1704
 msgid "A leprechaun offers you the %{art} for the small price of %{gold} Gold."
 msgstr "Egy manó %{art}-t kínál neked %{gold} aranyért cserébe."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1709
 msgid ""
-"A leprechaun offers you the %{art} for the small price of %{gold} Gold and %"
-"{count} %{res}."
+"A leprechaun offers you the %{art} for the small price of %{gold} Gold and "
+"%{count} %{res}."
 msgstr ""
 "Egy manó %{art}-t kínál neked %{gold} aranyért és %{count} %{res}-ért "
 "cserébe."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1718
 msgid "Do you wish to buy this artifact?"
 msgstr "Meg akarod venni ezt a varázstárgyat?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1731
 msgid ""
 "You try to pay the leprechaun, but realize that you can't afford it. The "
 "leprechaun stamps his foot and ignores you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1735
 msgid ""
 "Insulted by your refusal of his generous offer, the leprechaun stamps his "
 "foot and ignores you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1746
-#: ../fheroes2/heroes/heroes_action.cpp:1821
 msgid "You've found the artifact: "
 msgstr "Megtaláltad a varázstárgyat. "
 
-#: ../fheroes2/heroes/heroes_action.cpp:1756
 msgid ""
 "You've found the humble dwelling of a withered hermit. The hermit tells you "
 "that he is willing to give the %{art} to the first wise person he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1759
 msgid ""
 "You've come across the spartan quarters of a retired soldier. The soldier "
 "tells you that he is willing to pass on the %{art} to the first true leader "
 "he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1780
 msgid ""
 "You come upon an ancient artifact. As you reach for it, a pack of Rogues "
 "leap out of the brush to guard their stolen loot."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1783
 msgid ""
 "Through a clearing you observe an ancient artifact. Unfortunately, it's "
 "guarded by a nearby %{monster}. Do you want to fight the %{monster} for the "
 "artifact?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1798
 msgid "Victorious, you take your prize, the %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1810
 msgid ""
 "Discretion is the better part of valor, and you decide to avoid this fight "
 "for today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1866
-#: ../fheroes2/heroes/heroes_action.cpp:1881
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold pieces."
 msgstr ""
-"Több órás munkával sikerül kihalásznod egy ládát a tengerből. Kinyitod, és %"
-"{gold} aranyat találsz benne."
+"Több órás munkával sikerül kihalásznod egy ládát a tengerből. Kinyitod, és "
+"%{gold} aranyat találsz benne."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1872
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold and the %{art}."
 msgstr ""
-"Több órás munkával sikerül kihalásznod egy ládát a tengerből. Kinyitod, és %"
-"{gold} aranyat valamint egy %{art} varázstárgyat találsz benne."
+"Több órás munkával sikerül kihalásznod egy ládát a tengerből. Kinyitod, és "
+"%{gold} aranyat valamint egy %{art} varázstárgyat találsz benne."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1888
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it, "
 "only to find it empty."
@@ -3356,7 +3618,6 @@ msgstr ""
 "Több órás munkával sikerül kihalásznod egy ládát a tengerből. Kinyitod, de "
 "nem találsz benne semmit sem."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1898
 msgid ""
 "After scouring the area, you fall upon a hidden treasure cache. You may take "
 "the gold or distribute the gold to the peasants for experience. Do you wish "
@@ -3366,49 +3627,35 @@ msgstr ""
 "Elteheted magadnak az aranyat, vagy szétoszthatod tapasztalati ponttért "
 "cserébe a parasztok között. Megtartod az aranyat?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1912
 msgid ""
-"After scouring the area, you fall upon a hidden chest, containing the %"
-"{gold} gold pieces."
+"After scouring the area, you fall upon a hidden chest, containing the "
+"%{gold} gold pieces."
 msgstr ""
 "A terület átkutatása után rábukkansz egy elrejtett ládára, amiben %{gold} "
 "arany van."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1918
 msgid ""
 "After scouring the area, you fall upon a hidden chest, containing the "
 "ancient artifact %{art}."
 msgstr ""
-"A terület átkutatása után rábukkansz egy elrejtett ládára, amiben egy régi %"
-"{art} varázstárgy van."
+"A terület átkutatása után rábukkansz egy elrejtett ládára, amiben egy régi "
+"%{art} varázstárgy van."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1942
 msgid ""
 "You stumble upon a dented and tarnished lamp lodged deep in the earth. Do "
 "you wish to rub the lamp?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "A whirlpool engulfs your ship."
-msgstr "Egy örvény elnyeli a hajód."
-
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "Some of your army has fallen overboard."
-msgstr "A csapatod néhány tagja a tengerbe esett."
-
-#: ../fheroes2/heroes/heroes_action.cpp:2045
 msgid ""
 "You come upon an abandoned gold mine. The mine appears to be haunted. Do you "
 "wish to enter?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2064
 msgid ""
 "You have taken control of the local Alchemist shop. It will provide you with "
 "%{count} unit of Mercury per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2070
 msgid ""
 "You gain control of a sawmill. It will provide you with %{count} units of "
 "wood per day."
@@ -3416,7 +3663,9 @@ msgstr ""
 "Megszereztél egy fűrészmalmot. Ez naponta %{count} egységnyi fát biztosít "
 "számodra."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2081
+msgid "You beat the Ghosts and are able to restore the mine to production."
+msgstr "Elűzted a szellemeket, a bánya újra használható."
+
 msgid ""
 "You gain control of an ore mine. It will provide you with %{count} units of "
 "ore per day."
@@ -3424,14 +3673,12 @@ msgstr ""
 "Megszereztél egy vasércbányát. Ez naponta %{count} egységnyi vasércet ad "
 "neked."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2083
 msgid ""
 "You gain control of a sulfur mine. It will provide you with %{count} unit of "
 "sulfur per day."
 msgstr ""
 "Megszereztél egy kénbányát. Ez naponta %{count} egységnyi ként ad neked."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2085
 msgid ""
 "You gain control of a crystal mine. It will provide you with %{count} unit "
 "of crystal per day."
@@ -3439,7 +3686,6 @@ msgstr ""
 "Megszereztél egy kristálybányát. Ez naponta %{count} egységnyi kristályt ad "
 "neked."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2087
 msgid ""
 "You gain control of a gem mine. It will provide you with %{count} unit of "
 "gems per day."
@@ -3447,17 +3693,11 @@ msgstr ""
 "Megszereztél egy gyöngybányát. Ez naponta %{count} egységnyi gyöngyöt ad "
 "neked."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2089
 msgid ""
 "You gain control of a gold mine. It will provide you with %{count} gold per "
 "day."
 msgstr "Megszereztél egy auranybányát. Ez naponta %{count} aranyat ad neked."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2096
-msgid "You beat the Ghosts and are able to restore the mine to production."
-msgstr "Elűzted a szellemeket, a bánya újra használható."
-
-#: ../fheroes2/heroes/heroes_action.cpp:2101
 msgid ""
 "The lighthouse is now under your control, and all of your ships will now "
 "move further each turn."
@@ -3465,11 +3705,9 @@ msgstr ""
 "A kilátótorony a fennhatóságod alá került, és minden hajód többet mozoghat "
 "minden körben."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2105
 msgid "You gain control of a %{name}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2188
 msgid ""
 "A group of %{monster} with a desire for greater glory wish to join you. Do "
 "you accept?"
@@ -3477,12 +3715,10 @@ msgstr ""
 "%{monster} egy csoportja a dicsőség reményében csatlakozna hozzád. Elfogadod "
 "őket?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2215
 msgid "As you approach the dwelling, you notice that there is no one here."
 msgstr ""
 "Ahogy megközelítetted a lakóhelyet, észreveszed, hogy nincs senki bent."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2232
 msgid ""
 "You search the ruins, but the Medusas that used to live here are gone. "
 "Perhaps there will be more next week."
@@ -3490,7 +3726,6 @@ msgstr ""
 "Átkutattad a romokat, ahol Medúzák laknak, de most nem találsz itt senkit. "
 "Próbáld meg a jövő héten."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2233
 msgid ""
 "You've found some Medusas living in the ruins. They are willing to join your "
 "army for a price. Do you want to recruit Medusas?"
@@ -3498,7 +3733,6 @@ msgstr ""
 "Megtaláltad a romok közt élő Medúzákat. Csatlakoznak hozzád aranyért "
 "cserébe. Akarsz Medúzát toborozni?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2238
 msgid ""
 "You've found a Sprite Tree City. Unfortunately, none of the Sprites living "
 "there wish to join an army. Maybe next week."
@@ -3506,7 +3740,6 @@ msgstr ""
 "Találtál egy Tündér Fa Várost. Sajnos egyetlen Tündér sem tartózkodik itt, "
 "hogy csatlakozzanak hozzád. Talán a jövő héten."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2239
 msgid ""
 "Some of the Sprites living in the tree city are willing to join your army "
 "for a price. Do you want to recruit Sprites?"
@@ -3514,46 +3747,38 @@ msgstr ""
 "Tündérek laknak a Fa Városukban és csatlakoznának hozzád aranyért cserébe. "
 "Szeretnél Tündért toborozni?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2244
 msgid ""
 "A colorful Rogues' wagon stands empty here. Perhaps more Rogues will be here "
 "later."
 msgstr "Egy tarka szekér áll itt. Lehet, hogy később rablók bukkannak fel."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2245
 msgid ""
 "Distant sounds of music and laughter draw you to a colorful wagon housing "
 "Rogues. Do you wish to have any Rogues join your army?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2250
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. The "
 "tents are unoccupied. Perhaps more Nomads will be here later."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2251
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. Do you "
 "wish to have any Nomads join you during your travels?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2256
 msgid "The pit of mud bubbles for a minute and then lies still."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2257
 msgid ""
 "As you approach the bubbling pit of mud, creatures begin to climb out and "
 "position themselves around it. In unison they say: \"Mother Earth would like "
 "to offer you a few of her troops. Do you want to recruit Earth Elementals?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2261
 msgid "You enter the structure of white stone pillars, and find nothing."
 msgstr "Belépsz a fehér kő pillér építménybe, de nem találsz semmit."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2262
 msgid ""
 "White stone pillars support a roof that rises up to the sky. As you enter "
 "the structure, the dead air of the outside gives way to a whirling gust that "
@@ -3563,34 +3788,28 @@ msgid ""
 "air?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2266
 msgid "No Fire Elementals approach you from the lava pool."
 msgstr "A láva medencéből nem közeledik feléd egyetlen Tűz Elementál sem."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2267
 msgid ""
 "Beneath a structure that serves to hold in heat, Fire Elementals move about "
 "in a fiery pool of molten lava. A group of them approach you and offer their "
 "services. Would you like to recruit Fire Elementals?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2271
 msgid "A face forms in the water for a moment, and then is gone."
 msgstr ""
 "Egy arckép válik láthatóvá a vízben egy piilanatra és aztán el is tűnik."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2272
 msgid ""
 "Crystalline structures cast shadows over a small reflective pool of water. "
 "You peer into the pool, and a face that is not your own peers back. It asks: "
 "\"Would you like to call upon the powers of water?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2276
 msgid "This burial site is deathly still."
 msgstr "A temetkezési hely még mindig halálos."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2277
 msgid ""
 "Restless spirits of long dead warriors seeking their final resting place "
 "offer to join you in hopes of finding peace. Do you wish to recruit ghosts?"
@@ -3598,7 +3817,6 @@ msgstr ""
 "Sok halott harcos nyughatatlan lelke a végső nyughely megtalálásának "
 "reményében csatlakoznának hozzád. Szeretnél szellemeket toborozni?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2313
 msgid ""
 "The City of the Dead is empty of life, and empty of unlife as well. Perhaps "
 "some undead will move in next week."
@@ -3606,7 +3824,6 @@ msgstr ""
 "A Halott Városban jelenleg egy lélek sem található. Talán a jövő héten lesz "
 "néhány élőhalott."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2314
 msgid ""
 "Some Liches living here are willing to join your army for a price. Do you "
 "want to recruit Liches?"
@@ -3614,7 +3831,6 @@ msgstr ""
 "Néhány Lich él itt és fizetség fejében csatlakoznak hozzád. Akarsz Lich-eket "
 "toborozni?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2315
 msgid ""
 "You've found the ruins of an ancient city, now inhabited solely by the "
 "undead. Will you search?"
@@ -3622,7 +3838,6 @@ msgstr ""
 "Egy ősi város romjaira bukkantál, melyet kizárólag élőholtak laknak. "
 "Szeretnél körülnézni?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2316
 msgid ""
 "Some of the surviving Liches are impressed by your victory over their "
 "fellows, and offer to join you for a price. Do you want to recruit Liches?"
@@ -3631,7 +3846,6 @@ msgstr ""
 "felajánlják, hogy fizettségért cserébe csatlakoznak hozzád. Akarsz Lich-eket "
 "toborozni?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2320
 msgid ""
 "You've found one of those bridges that Trolls are so fond of living under, "
 "but there are none here. Perhaps there will be some next week."
@@ -3639,7 +3853,6 @@ msgstr ""
 "Találtál egy olyan hidat, amely alatt Trollok laknak, de most nincs itt egy "
 "sem. Talán a jövő héten itt lesznek néhánzan."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2321
 msgid ""
 "Some Trolls living under a bridge are willing to join your army, but for a "
 "price. Do you want to recruit Trolls?"
@@ -3647,11 +3860,9 @@ msgstr ""
 "Néhány Troll él a híd alatt, akik némi pénzért cserébe csatlakoznának "
 "hozzád. Felfogadod őket?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2322
 msgid "Trolls living under the bridge challenge you. Will you fight them?"
 msgstr "A híd alatt élő Trollok belédkötnek. Megküzdesz velük?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2323
 msgid ""
 "A few Trolls remain, cowering under the bridge. They approach you and offer "
 "to join your forces as mercenaries. Do you want to buy any Trolls?"
@@ -3659,7 +3870,6 @@ msgstr ""
 "Egy kevés Troll a híd alatt rejtőzködik. Felajánlják, hogy beállnak hozzád "
 "zsoldosnak. Akarsz vásárolni néhány Trollt?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2327
 msgid ""
 "The Dragon city has no Dragons willing to join you this week. Perhaps a "
 "Dragon will become available next week."
@@ -3667,7 +3877,6 @@ msgstr ""
 "A Sárkány városban nincsenek Sárkányok ezen a héten. Talán a következő héten "
 "újra lesznek."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2328
 msgid ""
 "The Dragon city is willing to offer some Dragons for your army for a price. "
 "Do you wish to recruit Dragons?"
@@ -3675,13 +3884,11 @@ msgstr ""
 "A Sárkány városban lévő Sárkányok fizetség fejében csatlakoznak hozzád. "
 "Akarsz Sárkányokat toborozni?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2329
 msgid ""
 "You stand before the Dragon City, a place off-limits to mere humans. Do you "
 "wish to violate this rule and challenge the Dragons to a fight?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2330
 msgid ""
 "Having defeated the Dragon champions, the city's leaders agree to supply "
 "some Dragons to your army for a price. Do you wish to recruit Dragons?"
@@ -3690,18 +3897,15 @@ msgstr ""
 "fizetségért cserébe Sárkányokat vehetsz a csapatodba. Szeretnél Sárkányokat "
 "toborozni?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2389
 msgid "From the observation tower, you are able to see distant lands."
 msgstr "A Kilátótoronyból láthatod a távoli vidéket is."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2401
 msgid ""
 "The spring only refills once a week, and someone's already been here this "
 "week."
 msgstr ""
 "A forrás csak heti egyszer telik meg, és valaki már járt itt mostanában."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2407
 msgid ""
 "A drink at the spring is supposed to give you twice your normal spell "
 "points, but you are already at that level."
@@ -3709,7 +3913,6 @@ msgstr ""
 "Állítólag, ha iszol a forrásból, akkor megkétszereződik a normál "
 "varázspontjaid száma, de te ezt a szintet már elérted."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2418
 msgid ""
 "A drink from the spring fills your blood with magic! You have twice your "
 "normal spell points in reserve."
@@ -3717,7 +3920,6 @@ msgstr ""
 "Ha iszol a forrásból, akkor a véred megtelik varázserővel! Megkétszereződik "
 "a normál varázspontjaid száma."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2437
 msgid ""
 "Recognizing you, the butler refuses to admit you. \"The master,\" he says, "
 "\"will not see the same student twice.\""
@@ -3725,13 +3927,11 @@ msgstr ""
 "A komornyik felismer téged és nem engedi, hogy belépj. \"A Mester\" mondja "
 "\"egy tanítványt sem fogad kétszer.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2457
 msgid ""
 "The butler admits you to see the master of the house. He trains you in the "
 "four skills a hero should know."
 msgstr "Az inas beenged a mesterhez, aki 4 tulajdonságodban is kiképez."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2467
 msgid ""
 "The butler opens the door and looks you up and down. \"You are neither "
 "famous nor diplomatic enough to be admitted to see my master,\" he sniffs. "
@@ -3741,7 +3941,6 @@ msgstr ""
 "diplomatikus ahhoz, hogy beengedjelek a mesteremhez. Gyere vissza, ha úgy "
 "érzed, hogy fejlődtél valamennyit.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2510
 msgid ""
 "All of the %{monsters} you have in your army have been trained by the battle "
 "masters of the fort. Your army now contains %{monsters2}."
@@ -3749,21 +3948,19 @@ msgstr ""
 "Az összes csapatodban lévő %{monsters} lényed az erődítmény harcos "
 "mestereitől vettek leckét. A csapatodban már %{monsters2} lények vannak."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2513
 msgid ""
-"An unusual alliance of Orcs, Ogres, and Dwarves offer to train (upgrade) any "
+"An unusual alliance of Ogres, Orcs, and Dwarves offer to train (upgrade) any "
 "such troops brought to them. Unfortunately, you have none with you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2524
 msgid "All of your %{monsters} have been upgraded into %{monsters2}."
 msgstr "Minden %{monsters} fel lett fejlesztve %{monsters2}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2527
+#, fuzzy
 msgid ""
 "A blacksmith working at the foundry offers to convert all Pikemen and "
 "Swordsmen's weapons brought to him from iron to steel. He also says that he "
-"knows a process that will convert Iron Golems into Steel Golems.  "
+"knows a process that will convert Iron Golems into Steel Golems. "
 "Unfortunately, you have none of these troops in your army, so he can't help "
 "you."
 msgstr ""
@@ -3772,7 +3969,6 @@ msgstr ""
 "Acélgólem átalakításának módszerét is. Sajnos, egyik egység sincs a "
 "seregedben, ezért nem tud neked segíteni."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2585
 msgid ""
 "A retired captain living on this refurbished fishing platform offers to sell "
 "you maps of the sea he made in his younger days for 1,000 gold. Do you wish "
@@ -3782,7 +3978,6 @@ msgstr ""
 "általa, fiatalkorában készített tengeri térképet, 1000 aranyért cserébe. "
 "Megvásárolod a térképet?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2598
 msgid ""
 "The captain sighs. \"You don't have enough money, eh?  You can't expect me "
 "to give my maps away for free!\""
@@ -3790,11 +3985,9 @@ msgstr ""
 "A kapitány elmosolyodik. \"Nincs elég pénzed, ugye? Csak nem képzeled, hogy "
 "ingyen odaadom a térképemet?\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2632
 msgid "You find %{artifact}."
 msgstr "Megtaláltad a %{artifact}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2655
 msgid ""
 "You come upon an obelisk made from a type of stone you have never seen "
 "before. Staring at it intensely, the smooth surface suddenly changes to an "
@@ -3802,11 +3995,9 @@ msgid ""
 "copy down the piece and the inscription vanishes as abruptly as it appeared."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2659
 msgid "You have already been to this obelisk."
 msgstr "Már megnézted ezt az obeliszket."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2671
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"It is good to see "
 "you, my student. I hope my teachings have helped you.\""
@@ -3814,7 +4005,6 @@ msgstr ""
 "Ahogy megközelíted, a fa kinyitja a szemeit . \"Öröm látni téged, "
 "tanítványom. Remélem a tanításaim segítségedre lesznek.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2683
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"Ahh, an "
 "adventurer! Allow me to teach you a little of what I have learned over the "
@@ -3823,11 +4013,9 @@ msgstr ""
 "Ahogy megközelíted, a fa kinyitja a szemeit . \"Ahh, egy kalandor! Engedd "
 "meg, hogy megtanítsalak valamire, amit évek során megtanultam.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2692
 msgid "Upon your approach, the tree opens its eyes in delight."
 msgstr "Ahogy megközelíted, a fa kinyitja a szemeit ."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2694
 #, fuzzy
 msgid ""
 "\"Ahh, an adventurer! I will be happy to teach you a little of what I have "
@@ -3836,24 +4024,25 @@ msgstr ""
 "\"Ahh, egy kalandor! Szívesen megtanítalak 10 gyöngyért cserébe valamire, "
 "amit évek során megtanultam.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2696
 msgid "(Just bury it around my roots.)"
 msgstr "(Csak ásd el a gyökereim közé.)"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2703
 msgid "Tears brim in the eyes of the tree."
 msgstr "A fa szemei megtelnek könnyel."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2705
 #, fuzzy
 msgid "\"I need %{count} %{res}.\""
 msgstr "Szükségem van 10 drágakőre."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2707
 msgid "it whispers. (sniff) \"Well, come back when you can pay me.\""
 msgstr "Azt suttogja. (hüpp) \"Nos, gyere vissza amikor már tudsz fizetni.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2737
+msgid ""
+"Nestled among the trees sits a blind seer. After explaining the intent of "
+"your journey, the seer activates his crystal ball, allowing you to see the "
+"strengths and weaknesses of your opponents."
+msgstr ""
+
 msgid ""
 "The entrance to the cave is dark, and a foul, sulfurous smell issues from "
 "the cave mouth. Will you enter?"
@@ -3861,7 +4050,6 @@ msgstr ""
 "A barlang bejárata sötét, és undorító, kénes szag áramlik ki a barlang "
 "szájából. Belépsz?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2749
 msgid ""
 "You find a powerful and grotesque Demon in the cave. \"Today,\" it rasps, "
 "\"you will fight and surely die. But I will give you a choice of deaths. You "
@@ -3869,7 +4057,6 @@ msgid ""
 "servants?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2759
 #, fuzzy
 msgid ""
 "Upon defeating the daemon's servants, you find a hidden cache with %{count} "
@@ -3877,66 +4064,55 @@ msgid ""
 msgstr ""
 "Miután legyőzted a démon alattvalóit, találsz egy elrejtett 2500 aranyat."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2774
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and receive %{exp} experience points."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2784
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and find the %{art} in the back of the cave."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2794
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
-"battle, you slay the monster and receive %{exp) experience points and %"
-"{count} gold."
+"battle, you slay the monster and receive %{exp} experience points and "
+"%{count} gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2809
 msgid ""
 "The Demon leaps upon you and has its claws at your throat before you can "
 "even draw your sword. \"Your life is mine,\" it says. \"I will sell it back "
 "to you for %{count} gold.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2810
 msgid ""
 "Seeing that you do not have %{count} gold, the demon slashes you with its "
 "claws, and the last thing you see is a red haze."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2835
 msgid "Except for evidence of a terrible battle, the cave is empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2860
 msgid "For %{gold} gold, the alchemist will remove it for you. Do you pay?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2871
 msgid ""
 "You hear a voice from behind the locked door, \"You don't have enough gold "
 "to pay for my services.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2874
 msgid ""
 "You hear a voice from high above in the tower, \"Go away! I can't help you!\""
 msgstr ""
 "Egy hangot hallasz a torony tetejéről: \"Menj el! Nem tudok neked segíteni!\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2886
 msgid ""
 "The head groom approaches you and speaks, \"You already have a fine horse, "
 "and have no inexperienced cavalry which might make use of our trained war "
 "horses.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2889
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, his "
@@ -3945,7 +4121,6 @@ msgid ""
 "mounted soldiers, but you have none we can help.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2892
 msgid ""
 "The head groom speaks to you, \"That is a fine looking horse you have. I am "
 "afraid we can give you no better, but the horses your cavalry are riding "
@@ -3953,7 +4128,6 @@ msgid ""
 "would aid your riders greatly. I insist you take them.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2895
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, he will "
@@ -3961,17 +4135,14 @@ msgid ""
 "mounted soldiers, their horses look shoddy and weak.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2922
 msgid "The Arena guards turn you away."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2939
 msgid ""
 "As the sirens sing their eerie song, your small, determined army manages to "
 "overcome the urge to dive headlong into the sea."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2944
 msgid ""
 "You have your crew stop up their ears with wax before the sirens' eerie song "
 "has any chance of luring them to a watery grave. An eerie wailing song "
@@ -3980,29 +4151,24 @@ msgid ""
 "for the visit, and gain %{exp} experience."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2964
 msgid ""
 "In a dazzling display of daring, you break into the local jail and free the "
 "hero imprisoned there, who, in return, pledges loyalty to your cause."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2980
 msgid ""
 "You already have %{count} heroes, and regretfully must leave the prisoner in "
 "this jail to languish in agony for untold days."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2991
 msgid ""
 "You enter a rickety hut and talk to the magician who lives there. He tells "
 "you of places near and far which may aid you in your journeys."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3004
 msgid "This eye seems to be intently studying its surroundings."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3015
 msgid ""
 "\"I have a riddle for you,\" the Sphinx says. \"Answer correctly, and you "
 "shall be rewarded. Answer incorrectly, and you shall be eaten. Do you accept "
@@ -4011,11 +4177,15 @@ msgstr ""
 "\"Van számodra egy rejtvényem.\" - mondja. \"Ha jó a válaszod, "
 "megjutalmazlak. Ha rossz a válaszod, felfallak. Elfogadod a kihívás?\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3017
-msgid "The Sphinx asks you the following riddle: %{riddle}. Your answer?"
+#, fuzzy
+msgid ""
+"The Sphinx asks you the following riddle:\n"
+" \n"
+"'%{riddle}'\n"
+" \n"
+"Your answer?"
 msgstr "A Szfinx a következő rejtvényt adja fel:  %{riddle}. Mi a válaszod?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:3025
 msgid ""
 "Looking somewhat disappointed, the Sphinx sighs. You've answered my riddle "
 "so here's your reward. Now begone."
@@ -4023,7 +4193,6 @@ msgstr ""
 "A Szfinx kissé csalódottan felsóhajt. \"Jó a válaszod, itt van a jutalmad. "
 "Most menj!\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3052
 msgid ""
 "\"You guessed incorrectly,\" the Sphinx says, smiling. The Sphinx swipes at "
 "you with a paw, knocking you to the ground. Another blow makes the world go "
@@ -4033,11 +4202,9 @@ msgstr ""
 "mancsával, és ledönt a földre. A következő ütésre elsötétül előtted a világ, "
 "többre nem emlékszel."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3060
 msgid "You come across a giant Sphinx. The Sphinx remains strangely quiet."
 msgstr "Egy hatalmas Szfinxhez érkezel. A Szfinx furcsán suttogva megszólít."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3073
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -4045,7 +4212,6 @@ msgid ""
 "As you speak the magic word, the glowing barrier dissolves into nothingness."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3083
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -4053,7 +4219,6 @@ msgid ""
 "You speak, and nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3093
 msgid ""
 "You enter the tent and see an old woman gazing into a magic gem. She looks "
 "up and says,\n"
@@ -4061,328 +4226,15 @@ msgid ""
 "oracle taught me his skill. I have the answer you seek.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_base.cpp:401
 msgid ""
 "That spell costs %{mana} mana. You only have %{point} mana, so you can't "
 "cast the spell."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Lord Kilburn"
-msgstr "Lord Kilburn"
+#, fuzzy
+msgid "%{name} the %{race} (Level %{level})"
+msgstr "%{level} szint"
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Sir Gallanth"
-msgstr "Sir Gallanth"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ector"
-msgstr "Ector"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Gwenneth"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Tyro"
-msgstr "Tyro"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ambrose"
-msgstr "Ambrose"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ruby"
-msgstr "Ruby"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Maximus"
-msgstr "Maximus"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Dimitry"
-msgstr "Dimitry"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Thundax"
-msgstr "Thundax"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Fineous"
-msgstr "Fineous"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jojosh"
-msgstr "Jojosh"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Crag Hack"
-msgstr "Crag Hack"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jezebel"
-msgstr "Jezebel"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jaclyn"
-msgstr "Jaclyn"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Ergon"
-msgstr "Ergon"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Tsabu"
-msgstr "Tsabu"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Atlas"
-msgstr "Atlas"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Astra"
-msgstr "Astra"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Natasha"
-msgstr "Natasha"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Troyan"
-msgstr "Troyan"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Vatawna"
-msgstr "Vatawna"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Rebecca"
-msgstr "Rebecca"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Gem"
-msgstr "Gem"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Ariel"
-msgstr "Ariel"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Carlawn"
-msgstr "Carlawn"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Luna"
-msgstr "Luna"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Arie"
-msgstr "Arie"
-
-#: ../fheroes2/heroes/heroes.cpp:61 ../fheroes2/resource/maps_text.cpp:59
-msgid "Alamar"
-msgstr "Alamar"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Vesper"
-msgstr "Vesper"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Crodo"
-msgstr "Crodo"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Barok"
-msgstr "Barok"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Kastore"
-msgstr "Kastore"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Agar"
-msgstr "Agar"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Falagar"
-msgstr "Falagar"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Wrathmont"
-msgstr "Wrathmont"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myra"
-msgstr "Myra"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Flint"
-msgstr "Flint"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Dawn"
-msgstr "Dawn"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Halon"
-msgstr "Halon"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myrini"
-msgstr "Myrini"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Wilfrey"
-msgstr "Wilfrey"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Sarakin"
-msgstr "Sarakin"
-
-#: ../fheroes2/heroes/heroes.cpp:63 ../fheroes2/resource/maps_text.cpp:377
-msgid "Kalindra"
-msgstr "Kalindra"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Mandigal"
-msgstr "Mandigal"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zom"
-msgstr "Zom"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Darlana"
-msgstr "Darlana"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zam"
-msgstr "Zam"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Ranloo"
-msgstr "Ranloo"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Charity"
-msgstr "Charity"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Rialdo"
-msgstr "Rialdo"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Roxana"
-msgstr "Roxana"
-
-#: ../fheroes2/heroes/heroes.cpp:65 ../fheroes2/resource/maps_text.cpp:557
-msgid "Sandro"
-msgstr "Sandro"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Celia"
-msgstr "Celia"
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:552
-msgid "Roland"
-msgstr "Roland"
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Lord Corlagon"
-msgstr "Lord Corlagon"
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Sister Eliza"
-msgstr "Eliza nővér"
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:88
-msgid "Archibald"
-msgstr "Archibald"
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:403
-msgid "Lord Halton"
-msgstr "Lord Halton"
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Brother Bax"
-msgstr "Bax atya"
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Solmyr"
-msgstr "Solmyr"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:194
-msgid "Dainwin"
-msgstr "Dainwin"
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Mog"
-msgstr "Mog"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:760
-msgid "Uncle Ivan"
-msgstr "Uncle nagybácsi"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:373
-msgid "Joseph"
-msgstr "Joseph"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:285
-msgid "Gallavant"
-msgstr "Gallavant"
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Elderian"
-msgstr "Elderian"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:179
-msgid "Ceallach"
-msgstr "Ceallach"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:229
-msgid "Drakonia"
-msgstr "Drakonia"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:422
-msgid "Martine"
-msgstr "Martine"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:370
-msgid "Jarkonas"
-msgstr "Jarkonas"
-
-#: ../fheroes2/heroes/heroes.cpp:940
-msgid ""
-"You must purchase a spell book to use the mage guild, but you currently have "
-"no room for a spell book. Try giving one of your artifacts to another hero."
-msgstr ""
-"Hogy használd a varázstoronyban lévő varázslatokat, szükséged van "
-"varázskönyvre, de nincs szabad hely a könyv számára. Próbálj meg egy "
-"varázstárgyat átadni egy másik hősnek."
-
-#: ../fheroes2/heroes/heroes.cpp:950
-msgid "The three Anduran artifacts magically combine into one."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1056
-msgid "To cast spells, you must first buy a spell book for %{gold} gold."
-msgstr ""
-"Hogy varázsolhass, először vásárolnod kell %{gold} aranyért varázskönyvet."
-
-#: ../fheroes2/heroes/heroes.cpp:1064
-msgid "Unfortunately, you seem to be a little short of cash at the moment."
-msgstr "Sajnos, nincs elég aranyad."
-
-#: ../fheroes2/heroes/heroes.cpp:1078
-msgid "Do you wish to buy one?"
-msgstr "Szeretnél venni egyet?"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:72
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:55
-msgid "%{name} the %{race} ( Level %{level} )"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:118
 msgid ""
 "'Grouped' combat formation bunches your army together in the center of your "
 "side of the battlefield."
@@ -4390,99 +4242,76 @@ msgstr ""
 "'Szoros' csataalakzatban az egységeid szorosan egymás mellett helyezkednek "
 "el a harcmező oldalának közepén."
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:161
 msgid "Are you sure you want to dismiss this Hero?"
 msgstr "Biztos, hogy elbocsátod ezt a Hőst?"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:341
 #, fuzzy
 msgid "View Stats"
 msgstr "Varázstárgyak mutatása"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:344
-msgid "View Morale Info"
-msgstr "Morál információ"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:347
-msgid "View Luck Info"
-msgstr "Szerencse információ"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:350
 msgid "View Experience Info"
 msgstr "Tapasztalat információ"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:353
 msgid "View Spell Points Info"
 msgstr "Varázspont információ"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:356
 msgid "Set army combat formation to 'Spread'"
 msgstr "A csataalakzata legyen 'Laza'."
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:359
 msgid "Set army combat formation to 'Grouped'"
 msgstr "A csataalakzat legyen 'Szoros'."
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:362
-msgid "Exit hero"
+msgid "Exit Hero Screen"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:369
-msgid "Dismiss hero"
-msgstr "Hős elbocsátása"
+msgid "You cannot dismiss a hero in a castle"
+msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:373
-msgid "Show prev heroes"
-msgstr "Elöző hősök"
+msgid "Dismissal of %{name} the %{race} is prohibited by scenario"
+msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:376
-msgid "Show next heroes"
+#, fuzzy
+msgid "Dismiss %{name} the %{race}"
+msgstr "%{name} a %{race}"
+
+#, fuzzy
+msgid "Show previous hero"
+msgstr "Előző város mutatása"
+
+#, fuzzy
+msgid "Show next hero"
 msgstr "Következő hősök"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:379
-msgid "Hero Screen"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:39
-msgid "Bad Morale"
-msgstr "Rossz Morál"
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:42
-msgid "Neutral Morale"
-msgstr "Semleges Morál"
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:47
-msgid "Good Morale"
+#, fuzzy
+msgid "Blood Morale"
 msgstr "Jó Morál"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:61
-msgid "Bad Luck"
-msgstr "Rossz szerencse"
+#, fuzzy
+msgid "%{morale} Morale"
+msgstr "morál|Normál"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:64
-msgid "Neutral Luck"
-msgstr "Semleges szerencse"
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:69
-msgid "Good Luck"
-msgstr "Jó szerencse"
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:113
-#: ../fheroes2/heroes/heroes_indicator.cpp:159
-#: ../fheroes2/heroes/skill.cpp:197
-msgid "Current Modifiers:"
+msgid "%{luck} Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:195
-msgid "Current experience %{exp1} Next level %{exp2}."
+msgid "Current Luck Modifiers:"
+msgstr ""
+
+msgid "Current Morale Modifiers:"
+msgstr ""
+
+#, fuzzy
+msgid "Entire army is undead, so morale does not apply."
+msgstr "A csapat minden tagja élőhalott, így a morál nem hat rájuk."
+
+#, fuzzy
+msgid ""
+"Current experience %{exp1}.\n"
+" Next level %{exp2}."
 msgstr "Jelenlegi tapasztalati pont %{exp1} Következő szint %{exp2}."
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:215
 msgid "Level %{level}"
 msgstr "%{level} szint"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:226
 msgid ""
 "%{name} currently has %{point} spell points out of a maximum of %{max}. The "
 "maximum number of spell points is 10 times your knowledge. It is "
@@ -4493,86 +4322,85 @@ msgstr ""
 "varázspont maximális száma a tudásod értékének 10-szerese. Ez speciális "
 "esetekben lehet több is."
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:65
 msgid "%{name1} meets %{name2}"
 msgstr "%{name1} és %{name2} találkozik"
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:396
-#: ../fheroes2/heroes/heroes_meeting.cpp:406
 msgid " and "
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:414
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:417
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:420
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches %"
-"{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches "
+"%{spells2} to %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:431
 msgid "Scholar Ability"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:83 ../fheroes2/spell/spell.cpp:109
 msgid "Town Portal"
 msgstr "Városba lépés"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:86
 msgid "Select town to port to."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:106
 msgid "Your hero is too tired to cast this spell today. Try again tomorrow."
 msgstr ""
 "A hősöd túl fáradt ehhez a varázslathoz a mai nap. Próbáld újra holnap."
 
-#: ../fheroes2/heroes/heroes_spell.cpp:187
 msgid "%{spell} failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:236
+msgid "This spell is already in use."
+msgstr ""
+
 msgid "Enemy heroes are now fully identifiable."
 msgstr "Az ellenséges hősök teljes mértékben azonosíthatóak."
 
-#: ../fheroes2/heroes/heroes_spell.cpp:362
-#: ../fheroes2/heroes/heroes_spell.cpp:386
-msgid "No available towns. Spell Failed!!!"
+#, fuzzy
+msgid "This spell cannot be used on a boat."
+msgstr "Ezt a várost nem lehet kastéllyá fejleszteni."
+
+msgid "This spell can be casted only nearby water."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"No available towns.\n"
+"Spell Failed!!!"
 msgstr "Nincs használható város. Sikertelen Varázslat!!!"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:459
-msgid "I fear these creatures are in the mood for a fight."
-msgstr "Félő, hogy ezek a lények készek harcolni."
+#, fuzzy
+msgid ""
+"Nearest town occupied.\n"
+"Spell Failed!!!"
+msgstr "Nincs használható város. Sikertelen Varázslat!!!"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:463
-msgid "The creatures are willing to join us!"
-msgstr "A lények csatlakozni akarnak hozzád!"
-
-#: ../fheroes2/heroes/heroes_spell.cpp:468
-msgid "All the creatures will join us..."
-msgstr "Minden lény csatlakozna hozzás..."
-
-#: ../fheroes2/heroes/heroes_spell.cpp:480
-msgid "These weak creatures will surely flee before us."
-msgstr "Ezek a gyenge lények valószínű elmenekül előled."
-
-#: ../fheroes2/heroes/heroes_spell.cpp:489
 msgid ""
 "You must be within %{count} spaces of a monster for the Visions spell to "
 "work."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:506
+msgid "I fear these creatures are in the mood for a fight."
+msgstr "Félő, hogy ezek a lények készek harcolni."
+
+msgid "The creatures are willing to join us!"
+msgstr "A lények csatlakozni akarnak hozzád!"
+
+msgid "All the creatures will join us..."
+msgstr "Minden lény csatlakozna hozzás..."
+
+msgid "These weak creatures will surely flee before us."
+msgstr "Ezek a gyenge lények valószínű elmenekül előled."
+
 msgid ""
 "You must be standing on the entrance to a mine (sawmills and alchemists "
 "don't count) to cast this spell."
@@ -4580,462 +4408,370 @@ msgstr ""
 "A bánya bejáratánál kell állnod (a fűrészmalmot és az alkimista labort "
 "leszámítva), hogy használd ezt a varázslatot."
 
-#: ../fheroes2/heroes/skill.cpp:151
-msgid "Power"
-msgstr "Erő"
-
-#: ../fheroes2/heroes/skill.cpp:172
 msgid "Your attack skill is a bonus added to each creature's attack skill."
 msgstr ""
 "A támadóerőd értéke bónuszként hozzáadódik mindegyik lényed támadóerejéhez."
 
-#: ../fheroes2/heroes/skill.cpp:177
 msgid "Your defense skill is a bonus added to each creature's defense skill."
 msgstr ""
 "A védőerőd értéke bónuszként hozzáadódik mindegyik lényed védőerejéhez."
 
-#: ../fheroes2/heroes/skill.cpp:182
 msgid "Your spell power determines the length or power of a spell."
 msgstr "A varázserőd meghatározza a varázslat hatóidejét."
 
-#: ../fheroes2/heroes/skill.cpp:187
 msgid ""
 "Your knowledge determines how many spell points your hero may have. Under "
-"normal cirumstances, a hero is limited to 10 spell points per level of "
+"normal circumstances, a hero is limited to 10 spell points per level of "
 "knowledge."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
+msgid "Current Modifiers:"
+msgstr ""
+
 #, fuzzy
 msgid "skill|Basic"
 msgstr "Alap"
 
-#: ../fheroes2/heroes/skill.cpp:214
 #, fuzzy
 msgid "skill|Advanced"
 msgstr "Haladó"
 
-#: ../fheroes2/heroes/skill.cpp:214
 #, fuzzy
 msgid "skill|Expert"
 msgstr "Fejlett"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Pathfinding"
 msgstr "Nyomkövetés"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Archery"
 msgstr "Íjászat"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Logistics"
 msgstr "Logisztika"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Scouting"
 msgstr "Cserkészet"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Diplomacy"
 msgstr "Diplomácia"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Navigation"
 msgstr "Navigáció"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Leadership"
 msgstr "Vezetés"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Wisdom"
 msgstr "Bölcsesség"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Mysticism"
 msgstr "Misztika"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Ballistics"
 msgstr "Ballisztika"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Eagle Eye"
 msgstr "Sasszem"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Necromancy"
 msgstr "Nekromancia"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Estates"
 msgstr "Vagyon"
 
-#: ../fheroes2/heroes/skill.cpp:367
 #, fuzzy
 msgid "Basic Pathfinding"
 msgstr "Nyomkövetés"
 
-#: ../fheroes2/heroes/skill.cpp:367
 #, fuzzy
 msgid "Advanced Pathfinding"
 msgstr "Nyomkövetés"
 
-#: ../fheroes2/heroes/skill.cpp:367
 #, fuzzy
 msgid "Expert Pathfinding"
 msgstr "Nyomkövetés"
 
-#: ../fheroes2/heroes/skill.cpp:368
 #, fuzzy
 msgid "Basic Archery"
 msgstr "Íjászat"
 
-#: ../fheroes2/heroes/skill.cpp:368
 #, fuzzy
 msgid "Advanced Archery"
 msgstr "Haladó"
 
-#: ../fheroes2/heroes/skill.cpp:368
 #, fuzzy
 msgid "Expert Archery"
 msgstr "Íjászat"
 
-#: ../fheroes2/heroes/skill.cpp:369
 #, fuzzy
 msgid "Basic Logistics"
 msgstr "Logisztika"
 
-#: ../fheroes2/heroes/skill.cpp:369
 #, fuzzy
 msgid "Advanced Logistics"
 msgstr "Logisztika"
 
-#: ../fheroes2/heroes/skill.cpp:369
 #, fuzzy
 msgid "Expert Logistics"
 msgstr "Logisztika"
 
-#: ../fheroes2/heroes/skill.cpp:370
 #, fuzzy
 msgid "Basic Scouting"
 msgstr "Cserkészet"
 
-#: ../fheroes2/heroes/skill.cpp:370
 #, fuzzy
 msgid "Advanced Scouting"
 msgstr "Haladó"
 
-#: ../fheroes2/heroes/skill.cpp:370
 #, fuzzy
 msgid "Expert Scouting"
 msgstr "Cserkészet"
 
-#: ../fheroes2/heroes/skill.cpp:371
 #, fuzzy
 msgid "Basic Diplomacy"
 msgstr "Diplomácia"
 
-#: ../fheroes2/heroes/skill.cpp:371
 #, fuzzy
 msgid "Advanced Diplomacy"
 msgstr "Diplomácia"
 
-#: ../fheroes2/heroes/skill.cpp:371
 #, fuzzy
 msgid "Expert Diplomacy"
 msgstr "Diplomácia"
 
-#: ../fheroes2/heroes/skill.cpp:372
 #, fuzzy
 msgid "Basic Navigation"
 msgstr "Navigáció"
 
-#: ../fheroes2/heroes/skill.cpp:372
 #, fuzzy
 msgid "Advanced Navigation"
 msgstr "Navigáció"
 
-#: ../fheroes2/heroes/skill.cpp:372
 #, fuzzy
 msgid "Expert Navigation"
 msgstr "Navigáció"
 
-#: ../fheroes2/heroes/skill.cpp:373
 #, fuzzy
 msgid "Basic Leadership"
 msgstr "Vezetés"
 
-#: ../fheroes2/heroes/skill.cpp:373
 #, fuzzy
 msgid "Advanced Leadership"
 msgstr "Vezetés"
 
-#: ../fheroes2/heroes/skill.cpp:373
 #, fuzzy
 msgid "Expert Leadership"
 msgstr "Vezetés"
 
-#: ../fheroes2/heroes/skill.cpp:374
 #, fuzzy
 msgid "Basic Wisdom"
 msgstr "Bölcsesség"
 
-#: ../fheroes2/heroes/skill.cpp:374
 #, fuzzy
 msgid "Advanced Wisdom"
 msgstr "Haladó"
 
-#: ../fheroes2/heroes/skill.cpp:374
 #, fuzzy
 msgid "Expert Wisdom"
 msgstr "Fejlett"
 
-#: ../fheroes2/heroes/skill.cpp:375
 #, fuzzy
 msgid "Basic Mysticism"
 msgstr "Misztika"
 
-#: ../fheroes2/heroes/skill.cpp:375
 #, fuzzy
 msgid "Advanced Mysticism"
 msgstr "Misztika"
 
-#: ../fheroes2/heroes/skill.cpp:375
 #, fuzzy
 msgid "Expert Mysticism"
 msgstr "Misztika"
 
-#: ../fheroes2/heroes/skill.cpp:376
 #, fuzzy
 msgid "Basic Luck"
 msgstr "Rossz szerencse"
 
-#: ../fheroes2/heroes/skill.cpp:376
 #, fuzzy
 msgid "Advanced Luck"
 msgstr "Haladó"
 
-#: ../fheroes2/heroes/skill.cpp:376
 #, fuzzy
 msgid "Expert Luck"
 msgstr "Fejlett"
 
-#: ../fheroes2/heroes/skill.cpp:377
 #, fuzzy
 msgid "Basic Ballistics"
 msgstr "Ballisztika"
 
-#: ../fheroes2/heroes/skill.cpp:377
 #, fuzzy
 msgid "Advanced Ballistics"
 msgstr "Ballisztika"
 
-#: ../fheroes2/heroes/skill.cpp:377
 #, fuzzy
 msgid "Expert Ballistics"
 msgstr "Ballisztika"
 
-#: ../fheroes2/heroes/skill.cpp:378
 #, fuzzy
 msgid "Basic Eagle Eye"
 msgstr "Sasszem"
 
-#: ../fheroes2/heroes/skill.cpp:378
 #, fuzzy
 msgid "Advanced Eagle Eye"
 msgstr "Sasszem"
 
-#: ../fheroes2/heroes/skill.cpp:378
 #, fuzzy
 msgid "Expert Eagle Eye"
 msgstr "Sasszem"
 
-#: ../fheroes2/heroes/skill.cpp:379
 #, fuzzy
 msgid "Basic Necromancy"
 msgstr "Nekromancia"
 
-#: ../fheroes2/heroes/skill.cpp:379
 #, fuzzy
 msgid "Advanced Necromancy"
 msgstr "Nekromancia"
 
-#: ../fheroes2/heroes/skill.cpp:379
 #, fuzzy
 msgid "Expert Necromancy"
 msgstr "Nekromancia"
 
-#: ../fheroes2/heroes/skill.cpp:380
 #, fuzzy
 msgid "Basic Estates"
 msgstr "Vagyon"
 
-#: ../fheroes2/heroes/skill.cpp:380
 #, fuzzy
 msgid "Advanced Estates"
 msgstr "Haladó"
 
-#: ../fheroes2/heroes/skill.cpp:380
 #, fuzzy
 msgid "Expert Estates"
 msgstr "Vagyon"
 
-#: ../fheroes2/heroes/skill.cpp:406
 #, fuzzy
-msgid "Allows you to negotiate with monsters who are weaker than your group."
+msgid " allows you to negotiate with monsters who are weaker than your group."
 msgstr ""
 "A Fejlett Diplomácia lehetővé teszi a seregednél gyengébb lényekkel való "
 "tárgyalást. Mindannyian csatlakozhatnak hozzád."
 
-#: ../fheroes2/heroes/skill.cpp:421
 #, fuzzy
-msgid "Allows your hero to learn third level spells."
+msgid "All of the creatures may offer to join you."
+msgstr ""
+"Alap Diplomácia lehetővé teszi, hogy a csapatodnál gyengébb szörnyekkel "
+"tárgyalj. Kb. a lények %{count} százaléka csatlakozhat hozzád."
+
+#, fuzzy
+msgid " allows your hero to learn third level spells."
 msgstr ""
 "Az Alap Bölcsesség képessé teszi a hősödet 3. szintű varázslatok "
 "használatára."
 
-#: ../fheroes2/heroes/skill.cpp:423
 #, fuzzy
-msgid "Allows your hero to learn fourth level spells."
+msgid " allows your hero to learn fourth level spells."
 msgstr ""
 "A Haladó Bölcsesség képessé teszi a hősödet 4. szintű varázslatok "
 "használatára."
 
-#: ../fheroes2/heroes/skill.cpp:425
 #, fuzzy
-msgid "Allows your hero to learn fifth level spells."
+msgid " allows your hero to learn fifth level spells."
 msgstr ""
 "A Fejlett Bölcsesség képessé teszi a hősödet 5. szintű varázslatok "
 "használatára."
 
-#: ../fheroes2/heroes/skill.cpp:440
 #, fuzzy
 msgid ""
-"Gives your hero's catapult shots a greater chance to hit and do damage to "
+" gives your hero's catapult shots a greater chance to hit and do damage to "
 "castle walls."
 msgstr ""
 "Az Alap Ballisztika nagyobb esélyt ad a hősöd katapultjának a találatra és "
 "kastélyfal sebzésre."
 
-#: ../fheroes2/heroes/skill.cpp:442
 #, fuzzy
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot has a greater chance "
-"to hit and do damage to castle walls."
+" gives your hero's catapult an extra shot, and each shot has a greater "
+"chance to hit and do damage to castle walls."
 msgstr ""
 "A Haladó Ballisztika egy plusz lövést és nagyobb esélyt ad a hősöd "
 "katapultjának a találatra és kastélyfal sebzésre."
 
-#: ../fheroes2/heroes/skill.cpp:444
 #, fuzzy
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot automatically "
+" gives your hero's catapult an extra shot, and each shot automatically "
 "destroys any wall, except a fortified wall in a Knight town."
 msgstr ""
 "A Haladó Ballisztika egy plusz lövést ad a hősöd katapultjának. Minden lövés "
 "automatikusan rombolja a falat, kivéve a Lovagvár sánccal megerősített várát."
 
-#: ../fheroes2/heroes/skill.cpp:858 ../fheroes2/heroes/skill.cpp:959
-#, fuzzy
-msgid "View %{skill} Info"
-msgstr "%{level} %{skill} információ"
-
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:108
 msgid "Blue"
 msgstr "Kék"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:111
 msgid "Green"
 msgstr "Zöld"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:114
 msgid "Red"
 msgstr "Vörös"
 
-#: ../fheroes2/kingdom/color.cpp:32
 msgid "Yellow"
 msgstr "Sárga"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:112
 msgid "Orange"
 msgstr "Narancs"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:113
 msgid "Purple"
 msgstr "Lila"
 
-#: ../fheroes2/kingdom/color.cpp:107
 msgid "Aqua"
 msgstr "Tengerkék"
 
-#: ../fheroes2/kingdom/color.cpp:109
 msgid "Brown"
 msgstr "Barna"
 
-#: ../fheroes2/kingdom/color.cpp:110 ../fheroes2/resource/resource.cpp:283
 msgid "Gold"
 msgstr "Arany"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:238
 #, fuzzy
 msgid "Hero/Stats"
 msgstr "Legjobb hős statisztikái:"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:241
 #, fuzzy
 msgid "Skills"
 msgstr "Fűrészmalom"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:244
 #, fuzzy
 msgid "Artifacts"
 msgstr "Varázstárgy"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:473
 #, fuzzy
 msgid "Town/Castle"
 msgstr "Kastély"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:476
 msgid "Garrison"
 msgstr "Helyőrség"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:566
 #, fuzzy
 msgid "Gold Per Day:"
 msgstr "Arany a kincstárban:"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Cursed"
 msgstr "szerencse|Átkozott"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Awful"
 msgstr "szerencse|Szörnyű"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Bad"
 msgstr "szerencse|Rossz"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Normal"
 msgstr "szerencse|Normál"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Good"
 msgstr "szerencse|Jó"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Great"
 msgstr "szerencse|Nagyszerű"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Irish"
 msgstr "szerencse|Páratlan"
 
-#: ../fheroes2/kingdom/luck.cpp:48
 msgid ""
 "Bad luck sometimes falls on your armies in combat, causing their attacks to "
 "only do half damage."
@@ -5043,7 +4779,6 @@ msgstr ""
 "A Rossz szerencse következtében a csatában alkalmanként egyes egységek "
 "sebzése felére csökken."
 
-#: ../fheroes2/kingdom/luck.cpp:49
 msgid ""
 "Neutral luck means your armies will never get lucky or unlucky attacks on "
 "the enemy."
@@ -5051,7 +4786,6 @@ msgstr ""
 "A Semleges szerencse azt jelenti, hogy a csata során se szerencse se "
 "balszerencse nem éri az egységeid támadását."
 
-#: ../fheroes2/kingdom/luck.cpp:50
 msgid ""
 "Good luck sometimes lets your armies get lucky attacks (double strength) in "
 "combat."
@@ -5059,39 +4793,30 @@ msgstr ""
 "Jószerencse esetén a csapatod tagjainak alkalmanként esélye van szerencsés "
 "támadásra (dupla erősségű) a csata során."
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Treason"
 msgstr "morál|Felségárulás"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Awful"
 msgstr "morál|Szörnyű"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Poor"
 msgstr "morál|Rossz"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Normal"
 msgstr "morál|Normál"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Good"
 msgstr "morál|Jó"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Great"
 msgstr "morál|Nagyszerű"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Blood!"
 msgstr "morál|Örjöngő"
 
-#: ../fheroes2/kingdom/morale.cpp:48
 msgid "Bad morale may cause your armies to freeze in combat."
 msgstr "Rossz morál következtében csapattagok kimaradhatnak a körből."
 
-#: ../fheroes2/kingdom/morale.cpp:49
 msgid ""
 "Neutral morale means your armies will never be blessed with extra attacks or "
 "freeze in combat."
@@ -5099,2036 +4824,1031 @@ msgstr ""
 "Semleges morál azt jelenti, hogy a csapattagok nem kapnak lehetősége extra "
 "támadásra és nem is maradnak ki."
 
-#: ../fheroes2/kingdom/morale.cpp:50
 msgid "Good morale may give your armies extra attacks in combat."
 msgstr "Jó morál esetén az egységek extra támadási lehetőséget kaphatnak."
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Knight"
 msgstr "Lovag"
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Barbarian"
 msgstr "Barbár"
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Sorceress"
 msgstr "Varázslónő"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Warlock"
 msgstr "Boszorkánymester"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Wizard"
 msgstr "Varázsló"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Necromancer"
 msgstr "Hullamágus"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Multi"
 msgstr "Többszörös"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Standing"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Crawling"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Very Slow"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Slow"
 msgstr "sebesség|Lassú"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Average"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Very Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Ultra Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Blazing"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Instant"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:32
 msgid "week|PLAGUE"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Ant"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Grasshopper"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Dragonfly"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Spider"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Butterfly"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Bumblebee"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Locust"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Earthworm"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Hornet"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Beetle"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Squirrel"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Rabbit"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Gopher"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Badger"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Eagle"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Weasel"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Raven"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Mongoose"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Aardvark"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Lizard"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Tortoise"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Hedgehog"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Condor"
 msgstr ""
 
-#: ../fheroes2/kingdom/world_loadmap.cpp:1424
-#, fuzzy
-msgid "The ultimate artifact is really the %{name}"
-msgstr "A Múmiák átka lesújt a(z) %{name}!"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1428
-msgid "The ultimate artifact may be found in the %{name} regions of the world."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1433
-msgid "north-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1436
-#, fuzzy
-msgid "north"
-msgstr "Erőd"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1438
-msgid "north-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1444
-#, fuzzy
-msgid "west"
-msgstr "Fészek"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1447
-#, fuzzy
-msgid "center"
-msgstr "Szörny"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1449
-#, fuzzy
-msgid "east"
-msgstr "Fészek"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1454
-msgid "south-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1457
-#, fuzzy
-msgid "south"
-msgstr "hang"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1459
-msgid "south-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1463
-msgid "The truth is out there."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1464
-msgid "The dark side is stronger."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1465
-msgid "The end of the world is near."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1466
-msgid "The bones of Lord Slayer are buried in the foundation of the arena."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1467
-msgid "A Black Dragon will take out a Titan any day of the week."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1468
-msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1470
-msgid ""
-"You can load the newest version of game from a site:\n"
-" http://sf.net/projects/fheroes2"
-msgstr ""
-"Letöltheted a legújabb verziót az oldalról:\n"
-"http://sf.net/projects/fheroes2"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1471
-msgid "This game is now in beta development version. ;)"
-msgstr ""
-
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Desert"
 msgstr "Sivatag"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Snow"
 msgstr "Hó"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Wasteland"
 msgstr "Pusztulat"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Beach"
 msgstr "Part"
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Lava"
 msgstr "Láva"
 
-#: ../fheroes2/maps/ground.cpp:31 ../fheroes2/resource/maps_text.cpp:210
 msgid "Dirt"
 msgstr "Sár"
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Grass"
 msgstr "Fű"
 
-#: ../fheroes2/maps/ground.cpp:31
-msgid "Water"
-msgstr "Víz"
+msgid "Ocean"
+msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Small"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Medium"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Large"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Extra Large"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Custom Size"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:122
 msgid "Ore Mine"
 msgstr "Ércbánya"
 
-#: ../fheroes2/maps/maps.cpp:123
 msgid "Sulfur Mine"
 msgstr "Kénbánya"
 
-#: ../fheroes2/maps/maps.cpp:124
 msgid "Crystal Mine"
 msgstr "Kristálybánya"
 
-#: ../fheroes2/maps/maps.cpp:125
 msgid "Gems Mine"
 msgstr "Drágakőbánya"
 
-#: ../fheroes2/maps/maps.cpp:126
 msgid "Gold Mine"
 msgstr "Aranybánya"
 
-#: ../fheroes2/maps/maps.cpp:130
 msgid "Mine"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:365
 msgid "Alchemist Lab"
 msgstr "Alkímista labor"
 
-#: ../fheroes2/maps/mp2.cpp:367
 msgid "Daemon Cave"
 msgstr "Démonbarlang"
 
-#: ../fheroes2/maps/mp2.cpp:369
 msgid "Faerie Ring"
 msgstr "Tündérgyűrű"
 
-#: ../fheroes2/maps/mp2.cpp:373 ../fheroes2/resource/maps_text.cpp:217
 msgid "Dragon City"
 msgstr "Sárkányváros"
 
-#: ../fheroes2/maps/mp2.cpp:375
-msgid "Light House"
+#, fuzzy
+msgid "Lighthouse"
 msgstr "Világítótorony"
 
-#: ../fheroes2/maps/mp2.cpp:377
 msgid "Water Wheel"
 msgstr "Vizikerék"
 
-#: ../fheroes2/maps/mp2.cpp:379
 msgid "Mines"
 msgstr "Bányák"
 
-#: ../fheroes2/maps/mp2.cpp:381
 msgid "Obelisk"
 msgstr "Obeliszk"
 
-#: ../fheroes2/maps/mp2.cpp:383
 msgid "Oasis"
 msgstr "Oázis"
 
-#: ../fheroes2/maps/mp2.cpp:385
 msgid "Sawmill"
 msgstr "Fűrészmalom"
 
-#: ../fheroes2/maps/mp2.cpp:387
 msgid "Oracle"
 msgstr "Orákulum"
 
-#: ../fheroes2/maps/mp2.cpp:389
 msgid "Desert Tent"
 msgstr "Sivatagi sátor"
 
-#: ../fheroes2/maps/mp2.cpp:393
 msgid "Wagon Camp"
 msgstr "Szekértábor"
 
-#: ../fheroes2/maps/mp2.cpp:395
 msgid "Windmill"
 msgstr "Szélmalom"
 
-#: ../fheroes2/maps/mp2.cpp:397
 msgid "Random Town"
 msgstr "Véletlenszerű város"
 
-#: ../fheroes2/maps/mp2.cpp:399
 msgid "Random Castle"
 msgstr "Véletlenszerű kastély"
 
-#: ../fheroes2/maps/mp2.cpp:401
 msgid "Watch Tower"
 msgstr "Toronyóra"
 
-#: ../fheroes2/maps/mp2.cpp:403
 msgid "Tree City"
 msgstr "Fa Város"
 
-#: ../fheroes2/maps/mp2.cpp:405
 msgid "Tree House"
 msgstr "Fa Ház"
 
-#: ../fheroes2/maps/mp2.cpp:407
 msgid "Ruins"
 msgstr "Romok"
 
-#: ../fheroes2/maps/mp2.cpp:409
 msgid "Fort"
 msgstr "Erőd"
 
-#: ../fheroes2/maps/mp2.cpp:411
-msgid "Trading Post"
-msgstr "Kereskedelmi Állomás"
-
-#: ../fheroes2/maps/mp2.cpp:413
 msgid "Abandoned Mine"
 msgstr "Elhagyott bánya"
 
-#: ../fheroes2/maps/mp2.cpp:415
 msgid "Tree of Knowledge"
 msgstr "A Tudás fája"
 
-#: ../fheroes2/maps/mp2.cpp:417
 msgid "Witch Doctor's Hut"
 msgstr "Vajákoskunyhó"
 
-#: ../fheroes2/maps/mp2.cpp:419
 msgid "Temple"
 msgstr "Templom"
 
-#: ../fheroes2/maps/mp2.cpp:421
 msgid "Hill Fort"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:423
 msgid "Halfling Hole"
 msgstr "Hobbitlak"
 
-#: ../fheroes2/maps/mp2.cpp:425
 msgid "Mercenary Camp"
 msgstr "Zsoldostábor"
 
-#: ../fheroes2/maps/mp2.cpp:429
 msgid "City of the Dead"
 msgstr "Holtak városa"
 
-#: ../fheroes2/maps/mp2.cpp:433
 msgid "Sphinx"
 msgstr "Szfinx"
 
-#: ../fheroes2/maps/mp2.cpp:435
 msgid "Troll Bridge"
 msgstr "Troll Híd"
 
-#: ../fheroes2/maps/mp2.cpp:437
 msgid "Witch Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:439
 msgid "Xanadu"
 msgstr "Xanadu"
 
-#: ../fheroes2/maps/mp2.cpp:443
 msgid "Magellan Maps"
 msgstr "Magellán Térképe"
 
-#: ../fheroes2/maps/mp2.cpp:445
 msgid "Derelict Ship"
 msgstr "Gazdátlan Hajó"
 
-#: ../fheroes2/maps/mp2.cpp:447
-msgid "Ship Wreck"
+#, fuzzy
+msgid "Shipwreck"
 msgstr "Hajóroncs"
 
-#: ../fheroes2/maps/mp2.cpp:449
 msgid "Observation Tower"
 msgstr "Kilátótorony"
 
-#: ../fheroes2/maps/mp2.cpp:451
-msgid "Freeman Foundry"
+#, fuzzy
+msgid "Freeman's Foundry"
 msgstr "Öntöde Műhely"
 
-#: ../fheroes2/maps/mp2.cpp:453
 msgid "Watering Hole"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:455
 msgid "Artesian Spring"
 msgstr "Artéziforrás"
 
-#: ../fheroes2/maps/mp2.cpp:457
 msgid "Gazebo"
 msgstr "Kilátó"
 
-#: ../fheroes2/maps/mp2.cpp:459
 msgid "Archer's House"
 msgstr "Íjász Ház"
 
-#: ../fheroes2/maps/mp2.cpp:461
 msgid "Peasant Hut"
 msgstr "Tanya"
 
-#: ../fheroes2/maps/mp2.cpp:463
 msgid "Dwarf Cottage"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:465
 msgid "Stone Liths"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:467
 msgid "Magic Well"
 msgstr "Varázskút"
 
-#: ../fheroes2/maps/mp2.cpp:468
 msgid "Heroes"
 msgstr "Hősök"
 
-#: ../fheroes2/maps/mp2.cpp:470 ../fheroes2/maps/mp2.cpp:488
-msgid "Shrub"
-msgstr "Bozót"
-
-#: ../fheroes2/maps/mp2.cpp:471
 msgid "Nothing Special"
 msgstr "Semmi érdekes"
 
-#: ../fheroes2/maps/mp2.cpp:472
 msgid "Tar Pit"
 msgstr "Kátrányosgödör"
 
-#: ../fheroes2/maps/mp2.cpp:473
-msgid "Coast"
-msgstr "Part"
-
-#: ../fheroes2/maps/mp2.cpp:474
 msgid "Mound"
 msgstr "Bucka"
 
-#: ../fheroes2/maps/mp2.cpp:475
 msgid "Dune"
 msgstr "Dűne"
 
-#: ../fheroes2/maps/mp2.cpp:476
 msgid "Stump"
 msgstr "Tuskó"
 
-#: ../fheroes2/maps/mp2.cpp:477
 msgid "Cactus"
 msgstr "Kaktusz"
 
-#: ../fheroes2/maps/mp2.cpp:478
 msgid "Trees"
 msgstr "Fák"
 
-#: ../fheroes2/maps/mp2.cpp:479
 msgid "Dead Tree"
 msgstr "Kiszáradt fa"
 
-#: ../fheroes2/maps/mp2.cpp:480
 msgid "Mountains"
 msgstr "Hegyek"
 
-#: ../fheroes2/maps/mp2.cpp:481
 msgid "Volcano"
 msgstr "Vulkán"
 
-#: ../fheroes2/maps/mp2.cpp:482
 msgid "Rock"
 msgstr "Kő"
 
-#: ../fheroes2/maps/mp2.cpp:483
 msgid "Flowers"
 msgstr "Virágok"
 
-#: ../fheroes2/maps/mp2.cpp:484
 msgid "Water Lake"
 msgstr "Tó"
 
-#: ../fheroes2/maps/mp2.cpp:485
 msgid "Mandrake"
 msgstr "Mandragóra"
 
-#: ../fheroes2/maps/mp2.cpp:486
 msgid "Crater"
 msgstr "Kráter"
 
-#: ../fheroes2/maps/mp2.cpp:487
 msgid "Lava Pool"
 msgstr "Lávató"
 
-#: ../fheroes2/maps/mp2.cpp:489
+msgid "Shrub"
+msgstr "Bozót"
+
 msgid "Buoy"
 msgstr "Bója"
 
-#: ../fheroes2/maps/mp2.cpp:491 ../fheroes2/monster/monster.cpp:116
 #, fuzzy
 msgid "Skeleton"
 msgstr "Csontváz"
 
-#: ../fheroes2/maps/mp2.cpp:492
 msgid "Treasure Chest"
 msgstr "Kincsesláda"
 
-#: ../fheroes2/maps/mp2.cpp:493
 msgid "Sea Chest"
 msgstr "Tengeri Kincs"
 
-#: ../fheroes2/maps/mp2.cpp:494
 msgid "Campfire"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:495
 msgid "Fountain"
 msgstr "Szökőkút"
 
-#: ../fheroes2/maps/mp2.cpp:496
 msgid "Genie Lamp"
 msgstr "Lámpás"
 
-#: ../fheroes2/maps/mp2.cpp:497
 msgid "Goblin Hut"
 msgstr "Goblinkunyhó"
 
-#: ../fheroes2/maps/mp2.cpp:499
 msgid "Monster"
 msgstr "Szörny"
 
-#: ../fheroes2/maps/mp2.cpp:500
 msgid "Resource"
 msgstr "Erőforrás"
 
-#: ../fheroes2/maps/mp2.cpp:501
 msgid "Whirlpool"
 msgstr "Örvény"
 
-#: ../fheroes2/maps/mp2.cpp:502
 msgid "Artifact"
 msgstr "Varázstárgy"
 
-#: ../fheroes2/maps/mp2.cpp:503
 msgid "Boat"
 msgstr "Csónak"
 
-#: ../fheroes2/maps/mp2.cpp:510
 msgid "Standing Stones"
 msgstr "Álló Kövek"
 
-#: ../fheroes2/maps/mp2.cpp:514
 msgid "Idol"
 msgstr "Bálvány"
 
-#: ../fheroes2/maps/mp2.cpp:515
 msgid "Shrine of the First Circle"
 msgstr "Az Első Kör szentélye"
 
-#: ../fheroes2/maps/mp2.cpp:516
 msgid "Shrine of the Second Circle"
 msgstr "A Második Kör szentélye"
 
-#: ../fheroes2/maps/mp2.cpp:517
 msgid "Shrine of the Third Circle"
 msgstr "A Harmadik Kör szentélye"
 
-#: ../fheroes2/maps/mp2.cpp:518
 msgid "Wagon"
 msgstr "Szekér"
 
-#: ../fheroes2/maps/mp2.cpp:519
 msgid "Lean To"
 msgstr "Fészer"
 
-#: ../fheroes2/maps/mp2.cpp:520
 msgid "Flotsam"
 msgstr "Uszadék"
 
-#: ../fheroes2/maps/mp2.cpp:521
 #, fuzzy
 msgid "Shipwreck Survivor"
 msgstr "Hajótörött"
 
-#: ../fheroes2/maps/mp2.cpp:522
 msgid "Bottle"
 msgstr "Üveg"
 
-#: ../fheroes2/maps/mp2.cpp:523
 msgid "Magic Garden"
 msgstr "Varázskert"
 
-#: ../fheroes2/maps/mp2.cpp:529
 msgid "Jail"
 msgstr "Börtön"
 
-#: ../fheroes2/maps/mp2.cpp:531
 msgid "Traveller's Tent"
 msgstr "Utazók Sátra"
 
-#: ../fheroes2/maps/mp2.cpp:532
 msgid "Barrier"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:535
 msgid "Fire Summoning Altar"
 msgstr "Tűzidéző oltár"
 
-#: ../fheroes2/maps/mp2.cpp:537
 msgid "Air Summoning Altar"
 msgstr "Légidéző oltár"
 
-#: ../fheroes2/maps/mp2.cpp:539
 msgid "Earth Summoning Altar"
 msgstr "Földidéző oltár"
 
-#: ../fheroes2/maps/mp2.cpp:541
 msgid "Water Summoning Altar"
 msgstr "Vízidéző oltár"
 
-#: ../fheroes2/maps/mp2.cpp:543
 msgid "Barrow Mounds"
 msgstr "Barrow Dombság"
 
-#: ../fheroes2/maps/mp2.cpp:545
-msgid "Arena"
-msgstr "Aréna"
-
-#: ../fheroes2/maps/mp2.cpp:547
 msgid "Stables"
 msgstr "Istálló"
 
-#: ../fheroes2/maps/mp2.cpp:549
 msgid "Alchemist's Tower"
 msgstr "Alkímista torony"
 
-#: ../fheroes2/maps/mp2.cpp:551
 msgid "Hut of the Magi"
 msgstr "Máguskunyhó"
 
-#: ../fheroes2/maps/mp2.cpp:553
 msgid "Eye of the Magi"
 msgstr "Mágus Szem"
 
-#: ../fheroes2/maps/mp2.cpp:555
 msgid "Mermaid"
 msgstr "Sellő"
 
-#: ../fheroes2/maps/mp2.cpp:557
 msgid "Sirens"
 msgstr "Szirének"
 
-#: ../fheroes2/maps/mp2.cpp:558
 msgid "Reefs"
 msgstr "Zátonyok"
 
-#: ../fheroes2/monster/monster.cpp:59
-#, fuzzy
-msgid "Peasant"
-msgstr "Jobbágy"
-
-#: ../fheroes2/monster/monster.cpp:59 ../fheroes2/resource/maps_text.cpp:501
-msgid "Peasants"
-msgstr "Paraszt"
-
-#: ../fheroes2/monster/monster.cpp:60
-#, fuzzy
-msgid "Archer"
-msgstr "Íjász"
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Archers"
-msgstr "Íjász"
-
-#: ../fheroes2/monster/monster.cpp:61
-#, fuzzy
-msgid "Ranger"
-msgstr "Erdőjáró"
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Rangers"
-msgstr "Erdész"
-
-#: ../fheroes2/monster/monster.cpp:62
-#, fuzzy
-msgid "Pikeman"
-msgstr "Lándzsás"
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Pikemen"
-msgstr "Lándzsások"
-
-#: ../fheroes2/monster/monster.cpp:63
-#, fuzzy
-msgid "Veteran Pikeman"
-msgstr "Veterán lándzsás"
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Veteran Pikemen"
-msgstr "Veterán lándzsások"
-
-#: ../fheroes2/monster/monster.cpp:64
-#, fuzzy
-msgid "Swordsman"
-msgstr "Kardforgató"
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Swordsmen"
-msgstr "Kardforgatók"
-
-#: ../fheroes2/monster/monster.cpp:65
-#, fuzzy
-msgid "Master Swordsman"
-msgstr "Kardforgató Mester"
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Master Swordsmen"
-msgstr "Kardforgató Mesterek"
-
-#: ../fheroes2/monster/monster.cpp:66
-#, fuzzy
-msgid "Cavalry"
-msgstr "Huszár"
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Cavalries"
-msgstr "Lovagok"
-
-#: ../fheroes2/monster/monster.cpp:67
-#, fuzzy
-msgid "Champion"
-msgstr "Bajnok"
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Champions"
-msgstr "Bajnok"
-
-#: ../fheroes2/monster/monster.cpp:68
-#, fuzzy
-msgid "Paladin"
-msgstr "Paplovag"
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Paladins"
-msgstr "Paplovag"
-
-#: ../fheroes2/monster/monster.cpp:69
-#, fuzzy
-msgid "Crusader"
-msgstr "Kereszteslovag"
-
-#: ../fheroes2/monster/monster.cpp:69
-msgid "Crusaders"
-msgstr "Kereszteslovag"
-
-#: ../fheroes2/monster/monster.cpp:72
-#, fuzzy
-msgid "Goblin"
-msgstr "Goblin"
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Goblins"
-msgstr "Goblin"
-
-#: ../fheroes2/monster/monster.cpp:73
-#, fuzzy
-msgid "Orc"
-msgstr "Ork"
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orcs"
-msgstr "Ork"
-
-#: ../fheroes2/monster/monster.cpp:74
-#, fuzzy
-msgid "Orc Chief"
-msgstr "Ork Vezér"
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chiefs"
-msgstr "Ork Vezér"
-
-#: ../fheroes2/monster/monster.cpp:75
-#, fuzzy
-msgid "Wolf"
-msgstr "Farkas"
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Wolves"
-msgstr "Farkas"
-
-#: ../fheroes2/monster/monster.cpp:76
-#, fuzzy
-msgid "Ogre"
-msgstr "Ogre"
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogres"
-msgstr "Ogárok"
-
-#: ../fheroes2/monster/monster.cpp:77
-#, fuzzy
-msgid "Ogre Lord"
-msgstr "Ogre Nagyúr"
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Ogre Lords"
-msgstr "Ogre Nagyúr"
-
-#: ../fheroes2/monster/monster.cpp:78
-#, fuzzy
-msgid "Troll"
-msgstr "Troll"
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "Trolls"
-msgstr "Troll"
-
-#: ../fheroes2/monster/monster.cpp:79
-#, fuzzy
-msgid "War Troll"
-msgstr "Harci Troll"
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "War Trolls"
-msgstr "Harci Troll"
-
-#: ../fheroes2/monster/monster.cpp:80
-#, fuzzy
-msgid "Cyclops"
-msgstr "Küklopsz"
-
-#: ../fheroes2/monster/monster.cpp:80
-msgid "Cyclopes"
-msgstr "Küklopszok"
-
-#: ../fheroes2/monster/monster.cpp:83
-#, fuzzy
-msgid "Sprite"
-msgstr "Tündér"
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Sprites"
-msgstr "Tündér"
-
-#: ../fheroes2/monster/monster.cpp:84
-#, fuzzy
-msgid "Dwarf"
-msgstr "Törpe"
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Dwarves"
-msgstr "Törpök"
-
-#: ../fheroes2/monster/monster.cpp:85
-#, fuzzy
-msgid "Battle Dwarf"
-msgstr "Harci Törpe"
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Battle Dwarves"
-msgstr "Törp harcos"
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elves"
-msgstr "Tündék"
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elves"
-msgstr "Tünde urak"
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druid"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druids"
-msgstr "Druida"
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druid"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druids"
-msgstr "Nemes Druida"
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorn"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorns"
-msgstr "Egyszarvú"
-
-#: ../fheroes2/monster/monster.cpp:91
-msgid "Phoenix"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:91
-#, fuzzy
-msgid "Phoenixes"
-msgstr "Dzsinn"
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaur"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaurs"
-msgstr "Kentaur"
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyle"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyles"
-msgstr "Vízköpő"
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffins"
-msgstr "Griff"
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaur"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaurs"
-msgstr "Minotauroszok"
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur King"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur Kings"
-msgstr "Minotaurusz Király"
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydra"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydras"
-msgstr "Hidra"
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragons"
-msgstr "Zöld Sárkány"
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragons"
-msgstr "Vörös Sárkány"
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragons"
-msgstr "Fekete Sárkány"
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halfling"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halflings"
-msgstr "Hobbit"
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boar"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boars"
-msgstr "Vaddisznó"
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golem"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golems"
-msgstr "Vasgólem"
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golem"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golems"
-msgstr "Acélgólem"
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Roc"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Rocs"
-msgstr "Sas"
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Mage"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Magi"
-msgstr "Mágus"
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmage"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmagi"
-msgstr "Főmágus"
-
-#: ../fheroes2/monster/monster.cpp:112
-msgid "Giant"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:112 ../fheroes2/resource/maps_text.cpp:293
-msgid "Giants"
-msgstr "Óriás"
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titan"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titans"
-msgstr "Titán"
-
-#: ../fheroes2/monster/monster.cpp:116
-msgid "Skeletons"
-msgstr "Csontváz"
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombies"
-msgstr "Zombi"
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombies"
-msgstr "Mutáns Zombi"
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummy"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummies"
-msgstr "Múmiák"
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummy"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummies"
-msgstr "Királyi múmiák"
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampire"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampires"
-msgstr "Vámpír"
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lord"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lords"
-msgstr "Vámpír Nagyúr"
-
-#: ../fheroes2/monster/monster.cpp:123
-#, fuzzy
-msgid "Lich"
-msgstr "Lich"
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Liches"
-msgstr "Lich-ek"
-
-#: ../fheroes2/monster/monster.cpp:124
-#, fuzzy
-msgid "Power Lich"
-msgstr "Őslich"
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Liches"
-msgstr "Őslich-ek"
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragons"
-msgstr "Csontsárkány"
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogue"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogues"
-msgstr "Rabló"
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomad"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomads"
-msgstr "Nomád"
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghost"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghosts"
-msgstr "Szellem"
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genies"
-msgstr "Dzsinn"
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusa"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusas"
-msgstr "Medúza"
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elementals"
-msgstr "Földelementál"
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elementals"
-msgstr "Légelementálok"
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elementals"
-msgstr "Tűzelementál"
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elementals"
-msgstr "Vízelementál"
-
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:694
-msgid "buy"
-msgstr "vásárol"
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:158
-msgid "Campaign Game"
-msgstr "Hadjárat"
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "Error"
-msgstr "Hiba"
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "This release is compiled without network support."
-msgstr ""
-
-#: ../fheroes2/resource/artifact.cpp:51
 msgid "Ultimate Book of Knowledge"
 msgstr "Tudás Szent Könyve"
 
-#: ../fheroes2/resource/artifact.cpp:51 ../fheroes2/resource/artifact.cpp:77
-#: ../fheroes2/resource/artifact.cpp:78 ../fheroes2/resource/artifact.cpp:79
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "The %{name} increases your knowledge by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:52
 msgid "Ultimate Sword of Dominion"
 msgstr "Hatalom Szent Kardja"
 
-#: ../fheroes2/resource/artifact.cpp:52 ../fheroes2/resource/artifact.cpp:68
-#: ../fheroes2/resource/artifact.cpp:71 ../fheroes2/resource/artifact.cpp:74
-#: ../fheroes2/resource/artifact.cpp:75 ../fheroes2/resource/artifact.cpp:149
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "The %{name} increases your attack skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:53
 msgid "Ultimate Cloak of Protection"
 msgstr "Védelem Szent Köpenye"
 
-#: ../fheroes2/resource/artifact.cpp:53 ../fheroes2/resource/artifact.cpp:70
-#: ../fheroes2/resource/artifact.cpp:73 ../fheroes2/resource/artifact.cpp:76
 msgid "The %{name} increases your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:54
 msgid "Ultimate Wand of Magic"
 msgstr "Varázslás Szet Pálcája"
 
-#: ../fheroes2/resource/artifact.cpp:54 ../fheroes2/resource/artifact.cpp:59
-#: ../fheroes2/resource/artifact.cpp:60 ../fheroes2/resource/artifact.cpp:61
-#: ../fheroes2/resource/artifact.cpp:62 ../fheroes2/resource/artifact.cpp:148
 msgid "The %{name} increases your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:55
 msgid "Ultimate Shield"
 msgstr "Szent Pajzs"
 
-#: ../fheroes2/resource/artifact.cpp:55 ../fheroes2/resource/artifact.cpp:128
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "The %{name} increases your attack and defense skills by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:56
 msgid "Ultimate Staff"
 msgstr "Szent Jogar"
 
-#: ../fheroes2/resource/artifact.cpp:56 ../fheroes2/resource/artifact.cpp:130
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "The %{name} increases your spell power and knowledge by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "Ultimate Crown"
 msgstr "Szent Korona"
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "The %{name} increases each of your basic skills by %{count} points."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "Golden Goose"
 msgstr "Arany Lúd"
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "The %{name} brings in an income of %{count} gold per turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:59
 msgid "Arcane Necklace of Magic"
 msgstr "Misztikus Varázslás Nyaklánca"
 
-#: ../fheroes2/resource/artifact.cpp:60
 msgid "Caster's Bracelet of Magic"
 msgstr "Idéző Varázslat Karkötője"
 
-#: ../fheroes2/resource/artifact.cpp:61
 msgid "Mage's Ring of Power"
 msgstr "Mágus Erejénak Gyűrűje"
 
-#: ../fheroes2/resource/artifact.cpp:62
 msgid "Witch's Broach of Magic"
 msgstr "Boszorkány Talizmánja"
 
-#: ../fheroes2/resource/artifact.cpp:63
 msgid "Medal of Valor"
 msgstr "Vitézség Medál"
 
-#: ../fheroes2/resource/artifact.cpp:63 ../fheroes2/resource/artifact.cpp:64
-#: ../fheroes2/resource/artifact.cpp:65 ../fheroes2/resource/artifact.cpp:66
 msgid "The %{name} increases your morale."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:64
 msgid "Medal of Courage"
 msgstr "Bátorság Medál"
 
-#: ../fheroes2/resource/artifact.cpp:65
 msgid "Medal of Honor"
 msgstr "Becsület Medál"
 
-#: ../fheroes2/resource/artifact.cpp:66
 msgid "Medal of Distinction"
 msgstr "Kiválóság Medál"
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "Fizbin of Misfortune"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "The %{name} greatly decreases your morale by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:68
 msgid "Thunder Mace of Dominion"
 msgstr "Hatalom Mennydörgő Buzogánya"
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "Armored Gauntlets of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "The %{name} increase your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:70
 msgid "Defender Helm of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:71
 msgid "Giant Flail of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "Ballista of Quickness"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "The %{name} lets your catapult fire twice per combat round."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:73
 msgid "Stealth Shield of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:74
 msgid "Dragon Sword of Dominion"
 msgstr "Sárkány Hatalom Kardja"
 
-#: ../fheroes2/resource/artifact.cpp:75
 msgid "Power Axe of Dominion"
 msgstr "Erő Hatalom Fejzséje"
 
-#: ../fheroes2/resource/artifact.cpp:76
 msgid "Divine Breastplate of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:77
 msgid "Minor Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:78
 msgid "Major Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:79
 msgid "Superior Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "Foremost Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:81
 msgid "Endless Sack of Gold"
 msgstr "Végtelen Aranyzsák"
 
-#: ../fheroes2/resource/artifact.cpp:81 ../fheroes2/resource/artifact.cpp:82
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "The %{name} provides you with %{count} gold per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:82
 msgid "Endless Bag of Gold"
 msgstr "Végtelen Aranytarisznya"
 
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "Endless Purse of Gold"
 msgstr "Végtelen Aranyerszény"
 
-#: ../fheroes2/resource/artifact.cpp:84
 msgid "Nomad Boots of Mobility"
 msgstr "Nomádcsizma"
 
-#: ../fheroes2/resource/artifact.cpp:84 ../fheroes2/resource/artifact.cpp:85
 msgid "The %{name} increase your movement on land."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:85
 msgid "Traveler's Boots of Mobility"
 msgstr "Utazócsizma"
 
-#: ../fheroes2/resource/artifact.cpp:86
 msgid "Lucky Rabbit's Foot"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:86 ../fheroes2/resource/artifact.cpp:87
-#: ../fheroes2/resource/artifact.cpp:88 ../fheroes2/resource/artifact.cpp:89
 msgid "The %{name} increases your luck in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:87
 msgid "Golden Horseshoe"
 msgstr "Arany Lópatkó"
 
-#: ../fheroes2/resource/artifact.cpp:88
 msgid "Gambler's Lucky Coin"
 msgstr "Szerencsepénz"
 
-#: ../fheroes2/resource/artifact.cpp:89
 msgid "Four-Leaf Clover"
 msgstr "Négylevelű Lóhere"
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "True Compass of Mobility"
 msgstr "Iránytű"
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "The %{name} increases your movement on land and sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "Sailor's Astrolabe of Mobility"
 msgstr "Tengerészeti Magasságmérő"
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "The %{name} increases your movement on sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "Evil Eye"
 msgstr "Gonosz Szem"
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "The %{name} reduces the casting cost of curse spells by half."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "Enchanted Hourglass"
 msgstr "Bűvös Homokóra"
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "The %{name} extends the duration of all your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "Gold Watch"
 msgstr "Arany Óra"
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "The %{name} doubles the effectiveness of your hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "Skullcap"
 msgstr "Csontsapka"
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "The %{name} halves the casting cost of all mind influencing spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "Ice Cloak"
 msgstr "Jégköpeny"
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "The %{name} halves all damage your troops take from cold spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "Fire Cloak"
 msgstr "Tűzköpeny"
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "The %{name} halves all damage your troops take from fire spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "Lightning Helm"
 msgstr "Villám Sisak"
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "The %{name} halves all damage your troops take from lightning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid "Evercold Icicle"
 msgstr "Örök Jégcsap"
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid ""
 "The %{name} causes your cold spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid "Everhot Lava Rock"
 msgstr "Örökké Izzó Láva"
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid ""
 "The %{name} causes your fire spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid "Lightning Rod"
 msgstr "Villámló Bot"
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid ""
 "The %{name} causes your lightning spells to do %{count} percent more damage "
 "to enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "Snake-Ring"
 msgstr "Kígyógyűrű"
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "The %{name} halves the casting cost of all your bless spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid "Ankh"
 msgstr "Ankh"
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid ""
 "The %{name} doubles the effectiveness of all your resurrect and animate "
 "spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "Book of Elements"
 msgstr "Elemek Könyve"
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "The %{name} doubles the effectiveness of all your summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "Elemental Ring"
 msgstr "Elemi Gyűrű"
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "The %{name} halves the casting cost of all summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "Holy Pendant"
 msgstr "Szent Nyakék"
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "The %{name} makes all your troops immune to curse spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "Pendant of Free Will"
 msgstr "Szabad Akarat Nyakék"
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "The %{name} makes all your troops immune to hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "Pendant of Life"
 msgstr "Élet Nyakék"
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "The %{name} makes all your troops immune to death spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "Serenity Pendant"
 msgstr "Tisztaság Nyakék"
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "The %{name} makes all your troops immune to berserk spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "Seeing-eye Pendant"
 msgstr "Látás Nyakék"
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "The %{name} makes all your troops immune to blindness spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "Kinetic Pendant"
 msgstr "Mozgás Nyakék"
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "The %{name} makes all your troops immune to paralyze spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "Pendant of Death"
 msgstr "Halál Nyakék"
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "The %{name} makes all your troops immune to holy spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "Wand of Negation"
 msgstr "Tagadás Pálca"
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "The %{name} protects your troops from the Dispel Magic spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid "Golden Bow"
 msgstr "Arany Íj"
 
-#: ../fheroes2/resource/artifact.cpp:114
+#, fuzzy
 msgid ""
 "The %{name} eliminates the %{count} percent penalty for your troops shooting "
-"past obstacles. (e.g. castle walls)"
-msgstr ""
+"past obstacles (e.g. castle walls)."
+msgstr "Az Arany Íj eltörli az 50%-os távolsági büntetést."
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid "Telescope"
 msgstr "Teleszkóp"
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid ""
 "The %{name} increases the amount of terrain your hero reveals when "
 "adventuring by %{count} extra square."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid "Statesman's Quill"
 msgstr "Politikus Pennája"
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid ""
 "The %{name} reduces the cost of surrender to %{count} percent of the total "
 "cost of troops you have in your army."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "Wizard's Hat"
 msgstr "Varázslósüveg"
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "The %{name} increases the duration of your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "Power Ring"
 msgstr "Hatalom gyűrűje"
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "The %{name} returns %{count} extra power points/turn to your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "Ammo Cart"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "The %{name} provides endless ammunition for all your troops that shoot."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "Tax Lien"
 msgstr "Adóteher"
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "The %{name} costs you %{count} gold pieces/turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "Hideous Mask"
 msgstr "Förtelmes Maszk"
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "The %{name} prevents all 'wandering' armies from joining your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "Endless Pouch of Sulfur"
 msgstr "Végtelen Kénzacskó"
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "The %{name} provides %{count} unit of sulfur per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "Endless Vial of Mercury"
 msgstr "Végtelen Higanyzacskó"
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "The %{name} provides %{count} unit of mercury per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "Endless Pouch of Gems"
 msgstr "Végtelen Drágakőzacskó"
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "The %{name} provides %{count} unit of gems per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "Endless Cord of Wood"
 msgstr "Végtelen Fahalom"
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "The %{name} provides %{count} unit of wood per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "Endless Cart of Ore"
 msgstr "Végtelen Érccsille"
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "The %{name} provides %{count} unit of ore per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "Endless Pouch of Crystal"
 msgstr "Végtelen Kristályzacskó"
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "The %{name} provides %{count} unit of crystal/day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:128
 msgid "Spiked Helm"
 msgstr "Tüskés Sisak"
 
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "Spiked Shield"
 msgstr "Tüskés Pajzs"
 
-#: ../fheroes2/resource/artifact.cpp:130
 msgid "White Pearl"
 msgstr "Fehér Gyöngy"
 
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "Black Pearl"
 msgstr "Fekete Gyöngy"
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "Magic Book"
 msgstr "Varázskönyv"
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "The %{name} enables you to cast spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "Spell Scroll"
 msgstr "Varázstekercs"
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid "Arm of the Martyr"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid ""
 "The %{name} increases your spell power by %{count} but adds the undead "
 "morale penalty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "Breastplate of Anduran"
 msgstr "Anduran Mellvértje"
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "The %{name} increases your defense by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid "Broach of Shielding"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid ""
 "The %{name} provides %{count} percent protection from Armageddon and "
 "Elemental Storm, but decreases spell power by 2."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid "Battle Garb of Anduran"
 msgstr "Anduran Harci Pajzsa"
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid ""
 "The %{name} combines the powers of the three Anduran artifacts.  It provides "
 "maximum luck and morale for your troops and gives you the Town Portal spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid "Crystal Ball"
 msgstr "Kristály Gömb"
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid ""
 "The %{name} lets you get more specific information about monsters, enemy "
 "heroes, and castles nearby the hero who holds it."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid "Heart of Fire"
 msgstr "Tűzszív"
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid ""
 "The %{name} provides %{count} percent protection from fire, but doubles the "
 "damage taken from cold."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid "Heart of Ice"
 msgstr "Jégszív"
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid ""
 "The %{name} provides %{count} percent protection from cold, but doubles the "
 "damage taken from fire."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:148
 msgid "Helmet of Anduran"
 msgstr "Anduran Sisakja"
 
-#: ../fheroes2/resource/artifact.cpp:149
 msgid "Holy Hammer"
 msgstr "Szent Kalapács"
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "Legendary Scepter"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "The %{name} adds %{count} points to all attributes."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "Masthead"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "The %{name} boosts your luck and morale by %{count} each in sea combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "Sphere of Negation"
 msgstr "Tagadás Gömbje"
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "The %{name} disables all spell casting, for both sides, in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "Staff of Wizardry"
 msgstr "Varázsjogar"
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "The %{name} boosts your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "Sword Breaker"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "The %{name} increases your defense by %{count} and attack by 1."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "Sword of Anduran"
 msgstr "Anduran Kardja"
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "Spade of Necromancy"
 msgstr "Nekromancia Ásó"
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "The %{name} gives you increased necromancy skill."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:638
 msgid ""
 "You find an elaborate aontainer which housesan old vellum scroll. The runes "
 "on the container are very old, and the artistry with whitch it was put "
@@ -7136,7 +5856,6 @@ msgid ""
 "magical power."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:639
 msgid ""
 "One of the less intelligent members of your party picks up an arm off of the "
 "ground. Despite its missing a body, it is still moving. Your troops find the "
@@ -7145,7 +5864,6 @@ msgid ""
 "making."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:640
 msgid ""
 "You come upon a sign. It reads: \"Here lies the body of Anduran. Bow and "
 "swear fealty, and you shall be rewarded.\" You decide to do as it says. As "
@@ -7153,21 +5871,18 @@ msgid ""
 "that you are suddenly wearing a gleaming, ornate breastplate."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:641
 msgid ""
 "A kindly Sorceress thinks that your army's defenses could use a magical "
 "boost. She offers to enchant the Broach that you wear on your cloak, and you "
 "accept."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:642
 msgid ""
 "Out of pity for a poor peasant, you purchase a chest of old junk they are "
 "hawking for too much gold. Later, as you search through it, you find it "
 "contains the 3 pieces of the legendary battle garb of Anduran!"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:643
 msgid ""
 "You come upon a caravan of gypsies who are feasting and fortifying their "
 "bodies with mead. They call you forward and say \"If you prove that you can "
@@ -7176,7 +5891,6 @@ msgid ""
 "Crystal Ball."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:644
 msgid ""
 "You enter a recently burned glade and come upon a Fire Elemental sitting "
 "atop a rock. It looks up, its flaming face contorted in a look of severe "
@@ -7184,7 +5898,6 @@ msgid ""
 "it, but it passes right through them and sears itself into your chest."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:645
 msgid ""
 "Suddenly, a biting coldness engulfs your body. You seize up, falling from "
 "your horse. The pain subsides, but you still feel as if your chest is "
@@ -7193,7 +5906,6 @@ msgid ""
 "woods and disappear."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:646
 msgid ""
 "You spy a gleaming object poking up out of the ground. You send a member of "
 "your party over to investigate. He comes back with a golden helmet in his "
@@ -7201,7 +5913,6 @@ msgid ""
 "only man who was known to wear solid gold armor."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:647
 msgid ""
 "You come upon a battle where a Paladin has been mortally wounded by a group "
 "of Zombies. He asks you to take his hammer and finish what he started.  As "
@@ -7209,7 +5920,6 @@ msgid ""
 "Zombies lie dead, the hammer dripping with blood. You strap it to your belt."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:648
 msgid ""
 "Upon cresting a small hill, you come upon a ridiculous looking sight. A "
 "Sprite is attempting to carry a Scepter that is almost as big as it is. "
@@ -7218,7 +5928,6 @@ msgid ""
 "flying anyway.\""
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:649
 msgid ""
 "An old seaman tells you a tale of an enchanted masthead that he used in his "
 "youth to rally his crew during times of trouble. He then hands you a faded "
@@ -7226,14 +5935,12 @@ msgid ""
 "underneath a nearby dock."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:650
 msgid ""
 "You stop to help a Peasant catch a runaway mare. To show his gratitude, he "
 "hands you a tiny sphere. As soon as you grasp it, you feel the magical "
 "energy drain from your limbs..."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:651
 msgid ""
 "While out scaring up game, your troops find a mysterious staff levitating "
 "about three feet off of the ground. They hand it to you, and you notice an "
@@ -7241,13 +5948,11 @@ msgid ""
 "words, and you'll win every fight.\""
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:652
 msgid ""
 "A former Captain of the Guard admires your quest and gives you the enchanted "
 "Sword Breaker that he relied on during his tour of duty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:653
 msgid ""
 "A Troll stops you and says: \"Pay me 5,000 gold, or the Sword of Anduran "
 "will slay you where you stand.\" You refuse. The troll grabs the sword "
@@ -7256,4449 +5961,72 @@ msgid ""
 "sharp objects."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:654
 msgid ""
 "A dirty shovel has been thrust into a dirt mound nearby. Upon investigation, "
 "you discover it to be the enchanted shovel of the Gravediggers, long thought "
 "lost by mortals."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:896
 msgid ""
-"Do you want to use your knowledge of magical secrets to transcribe the %"
-"{spell} Scroll into your spell book?\n"
-"The Scroll will be consumed.\n"
-" Spell point: %{sp}"
+"Do you want to use your knowledge of magical secrets to transcribe the "
+"%{spell} Scroll into your Magic Book?\n"
+"The Spell Scroll will be consumed.\n"
+" Cost in spell points: %{sp}"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:960
-msgid "Open book"
-msgstr ""
+#, fuzzy
+msgid "Transcribe Spell Scroll"
+msgstr "Varázstekercs"
 
-#: ../fheroes2/resource/artifact.cpp:965
-msgid "Transcribe scroll"
-msgstr ""
+#, fuzzy
+msgid "View Spells"
+msgstr "Minden mutatása"
 
-#: ../fheroes2/resource/artifact.cpp:975
-#: ../fheroes2/resource/artifact.cpp:1008
+#, fuzzy
+msgid "View %{name} Info"
+msgstr "%{name} adatai."
+
 #, fuzzy
 msgid "Move %{name}"
 msgstr "%{name} ide lép."
 
-#: ../fheroes2/resource/artifact.cpp:998
 #, fuzzy
 msgid "Cannot move artifact"
 msgstr " egy varázstárggyal"
 
-#: ../fheroes2/resource/maps_text.cpp:15
-msgid ""
-"425 bottles of beer on the wall, 425 bottles of beer! If one of those "
-"bottles should happen to fall, there'll be..."
+msgid "This item can't be traded."
 msgstr ""
 
-#: ../fheroes2/resource/maps_text.cpp:16
-msgid "A balanced scenario with lots of resources and land to explore."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:17
-msgid ""
-"A bandit army of gorgons jump you without warning.  they stone your entire "
-"army demand 500 gold before they will release your comrads.  Realizing that "
-"it is much cheeper to pay then rebuild your army you part with the gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:18
-msgid "Abandon All Hope!"
-msgstr "Miden Remény Elveszett!"
-
-#: ../fheroes2/resource/maps_text.cpp:19
-msgid "Abandon All Hope Ye That Enter Here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:20
-msgid "A bit of crystal!"
-msgstr "Egy kevés kristály!"
-
-#: ../fheroes2/resource/maps_text.cpp:21
-msgid "A bit of mercury!"
-msgstr "Egy kevés higany!"
-
-#: ../fheroes2/resource/maps_text.cpp:22
-msgid "A bit of sulfur!"
-msgstr "Egy kevés kén!"
-
-#: ../fheroes2/resource/maps_text.cpp:23
-msgid ""
-"Above you looms the ancient Ice Palace.  Dimly remembered myth speaks of a "
-"Prince who rejected the advances of the Winter Goddess, and thus he and his "
-"domain were cursed to remain shrouded in ice, hidden in a forgotten corner "
-"of the world.  It is said that he can only be rescued by a hero who is both "
-"clever and bold.  Are you that one?  Do you dare enter this frozen domain?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:24
-msgid "A cache of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:25
-msgid "A cache of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:26
-msgid "A cache of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:27
-msgid "A cache of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:28
-msgid "A cache of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:29
-msgid ""
-"A chance to end a bitter war has finally arrived as a new resource-laden "
-"land has been discovered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:30
-msgid "A chunk of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:31
-msgid "A chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:32
-msgid "A couple of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:33
-msgid "\"Act of Desperation\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:34
-msgid ""
-"A desert isle rich in resources rewards the quick.  Just be sure to watch "
-"your back!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:35
-msgid "A dolphin playfully jumps into the air."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:36
-msgid ""
-"A Dragon, A Cyclops, or an Undead. King of the Centaurs, His name is ....?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:37
-msgid "A flight of dragons circles overhead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:38
-msgid "A flock of seagulls circle overhead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:39
-msgid "A friendly dolphin splashes alongside the ship."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:40
-msgid ""
-"After a long search of the island, I have discovered that there is no way "
-"for me to escape without help.  I can not steal a ship from one of the "
-"coastal castles, and I dare not venture into the desert unless I wish to "
-"become Dragon food.  Should anyone find this, I beg of you, please send a "
-"ship and get me off this cursed island!  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:41
-msgid ""
-"After centuries of friendship, the Wizards have suddenly decided to stop "
-"sharing their Library with the rest of the world.  This can't be good!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:42
-msgid ""
-"After many years of peace, you discover that your sworn enemy from across "
-"the sea has chosen to invade your homeland by raising up the ocean floor to "
-"bridge the distance! You must not let them gain a foothold on this "
-"continent, in fact, your King has ordered you to establish a foothold on "
-"theirs!  To make matters worse, two of your OWN towns have thrown in their "
-"lots with the enemy..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:43
-msgid ""
-"After you return from a scouting trip, your Seneschal hurries to greet you.  "
-"\"My Lord, in your absence I signed an agreement in your name with a Master "
-"Merchant.  If we supply him with the resources he needs, through trading, he "
-"can return the resources to us in a week or so, plus some additional ones."
-"\"  The Seneschal eyes you anxiously.  You hesitate, then nod slowly, "
-"\"Good, we can use more resources>\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:44
-msgid "A ghostly pirate ship appears and sails on by."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:45
-msgid ""
-"A Gift from your King, and a note that reads \"Use these resources wisely, "
-"It's all we have left\"."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:46
-msgid ""
-"A gift of gold, m'lord, from the people of Enroth, to the people of Enroth.  "
-"Good luck, and may God save true King Roland!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:47
-msgid "A glint by a tree catches your eye..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:48
-msgid "A gold cache!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:49
-msgid "A gold chunk!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:50
-msgid "A gold nugget!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:51
-msgid ""
-"A great Black dragon stands before you. It speaks in a suprisingly soft "
-"voice, saying, \"The elves believe they have sent another hero to reclaim "
-"their prize. I believe they have sent me another meal.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:52
-msgid ""
-"A group of peasant farmers approaches you, \"We are in dire need of your "
-"assistance.  Our castle to the north has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:53
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance.  Our castle to the east has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:54
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance. Our castle to the east has been overrun and our Lord killed. "
-"Please help us regain our homes! There are still women and children there! "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:55
-msgid ""
-"A group of peasant farmers approach you, We are in dire need of your "
-"assistance.  Our castle to the northeast has been overrun and our Lord "
-"killed.  Please help us regain our homes!  There are still women and "
-"children there!  Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:56
-msgid "A handful of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:57
-msgid ""
-"Ah, you stumble across something buried in the sand.  As you dig it up you "
-"discover a small pile of gems and crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:58
-msgid ""
-"A Knight and Necromancer team up against the Barbarian and Sorceress. (Blue "
-"and Green vs Red and Yellow)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:60
-msgid ""
-"A large contingent of the king's guard approaches you.  \"Ahh, we have "
-"finally caught up to you.  The king requires tribute from all of his vassals "
-"and you have been negligent far too long.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:61
-msgid ""
-"A large map with lots of resources and treasure. Exploration and victory "
-"will require many heroes."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:62
-msgid "A legion of peasants stands between you and this unclaimed island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:63
-msgid "Algary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:64
-msgid "A little bit closer..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:65
-msgid "All mines are grouped by type. Trade is your only hope."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:66
-msgid "A lump of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:67
-msgid "A lump of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:68
-msgid "A lump of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:69
-msgid ""
-"A man appears from behind the sand dune. \"At last,\" he says, \"Someone has "
-"come to rescue me! I am forever grateful. Alas all I have to offer you in "
-"return are these souvenirs from my wrecked ship.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:70
-msgid ""
-"A man is laying on the ground, near death. He looks to you and speaks, "
-"\"Please help my companions! Please... they can't...cough...get away from..."
-"cough...the drag...\" With that, he dies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:71
-msgid ""
-"A merchant caravan arrives, bringing gold and supplies, however, no one can "
-"seem to remember where they came from.  You silently praise this anonymous "
-"benefactor and continue your duties."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:72
-msgid "a mirror"
-msgstr "egy tükör"
-
-#: ../fheroes2/resource/maps_text.cpp:73
-msgid "An albatross flies ahead of the ship for a while"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:74
-msgid "Anduran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:75
-msgid ""
-"An enemy from across the sea has seized half your towns.  Can you put aside "
-"your own feud with your brother to fight this common enemy?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:76
-msgid "\"Annexation\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:77
-msgid ""
-"An old elf is sitting on a rock in a glen, pounding on the shackles on his "
-"feet with a stone. You help him remove them and ask him his tale. \"I'm a "
-"deserter from Drakonia's army. She has enslaved all the elves to support her "
-"madness. She must be stopped.\" Then he slips into the woods without a "
-"sound, leaving behind just his cloak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:78
-msgid "Antioch"
-msgstr "Antioch"
-
-#: ../fheroes2/resource/maps_text.cpp:79
-msgid "A piece of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:80
-msgid "A pile of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:81
-msgid "A pile of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:82
-msgid "A pile of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:83
-msgid ""
-"A plague of undead is upon us. Who will unite the living against the dead?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:84
-msgid "\"Apocalypse\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:85
-msgid "A quantity of crystal!"
-msgstr "Egy kupac kristály!"
-
-#: ../fheroes2/resource/maps_text.cpp:86
-msgid "A quantity of mercury!"
-msgstr "Egy kupac higany!"
-
-#: ../fheroes2/resource/maps_text.cpp:87
-msgid "A quantity of sulfur!"
-msgstr "Egy kupac kén!"
-
-#: ../fheroes2/resource/maps_text.cpp:89
-msgid ""
-"Archibald has also sent an army to find the Crown, you must find it first or "
-"all is lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:90
-msgid "Archibald is hiding at the end of the river."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:91
-msgid ""
-"A resource rich valley keeps the Wizard and the Necromancer apart. Your "
-"opponent's army will arrive in 3 months so hurry."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:92
-msgid "Arm of the Crusader"
-msgstr "Kereszteslovag Karja"
-
-#: ../fheroes2/resource/maps_text.cpp:93
-msgid "Arm of the Cyclops"
-msgstr "Küklopsz Karja"
-
-#: ../fheroes2/resource/maps_text.cpp:94
-msgid "Arm of the Dragon"
-msgstr "Sárkány Karja"
-
-#: ../fheroes2/resource/maps_text.cpp:95
-msgid "Arm of the Phoenix"
-msgstr "Főnix Karja"
-
-#: ../fheroes2/resource/maps_text.cpp:96
-msgid "Arm of the Titan"
-msgstr "Titán Karja"
-
-#: ../fheroes2/resource/maps_text.cpp:97
-msgid "Arr' Here be pirates gold buried."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:98
-msgid "A shipment of wood has arrived from your kingdom!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:99
-msgid ""
-"A splash in the seaweed alerts you to a mermaid waving in a friendly manner. "
-"\"Oh, I thought you were Ahab.\" She is surprised, but quickly composes "
-"herself. \"Well, if you meet him, give him these treasures I have collected."
-"\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:100
-msgid "Assassins tried to kill our ally."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:101
-msgid "Astircaer"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:102
-msgid ""
-"A stranded Wizard with only a small force must conquer an entire continent "
-"of hostile forces."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:103
-msgid ""
-"A supply ship has arrived from the homeland!  You send word home that all is "
-"well."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:104
-msgid ""
-"As you approach the barrier, you see the old elf you helped free. This time, "
-"however, you see that he is wearing a cape of fine weave, and a wooden crown "
-"is on his head. He sees your forces, and says \"Take this sword, and with "
-"it, strike down Drakonia and help free my people.\" The old elf then strides "
-"regally into the woods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:105
-msgid ""
-"As you approach the gates of the Ice Palace, one of your troops points in "
-"terror.  You watch in awe as great slabs of ice separate from the castle "
-"walls with loud cracking reports and crash to the ground.  Soon the ice is "
-"gone and the sun begins to peak through the gloom.  The deathly silence that "
-"must have ruled these lands for centuries ends as birds begin to sing.  From "
-"inside you hear the sounds of life."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:106
-msgid ""
-"As you approach the tent, the leader of the nomads comes out to greet you. "
-"He says, \"It was prophecied many years ago that a great hero would come to "
-"greet us in our sacred valley, and we would prosper afterwords. Now it has "
-"come to pass, and we offer you these gifts as tokens of our thanks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:107
-msgid ""
-"As you approach,  you hear whispered mentions of \"the wild barbarian who "
-"passed this way months before\". One of the villagers approaches you and "
-"hands you an object, saying \"The wild one dropped this. You must be his "
-"kin. Therefore I give it to you. But beware! Many in the village will not be "
-"as friendly as I.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:108
-msgid ""
-"As you break your fast your sage rushes in, \"Good news, my lord!  I have "
-"translated the message.  Two great heroes were imprisoned many years ago.  "
-"They lie sleeping - still guarded by magic barriers and monsters.  My lord, "
-"they lie nearby- in between our ally and us.  If we could free them, they "
-"would surely aid us against our enemies!  The password to the first magic "
-"barrier can be learned at the Aqua Traveller's Tent.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:109
-msgid ""
-"As you enter the small clearing, you see a familiar figure talking to a "
-"group of halflings and soldiers. You stay awhile and listen to his speech. "
-"\"The time to throw off these chains of tyranny is now! We must strike at "
-"the heart of her empire, and destroy the evil that she has brought to our "
-"land.\" As the old elf finishes speaking, he gets up from his mossy seat and "
-"once again, blends into the woods with incredible grace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:110
-msgid ""
-"As you lay down to nap after a long battle, you notice a lucky four-leaf "
-"clover."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:111
-msgid ""
-"As you make  your way through the last of the golemn debris, a group of "
-"halflings runs towards you carrying fruit and flowers. \"Thank you so much!"
-"\" Their leader exclaims, \"We've been trapped in here for ever! Come by our "
-"homes, we'll pack up and go with you!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:112
-msgid ""
-"As you make your way to the shrine, some very thin and hollow-eyed men come "
-"out of the flower patch and stare at you.  Seeing that you want the gold, "
-"one of them says to you \"Hey, man, if you're, like, so lusty for earthly "
-"wealth, then, like, have this too.\" You graciously take what they have "
-"offered and back out of the clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:113
-msgid ""
-"As you prepare your lands to fight the onslaught from the South, a curious "
-"message appears on your table in the Great Hall of your Castle.  Written in "
-"some ancient language, none but your sage can make any sense of it.  She "
-"promises to have the words deciphered by tomorrow..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:114
-msgid "A three hour tour, a three hour tour..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:115
-msgid ""
-"A tiny gnome points to a chunk of crystal you otherwise would have "
-"overlooked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:116
-msgid "Atlantium"
-msgstr "Atlantium"
-
-#: ../fheroes2/resource/maps_text.cpp:117
-msgid ""
-"At last, the king is dead.  For years you have planned his demise, but now "
-"it is done, and there is no heir to take his place, though the Knights to "
-"the south believe that they are the rightful successors.  A wealth in wood "
-"(to the south) and ore (in the northern mountains) provides you with trade "
-"goods, and your isolation has allowed you to prepare your forces of darkness "
-"for this day.  Go, now, and fulfill your destiny!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:118
-msgid ""
-"At the base of the mountain you see something that glitters.   You discover "
-"an ancient pile of offerings to the gods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:119
-msgid "Avalon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:120
-msgid "Avone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:121
-msgid ""
-"A wild magic has allowed a bridge to form between two lands...  Your one "
-"hope is to capture castle \"Black Fang\"."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:122
-msgid "Barbarian's castle lies to the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:123
-msgid ""
-"Barbarians from the north threaten all civilization. Can you repel the "
-"hordes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:124
-msgid "\"Barbarian Wars\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:125
-msgid "Barrowton"
-msgstr "Barrowton"
-
-#: ../fheroes2/resource/maps_text.cpp:126
-msgid "Basenji"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:127
-msgid "Bayside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:128
-msgid "Baywatch"
-msgstr "Baywatch"
-
-#: ../fheroes2/resource/maps_text.cpp:129
-msgid ""
-"Because the Darkscale Valley is so barren, the Emperor will be sending wood "
-"to you every week. Use it wisely, for it is all you shall have."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:130
-msgid ""
-"Before questing for the orb of negation, you must first crush the local "
-"opposition. After the Sorceresses are removed from the earth, go east where "
-"legend says the orb lies.  You may expect a convoy of supplies in a week or "
-"so to aid your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:131
-msgid ""
-"Before you may pass, the spirit guardian of this valley demands tribute."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:132
-msgid "Being held...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:133
-msgid "Beltway"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:134
-msgid "\"Betrayal!\""
-msgstr "\"Árulás!'"
-
-#: ../fheroes2/resource/maps_text.cpp:135
-msgid "Beware -- Entering Hyrda Country"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:136
-msgid "Beware for whom the bell trolls."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:137
-msgid "Beware of Pirates!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:138
-msgid "Beware of thieves!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:139
-msgid "Beware of traps ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:140
-msgid "Beware of Warlocks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:141
-msgid "Beware the deadly swamps!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:142
-msgid "Beware the Domain of Dragons"
-msgstr "Óvakodj a sárkány birodalmától"
-
-#: ../fheroes2/resource/maps_text.cpp:143
-msgid "Beware the Dragon Leader"
-msgstr "Óvakodj a sárkányvezértől"
-
-#: ../fheroes2/resource/maps_text.cpp:144
-msgid "Beware the edge of the world!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:145
-msgid "Beware the moors and stick to the roads."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:146
-msgid "Beware the rocks"
-msgstr "Óvakodj a kövektől"
-
-#: ../fheroes2/resource/maps_text.cpp:147
-msgid "Beware the sirens!!!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:148
-msgid "Beware the sirens!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:149
-msgid "Beware the whiporwill..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:150
-msgid "Beware, the whirlpool may not take you into a friendly embrace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:151
-msgid "Beyond here be Dragons!"
-msgstr "Amott sárkányok vannak!"
-
-#: ../fheroes2/resource/maps_text.cpp:152
-msgid "Beyond the door, there be Dragons. BEWARE!"
-msgstr "Az átjárón túl sárkányok vannak. VIGYÁZZ!"
-
-#: ../fheroes2/resource/maps_text.cpp:153
-msgid "Big Oak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:154
-msgid "Blackburn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:155
-msgid "Blackfang"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:156
-msgid "Black Fang"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:157
-msgid "Black Oak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:158
-msgid "Blackridge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:159
-msgid "Blacksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:160
-msgid "Black Vein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:161
-msgid "Blackwind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:162
-msgid "Bloodreign"
-msgstr "Bloodreign"
-
-#: ../fheroes2/resource/maps_text.cpp:163
-msgid "Boats my be needed to access some parts of this peninsula."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:164
-msgid "Boats Sold Here            Inquire Within"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:165
-msgid "BoneVille"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:166
-msgid "Borderlands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:167
-msgid "Bridge out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:168
-msgid "Bridge Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:169
-msgid "Brindamoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:170
-msgid "Broken Alliance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:171
-msgid "Brownston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:172
-msgid "Buried Treasure!"
-msgstr "Eltemetett kincs!"
-
-#: ../fheroes2/resource/maps_text.cpp:173
-msgid "Burlock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:174
-msgid "Burton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:175
-msgid ""
-"Capture the necromancer's dreaded castle \"Death Gate\" and free the land "
-"from the undead plague."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:176
-msgid ""
-"Capture the town on the island off the southeast shore in order to construct "
-"a boat and travel back towards the mainland."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:177
-msgid "\"Carator Mines\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:178
-msgid "Cathcart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:180
-msgid "Chandler"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:181
-msgid "Chilton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:182
-msgid "Chronos"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:183
-msgid "Come and...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:184
-msgid ""
-"Compared to the rest of the villages in this land, this village seems grand, "
-"but in any other land it would seem poor. From here you can see the tall "
-"spires of the Warlock's tower of Dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:185
-msgid "Complete"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:186
-msgid "Condemned!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:187
-msgid ""
-"Congratulations! After navigating the treacherous coast, you have "
-"established trade between the north and south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:188
-msgid "Corackston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:189
-msgid "Corlagon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:190
-msgid "\"Country Lords\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:191
-msgid "Crossroads"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:192
-msgid "Crossroads North"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:193
-msgid "Crossroads South"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:195
-msgid "Danger a whirlpool destroyed my ship."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:196
-msgid "Danger, Dragons abound!"
-msgstr "Veszély, sárkányok!"
-
-#: ../fheroes2/resource/maps_text.cpp:197
-msgid "DANGER!  QUICKSAND!"
-msgstr "VESZÉLY! FUTÓHOMOK!"
-
-#: ../fheroes2/resource/maps_text.cpp:198
-msgid "Danger! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:199
-msgid "Danger - Turn Back Now"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:200
-msgid "Dark clouds loom overhead as you enter this valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:201
-msgid "Dead Pine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:202
-msgid ""
-"Dear Diary,                           I found a mermaid today.  She was "
-"floating in a patch of seaweed next to a rock.  A very friendly sort of "
-"creature too!  Gave me all sorts of lovely gems and jewelry!  She said to "
-"come back again sometime for more of the sea riches.  Wow. Ahab"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:203
-msgid "Deathgate"
-msgstr "Deathgate"
-
-#: ../fheroes2/resource/maps_text.cpp:204
-msgid "DeathGate"
-msgstr "DeathGate"
-
-#: ../fheroes2/resource/maps_text.cpp:205
-msgid "Decisions"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:206
-msgid "\"Defender\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:207
-msgid ""
-"Destroy the Barbarians who are attacking the southern border of your "
-"kingdom! Recover your towns and then invade the jungle kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:208
-msgid ""
-"Detour! Mountain pass to the East has been known to have avalanches! For "
-"your own safety, follow the road South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:209
-msgid "Detour! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:211
-msgid "DirtWater"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:212
-msgid "Dominion"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:213
-msgid "Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:214
-msgid "Do not remove coins from fountain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:215
-msgid "Dragadune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:216
-msgid "Dragonburg"
-msgstr "Dragonburg"
-
-#: ../fheroes2/resource/maps_text.cpp:218
-msgid "Dragon City lies beyond the Scorpion Hills."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:219
-msgid "Dragon Hill"
-msgstr "Dragon Hill"
-
-#: ../fheroes2/resource/maps_text.cpp:220
-msgid "\"Dragon Master\""
-msgstr "\"Sárkánymester\""
-
-#: ../fheroes2/resource/maps_text.cpp:221
-msgid "Dragon Rider"
-msgstr "Sárkánylovas"
-
-#: ../fheroes2/resource/maps_text.cpp:222
-msgid "Dragons Everywhere!"
-msgstr "Sárkányok vannak mindenütt!"
-
-#: ../fheroes2/resource/maps_text.cpp:223
-msgid "Dragon's Eye"
-msgstr "Sárkány Szem"
-
-#: ../fheroes2/resource/maps_text.cpp:224
-msgid "Dragontooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:225
-msgid "Dragon Town"
-msgstr "Sárkányváros"
-
-#: ../fheroes2/resource/maps_text.cpp:226
-msgid "Dragonville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:227
-msgid "Dragon Wars"
-msgstr "Sárkányharc"
-
-#: ../fheroes2/resource/maps_text.cpp:228
-msgid "Dragon Watch"
-msgstr "Sárkányóra"
-
-#: ../fheroes2/resource/maps_text.cpp:230
-msgid "Drakoran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:231
-msgid "Dwarfhall"
-msgstr "Dwarfhall"
-
-#: ../fheroes2/resource/maps_text.cpp:232
-msgid "Dwarfhall, Domain of the dwarf King."
-msgstr "Dwarfhall, a Törpekirály birtoka"
-
-#: ../fheroes2/resource/maps_text.cpp:233
-msgid "Dwarf Hall, domain of the dwarf King."
-msgstr "Dwarfhall, a Törpekirály birtoka"
-
-#: ../fheroes2/resource/maps_text.cpp:234
-msgid "Eatio"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:235
-msgid "Edgewood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:236
-msgid "Elk's Head"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:237
-msgid "Elowyn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:238
-msgid "Enroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:239
-msgid "Entering high in the desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:240
-msgid "Entering Praires of the Middlelands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:241
-msgid "Entering the desert high"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:242
-msgid "Entering the high desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:243
-msgid "Entering the higher desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:244
-msgid "Entering the Valley of Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:245
-msgid "Erliquin"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:246
-msgid "Evil Igor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:247
-msgid "Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:248
-msgid "Fantasy Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:249
-msgid "Farlien"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:250
-msgid ""
-"Federal express, when it absolutely positively has to be there turn one."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:251
-msgid "fedx comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:252
-msgid "Fedx for comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:253
-msgid "Fenton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:254
-msgid "Fetid Elm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:255
-msgid ""
-"Final message from Overlord. \"The royal executioners are on their way. My "
-"gold, the land or your head- it's your choice.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:256
-msgid "Find and defeat the Pirate Leader!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:257
-msgid "Find and destroy the evil beings who rule the wastelands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:258
-msgid "Find the center island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:259
-msgid ""
-"Find the Ultimate Artifact and be proclaimed King, or smash the opposition "
-"and take control."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:260
-msgid ""
-"Find Your Wayward Son who is rumored to be living in the desolate lands. Do "
-"it within 8 weeks or it will be of no help to your family."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:261
-msgid "Fire King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:262
-msgid "\"First Blood\""
-msgstr "\"Első vérig\""
-
-#: ../fheroes2/resource/maps_text.cpp:263
-msgid "Five heroes vie for control of a familiar land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:264
-msgid "Fool's Gold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:265
-msgid ""
-"For a total of 400,000 gold your opponents will become \"loyal\" subjects, "
-"otherwise... let them eat cake!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:266
-msgid ""
-"For centuries, the Wizards of the North have maintained a vast library for "
-"all the world to share.  Now, however, they have closed their doors, and "
-"issued declarations of war to each of the other rulers of the land.  To make "
-"matters worse, rather than ally with you to face the Wizards, each of the "
-"others have decided to go forth on their own in an effort to conquer this "
-"land for themselves!  Prepare your forces, commander, for you now stand "
-"alone."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:267
-msgid "\"Force of Arms\""
-msgstr "\"Karok Ereje\""
-
-#: ../fheroes2/resource/maps_text.cpp:268
-msgid ""
-"For decades you have studied, learned, and allowed yourself to be ruled by "
-"that pitiful excuse for a king, knowing that one day the time would come for "
-"you to sit on the throne.  That time is now, for the king is dead and "
-"without an heir.  You have the advantage of isolation from the rest of the "
-"kingdom, but beware the miles of coastline that could leave you vulnerable "
-"to attack.  Go, now, and wipe your enemies from this land!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:269
-msgid "Forder Oaks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:270
-msgid "Forestria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:271
-msgid "For Honor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:272
-msgid ""
-"For information about Ye Rich lands to the south, speak to Alponse at the "
-"Golden Goose Tavern. Excellent views, plentiful water."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:273
-msgid "Forsaken Lands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:274
-msgid "For sale."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:275
-msgid "Fortress Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:276
-msgid ""
-"For years, you have existed peacefully in the Forest of Dreams, knowing that "
-"your king was the kindest and strongest ruler the land had seen in "
-"centuries.  Now, however, his reign is at an end, and there is no heir to "
-"succeed him.  You realize that a power struggle is coming, and that you must "
-"brace yourself for war, and prevent those who would harm this land from "
-"coming into power!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:277
-msgid ""
-"For years, you've been able to keep your subjects \"appeased.\"  Now "
-"however, you discover not only that your entire kingdom has turned against "
-"you, but most of your outer towns have fallen to the different factions.  To "
-"make matters worse, all your gold suddenly seems to be missing from the "
-"treasury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:278
-msgid "Fountainhead"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:279
-msgid "Four kingdoms race to capture the island of Sharkania."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:280
-msgid "Four lakes have castles, three have treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:281
-msgid "Four players must work together to assault the Wizards' Stronghold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:282
-msgid "Frozenpeak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:283
-msgid "Full House"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:284
-msgid ""
-"Gain the aid of the elves. They will not allow trees to be chopped down, so "
-"we will send you wood every 2 weeks. You have 7 months!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:286
-msgid "Galveston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:287
-msgid "Garamok"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:288
-msgid "Gate"
-msgstr "Kapu"
-
-#: ../fheroes2/resource/maps_text.cpp:289
-msgid "Gate to the Isle of Knowledge"
-msgstr "Kapu a Tudás Szigetére"
-
-#: ../fheroes2/resource/maps_text.cpp:290
-msgid "Gate to The Isle of Knowledge"
-msgstr "Kapu a Tudás Szigetére"
-
-#: ../fheroes2/resource/maps_text.cpp:291
-msgid "Gaurdian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:292
-msgid "Gavonshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:294
-msgid "Glastonbury"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:295
-msgid "Go away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:296
-msgid "GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:297
-msgid "Goblin Island"
-msgstr "Goblinok Szigete"
-
-#: ../fheroes2/resource/maps_text.cpp:298
-msgid "Goblin King"
-msgstr "Goblinkirály"
-
-#: ../fheroes2/resource/maps_text.cpp:299
-msgid "Go Home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:300
-msgid "Go north to find the lost gold-mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:301
-msgid "Good vs. Evil"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:302
-msgid "Gorgomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:303
-msgid "\"Greater Glory\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:304
-msgid "Greed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:305
-msgid "Green bonus stuff"
-msgstr "bónusz anyag a zöldnek"
-
-#: ../fheroes2/resource/maps_text.cpp:306
-msgid "Green gets stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:307
-msgid "Greenroot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:308
-msgid "Green's Allowance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:309
-msgid "Green's Groceries"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:310
-msgid "green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:311
-msgid "Green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:312
-msgid "Greywind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:313
-msgid "Grim"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:314
-msgid "Grrr, Blazzer, Grrupt. Be gone with you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:315
-msgid "Guardian War"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:316
-msgid "Gungtooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:317
-msgid "Hail Unicorns!"
-msgstr "Üdvözlet az Egyszarvúnak!"
-
-#: ../fheroes2/resource/maps_text.cpp:318
-msgid "Hampshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:319
-msgid "Have fun storming the castle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:320
-msgid "Havenwood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:321
-msgid "Hawkins"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:322
-msgid "Help!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:323
-msgid "Help me...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:324
-msgid ""
-"Help peasant farmers regain their castle and land, else they'll take your "
-"crops."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:325
-msgid "Hero's Hall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:326
-msgid ""
-"High in the snowy crags, you meet an old witch who, in return for a trinket "
-"of yours, gives you a powerful magical object she used to use as a footstool "
-"before she was exiled into the mountains by her own townspeople."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:327
-msgid "Hillstone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:328
-msgid "Hilltop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:329
-msgid "Hilltown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:330
-msgid "Horizon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:331
-msgid "Hot Spot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:332
-msgid "Hungry dragons await.  Welcome, food."
-msgstr "Éhes sárkányok várakoznak. Isten hozott, betevő falatom!"
-
-#: ../fheroes2/resource/maps_text.cpp:333
-msgid "Hurry, no time to wait.  This way to the dock."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:334
-msgid "Hurry up! Few days are left before the enemy's army arrives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:335
-msgid "I am...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:336
-msgid ""
-"I am one of the few remaining survivors of the wrecked pleasure ship, "
-"Exhorbitance. I think we'll all be dead of hunger soon, for we are out of "
-"caviar. We ate the chef yesterday."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:337
-msgid "Ibn Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:338
-msgid "Ice Palace"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:339
-msgid "Ice Prince"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:340
-msgid "Icy lands ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:341
-msgid "I didn't do it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:342
-msgid ""
-"If three heroes could dig six holes in three days, how long would it take "
-"six heroes to dig twelve holes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:343
-msgid "If you free a hero, they may help..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:344
-msgid ""
-"If you value your lives, for God's sake, Don't go through this whirlpool!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:345
-msgid "Income for Yellow."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:346
-msgid "In the hole you find a chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:347
-msgid "In the stream you find an old compass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:348
-msgid "In this glen live some very naughty halflings. Stay Away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:349
-msgid ""
-"In two more weeks, if you have not located Joseph, your kingdom will surely "
-"lose its current battle with Harondale."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:350
-msgid "I see you, you see me."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:351
-msgid "Is it something I said? Go back and I will forget the whole thing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:352
-msgid "IslandHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:353
-msgid "Island of the Elves"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:354
-msgid "Island of the meek"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:355
-msgid "Island of Wolcott"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:356
-msgid "Isle Maze"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:357
-msgid "Isle of Knowledge"
-msgstr "Tudás Szigete"
-
-#: ../fheroes2/resource/maps_text.cpp:358
-msgid ""
-"It has become apparent that if all your enemies were eliminated, you would "
-"have all the time you need to find the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:359
-msgid ""
-"It is obvious that the mage that once was here had won many battles!  There, "
-"upon his hand, is a most powerful ring!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:360
-msgid ""
-"It is rumored that a bridge of land used to exist between the two "
-"continents, but that a wild magic caused it to sink into the sea, taking "
-"with it all those who used to inhabit it.  To try to raise this bridge is to "
-"invite a curse upon the world!  The spirits of the dead will haunt us all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:361
-msgid ""
-"It is said that King Zealot found the gods' artifact once and it let him "
-"rule for 100 years."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:362
-msgid ""
-"It looks like there used to be an ore mine here but all you see now is a "
-"hole in the ground and some minerals scattered around."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:363
-msgid ""
-"It's a battle for supremacy as the Blue and Green heroes take on Red and "
-"Orange in team competition!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:364
-msgid "It's windy at the top.  Defend, Divide, and Conquer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:365
-msgid "IvanHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:366
-msgid "Ivan lives in the desert."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:367
-msgid "Ivory Gates"
-msgstr "Ivory Gates"
-
-#: ../fheroes2/resource/maps_text.cpp:368
-msgid ""
-"I, Wilgatus, besiege you - do not fight me for I am all powerful and will "
-"destroy you if you persue me.  I will demonstrate my power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:369
-msgid "I Would Go That Way If I Were You."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:371
-msgid "Jarkonas VI"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:372
-msgid "Jolly Roger was here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:374
-msgid "Jungomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:375
-msgid "Just 30 days left!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:376
-msgid "Just ONE week left!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:378
-msgid "Kastor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:379
-msgid "Keep going south"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:380
-msgid "Keep Off The Grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:381
-msgid "Keep Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:382
-msgid "King John"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:383
-msgid "King of Death"
-msgstr "Halálkirály"
-
-#: ../fheroes2/resource/maps_text.cpp:384
-msgid "Knight's Trail."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:385
-msgid "Knight stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:386
-msgid "Lakeside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:387
-msgid "Land's Edge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:388
-msgid "Land teleporters will get you to your destination sooner."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:389
-msgid "Lankershire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:390
-msgid "Lavalor"
-msgstr "Lavalor"
-
-#: ../fheroes2/resource/maps_text.cpp:391
-msgid "Like, Stuff And Junk?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:392
-msgid ""
-"Living on the outskirts of the kingdom, you are considered an unwelcome "
-"outcast by the other leaders of the realm, though you always showed your "
-"support for the king.  Now, however, the king is dead, and many of those who "
-"spoke out againt him seek to seize his throne for themselves.  You have a "
-"vast desert at your back, rich with gems, and the advantage that many do not "
-"consider you a threat.  Go, now, and show them how wrong they are!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:393
-msgid "Lladner Dock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:394
-msgid ""
-"Log go up... Log go down... Log go up... Log go down...  OOoohhhhhhhh........"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:395
-msgid "Lombard"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:396
-msgid "Long live Roland the true King!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:397
-msgid "Long live Roland the true King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:398
-msgid "Look before you leap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:399
-msgid "Look out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:400
-msgid "Lord Alberon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:401
-msgid ""
-"Lord Alberon calls you into his war room. He says, \"I am glad you have "
-"chosen to remain loyal to me, but this war is a terrible one for my kingdom. "
-"Already, the sorceress' towns to the Northeast have become unsure about "
-"their loyalties, and will not pledge allegiance to either side. This is hard "
-"on our cities as most of the wood in the land comes from these towns. We "
-"will need to recover their sawmills and take their towns by force.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:402
-msgid "Lord Haart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:404
-msgid "Lord Kreager"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:405
-msgid ""
-"Lord, messages have begun pouring in from our spies in the other island "
-"courts.  They have learned of a new volcanic island with vast amounts of "
-"reasources.  Your Majesty, with these new reasources we could put an end to "
-"a century of war between the islands, and reunite them under your rightful "
-"rule."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:406
-msgid "Lost Continent"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:407
-msgid "Lost Gold- Mine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:408
-msgid "Lost Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:409
-msgid "Lost Relic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:410
-msgid "Maelstrom of Deceit"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:411
-msgid "Maelstrom of Misery"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:412
-msgid "Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:413
-msgid "Magic Three"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:414
-msgid ""
-"Many dust plumes rise from the floor of this small valley. You see various "
-"bands of nomads roaming about, and in the distant, the bright flames of "
-"their camp."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:415
-msgid ""
-"Many guardians stand between you and your enemies, but anybody can sneak "
-"through the back door!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:416
-msgid "Many that have gone through this door have never returned."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:417
-msgid ""
-"Many years ago, a couple of mages had a \"duel\" that forever changed the "
-"lake at the center of this continent.  Hearty adventurers might find "
-"interesting treasure there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:418
-msgid ""
-"Many years ago, a falling star crashed near here.  Only now the area is safe "
-"enough to explore.  Rumor has it a castle exist where the star fell."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:419
-msgid ""
-"Many years ago, your father, the King, died in a freak hunting accident.  "
-"Since then, you and your brother have jointly ruled his kingdom, but both of "
-"you have been seeking a way to seize the throne for yourself.  You got your "
-"wish.  Attackers from across the sea have captured more than half your towns "
-"and castles, effectively dividing the continent in two.  Now is the time to "
-"repel these invaders and do away with your brother once and for all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:420
-msgid "Marco"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:421
-msgid "Marsh Home"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:423
-msgid "Mayland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:424
-msgid "Meramec"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:425
-msgid "Message from Archibald. \" Do not dare to return without my Crown.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:426
-msgid ""
-"Message from Archibald. \" General, thank you for bringing me this lovely "
-"gift. I have decided to participate directly in the capture of my brother "
-"Roland. Since your military advice has taken us this far, I will follow your "
-"orders to the letter.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:427
-msgid "Message from Overlord. \"STILL WAITING FOR MY GOLD!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:428
-msgid "Message from Overlord. \"WHERE'S MY GOLD?\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:429
-msgid ""
-"Message from Roland. \"General, circumstances permit me to take a hand in "
-"the events of this final conflict. I have your spoils of war with me and I "
-"will follow your advice explicitly.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:430
-msgid ""
-"Message from Roland.  \"General, I have sent most of our troops and material "
-"ahead to the region of the final conflict with Archibald.  Unfortunately, "
-"Lord Corlagon has cut us off from the rest of our army.  I will be awaiting "
-"your victory in a castle across the west river.  I should be safe from "
-"attack.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:431
-msgid ""
-"Message from Roland. \" We cannot hope to defeat Archibald without the "
-"Crown, I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:432
-msgid "Middle Gate"
-msgstr "Middle Gate"
-
-#: ../fheroes2/resource/maps_text.cpp:433
-msgid "Middleton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:434
-msgid "Middletown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:435
-msgid "Might vs. Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:436
-msgid "Mineral Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:437
-msgid "Mirkosov"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:438
-msgid "mirror"
-msgstr "tükör"
-
-#: ../fheroes2/resource/maps_text.cpp:439
-msgid "Money For Red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:440
-msgid "MONEY, MONEY, MONEY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:441
-msgid "Morale becomes even lower as the endless cliffs move past."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:442
-msgid ""
-"More water than land, you'll still spend lots of time on foot as you search "
-"a literal horde of islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:443
-msgid "Mountain king"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:444
-msgid "Mountainview"
-msgstr "Mountainview"
-
-#: ../fheroes2/resource/maps_text.cpp:445
-msgid "Mr Ed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:446
-msgid "Mr. Yellow's Income"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:447
-msgid "Murray's resort Isle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:448
-msgid ""
-"Mutiny!  The crew has dumped off my precious cargo into the sea!  Thank "
-"goodness it floats - when I've rid of them, I'll come back to pick it up!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:449
-msgid ""
-"My leige, our scouts report three other lords are attacking from the south. "
-"They work in conjuction with each other to eliminate us! We must keep this "
-"castle and remove the threat of the enemy. We wish you luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:450
-msgid ""
-"My leige, we have established a foothold (which we cannot afford to lose) "
-"and all of our Heroes have joined us. The king has made us the offer to "
-"purchase this land for 200,000 gold or we may take it by force. The local "
-"lords have been fighting and each wants to be the one that defeats us. Now "
-"all the local armies have arrived on the beach, creating a state of complete "
-"Pandemonium!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:451
-msgid "My Treasure Is Buried Beneath Three Palm Trees"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:452
-msgid "\"Necromancers!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:453
-msgid "New Dawn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:454
-msgid "New Enemies"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:455
-msgid "New Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:456
-msgid "Nightshadow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:457
-msgid "No Description"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:458
-msgid "No Fishing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:459
-msgid "No gems, crystal, or mercury for red."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:460
-msgid ""
-"None of the four leaders like being stuck in a land that has only one season."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:461
-msgid "NO, Not That Way. This Way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:462
-msgid "No one has ever made it out of the deadly swamps alive!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:463
-msgid "Noraston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:464
-msgid "North Road"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:465
-msgid "North vs. South"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:466
-msgid "No stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:467
-msgid "No sulfer fer Yella."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:468
-msgid "No swimming."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:469
-msgid "Notice- Those who put messages in bottles will be tortured."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:470
-msgid "No Trespassing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:471
-msgid "No tresspath...  No tree...  No thresh...  GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:472
-msgid "Now leaving Swamplands of the Eternial"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:473
-msgid "Obsidian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:474
-msgid "Of the necromancers...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:475
-msgid "Ogrehild"
-msgstr "Ogrehild"
-
-#: ../fheroes2/resource/maps_text.cpp:476
-msgid "Olympus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:477
-msgid ""
-"One of the seers in your castle comes to you in the morning with urgent "
-"news. Your one time comrade, the wizard Joseph, and his armies have been "
-"imprisoned in a jail nearby. His power would surely aid you in your quest to "
-"reclaim the library, you think to yourself. Perhaps there is a way to rescue "
-"him..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:478
-msgid ""
-"One of your aides reports that the Castle of Farlien is located on the "
-"northeast spur of this island, and is a stronghold for the enemy. He urges "
-"you to take it out as soon as possible, and then move onto other islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:479
-msgid ""
-"One of your \"allies\" has joined Archibald.  You now face an opponent with "
-"three castles to your one.  Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:480
-msgid ""
-"One of your \"Allies\" has joined Roland. You are now facing three castles, "
-"all belonging to the enemy. Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:481
-msgid "One of your loyal goblins has brought you an armload of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:482
-msgid ""
-"One of your loyal subjects, a fairy tells you where to find a cache of "
-"mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:483
-msgid ""
-"One of your scouts reports a tiny cave nearby. Upon investigating, you "
-"discover a small cache of goods. In the dirt by them is etched 'Ivan'."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:484
-msgid ""
-"One of your troops stubs its paw on something buried here.  After a few "
-"hours of digging you unearth a cache of treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:485
-msgid "Only a month remains in which to find Joseph."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:486
-msgid "On quite days, Nubbie the sea monster can be seen!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:487
-msgid "Orange stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:488
-msgid "Orcville"
-msgstr "Orcville"
-
-#: ../fheroes2/resource/maps_text.cpp:489
-msgid "Ostoroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:490
-msgid "Other than the dragons, the elves don't have any enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:491
-msgid "Our ally was greatly weakened when his resources were plundered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:492
-msgid "\"Our Finest Hour\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:493
-msgid "Our reinforcements were lost in a storm, we salvaged all we could!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:494
-msgid ""
-"Our spies have discovered that the barbarian hordes are now receiving "
-"support from kraeger! You must hurry and find the third piece before your "
-"forces here are crushed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:495
-msgid "Overlord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:496
-msgid "Pandemonium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:497
-msgid "Paper can gain you what wood and sail cannot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:498
-msgid "Password found by Crystals to the South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:499
-msgid "Peacekeeper"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:500
-msgid "\"Peasants!\""
-msgstr "Parasztok!"
-
-#: ../fheroes2/resource/maps_text.cpp:502
-msgid "Peasantsville"
-msgstr "Peasantsville"
-
-#: ../fheroes2/resource/maps_text.cpp:503
-msgid "Perenor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:504
-msgid "Pet Cemetary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:505
-msgid "Pick one of four Knights in this large and inhospitable land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:506
-msgid "Pig's Eye"
-msgstr "Disznó Szem"
-
-#: ../fheroes2/resource/maps_text.cpp:507
-msgid "Pinehurst"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:508
-msgid "Pirate Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:509
-msgid "Pirate's Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:510
-msgid "Pirate Utopia"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:511
-msgid "Pirites strike and take the gold from you holds."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:512
-msgid "Pixie"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:513
-msgid ""
-"Play the Knight or Barbarian in an alliance in this classic duel against the "
-"four spell casters. (Blue and Green vs Red)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:514
-msgid "Please...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:515
-msgid ""
-"Plenty of resources and lots of ground to cover. Watch out for Orange and "
-"Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:516
-msgid "Portals"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:517
-msgid "Portsmith"
-msgstr "Portsmith"
-
-#: ../fheroes2/resource/maps_text.cpp:518
-msgid "POSION - DO NOT DRINK"
-msgstr "MÉREG - NE IGYAD MEG"
-
-#: ../fheroes2/resource/maps_text.cpp:519
-msgid "Powerful magic lies southwest of here in the Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:520
-msgid "Prisoner on...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:522
-msgid "Quick Silver"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:523
-msgid "Raste"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:524
-msgid "Realm of the Undead.  Fresh blood welcome."
-msgstr "Az Élőholtak birodalma. Isten hozott, friss vér!"
-
-#: ../fheroes2/resource/maps_text.cpp:525
-msgid "Red bonus"
-msgstr "bónusz a pirosnak"
-
-#: ../fheroes2/resource/maps_text.cpp:526
-msgid "Red player sympathizes with the undead cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:527
-msgid "Red's Connection"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:528
-msgid "Redshield"
-msgstr "Redshield"
-
-#: ../fheroes2/resource/maps_text.cpp:529
-msgid "Red's Lunch Money"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:530
-msgid "Red's Rubles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:531
-msgid "Red stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:532
-msgid ""
-"Regrettably, you have no castle with which to begin your assault. "
-"Fortunately, however, Kraeger's forces are weak here in the south, and you "
-"have bribed a rebel necromancer to aid you in the beginning of your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:533
-msgid "Reinforcements have arrived, Gold from the homelands!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:534
-msgid ""
-"Remains of a long since dead wizard have attracted an ancient artifact.  "
-"This artifact has now attached itself to you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:535
-msgid ""
-"Remember, you're searching for the Ultimate Artifact... don't get distracted!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:536
-msgid ""
-"Rendall Koski was here. 1997.  Northampton, Massachusetts There is a "
-"powerful artifact in the southeastern corner of the world.  Go for it, "
-"explorer!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:537
-msgid ""
-"Reports from your spies tell of enemies on the march.  As you rush to the "
-"castle courtyard to prepare your armies, you are intercepted by your "
-"Chaplain.  \"My Lord, I have received word that we should send what Heroes "
-"we can to the Isle of Knowledge.   The Scholars there have agreed to teach "
-"them so they will be strong for the battles ahead of us.\"  You thank the "
-"Chaplain for the information and head thoughtfully into the courtyard."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:538
-msgid ""
-"Rescue your crazy Uncle Ivan. Find him within 4 months or it will be no help "
-"to your kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:539
-msgid "Restricted Area, Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:540
-msgid "Rest stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:541
-msgid "Retake the Castle of Ivory Gates."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:542
-msgid "Revolution"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:543
-msgid "Right thinking - he who takes the riskes deserves the rewards."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:544
-msgid "River Crossing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:545
-msgid "Road Ends"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:546
-msgid "Road to Isle of Knowledge"
-msgstr "Út a Tudás Szigetére"
-
-#: ../fheroes2/resource/maps_text.cpp:547
-msgid "Road to the Isle of Knowledge"
-msgstr "Út a Tudás Szigetére"
-
-#: ../fheroes2/resource/maps_text.cpp:548
-msgid "Robbers have looted your treasury and you have lost valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:549
-msgid "Robbers have looted your treasury, stealing valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:550
-msgid "Roc Haven"
-msgstr "Sasmenedék"
-
-#: ../fheroes2/resource/maps_text.cpp:551
-msgid "Rogar"
-msgstr "Rogar"
-
-#: ../fheroes2/resource/maps_text.cpp:553
-msgid "Roscomon"
-msgstr "Roscomon"
-
-#: ../fheroes2/resource/maps_text.cpp:554
-msgid "Rotten Birch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:555
-msgid ""
-"Rumors abound and your faithful hero Sandro is now highly regarded by the "
-"masses. Should Sandro desert you, all will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:556
-msgid "Sandcaster"
-msgstr "Sandcaster"
-
-#: ../fheroes2/resource/maps_text.cpp:558
-msgid "Sands of Time"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:559
-msgid "Sansobar"
-msgstr "Sansobar"
-
-#: ../fheroes2/resource/maps_text.cpp:560
-msgid "\"Save the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:561
-msgid "Scabsdale"
-msgstr "Scabsdale"
-
-#: ../fheroes2/resource/maps_text.cpp:562
-msgid "Scorched Earth"
-msgstr "Felperzselt Föld"
-
-#: ../fheroes2/resource/maps_text.cpp:563
-msgid ""
-"Scouts have reported a town to the North.  They have also heard some "
-"disturbing news.  Their seems to be a war raging in this area."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:564
-msgid ""
-"Scouts report the enemy's stronghold lies to the Southwest. Our swift "
-"arrival has caught them by surprise. If you move quickly their resistance "
-"will be minimal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:565
-msgid ""
-"Scouts report the notorious necromancer \"Wyrm\" has been sighted to the "
-"northeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:566
-msgid "Scummy"
-msgstr "Scummy"
-
-#: ../fheroes2/resource/maps_text.cpp:567
-msgid ""
-"Searching in the dust of this abandoned campsite, you find a magic scroll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:568
-msgid "Seasons Change"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:569
-msgid "Secret Mountain Pass"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:570
-msgid ""
-"Seek out the Ultimate Artifact to be victorious in this strangely shaped "
-"land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:571
-msgid ""
-"Seek the great library, for only with the guidance of the musty tomes therin "
-"will you find the means to reveal and bind the fount to your will."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:572
-msgid "Seven Lakes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:573
-msgid "Sharkania"
-msgstr "Sharkania"
-
-#: ../fheroes2/resource/maps_text.cpp:574
-msgid "Sheltemburg"
-msgstr "Sheltemburg"
-
-#: ../fheroes2/resource/maps_text.cpp:575
-msgid "Sherman"
-msgstr "Sherman"
-
-#: ../fheroes2/resource/maps_text.cpp:576
-msgid "Shipwrecked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:577
-msgid ""
-"Should this message ever reach home, please know that this has become a "
-"hostile place since the King's death.  No less than six factions are at war "
-"with each other, each seeking to be the King's successor.  Beware especially "
-"of the Barbarians and the Necromancers who control the north, their regions "
-"are easily defended and they have a wealth of gold and gems.  Do not venture "
-"to this land without a sizeable force.  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:578
-msgid "Sirein"
-msgstr "Sirein"
-
-#: ../fheroes2/resource/maps_text.cpp:579
-msgid ""
-"Six factions have established a foothold on a huge, unexplored continent.  "
-"Can you eliminate the other five?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:580
-msgid ""
-"Six heroes with large armies prepare to slug it out for total domination!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:581
-msgid "Skirmish"
-msgstr "Skirmish"
-
-#: ../fheroes2/resource/maps_text.cpp:582
-msgid "\"Slay the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:583
-msgid "Slippery when wet."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:584
-msgid "Slugfest"
-msgstr "Slugfest"
-
-#: ../fheroes2/resource/maps_text.cpp:585
-msgid ""
-"Snagged on a thorny bush, you discover a scrap of cloth. The design on it "
-"looks like the coat of arms of Ivan's house!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:586
-msgid "Snowdrop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:587
-msgid "Somebody has stuffed a pile of gems in the ditch!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:588
-msgid "Some crystal!"
-msgstr "Néhány kristály!"
-
-#: ../fheroes2/resource/maps_text.cpp:589
-msgid "Some gems!"
-msgstr "Néhány drágakő!"
-
-#: ../fheroes2/resource/maps_text.cpp:590
-msgid ""
-"Someone has stolen 100 wood and 77 ore from you. Ah, that's nothing. Let's "
-"keep going."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:591
-msgid ""
-"Someone has stolen gold and resources from  the palace treasury!  You "
-"suspect your enemies, but you can't know for certain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:592
-msgid "Someone is playing a pan flute around here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:593
-msgid ""
-"Someone notices a piece of parchment lying behind a clump of grass. You pick "
-"it up. It looks to be a page from a journal, and it reads, \"...made it past "
-"the first guardians. Hopefully will reach the ancient desert city soon. Only "
-"hope my forces are strong enough to survive...\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:594
-msgid "Some ore!"
-msgstr "Néhány érc!"
-
-#: ../fheroes2/resource/maps_text.cpp:595
-msgid "Some sulfur!"
-msgstr "Néhány kén!"
-
-#: ../fheroes2/resource/maps_text.cpp:596
-msgid ""
-"Some unlucky adventurers have been captured and imprisoned in these lands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:597
-msgid "Sorceress Forest.  Show respect for nature!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:598
-msgid "Sorpigal"
-msgstr "Sorpigal"
-
-#: ../fheroes2/resource/maps_text.cpp:599
-msgid "South Mill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:600
-msgid "So you think you're smart?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:601
-msgid "Spector"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:602
-msgid "Spell Casters"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:603
-msgid ""
-"Spies report Roland has sent a hero to search for the Crown. If he finds it "
-"first, all is lost!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:604
-msgid "Spirit City"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:605
-msgid "Spy Tower - see what your competition is doing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:606
-msgid "Stairs"
-msgstr "Lépcsők"
-
-#: ../fheroes2/resource/maps_text.cpp:607
-msgid ""
-"Start with five castles!  How could you lose!?  Oh yeah, everyone else "
-"starts with five, too."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:608
-msgid "Stick to the road!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:609
-msgid "Stromgild"
-msgstr "Stromgild"
-
-#: ../fheroes2/resource/maps_text.cpp:610
-msgid "Stromhild"
-msgstr "Stromhild"
-
-#: ../fheroes2/resource/maps_text.cpp:611
-msgid "Stronghold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:612
-msgid "Stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:613
-msgid "Stuff for Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:614
-msgid "Stuff For Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:615
-msgid "Subbaculcha"
-msgstr "Subbaculcha"
-
-#: ../fheroes2/resource/maps_text.cpp:616
-msgid "Sundune"
-msgstr "Sundune"
-
-#: ../fheroes2/resource/maps_text.cpp:617
-msgid "Surf and Turf"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:618
-msgid "Swimming near the kelp is a pod of dolphins."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:619
-msgid "Tacma"
-msgstr "Tacma"
-
-#: ../fheroes2/resource/maps_text.cpp:620
-msgid "Tchudes"
-msgstr "Tchudes"
-
-#: ../fheroes2/resource/maps_text.cpp:621
-msgid "Teleporters"
-msgstr "Teleportok"
-
-#: ../fheroes2/resource/maps_text.cpp:622
-msgid "Terra Firma"
-msgstr "Terra Firma"
-
-#: ../fheroes2/resource/maps_text.cpp:623
-msgid "Terrain Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:624
-msgid ""
-"The alliance has crumbled and all are at war. Lots of resources but little "
-"time to prepare."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:625
-msgid ""
-"The ancient King Zealot had the artifact of the gods and then hid it in his "
-"old age so that it could not be used by others."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:626
-msgid "The Back Door"
-msgstr "Hátsó ajtó"
-
-#: ../fheroes2/resource/maps_text.cpp:627
-msgid ""
-"The Barbarian's lands are being invaded. Are you strong enough to resist the "
-"invasion?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:628
-msgid ""
-"The castle of Drakonran in the east has been taken by the barbarians! Two "
-"other towns to the west have also been taken, but the barbarian armies were "
-"fairly decimated in the process."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:629
-msgid "The center island is rumored to harbor great spells."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:630
-msgid "The Citadel"
-msgstr "Citadella"
-
-#: ../fheroes2/resource/maps_text.cpp:631
-msgid "The cities of the plains."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:632
-msgid "The Clearing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:633
-msgid ""
-"The convoy has at long last arrived. Regretably, it has been beset by "
-"bandits on its journey here, and has far less supplies than we had hoped. "
-"Make your way south, for our spies have found rich mines there."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:634
-msgid ""
-"The convoy should have been here by now! Let us hope that it is safe and "
-"still on its way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:635
-msgid ""
-"The country lords have allied and pooled their resources into one command. "
-"Not only have they massed their forces in the north, but they have sent a "
-"knight to the west to steal your supplies. Scouts report a castle to the "
-"east that would be ideal as a base of operations."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:636
-msgid "The crew are unworthy!  I am not going down with the ship! -The Captain"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:637
-msgid "\"The Crown\""
-msgstr "\"Korona\""
-
-#: ../fheroes2/resource/maps_text.cpp:638
-msgid ""
-"The day you have feared has finally arrived.  The king, who you have "
-"faithfully served, has died, leaving no heir to his throne.  As his captain, "
-"you feel that this job should now be yours, but several factions even now "
-"are preparing for conquest.  You are at the center of the trade routes, "
-"having the sea to the south and the great forest to the north.  Go, now, "
-"Commander, and claim what is rightfully yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:639
-msgid ""
-"The diplomats who were sent here ahead of you report that the elves will "
-"only cooperate with you if you will recover the golden bow for them. It was "
-"stolen by their enemies, the Dragons and hidden behind magic barriers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:640
-msgid "The Eastern Town."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:641
-msgid "The edge of the world is your edge.  But prepare to be prepared."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:642
-msgid "The Emerald Isle"
-msgstr "Emerald-sziget"
-
-#: ../fheroes2/resource/maps_text.cpp:643
-msgid "The Enchanted Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:644
-msgid "The End of the World is Nigh!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:645
-msgid "The End of the World is Nigh"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:646
-msgid ""
-"The Epic battle against Your Rival! Eliminate everything! Total Warfare! "
-"Don't Lose your first hero!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:647
-msgid ""
-"The Fire King is an ally to the dragons, and will help a friend of theirs."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:648
-msgid "The First One To Take Astircaer Wins!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:649
-msgid ""
-"The first piece of the artifact now lies in the hands of the Unholy Order of "
-"Warlocks. You must annihilate them, and their allies to the north. They will "
-"surely give us what we seek in exchange for their feeble lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:650
-msgid ""
-"The Fortune of Infamous Uae was buried on one of these islands. She died "
-"without ever revealing it.  Find it before the other cutthroats."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:651
-msgid "The four factions race to capture a mystical castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:652
-msgid ""
-"The four spell casters face off with substantial starting armies. Can the "
-"crusaders keep the peace?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:653
-msgid "\"The Gauntlet\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:654
-msgid ""
-"The Gods have given you 6 months to prove yourself. Good or Evil - who shall "
-"prevail? (Blue,Green and Red vs Yellow, Orange and Purple)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:655
-msgid ""
-"The gods have granted this world a great artifact, to find it means victory."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:656
-msgid "The Gods themselves will aid us in this War."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:657
-msgid "The Gold Traveller's Tent is near the Aqua Taveller's Tent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:658
-msgid "The guardians of Dragon Isle reside in the jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:659
-msgid "The Ice Prince stands frozen in some forgotten corner of the world."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:660
-msgid "The island...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:661
-msgid "The Island of Lost Reason"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:662
-msgid "The islands have much wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:663
-msgid "The Isle of Armoria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:664
-msgid "The key to success is rubbing enough lamps."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:665
-msgid ""
-"The King has declared you his hier apparent and champion. You must seek out "
-"and destroy your common enemy, Wilgatus and his Castle, Mirkosov, the source "
-"of his power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:666
-msgid ""
-"The King is dead, his kingdom has been shattered, and six leaders seek to "
-"seize power for themselves."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:667
-msgid "The Kingly Wastes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:668
-msgid "The Kings Road."
-msgstr "Királyok útja"
-
-#: ../fheroes2/resource/maps_text.cpp:669
-msgid ""
-"The King will sell you this land for 200,000 gold or you can take it by "
-"force. The choice is yours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:670
-msgid "The land of Heroes II."
-msgstr "Heroes II. ország"
-
-#: ../fheroes2/resource/maps_text.cpp:671
-msgid "The Lost Castle of the Ancients"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:672
-msgid ""
-"The mage wars have caused a great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:673
-msgid ""
-"The mage wars have caused great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:674
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trade.  "
-"Plus a little gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:675
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trading.  "
-"Plus a little more gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:676
-msgid ""
-"The Master Merchant arrives at your Castle.  He tells you tall tales of "
-"travel, full of outrageous lies.  He also gives you, your share of the "
-"profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:677
-msgid ""
-"The Master Merchant arrives back at your Castle.  He tells you tall tales of "
-"faraway places full of outrageous lies.  He also gives you, your share of "
-"the profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:678
-msgid "The Medusas have the password and they can be found just to the west."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:679
-msgid "The more there is the less you see."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:680
-msgid "The North Road to Roland's castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:681
-msgid ""
-"The note in this bottle has become mostly indecipherable. All you can make "
-"out are references to deadly pirates, and hidden gold mines."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:682
-msgid "The Other Side"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:683
-msgid ""
-"The Overlord has given you 4 months to conquer this land or deliver to him "
-"the sum of 150,000 gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:684
-msgid ""
-"The people on the Isle of Knowledge are taking up a collection to aid us."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:685
-msgid "The Proving Grounds"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:686
-msgid "The Queen's Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:687
-msgid "The Realm of Air is barred, but you may appeal here for help."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:688
-msgid ""
-"There are remnants of a mighty battle fought here, not too long ago. It "
-"looks as if whoever came this way may have made this their final stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:689
-msgid ""
-"There are three enemy castles to the north. Capture them in the name of "
-"Roland the true king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:690
-msgid ""
-"The Red Tide of War rolls North.  Stopping the flood seems hopeless.  Yet, "
-"Honor demands you and your ally die trying."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:691
-msgid "There is hidden treasure north of the Green Lord's Ore Mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:692
-msgid "There is hidden treasure south of the Blue Lord's Sawmill."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:693
-msgid "There's a warm wind blowing from the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:694
-msgid "There's a Wizard living in the north who is behind this peasant revolt."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:695
-msgid "The Retreat of the Alchemist Doctor Yu"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:696
-msgid ""
-"There used to be a mine here, but it has long since run out of ore.  You are "
-"only able to scavenge 5 units of ore from the old site."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:697
-msgid "There was a shipreck in the far east waters recently."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:698
-msgid "The River Styx"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:699
-msgid "The roars of several dragons echo from the towers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:700
-msgid "The Rock Store."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:701
-msgid "The Royal Gardens."
-msgstr "Királyi Kertek"
-
-#: ../fheroes2/resource/maps_text.cpp:702
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:703
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you defend against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:704
-msgid "These doors are a risk the likes of which you do not know."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:705
-msgid "These lands are beholden to Lord Kraeger."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:706
-msgid ""
-"These lands are desolate and for the most part devoid of resources. Not even "
-"the bravest heroes dare to venture into them, and plants are rare and "
-"precious here. Who knows what else awaits?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:707
-msgid ""
-"The Southern Witch is biding her time.  She will strike when your armies are "
-"weak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:708
-msgid "the stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:709
-msgid "The Table in the Great Hall of the Castle is Haunted."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:710
-msgid ""
-"The third piece of the artifact is somewhere to the north, that much we "
-"know. We are still unsure of its exact location, but our spies are out "
-"gathering information. The forces in this area are too strong to be "
-"completely subjugated, so take what you can and hold on to it tightly."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:711
-msgid ""
-"The troops have sworn their allegiance, but should lose a battle they will "
-"lose faith and our cause will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:712
-msgid "The Valley of Aruk."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:713
-msgid ""
-"The Valley of Magic holds many surprises.  You discover an old pair of boots "
-"sticking out of the sand."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:714
-msgid "The Valley of Tresures"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:715
-msgid "The Wasteland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:716
-msgid "The way of magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:717
-msgid "The way of might"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:718
-msgid "The way of numbers"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:719
-msgid "The western town."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:720
-msgid "The winds howl in mourning around the shipwreck."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:721
-msgid "The wizard has an island in the southeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:722
-msgid ""
-"The Wizards who have captured the Necromancers' town have wasted no time in "
-"building defenses designed to stop you, and their last castle has just been "
-"completed. Fortunately only a Captain of the Guard and a small garrison are "
-"currently present.  If you hurry, you should be able to capture the castle "
-"before they have a chance to reinforce it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:723
-msgid "The wood has arrived."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:724
-msgid "The writing on this sign is too faded to read."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:725
-msgid "The Yellow Lord has the Ultimate Artifact."
-msgstr "A sárga lordnál van a Szent Varázstárgy."
-
-#: ../fheroes2/resource/maps_text.cpp:726
-msgid ""
-"The Yellow Lord is a hothead who will attack before his allies can send him "
-"aid."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:727
-msgid "They say there's mermaids in these waters..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:728
-msgid ""
-"This area is rich in resources. Explore, but beware, a castle left "
-"undefended will quickly fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:729
-msgid ""
-"This area must be secured for the sake of the Empire. Our spies have "
-"reported a discord between The kingdom of the knights to the north, and that "
-"of the oppressive sorceresses to the northeast. Perhaps this feud can be "
-"exploited for our gain..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:730
-msgid "This bottle is empty."
-msgstr "Ez az üveg üres."
-
-#: ../fheroes2/resource/maps_text.cpp:731
-msgid ""
-"This is the last week you have to find the rebel wizard Joseph! Good Luck in "
-"your quest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:732
-msgid ""
-"This land and all others are now under the sole ownership of Ibn Fadlan, the "
-"Undead King. Any disregard for his magesty's soverign rule is to be punished "
-"by death most horrendous."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:733
-msgid ""
-"This land has been claimed by the nation of Neroli. Interlopers are "
-"UNWELCOME."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:734
-msgid ""
-"This rugged land will have rivals fighting the terrain as well as each other."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:735
-msgid ""
-"This rundown village looks like it was once the epicenter of an enormous, "
-"but now ruined, city. Under a pile of rubble you find an object which looks "
-"like it has lain there for ages."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:736
-msgid ""
-"This spot overlooks an old quarry.  This was one of the only places in the "
-"world where ore could be taken right out of the ground.  Unfortunately the "
-"jungle has reclaimed the quarry and it is unusable.  You collect the last of "
-"the ore and depart."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:737
-msgid ""
-"This twisted maze of sorceress towns has three factions struggling for sole "
-"control.  Use your resources wisely!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:738
-msgid ""
-"This village appears to be in little better shape than the first one you "
-"saw. As you approach the village an old man hands you a slip of paper, with "
-"the following message, \"Joseph lives in the town of IslandHome.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:739
-msgid ""
-"This village is in extremely poor shape. There is no chance of getting more "
-"than some of the lesser creatures here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:740
-msgid "This way to the Necromancer Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:741
-msgid "Those who seek knowledge are welcome to the city of Chronos."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:742
-msgid ""
-"Three Warlocks in the land of Dragons. Lose thy home and all will be lost. "
-"Conquer thy enemies and the land shall forever be yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:743
-msgid "Timberhill"
-msgstr "Timberhill"
-
-#: ../fheroes2/resource/maps_text.cpp:744
-msgid "Time for a refreshing drink."
-msgstr "Itt az idő a frissítő iváshoz."
-
-#: ../fheroes2/resource/maps_text.cpp:745
-msgid "Time is running out! The enemy's reinforcements are almost here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:746
-msgid "To pass you must pay troll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:747
-msgid "TreeHome"
-msgstr "TreeHome"
-
-#: ../fheroes2/resource/maps_text.cpp:748
-msgid "Trespassers will be EATEN!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:749
-msgid "Trilobar"
-msgstr "Trilobar"
-
-#: ../fheroes2/resource/maps_text.cpp:750
-msgid "Troy"
-msgstr "Troy"
-
-#: ../fheroes2/resource/maps_text.cpp:751
-msgid "Tundara"
-msgstr "Tundara"
-
-#: ../fheroes2/resource/maps_text.cpp:752
-msgid "Turn back, friend, while you still can!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:753
-msgid "Turn Back Now!"
-msgstr "Azonnal fordulj vissza!"
-
-#: ../fheroes2/resource/maps_text.cpp:754
-msgid "Turn Back Now or all will be LOST!"
-msgstr "Azonnal fordulj vissza, különben mindennek vége!"
-
-#: ../fheroes2/resource/maps_text.cpp:755
-msgid "Turn Back or DIE!"
-msgstr "Fordulj vissza vagy meghalsz!"
-
-#: ../fheroes2/resource/maps_text.cpp:756
-msgid "Turn Back or else!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:757
-msgid "Turn back, you fool."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:758
-msgid "\"Turning Point\""
-msgstr "Fordulópont"
-
-#: ../fheroes2/resource/maps_text.cpp:759
-msgid ""
-"Uae was the scurviest, pirate ye'd never wanta see. In all her years of "
-"murdering and thieving she amassed so much ill-gotten booty that she "
-"couldn't carry it around in her galleon.  Besides, even the meanest can't "
-"stay awake all the time.  Legend tells that she hid it so well, she was "
-"thinking that she just might forget where it was.  So she left clues around "
-"the islands, carved in stone.  Well, she's dead now.  It's up to you to "
-"recover her legacy."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:761
-msgid "Uncle Leo"
-msgstr "Leo nagybácsi"
-
-#: ../fheroes2/resource/maps_text.cpp:762
-msgid "Uncle Milty"
-msgstr "Milty nagybácsi"
-
-#: ../fheroes2/resource/maps_text.cpp:763
-msgid "Undead Armies"
-msgstr "Élőholt hadsereg"
-
-#: ../fheroes2/resource/maps_text.cpp:764
-msgid "Unholy Alliance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:765
-msgid "Unite the Tribes. Don't lose your main hero, the first Descendant."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:766
-msgid "Valley of Death"
-msgstr "Halálvölgy"
-
-#: ../fheroes2/resource/maps_text.cpp:767
-msgid "Valley Of The Damned"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:768
-msgid "Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:769
-msgid "Vaultius"
-msgstr "Vaultius"
-
-#: ../fheroes2/resource/maps_text.cpp:770
-msgid "Vertigo"
-msgstr "Vertigo"
-
-#: ../fheroes2/resource/maps_text.cpp:771
-msgid "Vikings!"
-msgstr "Vikingek!"
-
-#: ../fheroes2/resource/maps_text.cpp:772
-msgid "Viper's Nest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:773
-msgid "Vulcania"
-msgstr "Vulcania"
-
-#: ../fheroes2/resource/maps_text.cpp:774
-msgid "Warrior Knight"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:775
-msgid "Wastelands"
-msgstr "Wastelands"
-
-#: ../fheroes2/resource/maps_text.cpp:776
-msgid "Watch out for Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:777
-msgid "Waystop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:778
-msgid ""
-"\"We are at the edge of the world!\"  they scream.  \"What are we doing here?"
-"\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:779
-msgid "Weddington"
-msgstr "Weddington"
-
-#: ../fheroes2/resource/maps_text.cpp:780
-msgid "Weed Patch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:781
-msgid ""
-"We found a weakness my lord. Capture castle Black Fang and victory is ours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:782
-msgid ""
-"We have just learned that the artifact is on an island north of this "
-"continent. However, there does not appear to be any means to get there. Stay "
-"very alert for any possible way across the narrow channel."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:783
-msgid ""
-"Welcome back general.  Have you finished the conquest of the northern "
-"lands?  What? you still have not finished your mission!  Get back there and "
-"teach those rebels a lesson!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:784
-msgid "Welcome to Li'l Alctatraz! Vistors NOT welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:785
-msgid ""
-"Welcome to Power Island. He who controls this Isle controls the Seven Lakes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:786
-msgid "Welcome to the Sandbar."
-msgstr "Isten hozta Sandbar-ban!"
-
-#: ../fheroes2/resource/maps_text.cpp:787
-msgid "Welcome to the sandy Isle."
-msgstr "Isten hozta Homoksziget-en!"
-
-#: ../fheroes2/resource/maps_text.cpp:788
-msgid "Welcome to the sorceress' guild."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:789
-msgid "Welcome to the Spiral Isles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:790
-msgid ""
-"Welcome to the wounderous Kitisland range.  Eruptions each day, beware of "
-"dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:791
-msgid "Welcome to Windfall Island!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:792
-msgid "Welcome to your DOOM!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:793
-msgid "We'll join you - for the right price."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:794
-msgid ""
-"Well placed bribes have won you a stronghold near the warring Barbarians. Be "
-"advised that given their proximity an unguarded castle is an open invitation "
-"to defeat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:795
-msgid "Westfork"
-msgstr "Westfork"
-
-#: ../fheroes2/resource/maps_text.cpp:796
-msgid "Westmoor"
-msgstr "Westmoor"
-
-#: ../fheroes2/resource/maps_text.cpp:797
-msgid "We told you not to drink!"
-msgstr "Mondtuk, hogy ne igyál!"
-
-#: ../fheroes2/resource/maps_text.cpp:798
-msgid "What are you doing here?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:799
-msgid "What cannot be seen but only heard, and will not speak until spoken to?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:800
-msgid "What everyday word is most often pronounced incorrectly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:801
-msgid "What goes up and down but never moves?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:802
-msgid ""
-"What good fortune!  You've discovered a long-abandoned settlement.  To your "
-"surprise, you discover that the previous inhabitants left some of their "
-"resources behind when they departed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:803
-msgid "What is always coming but never arrives?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:804
-msgid "What is the Sum of all Numbers from 1 to 200?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:805
-msgid "What is time spent poorly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:806
-msgid "What's another word for pirate treasure?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:807
-msgid "What's behind door number one?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:808
-msgid "What's this? A pile of gems?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:809
-msgid "What's this? Someone has left a pile of wood here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:810
-msgid ""
-"What team won Super Bowl XXI and Super Bowl XXV?  (Hint... a Wizard might "
-"have these troops in his army)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:811
-msgid "What turns everything around but does not move?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:812
-msgid ""
-"What walks in the morning on four legs, two in the afternoon and three in "
-"the evening?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:813
-msgid "What?  What's this?  Something at the bottom of this pool..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:814
-msgid "When you're ready, take the teleport to the Island's Hot Spot!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:815
-msgid ""
-"When you think yourself invincible, walk through this gate.  Even then, "
-"prepare to meet your bitter end."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:816
-msgid "Where am I?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:817
-msgid "While away seeking the Ultimate Artifact, Kastor's kingdom is invaded!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:818
-msgid ""
-"While traveling a mesenger meets you on the road.  His message tells of a "
-"new ally from an island far to the south.  This ally can not offer forces to "
-"your battle but has agreed to send some support in the form of gold and "
-"crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:819
-msgid "Whiteshield"
-msgstr "Whiteshield"
-
-#: ../fheroes2/resource/maps_text.cpp:820
-msgid "Whittingham"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:821
-msgid "Who am I?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:822
-msgid ""
-"Who am I?...  Where am I?...  Oh no! My Ship!  Well it's consigned to the "
-"ghosts of my dead crew now, at least I still have my lucky rabbits foot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:823
-msgid "Who is the true King?"
-msgstr "Ki az igazi király?"
-
-#: ../fheroes2/resource/maps_text.cpp:824
-msgid ""
-"\"Why have we come this way?\"  asks the first mate.  You have no answer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:825
-msgid "Wicked Warlock Way"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:826
-msgid "Wilasher"
-msgstr "Wilasher"
-
-#: ../fheroes2/resource/maps_text.cpp:827
-msgid "Wildabar"
-msgstr "Wildabar"
-
-#: ../fheroes2/resource/maps_text.cpp:828
-msgid "Wilgatus"
-msgstr "Wilgatus"
-
-#: ../fheroes2/resource/maps_text.cpp:829
-msgid "Willow"
-msgstr "Willow"
-
-#: ../fheroes2/resource/maps_text.cpp:830
-msgid "Windfall Isle"
-msgstr "Windfall-sziget"
-
-#: ../fheroes2/resource/maps_text.cpp:831
-msgid "Winterkill"
-msgstr "Winterkill"
-
-#: ../fheroes2/resource/maps_text.cpp:832
-msgid "Winterlands"
-msgstr "Winterlands"
-
-#: ../fheroes2/resource/maps_text.cpp:833
-msgid "Witch Hunt"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:834
-msgid ""
-"With the year long eruption of Mt. Kitisland, your three worst enemies now "
-"have a ground bridge to your eastern contenent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:835
-msgid "Wizardwood.  Magicians welcome!"
-msgstr "Wizardwood. Üdvözlet a varázslóknak!"
-
-#: ../fheroes2/resource/maps_text.cpp:836
-msgid "Woodhaven"
-msgstr "Woodhaven"
-
-#: ../fheroes2/resource/maps_text.cpp:837
-msgid "Wood's Lord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:838
-msgid "Woodstock"
-msgstr "Woodstock"
-
-#: ../fheroes2/resource/maps_text.cpp:839
-msgid "Woodville"
-msgstr "Woodville"
-
-#: ../fheroes2/resource/maps_text.cpp:840
-msgid "Wormed Ash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:841
-msgid "Wow, somebody has left a pile of wood here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:842
-msgid "Wyrm"
-msgstr "Wyrm"
-
-#: ../fheroes2/resource/maps_text.cpp:843
-msgid "Xabran"
-msgstr "Xabran"
-
-#: ../fheroes2/resource/maps_text.cpp:844
-msgid "Yellow gets some stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:845
-msgid "Yellow's Steady Cash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:846
-msgid "Yellow stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:847
-msgid "Yellow's Yarbols"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:848
-msgid "Ye old fish liver oil."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:849
-msgid "Yorksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:850
-msgid ""
-"You and your ally's families were given custody of The Isle of Knowledge.  "
-"Other Lords feel the time has come for new guardians..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:851
-msgid "You are a fool to come here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:852
-msgid "You are fighting on the side of your king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:853
-msgid "You are fighting on the side of your sister!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:854
-msgid "You are now entering the domain of Prince Roland. Have a nice day."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:855
-msgid "You are now entering the domain of Prince Roland. Have a pleasant stay."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:856
-msgid ""
-"You bribe the entrance guards of this dingy prison camp. They agree to look "
-"the other way for a little while."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:857
-msgid ""
-"You can only reach your enemies via teleporters, but each jump is a leap of "
-"faith."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:858
-msgid ""
-"You cautiously ride through the trees, looking out for enemy assaults, when "
-"suddenly, the old elf is beside you. \"Your quest is almost at an end, my "
-"friend. All that remains is for you to lay seige to these last few castles. "
-"The fate of my people rests upon your final battles here. May the gods be "
-"with you as well.\"  He turns to leave, but you ask him his name before he "
-"is gone. Over his shoulder, as he is leaving he says \"I am Ilthanis, king "
-"of the elves.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:859
-msgid ""
-"You come across the dead remains of what was appearantly a powerful wizard!  "
-"You wonder if it's safe to continue."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:860
-msgid ""
-"You face three opponents in this scenario. Capture their castles and their "
-"heroes to prove your worthiness to Archibald."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:861
-msgid ""
-"You find a beautiful helm buried in the lava.  As you move to put it on your "
-"head it turns into the Hideous mask and now you realize that no creature "
-"will join you."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:862
-msgid ""
-"You find a gleaming gold medalion buried in the  snow.  As you move to put "
-"it on it changes to the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:863
-msgid ""
-"You find an old signpost in the midst of a thicket that reads \"Warlock "
-"Wood, West.  Barbarian Fields, East.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:864
-msgid ""
-"You find a note in the bottle! It reads, \"My ship has been wrecked by the "
-"notorious pirates in this area! I am stranded on a small and barren island. "
-"Please, I beg you to come and rescue me!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:865
-msgid "You found something!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:866
-msgid "You found Treasure!"
-msgstr "Kincset találtál!"
-
-#: ../fheroes2/resource/maps_text.cpp:867
-msgid ""
-"You have been ordered here to claim this land in the name of your King and "
-"recover any riches that you might find.  However, five other Kings and "
-"Queens have also sent their heroes to this land, so you must watch out for "
-"them as well as the natives!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:868
-msgid "You have found what someone else has lost..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:869
-msgid ""
-"You have hired a barbarian of great power to aid you in this, your last "
-"quest. His origins are unknown to you, but you sense strong nobility beneath "
-"the furs and dirt that cover him. In addition, the famous explorer, Marco "
-"the wizard, is rumored to have wrecked his ship in this new land. Finding "
-"him would prove to be a much needed boon to your cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:870
-msgid ""
-"You have just 8 weeks  to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:871
-msgid ""
-"You have just 8 weeks to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:872
-msgid ""
-"You have received a message from Archibald. \"General, these peasants "
-"deserve punishment. Put them to the sword and let Corlagon have his way with "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:873
-msgid ""
-"You have received a message from Archibald.  \" HOW DARE YOU BETRAY ME! I "
-"will see your head on the block alongside your new master's once I have won."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:874
-msgid ""
-"You have received a message from Roland. \" I am shocked! I had thought "
-"better of you, but I was terribly wrong. Now you'll have to live with your "
-"dark decision for the rest of your life.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:875
-msgid "You have recieved a shipment of supplies from your kingdom!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:876
-msgid ""
-"You have recieved a shipment of supplies from your kingdom! There is a note "
-"attached, \"These are all we could afford to send you from our treasuries, "
-"as the war with Harondale is taxing us greatly. We will send more in two "
-"weeks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:877
-msgid ""
-"You have six months to destroy the Necromancer Stronghold in the heart of "
-"the valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:878
-msgid ""
-"You have washed up on the beach after being shipwrecked. Your goal is to "
-"find a way home."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:879
-msgid ""
-"You hear a low rumble, look up and see an avalanche!  You dive onto a large "
-"patch of grass to avoid it.  While dusting yourself off, you consider "
-"yourself quite lucky to be alive.  Luckier still to find a Four-Leaf Clover "
-"stuck on your nose."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:880
-msgid ""
-"You hear a rumor from a peasant who lives in the town of Waystop. He says, "
-"\"The pirates control most of the sulfur mines in this area. They use it for "
-"the cannons on their bigger boats. If you want a mine, you'll have to defeat "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:881
-msgid "You hear melodic strains of elvish music as you enter this clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:882
-msgid ""
-"You must, like, forsake your earthly wealth and, like, join us on the island "
-"of the lotus eaters."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:883
-msgid ""
-"You must search the world for your mortal enemy, Wilgatus.  Can you find him "
-"before its too late?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:884
-msgid ""
-"You notice some runes hastily scrawled into a rock by your feet, They look "
-"like the initials of Uncle Ivan!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:885
-msgid ""
-"You notice that mines and resources in the elvish lands are few, and you "
-"send word to your kingdom that you will need extra supplies. They should "
-"respond within a fortnight."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:886
-msgid ""
-"Your advance scouts come riding back to you with the following news. They "
-"believe they have found signs that Uncle Ivan was in this general area, and "
-"that he made his way to the north many months ago. Also they say there is a "
-"town nearby and many resources to the east."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:887
-msgid ""
-"Your advisor approaches you, \"My liege, something must be done about these "
-"peasants! They still refuse to work.  At this rate you won't have anything "
-"to put in your daughter's dowry!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:888
-msgid ""
-"Your advisor approaches you smiling greatly, \"My liege! The peasants are "
-"making money in the market, and are finally paying taxes!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:889
-msgid ""
-"Your advisor approaches you with a long face, \"My liege, the peasant's "
-"numbers are growing steadily.  All they do is take, take, take! We are "
-"beginning to suffer dearly because of them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:890
-msgid ""
-"Your advisor approaches you with some startling information, \"My liege, the "
-"peasants are draining us. They do nothing, and take everything! We must get "
-"them home. Your own citizens are beginning to suffer!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:891
-msgid ""
-"Your arrival here was a surprise to those sworn to guard Dragon Isle, and "
-"you were able to quickly capture one of their castles.  Use caution, though, "
-"for two other guardians remain in this jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:892
-msgid ""
-"Your castle, founded inside the center of a mile wide crater, is besieged by "
-"those who desire your mineral wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:893
-msgid "Your castle is the last outpost in the area, Don't lose it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:894
-msgid "Your crew begins to grumble."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:895
-msgid ""
-"Your crew seriously entertains thoughts of mutiny.  Your nights are "
-"sleepless."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:896
-msgid "You're almost there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:897
-msgid "You, recieve word that you have been robbed."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:898
-msgid "You're getting colder."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:899
-msgid "You're getting warmer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:900
-msgid ""
-"You're here! Oh, thank you thank you thank you! I'm in the jail east of the "
-"castle. Please hurry!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:901
-msgid ""
-"Your expedition has taken a turn for the worse... you now have no way to get "
-"home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:902
-msgid ""
-"Your forces are thinly spread in an effort to defend all the dwarf towns "
-"(which may not be transformed into castles). Consolidate your forces and "
-"smite the enemy before the towns fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:903
-msgid ""
-"Your horse stumbles and throws you from the saddle.  When you awaken you "
-"find that you have hit your head on the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:904
-msgid ""
-"Your isolation from the rest of the kingdom has largely kept you out of the "
-"political struggles, but now with the king's death, and lack of an heir, you "
-"see a golden opportunity to seize the throne for yourself.  Just remember "
-"that you have relied largely on trade for several key resources, especially "
-"sulfur, but with a little planning this land can be yours.  Go, now, and "
-"show these peasants how to rule!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:905
-msgid "Your king has sent supplies to aid the war effort."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:906
-msgid ""
-"Your opponents are allied against you and each is twice as powerful as his "
-"predecessor! Is it possible to win?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:907
-msgid ""
-"Your Queen sent you here to explore this newly discovered territory, but a "
-"freak storm scattered your fleet and left you stranded.  You gather the "
-"survivors and form a small settlement, naming it New Vertigo.  This place is "
-"your home now, and survival is your highest priority, but remember, if you "
-"are captured or killed, it's over!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:908
-msgid ""
-"Your rival, the kingdom of Harondale, is attacking your weak border towns! "
-"Recover from their first strike and crush them completely."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:909
-msgid ""
-"Your Scouts report talking to a young knight, a squire to the two sleeping "
-"heroes.  The squire is trapped by the Aqua Magic Barriers and a group of "
-"fallen Paladins.  He says the two heroes, Dainwin and Ceallach, have "
-"awakened but are still trapped by a Gold Magical Barrier and asks your aid "
-"in freeing them."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:910
-msgid ""
-"Your Scouts report that the Aqua Traveller's Tent is located along The North "
-"Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:911
-msgid ""
-"Your scouts return with grim news.  The natives of this land are currently "
-"at war with each other, and they like outsiders even less than they like "
-"each other!  Congratulations, Commander, you're at war!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:912
-msgid ""
-"Your sister calls you before her altar in the morning. \"I have important "
-"news,\" she says, \"The barbarian kingdoms which border this land have "
-"agreed to lend us some of their castles and warriors in return for a share "
-"of the spoils. I hope victory comes swiftly, but your presence gives me "
-"strength to stand until whatever end awaits.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:913
-msgid "Your subjects contribute to your war effort!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:914
-msgid ""
-"Your town is undefended and your heroes are scattered.  Do you attack or "
-"defend?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:915
-msgid ""
-"Your treasury has been looted by robbers and you have lost valuable "
-"resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:916
-msgid "Your troops begin to wonder about your sanity."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:917
-msgid ""
-"You run aground on the rocks and have to use some wood to fix your boat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:918
-msgid ""
-"You see a family of refugees making their way from the beach. You ask them "
-"about their plight and they tell you that they are from a once great city "
-"called Moss Side. They tell you that the castle was destroyed in a great "
-"conflagration, and they fled for fear of their lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:919
-msgid ""
-"You see an old man bringing water towards the stables. Recognizing him as "
-"the mystic, you attempt to thank him for his gift with some gold. He "
-"refuses, but says to you instead, \"There are riddles guarding the source of "
-"the fount's power, and the dragons know the answers. Make your way through "
-"their lair, and you shall know victory.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:920
-msgid ""
-"You see an old mystic perched on a rock. You walk towards him to see if he "
-"has any words for you on your quest, and he says \"First I see you as a "
-"great conquerer of the lands of men. Secondly, I see you as a mighty ruler "
-"of vast armies, well loved by your troops. Thirdly, I see you as a slayer of "
-"legions of dragons, your body bathed in their fire. Lastly, I see you "
-"standing on the shores of the fount, unable to cross.\" Then the Mystic "
-"fades away."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:921
-msgid "You see something that could just be the elusive Nubbie!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:922
-msgid ""
-"You see the mast of ancient ship here.  On further investigation you find "
-"that the ships holds are full of gems.  The hours pass as your crue "
-"liberates the treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:923
-msgid ""
-"You see the remains of a burned out sawmill here.  All you can salvage is "
-"some ofwood left for scrap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:924
-msgid ""
-"You see the remains of an old sawmill, but it is obvious that you will not "
-"be able to make it work again."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:925
-msgid ""
-"You see the remains of an old sawmill just to realize that it will no longer "
-"produce.  You gather the ramains and move on."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:926
-msgid ""
-"You send this letter back to the king,\"A month has passed and we have not "
-"discovered the wizard Joseph. I only hope that we are able to locate him in "
-"time to aid us in our struggle.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:927
-msgid "You should turn back."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:928
-msgid ""
-"You stumble upon an old man who proclaims you Lord of the Realm, hands you "
-"his boots and wonders into the mountains mumbling something about being late "
-"for an important date."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:929
-msgid ""
-"You stumple across three small rocks piled on top of each other and decide "
-"to dig undernear them.  There you find an old weather-beaten bag of gems."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:930
-msgid "You uncover a compass in the grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:931
-msgid "You've been warned!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:932
-msgid ""
-"You've received a message from Roland. \"In the absence of a strong leader, "
-"the local lords have fallen to fighting. Uniting this area is critical to "
-"our cause, so we must not fail.  Leaving your castle undefended in this "
-"highly contested region will surely lead to defeat. I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:933
-msgid ""
-"You've received a message from the guild. \"Thank God you've arrived! We're "
-"under seige from two enemies from the north and one from across the sea. "
-"Please save us, you're our only hope.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:934
-msgid ""
-"You've ruled with an iron fist (and an army of undead), but now your kingdom "
-"has turned against you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:935
-msgid ""
-"You've saved a group of miners from the dragons.  One of them approaches "
-"you, \"Thank you so much for saving us!  We found this sulfer and sword in "
-"the mine, then those dragons chased us!  I don't know how much longer we "
-"could survive!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:936
-msgid ""
-"You will clash quickly on this small head-to-head map, so stay on your toes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:937
-msgid ""
-"You will need a stronger army than that, mortal, to step through this portal."
-msgstr ""
-
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Wood"
 msgstr "Fa"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Mercury"
 msgstr "Higany"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Ore"
 msgstr "Érc"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Sulfur"
 msgstr "Kén"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Crystal"
 msgstr "Kristály"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Gems"
 msgstr "Drágakövek"
 
-#: ../fheroes2/spell/spell_book.cpp:61 ../fheroes2/spell/spell_book.cpp:79
-msgid "No spell to cast."
-msgstr ""
-
-#: ../fheroes2/spell/spell_book.cpp:138
-msgid "Your hero has %{point} spell points remaining"
-msgstr "A hősödnek van még %{point} varázspontja."
-
-#: ../fheroes2/spell/spell.cpp:50
 msgid "Fireball"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:50
 msgid ""
 "Causes a giant fireball to strike the selected area, damaging all nearby "
 "creatures."
 msgstr ""
 "Egy hatalmas tűzgolyó robban a területen, megsebesítvén a közeli lényeket."
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid "Fireblast"
 msgstr "Tűzlabda"
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid ""
 "An improved version of fireball, fireblast affects two hexes around the "
 "center point of the spell, rather than one."
@@ -11706,19 +6034,15 @@ msgstr ""
 "A tűzgolyó fejlettebb változata, a varázslat középpontjától 2 hexányi "
 "területen hat."
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Lightning Bolt"
 msgstr "Villám"
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Causes a bolt of electrical energy to strike the selected creature."
 msgstr "Elektromos villámcsapást okoz a kiválasztott lényen."
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid "Chain Lightning"
 msgstr "Láncvillám"
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid ""
 "Causes a bolt of electrical energy to strike a selected creature, then "
 "strike the nearest creature with half damage, then strike the NEXT nearest "
@@ -11729,285 +6053,219 @@ msgstr ""
 "feleakkora sebzéssel, és így tovább mindaddig,amig el nem fogy az energiája. "
 "Vigyázat: ez a varázslat saját egységet is sebezhet!"
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid "Teleport"
 msgstr "Teleportálás"
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid ""
 "Teleports the creature you select to any open position on the battlefield."
 msgstr "Áthelyezi a kiválasztott egységet a csatatér bármely szabad pontjára."
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid "Cure"
 msgstr "Gyógyítás"
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid ""
-"Removes all negative spells cast upon one of your units, and restores up to %"
-"{count} HP per level of spell power."
+"Removes all negative spells cast upon one of your units, and restores up to "
+"%{count} HP per level of spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid "Mass Cure"
 msgstr "Tömeges Gyógyítás"
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid ""
-"Removes all negative spells cast upon your forces, and restores up to %"
-"{count} HP per level of spell power, per creature."
+"Removes all negative spells cast upon your forces, and restores up to "
+"%{count} HP per level of spell power, per creature."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrect"
 msgstr "Feltámasztás"
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrects creatures from a damaged or dead unit until end of combat."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrect True"
 msgstr "Valódi feltámasztás"
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrects creatures from a damaged or dead unit permanently."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Haste"
 msgstr "Gyorsítás"
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Increases the speed of any creature by %{count}."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Mass Haste"
 msgstr "Teljes Gyorsítás"
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Increases the speed of all of your creatures by %{count}."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "spell|Slow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "Slows target to half movement rate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Mass Slow"
 msgstr "Teljes Lassítás"
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Slows all enemies to half movement rate."
 msgstr "Felezi az összes ellenség sebességét."
 
-#: ../fheroes2/spell/spell.cpp:64
-msgid "Blind "
-msgstr "Vakítás "
+msgid "spell|Blind"
+msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:64
 msgid "Clouds the affected creatures' eyes, preventing them from moving."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Bless"
 msgstr "Áldás"
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Causes the selected creatures to inflict maximum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Mass Bless"
 msgstr "Teljes Áldás"
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Causes all of your units to inflict maximum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Stoneskin"
 msgstr "Kőbőr"
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Magically increases the defense skill of the selected creatures."
 msgstr "A kiválasztott lény védőereje varázslatosan növekszik."
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid "Steelskin"
 msgstr "Acélbőr"
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid ""
 "Increases the defense skill of the targeted creatures.  This is an improved "
 "version of Stoneskin."
 msgstr ""
 "A kiválasztott lény védőereje növekszik. Ez a Kőbőr egy fejlettebb változata."
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Curse"
 msgstr "Átok"
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Causes the selected creatures to inflict minimum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Mass Curse"
 msgstr "Teljes Átok"
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Causes all enemy troops to inflict minimum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Holy Word"
 msgstr "Szent Ige"
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Damages all undead in the battle."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid "Holy Shout"
 msgstr "Szent Kiáltás"
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid ""
 "Damages all undead in the battle.  This is an improved version of Holy Word."
 msgstr ""
 "Megsebesít minden élőholtat a csatában. A Szent Ige varázslat egy fejlettebb "
 "formája."
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Anti-Magic"
 msgstr "Antimágia"
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Prevents harmful magic against the selected creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Dispel Magic"
 msgstr "Varázslatűzés"
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Removes all magic spells from a single target."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Mass Dispel"
 msgstr "Teljes Varázslatűzés"
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Removes all magic spells from all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Magic Arrow"
 msgstr "Varázsnyíl"
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Causes a magic arrow to strike the selected target."
 msgstr "Varázsnyillal mér csapást a kiválasztott célpontra."
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Berserker"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Causes a creature to attack its nearest neighbor."
 msgstr "A lény megtámadja a legközelebbi szomszédját."
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid "Armageddon"
 msgstr "Végítélet"
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid ""
 "Holy terror strikes the battlefield, causing severe damage to all creatures."
 msgstr "A Szent Terror csapást mér a harcmező összes egységére."
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Elemental Storm"
 msgstr "Elemi Vihar"
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Magical elements pour down on the battlefield, damaging all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid "Meteor Shower"
 msgstr "Meteoreső"
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid ""
 "A rain of rocks strikes an area of the battlefield, damaging all nearby "
 "creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "Paralyze"
 msgstr "Bénítás"
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "The targeted creatures are paralyzed, unable to move or retaliate."
 msgstr "A kiválasztott egység megbénul, nem képes mozogni vagy visszaütni."
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid "Hypnotize"
 msgstr "Hipnózis"
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid ""
-"Brings a single enemy unit under your control for one combat round if its "
-"hits are less than %{count} times the caster's spell power."
+"Brings a single enemy unit under your control if its hits are less than "
+"%{count} times the caster's spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Cold Ray"
 msgstr "Jégsugár"
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Drains body heat from a single enemy unit."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid "Cold Ring"
 msgstr "Jéggyűrű"
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid ""
 "Drains body heat from all units surrounding the center point, but not "
 "including the center point."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Disrupting Ray"
 msgstr "Gyengítő Sugár"
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Reduces the defense rating of an enemy unit by three."
 msgstr "Csöllenti egy ellenséges egység védelmi osztályát 3-mal."
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Death Ripple"
 msgstr "Halállökés"
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Damages all living (non-undead) units in the battle."
 msgstr "Az összes élő (nem élőhalott) egység a csatatéren sebződik."
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid "Death Wave"
 msgstr "Halálhullám"
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid ""
 "Damages all living (non-undead) units in the battle.  This spell is an "
 "improved version of Death Ripple."
@@ -12015,35 +6273,27 @@ msgstr ""
 "Megsebesít minden élőt (nem az élőhalottat) a csatában. Ez a varázslat a "
 "Halállökés egy fejlettebb változata."
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Dragon Slayer"
 msgstr "Sárkányölő"
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Greatly increases a unit's attack skill vs. Dragons."
 msgstr "Az egység támadóereje jelentősen növekszik sárkányok ellen."
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Blood Lust"
 msgstr "Vérszomj"
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Increases a unit's attack skill."
 msgstr "Az egység támadóereje növekszik."
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Animate Dead"
 msgstr "Feltámasztás"
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Resurrects creatures from a damaged or dead undead unit permanently."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid "Mirror Image"
 msgstr "Tükörkép"
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid ""
 "Creates an illusionary unit that duplicates one of your existing units.  "
 "This illusionary unit does the same damages as the original, but will vanish "
@@ -12053,507 +6303,1137 @@ msgstr ""
 "ugyanakkora erővel támad, mint az eredeti, de bármilyen sebzés következtében "
 "eltűnik."
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Shield"
 msgstr "Pajzs"
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Halves damage received from ranged attacks for a single unit."
 msgstr "Felére csökkenti a távolsági sebzéseket egy kiválasztott egységnek."
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Mass Shield"
 msgstr "Teljes Pajzs"
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Halves damage received from ranged attacks for all of your units."
 msgstr "Felére csökkenti a távolsági sebzéseket minden egységnek."
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summon Earth Elemental"
 msgstr "Földelementál idézése"
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summons Earth Elementals to fight for your army."
 msgstr "Megidézett Földelementálok segítenek a harcban."
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summon Air Elemental"
 msgstr "Légelementál idézése"
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summons Air Elementals to fight for your army."
 msgstr "Megidézett Légelementálok segítenek a harcban."
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summon Fire Elemental"
 msgstr "Tűzelementál idézése"
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summons Fire Elementals to fight for your army."
 msgstr "Megidézett Tűzelementálok segítenek a harcban."
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summon Water Elemental"
 msgstr "Vízelementál idézése"
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summons Water Elementals to fight for your army."
 msgstr "Megidézett Vízelementálok segítenek a harcban."
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Earthquake"
 msgstr "Földrengés"
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Damages castle walls."
 msgstr "Megsebzi a kastély falait."
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "View Mines"
 msgstr "Bányák mutatása"
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "Causes all mines across the land to become visible."
 msgstr "Láthatóvá teszi a környék összes bányáját."
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "View Resources"
 msgstr "Nyersaanyagok mutatása"
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "Causes all resources across the land to become visible."
 msgstr "Láthatóvá teszi a környék összes nyersanyagát."
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "View Artifacts"
 msgstr "Varázstárgyak mutatása"
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "Causes all artifacts across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "View Towns"
 msgstr "Városok mutatása"
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "Causes all towns and castles across the land to become visible."
 msgstr "A környék összes városa és kastélyja látható."
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "View Heroes"
 msgstr "Hősök mutatása"
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "Causes all Heroes across the land to become visible."
 msgstr "A környék összes hőse látható."
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "View All"
 msgstr "Minden mutatása"
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "Causes the entire land to become visible."
 msgstr "A környéken minden látható."
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Identify Hero"
 msgstr "Hősazonosítás"
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Allows the caster to view detailed information on enemy Heroes."
 msgstr "Részletes információkat ad az ellenséges hősökről."
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid "Summon Boat"
 msgstr "Hajó idézése"
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid ""
 "Summons the nearest unoccupied, friendly boat to an adjacent shore "
 "location.  A friendly boat is one which you just built or were the most "
 "recent player to occupy."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Dimension Door"
 msgstr "Dimenziókapu"
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Allows the caster to magically transport to a nearby location."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Town Gate"
 msgstr "Városkapu"
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Returns the caster to any town or castle currently owned."
 msgstr "A varázsló visszatér bármelyik saját városába vagy várába"
 
-#: ../fheroes2/spell/spell.cpp:109
 msgid ""
 "Returns the hero to the town or castle of choice, provided it is controlled "
 "by you."
 msgstr "A hős visszaugorhat egy kiválasztott saját városába vagy várába"
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid "Visions"
 msgstr "Látomás"
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid ""
 "Visions predicts the likely outcome of an encounter with a neutral army camp."
 msgstr "Megjósolja az összecsapás kimenetelét egy semleges csapattal szemben."
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid "Haunt"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid ""
 "Haunts a mine you control with Ghosts.  This mine stops producing "
 "resources.  (If I can't keep it, nobody will!)"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Set Earth Guardian"
 msgstr "Földelementál Őr"
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Sets Earth Elementals to guard a mine against enemy armies."
 msgstr "Földelementálok beállítása bányaőrzőnek."
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Set Air Guardian"
 msgstr "Légelementál Őr"
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Sets Air Elementals to guard a mine against enemy armies."
 msgstr "Légelementálok beállítása bányaőrzőnek."
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Set Fire Guardian"
 msgstr "Tűzelementál Őr"
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Sets Fire Elementals to guard a mine against enemy armies."
 msgstr "Tűzelementálok beállítása bányaőrzőnek."
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Set Water Guardian"
 msgstr "Vízelementál Őr"
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Sets Water Elementals to guard a mine against enemy armies."
 msgstr "Vízelementálok beállítása bányaőrzőnek."
 
-#: ../fheroes2/system/players.cpp:665
-msgid "Necroman"
-msgstr "Nekromanta"
-
-#: ../fheroes2/system/players.cpp:691
-msgid ""
-"This lets you change player starting positions and colors. A particular "
-"color will always start in a particular location. Some positions may only be "
-"played by a computer player or only by a human player."
+msgid "No spell to cast."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:695
-msgid ""
-"This lets you change the class of a player. Classes are not always "
-"changeable. Depending on the scenario, a player may receive additional towns "
-"and/or heroes not of their primary alignment."
-msgstr ""
-
-#: ../fheroes2/system/players.cpp:734
 #, fuzzy
-msgid "%{color} player"
-msgstr "%{color} játékos köre"
+msgid "Your hero has %{point} spell points remaining."
+msgstr "A hősödnek van még %{point} varázspontja."
 
-#: ../fheroes2/system/settings.cpp:126
+#, fuzzy
+msgid "View Adventure Spells"
+msgstr "Kaland Opciók"
+
+#, fuzzy
+msgid "View Combat Spells"
+msgstr "Varázslás"
+
+#, fuzzy
+msgid "View previous page"
+msgstr "Előző város mutatása"
+
+#, fuzzy
+msgid "View next page"
+msgstr "%{name} mutatása"
+
+#, fuzzy
+msgid "Close Spellbook"
+msgstr "Varázslás"
+
+#, fuzzy
+msgid "View %{spell}"
+msgstr "%{name} mutatása"
+
 msgid "game: always confirm for rewrite savefile"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:127
-msgid "game: also confirm autosave"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:128
 msgid "game: remember last focus"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:129
-msgid "game: battle show grid"
+msgid "battle: show damage info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:130
-msgid "game: battle mouse shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:131
-msgid "game: battle move shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:132
-msgid "game: battle show damage info"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:133
-msgid "game: castle flash building"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:134
 msgid "world: show visited content from objects"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:135
+msgid "world: show terrain penalty"
+msgstr ""
+
 msgid "world: scouting skill show extended content info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:136
-msgid "world: abandoned mine random resource"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:137
-msgid "world: save count monster after battle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:138
 msgid "world: allow set guardian to objects"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:139
-msgid "world: guardian objects gets +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:140
-msgid "world: no in-built requirements or guardians for placed artifacts"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:141
-msgid "world: only the first monster will attack (H2 bug)."
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:142
 msgid "world: Eagle Eye also works like Scholar in H3."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:143
 msgid "world: ban for WeekOf/MonthOf Monsters"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:144
-msgid "world: new version WeekOf (+growth)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:145
 msgid "world: ban plagues months"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:146
 msgid "world: Months Of Monsters do not place creatures on map"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:147
 msgid "world: Crystal Ball also added Identify Hero and Visions spells"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:148
-msgid "world: Artesian Springs have two separately visitable squares (h3 ver)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:149
 msgid "world: Starting heroes as Loss Conditions for Human Players"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:150
 msgid "world: Only 1 hero can be hired by the one player every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:151
-msgid "world: each castle allows one hero to be recruited every week"
+msgid "world: Each castle allows one hero to be recruited every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:152
-msgid "world: Outer creature dwellings should accumulate units"
+msgid "world: Neutral armies scale with game difficulty"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:153
-msgid "world: use unique artifacts for morale/luck"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:154
 msgid "world: use unique artifacts for resource affecting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:155
 msgid "world: use unique artifacts for primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:156
 msgid "world: use unique artifacts for secondary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:157
 msgid "world: Wind/Water Mills and Magic Garden can be captured"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:158
 #, fuzzy
 msgid "world: disable Barrow Mounds"
 msgstr "Barrow Dombság"
 
-#: ../fheroes2/system/settings.cpp:159
-msgid "castle: allow buy from well"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:160
 msgid "castle: allow guardians"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:161
 msgid ""
 "castle: higher mage guilds regenerate more spell points/turn "
 "(20/40/60/80/100%)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:162
-msgid "castle: allow recruits special/expansion heroes"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:163
 msgid "heroes: allow buy a spellbook from Shrines"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:164
-msgid "heroes: learn new spells with day"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:165
 msgid "heroes: recruit cost to be dependent on hero level"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:166
-msgid "heroes: remember MP/SP for retreat/surrender result"
+msgid "heroes: remember move points for retreat/surrender result"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:167
-msgid "heroes: surrendering gives some experience"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:168
-msgid "heroes: recalculate movement points after creatures movement"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:169
-msgid "heroes: allow pickup objects for patrol"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:170
-msgid "heroes: after battle move to target cell"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:171
 msgid "heroes: allow transcribing scrolls (needs: Eye Eagle skill)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:172
-msgid "heroes: allow banned sec. skills upgrade"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:173
 msgid "heroes: in Arena can choose any of primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:174
 msgid "unions: allow meeting heroes"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:175
 msgid "unions: allow castle visiting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:176
+msgid "battle: show army order"
+msgstr ""
+
 msgid "battle: soft wait troop"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:177
-msgid "battle: high objects are an obstacle for archers"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:178
-msgid "battle: merge armies for hero from castle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:179
-msgid "battle: archmage can resists (20%) bad spells"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:180
-msgid "battle: magical creature resists (20%) the same magic"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:181
-msgid "battle: skip increase +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:182
 msgid "battle: reverse wait order (fast, average, slow)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:183
 msgid "game: show system info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:184
 msgid "game: autosave on"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:185
 msgid "game: autosave will be made at the beginning of the day"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:186
 msgid "game: use fade"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:187
-msgid "game: show SDL logo"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:188
 msgid "game: use evil interface"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:189
-msgid "game: also use dynamic interface for castles"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:190
 msgid "game: hide interface"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:191
 msgid "game: offer to continue the game afer victory condition"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:192
-msgid "pocketpc: hide cursor"
+#, fuzzy
+msgid "The ultimate artifact is really the %{name}."
+msgstr "A Múmiák átka lesújt a(z) %{name}!"
+
+msgid "The ultimate artifact may be found in the %{name} regions of the world."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:193
-msgid "pocketpc: tap mode"
+msgid "north-west"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:194
-msgid "pocketpc: drag&drop gamearea as scroll"
+#, fuzzy
+msgid "north"
+msgstr "Erőd"
+
+msgid "north-east"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:195
-msgid "pocketpc: low memory"
+#, fuzzy
+msgid "west"
+msgstr "Fészek"
+
+#, fuzzy
+msgid "center"
+msgstr "Szörny"
+
+#, fuzzy
+msgid "east"
+msgstr "Fészek"
+
+msgid "south-west"
 msgstr ""
+
+#, fuzzy
+msgid "south"
+msgstr "hang"
+
+msgid "south-east"
+msgstr ""
+
+msgid "The truth is out there."
+msgstr ""
+
+msgid "The dark side is stronger."
+msgstr ""
+
+msgid "The end of the world is near."
+msgstr ""
+
+msgid "The bones of Lord Slayer are buried in the foundation of the arena."
+msgstr ""
+
+msgid "A Black Dragon will take out a Titan any day of the week."
+msgstr ""
+
+msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
+msgstr ""
+
+msgid "An unknown force is being ressurected..."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Check the newest version of game at\n"
+"https://github.com/ihhub/\n"
+"fheroes2/releases"
+msgstr ""
+"Letöltheted a legújabb verziót az oldalról:\n"
+"http://sf.net/projects/fheroes2"
+
+#~ msgid "Tower do %{damage} damage."
+#~ msgstr "A torony %{damage} sebzést okoz."
+
+#~ msgid "You don't have enough gold!"
+#~ msgstr "Nincs elég aranyod!"
+
+#~ msgid "For the QVGA version is not available."
+#~ msgstr "A QVGA verzió nam alkalmazható."
+
+#~ msgid "Cost per troop:"
+#~ msgstr "Sereg ára:"
+
+#~ msgid "sound"
+#~ msgstr "hang"
+
+#~ msgid "You have no room to carry another artifact!"
+#~ msgstr "Nincs hely, hogy eltedd a varázstárgyat."
+
+#~ msgid "View Morale Info"
+#~ msgstr "Morál információ"
+
+#~ msgid "View Luck Info"
+#~ msgstr "Szerencse információ"
+
+#~ msgid "Dismiss hero"
+#~ msgstr "Hős elbocsátása"
+
+#~ msgid "Show prev heroes"
+#~ msgstr "Elöző hősök"
+
+#~ msgid "Bad Morale"
+#~ msgstr "Rossz Morál"
+
+#~ msgid "Neutral Morale"
+#~ msgstr "Semleges Morál"
+
+#~ msgid "Bad Luck"
+#~ msgstr "Rossz szerencse"
+
+#~ msgid "Neutral Luck"
+#~ msgstr "Semleges szerencse"
+
+#~ msgid "Good Luck"
+#~ msgstr "Jó szerencse"
+
+#~ msgid "Water"
+#~ msgstr "Víz"
+
+#~ msgid "Coast"
+#~ msgstr "Part"
+
+#, fuzzy
+#~ msgid "Peasant"
+#~ msgstr "Jobbágy"
+
+#~ msgid "Peasants"
+#~ msgstr "Paraszt"
+
+#, fuzzy
+#~ msgid "Archer"
+#~ msgstr "Íjász"
+
+#~ msgid "Archers"
+#~ msgstr "Íjász"
+
+#, fuzzy
+#~ msgid "Ranger"
+#~ msgstr "Erdőjáró"
+
+#~ msgid "Rangers"
+#~ msgstr "Erdész"
+
+#, fuzzy
+#~ msgid "Pikeman"
+#~ msgstr "Lándzsás"
+
+#~ msgid "Pikemen"
+#~ msgstr "Lándzsások"
+
+#, fuzzy
+#~ msgid "Veteran Pikeman"
+#~ msgstr "Veterán lándzsás"
+
+#~ msgid "Veteran Pikemen"
+#~ msgstr "Veterán lándzsások"
+
+#, fuzzy
+#~ msgid "Swordsman"
+#~ msgstr "Kardforgató"
+
+#~ msgid "Swordsmen"
+#~ msgstr "Kardforgatók"
+
+#, fuzzy
+#~ msgid "Master Swordsman"
+#~ msgstr "Kardforgató Mester"
+
+#~ msgid "Master Swordsmen"
+#~ msgstr "Kardforgató Mesterek"
+
+#, fuzzy
+#~ msgid "Cavalry"
+#~ msgstr "Huszár"
+
+#~ msgid "Cavalries"
+#~ msgstr "Lovagok"
+
+#, fuzzy
+#~ msgid "Champion"
+#~ msgstr "Bajnok"
+
+#~ msgid "Champions"
+#~ msgstr "Bajnok"
+
+#, fuzzy
+#~ msgid "Paladin"
+#~ msgstr "Paplovag"
+
+#~ msgid "Paladins"
+#~ msgstr "Paplovag"
+
+#, fuzzy
+#~ msgid "Crusader"
+#~ msgstr "Kereszteslovag"
+
+#~ msgid "Crusaders"
+#~ msgstr "Kereszteslovag"
+
+#, fuzzy
+#~ msgid "Goblin"
+#~ msgstr "Goblin"
+
+#~ msgid "Goblins"
+#~ msgstr "Goblin"
+
+#, fuzzy
+#~ msgid "Orc"
+#~ msgstr "Ork"
+
+#~ msgid "Orcs"
+#~ msgstr "Ork"
+
+#, fuzzy
+#~ msgid "Orc Chief"
+#~ msgstr "Ork Vezér"
+
+#~ msgid "Orc Chiefs"
+#~ msgstr "Ork Vezér"
+
+#, fuzzy
+#~ msgid "Wolf"
+#~ msgstr "Farkas"
+
+#~ msgid "Wolves"
+#~ msgstr "Farkas"
+
+#, fuzzy
+#~ msgid "Ogre"
+#~ msgstr "Ogre"
+
+#~ msgid "Ogres"
+#~ msgstr "Ogárok"
+
+#, fuzzy
+#~ msgid "Ogre Lord"
+#~ msgstr "Ogre Nagyúr"
+
+#, fuzzy
+#~ msgid "Troll"
+#~ msgstr "Troll"
+
+#~ msgid "Trolls"
+#~ msgstr "Troll"
+
+#, fuzzy
+#~ msgid "War Troll"
+#~ msgstr "Harci Troll"
+
+#~ msgid "War Trolls"
+#~ msgstr "Harci Troll"
+
+#, fuzzy
+#~ msgid "Cyclops"
+#~ msgstr "Küklopsz"
+
+#~ msgid "Cyclopes"
+#~ msgstr "Küklopszok"
+
+#, fuzzy
+#~ msgid "Sprite"
+#~ msgstr "Tündér"
+
+#~ msgid "Sprites"
+#~ msgstr "Tündér"
+
+#, fuzzy
+#~ msgid "Dwarf"
+#~ msgstr "Törpe"
+
+#~ msgid "Dwarves"
+#~ msgstr "Törpök"
+
+#~ msgid "Elves"
+#~ msgstr "Tündék"
+
+#~ msgid "Grand Elves"
+#~ msgstr "Tünde urak"
+
+#~ msgid "Druids"
+#~ msgstr "Druida"
+
+#~ msgid "Unicorns"
+#~ msgstr "Egyszarvú"
+
+#, fuzzy
+#~ msgid "Phoenixes"
+#~ msgstr "Dzsinn"
+
+#~ msgid "Centaurs"
+#~ msgstr "Kentaur"
+
+#~ msgid "Gargoyles"
+#~ msgstr "Vízköpő"
+
+#~ msgid "Griffins"
+#~ msgstr "Griff"
+
+#~ msgid "Minotaurs"
+#~ msgstr "Minotauroszok"
+
+#~ msgid "Minotaur Kings"
+#~ msgstr "Minotaurusz Király"
+
+#~ msgid "Hydras"
+#~ msgstr "Hidra"
+
+#~ msgid "Green Dragons"
+#~ msgstr "Zöld Sárkány"
+
+#~ msgid "Red Dragons"
+#~ msgstr "Vörös Sárkány"
+
+#~ msgid "Black Dragons"
+#~ msgstr "Fekete Sárkány"
+
+#~ msgid "Halflings"
+#~ msgstr "Hobbit"
+
+#~ msgid "Boars"
+#~ msgstr "Vaddisznó"
+
+#~ msgid "Iron Golems"
+#~ msgstr "Vasgólem"
+
+#~ msgid "Steel Golems"
+#~ msgstr "Acélgólem"
+
+#~ msgid "Rocs"
+#~ msgstr "Sas"
+
+#~ msgid "Magi"
+#~ msgstr "Mágus"
+
+#~ msgid "Archmagi"
+#~ msgstr "Főmágus"
+
+#~ msgid "Giants"
+#~ msgstr "Óriás"
+
+#~ msgid "Titans"
+#~ msgstr "Titán"
+
+#~ msgid "Skeletons"
+#~ msgstr "Csontváz"
+
+#~ msgid "Zombies"
+#~ msgstr "Zombi"
+
+#~ msgid "Mutant Zombies"
+#~ msgstr "Mutáns Zombi"
+
+#~ msgid "Mummies"
+#~ msgstr "Múmiák"
+
+#~ msgid "Royal Mummies"
+#~ msgstr "Királyi múmiák"
+
+#~ msgid "Vampires"
+#~ msgstr "Vámpír"
+
+#~ msgid "Vampire Lords"
+#~ msgstr "Vámpír Nagyúr"
+
+#, fuzzy
+#~ msgid "Lich"
+#~ msgstr "Lich"
+
+#~ msgid "Liches"
+#~ msgstr "Lich-ek"
+
+#, fuzzy
+#~ msgid "Power Lich"
+#~ msgstr "Őslich"
+
+#~ msgid "Power Liches"
+#~ msgstr "Őslich-ek"
+
+#~ msgid "Bone Dragons"
+#~ msgstr "Csontsárkány"
+
+#~ msgid "Rogues"
+#~ msgstr "Rabló"
+
+#~ msgid "Nomads"
+#~ msgstr "Nomád"
+
+#~ msgid "Ghosts"
+#~ msgstr "Szellem"
+
+#~ msgid "Genies"
+#~ msgstr "Dzsinn"
+
+#~ msgid "Medusas"
+#~ msgstr "Medúza"
+
+#~ msgid "Earth Elementals"
+#~ msgstr "Földelementál"
+
+#~ msgid "Air Elementals"
+#~ msgstr "Légelementálok"
+
+#~ msgid "Fire Elementals"
+#~ msgstr "Tűzelementál"
+
+#~ msgid "Water Elementals"
+#~ msgstr "Vízelementál"
+
+#~ msgid "buy"
+#~ msgstr "vásárol"
+
+#~ msgid "Error"
+#~ msgstr "Hiba"
+
+#~ msgid "Abandon All Hope!"
+#~ msgstr "Miden Remény Elveszett!"
+
+#~ msgid "A bit of crystal!"
+#~ msgstr "Egy kevés kristály!"
+
+#~ msgid "A bit of mercury!"
+#~ msgstr "Egy kevés higany!"
+
+#~ msgid "A bit of sulfur!"
+#~ msgstr "Egy kevés kén!"
+
+#~ msgid "a mirror"
+#~ msgstr "egy tükör"
+
+#~ msgid "Antioch"
+#~ msgstr "Antioch"
+
+#~ msgid "A quantity of crystal!"
+#~ msgstr "Egy kupac kristály!"
+
+#~ msgid "A quantity of mercury!"
+#~ msgstr "Egy kupac higany!"
+
+#~ msgid "A quantity of sulfur!"
+#~ msgstr "Egy kupac kén!"
+
+#~ msgid "Arm of the Crusader"
+#~ msgstr "Kereszteslovag Karja"
+
+#~ msgid "Arm of the Cyclops"
+#~ msgstr "Küklopsz Karja"
+
+#~ msgid "Arm of the Dragon"
+#~ msgstr "Sárkány Karja"
+
+#~ msgid "Arm of the Phoenix"
+#~ msgstr "Főnix Karja"
+
+#~ msgid "Arm of the Titan"
+#~ msgstr "Titán Karja"
+
+#~ msgid "Atlantium"
+#~ msgstr "Atlantium"
+
+#~ msgid "Barrowton"
+#~ msgstr "Barrowton"
+
+#~ msgid "Baywatch"
+#~ msgstr "Baywatch"
+
+#~ msgid "Beware the Domain of Dragons"
+#~ msgstr "Óvakodj a sárkány birodalmától"
+
+#~ msgid "Beware the Dragon Leader"
+#~ msgstr "Óvakodj a sárkányvezértől"
+
+#~ msgid "Beware the rocks"
+#~ msgstr "Óvakodj a kövektől"
+
+#~ msgid "Beyond here be Dragons!"
+#~ msgstr "Amott sárkányok vannak!"
+
+#~ msgid "Beyond the door, there be Dragons. BEWARE!"
+#~ msgstr "Az átjárón túl sárkányok vannak. VIGYÁZZ!"
+
+#~ msgid "Bloodreign"
+#~ msgstr "Bloodreign"
+
+#~ msgid "Buried Treasure!"
+#~ msgstr "Eltemetett kincs!"
+
+#~ msgid "Danger, Dragons abound!"
+#~ msgstr "Veszély, sárkányok!"
+
+#~ msgid "DANGER!  QUICKSAND!"
+#~ msgstr "VESZÉLY! FUTÓHOMOK!"
+
+#~ msgid "Deathgate"
+#~ msgstr "Deathgate"
+
+#~ msgid "DeathGate"
+#~ msgstr "DeathGate"
+
+#~ msgid "Dragonburg"
+#~ msgstr "Dragonburg"
+
+#~ msgid "Dragon Hill"
+#~ msgstr "Dragon Hill"
+
+#~ msgid "Dragon Rider"
+#~ msgstr "Sárkánylovas"
+
+#~ msgid "Dragons Everywhere!"
+#~ msgstr "Sárkányok vannak mindenütt!"
+
+#~ msgid "Dragon Town"
+#~ msgstr "Sárkányváros"
+
+#~ msgid "Dragon Wars"
+#~ msgstr "Sárkányharc"
+
+#~ msgid "Dragon Watch"
+#~ msgstr "Sárkányóra"
+
+#~ msgid "Dwarfhall"
+#~ msgstr "Dwarfhall"
+
+#~ msgid "Dwarfhall, Domain of the dwarf King."
+#~ msgstr "Dwarfhall, a Törpekirály birtoka"
+
+#~ msgid "Dwarf Hall, domain of the dwarf King."
+#~ msgstr "Dwarfhall, a Törpekirály birtoka"
+
+#~ msgid "Gate"
+#~ msgstr "Kapu"
+
+#~ msgid "Gate to the Isle of Knowledge"
+#~ msgstr "Kapu a Tudás Szigetére"
+
+#~ msgid "Gate to The Isle of Knowledge"
+#~ msgstr "Kapu a Tudás Szigetére"
+
+#~ msgid "Goblin Island"
+#~ msgstr "Goblinok Szigete"
+
+#~ msgid "Goblin King"
+#~ msgstr "Goblinkirály"
+
+#~ msgid "Green bonus stuff"
+#~ msgstr "bónusz anyag a zöldnek"
+
+#~ msgid "Hail Unicorns!"
+#~ msgstr "Üdvözlet az Egyszarvúnak!"
+
+#~ msgid "Hungry dragons await.  Welcome, food."
+#~ msgstr "Éhes sárkányok várakoznak. Isten hozott, betevő falatom!"
+
+#~ msgid "Isle of Knowledge"
+#~ msgstr "Tudás Szigete"
+
+#~ msgid "King of Death"
+#~ msgstr "Halálkirály"
+
+#~ msgid "Lavalor"
+#~ msgstr "Lavalor"
+
+#~ msgid "Middle Gate"
+#~ msgstr "Middle Gate"
+
+#~ msgid "mirror"
+#~ msgstr "tükör"
+
+#~ msgid "Mountainview"
+#~ msgstr "Mountainview"
+
+#~ msgid "Ogrehild"
+#~ msgstr "Ogrehild"
+
+#~ msgid "Orcville"
+#~ msgstr "Orcville"
+
+#~ msgid "\"Peasants!\""
+#~ msgstr "Parasztok!"
+
+#~ msgid "Peasantsville"
+#~ msgstr "Peasantsville"
+
+#~ msgid "Pig's Eye"
+#~ msgstr "Disznó Szem"
+
+#~ msgid "Portsmith"
+#~ msgstr "Portsmith"
+
+#~ msgid "POSION - DO NOT DRINK"
+#~ msgstr "MÉREG - NE IGYAD MEG"
+
+#~ msgid "Realm of the Undead.  Fresh blood welcome."
+#~ msgstr "Az Élőholtak birodalma. Isten hozott, friss vér!"
+
+#~ msgid "Redshield"
+#~ msgstr "Redshield"
+
+#~ msgid "Road to Isle of Knowledge"
+#~ msgstr "Út a Tudás Szigetére"
+
+#~ msgid "Road to the Isle of Knowledge"
+#~ msgstr "Út a Tudás Szigetére"
+
+#~ msgid "Roc Haven"
+#~ msgstr "Sasmenedék"
+
+#~ msgid "Rogar"
+#~ msgstr "Rogar"
+
+#~ msgid "Roscomon"
+#~ msgstr "Roscomon"
+
+#~ msgid "Sandcaster"
+#~ msgstr "Sandcaster"
+
+#~ msgid "Sansobar"
+#~ msgstr "Sansobar"
+
+#~ msgid "Scabsdale"
+#~ msgstr "Scabsdale"
+
+#~ msgid "Scorched Earth"
+#~ msgstr "Felperzselt Föld"
+
+#~ msgid "Scummy"
+#~ msgstr "Scummy"
+
+#~ msgid "Sharkania"
+#~ msgstr "Sharkania"
+
+#~ msgid "Sheltemburg"
+#~ msgstr "Sheltemburg"
+
+#~ msgid "Sherman"
+#~ msgstr "Sherman"
+
+#~ msgid "Sirein"
+#~ msgstr "Sirein"
+
+#~ msgid "Skirmish"
+#~ msgstr "Skirmish"
+
+#~ msgid "Slugfest"
+#~ msgstr "Slugfest"
+
+#~ msgid "Some crystal!"
+#~ msgstr "Néhány kristály!"
+
+#~ msgid "Some gems!"
+#~ msgstr "Néhány drágakő!"
+
+#~ msgid "Some ore!"
+#~ msgstr "Néhány érc!"
+
+#~ msgid "Some sulfur!"
+#~ msgstr "Néhány kén!"
+
+#~ msgid "Sorpigal"
+#~ msgstr "Sorpigal"
+
+#~ msgid "Stairs"
+#~ msgstr "Lépcsők"
+
+#~ msgid "Stromgild"
+#~ msgstr "Stromgild"
+
+#~ msgid "Stromhild"
+#~ msgstr "Stromhild"
+
+#~ msgid "Subbaculcha"
+#~ msgstr "Subbaculcha"
+
+#~ msgid "Sundune"
+#~ msgstr "Sundune"
+
+#~ msgid "Tacma"
+#~ msgstr "Tacma"
+
+#~ msgid "Tchudes"
+#~ msgstr "Tchudes"
+
+#~ msgid "Teleporters"
+#~ msgstr "Teleportok"
+
+#~ msgid "Terra Firma"
+#~ msgstr "Terra Firma"
+
+#~ msgid "The Back Door"
+#~ msgstr "Hátsó ajtó"
+
+#~ msgid "The Citadel"
+#~ msgstr "Citadella"
+
+#~ msgid "The Kings Road."
+#~ msgstr "Királyok útja"
+
+#~ msgid "The land of Heroes II."
+#~ msgstr "Heroes II. ország"
+
+#~ msgid "The Royal Gardens."
+#~ msgstr "Királyi Kertek"
+
+#~ msgid "The Yellow Lord has the Ultimate Artifact."
+#~ msgstr "A sárga lordnál van a Szent Varázstárgy."
+
+#~ msgid "This bottle is empty."
+#~ msgstr "Ez az üveg üres."
+
+#~ msgid "Timberhill"
+#~ msgstr "Timberhill"
+
+#~ msgid "Time for a refreshing drink."
+#~ msgstr "Itt az idő a frissítő iváshoz."
+
+#~ msgid "TreeHome"
+#~ msgstr "TreeHome"
+
+#~ msgid "Trilobar"
+#~ msgstr "Trilobar"
+
+#~ msgid "Troy"
+#~ msgstr "Troy"
+
+#~ msgid "Tundara"
+#~ msgstr "Tundara"
+
+#~ msgid "Turn Back Now!"
+#~ msgstr "Azonnal fordulj vissza!"
+
+#~ msgid "Turn Back Now or all will be LOST!"
+#~ msgstr "Azonnal fordulj vissza, különben mindennek vége!"
+
+#~ msgid "Turn Back or DIE!"
+#~ msgstr "Fordulj vissza vagy meghalsz!"
+
+#~ msgid "Uncle Leo"
+#~ msgstr "Leo nagybácsi"
+
+#~ msgid "Uncle Milty"
+#~ msgstr "Milty nagybácsi"
+
+#~ msgid "Undead Armies"
+#~ msgstr "Élőholt hadsereg"
+
+#~ msgid "Valley of Death"
+#~ msgstr "Halálvölgy"
+
+#~ msgid "Vaultius"
+#~ msgstr "Vaultius"
+
+#~ msgid "Vertigo"
+#~ msgstr "Vertigo"
+
+#~ msgid "Vikings!"
+#~ msgstr "Vikingek!"
+
+#~ msgid "Vulcania"
+#~ msgstr "Vulcania"
+
+#~ msgid "Wastelands"
+#~ msgstr "Wastelands"
+
+#~ msgid "Weddington"
+#~ msgstr "Weddington"
+
+#~ msgid "Welcome to the Sandbar."
+#~ msgstr "Isten hozta Sandbar-ban!"
+
+#~ msgid "Welcome to the sandy Isle."
+#~ msgstr "Isten hozta Homoksziget-en!"
+
+#~ msgid "Westfork"
+#~ msgstr "Westfork"
+
+#~ msgid "Westmoor"
+#~ msgstr "Westmoor"
+
+#~ msgid "We told you not to drink!"
+#~ msgstr "Mondtuk, hogy ne igyál!"
+
+#~ msgid "Whiteshield"
+#~ msgstr "Whiteshield"
+
+#~ msgid "Who is the true King?"
+#~ msgstr "Ki az igazi király?"
+
+#~ msgid "Wilasher"
+#~ msgstr "Wilasher"
+
+#~ msgid "Wildabar"
+#~ msgstr "Wildabar"
+
+#~ msgid "Wilgatus"
+#~ msgstr "Wilgatus"
+
+#~ msgid "Willow"
+#~ msgstr "Willow"
+
+#~ msgid "Windfall Isle"
+#~ msgstr "Windfall-sziget"
+
+#~ msgid "Winterkill"
+#~ msgstr "Winterkill"
+
+#~ msgid "Winterlands"
+#~ msgstr "Winterlands"
+
+#~ msgid "Wizardwood.  Magicians welcome!"
+#~ msgstr "Wizardwood. Üdvözlet a varázslóknak!"
+
+#~ msgid "Woodhaven"
+#~ msgstr "Woodhaven"
+
+#~ msgid "Woodstock"
+#~ msgstr "Woodstock"
+
+#~ msgid "Woodville"
+#~ msgstr "Woodville"
+
+#~ msgid "Wyrm"
+#~ msgstr "Wyrm"
+
+#~ msgid "Xabran"
+#~ msgstr "Xabran"
+
+#~ msgid "You found Treasure!"
+#~ msgstr "Kincset találtál!"
+
+#~ msgid "Blind "
+#~ msgstr "Vakítás "
 
 #, fuzzy
 #~ msgid "Shoot %{monster} (%{count} shot(s) left)"
@@ -12629,9 +7509,6 @@ msgstr ""
 #~ msgid "Stream Mode"
 #~ msgstr "Sugárzási Mód"
 
-#~ msgid "Road Mode"
-#~ msgstr "Út Mód"
-
 #~ msgid "Erase Mode"
 #~ msgstr "Radít Mód"
 
@@ -12671,9 +7548,6 @@ msgstr ""
 #~ msgid "Used to place a town or castle."
 #~ msgstr "Város vagy kastély elhelyezésére való."
 
-#~ msgid "Monsters"
-#~ msgstr "Szörnyek"
-
 #~ msgid "Used to place a monster group."
 #~ msgstr "Szörnyek elhelyezésére való."
 
@@ -12696,11 +7570,11 @@ msgstr ""
 #~ msgid_plural ""
 #~ "Reduces the movement penalty for rough terrain by %{count} percent."
 #~ msgstr[0] ""
-#~ "Alap Nyomkövetés hatására a nehéz terepen történő haladás büntetése %"
-#~ "{count} százalékkal csökken."
+#~ "Alap Nyomkövetés hatására a nehéz terepen történő haladás büntetése "
+#~ "%{count} százalékkal csökken."
 #~ msgstr[1] ""
-#~ "Alap Nyomkövetés hatására a nehéz terepen történő haladás büntetése %"
-#~ "{count} százalékkal csökken."
+#~ "Alap Nyomkövetés hatására a nehéz terepen történő haladás büntetése "
+#~ "%{count} százalékkal csökken."
 
 #, fuzzy
 #~ msgid ""
@@ -12727,18 +7601,6 @@ msgstr ""
 #~ msgid_plural "Increases your hero's viewable area by %{count} squares."
 #~ msgstr[0] "Alap Felderítés növeli a hős láthatárát %{count} egységgel."
 #~ msgstr[1] "Alap Felderítés növeli a hős láthatárát %{count} egységgel."
-
-#, fuzzy
-#~ msgid ""
-#~ "Approximately %{count} percent of the creatures may offer to join you."
-#~ msgid_plural ""
-#~ "Approximately %{count} percent of the creatures may offer to join you."
-#~ msgstr[0] ""
-#~ "Alap Diplomácia lehetővé teszi, hogy a csapatodnál gyengébb szörnyekkel "
-#~ "tárgyalj. Kb. a lények %{count} százaléka csatlakozhat hozzád."
-#~ msgstr[1] ""
-#~ "Alap Diplomácia lehetővé teszi, hogy a csapatodnál gyengébb szörnyekkel "
-#~ "tárgyalj. Kb. a lények %{count} százaléka csatlakozhat hozzád."
 
 #, fuzzy
 #~ msgid ""
@@ -12907,15 +7769,15 @@ msgstr ""
 #~ msgstr "Megtanulhatod %{level1} %{skill1} vagy %{level2} %{skill2}."
 
 #~ msgid ""
-#~ "Advanced Pathfinding reduces the movement penalty for rough terrain by %"
-#~ "{count} percent."
+#~ "Advanced Pathfinding reduces the movement penalty for rough terrain by "
+#~ "%{count} percent."
 #~ msgstr ""
-#~ "Haladó Nyomkövetés hatására a nehéz terepen történő haladás büntetése %"
-#~ "{count} százalékkal csökken."
+#~ "Haladó Nyomkövetés hatására a nehéz terepen történő haladás büntetése "
+#~ "%{count} százalékkal csökken."
 
 #~ msgid ""
-#~ "Expert Pathfinding eliminates the movement penalty for rough terrain by %"
-#~ "{count} percent."
+#~ "Expert Pathfinding eliminates the movement penalty for rough terrain by "
+#~ "%{count} percent."
 #~ msgstr ""
 #~ "Gyakorlott Nyomkövetés hatására a nehéz terepen történő haladás büntetése "
 #~ "%{count} százalékkal csökken."
@@ -12927,8 +7789,8 @@ msgstr ""
 #~ "Haladó Íjászat növeli a távolsági támadások sebzését %{count} százalékkal."
 
 #~ msgid ""
-#~ "Expert Archery increases the damage done by range attacking creatures by %"
-#~ "{count} percent."
+#~ "Expert Archery increases the damage done by range attacking creatures by "
+#~ "%{count} percent."
 #~ msgstr ""
 #~ "Gyakorlott Íjászat növeli a távolsági támadások sebzését %{count} "
 #~ "százalékkal."
@@ -12970,15 +7832,15 @@ msgstr ""
 #~ "szörnyekkel tárgyalj. Kb. a lények %{count} százaléka csatlakozhat hozzád."
 
 #~ msgid ""
-#~ "Advanced Navigation increases your hero's movement points over water by %"
-#~ "{count} percent."
+#~ "Advanced Navigation increases your hero's movement points over water by "
+#~ "%{count} percent."
 #~ msgstr ""
 #~ "Fejlett Navigáció növeli a hős vízen történő mozgáspontjait %{count} "
 #~ "százalékkal."
 
 #~ msgid ""
-#~ "Expert Navigation increases your hero's movement points over water by %"
-#~ "{count} percent."
+#~ "Expert Navigation increases your hero's movement points over water by "
+#~ "%{count} percent."
 #~ msgstr ""
 #~ "Gyakorlott Navigáció növeli a hős vízen történő mozgáspontjait %{count} "
 #~ "százalékkal."
@@ -13024,14 +7886,8 @@ msgstr ""
 #~ "Gyakorlott Nekromancia segítségével a csatában megölt lények %{count} "
 #~ "százalékából Csontvázakat készíthetünk."
 
-#~ msgid "For valor in combat, %{name} receives %{exp} experience."
-#~ msgstr "Vitézségéért %{name} %{exp} tapasztalati pontot kap."
-
 #~ msgid "Your forces suffer a bitter defeat, and %{name} abandons your cause."
 #~ msgstr "%{name}  szörnyű vereséget szenvedett és elhagyja csapatodat."
-
-#~ msgid "%{tower} does %{dmg} damage."
-#~ msgstr "%{tower} sebzése %{dmg}"
 
 #~ msgid "High morale enables the %{name} to attack again."
 #~ msgstr "A jó morál miatt %{name} újra támadhat"
@@ -13204,9 +8060,6 @@ msgstr ""
 #~ msgid "Customize system options"
 #~ msgstr "Rendszerbeálltások testreszabása"
 
-#~ msgid "animation"
-#~ msgstr "animáció"
-
 #~ msgid "Attack %{name}"
 #~ msgstr "%{name} megtámadása"
 
@@ -13242,9 +8095,6 @@ msgstr ""
 
 #~ msgid "Impossible"
 #~ msgstr "Lehetetlen"
-
-#~ msgid "A single player game playing through a series of maps."
-#~ msgstr "Egyjátékos mód egy csomó pályán át."
 
 #~ msgid "Perhaps you should try again next week."
 #~ msgstr "Talán újra megpróbálhatnád jövő héten."
@@ -13348,9 +8198,6 @@ msgstr ""
 #~ msgid "Caster's Bracelet"
 #~ msgstr "Varázs Karperec"
 
-#~ msgid "Mage's Ring"
-#~ msgstr "Varázsgyűrű"
-
 #~ msgid "The Stealth Shield of Protection increases your defense skill by 2."
 #~ msgstr "A Védelem Titkos Pajzsa növeli a védőerődet 2 ponttal."
 
@@ -13400,9 +8247,6 @@ msgstr ""
 
 #~ msgid "The Minor Scroll of Knowledge increases your knowledge by 2."
 #~ msgstr "A Kis Pergamentekercs növeli a tudásodat 2 ponttal."
-
-#~ msgid "Minor Scroll"
-#~ msgstr "Kis Pergamentekercs"
 
 #~ msgid "The Foremost Scroll of Knowledge increases your knowledge by 5."
 #~ msgstr "A Hatalmas Pergamentekercs növeli a tudásodat 5 ponttal."
@@ -13655,19 +8499,11 @@ msgstr ""
 #~ "mushrooms."
 #~ msgstr "Elkaptál egy manót, aki ostoba módon elaludt egy varázsgombamezőn."
 
-#~ msgid ""
-#~ "The Golden Bow eliminates the 50 percent penalty for your troops shooting "
-#~ "past obstacles. (e.g. castle walls)"
-#~ msgstr "Az Arany Íj eltörli az 50%-os távolsági büntetést."
-
 #~ msgid "Master Swordmen"
 #~ msgstr "Kardforgató mester"
 
 #~ msgid "Dwarf Cottadge"
 #~ msgstr "Törpekunyhó"
-
-#~ msgid "Dragon Sword"
-#~ msgstr "Sárkánykard"
 
 #~ msgid "Giant Flail"
 #~ msgstr "Óriás Cséphadaró"
@@ -13686,9 +8522,6 @@ msgstr ""
 
 #~ msgid "Earthworm"
 #~ msgstr "Earthworm"
-
-#~ msgid "View %{name} info."
-#~ msgstr "%{name} adatai."
 
 #~ msgid ""
 #~ "Advanced Pathfinding reduces the movement penalty for rough terrain by 50 "

--- a/files/lang/lt.po
+++ b/files/lang/lt.po
@@ -6,49 +6,20 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
-"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
-"POT-Creation-Date: 2013-10-09 10:23+0900\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-07-01 15:11+0200\n"
 "PO-Revision-Date: 2014-11-08 12:00+0000\n"
 "Last-Translator: Mantas Kriaučiūnas <mantas@akl.lt>\n"
 "Language-Team: Lithuanian <lt@li.org>\n"
+"Language: lt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"(n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n"
+"%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Launchpad-Export-Date: 2014-12-05 05:56+0000\n"
 "X-Generator: Launchpad (build 17274)\n"
 
-#: ../fheroes2/ai/ai_action.cpp:158 ../fheroes2/heroes/heroes_action.cpp:249
-msgid "Hero %{name} also got a %{count} experience."
-msgstr "Herojus %{name} taip pat gavo %{count} patirties."
-
-#: ../fheroes2/army/army_bar.cpp:220 ../fheroes2/resource/artifact.cpp:964
-msgid "View %{name}"
-msgstr "Žiūrėti %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:226 ../fheroes2/army/army_bar.cpp:309
-msgid "Move or right click to redistribute %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:232 ../fheroes2/army/army_bar.cpp:300
-msgid "Combine %{name} armies"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:237 ../fheroes2/army/army_bar.cpp:291
-#: ../fheroes2/resource/artifact.cpp:976 ../fheroes2/resource/artifact.cpp:998
-msgid "Exchange %{name2} with %{name}"
-msgstr "Sukeisti %{name2} su %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:245 ../fheroes2/resource/artifact.cpp:984
-msgid "Select %{name}"
-msgstr "Pasirinkti %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:297 ../fheroes2/army/army_bar.cpp:306
-msgid "Cannot move last troop"
-msgstr ""
-
-#: ../fheroes2/army/army.cpp:85
 msgid ""
 "A few\n"
 "%{monster}"
@@ -56,7 +27,6 @@ msgstr ""
 "Mažai\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:86
 msgid ""
 "Several\n"
 "%{monster}"
@@ -64,7 +34,6 @@ msgstr ""
 "Keletas\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:87
 msgid ""
 "A pack of\n"
 "%{monster}"
@@ -72,981 +41,1210 @@ msgstr ""
 "Keliolika\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:88
 msgid ""
 "Lots of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:89
 msgid ""
 "A horde of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:90
 msgid ""
 "A throng of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:91
 msgid ""
 "A swarm of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:92
 msgid ""
 "Zounds of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:93
 msgid ""
 "A legion of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Few"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Several"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Pack"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Lots"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Horde"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Throng"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Swarm"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Zounds"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Legion"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:924
 msgid "All %{race} troops +1"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:935
-msgid "Entire unit is undead, so morale does not apply."
-msgstr ""
-
-#: ../fheroes2/army/army.cpp:945
 msgid "Troops of 3 alignments -1"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:953
 msgid "Troops of 4 alignments -2"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:961
 msgid "Troops of 5 alignments -3"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:975
 msgid "Some undead in groups -1"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:762
+msgid "View %{name}"
+msgstr "Žiūrėti %{name}"
+
+msgid "Move or right click to redistribute %{name}"
+msgstr ""
+
+msgid "Combine %{name} armies"
+msgstr ""
+
+msgid "Exchange %{name2} with %{name}"
+msgstr "Sukeisti %{name2} su %{name}"
+
+msgid "Select %{name}"
+msgstr "Pasirinkti %{name}"
+
+msgid "Cannot move last troop"
+msgstr ""
+
+msgid "%{name} half the enemy troops!"
+msgstr ""
+
 msgid "Set auto battle off"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:767
 msgid "Set auto battle on"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:877
 msgid "spell failed!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:679
 msgid ""
 "The Sphere of Negation artifact is in effect for this battle, disabling all "
 "combat spells."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:688
 msgid "You have already cast a spell this round."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:694
-#: ../fheroes2/battle/battle_arena.cpp:742
 msgid "That spell will affect no one!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:713
 msgid "You may only summon one type of elemental per combat."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:719
-msgid ""
-"There is no open space adjacent to your hero to summon an Elemental to."
+msgid "There is no open space adjacent to your hero to summon an Elemental to."
 msgstr ""
 
-#: ../fheroes2/battle/battle_board.cpp:968
 msgid ""
 "The Moat reduces by -%{count} the defense skill of any unit and slows to "
 "half movement rate."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:50
-msgid "speed: %{speed}"
+msgid "Speed"
+msgstr "Greitis"
+
+msgid "Speed: %{speed}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:165
+msgid "Auto Spell Casting"
+msgstr ""
+
+msgid "Grid"
+msgstr ""
+
+msgid "Shadow Movement"
+msgstr ""
+
+msgid "Shadow Cursor"
+msgstr ""
+
+msgid "On"
+msgstr ""
+
+msgid "Off"
+msgstr ""
+
 msgid "The enemy has surrendered!"
 msgstr "Priešas pasidavė!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:168
 msgid "The enemy has fled!"
 msgstr "Priešas pabėgo!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:170
-#: ../fheroes2/battle/battle_dialogs.cpp:256
 msgid "A glorious victory!"
 msgstr "Šlovinga pergalė!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:175
-msgid "For valor in combat, %{name} receives %{exp} experience"
+msgid "For valor in combat, %{name} receives %{exp} experience."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:184
 msgid "The cowardly %{name} flees from battle."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:191
 msgid "%{name} surrenders to the enemy, and departs in shame."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:197
 msgid "Your force suffer a bitter defeat, and %{name} abandons your cause."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:249
 msgid "Your force suffer a bitter defeat."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:296
 msgid "Battlefield Casualties"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:300
 msgid "Attacker"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:312
 msgid "Defender"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:394
+msgid "You have captured an enemy artifact!"
+msgstr "Jūs gavote magišką artefaktą iš priešo!"
+
+msgid "Necromancy!"
+msgstr ""
+
+msgid ""
+"Practicing the dark arts of necromancy, you are able to raise %{count} of "
+"the enemy's dead to return under your service as %{monster}."
+msgstr ""
+
 msgid "%{name} the %{race}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:401
-#: ../fheroes2/castle/castle_well.cpp:311
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:194
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:834
-#: ../fheroes2/heroes/skill.cpp:167
 msgid "Attack"
 msgstr "Puolimas"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:406
-#: ../fheroes2/castle/castle_well.cpp:317
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:206
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:844
-#: ../fheroes2/heroes/skill.cpp:167
 msgid "Defense"
 msgstr "Gynyba"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:411
-#: ../fheroes2/castle/castle_town.cpp:310
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:854
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:142
-#: ../fheroes2/heroes/heroes_meeting.cpp:292
 msgid "Spell Power"
 msgstr "Burtų galia"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:416
-#: ../fheroes2/castle/castle_town.cpp:319
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:864
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:147
-#: ../fheroes2/heroes/heroes_meeting.cpp:296 ../fheroes2/heroes/skill.cpp:167
 msgid "Knowledge"
 msgstr "Išmanymas"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:421
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:276
 msgid "Morale"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:426
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:286 ../fheroes2/heroes/skill.cpp:354
 msgid "Luck"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:431
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:874
-#: ../fheroes2/heroes/heroes_indicator.cpp:247
 msgid "Spell Points"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
-#: ../fheroes2/gui/interface_buttons.cpp:189
+msgid "Hero's Options"
+msgstr ""
+
 msgid "Cast Spell"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
-msgid ""
-"Cast a magical spell. You may only cast one spell per combat round. The "
-"round is reset when every creature has had a turn"
-msgstr ""
-
-#: ../fheroes2/battle/battle_dialogs.cpp:488
 msgid "Retreat"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:488
+msgid "Surrender"
+msgstr "Pasiduoti"
+
+msgid "Cancel"
+msgstr "Atsisakyti"
+
+msgid "Hero Screen"
+msgstr ""
+
+msgid ""
+"Cast a magical spell. You may only cast one spell per combat round. The "
+"round is reset when every creature has had a turn."
+msgstr ""
+
 msgid ""
 "Retreat your hero, abandoning your creatures. Your hero will be available "
 "for you to recruit again, however, the hero will have only a novice hero's "
 "forces."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:491
-msgid "Surrender"
-msgstr "Pasiduoti"
-
-#: ../fheroes2/battle/battle_dialogs.cpp:491
 msgid ""
 "Surrendering costs gold. However if you pay the ransom, the hero and all of "
 "his or her surviving creatures will be available to recruit again."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:166
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:227
-msgid "Cancel"
-msgstr "Atsisakyti"
+msgid "Open Hero Screen to view full information about the hero."
+msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
 msgid "Return to the battle."
 msgstr "Grįžti į mūšį."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:549
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:438
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:497
 msgid "Not enough gold (%{gold})"
 msgstr "Neužtenka aukso (%{gold})"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:564
 msgid "%{name} states:"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:569
 msgid ""
-"I will accept your surrender and grant you and your troops safe passage for "
-"the price of %{price} gold."
+"\"I will accept your surrender and grant you and your troops safe passage "
+"for the price of %{price} gold.\""
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:610
-#: ../fheroes2/battle/battle_interface.cpp:1371
 msgid "View %{monster} info."
 msgstr "Žiūrėti %{monster} informaciją."
 
-#: ../fheroes2/battle/battle_interface.cpp:1379
-msgid "Shoot %{monster} (%{count} shot(s) left)"
-msgstr ""
+#, fuzzy
+msgid "Shoot %{monster}"
+msgstr "Pulti %{monster}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1399
 msgid "Attack %{monster}"
 msgstr "Pulti %{monster}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1411
 msgid "Fly %{monster} here."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1411
 msgid "Move %{monster} here."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1417
-#: ../fheroes2/battle/battle_interface.cpp:1506
 msgid "Turn %{turn}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Teleport Here"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1447
 msgid "Invalid Teleport Destination"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1453
 msgid "Cast %{spell} on %{monster}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1463
 msgid "Cast %{spell}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1469
 msgid "Select Spell Target"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1644
-msgid "Spell cast"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:1656
 msgid "View Ballista Info"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1669
-#: ../fheroes2/battle/battle_tower.cpp:53
 msgid "Ballista"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1682
 msgid "Auto combat"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1689
 msgid "Customize system options."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1697
 msgid "Wait this unit"
 msgstr "Šis karys palauks"
 
-#: ../fheroes2/battle/battle_interface.cpp:1704
 msgid "Skip this unit"
 msgstr "Šis karys praleis ėjimą"
 
-#: ../fheroes2/battle/battle_interface.cpp:1712
-#: ../fheroes2/battle/battle_interface.cpp:1744
-msgid "Hero's Options"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:1723
-#: ../fheroes2/battle/battle_interface.cpp:1755
 msgid "View Opposing Hero"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1810
 msgid "Hide logs"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1810
 msgid "Show logs"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1848
 msgid "%{color} cast spell: %{spell}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2150
 msgid "%{name} skipping turn"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2151
-msgid ", and get +2 defense"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:2154
 msgid "%{name} waiting turn"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2291
 msgid "%{attacker} do %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2311
-#: ../fheroes2/battle/battle_interface.cpp:2712
-msgid "one creature perishes."
-msgid_plural "%{count} creatures perish."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/battle/battle_interface.cpp:2323
-#: ../fheroes2/battle/battle_interface.cpp:2898
-msgid "one %{defender} perishes."
-msgid_plural "%{count} %{defender} perish."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/battle/battle_interface.cpp:2446
 msgid "Moved %{monster}: %{src}, %{dst}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2561
+#, fuzzy
+msgid "Moved %{monster}"
+msgstr ""
+"Keletas\n"
+"%{monster}"
+
 msgid "The %{name} resist the spell!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2574
 msgid "%{name} casts %{spell} on the %{troop}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2579
 msgid "%{name} casts %{spell}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2700
-msgid "The %{spell} spell does %{damage} damage to all undead creatures."
+msgid "The %{spell} does %{damage} damage to one undead creature."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2703
-msgid "The %{spell} spell does %{damage} damage to all living creatures."
+msgid "The %{spell} does %{damage} damage to all undead creatures."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2705
+msgid "The %{spell} does %{damage} damage, %{count} creatures perish."
+msgstr ""
+
 msgid "The %{spell} does %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2746
+msgid "The %{spell} does %{damage} damage to one living creature."
+msgstr ""
+
+msgid "The %{spell} does %{damage} damage to all living creatures."
+msgstr ""
+
 msgid "The Unicorns attack blinds the %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2747
 msgid "The Medusas gaze turns the %{name} to stone!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2749
 msgid "The Mummies' curse falls upon the %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2750
 msgid "The %{name} are paralyzed by the Cyclopes!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2751
 msgid "The Archmagi dispel all good spells on your %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2769
-msgid "Good luck shines on the  %{attacker}"
+msgid "Good luck shines on the %{attacker}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2821
 msgid "Bad luck descends on the %{attacker}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2833
 msgid "High morale enables the %{monster} to attack again."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2840
 msgid "Low morale causes the %{monster} to freeze in panic."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2893
-msgid "Tower do %{damage} damage."
+msgid "%{tower} does %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:3206
 msgid "MirrorImage created"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:3754
-msgid "MirrorImage ended"
+msgid "The mirror image is destroyed!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4096
+msgid "Break auto battle?"
+msgstr ""
+
 msgid "No spells to cast."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4105
 msgid "Are you sure you want to retreat?"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4127
-msgid "You don't have enough gold!"
-msgstr "Jums neužtenka aukso!"
+msgid "Retreat disabled"
+msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4193
+#, fuzzy
+msgid "Surrender disabled"
+msgstr "Pasiduoti"
+
 msgid "Damage: %{max}"
 msgstr "Žala: %{max}"
 
-#: ../fheroes2/battle/battle_interface.cpp:4193
 msgid "Damage: %{min} - %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4206
 msgid "Perish: %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4206
 msgid "Perish: %{min} - %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_main.cpp:190
-msgid "You have captured an enemy artifact!"
-msgstr "Jūs gavote magišką artefaktą iš priešo!"
-
-#: ../fheroes2/battle/battle_main.cpp:241
 msgid ""
 "Through eagle-eyed observation, %{name} is able to learn the magic spell "
 "%{spell}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_main.cpp:280
-msgid ""
-"Practicing the dark arts of necromancy, you are able to raise %{count} of "
-"the enemy's dead to return under your service as %{monster}"
-msgstr ""
-
-#: ../fheroes2/battle/battle_tower.cpp:47 ../fheroes2/castle/castle.cpp:468
 msgid "Left Turret"
 msgstr "Kairysis bokštelis"
 
-#: ../fheroes2/battle/battle_tower.cpp:48 ../fheroes2/castle/castle.cpp:469
 msgid "Right Turret"
 msgstr "Dešinysis bokštelis"
 
-#: ../fheroes2/battle/battle_tower.cpp:122
 msgid "The %{name} fires with the strength of %{count} Archers"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:123
 msgid "each with a +%{attack} bonus to their attack skill."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:863
-msgid "%{name} half the enemy troops!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_troop.cpp:950
 msgid ""
 "The %{artifact} artifact is in effect for this battle, disabling %{spell} "
 "spell."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:1598
 msgid "%{count} %{name} rise(s) from the dead!"
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:258
+#, fuzzy
+msgid "Sorceress Guild"
+msgstr "Vagių gildija"
+
+msgid "Necromancer Guild"
+msgstr ""
+
+#, fuzzy
+msgid "Dragon Alliance"
+msgstr "Drakonų miestas"
+
+msgid "Elven Alliance"
+msgstr ""
+
+msgid "Wayward Son"
+msgstr ""
+
+msgid "Uncle Ivan"
+msgstr ""
+
+msgid "Force of Arms"
+msgstr ""
+
+msgid "Annexation"
+msgstr ""
+
+msgid "Save the Dwarves"
+msgstr ""
+
+#, fuzzy
+msgid "Carator Mines"
+msgstr "Kristalų kasykla"
+
+msgid "Turning Point"
+msgstr ""
+
+msgid "The Gauntlet"
+msgstr ""
+
+#, fuzzy
+msgid "The Crown"
+msgstr "Rytų miestas."
+
+msgid "Corlagon's Defense"
+msgstr ""
+
+msgid "Final Justice"
+msgstr ""
+
+msgid "First Blood"
+msgstr ""
+
+msgid "Barbarian Wars"
+msgstr ""
+
+msgid "Necromancers"
+msgstr ""
+
+msgid "Slay the Dwarves"
+msgstr ""
+
+msgid "Rebellion"
+msgstr ""
+
+msgid "Dragon Master"
+msgstr ""
+
+msgid "Country Lords"
+msgstr ""
+
+msgid "Greater Glory"
+msgstr ""
+
+msgid "Apocalypse"
+msgstr ""
+
+msgid "Uprising"
+msgstr ""
+
+msgid "Island of Chaos"
+msgstr ""
+
+msgid "Arrow's Flight"
+msgstr ""
+
+msgid "The Abyss"
+msgstr ""
+
+msgid "The Giant's Pass"
+msgstr ""
+
+msgid "Aurora Borealis"
+msgstr ""
+
+msgid "Betrayal's End"
+msgstr ""
+
+msgid "Corruption's Heart"
+msgstr ""
+
+msgid "Conquer and Unify"
+msgstr ""
+
+#, fuzzy
+msgid "Border Towns"
+msgstr "Rodyti miestus"
+
+msgid "The Wayward Son"
+msgstr ""
+
+msgid "Crazy Uncle Ivan"
+msgstr ""
+
+msgid "The Southern War"
+msgstr ""
+
+msgid "Ivory Gates"
+msgstr ""
+
+msgid "The Elven Lands"
+msgstr ""
+
+msgid "The Epic Battle"
+msgstr ""
+
+msgid "The Shrouded Isles"
+msgstr ""
+
+#, fuzzy
+msgid "The Eternal Scrolls"
+msgstr "Rytų miestas."
+
+msgid "Power's End"
+msgstr ""
+
+msgid "Fount of Wizardry"
+msgstr ""
+
+msgid "Stranded"
+msgstr ""
+
+msgid "Pirate Isles"
+msgstr ""
+
+msgid "King and Country"
+msgstr ""
+
+msgid "Blood is Thicker"
+msgstr ""
+
+msgid ""
+"Roland needs you to defeat the lords near his castle to begin his war of "
+"rebellion against his brother.  They are not allied with each other, so they "
+"will spend most of their time fighting with one another.  Victory is yours "
+"when you have defeated all of their castles and heroes."
+msgstr ""
+
+msgid ""
+"The local lords refuse to swear allegiance to Roland, and must be subdued. "
+"They are wealthy and powerful, so be prepared for a tough fight. Capture all "
+"enemy castles to win."
+msgstr ""
+
+msgid ""
+"Your task is to defend the Dwarves against Archibald's forces. Capture all "
+"of the enemy towns and castles to win, and be sure not to lose all of the "
+"dwarf towns at once, or the enemy will have won."
+msgstr ""
+
+msgid ""
+"You will face four allied enemies in a straightforward fight for resource "
+"and treasure. Capture all of the enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Your enemies are allied against you and start close by, so be ready to come "
+"out fighting. You will need to own all four castles in this small valley to "
+"win."
+msgstr ""
+
+msgid ""
+"The Sorceress' guild of Noraston has requested Roland's aid against an "
+"attack from Archibald's allies. Capture all of the enemy castles to win, and "
+"don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy "
+"castle on an island in the ocean.)"
+msgstr ""
+
+msgid ""
+"Gather as large an army as possible and capture the enemy castle within 8 "
+"weeks. You are opposed by only one enemy, but must travel a long way to get "
+"to the enemy castle. Any troops you have in your army at the end of this "
+"scenario will be with you in the final battle."
+msgstr ""
+
+msgid ""
+"Find the Crown before Archibald's heroes find it. Roland will need the Crown "
+"for the final battle against Archibald."
+msgstr ""
+
+msgid ""
+"Three allied enemies stand before you and victory, including Lord Corlagon. "
+"Roland is in a castle to the northwest, and you will lose if he falls to the "
+"enemy. Remember that capturing Lord Corlagon will ensure that he will not "
+"fight against you in the final scenario."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Archibald to end the war!"
+msgstr ""
+
+msgid ""
+"King Archibald requires you to defeat the three enemies in this region.  "
+"They are not allied with one another, so they will spend most of their "
+"energy fighting amongst themselves.  You will win when you own all of the "
+"enemy castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"You must unify the barbarian tribes of the north by conquering them. As in "
+"the previous mission, the enemy is not allied against you, but they have "
+"more resources at their disposal. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"Do-gooder wizards have taken the Necromancers' castle. You must retake it to "
+"achieve victory. Remember that while you start with a powerful army, you "
+"have no castle and must take one within 7 days, or lose this battle. (Hint: "
+"The nearest castle is to the southeast.)"
+msgstr ""
+
+msgid ""
+"The dwarves need conquering before they can interfere in King Archibald's "
+"plans. Roland's forces have more than one hero and many towns to start with, "
+"so be ready for attack from multiple directions. You must capture all of the "
+"enemy towns and castles to claim victory."
+msgstr ""
+
+msgid ""
+"You must put down a peasant revolt led by Roland's forces. All are allied "
+"against you, but you have Lord Corlagon, an experienced hero, to help you. "
+"Capture all enemy castles to win."
+msgstr ""
+
+msgid ""
+"There are two enemies allied against you in this mission. Both are well "
+"armed and seek to evict you from their island. Avoid them and capture Dragon "
+"City to win"
+msgstr ""
+
+msgid ""
+"Your orders are to conquer the country lords that have sworn to serve "
+"Roland. All of the enemy castles are unified against you. Since you start "
+"without a castle, you must hurry to capture one before the end of the week. "
+"Capture all enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Find the Crown before Roland's heroes find it. Archibald will need the Crown "
+"for the final battle against Roland."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Roland to win the war, and be sure "
+"not to lose Archibald in the fight!"
+msgstr ""
+
+msgid ""
+"Subdue the unruly local lords in order to provide the Empire with facilities "
+"to operate in this region."
+msgstr ""
+
+msgid ""
+"Eliminate all oposition in this area. Then the first piece of the artifact "
+"will be yours."
+msgstr ""
+
+msgid ""
+"The sorceresses to the northeast are rebelling! For the good of the empire "
+"you must quash their feeble uprising on your way to the mountains."
+msgstr ""
+
+msgid ""
+"Having prepared for your arrival, Kraeger has arranged for a force of "
+"necromancers to thwart your quest. You must capture the castle of Scabsdale "
+"before the first day of the third week, or the Necromancers will be too "
+"strong for you."
+msgstr ""
+
+msgid ""
+"The barbarian despot in this area is, as yet, ignorant of your presence. "
+"Quickly, build up your forces before you are discovered and attacked! Secure "
+"the region by subduing all enemy forces."
+msgstr ""
+
+msgid ""
+"The Empire is weak in this region. You will be unable to completely subdue "
+"all forces in this area, so take what you can before reprisal strikes. "
+"Remember, your true goal is to claim the Helmet of Anduran."
+msgstr ""
+
+msgid "For the good of the Empire, eliminate Kraeger."
+msgstr ""
+
+msgid ""
+"At last, you have the opportunity and the facilities to rid the Empire of "
+"the necromancer's evil. Eradicate them completely, and you will be sung as a "
+"hero for all time."
+msgstr ""
+
+msgid ""
+"Conquer and unite all the enemy tribes. Don't lose the hero Jarkonas, the "
+"forefather of all descendants."
+msgstr ""
+
+msgid ""
+"Your rival, the Kingdom of Harondale, is attacking weak towns on your "
+"border! Recover from their first strike and crush them completely!"
+msgstr ""
+
+msgid ""
+"Find your wayward son Joseph who is rumored to be living in the desolate "
+"lands. Do it before the first day of the third month or it will be of no "
+"help to your family."
+msgstr ""
+
+msgid ""
+"Rescue your crazy uncle Ivan. Find him before the first day of the fourth "
+"month or it will be no help to your kingdom."
+msgstr ""
+
+msgid ""
+"Destroy the barbarians who are attacking the southern border of your "
+"kingdom! Recover your fallen towns, and then invade the jungle kingdom. "
+"Leave no enemy standing."
+msgstr ""
+
+msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
+msgstr ""
+
+msgid ""
+"Gain the favor of the elves. They will not allow trees to be chopped down, "
+"so they will send you wood every 2 weeks. You must complete your mission "
+"before the first day of the seventh month, or the kingdom will surely fall."
+msgstr ""
+
+msgid ""
+"This is the final battle against your rival kingdom of Harondale. Eliminate "
+"everyone, and don't lose the hero Jarkonas VI."
+msgstr ""
+
+msgid ""
+"Your mission is to vanquish the warring mages in the magical Shrouded Isles. "
+"The completion of this task will give you a fighting chance against your "
+"rivals."
+msgstr ""
+
+msgid ""
+"The location of the great library has been dicovered! You must make your way "
+"to it, and reclaim the city of Chronos in which it lies."
+msgstr ""
+
+msgid ""
+"Find the Orb of negation, which is said to be buried in this land. There are "
+"clues inscribed on stone obelisks which will help lead you to your price. "
+"Find the orb before the first day of the sixth month, or your rivals will "
+"surely have gotten to the fount before you."
+msgstr ""
+
+msgid ""
+"You must take control of the castle of Magic, where the fount of wizardry "
+"lies. Do this and your victory will be supreme."
+msgstr ""
+
+msgid ""
+"Capture the town on the island off the southeast shore in order to construct "
+"a boat and travel back towards the mainland. Do not lose the hero Gallavant."
+msgstr ""
+
+msgid ""
+"Find and defeat Martine, the pirate leader, who resides in Pirates Cove. Do "
+"not lose Gallavant or your quest will be over."
+msgstr ""
+
+msgid ""
+"Eliminate all the other forces who oppose the rule of Lord Alberon. "
+"Gallavant must not die."
+msgstr ""
+
+msgid ""
+"Overthrow the entrenched monarchy of Lord Alberon, and claim all the land in "
+"your name. Gallavant must not die."
+msgstr ""
+
+msgid " bane"
+msgstr ""
+
+msgid " alliance"
+msgstr ""
+
+msgid "Carry-over forces"
+msgstr ""
+
+msgid " bonus"
+msgstr ""
+
+msgid " defeated"
+msgstr ""
+
+msgid "Thunder Mace"
+msgstr ""
+
+msgid "Minor Scroll"
+msgstr ""
+
+#, fuzzy
+msgid "Dragon Sword"
+msgstr "Drakonų miestas"
+
+#, fuzzy
+msgid "Breastplate"
+msgstr "Turgus"
+
+msgid "Fibzin Medal"
+msgstr ""
+
+msgid "Mage's ring"
+msgstr ""
+
+#, fuzzy
+msgid "Defender Helm"
+msgstr "Gynybos įgūdis"
+
+msgid "Power Axe"
+msgstr ""
+
+msgid "Summon Earth"
+msgstr ""
+
 msgid "The %{building} produces %{monster}."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:505
 msgid "Requires:"
 msgstr "Reikalauja:"
 
-#: ../fheroes2/castle/buildinginfo.cpp:597
 msgid "Cannot build. Already built here this turn."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:601
 msgid "For this action it is necessary first to build a castle."
 msgstr "Pradžioje būtina pastatyti pilį."
 
-#: ../fheroes2/castle/buildinginfo.cpp:623
 msgid "Cannot build %{name} because castle is too far from water."
 msgstr "Negalima statyti %{name} kadangi pilis yra per toli nuo vandens."
 
-#: ../fheroes2/castle/buildinginfo.cpp:631
-msgid "Cannot afford %{name}"
+msgid "Cannot afford %{name}."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:636
-msgid "%{name} is already built"
+msgid "%{name} is already built."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:641
-msgid "Cannot build %{name}"
+msgid "Cannot build %{name}."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:646
-msgid "Build %{name}"
-msgstr ""
+#, fuzzy
+msgid "Build %{name}."
+msgstr "Žiūrėti %{name}"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Thieves' Guild"
 msgstr "Vagių gildija"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Tavern"
 msgstr "Taverna"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Shipyard"
 msgstr "Laivų  statykla"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Well"
 msgstr "Šulinys"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Statue"
 msgstr "Statula"
 
-#: ../fheroes2/castle/castle.cpp:469
-#: ../fheroes2/dialog/dialog_marketplace.cpp:212
 msgid "Marketplace"
 msgstr "Turgus"
 
-#: ../fheroes2/castle/castle.cpp:469
 msgid "Moat"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:469 ../fheroes2/maps/mp2.cpp:391
 msgid "Castle"
 msgstr "Pilis"
 
-#: ../fheroes2/castle/castle.cpp:469
 msgid "Tent"
 msgstr "Palapinė"
 
-#: ../fheroes2/castle/castle.cpp:469
 msgid "Captain's Quarters"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:469
 msgid "Mage Guild, Level 1"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Mage Guild, Level 2"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Mage Guild, Level 3"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Mage Guild, Level 4"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Mage Guild, Level 5"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Farm"
 msgstr "Ferma"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Garbage Heap"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Crystal Garden"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Waterfall"
 msgstr "Krioklys"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Orchard"
 msgstr "Vaisių sodas"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Skull Pile"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:474
 msgid "Fortifications"
 msgstr "Įtvirtinimai"
 
-#: ../fheroes2/castle/castle.cpp:474
 msgid "Coliseum"
 msgstr "Koliziejus"
 
-#: ../fheroes2/castle/castle.cpp:474
 msgid "Rainbow"
 msgstr "Vaivorykštė"
 
-#: ../fheroes2/castle/castle.cpp:474
 msgid "Dungeon"
 msgstr "Požemiai"
 
-#: ../fheroes2/castle/castle.cpp:474
 msgid "Library"
 msgstr "Biblioteka"
 
-#: ../fheroes2/castle/castle.cpp:474
 msgid "Storm"
 msgstr "Audra"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/maps/mp2.cpp:498
 msgid "Thatched Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Treehouse"
 msgstr "Namelis medyje"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/maps/mp2.cpp:441
 msgid "Cave"
 msgstr "Urvas"
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Habitat"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/maps/mp2.cpp:431
 msgid "Excavation"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478 ../fheroes2/castle/castle.cpp:479
 msgid "Archery Range"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Stick Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Cottage"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478 ../fheroes2/castle/castle.cpp:485
 msgid "Crypt"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478 ../fheroes2/castle/castle.cpp:485
 msgid "Pen"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478 ../fheroes2/maps/mp2.cpp:371
 msgid "Graveyard"
 msgstr "Kapinės"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Blacksmith"
 msgstr "Kalvė"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
 msgid "Den"
 msgstr "Ola"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
 msgid "Nest"
 msgstr "Lizdas"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Foundry"
 msgstr "Liejykla"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:482
-#: ../fheroes2/castle/castle.cpp:489 ../fheroes2/maps/mp2.cpp:427
-#: ../fheroes2/resource/maps_text.cpp:521
 msgid "Pyramid"
 msgstr "Piramidė"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Armory"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Adobe"
 msgstr "Moliniai nameliai"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Stonehenge"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Maze"
 msgstr "Labirintas"
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Cliff Nest"
 msgstr "Lizdas ant uolos"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Mansion"
 msgstr "Apleisti rūmai"
 
-#: ../fheroes2/castle/castle.cpp:481
 msgid "Jousting Arena"
 msgstr "Riterių arena"
 
-#: ../fheroes2/castle/castle.cpp:481
 msgid "Bridge"
 msgstr "Tiltas"
 
-#: ../fheroes2/castle/castle.cpp:481 ../fheroes2/castle/castle.cpp:488
 msgid "Fenced Meadow"
 msgstr "Aptverta pieva"
 
-#: ../fheroes2/castle/castle.cpp:481 ../fheroes2/castle/castle.cpp:488
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Swamp"
 msgstr "Pelkė"
 
-#: ../fheroes2/castle/castle.cpp:481
 msgid "Ivory Tower"
 msgstr "Burtininkų bokštas"
 
-#: ../fheroes2/castle/castle.cpp:481
 msgid "Mausoleum"
 msgstr "Mauzoliejus"
 
-#: ../fheroes2/castle/castle.cpp:482
 msgid "Cathedral"
 msgstr "Katedra"
 
-#: ../fheroes2/castle/castle.cpp:482 ../fheroes2/castle/castle.cpp:489
 msgid "Red Tower"
 msgstr "Raudonas bokštas"
 
-#: ../fheroes2/castle/castle.cpp:482
 msgid "Green Tower"
 msgstr "Žalias bokštas"
 
-#: ../fheroes2/castle/castle.cpp:482
 msgid "Cloud Castle"
 msgstr "Dangaus pilis"
 
-#: ../fheroes2/castle/castle.cpp:482 ../fheroes2/castle/castle.cpp:489
 msgid "Laboratory"
 msgstr "Laboratorija"
 
-#: ../fheroes2/castle/castle.cpp:485 ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Archery Range"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Stick Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Cottage"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Graveyard"
 msgstr "Geresnės kapinės"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Blacksmith"
 msgstr "Geresnė kalvė"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Foundry"
 msgstr "Geresnė liejykla"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Pyramid"
 msgstr "Didžioji piramidė"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Armory"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Adobe"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Stonehenge"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Maze"
 msgstr "Tobulesnis labirintas"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Mansion"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:488
 msgid "Upg. Jousting Arena"
 msgstr "Geresnė riterių arena"
 
-#: ../fheroes2/castle/castle.cpp:488
 msgid "Upg. Bridge"
 msgstr "Tobulesnis tiltas"
 
-#: ../fheroes2/castle/castle.cpp:488
 msgid "Upg. Ivory Tower"
 msgstr "Tobulesnis burtininkų bokštas"
 
-#: ../fheroes2/castle/castle.cpp:488
 msgid "Upg. Mausoleum"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:489
 msgid "Upg. Cathedral"
 msgstr "Geresnė katedra"
 
-#: ../fheroes2/castle/castle.cpp:489
 msgid "Upg. Cloud Castle"
 msgstr "Geresnė dangaus pilis"
 
-#: ../fheroes2/castle/castle.cpp:490
 msgid "Black Tower"
 msgstr "Juodas bokštas"
 
-#: ../fheroes2/castle/castle.cpp:492
 msgid "Shrine"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:554
 msgid ""
 "The Thieves' Guild provides information on enemy players. Thieves' Guilds "
-"can also provide scouting information on enemy towns."
+"can also provide scouting information on enemy towns. Additional Guilds "
+"provide more information."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:555
 msgid "The Tavern increases morale for troops defending the castle."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:556
 msgid "The Shipyard allows ships to be built."
 msgstr "Laivų statykla leidžia statyti laivus."
 
-#: ../fheroes2/castle/castle.cpp:557
 msgid ""
 "The Well increases the growth rate of all dwellings by %{count} creatures "
 "per week."
 msgstr ""
 "Šulinys padidina prieaugį visuose būstuose % {count} būtybėm per savaitę."
 
-#: ../fheroes2/castle/castle.cpp:558
 msgid "The Statue increases your town's income by %{count} per day."
 msgstr "Statula padidina jūsų miesto pajamas %{count} auksinių per dieną."
 
-#: ../fheroes2/castle/castle.cpp:559
 msgid "The Left Turret provides extra firepower during castle combat."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:560
 msgid "The Right Turret provides extra firepower during castle combat."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:561
 msgid ""
 "The Marketplace can be used to convert one type of resource into another. "
 "The more marketplaces you control, the better the exchange rate."
@@ -1055,13 +1253,11 @@ msgstr ""
 "gyvsidabrį). Kuo daugiau turėsite turgų, tuo geresniu santykiu galėsite "
 "keisti."
 
-#: ../fheroes2/castle/castle.cpp:562
 msgid ""
 "The Moat slows attacking units. Any unit entering the moat must end its turn "
 "there and becomes more vulnerable to attack."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:563
 msgid ""
 "The Castle improves town defense and increases income to %{count} gold per "
 "day."
@@ -1069,381 +1265,353 @@ msgstr ""
 "Pilis sustiprina miesto gynybą bei padidina pajamas %{count} aukso monetų "
 "per dieną."
 
-#: ../fheroes2/castle/castle.cpp:564
 msgid ""
 "The Tent provides workers to build a castle, provided the materials and the "
 "gold are available."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:565
 msgid ""
 "The Captain's Quarters provides a captain to assist in the castle's defense "
 "when no hero is present."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:566
 msgid ""
 "The Mage Guild allows heroes to learn spells and replenish their spell "
 "points."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:569
 msgid "The Farm increases production of Peasants by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:570
-msgid ""
-"The Garbage Heap increases production of Goblins by %{count} per week."
+msgid "The Garbage Heap increases production of Goblins by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:571
 msgid ""
 "The Crystal Garden increases production of Sprites by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:572
 msgid "The Waterfall increases production of Centaurs by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:573
 msgid "The Orchard increases production of Halflings by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:574
-msgid ""
-"The Skull Pile increases production of Skeletons by %{count} per week."
+msgid "The Skull Pile increases production of Skeletons by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:577
 msgid ""
 "The Fortifications increase the toughness of the walls, increasing the "
 "number of turns it takes to knock them down."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:578
 msgid ""
 "The Coliseum provides inspiring spectacles to defending troops, raising "
 "their morale by two during combat."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:579
 msgid "The Rainbow increases the luck of the defending units by two."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:580
 msgid "The Dungeon increases the income of the town by %{count} / day."
 msgstr ""
 "Požeminiai rūsiai padidina jūsų miesto pajamas %{count} auksinių per dieną."
 
-#: ../fheroes2/castle/castle.cpp:581
 msgid ""
 "The Library increases the number of spells in the Guild by one for each "
 "level of the guild."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:582
 msgid "The Storm adds +2 to the power of spells of a defending spell caster."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:584
 msgid ""
 "The Shrine increases the necromancy skill of all your necromancers by 10 "
 "percent."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:634
 msgid "Cannot recruit - you already recruit hero in current week."
 msgstr "Negalima samdyti - šią savaitę jūs jau pasamdėte herojų."
 
-#: ../fheroes2/castle/castle.cpp:647
 msgid "Cannot recruit - guest to guard automove error."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:653
 msgid "Cannot recruit - you already have a Hero in this town."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:661
 msgid "Cannot recruit - you have too many Heroes."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:667
 msgid "Cannot afford a Hero"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:758
 msgid "There is no room in the garrison for this army."
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:271
+msgid "Recruit %{name}"
+msgstr "Pasamdyti %{name}"
+
 msgid "Month: %{month}, Week: %{week}, Day: %{day}"
 msgstr "Mėnuo: %{month}, Savaitė: %{week}, Diena: %{day}"
 
-#: ../fheroes2/castle/castle_dialog.cpp:601
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
+msgid "Income"
+msgstr ""
+
+msgid "Join Error"
+msgstr ""
+
+msgid "Army is full"
+msgstr ""
+
+msgid ""
+"You must purchase a spell book to use the mage guild, but you currently have "
+"no room for a spell book. Try giving one of your artifacts to another hero."
+msgstr ""
+
 msgid "Town"
 msgstr "Miestelis"
 
-#: ../fheroes2/castle/castle_dialog.cpp:601
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
 msgid "This town may not be upgraded to a castle."
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:715
-msgid "Exit castle"
+#, fuzzy
+msgid "Exit Castle"
 msgstr "Išeiti iš pilies"
 
-#: ../fheroes2/castle/castle_dialog.cpp:715
-msgid "Exit town"
+#, fuzzy
+msgid "Exit Town"
 msgstr "Išeiti iš miesto"
 
-#: ../fheroes2/castle/castle_dialog.cpp:718
-msgid "Show income"
+msgid "Show Income"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:722
 msgid "Show previous town"
 msgstr "Rodyti ankstesnį miestą"
 
-#: ../fheroes2/castle/castle_dialog.cpp:726
 msgid "Show next town"
 msgstr "Rodyti kitą miestą"
 
-#: ../fheroes2/castle/castle_dialog.cpp:729
 msgid "Swap Heroes"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:732
 msgid "Meeting Heroes"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:737
 msgid "View Hero"
 msgstr ""
 
-#: ../fheroes2/castle/castle_mageguild.cpp:150
+#, fuzzy
+msgid "The above spells are available here."
+msgstr "Šie burtai buvo įdėti į jūsų knygą."
+
 msgid "The above spells have been added to your book."
 msgstr "Šie burtai buvo įdėti į jūsų knygą."
 
-#: ../fheroes2/castle/castle_tavern.cpp:39
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:747
 msgid "A generous tip for the barkeep yields the following rumor:"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:54
 msgid "Recruit Hero"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:59
-msgid "%{name} is a level %{value} %{race}"
+msgid "%{name} is a level %{value} %{race} "
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with %{count} artifacts"
-msgstr ""
-
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with one artifact"
+#, fuzzy
+msgid "with %{count} artifacts."
 msgstr " su vienu artefaktu"
 
-#: ../fheroes2/castle/castle_town.cpp:283
-#: ../fheroes2/heroes/heroes_dialog.cpp:108
+#, fuzzy
+msgid "with 1 artifact."
+msgstr " su vienu artefaktu"
+
+#, fuzzy
+msgid "without artifacts."
+msgstr " su vienu artefaktu"
+
 msgid ""
 "'Spread' combat formation spreads your armies from the top to the bottom of "
 "the battlefield, with at least one empty space between each army."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:284
 msgid ""
 "'Grouped' combat formation bunches your army toget her in the center of your "
 "side of the battlefield."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:292
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:132
-#: ../fheroes2/heroes/heroes_meeting.cpp:284
 msgid "Attack Skill"
 msgstr "Puolimo įgūdis"
 
-#: ../fheroes2/castle/castle_town.cpp:301
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:137
-#: ../fheroes2/heroes/heroes_meeting.cpp:288
 msgid "Defense Skill"
 msgstr "Gynybos įgūdis"
 
-#: ../fheroes2/castle/castle_town.cpp:487
-#: ../fheroes2/heroes/heroes_dialog.cpp:334
 msgid "Spread Formation"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:489
-#: ../fheroes2/heroes/heroes_dialog.cpp:337
 msgid "Grouped Formation"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:540
-#: ../fheroes2/castle/castle_town.cpp:553
 msgid "Recruit %{name} the %{race}"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:561
 msgid "Set garrison combat formation to 'Spread'"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:564
 msgid "Set garrison combat formation to 'Grouped'"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:567
+#, fuzzy
+msgid "Exit Castle Options"
+msgstr "Išeiti iš pilies"
+
 msgid "Castle Options"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:158
-msgid "Buy Monsters:"
+msgid "Not enough resources to buy monsters."
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:221
+msgid "No monsters available for purchase."
+msgstr ""
+
+msgid "Buy Monsters"
+msgstr ""
+
 msgid "Town Population Information and Statistics"
 msgstr "Miesto gyventojų informacija bei statistika"
 
-#: ../fheroes2/castle/castle_well.cpp:323
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:231
 msgid "Damage"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:329
 msgid "HP"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:335
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:266
-msgid "Speed"
-msgstr "Greitis"
-
-#: ../fheroes2/castle/castle_well.cpp:351
 msgid "Growth"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:355
 msgid "week"
 msgstr "savait."
 
-#: ../fheroes2/castle/castle_well.cpp:361
-#: ../fheroes2/kingdom/kingdom_overview.cpp:478
 msgid "Available"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:89
 msgid "View the entire world."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:90
 msgid "View the obelisk puzzle."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:91
 msgid "View information on the scenario you are currently playing."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:92
 msgid "Dig for the Ultimate Artifact."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:93
 msgid "Exit this menu without doing anything."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_arena.cpp:48
+msgid "Arena"
+msgstr ""
+
 msgid ""
 "You enter the arena and face a pack of vicious lions. You handily defeat "
 "them, to the wild cheers of the crowd.  Impressed by your skill, the aged "
 "trainer of gladiators agrees to train you in a skill of your choice."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:154
-msgid ""
-"Your troops can be upgraded, but it will cost you %{ratio} times the "
-"difference in cost for each troop, rounded up to next highest number. Do you "
-"wish to upgrade them?"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:155
 msgid ""
 "Your troops can be upgraded, but it will cost you dearly. Do you wish to "
 "upgrade them?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:166
 msgid "Are you sure you want to dismiss this army?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots Left"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots"
 msgstr "Šūviai"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:244
 msgid "Hit Points"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:255
 msgid "Hit Points Left"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:379
+#, fuzzy
+msgid "Followers"
+msgstr "Burtų galia"
+
 msgid ""
-"The creature is swayed by your diplomatic tongue, and offers to join your "
+"A group of %{monster} with a desire for greater glory wish to join you.\n"
+"Do you accept?"
+msgstr ""
+
+msgid ""
+"The %{monster} is swayed by your diplomatic tongue, and offers to join your "
 "army for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:382
 msgid ""
 "The creatures are swayed by your diplomatic\n"
 "tongue, and make you an offer:\n"
 " \n"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:385
 msgid ""
 "%{offer} of the %{total} %{monster} will join your army, and the rest will "
 "leave you alone, for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:387
 msgid ""
 "All %{offer} of the %{monster} will join your army for the sum of %{gold} "
 "gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:401
 msgid "(Rate: %{percent})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:451
-msgid ""
-"Not room in\n"
-"the garrison"
+msgid "No room in"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:48
+msgid "the garrison"
+msgstr ""
+
 msgid "Build a new ship:"
 msgstr "Statyti naują laivą:"
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:63
 msgid "Resource cost:"
 msgstr "Išteklio kaina:"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:40
-msgid "For the QVGA version is not available."
+msgid "Load Game"
+msgstr "Įkelti žaidimą"
+
+msgid "No save files to load."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:62
+msgid "New Game"
+msgstr ""
+
+msgid "Start a single or multi-player game."
+msgstr ""
+
+msgid "Load a previously saved game."
+msgstr "Atverti prieš tai įrašytą žaidimą"
+
+#, fuzzy
+msgid "Save Game"
+msgstr "Įkelti žaidimą"
+
+msgid "Save the current game."
+msgstr ""
+
+msgid "Quit"
+msgstr ""
+
+msgid "Quit out of Free Heroes of Might and Magic II."
+msgstr ""
+
 msgid ""
 "Map\n"
 "Difficulty"
@@ -1451,7 +1619,6 @@ msgstr ""
 "Žemėlapis\n"
 "Sudėtingumas"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:65
 msgid ""
 "Game\n"
 "Difficulty"
@@ -1459,972 +1626,873 @@ msgstr ""
 "Žaidimas\n"
 "Sudėtingumas"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:68
 msgid "Rating"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:71
 msgid "Map Size"
 msgstr "Pasaulio dydis"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:89
-#: ../fheroes2/system/players.cpp:663
 msgid "Opponents"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:92
-#: ../fheroes2/system/players.cpp:667
 msgid "Class"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:100
 msgid ""
 "Victory\n"
 "Conditions"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:106
 msgid ""
 "Loss\n"
 "Conditions"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:168
 msgid "You cannot select %{resource}!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:174
 msgid "Select count %{resource}:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:201
 msgid "Set Guardian"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:237
-#: ../fheroes2/dialog/dialog_guardian.cpp:293
 msgid "Your army too big!"
 msgstr "Jūsų armija per didelė!"
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:34
-#: ../fheroes2/dialog/dialog_levelup.cpp:44
-#: ../fheroes2/dialog/dialog_levelup.cpp:74
 msgid "%{name} has gained a level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:36
-#: ../fheroes2/dialog/dialog_levelup.cpp:46
-#: ../fheroes2/dialog/dialog_levelup.cpp:76
-msgid "%{skill} Skill +1"
-msgstr ""
+#, fuzzy
+msgid "%{skill} +1"
+msgstr "Žiūrėti %{skill} informaciją"
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:51
 msgid "You have learned %{skill}."
 msgstr "Jūs išmokote %{skill}."
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:94
 msgid "You may learn either:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:97
 msgid "or"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:66
 msgid ""
 "Please inspect our fine wares. If you feel like offering a trade, click on "
 "the items you wish to trade with and for."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:104
 msgid ""
 "You have received quite a bargain. I expect to make no profit on the deal. "
 "Can I interest you in any of my other wares?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:130
 msgid "I can offer you %{count} for 1 unit of %{resfrom}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:136
 msgid "I can offer you 1 unit of %{resto} for %{count} units of %{resfrom}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:164
 msgid "Qty to trade"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:235
+msgid "Trading Post"
+msgstr ""
+
 msgid "Your Resources"
 msgstr "Tavo ištekliai"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:257
 msgid "Available Trades"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:573
 msgid "n/a"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:77
-msgid "guarded by %{count} of %{monster}"
+msgid "guarded by %{count} %{monster}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:149
 msgid "(available: %{count})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:181
 msgid "already learned"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:205
 msgid "already knows this skill"
 msgstr "jau moka šį įgūdį"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:212
 msgid "already has max skills"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:260
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:276
 msgid "(already visited)"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
 msgid "(not visited)"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:296
+msgid "Road"
+msgstr ""
+
+msgid "(digging ok)"
+msgstr ""
+
+msgid "(no digging)"
+msgstr ""
+
 msgid "penalty: %{cost}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:382
-msgid "Unchartered Territory"
+msgid "Uncharted Territory"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:635
 msgid "Defenders:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:674
-#: ../fheroes2/heroes/heroes_indicator.cpp:125
-#: ../fheroes2/heroes/heroes_indicator.cpp:171
 msgid "None"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:756
-msgid "%{name} ( Level %{level} )"
+msgid "Unknown"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:884
+msgid "%{name} (Level %{level})"
+msgstr ""
+
 msgid "Move Points"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:40
-#: ../fheroes2/dialog/dialog_recrut.cpp:579
 msgid "Available: %{count}"
 msgstr "Yra: %{count}"
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:101
-msgid "Cost per troop:"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:107
-#: ../fheroes2/dialog/dialog_recrut.cpp:506
-msgid "Recruit %{name}"
-msgstr "Pasamdyti %{name}"
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:210
 msgid "Number to buy:"
 msgstr "Norimas kiekis:"
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:314
 msgid "How many troops to move?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:358
 msgid "Fast separation into slots:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:172
 msgid "File to Save:"
 msgstr "Įrašyti į failą:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:178
 msgid "File to Load:"
 msgstr "Failas įkėlimui:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:294
 msgid "Are you sure you want to delete file:"
 msgstr "Ar jūs tikrai norite ištrinti failą:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:297
 msgid "Warning!"
 msgstr "Įspėjimas!"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:144
-msgid "Maps Difficulty:"
+#, fuzzy
+msgid "Map difficulty:"
+msgstr ""
+"Žemėlapis\n"
+"Sudėtingumas"
+
+msgid "No maps exist at that size"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:296
 msgid "Small Maps"
 msgstr "Maži žemėlapiai"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:296
-msgid "View only maps of size small (36x36)."
+msgid "View only maps of size small (36 x 36)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:298
 msgid "Medium Maps"
 msgstr "Vidutiniai žemėlapiai"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:298
-msgid "View only maps of size medium (72x72)."
+msgid "View only maps of size medium (72 x 72)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
 msgid "Large Maps"
 msgstr "Dideli žemėlapiai"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
-msgid "View only maps of size large (108x108)."
+msgid "View only maps of size large (108 x 108)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
 msgid "Extra Large Maps"
 msgstr "Ypač dideli žemėlapiai"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
-msgid "View only maps of size extra large (144x144)."
+msgid "View only maps of size extra large (144 x 144)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
 msgid "All Maps"
 msgstr "Visi žemėlapiai"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
 msgid "View all maps, regardless of size."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
 msgid "Players Icon"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
 msgid ""
-"Indicates how many players total are in the EditScenario. Any positions not "
+"Indicates how many players total are in the scenario. Any positions not "
 "occupied by humans will be occupied by computer players."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "Size Icon"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid ""
-"Indicates whether the maps is small (36x36), medium (72x72), large "
-"(108x108), or extra large (144x144)."
+"Indicates whether the map\n"
+"is small (36 x 36), medium\n"
+"(72 x 72), large (108 x 108),\n"
+"or extra large (144 x 144)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
 msgid "Selected Name"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
 msgid "The name of the currently selected map."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:328
 msgid "Selected Map Difficulty"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:328
 msgid ""
 "The map difficulty of the currently selected map.  The map difficulty is "
-"determined by the EditScenario designer. More difficult maps might include "
-"more or stronger enemies, fewer resources, or other special conditions "
-"making things tougher for the human player."
+"determined by the scenario designer. More difficult maps might include more "
+"or stronger enemies, fewer resources, or other special conditions making "
+"things tougher for the human player."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:330
 msgid "Selected Description"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:330
 msgid "The description of the currently selected map."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
-msgid "OK"
-msgstr "Gerai"
+msgid "Okay"
+msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid "Accept the choice made."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:360
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose all your heroes and towns."
 msgstr "Prarasti visus savo herojus bei miestus."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:361
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific town."
 msgstr "Prarasti konkretų miestą."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:362
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific hero."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:363
 msgid "Run out of time. Fail to win by a certain point."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:366
 msgid "Loss Condition"
 msgstr "Pralaimėjimo sąlygos"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:375
 msgid "Defeat all enemy heroes and towns."
 msgstr "Nugalėti visus priešų herojus bei miestus."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:376
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Capture a specific town."
 msgstr "Užimti konkretų miestą."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:377
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat a specific hero."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:378
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Find a specific artifact."
 msgstr "Rasti konkretų magišką artefaktą."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:379
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Your side defeats the opposing side."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:380
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Accumulate a large amount of gold."
 msgstr "Sukaupti labai daug aukso."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:383
 msgid "Victory Condition"
 msgstr "Pergalės salygos"
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:48
-#: ../fheroes2/heroes/heroes_action.cpp:135
 msgid "one"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:51
-#: ../fheroes2/heroes/heroes_action.cpp:136
 msgid "two"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:189
-msgid "sound"
+msgid "Music"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:194
-#: ../fheroes2/dialog/dialog_system.cpp:207
-#: ../fheroes2/dialog/dialog_system.cpp:230
-#: ../fheroes2/dialog/dialog_system.cpp:244
-msgid "off"
+msgid "Toggle ambient music level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:202
-msgid "music"
+msgid "Effects"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:225
-msgid "hero speed"
+msgid "Toggle foreground sounds level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:239
-msgid "ai speed"
+msgid "Music Type"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:253
-msgid "scroll speed"
+msgid "Change the type of music."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:264
-#: ../fheroes2/dialog/dialog_system.cpp:278
+#, fuzzy
+msgid "Hero Speed"
+msgstr "Greitis"
+
+msgid "Change the speed at which your heroes move on the main screen."
+msgstr ""
+
+#, fuzzy
+msgid "Enemy Speed"
+msgstr "Greitis"
+
+msgid ""
+"Sets the speed that A.I. heroes move at.  You can also elect not to view A."
+"I. movement at all."
+msgstr ""
+
+msgid "Scroll Speed"
+msgstr ""
+
+msgid "Sets the speed at which you scroll the window."
+msgstr ""
+
+msgid "Interface Type"
+msgstr ""
+
+msgid "Toggle the type of interface you want to use."
+msgstr ""
+
 msgid "Interface"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:267
+msgid "Toggle interface visibility."
+msgstr ""
+
+msgid "Battles"
+msgstr ""
+
+msgid "Toggle instant battle mode."
+msgstr ""
+
+msgid "OK"
+msgstr "Gerai"
+
+#, fuzzy
+msgid "Exit this menu."
+msgstr "Šis karys palauks"
+
+msgid "off"
+msgstr ""
+
+msgid "MIDI"
+msgstr ""
+
+#, fuzzy
+msgid "MIDI Expansion"
+msgstr "Apleisti rūmai"
+
+msgid "CD Stereo"
+msgstr ""
+
+msgid "External"
+msgstr ""
+
+msgid "Jump"
+msgstr ""
+
+msgid "Don't Show"
+msgstr ""
+
 msgid "Evil"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:269
 msgid "Good"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:283
 msgid "Hide"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:289
 msgid "Show"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:285
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:96
+msgid "Auto Resolve"
+msgstr ""
+
+msgid "Auto, No Spells"
+msgstr ""
+
+msgid "Manual"
+msgstr ""
+
+msgid "Att."
+msgstr ""
+
+msgid "Def."
+msgstr ""
+
+msgid "Power"
+msgstr ""
+
+#, fuzzy
+msgid "Knowl"
+msgstr "Išmanymas"
+
+msgid "Human"
+msgstr ""
+
 msgid "1st"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:286
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:97
 msgid "2nd"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:98
 msgid "3rd"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:288
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:99
 msgid "4th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:289
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:100
 msgid "5th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:290
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:101
 msgid "6th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:305
-msgid "Thieves' Guild: Player RanKings"
+msgid "Oracle: Player Rankings"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:315
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:114
+#, fuzzy
+msgid "Thieves' Guild: Player Rankings"
+msgstr "Vagių gildija"
+
 msgid "Number of Towns:"
 msgstr "Miestų kiekis:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:324
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:123
 msgid "Number of Castles:"
 msgstr "Pilių kiekis:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:333
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:132
 msgid "Number of Heroes:"
 msgstr "Herojų kiekis:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:342
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:141
 msgid "Gold in Treasury:"
 msgstr "Aukso saugyklose:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:351
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:150
 msgid "Wood & Ore:"
 msgstr "Mediena bei rūda:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:360
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:159
 msgid "Gems, Cr, Slf & Mer:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:369
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:168
 msgid "Obelisks Found:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:378
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:177
+#, fuzzy
+msgid "Artifacts:"
+msgstr "Magiškas artefaktas"
+
 msgid "Total Army Strength:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:387
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:186
 msgid "Income:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:408
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:211
 msgid "Best Hero:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:417
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:220
 msgid "Best Hero Stats:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:426
 msgid "Personality:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:435
 msgid "Best Monster:"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Easy"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Normal"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Hard"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Expert"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Impossible"
 msgstr ""
 
-#: ../fheroes2/game/game.cpp:313
-msgid "Maps Loading..."
+msgid "Map is loading..."
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:96
-msgid "Are you sure you want to overwrite the save with this name?"
+msgid "and more..."
 msgstr ""
-"Ar tikrai norite perrašyti anksčiau tuo pačiu pavadinimu įrašytą failą?"
 
-#: ../fheroes2/game/game_io.cpp:218
+msgid "Campaign Scenario loading failure"
+msgstr ""
+
+msgid "Please make sure that campaign files are correct and present."
+msgstr ""
+
+msgid "Unknown Hero"
+msgstr ""
+
+msgid "Your Name"
+msgstr ""
+
 msgid ""
-"This file is saved in the \"Price Loyalty\" version.\n"
+"Invalid file game type. Please ensure that you are running the latest type "
+"of save files."
+msgstr ""
+
+msgid ""
+"This file is saved in the \"The Price of Loyalty\" version.\n"
 "Some items may be unavailable."
 msgstr ""
 
-#: ../fheroes2/game/game_mainmenu.cpp:157
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:95
-msgid "Quit"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:157
-msgid "Quit Heroes of Might and Magic and return to the operating system."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:79
-msgid "Load Game"
-msgstr "Įkelti žaidimą"
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-msgid "Load a previously saved game."
-msgstr "Atverti prieš tai įrašytą žaidimą"
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:91
-msgid "Credits"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-msgid "View the credits screen."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:87
-msgid "High Scores"
-msgstr "Geriausi rezultatai"
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-msgid "View the high score screen."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:75
-msgid "New Game"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-msgid "Start a single or multi-player game."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid "Host"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid ""
-"The host sets up the game options. There can only be one host per network "
-"game."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid "Guest"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid ""
-"The guest waits for the host to set up the game, then is automatically added "
-"in. There can be multiple guests for TCP/IP games."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-msgid "Cancel back to the main menu."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:214
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:154
-msgid "Standard Game"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:214
-msgid "A single player game playing out a single map."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:216
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:162
-msgid "Multi-Player Game"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:216
-msgid ""
-"A multi-player game, with several human players completing against each "
-"other on a single map."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:217
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:83
-msgid "Settings"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:217
-msgid "FHeroes2 game settings."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:271
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:219
 msgid "Hot Seat"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:271
 msgid ""
 "Play a Hot Seat game, where 2 to 4 players play around the same computer, "
 "switching into the 'Hot Seat' when it is their turn."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:279
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:223
+msgid "Cancel back to the main menu."
+msgstr ""
+
 msgid "Network"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:279
 msgid ""
 "Play a network game, where 2 players use their own computers connected "
 "through a LAN (Local Area Network)."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:343
+msgid "Standard Game"
+msgstr ""
+
+msgid "A single player game playing out a single map."
+msgstr ""
+
+msgid "Campaign Game"
+msgstr ""
+
+msgid "A single player game playing through a series of maps."
+msgstr ""
+
+msgid "Multi-Player Game"
+msgstr ""
+
+msgid ""
+"A multi-player game, with several human players completing against each "
+"other on a single map."
+msgstr ""
+
+msgid "Greetings!"
+msgstr ""
+
+msgid ""
+"Welcome to Free Heroes of Might and Magic II! Before starting the game "
+"please choose game resolution."
+msgstr ""
+
+msgid "Please Remember"
+msgstr ""
+
+msgid "You can always change game resolution by clicking on the "
+msgstr ""
+
+msgid "door"
+msgstr ""
+
+msgid ""
+" on the left side of main menu.\n"
+"\n"
+"To switch between windowed and full screen modes\n"
+"press "
+msgstr ""
+
+msgid "F4"
+msgstr ""
+
+msgid ""
+" key on the keyboard.\n"
+"\n"
+"Enjoy the game!"
+msgstr ""
+
+msgid "Quit Heroes of Might and Magic and return to the operating system."
+msgstr ""
+
+msgid "Credits"
+msgstr ""
+
+msgid "View the credits screen."
+msgstr ""
+
+msgid "High Scores"
+msgstr "Geriausi rezultatai"
+
+msgid "View the high score screen."
+msgstr ""
+
+msgid "Select Game Resolution"
+msgstr ""
+
+msgid "Change resolution of the game."
+msgstr ""
+
+msgid "Original Campaign"
+msgstr ""
+
+msgid ""
+"Either Roland's or Archibald's campaign from the original Heroes of Might "
+"and Magic II."
+msgstr ""
+
+msgid "Expansion Campaign"
+msgstr ""
+
+msgid "One of the four new campaigns from the Price of Loyalty expansion set."
+msgstr ""
+
+msgid "Host"
+msgstr ""
+
+msgid ""
+"The host sets up the game options. There can only be one host per network "
+"game."
+msgstr ""
+
+msgid "Guest"
+msgstr ""
+
+msgid ""
+"The guest waits for the host to set up the game, then is automatically added "
+"in. There can be multiple guests for TCP/IP games."
+msgstr ""
+
+msgid "Battle Only"
+msgstr ""
+
+msgid "Setup and play a battle without loading any map."
+msgstr ""
+
+msgid "Settings"
+msgstr ""
+
+msgid "Experimental game settings."
+msgstr ""
+
 msgid "2 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:343
 msgid ""
 "Play with 2 human players, and optionally, up, to 4 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid "3 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid ""
 "Play with 3 human players, and optionally, up, to 3 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid "4 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid ""
 "Play with 4 human players, and optionally, up, to 2 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid "5 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid ""
 "Play with 5 human players, and optionally, up, to 1 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "6 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "Play with 6 human players."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat all enemy heroes and capture all enemy towns and castles."
 msgstr ""
 "Nugalėti visus priešo herojus bei užimti visas priešo pilis bei miestelius."
 
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Run out of time. (Fail to win by a certain point.)"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the castle '%{name}'"
 msgstr "Užimti pilį '%{name}'"
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the town '%{name}'"
 msgstr "Užimti miestą '%{name}'"
 
-#: ../fheroes2/game/game_over.cpp:83
 msgid "Defeat the hero '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:91
 msgid "Find the ultimate artifact"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:95
 msgid "Find the '%{name}' artifact"
 msgstr "Rasti magišką artefaktą '%{name}'"
 
-#: ../fheroes2/game/game_over.cpp:102
 msgid "Accumulate %{count} gold"
 msgstr "Sukaupti %{count} aukso"
 
-#: ../fheroes2/game/game_over.cpp:106
 msgid ""
 ", or you may win by defeating all enemy heroes and capturing all enemy towns "
 "and castles."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the castle '%{name}'."
 msgstr "Prarasti pilį '%{name}'."
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the town '%{name}'."
 msgstr "Prarasti miestą '%{name}'."
 
-#: ../fheroes2/game/game_over.cpp:126 ../fheroes2/game/game_over.cpp:145
 msgid "Lose the hero: %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:133
 msgid "Fail to win by the end of month %{month}, week %{week}, day %{day}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:145
 msgid "Lose the heroes: %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:167
 msgid ""
 "You captured %{name}!\n"
 "You are victorious."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:175
 msgid ""
 "You have captured the enemy hero %{name}!\n"
 "Your quest is complete."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:183
 msgid ""
 "You have found the %{name}.\n"
 "Your quest is complete."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:195
 msgid ""
 "The enemy is beaten.\n"
 "Your side has triumphed!"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:200
 msgid ""
 "You have built up over %{count} gold in your treasury.\n"
 "All enemies bow before your wealth and power."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:222
 msgid ""
 "The enemy has found the %{name}.\n"
 "Your quest is a failure."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:230
 msgid ""
 "%{color} has fallen!\n"
 "All is lost."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:237
 msgid ""
 "The enemy has built up over %{count} gold in his treasury.\n"
 "You must bow done in defeat before his wealth and power."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:243
 msgid "You have been eliminated from the game!!!"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:248
 msgid ""
 "The enemy has captured %{name}!\n"
 "They are triumphant."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:256 ../fheroes2/game/game_over.cpp:263
 msgid ""
 "You have lost the hero %{name}.\n"
 "Your quest is over."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:270
 msgid ""
 "You have failed to complete your quest in time.\n"
 "All is lost."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:318
-msgid "%{color} has been vanquished!"
+msgid "%{color} player has been vanquished!"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "Warning"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "No maps available!"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Scenario"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Click here to select which scenario to play."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid "Game Difficulty"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid ""
 "This lets you change the starting difficulty at which you will play. Higher "
 "difficulty levels start you of with fewer resources, and at the higher "
 "settings, give extra resources to the computer."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid "Difficulty Rating"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid ""
 "The difficulty rating reflects a combination of various settings for your "
 "game. This number will be applied to your final score."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
 msgid "Click to accept these settings and start a new game."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
 msgid "Click to return to the main menu."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:342
 msgid "Scenario:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:350
 msgid "Game Difficulty:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:354
 msgid "Opponents:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:358
 msgid "Class:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:384
 msgid "Rating %{rating}%"
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:231
 msgid "Astrologers proclaim Month of the %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:231
 msgid "Astrologers proclaim Week of the %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:245
 msgid "After regular growth, population of %{monster} is doubled!"
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:246
-msgid ""
-"After regular growth, population of %{monter} increase on %{count} percent!"
-msgid_plural ""
-"After regular growth, population of %{monter} increase on %{count} percent!"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/game/game_startgame.cpp:249
-msgid "%{monster} population increases by +%{count}."
-msgid_plural "%{monster} population increases by +%{count}."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/game/game_startgame.cpp:257
 msgid " All populations are halved."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:259
 msgid " All dwellings increase population."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:288
 msgid ""
 "%{color} player, your heroes abandon you, and you are banished from this "
 "land."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:295
 msgid ""
 "%{color} player, this is your last day to capture a town, or you will be "
 "banished from this land."
@@ -2432,7 +2500,6 @@ msgstr ""
 "%{color} žaidėjau, šiandien bus paskutinė tavo diena šiame žaidime, jei "
 "neužimsi kokio nors miesto."
 
-#: ../fheroes2/game/game_startgame.cpp:300
 msgid ""
 "%{color} player, you only have %{day} days left to capture a town, or you "
 "will be banished from this land."
@@ -2440,145 +2507,121 @@ msgstr ""
 "%{color} žaidėjau, tau liko tik %{day} dienos šiame žaidime - jei neužimsi "
 "kokio nors miesto, būsi pašalintas."
 
-#: ../fheroes2/game/game_startgame.cpp:589
-msgid "%{color} player's turn"
+msgid "%{color} player's turn."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:1000
 msgid ""
 "%{color} player, you have lost your last town. If you do not conquer another "
 "town in next week, you will be eliminated."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Next Hero"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Select the next Hero."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue Movement"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue the Hero's movement along the current path."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "Kingdom Summary"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "View a Summary of your Kingdom."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:189
 msgid "Cast an adventure spell."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End Turn"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End your turn and left the computer take its turn."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Adventure Options"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Bring up the adventure options menu."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "File Options"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "Bring up the file options menu, alloving you to load menu, save etc."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "System Options"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
-msgid ""
-"Bring up the system options menu, alloving you to customize your game."
+msgid "Bring up the system options menu, alloving you to customize your game."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:176
 msgid ""
 "One or more heroes may still move, are you sure you want to end your turn?"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:213
-msgid "Are you sure you want to restart? (Your current game will be lost)"
-msgstr ""
-
-#: ../fheroes2/gui/interface_events.cpp:276
 msgid "Are you sure you want to quit?"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:308
-msgid "Game saved successfully."
-msgstr "Žaidimas sėkmingai įrašytas."
-
-#: ../fheroes2/gui/interface_events.cpp:314
-msgid ""
-"Are you sure you want to load a new game? (Your current game will be lost)"
+#, fuzzy
+msgid "Are you sure you want to restart? (Your current game will be lost.)"
 msgstr ""
 "Ar tikrai norite įkelti anksčiau įrašytą žaidimą? (Dabartinis žaidimas bus "
 "prarastas, jei neįrašėte)"
 
-#: ../fheroes2/gui/interface_events.cpp:353
+msgid "Are you sure you want to overwrite the save with this name?"
+msgstr ""
+"Ar tikrai norite perrašyti anksčiau tuo pačiu pavadinimu įrašytą failą?"
+
+msgid "Game saved successfully."
+msgstr "Žaidimas sėkmingai įrašytas."
+
+msgid "There was an issue during saving."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Are you sure you want to load a new game? (Your current game will be lost.)"
+msgstr ""
+"Ar tikrai norite įkelti anksčiau įrašytą žaidimą? (Dabartinis žaidimas bus "
+"prarastas, jei neįrašėte)"
+
 msgid "Try looking on land!!!"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:368
 msgid ""
-"After spending many hours digging here, you have uncovered the %{artifact}"
+"After spending many hours digging here, you have uncovered the %{artifact}."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:370
 msgid "Congratulations!"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:384
 msgid "Nothing here. Where could it be?"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:395
 msgid "Try searching on clear ground."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:399
 msgid "Digging for artifacts requires a whole day, try again tomorrow."
 msgstr ""
 "Magiško artefakto kasinėjimas užima visą dieną - bandykite dar kartą rytoj."
 
-#: ../fheroes2/gui/interface_radar.cpp:400
 msgid "World Map"
 msgstr ""
 
-#: ../fheroes2/gui/interface_radar.cpp:400
 msgid "A miniature view of the known world. Left click to move viewing area."
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:216
 msgid "Month: %{month} Week: %{week}"
 msgstr "Mėnuo: %{month} Savaitė: %{week}"
 
-#: ../fheroes2/gui/interface_status.cpp:222
-#: ../fheroes2/kingdom/kingdom_overview.cpp:568
 msgid "Day: %{day}"
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:257
 msgid ""
 "You find a small\n"
 "quantity of %{resource}."
@@ -2586,85 +2629,327 @@ msgstr ""
 "Jūs radote šiek\n"
 "tiek %{resource}."
 
-#: ../fheroes2/gui/interface_status.cpp:407
 msgid "Status Window"
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:407
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date."
+msgstr ""
+
 msgid ""
 "This window provides information on the status of your hero or kingdom, and "
 "shows the date. Left click here to cycle throungh these windows."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:113
+msgid "Necroman"
+msgstr ""
+
+msgid ""
+"This lets you change player starting positions and colors. A particular "
+"color will always start in a particular location. Some positions may only be "
+"played by a computer player or only by a human player."
+msgstr ""
+
+msgid ""
+"This lets you change the class of a player. Classes are not always "
+"changeable. Depending on the scenario, a player may receive additional towns "
+"and/or heroes not of their primary alignment."
+msgstr ""
+
+msgid "%{color} player"
+msgstr ""
+
+msgid "View %{skill} Info"
+msgstr "Žiūrėti %{skill} informaciją"
+
+msgid "Lord Kilburn"
+msgstr ""
+
+msgid "Sir Gallant"
+msgstr ""
+
+msgid "Ector"
+msgstr ""
+
+msgid "Gwenneth"
+msgstr ""
+
+msgid "Tyro"
+msgstr ""
+
+msgid "Ambrose"
+msgstr ""
+
+msgid "Ruby"
+msgstr ""
+
+msgid "Maximus"
+msgstr ""
+
+msgid "Dimitry"
+msgstr ""
+
+msgid "Thundax"
+msgstr ""
+
+msgid "Fineous"
+msgstr ""
+
+msgid "Jojosh"
+msgstr ""
+
+msgid "Crag Hack"
+msgstr ""
+
+msgid "Jezebel"
+msgstr ""
+
+msgid "Jaclyn"
+msgstr ""
+
+msgid "Ergon"
+msgstr ""
+
+msgid "Tsabu"
+msgstr ""
+
+msgid "Atlas"
+msgstr ""
+
+msgid "Astra"
+msgstr ""
+
+msgid "Natasha"
+msgstr ""
+
+msgid "Troyan"
+msgstr ""
+
+msgid "Vatawna"
+msgstr ""
+
+msgid "Rebecca"
+msgstr ""
+
+msgid "Gem"
+msgstr "Brangakmenis"
+
+msgid "Ariel"
+msgstr ""
+
+msgid "Carlawn"
+msgstr ""
+
+msgid "Luna"
+msgstr ""
+
+msgid "Arie"
+msgstr ""
+
+msgid "Alamar"
+msgstr ""
+
+msgid "Vesper"
+msgstr ""
+
+msgid "Crodo"
+msgstr ""
+
+msgid "Barok"
+msgstr ""
+
+msgid "Kastore"
+msgstr ""
+
+msgid "Agar"
+msgstr ""
+
+msgid "Falagar"
+msgstr ""
+
+msgid "Wrathmont"
+msgstr ""
+
+msgid "Myra"
+msgstr ""
+
+msgid "Flint"
+msgstr ""
+
+msgid "Dawn"
+msgstr ""
+
+msgid "Halon"
+msgstr ""
+
+msgid "Myrini"
+msgstr ""
+
+msgid "Wilfrey"
+msgstr ""
+
+msgid "Sarakin"
+msgstr ""
+
+msgid "Kalindra"
+msgstr ""
+
+msgid "Mandigal"
+msgstr ""
+
+msgid "Zom"
+msgstr ""
+
+msgid "Darlana"
+msgstr ""
+
+msgid "Zam"
+msgstr ""
+
+msgid "Ranloo"
+msgstr ""
+
+msgid "Charity"
+msgstr ""
+
+msgid "Rialdo"
+msgstr ""
+
+msgid "Roxana"
+msgstr ""
+
+msgid "Sandro"
+msgstr ""
+
+msgid "Celia"
+msgstr ""
+
+msgid "Roland"
+msgstr ""
+
+msgid "Lord Corlagon"
+msgstr ""
+
+msgid "Sister Eliza"
+msgstr ""
+
+msgid "Archibald"
+msgstr ""
+
+msgid "Lord Halton"
+msgstr ""
+
+msgid "Brother Brax"
+msgstr ""
+
+msgid "Solmyr"
+msgstr ""
+
+msgid "Dainwin"
+msgstr ""
+
+msgid "Mog"
+msgstr ""
+
+msgid "Joseph"
+msgstr ""
+
+msgid "Gallavant"
+msgstr ""
+
+msgid "Elderian"
+msgstr ""
+
+msgid "Ceallach"
+msgstr ""
+
+msgid "Drakonia"
+msgstr ""
+
+msgid "Martine"
+msgstr ""
+
+msgid "Jarkonas"
+msgstr ""
+
+msgid "%{object} robber"
+msgstr ""
+
+msgid "%{object} raided"
+msgstr ""
+
+msgid "You cannot pick up this artifact, you already have a full load!"
+msgstr ""
+
+msgid "The three Anduran artifacts magically combine into one."
+msgstr ""
+
+msgid "To cast spells, you must first buy a spell book for %{gold} gold."
+msgstr ""
+"Burtus galėsite naudoti tik nusipirkę burtų knygą už %{gold} aukso monetų."
+
+msgid "Unfortunately, you seem to be a little short of cash at the moment."
+msgstr ""
+
+msgid "Do you wish to buy one?"
+msgstr "Ar norite nusipirkti vieną?"
+
 msgid "%{count} / day"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:331
-#: ../fheroes2/heroes/heroes_action.cpp:2192
 msgid "You are unable to recruit at this time, your ranks are full."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:599
-msgid ""
-"A group of %{monster} with a desire for greater glory wish to join you.\n"
-"Do you accept?"
+msgid "A whirlpool engulfs your ship."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:609
-#: ../fheroes2/heroes/heroes_action.cpp:630
+msgid "Some of your army has fallen overboard."
+msgstr ""
+
 msgid "Insulted by your refusal of their offer, the monsters attack!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:638
 msgid ""
 "The %{monster}, awed by the power of your forces, begin to scatter.\n"
 "Do you wish to pursue and engage them?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:931
 msgid "Ransacking an enemy camp, you discover a hidden cache of treasures."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:963
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with these resources, "
 "come back next week for more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:964
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there are no resources currently available. Please try "
 "again next week.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:969
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with this gold, come "
 "back next week for more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:970
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there is no gold currently available. Please try again "
 "next week.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:976
 msgid ""
 "You've found an abandoned lean-to.\n"
 "Poking about, you discover some resources hidden nearby."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:977
 msgid "The lean-to is long abandoned. There is nothing of value here."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:982
 msgid ""
 "You catch a leprechaun foolishly sleeping amidst a cluster of magic "
 "mushrooms.\n"
@@ -2672,100 +2957,79 @@ msgid ""
 "precious things."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:983
 msgid ""
 "You've found a magic garden, the kind of place that leprechauns and faeries "
 "like to cavort in, but there is no one here today.\n"
 "Perhaps you should try again next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1020
 msgid "You come upon the remains of an unfortunate adventurer."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1031
 msgid "Treasure"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1038
 msgid "Searching through the tattered clothing, you find %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1049
 msgid "Searching through the tattered clothing, you find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1061
 msgid ""
 "You come across an old wagon left by a trader who didn't quite make it to "
 "safe terrain."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1072
-#: ../fheroes2/heroes/heroes_action.cpp:1100
 msgid "Unfortunately, others have found it first, and the wagon is empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1079
 msgid "Searching inside, you find the %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1090
 msgid "Inside, you find some of the wagon's cargo still intact."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1120
 msgid "You search through the flotsam, and find some wood and some gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1121
 msgid "You search through the flotsam, and find some wood."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1127
 msgid "You search through the flotsam, but find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1148
 msgid "Shrine of the 1st Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1149
 msgid ""
 "You come across a small shrine attended by a group of novice acolytes.\n"
 "In exchange for your protection, they agree to teach you a simple spell - "
 "'%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1152
 msgid "Shrine of the 2nd Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1153
 msgid ""
 "You come across an ornate shrine attended by a group of rotund friars.\n"
 "In exchange for your protection, they agree to teach you a spell - "
 "'%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1156
 msgid "Shrine of the 3rd Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1157
 msgid ""
 "You come across a lavish shrine attended by a group of high priests.\n"
 "In exchange for your protection, they agree to teach you a sophisticated "
 "spell - '%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1170
 msgid ""
 "\n"
 "Unfortunately, you have no Magic Book to record the spell with."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1181
 msgid ""
 "\n"
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
@@ -2775,77 +3039,63 @@ msgstr ""
 "Deja, jūs neturite pakankamai išminties kad suprasti šį burtą, todėl "
 "negalite jo išmokti."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1189
 msgid ""
 "\n"
 "Unfortunately, you already have knowledge of this spell, so there is nothing "
 "more for them to teach you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1212
 msgid ""
 "You approach the hut and observe a witch inside studying an ancient tome on "
 "%{skill}.\n"
 " \n"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1219
 msgid ""
 "As you approach, she turns and focuses her one glass eye on you.\n"
 "\"You already know everything you deserve to learn!\" the witch screeches. "
 "\"NOW GET OUT OF MY HOUSE!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1226
 msgid ""
 "As you approach, she turns and speaks.\n"
 "\"You already know that which I would teach you. I can help you no further.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1233
 msgid ""
 "An ancient and immortal witch living in a hut with bird's legs for stilts "
 "teaches you %{skill} for her own inscrutable purposes."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1252
 msgid "You drink from the enchanted fountain, but nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1253
 msgid "As you drink the sweet water, you gain luck for your next battle."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1257
 msgid "You enter the faerie ring, but nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1258
 msgid ""
 "Upon entering the mystical faerie ring, your army gains luck for its next "
 "battle."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1262
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "It is supposed to grant luck to visitors, but since the stars are already "
 "smiling upon you, it does nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1263
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "Kissing it is supposed to be lucky, so you do. The stone is very cold to the "
 "touch."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1267
-msgid ""
-"The mermaids silently entice you to return later and be blessed again."
+msgid "The mermaids silently entice you to return later and be blessed again."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1268
 msgid ""
 "The magical, soothing beauty of the Mermaids reaches you and your crew.\n"
 "Just for a moment, you forget your worries and bask in the beauty of the "
@@ -2853,7 +3103,6 @@ msgid ""
 "The mermaids charms bless you with increased luck for your next combat."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1300
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "You are tempted to search it for treasure, but all the old stories warn of "
@@ -2861,17 +3110,14 @@ msgid ""
 "Will you search?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1301
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "Routine exploration reveals that the pyramid is completely empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1326
 msgid "Unfortunately, you have no Magic Book to record the spell with."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1330
 msgid ""
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
@@ -2879,328 +3125,261 @@ msgstr ""
 "Deja, jūs neturite pakankamai išminties kad suprasti šį burtą, todėl "
 "negalite jo išmokti."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1334
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
 "telling the secret of the spell."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1381
+msgid "Sign"
+msgstr ""
+
 msgid ""
 "A drink at the well is supposed to restore your spell points, but you are "
 "already at maximum."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1388
 msgid "A second drink at the well in one day will not help you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1395
 msgid "A drink from the well has restored your spell points to maximum."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1420
 msgid ""
 "\"I'm sorry sir,\" The leader of the soldiers says, \"but you already know "
 "everything we have to teach.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1421
 msgid "The soldiers living in the fort teach you a few new defensive tricks."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1426
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. \"You're too "
 "advanced for us,\" the mercenary captain says. \"We can teach nothing more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1427
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. The mercenaries "
 "welcome you and your troops and invite you to train with them."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1432
 msgid "\"Go 'way!\", the witch doctor barks, \"you know all I know.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1433
 msgid ""
 "An Orcish witch doctor living in the hut deepens your knowledge of magic by "
 "showing you how to cast stones, read portents, and decipher the intricacies "
 "of chicken entrails."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1438
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, the Druids turn you away, indicating they have nothing "
 "new to teach you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1439
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, they teach you new ways to cast spells."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1475
 msgid ""
 "You tentatively approach the burial ground of ancient warriors. Do you want "
 "to search the graves?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1476
 msgid ""
 "Upon defeating the Zombies you spend several hours searching the graves and "
 "find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1477
-msgid "Upon defeating the zomies you search the graves and find something!"
+msgid "Upon defeating the Zombies you search the graves and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1480
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the shipwreck?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1481
 msgid ""
 "Upon defeating the Ghosts you spend several hours sifting through the debris "
 "and find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1482
 msgid ""
 "Upon defeating the Ghosts you sift through the debris and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1485
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the ship?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1486
 msgid ""
 "Upon defeating the Skeletons you spend several hours sifting through the "
 "debris and find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1487
 msgid ""
 "Upon defeating the Skeletons you sift through the debris and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1560
 msgid "Your men spot a navigational buoy, confirming that you are on course."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1561
 msgid ""
 "Your men spot a navigational buoy, confirming that you are on course and "
 "increasing their morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1565
 msgid ""
 "The drink at the oasis is refreshing, but offers no further benefit. The "
 "oasis might help again if you fought a battle first."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1566
 msgid ""
 "A drink at the oasis fills your troops with strength and lifts their "
 "spirits.  You can travel a bit further today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1571
 msgid ""
 "The drink at the watering hole is refreshing, but offers no further benefit. "
 "The watering hole might help again if you fought a battle first."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1572
 msgid ""
 "A drink at the watering hole fills your troops with strength and lifts their "
 "spirits. You can travel a bit further today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1577
 msgid ""
 "It doesn't help to pray twice before a battle. Come back after you've fought."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1578
 msgid "A visit and a prayer at the temple raises the morale of your troops."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1618
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"I am sorry, my liege, I "
 "have taught you all I can.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1619
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"My liege, I will teach "
 "you all that I know to aid you in your travels.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1658
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
 "ocean. Grateful, he says, \"I would give you an artifact as a reward, but "
 "you're all full.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1665
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
 "ocean. Grateful, he rewards you for your act of kindness by giving you the "
 "%{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1684 ../fheroes2/heroes/heroes.cpp:937
-msgid "You have no room to carry another artifact!"
+msgid "A leprechaun offers you the %{art} for the small price of %{gold} Gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1700
-msgid ""
-"A leprechaun offers you the %{art} for the small price of %{gold} Gold."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:1705
 msgid ""
 "A leprechaun offers you the %{art} for the small price of %{gold} Gold and "
 "%{count} %{res}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1714
 msgid "Do you wish to buy this artifact?"
 msgstr "Ar jūs norite pirkti šį magišką artefaktą?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1727
 msgid ""
 "You try to pay the leprechaun, but realize that you can't afford it. The "
 "leprechaun stamps his foot and ignores you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1731
 msgid ""
 "Insulted by your refusal of his generous offer, the leprechaun stamps his "
 "foot and ignores you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1742
-#: ../fheroes2/heroes/heroes_action.cpp:1814
 msgid "You've found the artifact: "
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1752
 msgid ""
 "You've found the humble dwelling of a withered hermit. The hermit tells you "
 "that he is willing to give the %{art} to the first wise person he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1755
 msgid ""
 "You've come across the spartan quarters of a retired soldier. The soldier "
 "tells you that he is willing to pass on the %{art} to the first true leader "
 "he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1774
 msgid ""
 "You come upon an ancient artifact. As you reach for it, a pack of Rogues "
 "leap out of the brush to guard their stolen loot."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1777
 msgid ""
 "Through a clearing you observe an ancient artifact. Unfortunately, it's "
 "guarded by a nearby %{monster}. Do you want to fight the %{monster} for the "
 "artifact?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1791
 msgid "Victorious, you take your prize, the %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1803
 msgid ""
 "Discretion is the better part of valor, and you decide to avoid this fight "
 "for today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1859
-#: ../fheroes2/heroes/heroes_action.cpp:1874
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold pieces."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1865
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold and the %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1881
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it, "
 "only to find it empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1891
 msgid ""
 "After scouring the area, you fall upon a hidden treasure cache. You may take "
 "the gold or distribute the gold to the peasants for experience. Do you wish "
 "to keep the gold?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1905
 msgid ""
 "After scouring the area, you fall upon a hidden chest, containing the "
 "%{gold} gold pieces."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1911
 msgid ""
 "After scouring the area, you fall upon a hidden chest, containing the "
 "ancient artifact %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1935
 msgid ""
 "You stumble upon a dented and tarnished lamp lodged deep in the earth. Do "
 "you wish to rub the lamp?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2023
-msgid "A whirlpool engulfs your ship."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2023
-msgid "Some of your army has fallen overboard."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2038
 msgid ""
 "You come upon an abandoned gold mine. The mine appears to be haunted. Do you "
 "wish to enter?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2057
 msgid ""
 "You have taken control of the local Alchemist shop. It will provide you with "
 "%{count} unit of Mercury per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2063
 msgid ""
 "You gain control of a sawmill. It will provide you with %{count} units of "
 "wood per day."
@@ -3208,7 +3387,9 @@ msgstr ""
 "Jūs užvaldėte lentpjūvę. Ši lentpjūvė gamins jums %{count} medienos vnt. per "
 "dieną."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2074
+msgid "You beat the Ghosts and are able to restore the mine to production."
+msgstr ""
+
 msgid ""
 "You gain control of an ore mine. It will provide you with %{count} units of "
 "ore per day."
@@ -3216,7 +3397,6 @@ msgstr ""
 "Jūs užvaldėte geležies rūdos kasyklą. Ši kasykla iškas jums %{count} rūdos "
 "vnt. per dieną."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2076
 msgid ""
 "You gain control of a sulfur mine. It will provide you with %{count} unit of "
 "sulfur per day."
@@ -3224,7 +3404,6 @@ msgstr ""
 "Jūs užvaldėte sieros kasyklą. Ši kasykla iškas jums %{count} sieros vnt. per "
 "dieną."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2078
 msgid ""
 "You gain control of a crystal mine. It will provide you with %{count} unit "
 "of crystal per day."
@@ -3232,7 +3411,6 @@ msgstr ""
 "Jūs užvaldėte kristalų kasyklą. Ši kasykla iškas jums %{count} kristalą(us) "
 "per dieną."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2080
 msgid ""
 "You gain control of a gem mine. It will provide you with %{count} unit of "
 "gems per day."
@@ -3240,7 +3418,6 @@ msgstr ""
 "Jūs užvaldėte brangakmenių kasyklą. Ši kasykla iškas jums %{count} "
 "brangakmenį per dieną."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2082
 msgid ""
 "You gain control of a gold mine. It will provide you with %{count} gold per "
 "day."
@@ -3248,94 +3425,74 @@ msgstr ""
 "Jūs užvaldėte aukso kasyklą. Ši kasykla pagamins jums %{count} aukso monetų "
 "per dieną."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2089
-msgid "You beat the Ghosts and are able to restore the mine to production."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2094
 msgid ""
 "The lighthouse is now under your control, and all of your ships will now "
 "move further each turn."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2098
 msgid "You gain control of a %{name}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2181
 msgid ""
 "A group of %{monster} with a desire for greater glory wish to join you. Do "
 "you accept?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2208
 msgid "As you approach the dwelling, you notice that there is no one here."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2225
 msgid ""
 "You search the ruins, but the Medusas that used to live here are gone. "
 "Perhaps there will be more next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2226
 msgid ""
 "You've found some Medusas living in the ruins. They are willing to join your "
 "army for a price. Do you want to recruit Medusas?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2231
 msgid ""
 "You've found a Sprite Tree City. Unfortunately, none of the Sprites living "
 "there wish to join an army. Maybe next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2232
 msgid ""
 "Some of the Sprites living in the tree city are willing to join your army "
 "for a price. Do you want to recruit Sprites?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2237
 msgid ""
 "A colorful Rogues' wagon stands empty here. Perhaps more Rogues will be here "
 "later."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2238
 msgid ""
 "Distant sounds of music and laughter draw you to a colorful wagon housing "
 "Rogues. Do you wish to have any Rogues join your army?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2243
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. The "
 "tents are unoccupied. Perhaps more Nomads will be here later."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2244
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. Do you "
 "wish to have any Nomads join you during your travels?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2249
 msgid "The pit of mud bubbles for a minute and then lies still."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2250
 msgid ""
 "As you approach the bubbling pit of mud, creatures begin to climb out and "
 "position themselves around it. In unison they say: \"Mother Earth would like "
 "to offer you a few of her troops. Do you want to recruit Earth Elementals?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2254
 msgid "You enter the structure of white stone pillars, and find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2255
 msgid ""
 "White stone pillars support a roof that rises up to the sky. As you enter "
 "the structure, the dead air of the outside gives way to a whirling gust that "
@@ -3345,192 +3502,159 @@ msgid ""
 "air?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2259
 msgid "No Fire Elementals approach you from the lava pool."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2260
 msgid ""
 "Beneath a structure that serves to hold in heat, Fire Elementals move about "
 "in a fiery pool of molten lava. A group of them approach you and offer their "
 "services. Would you like to recruit Fire Elementals?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2264
 msgid "A face forms in the water for a moment, and then is gone."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2265
 msgid ""
 "Crystalline structures cast shadows over a small reflective pool of water. "
 "You peer into the pool, and a face that is not your own peers back. It asks: "
 "\"Would you like to call upon the powers of water?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2269
 msgid "This burial site is deathly still."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2270
 msgid ""
 "Restless spirits of long dead warriors seeking their final resting place "
 "offer to join you in hopes of finding peace. Do you wish to recruit ghosts?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2306
 msgid ""
 "The City of the Dead is empty of life, and empty of unlife as well. Perhaps "
 "some undead will move in next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2307
 msgid ""
 "Some Liches living here are willing to join your army for a price. Do you "
 "want to recruit Liches?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2308
 msgid ""
 "You've found the ruins of an ancient city, now inhabited solely by the "
 "undead. Will you search?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2309
 msgid ""
 "Some of the surviving Liches are impressed by your victory over their "
 "fellows, and offer to join you for a price. Do you want to recruit Liches?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2313
 msgid ""
 "You've found one of those bridges that Trolls are so fond of living under, "
 "but there are none here. Perhaps there will be some next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2314
 msgid ""
 "Some Trolls living under a bridge are willing to join your army, but for a "
 "price. Do you want to recruit Trolls?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2315
 msgid "Trolls living under the bridge challenge you. Will you fight them?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2316
 msgid ""
 "A few Trolls remain, cowering under the bridge. They approach you and offer "
 "to join your forces as mercenaries. Do you want to buy any Trolls?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2320
 msgid ""
 "The Dragon city has no Dragons willing to join you this week. Perhaps a "
 "Dragon will become available next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2321
 msgid ""
 "The Dragon city is willing to offer some Dragons for your army for a price. "
 "Do you wish to recruit Dragons?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2322
 msgid ""
 "You stand before the Dragon City, a place off-limits to mere humans. Do you "
 "wish to violate this rule and challenge the Dragons to a fight?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2323
 msgid ""
 "Having defeated the Dragon champions, the city's leaders agree to supply "
 "some Dragons to your army for a price. Do you wish to recruit Dragons?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2382
 msgid "From the observation tower, you are able to see distant lands."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2394
 msgid ""
 "The spring only refills once a week, and someone's already been here this "
 "week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2400
 msgid ""
 "A drink at the spring is supposed to give you twice your normal spell "
 "points, but you are already at that level."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2411
 msgid ""
 "A drink from the spring fills your blood with magic! You have twice your "
 "normal spell points in reserve."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2430
 msgid ""
 "Recognizing you, the butler refuses to admit you. \"The master,\" he says, "
 "\"will not see the same student twice.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2450
 msgid ""
 "The butler admits you to see the master of the house. He trains you in the "
 "four skills a hero should know."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2460
 msgid ""
 "The butler opens the door and looks you up and down. \"You are neither "
 "famous nor diplomatic enough to be admitted to see my master,\" he sniffs. "
 "\"Come back when you think yourself worthy.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2503
 msgid ""
 "All of the %{monsters} you have in your army have been trained by the battle "
 "masters of the fort. Your army now contains %{monsters2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2506
 msgid ""
-"An unusual alliance of Orcs, Ogres, and Dwarves offer to train (upgrade) any "
+"An unusual alliance of Ogres, Orcs, and Dwarves offer to train (upgrade) any "
 "such troops brought to them. Unfortunately, you have none with you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2517
 msgid "All of your %{monsters} have been upgraded into %{monsters2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2520
 msgid ""
 "A blacksmith working at the foundry offers to convert all Pikemen and "
 "Swordsmen's weapons brought to him from iron to steel. He also says that he "
-"knows a process that will convert Iron Golems into Steel Golems.  "
+"knows a process that will convert Iron Golems into Steel Golems. "
 "Unfortunately, you have none of these troops in your army, so he can't help "
 "you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2578
 msgid ""
 "A retired captain living on this refurbished fishing platform offers to sell "
 "you maps of the sea he made in his younger days for 1,000 gold. Do you wish "
 "to buy the maps?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2591
 msgid ""
 "The captain sighs. \"You don't have enough money, eh?  You can't expect me "
 "to give my maps away for free!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2624
 msgid "You find %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2647
 msgid ""
 "You come upon an obelisk made from a type of stone you have never seen "
 "before. Staring at it intensely, the smooth surface suddenly changes to an "
@@ -3538,56 +3662,51 @@ msgid ""
 "copy down the piece and the inscription vanishes as abruptly as it appeared."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2651
 msgid "You have already been to this obelisk."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2663
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"It is good to see "
 "you, my student. I hope my teachings have helped you.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2675
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"Ahh, an "
 "adventurer! Allow me to teach you a little of what I have learned over the "
 "ages.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2684
 msgid "Upon your approach, the tree opens its eyes in delight."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2686
 msgid ""
 "\"Ahh, an adventurer! I will be happy to teach you a little of what I have "
 "learned over the ages for a mere %{count} %{res}.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2688
 msgid "(Just bury it around my roots.)"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2695
 msgid "Tears brim in the eyes of the tree."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2697
 msgid "\"I need %{count} %{res}.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2699
 msgid "it whispers. (sniff) \"Well, come back when you can pay me.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2729
+msgid ""
+"Nestled among the trees sits a blind seer. After explaining the intent of "
+"your journey, the seer activates his crystal ball, allowing you to see the "
+"strengths and weaknesses of your opponents."
+msgstr ""
+
 msgid ""
 "The entrance to the cave is dark, and a foul, sulfurous smell issues from "
 "the cave mouth. Will you enter?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2741
 msgid ""
 "You find a powerful and grotesque Demon in the cave. \"Today,\" it rasps, "
 "\"you will fight and surely die. But I will give you a choice of deaths. You "
@@ -3595,78 +3714,59 @@ msgid ""
 "servants?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2751
 msgid ""
 "Upon defeating the daemon's servants, you find a hidden cache with %{count} "
 "gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2766
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and receive %{exp} experience points."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2776
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and find the %{art} in the back of the cave."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2786
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
-"battle, you slay the monster and receive %{exp) experience points and "
+"battle, you slay the monster and receive %{exp} experience points and "
 "%{count} gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2801
 msgid ""
 "The Demon leaps upon you and has its claws at your throat before you can "
 "even draw your sword. \"Your life is mine,\" it says. \"I will sell it back "
 "to you for %{count} gold.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2802
 msgid ""
 "Seeing that you do not have %{count} gold, the demon slashes you with its "
 "claws, and the last thing you see is a red haze."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2827
 msgid "Except for evidence of a terrible battle, the cave is empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2848
-msgid "He checks your pack, and sees that you have 1 cursed item."
-msgid_plural ""
-"He checks your pack, and sees that you have %{count} cursed items."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2852
 msgid "For %{gold} gold, the alchemist will remove it for you. Do you pay?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2863
 msgid ""
 "You hear a voice from behind the locked door, \"You don't have enough gold "
 "to pay for my services.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2866
 msgid ""
 "You hear a voice from high above in the tower, \"Go away! I can't help you!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2878
 msgid ""
 "The head groom approaches you and speaks, \"You already have a fine horse, "
 "and have no inexperienced cavalry which might make use of our trained war "
 "horses.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2881
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, his "
@@ -3675,7 +3775,6 @@ msgid ""
 "mounted soldiers, but you have none we can help.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2884
 msgid ""
 "The head groom speaks to you, \"That is a fine looking horse you have. I am "
 "afraid we can give you no better, but the horses your cavalry are riding "
@@ -3683,7 +3782,6 @@ msgid ""
 "would aid your riders greatly. I insist you take them.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2887
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, he will "
@@ -3691,17 +3789,14 @@ msgid ""
 "mounted soldiers, their horses look shoddy and weak.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2914
 msgid "The Arena guards turn you away."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2931
 msgid ""
 "As the sirens sing their eerie song, your small, determined army manages to "
 "overcome the urge to dive headlong into the sea."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2936
 msgid ""
 "You have your crew stop up their ears with wax before the sirens' eerie song "
 "has any chance of luring them to a watery grave. An eerie wailing song "
@@ -3710,57 +3805,52 @@ msgid ""
 "for the visit, and gain %{exp} experience."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2956
 msgid ""
 "In a dazzling display of daring, you break into the local jail and free the "
 "hero imprisoned there, who, in return, pledges loyalty to your cause."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2972
 msgid ""
 "You already have %{count} heroes, and regretfully must leave the prisoner in "
 "this jail to languish in agony for untold days."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2983
 msgid ""
 "You enter a rickety hut and talk to the magician who lives there. He tells "
 "you of places near and far which may aid you in your journeys."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2996
 msgid "This eye seems to be intently studying its surroundings."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3007
 msgid ""
 "\"I have a riddle for you,\" the Sphinx says. \"Answer correctly, and you "
 "shall be rewarded. Answer incorrectly, and you shall be eaten. Do you accept "
 "the challenge?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3009
-msgid "The Sphinx asks you the following riddle: %{riddle}. Your answer?"
+msgid ""
+"The Sphinx asks you the following riddle:\n"
+" \n"
+"'%{riddle}'\n"
+" \n"
+"Your answer?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3017
 msgid ""
 "Looking somewhat disappointed, the Sphinx sighs. You've answered my riddle "
 "so here's your reward. Now begone."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3044
 msgid ""
 "\"You guessed incorrectly,\" the Sphinx says, smiling. The Sphinx swipes at "
 "you with a paw, knocking you to the ground. Another blow makes the world go "
 "black, and you know no more."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3052
 msgid "You come across a giant Sphinx. The Sphinx remains strangely quiet."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3065
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -3768,7 +3858,6 @@ msgid ""
 "As you speak the magic word, the glowing barrier dissolves into nothingness."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3075
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -3776,7 +3865,6 @@ msgid ""
 "You speak, and nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3085
 msgid ""
 "You enter the tent and see an old woman gazing into a magic gem. She looks "
 "up and says,\n"
@@ -3784,422 +3872,83 @@ msgid ""
 "oracle taught me his skill. I have the answer you seek.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_base.cpp:401
 msgid ""
 "That spell costs %{mana} mana. You only have %{point} mana, so you can't "
 "cast the spell."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Lord Kilburn"
+msgid "%{name} the %{race} (Level %{level})"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Sir Gallanth"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ector"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Gwenneth"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Tyro"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ambrose"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ruby"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Maximus"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Dimitry"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Thundax"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Fineous"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jojosh"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Crag Hack"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jezebel"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jaclyn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Ergon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Tsabu"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Atlas"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Astra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Natasha"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Troyan"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Vatawna"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Rebecca"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Gem"
-msgstr "Brangakmenis"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Ariel"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Carlawn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Luna"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Arie"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61 ../fheroes2/resource/maps_text.cpp:59
-msgid "Alamar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Vesper"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Crodo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Barok"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Kastore"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Agar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Falagar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Wrathmont"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Flint"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Dawn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Halon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myrini"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Wilfrey"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Sarakin"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63 ../fheroes2/resource/maps_text.cpp:377
-msgid "Kalindra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Mandigal"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zom"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Darlana"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zam"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Ranloo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Charity"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Rialdo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Roxana"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65 ../fheroes2/resource/maps_text.cpp:557
-msgid "Sandro"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Celia"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:552
-msgid "Roland"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Lord Corlagon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Sister Eliza"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:88
-msgid "Archibald"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:403
-msgid "Lord Halton"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Brother Bax"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Solmyr"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:194
-msgid "Dainwin"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Mog"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:760
-msgid "Uncle Ivan"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:373
-msgid "Joseph"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:285
-msgid "Gallavant"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Elderian"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:179
-msgid "Ceallach"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:229
-msgid "Drakonia"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:422
-msgid "Martine"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:370
-msgid "Jarkonas"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:936
-msgid ""
-"You must purchase a spell book to use the mage guild, but you currently have "
-"no room for a spell book. Try giving one of your artifacts to another hero."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:946
-msgid "The three Anduran artifacts magically combine into one."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1052
-msgid "To cast spells, you must first buy a spell book for %{gold} gold."
-msgstr ""
-"Burtus galėsite naudoti tik nusipirkę burtų knygą už %{gold} aukso monetų."
-
-#: ../fheroes2/heroes/heroes.cpp:1060
-msgid "Unfortunately, you seem to be a little short of cash at the moment."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1075
-msgid "Do you wish to buy one?"
-msgstr "Ar norite nusipirkti vieną?"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:72
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:55
-msgid "%{name} the %{race} ( Level %{level} )"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:118
 msgid ""
 "'Grouped' combat formation bunches your army together in the center of your "
 "side of the battlefield."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:161
 msgid "Are you sure you want to dismiss this Hero?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:341
 msgid "View Stats"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:344
-msgid "View Morale Info"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:347
-msgid "View Luck Info"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:350
 msgid "View Experience Info"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:353
 msgid "View Spell Points Info"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:356
 msgid "Set army combat formation to 'Spread'"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:359
 msgid "Set army combat formation to 'Grouped'"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:362
-msgid "Exit hero"
+msgid "Exit Hero Screen"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:369
-msgid "Dismiss hero"
+msgid "You cannot dismiss a hero in a castle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:373
-msgid "Show prev heroes"
+msgid "Dismissal of %{name} the %{race} is prohibited by scenario"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:376
-msgid "Show next heroes"
+msgid "Dismiss %{name} the %{race}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:379
-msgid "Hero Screen"
+#, fuzzy
+msgid "Show previous hero"
+msgstr "Rodyti ankstesnį miestą"
+
+#, fuzzy
+msgid "Show next hero"
+msgstr "Rodyti kitą miestą"
+
+msgid "Blood Morale"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:39
-msgid "Bad Morale"
+msgid "%{morale} Morale"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:42
-msgid "Neutral Morale"
+msgid "%{luck} Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:47
-msgid "Good Morale"
+msgid "Current Luck Modifiers:"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:61
-msgid "Bad Luck"
+msgid "Current Morale Modifiers:"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:64
-msgid "Neutral Luck"
+msgid "Entire army is undead, so morale does not apply."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:69
-msgid "Good Luck"
+msgid ""
+"Current experience %{exp1}.\n"
+" Next level %{exp2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:113
-#: ../fheroes2/heroes/heroes_indicator.cpp:159
-#: ../fheroes2/heroes/skill.cpp:213
-msgid "Current Modifiers:"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:195
-msgid "Current experience %{exp1} Next level %{exp2}."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:215
 msgid "Level %{level}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:226
 msgid ""
 "%{name} currently has %{point} spell points out of a maximum of %{max}. The "
 "maximum number of spell points is 10 times your knowledge. It is "
@@ -4207,2815 +3956,1443 @@ msgid ""
 "special events."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:65
 msgid "%{name1} meets %{name2}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:396
-#: ../fheroes2/heroes/heroes_meeting.cpp:406
 msgid " and "
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:414
 msgid ""
 "%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
 "%{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:417
 msgid ""
 "%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
 "%{spells1} from %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:420
 msgid ""
 "%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches "
 "%{spells2} to %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:431
 msgid "Scholar Ability"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:83 ../fheroes2/spell/spell.cpp:116
 msgid "Town Portal"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:86
 msgid "Select town to port to."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:106
 msgid "Your hero is too tired to cast this spell today. Try again tomorrow."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:236
+msgid "%{spell} failed!!!"
+msgstr ""
+
+msgid "This spell is already in use."
+msgstr ""
+
 msgid "Enemy heroes are now fully identifiable."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:362
-#: ../fheroes2/heroes/heroes_spell.cpp:386
-msgid "No available towns. Spell Failed!!!"
+msgid "This spell cannot be used on a boat."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:459
-msgid "I fear these creatures are in the mood for a fight."
+msgid "This spell can be casted only nearby water."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:463
-msgid "The creatures are willing to join us!"
+msgid ""
+"No available towns.\n"
+"Spell Failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:468
-msgid "All the creatures will join us..."
+msgid ""
+"Nearest town occupied.\n"
+"Spell Failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:471
-msgid "The creature will join us..."
-msgid_plural "%{count} of the creatures will join us..."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/heroes/heroes_spell.cpp:480
-msgid "These weak creatures will surely flee before us."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_spell.cpp:489
 msgid ""
 "You must be within %{count} spaces of a monster for the Visions spell to "
 "work."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:506
+msgid "I fear these creatures are in the mood for a fight."
+msgstr ""
+
+msgid "The creatures are willing to join us!"
+msgstr ""
+
+msgid "All the creatures will join us..."
+msgstr ""
+
+msgid "These weak creatures will surely flee before us."
+msgstr ""
+
 msgid ""
 "You must be standing on the entrance to a mine (sawmills and alchemists "
 "don't count) to cast this spell."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:167
-msgid "Power"
-msgstr ""
-
-#: ../fheroes2/heroes/skill.cpp:188
 msgid "Your attack skill is a bonus added to each creature's attack skill."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:193
 msgid "Your defense skill is a bonus added to each creature's defense skill."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:198
 msgid "Your spell power determines the length or power of a spell."
 msgstr ""
 "Nuo herojaus burtų galios priklauso burtų galiojimo laikas bei galingumas."
 
-#: ../fheroes2/heroes/skill.cpp:203
 msgid ""
 "Your knowledge determines how many spell points your hero may have. Under "
-"normal cirumstances, a hero is limited to 10 spell points per level of "
+"normal circumstances, a hero is limited to 10 spell points per level of "
 "knowledge."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:230
+msgid "Current Modifiers:"
+msgstr ""
+
 msgid "skill|Basic"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:230
 msgid "skill|Advanced"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:230
 msgid "skill|Expert"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:353
 msgid "Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:353
 msgid "Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:353
 msgid "Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:353
 msgid "Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:353
 msgid "Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:353
 msgid "Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:354
 msgid "Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:354
 msgid "Wisdom"
 msgstr "Išmintis"
 
-#: ../fheroes2/heroes/skill.cpp:354
 msgid "Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:354
 msgid "Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:354
 msgid "Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:354
 msgid "Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:354
 msgid "Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:383
 msgid "Basic Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:383
 msgid "Advanced Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:383
 msgid "Expert Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:384
 msgid "Basic Archery"
 msgstr "Pradinis šaudymas"
 
-#: ../fheroes2/heroes/skill.cpp:384
 msgid "Advanced Archery"
 msgstr "Pažangus šaudymas"
 
-#: ../fheroes2/heroes/skill.cpp:384
 msgid "Expert Archery"
 msgstr "Eksperto šaudymas"
 
-#: ../fheroes2/heroes/skill.cpp:385
 msgid "Basic Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:385
 msgid "Advanced Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:385
 msgid "Expert Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:386
 msgid "Basic Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:386
 msgid "Advanced Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:386
 msgid "Expert Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:387
 msgid "Basic Diplomacy"
 msgstr "Pradinė diplomatija"
 
-#: ../fheroes2/heroes/skill.cpp:387
 msgid "Advanced Diplomacy"
 msgstr "Pažangi diplomatija"
 
-#: ../fheroes2/heroes/skill.cpp:387
 msgid "Expert Diplomacy"
 msgstr "Eksperto diplomatija"
 
-#: ../fheroes2/heroes/skill.cpp:388
 msgid "Basic Navigation"
 msgstr "Pradinė navigacija"
 
-#: ../fheroes2/heroes/skill.cpp:388
 msgid "Advanced Navigation"
 msgstr "Pažangi navigacija"
 
-#: ../fheroes2/heroes/skill.cpp:388
 msgid "Expert Navigation"
 msgstr "Eksperto navigacija"
 
-#: ../fheroes2/heroes/skill.cpp:389
 msgid "Basic Leadership"
 msgstr "Pradinė lyderystė"
 
-#: ../fheroes2/heroes/skill.cpp:389
 msgid "Advanced Leadership"
 msgstr "Pažangi lyderystė"
 
-#: ../fheroes2/heroes/skill.cpp:389
 msgid "Expert Leadership"
 msgstr "Eksperto lyderystė"
 
-#: ../fheroes2/heroes/skill.cpp:390
 msgid "Basic Wisdom"
 msgstr "Pradinė išmintis"
 
-#: ../fheroes2/heroes/skill.cpp:390
 msgid "Advanced Wisdom"
 msgstr "Pažangi išmintis"
 
-#: ../fheroes2/heroes/skill.cpp:390
 msgid "Expert Wisdom"
 msgstr "Eksperto išmintis"
 
-#: ../fheroes2/heroes/skill.cpp:391
 msgid "Basic Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:391
 msgid "Advanced Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:391
 msgid "Expert Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:392
 msgid "Basic Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:392
 msgid "Advanced Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:392
 msgid "Expert Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:393
 msgid "Basic Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:393
 msgid "Advanced Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:393
 msgid "Expert Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:394
 msgid "Basic Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:394
 msgid "Advanced Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:394
 msgid "Expert Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:395
 msgid "Basic Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:395
 msgid "Advanced Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:395
 msgid "Expert Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:396
 msgid "Basic Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:396
 msgid "Advanced Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:396
 msgid "Expert Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:410
-msgid "Reduces the movement penalty for rough terrain by %{count} percent."
-msgid_plural ""
-"Reduces the movement penalty for rough terrain by %{count} percent."
-msgstr[0] ""
-msgstr[1] ""
+msgid " allows you to negotiate with monsters who are weaker than your group."
+msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:413
+msgid "All of the creatures may offer to join you."
+msgstr ""
+
+msgid " allows your hero to learn third level spells."
+msgstr ""
+
+msgid " allows your hero to learn fourth level spells."
+msgstr ""
+
+msgid " allows your hero to learn fifth level spells."
+msgstr ""
+
 msgid ""
-"Increases the damage done by range attacking creatures by %{count} percent."
-msgid_plural ""
-"Increases the damage done by range attacking creatures by %{count} percent."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/heroes/skill.cpp:416
-msgid "Increases your hero's movement points by %{count} percent."
-msgid_plural "Increases your hero's movement points by %{count} percent."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/heroes/skill.cpp:419
-msgid "Increases your hero's viewable area by %{count} square."
-msgid_plural "Increases your hero's viewable area by %{count} squares."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/heroes/skill.cpp:422
-msgid "Allows you to negotiate with monsters who are weaker than your group."
-msgstr ""
-
-#: ../fheroes2/heroes/skill.cpp:424
-msgid ""
-"Approximately %{count} percent of the creatures may offer to join you."
-msgid_plural ""
-"Approximately %{count} percent of the creatures may offer to join you."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/heroes/skill.cpp:427
-msgid "Increases your hero's movement points over water by %{count} percent."
-msgid_plural ""
-"Increases your hero's movement points over water by %{count} percent."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/heroes/skill.cpp:430
-msgid "Increases your hero's troops morale by %{count}."
-msgid_plural "Increases your hero's troops morale by %{count}."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/heroes/skill.cpp:437
-msgid "Allows your hero to learn third level spells."
-msgstr ""
-
-#: ../fheroes2/heroes/skill.cpp:439
-msgid "Allows your hero to learn fourth level spells."
-msgstr ""
-
-#: ../fheroes2/heroes/skill.cpp:441
-msgid "Allows your hero to learn fifth level spells."
-msgstr ""
-
-#: ../fheroes2/heroes/skill.cpp:447
-msgid "Regenerates %{count} of your hero's spell point per day."
-msgid_plural "Regenerates %{count} of your hero's spell points per day."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/heroes/skill.cpp:450
-msgid "Increases your hero's luck by %{count}."
-msgid_plural "Increases your hero's luck by %{count}."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/heroes/skill.cpp:456
-msgid ""
-"Gives your hero's catapult shots a greater chance to hit and do damage to "
+" gives your hero's catapult shots a greater chance to hit and do damage to "
 "castle walls."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:458
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot has a greater chance "
-"to hit and do damage to castle walls."
+" gives your hero's catapult an extra shot, and each shot has a greater "
+"chance to hit and do damage to castle walls."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:460
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot automatically "
+" gives your hero's catapult an extra shot, and each shot automatically "
 "destroys any wall, except a fortified wall in a Knight town."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:468
-msgid ""
-"Gives your hero a %{count} percent chance to learn any given 1st or 2nd "
-"level enemy spell used against him in a combat."
-msgid_plural ""
-"Gives your hero a %{count} percent chance to learn any given 1st or 2nd "
-"level enemy spell used against him in a combat."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/heroes/skill.cpp:471
-msgid ""
-"Gives your hero a %{count} percent chance to learn any given 3rd level spell "
-"(or below) used against him in combat."
-msgid_plural ""
-"Gives your hero a %{count} percent chance to learn any given 3rd level spell "
-"(or below) used against him in combat."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/heroes/skill.cpp:474
-msgid ""
-"Gives your hero a %{count} percent chance to learn any given 4th level spell "
-"(or below) used against him in combat."
-msgid_plural ""
-"Gives your hero a %{count} percent chance to learn any given 4th level spell "
-"(or below) used against him in combat."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/heroes/skill.cpp:480
-msgid ""
-"Allows %{count} percent of the creatures killed in combat to be brought back "
-"from the dead as Skeletons."
-msgid_plural ""
-"Allows %{count} percent of the creatures killed in combat to be brought back "
-"from the dead as Skeletons."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/heroes/skill.cpp:483
-msgid ""
-"Your hero produce %{count} gold pieces per turn as tax revenue from estates."
-msgid_plural ""
-"Your hero produces %{count} gold pieces per turn as tax revenue from estates."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/heroes/skill.cpp:885 ../fheroes2/heroes/skill.cpp:986
-msgid "View %{skill} Info"
-msgstr "Žiūrėti %{skill} informaciją"
-
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:108
 msgid "Blue"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:111
 msgid "Green"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:114
 msgid "Red"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32
 msgid "Yellow"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:112
 msgid "Orange"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:113
 msgid "Purple"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:107
 msgid "Aqua"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:109
 msgid "Brown"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:110 ../fheroes2/resource/resource.cpp:283
 msgid "Gold"
 msgstr "Auksas"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:238
 msgid "Hero/Stats"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:241
 msgid "Skills"
 msgstr "Įgūdžiai"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:244
 msgid "Artifacts"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:472
 msgid "Town/Castle"
 msgstr "Miestelis/Pilis"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:475
 msgid "Garrison"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:565
 msgid "Gold Per Day:"
 msgstr "Aukso per dieną:"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Cursed"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Awful"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Bad"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Normal"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Good"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Great"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Irish"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:48
 msgid ""
 "Bad luck sometimes falls on your armies in combat, causing their attacks to "
 "only do half damage."
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:49
 msgid ""
 "Neutral luck means your armies will never get lucky or unlucky attacks on "
 "the enemy."
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:50
 msgid ""
 "Good luck sometimes lets your armies get lucky attacks (double strength) in "
 "combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Treason"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Awful"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Poor"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Normal"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Good"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Great"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Blood!"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:48
 msgid "Bad morale may cause your armies to freeze in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:49
 msgid ""
 "Neutral morale means your armies will never be blessed with extra attacks or "
 "freeze in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:50
 msgid "Good morale may give your armies extra attacks in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Knight"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Barbarian"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Sorceress"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Warlock"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Wizard"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Necromancer"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Multi"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Standing"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Crawling"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Very Slow"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Slow"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Average"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Very Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Ultra Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Blazing"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Instant"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:32
 msgid "week|PLAGUE"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Ant"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Grasshopper"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Dragonfly"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Spider"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Butterfly"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Bumblebee"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Locust"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Earthworm"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Hornet"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Beetle"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Squirrel"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Rabbit"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Gopher"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Badger"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Eagle"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Weasel"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Raven"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Mongoose"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Aardvark"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Lizard"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Tortoise"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Hedgehog"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Condor"
 msgstr ""
 
-#: ../fheroes2/kingdom/world_loadmap.cpp:1374
-msgid "The ultimate artifact is really the %{name}"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1378
-msgid ""
-"The ultimate artifact may be found in the %{name} regions of the world."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1383
-msgid "north-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1386
-msgid "north"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1388
-msgid "north-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1394
-msgid "west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1397
-msgid "center"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1399
-msgid "east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1404
-msgid "south-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1407
-msgid "south"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1409
-msgid "south-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1413
-msgid "The truth is out there."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1414
-msgid "The dark side is stronger."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1415
-msgid "The end of the world is near."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1416
-msgid "The bones of Lord Slayer are buried in the foundation of the arena."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1417
-msgid "A Black Dragon will take out a Titan any day of the week."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1418
-msgid ""
-"He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1420
-msgid ""
-"You can load the newest version of game from a site:\n"
-" http://sf.net/projects/fheroes2"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1421
-msgid "This game is now in beta development version. ;)"
-msgstr ""
-
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Desert"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Snow"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Wasteland"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Beach"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Lava"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:31 ../fheroes2/resource/maps_text.cpp:210
 msgid "Dirt"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Grass"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:31
-msgid "Water"
+msgid "Ocean"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Small"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Medium"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Large"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Extra Large"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Custom Size"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:122
 msgid "Ore Mine"
 msgstr "Rūdos kasykla"
 
-#: ../fheroes2/maps/maps.cpp:123
 msgid "Sulfur Mine"
 msgstr "Sieros kasykla"
 
-#: ../fheroes2/maps/maps.cpp:124
 msgid "Crystal Mine"
 msgstr "Kristalų kasykla"
 
-#: ../fheroes2/maps/maps.cpp:125
 msgid "Gems Mine"
 msgstr "Brangakmenių telkinys"
 
-#: ../fheroes2/maps/maps.cpp:126
 msgid "Gold Mine"
 msgstr "Aukso kasykla"
 
-#: ../fheroes2/maps/maps.cpp:130
 msgid "Mine"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:365
 msgid "Alchemist Lab"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:367
 msgid "Daemon Cave"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:369
 msgid "Faerie Ring"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:373 ../fheroes2/resource/maps_text.cpp:217
 msgid "Dragon City"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:375
-msgid "Light House"
+msgid "Lighthouse"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:377
 msgid "Water Wheel"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:379
 msgid "Mines"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:381
 msgid "Obelisk"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:383
 msgid "Oasis"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:385
 msgid "Sawmill"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:387
 msgid "Oracle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:389
 msgid "Desert Tent"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:393
 msgid "Wagon Camp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:395
 msgid "Windmill"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:397
 msgid "Random Town"
 msgstr "Atsitiktinis miestas"
 
-#: ../fheroes2/maps/mp2.cpp:399
 msgid "Random Castle"
 msgstr "Atsitiktinė pilis"
 
-#: ../fheroes2/maps/mp2.cpp:401
 msgid "Watch Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:403
 msgid "Tree City"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:405
 msgid "Tree House"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:407
 msgid "Ruins"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:409
 msgid "Fort"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:411
-msgid "Trading Post"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:413
 msgid "Abandoned Mine"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:415
 msgid "Tree of Knowledge"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:417
 msgid "Witch Doctor's Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:419
 msgid "Temple"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:421
 msgid "Hill Fort"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:423
 msgid "Halfling Hole"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:425
 msgid "Mercenary Camp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:429
 msgid "City of the Dead"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:433
 msgid "Sphinx"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:435
 msgid "Troll Bridge"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:437
 msgid "Witch Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:439
 msgid "Xanadu"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:443
 msgid "Magellan Maps"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:445
 msgid "Derelict Ship"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:447
-msgid "Ship Wreck"
+msgid "Shipwreck"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:449
 msgid "Observation Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:451
-msgid "Freeman Foundry"
+msgid "Freeman's Foundry"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:453
 msgid "Watering Hole"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:455
 msgid "Artesian Spring"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:457
 msgid "Gazebo"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:459
 msgid "Archer's House"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:461
 msgid "Peasant Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:463
 msgid "Dwarf Cottage"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:465
 msgid "Stone Liths"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:467
 msgid "Magic Well"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:468
 msgid "Heroes"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:469
-msgid "Sign"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:470 ../fheroes2/maps/mp2.cpp:488
-msgid "Shrub"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:471
 msgid "Nothing Special"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:472
 msgid "Tar Pit"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:473
-msgid "Coast"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:474
 msgid "Mound"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:475
 msgid "Dune"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:476
 msgid "Stump"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:477
 msgid "Cactus"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:478
 msgid "Trees"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:479
 msgid "Dead Tree"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:480
 msgid "Mountains"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:481
 msgid "Volcano"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:482
 msgid "Rock"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:483
 msgid "Flowers"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:484
 msgid "Water Lake"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:485
 msgid "Mandrake"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:486
 msgid "Crater"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:487
 msgid "Lava Pool"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:489
+msgid "Shrub"
+msgstr ""
+
 msgid "Buoy"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:491 ../fheroes2/monster/monster.cpp:115
-#: ../fheroes2/monster/monster.cpp:1199
 msgid "Skeleton"
-msgid_plural "Skeletons"
-msgstr[0] ""
-msgstr[1] ""
+msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:492
 msgid "Treasure Chest"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:493
 msgid "Sea Chest"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:494
 msgid "Campfire"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:495
 msgid "Fountain"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:496
 msgid "Genie Lamp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:497
 msgid "Goblin Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:499
 msgid "Monster"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:500
 msgid "Resource"
 msgstr "Ištekliai"
 
-#: ../fheroes2/maps/mp2.cpp:501
 msgid "Whirlpool"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:502
 msgid "Artifact"
 msgstr "Magiškas artefaktas"
 
-#: ../fheroes2/maps/mp2.cpp:503
 msgid "Boat"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:510
 msgid "Standing Stones"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:514
 msgid "Idol"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:515
 msgid "Shrine of the First Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:516
 msgid "Shrine of the Second Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:517
 msgid "Shrine of the Third Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:518
 msgid "Wagon"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:519
 msgid "Lean To"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:520
 msgid "Flotsam"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:521
 msgid "Shipwreck Survivor"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:522
 msgid "Bottle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:523
 msgid "Magic Garden"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:529
 msgid "Jail"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:531
 msgid "Traveller's Tent"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:532
 msgid "Barrier"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:535
 msgid "Fire Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:537
 msgid "Air Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:539
 msgid "Earth Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:541
 msgid "Water Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:543
 msgid "Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:545
-msgid "Arena"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:547
 msgid "Stables"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:549
 msgid "Alchemist's Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:551
 msgid "Hut of the Magi"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:553
 msgid "Eye of the Magi"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:555
 msgid "Mermaid"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:557
 msgid "Sirens"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:558
 msgid "Reefs"
 msgstr ""
 
-#: ../fheroes2/monster/monster.cpp:58 ../fheroes2/monster/monster.cpp:1147
-msgid "Peasant"
-msgid_plural "Peasants"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:58 ../fheroes2/resource/maps_text.cpp:501
-msgid "Peasants"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:59 ../fheroes2/monster/monster.cpp:1148
-msgid "Archer"
-msgid_plural "Archers"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:59
-msgid "Archers"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:60 ../fheroes2/monster/monster.cpp:1149
-msgid "Ranger"
-msgid_plural "Rangers"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Rangers"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:61 ../fheroes2/monster/monster.cpp:1150
-msgid "Pikeman"
-msgid_plural "Pikemen"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Pikemen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:62 ../fheroes2/monster/monster.cpp:1151
-msgid "Veteran Pikeman"
-msgid_plural "Veteran Pikemen"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Veteran Pikemen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:63 ../fheroes2/monster/monster.cpp:1152
-msgid "Swordsman"
-msgid_plural "Swordsmen"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Swordsmen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:64 ../fheroes2/monster/monster.cpp:1153
-msgid "Master Swordsman"
-msgid_plural "Master Swordsmen"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Master Swordsmen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:65 ../fheroes2/monster/monster.cpp:1154
-msgid "Cavalry"
-msgid_plural "Cavalries"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Cavalries"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:66 ../fheroes2/monster/monster.cpp:1155
-msgid "Champion"
-msgid_plural "Champions"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Champions"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:67 ../fheroes2/monster/monster.cpp:1156
-msgid "Paladin"
-msgid_plural "Paladins"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Paladins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:68 ../fheroes2/monster/monster.cpp:1157
-msgid "Crusader"
-msgid_plural "Crusaders"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Crusaders"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:71 ../fheroes2/monster/monster.cpp:1159
-msgid "Goblin"
-msgid_plural "Goblins"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:71
-msgid "Goblins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:72 ../fheroes2/monster/monster.cpp:1160
-msgid "Orc"
-msgid_plural "Orcs"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Orcs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:73 ../fheroes2/monster/monster.cpp:1161
-msgid "Orc Chief"
-msgid_plural "Orc Chiefs"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orc Chiefs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:74 ../fheroes2/monster/monster.cpp:1162
-msgid "Wolf"
-msgid_plural "Wolves"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Wolves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:75 ../fheroes2/monster/monster.cpp:1163
-msgid "Ogre"
-msgid_plural "Ogres"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Ogres"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:76 ../fheroes2/monster/monster.cpp:1164
-msgid "Ogre Lord"
-msgid_plural "Ogre Lords"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogre Lords"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:77 ../fheroes2/monster/monster.cpp:1165
-msgid "Troll"
-msgid_plural "Trolls"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Trolls"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:78 ../fheroes2/monster/monster.cpp:1166
-msgid "War Troll"
-msgid_plural "War Trolls"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "War Trolls"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:79 ../fheroes2/monster/monster.cpp:1167
-msgid "Cyclops"
-msgid_plural "Cyclopes"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "Cyclopes"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:82 ../fheroes2/monster/monster.cpp:1169
-msgid "Sprite"
-msgid_plural "Sprites"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:82
-msgid "Sprites"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:83 ../fheroes2/monster/monster.cpp:1170
-msgid "Dwarf"
-msgid_plural "Dwarves"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Dwarves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:84 ../fheroes2/monster/monster.cpp:1171
-msgid "Battle Dwarf"
-msgid_plural "Battle Dwarves"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Battle Dwarves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:85 ../fheroes2/monster/monster.cpp:1172
-msgid "Elf"
-msgid_plural "Elves"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Elves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:86 ../fheroes2/monster/monster.cpp:1173
-msgid "Grand Elf"
-msgid_plural "Grand Elves"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Grand Elves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:87 ../fheroes2/monster/monster.cpp:1174
-msgid "Druid"
-msgid_plural "Druids"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Druids"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:88 ../fheroes2/monster/monster.cpp:1175
-msgid "Greater Druid"
-msgid_plural "Greater Druids"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Greater Druids"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:89 ../fheroes2/monster/monster.cpp:1176
-msgid "Unicorn"
-msgid_plural "Unicorns"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Unicorns"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:90 ../fheroes2/monster/monster.cpp:1177
-msgid "Phoenix"
-msgid_plural "Phoenix"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:93 ../fheroes2/monster/monster.cpp:1179
-msgid "Centaur"
-msgid_plural "Centaurs"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:93
-msgid "Centaurs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:94 ../fheroes2/monster/monster.cpp:1180
-msgid "Gargoyle"
-msgid_plural "Gargoyles"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Gargoyles"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:95 ../fheroes2/monster/monster.cpp:1181
-msgid "Griffin"
-msgid_plural "Griffins"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Griffins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:96 ../fheroes2/monster/monster.cpp:1182
-msgid "Minotaur"
-msgid_plural "Minotaurs"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Minotaurs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:97 ../fheroes2/monster/monster.cpp:1183
-msgid "Minotaur King"
-msgid_plural "Minotaur Kings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaur Kings"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:98 ../fheroes2/monster/monster.cpp:1184
-msgid "Hydra"
-msgid_plural "Hydras"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Hydras"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:99 ../fheroes2/monster/monster.cpp:1185
-msgid "Green Dragon"
-msgid_plural "Green Dragons"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Green Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:100 ../fheroes2/monster/monster.cpp:1186
-msgid "Red Dragon"
-msgid_plural "Red Dragons"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Red Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:101 ../fheroes2/monster/monster.cpp:1187
-msgid "Black Dragon"
-msgid_plural "Black Dragons"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Black Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:104 ../fheroes2/monster/monster.cpp:1189
-msgid "Halfling"
-msgid_plural "Halflings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:104
-msgid "Halflings"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:105 ../fheroes2/monster/monster.cpp:1190
-msgid "Boar"
-msgid_plural "Boars"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Boars"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:106 ../fheroes2/monster/monster.cpp:1191
-msgid "Iron Golem"
-msgid_plural "Iron Golems"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Iron Golems"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:107 ../fheroes2/monster/monster.cpp:1192
-msgid "Steel Golem"
-msgid_plural "Steel Golems"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Steel Golems"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:108 ../fheroes2/monster/monster.cpp:1193
-msgid "Roc"
-msgid_plural "Rocs"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Rocs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:109 ../fheroes2/monster/monster.cpp:1194
-msgid "Mage"
-msgid_plural "Magi"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Magi"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:110 ../fheroes2/monster/monster.cpp:1195
-msgid "Archmage"
-msgid_plural "Archmagi"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Archmagi"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:111 ../fheroes2/monster/monster.cpp:1196
-msgid "Giant"
-msgid_plural "Giants"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:111 ../fheroes2/resource/maps_text.cpp:293
-msgid "Giants"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:112 ../fheroes2/monster/monster.cpp:1197
-msgid "Titan"
-msgid_plural "Titans"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:112
-msgid "Titans"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:115
-msgid "Skeletons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:116 ../fheroes2/monster/monster.cpp:1200
-msgid "Zombie"
-msgid_plural "Zombies"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:116
-msgid "Zombies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:117 ../fheroes2/monster/monster.cpp:1201
-msgid "Mutant Zombie"
-msgid_plural "Mutant Zombies"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Mutant Zombies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:118 ../fheroes2/monster/monster.cpp:1202
-msgid "Mummy"
-msgid_plural "Mummies"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mummies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:119 ../fheroes2/monster/monster.cpp:1203
-msgid "Royal Mummy"
-msgid_plural "Royal Mummies"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Royal Mummies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:120 ../fheroes2/monster/monster.cpp:1204
-msgid "Vampire"
-msgid_plural "Vampires"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Vampires"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:121 ../fheroes2/monster/monster.cpp:1205
-msgid "Vampire Lord"
-msgid_plural "Vampire Lords"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampire Lords"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:122 ../fheroes2/monster/monster.cpp:1206
-msgid "Lich"
-msgid_plural "Liches"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Liches"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:123 ../fheroes2/monster/monster.cpp:1207
-msgid "Power Lich"
-msgid_plural "Power Liches"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Power Liches"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:124 ../fheroes2/monster/monster.cpp:1208
-msgid "Bone Dragon"
-msgid_plural "Bone Dragons"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Bone Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:127 ../fheroes2/monster/monster.cpp:1210
-msgid "Rogue"
-msgid_plural "Rogues"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:127
-msgid "Rogues"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:128 ../fheroes2/monster/monster.cpp:1211
-msgid "Nomad"
-msgid_plural "Nomads"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Nomads"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:129 ../fheroes2/monster/monster.cpp:1212
-msgid "Ghost"
-msgid_plural "Ghosts"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Ghosts"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:130 ../fheroes2/monster/monster.cpp:1213
-msgid "Genie"
-msgid_plural "Genies"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Genies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:131 ../fheroes2/monster/monster.cpp:1214
-msgid "Medusa"
-msgid_plural "Medusas"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Medusas"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:132 ../fheroes2/monster/monster.cpp:1215
-msgid "Earth Elemental"
-msgid_plural "Earth Elementals"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Earth Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:133 ../fheroes2/monster/monster.cpp:1216
-msgid "Air Elemental"
-msgid_plural "Air Elementals"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Air Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:134 ../fheroes2/monster/monster.cpp:1217
-msgid "Fire Elemental"
-msgid_plural "Fire Elementals"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Fire Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:135 ../fheroes2/monster/monster.cpp:1218
-msgid "Water Elemental"
-msgid_plural "Water Elementals"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Water Elementals"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:693
-msgid "buy"
-msgstr "pirkti"
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:158
-msgid "Campaign Game"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "Error"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "This release is compiled without network support."
-msgstr ""
-
-#: ../fheroes2/resource/artifact.cpp:51
 msgid "Ultimate Book of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:51 ../fheroes2/resource/artifact.cpp:77
-#: ../fheroes2/resource/artifact.cpp:78 ../fheroes2/resource/artifact.cpp:79
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "The %{name} increases your knowledge by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:52
 msgid "Ultimate Sword of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:52 ../fheroes2/resource/artifact.cpp:68
-#: ../fheroes2/resource/artifact.cpp:71 ../fheroes2/resource/artifact.cpp:74
-#: ../fheroes2/resource/artifact.cpp:75 ../fheroes2/resource/artifact.cpp:149
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "The %{name} increases your attack skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:53
 msgid "Ultimate Cloak of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:53 ../fheroes2/resource/artifact.cpp:70
-#: ../fheroes2/resource/artifact.cpp:73 ../fheroes2/resource/artifact.cpp:76
 msgid "The %{name} increases your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:54
 msgid "Ultimate Wand of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:54 ../fheroes2/resource/artifact.cpp:59
-#: ../fheroes2/resource/artifact.cpp:60 ../fheroes2/resource/artifact.cpp:61
-#: ../fheroes2/resource/artifact.cpp:62 ../fheroes2/resource/artifact.cpp:148
 msgid "The %{name} increases your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:55
 msgid "Ultimate Shield"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:55 ../fheroes2/resource/artifact.cpp:128
-#: ../fheroes2/resource/artifact.cpp:129
-msgid ""
-"The %{name} increases your attack and defense skills by %{count} each."
+msgid "The %{name} increases your attack and defense skills by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:56
 msgid "Ultimate Staff"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:56 ../fheroes2/resource/artifact.cpp:130
-#: ../fheroes2/resource/artifact.cpp:131
-msgid ""
-"The %{name} increases your spell power and knowledge by %{count} each."
+msgid "The %{name} increases your spell power and knowledge by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "Ultimate Crown"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "The %{name} increases each of your basic skills by %{count} points."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "Golden Goose"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "The %{name} brings in an income of %{count} gold per turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:59
 msgid "Arcane Necklace of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:60
 msgid "Caster's Bracelet of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:61
 msgid "Mage's Ring of Power"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:62
 msgid "Witch's Broach of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:63
 msgid "Medal of Valor"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:63 ../fheroes2/resource/artifact.cpp:64
-#: ../fheroes2/resource/artifact.cpp:65 ../fheroes2/resource/artifact.cpp:66
 msgid "The %{name} increases your morale."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:64
 msgid "Medal of Courage"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:65
 msgid "Medal of Honor"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:66
 msgid "Medal of Distinction"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "Fizbin of Misfortune"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "The %{name} greatly decreases your morale by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:68
 msgid "Thunder Mace of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "Armored Gauntlets of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "The %{name} increase your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:70
 msgid "Defender Helm of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:71
 msgid "Giant Flail of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "Ballista of Quickness"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "The %{name} lets your catapult fire twice per combat round."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:73
 msgid "Stealth Shield of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:74
 msgid "Dragon Sword of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:75
 msgid "Power Axe of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:76
 msgid "Divine Breastplate of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:77
 msgid "Minor Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:78
 msgid "Major Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:79
 msgid "Superior Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "Foremost Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:81
 msgid "Endless Sack of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:81 ../fheroes2/resource/artifact.cpp:82
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "The %{name} provides you with %{count} gold per day."
 msgstr "%{name} teikia jums %{count} aukso monetų per dieną."
 
-#: ../fheroes2/resource/artifact.cpp:82
 msgid "Endless Bag of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "Endless Purse of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:84
 msgid "Nomad Boots of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:84 ../fheroes2/resource/artifact.cpp:85
 msgid "The %{name} increase your movement on land."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:85
 msgid "Traveler's Boots of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:86
 msgid "Lucky Rabbit's Foot"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:86 ../fheroes2/resource/artifact.cpp:87
-#: ../fheroes2/resource/artifact.cpp:88 ../fheroes2/resource/artifact.cpp:89
 msgid "The %{name} increases your luck in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:87
 msgid "Golden Horseshoe"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:88
 msgid "Gambler's Lucky Coin"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:89
 msgid "Four-Leaf Clover"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "True Compass of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "The %{name} increases your movement on land and sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "Sailor's Astrolabe of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "The %{name} increases your movement on sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "Evil Eye"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "The %{name} reduces the casting cost of curse spells by half."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "Enchanted Hourglass"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:93
-msgid ""
-"The %{name} extends the duration of all your spells by %{count} turns."
+msgid "The %{name} extends the duration of all your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "Gold Watch"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "The %{name} doubles the effectiveness of your hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "Skullcap"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "The %{name} halves the casting cost of all mind influencing spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "Ice Cloak"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "The %{name} halves all damage your troops take from cold spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "Fire Cloak"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "The %{name} halves all damage your troops take from fire spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "Lightning Helm"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "The %{name} halves all damage your troops take from lightning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid "Evercold Icicle"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid ""
 "The %{name} causes your cold spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid "Everhot Lava Rock"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid ""
 "The %{name} causes your fire spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid "Lightning Rod"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid ""
 "The %{name} causes your lightning spells to do %{count} percent more damage "
 "to enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "Snake-Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "The %{name} halves the casting cost of all your bless spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid "Ankh"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid ""
 "The %{name} doubles the effectiveness of all your resurrect and animate "
 "spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "Book of Elements"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "The %{name} doubles the effectiveness of all your summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "Elemental Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "The %{name} halves the casting cost of all summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "Holy Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "The %{name} makes all your troops immune to curse spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "Pendant of Free Will"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "The %{name} makes all your troops immune to hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "Pendant of Life"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "The %{name} makes all your troops immune to death spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "Serenity Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "The %{name} makes all your troops immune to berserk spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "Seeing-eye Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "The %{name} makes all your troops immune to blindness spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "Kinetic Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "The %{name} makes all your troops immune to paralyze spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "Pendant of Death"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "The %{name} makes all your troops immune to holy spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "Wand of Negation"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "The %{name} protects your troops from the Dispel Magic spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid "Golden Bow"
 msgstr "Auksinis lankas"
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid ""
 "The %{name} eliminates the %{count} percent penalty for your troops shooting "
-"past obstacles. (e.g. castle walls)"
+"past obstacles (e.g. castle walls)."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid "Telescope"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid ""
 "The %{name} increases the amount of terrain your hero reveals when "
 "adventuring by %{count} extra square."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid "Statesman's Quill"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid ""
 "The %{name} reduces the cost of surrender to %{count} percent of the total "
 "cost of troops you have in your army."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "Wizard's Hat"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "The %{name} increases the duration of your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "Power Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "The %{name} returns %{count} extra power points/turn to your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "Ammo Cart"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
-msgid ""
-"The %{name} provides endless ammunition for all your troops that shoot."
+msgid "The %{name} provides endless ammunition for all your troops that shoot."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "Tax Lien"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "The %{name} costs you %{count} gold pieces/turn."
 msgstr "%{name} kainuos jums %{count} aukso monetų per dieną."
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "Hideous Mask"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "The %{name} prevents all 'wandering' armies from joining your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "Endless Pouch of Sulfur"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:122 ../fheroes2/resource/artifact.cpp:175
+#, fuzzy
 msgid "The %{name} provides %{count} unit of sulfur per day."
-msgid_plural "The %{name} provides %{count} units of sulfur per day."
-msgstr[0] "%{name} teikia %{count} sieros vnt. per dieną."
-msgstr[1] "%{name} teikia %{count} sieros vnt. per dieną."
-msgstr[2] "%{name} teikia %{count} sieros vnt. per dieną."
+msgstr "%{name} teikia %{count} sieros vnt. per dieną."
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "Endless Vial of Mercury"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:123 ../fheroes2/resource/artifact.cpp:178
+#, fuzzy
 msgid "The %{name} provides %{count} unit of mercury per day."
-msgid_plural "The %{name} provides %{count} units of mercury per day."
-msgstr[0] "%{name} teikia %{count} gyvsidabrio vnt. per dieną."
-msgstr[1] "%{name} teikia %{count} gyvsidabrio vnt. per dieną."
-msgstr[2] "%{name} teikia %{count} gyvsidabrio vnt. per dieną."
+msgstr "%{name} teikia %{count} gyvsidabrio vnt. per dieną."
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "Endless Pouch of Gems"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:124 ../fheroes2/resource/artifact.cpp:181
+#, fuzzy
 msgid "The %{name} provides %{count} unit of gems per day."
-msgid_plural "The %{name} provides %{count} units of gems per day."
-msgstr[0] "%{name} teikia %{count} brangakmenį per dieną."
-msgstr[1] "%{name} teikia %{count} brangakmenius per dieną."
-msgstr[2] "%{name} teikia %{count} brangakmenių per dieną."
+msgstr "%{name} teikia %{count} brangakmenį per dieną."
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "Endless Cord of Wood"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:125 ../fheroes2/resource/artifact.cpp:184
+#, fuzzy
 msgid "The %{name} provides %{count} unit of wood per day."
-msgid_plural "The %{name} provides %{count} units of wood per day."
-msgstr[0] "%{name} teikia %{count} medienos vnt. per dieną."
-msgstr[1] "%{name} teikia %{count} medienos vnt. per dieną."
-msgstr[2] "%{name} teikia %{count} medienos vnt. per dieną."
+msgstr "%{name} teikia %{count} medienos vnt. per dieną."
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "Endless Cart of Ore"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:126 ../fheroes2/resource/artifact.cpp:187
+#, fuzzy
 msgid "The %{name} provides %{count} unit of ore per day."
-msgid_plural "The %{name} provides %{count} units of ore per day."
-msgstr[0] "%{name} teikia %{count} geležies rūdos vnt. per dieną."
-msgstr[1] "%{name} teikia %{count} geležies rūdos vnt. per dieną."
-msgstr[2] "%{name} teikia %{count} geležies rūdos vnt. per dieną."
+msgstr "%{name} teikia %{count} geležies rūdos vnt. per dieną."
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "Endless Pouch of Crystal"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "The %{name} provides %{count} unit of crystal/day."
 msgstr "%{name} teikia %{count} kristalą per dieną."
 
-#: ../fheroes2/resource/artifact.cpp:128
 msgid "Spiked Helm"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "Spiked Shield"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:130
 msgid "White Pearl"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "Black Pearl"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "Magic Book"
 msgstr "Magiška knyga"
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "The %{name} enables you to cast spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "Spell Scroll"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid "Arm of the Martyr"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid ""
 "The %{name} increases your spell power by %{count} but adds the undead "
 "morale penalty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "Breastplate of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "The %{name} increases your defense by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid "Broach of Shielding"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid ""
 "The %{name} provides %{count} percent protection from Armageddon and "
 "Elemental Storm, but decreases spell power by 2."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid "Battle Garb of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid ""
 "The %{name} combines the powers of the three Anduran artifacts.  It provides "
 "maximum luck and morale for your troops and gives you the Town Portal spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid "Crystal Ball"
 msgstr "Krištolinis kamuolys"
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid ""
 "The %{name} lets you get more specific information about monsters, enemy "
 "heroes, and castles nearby the hero who holds it."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid "Heart of Fire"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid ""
 "The %{name} provides %{count} percent protection from fire, but doubles the "
 "damage taken from cold."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid "Heart of Ice"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid ""
 "The %{name} provides %{count} percent protection from cold, but doubles the "
 "damage taken from fire."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:148
 msgid "Helmet of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:149
 msgid "Holy Hammer"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "Legendary Scepter"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "The %{name} adds %{count} points to all attributes."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "Masthead"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
-msgid ""
-"The %{name} boosts your luck and morale by %{count} each in sea combat."
+msgid "The %{name} boosts your luck and morale by %{count} each in sea combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "Sphere of Negation"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "The %{name} disables all spell casting, for both sides, in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "Staff of Wizardry"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "The %{name} boosts your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "Sword Breaker"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "The %{name} increases your defense by %{count} and attack by 1."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "Sword of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "Spade of Necromancy"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "The %{name} gives you increased necromancy skill."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:166
-msgid "The %{name} extends the duration of all your spells by %{count} turn."
-msgid_plural ""
-"The %{name} extends the duration of all your spells by %{count} turns."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/resource/artifact.cpp:169
-msgid "The %{name} increases the duration of your spells by %{count} turn."
-msgid_plural ""
-"The %{name} increases the duration of your spells by %{count} turns."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/resource/artifact.cpp:172
-msgid "The %{name} returns %{count} extra power point/turn to your hero."
-msgid_plural ""
-"The %{name} returns %{count} extra power points/turn to your hero."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../fheroes2/resource/artifact.cpp:190
-msgid "The %{name} provides %{count} unit of crystal per day."
-msgid_plural "The %{name} provides %{count} units of crystal per day."
-msgstr[0] "%{name} teikia %{count} kristalą per dieną."
-msgstr[1] "%{name} teikia %{count} kristalus per dieną."
-msgstr[2] "%{name} teikia %{count} kristalų per dieną."
-
-#: ../fheroes2/resource/artifact.cpp:627
 msgid ""
 "You find an elaborate aontainer which housesan old vellum scroll. The runes "
 "on the container are very old, and the artistry with whitch it was put "
@@ -7023,7 +5400,6 @@ msgid ""
 "magical power."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:628
 msgid ""
 "One of the less intelligent members of your party picks up an arm off of the "
 "ground. Despite its missing a body, it is still moving. Your troops find the "
@@ -7032,7 +5408,6 @@ msgid ""
 "making."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:629
 msgid ""
 "You come upon a sign. It reads: \"Here lies the body of Anduran. Bow and "
 "swear fealty, and you shall be rewarded.\" You decide to do as it says. As "
@@ -7040,21 +5415,18 @@ msgid ""
 "that you are suddenly wearing a gleaming, ornate breastplate."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:630
 msgid ""
 "A kindly Sorceress thinks that your army's defenses could use a magical "
 "boost. She offers to enchant the Broach that you wear on your cloak, and you "
 "accept."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:631
 msgid ""
 "Out of pity for a poor peasant, you purchase a chest of old junk they are "
 "hawking for too much gold. Later, as you search through it, you find it "
 "contains the 3 pieces of the legendary battle garb of Anduran!"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:632
 msgid ""
 "You come upon a caravan of gypsies who are feasting and fortifying their "
 "bodies with mead. They call you forward and say \"If you prove that you can "
@@ -7063,7 +5435,6 @@ msgid ""
 "Crystal Ball."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:633
 msgid ""
 "You enter a recently burned glade and come upon a Fire Elemental sitting "
 "atop a rock. It looks up, its flaming face contorted in a look of severe "
@@ -7071,7 +5442,6 @@ msgid ""
 "it, but it passes right through them and sears itself into your chest."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:634
 msgid ""
 "Suddenly, a biting coldness engulfs your body. You seize up, falling from "
 "your horse. The pain subsides, but you still feel as if your chest is "
@@ -7080,7 +5450,6 @@ msgid ""
 "woods and disappear."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:635
 msgid ""
 "You spy a gleaming object poking up out of the ground. You send a member of "
 "your party over to investigate. He comes back with a golden helmet in his "
@@ -7088,7 +5457,6 @@ msgid ""
 "only man who was known to wear solid gold armor."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:636
 msgid ""
 "You come upon a battle where a Paladin has been mortally wounded by a group "
 "of Zombies. He asks you to take his hammer and finish what he started.  As "
@@ -7096,7 +5464,6 @@ msgid ""
 "Zombies lie dead, the hammer dripping with blood. You strap it to your belt."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:637
 msgid ""
 "Upon cresting a small hill, you come upon a ridiculous looking sight. A "
 "Sprite is attempting to carry a Scepter that is almost as big as it is. "
@@ -7105,7 +5472,6 @@ msgid ""
 "flying anyway.\""
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:638
 msgid ""
 "An old seaman tells you a tale of an enchanted masthead that he used in his "
 "youth to rally his crew during times of trouble. He then hands you a faded "
@@ -7113,14 +5479,12 @@ msgid ""
 "underneath a nearby dock."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:639
 msgid ""
 "You stop to help a Peasant catch a runaway mare. To show his gratitude, he "
 "hands you a tiny sphere. As soon as you grasp it, you feel the magical "
 "energy drain from your limbs..."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:640
 msgid ""
 "While out scaring up game, your troops find a mysterious staff levitating "
 "about three feet off of the ground. They hand it to you, and you notice an "
@@ -7128,13 +5492,11 @@ msgid ""
 "words, and you'll win every fight.\""
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:641
 msgid ""
 "A former Captain of the Guard admires your quest and gives you the enchanted "
 "Sword Breaker that he relied on during his tour of duty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:642
 msgid ""
 "A Troll stops you and says: \"Pay me 5,000 gold, or the Sword of Anduran "
 "will slay you where you stand.\" You refuse. The troll grabs the sword "
@@ -7143,4472 +5505,81 @@ msgid ""
 "sharp objects."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:643
 msgid ""
 "A dirty shovel has been thrust into a dirt mound nearby. Upon investigation, "
 "you discover it to be the enchanted shovel of the Gravediggers, long thought "
 "lost by mortals."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:892
 msgid ""
 "Do you want to use your knowledge of magical secrets to transcribe the "
-"%{spell} Scroll into your spell book?\n"
-"The Scroll will be consumed.\n"
-" Spell point: %{sp}"
+"%{spell} Scroll into your Magic Book?\n"
+"The Spell Scroll will be consumed.\n"
+" Cost in spell points: %{sp}"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:956
-msgid "Open book"
+msgid "Transcribe Spell Scroll"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:961
-msgid "Transcribe scroll"
+msgid "View Spells"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:971
-#: ../fheroes2/resource/artifact.cpp:1004
+#, fuzzy
+msgid "View %{name} Info"
+msgstr "Žiūrėti %{name}"
+
 msgid "Move %{name}"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:994
 msgid "Cannot move artifact"
 msgstr "Negalima perkelti artefakto"
 
-#: ../fheroes2/resource/maps_text.cpp:15
-msgid ""
-"425 bottles of beer on the wall, 425 bottles of beer! If one of those "
-"bottles should happen to fall, there'll be..."
+msgid "This item can't be traded."
 msgstr ""
 
-#: ../fheroes2/resource/maps_text.cpp:16
-msgid "A balanced scenario with lots of resources and land to explore."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:17
-msgid ""
-"A bandit army of gorgons jump you without warning.  they stone your entire "
-"army demand 500 gold before they will release your comrads.  Realizing that "
-"it is much cheeper to pay then rebuild your army you part with the gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:18
-msgid "Abandon All Hope!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:19
-msgid "Abandon All Hope Ye That Enter Here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:20
-msgid "A bit of crystal!"
-msgstr "Šiek tiek kristalų!"
-
-#: ../fheroes2/resource/maps_text.cpp:21
-msgid "A bit of mercury!"
-msgstr "Šiek tiek gyvsidabrio!"
-
-#: ../fheroes2/resource/maps_text.cpp:22
-msgid "A bit of sulfur!"
-msgstr "Šiek tiek sieros!"
-
-#: ../fheroes2/resource/maps_text.cpp:23
-msgid ""
-"Above you looms the ancient Ice Palace.  Dimly remembered myth speaks of a "
-"Prince who rejected the advances of the Winter Goddess, and thus he and his "
-"domain were cursed to remain shrouded in ice, hidden in a forgotten corner "
-"of the world.  It is said that he can only be rescued by a hero who is both "
-"clever and bold.  Are you that one?  Do you dare enter this frozen domain?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:24
-msgid "A cache of crystal!"
-msgstr "Kristalų slaptavietė!"
-
-#: ../fheroes2/resource/maps_text.cpp:25
-msgid "A cache of gems!"
-msgstr "Brangakmenių slaptavietė!"
-
-#: ../fheroes2/resource/maps_text.cpp:26
-msgid "A cache of gold!"
-msgstr "Aukso slaptavietė!"
-
-#: ../fheroes2/resource/maps_text.cpp:27
-msgid "A cache of mercury!"
-msgstr "Gyvsidabrio slaptavietė!"
-
-#: ../fheroes2/resource/maps_text.cpp:28
-msgid "A cache of sulfur!"
-msgstr "Sieros slaptavietė!"
-
-#: ../fheroes2/resource/maps_text.cpp:29
-msgid ""
-"A chance to end a bitter war has finally arrived as a new resource-laden "
-"land has been discovered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:30
-msgid "A chunk of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:31
-msgid "A chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:32
-msgid "A couple of gems!"
-msgstr "Pora brangakmenių!"
-
-#: ../fheroes2/resource/maps_text.cpp:33
-msgid "\"Act of Desperation\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:34
-msgid ""
-"A desert isle rich in resources rewards the quick.  Just be sure to watch "
-"your back!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:35
-msgid "A dolphin playfully jumps into the air."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:36
-msgid ""
-"A Dragon, A Cyclops, or an Undead. King of the Centaurs, His name is ....?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:37
-msgid "A flight of dragons circles overhead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:38
-msgid "A flock of seagulls circle overhead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:39
-msgid "A friendly dolphin splashes alongside the ship."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:40
-msgid ""
-"After a long search of the island, I have discovered that there is no way "
-"for me to escape without help.  I can not steal a ship from one of the "
-"coastal castles, and I dare not venture into the desert unless I wish to "
-"become Dragon food.  Should anyone find this, I beg of you, please send a "
-"ship and get me off this cursed island!  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:41
-msgid ""
-"After centuries of friendship, the Wizards have suddenly decided to stop "
-"sharing their Library with the rest of the world.  This can't be good!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:42
-msgid ""
-"After many years of peace, you discover that your sworn enemy from across "
-"the sea has chosen to invade your homeland by raising up the ocean floor to "
-"bridge the distance! You must not let them gain a foothold on this "
-"continent, in fact, your King has ordered you to establish a foothold on "
-"theirs!  To make matters worse, two of your OWN towns have thrown in their "
-"lots with the enemy..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:43
-msgid ""
-"After you return from a scouting trip, your Seneschal hurries to greet you.  "
-"\"My Lord, in your absence I signed an agreement in your name with a Master "
-"Merchant.  If we supply him with the resources he needs, through trading, he "
-"can return the resources to us in a week or so, plus some additional ones.\" "
-" The Seneschal eyes you anxiously.  You hesitate, then nod slowly, \"Good, "
-"we can use more resources>\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:44
-msgid "A ghostly pirate ship appears and sails on by."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:45
-msgid ""
-"A Gift from your King, and a note that reads \"Use these resources wisely, "
-"It's all we have left\"."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:46
-msgid ""
-"A gift of gold, m'lord, from the people of Enroth, to the people of Enroth.  "
-"Good luck, and may God save true King Roland!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:47
-msgid "A glint by a tree catches your eye..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:48
-msgid "A gold cache!"
-msgstr "Aukso skrynia!"
-
-#: ../fheroes2/resource/maps_text.cpp:49
-msgid "A gold chunk!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:50
-msgid "A gold nugget!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:51
-msgid ""
-"A great Black dragon stands before you. It speaks in a suprisingly soft "
-"voice, saying, \"The elves believe they have sent another hero to reclaim "
-"their prize. I believe they have sent me another meal.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:52
-msgid ""
-"A group of peasant farmers approaches you, \"We are in dire need of your "
-"assistance.  Our castle to the north has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:53
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance.  Our castle to the east has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:54
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance. Our castle to the east has been overrun and our Lord killed. "
-"Please help us regain our homes! There are still women and children there! "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:55
-msgid ""
-"A group of peasant farmers approach you, We are in dire need of your "
-"assistance.  Our castle to the northeast has been overrun and our Lord "
-"killed.  Please help us regain our homes!  There are still women and "
-"children there!  Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:56
-msgid "A handful of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:57
-msgid ""
-"Ah, you stumble across something buried in the sand.  As you dig it up you "
-"discover a small pile of gems and crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:58
-msgid ""
-"A Knight and Necromancer team up against the Barbarian and Sorceress. (Blue "
-"and Green vs Red and Yellow)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:60
-msgid ""
-"A large contingent of the king's guard approaches you.  \"Ahh, we have "
-"finally caught up to you.  The king requires tribute from all of his vassals "
-"and you have been negligent far too long.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:61
-msgid ""
-"A large map with lots of resources and treasure. Exploration and victory "
-"will require many heroes."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:62
-msgid "A legion of peasants stands between you and this unclaimed island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:63
-msgid "Algary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:64
-msgid "A little bit closer..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:65
-msgid "All mines are grouped by type. Trade is your only hope."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:66
-msgid "A lump of crystal!"
-msgstr "Krūva kristalų!"
-
-#: ../fheroes2/resource/maps_text.cpp:67
-msgid "A lump of gold!"
-msgstr "Aukso luitas!"
-
-#: ../fheroes2/resource/maps_text.cpp:68
-msgid "A lump of mercury!"
-msgstr "Krūva gyvsidabrio!"
-
-#: ../fheroes2/resource/maps_text.cpp:69
-msgid ""
-"A man appears from behind the sand dune. \"At last,\" he says, \"Someone has "
-"come to rescue me! I am forever grateful. Alas all I have to offer you in "
-"return are these souvenirs from my wrecked ship.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:70
-msgid ""
-"A man is laying on the ground, near death. He looks to you and speaks, "
-"\"Please help my companions! Please... they can't...cough...get away "
-"from...cough...the drag...\" With that, he dies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:71
-msgid ""
-"A merchant caravan arrives, bringing gold and supplies, however, no one can "
-"seem to remember where they came from.  You silently praise this anonymous "
-"benefactor and continue your duties."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:72
-msgid "a mirror"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:73
-msgid "An albatross flies ahead of the ship for a while"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:74
-msgid "Anduran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:75
-msgid ""
-"An enemy from across the sea has seized half your towns.  Can you put aside "
-"your own feud with your brother to fight this common enemy?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:76
-msgid "\"Annexation\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:77
-msgid ""
-"An old elf is sitting on a rock in a glen, pounding on the shackles on his "
-"feet with a stone. You help him remove them and ask him his tale. \"I'm a "
-"deserter from Drakonia's army. She has enslaved all the elves to support her "
-"madness. She must be stopped.\" Then he slips into the woods without a "
-"sound, leaving behind just his cloak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:78
-msgid "Antioch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:79
-msgid "A piece of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:80
-msgid "A pile of crystal!"
-msgstr "Kristalų krūvelė!"
-
-#: ../fheroes2/resource/maps_text.cpp:81
-msgid "A pile of gems!"
-msgstr "Brangakmenių krūvelė!"
-
-#: ../fheroes2/resource/maps_text.cpp:82
-msgid "A pile of gold!"
-msgstr "Aukso krūvelė!"
-
-#: ../fheroes2/resource/maps_text.cpp:83
-msgid ""
-"A plague of undead is upon us. Who will unite the living against the dead?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:84
-msgid "\"Apocalypse\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:85
-msgid "A quantity of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:86
-msgid "A quantity of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:87
-msgid "A quantity of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:89
-msgid ""
-"Archibald has also sent an army to find the Crown, you must find it first or "
-"all is lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:90
-msgid "Archibald is hiding at the end of the river."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:91
-msgid ""
-"A resource rich valley keeps the Wizard and the Necromancer apart. Your "
-"opponent's army will arrive in 3 months so hurry."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:92
-msgid "Arm of the Crusader"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:93
-msgid "Arm of the Cyclops"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:94
-msgid "Arm of the Dragon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:95
-msgid "Arm of the Phoenix"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:96
-msgid "Arm of the Titan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:97
-msgid "Arr' Here be pirates gold buried."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:98
-msgid "A shipment of wood has arrived from your kingdom!"
-msgstr "Medienos krovinys gautas iš jūsų karalystės!"
-
-#: ../fheroes2/resource/maps_text.cpp:99
-msgid ""
-"A splash in the seaweed alerts you to a mermaid waving in a friendly manner. "
-"\"Oh, I thought you were Ahab.\" She is surprised, but quickly composes "
-"herself. \"Well, if you meet him, give him these treasures I have "
-"collected.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:100
-msgid "Assassins tried to kill our ally."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:101
-msgid "Astircaer"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:102
-msgid ""
-"A stranded Wizard with only a small force must conquer an entire continent "
-"of hostile forces."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:103
-msgid ""
-"A supply ship has arrived from the homeland!  You send word home that all is "
-"well."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:104
-msgid ""
-"As you approach the barrier, you see the old elf you helped free. This time, "
-"however, you see that he is wearing a cape of fine weave, and a wooden crown "
-"is on his head. He sees your forces, and says \"Take this sword, and with "
-"it, strike down Drakonia and help free my people.\" The old elf then strides "
-"regally into the woods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:105
-msgid ""
-"As you approach the gates of the Ice Palace, one of your troops points in "
-"terror.  You watch in awe as great slabs of ice separate from the castle "
-"walls with loud cracking reports and crash to the ground.  Soon the ice is "
-"gone and the sun begins to peak through the gloom.  The deathly silence that "
-"must have ruled these lands for centuries ends as birds begin to sing.  From "
-"inside you hear the sounds of life."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:106
-msgid ""
-"As you approach the tent, the leader of the nomads comes out to greet you. "
-"He says, \"It was prophecied many years ago that a great hero would come to "
-"greet us in our sacred valley, and we would prosper afterwords. Now it has "
-"come to pass, and we offer you these gifts as tokens of our thanks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:107
-msgid ""
-"As you approach,  you hear whispered mentions of \"the wild barbarian who "
-"passed this way months before\". One of the villagers approaches you and "
-"hands you an object, saying \"The wild one dropped this. You must be his "
-"kin. Therefore I give it to you. But beware! Many in the village will not be "
-"as friendly as I.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:108
-msgid ""
-"As you break your fast your sage rushes in, \"Good news, my lord!  I have "
-"translated the message.  Two great heroes were imprisoned many years ago.  "
-"They lie sleeping - still guarded by magic barriers and monsters.  My lord, "
-"they lie nearby- in between our ally and us.  If we could free them, they "
-"would surely aid us against our enemies!  The password to the first magic "
-"barrier can be learned at the Aqua Traveller's Tent.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:109
-msgid ""
-"As you enter the small clearing, you see a familiar figure talking to a "
-"group of halflings and soldiers. You stay awhile and listen to his speech. "
-"\"The time to throw off these chains of tyranny is now! We must strike at "
-"the heart of her empire, and destroy the evil that she has brought to our "
-"land.\" As the old elf finishes speaking, he gets up from his mossy seat and "
-"once again, blends into the woods with incredible grace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:110
-msgid ""
-"As you lay down to nap after a long battle, you notice a lucky four-leaf "
-"clover."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:111
-msgid ""
-"As you make  your way through the last of the golemn debris, a group of "
-"halflings runs towards you carrying fruit and flowers. \"Thank you so "
-"much!\" Their leader exclaims, \"We've been trapped in here for ever! Come "
-"by our homes, we'll pack up and go with you!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:112
-msgid ""
-"As you make your way to the shrine, some very thin and hollow-eyed men come "
-"out of the flower patch and stare at you.  Seeing that you want the gold, "
-"one of them says to you \"Hey, man, if you're, like, so lusty for earthly "
-"wealth, then, like, have this too.\" You graciously take what they have "
-"offered and back out of the clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:113
-msgid ""
-"As you prepare your lands to fight the onslaught from the South, a curious "
-"message appears on your table in the Great Hall of your Castle.  Written in "
-"some ancient language, none but your sage can make any sense of it.  She "
-"promises to have the words deciphered by tomorrow..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:114
-msgid "A three hour tour, a three hour tour..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:115
-msgid ""
-"A tiny gnome points to a chunk of crystal you otherwise would have "
-"overlooked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:116
-msgid "Atlantium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:117
-msgid ""
-"At last, the king is dead.  For years you have planned his demise, but now "
-"it is done, and there is no heir to take his place, though the Knights to "
-"the south believe that they are the rightful successors.  A wealth in wood "
-"(to the south) and ore (in the northern mountains) provides you with trade "
-"goods, and your isolation has allowed you to prepare your forces of darkness "
-"for this day.  Go, now, and fulfill your destiny!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:118
-msgid ""
-"At the base of the mountain you see something that glitters.   You discover "
-"an ancient pile of offerings to the gods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:119
-msgid "Avalon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:120
-msgid "Avone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:121
-msgid ""
-"A wild magic has allowed a bridge to form between two lands...  Your one "
-"hope is to capture castle \"Black Fang\"."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:122
-msgid "Barbarian's castle lies to the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:123
-msgid ""
-"Barbarians from the north threaten all civilization. Can you repel the "
-"hordes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:124
-msgid "\"Barbarian Wars\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:125
-msgid "Barrowton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:126
-msgid "Basenji"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:127
-msgid "Bayside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:128
-msgid "Baywatch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:129
-msgid ""
-"Because the Darkscale Valley is so barren, the Emperor will be sending wood "
-"to you every week. Use it wisely, for it is all you shall have."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:130
-msgid ""
-"Before questing for the orb of negation, you must first crush the local "
-"opposition. After the Sorceresses are removed from the earth, go east where "
-"legend says the orb lies.  You may expect a convoy of supplies in a week or "
-"so to aid your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:131
-msgid ""
-"Before you may pass, the spirit guardian of this valley demands tribute."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:132
-msgid "Being held...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:133
-msgid "Beltway"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:134
-msgid "\"Betrayal!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:135
-msgid "Beware -- Entering Hyrda Country"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:136
-msgid "Beware for whom the bell trolls."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:137
-msgid "Beware of Pirates!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:138
-msgid "Beware of thieves!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:139
-msgid "Beware of traps ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:140
-msgid "Beware of Warlocks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:141
-msgid "Beware the deadly swamps!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:142
-msgid "Beware the Domain of Dragons"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:143
-msgid "Beware the Dragon Leader"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:144
-msgid "Beware the edge of the world!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:145
-msgid "Beware the moors and stick to the roads."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:146
-msgid "Beware the rocks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:147
-msgid "Beware the sirens!!!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:148
-msgid "Beware the sirens!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:149
-msgid "Beware the whiporwill..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:150
-msgid "Beware, the whirlpool may not take you into a friendly embrace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:151
-msgid "Beyond here be Dragons!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:152
-msgid "Beyond the door, there be Dragons. BEWARE!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:153
-msgid "Big Oak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:154
-msgid "Blackburn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:155
-msgid "Blackfang"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:156
-msgid "Black Fang"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:157
-msgid "Black Oak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:158
-msgid "Blackridge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:159
-msgid "Blacksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:160
-msgid "Black Vein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:161
-msgid "Blackwind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:162
-msgid "Bloodreign"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:163
-msgid "Boats my be needed to access some parts of this peninsula."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:164
-msgid "Boats Sold Here            Inquire Within"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:165
-msgid "BoneVille"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:166
-msgid "Borderlands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:167
-msgid "Bridge out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:168
-msgid "Bridge Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:169
-msgid "Brindamoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:170
-msgid "Broken Alliance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:171
-msgid "Brownston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:172
-msgid "Buried Treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:173
-msgid "Burlock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:174
-msgid "Burton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:175
-msgid ""
-"Capture the necromancer's dreaded castle \"Death Gate\" and free the land "
-"from the undead plague."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:176
-msgid ""
-"Capture the town on the island off the southeast shore in order to construct "
-"a boat and travel back towards the mainland."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:177
-msgid "\"Carator Mines\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:178
-msgid "Cathcart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:180
-msgid "Chandler"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:181
-msgid "Chilton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:182
-msgid "Chronos"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:183
-msgid "Come and...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:184
-msgid ""
-"Compared to the rest of the villages in this land, this village seems grand, "
-"but in any other land it would seem poor. From here you can see the tall "
-"spires of the Warlock's tower of Dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:185
-msgid "Complete"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:186
-msgid "Condemned!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:187
-msgid ""
-"Congratulations! After navigating the treacherous coast, you have "
-"established trade between the north and south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:188
-msgid "Corackston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:189
-msgid "Corlagon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:190
-msgid "\"Country Lords\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:191
-msgid "Crossroads"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:192
-msgid "Crossroads North"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:193
-msgid "Crossroads South"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:195
-msgid "Danger a whirlpool destroyed my ship."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:196
-msgid "Danger, Dragons abound!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:197
-msgid "DANGER!  QUICKSAND!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:198
-msgid "Danger! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:199
-msgid "Danger - Turn Back Now"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:200
-msgid "Dark clouds loom overhead as you enter this valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:201
-msgid "Dead Pine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:202
-msgid ""
-"Dear Diary,                           I found a mermaid today.  She was "
-"floating in a patch of seaweed next to a rock.  A very friendly sort of "
-"creature too!  Gave me all sorts of lovely gems and jewelry!  She said to "
-"come back again sometime for more of the sea riches.  Wow. Ahab"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:203
-msgid "Deathgate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:204
-msgid "DeathGate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:205
-msgid "Decisions"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:206
-msgid "\"Defender\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:207
-msgid ""
-"Destroy the Barbarians who are attacking the southern border of your "
-"kingdom! Recover your towns and then invade the jungle kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:208
-msgid ""
-"Detour! Mountain pass to the East has been known to have avalanches! For "
-"your own safety, follow the road South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:209
-msgid "Detour! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:211
-msgid "DirtWater"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:212
-msgid "Dominion"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:213
-msgid "Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:214
-msgid "Do not remove coins from fountain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:215
-msgid "Dragadune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:216
-msgid "Dragonburg"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:218
-msgid "Dragon City lies beyond the Scorpion Hills."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:219
-msgid "Dragon Hill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:220
-msgid "\"Dragon Master\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:221
-msgid "Dragon Rider"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:222
-msgid "Dragons Everywhere!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:223
-msgid "Dragon's Eye"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:224
-msgid "Dragontooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:225
-msgid "Dragon Town"
-msgstr "Drakonų miestas"
-
-#: ../fheroes2/resource/maps_text.cpp:226
-msgid "Dragonville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:227
-msgid "Dragon Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:228
-msgid "Dragon Watch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:230
-msgid "Drakoran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:231
-msgid "Dwarfhall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:232
-msgid "Dwarfhall, Domain of the dwarf King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:233
-msgid "Dwarf Hall, domain of the dwarf King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:234
-msgid "Eatio"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:235
-msgid "Edgewood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:236
-msgid "Elk's Head"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:237
-msgid "Elowyn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:238
-msgid "Enroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:239
-msgid "Entering high in the desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:240
-msgid "Entering Praires of the Middlelands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:241
-msgid "Entering the desert high"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:242
-msgid "Entering the high desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:243
-msgid "Entering the higher desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:244
-msgid "Entering the Valley of Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:245
-msgid "Erliquin"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:246
-msgid "Evil Igor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:247
-msgid "Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:248
-msgid "Fantasy Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:249
-msgid "Farlien"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:250
-msgid ""
-"Federal express, when it absolutely positively has to be there turn one."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:251
-msgid "fedx comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:252
-msgid "Fedx for comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:253
-msgid "Fenton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:254
-msgid "Fetid Elm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:255
-msgid ""
-"Final message from Overlord. \"The royal executioners are on their way. My "
-"gold, the land or your head- it's your choice.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:256
-msgid "Find and defeat the Pirate Leader!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:257
-msgid "Find and destroy the evil beings who rule the wastelands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:258
-msgid "Find the center island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:259
-msgid ""
-"Find the Ultimate Artifact and be proclaimed King, or smash the opposition "
-"and take control."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:260
-msgid ""
-"Find Your Wayward Son who is rumored to be living in the desolate lands. Do "
-"it within 8 weeks or it will be of no help to your family."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:261
-msgid "Fire King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:262
-msgid "\"First Blood\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:263
-msgid "Five heroes vie for control of a familiar land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:264
-msgid "Fool's Gold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:265
-msgid ""
-"For a total of 400,000 gold your opponents will become \"loyal\" subjects, "
-"otherwise... let them eat cake!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:266
-msgid ""
-"For centuries, the Wizards of the North have maintained a vast library for "
-"all the world to share.  Now, however, they have closed their doors, and "
-"issued declarations of war to each of the other rulers of the land.  To make "
-"matters worse, rather than ally with you to face the Wizards, each of the "
-"others have decided to go forth on their own in an effort to conquer this "
-"land for themselves!  Prepare your forces, commander, for you now stand "
-"alone."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:267
-msgid "\"Force of Arms\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:268
-msgid ""
-"For decades you have studied, learned, and allowed yourself to be ruled by "
-"that pitiful excuse for a king, knowing that one day the time would come for "
-"you to sit on the throne.  That time is now, for the king is dead and "
-"without an heir.  You have the advantage of isolation from the rest of the "
-"kingdom, but beware the miles of coastline that could leave you vulnerable "
-"to attack.  Go, now, and wipe your enemies from this land!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:269
-msgid "Forder Oaks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:270
-msgid "Forestria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:271
-msgid "For Honor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:272
-msgid ""
-"For information about Ye Rich lands to the south, speak to Alponse at the "
-"Golden Goose Tavern. Excellent views, plentiful water."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:273
-msgid "Forsaken Lands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:274
-msgid "For sale."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:275
-msgid "Fortress Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:276
-msgid ""
-"For years, you have existed peacefully in the Forest of Dreams, knowing that "
-"your king was the kindest and strongest ruler the land had seen in "
-"centuries.  Now, however, his reign is at an end, and there is no heir to "
-"succeed him.  You realize that a power struggle is coming, and that you must "
-"brace yourself for war, and prevent those who would harm this land from "
-"coming into power!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:277
-msgid ""
-"For years, you've been able to keep your subjects \"appeased.\"  Now "
-"however, you discover not only that your entire kingdom has turned against "
-"you, but most of your outer towns have fallen to the different factions.  To "
-"make matters worse, all your gold suddenly seems to be missing from the "
-"treasury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:278
-msgid "Fountainhead"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:279
-msgid "Four kingdoms race to capture the island of Sharkania."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:280
-msgid "Four lakes have castles, three have treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:281
-msgid "Four players must work together to assault the Wizards' Stronghold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:282
-msgid "Frozenpeak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:283
-msgid "Full House"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:284
-msgid ""
-"Gain the aid of the elves. They will not allow trees to be chopped down, so "
-"we will send you wood every 2 weeks. You have 7 months!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:286
-msgid "Galveston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:287
-msgid "Garamok"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:288
-msgid "Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:289
-msgid "Gate to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:290
-msgid "Gate to The Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:291
-msgid "Gaurdian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:292
-msgid "Gavonshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:294
-msgid "Glastonbury"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:295
-msgid "Go away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:296
-msgid "GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:297
-msgid "Goblin Island"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:298
-msgid "Goblin King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:299
-msgid "Go Home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:300
-msgid "Go north to find the lost gold-mine."
-msgstr "Dingusią aukso kasyklą rasite šiaurėje."
-
-#: ../fheroes2/resource/maps_text.cpp:301
-msgid "Good vs. Evil"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:302
-msgid "Gorgomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:303
-msgid "\"Greater Glory\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:304
-msgid "Greed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:305
-msgid "Green bonus stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:306
-msgid "Green gets stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:307
-msgid "Greenroot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:308
-msgid "Green's Allowance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:309
-msgid "Green's Groceries"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:310
-msgid "green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:311
-msgid "Green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:312
-msgid "Greywind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:313
-msgid "Grim"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:314
-msgid "Grrr, Blazzer, Grrupt. Be gone with you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:315
-msgid "Guardian War"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:316
-msgid "Gungtooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:317
-msgid "Hail Unicorns!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:318
-msgid "Hampshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:319
-msgid "Have fun storming the castle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:320
-msgid "Havenwood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:321
-msgid "Hawkins"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:322
-msgid "Help!"
-msgstr "Pagalbos!"
-
-#: ../fheroes2/resource/maps_text.cpp:323
-msgid "Help me...."
-msgstr "Padėkite man...."
-
-#: ../fheroes2/resource/maps_text.cpp:324
-msgid ""
-"Help peasant farmers regain their castle and land, else they'll take your "
-"crops."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:325
-msgid "Hero's Hall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:326
-msgid ""
-"High in the snowy crags, you meet an old witch who, in return for a trinket "
-"of yours, gives you a powerful magical object she used to use as a footstool "
-"before she was exiled into the mountains by her own townspeople."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:327
-msgid "Hillstone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:328
-msgid "Hilltop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:329
-msgid "Hilltown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:330
-msgid "Horizon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:331
-msgid "Hot Spot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:332
-msgid "Hungry dragons await.  Welcome, food."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:333
-msgid "Hurry, no time to wait.  This way to the dock."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:334
-msgid "Hurry up! Few days are left before the enemy's army arrives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:335
-msgid "I am...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:336
-msgid ""
-"I am one of the few remaining survivors of the wrecked pleasure ship, "
-"Exhorbitance. I think we'll all be dead of hunger soon, for we are out of "
-"caviar. We ate the chef yesterday."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:337
-msgid "Ibn Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:338
-msgid "Ice Palace"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:339
-msgid "Ice Prince"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:340
-msgid "Icy lands ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:341
-msgid "I didn't do it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:342
-msgid ""
-"If three heroes could dig six holes in three days, how long would it take "
-"six heroes to dig twelve holes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:343
-msgid "If you free a hero, they may help..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:344
-msgid ""
-"If you value your lives, for God's sake, Don't go through this whirlpool!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:345
-msgid "Income for Yellow."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:346
-msgid "In the hole you find a chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:347
-msgid "In the stream you find an old compass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:348
-msgid "In this glen live some very naughty halflings. Stay Away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:349
-msgid ""
-"In two more weeks, if you have not located Joseph, your kingdom will surely "
-"lose its current battle with Harondale."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:350
-msgid "I see you, you see me."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:351
-msgid "Is it something I said? Go back and I will forget the whole thing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:352
-msgid "IslandHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:353
-msgid "Island of the Elves"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:354
-msgid "Island of the meek"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:355
-msgid "Island of Wolcott"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:356
-msgid "Isle Maze"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:357
-msgid "Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:358
-msgid ""
-"It has become apparent that if all your enemies were eliminated, you would "
-"have all the time you need to find the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:359
-msgid ""
-"It is obvious that the mage that once was here had won many battles!  There, "
-"upon his hand, is a most powerful ring!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:360
-msgid ""
-"It is rumored that a bridge of land used to exist between the two "
-"continents, but that a wild magic caused it to sink into the sea, taking "
-"with it all those who used to inhabit it.  To try to raise this bridge is to "
-"invite a curse upon the world!  The spirits of the dead will haunt us all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:361
-msgid ""
-"It is said that King Zealot found the gods' artifact once and it let him "
-"rule for 100 years."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:362
-msgid ""
-"It looks like there used to be an ore mine here but all you see now is a "
-"hole in the ground and some minerals scattered around."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:363
-msgid ""
-"It's a battle for supremacy as the Blue and Green heroes take on Red and "
-"Orange in team competition!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:364
-msgid "It's windy at the top.  Defend, Divide, and Conquer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:365
-msgid "IvanHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:366
-msgid "Ivan lives in the desert."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:367
-msgid "Ivory Gates"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:368
-msgid ""
-"I, Wilgatus, besiege you - do not fight me for I am all powerful and will "
-"destroy you if you persue me.  I will demonstrate my power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:369
-msgid "I Would Go That Way If I Were You."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:371
-msgid "Jarkonas VI"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:372
-msgid "Jolly Roger was here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:374
-msgid "Jungomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:375
-msgid "Just 30 days left!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:376
-msgid "Just ONE week left!"
-msgstr "Liko tik VIENA savaitė!"
-
-#: ../fheroes2/resource/maps_text.cpp:378
-msgid "Kastor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:379
-msgid "Keep going south"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:380
-msgid "Keep Off The Grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:381
-msgid "Keep Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:382
-msgid "King John"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:383
-msgid "King of Death"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:384
-msgid "Knight's Trail."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:385
-msgid "Knight stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:386
-msgid "Lakeside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:387
-msgid "Land's Edge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:388
-msgid "Land teleporters will get you to your destination sooner."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:389
-msgid "Lankershire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:390
-msgid "Lavalor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:391
-msgid "Like, Stuff And Junk?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:392
-msgid ""
-"Living on the outskirts of the kingdom, you are considered an unwelcome "
-"outcast by the other leaders of the realm, though you always showed your "
-"support for the king.  Now, however, the king is dead, and many of those who "
-"spoke out againt him seek to seize his throne for themselves.  You have a "
-"vast desert at your back, rich with gems, and the advantage that many do not "
-"consider you a threat.  Go, now, and show them how wrong they are!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:393
-msgid "Lladner Dock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:394
-msgid ""
-"Log go up... Log go down... Log go up... Log go down...  OOoohhhhhhhh........"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:395
-msgid "Lombard"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:396
-msgid "Long live Roland the true King!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:397
-msgid "Long live Roland the true King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:398
-msgid "Look before you leap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:399
-msgid "Look out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:400
-msgid "Lord Alberon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:401
-msgid ""
-"Lord Alberon calls you into his war room. He says, \"I am glad you have "
-"chosen to remain loyal to me, but this war is a terrible one for my kingdom. "
-"Already, the sorceress' towns to the Northeast have become unsure about "
-"their loyalties, and will not pledge allegiance to either side. This is hard "
-"on our cities as most of the wood in the land comes from these towns. We "
-"will need to recover their sawmills and take their towns by force.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:402
-msgid "Lord Haart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:404
-msgid "Lord Kreager"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:405
-msgid ""
-"Lord, messages have begun pouring in from our spies in the other island "
-"courts.  They have learned of a new volcanic island with vast amounts of "
-"reasources.  Your Majesty, with these new reasources we could put an end to "
-"a century of war between the islands, and reunite them under your rightful "
-"rule."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:406
-msgid "Lost Continent"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:407
-msgid "Lost Gold- Mine"
-msgstr "Dingusi aukso kasykla"
-
-#: ../fheroes2/resource/maps_text.cpp:408
-msgid "Lost Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:409
-msgid "Lost Relic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:410
-msgid "Maelstrom of Deceit"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:411
-msgid "Maelstrom of Misery"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:412
-msgid "Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:413
-msgid "Magic Three"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:414
-msgid ""
-"Many dust plumes rise from the floor of this small valley. You see various "
-"bands of nomads roaming about, and in the distant, the bright flames of "
-"their camp."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:415
-msgid ""
-"Many guardians stand between you and your enemies, but anybody can sneak "
-"through the back door!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:416
-msgid "Many that have gone through this door have never returned."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:417
-msgid ""
-"Many years ago, a couple of mages had a \"duel\" that forever changed the "
-"lake at the center of this continent.  Hearty adventurers might find "
-"interesting treasure there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:418
-msgid ""
-"Many years ago, a falling star crashed near here.  Only now the area is safe "
-"enough to explore.  Rumor has it a castle exist where the star fell."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:419
-msgid ""
-"Many years ago, your father, the King, died in a freak hunting accident.  "
-"Since then, you and your brother have jointly ruled his kingdom, but both of "
-"you have been seeking a way to seize the throne for yourself.  You got your "
-"wish.  Attackers from across the sea have captured more than half your towns "
-"and castles, effectively dividing the continent in two.  Now is the time to "
-"repel these invaders and do away with your brother once and for all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:420
-msgid "Marco"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:421
-msgid "Marsh Home"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:423
-msgid "Mayland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:424
-msgid "Meramec"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:425
-msgid "Message from Archibald. \" Do not dare to return without my Crown.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:426
-msgid ""
-"Message from Archibald. \" General, thank you for bringing me this lovely "
-"gift. I have decided to participate directly in the capture of my brother "
-"Roland. Since your military advice has taken us this far, I will follow your "
-"orders to the letter.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:427
-msgid "Message from Overlord. \"STILL WAITING FOR MY GOLD!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:428
-msgid "Message from Overlord. \"WHERE'S MY GOLD?\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:429
-msgid ""
-"Message from Roland. \"General, circumstances permit me to take a hand in "
-"the events of this final conflict. I have your spoils of war with me and I "
-"will follow your advice explicitly.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:430
-msgid ""
-"Message from Roland.  \"General, I have sent most of our troops and material "
-"ahead to the region of the final conflict with Archibald.  Unfortunately, "
-"Lord Corlagon has cut us off from the rest of our army.  I will be awaiting "
-"your victory in a castle across the west river.  I should be safe from "
-"attack.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:431
-msgid ""
-"Message from Roland. \" We cannot hope to defeat Archibald without the "
-"Crown, I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:432
-msgid "Middle Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:433
-msgid "Middleton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:434
-msgid "Middletown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:435
-msgid "Might vs. Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:436
-msgid "Mineral Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:437
-msgid "Mirkosov"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:438
-msgid "mirror"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:439
-msgid "Money For Red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:440
-msgid "MONEY, MONEY, MONEY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:441
-msgid "Morale becomes even lower as the endless cliffs move past."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:442
-msgid ""
-"More water than land, you'll still spend lots of time on foot as you search "
-"a literal horde of islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:443
-msgid "Mountain king"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:444
-msgid "Mountainview"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:445
-msgid "Mr Ed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:446
-msgid "Mr. Yellow's Income"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:447
-msgid "Murray's resort Isle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:448
-msgid ""
-"Mutiny!  The crew has dumped off my precious cargo into the sea!  Thank "
-"goodness it floats - when I've rid of them, I'll come back to pick it up!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:449
-msgid ""
-"My leige, our scouts report three other lords are attacking from the south. "
-"They work in conjuction with each other to eliminate us! We must keep this "
-"castle and remove the threat of the enemy. We wish you luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:450
-msgid ""
-"My leige, we have established a foothold (which we cannot afford to lose) "
-"and all of our Heroes have joined us. The king has made us the offer to "
-"purchase this land for 200,000 gold or we may take it by force. The local "
-"lords have been fighting and each wants to be the one that defeats us. Now "
-"all the local armies have arrived on the beach, creating a state of complete "
-"Pandemonium!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:451
-msgid "My Treasure Is Buried Beneath Three Palm Trees"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:452
-msgid "\"Necromancers!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:453
-msgid "New Dawn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:454
-msgid "New Enemies"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:455
-msgid "New Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:456
-msgid "Nightshadow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:457
-msgid "No Description"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:458
-msgid "No Fishing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:459
-msgid "No gems, crystal, or mercury for red."
-msgstr "Raudonasis negavo brangakmenių, kristalų bei gyvsidabrio."
-
-#: ../fheroes2/resource/maps_text.cpp:460
-msgid ""
-"None of the four leaders like being stuck in a land that has only one season."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:461
-msgid "NO, Not That Way. This Way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:462
-msgid "No one has ever made it out of the deadly swamps alive!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:463
-msgid "Noraston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:464
-msgid "North Road"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:465
-msgid "North vs. South"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:466
-msgid "No stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:467
-msgid "No sulfer fer Yella."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:468
-msgid "No swimming."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:469
-msgid "Notice- Those who put messages in bottles will be tortured."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:470
-msgid "No Trespassing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:471
-msgid "No tresspath...  No tree...  No thresh...  GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:472
-msgid "Now leaving Swamplands of the Eternial"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:473
-msgid "Obsidian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:474
-msgid "Of the necromancers...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:475
-msgid "Ogrehild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:476
-msgid "Olympus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:477
-msgid ""
-"One of the seers in your castle comes to you in the morning with urgent "
-"news. Your one time comrade, the wizard Joseph, and his armies have been "
-"imprisoned in a jail nearby. His power would surely aid you in your quest to "
-"reclaim the library, you think to yourself. Perhaps there is a way to rescue "
-"him..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:478
-msgid ""
-"One of your aides reports that the Castle of Farlien is located on the "
-"northeast spur of this island, and is a stronghold for the enemy. He urges "
-"you to take it out as soon as possible, and then move onto other islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:479
-msgid ""
-"One of your \"allies\" has joined Archibald.  You now face an opponent with "
-"three castles to your one.  Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:480
-msgid ""
-"One of your \"Allies\" has joined Roland. You are now facing three castles, "
-"all belonging to the enemy. Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:481
-msgid "One of your loyal goblins has brought you an armload of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:482
-msgid ""
-"One of your loyal subjects, a fairy tells you where to find a cache of "
-"mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:483
-msgid ""
-"One of your scouts reports a tiny cave nearby. Upon investigating, you "
-"discover a small cache of goods. In the dirt by them is etched 'Ivan'."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:484
-msgid ""
-"One of your troops stubs its paw on something buried here.  After a few "
-"hours of digging you unearth a cache of treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:485
-msgid "Only a month remains in which to find Joseph."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:486
-msgid "On quite days, Nubbie the sea monster can be seen!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:487
-msgid "Orange stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:488
-msgid "Orcville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:489
-msgid "Ostoroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:490
-msgid "Other than the dragons, the elves don't have any enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:491
-msgid "Our ally was greatly weakened when his resources were plundered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:492
-msgid "\"Our Finest Hour\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:493
-msgid "Our reinforcements were lost in a storm, we salvaged all we could!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:494
-msgid ""
-"Our spies have discovered that the barbarian hordes are now receiving "
-"support from kraeger! You must hurry and find the third piece before your "
-"forces here are crushed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:495
-msgid "Overlord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:496
-msgid "Pandemonium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:497
-msgid "Paper can gain you what wood and sail cannot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:498
-msgid "Password found by Crystals to the South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:499
-msgid "Peacekeeper"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:500
-msgid "\"Peasants!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:502
-msgid "Peasantsville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:503
-msgid "Perenor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:504
-msgid "Pet Cemetary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:505
-msgid "Pick one of four Knights in this large and inhospitable land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:506
-msgid "Pig's Eye"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:507
-msgid "Pinehurst"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:508
-msgid "Pirate Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:509
-msgid "Pirate's Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:510
-msgid "Pirate Utopia"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:511
-msgid "Pirites strike and take the gold from you holds."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:512
-msgid "Pixie"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:513
-msgid ""
-"Play the Knight or Barbarian in an alliance in this classic duel against the "
-"four spell casters. (Blue and Green vs Red)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:514
-msgid "Please...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:515
-msgid ""
-"Plenty of resources and lots of ground to cover. Watch out for Orange and "
-"Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:516
-msgid "Portals"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:517
-msgid "Portsmith"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:518
-msgid "POSION - DO NOT DRINK"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:519
-msgid "Powerful magic lies southwest of here in the Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:520
-msgid "Prisoner on...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:522
-msgid "Quick Silver"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:523
-msgid "Raste"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:524
-msgid "Realm of the Undead.  Fresh blood welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:525
-msgid "Red bonus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:526
-msgid "Red player sympathizes with the undead cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:527
-msgid "Red's Connection"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:528
-msgid "Redshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:529
-msgid "Red's Lunch Money"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:530
-msgid "Red's Rubles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:531
-msgid "Red stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:532
-msgid ""
-"Regrettably, you have no castle with which to begin your assault. "
-"Fortunately, however, Kraeger's forces are weak here in the south, and you "
-"have bribed a rebel necromancer to aid you in the beginning of your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:533
-msgid "Reinforcements have arrived, Gold from the homelands!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:534
-msgid ""
-"Remains of a long since dead wizard have attracted an ancient artifact.  "
-"This artifact has now attached itself to you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:535
-msgid ""
-"Remember, you're searching for the Ultimate Artifact... don't get distracted!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:536
-msgid ""
-"Rendall Koski was here. 1997.  Northampton, Massachusetts There is a "
-"powerful artifact in the southeastern corner of the world.  Go for it, "
-"explorer!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:537
-msgid ""
-"Reports from your spies tell of enemies on the march.  As you rush to the "
-"castle courtyard to prepare your armies, you are intercepted by your "
-"Chaplain.  \"My Lord, I have received word that we should send what Heroes "
-"we can to the Isle of Knowledge.   The Scholars there have agreed to teach "
-"them so they will be strong for the battles ahead of us.\"  You thank the "
-"Chaplain for the information and head thoughtfully into the courtyard."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:538
-msgid ""
-"Rescue your crazy Uncle Ivan. Find him within 4 months or it will be no help "
-"to your kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:539
-msgid "Restricted Area, Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:540
-msgid "Rest stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:541
-msgid "Retake the Castle of Ivory Gates."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:542
-msgid "Revolution"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:543
-msgid "Right thinking - he who takes the riskes deserves the rewards."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:544
-msgid "River Crossing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:545
-msgid "Road Ends"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:546
-msgid "Road to Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:547
-msgid "Road to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:548
-msgid ""
-"Robbers have looted your treasury and you have lost valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:549
-msgid "Robbers have looted your treasury, stealing valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:550
-msgid "Roc Haven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:551
-msgid "Rogar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:553
-msgid "Roscomon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:554
-msgid "Rotten Birch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:555
-msgid ""
-"Rumors abound and your faithful hero Sandro is now highly regarded by the "
-"masses. Should Sandro desert you, all will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:556
-msgid "Sandcaster"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:558
-msgid "Sands of Time"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:559
-msgid "Sansobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:560
-msgid "\"Save the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:561
-msgid "Scabsdale"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:562
-msgid "Scorched Earth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:563
-msgid ""
-"Scouts have reported a town to the North.  They have also heard some "
-"disturbing news.  Their seems to be a war raging in this area."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:564
-msgid ""
-"Scouts report the enemy's stronghold lies to the Southwest. Our swift "
-"arrival has caught them by surprise. If you move quickly their resistance "
-"will be minimal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:565
-msgid ""
-"Scouts report the notorious necromancer \"Wyrm\" has been sighted to the "
-"northeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:566
-msgid "Scummy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:567
-msgid ""
-"Searching in the dust of this abandoned campsite, you find a magic scroll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:568
-msgid "Seasons Change"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:569
-msgid "Secret Mountain Pass"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:570
-msgid ""
-"Seek out the Ultimate Artifact to be victorious in this strangely shaped "
-"land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:571
-msgid ""
-"Seek the great library, for only with the guidance of the musty tomes therin "
-"will you find the means to reveal and bind the fount to your will."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:572
-msgid "Seven Lakes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:573
-msgid "Sharkania"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:574
-msgid "Sheltemburg"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:575
-msgid "Sherman"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:576
-msgid "Shipwrecked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:577
-msgid ""
-"Should this message ever reach home, please know that this has become a "
-"hostile place since the King's death.  No less than six factions are at war "
-"with each other, each seeking to be the King's successor.  Beware especially "
-"of the Barbarians and the Necromancers who control the north, their regions "
-"are easily defended and they have a wealth of gold and gems.  Do not venture "
-"to this land without a sizeable force.  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:578
-msgid "Sirein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:579
-msgid ""
-"Six factions have established a foothold on a huge, unexplored continent.  "
-"Can you eliminate the other five?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:580
-msgid ""
-"Six heroes with large armies prepare to slug it out for total domination!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:581
-msgid "Skirmish"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:582
-msgid "\"Slay the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:583
-msgid "Slippery when wet."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:584
-msgid "Slugfest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:585
-msgid ""
-"Snagged on a thorny bush, you discover a scrap of cloth. The design on it "
-"looks like the coat of arms of Ivan's house!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:586
-msgid "Snowdrop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:587
-msgid "Somebody has stuffed a pile of gems in the ditch!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:588
-msgid "Some crystal!"
-msgstr "Truputis kristalų!"
-
-#: ../fheroes2/resource/maps_text.cpp:589
-msgid "Some gems!"
-msgstr "Truputis brangakmenių!"
-
-#: ../fheroes2/resource/maps_text.cpp:590
-msgid ""
-"Someone has stolen 100 wood and 77 ore from you. Ah, that's nothing. Let's "
-"keep going."
-msgstr ""
-"Kažkas pavogė iš tavęs 100 vnt. medienos bei 77 vnt. rūdos. Ai, ką padarysi. "
-"Reikia gyventi toliau."
-
-#: ../fheroes2/resource/maps_text.cpp:591
-msgid ""
-"Someone has stolen gold and resources from  the palace treasury!  You "
-"suspect your enemies, but you can't know for certain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:592
-msgid "Someone is playing a pan flute around here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:593
-msgid ""
-"Someone notices a piece of parchment lying behind a clump of grass. You pick "
-"it up. It looks to be a page from a journal, and it reads, \"...made it past "
-"the first guardians. Hopefully will reach the ancient desert city soon. Only "
-"hope my forces are strong enough to survive...\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:594
-msgid "Some ore!"
-msgstr "Šiek tiek rūdos!"
-
-#: ../fheroes2/resource/maps_text.cpp:595
-msgid "Some sulfur!"
-msgstr "Truputis sieros!"
-
-#: ../fheroes2/resource/maps_text.cpp:596
-msgid ""
-"Some unlucky adventurers have been captured and imprisoned in these lands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:597
-msgid "Sorceress Forest.  Show respect for nature!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:598
-msgid "Sorpigal"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:599
-msgid "South Mill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:600
-msgid "So you think you're smart?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:601
-msgid "Spector"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:602
-msgid "Spell Casters"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:603
-msgid ""
-"Spies report Roland has sent a hero to search for the Crown. If he finds it "
-"first, all is lost!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:604
-msgid "Spirit City"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:605
-msgid "Spy Tower - see what your competition is doing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:606
-msgid "Stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:607
-msgid ""
-"Start with five castles!  How could you lose!?  Oh yeah, everyone else "
-"starts with five, too."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:608
-msgid "Stick to the road!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:609
-msgid "Stromgild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:610
-msgid "Stromhild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:611
-msgid "Stronghold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:612
-msgid "Stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:613
-msgid "Stuff for Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:614
-msgid "Stuff For Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:615
-msgid "Subbaculcha"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:616
-msgid "Sundune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:617
-msgid "Surf and Turf"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:618
-msgid "Swimming near the kelp is a pod of dolphins."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:619
-msgid "Tacma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:620
-msgid "Tchudes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:621
-msgid "Teleporters"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:622
-msgid "Terra Firma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:623
-msgid "Terrain Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:624
-msgid ""
-"The alliance has crumbled and all are at war. Lots of resources but little "
-"time to prepare."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:625
-msgid ""
-"The ancient King Zealot had the artifact of the gods and then hid it in his "
-"old age so that it could not be used by others."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:626
-msgid "The Back Door"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:627
-msgid ""
-"The Barbarian's lands are being invaded. Are you strong enough to resist the "
-"invasion?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:628
-msgid ""
-"The castle of Drakonran in the east has been taken by the barbarians! Two "
-"other towns to the west have also been taken, but the barbarian armies were "
-"fairly decimated in the process."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:629
-msgid "The center island is rumored to harbor great spells."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:630
-msgid "The Citadel"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:631
-msgid "The cities of the plains."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:632
-msgid "The Clearing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:633
-msgid ""
-"The convoy has at long last arrived. Regretably, it has been beset by "
-"bandits on its journey here, and has far less supplies than we had hoped. "
-"Make your way south, for our spies have found rich mines there."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:634
-msgid ""
-"The convoy should have been here by now! Let us hope that it is safe and "
-"still on its way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:635
-msgid ""
-"The country lords have allied and pooled their resources into one command. "
-"Not only have they massed their forces in the north, but they have sent a "
-"knight to the west to steal your supplies. Scouts report a castle to the "
-"east that would be ideal as a base of operations."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:636
-msgid ""
-"The crew are unworthy!  I am not going down with the ship! -The Captain"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:637
-msgid "\"The Crown\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:638
-msgid ""
-"The day you have feared has finally arrived.  The king, who you have "
-"faithfully served, has died, leaving no heir to his throne.  As his captain, "
-"you feel that this job should now be yours, but several factions even now "
-"are preparing for conquest.  You are at the center of the trade routes, "
-"having the sea to the south and the great forest to the north.  Go, now, "
-"Commander, and claim what is rightfully yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:639
-msgid ""
-"The diplomats who were sent here ahead of you report that the elves will "
-"only cooperate with you if you will recover the golden bow for them. It was "
-"stolen by their enemies, the Dragons and hidden behind magic barriers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:640
-msgid "The Eastern Town."
-msgstr "Rytų miestas."
-
-#: ../fheroes2/resource/maps_text.cpp:641
-msgid "The edge of the world is your edge.  But prepare to be prepared."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:642
-msgid "The Emerald Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:643
-msgid "The Enchanted Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:644
-msgid "The End of the World is Nigh!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:645
-msgid "The End of the World is Nigh"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:646
-msgid ""
-"The Epic battle against Your Rival! Eliminate everything! Total Warfare! "
-"Don't Lose your first hero!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:647
-msgid ""
-"The Fire King is an ally to the dragons, and will help a friend of theirs."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:648
-msgid "The First One To Take Astircaer Wins!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:649
-msgid ""
-"The first piece of the artifact now lies in the hands of the Unholy Order of "
-"Warlocks. You must annihilate them, and their allies to the north. They will "
-"surely give us what we seek in exchange for their feeble lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:650
-msgid ""
-"The Fortune of Infamous Uae was buried on one of these islands. She died "
-"without ever revealing it.  Find it before the other cutthroats."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:651
-msgid "The four factions race to capture a mystical castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:652
-msgid ""
-"The four spell casters face off with substantial starting armies. Can the "
-"crusaders keep the peace?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:653
-msgid "\"The Gauntlet\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:654
-msgid ""
-"The Gods have given you 6 months to prove yourself. Good or Evil - who shall "
-"prevail? (Blue,Green and Red vs Yellow, Orange and Purple)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:655
-msgid ""
-"The gods have granted this world a great artifact, to find it means victory."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:656
-msgid "The Gods themselves will aid us in this War."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:657
-msgid "The Gold Traveller's Tent is near the Aqua Taveller's Tent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:658
-msgid "The guardians of Dragon Isle reside in the jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:659
-msgid "The Ice Prince stands frozen in some forgotten corner of the world."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:660
-msgid "The island...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:661
-msgid "The Island of Lost Reason"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:662
-msgid "The islands have much wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:663
-msgid "The Isle of Armoria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:664
-msgid "The key to success is rubbing enough lamps."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:665
-msgid ""
-"The King has declared you his hier apparent and champion. You must seek out "
-"and destroy your common enemy, Wilgatus and his Castle, Mirkosov, the source "
-"of his power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:666
-msgid ""
-"The King is dead, his kingdom has been shattered, and six leaders seek to "
-"seize power for themselves."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:667
-msgid "The Kingly Wastes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:668
-msgid "The Kings Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:669
-msgid ""
-"The King will sell you this land for 200,000 gold or you can take it by "
-"force. The choice is yours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:670
-msgid "The land of Heroes II."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:671
-msgid "The Lost Castle of the Ancients"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:672
-msgid ""
-"The mage wars have caused a great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:673
-msgid ""
-"The mage wars have caused great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:674
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trade.  "
-"Plus a little gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:675
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trading.  "
-"Plus a little more gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:676
-msgid ""
-"The Master Merchant arrives at your Castle.  He tells you tall tales of "
-"travel, full of outrageous lies.  He also gives you, your share of the "
-"profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:677
-msgid ""
-"The Master Merchant arrives back at your Castle.  He tells you tall tales of "
-"faraway places full of outrageous lies.  He also gives you, your share of "
-"the profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:678
-msgid "The Medusas have the password and they can be found just to the west."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:679
-msgid "The more there is the less you see."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:680
-msgid "The North Road to Roland's castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:681
-msgid ""
-"The note in this bottle has become mostly indecipherable. All you can make "
-"out are references to deadly pirates, and hidden gold mines."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:682
-msgid "The Other Side"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:683
-msgid ""
-"The Overlord has given you 4 months to conquer this land or deliver to him "
-"the sum of 150,000 gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:684
-msgid ""
-"The people on the Isle of Knowledge are taking up a collection to aid us."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:685
-msgid "The Proving Grounds"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:686
-msgid "The Queen's Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:687
-msgid "The Realm of Air is barred, but you may appeal here for help."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:688
-msgid ""
-"There are remnants of a mighty battle fought here, not too long ago. It "
-"looks as if whoever came this way may have made this their final stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:689
-msgid ""
-"There are three enemy castles to the north. Capture them in the name of "
-"Roland the true king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:690
-msgid ""
-"The Red Tide of War rolls North.  Stopping the flood seems hopeless.  Yet, "
-"Honor demands you and your ally die trying."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:691
-msgid "There is hidden treasure north of the Green Lord's Ore Mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:692
-msgid "There is hidden treasure south of the Blue Lord's Sawmill."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:693
-msgid "There's a warm wind blowing from the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:694
-msgid ""
-"There's a Wizard living in the north who is behind this peasant revolt."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:695
-msgid "The Retreat of the Alchemist Doctor Yu"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:696
-msgid ""
-"There used to be a mine here, but it has long since run out of ore.  You are "
-"only able to scavenge 5 units of ore from the old site."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:697
-msgid "There was a shipreck in the far east waters recently."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:698
-msgid "The River Styx"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:699
-msgid "The roars of several dragons echo from the towers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:700
-msgid "The Rock Store."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:701
-msgid "The Royal Gardens."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:702
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:703
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you defend against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:704
-msgid "These doors are a risk the likes of which you do not know."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:705
-msgid "These lands are beholden to Lord Kraeger."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:706
-msgid ""
-"These lands are desolate and for the most part devoid of resources. Not even "
-"the bravest heroes dare to venture into them, and plants are rare and "
-"precious here. Who knows what else awaits?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:707
-msgid ""
-"The Southern Witch is biding her time.  She will strike when your armies are "
-"weak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:708
-msgid "the stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:709
-msgid "The Table in the Great Hall of the Castle is Haunted."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:710
-msgid ""
-"The third piece of the artifact is somewhere to the north, that much we "
-"know. We are still unsure of its exact location, but our spies are out "
-"gathering information. The forces in this area are too strong to be "
-"completely subjugated, so take what you can and hold on to it tightly."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:711
-msgid ""
-"The troops have sworn their allegiance, but should lose a battle they will "
-"lose faith and our cause will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:712
-msgid "The Valley of Aruk."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:713
-msgid ""
-"The Valley of Magic holds many surprises.  You discover an old pair of boots "
-"sticking out of the sand."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:714
-msgid "The Valley of Tresures"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:715
-msgid "The Wasteland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:716
-msgid "The way of magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:717
-msgid "The way of might"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:718
-msgid "The way of numbers"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:719
-msgid "The western town."
-msgstr "Vakarų miestas."
-
-#: ../fheroes2/resource/maps_text.cpp:720
-msgid "The winds howl in mourning around the shipwreck."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:721
-msgid "The wizard has an island in the southeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:722
-msgid ""
-"The Wizards who have captured the Necromancers' town have wasted no time in "
-"building defenses designed to stop you, and their last castle has just been "
-"completed. Fortunately only a Captain of the Guard and a small garrison are "
-"currently present.  If you hurry, you should be able to capture the castle "
-"before they have a chance to reinforce it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:723
-msgid "The wood has arrived."
-msgstr "Gavote medienos krovinį."
-
-#: ../fheroes2/resource/maps_text.cpp:724
-msgid "The writing on this sign is too faded to read."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:725
-msgid "The Yellow Lord has the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:726
-msgid ""
-"The Yellow Lord is a hothead who will attack before his allies can send him "
-"aid."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:727
-msgid "They say there's mermaids in these waters..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:728
-msgid ""
-"This area is rich in resources. Explore, but beware, a castle left "
-"undefended will quickly fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:729
-msgid ""
-"This area must be secured for the sake of the Empire. Our spies have "
-"reported a discord between The kingdom of the knights to the north, and that "
-"of the oppressive sorceresses to the northeast. Perhaps this feud can be "
-"exploited for our gain..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:730
-msgid "This bottle is empty."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:731
-msgid ""
-"This is the last week you have to find the rebel wizard Joseph! Good Luck in "
-"your quest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:732
-msgid ""
-"This land and all others are now under the sole ownership of Ibn Fadlan, the "
-"Undead King. Any disregard for his magesty's soverign rule is to be punished "
-"by death most horrendous."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:733
-msgid ""
-"This land has been claimed by the nation of Neroli. Interlopers are "
-"UNWELCOME."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:734
-msgid ""
-"This rugged land will have rivals fighting the terrain as well as each other."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:735
-msgid ""
-"This rundown village looks like it was once the epicenter of an enormous, "
-"but now ruined, city. Under a pile of rubble you find an object which looks "
-"like it has lain there for ages."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:736
-msgid ""
-"This spot overlooks an old quarry.  This was one of the only places in the "
-"world where ore could be taken right out of the ground.  Unfortunately the "
-"jungle has reclaimed the quarry and it is unusable.  You collect the last of "
-"the ore and depart."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:737
-msgid ""
-"This twisted maze of sorceress towns has three factions struggling for sole "
-"control.  Use your resources wisely!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:738
-msgid ""
-"This village appears to be in little better shape than the first one you "
-"saw. As you approach the village an old man hands you a slip of paper, with "
-"the following message, \"Joseph lives in the town of IslandHome.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:739
-msgid ""
-"This village is in extremely poor shape. There is no chance of getting more "
-"than some of the lesser creatures here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:740
-msgid "This way to the Necromancer Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:741
-msgid "Those who seek knowledge are welcome to the city of Chronos."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:742
-msgid ""
-"Three Warlocks in the land of Dragons. Lose thy home and all will be lost. "
-"Conquer thy enemies and the land shall forever be yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:743
-msgid "Timberhill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:744
-msgid "Time for a refreshing drink."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:745
-msgid "Time is running out! The enemy's reinforcements are almost here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:746
-msgid "To pass you must pay troll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:747
-msgid "TreeHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:748
-msgid "Trespassers will be EATEN!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:749
-msgid "Trilobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:750
-msgid "Troy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:751
-msgid "Tundara"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:752
-msgid "Turn back, friend, while you still can!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:753
-msgid "Turn Back Now!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:754
-msgid "Turn Back Now or all will be LOST!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:755
-msgid "Turn Back or DIE!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:756
-msgid "Turn Back or else!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:757
-msgid "Turn back, you fool."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:758
-msgid "\"Turning Point\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:759
-msgid ""
-"Uae was the scurviest, pirate ye'd never wanta see. In all her years of "
-"murdering and thieving she amassed so much ill-gotten booty that she "
-"couldn't carry it around in her galleon.  Besides, even the meanest can't "
-"stay awake all the time.  Legend tells that she hid it so well, she was "
-"thinking that she just might forget where it was.  So she left clues around "
-"the islands, carved in stone.  Well, she's dead now.  It's up to you to "
-"recover her legacy."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:761
-msgid "Uncle Leo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:762
-msgid "Uncle Milty"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:763
-msgid "Undead Armies"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:764
-msgid "Unholy Alliance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:765
-msgid "Unite the Tribes. Don't lose your main hero, the first Descendant."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:766
-msgid "Valley of Death"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:767
-msgid "Valley Of The Damned"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:768
-msgid "Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:769
-msgid "Vaultius"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:770
-msgid "Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:771
-msgid "Vikings!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:772
-msgid "Viper's Nest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:773
-msgid "Vulcania"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:774
-msgid "Warrior Knight"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:775
-msgid "Wastelands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:776
-msgid "Watch out for Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:777
-msgid "Waystop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:778
-msgid ""
-"\"We are at the edge of the world!\"  they scream.  \"What are we doing "
-"here?\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:779
-msgid "Weddington"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:780
-msgid "Weed Patch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:781
-msgid ""
-"We found a weakness my lord. Capture castle Black Fang and victory is ours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:782
-msgid ""
-"We have just learned that the artifact is on an island north of this "
-"continent. However, there does not appear to be any means to get there. Stay "
-"very alert for any possible way across the narrow channel."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:783
-msgid ""
-"Welcome back general.  Have you finished the conquest of the northern lands? "
-" What? you still have not finished your mission!  Get back there and teach "
-"those rebels a lesson!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:784
-msgid "Welcome to Li'l Alctatraz! Vistors NOT welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:785
-msgid ""
-"Welcome to Power Island. He who controls this Isle controls the Seven Lakes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:786
-msgid "Welcome to the Sandbar."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:787
-msgid "Welcome to the sandy Isle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:788
-msgid "Welcome to the sorceress' guild."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:789
-msgid "Welcome to the Spiral Isles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:790
-msgid ""
-"Welcome to the wounderous Kitisland range.  Eruptions each day, beware of "
-"dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:791
-msgid "Welcome to Windfall Island!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:792
-msgid "Welcome to your DOOM!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:793
-msgid "We'll join you - for the right price."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:794
-msgid ""
-"Well placed bribes have won you a stronghold near the warring Barbarians. Be "
-"advised that given their proximity an unguarded castle is an open invitation "
-"to defeat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:795
-msgid "Westfork"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:796
-msgid "Westmoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:797
-msgid "We told you not to drink!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:798
-msgid "What are you doing here?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:799
-msgid ""
-"What cannot be seen but only heard, and will not speak until spoken to?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:800
-msgid "What everyday word is most often pronounced incorrectly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:801
-msgid "What goes up and down but never moves?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:802
-msgid ""
-"What good fortune!  You've discovered a long-abandoned settlement.  To your "
-"surprise, you discover that the previous inhabitants left some of their "
-"resources behind when they departed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:803
-msgid "What is always coming but never arrives?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:804
-msgid "What is the Sum of all Numbers from 1 to 200?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:805
-msgid "What is time spent poorly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:806
-msgid "What's another word for pirate treasure?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:807
-msgid "What's behind door number one?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:808
-msgid "What's this? A pile of gems?"
-msgstr "Kas tai? Brangakmenių krūvelė?"
-
-#: ../fheroes2/resource/maps_text.cpp:809
-msgid "What's this? Someone has left a pile of wood here!"
-msgstr "Kas tai? Kažkas čia paliko medienos rietuvę!"
-
-#: ../fheroes2/resource/maps_text.cpp:810
-msgid ""
-"What team won Super Bowl XXI and Super Bowl XXV?  (Hint... a Wizard might "
-"have these troops in his army)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:811
-msgid "What turns everything around but does not move?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:812
-msgid ""
-"What walks in the morning on four legs, two in the afternoon and three in "
-"the evening?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:813
-msgid "What?  What's this?  Something at the bottom of this pool..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:814
-msgid "When you're ready, take the teleport to the Island's Hot Spot!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:815
-msgid ""
-"When you think yourself invincible, walk through this gate.  Even then, "
-"prepare to meet your bitter end."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:816
-msgid "Where am I?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:817
-msgid ""
-"While away seeking the Ultimate Artifact, Kastor's kingdom is invaded!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:818
-msgid ""
-"While traveling a mesenger meets you on the road.  His message tells of a "
-"new ally from an island far to the south.  This ally can not offer forces to "
-"your battle but has agreed to send some support in the form of gold and "
-"crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:819
-msgid "Whiteshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:820
-msgid "Whittingham"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:821
-msgid "Who am I?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:822
-msgid ""
-"Who am I?...  Where am I?...  Oh no! My Ship!  Well it's consigned to the "
-"ghosts of my dead crew now, at least I still have my lucky rabbits foot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:823
-msgid "Who is the true King?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:824
-msgid ""
-"\"Why have we come this way?\"  asks the first mate.  You have no answer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:825
-msgid "Wicked Warlock Way"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:826
-msgid "Wilasher"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:827
-msgid "Wildabar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:828
-msgid "Wilgatus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:829
-msgid "Willow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:830
-msgid "Windfall Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:831
-msgid "Winterkill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:832
-msgid "Winterlands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:833
-msgid "Witch Hunt"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:834
-msgid ""
-"With the year long eruption of Mt. Kitisland, your three worst enemies now "
-"have a ground bridge to your eastern contenent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:835
-msgid "Wizardwood.  Magicians welcome!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:836
-msgid "Woodhaven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:837
-msgid "Wood's Lord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:838
-msgid "Woodstock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:839
-msgid "Woodville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:840
-msgid "Wormed Ash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:841
-msgid "Wow, somebody has left a pile of wood here!"
-msgstr "Oho, kažkas čia paliko medienos rietuvę!"
-
-#: ../fheroes2/resource/maps_text.cpp:842
-msgid "Wyrm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:843
-msgid "Xabran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:844
-msgid "Yellow gets some stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:845
-msgid "Yellow's Steady Cash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:846
-msgid "Yellow stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:847
-msgid "Yellow's Yarbols"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:848
-msgid "Ye old fish liver oil."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:849
-msgid "Yorksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:850
-msgid ""
-"You and your ally's families were given custody of The Isle of Knowledge.  "
-"Other Lords feel the time has come for new guardians..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:851
-msgid "You are a fool to come here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:852
-msgid "You are fighting on the side of your king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:853
-msgid "You are fighting on the side of your sister!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:854
-msgid "You are now entering the domain of Prince Roland. Have a nice day."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:855
-msgid ""
-"You are now entering the domain of Prince Roland. Have a pleasant stay."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:856
-msgid ""
-"You bribe the entrance guards of this dingy prison camp. They agree to look "
-"the other way for a little while."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:857
-msgid ""
-"You can only reach your enemies via teleporters, but each jump is a leap of "
-"faith."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:858
-msgid ""
-"You cautiously ride through the trees, looking out for enemy assaults, when "
-"suddenly, the old elf is beside you. \"Your quest is almost at an end, my "
-"friend. All that remains is for you to lay seige to these last few castles. "
-"The fate of my people rests upon your final battles here. May the gods be "
-"with you as well.\"  He turns to leave, but you ask him his name before he "
-"is gone. Over his shoulder, as he is leaving he says \"I am Ilthanis, king "
-"of the elves.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:859
-msgid ""
-"You come across the dead remains of what was appearantly a powerful wizard!  "
-"You wonder if it's safe to continue."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:860
-msgid ""
-"You face three opponents in this scenario. Capture their castles and their "
-"heroes to prove your worthiness to Archibald."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:861
-msgid ""
-"You find a beautiful helm buried in the lava.  As you move to put it on your "
-"head it turns into the Hideous mask and now you realize that no creature "
-"will join you."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:862
-msgid ""
-"You find a gleaming gold medalion buried in the  snow.  As you move to put "
-"it on it changes to the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:863
-msgid ""
-"You find an old signpost in the midst of a thicket that reads \"Warlock "
-"Wood, West.  Barbarian Fields, East.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:864
-msgid ""
-"You find a note in the bottle! It reads, \"My ship has been wrecked by the "
-"notorious pirates in this area! I am stranded on a small and barren island. "
-"Please, I beg you to come and rescue me!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:865
-msgid "You found something!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:866
-msgid "You found Treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:867
-msgid ""
-"You have been ordered here to claim this land in the name of your King and "
-"recover any riches that you might find.  However, five other Kings and "
-"Queens have also sent their heroes to this land, so you must watch out for "
-"them as well as the natives!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:868
-msgid "You have found what someone else has lost..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:869
-msgid ""
-"You have hired a barbarian of great power to aid you in this, your last "
-"quest. His origins are unknown to you, but you sense strong nobility beneath "
-"the furs and dirt that cover him. In addition, the famous explorer, Marco "
-"the wizard, is rumored to have wrecked his ship in this new land. Finding "
-"him would prove to be a much needed boon to your cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:870
-msgid ""
-"You have just 8 weeks  to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:871
-msgid ""
-"You have just 8 weeks to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:872
-msgid ""
-"You have received a message from Archibald. \"General, these peasants "
-"deserve punishment. Put them to the sword and let Corlagon have his way with "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:873
-msgid ""
-"You have received a message from Archibald.  \" HOW DARE YOU BETRAY ME! I "
-"will see your head on the block alongside your new master's once I have won."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:874
-msgid ""
-"You have received a message from Roland. \" I am shocked! I had thought "
-"better of you, but I was terribly wrong. Now you'll have to live with your "
-"dark decision for the rest of your life.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:875
-msgid "You have recieved a shipment of supplies from your kingdom!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:876
-msgid ""
-"You have recieved a shipment of supplies from your kingdom! There is a note "
-"attached, \"These are all we could afford to send you from our treasuries, "
-"as the war with Harondale is taxing us greatly. We will send more in two "
-"weeks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:877
-msgid ""
-"You have six months to destroy the Necromancer Stronghold in the heart of "
-"the valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:878
-msgid ""
-"You have washed up on the beach after being shipwrecked. Your goal is to "
-"find a way home."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:879
-msgid ""
-"You hear a low rumble, look up and see an avalanche!  You dive onto a large "
-"patch of grass to avoid it.  While dusting yourself off, you consider "
-"yourself quite lucky to be alive.  Luckier still to find a Four-Leaf Clover "
-"stuck on your nose."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:880
-msgid ""
-"You hear a rumor from a peasant who lives in the town of Waystop. He says, "
-"\"The pirates control most of the sulfur mines in this area. They use it for "
-"the cannons on their bigger boats. If you want a mine, you'll have to defeat "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:881
-msgid "You hear melodic strains of elvish music as you enter this clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:882
-msgid ""
-"You must, like, forsake your earthly wealth and, like, join us on the island "
-"of the lotus eaters."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:883
-msgid ""
-"You must search the world for your mortal enemy, Wilgatus.  Can you find him "
-"before its too late?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:884
-msgid ""
-"You notice some runes hastily scrawled into a rock by your feet, They look "
-"like the initials of Uncle Ivan!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:885
-msgid ""
-"You notice that mines and resources in the elvish lands are few, and you "
-"send word to your kingdom that you will need extra supplies. They should "
-"respond within a fortnight."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:886
-msgid ""
-"Your advance scouts come riding back to you with the following news. They "
-"believe they have found signs that Uncle Ivan was in this general area, and "
-"that he made his way to the north many months ago. Also they say there is a "
-"town nearby and many resources to the east."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:887
-msgid ""
-"Your advisor approaches you, \"My liege, something must be done about these "
-"peasants! They still refuse to work.  At this rate you won't have anything "
-"to put in your daughter's dowry!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:888
-msgid ""
-"Your advisor approaches you smiling greatly, \"My liege! The peasants are "
-"making money in the market, and are finally paying taxes!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:889
-msgid ""
-"Your advisor approaches you with a long face, \"My liege, the peasant's "
-"numbers are growing steadily.  All they do is take, take, take! We are "
-"beginning to suffer dearly because of them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:890
-msgid ""
-"Your advisor approaches you with some startling information, \"My liege, the "
-"peasants are draining us. They do nothing, and take everything! We must get "
-"them home. Your own citizens are beginning to suffer!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:891
-msgid ""
-"Your arrival here was a surprise to those sworn to guard Dragon Isle, and "
-"you were able to quickly capture one of their castles.  Use caution, though, "
-"for two other guardians remain in this jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:892
-msgid ""
-"Your castle, founded inside the center of a mile wide crater, is besieged by "
-"those who desire your mineral wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:893
-msgid "Your castle is the last outpost in the area, Don't lose it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:894
-msgid "Your crew begins to grumble."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:895
-msgid ""
-"Your crew seriously entertains thoughts of mutiny.  Your nights are "
-"sleepless."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:896
-msgid "You're almost there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:897
-msgid "You, recieve word that you have been robbed."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:898
-msgid "You're getting colder."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:899
-msgid "You're getting warmer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:900
-msgid ""
-"You're here! Oh, thank you thank you thank you! I'm in the jail east of the "
-"castle. Please hurry!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:901
-msgid ""
-"Your expedition has taken a turn for the worse... you now have no way to get "
-"home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:902
-msgid ""
-"Your forces are thinly spread in an effort to defend all the dwarf towns "
-"(which may not be transformed into castles). Consolidate your forces and "
-"smite the enemy before the towns fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:903
-msgid ""
-"Your horse stumbles and throws you from the saddle.  When you awaken you "
-"find that you have hit your head on the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:904
-msgid ""
-"Your isolation from the rest of the kingdom has largely kept you out of the "
-"political struggles, but now with the king's death, and lack of an heir, you "
-"see a golden opportunity to seize the throne for yourself.  Just remember "
-"that you have relied largely on trade for several key resources, especially "
-"sulfur, but with a little planning this land can be yours.  Go, now, and "
-"show these peasants how to rule!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:905
-msgid "Your king has sent supplies to aid the war effort."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:906
-msgid ""
-"Your opponents are allied against you and each is twice as powerful as his "
-"predecessor! Is it possible to win?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:907
-msgid ""
-"Your Queen sent you here to explore this newly discovered territory, but a "
-"freak storm scattered your fleet and left you stranded.  You gather the "
-"survivors and form a small settlement, naming it New Vertigo.  This place is "
-"your home now, and survival is your highest priority, but remember, if you "
-"are captured or killed, it's over!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:908
-msgid ""
-"Your rival, the kingdom of Harondale, is attacking your weak border towns! "
-"Recover from their first strike and crush them completely."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:909
-msgid ""
-"Your Scouts report talking to a young knight, a squire to the two sleeping "
-"heroes.  The squire is trapped by the Aqua Magic Barriers and a group of "
-"fallen Paladins.  He says the two heroes, Dainwin and Ceallach, have "
-"awakened but are still trapped by a Gold Magical Barrier and asks your aid "
-"in freeing them."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:910
-msgid ""
-"Your Scouts report that the Aqua Traveller's Tent is located along The North "
-"Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:911
-msgid ""
-"Your scouts return with grim news.  The natives of this land are currently "
-"at war with each other, and they like outsiders even less than they like "
-"each other!  Congratulations, Commander, you're at war!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:912
-msgid ""
-"Your sister calls you before her altar in the morning. \"I have important "
-"news,\" she says, \"The barbarian kingdoms which border this land have "
-"agreed to lend us some of their castles and warriors in return for a share "
-"of the spoils. I hope victory comes swiftly, but your presence gives me "
-"strength to stand until whatever end awaits.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:913
-msgid "Your subjects contribute to your war effort!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:914
-msgid ""
-"Your town is undefended and your heroes are scattered.  Do you attack or "
-"defend?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:915
-msgid ""
-"Your treasury has been looted by robbers and you have lost valuable "
-"resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:916
-msgid "Your troops begin to wonder about your sanity."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:917
-msgid ""
-"You run aground on the rocks and have to use some wood to fix your boat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:918
-msgid ""
-"You see a family of refugees making their way from the beach. You ask them "
-"about their plight and they tell you that they are from a once great city "
-"called Moss Side. They tell you that the castle was destroyed in a great "
-"conflagration, and they fled for fear of their lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:919
-msgid ""
-"You see an old man bringing water towards the stables. Recognizing him as "
-"the mystic, you attempt to thank him for his gift with some gold. He "
-"refuses, but says to you instead, \"There are riddles guarding the source of "
-"the fount's power, and the dragons know the answers. Make your way through "
-"their lair, and you shall know victory.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:920
-msgid ""
-"You see an old mystic perched on a rock. You walk towards him to see if he "
-"has any words for you on your quest, and he says \"First I see you as a "
-"great conquerer of the lands of men. Secondly, I see you as a mighty ruler "
-"of vast armies, well loved by your troops. Thirdly, I see you as a slayer of "
-"legions of dragons, your body bathed in their fire. Lastly, I see you "
-"standing on the shores of the fount, unable to cross.\" Then the Mystic "
-"fades away."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:921
-msgid "You see something that could just be the elusive Nubbie!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:922
-msgid ""
-"You see the mast of ancient ship here.  On further investigation you find "
-"that the ships holds are full of gems.  The hours pass as your crue "
-"liberates the treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:923
-msgid ""
-"You see the remains of a burned out sawmill here.  All you can salvage is "
-"some ofwood left for scrap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:924
-msgid ""
-"You see the remains of an old sawmill, but it is obvious that you will not "
-"be able to make it work again."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:925
-msgid ""
-"You see the remains of an old sawmill just to realize that it will no longer "
-"produce.  You gather the ramains and move on."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:926
-msgid ""
-"You send this letter back to the king,\"A month has passed and we have not "
-"discovered the wizard Joseph. I only hope that we are able to locate him in "
-"time to aid us in our struggle.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:927
-msgid "You should turn back."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:928
-msgid ""
-"You stumble upon an old man who proclaims you Lord of the Realm, hands you "
-"his boots and wonders into the mountains mumbling something about being late "
-"for an important date."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:929
-msgid ""
-"You stumple across three small rocks piled on top of each other and decide "
-"to dig undernear them.  There you find an old weather-beaten bag of gems."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:930
-msgid "You uncover a compass in the grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:931
-msgid "You've been warned!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:932
-msgid ""
-"You've received a message from Roland. \"In the absence of a strong leader, "
-"the local lords have fallen to fighting. Uniting this area is critical to "
-"our cause, so we must not fail.  Leaving your castle undefended in this "
-"highly contested region will surely lead to defeat. I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:933
-msgid ""
-"You've received a message from the guild. \"Thank God you've arrived! We're "
-"under seige from two enemies from the north and one from across the sea. "
-"Please save us, you're our only hope.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:934
-msgid ""
-"You've ruled with an iron fist (and an army of undead), but now your kingdom "
-"has turned against you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:935
-msgid ""
-"You've saved a group of miners from the dragons.  One of them approaches "
-"you, \"Thank you so much for saving us!  We found this sulfer and sword in "
-"the mine, then those dragons chased us!  I don't know how much longer we "
-"could survive!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:936
-msgid ""
-"You will clash quickly on this small head-to-head map, so stay on your toes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:937
-msgid ""
-"You will need a stronger army than that, mortal, to step through this portal."
-msgstr ""
-
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Wood"
 msgstr "Mediena"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Mercury"
 msgstr "Gyvsidabris"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Ore"
 msgstr "Rūda"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Sulfur"
 msgstr "Siera"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Crystal"
 msgstr "Kristalai"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Gems"
 msgstr "Brangakmeniai"
 
-#: ../fheroes2/spell/spell_book.cpp:61 ../fheroes2/spell/spell_book.cpp:79
-msgid "No spell to cast."
-msgstr ""
-
-#: ../fheroes2/spell/spell_book.cpp:138
-msgid "Your hero has %{point} spell points remaining"
-msgstr ""
-
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Fireball"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid ""
 "Causes a giant fireball to strike the selected area, damaging all nearby "
 "creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Fireblast"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid ""
 "An improved version of fireball, fireblast affects two hexes around the "
 "center point of the spell, rather than one."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Lightning Bolt"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Causes a bolt of electrical energy to strike the selected creature."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Chain Lightning"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid ""
 "Causes a bolt of electrical energy to strike a selected creature, then "
 "strike the nearest creature with half damage, then strike the NEXT nearest "
@@ -11616,832 +5587,723 @@ msgid ""
 "harmful.  Warning:  This spell can hit your own creatures!"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "Teleport"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid ""
 "Teleports the creature you select to any open position on the battlefield."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Cure"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid ""
 "Removes all negative spells cast upon one of your units, and restores up to "
 "%{count} HP per level of spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:63
 msgid "Mass Cure"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:63
 msgid ""
 "Removes all negative spells cast upon your forces, and restores up to "
 "%{count} HP per level of spell power, per creature."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:64
 msgid "Resurrect"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:64
 msgid "Resurrects creatures from a damaged or dead unit until end of combat."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Resurrect True"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Resurrects creatures from a damaged or dead unit permanently."
 msgstr "Atgaivina sužeistas ar numirusias būtybes."
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Haste"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Increases the speed of any creature by %{count}."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Mass Haste"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Increases the speed of all of your creatures by %{count}."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid "spell|Slow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid "Slows target to half movement rate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Mass Slow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Slows all enemies to half movement rate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:71
-msgid "Blind "
+msgid "spell|Blind"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Clouds the affected creatures' eyes, preventing them from moving."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid "Bless"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid "Causes the selected creatures to inflict maximum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Mass Bless"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Causes all of your units to inflict maximum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Stoneskin"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Magically increases the defense skill of the selected creatures."
 msgstr "Magiškai padidina pasirinktų karių gynybos įgūdžius."
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Steelskin"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid ""
 "Increases the defense skill of the targeted creatures.  This is an improved "
 "version of Stoneskin."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Curse"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Causes the selected creatures to inflict minimum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Mass Curse"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Causes all enemy troops to inflict minimum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid "Holy Word"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid "Damages all undead in the battle."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Holy Shout"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid ""
 "Damages all undead in the battle.  This is an improved version of Holy Word."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid "Anti-Magic"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid "Prevents harmful magic against the selected creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "Dispel Magic"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "Removes all magic spells from a single target."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid "Mass Dispel"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid "Removes all magic spells from all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Magic Arrow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Causes a magic arrow to strike the selected target."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid "Berserker"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid "Causes a creature to attack its nearest neighbor."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Armageddon"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid ""
 "Holy terror strikes the battlefield, causing severe damage to all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Elemental Storm"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:86
-msgid ""
-"Magical elements pour down on the battlefield, damaging all creatures."
+msgid "Magical elements pour down on the battlefield, damaging all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid "Meteor Shower"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid ""
 "A rain of rocks strikes an area of the battlefield, damaging all nearby "
 "creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Paralyze"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "The targeted creatures are paralyzed, unable to move or retaliate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Hypnotize"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid ""
-"Brings a single enemy unit under your control for one combat round if its "
-"hits are less than %{count} times the caster's spell power."
+"Brings a single enemy unit under your control if its hits are less than "
+"%{count} times the caster's spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Cold Ray"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Drains body heat from a single enemy unit."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid "Cold Ring"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid ""
 "Drains body heat from all units surrounding the center point, but not "
 "including the center point."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Disrupting Ray"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Reduces the defense rating of an enemy unit by three."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Death Ripple"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Damages all living (non-undead) units in the battle."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Death Wave"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid ""
 "Damages all living (non-undead) units in the battle.  This spell is an "
 "improved version of Death Ripple."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Dragon Slayer"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Greatly increases a unit's attack skill vs. Dragons."
 msgstr "Smarkiai padidina kario puolimo įgūdžius prieš drakonus."
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Blood Lust"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Increases a unit's attack skill."
 msgstr "Padidina kario puolimo įgūdžius."
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Animate Dead"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Resurrects creatures from a damaged or dead undead unit permanently."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Mirror Image"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid ""
 "Creates an illusionary unit that duplicates one of your existing units.  "
 "This illusionary unit does the same damages as the original, but will vanish "
 "if it takes any damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "Shield"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "Halves damage received from ranged attacks for a single unit."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "Mass Shield"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "Halves damage received from ranged attacks for all of your units."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "Summon Earth Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "Summons Earth Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "Summon Air Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "Summons Air Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "Summon Fire Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "Summons Fire Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "Summon Water Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "Summons Water Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Earthquake"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Damages castle walls."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid "View Mines"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid "Causes all mines across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "View Resources"
 msgstr "Rodyti išteklius"
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Causes all resources across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "View Artifacts"
 msgstr "Rodyti magiškus artefaktus"
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Causes all artifacts across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:109
 msgid "View Towns"
 msgstr "Rodyti miestus"
 
-#: ../fheroes2/spell/spell.cpp:109
 msgid "Causes all towns and castles across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid "View Heroes"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid "Causes all Heroes across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid "View All"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid "Causes the entire land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Identify Hero"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Allows the caster to view detailed information on enemy Heroes."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Summon Boat"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid ""
-"Summons the nearest unoccupied, friendly boat to an adjacent shore location. "
-" A friendly boat is one which you just built or were the most recent player "
-"to occupy."
+"Summons the nearest unoccupied, friendly boat to an adjacent shore "
+"location.  A friendly boat is one which you just built or were the most "
+"recent player to occupy."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Dimension Door"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Allows the caster to magically transport to a nearby location."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Town Gate"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Returns the caster to any town or castle currently owned."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:116
 msgid ""
 "Returns the hero to the town or castle of choice, provided it is controlled "
 "by you."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:117
 msgid "Visions"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:117
 msgid ""
 "Visions predicts the likely outcome of an encounter with a neutral army camp."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:118
 msgid "Haunt"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:118
 msgid ""
-"Haunts a mine you control with Ghosts.  This mine stops producing resources. "
-" (If I can't keep it, nobody will!)"
+"Haunts a mine you control with Ghosts.  This mine stops producing "
+"resources.  (If I can't keep it, nobody will!)"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:119
 msgid "Set Earth Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:119
 msgid "Sets Earth Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:120
 msgid "Set Air Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:120
 msgid "Sets Air Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:121
 msgid "Set Fire Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:121
 msgid "Sets Fire Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:122
 msgid "Set Water Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:122
 msgid "Sets Water Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:123
-msgid "Stone"
+msgid "No spell to cast."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:123
-msgid "Stone spell from Medusa."
+msgid "Your hero has %{point} spell points remaining."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:637
-msgid "Necroman"
+msgid "View Adventure Spells"
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:663
-msgid ""
-"This lets you change player starting positions and colors. A particular "
-"color will always start in a particular location. Some positions may only be "
-"played by a computer player or only by a human player."
+msgid "View Combat Spells"
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:667
-msgid ""
-"This lets you change the class of a player. Classes are not always "
-"changeable. Depending on the scenario, a player may receive additional towns "
-"and/or heroes not of their primary alignment."
+#, fuzzy
+msgid "View previous page"
+msgstr "Rodyti ankstesnį miestą"
+
+#, fuzzy
+msgid "View next page"
+msgstr "Žiūrėti %{name}"
+
+msgid "Close Spellbook"
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:706
-msgid "%{color} player"
-msgstr ""
+#, fuzzy
+msgid "View %{spell}"
+msgstr "Žiūrėti %{name}"
 
-#: ../fheroes2/system/settings.cpp:127
 msgid "game: always confirm for rewrite savefile"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:128
-msgid "game: also confirm autosave"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:129
 msgid "game: remember last focus"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:130
-msgid "game: battle show grid"
+msgid "battle: show damage info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:131
-msgid "game: battle mouse shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:132
-msgid "game: battle move shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:133
-msgid "game: battle show damage info"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:134
-msgid "game: castle flash building"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:135
 msgid "world: show visited content from objects"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:136
+msgid "world: show terrain penalty"
+msgstr ""
+
 msgid "world: scouting skill show extended content info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:137
-msgid "world: abandoned mine random resource"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:138
-msgid "world: save count monster after battle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:139
 msgid "world: allow set guardian to objects"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:140
-msgid "world: guardian objects gets +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:141
-msgid "world: no in-built requirements or guardians for placed artifacts"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:142
-msgid "world: only the first monster will attack (H2 bug)."
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:143
 msgid "world: Eagle Eye also works like Scholar in H3."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:144
 msgid "world: ban for WeekOf/MonthOf Monsters"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:145
-msgid "world: new version WeekOf (+growth)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:146
 msgid "world: ban plagues months"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:147
 msgid "world: Months Of Monsters do not place creatures on map"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:148
 msgid "world: Crystal Ball also added Identify Hero and Visions spells"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:149
-msgid ""
-"world: Artesian Springs have two separately visitable squares (h3 ver)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:150
 msgid "world: Starting heroes as Loss Conditions for Human Players"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:151
 msgid "world: Only 1 hero can be hired by the one player every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:152
-msgid "world: each castle allows one hero to be recruited every week"
+msgid "world: Each castle allows one hero to be recruited every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:153
-msgid "world: Outer creature dwellings should accumulate units"
+msgid "world: Neutral armies scale with game difficulty"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:154
-msgid "world: use unique artifacts for morale/luck"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:155
 msgid "world: use unique artifacts for resource affecting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:156
 msgid "world: use unique artifacts for primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:157
 msgid "world: use unique artifacts for secondary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:158
 msgid "world: Wind/Water Mills and Magic Garden can be captured"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:159
 msgid "world: disable Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:160
-msgid "castle: allow buy from well"
-msgstr "pilis: leisti pirkti per šulinį"
-
-#: ../fheroes2/system/settings.cpp:161
 msgid "castle: allow guardians"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:162
 msgid ""
 "castle: higher mage guilds regenerate more spell points/turn "
 "(20/40/60/80/100%)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:163
-msgid "castle: allow recruits special/expansion heroes"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:164
 msgid "heroes: allow buy a spellbook from Shrines"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:165
-msgid "heroes: learn new spells with day"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:166
 msgid "heroes: recruit cost to be dependent on hero level"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:167
-msgid "heroes: remember MP/SP for retreat/surrender result"
+msgid "heroes: remember move points for retreat/surrender result"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:168
-msgid "heroes: surrendering gives some experience"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:169
-msgid "heroes: recalculate movement points after creatures movement"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:170
-msgid "heroes: allow pickup objects for patrol"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:171
-msgid "heroes: after battle move to target cell"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:172
 msgid "heroes: allow transcribing scrolls (needs: Eye Eagle skill)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:173
-msgid "heroes: allow banned sec. skills upgrade"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:174
 msgid "heroes: in Arena can choose any of primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:175
 msgid "unions: allow meeting heroes"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:176
 msgid "unions: allow castle visiting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:177
+msgid "battle: show army order"
+msgstr ""
+
 msgid "battle: soft wait troop"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:178
-msgid "battle: high objects are an obstacle for archers"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:179
-msgid "battle: merge armies for hero from castle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:180
-msgid "battle: archmage can resists (20%) bad spells"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:181
-msgid "battle: magical creature resists (20%) the same magic"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:182
-msgid "battle: skip increase +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:183
 msgid "battle: reverse wait order (fast, average, slow)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:184
 msgid "game: show system info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:185
 msgid "game: autosave on"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:186
 msgid "game: autosave will be made at the beginning of the day"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:187
 msgid "game: use fade"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:188
-msgid "game: show SDL logo"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:189
 msgid "game: use evil interface"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:190
-msgid "game: also use dynamic interface for castles"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:191
 msgid "game: hide interface"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:192
 msgid "game: offer to continue the game afer victory condition"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:193
-msgid "pocketpc: hide cursor"
+msgid "The ultimate artifact is really the %{name}."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:194
-msgid "pocketpc: tap mode"
+msgid "The ultimate artifact may be found in the %{name} regions of the world."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:195
-msgid "pocketpc: drag&drop gamearea as scroll"
+msgid "north-west"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:196
-msgid "pocketpc: low display resolution (needs restart)"
+msgid "north"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:197
-msgid "pocketpc: low memory"
+msgid "north-east"
 msgstr ""
+
+msgid "west"
+msgstr ""
+
+msgid "center"
+msgstr ""
+
+msgid "east"
+msgstr ""
+
+msgid "south-west"
+msgstr ""
+
+msgid "south"
+msgstr ""
+
+msgid "south-east"
+msgstr ""
+
+msgid "The truth is out there."
+msgstr ""
+
+msgid "The dark side is stronger."
+msgstr ""
+
+msgid "The end of the world is near."
+msgstr ""
+
+msgid "The bones of Lord Slayer are buried in the foundation of the arena."
+msgstr ""
+
+msgid "A Black Dragon will take out a Titan any day of the week."
+msgstr ""
+
+msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
+msgstr ""
+
+msgid "An unknown force is being ressurected..."
+msgstr ""
+
+msgid ""
+"Check the newest version of game at\n"
+"https://github.com/ihhub/\n"
+"fheroes2/releases"
+msgstr ""
+
+#~ msgid "Hero %{name} also got a %{count} experience."
+#~ msgstr "Herojus %{name} taip pat gavo %{count} patirties."
+
+#~ msgid "You don't have enough gold!"
+#~ msgstr "Jums neužtenka aukso!"
+
+#~ msgid "buy"
+#~ msgstr "pirkti"
+
+#~ msgid "The %{name} provides %{count} unit of crystal per day."
+#~ msgid_plural "The %{name} provides %{count} units of crystal per day."
+#~ msgstr[0] "%{name} teikia %{count} kristalą per dieną."
+#~ msgstr[1] "%{name} teikia %{count} kristalus per dieną."
+#~ msgstr[2] "%{name} teikia %{count} kristalų per dieną."
+
+#~ msgid "A bit of crystal!"
+#~ msgstr "Šiek tiek kristalų!"
+
+#~ msgid "A bit of mercury!"
+#~ msgstr "Šiek tiek gyvsidabrio!"
+
+#~ msgid "A bit of sulfur!"
+#~ msgstr "Šiek tiek sieros!"
+
+#~ msgid "A cache of crystal!"
+#~ msgstr "Kristalų slaptavietė!"
+
+#~ msgid "A cache of gems!"
+#~ msgstr "Brangakmenių slaptavietė!"
+
+#~ msgid "A cache of gold!"
+#~ msgstr "Aukso slaptavietė!"
+
+#~ msgid "A cache of mercury!"
+#~ msgstr "Gyvsidabrio slaptavietė!"
+
+#~ msgid "A cache of sulfur!"
+#~ msgstr "Sieros slaptavietė!"
+
+#~ msgid "A couple of gems!"
+#~ msgstr "Pora brangakmenių!"
+
+#~ msgid "A gold cache!"
+#~ msgstr "Aukso skrynia!"
+
+#~ msgid "A lump of crystal!"
+#~ msgstr "Krūva kristalų!"
+
+#~ msgid "A lump of gold!"
+#~ msgstr "Aukso luitas!"
+
+#~ msgid "A lump of mercury!"
+#~ msgstr "Krūva gyvsidabrio!"
+
+#~ msgid "A pile of crystal!"
+#~ msgstr "Kristalų krūvelė!"
+
+#~ msgid "A pile of gems!"
+#~ msgstr "Brangakmenių krūvelė!"
+
+#~ msgid "A pile of gold!"
+#~ msgstr "Aukso krūvelė!"
+
+#~ msgid "A shipment of wood has arrived from your kingdom!"
+#~ msgstr "Medienos krovinys gautas iš jūsų karalystės!"
+
+#~ msgid "Go north to find the lost gold-mine."
+#~ msgstr "Dingusią aukso kasyklą rasite šiaurėje."
+
+#~ msgid "Help!"
+#~ msgstr "Pagalbos!"
+
+#~ msgid "Help me...."
+#~ msgstr "Padėkite man...."
+
+#~ msgid "Just ONE week left!"
+#~ msgstr "Liko tik VIENA savaitė!"
+
+#~ msgid "Lost Gold- Mine"
+#~ msgstr "Dingusi aukso kasykla"
+
+#~ msgid "No gems, crystal, or mercury for red."
+#~ msgstr "Raudonasis negavo brangakmenių, kristalų bei gyvsidabrio."
+
+#~ msgid "Some crystal!"
+#~ msgstr "Truputis kristalų!"
+
+#~ msgid "Some gems!"
+#~ msgstr "Truputis brangakmenių!"
+
+#~ msgid ""
+#~ "Someone has stolen 100 wood and 77 ore from you. Ah, that's nothing. "
+#~ "Let's keep going."
+#~ msgstr ""
+#~ "Kažkas pavogė iš tavęs 100 vnt. medienos bei 77 vnt. rūdos. Ai, ką "
+#~ "padarysi. Reikia gyventi toliau."
+
+#~ msgid "Some ore!"
+#~ msgstr "Šiek tiek rūdos!"
+
+#~ msgid "Some sulfur!"
+#~ msgstr "Truputis sieros!"
+
+#~ msgid "The western town."
+#~ msgstr "Vakarų miestas."
+
+#~ msgid "The wood has arrived."
+#~ msgstr "Gavote medienos krovinį."
+
+#~ msgid "What's this? A pile of gems?"
+#~ msgstr "Kas tai? Brangakmenių krūvelė?"
+
+#~ msgid "What's this? Someone has left a pile of wood here!"
+#~ msgstr "Kas tai? Kažkas čia paliko medienos rietuvę!"
+
+#~ msgid "Wow, somebody has left a pile of wood here!"
+#~ msgstr "Oho, kažkas čia paliko medienos rietuvę!"
+
+#~ msgid "castle: allow buy from well"
+#~ msgstr "pilis: leisti pirkti per šulinį"

--- a/files/lang/nl.po
+++ b/files/lang/nl.po
@@ -7,2637 +7,2881 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-10-23 10:54+0900\n"
+"POT-Creation-Date: 2021-07-01 15:11+0200\n"
 "PO-Revision-Date: 2009-08-10 12:30+0000\n"
 "Last-Translator: Yentl <y.v.t@scarlet.be>\n"
 "Language-Team: Dutch <nl@li.org>\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nl\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Launchpad-Export-Date: 2010-05-27 09:12+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: ../fheroes2/ai/ai_action.cpp:157 ../fheroes2/heroes/heroes_action.cpp:248
-msgid "Hero %{name} also got a %{count} experience."
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:221 ../fheroes2/resource/artifact.cpp:968
-msgid "View %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:227 ../fheroes2/army/army_bar.cpp:310
-msgid "Move or right click to redistribute %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:233 ../fheroes2/army/army_bar.cpp:301
-msgid "Combine %{name} armies"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:238 ../fheroes2/army/army_bar.cpp:292
-#: ../fheroes2/resource/artifact.cpp:980
-#: ../fheroes2/resource/artifact.cpp:1002
-msgid "Exchange %{name2} with %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:246 ../fheroes2/resource/artifact.cpp:988
-msgid "Select %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:298 ../fheroes2/army/army_bar.cpp:307
-msgid "Cannot move last troop"
-msgstr ""
-
-#: ../fheroes2/army/army.cpp:85
 msgid ""
 "A few\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:86
 msgid ""
 "Several\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:87
 msgid ""
 "A pack of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:88
 msgid ""
 "Lots of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:89
 msgid ""
 "A horde of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:90
 msgid ""
 "A throng of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:91
 msgid ""
 "A swarm of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:92
 msgid ""
 "Zounds of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:93
 msgid ""
 "A legion of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Few"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Several"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Pack"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Lots"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Horde"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Throng"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Swarm"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Zounds"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Legion"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:925
 msgid "All %{race} troops +1"
 msgstr "Alle %{ras} troepen +1"
 
-#: ../fheroes2/army/army.cpp:936
-msgid "Entire unit is undead, so morale does not apply."
-msgstr ""
-
-#: ../fheroes2/army/army.cpp:946
 msgid "Troops of 3 alignments -1"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:954
 msgid "Troops of 4 alignments -2"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:962
 msgid "Troops of 5 alignments -3"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:976
 msgid "Some undead in groups -1"
 msgstr "Enkele ondoden in groepen -1"
 
-#: ../fheroes2/battle/battle_action.cpp:752
+msgid "View %{name}"
+msgstr ""
+
+msgid "Move or right click to redistribute %{name}"
+msgstr ""
+
+msgid "Combine %{name} armies"
+msgstr ""
+
+msgid "Exchange %{name2} with %{name}"
+msgstr ""
+
+msgid "Select %{name}"
+msgstr ""
+
+msgid "Cannot move last troop"
+msgstr ""
+
+msgid "%{name} half the enemy troops!"
+msgstr ""
+
 msgid "Set auto battle off"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:757
 msgid "Set auto battle on"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:864
 msgid "spell failed!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:705
 msgid ""
 "The Sphere of Negation artifact is in effect for this battle, disabling all "
 "combat spells."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:714
 msgid "You have already cast a spell this round."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:720
-#: ../fheroes2/battle/battle_arena.cpp:768
 msgid "That spell will affect no one!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:739
 msgid "You may only summon one type of elemental per combat."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:745
 msgid "There is no open space adjacent to your hero to summon an Elemental to."
 msgstr ""
 
-#: ../fheroes2/battle/battle_board.cpp:968
 msgid ""
 "The Moat reduces by -%{count} the defense skill of any unit and slows to "
 "half movement rate."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:50
-msgid "speed: %{speed}"
+msgid "Speed"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:165
+msgid "Speed: %{speed}"
+msgstr ""
+
+msgid "Auto Spell Casting"
+msgstr ""
+
+msgid "Grid"
+msgstr ""
+
+msgid "Shadow Movement"
+msgstr ""
+
+msgid "Shadow Cursor"
+msgstr ""
+
+msgid "On"
+msgstr ""
+
+msgid "Off"
+msgstr ""
+
 msgid "The enemy has surrendered!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:168
 msgid "The enemy has fled!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:170
-#: ../fheroes2/battle/battle_dialogs.cpp:256
 msgid "A glorious victory!"
 msgstr "Een glorieuze overwinning!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:175
-msgid "For valor in combat, %{name} receives %{exp} experience"
+msgid "For valor in combat, %{name} receives %{exp} experience."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:184
 msgid "The cowardly %{name} flees from battle."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:191
 msgid "%{name} surrenders to the enemy, and departs in shame."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:197
 msgid "Your force suffer a bitter defeat, and %{name} abandons your cause."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:249
 msgid "Your force suffer a bitter defeat."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:296
 msgid "Battlefield Casualties"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:300
 msgid "Attacker"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:312
 msgid "Defender"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:394
+msgid "You have captured an enemy artifact!"
+msgstr ""
+
+msgid "Necromancy!"
+msgstr ""
+
+msgid ""
+"Practicing the dark arts of necromancy, you are able to raise %{count} of "
+"the enemy's dead to return under your service as %{monster}."
+msgstr ""
+
 msgid "%{name} the %{race}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:401
-#: ../fheroes2/castle/castle_well.cpp:311
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:194
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:834
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Attack"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:406
-#: ../fheroes2/castle/castle_well.cpp:317
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:206
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:844
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Defense"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:411
-#: ../fheroes2/castle/castle_town.cpp:310
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:854
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:142
-#: ../fheroes2/heroes/heroes_meeting.cpp:292
 msgid "Spell Power"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:416
-#: ../fheroes2/castle/castle_town.cpp:319
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:864
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:147
-#: ../fheroes2/heroes/heroes_meeting.cpp:296 ../fheroes2/heroes/skill.cpp:151
 msgid "Knowledge"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:421
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:276
 msgid "Morale"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:426
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:286 ../fheroes2/heroes/skill.cpp:338
 msgid "Luck"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:431
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:874
-#: ../fheroes2/heroes/heroes_indicator.cpp:247
 msgid "Spell Points"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
-#: ../fheroes2/gui/interface_buttons.cpp:189
+msgid "Hero's Options"
+msgstr ""
+
 msgid "Cast Spell"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
-msgid ""
-"Cast a magical spell. You may only cast one spell per combat round. The "
-"round is reset when every creature has had a turn"
-msgstr ""
-
-#: ../fheroes2/battle/battle_dialogs.cpp:488
 msgid "Retreat"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:488
+msgid "Surrender"
+msgstr ""
+
+msgid "Cancel"
+msgstr ""
+
+msgid "Hero Screen"
+msgstr ""
+
+msgid ""
+"Cast a magical spell. You may only cast one spell per combat round. The "
+"round is reset when every creature has had a turn."
+msgstr ""
+
 msgid ""
 "Retreat your hero, abandoning your creatures. Your hero will be available "
 "for you to recruit again, however, the hero will have only a novice hero's "
 "forces."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:491
-msgid "Surrender"
-msgstr ""
-
-#: ../fheroes2/battle/battle_dialogs.cpp:491
 msgid ""
 "Surrendering costs gold. However if you pay the ransom, the hero and all of "
 "his or her surviving creatures will be available to recruit again."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:166
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:227
-msgid "Cancel"
+msgid "Open Hero Screen to view full information about the hero."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
 msgid "Return to the battle."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:549
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:438
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:497
 msgid "Not enough gold (%{gold})"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:564
 msgid "%{name} states:"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:569
 msgid ""
-"I will accept your surrender and grant you and your troops safe passage for "
-"the price of %{price} gold."
+"\"I will accept your surrender and grant you and your troops safe passage "
+"for the price of %{price} gold.\""
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:613
-#: ../fheroes2/battle/battle_interface.cpp:1401
 msgid "View %{monster} info."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1409
 msgid "Shoot %{monster}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1431
 msgid "Attack %{monster}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Fly %{monster} here."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Move %{monster} here."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1449
-#: ../fheroes2/battle/battle_interface.cpp:1538
 msgid "Turn %{turn}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1475
 msgid "Teleport Here"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1479
 msgid "Invalid Teleport Destination"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1485
 msgid "Cast %{spell} on %{monster}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1495
 msgid "Cast %{spell}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1501
 msgid "Select Spell Target"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1674
-msgid "Spell cast"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:1686
 msgid "View Ballista Info"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1699
-#: ../fheroes2/battle/battle_tower.cpp:53
 msgid "Ballista"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1712
 msgid "Auto combat"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1719
 msgid "Customize system options."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1727
 msgid "Wait this unit"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1734
 msgid "Skip this unit"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1742
-#: ../fheroes2/battle/battle_interface.cpp:1774
-msgid "Hero's Options"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:1753
-#: ../fheroes2/battle/battle_interface.cpp:1785
 msgid "View Opposing Hero"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Hide logs"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Show logs"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1878
 msgid "%{color} cast spell: %{spell}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2202
 msgid "%{name} skipping turn"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2203
-msgid ", and get +2 defense"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:2206
 msgid "%{name} waiting turn"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2343
 msgid "%{attacker} do %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2497
 msgid "Moved %{monster}: %{src}, %{dst}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2612
+msgid "Moved %{monster}"
+msgstr ""
+
 msgid "The %{name} resist the spell!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2625
 msgid "%{name} casts %{spell} on the %{troop}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2630
 msgid "%{name} casts %{spell}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2751
-msgid "The %{spell} spell does %{damage} damage to all undead creatures."
+msgid "The %{spell} does %{damage} damage to one undead creature."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2754
-msgid "The %{spell} spell does %{damage} damage to all living creatures."
+msgid "The %{spell} does %{damage} damage to all undead creatures."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2756
+msgid "The %{spell} does %{damage} damage, %{count} creatures perish."
+msgstr ""
+
 msgid "The %{spell} does %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2797
+msgid "The %{spell} does %{damage} damage to one living creature."
+msgstr ""
+
+msgid "The %{spell} does %{damage} damage to all living creatures."
+msgstr ""
+
 msgid "The Unicorns attack blinds the %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2798
 msgid "The Medusas gaze turns the %{name} to stone!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2800
 msgid "The Mummies' curse falls upon the %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2801
 msgid "The %{name} are paralyzed by the Cyclopes!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2802
 msgid "The Archmagi dispel all good spells on your %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2820
-msgid "Good luck shines on the  %{attacker}"
+msgid "Good luck shines on the %{attacker}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2872
 msgid "Bad luck descends on the %{attacker}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2884
 msgid "High morale enables the %{monster} to attack again."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2891
 msgid "Low morale causes the %{monster} to freeze in panic."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2944
-msgid "Tower do %{damage} damage."
+msgid "%{tower} does %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:3257
 msgid "MirrorImage created"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:3798
-msgid "MirrorImage ended"
+msgid "The mirror image is destroyed!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4089
 msgid "Break auto battle?"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4138
 msgid "No spells to cast."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4147
 msgid "Are you sure you want to retreat?"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4155
 msgid "Retreat disabled"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4169
-msgid "You don't have enough gold!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:4180
 msgid "Surrender disabled"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{min} - %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{min} - %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_main.cpp:190
-msgid "You have captured an enemy artifact!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_main.cpp:241
 msgid ""
-"Through eagle-eyed observation, %{name} is able to learn the magic spell %"
-"{spell}."
+"Through eagle-eyed observation, %{name} is able to learn the magic spell "
+"%{spell}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_main.cpp:280
-msgid ""
-"Practicing the dark arts of necromancy, you are able to raise %{count} of "
-"the enemy's dead to return under your service as %{monster}"
-msgstr ""
-
-#: ../fheroes2/battle/battle_tower.cpp:47 ../fheroes2/castle/castle.cpp:466
 msgid "Left Turret"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:48 ../fheroes2/castle/castle.cpp:467
 msgid "Right Turret"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:115
 msgid "The %{name} fires with the strength of %{count} Archers"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:116
 msgid "each with a +%{attack} bonus to their attack skill."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:863
-msgid "%{name} half the enemy troops!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_troop.cpp:950
 msgid ""
 "The %{artifact} artifact is in effect for this battle, disabling %{spell} "
 "spell."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:1598
 msgid "%{count} %{name} rise(s) from the dead!"
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:258
+msgid "Sorceress Guild"
+msgstr ""
+
+msgid "Necromancer Guild"
+msgstr ""
+
+msgid "Dragon Alliance"
+msgstr ""
+
+msgid "Elven Alliance"
+msgstr ""
+
+msgid "Wayward Son"
+msgstr ""
+
+msgid "Uncle Ivan"
+msgstr ""
+
+msgid "Force of Arms"
+msgstr ""
+
+msgid "Annexation"
+msgstr ""
+
+msgid "Save the Dwarves"
+msgstr ""
+
+msgid "Carator Mines"
+msgstr ""
+
+msgid "Turning Point"
+msgstr ""
+
+msgid "The Gauntlet"
+msgstr ""
+
+msgid "The Crown"
+msgstr ""
+
+msgid "Corlagon's Defense"
+msgstr ""
+
+msgid "Final Justice"
+msgstr ""
+
+msgid "First Blood"
+msgstr ""
+
+msgid "Barbarian Wars"
+msgstr ""
+
+msgid "Necromancers"
+msgstr ""
+
+msgid "Slay the Dwarves"
+msgstr ""
+
+msgid "Rebellion"
+msgstr ""
+
+msgid "Dragon Master"
+msgstr ""
+
+msgid "Country Lords"
+msgstr ""
+
+msgid "Greater Glory"
+msgstr ""
+
+msgid "Apocalypse"
+msgstr ""
+
+msgid "Uprising"
+msgstr ""
+
+msgid "Island of Chaos"
+msgstr ""
+
+msgid "Arrow's Flight"
+msgstr ""
+
+msgid "The Abyss"
+msgstr ""
+
+msgid "The Giant's Pass"
+msgstr ""
+
+msgid "Aurora Borealis"
+msgstr ""
+
+msgid "Betrayal's End"
+msgstr ""
+
+msgid "Corruption's Heart"
+msgstr ""
+
+msgid "Conquer and Unify"
+msgstr ""
+
+msgid "Border Towns"
+msgstr ""
+
+msgid "The Wayward Son"
+msgstr ""
+
+msgid "Crazy Uncle Ivan"
+msgstr ""
+
+msgid "The Southern War"
+msgstr ""
+
+msgid "Ivory Gates"
+msgstr ""
+
+msgid "The Elven Lands"
+msgstr ""
+
+msgid "The Epic Battle"
+msgstr ""
+
+msgid "The Shrouded Isles"
+msgstr ""
+
+msgid "The Eternal Scrolls"
+msgstr ""
+
+msgid "Power's End"
+msgstr ""
+
+msgid "Fount of Wizardry"
+msgstr ""
+
+msgid "Stranded"
+msgstr ""
+
+msgid "Pirate Isles"
+msgstr ""
+
+msgid "King and Country"
+msgstr ""
+
+msgid "Blood is Thicker"
+msgstr ""
+
+msgid ""
+"Roland needs you to defeat the lords near his castle to begin his war of "
+"rebellion against his brother.  They are not allied with each other, so they "
+"will spend most of their time fighting with one another.  Victory is yours "
+"when you have defeated all of their castles and heroes."
+msgstr ""
+
+msgid ""
+"The local lords refuse to swear allegiance to Roland, and must be subdued. "
+"They are wealthy and powerful, so be prepared for a tough fight. Capture all "
+"enemy castles to win."
+msgstr ""
+
+msgid ""
+"Your task is to defend the Dwarves against Archibald's forces. Capture all "
+"of the enemy towns and castles to win, and be sure not to lose all of the "
+"dwarf towns at once, or the enemy will have won."
+msgstr ""
+
+msgid ""
+"You will face four allied enemies in a straightforward fight for resource "
+"and treasure. Capture all of the enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Your enemies are allied against you and start close by, so be ready to come "
+"out fighting. You will need to own all four castles in this small valley to "
+"win."
+msgstr ""
+
+msgid ""
+"The Sorceress' guild of Noraston has requested Roland's aid against an "
+"attack from Archibald's allies. Capture all of the enemy castles to win, and "
+"don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy "
+"castle on an island in the ocean.)"
+msgstr ""
+
+msgid ""
+"Gather as large an army as possible and capture the enemy castle within 8 "
+"weeks. You are opposed by only one enemy, but must travel a long way to get "
+"to the enemy castle. Any troops you have in your army at the end of this "
+"scenario will be with you in the final battle."
+msgstr ""
+
+msgid ""
+"Find the Crown before Archibald's heroes find it. Roland will need the Crown "
+"for the final battle against Archibald."
+msgstr ""
+
+msgid ""
+"Three allied enemies stand before you and victory, including Lord Corlagon. "
+"Roland is in a castle to the northwest, and you will lose if he falls to the "
+"enemy. Remember that capturing Lord Corlagon will ensure that he will not "
+"fight against you in the final scenario."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Archibald to end the war!"
+msgstr ""
+
+msgid ""
+"King Archibald requires you to defeat the three enemies in this region.  "
+"They are not allied with one another, so they will spend most of their "
+"energy fighting amongst themselves.  You will win when you own all of the "
+"enemy castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"You must unify the barbarian tribes of the north by conquering them. As in "
+"the previous mission, the enemy is not allied against you, but they have "
+"more resources at their disposal. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"Do-gooder wizards have taken the Necromancers' castle. You must retake it to "
+"achieve victory. Remember that while you start with a powerful army, you "
+"have no castle and must take one within 7 days, or lose this battle. (Hint: "
+"The nearest castle is to the southeast.)"
+msgstr ""
+
+msgid ""
+"The dwarves need conquering before they can interfere in King Archibald's "
+"plans. Roland's forces have more than one hero and many towns to start with, "
+"so be ready for attack from multiple directions. You must capture all of the "
+"enemy towns and castles to claim victory."
+msgstr ""
+
+msgid ""
+"You must put down a peasant revolt led by Roland's forces. All are allied "
+"against you, but you have Lord Corlagon, an experienced hero, to help you. "
+"Capture all enemy castles to win."
+msgstr ""
+
+msgid ""
+"There are two enemies allied against you in this mission. Both are well "
+"armed and seek to evict you from their island. Avoid them and capture Dragon "
+"City to win"
+msgstr ""
+
+msgid ""
+"Your orders are to conquer the country lords that have sworn to serve "
+"Roland. All of the enemy castles are unified against you. Since you start "
+"without a castle, you must hurry to capture one before the end of the week. "
+"Capture all enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Find the Crown before Roland's heroes find it. Archibald will need the Crown "
+"for the final battle against Roland."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Roland to win the war, and be sure "
+"not to lose Archibald in the fight!"
+msgstr ""
+
+msgid ""
+"Subdue the unruly local lords in order to provide the Empire with facilities "
+"to operate in this region."
+msgstr ""
+
+msgid ""
+"Eliminate all oposition in this area. Then the first piece of the artifact "
+"will be yours."
+msgstr ""
+
+msgid ""
+"The sorceresses to the northeast are rebelling! For the good of the empire "
+"you must quash their feeble uprising on your way to the mountains."
+msgstr ""
+
+msgid ""
+"Having prepared for your arrival, Kraeger has arranged for a force of "
+"necromancers to thwart your quest. You must capture the castle of Scabsdale "
+"before the first day of the third week, or the Necromancers will be too "
+"strong for you."
+msgstr ""
+
+msgid ""
+"The barbarian despot in this area is, as yet, ignorant of your presence. "
+"Quickly, build up your forces before you are discovered and attacked! Secure "
+"the region by subduing all enemy forces."
+msgstr ""
+
+msgid ""
+"The Empire is weak in this region. You will be unable to completely subdue "
+"all forces in this area, so take what you can before reprisal strikes. "
+"Remember, your true goal is to claim the Helmet of Anduran."
+msgstr ""
+
+msgid "For the good of the Empire, eliminate Kraeger."
+msgstr ""
+
+msgid ""
+"At last, you have the opportunity and the facilities to rid the Empire of "
+"the necromancer's evil. Eradicate them completely, and you will be sung as a "
+"hero for all time."
+msgstr ""
+
+msgid ""
+"Conquer and unite all the enemy tribes. Don't lose the hero Jarkonas, the "
+"forefather of all descendants."
+msgstr ""
+
+msgid ""
+"Your rival, the Kingdom of Harondale, is attacking weak towns on your "
+"border! Recover from their first strike and crush them completely!"
+msgstr ""
+
+msgid ""
+"Find your wayward son Joseph who is rumored to be living in the desolate "
+"lands. Do it before the first day of the third month or it will be of no "
+"help to your family."
+msgstr ""
+
+msgid ""
+"Rescue your crazy uncle Ivan. Find him before the first day of the fourth "
+"month or it will be no help to your kingdom."
+msgstr ""
+
+msgid ""
+"Destroy the barbarians who are attacking the southern border of your "
+"kingdom! Recover your fallen towns, and then invade the jungle kingdom. "
+"Leave no enemy standing."
+msgstr ""
+
+msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
+msgstr ""
+
+msgid ""
+"Gain the favor of the elves. They will not allow trees to be chopped down, "
+"so they will send you wood every 2 weeks. You must complete your mission "
+"before the first day of the seventh month, or the kingdom will surely fall."
+msgstr ""
+
+msgid ""
+"This is the final battle against your rival kingdom of Harondale. Eliminate "
+"everyone, and don't lose the hero Jarkonas VI."
+msgstr ""
+
+msgid ""
+"Your mission is to vanquish the warring mages in the magical Shrouded Isles. "
+"The completion of this task will give you a fighting chance against your "
+"rivals."
+msgstr ""
+
+msgid ""
+"The location of the great library has been dicovered! You must make your way "
+"to it, and reclaim the city of Chronos in which it lies."
+msgstr ""
+
+msgid ""
+"Find the Orb of negation, which is said to be buried in this land. There are "
+"clues inscribed on stone obelisks which will help lead you to your price. "
+"Find the orb before the first day of the sixth month, or your rivals will "
+"surely have gotten to the fount before you."
+msgstr ""
+
+msgid ""
+"You must take control of the castle of Magic, where the fount of wizardry "
+"lies. Do this and your victory will be supreme."
+msgstr ""
+
+msgid ""
+"Capture the town on the island off the southeast shore in order to construct "
+"a boat and travel back towards the mainland. Do not lose the hero Gallavant."
+msgstr ""
+
+msgid ""
+"Find and defeat Martine, the pirate leader, who resides in Pirates Cove. Do "
+"not lose Gallavant or your quest will be over."
+msgstr ""
+
+msgid ""
+"Eliminate all the other forces who oppose the rule of Lord Alberon. "
+"Gallavant must not die."
+msgstr ""
+
+msgid ""
+"Overthrow the entrenched monarchy of Lord Alberon, and claim all the land in "
+"your name. Gallavant must not die."
+msgstr ""
+
+msgid " bane"
+msgstr ""
+
+msgid " alliance"
+msgstr ""
+
+msgid "Carry-over forces"
+msgstr ""
+
+msgid " bonus"
+msgstr ""
+
+msgid " defeated"
+msgstr ""
+
+msgid "Thunder Mace"
+msgstr ""
+
+msgid "Minor Scroll"
+msgstr ""
+
+msgid "Dragon Sword"
+msgstr ""
+
+msgid "Breastplate"
+msgstr ""
+
+msgid "Fibzin Medal"
+msgstr ""
+
+msgid "Mage's ring"
+msgstr ""
+
+msgid "Defender Helm"
+msgstr ""
+
+msgid "Power Axe"
+msgstr ""
+
+msgid "Summon Earth"
+msgstr ""
+
 msgid "The %{building} produces %{monster}."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:505
 msgid "Requires:"
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:597
 msgid "Cannot build. Already built here this turn."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:601
 msgid "For this action it is necessary first to build a castle."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:623
 msgid "Cannot build %{name} because castle is too far from water."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:631
-msgid "Cannot afford %{name}"
+msgid "Cannot afford %{name}."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:636
-msgid "%{name} is already built"
+msgid "%{name} is already built."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:641
-msgid "Cannot build %{name}"
+msgid "Cannot build %{name}."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:646
-msgid "Build %{name}"
+msgid "Build %{name}."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Thieves' Guild"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Tavern"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Shipyard"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Well"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Statue"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467
-#: ../fheroes2/dialog/dialog_marketplace.cpp:212
 msgid "Marketplace"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Moat"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467 ../fheroes2/maps/mp2.cpp:391
 msgid "Castle"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Tent"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Captain's Quarters"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Mage Guild, Level 1"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 2"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 3"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 4"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 5"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Farm"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Garbage Heap"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Crystal Garden"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Waterfall"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Orchard"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Skull Pile"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Fortifications"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Coliseum"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Rainbow"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Dungeon"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Library"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Storm"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:498
 msgid "Thatched Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Treehouse"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:441
 msgid "Cave"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Habitat"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:431
 msgid "Excavation"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:477
 msgid "Archery Range"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Stick Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Cottage"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Crypt"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Pen"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/maps/mp2.cpp:371
 msgid "Graveyard"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Blacksmith"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Den"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Nest"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Foundry"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:480
-#: ../fheroes2/castle/castle.cpp:487 ../fheroes2/maps/mp2.cpp:427
-#: ../fheroes2/resource/maps_text.cpp:521
 msgid "Pyramid"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Armory"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Adobe"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Stonehenge"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Maze"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478 ../fheroes2/castle/castle.cpp:485
 msgid "Cliff Nest"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Mansion"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Jousting Arena"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Bridge"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
 msgid "Fenced Meadow"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Swamp"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Ivory Tower"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Mausoleum"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cathedral"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Red Tower"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Green Tower"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cloud Castle"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Laboratory"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:483 ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Archery Range"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Stick Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Cottage"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Graveyard"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Blacksmith"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Foundry"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Pyramid"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Armory"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Adobe"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Stonehenge"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Maze"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Mansion"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Jousting Arena"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Bridge"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Ivory Tower"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Mausoleum"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cathedral"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cloud Castle"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:488
 msgid "Black Tower"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:490
 msgid "Shrine"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:552
 msgid ""
 "The Thieves' Guild provides information on enemy players. Thieves' Guilds "
-"can also provide scouting information on enemy towns."
+"can also provide scouting information on enemy towns. Additional Guilds "
+"provide more information."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:553
 msgid "The Tavern increases morale for troops defending the castle."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:554
 msgid "The Shipyard allows ships to be built."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:555
 msgid ""
 "The Well increases the growth rate of all dwellings by %{count} creatures "
 "per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:556
 msgid "The Statue increases your town's income by %{count} per day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:557
 msgid "The Left Turret provides extra firepower during castle combat."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:558
 msgid "The Right Turret provides extra firepower during castle combat."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:559
 msgid ""
 "The Marketplace can be used to convert one type of resource into another. "
 "The more marketplaces you control, the better the exchange rate."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:560
 msgid ""
 "The Moat slows attacking units. Any unit entering the moat must end its turn "
 "there and becomes more vulnerable to attack."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:561
 msgid ""
 "The Castle improves town defense and increases income to %{count} gold per "
 "day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:562
 msgid ""
 "The Tent provides workers to build a castle, provided the materials and the "
 "gold are available."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:563
 msgid ""
 "The Captain's Quarters provides a captain to assist in the castle's defense "
 "when no hero is present."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:564
 msgid ""
 "The Mage Guild allows heroes to learn spells and replenish their spell "
 "points."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:567
 msgid "The Farm increases production of Peasants by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:568
 msgid "The Garbage Heap increases production of Goblins by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:569
 msgid ""
 "The Crystal Garden increases production of Sprites by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:570
 msgid "The Waterfall increases production of Centaurs by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:571
 msgid "The Orchard increases production of Halflings by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:572
 msgid "The Skull Pile increases production of Skeletons by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:575
 msgid ""
 "The Fortifications increase the toughness of the walls, increasing the "
 "number of turns it takes to knock them down."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:576
 msgid ""
 "The Coliseum provides inspiring spectacles to defending troops, raising "
 "their morale by two during combat."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:577
 msgid "The Rainbow increases the luck of the defending units by two."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:578
 msgid "The Dungeon increases the income of the town by %{count} / day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:579
 msgid ""
 "The Library increases the number of spells in the Guild by one for each "
 "level of the guild."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:580
 msgid "The Storm adds +2 to the power of spells of a defending spell caster."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:582
 msgid ""
 "The Shrine increases the necromancy skill of all your necromancers by 10 "
 "percent."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:632
 msgid "Cannot recruit - you already recruit hero in current week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:645
 msgid "Cannot recruit - guest to guard automove error."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:651
 msgid "Cannot recruit - you already have a Hero in this town."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:659
 msgid "Cannot recruit - you have too many Heroes."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:665
 msgid "Cannot afford a Hero"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:756
 msgid "There is no room in the garrison for this army."
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:272
+msgid "Recruit %{name}"
+msgstr ""
+
 msgid "Month: %{month}, Week: %{week}, Day: %{day}"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:393
-#: ../fheroes2/castle/castle_dialog.cpp:396
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:387
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:186
-msgid "Income:"
+msgid "Income"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 msgid "Join Error"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 msgid "Army is full"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
+msgid ""
+"You must purchase a spell book to use the mage guild, but you currently have "
+"no room for a spell book. Try giving one of your artifacts to another hero."
+msgstr ""
+
 msgid "Town"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
 msgid "This town may not be upgraded to a castle."
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit castle"
+msgid "Exit Castle"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit town"
+msgid "Exit Town"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:730
-msgid "Show income"
+msgid "Show Income"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:734
 msgid "Show previous town"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:738
 msgid "Show next town"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:741
 msgid "Swap Heroes"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:744
 msgid "Meeting Heroes"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:749
 msgid "View Hero"
 msgstr ""
 
-#: ../fheroes2/castle/castle_mageguild.cpp:150
+msgid "The above spells are available here."
+msgstr ""
+
 msgid "The above spells have been added to your book."
 msgstr ""
 
-#: ../fheroes2/castle/castle_tavern.cpp:39
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:748
 msgid "A generous tip for the barkeep yields the following rumor:"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:54
 msgid "Recruit Hero"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:59
-msgid "%{name} is a level %{value} %{race}"
+msgid "%{name} is a level %{value} %{race} "
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with %{count} artifacts"
+msgid "with %{count} artifacts."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with one artifact"
+msgid "with 1 artifact."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:283
-#: ../fheroes2/heroes/heroes_dialog.cpp:108
+msgid "without artifacts."
+msgstr ""
+
 msgid ""
 "'Spread' combat formation spreads your armies from the top to the bottom of "
 "the battlefield, with at least one empty space between each army."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:284
 msgid ""
 "'Grouped' combat formation bunches your army toget her in the center of your "
 "side of the battlefield."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:292
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:132
-#: ../fheroes2/heroes/heroes_meeting.cpp:284
 msgid "Attack Skill"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:301
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:137
-#: ../fheroes2/heroes/heroes_meeting.cpp:288
 msgid "Defense Skill"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:487
-#: ../fheroes2/heroes/heroes_dialog.cpp:334
 msgid "Spread Formation"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:489
-#: ../fheroes2/heroes/heroes_dialog.cpp:337
 msgid "Grouped Formation"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:540
-#: ../fheroes2/castle/castle_town.cpp:553
 msgid "Recruit %{name} the %{race}"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:561
 msgid "Set garrison combat formation to 'Spread'"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:564
 msgid "Set garrison combat formation to 'Grouped'"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:567
+msgid "Exit Castle Options"
+msgstr ""
+
 msgid "Castle Options"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:158
-msgid "Buy Monsters:"
+msgid "Not enough resources to buy monsters."
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:221
+msgid "No monsters available for purchase."
+msgstr ""
+
+msgid "Buy Monsters"
+msgstr ""
+
 msgid "Town Population Information and Statistics"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:323
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:231
 msgid "Damage"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:329
 msgid "HP"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:335
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:266
-msgid "Speed"
-msgstr ""
-
-#: ../fheroes2/castle/castle_well.cpp:351
 msgid "Growth"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:355
 msgid "week"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:361
-#: ../fheroes2/kingdom/kingdom_overview.cpp:479
 msgid "Available"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:89
 msgid "View the entire world."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:90
 msgid "View the obelisk puzzle."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:91
 msgid "View information on the scenario you are currently playing."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:92
 msgid "Dig for the Ultimate Artifact."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:93
 msgid "Exit this menu without doing anything."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_arena.cpp:48
+msgid "Arena"
+msgstr ""
+
 msgid ""
 "You enter the arena and face a pack of vicious lions. You handily defeat "
 "them, to the wild cheers of the crowd.  Impressed by your skill, the aged "
 "trainer of gladiators agrees to train you in a skill of your choice."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:154
-msgid ""
-"Your troops can be upgraded, but it will cost you %{ratio} times the "
-"difference in cost for each troop, rounded up to next highest number. Do you "
-"wish to upgrade them?"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:155
 msgid ""
 "Your troops can be upgraded, but it will cost you dearly. Do you wish to "
 "upgrade them?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:166
 msgid "Are you sure you want to dismiss this army?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots Left"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:244
 msgid "Hit Points"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:255
 msgid "Hit Points Left"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:379
+msgid "Followers"
+msgstr ""
+
 msgid ""
-"The creature is swayed by your diplomatic tongue, and offers to join your "
+"A group of %{monster} with a desire for greater glory wish to join you.\n"
+"Do you accept?"
+msgstr ""
+
+msgid ""
+"The %{monster} is swayed by your diplomatic tongue, and offers to join your "
 "army for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:382
 msgid ""
 "The creatures are swayed by your diplomatic\n"
 "tongue, and make you an offer:\n"
 " \n"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:385
 msgid ""
 "%{offer} of the %{total} %{monster} will join your army, and the rest will "
 "leave you alone, for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:387
 msgid ""
 "All %{offer} of the %{monster} will join your army for the sum of %{gold} "
 "gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:401
 msgid "(Rate: %{percent})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:451
-msgid ""
-"Not room in\n"
-"the garrison"
+msgid "No room in"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:48
+msgid "the garrison"
+msgstr ""
+
 msgid "Build a new ship:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:63
 msgid "Resource cost:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:40
-msgid "For the QVGA version is not available."
+msgid "Load Game"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:62
+msgid "No save files to load."
+msgstr ""
+
+msgid "New Game"
+msgstr ""
+
+msgid "Start a single or multi-player game."
+msgstr ""
+
+msgid "Load a previously saved game."
+msgstr ""
+
+msgid "Save Game"
+msgstr ""
+
+msgid "Save the current game."
+msgstr ""
+
+msgid "Quit"
+msgstr ""
+
+msgid "Quit out of Free Heroes of Might and Magic II."
+msgstr ""
+
 msgid ""
 "Map\n"
 "Difficulty"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:65
 msgid ""
 "Game\n"
 "Difficulty"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:68
 msgid "Rating"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:71
 msgid "Map Size"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:89
-#: ../fheroes2/system/players.cpp:691
 msgid "Opponents"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:92
-#: ../fheroes2/system/players.cpp:695
 msgid "Class"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:100
 msgid ""
 "Victory\n"
 "Conditions"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:106
 msgid ""
 "Loss\n"
 "Conditions"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:167
 msgid "You cannot select %{resource}!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:173
 msgid "Select count %{resource}:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:200
 msgid "Set Guardian"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:236
-#: ../fheroes2/dialog/dialog_guardian.cpp:292
 msgid "Your army too big!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:34
-#: ../fheroes2/dialog/dialog_levelup.cpp:44
-#: ../fheroes2/dialog/dialog_levelup.cpp:73
 msgid "%{name} has gained a level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:36
-#: ../fheroes2/dialog/dialog_levelup.cpp:46
-#: ../fheroes2/dialog/dialog_levelup.cpp:75
-msgid "%{skill} Skill +1"
+msgid "%{skill} +1"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:51
 msgid "You have learned %{skill}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:93
 msgid "You may learn either:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:96
 msgid "or"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:66
 msgid ""
 "Please inspect our fine wares. If you feel like offering a trade, click on "
 "the items you wish to trade with and for."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:104
 msgid ""
 "You have received quite a bargain. I expect to make no profit on the deal. "
 "Can I interest you in any of my other wares?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:130
 msgid "I can offer you %{count} for 1 unit of %{resfrom}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:136
 msgid "I can offer you 1 unit of %{resto} for %{count} units of %{resfrom}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:164
 msgid "Qty to trade"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:235
+msgid "Trading Post"
+msgstr ""
+
 msgid "Your Resources"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:257
 msgid "Available Trades"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:573
 msgid "n/a"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:77
-msgid "guarded by %{count} of %{monster}"
+msgid "guarded by %{count} %{monster}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:149
 msgid "(available: %{count})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:181
 msgid "already learned"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:205
 msgid "already knows this skill"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:212
 msgid "already has max skills"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:260
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:276
 msgid "(already visited)"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
 msgid "(not visited)"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:296
+msgid "Road"
+msgstr ""
+
+msgid "(digging ok)"
+msgstr ""
+
+msgid "(no digging)"
+msgstr ""
+
 msgid "penalty: %{cost}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:382
-msgid "Unchartered Territory"
+msgid "Uncharted Territory"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:635
 msgid "Defenders:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:674
-#: ../fheroes2/heroes/heroes_indicator.cpp:125
-#: ../fheroes2/heroes/heroes_indicator.cpp:171
 msgid "None"
 msgstr "Geen"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:756
-msgid "%{name} ( Level %{level} )"
+msgid "Unknown"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:884
+msgid "%{name} (Level %{level})"
+msgstr ""
+
 msgid "Move Points"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:40
-#: ../fheroes2/dialog/dialog_recrut.cpp:579
 msgid "Available: %{count}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:101
-msgid "Cost per troop:"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:107
-#: ../fheroes2/dialog/dialog_recrut.cpp:506
-msgid "Recruit %{name}"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:210
 msgid "Number to buy:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:314
 msgid "How many troops to move?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:358
 msgid "Fast separation into slots:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:180
 msgid "File to Save:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:186
 msgid "File to Load:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:302
 msgid "Are you sure you want to delete file:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:305
 msgid "Warning!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:144
-msgid "Maps Difficulty:"
+msgid "Map difficulty:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
+msgid "No maps exist at that size"
+msgstr ""
+
 msgid "Small Maps"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
-msgid "View only maps of size small (36x36)."
+msgid "View only maps of size small (36 x 36)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
 msgid "Medium Maps"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
-msgid "View only maps of size medium (72x72)."
+msgid "View only maps of size medium (72 x 72)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
 msgid "Large Maps"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
-msgid "View only maps of size large (108x108)."
+msgid "View only maps of size large (108 x 108)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
 msgid "Extra Large Maps"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
-msgid "View only maps of size extra large (144x144)."
+msgid "View only maps of size extra large (144 x 144)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "All Maps"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "View all maps, regardless of size."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
 msgid "Players Icon"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
 msgid ""
-"Indicates how many players total are in the EditScenario. Any positions not "
+"Indicates how many players total are in the scenario. Any positions not "
 "occupied by humans will be occupied by computer players."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
 msgid "Size Icon"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
 msgid ""
-"Indicates whether the maps is small (36x36), medium (72x72), large "
-"(108x108), or extra large (144x144)."
+"Indicates whether the map\n"
+"is small (36 x 36), medium\n"
+"(72 x 72), large (108 x 108),\n"
+"or extra large (144 x 144)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "Selected Name"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "The name of the currently selected map."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid "Selected Map Difficulty"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid ""
 "The map difficulty of the currently selected map.  The map difficulty is "
-"determined by the EditScenario designer. More difficult maps might include "
-"more or stronger enemies, fewer resources, or other special conditions "
-"making things tougher for the human player."
+"determined by the scenario designer. More difficult maps might include more "
+"or stronger enemies, fewer resources, or other special conditions making "
+"things tougher for the human player."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "Selected Description"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "The description of the currently selected map."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
-msgid "OK"
+msgid "Okay"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
 msgid "Accept the choice made."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:364
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose all your heroes and towns."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:365
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific town."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:366
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific hero."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:367
 msgid "Run out of time. Fail to win by a certain point."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:370
 msgid "Loss Condition"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:379
 msgid "Defeat all enemy heroes and towns."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:380
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Capture a specific town."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:381
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat a specific hero."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:382
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Find a specific artifact."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:383
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Your side defeats the opposing side."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:384
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Accumulate a large amount of gold."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:387
 msgid "Victory Condition"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:48
-#: ../fheroes2/heroes/heroes_action.cpp:134
 msgid "one"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:51
-#: ../fheroes2/heroes/heroes_action.cpp:135
 msgid "two"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:187
-msgid "sound"
+msgid "Music"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:192
-#: ../fheroes2/dialog/dialog_system.cpp:205
-#: ../fheroes2/dialog/dialog_system.cpp:228
-#: ../fheroes2/dialog/dialog_system.cpp:242
-msgid "off"
+msgid "Toggle ambient music level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:200
-msgid "music"
+msgid "Effects"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:223
-msgid "hero speed"
+msgid "Toggle foreground sounds level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:237
-msgid "ai speed"
+msgid "Music Type"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:251
-msgid "scroll speed"
+msgid "Change the type of music."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:262
-#: ../fheroes2/dialog/dialog_system.cpp:276
+msgid "Hero Speed"
+msgstr ""
+
+msgid "Change the speed at which your heroes move on the main screen."
+msgstr ""
+
+msgid "Enemy Speed"
+msgstr ""
+
+msgid ""
+"Sets the speed that A.I. heroes move at.  You can also elect not to view A."
+"I. movement at all."
+msgstr ""
+
+msgid "Scroll Speed"
+msgstr ""
+
+msgid "Sets the speed at which you scroll the window."
+msgstr ""
+
+msgid "Interface Type"
+msgstr ""
+
+msgid "Toggle the type of interface you want to use."
+msgstr ""
+
 msgid "Interface"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:265
+msgid "Toggle interface visibility."
+msgstr ""
+
+msgid "Battles"
+msgstr ""
+
+msgid "Toggle instant battle mode."
+msgstr ""
+
+msgid "OK"
+msgstr ""
+
+msgid "Exit this menu."
+msgstr ""
+
+msgid "off"
+msgstr ""
+
+msgid "MIDI"
+msgstr ""
+
+msgid "MIDI Expansion"
+msgstr ""
+
+msgid "CD Stereo"
+msgstr ""
+
+msgid "External"
+msgstr ""
+
+msgid "Jump"
+msgstr ""
+
+msgid "Don't Show"
+msgstr ""
+
 msgid "Evil"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:267
 msgid "Good"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:281
 #, fuzzy
 msgid "Hide"
 msgstr "Horde"
 
-#: ../fheroes2/dialog/dialog_system.cpp:287
 msgid "Show"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:285
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:96
+msgid "Auto Resolve"
+msgstr ""
+
+msgid "Auto, No Spells"
+msgstr ""
+
+msgid "Manual"
+msgstr ""
+
+msgid "Att."
+msgstr ""
+
+msgid "Def."
+msgstr ""
+
+msgid "Power"
+msgstr ""
+
+msgid "Knowl"
+msgstr ""
+
+msgid "Human"
+msgstr ""
+
 msgid "1st"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:286
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:97
 msgid "2nd"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:98
 msgid "3rd"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:288
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:99
 msgid "4th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:289
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:100
 msgid "5th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:290
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:101
 msgid "6th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:305
-msgid "Thieves' Guild: Player RanKings"
+msgid "Oracle: Player Rankings"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:315
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:114
+msgid "Thieves' Guild: Player Rankings"
+msgstr ""
+
 msgid "Number of Towns:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:324
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:123
 msgid "Number of Castles:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:333
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:132
 msgid "Number of Heroes:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:342
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:141
 msgid "Gold in Treasury:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:351
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:150
 msgid "Wood & Ore:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:360
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:159
 msgid "Gems, Cr, Slf & Mer:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:369
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:168
 msgid "Obelisks Found:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:378
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:177
+msgid "Artifacts:"
+msgstr ""
+
 msgid "Total Army Strength:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:408
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:211
+msgid "Income:"
+msgstr ""
+
 msgid "Best Hero:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:417
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:220
 msgid "Best Hero Stats:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:426
 msgid "Personality:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:435
 msgid "Best Monster:"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Easy"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Normal"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Hard"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Expert"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Impossible"
 msgstr ""
 
-#: ../fheroes2/game/game.cpp:314
-msgid "Maps Loading..."
+msgid "Map is loading..."
 msgstr ""
 
-#: ../fheroes2/game/game_highscores.cpp:239
-#: ../fheroes2/game/game_highscores.cpp:242
+msgid "and more..."
+msgstr ""
+
+msgid "Campaign Scenario loading failure"
+msgstr ""
+
+msgid "Please make sure that campaign files are correct and present."
+msgstr ""
+
 msgid "Unknown Hero"
 msgstr ""
 
-#: ../fheroes2/game/game_highscores.cpp:240
 msgid "Your Name"
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:95
-msgid "Are you sure you want to overwrite the save with this name?"
+msgid ""
+"Invalid file game type. Please ensure that you are running the latest type "
+"of save files."
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:191
 msgid ""
-"This file is saved in the \"Price Loyalty\" version.\n"
+"This file is saved in the \"The Price of Loyalty\" version.\n"
 "Some items may be unavailable."
 msgstr ""
 
-#: ../fheroes2/game/game_mainmenu.cpp:157
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:95
-msgid "Quit"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:157
-msgid "Quit Heroes of Might and Magic and return to the operating system."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:79
-msgid "Load Game"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-msgid "Load a previously saved game."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:91
-msgid "Credits"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-msgid "View the credits screen."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:87
-msgid "High Scores"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-msgid "View the high score screen."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:75
-msgid "New Game"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-msgid "Start a single or multi-player game."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid "Host"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid ""
-"The host sets up the game options. There can only be one host per network "
-"game."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid "Guest"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid ""
-"The guest waits for the host to set up the game, then is automatically added "
-"in. There can be multiple guests for TCP/IP games."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-msgid "Cancel back to the main menu."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:214
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:154
-msgid "Standard Game"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:214
-msgid "A single player game playing out a single map."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:216
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:162
-msgid "Multi-Player Game"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:216
-msgid ""
-"A multi-player game, with several human players completing against each "
-"other on a single map."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:217
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:83
-msgid "Settings"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:217
-msgid "FHeroes2 game settings."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:271
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:219
 msgid "Hot Seat"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:271
 msgid ""
 "Play a Hot Seat game, where 2 to 4 players play around the same computer, "
 "switching into the 'Hot Seat' when it is their turn."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:279
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:223
+msgid "Cancel back to the main menu."
+msgstr ""
+
 msgid "Network"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:279
 msgid ""
 "Play a network game, where 2 players use their own computers connected "
 "through a LAN (Local Area Network)."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:343
+msgid "Standard Game"
+msgstr ""
+
+msgid "A single player game playing out a single map."
+msgstr ""
+
+msgid "Campaign Game"
+msgstr ""
+
+msgid "A single player game playing through a series of maps."
+msgstr ""
+
+msgid "Multi-Player Game"
+msgstr ""
+
+msgid ""
+"A multi-player game, with several human players completing against each "
+"other on a single map."
+msgstr ""
+
+msgid "Greetings!"
+msgstr ""
+
+msgid ""
+"Welcome to Free Heroes of Might and Magic II! Before starting the game "
+"please choose game resolution."
+msgstr ""
+
+msgid "Please Remember"
+msgstr ""
+
+msgid "You can always change game resolution by clicking on the "
+msgstr ""
+
+msgid "door"
+msgstr ""
+
+msgid ""
+" on the left side of main menu.\n"
+"\n"
+"To switch between windowed and full screen modes\n"
+"press "
+msgstr ""
+
+msgid "F4"
+msgstr ""
+
+msgid ""
+" key on the keyboard.\n"
+"\n"
+"Enjoy the game!"
+msgstr ""
+
+msgid "Quit Heroes of Might and Magic and return to the operating system."
+msgstr ""
+
+msgid "Credits"
+msgstr ""
+
+msgid "View the credits screen."
+msgstr ""
+
+msgid "High Scores"
+msgstr ""
+
+msgid "View the high score screen."
+msgstr ""
+
+msgid "Select Game Resolution"
+msgstr ""
+
+msgid "Change resolution of the game."
+msgstr ""
+
+msgid "Original Campaign"
+msgstr ""
+
+msgid ""
+"Either Roland's or Archibald's campaign from the original Heroes of Might "
+"and Magic II."
+msgstr ""
+
+msgid "Expansion Campaign"
+msgstr ""
+
+msgid "One of the four new campaigns from the Price of Loyalty expansion set."
+msgstr ""
+
+msgid "Host"
+msgstr ""
+
+msgid ""
+"The host sets up the game options. There can only be one host per network "
+"game."
+msgstr ""
+
+msgid "Guest"
+msgstr ""
+
+msgid ""
+"The guest waits for the host to set up the game, then is automatically added "
+"in. There can be multiple guests for TCP/IP games."
+msgstr ""
+
+msgid "Battle Only"
+msgstr ""
+
+msgid "Setup and play a battle without loading any map."
+msgstr ""
+
+msgid "Settings"
+msgstr ""
+
+msgid "Experimental game settings."
+msgstr ""
+
 msgid "2 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:343
 msgid ""
 "Play with 2 human players, and optionally, up, to 4 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid "3 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid ""
 "Play with 3 human players, and optionally, up, to 3 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid "4 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid ""
 "Play with 4 human players, and optionally, up, to 2 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid "5 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid ""
 "Play with 5 human players, and optionally, up, to 1 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "6 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "Play with 6 human players."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat all enemy heroes and capture all enemy towns and castles."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Run out of time. (Fail to win by a certain point.)"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the castle '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the town '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:83
 msgid "Defeat the hero '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:91
 msgid "Find the ultimate artifact"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:95
 msgid "Find the '%{name}' artifact"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:102
 msgid "Accumulate %{count} gold"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:106
 msgid ""
 ", or you may win by defeating all enemy heroes and capturing all enemy towns "
 "and castles."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the castle '%{name}'."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the town '%{name}'."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:126 ../fheroes2/game/game_over.cpp:145
 msgid "Lose the hero: %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:133
 msgid "Fail to win by the end of month %{month}, week %{week}, day %{day}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:145
 msgid "Lose the heroes: %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:167
 msgid ""
 "You captured %{name}!\n"
 "You are victorious."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:175
 msgid ""
 "You have captured the enemy hero %{name}!\n"
 "Your quest is complete."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:183
 msgid ""
 "You have found the %{name}.\n"
 "Your quest is complete."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:195
 msgid ""
 "The enemy is beaten.\n"
 "Your side has triumphed!"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:200
 msgid ""
 "You have built up over %{count} gold in your treasury.\n"
 "All enemies bow before your wealth and power."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:222
 msgid ""
 "The enemy has found the %{name}.\n"
 "Your quest is a failure."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:230
 msgid ""
 "%{color} has fallen!\n"
 "All is lost."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:237
 msgid ""
 "The enemy has built up over %{count} gold in his treasury.\n"
 "You must bow done in defeat before his wealth and power."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:243
 msgid "You have been eliminated from the game!!!"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:248
 msgid ""
 "The enemy has captured %{name}!\n"
 "They are triumphant."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:257 ../fheroes2/game/game_over.cpp:264
 msgid ""
 "You have lost the hero %{name}.\n"
 "Your quest is over."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:272
 msgid ""
 "You have failed to complete your quest in time.\n"
 "All is lost."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:320
-msgid "%{color} has been vanquished!"
+msgid "%{color} player has been vanquished!"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "Warning"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "No maps available!"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Scenario"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Click here to select which scenario to play."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid "Game Difficulty"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid ""
 "This lets you change the starting difficulty at which you will play. Higher "
 "difficulty levels start you of with fewer resources, and at the higher "
 "settings, give extra resources to the computer."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid "Difficulty Rating"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid ""
 "The difficulty rating reflects a combination of various settings for your "
 "game. This number will be applied to your final score."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
 msgid "Click to accept these settings and start a new game."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
 msgid "Click to return to the main menu."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:342
 msgid "Scenario:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:350
 msgid "Game Difficulty:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:354
 msgid "Opponents:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:358
 msgid "Class:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:384
 msgid "Rating %{rating}%"
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:226
 msgid "Astrologers proclaim Month of the %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:226
 msgid "Astrologers proclaim Week of the %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:240
 msgid "After regular growth, population of %{monster} is doubled!"
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:252
 msgid " All populations are halved."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:254
 msgid " All dwellings increase population."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:283
 msgid ""
 "%{color} player, your heroes abandon you, and you are banished from this "
 "land."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:290
 msgid ""
 "%{color} player, this is your last day to capture a town, or you will be "
 "banished from this land."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:295
 msgid ""
 "%{color} player, you only have %{day} days left to capture a town, or you "
 "will be banished from this land."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:584
-msgid "%{color} player's turn"
+msgid "%{color} player's turn."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:995
 msgid ""
 "%{color} player, you have lost your last town. If you do not conquer another "
 "town in next week, you will be eliminated."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Next Hero"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Select the next Hero."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue Movement"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue the Hero's movement along the current path."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "Kingdom Summary"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "View a Summary of your Kingdom."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:189
 msgid "Cast an adventure spell."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End Turn"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End your turn and left the computer take its turn."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Adventure Options"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Bring up the adventure options menu."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "File Options"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "Bring up the file options menu, alloving you to load menu, save etc."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "System Options"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "Bring up the system options menu, alloving you to customize your game."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:175
 msgid ""
 "One or more heroes may still move, are you sure you want to end your turn?"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:212
-msgid "Are you sure you want to restart? (Your current game will be lost)"
-msgstr ""
-
-#: ../fheroes2/gui/interface_events.cpp:276
 msgid "Are you sure you want to quit?"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:308
+msgid "Are you sure you want to restart? (Your current game will be lost.)"
+msgstr ""
+
+msgid "Are you sure you want to overwrite the save with this name?"
+msgstr ""
+
 msgid "Game saved successfully."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:314
-msgid ""
-"Are you sure you want to load a new game? (Your current game will be lost)"
+msgid "There was an issue during saving."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:353
+msgid ""
+"Are you sure you want to load a new game? (Your current game will be lost.)"
+msgstr ""
+
 msgid "Try looking on land!!!"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:368
 msgid ""
-"After spending many hours digging here, you have uncovered the %{artifact}"
+"After spending many hours digging here, you have uncovered the %{artifact}."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:370
 msgid "Congratulations!"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:384
 msgid "Nothing here. Where could it be?"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:395
 msgid "Try searching on clear ground."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:399
 msgid "Digging for artifacts requires a whole day, try again tomorrow."
 msgstr ""
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "World Map"
 msgstr ""
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "A miniature view of the known world. Left click to move viewing area."
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:216
 msgid "Month: %{month} Week: %{week}"
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:222
-#: ../fheroes2/kingdom/kingdom_overview.cpp:569
 msgid "Day: %{day}"
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:257
 msgid ""
 "You find a small\n"
 "quantity of %{resource}."
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:407
 msgid "Status Window"
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:407
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date."
+msgstr ""
+
 msgid ""
 "This window provides information on the status of your hero or kingdom, and "
 "shows the date. Left click here to cycle throungh these windows."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:112
+msgid "Necroman"
+msgstr ""
+
+msgid ""
+"This lets you change player starting positions and colors. A particular "
+"color will always start in a particular location. Some positions may only be "
+"played by a computer player or only by a human player."
+msgstr ""
+
+msgid ""
+"This lets you change the class of a player. Classes are not always "
+"changeable. Depending on the scenario, a player may receive additional towns "
+"and/or heroes not of their primary alignment."
+msgstr ""
+
+msgid "%{color} player"
+msgstr ""
+
+msgid "View %{skill} Info"
+msgstr ""
+
+msgid "Lord Kilburn"
+msgstr ""
+
+msgid "Sir Gallant"
+msgstr ""
+
+msgid "Ector"
+msgstr ""
+
+msgid "Gwenneth"
+msgstr ""
+
+msgid "Tyro"
+msgstr ""
+
+msgid "Ambrose"
+msgstr ""
+
+msgid "Ruby"
+msgstr ""
+
+msgid "Maximus"
+msgstr ""
+
+msgid "Dimitry"
+msgstr ""
+
+msgid "Thundax"
+msgstr ""
+
+msgid "Fineous"
+msgstr ""
+
+msgid "Jojosh"
+msgstr ""
+
+msgid "Crag Hack"
+msgstr ""
+
+msgid "Jezebel"
+msgstr ""
+
+msgid "Jaclyn"
+msgstr ""
+
+msgid "Ergon"
+msgstr ""
+
+msgid "Tsabu"
+msgstr ""
+
+msgid "Atlas"
+msgstr ""
+
+msgid "Astra"
+msgstr ""
+
+msgid "Natasha"
+msgstr ""
+
+msgid "Troyan"
+msgstr ""
+
+msgid "Vatawna"
+msgstr ""
+
+msgid "Rebecca"
+msgstr ""
+
+msgid "Gem"
+msgstr ""
+
+msgid "Ariel"
+msgstr ""
+
+msgid "Carlawn"
+msgstr ""
+
+msgid "Luna"
+msgstr ""
+
+msgid "Arie"
+msgstr ""
+
+msgid "Alamar"
+msgstr ""
+
+msgid "Vesper"
+msgstr ""
+
+msgid "Crodo"
+msgstr ""
+
+msgid "Barok"
+msgstr ""
+
+msgid "Kastore"
+msgstr ""
+
+msgid "Agar"
+msgstr ""
+
+msgid "Falagar"
+msgstr ""
+
+msgid "Wrathmont"
+msgstr ""
+
+msgid "Myra"
+msgstr ""
+
+msgid "Flint"
+msgstr ""
+
+msgid "Dawn"
+msgstr ""
+
+msgid "Halon"
+msgstr ""
+
+msgid "Myrini"
+msgstr ""
+
+msgid "Wilfrey"
+msgstr ""
+
+msgid "Sarakin"
+msgstr ""
+
+msgid "Kalindra"
+msgstr ""
+
+msgid "Mandigal"
+msgstr ""
+
+msgid "Zom"
+msgstr ""
+
+msgid "Darlana"
+msgstr ""
+
+msgid "Zam"
+msgstr ""
+
+msgid "Ranloo"
+msgstr ""
+
+msgid "Charity"
+msgstr ""
+
+msgid "Rialdo"
+msgstr ""
+
+msgid "Roxana"
+msgstr ""
+
+msgid "Sandro"
+msgstr ""
+
+msgid "Celia"
+msgstr ""
+
+msgid "Roland"
+msgstr ""
+
+msgid "Lord Corlagon"
+msgstr ""
+
+msgid "Sister Eliza"
+msgstr ""
+
+msgid "Archibald"
+msgstr ""
+
+msgid "Lord Halton"
+msgstr ""
+
+msgid "Brother Brax"
+msgstr ""
+
+msgid "Solmyr"
+msgstr ""
+
+msgid "Dainwin"
+msgstr ""
+
+msgid "Mog"
+msgstr ""
+
+msgid "Joseph"
+msgstr ""
+
+msgid "Gallavant"
+msgstr ""
+
+msgid "Elderian"
+msgstr ""
+
+msgid "Ceallach"
+msgstr ""
+
+msgid "Drakonia"
+msgstr ""
+
+msgid "Martine"
+msgstr ""
+
+msgid "Jarkonas"
+msgstr ""
+
+msgid "%{object} robber"
+msgstr ""
+
+msgid "%{object} raided"
+msgstr ""
+
+msgid "You cannot pick up this artifact, you already have a full load!"
+msgstr ""
+
+msgid "The three Anduran artifacts magically combine into one."
+msgstr ""
+
+msgid "To cast spells, you must first buy a spell book for %{gold} gold."
+msgstr ""
+
+msgid "Unfortunately, you seem to be a little short of cash at the moment."
+msgstr ""
+
+msgid "Do you wish to buy one?"
+msgstr ""
+
 msgid "%{count} / day"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:331
-#: ../fheroes2/heroes/heroes_action.cpp:2199
 msgid "You are unable to recruit at this time, your ranks are full."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:599
-msgid ""
-"A group of %{monster} with a desire for greater glory wish to join you.\n"
-"Do you accept?"
+msgid "A whirlpool engulfs your ship."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:609
-#: ../fheroes2/heroes/heroes_action.cpp:630
+msgid "Some of your army has fallen overboard."
+msgstr ""
+
 msgid "Insulted by your refusal of their offer, the monsters attack!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:638
 msgid ""
 "The %{monster}, awed by the power of your forces, begin to scatter.\n"
 "Do you wish to pursue and engage them?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:934
 msgid "Ransacking an enemy camp, you discover a hidden cache of treasures."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:966
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with these resources, "
 "come back next week for more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:967
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there are no resources currently available. Please try "
 "again next week.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:972
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with this gold, come "
 "back next week for more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:973
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there is no gold currently available. Please try again "
 "next week.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:979
 msgid ""
 "You've found an abandoned lean-to.\n"
 "Poking about, you discover some resources hidden nearby."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:980
 msgid "The lean-to is long abandoned. There is nothing of value here."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:985
 msgid ""
 "You catch a leprechaun foolishly sleeping amidst a cluster of magic "
 "mushrooms.\n"
@@ -2645,176 +2889,142 @@ msgid ""
 "precious things."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:986
 msgid ""
 "You've found a magic garden, the kind of place that leprechauns and faeries "
 "like to cavort in, but there is no one here today.\n"
 "Perhaps you should try again next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1023
 msgid "You come upon the remains of an unfortunate adventurer."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1034
 msgid "Treasure"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1041
 msgid "Searching through the tattered clothing, you find %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1052
 msgid "Searching through the tattered clothing, you find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1064
 msgid ""
 "You come across an old wagon left by a trader who didn't quite make it to "
 "safe terrain."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1075
-#: ../fheroes2/heroes/heroes_action.cpp:1103
 msgid "Unfortunately, others have found it first, and the wagon is empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1082
 msgid "Searching inside, you find the %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1093
 msgid "Inside, you find some of the wagon's cargo still intact."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1123
 msgid "You search through the flotsam, and find some wood and some gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1124
 msgid "You search through the flotsam, and find some wood."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1130
 msgid "You search through the flotsam, but find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1151
 msgid "Shrine of the 1st Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1152
 msgid ""
 "You come across a small shrine attended by a group of novice acolytes.\n"
-"In exchange for your protection, they agree to teach you a simple spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a simple spell - "
+"'%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1155
 msgid "Shrine of the 2nd Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1156
 msgid ""
 "You come across an ornate shrine attended by a group of rotund friars.\n"
-"In exchange for your protection, they agree to teach you a spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a spell - "
+"'%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1159
 msgid "Shrine of the 3rd Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1160
 msgid ""
 "You come across a lavish shrine attended by a group of high priests.\n"
 "In exchange for your protection, they agree to teach you a sophisticated "
 "spell - '%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1173
 msgid ""
 "\n"
 "Unfortunately, you have no Magic Book to record the spell with."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1184
 msgid ""
 "\n"
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1192
 msgid ""
 "\n"
 "Unfortunately, you already have knowledge of this spell, so there is nothing "
 "more for them to teach you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1215
 msgid ""
-"You approach the hut and observe a witch inside studying an ancient tome on %"
-"{skill}.\n"
+"You approach the hut and observe a witch inside studying an ancient tome on "
+"%{skill}.\n"
 " \n"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1222
 msgid ""
 "As you approach, she turns and focuses her one glass eye on you.\n"
 "\"You already know everything you deserve to learn!\" the witch screeches. "
 "\"NOW GET OUT OF MY HOUSE!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1229
 msgid ""
 "As you approach, she turns and speaks.\n"
 "\"You already know that which I would teach you. I can help you no further.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1236
 msgid ""
 "An ancient and immortal witch living in a hut with bird's legs for stilts "
 "teaches you %{skill} for her own inscrutable purposes."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1255
 msgid "You drink from the enchanted fountain, but nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1256
 msgid "As you drink the sweet water, you gain luck for your next battle."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1260
 msgid "You enter the faerie ring, but nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1261
 msgid ""
 "Upon entering the mystical faerie ring, your army gains luck for its next "
 "battle."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1265
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "It is supposed to grant luck to visitors, but since the stars are already "
 "smiling upon you, it does nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1266
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "Kissing it is supposed to be lucky, so you do. The stone is very cold to the "
 "touch."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1270
 msgid "The mermaids silently entice you to return later and be blessed again."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1271
 msgid ""
 "The magical, soothing beauty of the Mermaids reaches you and your crew.\n"
 "Just for a moment, you forget your worries and bask in the beauty of the "
@@ -2822,7 +3032,6 @@ msgid ""
 "The mermaids charms bless you with increased luck for your next combat."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1303
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "You are tempted to search it for treasure, but all the old stories warn of "
@@ -2830,470 +3039,375 @@ msgid ""
 "Will you search?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1304
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "Routine exploration reveals that the pyramid is completely empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1329
 msgid "Unfortunately, you have no Magic Book to record the spell with."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1333
 msgid ""
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1337
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
 "telling the secret of the spell."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1374 ../fheroes2/maps/mp2.cpp:469
 msgid "Sign"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1385
 msgid ""
 "A drink at the well is supposed to restore your spell points, but you are "
 "already at maximum."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1392
 msgid "A second drink at the well in one day will not help you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1399
 msgid "A drink from the well has restored your spell points to maximum."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1424
 msgid ""
 "\"I'm sorry sir,\" The leader of the soldiers says, \"but you already know "
 "everything we have to teach.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1425
 msgid "The soldiers living in the fort teach you a few new defensive tricks."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1430
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. \"You're too "
 "advanced for us,\" the mercenary captain says. \"We can teach nothing more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1431
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. The mercenaries "
 "welcome you and your troops and invite you to train with them."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1436
 msgid "\"Go 'way!\", the witch doctor barks, \"you know all I know.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1437
 msgid ""
 "An Orcish witch doctor living in the hut deepens your knowledge of magic by "
 "showing you how to cast stones, read portents, and decipher the intricacies "
 "of chicken entrails."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1442
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, the Druids turn you away, indicating they have nothing "
 "new to teach you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1443
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, they teach you new ways to cast spells."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1479
 msgid ""
 "You tentatively approach the burial ground of ancient warriors. Do you want "
 "to search the graves?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1480
 msgid ""
 "Upon defeating the Zombies you spend several hours searching the graves and "
 "find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1481
-msgid "Upon defeating the zomies you search the graves and find something!"
+msgid "Upon defeating the Zombies you search the graves and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1484
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the shipwreck?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1485
 msgid ""
 "Upon defeating the Ghosts you spend several hours sifting through the debris "
 "and find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1486
 msgid ""
 "Upon defeating the Ghosts you sift through the debris and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1489
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the ship?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1490
 msgid ""
 "Upon defeating the Skeletons you spend several hours sifting through the "
 "debris and find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1491
 msgid ""
 "Upon defeating the Skeletons you sift through the debris and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1564
 msgid "Your men spot a navigational buoy, confirming that you are on course."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1565
 msgid ""
 "Your men spot a navigational buoy, confirming that you are on course and "
 "increasing their morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1569
 msgid ""
 "The drink at the oasis is refreshing, but offers no further benefit. The "
 "oasis might help again if you fought a battle first."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1570
 msgid ""
 "A drink at the oasis fills your troops with strength and lifts their "
 "spirits.  You can travel a bit further today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1575
 msgid ""
 "The drink at the watering hole is refreshing, but offers no further benefit. "
 "The watering hole might help again if you fought a battle first."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1576
 msgid ""
 "A drink at the watering hole fills your troops with strength and lifts their "
 "spirits. You can travel a bit further today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1581
 msgid ""
 "It doesn't help to pray twice before a battle. Come back after you've fought."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1582
 msgid "A visit and a prayer at the temple raises the morale of your troops."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1622
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"I am sorry, my liege, I "
 "have taught you all I can.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1623
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"My liege, I will teach "
 "you all that I know to aid you in your travels.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1662
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
 "ocean. Grateful, he says, \"I would give you an artifact as a reward, but "
 "you're all full.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1669
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
-"ocean. Grateful, he rewards you for your act of kindness by giving you the %"
-"{art}."
+"ocean. Grateful, he rewards you for your act of kindness by giving you the "
+"%{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1688 ../fheroes2/heroes/heroes.cpp:941
-msgid "You have no room to carry another artifact!"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:1704
 msgid "A leprechaun offers you the %{art} for the small price of %{gold} Gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1709
 msgid ""
-"A leprechaun offers you the %{art} for the small price of %{gold} Gold and %"
-"{count} %{res}."
+"A leprechaun offers you the %{art} for the small price of %{gold} Gold and "
+"%{count} %{res}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1718
 msgid "Do you wish to buy this artifact?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1731
 msgid ""
 "You try to pay the leprechaun, but realize that you can't afford it. The "
 "leprechaun stamps his foot and ignores you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1735
 msgid ""
 "Insulted by your refusal of his generous offer, the leprechaun stamps his "
 "foot and ignores you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1746
-#: ../fheroes2/heroes/heroes_action.cpp:1821
 msgid "You've found the artifact: "
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1756
 msgid ""
 "You've found the humble dwelling of a withered hermit. The hermit tells you "
 "that he is willing to give the %{art} to the first wise person he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1759
 msgid ""
 "You've come across the spartan quarters of a retired soldier. The soldier "
 "tells you that he is willing to pass on the %{art} to the first true leader "
 "he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1780
 msgid ""
 "You come upon an ancient artifact. As you reach for it, a pack of Rogues "
 "leap out of the brush to guard their stolen loot."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1783
 msgid ""
 "Through a clearing you observe an ancient artifact. Unfortunately, it's "
 "guarded by a nearby %{monster}. Do you want to fight the %{monster} for the "
 "artifact?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1798
 msgid "Victorious, you take your prize, the %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1810
 msgid ""
 "Discretion is the better part of valor, and you decide to avoid this fight "
 "for today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1866
-#: ../fheroes2/heroes/heroes_action.cpp:1881
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold pieces."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1872
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold and the %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1888
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it, "
 "only to find it empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1898
 msgid ""
 "After scouring the area, you fall upon a hidden treasure cache. You may take "
 "the gold or distribute the gold to the peasants for experience. Do you wish "
 "to keep the gold?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1912
 msgid ""
-"After scouring the area, you fall upon a hidden chest, containing the %"
-"{gold} gold pieces."
+"After scouring the area, you fall upon a hidden chest, containing the "
+"%{gold} gold pieces."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1918
 msgid ""
 "After scouring the area, you fall upon a hidden chest, containing the "
 "ancient artifact %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1942
 msgid ""
 "You stumble upon a dented and tarnished lamp lodged deep in the earth. Do "
 "you wish to rub the lamp?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "A whirlpool engulfs your ship."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "Some of your army has fallen overboard."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2045
 msgid ""
 "You come upon an abandoned gold mine. The mine appears to be haunted. Do you "
 "wish to enter?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2064
 msgid ""
 "You have taken control of the local Alchemist shop. It will provide you with "
 "%{count} unit of Mercury per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2070
 msgid ""
 "You gain control of a sawmill. It will provide you with %{count} units of "
 "wood per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2081
+msgid "You beat the Ghosts and are able to restore the mine to production."
+msgstr ""
+
 msgid ""
 "You gain control of an ore mine. It will provide you with %{count} units of "
 "ore per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2083
 msgid ""
 "You gain control of a sulfur mine. It will provide you with %{count} unit of "
 "sulfur per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2085
 msgid ""
 "You gain control of a crystal mine. It will provide you with %{count} unit "
 "of crystal per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2087
 msgid ""
 "You gain control of a gem mine. It will provide you with %{count} unit of "
 "gems per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2089
 msgid ""
 "You gain control of a gold mine. It will provide you with %{count} gold per "
 "day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2096
-msgid "You beat the Ghosts and are able to restore the mine to production."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2101
 msgid ""
 "The lighthouse is now under your control, and all of your ships will now "
 "move further each turn."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2105
 msgid "You gain control of a %{name}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2188
 msgid ""
 "A group of %{monster} with a desire for greater glory wish to join you. Do "
 "you accept?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2215
 msgid "As you approach the dwelling, you notice that there is no one here."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2232
 msgid ""
 "You search the ruins, but the Medusas that used to live here are gone. "
 "Perhaps there will be more next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2233
 msgid ""
 "You've found some Medusas living in the ruins. They are willing to join your "
 "army for a price. Do you want to recruit Medusas?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2238
 msgid ""
 "You've found a Sprite Tree City. Unfortunately, none of the Sprites living "
 "there wish to join an army. Maybe next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2239
 msgid ""
 "Some of the Sprites living in the tree city are willing to join your army "
 "for a price. Do you want to recruit Sprites?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2244
 msgid ""
 "A colorful Rogues' wagon stands empty here. Perhaps more Rogues will be here "
 "later."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2245
 msgid ""
 "Distant sounds of music and laughter draw you to a colorful wagon housing "
 "Rogues. Do you wish to have any Rogues join your army?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2250
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. The "
 "tents are unoccupied. Perhaps more Nomads will be here later."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2251
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. Do you "
 "wish to have any Nomads join you during your travels?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2256
 msgid "The pit of mud bubbles for a minute and then lies still."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2257
 msgid ""
 "As you approach the bubbling pit of mud, creatures begin to climb out and "
 "position themselves around it. In unison they say: \"Mother Earth would like "
 "to offer you a few of her troops. Do you want to recruit Earth Elementals?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2261
 msgid "You enter the structure of white stone pillars, and find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2262
 msgid ""
 "White stone pillars support a roof that rises up to the sky. As you enter "
 "the structure, the dead air of the outside gives way to a whirling gust that "
@@ -3303,192 +3417,159 @@ msgid ""
 "air?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2266
 msgid "No Fire Elementals approach you from the lava pool."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2267
 msgid ""
 "Beneath a structure that serves to hold in heat, Fire Elementals move about "
 "in a fiery pool of molten lava. A group of them approach you and offer their "
 "services. Would you like to recruit Fire Elementals?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2271
 msgid "A face forms in the water for a moment, and then is gone."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2272
 msgid ""
 "Crystalline structures cast shadows over a small reflective pool of water. "
 "You peer into the pool, and a face that is not your own peers back. It asks: "
 "\"Would you like to call upon the powers of water?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2276
 msgid "This burial site is deathly still."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2277
 msgid ""
 "Restless spirits of long dead warriors seeking their final resting place "
 "offer to join you in hopes of finding peace. Do you wish to recruit ghosts?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2313
 msgid ""
 "The City of the Dead is empty of life, and empty of unlife as well. Perhaps "
 "some undead will move in next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2314
 msgid ""
 "Some Liches living here are willing to join your army for a price. Do you "
 "want to recruit Liches?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2315
 msgid ""
 "You've found the ruins of an ancient city, now inhabited solely by the "
 "undead. Will you search?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2316
 msgid ""
 "Some of the surviving Liches are impressed by your victory over their "
 "fellows, and offer to join you for a price. Do you want to recruit Liches?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2320
 msgid ""
 "You've found one of those bridges that Trolls are so fond of living under, "
 "but there are none here. Perhaps there will be some next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2321
 msgid ""
 "Some Trolls living under a bridge are willing to join your army, but for a "
 "price. Do you want to recruit Trolls?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2322
 msgid "Trolls living under the bridge challenge you. Will you fight them?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2323
 msgid ""
 "A few Trolls remain, cowering under the bridge. They approach you and offer "
 "to join your forces as mercenaries. Do you want to buy any Trolls?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2327
 msgid ""
 "The Dragon city has no Dragons willing to join you this week. Perhaps a "
 "Dragon will become available next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2328
 msgid ""
 "The Dragon city is willing to offer some Dragons for your army for a price. "
 "Do you wish to recruit Dragons?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2329
 msgid ""
 "You stand before the Dragon City, a place off-limits to mere humans. Do you "
 "wish to violate this rule and challenge the Dragons to a fight?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2330
 msgid ""
 "Having defeated the Dragon champions, the city's leaders agree to supply "
 "some Dragons to your army for a price. Do you wish to recruit Dragons?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2389
 msgid "From the observation tower, you are able to see distant lands."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2401
 msgid ""
 "The spring only refills once a week, and someone's already been here this "
 "week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2407
 msgid ""
 "A drink at the spring is supposed to give you twice your normal spell "
 "points, but you are already at that level."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2418
 msgid ""
 "A drink from the spring fills your blood with magic! You have twice your "
 "normal spell points in reserve."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2437
 msgid ""
 "Recognizing you, the butler refuses to admit you. \"The master,\" he says, "
 "\"will not see the same student twice.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2457
 msgid ""
 "The butler admits you to see the master of the house. He trains you in the "
 "four skills a hero should know."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2467
 msgid ""
 "The butler opens the door and looks you up and down. \"You are neither "
 "famous nor diplomatic enough to be admitted to see my master,\" he sniffs. "
 "\"Come back when you think yourself worthy.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2510
 msgid ""
 "All of the %{monsters} you have in your army have been trained by the battle "
 "masters of the fort. Your army now contains %{monsters2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2513
 msgid ""
-"An unusual alliance of Orcs, Ogres, and Dwarves offer to train (upgrade) any "
+"An unusual alliance of Ogres, Orcs, and Dwarves offer to train (upgrade) any "
 "such troops brought to them. Unfortunately, you have none with you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2524
 msgid "All of your %{monsters} have been upgraded into %{monsters2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2527
 msgid ""
 "A blacksmith working at the foundry offers to convert all Pikemen and "
 "Swordsmen's weapons brought to him from iron to steel. He also says that he "
-"knows a process that will convert Iron Golems into Steel Golems.  "
+"knows a process that will convert Iron Golems into Steel Golems. "
 "Unfortunately, you have none of these troops in your army, so he can't help "
 "you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2585
 msgid ""
 "A retired captain living on this refurbished fishing platform offers to sell "
 "you maps of the sea he made in his younger days for 1,000 gold. Do you wish "
 "to buy the maps?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2598
 msgid ""
 "The captain sighs. \"You don't have enough money, eh?  You can't expect me "
 "to give my maps away for free!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2632
 msgid "You find %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2655
 msgid ""
 "You come upon an obelisk made from a type of stone you have never seen "
 "before. Staring at it intensely, the smooth surface suddenly changes to an "
@@ -3496,56 +3577,51 @@ msgid ""
 "copy down the piece and the inscription vanishes as abruptly as it appeared."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2659
 msgid "You have already been to this obelisk."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2671
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"It is good to see "
 "you, my student. I hope my teachings have helped you.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2683
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"Ahh, an "
 "adventurer! Allow me to teach you a little of what I have learned over the "
 "ages.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2692
 msgid "Upon your approach, the tree opens its eyes in delight."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2694
 msgid ""
 "\"Ahh, an adventurer! I will be happy to teach you a little of what I have "
 "learned over the ages for a mere %{count} %{res}.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2696
 msgid "(Just bury it around my roots.)"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2703
 msgid "Tears brim in the eyes of the tree."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2705
 msgid "\"I need %{count} %{res}.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2707
 msgid "it whispers. (sniff) \"Well, come back when you can pay me.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2737
+msgid ""
+"Nestled among the trees sits a blind seer. After explaining the intent of "
+"your journey, the seer activates his crystal ball, allowing you to see the "
+"strengths and weaknesses of your opponents."
+msgstr ""
+
 msgid ""
 "The entrance to the cave is dark, and a foul, sulfurous smell issues from "
 "the cave mouth. Will you enter?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2749
 msgid ""
 "You find a powerful and grotesque Demon in the cave. \"Today,\" it rasps, "
 "\"you will fight and surely die. But I will give you a choice of deaths. You "
@@ -3553,71 +3629,59 @@ msgid ""
 "servants?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2759
 msgid ""
 "Upon defeating the daemon's servants, you find a hidden cache with %{count} "
 "gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2774
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and receive %{exp} experience points."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2784
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and find the %{art} in the back of the cave."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2794
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
-"battle, you slay the monster and receive %{exp) experience points and %"
-"{count} gold."
+"battle, you slay the monster and receive %{exp} experience points and "
+"%{count} gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2809
 msgid ""
 "The Demon leaps upon you and has its claws at your throat before you can "
 "even draw your sword. \"Your life is mine,\" it says. \"I will sell it back "
 "to you for %{count} gold.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2810
 msgid ""
 "Seeing that you do not have %{count} gold, the demon slashes you with its "
 "claws, and the last thing you see is a red haze."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2835
 msgid "Except for evidence of a terrible battle, the cave is empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2860
 msgid "For %{gold} gold, the alchemist will remove it for you. Do you pay?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2871
 msgid ""
 "You hear a voice from behind the locked door, \"You don't have enough gold "
 "to pay for my services.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2874
 msgid ""
 "You hear a voice from high above in the tower, \"Go away! I can't help you!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2886
 msgid ""
 "The head groom approaches you and speaks, \"You already have a fine horse, "
 "and have no inexperienced cavalry which might make use of our trained war "
 "horses.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2889
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, his "
@@ -3626,7 +3690,6 @@ msgid ""
 "mounted soldiers, but you have none we can help.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2892
 msgid ""
 "The head groom speaks to you, \"That is a fine looking horse you have. I am "
 "afraid we can give you no better, but the horses your cavalry are riding "
@@ -3634,7 +3697,6 @@ msgid ""
 "would aid your riders greatly. I insist you take them.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2895
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, he will "
@@ -3642,17 +3704,14 @@ msgid ""
 "mounted soldiers, their horses look shoddy and weak.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2922
 msgid "The Arena guards turn you away."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2939
 msgid ""
 "As the sirens sing their eerie song, your small, determined army manages to "
 "overcome the urge to dive headlong into the sea."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2944
 msgid ""
 "You have your crew stop up their ears with wax before the sirens' eerie song "
 "has any chance of luring them to a watery grave. An eerie wailing song "
@@ -3661,57 +3720,52 @@ msgid ""
 "for the visit, and gain %{exp} experience."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2964
 msgid ""
 "In a dazzling display of daring, you break into the local jail and free the "
 "hero imprisoned there, who, in return, pledges loyalty to your cause."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2980
 msgid ""
 "You already have %{count} heroes, and regretfully must leave the prisoner in "
 "this jail to languish in agony for untold days."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2991
 msgid ""
 "You enter a rickety hut and talk to the magician who lives there. He tells "
 "you of places near and far which may aid you in your journeys."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3004
 msgid "This eye seems to be intently studying its surroundings."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3015
 msgid ""
 "\"I have a riddle for you,\" the Sphinx says. \"Answer correctly, and you "
 "shall be rewarded. Answer incorrectly, and you shall be eaten. Do you accept "
 "the challenge?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3017
-msgid "The Sphinx asks you the following riddle: %{riddle}. Your answer?"
+msgid ""
+"The Sphinx asks you the following riddle:\n"
+" \n"
+"'%{riddle}'\n"
+" \n"
+"Your answer?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3025
 msgid ""
 "Looking somewhat disappointed, the Sphinx sighs. You've answered my riddle "
 "so here's your reward. Now begone."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3052
 msgid ""
 "\"You guessed incorrectly,\" the Sphinx says, smiling. The Sphinx swipes at "
 "you with a paw, knocking you to the ground. Another blow makes the world go "
 "black, and you know no more."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3060
 msgid "You come across a giant Sphinx. The Sphinx remains strangely quiet."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3073
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -3719,7 +3773,6 @@ msgid ""
 "As you speak the magic word, the glowing barrier dissolves into nothingness."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3083
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -3727,7 +3780,6 @@ msgid ""
 "You speak, and nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3093
 msgid ""
 "You enter the tent and see an old woman gazing into a magic gem. She looks "
 "up and says,\n"
@@ -3735,421 +3787,81 @@ msgid ""
 "oracle taught me his skill. I have the answer you seek.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_base.cpp:401
 msgid ""
 "That spell costs %{mana} mana. You only have %{point} mana, so you can't "
 "cast the spell."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Lord Kilburn"
+msgid "%{name} the %{race} (Level %{level})"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Sir Gallanth"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ector"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Gwenneth"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Tyro"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ambrose"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ruby"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Maximus"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Dimitry"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Thundax"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Fineous"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jojosh"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Crag Hack"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jezebel"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jaclyn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Ergon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Tsabu"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Atlas"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Astra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Natasha"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Troyan"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Vatawna"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Rebecca"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Gem"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Ariel"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Carlawn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Luna"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Arie"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61 ../fheroes2/resource/maps_text.cpp:59
-msgid "Alamar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Vesper"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Crodo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Barok"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Kastore"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Agar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Falagar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Wrathmont"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Flint"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Dawn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Halon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myrini"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Wilfrey"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Sarakin"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63 ../fheroes2/resource/maps_text.cpp:377
-msgid "Kalindra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Mandigal"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zom"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Darlana"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zam"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Ranloo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Charity"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Rialdo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Roxana"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65 ../fheroes2/resource/maps_text.cpp:557
-msgid "Sandro"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Celia"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:552
-msgid "Roland"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Lord Corlagon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Sister Eliza"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:88
-msgid "Archibald"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:403
-msgid "Lord Halton"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Brother Bax"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Solmyr"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:194
-msgid "Dainwin"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Mog"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:760
-msgid "Uncle Ivan"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:373
-msgid "Joseph"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:285
-msgid "Gallavant"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Elderian"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:179
-msgid "Ceallach"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:229
-msgid "Drakonia"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:422
-msgid "Martine"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:370
-msgid "Jarkonas"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:940
-msgid ""
-"You must purchase a spell book to use the mage guild, but you currently have "
-"no room for a spell book. Try giving one of your artifacts to another hero."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:950
-msgid "The three Anduran artifacts magically combine into one."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1056
-msgid "To cast spells, you must first buy a spell book for %{gold} gold."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1064
-msgid "Unfortunately, you seem to be a little short of cash at the moment."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1078
-msgid "Do you wish to buy one?"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:72
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:55
-msgid "%{name} the %{race} ( Level %{level} )"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:118
 msgid ""
 "'Grouped' combat formation bunches your army together in the center of your "
 "side of the battlefield."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:161
 msgid "Are you sure you want to dismiss this Hero?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:341
 msgid "View Stats"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:344
-msgid "View Morale Info"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:347
-msgid "View Luck Info"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:350
 msgid "View Experience Info"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:353
 msgid "View Spell Points Info"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:356
 msgid "Set army combat formation to 'Spread'"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:359
 msgid "Set army combat formation to 'Grouped'"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:362
-msgid "Exit hero"
+msgid "Exit Hero Screen"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:369
-msgid "Dismiss hero"
+msgid "You cannot dismiss a hero in a castle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:373
-msgid "Show prev heroes"
+msgid "Dismissal of %{name} the %{race} is prohibited by scenario"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:376
-msgid "Show next heroes"
+msgid "Dismiss %{name} the %{race}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:379
-msgid "Hero Screen"
+msgid "Show previous hero"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:39
-msgid "Bad Morale"
+msgid "Show next hero"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:42
-msgid "Neutral Morale"
+msgid "Blood Morale"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:47
-msgid "Good Morale"
+msgid "%{morale} Morale"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:61
-msgid "Bad Luck"
+msgid "%{luck} Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:64
-msgid "Neutral Luck"
+msgid "Current Luck Modifiers:"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:69
-msgid "Good Luck"
+msgid "Current Morale Modifiers:"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:113
-#: ../fheroes2/heroes/heroes_indicator.cpp:159
-#: ../fheroes2/heroes/skill.cpp:197
-msgid "Current Modifiers:"
+msgid "Entire army is undead, so morale does not apply."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:195
-msgid "Current experience %{exp1} Next level %{exp2}."
+msgid ""
+"Current experience %{exp1}.\n"
+" Next level %{exp2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:215
 msgid "Level %{level}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:226
 msgid ""
 "%{name} currently has %{point} spell points out of a maximum of %{max}. The "
 "maximum number of spell points is 10 times your knowledge. It is "
@@ -4157,2521 +3869,1437 @@ msgid ""
 "special events."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:65
 msgid "%{name1} meets %{name2}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:396
-#: ../fheroes2/heroes/heroes_meeting.cpp:406
 msgid " and "
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:414
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:417
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:420
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches %"
-"{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches "
+"%{spells2} to %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:431
 msgid "Scholar Ability"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:83 ../fheroes2/spell/spell.cpp:109
 msgid "Town Portal"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:86
 msgid "Select town to port to."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:106
 msgid "Your hero is too tired to cast this spell today. Try again tomorrow."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:187
 msgid "%{spell} failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:236
+msgid "This spell is already in use."
+msgstr ""
+
 msgid "Enemy heroes are now fully identifiable."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:362
-#: ../fheroes2/heroes/heroes_spell.cpp:386
-msgid "No available towns. Spell Failed!!!"
+msgid "This spell cannot be used on a boat."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:459
-msgid "I fear these creatures are in the mood for a fight."
+msgid "This spell can be casted only nearby water."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:463
-msgid "The creatures are willing to join us!"
+msgid ""
+"No available towns.\n"
+"Spell Failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:468
-msgid "All the creatures will join us..."
+msgid ""
+"Nearest town occupied.\n"
+"Spell Failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:480
-msgid "These weak creatures will surely flee before us."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_spell.cpp:489
 msgid ""
 "You must be within %{count} spaces of a monster for the Visions spell to "
 "work."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:506
+msgid "I fear these creatures are in the mood for a fight."
+msgstr ""
+
+msgid "The creatures are willing to join us!"
+msgstr ""
+
+msgid "All the creatures will join us..."
+msgstr ""
+
+msgid "These weak creatures will surely flee before us."
+msgstr ""
+
 msgid ""
 "You must be standing on the entrance to a mine (sawmills and alchemists "
 "don't count) to cast this spell."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:151
-msgid "Power"
-msgstr ""
-
-#: ../fheroes2/heroes/skill.cpp:172
 msgid "Your attack skill is a bonus added to each creature's attack skill."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:177
 msgid "Your defense skill is a bonus added to each creature's defense skill."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:182
 msgid "Your spell power determines the length or power of a spell."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:187
 msgid ""
 "Your knowledge determines how many spell points your hero may have. Under "
-"normal cirumstances, a hero is limited to 10 spell points per level of "
+"normal circumstances, a hero is limited to 10 spell points per level of "
 "knowledge."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
+msgid "Current Modifiers:"
+msgstr ""
+
 msgid "skill|Basic"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
 msgid "skill|Advanced"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
 msgid "skill|Expert"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Basic Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Advanced Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Expert Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Basic Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Advanced Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Expert Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Basic Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Advanced Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Expert Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Basic Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Advanced Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Expert Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Basic Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Advanced Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Expert Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Basic Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Advanced Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Expert Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Basic Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Advanced Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Expert Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Basic Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Advanced Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Expert Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Basic Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Advanced Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Expert Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Basic Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Advanced Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Expert Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Basic Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Advanced Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Expert Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Basic Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Advanced Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Expert Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Basic Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Advanced Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Expert Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Basic Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Advanced Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Expert Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:406
-msgid "Allows you to negotiate with monsters who are weaker than your group."
+msgid " allows you to negotiate with monsters who are weaker than your group."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:421
-msgid "Allows your hero to learn third level spells."
+msgid "All of the creatures may offer to join you."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:423
-msgid "Allows your hero to learn fourth level spells."
+msgid " allows your hero to learn third level spells."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:425
-msgid "Allows your hero to learn fifth level spells."
+msgid " allows your hero to learn fourth level spells."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:440
+msgid " allows your hero to learn fifth level spells."
+msgstr ""
+
 msgid ""
-"Gives your hero's catapult shots a greater chance to hit and do damage to "
+" gives your hero's catapult shots a greater chance to hit and do damage to "
 "castle walls."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:442
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot has a greater chance "
-"to hit and do damage to castle walls."
+" gives your hero's catapult an extra shot, and each shot has a greater "
+"chance to hit and do damage to castle walls."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:444
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot automatically "
+" gives your hero's catapult an extra shot, and each shot automatically "
 "destroys any wall, except a fortified wall in a Knight town."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:858 ../fheroes2/heroes/skill.cpp:959
-msgid "View %{skill} Info"
-msgstr ""
-
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:108
 msgid "Blue"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:111
 msgid "Green"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:114
 msgid "Red"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32
 msgid "Yellow"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:112
 msgid "Orange"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:113
 msgid "Purple"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:107
 msgid "Aqua"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:109
 msgid "Brown"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:110 ../fheroes2/resource/resource.cpp:283
 msgid "Gold"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:238
 msgid "Hero/Stats"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:241
 msgid "Skills"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:244
 msgid "Artifacts"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:473
 msgid "Town/Castle"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:476
 msgid "Garrison"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:566
 msgid "Gold Per Day:"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Cursed"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Awful"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Bad"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Normal"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Good"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Great"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Irish"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:48
 msgid ""
 "Bad luck sometimes falls on your armies in combat, causing their attacks to "
 "only do half damage."
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:49
 msgid ""
 "Neutral luck means your armies will never get lucky or unlucky attacks on "
 "the enemy."
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:50
 msgid ""
 "Good luck sometimes lets your armies get lucky attacks (double strength) in "
 "combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Treason"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Awful"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Poor"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Normal"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Good"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Great"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Blood!"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:48
 msgid "Bad morale may cause your armies to freeze in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:49
 msgid ""
 "Neutral morale means your armies will never be blessed with extra attacks or "
 "freeze in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:50
 msgid "Good morale may give your armies extra attacks in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Knight"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Barbarian"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Sorceress"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Warlock"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Wizard"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Necromancer"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Multi"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Standing"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Crawling"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Very Slow"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Slow"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Average"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Very Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Ultra Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Blazing"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Instant"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:32
 msgid "week|PLAGUE"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Ant"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Grasshopper"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Dragonfly"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Spider"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Butterfly"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Bumblebee"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Locust"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Earthworm"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Hornet"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Beetle"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Squirrel"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Rabbit"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Gopher"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Badger"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Eagle"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Weasel"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Raven"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Mongoose"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Aardvark"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Lizard"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Tortoise"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Hedgehog"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Condor"
 msgstr ""
 
-#: ../fheroes2/kingdom/world_loadmap.cpp:1424
-msgid "The ultimate artifact is really the %{name}"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1428
-msgid "The ultimate artifact may be found in the %{name} regions of the world."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1433
-msgid "north-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1436
-msgid "north"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1438
-msgid "north-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1444
-msgid "west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1447
-msgid "center"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1449
-msgid "east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1454
-msgid "south-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1457
-msgid "south"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1459
-msgid "south-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1463
-msgid "The truth is out there."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1464
-msgid "The dark side is stronger."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1465
-msgid "The end of the world is near."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1466
-msgid "The bones of Lord Slayer are buried in the foundation of the arena."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1467
-msgid "A Black Dragon will take out a Titan any day of the week."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1468
-msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1470
-msgid ""
-"You can load the newest version of game from a site:\n"
-" http://sf.net/projects/fheroes2"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1471
-msgid "This game is now in beta development version. ;)"
-msgstr ""
-
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Desert"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Snow"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Wasteland"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Beach"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Lava"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:31 ../fheroes2/resource/maps_text.cpp:210
 msgid "Dirt"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Grass"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:31
-msgid "Water"
+msgid "Ocean"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Small"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Medium"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Large"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Extra Large"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Custom Size"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:122
 msgid "Ore Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:123
 msgid "Sulfur Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:124
 msgid "Crystal Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:125
 msgid "Gems Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:126
 msgid "Gold Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:130
 msgid "Mine"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:365
 msgid "Alchemist Lab"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:367
 msgid "Daemon Cave"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:369
 msgid "Faerie Ring"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:373 ../fheroes2/resource/maps_text.cpp:217
 msgid "Dragon City"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:375
-msgid "Light House"
+msgid "Lighthouse"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:377
 msgid "Water Wheel"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:379
 msgid "Mines"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:381
 msgid "Obelisk"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:383
 msgid "Oasis"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:385
 msgid "Sawmill"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:387
 msgid "Oracle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:389
 msgid "Desert Tent"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:393
 msgid "Wagon Camp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:395
 msgid "Windmill"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:397
 msgid "Random Town"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:399
 msgid "Random Castle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:401
 msgid "Watch Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:403
 msgid "Tree City"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:405
 msgid "Tree House"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:407
 msgid "Ruins"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:409
 msgid "Fort"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:411
-msgid "Trading Post"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:413
 msgid "Abandoned Mine"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:415
 msgid "Tree of Knowledge"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:417
 msgid "Witch Doctor's Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:419
 msgid "Temple"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:421
 msgid "Hill Fort"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:423
 msgid "Halfling Hole"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:425
 msgid "Mercenary Camp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:429
 msgid "City of the Dead"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:433
 msgid "Sphinx"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:435
 msgid "Troll Bridge"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:437
 msgid "Witch Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:439
 msgid "Xanadu"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:443
 msgid "Magellan Maps"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:445
 msgid "Derelict Ship"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:447
-msgid "Ship Wreck"
+msgid "Shipwreck"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:449
 msgid "Observation Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:451
-msgid "Freeman Foundry"
+msgid "Freeman's Foundry"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:453
 msgid "Watering Hole"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:455
 msgid "Artesian Spring"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:457
 msgid "Gazebo"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:459
 msgid "Archer's House"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:461
 msgid "Peasant Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:463
 msgid "Dwarf Cottage"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:465
 msgid "Stone Liths"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:467
 msgid "Magic Well"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:468
 msgid "Heroes"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:470 ../fheroes2/maps/mp2.cpp:488
-msgid "Shrub"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:471
 msgid "Nothing Special"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:472
 msgid "Tar Pit"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:473
-msgid "Coast"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:474
 msgid "Mound"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:475
 msgid "Dune"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:476
 msgid "Stump"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:477
 msgid "Cactus"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:478
 msgid "Trees"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:479
 msgid "Dead Tree"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:480
 msgid "Mountains"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:481
 msgid "Volcano"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:482
 msgid "Rock"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:483
 msgid "Flowers"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:484
 msgid "Water Lake"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:485
 msgid "Mandrake"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:486
 msgid "Crater"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:487
 msgid "Lava Pool"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:489
+msgid "Shrub"
+msgstr ""
+
 msgid "Buoy"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:491 ../fheroes2/monster/monster.cpp:116
 msgid "Skeleton"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:492
 msgid "Treasure Chest"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:493
 msgid "Sea Chest"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:494
 msgid "Campfire"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:495
 msgid "Fountain"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:496
 msgid "Genie Lamp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:497
 msgid "Goblin Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:499
 msgid "Monster"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:500
 msgid "Resource"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:501
 msgid "Whirlpool"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:502
 msgid "Artifact"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:503
 msgid "Boat"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:510
 msgid "Standing Stones"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:514
 msgid "Idol"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:515
 msgid "Shrine of the First Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:516
 msgid "Shrine of the Second Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:517
 msgid "Shrine of the Third Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:518
 msgid "Wagon"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:519
 msgid "Lean To"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:520
 msgid "Flotsam"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:521
 msgid "Shipwreck Survivor"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:522
 msgid "Bottle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:523
 msgid "Magic Garden"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:529
 msgid "Jail"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:531
 msgid "Traveller's Tent"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:532
 msgid "Barrier"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:535
 msgid "Fire Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:537
 msgid "Air Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:539
 msgid "Earth Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:541
 msgid "Water Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:543
 msgid "Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:545
-msgid "Arena"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:547
 msgid "Stables"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:549
 msgid "Alchemist's Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:551
 msgid "Hut of the Magi"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:553
 msgid "Eye of the Magi"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:555
 msgid "Mermaid"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:557
 msgid "Sirens"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:558
 msgid "Reefs"
 msgstr ""
 
-#: ../fheroes2/monster/monster.cpp:59
-msgid "Peasant"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:59 ../fheroes2/resource/maps_text.cpp:501
-msgid "Peasants"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Archer"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Archers"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Ranger"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Rangers"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Pikeman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Pikemen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Veteran Pikeman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Veteran Pikemen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Swordsman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Swordsmen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Master Swordsman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Master Swordsmen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Cavalry"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Cavalries"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Champion"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Champions"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Paladin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Paladins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:69
-msgid "Crusader"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:69
-msgid "Crusaders"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Goblin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Goblins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orc"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orcs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chief"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chiefs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Wolf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Wolves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogre"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogres"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Ogre Lord"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Ogre Lords"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "Troll"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "Trolls"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "War Troll"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "War Trolls"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:80
-msgid "Cyclops"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:80
-msgid "Cyclopes"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Sprite"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Sprites"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Dwarf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Dwarves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Battle Dwarf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Battle Dwarves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druid"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druids"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druid"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druids"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorn"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorns"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:91
-msgid "Phoenix"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:91
-msgid "Phoenixes"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaur"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaurs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyle"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyles"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaur"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaurs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur King"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur Kings"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydra"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydras"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halfling"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halflings"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boar"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boars"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golem"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golems"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golem"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golems"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Roc"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Rocs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Mage"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Magi"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmage"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmagi"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:112
-msgid "Giant"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:112 ../fheroes2/resource/maps_text.cpp:293
-msgid "Giants"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titan"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titans"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:116
-msgid "Skeletons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummy"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummy"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampire"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampires"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lord"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lords"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Lich"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Liches"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Lich"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Liches"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogue"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogues"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomad"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomads"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghost"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghosts"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusa"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusas"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elementals"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:694
-msgid "buy"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:158
-msgid "Campaign Game"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "Error"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "This release is compiled without network support."
-msgstr ""
-
-#: ../fheroes2/resource/artifact.cpp:51
 msgid "Ultimate Book of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:51 ../fheroes2/resource/artifact.cpp:77
-#: ../fheroes2/resource/artifact.cpp:78 ../fheroes2/resource/artifact.cpp:79
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "The %{name} increases your knowledge by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:52
 msgid "Ultimate Sword of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:52 ../fheroes2/resource/artifact.cpp:68
-#: ../fheroes2/resource/artifact.cpp:71 ../fheroes2/resource/artifact.cpp:74
-#: ../fheroes2/resource/artifact.cpp:75 ../fheroes2/resource/artifact.cpp:149
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "The %{name} increases your attack skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:53
 msgid "Ultimate Cloak of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:53 ../fheroes2/resource/artifact.cpp:70
-#: ../fheroes2/resource/artifact.cpp:73 ../fheroes2/resource/artifact.cpp:76
 msgid "The %{name} increases your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:54
 msgid "Ultimate Wand of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:54 ../fheroes2/resource/artifact.cpp:59
-#: ../fheroes2/resource/artifact.cpp:60 ../fheroes2/resource/artifact.cpp:61
-#: ../fheroes2/resource/artifact.cpp:62 ../fheroes2/resource/artifact.cpp:148
 msgid "The %{name} increases your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:55
 msgid "Ultimate Shield"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:55 ../fheroes2/resource/artifact.cpp:128
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "The %{name} increases your attack and defense skills by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:56
 msgid "Ultimate Staff"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:56 ../fheroes2/resource/artifact.cpp:130
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "The %{name} increases your spell power and knowledge by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "Ultimate Crown"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "The %{name} increases each of your basic skills by %{count} points."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "Golden Goose"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "The %{name} brings in an income of %{count} gold per turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:59
 msgid "Arcane Necklace of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:60
 msgid "Caster's Bracelet of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:61
 msgid "Mage's Ring of Power"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:62
 msgid "Witch's Broach of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:63
 msgid "Medal of Valor"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:63 ../fheroes2/resource/artifact.cpp:64
-#: ../fheroes2/resource/artifact.cpp:65 ../fheroes2/resource/artifact.cpp:66
 msgid "The %{name} increases your morale."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:64
 msgid "Medal of Courage"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:65
 msgid "Medal of Honor"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:66
 msgid "Medal of Distinction"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "Fizbin of Misfortune"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "The %{name} greatly decreases your morale by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:68
 msgid "Thunder Mace of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "Armored Gauntlets of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "The %{name} increase your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:70
 msgid "Defender Helm of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:71
 msgid "Giant Flail of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "Ballista of Quickness"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "The %{name} lets your catapult fire twice per combat round."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:73
 msgid "Stealth Shield of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:74
 msgid "Dragon Sword of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:75
 msgid "Power Axe of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:76
 msgid "Divine Breastplate of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:77
 msgid "Minor Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:78
 msgid "Major Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:79
 msgid "Superior Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "Foremost Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:81
 msgid "Endless Sack of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:81 ../fheroes2/resource/artifact.cpp:82
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "The %{name} provides you with %{count} gold per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:82
 msgid "Endless Bag of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "Endless Purse of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:84
 msgid "Nomad Boots of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:84 ../fheroes2/resource/artifact.cpp:85
 msgid "The %{name} increase your movement on land."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:85
 msgid "Traveler's Boots of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:86
 msgid "Lucky Rabbit's Foot"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:86 ../fheroes2/resource/artifact.cpp:87
-#: ../fheroes2/resource/artifact.cpp:88 ../fheroes2/resource/artifact.cpp:89
 msgid "The %{name} increases your luck in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:87
 msgid "Golden Horseshoe"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:88
 msgid "Gambler's Lucky Coin"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:89
 msgid "Four-Leaf Clover"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "True Compass of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "The %{name} increases your movement on land and sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "Sailor's Astrolabe of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "The %{name} increases your movement on sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "Evil Eye"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "The %{name} reduces the casting cost of curse spells by half."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "Enchanted Hourglass"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "The %{name} extends the duration of all your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "Gold Watch"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "The %{name} doubles the effectiveness of your hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "Skullcap"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "The %{name} halves the casting cost of all mind influencing spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "Ice Cloak"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "The %{name} halves all damage your troops take from cold spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "Fire Cloak"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "The %{name} halves all damage your troops take from fire spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "Lightning Helm"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "The %{name} halves all damage your troops take from lightning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid "Evercold Icicle"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid ""
 "The %{name} causes your cold spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid "Everhot Lava Rock"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid ""
 "The %{name} causes your fire spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid "Lightning Rod"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid ""
 "The %{name} causes your lightning spells to do %{count} percent more damage "
 "to enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "Snake-Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "The %{name} halves the casting cost of all your bless spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid "Ankh"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid ""
 "The %{name} doubles the effectiveness of all your resurrect and animate "
 "spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "Book of Elements"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "The %{name} doubles the effectiveness of all your summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "Elemental Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "The %{name} halves the casting cost of all summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "Holy Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "The %{name} makes all your troops immune to curse spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "Pendant of Free Will"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "The %{name} makes all your troops immune to hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "Pendant of Life"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "The %{name} makes all your troops immune to death spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "Serenity Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "The %{name} makes all your troops immune to berserk spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "Seeing-eye Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "The %{name} makes all your troops immune to blindness spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "Kinetic Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "The %{name} makes all your troops immune to paralyze spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "Pendant of Death"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "The %{name} makes all your troops immune to holy spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "Wand of Negation"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "The %{name} protects your troops from the Dispel Magic spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid "Golden Bow"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid ""
 "The %{name} eliminates the %{count} percent penalty for your troops shooting "
-"past obstacles. (e.g. castle walls)"
+"past obstacles (e.g. castle walls)."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid "Telescope"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid ""
 "The %{name} increases the amount of terrain your hero reveals when "
 "adventuring by %{count} extra square."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid "Statesman's Quill"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid ""
 "The %{name} reduces the cost of surrender to %{count} percent of the total "
 "cost of troops you have in your army."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "Wizard's Hat"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "The %{name} increases the duration of your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "Power Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "The %{name} returns %{count} extra power points/turn to your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "Ammo Cart"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "The %{name} provides endless ammunition for all your troops that shoot."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "Tax Lien"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "The %{name} costs you %{count} gold pieces/turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "Hideous Mask"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "The %{name} prevents all 'wandering' armies from joining your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "Endless Pouch of Sulfur"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "The %{name} provides %{count} unit of sulfur per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "Endless Vial of Mercury"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "The %{name} provides %{count} unit of mercury per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "Endless Pouch of Gems"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "The %{name} provides %{count} unit of gems per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "Endless Cord of Wood"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "The %{name} provides %{count} unit of wood per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "Endless Cart of Ore"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "The %{name} provides %{count} unit of ore per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "Endless Pouch of Crystal"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "The %{name} provides %{count} unit of crystal/day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:128
 msgid "Spiked Helm"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "Spiked Shield"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:130
 msgid "White Pearl"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "Black Pearl"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "Magic Book"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "The %{name} enables you to cast spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "Spell Scroll"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid "Arm of the Martyr"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid ""
 "The %{name} increases your spell power by %{count} but adds the undead "
 "morale penalty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "Breastplate of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "The %{name} increases your defense by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid "Broach of Shielding"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid ""
 "The %{name} provides %{count} percent protection from Armageddon and "
 "Elemental Storm, but decreases spell power by 2."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid "Battle Garb of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid ""
 "The %{name} combines the powers of the three Anduran artifacts.  It provides "
 "maximum luck and morale for your troops and gives you the Town Portal spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid "Crystal Ball"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid ""
 "The %{name} lets you get more specific information about monsters, enemy "
 "heroes, and castles nearby the hero who holds it."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid "Heart of Fire"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid ""
 "The %{name} provides %{count} percent protection from fire, but doubles the "
 "damage taken from cold."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid "Heart of Ice"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid ""
 "The %{name} provides %{count} percent protection from cold, but doubles the "
 "damage taken from fire."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:148
 msgid "Helmet of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:149
 msgid "Holy Hammer"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "Legendary Scepter"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "The %{name} adds %{count} points to all attributes."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "Masthead"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "The %{name} boosts your luck and morale by %{count} each in sea combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "Sphere of Negation"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "The %{name} disables all spell casting, for both sides, in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "Staff of Wizardry"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "The %{name} boosts your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "Sword Breaker"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "The %{name} increases your defense by %{count} and attack by 1."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "Sword of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "Spade of Necromancy"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "The %{name} gives you increased necromancy skill."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:638
 msgid ""
 "You find an elaborate aontainer which housesan old vellum scroll. The runes "
 "on the container are very old, and the artistry with whitch it was put "
@@ -6679,7 +5307,6 @@ msgid ""
 "magical power."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:639
 msgid ""
 "One of the less intelligent members of your party picks up an arm off of the "
 "ground. Despite its missing a body, it is still moving. Your troops find the "
@@ -6688,7 +5315,6 @@ msgid ""
 "making."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:640
 msgid ""
 "You come upon a sign. It reads: \"Here lies the body of Anduran. Bow and "
 "swear fealty, and you shall be rewarded.\" You decide to do as it says. As "
@@ -6696,21 +5322,18 @@ msgid ""
 "that you are suddenly wearing a gleaming, ornate breastplate."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:641
 msgid ""
 "A kindly Sorceress thinks that your army's defenses could use a magical "
 "boost. She offers to enchant the Broach that you wear on your cloak, and you "
 "accept."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:642
 msgid ""
 "Out of pity for a poor peasant, you purchase a chest of old junk they are "
 "hawking for too much gold. Later, as you search through it, you find it "
 "contains the 3 pieces of the legendary battle garb of Anduran!"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:643
 msgid ""
 "You come upon a caravan of gypsies who are feasting and fortifying their "
 "bodies with mead. They call you forward and say \"If you prove that you can "
@@ -6719,7 +5342,6 @@ msgid ""
 "Crystal Ball."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:644
 msgid ""
 "You enter a recently burned glade and come upon a Fire Elemental sitting "
 "atop a rock. It looks up, its flaming face contorted in a look of severe "
@@ -6727,7 +5349,6 @@ msgid ""
 "it, but it passes right through them and sears itself into your chest."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:645
 msgid ""
 "Suddenly, a biting coldness engulfs your body. You seize up, falling from "
 "your horse. The pain subsides, but you still feel as if your chest is "
@@ -6736,7 +5357,6 @@ msgid ""
 "woods and disappear."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:646
 msgid ""
 "You spy a gleaming object poking up out of the ground. You send a member of "
 "your party over to investigate. He comes back with a golden helmet in his "
@@ -6744,7 +5364,6 @@ msgid ""
 "only man who was known to wear solid gold armor."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:647
 msgid ""
 "You come upon a battle where a Paladin has been mortally wounded by a group "
 "of Zombies. He asks you to take his hammer and finish what he started.  As "
@@ -6752,7 +5371,6 @@ msgid ""
 "Zombies lie dead, the hammer dripping with blood. You strap it to your belt."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:648
 msgid ""
 "Upon cresting a small hill, you come upon a ridiculous looking sight. A "
 "Sprite is attempting to carry a Scepter that is almost as big as it is. "
@@ -6761,7 +5379,6 @@ msgid ""
 "flying anyway.\""
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:649
 msgid ""
 "An old seaman tells you a tale of an enchanted masthead that he used in his "
 "youth to rally his crew during times of trouble. He then hands you a faded "
@@ -6769,14 +5386,12 @@ msgid ""
 "underneath a nearby dock."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:650
 msgid ""
 "You stop to help a Peasant catch a runaway mare. To show his gratitude, he "
 "hands you a tiny sphere. As soon as you grasp it, you feel the magical "
 "energy drain from your limbs..."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:651
 msgid ""
 "While out scaring up game, your troops find a mysterious staff levitating "
 "about three feet off of the ground. They hand it to you, and you notice an "
@@ -6784,13 +5399,11 @@ msgid ""
 "words, and you'll win every fight.\""
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:652
 msgid ""
 "A former Captain of the Guard admires your quest and gives you the enchanted "
 "Sword Breaker that he relied on during his tour of duty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:653
 msgid ""
 "A Troll stops you and says: \"Pay me 5,000 gold, or the Sword of Anduran "
 "will slay you where you stand.\" You refuse. The troll grabs the sword "
@@ -6799,4464 +5412,80 @@ msgid ""
 "sharp objects."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:654
 msgid ""
 "A dirty shovel has been thrust into a dirt mound nearby. Upon investigation, "
 "you discover it to be the enchanted shovel of the Gravediggers, long thought "
 "lost by mortals."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:896
 msgid ""
-"Do you want to use your knowledge of magical secrets to transcribe the %"
-"{spell} Scroll into your spell book?\n"
-"The Scroll will be consumed.\n"
-" Spell point: %{sp}"
+"Do you want to use your knowledge of magical secrets to transcribe the "
+"%{spell} Scroll into your Magic Book?\n"
+"The Spell Scroll will be consumed.\n"
+" Cost in spell points: %{sp}"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:960
-msgid "Open book"
+msgid "Transcribe Spell Scroll"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:965
-msgid "Transcribe scroll"
+msgid "View Spells"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:975
-#: ../fheroes2/resource/artifact.cpp:1008
+msgid "View %{name} Info"
+msgstr ""
+
 msgid "Move %{name}"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:998
 msgid "Cannot move artifact"
 msgstr ""
 
-#: ../fheroes2/resource/maps_text.cpp:15
-msgid ""
-"425 bottles of beer on the wall, 425 bottles of beer! If one of those "
-"bottles should happen to fall, there'll be..."
+msgid "This item can't be traded."
 msgstr ""
 
-#: ../fheroes2/resource/maps_text.cpp:16
-msgid "A balanced scenario with lots of resources and land to explore."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:17
-msgid ""
-"A bandit army of gorgons jump you without warning.  they stone your entire "
-"army demand 500 gold before they will release your comrads.  Realizing that "
-"it is much cheeper to pay then rebuild your army you part with the gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:18
-msgid "Abandon All Hope!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:19
-msgid "Abandon All Hope Ye That Enter Here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:20
-msgid "A bit of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:21
-msgid "A bit of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:22
-msgid "A bit of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:23
-msgid ""
-"Above you looms the ancient Ice Palace.  Dimly remembered myth speaks of a "
-"Prince who rejected the advances of the Winter Goddess, and thus he and his "
-"domain were cursed to remain shrouded in ice, hidden in a forgotten corner "
-"of the world.  It is said that he can only be rescued by a hero who is both "
-"clever and bold.  Are you that one?  Do you dare enter this frozen domain?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:24
-msgid "A cache of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:25
-msgid "A cache of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:26
-msgid "A cache of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:27
-msgid "A cache of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:28
-msgid "A cache of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:29
-msgid ""
-"A chance to end a bitter war has finally arrived as a new resource-laden "
-"land has been discovered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:30
-msgid "A chunk of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:31
-msgid "A chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:32
-msgid "A couple of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:33
-msgid "\"Act of Desperation\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:34
-msgid ""
-"A desert isle rich in resources rewards the quick.  Just be sure to watch "
-"your back!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:35
-msgid "A dolphin playfully jumps into the air."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:36
-msgid ""
-"A Dragon, A Cyclops, or an Undead. King of the Centaurs, His name is ....?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:37
-msgid "A flight of dragons circles overhead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:38
-msgid "A flock of seagulls circle overhead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:39
-msgid "A friendly dolphin splashes alongside the ship."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:40
-msgid ""
-"After a long search of the island, I have discovered that there is no way "
-"for me to escape without help.  I can not steal a ship from one of the "
-"coastal castles, and I dare not venture into the desert unless I wish to "
-"become Dragon food.  Should anyone find this, I beg of you, please send a "
-"ship and get me off this cursed island!  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:41
-msgid ""
-"After centuries of friendship, the Wizards have suddenly decided to stop "
-"sharing their Library with the rest of the world.  This can't be good!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:42
-msgid ""
-"After many years of peace, you discover that your sworn enemy from across "
-"the sea has chosen to invade your homeland by raising up the ocean floor to "
-"bridge the distance! You must not let them gain a foothold on this "
-"continent, in fact, your King has ordered you to establish a foothold on "
-"theirs!  To make matters worse, two of your OWN towns have thrown in their "
-"lots with the enemy..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:43
-msgid ""
-"After you return from a scouting trip, your Seneschal hurries to greet you.  "
-"\"My Lord, in your absence I signed an agreement in your name with a Master "
-"Merchant.  If we supply him with the resources he needs, through trading, he "
-"can return the resources to us in a week or so, plus some additional ones."
-"\"  The Seneschal eyes you anxiously.  You hesitate, then nod slowly, "
-"\"Good, we can use more resources>\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:44
-msgid "A ghostly pirate ship appears and sails on by."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:45
-msgid ""
-"A Gift from your King, and a note that reads \"Use these resources wisely, "
-"It's all we have left\"."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:46
-msgid ""
-"A gift of gold, m'lord, from the people of Enroth, to the people of Enroth.  "
-"Good luck, and may God save true King Roland!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:47
-msgid "A glint by a tree catches your eye..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:48
-msgid "A gold cache!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:49
-msgid "A gold chunk!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:50
-msgid "A gold nugget!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:51
-msgid ""
-"A great Black dragon stands before you. It speaks in a suprisingly soft "
-"voice, saying, \"The elves believe they have sent another hero to reclaim "
-"their prize. I believe they have sent me another meal.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:52
-msgid ""
-"A group of peasant farmers approaches you, \"We are in dire need of your "
-"assistance.  Our castle to the north has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:53
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance.  Our castle to the east has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:54
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance. Our castle to the east has been overrun and our Lord killed. "
-"Please help us regain our homes! There are still women and children there! "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:55
-msgid ""
-"A group of peasant farmers approach you, We are in dire need of your "
-"assistance.  Our castle to the northeast has been overrun and our Lord "
-"killed.  Please help us regain our homes!  There are still women and "
-"children there!  Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:56
-msgid "A handful of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:57
-msgid ""
-"Ah, you stumble across something buried in the sand.  As you dig it up you "
-"discover a small pile of gems and crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:58
-msgid ""
-"A Knight and Necromancer team up against the Barbarian and Sorceress. (Blue "
-"and Green vs Red and Yellow)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:60
-msgid ""
-"A large contingent of the king's guard approaches you.  \"Ahh, we have "
-"finally caught up to you.  The king requires tribute from all of his vassals "
-"and you have been negligent far too long.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:61
-msgid ""
-"A large map with lots of resources and treasure. Exploration and victory "
-"will require many heroes."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:62
-msgid "A legion of peasants stands between you and this unclaimed island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:63
-msgid "Algary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:64
-msgid "A little bit closer..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:65
-msgid "All mines are grouped by type. Trade is your only hope."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:66
-msgid "A lump of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:67
-msgid "A lump of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:68
-msgid "A lump of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:69
-msgid ""
-"A man appears from behind the sand dune. \"At last,\" he says, \"Someone has "
-"come to rescue me! I am forever grateful. Alas all I have to offer you in "
-"return are these souvenirs from my wrecked ship.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:70
-msgid ""
-"A man is laying on the ground, near death. He looks to you and speaks, "
-"\"Please help my companions! Please... they can't...cough...get away from..."
-"cough...the drag...\" With that, he dies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:71
-msgid ""
-"A merchant caravan arrives, bringing gold and supplies, however, no one can "
-"seem to remember where they came from.  You silently praise this anonymous "
-"benefactor and continue your duties."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:72
-msgid "a mirror"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:73
-msgid "An albatross flies ahead of the ship for a while"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:74
-msgid "Anduran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:75
-msgid ""
-"An enemy from across the sea has seized half your towns.  Can you put aside "
-"your own feud with your brother to fight this common enemy?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:76
-msgid "\"Annexation\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:77
-msgid ""
-"An old elf is sitting on a rock in a glen, pounding on the shackles on his "
-"feet with a stone. You help him remove them and ask him his tale. \"I'm a "
-"deserter from Drakonia's army. She has enslaved all the elves to support her "
-"madness. She must be stopped.\" Then he slips into the woods without a "
-"sound, leaving behind just his cloak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:78
-msgid "Antioch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:79
-msgid "A piece of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:80
-msgid "A pile of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:81
-msgid "A pile of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:82
-msgid "A pile of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:83
-msgid ""
-"A plague of undead is upon us. Who will unite the living against the dead?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:84
-msgid "\"Apocalypse\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:85
-msgid "A quantity of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:86
-msgid "A quantity of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:87
-msgid "A quantity of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:89
-msgid ""
-"Archibald has also sent an army to find the Crown, you must find it first or "
-"all is lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:90
-msgid "Archibald is hiding at the end of the river."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:91
-msgid ""
-"A resource rich valley keeps the Wizard and the Necromancer apart. Your "
-"opponent's army will arrive in 3 months so hurry."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:92
-msgid "Arm of the Crusader"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:93
-msgid "Arm of the Cyclops"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:94
-msgid "Arm of the Dragon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:95
-msgid "Arm of the Phoenix"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:96
-msgid "Arm of the Titan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:97
-msgid "Arr' Here be pirates gold buried."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:98
-msgid "A shipment of wood has arrived from your kingdom!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:99
-msgid ""
-"A splash in the seaweed alerts you to a mermaid waving in a friendly manner. "
-"\"Oh, I thought you were Ahab.\" She is surprised, but quickly composes "
-"herself. \"Well, if you meet him, give him these treasures I have collected."
-"\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:100
-msgid "Assassins tried to kill our ally."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:101
-msgid "Astircaer"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:102
-msgid ""
-"A stranded Wizard with only a small force must conquer an entire continent "
-"of hostile forces."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:103
-msgid ""
-"A supply ship has arrived from the homeland!  You send word home that all is "
-"well."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:104
-msgid ""
-"As you approach the barrier, you see the old elf you helped free. This time, "
-"however, you see that he is wearing a cape of fine weave, and a wooden crown "
-"is on his head. He sees your forces, and says \"Take this sword, and with "
-"it, strike down Drakonia and help free my people.\" The old elf then strides "
-"regally into the woods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:105
-msgid ""
-"As you approach the gates of the Ice Palace, one of your troops points in "
-"terror.  You watch in awe as great slabs of ice separate from the castle "
-"walls with loud cracking reports and crash to the ground.  Soon the ice is "
-"gone and the sun begins to peak through the gloom.  The deathly silence that "
-"must have ruled these lands for centuries ends as birds begin to sing.  From "
-"inside you hear the sounds of life."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:106
-msgid ""
-"As you approach the tent, the leader of the nomads comes out to greet you. "
-"He says, \"It was prophecied many years ago that a great hero would come to "
-"greet us in our sacred valley, and we would prosper afterwords. Now it has "
-"come to pass, and we offer you these gifts as tokens of our thanks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:107
-msgid ""
-"As you approach,  you hear whispered mentions of \"the wild barbarian who "
-"passed this way months before\". One of the villagers approaches you and "
-"hands you an object, saying \"The wild one dropped this. You must be his "
-"kin. Therefore I give it to you. But beware! Many in the village will not be "
-"as friendly as I.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:108
-msgid ""
-"As you break your fast your sage rushes in, \"Good news, my lord!  I have "
-"translated the message.  Two great heroes were imprisoned many years ago.  "
-"They lie sleeping - still guarded by magic barriers and monsters.  My lord, "
-"they lie nearby- in between our ally and us.  If we could free them, they "
-"would surely aid us against our enemies!  The password to the first magic "
-"barrier can be learned at the Aqua Traveller's Tent.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:109
-msgid ""
-"As you enter the small clearing, you see a familiar figure talking to a "
-"group of halflings and soldiers. You stay awhile and listen to his speech. "
-"\"The time to throw off these chains of tyranny is now! We must strike at "
-"the heart of her empire, and destroy the evil that she has brought to our "
-"land.\" As the old elf finishes speaking, he gets up from his mossy seat and "
-"once again, blends into the woods with incredible grace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:110
-msgid ""
-"As you lay down to nap after a long battle, you notice a lucky four-leaf "
-"clover."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:111
-msgid ""
-"As you make  your way through the last of the golemn debris, a group of "
-"halflings runs towards you carrying fruit and flowers. \"Thank you so much!"
-"\" Their leader exclaims, \"We've been trapped in here for ever! Come by our "
-"homes, we'll pack up and go with you!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:112
-msgid ""
-"As you make your way to the shrine, some very thin and hollow-eyed men come "
-"out of the flower patch and stare at you.  Seeing that you want the gold, "
-"one of them says to you \"Hey, man, if you're, like, so lusty for earthly "
-"wealth, then, like, have this too.\" You graciously take what they have "
-"offered and back out of the clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:113
-msgid ""
-"As you prepare your lands to fight the onslaught from the South, a curious "
-"message appears on your table in the Great Hall of your Castle.  Written in "
-"some ancient language, none but your sage can make any sense of it.  She "
-"promises to have the words deciphered by tomorrow..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:114
-msgid "A three hour tour, a three hour tour..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:115
-msgid ""
-"A tiny gnome points to a chunk of crystal you otherwise would have "
-"overlooked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:116
-msgid "Atlantium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:117
-msgid ""
-"At last, the king is dead.  For years you have planned his demise, but now "
-"it is done, and there is no heir to take his place, though the Knights to "
-"the south believe that they are the rightful successors.  A wealth in wood "
-"(to the south) and ore (in the northern mountains) provides you with trade "
-"goods, and your isolation has allowed you to prepare your forces of darkness "
-"for this day.  Go, now, and fulfill your destiny!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:118
-msgid ""
-"At the base of the mountain you see something that glitters.   You discover "
-"an ancient pile of offerings to the gods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:119
-msgid "Avalon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:120
-msgid "Avone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:121
-msgid ""
-"A wild magic has allowed a bridge to form between two lands...  Your one "
-"hope is to capture castle \"Black Fang\"."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:122
-msgid "Barbarian's castle lies to the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:123
-msgid ""
-"Barbarians from the north threaten all civilization. Can you repel the "
-"hordes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:124
-msgid "\"Barbarian Wars\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:125
-msgid "Barrowton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:126
-msgid "Basenji"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:127
-msgid "Bayside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:128
-msgid "Baywatch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:129
-msgid ""
-"Because the Darkscale Valley is so barren, the Emperor will be sending wood "
-"to you every week. Use it wisely, for it is all you shall have."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:130
-msgid ""
-"Before questing for the orb of negation, you must first crush the local "
-"opposition. After the Sorceresses are removed from the earth, go east where "
-"legend says the orb lies.  You may expect a convoy of supplies in a week or "
-"so to aid your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:131
-msgid ""
-"Before you may pass, the spirit guardian of this valley demands tribute."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:132
-msgid "Being held...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:133
-msgid "Beltway"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:134
-msgid "\"Betrayal!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:135
-msgid "Beware -- Entering Hyrda Country"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:136
-msgid "Beware for whom the bell trolls."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:137
-msgid "Beware of Pirates!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:138
-msgid "Beware of thieves!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:139
-msgid "Beware of traps ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:140
-msgid "Beware of Warlocks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:141
-msgid "Beware the deadly swamps!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:142
-msgid "Beware the Domain of Dragons"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:143
-msgid "Beware the Dragon Leader"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:144
-msgid "Beware the edge of the world!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:145
-msgid "Beware the moors and stick to the roads."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:146
-msgid "Beware the rocks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:147
-msgid "Beware the sirens!!!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:148
-msgid "Beware the sirens!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:149
-msgid "Beware the whiporwill..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:150
-msgid "Beware, the whirlpool may not take you into a friendly embrace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:151
-msgid "Beyond here be Dragons!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:152
-msgid "Beyond the door, there be Dragons. BEWARE!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:153
-msgid "Big Oak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:154
-msgid "Blackburn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:155
-msgid "Blackfang"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:156
-msgid "Black Fang"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:157
-msgid "Black Oak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:158
-msgid "Blackridge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:159
-msgid "Blacksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:160
-msgid "Black Vein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:161
-msgid "Blackwind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:162
-msgid "Bloodreign"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:163
-msgid "Boats my be needed to access some parts of this peninsula."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:164
-msgid "Boats Sold Here            Inquire Within"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:165
-msgid "BoneVille"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:166
-msgid "Borderlands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:167
-msgid "Bridge out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:168
-msgid "Bridge Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:169
-msgid "Brindamoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:170
-msgid "Broken Alliance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:171
-msgid "Brownston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:172
-msgid "Buried Treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:173
-msgid "Burlock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:174
-msgid "Burton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:175
-msgid ""
-"Capture the necromancer's dreaded castle \"Death Gate\" and free the land "
-"from the undead plague."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:176
-msgid ""
-"Capture the town on the island off the southeast shore in order to construct "
-"a boat and travel back towards the mainland."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:177
-msgid "\"Carator Mines\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:178
-msgid "Cathcart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:180
-msgid "Chandler"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:181
-msgid "Chilton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:182
-msgid "Chronos"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:183
-msgid "Come and...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:184
-msgid ""
-"Compared to the rest of the villages in this land, this village seems grand, "
-"but in any other land it would seem poor. From here you can see the tall "
-"spires of the Warlock's tower of Dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:185
-msgid "Complete"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:186
-msgid "Condemned!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:187
-msgid ""
-"Congratulations! After navigating the treacherous coast, you have "
-"established trade between the north and south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:188
-msgid "Corackston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:189
-msgid "Corlagon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:190
-msgid "\"Country Lords\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:191
-msgid "Crossroads"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:192
-msgid "Crossroads North"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:193
-msgid "Crossroads South"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:195
-msgid "Danger a whirlpool destroyed my ship."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:196
-msgid "Danger, Dragons abound!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:197
-msgid "DANGER!  QUICKSAND!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:198
-msgid "Danger! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:199
-msgid "Danger - Turn Back Now"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:200
-msgid "Dark clouds loom overhead as you enter this valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:201
-msgid "Dead Pine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:202
-msgid ""
-"Dear Diary,                           I found a mermaid today.  She was "
-"floating in a patch of seaweed next to a rock.  A very friendly sort of "
-"creature too!  Gave me all sorts of lovely gems and jewelry!  She said to "
-"come back again sometime for more of the sea riches.  Wow. Ahab"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:203
-msgid "Deathgate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:204
-msgid "DeathGate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:205
-msgid "Decisions"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:206
-msgid "\"Defender\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:207
-msgid ""
-"Destroy the Barbarians who are attacking the southern border of your "
-"kingdom! Recover your towns and then invade the jungle kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:208
-msgid ""
-"Detour! Mountain pass to the East has been known to have avalanches! For "
-"your own safety, follow the road South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:209
-msgid "Detour! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:211
-msgid "DirtWater"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:212
-msgid "Dominion"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:213
-msgid "Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:214
-msgid "Do not remove coins from fountain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:215
-msgid "Dragadune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:216
-msgid "Dragonburg"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:218
-msgid "Dragon City lies beyond the Scorpion Hills."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:219
-msgid "Dragon Hill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:220
-msgid "\"Dragon Master\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:221
-msgid "Dragon Rider"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:222
-msgid "Dragons Everywhere!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:223
-msgid "Dragon's Eye"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:224
-msgid "Dragontooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:225
-msgid "Dragon Town"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:226
-msgid "Dragonville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:227
-msgid "Dragon Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:228
-msgid "Dragon Watch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:230
-msgid "Drakoran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:231
-msgid "Dwarfhall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:232
-msgid "Dwarfhall, Domain of the dwarf King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:233
-msgid "Dwarf Hall, domain of the dwarf King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:234
-msgid "Eatio"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:235
-msgid "Edgewood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:236
-msgid "Elk's Head"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:237
-msgid "Elowyn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:238
-msgid "Enroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:239
-msgid "Entering high in the desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:240
-msgid "Entering Praires of the Middlelands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:241
-msgid "Entering the desert high"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:242
-msgid "Entering the high desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:243
-msgid "Entering the higher desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:244
-msgid "Entering the Valley of Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:245
-msgid "Erliquin"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:246
-msgid "Evil Igor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:247
-msgid "Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:248
-msgid "Fantasy Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:249
-msgid "Farlien"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:250
-msgid ""
-"Federal express, when it absolutely positively has to be there turn one."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:251
-msgid "fedx comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:252
-msgid "Fedx for comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:253
-msgid "Fenton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:254
-msgid "Fetid Elm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:255
-msgid ""
-"Final message from Overlord. \"The royal executioners are on their way. My "
-"gold, the land or your head- it's your choice.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:256
-msgid "Find and defeat the Pirate Leader!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:257
-msgid "Find and destroy the evil beings who rule the wastelands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:258
-msgid "Find the center island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:259
-msgid ""
-"Find the Ultimate Artifact and be proclaimed King, or smash the opposition "
-"and take control."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:260
-msgid ""
-"Find Your Wayward Son who is rumored to be living in the desolate lands. Do "
-"it within 8 weeks or it will be of no help to your family."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:261
-msgid "Fire King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:262
-msgid "\"First Blood\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:263
-msgid "Five heroes vie for control of a familiar land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:264
-msgid "Fool's Gold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:265
-msgid ""
-"For a total of 400,000 gold your opponents will become \"loyal\" subjects, "
-"otherwise... let them eat cake!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:266
-msgid ""
-"For centuries, the Wizards of the North have maintained a vast library for "
-"all the world to share.  Now, however, they have closed their doors, and "
-"issued declarations of war to each of the other rulers of the land.  To make "
-"matters worse, rather than ally with you to face the Wizards, each of the "
-"others have decided to go forth on their own in an effort to conquer this "
-"land for themselves!  Prepare your forces, commander, for you now stand "
-"alone."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:267
-msgid "\"Force of Arms\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:268
-msgid ""
-"For decades you have studied, learned, and allowed yourself to be ruled by "
-"that pitiful excuse for a king, knowing that one day the time would come for "
-"you to sit on the throne.  That time is now, for the king is dead and "
-"without an heir.  You have the advantage of isolation from the rest of the "
-"kingdom, but beware the miles of coastline that could leave you vulnerable "
-"to attack.  Go, now, and wipe your enemies from this land!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:269
-msgid "Forder Oaks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:270
-msgid "Forestria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:271
-msgid "For Honor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:272
-msgid ""
-"For information about Ye Rich lands to the south, speak to Alponse at the "
-"Golden Goose Tavern. Excellent views, plentiful water."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:273
-msgid "Forsaken Lands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:274
-msgid "For sale."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:275
-msgid "Fortress Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:276
-msgid ""
-"For years, you have existed peacefully in the Forest of Dreams, knowing that "
-"your king was the kindest and strongest ruler the land had seen in "
-"centuries.  Now, however, his reign is at an end, and there is no heir to "
-"succeed him.  You realize that a power struggle is coming, and that you must "
-"brace yourself for war, and prevent those who would harm this land from "
-"coming into power!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:277
-msgid ""
-"For years, you've been able to keep your subjects \"appeased.\"  Now "
-"however, you discover not only that your entire kingdom has turned against "
-"you, but most of your outer towns have fallen to the different factions.  To "
-"make matters worse, all your gold suddenly seems to be missing from the "
-"treasury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:278
-msgid "Fountainhead"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:279
-msgid "Four kingdoms race to capture the island of Sharkania."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:280
-msgid "Four lakes have castles, three have treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:281
-msgid "Four players must work together to assault the Wizards' Stronghold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:282
-msgid "Frozenpeak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:283
-msgid "Full House"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:284
-msgid ""
-"Gain the aid of the elves. They will not allow trees to be chopped down, so "
-"we will send you wood every 2 weeks. You have 7 months!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:286
-msgid "Galveston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:287
-msgid "Garamok"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:288
-msgid "Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:289
-msgid "Gate to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:290
-msgid "Gate to The Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:291
-msgid "Gaurdian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:292
-msgid "Gavonshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:294
-msgid "Glastonbury"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:295
-msgid "Go away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:296
-msgid "GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:297
-msgid "Goblin Island"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:298
-msgid "Goblin King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:299
-msgid "Go Home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:300
-msgid "Go north to find the lost gold-mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:301
-msgid "Good vs. Evil"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:302
-msgid "Gorgomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:303
-msgid "\"Greater Glory\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:304
-msgid "Greed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:305
-msgid "Green bonus stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:306
-msgid "Green gets stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:307
-msgid "Greenroot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:308
-msgid "Green's Allowance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:309
-msgid "Green's Groceries"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:310
-msgid "green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:311
-msgid "Green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:312
-msgid "Greywind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:313
-msgid "Grim"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:314
-msgid "Grrr, Blazzer, Grrupt. Be gone with you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:315
-msgid "Guardian War"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:316
-msgid "Gungtooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:317
-msgid "Hail Unicorns!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:318
-msgid "Hampshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:319
-msgid "Have fun storming the castle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:320
-msgid "Havenwood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:321
-msgid "Hawkins"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:322
-msgid "Help!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:323
-msgid "Help me...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:324
-msgid ""
-"Help peasant farmers regain their castle and land, else they'll take your "
-"crops."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:325
-msgid "Hero's Hall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:326
-msgid ""
-"High in the snowy crags, you meet an old witch who, in return for a trinket "
-"of yours, gives you a powerful magical object she used to use as a footstool "
-"before she was exiled into the mountains by her own townspeople."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:327
-msgid "Hillstone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:328
-msgid "Hilltop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:329
-msgid "Hilltown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:330
-msgid "Horizon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:331
-msgid "Hot Spot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:332
-msgid "Hungry dragons await.  Welcome, food."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:333
-msgid "Hurry, no time to wait.  This way to the dock."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:334
-msgid "Hurry up! Few days are left before the enemy's army arrives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:335
-msgid "I am...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:336
-msgid ""
-"I am one of the few remaining survivors of the wrecked pleasure ship, "
-"Exhorbitance. I think we'll all be dead of hunger soon, for we are out of "
-"caviar. We ate the chef yesterday."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:337
-msgid "Ibn Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:338
-msgid "Ice Palace"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:339
-msgid "Ice Prince"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:340
-msgid "Icy lands ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:341
-msgid "I didn't do it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:342
-msgid ""
-"If three heroes could dig six holes in three days, how long would it take "
-"six heroes to dig twelve holes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:343
-msgid "If you free a hero, they may help..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:344
-msgid ""
-"If you value your lives, for God's sake, Don't go through this whirlpool!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:345
-msgid "Income for Yellow."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:346
-msgid "In the hole you find a chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:347
-msgid "In the stream you find an old compass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:348
-msgid "In this glen live some very naughty halflings. Stay Away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:349
-msgid ""
-"In two more weeks, if you have not located Joseph, your kingdom will surely "
-"lose its current battle with Harondale."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:350
-msgid "I see you, you see me."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:351
-msgid "Is it something I said? Go back and I will forget the whole thing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:352
-msgid "IslandHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:353
-msgid "Island of the Elves"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:354
-msgid "Island of the meek"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:355
-msgid "Island of Wolcott"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:356
-msgid "Isle Maze"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:357
-msgid "Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:358
-msgid ""
-"It has become apparent that if all your enemies were eliminated, you would "
-"have all the time you need to find the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:359
-msgid ""
-"It is obvious that the mage that once was here had won many battles!  There, "
-"upon his hand, is a most powerful ring!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:360
-msgid ""
-"It is rumored that a bridge of land used to exist between the two "
-"continents, but that a wild magic caused it to sink into the sea, taking "
-"with it all those who used to inhabit it.  To try to raise this bridge is to "
-"invite a curse upon the world!  The spirits of the dead will haunt us all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:361
-msgid ""
-"It is said that King Zealot found the gods' artifact once and it let him "
-"rule for 100 years."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:362
-msgid ""
-"It looks like there used to be an ore mine here but all you see now is a "
-"hole in the ground and some minerals scattered around."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:363
-msgid ""
-"It's a battle for supremacy as the Blue and Green heroes take on Red and "
-"Orange in team competition!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:364
-msgid "It's windy at the top.  Defend, Divide, and Conquer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:365
-msgid "IvanHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:366
-msgid "Ivan lives in the desert."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:367
-msgid "Ivory Gates"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:368
-msgid ""
-"I, Wilgatus, besiege you - do not fight me for I am all powerful and will "
-"destroy you if you persue me.  I will demonstrate my power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:369
-msgid "I Would Go That Way If I Were You."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:371
-msgid "Jarkonas VI"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:372
-msgid "Jolly Roger was here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:374
-msgid "Jungomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:375
-msgid "Just 30 days left!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:376
-msgid "Just ONE week left!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:378
-msgid "Kastor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:379
-msgid "Keep going south"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:380
-msgid "Keep Off The Grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:381
-msgid "Keep Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:382
-msgid "King John"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:383
-msgid "King of Death"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:384
-msgid "Knight's Trail."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:385
-msgid "Knight stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:386
-msgid "Lakeside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:387
-msgid "Land's Edge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:388
-msgid "Land teleporters will get you to your destination sooner."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:389
-msgid "Lankershire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:390
-msgid "Lavalor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:391
-msgid "Like, Stuff And Junk?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:392
-msgid ""
-"Living on the outskirts of the kingdom, you are considered an unwelcome "
-"outcast by the other leaders of the realm, though you always showed your "
-"support for the king.  Now, however, the king is dead, and many of those who "
-"spoke out againt him seek to seize his throne for themselves.  You have a "
-"vast desert at your back, rich with gems, and the advantage that many do not "
-"consider you a threat.  Go, now, and show them how wrong they are!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:393
-msgid "Lladner Dock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:394
-msgid ""
-"Log go up... Log go down... Log go up... Log go down...  OOoohhhhhhhh........"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:395
-msgid "Lombard"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:396
-msgid "Long live Roland the true King!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:397
-msgid "Long live Roland the true King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:398
-msgid "Look before you leap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:399
-msgid "Look out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:400
-msgid "Lord Alberon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:401
-msgid ""
-"Lord Alberon calls you into his war room. He says, \"I am glad you have "
-"chosen to remain loyal to me, but this war is a terrible one for my kingdom. "
-"Already, the sorceress' towns to the Northeast have become unsure about "
-"their loyalties, and will not pledge allegiance to either side. This is hard "
-"on our cities as most of the wood in the land comes from these towns. We "
-"will need to recover their sawmills and take their towns by force.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:402
-msgid "Lord Haart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:404
-msgid "Lord Kreager"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:405
-msgid ""
-"Lord, messages have begun pouring in from our spies in the other island "
-"courts.  They have learned of a new volcanic island with vast amounts of "
-"reasources.  Your Majesty, with these new reasources we could put an end to "
-"a century of war between the islands, and reunite them under your rightful "
-"rule."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:406
-msgid "Lost Continent"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:407
-msgid "Lost Gold- Mine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:408
-msgid "Lost Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:409
-msgid "Lost Relic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:410
-msgid "Maelstrom of Deceit"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:411
-msgid "Maelstrom of Misery"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:412
-msgid "Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:413
-msgid "Magic Three"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:414
-msgid ""
-"Many dust plumes rise from the floor of this small valley. You see various "
-"bands of nomads roaming about, and in the distant, the bright flames of "
-"their camp."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:415
-msgid ""
-"Many guardians stand between you and your enemies, but anybody can sneak "
-"through the back door!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:416
-msgid "Many that have gone through this door have never returned."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:417
-msgid ""
-"Many years ago, a couple of mages had a \"duel\" that forever changed the "
-"lake at the center of this continent.  Hearty adventurers might find "
-"interesting treasure there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:418
-msgid ""
-"Many years ago, a falling star crashed near here.  Only now the area is safe "
-"enough to explore.  Rumor has it a castle exist where the star fell."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:419
-msgid ""
-"Many years ago, your father, the King, died in a freak hunting accident.  "
-"Since then, you and your brother have jointly ruled his kingdom, but both of "
-"you have been seeking a way to seize the throne for yourself.  You got your "
-"wish.  Attackers from across the sea have captured more than half your towns "
-"and castles, effectively dividing the continent in two.  Now is the time to "
-"repel these invaders and do away with your brother once and for all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:420
-msgid "Marco"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:421
-msgid "Marsh Home"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:423
-msgid "Mayland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:424
-msgid "Meramec"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:425
-msgid "Message from Archibald. \" Do not dare to return without my Crown.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:426
-msgid ""
-"Message from Archibald. \" General, thank you for bringing me this lovely "
-"gift. I have decided to participate directly in the capture of my brother "
-"Roland. Since your military advice has taken us this far, I will follow your "
-"orders to the letter.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:427
-msgid "Message from Overlord. \"STILL WAITING FOR MY GOLD!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:428
-msgid "Message from Overlord. \"WHERE'S MY GOLD?\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:429
-msgid ""
-"Message from Roland. \"General, circumstances permit me to take a hand in "
-"the events of this final conflict. I have your spoils of war with me and I "
-"will follow your advice explicitly.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:430
-msgid ""
-"Message from Roland.  \"General, I have sent most of our troops and material "
-"ahead to the region of the final conflict with Archibald.  Unfortunately, "
-"Lord Corlagon has cut us off from the rest of our army.  I will be awaiting "
-"your victory in a castle across the west river.  I should be safe from "
-"attack.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:431
-msgid ""
-"Message from Roland. \" We cannot hope to defeat Archibald without the "
-"Crown, I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:432
-msgid "Middle Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:433
-msgid "Middleton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:434
-msgid "Middletown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:435
-msgid "Might vs. Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:436
-msgid "Mineral Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:437
-msgid "Mirkosov"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:438
-msgid "mirror"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:439
-msgid "Money For Red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:440
-msgid "MONEY, MONEY, MONEY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:441
-msgid "Morale becomes even lower as the endless cliffs move past."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:442
-msgid ""
-"More water than land, you'll still spend lots of time on foot as you search "
-"a literal horde of islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:443
-msgid "Mountain king"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:444
-msgid "Mountainview"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:445
-msgid "Mr Ed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:446
-msgid "Mr. Yellow's Income"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:447
-msgid "Murray's resort Isle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:448
-msgid ""
-"Mutiny!  The crew has dumped off my precious cargo into the sea!  Thank "
-"goodness it floats - when I've rid of them, I'll come back to pick it up!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:449
-msgid ""
-"My leige, our scouts report three other lords are attacking from the south. "
-"They work in conjuction with each other to eliminate us! We must keep this "
-"castle and remove the threat of the enemy. We wish you luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:450
-msgid ""
-"My leige, we have established a foothold (which we cannot afford to lose) "
-"and all of our Heroes have joined us. The king has made us the offer to "
-"purchase this land for 200,000 gold or we may take it by force. The local "
-"lords have been fighting and each wants to be the one that defeats us. Now "
-"all the local armies have arrived on the beach, creating a state of complete "
-"Pandemonium!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:451
-msgid "My Treasure Is Buried Beneath Three Palm Trees"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:452
-msgid "\"Necromancers!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:453
-msgid "New Dawn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:454
-msgid "New Enemies"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:455
-msgid "New Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:456
-msgid "Nightshadow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:457
-msgid "No Description"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:458
-msgid "No Fishing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:459
-msgid "No gems, crystal, or mercury for red."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:460
-msgid ""
-"None of the four leaders like being stuck in a land that has only one season."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:461
-msgid "NO, Not That Way. This Way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:462
-msgid "No one has ever made it out of the deadly swamps alive!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:463
-msgid "Noraston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:464
-msgid "North Road"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:465
-msgid "North vs. South"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:466
-msgid "No stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:467
-msgid "No sulfer fer Yella."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:468
-msgid "No swimming."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:469
-msgid "Notice- Those who put messages in bottles will be tortured."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:470
-msgid "No Trespassing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:471
-msgid "No tresspath...  No tree...  No thresh...  GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:472
-msgid "Now leaving Swamplands of the Eternial"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:473
-msgid "Obsidian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:474
-msgid "Of the necromancers...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:475
-msgid "Ogrehild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:476
-msgid "Olympus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:477
-msgid ""
-"One of the seers in your castle comes to you in the morning with urgent "
-"news. Your one time comrade, the wizard Joseph, and his armies have been "
-"imprisoned in a jail nearby. His power would surely aid you in your quest to "
-"reclaim the library, you think to yourself. Perhaps there is a way to rescue "
-"him..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:478
-msgid ""
-"One of your aides reports that the Castle of Farlien is located on the "
-"northeast spur of this island, and is a stronghold for the enemy. He urges "
-"you to take it out as soon as possible, and then move onto other islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:479
-msgid ""
-"One of your \"allies\" has joined Archibald.  You now face an opponent with "
-"three castles to your one.  Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:480
-msgid ""
-"One of your \"Allies\" has joined Roland. You are now facing three castles, "
-"all belonging to the enemy. Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:481
-msgid "One of your loyal goblins has brought you an armload of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:482
-msgid ""
-"One of your loyal subjects, a fairy tells you where to find a cache of "
-"mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:483
-msgid ""
-"One of your scouts reports a tiny cave nearby. Upon investigating, you "
-"discover a small cache of goods. In the dirt by them is etched 'Ivan'."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:484
-msgid ""
-"One of your troops stubs its paw on something buried here.  After a few "
-"hours of digging you unearth a cache of treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:485
-msgid "Only a month remains in which to find Joseph."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:486
-msgid "On quite days, Nubbie the sea monster can be seen!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:487
-msgid "Orange stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:488
-msgid "Orcville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:489
-msgid "Ostoroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:490
-msgid "Other than the dragons, the elves don't have any enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:491
-msgid "Our ally was greatly weakened when his resources were plundered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:492
-msgid "\"Our Finest Hour\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:493
-msgid "Our reinforcements were lost in a storm, we salvaged all we could!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:494
-msgid ""
-"Our spies have discovered that the barbarian hordes are now receiving "
-"support from kraeger! You must hurry and find the third piece before your "
-"forces here are crushed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:495
-msgid "Overlord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:496
-msgid "Pandemonium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:497
-msgid "Paper can gain you what wood and sail cannot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:498
-msgid "Password found by Crystals to the South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:499
-msgid "Peacekeeper"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:500
-msgid "\"Peasants!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:502
-msgid "Peasantsville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:503
-msgid "Perenor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:504
-msgid "Pet Cemetary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:505
-msgid "Pick one of four Knights in this large and inhospitable land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:506
-msgid "Pig's Eye"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:507
-msgid "Pinehurst"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:508
-msgid "Pirate Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:509
-msgid "Pirate's Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:510
-msgid "Pirate Utopia"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:511
-msgid "Pirites strike and take the gold from you holds."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:512
-msgid "Pixie"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:513
-msgid ""
-"Play the Knight or Barbarian in an alliance in this classic duel against the "
-"four spell casters. (Blue and Green vs Red)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:514
-msgid "Please...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:515
-msgid ""
-"Plenty of resources and lots of ground to cover. Watch out for Orange and "
-"Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:516
-msgid "Portals"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:517
-msgid "Portsmith"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:518
-msgid "POSION - DO NOT DRINK"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:519
-msgid "Powerful magic lies southwest of here in the Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:520
-msgid "Prisoner on...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:522
-msgid "Quick Silver"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:523
-msgid "Raste"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:524
-msgid "Realm of the Undead.  Fresh blood welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:525
-msgid "Red bonus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:526
-msgid "Red player sympathizes with the undead cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:527
-msgid "Red's Connection"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:528
-msgid "Redshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:529
-msgid "Red's Lunch Money"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:530
-msgid "Red's Rubles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:531
-msgid "Red stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:532
-msgid ""
-"Regrettably, you have no castle with which to begin your assault. "
-"Fortunately, however, Kraeger's forces are weak here in the south, and you "
-"have bribed a rebel necromancer to aid you in the beginning of your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:533
-msgid "Reinforcements have arrived, Gold from the homelands!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:534
-msgid ""
-"Remains of a long since dead wizard have attracted an ancient artifact.  "
-"This artifact has now attached itself to you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:535
-msgid ""
-"Remember, you're searching for the Ultimate Artifact... don't get distracted!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:536
-msgid ""
-"Rendall Koski was here. 1997.  Northampton, Massachusetts There is a "
-"powerful artifact in the southeastern corner of the world.  Go for it, "
-"explorer!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:537
-msgid ""
-"Reports from your spies tell of enemies on the march.  As you rush to the "
-"castle courtyard to prepare your armies, you are intercepted by your "
-"Chaplain.  \"My Lord, I have received word that we should send what Heroes "
-"we can to the Isle of Knowledge.   The Scholars there have agreed to teach "
-"them so they will be strong for the battles ahead of us.\"  You thank the "
-"Chaplain for the information and head thoughtfully into the courtyard."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:538
-msgid ""
-"Rescue your crazy Uncle Ivan. Find him within 4 months or it will be no help "
-"to your kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:539
-msgid "Restricted Area, Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:540
-msgid "Rest stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:541
-msgid "Retake the Castle of Ivory Gates."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:542
-msgid "Revolution"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:543
-msgid "Right thinking - he who takes the riskes deserves the rewards."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:544
-msgid "River Crossing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:545
-msgid "Road Ends"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:546
-msgid "Road to Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:547
-msgid "Road to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:548
-msgid "Robbers have looted your treasury and you have lost valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:549
-msgid "Robbers have looted your treasury, stealing valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:550
-msgid "Roc Haven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:551
-msgid "Rogar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:553
-msgid "Roscomon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:554
-msgid "Rotten Birch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:555
-msgid ""
-"Rumors abound and your faithful hero Sandro is now highly regarded by the "
-"masses. Should Sandro desert you, all will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:556
-msgid "Sandcaster"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:558
-msgid "Sands of Time"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:559
-msgid "Sansobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:560
-msgid "\"Save the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:561
-msgid "Scabsdale"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:562
-msgid "Scorched Earth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:563
-msgid ""
-"Scouts have reported a town to the North.  They have also heard some "
-"disturbing news.  Their seems to be a war raging in this area."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:564
-msgid ""
-"Scouts report the enemy's stronghold lies to the Southwest. Our swift "
-"arrival has caught them by surprise. If you move quickly their resistance "
-"will be minimal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:565
-msgid ""
-"Scouts report the notorious necromancer \"Wyrm\" has been sighted to the "
-"northeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:566
-msgid "Scummy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:567
-msgid ""
-"Searching in the dust of this abandoned campsite, you find a magic scroll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:568
-msgid "Seasons Change"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:569
-msgid "Secret Mountain Pass"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:570
-msgid ""
-"Seek out the Ultimate Artifact to be victorious in this strangely shaped "
-"land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:571
-msgid ""
-"Seek the great library, for only with the guidance of the musty tomes therin "
-"will you find the means to reveal and bind the fount to your will."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:572
-msgid "Seven Lakes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:573
-msgid "Sharkania"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:574
-msgid "Sheltemburg"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:575
-msgid "Sherman"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:576
-msgid "Shipwrecked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:577
-msgid ""
-"Should this message ever reach home, please know that this has become a "
-"hostile place since the King's death.  No less than six factions are at war "
-"with each other, each seeking to be the King's successor.  Beware especially "
-"of the Barbarians and the Necromancers who control the north, their regions "
-"are easily defended and they have a wealth of gold and gems.  Do not venture "
-"to this land without a sizeable force.  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:578
-msgid "Sirein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:579
-msgid ""
-"Six factions have established a foothold on a huge, unexplored continent.  "
-"Can you eliminate the other five?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:580
-msgid ""
-"Six heroes with large armies prepare to slug it out for total domination!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:581
-msgid "Skirmish"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:582
-msgid "\"Slay the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:583
-msgid "Slippery when wet."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:584
-msgid "Slugfest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:585
-msgid ""
-"Snagged on a thorny bush, you discover a scrap of cloth. The design on it "
-"looks like the coat of arms of Ivan's house!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:586
-msgid "Snowdrop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:587
-msgid "Somebody has stuffed a pile of gems in the ditch!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:588
-msgid "Some crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:589
-msgid "Some gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:590
-msgid ""
-"Someone has stolen 100 wood and 77 ore from you. Ah, that's nothing. Let's "
-"keep going."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:591
-msgid ""
-"Someone has stolen gold and resources from  the palace treasury!  You "
-"suspect your enemies, but you can't know for certain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:592
-msgid "Someone is playing a pan flute around here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:593
-msgid ""
-"Someone notices a piece of parchment lying behind a clump of grass. You pick "
-"it up. It looks to be a page from a journal, and it reads, \"...made it past "
-"the first guardians. Hopefully will reach the ancient desert city soon. Only "
-"hope my forces are strong enough to survive...\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:594
-msgid "Some ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:595
-msgid "Some sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:596
-msgid ""
-"Some unlucky adventurers have been captured and imprisoned in these lands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:597
-msgid "Sorceress Forest.  Show respect for nature!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:598
-msgid "Sorpigal"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:599
-msgid "South Mill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:600
-msgid "So you think you're smart?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:601
-msgid "Spector"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:602
-msgid "Spell Casters"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:603
-msgid ""
-"Spies report Roland has sent a hero to search for the Crown. If he finds it "
-"first, all is lost!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:604
-msgid "Spirit City"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:605
-msgid "Spy Tower - see what your competition is doing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:606
-msgid "Stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:607
-msgid ""
-"Start with five castles!  How could you lose!?  Oh yeah, everyone else "
-"starts with five, too."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:608
-msgid "Stick to the road!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:609
-msgid "Stromgild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:610
-msgid "Stromhild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:611
-msgid "Stronghold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:612
-msgid "Stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:613
-msgid "Stuff for Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:614
-msgid "Stuff For Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:615
-msgid "Subbaculcha"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:616
-msgid "Sundune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:617
-msgid "Surf and Turf"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:618
-msgid "Swimming near the kelp is a pod of dolphins."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:619
-msgid "Tacma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:620
-msgid "Tchudes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:621
-msgid "Teleporters"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:622
-msgid "Terra Firma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:623
-msgid "Terrain Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:624
-msgid ""
-"The alliance has crumbled and all are at war. Lots of resources but little "
-"time to prepare."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:625
-msgid ""
-"The ancient King Zealot had the artifact of the gods and then hid it in his "
-"old age so that it could not be used by others."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:626
-msgid "The Back Door"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:627
-msgid ""
-"The Barbarian's lands are being invaded. Are you strong enough to resist the "
-"invasion?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:628
-msgid ""
-"The castle of Drakonran in the east has been taken by the barbarians! Two "
-"other towns to the west have also been taken, but the barbarian armies were "
-"fairly decimated in the process."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:629
-msgid "The center island is rumored to harbor great spells."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:630
-msgid "The Citadel"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:631
-msgid "The cities of the plains."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:632
-msgid "The Clearing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:633
-msgid ""
-"The convoy has at long last arrived. Regretably, it has been beset by "
-"bandits on its journey here, and has far less supplies than we had hoped. "
-"Make your way south, for our spies have found rich mines there."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:634
-msgid ""
-"The convoy should have been here by now! Let us hope that it is safe and "
-"still on its way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:635
-msgid ""
-"The country lords have allied and pooled their resources into one command. "
-"Not only have they massed their forces in the north, but they have sent a "
-"knight to the west to steal your supplies. Scouts report a castle to the "
-"east that would be ideal as a base of operations."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:636
-msgid "The crew are unworthy!  I am not going down with the ship! -The Captain"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:637
-msgid "\"The Crown\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:638
-msgid ""
-"The day you have feared has finally arrived.  The king, who you have "
-"faithfully served, has died, leaving no heir to his throne.  As his captain, "
-"you feel that this job should now be yours, but several factions even now "
-"are preparing for conquest.  You are at the center of the trade routes, "
-"having the sea to the south and the great forest to the north.  Go, now, "
-"Commander, and claim what is rightfully yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:639
-msgid ""
-"The diplomats who were sent here ahead of you report that the elves will "
-"only cooperate with you if you will recover the golden bow for them. It was "
-"stolen by their enemies, the Dragons and hidden behind magic barriers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:640
-msgid "The Eastern Town."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:641
-msgid "The edge of the world is your edge.  But prepare to be prepared."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:642
-msgid "The Emerald Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:643
-msgid "The Enchanted Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:644
-msgid "The End of the World is Nigh!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:645
-msgid "The End of the World is Nigh"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:646
-msgid ""
-"The Epic battle against Your Rival! Eliminate everything! Total Warfare! "
-"Don't Lose your first hero!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:647
-msgid ""
-"The Fire King is an ally to the dragons, and will help a friend of theirs."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:648
-msgid "The First One To Take Astircaer Wins!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:649
-msgid ""
-"The first piece of the artifact now lies in the hands of the Unholy Order of "
-"Warlocks. You must annihilate them, and their allies to the north. They will "
-"surely give us what we seek in exchange for their feeble lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:650
-msgid ""
-"The Fortune of Infamous Uae was buried on one of these islands. She died "
-"without ever revealing it.  Find it before the other cutthroats."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:651
-msgid "The four factions race to capture a mystical castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:652
-msgid ""
-"The four spell casters face off with substantial starting armies. Can the "
-"crusaders keep the peace?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:653
-msgid "\"The Gauntlet\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:654
-msgid ""
-"The Gods have given you 6 months to prove yourself. Good or Evil - who shall "
-"prevail? (Blue,Green and Red vs Yellow, Orange and Purple)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:655
-msgid ""
-"The gods have granted this world a great artifact, to find it means victory."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:656
-msgid "The Gods themselves will aid us in this War."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:657
-msgid "The Gold Traveller's Tent is near the Aqua Taveller's Tent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:658
-msgid "The guardians of Dragon Isle reside in the jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:659
-msgid "The Ice Prince stands frozen in some forgotten corner of the world."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:660
-msgid "The island...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:661
-msgid "The Island of Lost Reason"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:662
-msgid "The islands have much wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:663
-msgid "The Isle of Armoria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:664
-msgid "The key to success is rubbing enough lamps."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:665
-msgid ""
-"The King has declared you his hier apparent and champion. You must seek out "
-"and destroy your common enemy, Wilgatus and his Castle, Mirkosov, the source "
-"of his power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:666
-msgid ""
-"The King is dead, his kingdom has been shattered, and six leaders seek to "
-"seize power for themselves."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:667
-msgid "The Kingly Wastes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:668
-msgid "The Kings Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:669
-msgid ""
-"The King will sell you this land for 200,000 gold or you can take it by "
-"force. The choice is yours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:670
-msgid "The land of Heroes II."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:671
-msgid "The Lost Castle of the Ancients"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:672
-msgid ""
-"The mage wars have caused a great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:673
-msgid ""
-"The mage wars have caused great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:674
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trade.  "
-"Plus a little gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:675
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trading.  "
-"Plus a little more gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:676
-msgid ""
-"The Master Merchant arrives at your Castle.  He tells you tall tales of "
-"travel, full of outrageous lies.  He also gives you, your share of the "
-"profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:677
-msgid ""
-"The Master Merchant arrives back at your Castle.  He tells you tall tales of "
-"faraway places full of outrageous lies.  He also gives you, your share of "
-"the profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:678
-msgid "The Medusas have the password and they can be found just to the west."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:679
-msgid "The more there is the less you see."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:680
-msgid "The North Road to Roland's castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:681
-msgid ""
-"The note in this bottle has become mostly indecipherable. All you can make "
-"out are references to deadly pirates, and hidden gold mines."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:682
-msgid "The Other Side"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:683
-msgid ""
-"The Overlord has given you 4 months to conquer this land or deliver to him "
-"the sum of 150,000 gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:684
-msgid ""
-"The people on the Isle of Knowledge are taking up a collection to aid us."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:685
-msgid "The Proving Grounds"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:686
-msgid "The Queen's Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:687
-msgid "The Realm of Air is barred, but you may appeal here for help."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:688
-msgid ""
-"There are remnants of a mighty battle fought here, not too long ago. It "
-"looks as if whoever came this way may have made this their final stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:689
-msgid ""
-"There are three enemy castles to the north. Capture them in the name of "
-"Roland the true king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:690
-msgid ""
-"The Red Tide of War rolls North.  Stopping the flood seems hopeless.  Yet, "
-"Honor demands you and your ally die trying."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:691
-msgid "There is hidden treasure north of the Green Lord's Ore Mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:692
-msgid "There is hidden treasure south of the Blue Lord's Sawmill."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:693
-msgid "There's a warm wind blowing from the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:694
-msgid "There's a Wizard living in the north who is behind this peasant revolt."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:695
-msgid "The Retreat of the Alchemist Doctor Yu"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:696
-msgid ""
-"There used to be a mine here, but it has long since run out of ore.  You are "
-"only able to scavenge 5 units of ore from the old site."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:697
-msgid "There was a shipreck in the far east waters recently."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:698
-msgid "The River Styx"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:699
-msgid "The roars of several dragons echo from the towers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:700
-msgid "The Rock Store."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:701
-msgid "The Royal Gardens."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:702
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:703
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you defend against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:704
-msgid "These doors are a risk the likes of which you do not know."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:705
-msgid "These lands are beholden to Lord Kraeger."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:706
-msgid ""
-"These lands are desolate and for the most part devoid of resources. Not even "
-"the bravest heroes dare to venture into them, and plants are rare and "
-"precious here. Who knows what else awaits?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:707
-msgid ""
-"The Southern Witch is biding her time.  She will strike when your armies are "
-"weak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:708
-msgid "the stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:709
-msgid "The Table in the Great Hall of the Castle is Haunted."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:710
-msgid ""
-"The third piece of the artifact is somewhere to the north, that much we "
-"know. We are still unsure of its exact location, but our spies are out "
-"gathering information. The forces in this area are too strong to be "
-"completely subjugated, so take what you can and hold on to it tightly."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:711
-msgid ""
-"The troops have sworn their allegiance, but should lose a battle they will "
-"lose faith and our cause will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:712
-msgid "The Valley of Aruk."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:713
-msgid ""
-"The Valley of Magic holds many surprises.  You discover an old pair of boots "
-"sticking out of the sand."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:714
-msgid "The Valley of Tresures"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:715
-msgid "The Wasteland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:716
-msgid "The way of magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:717
-msgid "The way of might"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:718
-msgid "The way of numbers"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:719
-msgid "The western town."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:720
-msgid "The winds howl in mourning around the shipwreck."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:721
-msgid "The wizard has an island in the southeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:722
-msgid ""
-"The Wizards who have captured the Necromancers' town have wasted no time in "
-"building defenses designed to stop you, and their last castle has just been "
-"completed. Fortunately only a Captain of the Guard and a small garrison are "
-"currently present.  If you hurry, you should be able to capture the castle "
-"before they have a chance to reinforce it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:723
-msgid "The wood has arrived."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:724
-msgid "The writing on this sign is too faded to read."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:725
-msgid "The Yellow Lord has the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:726
-msgid ""
-"The Yellow Lord is a hothead who will attack before his allies can send him "
-"aid."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:727
-msgid "They say there's mermaids in these waters..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:728
-msgid ""
-"This area is rich in resources. Explore, but beware, a castle left "
-"undefended will quickly fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:729
-msgid ""
-"This area must be secured for the sake of the Empire. Our spies have "
-"reported a discord between The kingdom of the knights to the north, and that "
-"of the oppressive sorceresses to the northeast. Perhaps this feud can be "
-"exploited for our gain..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:730
-msgid "This bottle is empty."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:731
-msgid ""
-"This is the last week you have to find the rebel wizard Joseph! Good Luck in "
-"your quest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:732
-msgid ""
-"This land and all others are now under the sole ownership of Ibn Fadlan, the "
-"Undead King. Any disregard for his magesty's soverign rule is to be punished "
-"by death most horrendous."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:733
-msgid ""
-"This land has been claimed by the nation of Neroli. Interlopers are "
-"UNWELCOME."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:734
-msgid ""
-"This rugged land will have rivals fighting the terrain as well as each other."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:735
-msgid ""
-"This rundown village looks like it was once the epicenter of an enormous, "
-"but now ruined, city. Under a pile of rubble you find an object which looks "
-"like it has lain there for ages."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:736
-msgid ""
-"This spot overlooks an old quarry.  This was one of the only places in the "
-"world where ore could be taken right out of the ground.  Unfortunately the "
-"jungle has reclaimed the quarry and it is unusable.  You collect the last of "
-"the ore and depart."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:737
-msgid ""
-"This twisted maze of sorceress towns has three factions struggling for sole "
-"control.  Use your resources wisely!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:738
-msgid ""
-"This village appears to be in little better shape than the first one you "
-"saw. As you approach the village an old man hands you a slip of paper, with "
-"the following message, \"Joseph lives in the town of IslandHome.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:739
-msgid ""
-"This village is in extremely poor shape. There is no chance of getting more "
-"than some of the lesser creatures here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:740
-msgid "This way to the Necromancer Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:741
-msgid "Those who seek knowledge are welcome to the city of Chronos."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:742
-msgid ""
-"Three Warlocks in the land of Dragons. Lose thy home and all will be lost. "
-"Conquer thy enemies and the land shall forever be yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:743
-msgid "Timberhill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:744
-msgid "Time for a refreshing drink."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:745
-msgid "Time is running out! The enemy's reinforcements are almost here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:746
-msgid "To pass you must pay troll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:747
-msgid "TreeHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:748
-msgid "Trespassers will be EATEN!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:749
-msgid "Trilobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:750
-msgid "Troy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:751
-msgid "Tundara"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:752
-msgid "Turn back, friend, while you still can!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:753
-msgid "Turn Back Now!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:754
-msgid "Turn Back Now or all will be LOST!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:755
-msgid "Turn Back or DIE!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:756
-msgid "Turn Back or else!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:757
-msgid "Turn back, you fool."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:758
-msgid "\"Turning Point\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:759
-msgid ""
-"Uae was the scurviest, pirate ye'd never wanta see. In all her years of "
-"murdering and thieving she amassed so much ill-gotten booty that she "
-"couldn't carry it around in her galleon.  Besides, even the meanest can't "
-"stay awake all the time.  Legend tells that she hid it so well, she was "
-"thinking that she just might forget where it was.  So she left clues around "
-"the islands, carved in stone.  Well, she's dead now.  It's up to you to "
-"recover her legacy."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:761
-msgid "Uncle Leo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:762
-msgid "Uncle Milty"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:763
-msgid "Undead Armies"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:764
-msgid "Unholy Alliance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:765
-msgid "Unite the Tribes. Don't lose your main hero, the first Descendant."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:766
-msgid "Valley of Death"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:767
-msgid "Valley Of The Damned"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:768
-msgid "Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:769
-msgid "Vaultius"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:770
-msgid "Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:771
-msgid "Vikings!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:772
-msgid "Viper's Nest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:773
-msgid "Vulcania"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:774
-msgid "Warrior Knight"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:775
-msgid "Wastelands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:776
-msgid "Watch out for Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:777
-msgid "Waystop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:778
-msgid ""
-"\"We are at the edge of the world!\"  they scream.  \"What are we doing here?"
-"\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:779
-msgid "Weddington"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:780
-msgid "Weed Patch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:781
-msgid ""
-"We found a weakness my lord. Capture castle Black Fang and victory is ours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:782
-msgid ""
-"We have just learned that the artifact is on an island north of this "
-"continent. However, there does not appear to be any means to get there. Stay "
-"very alert for any possible way across the narrow channel."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:783
-msgid ""
-"Welcome back general.  Have you finished the conquest of the northern "
-"lands?  What? you still have not finished your mission!  Get back there and "
-"teach those rebels a lesson!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:784
-msgid "Welcome to Li'l Alctatraz! Vistors NOT welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:785
-msgid ""
-"Welcome to Power Island. He who controls this Isle controls the Seven Lakes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:786
-msgid "Welcome to the Sandbar."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:787
-msgid "Welcome to the sandy Isle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:788
-msgid "Welcome to the sorceress' guild."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:789
-msgid "Welcome to the Spiral Isles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:790
-msgid ""
-"Welcome to the wounderous Kitisland range.  Eruptions each day, beware of "
-"dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:791
-msgid "Welcome to Windfall Island!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:792
-msgid "Welcome to your DOOM!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:793
-msgid "We'll join you - for the right price."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:794
-msgid ""
-"Well placed bribes have won you a stronghold near the warring Barbarians. Be "
-"advised that given their proximity an unguarded castle is an open invitation "
-"to defeat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:795
-msgid "Westfork"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:796
-msgid "Westmoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:797
-msgid "We told you not to drink!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:798
-msgid "What are you doing here?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:799
-msgid "What cannot be seen but only heard, and will not speak until spoken to?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:800
-msgid "What everyday word is most often pronounced incorrectly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:801
-msgid "What goes up and down but never moves?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:802
-msgid ""
-"What good fortune!  You've discovered a long-abandoned settlement.  To your "
-"surprise, you discover that the previous inhabitants left some of their "
-"resources behind when they departed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:803
-msgid "What is always coming but never arrives?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:804
-msgid "What is the Sum of all Numbers from 1 to 200?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:805
-msgid "What is time spent poorly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:806
-msgid "What's another word for pirate treasure?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:807
-msgid "What's behind door number one?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:808
-msgid "What's this? A pile of gems?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:809
-msgid "What's this? Someone has left a pile of wood here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:810
-msgid ""
-"What team won Super Bowl XXI and Super Bowl XXV?  (Hint... a Wizard might "
-"have these troops in his army)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:811
-msgid "What turns everything around but does not move?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:812
-msgid ""
-"What walks in the morning on four legs, two in the afternoon and three in "
-"the evening?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:813
-msgid "What?  What's this?  Something at the bottom of this pool..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:814
-msgid "When you're ready, take the teleport to the Island's Hot Spot!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:815
-msgid ""
-"When you think yourself invincible, walk through this gate.  Even then, "
-"prepare to meet your bitter end."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:816
-msgid "Where am I?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:817
-msgid "While away seeking the Ultimate Artifact, Kastor's kingdom is invaded!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:818
-msgid ""
-"While traveling a mesenger meets you on the road.  His message tells of a "
-"new ally from an island far to the south.  This ally can not offer forces to "
-"your battle but has agreed to send some support in the form of gold and "
-"crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:819
-msgid "Whiteshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:820
-msgid "Whittingham"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:821
-msgid "Who am I?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:822
-msgid ""
-"Who am I?...  Where am I?...  Oh no! My Ship!  Well it's consigned to the "
-"ghosts of my dead crew now, at least I still have my lucky rabbits foot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:823
-msgid "Who is the true King?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:824
-msgid ""
-"\"Why have we come this way?\"  asks the first mate.  You have no answer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:825
-msgid "Wicked Warlock Way"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:826
-msgid "Wilasher"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:827
-msgid "Wildabar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:828
-msgid "Wilgatus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:829
-msgid "Willow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:830
-msgid "Windfall Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:831
-msgid "Winterkill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:832
-msgid "Winterlands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:833
-msgid "Witch Hunt"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:834
-msgid ""
-"With the year long eruption of Mt. Kitisland, your three worst enemies now "
-"have a ground bridge to your eastern contenent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:835
-msgid "Wizardwood.  Magicians welcome!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:836
-msgid "Woodhaven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:837
-msgid "Wood's Lord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:838
-msgid "Woodstock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:839
-msgid "Woodville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:840
-msgid "Wormed Ash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:841
-msgid "Wow, somebody has left a pile of wood here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:842
-msgid "Wyrm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:843
-msgid "Xabran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:844
-msgid "Yellow gets some stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:845
-msgid "Yellow's Steady Cash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:846
-msgid "Yellow stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:847
-msgid "Yellow's Yarbols"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:848
-msgid "Ye old fish liver oil."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:849
-msgid "Yorksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:850
-msgid ""
-"You and your ally's families were given custody of The Isle of Knowledge.  "
-"Other Lords feel the time has come for new guardians..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:851
-msgid "You are a fool to come here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:852
-msgid "You are fighting on the side of your king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:853
-msgid "You are fighting on the side of your sister!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:854
-msgid "You are now entering the domain of Prince Roland. Have a nice day."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:855
-msgid "You are now entering the domain of Prince Roland. Have a pleasant stay."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:856
-msgid ""
-"You bribe the entrance guards of this dingy prison camp. They agree to look "
-"the other way for a little while."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:857
-msgid ""
-"You can only reach your enemies via teleporters, but each jump is a leap of "
-"faith."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:858
-msgid ""
-"You cautiously ride through the trees, looking out for enemy assaults, when "
-"suddenly, the old elf is beside you. \"Your quest is almost at an end, my "
-"friend. All that remains is for you to lay seige to these last few castles. "
-"The fate of my people rests upon your final battles here. May the gods be "
-"with you as well.\"  He turns to leave, but you ask him his name before he "
-"is gone. Over his shoulder, as he is leaving he says \"I am Ilthanis, king "
-"of the elves.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:859
-msgid ""
-"You come across the dead remains of what was appearantly a powerful wizard!  "
-"You wonder if it's safe to continue."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:860
-msgid ""
-"You face three opponents in this scenario. Capture their castles and their "
-"heroes to prove your worthiness to Archibald."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:861
-msgid ""
-"You find a beautiful helm buried in the lava.  As you move to put it on your "
-"head it turns into the Hideous mask and now you realize that no creature "
-"will join you."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:862
-msgid ""
-"You find a gleaming gold medalion buried in the  snow.  As you move to put "
-"it on it changes to the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:863
-msgid ""
-"You find an old signpost in the midst of a thicket that reads \"Warlock "
-"Wood, West.  Barbarian Fields, East.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:864
-msgid ""
-"You find a note in the bottle! It reads, \"My ship has been wrecked by the "
-"notorious pirates in this area! I am stranded on a small and barren island. "
-"Please, I beg you to come and rescue me!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:865
-msgid "You found something!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:866
-msgid "You found Treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:867
-msgid ""
-"You have been ordered here to claim this land in the name of your King and "
-"recover any riches that you might find.  However, five other Kings and "
-"Queens have also sent their heroes to this land, so you must watch out for "
-"them as well as the natives!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:868
-msgid "You have found what someone else has lost..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:869
-msgid ""
-"You have hired a barbarian of great power to aid you in this, your last "
-"quest. His origins are unknown to you, but you sense strong nobility beneath "
-"the furs and dirt that cover him. In addition, the famous explorer, Marco "
-"the wizard, is rumored to have wrecked his ship in this new land. Finding "
-"him would prove to be a much needed boon to your cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:870
-msgid ""
-"You have just 8 weeks  to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:871
-msgid ""
-"You have just 8 weeks to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:872
-msgid ""
-"You have received a message from Archibald. \"General, these peasants "
-"deserve punishment. Put them to the sword and let Corlagon have his way with "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:873
-msgid ""
-"You have received a message from Archibald.  \" HOW DARE YOU BETRAY ME! I "
-"will see your head on the block alongside your new master's once I have won."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:874
-msgid ""
-"You have received a message from Roland. \" I am shocked! I had thought "
-"better of you, but I was terribly wrong. Now you'll have to live with your "
-"dark decision for the rest of your life.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:875
-msgid "You have recieved a shipment of supplies from your kingdom!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:876
-msgid ""
-"You have recieved a shipment of supplies from your kingdom! There is a note "
-"attached, \"These are all we could afford to send you from our treasuries, "
-"as the war with Harondale is taxing us greatly. We will send more in two "
-"weeks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:877
-msgid ""
-"You have six months to destroy the Necromancer Stronghold in the heart of "
-"the valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:878
-msgid ""
-"You have washed up on the beach after being shipwrecked. Your goal is to "
-"find a way home."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:879
-msgid ""
-"You hear a low rumble, look up and see an avalanche!  You dive onto a large "
-"patch of grass to avoid it.  While dusting yourself off, you consider "
-"yourself quite lucky to be alive.  Luckier still to find a Four-Leaf Clover "
-"stuck on your nose."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:880
-msgid ""
-"You hear a rumor from a peasant who lives in the town of Waystop. He says, "
-"\"The pirates control most of the sulfur mines in this area. They use it for "
-"the cannons on their bigger boats. If you want a mine, you'll have to defeat "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:881
-msgid "You hear melodic strains of elvish music as you enter this clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:882
-msgid ""
-"You must, like, forsake your earthly wealth and, like, join us on the island "
-"of the lotus eaters."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:883
-msgid ""
-"You must search the world for your mortal enemy, Wilgatus.  Can you find him "
-"before its too late?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:884
-msgid ""
-"You notice some runes hastily scrawled into a rock by your feet, They look "
-"like the initials of Uncle Ivan!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:885
-msgid ""
-"You notice that mines and resources in the elvish lands are few, and you "
-"send word to your kingdom that you will need extra supplies. They should "
-"respond within a fortnight."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:886
-msgid ""
-"Your advance scouts come riding back to you with the following news. They "
-"believe they have found signs that Uncle Ivan was in this general area, and "
-"that he made his way to the north many months ago. Also they say there is a "
-"town nearby and many resources to the east."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:887
-msgid ""
-"Your advisor approaches you, \"My liege, something must be done about these "
-"peasants! They still refuse to work.  At this rate you won't have anything "
-"to put in your daughter's dowry!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:888
-msgid ""
-"Your advisor approaches you smiling greatly, \"My liege! The peasants are "
-"making money in the market, and are finally paying taxes!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:889
-msgid ""
-"Your advisor approaches you with a long face, \"My liege, the peasant's "
-"numbers are growing steadily.  All they do is take, take, take! We are "
-"beginning to suffer dearly because of them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:890
-msgid ""
-"Your advisor approaches you with some startling information, \"My liege, the "
-"peasants are draining us. They do nothing, and take everything! We must get "
-"them home. Your own citizens are beginning to suffer!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:891
-msgid ""
-"Your arrival here was a surprise to those sworn to guard Dragon Isle, and "
-"you were able to quickly capture one of their castles.  Use caution, though, "
-"for two other guardians remain in this jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:892
-msgid ""
-"Your castle, founded inside the center of a mile wide crater, is besieged by "
-"those who desire your mineral wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:893
-msgid "Your castle is the last outpost in the area, Don't lose it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:894
-msgid "Your crew begins to grumble."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:895
-msgid ""
-"Your crew seriously entertains thoughts of mutiny.  Your nights are "
-"sleepless."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:896
-msgid "You're almost there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:897
-msgid "You, recieve word that you have been robbed."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:898
-msgid "You're getting colder."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:899
-msgid "You're getting warmer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:900
-msgid ""
-"You're here! Oh, thank you thank you thank you! I'm in the jail east of the "
-"castle. Please hurry!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:901
-msgid ""
-"Your expedition has taken a turn for the worse... you now have no way to get "
-"home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:902
-msgid ""
-"Your forces are thinly spread in an effort to defend all the dwarf towns "
-"(which may not be transformed into castles). Consolidate your forces and "
-"smite the enemy before the towns fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:903
-msgid ""
-"Your horse stumbles and throws you from the saddle.  When you awaken you "
-"find that you have hit your head on the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:904
-msgid ""
-"Your isolation from the rest of the kingdom has largely kept you out of the "
-"political struggles, but now with the king's death, and lack of an heir, you "
-"see a golden opportunity to seize the throne for yourself.  Just remember "
-"that you have relied largely on trade for several key resources, especially "
-"sulfur, but with a little planning this land can be yours.  Go, now, and "
-"show these peasants how to rule!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:905
-msgid "Your king has sent supplies to aid the war effort."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:906
-msgid ""
-"Your opponents are allied against you and each is twice as powerful as his "
-"predecessor! Is it possible to win?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:907
-msgid ""
-"Your Queen sent you here to explore this newly discovered territory, but a "
-"freak storm scattered your fleet and left you stranded.  You gather the "
-"survivors and form a small settlement, naming it New Vertigo.  This place is "
-"your home now, and survival is your highest priority, but remember, if you "
-"are captured or killed, it's over!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:908
-msgid ""
-"Your rival, the kingdom of Harondale, is attacking your weak border towns! "
-"Recover from their first strike and crush them completely."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:909
-msgid ""
-"Your Scouts report talking to a young knight, a squire to the two sleeping "
-"heroes.  The squire is trapped by the Aqua Magic Barriers and a group of "
-"fallen Paladins.  He says the two heroes, Dainwin and Ceallach, have "
-"awakened but are still trapped by a Gold Magical Barrier and asks your aid "
-"in freeing them."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:910
-msgid ""
-"Your Scouts report that the Aqua Traveller's Tent is located along The North "
-"Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:911
-msgid ""
-"Your scouts return with grim news.  The natives of this land are currently "
-"at war with each other, and they like outsiders even less than they like "
-"each other!  Congratulations, Commander, you're at war!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:912
-msgid ""
-"Your sister calls you before her altar in the morning. \"I have important "
-"news,\" she says, \"The barbarian kingdoms which border this land have "
-"agreed to lend us some of their castles and warriors in return for a share "
-"of the spoils. I hope victory comes swiftly, but your presence gives me "
-"strength to stand until whatever end awaits.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:913
-msgid "Your subjects contribute to your war effort!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:914
-msgid ""
-"Your town is undefended and your heroes are scattered.  Do you attack or "
-"defend?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:915
-msgid ""
-"Your treasury has been looted by robbers and you have lost valuable "
-"resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:916
-msgid "Your troops begin to wonder about your sanity."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:917
-msgid ""
-"You run aground on the rocks and have to use some wood to fix your boat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:918
-msgid ""
-"You see a family of refugees making their way from the beach. You ask them "
-"about their plight and they tell you that they are from a once great city "
-"called Moss Side. They tell you that the castle was destroyed in a great "
-"conflagration, and they fled for fear of their lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:919
-msgid ""
-"You see an old man bringing water towards the stables. Recognizing him as "
-"the mystic, you attempt to thank him for his gift with some gold. He "
-"refuses, but says to you instead, \"There are riddles guarding the source of "
-"the fount's power, and the dragons know the answers. Make your way through "
-"their lair, and you shall know victory.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:920
-msgid ""
-"You see an old mystic perched on a rock. You walk towards him to see if he "
-"has any words for you on your quest, and he says \"First I see you as a "
-"great conquerer of the lands of men. Secondly, I see you as a mighty ruler "
-"of vast armies, well loved by your troops. Thirdly, I see you as a slayer of "
-"legions of dragons, your body bathed in their fire. Lastly, I see you "
-"standing on the shores of the fount, unable to cross.\" Then the Mystic "
-"fades away."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:921
-msgid "You see something that could just be the elusive Nubbie!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:922
-msgid ""
-"You see the mast of ancient ship here.  On further investigation you find "
-"that the ships holds are full of gems.  The hours pass as your crue "
-"liberates the treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:923
-msgid ""
-"You see the remains of a burned out sawmill here.  All you can salvage is "
-"some ofwood left for scrap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:924
-msgid ""
-"You see the remains of an old sawmill, but it is obvious that you will not "
-"be able to make it work again."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:925
-msgid ""
-"You see the remains of an old sawmill just to realize that it will no longer "
-"produce.  You gather the ramains and move on."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:926
-msgid ""
-"You send this letter back to the king,\"A month has passed and we have not "
-"discovered the wizard Joseph. I only hope that we are able to locate him in "
-"time to aid us in our struggle.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:927
-msgid "You should turn back."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:928
-msgid ""
-"You stumble upon an old man who proclaims you Lord of the Realm, hands you "
-"his boots and wonders into the mountains mumbling something about being late "
-"for an important date."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:929
-msgid ""
-"You stumple across three small rocks piled on top of each other and decide "
-"to dig undernear them.  There you find an old weather-beaten bag of gems."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:930
-msgid "You uncover a compass in the grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:931
-msgid "You've been warned!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:932
-msgid ""
-"You've received a message from Roland. \"In the absence of a strong leader, "
-"the local lords have fallen to fighting. Uniting this area is critical to "
-"our cause, so we must not fail.  Leaving your castle undefended in this "
-"highly contested region will surely lead to defeat. I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:933
-msgid ""
-"You've received a message from the guild. \"Thank God you've arrived! We're "
-"under seige from two enemies from the north and one from across the sea. "
-"Please save us, you're our only hope.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:934
-msgid ""
-"You've ruled with an iron fist (and an army of undead), but now your kingdom "
-"has turned against you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:935
-msgid ""
-"You've saved a group of miners from the dragons.  One of them approaches "
-"you, \"Thank you so much for saving us!  We found this sulfer and sword in "
-"the mine, then those dragons chased us!  I don't know how much longer we "
-"could survive!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:936
-msgid ""
-"You will clash quickly on this small head-to-head map, so stay on your toes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:937
-msgid ""
-"You will need a stronger army than that, mortal, to step through this portal."
-msgstr ""
-
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Wood"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Mercury"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Ore"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Sulfur"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Crystal"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Gems"
 msgstr ""
 
-#: ../fheroes2/spell/spell_book.cpp:61 ../fheroes2/spell/spell_book.cpp:79
-msgid "No spell to cast."
-msgstr ""
-
-#: ../fheroes2/spell/spell_book.cpp:138
-msgid "Your hero has %{point} spell points remaining"
-msgstr ""
-
-#: ../fheroes2/spell/spell.cpp:50
 msgid "Fireball"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:50
 msgid ""
 "Causes a giant fireball to strike the selected area, damaging all nearby "
 "creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid "Fireblast"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid ""
 "An improved version of fireball, fireblast affects two hexes around the "
 "center point of the spell, rather than one."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Lightning Bolt"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Causes a bolt of electrical energy to strike the selected creature."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid "Chain Lightning"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid ""
 "Causes a bolt of electrical energy to strike a selected creature, then "
 "strike the nearest creature with half damage, then strike the NEXT nearest "
@@ -11264,820 +5493,601 @@ msgid ""
 "harmful.  Warning:  This spell can hit your own creatures!"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid "Teleport"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid ""
 "Teleports the creature you select to any open position on the battlefield."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid "Cure"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid ""
-"Removes all negative spells cast upon one of your units, and restores up to %"
-"{count} HP per level of spell power."
+"Removes all negative spells cast upon one of your units, and restores up to "
+"%{count} HP per level of spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid "Mass Cure"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid ""
-"Removes all negative spells cast upon your forces, and restores up to %"
-"{count} HP per level of spell power, per creature."
+"Removes all negative spells cast upon your forces, and restores up to "
+"%{count} HP per level of spell power, per creature."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrect"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrects creatures from a damaged or dead unit until end of combat."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrect True"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrects creatures from a damaged or dead unit permanently."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Haste"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Increases the speed of any creature by %{count}."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Mass Haste"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Increases the speed of all of your creatures by %{count}."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "spell|Slow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "Slows target to half movement rate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Mass Slow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Slows all enemies to half movement rate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:64
-msgid "Blind "
+msgid "spell|Blind"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:64
 msgid "Clouds the affected creatures' eyes, preventing them from moving."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Bless"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Causes the selected creatures to inflict maximum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Mass Bless"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Causes all of your units to inflict maximum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Stoneskin"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Magically increases the defense skill of the selected creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid "Steelskin"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid ""
 "Increases the defense skill of the targeted creatures.  This is an improved "
 "version of Stoneskin."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Curse"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Causes the selected creatures to inflict minimum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Mass Curse"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Causes all enemy troops to inflict minimum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Holy Word"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Damages all undead in the battle."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid "Holy Shout"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid ""
 "Damages all undead in the battle.  This is an improved version of Holy Word."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Anti-Magic"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Prevents harmful magic against the selected creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Dispel Magic"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Removes all magic spells from a single target."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Mass Dispel"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Removes all magic spells from all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Magic Arrow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Causes a magic arrow to strike the selected target."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Berserker"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Causes a creature to attack its nearest neighbor."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid "Armageddon"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid ""
 "Holy terror strikes the battlefield, causing severe damage to all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Elemental Storm"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Magical elements pour down on the battlefield, damaging all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid "Meteor Shower"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid ""
 "A rain of rocks strikes an area of the battlefield, damaging all nearby "
 "creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "Paralyze"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "The targeted creatures are paralyzed, unable to move or retaliate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid "Hypnotize"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid ""
-"Brings a single enemy unit under your control for one combat round if its "
-"hits are less than %{count} times the caster's spell power."
+"Brings a single enemy unit under your control if its hits are less than "
+"%{count} times the caster's spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Cold Ray"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Drains body heat from a single enemy unit."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid "Cold Ring"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid ""
 "Drains body heat from all units surrounding the center point, but not "
 "including the center point."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Disrupting Ray"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Reduces the defense rating of an enemy unit by three."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Death Ripple"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Damages all living (non-undead) units in the battle."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid "Death Wave"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid ""
 "Damages all living (non-undead) units in the battle.  This spell is an "
 "improved version of Death Ripple."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Dragon Slayer"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Greatly increases a unit's attack skill vs. Dragons."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Blood Lust"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Increases a unit's attack skill."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Animate Dead"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Resurrects creatures from a damaged or dead undead unit permanently."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid "Mirror Image"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid ""
 "Creates an illusionary unit that duplicates one of your existing units.  "
 "This illusionary unit does the same damages as the original, but will vanish "
 "if it takes any damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Shield"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Halves damage received from ranged attacks for a single unit."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Mass Shield"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Halves damage received from ranged attacks for all of your units."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summon Earth Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summons Earth Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summon Air Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summons Air Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summon Fire Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summons Fire Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summon Water Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summons Water Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Earthquake"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Damages castle walls."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "View Mines"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "Causes all mines across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "View Resources"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "Causes all resources across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "View Artifacts"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "Causes all artifacts across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "View Towns"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "Causes all towns and castles across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "View Heroes"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "Causes all Heroes across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "View All"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "Causes the entire land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Identify Hero"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Allows the caster to view detailed information on enemy Heroes."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid "Summon Boat"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid ""
 "Summons the nearest unoccupied, friendly boat to an adjacent shore "
 "location.  A friendly boat is one which you just built or were the most "
 "recent player to occupy."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Dimension Door"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Allows the caster to magically transport to a nearby location."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Town Gate"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Returns the caster to any town or castle currently owned."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:109
 msgid ""
 "Returns the hero to the town or castle of choice, provided it is controlled "
 "by you."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid "Visions"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid ""
 "Visions predicts the likely outcome of an encounter with a neutral army camp."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid "Haunt"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid ""
 "Haunts a mine you control with Ghosts.  This mine stops producing "
 "resources.  (If I can't keep it, nobody will!)"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Set Earth Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Sets Earth Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Set Air Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Sets Air Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Set Fire Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Sets Fire Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Set Water Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Sets Water Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:665
-msgid "Necroman"
+msgid "No spell to cast."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:691
-msgid ""
-"This lets you change player starting positions and colors. A particular "
-"color will always start in a particular location. Some positions may only be "
-"played by a computer player or only by a human player."
+msgid "Your hero has %{point} spell points remaining."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:695
-msgid ""
-"This lets you change the class of a player. Classes are not always "
-"changeable. Depending on the scenario, a player may receive additional towns "
-"and/or heroes not of their primary alignment."
+msgid "View Adventure Spells"
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:734
-msgid "%{color} player"
+msgid "View Combat Spells"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:126
+msgid "View previous page"
+msgstr ""
+
+msgid "View next page"
+msgstr ""
+
+msgid "Close Spellbook"
+msgstr ""
+
+msgid "View %{spell}"
+msgstr ""
+
 msgid "game: always confirm for rewrite savefile"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:127
-msgid "game: also confirm autosave"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:128
 msgid "game: remember last focus"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:129
-msgid "game: battle show grid"
+msgid "battle: show damage info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:130
-msgid "game: battle mouse shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:131
-msgid "game: battle move shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:132
-msgid "game: battle show damage info"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:133
-msgid "game: castle flash building"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:134
 msgid "world: show visited content from objects"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:135
+msgid "world: show terrain penalty"
+msgstr ""
+
 msgid "world: scouting skill show extended content info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:136
-msgid "world: abandoned mine random resource"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:137
-msgid "world: save count monster after battle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:138
 msgid "world: allow set guardian to objects"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:139
-msgid "world: guardian objects gets +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:140
-msgid "world: no in-built requirements or guardians for placed artifacts"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:141
-msgid "world: only the first monster will attack (H2 bug)."
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:142
 msgid "world: Eagle Eye also works like Scholar in H3."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:143
 msgid "world: ban for WeekOf/MonthOf Monsters"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:144
-msgid "world: new version WeekOf (+growth)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:145
 msgid "world: ban plagues months"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:146
 msgid "world: Months Of Monsters do not place creatures on map"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:147
 msgid "world: Crystal Ball also added Identify Hero and Visions spells"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:148
-msgid "world: Artesian Springs have two separately visitable squares (h3 ver)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:149
 msgid "world: Starting heroes as Loss Conditions for Human Players"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:150
 msgid "world: Only 1 hero can be hired by the one player every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:151
-msgid "world: each castle allows one hero to be recruited every week"
+msgid "world: Each castle allows one hero to be recruited every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:152
-msgid "world: Outer creature dwellings should accumulate units"
+msgid "world: Neutral armies scale with game difficulty"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:153
-msgid "world: use unique artifacts for morale/luck"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:154
 msgid "world: use unique artifacts for resource affecting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:155
 msgid "world: use unique artifacts for primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:156
 msgid "world: use unique artifacts for secondary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:157
 msgid "world: Wind/Water Mills and Magic Garden can be captured"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:158
 msgid "world: disable Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:159
-msgid "castle: allow buy from well"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:160
 msgid "castle: allow guardians"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:161
 msgid ""
 "castle: higher mage guilds regenerate more spell points/turn "
 "(20/40/60/80/100%)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:162
-msgid "castle: allow recruits special/expansion heroes"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:163
 msgid "heroes: allow buy a spellbook from Shrines"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:164
-msgid "heroes: learn new spells with day"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:165
 msgid "heroes: recruit cost to be dependent on hero level"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:166
-msgid "heroes: remember MP/SP for retreat/surrender result"
+msgid "heroes: remember move points for retreat/surrender result"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:167
-msgid "heroes: surrendering gives some experience"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:168
-msgid "heroes: recalculate movement points after creatures movement"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:169
-msgid "heroes: allow pickup objects for patrol"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:170
-msgid "heroes: after battle move to target cell"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:171
 msgid "heroes: allow transcribing scrolls (needs: Eye Eagle skill)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:172
-msgid "heroes: allow banned sec. skills upgrade"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:173
 msgid "heroes: in Arena can choose any of primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:174
 msgid "unions: allow meeting heroes"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:175
 msgid "unions: allow castle visiting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:176
+msgid "battle: show army order"
+msgstr ""
+
 msgid "battle: soft wait troop"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:177
-msgid "battle: high objects are an obstacle for archers"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:178
-msgid "battle: merge armies for hero from castle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:179
-msgid "battle: archmage can resists (20%) bad spells"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:180
-msgid "battle: magical creature resists (20%) the same magic"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:181
-msgid "battle: skip increase +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:182
 msgid "battle: reverse wait order (fast, average, slow)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:183
 msgid "game: show system info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:184
 msgid "game: autosave on"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:185
 msgid "game: autosave will be made at the beginning of the day"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:186
 msgid "game: use fade"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:187
-msgid "game: show SDL logo"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:188
 msgid "game: use evil interface"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:189
-msgid "game: also use dynamic interface for castles"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:190
 msgid "game: hide interface"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:191
 msgid "game: offer to continue the game afer victory condition"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:192
-msgid "pocketpc: hide cursor"
+msgid "The ultimate artifact is really the %{name}."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:193
-msgid "pocketpc: tap mode"
+msgid "The ultimate artifact may be found in the %{name} regions of the world."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:194
-msgid "pocketpc: drag&drop gamearea as scroll"
+msgid "north-west"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:195
-msgid "pocketpc: low memory"
+msgid "north"
+msgstr ""
+
+msgid "north-east"
+msgstr ""
+
+msgid "west"
+msgstr ""
+
+msgid "center"
+msgstr ""
+
+msgid "east"
+msgstr ""
+
+msgid "south-west"
+msgstr ""
+
+msgid "south"
+msgstr ""
+
+msgid "south-east"
+msgstr ""
+
+msgid "The truth is out there."
+msgstr ""
+
+msgid "The dark side is stronger."
+msgstr ""
+
+msgid "The end of the world is near."
+msgstr ""
+
+msgid "The bones of Lord Slayer are buried in the foundation of the arena."
+msgstr ""
+
+msgid "A Black Dragon will take out a Titan any day of the week."
+msgstr ""
+
+msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
+msgstr ""
+
+msgid "An unknown force is being ressurected..."
+msgstr ""
+
+msgid ""
+"Check the newest version of game at\n"
+"https://github.com/ihhub/\n"
+"fheroes2/releases"
 msgstr ""
 
 #~ msgid "Pack"

--- a/files/lang/pl.po
+++ b/files/lang/pl.po
@@ -9,50 +9,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-10-23 10:54+0900\n"
+"POT-Creation-Date: 2021-07-01 15:11+0200\n"
 "PO-Revision-Date: 2013-10-04 21:15+0000\n"
 "Last-Translator: Łukasz Cieliński <lukasc@mp.pl>\n"
 "Language-Team: Polish <pl@li.org>\n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pl\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Launchpad-Export-Date: 2013-10-09 02:01+0000\n"
 "X-Generator: Launchpad (build 16799)\n"
 
-#: ../fheroes2/ai/ai_action.cpp:157 ../fheroes2/heroes/heroes_action.cpp:248
-msgid "Hero %{name} also got a %{count} experience."
-msgstr "Bohater %{name} otrzymał także %{count} doświadczenia."
-
-#: ../fheroes2/army/army_bar.cpp:221 ../fheroes2/resource/artifact.cpp:968
-msgid "View %{name}"
-msgstr "Obejrzyj jednostkę (%{name})"
-
-#: ../fheroes2/army/army_bar.cpp:227 ../fheroes2/army/army_bar.cpp:310
-msgid "Move or right click to redistribute %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:233 ../fheroes2/army/army_bar.cpp:301
-msgid "Combine %{name} armies"
-msgstr "Połącz jednostki (%{name})"
-
-#: ../fheroes2/army/army_bar.cpp:238 ../fheroes2/army/army_bar.cpp:292
-#: ../fheroes2/resource/artifact.cpp:980
-#: ../fheroes2/resource/artifact.cpp:1002
-msgid "Exchange %{name2} with %{name}"
-msgstr "Zamień pozycje jednostek: %{name2} i %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:246 ../fheroes2/resource/artifact.cpp:988
-msgid "Select %{name}"
-msgstr "Wybierz jednostkę (%{name})"
-
-#: ../fheroes2/army/army_bar.cpp:298 ../fheroes2/army/army_bar.cpp:307
-msgid "Cannot move last troop"
-msgstr ""
-
-#: ../fheroes2/army/army.cpp:85
 msgid ""
 "A few\n"
 "%{monster}"
@@ -60,7 +29,6 @@ msgstr ""
 "Niewiele\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:86
 msgid ""
 "Several\n"
 "%{monster}"
@@ -68,7 +36,6 @@ msgstr ""
 "Kilka\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:87
 msgid ""
 "A pack of\n"
 "%{monster}"
@@ -76,7 +43,6 @@ msgstr ""
 "Grupa\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:88
 msgid ""
 "Lots of\n"
 "%{monster}"
@@ -84,7 +50,6 @@ msgstr ""
 "Mnóstwo\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:89
 msgid ""
 "A horde of\n"
 "%{monster}"
@@ -92,7 +57,6 @@ msgstr ""
 "Horda\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:90
 msgid ""
 "A throng of\n"
 "%{monster}"
@@ -100,7 +64,6 @@ msgstr ""
 "Chmara\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:91
 msgid ""
 "A swarm of\n"
 "%{monster}"
@@ -108,7 +71,6 @@ msgstr ""
 "Rój\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:92
 msgid ""
 "Zounds of\n"
 "%{monster}"
@@ -116,7 +78,6 @@ msgstr ""
 "Od cholery\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:93
 msgid ""
 "A legion of\n"
 "%{monster}"
@@ -124,79 +85,78 @@ msgstr ""
 "Legion\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Few"
 msgstr "army|Niewiele"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Several"
 msgstr "army|Kilka"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Pack"
 msgstr "army|Paczka"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Lots"
 msgstr "army|Mnóstwo"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Horde"
 msgstr "army|Horda"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Throng"
 msgstr "army|Masa"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Swarm"
 msgstr "army|Rój"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Zounds"
 msgstr "army|W cholerę"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Legion"
 msgstr "army|Legion"
 
-#: ../fheroes2/army/army.cpp:925
 msgid "All %{race} troops +1"
 msgstr "Wszystkie %{race} oddziały +1"
 
-#: ../fheroes2/army/army.cpp:936
-msgid "Entire unit is undead, so morale does not apply."
-msgstr "Cały oddział nie jest martwy, więc morali nie przybyło."
-
-#: ../fheroes2/army/army.cpp:946
 msgid "Troops of 3 alignments -1"
 msgstr "Jednostki z 3 różnych frakcji -1"
 
-#: ../fheroes2/army/army.cpp:954
 msgid "Troops of 4 alignments -2"
 msgstr "Jednostki z 4 różnych frakcji -2"
 
-#: ../fheroes2/army/army.cpp:962
 msgid "Troops of 5 alignments -3"
 msgstr "Jednostki z 5 różnych frakcji -3"
 
-#: ../fheroes2/army/army.cpp:976
 msgid "Some undead in groups -1"
 msgstr "Nieumarli w armii -1"
 
-#: ../fheroes2/battle/battle_action.cpp:752
+msgid "View %{name}"
+msgstr "Obejrzyj jednostkę (%{name})"
+
+msgid "Move or right click to redistribute %{name}"
+msgstr ""
+
+msgid "Combine %{name} armies"
+msgstr "Połącz jednostki (%{name})"
+
+msgid "Exchange %{name2} with %{name}"
+msgstr "Zamień pozycje jednostek: %{name2} i %{name}"
+
+msgid "Select %{name}"
+msgstr "Wybierz jednostkę (%{name})"
+
+msgid "Cannot move last troop"
+msgstr ""
+
+msgid "%{name} half the enemy troops!"
+msgstr "%{name} Połowa żołnierzy wroga!"
+
 msgid "Set auto battle off"
 msgstr "Wyłącz automatyczną walkę"
 
-#: ../fheroes2/battle/battle_action.cpp:757
 msgid "Set auto battle on"
 msgstr "Włącz automatyczną walkę"
 
-#: ../fheroes2/battle/battle_action.cpp:864
 msgid "spell failed!"
 msgstr "Czar nie udany!"
 
-#: ../fheroes2/battle/battle_arena.cpp:705
 msgid ""
 "The Sphere of Negation artifact is in effect for this battle, disabling all "
 "combat spells."
@@ -204,26 +164,20 @@ msgstr ""
 "W czasie bitwy działa artefakt o nazwie Kula Negacji, uniemożliwiający "
 "rzucenie wszelkich zaklęć bojowych."
 
-#: ../fheroes2/battle/battle_arena.cpp:714
 msgid "You have already cast a spell this round."
 msgstr "W tej rundzie zaklęcie zostało już rzucone."
 
-#: ../fheroes2/battle/battle_arena.cpp:720
-#: ../fheroes2/battle/battle_arena.cpp:768
 msgid "That spell will affect no one!"
 msgstr "To zaklęcie na nikogo nie zadziała!"
 
-#: ../fheroes2/battle/battle_arena.cpp:739
 msgid "You may only summon one type of elemental per combat."
 msgstr "W czasie walki możesz przywołać tylko jeden rodzaj żywiołaka."
 
-#: ../fheroes2/battle/battle_arena.cpp:745
 msgid "There is no open space adjacent to your hero to summon an Elemental to."
 msgstr ""
 "Obok twojego bohatera nie ma wolnego miejsca gdzie możnaby przywołać "
 "żywiołaki."
 
-#: ../fheroes2/battle/battle_board.cpp:968
 msgid ""
 "The Moat reduces by -%{count} the defense skill of any unit and slows to "
 "half movement rate."
@@ -231,125 +185,133 @@ msgstr ""
 "Fosa zmniejsza współczynnik obrony o -%{count} oraz spowalnia jednostki o "
 "połowę."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:50
-msgid "speed: %{speed}"
+msgid "Speed"
+msgstr "Szybkość"
+
+#, fuzzy
+msgid "Speed: %{speed}"
 msgstr "prędkość: %{speed}"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:165
+#, fuzzy
+msgid "Auto Spell Casting"
+msgstr "Czarodzieje"
+
+msgid "Grid"
+msgstr ""
+
+#, fuzzy
+msgid "Shadow Movement"
+msgstr "Dalszy ruch"
+
+msgid "Shadow Cursor"
+msgstr ""
+
+msgid "On"
+msgstr ""
+
+#, fuzzy
+msgid "Off"
+msgstr "wyłączone"
+
 msgid "The enemy has surrendered!"
 msgstr "Przeciwnik się poddał!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:168
 msgid "The enemy has fled!"
 msgstr "Przeciwnik uciekł!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:170
-#: ../fheroes2/battle/battle_dialogs.cpp:256
 msgid "A glorious victory!"
 msgstr "Wspaniałe zwycięstwo!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:175
-msgid "For valor in combat, %{name} receives %{exp} experience"
+#, fuzzy
+msgid "For valor in combat, %{name} receives %{exp} experience."
 msgstr "Za męstwo w walce, %{name} otrzymuje %{exp} pkt. doświadczenia"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:184
 msgid "The cowardly %{name} flees from battle."
 msgstr "%{name} tchórzliwie ucieka z pola bitwy."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:191
 msgid "%{name} surrenders to the enemy, and departs in shame."
 msgstr "%{name} poddaje się wrogowi i odchodzi w hańbie."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:197
 msgid "Your force suffer a bitter defeat, and %{name} abandons your cause."
 msgstr "Twoje wojska ponoszą dotkliwą klęskę, a %{name} opuszcza cię."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:249
 msgid "Your force suffer a bitter defeat."
 msgstr "Twoje wojska ponoszą dotkliwą klęskę."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:296
 msgid "Battlefield Casualties"
 msgstr "Ofiary walki"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:300
 msgid "Attacker"
 msgstr "Atakujący"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:312
 msgid "Defender"
 msgstr "Obrońca"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:394
+msgid "You have captured an enemy artifact!"
+msgstr "Udało ci się zdobyć artfeakt przeciwnika!"
+
+#, fuzzy
+msgid "Necromancy!"
+msgstr "Nekromancja"
+
+#, fuzzy
+msgid ""
+"Practicing the dark arts of necromancy, you are able to raise %{count} of "
+"the enemy's dead to return under your service as %{monster}."
+msgstr ""
+"Korzystając z mrocznej sztuki nekromancji, ożywiasz %{count} martwych "
+"przeciwników i wcielasz ich do swojej armii jako %{monster}."
+
 msgid "%{name} the %{race}"
 msgstr "%{name}, %{race}"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:401
-#: ../fheroes2/castle/castle_well.cpp:311
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:194
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:834
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Attack"
 msgstr "Atak"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:406
-#: ../fheroes2/castle/castle_well.cpp:317
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:206
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:844
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Defense"
 msgstr "Obrona"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:411
-#: ../fheroes2/castle/castle_town.cpp:310
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:854
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:142
-#: ../fheroes2/heroes/heroes_meeting.cpp:292
 msgid "Spell Power"
 msgstr "Moc zaklęć"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:416
-#: ../fheroes2/castle/castle_town.cpp:319
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:864
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:147
-#: ../fheroes2/heroes/heroes_meeting.cpp:296 ../fheroes2/heroes/skill.cpp:151
 msgid "Knowledge"
 msgstr "Wiedza"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:421
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:276
 msgid "Morale"
 msgstr "Morale"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:426
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:286 ../fheroes2/heroes/skill.cpp:338
 msgid "Luck"
 msgstr "Szczęście"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:431
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:874
-#: ../fheroes2/heroes/heroes_indicator.cpp:247
 msgid "Spell Points"
 msgstr "Punkty magii"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
-#: ../fheroes2/gui/interface_buttons.cpp:189
+msgid "Hero's Options"
+msgstr "Opcje bohatera"
+
 msgid "Cast Spell"
 msgstr "Rzuć zaklęcie"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
+msgid "Retreat"
+msgstr "Ucieczka"
+
+msgid "Surrender"
+msgstr "Kapitulacja"
+
+msgid "Cancel"
+msgstr "Anuluj"
+
+msgid "Hero Screen"
+msgstr "Ekran bohatera"
+
+#, fuzzy
 msgid ""
 "Cast a magical spell. You may only cast one spell per combat round. The "
-"round is reset when every creature has had a turn"
+"round is reset when every creature has had a turn."
 msgstr ""
 "Rzuć magiczne zaklęcie. Możesz rzucić tylko jeden czar na rundę walki. Runda "
 "kończy się gdy wszystkie stworzenia wykonają ruch."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:488
-msgid "Retreat"
-msgstr "Ucieczka"
-
-#: ../fheroes2/battle/battle_dialogs.cpp:488
 msgid ""
 "Retreat your hero, abandoning your creatures. Your hero will be available "
 "for you to recruit again, however, the hero will have only a novice hero's "
@@ -358,11 +320,6 @@ msgstr ""
 "Ucieczka bohatera i porzucenie wojsk. Bohatera będzie można nająć ponownie, "
 "ale będzie posiadać jedynie początkowe oddziały."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:491
-msgid "Surrender"
-msgstr "Kapitulacja"
-
-#: ../fheroes2/battle/battle_dialogs.cpp:491
 msgid ""
 "Surrendering costs gold. However if you pay the ransom, the hero and all of "
 "his or her surviving creatures will be available to recruit again."
@@ -370,315 +327,234 @@ msgstr ""
 "Za możliwość kapitulacji płaci się w złocie. Jeśli jednak zapłacisz okup, "
 "będzie można nająć ponownie zarówno bohatera jak i ocalałe jednostki."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:166
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:227
-msgid "Cancel"
-msgstr "Anuluj"
+#, fuzzy
+msgid "Open Hero Screen to view full information about the hero."
+msgstr ""
+"Pozwala osobie rzucającej zaklęcie zobaczyć szczegółowe informacje na temat "
+"herosów wroga."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
 msgid "Return to the battle."
 msgstr "Powrót na pole bitwy."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:549
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:438
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:497
 msgid "Not enough gold (%{gold})"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:564
 msgid "%{name} states:"
 msgstr "%{name} oznajmia:"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:569
+#, fuzzy
 msgid ""
-"I will accept your surrender and grant you and your troops safe passage for "
-"the price of %{price} gold."
+"\"I will accept your surrender and grant you and your troops safe passage "
+"for the price of %{price} gold.\""
 msgstr ""
-"Przystanę na Twoją propozycję i oszczędzę Ciebie oraz Twój oddział za %"
-"{price} złota."
+"Przystanę na Twoją propozycję i oszczędzę Ciebie oraz Twój oddział za "
+"%{price} złota."
 
-#: ../fheroes2/battle/battle_interface.cpp:613
-#: ../fheroes2/battle/battle_interface.cpp:1401
 msgid "View %{monster} info."
 msgstr "Informacje o jednostce: {monster}."
 
-#: ../fheroes2/battle/battle_interface.cpp:1409
 #, fuzzy
 msgid "Shoot %{monster}"
 msgstr ""
 "Mnóstwo\n"
 "%{monster}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1431
 msgid "Attack %{monster}"
 msgstr "Zaatakuj jednostkę (%{monster})"
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Fly %{monster} here."
 msgstr "Przefruń jednostką (%{monster}) tutaj."
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Move %{monster} here."
 msgstr "Przemieść jednostkę (%{monster}) tutaj."
 
-#: ../fheroes2/battle/battle_interface.cpp:1449
-#: ../fheroes2/battle/battle_interface.cpp:1538
 msgid "Turn %{turn}"
 msgstr "Tura %{turn}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1475
 msgid "Teleport Here"
 msgstr "Teleportuj w to miejsce"
 
-#: ../fheroes2/battle/battle_interface.cpp:1479
 msgid "Invalid Teleport Destination"
 msgstr "Teleportacja w to miejsce jest niemożliwa"
 
-#: ../fheroes2/battle/battle_interface.cpp:1485
 msgid "Cast %{spell} on %{monster}"
 msgstr "Rzuć zaklęcie: %{spell} na: %{monster}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1495
 msgid "Cast %{spell}"
 msgstr "Rzuć zaklęcie: %{spell}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1501
 msgid "Select Spell Target"
 msgstr "Wybierz cel zaklęcia"
 
-#: ../fheroes2/battle/battle_interface.cpp:1674
-msgid "Spell cast"
-msgstr "Zaklęcie zostało rzucone"
-
-#: ../fheroes2/battle/battle_interface.cpp:1686
 msgid "View Ballista Info"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1699
-#: ../fheroes2/battle/battle_tower.cpp:53
 msgid "Ballista"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1712
 msgid "Auto combat"
 msgstr "Automatyczna walka"
 
-#: ../fheroes2/battle/battle_interface.cpp:1719
 msgid "Customize system options."
 msgstr "Dostosuj ustawienia systemowe."
 
-#: ../fheroes2/battle/battle_interface.cpp:1727
 msgid "Wait this unit"
 msgstr "Zatrzymaj tą jednostkę"
 
-#: ../fheroes2/battle/battle_interface.cpp:1734
 msgid "Skip this unit"
 msgstr "Pomiń tę jednostkę"
 
-#: ../fheroes2/battle/battle_interface.cpp:1742
-#: ../fheroes2/battle/battle_interface.cpp:1774
-msgid "Hero's Options"
-msgstr "Opcje bohatera"
-
-#: ../fheroes2/battle/battle_interface.cpp:1753
-#: ../fheroes2/battle/battle_interface.cpp:1785
 msgid "View Opposing Hero"
 msgstr "Obejrzyj wrogiego bohatera"
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Hide logs"
 msgstr "Ukryj logi"
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Show logs"
 msgstr "Pokaż logi"
 
-#: ../fheroes2/battle/battle_interface.cpp:1878
 msgid "%{color} cast spell: %{spell}"
 msgstr "%{color} rzuconych zaklęć: %{spell}"
 
-#: ../fheroes2/battle/battle_interface.cpp:2202
 msgid "%{name} skipping turn"
 msgstr "Pomiń turę"
 
-#: ../fheroes2/battle/battle_interface.cpp:2203
-msgid ", and get +2 defense"
-msgstr "i otrzymuje +2 do obrony"
-
-#: ../fheroes2/battle/battle_interface.cpp:2206
 msgid "%{name} waiting turn"
 msgstr "%{name} czeka"
 
-#: ../fheroes2/battle/battle_interface.cpp:2343
 msgid "%{attacker} do %{damage} damage."
 msgstr "Jednostka %{attacker} zadaje %{damage} pkt. obrażeń."
 
-#: ../fheroes2/battle/battle_interface.cpp:2497
 msgid "Moved %{monster}: %{src}, %{dst}"
 msgstr "Przenieść %{monster}: %{src}, %{dst}"
 
-#: ../fheroes2/battle/battle_interface.cpp:2612
+#, fuzzy
+msgid "Moved %{monster}"
+msgstr "Przemieść jednostkę (%{monster}) tutaj."
+
 msgid "The %{name} resist the spell!"
 msgstr "%{name} odpierają zaklęcie!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2625
 msgid "%{name} casts %{spell} on the %{troop}."
 msgstr "%{name} rzuca zaklęcie '%{spell}' na: %{troop}."
 
-#: ../fheroes2/battle/battle_interface.cpp:2630
 msgid "%{name} casts %{spell}."
 msgstr "%{name} rzuca zaklęcie '%{spell}'."
 
-#: ../fheroes2/battle/battle_interface.cpp:2751
-msgid "The %{spell} spell does %{damage} damage to all undead creatures."
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to one undead creature."
 msgstr ""
 "Czar %{spell} zadaje %{damage} pkt. obrażeń wszystkim nieumarłym istotom."
 
-#: ../fheroes2/battle/battle_interface.cpp:2754
-msgid "The %{spell} spell does %{damage} damage to all living creatures."
-msgstr "%{spell} zadaje %{damage} pkt. obrażeń wszystkim żywym istotom."
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to all undead creatures."
+msgstr ""
+"Czar %{spell} zadaje %{damage} pkt. obrażeń wszystkim nieumarłym istotom."
 
-#: ../fheroes2/battle/battle_interface.cpp:2756
+#, fuzzy
+msgid "The %{spell} does %{damage} damage, %{count} creatures perish."
+msgstr ""
+"Czar %{spell} zadaje %{damage} pkt. obrażeń wszystkim nieumarłym istotom."
+
 msgid "The %{spell} does %{damage} damage."
 msgstr "%{spell} zadaje %{damage} pkt. obrażeń."
 
-#: ../fheroes2/battle/battle_interface.cpp:2797
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to one living creature."
+msgstr "%{spell} zadaje %{damage} pkt. obrażeń wszystkim żywym istotom."
+
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to all living creatures."
+msgstr "%{spell} zadaje %{damage} pkt. obrażeń wszystkim żywym istotom."
+
 msgid "The Unicorns attack blinds the %{name}!"
 msgstr "Atak jednorożców oślepia jednostkę (%{name})!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2798
 msgid "The Medusas gaze turns the %{name} to stone!"
 msgstr "Spojrzenie meduz zamienia jednostkę (%{name}) w kamień!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2800
 msgid "The Mummies' curse falls upon the %{name}!"
 msgstr "Ta jednostka (%{name}) zostaje dotknięta klątwą mumii!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2801
 msgid "The %{name} are paralyzed by the Cyclopes!"
 msgstr "Atak cyklopów paraliżuje jednostkę (%{name})!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2802
 msgid "The Archmagi dispel all good spells on your %{name}!"
 msgstr ""
-"Arcymagowie rozpraszają wszystkie korzystne zaklęcia u tej jednostki (%"
-"{name})!"
+"Arcymagowie rozpraszają wszystkie korzystne zaklęcia u tej jednostki "
+"(%{name})!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2820
-msgid "Good luck shines on the  %{attacker}"
+#, fuzzy
+msgid "Good luck shines on the %{attacker}"
 msgstr "Tej jednostce (%{attacker}) sprzyja szczęście."
 
-#: ../fheroes2/battle/battle_interface.cpp:2872
 msgid "Bad luck descends on the %{attacker}"
 msgstr "Tej jednostce (%{attacker}) nie sprzyja los."
 
-#: ../fheroes2/battle/battle_interface.cpp:2884
 msgid "High morale enables the %{monster} to attack again."
 msgstr "Wysokie morale pozwala jednostce (%{monster}) na dodatkowy atak."
 
-#: ../fheroes2/battle/battle_interface.cpp:2891
 msgid "Low morale causes the %{monster} to freeze in panic."
 msgstr "Niskie morale sprawia, że jednostka (%{monster}) zamiera w panice."
 
-#: ../fheroes2/battle/battle_interface.cpp:2944
-msgid "Tower do %{damage} damage."
+#, fuzzy
+msgid "%{tower} does %{damage} damage."
 msgstr "Wieża zadaje %{damage} pkt. obrażeń."
 
-#: ../fheroes2/battle/battle_interface.cpp:3257
 msgid "MirrorImage created"
 msgstr "Stworzono lustrzane odbicie"
 
-#: ../fheroes2/battle/battle_interface.cpp:3798
-msgid "MirrorImage ended"
-msgstr "Zakończono odbicie lustrzane"
+msgid "The mirror image is destroyed!"
+msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4089
 #, fuzzy
 msgid "Break auto battle?"
 msgstr "Włącz automatyczną walkę"
 
-#: ../fheroes2/battle/battle_interface.cpp:4138
 msgid "No spells to cast."
 msgstr "Brak zaklęć."
 
-#: ../fheroes2/battle/battle_interface.cpp:4147
 msgid "Are you sure you want to retreat?"
 msgstr "Czy na pewno chcesz się wycofać?"
 
-#: ../fheroes2/battle/battle_interface.cpp:4155
 #, fuzzy
 msgid "Retreat disabled"
 msgstr "Ucieczka"
 
-#: ../fheroes2/battle/battle_interface.cpp:4169
-msgid "You don't have enough gold!"
-msgstr "Nie posiadasz tyle złota!"
-
-#: ../fheroes2/battle/battle_interface.cpp:4180
 #, fuzzy
 msgid "Surrender disabled"
 msgstr "Kapitulacja"
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{max}"
 msgstr "Uszkodzenia: %{max}"
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{min} - %{max}"
 msgstr "Uszkodzenia: %{min} - %{max}"
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{max}"
 msgstr "Zabici: %{max}"
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{min} - %{max}"
 msgstr "Zabici: %{min} - %{max}"
 
-#: ../fheroes2/battle/battle_main.cpp:190
-msgid "You have captured an enemy artifact!"
-msgstr "Udało ci się zdobyć artfeakt przeciwnika!"
-
-#: ../fheroes2/battle/battle_main.cpp:241
 msgid ""
-"Through eagle-eyed observation, %{name} is able to learn the magic spell %"
-"{spell}."
+"Through eagle-eyed observation, %{name} is able to learn the magic spell "
+"%{spell}."
 msgstr ""
 "Dzięki swemu sokolemu wzrokowi, %{name} może nauczyć się zaklęcia '%{spell}'."
 
-#: ../fheroes2/battle/battle_main.cpp:280
-msgid ""
-"Practicing the dark arts of necromancy, you are able to raise %{count} of "
-"the enemy's dead to return under your service as %{monster}"
-msgstr ""
-"Korzystając z mrocznej sztuki nekromancji, ożywiasz %{count} martwych "
-"przeciwników i wcielasz ich do swojej armii jako %{monster}."
-
-#: ../fheroes2/battle/battle_tower.cpp:47 ../fheroes2/castle/castle.cpp:466
 msgid "Left Turret"
 msgstr "Lewa wieżyczka"
 
-#: ../fheroes2/battle/battle_tower.cpp:48 ../fheroes2/castle/castle.cpp:467
 msgid "Right Turret"
 msgstr "Prawa wieżyczka"
 
-#: ../fheroes2/battle/battle_tower.cpp:115
 msgid "The %{name} fires with the strength of %{count} Archers"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:116
 msgid "each with a +%{attack} bonus to their attack skill."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:863
-msgid "%{name} half the enemy troops!"
-msgstr "%{name} Połowa żołnierzy wroga!"
-
-#: ../fheroes2/battle/battle_troop.cpp:950
 msgid ""
 "The %{artifact} artifact is in effect for this battle, disabling %{spell} "
 "spell."
@@ -686,391 +562,767 @@ msgstr ""
 "W czasie bitwy działa artefakt o nazwie %{artifact}, uniemożliwiający "
 "rzucenie czaru %{spell}."
 
-#: ../fheroes2/battle/battle_troop.cpp:1598
 msgid "%{count} %{name} rise(s) from the dead!"
 msgstr "%{count} %{name} powstaje z martwych!"
 
-#: ../fheroes2/castle/buildinginfo.cpp:258
+#, fuzzy
+msgid "Sorceress Guild"
+msgstr "Czarodziejka"
+
+#, fuzzy
+msgid "Necromancer Guild"
+msgstr "Nekromanta"
+
+#, fuzzy
+msgid "Dragon Alliance"
+msgstr "Zerwany sojusz"
+
+#, fuzzy
+msgid "Elven Alliance"
+msgstr "Zerwany sojusz"
+
+msgid "Wayward Son"
+msgstr ""
+
+msgid "Uncle Ivan"
+msgstr "Wuj Ivan"
+
+msgid "Force of Arms"
+msgstr ""
+
+#, fuzzy
+msgid "Annexation"
+msgstr "\"Annexation\""
+
+#, fuzzy
+msgid "Save the Dwarves"
+msgstr "Krasnoludzcy wojownicy"
+
+#, fuzzy
+msgid "Carator Mines"
+msgstr "Kopalnie Caratora"
+
+#, fuzzy
+msgid "Turning Point"
+msgstr "Faktoria handlowa"
+
+msgid "The Gauntlet"
+msgstr ""
+
+#, fuzzy
+msgid "The Crown"
+msgstr "Przesieka"
+
+#, fuzzy
+msgid "Corlagon's Defense"
+msgstr "Corlagon"
+
+msgid "Final Justice"
+msgstr ""
+
+msgid "First Blood"
+msgstr ""
+
+#, fuzzy
+msgid "Barbarian Wars"
+msgstr "Barbarzyńca"
+
+#, fuzzy
+msgid "Necromancers"
+msgstr "Nekromanta"
+
+#, fuzzy
+msgid "Slay the Dwarves"
+msgstr "Krasnoludzcy wojownicy"
+
+msgid "Rebellion"
+msgstr ""
+
+#, fuzzy
+msgid "Dragon Master"
+msgstr "Władca Smoków"
+
+#, fuzzy
+msgid "Country Lords"
+msgstr "Kraina Władców"
+
+#, fuzzy
+msgid "Greater Glory"
+msgstr "Wielki druid"
+
+#, fuzzy
+msgid "Apocalypse"
+msgstr "Apokalipsa"
+
+msgid "Uprising"
+msgstr ""
+
+msgid "Island of Chaos"
+msgstr ""
+
+msgid "Arrow's Flight"
+msgstr ""
+
+msgid "The Abyss"
+msgstr ""
+
+msgid "The Giant's Pass"
+msgstr ""
+
+msgid "Aurora Borealis"
+msgstr ""
+
+#, fuzzy
+msgid "Betrayal's End"
+msgstr "Zdrada!"
+
+#, fuzzy
+msgid "Corruption's Heart"
+msgstr "Kwatera kapitana"
+
+msgid "Conquer and Unify"
+msgstr ""
+
+#, fuzzy
+msgid "Border Towns"
+msgstr "Borderlands"
+
+msgid "The Wayward Son"
+msgstr ""
+
+#, fuzzy
+msgid "Crazy Uncle Ivan"
+msgstr "Wuj Ivan"
+
+#, fuzzy
+msgid "The Southern War"
+msgstr "Druga Strona"
+
+msgid "Ivory Gates"
+msgstr ""
+
+#, fuzzy
+msgid "The Elven Lands"
+msgstr "Siedem Jezior"
+
+msgid "The Epic Battle"
+msgstr ""
+
+msgid "The Shrouded Isles"
+msgstr ""
+
+msgid "The Eternal Scrolls"
+msgstr ""
+
+#, fuzzy
+msgid "Power's End"
+msgstr "Pierścień mocy"
+
+#, fuzzy
+msgid "Fount of Wizardry"
+msgstr "Kostur czarodziejstwa"
+
+msgid "Stranded"
+msgstr ""
+
+msgid "Pirate Isles"
+msgstr ""
+
+msgid "King and Country"
+msgstr ""
+
+msgid "Blood is Thicker"
+msgstr ""
+
+msgid ""
+"Roland needs you to defeat the lords near his castle to begin his war of "
+"rebellion against his brother.  They are not allied with each other, so they "
+"will spend most of their time fighting with one another.  Victory is yours "
+"when you have defeated all of their castles and heroes."
+msgstr ""
+
+msgid ""
+"The local lords refuse to swear allegiance to Roland, and must be subdued. "
+"They are wealthy and powerful, so be prepared for a tough fight. Capture all "
+"enemy castles to win."
+msgstr ""
+
+msgid ""
+"Your task is to defend the Dwarves against Archibald's forces. Capture all "
+"of the enemy towns and castles to win, and be sure not to lose all of the "
+"dwarf towns at once, or the enemy will have won."
+msgstr ""
+
+msgid ""
+"You will face four allied enemies in a straightforward fight for resource "
+"and treasure. Capture all of the enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Your enemies are allied against you and start close by, so be ready to come "
+"out fighting. You will need to own all four castles in this small valley to "
+"win."
+msgstr ""
+
+msgid ""
+"The Sorceress' guild of Noraston has requested Roland's aid against an "
+"attack from Archibald's allies. Capture all of the enemy castles to win, and "
+"don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy "
+"castle on an island in the ocean.)"
+msgstr ""
+
+msgid ""
+"Gather as large an army as possible and capture the enemy castle within 8 "
+"weeks. You are opposed by only one enemy, but must travel a long way to get "
+"to the enemy castle. Any troops you have in your army at the end of this "
+"scenario will be with you in the final battle."
+msgstr ""
+
+msgid ""
+"Find the Crown before Archibald's heroes find it. Roland will need the Crown "
+"for the final battle against Archibald."
+msgstr ""
+
+msgid ""
+"Three allied enemies stand before you and victory, including Lord Corlagon. "
+"Roland is in a castle to the northwest, and you will lose if he falls to the "
+"enemy. Remember that capturing Lord Corlagon will ensure that he will not "
+"fight against you in the final scenario."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Archibald to end the war!"
+msgstr ""
+
+msgid ""
+"King Archibald requires you to defeat the three enemies in this region.  "
+"They are not allied with one another, so they will spend most of their "
+"energy fighting amongst themselves.  You will win when you own all of the "
+"enemy castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"You must unify the barbarian tribes of the north by conquering them. As in "
+"the previous mission, the enemy is not allied against you, but they have "
+"more resources at their disposal. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"Do-gooder wizards have taken the Necromancers' castle. You must retake it to "
+"achieve victory. Remember that while you start with a powerful army, you "
+"have no castle and must take one within 7 days, or lose this battle. (Hint: "
+"The nearest castle is to the southeast.)"
+msgstr ""
+
+msgid ""
+"The dwarves need conquering before they can interfere in King Archibald's "
+"plans. Roland's forces have more than one hero and many towns to start with, "
+"so be ready for attack from multiple directions. You must capture all of the "
+"enemy towns and castles to claim victory."
+msgstr ""
+
+msgid ""
+"You must put down a peasant revolt led by Roland's forces. All are allied "
+"against you, but you have Lord Corlagon, an experienced hero, to help you. "
+"Capture all enemy castles to win."
+msgstr ""
+
+msgid ""
+"There are two enemies allied against you in this mission. Both are well "
+"armed and seek to evict you from their island. Avoid them and capture Dragon "
+"City to win"
+msgstr ""
+
+msgid ""
+"Your orders are to conquer the country lords that have sworn to serve "
+"Roland. All of the enemy castles are unified against you. Since you start "
+"without a castle, you must hurry to capture one before the end of the week. "
+"Capture all enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Find the Crown before Roland's heroes find it. Archibald will need the Crown "
+"for the final battle against Roland."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Roland to win the war, and be sure "
+"not to lose Archibald in the fight!"
+msgstr ""
+
+msgid ""
+"Subdue the unruly local lords in order to provide the Empire with facilities "
+"to operate in this region."
+msgstr ""
+
+msgid ""
+"Eliminate all oposition in this area. Then the first piece of the artifact "
+"will be yours."
+msgstr ""
+
+msgid ""
+"The sorceresses to the northeast are rebelling! For the good of the empire "
+"you must quash their feeble uprising on your way to the mountains."
+msgstr ""
+
+msgid ""
+"Having prepared for your arrival, Kraeger has arranged for a force of "
+"necromancers to thwart your quest. You must capture the castle of Scabsdale "
+"before the first day of the third week, or the Necromancers will be too "
+"strong for you."
+msgstr ""
+
+msgid ""
+"The barbarian despot in this area is, as yet, ignorant of your presence. "
+"Quickly, build up your forces before you are discovered and attacked! Secure "
+"the region by subduing all enemy forces."
+msgstr ""
+
+msgid ""
+"The Empire is weak in this region. You will be unable to completely subdue "
+"all forces in this area, so take what you can before reprisal strikes. "
+"Remember, your true goal is to claim the Helmet of Anduran."
+msgstr ""
+
+msgid "For the good of the Empire, eliminate Kraeger."
+msgstr ""
+
+msgid ""
+"At last, you have the opportunity and the facilities to rid the Empire of "
+"the necromancer's evil. Eradicate them completely, and you will be sung as a "
+"hero for all time."
+msgstr ""
+
+msgid ""
+"Conquer and unite all the enemy tribes. Don't lose the hero Jarkonas, the "
+"forefather of all descendants."
+msgstr ""
+
+msgid ""
+"Your rival, the Kingdom of Harondale, is attacking weak towns on your "
+"border! Recover from their first strike and crush them completely!"
+msgstr ""
+
+msgid ""
+"Find your wayward son Joseph who is rumored to be living in the desolate "
+"lands. Do it before the first day of the third month or it will be of no "
+"help to your family."
+msgstr ""
+
+msgid ""
+"Rescue your crazy uncle Ivan. Find him before the first day of the fourth "
+"month or it will be no help to your kingdom."
+msgstr ""
+
+msgid ""
+"Destroy the barbarians who are attacking the southern border of your "
+"kingdom! Recover your fallen towns, and then invade the jungle kingdom. "
+"Leave no enemy standing."
+msgstr ""
+
+msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
+msgstr ""
+
+msgid ""
+"Gain the favor of the elves. They will not allow trees to be chopped down, "
+"so they will send you wood every 2 weeks. You must complete your mission "
+"before the first day of the seventh month, or the kingdom will surely fall."
+msgstr ""
+
+msgid ""
+"This is the final battle against your rival kingdom of Harondale. Eliminate "
+"everyone, and don't lose the hero Jarkonas VI."
+msgstr ""
+
+msgid ""
+"Your mission is to vanquish the warring mages in the magical Shrouded Isles. "
+"The completion of this task will give you a fighting chance against your "
+"rivals."
+msgstr ""
+
+msgid ""
+"The location of the great library has been dicovered! You must make your way "
+"to it, and reclaim the city of Chronos in which it lies."
+msgstr ""
+
+msgid ""
+"Find the Orb of negation, which is said to be buried in this land. There are "
+"clues inscribed on stone obelisks which will help lead you to your price. "
+"Find the orb before the first day of the sixth month, or your rivals will "
+"surely have gotten to the fount before you."
+msgstr ""
+
+msgid ""
+"You must take control of the castle of Magic, where the fount of wizardry "
+"lies. Do this and your victory will be supreme."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Capture the town on the island off the southeast shore in order to construct "
+"a boat and travel back towards the mainland. Do not lose the hero Gallavant."
+msgstr ""
+"Przejmij miasto na wyspie południowo-wschodniego wybrzeża aby zbudować łódź "
+"i wrócić z powrotem na ląd."
+
+msgid ""
+"Find and defeat Martine, the pirate leader, who resides in Pirates Cove. Do "
+"not lose Gallavant or your quest will be over."
+msgstr ""
+
+msgid ""
+"Eliminate all the other forces who oppose the rule of Lord Alberon. "
+"Gallavant must not die."
+msgstr ""
+
+msgid ""
+"Overthrow the entrenched monarchy of Lord Alberon, and claim all the land in "
+"your name. Gallavant must not die."
+msgstr ""
+
+msgid " bane"
+msgstr ""
+
+#, fuzzy
+msgid " alliance"
+msgstr "Zerwany sojusz"
+
+msgid "Carry-over forces"
+msgstr ""
+
+msgid " bonus"
+msgstr ""
+
+msgid " defeated"
+msgstr ""
+
+#, fuzzy
+msgid "Thunder Mace"
+msgstr "Grzmiąca maczuga dominium"
+
+#, fuzzy
+msgid "Minor Scroll"
+msgstr "Pomniejszy zwój wiedzy"
+
+#, fuzzy
+msgid "Dragon Sword"
+msgstr "Zabójca smoków"
+
+#, fuzzy
+msgid "Breastplate"
+msgstr "Napierśnik Andurana"
+
+msgid "Fibzin Medal"
+msgstr ""
+
+#, fuzzy
+msgid "Mage's ring"
+msgstr "Pierścień mocy maga"
+
+#, fuzzy
+msgid "Defender Helm"
+msgstr "Obrońca"
+
+#, fuzzy
+msgid "Power Axe"
+msgstr "Moc"
+
+#, fuzzy
+msgid "Summon Earth"
+msgstr "Przywołanie łodzi"
+
 msgid "The %{building} produces %{monster}."
 msgstr "%{building} - tu rekrutuje się: %{monster}."
 
-#: ../fheroes2/castle/buildinginfo.cpp:505
 msgid "Requires:"
 msgstr "Wymagania:"
 
-#: ../fheroes2/castle/buildinginfo.cpp:597
 msgid "Cannot build. Already built here this turn."
 msgstr "Nie można budować. Już to robiono w tej turze."
 
-#: ../fheroes2/castle/buildinginfo.cpp:601
 msgid "For this action it is necessary first to build a castle."
 msgstr "Najpierw trzeba zbudować zamek."
 
-#: ../fheroes2/castle/buildinginfo.cpp:623
 msgid "Cannot build %{name} because castle is too far from water."
 msgstr "%{name} - nie można zbudować, zamek jest za daleko od wody"
 
-#: ../fheroes2/castle/buildinginfo.cpp:631
-msgid "Cannot afford %{name}"
+#, fuzzy
+msgid "Cannot afford %{name}."
 msgstr "%{name} - nie stać cię na ten budynek"
 
-#: ../fheroes2/castle/buildinginfo.cpp:636
-msgid "%{name} is already built"
+#, fuzzy
+msgid "%{name} is already built."
 msgstr "%{name} - ten budynek został już wzniesiony"
 
-#: ../fheroes2/castle/buildinginfo.cpp:641
-msgid "Cannot build %{name}"
+#, fuzzy
+msgid "Cannot build %{name}."
 msgstr "%{name} - nie można zbudować"
 
-#: ../fheroes2/castle/buildinginfo.cpp:646
-msgid "Build %{name}"
+#, fuzzy
+msgid "Build %{name}."
 msgstr "Zbuduj: %{name}"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Thieves' Guild"
 msgstr "Gildia złodziei"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Tavern"
 msgstr "Karczma"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Shipyard"
 msgstr "Stocznia"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Well"
 msgstr "Studnia"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Statue"
 msgstr "Statua"
 
-#: ../fheroes2/castle/castle.cpp:467
-#: ../fheroes2/dialog/dialog_marketplace.cpp:212
 msgid "Marketplace"
 msgstr "Targowisko"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Moat"
 msgstr "Fosa"
 
-#: ../fheroes2/castle/castle.cpp:467 ../fheroes2/maps/mp2.cpp:391
 msgid "Castle"
 msgstr "Zamek"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Tent"
 msgstr "Namiot"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Captain's Quarters"
 msgstr "Kwatera kapitana"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Mage Guild, Level 1"
 msgstr "Gildia magów, poz. 1"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 2"
 msgstr "Gildia magów, poz. 2"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 3"
 msgstr "Gildia magów, poz. 3"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 4"
 msgstr "Gildia magów, poz. 4"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 5"
 msgstr "Gildia magów, poz. 5"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Farm"
 msgstr "Farma"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Garbage Heap"
 msgstr "Sterta śmieci"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Crystal Garden"
 msgstr "Kryształowy ogród"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Waterfall"
 msgstr "Wodospad"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Orchard"
 msgstr "Sad"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Skull Pile"
 msgstr "Stos czaszek"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Fortifications"
 msgstr "Fortyfikacje"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Coliseum"
 msgstr "Koloseum"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Rainbow"
 msgstr "Tęcza"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Dungeon"
 msgstr "Loch"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Library"
 msgstr "Biblioteka"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Storm"
 msgstr "Wieczna burza"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:498
 msgid "Thatched Hut"
 msgstr "Chata kryta słomą"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Hut"
 msgstr "Chata"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Treehouse"
 msgstr "Dom na drzewie"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:441
 msgid "Cave"
 msgstr "Jaskinia"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Habitat"
 msgstr "Pagórek"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:431
 msgid "Excavation"
 msgstr "Wykopalisko"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:477
 msgid "Archery Range"
 msgstr "Tor strzelecki"
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Stick Hut"
 msgstr "Chata z patyków"
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Cottage"
 msgstr "Domek"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Crypt"
 msgstr "Krypta"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Pen"
 msgstr "Zagroda"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/maps/mp2.cpp:371
 msgid "Graveyard"
 msgstr "Cmentarz"
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Blacksmith"
 msgstr "Kuźnia"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Den"
 msgstr "Legowisko"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Nest"
 msgstr "Gniazdo"
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Foundry"
 msgstr "Odlewnia"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:480
-#: ../fheroes2/castle/castle.cpp:487 ../fheroes2/maps/mp2.cpp:427
-#: ../fheroes2/resource/maps_text.cpp:521
 msgid "Pyramid"
 msgstr "Piramida"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Armory"
 msgstr "Zbrojownia"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Adobe"
 msgstr "Lepianka"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Stonehenge"
 msgstr "Kamienny krąg"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Maze"
 msgstr "Labirynt"
 
-#: ../fheroes2/castle/castle.cpp:478 ../fheroes2/castle/castle.cpp:485
 msgid "Cliff Nest"
 msgstr "Gniazdo na urwisku"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Mansion"
 msgstr "Posiadłość"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Jousting Arena"
 msgstr "Plac turniejowy"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Bridge"
 msgstr "Most"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
 msgid "Fenced Meadow"
 msgstr "Ogrodzona łąka"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Swamp"
 msgstr "Bagno"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Ivory Tower"
 msgstr "Wieża z kości słoniowej"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Mausoleum"
 msgstr "Mauzoleum"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cathedral"
 msgstr "Katedra"
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Red Tower"
 msgstr "Czerwona wieża"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Green Tower"
 msgstr "Zielona wieża"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cloud Castle"
 msgstr "Zamek w chmurach"
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Laboratory"
 msgstr "Laboratorium"
 
-#: ../fheroes2/castle/castle.cpp:483 ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Archery Range"
 msgstr "Rozb. tor strzelecki"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Stick Hut"
 msgstr "Rozb. chata z patyków"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Cottage"
 msgstr "Rozb. domek"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Graveyard"
 msgstr "Rozb. cmentarz"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Blacksmith"
 msgstr "Rozb. kuźnia"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Foundry"
 msgstr "Rozb. odlewnia"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Pyramid"
 msgstr "Rozb. piramida"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Armory"
 msgstr "Rozb. zbrojownia"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Adobe"
 msgstr "Rozb. lepianka"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Stonehenge"
 msgstr "Rozb. kammienny krąg"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Maze"
 msgstr "Rozb. labirynt"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Mansion"
 msgstr "Rozb. posiadłość"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Jousting Arena"
 msgstr "Rozb. plac turniejowy"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Bridge"
 msgstr "Rozb. most"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Ivory Tower"
 msgstr "Rozb. wieża"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Mausoleum"
 msgstr "Rozb. mauzoleum"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cathedral"
 msgstr "Rozb. katedra"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cloud Castle"
 msgstr "Rozb. zamek w chmurach"
 
-#: ../fheroes2/castle/castle.cpp:488
 msgid "Black Tower"
 msgstr "Czarna wieża"
 
-#: ../fheroes2/castle/castle.cpp:490
 msgid "Shrine"
 msgstr "Kapliczka"
 
-#: ../fheroes2/castle/castle.cpp:552
+#, fuzzy
 msgid ""
 "The Thieves' Guild provides information on enemy players. Thieves' Guilds "
-"can also provide scouting information on enemy towns."
+"can also provide scouting information on enemy towns. Additional Guilds "
+"provide more information."
 msgstr ""
 "Gildia Złodziei dostarcza dane na temat wrogich graczy, a także ich miast. "
 "Dodatkowe gildie rozszerzają zakres podawanych informacji."
 
-#: ../fheroes2/castle/castle.cpp:553
 msgid "The Tavern increases morale for troops defending the castle."
 msgstr "Karczma zwiększa morale oddziałów broniących zamku."
 
-#: ../fheroes2/castle/castle.cpp:554
 msgid "The Shipyard allows ships to be built."
 msgstr "W stoczni można budować statki."
 
-#: ../fheroes2/castle/castle.cpp:555
 msgid ""
 "The Well increases the growth rate of all dwellings by %{count} creatures "
 "per week."
@@ -1078,21 +1330,17 @@ msgstr ""
 "Studnia zwiększa przyrost populacji wszystkich stworzeń o 2 jednostki "
 "tygodniowo."
 
-#: ../fheroes2/castle/castle.cpp:556
 msgid "The Statue increases your town's income by %{count} per day."
 msgstr "Statua zwiększa dzienny przychód miasta o %{count} sztuk złota."
 
-#: ../fheroes2/castle/castle.cpp:557
 msgid "The Left Turret provides extra firepower during castle combat."
 msgstr ""
 "Lewa wieżyczka zwiększa możliwość ostrzału wroga podczas oblężenia zamku."
 
-#: ../fheroes2/castle/castle.cpp:558
 msgid "The Right Turret provides extra firepower during castle combat."
 msgstr ""
 "Prawa wieżyczka zwiększa możliwość ostrzału wroga podczas oblężenia zamku."
 
-#: ../fheroes2/castle/castle.cpp:559
 msgid ""
 "The Marketplace can be used to convert one type of resource into another. "
 "The more marketplaces you control, the better the exchange rate."
@@ -1100,7 +1348,6 @@ msgstr ""
 "Targowisko pozwala na wymianę jednego typu surowca na inny. Im więcej "
 "targowisk posiadasz tym lepszy kurs wymiany."
 
-#: ../fheroes2/castle/castle.cpp:560
 msgid ""
 "The Moat slows attacking units. Any unit entering the moat must end its turn "
 "there and becomes more vulnerable to attack."
@@ -1108,7 +1355,6 @@ msgstr ""
 "Fosa spowalnia atakujące jednostki. Każdy oddział, który wejdzie do fosy, "
 "musi się w niej zatrzymać i staje się mniej odporny ma ataki."
 
-#: ../fheroes2/castle/castle.cpp:561
 msgid ""
 "The Castle improves town defense and increases income to %{count} gold per "
 "day."
@@ -1116,7 +1362,6 @@ msgstr ""
 "Zamek poprawia obronę miasta i zwiększa dzienny przychód o %{count} sztuk "
 "złota."
 
-#: ../fheroes2/castle/castle.cpp:562
 msgid ""
 "The Tent provides workers to build a castle, provided the materials and the "
 "gold are available."
@@ -1124,7 +1369,6 @@ msgstr ""
 "W namiocie mieszkają robotnicy mogący zbudować zamek, pod warunkiem, że "
 "dostępne jest złoto i inne potrzebne materiały."
 
-#: ../fheroes2/castle/castle.cpp:563
 msgid ""
 "The Captain's Quarters provides a captain to assist in the castle's defense "
 "when no hero is present."
@@ -1132,39 +1376,31 @@ msgstr ""
 "W kwaterze mieszka kapitan, który dowodzi obroną zamku gdy nie ma w nim "
 "bohatera."
 
-#: ../fheroes2/castle/castle.cpp:564
 msgid ""
 "The Mage Guild allows heroes to learn spells and replenish their spell "
 "points."
 msgstr ""
 "W gildii magów bohaterowie mogą uczyć się zaklęć i odzyskiwać punkty magii."
 
-#: ../fheroes2/castle/castle.cpp:567
 msgid "The Farm increases production of Peasants by %{count} per week."
 msgstr "Farma zwiększa przyrost Chłopów o %{count} tygodniowo."
 
-#: ../fheroes2/castle/castle.cpp:568
 msgid "The Garbage Heap increases production of Goblins by %{count} per week."
 msgstr "Sterta śmieci zwiększa przyrost Goblinów o %{count} tygodniowo."
 
-#: ../fheroes2/castle/castle.cpp:569
 msgid ""
 "The Crystal Garden increases production of Sprites by %{count} per week."
 msgstr "Kryształowy ogród zwiększa przyrost Rusałek o %{count} tygodniowo."
 
-#: ../fheroes2/castle/castle.cpp:570
 msgid "The Waterfall increases production of Centaurs by %{count} per week."
 msgstr "Wodospad zwiększa przyrost Centaurów o %{count} tygodniowo."
 
-#: ../fheroes2/castle/castle.cpp:571
 msgid "The Orchard increases production of Halflings by %{count} per week."
 msgstr "Sad zwiększa przyrost Niziołków o %{count} tygodniowo."
 
-#: ../fheroes2/castle/castle.cpp:572
 msgid "The Skull Pile increases production of Skeletons by %{count} per week."
 msgstr "Stos czaszek zwiększa przyrost Szkieletów o %{count} tygodniowo."
 
-#: ../fheroes2/castle/castle.cpp:575
 msgid ""
 "The Fortifications increase the toughness of the walls, increasing the "
 "number of turns it takes to knock them down."
@@ -1172,7 +1408,6 @@ msgstr ""
 "Fortyfikacje wzmacniają mury, sprawiając, że ich zniszczenie zajmuje więcej "
 "czasu."
 
-#: ../fheroes2/castle/castle.cpp:576
 msgid ""
 "The Coliseum provides inspiring spectacles to defending troops, raising "
 "their morale by two during combat."
@@ -1180,15 +1415,12 @@ msgstr ""
 "W Koloseum pokazywane są przedstawienia dla oddziałów obrońców, co o dwa "
 "punkty zwiększa ich morale w walce."
 
-#: ../fheroes2/castle/castle.cpp:577
 msgid "The Rainbow increases the luck of the defending units by two."
 msgstr "Tęcza zwiększa szczęście oddziałów obrońców o dwa punkty."
 
-#: ../fheroes2/castle/castle.cpp:578
 msgid "The Dungeon increases the income of the town by %{count} / day."
 msgstr "Loch zwiększa dochody miasta o %{count} sztuk złota na dzień."
 
-#: ../fheroes2/castle/castle.cpp:579
 msgid ""
 "The Library increases the number of spells in the Guild by one for each "
 "level of the guild."
@@ -1196,11 +1428,9 @@ msgstr ""
 "Biblioteka zwiększa liczbę zaklęć dostępnych w gildii o jedno na każdy jej "
 "poziom."
 
-#: ../fheroes2/castle/castle.cpp:580
 msgid "The Storm adds +2 to the power of spells of a defending spell caster."
 msgstr "Wieczna burza dodaje +2 do mocy zaklęć obrońcy zamku."
 
-#: ../fheroes2/castle/castle.cpp:582
 msgid ""
 "The Shrine increases the necromancy skill of all your necromancers by 10 "
 "percent."
@@ -1208,123 +1438,114 @@ msgstr ""
 "Kapliczka zwiększa o 10 procent umiejętność nekromancji u wszystkich twoich "
 "nekromantów."
 
-#: ../fheroes2/castle/castle.cpp:632
 msgid "Cannot recruit - you already recruit hero in current week."
 msgstr "Nie możesz rekrutować - w tym tygodniu wynająłeś już nowego bohatera"
 
-#: ../fheroes2/castle/castle.cpp:645
 #, fuzzy
 msgid "Cannot recruit - guest to guard automove error."
 msgstr "Nie możesz rekrutować - masz za dużo bohaterów."
 
-#: ../fheroes2/castle/castle.cpp:651
 msgid "Cannot recruit - you already have a Hero in this town."
 msgstr "Nie możesz rekrutować - w mieście jest już bohater."
 
-#: ../fheroes2/castle/castle.cpp:659
 msgid "Cannot recruit - you have too many Heroes."
 msgstr "Nie możesz rekrutować - masz za dużo bohaterów."
 
-#: ../fheroes2/castle/castle.cpp:665
 msgid "Cannot afford a Hero"
 msgstr "Nie stać cię na bohatera."
 
-#: ../fheroes2/castle/castle.cpp:756
 msgid "There is no room in the garrison for this army."
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:272
+msgid "Recruit %{name}"
+msgstr "Rekrutuj: %{name}"
+
 msgid "Month: %{month}, Week: %{week}, Day: %{day}"
 msgstr "Miesiąc: %{month}, Tydzień: %{week}, Dzień: %{day}"
 
-#: ../fheroes2/castle/castle_dialog.cpp:393
-#: ../fheroes2/castle/castle_dialog.cpp:396
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:387
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:186
-msgid "Income:"
+#, fuzzy
+msgid "Income"
 msgstr "Przychód:"
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 #, fuzzy
 msgid "Join Error"
 msgstr "Błąd"
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 msgid "Army is full"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
+msgid ""
+"You must purchase a spell book to use the mage guild, but you currently have "
+"no room for a spell book. Try giving one of your artifacts to another hero."
+msgstr ""
+"Aby korzystać z gildii magów, musisz kupić księgę czarów. W tej chwili nie "
+"masz jednak na nią miejsca. Spróbuj przekazać jeden ze swoich artefaktów "
+"innemu bohaterowi."
+
 msgid "Town"
 msgstr "Miasto"
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
 msgid "This town may not be upgraded to a castle."
 msgstr "Tego miasta nie można rozbudować do poziomu zamku."
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit castle"
+#, fuzzy
+msgid "Exit Castle"
 msgstr "Wyjście z zamku"
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit town"
+#, fuzzy
+msgid "Exit Town"
 msgstr "Wyjście z miasta"
 
-#: ../fheroes2/castle/castle_dialog.cpp:730
 #, fuzzy
-msgid "Show income"
+msgid "Show Income"
 msgstr "Pokaż logi"
 
-#: ../fheroes2/castle/castle_dialog.cpp:734
 msgid "Show previous town"
 msgstr "Pokaż poprzednie miasto"
 
-#: ../fheroes2/castle/castle_dialog.cpp:738
 msgid "Show next town"
 msgstr "Pokaż następne miasto"
 
-#: ../fheroes2/castle/castle_dialog.cpp:741
 msgid "Swap Heroes"
 msgstr "Zamień bohaterów"
 
-#: ../fheroes2/castle/castle_dialog.cpp:744
 msgid "Meeting Heroes"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:749
 msgid "View Hero"
 msgstr "Pokaż bohatera"
 
-#: ../fheroes2/castle/castle_mageguild.cpp:150
+#, fuzzy
+msgid "The above spells are available here."
+msgstr "Powyższe zaklęcia zostały dodane do twojej księgi."
+
 msgid "The above spells have been added to your book."
 msgstr "Powyższe zaklęcia zostały dodane do twojej księgi."
 
-#: ../fheroes2/castle/castle_tavern.cpp:39
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:748
 msgid "A generous tip for the barkeep yields the following rumor:"
 msgstr ""
 "Dajesz karczmarzowi szczodry napiwek, a on w zamian przekazuje ci "
 "następujące wieści:"
 
-#: ../fheroes2/castle/castle_town.cpp:54
 msgid "Recruit Hero"
 msgstr "Najmij bohatera"
 
-#: ../fheroes2/castle/castle_town.cpp:59
-msgid "%{name} is a level %{value} %{race}"
+#, fuzzy
+msgid "%{name} is a level %{value} %{race} "
 msgstr "%{name} ma poziom %{value}. To %{race}"
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with %{count} artifacts"
+#, fuzzy
+msgid "with %{count} artifacts."
 msgstr " z %{count} artefaktami"
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with one artifact"
+#, fuzzy
+msgid "with 1 artifact."
 msgstr " z jednym artefaktem"
 
-#: ../fheroes2/castle/castle_town.cpp:283
-#: ../fheroes2/heroes/heroes_dialog.cpp:108
+#, fuzzy
+msgid "without artifacts."
+msgstr " z %{count} artefaktami"
+
 msgid ""
 "'Spread' combat formation spreads your armies from the top to the bottom of "
 "the battlefield, with at least one empty space between each army."
@@ -1332,7 +1553,6 @@ msgstr ""
 "Wybór luźnej formacji oznacza, że twoja wojska będą stać rozproszone wzdłuż "
 "pola bitwy, a pomiędzy oddziałami będzie przynajmniej jedno wolne pole."
 
-#: ../fheroes2/castle/castle_town.cpp:284
 msgid ""
 "'Grouped' combat formation bunches your army toget her in the center of your "
 "side of the battlefield."
@@ -1340,101 +1560,80 @@ msgstr ""
 "Wybór zwartej formacji sprawia, że twoja armia zbierze się razem pośrodku "
 "twojej części pola bitwy."
 
-#: ../fheroes2/castle/castle_town.cpp:292
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:132
-#: ../fheroes2/heroes/heroes_meeting.cpp:284
 msgid "Attack Skill"
 msgstr "Atak"
 
-#: ../fheroes2/castle/castle_town.cpp:301
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:137
-#: ../fheroes2/heroes/heroes_meeting.cpp:288
 msgid "Defense Skill"
 msgstr "Obrona"
 
-#: ../fheroes2/castle/castle_town.cpp:487
-#: ../fheroes2/heroes/heroes_dialog.cpp:334
 msgid "Spread Formation"
 msgstr "Luźna formacja"
 
-#: ../fheroes2/castle/castle_town.cpp:489
-#: ../fheroes2/heroes/heroes_dialog.cpp:337
 msgid "Grouped Formation"
 msgstr "Zwarta formacja"
 
-#: ../fheroes2/castle/castle_town.cpp:540
-#: ../fheroes2/castle/castle_town.cpp:553
 msgid "Recruit %{name} the %{race}"
 msgstr "Rekrutuj: %{name} %{race}"
 
-#: ../fheroes2/castle/castle_town.cpp:561
 msgid "Set garrison combat formation to 'Spread'"
 msgstr "Ustaw szyk garnizonu na 'luźny'"
 
-#: ../fheroes2/castle/castle_town.cpp:564
 msgid "Set garrison combat formation to 'Grouped'"
 msgstr "Ustaw szyk garnizonu na 'zwarty'"
 
-#: ../fheroes2/castle/castle_town.cpp:567
+#, fuzzy
+msgid "Exit Castle Options"
+msgstr "Opcje zamku"
+
 msgid "Castle Options"
 msgstr "Opcje zamku"
 
-#: ../fheroes2/castle/castle_well.cpp:158
-msgid "Buy Monsters:"
+msgid "Not enough resources to buy monsters."
+msgstr ""
+
+msgid "No monsters available for purchase."
+msgstr ""
+
+#, fuzzy
+msgid "Buy Monsters"
 msgstr "Kup potwory:"
 
-#: ../fheroes2/castle/castle_well.cpp:221
 msgid "Town Population Information and Statistics"
 msgstr "Statystyki populacji miasta"
 
-#: ../fheroes2/castle/castle_well.cpp:323
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:231
 msgid "Damage"
 msgstr "Obrażenia"
 
-#: ../fheroes2/castle/castle_well.cpp:329
 msgid "HP"
 msgstr "Punkty życia"
 
-#: ../fheroes2/castle/castle_well.cpp:335
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:266
-msgid "Speed"
-msgstr "Szybkość"
-
-#: ../fheroes2/castle/castle_well.cpp:351
 msgid "Growth"
 msgstr "Przyrost"
 
-#: ../fheroes2/castle/castle_well.cpp:355
 msgid "week"
 msgstr "tydzień"
 
-#: ../fheroes2/castle/castle_well.cpp:361
-#: ../fheroes2/kingdom/kingdom_overview.cpp:479
 msgid "Available"
 msgstr "Dostępne"
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:89
 msgid "View the entire world."
 msgstr "Pokaż cały świat."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:90
 msgid "View the obelisk puzzle."
 msgstr "Pokaż wzór na obelisku."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:91
 msgid "View information on the scenario you are currently playing."
 msgstr "Obejrzyj informacje na temat scenariusza, w który obecnie grasz."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:92
 msgid "Dig for the Ultimate Artifact."
 msgstr "Kop w poszukiwaniu Najpotężniejszego Artefaktu."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:93
 msgid "Exit this menu without doing anything."
 msgstr "Wyjdź z menu nie wprowadzając żadnych zmian."
 
-#: ../fheroes2/dialog/dialog_arena.cpp:48
+msgid "Arena"
+msgstr "Arena"
+
 msgid ""
 "You enter the arena and face a pack of vicious lions. You handily defeat "
 "them, to the wild cheers of the crowd.  Impressed by your skill, the aged "
@@ -1444,17 +1643,6 @@ msgstr ""
 "aplauzie gawiedzi pokonujesz je po zaciekłej walce. Stary trener gladiatorów "
 "proponuje ci pomoc w rozwinięciu wybranej przez ciebie umiejętności."
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:154
-msgid ""
-"Your troops can be upgraded, but it will cost you %{ratio} times the "
-"difference in cost for each troop, rounded up to next highest number. Do you "
-"wish to upgrade them?"
-msgstr ""
-"Twoje wojska mogą zostać zmodernizowane, ale to będzie kosztować %{ratio} "
-"razy różnicy w cenie dla każdego oddziału, zaokrąglona do następnej liczby w "
-"górę. Chcesz je aktualizować?"
-
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:155
 msgid ""
 "Your troops can be upgraded, but it will cost you dearly. Do you wish to "
 "upgrade them?"
@@ -1462,36 +1650,41 @@ msgstr ""
 "Możesz ulepszyć swoje oddziały, ale będzie cię to sporo kosztować. Czy "
 "chcesz je ulepszyć?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:166
 msgid "Are you sure you want to dismiss this army?"
 msgstr "Czy na pewno chcesz zwolnić ten oddział?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots Left"
 msgstr "Pozostałe strzały"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots"
 msgstr "Strzały"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:244
 msgid "Hit Points"
 msgstr "PŻ"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:255
 msgid "Hit Points Left"
 msgstr "Aktualne PŻ"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:379
+#, fuzzy
+msgid "Followers"
+msgstr "Kwiaty"
+
 msgid ""
-"The creature is swayed by your diplomatic tongue, and offers to join your "
+"A group of %{monster} with a desire for greater glory wish to join you.\n"
+"Do you accept?"
+msgstr ""
+"Chcą się do ciebie przyłączyć %{monster}, pragnąc zyskać chwałę.\n"
+"Zgadzasz się?"
+
+#, fuzzy
+msgid ""
+"The %{monster} is swayed by your diplomatic tongue, and offers to join your "
 "army for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
 "Przeciwnik jest pod wrażeniem twej dyplomatycznej przemowy i proponuje, że "
 "przyłączy się do twej armii za cenę %{gold} szt. złota. Zgadzasz się?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:382
 msgid ""
 "The creatures are swayed by your diplomatic\n"
 "tongue, and make you an offer:\n"
@@ -1501,7 +1694,6 @@ msgstr ""
 "ofertę:\n"
 " \n"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:385
 msgid ""
 "%{offer} of the %{total} %{monster} will join your army, and the rest will "
 "leave you alone, for the sum of %{gold} gold.\n"
@@ -1511,7 +1703,6 @@ msgstr ""
 "zostawi cię w spokoju za cenę %{gold} szt. złota.\n"
 "Zgadzasz się?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:387
 msgid ""
 "All %{offer} of the %{monster} will join your army for the sum of %{gold} "
 "gold.\n"
@@ -1521,29 +1712,51 @@ msgstr ""
 "złota.\n"
 "Zgadzasz się?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:401
 msgid "(Rate: %{percent})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:451
-msgid ""
-"Not room in\n"
-"the garrison"
+msgid "No room in"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:48
+#, fuzzy
+msgid "the garrison"
+msgstr "Garnizon"
+
 msgid "Build a new ship:"
 msgstr "Zbuduj nowy statek:"
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:63
 msgid "Resource cost:"
 msgstr "Koszt:"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:40
-msgid "For the QVGA version is not available."
-msgstr "Niedostępne w wersji QVGA."
+msgid "Load Game"
+msgstr "Wczytaj grę"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:62
+#, fuzzy
+msgid "No save files to load."
+msgstr "Brak zaklęć."
+
+msgid "New Game"
+msgstr "Nowa gra"
+
+msgid "Start a single or multi-player game."
+msgstr "Rozpocznij grę dla jednego lub wielu graczy."
+
+msgid "Load a previously saved game."
+msgstr "Wczytaj uprzednio zapisaną grę"
+
+#, fuzzy
+msgid "Save Game"
+msgstr "Nowa gra"
+
+msgid "Save the current game."
+msgstr ""
+
+msgid "Quit"
+msgstr "Wyjście"
+
+msgid "Quit out of Free Heroes of Might and Magic II."
+msgstr ""
+
 msgid ""
 "Map\n"
 "Difficulty"
@@ -1551,7 +1764,6 @@ msgstr ""
 "Trudność\n"
 "mapy"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:65
 msgid ""
 "Game\n"
 "Difficulty"
@@ -1559,25 +1771,18 @@ msgstr ""
 "Trudność\n"
 "gry"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:68
 msgid "Rating"
 msgstr "Ocena"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:71
 msgid "Map Size"
 msgstr "Wielkość mapy"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:89
-#: ../fheroes2/system/players.cpp:691
 msgid "Opponents"
 msgstr "Przeciwnicy"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:92
-#: ../fheroes2/system/players.cpp:695
 msgid "Class"
 msgstr "Klasa"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:100
 msgid ""
 "Victory\n"
 "Conditions"
@@ -1585,7 +1790,6 @@ msgstr ""
 "Warunki\n"
 "zwycięstwa"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:106
 msgid ""
 "Loss\n"
 "Conditions"
@@ -1593,48 +1797,34 @@ msgstr ""
 "Warunki\n"
 "przegranej"
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:167
 msgid "You cannot select %{resource}!"
 msgstr "Nie możesz wybrać %{resource}!"
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:173
 msgid "Select count %{resource}:"
 msgstr "Wybierz ilość %{resource}:"
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:200
 msgid "Set Guardian"
 msgstr "Ustaw strażnika"
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:236
-#: ../fheroes2/dialog/dialog_guardian.cpp:292
 msgid "Your army too big!"
 msgstr "Twoja armia jest za duża!"
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:34
-#: ../fheroes2/dialog/dialog_levelup.cpp:44
-#: ../fheroes2/dialog/dialog_levelup.cpp:73
 msgid "%{name} has gained a level."
 msgstr "%{name} zyskuje poziom."
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:36
-#: ../fheroes2/dialog/dialog_levelup.cpp:46
-#: ../fheroes2/dialog/dialog_levelup.cpp:75
-msgid "%{skill} Skill +1"
+#, fuzzy
+msgid "%{skill} +1"
 msgstr "%{skill} +1"
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:51
 msgid "You have learned %{skill}."
 msgstr "Nauczyłeś się %{skill}."
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:93
 msgid "You may learn either:"
 msgstr "Możesz nauczyć się:"
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:96
 msgid "or"
 msgstr "lub"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:66
 msgid ""
 "Please inspect our fine wares. If you feel like offering a trade, click on "
 "the items you wish to trade with and for."
@@ -1642,7 +1832,6 @@ msgstr ""
 "Proszę, zapoznaj się z naszą ofertą. Jeśli masz zamiar handlować, kliknij na "
 "towarach które chesz wymienić."
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:104
 msgid ""
 "You have received quite a bargain. I expect to make no profit on the deal. "
 "Can I interest you in any of my other wares?"
@@ -1650,600 +1839,490 @@ msgstr ""
 "Udało ci się ubić niezły interes. Chyba na tym nic nie zarobię. Może "
 "interesują cię inne moje towary?"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:130
 msgid "I can offer you %{count} for 1 unit of %{resfrom}."
 msgstr "Mogę ci zaproponować %{count} za 1 szt. %{resfrom}."
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:136
 msgid "I can offer you 1 unit of %{resto} for %{count} units of %{resfrom}."
 msgstr "Mogę ci zaproponować 1 szt. %{resto} za %{count} szt. %{resfrom}."
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:164
 msgid "Qty to trade"
 msgstr "Ilość"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:235
+msgid "Trading Post"
+msgstr "Faktoria handlowa"
+
 msgid "Your Resources"
 msgstr "Twoje surowce"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:257
 msgid "Available Trades"
 msgstr "Oferta"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:573
 msgid "n/a"
 msgstr "nd."
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:77
-msgid "guarded by %{count} of %{monster}"
+#, fuzzy
+msgid "guarded by %{count} %{monster}"
 msgstr "Strażnicy: %{monster} (%{count})"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:149
 msgid "(available: %{count})"
 msgstr "(dostępne: %{count})"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:181
 msgid "already learned"
 msgstr "Już to umiesz"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:205
 msgid "already knows this skill"
 msgstr "Już znasz tę umiejętność"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:212
 msgid "already has max skills"
 msgstr "Posiadasz maksimum umiejętności"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:260
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:276
 msgid "(already visited)"
 msgstr "(już odwiedzono)"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
 msgid "(not visited)"
 msgstr "(nie odwiedzono)"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:296
+#, fuzzy
+msgid "Road"
+msgstr "Tryb dróg"
+
+msgid "(digging ok)"
+msgstr ""
+
+msgid "(no digging)"
+msgstr ""
+
 msgid "penalty: %{cost}"
 msgstr "kary: %{cost}"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:382
-msgid "Unchartered Territory"
+#, fuzzy
+msgid "Uncharted Territory"
 msgstr "Niezbadane terytorium"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:635
 msgid "Defenders:"
 msgstr "Obrońcy:"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:674
-#: ../fheroes2/heroes/heroes_indicator.cpp:125
-#: ../fheroes2/heroes/heroes_indicator.cpp:171
 msgid "None"
 msgstr "Brak"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:756
-msgid "%{name} ( Level %{level} )"
+msgid "Unknown"
+msgstr ""
+
+#, fuzzy
+msgid "%{name} (Level %{level})"
 msgstr "%{name} ( Poziom %{level} )"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:884
 msgid "Move Points"
 msgstr "Przenieś punkty"
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:40
-#: ../fheroes2/dialog/dialog_recrut.cpp:579
 msgid "Available: %{count}"
 msgstr "Dostępne: %{count}"
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:101
-msgid "Cost per troop:"
-msgstr "Koszt jednostki:"
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:107
-#: ../fheroes2/dialog/dialog_recrut.cpp:506
-msgid "Recruit %{name}"
-msgstr "Rekrutuj: %{name}"
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:210
 msgid "Number to buy:"
 msgstr "Rekrutuj:"
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:314
 msgid "How many troops to move?"
 msgstr "Ile jednostek przenieść?"
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:358
 msgid "Fast separation into slots:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:180
 msgid "File to Save:"
 msgstr "Zapisz plik:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:186
 msgid "File to Load:"
 msgstr "Wczytaj plik:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:302
 msgid "Are you sure you want to delete file:"
 msgstr "Czy na pewno chcesz usunąć plik:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:305
 msgid "Warning!"
 msgstr "Uwaga!"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:144
-msgid "Maps Difficulty:"
+#, fuzzy
+msgid "Map difficulty:"
 msgstr "Trudność:"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
+msgid "No maps exist at that size"
+msgstr ""
+
 msgid "Small Maps"
 msgstr "Małe mapy"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
-msgid "View only maps of size small (36x36)."
+#, fuzzy
+msgid "View only maps of size small (36 x 36)."
 msgstr "Pokaż tylko małe mapy (36 x 36)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
 msgid "Medium Maps"
 msgstr "Średnie mapy"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
-msgid "View only maps of size medium (72x72)."
+#, fuzzy
+msgid "View only maps of size medium (72 x 72)."
 msgstr "Pokaż tylko średnie mapy (72 x 72)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
 msgid "Large Maps"
 msgstr "Duże mapy"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
-msgid "View only maps of size large (108x108)."
+#, fuzzy
+msgid "View only maps of size large (108 x 108)."
 msgstr "Pokaż tylko duże mapy (108 x 108)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
 msgid "Extra Large Maps"
 msgstr "Bardzo duże mapy"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
-msgid "View only maps of size extra large (144x144)."
+#, fuzzy
+msgid "View only maps of size extra large (144 x 144)."
 msgstr "Pokaż tylko bardzo duże mapy (144 x 144)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "All Maps"
 msgstr "Wszystkie mapy"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "View all maps, regardless of size."
 msgstr "Pokaż wszystkie mapy, niezależnie od wielkości."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
 msgid "Players Icon"
 msgstr "Ikona graczy"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
+#, fuzzy
 msgid ""
-"Indicates how many players total are in the EditScenario. Any positions not "
+"Indicates how many players total are in the scenario. Any positions not "
 "occupied by humans will be occupied by computer players."
 msgstr ""
 "Pokazuje ilu graczy bierze udział w tym scenariuszu. Każde miejsce nie "
 "zajęte przez ludzi, zostanie zajęte przez komputer."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
 msgid "Size Icon"
 msgstr "Ikona wielkości"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
+#, fuzzy
 msgid ""
-"Indicates whether the maps is small (36x36), medium (72x72), large "
-"(108x108), or extra large (144x144)."
+"Indicates whether the map\n"
+"is small (36 x 36), medium\n"
+"(72 x 72), large (108 x 108),\n"
+"or extra large (144 x 144)."
 msgstr ""
 "Wskazuje czy mapa jest mała (36 x 36), średnia (72 x 72), duża (108 x 108), "
 "czy też bardzo duża (144 x 144)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "Selected Name"
 msgstr "Wybrana nazwa"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "The name of the currently selected map."
 msgstr "Nazwa aktualnie wybranej mapy."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid "Selected Map Difficulty"
 msgstr "Trudność wybranej mapy"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
+#, fuzzy
 msgid ""
 "The map difficulty of the currently selected map.  The map difficulty is "
-"determined by the EditScenario designer. More difficult maps might include "
-"more or stronger enemies, fewer resources, or other special conditions "
-"making things tougher for the human player."
+"determined by the scenario designer. More difficult maps might include more "
+"or stronger enemies, fewer resources, or other special conditions making "
+"things tougher for the human player."
 msgstr ""
 "Poziom trudności na aktualnie wybranej mapie, określony przez autora "
 "scenariusza. Na bardziej złożonych mapach mogą występować silniejsi "
 "przeciwnicy, mniej zasobów lub inne specjalne warunki utrudniające rozgrywkę."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "Selected Description"
 msgstr "Wybrany opis"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "The description of the currently selected map."
 msgstr "Opis aktualnie wybranej mapy."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
-msgid "OK"
-msgstr "OK"
+msgid "Okay"
+msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
 msgid "Accept the choice made."
 msgstr "Zastosuj wprowadzone zmiany."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:364
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose all your heroes and towns."
 msgstr "Utrata wszystkich bohaterów i miast."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:365
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific town."
 msgstr "Utrata określonego miasta."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:366
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific hero."
 msgstr "Utrata określonego bohatera."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:367
 msgid "Run out of time. Fail to win by a certain point."
 msgstr "Upływ czasu. Nieukończenie gry w określonym czasie."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:370
 msgid "Loss Condition"
 msgstr "Warunki porażki"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:379
 msgid "Defeat all enemy heroes and towns."
 msgstr "Pokonaj wszystkich wrogów i miasta."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:380
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Capture a specific town."
 msgstr "Zdobądź określone miasto."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:381
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat a specific hero."
 msgstr "Pokonaj określonego bohatera."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:382
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Find a specific artifact."
 msgstr "Znajdź określony artefakt."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:383
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Your side defeats the opposing side."
 msgstr "Twoja strona pokonuje przeciwną."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:384
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Accumulate a large amount of gold."
 msgstr "Zgromadź dużą ilość złota."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:387
 msgid "Victory Condition"
 msgstr "Warunki zwycięstwa"
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:48
-#: ../fheroes2/heroes/heroes_action.cpp:134
 msgid "one"
 msgstr "jeden"
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:51
-#: ../fheroes2/heroes/heroes_action.cpp:135
 msgid "two"
 msgstr "dwa"
 
-#: ../fheroes2/dialog/dialog_system.cpp:187
-msgid "sound"
-msgstr "dźwięk"
-
-#: ../fheroes2/dialog/dialog_system.cpp:192
-#: ../fheroes2/dialog/dialog_system.cpp:205
-#: ../fheroes2/dialog/dialog_system.cpp:228
-#: ../fheroes2/dialog/dialog_system.cpp:242
-msgid "off"
-msgstr "wyłączone"
-
-#: ../fheroes2/dialog/dialog_system.cpp:200
-msgid "music"
+#, fuzzy
+msgid "Music"
 msgstr "muzyka"
 
-#: ../fheroes2/dialog/dialog_system.cpp:223
-msgid "hero speed"
+msgid "Toggle ambient music level."
+msgstr ""
+
+msgid "Effects"
+msgstr ""
+
+msgid "Toggle foreground sounds level."
+msgstr ""
+
+msgid "Music Type"
+msgstr ""
+
+msgid "Change the type of music."
+msgstr ""
+
+#, fuzzy
+msgid "Hero Speed"
 msgstr "prędkość bohatera"
 
-#: ../fheroes2/dialog/dialog_system.cpp:237
-msgid "ai speed"
-msgstr "Prędkość sztucznej inteligencji"
+msgid "Change the speed at which your heroes move on the main screen."
+msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:251
-msgid "scroll speed"
+#, fuzzy
+msgid "Enemy Speed"
+msgstr "Szybkość"
+
+msgid ""
+"Sets the speed that A.I. heroes move at.  You can also elect not to view A."
+"I. movement at all."
+msgstr ""
+
+#, fuzzy
+msgid "Scroll Speed"
 msgstr "prędkość przewijania"
 
-#: ../fheroes2/dialog/dialog_system.cpp:262
-#: ../fheroes2/dialog/dialog_system.cpp:276
+msgid "Sets the speed at which you scroll the window."
+msgstr ""
+
+#, fuzzy
+msgid "Interface Type"
+msgstr "Intefejs"
+
+msgid "Toggle the type of interface you want to use."
+msgstr ""
+
 msgid "Interface"
 msgstr "Intefejs"
 
-#: ../fheroes2/dialog/dialog_system.cpp:265
+msgid "Toggle interface visibility."
+msgstr ""
+
+#, fuzzy
+msgid "Battles"
+msgstr "Butelka"
+
+msgid "Toggle instant battle mode."
+msgstr ""
+
+msgid "OK"
+msgstr "OK"
+
+#, fuzzy
+msgid "Exit this menu."
+msgstr "Zatrzymaj tą jednostkę"
+
+msgid "off"
+msgstr "wyłączone"
+
+msgid "MIDI"
+msgstr ""
+
+#, fuzzy
+msgid "MIDI Expansion"
+msgstr "Posiadłość"
+
+msgid "CD Stereo"
+msgstr ""
+
+msgid "External"
+msgstr ""
+
+msgid "Jump"
+msgstr ""
+
+msgid "Don't Show"
+msgstr ""
+
 msgid "Evil"
 msgstr "Zły"
 
-#: ../fheroes2/dialog/dialog_system.cpp:267
 msgid "Good"
 msgstr "Dobry"
 
-#: ../fheroes2/dialog/dialog_system.cpp:281
 msgid "Hide"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:287
 msgid "Show"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:285
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:96
+msgid "Auto Resolve"
+msgstr ""
+
+msgid "Auto, No Spells"
+msgstr ""
+
+msgid "Manual"
+msgstr ""
+
+msgid "Att."
+msgstr ""
+
+msgid "Def."
+msgstr ""
+
+msgid "Power"
+msgstr "Moc"
+
+#, fuzzy
+msgid "Knowl"
+msgstr "Wiedza"
+
+msgid "Human"
+msgstr ""
+
 msgid "1st"
 msgstr "pierwszy"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:286
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:97
 msgid "2nd"
 msgstr "drugi"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:98
 msgid "3rd"
 msgstr "trzeci"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:288
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:99
 msgid "4th"
 msgstr "czwarty"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:289
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:100
 msgid "5th"
 msgstr "piąty"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:290
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:101
 msgid "6th"
 msgstr "szósty"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:305
-msgid "Thieves' Guild: Player RanKings"
+#, fuzzy
+msgid "Oracle: Player Rankings"
 msgstr "Gildia złodziei - ranking graczy"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:315
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:114
+#, fuzzy
+msgid "Thieves' Guild: Player Rankings"
+msgstr "Gildia złodziei - ranking graczy"
+
 msgid "Number of Towns:"
 msgstr "Liczba miast:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:324
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:123
 msgid "Number of Castles:"
 msgstr "Liczba zamków:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:333
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:132
 msgid "Number of Heroes:"
 msgstr "Liczba bohaterów:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:342
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:141
 msgid "Gold in Treasury:"
 msgstr "Złoto w skarbcu:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:351
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:150
 msgid "Wood & Ore:"
 msgstr "Drewno i ruda:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:360
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:159
 msgid "Gems, Cr, Slf & Mer:"
 msgstr "Klejn., kr., siar. i rtęć:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:369
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:168
 msgid "Obelisks Found:"
 msgstr "Znalezione obeliski:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:378
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:177
+#, fuzzy
+msgid "Artifacts:"
+msgstr "Artefakty"
+
 msgid "Total Army Strength:"
 msgstr "Całkowita siła armii:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:408
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:211
+msgid "Income:"
+msgstr "Przychód:"
+
 msgid "Best Hero:"
 msgstr "Najlepszy bohater:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:417
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:220
 msgid "Best Hero Stats:"
 msgstr "Najlepsze cechy:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:426
 msgid "Personality:"
 msgstr "Osobowość:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:435
 msgid "Best Monster:"
 msgstr "Najlepszy potwór:"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Easy"
 msgstr "Łatwy"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Normal"
 msgstr "Normalny"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Hard"
 msgstr "Trudny"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Expert"
 msgstr "Ekspert"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Impossible"
 msgstr "Niemożliwy"
 
-#: ../fheroes2/game/game.cpp:314
-msgid "Maps Loading..."
+#, fuzzy
+msgid "Map is loading..."
 msgstr "Ładowanie mapy..."
 
-#: ../fheroes2/game/game_highscores.cpp:239
-#: ../fheroes2/game/game_highscores.cpp:242
+msgid "and more..."
+msgstr ""
+
+msgid "Campaign Scenario loading failure"
+msgstr ""
+
+msgid "Please make sure that campaign files are correct and present."
+msgstr ""
+
 msgid "Unknown Hero"
 msgstr ""
 
-#: ../fheroes2/game/game_highscores.cpp:240
 msgid "Your Name"
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:95
-msgid "Are you sure you want to overwrite the save with this name?"
-msgstr "Czy na pewno chcesz podpisać stan gry z taką samą nazwą?"
-
-#: ../fheroes2/game/game_io.cpp:191
 msgid ""
-"This file is saved in the \"Price Loyalty\" version.\n"
+"Invalid file game type. Please ensure that you are running the latest type "
+"of save files."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"This file is saved in the \"The Price of Loyalty\" version.\n"
 "Some items may be unavailable."
 msgstr "Ten plik jest zapisany w wersji dodatku \"Price of Loyalty\"."
 
-#: ../fheroes2/game/game_mainmenu.cpp:157
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:95
-msgid "Quit"
-msgstr "Wyjście"
-
-#: ../fheroes2/game/game_mainmenu.cpp:157
-msgid "Quit Heroes of Might and Magic and return to the operating system."
-msgstr ""
-"Zakończenie gry Heroes of Might and Magic i powrót do systemu operacyjnego."
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:79
-msgid "Load Game"
-msgstr "Wczytaj grę"
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-msgid "Load a previously saved game."
-msgstr "Wczytaj uprzednio zapisaną grę"
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:91
-msgid "Credits"
-msgstr "Autorzy"
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-msgid "View the credits screen."
-msgstr "Obejrzyj autorów gry"
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:87
-msgid "High Scores"
-msgstr "Najlepsze wyniki"
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-msgid "View the high score screen."
-msgstr "Obejrzyj najlepsze wyniki"
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:75
-msgid "New Game"
-msgstr "Nowa gra"
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-msgid "Start a single or multi-player game."
-msgstr "Rozpocznij grę dla jednego lub wielu graczy."
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid "Host"
-msgstr "Gospodarz"
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid ""
-"The host sets up the game options. There can only be one host per network "
-"game."
-msgstr ""
-"Gospodarz ustala opcje gry. W grze sieciowej może być tylko jeden gospodarz."
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid "Guest"
-msgstr "Gość"
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid ""
-"The guest waits for the host to set up the game, then is automatically added "
-"in. There can be multiple guests for TCP/IP games."
-msgstr ""
-"ość czeka, aż gospodarz rozpocznie grę, a następnie włącza się do niej "
-"automatycznie. W grze opartej na połączeniach TCP/IP może być więcej gości."
-
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-msgid "Cancel back to the main menu."
-msgstr "Wróć do głównego menu."
-
-#: ../fheroes2/game/game_newgame.cpp:214
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:154
-msgid "Standard Game"
-msgstr "Gra standardowa"
-
-#: ../fheroes2/game/game_newgame.cpp:214
-msgid "A single player game playing out a single map."
-msgstr "Gra dla jednej osoby na pojedynczej mapie."
-
-#: ../fheroes2/game/game_newgame.cpp:216
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:162
-msgid "Multi-Player Game"
-msgstr "Gra dla wielu osób"
-
-#: ../fheroes2/game/game_newgame.cpp:216
-msgid ""
-"A multi-player game, with several human players completing against each "
-"other on a single map."
-msgstr ""
-"Gra dla wielu osób, gdzie kilku graczy walczy przeciw sobie na pojedynczej "
-"mapie."
-
-#: ../fheroes2/game/game_newgame.cpp:217
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:83
-msgid "Settings"
-msgstr "Ustawienia"
-
-#: ../fheroes2/game/game_newgame.cpp:217
-msgid "FHeroes2 game settings."
-msgstr "Ustawienia gry FHeroes2."
-
-#: ../fheroes2/game/game_newgame.cpp:271
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:219
 msgid "Hot Seat"
 msgstr "Na zmianę"
 
-#: ../fheroes2/game/game_newgame.cpp:271
 msgid ""
 "Play a Hot Seat game, where 2 to 4 players play around the same computer, "
 "switching into the 'Hot Seat' when it is their turn."
@@ -2251,12 +2330,12 @@ msgstr ""
 "Graj wraz z 2-4 graczami na jednym komputerze, zamieniając się miejscami gdy "
 "przychodzi wasza kolej."
 
-#: ../fheroes2/game/game_newgame.cpp:279
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:223
+msgid "Cancel back to the main menu."
+msgstr "Wróć do głównego menu."
+
 msgid "Network"
 msgstr "Sieć"
 
-#: ../fheroes2/game/game_newgame.cpp:279
 msgid ""
 "Play a network game, where 2 players use their own computers connected "
 "through a LAN (Local Area Network)."
@@ -2264,11 +2343,136 @@ msgstr ""
 "Graj w sieci, gdzie 2 graczy korzysta ze swych własnych komputerów "
 "połączonych w sieci lokalnej (LAN)."
 
-#: ../fheroes2/game/game_newgame.cpp:343
+msgid "Standard Game"
+msgstr "Gra standardowa"
+
+msgid "A single player game playing out a single map."
+msgstr "Gra dla jednej osoby na pojedynczej mapie."
+
+msgid "Campaign Game"
+msgstr "Kampania"
+
+#, fuzzy
+msgid "A single player game playing through a series of maps."
+msgstr "Gra dla jednej osoby na pojedynczej mapie."
+
+msgid "Multi-Player Game"
+msgstr "Gra dla wielu osób"
+
+msgid ""
+"A multi-player game, with several human players completing against each "
+"other on a single map."
+msgstr ""
+"Gra dla wielu osób, gdzie kilku graczy walczy przeciw sobie na pojedynczej "
+"mapie."
+
+#, fuzzy
+msgid "Greetings!"
+msgstr "Ustawienia"
+
+msgid ""
+"Welcome to Free Heroes of Might and Magic II! Before starting the game "
+"please choose game resolution."
+msgstr ""
+
+msgid "Please Remember"
+msgstr ""
+
+msgid "You can always change game resolution by clicking on the "
+msgstr ""
+
+msgid "door"
+msgstr ""
+
+msgid ""
+" on the left side of main menu.\n"
+"\n"
+"To switch between windowed and full screen modes\n"
+"press "
+msgstr ""
+
+msgid "F4"
+msgstr ""
+
+msgid ""
+" key on the keyboard.\n"
+"\n"
+"Enjoy the game!"
+msgstr ""
+
+msgid "Quit Heroes of Might and Magic and return to the operating system."
+msgstr ""
+"Zakończenie gry Heroes of Might and Magic i powrót do systemu operacyjnego."
+
+msgid "Credits"
+msgstr "Autorzy"
+
+msgid "View the credits screen."
+msgstr "Obejrzyj autorów gry"
+
+msgid "High Scores"
+msgstr "Najlepsze wyniki"
+
+msgid "View the high score screen."
+msgstr "Obejrzyj najlepsze wyniki"
+
+#, fuzzy
+msgid "Select Game Resolution"
+msgstr "Wybrany opis"
+
+msgid "Change resolution of the game."
+msgstr ""
+
+msgid "Original Campaign"
+msgstr ""
+
+msgid ""
+"Either Roland's or Archibald's campaign from the original Heroes of Might "
+"and Magic II."
+msgstr ""
+
+msgid "Expansion Campaign"
+msgstr ""
+
+msgid "One of the four new campaigns from the Price of Loyalty expansion set."
+msgstr ""
+
+msgid "Host"
+msgstr "Gospodarz"
+
+msgid ""
+"The host sets up the game options. There can only be one host per network "
+"game."
+msgstr ""
+"Gospodarz ustala opcje gry. W grze sieciowej może być tylko jeden gospodarz."
+
+msgid "Guest"
+msgstr "Gość"
+
+msgid ""
+"The guest waits for the host to set up the game, then is automatically added "
+"in. There can be multiple guests for TCP/IP games."
+msgstr ""
+"ość czeka, aż gospodarz rozpocznie grę, a następnie włącza się do niej "
+"automatycznie. W grze opartej na połączeniach TCP/IP może być więcej gości."
+
+#, fuzzy
+msgid "Battle Only"
+msgstr "Krasnolud wojownik"
+
+msgid "Setup and play a battle without loading any map."
+msgstr ""
+
+msgid "Settings"
+msgstr "Ustawienia"
+
+#, fuzzy
+msgid "Experimental game settings."
+msgstr "Ustawienia gry FHeroes2."
+
 msgid "2 Players"
 msgstr "2 graczy"
 
-#: ../fheroes2/game/game_newgame.cpp:343
 msgid ""
 "Play with 2 human players, and optionally, up, to 4 additional computer "
 "players."
@@ -2276,11 +2480,9 @@ msgstr ""
 "Graj z 2 innymi osobami i opcjonalnie z 4 graczami sterowanymi przez "
 "komputer."
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid "3 Players"
 msgstr "3 graczy"
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid ""
 "Play with 3 human players, and optionally, up, to 3 additional computer "
 "players."
@@ -2288,11 +2490,9 @@ msgstr ""
 "Graj z 3 innymi osobami i opcjonalnie z 3 graczami sterowanymi przez "
 "komputer."
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid "4 Players"
 msgstr "4 graczy"
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid ""
 "Play with 4 human players, and optionally, up, to 2 additional computer "
 "players."
@@ -2300,58 +2500,45 @@ msgstr ""
 "Graj z 4 innymi osobami i opcjonalnie z 2 graczami sterowanymi przez "
 "komputer."
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid "5 Players"
 msgstr "5 graczy"
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid ""
 "Play with 5 human players, and optionally, up, to 1 additional computer "
 "players."
 msgstr ""
 "Graj z 5 innymi osobami i opcjonalnie 1 graczem sterowanym przez komputer."
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "6 Players"
 msgstr "6 graczy"
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "Play with 6 human players."
 msgstr "Graj z 6 innymi osobami."
 
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat all enemy heroes and capture all enemy towns and castles."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Run out of time. (Fail to win by a certain point.)"
 msgstr "Upływ czasu (nieukończenie gry w określonym czasie.)"
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the castle '%{name}'"
 msgstr "Przejmij zamek"
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the town '%{name}'"
 msgstr "Przejmij miasto"
 
-#: ../fheroes2/game/game_over.cpp:83
 msgid "Defeat the hero '%{name}'"
 msgstr "Bohater został pokonany"
 
-#: ../fheroes2/game/game_over.cpp:91
 msgid "Find the ultimate artifact"
 msgstr "Znajdź najwyższy artefakt"
 
-#: ../fheroes2/game/game_over.cpp:95
 msgid "Find the '%{name}' artifact"
 msgstr "Znajdź '%{name}' artefakt"
 
-#: ../fheroes2/game/game_over.cpp:102
 msgid "Accumulate %{count} gold"
 msgstr "Zgromadź %{count} złota"
 
-#: ../fheroes2/game/game_over.cpp:106
 msgid ""
 ", or you may win by defeating all enemy heroes and capturing all enemy towns "
 "and castles."
@@ -2359,29 +2546,23 @@ msgstr ""
 ", możesz także wygrać pokonując wszystkich bohaterów wroga i przechwytując "
 "wszystkie jego miasta i zamki."
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the castle '%{name}'."
 msgstr "Straciłeś zamek"
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the town '%{name}'."
 msgstr "Straciłeś miasto"
 
-#: ../fheroes2/game/game_over.cpp:126 ../fheroes2/game/game_over.cpp:145
 msgid "Lose the hero: %{name}."
 msgstr "Przegrywa bohater: %{name}."
 
-#: ../fheroes2/game/game_over.cpp:133
 msgid "Fail to win by the end of month %{month}, week %{week}, day %{day}."
 msgstr ""
 "Nie udało Ci się wygrać przed końcem miesiąca %{month},  tygodnia %{week}, "
 "dnia %{day}."
 
-#: ../fheroes2/game/game_over.cpp:145
 msgid "Lose the heroes: %{name}."
 msgstr "Tracisz bohaterów: %{name}."
 
-#: ../fheroes2/game/game_over.cpp:167
 msgid ""
 "You captured %{name}!\n"
 "You are victorious."
@@ -2389,7 +2570,6 @@ msgstr ""
 "Udało ci się zdobyć miasto %{name}!\n"
 "Odnosisz zwycięstwo."
 
-#: ../fheroes2/game/game_over.cpp:175
 msgid ""
 "You have captured the enemy hero %{name}!\n"
 "Your quest is complete."
@@ -2397,7 +2577,6 @@ msgstr ""
 "Udało ci się schwytać wrogiego bohatera - %{name}!\n"
 "Twoje zadanie zostało wypełnione."
 
-#: ../fheroes2/game/game_over.cpp:183
 msgid ""
 "You have found the %{name}.\n"
 "Your quest is complete."
@@ -2405,7 +2584,6 @@ msgstr ""
 "Odnajdujesz artefakt (%{name}).\n"
 "Twoja misja zakończyła się sukcesem."
 
-#: ../fheroes2/game/game_over.cpp:195
 msgid ""
 "The enemy is beaten.\n"
 "Your side has triumphed!"
@@ -2413,7 +2591,6 @@ msgstr ""
 "Wróg został pobity.\n"
 "Twoje wojska tryumfują!"
 
-#: ../fheroes2/game/game_over.cpp:200
 msgid ""
 "You have built up over %{count} gold in your treasury.\n"
 "All enemies bow before your wealth and power."
@@ -2421,7 +2598,6 @@ msgstr ""
 "W twoim skarbcu udało ci się zebrać ponad %{count} szt. złota.\n"
 "Wszyscy przeciwnicy korzą się przed twym bogactwem i potęgą."
 
-#: ../fheroes2/game/game_over.cpp:222
 msgid ""
 "The enemy has found the %{name}.\n"
 "Your quest is a failure."
@@ -2429,7 +2605,6 @@ msgstr ""
 "Przeciwnik znalazł artefakt - %{name}.\n"
 "Twoja misja zakończyła się niepowodzeniem."
 
-#: ../fheroes2/game/game_over.cpp:230
 msgid ""
 "%{color} has fallen!\n"
 "All is lost."
@@ -2437,7 +2612,6 @@ msgstr ""
 "Miasto %{color} padło!\n"
 "Wszystko stracone."
 
-#: ../fheroes2/game/game_over.cpp:237
 msgid ""
 "The enemy has built up over %{count} gold in his treasury.\n"
 "You must bow done in defeat before his wealth and power."
@@ -2445,17 +2619,14 @@ msgstr ""
 "Przeciwnik zebrał ponad %{count} szt. złota w swoim skarbcu.\n"
 "Musisz ukorzyć się przed jego bogactwem i potęgą."
 
-#: ../fheroes2/game/game_over.cpp:243
 msgid "You have been eliminated from the game!!!"
 msgstr "Zostajesz wyeliminowany z gry!!!"
 
-#: ../fheroes2/game/game_over.cpp:248
 msgid ""
 "The enemy has captured %{name}!\n"
 "They are triumphant."
 msgstr "Wróg zdobył miasto %{name} i odnosi zwycięstwo!"
 
-#: ../fheroes2/game/game_over.cpp:257 ../fheroes2/game/game_over.cpp:264
 msgid ""
 "You have lost the hero %{name}.\n"
 "Your quest is over."
@@ -2463,40 +2634,31 @@ msgstr ""
 "Tracisz bohatera (%{name}).\n"
 "Nie udaje ci się wypełnić misji."
 
-#: ../fheroes2/game/game_over.cpp:272
 msgid ""
 "You have failed to complete your quest in time.\n"
 "All is lost."
 msgstr ""
 "Nie udaje ci się wypełnić misji w określonym czasie. Wszystko stracone."
 
-#: ../fheroes2/game/game_over.cpp:320
-msgid "%{color} has been vanquished!"
+#, fuzzy
+msgid "%{color} player has been vanquished!"
 msgstr "%{color} zostaje zniszczony!"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "Warning"
 msgstr "Uwaga"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "No maps available!"
 msgstr "Mapy niedostępne!"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Scenario"
 msgstr "Scenariusz"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Click here to select which scenario to play."
 msgstr "Kliknij tutaj, aby wybrać scenariusz, który chcesz rozegrać."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid "Game Difficulty"
 msgstr "Trudność gry"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid ""
 "This lets you change the starting difficulty at which you will play. Higher "
 "difficulty levels start you of with fewer resources, and at the higher "
@@ -2506,11 +2668,9 @@ msgstr ""
 "oznacza rozpoczęcie z mniejszą ilością zasobów oraz dodatkowo przekazanie "
 "dodatkowych surowców graczowi komputerowemu."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid "Difficulty Rating"
 msgstr "Ocena trudności"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid ""
 "The difficulty rating reflects a combination of various settings for your "
 "game. This number will be applied to your final score."
@@ -2518,62 +2678,48 @@ msgstr ""
 "Ocena trudności odzwierciedla kombinacje różnorakich ustawień gry. Wartość "
 "ta zostanie dodana do wyniku końcowego."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
 msgid "Click to accept these settings and start a new game."
 msgstr "Klikni, aby użyć tych ustawień i rozpocząć nową grę."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
 msgid "Click to return to the main menu."
 msgstr "Kliknij, aby wrócić do głównego menu."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:342
 msgid "Scenario:"
 msgstr "Scenariusz:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:350
 msgid "Game Difficulty:"
 msgstr "Poziom trudności:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:354
 msgid "Opponents:"
 msgstr "Przeciwnicy:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:358
 msgid "Class:"
 msgstr "Klasa:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:384
 msgid "Rating %{rating}%"
 msgstr "Poziom %{rating}%"
 
-#: ../fheroes2/game/game_startgame.cpp:226
 msgid "Astrologers proclaim Month of the %{name}."
 msgstr "Astrologowie zapowiadają Miesiąc %{name}."
 
-#: ../fheroes2/game/game_startgame.cpp:226
 msgid "Astrologers proclaim Week of the %{name}."
 msgstr "Astrologowie zapowiadają Tydzień %{name}."
 
-#: ../fheroes2/game/game_startgame.cpp:240
 msgid "After regular growth, population of %{monster} is doubled!"
 msgstr "Dzięki naturalnemu przyrostowi, populacja %{monster} jest podwojona!"
 
-#: ../fheroes2/game/game_startgame.cpp:252
 msgid " All populations are halved."
 msgstr " Ginie połowa populacji królestwa."
 
-#: ../fheroes2/game/game_startgame.cpp:254
 msgid " All dwellings increase population."
 msgstr " Zwiększa się populacja całego królestwa."
 
-#: ../fheroes2/game/game_startgame.cpp:283
 msgid ""
 "%{color} player, your heroes abandon you, and you are banished from this "
 "land."
 msgstr ""
 "%{color}, twoi bohaterowie cię opuszczają i zostajesz wygnany z tej krainy."
 
-#: ../fheroes2/game/game_startgame.cpp:290
 msgid ""
 "%{color} player, this is your last day to capture a town, or you will be "
 "banished from this land."
@@ -2581,7 +2727,6 @@ msgstr ""
 "%{color}, został ci tylko jeden dzień na podbicie jakiegoś miasta, albo "
 "dojdzie do twego wygnania z tej krainy."
 
-#: ../fheroes2/game/game_startgame.cpp:295
 msgid ""
 "%{color} player, you only have %{day} days left to capture a town, or you "
 "will be banished from this land."
@@ -2589,11 +2734,10 @@ msgstr ""
 "%{color}, masz tylko %{day} dni na podbicie jakiegoś miasta, albo dojdzie do "
 "twego wygnania z tej krainy."
 
-#: ../fheroes2/game/game_startgame.cpp:584
-msgid "%{color} player's turn"
+#, fuzzy
+msgid "%{color} player's turn."
 msgstr "%{color} - nowa tura."
 
-#: ../fheroes2/game/game_startgame.cpp:995
 msgid ""
 "%{color} player, you have lost your last town. If you do not conquer another "
 "town in next week, you will be eliminated."
@@ -2601,150 +2745,134 @@ msgstr ""
 "%{color}, twoje ostatnie miasto zostało podbite. Jeśli nie zdołasz zdobyć "
 "innego miasta w ciągu tygodnia, gra się dla ciebie skończy."
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Next Hero"
 msgstr "Następny bohater"
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Select the next Hero."
 msgstr "Wybierz następnego bohatera."
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue Movement"
 msgstr "Dalszy ruch"
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue the Hero's movement along the current path."
 msgstr "Dalszy ruch bohatera wzdłuż wybranej ścieżki."
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "Kingdom Summary"
 msgstr "Przegląd królestwa"
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "View a Summary of your Kingdom."
 msgstr "Obejrzyj informacje na temat swego królestwa."
 
-#: ../fheroes2/gui/interface_buttons.cpp:189
 msgid "Cast an adventure spell."
 msgstr "Rzuć zaklęcie podróżne."
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End Turn"
 msgstr "Koniec tury"
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End your turn and left the computer take its turn."
 msgstr "Zakończ swoją turę i pozwól ruszać się komputerowi."
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Adventure Options"
 msgstr "Opcje przygody"
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Bring up the adventure options menu."
 msgstr "Pokazuje menu z opcjami przygody."
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "File Options"
 msgstr "Opcje plików"
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "Bring up the file options menu, alloving you to load menu, save etc."
 msgstr ""
 "Pokazuje menu z opcjami plików, pozwalając na wczytanie gry, zapisanie, itp."
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "System Options"
 msgstr "Opcje systemowe"
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "Bring up the system options menu, alloving you to customize your game."
 msgstr ""
 "Pokazuje menu z opcjami systemowymi, pozwalając na zmianę ustawień gry."
 
-#: ../fheroes2/gui/interface_events.cpp:175
 msgid ""
 "One or more heroes may still move, are you sure you want to end your turn?"
 msgstr ""
 "Jeden lub więcej bohaterów wciąż może się ruszać. Czy na pewno chcesz "
 "zakończyć turę?"
 
-#: ../fheroes2/gui/interface_events.cpp:212
-msgid "Are you sure you want to restart? (Your current game will be lost)"
+msgid "Are you sure you want to quit?"
+msgstr "Czy na pewno chcesz wyjść?"
+
+#, fuzzy
+msgid "Are you sure you want to restart? (Your current game will be lost.)"
 msgstr ""
 "Czy na pewno chcesz rozpocząć od nowa? (Aktualna rozgrywka zostanie "
 "przerwana)"
 
-#: ../fheroes2/gui/interface_events.cpp:276
-msgid "Are you sure you want to quit?"
-msgstr "Czy na pewno chcesz wyjść?"
+msgid "Are you sure you want to overwrite the save with this name?"
+msgstr "Czy na pewno chcesz podpisać stan gry z taką samą nazwą?"
 
-#: ../fheroes2/gui/interface_events.cpp:308
 msgid "Game saved successfully."
 msgstr "Udało się zapisać stan gry."
 
-#: ../fheroes2/gui/interface_events.cpp:314
+msgid "There was an issue during saving."
+msgstr ""
+
+#, fuzzy
 msgid ""
-"Are you sure you want to load a new game? (Your current game will be lost)"
+"Are you sure you want to load a new game? (Your current game will be lost.)"
 msgstr ""
 "Czy na pewno chcesz wczytać nową grę? (Aktualna rozgrywka zostanie przerwana)"
 
-#: ../fheroes2/gui/interface_events.cpp:353
 msgid "Try looking on land!!!"
 msgstr "Spróbuj na lądzie!!!"
 
-#: ../fheroes2/gui/interface_events.cpp:368
+#, fuzzy
 msgid ""
-"After spending many hours digging here, you have uncovered the %{artifact}"
+"After spending many hours digging here, you have uncovered the %{artifact}."
 msgstr "Po spędzeniu wielu godzin na kopaniu, odkryłeś %{artifact}"
 
-#: ../fheroes2/gui/interface_events.cpp:370
 msgid "Congratulations!"
 msgstr "Gratulacje!"
 
-#: ../fheroes2/gui/interface_events.cpp:384
 msgid "Nothing here. Where could it be?"
 msgstr "Nic tu nie ma. Gdzie to może być?"
 
-#: ../fheroes2/gui/interface_events.cpp:395
 msgid "Try searching on clear ground."
 msgstr "Spróbuj szukać na czystym terenie."
 
-#: ../fheroes2/gui/interface_events.cpp:399
 msgid "Digging for artifacts requires a whole day, try again tomorrow."
 msgstr "Szukanie artefaktu zajmuje cały dzień, spróbuj ponownie jutro."
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "World Map"
 msgstr "Mapa świata"
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "A miniature view of the known world. Left click to move viewing area."
 msgstr ""
 "Miniaturowy obraz znanego świata. Kliknij lewym przyciskiem, aby przesunąć "
 "widoczny obszar."
 
-#: ../fheroes2/gui/interface_status.cpp:216
 msgid "Month: %{month} Week: %{week}"
 msgstr "Miesiąc: %{month} Tydzień: %{week}"
 
-#: ../fheroes2/gui/interface_status.cpp:222
-#: ../fheroes2/kingdom/kingdom_overview.cpp:569
 msgid "Day: %{day}"
 msgstr "Dzień: %{day}"
 
-#: ../fheroes2/gui/interface_status.cpp:257
 msgid ""
 "You find a small\n"
 "quantity of %{resource}."
 msgstr "Znajdujesz: %{resource}."
 
-#: ../fheroes2/gui/interface_status.cpp:407
 msgid "Status Window"
 msgstr "Okno informacyjne"
 
-#: ../fheroes2/gui/interface_status.cpp:407
+#, fuzzy
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date."
+msgstr ""
+"W tym oknie umieszczone są informacje na temat stanu twojego bohatera lub "
+"królestwa, a także aktualna data. Kliknij tu lewym przyciskiem, aby "
+"przejrzeć kolejne informacje."
+
 msgid ""
 "This window provides information on the status of your hero or kingdom, and "
 "shows the date. Left click here to cycle throungh these windows."
@@ -2753,29 +2881,284 @@ msgstr ""
 "królestwa, a także aktualna data. Kliknij tu lewym przyciskiem, aby "
 "przejrzeć kolejne informacje."
 
-#: ../fheroes2/heroes/heroes_action.cpp:112
+msgid "Necroman"
+msgstr "Nekromanta"
+
+msgid ""
+"This lets you change player starting positions and colors. A particular "
+"color will always start in a particular location. Some positions may only be "
+"played by a computer player or only by a human player."
+msgstr ""
+"Opcja ta pozwala na zmianę barw i startowej pozycji gracza. Dany kolor "
+"zawsze będzie rozpoczynać grę w określonym miejscu. Niektóre pozycje mogą "
+"być zajęte jedynie przez komputer, a inne tylko przez graczy - ludzi."
+
+msgid ""
+"This lets you change the class of a player. Classes are not always "
+"changeable. Depending on the scenario, a player may receive additional towns "
+"and/or heroes not of their primary alignment."
+msgstr ""
+"Pozwal ci zmienić klasę gracza. Opcja ta nie zawsze jest aktywna. W "
+"zależności od scenariusza, gracz może otrzymać dodatkowe miasta oraz/lub "
+"bohaterów niezgodne z przynależną im klasą."
+
+msgid "%{color} player"
+msgstr "%{color} Gracz"
+
+msgid "View %{skill} Info"
+msgstr "Wyświetl informacje o %{skill}"
+
+msgid "Lord Kilburn"
+msgstr "Lord Kilburn"
+
+#, fuzzy
+msgid "Sir Gallant"
+msgstr "Sir Gallant"
+
+msgid "Ector"
+msgstr "Ector"
+
+msgid "Gwenneth"
+msgstr "Gwenneth"
+
+msgid "Tyro"
+msgstr "Tyro"
+
+msgid "Ambrose"
+msgstr "Ambrose"
+
+msgid "Ruby"
+msgstr "Ruby"
+
+msgid "Maximus"
+msgstr "Maximus"
+
+msgid "Dimitry"
+msgstr "Dimitri"
+
+msgid "Thundax"
+msgstr "Thundax"
+
+msgid "Fineous"
+msgstr "Fineous"
+
+msgid "Jojosh"
+msgstr "Jojosh"
+
+msgid "Crag Hack"
+msgstr "Crag Hack"
+
+msgid "Jezebel"
+msgstr "Jezebel"
+
+msgid "Jaclyn"
+msgstr "Jaclyn"
+
+msgid "Ergon"
+msgstr "Ergon"
+
+msgid "Tsabu"
+msgstr "Tsabu"
+
+msgid "Atlas"
+msgstr "Atlas"
+
+msgid "Astra"
+msgstr "Astra"
+
+msgid "Natasha"
+msgstr "Natasha"
+
+msgid "Troyan"
+msgstr "Troyan"
+
+msgid "Vatawna"
+msgstr "Vatawna"
+
+msgid "Rebecca"
+msgstr "Rebecca"
+
+msgid "Gem"
+msgstr "Gem"
+
+msgid "Ariel"
+msgstr "Ariel"
+
+msgid "Carlawn"
+msgstr "Carlawn"
+
+msgid "Luna"
+msgstr "Luna"
+
+msgid "Arie"
+msgstr "Arie"
+
+msgid "Alamar"
+msgstr "Alamar"
+
+msgid "Vesper"
+msgstr "Vesper"
+
+msgid "Crodo"
+msgstr "Crodo"
+
+msgid "Barok"
+msgstr "Barok"
+
+msgid "Kastore"
+msgstr "Kastore"
+
+msgid "Agar"
+msgstr "Agar"
+
+msgid "Falagar"
+msgstr "Falagar"
+
+msgid "Wrathmont"
+msgstr "Wrathmont"
+
+msgid "Myra"
+msgstr "Myra"
+
+msgid "Flint"
+msgstr "Flint"
+
+msgid "Dawn"
+msgstr "Dawn"
+
+msgid "Halon"
+msgstr "Halon"
+
+msgid "Myrini"
+msgstr "Myrini"
+
+msgid "Wilfrey"
+msgstr "Wilfrey"
+
+msgid "Sarakin"
+msgstr "Sarakin"
+
+msgid "Kalindra"
+msgstr "Kalindra"
+
+msgid "Mandigal"
+msgstr "Mandigal"
+
+msgid "Zom"
+msgstr "Zom"
+
+msgid "Darlana"
+msgstr "Darlana"
+
+msgid "Zam"
+msgstr "Zam"
+
+msgid "Ranloo"
+msgstr "Ranloo"
+
+msgid "Charity"
+msgstr "Charity"
+
+msgid "Rialdo"
+msgstr "Rialdo"
+
+msgid "Roxana"
+msgstr "Roxana"
+
+msgid "Sandro"
+msgstr "Sandro"
+
+msgid "Celia"
+msgstr "Celia"
+
+msgid "Roland"
+msgstr "Roland"
+
+msgid "Lord Corlagon"
+msgstr "Lorda Corlagon"
+
+msgid "Sister Eliza"
+msgstr "Siostra Eliza"
+
+msgid "Archibald"
+msgstr "Archibald"
+
+msgid "Lord Halton"
+msgstr "Lord Halton"
+
+#, fuzzy
+msgid "Brother Brax"
+msgstr "Brat Brax"
+
+msgid "Solmyr"
+msgstr "Solmyr"
+
+msgid "Dainwin"
+msgstr "Dainwin"
+
+msgid "Mog"
+msgstr "Mog"
+
+msgid "Joseph"
+msgstr "Joseph"
+
+msgid "Gallavant"
+msgstr "Gallavant"
+
+msgid "Elderian"
+msgstr "Elderian"
+
+msgid "Ceallach"
+msgstr "Ceallach"
+
+msgid "Drakonia"
+msgstr "Drakonia"
+
+msgid "Martine"
+msgstr "Martine"
+
+msgid "Jarkonas"
+msgstr "Jarkonas"
+
+msgid "%{object} robber"
+msgstr ""
+
+msgid "%{object} raided"
+msgstr ""
+
+msgid "You cannot pick up this artifact, you already have a full load!"
+msgstr ""
+
+msgid "The three Anduran artifacts magically combine into one."
+msgstr "Trzy Anduriańskie artefakty magicznie połączone w jeden."
+
+msgid "To cast spells, you must first buy a spell book for %{gold} gold."
+msgstr ""
+"Aby móc rzucać zaklęcia, musisz najpierw kupić księgę czarów za %{gold} "
+"sztuk złota."
+
+msgid "Unfortunately, you seem to be a little short of cash at the moment."
+msgstr ""
+"Niestety wygląda na to, że w chwili obecnej brakuje ci trochę pieniędzy."
+
+msgid "Do you wish to buy one?"
+msgstr "Czy chcesz ją kupić?"
+
 msgid "%{count} / day"
 msgstr "%{count} / dzień"
 
-#: ../fheroes2/heroes/heroes_action.cpp:331
-#: ../fheroes2/heroes/heroes_action.cpp:2199
 msgid "You are unable to recruit at this time, your ranks are full."
 msgstr "Nie możesz teraz rekrutować, w twojej armii nie ma już miejsca."
 
-#: ../fheroes2/heroes/heroes_action.cpp:599
-msgid ""
-"A group of %{monster} with a desire for greater glory wish to join you.\n"
-"Do you accept?"
-msgstr ""
-"Chcą się do ciebie przyłączyć %{monster}, pragnąc zyskać chwałę.\n"
-"Zgadzasz się?"
+msgid "A whirlpool engulfs your ship."
+msgstr "Statek zostaje wciągnięty przez wir."
 
-#: ../fheroes2/heroes/heroes_action.cpp:609
-#: ../fheroes2/heroes/heroes_action.cpp:630
+msgid "Some of your army has fallen overboard."
+msgstr "Część twych wojsk wypada za pokład."
+
 msgid "Insulted by your refusal of their offer, the monsters attack!"
 msgstr "Przeciwnicy, obrażeni odrzuceniem ich propozycji, ruszają do ataku!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:638
 msgid ""
 "The %{monster}, awed by the power of your forces, begin to scatter.\n"
 "Do you wish to pursue and engage them?"
@@ -2783,11 +3166,9 @@ msgstr ""
 "%{monster} uciekają w trwodze przed potęgą twojej armii.\n"
 "Czy chcesz dogonić przeciwników i z nimi walczyć?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:934
 msgid "Ransacking an enemy camp, you discover a hidden cache of treasures."
 msgstr "Przetrząsając obóz wroga odnajdujesz ukrytą skrzynię ze skarbami."
 
-#: ../fheroes2/heroes/heroes_action.cpp:966
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with these resources, "
@@ -2796,7 +3177,6 @@ msgstr ""
 "Właściciel młyna oznajmia: \"Wasza dostojność, ciężko pracowałem, aby zebrać "
 "te zasoby. Wróć proszę po więcej w przyszłym tygodniu.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:967
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there are no resources currently available. Please try "
@@ -2805,7 +3185,6 @@ msgstr ""
 "Właściciel młyna oznajmia: \"Wasza dostojność, nie mam więcej surowców. Wróć "
 "proszę w przyszłym tygodniu.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:972
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with this gold, come "
@@ -2814,7 +3193,6 @@ msgstr ""
 "Właściciel młyna oznajmia: \"Wasza dostojność, ciężko pracowałem, aby zebrać "
 "to złoto. Wróć proszę po więcej w przyszłym tygodniu.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:973
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there is no gold currently available. Please try again "
@@ -2823,7 +3201,6 @@ msgstr ""
 "Właściciel młyna oznajmia:\n"
 "\"Wasza dostojność, nie mam więcej złota, wróć proszę w przyszłym tygodniu.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:979
 msgid ""
 "You've found an abandoned lean-to.\n"
 "Poking about, you discover some resources hidden nearby."
@@ -2831,11 +3208,9 @@ msgstr ""
 "Znajdujesz starą szopę.\n"
 "Przeszukujesz ją i znajdujesz trochę przydatnych zasobów."
 
-#: ../fheroes2/heroes/heroes_action.cpp:980
 msgid "The lean-to is long abandoned. There is nothing of value here."
 msgstr "Stara szopa jest opuszczona. Nie ma w niej nic wartościowego."
 
-#: ../fheroes2/heroes/heroes_action.cpp:985
 msgid ""
 "You catch a leprechaun foolishly sleeping amidst a cluster of magic "
 "mushrooms.\n"
@@ -2846,7 +3221,6 @@ msgstr ""
 "W zamian za uwolnienie wskazuje ci miejsce ukrycia małego dzbana pełnego "
 "kosztowności."
 
-#: ../fheroes2/heroes/heroes_action.cpp:986
 msgid ""
 "You've found a magic garden, the kind of place that leprechauns and faeries "
 "like to cavort in, but there is no one here today.\n"
@@ -2856,23 +3230,18 @@ msgstr ""
 "dziś nikogo tu nie ma.\n"
 "Spróbuj przyjść tu za tydzień."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1023
 msgid "You come upon the remains of an unfortunate adventurer."
 msgstr "Dotarłeś do szczątek pechowego poszukiwacza"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1034
 msgid "Treasure"
 msgstr "Skarb"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1041
 msgid "Searching through the tattered clothing, you find %{artifact}."
 msgstr "Po przeszukaniu rozdartego ubrania, znajdujesz %{artifact}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1052
 msgid "Searching through the tattered clothing, you find nothing."
 msgstr "Nic nie znajdujesz w tym podartym ubraniu"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1064
 msgid ""
 "You come across an old wagon left by a trader who didn't quite make it to "
 "safe terrain."
@@ -2880,63 +3249,50 @@ msgstr ""
 "Odnajdujesz stary wóz pozostawiony przez kupca któremu nie udało się dotrzeć "
 "na bezpieczny teren."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1075
-#: ../fheroes2/heroes/heroes_action.cpp:1103
 msgid "Unfortunately, others have found it first, and the wagon is empty."
 msgstr "Niestety, inni odkryli go pierwsi przez co wóz jest pusty."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1082
 msgid "Searching inside, you find the %{artifact}."
 msgstr "Przeszukując wnętrze, znajdujesz %{artifact}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1093
 msgid "Inside, you find some of the wagon's cargo still intact."
 msgstr "Wewnatrz, odkrywasz, że część ładunku jest nadal nienaruszona."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1123
 msgid "You search through the flotsam, and find some wood and some gold."
 msgstr "Przeszukujsz wrak i znajdujesz trochę drewna i trochę złota."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1124
 msgid "You search through the flotsam, and find some wood."
 msgstr "Przeszukujsz wrak i znajdujesz trochę drewna."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1130
 msgid "You search through the flotsam, but find nothing."
 msgstr "Przeszukujsz wrak, lecz nie znajdujesz niczego"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1151
 msgid "Shrine of the 1st Circle"
 msgstr "Kaplica pierwszego kręgu"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1152
 msgid ""
 "You come across a small shrine attended by a group of novice acolytes.\n"
-"In exchange for your protection, they agree to teach you a simple spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a simple spell - "
+"'%{spell}'."
 msgstr ""
 "Trafiasz do małej kaplicy, którą opiekuje się grupa akolitów.\n"
 "W zamian za ochronę proponują nauczyć cię prostego zaklęcia - '%{spell}'."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1155
 msgid "Shrine of the 2nd Circle"
 msgstr "Kaplica drugiego kręgu"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1156
 msgid ""
 "You come across an ornate shrine attended by a group of rotund friars.\n"
-"In exchange for your protection, they agree to teach you a spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a spell - "
+"'%{spell}'."
 msgstr ""
 "Trafiasz do bogato zdobionej kaplicy, którą opiekuje się grupa pulchnych "
 "mnichów.\n"
 "W zamian za ochronę proponują nauczyć cię zaklęcia - '%{spell}'."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1159
 msgid "Shrine of the 3rd Circle"
 msgstr "Kaplica trzeciego kręgu"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1160
 msgid ""
 "You come across a lavish shrine attended by a group of high priests.\n"
 "In exchange for your protection, they agree to teach you a sophisticated "
@@ -2944,10 +3300,9 @@ msgid ""
 msgstr ""
 "Zbliżasz się do urządzonej z przepychem kaplicy, którą opiekuje się kilku "
 "wysokich rangą kapłanów.\n"
-"W zamian za ochronę proponują nauczyć cię skomplikowanego zaklęcia - '%"
-"{spell}'."
+"W zamian za ochronę proponują nauczyć cię skomplikowanego zaklęcia - "
+"'%{spell}'."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1173
 msgid ""
 "\n"
 "Unfortunately, you have no Magic Book to record the spell with."
@@ -2955,7 +3310,6 @@ msgstr ""
 "\n"
 "Niestety nie masz księgi czarów, w której można zapisać zaklęcie."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1184
 msgid ""
 "\n"
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
@@ -2965,7 +3319,6 @@ msgstr ""
 "Niestety, twoja mądrość jest zbyt mała, by móc zrozumieć to zaklęcie i nie "
 "jesteś w stanie się go nauczyć."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1192
 msgid ""
 "\n"
 "Unfortunately, you already have knowledge of this spell, so there is nothing "
@@ -2975,16 +3328,14 @@ msgstr ""
 "Niestety, masz już wiedzę o tym zaklęciu, więc nie możesz nauczyć się go "
 "ponownie."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1215
 msgid ""
-"You approach the hut and observe a witch inside studying an ancient tome on %"
-"{skill}.\n"
+"You approach the hut and observe a witch inside studying an ancient tome on "
+"%{skill}.\n"
 " \n"
 msgstr ""
 "Wchodzisz do chaty i widzisz wiedźmę uczącą umiejętności %{skill}.\n"
 " \n"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1222
 msgid ""
 "As you approach, she turns and focuses her one glass eye on you.\n"
 "\"You already know everything you deserve to learn!\" the witch screeches. "
@@ -2994,7 +3345,6 @@ msgstr ""
 "\"Wiesz już wszystko, co możesz wiedzieć!\" skrzeczy wiedźma. \"A TERAZ "
 "WYNOCHA Z MOJEGO DOMU!\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1229
 msgid ""
 "As you approach, she turns and speaks.\n"
 "\"You already know that which I would teach you. I can help you no further.\""
@@ -3003,7 +3353,6 @@ msgstr ""
 "\"Wiesz już wszystko, czego mogłam cię nauczyć. Nie potrafię ci w niczym "
 "pomóc.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1236
 msgid ""
 "An ancient and immortal witch living in a hut with bird's legs for stilts "
 "teaches you %{skill} for her own inscrutable purposes."
@@ -3011,20 +3360,16 @@ msgstr ""
 "Stara wiedźma mieszkająca w chatce na kurzej łapce z sobie tylko znanych "
 "powodów przekazuje ci wiedzę o umiejętności %{skill}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1255
 msgid "You drink from the enchanted fountain, but nothing happens."
 msgstr "Pijesz wodę z zaklętej fontanny ale nic się nie dzieje."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1256
 msgid "As you drink the sweet water, you gain luck for your next battle."
 msgstr ""
 "Pijesz słodką wodę i czujesz, że w następnej bitwie dopisze ci szczęście."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1260
 msgid "You enter the faerie ring, but nothing happens."
 msgstr "Wchodzisz do zaklętego kręgu, ale nic się nie dzieje."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1261
 msgid ""
 "Upon entering the mystical faerie ring, your army gains luck for its next "
 "battle."
@@ -3032,7 +3377,6 @@ msgstr ""
 "Po wejściu do tajemniczego zaklętego kręgu, twoja armia zyskuje szczęście na "
 "czas kolejnej bitwy."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1265
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "It is supposed to grant luck to visitors, but since the stars are already "
@@ -3042,7 +3386,6 @@ msgstr ""
 "Podobno pocałowanie go przynosi szczęście, ale kiedy to czynisz, nic "
 "specjalnego się nie dzieje."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1266
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "Kissing it is supposed to be lucky, so you do. The stone is very cold to the "
@@ -3052,12 +3395,10 @@ msgstr ""
 "Podobno pocałowanie go przynosi szczęście, czynisz więc to. Kamienny posąg "
 "jest bardzo zimny."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1270
 msgid "The mermaids silently entice you to return later and be blessed again."
 msgstr ""
 "Syreny w ciszy zachęcają cię, by wrócić do nich później po błogosławieństwo."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1271
 msgid ""
 "The magical, soothing beauty of the Mermaids reaches you and your crew.\n"
 "Just for a moment, you forget your worries and bask in the beauty of the "
@@ -3069,7 +3410,6 @@ msgstr ""
 "Na odchodne syreny błogosławią twoje wojska, co ma przynieść ci szczęście "
 "podczas następnej bitwy."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1303
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "You are tempted to search it for treasure, but all the old stories warn of "
@@ -3082,7 +3422,6 @@ msgstr ""
 "klątwami i nieumarłymi strażnikami.\n"
 "Czy mimo to chcesz wejść do piramidy?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1304
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "Routine exploration reveals that the pyramid is completely empty."
@@ -3090,11 +3429,9 @@ msgstr ""
 "Natrafiasz na piramidę zbudowaną ku chwale potężnego, starożytnego króla.\n"
 "Przeszukujesz ją, ale okazuje się, że jest zupełnie pusta."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1329
 msgid "Unfortunately, you have no Magic Book to record the spell with."
 msgstr "Niestety nie masz księgi czarów, w której można zapisać zaklęcie."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1333
 msgid ""
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
@@ -3102,7 +3439,6 @@ msgstr ""
 "Niestety, twoja mądrość jest zbyt mała, by móc zrozumieć to zaklęcie i nie "
 "jesteś w stanie się go nauczyć."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1337
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
 "telling the secret of the spell."
@@ -3110,11 +3446,9 @@ msgstr ""
 "Pokonawszy potwory, odczytujesz prastary glif na ścianie, dzięki czemu "
 "poznajesz tajemnice zaklęcia."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1374 ../fheroes2/maps/mp2.cpp:469
 msgid "Sign"
 msgstr "Drogowskaz"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1385
 msgid ""
 "A drink at the well is supposed to restore your spell points, but you are "
 "already at maximum."
@@ -3122,16 +3456,13 @@ msgstr ""
 "Łyk wody z magicznej studni może przywrócić ci wszystkie punkty magii, ale "
 "masz już ich maksymalną liczbę."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1392
 msgid "A second drink at the well in one day will not help you."
 msgstr ""
 "Ponowne napicie się ze studni w ciągu jednego dnia nie przyniesie efektów."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1399
 msgid "A drink from the well has restored your spell points to maximum."
 msgstr "Łyk wody z magicznej studni przywrócił ci wszystkie punkty magii."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1424
 msgid ""
 "\"I'm sorry sir,\" The leader of the soldiers says, \"but you already know "
 "everything we have to teach.\""
@@ -3139,11 +3470,9 @@ msgstr ""
 "\"Wybacz panie,\" mówi dowódca żołnierzy, \"ale wiesz już wszystko, co "
 "moglibyśmy cię nauczyć.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1425
 msgid "The soldiers living in the fort teach you a few new defensive tricks."
 msgstr "Żołnierze z fortu uczą cię kilku sztuczek przydatnych w obronie."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1430
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. \"You're too "
 "advanced for us,\" the mercenary captain says. \"We can teach nothing more.\""
@@ -3152,7 +3481,6 @@ msgstr ""
 "trudnym przeciwnikiem,\" mówi ich dowódca. \"Nie nauczymy cię niczego nowego."
 "\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1431
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. The mercenaries "
 "welcome you and your troops and invite you to train with them."
@@ -3160,11 +3488,9 @@ msgstr ""
 "Trafiasz do obozu, w którym właśnie trenują najemnicy. Żołnierze z obozu "
 "witają cię i zapraszają twoich ludzi do wspólnych ćwiczeń."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1436
 msgid "\"Go 'way!\", the witch doctor barks, \"you know all I know.\""
 msgstr "\"Wynocha!\", warczy znachor, \"wiesz już wszystko to co ja.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1437
 msgid ""
 "An Orcish witch doctor living in the hut deepens your knowledge of magic by "
 "showing you how to cast stones, read portents, and decipher the intricacies "
@@ -3174,7 +3500,6 @@ msgstr ""
 "pokazując ci, jak wróżyć z kamieni, odczytywać znaki i wieszczyć z "
 "wnętrzności kurczaka."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1442
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, the Druids turn you away, indicating they have nothing "
@@ -3184,7 +3509,6 @@ msgstr ""
 "kamiennych struktur. Druidzi w milczeniu odwracając się od ciebie, "
 "pokazując, że nie mogą nauczyć cię niczego nowego."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1443
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, they teach you new ways to cast spells."
@@ -3193,7 +3517,6 @@ msgstr ""
 "kamiennych struktur. Druidzi w milczeniu uczą cię nowych sposobów rzucania "
 "zaklęć."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1479
 msgid ""
 "You tentatively approach the burial ground of ancient warriors. Do you want "
 "to search the graves?"
@@ -3201,7 +3524,6 @@ msgstr ""
 "Ostrożnie zbliżasz się do cmentarzyska pradawnych wojowników. Czy chcesz "
 "przeszukać groby?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1480
 msgid ""
 "Upon defeating the Zombies you spend several hours searching the graves and "
 "find nothing. Such a despicable act reduces your army's morale."
@@ -3209,12 +3531,11 @@ msgstr ""
 "Po pokonaniu zombie spędzasz wiele godzin na przeszukiwaniu grobów, lecz nic "
 "nie znajdujesz. Ten akt profanacji obniża morale twojej armii."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1481
-msgid "Upon defeating the zomies you search the graves and find something!"
+#, fuzzy
+msgid "Upon defeating the Zombies you search the graves and find something!"
 msgstr ""
 "Po pokonaniu zombie przeszukujesz groby i znajdujesz coś wartościowego!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1484
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the shipwreck?"
@@ -3222,7 +3543,6 @@ msgstr ""
 "Gnijący kadłub olbrzymiego statku pirackiego poskrzypuje z cicha ocierając "
 "się o przybrzeżne skały. Czy chcesz przeszukać wrak?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1485
 msgid ""
 "Upon defeating the Ghosts you spend several hours sifting through the debris "
 "and find nothing. Such a despicable act reduces your army's morale."
@@ -3230,12 +3550,10 @@ msgstr ""
 "Po pokonaniu duchów spędzasz wiele godzin na przeszukiwaniu wraku, lecz nic "
 "nie znajdujesz. Ten akt profanacji obniża morale twojej armii."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1486
 msgid ""
 "Upon defeating the Ghosts you sift through the debris and find something!"
 msgstr "Po pokonaniu duchów przeszukujesz wrak i znajdujesz coś wartościowego!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1489
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the ship?"
@@ -3243,7 +3561,6 @@ msgstr ""
 "Gnijący kadłub olbrzymiego statku pirackiego poskrzypuje z cicha ocierając "
 "się o przybrzeżne skały. Czy chcesz przeszukać wrak?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1490
 msgid ""
 "Upon defeating the Skeletons you spend several hours sifting through the "
 "debris and find nothing. Such a despicable act reduces your army's morale."
@@ -3251,19 +3568,16 @@ msgstr ""
 "Po pokonaniu szkieletów spędzasz wiele godzin na przeszukiwaniu wraku, lecz "
 "nic nie znajdujesz. Ten akt profanacji obniża morale twojej armii."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1491
 msgid ""
 "Upon defeating the Skeletons you sift through the debris and find something!"
 msgstr ""
 "Po pokonaniu szkieletów przeszukujesz wrak i znajdujesz coś wartościowego!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1564
 msgid "Your men spot a navigational buoy, confirming that you are on course."
 msgstr ""
 "Twoi ludzie zauważają boję nawigacyjną, co potwierdza, że płyniecie dobrym "
 "kursem."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1565
 msgid ""
 "Your men spot a navigational buoy, confirming that you are on course and "
 "increasing their morale."
@@ -3271,7 +3585,6 @@ msgstr ""
 "Twoi ludzie zauważają boję nawigacyjną, co potwierdza, że płyniecie dobrym "
 "kursem i zwiększa ich morale."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1569
 msgid ""
 "The drink at the oasis is refreshing, but offers no further benefit. The "
 "oasis might help again if you fought a battle first."
@@ -3279,7 +3592,6 @@ msgstr ""
 "Pijesz wodę w oazie, ale nic się nie dzieje. Być może trzeba tu wrócić po "
 "najbliższej bitwie."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1570
 msgid ""
 "A drink at the oasis fills your troops with strength and lifts their "
 "spirits.  You can travel a bit further today."
@@ -3287,7 +3599,6 @@ msgstr ""
 "Orzeźwiająca woda z oazy wzmacnia ducha twoich żołnierzy i dodaje im sił. "
 "Możesz dziś jeszcze pokonać spory kawałek drogi."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1575
 msgid ""
 "The drink at the watering hole is refreshing, but offers no further benefit. "
 "The watering hole might help again if you fought a battle first."
@@ -3295,7 +3606,6 @@ msgstr ""
 "Zimna woda orzeźwia twoich żołnierzy, ale nie dzieje się nic specjalnego. "
 "Może warto przyjść tutaj po walce."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1576
 msgid ""
 "A drink at the watering hole fills your troops with strength and lifts their "
 "spirits. You can travel a bit further today."
@@ -3303,17 +3613,14 @@ msgstr ""
 "Zimna woda orzeźwia twoich żołnierzy i dodaje im sił. Dzisiaj możesz pokonać "
 "jeszcze sporo drogi."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1581
 msgid ""
 "It doesn't help to pray twice before a battle. Come back after you've fought."
 msgstr ""
 "Dwukrotna modlitwa przed bitwą w niczym ci nie pomoże. Wróć tu po walce."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1582
 msgid "A visit and a prayer at the temple raises the morale of your troops."
 msgstr "Wizyta i modlitwa w świątyni podnosi morale twoich oddziałów."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1622
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"I am sorry, my liege, I "
 "have taught you all I can.\""
@@ -3321,7 +3628,6 @@ msgstr ""
 "Na schodach altany staje sędziwy rycerz. \"Wasza dostojność wybaczy, ale "
 "nauczyłem ją wszystkiego co umiem.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1623
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"My liege, I will teach "
 "you all that I know to aid you in your travels.\""
@@ -3329,7 +3635,6 @@ msgstr ""
 "Na schodach altany staje sędziwy rycerz. \"Wasza dostojność, aby pomóc ci w "
 "twych podróżach, nauczę cię wszystkiego co sam umiem.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1662
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
 "ocean. Grateful, he says, \"I would give you an artifact as a reward, but "
@@ -3340,38 +3645,29 @@ msgstr ""
 "odwdzięczyłbym się, dając ci artefakt, ale widzę, że nie masz już miejsca w "
 "swoim ekwipunku.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1669
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
-"ocean. Grateful, he rewards you for your act of kindness by giving you the %"
-"{art}."
+"ocean. Grateful, he rewards you for your act of kindness by giving you the "
+"%{art}."
 msgstr ""
-"Uratowałeś rozbitka przed utonięciem. W podzięce za uratowanie, dostajesz %"
-"{art}."
+"Uratowałeś rozbitka przed utonięciem. W podzięce za uratowanie, dostajesz "
+"%{art}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1688 ../fheroes2/heroes/heroes.cpp:941
-msgid "You have no room to carry another artifact!"
-msgstr "Nie masz miejsca, by nieść kolejny artefakt!"
-
-#: ../fheroes2/heroes/heroes_action.cpp:1704
 msgid "A leprechaun offers you the %{art} for the small price of %{gold} Gold."
 msgstr ""
 "%{art} - leprekaun proponuje, że sprzeda ci ten artefakt za %{gold} sztuk "
 "złota."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1709
 msgid ""
-"A leprechaun offers you the %{art} for the small price of %{gold} Gold and %"
-"{count} %{res}."
+"A leprechaun offers you the %{art} for the small price of %{gold} Gold and "
+"%{count} %{res}."
 msgstr ""
 "%{art} - leprekaun proponuje, że sprzeda ci ten artefakt za %{gold} sztuk "
 "złota i %{count} jednostki surowca (%{res})."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1718
 msgid "Do you wish to buy this artifact?"
 msgstr "Czy chcesz go kupić?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1731
 msgid ""
 "You try to pay the leprechaun, but realize that you can't afford it. The "
 "leprechaun stamps his foot and ignores you."
@@ -3379,7 +3675,6 @@ msgstr ""
 "Chcesz zapłacić leprekaunowi, ale zdajesz sobie sprawę, że cię na to nie "
 "stać. Leprekaun tupie ze złością nóżką i postanawia cię zignorować."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1735
 msgid ""
 "Insulted by your refusal of his generous offer, the leprechaun stamps his "
 "foot and ignores you."
@@ -3387,20 +3682,16 @@ msgstr ""
 "Obrażony odrzuceniem hojnej oferty leprekaun tupie ze złością małą nóżką i "
 "postanawia cię zignorować."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1746
-#: ../fheroes2/heroes/heroes_action.cpp:1821
 msgid "You've found the artifact: "
 msgstr "Odnajdujesz artefakt: "
 
-#: ../fheroes2/heroes/heroes_action.cpp:1756
 msgid ""
 "You've found the humble dwelling of a withered hermit. The hermit tells you "
 "that he is willing to give the %{art} to the first wise person he meets."
 msgstr ""
-"Trafiasz do skromnego domku starego pustelnika. Pustelnik oznajmia, że  %"
-"{art} będzie należeć do pierwszej mądrej osoby, która go odwiedzi."
+"Trafiasz do skromnego domku starego pustelnika. Pustelnik oznajmia, że  "
+"%{art} będzie należeć do pierwszej mądrej osoby, która go odwiedzi."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1759
 msgid ""
 "You've come across the spartan quarters of a retired soldier. The soldier "
 "tells you that he is willing to pass on the %{art} to the first true leader "
@@ -3409,7 +3700,6 @@ msgstr ""
 "Trafiasz do spartańskiej kwatery starego żołnierza. Żołnierz oznajmia ci, że "
 "%{art} będzie należeć do pierwszego prawdziwego dowódcy, który go odwiedzi..."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1780
 msgid ""
 "You come upon an ancient artifact. As you reach for it, a pack of Rogues "
 "leap out of the brush to guard their stolen loot."
@@ -3417,7 +3707,6 @@ msgstr ""
 "Przypadkowo znajdujesz prastary artefakt. Gdy po niego sięgasz, z krzaków "
 "wyskakuje banda rozbójników broniąca swego łupu."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1783
 msgid ""
 "Through a clearing you observe an ancient artifact. Unfortunately, it's "
 "guarded by a nearby %{monster}. Do you want to fight the %{monster} for the "
@@ -3427,19 +3716,15 @@ msgstr ""
 "strażnik - %{monster}. Czy chcesz walczyć ze strażnikiem (%{monster}) o "
 "artefakt?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1798
 msgid "Victorious, you take your prize, the %{art}."
 msgstr "Zwyciężywszy zabierasz swoją zdobycz. Jest to %{art}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1810
 msgid ""
 "Discretion is the better part of valor, and you decide to avoid this fight "
 "for today."
 msgstr ""
 "Rozsądek przeważa nad męstwem i uznajesz, że lepiej dziś uniknąć tej walki."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1866
-#: ../fheroes2/heroes/heroes_action.cpp:1881
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold pieces."
@@ -3447,7 +3732,6 @@ msgstr ""
 "Spędziwszy wiele godzin na próbach wyłowienia skrzyni wciągasz ją w końcu na "
 "pokład i odkrywasz, iż znajduje się w niej %{gold} sztuk złota."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1872
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold and the %{art}."
@@ -3455,7 +3739,6 @@ msgstr ""
 "Spędziwszy wiele godzin na próbach wyłowienia skrzyni wciągasz ją w końcu na "
 "pokład i odkrywasz, iż znajduje się w niej %{gold} sztuk złota oraz %{art}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1888
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it, "
 "only to find it empty."
@@ -3463,7 +3746,6 @@ msgstr ""
 "Spędziwszy wiele godzin na próbach wyłowienia skrzyni wciągasz ją w końcu na "
 "pokład i odkrywasz, iż jest ona kompletnie pusta."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1898
 msgid ""
 "After scouring the area, you fall upon a hidden treasure cache. You may take "
 "the gold or distribute the gold to the peasants for experience. Do you wish "
@@ -3473,15 +3755,13 @@ msgstr ""
 "złoto lub oddać je wieśniakom zyskując doświadczenie. Czy chcesz zatrzymać "
 "złoto?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1912
 msgid ""
-"After scouring the area, you fall upon a hidden chest, containing the %"
-"{gold} gold pieces."
+"After scouring the area, you fall upon a hidden chest, containing the "
+"%{gold} gold pieces."
 msgstr ""
 "Przeszukując okolicę odnajdujesz ukrytą skrzynię zawierającą %{gold} sztuk "
 "złota."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1918
 msgid ""
 "After scouring the area, you fall upon a hidden chest, containing the "
 "ancient artifact %{art}."
@@ -3489,7 +3769,6 @@ msgstr ""
 "Przeszukując okolicę odnajdujesz ukrytą skrzynię. Okazuje się, iż kufer "
 "zawiera starożytny artefakt - %{art}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1942
 msgid ""
 "You stumble upon a dented and tarnished lamp lodged deep in the earth. Do "
 "you wish to rub the lamp?"
@@ -3497,15 +3776,6 @@ msgstr ""
 "Znajdujesz wyszczerbioną i zmatowiałą lampę na wpół zakopaną w ziemi. Czy "
 "chcesz ją potrzeć?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "A whirlpool engulfs your ship."
-msgstr "Statek zostaje wciągnięty przez wir."
-
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "Some of your army has fallen overboard."
-msgstr "Część twych wojsk wypada za pokład."
-
-#: ../fheroes2/heroes/heroes_action.cpp:2045
 msgid ""
 "You come upon an abandoned gold mine. The mine appears to be haunted. Do you "
 "wish to enter?"
@@ -3513,7 +3783,6 @@ msgstr ""
 "Zbliżasz się do opuszczonej kopalni złota. Wygląda na to, że jest "
 "nawiedzona. Czy chcesz do niej wejść?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2064
 msgid ""
 "You have taken control of the local Alchemist shop. It will provide you with "
 "%{count} unit of Mercury per day."
@@ -3521,7 +3790,6 @@ msgstr ""
 "Przejmujesz kontrolę nad sklepem miejscowego alchemika. Dostarczać ci będzie "
 "%{count} jednostki rtęci dziennie."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2070
 msgid ""
 "You gain control of a sawmill. It will provide you with %{count} units of "
 "wood per day."
@@ -3529,7 +3797,9 @@ msgstr ""
 "Przejmujesz kontrolę nad tartakiem. Dostarczać ci będzie %{count} jednostki "
 "drewna dziennie."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2081
+msgid "You beat the Ghosts and are able to restore the mine to production."
+msgstr "Pokonujesz duchy i w kopalni ponownie może rozpocząć się wydobycie."
+
 msgid ""
 "You gain control of an ore mine. It will provide you with %{count} units of "
 "ore per day."
@@ -3537,7 +3807,6 @@ msgstr ""
 "Przejmujesz kontrolę nad kopalnią rudy. Dostarczać ci będzie %{count} "
 "jednostki rudy dziennie."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2083
 msgid ""
 "You gain control of a sulfur mine. It will provide you with %{count} unit of "
 "sulfur per day."
@@ -3545,7 +3814,6 @@ msgstr ""
 "Przejmujesz kontrolę nad kopalnią siarki. Dostarczać ci będzie %{count} "
 "jednostki siarki dziennie."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2085
 msgid ""
 "You gain control of a crystal mine. It will provide you with %{count} unit "
 "of crystal per day."
@@ -3553,7 +3821,6 @@ msgstr ""
 "Przejmujesz kontrolę nad kopalnią kryształów. Dostarczać ci będzie %{count} "
 "jednostki kryształów dziennie."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2087
 msgid ""
 "You gain control of a gem mine. It will provide you with %{count} unit of "
 "gems per day."
@@ -3561,7 +3828,6 @@ msgstr ""
 "Przejmujesz kontrolę nad kopalnią klejnotów. Dostarczać ci będzie %{count} "
 "klejnotów dziennie."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2089
 msgid ""
 "You gain control of a gold mine. It will provide you with %{count} gold per "
 "day."
@@ -3569,11 +3835,6 @@ msgstr ""
 "Przejmujesz kontrolę nad kopalnią złota. Dostarczać ci będzie %{count} sztuk "
 "złota dziennie."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2096
-msgid "You beat the Ghosts and are able to restore the mine to production."
-msgstr "Pokonujesz duchy i w kopalni ponownie może rozpocząć się wydobycie."
-
-#: ../fheroes2/heroes/heroes_action.cpp:2101
 msgid ""
 "The lighthouse is now under your control, and all of your ships will now "
 "move further each turn."
@@ -3581,11 +3842,9 @@ msgstr ""
 "Latarnia morska jest teraz pod twoją kontrolą i twoje okręty zwiększają "
 "zasięg swego ruchu w każdej turze."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2105
 msgid "You gain control of a %{name}."
 msgstr "Przejmujesz kontrolę nad %{name}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2188
 msgid ""
 "A group of %{monster} with a desire for greater glory wish to join you. Do "
 "you accept?"
@@ -3593,11 +3852,9 @@ msgstr ""
 "Chce się do ciebie dołączyć grupa stworzeń (%{monster}) pragnących chwały. "
 "Zgadzasz się?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2215
 msgid "As you approach the dwelling, you notice that there is no one here."
 msgstr "dy zbliżasz się do domostwa, zauważasz, że nikogo tam nie ma."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2232
 msgid ""
 "You search the ruins, but the Medusas that used to live here are gone. "
 "Perhaps there will be more next week."
@@ -3605,7 +3862,6 @@ msgstr ""
 "Przeszukujesz ruiny, ale zamieszkujące je meduzy gdzieś zniknęły. Może "
 "pojawią się w przyszłym tygodniu."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2233
 msgid ""
 "You've found some Medusas living in the ruins. They are willing to join your "
 "army for a price. Do you want to recruit Medusas?"
@@ -3613,7 +3869,6 @@ msgstr ""
 "Odnajdujesz kilka meduz żyjących wśród ruin. Gotowe są dołączyć do twojej "
 "armi za odpowiednią cenę. Czy chcesz nająć meduzy?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2238
 msgid ""
 "You've found a Sprite Tree City. Unfortunately, none of the Sprites living "
 "there wish to join an army. Maybe next week."
@@ -3621,7 +3876,6 @@ msgstr ""
 "Odnajdujesz nadrzewne miasto rusałek. Niestety żadna z mieszkających tu "
 "rusałek nie chce dołączyć do twojej armii. Może w przyszłym tygodniu."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2239
 msgid ""
 "Some of the Sprites living in the tree city are willing to join your army "
 "for a price. Do you want to recruit Sprites?"
@@ -3629,14 +3883,12 @@ msgstr ""
 "Część rusałek żyjących w nadrzewnym mieście chce dołączyć za pewną cenę do "
 "twojej armii. Czy chcesz nająć rusałki?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2244
 msgid ""
 "A colorful Rogues' wagon stands empty here. Perhaps more Rogues will be here "
 "later."
 msgstr ""
 "Kolorowe cygańskie wozy są puste. Może rozbójnicy zjawią się tu później."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2245
 msgid ""
 "Distant sounds of music and laughter draw you to a colorful wagon housing "
 "Rogues. Do you wish to have any Rogues join your army?"
@@ -3644,7 +3896,6 @@ msgstr ""
 "źwięki muzyki i śmiechy prowadzą cię do kolorowego taboru, w którym "
 "mieszkają rozbójnicy. Czy chcesz, aby przyłączyli się do ciebie?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2250
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. The "
 "tents are unoccupied. Perhaps more Nomads will be here later."
@@ -3652,7 +3903,6 @@ msgstr ""
 "Stoi tu kilka poszarpanych namiotów smaganych pustynnym wiatrem. Są puste. "
 "Może nomadowie przyjdą tu później."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2251
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. Do you "
 "wish to have any Nomads join you during your travels?"
@@ -3660,11 +3910,9 @@ msgstr ""
 "Stoi tu kilka poszarpanych namiotów smaganych pustynnym wiatrem. Czy chcesz, "
 "by przyłączyli się do ciebie nomadowie?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2256
 msgid "The pit of mud bubbles for a minute and then lies still."
 msgstr "W jamie przez chwile bulgocze błoto po czym się uspokaja."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2257
 msgid ""
 "As you approach the bubbling pit of mud, creatures begin to climb out and "
 "position themselves around it. In unison they say: \"Mother Earth would like "
@@ -3674,11 +3922,9 @@ msgstr ""
 "jakieś istoty i ustawiają wokół. Jednym głosem mówią: \"Matka Ziemia "
 "proponuje ci kilka z jej oddziałów. Czy chcesz nająć żywiołaki ziemi?\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2261
 msgid "You enter the structure of white stone pillars, and find nothing."
 msgstr "Wchodzisz pomiędzy białe kolumny, ale nic nie znajdujesz."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2262
 msgid ""
 "White stone pillars support a roof that rises up to the sky. As you enter "
 "the structure, the dead air of the outside gives way to a whirling gust that "
@@ -3693,11 +3939,9 @@ msgstr ""
 "ciebie głośnym szeptem: \"Po co tu przybywasz? Czy chcesz przywołać siły "
 "powietrza?\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2266
 msgid "No Fire Elementals approach you from the lava pool."
 msgstr "Z sadzawki lawy nie wychodzi żaden żywiołak ognia."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2267
 msgid ""
 "Beneath a structure that serves to hold in heat, Fire Elementals move about "
 "in a fiery pool of molten lava. A group of them approach you and offer their "
@@ -3707,11 +3951,9 @@ msgstr ""
 "powietrza pływające w strumieniach lawy. Część z nich zbliża się do ciebie "
 "proponując swe usługi. Czy chcesz nająć żywiołaki ognia?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2271
 msgid "A face forms in the water for a moment, and then is gone."
 msgstr "Przez chwilę w wodzie widoczna jest jakaś twarz, po czym znika."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2272
 msgid ""
 "Crystalline structures cast shadows over a small reflective pool of water. "
 "You peer into the pool, and a face that is not your own peers back. It asks: "
@@ -3721,11 +3963,9 @@ msgstr ""
 "zwierciadła. Patrzysz w wodę i widzisz odbicie nie swojej twarzy, która "
 "mówi: \"Czy chcesz przywołać moce wody?\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2276
 msgid "This burial site is deathly still."
 msgstr "Na cmentarzysku panuje niczym nie zmącona cisza."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2277
 msgid ""
 "Restless spirits of long dead warriors seeking their final resting place "
 "offer to join you in hopes of finding peace. Do you wish to recruit ghosts?"
@@ -3733,7 +3973,6 @@ msgstr ""
 "Chcą się do ciebie dołączyć niespokojne dusze martwych wojowników, którzy "
 "szukają miejsca ostatecznego spoczynku. Czy chcesz nająć duchy?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2313
 msgid ""
 "The City of the Dead is empty of life, and empty of unlife as well. Perhaps "
 "some undead will move in next week."
@@ -3741,7 +3980,6 @@ msgstr ""
 "W Mieście Umarłych nie ma życia, ale i śmierci tu nie widać. Może nieumarli "
 "pojawią się tu w przyszłym tygodniu."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2314
 msgid ""
 "Some Liches living here are willing to join your army for a price. Do you "
 "want to recruit Liches?"
@@ -3749,7 +3987,6 @@ msgstr ""
 "Część mieszkających tu liszy chce dołączyć za pewną cenę do twojej armii. "
 "Czy chcesz nająć lisze?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2315
 msgid ""
 "You've found the ruins of an ancient city, now inhabited solely by the "
 "undead. Will you search?"
@@ -3757,7 +3994,6 @@ msgstr ""
 "Odnajdujesz ruiny prastarego miasta, zamieszkałego obecnie jedynie przez "
 "nieumarłych. Czy chcesz je przeszukać?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2316
 msgid ""
 "Some of the surviving Liches are impressed by your victory over their "
 "fellows, and offer to join you for a price. Do you want to recruit Liches?"
@@ -3765,7 +4001,6 @@ msgstr ""
 "Część z ocalałych liszy jest pod wrażeniem twojego zwycięstwa nad nimi i "
 "proponują się do ciebie przyłączyć, za pewną cenę. Czy chcesz nająć lisze?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2320
 msgid ""
 "You've found one of those bridges that Trolls are so fond of living under, "
 "but there are none here. Perhaps there will be some next week."
@@ -3773,7 +4008,6 @@ msgstr ""
 "Odnajdujesz jeden z mostów, pod którymi tak lubią mieszkać trolle, ale teraz "
 "nikogo tu nie ma. Może pojawią się w przyszłym tygodniu."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2321
 msgid ""
 "Some Trolls living under a bridge are willing to join your army, but for a "
 "price. Do you want to recruit Trolls?"
@@ -3781,12 +4015,10 @@ msgstr ""
 "Część trolli żyjących pod mostem chce dołączyć za pewną cenę do twojej "
 "armii. Czy chcesz nająć trolle?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2322
 msgid "Trolls living under the bridge challenge you. Will you fight them?"
 msgstr ""
 "Trolle żyjące pod mostem rzucają ci wyzwanie. Czy będziesz z nimi walczyć?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2323
 msgid ""
 "A few Trolls remain, cowering under the bridge. They approach you and offer "
 "to join your forces as mercenaries. Do you want to buy any Trolls?"
@@ -3794,7 +4026,6 @@ msgstr ""
 "Pod mostem kuli się kilka trolli. Zbliają się do ciebie i proponują dołączyć "
 "się do twojej armii jako najemnicy. Czy chcesz nająć trolle?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2327
 msgid ""
 "The Dragon city has no Dragons willing to join you this week. Perhaps a "
 "Dragon will become available next week."
@@ -3802,7 +4033,6 @@ msgstr ""
 "W tym tygodniu w Smoczym Mieście nie ma smoków, które mogłyby się do ciebie "
 "przyłączyć. Spróbuj ponownie w przyszłym tygodniu."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2328
 msgid ""
 "The Dragon city is willing to offer some Dragons for your army for a price. "
 "Do you wish to recruit Dragons?"
@@ -3810,7 +4040,6 @@ msgstr ""
 "Smocze Miasto zgadza się przekazać kilka smoków do twojej armii. Czy chcesz "
 "nająć smoki?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2329
 msgid ""
 "You stand before the Dragon City, a place off-limits to mere humans. Do you "
 "wish to violate this rule and challenge the Dragons to a fight?"
@@ -3818,7 +4047,6 @@ msgstr ""
 "Stoisz przed Smoczym Miastem, miejscem niedostępnym dla zwykłych ludzi. Czy "
 "chcesz złamać tą zasadę i wyzwać smoki na pojedynek?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2330
 msgid ""
 "Having defeated the Dragon champions, the city's leaders agree to supply "
 "some Dragons to your army for a price. Do you wish to recruit Dragons?"
@@ -3826,18 +4054,15 @@ msgstr ""
 "Pokonawszy smoczych czempionów, przywódcy miasta zgadzają się za pewną cenę "
 "przekazać kilka smoków do twojej armii. Czy chcesz nająć smoki?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2389
 msgid "From the observation tower, you are able to see distant lands."
 msgstr "Z wieży obserwacyjnej możesz zobaczyć odległe krainy."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2401
 msgid ""
 "The spring only refills once a week, and someone's already been here this "
 "week."
 msgstr ""
 "Studnia wypełnia się tylko raz w tygodniu, a w tym tygodniu ktoś już tu był."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2407
 msgid ""
 "A drink at the spring is supposed to give you twice your normal spell "
 "points, but you are already at that level."
@@ -3845,7 +4070,6 @@ msgstr ""
 "Napicie się ze studni powinno dać ci dwa razy więcej punktów magii niż "
 "zwykle posiadasz, ale już masz tyle punktów."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2418
 msgid ""
 "A drink from the spring fills your blood with magic! You have twice your "
 "normal spell points in reserve."
@@ -3853,7 +4077,6 @@ msgstr ""
 "Łyk wody ze studni przepełnia cię magiczną mocą! Masz dwa razy więcej "
 "punktów magii niż normalnie."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2437
 msgid ""
 "Recognizing you, the butler refuses to admit you. \"The master,\" he says, "
 "\"will not see the same student twice.\""
@@ -3861,7 +4084,6 @@ msgstr ""
 "Lokaj rozpoznaje cię i odmawia otwarcia drzwi. \"Mój pan,\" mówi, \"nigdy "
 "nie uczy dwukrotnie tej samej osoby.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2457
 msgid ""
 "The butler admits you to see the master of the house. He trains you in the "
 "four skills a hero should know."
@@ -3869,7 +4091,6 @@ msgstr ""
 "Lokaj prowadzi cię do pana tego domostwa, który uczy cię czterech "
 "umiejętności potrzebnych każdemu bohaterowi."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2467
 msgid ""
 "The butler opens the door and looks you up and down. \"You are neither "
 "famous nor diplomatic enough to be admitted to see my master,\" he sniffs. "
@@ -3879,7 +4100,6 @@ msgstr ""
 "dyplomacji ani nie jesteś na tyle sławnym bohaterem, by móc spotkać się z "
 "moim panem,\" mówi. \"Wróć kiedy uznasz, że na to zasługujesz.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2510
 msgid ""
 "All of the %{monsters} you have in your army have been trained by the battle "
 "masters of the fort. Your army now contains %{monsters2}."
@@ -3887,24 +4107,23 @@ msgstr ""
 "Twoje jednostki, %{monsters}, przechodzą szkolenie u mistrzów walki z tego "
 "fortu. W twojej armii są teraz %{monsters2}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2513
+#, fuzzy
 msgid ""
-"An unusual alliance of Orcs, Ogres, and Dwarves offer to train (upgrade) any "
+"An unusual alliance of Ogres, Orcs, and Dwarves offer to train (upgrade) any "
 "such troops brought to them. Unfortunately, you have none with you."
 msgstr ""
 "Nietypowe przymierze orków, ogrów i krasnoludów proponuje ci wyszkolenie "
 "(ulepszenie) jednostek, które tu przyprowadzisz. Niestety nie masz oddziałów "
 "tego typu."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2524
 msgid "All of your %{monsters} have been upgraded into %{monsters2}."
 msgstr "Twoje jednostki, %s, zostają ulepszone. W twojej armii są teraz %s."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2527
+#, fuzzy
 msgid ""
 "A blacksmith working at the foundry offers to convert all Pikemen and "
 "Swordsmen's weapons brought to him from iron to steel. He also says that he "
-"knows a process that will convert Iron Golems into Steel Golems.  "
+"knows a process that will convert Iron Golems into Steel Golems. "
 "Unfortunately, you have none of these troops in your army, so he can't help "
 "you."
 msgstr ""
@@ -3913,7 +4132,6 @@ msgstr ""
 "golemów w golemy stalowe. Niestety nie masz żadnej z tych jednostek w swojej "
 "armii, więc nie może ci pomóc."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2585
 msgid ""
 "A retired captain living on this refurbished fishing platform offers to sell "
 "you maps of the sea he made in his younger days for 1,000 gold. Do you wish "
@@ -3923,7 +4141,6 @@ msgstr ""
 "1000 sztuk złota oferuje ci morskie mapy, które wykonał w czasach młodości. "
 "Czy chcesz je kupić?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2598
 msgid ""
 "The captain sighs. \"You don't have enough money, eh?  You can't expect me "
 "to give my maps away for free!\""
@@ -3931,11 +4148,9 @@ msgstr ""
 "Kapitan wzdycha. \"Nie masz dość pieniędzy, co? Nie myśl sobie, że oddam ci "
 "moje mapy za darmo!\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2632
 msgid "You find %{artifact}."
 msgstr "Znajdujesz %{artifact}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2655
 msgid ""
 "You come upon an obelisk made from a type of stone you have never seen "
 "before. Staring at it intensely, the smooth surface suddenly changes to an "
@@ -3947,11 +4162,9 @@ msgstr ""
 "jakieś znaki układające się w mapę. Szybko kopiujesz rysunek, który wkrótce "
 "znika tak nagle, jak się pojawił."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2659
 msgid "You have already been to this obelisk."
 msgstr "Ten obelisk jest już ci znany."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2671
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"It is good to see "
 "you, my student. I hope my teachings have helped you.\""
@@ -3959,7 +4172,6 @@ msgstr ""
 "Drzewo obserwuje twoje przybycie z wyraźnym zadowoleniem. \"Witaj, miło cię "
 "znowu widzieć. Mam nadzieję, iż moja wiedza okazała się przydatna.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2683
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"Ahh, an "
 "adventurer! Allow me to teach you a little of what I have learned over the "
@@ -3968,11 +4180,9 @@ msgstr ""
 "Drzewo obserwuje twoje przybycie z wyraźnym zadowoleniem. \"Ach, strudzony "
 "podróżnik! Pozwól, że przekażę ci część mojej wielowiekowej wiedzy.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2692
 msgid "Upon your approach, the tree opens its eyes in delight."
 msgstr "Drzewo obserwuje twoje przybycie z wyraźnym zadowoleniem."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2694
 msgid ""
 "\"Ahh, an adventurer! I will be happy to teach you a little of what I have "
 "learned over the ages for a mere %{count} %{res}.\""
@@ -3980,23 +4190,24 @@ msgstr ""
 "\"Ah, wędrowiec! Będę szczęśliwy móc nauczyć Cię tego czego sam nauczyłem "
 "się przez te wszystkie lata za drobne %{count} %{res}.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2696
 msgid "(Just bury it around my roots.)"
 msgstr "(Zakop je po prostu pod moimi korzeniami.)"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2703
 msgid "Tears brim in the eyes of the tree."
 msgstr "Do oczu drzewa napływają łzy."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2705
 msgid "\"I need %{count} %{res}.\""
 msgstr "\"Potrzebuję %{count} %{res}.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2707
 msgid "it whispers. (sniff) \"Well, come back when you can pay me.\""
 msgstr "szepcze łkając. \"No cóż, wróć kiedy je zdobędziesz.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2737
+msgid ""
+"Nestled among the trees sits a blind seer. After explaining the intent of "
+"your journey, the seer activates his crystal ball, allowing you to see the "
+"strengths and weaknesses of your opponents."
+msgstr ""
+
 msgid ""
 "The entrance to the cave is dark, and a foul, sulfurous smell issues from "
 "the cave mouth. Will you enter?"
@@ -4004,7 +4215,6 @@ msgstr ""
 "Wejście do jaskini jest czarne jak smoła, a z ciemności twych nozdrzy "
 "dochodzi ohydny, siarkowy odór. Czy chcesz wejść?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2749
 msgid ""
 "You find a powerful and grotesque Demon in the cave. \"Today,\" it rasps, "
 "\"you will fight and surely die. But I will give you a choice of deaths. You "
@@ -4016,14 +4226,12 @@ msgstr ""
 "rodzaj śmierci. Możesz walczyć ze mną lub z moimi sługami. Wolisz walczyć z "
 "moimi sługami?\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2759
 msgid ""
 "Upon defeating the daemon's servants, you find a hidden cache with %{count} "
 "gold."
 msgstr ""
 "Po pokonaniu sługusów demona, odnajdujesz ukrytą skrzynię z %{count} złota."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2774
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and receive %{exp} experience points."
@@ -4031,7 +4239,6 @@ msgstr ""
 "Demon wydaje z siebie wyzywający krzyk i atakuje! Po krótkiej bitwie, "
 "zabijasz potwora i otrzymjesz %{exp} punktów doświadczenia."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2784
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and find the %{art} in the back of the cave."
@@ -4039,17 +4246,16 @@ msgstr ""
 "Demon ryczy i rusza do ataku! Po krótkiej i gwałtownej walce pokonujesz "
 "potwora, a w głębi jaskini znajdujesz artefakt - %{art}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2794
+#, fuzzy
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
-"battle, you slay the monster and receive %{exp) experience points and %"
-"{count} gold."
+"battle, you slay the monster and receive %{exp} experience points and "
+"%{count} gold."
 msgstr ""
 "Demon wykrzykując wyzywa Cię na pojedynek po czym atakuje. Po krótkiej, "
 "rozpaczliwej walce, zabijasz potwora i otrzymujesz %{exp) punktów "
 "doświadczenia i %{count} złota."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2809
 msgid ""
 "The Demon leaps upon you and has its claws at your throat before you can "
 "even draw your sword. \"Your life is mine,\" it says. \"I will sell it back "
@@ -4059,7 +4265,6 @@ msgstr ""
 "wyciągnąć miecz. \"Twoje życie jest moje\", powiedział. \"Odsprzedam Ci je "
 "za %{count} złota.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2810
 msgid ""
 "Seeing that you do not have %{count} gold, the demon slashes you with its "
 "claws, and the last thing you see is a red haze."
@@ -4067,15 +4272,12 @@ msgstr ""
 "Widząc, że nie masz %{count} złota, demon rozrywa Cię swoimi pazurami, a "
 "ostatnią rzeczą którą widzisz jest czerwona  mgiełka."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2835
 msgid "Except for evidence of a terrible battle, the cave is empty."
 msgstr "Jaskinia jest pusta, nie licząc śladów po straszliwej walce."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2860
 msgid "For %{gold} gold, the alchemist will remove it for you. Do you pay?"
 msgstr "Za %{gold} złota, alchemik usunie to za Ciebie. Czy chcesz zapłacić ?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2871
 msgid ""
 "You hear a voice from behind the locked door, \"You don't have enough gold "
 "to pay for my services.\""
@@ -4083,14 +4285,12 @@ msgstr ""
 "Słyszysz głos zza zamkniętych drzwi, \"Nie masz wystarczającej ilości złota "
 "aby zapłacić za moje usługi.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2874
 msgid ""
 "You hear a voice from high above in the tower, \"Go away! I can't help you!\""
 msgstr ""
 "Słyszysz głos dobiegający z górnych pięter wieży: \"Odejdź! Nie mogę ci "
 "pomóc!\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2886
 msgid ""
 "The head groom approaches you and speaks, \"You already have a fine horse, "
 "and have no inexperienced cavalry which might make use of our trained war "
@@ -4100,7 +4300,6 @@ msgstr ""
 "dowodzisz niedoświadczoną kawalerią, której mogłyby się przydać nasze "
 "szkolone rumaki bojowe.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2889
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, his "
@@ -4114,7 +4313,6 @@ msgstr ""
 "musisz wrócić po nowego konia. Mamy także wiele rumaków bojowych, które "
 "byłyby dobre dla kawalerii, ale nie masz z sobą takich oddziałów.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2892
 msgid ""
 "The head groom speaks to you, \"That is a fine looking horse you have. I am "
 "afraid we can give you no better, but the horses your cavalry are riding "
@@ -4126,7 +4324,6 @@ msgstr ""
 "nienajlepszej hodowli. Mamy wiele szkolony rumaków bojowych, które "
 "przydałyby się twoim jeźdźcom. Weź je, nalegam.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2895
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, he will "
@@ -4138,11 +4335,9 @@ msgstr ""
 "Niestety, po tygodniu jazdy się zmęczy. Pozwól, że dam ci również lepsze "
 "konie dla twych kawalerzystów, bo te wyglądają na dość marne.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2922
 msgid "The Arena guards turn you away."
 msgstr "Strażnicy Areny każą ci odejść."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2939
 msgid ""
 "As the sirens sing their eerie song, your small, determined army manages to "
 "overcome the urge to dive headlong into the sea."
@@ -4150,7 +4345,6 @@ msgstr ""
 "Chociaż pieśń syren brzmi niesamowicie, twojej zdeterminowanej załodze udaje "
 "się pokonać obezwładniającą chęć wyskoczenia za burtę."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2944
 msgid ""
 "You have your crew stop up their ears with wax before the sirens' eerie song "
 "has any chance of luring them to a watery grave. An eerie wailing song "
@@ -4164,7 +4358,6 @@ msgstr ""
 "poddaje się czarowi pieśni i skacze za burtę, pogrążając się na zawsze w "
 "odmętach oceanu. To smutne doświadczenie daje ci %{exp} pkt. doświadczenia."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2964
 msgid ""
 "In a dazzling display of daring, you break into the local jail and free the "
 "hero imprisoned there, who, in return, pledges loyalty to your cause."
@@ -4172,7 +4365,6 @@ msgstr ""
 "W gwałtownym porywie odwagi wyważasz drzwi więzienia i uwalniasz zamkniętego "
 "w nim bohatera, który w ramach wdzięczności przysięga ci lojalność."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2980
 msgid ""
 "You already have %{count} heroes, and regretfully must leave the prisoner in "
 "this jail to languish in agony for untold days."
@@ -4180,7 +4372,6 @@ msgstr ""
 "Dowodzisz już %{count} bohaterami, musisz więc pozostawić więźnia w jego "
 "celi, skazując go tym samym na powolną agonię w udręce."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2991
 msgid ""
 "You enter a rickety hut and talk to the magician who lives there. He tells "
 "you of places near and far which may aid you in your journeys."
@@ -4189,11 +4380,9 @@ msgstr ""
 "Opowiada ci o różnych odległych miejscach, co może okazać się pomocne w "
 "czasie twych podróży."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3004
 msgid "This eye seems to be intently studying its surroundings."
 msgstr "Oko wydaje się dokładnie studiować okolicę."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3015
 msgid ""
 "\"I have a riddle for you,\" the Sphinx says. \"Answer correctly, and you "
 "shall be rewarded. Answer incorrectly, and you shall be eaten. Do you accept "
@@ -4202,11 +4391,15 @@ msgstr ""
 "\"Mam dla ciebie zagadkę,\" mówi Sfinks. \"Jeśli odpowiesz dobrze, dam ci "
 "nagrodę. Jeśli odpowiesz źle, pożrę cię. Podejmujesz moje wyzwanie?\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3017
-msgid "The Sphinx asks you the following riddle: %{riddle}. Your answer?"
+#, fuzzy
+msgid ""
+"The Sphinx asks you the following riddle:\n"
+" \n"
+"'%{riddle}'\n"
+" \n"
+"Your answer?"
 msgstr "Sfinks zadaje ci następującą zagadkę: '%{riddle}' Twoja odpowiedź?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:3025
 msgid ""
 "Looking somewhat disappointed, the Sphinx sighs. You've answered my riddle "
 "so here's your reward. Now begone."
@@ -4214,7 +4407,6 @@ msgstr ""
 "Sfinks wygląda na rozczarowanego i wzdycha \"Udało ci się odpowiedzieć na "
 "moją zagadkę, więc oto twoja nagroda. A teraz odejdź.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3052
 msgid ""
 "\"You guessed incorrectly,\" the Sphinx says, smiling. The Sphinx swipes at "
 "you with a paw, knocking you to the ground. Another blow makes the world go "
@@ -4224,11 +4416,9 @@ msgstr ""
 "cię łapą i przyciska do ziemi. Po następnym ciosie świat ciemnieje ci przed "
 "oczami i nic więcej nie pamiętasz."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3060
 msgid "You come across a giant Sphinx. The Sphinx remains strangely quiet."
 msgstr "Zbliżasz się do wielkiego sfinksa, który tajemniczo milczy."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3073
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -4239,7 +4429,6 @@ msgstr ""
 "głosi, \"Wypowiedz słowo, a otworzy się przejście.\"\n"
 "Gdy wypowiadasz magiczne słowo, lśniąca bariera rozwiewa się w powietrzu."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3083
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -4250,7 +4439,6 @@ msgstr ""
 "głosi, \"Wypowiedz słowo, a otworzy się przejście.\"\n"
 "Wypowiadasz słowo, ale nic się nie dzieje."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3093
 msgid ""
 "You enter the tent and see an old woman gazing into a magic gem. She looks "
 "up and says,\n"
@@ -4262,7 +4450,6 @@ msgstr ""
 "tajemnych sztukach magii. Wyrocznia przekazała mi swoją wiedzę. Znam "
 "odpowiedź, której szukasz.\""
 
-#: ../fheroes2/heroes/heroes_base.cpp:401
 msgid ""
 "That spell costs %{mana} mana. You only have %{point} mana, so you can't "
 "cast the spell."
@@ -4270,324 +4457,10 @@ msgstr ""
 "To zaklęcie kosztuje %{mana} pkt. magii. Masz tylko %{point}, więc nie "
 "możesz go rzucić."
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Lord Kilburn"
-msgstr "Lord Kilburn"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Sir Gallanth"
-msgstr "Sir Gallant"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ector"
-msgstr "Ector"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Gwenneth"
-msgstr "Gwenneth"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Tyro"
-msgstr "Tyro"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ambrose"
-msgstr "Ambrose"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ruby"
-msgstr "Ruby"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Maximus"
-msgstr "Maximus"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Dimitry"
-msgstr "Dimitri"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Thundax"
-msgstr "Thundax"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Fineous"
-msgstr "Fineous"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jojosh"
-msgstr "Jojosh"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Crag Hack"
-msgstr "Crag Hack"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jezebel"
-msgstr "Jezebel"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jaclyn"
-msgstr "Jaclyn"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Ergon"
-msgstr "Ergon"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Tsabu"
-msgstr "Tsabu"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Atlas"
-msgstr "Atlas"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Astra"
-msgstr "Astra"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Natasha"
-msgstr "Natasha"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Troyan"
-msgstr "Troyan"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Vatawna"
-msgstr "Vatawna"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Rebecca"
-msgstr "Rebecca"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Gem"
-msgstr "Gem"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Ariel"
-msgstr "Ariel"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Carlawn"
-msgstr "Carlawn"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Luna"
-msgstr "Luna"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Arie"
-msgstr "Arie"
-
-#: ../fheroes2/heroes/heroes.cpp:61 ../fheroes2/resource/maps_text.cpp:59
-msgid "Alamar"
-msgstr "Alamar"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Vesper"
-msgstr "Vesper"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Crodo"
-msgstr "Crodo"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Barok"
-msgstr "Barok"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Kastore"
-msgstr "Kastore"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Agar"
-msgstr "Agar"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Falagar"
-msgstr "Falagar"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Wrathmont"
-msgstr "Wrathmont"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myra"
-msgstr "Myra"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Flint"
-msgstr "Flint"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Dawn"
-msgstr "Dawn"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Halon"
-msgstr "Halon"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myrini"
-msgstr "Myrini"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Wilfrey"
-msgstr "Wilfrey"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Sarakin"
-msgstr "Sarakin"
-
-#: ../fheroes2/heroes/heroes.cpp:63 ../fheroes2/resource/maps_text.cpp:377
-msgid "Kalindra"
-msgstr "Kalindra"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Mandigal"
-msgstr "Mandigal"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zom"
-msgstr "Zom"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Darlana"
-msgstr "Darlana"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zam"
-msgstr "Zam"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Ranloo"
-msgstr "Ranloo"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Charity"
-msgstr "Charity"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Rialdo"
-msgstr "Rialdo"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Roxana"
-msgstr "Roxana"
-
-#: ../fheroes2/heroes/heroes.cpp:65 ../fheroes2/resource/maps_text.cpp:557
-msgid "Sandro"
-msgstr "Sandro"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Celia"
-msgstr "Celia"
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:552
-msgid "Roland"
-msgstr "Roland"
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Lord Corlagon"
-msgstr "Lorda Corlagon"
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Sister Eliza"
-msgstr "Siostra Eliza"
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:88
-msgid "Archibald"
-msgstr "Archibald"
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:403
-msgid "Lord Halton"
-msgstr "Lord Halton"
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Brother Bax"
-msgstr "Brat Brax"
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Solmyr"
-msgstr "Solmyr"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:194
-msgid "Dainwin"
-msgstr "Dainwin"
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Mog"
-msgstr "Mog"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:760
-msgid "Uncle Ivan"
-msgstr "Wuj Ivan"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:373
-msgid "Joseph"
-msgstr "Joseph"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:285
-msgid "Gallavant"
-msgstr "Gallavant"
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Elderian"
-msgstr "Elderian"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:179
-msgid "Ceallach"
-msgstr "Ceallach"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:229
-msgid "Drakonia"
-msgstr "Drakonia"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:422
-msgid "Martine"
-msgstr "Martine"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:370
-msgid "Jarkonas"
-msgstr "Jarkonas"
-
-#: ../fheroes2/heroes/heroes.cpp:940
-msgid ""
-"You must purchase a spell book to use the mage guild, but you currently have "
-"no room for a spell book. Try giving one of your artifacts to another hero."
-msgstr ""
-"Aby korzystać z gildii magów, musisz kupić księgę czarów. W tej chwili nie "
-"masz jednak na nią miejsca. Spróbuj przekazać jeden ze swoich artefaktów "
-"innemu bohaterowi."
-
-#: ../fheroes2/heroes/heroes.cpp:950
-msgid "The three Anduran artifacts magically combine into one."
-msgstr "Trzy Anduriańskie artefakty magicznie połączone w jeden."
-
-#: ../fheroes2/heroes/heroes.cpp:1056
-msgid "To cast spells, you must first buy a spell book for %{gold} gold."
-msgstr ""
-"Aby móc rzucać zaklęcia, musisz najpierw kupić księgę czarów za %{gold} "
-"sztuk złota."
-
-#: ../fheroes2/heroes/heroes.cpp:1064
-msgid "Unfortunately, you seem to be a little short of cash at the moment."
-msgstr ""
-"Niestety wygląda na to, że w chwili obecnej brakuje ci trochę pieniędzy."
-
-#: ../fheroes2/heroes/heroes.cpp:1078
-msgid "Do you wish to buy one?"
-msgstr "Czy chcesz ją kupić?"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:72
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:55
-msgid "%{name} the %{race} ( Level %{level} )"
+#, fuzzy
+msgid "%{name} the %{race} (Level %{level})"
 msgstr "%{name}, %{race} ( Poziom %{level} )"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:118
 msgid ""
 "'Grouped' combat formation bunches your army together in the center of your "
 "side of the battlefield."
@@ -4595,99 +4468,79 @@ msgstr ""
 "Wybór zwartej formacji sprawia, że twoja armia zbierze się razem pośrodku "
 "twojej części pola bitwy."
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:161
 msgid "Are you sure you want to dismiss this Hero?"
 msgstr "Czy na pewno chcesz zwolnić tego bohatera?"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:341
 #, fuzzy
 msgid "View Stats"
 msgstr "Pokaż artefakty"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:344
-msgid "View Morale Info"
-msgstr "Morale - informacje"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:347
-msgid "View Luck Info"
-msgstr "Szczęście - informacje"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:350
 msgid "View Experience Info"
 msgstr "Doświadczenie - informacje"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:353
 msgid "View Spell Points Info"
 msgstr "Punkty magii - informacje"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:356
 msgid "Set army combat formation to 'Spread'"
 msgstr "Ustaw armię w luźnej formacji"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:359
 msgid "Set army combat formation to 'Grouped'"
 msgstr "Ustaw armię w zwartej formacji"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:362
-msgid "Exit hero"
-msgstr "Wyjście z ekranu bohatera"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:369
-msgid "Dismiss hero"
-msgstr "Zwolnij bohatera"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:373
-msgid "Show prev heroes"
-msgstr "Pokaż poprzedniego bohatera"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:376
-msgid "Show next heroes"
-msgstr "Pokaż następnego bohatera"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:379
-msgid "Hero Screen"
+#, fuzzy
+msgid "Exit Hero Screen"
 msgstr "Ekran bohatera"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:39
-msgid "Bad Morale"
-msgstr "Niskie morale"
+msgid "You cannot dismiss a hero in a castle"
+msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:42
-msgid "Neutral Morale"
-msgstr "Zwykłe morale"
+msgid "Dismissal of %{name} the %{race} is prohibited by scenario"
+msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:47
-msgid "Good Morale"
+#, fuzzy
+msgid "Dismiss %{name} the %{race}"
+msgstr "%{name}, %{race}"
+
+#, fuzzy
+msgid "Show previous hero"
+msgstr "Pokaż poprzednie miasto"
+
+#, fuzzy
+msgid "Show next hero"
+msgstr "Pokaż następnego bohatera"
+
+#, fuzzy
+msgid "Blood Morale"
 msgstr "Wysokie morale"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:61
-msgid "Bad Luck"
-msgstr "Niskie szczęście"
+#, fuzzy
+msgid "%{morale} Morale"
+msgstr "Zwykłe"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:64
-msgid "Neutral Luck"
-msgstr "Normalne szczęście"
+msgid "%{luck} Luck"
+msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:69
-msgid "Good Luck"
-msgstr "Wysokie szczęście"
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:113
-#: ../fheroes2/heroes/heroes_indicator.cpp:159
-#: ../fheroes2/heroes/skill.cpp:197
-msgid "Current Modifiers:"
+#, fuzzy
+msgid "Current Luck Modifiers:"
 msgstr "Aktualne modyfikatory:"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:195
-msgid "Current experience %{exp1} Next level %{exp2}."
+#, fuzzy
+msgid "Current Morale Modifiers:"
+msgstr "Aktualne modyfikatory:"
+
+#, fuzzy
+msgid "Entire army is undead, so morale does not apply."
+msgstr "Cały oddział nie jest martwy, więc morali nie przybyło."
+
+#, fuzzy
+msgid ""
+"Current experience %{exp1}.\n"
+" Next level %{exp2}."
 msgstr "Obecne doświadczenie %{exp1} Następny poziom %{exp2}."
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:215
 msgid "Level %{level}"
 msgstr "Poziom %{level}"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:226
 msgid ""
 "%{name} currently has %{point} spell points out of a maximum of %{max}. The "
 "maximum number of spell points is 10 times your knowledge. It is "
@@ -4699,88 +4552,76 @@ msgstr ""
 "możliwe jest posiadanie większej liczby punktów magii, dzięki specjalnym "
 "wydarzeniom."
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:65
 msgid "%{name1} meets %{name2}"
 msgstr "Spotkanie: %{name1} i %{name2}"
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:396
-#: ../fheroes2/heroes/heroes_meeting.cpp:406
 msgid " and "
 msgstr " i "
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:414
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
 msgstr ""
 "%{teacher}, którego %{level} %{scholar} zna wiele magicznych sekretów,  uczy "
 "%{spells1} z %{learner}, i uczy %{spells2} do %{learner}."
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:417
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}."
 msgstr ""
 "%{teacher}, którego %{level} %{scholar} zna wiele magicznych sekretów,  uczy "
 "%{spells1} od %{learner}."
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:420
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches %"
-"{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches "
+"%{spells2} to %{learner}."
 msgstr ""
 "%{teacher}, którego %{level} %{scholar} zna wiele magicznych sekretów,  uczy "
 "%{spells2} do %{learner}."
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:431
 msgid "Scholar Ability"
 msgstr "Zdolność uczonego"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:83 ../fheroes2/spell/spell.cpp:109
 msgid "Town Portal"
 msgstr "Miejski portal"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:86
 msgid "Select town to port to."
 msgstr "Wybierz miasto docelowe."
 
-#: ../fheroes2/heroes/heroes_spell.cpp:106
 msgid "Your hero is too tired to cast this spell today. Try again tomorrow."
 msgstr ""
 "Twój bohater jest zbyt zmęczony, by rzucić dziś to zaklęcie. Spróbuj "
 "ponownie jutro."
 
-#: ../fheroes2/heroes/heroes_spell.cpp:187
 #, fuzzy
 msgid "%{spell} failed!!!"
 msgstr "Czar nie udany!"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:236
+msgid "This spell is already in use."
+msgstr ""
+
 msgid "Enemy heroes are now fully identifiable."
 msgstr "Można już w pełni zidentyfikować wrogich bohaterów."
 
-#: ../fheroes2/heroes/heroes_spell.cpp:362
-#: ../fheroes2/heroes/heroes_spell.cpp:386
-msgid "No available towns. Spell Failed!!!"
+#, fuzzy
+msgid "This spell cannot be used on a boat."
+msgstr "Tego miasta nie można rozbudować do poziomu zamku."
+
+msgid "This spell can be casted only nearby water."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"No available towns.\n"
+"Spell Failed!!!"
 msgstr "Brak dostępnego miasta. Zaklęcie się nie udało!!!"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:459
-msgid "I fear these creatures are in the mood for a fight."
-msgstr "Obawiam się, że te stworzenia są gotowe do walki."
+#, fuzzy
+msgid ""
+"Nearest town occupied.\n"
+"Spell Failed!!!"
+msgstr "Brak dostępnego miasta. Zaklęcie się nie udało!!!"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:463
-msgid "The creatures are willing to join us!"
-msgstr "Te stworzenia są chętne przyłączyć się do nas!"
-
-#: ../fheroes2/heroes/heroes_spell.cpp:468
-msgid "All the creatures will join us..."
-msgstr "Wszystkie te stworzenia dołączą do nas..."
-
-#: ../fheroes2/heroes/heroes_spell.cpp:480
-msgid "These weak creatures will surely flee before us."
-msgstr "Te słabowite stworzenia na pewno przed nami uciekną."
-
-#: ../fheroes2/heroes/heroes_spell.cpp:489
 msgid ""
 "You must be within %{count} spaces of a monster for the Visions spell to "
 "work."
@@ -4788,7 +4629,18 @@ msgstr ""
 "Aby zaklęcie 'Wizje' zadziałało, musisz znajdować się w zasięgu %{count} pól "
 "od przeciwnika."
 
-#: ../fheroes2/heroes/heroes_spell.cpp:506
+msgid "I fear these creatures are in the mood for a fight."
+msgstr "Obawiam się, że te stworzenia są gotowe do walki."
+
+msgid "The creatures are willing to join us!"
+msgstr "Te stworzenia są chętne przyłączyć się do nas!"
+
+msgid "All the creatures will join us..."
+msgstr "Wszystkie te stworzenia dołączą do nas..."
+
+msgid "These weak creatures will surely flee before us."
+msgstr "Te słabowite stworzenia na pewno przed nami uciekną."
+
 msgid ""
 "You must be standing on the entrance to a mine (sawmills and alchemists "
 "don't count) to cast this spell."
@@ -4796,398 +4648,313 @@ msgstr ""
 "Aby móc rzucić to zaklęcie, musisz stać w wejściu do kopalni (tartaki i "
 "laboratoria nie są brane pod uwagę)."
 
-#: ../fheroes2/heroes/skill.cpp:151
-msgid "Power"
-msgstr "Moc"
-
-#: ../fheroes2/heroes/skill.cpp:172
 msgid "Your attack skill is a bonus added to each creature's attack skill."
 msgstr ""
 "Twój współczynnik ataku stanowi premię dodawaną do ataku każdej jednostki."
 
-#: ../fheroes2/heroes/skill.cpp:177
 msgid "Your defense skill is a bonus added to each creature's defense skill."
 msgstr ""
 "Twój współczynnik obrony stanowi premię dodawaną do obrony każdej jednostki."
 
-#: ../fheroes2/heroes/skill.cpp:182
 msgid "Your spell power determines the length or power of a spell."
 msgstr ""
 "Od twojej mocy zaklęć zależy długość i moc rzucanych przez ciebie czarów."
 
-#: ../fheroes2/heroes/skill.cpp:187
+#, fuzzy
 msgid ""
 "Your knowledge determines how many spell points your hero may have. Under "
-"normal cirumstances, a hero is limited to 10 spell points per level of "
+"normal circumstances, a hero is limited to 10 spell points per level of "
 "knowledge."
 msgstr ""
 "Od wiedzy zależy liczba punktów magii, jakie może posiadać bohater. W "
 "normalnych warunkach bohater ograniczony jest do 10 punktów magii na każdy "
 "poziom wiedzy."
 
-#: ../fheroes2/heroes/skill.cpp:214
+msgid "Current Modifiers:"
+msgstr "Aktualne modyfikatory:"
+
 msgid "skill|Basic"
 msgstr "umiejętność | podstawowa"
 
-#: ../fheroes2/heroes/skill.cpp:214
 msgid "skill|Advanced"
 msgstr "umiejętność | zawaansowana"
 
-#: ../fheroes2/heroes/skill.cpp:214
 msgid "skill|Expert"
 msgstr "umiejętność | ekspert"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Pathfinding"
 msgstr "Znaj. drogi"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Archery"
 msgstr "Łucznictwo"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Logistics"
 msgstr "Logistyka"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Scouting"
 msgstr "Zwiad"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Diplomacy"
 msgstr "Dyplomacja"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Navigation"
 msgstr "Nawigacja"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Leadership"
 msgstr "Dowodzenie"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Wisdom"
 msgstr "Mądrość"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Mysticism"
 msgstr "Mistycyzm"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Ballistics"
 msgstr "Balistyka"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Eagle Eye"
 msgstr "Sokole oko"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Necromancy"
 msgstr "Nekromancja"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Estates"
 msgstr "Finanse"
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Basic Pathfinding"
 msgstr "Podstawowy Znajdowanie Drogi"
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Advanced Pathfinding"
 msgstr "Zaawansowany Znajdowanie Drogi"
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Expert Pathfinding"
 msgstr "Ekspert Znajdowanie Drogi"
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Basic Archery"
 msgstr "Podstawowe łucznictwo"
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Advanced Archery"
 msgstr "Zawaansowane łucznictwo"
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Expert Archery"
 msgstr "Mistrzowskie łucznictwo"
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Basic Logistics"
 msgstr "Podstawowa logistyka"
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Advanced Logistics"
 msgstr "Zawaansowana logistyka"
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Expert Logistics"
 msgstr "Mistrzowska logistyka"
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Basic Scouting"
 msgstr "Podstawowy Zwiadowca"
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Advanced Scouting"
 msgstr "Zaawansowany Zwiadowca"
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Expert Scouting"
 msgstr "Ekspert Zwiadowca"
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Basic Diplomacy"
 msgstr "Podstawowa dyplomacja"
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Advanced Diplomacy"
 msgstr "Zawaansowana dyplomacja"
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Expert Diplomacy"
 msgstr "Mistrzowska dyplomacja"
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Basic Navigation"
 msgstr "Podstawowa nawigacja"
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Advanced Navigation"
 msgstr "Zawaansowana nawigacja"
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Expert Navigation"
 msgstr "Mistrzowska nawigacja"
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Basic Leadership"
 msgstr "Podstawowe przywództwo"
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Advanced Leadership"
 msgstr "Zawaansowane przywództwo"
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Expert Leadership"
 msgstr "Mistrzowskie przywództwo"
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Basic Wisdom"
 msgstr "Podstawowa mądrość"
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Advanced Wisdom"
 msgstr "Zawaansowana mądrość"
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Expert Wisdom"
 msgstr "Mistrzowska mądrość"
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Basic Mysticism"
 msgstr "Podstawowy mistycyzm"
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Advanced Mysticism"
 msgstr "Zawaansowany mistycyzm"
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Expert Mysticism"
 msgstr "Mistrzowski mistycyzm"
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Basic Luck"
 msgstr "Podstawowe szczęście"
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Advanced Luck"
 msgstr "Zawaansowane szczęście"
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Expert Luck"
 msgstr "Mistrzowskie szczęście"
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Basic Ballistics"
 msgstr "Podstawowa balistyka"
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Advanced Ballistics"
 msgstr "Zawaansowana balistyka"
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Expert Ballistics"
 msgstr "Mistrzowska balistyka"
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Basic Eagle Eye"
 msgstr "Podstowowy wzrok orła"
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Advanced Eagle Eye"
 msgstr "Zawaansowany wzrok orła"
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Expert Eagle Eye"
 msgstr "Mistrzowski wzrok orła"
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Basic Necromancy"
 msgstr "Podstowowa nekromancja"
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Advanced Necromancy"
 msgstr "Zawaansowana nekromancja"
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Expert Necromancy"
 msgstr "Mistrzowska nekromancja"
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Basic Estates"
 msgstr "Podstawowy Majątek"
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Advanced Estates"
 msgstr "Zaawansowany Majątek"
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Expert Estates"
 msgstr "Ekspert Majątek"
 
-#: ../fheroes2/heroes/skill.cpp:406
-msgid "Allows you to negotiate with monsters who are weaker than your group."
+#, fuzzy
+msgid " allows you to negotiate with monsters who are weaker than your group."
 msgstr "Pozwala na negocjacje z potworami, które są słabsze niż twoja grupa."
 
-#: ../fheroes2/heroes/skill.cpp:421
-msgid "Allows your hero to learn third level spells."
+#, fuzzy
+msgid "All of the creatures may offer to join you."
+msgstr "Około %{count} procent stworzeń może zaoferować dołączenie do ciebie."
+
+#, fuzzy
+msgid " allows your hero to learn third level spells."
 msgstr "Pozwala nauczyć się twojemu bohaterowi trzeci poziom czarów."
 
-#: ../fheroes2/heroes/skill.cpp:423
-msgid "Allows your hero to learn fourth level spells."
+#, fuzzy
+msgid " allows your hero to learn fourth level spells."
 msgstr "Pozwala nauczyć się twojemu bohaterowi czwarty poziom czarów."
 
-#: ../fheroes2/heroes/skill.cpp:425
-msgid "Allows your hero to learn fifth level spells."
+#, fuzzy
+msgid " allows your hero to learn fifth level spells."
 msgstr "Pozwala nauczyć się twojemu bohaterowi piąty poziom czarów."
 
-#: ../fheroes2/heroes/skill.cpp:440
+#, fuzzy
 msgid ""
-"Gives your hero's catapult shots a greater chance to hit and do damage to "
+" gives your hero's catapult shots a greater chance to hit and do damage to "
 "castle walls."
 msgstr "Zwiększa szanse na uszkodzenie murów zamkowych przez katapultę."
 
-#: ../fheroes2/heroes/skill.cpp:442
+#, fuzzy
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot has a greater chance "
-"to hit and do damage to castle walls."
+" gives your hero's catapult an extra shot, and each shot has a greater "
+"chance to hit and do damage to castle walls."
 msgstr ""
 "Daje twojej katapulcie dodatkowy strzał, każdy strzał ma większą szansę na "
 "zniszczenie murów obronnych zamku."
 
-#: ../fheroes2/heroes/skill.cpp:444
+#, fuzzy
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot automatically "
+" gives your hero's catapult an extra shot, and each shot automatically "
 "destroys any wall, except a fortified wall in a Knight town."
 msgstr ""
 "Dodaje dodatkowy strzał dla Twojej katapulty, a każdy strzał automatycznie "
 "niszczy dowolną ścianę, z wyjątkiem murów obronnych zamku Rycerza."
 
-#: ../fheroes2/heroes/skill.cpp:858 ../fheroes2/heroes/skill.cpp:959
-msgid "View %{skill} Info"
-msgstr "Wyświetl informacje o %{skill}"
-
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:108
 msgid "Blue"
 msgstr "Niebieski"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:111
 msgid "Green"
 msgstr "Zielony"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:114
 msgid "Red"
 msgstr "Czerwony"
 
-#: ../fheroes2/kingdom/color.cpp:32
 msgid "Yellow"
 msgstr "Żółty"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:112
 msgid "Orange"
 msgstr "Pomarańczowy"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:113
 msgid "Purple"
 msgstr "Fioletowy"
 
-#: ../fheroes2/kingdom/color.cpp:107
 msgid "Aqua"
 msgstr "Seledynowy"
 
-#: ../fheroes2/kingdom/color.cpp:109
 msgid "Brown"
 msgstr "Brązowy"
 
-#: ../fheroes2/kingdom/color.cpp:110 ../fheroes2/resource/resource.cpp:283
 msgid "Gold"
 msgstr "Złoty"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:238
 msgid "Hero/Stats"
 msgstr "Bohater/Statystyki"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:241
 msgid "Skills"
 msgstr "Umiejętności"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:244
 msgid "Artifacts"
 msgstr "Artefakty"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:473
 msgid "Town/Castle"
 msgstr "Miasto/Zamek"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:476
 msgid "Garrison"
 msgstr "Garnizon"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:566
 msgid "Gold Per Day:"
 msgstr "Złota na dzień."
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Cursed"
 msgstr "Beznadziejne"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Awful"
 msgstr "Bardzo niskie"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Bad"
 msgstr "Niskie"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Normal"
 msgstr "Normalne"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Good"
 msgstr "Spore"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Great"
 msgstr "Wielkie"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Irish"
 msgstr "Przysłowiowe"
 
-#: ../fheroes2/kingdom/luck.cpp:48
 msgid ""
 "Bad luck sometimes falls on your armies in combat, causing their attacks to "
 "only do half damage."
@@ -5195,7 +4962,6 @@ msgstr ""
 "Niskie szczęście na polu bitwy oznacza, że twoje jednostki zadawać będą "
 "dwukrotnie mniejsze obrażenia."
 
-#: ../fheroes2/kingdom/luck.cpp:49
 msgid ""
 "Neutral luck means your armies will never get lucky or unlucky attacks on "
 "the enemy."
@@ -5203,7 +4969,6 @@ msgstr ""
 "Normalne szczęście oznacza, iż twoje jednostki nigdy nie będą otrzymywać "
 "premii na polu bitwy, ale też nie będą miały pecha."
 
-#: ../fheroes2/kingdom/luck.cpp:50
 msgid ""
 "Good luck sometimes lets your armies get lucky attacks (double strength) in "
 "combat."
@@ -5211,41 +4976,32 @@ msgstr ""
 "Wysokie szczęście sprawia, że twoim oddziałom czasami udaje się zadać ataki "
 "o podwójnej sile."
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Treason"
 msgstr "Tragiczne"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Awful"
 msgstr "Bardzo niskie"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Poor"
 msgstr "Niskie"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Normal"
 msgstr "Zwykłe"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Good"
 msgstr "Wysokie"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Great"
 msgstr "Bardzo wysokie"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Blood!"
 msgstr "Krwi!"
 
-#: ../fheroes2/kingdom/morale.cpp:48
 msgid "Bad morale may cause your armies to freeze in combat."
 msgstr ""
 "Niskie morale może sprawić, że twoje oddziały zastygną w bezruchu podczas "
 "walki."
 
-#: ../fheroes2/kingdom/morale.cpp:49
 msgid ""
 "Neutral morale means your armies will never be blessed with extra attacks or "
 "freeze in combat."
@@ -5253,1722 +5009,761 @@ msgstr ""
 "Zwykłe morale oznacza, że twoje wojska nigdy nie otrzymają dodatkowego ataku "
 "ani też nie zastygną w bezruchu podczas walki."
 
-#: ../fheroes2/kingdom/morale.cpp:50
 msgid "Good morale may give your armies extra attacks in combat."
 msgstr ""
 "Wysokie morale może sprawić, że twoje oddziały otrzymają dodatkowy atak "
 "podczas walki."
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Knight"
 msgstr "Rycerz"
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Barbarian"
 msgstr "Barbarzyńca"
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Sorceress"
 msgstr "Czarodziejka"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Warlock"
 msgstr "Czarnoksiężnik"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Wizard"
 msgstr "Czarodziej"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Necromancer"
 msgstr "Nekromanta"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Multi"
 msgstr "Multi"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Standing"
 msgstr "Stoi"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Crawling"
 msgstr "Pełza"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Very Slow"
 msgstr "Bardzo niska"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Slow"
 msgstr "Niska"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Average"
 msgstr "Średnia"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Fast"
 msgstr "Duża"
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Very Fast"
 msgstr "Bardzo duża"
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Ultra Fast"
 msgstr "Super duża"
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Blazing"
 msgstr "Ogromna"
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Instant"
 msgstr "Błyskawica"
 
-#: ../fheroes2/kingdom/week.cpp:32
 msgid "week|PLAGUE"
 msgstr "PLAGA"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Ant"
 msgstr "Mrówka"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Grasshopper"
 msgstr "Świerszcz"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Dragonfly"
 msgstr "Ważka"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Spider"
 msgstr "Pająk"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Butterfly"
 msgstr "Motyl"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Bumblebee"
 msgstr "Trzmiel"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Locust"
 msgstr "Szarańcza"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Earthworm"
 msgstr "Dżdżownica"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Hornet"
 msgstr "Szerszeń"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Beetle"
 msgstr "Żuk"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Squirrel"
 msgstr "Wiewiórka"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Rabbit"
 msgstr "Królik"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Gopher"
 msgstr "Świstak"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Badger"
 msgstr "Borsuk"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Eagle"
 msgstr "Orzeł"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Weasel"
 msgstr "Łasica"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Raven"
 msgstr "Kruk"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Mongoose"
 msgstr "Mangusta"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Aardvark"
 msgstr "Mrówkojad"
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Lizard"
 msgstr "Jaszczurka"
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Tortoise"
 msgstr "Żółw"
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Hedgehog"
 msgstr "Jeż"
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Condor"
 msgstr "Kondor"
 
-#: ../fheroes2/kingdom/world_loadmap.cpp:1424
-#, fuzzy
-msgid "The ultimate artifact is really the %{name}"
-msgstr "Ta jednostka (%{name}) zostaje dotknięta klątwą mumii!"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1428
-msgid "The ultimate artifact may be found in the %{name} regions of the world."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1433
-msgid "north-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1436
-#, fuzzy
-msgid "north"
-msgstr "Enroth"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1438
-msgid "north-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1444
-#, fuzzy
-msgid "west"
-msgstr "Gniazdo"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1447
-#, fuzzy
-msgid "center"
-msgstr "Potwór"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1449
-#, fuzzy
-msgid "east"
-msgstr "Gniazdo"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1454
-msgid "south-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1457
-#, fuzzy
-msgid "south"
-msgstr "dźwięk"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1459
-msgid "south-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1463
-msgid "The truth is out there."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1464
-msgid "The dark side is stronger."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1465
-#, fuzzy
-msgid "The end of the world is near."
-msgstr "Strzeż się skraju świata!"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1466
-msgid "The bones of Lord Slayer are buried in the foundation of the arena."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1467
-msgid "A Black Dragon will take out a Titan any day of the week."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1468
-msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1470
-msgid ""
-"You can load the newest version of game from a site:\n"
-" http://sf.net/projects/fheroes2"
-msgstr ""
-"Możesz pobrać najnowszą wersję gry ze strony:\n"
-" http://sf.net/projects/fheroes2"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1471
-msgid "This game is now in beta development version. ;)"
-msgstr "Gra jest obecnie w wersji beta. ;)"
-
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Desert"
 msgstr "Pustynia"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Snow"
 msgstr "Śnieg"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Wasteland"
 msgstr "Wyschnięty"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Beach"
 msgstr "Plaża"
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Lava"
 msgstr "Lawa"
 
-#: ../fheroes2/maps/ground.cpp:31 ../fheroes2/resource/maps_text.cpp:210
 msgid "Dirt"
 msgstr "Pył"
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Grass"
 msgstr "Trawa"
 
-#: ../fheroes2/maps/ground.cpp:31
-msgid "Water"
-msgstr "Woda"
+msgid "Ocean"
+msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Small"
 msgstr "Mapy|Małe"
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Medium"
 msgstr "Mapy|Średnie"
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Large"
 msgstr "Mapy|Duże"
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Extra Large"
 msgstr "Mapy|Olbrzymie"
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Custom Size"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:122
 msgid "Ore Mine"
 msgstr "Kopalnia rudy"
 
-#: ../fheroes2/maps/maps.cpp:123
 msgid "Sulfur Mine"
 msgstr "Kopalnia siarki"
 
-#: ../fheroes2/maps/maps.cpp:124
 msgid "Crystal Mine"
 msgstr "Kopalnia kryształów"
 
-#: ../fheroes2/maps/maps.cpp:125
 msgid "Gems Mine"
 msgstr "Kopalnia klejnotów"
 
-#: ../fheroes2/maps/maps.cpp:126
 msgid "Gold Mine"
 msgstr "Kopalnia złota"
 
-#: ../fheroes2/maps/maps.cpp:130
 msgid "Mine"
 msgstr "Kopalnia"
 
-#: ../fheroes2/maps/mp2.cpp:365
 msgid "Alchemist Lab"
 msgstr "Laboratorium"
 
-#: ../fheroes2/maps/mp2.cpp:367
 msgid "Daemon Cave"
 msgstr "Jaskinia demona"
 
-#: ../fheroes2/maps/mp2.cpp:369
 msgid "Faerie Ring"
 msgstr "Zaklęty krąg"
 
-#: ../fheroes2/maps/mp2.cpp:373 ../fheroes2/resource/maps_text.cpp:217
 msgid "Dragon City"
 msgstr "Smocze Miasto"
 
-#: ../fheroes2/maps/mp2.cpp:375
-msgid "Light House"
+#, fuzzy
+msgid "Lighthouse"
 msgstr "Latarnia morska"
 
-#: ../fheroes2/maps/mp2.cpp:377
 msgid "Water Wheel"
 msgstr "Młyn wodny"
 
-#: ../fheroes2/maps/mp2.cpp:379
 msgid "Mines"
 msgstr "Kopalnia"
 
-#: ../fheroes2/maps/mp2.cpp:381
 msgid "Obelisk"
 msgstr "Obelisk"
 
-#: ../fheroes2/maps/mp2.cpp:383
 msgid "Oasis"
 msgstr "Oaza"
 
-#: ../fheroes2/maps/mp2.cpp:385
 msgid "Sawmill"
 msgstr "Tartak"
 
-#: ../fheroes2/maps/mp2.cpp:387
 msgid "Oracle"
 msgstr "Wyrocznia"
 
-#: ../fheroes2/maps/mp2.cpp:389
 msgid "Desert Tent"
 msgstr "Namiot na pustyni"
 
-#: ../fheroes2/maps/mp2.cpp:393
 msgid "Wagon Camp"
 msgstr "Tabor"
 
-#: ../fheroes2/maps/mp2.cpp:395
 msgid "Windmill"
 msgstr "Wiatrak"
 
-#: ../fheroes2/maps/mp2.cpp:397
 msgid "Random Town"
 msgstr "Losowe miasto"
 
-#: ../fheroes2/maps/mp2.cpp:399
 msgid "Random Castle"
 msgstr "Losowy zamek"
 
-#: ../fheroes2/maps/mp2.cpp:401
 msgid "Watch Tower"
 msgstr "Wieża strażnicza"
 
-#: ../fheroes2/maps/mp2.cpp:403
 msgid "Tree City"
 msgstr "Nadrzewne miasto"
 
-#: ../fheroes2/maps/mp2.cpp:405
 msgid "Tree House"
 msgstr "Dom na drzewie"
 
-#: ../fheroes2/maps/mp2.cpp:407
 msgid "Ruins"
 msgstr "Ruiny"
 
-#: ../fheroes2/maps/mp2.cpp:409
 msgid "Fort"
 msgstr "Fort"
 
-#: ../fheroes2/maps/mp2.cpp:411
-msgid "Trading Post"
-msgstr "Faktoria handlowa"
-
-#: ../fheroes2/maps/mp2.cpp:413
 msgid "Abandoned Mine"
 msgstr "Opuszczona kopalnia"
 
-#: ../fheroes2/maps/mp2.cpp:415
 msgid "Tree of Knowledge"
 msgstr "Drzewo Wiedzy"
 
-#: ../fheroes2/maps/mp2.cpp:417
 msgid "Witch Doctor's Hut"
 msgstr "Chatka znachora"
 
-#: ../fheroes2/maps/mp2.cpp:419
 msgid "Temple"
 msgstr "Świątynia"
 
-#: ../fheroes2/maps/mp2.cpp:421
 msgid "Hill Fort"
 msgstr "Fort na wzgórzu"
 
-#: ../fheroes2/maps/mp2.cpp:423
 msgid "Halfling Hole"
 msgstr "Norka niziołków"
 
-#: ../fheroes2/maps/mp2.cpp:425
 msgid "Mercenary Camp"
 msgstr "Obóz najemników"
 
-#: ../fheroes2/maps/mp2.cpp:429
 msgid "City of the Dead"
 msgstr "Miasto Umarłych"
 
-#: ../fheroes2/maps/mp2.cpp:433
 msgid "Sphinx"
 msgstr "Sfinks"
 
-#: ../fheroes2/maps/mp2.cpp:435
 msgid "Troll Bridge"
 msgstr "Most trolli"
 
-#: ../fheroes2/maps/mp2.cpp:437
 msgid "Witch Hut"
 msgstr "Chatka wiedźmy"
 
-#: ../fheroes2/maps/mp2.cpp:439
 msgid "Xanadu"
 msgstr "Xanadu"
 
-#: ../fheroes2/maps/mp2.cpp:443
 msgid "Magellan Maps"
 msgstr "Mapy Magellana"
 
-#: ../fheroes2/maps/mp2.cpp:445
 msgid "Derelict Ship"
 msgstr "Opuszczony statek"
 
-#: ../fheroes2/maps/mp2.cpp:447
-msgid "Ship Wreck"
-msgstr "Szczątki statku"
+#, fuzzy
+msgid "Shipwreck"
+msgstr "Rozbitkowie!"
 
-#: ../fheroes2/maps/mp2.cpp:449
 msgid "Observation Tower"
 msgstr "Wieża obserwacyjna"
 
-#: ../fheroes2/maps/mp2.cpp:451
-msgid "Freeman Foundry"
+#, fuzzy
+msgid "Freeman's Foundry"
 msgstr "Odlewnia"
 
-#: ../fheroes2/maps/mp2.cpp:453
 msgid "Watering Hole"
 msgstr "Źródło"
 
-#: ../fheroes2/maps/mp2.cpp:455
 msgid "Artesian Spring"
 msgstr "Studnia artezyjska"
 
-#: ../fheroes2/maps/mp2.cpp:457
 msgid "Gazebo"
 msgstr "Altana"
 
-#: ../fheroes2/maps/mp2.cpp:459
 msgid "Archer's House"
 msgstr "Dom łuczników"
 
-#: ../fheroes2/maps/mp2.cpp:461
 msgid "Peasant Hut"
 msgstr "Chłopska chata"
 
-#: ../fheroes2/maps/mp2.cpp:463
 msgid "Dwarf Cottage"
 msgstr "Domek krasnoludów"
 
-#: ../fheroes2/maps/mp2.cpp:465
 msgid "Stone Liths"
 msgstr "Kamienny Lith"
 
-#: ../fheroes2/maps/mp2.cpp:467
 msgid "Magic Well"
 msgstr "Magiczna studnia"
 
-#: ../fheroes2/maps/mp2.cpp:468
 msgid "Heroes"
 msgstr "Bohaterowie"
 
-#: ../fheroes2/maps/mp2.cpp:470 ../fheroes2/maps/mp2.cpp:488
-msgid "Shrub"
-msgstr "Krzak"
-
-#: ../fheroes2/maps/mp2.cpp:471
 msgid "Nothing Special"
 msgstr "Nic specjalnego"
 
-#: ../fheroes2/maps/mp2.cpp:472
 msgid "Tar Pit"
 msgstr "Smoła"
 
-#: ../fheroes2/maps/mp2.cpp:473
-msgid "Coast"
-msgstr "Wybrzeże"
-
-#: ../fheroes2/maps/mp2.cpp:474
 msgid "Mound"
 msgstr "Kopiec"
 
-#: ../fheroes2/maps/mp2.cpp:475
 msgid "Dune"
 msgstr "Wydma"
 
-#: ../fheroes2/maps/mp2.cpp:476
 msgid "Stump"
 msgstr "Pieniek"
 
-#: ../fheroes2/maps/mp2.cpp:477
 msgid "Cactus"
 msgstr "Kaktus"
 
-#: ../fheroes2/maps/mp2.cpp:478
 msgid "Trees"
 msgstr "Drzewa"
 
-#: ../fheroes2/maps/mp2.cpp:479
 msgid "Dead Tree"
 msgstr "Martwe drzewo"
 
-#: ../fheroes2/maps/mp2.cpp:480
 msgid "Mountains"
 msgstr "Góry"
 
-#: ../fheroes2/maps/mp2.cpp:481
 msgid "Volcano"
 msgstr "Wulkan"
 
-#: ../fheroes2/maps/mp2.cpp:482
 msgid "Rock"
 msgstr "Kamień"
 
-#: ../fheroes2/maps/mp2.cpp:483
 msgid "Flowers"
 msgstr "Kwiaty"
 
-#: ../fheroes2/maps/mp2.cpp:484
 msgid "Water Lake"
 msgstr "Jezioro"
 
-#: ../fheroes2/maps/mp2.cpp:485
 msgid "Mandrake"
 msgstr "Mandragora"
 
-#: ../fheroes2/maps/mp2.cpp:486
 msgid "Crater"
 msgstr "Krater"
 
-#: ../fheroes2/maps/mp2.cpp:487
 msgid "Lava Pool"
 msgstr "Jezioro lawy"
 
-#: ../fheroes2/maps/mp2.cpp:489
+msgid "Shrub"
+msgstr "Krzak"
+
 msgid "Buoy"
 msgstr "Boja"
 
-#: ../fheroes2/maps/mp2.cpp:491 ../fheroes2/monster/monster.cpp:116
 #, fuzzy
 msgid "Skeleton"
 msgstr "Szkielet"
 
-#: ../fheroes2/maps/mp2.cpp:492
 msgid "Treasure Chest"
 msgstr "Skrzynia ze skarbem"
 
-#: ../fheroes2/maps/mp2.cpp:493
 msgid "Sea Chest"
 msgstr "Skrzynia"
 
-#: ../fheroes2/maps/mp2.cpp:494
 msgid "Campfire"
 msgstr "Obozowisko"
 
-#: ../fheroes2/maps/mp2.cpp:495
 msgid "Fountain"
 msgstr "Fontanna"
 
-#: ../fheroes2/maps/mp2.cpp:496
 msgid "Genie Lamp"
 msgstr "Lampa dżinna"
 
-#: ../fheroes2/maps/mp2.cpp:497
 msgid "Goblin Hut"
 msgstr "Chata goblinów"
 
-#: ../fheroes2/maps/mp2.cpp:499
 msgid "Monster"
 msgstr "Potwór"
 
-#: ../fheroes2/maps/mp2.cpp:500
 msgid "Resource"
 msgstr "Surowiec"
 
-#: ../fheroes2/maps/mp2.cpp:501
 msgid "Whirlpool"
 msgstr "Wir"
 
-#: ../fheroes2/maps/mp2.cpp:502
 msgid "Artifact"
 msgstr "Artefakt"
 
-#: ../fheroes2/maps/mp2.cpp:503
 msgid "Boat"
 msgstr "Łódź"
 
-#: ../fheroes2/maps/mp2.cpp:510
 msgid "Standing Stones"
 msgstr "Krąg kamieni"
 
-#: ../fheroes2/maps/mp2.cpp:514
 msgid "Idol"
 msgstr "Bożek"
 
-#: ../fheroes2/maps/mp2.cpp:515
 msgid "Shrine of the First Circle"
 msgstr "Kaplica pierwszego kręg"
 
-#: ../fheroes2/maps/mp2.cpp:516
 msgid "Shrine of the Second Circle"
 msgstr "Kaplica drugiego kręgu"
 
-#: ../fheroes2/maps/mp2.cpp:517
 msgid "Shrine of the Third Circle"
 msgstr "Kaplica trzeciego kręgu"
 
-#: ../fheroes2/maps/mp2.cpp:518
 msgid "Wagon"
 msgstr "Wóz"
 
-#: ../fheroes2/maps/mp2.cpp:519
 msgid "Lean To"
 msgstr "Szopa"
 
-#: ../fheroes2/maps/mp2.cpp:520
 msgid "Flotsam"
 msgstr "Szczątki statku"
 
-#: ../fheroes2/maps/mp2.cpp:521
 msgid "Shipwreck Survivor"
 msgstr "Ocalały rozbitek"
 
-#: ../fheroes2/maps/mp2.cpp:522
 msgid "Bottle"
 msgstr "Butelka"
 
-#: ../fheroes2/maps/mp2.cpp:523
 msgid "Magic Garden"
 msgstr "Magiczny ogród"
 
-#: ../fheroes2/maps/mp2.cpp:529
 msgid "Jail"
 msgstr "Więzienie"
 
-#: ../fheroes2/maps/mp2.cpp:531
 msgid "Traveller's Tent"
 msgstr "Namiot podróżnika"
 
-#: ../fheroes2/maps/mp2.cpp:532
 msgid "Barrier"
 msgstr "Bariera"
 
-#: ../fheroes2/maps/mp2.cpp:535
 msgid "Fire Summoning Altar"
 msgstr "Ołtarz Ognia"
 
-#: ../fheroes2/maps/mp2.cpp:537
 msgid "Air Summoning Altar"
 msgstr "Ołtarz Powietrza"
 
-#: ../fheroes2/maps/mp2.cpp:539
 msgid "Earth Summoning Altar"
 msgstr "Ołtarz Ziemi"
 
-#: ../fheroes2/maps/mp2.cpp:541
 msgid "Water Summoning Altar"
 msgstr "Ołtarz Wody"
 
-#: ../fheroes2/maps/mp2.cpp:543
 msgid "Barrow Mounds"
 msgstr "Kurhany"
 
-#: ../fheroes2/maps/mp2.cpp:545
-msgid "Arena"
-msgstr "Arena"
-
-#: ../fheroes2/maps/mp2.cpp:547
 msgid "Stables"
 msgstr "Stajnie"
 
-#: ../fheroes2/maps/mp2.cpp:549
 msgid "Alchemist's Tower"
 msgstr "Wieża alchemika"
 
-#: ../fheroes2/maps/mp2.cpp:551
 msgid "Hut of the Magi"
 msgstr "Chata maga"
 
-#: ../fheroes2/maps/mp2.cpp:553
 msgid "Eye of the Magi"
 msgstr "Oko maga"
 
-#: ../fheroes2/maps/mp2.cpp:555
 msgid "Mermaid"
 msgstr "Syrena"
 
-#: ../fheroes2/maps/mp2.cpp:557
 msgid "Sirens"
 msgstr "Syreny"
 
-#: ../fheroes2/maps/mp2.cpp:558
 msgid "Reefs"
 msgstr "Rafy"
 
-#: ../fheroes2/monster/monster.cpp:59
-#, fuzzy
-msgid "Peasant"
-msgstr "Chłop"
-
-#: ../fheroes2/monster/monster.cpp:59 ../fheroes2/resource/maps_text.cpp:501
-msgid "Peasants"
-msgstr "Chłopi"
-
-#: ../fheroes2/monster/monster.cpp:60
-#, fuzzy
-msgid "Archer"
-msgstr "Łucznik"
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Archers"
-msgstr "Łucznicy"
-
-#: ../fheroes2/monster/monster.cpp:61
-#, fuzzy
-msgid "Ranger"
-msgstr "Łowca"
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Rangers"
-msgstr "Łowcy"
-
-#: ../fheroes2/monster/monster.cpp:62
-#, fuzzy
-msgid "Pikeman"
-msgstr "Pikinier"
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Pikemen"
-msgstr "Pikinierzy"
-
-#: ../fheroes2/monster/monster.cpp:63
-#, fuzzy
-msgid "Veteran Pikeman"
-msgstr "Weteran"
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Veteran Pikemen"
-msgstr "Weterani"
-
-#: ../fheroes2/monster/monster.cpp:64
-#, fuzzy
-msgid "Swordsman"
-msgstr "Zbrojny"
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Swordsmen"
-msgstr "Zbrojni"
-
-#: ../fheroes2/monster/monster.cpp:65
-#, fuzzy
-msgid "Master Swordsman"
-msgstr "Mistrz miecza"
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Master Swordsmen"
-msgstr "Mistrzowie miecza"
-
-#: ../fheroes2/monster/monster.cpp:66
-#, fuzzy
-msgid "Cavalry"
-msgstr "Konny"
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Cavalries"
-msgstr "Konni"
-
-#: ../fheroes2/monster/monster.cpp:67
-#, fuzzy
-msgid "Champion"
-msgstr "Czempion"
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Champions"
-msgstr "Czempioni"
-
-#: ../fheroes2/monster/monster.cpp:68
-#, fuzzy
-msgid "Paladin"
-msgstr "Paladyn"
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Paladins"
-msgstr "Paladyni"
-
-#: ../fheroes2/monster/monster.cpp:69
-#, fuzzy
-msgid "Crusader"
-msgstr "Krzyżowiec"
-
-#: ../fheroes2/monster/monster.cpp:69
-msgid "Crusaders"
-msgstr "Krzyżowcy"
-
-#: ../fheroes2/monster/monster.cpp:72
-#, fuzzy
-msgid "Goblin"
-msgstr "Goblin"
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Goblins"
-msgstr "Gobliny"
-
-#: ../fheroes2/monster/monster.cpp:73
-#, fuzzy
-msgid "Orc"
-msgstr "Ork"
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orcs"
-msgstr "Orkowie"
-
-#: ../fheroes2/monster/monster.cpp:74
-#, fuzzy
-msgid "Orc Chief"
-msgstr "Ork wojownik"
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chiefs"
-msgstr "Orkowie wojownicy"
-
-#: ../fheroes2/monster/monster.cpp:75
-#, fuzzy
-msgid "Wolf"
-msgstr "Wilk"
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Wolves"
-msgstr "Wilki"
-
-#: ../fheroes2/monster/monster.cpp:76
-#, fuzzy
-msgid "Ogre"
-msgstr "Ogr"
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogres"
-msgstr "Ogry"
-
-#: ../fheroes2/monster/monster.cpp:77
-#, fuzzy
-msgid "Ogre Lord"
-msgstr "Wielki ogr"
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Ogre Lords"
-msgstr "Wielkie ogry"
-
-#: ../fheroes2/monster/monster.cpp:78
-#, fuzzy
-msgid "Troll"
-msgstr "Troll"
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "Trolls"
-msgstr "Trolle"
-
-#: ../fheroes2/monster/monster.cpp:79
-#, fuzzy
-msgid "War Troll"
-msgstr "Troll bojowy"
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "War Trolls"
-msgstr "Trolle bojowe"
-
-#: ../fheroes2/monster/monster.cpp:80
-#, fuzzy
-msgid "Cyclops"
-msgstr "Cyklop"
-
-#: ../fheroes2/monster/monster.cpp:80
-msgid "Cyclopes"
-msgstr "Cyklopy"
-
-#: ../fheroes2/monster/monster.cpp:83
-#, fuzzy
-msgid "Sprite"
-msgstr "Rusałka"
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Sprites"
-msgstr "Rusałki"
-
-#: ../fheroes2/monster/monster.cpp:84
-#, fuzzy
-msgid "Dwarf"
-msgstr "Krasnolud"
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Dwarves"
-msgstr "Krasnoludy"
-
-#: ../fheroes2/monster/monster.cpp:85
-#, fuzzy
-msgid "Battle Dwarf"
-msgstr "Krasnolud wojownik"
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Battle Dwarves"
-msgstr "Krasnoludzcy wojownicy"
-
-#: ../fheroes2/monster/monster.cpp:86
-#, fuzzy
-msgid "Elf"
-msgstr "Elf"
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elves"
-msgstr "Elfy"
-
-#: ../fheroes2/monster/monster.cpp:87
-#, fuzzy
-msgid "Grand Elf"
-msgstr "Wysoki elf"
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elves"
-msgstr "Wysokie elfy"
-
-#: ../fheroes2/monster/monster.cpp:88
-#, fuzzy
-msgid "Druid"
-msgstr "Druid"
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druids"
-msgstr "Druidzi"
-
-#: ../fheroes2/monster/monster.cpp:89
-#, fuzzy
-msgid "Greater Druid"
-msgstr "Wielki druid"
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druids"
-msgstr "Wielcy druidzi"
-
-#: ../fheroes2/monster/monster.cpp:90
-#, fuzzy
-msgid "Unicorn"
-msgstr "Jednorożec"
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorns"
-msgstr "Jednorożce"
-
-#: ../fheroes2/monster/monster.cpp:91
-#, fuzzy
-msgid "Phoenix"
-msgstr "Feniks"
-
-#: ../fheroes2/monster/monster.cpp:91
-#, fuzzy
-msgid "Phoenixes"
-msgstr "Feniks"
-
-#: ../fheroes2/monster/monster.cpp:94
-#, fuzzy
-msgid "Centaur"
-msgstr "Centaur"
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaurs"
-msgstr "Centaury"
-
-#: ../fheroes2/monster/monster.cpp:95
-#, fuzzy
-msgid "Gargoyle"
-msgstr "Gargulec"
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyles"
-msgstr "Gargulce"
-
-#: ../fheroes2/monster/monster.cpp:96
-#, fuzzy
-msgid "Griffin"
-msgstr "Gryf"
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffins"
-msgstr "Gryfy"
-
-#: ../fheroes2/monster/monster.cpp:97
-#, fuzzy
-msgid "Minotaur"
-msgstr "Minotaur"
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaurs"
-msgstr "Minotaury"
-
-#: ../fheroes2/monster/monster.cpp:98
-#, fuzzy
-msgid "Minotaur King"
-msgstr "Królewski minotaur"
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur Kings"
-msgstr "Królewskie minotaury"
-
-#: ../fheroes2/monster/monster.cpp:99
-#, fuzzy
-msgid "Hydra"
-msgstr "Hydra"
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydras"
-msgstr "Hydry"
-
-#: ../fheroes2/monster/monster.cpp:100
-#, fuzzy
-msgid "Green Dragon"
-msgstr "Zielony smok"
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragons"
-msgstr "Zielone smoki"
-
-#: ../fheroes2/monster/monster.cpp:101
-#, fuzzy
-msgid "Red Dragon"
-msgstr "Czerwony smok"
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragons"
-msgstr "Czerwone smoki"
-
-#: ../fheroes2/monster/monster.cpp:102
-#, fuzzy
-msgid "Black Dragon"
-msgstr "Czarny smok"
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragons"
-msgstr "Czarne smoki"
-
-#: ../fheroes2/monster/monster.cpp:105
-#, fuzzy
-msgid "Halfling"
-msgstr "Niziołek"
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halflings"
-msgstr "Niziołki"
-
-#: ../fheroes2/monster/monster.cpp:106
-#, fuzzy
-msgid "Boar"
-msgstr "Dzik"
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boars"
-msgstr "Dziki"
-
-#: ../fheroes2/monster/monster.cpp:107
-#, fuzzy
-msgid "Iron Golem"
-msgstr "Żelazny golem"
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golems"
-msgstr "Żelazne golemy"
-
-#: ../fheroes2/monster/monster.cpp:108
-#, fuzzy
-msgid "Steel Golem"
-msgstr "Stalowy golem"
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golems"
-msgstr "Stalowe golemy"
-
-#: ../fheroes2/monster/monster.cpp:109
-#, fuzzy
-msgid "Roc"
-msgstr "Rok"
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Rocs"
-msgstr "Roki"
-
-#: ../fheroes2/monster/monster.cpp:110
-#, fuzzy
-msgid "Mage"
-msgstr "Mag"
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Magi"
-msgstr "Magowie"
-
-#: ../fheroes2/monster/monster.cpp:111
-#, fuzzy
-msgid "Archmage"
-msgstr "Arcymag"
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmagi"
-msgstr "Arcymagowie"
-
-#: ../fheroes2/monster/monster.cpp:112
-#, fuzzy
-msgid "Giant"
-msgstr "Olbrzym"
-
-#: ../fheroes2/monster/monster.cpp:112 ../fheroes2/resource/maps_text.cpp:293
-msgid "Giants"
-msgstr "Olbrzymy"
-
-#: ../fheroes2/monster/monster.cpp:113
-#, fuzzy
-msgid "Titan"
-msgstr "Tytan"
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titans"
-msgstr "Tytani"
-
-#: ../fheroes2/monster/monster.cpp:116
-msgid "Skeletons"
-msgstr "Szkielety"
-
-#: ../fheroes2/monster/monster.cpp:117
-#, fuzzy
-msgid "Zombie"
-msgstr "Zombie"
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombies"
-msgstr "Zombie"
-
-#: ../fheroes2/monster/monster.cpp:118
-#, fuzzy
-msgid "Mutant Zombie"
-msgstr "Zmutowany zombie"
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombies"
-msgstr "Zmutowane zombie"
-
-#: ../fheroes2/monster/monster.cpp:119
-#, fuzzy
-msgid "Mummy"
-msgstr "Mumia"
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummies"
-msgstr "Mumie"
-
-#: ../fheroes2/monster/monster.cpp:120
-#, fuzzy
-msgid "Royal Mummy"
-msgstr "Królewska mumia"
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummies"
-msgstr "Królewskie mumie"
-
-#: ../fheroes2/monster/monster.cpp:121
-#, fuzzy
-msgid "Vampire"
-msgstr "Wampir"
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampires"
-msgstr "Wampiry"
-
-#: ../fheroes2/monster/monster.cpp:122
-#, fuzzy
-msgid "Vampire Lord"
-msgstr "Wampirzy lord"
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lords"
-msgstr "Wampirzy lordowi"
-
-#: ../fheroes2/monster/monster.cpp:123
-#, fuzzy
-msgid "Lich"
-msgstr "Lisz"
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Liches"
-msgstr "Lisze"
-
-#: ../fheroes2/monster/monster.cpp:124
-#, fuzzy
-msgid "Power Lich"
-msgstr "Potężny lisz"
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Liches"
-msgstr "Potężne lisze"
-
-#: ../fheroes2/monster/monster.cpp:125
-#, fuzzy
-msgid "Bone Dragon"
-msgstr "Kościany smok"
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragons"
-msgstr "Kościane smoki"
-
-#: ../fheroes2/monster/monster.cpp:128
-#, fuzzy
-msgid "Rogue"
-msgstr "Rozbójnik"
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogues"
-msgstr "Rozbójnicy"
-
-#: ../fheroes2/monster/monster.cpp:129
-#, fuzzy
-msgid "Nomad"
-msgstr "Nomad"
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomads"
-msgstr "Nomadowie"
-
-#: ../fheroes2/monster/monster.cpp:130
-#, fuzzy
-msgid "Ghost"
-msgstr "Duch"
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghosts"
-msgstr "Duchy"
-
-#: ../fheroes2/monster/monster.cpp:131
-#, fuzzy
-msgid "Genie"
-msgstr "Dżinn"
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genies"
-msgstr "Dżinny"
-
-#: ../fheroes2/monster/monster.cpp:132
-#, fuzzy
-msgid "Medusa"
-msgstr "Meduza"
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusas"
-msgstr "Meduzy"
-
-#: ../fheroes2/monster/monster.cpp:133
-#, fuzzy
-msgid "Earth Elemental"
-msgstr "Żywiołak ziemi"
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elementals"
-msgstr "Żywiołaki ziemi"
-
-#: ../fheroes2/monster/monster.cpp:134
-#, fuzzy
-msgid "Air Elemental"
-msgstr "Żywiołak powietrza"
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elementals"
-msgstr "Żywiołaki powietrza"
-
-#: ../fheroes2/monster/monster.cpp:135
-#, fuzzy
-msgid "Fire Elemental"
-msgstr "Żywiołak ognia"
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elementals"
-msgstr "Żywiołaki ognia"
-
-#: ../fheroes2/monster/monster.cpp:136
-#, fuzzy
-msgid "Water Elemental"
-msgstr "Żywiołak wody"
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elementals"
-msgstr "Żywiołaki wody"
-
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:694
-msgid "buy"
-msgstr "kup"
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:158
-msgid "Campaign Game"
-msgstr "Kampania"
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "Error"
-msgstr "Błąd"
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "This release is compiled without network support."
-msgstr "Ta wersja gry nie obsługuje połączeń sieciowych."
-
-#: ../fheroes2/resource/artifact.cpp:51
 msgid "Ultimate Book of Knowledge"
 msgstr "Najzn. księga wiedzy"
 
-#: ../fheroes2/resource/artifact.cpp:51 ../fheroes2/resource/artifact.cpp:77
-#: ../fheroes2/resource/artifact.cpp:78 ../fheroes2/resource/artifact.cpp:79
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "The %{name} increases your knowledge by %{count}."
 msgstr "%{name} zwiększa Twoją wiedzę o %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:52
 msgid "Ultimate Sword of Dominion"
 msgstr "Najzn. miecz dominium"
 
-#: ../fheroes2/resource/artifact.cpp:52 ../fheroes2/resource/artifact.cpp:68
-#: ../fheroes2/resource/artifact.cpp:71 ../fheroes2/resource/artifact.cpp:74
-#: ../fheroes2/resource/artifact.cpp:75 ../fheroes2/resource/artifact.cpp:149
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "The %{name} increases your attack skill by %{count}."
 msgstr "%{name} zwiększa Twój atak o %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:53
 msgid "Ultimate Cloak of Protection"
 msgstr "Najzn. płaszcz ochrony"
 
-#: ../fheroes2/resource/artifact.cpp:53 ../fheroes2/resource/artifact.cpp:70
-#: ../fheroes2/resource/artifact.cpp:73 ../fheroes2/resource/artifact.cpp:76
 msgid "The %{name} increases your defense skill by %{count}."
 msgstr "%{name} zwiększa twoją obronę o %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:54
 msgid "Ultimate Wand of Magic"
 msgstr "Najzn. różdżka magii"
 
-#: ../fheroes2/resource/artifact.cpp:54 ../fheroes2/resource/artifact.cpp:59
-#: ../fheroes2/resource/artifact.cpp:60 ../fheroes2/resource/artifact.cpp:61
-#: ../fheroes2/resource/artifact.cpp:62 ../fheroes2/resource/artifact.cpp:148
 msgid "The %{name} increases your spell power by %{count}."
 msgstr "%{name} zwiększa twoją moc o %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:55
 msgid "Ultimate Shield"
 msgstr "Najzn. tarcza"
 
-#: ../fheroes2/resource/artifact.cpp:55 ../fheroes2/resource/artifact.cpp:128
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "The %{name} increases your attack and defense skills by %{count} each."
 msgstr "%{name} zwiększa twój atak i obronę o %{count} pkt. każdy."
 
-#: ../fheroes2/resource/artifact.cpp:56
 msgid "Ultimate Staff"
 msgstr "Najzn. kostur"
 
-#: ../fheroes2/resource/artifact.cpp:56 ../fheroes2/resource/artifact.cpp:130
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "The %{name} increases your spell power and knowledge by %{count} each."
 msgstr "%{name} zwiększa twoją moc i wiedzę o %{count} pkt. każda."
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "Ultimate Crown"
 msgstr "Najzn. korona"
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "The %{name} increases each of your basic skills by %{count} points."
 msgstr "%{name} zwiększa każdą z twoich umiejętności o %{count} punktów."
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "Golden Goose"
 msgstr "Złota gęś"
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "The %{name} brings in an income of %{count} gold per turn."
 msgstr "%{name} dodaje przychód w wysokości %{count} sztuk złota na turę."
 
-#: ../fheroes2/resource/artifact.cpp:59
 msgid "Arcane Necklace of Magic"
 msgstr "Tajemny naszyjnik magii"
 
-#: ../fheroes2/resource/artifact.cpp:60
 msgid "Caster's Bracelet of Magic"
 msgstr "Magiczna bransoleta czarodzieja"
 
-#: ../fheroes2/resource/artifact.cpp:61
 msgid "Mage's Ring of Power"
 msgstr "Pierścień mocy maga"
 
-#: ../fheroes2/resource/artifact.cpp:62
 msgid "Witch's Broach of Magic"
 msgstr "Brosza magii wiedźmy"
 
-#: ../fheroes2/resource/artifact.cpp:63
 msgid "Medal of Valor"
 msgstr "Medal Męstwa"
 
-#: ../fheroes2/resource/artifact.cpp:63 ../fheroes2/resource/artifact.cpp:64
-#: ../fheroes2/resource/artifact.cpp:65 ../fheroes2/resource/artifact.cpp:66
 msgid "The %{name} increases your morale."
 msgstr "%{name} zwiększa twoje morale."
 
-#: ../fheroes2/resource/artifact.cpp:64
 msgid "Medal of Courage"
 msgstr "Medal Odwagi"
 
-#: ../fheroes2/resource/artifact.cpp:65
 msgid "Medal of Honor"
 msgstr "Medal Honoru"
 
-#: ../fheroes2/resource/artifact.cpp:66
 msgid "Medal of Distinction"
 msgstr "Medal Uznania"
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "Fizbin of Misfortune"
 msgstr "Fizbin Nieszczęścia"
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "The %{name} greatly decreases your morale by %{count}."
 msgstr "%{name} znacząco zmniejsza twoje morale o %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:68
 msgid "Thunder Mace of Dominion"
 msgstr "Grzmiąca maczuga dominium"
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "Armored Gauntlets of Protection"
 msgstr "Pancerne rękawice ochrony"
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "The %{name} increase your defense skill by %{count}."
 msgstr "%(name) zwiększa twoją obronę o %(count)."
 
-#: ../fheroes2/resource/artifact.cpp:70
 msgid "Defender Helm of Protection"
 msgstr "Wzmocniony hełm ochrony"
 
-#: ../fheroes2/resource/artifact.cpp:71
 msgid "Giant Flail of Dominion"
 msgstr "Olbrzymi korbacz dominium"
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "Ballista of Quickness"
 msgstr "Balista szybkości"
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "The %{name} lets your catapult fire twice per combat round."
 msgstr "%(name) pozwala twojej katapulcie strzelić dwa razy na rundę %(count)."
 
-#: ../fheroes2/resource/artifact.cpp:73
 msgid "Stealth Shield of Protection"
 msgstr "Maskująca tarcza ochrony"
 
-#: ../fheroes2/resource/artifact.cpp:74
 msgid "Dragon Sword of Dominion"
 msgstr "Smoczy miecz dominium"
 
-#: ../fheroes2/resource/artifact.cpp:75
 msgid "Power Axe of Dominion"
 msgstr "Potężny topór dominium"
 
-#: ../fheroes2/resource/artifact.cpp:76
 msgid "Divine Breastplate of Protection"
 msgstr "Boski napierśnik ochrony"
 
-#: ../fheroes2/resource/artifact.cpp:77
 msgid "Minor Scroll of Knowledge"
 msgstr "Pomniejszy zwój wiedzy"
 
-#: ../fheroes2/resource/artifact.cpp:78
 msgid "Major Scroll of Knowledge"
 msgstr "Większy zwój wiedzy"
 
-#: ../fheroes2/resource/artifact.cpp:79
 msgid "Superior Scroll of Knowledge"
 msgstr "Wspaniały zwój wiedzy"
 
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "Foremost Scroll of Knowledge"
 msgstr "Doskonały zwój wiedzy"
 
-#: ../fheroes2/resource/artifact.cpp:81
 msgid "Endless Sack of Gold"
 msgstr "Bezdenny worek złota"
 
-#: ../fheroes2/resource/artifact.cpp:81 ../fheroes2/resource/artifact.cpp:82
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "The %{name} provides you with %{count} gold per day."
 msgstr "%{name} zapewnia ci %{count} złota na dzień."
 
-#: ../fheroes2/resource/artifact.cpp:82
 msgid "Endless Bag of Gold"
 msgstr "Bezdenna torba złota"
 
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "Endless Purse of Gold"
 msgstr "Bezdenna sakiewka złota"
 
-#: ../fheroes2/resource/artifact.cpp:84
 msgid "Nomad Boots of Mobility"
 msgstr "Buty mobilności nomada"
 
-#: ../fheroes2/resource/artifact.cpp:84 ../fheroes2/resource/artifact.cpp:85
 msgid "The %{name} increase your movement on land."
 msgstr "%{name} zwiększa twój zasięg ruchu na lądzie."
 
-#: ../fheroes2/resource/artifact.cpp:85
 msgid "Traveler's Boots of Mobility"
 msgstr "Buty mobilności podróżnika"
 
-#: ../fheroes2/resource/artifact.cpp:86
 msgid "Lucky Rabbit's Foot"
 msgstr "Szczęśliwa królicza łapka"
 
-#: ../fheroes2/resource/artifact.cpp:86 ../fheroes2/resource/artifact.cpp:87
-#: ../fheroes2/resource/artifact.cpp:88 ../fheroes2/resource/artifact.cpp:89
 msgid "The %{name} increases your luck in combat."
 msgstr "%{name} zwiększa twoje szczęście w walce."
 
-#: ../fheroes2/resource/artifact.cpp:87
 msgid "Golden Horseshoe"
 msgstr "Złota podkowa"
 
-#: ../fheroes2/resource/artifact.cpp:88
 msgid "Gambler's Lucky Coin"
 msgstr "Szczęśliwa moneta hazardzisty"
 
-#: ../fheroes2/resource/artifact.cpp:89
 msgid "Four-Leaf Clover"
 msgstr "Czterolistna koniczyna"
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "True Compass of Mobility"
 msgstr "Prawdziwy kompas mobilności"
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "The %{name} increases your movement on land and sea."
 msgstr "%{name} zwiększa twój zasięg ruchu na lądzie i morzu."
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "Sailor's Astrolabe of Mobility"
 msgstr "Żeglarski sekstans mobilności"
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "The %{name} increases your movement on sea."
 msgstr "%{name} zwiększa twój zasięg na morzu."
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "Evil Eye"
 msgstr "Złe oko"
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "The %{name} reduces the casting cost of curse spells by half."
 msgstr "%{name} redukuje koszty klątw o połowę."
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "Enchanted Hourglass"
 msgstr "Zaklęta klepsydra"
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "The %{name} extends the duration of all your spells by %{count} turns."
 msgstr ""
 "%{name} zwiększa czas trwania wszystkich twoich czarów o %(count) tury."
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "Gold Watch"
 msgstr "Złoty zegarek"
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "The %{name} doubles the effectiveness of your hypnotize spells."
 msgstr "%{name} podwaja efektywność twoich czarów hipnozy."
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "Skullcap"
 msgstr "Czepiec"
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "The %{name} halves the casting cost of all mind influencing spells."
 msgstr "%{name} zmniejsza o połowę koszty czarów wpływających na umysł."
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "Ice Cloak"
 msgstr "Lodowy płaszcz"
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "The %{name} halves all damage your troops take from cold spells."
 msgstr ""
 "%{name} zmniejsza o połowę uszkodzenia od czarów zimna zadanych twoim "
 "oddziałom."
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "Fire Cloak"
 msgstr "Ognisty płaszcz"
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "The %{name} halves all damage your troops take from fire spells."
 msgstr ""
 "%{name} zmniejsza o połowę uszkodzenia od czarów ognia zadanych twoim "
 "oddziałom."
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "Lightning Helm"
 msgstr "Hełm błyskawicy"
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "The %{name} halves all damage your troops take from lightning spells."
 msgstr ""
 "%{name} zmniejsza o połowę uszkodzenia od czarów burzy zadanych twoim "
 "oddziałom."
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid "Evercold Icicle"
 msgstr "Wiecznie zimny sopel"
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid ""
 "The %{name} causes your cold spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr "%{name} zwiększa uszkodzenia twoich czarów zimna o %{count} procent."
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid "Everhot Lava Rock"
 msgstr "Niestygnąca bryła magmy"
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid ""
 "The %{name} causes your fire spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr "%{name} zwiększa uszkodzenia twoich czarów ognia o %{count} procent."
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid "Lightning Rod"
 msgstr "Piorunochron"
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid ""
 "The %{name} causes your lightning spells to do %{count} percent more damage "
 "to enemy troops."
 msgstr "%{name} zwiększa uszkodzenia twoich czarów burzy o %{count} procent."
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "Snake-Ring"
 msgstr "Wężowy pierścień"
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "The %{name} halves the casting cost of all your bless spells."
 msgstr ""
 "%{name} zmniejsza o połowę koszty wszystkich twoich czarów błogosławieństwa."
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid "Ankh"
 msgstr "Ankh"
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid ""
 "The %{name} doubles the effectiveness of all your resurrect and animate "
 "spells."
@@ -6976,103 +5771,80 @@ msgstr ""
 "%{name} podwaja skuteczność wszystkich twoich czarów wskrzeszania  i "
 "ożywiania."
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "Book of Elements"
 msgstr "Księga Żywiołów"
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "The %{name} doubles the effectiveness of all your summoning spells."
 msgstr "%{name} podwaja skuteczność wszystkich twoich czarów przywoływania."
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "Elemental Ring"
 msgstr "Pierścień Żywiołów"
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "The %{name} halves the casting cost of all summoning spells."
 msgstr "%{name} zmniejsza o połowę koszty wszystkich czarów przywoływania."
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "Holy Pendant"
 msgstr "Święty medalion"
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "The %{name} makes all your troops immune to curse spells."
 msgstr "%{name} uodparnia wszystkie twoje oddziały na czary klątw."
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "Pendant of Free Will"
 msgstr "Medalion wolnej woli"
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "The %{name} makes all your troops immune to hypnotize spells."
 msgstr "%{name} uodparnia wszystkie twoje oddziały na czary hipnozy."
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "Pendant of Life"
 msgstr "Medalion Życia"
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "The %{name} makes all your troops immune to death spells."
 msgstr "%{name} uodparnia wszystkie twoje oddziały na czary śmierci."
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "Serenity Pendant"
 msgstr "Medalion spokoju"
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "The %{name} makes all your troops immune to berserk spells."
 msgstr "%{name} uodparnia wszystkie twoje oddziały na czary szału."
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "Seeing-eye Pendant"
 msgstr "Medalion wszystkowidzenia"
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "The %{name} makes all your troops immune to blindness spells."
 msgstr "%{name} uodparnia wszystkie twoje oddziały na czary oślepienia."
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "Kinetic Pendant"
 msgstr "Kinetyczny medalion"
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "The %{name} makes all your troops immune to paralyze spells."
 msgstr "%{name} uodparnia wszystkie twoje oddziały na czary paraliżu."
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "Pendant of Death"
 msgstr "Medalion Śmierci"
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "The %{name} makes all your troops immune to holy spells."
 msgstr "%{name} uodparnia wszystkie twoje oddziały na święte czary."
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "Wand of Negation"
 msgstr "Różdżka Negacji"
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "The %{name} protects your troops from the Dispel Magic spell."
 msgstr "%{name} chroni oddziały przed czarem Rozproszenie Czarów."
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid "Golden Bow"
 msgstr "Złoty łuk"
 
-#: ../fheroes2/resource/artifact.cpp:114
+#, fuzzy
 msgid ""
 "The %{name} eliminates the %{count} percent penalty for your troops shooting "
-"past obstacles. (e.g. castle walls)"
+"past obstacles (e.g. castle walls)."
 msgstr ""
 "%{name} eliminuje %{count} procent kary dla twoich oddziałów strzelających "
 "przez przeszkody (np. mury zamków)"
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid "Telescope"
 msgstr "Teleskop"
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid ""
 "The %{name} increases the amount of terrain your hero reveals when "
 "adventuring by %{count} extra square."
@@ -7080,11 +5852,9 @@ msgstr ""
 "%{name} zwiększa ilość odsłanianego terenu podczas zwiedzania o %{count} "
 "dodatkowe pola."
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid "Statesman's Quill"
 msgstr "Pióro dyplomaty"
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid ""
 "The %{name} reduces the cost of surrender to %{count} percent of the total "
 "cost of troops you have in your army."
@@ -7092,142 +5862,110 @@ msgstr ""
 "%{name} redukuje koszt kapitulacji do %{count} procent całego kosztu armii "
 "będącej w posiadaniu"
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "Wizard's Hat"
 msgstr "Kapelusz czarodzieja"
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "The %{name} increases the duration of your spells by %{count} turns."
 msgstr "%{name} zwiększa czas trwania twoich czarów o %{count} tur."
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "Power Ring"
 msgstr "Pierścień mocy"
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "The %{name} returns %{count} extra power points/turn to your hero."
 msgstr ""
 "%{name} przywraca %{count} dodatkowych punktów mocy na turę dla twojego "
 "bohatera"
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "Ammo Cart"
 msgstr "Wóz z amunicją"
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "The %{name} provides endless ammunition for all your troops that shoot."
 msgstr ""
 "%{name} zapewnia nieskończoną amunicję dla wszystkich twoich oddziałów "
 "strzelających"
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "Tax Lien"
 msgstr "Weksel fiskalny"
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "The %{name} costs you %{count} gold pieces/turn."
 msgstr "%{name} kosztuje cię %{count} złota na turę."
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "Hideous Mask"
 msgstr "Potworna maska"
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "The %{name} prevents all 'wandering' armies from joining your hero."
 msgstr ""
 "%{name} zapobiega dołączaniu wszystkich \"wędrownych\" armii do twojego "
 "bohatera"
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "Endless Pouch of Sulfur"
 msgstr "Bezdenna sakiewka siarki"
 
-#: ../fheroes2/resource/artifact.cpp:122
 #, fuzzy
 msgid "The %{name} provides %{count} unit of sulfur per day."
 msgstr "%{name} zapewnia %{count} jednostkę siarki na dzień"
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "Endless Vial of Mercury"
 msgstr "Bezdenna fiolka rtęci"
 
-#: ../fheroes2/resource/artifact.cpp:123
 #, fuzzy
 msgid "The %{name} provides %{count} unit of mercury per day."
 msgstr "%{name} zapewnia %{count} jednostkę rtęci dziennie"
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "Endless Pouch of Gems"
 msgstr "Bezdenna sakiewka klejnotów"
 
-#: ../fheroes2/resource/artifact.cpp:124
 #, fuzzy
 msgid "The %{name} provides %{count} unit of gems per day."
 msgstr "%{name} zapewnia %{count} klejnot dziennie"
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "Endless Cord of Wood"
 msgstr "Niewyczerpany stos drewna"
 
-#: ../fheroes2/resource/artifact.cpp:125
 #, fuzzy
 msgid "The %{name} provides %{count} unit of wood per day."
 msgstr "%{name} zapewnia %{count} drewna dziennie"
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "Endless Cart of Ore"
 msgstr "Wiecznie pełny wóz rudy"
 
-#: ../fheroes2/resource/artifact.cpp:126
 #, fuzzy
 msgid "The %{name} provides %{count} unit of ore per day."
 msgstr "%{name} zapewnia %{count} rudę dziennie"
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "Endless Pouch of Crystal"
 msgstr "Bezdenna sakiewka kryształów"
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "The %{name} provides %{count} unit of crystal/day."
 msgstr "%{name} zapewnia %{count} kryształu dziennie"
 
-#: ../fheroes2/resource/artifact.cpp:128
 msgid "Spiked Helm"
 msgstr "Rogaty hełm"
 
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "Spiked Shield"
 msgstr "Rogata tarcza"
 
-#: ../fheroes2/resource/artifact.cpp:130
 msgid "White Pearl"
 msgstr "Biała perła"
 
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "Black Pearl"
 msgstr "Czarna perła"
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "Magic Book"
 msgstr "Księga magii"
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "The %{name} enables you to cast spells."
 msgstr "%{name} pozwala ci rzucać czary."
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "Spell Scroll"
 msgstr "Zwój z zaklęciem"
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
 msgstr "%{name} daje twojemu bohaterowi mozliwość rzucania czaru %{spell}"
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid "Arm of the Martyr"
 msgstr "Ramię męczennika"
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid ""
 "The %{name} increases your spell power by %{count} but adds the undead "
 "morale penalty."
@@ -7235,19 +5973,15 @@ msgstr ""
 "%{name}  zwiększa twoją Moc czaru o %{count} ale również dodaje ujemne "
 "morale dla nieumarłych"
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "Breastplate of Anduran"
 msgstr "Napierśnik Andurana"
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "The %{name} increases your defense by %{count}."
 msgstr "%{name} zwiększa twoją obronę o %{count}"
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid "Broach of Shielding"
 msgstr "Brosza osłony"
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid ""
 "The %{name} provides %{count} percent protection from Armageddon and "
 "Elemental Storm, but decreases spell power by 2."
@@ -7255,11 +5989,9 @@ msgstr ""
 "%{name} zapewnia %{count}  procent ochrony od zaklęcia Armageddon i Burza "
 "Żywiołów, ale obniża moc czarów o 2."
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid "Battle Garb of Anduran"
 msgstr "Bitewny strój Andurana"
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid ""
 "The %{name} combines the powers of the three Anduran artifacts.  It provides "
 "maximum luck and morale for your troops and gives you the Town Portal spell."
@@ -7267,11 +5999,9 @@ msgstr ""
 "%{name} łączy moce trzech Anduriańskich artefaktów. Zapewnia maksymalne "
 "szczęście i morale dla oddziałów oraz dodaje czar Portal Miejski."
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid "Crystal Ball"
 msgstr "Kryształowa kula"
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid ""
 "The %{name} lets you get more specific information about monsters, enemy "
 "heroes, and castles nearby the hero who holds it."
@@ -7279,11 +6009,9 @@ msgstr ""
 "%{name} pozwala zdobyć bardziej szczegółowe informacje na temat potworów, "
 "wrogich armii i zamków znajdujących się w pobliżu bohatera który to nosi."
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid "Heart of Fire"
 msgstr "Serce Ognia"
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid ""
 "The %{name} provides %{count} percent protection from fire, but doubles the "
 "damage taken from cold."
@@ -7291,11 +6019,9 @@ msgstr ""
 "%{name} zapewnia %{count} procent ochrony od ognia, ale podwaja uszkodzenia "
 "otrzymane od zimna"
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid "Heart of Ice"
 msgstr "Serce Lodu"
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid ""
 "The %{name} provides %{count} percent protection from cold, but doubles the "
 "damage taken from fire."
@@ -7303,68 +6029,52 @@ msgstr ""
 "%{name} zapewnia %{count} procent ochrony od zimna, ale podwaja uszkodzenia "
 "otrzymane od ognia."
 
-#: ../fheroes2/resource/artifact.cpp:148
 msgid "Helmet of Anduran"
 msgstr "Hełm Andurana"
 
-#: ../fheroes2/resource/artifact.cpp:149
 msgid "Holy Hammer"
 msgstr "Święty młot"
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "Legendary Scepter"
 msgstr "Legendarne berło"
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "The %{name} adds %{count} points to all attributes."
 msgstr "%{name} dodaje %{count} punktów do wszystkich atrybutów."
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "Masthead"
 msgstr "Top masztowy"
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "The %{name} boosts your luck and morale by %{count} each in sea combat."
 msgstr ""
 "%{name} zwiększa twoje szczęście i morale o %{count} podczas walki na morzu."
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "Sphere of Negation"
 msgstr "Kula Negacji"
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "The %{name} disables all spell casting, for both sides, in combat."
 msgstr "%{name} blokuje możliwość rzucania czarów dla obu stron w walce."
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "Staff of Wizardry"
 msgstr "Kostur czarodziejstwa"
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "The %{name} boosts your spell power by %{count}."
 msgstr "%{name} zwiększa moc magiczną o %{count}"
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "Sword Breaker"
 msgstr "Łamacz mieczy"
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "The %{name} increases your defense by %{count} and attack by 1."
 msgstr "%{name} zwiększa twoją obronę o %{count} i atak o 1."
 
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "Sword of Anduran"
 msgstr "Miecz Andurana"
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "Spade of Necromancy"
 msgstr "Szpadel Nekromancji"
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "The %{name} gives you increased necromancy skill."
 msgstr "%{name} zwiększa twoją umiejętność nekromancji."
 
-#: ../fheroes2/resource/artifact.cpp:638
 msgid ""
 "You find an elaborate aontainer which housesan old vellum scroll. The runes "
 "on the container are very old, and the artistry with whitch it was put "
@@ -7375,7 +6085,6 @@ msgstr ""
 "zaglądasz do środka i znajdujesz stary pergamin. Wyciągasz go z "
 "niecierpliwością i nagle czujesz, jak twe ciało wypełnia magiczna moc."
 
-#: ../fheroes2/resource/artifact.cpp:639
 msgid ""
 "One of the less intelligent members of your party picks up an arm off of the "
 "ground. Despite its missing a body, it is still moving. Your troops find the "
@@ -7388,7 +6097,6 @@ msgstr ""
 "obrzydliwe, nie możesz się zmusić, by je zostawić - ma chyba jakąś magiczną "
 "moc, która wpływa na podejmowanie przez ciebie decyzji."
 
-#: ../fheroes2/resource/artifact.cpp:640
 msgid ""
 "You come upon a sign. It reads: \"Here lies the body of Anduran. Bow and "
 "swear fealty, and you shall be rewarded.\" You decide to do as it says. As "
@@ -7400,7 +6108,6 @@ msgstr ""
 "Decydujesz się to zrobić. Gdy wstajesz, czujesz coś chłodnego na swoim "
 "ciele. Spoglądasz w dół i widzisz, że masz na sobie zdobiony napierśnik."
 
-#: ../fheroes2/resource/artifact.cpp:641
 msgid ""
 "A kindly Sorceress thinks that your army's defenses could use a magical "
 "boost. She offers to enchant the Broach that you wear on your cloak, and you "
@@ -7410,7 +6117,6 @@ msgstr ""
 "wzmocnienie. Proponuje, że rzuci specjalne zaklęcie na noszoną przez ciebie "
 "broszę, na co się ochoczo zgadzasz."
 
-#: ../fheroes2/resource/artifact.cpp:642
 msgid ""
 "Out of pity for a poor peasant, you purchase a chest of old junk they are "
 "hawking for too much gold. Later, as you search through it, you find it "
@@ -7420,7 +6126,6 @@ msgstr ""
 "rupieci. Gdy później je przeglądasz, znajdujesz wśród nich 3 części "
 "legendarnego stroju Andurana!"
 
-#: ../fheroes2/resource/artifact.cpp:643
 msgid ""
 "You come upon a caravan of gypsies who are feasting and fortifying their "
 "bodies with mead. They call you forward and say \"If you prove that you can "
@@ -7433,7 +6138,6 @@ msgstr ""
 "wiesz, o jaki taniec chodzi, ale zgadzasz się. Cały obóz śmieje się widząc "
 "twoje podskoki, ale doceniając twą odwagę wręczają ci kryształową kulę."
 
-#: ../fheroes2/resource/artifact.cpp:644
 msgid ""
 "You enter a recently burned glade and come upon a Fire Elemental sitting "
 "atop a rock. It looks up, its flaming face contorted in a look of severe "
@@ -7445,7 +6149,6 @@ msgstr ""
 "rzuca w ciebie jakimś błyszczącym przedmiotem. Podnosisz ręce, aby się "
 "osłonić, ale przedmiot przelatuje ci przez dłonie i wtapia ci się w pierś."
 
-#: ../fheroes2/resource/artifact.cpp:645
 msgid ""
 "Suddenly, a biting coldness engulfs your body. You seize up, falling from "
 "your horse. The pain subsides, but you still feel as if your chest is "
@@ -7458,7 +6161,6 @@ msgstr ""
 "się z ziemi, słyszysz jowialny śmiech. Obracasz się i widzisz śnieżnego "
 "olbrzyma, który wbiega do lasu i znika ci z oczu."
 
-#: ../fheroes2/resource/artifact.cpp:646
 msgid ""
 "You spy a gleaming object poking up out of the ground. You send a member of "
 "your party over to investigate. He comes back with a golden helmet in his "
@@ -7470,7 +6172,6 @@ msgstr ""
 "Zdajesz sobie sprawę, że musi to być hełm legendarnego Andurana, jedynego "
 "znanego człowieka, który nosił zbroję ze szczerego złota."
 
-#: ../fheroes2/resource/artifact.cpp:647
 msgid ""
 "You come upon a battle where a Paladin has been mortally wounded by a group "
 "of Zombies. He asks you to take his hammer and finish what he started.  As "
@@ -7482,7 +6183,6 @@ msgstr ""
 "podnosisz młot, rozbrzmiewa dziwnym dźwiękiem, a po chwili wszystko zamazuje "
 "ci się przed oczami. Zombie leżą martwe, a z młota kapie krew."
 
-#: ../fheroes2/resource/artifact.cpp:648
 msgid ""
 "Upon cresting a small hill, you come upon a ridiculous looking sight. A "
 "Sprite is attempting to carry a Scepter that is almost as big as it is. "
@@ -7495,7 +6195,6 @@ msgstr ""
 "śmiechem, pytasz: \"Może pomóc?\" Rusałka spogląda na ciebie i odpowiada: "
 "\"Uważasz, że to śmieszne? Dobrze. Trzymaj, to dla ciebie.\""
 
-#: ../fheroes2/resource/artifact.cpp:649
 msgid ""
 "An old seaman tells you a tale of an enchanted masthead that he used in his "
 "youth to rally his crew during times of trouble. He then hands you a faded "
@@ -7507,7 +6206,6 @@ msgstr ""
 "pożółkłą mapę, na której zaznaczył miejsce jego ukrycia. Po długich "
 "poszukiwaniach odnajdujesz go na pobliskiej przystani."
 
-#: ../fheroes2/resource/artifact.cpp:650
 msgid ""
 "You stop to help a Peasant catch a runaway mare. To show his gratitude, he "
 "hands you a tiny sphere. As soon as you grasp it, you feel the magical "
@@ -7517,7 +6215,6 @@ msgstr ""
 "podzięce wręcz ci maleńką kulę. Kiedy tylko bierzesz ją do ręki, czujesz jak "
 "z twych członków uchodzi magiczna energia..."
 
-#: ../fheroes2/resource/artifact.cpp:651
 msgid ""
 "While out scaring up game, your troops find a mysterious staff levitating "
 "about three feet off of the ground. They hand it to you, and you notice an "
@@ -7529,7 +6226,6 @@ msgstr ""
 "która głosi: \"Magia lepsza jest od miecza, a od siły umysł jest ważniejszy. "
 "Pamiętaj o moich słowach, a będziesz najpotężniejszy.\""
 
-#: ../fheroes2/resource/artifact.cpp:652
 msgid ""
 "A former Captain of the Guard admires your quest and gives you the enchanted "
 "Sword Breaker that he relied on during his tour of duty."
@@ -7537,7 +6233,6 @@ msgstr ""
 "Były kapitan straży, pełen podziwu dla twej misji, wręcza ci zaklęty Łamacz "
 "Mieczy, którego używał w czasie swojej służby."
 
-#: ../fheroes2/resource/artifact.cpp:653
 msgid ""
 "A Troll stops you and says: \"Pay me 5,000 gold, or the Sword of Anduran "
 "will slay you where you stand.\" You refuse. The troll grabs the sword "
@@ -7550,7 +6245,6 @@ msgstr ""
 "pasa, krzyczy z bólu i ucieka. Podnosisz legendarny miecz, dziękując że "
 "głupie trolle często chwytają ostre przedmioty z niewłaściwej strony."
 
-#: ../fheroes2/resource/artifact.cpp:654
 msgid ""
 "A dirty shovel has been thrust into a dirt mound nearby. Upon investigation, "
 "you discover it to be the enchanted shovel of the Gravediggers, long thought "
@@ -7560,4578 +6254,58 @@ msgstr ""
 "przedmiotu odkrywasz, że jest to zaklęty topór Grabarzy, zaginiony dawno "
 "temu."
 
-#: ../fheroes2/resource/artifact.cpp:896
+#, fuzzy
 msgid ""
-"Do you want to use your knowledge of magical secrets to transcribe the %"
-"{spell} Scroll into your spell book?\n"
-"The Scroll will be consumed.\n"
-" Spell point: %{sp}"
+"Do you want to use your knowledge of magical secrets to transcribe the "
+"%{spell} Scroll into your Magic Book?\n"
+"The Spell Scroll will be consumed.\n"
+" Cost in spell points: %{sp}"
 msgstr ""
 "Czy chcesz wykorzystać swoją wiedzę magiczną aby zapisać %{spell} zwój do "
 "swojej księgi czarów ?"
 
-#: ../fheroes2/resource/artifact.cpp:960
-msgid "Open book"
-msgstr ""
+#, fuzzy
+msgid "Transcribe Spell Scroll"
+msgstr "Zwój z zaklęciem"
 
-#: ../fheroes2/resource/artifact.cpp:965
-msgid "Transcribe scroll"
-msgstr ""
+#, fuzzy
+msgid "View Spells"
+msgstr "Pokaż wszystko"
 
-#: ../fheroes2/resource/artifact.cpp:975
-#: ../fheroes2/resource/artifact.cpp:1008
+#, fuzzy
+msgid "View %{name} Info"
+msgstr "Obejrzyj jednostkę (%{name})"
+
 msgid "Move %{name}"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:998
 msgid "Cannot move artifact"
 msgstr ""
 
-#: ../fheroes2/resource/maps_text.cpp:15
-msgid ""
-"425 bottles of beer on the wall, 425 bottles of beer! If one of those "
-"bottles should happen to fall, there'll be..."
+msgid "This item can't be traded."
 msgstr ""
-"425 butelek piwa na ścianie, 425 butelek piwa! Jeśli jedna z tych butelek "
-"spadnie, zostanie ..."
 
-#: ../fheroes2/resource/maps_text.cpp:16
-msgid "A balanced scenario with lots of resources and land to explore."
-msgstr "Scenariusz z ogromną ilością surowców i terenu do odkrywania."
-
-#: ../fheroes2/resource/maps_text.cpp:17
-msgid ""
-"A bandit army of gorgons jump you without warning.  they stone your entire "
-"army demand 500 gold before they will release your comrads.  Realizing that "
-"it is much cheeper to pay then rebuild your army you part with the gold."
-msgstr ""
-"Bandycka armia gorgon doskakuje cię bez ostrzeżenia, ukamienowawszy całą "
-"twoją armię, zażądali 500 złota zanim wypuszczą twoich towarzyszy. Zdajesz "
-"sobie sprawę, że jest to o wiele tańsze rozwiązanie niż odbudowa całej armii."
-
-#: ../fheroes2/resource/maps_text.cpp:18
-msgid "Abandon All Hope!"
-msgstr "Cała nadzieja w Abandon"
-
-#: ../fheroes2/resource/maps_text.cpp:19
-msgid "Abandon All Hope Ye That Enter Here"
-msgstr "Cała nadzieja w Abandon, wejście znajduję się tutaj"
-
-#: ../fheroes2/resource/maps_text.cpp:20
-msgid "A bit of crystal!"
-msgstr "Trochę kryształów"
-
-#: ../fheroes2/resource/maps_text.cpp:21
-msgid "A bit of mercury!"
-msgstr "Trochę rtęci"
-
-#: ../fheroes2/resource/maps_text.cpp:22
-msgid "A bit of sulfur!"
-msgstr "Trochę siarki"
-
-#: ../fheroes2/resource/maps_text.cpp:23
-msgid ""
-"Above you looms the ancient Ice Palace.  Dimly remembered myth speaks of a "
-"Prince who rejected the advances of the Winter Goddess, and thus he and his "
-"domain were cursed to remain shrouded in ice, hidden in a forgotten corner "
-"of the world.  It is said that he can only be rescued by a hero who is both "
-"clever and bold.  Are you that one?  Do you dare enter this frozen domain?"
-msgstr ""
-"Nad Tobą unosi się mroźny zapach starożytnego miasta Ice Palace. Słabo, lecz "
-"przypominam sobie mit o księci który odmówil zaloty Królowej Mrozu. Teraz "
-"spowity lodem i ukryty gdzieś, czeka na ratunek. Mówi się że może zostać "
-"uratowany tylko przez mądrego i odważnego bohatera. Czy jesteś nim? Czy "
-"odważysz się wejść w tą spowitą lodem krainą?"
-
-#: ../fheroes2/resource/maps_text.cpp:24
-msgid "A cache of crystal!"
-msgstr "Kopalnia kryształów"
-
-#: ../fheroes2/resource/maps_text.cpp:25
-msgid "A cache of gems!"
-msgstr "Kopalnia kamieni!"
-
-#: ../fheroes2/resource/maps_text.cpp:26
-msgid "A cache of gold!"
-msgstr "Kopalnia złota!"
-
-#: ../fheroes2/resource/maps_text.cpp:27
-msgid "A cache of mercury!"
-msgstr "Kopalnia rtęci!"
-
-#: ../fheroes2/resource/maps_text.cpp:28
-msgid "A cache of sulfur!"
-msgstr "Kopalnia siarki!"
-
-#: ../fheroes2/resource/maps_text.cpp:29
-msgid ""
-"A chance to end a bitter war has finally arrived as a new resource-laden "
-"land has been discovered."
-msgstr "Nadeszła szansa na koniec gorzkiej wojny. Nowe ziemie zostały odkryte."
-
-#: ../fheroes2/resource/maps_text.cpp:30
-msgid "A chunk of gold!"
-msgstr "Kawałek złota!"
-
-#: ../fheroes2/resource/maps_text.cpp:31
-msgid "A chunk of ore!"
-msgstr "Kawałek rudy!"
-
-#: ../fheroes2/resource/maps_text.cpp:32
-msgid "A couple of gems!"
-msgstr "Sporo Kamieni!"
-
-#: ../fheroes2/resource/maps_text.cpp:33
-msgid "\"Act of Desperation\""
-msgstr "\"Akt Desperacji\""
-
-#: ../fheroes2/resource/maps_text.cpp:34
-msgid ""
-"A desert isle rich in resources rewards the quick.  Just be sure to watch "
-"your back!"
-msgstr ""
-"Na pustynii możesz szybko wzbogacić się w zasoby. Tylko pamiętaj, żeby "
-"oglądać się za siebie!"
-
-#: ../fheroes2/resource/maps_text.cpp:35
-msgid "A dolphin playfully jumps into the air."
-msgstr "Delfin radośnie wyskakuje w powietrze."
-
-#: ../fheroes2/resource/maps_text.cpp:36
-msgid ""
-"A Dragon, A Cyclops, or an Undead. King of the Centaurs, His name is ....?"
-msgstr "Smok, Cyklopi albo Nieumarły. Król Centaurów, jego imię to ....?"
-
-#: ../fheroes2/resource/maps_text.cpp:37
-msgid "A flight of dragons circles overhead."
-msgstr "Smoki latają w koło nad głową."
-
-#: ../fheroes2/resource/maps_text.cpp:38
-msgid "A flock of seagulls circle overhead."
-msgstr "Stado mew lata w koło nad głową."
-
-#: ../fheroes2/resource/maps_text.cpp:39
-msgid "A friendly dolphin splashes alongside the ship."
-msgstr "Przyjacielski delfin pluska w pobliżu statku."
-
-#: ../fheroes2/resource/maps_text.cpp:40
-msgid ""
-"After a long search of the island, I have discovered that there is no way "
-"for me to escape without help.  I can not steal a ship from one of the "
-"coastal castles, and I dare not venture into the desert unless I wish to "
-"become Dragon food.  Should anyone find this, I beg of you, please send a "
-"ship and get me off this cursed island!  -Sir Christian"
-msgstr ""
-"Po długim przeszukiwaniu wyspy, odkryłem iż nie ma drogi ucieczki bez "
-"jakiejkolwiek pomocy. Nie mogę ukraść statku, z żadnego z przybrzeżnych "
-"zamków, i nie ośmielę się udać na pustynię, gdyż nie śpieszy mi się "
-"zwiedzanie wnętrza smoka jako jego pokarm. Jeśli ktoś to znajdzie, błagam "
-"Cię, wyślij statek i wyciągnij mnie z tej jebanej wyspy! - Sir Christian"
-
-#: ../fheroes2/resource/maps_text.cpp:41
-msgid ""
-"After centuries of friendship, the Wizards have suddenly decided to stop "
-"sharing their Library with the rest of the world.  This can't be good!"
-msgstr ""
-"Po wiekach przyjaźni, Czarodzieje zdecydowali nagle by zaprzestać "
-"udostępniania swojej biblioteki reszcie świata. Nic z tego dobrego nie "
-"wyniknie!"
-
-#: ../fheroes2/resource/maps_text.cpp:42
-msgid ""
-"After many years of peace, you discover that your sworn enemy from across "
-"the sea has chosen to invade your homeland by raising up the ocean floor to "
-"bridge the distance! You must not let them gain a foothold on this "
-"continent, in fact, your King has ordered you to establish a foothold on "
-"theirs!  To make matters worse, two of your OWN towns have thrown in their "
-"lots with the enemy..."
-msgstr ""
-"Po wielu latach pokoju, odkrywasz że twój zaprzysiężony wróg zza morza "
-"ośmielił się zaatakować twoją ojczyznę poprzez podniesienie poziomu oceanu "
-"aby zmniejszyć dystans. Nie możesz pozwolić by stanął na tym kontynencie, w "
-"zasadzie to twój Król rozkazał ci udać się na ich krainę! Jakby tego było "
-"mało dwa z twoich własnych miast rozpoczęło starcie z wrogiem z użyciem "
-"całych swoich sił militarnych."
-
-#: ../fheroes2/resource/maps_text.cpp:43
-msgid ""
-"After you return from a scouting trip, your Seneschal hurries to greet you.  "
-"\"My Lord, in your absence I signed an agreement in your name with a Master "
-"Merchant.  If we supply him with the resources he needs, through trading, he "
-"can return the resources to us in a week or so, plus some additional ones."
-"\"  The Seneschal eyes you anxiously.  You hesitate, then nod slowly, "
-"\"Good, we can use more resources>\""
-msgstr ""
-"Po powrocie ze zwiadów, Seneschal śpieszy by cię powitać. \"Mój Panie, "
-"podczas twojej nieobecności, podpisałem umowę w twoim imieniu z Mistrzem "
-"Kupiectwa. Jeśli wspomożemy go surowcami których potrzebuje, on zwróci nam "
-"te surowce z nadwyżką.\" Seneschal spojrzał na ciebie z obawą. Wahasz się, "
-"po czym powoli przytakujesz \"Dobrze, przyda nam się więcej surowców\"."
-
-#: ../fheroes2/resource/maps_text.cpp:44
-msgid "A ghostly pirate ship appears and sails on by."
-msgstr "Nawiedzony statek widmo pojawia się na horyzoncie i podpływa."
-
-#: ../fheroes2/resource/maps_text.cpp:45
-msgid ""
-"A Gift from your King, and a note that reads \"Use these resources wisely, "
-"It's all we have left\"."
-msgstr ""
-"Dar od Króla, i notatka na której jest napisane \"Użyj tych surowców mądrze, "
-"to wszystko co nam zostało\"."
-
-#: ../fheroes2/resource/maps_text.cpp:46
-msgid ""
-"A gift of gold, m'lord, from the people of Enroth, to the people of Enroth.  "
-"Good luck, and may God save true King Roland!"
-msgstr ""
-"Dar złota, od ludzi z Enroth dla ludzi z Enroth. Powodzenia, niech Bóg ma w "
-"opiece prawdziwego Króla Rolanda!"
-
-#: ../fheroes2/resource/maps_text.cpp:47
-msgid "A glint by a tree catches your eye..."
-msgstr "Błysk w drzewie przykuwa twoją uwagę."
-
-#: ../fheroes2/resource/maps_text.cpp:48
-msgid "A gold cache!"
-msgstr "Skrzynia ze złotem!"
-
-#: ../fheroes2/resource/maps_text.cpp:49
-msgid "A gold chunk!"
-msgstr "Kawał złota!"
-
-#: ../fheroes2/resource/maps_text.cpp:50
-msgid "A gold nugget!"
-msgstr "Bryłka złota!"
-
-#: ../fheroes2/resource/maps_text.cpp:51
-msgid ""
-"A great Black dragon stands before you. It speaks in a suprisingly soft "
-"voice, saying, \"The elves believe they have sent another hero to reclaim "
-"their prize. I believe they have sent me another meal.\""
-msgstr ""
-"Wielki Czarny Smok staje przed tobą. Przemawia z zadziwiająco łagodnym "
-"głosem, mówiąc, \"Elfy wierzą iż wysłały kolejnego bohatera zdolnego odebrać "
-"ich skarb. Ja uważam, iż przysłały mi kolejne mięcho.\""
-
-#: ../fheroes2/resource/maps_text.cpp:52
-msgid ""
-"A group of peasant farmers approaches you, \"We are in dire need of your "
-"assistance.  Our castle to the north has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-"Grupa chłopów zbliża się do Ciebie, \"Potrzebujemy twojego wsparcia. Nasz "
-"zamek na północy został przejęty a nasz Pan zabity. Proszę, pomóż nam odbić "
-"nasz dom!. Tam ciągle są nasze kobiety i dzieci! Bierz co chcesz, ale pomóż "
-"nam!\""
-
-#: ../fheroes2/resource/maps_text.cpp:53
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance.  Our castle to the east has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-"Grupa chłopów zbliża się do Ciebie, \"Potrzebujemy twojego wsparcia. Nasz "
-"zamek na wschodzie został przejęty a nasz Pan zabity. Proszę, pomóż nam "
-"odbić nasz dom!. Tam ciągle są nasze kobiety i dzieci! Bierz co chcesz, ale "
-"pomóż nam!\""
-
-#: ../fheroes2/resource/maps_text.cpp:54
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance. Our castle to the east has been overrun and our Lord killed. "
-"Please help us regain our homes! There are still women and children there! "
-"Take what we have to help!\""
-msgstr ""
-"Grupa chłopów zbliża się do Ciebie, \"Potrzebujemy twojego wsparcia. Nasz "
-"zamek na wschodzie został przejęty a nasz Pan zabity. Proszę, pomóż nam "
-"odbić nasz dom!. Tam ciągle są nasze kobiety i dzieci! Bierz co chcesz, ale "
-"pomóż nam!\""
-
-#: ../fheroes2/resource/maps_text.cpp:55
-msgid ""
-"A group of peasant farmers approach you, We are in dire need of your "
-"assistance.  Our castle to the northeast has been overrun and our Lord "
-"killed.  Please help us regain our homes!  There are still women and "
-"children there!  Take what we have to help!\""
-msgstr ""
-"Grupa chłopów zbliża się do Ciebie, \"Potrzebujemy twojego wsparcia. Nasz "
-"zamek na północnym-wschodzie został przejęty a nasz Pan zabity. Proszę, "
-"pomóż nam odbić nasz dom!. Tam ciągle są nasze kobiety i dzieci! Bierz co "
-"chcesz, ale pomóż nam!\""
-
-#: ../fheroes2/resource/maps_text.cpp:56
-msgid "A handful of gems!"
-msgstr "Garść klejnotów!"
-
-#: ../fheroes2/resource/maps_text.cpp:57
-msgid ""
-"Ah, you stumble across something buried in the sand.  As you dig it up you "
-"discover a small pile of gems and crystal."
-msgstr ""
-"Auć! Potykasz się o coś zakopanego w piasku. Po odkopaniu okrywasz stos "
-"małych klejnotów i kryształów!"
-
-#: ../fheroes2/resource/maps_text.cpp:58
-msgid ""
-"A Knight and Necromancer team up against the Barbarian and Sorceress. (Blue "
-"and Green vs Red and Yellow)"
-msgstr ""
-"Rycerz i Nekromanta jednoczą siły przeciwko Barbarzyńcy i Czarodziejce "
-"(Niebieski i Zielony kontra Czerwony i Żółty)."
-
-#: ../fheroes2/resource/maps_text.cpp:60
-msgid ""
-"A large contingent of the king's guard approaches you.  \"Ahh, we have "
-"finally caught up to you.  The king requires tribute from all of his vassals "
-"and you have been negligent far too long.\""
-msgstr ""
-"Kontyngent królewskiej straży zbliża się do Ciebie. \"W końcu cię "
-"złapaliśmy. Król potrzebuje wyrazów uznania od wszystkich swoich wasali a ty "
-"zbyt długo byłeś nonszalancki.\""
-
-#: ../fheroes2/resource/maps_text.cpp:61
-msgid ""
-"A large map with lots of resources and treasure. Exploration and victory "
-"will require many heroes."
-msgstr ""
-"Duża mapa pełna surowców i skarbów. Zbadanie i podbój tej krainy będzie "
-"wymagało dużej liczby bohaterów."
-
-#: ../fheroes2/resource/maps_text.cpp:62
-msgid "A legion of peasants stands between you and this unclaimed island."
-msgstr ""
-"Pomiędzy tobą a tą ziemią niczyją stoją zastępy wrogo nastawionych chłopów."
-
-#: ../fheroes2/resource/maps_text.cpp:63
-msgid "Algary"
-msgstr "Algary"
-
-#: ../fheroes2/resource/maps_text.cpp:64
-msgid "A little bit closer..."
-msgstr "Nieco bliżej..."
-
-#: ../fheroes2/resource/maps_text.cpp:65
-msgid "All mines are grouped by type. Trade is your only hope."
-msgstr ""
-"Kopalnie poszczególnych surowców występują w skupiskach. Handel jest twoją "
-"jedyną nadzieją."
-
-#: ../fheroes2/resource/maps_text.cpp:66
-msgid "A lump of crystal!"
-msgstr "Bryła kryształu!"
-
-#: ../fheroes2/resource/maps_text.cpp:67
-msgid "A lump of gold!"
-msgstr "Bryła złota!"
-
-#: ../fheroes2/resource/maps_text.cpp:68
-msgid "A lump of mercury!"
-msgstr "Nieco rtęci!"
-
-#: ../fheroes2/resource/maps_text.cpp:69
-msgid ""
-"A man appears from behind the sand dune. \"At last,\" he says, \"Someone has "
-"come to rescue me! I am forever grateful. Alas all I have to offer you in "
-"return are these souvenirs from my wrecked ship.\""
-msgstr ""
-"Człowiek pojawia się zza wydmy piasku. \"Na reszcie,\" powiada, \"Ktoś "
-"nadchodzi by mnie uratować! Jestem wdzięczny na wieki. Niestety wszystko co "
-"mam do zaoferowania to te kilka pamiątek z wraku mojego statku."
-
-#: ../fheroes2/resource/maps_text.cpp:70
-msgid ""
-"A man is laying on the ground, near death. He looks to you and speaks, "
-"\"Please help my companions! Please... they can't...cough...get away from..."
-"cough...the drag...\" With that, he dies."
-msgstr ""
-"Człowiek leży na ziemi, jest bliski śmierci. Patrzy na ciebie i mówi, "
-"\"Proszę pomóż moim kompanom! Proszę... nie mogą...(kaszle)...odejść..."
-"(kaszle)...smo...\" Mowiąc to, umiera."
-
-#: ../fheroes2/resource/maps_text.cpp:71
-msgid ""
-"A merchant caravan arrives, bringing gold and supplies, however, no one can "
-"seem to remember where they came from.  You silently praise this anonymous "
-"benefactor and continue your duties."
-msgstr ""
-"Kupiecka karawana nadjeżdża, przywożąc złoto i dostawę, nie wydaje się aby "
-"ktokolwiek pamiętał skąd przybyli. Cicho chwalisz anonimowego dobroczyńcę i "
-"przechodzisz do swoich obowiązków."
-
-#: ../fheroes2/resource/maps_text.cpp:72
-msgid "a mirror"
-msgstr "lustro"
-
-#: ../fheroes2/resource/maps_text.cpp:73
-msgid "An albatross flies ahead of the ship for a while"
-msgstr "Albatros przelatuje przed statkiem przez krótką chwilę."
-
-#: ../fheroes2/resource/maps_text.cpp:74
-msgid "Anduran"
-msgstr "Anduran"
-
-#: ../fheroes2/resource/maps_text.cpp:75
-msgid ""
-"An enemy from across the sea has seized half your towns.  Can you put aside "
-"your own feud with your brother to fight this common enemy?"
-msgstr ""
-"Wróg zza morza przejął większość twoich miast.  Czy zapomnisz o konflikcie z "
-"bratem, byście wspólnie mogli stawić czoła temu wrogowi?"
-
-#: ../fheroes2/resource/maps_text.cpp:76
-msgid "\"Annexation\""
-msgstr "\"Annexation\""
-
-#: ../fheroes2/resource/maps_text.cpp:77
-msgid ""
-"An old elf is sitting on a rock in a glen, pounding on the shackles on his "
-"feet with a stone. You help him remove them and ask him his tale. \"I'm a "
-"deserter from Drakonia's army. She has enslaved all the elves to support her "
-"madness. She must be stopped.\" Then he slips into the woods without a "
-"sound, leaving behind just his cloak."
-msgstr ""
-"Stary elf siedzi na skale w dolinie, uderzając kamieniem w kajdany założone "
-"na jego stopy. Pomagasz mu je usunąć i prosisz by ci o sobie opowiedział. "
-"\"Jestem dezerterem z armii Drakonii. Zniewoliła wszystkich elfów by brali "
-"udział w jej szaleństwie. Ktoś musi to powstrzymać.\" Wtedy znika w lesie "
-"bezszelestnie zostawiając za sobą swoją pelerynę."
-
-#: ../fheroes2/resource/maps_text.cpp:78
-msgid "Antioch"
-msgstr "Antioch"
-
-#: ../fheroes2/resource/maps_text.cpp:79
-msgid "A piece of crystal!"
-msgstr "Nieco kryształu!"
-
-#: ../fheroes2/resource/maps_text.cpp:80
-msgid "A pile of crystal!"
-msgstr "Sterta kryształu"
-
-#: ../fheroes2/resource/maps_text.cpp:81
-msgid "A pile of gems!"
-msgstr "Sterta klejnotów."
-
-#: ../fheroes2/resource/maps_text.cpp:82
-msgid "A pile of gold!"
-msgstr "Sterta złota"
-
-#: ../fheroes2/resource/maps_text.cpp:83
-msgid ""
-"A plague of undead is upon us. Who will unite the living against the dead?"
-msgstr "Spadła na nas plaga nieumarłych. Kto zjednoczy żywych przeciw martwym?"
-
-#: ../fheroes2/resource/maps_text.cpp:84
-msgid "\"Apocalypse\""
-msgstr "Apokalipsa"
-
-#: ../fheroes2/resource/maps_text.cpp:85
-msgid "A quantity of crystal!"
-msgstr "Mnóstwo kryształu!"
-
-#: ../fheroes2/resource/maps_text.cpp:86
-msgid "A quantity of mercury!"
-msgstr "Nieco rtęci!"
-
-#: ../fheroes2/resource/maps_text.cpp:87
-msgid "A quantity of sulfur!"
-msgstr "Nieco siarki!"
-
-#: ../fheroes2/resource/maps_text.cpp:89
-msgid ""
-"Archibald has also sent an army to find the Crown, you must find it first or "
-"all is lost."
-msgstr ""
-"Archibald również wysłał armię by odnaleźć Koronę, musisz odnaleźć ją "
-"pierwszy w innym razie wszystko przepadnie."
-
-#: ../fheroes2/resource/maps_text.cpp:90
-msgid "Archibald is hiding at the end of the river."
-msgstr "Archibald kryje się na skraju rzeki."
-
-#: ../fheroes2/resource/maps_text.cpp:91
-msgid ""
-"A resource rich valley keeps the Wizard and the Necromancer apart. Your "
-"opponent's army will arrive in 3 months so hurry."
-msgstr ""
-"Dolina bogata w surowce dzieli Czarodzieja i Nekromantę. Armia twojego wroga "
-"na w przeciągu 3 miesięcy, więc nie masz zbyt wiele czasu."
-
-#: ../fheroes2/resource/maps_text.cpp:92
-msgid "Arm of the Crusader"
-msgstr "Armia Paladynów"
-
-#: ../fheroes2/resource/maps_text.cpp:93
-msgid "Arm of the Cyclops"
-msgstr "Armia Cyklopów"
-
-#: ../fheroes2/resource/maps_text.cpp:94
-msgid "Arm of the Dragon"
-msgstr "Armia Smoków"
-
-#: ../fheroes2/resource/maps_text.cpp:95
-msgid "Arm of the Phoenix"
-msgstr "Armia Feniksów"
-
-#: ../fheroes2/resource/maps_text.cpp:96
-msgid "Arm of the Titan"
-msgstr "Armia Tytanów"
-
-#: ../fheroes2/resource/maps_text.cpp:97
-msgid "Arr' Here be pirates gold buried."
-msgstr "Tutaj pochowano złoto piratów"
-
-#: ../fheroes2/resource/maps_text.cpp:98
-msgid "A shipment of wood has arrived from your kingdom!"
-msgstr "Transport drewna z twojego królestwa został dostarczony!"
-
-#: ../fheroes2/resource/maps_text.cpp:99
-msgid ""
-"A splash in the seaweed alerts you to a mermaid waving in a friendly manner. "
-"\"Oh, I thought you were Ahab.\" She is surprised, but quickly composes "
-"herself. \"Well, if you meet him, give him these treasures I have collected."
-"\""
-msgstr ""
-"Plusk w wodorostach zwraca twoją uwagę na syrenkę machająca przyjaźnie do "
-"ciebie. \"O, myślałam że jesteś Ahab.\" Jest zaskoczona, lecz opanowana. "
-"\"Jeśli go spotkasz, daj mu skarby które zebrałam.\""
-
-#: ../fheroes2/resource/maps_text.cpp:100
-msgid "Assassins tried to kill our ally."
-msgstr "Zabójcy próbowali zabić naszego sprzymierzeńca."
-
-#: ../fheroes2/resource/maps_text.cpp:101
-msgid "Astircaer"
-msgstr "Astircaer"
-
-#: ../fheroes2/resource/maps_text.cpp:102
-msgid ""
-"A stranded Wizard with only a small force must conquer an entire continent "
-"of hostile forces."
-msgstr "Samotny czarodziej rozbija się na nieznanym kontynencie pełnym wrogów."
-
-#: ../fheroes2/resource/maps_text.cpp:103
-msgid ""
-"A supply ship has arrived from the homeland!  You send word home that all is "
-"well."
-msgstr ""
-"Statek transportowy z ojczyzny dotarł. Wysyłasz wiadomość, że wszystko jest "
-"w porządku."
-
-#: ../fheroes2/resource/maps_text.cpp:104
-msgid ""
-"As you approach the barrier, you see the old elf you helped free. This time, "
-"however, you see that he is wearing a cape of fine weave, and a wooden crown "
-"is on his head. He sees your forces, and says \"Take this sword, and with "
-"it, strike down Drakonia and help free my people.\" The old elf then strides "
-"regally into the woods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:105
-msgid ""
-"As you approach the gates of the Ice Palace, one of your troops points in "
-"terror.  You watch in awe as great slabs of ice separate from the castle "
-"walls with loud cracking reports and crash to the ground.  Soon the ice is "
-"gone and the sun begins to peak through the gloom.  The deathly silence that "
-"must have ruled these lands for centuries ends as birds begin to sing.  From "
-"inside you hear the sounds of life."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:106
-msgid ""
-"As you approach the tent, the leader of the nomads comes out to greet you. "
-"He says, \"It was prophecied many years ago that a great hero would come to "
-"greet us in our sacred valley, and we would prosper afterwords. Now it has "
-"come to pass, and we offer you these gifts as tokens of our thanks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:107
-msgid ""
-"As you approach,  you hear whispered mentions of \"the wild barbarian who "
-"passed this way months before\". One of the villagers approaches you and "
-"hands you an object, saying \"The wild one dropped this. You must be his "
-"kin. Therefore I give it to you. But beware! Many in the village will not be "
-"as friendly as I.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:108
-msgid ""
-"As you break your fast your sage rushes in, \"Good news, my lord!  I have "
-"translated the message.  Two great heroes were imprisoned many years ago.  "
-"They lie sleeping - still guarded by magic barriers and monsters.  My lord, "
-"they lie nearby- in between our ally and us.  If we could free them, they "
-"would surely aid us against our enemies!  The password to the first magic "
-"barrier can be learned at the Aqua Traveller's Tent.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:109
-msgid ""
-"As you enter the small clearing, you see a familiar figure talking to a "
-"group of halflings and soldiers. You stay awhile and listen to his speech. "
-"\"The time to throw off these chains of tyranny is now! We must strike at "
-"the heart of her empire, and destroy the evil that she has brought to our "
-"land.\" As the old elf finishes speaking, he gets up from his mossy seat and "
-"once again, blends into the woods with incredible grace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:110
-msgid ""
-"As you lay down to nap after a long battle, you notice a lucky four-leaf "
-"clover."
-msgstr ""
-"Postanowiłeś zdrzemnąć się po wygranej bitwie. Układając się do snu "
-"znajdujesz w trawie czterolistną koniczynkę."
-
-#: ../fheroes2/resource/maps_text.cpp:111
-msgid ""
-"As you make  your way through the last of the golemn debris, a group of "
-"halflings runs towards you carrying fruit and flowers. \"Thank you so much!"
-"\" Their leader exclaims, \"We've been trapped in here for ever! Come by our "
-"homes, we'll pack up and go with you!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:112
-msgid ""
-"As you make your way to the shrine, some very thin and hollow-eyed men come "
-"out of the flower patch and stare at you.  Seeing that you want the gold, "
-"one of them says to you \"Hey, man, if you're, like, so lusty for earthly "
-"wealth, then, like, have this too.\" You graciously take what they have "
-"offered and back out of the clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:113
-msgid ""
-"As you prepare your lands to fight the onslaught from the South, a curious "
-"message appears on your table in the Great Hall of your Castle.  Written in "
-"some ancient language, none but your sage can make any sense of it.  She "
-"promises to have the words deciphered by tomorrow..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:114
-msgid "A three hour tour, a three hour tour..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:115
-msgid ""
-"A tiny gnome points to a chunk of crystal you otherwise would have "
-"overlooked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:116
-msgid "Atlantium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:117
-msgid ""
-"At last, the king is dead.  For years you have planned his demise, but now "
-"it is done, and there is no heir to take his place, though the Knights to "
-"the south believe that they are the rightful successors.  A wealth in wood "
-"(to the south) and ore (in the northern mountains) provides you with trade "
-"goods, and your isolation has allowed you to prepare your forces of darkness "
-"for this day.  Go, now, and fulfill your destiny!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:118
-msgid ""
-"At the base of the mountain you see something that glitters.   You discover "
-"an ancient pile of offerings to the gods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:119
-msgid "Avalon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:120
-msgid "Avone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:121
-msgid ""
-"A wild magic has allowed a bridge to form between two lands...  Your one "
-"hope is to capture castle \"Black Fang\"."
-msgstr ""
-"Dzięki magii pomiędzy dwoma światami powstał most...  Twoją jedyną nadzieją "
-"jest zdobycie zamku \"Black Fang\"."
-
-#: ../fheroes2/resource/maps_text.cpp:122
-msgid "Barbarian's castle lies to the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:123
-msgid ""
-"Barbarians from the north threaten all civilization. Can you repel the "
-"hordes?"
-msgstr ""
-"Barbarzyńcy z północy zagrażają całej cywilizacji. Czy zdołasz odeprzeć ich "
-"hordy?"
-
-#: ../fheroes2/resource/maps_text.cpp:124
-msgid "\"Barbarian Wars\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:125
-msgid "Barrowton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:126
-msgid "Basenji"
-msgstr "Basenji"
-
-#: ../fheroes2/resource/maps_text.cpp:127
-msgid "Bayside"
-msgstr "Bayside"
-
-#: ../fheroes2/resource/maps_text.cpp:128
-msgid "Baywatch"
-msgstr "Przystań"
-
-#: ../fheroes2/resource/maps_text.cpp:129
-msgid ""
-"Because the Darkscale Valley is so barren, the Emperor will be sending wood "
-"to you every week. Use it wisely, for it is all you shall have."
-msgstr ""
-"Ponieważ Dolina Darkscale jest taka jałowa, Imperator będzie wysyłał tobie "
-"drewno każdego tygodnia. Używaj go mądrze, to wszystko co powinieneś mieć do "
-"osiągnięcia celu."
-
-#: ../fheroes2/resource/maps_text.cpp:130
-msgid ""
-"Before questing for the orb of negation, you must first crush the local "
-"opposition. After the Sorceresses are removed from the earth, go east where "
-"legend says the orb lies.  You may expect a convoy of supplies in a week or "
-"so to aid your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:131
-msgid ""
-"Before you may pass, the spirit guardian of this valley demands tribute."
-msgstr ""
-"Zanim przejdziesz, dusza strażnika tej doliny oczekuje wyrazów uznania."
-
-#: ../fheroes2/resource/maps_text.cpp:132
-msgid "Being held...."
-msgstr "Jest przetrzymywany..."
-
-#: ../fheroes2/resource/maps_text.cpp:133
-msgid "Beltway"
-msgstr "Okrężna droga"
-
-#: ../fheroes2/resource/maps_text.cpp:134
-msgid "\"Betrayal!\""
-msgstr "Zdrada!"
-
-#: ../fheroes2/resource/maps_text.cpp:135
-msgid "Beware -- Entering Hyrda Country"
-msgstr "Strzeż się Wchodząc do Krainy Hydr"
-
-#: ../fheroes2/resource/maps_text.cpp:136
-msgid "Beware for whom the bell trolls."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:137
-msgid "Beware of Pirates!"
-msgstr "Strzeż się piratów!"
-
-#: ../fheroes2/resource/maps_text.cpp:138
-msgid "Beware of thieves!"
-msgstr "Strzeż się złodzieji!"
-
-#: ../fheroes2/resource/maps_text.cpp:139
-msgid "Beware of traps ahead."
-msgstr "Strzeż się pułapek."
-
-#: ../fheroes2/resource/maps_text.cpp:140
-msgid "Beware of Warlocks"
-msgstr "Strzeż się Czarnoksiężników."
-
-#: ../fheroes2/resource/maps_text.cpp:141
-msgid "Beware the deadly swamps!"
-msgstr "Strzeż się śmiertelnych bagien!"
-
-#: ../fheroes2/resource/maps_text.cpp:142
-msgid "Beware the Domain of Dragons"
-msgstr "Strzeż się  Królestwa Smoków!"
-
-#: ../fheroes2/resource/maps_text.cpp:143
-msgid "Beware the Dragon Leader"
-msgstr "Strzeż się Smoczego Przywódcy!"
-
-#: ../fheroes2/resource/maps_text.cpp:144
-msgid "Beware the edge of the world!"
-msgstr "Strzeż się skraju świata!"
-
-#: ../fheroes2/resource/maps_text.cpp:145
-msgid "Beware the moors and stick to the roads."
-msgstr "Strzeż się mokradeł, korzystaj z dróg!"
-
-#: ../fheroes2/resource/maps_text.cpp:146
-msgid "Beware the rocks"
-msgstr "Uważaj na skały."
-
-#: ../fheroes2/resource/maps_text.cpp:147
-msgid "Beware the sirens!!!"
-msgstr "Uważaj na syreny!!!"
-
-#: ../fheroes2/resource/maps_text.cpp:148
-msgid "Beware the sirens!"
-msgstr "Uważaj na syreny!"
-
-#: ../fheroes2/resource/maps_text.cpp:149
-msgid "Beware the whiporwill..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:150
-msgid "Beware, the whirlpool may not take you into a friendly embrace."
-msgstr "Strzeż się, wir wodny może nie być dla ciebie zbyt przyjazny."
-
-#: ../fheroes2/resource/maps_text.cpp:151
-msgid "Beyond here be Dragons!"
-msgstr "Dalej są Smoki!"
-
-#: ../fheroes2/resource/maps_text.cpp:152
-msgid "Beyond the door, there be Dragons. BEWARE!"
-msgstr "Za drzwiami, są Smoki, STRZEŻ SIĘ!"
-
-#: ../fheroes2/resource/maps_text.cpp:153
-msgid "Big Oak"
-msgstr "Wielki Dąb \"Bartek\""
-
-#: ../fheroes2/resource/maps_text.cpp:154
-msgid "Blackburn"
-msgstr "Blackburn"
-
-#: ../fheroes2/resource/maps_text.cpp:155
-msgid "Blackfang"
-msgstr "Czarny Kieł"
-
-#: ../fheroes2/resource/maps_text.cpp:156
-msgid "Black Fang"
-msgstr "Czarny Kieł"
-
-#: ../fheroes2/resource/maps_text.cpp:157
-msgid "Black Oak"
-msgstr "Czarny Dąb"
-
-#: ../fheroes2/resource/maps_text.cpp:158
-msgid "Blackridge"
-msgstr "Blackridge"
-
-#: ../fheroes2/resource/maps_text.cpp:159
-msgid "Blacksford"
-msgstr "Blacksford"
-
-#: ../fheroes2/resource/maps_text.cpp:160
-msgid "Black Vein"
-msgstr "Black Vein"
-
-#: ../fheroes2/resource/maps_text.cpp:161
-msgid "Blackwind"
-msgstr "Blackwind"
-
-#: ../fheroes2/resource/maps_text.cpp:162
-msgid "Bloodreign"
-msgstr "Bloodreign"
-
-#: ../fheroes2/resource/maps_text.cpp:163
-msgid "Boats my be needed to access some parts of this peninsula."
-msgstr "Łodzie mogą być niezbędne by dotrzeć w niektóre części  półwyspu."
-
-#: ../fheroes2/resource/maps_text.cpp:164
-msgid "Boats Sold Here            Inquire Within"
-msgstr "Tutaj sprzedawane są łodzie"
-
-#: ../fheroes2/resource/maps_text.cpp:165
-msgid "BoneVille"
-msgstr "BoneVille"
-
-#: ../fheroes2/resource/maps_text.cpp:166
-msgid "Borderlands"
-msgstr "Borderlands"
-
-#: ../fheroes2/resource/maps_text.cpp:167
-msgid "Bridge out!"
-msgstr "Zniszczony most!"
-
-#: ../fheroes2/resource/maps_text.cpp:168
-msgid "Bridge Out!"
-msgstr "Zniszczony most!"
-
-#: ../fheroes2/resource/maps_text.cpp:169
-msgid "Brindamoor"
-msgstr "Brindamoor"
-
-#: ../fheroes2/resource/maps_text.cpp:170
-msgid "Broken Alliance"
-msgstr "Zerwany sojusz"
-
-#: ../fheroes2/resource/maps_text.cpp:171
-msgid "Brownston"
-msgstr "Brownston"
-
-#: ../fheroes2/resource/maps_text.cpp:172
-msgid "Buried Treasure!"
-msgstr "Zakopany skarb"
-
-#: ../fheroes2/resource/maps_text.cpp:173
-msgid "Burlock"
-msgstr "Burlock"
-
-#: ../fheroes2/resource/maps_text.cpp:174
-msgid "Burton"
-msgstr "Burton"
-
-#: ../fheroes2/resource/maps_text.cpp:175
-msgid ""
-"Capture the necromancer's dreaded castle \"Death Gate\" and free the land "
-"from the undead plague."
-msgstr ""
-"Zdobądź złowrogi zamek Nekromanty, \"Death Gate\", i uwolnij krainę od plagi "
-"nieumarłych."
-
-#: ../fheroes2/resource/maps_text.cpp:176
-msgid ""
-"Capture the town on the island off the southeast shore in order to construct "
-"a boat and travel back towards the mainland."
-msgstr ""
-"Przejmij miasto na wyspie południowo-wschodniego wybrzeża aby zbudować łódź "
-"i wrócić z powrotem na ląd."
-
-#: ../fheroes2/resource/maps_text.cpp:177
-msgid "\"Carator Mines\""
-msgstr "Kopalnie Caratora"
-
-#: ../fheroes2/resource/maps_text.cpp:178
-msgid "Cathcart"
-msgstr "Cathcart"
-
-#: ../fheroes2/resource/maps_text.cpp:180
-msgid "Chandler"
-msgstr "Chandler"
-
-#: ../fheroes2/resource/maps_text.cpp:181
-msgid "Chilton"
-msgstr "Chilton"
-
-#: ../fheroes2/resource/maps_text.cpp:182
-msgid "Chronos"
-msgstr "Chronos"
-
-#: ../fheroes2/resource/maps_text.cpp:183
-msgid "Come and...."
-msgstr "Podejdź i..."
-
-#: ../fheroes2/resource/maps_text.cpp:184
-msgid ""
-"Compared to the rest of the villages in this land, this village seems grand, "
-"but in any other land it would seem poor. From here you can see the tall "
-"spires of the Warlock's tower of Dragons."
-msgstr ""
-"Porównując z resztą wiosek na tej wyspie, ta wioska wydaje się być wielka, "
-"ale w innych krainach nie byłaby taka. Stąd możesz zobaczyć wysokie iglice "
-"Wieży Smoków"
-
-#: ../fheroes2/resource/maps_text.cpp:185
-msgid "Complete"
-msgstr "Zrobione"
-
-#: ../fheroes2/resource/maps_text.cpp:186
-msgid "Condemned!"
-msgstr "Potępiony!"
-
-#: ../fheroes2/resource/maps_text.cpp:187
-msgid ""
-"Congratulations! After navigating the treacherous coast, you have "
-"established trade between the north and south."
-msgstr ""
-"Gratulacje!  Po dotarciu do zdradzieckiego wybrzeża, dokonałeś wymiany "
-"pomiędzy północą i południem."
-
-#: ../fheroes2/resource/maps_text.cpp:188
-msgid "Corackston"
-msgstr "Corackston"
-
-#: ../fheroes2/resource/maps_text.cpp:189
-msgid "Corlagon"
-msgstr "Corlagon"
-
-#: ../fheroes2/resource/maps_text.cpp:190
-msgid "\"Country Lords\""
-msgstr "Kraina Władców"
-
-#: ../fheroes2/resource/maps_text.cpp:191
-msgid "Crossroads"
-msgstr "Rozdroża"
-
-#: ../fheroes2/resource/maps_text.cpp:192
-msgid "Crossroads North"
-msgstr "Rozdroża Północy"
-
-#: ../fheroes2/resource/maps_text.cpp:193
-msgid "Crossroads South"
-msgstr "Rozdroża  Południa"
-
-#: ../fheroes2/resource/maps_text.cpp:195
-msgid "Danger a whirlpool destroyed my ship."
-msgstr "Niebezpieczny wir wodny zniszczył mój statek."
-
-#: ../fheroes2/resource/maps_text.cpp:196
-msgid "Danger, Dragons abound!"
-msgstr "Niebezpieczeństwo Smoki mnożą się!"
-
-#: ../fheroes2/resource/maps_text.cpp:197
-msgid "DANGER!  QUICKSAND!"
-msgstr "UWAGA! Ruchome piaski!"
-
-#: ../fheroes2/resource/maps_text.cpp:198
-msgid "Danger! Troll bridge ahead!"
-msgstr "Uwaga! Most Trolli!"
-
-#: ../fheroes2/resource/maps_text.cpp:199
-msgid "Danger - Turn Back Now"
-msgstr "Niebezpieczeństwo - Zawróć natychmiast."
-
-#: ../fheroes2/resource/maps_text.cpp:200
-msgid "Dark clouds loom overhead as you enter this valley."
-msgstr ""
-"Ciemne chmury wyłaniają się nad głową z chwilą gdy wkroczyłeś do doliny"
-
-#: ../fheroes2/resource/maps_text.cpp:201
-msgid "Dead Pine"
-msgstr "Martwa Sosna"
-
-#: ../fheroes2/resource/maps_text.cpp:202
-msgid ""
-"Dear Diary,                           I found a mermaid today.  She was "
-"floating in a patch of seaweed next to a rock.  A very friendly sort of "
-"creature too!  Gave me all sorts of lovely gems and jewelry!  She said to "
-"come back again sometime for more of the sea riches.  Wow. Ahab"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:203
-msgid "Deathgate"
-msgstr "Brama Śmierci"
-
-#: ../fheroes2/resource/maps_text.cpp:204
-msgid "DeathGate"
-msgstr "Brama Śmierci"
-
-#: ../fheroes2/resource/maps_text.cpp:205
-msgid "Decisions"
-msgstr "Decyzje"
-
-#: ../fheroes2/resource/maps_text.cpp:206
-msgid "\"Defender\""
-msgstr "Obrońca"
-
-#: ../fheroes2/resource/maps_text.cpp:207
-msgid ""
-"Destroy the Barbarians who are attacking the southern border of your "
-"kingdom! Recover your towns and then invade the jungle kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:208
-msgid ""
-"Detour! Mountain pass to the East has been known to have avalanches! For "
-"your own safety, follow the road South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:209
-msgid "Detour! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:211
-msgid "DirtWater"
-msgstr "Brudna Woda"
-
-#: ../fheroes2/resource/maps_text.cpp:212
-msgid "Dominion"
-msgstr "Dominium"
-
-#: ../fheroes2/resource/maps_text.cpp:213
-msgid "Do Not Enter!"
-msgstr "Nie wchodzić!"
-
-#: ../fheroes2/resource/maps_text.cpp:214
-msgid "Do not remove coins from fountain."
-msgstr "Nie zabierać monet z fontanny!"
-
-#: ../fheroes2/resource/maps_text.cpp:215
-msgid "Dragadune"
-msgstr "Dragadune"
-
-#: ../fheroes2/resource/maps_text.cpp:216
-msgid "Dragonburg"
-msgstr "Dragonburg"
-
-#: ../fheroes2/resource/maps_text.cpp:218
-msgid "Dragon City lies beyond the Scorpion Hills."
-msgstr "Miasto Smoków leży poniżej wzgórz Skorpiona"
-
-#: ../fheroes2/resource/maps_text.cpp:219
-msgid "Dragon Hill"
-msgstr "Wzgórze Smoków"
-
-#: ../fheroes2/resource/maps_text.cpp:220
-msgid "\"Dragon Master\""
-msgstr "Władca Smoków"
-
-#: ../fheroes2/resource/maps_text.cpp:221
-msgid "Dragon Rider"
-msgstr "Smoczy Jeździec"
-
-#: ../fheroes2/resource/maps_text.cpp:222
-msgid "Dragons Everywhere!"
-msgstr "Smoki! Wszędzie Smoki!"
-
-#: ../fheroes2/resource/maps_text.cpp:223
-msgid "Dragon's Eye"
-msgstr "Oko Smoka!"
-
-#: ../fheroes2/resource/maps_text.cpp:224
-msgid "Dragontooth"
-msgstr "Dragontooth"
-
-#: ../fheroes2/resource/maps_text.cpp:225
-msgid "Dragon Town"
-msgstr "Miasto Smoka"
-
-#: ../fheroes2/resource/maps_text.cpp:226
-msgid "Dragonville"
-msgstr "Dragonville"
-
-#: ../fheroes2/resource/maps_text.cpp:227
-msgid "Dragon Wars"
-msgstr "Smocze wojny"
-
-#: ../fheroes2/resource/maps_text.cpp:228
-msgid "Dragon Watch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:230
-msgid "Drakoran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:231
-msgid "Dwarfhall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:232
-msgid "Dwarfhall, Domain of the dwarf King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:233
-msgid "Dwarf Hall, domain of the dwarf King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:234
-msgid "Eatio"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:235
-msgid "Edgewood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:236
-msgid "Elk's Head"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:237
-msgid "Elowyn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:238
-msgid "Enroth"
-msgstr "Enroth"
-
-#: ../fheroes2/resource/maps_text.cpp:239
-msgid "Entering high in the desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:240
-msgid "Entering Praires of the Middlelands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:241
-msgid "Entering the desert high"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:242
-msgid "Entering the high desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:243
-msgid "Entering the higher desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:244
-msgid "Entering the Valley of Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:245
-msgid "Erliquin"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:246
-msgid "Evil Igor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:247
-msgid "Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:248
-msgid "Fantasy Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:249
-msgid "Farlien"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:250
-msgid ""
-"Federal express, when it absolutely positively has to be there turn one."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:251
-msgid "fedx comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:252
-msgid "Fedx for comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:253
-msgid "Fenton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:254
-msgid "Fetid Elm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:255
-msgid ""
-"Final message from Overlord. \"The royal executioners are on their way. My "
-"gold, the land or your head- it's your choice.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:256
-msgid "Find and defeat the Pirate Leader!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:257
-msgid "Find and destroy the evil beings who rule the wastelands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:258
-msgid "Find the center island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:259
-msgid ""
-"Find the Ultimate Artifact and be proclaimed King, or smash the opposition "
-"and take control."
-msgstr ""
-"Odnajdź Najpotężniejszy Artefakt i zostań królem, lub zmiażdż przeciwników."
-
-#: ../fheroes2/resource/maps_text.cpp:260
-msgid ""
-"Find Your Wayward Son who is rumored to be living in the desolate lands. Do "
-"it within 8 weeks or it will be of no help to your family."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:261
-msgid "Fire King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:262
-msgid "\"First Blood\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:263
-msgid "Five heroes vie for control of a familiar land."
-msgstr "Pięciu bohaterów rywalizuje o władzę w kraju."
-
-#: ../fheroes2/resource/maps_text.cpp:264
-msgid "Fool's Gold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:265
-msgid ""
-"For a total of 400,000 gold your opponents will become \"loyal\" subjects, "
-"otherwise... let them eat cake!"
-msgstr ""
-"Za sumę 400,000 sztuk złota twoi przeciwnicy zostaną \"lojalnymi poddanymi"
-"\", ale... możesz im również spuścić lanie!"
-
-#: ../fheroes2/resource/maps_text.cpp:266
-msgid ""
-"For centuries, the Wizards of the North have maintained a vast library for "
-"all the world to share.  Now, however, they have closed their doors, and "
-"issued declarations of war to each of the other rulers of the land.  To make "
-"matters worse, rather than ally with you to face the Wizards, each of the "
-"others have decided to go forth on their own in an effort to conquer this "
-"land for themselves!  Prepare your forces, commander, for you now stand "
-"alone."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:267
-msgid "\"Force of Arms\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:268
-msgid ""
-"For decades you have studied, learned, and allowed yourself to be ruled by "
-"that pitiful excuse for a king, knowing that one day the time would come for "
-"you to sit on the throne.  That time is now, for the king is dead and "
-"without an heir.  You have the advantage of isolation from the rest of the "
-"kingdom, but beware the miles of coastline that could leave you vulnerable "
-"to attack.  Go, now, and wipe your enemies from this land!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:269
-msgid "Forder Oaks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:270
-msgid "Forestria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:271
-msgid "For Honor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:272
-msgid ""
-"For information about Ye Rich lands to the south, speak to Alponse at the "
-"Golden Goose Tavern. Excellent views, plentiful water."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:273
-msgid "Forsaken Lands"
-msgstr "Zapomn. Krainy"
-
-#: ../fheroes2/resource/maps_text.cpp:274
-msgid "For sale."
-msgstr "Na sprzedaż."
-
-#: ../fheroes2/resource/maps_text.cpp:275
-msgid "Fortress Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:276
-msgid ""
-"For years, you have existed peacefully in the Forest of Dreams, knowing that "
-"your king was the kindest and strongest ruler the land had seen in "
-"centuries.  Now, however, his reign is at an end, and there is no heir to "
-"succeed him.  You realize that a power struggle is coming, and that you must "
-"brace yourself for war, and prevent those who would harm this land from "
-"coming into power!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:277
-msgid ""
-"For years, you've been able to keep your subjects \"appeased.\"  Now "
-"however, you discover not only that your entire kingdom has turned against "
-"you, but most of your outer towns have fallen to the different factions.  To "
-"make matters worse, all your gold suddenly seems to be missing from the "
-"treasury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:278
-msgid "Fountainhead"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:279
-msgid "Four kingdoms race to capture the island of Sharkania."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:280
-msgid "Four lakes have castles, three have treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:281
-msgid "Four players must work together to assault the Wizards' Stronghold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:282
-msgid "Frozenpeak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:283
-msgid "Full House"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:284
-msgid ""
-"Gain the aid of the elves. They will not allow trees to be chopped down, so "
-"we will send you wood every 2 weeks. You have 7 months!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:286
-msgid "Galveston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:287
-msgid "Garamok"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:288
-msgid "Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:289
-msgid "Gate to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:290
-msgid "Gate to The Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:291
-msgid "Gaurdian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:292
-msgid "Gavonshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:294
-msgid "Glastonbury"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:295
-msgid "Go away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:296
-msgid "GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:297
-msgid "Goblin Island"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:298
-msgid "Goblin King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:299
-msgid "Go Home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:300
-msgid "Go north to find the lost gold-mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:301
-msgid "Good vs. Evil"
-msgstr "Dobro kontra Zło"
-
-#: ../fheroes2/resource/maps_text.cpp:302
-msgid "Gorgomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:303
-msgid "\"Greater Glory\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:304
-msgid "Greed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:305
-msgid "Green bonus stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:306
-msgid "Green gets stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:307
-msgid "Greenroot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:308
-msgid "Green's Allowance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:309
-msgid "Green's Groceries"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:310
-msgid "green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:311
-msgid "Green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:312
-msgid "Greywind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:313
-msgid "Grim"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:314
-msgid "Grrr, Blazzer, Grrupt. Be gone with you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:315
-msgid "Guardian War"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:316
-msgid "Gungtooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:317
-msgid "Hail Unicorns!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:318
-msgid "Hampshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:319
-msgid "Have fun storming the castle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:320
-msgid "Havenwood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:321
-msgid "Hawkins"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:322
-msgid "Help!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:323
-msgid "Help me...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:324
-msgid ""
-"Help peasant farmers regain their castle and land, else they'll take your "
-"crops."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:325
-msgid "Hero's Hall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:326
-msgid ""
-"High in the snowy crags, you meet an old witch who, in return for a trinket "
-"of yours, gives you a powerful magical object she used to use as a footstool "
-"before she was exiled into the mountains by her own townspeople."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:327
-msgid "Hillstone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:328
-msgid "Hilltop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:329
-msgid "Hilltown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:330
-msgid "Horizon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:331
-msgid "Hot Spot"
-msgstr "Punkt Zapalny"
-
-#: ../fheroes2/resource/maps_text.cpp:332
-msgid "Hungry dragons await.  Welcome, food."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:333
-msgid "Hurry, no time to wait.  This way to the dock."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:334
-msgid "Hurry up! Few days are left before the enemy's army arrives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:335
-msgid "I am...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:336
-msgid ""
-"I am one of the few remaining survivors of the wrecked pleasure ship, "
-"Exhorbitance. I think we'll all be dead of hunger soon, for we are out of "
-"caviar. We ate the chef yesterday."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:337
-msgid "Ibn Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:338
-msgid "Ice Palace"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:339
-msgid "Ice Prince"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:340
-msgid "Icy lands ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:341
-msgid "I didn't do it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:342
-msgid ""
-"If three heroes could dig six holes in three days, how long would it take "
-"six heroes to dig twelve holes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:343
-msgid "If you free a hero, they may help..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:344
-msgid ""
-"If you value your lives, for God's sake, Don't go through this whirlpool!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:345
-msgid "Income for Yellow."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:346
-msgid "In the hole you find a chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:347
-msgid "In the stream you find an old compass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:348
-msgid "In this glen live some very naughty halflings. Stay Away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:349
-msgid ""
-"In two more weeks, if you have not located Joseph, your kingdom will surely "
-"lose its current battle with Harondale."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:350
-msgid "I see you, you see me."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:351
-msgid "Is it something I said? Go back and I will forget the whole thing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:352
-msgid "IslandHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:353
-msgid "Island of the Elves"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:354
-msgid "Island of the meek"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:355
-msgid "Island of Wolcott"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:356
-msgid "Isle Maze"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:357
-msgid "Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:358
-msgid ""
-"It has become apparent that if all your enemies were eliminated, you would "
-"have all the time you need to find the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:359
-msgid ""
-"It is obvious that the mage that once was here had won many battles!  There, "
-"upon his hand, is a most powerful ring!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:360
-msgid ""
-"It is rumored that a bridge of land used to exist between the two "
-"continents, but that a wild magic caused it to sink into the sea, taking "
-"with it all those who used to inhabit it.  To try to raise this bridge is to "
-"invite a curse upon the world!  The spirits of the dead will haunt us all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:361
-msgid ""
-"It is said that King Zealot found the gods' artifact once and it let him "
-"rule for 100 years."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:362
-msgid ""
-"It looks like there used to be an ore mine here but all you see now is a "
-"hole in the ground and some minerals scattered around."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:363
-msgid ""
-"It's a battle for supremacy as the Blue and Green heroes take on Red and "
-"Orange in team competition!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:364
-msgid "It's windy at the top.  Defend, Divide, and Conquer."
-msgstr "Na szczycie wieje porywisty wiatr.  Broń, dziel, i rządź."
-
-#: ../fheroes2/resource/maps_text.cpp:365
-msgid "IvanHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:366
-msgid "Ivan lives in the desert."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:367
-msgid "Ivory Gates"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:368
-msgid ""
-"I, Wilgatus, besiege you - do not fight me for I am all powerful and will "
-"destroy you if you persue me.  I will demonstrate my power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:369
-msgid "I Would Go That Way If I Were You."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:371
-msgid "Jarkonas VI"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:372
-msgid "Jolly Roger was here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:374
-msgid "Jungomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:375
-msgid "Just 30 days left!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:376
-msgid "Just ONE week left!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:378
-msgid "Kastor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:379
-msgid "Keep going south"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:380
-msgid "Keep Off The Grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:381
-msgid "Keep Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:382
-msgid "King John"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:383
-msgid "King of Death"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:384
-msgid "Knight's Trail."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:385
-msgid "Knight stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:386
-msgid "Lakeside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:387
-msgid "Land's Edge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:388
-msgid "Land teleporters will get you to your destination sooner."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:389
-msgid "Lankershire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:390
-msgid "Lavalor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:391
-msgid "Like, Stuff And Junk?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:392
-msgid ""
-"Living on the outskirts of the kingdom, you are considered an unwelcome "
-"outcast by the other leaders of the realm, though you always showed your "
-"support for the king.  Now, however, the king is dead, and many of those who "
-"spoke out againt him seek to seize his throne for themselves.  You have a "
-"vast desert at your back, rich with gems, and the advantage that many do not "
-"consider you a threat.  Go, now, and show them how wrong they are!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:393
-msgid "Lladner Dock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:394
-msgid ""
-"Log go up... Log go down... Log go up... Log go down...  OOoohhhhhhhh........"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:395
-msgid "Lombard"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:396
-msgid "Long live Roland the true King!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:397
-msgid "Long live Roland the true King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:398
-msgid "Look before you leap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:399
-msgid "Look out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:400
-msgid "Lord Alberon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:401
-msgid ""
-"Lord Alberon calls you into his war room. He says, \"I am glad you have "
-"chosen to remain loyal to me, but this war is a terrible one for my kingdom. "
-"Already, the sorceress' towns to the Northeast have become unsure about "
-"their loyalties, and will not pledge allegiance to either side. This is hard "
-"on our cities as most of the wood in the land comes from these towns. We "
-"will need to recover their sawmills and take their towns by force.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:402
-msgid "Lord Haart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:404
-msgid "Lord Kreager"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:405
-msgid ""
-"Lord, messages have begun pouring in from our spies in the other island "
-"courts.  They have learned of a new volcanic island with vast amounts of "
-"reasources.  Your Majesty, with these new reasources we could put an end to "
-"a century of war between the islands, and reunite them under your rightful "
-"rule."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:406
-msgid "Lost Continent"
-msgstr "Zag. kontynent"
-
-#: ../fheroes2/resource/maps_text.cpp:407
-msgid "Lost Gold- Mine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:408
-msgid "Lost Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:409
-msgid "Lost Relic"
-msgstr "Zaginiony relikt"
-
-#: ../fheroes2/resource/maps_text.cpp:410
-msgid "Maelstrom of Deceit"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:411
-msgid "Maelstrom of Misery"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:412
-msgid "Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:413
-msgid "Magic Three"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:414
-msgid ""
-"Many dust plumes rise from the floor of this small valley. You see various "
-"bands of nomads roaming about, and in the distant, the bright flames of "
-"their camp."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:415
-msgid ""
-"Many guardians stand between you and your enemies, but anybody can sneak "
-"through the back door!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:416
-msgid "Many that have gone through this door have never returned."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:417
-msgid ""
-"Many years ago, a couple of mages had a \"duel\" that forever changed the "
-"lake at the center of this continent.  Hearty adventurers might find "
-"interesting treasure there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:418
-msgid ""
-"Many years ago, a falling star crashed near here.  Only now the area is safe "
-"enough to explore.  Rumor has it a castle exist where the star fell."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:419
-msgid ""
-"Many years ago, your father, the King, died in a freak hunting accident.  "
-"Since then, you and your brother have jointly ruled his kingdom, but both of "
-"you have been seeking a way to seize the throne for yourself.  You got your "
-"wish.  Attackers from across the sea have captured more than half your towns "
-"and castles, effectively dividing the continent in two.  Now is the time to "
-"repel these invaders and do away with your brother once and for all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:420
-msgid "Marco"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:421
-msgid "Marsh Home"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:423
-msgid "Mayland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:424
-msgid "Meramec"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:425
-msgid "Message from Archibald. \" Do not dare to return without my Crown.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:426
-msgid ""
-"Message from Archibald. \" General, thank you for bringing me this lovely "
-"gift. I have decided to participate directly in the capture of my brother "
-"Roland. Since your military advice has taken us this far, I will follow your "
-"orders to the letter.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:427
-msgid "Message from Overlord. \"STILL WAITING FOR MY GOLD!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:428
-msgid "Message from Overlord. \"WHERE'S MY GOLD?\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:429
-msgid ""
-"Message from Roland. \"General, circumstances permit me to take a hand in "
-"the events of this final conflict. I have your spoils of war with me and I "
-"will follow your advice explicitly.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:430
-msgid ""
-"Message from Roland.  \"General, I have sent most of our troops and material "
-"ahead to the region of the final conflict with Archibald.  Unfortunately, "
-"Lord Corlagon has cut us off from the rest of our army.  I will be awaiting "
-"your victory in a castle across the west river.  I should be safe from "
-"attack.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:431
-msgid ""
-"Message from Roland. \" We cannot hope to defeat Archibald without the "
-"Crown, I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:432
-msgid "Middle Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:433
-msgid "Middleton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:434
-msgid "Middletown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:435
-msgid "Might vs. Magic"
-msgstr "Moc vs Magia"
-
-#: ../fheroes2/resource/maps_text.cpp:436
-msgid "Mineral Wars"
-msgstr "Walka o minerał"
-
-#: ../fheroes2/resource/maps_text.cpp:437
-msgid "Mirkosov"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:438
-msgid "mirror"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:439
-msgid "Money For Red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:440
-msgid "MONEY, MONEY, MONEY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:441
-msgid "Morale becomes even lower as the endless cliffs move past."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:442
-msgid ""
-"More water than land, you'll still spend lots of time on foot as you search "
-"a literal horde of islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:443
-msgid "Mountain king"
-msgstr "Król Gór"
-
-#: ../fheroes2/resource/maps_text.cpp:444
-msgid "Mountainview"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:445
-msgid "Mr Ed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:446
-msgid "Mr. Yellow's Income"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:447
-msgid "Murray's resort Isle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:448
-msgid ""
-"Mutiny!  The crew has dumped off my precious cargo into the sea!  Thank "
-"goodness it floats - when I've rid of them, I'll come back to pick it up!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:449
-msgid ""
-"My leige, our scouts report three other lords are attacking from the south. "
-"They work in conjuction with each other to eliminate us! We must keep this "
-"castle and remove the threat of the enemy. We wish you luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:450
-msgid ""
-"My leige, we have established a foothold (which we cannot afford to lose) "
-"and all of our Heroes have joined us. The king has made us the offer to "
-"purchase this land for 200,000 gold or we may take it by force. The local "
-"lords have been fighting and each wants to be the one that defeats us. Now "
-"all the local armies have arrived on the beach, creating a state of complete "
-"Pandemonium!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:451
-msgid "My Treasure Is Buried Beneath Three Palm Trees"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:452
-msgid "\"Necromancers!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:453
-msgid "New Dawn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:454
-msgid "New Enemies"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:455
-msgid "New Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:456
-msgid "Nightshadow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:457
-msgid "No Description"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:458
-msgid "No Fishing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:459
-msgid "No gems, crystal, or mercury for red."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:460
-msgid ""
-"None of the four leaders like being stuck in a land that has only one season."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:461
-msgid "NO, Not That Way. This Way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:462
-msgid "No one has ever made it out of the deadly swamps alive!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:463
-msgid "Noraston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:464
-msgid "North Road"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:465
-msgid "North vs. South"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:466
-msgid "No stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:467
-msgid "No sulfer fer Yella."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:468
-msgid "No swimming."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:469
-msgid "Notice- Those who put messages in bottles will be tortured."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:470
-msgid "No Trespassing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:471
-msgid "No tresspath...  No tree...  No thresh...  GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:472
-msgid "Now leaving Swamplands of the Eternial"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:473
-msgid "Obsidian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:474
-msgid "Of the necromancers...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:475
-msgid "Ogrehild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:476
-msgid "Olympus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:477
-msgid ""
-"One of the seers in your castle comes to you in the morning with urgent "
-"news. Your one time comrade, the wizard Joseph, and his armies have been "
-"imprisoned in a jail nearby. His power would surely aid you in your quest to "
-"reclaim the library, you think to yourself. Perhaps there is a way to rescue "
-"him..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:478
-msgid ""
-"One of your aides reports that the Castle of Farlien is located on the "
-"northeast spur of this island, and is a stronghold for the enemy. He urges "
-"you to take it out as soon as possible, and then move onto other islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:479
-msgid ""
-"One of your \"allies\" has joined Archibald.  You now face an opponent with "
-"three castles to your one.  Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:480
-msgid ""
-"One of your \"Allies\" has joined Roland. You are now facing three castles, "
-"all belonging to the enemy. Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:481
-msgid "One of your loyal goblins has brought you an armload of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:482
-msgid ""
-"One of your loyal subjects, a fairy tells you where to find a cache of "
-"mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:483
-msgid ""
-"One of your scouts reports a tiny cave nearby. Upon investigating, you "
-"discover a small cache of goods. In the dirt by them is etched 'Ivan'."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:484
-msgid ""
-"One of your troops stubs its paw on something buried here.  After a few "
-"hours of digging you unearth a cache of treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:485
-msgid "Only a month remains in which to find Joseph."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:486
-msgid "On quite days, Nubbie the sea monster can be seen!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:487
-msgid "Orange stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:488
-msgid "Orcville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:489
-msgid "Ostoroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:490
-msgid "Other than the dragons, the elves don't have any enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:491
-msgid "Our ally was greatly weakened when his resources were plundered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:492
-msgid "\"Our Finest Hour\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:493
-msgid "Our reinforcements were lost in a storm, we salvaged all we could!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:494
-msgid ""
-"Our spies have discovered that the barbarian hordes are now receiving "
-"support from kraeger! You must hurry and find the third piece before your "
-"forces here are crushed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:495
-msgid "Overlord"
-msgstr "Suweren"
-
-#: ../fheroes2/resource/maps_text.cpp:496
-msgid "Pandemonium"
-msgstr "Pandemonium"
-
-#: ../fheroes2/resource/maps_text.cpp:497
-msgid "Paper can gain you what wood and sail cannot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:498
-msgid "Password found by Crystals to the South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:499
-msgid "Peacekeeper"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:500
-msgid "\"Peasants!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:502
-msgid "Peasantsville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:503
-msgid "Perenor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:504
-msgid "Pet Cemetary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:505
-msgid "Pick one of four Knights in this large and inhospitable land."
-msgstr ""
-"Wybierz jednego spośród czterech Rycerzy na tych rozległych i nieprzyjaznych "
-"terenach."
-
-#: ../fheroes2/resource/maps_text.cpp:506
-msgid "Pig's Eye"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:507
-msgid "Pinehurst"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:508
-msgid "Pirate Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:509
-msgid "Pirate's Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:510
-msgid "Pirate Utopia"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:511
-msgid "Pirites strike and take the gold from you holds."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:512
-msgid "Pixie"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:513
-msgid ""
-"Play the Knight or Barbarian in an alliance in this classic duel against the "
-"four spell casters. (Blue and Green vs Red)"
-msgstr ""
-"Zostań Rycerzem lub Barbarzyńcą w pojedynku przeciwko czterem czarownikom "
-"(Niebieski i Zielony kontra Czerwony)."
-
-#: ../fheroes2/resource/maps_text.cpp:514
-msgid "Please...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:515
-msgid ""
-"Plenty of resources and lots of ground to cover. Watch out for Orange and "
-"Purple!"
-msgstr ""
-"Bardzo dużo surowców i terenu do odkrywania. Uważaj na graczy oznaczonych "
-"kolorami Pomarańczowym i Purpurowym!"
-
-#: ../fheroes2/resource/maps_text.cpp:516
-msgid "Portals"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:517
-msgid "Portsmith"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:518
-msgid "POSION - DO NOT DRINK"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:519
-msgid "Powerful magic lies southwest of here in the Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:520
-msgid "Prisoner on...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:522
-msgid "Quick Silver"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:523
-msgid "Raste"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:524
-msgid "Realm of the Undead.  Fresh blood welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:525
-msgid "Red bonus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:526
-msgid "Red player sympathizes with the undead cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:527
-msgid "Red's Connection"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:528
-msgid "Redshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:529
-msgid "Red's Lunch Money"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:530
-msgid "Red's Rubles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:531
-msgid "Red stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:532
-msgid ""
-"Regrettably, you have no castle with which to begin your assault. "
-"Fortunately, however, Kraeger's forces are weak here in the south, and you "
-"have bribed a rebel necromancer to aid you in the beginning of your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:533
-msgid "Reinforcements have arrived, Gold from the homelands!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:534
-msgid ""
-"Remains of a long since dead wizard have attracted an ancient artifact.  "
-"This artifact has now attached itself to you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:535
-msgid ""
-"Remember, you're searching for the Ultimate Artifact... don't get distracted!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:536
-msgid ""
-"Rendall Koski was here. 1997.  Northampton, Massachusetts There is a "
-"powerful artifact in the southeastern corner of the world.  Go for it, "
-"explorer!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:537
-msgid ""
-"Reports from your spies tell of enemies on the march.  As you rush to the "
-"castle courtyard to prepare your armies, you are intercepted by your "
-"Chaplain.  \"My Lord, I have received word that we should send what Heroes "
-"we can to the Isle of Knowledge.   The Scholars there have agreed to teach "
-"them so they will be strong for the battles ahead of us.\"  You thank the "
-"Chaplain for the information and head thoughtfully into the courtyard."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:538
-msgid ""
-"Rescue your crazy Uncle Ivan. Find him within 4 months or it will be no help "
-"to your kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:539
-msgid "Restricted Area, Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:540
-msgid "Rest stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:541
-msgid "Retake the Castle of Ivory Gates."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:542
-msgid "Revolution"
-msgstr "Rewolucja"
-
-#: ../fheroes2/resource/maps_text.cpp:543
-msgid "Right thinking - he who takes the riskes deserves the rewards."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:544
-msgid "River Crossing"
-msgstr "Rzeka"
-
-#: ../fheroes2/resource/maps_text.cpp:545
-msgid "Road Ends"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:546
-msgid "Road to Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:547
-msgid "Road to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:548
-msgid "Robbers have looted your treasury and you have lost valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:549
-msgid "Robbers have looted your treasury, stealing valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:550
-msgid "Roc Haven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:551
-msgid "Rogar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:553
-msgid "Roscomon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:554
-msgid "Rotten Birch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:555
-msgid ""
-"Rumors abound and your faithful hero Sandro is now highly regarded by the "
-"masses. Should Sandro desert you, all will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:556
-msgid "Sandcaster"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:558
-msgid "Sands of Time"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:559
-msgid "Sansobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:560
-msgid "\"Save the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:561
-msgid "Scabsdale"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:562
-msgid "Scorched Earth"
-msgstr "Spalone ziemie"
-
-#: ../fheroes2/resource/maps_text.cpp:563
-msgid ""
-"Scouts have reported a town to the North.  They have also heard some "
-"disturbing news.  Their seems to be a war raging in this area."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:564
-msgid ""
-"Scouts report the enemy's stronghold lies to the Southwest. Our swift "
-"arrival has caught them by surprise. If you move quickly their resistance "
-"will be minimal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:565
-msgid ""
-"Scouts report the notorious necromancer \"Wyrm\" has been sighted to the "
-"northeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:566
-msgid "Scummy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:567
-msgid ""
-"Searching in the dust of this abandoned campsite, you find a magic scroll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:568
-msgid "Seasons Change"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:569
-msgid "Secret Mountain Pass"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:570
-msgid ""
-"Seek out the Ultimate Artifact to be victorious in this strangely shaped "
-"land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:571
-msgid ""
-"Seek the great library, for only with the guidance of the musty tomes therin "
-"will you find the means to reveal and bind the fount to your will."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:572
-msgid "Seven Lakes"
-msgstr "Siedem Jezior"
-
-#: ../fheroes2/resource/maps_text.cpp:573
-msgid "Sharkania"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:574
-msgid "Sheltemburg"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:575
-msgid "Sherman"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:576
-msgid "Shipwrecked!"
-msgstr "Rozbitkowie!"
-
-#: ../fheroes2/resource/maps_text.cpp:577
-msgid ""
-"Should this message ever reach home, please know that this has become a "
-"hostile place since the King's death.  No less than six factions are at war "
-"with each other, each seeking to be the King's successor.  Beware especially "
-"of the Barbarians and the Necromancers who control the north, their regions "
-"are easily defended and they have a wealth of gold and gems.  Do not venture "
-"to this land without a sizeable force.  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:578
-msgid "Sirein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:579
-msgid ""
-"Six factions have established a foothold on a huge, unexplored continent.  "
-"Can you eliminate the other five?"
-msgstr ""
-"Sześć drużyn pojawia się na ogromnym, niezbadanym kontynencie.  Czy zdołasz "
-"wyeliminować pozostałe pięć?"
-
-#: ../fheroes2/resource/maps_text.cpp:580
-msgid ""
-"Six heroes with large armies prepare to slug it out for total domination!"
-msgstr ""
-"Sześciu bohaterów stojących na czele potężnych armii walczy pomiędzy sobą o "
-"władzę!"
-
-#: ../fheroes2/resource/maps_text.cpp:581
-msgid "Skirmish"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:582
-msgid "\"Slay the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:583
-msgid "Slippery when wet."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:584
-msgid "Slugfest"
-msgstr "Porachunki"
-
-#: ../fheroes2/resource/maps_text.cpp:585
-msgid ""
-"Snagged on a thorny bush, you discover a scrap of cloth. The design on it "
-"looks like the coat of arms of Ivan's house!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:586
-msgid "Snowdrop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:587
-msgid "Somebody has stuffed a pile of gems in the ditch!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:588
-msgid "Some crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:589
-msgid "Some gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:590
-msgid ""
-"Someone has stolen 100 wood and 77 ore from you. Ah, that's nothing. Let's "
-"keep going."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:591
-msgid ""
-"Someone has stolen gold and resources from  the palace treasury!  You "
-"suspect your enemies, but you can't know for certain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:592
-msgid "Someone is playing a pan flute around here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:593
-msgid ""
-"Someone notices a piece of parchment lying behind a clump of grass. You pick "
-"it up. It looks to be a page from a journal, and it reads, \"...made it past "
-"the first guardians. Hopefully will reach the ancient desert city soon. Only "
-"hope my forces are strong enough to survive...\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:594
-msgid "Some ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:595
-msgid "Some sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:596
-msgid ""
-"Some unlucky adventurers have been captured and imprisoned in these lands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:597
-msgid "Sorceress Forest.  Show respect for nature!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:598
-msgid "Sorpigal"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:599
-msgid "South Mill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:600
-msgid "So you think you're smart?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:601
-msgid "Spector"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:602
-msgid "Spell Casters"
-msgstr "Czarodzieje"
-
-#: ../fheroes2/resource/maps_text.cpp:603
-msgid ""
-"Spies report Roland has sent a hero to search for the Crown. If he finds it "
-"first, all is lost!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:604
-msgid "Spirit City"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:605
-msgid "Spy Tower - see what your competition is doing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:606
-msgid "Stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:607
-msgid ""
-"Start with five castles!  How could you lose!?  Oh yeah, everyone else "
-"starts with five, too."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:608
-msgid "Stick to the road!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:609
-msgid "Stromgild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:610
-msgid "Stromhild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:611
-msgid "Stronghold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:612
-msgid "Stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:613
-msgid "Stuff for Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:614
-msgid "Stuff For Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:615
-msgid "Subbaculcha"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:616
-msgid "Sundune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:617
-msgid "Surf and Turf"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:618
-msgid "Swimming near the kelp is a pod of dolphins."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:619
-msgid "Tacma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:620
-msgid "Tchudes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:621
-msgid "Teleporters"
-msgstr "Teleporty"
-
-#: ../fheroes2/resource/maps_text.cpp:622
-msgid "Terra Firma"
-msgstr "Terra Firma"
-
-#: ../fheroes2/resource/maps_text.cpp:623
-msgid "Terrain Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:624
-msgid ""
-"The alliance has crumbled and all are at war. Lots of resources but little "
-"time to prepare."
-msgstr ""
-"Przymierze upadło i wszyscy walczą ze sobą nawzajem. Dużo surowców, ale mało "
-"czasu na przygotowanie."
-
-#: ../fheroes2/resource/maps_text.cpp:625
-msgid ""
-"The ancient King Zealot had the artifact of the gods and then hid it in his "
-"old age so that it could not be used by others."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:626
-msgid "The Back Door"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:627
-msgid ""
-"The Barbarian's lands are being invaded. Are you strong enough to resist the "
-"invasion?"
-msgstr ""
-"Kraina Barbarzyńców zostaje zaatakowana. Czy jesteś dość silny, by odeprzeć "
-"inwazję?"
-
-#: ../fheroes2/resource/maps_text.cpp:628
-msgid ""
-"The castle of Drakonran in the east has been taken by the barbarians! Two "
-"other towns to the west have also been taken, but the barbarian armies were "
-"fairly decimated in the process."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:629
-msgid "The center island is rumored to harbor great spells."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:630
-msgid "The Citadel"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:631
-msgid "The cities of the plains."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:632
-msgid "The Clearing"
-msgstr "Przesieka"
-
-#: ../fheroes2/resource/maps_text.cpp:633
-msgid ""
-"The convoy has at long last arrived. Regretably, it has been beset by "
-"bandits on its journey here, and has far less supplies than we had hoped. "
-"Make your way south, for our spies have found rich mines there."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:634
-msgid ""
-"The convoy should have been here by now! Let us hope that it is safe and "
-"still on its way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:635
-msgid ""
-"The country lords have allied and pooled their resources into one command. "
-"Not only have they massed their forces in the north, but they have sent a "
-"knight to the west to steal your supplies. Scouts report a castle to the "
-"east that would be ideal as a base of operations."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:636
-msgid "The crew are unworthy!  I am not going down with the ship! -The Captain"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:637
-msgid "\"The Crown\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:638
-msgid ""
-"The day you have feared has finally arrived.  The king, who you have "
-"faithfully served, has died, leaving no heir to his throne.  As his captain, "
-"you feel that this job should now be yours, but several factions even now "
-"are preparing for conquest.  You are at the center of the trade routes, "
-"having the sea to the south and the great forest to the north.  Go, now, "
-"Commander, and claim what is rightfully yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:639
-msgid ""
-"The diplomats who were sent here ahead of you report that the elves will "
-"only cooperate with you if you will recover the golden bow for them. It was "
-"stolen by their enemies, the Dragons and hidden behind magic barriers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:640
-msgid "The Eastern Town."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:641
-msgid "The edge of the world is your edge.  But prepare to be prepared."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:642
-msgid "The Emerald Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:643
-msgid "The Enchanted Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:644
-msgid "The End of the World is Nigh!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:645
-msgid "The End of the World is Nigh"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:646
-msgid ""
-"The Epic battle against Your Rival! Eliminate everything! Total Warfare! "
-"Don't Lose your first hero!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:647
-msgid ""
-"The Fire King is an ally to the dragons, and will help a friend of theirs."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:648
-msgid "The First One To Take Astircaer Wins!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:649
-msgid ""
-"The first piece of the artifact now lies in the hands of the Unholy Order of "
-"Warlocks. You must annihilate them, and their allies to the north. They will "
-"surely give us what we seek in exchange for their feeble lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:650
-msgid ""
-"The Fortune of Infamous Uae was buried on one of these islands. She died "
-"without ever revealing it.  Find it before the other cutthroats."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:651
-msgid "The four factions race to capture a mystical castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:652
-msgid ""
-"The four spell casters face off with substantial starting armies. Can the "
-"crusaders keep the peace?"
-msgstr ""
-"Czterej czarodzieje z dużymi armiami walczą między sobą. Czy krzyżowcom uda "
-"się utrzymać pokój?"
-
-#: ../fheroes2/resource/maps_text.cpp:653
-msgid "\"The Gauntlet\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:654
-msgid ""
-"The Gods have given you 6 months to prove yourself. Good or Evil - who shall "
-"prevail? (Blue,Green and Red vs Yellow, Orange and Purple)"
-msgstr ""
-"Bogowie dali wam 6 miesięcy na przeprowadzenie próby sił. Dobro lub Zło - "
-"kto zwycięży? (Nieb., Ziel. i Czerw. kontra Żółty, Pom. i Purpurowy)"
-
-#: ../fheroes2/resource/maps_text.cpp:655
-msgid ""
-"The gods have granted this world a great artifact, to find it means victory."
-msgstr ""
-"Bogowie powierzyli temu światu potężny artefakt, znajdź go, a zwyciężysz."
-
-#: ../fheroes2/resource/maps_text.cpp:656
-msgid "The Gods themselves will aid us in this War."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:657
-msgid "The Gold Traveller's Tent is near the Aqua Taveller's Tent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:658
-msgid "The guardians of Dragon Isle reside in the jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:659
-msgid "The Ice Prince stands frozen in some forgotten corner of the world."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:660
-msgid "The island...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:661
-msgid "The Island of Lost Reason"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:662
-msgid "The islands have much wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:663
-msgid "The Isle of Armoria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:664
-msgid "The key to success is rubbing enough lamps."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:665
-msgid ""
-"The King has declared you his hier apparent and champion. You must seek out "
-"and destroy your common enemy, Wilgatus and his Castle, Mirkosov, the source "
-"of his power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:666
-msgid ""
-"The King is dead, his kingdom has been shattered, and six leaders seek to "
-"seize power for themselves."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:667
-msgid "The Kingly Wastes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:668
-msgid "The Kings Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:669
-msgid ""
-"The King will sell you this land for 200,000 gold or you can take it by "
-"force. The choice is yours."
-msgstr ""
-"Król chciałby odsprzedać ci te ziemie za 200,000 sztuk złota, możesz je "
-"również przejąć siłą. Wybór należy do ciebie."
-
-#: ../fheroes2/resource/maps_text.cpp:670
-msgid "The land of Heroes II."
-msgstr "Kraina gry Heroes II."
-
-#: ../fheroes2/resource/maps_text.cpp:671
-msgid "The Lost Castle of the Ancients"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:672
-msgid ""
-"The mage wars have caused a great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:673
-msgid ""
-"The mage wars have caused great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:674
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trade.  "
-"Plus a little gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:675
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trading.  "
-"Plus a little more gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:676
-msgid ""
-"The Master Merchant arrives at your Castle.  He tells you tall tales of "
-"travel, full of outrageous lies.  He also gives you, your share of the "
-"profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:677
-msgid ""
-"The Master Merchant arrives back at your Castle.  He tells you tall tales of "
-"faraway places full of outrageous lies.  He also gives you, your share of "
-"the profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:678
-msgid "The Medusas have the password and they can be found just to the west."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:679
-msgid "The more there is the less you see."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:680
-msgid "The North Road to Roland's castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:681
-msgid ""
-"The note in this bottle has become mostly indecipherable. All you can make "
-"out are references to deadly pirates, and hidden gold mines."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:682
-msgid "The Other Side"
-msgstr "Druga Strona"
-
-#: ../fheroes2/resource/maps_text.cpp:683
-msgid ""
-"The Overlord has given you 4 months to conquer this land or deliver to him "
-"the sum of 150,000 gold."
-msgstr ""
-"Dostałeś od swojego Suwerena 4 miesiące na podbicie tej krainy; jeśli ci się "
-"nie uda, będziesz musiał zapłacić 150,000 sztuk złota."
-
-#: ../fheroes2/resource/maps_text.cpp:684
-msgid ""
-"The people on the Isle of Knowledge are taking up a collection to aid us."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:685
-msgid "The Proving Grounds"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:686
-msgid "The Queen's Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:687
-msgid "The Realm of Air is barred, but you may appeal here for help."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:688
-msgid ""
-"There are remnants of a mighty battle fought here, not too long ago. It "
-"looks as if whoever came this way may have made this their final stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:689
-msgid ""
-"There are three enemy castles to the north. Capture them in the name of "
-"Roland the true king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:690
-msgid ""
-"The Red Tide of War rolls North.  Stopping the flood seems hopeless.  Yet, "
-"Honor demands you and your ally die trying."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:691
-msgid "There is hidden treasure north of the Green Lord's Ore Mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:692
-msgid "There is hidden treasure south of the Blue Lord's Sawmill."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:693
-msgid "There's a warm wind blowing from the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:694
-msgid "There's a Wizard living in the north who is behind this peasant revolt."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:695
-msgid "The Retreat of the Alchemist Doctor Yu"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:696
-msgid ""
-"There used to be a mine here, but it has long since run out of ore.  You are "
-"only able to scavenge 5 units of ore from the old site."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:697
-msgid "There was a shipreck in the far east waters recently."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:698
-msgid "The River Styx"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:699
-msgid "The roars of several dragons echo from the towers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:700
-msgid "The Rock Store."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:701
-msgid "The Royal Gardens."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:702
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:703
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you defend against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:704
-msgid "These doors are a risk the likes of which you do not know."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:705
-msgid "These lands are beholden to Lord Kraeger."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:706
-msgid ""
-"These lands are desolate and for the most part devoid of resources. Not even "
-"the bravest heroes dare to venture into them, and plants are rare and "
-"precious here. Who knows what else awaits?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:707
-msgid ""
-"The Southern Witch is biding her time.  She will strike when your armies are "
-"weak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:708
-msgid "the stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:709
-msgid "The Table in the Great Hall of the Castle is Haunted."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:710
-msgid ""
-"The third piece of the artifact is somewhere to the north, that much we "
-"know. We are still unsure of its exact location, but our spies are out "
-"gathering information. The forces in this area are too strong to be "
-"completely subjugated, so take what you can and hold on to it tightly."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:711
-msgid ""
-"The troops have sworn their allegiance, but should lose a battle they will "
-"lose faith and our cause will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:712
-msgid "The Valley of Aruk."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:713
-msgid ""
-"The Valley of Magic holds many surprises.  You discover an old pair of boots "
-"sticking out of the sand."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:714
-msgid "The Valley of Tresures"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:715
-msgid "The Wasteland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:716
-msgid "The way of magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:717
-msgid "The way of might"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:718
-msgid "The way of numbers"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:719
-msgid "The western town."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:720
-msgid "The winds howl in mourning around the shipwreck."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:721
-msgid "The wizard has an island in the southeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:722
-msgid ""
-"The Wizards who have captured the Necromancers' town have wasted no time in "
-"building defenses designed to stop you, and their last castle has just been "
-"completed. Fortunately only a Captain of the Guard and a small garrison are "
-"currently present.  If you hurry, you should be able to capture the castle "
-"before they have a chance to reinforce it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:723
-msgid "The wood has arrived."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:724
-msgid "The writing on this sign is too faded to read."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:725
-msgid "The Yellow Lord has the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:726
-msgid ""
-"The Yellow Lord is a hothead who will attack before his allies can send him "
-"aid."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:727
-msgid "They say there's mermaids in these waters..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:728
-msgid ""
-"This area is rich in resources. Explore, but beware, a castle left "
-"undefended will quickly fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:729
-msgid ""
-"This area must be secured for the sake of the Empire. Our spies have "
-"reported a discord between The kingdom of the knights to the north, and that "
-"of the oppressive sorceresses to the northeast. Perhaps this feud can be "
-"exploited for our gain..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:730
-msgid "This bottle is empty."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:731
-msgid ""
-"This is the last week you have to find the rebel wizard Joseph! Good Luck in "
-"your quest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:732
-msgid ""
-"This land and all others are now under the sole ownership of Ibn Fadlan, the "
-"Undead King. Any disregard for his magesty's soverign rule is to be punished "
-"by death most horrendous."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:733
-msgid ""
-"This land has been claimed by the nation of Neroli. Interlopers are "
-"UNWELCOME."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:734
-msgid ""
-"This rugged land will have rivals fighting the terrain as well as each other."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:735
-msgid ""
-"This rundown village looks like it was once the epicenter of an enormous, "
-"but now ruined, city. Under a pile of rubble you find an object which looks "
-"like it has lain there for ages."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:736
-msgid ""
-"This spot overlooks an old quarry.  This was one of the only places in the "
-"world where ore could be taken right out of the ground.  Unfortunately the "
-"jungle has reclaimed the quarry and it is unusable.  You collect the last of "
-"the ore and depart."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:737
-msgid ""
-"This twisted maze of sorceress towns has three factions struggling for sole "
-"control.  Use your resources wisely!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:738
-msgid ""
-"This village appears to be in little better shape than the first one you "
-"saw. As you approach the village an old man hands you a slip of paper, with "
-"the following message, \"Joseph lives in the town of IslandHome.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:739
-msgid ""
-"This village is in extremely poor shape. There is no chance of getting more "
-"than some of the lesser creatures here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:740
-msgid "This way to the Necromancer Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:741
-msgid "Those who seek knowledge are welcome to the city of Chronos."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:742
-msgid ""
-"Three Warlocks in the land of Dragons. Lose thy home and all will be lost. "
-"Conquer thy enemies and the land shall forever be yours!"
-msgstr ""
-"3 czarnoksiężników w krainie smoków. Jeśli stracisz siedzibę, będziesz "
-"zgubiony. Ale jeśli pokonasz swoich wrogów, kraina na zawsze będzie twoja!"
-
-#: ../fheroes2/resource/maps_text.cpp:743
-msgid "Timberhill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:744
-msgid "Time for a refreshing drink."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:745
-msgid "Time is running out! The enemy's reinforcements are almost here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:746
-msgid "To pass you must pay troll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:747
-msgid "TreeHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:748
-msgid "Trespassers will be EATEN!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:749
-msgid "Trilobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:750
-msgid "Troy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:751
-msgid "Tundara"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:752
-msgid "Turn back, friend, while you still can!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:753
-msgid "Turn Back Now!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:754
-msgid "Turn Back Now or all will be LOST!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:755
-msgid "Turn Back or DIE!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:756
-msgid "Turn Back or else!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:757
-msgid "Turn back, you fool."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:758
-msgid "\"Turning Point\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:759
-msgid ""
-"Uae was the scurviest, pirate ye'd never wanta see. In all her years of "
-"murdering and thieving she amassed so much ill-gotten booty that she "
-"couldn't carry it around in her galleon.  Besides, even the meanest can't "
-"stay awake all the time.  Legend tells that she hid it so well, she was "
-"thinking that she just might forget where it was.  So she left clues around "
-"the islands, carved in stone.  Well, she's dead now.  It's up to you to "
-"recover her legacy."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:761
-msgid "Uncle Leo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:762
-msgid "Uncle Milty"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:763
-msgid "Undead Armies"
-msgstr "Nieumarli"
-
-#: ../fheroes2/resource/maps_text.cpp:764
-msgid "Unholy Alliance"
-msgstr "Przekl. sojusz"
-
-#: ../fheroes2/resource/maps_text.cpp:765
-msgid "Unite the Tribes. Don't lose your main hero, the first Descendant."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:766
-msgid "Valley of Death"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:767
-msgid "Valley Of The Damned"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:768
-msgid "Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:769
-msgid "Vaultius"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:770
-msgid "Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:771
-msgid "Vikings!"
-msgstr "Wikingowie!"
-
-#: ../fheroes2/resource/maps_text.cpp:772
-msgid "Viper's Nest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:773
-msgid "Vulcania"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:774
-msgid "Warrior Knight"
-msgstr "Dzielny Rycerz"
-
-#: ../fheroes2/resource/maps_text.cpp:775
-msgid "Wastelands"
-msgstr "Bezdroża"
-
-#: ../fheroes2/resource/maps_text.cpp:776
-msgid "Watch out for Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:777
-msgid "Waystop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:778
-msgid ""
-"\"We are at the edge of the world!\"  they scream.  \"What are we doing here?"
-"\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:779
-msgid "Weddington"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:780
-msgid "Weed Patch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:781
-msgid ""
-"We found a weakness my lord. Capture castle Black Fang and victory is ours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:782
-msgid ""
-"We have just learned that the artifact is on an island north of this "
-"continent. However, there does not appear to be any means to get there. Stay "
-"very alert for any possible way across the narrow channel."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:783
-msgid ""
-"Welcome back general.  Have you finished the conquest of the northern "
-"lands?  What? you still have not finished your mission!  Get back there and "
-"teach those rebels a lesson!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:784
-msgid "Welcome to Li'l Alctatraz! Vistors NOT welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:785
-msgid ""
-"Welcome to Power Island. He who controls this Isle controls the Seven Lakes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:786
-msgid "Welcome to the Sandbar."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:787
-msgid "Welcome to the sandy Isle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:788
-msgid "Welcome to the sorceress' guild."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:789
-msgid "Welcome to the Spiral Isles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:790
-msgid ""
-"Welcome to the wounderous Kitisland range.  Eruptions each day, beware of "
-"dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:791
-msgid "Welcome to Windfall Island!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:792
-msgid "Welcome to your DOOM!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:793
-msgid "We'll join you - for the right price."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:794
-msgid ""
-"Well placed bribes have won you a stronghold near the warring Barbarians. Be "
-"advised that given their proximity an unguarded castle is an open invitation "
-"to defeat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:795
-msgid "Westfork"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:796
-msgid "Westmoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:797
-msgid "We told you not to drink!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:798
-msgid "What are you doing here?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:799
-msgid "What cannot be seen but only heard, and will not speak until spoken to?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:800
-msgid "What everyday word is most often pronounced incorrectly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:801
-msgid "What goes up and down but never moves?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:802
-msgid ""
-"What good fortune!  You've discovered a long-abandoned settlement.  To your "
-"surprise, you discover that the previous inhabitants left some of their "
-"resources behind when they departed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:803
-msgid "What is always coming but never arrives?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:804
-msgid "What is the Sum of all Numbers from 1 to 200?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:805
-msgid "What is time spent poorly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:806
-msgid "What's another word for pirate treasure?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:807
-msgid "What's behind door number one?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:808
-msgid "What's this? A pile of gems?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:809
-msgid "What's this? Someone has left a pile of wood here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:810
-msgid ""
-"What team won Super Bowl XXI and Super Bowl XXV?  (Hint... a Wizard might "
-"have these troops in his army)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:811
-msgid "What turns everything around but does not move?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:812
-msgid ""
-"What walks in the morning on four legs, two in the afternoon and three in "
-"the evening?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:813
-msgid "What?  What's this?  Something at the bottom of this pool..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:814
-msgid "When you're ready, take the teleport to the Island's Hot Spot!"
-msgstr "Kiedy będziesz już gotowy, teleportuj się do Punktu Zapalnego!"
-
-#: ../fheroes2/resource/maps_text.cpp:815
-msgid ""
-"When you think yourself invincible, walk through this gate.  Even then, "
-"prepare to meet your bitter end."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:816
-msgid "Where am I?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:817
-msgid "While away seeking the Ultimate Artifact, Kastor's kingdom is invaded!"
-msgstr ""
-"Podczas gdy Kastor poszukuje Najwspanialszego Artefaktu, jego królestwo "
-"zostaje zaatakowane przez wrogów!"
-
-#: ../fheroes2/resource/maps_text.cpp:818
-msgid ""
-"While traveling a mesenger meets you on the road.  His message tells of a "
-"new ally from an island far to the south.  This ally can not offer forces to "
-"your battle but has agreed to send some support in the form of gold and "
-"crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:819
-msgid "Whiteshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:820
-msgid "Whittingham"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:821
-msgid "Who am I?"
-msgstr "Kim jestem?"
-
-#: ../fheroes2/resource/maps_text.cpp:822
-msgid ""
-"Who am I?...  Where am I?...  Oh no! My Ship!  Well it's consigned to the "
-"ghosts of my dead crew now, at least I still have my lucky rabbits foot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:823
-msgid "Who is the true King?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:824
-msgid ""
-"\"Why have we come this way?\"  asks the first mate.  You have no answer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:825
-msgid "Wicked Warlock Way"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:826
-msgid "Wilasher"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:827
-msgid "Wildabar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:828
-msgid "Wilgatus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:829
-msgid "Willow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:830
-msgid "Windfall Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:831
-msgid "Winterkill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:832
-msgid "Winterlands"
-msgstr "Królestwo Zimy"
-
-#: ../fheroes2/resource/maps_text.cpp:833
-msgid "Witch Hunt"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:834
-msgid ""
-"With the year long eruption of Mt. Kitisland, your three worst enemies now "
-"have a ground bridge to your eastern contenent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:835
-msgid "Wizardwood.  Magicians welcome!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:836
-msgid "Woodhaven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:837
-msgid "Wood's Lord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:838
-msgid "Woodstock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:839
-msgid "Woodville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:840
-msgid "Wormed Ash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:841
-msgid "Wow, somebody has left a pile of wood here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:842
-msgid "Wyrm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:843
-msgid "Xabran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:844
-msgid "Yellow gets some stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:845
-msgid "Yellow's Steady Cash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:846
-msgid "Yellow stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:847
-msgid "Yellow's Yarbols"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:848
-msgid "Ye old fish liver oil."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:849
-msgid "Yorksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:850
-msgid ""
-"You and your ally's families were given custody of The Isle of Knowledge.  "
-"Other Lords feel the time has come for new guardians..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:851
-msgid "You are a fool to come here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:852
-msgid "You are fighting on the side of your king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:853
-msgid "You are fighting on the side of your sister!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:854
-msgid "You are now entering the domain of Prince Roland. Have a nice day."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:855
-msgid "You are now entering the domain of Prince Roland. Have a pleasant stay."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:856
-msgid ""
-"You bribe the entrance guards of this dingy prison camp. They agree to look "
-"the other way for a little while."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:857
-msgid ""
-"You can only reach your enemies via teleporters, but each jump is a leap of "
-"faith."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:858
-msgid ""
-"You cautiously ride through the trees, looking out for enemy assaults, when "
-"suddenly, the old elf is beside you. \"Your quest is almost at an end, my "
-"friend. All that remains is for you to lay seige to these last few castles. "
-"The fate of my people rests upon your final battles here. May the gods be "
-"with you as well.\"  He turns to leave, but you ask him his name before he "
-"is gone. Over his shoulder, as he is leaving he says \"I am Ilthanis, king "
-"of the elves.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:859
-msgid ""
-"You come across the dead remains of what was appearantly a powerful wizard!  "
-"You wonder if it's safe to continue."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:860
-msgid ""
-"You face three opponents in this scenario. Capture their castles and their "
-"heroes to prove your worthiness to Archibald."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:861
-msgid ""
-"You find a beautiful helm buried in the lava.  As you move to put it on your "
-"head it turns into the Hideous mask and now you realize that no creature "
-"will join you."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:862
-msgid ""
-"You find a gleaming gold medalion buried in the  snow.  As you move to put "
-"it on it changes to the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:863
-msgid ""
-"You find an old signpost in the midst of a thicket that reads \"Warlock "
-"Wood, West.  Barbarian Fields, East.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:864
-msgid ""
-"You find a note in the bottle! It reads, \"My ship has been wrecked by the "
-"notorious pirates in this area! I am stranded on a small and barren island. "
-"Please, I beg you to come and rescue me!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:865
-msgid "You found something!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:866
-msgid "You found Treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:867
-msgid ""
-"You have been ordered here to claim this land in the name of your King and "
-"recover any riches that you might find.  However, five other Kings and "
-"Queens have also sent their heroes to this land, so you must watch out for "
-"them as well as the natives!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:868
-msgid "You have found what someone else has lost..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:869
-msgid ""
-"You have hired a barbarian of great power to aid you in this, your last "
-"quest. His origins are unknown to you, but you sense strong nobility beneath "
-"the furs and dirt that cover him. In addition, the famous explorer, Marco "
-"the wizard, is rumored to have wrecked his ship in this new land. Finding "
-"him would prove to be a much needed boon to your cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:870
-msgid ""
-"You have just 8 weeks  to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:871
-msgid ""
-"You have just 8 weeks to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:872
-msgid ""
-"You have received a message from Archibald. \"General, these peasants "
-"deserve punishment. Put them to the sword and let Corlagon have his way with "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:873
-msgid ""
-"You have received a message from Archibald.  \" HOW DARE YOU BETRAY ME! I "
-"will see your head on the block alongside your new master's once I have won."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:874
-msgid ""
-"You have received a message from Roland. \" I am shocked! I had thought "
-"better of you, but I was terribly wrong. Now you'll have to live with your "
-"dark decision for the rest of your life.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:875
-msgid "You have recieved a shipment of supplies from your kingdom!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:876
-msgid ""
-"You have recieved a shipment of supplies from your kingdom! There is a note "
-"attached, \"These are all we could afford to send you from our treasuries, "
-"as the war with Harondale is taxing us greatly. We will send more in two "
-"weeks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:877
-msgid ""
-"You have six months to destroy the Necromancer Stronghold in the heart of "
-"the valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:878
-msgid ""
-"You have washed up on the beach after being shipwrecked. Your goal is to "
-"find a way home."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:879
-msgid ""
-"You hear a low rumble, look up and see an avalanche!  You dive onto a large "
-"patch of grass to avoid it.  While dusting yourself off, you consider "
-"yourself quite lucky to be alive.  Luckier still to find a Four-Leaf Clover "
-"stuck on your nose."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:880
-msgid ""
-"You hear a rumor from a peasant who lives in the town of Waystop. He says, "
-"\"The pirates control most of the sulfur mines in this area. They use it for "
-"the cannons on their bigger boats. If you want a mine, you'll have to defeat "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:881
-msgid "You hear melodic strains of elvish music as you enter this clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:882
-msgid ""
-"You must, like, forsake your earthly wealth and, like, join us on the island "
-"of the lotus eaters."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:883
-msgid ""
-"You must search the world for your mortal enemy, Wilgatus.  Can you find him "
-"before its too late?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:884
-msgid ""
-"You notice some runes hastily scrawled into a rock by your feet, They look "
-"like the initials of Uncle Ivan!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:885
-msgid ""
-"You notice that mines and resources in the elvish lands are few, and you "
-"send word to your kingdom that you will need extra supplies. They should "
-"respond within a fortnight."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:886
-msgid ""
-"Your advance scouts come riding back to you with the following news. They "
-"believe they have found signs that Uncle Ivan was in this general area, and "
-"that he made his way to the north many months ago. Also they say there is a "
-"town nearby and many resources to the east."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:887
-msgid ""
-"Your advisor approaches you, \"My liege, something must be done about these "
-"peasants! They still refuse to work.  At this rate you won't have anything "
-"to put in your daughter's dowry!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:888
-msgid ""
-"Your advisor approaches you smiling greatly, \"My liege! The peasants are "
-"making money in the market, and are finally paying taxes!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:889
-msgid ""
-"Your advisor approaches you with a long face, \"My liege, the peasant's "
-"numbers are growing steadily.  All they do is take, take, take! We are "
-"beginning to suffer dearly because of them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:890
-msgid ""
-"Your advisor approaches you with some startling information, \"My liege, the "
-"peasants are draining us. They do nothing, and take everything! We must get "
-"them home. Your own citizens are beginning to suffer!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:891
-msgid ""
-"Your arrival here was a surprise to those sworn to guard Dragon Isle, and "
-"you were able to quickly capture one of their castles.  Use caution, though, "
-"for two other guardians remain in this jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:892
-msgid ""
-"Your castle, founded inside the center of a mile wide crater, is besieged by "
-"those who desire your mineral wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:893
-msgid "Your castle is the last outpost in the area, Don't lose it!"
-msgstr "Twój zamek to ostatni bastion w okolicy, nie strać go!"
-
-#: ../fheroes2/resource/maps_text.cpp:894
-msgid "Your crew begins to grumble."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:895
-msgid ""
-"Your crew seriously entertains thoughts of mutiny.  Your nights are "
-"sleepless."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:896
-msgid "You're almost there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:897
-msgid "You, recieve word that you have been robbed."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:898
-msgid "You're getting colder."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:899
-msgid "You're getting warmer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:900
-msgid ""
-"You're here! Oh, thank you thank you thank you! I'm in the jail east of the "
-"castle. Please hurry!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:901
-msgid ""
-"Your expedition has taken a turn for the worse... you now have no way to get "
-"home!"
-msgstr ""
-"Twoja wyprawa zakończyła się klęską... co gorsza, nie masz jak wrócić do "
-"domu!"
-
-#: ../fheroes2/resource/maps_text.cpp:902
-msgid ""
-"Your forces are thinly spread in an effort to defend all the dwarf towns "
-"(which may not be transformed into castles). Consolidate your forces and "
-"smite the enemy before the towns fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:903
-msgid ""
-"Your horse stumbles and throws you from the saddle.  When you awaken you "
-"find that you have hit your head on the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:904
-msgid ""
-"Your isolation from the rest of the kingdom has largely kept you out of the "
-"political struggles, but now with the king's death, and lack of an heir, you "
-"see a golden opportunity to seize the throne for yourself.  Just remember "
-"that you have relied largely on trade for several key resources, especially "
-"sulfur, but with a little planning this land can be yours.  Go, now, and "
-"show these peasants how to rule!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:905
-msgid "Your king has sent supplies to aid the war effort."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:906
-msgid ""
-"Your opponents are allied against you and each is twice as powerful as his "
-"predecessor! Is it possible to win?"
-msgstr ""
-"Twoi przeciwnicy połączyli siły, a każdy z nich jest dwukrotnie potężniejszy "
-"od swojego poprzednika! Czy w takiej bitwie można wygrać?"
-
-#: ../fheroes2/resource/maps_text.cpp:907
-msgid ""
-"Your Queen sent you here to explore this newly discovered territory, but a "
-"freak storm scattered your fleet and left you stranded.  You gather the "
-"survivors and form a small settlement, naming it New Vertigo.  This place is "
-"your home now, and survival is your highest priority, but remember, if you "
-"are captured or killed, it's over!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:908
-msgid ""
-"Your rival, the kingdom of Harondale, is attacking your weak border towns! "
-"Recover from their first strike and crush them completely."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:909
-msgid ""
-"Your Scouts report talking to a young knight, a squire to the two sleeping "
-"heroes.  The squire is trapped by the Aqua Magic Barriers and a group of "
-"fallen Paladins.  He says the two heroes, Dainwin and Ceallach, have "
-"awakened but are still trapped by a Gold Magical Barrier and asks your aid "
-"in freeing them."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:910
-msgid ""
-"Your Scouts report that the Aqua Traveller's Tent is located along The North "
-"Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:911
-msgid ""
-"Your scouts return with grim news.  The natives of this land are currently "
-"at war with each other, and they like outsiders even less than they like "
-"each other!  Congratulations, Commander, you're at war!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:912
-msgid ""
-"Your sister calls you before her altar in the morning. \"I have important "
-"news,\" she says, \"The barbarian kingdoms which border this land have "
-"agreed to lend us some of their castles and warriors in return for a share "
-"of the spoils. I hope victory comes swiftly, but your presence gives me "
-"strength to stand until whatever end awaits.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:913
-msgid "Your subjects contribute to your war effort!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:914
-msgid ""
-"Your town is undefended and your heroes are scattered.  Do you attack or "
-"defend?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:915
-msgid ""
-"Your treasury has been looted by robbers and you have lost valuable "
-"resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:916
-msgid "Your troops begin to wonder about your sanity."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:917
-msgid ""
-"You run aground on the rocks and have to use some wood to fix your boat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:918
-msgid ""
-"You see a family of refugees making their way from the beach. You ask them "
-"about their plight and they tell you that they are from a once great city "
-"called Moss Side. They tell you that the castle was destroyed in a great "
-"conflagration, and they fled for fear of their lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:919
-msgid ""
-"You see an old man bringing water towards the stables. Recognizing him as "
-"the mystic, you attempt to thank him for his gift with some gold. He "
-"refuses, but says to you instead, \"There are riddles guarding the source of "
-"the fount's power, and the dragons know the answers. Make your way through "
-"their lair, and you shall know victory.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:920
-msgid ""
-"You see an old mystic perched on a rock. You walk towards him to see if he "
-"has any words for you on your quest, and he says \"First I see you as a "
-"great conquerer of the lands of men. Secondly, I see you as a mighty ruler "
-"of vast armies, well loved by your troops. Thirdly, I see you as a slayer of "
-"legions of dragons, your body bathed in their fire. Lastly, I see you "
-"standing on the shores of the fount, unable to cross.\" Then the Mystic "
-"fades away."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:921
-msgid "You see something that could just be the elusive Nubbie!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:922
-msgid ""
-"You see the mast of ancient ship here.  On further investigation you find "
-"that the ships holds are full of gems.  The hours pass as your crue "
-"liberates the treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:923
-msgid ""
-"You see the remains of a burned out sawmill here.  All you can salvage is "
-"some ofwood left for scrap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:924
-msgid ""
-"You see the remains of an old sawmill, but it is obvious that you will not "
-"be able to make it work again."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:925
-msgid ""
-"You see the remains of an old sawmill just to realize that it will no longer "
-"produce.  You gather the ramains and move on."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:926
-msgid ""
-"You send this letter back to the king,\"A month has passed and we have not "
-"discovered the wizard Joseph. I only hope that we are able to locate him in "
-"time to aid us in our struggle.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:927
-msgid "You should turn back."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:928
-msgid ""
-"You stumble upon an old man who proclaims you Lord of the Realm, hands you "
-"his boots and wonders into the mountains mumbling something about being late "
-"for an important date."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:929
-msgid ""
-"You stumple across three small rocks piled on top of each other and decide "
-"to dig undernear them.  There you find an old weather-beaten bag of gems."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:930
-msgid "You uncover a compass in the grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:931
-msgid "You've been warned!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:932
-msgid ""
-"You've received a message from Roland. \"In the absence of a strong leader, "
-"the local lords have fallen to fighting. Uniting this area is critical to "
-"our cause, so we must not fail.  Leaving your castle undefended in this "
-"highly contested region will surely lead to defeat. I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:933
-msgid ""
-"You've received a message from the guild. \"Thank God you've arrived! We're "
-"under seige from two enemies from the north and one from across the sea. "
-"Please save us, you're our only hope.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:934
-msgid ""
-"You've ruled with an iron fist (and an army of undead), but now your kingdom "
-"has turned against you!"
-msgstr ""
-"Przy pomocy armii nieumarłych, sprawowałeś w kraju władzę 'silnej ręki', "
-"lecz teraz twoje królestwo zwróciło się przeciwko tobie!"
-
-#: ../fheroes2/resource/maps_text.cpp:935
-msgid ""
-"You've saved a group of miners from the dragons.  One of them approaches "
-"you, \"Thank you so much for saving us!  We found this sulfer and sword in "
-"the mine, then those dragons chased us!  I don't know how much longer we "
-"could survive!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:936
-msgid ""
-"You will clash quickly on this small head-to-head map, so stay on your toes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:937
-msgid ""
-"You will need a stronger army than that, mortal, to step through this portal."
-msgstr ""
-
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Wood"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Mercury"
 msgstr "Rtęć"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Ore"
 msgstr "Ruda Żelaza"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Sulfur"
 msgstr "Siarka"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Crystal"
 msgstr "Kryształ"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Gems"
 msgstr "Klejnoty"
 
-#: ../fheroes2/spell/spell_book.cpp:61 ../fheroes2/spell/spell_book.cpp:79
-msgid "No spell to cast."
-msgstr "Brak zaklęć."
-
-#: ../fheroes2/spell/spell_book.cpp:138
-msgid "Your hero has %{point} spell points remaining"
-msgstr "Twój bohater ma jeszcze %{point} pkt. magii"
-
-#: ../fheroes2/spell/spell.cpp:50
 msgid "Fireball"
 msgstr "Kula Ognia"
 
-#: ../fheroes2/spell/spell.cpp:50
 msgid ""
 "Causes a giant fireball to strike the selected area, damaging all nearby "
 "creatures."
@@ -12139,11 +6313,9 @@ msgstr ""
 "Tworzy wielką kulę ognia w wybranym obszarze uszkadzając wszystkie pobliskie "
 "jednostki."
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid "Fireblast"
 msgstr "Eksplozja Ognia"
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid ""
 "An improved version of fireball, fireblast affects two hexes around the "
 "center point of the spell, rather than one."
@@ -12151,19 +6323,15 @@ msgstr ""
 "Wzmocniona wersja Kuli Ognia, Eksplozja oddziaływuje na dwa pola wokół "
 "punktu centralnego czaru, zamiast na jeden."
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Lightning Bolt"
 msgstr "Błyskawica"
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Causes a bolt of electrical energy to strike the selected creature."
 msgstr "Uderza w wybrane stworzenie za pomocą energii elektrycznej."
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid "Chain Lightning"
 msgstr "Łańcuch piorunów"
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid ""
 "Causes a bolt of electrical energy to strike a selected creature, then "
 "strike the nearest creature with half damage, then strike the NEXT nearest "
@@ -12175,129 +6343,102 @@ msgstr ""
 "energia się nie wyczerpie.\r\n"
 "Uwaga: Czar może uszkodzić twoje stworzenia!"
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid "Teleport"
 msgstr "Teleportacja"
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid ""
 "Teleports the creature you select to any open position on the battlefield."
 msgstr ""
 "Teleportuje stworzenia które wybierzesz do dowolnego miejsca na polu walki."
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid "Cure"
 msgstr "Oczyszczenie"
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid ""
-"Removes all negative spells cast upon one of your units, and restores up to %"
-"{count} HP per level of spell power."
+"Removes all negative spells cast upon one of your units, and restores up to "
+"%{count} HP per level of spell power."
 msgstr ""
 "Usuwa wszelkie negatywne efekty czarów z wybranej jednostki, i przywraca  do "
 "%{count} punktów życia na poziom Mocy."
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid "Mass Cure"
 msgstr "Masowe Leczenie"
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid ""
-"Removes all negative spells cast upon your forces, and restores up to %"
-"{count} HP per level of spell power, per creature."
+"Removes all negative spells cast upon your forces, and restores up to "
+"%{count} HP per level of spell power, per creature."
 msgstr ""
-"Usuwa wszystkie negatywne efekty czarów z twoich jednostek i przywraca  %"
-"{count}  punktów życia na poziom Mocy, każdemu stworzeniu."
+"Usuwa wszystkie negatywne efekty czarów z twoich jednostek i przywraca  "
+"%{count}  punktów życia na poziom Mocy, każdemu stworzeniu."
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrect"
 msgstr "Wskrzeszenie"
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrects creatures from a damaged or dead unit until end of combat."
 msgstr ""
 "Wskrzesza stworzenia z uszkodzonej lub martwej jednostki do końca walki."
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrect True"
 msgstr "Prawdziwe wskrzeszenie"
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrects creatures from a damaged or dead unit permanently."
 msgstr "Na stałe wskrzesza zabite/uszkodzone jednostki."
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Haste"
 msgstr "Przyspieszenie"
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Increases the speed of any creature by %{count}."
 msgstr "zwiększa szybkość wszystkich Twoich jednostek o %{count}."
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Mass Haste"
 msgstr "Grupowe przyspieszenie"
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Increases the speed of all of your creatures by %{count}."
 msgstr "Zwiększa szybkość wszystkich twoich stworzeń o %{count}."
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "spell|Slow"
 msgstr "Spowolnienie"
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "Slows target to half movement rate."
 msgstr ""
 "Jednostka, na którą rzucone zostanie zaklęcie, będzie mieć o połowę "
 "zmniejszony ruch."
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Mass Slow"
 msgstr "Grupowe spowolnienie"
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Slows all enemies to half movement rate."
 msgstr "Wszyscy przeciwnicy mają o połowę zmniejszony ruch."
 
-#: ../fheroes2/spell/spell.cpp:64
-msgid "Blind "
-msgstr "Oślepienie "
+#, fuzzy
+msgid "spell|Blind"
+msgstr "Spowolnienie"
 
-#: ../fheroes2/spell/spell.cpp:64
 msgid "Clouds the affected creatures' eyes, preventing them from moving."
 msgstr "Oślepia wybraną jednostkę nie pozwalając jej na ruch."
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Bless"
 msgstr "Błogosławieństwo"
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Causes the selected creatures to inflict maximum damage."
 msgstr "Sprawia, że wybrane stworzenia zadają maksymalne obrażenia."
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Mass Bless"
 msgstr "Grupowe błogosławieństwo"
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Causes all of your units to inflict maximum damage."
 msgstr ""
 "Sprawia, że wszystkie twoje jednostki będą zadawać maksymalne obrażenia."
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Stoneskin"
 msgstr "Kamienna skóra"
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Magically increases the defense skill of the selected creatures."
 msgstr "Magicznie podnosi współczynnik obrony wybranych stworzeń."
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid "Steelskin"
 msgstr "Stalowa skóra"
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid ""
 "Increases the defense skill of the targeted creatures.  This is an improved "
 "version of Stoneskin."
@@ -12305,107 +6446,83 @@ msgstr ""
 "Podnosi współczynnik obrony wybranych stworzeń. Zaklęcie to jest ulepszoną "
 "wersją 'kamiennej skóry'."
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Curse"
 msgstr "Klątwa"
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Causes the selected creatures to inflict minimum damage."
 msgstr "Sprawia, że wybrane stworzenia zadają minimalne obrażenia."
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Mass Curse"
 msgstr "Grupowa klątwa"
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Causes all enemy troops to inflict minimum damage."
 msgstr "prawia, że wszystkie wrogie oddziały zadają minimalne obrażenia."
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Holy Word"
 msgstr "Święte słowo"
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Damages all undead in the battle."
 msgstr "Zadaje obrażenia wszystkim nieumarłym na polu bitwy."
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid "Holy Shout"
 msgstr "Święte zawołanie"
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid ""
 "Damages all undead in the battle.  This is an improved version of Holy Word."
 msgstr ""
 "Zadaje obrażenia wszystkim nieumarłym na polu bitwy. Zaklęcie to jest "
 "ulepszoną wersją 'świętego słowa'."
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Anti-Magic"
 msgstr "Antymagia"
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Prevents harmful magic against the selected creatures."
 msgstr "Neguje działanie wrogich zaklęć na wybranej jednostce."
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Dispel Magic"
 msgstr "Rozproszenie magii"
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Removes all magic spells from a single target."
 msgstr "Przerywa działanie wszystkich zaklęć rzuconych na jednostkę."
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Mass Dispel"
 msgstr "Grupowe rozproszenie"
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Removes all magic spells from all creatures."
 msgstr "Przerywa działanie wszelkich zaklęć rzuconych na wszystkie jednostki."
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Magic Arrow"
 msgstr "Magiczna strzała"
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Causes a magic arrow to strike the selected target."
 msgstr "Tworzy magiczną strzałę, która uderza w wybrany cel."
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Berserker"
 msgstr "Szał bitewny"
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Causes a creature to attack its nearest neighbor."
 msgstr "Sprawia, że jednostka atakuje najbliższy oddział."
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid "Armageddon"
 msgstr "Armagedon"
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid ""
 "Holy terror strikes the battlefield, causing severe damage to all creatures."
 msgstr ""
 "Na pole bitwy spada święty kataklizm, który zadaje poważne obrażenia "
 "wszystkim stworzeniom."
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Elemental Storm"
 msgstr "Burza żywiołów"
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Magical elements pour down on the battlefield, damaging all creatures."
 msgstr ""
 "Nad polem bitwy przetacza się burza żywiołów, zadająca obrażenia wszystkim "
 "stworzeniom."
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid "Meteor Shower"
 msgstr "Deszcz meteorów"
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid ""
 "A rain of rocks strikes an area of the battlefield, damaging all nearby "
 "creatures."
@@ -12413,42 +6530,35 @@ msgstr ""
 "W wyznaczone miejsce pola bitwy uderza deszcz meteorów, raniąc wszystkie "
 "stworzenia w pobliżu."
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "Paralyze"
 msgstr "Paraliż"
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "The targeted creatures are paralyzed, unable to move or retaliate."
 msgstr ""
 "Stworzenia dotknięte działaniem tego czaru zostają sparaliżowane. Nie mogą "
 "się ruszać ani kontratakować."
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid "Hypnotize"
 msgstr "Hipnoza"
 
-#: ../fheroes2/spell/spell.cpp:82
+#, fuzzy
 msgid ""
-"Brings a single enemy unit under your control for one combat round if its "
-"hits are less than %{count} times the caster's spell power."
+"Brings a single enemy unit under your control if its hits are less than "
+"%{count} times the caster's spell power."
 msgstr ""
 "Sprawia, że wybrany oddział przeciwnika dostaje się pod twą kontrolę na czas "
 "jednej rundy walki, pod warunkiem, że jego punkty życia są %{count} razy "
 "mniejsze niż moc osoby rzucającej zaklęcie."
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Cold Ray"
 msgstr "Promień zimna"
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Drains body heat from a single enemy unit."
 msgstr "Wysysa ciepło z pojedynczej wrogiej jednostki."
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid "Cold Ring"
 msgstr "Krąg zimna"
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid ""
 "Drains body heat from all units surrounding the center point, but not "
 "including the center point."
@@ -12456,27 +6566,21 @@ msgstr ""
 "Wysysa ciepło ze wszystkich jednostek wokół punktu rzucenia zaklęcia, z "
 "pominięciem właśnie punktu centralnego."
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Disrupting Ray"
 msgstr "Promień osłabienia"
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Reduces the defense rating of an enemy unit by three."
 msgstr "O trzy punkty zmniejsza współczynnik obrony wrogiej jednostki."
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Death Ripple"
 msgstr "Drgawki śmierci"
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Damages all living (non-undead) units in the battle."
 msgstr "Zadaje obrażenia wszystkim żywym jednostkom na polu bitwy."
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid "Death Wave"
 msgstr "Fala śmierci"
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid ""
 "Damages all living (non-undead) units in the battle.  This spell is an "
 "improved version of Death Ripple."
@@ -12484,37 +6588,29 @@ msgstr ""
 "Zadaje obrażenia wszystkim żywym jednostkom na polu bitwy. Zaklęcie to jest "
 "ulepszoną wersją 'drgawek śmierci'."
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Dragon Slayer"
 msgstr "Zabójca smoków"
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Greatly increases a unit's attack skill vs. Dragons."
 msgstr "Znacznie zwiększa umiejętność ataku jednostki w walce ze smokami."
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Blood Lust"
 msgstr "Żądza krwi"
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Increases a unit's attack skill."
 msgstr "Zwiększa umiejętność ataku jednostki."
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Animate Dead"
 msgstr "Ożywienie martwych"
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Resurrects creatures from a damaged or dead undead unit permanently."
 msgstr ""
 "Na stałe 'wskrzesza' stworzenia z uszkodzonej lub zniszczonej jednostki "
 "nieumarłych."
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid "Mirror Image"
 msgstr "Lustrzane odbicie"
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid ""
 "Creates an illusionary unit that duplicates one of your existing units.  "
 "This illusionary unit does the same damages as the original, but will vanish "
@@ -12523,130 +6619,100 @@ msgstr ""
 "Tworzy iluzję jednej z twoich istniejących jednostek. Walczy tak samo jak "
 "oryginalna jednostka, ale znika po otrzymaniu jakichkolwiek obrażeń."
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Shield"
 msgstr "Tarcza"
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Halves damage received from ranged attacks for a single unit."
 msgstr ""
 "Zmniejsza o połowę obrażenia, jakie otrzymuje jedna z twoich jednostek z "
 "powodu ataków dystansowych."
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Mass Shield"
 msgstr "Grupowa tarcza"
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Halves damage received from ranged attacks for all of your units."
 msgstr ""
 "Zmniejsza o połowę obrażenia, jakie otrzymują wszystkie twoje jednostki z "
 "powodu ataków dystansowych."
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summon Earth Elemental"
 msgstr "Przywołanie żywiołaka ziemi"
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summons Earth Elementals to fight for your army."
 msgstr "Przywołuje żywiołaki ziemi, które walczą po twojej stronie."
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summon Air Elemental"
 msgstr "Przywołanie żywiołaka powietrza"
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summons Air Elementals to fight for your army."
 msgstr "Przywołuje żywiołaki powietrza, które walczą po twojej stronie."
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summon Fire Elemental"
 msgstr "Przywołanie żywiołaka ognia"
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summons Fire Elementals to fight for your army."
 msgstr "Przywołuje żywiołaki ognia, które walczą po twojej stronie."
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summon Water Elemental"
 msgstr "Przywołanie żywiołaka wody"
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summons Water Elementals to fight for your army."
 msgstr "Przywołuje żywiołaki wody, które walczą po twojej stronie."
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Earthquake"
 msgstr "Trzęsienie ziemi"
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Damages castle walls."
 msgstr "Uszkadza mury zamku."
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "View Mines"
 msgstr "Pokaż kopalnie"
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "Causes all mines across the land to become visible."
 msgstr "Czar ten sprawia, że wszystkie kopalnie w krainie stają się widoczne."
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "View Resources"
 msgstr "Pokaż zasoby"
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "Causes all resources across the land to become visible."
 msgstr "Czar ten sprawia, że wszystkie zasoby w krainie stają się widoczne."
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "View Artifacts"
 msgstr "Pokaż artefakty"
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "Causes all artifacts across the land to become visible."
 msgstr "Czar ten sprawia, że wszystkie artefakty w krainie stają się widoczne."
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "View Towns"
 msgstr "Pokaż miasta"
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "Causes all towns and castles across the land to become visible."
 msgstr ""
 "Czar ten sprawia, że wszystkie miasta i zamki w krainie stają się widoczne."
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "View Heroes"
 msgstr "Pokaż bohaterów"
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "Causes all Heroes across the land to become visible."
 msgstr "Czar ten sprawia, że wszyscy bohaterowie w krainie stają się widoczni."
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "View All"
 msgstr "Pokaż wszystko"
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "Causes the entire land to become visible."
 msgstr "Czar ten sprawia, że widoczna staje się cała kraina."
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Identify Hero"
 msgstr "Identyfikacja bohatera"
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Allows the caster to view detailed information on enemy Heroes."
 msgstr ""
 "Pozwala osobie rzucającej zaklęcie zobaczyć szczegółowe informacje na temat "
 "herosów wroga."
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid "Summon Boat"
 msgstr "Przywołanie łodzi"
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid ""
 "Summons the nearest unoccupied, friendly boat to an adjacent shore "
 "location.  A friendly boat is one which you just built or were the most "
@@ -12656,27 +6722,22 @@ msgstr ""
 "wybrzeża. Własna łódź to taka, która została przez ciebie zbudowana, lub "
 "była ostatnio przez ciebie użytkowana."
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Dimension Door"
 msgstr "Brama między wymiarami"
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Allows the caster to magically transport to a nearby location."
 msgstr ""
 "Pozwala osobie rzucającej zaklęcie magicznie przenieść się w inne, pobliskie "
 "miejsce."
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Town Gate"
 msgstr "Brama do miasta"
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Returns the caster to any town or castle currently owned."
 msgstr ""
 "Pozwala osobie rzucającej zaklęcie wrócić do najbliższego własnego miasta "
 "lub zamku."
 
-#: ../fheroes2/spell/spell.cpp:109
 msgid ""
 "Returns the hero to the town or castle of choice, provided it is controlled "
 "by you."
@@ -12684,22 +6745,18 @@ msgstr ""
 "Przenosi bohatera do wybranego zamku lub miasta, znajdującego się pod twoją "
 "kontrolą."
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid "Visions"
 msgstr "Wizje"
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid ""
 "Visions predicts the likely outcome of an encounter with a neutral army camp."
 msgstr ""
 "Zaklęcie to pozwala przewidzieć prawdopodobny wynik starcia z neutralną "
 "armią."
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid "Haunt"
 msgstr "Nawiedzenie"
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid ""
 "Haunts a mine you control with Ghosts.  This mine stops producing "
 "resources.  (If I can't keep it, nobody will!)"
@@ -12707,356 +6764,1829 @@ msgstr ""
 "Sprawia, że jedną z twych kopalni nawiedzają duchy. Kopalnia zaprzestaje "
 "wydobycia. (Jeśli nie mogę jej mieć, to nikt jej mieć nie będzie!)"
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Set Earth Guardian"
 msgstr "Ustawienie strażnika ziemi"
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Sets Earth Elementals to guard a mine against enemy armies."
 msgstr "Wzywa żywiołaki ziemi, które pilnują kopalni przed wrogimi armiami."
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Set Air Guardian"
 msgstr "Ustawienie strażnika powietrza"
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Sets Air Elementals to guard a mine against enemy armies."
 msgstr ""
 "Wzywa żywiołaki powietrza, które pilnują kopalni przed wrogimi armiami."
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Set Fire Guardian"
 msgstr "Ustawienie strażnika ognia"
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Sets Fire Elementals to guard a mine against enemy armies."
 msgstr "Wzywa żywiołaki ognia, które pilnują kopalni przed wrogimi armiami."
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Set Water Guardian"
 msgstr "Ustawienie strażnika wody"
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Sets Water Elementals to guard a mine against enemy armies."
 msgstr "Wzywa żywiołaki wody, które pilnują kopalni przed wrogimi armiami."
 
-#: ../fheroes2/system/players.cpp:665
-msgid "Necroman"
-msgstr "Nekromanta"
+msgid "No spell to cast."
+msgstr "Brak zaklęć."
 
-#: ../fheroes2/system/players.cpp:691
-msgid ""
-"This lets you change player starting positions and colors. A particular "
-"color will always start in a particular location. Some positions may only be "
-"played by a computer player or only by a human player."
-msgstr ""
-"Opcja ta pozwala na zmianę barw i startowej pozycji gracza. Dany kolor "
-"zawsze będzie rozpoczynać grę w określonym miejscu. Niektóre pozycje mogą "
-"być zajęte jedynie przez komputer, a inne tylko przez graczy - ludzi."
+#, fuzzy
+msgid "Your hero has %{point} spell points remaining."
+msgstr "Twój bohater ma jeszcze %{point} pkt. magii"
 
-#: ../fheroes2/system/players.cpp:695
-msgid ""
-"This lets you change the class of a player. Classes are not always "
-"changeable. Depending on the scenario, a player may receive additional towns "
-"and/or heroes not of their primary alignment."
-msgstr ""
-"Pozwal ci zmienić klasę gracza. Opcja ta nie zawsze jest aktywna. W "
-"zależności od scenariusza, gracz może otrzymać dodatkowe miasta oraz/lub "
-"bohaterów niezgodne z przynależną im klasą."
+#, fuzzy
+msgid "View Adventure Spells"
+msgstr "Opcje przygody"
 
-#: ../fheroes2/system/players.cpp:734
-msgid "%{color} player"
-msgstr "%{color} Gracz"
+#, fuzzy
+msgid "View Combat Spells"
+msgstr "Rzuć zaklęcie"
 
-#: ../fheroes2/system/settings.cpp:126
+#, fuzzy
+msgid "View previous page"
+msgstr "Pokaż poprzednie miasto"
+
+#, fuzzy
+msgid "View next page"
+msgstr "Obejrzyj jednostkę (%{name})"
+
+#, fuzzy
+msgid "Close Spellbook"
+msgstr "Rzuć zaklęcie"
+
+#, fuzzy
+msgid "View %{spell}"
+msgstr "Obejrzyj jednostkę (%{name})"
+
 msgid "game: always confirm for rewrite savefile"
 msgstr "gra: zawsze potwierdzaj nadpisanie zapisu stanu gry"
 
-#: ../fheroes2/system/settings.cpp:127
-msgid "game: also confirm autosave"
-msgstr "game: potwierdzaj auto zapisywanie"
-
-#: ../fheroes2/system/settings.cpp:128
 msgid "game: remember last focus"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:129
-msgid "game: battle show grid"
-msgstr "gra: pokaż siatkę podczas walki"
-
-#: ../fheroes2/system/settings.cpp:130
-msgid "game: battle mouse shadow"
-msgstr "gra: podczas walki pokaż cień myszy"
-
-#: ../fheroes2/system/settings.cpp:131
-msgid "game: battle move shadow"
-msgstr "gra: podczas walki cień ruchu"
-
-#: ../fheroes2/system/settings.cpp:132
-msgid "game: battle show damage info"
+#, fuzzy
+msgid "battle: show damage info"
 msgstr "game: pokaż informacje o uszkodzeniach w bitwie"
 
-#: ../fheroes2/system/settings.cpp:133
-msgid "game: castle flash building"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:134
 msgid "world: show visited content from objects"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:135
+msgid "world: show terrain penalty"
+msgstr ""
+
 msgid "world: scouting skill show extended content info"
 msgstr ""
 "świat: umiejętność zwiedzania pokazuje dodatkowe informacje o zawartości"
 
-#: ../fheroes2/system/settings.cpp:136
-msgid "world: abandoned mine random resource"
-msgstr "świat: losowe surowce w opuszczonej kopalni"
-
-#: ../fheroes2/system/settings.cpp:137
-msgid "world: save count monster after battle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:138
 msgid "world: allow set guardian to objects"
 msgstr "świat: pozwól zostawiać strażników w obiektach"
 
-#: ../fheroes2/system/settings.cpp:139
-msgid "world: guardian objects gets +2 defense"
-msgstr "świat: strażnicy obiektów zyskują +2 obrony"
-
-#: ../fheroes2/system/settings.cpp:140
-msgid "world: no in-built requirements or guardians for placed artifacts"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:141
-msgid "world: only the first monster will attack (H2 bug)."
-msgstr "świat: tylko pierwszy potwór zaatakuje (Bug Heroes 2)"
-
-#: ../fheroes2/system/settings.cpp:142
 msgid "world: Eagle Eye also works like Scholar in H3."
 msgstr "świat: Orli Wzrok działa jak \"Naukowiec\" z Heroes 3."
 
-#: ../fheroes2/system/settings.cpp:143
 msgid "world: ban for WeekOf/MonthOf Monsters"
 msgstr "świat: zabroń Tygodnie/Miesiące potworów"
 
-#: ../fheroes2/system/settings.cpp:144
-msgid "world: new version WeekOf (+growth)"
-msgstr "świat: nowa wersja Tygodnia... (+wzrost)"
-
-#: ../fheroes2/system/settings.cpp:145
 msgid "world: ban plagues months"
 msgstr "świat: wyłącz miesiące plagi"
 
-#: ../fheroes2/system/settings.cpp:146
 msgid "world: Months Of Monsters do not place creatures on map"
 msgstr "świat: podczas Miesiąca Potworów nie umieszczaj stworzeń na mapie"
 
-#: ../fheroes2/system/settings.cpp:147
 msgid "world: Crystal Ball also added Identify Hero and Visions spells"
 msgstr ""
 "świat: Kryształowa Kula dodaje zaklęcia: identyfikacja bohatera oraz Wizje"
 
-#: ../fheroes2/system/settings.cpp:148
-msgid "world: Artesian Springs have two separately visitable squares (h3 ver)"
-msgstr "świat: Artezjańskie Wiosny mają dwa oddzielne miejsca wizyt"
-
-#: ../fheroes2/system/settings.cpp:149
 msgid "world: Starting heroes as Loss Conditions for Human Players"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:150
 msgid "world: Only 1 hero can be hired by the one player every week"
 msgstr ""
 "świat: W ciągu tygodnia może być najęty tylko 1 bohater przez każdego gracza."
 
-#: ../fheroes2/system/settings.cpp:151
-msgid "world: each castle allows one hero to be recruited every week"
+#, fuzzy
+msgid "world: Each castle allows one hero to be recruited every week"
 msgstr ""
 "świat: każdy zamek umożliwia wynajęcie jednego bohatera w ciągu całego "
 "tygodnia"
 
-#: ../fheroes2/system/settings.cpp:152
-msgid "world: Outer creature dwellings should accumulate units"
-msgstr "świat: zewnętrzne posiadłości stworzeń powinny gromadzić jednostki"
+msgid "world: Neutral armies scale with game difficulty"
+msgstr ""
 
-#: ../fheroes2/system/settings.cpp:153
-msgid "world: use unique artifacts for morale/luck"
-msgstr "świat: użyj unikatowych artefaktów dla morale/szczęścia"
-
-#: ../fheroes2/system/settings.cpp:154
 msgid "world: use unique artifacts for resource affecting"
 msgstr "świat: użyj unikalnych artefaktów do pozyskania zasobów"
 
-#: ../fheroes2/system/settings.cpp:155
 msgid "world: use unique artifacts for primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:156
 msgid "world: use unique artifacts for secondary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:157
 msgid "world: Wind/Water Mills and Magic Garden can be captured"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:158
 msgid "world: disable Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:159
-msgid "castle: allow buy from well"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:160
 msgid "castle: allow guardians"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:161
 msgid ""
 "castle: higher mage guilds regenerate more spell points/turn "
 "(20/40/60/80/100%)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:162
-msgid "castle: allow recruits special/expansion heroes"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:163
 msgid "heroes: allow buy a spellbook from Shrines"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:164
-msgid "heroes: learn new spells with day"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:165
 msgid "heroes: recruit cost to be dependent on hero level"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:166
-msgid "heroes: remember MP/SP for retreat/surrender result"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:167
-msgid "heroes: surrendering gives some experience"
-msgstr "heroes: poddanie się daje trochę doświadczenia"
-
-#: ../fheroes2/system/settings.cpp:168
-msgid "heroes: recalculate movement points after creatures movement"
+#, fuzzy
+msgid "heroes: remember move points for retreat/surrender result"
 msgstr "heroes: przelicz punkty ruchu po ruchach stworzeń"
 
-#: ../fheroes2/system/settings.cpp:169
-msgid "heroes: allow pickup objects for patrol"
-msgstr "heroes: pozwól patrolom podnosić obiekty"
-
-#: ../fheroes2/system/settings.cpp:170
-msgid "heroes: after battle move to target cell"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:171
 msgid "heroes: allow transcribing scrolls (needs: Eye Eagle skill)"
 msgstr "bohaterowie: pozwól transkrybować zwoje (potrzeba: Umj. Orli Wzrok)"
 
-#: ../fheroes2/system/settings.cpp:172
-msgid "heroes: allow banned sec. skills upgrade"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:173
 msgid "heroes: in Arena can choose any of primary skills"
 msgstr ""
 "bohaterowie: na Arenie pozwól wybrać dowolną z podstawowych umiejętności"
 
-#: ../fheroes2/system/settings.cpp:174
 msgid "unions: allow meeting heroes"
 msgstr "sojusze: pozwól poznać bohaterów"
 
-#: ../fheroes2/system/settings.cpp:175
 msgid "unions: allow castle visiting"
 msgstr "sojusze: pozwól odwiedzać zamki"
 
-#: ../fheroes2/system/settings.cpp:176
+#, fuzzy
+msgid "battle: show army order"
+msgstr "gra: pokaż siatkę podczas walki"
+
 msgid "battle: soft wait troop"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:177
-msgid "battle: high objects are an obstacle for archers"
-msgstr "walka: wysokie obiekty są przeszkodą dla jednostek strzelających"
-
-#: ../fheroes2/system/settings.cpp:178
-msgid "battle: merge armies for hero from castle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:179
-msgid "battle: archmage can resists (20%) bad spells"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:180
-msgid "battle: magical creature resists (20%) the same magic"
-msgstr ""
-"Walka: magiczne stwory otrzymują 20% odporności na magię tego samego typu"
-
-#: ../fheroes2/system/settings.cpp:181
-msgid "battle: skip increase +2 defense"
-msgstr "Walka: pominięcie kolejki zwiększa obronę o 2pkt"
-
-#: ../fheroes2/system/settings.cpp:182
 msgid "battle: reverse wait order (fast, average, slow)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:183
 msgid "game: show system info"
 msgstr "game: pokaż informacje systemowe"
 
-#: ../fheroes2/system/settings.cpp:184
 msgid "game: autosave on"
 msgstr "game: autozapis włączony"
 
-#: ../fheroes2/system/settings.cpp:185
 msgid "game: autosave will be made at the beginning of the day"
 msgstr "Gra: Autozapis nastąpi na początku każdego dnia"
 
-#: ../fheroes2/system/settings.cpp:186
 msgid "game: use fade"
 msgstr "game: użyj zanikania"
 
-#: ../fheroes2/system/settings.cpp:187
-msgid "game: show SDL logo"
-msgstr "game: pokaż logo SDL"
-
-#: ../fheroes2/system/settings.cpp:188
 msgid "game: use evil interface"
 msgstr "game: użyj fatalnego interfejsu"
 
-#: ../fheroes2/system/settings.cpp:189
-msgid "game: also use dynamic interface for castles"
-msgstr "game: użyj dynamicznego interfejsu do zamków"
-
-#: ../fheroes2/system/settings.cpp:190
 msgid "game: hide interface"
 msgstr "game: ukryj interfejs"
 
-#: ../fheroes2/system/settings.cpp:191
 msgid "game: offer to continue the game afer victory condition"
 msgstr ""
 "Gra: zaproponuj kontynuację rozgrywki po spełnieniu warunków zwycięstwa."
 
-#: ../fheroes2/system/settings.cpp:192
-msgid "pocketpc: hide cursor"
-msgstr "pocketpc: ukryj kursor"
+#, fuzzy
+msgid "The ultimate artifact is really the %{name}."
+msgstr "Ta jednostka (%{name}) zostaje dotknięta klątwą mumii!"
 
-#: ../fheroes2/system/settings.cpp:193
-msgid "pocketpc: tap mode"
-msgstr "pocketpc: tryb tapnięcia"
+msgid "The ultimate artifact may be found in the %{name} regions of the world."
+msgstr ""
 
-#: ../fheroes2/system/settings.cpp:194
-msgid "pocketpc: drag&drop gamearea as scroll"
-msgstr "pocketpc: przeciągnij i upiść aby przewinąć"
+msgid "north-west"
+msgstr ""
 
-#: ../fheroes2/system/settings.cpp:195
-msgid "pocketpc: low memory"
-msgstr "pocketpc: mało pamięci"
+#, fuzzy
+msgid "north"
+msgstr "Enroth"
+
+msgid "north-east"
+msgstr ""
+
+#, fuzzy
+msgid "west"
+msgstr "Gniazdo"
+
+#, fuzzy
+msgid "center"
+msgstr "Potwór"
+
+#, fuzzy
+msgid "east"
+msgstr "Gniazdo"
+
+msgid "south-west"
+msgstr ""
+
+#, fuzzy
+msgid "south"
+msgstr "dźwięk"
+
+msgid "south-east"
+msgstr ""
+
+msgid "The truth is out there."
+msgstr ""
+
+msgid "The dark side is stronger."
+msgstr ""
+
+#, fuzzy
+msgid "The end of the world is near."
+msgstr "Strzeż się skraju świata!"
+
+msgid "The bones of Lord Slayer are buried in the foundation of the arena."
+msgstr ""
+
+msgid "A Black Dragon will take out a Titan any day of the week."
+msgstr ""
+
+msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
+msgstr ""
+
+msgid "An unknown force is being ressurected..."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Check the newest version of game at\n"
+"https://github.com/ihhub/\n"
+"fheroes2/releases"
+msgstr ""
+"Możesz pobrać najnowszą wersję gry ze strony:\n"
+" http://sf.net/projects/fheroes2"
+
+#~ msgid "Hero %{name} also got a %{count} experience."
+#~ msgstr "Bohater %{name} otrzymał także %{count} doświadczenia."
+
+#~ msgid "Spell cast"
+#~ msgstr "Zaklęcie zostało rzucone"
+
+#~ msgid ", and get +2 defense"
+#~ msgstr "i otrzymuje +2 do obrony"
+
+#~ msgid "MirrorImage ended"
+#~ msgstr "Zakończono odbicie lustrzane"
+
+#~ msgid "You don't have enough gold!"
+#~ msgstr "Nie posiadasz tyle złota!"
+
+#~ msgid ""
+#~ "Your troops can be upgraded, but it will cost you %{ratio} times the "
+#~ "difference in cost for each troop, rounded up to next highest number. Do "
+#~ "you wish to upgrade them?"
+#~ msgstr ""
+#~ "Twoje wojska mogą zostać zmodernizowane, ale to będzie kosztować %{ratio} "
+#~ "razy różnicy w cenie dla każdego oddziału, zaokrąglona do następnej "
+#~ "liczby w górę. Chcesz je aktualizować?"
+
+#~ msgid "For the QVGA version is not available."
+#~ msgstr "Niedostępne w wersji QVGA."
+
+#~ msgid "Cost per troop:"
+#~ msgstr "Koszt jednostki:"
+
+#~ msgid "sound"
+#~ msgstr "dźwięk"
+
+#~ msgid "ai speed"
+#~ msgstr "Prędkość sztucznej inteligencji"
+
+#~ msgid "You have no room to carry another artifact!"
+#~ msgstr "Nie masz miejsca, by nieść kolejny artefakt!"
+
+#~ msgid "View Morale Info"
+#~ msgstr "Morale - informacje"
+
+#~ msgid "View Luck Info"
+#~ msgstr "Szczęście - informacje"
+
+#~ msgid "Exit hero"
+#~ msgstr "Wyjście z ekranu bohatera"
+
+#~ msgid "Dismiss hero"
+#~ msgstr "Zwolnij bohatera"
+
+#~ msgid "Show prev heroes"
+#~ msgstr "Pokaż poprzedniego bohatera"
+
+#~ msgid "Bad Morale"
+#~ msgstr "Niskie morale"
+
+#~ msgid "Neutral Morale"
+#~ msgstr "Zwykłe morale"
+
+#~ msgid "Bad Luck"
+#~ msgstr "Niskie szczęście"
+
+#~ msgid "Neutral Luck"
+#~ msgstr "Normalne szczęście"
+
+#~ msgid "Good Luck"
+#~ msgstr "Wysokie szczęście"
+
+#~ msgid "This game is now in beta development version. ;)"
+#~ msgstr "Gra jest obecnie w wersji beta. ;)"
+
+#~ msgid "Water"
+#~ msgstr "Woda"
+
+#~ msgid "Ship Wreck"
+#~ msgstr "Szczątki statku"
+
+#~ msgid "Coast"
+#~ msgstr "Wybrzeże"
+
+#, fuzzy
+#~ msgid "Peasant"
+#~ msgstr "Chłop"
+
+#~ msgid "Peasants"
+#~ msgstr "Chłopi"
+
+#, fuzzy
+#~ msgid "Archer"
+#~ msgstr "Łucznik"
+
+#~ msgid "Archers"
+#~ msgstr "Łucznicy"
+
+#, fuzzy
+#~ msgid "Ranger"
+#~ msgstr "Łowca"
+
+#~ msgid "Rangers"
+#~ msgstr "Łowcy"
+
+#, fuzzy
+#~ msgid "Pikeman"
+#~ msgstr "Pikinier"
+
+#~ msgid "Pikemen"
+#~ msgstr "Pikinierzy"
+
+#, fuzzy
+#~ msgid "Veteran Pikeman"
+#~ msgstr "Weteran"
+
+#~ msgid "Veteran Pikemen"
+#~ msgstr "Weterani"
+
+#, fuzzy
+#~ msgid "Swordsman"
+#~ msgstr "Zbrojny"
+
+#~ msgid "Swordsmen"
+#~ msgstr "Zbrojni"
+
+#, fuzzy
+#~ msgid "Master Swordsman"
+#~ msgstr "Mistrz miecza"
+
+#~ msgid "Master Swordsmen"
+#~ msgstr "Mistrzowie miecza"
+
+#, fuzzy
+#~ msgid "Cavalry"
+#~ msgstr "Konny"
+
+#~ msgid "Cavalries"
+#~ msgstr "Konni"
+
+#, fuzzy
+#~ msgid "Champion"
+#~ msgstr "Czempion"
+
+#~ msgid "Champions"
+#~ msgstr "Czempioni"
+
+#, fuzzy
+#~ msgid "Paladin"
+#~ msgstr "Paladyn"
+
+#~ msgid "Paladins"
+#~ msgstr "Paladyni"
+
+#, fuzzy
+#~ msgid "Crusader"
+#~ msgstr "Krzyżowiec"
+
+#~ msgid "Crusaders"
+#~ msgstr "Krzyżowcy"
+
+#, fuzzy
+#~ msgid "Goblin"
+#~ msgstr "Goblin"
+
+#~ msgid "Goblins"
+#~ msgstr "Gobliny"
+
+#, fuzzy
+#~ msgid "Orc"
+#~ msgstr "Ork"
+
+#~ msgid "Orcs"
+#~ msgstr "Orkowie"
+
+#, fuzzy
+#~ msgid "Orc Chief"
+#~ msgstr "Ork wojownik"
+
+#~ msgid "Orc Chiefs"
+#~ msgstr "Orkowie wojownicy"
+
+#, fuzzy
+#~ msgid "Wolf"
+#~ msgstr "Wilk"
+
+#~ msgid "Wolves"
+#~ msgstr "Wilki"
+
+#, fuzzy
+#~ msgid "Ogre"
+#~ msgstr "Ogr"
+
+#~ msgid "Ogres"
+#~ msgstr "Ogry"
+
+#, fuzzy
+#~ msgid "Ogre Lord"
+#~ msgstr "Wielki ogr"
+
+#~ msgid "Ogre Lords"
+#~ msgstr "Wielkie ogry"
+
+#, fuzzy
+#~ msgid "Troll"
+#~ msgstr "Troll"
+
+#~ msgid "Trolls"
+#~ msgstr "Trolle"
+
+#, fuzzy
+#~ msgid "War Troll"
+#~ msgstr "Troll bojowy"
+
+#~ msgid "War Trolls"
+#~ msgstr "Trolle bojowe"
+
+#, fuzzy
+#~ msgid "Cyclops"
+#~ msgstr "Cyklop"
+
+#~ msgid "Cyclopes"
+#~ msgstr "Cyklopy"
+
+#, fuzzy
+#~ msgid "Sprite"
+#~ msgstr "Rusałka"
+
+#~ msgid "Sprites"
+#~ msgstr "Rusałki"
+
+#, fuzzy
+#~ msgid "Dwarf"
+#~ msgstr "Krasnolud"
+
+#~ msgid "Dwarves"
+#~ msgstr "Krasnoludy"
+
+#, fuzzy
+#~ msgid "Elf"
+#~ msgstr "Elf"
+
+#~ msgid "Elves"
+#~ msgstr "Elfy"
+
+#, fuzzy
+#~ msgid "Grand Elf"
+#~ msgstr "Wysoki elf"
+
+#~ msgid "Grand Elves"
+#~ msgstr "Wysokie elfy"
+
+#, fuzzy
+#~ msgid "Druid"
+#~ msgstr "Druid"
+
+#~ msgid "Druids"
+#~ msgstr "Druidzi"
+
+#~ msgid "Greater Druids"
+#~ msgstr "Wielcy druidzi"
+
+#, fuzzy
+#~ msgid "Unicorn"
+#~ msgstr "Jednorożec"
+
+#~ msgid "Unicorns"
+#~ msgstr "Jednorożce"
+
+#, fuzzy
+#~ msgid "Phoenix"
+#~ msgstr "Feniks"
+
+#, fuzzy
+#~ msgid "Phoenixes"
+#~ msgstr "Feniks"
+
+#, fuzzy
+#~ msgid "Centaur"
+#~ msgstr "Centaur"
+
+#~ msgid "Centaurs"
+#~ msgstr "Centaury"
+
+#, fuzzy
+#~ msgid "Gargoyle"
+#~ msgstr "Gargulec"
+
+#~ msgid "Gargoyles"
+#~ msgstr "Gargulce"
+
+#, fuzzy
+#~ msgid "Griffin"
+#~ msgstr "Gryf"
+
+#~ msgid "Griffins"
+#~ msgstr "Gryfy"
+
+#, fuzzy
+#~ msgid "Minotaur"
+#~ msgstr "Minotaur"
+
+#~ msgid "Minotaurs"
+#~ msgstr "Minotaury"
+
+#, fuzzy
+#~ msgid "Minotaur King"
+#~ msgstr "Królewski minotaur"
+
+#~ msgid "Minotaur Kings"
+#~ msgstr "Królewskie minotaury"
+
+#, fuzzy
+#~ msgid "Hydra"
+#~ msgstr "Hydra"
+
+#~ msgid "Hydras"
+#~ msgstr "Hydry"
+
+#, fuzzy
+#~ msgid "Green Dragon"
+#~ msgstr "Zielony smok"
+
+#~ msgid "Green Dragons"
+#~ msgstr "Zielone smoki"
+
+#, fuzzy
+#~ msgid "Red Dragon"
+#~ msgstr "Czerwony smok"
+
+#~ msgid "Red Dragons"
+#~ msgstr "Czerwone smoki"
+
+#, fuzzy
+#~ msgid "Black Dragon"
+#~ msgstr "Czarny smok"
+
+#~ msgid "Black Dragons"
+#~ msgstr "Czarne smoki"
+
+#, fuzzy
+#~ msgid "Halfling"
+#~ msgstr "Niziołek"
+
+#~ msgid "Halflings"
+#~ msgstr "Niziołki"
+
+#, fuzzy
+#~ msgid "Boar"
+#~ msgstr "Dzik"
+
+#~ msgid "Boars"
+#~ msgstr "Dziki"
+
+#, fuzzy
+#~ msgid "Iron Golem"
+#~ msgstr "Żelazny golem"
+
+#~ msgid "Iron Golems"
+#~ msgstr "Żelazne golemy"
+
+#, fuzzy
+#~ msgid "Steel Golem"
+#~ msgstr "Stalowy golem"
+
+#~ msgid "Steel Golems"
+#~ msgstr "Stalowe golemy"
+
+#, fuzzy
+#~ msgid "Roc"
+#~ msgstr "Rok"
+
+#~ msgid "Rocs"
+#~ msgstr "Roki"
+
+#, fuzzy
+#~ msgid "Mage"
+#~ msgstr "Mag"
+
+#~ msgid "Magi"
+#~ msgstr "Magowie"
+
+#, fuzzy
+#~ msgid "Archmage"
+#~ msgstr "Arcymag"
+
+#~ msgid "Archmagi"
+#~ msgstr "Arcymagowie"
+
+#, fuzzy
+#~ msgid "Giant"
+#~ msgstr "Olbrzym"
+
+#~ msgid "Giants"
+#~ msgstr "Olbrzymy"
+
+#, fuzzy
+#~ msgid "Titan"
+#~ msgstr "Tytan"
+
+#~ msgid "Titans"
+#~ msgstr "Tytani"
+
+#~ msgid "Skeletons"
+#~ msgstr "Szkielety"
+
+#, fuzzy
+#~ msgid "Zombie"
+#~ msgstr "Zombie"
+
+#~ msgid "Zombies"
+#~ msgstr "Zombie"
+
+#, fuzzy
+#~ msgid "Mutant Zombie"
+#~ msgstr "Zmutowany zombie"
+
+#~ msgid "Mutant Zombies"
+#~ msgstr "Zmutowane zombie"
+
+#, fuzzy
+#~ msgid "Mummy"
+#~ msgstr "Mumia"
+
+#~ msgid "Mummies"
+#~ msgstr "Mumie"
+
+#, fuzzy
+#~ msgid "Royal Mummy"
+#~ msgstr "Królewska mumia"
+
+#~ msgid "Royal Mummies"
+#~ msgstr "Królewskie mumie"
+
+#, fuzzy
+#~ msgid "Vampire"
+#~ msgstr "Wampir"
+
+#~ msgid "Vampires"
+#~ msgstr "Wampiry"
+
+#, fuzzy
+#~ msgid "Vampire Lord"
+#~ msgstr "Wampirzy lord"
+
+#~ msgid "Vampire Lords"
+#~ msgstr "Wampirzy lordowi"
+
+#, fuzzy
+#~ msgid "Lich"
+#~ msgstr "Lisz"
+
+#~ msgid "Liches"
+#~ msgstr "Lisze"
+
+#, fuzzy
+#~ msgid "Power Lich"
+#~ msgstr "Potężny lisz"
+
+#~ msgid "Power Liches"
+#~ msgstr "Potężne lisze"
+
+#, fuzzy
+#~ msgid "Bone Dragon"
+#~ msgstr "Kościany smok"
+
+#~ msgid "Bone Dragons"
+#~ msgstr "Kościane smoki"
+
+#, fuzzy
+#~ msgid "Rogue"
+#~ msgstr "Rozbójnik"
+
+#~ msgid "Rogues"
+#~ msgstr "Rozbójnicy"
+
+#, fuzzy
+#~ msgid "Nomad"
+#~ msgstr "Nomad"
+
+#~ msgid "Nomads"
+#~ msgstr "Nomadowie"
+
+#, fuzzy
+#~ msgid "Ghost"
+#~ msgstr "Duch"
+
+#~ msgid "Ghosts"
+#~ msgstr "Duchy"
+
+#, fuzzy
+#~ msgid "Genie"
+#~ msgstr "Dżinn"
+
+#~ msgid "Genies"
+#~ msgstr "Dżinny"
+
+#, fuzzy
+#~ msgid "Medusa"
+#~ msgstr "Meduza"
+
+#~ msgid "Medusas"
+#~ msgstr "Meduzy"
+
+#, fuzzy
+#~ msgid "Earth Elemental"
+#~ msgstr "Żywiołak ziemi"
+
+#~ msgid "Earth Elementals"
+#~ msgstr "Żywiołaki ziemi"
+
+#, fuzzy
+#~ msgid "Air Elemental"
+#~ msgstr "Żywiołak powietrza"
+
+#~ msgid "Air Elementals"
+#~ msgstr "Żywiołaki powietrza"
+
+#, fuzzy
+#~ msgid "Fire Elemental"
+#~ msgstr "Żywiołak ognia"
+
+#~ msgid "Fire Elementals"
+#~ msgstr "Żywiołaki ognia"
+
+#, fuzzy
+#~ msgid "Water Elemental"
+#~ msgstr "Żywiołak wody"
+
+#~ msgid "Water Elementals"
+#~ msgstr "Żywiołaki wody"
+
+#~ msgid "buy"
+#~ msgstr "kup"
+
+#~ msgid "Error"
+#~ msgstr "Błąd"
+
+#~ msgid "This release is compiled without network support."
+#~ msgstr "Ta wersja gry nie obsługuje połączeń sieciowych."
+
+#~ msgid ""
+#~ "425 bottles of beer on the wall, 425 bottles of beer! If one of those "
+#~ "bottles should happen to fall, there'll be..."
+#~ msgstr ""
+#~ "425 butelek piwa na ścianie, 425 butelek piwa! Jeśli jedna z tych butelek "
+#~ "spadnie, zostanie ..."
+
+#~ msgid "A balanced scenario with lots of resources and land to explore."
+#~ msgstr "Scenariusz z ogromną ilością surowców i terenu do odkrywania."
+
+#~ msgid ""
+#~ "A bandit army of gorgons jump you without warning.  they stone your "
+#~ "entire army demand 500 gold before they will release your comrads.  "
+#~ "Realizing that it is much cheeper to pay then rebuild your army you part "
+#~ "with the gold."
+#~ msgstr ""
+#~ "Bandycka armia gorgon doskakuje cię bez ostrzeżenia, ukamienowawszy całą "
+#~ "twoją armię, zażądali 500 złota zanim wypuszczą twoich towarzyszy. "
+#~ "Zdajesz sobie sprawę, że jest to o wiele tańsze rozwiązanie niż odbudowa "
+#~ "całej armii."
+
+#~ msgid "Abandon All Hope!"
+#~ msgstr "Cała nadzieja w Abandon"
+
+#~ msgid "Abandon All Hope Ye That Enter Here"
+#~ msgstr "Cała nadzieja w Abandon, wejście znajduję się tutaj"
+
+#~ msgid "A bit of crystal!"
+#~ msgstr "Trochę kryształów"
+
+#~ msgid "A bit of mercury!"
+#~ msgstr "Trochę rtęci"
+
+#~ msgid "A bit of sulfur!"
+#~ msgstr "Trochę siarki"
+
+#~ msgid ""
+#~ "Above you looms the ancient Ice Palace.  Dimly remembered myth speaks of "
+#~ "a Prince who rejected the advances of the Winter Goddess, and thus he and "
+#~ "his domain were cursed to remain shrouded in ice, hidden in a forgotten "
+#~ "corner of the world.  It is said that he can only be rescued by a hero "
+#~ "who is both clever and bold.  Are you that one?  Do you dare enter this "
+#~ "frozen domain?"
+#~ msgstr ""
+#~ "Nad Tobą unosi się mroźny zapach starożytnego miasta Ice Palace. Słabo, "
+#~ "lecz przypominam sobie mit o księci który odmówil zaloty Królowej Mrozu. "
+#~ "Teraz spowity lodem i ukryty gdzieś, czeka na ratunek. Mówi się że może "
+#~ "zostać uratowany tylko przez mądrego i odważnego bohatera. Czy jesteś "
+#~ "nim? Czy odważysz się wejść w tą spowitą lodem krainą?"
+
+#~ msgid "A cache of crystal!"
+#~ msgstr "Kopalnia kryształów"
+
+#~ msgid "A cache of gems!"
+#~ msgstr "Kopalnia kamieni!"
+
+#~ msgid "A cache of gold!"
+#~ msgstr "Kopalnia złota!"
+
+#~ msgid "A cache of mercury!"
+#~ msgstr "Kopalnia rtęci!"
+
+#~ msgid "A cache of sulfur!"
+#~ msgstr "Kopalnia siarki!"
+
+#~ msgid ""
+#~ "A chance to end a bitter war has finally arrived as a new resource-laden "
+#~ "land has been discovered."
+#~ msgstr ""
+#~ "Nadeszła szansa na koniec gorzkiej wojny. Nowe ziemie zostały odkryte."
+
+#~ msgid "A chunk of gold!"
+#~ msgstr "Kawałek złota!"
+
+#~ msgid "A chunk of ore!"
+#~ msgstr "Kawałek rudy!"
+
+#~ msgid "A couple of gems!"
+#~ msgstr "Sporo Kamieni!"
+
+#~ msgid "\"Act of Desperation\""
+#~ msgstr "\"Akt Desperacji\""
+
+#~ msgid ""
+#~ "A desert isle rich in resources rewards the quick.  Just be sure to watch "
+#~ "your back!"
+#~ msgstr ""
+#~ "Na pustynii możesz szybko wzbogacić się w zasoby. Tylko pamiętaj, żeby "
+#~ "oglądać się za siebie!"
+
+#~ msgid "A dolphin playfully jumps into the air."
+#~ msgstr "Delfin radośnie wyskakuje w powietrze."
+
+#~ msgid ""
+#~ "A Dragon, A Cyclops, or an Undead. King of the Centaurs, His name is ....?"
+#~ msgstr "Smok, Cyklopi albo Nieumarły. Król Centaurów, jego imię to ....?"
+
+#~ msgid "A flight of dragons circles overhead."
+#~ msgstr "Smoki latają w koło nad głową."
+
+#~ msgid "A flock of seagulls circle overhead."
+#~ msgstr "Stado mew lata w koło nad głową."
+
+#~ msgid "A friendly dolphin splashes alongside the ship."
+#~ msgstr "Przyjacielski delfin pluska w pobliżu statku."
+
+#~ msgid ""
+#~ "After a long search of the island, I have discovered that there is no way "
+#~ "for me to escape without help.  I can not steal a ship from one of the "
+#~ "coastal castles, and I dare not venture into the desert unless I wish to "
+#~ "become Dragon food.  Should anyone find this, I beg of you, please send a "
+#~ "ship and get me off this cursed island!  -Sir Christian"
+#~ msgstr ""
+#~ "Po długim przeszukiwaniu wyspy, odkryłem iż nie ma drogi ucieczki bez "
+#~ "jakiejkolwiek pomocy. Nie mogę ukraść statku, z żadnego z przybrzeżnych "
+#~ "zamków, i nie ośmielę się udać na pustynię, gdyż nie śpieszy mi się "
+#~ "zwiedzanie wnętrza smoka jako jego pokarm. Jeśli ktoś to znajdzie, błagam "
+#~ "Cię, wyślij statek i wyciągnij mnie z tej jebanej wyspy! - Sir Christian"
+
+#~ msgid ""
+#~ "After centuries of friendship, the Wizards have suddenly decided to stop "
+#~ "sharing their Library with the rest of the world.  This can't be good!"
+#~ msgstr ""
+#~ "Po wiekach przyjaźni, Czarodzieje zdecydowali nagle by zaprzestać "
+#~ "udostępniania swojej biblioteki reszcie świata. Nic z tego dobrego nie "
+#~ "wyniknie!"
+
+#~ msgid ""
+#~ "After many years of peace, you discover that your sworn enemy from across "
+#~ "the sea has chosen to invade your homeland by raising up the ocean floor "
+#~ "to bridge the distance! You must not let them gain a foothold on this "
+#~ "continent, in fact, your King has ordered you to establish a foothold on "
+#~ "theirs!  To make matters worse, two of your OWN towns have thrown in "
+#~ "their lots with the enemy..."
+#~ msgstr ""
+#~ "Po wielu latach pokoju, odkrywasz że twój zaprzysiężony wróg zza morza "
+#~ "ośmielił się zaatakować twoją ojczyznę poprzez podniesienie poziomu "
+#~ "oceanu aby zmniejszyć dystans. Nie możesz pozwolić by stanął na tym "
+#~ "kontynencie, w zasadzie to twój Król rozkazał ci udać się na ich krainę! "
+#~ "Jakby tego było mało dwa z twoich własnych miast rozpoczęło starcie z "
+#~ "wrogiem z użyciem całych swoich sił militarnych."
+
+#~ msgid ""
+#~ "After you return from a scouting trip, your Seneschal hurries to greet "
+#~ "you.  \"My Lord, in your absence I signed an agreement in your name with "
+#~ "a Master Merchant.  If we supply him with the resources he needs, through "
+#~ "trading, he can return the resources to us in a week or so, plus some "
+#~ "additional ones.\"  The Seneschal eyes you anxiously.  You hesitate, then "
+#~ "nod slowly, \"Good, we can use more resources>\""
+#~ msgstr ""
+#~ "Po powrocie ze zwiadów, Seneschal śpieszy by cię powitać. \"Mój Panie, "
+#~ "podczas twojej nieobecności, podpisałem umowę w twoim imieniu z Mistrzem "
+#~ "Kupiectwa. Jeśli wspomożemy go surowcami których potrzebuje, on zwróci "
+#~ "nam te surowce z nadwyżką.\" Seneschal spojrzał na ciebie z obawą. Wahasz "
+#~ "się, po czym powoli przytakujesz \"Dobrze, przyda nam się więcej surowców"
+#~ "\"."
+
+#~ msgid "A ghostly pirate ship appears and sails on by."
+#~ msgstr "Nawiedzony statek widmo pojawia się na horyzoncie i podpływa."
+
+#~ msgid ""
+#~ "A Gift from your King, and a note that reads \"Use these resources "
+#~ "wisely, It's all we have left\"."
+#~ msgstr ""
+#~ "Dar od Króla, i notatka na której jest napisane \"Użyj tych surowców "
+#~ "mądrze, to wszystko co nam zostało\"."
+
+#~ msgid ""
+#~ "A gift of gold, m'lord, from the people of Enroth, to the people of "
+#~ "Enroth.  Good luck, and may God save true King Roland!"
+#~ msgstr ""
+#~ "Dar złota, od ludzi z Enroth dla ludzi z Enroth. Powodzenia, niech Bóg ma "
+#~ "w opiece prawdziwego Króla Rolanda!"
+
+#~ msgid "A glint by a tree catches your eye..."
+#~ msgstr "Błysk w drzewie przykuwa twoją uwagę."
+
+#~ msgid "A gold cache!"
+#~ msgstr "Skrzynia ze złotem!"
+
+#~ msgid "A gold chunk!"
+#~ msgstr "Kawał złota!"
+
+#~ msgid "A gold nugget!"
+#~ msgstr "Bryłka złota!"
+
+#~ msgid ""
+#~ "A great Black dragon stands before you. It speaks in a suprisingly soft "
+#~ "voice, saying, \"The elves believe they have sent another hero to reclaim "
+#~ "their prize. I believe they have sent me another meal.\""
+#~ msgstr ""
+#~ "Wielki Czarny Smok staje przed tobą. Przemawia z zadziwiająco łagodnym "
+#~ "głosem, mówiąc, \"Elfy wierzą iż wysłały kolejnego bohatera zdolnego "
+#~ "odebrać ich skarb. Ja uważam, iż przysłały mi kolejne mięcho.\""
+
+#~ msgid ""
+#~ "A group of peasant farmers approaches you, \"We are in dire need of your "
+#~ "assistance.  Our castle to the north has been overrun and our Lord "
+#~ "killed.  Please help us regain our homes!  There are still women and "
+#~ "children there!  Take what we have to help!\""
+#~ msgstr ""
+#~ "Grupa chłopów zbliża się do Ciebie, \"Potrzebujemy twojego wsparcia. Nasz "
+#~ "zamek na północy został przejęty a nasz Pan zabity. Proszę, pomóż nam "
+#~ "odbić nasz dom!. Tam ciągle są nasze kobiety i dzieci! Bierz co chcesz, "
+#~ "ale pomóż nam!\""
+
+#~ msgid ""
+#~ "A group of peasant farmers approach you, \"We are in dire need of your "
+#~ "assistance.  Our castle to the east has been overrun and our Lord "
+#~ "killed.  Please help us regain our homes!  There are still women and "
+#~ "children there!  Take what we have to help!\""
+#~ msgstr ""
+#~ "Grupa chłopów zbliża się do Ciebie, \"Potrzebujemy twojego wsparcia. Nasz "
+#~ "zamek na wschodzie został przejęty a nasz Pan zabity. Proszę, pomóż nam "
+#~ "odbić nasz dom!. Tam ciągle są nasze kobiety i dzieci! Bierz co chcesz, "
+#~ "ale pomóż nam!\""
+
+#~ msgid ""
+#~ "A group of peasant farmers approach you, \"We are in dire need of your "
+#~ "assistance. Our castle to the east has been overrun and our Lord killed. "
+#~ "Please help us regain our homes! There are still women and children "
+#~ "there! Take what we have to help!\""
+#~ msgstr ""
+#~ "Grupa chłopów zbliża się do Ciebie, \"Potrzebujemy twojego wsparcia. Nasz "
+#~ "zamek na wschodzie został przejęty a nasz Pan zabity. Proszę, pomóż nam "
+#~ "odbić nasz dom!. Tam ciągle są nasze kobiety i dzieci! Bierz co chcesz, "
+#~ "ale pomóż nam!\""
+
+#~ msgid ""
+#~ "A group of peasant farmers approach you, We are in dire need of your "
+#~ "assistance.  Our castle to the northeast has been overrun and our Lord "
+#~ "killed.  Please help us regain our homes!  There are still women and "
+#~ "children there!  Take what we have to help!\""
+#~ msgstr ""
+#~ "Grupa chłopów zbliża się do Ciebie, \"Potrzebujemy twojego wsparcia. Nasz "
+#~ "zamek na północnym-wschodzie został przejęty a nasz Pan zabity. Proszę, "
+#~ "pomóż nam odbić nasz dom!. Tam ciągle są nasze kobiety i dzieci! Bierz co "
+#~ "chcesz, ale pomóż nam!\""
+
+#~ msgid "A handful of gems!"
+#~ msgstr "Garść klejnotów!"
+
+#~ msgid ""
+#~ "Ah, you stumble across something buried in the sand.  As you dig it up "
+#~ "you discover a small pile of gems and crystal."
+#~ msgstr ""
+#~ "Auć! Potykasz się o coś zakopanego w piasku. Po odkopaniu okrywasz stos "
+#~ "małych klejnotów i kryształów!"
+
+#~ msgid ""
+#~ "A Knight and Necromancer team up against the Barbarian and Sorceress. "
+#~ "(Blue and Green vs Red and Yellow)"
+#~ msgstr ""
+#~ "Rycerz i Nekromanta jednoczą siły przeciwko Barbarzyńcy i Czarodziejce "
+#~ "(Niebieski i Zielony kontra Czerwony i Żółty)."
+
+#~ msgid ""
+#~ "A large contingent of the king's guard approaches you.  \"Ahh, we have "
+#~ "finally caught up to you.  The king requires tribute from all of his "
+#~ "vassals and you have been negligent far too long.\""
+#~ msgstr ""
+#~ "Kontyngent królewskiej straży zbliża się do Ciebie. \"W końcu cię "
+#~ "złapaliśmy. Król potrzebuje wyrazów uznania od wszystkich swoich wasali a "
+#~ "ty zbyt długo byłeś nonszalancki.\""
+
+#~ msgid ""
+#~ "A large map with lots of resources and treasure. Exploration and victory "
+#~ "will require many heroes."
+#~ msgstr ""
+#~ "Duża mapa pełna surowców i skarbów. Zbadanie i podbój tej krainy będzie "
+#~ "wymagało dużej liczby bohaterów."
+
+#~ msgid "A legion of peasants stands between you and this unclaimed island."
+#~ msgstr ""
+#~ "Pomiędzy tobą a tą ziemią niczyją stoją zastępy wrogo nastawionych "
+#~ "chłopów."
+
+#~ msgid "Algary"
+#~ msgstr "Algary"
+
+#~ msgid "A little bit closer..."
+#~ msgstr "Nieco bliżej..."
+
+#~ msgid "All mines are grouped by type. Trade is your only hope."
+#~ msgstr ""
+#~ "Kopalnie poszczególnych surowców występują w skupiskach. Handel jest "
+#~ "twoją jedyną nadzieją."
+
+#~ msgid "A lump of crystal!"
+#~ msgstr "Bryła kryształu!"
+
+#~ msgid "A lump of gold!"
+#~ msgstr "Bryła złota!"
+
+#~ msgid "A lump of mercury!"
+#~ msgstr "Nieco rtęci!"
+
+#~ msgid ""
+#~ "A man appears from behind the sand dune. \"At last,\" he says, \"Someone "
+#~ "has come to rescue me! I am forever grateful. Alas all I have to offer "
+#~ "you in return are these souvenirs from my wrecked ship.\""
+#~ msgstr ""
+#~ "Człowiek pojawia się zza wydmy piasku. \"Na reszcie,\" powiada, \"Ktoś "
+#~ "nadchodzi by mnie uratować! Jestem wdzięczny na wieki. Niestety wszystko "
+#~ "co mam do zaoferowania to te kilka pamiątek z wraku mojego statku."
+
+#~ msgid ""
+#~ "A man is laying on the ground, near death. He looks to you and speaks, "
+#~ "\"Please help my companions! Please... they can't...cough...get away "
+#~ "from...cough...the drag...\" With that, he dies."
+#~ msgstr ""
+#~ "Człowiek leży na ziemi, jest bliski śmierci. Patrzy na ciebie i mówi, "
+#~ "\"Proszę pomóż moim kompanom! Proszę... nie mogą...(kaszle)...odejść..."
+#~ "(kaszle)...smo...\" Mowiąc to, umiera."
+
+#~ msgid ""
+#~ "A merchant caravan arrives, bringing gold and supplies, however, no one "
+#~ "can seem to remember where they came from.  You silently praise this "
+#~ "anonymous benefactor and continue your duties."
+#~ msgstr ""
+#~ "Kupiecka karawana nadjeżdża, przywożąc złoto i dostawę, nie wydaje się "
+#~ "aby ktokolwiek pamiętał skąd przybyli. Cicho chwalisz anonimowego "
+#~ "dobroczyńcę i przechodzisz do swoich obowiązków."
+
+#~ msgid "a mirror"
+#~ msgstr "lustro"
+
+#~ msgid "An albatross flies ahead of the ship for a while"
+#~ msgstr "Albatros przelatuje przed statkiem przez krótką chwilę."
+
+#~ msgid "Anduran"
+#~ msgstr "Anduran"
+
+#~ msgid ""
+#~ "An enemy from across the sea has seized half your towns.  Can you put "
+#~ "aside your own feud with your brother to fight this common enemy?"
+#~ msgstr ""
+#~ "Wróg zza morza przejął większość twoich miast.  Czy zapomnisz o "
+#~ "konflikcie z bratem, byście wspólnie mogli stawić czoła temu wrogowi?"
+
+#~ msgid ""
+#~ "An old elf is sitting on a rock in a glen, pounding on the shackles on "
+#~ "his feet with a stone. You help him remove them and ask him his tale. "
+#~ "\"I'm a deserter from Drakonia's army. She has enslaved all the elves to "
+#~ "support her madness. She must be stopped.\" Then he slips into the woods "
+#~ "without a sound, leaving behind just his cloak."
+#~ msgstr ""
+#~ "Stary elf siedzi na skale w dolinie, uderzając kamieniem w kajdany "
+#~ "założone na jego stopy. Pomagasz mu je usunąć i prosisz by ci o sobie "
+#~ "opowiedział. \"Jestem dezerterem z armii Drakonii. Zniewoliła wszystkich "
+#~ "elfów by brali udział w jej szaleństwie. Ktoś musi to powstrzymać.\" "
+#~ "Wtedy znika w lesie bezszelestnie zostawiając za sobą swoją pelerynę."
+
+#~ msgid "Antioch"
+#~ msgstr "Antioch"
+
+#~ msgid "A piece of crystal!"
+#~ msgstr "Nieco kryształu!"
+
+#~ msgid "A pile of crystal!"
+#~ msgstr "Sterta kryształu"
+
+#~ msgid "A pile of gems!"
+#~ msgstr "Sterta klejnotów."
+
+#~ msgid "A pile of gold!"
+#~ msgstr "Sterta złota"
+
+#~ msgid ""
+#~ "A plague of undead is upon us. Who will unite the living against the dead?"
+#~ msgstr ""
+#~ "Spadła na nas plaga nieumarłych. Kto zjednoczy żywych przeciw martwym?"
+
+#~ msgid "A quantity of crystal!"
+#~ msgstr "Mnóstwo kryształu!"
+
+#~ msgid "A quantity of mercury!"
+#~ msgstr "Nieco rtęci!"
+
+#~ msgid "A quantity of sulfur!"
+#~ msgstr "Nieco siarki!"
+
+#~ msgid ""
+#~ "Archibald has also sent an army to find the Crown, you must find it first "
+#~ "or all is lost."
+#~ msgstr ""
+#~ "Archibald również wysłał armię by odnaleźć Koronę, musisz odnaleźć ją "
+#~ "pierwszy w innym razie wszystko przepadnie."
+
+#~ msgid "Archibald is hiding at the end of the river."
+#~ msgstr "Archibald kryje się na skraju rzeki."
+
+#~ msgid ""
+#~ "A resource rich valley keeps the Wizard and the Necromancer apart. Your "
+#~ "opponent's army will arrive in 3 months so hurry."
+#~ msgstr ""
+#~ "Dolina bogata w surowce dzieli Czarodzieja i Nekromantę. Armia twojego "
+#~ "wroga na w przeciągu 3 miesięcy, więc nie masz zbyt wiele czasu."
+
+#~ msgid "Arm of the Crusader"
+#~ msgstr "Armia Paladynów"
+
+#~ msgid "Arm of the Cyclops"
+#~ msgstr "Armia Cyklopów"
+
+#~ msgid "Arm of the Dragon"
+#~ msgstr "Armia Smoków"
+
+#~ msgid "Arm of the Phoenix"
+#~ msgstr "Armia Feniksów"
+
+#~ msgid "Arm of the Titan"
+#~ msgstr "Armia Tytanów"
+
+#~ msgid "Arr' Here be pirates gold buried."
+#~ msgstr "Tutaj pochowano złoto piratów"
+
+#~ msgid "A shipment of wood has arrived from your kingdom!"
+#~ msgstr "Transport drewna z twojego królestwa został dostarczony!"
+
+#~ msgid ""
+#~ "A splash in the seaweed alerts you to a mermaid waving in a friendly "
+#~ "manner. \"Oh, I thought you were Ahab.\" She is surprised, but quickly "
+#~ "composes herself. \"Well, if you meet him, give him these treasures I "
+#~ "have collected.\""
+#~ msgstr ""
+#~ "Plusk w wodorostach zwraca twoją uwagę na syrenkę machająca przyjaźnie do "
+#~ "ciebie. \"O, myślałam że jesteś Ahab.\" Jest zaskoczona, lecz opanowana. "
+#~ "\"Jeśli go spotkasz, daj mu skarby które zebrałam.\""
+
+#~ msgid "Assassins tried to kill our ally."
+#~ msgstr "Zabójcy próbowali zabić naszego sprzymierzeńca."
+
+#~ msgid "Astircaer"
+#~ msgstr "Astircaer"
+
+#~ msgid ""
+#~ "A stranded Wizard with only a small force must conquer an entire "
+#~ "continent of hostile forces."
+#~ msgstr ""
+#~ "Samotny czarodziej rozbija się na nieznanym kontynencie pełnym wrogów."
+
+#~ msgid ""
+#~ "A supply ship has arrived from the homeland!  You send word home that all "
+#~ "is well."
+#~ msgstr ""
+#~ "Statek transportowy z ojczyzny dotarł. Wysyłasz wiadomość, że wszystko "
+#~ "jest w porządku."
+
+#~ msgid ""
+#~ "As you lay down to nap after a long battle, you notice a lucky four-leaf "
+#~ "clover."
+#~ msgstr ""
+#~ "Postanowiłeś zdrzemnąć się po wygranej bitwie. Układając się do snu "
+#~ "znajdujesz w trawie czterolistną koniczynkę."
+
+#~ msgid ""
+#~ "A wild magic has allowed a bridge to form between two lands...  Your one "
+#~ "hope is to capture castle \"Black Fang\"."
+#~ msgstr ""
+#~ "Dzięki magii pomiędzy dwoma światami powstał most...  Twoją jedyną "
+#~ "nadzieją jest zdobycie zamku \"Black Fang\"."
+
+#~ msgid ""
+#~ "Barbarians from the north threaten all civilization. Can you repel the "
+#~ "hordes?"
+#~ msgstr ""
+#~ "Barbarzyńcy z północy zagrażają całej cywilizacji. Czy zdołasz odeprzeć "
+#~ "ich hordy?"
+
+#~ msgid "Basenji"
+#~ msgstr "Basenji"
+
+#~ msgid "Bayside"
+#~ msgstr "Bayside"
+
+#~ msgid "Baywatch"
+#~ msgstr "Przystań"
+
+#~ msgid ""
+#~ "Because the Darkscale Valley is so barren, the Emperor will be sending "
+#~ "wood to you every week. Use it wisely, for it is all you shall have."
+#~ msgstr ""
+#~ "Ponieważ Dolina Darkscale jest taka jałowa, Imperator będzie wysyłał "
+#~ "tobie drewno każdego tygodnia. Używaj go mądrze, to wszystko co "
+#~ "powinieneś mieć do osiągnięcia celu."
+
+#~ msgid ""
+#~ "Before you may pass, the spirit guardian of this valley demands tribute."
+#~ msgstr ""
+#~ "Zanim przejdziesz, dusza strażnika tej doliny oczekuje wyrazów uznania."
+
+#~ msgid "Being held...."
+#~ msgstr "Jest przetrzymywany..."
+
+#~ msgid "Beltway"
+#~ msgstr "Okrężna droga"
+
+#~ msgid "Beware -- Entering Hyrda Country"
+#~ msgstr "Strzeż się Wchodząc do Krainy Hydr"
+
+#~ msgid "Beware of Pirates!"
+#~ msgstr "Strzeż się piratów!"
+
+#~ msgid "Beware of thieves!"
+#~ msgstr "Strzeż się złodzieji!"
+
+#~ msgid "Beware of traps ahead."
+#~ msgstr "Strzeż się pułapek."
+
+#~ msgid "Beware of Warlocks"
+#~ msgstr "Strzeż się Czarnoksiężników."
+
+#~ msgid "Beware the deadly swamps!"
+#~ msgstr "Strzeż się śmiertelnych bagien!"
+
+#~ msgid "Beware the Domain of Dragons"
+#~ msgstr "Strzeż się  Królestwa Smoków!"
+
+#~ msgid "Beware the Dragon Leader"
+#~ msgstr "Strzeż się Smoczego Przywódcy!"
+
+#~ msgid "Beware the edge of the world!"
+#~ msgstr "Strzeż się skraju świata!"
+
+#~ msgid "Beware the moors and stick to the roads."
+#~ msgstr "Strzeż się mokradeł, korzystaj z dróg!"
+
+#~ msgid "Beware the rocks"
+#~ msgstr "Uważaj na skały."
+
+#~ msgid "Beware the sirens!!!"
+#~ msgstr "Uważaj na syreny!!!"
+
+#~ msgid "Beware the sirens!"
+#~ msgstr "Uważaj na syreny!"
+
+#~ msgid "Beware, the whirlpool may not take you into a friendly embrace."
+#~ msgstr "Strzeż się, wir wodny może nie być dla ciebie zbyt przyjazny."
+
+#~ msgid "Beyond here be Dragons!"
+#~ msgstr "Dalej są Smoki!"
+
+#~ msgid "Beyond the door, there be Dragons. BEWARE!"
+#~ msgstr "Za drzwiami, są Smoki, STRZEŻ SIĘ!"
+
+#~ msgid "Big Oak"
+#~ msgstr "Wielki Dąb \"Bartek\""
+
+#~ msgid "Blackburn"
+#~ msgstr "Blackburn"
+
+#~ msgid "Blackfang"
+#~ msgstr "Czarny Kieł"
+
+#~ msgid "Black Fang"
+#~ msgstr "Czarny Kieł"
+
+#~ msgid "Black Oak"
+#~ msgstr "Czarny Dąb"
+
+#~ msgid "Blackridge"
+#~ msgstr "Blackridge"
+
+#~ msgid "Blacksford"
+#~ msgstr "Blacksford"
+
+#~ msgid "Black Vein"
+#~ msgstr "Black Vein"
+
+#~ msgid "Blackwind"
+#~ msgstr "Blackwind"
+
+#~ msgid "Bloodreign"
+#~ msgstr "Bloodreign"
+
+#~ msgid "Boats my be needed to access some parts of this peninsula."
+#~ msgstr "Łodzie mogą być niezbędne by dotrzeć w niektóre części  półwyspu."
+
+#~ msgid "Boats Sold Here            Inquire Within"
+#~ msgstr "Tutaj sprzedawane są łodzie"
+
+#~ msgid "BoneVille"
+#~ msgstr "BoneVille"
+
+#~ msgid "Bridge out!"
+#~ msgstr "Zniszczony most!"
+
+#~ msgid "Bridge Out!"
+#~ msgstr "Zniszczony most!"
+
+#~ msgid "Brindamoor"
+#~ msgstr "Brindamoor"
+
+#~ msgid "Brownston"
+#~ msgstr "Brownston"
+
+#~ msgid "Buried Treasure!"
+#~ msgstr "Zakopany skarb"
+
+#~ msgid "Burlock"
+#~ msgstr "Burlock"
+
+#~ msgid "Burton"
+#~ msgstr "Burton"
+
+#~ msgid ""
+#~ "Capture the necromancer's dreaded castle \"Death Gate\" and free the land "
+#~ "from the undead plague."
+#~ msgstr ""
+#~ "Zdobądź złowrogi zamek Nekromanty, \"Death Gate\", i uwolnij krainę od "
+#~ "plagi nieumarłych."
+
+#~ msgid "Cathcart"
+#~ msgstr "Cathcart"
+
+#~ msgid "Chandler"
+#~ msgstr "Chandler"
+
+#~ msgid "Chilton"
+#~ msgstr "Chilton"
+
+#~ msgid "Chronos"
+#~ msgstr "Chronos"
+
+#~ msgid "Come and...."
+#~ msgstr "Podejdź i..."
+
+#~ msgid ""
+#~ "Compared to the rest of the villages in this land, this village seems "
+#~ "grand, but in any other land it would seem poor. From here you can see "
+#~ "the tall spires of the Warlock's tower of Dragons."
+#~ msgstr ""
+#~ "Porównując z resztą wiosek na tej wyspie, ta wioska wydaje się być "
+#~ "wielka, ale w innych krainach nie byłaby taka. Stąd możesz zobaczyć "
+#~ "wysokie iglice Wieży Smoków"
+
+#~ msgid "Complete"
+#~ msgstr "Zrobione"
+
+#~ msgid "Condemned!"
+#~ msgstr "Potępiony!"
+
+#~ msgid ""
+#~ "Congratulations! After navigating the treacherous coast, you have "
+#~ "established trade between the north and south."
+#~ msgstr ""
+#~ "Gratulacje!  Po dotarciu do zdradzieckiego wybrzeża, dokonałeś wymiany "
+#~ "pomiędzy północą i południem."
+
+#~ msgid "Corackston"
+#~ msgstr "Corackston"
+
+#~ msgid "Crossroads"
+#~ msgstr "Rozdroża"
+
+#~ msgid "Crossroads North"
+#~ msgstr "Rozdroża Północy"
+
+#~ msgid "Crossroads South"
+#~ msgstr "Rozdroża  Południa"
+
+#~ msgid "Danger a whirlpool destroyed my ship."
+#~ msgstr "Niebezpieczny wir wodny zniszczył mój statek."
+
+#~ msgid "Danger, Dragons abound!"
+#~ msgstr "Niebezpieczeństwo Smoki mnożą się!"
+
+#~ msgid "DANGER!  QUICKSAND!"
+#~ msgstr "UWAGA! Ruchome piaski!"
+
+#~ msgid "Danger! Troll bridge ahead!"
+#~ msgstr "Uwaga! Most Trolli!"
+
+#~ msgid "Danger - Turn Back Now"
+#~ msgstr "Niebezpieczeństwo - Zawróć natychmiast."
+
+#~ msgid "Dark clouds loom overhead as you enter this valley."
+#~ msgstr ""
+#~ "Ciemne chmury wyłaniają się nad głową z chwilą gdy wkroczyłeś do doliny"
+
+#~ msgid "Dead Pine"
+#~ msgstr "Martwa Sosna"
+
+#~ msgid "Deathgate"
+#~ msgstr "Brama Śmierci"
+
+#~ msgid "DeathGate"
+#~ msgstr "Brama Śmierci"
+
+#~ msgid "Decisions"
+#~ msgstr "Decyzje"
+
+#~ msgid "\"Defender\""
+#~ msgstr "Obrońca"
+
+#~ msgid "DirtWater"
+#~ msgstr "Brudna Woda"
+
+#~ msgid "Dominion"
+#~ msgstr "Dominium"
+
+#~ msgid "Do Not Enter!"
+#~ msgstr "Nie wchodzić!"
+
+#~ msgid "Do not remove coins from fountain."
+#~ msgstr "Nie zabierać monet z fontanny!"
+
+#~ msgid "Dragadune"
+#~ msgstr "Dragadune"
+
+#~ msgid "Dragonburg"
+#~ msgstr "Dragonburg"
+
+#~ msgid "Dragon City lies beyond the Scorpion Hills."
+#~ msgstr "Miasto Smoków leży poniżej wzgórz Skorpiona"
+
+#~ msgid "Dragon Hill"
+#~ msgstr "Wzgórze Smoków"
+
+#~ msgid "Dragon Rider"
+#~ msgstr "Smoczy Jeździec"
+
+#~ msgid "Dragons Everywhere!"
+#~ msgstr "Smoki! Wszędzie Smoki!"
+
+#~ msgid "Dragon's Eye"
+#~ msgstr "Oko Smoka!"
+
+#~ msgid "Dragontooth"
+#~ msgstr "Dragontooth"
+
+#~ msgid "Dragon Town"
+#~ msgstr "Miasto Smoka"
+
+#~ msgid "Dragonville"
+#~ msgstr "Dragonville"
+
+#~ msgid "Dragon Wars"
+#~ msgstr "Smocze wojny"
+
+#~ msgid "Enroth"
+#~ msgstr "Enroth"
+
+#~ msgid ""
+#~ "Find the Ultimate Artifact and be proclaimed King, or smash the "
+#~ "opposition and take control."
+#~ msgstr ""
+#~ "Odnajdź Najpotężniejszy Artefakt i zostań królem, lub zmiażdż "
+#~ "przeciwników."
+
+#~ msgid "Five heroes vie for control of a familiar land."
+#~ msgstr "Pięciu bohaterów rywalizuje o władzę w kraju."
+
+#~ msgid ""
+#~ "For a total of 400,000 gold your opponents will become \"loyal\" "
+#~ "subjects, otherwise... let them eat cake!"
+#~ msgstr ""
+#~ "Za sumę 400,000 sztuk złota twoi przeciwnicy zostaną \"lojalnymi poddanymi"
+#~ "\", ale... możesz im również spuścić lanie!"
+
+#~ msgid "Forsaken Lands"
+#~ msgstr "Zapomn. Krainy"
+
+#~ msgid "For sale."
+#~ msgstr "Na sprzedaż."
+
+#~ msgid "Good vs. Evil"
+#~ msgstr "Dobro kontra Zło"
+
+#~ msgid "Hot Spot"
+#~ msgstr "Punkt Zapalny"
+
+#~ msgid "It's windy at the top.  Defend, Divide, and Conquer."
+#~ msgstr "Na szczycie wieje porywisty wiatr.  Broń, dziel, i rządź."
+
+#~ msgid "Lost Continent"
+#~ msgstr "Zag. kontynent"
+
+#~ msgid "Lost Relic"
+#~ msgstr "Zaginiony relikt"
+
+#~ msgid "Might vs. Magic"
+#~ msgstr "Moc vs Magia"
+
+#~ msgid "Mineral Wars"
+#~ msgstr "Walka o minerał"
+
+#~ msgid "Mountain king"
+#~ msgstr "Król Gór"
+
+#~ msgid "Overlord"
+#~ msgstr "Suweren"
+
+#~ msgid "Pandemonium"
+#~ msgstr "Pandemonium"
+
+#~ msgid "Pick one of four Knights in this large and inhospitable land."
+#~ msgstr ""
+#~ "Wybierz jednego spośród czterech Rycerzy na tych rozległych i "
+#~ "nieprzyjaznych terenach."
+
+#~ msgid ""
+#~ "Play the Knight or Barbarian in an alliance in this classic duel against "
+#~ "the four spell casters. (Blue and Green vs Red)"
+#~ msgstr ""
+#~ "Zostań Rycerzem lub Barbarzyńcą w pojedynku przeciwko czterem czarownikom "
+#~ "(Niebieski i Zielony kontra Czerwony)."
+
+#~ msgid ""
+#~ "Plenty of resources and lots of ground to cover. Watch out for Orange and "
+#~ "Purple!"
+#~ msgstr ""
+#~ "Bardzo dużo surowców i terenu do odkrywania. Uważaj na graczy oznaczonych "
+#~ "kolorami Pomarańczowym i Purpurowym!"
+
+#~ msgid "Revolution"
+#~ msgstr "Rewolucja"
+
+#~ msgid "River Crossing"
+#~ msgstr "Rzeka"
+
+#~ msgid "Scorched Earth"
+#~ msgstr "Spalone ziemie"
+
+#~ msgid ""
+#~ "Six factions have established a foothold on a huge, unexplored "
+#~ "continent.  Can you eliminate the other five?"
+#~ msgstr ""
+#~ "Sześć drużyn pojawia się na ogromnym, niezbadanym kontynencie.  Czy "
+#~ "zdołasz wyeliminować pozostałe pięć?"
+
+#~ msgid ""
+#~ "Six heroes with large armies prepare to slug it out for total domination!"
+#~ msgstr ""
+#~ "Sześciu bohaterów stojących na czele potężnych armii walczy pomiędzy sobą "
+#~ "o władzę!"
+
+#~ msgid "Slugfest"
+#~ msgstr "Porachunki"
+
+#~ msgid "Teleporters"
+#~ msgstr "Teleporty"
+
+#~ msgid "Terra Firma"
+#~ msgstr "Terra Firma"
+
+#~ msgid ""
+#~ "The alliance has crumbled and all are at war. Lots of resources but "
+#~ "little time to prepare."
+#~ msgstr ""
+#~ "Przymierze upadło i wszyscy walczą ze sobą nawzajem. Dużo surowców, ale "
+#~ "mało czasu na przygotowanie."
+
+#~ msgid ""
+#~ "The Barbarian's lands are being invaded. Are you strong enough to resist "
+#~ "the invasion?"
+#~ msgstr ""
+#~ "Kraina Barbarzyńców zostaje zaatakowana. Czy jesteś dość silny, by "
+#~ "odeprzeć inwazję?"
+
+#~ msgid ""
+#~ "The four spell casters face off with substantial starting armies. Can the "
+#~ "crusaders keep the peace?"
+#~ msgstr ""
+#~ "Czterej czarodzieje z dużymi armiami walczą między sobą. Czy krzyżowcom "
+#~ "uda się utrzymać pokój?"
+
+#~ msgid ""
+#~ "The Gods have given you 6 months to prove yourself. Good or Evil - who "
+#~ "shall prevail? (Blue,Green and Red vs Yellow, Orange and Purple)"
+#~ msgstr ""
+#~ "Bogowie dali wam 6 miesięcy na przeprowadzenie próby sił. Dobro lub Zło - "
+#~ "kto zwycięży? (Nieb., Ziel. i Czerw. kontra Żółty, Pom. i Purpurowy)"
+
+#~ msgid ""
+#~ "The gods have granted this world a great artifact, to find it means "
+#~ "victory."
+#~ msgstr ""
+#~ "Bogowie powierzyli temu światu potężny artefakt, znajdź go, a zwyciężysz."
+
+#~ msgid ""
+#~ "The King will sell you this land for 200,000 gold or you can take it by "
+#~ "force. The choice is yours."
+#~ msgstr ""
+#~ "Król chciałby odsprzedać ci te ziemie za 200,000 sztuk złota, możesz je "
+#~ "również przejąć siłą. Wybór należy do ciebie."
+
+#~ msgid "The land of Heroes II."
+#~ msgstr "Kraina gry Heroes II."
+
+#~ msgid ""
+#~ "The Overlord has given you 4 months to conquer this land or deliver to "
+#~ "him the sum of 150,000 gold."
+#~ msgstr ""
+#~ "Dostałeś od swojego Suwerena 4 miesiące na podbicie tej krainy; jeśli ci "
+#~ "się nie uda, będziesz musiał zapłacić 150,000 sztuk złota."
+
+#~ msgid ""
+#~ "Three Warlocks in the land of Dragons. Lose thy home and all will be "
+#~ "lost. Conquer thy enemies and the land shall forever be yours!"
+#~ msgstr ""
+#~ "3 czarnoksiężników w krainie smoków. Jeśli stracisz siedzibę, będziesz "
+#~ "zgubiony. Ale jeśli pokonasz swoich wrogów, kraina na zawsze będzie twoja!"
+
+#~ msgid "Undead Armies"
+#~ msgstr "Nieumarli"
+
+#~ msgid "Unholy Alliance"
+#~ msgstr "Przekl. sojusz"
+
+#~ msgid "Vikings!"
+#~ msgstr "Wikingowie!"
+
+#~ msgid "Warrior Knight"
+#~ msgstr "Dzielny Rycerz"
+
+#~ msgid "Wastelands"
+#~ msgstr "Bezdroża"
+
+#~ msgid "When you're ready, take the teleport to the Island's Hot Spot!"
+#~ msgstr "Kiedy będziesz już gotowy, teleportuj się do Punktu Zapalnego!"
+
+#~ msgid ""
+#~ "While away seeking the Ultimate Artifact, Kastor's kingdom is invaded!"
+#~ msgstr ""
+#~ "Podczas gdy Kastor poszukuje Najwspanialszego Artefaktu, jego królestwo "
+#~ "zostaje zaatakowane przez wrogów!"
+
+#~ msgid "Who am I?"
+#~ msgstr "Kim jestem?"
+
+#~ msgid "Winterlands"
+#~ msgstr "Królestwo Zimy"
+
+#~ msgid "Your castle is the last outpost in the area, Don't lose it!"
+#~ msgstr "Twój zamek to ostatni bastion w okolicy, nie strać go!"
+
+#~ msgid ""
+#~ "Your expedition has taken a turn for the worse... you now have no way to "
+#~ "get home!"
+#~ msgstr ""
+#~ "Twoja wyprawa zakończyła się klęską... co gorsza, nie masz jak wrócić do "
+#~ "domu!"
+
+#~ msgid ""
+#~ "Your opponents are allied against you and each is twice as powerful as "
+#~ "his predecessor! Is it possible to win?"
+#~ msgstr ""
+#~ "Twoi przeciwnicy połączyli siły, a każdy z nich jest dwukrotnie "
+#~ "potężniejszy od swojego poprzednika! Czy w takiej bitwie można wygrać?"
+
+#~ msgid ""
+#~ "You've ruled with an iron fist (and an army of undead), but now your "
+#~ "kingdom has turned against you!"
+#~ msgstr ""
+#~ "Przy pomocy armii nieumarłych, sprawowałeś w kraju władzę 'silnej ręki', "
+#~ "lecz teraz twoje królestwo zwróciło się przeciwko tobie!"
+
+#~ msgid "Blind "
+#~ msgstr "Oślepienie "
+
+#~ msgid "game: also confirm autosave"
+#~ msgstr "game: potwierdzaj auto zapisywanie"
+
+#~ msgid "game: battle mouse shadow"
+#~ msgstr "gra: podczas walki pokaż cień myszy"
+
+#~ msgid "game: battle move shadow"
+#~ msgstr "gra: podczas walki cień ruchu"
+
+#~ msgid "world: abandoned mine random resource"
+#~ msgstr "świat: losowe surowce w opuszczonej kopalni"
+
+#~ msgid "world: guardian objects gets +2 defense"
+#~ msgstr "świat: strażnicy obiektów zyskują +2 obrony"
+
+#~ msgid "world: only the first monster will attack (H2 bug)."
+#~ msgstr "świat: tylko pierwszy potwór zaatakuje (Bug Heroes 2)"
+
+#~ msgid "world: new version WeekOf (+growth)"
+#~ msgstr "świat: nowa wersja Tygodnia... (+wzrost)"
+
+#~ msgid ""
+#~ "world: Artesian Springs have two separately visitable squares (h3 ver)"
+#~ msgstr "świat: Artezjańskie Wiosny mają dwa oddzielne miejsca wizyt"
+
+#~ msgid "world: Outer creature dwellings should accumulate units"
+#~ msgstr "świat: zewnętrzne posiadłości stworzeń powinny gromadzić jednostki"
+
+#~ msgid "world: use unique artifacts for morale/luck"
+#~ msgstr "świat: użyj unikatowych artefaktów dla morale/szczęścia"
+
+#~ msgid "heroes: surrendering gives some experience"
+#~ msgstr "heroes: poddanie się daje trochę doświadczenia"
+
+#~ msgid "heroes: allow pickup objects for patrol"
+#~ msgstr "heroes: pozwól patrolom podnosić obiekty"
+
+#~ msgid "battle: high objects are an obstacle for archers"
+#~ msgstr "walka: wysokie obiekty są przeszkodą dla jednostek strzelających"
+
+#~ msgid "battle: magical creature resists (20%) the same magic"
+#~ msgstr ""
+#~ "Walka: magiczne stwory otrzymują 20% odporności na magię tego samego typu"
+
+#~ msgid "battle: skip increase +2 defense"
+#~ msgstr "Walka: pominięcie kolejki zwiększa obronę o 2pkt"
+
+#~ msgid "game: show SDL logo"
+#~ msgstr "game: pokaż logo SDL"
+
+#~ msgid "game: also use dynamic interface for castles"
+#~ msgstr "game: użyj dynamicznego interfejsu do zamków"
+
+#~ msgid "pocketpc: hide cursor"
+#~ msgstr "pocketpc: ukryj kursor"
+
+#~ msgid "pocketpc: tap mode"
+#~ msgstr "pocketpc: tryb tapnięcia"
+
+#~ msgid "pocketpc: drag&drop gamearea as scroll"
+#~ msgstr "pocketpc: przeciągnij i upiść aby przewinąć"
+
+#~ msgid "pocketpc: low memory"
+#~ msgstr "pocketpc: mało pamięci"
 
 #~ msgid "Shoot %{monster} (%{count} shot(s) left)"
 #~ msgstr "Strzał %{monster} (%{count} pocisków pozostało)"
@@ -13158,9 +8688,6 @@ msgstr "pocketpc: mało pamięci"
 
 #~ msgid "Allows you to draw streams by clicking and dragging."
 #~ msgstr "Służy do rysowania strumieni metodą 'kliknij i przeciągnij'."
-
-#~ msgid "Road Mode"
-#~ msgstr "Tryb dróg"
 
 #~ msgid "Allows you to draw roads by clicking and dragging."
 #~ msgstr "Służy do rysowania dróg metodą 'kliknij i przeciągnij'."
@@ -13293,14 +8820,14 @@ msgstr "pocketpc: mało pamięci"
 #~ "After regular growth, population of %{monter} increase on %{count} "
 #~ "percent!"
 #~ msgstr[0] ""
-#~ "Dzięki naturalnemu przyrostowi populacja %{monter} zwiększa się o %"
-#~ "{count} procent!"
+#~ "Dzięki naturalnemu przyrostowi populacja %{monter} zwiększa się o "
+#~ "%{count} procent!"
 #~ msgstr[1] ""
-#~ "Dzięki naturalnemu przyrostowi populacja %{monter} zwiększa się o %"
-#~ "{count} procent!"
+#~ "Dzięki naturalnemu przyrostowi populacja %{monter} zwiększa się o "
+#~ "%{count} procent!"
 #~ msgstr[2] ""
-#~ "Dzięki naturalnemu przyrostowi populacja %{monter} zwiększa się o %"
-#~ "{count} procent!"
+#~ "Dzięki naturalnemu przyrostowi populacja %{monter} zwiększa się o "
+#~ "%{count} procent!"
 
 #~ msgid "%{monster} population increases by +%{count}."
 #~ msgid_plural "%{monster} population increases by +%{count}."
@@ -13359,17 +8886,6 @@ msgstr "pocketpc: mało pamięci"
 #~ msgstr[0] "Zwiększa pole widzenia bohatera o %{count} kwadrat."
 #~ msgstr[1] "Zwiększa pole widzenia bohatera o %{count} kwadratów."
 #~ msgstr[2] "Zwiększa pole widzenia bohatera o %{count} kwadratów."
-
-#~ msgid ""
-#~ "Approximately %{count} percent of the creatures may offer to join you."
-#~ msgid_plural ""
-#~ "Approximately %{count} percent of the creatures may offer to join you."
-#~ msgstr[0] ""
-#~ "Około %{count} procent stworzeń może zaoferować dołączenie do ciebie."
-#~ msgstr[1] ""
-#~ "Około %{count} procent stworzeń może zaoferować dołączenie do ciebie."
-#~ msgstr[2] ""
-#~ "Około %{count} procent stworzeń może zaoferować dołączenie do ciebie."
 
 #~ msgid ""
 #~ "Increases your hero's movement points over water by %{count} percent."

--- a/files/lang/pt.po
+++ b/files/lang/pt.po
@@ -7,51 +7,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-10-23 10:54+0900\n"
+"POT-Creation-Date: 2021-07-01 15:11+0200\n"
 "PO-Revision-Date: 2010-02-09 01:11+0000\n"
 "Last-Translator: nestorneto <nestor.magalhaes@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt_BR\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Launchpad-Export-Date: 2010-05-27 09:12+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: ../fheroes2/ai/ai_action.cpp:157 ../fheroes2/heroes/heroes_action.cpp:248
-msgid "Hero %{name} also got a %{count} experience."
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:221 ../fheroes2/resource/artifact.cpp:968
-msgid "View %{name}"
-msgstr "Ver %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:227 ../fheroes2/army/army_bar.cpp:310
-#, fuzzy
-msgid "Move or right click to redistribute %{name}"
-msgstr "Mova e clica com o botao direito para redistribuir %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:233 ../fheroes2/army/army_bar.cpp:301
-msgid "Combine %{name} armies"
-msgstr "Juntar os exércitos de %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:238 ../fheroes2/army/army_bar.cpp:292
-#: ../fheroes2/resource/artifact.cpp:980
-#: ../fheroes2/resource/artifact.cpp:1002
-msgid "Exchange %{name2} with %{name}"
-msgstr "Trocar %{name2} com %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:246 ../fheroes2/resource/artifact.cpp:988
-msgid "Select %{name}"
-msgstr "Selecione %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:298 ../fheroes2/army/army_bar.cpp:307
-#, fuzzy
-msgid "Cannot move last troop"
-msgstr "Não é possível mover o último exército à fortaleza"
-
-#: ../fheroes2/army/army.cpp:85
 msgid ""
 "A few\n"
 "%{monster}"
@@ -59,7 +26,6 @@ msgstr ""
 "Um pouco de\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:86
 msgid ""
 "Several\n"
 "%{monster}"
@@ -67,7 +33,6 @@ msgstr ""
 "Alguns\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:87
 msgid ""
 "A pack of\n"
 "%{monster}"
@@ -75,7 +40,6 @@ msgstr ""
 "Muito pouco de\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:88
 msgid ""
 "Lots of\n"
 "%{monster}"
@@ -83,7 +47,6 @@ msgstr ""
 "Muitos de\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:89
 msgid ""
 "A horde of\n"
 "%{monster}"
@@ -91,7 +54,6 @@ msgstr ""
 "Uma horada de\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:90
 msgid ""
 "A throng of\n"
 "%{monster}"
@@ -99,7 +61,6 @@ msgstr ""
 "Uma multidão de\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:91
 msgid ""
 "A swarm of\n"
 "%{monster}"
@@ -107,7 +68,6 @@ msgstr ""
 "Um enxame de\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:92
 msgid ""
 "Zounds of\n"
 "%{monster}"
@@ -115,7 +75,6 @@ msgstr ""
 "Um inferno de\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:93
 msgid ""
 "A legion of\n"
 "%{monster}"
@@ -123,226 +82,223 @@ msgstr ""
 "Uma legião de\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Few"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Several"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Pack"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Lots"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Horde"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Throng"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Swarm"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Zounds"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Legion"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:925
 msgid "All %{race} troops +1"
 msgstr "Toda tropa de %{race}  +1"
 
-#: ../fheroes2/army/army.cpp:936
-msgid "Entire unit is undead, so morale does not apply."
-msgstr ""
-
-#: ../fheroes2/army/army.cpp:946
 msgid "Troops of 3 alignments -1"
 msgstr "Tropas de Nivel 3 -1"
 
-#: ../fheroes2/army/army.cpp:954
 msgid "Troops of 4 alignments -2"
 msgstr "Tropas de Nivel 4 -2"
 
-#: ../fheroes2/army/army.cpp:962
 msgid "Troops of 5 alignments -3"
 msgstr "Tropas de Nivel 5 -3"
 
-#: ../fheroes2/army/army.cpp:976
 msgid "Some undead in groups -1"
 msgstr "Algum morto-vivo no grupo -1"
 
-#: ../fheroes2/battle/battle_action.cpp:752
+msgid "View %{name}"
+msgstr "Ver %{name}"
+
+#, fuzzy
+msgid "Move or right click to redistribute %{name}"
+msgstr "Mova e clica com o botao direito para redistribuir %{name}"
+
+msgid "Combine %{name} armies"
+msgstr "Juntar os exércitos de %{name}"
+
+msgid "Exchange %{name2} with %{name}"
+msgstr "Trocar %{name2} com %{name}"
+
+msgid "Select %{name}"
+msgstr "Selecione %{name}"
+
+#, fuzzy
+msgid "Cannot move last troop"
+msgstr "Não é possível mover o último exército à fortaleza"
+
+msgid "%{name} half the enemy troops!"
+msgstr ""
+
 msgid "Set auto battle off"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:757
 msgid "Set auto battle on"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:864
 msgid "spell failed!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:705
 msgid ""
 "The Sphere of Negation artifact is in effect for this battle, disabling all "
 "combat spells."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:714
 msgid "You have already cast a spell this round."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:720
-#: ../fheroes2/battle/battle_arena.cpp:768
 msgid "That spell will affect no one!"
 msgstr "Esta magia não afetará ninguem!"
 
-#: ../fheroes2/battle/battle_arena.cpp:739
 msgid "You may only summon one type of elemental per combat."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:745
 msgid "There is no open space adjacent to your hero to summon an Elemental to."
 msgstr ""
 
-#: ../fheroes2/battle/battle_board.cpp:968
 msgid ""
 "The Moat reduces by -%{count} the defense skill of any unit and slows to "
 "half movement rate."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:50
-msgid "speed: %{speed}"
+msgid "Speed"
+msgstr "Veloc."
+
+msgid "Speed: %{speed}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:165
+msgid "Auto Spell Casting"
+msgstr ""
+
+msgid "Grid"
+msgstr ""
+
+#, fuzzy
+msgid "Shadow Movement"
+msgstr "Continuar a Andar"
+
+msgid "Shadow Cursor"
+msgstr ""
+
+msgid "On"
+msgstr ""
+
+#, fuzzy
+msgid "Off"
+msgstr "off"
+
 msgid "The enemy has surrendered!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:168
 msgid "The enemy has fled!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:170
-#: ../fheroes2/battle/battle_dialogs.cpp:256
 msgid "A glorious victory!"
 msgstr "Uma vitoria gloriosa!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:175
-msgid "For valor in combat, %{name} receives %{exp} experience"
+msgid "For valor in combat, %{name} receives %{exp} experience."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:184
 msgid "The cowardly %{name} flees from battle."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:191
 msgid "%{name} surrenders to the enemy, and departs in shame."
 msgstr "%{name} rende-se ao inimigo, e retira-se na vergonha."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:197
 msgid "Your force suffer a bitter defeat, and %{name} abandons your cause."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:249
 msgid "Your force suffer a bitter defeat."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:296
 msgid "Battlefield Casualties"
 msgstr "Feridos em Guerras"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:300
 msgid "Attacker"
 msgstr "Agressor"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:312
 msgid "Defender"
 msgstr "Defensor"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:394
+msgid "You have captured an enemy artifact!"
+msgstr "Vou capturou um artefato inimigo!"
+
+#, fuzzy
+msgid "Necromancy!"
+msgstr "Necromante:"
+
+msgid ""
+"Practicing the dark arts of necromancy, you are able to raise %{count} of "
+"the enemy's dead to return under your service as %{monster}."
+msgstr ""
+
 msgid "%{name} the %{race}"
 msgstr "%{name} a %{race}"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:401
-#: ../fheroes2/castle/castle_well.cpp:311
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:194
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:834
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Attack"
 msgstr "Ataque"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:406
-#: ../fheroes2/castle/castle_well.cpp:317
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:206
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:844
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Defense"
 msgstr "Defesa"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:411
-#: ../fheroes2/castle/castle_town.cpp:310
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:854
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:142
-#: ../fheroes2/heroes/heroes_meeting.cpp:292
 msgid "Spell Power"
 msgstr "Poder de Magia"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:416
-#: ../fheroes2/castle/castle_town.cpp:319
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:864
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:147
-#: ../fheroes2/heroes/heroes_meeting.cpp:296 ../fheroes2/heroes/skill.cpp:151
 msgid "Knowledge"
 msgstr "Conhecimento"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:421
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:276
 msgid "Morale"
 msgstr "Moral"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:426
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:286 ../fheroes2/heroes/skill.cpp:338
 msgid "Luck"
 msgstr "Sorte"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:431
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:874
-#: ../fheroes2/heroes/heroes_indicator.cpp:247
 msgid "Spell Points"
 msgstr "Mana"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
-#: ../fheroes2/gui/interface_buttons.cpp:189
+msgid "Hero's Options"
+msgstr "Opções do Herói"
+
 msgid "Cast Spell"
 msgstr "Magia"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
+msgid "Retreat"
+msgstr "Retirada"
+
+msgid "Surrender"
+msgstr "Render-se"
+
+msgid "Cancel"
+msgstr "Cancelar"
+
+msgid "Hero Screen"
+msgstr ""
+
+#, fuzzy
 msgid ""
 "Cast a magical spell. You may only cast one spell per combat round. The "
-"round is reset when every creature has had a turn"
+"round is reset when every creature has had a turn."
 msgstr ""
 "Lançar uma magia. Você só pode lançar uma magia por rodada. Uma nova rodada "
 "é iniciada quando toda criatura tem tido a sua vez."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:488
-msgid "Retreat"
-msgstr "Retirada"
-
-#: ../fheroes2/battle/battle_dialogs.cpp:488
 msgid ""
 "Retreat your hero, abandoning your creatures. Your hero will be available "
 "for you to recruit again, however, the hero will have only a novice hero's "
@@ -352,11 +308,6 @@ msgstr ""
 "estará disponível para recrutar mais uma vez, no entanto, o herói terá "
 "apenas as tropas iniciais."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:491
-msgid "Surrender"
-msgstr "Render-se"
-
-#: ../fheroes2/battle/battle_dialogs.cpp:491
 msgid ""
 "Surrendering costs gold. However if you pay the ransom, the hero and all of "
 "his or her surviving creatures will be available to recruit again."
@@ -364,719 +315,972 @@ msgstr ""
 "Render-se custa ouro. No entanto, se você pagar o custo, o herói e todas as "
 "suas criaturas vivas estarão disponíveis para recrutar novamente."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:166
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:227
-msgid "Cancel"
-msgstr "Cancelar"
+msgid "Open Hero Screen to view full information about the hero."
+msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
 msgid "Return to the battle."
 msgstr "Retornar à batalha."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:549
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:438
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:497
 msgid "Not enough gold (%{gold})"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:564
 msgid "%{name} states:"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:569
 msgid ""
-"I will accept your surrender and grant you and your troops safe passage for "
-"the price of %{price} gold."
+"\"I will accept your surrender and grant you and your troops safe passage "
+"for the price of %{price} gold.\""
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:613
-#: ../fheroes2/battle/battle_interface.cpp:1401
 msgid "View %{monster} info."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1409
 #, fuzzy
 msgid "Shoot %{monster}"
 msgstr ""
 "Muitos de\n"
 "%{monster}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1431
 msgid "Attack %{monster}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Fly %{monster} here."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Move %{monster} here."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1449
-#: ../fheroes2/battle/battle_interface.cpp:1538
 msgid "Turn %{turn}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1475
 msgid "Teleport Here"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1479
 msgid "Invalid Teleport Destination"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1485
 msgid "Cast %{spell} on %{monster}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1495
 msgid "Cast %{spell}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1501
 msgid "Select Spell Target"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1674
-msgid "Spell cast"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:1686
 msgid "View Ballista Info"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1699
-#: ../fheroes2/battle/battle_tower.cpp:53
 msgid "Ballista"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1712
 msgid "Auto combat"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1719
 msgid "Customize system options."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1727
 #, fuzzy
 msgid "Wait this unit"
 msgstr "Passar a vez desta criatura"
 
-#: ../fheroes2/battle/battle_interface.cpp:1734
 msgid "Skip this unit"
 msgstr "Passar a vez desta criatura"
 
-#: ../fheroes2/battle/battle_interface.cpp:1742
-#: ../fheroes2/battle/battle_interface.cpp:1774
-msgid "Hero's Options"
-msgstr "Opções do Herói"
-
-#: ../fheroes2/battle/battle_interface.cpp:1753
-#: ../fheroes2/battle/battle_interface.cpp:1785
 msgid "View Opposing Hero"
 msgstr "Ver Heróis oponentes"
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Hide logs"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Show logs"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1878
 msgid "%{color} cast spell: %{spell}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2202
 msgid "%{name} skipping turn"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2203
-msgid ", and get +2 defense"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:2206
 msgid "%{name} waiting turn"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2343
 msgid "%{attacker} do %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2497
 msgid "Moved %{monster}: %{src}, %{dst}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2612
+#, fuzzy
+msgid "Moved %{monster}"
+msgstr ""
+"Muitos de\n"
+"%{monster}"
+
 msgid "The %{name} resist the spell!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2625
 msgid "%{name} casts %{spell} on the %{troop}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2630
 msgid "%{name} casts %{spell}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2751
-msgid "The %{spell} spell does %{damage} damage to all undead creatures."
+msgid "The %{spell} does %{damage} damage to one undead creature."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2754
-msgid "The %{spell} spell does %{damage} damage to all living creatures."
+msgid "The %{spell} does %{damage} damage to all undead creatures."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2756
+msgid "The %{spell} does %{damage} damage, %{count} creatures perish."
+msgstr ""
+
 msgid "The %{spell} does %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2797
+msgid "The %{spell} does %{damage} damage to one living creature."
+msgstr ""
+
+msgid "The %{spell} does %{damage} damage to all living creatures."
+msgstr ""
+
 msgid "The Unicorns attack blinds the %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2798
 msgid "The Medusas gaze turns the %{name} to stone!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2800
 msgid "The Mummies' curse falls upon the %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2801
 msgid "The %{name} are paralyzed by the Cyclopes!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2802
 msgid "The Archmagi dispel all good spells on your %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2820
-msgid "Good luck shines on the  %{attacker}"
+msgid "Good luck shines on the %{attacker}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2872
 msgid "Bad luck descends on the %{attacker}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2884
 msgid "High morale enables the %{monster} to attack again."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2891
 msgid "Low morale causes the %{monster} to freeze in panic."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2944
-msgid "Tower do %{damage} damage."
+msgid "%{tower} does %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:3257
 msgid "MirrorImage created"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:3798
-msgid "MirrorImage ended"
+msgid "The mirror image is destroyed!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4089
 msgid "Break auto battle?"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4138
 msgid "No spells to cast."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4147
 msgid "Are you sure you want to retreat?"
 msgstr "Tem certeza de que quer a retirada?"
 
-#: ../fheroes2/battle/battle_interface.cpp:4155
 #, fuzzy
 msgid "Retreat disabled"
 msgstr "Retirada"
 
-#: ../fheroes2/battle/battle_interface.cpp:4169
-msgid "You don't have enough gold!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:4180
 #, fuzzy
 msgid "Surrender disabled"
 msgstr "Render-se"
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 #, fuzzy
 msgid "Damage: %{max}"
 msgstr "Dia: %{day}"
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{min} - %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 #, fuzzy
 msgid "Perish: %{max}"
 msgstr "Dia: %{day}"
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{min} - %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_main.cpp:190
-msgid "You have captured an enemy artifact!"
-msgstr "Vou capturou um artefato inimigo!"
-
-#: ../fheroes2/battle/battle_main.cpp:241
 msgid ""
-"Through eagle-eyed observation, %{name} is able to learn the magic spell %"
-"{spell}."
+"Through eagle-eyed observation, %{name} is able to learn the magic spell "
+"%{spell}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_main.cpp:280
-msgid ""
-"Practicing the dark arts of necromancy, you are able to raise %{count} of "
-"the enemy's dead to return under your service as %{monster}"
-msgstr ""
-
-#: ../fheroes2/battle/battle_tower.cpp:47 ../fheroes2/castle/castle.cpp:466
 msgid "Left Turret"
 msgstr "Torre Esquerda"
 
-#: ../fheroes2/battle/battle_tower.cpp:48 ../fheroes2/castle/castle.cpp:467
 msgid "Right Turret"
 msgstr "Torre Direita"
 
-#: ../fheroes2/battle/battle_tower.cpp:115
 msgid "The %{name} fires with the strength of %{count} Archers"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:116
 msgid "each with a +%{attack} bonus to their attack skill."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:863
-msgid "%{name} half the enemy troops!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_troop.cpp:950
 msgid ""
 "The %{artifact} artifact is in effect for this battle, disabling %{spell} "
 "spell."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:1598
 msgid "%{count} %{name} rise(s) from the dead!"
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:258
+#, fuzzy
+msgid "Sorceress Guild"
+msgstr "Guilda de Ladrões"
+
+#, fuzzy
+msgid "Necromancer Guild"
+msgstr "Necromante:"
+
+msgid "Dragon Alliance"
+msgstr ""
+
+msgid "Elven Alliance"
+msgstr ""
+
+msgid "Wayward Son"
+msgstr ""
+
+msgid "Uncle Ivan"
+msgstr ""
+
+msgid "Force of Arms"
+msgstr ""
+
+#, fuzzy
+msgid "Annexation"
+msgstr "animação"
+
+msgid "Save the Dwarves"
+msgstr ""
+
+msgid "Carator Mines"
+msgstr ""
+
+#, fuzzy
+msgid "Turning Point"
+msgstr "HP"
+
+msgid "The Gauntlet"
+msgstr ""
+
+msgid "The Crown"
+msgstr ""
+
+msgid "Corlagon's Defense"
+msgstr ""
+
+msgid "Final Justice"
+msgstr ""
+
+msgid "First Blood"
+msgstr ""
+
+msgid "Barbarian Wars"
+msgstr ""
+
+#, fuzzy
+msgid "Necromancers"
+msgstr "Necromante:"
+
+msgid "Slay the Dwarves"
+msgstr ""
+
+msgid "Rebellion"
+msgstr ""
+
+msgid "Dragon Master"
+msgstr ""
+
+msgid "Country Lords"
+msgstr ""
+
+msgid "Greater Glory"
+msgstr ""
+
+msgid "Apocalypse"
+msgstr ""
+
+msgid "Uprising"
+msgstr ""
+
+msgid "Island of Chaos"
+msgstr ""
+
+msgid "Arrow's Flight"
+msgstr ""
+
+msgid "The Abyss"
+msgstr ""
+
+msgid "The Giant's Pass"
+msgstr ""
+
+msgid "Aurora Borealis"
+msgstr ""
+
+msgid "Betrayal's End"
+msgstr ""
+
+#, fuzzy
+msgid "Corruption's Heart"
+msgstr "Quartel do Capitão"
+
+msgid "Conquer and Unify"
+msgstr ""
+
+msgid "Border Towns"
+msgstr ""
+
+msgid "The Wayward Son"
+msgstr ""
+
+msgid "Crazy Uncle Ivan"
+msgstr ""
+
+msgid "The Southern War"
+msgstr ""
+
+msgid "Ivory Gates"
+msgstr ""
+
+msgid "The Elven Lands"
+msgstr ""
+
+msgid "The Epic Battle"
+msgstr ""
+
+msgid "The Shrouded Isles"
+msgstr ""
+
+msgid "The Eternal Scrolls"
+msgstr ""
+
+msgid "Power's End"
+msgstr ""
+
+msgid "Fount of Wizardry"
+msgstr ""
+
+msgid "Stranded"
+msgstr ""
+
+msgid "Pirate Isles"
+msgstr ""
+
+msgid "King and Country"
+msgstr ""
+
+msgid "Blood is Thicker"
+msgstr ""
+
+msgid ""
+"Roland needs you to defeat the lords near his castle to begin his war of "
+"rebellion against his brother.  They are not allied with each other, so they "
+"will spend most of their time fighting with one another.  Victory is yours "
+"when you have defeated all of their castles and heroes."
+msgstr ""
+
+msgid ""
+"The local lords refuse to swear allegiance to Roland, and must be subdued. "
+"They are wealthy and powerful, so be prepared for a tough fight. Capture all "
+"enemy castles to win."
+msgstr ""
+
+msgid ""
+"Your task is to defend the Dwarves against Archibald's forces. Capture all "
+"of the enemy towns and castles to win, and be sure not to lose all of the "
+"dwarf towns at once, or the enemy will have won."
+msgstr ""
+
+msgid ""
+"You will face four allied enemies in a straightforward fight for resource "
+"and treasure. Capture all of the enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Your enemies are allied against you and start close by, so be ready to come "
+"out fighting. You will need to own all four castles in this small valley to "
+"win."
+msgstr ""
+
+msgid ""
+"The Sorceress' guild of Noraston has requested Roland's aid against an "
+"attack from Archibald's allies. Capture all of the enemy castles to win, and "
+"don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy "
+"castle on an island in the ocean.)"
+msgstr ""
+
+msgid ""
+"Gather as large an army as possible and capture the enemy castle within 8 "
+"weeks. You are opposed by only one enemy, but must travel a long way to get "
+"to the enemy castle. Any troops you have in your army at the end of this "
+"scenario will be with you in the final battle."
+msgstr ""
+
+msgid ""
+"Find the Crown before Archibald's heroes find it. Roland will need the Crown "
+"for the final battle against Archibald."
+msgstr ""
+
+msgid ""
+"Three allied enemies stand before you and victory, including Lord Corlagon. "
+"Roland is in a castle to the northwest, and you will lose if he falls to the "
+"enemy. Remember that capturing Lord Corlagon will ensure that he will not "
+"fight against you in the final scenario."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Archibald to end the war!"
+msgstr ""
+
+msgid ""
+"King Archibald requires you to defeat the three enemies in this region.  "
+"They are not allied with one another, so they will spend most of their "
+"energy fighting amongst themselves.  You will win when you own all of the "
+"enemy castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"You must unify the barbarian tribes of the north by conquering them. As in "
+"the previous mission, the enemy is not allied against you, but they have "
+"more resources at their disposal. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"Do-gooder wizards have taken the Necromancers' castle. You must retake it to "
+"achieve victory. Remember that while you start with a powerful army, you "
+"have no castle and must take one within 7 days, or lose this battle. (Hint: "
+"The nearest castle is to the southeast.)"
+msgstr ""
+
+msgid ""
+"The dwarves need conquering before they can interfere in King Archibald's "
+"plans. Roland's forces have more than one hero and many towns to start with, "
+"so be ready for attack from multiple directions. You must capture all of the "
+"enemy towns and castles to claim victory."
+msgstr ""
+
+msgid ""
+"You must put down a peasant revolt led by Roland's forces. All are allied "
+"against you, but you have Lord Corlagon, an experienced hero, to help you. "
+"Capture all enemy castles to win."
+msgstr ""
+
+msgid ""
+"There are two enemies allied against you in this mission. Both are well "
+"armed and seek to evict you from their island. Avoid them and capture Dragon "
+"City to win"
+msgstr ""
+
+msgid ""
+"Your orders are to conquer the country lords that have sworn to serve "
+"Roland. All of the enemy castles are unified against you. Since you start "
+"without a castle, you must hurry to capture one before the end of the week. "
+"Capture all enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Find the Crown before Roland's heroes find it. Archibald will need the Crown "
+"for the final battle against Roland."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Roland to win the war, and be sure "
+"not to lose Archibald in the fight!"
+msgstr ""
+
+msgid ""
+"Subdue the unruly local lords in order to provide the Empire with facilities "
+"to operate in this region."
+msgstr ""
+
+msgid ""
+"Eliminate all oposition in this area. Then the first piece of the artifact "
+"will be yours."
+msgstr ""
+
+msgid ""
+"The sorceresses to the northeast are rebelling! For the good of the empire "
+"you must quash their feeble uprising on your way to the mountains."
+msgstr ""
+
+msgid ""
+"Having prepared for your arrival, Kraeger has arranged for a force of "
+"necromancers to thwart your quest. You must capture the castle of Scabsdale "
+"before the first day of the third week, or the Necromancers will be too "
+"strong for you."
+msgstr ""
+
+msgid ""
+"The barbarian despot in this area is, as yet, ignorant of your presence. "
+"Quickly, build up your forces before you are discovered and attacked! Secure "
+"the region by subduing all enemy forces."
+msgstr ""
+
+msgid ""
+"The Empire is weak in this region. You will be unable to completely subdue "
+"all forces in this area, so take what you can before reprisal strikes. "
+"Remember, your true goal is to claim the Helmet of Anduran."
+msgstr ""
+
+msgid "For the good of the Empire, eliminate Kraeger."
+msgstr ""
+
+msgid ""
+"At last, you have the opportunity and the facilities to rid the Empire of "
+"the necromancer's evil. Eradicate them completely, and you will be sung as a "
+"hero for all time."
+msgstr ""
+
+msgid ""
+"Conquer and unite all the enemy tribes. Don't lose the hero Jarkonas, the "
+"forefather of all descendants."
+msgstr ""
+
+msgid ""
+"Your rival, the Kingdom of Harondale, is attacking weak towns on your "
+"border! Recover from their first strike and crush them completely!"
+msgstr ""
+
+msgid ""
+"Find your wayward son Joseph who is rumored to be living in the desolate "
+"lands. Do it before the first day of the third month or it will be of no "
+"help to your family."
+msgstr ""
+
+msgid ""
+"Rescue your crazy uncle Ivan. Find him before the first day of the fourth "
+"month or it will be no help to your kingdom."
+msgstr ""
+
+msgid ""
+"Destroy the barbarians who are attacking the southern border of your "
+"kingdom! Recover your fallen towns, and then invade the jungle kingdom. "
+"Leave no enemy standing."
+msgstr ""
+
+msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
+msgstr ""
+
+msgid ""
+"Gain the favor of the elves. They will not allow trees to be chopped down, "
+"so they will send you wood every 2 weeks. You must complete your mission "
+"before the first day of the seventh month, or the kingdom will surely fall."
+msgstr ""
+
+msgid ""
+"This is the final battle against your rival kingdom of Harondale. Eliminate "
+"everyone, and don't lose the hero Jarkonas VI."
+msgstr ""
+
+msgid ""
+"Your mission is to vanquish the warring mages in the magical Shrouded Isles. "
+"The completion of this task will give you a fighting chance against your "
+"rivals."
+msgstr ""
+
+msgid ""
+"The location of the great library has been dicovered! You must make your way "
+"to it, and reclaim the city of Chronos in which it lies."
+msgstr ""
+
+msgid ""
+"Find the Orb of negation, which is said to be buried in this land. There are "
+"clues inscribed on stone obelisks which will help lead you to your price. "
+"Find the orb before the first day of the sixth month, or your rivals will "
+"surely have gotten to the fount before you."
+msgstr ""
+
+msgid ""
+"You must take control of the castle of Magic, where the fount of wizardry "
+"lies. Do this and your victory will be supreme."
+msgstr ""
+
+msgid ""
+"Capture the town on the island off the southeast shore in order to construct "
+"a boat and travel back towards the mainland. Do not lose the hero Gallavant."
+msgstr ""
+
+msgid ""
+"Find and defeat Martine, the pirate leader, who resides in Pirates Cove. Do "
+"not lose Gallavant or your quest will be over."
+msgstr ""
+
+msgid ""
+"Eliminate all the other forces who oppose the rule of Lord Alberon. "
+"Gallavant must not die."
+msgstr ""
+
+msgid ""
+"Overthrow the entrenched monarchy of Lord Alberon, and claim all the land in "
+"your name. Gallavant must not die."
+msgstr ""
+
+msgid " bane"
+msgstr ""
+
+msgid " alliance"
+msgstr ""
+
+msgid "Carry-over forces"
+msgstr ""
+
+msgid " bonus"
+msgstr ""
+
+msgid " defeated"
+msgstr ""
+
+msgid "Thunder Mace"
+msgstr ""
+
+msgid "Minor Scroll"
+msgstr ""
+
+msgid "Dragon Sword"
+msgstr ""
+
+#, fuzzy
+msgid "Breastplate"
+msgstr "Mercado"
+
+msgid "Fibzin Medal"
+msgstr ""
+
+msgid "Mage's ring"
+msgstr ""
+
+#, fuzzy
+msgid "Defender Helm"
+msgstr "Defensor"
+
+msgid "Power Axe"
+msgstr ""
+
+msgid "Summon Earth"
+msgstr ""
+
 msgid "The %{building} produces %{monster}."
 msgstr "A %{building} produz %{monster}."
 
-#: ../fheroes2/castle/buildinginfo.cpp:505
 msgid "Requires:"
 msgstr "Requer:"
 
-#: ../fheroes2/castle/buildinginfo.cpp:597
 msgid "Cannot build. Already built here this turn."
 msgstr "Não é possível construir. Já foi construída neste turno."
 
-#: ../fheroes2/castle/buildinginfo.cpp:601
 msgid "For this action it is necessary first to build a castle."
 msgstr "Para esta ação, é necessário primeiro a construir um castelo."
 
-#: ../fheroes2/castle/buildinginfo.cpp:623
 msgid "Cannot build %{name} because castle is too far from water."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:631
-msgid "Cannot afford %{name}"
+#, fuzzy
+msgid "Cannot afford %{name}."
 msgstr "Não pôde arcar com as despesas %{name}"
 
-#: ../fheroes2/castle/buildinginfo.cpp:636
-msgid "%{name} is already built"
+#, fuzzy
+msgid "%{name} is already built."
 msgstr "%{name} já está construída"
 
-#: ../fheroes2/castle/buildinginfo.cpp:641
-msgid "Cannot build %{name}"
+#, fuzzy
+msgid "Cannot build %{name}."
 msgstr "Não é possivel construir %{name}"
 
-#: ../fheroes2/castle/buildinginfo.cpp:646
-msgid "Build %{name}"
+#, fuzzy
+msgid "Build %{name}."
 msgstr "Construir %{name}"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Thieves' Guild"
 msgstr "Guilda de Ladrões"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Tavern"
 msgstr "Taverna"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Shipyard"
 msgstr "Estaleiro"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Well"
 msgstr "Poço"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Statue"
 msgstr "Estátua"
 
-#: ../fheroes2/castle/castle.cpp:467
-#: ../fheroes2/dialog/dialog_marketplace.cpp:212
 msgid "Marketplace"
 msgstr "Mercado"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Moat"
 msgstr "Fosso"
 
-#: ../fheroes2/castle/castle.cpp:467 ../fheroes2/maps/mp2.cpp:391
 msgid "Castle"
 msgstr "Castelo"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Tent"
 msgstr "Tenda"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Captain's Quarters"
 msgstr "Quartel do Capitão"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Mage Guild, Level 1"
 msgstr "Corporação dos Magos, Nível 1"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 2"
 msgstr "Corporação dos Magos, Nível 2"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 3"
 msgstr "Corporação dos Magos, Nível 3"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 4"
 msgstr "Corporação dos Magos, Nível 4"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 5"
 msgstr "Corporação dos Magos, Nível 5"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Farm"
 msgstr "Fazenda"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Garbage Heap"
 msgstr "Acúmulo de Lixo"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Crystal Garden"
 msgstr "Jardim de Cristal"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Waterfall"
 msgstr "Cachoeira"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Orchard"
 msgstr "Pomar"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Skull Pile"
 msgstr "Pilha de Caveiras"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Fortifications"
 msgstr "Fortificações"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Coliseum"
 msgstr "Coliseu"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Rainbow"
 msgstr "Arco-Íris"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Dungeon"
 msgstr "Calabouço"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Library"
 msgstr "Biblioteca"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Storm"
 msgstr "Tempestade"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:498
 msgid "Thatched Hut"
 msgstr "Cabana Elaborada"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Hut"
 msgstr "Cabana"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Treehouse"
 msgstr "Casa na Árvore"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:441
 msgid "Cave"
 msgstr "Caverna"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Habitat"
 msgstr "Habitat"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:431
 msgid "Excavation"
 msgstr "Escavação"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:477
 msgid "Archery Range"
 msgstr "Campo de Arqueiros"
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Stick Hut"
 msgstr "Cabana de Pau"
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Cottage"
 msgstr "Chalé"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Crypt"
 msgstr "Cripta"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Pen"
 msgstr "Curral"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/maps/mp2.cpp:371
 msgid "Graveyard"
 msgstr "Cemitério"
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Blacksmith"
 msgstr "Ferreiro"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Den"
 msgstr "Toca"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Nest"
 msgstr "Ninho"
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Foundry"
 msgstr "Fundição"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:480
-#: ../fheroes2/castle/castle.cpp:487 ../fheroes2/maps/mp2.cpp:427
-#: ../fheroes2/resource/maps_text.cpp:521
 msgid "Pyramid"
 msgstr "Pirâmide"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Armory"
 msgstr "Armaria"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Adobe"
 msgstr "Adobe"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Stonehenge"
 msgstr "Stonehenge"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Maze"
 msgstr "Labirinto"
 
-#: ../fheroes2/castle/castle.cpp:478 ../fheroes2/castle/castle.cpp:485
 msgid "Cliff Nest"
 msgstr "Ninho no Penhasco"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Mansion"
 msgstr "Mansão"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Jousting Arena"
 msgstr "Arena de Lanceiros"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Bridge"
 msgstr "Ponte"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
 msgid "Fenced Meadow"
 msgstr "Campo Cercado"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Swamp"
 msgstr "Pântano"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Ivory Tower"
 msgstr "Torre de Marfim"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Mausoleum"
 msgstr "Mausoléu"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cathedral"
 msgstr "Catedral"
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Red Tower"
 msgstr "Torre Vermelha"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Green Tower"
 msgstr "Torre Verde"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cloud Castle"
 msgstr "Castelo nas Nuvens"
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Laboratory"
 msgstr "Laboratório"
 
-#: ../fheroes2/castle/castle.cpp:483 ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Archery Range"
 msgstr "Upg. Campo de Arqueiros++"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Stick Hut"
 msgstr "Upg. Cabana de Pau++"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Cottage"
 msgstr "Upg. Chalé++"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Graveyard"
 msgstr "Upg. Cemitério++"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Blacksmith"
 msgstr "Upg. Ferreiro++"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Foundry"
 msgstr "Upg. Fundição++"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Pyramid"
 msgstr "Upg. Pirâmide++"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Armory"
 msgstr "Upg. Armoria++"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Adobe"
 msgstr "Upg. Adobe++"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Stonehenge"
 msgstr "Upg. Stonehenge++"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Maze"
 msgstr "Upg. Labirinto++"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Mansion"
 msgstr "Upg. Mansão++"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Jousting Arena"
 msgstr "Upg. Arena de Lanceiros++"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Bridge"
 msgstr "Upg. Ponte++"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Ivory Tower"
 msgstr "Upg. Torre de Marfim++"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Mausoleum"
 msgstr "Upg. Mausoléu++"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cathedral"
 msgstr "Upg. Catedral++"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cloud Castle"
 msgstr "Upg. Castelo nas Nuvens++"
 
-#: ../fheroes2/castle/castle.cpp:488
 msgid "Black Tower"
 msgstr "Torre Negra"
 
-#: ../fheroes2/castle/castle.cpp:490
 msgid "Shrine"
 msgstr "Abside"
 
-#: ../fheroes2/castle/castle.cpp:552
+#, fuzzy
 msgid ""
 "The Thieves' Guild provides information on enemy players. Thieves' Guilds "
-"can also provide scouting information on enemy towns."
+"can also provide scouting information on enemy towns. Additional Guilds "
+"provide more information."
 msgstr ""
 "A Guilda de Ladrões fornece informações sobre os jogadores inimigo. Porém, "
 "também pode fornecer informações suas para para jogadores inimigos."
 
-#: ../fheroes2/castle/castle.cpp:553
 msgid "The Tavern increases morale for troops defending the castle."
 msgstr "A taverna aumenta a moral das tropas que estão defendendo o castelo."
 
-#: ../fheroes2/castle/castle.cpp:554
 msgid "The Shipyard allows ships to be built."
 msgstr "O estaleiro permite à construir barcos."
 
-#: ../fheroes2/castle/castle.cpp:555
 msgid ""
 "The Well increases the growth rate of all dwellings by %{count} creatures "
 "per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:556
 msgid "The Statue increases your town's income by %{count} per day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:557
 msgid "The Left Turret provides extra firepower during castle combat."
 msgstr ""
 "A Torre Esquerda prevê o poder de fogo extra durante o combate no castelo."
 
-#: ../fheroes2/castle/castle.cpp:558
 msgid "The Right Turret provides extra firepower during castle combat."
 msgstr ""
 "A Torre Direita prevê o poder de fogo extra durante o combate no castelo."
 
-#: ../fheroes2/castle/castle.cpp:559
 msgid ""
 "The Marketplace can be used to convert one type of resource into another. "
 "The more marketplaces you control, the better the exchange rate."
@@ -1084,7 +1288,6 @@ msgstr ""
 "O mercado pode ser usado para converter um tipo de recurso em outro. Quanto "
 "mais mercados você controla, melhor será a taxa de câmbio."
 
-#: ../fheroes2/castle/castle.cpp:560
 msgid ""
 "The Moat slows attacking units. Any unit entering the moat must end its turn "
 "there and becomes more vulnerable to attack."
@@ -1092,13 +1295,11 @@ msgstr ""
 "O Fosso retarda unidades de ataque. Qualquer unidade que entrar no fosso "
 "deve terminar seu turno lá e se torna mais vulnerável a ataques."
 
-#: ../fheroes2/castle/castle.cpp:561
 msgid ""
 "The Castle improves town defense and increases income to %{count} gold per "
 "day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:562
 msgid ""
 "The Tent provides workers to build a castle, provided the materials and the "
 "gold are available."
@@ -1106,7 +1307,6 @@ msgstr ""
 "A Tenda oferece aos trabalhadores construir um castelo, desde que os "
 "materiais eo ouro estejam disponíveis."
 
-#: ../fheroes2/castle/castle.cpp:563
 msgid ""
 "The Captain's Quarters provides a captain to assist in the castle's defense "
 "when no hero is present."
@@ -1114,39 +1314,31 @@ msgstr ""
 "O Quartel do Capitão fornece um capitão para ajudar na defesa do castelo, "
 "quando o herói não está presente."
 
-#: ../fheroes2/castle/castle.cpp:564
 msgid ""
 "The Mage Guild allows heroes to learn spells and replenish their spell "
 "points."
 msgstr ""
 "A Comporação de Magos permite heróis a aprender magia e reabastecer sua mana."
 
-#: ../fheroes2/castle/castle.cpp:567
 msgid "The Farm increases production of Peasants by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:568
 msgid "The Garbage Heap increases production of Goblins by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:569
 msgid ""
 "The Crystal Garden increases production of Sprites by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:570
 msgid "The Waterfall increases production of Centaurs by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:571
 msgid "The Orchard increases production of Halflings by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:572
 msgid "The Skull Pile increases production of Skeletons by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:575
 msgid ""
 "The Fortifications increase the toughness of the walls, increasing the "
 "number of turns it takes to knock them down."
@@ -1154,7 +1346,6 @@ msgstr ""
 "As Fortificações aumentar a resistência das paredes do castelo, aumentando o "
 "número de rodadas que leva para derrubá-los."
 
-#: ../fheroes2/castle/castle.cpp:576
 msgid ""
 "The Coliseum provides inspiring spectacles to defending troops, raising "
 "their morale by two during combat."
@@ -1162,16 +1353,13 @@ msgstr ""
 "O Coliseu oferece espetáculos inspiradores para as tropas de defesa do "
 "castelo, levantando sua moral por em 2 (dois) durante o combate."
 
-#: ../fheroes2/castle/castle.cpp:577
 msgid "The Rainbow increases the luck of the defending units by two."
 msgstr ""
 "O Arco-Íris aumenta a sorte das tropas de defesa do castelo em por 2 (dois)."
 
-#: ../fheroes2/castle/castle.cpp:578
 msgid "The Dungeon increases the income of the town by %{count} / day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:579
 msgid ""
 "The Library increases the number of spells in the Guild by one for each "
 "level of the guild."
@@ -1179,11 +1367,9 @@ msgstr ""
 "A Biblioteca aumenta o número de magias na Corporação dos Magos em um para "
 "cada nível."
 
-#: ../fheroes2/castle/castle.cpp:580
 msgid "The Storm adds +2 to the power of spells of a defending spell caster."
 msgstr "A Tempestade adiciona +2  ao Poder de Magia para defensor do castelo."
 
-#: ../fheroes2/castle/castle.cpp:582
 msgid ""
 "The Shrine increases the necromancy skill of all your necromancers by 10 "
 "percent."
@@ -1191,122 +1377,109 @@ msgstr ""
 "A Abside aumenta a habilidade de Necromancia  para todos os necromantes em "
 "10%."
 
-#: ../fheroes2/castle/castle.cpp:632
 #, fuzzy
 msgid "Cannot recruit - you already recruit hero in current week."
 msgstr "Impossível recrutar - você já possui um herói na cidade."
 
-#: ../fheroes2/castle/castle.cpp:645
 #, fuzzy
 msgid "Cannot recruit - guest to guard automove error."
 msgstr "Impossível recrutar - você tem muitos heróis."
 
-#: ../fheroes2/castle/castle.cpp:651
 msgid "Cannot recruit - you already have a Hero in this town."
 msgstr "Impossível recrutar - você já possui um herói na cidade."
 
-#: ../fheroes2/castle/castle.cpp:659
 msgid "Cannot recruit - you have too many Heroes."
 msgstr "Impossível recrutar - você tem muitos heróis."
 
-#: ../fheroes2/castle/castle.cpp:665
 msgid "Cannot afford a Hero"
 msgstr "Não pôde arcar com a despesa do herói"
 
-#: ../fheroes2/castle/castle.cpp:756
 msgid "There is no room in the garrison for this army."
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:272
+msgid "Recruit %{name}"
+msgstr "Recruta %{name}"
+
 msgid "Month: %{month}, Week: %{week}, Day: %{day}"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:393
-#: ../fheroes2/castle/castle_dialog.cpp:396
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:387
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:186
-msgid "Income:"
+#, fuzzy
+msgid "Income"
 msgstr "Renda:"
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 msgid "Join Error"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 msgid "Army is full"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
+msgid ""
+"You must purchase a spell book to use the mage guild, but you currently have "
+"no room for a spell book. Try giving one of your artifacts to another hero."
+msgstr ""
+
 msgid "Town"
 msgstr "Cidade"
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
 msgid "This town may not be upgraded to a castle."
 msgstr "Esta cidade não pode ser transformada em castelo."
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit castle"
+#, fuzzy
+msgid "Exit Castle"
 msgstr "Sair do Castelo"
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit town"
+#, fuzzy
+msgid "Exit Town"
 msgstr "Sair da Cidade"
 
-#: ../fheroes2/castle/castle_dialog.cpp:730
-msgid "Show income"
-msgstr ""
+#, fuzzy
+msgid "Show Income"
+msgstr "Renda:"
 
-#: ../fheroes2/castle/castle_dialog.cpp:734
 msgid "Show previous town"
 msgstr "Mostrar cidade anterior"
 
-#: ../fheroes2/castle/castle_dialog.cpp:738
 msgid "Show next town"
 msgstr "Mostrar proxima cidade"
 
-#: ../fheroes2/castle/castle_dialog.cpp:741
 #, fuzzy
 msgid "Swap Heroes"
 msgstr "Heróis"
 
-#: ../fheroes2/castle/castle_dialog.cpp:744
 #, fuzzy
 msgid "Meeting Heroes"
 msgstr "Proximo Herói"
 
-#: ../fheroes2/castle/castle_dialog.cpp:749
 msgid "View Hero"
 msgstr "Ver Herói"
 
-#: ../fheroes2/castle/castle_mageguild.cpp:150
+#, fuzzy
+msgid "The above spells are available here."
+msgstr "As magias acima foram adicionadas ao seu livro de magias."
+
 msgid "The above spells have been added to your book."
 msgstr "As magias acima foram adicionadas ao seu livro de magias."
 
-#: ../fheroes2/castle/castle_tavern.cpp:39
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:748
 msgid "A generous tip for the barkeep yields the following rumor:"
 msgstr "A gorjeta generosa para o barman rende o boato que se segue:"
 
-#: ../fheroes2/castle/castle_town.cpp:54
 msgid "Recruit Hero"
 msgstr "Recrutar Herói"
 
-#: ../fheroes2/castle/castle_town.cpp:59
-msgid "%{name} is a level %{value} %{race}"
+#, fuzzy
+msgid "%{name} is a level %{value} %{race} "
+msgstr "%{name} a %{race}"
+
+msgid "with %{count} artifacts."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with %{count} artifacts"
+#, fuzzy
+msgid "with 1 artifact."
+msgstr "Não é possível mover o último exército à fortaleza"
+
+msgid "without artifacts."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with one artifact"
-msgstr ""
-
-#: ../fheroes2/castle/castle_town.cpp:283
-#: ../fheroes2/heroes/heroes_dialog.cpp:108
 msgid ""
 "'Spread' combat formation spreads your armies from the top to the bottom of "
 "the battlefield, with at least one empty space between each army."
@@ -1315,7 +1488,6 @@ msgstr ""
 "ao fundo do campo de batalha, com pelo menos um espaço vazio entre cada "
 "exército."
 
-#: ../fheroes2/castle/castle_town.cpp:284
 msgid ""
 "'Grouped' combat formation bunches your army toget her in the center of your "
 "side of the battlefield."
@@ -1323,102 +1495,80 @@ msgstr ""
 "Formação de combate \"Agrupada\" seu exército fica junto no centro da linha "
 "inicial do campo de batalha."
 
-#: ../fheroes2/castle/castle_town.cpp:292
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:132
-#: ../fheroes2/heroes/heroes_meeting.cpp:284
 msgid "Attack Skill"
 msgstr "Habilidade de Ataque"
 
-#: ../fheroes2/castle/castle_town.cpp:301
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:137
-#: ../fheroes2/heroes/heroes_meeting.cpp:288
 msgid "Defense Skill"
 msgstr "Habilidade de Defesa"
 
-#: ../fheroes2/castle/castle_town.cpp:487
-#: ../fheroes2/heroes/heroes_dialog.cpp:334
 msgid "Spread Formation"
 msgstr "Formação Espalhada"
 
-#: ../fheroes2/castle/castle_town.cpp:489
-#: ../fheroes2/heroes/heroes_dialog.cpp:337
 msgid "Grouped Formation"
 msgstr "Formação Agrupada"
 
-#: ../fheroes2/castle/castle_town.cpp:540
-#: ../fheroes2/castle/castle_town.cpp:553
 msgid "Recruit %{name} the %{race}"
 msgstr "Recrutar %{name} da raça %{race}"
 
-#: ../fheroes2/castle/castle_town.cpp:561
 msgid "Set garrison combat formation to 'Spread'"
 msgstr "Definir formação de combate na Fortaleza para \"Espalhada\""
 
-#: ../fheroes2/castle/castle_town.cpp:564
 msgid "Set garrison combat formation to 'Grouped'"
 msgstr "Definir formação de combate na Fortaleza para \"Agrupada\""
 
-#: ../fheroes2/castle/castle_town.cpp:567
+#, fuzzy
+msgid "Exit Castle Options"
+msgstr "Opções do Castelo"
+
 msgid "Castle Options"
 msgstr "Opções do Castelo"
 
-#: ../fheroes2/castle/castle_well.cpp:158
+msgid "Not enough resources to buy monsters."
+msgstr ""
+
+msgid "No monsters available for purchase."
+msgstr ""
+
 #, fuzzy
-msgid "Buy Monsters:"
+msgid "Buy Monsters"
 msgstr "Melhor Criatura:"
 
-#: ../fheroes2/castle/castle_well.cpp:221
 msgid "Town Population Information and Statistics"
 msgstr "Informações da População da Cidade e Estatísticas"
 
-#: ../fheroes2/castle/castle_well.cpp:323
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:231
 msgid "Damage"
 msgstr "Dano"
 
-#: ../fheroes2/castle/castle_well.cpp:329
 msgid "HP"
 msgstr "HP"
 
-#: ../fheroes2/castle/castle_well.cpp:335
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:266
-msgid "Speed"
-msgstr "Veloc."
-
-#: ../fheroes2/castle/castle_well.cpp:351
 msgid "Growth"
 msgstr "Produção"
 
-#: ../fheroes2/castle/castle_well.cpp:355
 msgid "week"
 msgstr "semana"
 
-#: ../fheroes2/castle/castle_well.cpp:361
-#: ../fheroes2/kingdom/kingdom_overview.cpp:479
 msgid "Available"
 msgstr "Disponível"
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:89
 msgid "View the entire world."
 msgstr "Ver o mundo inteiro."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:90
 msgid "View the obelisk puzzle."
 msgstr "Ver enigma do obelisco."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:91
 msgid "View information on the scenario you are currently playing."
 msgstr "Veja informações sobre o cenário que você está jogando atualmente."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:92
 msgid "Dig for the Ultimate Artifact."
 msgstr "Escavar em busca do Artefato Supremo."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:93
 msgid "Exit this menu without doing anything."
 msgstr "Sair do menu sem fazer nada."
 
-#: ../fheroes2/dialog/dialog_arena.cpp:48
+msgid "Arena"
+msgstr ""
+
 msgid ""
 "You enter the arena and face a pack of vicious lions. You handily defeat "
 "them, to the wild cheers of the crowd.  Impressed by your skill, the aged "
@@ -1429,42 +1579,40 @@ msgstr ""
 "habilidade, o velho treinador de gladiadores concorda em treiná-lo em uma "
 "habilidade de sua escolha."
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:154
-msgid ""
-"Your troops can be upgraded, but it will cost you %{ratio} times the "
-"difference in cost for each troop, rounded up to next highest number. Do you "
-"wish to upgrade them?"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:155
 msgid ""
 "Your troops can be upgraded, but it will cost you dearly. Do you wish to "
 "upgrade them?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:166
 msgid "Are you sure you want to dismiss this army?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots Left"
 msgstr "Tiros restantes"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:244
 msgid "Hit Points"
 msgstr "HP"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:255
 msgid "Hit Points Left"
 msgstr "HP restantes"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:379
+#, fuzzy
+msgid "Followers"
+msgstr "Poder de Magia"
+
 msgid ""
-"The creature is swayed by your diplomatic tongue, and offers to join your "
+"A group of %{monster} with a desire for greater glory wish to join you.\n"
+"Do you accept?"
+msgstr ""
+"Um grupo de %{monster} que procura uma grande gloria quer se juntar a você.\n"
+"Você aceita?"
+
+#, fuzzy
+msgid ""
+"The %{monster} is swayed by your diplomatic tongue, and offers to join your "
 "army for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
@@ -1472,7 +1620,6 @@ msgstr ""
 "participar do seu exército pela soma de %{gold} de outro.\n"
 "Você aceita?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:382
 msgid ""
 "The creatures are swayed by your diplomatic\n"
 "tongue, and make you an offer:\n"
@@ -1482,7 +1629,6 @@ msgstr ""
 "e fazer-lhe uma oferta:\n"
 " \n"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:385
 msgid ""
 "%{offer} of the %{total} %{monster} will join your army, and the rest will "
 "leave you alone, for the sum of %{gold} gold.\n"
@@ -1492,39 +1638,58 @@ msgstr ""
 "deixá-lo sozinho,pela soma de %{gold} gold.\n"
 "Você aceita?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:387
 msgid ""
 "All %{offer} of the %{monster} will join your army for the sum of %{gold} "
 "gold.\n"
 "Do you accept?"
 msgstr ""
-"Todos %{offer} dos %{monster} vão se juntar ao seu exértico pela soma de %"
-"{gold} ouro.\n"
+"Todos %{offer} dos %{monster} vão se juntar ao seu exértico pela soma de "
+"%{gold} ouro.\n"
 "Você Aceita?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:401
 msgid "(Rate: %{percent})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:451
-msgid ""
-"Not room in\n"
-"the garrison"
+msgid "No room in"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:48
+msgid "the garrison"
+msgstr ""
+
 msgid "Build a new ship:"
 msgstr "Construir um novo banrco:"
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:63
 msgid "Resource cost:"
 msgstr "Custo de recursos:"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:40
-msgid "For the QVGA version is not available."
-msgstr "Para a versão QVGA não está disponível."
+msgid "Load Game"
+msgstr "Carregar Jogo"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:62
+msgid "No save files to load."
+msgstr ""
+
+msgid "New Game"
+msgstr "Novo Jogo"
+
+msgid "Start a single or multi-player game."
+msgstr "Iniciar um jogo em modo sozinho ou multi-jogadores."
+
+msgid "Load a previously saved game."
+msgstr "Carregar um jogo salvo anteriormente."
+
+#, fuzzy
+msgid "Save Game"
+msgstr "Novo Jogo"
+
+msgid "Save the current game."
+msgstr ""
+
+msgid "Quit"
+msgstr "Sair"
+
+msgid "Quit out of Free Heroes of Might and Magic II."
+msgstr ""
+
 msgid ""
 "Map\n"
 "Difficulty"
@@ -1533,7 +1698,6 @@ msgstr ""
 "do\n"
 "Mapa"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:65
 msgid ""
 "Game\n"
 "Difficulty"
@@ -1542,25 +1706,18 @@ msgstr ""
 "do\n"
 "Jogo"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:68
 msgid "Rating"
 msgstr "Grau"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:71
 msgid "Map Size"
 msgstr "Tamano do Mapa"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:89
-#: ../fheroes2/system/players.cpp:691
 msgid "Opponents"
 msgstr "Oponentes"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:92
-#: ../fheroes2/system/players.cpp:695
 msgid "Class"
 msgstr "Classes"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:100
 msgid ""
 "Victory\n"
 "Conditions"
@@ -1569,7 +1726,6 @@ msgstr ""
 "de\n"
 "Vitória"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:106
 msgid ""
 "Loss\n"
 "Conditions"
@@ -1578,48 +1734,33 @@ msgstr ""
 "de\n"
 "Derrota"
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:167
 msgid "You cannot select %{resource}!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:173
 msgid "Select count %{resource}:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:200
 msgid "Set Guardian"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:236
-#: ../fheroes2/dialog/dialog_guardian.cpp:292
 msgid "Your army too big!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:34
-#: ../fheroes2/dialog/dialog_levelup.cpp:44
-#: ../fheroes2/dialog/dialog_levelup.cpp:73
 msgid "%{name} has gained a level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:36
-#: ../fheroes2/dialog/dialog_levelup.cpp:46
-#: ../fheroes2/dialog/dialog_levelup.cpp:75
-msgid "%{skill} Skill +1"
+msgid "%{skill} +1"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:51
 msgid "You have learned %{skill}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:93
 msgid "You may learn either:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:96
 msgid "or"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:66
 msgid ""
 "Please inspect our fine wares. If you feel like offering a trade, click on "
 "the items you wish to trade with and for."
@@ -1627,7 +1768,6 @@ msgstr ""
 "Por favor consultar nossas mercadorias. Se você se sentir a vontade com a "
 "oferta, clique sobre os itens que você deseja negociar."
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:104
 msgid ""
 "You have received quite a bargain. I expect to make no profit on the deal. "
 "Can I interest you in any of my other wares?"
@@ -1635,616 +1775,499 @@ msgstr ""
 "Você recebeu uma real pechincha. Eu espero não fazer nenhum lucro na "
 "transação. Interessa em quaisquer das minhas outras mercadorias?"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:130
 msgid "I can offer you %{count} for 1 unit of %{resfrom}."
 msgstr "Eu posso oferecer à você %{count} por 1 unidade de %{resfrom}."
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:136
 msgid "I can offer you 1 unit of %{resto} for %{count} units of %{resfrom}."
 msgstr ""
-"Eu posso oferecer a você 1 unidade de %{resto} por %{count} unidade de %"
-"{resfrom}."
+"Eu posso oferecer a você 1 unidade de %{resto} por %{count} unidade de "
+"%{resfrom}."
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:164
 msgid "Qty to trade"
 msgstr "Qtd a trocar"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:235
+msgid "Trading Post"
+msgstr ""
+
 msgid "Your Resources"
 msgstr "Seus Recursos"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:257
 msgid "Available Trades"
 msgstr "Trocas Disponíveis"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:573
 msgid "n/a"
 msgstr "n/d"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:77
-msgid "guarded by %{count} of %{monster}"
+msgid "guarded by %{count} %{monster}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:149
 msgid "(available: %{count})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:181
 msgid "already learned"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:205
 msgid "already knows this skill"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:212
 msgid "already has max skills"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:260
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:276
 msgid "(already visited)"
 msgstr "(Já Visitado)"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
 msgid "(not visited)"
 msgstr "(Sem Visita)"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:296
+#, fuzzy
+msgid "Road"
+msgstr "Modo Estrada"
+
+msgid "(digging ok)"
+msgstr ""
+
+msgid "(no digging)"
+msgstr ""
+
 msgid "penalty: %{cost}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:382
-msgid "Unchartered Territory"
+#, fuzzy
+msgid "Uncharted Territory"
 msgstr "Território sem Lei"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:635
 msgid "Defenders:"
 msgstr "Defensores:"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:674
-#: ../fheroes2/heroes/heroes_indicator.cpp:125
-#: ../fheroes2/heroes/heroes_indicator.cpp:171
 msgid "None"
 msgstr "Nenhum"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:756
+msgid "Unknown"
+msgstr ""
+
 #, fuzzy
-msgid "%{name} ( Level %{level} )"
+msgid "%{name} (Level %{level})"
 msgstr "%{name} a %{race}"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:884
 #, fuzzy
 msgid "Move Points"
 msgstr "Mana"
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:40
-#: ../fheroes2/dialog/dialog_recrut.cpp:579
 msgid "Available: %{count}"
 msgstr "Disponível: %{count}"
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:101
-msgid "Cost per troop:"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:107
-#: ../fheroes2/dialog/dialog_recrut.cpp:506
-msgid "Recruit %{name}"
-msgstr "Recruta %{name}"
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:210
 msgid "Number to buy:"
 msgstr "Qtd. à Comprar:"
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:314
 msgid "How many troops to move?"
 msgstr "Mover quantas tropas?"
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:358
 msgid "Fast separation into slots:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:180
 msgid "File to Save:"
 msgstr "Arquivo a Salvar:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:186
 msgid "File to Load:"
 msgstr "Arquivo a Carregar:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:302
 msgid "Are you sure you want to delete file:"
 msgstr "Você tem certeza que quer deletar este arquivo:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:305
 msgid "Warning!"
 msgstr "Aviso!"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:144
-msgid "Maps Difficulty:"
+#, fuzzy
+msgid "Map difficulty:"
 msgstr "Dificuldade do Mapa:"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
+msgid "No maps exist at that size"
+msgstr ""
+
 msgid "Small Maps"
 msgstr "Mapa Pequena"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
-msgid "View only maps of size small (36x36)."
+#, fuzzy
+msgid "View only maps of size small (36 x 36)."
 msgstr "Ver apenas mapas pequenos (36x36)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
 msgid "Medium Maps"
 msgstr "Mapas medios"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
-msgid "View only maps of size medium (72x72)."
+#, fuzzy
+msgid "View only maps of size medium (72 x 72)."
 msgstr "Ver apenas mapas medios (72x72)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
 msgid "Large Maps"
 msgstr "Mapas Grandes"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
-msgid "View only maps of size large (108x108)."
+#, fuzzy
+msgid "View only maps of size large (108 x 108)."
 msgstr "Ver apenas mapas grandes (108x108)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
 msgid "Extra Large Maps"
 msgstr "Mapas Muito Grades"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
-msgid "View only maps of size extra large (144x144)."
+#, fuzzy
+msgid "View only maps of size extra large (144 x 144)."
 msgstr "Ver Apenas mapas muito grandes (144x144)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "All Maps"
 msgstr "Todos os Mapas"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "View all maps, regardless of size."
 msgstr "Ver todos os mapas, independente do tamanho."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
 msgid "Players Icon"
 msgstr "Ícone de Jogadores"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
+#, fuzzy
 msgid ""
-"Indicates how many players total are in the EditScenario. Any positions not "
+"Indicates how many players total are in the scenario. Any positions not "
 "occupied by humans will be occupied by computer players."
 msgstr ""
 "Indica o total de jogadores que esta definido no Editor do Cenário. Todas as "
 "posições não ocupadas por seres humanos serão ocupadas por jogadores de "
 "computador."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
 msgid "Size Icon"
 msgstr "Ícone de Tamanho"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
+#, fuzzy
 msgid ""
-"Indicates whether the maps is small (36x36), medium (72x72), large "
-"(108x108), or extra large (144x144)."
+"Indicates whether the map\n"
+"is small (36 x 36), medium\n"
+"(72 x 72), large (108 x 108),\n"
+"or extra large (144 x 144)."
 msgstr ""
 "Indica se os mapas é pequeno (36x36), médio (72x72), grande (108x108) ou "
 "muito grande (144x144)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "Selected Name"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "The name of the currently selected map."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid "Selected Map Difficulty"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid ""
 "The map difficulty of the currently selected map.  The map difficulty is "
-"determined by the EditScenario designer. More difficult maps might include "
-"more or stronger enemies, fewer resources, or other special conditions "
-"making things tougher for the human player."
+"determined by the scenario designer. More difficult maps might include more "
+"or stronger enemies, fewer resources, or other special conditions making "
+"things tougher for the human player."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "Selected Description"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "The description of the currently selected map."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
-msgid "OK"
-msgstr "OK"
+msgid "Okay"
+msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
 msgid "Accept the choice made."
 msgstr "Aceitar a escolha feita."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:364
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose all your heroes and towns."
 msgstr "Perder todos os seus heróis e das cidades."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:365
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific town."
 msgstr "Perder uma cidade específica."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:366
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific hero."
 msgstr "Perder um herói específico."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:367
 msgid "Run out of time. Fail to win by a certain point."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:370
 msgid "Loss Condition"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:379
 msgid "Defeat all enemy heroes and towns."
 msgstr "Derrotar todos os heróis inimigos e cidades."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:380
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Capture a specific town."
 msgstr "Captura de uma cidade específica."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:381
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat a specific hero."
 msgstr "Derrotar um herói específico."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:382
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Find a specific artifact."
 msgstr "Encontre um artefato específico."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:383
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Your side defeats the opposing side."
 msgstr "Seu lado derrota o lado oposto."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:384
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Accumulate a large amount of gold."
 msgstr "Acumular uma grande quantidade de ouro."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:387
 msgid "Victory Condition"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:48
-#: ../fheroes2/heroes/heroes_action.cpp:134
 msgid "one"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:51
-#: ../fheroes2/heroes/heroes_action.cpp:135
 msgid "two"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:187
-msgid "sound"
-msgstr "som"
-
-#: ../fheroes2/dialog/dialog_system.cpp:192
-#: ../fheroes2/dialog/dialog_system.cpp:205
-#: ../fheroes2/dialog/dialog_system.cpp:228
-#: ../fheroes2/dialog/dialog_system.cpp:242
-msgid "off"
-msgstr "off"
-
-#: ../fheroes2/dialog/dialog_system.cpp:200
-msgid "music"
+#, fuzzy
+msgid "Music"
 msgstr "música"
 
-#: ../fheroes2/dialog/dialog_system.cpp:223
-msgid "hero speed"
+msgid "Toggle ambient music level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:237
+msgid "Effects"
+msgstr ""
+
+msgid "Toggle foreground sounds level."
+msgstr ""
+
+msgid "Music Type"
+msgstr ""
+
+msgid "Change the type of music."
+msgstr ""
+
 #, fuzzy
-msgid "ai speed"
+msgid "Hero Speed"
 msgstr "Veloc."
 
-#: ../fheroes2/dialog/dialog_system.cpp:251
-msgid "scroll speed"
+msgid "Change the speed at which your heroes move on the main screen."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:262
-#: ../fheroes2/dialog/dialog_system.cpp:276
+#, fuzzy
+msgid "Enemy Speed"
+msgstr "Veloc."
+
+msgid ""
+"Sets the speed that A.I. heroes move at.  You can also elect not to view A."
+"I. movement at all."
+msgstr ""
+
+msgid "Scroll Speed"
+msgstr ""
+
+msgid "Sets the speed at which you scroll the window."
+msgstr ""
+
+#, fuzzy
+msgid "Interface Type"
+msgstr "Aparência"
+
+msgid "Toggle the type of interface you want to use."
+msgstr ""
+
 msgid "Interface"
 msgstr "Aparência"
 
-#: ../fheroes2/dialog/dialog_system.cpp:265
+msgid "Toggle interface visibility."
+msgstr ""
+
+msgid "Battles"
+msgstr ""
+
+msgid "Toggle instant battle mode."
+msgstr ""
+
+msgid "OK"
+msgstr "OK"
+
+#, fuzzy
+msgid "Exit this menu."
+msgstr "Passar a vez desta criatura"
+
+msgid "off"
+msgstr "off"
+
+msgid "MIDI"
+msgstr ""
+
+#, fuzzy
+msgid "MIDI Expansion"
+msgstr "Mansão"
+
+msgid "CD Stereo"
+msgstr ""
+
+msgid "External"
+msgstr ""
+
+msgid "Jump"
+msgstr ""
+
+msgid "Don't Show"
+msgstr ""
+
 msgid "Evil"
 msgstr "Mal"
 
-#: ../fheroes2/dialog/dialog_system.cpp:267
 msgid "Good"
 msgstr "Bom"
 
-#: ../fheroes2/dialog/dialog_system.cpp:281
 #, fuzzy
 msgid "Hide"
 msgstr "Ponte"
 
-#: ../fheroes2/dialog/dialog_system.cpp:287
 #, fuzzy
 msgid "Show"
 msgstr "Neve"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:285
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:96
+msgid "Auto Resolve"
+msgstr ""
+
+msgid "Auto, No Spells"
+msgstr ""
+
+msgid "Manual"
+msgstr ""
+
+msgid "Att."
+msgstr ""
+
+msgid "Def."
+msgstr ""
+
+msgid "Power"
+msgstr ""
+
+#, fuzzy
+msgid "Knowl"
+msgstr "Conhecimento"
+
+msgid "Human"
+msgstr ""
+
 msgid "1st"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:286
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:97
 msgid "2nd"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:98
 msgid "3rd"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:288
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:99
 msgid "4th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:289
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:100
 msgid "5th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:290
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:101
 msgid "6th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:305
-msgid "Thieves' Guild: Player RanKings"
+#, fuzzy
+msgid "Oracle: Player Rankings"
 msgstr "Guilda de Ladrões: Ranking de Jogadores"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:315
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:114
+#, fuzzy
+msgid "Thieves' Guild: Player Rankings"
+msgstr "Guilda de Ladrões: Ranking de Jogadores"
+
 msgid "Number of Towns:"
 msgstr "Numero de Cidades:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:324
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:123
 msgid "Number of Castles:"
 msgstr "Numero de Castelos:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:333
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:132
 msgid "Number of Heroes:"
 msgstr "Numero de Heróis:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:342
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:141
 msgid "Gold in Treasury:"
 msgstr "Ouro Total:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:351
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:150
 msgid "Wood & Ore:"
 msgstr "Madeira & Minério:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:360
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:159
 msgid "Gems, Cr, Slf & Mer:"
 msgstr "Gemas, Cri, Sulf & Mer:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:369
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:168
 msgid "Obelisks Found:"
 msgstr "Obeliscos encontrados:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:378
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:177
+#, fuzzy
+msgid "Artifacts:"
+msgstr "Artefato"
+
 msgid "Total Army Strength:"
 msgstr "Total Força de Exército:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:408
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:211
+msgid "Income:"
+msgstr "Renda:"
+
 msgid "Best Hero:"
 msgstr "Melhor Herói:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:417
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:220
 msgid "Best Hero Stats:"
 msgstr "Melhor Herói em Stats:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:426
 msgid "Personality:"
 msgstr "Personalidade:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:435
 msgid "Best Monster:"
 msgstr "Melhor Criatura:"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Easy"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Normal"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Hard"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Expert"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Impossible"
 msgstr ""
 
-#: ../fheroes2/game/game.cpp:314
-msgid "Maps Loading..."
+#, fuzzy
+msgid "Map is loading..."
 msgstr "Carregando Mapa..."
 
-#: ../fheroes2/game/game_highscores.cpp:239
-#: ../fheroes2/game/game_highscores.cpp:242
+msgid "and more..."
+msgstr ""
+
+msgid "Campaign Scenario loading failure"
+msgstr ""
+
+msgid "Please make sure that campaign files are correct and present."
+msgstr ""
+
 msgid "Unknown Hero"
 msgstr ""
 
-#: ../fheroes2/game/game_highscores.cpp:240
 msgid "Your Name"
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:95
-msgid "Are you sure you want to overwrite the save with this name?"
+msgid ""
+"Invalid file game type. Please ensure that you are running the latest type "
+"of save files."
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:191
 msgid ""
-"This file is saved in the \"Price Loyalty\" version.\n"
+"This file is saved in the \"The Price of Loyalty\" version.\n"
 "Some items may be unavailable."
 msgstr ""
 
-#: ../fheroes2/game/game_mainmenu.cpp:157
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:95
-msgid "Quit"
-msgstr "Sair"
-
-#: ../fheroes2/game/game_mainmenu.cpp:157
-msgid "Quit Heroes of Might and Magic and return to the operating system."
-msgstr "Sair do Jogo & retornar ao sistema operacional."
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:79
-msgid "Load Game"
-msgstr "Carregar Jogo"
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-msgid "Load a previously saved game."
-msgstr "Carregar um jogo salvo anteriormente."
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:91
-msgid "Credits"
-msgstr "Créditos"
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-msgid "View the credits screen."
-msgstr "Ver tela dos créditos."
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:87
-msgid "High Scores"
-msgstr "Recordes"
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-msgid "View the high score screen."
-msgstr "Ver a tela de Records."
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:75
-msgid "New Game"
-msgstr "Novo Jogo"
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-msgid "Start a single or multi-player game."
-msgstr "Iniciar um jogo em modo sozinho ou multi-jogadores."
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid "Host"
-msgstr "Host"
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid ""
-"The host sets up the game options. There can only be one host per network "
-"game."
-msgstr ""
-"O host configura as opções de jogo. Só pode haver um host por jogo em modo "
-"network."
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid "Guest"
-msgstr "Convidado"
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid ""
-"The guest waits for the host to set up the game, then is automatically added "
-"in. There can be multiple guests for TCP/IP games."
-msgstr ""
-"O convidado espera pelo host configurar o jogo, em seguida, é adicionado "
-"automaticamente dentro. Não pode haver vários convidados para  Jogos TCP/IP."
-
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-msgid "Cancel back to the main menu."
-msgstr "Cancelar e voltar para o menu principal."
-
-#: ../fheroes2/game/game_newgame.cpp:214
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:154
-msgid "Standard Game"
-msgstr "Unico Jogador"
-
-#: ../fheroes2/game/game_newgame.cpp:214
-msgid "A single player game playing out a single map."
-msgstr "Um jogo com um único jogador."
-
-#: ../fheroes2/game/game_newgame.cpp:216
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:162
-msgid "Multi-Player Game"
-msgstr "Mult-Jogadores"
-
-#: ../fheroes2/game/game_newgame.cpp:216
-msgid ""
-"A multi-player game, with several human players completing against each "
-"other on a single map."
-msgstr ""
-"Um jogo multi-jogador, com vários jogadores humanos completando uns contra "
-"os outros em um único mapa."
-
-#: ../fheroes2/game/game_newgame.cpp:217
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:83
-msgid "Settings"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:217
-msgid "FHeroes2 game settings."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:271
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:219
 msgid "Hot Seat"
 msgstr "Hot Seat"
 
-#: ../fheroes2/game/game_newgame.cpp:271
 msgid ""
 "Play a Hot Seat game, where 2 to 4 players play around the same computer, "
 "switching into the 'Hot Seat' when it is their turn."
 msgstr "Modo \"Hot Seat\", onde 2 a 4 jogadores jogam no mesmo computador."
 
-#: ../fheroes2/game/game_newgame.cpp:279
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:223
+msgid "Cancel back to the main menu."
+msgstr "Cancelar e voltar para o menu principal."
+
 msgid "Network"
 msgstr "Rede"
 
-#: ../fheroes2/game/game_newgame.cpp:279
 msgid ""
 "Play a network game, where 2 players use their own computers connected "
 "through a LAN (Local Area Network)."
@@ -2252,117 +2275,214 @@ msgstr ""
 "Jogue um jogo em rede, onde 2 jogadores usam seus próprios computadores "
 "conectados através de uma LAN (Local Area Network)."
 
-#: ../fheroes2/game/game_newgame.cpp:343
+msgid "Standard Game"
+msgstr "Unico Jogador"
+
+msgid "A single player game playing out a single map."
+msgstr "Um jogo com um único jogador."
+
+msgid "Campaign Game"
+msgstr "Campanha"
+
+msgid "A single player game playing through a series of maps."
+msgstr "Um único jogador jogando em uma série de mapas."
+
+msgid "Multi-Player Game"
+msgstr "Mult-Jogadores"
+
+msgid ""
+"A multi-player game, with several human players completing against each "
+"other on a single map."
+msgstr ""
+"Um jogo multi-jogador, com vários jogadores humanos completando uns contra "
+"os outros em um único mapa."
+
+msgid "Greetings!"
+msgstr ""
+
+msgid ""
+"Welcome to Free Heroes of Might and Magic II! Before starting the game "
+"please choose game resolution."
+msgstr ""
+
+msgid "Please Remember"
+msgstr ""
+
+msgid "You can always change game resolution by clicking on the "
+msgstr ""
+
+msgid "door"
+msgstr ""
+
+msgid ""
+" on the left side of main menu.\n"
+"\n"
+"To switch between windowed and full screen modes\n"
+"press "
+msgstr ""
+
+msgid "F4"
+msgstr ""
+
+msgid ""
+" key on the keyboard.\n"
+"\n"
+"Enjoy the game!"
+msgstr ""
+
+msgid "Quit Heroes of Might and Magic and return to the operating system."
+msgstr "Sair do Jogo & retornar ao sistema operacional."
+
+msgid "Credits"
+msgstr "Créditos"
+
+msgid "View the credits screen."
+msgstr "Ver tela dos créditos."
+
+msgid "High Scores"
+msgstr "Recordes"
+
+msgid "View the high score screen."
+msgstr "Ver a tela de Records."
+
+msgid "Select Game Resolution"
+msgstr ""
+
+msgid "Change resolution of the game."
+msgstr ""
+
+msgid "Original Campaign"
+msgstr ""
+
+msgid ""
+"Either Roland's or Archibald's campaign from the original Heroes of Might "
+"and Magic II."
+msgstr ""
+
+msgid "Expansion Campaign"
+msgstr ""
+
+msgid "One of the four new campaigns from the Price of Loyalty expansion set."
+msgstr ""
+
+msgid "Host"
+msgstr "Host"
+
+msgid ""
+"The host sets up the game options. There can only be one host per network "
+"game."
+msgstr ""
+"O host configura as opções de jogo. Só pode haver um host por jogo em modo "
+"network."
+
+msgid "Guest"
+msgstr "Convidado"
+
+msgid ""
+"The guest waits for the host to set up the game, then is automatically added "
+"in. There can be multiple guests for TCP/IP games."
+msgstr ""
+"O convidado espera pelo host configurar o jogo, em seguida, é adicionado "
+"automaticamente dentro. Não pode haver vários convidados para  Jogos TCP/IP."
+
+msgid "Battle Only"
+msgstr ""
+
+msgid "Setup and play a battle without loading any map."
+msgstr ""
+
+msgid "Settings"
+msgstr ""
+
+msgid "Experimental game settings."
+msgstr ""
+
 msgid "2 Players"
 msgstr "2 Jogadores"
 
-#: ../fheroes2/game/game_newgame.cpp:343
 msgid ""
 "Play with 2 human players, and optionally, up, to 4 additional computer "
 "players."
 msgstr "Jogue com 2 jogadores humanos, e, opcionalmente, até 4 jogadores."
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid "3 Players"
 msgstr "3 Jogadores"
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid ""
 "Play with 3 human players, and optionally, up, to 3 additional computer "
 "players."
 msgstr ""
 "Jogue com 3 jogadores humanos, e, opcionalmente, até 3 jogadores não humanos."
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid "4 Players"
 msgstr "4 Jogadores"
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid ""
 "Play with 4 human players, and optionally, up, to 2 additional computer "
 "players."
 msgstr ""
 "Jogue com 4 jogadores humanos, e, opcionalmente, até 2 jogadores não humanos."
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid "5 Players"
 msgstr "5 Jogadores"
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid ""
 "Play with 5 human players, and optionally, up, to 1 additional computer "
 "players."
 msgstr ""
 "Jogue com 5 jogadores humanos, e, opcionalmente, até 1 jogadores não humanos."
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "6 Players"
 msgstr "6 Jogadores"
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "Play with 6 human players."
 msgstr "Jogue com 6 jogadores humanos."
 
-#: ../fheroes2/game/game_over.cpp:37
 #, fuzzy
 msgid "Defeat all enemy heroes and capture all enemy towns and castles."
 msgstr "Derrotar todos os heróis inimigos e cidades."
 
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Run out of time. (Fail to win by a certain point.)"
 msgstr "Acabar o tempo. (Imposibilitado de vencer apartir de um certo ponto.)"
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the castle '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the town '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:83
 msgid "Defeat the hero '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:91
 msgid "Find the ultimate artifact"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:95
 msgid "Find the '%{name}' artifact"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:102
 msgid "Accumulate %{count} gold"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:106
 msgid ""
 ", or you may win by defeating all enemy heroes and capturing all enemy towns "
 "and castles."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the castle '%{name}'."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the town '%{name}'."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:126 ../fheroes2/game/game_over.cpp:145
 msgid "Lose the hero: %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:133
 msgid "Fail to win by the end of month %{month}, week %{week}, day %{day}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:145
 msgid "Lose the heroes: %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:167
 msgid ""
 "You captured %{name}!\n"
 "You are victorious."
@@ -2370,7 +2490,6 @@ msgstr ""
 "Você capturou %{name}!\n"
 "Você Venceu."
 
-#: ../fheroes2/game/game_over.cpp:175
 msgid ""
 "You have captured the enemy hero %{name}!\n"
 "Your quest is complete."
@@ -2378,7 +2497,6 @@ msgstr ""
 "Você capturou o herói inimigo %{name}!\n"
 "Missão Cumprida!"
 
-#: ../fheroes2/game/game_over.cpp:183
 msgid ""
 "You have found the %{name}.\n"
 "Your quest is complete."
@@ -2386,7 +2504,6 @@ msgstr ""
 "Você achou o %{name}.\n"
 "Missão Cumprida!"
 
-#: ../fheroes2/game/game_over.cpp:195
 msgid ""
 "The enemy is beaten.\n"
 "Your side has triumphed!"
@@ -2394,7 +2511,6 @@ msgstr ""
 "O inimigo foi derrotado.\n"
 "Seu lado triunfou!"
 
-#: ../fheroes2/game/game_over.cpp:200
 msgid ""
 "You have built up over %{count} gold in your treasury.\n"
 "All enemies bow before your wealth and power."
@@ -2402,7 +2518,6 @@ msgstr ""
 "Você tem acumulou o total %{count} de ouro.\n"
 "Todos os inimigos curvar-se diante de sua riqueza e poder."
 
-#: ../fheroes2/game/game_over.cpp:222
 msgid ""
 "The enemy has found the %{name}.\n"
 "Your quest is a failure."
@@ -2410,7 +2525,6 @@ msgstr ""
 "O inimigo achou o %{name}.\n"
 "Missão Falhada."
 
-#: ../fheroes2/game/game_over.cpp:230
 msgid ""
 "%{color} has fallen!\n"
 "All is lost."
@@ -2418,7 +2532,6 @@ msgstr ""
 "%{color} foi derrotado!\n"
 "Tudo está perdido."
 
-#: ../fheroes2/game/game_over.cpp:237
 msgid ""
 "The enemy has built up over %{count} gold in his treasury.\n"
 "You must bow done in defeat before his wealth and power."
@@ -2426,11 +2539,9 @@ msgstr ""
 "O inimigo acumulou o total de %{count} de ouro.\n"
 "Você curvou-se diante do seu poder e riqueza."
 
-#: ../fheroes2/game/game_over.cpp:243
 msgid "You have been eliminated from the game!!!"
 msgstr "Você foi eliminado do do jogo!"
 
-#: ../fheroes2/game/game_over.cpp:248
 msgid ""
 "The enemy has captured %{name}!\n"
 "They are triumphant."
@@ -2438,7 +2549,6 @@ msgstr ""
 "O inimigo capturou %{name}!\n"
 "Eles venceram o jogo."
 
-#: ../fheroes2/game/game_over.cpp:257 ../fheroes2/game/game_over.cpp:264
 msgid ""
 "You have lost the hero %{name}.\n"
 "Your quest is over."
@@ -2446,7 +2556,6 @@ msgstr ""
 "Você perdeu o herói %{name}.\n"
 "Sua Missão acabou."
 
-#: ../fheroes2/game/game_over.cpp:272
 msgid ""
 "You have failed to complete your quest in time.\n"
 "All is lost."
@@ -2454,33 +2563,25 @@ msgstr ""
 "Você não conseguiu concluir sua missão no tempo.\n"
 "Tudo está acabado."
 
-#: ../fheroes2/game/game_over.cpp:320
-msgid "%{color} has been vanquished!"
+#, fuzzy
+msgid "%{color} player has been vanquished!"
 msgstr "%{color} foi derrotado!"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "Warning"
 msgstr "Atenção"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "No maps available!"
 msgstr "Não há mapas disponíveis!"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Scenario"
 msgstr "Cenário"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Click here to select which scenario to play."
 msgstr "Clique aqui para selecionar o cenário a jogar."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid "Game Difficulty"
 msgstr "Dificuldade do Jogo"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid ""
 "This lets you change the starting difficulty at which you will play. Higher "
 "difficulty levels start you of with fewer resources, and at the higher "
@@ -2490,11 +2591,9 @@ msgstr ""
 "Quanto maior o nivel de dificuldade, menos recursos você começa, e da mais "
 "recursos ao computador."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid "Difficulty Rating"
 msgstr "Taxa de Dificuldade"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid ""
 "The difficulty rating reflects a combination of various settings for your "
 "game. This number will be applied to your final score."
@@ -2502,57 +2601,44 @@ msgstr ""
 "O grau de dificuldade reflete uma combinação de várias definições para o seu "
 "jogo. Este número será aplicado à sua pontuação final."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
 msgid "Click to accept these settings and start a new game."
 msgstr "Clique para aceitar estas configurações e começar um novo jogo."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
 msgid "Click to return to the main menu."
 msgstr "Clique para retornar ao menu principal."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:342
 msgid "Scenario:"
 msgstr "Cenário:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:350
 msgid "Game Difficulty:"
 msgstr "Dificuldade do Jogo:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:354
 msgid "Opponents:"
 msgstr "Oponentes:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:358
 msgid "Class:"
 msgstr "Classe:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:384
 msgid "Rating %{rating}%"
 msgstr "Taxa %{rating}%"
 
-#: ../fheroes2/game/game_startgame.cpp:226
 #, fuzzy
 msgid "Astrologers proclaim Month of the %{name}."
 msgstr "Astrólogos proclamar o mês do %{name}."
 
-#: ../fheroes2/game/game_startgame.cpp:226
 #, fuzzy
 msgid "Astrologers proclaim Week of the %{name}."
 msgstr "Astrólogos proclamar a semana do %{name}."
 
-#: ../fheroes2/game/game_startgame.cpp:240
 msgid "After regular growth, population of %{monster} is doubled!"
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:252
 msgid " All populations are halved."
 msgstr " Todas as população foi reduzidas a metade."
 
-#: ../fheroes2/game/game_startgame.cpp:254
 msgid " All dwellings increase population."
 msgstr " Todas as populações aumentaram nas habitações."
 
-#: ../fheroes2/game/game_startgame.cpp:283
 msgid ""
 "%{color} player, your heroes abandon you, and you are banished from this "
 "land."
@@ -2560,7 +2646,6 @@ msgstr ""
 "Jogador %{color}, seus heróis abandonaram você, e você foi banido de sua "
 "terra."
 
-#: ../fheroes2/game/game_startgame.cpp:290
 msgid ""
 "%{color} player, this is your last day to capture a town, or you will be "
 "banished from this land."
@@ -2568,7 +2653,6 @@ msgstr ""
 "Jogador %{color}, este é o último dia para capturar uma cidade, ou você será "
 "banido desta terra."
 
-#: ../fheroes2/game/game_startgame.cpp:295
 msgid ""
 "%{color} player, you only have %{day} days left to capture a town, or you "
 "will be banished from this land."
@@ -2576,11 +2660,10 @@ msgstr ""
 "Jogador %{color}, você tem somente %{day} dias para capturar uma cidade, ou "
 "você será banido desta terra."
 
-#: ../fheroes2/game/game_startgame.cpp:584
-msgid "%{color} player's turn"
+#, fuzzy
+msgid "%{color} player's turn."
 msgstr "Turno do jogador %{color}"
 
-#: ../fheroes2/game/game_startgame.cpp:995
 msgid ""
 "%{color} player, you have lost your last town. If you do not conquer another "
 "town in next week, you will be eliminated."
@@ -2588,141 +2671,117 @@ msgstr ""
 "%{color}, você perdeu sua última cidade. Se você não conquistar uma outra "
 "cidade na próxima semana, será eliminado."
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Next Hero"
 msgstr "Proximo Herói"
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Select the next Hero."
 msgstr "Selecione o proximo Herói"
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue Movement"
 msgstr "Continuar a Andar"
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue the Hero's movement along the current path."
 msgstr "Continue o movimento do herói ao longo do trajeto atual."
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "Kingdom Summary"
 msgstr "Resumo do Reino"
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "View a Summary of your Kingdom."
 msgstr "Ver o resumo de seu reino."
 
-#: ../fheroes2/gui/interface_buttons.cpp:189
 msgid "Cast an adventure spell."
 msgstr "Lançar uma magia."
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End Turn"
 msgstr "Terminar Turno"
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End your turn and left the computer take its turn."
 msgstr "Termina o seu turno."
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Adventure Options"
 msgstr "Opções de Aventura"
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Bring up the adventure options menu."
 msgstr "Traz a menu de opções da aventura."
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "File Options"
 msgstr "Opções de Arquivo"
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "Bring up the file options menu, alloving you to load menu, save etc."
 msgstr ""
 "Trazer o arquivo menu de opções, permitindo que você carregue menu, salvar "
 "etc"
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "System Options"
 msgstr "Opções do Sistema"
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "Bring up the system options menu, alloving you to customize your game."
 msgstr ""
 "Traz o sistema de menu de opções, permitindo você personalizar seu jogo."
 
-#: ../fheroes2/gui/interface_events.cpp:175
 msgid ""
 "One or more heroes may still move, are you sure you want to end your turn?"
 msgstr ""
 "Um ou mais heróis ainda pode andar, você tem certeza que quer terminar o seu "
 "turno?"
 
-#: ../fheroes2/gui/interface_events.cpp:212
-msgid "Are you sure you want to restart? (Your current game will be lost)"
-msgstr "Tem certeza que deseja reiniciar? (O jogo atual será perdido)"
-
-#: ../fheroes2/gui/interface_events.cpp:276
 msgid "Are you sure you want to quit?"
 msgstr "Você tem certeza que deseja sair?"
 
-#: ../fheroes2/gui/interface_events.cpp:308
+#, fuzzy
+msgid "Are you sure you want to restart? (Your current game will be lost.)"
+msgstr "Tem certeza que deseja reiniciar? (O jogo atual será perdido)"
+
+msgid "Are you sure you want to overwrite the save with this name?"
+msgstr ""
+
 msgid "Game saved successfully."
 msgstr "Jogo salvo com sucesso."
 
-#: ../fheroes2/gui/interface_events.cpp:314
+msgid "There was an issue during saving."
+msgstr ""
+
+#, fuzzy
 msgid ""
-"Are you sure you want to load a new game? (Your current game will be lost)"
+"Are you sure you want to load a new game? (Your current game will be lost.)"
 msgstr ""
 "Você tem certeza que quer carregar um novo jogo? (O jogo atual será perdido)"
 
-#: ../fheroes2/gui/interface_events.cpp:353
 msgid "Try looking on land!!!"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:368
 #, fuzzy
 msgid ""
-"After spending many hours digging here, you have uncovered the %{artifact}"
+"After spending many hours digging here, you have uncovered the %{artifact}."
 msgstr "Depois de passar muitas horas escavando aqui, você achou o "
 
-#: ../fheroes2/gui/interface_events.cpp:370
 msgid "Congratulations!"
 msgstr "Parabéns!"
 
-#: ../fheroes2/gui/interface_events.cpp:384
 msgid "Nothing here. Where could it be?"
 msgstr "Nada aqui. Onde poderia estar?"
 
-#: ../fheroes2/gui/interface_events.cpp:395
 msgid "Try searching on clear ground."
 msgstr "Tente achar no chão sem obstaculos."
 
-#: ../fheroes2/gui/interface_events.cpp:399
 msgid "Digging for artifacts requires a whole day, try again tomorrow."
 msgstr ""
 "Escavar em busca de artefatos requer um dia inteiro, tente novamente amanhã."
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "World Map"
 msgstr "Mapa-Múndi"
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "A miniature view of the known world. Left click to move viewing area."
 msgstr ""
 "Uma visão em miniatura do mundo conhecido. Clique o botao esquerdo para "
 "mover área de visualização."
 
-#: ../fheroes2/gui/interface_status.cpp:216
 msgid "Month: %{month} Week: %{week}"
 msgstr "Mês: %{month} Semana: %{week}"
 
-#: ../fheroes2/gui/interface_status.cpp:222
-#: ../fheroes2/kingdom/kingdom_overview.cpp:569
 msgid "Day: %{day}"
 msgstr "Dia: %{day}"
 
-#: ../fheroes2/gui/interface_status.cpp:257
 msgid ""
 "You find a small\n"
 "quantity of %{resource}."
@@ -2730,11 +2789,17 @@ msgstr ""
 "Você achou uma pequena\n"
 "quantidade de %{resource}."
 
-#: ../fheroes2/gui/interface_status.cpp:407
 msgid "Status Window"
 msgstr "Janela de Status"
 
-#: ../fheroes2/gui/interface_status.cpp:407
+#, fuzzy
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date."
+msgstr ""
+"Esta janela fornece informações sobre o status do seu herói ou reino, e "
+"mostra a data. Clique o botão esquerdo para alternar as janelas."
+
 msgid ""
 "This window provides information on the status of your hero or kingdom, and "
 "shows the date. Left click here to cycle throungh these windows."
@@ -2742,29 +2807,280 @@ msgstr ""
 "Esta janela fornece informações sobre o status do seu herói ou reino, e "
 "mostra a data. Clique o botão esquerdo para alternar as janelas."
 
-#: ../fheroes2/heroes/heroes_action.cpp:112
+msgid "Necroman"
+msgstr "Necromante:"
+
+msgid ""
+"This lets you change player starting positions and colors. A particular "
+"color will always start in a particular location. Some positions may only be "
+"played by a computer player or only by a human player."
+msgstr ""
+"Isso permite que você altere o jogador a partir de posições e cores. Uma cor "
+"especial começará sempre em um determinado local. Algumas posições só pode "
+"ser jogado por um computador ou apenas por um jogador humano."
+
+msgid ""
+"This lets you change the class of a player. Classes are not always "
+"changeable. Depending on the scenario, a player may receive additional towns "
+"and/or heroes not of their primary alignment."
+msgstr ""
+"Isso permite que você alterar a classe de um jogador. Classes não são sempre "
+"alteravel. Dependendo do cenário, um jogador não pode receber cidades "
+"adicionais e / ou heróis do seu alinhamento primário."
+
+#, fuzzy
+msgid "%{color} player"
+msgstr "Turno do jogador %{color}"
+
+msgid "View %{skill} Info"
+msgstr ""
+
+msgid "Lord Kilburn"
+msgstr ""
+
+msgid "Sir Gallant"
+msgstr ""
+
+msgid "Ector"
+msgstr ""
+
+msgid "Gwenneth"
+msgstr ""
+
+msgid "Tyro"
+msgstr ""
+
+msgid "Ambrose"
+msgstr ""
+
+msgid "Ruby"
+msgstr ""
+
+msgid "Maximus"
+msgstr ""
+
+msgid "Dimitry"
+msgstr ""
+
+msgid "Thundax"
+msgstr ""
+
+msgid "Fineous"
+msgstr ""
+
+msgid "Jojosh"
+msgstr ""
+
+msgid "Crag Hack"
+msgstr ""
+
+msgid "Jezebel"
+msgstr ""
+
+msgid "Jaclyn"
+msgstr ""
+
+msgid "Ergon"
+msgstr ""
+
+msgid "Tsabu"
+msgstr ""
+
+msgid "Atlas"
+msgstr ""
+
+msgid "Astra"
+msgstr ""
+
+msgid "Natasha"
+msgstr ""
+
+msgid "Troyan"
+msgstr ""
+
+msgid "Vatawna"
+msgstr ""
+
+msgid "Rebecca"
+msgstr ""
+
+msgid "Gem"
+msgstr ""
+
+msgid "Ariel"
+msgstr ""
+
+msgid "Carlawn"
+msgstr ""
+
+msgid "Luna"
+msgstr ""
+
+msgid "Arie"
+msgstr ""
+
+msgid "Alamar"
+msgstr ""
+
+msgid "Vesper"
+msgstr ""
+
+msgid "Crodo"
+msgstr ""
+
+msgid "Barok"
+msgstr ""
+
+msgid "Kastore"
+msgstr ""
+
+msgid "Agar"
+msgstr ""
+
+msgid "Falagar"
+msgstr ""
+
+msgid "Wrathmont"
+msgstr ""
+
+msgid "Myra"
+msgstr ""
+
+msgid "Flint"
+msgstr ""
+
+msgid "Dawn"
+msgstr ""
+
+msgid "Halon"
+msgstr ""
+
+msgid "Myrini"
+msgstr ""
+
+msgid "Wilfrey"
+msgstr ""
+
+msgid "Sarakin"
+msgstr ""
+
+msgid "Kalindra"
+msgstr ""
+
+msgid "Mandigal"
+msgstr ""
+
+msgid "Zom"
+msgstr ""
+
+msgid "Darlana"
+msgstr ""
+
+msgid "Zam"
+msgstr ""
+
+msgid "Ranloo"
+msgstr ""
+
+msgid "Charity"
+msgstr ""
+
+msgid "Rialdo"
+msgstr ""
+
+msgid "Roxana"
+msgstr ""
+
+msgid "Sandro"
+msgstr ""
+
+msgid "Celia"
+msgstr ""
+
+msgid "Roland"
+msgstr ""
+
+msgid "Lord Corlagon"
+msgstr ""
+
+msgid "Sister Eliza"
+msgstr ""
+
+msgid "Archibald"
+msgstr ""
+
+msgid "Lord Halton"
+msgstr ""
+
+msgid "Brother Brax"
+msgstr ""
+
+msgid "Solmyr"
+msgstr ""
+
+msgid "Dainwin"
+msgstr ""
+
+msgid "Mog"
+msgstr ""
+
+msgid "Joseph"
+msgstr ""
+
+msgid "Gallavant"
+msgstr ""
+
+msgid "Elderian"
+msgstr ""
+
+msgid "Ceallach"
+msgstr ""
+
+msgid "Drakonia"
+msgstr ""
+
+msgid "Martine"
+msgstr ""
+
+msgid "Jarkonas"
+msgstr ""
+
+msgid "%{object} robber"
+msgstr ""
+
+msgid "%{object} raided"
+msgstr ""
+
+msgid "You cannot pick up this artifact, you already have a full load!"
+msgstr ""
+
+msgid "The three Anduran artifacts magically combine into one."
+msgstr ""
+
+msgid "To cast spells, you must first buy a spell book for %{gold} gold."
+msgstr ""
+
+msgid "Unfortunately, you seem to be a little short of cash at the moment."
+msgstr ""
+
+msgid "Do you wish to buy one?"
+msgstr ""
+
 msgid "%{count} / day"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:331
-#: ../fheroes2/heroes/heroes_action.cpp:2199
 msgid "You are unable to recruit at this time, your ranks are full."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:599
-msgid ""
-"A group of %{monster} with a desire for greater glory wish to join you.\n"
-"Do you accept?"
+msgid "A whirlpool engulfs your ship."
 msgstr ""
-"Um grupo de %{monster} que procura uma grande gloria quer se juntar a você.\n"
-"Você aceita?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:609
-#: ../fheroes2/heroes/heroes_action.cpp:630
+msgid "Some of your army has fallen overboard."
+msgstr ""
+
 msgid "Insulted by your refusal of their offer, the monsters attack!"
 msgstr "Insultado pela sua recusa da oferta, as criaturas atacam!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:638
 msgid ""
 "The %{monster}, awed by the power of your forces, begin to scatter.\n"
 "Do you wish to pursue and engage them?"
@@ -2772,13 +3088,11 @@ msgstr ""
 "O %{monster}, impressionado com o poder de suas forças, começam a fugir.\n"
 "Deseja prosseguir e ataca-los?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:934
 msgid "Ransacking an enemy camp, you discover a hidden cache of treasures."
 msgstr ""
 "Saqueando um campo inimigo, você descobre um esconderijo de tesouros "
 "escondidos."
 
-#: ../fheroes2/heroes/heroes_action.cpp:966
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with these resources, "
@@ -2788,7 +3102,6 @@ msgstr ""
 "\"Milord, tenho trabalhado muito duro para lhe fornecer esses recursos, "
 "volte na próxima semana para receber mais.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:967
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there are no resources currently available. Please try "
@@ -2798,7 +3111,6 @@ msgstr ""
 "\"Milord, lamento, não há recursos disponíveis no momento. Por favor, tente "
 "novamente na próxima semana.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:972
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with this gold, come "
@@ -2808,7 +3120,6 @@ msgstr ""
 "\"Milord, tenho estado a trabalhar arduamente para lhe proporcionar este "
 "ouro, volte na próxima semana para receber mais.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:973
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there is no gold currently available. Please try again "
@@ -2818,17 +3129,14 @@ msgstr ""
 "\"Milord, lamento, não há ouro atualmente disponível. Por favor, tente "
 "novamente na próxima semana.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:979
 msgid ""
 "You've found an abandoned lean-to.\n"
 "Poking about, you discover some resources hidden nearby."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:980
 msgid "The lean-to is long abandoned. There is nothing of value here."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:985
 msgid ""
 "You catch a leprechaun foolishly sleeping amidst a cluster of magic "
 "mushrooms.\n"
@@ -2836,38 +3144,32 @@ msgid ""
 "precious things."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:986
 msgid ""
 "You've found a magic garden, the kind of place that leprechauns and faeries "
 "like to cavort in, but there is no one here today.\n"
 "Perhaps you should try again next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1023
 #, fuzzy
 msgid "You come upon the remains of an unfortunate adventurer."
 msgstr ""
 "Você vai sobre os restos de um aventureiro infeliz.\n"
 "Olhando através da roupa esfarrapada, você encontra nada."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1034
 #, fuzzy
 msgid "Treasure"
 msgstr "Tesouros"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1041
 #, fuzzy
 msgid "Searching through the tattered clothing, you find %{artifact}."
 msgstr ""
 "Você vai sobre os restos de um aventureiro infeliz.\n"
 "Olhando através da roupa esfarrapada, você encontra um artefato %{artifact}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1052
 #, fuzzy
 msgid "Searching through the tattered clothing, you find nothing."
 msgstr "Você procura através dos destroços, mas não acha nada."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1064
 #, fuzzy
 msgid ""
 "You come across an old wagon left by a trader who didn't quite make it to "
@@ -2877,8 +3179,6 @@ msgstr ""
 "chegou a um lugar seguro.\n"
 "Olhando dentro, você encontra o artefato %{artifact}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1075
-#: ../fheroes2/heroes/heroes_action.cpp:1103
 #, fuzzy
 msgid "Unfortunately, others have found it first, and the wagon is empty."
 msgstr ""
@@ -2886,62 +3186,51 @@ msgstr ""
 "chegou a um lugar seguro.\n"
 "Infelismente, outros acharam isso primeiro. A carroça está vazia."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1082
 msgid "Searching inside, you find the %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1093
 msgid "Inside, you find some of the wagon's cargo still intact."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1123
 msgid "You search through the flotsam, and find some wood and some gold."
 msgstr ""
 "Você procura através dos destroços, e encontrar um pouco de madeira e um "
 "pouco de ouro."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1124
 msgid "You search through the flotsam, and find some wood."
 msgstr "Você procura através dos destroços, e encontrar um pouco de madeira."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1130
 msgid "You search through the flotsam, but find nothing."
 msgstr "Você procura através dos destroços, mas não acha nada."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1151
 msgid "Shrine of the 1st Circle"
 msgstr "Abside no Primeiro Ciclo."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1152
 msgid ""
 "You come across a small shrine attended by a group of novice acolytes.\n"
-"In exchange for your protection, they agree to teach you a simple spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a simple spell - "
+"'%{spell}'."
 msgstr ""
 "Você se deparar com um pequeno santuário com a participação de um grupo de "
 "noviços acólitos.\n"
-"Em troca de proteção, eles concordam em ensinar-lhe uma magia simples - '%"
-"{spell}'."
+"Em troca de proteção, eles concordam em ensinar-lhe uma magia simples - "
+"'%{spell}'."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1155
 msgid "Shrine of the 2nd Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1156
 msgid ""
 "You come across an ornate shrine attended by a group of rotund friars.\n"
-"In exchange for your protection, they agree to teach you a spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a spell - "
+"'%{spell}'."
 msgstr ""
 "Você se deparar com um santuário ornamentado com a participação de um grupo "
 "de frades rotundo.\n"
 "Em troca de proteção, eles concordam em ensinar-lhe uma magia - '%{spell}'."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1159
 msgid "Shrine of the 3rd Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1160
 msgid ""
 "You come across a lavish shrine attended by a group of high priests.\n"
 "In exchange for your protection, they agree to teach you a sophisticated "
@@ -2952,7 +3241,6 @@ msgstr ""
 "Em troca de sua proteção, eles concordam em ensinar-lhe uma magia "
 "sofisticada - '%{spell}'."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1173
 msgid ""
 "\n"
 "Unfortunately, you have no Magic Book to record the spell with."
@@ -2960,7 +3248,6 @@ msgstr ""
 "\n"
 "Infelizmente, você não tem nenhum livro de magia para gravar com a magia."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1184
 msgid ""
 "\n"
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
@@ -2970,24 +3257,21 @@ msgstr ""
 "Infelizmente, você não tem a sabedoria para compreender a magia, e você é "
 "incapaz de aprender."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1192
 msgid ""
 "\n"
 "Unfortunately, you already have knowledge of this spell, so there is nothing "
 "more for them to teach you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1215
 msgid ""
-"You approach the hut and observe a witch inside studying an ancient tome on %"
-"{skill}.\n"
+"You approach the hut and observe a witch inside studying an ancient tome on "
+"%{skill}.\n"
 " \n"
 msgstr ""
 "Você aproxima da cabana e observa uma bruxa dentro, estudando um antigo "
 "livro em %{skill}.\n"
 " \n"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1222
 msgid ""
 "As you approach, she turns and focuses her one glass eye on you.\n"
 "\"You already know everything you deserve to learn!\" the witch screeches. "
@@ -2998,7 +3282,6 @@ msgstr ""
 "\"Você já sabe tudo o que você merece a aprender!\" os gritos da bruxa. "
 "\"Agora sai da minha casa!\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1229
 msgid ""
 "As you approach, she turns and speaks.\n"
 "\"You already know that which I would teach you. I can help you no further.\""
@@ -3006,7 +3289,6 @@ msgstr ""
 "Quando você se aproxima, ela se vira e fala.\n"
 "\"Você já sabe o que eu ia te ensinar. Eu não posso te ajudar mais.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1236
 msgid ""
 "An ancient and immortal witch living in a hut with bird's legs for stilts "
 "teaches you %{skill} for her own inscrutable purposes."
@@ -3014,20 +3296,16 @@ msgstr ""
 "Uma bruxa antiga e imortal vivendo em uma cabana com patas de pássaro de "
 "palafitas ensina %{skill} pelos seus próprios propósitos incompreensíveis."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1255
 msgid "You drink from the enchanted fountain, but nothing happens."
 msgstr "Você bebe da fonte encantada, mas nada acontece."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1256
 msgid "As you drink the sweet water, you gain luck for your next battle."
 msgstr ""
 "Como você bebeu a água doce, você ganha sorte para sua proxima batalha."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1260
 msgid "You enter the faerie ring, but nothing happens."
 msgstr "Você entra no círculo das fadas, mas nada que acontece."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1261
 msgid ""
 "Upon entering the mystical faerie ring, your army gains luck for its next "
 "battle."
@@ -3035,7 +3313,6 @@ msgstr ""
 "Ao entrar no círculo da fada mística, o seu exército ganha sorte para a sua "
 "próxima batalha."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1265
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "It is supposed to grant luck to visitors, but since the stars are already "
@@ -3045,7 +3322,6 @@ msgstr ""
 "Supõe-se isso garante sorte aos visitantes, mas desde que as estrelas já "
 "estão sorrindo em cima de você, não fez nada."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1266
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "Kissing it is supposed to be lucky, so you do. The stone is very cold to the "
@@ -3055,13 +3331,11 @@ msgstr ""
 "Beijar é Supõe-se ter sorte, assim que você faz. A pedra é muito fria ao "
 "toque."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1270
 msgid "The mermaids silently entice you to return later and be blessed again."
 msgstr ""
 "As sereias silenciosamente seduzi-o a retornar mais tarde e ser abençoada "
 "novamente."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1271
 msgid ""
 "The magical, soothing beauty of the Mermaids reaches you and your crew.\n"
 "Just for a moment, you forget your worries and bask in the beauty of the "
@@ -3073,7 +3347,6 @@ msgstr ""
 "momento.\n"
 "As sereias encanta e abençoa com maior sorte para o seu próximo combate."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1303
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "You are tempted to search it for treasure, but all the old stories warn of "
@@ -3085,7 +3358,6 @@ msgstr ""
 "alerta sobre temerosos e guardiões mortos-vivos.\n"
 "Você vai buscar?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1304
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "Routine exploration reveals that the pyramid is completely empty."
@@ -3093,12 +3365,10 @@ msgstr ""
 "Você chega em cima da pirâmide de um grande rei antigo.\n"
 "Exploração de rotina revela que a pirâmide está completamente vazia."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1329
 msgid "Unfortunately, you have no Magic Book to record the spell with."
 msgstr ""
 "Infelizmente, você não tem nenhum livro mágico para gravar com a magia."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1333
 msgid ""
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
@@ -3106,7 +3376,6 @@ msgstr ""
 "Infelizmente, você não tem a sabedoria para compreender a magia, e você é "
 "incapaz de aprender."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1337
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
 "telling the secret of the spell."
@@ -3114,26 +3383,21 @@ msgstr ""
 "Após derrotar as criaturas, você decifrar um hieróglifo antigo na parede, "
 "contando o segredo da magia."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1374 ../fheroes2/maps/mp2.cpp:469
 msgid "Sign"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1385
 msgid ""
 "A drink at the well is supposed to restore your spell points, but you are "
 "already at maximum."
 msgstr ""
 "Ao beber do poço, era suposto restaurar sua mana, mas você já está no máximo."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1392
 msgid "A second drink at the well in one day will not help you."
 msgstr "A segunda bebida do poço em um dia não vai te ajudar."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1399
 msgid "A drink from the well has restored your spell points to maximum."
 msgstr "Gole da agua do poço restaurou sua mana ao máximo."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1424
 msgid ""
 "\"I'm sorry sir,\" The leader of the soldiers says, \"but you already know "
 "everything we have to teach.\""
@@ -3141,12 +3405,10 @@ msgstr ""
 "\"Me desculpe, senhor\", o líder dos soldados diz, \"mas você já sabe tudo o "
 "que temos para ensinar.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1425
 msgid "The soldiers living in the fort teach you a few new defensive tricks."
 msgstr ""
 "Os soldados que vivem no forte lhe ensinaa alguns novos truques de defesa."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1430
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. \"You're too "
 "advanced for us,\" the mercenary captain says. \"We can teach nothing more.\""
@@ -3155,7 +3417,6 @@ msgstr ""
 "avançado para nós\", diz o capitão mercenário. \"Nada poderemos lhe ensinar."
 "\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1431
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. The mercenaries "
 "welcome you and your troops and invite you to train with them."
@@ -3163,11 +3424,9 @@ msgstr ""
 "Você vai ate um campo de mercenários praticando suas táticas. Os mercenários "
 "recebê-lo e convidá-lo à treinar com eles."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1436
 msgid "\"Go 'way!\", the witch doctor barks, \"you know all I know.\""
 msgstr "\"Vá Embora! Você sabe tudo o que sei.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1437
 msgid ""
 "An Orcish witch doctor living in the hut deepens your knowledge of magic by "
 "showing you how to cast stones, read portents, and decipher the intricacies "
@@ -3177,7 +3436,6 @@ msgstr ""
 "magia, mostrando-lhe como atirar pedras, leia portentos, e decifrar os "
 "meandros de vísceras de frango."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1442
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, the Druids turn you away, indicating they have nothing "
@@ -3187,7 +3445,6 @@ msgstr ""
 "estranha. Silenciosamente, os druidas transformá-lo afastado, indicando que "
 "não têm nada de novo para ensinar-lhe."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1443
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, they teach you new ways to cast spells."
@@ -3195,7 +3452,6 @@ msgstr ""
 "Você encontrou um grupo de druidas adorando em um de seus edifícios de pedra "
 "estranha. Silenciosamente, eles lhe ensinam novas formas de magias."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1479
 msgid ""
 "You tentatively approach the burial ground of ancient warriors. Do you want "
 "to search the graves?"
@@ -3203,7 +3459,6 @@ msgstr ""
 "Você avista um grupo de querreiros antigos. Você deseja pesquisar as "
 "sepulturas?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1480
 msgid ""
 "Upon defeating the Zombies you spend several hours searching the graves and "
 "find nothing. Such a despicable act reduces your army's morale."
@@ -3212,12 +3467,11 @@ msgstr ""
 "sepulturas e não encontrar nada. Um ato tão desprezível  reduz a moral de "
 "seu exército."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1481
-msgid "Upon defeating the zomies you search the graves and find something!"
+#, fuzzy
+msgid "Upon defeating the Zombies you search the graves and find something!"
 msgstr ""
 "Após derrotar o zumbis você pesquisar os túmulos e encontrar alguma coisa!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1484
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the shipwreck?"
@@ -3225,7 +3479,6 @@ msgstr ""
 "A podridão do casco de um navio pirata range assustadoramente grande quando "
 "ele é empurrado contra as rochas. Do que você deseja pesquisar o naufrágio?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1485
 msgid ""
 "Upon defeating the Ghosts you spend several hours sifting through the debris "
 "and find nothing. Such a despicable act reduces your army's morale."
@@ -3233,13 +3486,11 @@ msgstr ""
 "Após derrotar os fantasmas que passar várias horas peneirando os detritos e "
 "não encontrar nada. Um ato tão desprezível reduz a moral de seu exército."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1486
 msgid ""
 "Upon defeating the Ghosts you sift through the debris and find something!"
 msgstr ""
 "Após derrotar os fantasmas que peneira os detritos e encontrar alguma coisa!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1489
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the ship?"
@@ -3247,345 +3498,273 @@ msgstr ""
 "A podridão do casco de um navio pirata range assustadoramente grande quando "
 "ele é empurrado contra as rochas. Você deseja pesquisar o navio?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1490
 msgid ""
 "Upon defeating the Skeletons you spend several hours sifting through the "
 "debris and find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1491
 msgid ""
 "Upon defeating the Skeletons you sift through the debris and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1564
 msgid "Your men spot a navigational buoy, confirming that you are on course."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1565
 msgid ""
 "Your men spot a navigational buoy, confirming that you are on course and "
 "increasing their morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1569
 msgid ""
 "The drink at the oasis is refreshing, but offers no further benefit. The "
 "oasis might help again if you fought a battle first."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1570
 msgid ""
 "A drink at the oasis fills your troops with strength and lifts their "
 "spirits.  You can travel a bit further today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1575
 msgid ""
 "The drink at the watering hole is refreshing, but offers no further benefit. "
 "The watering hole might help again if you fought a battle first."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1576
 msgid ""
 "A drink at the watering hole fills your troops with strength and lifts their "
 "spirits. You can travel a bit further today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1581
 msgid ""
 "It doesn't help to pray twice before a battle. Come back after you've fought."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1582
 msgid "A visit and a prayer at the temple raises the morale of your troops."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1622
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"I am sorry, my liege, I "
 "have taught you all I can.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1623
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"My liege, I will teach "
 "you all that I know to aid you in your travels.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1662
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
 "ocean. Grateful, he says, \"I would give you an artifact as a reward, but "
 "you're all full.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1669
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
-"ocean. Grateful, he rewards you for your act of kindness by giving you the %"
-"{art}."
+"ocean. Grateful, he rewards you for your act of kindness by giving you the "
+"%{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1688 ../fheroes2/heroes/heroes.cpp:941
-msgid "You have no room to carry another artifact!"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:1704
 msgid "A leprechaun offers you the %{art} for the small price of %{gold} Gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1709
 msgid ""
-"A leprechaun offers you the %{art} for the small price of %{gold} Gold and %"
-"{count} %{res}."
+"A leprechaun offers you the %{art} for the small price of %{gold} Gold and "
+"%{count} %{res}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1718
 msgid "Do you wish to buy this artifact?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1731
 msgid ""
 "You try to pay the leprechaun, but realize that you can't afford it. The "
 "leprechaun stamps his foot and ignores you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1735
 msgid ""
 "Insulted by your refusal of his generous offer, the leprechaun stamps his "
 "foot and ignores you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1746
-#: ../fheroes2/heroes/heroes_action.cpp:1821
 msgid "You've found the artifact: "
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1756
 msgid ""
 "You've found the humble dwelling of a withered hermit. The hermit tells you "
 "that he is willing to give the %{art} to the first wise person he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1759
 msgid ""
 "You've come across the spartan quarters of a retired soldier. The soldier "
 "tells you that he is willing to pass on the %{art} to the first true leader "
 "he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1780
 msgid ""
 "You come upon an ancient artifact. As you reach for it, a pack of Rogues "
 "leap out of the brush to guard their stolen loot."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1783
 msgid ""
 "Through a clearing you observe an ancient artifact. Unfortunately, it's "
 "guarded by a nearby %{monster}. Do you want to fight the %{monster} for the "
 "artifact?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1798
 msgid "Victorious, you take your prize, the %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1810
 msgid ""
 "Discretion is the better part of valor, and you decide to avoid this fight "
 "for today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1866
-#: ../fheroes2/heroes/heroes_action.cpp:1881
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold pieces."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1872
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold and the %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1888
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it, "
 "only to find it empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1898
 msgid ""
 "After scouring the area, you fall upon a hidden treasure cache. You may take "
 "the gold or distribute the gold to the peasants for experience. Do you wish "
 "to keep the gold?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1912
 msgid ""
-"After scouring the area, you fall upon a hidden chest, containing the %"
-"{gold} gold pieces."
+"After scouring the area, you fall upon a hidden chest, containing the "
+"%{gold} gold pieces."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1918
 msgid ""
 "After scouring the area, you fall upon a hidden chest, containing the "
 "ancient artifact %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1942
 msgid ""
 "You stumble upon a dented and tarnished lamp lodged deep in the earth. Do "
 "you wish to rub the lamp?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "A whirlpool engulfs your ship."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "Some of your army has fallen overboard."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2045
 msgid ""
 "You come upon an abandoned gold mine. The mine appears to be haunted. Do you "
 "wish to enter?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2064
 msgid ""
 "You have taken control of the local Alchemist shop. It will provide you with "
 "%{count} unit of Mercury per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2070
 msgid ""
 "You gain control of a sawmill. It will provide you with %{count} units of "
 "wood per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2081
+msgid "You beat the Ghosts and are able to restore the mine to production."
+msgstr ""
+
 msgid ""
 "You gain control of an ore mine. It will provide you with %{count} units of "
 "ore per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2083
 msgid ""
 "You gain control of a sulfur mine. It will provide you with %{count} unit of "
 "sulfur per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2085
 msgid ""
 "You gain control of a crystal mine. It will provide you with %{count} unit "
 "of crystal per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2087
 msgid ""
 "You gain control of a gem mine. It will provide you with %{count} unit of "
 "gems per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2089
 msgid ""
 "You gain control of a gold mine. It will provide you with %{count} gold per "
 "day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2096
-msgid "You beat the Ghosts and are able to restore the mine to production."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2101
 msgid ""
 "The lighthouse is now under your control, and all of your ships will now "
 "move further each turn."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2105
 msgid "You gain control of a %{name}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2188
 msgid ""
 "A group of %{monster} with a desire for greater glory wish to join you. Do "
 "you accept?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2215
 msgid "As you approach the dwelling, you notice that there is no one here."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2232
 msgid ""
 "You search the ruins, but the Medusas that used to live here are gone. "
 "Perhaps there will be more next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2233
 msgid ""
 "You've found some Medusas living in the ruins. They are willing to join your "
 "army for a price. Do you want to recruit Medusas?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2238
 msgid ""
 "You've found a Sprite Tree City. Unfortunately, none of the Sprites living "
 "there wish to join an army. Maybe next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2239
 msgid ""
 "Some of the Sprites living in the tree city are willing to join your army "
 "for a price. Do you want to recruit Sprites?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2244
 msgid ""
 "A colorful Rogues' wagon stands empty here. Perhaps more Rogues will be here "
 "later."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2245
 msgid ""
 "Distant sounds of music and laughter draw you to a colorful wagon housing "
 "Rogues. Do you wish to have any Rogues join your army?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2250
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. The "
 "tents are unoccupied. Perhaps more Nomads will be here later."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2251
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. Do you "
 "wish to have any Nomads join you during your travels?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2256
 msgid "The pit of mud bubbles for a minute and then lies still."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2257
 msgid ""
 "As you approach the bubbling pit of mud, creatures begin to climb out and "
 "position themselves around it. In unison they say: \"Mother Earth would like "
 "to offer you a few of her troops. Do you want to recruit Earth Elementals?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2261
 msgid "You enter the structure of white stone pillars, and find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2262
 msgid ""
 "White stone pillars support a roof that rises up to the sky. As you enter "
 "the structure, the dead air of the outside gives way to a whirling gust that "
@@ -3595,192 +3774,159 @@ msgid ""
 "air?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2266
 msgid "No Fire Elementals approach you from the lava pool."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2267
 msgid ""
 "Beneath a structure that serves to hold in heat, Fire Elementals move about "
 "in a fiery pool of molten lava. A group of them approach you and offer their "
 "services. Would you like to recruit Fire Elementals?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2271
 msgid "A face forms in the water for a moment, and then is gone."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2272
 msgid ""
 "Crystalline structures cast shadows over a small reflective pool of water. "
 "You peer into the pool, and a face that is not your own peers back. It asks: "
 "\"Would you like to call upon the powers of water?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2276
 msgid "This burial site is deathly still."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2277
 msgid ""
 "Restless spirits of long dead warriors seeking their final resting place "
 "offer to join you in hopes of finding peace. Do you wish to recruit ghosts?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2313
 msgid ""
 "The City of the Dead is empty of life, and empty of unlife as well. Perhaps "
 "some undead will move in next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2314
 msgid ""
 "Some Liches living here are willing to join your army for a price. Do you "
 "want to recruit Liches?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2315
 msgid ""
 "You've found the ruins of an ancient city, now inhabited solely by the "
 "undead. Will you search?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2316
 msgid ""
 "Some of the surviving Liches are impressed by your victory over their "
 "fellows, and offer to join you for a price. Do you want to recruit Liches?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2320
 msgid ""
 "You've found one of those bridges that Trolls are so fond of living under, "
 "but there are none here. Perhaps there will be some next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2321
 msgid ""
 "Some Trolls living under a bridge are willing to join your army, but for a "
 "price. Do you want to recruit Trolls?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2322
 msgid "Trolls living under the bridge challenge you. Will you fight them?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2323
 msgid ""
 "A few Trolls remain, cowering under the bridge. They approach you and offer "
 "to join your forces as mercenaries. Do you want to buy any Trolls?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2327
 msgid ""
 "The Dragon city has no Dragons willing to join you this week. Perhaps a "
 "Dragon will become available next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2328
 msgid ""
 "The Dragon city is willing to offer some Dragons for your army for a price. "
 "Do you wish to recruit Dragons?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2329
 msgid ""
 "You stand before the Dragon City, a place off-limits to mere humans. Do you "
 "wish to violate this rule and challenge the Dragons to a fight?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2330
 msgid ""
 "Having defeated the Dragon champions, the city's leaders agree to supply "
 "some Dragons to your army for a price. Do you wish to recruit Dragons?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2389
 msgid "From the observation tower, you are able to see distant lands."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2401
 msgid ""
 "The spring only refills once a week, and someone's already been here this "
 "week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2407
 msgid ""
 "A drink at the spring is supposed to give you twice your normal spell "
 "points, but you are already at that level."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2418
 msgid ""
 "A drink from the spring fills your blood with magic! You have twice your "
 "normal spell points in reserve."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2437
 msgid ""
 "Recognizing you, the butler refuses to admit you. \"The master,\" he says, "
 "\"will not see the same student twice.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2457
 msgid ""
 "The butler admits you to see the master of the house. He trains you in the "
 "four skills a hero should know."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2467
 msgid ""
 "The butler opens the door and looks you up and down. \"You are neither "
 "famous nor diplomatic enough to be admitted to see my master,\" he sniffs. "
 "\"Come back when you think yourself worthy.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2510
 msgid ""
 "All of the %{monsters} you have in your army have been trained by the battle "
 "masters of the fort. Your army now contains %{monsters2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2513
 msgid ""
-"An unusual alliance of Orcs, Ogres, and Dwarves offer to train (upgrade) any "
+"An unusual alliance of Ogres, Orcs, and Dwarves offer to train (upgrade) any "
 "such troops brought to them. Unfortunately, you have none with you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2524
 msgid "All of your %{monsters} have been upgraded into %{monsters2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2527
 msgid ""
 "A blacksmith working at the foundry offers to convert all Pikemen and "
 "Swordsmen's weapons brought to him from iron to steel. He also says that he "
-"knows a process that will convert Iron Golems into Steel Golems.  "
+"knows a process that will convert Iron Golems into Steel Golems. "
 "Unfortunately, you have none of these troops in your army, so he can't help "
 "you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2585
 msgid ""
 "A retired captain living on this refurbished fishing platform offers to sell "
 "you maps of the sea he made in his younger days for 1,000 gold. Do you wish "
 "to buy the maps?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2598
 msgid ""
 "The captain sighs. \"You don't have enough money, eh?  You can't expect me "
 "to give my maps away for free!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2632
 msgid "You find %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2655
 msgid ""
 "You come upon an obelisk made from a type of stone you have never seen "
 "before. Staring at it intensely, the smooth surface suddenly changes to an "
@@ -3788,56 +3934,51 @@ msgid ""
 "copy down the piece and the inscription vanishes as abruptly as it appeared."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2659
 msgid "You have already been to this obelisk."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2671
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"It is good to see "
 "you, my student. I hope my teachings have helped you.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2683
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"Ahh, an "
 "adventurer! Allow me to teach you a little of what I have learned over the "
 "ages.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2692
 msgid "Upon your approach, the tree opens its eyes in delight."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2694
 msgid ""
 "\"Ahh, an adventurer! I will be happy to teach you a little of what I have "
 "learned over the ages for a mere %{count} %{res}.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2696
 msgid "(Just bury it around my roots.)"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2703
 msgid "Tears brim in the eyes of the tree."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2705
 msgid "\"I need %{count} %{res}.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2707
 msgid "it whispers. (sniff) \"Well, come back when you can pay me.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2737
+msgid ""
+"Nestled among the trees sits a blind seer. After explaining the intent of "
+"your journey, the seer activates his crystal ball, allowing you to see the "
+"strengths and weaknesses of your opponents."
+msgstr ""
+
 msgid ""
 "The entrance to the cave is dark, and a foul, sulfurous smell issues from "
 "the cave mouth. Will you enter?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2749
 msgid ""
 "You find a powerful and grotesque Demon in the cave. \"Today,\" it rasps, "
 "\"you will fight and surely die. But I will give you a choice of deaths. You "
@@ -3845,71 +3986,59 @@ msgid ""
 "servants?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2759
 msgid ""
 "Upon defeating the daemon's servants, you find a hidden cache with %{count} "
 "gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2774
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and receive %{exp} experience points."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2784
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and find the %{art} in the back of the cave."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2794
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
-"battle, you slay the monster and receive %{exp) experience points and %"
-"{count} gold."
+"battle, you slay the monster and receive %{exp} experience points and "
+"%{count} gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2809
 msgid ""
 "The Demon leaps upon you and has its claws at your throat before you can "
 "even draw your sword. \"Your life is mine,\" it says. \"I will sell it back "
 "to you for %{count} gold.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2810
 msgid ""
 "Seeing that you do not have %{count} gold, the demon slashes you with its "
 "claws, and the last thing you see is a red haze."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2835
 msgid "Except for evidence of a terrible battle, the cave is empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2860
 msgid "For %{gold} gold, the alchemist will remove it for you. Do you pay?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2871
 msgid ""
 "You hear a voice from behind the locked door, \"You don't have enough gold "
 "to pay for my services.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2874
 msgid ""
 "You hear a voice from high above in the tower, \"Go away! I can't help you!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2886
 msgid ""
 "The head groom approaches you and speaks, \"You already have a fine horse, "
 "and have no inexperienced cavalry which might make use of our trained war "
 "horses.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2889
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, his "
@@ -3918,7 +4047,6 @@ msgid ""
 "mounted soldiers, but you have none we can help.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2892
 msgid ""
 "The head groom speaks to you, \"That is a fine looking horse you have. I am "
 "afraid we can give you no better, but the horses your cavalry are riding "
@@ -3926,7 +4054,6 @@ msgid ""
 "would aid your riders greatly. I insist you take them.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2895
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, he will "
@@ -3934,17 +4061,14 @@ msgid ""
 "mounted soldiers, their horses look shoddy and weak.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2922
 msgid "The Arena guards turn you away."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2939
 msgid ""
 "As the sirens sing their eerie song, your small, determined army manages to "
 "overcome the urge to dive headlong into the sea."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2944
 msgid ""
 "You have your crew stop up their ears with wax before the sirens' eerie song "
 "has any chance of luring them to a watery grave. An eerie wailing song "
@@ -3953,57 +4077,52 @@ msgid ""
 "for the visit, and gain %{exp} experience."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2964
 msgid ""
 "In a dazzling display of daring, you break into the local jail and free the "
 "hero imprisoned there, who, in return, pledges loyalty to your cause."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2980
 msgid ""
 "You already have %{count} heroes, and regretfully must leave the prisoner in "
 "this jail to languish in agony for untold days."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2991
 msgid ""
 "You enter a rickety hut and talk to the magician who lives there. He tells "
 "you of places near and far which may aid you in your journeys."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3004
 msgid "This eye seems to be intently studying its surroundings."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3015
 msgid ""
 "\"I have a riddle for you,\" the Sphinx says. \"Answer correctly, and you "
 "shall be rewarded. Answer incorrectly, and you shall be eaten. Do you accept "
 "the challenge?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3017
-msgid "The Sphinx asks you the following riddle: %{riddle}. Your answer?"
+msgid ""
+"The Sphinx asks you the following riddle:\n"
+" \n"
+"'%{riddle}'\n"
+" \n"
+"Your answer?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3025
 msgid ""
 "Looking somewhat disappointed, the Sphinx sighs. You've answered my riddle "
 "so here's your reward. Now begone."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3052
 msgid ""
 "\"You guessed incorrectly,\" the Sphinx says, smiling. The Sphinx swipes at "
 "you with a paw, knocking you to the ground. Another blow makes the world go "
 "black, and you know no more."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3060
 msgid "You come across a giant Sphinx. The Sphinx remains strangely quiet."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3073
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -4011,7 +4130,6 @@ msgid ""
 "As you speak the magic word, the glowing barrier dissolves into nothingness."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3083
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -4019,7 +4137,6 @@ msgid ""
 "You speak, and nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3093
 msgid ""
 "You enter the tent and see an old woman gazing into a magic gem. She looks "
 "up and says,\n"
@@ -4027,422 +4144,87 @@ msgid ""
 "oracle taught me his skill. I have the answer you seek.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_base.cpp:401
 msgid ""
 "That spell costs %{mana} mana. You only have %{point} mana, so you can't "
 "cast the spell."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Lord Kilburn"
-msgstr ""
+#, fuzzy
+msgid "%{name} the %{race} (Level %{level})"
+msgstr "%{name} a %{race}"
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Sir Gallanth"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ector"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Gwenneth"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Tyro"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ambrose"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ruby"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Maximus"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Dimitry"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Thundax"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Fineous"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jojosh"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Crag Hack"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jezebel"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jaclyn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Ergon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Tsabu"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Atlas"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Astra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Natasha"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Troyan"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Vatawna"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Rebecca"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Gem"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Ariel"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Carlawn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Luna"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Arie"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61 ../fheroes2/resource/maps_text.cpp:59
-msgid "Alamar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Vesper"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Crodo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Barok"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Kastore"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Agar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Falagar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Wrathmont"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Flint"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Dawn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Halon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myrini"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Wilfrey"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Sarakin"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63 ../fheroes2/resource/maps_text.cpp:377
-msgid "Kalindra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Mandigal"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zom"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Darlana"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zam"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Ranloo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Charity"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Rialdo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Roxana"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65 ../fheroes2/resource/maps_text.cpp:557
-msgid "Sandro"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Celia"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:552
-msgid "Roland"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Lord Corlagon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Sister Eliza"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:88
-msgid "Archibald"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:403
-msgid "Lord Halton"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Brother Bax"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Solmyr"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:194
-msgid "Dainwin"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Mog"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:760
-msgid "Uncle Ivan"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:373
-msgid "Joseph"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:285
-msgid "Gallavant"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Elderian"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:179
-msgid "Ceallach"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:229
-msgid "Drakonia"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:422
-msgid "Martine"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:370
-msgid "Jarkonas"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:940
-msgid ""
-"You must purchase a spell book to use the mage guild, but you currently have "
-"no room for a spell book. Try giving one of your artifacts to another hero."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:950
-msgid "The three Anduran artifacts magically combine into one."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1056
-msgid "To cast spells, you must first buy a spell book for %{gold} gold."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1064
-msgid "Unfortunately, you seem to be a little short of cash at the moment."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1078
-msgid "Do you wish to buy one?"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:72
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:55
-msgid "%{name} the %{race} ( Level %{level} )"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:118
 msgid ""
 "'Grouped' combat formation bunches your army together in the center of your "
 "side of the battlefield."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:161
 msgid "Are you sure you want to dismiss this Hero?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:341
 #, fuzzy
 msgid "View Stats"
 msgstr "Melhor Herói em Stats:"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:344
-msgid "View Morale Info"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:347
-msgid "View Luck Info"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:350
 msgid "View Experience Info"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:353
 msgid "View Spell Points Info"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:356
 msgid "Set army combat formation to 'Spread'"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:359
 msgid "Set army combat formation to 'Grouped'"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:362
-msgid "Exit hero"
+msgid "Exit Hero Screen"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:369
-msgid "Dismiss hero"
+msgid "You cannot dismiss a hero in a castle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:373
-msgid "Show prev heroes"
+msgid "Dismissal of %{name} the %{race} is prohibited by scenario"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:376
-msgid "Show next heroes"
+#, fuzzy
+msgid "Dismiss %{name} the %{race}"
+msgstr "%{name} a %{race}"
+
+#, fuzzy
+msgid "Show previous hero"
+msgstr "Mostrar cidade anterior"
+
+#, fuzzy
+msgid "Show next hero"
+msgstr "Mostrar proxima cidade"
+
+#, fuzzy
+msgid "Blood Morale"
+msgstr "Moral"
+
+msgid "%{morale} Morale"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:379
-msgid "Hero Screen"
+msgid "%{luck} Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:39
-msgid "Bad Morale"
+msgid "Current Luck Modifiers:"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:42
-msgid "Neutral Morale"
+msgid "Current Morale Modifiers:"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:47
-msgid "Good Morale"
+msgid "Entire army is undead, so morale does not apply."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:61
-msgid "Bad Luck"
+msgid ""
+"Current experience %{exp1}.\n"
+" Next level %{exp2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:64
-msgid "Neutral Luck"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:69
-msgid "Good Luck"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:113
-#: ../fheroes2/heroes/heroes_indicator.cpp:159
-#: ../fheroes2/heroes/skill.cpp:197
-msgid "Current Modifiers:"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:195
-msgid "Current experience %{exp1} Next level %{exp2}."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:215
 msgid "Level %{level}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:226
 msgid ""
 "%{name} currently has %{point} spell points out of a maximum of %{max}. The "
 "maximum number of spell points is 10 times your knowledge. It is "
@@ -4450,2538 +4232,1451 @@ msgid ""
 "special events."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:65
 msgid "%{name1} meets %{name2}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:396
-#: ../fheroes2/heroes/heroes_meeting.cpp:406
 msgid " and "
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:414
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:417
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:420
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches %"
-"{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches "
+"%{spells2} to %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:431
 msgid "Scholar Ability"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:83 ../fheroes2/spell/spell.cpp:109
 msgid "Town Portal"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:86
 msgid "Select town to port to."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:106
 msgid "Your hero is too tired to cast this spell today. Try again tomorrow."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:187
 msgid "%{spell} failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:236
+msgid "This spell is already in use."
+msgstr ""
+
 msgid "Enemy heroes are now fully identifiable."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:362
-#: ../fheroes2/heroes/heroes_spell.cpp:386
-msgid "No available towns. Spell Failed!!!"
+#, fuzzy
+msgid "This spell cannot be used on a boat."
+msgstr "Esta cidade não pode ser transformada em castelo."
+
+msgid "This spell can be casted only nearby water."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:459
-msgid "I fear these creatures are in the mood for a fight."
+msgid ""
+"No available towns.\n"
+"Spell Failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:463
-msgid "The creatures are willing to join us!"
+msgid ""
+"Nearest town occupied.\n"
+"Spell Failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:468
-msgid "All the creatures will join us..."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_spell.cpp:480
-msgid "These weak creatures will surely flee before us."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_spell.cpp:489
 msgid ""
 "You must be within %{count} spaces of a monster for the Visions spell to "
 "work."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:506
+msgid "I fear these creatures are in the mood for a fight."
+msgstr ""
+
+msgid "The creatures are willing to join us!"
+msgstr ""
+
+msgid "All the creatures will join us..."
+msgstr ""
+
+msgid "These weak creatures will surely flee before us."
+msgstr ""
+
 msgid ""
 "You must be standing on the entrance to a mine (sawmills and alchemists "
 "don't count) to cast this spell."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:151
-msgid "Power"
-msgstr ""
-
-#: ../fheroes2/heroes/skill.cpp:172
 msgid "Your attack skill is a bonus added to each creature's attack skill."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:177
 msgid "Your defense skill is a bonus added to each creature's defense skill."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:182
 msgid "Your spell power determines the length or power of a spell."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:187
 msgid ""
 "Your knowledge determines how many spell points your hero may have. Under "
-"normal cirumstances, a hero is limited to 10 spell points per level of "
+"normal circumstances, a hero is limited to 10 spell points per level of "
 "knowledge."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
+msgid "Current Modifiers:"
+msgstr ""
+
 msgid "skill|Basic"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
 msgid "skill|Advanced"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
 #, fuzzy
 msgid "skill|Expert"
 msgstr "Especialista"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Basic Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Advanced Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Expert Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Basic Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Advanced Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
 #, fuzzy
 msgid "Expert Archery"
 msgstr "Especialista"
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Basic Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Advanced Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Expert Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Basic Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Advanced Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Expert Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Basic Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Advanced Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Expert Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:372
 #, fuzzy
 msgid "Basic Navigation"
 msgstr "Escavação"
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Advanced Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:372
 #, fuzzy
 msgid "Expert Navigation"
 msgstr "Escavação"
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Basic Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Advanced Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Expert Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Basic Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Advanced Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
 #, fuzzy
 msgid "Expert Wisdom"
 msgstr "Especialista"
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Basic Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Advanced Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Expert Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Basic Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Advanced Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
 #, fuzzy
 msgid "Expert Luck"
 msgstr "Especialista"
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Basic Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Advanced Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Expert Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Basic Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Advanced Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Expert Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
 #, fuzzy
 msgid "Basic Necromancy"
 msgstr "Necromante:"
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Advanced Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
 #, fuzzy
 msgid "Expert Necromancy"
 msgstr "Necromante:"
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Basic Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Advanced Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 #, fuzzy
 msgid "Expert Estates"
 msgstr "Especialista"
 
-#: ../fheroes2/heroes/skill.cpp:406
-msgid "Allows you to negotiate with monsters who are weaker than your group."
+msgid " allows you to negotiate with monsters who are weaker than your group."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:421
-msgid "Allows your hero to learn third level spells."
+msgid "All of the creatures may offer to join you."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:423
-msgid "Allows your hero to learn fourth level spells."
+msgid " allows your hero to learn third level spells."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:425
-msgid "Allows your hero to learn fifth level spells."
+msgid " allows your hero to learn fourth level spells."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:440
+msgid " allows your hero to learn fifth level spells."
+msgstr ""
+
 msgid ""
-"Gives your hero's catapult shots a greater chance to hit and do damage to "
+" gives your hero's catapult shots a greater chance to hit and do damage to "
 "castle walls."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:442
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot has a greater chance "
-"to hit and do damage to castle walls."
+" gives your hero's catapult an extra shot, and each shot has a greater "
+"chance to hit and do damage to castle walls."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:444
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot automatically "
+" gives your hero's catapult an extra shot, and each shot automatically "
 "destroys any wall, except a fortified wall in a Knight town."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:858 ../fheroes2/heroes/skill.cpp:959
-msgid "View %{skill} Info"
-msgstr ""
-
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:108
 msgid "Blue"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:111
 msgid "Green"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:114
 msgid "Red"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32
 msgid "Yellow"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:112
 msgid "Orange"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:113
 msgid "Purple"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:107
 msgid "Aqua"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:109
 msgid "Brown"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:110 ../fheroes2/resource/resource.cpp:283
 msgid "Gold"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:238
 #, fuzzy
 msgid "Hero/Stats"
 msgstr "Melhor Herói em Stats:"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:241
 msgid "Skills"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:244
 #, fuzzy
 msgid "Artifacts"
 msgstr "Artefato"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:473
 #, fuzzy
 msgid "Town/Castle"
 msgstr "Castelo"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:476
 msgid "Garrison"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:566
 #, fuzzy
 msgid "Gold Per Day:"
 msgstr "Ouro Total:"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Cursed"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Awful"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Bad"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Normal"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Good"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Great"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Irish"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:48
 msgid ""
 "Bad luck sometimes falls on your armies in combat, causing their attacks to "
 "only do half damage."
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:49
 msgid ""
 "Neutral luck means your armies will never get lucky or unlucky attacks on "
 "the enemy."
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:50
 msgid ""
 "Good luck sometimes lets your armies get lucky attacks (double strength) in "
 "combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Treason"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Awful"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Poor"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Normal"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Good"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Great"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Blood!"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:48
 msgid "Bad morale may cause your armies to freeze in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:49
 msgid ""
 "Neutral morale means your armies will never be blessed with extra attacks or "
 "freeze in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:50
 msgid "Good morale may give your armies extra attacks in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Knight"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Barbarian"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Sorceress"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Warlock"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Wizard"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Necromancer"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Multi"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Standing"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Crawling"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Very Slow"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Slow"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Average"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Very Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Ultra Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Blazing"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Instant"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:32
 msgid "week|PLAGUE"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Ant"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Grasshopper"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Dragonfly"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Spider"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Butterfly"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Bumblebee"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Locust"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Earthworm"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Hornet"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Beetle"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Squirrel"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Rabbit"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Gopher"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Badger"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Eagle"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Weasel"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Raven"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Mongoose"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Aardvark"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Lizard"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Tortoise"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Hedgehog"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Condor"
 msgstr ""
 
-#: ../fheroes2/kingdom/world_loadmap.cpp:1424
-msgid "The ultimate artifact is really the %{name}"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1428
-msgid "The ultimate artifact may be found in the %{name} regions of the world."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1433
-msgid "north-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1436
-msgid "north"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1438
-msgid "north-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1444
-#, fuzzy
-msgid "west"
-msgstr "Ninho"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1447
-#, fuzzy
-msgid "center"
-msgstr "Tenda"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1449
-#, fuzzy
-msgid "east"
-msgstr "Ninho"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1454
-msgid "south-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1457
-#, fuzzy
-msgid "south"
-msgstr "som"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1459
-msgid "south-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1463
-msgid "The truth is out there."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1464
-msgid "The dark side is stronger."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1465
-msgid "The end of the world is near."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1466
-msgid "The bones of Lord Slayer are buried in the foundation of the arena."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1467
-msgid "A Black Dragon will take out a Titan any day of the week."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1468
-msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1470
-msgid ""
-"You can load the newest version of game from a site:\n"
-" http://sf.net/projects/fheroes2"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1471
-msgid "This game is now in beta development version. ;)"
-msgstr ""
-
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Desert"
 msgstr "Deserto"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Snow"
 msgstr "Neve"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Wasteland"
 msgstr "Terreno Baldio"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Beach"
 msgstr "Praia"
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Lava"
 msgstr "Lava"
 
-#: ../fheroes2/maps/ground.cpp:31 ../fheroes2/resource/maps_text.cpp:210
 msgid "Dirt"
 msgstr "Lama"
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Grass"
 msgstr "Grama"
 
-#: ../fheroes2/maps/ground.cpp:31
-msgid "Water"
-msgstr "Água"
+msgid "Ocean"
+msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Small"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Medium"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Large"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Extra Large"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Custom Size"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:122
 msgid "Ore Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:123
 msgid "Sulfur Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:124
 msgid "Crystal Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:125
 msgid "Gems Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:126
 msgid "Gold Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:130
 msgid "Mine"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:365
 msgid "Alchemist Lab"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:367
 msgid "Daemon Cave"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:369
 msgid "Faerie Ring"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:373 ../fheroes2/resource/maps_text.cpp:217
 msgid "Dragon City"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:375
-msgid "Light House"
+msgid "Lighthouse"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:377
 msgid "Water Wheel"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:379
 msgid "Mines"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:381
 msgid "Obelisk"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:383
 msgid "Oasis"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:385
 msgid "Sawmill"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:387
 msgid "Oracle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:389
 msgid "Desert Tent"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:393
 msgid "Wagon Camp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:395
 msgid "Windmill"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:397
 msgid "Random Town"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:399
 msgid "Random Castle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:401
 msgid "Watch Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:403
 msgid "Tree City"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:405
 msgid "Tree House"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:407
 msgid "Ruins"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:409
 msgid "Fort"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:411
-msgid "Trading Post"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:413
 msgid "Abandoned Mine"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:415
 msgid "Tree of Knowledge"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:417
 msgid "Witch Doctor's Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:419
 msgid "Temple"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:421
 msgid "Hill Fort"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:423
 msgid "Halfling Hole"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:425
 msgid "Mercenary Camp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:429
 msgid "City of the Dead"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:433
 msgid "Sphinx"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:435
 msgid "Troll Bridge"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:437
 msgid "Witch Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:439
 msgid "Xanadu"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:443
 msgid "Magellan Maps"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:445
 msgid "Derelict Ship"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:447
-msgid "Ship Wreck"
+msgid "Shipwreck"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:449
 msgid "Observation Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:451
-msgid "Freeman Foundry"
+msgid "Freeman's Foundry"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:453
 msgid "Watering Hole"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:455
 msgid "Artesian Spring"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:457
 msgid "Gazebo"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:459
 msgid "Archer's House"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:461
 msgid "Peasant Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:463
 msgid "Dwarf Cottage"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:465
 msgid "Stone Liths"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:467
 msgid "Magic Well"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:468
 msgid "Heroes"
 msgstr "Heróis"
 
-#: ../fheroes2/maps/mp2.cpp:470 ../fheroes2/maps/mp2.cpp:488
-msgid "Shrub"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:471
 msgid "Nothing Special"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:472
 msgid "Tar Pit"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:473
-msgid "Coast"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:474
 msgid "Mound"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:475
 msgid "Dune"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:476
 msgid "Stump"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:477
 msgid "Cactus"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:478
 msgid "Trees"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:479
 msgid "Dead Tree"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:480
 msgid "Mountains"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:481
 msgid "Volcano"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:482
 msgid "Rock"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:483
 msgid "Flowers"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:484
 msgid "Water Lake"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:485
 msgid "Mandrake"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:486
 msgid "Crater"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:487
 msgid "Lava Pool"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:489
+msgid "Shrub"
+msgstr ""
+
 msgid "Buoy"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:491 ../fheroes2/monster/monster.cpp:116
 msgid "Skeleton"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:492
 msgid "Treasure Chest"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:493
 msgid "Sea Chest"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:494
 msgid "Campfire"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:495
 msgid "Fountain"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:496
 msgid "Genie Lamp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:497
 msgid "Goblin Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:499
 msgid "Monster"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:500
 msgid "Resource"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:501
 msgid "Whirlpool"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:502
 msgid "Artifact"
 msgstr "Artefato"
 
-#: ../fheroes2/maps/mp2.cpp:503
 msgid "Boat"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:510
 msgid "Standing Stones"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:514
 msgid "Idol"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:515
 msgid "Shrine of the First Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:516
 msgid "Shrine of the Second Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:517
 msgid "Shrine of the Third Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:518
 msgid "Wagon"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:519
 msgid "Lean To"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:520
 msgid "Flotsam"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:521
 msgid "Shipwreck Survivor"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:522
 msgid "Bottle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:523
 msgid "Magic Garden"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:529
 msgid "Jail"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:531
 msgid "Traveller's Tent"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:532
 msgid "Barrier"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:535
 msgid "Fire Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:537
 msgid "Air Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:539
 msgid "Earth Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:541
 msgid "Water Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:543
 msgid "Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:545
-msgid "Arena"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:547
 msgid "Stables"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:549
 msgid "Alchemist's Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:551
 msgid "Hut of the Magi"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:553
 msgid "Eye of the Magi"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:555
 msgid "Mermaid"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:557
 msgid "Sirens"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:558
 msgid "Reefs"
 msgstr ""
 
-#: ../fheroes2/monster/monster.cpp:59
-msgid "Peasant"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:59 ../fheroes2/resource/maps_text.cpp:501
-msgid "Peasants"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Archer"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Archers"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Ranger"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Rangers"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Pikeman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Pikemen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Veteran Pikeman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Veteran Pikemen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Swordsman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Swordsmen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Master Swordsman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Master Swordsmen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Cavalry"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Cavalries"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Champion"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Champions"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Paladin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Paladins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:69
-msgid "Crusader"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:69
-msgid "Crusaders"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Goblin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Goblins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orc"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orcs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chief"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chiefs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Wolf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Wolves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogre"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogres"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Ogre Lord"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Ogre Lords"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "Troll"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "Trolls"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "War Troll"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "War Trolls"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:80
-msgid "Cyclops"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:80
-msgid "Cyclopes"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Sprite"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Sprites"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Dwarf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Dwarves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Battle Dwarf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Battle Dwarves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druid"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druids"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druid"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druids"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorn"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorns"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:91
-msgid "Phoenix"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:91
-msgid "Phoenixes"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaur"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaurs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyle"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyles"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaur"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaurs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur King"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur Kings"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydra"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydras"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halfling"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halflings"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boar"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boars"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golem"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golems"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golem"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golems"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Roc"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Rocs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Mage"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Magi"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmage"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmagi"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:112
-msgid "Giant"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:112 ../fheroes2/resource/maps_text.cpp:293
-msgid "Giants"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titan"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titans"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:116
-msgid "Skeletons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummy"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummy"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampire"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampires"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lord"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lords"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Lich"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Liches"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Lich"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Liches"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogue"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogues"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomad"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomads"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghost"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghosts"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusa"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusas"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elementals"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:694
-msgid "buy"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:158
-msgid "Campaign Game"
-msgstr "Campanha"
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "Error"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "This release is compiled without network support."
-msgstr ""
-
-#: ../fheroes2/resource/artifact.cpp:51
 msgid "Ultimate Book of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:51 ../fheroes2/resource/artifact.cpp:77
-#: ../fheroes2/resource/artifact.cpp:78 ../fheroes2/resource/artifact.cpp:79
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "The %{name} increases your knowledge by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:52
 msgid "Ultimate Sword of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:52 ../fheroes2/resource/artifact.cpp:68
-#: ../fheroes2/resource/artifact.cpp:71 ../fheroes2/resource/artifact.cpp:74
-#: ../fheroes2/resource/artifact.cpp:75 ../fheroes2/resource/artifact.cpp:149
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "The %{name} increases your attack skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:53
 msgid "Ultimate Cloak of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:53 ../fheroes2/resource/artifact.cpp:70
-#: ../fheroes2/resource/artifact.cpp:73 ../fheroes2/resource/artifact.cpp:76
 msgid "The %{name} increases your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:54
 msgid "Ultimate Wand of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:54 ../fheroes2/resource/artifact.cpp:59
-#: ../fheroes2/resource/artifact.cpp:60 ../fheroes2/resource/artifact.cpp:61
-#: ../fheroes2/resource/artifact.cpp:62 ../fheroes2/resource/artifact.cpp:148
 msgid "The %{name} increases your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:55
 msgid "Ultimate Shield"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:55 ../fheroes2/resource/artifact.cpp:128
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "The %{name} increases your attack and defense skills by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:56
 msgid "Ultimate Staff"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:56 ../fheroes2/resource/artifact.cpp:130
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "The %{name} increases your spell power and knowledge by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "Ultimate Crown"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "The %{name} increases each of your basic skills by %{count} points."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "Golden Goose"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "The %{name} brings in an income of %{count} gold per turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:59
 msgid "Arcane Necklace of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:60
 msgid "Caster's Bracelet of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:61
 msgid "Mage's Ring of Power"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:62
 msgid "Witch's Broach of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:63
 msgid "Medal of Valor"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:63 ../fheroes2/resource/artifact.cpp:64
-#: ../fheroes2/resource/artifact.cpp:65 ../fheroes2/resource/artifact.cpp:66
 msgid "The %{name} increases your morale."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:64
 msgid "Medal of Courage"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:65
 msgid "Medal of Honor"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:66
 msgid "Medal of Distinction"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "Fizbin of Misfortune"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "The %{name} greatly decreases your morale by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:68
 msgid "Thunder Mace of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "Armored Gauntlets of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "The %{name} increase your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:70
 msgid "Defender Helm of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:71
 msgid "Giant Flail of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "Ballista of Quickness"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "The %{name} lets your catapult fire twice per combat round."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:73
 msgid "Stealth Shield of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:74
 msgid "Dragon Sword of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:75
 msgid "Power Axe of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:76
 msgid "Divine Breastplate of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:77
 msgid "Minor Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:78
 msgid "Major Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:79
 msgid "Superior Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "Foremost Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:81
 msgid "Endless Sack of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:81 ../fheroes2/resource/artifact.cpp:82
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "The %{name} provides you with %{count} gold per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:82
 msgid "Endless Bag of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "Endless Purse of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:84
 msgid "Nomad Boots of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:84 ../fheroes2/resource/artifact.cpp:85
 msgid "The %{name} increase your movement on land."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:85
 msgid "Traveler's Boots of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:86
 msgid "Lucky Rabbit's Foot"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:86 ../fheroes2/resource/artifact.cpp:87
-#: ../fheroes2/resource/artifact.cpp:88 ../fheroes2/resource/artifact.cpp:89
 msgid "The %{name} increases your luck in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:87
 msgid "Golden Horseshoe"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:88
 msgid "Gambler's Lucky Coin"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:89
 msgid "Four-Leaf Clover"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "True Compass of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "The %{name} increases your movement on land and sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "Sailor's Astrolabe of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "The %{name} increases your movement on sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "Evil Eye"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "The %{name} reduces the casting cost of curse spells by half."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "Enchanted Hourglass"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "The %{name} extends the duration of all your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "Gold Watch"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "The %{name} doubles the effectiveness of your hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "Skullcap"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "The %{name} halves the casting cost of all mind influencing spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "Ice Cloak"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "The %{name} halves all damage your troops take from cold spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "Fire Cloak"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "The %{name} halves all damage your troops take from fire spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "Lightning Helm"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "The %{name} halves all damage your troops take from lightning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid "Evercold Icicle"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid ""
 "The %{name} causes your cold spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid "Everhot Lava Rock"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid ""
 "The %{name} causes your fire spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid "Lightning Rod"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid ""
 "The %{name} causes your lightning spells to do %{count} percent more damage "
 "to enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "Snake-Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "The %{name} halves the casting cost of all your bless spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid "Ankh"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid ""
 "The %{name} doubles the effectiveness of all your resurrect and animate "
 "spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "Book of Elements"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "The %{name} doubles the effectiveness of all your summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "Elemental Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "The %{name} halves the casting cost of all summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "Holy Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "The %{name} makes all your troops immune to curse spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "Pendant of Free Will"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "The %{name} makes all your troops immune to hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "Pendant of Life"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "The %{name} makes all your troops immune to death spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "Serenity Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "The %{name} makes all your troops immune to berserk spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "Seeing-eye Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "The %{name} makes all your troops immune to blindness spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "Kinetic Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "The %{name} makes all your troops immune to paralyze spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "Pendant of Death"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "The %{name} makes all your troops immune to holy spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "Wand of Negation"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "The %{name} protects your troops from the Dispel Magic spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid "Golden Bow"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid ""
 "The %{name} eliminates the %{count} percent penalty for your troops shooting "
-"past obstacles. (e.g. castle walls)"
+"past obstacles (e.g. castle walls)."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid "Telescope"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid ""
 "The %{name} increases the amount of terrain your hero reveals when "
 "adventuring by %{count} extra square."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid "Statesman's Quill"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid ""
 "The %{name} reduces the cost of surrender to %{count} percent of the total "
 "cost of troops you have in your army."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "Wizard's Hat"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "The %{name} increases the duration of your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "Power Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "The %{name} returns %{count} extra power points/turn to your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "Ammo Cart"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "The %{name} provides endless ammunition for all your troops that shoot."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "Tax Lien"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "The %{name} costs you %{count} gold pieces/turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "Hideous Mask"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "The %{name} prevents all 'wandering' armies from joining your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "Endless Pouch of Sulfur"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "The %{name} provides %{count} unit of sulfur per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "Endless Vial of Mercury"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "The %{name} provides %{count} unit of mercury per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "Endless Pouch of Gems"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "The %{name} provides %{count} unit of gems per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "Endless Cord of Wood"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "The %{name} provides %{count} unit of wood per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "Endless Cart of Ore"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "The %{name} provides %{count} unit of ore per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "Endless Pouch of Crystal"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "The %{name} provides %{count} unit of crystal/day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:128
 msgid "Spiked Helm"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "Spiked Shield"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:130
 msgid "White Pearl"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "Black Pearl"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "Magic Book"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "The %{name} enables you to cast spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "Spell Scroll"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid "Arm of the Martyr"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid ""
 "The %{name} increases your spell power by %{count} but adds the undead "
 "morale penalty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "Breastplate of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "The %{name} increases your defense by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid "Broach of Shielding"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid ""
 "The %{name} provides %{count} percent protection from Armageddon and "
 "Elemental Storm, but decreases spell power by 2."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid "Battle Garb of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid ""
 "The %{name} combines the powers of the three Anduran artifacts.  It provides "
 "maximum luck and morale for your troops and gives you the Town Portal spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid "Crystal Ball"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid ""
 "The %{name} lets you get more specific information about monsters, enemy "
 "heroes, and castles nearby the hero who holds it."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid "Heart of Fire"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid ""
 "The %{name} provides %{count} percent protection from fire, but doubles the "
 "damage taken from cold."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid "Heart of Ice"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid ""
 "The %{name} provides %{count} percent protection from cold, but doubles the "
 "damage taken from fire."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:148
 msgid "Helmet of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:149
 msgid "Holy Hammer"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "Legendary Scepter"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "The %{name} adds %{count} points to all attributes."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "Masthead"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "The %{name} boosts your luck and morale by %{count} each in sea combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "Sphere of Negation"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "The %{name} disables all spell casting, for both sides, in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "Staff of Wizardry"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "The %{name} boosts your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "Sword Breaker"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "The %{name} increases your defense by %{count} and attack by 1."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "Sword of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "Spade of Necromancy"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "The %{name} gives you increased necromancy skill."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:638
 msgid ""
 "You find an elaborate aontainer which housesan old vellum scroll. The runes "
 "on the container are very old, and the artistry with whitch it was put "
@@ -6989,7 +5684,6 @@ msgid ""
 "magical power."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:639
 msgid ""
 "One of the less intelligent members of your party picks up an arm off of the "
 "ground. Despite its missing a body, it is still moving. Your troops find the "
@@ -6998,7 +5692,6 @@ msgid ""
 "making."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:640
 msgid ""
 "You come upon a sign. It reads: \"Here lies the body of Anduran. Bow and "
 "swear fealty, and you shall be rewarded.\" You decide to do as it says. As "
@@ -7006,21 +5699,18 @@ msgid ""
 "that you are suddenly wearing a gleaming, ornate breastplate."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:641
 msgid ""
 "A kindly Sorceress thinks that your army's defenses could use a magical "
 "boost. She offers to enchant the Broach that you wear on your cloak, and you "
 "accept."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:642
 msgid ""
 "Out of pity for a poor peasant, you purchase a chest of old junk they are "
 "hawking for too much gold. Later, as you search through it, you find it "
 "contains the 3 pieces of the legendary battle garb of Anduran!"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:643
 msgid ""
 "You come upon a caravan of gypsies who are feasting and fortifying their "
 "bodies with mead. They call you forward and say \"If you prove that you can "
@@ -7029,7 +5719,6 @@ msgid ""
 "Crystal Ball."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:644
 msgid ""
 "You enter a recently burned glade and come upon a Fire Elemental sitting "
 "atop a rock. It looks up, its flaming face contorted in a look of severe "
@@ -7037,7 +5726,6 @@ msgid ""
 "it, but it passes right through them and sears itself into your chest."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:645
 msgid ""
 "Suddenly, a biting coldness engulfs your body. You seize up, falling from "
 "your horse. The pain subsides, but you still feel as if your chest is "
@@ -7046,7 +5734,6 @@ msgid ""
 "woods and disappear."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:646
 msgid ""
 "You spy a gleaming object poking up out of the ground. You send a member of "
 "your party over to investigate. He comes back with a golden helmet in his "
@@ -7054,7 +5741,6 @@ msgid ""
 "only man who was known to wear solid gold armor."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:647
 msgid ""
 "You come upon a battle where a Paladin has been mortally wounded by a group "
 "of Zombies. He asks you to take his hammer and finish what he started.  As "
@@ -7062,7 +5748,6 @@ msgid ""
 "Zombies lie dead, the hammer dripping with blood. You strap it to your belt."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:648
 msgid ""
 "Upon cresting a small hill, you come upon a ridiculous looking sight. A "
 "Sprite is attempting to carry a Scepter that is almost as big as it is. "
@@ -7071,7 +5756,6 @@ msgid ""
 "flying anyway.\""
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:649
 msgid ""
 "An old seaman tells you a tale of an enchanted masthead that he used in his "
 "youth to rally his crew during times of trouble. He then hands you a faded "
@@ -7079,14 +5763,12 @@ msgid ""
 "underneath a nearby dock."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:650
 msgid ""
 "You stop to help a Peasant catch a runaway mare. To show his gratitude, he "
 "hands you a tiny sphere. As soon as you grasp it, you feel the magical "
 "energy drain from your limbs..."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:651
 msgid ""
 "While out scaring up game, your troops find a mysterious staff levitating "
 "about three feet off of the ground. They hand it to you, and you notice an "
@@ -7094,13 +5776,11 @@ msgid ""
 "words, and you'll win every fight.\""
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:652
 msgid ""
 "A former Captain of the Guard admires your quest and gives you the enchanted "
 "Sword Breaker that he relied on during his tour of duty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:653
 msgid ""
 "A Troll stops you and says: \"Pay me 5,000 gold, or the Sword of Anduran "
 "will slay you where you stand.\" You refuse. The troll grabs the sword "
@@ -7109,4466 +5789,84 @@ msgid ""
 "sharp objects."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:654
 msgid ""
 "A dirty shovel has been thrust into a dirt mound nearby. Upon investigation, "
 "you discover it to be the enchanted shovel of the Gravediggers, long thought "
 "lost by mortals."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:896
 msgid ""
-"Do you want to use your knowledge of magical secrets to transcribe the %"
-"{spell} Scroll into your spell book?\n"
-"The Scroll will be consumed.\n"
-" Spell point: %{sp}"
+"Do you want to use your knowledge of magical secrets to transcribe the "
+"%{spell} Scroll into your Magic Book?\n"
+"The Spell Scroll will be consumed.\n"
+" Cost in spell points: %{sp}"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:960
-msgid "Open book"
+msgid "Transcribe Spell Scroll"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:965
-msgid "Transcribe scroll"
-msgstr ""
+#, fuzzy
+msgid "View Spells"
+msgstr "Melhor Herói em Stats:"
 
-#: ../fheroes2/resource/artifact.cpp:975
-#: ../fheroes2/resource/artifact.cpp:1008
+#, fuzzy
+msgid "View %{name} Info"
+msgstr "Ver %{name}"
+
 #, fuzzy
 msgid "Move %{name}"
 msgstr "Ver %{name}"
 
-#: ../fheroes2/resource/artifact.cpp:998
 #, fuzzy
 msgid "Cannot move artifact"
 msgstr "Não é possível mover o último exército à fortaleza"
 
-#: ../fheroes2/resource/maps_text.cpp:15
-msgid ""
-"425 bottles of beer on the wall, 425 bottles of beer! If one of those "
-"bottles should happen to fall, there'll be..."
+msgid "This item can't be traded."
 msgstr ""
 
-#: ../fheroes2/resource/maps_text.cpp:16
-msgid "A balanced scenario with lots of resources and land to explore."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:17
-msgid ""
-"A bandit army of gorgons jump you without warning.  they stone your entire "
-"army demand 500 gold before they will release your comrads.  Realizing that "
-"it is much cheeper to pay then rebuild your army you part with the gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:18
-msgid "Abandon All Hope!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:19
-msgid "Abandon All Hope Ye That Enter Here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:20
-msgid "A bit of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:21
-msgid "A bit of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:22
-msgid "A bit of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:23
-msgid ""
-"Above you looms the ancient Ice Palace.  Dimly remembered myth speaks of a "
-"Prince who rejected the advances of the Winter Goddess, and thus he and his "
-"domain were cursed to remain shrouded in ice, hidden in a forgotten corner "
-"of the world.  It is said that he can only be rescued by a hero who is both "
-"clever and bold.  Are you that one?  Do you dare enter this frozen domain?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:24
-msgid "A cache of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:25
-msgid "A cache of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:26
-msgid "A cache of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:27
-msgid "A cache of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:28
-msgid "A cache of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:29
-msgid ""
-"A chance to end a bitter war has finally arrived as a new resource-laden "
-"land has been discovered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:30
-msgid "A chunk of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:31
-msgid "A chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:32
-msgid "A couple of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:33
-msgid "\"Act of Desperation\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:34
-msgid ""
-"A desert isle rich in resources rewards the quick.  Just be sure to watch "
-"your back!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:35
-msgid "A dolphin playfully jumps into the air."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:36
-msgid ""
-"A Dragon, A Cyclops, or an Undead. King of the Centaurs, His name is ....?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:37
-msgid "A flight of dragons circles overhead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:38
-msgid "A flock of seagulls circle overhead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:39
-msgid "A friendly dolphin splashes alongside the ship."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:40
-msgid ""
-"After a long search of the island, I have discovered that there is no way "
-"for me to escape without help.  I can not steal a ship from one of the "
-"coastal castles, and I dare not venture into the desert unless I wish to "
-"become Dragon food.  Should anyone find this, I beg of you, please send a "
-"ship and get me off this cursed island!  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:41
-msgid ""
-"After centuries of friendship, the Wizards have suddenly decided to stop "
-"sharing their Library with the rest of the world.  This can't be good!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:42
-msgid ""
-"After many years of peace, you discover that your sworn enemy from across "
-"the sea has chosen to invade your homeland by raising up the ocean floor to "
-"bridge the distance! You must not let them gain a foothold on this "
-"continent, in fact, your King has ordered you to establish a foothold on "
-"theirs!  To make matters worse, two of your OWN towns have thrown in their "
-"lots with the enemy..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:43
-msgid ""
-"After you return from a scouting trip, your Seneschal hurries to greet you.  "
-"\"My Lord, in your absence I signed an agreement in your name with a Master "
-"Merchant.  If we supply him with the resources he needs, through trading, he "
-"can return the resources to us in a week or so, plus some additional ones."
-"\"  The Seneschal eyes you anxiously.  You hesitate, then nod slowly, "
-"\"Good, we can use more resources>\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:44
-msgid "A ghostly pirate ship appears and sails on by."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:45
-msgid ""
-"A Gift from your King, and a note that reads \"Use these resources wisely, "
-"It's all we have left\"."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:46
-msgid ""
-"A gift of gold, m'lord, from the people of Enroth, to the people of Enroth.  "
-"Good luck, and may God save true King Roland!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:47
-msgid "A glint by a tree catches your eye..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:48
-msgid "A gold cache!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:49
-msgid "A gold chunk!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:50
-msgid "A gold nugget!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:51
-msgid ""
-"A great Black dragon stands before you. It speaks in a suprisingly soft "
-"voice, saying, \"The elves believe they have sent another hero to reclaim "
-"their prize. I believe they have sent me another meal.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:52
-msgid ""
-"A group of peasant farmers approaches you, \"We are in dire need of your "
-"assistance.  Our castle to the north has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:53
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance.  Our castle to the east has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:54
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance. Our castle to the east has been overrun and our Lord killed. "
-"Please help us regain our homes! There are still women and children there! "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:55
-msgid ""
-"A group of peasant farmers approach you, We are in dire need of your "
-"assistance.  Our castle to the northeast has been overrun and our Lord "
-"killed.  Please help us regain our homes!  There are still women and "
-"children there!  Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:56
-msgid "A handful of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:57
-msgid ""
-"Ah, you stumble across something buried in the sand.  As you dig it up you "
-"discover a small pile of gems and crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:58
-msgid ""
-"A Knight and Necromancer team up against the Barbarian and Sorceress. (Blue "
-"and Green vs Red and Yellow)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:60
-msgid ""
-"A large contingent of the king's guard approaches you.  \"Ahh, we have "
-"finally caught up to you.  The king requires tribute from all of his vassals "
-"and you have been negligent far too long.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:61
-msgid ""
-"A large map with lots of resources and treasure. Exploration and victory "
-"will require many heroes."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:62
-msgid "A legion of peasants stands between you and this unclaimed island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:63
-msgid "Algary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:64
-msgid "A little bit closer..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:65
-msgid "All mines are grouped by type. Trade is your only hope."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:66
-msgid "A lump of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:67
-msgid "A lump of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:68
-msgid "A lump of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:69
-msgid ""
-"A man appears from behind the sand dune. \"At last,\" he says, \"Someone has "
-"come to rescue me! I am forever grateful. Alas all I have to offer you in "
-"return are these souvenirs from my wrecked ship.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:70
-msgid ""
-"A man is laying on the ground, near death. He looks to you and speaks, "
-"\"Please help my companions! Please... they can't...cough...get away from..."
-"cough...the drag...\" With that, he dies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:71
-msgid ""
-"A merchant caravan arrives, bringing gold and supplies, however, no one can "
-"seem to remember where they came from.  You silently praise this anonymous "
-"benefactor and continue your duties."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:72
-msgid "a mirror"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:73
-msgid "An albatross flies ahead of the ship for a while"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:74
-msgid "Anduran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:75
-msgid ""
-"An enemy from across the sea has seized half your towns.  Can you put aside "
-"your own feud with your brother to fight this common enemy?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:76
-msgid "\"Annexation\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:77
-msgid ""
-"An old elf is sitting on a rock in a glen, pounding on the shackles on his "
-"feet with a stone. You help him remove them and ask him his tale. \"I'm a "
-"deserter from Drakonia's army. She has enslaved all the elves to support her "
-"madness. She must be stopped.\" Then he slips into the woods without a "
-"sound, leaving behind just his cloak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:78
-msgid "Antioch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:79
-msgid "A piece of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:80
-msgid "A pile of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:81
-msgid "A pile of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:82
-msgid "A pile of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:83
-msgid ""
-"A plague of undead is upon us. Who will unite the living against the dead?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:84
-msgid "\"Apocalypse\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:85
-msgid "A quantity of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:86
-msgid "A quantity of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:87
-msgid "A quantity of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:89
-msgid ""
-"Archibald has also sent an army to find the Crown, you must find it first or "
-"all is lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:90
-msgid "Archibald is hiding at the end of the river."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:91
-msgid ""
-"A resource rich valley keeps the Wizard and the Necromancer apart. Your "
-"opponent's army will arrive in 3 months so hurry."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:92
-msgid "Arm of the Crusader"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:93
-msgid "Arm of the Cyclops"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:94
-msgid "Arm of the Dragon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:95
-msgid "Arm of the Phoenix"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:96
-msgid "Arm of the Titan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:97
-msgid "Arr' Here be pirates gold buried."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:98
-msgid "A shipment of wood has arrived from your kingdom!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:99
-msgid ""
-"A splash in the seaweed alerts you to a mermaid waving in a friendly manner. "
-"\"Oh, I thought you were Ahab.\" She is surprised, but quickly composes "
-"herself. \"Well, if you meet him, give him these treasures I have collected."
-"\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:100
-msgid "Assassins tried to kill our ally."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:101
-msgid "Astircaer"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:102
-msgid ""
-"A stranded Wizard with only a small force must conquer an entire continent "
-"of hostile forces."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:103
-msgid ""
-"A supply ship has arrived from the homeland!  You send word home that all is "
-"well."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:104
-msgid ""
-"As you approach the barrier, you see the old elf you helped free. This time, "
-"however, you see that he is wearing a cape of fine weave, and a wooden crown "
-"is on his head. He sees your forces, and says \"Take this sword, and with "
-"it, strike down Drakonia and help free my people.\" The old elf then strides "
-"regally into the woods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:105
-msgid ""
-"As you approach the gates of the Ice Palace, one of your troops points in "
-"terror.  You watch in awe as great slabs of ice separate from the castle "
-"walls with loud cracking reports and crash to the ground.  Soon the ice is "
-"gone and the sun begins to peak through the gloom.  The deathly silence that "
-"must have ruled these lands for centuries ends as birds begin to sing.  From "
-"inside you hear the sounds of life."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:106
-msgid ""
-"As you approach the tent, the leader of the nomads comes out to greet you. "
-"He says, \"It was prophecied many years ago that a great hero would come to "
-"greet us in our sacred valley, and we would prosper afterwords. Now it has "
-"come to pass, and we offer you these gifts as tokens of our thanks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:107
-msgid ""
-"As you approach,  you hear whispered mentions of \"the wild barbarian who "
-"passed this way months before\". One of the villagers approaches you and "
-"hands you an object, saying \"The wild one dropped this. You must be his "
-"kin. Therefore I give it to you. But beware! Many in the village will not be "
-"as friendly as I.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:108
-msgid ""
-"As you break your fast your sage rushes in, \"Good news, my lord!  I have "
-"translated the message.  Two great heroes were imprisoned many years ago.  "
-"They lie sleeping - still guarded by magic barriers and monsters.  My lord, "
-"they lie nearby- in between our ally and us.  If we could free them, they "
-"would surely aid us against our enemies!  The password to the first magic "
-"barrier can be learned at the Aqua Traveller's Tent.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:109
-msgid ""
-"As you enter the small clearing, you see a familiar figure talking to a "
-"group of halflings and soldiers. You stay awhile and listen to his speech. "
-"\"The time to throw off these chains of tyranny is now! We must strike at "
-"the heart of her empire, and destroy the evil that she has brought to our "
-"land.\" As the old elf finishes speaking, he gets up from his mossy seat and "
-"once again, blends into the woods with incredible grace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:110
-msgid ""
-"As you lay down to nap after a long battle, you notice a lucky four-leaf "
-"clover."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:111
-msgid ""
-"As you make  your way through the last of the golemn debris, a group of "
-"halflings runs towards you carrying fruit and flowers. \"Thank you so much!"
-"\" Their leader exclaims, \"We've been trapped in here for ever! Come by our "
-"homes, we'll pack up and go with you!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:112
-msgid ""
-"As you make your way to the shrine, some very thin and hollow-eyed men come "
-"out of the flower patch and stare at you.  Seeing that you want the gold, "
-"one of them says to you \"Hey, man, if you're, like, so lusty for earthly "
-"wealth, then, like, have this too.\" You graciously take what they have "
-"offered and back out of the clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:113
-msgid ""
-"As you prepare your lands to fight the onslaught from the South, a curious "
-"message appears on your table in the Great Hall of your Castle.  Written in "
-"some ancient language, none but your sage can make any sense of it.  She "
-"promises to have the words deciphered by tomorrow..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:114
-msgid "A three hour tour, a three hour tour..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:115
-msgid ""
-"A tiny gnome points to a chunk of crystal you otherwise would have "
-"overlooked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:116
-msgid "Atlantium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:117
-msgid ""
-"At last, the king is dead.  For years you have planned his demise, but now "
-"it is done, and there is no heir to take his place, though the Knights to "
-"the south believe that they are the rightful successors.  A wealth in wood "
-"(to the south) and ore (in the northern mountains) provides you with trade "
-"goods, and your isolation has allowed you to prepare your forces of darkness "
-"for this day.  Go, now, and fulfill your destiny!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:118
-msgid ""
-"At the base of the mountain you see something that glitters.   You discover "
-"an ancient pile of offerings to the gods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:119
-msgid "Avalon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:120
-msgid "Avone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:121
-msgid ""
-"A wild magic has allowed a bridge to form between two lands...  Your one "
-"hope is to capture castle \"Black Fang\"."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:122
-msgid "Barbarian's castle lies to the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:123
-msgid ""
-"Barbarians from the north threaten all civilization. Can you repel the "
-"hordes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:124
-msgid "\"Barbarian Wars\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:125
-msgid "Barrowton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:126
-msgid "Basenji"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:127
-msgid "Bayside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:128
-msgid "Baywatch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:129
-msgid ""
-"Because the Darkscale Valley is so barren, the Emperor will be sending wood "
-"to you every week. Use it wisely, for it is all you shall have."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:130
-msgid ""
-"Before questing for the orb of negation, you must first crush the local "
-"opposition. After the Sorceresses are removed from the earth, go east where "
-"legend says the orb lies.  You may expect a convoy of supplies in a week or "
-"so to aid your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:131
-msgid ""
-"Before you may pass, the spirit guardian of this valley demands tribute."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:132
-msgid "Being held...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:133
-msgid "Beltway"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:134
-msgid "\"Betrayal!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:135
-msgid "Beware -- Entering Hyrda Country"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:136
-msgid "Beware for whom the bell trolls."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:137
-msgid "Beware of Pirates!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:138
-msgid "Beware of thieves!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:139
-msgid "Beware of traps ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:140
-msgid "Beware of Warlocks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:141
-msgid "Beware the deadly swamps!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:142
-msgid "Beware the Domain of Dragons"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:143
-msgid "Beware the Dragon Leader"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:144
-msgid "Beware the edge of the world!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:145
-msgid "Beware the moors and stick to the roads."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:146
-msgid "Beware the rocks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:147
-msgid "Beware the sirens!!!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:148
-msgid "Beware the sirens!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:149
-msgid "Beware the whiporwill..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:150
-msgid "Beware, the whirlpool may not take you into a friendly embrace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:151
-msgid "Beyond here be Dragons!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:152
-msgid "Beyond the door, there be Dragons. BEWARE!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:153
-msgid "Big Oak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:154
-msgid "Blackburn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:155
-msgid "Blackfang"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:156
-msgid "Black Fang"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:157
-msgid "Black Oak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:158
-msgid "Blackridge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:159
-msgid "Blacksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:160
-msgid "Black Vein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:161
-msgid "Blackwind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:162
-msgid "Bloodreign"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:163
-msgid "Boats my be needed to access some parts of this peninsula."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:164
-msgid "Boats Sold Here            Inquire Within"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:165
-msgid "BoneVille"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:166
-msgid "Borderlands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:167
-msgid "Bridge out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:168
-msgid "Bridge Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:169
-msgid "Brindamoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:170
-msgid "Broken Alliance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:171
-msgid "Brownston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:172
-msgid "Buried Treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:173
-msgid "Burlock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:174
-msgid "Burton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:175
-msgid ""
-"Capture the necromancer's dreaded castle \"Death Gate\" and free the land "
-"from the undead plague."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:176
-msgid ""
-"Capture the town on the island off the southeast shore in order to construct "
-"a boat and travel back towards the mainland."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:177
-msgid "\"Carator Mines\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:178
-msgid "Cathcart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:180
-msgid "Chandler"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:181
-msgid "Chilton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:182
-msgid "Chronos"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:183
-msgid "Come and...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:184
-msgid ""
-"Compared to the rest of the villages in this land, this village seems grand, "
-"but in any other land it would seem poor. From here you can see the tall "
-"spires of the Warlock's tower of Dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:185
-msgid "Complete"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:186
-msgid "Condemned!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:187
-msgid ""
-"Congratulations! After navigating the treacherous coast, you have "
-"established trade between the north and south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:188
-msgid "Corackston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:189
-msgid "Corlagon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:190
-msgid "\"Country Lords\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:191
-msgid "Crossroads"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:192
-msgid "Crossroads North"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:193
-msgid "Crossroads South"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:195
-msgid "Danger a whirlpool destroyed my ship."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:196
-msgid "Danger, Dragons abound!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:197
-msgid "DANGER!  QUICKSAND!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:198
-msgid "Danger! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:199
-msgid "Danger - Turn Back Now"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:200
-msgid "Dark clouds loom overhead as you enter this valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:201
-msgid "Dead Pine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:202
-msgid ""
-"Dear Diary,                           I found a mermaid today.  She was "
-"floating in a patch of seaweed next to a rock.  A very friendly sort of "
-"creature too!  Gave me all sorts of lovely gems and jewelry!  She said to "
-"come back again sometime for more of the sea riches.  Wow. Ahab"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:203
-msgid "Deathgate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:204
-msgid "DeathGate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:205
-msgid "Decisions"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:206
-msgid "\"Defender\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:207
-msgid ""
-"Destroy the Barbarians who are attacking the southern border of your "
-"kingdom! Recover your towns and then invade the jungle kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:208
-msgid ""
-"Detour! Mountain pass to the East has been known to have avalanches! For "
-"your own safety, follow the road South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:209
-msgid "Detour! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:211
-msgid "DirtWater"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:212
-msgid "Dominion"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:213
-msgid "Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:214
-msgid "Do not remove coins from fountain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:215
-msgid "Dragadune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:216
-msgid "Dragonburg"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:218
-msgid "Dragon City lies beyond the Scorpion Hills."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:219
-msgid "Dragon Hill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:220
-msgid "\"Dragon Master\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:221
-msgid "Dragon Rider"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:222
-msgid "Dragons Everywhere!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:223
-msgid "Dragon's Eye"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:224
-msgid "Dragontooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:225
-msgid "Dragon Town"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:226
-msgid "Dragonville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:227
-msgid "Dragon Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:228
-msgid "Dragon Watch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:230
-msgid "Drakoran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:231
-msgid "Dwarfhall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:232
-msgid "Dwarfhall, Domain of the dwarf King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:233
-msgid "Dwarf Hall, domain of the dwarf King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:234
-msgid "Eatio"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:235
-msgid "Edgewood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:236
-msgid "Elk's Head"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:237
-msgid "Elowyn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:238
-msgid "Enroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:239
-msgid "Entering high in the desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:240
-msgid "Entering Praires of the Middlelands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:241
-msgid "Entering the desert high"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:242
-msgid "Entering the high desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:243
-msgid "Entering the higher desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:244
-msgid "Entering the Valley of Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:245
-msgid "Erliquin"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:246
-msgid "Evil Igor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:247
-msgid "Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:248
-msgid "Fantasy Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:249
-msgid "Farlien"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:250
-msgid ""
-"Federal express, when it absolutely positively has to be there turn one."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:251
-msgid "fedx comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:252
-msgid "Fedx for comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:253
-msgid "Fenton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:254
-msgid "Fetid Elm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:255
-msgid ""
-"Final message from Overlord. \"The royal executioners are on their way. My "
-"gold, the land or your head- it's your choice.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:256
-msgid "Find and defeat the Pirate Leader!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:257
-msgid "Find and destroy the evil beings who rule the wastelands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:258
-msgid "Find the center island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:259
-msgid ""
-"Find the Ultimate Artifact and be proclaimed King, or smash the opposition "
-"and take control."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:260
-msgid ""
-"Find Your Wayward Son who is rumored to be living in the desolate lands. Do "
-"it within 8 weeks or it will be of no help to your family."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:261
-msgid "Fire King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:262
-msgid "\"First Blood\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:263
-msgid "Five heroes vie for control of a familiar land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:264
-msgid "Fool's Gold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:265
-msgid ""
-"For a total of 400,000 gold your opponents will become \"loyal\" subjects, "
-"otherwise... let them eat cake!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:266
-msgid ""
-"For centuries, the Wizards of the North have maintained a vast library for "
-"all the world to share.  Now, however, they have closed their doors, and "
-"issued declarations of war to each of the other rulers of the land.  To make "
-"matters worse, rather than ally with you to face the Wizards, each of the "
-"others have decided to go forth on their own in an effort to conquer this "
-"land for themselves!  Prepare your forces, commander, for you now stand "
-"alone."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:267
-msgid "\"Force of Arms\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:268
-msgid ""
-"For decades you have studied, learned, and allowed yourself to be ruled by "
-"that pitiful excuse for a king, knowing that one day the time would come for "
-"you to sit on the throne.  That time is now, for the king is dead and "
-"without an heir.  You have the advantage of isolation from the rest of the "
-"kingdom, but beware the miles of coastline that could leave you vulnerable "
-"to attack.  Go, now, and wipe your enemies from this land!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:269
-msgid "Forder Oaks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:270
-msgid "Forestria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:271
-msgid "For Honor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:272
-msgid ""
-"For information about Ye Rich lands to the south, speak to Alponse at the "
-"Golden Goose Tavern. Excellent views, plentiful water."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:273
-msgid "Forsaken Lands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:274
-msgid "For sale."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:275
-msgid "Fortress Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:276
-msgid ""
-"For years, you have existed peacefully in the Forest of Dreams, knowing that "
-"your king was the kindest and strongest ruler the land had seen in "
-"centuries.  Now, however, his reign is at an end, and there is no heir to "
-"succeed him.  You realize that a power struggle is coming, and that you must "
-"brace yourself for war, and prevent those who would harm this land from "
-"coming into power!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:277
-msgid ""
-"For years, you've been able to keep your subjects \"appeased.\"  Now "
-"however, you discover not only that your entire kingdom has turned against "
-"you, but most of your outer towns have fallen to the different factions.  To "
-"make matters worse, all your gold suddenly seems to be missing from the "
-"treasury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:278
-msgid "Fountainhead"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:279
-msgid "Four kingdoms race to capture the island of Sharkania."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:280
-msgid "Four lakes have castles, three have treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:281
-msgid "Four players must work together to assault the Wizards' Stronghold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:282
-msgid "Frozenpeak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:283
-msgid "Full House"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:284
-msgid ""
-"Gain the aid of the elves. They will not allow trees to be chopped down, so "
-"we will send you wood every 2 weeks. You have 7 months!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:286
-msgid "Galveston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:287
-msgid "Garamok"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:288
-msgid "Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:289
-msgid "Gate to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:290
-msgid "Gate to The Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:291
-msgid "Gaurdian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:292
-msgid "Gavonshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:294
-msgid "Glastonbury"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:295
-msgid "Go away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:296
-msgid "GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:297
-msgid "Goblin Island"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:298
-msgid "Goblin King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:299
-msgid "Go Home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:300
-msgid "Go north to find the lost gold-mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:301
-msgid "Good vs. Evil"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:302
-msgid "Gorgomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:303
-msgid "\"Greater Glory\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:304
-msgid "Greed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:305
-msgid "Green bonus stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:306
-msgid "Green gets stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:307
-msgid "Greenroot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:308
-msgid "Green's Allowance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:309
-msgid "Green's Groceries"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:310
-msgid "green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:311
-msgid "Green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:312
-msgid "Greywind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:313
-msgid "Grim"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:314
-msgid "Grrr, Blazzer, Grrupt. Be gone with you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:315
-msgid "Guardian War"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:316
-msgid "Gungtooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:317
-msgid "Hail Unicorns!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:318
-msgid "Hampshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:319
-msgid "Have fun storming the castle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:320
-msgid "Havenwood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:321
-msgid "Hawkins"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:322
-msgid "Help!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:323
-msgid "Help me...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:324
-msgid ""
-"Help peasant farmers regain their castle and land, else they'll take your "
-"crops."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:325
-msgid "Hero's Hall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:326
-msgid ""
-"High in the snowy crags, you meet an old witch who, in return for a trinket "
-"of yours, gives you a powerful magical object she used to use as a footstool "
-"before she was exiled into the mountains by her own townspeople."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:327
-msgid "Hillstone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:328
-msgid "Hilltop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:329
-msgid "Hilltown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:330
-msgid "Horizon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:331
-msgid "Hot Spot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:332
-msgid "Hungry dragons await.  Welcome, food."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:333
-msgid "Hurry, no time to wait.  This way to the dock."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:334
-msgid "Hurry up! Few days are left before the enemy's army arrives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:335
-msgid "I am...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:336
-msgid ""
-"I am one of the few remaining survivors of the wrecked pleasure ship, "
-"Exhorbitance. I think we'll all be dead of hunger soon, for we are out of "
-"caviar. We ate the chef yesterday."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:337
-msgid "Ibn Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:338
-msgid "Ice Palace"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:339
-msgid "Ice Prince"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:340
-msgid "Icy lands ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:341
-msgid "I didn't do it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:342
-msgid ""
-"If three heroes could dig six holes in three days, how long would it take "
-"six heroes to dig twelve holes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:343
-msgid "If you free a hero, they may help..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:344
-msgid ""
-"If you value your lives, for God's sake, Don't go through this whirlpool!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:345
-msgid "Income for Yellow."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:346
-msgid "In the hole you find a chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:347
-msgid "In the stream you find an old compass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:348
-msgid "In this glen live some very naughty halflings. Stay Away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:349
-msgid ""
-"In two more weeks, if you have not located Joseph, your kingdom will surely "
-"lose its current battle with Harondale."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:350
-msgid "I see you, you see me."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:351
-msgid "Is it something I said? Go back and I will forget the whole thing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:352
-msgid "IslandHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:353
-msgid "Island of the Elves"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:354
-msgid "Island of the meek"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:355
-msgid "Island of Wolcott"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:356
-msgid "Isle Maze"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:357
-msgid "Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:358
-msgid ""
-"It has become apparent that if all your enemies were eliminated, you would "
-"have all the time you need to find the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:359
-msgid ""
-"It is obvious that the mage that once was here had won many battles!  There, "
-"upon his hand, is a most powerful ring!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:360
-msgid ""
-"It is rumored that a bridge of land used to exist between the two "
-"continents, but that a wild magic caused it to sink into the sea, taking "
-"with it all those who used to inhabit it.  To try to raise this bridge is to "
-"invite a curse upon the world!  The spirits of the dead will haunt us all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:361
-msgid ""
-"It is said that King Zealot found the gods' artifact once and it let him "
-"rule for 100 years."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:362
-msgid ""
-"It looks like there used to be an ore mine here but all you see now is a "
-"hole in the ground and some minerals scattered around."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:363
-msgid ""
-"It's a battle for supremacy as the Blue and Green heroes take on Red and "
-"Orange in team competition!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:364
-msgid "It's windy at the top.  Defend, Divide, and Conquer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:365
-msgid "IvanHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:366
-msgid "Ivan lives in the desert."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:367
-msgid "Ivory Gates"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:368
-msgid ""
-"I, Wilgatus, besiege you - do not fight me for I am all powerful and will "
-"destroy you if you persue me.  I will demonstrate my power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:369
-msgid "I Would Go That Way If I Were You."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:371
-msgid "Jarkonas VI"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:372
-msgid "Jolly Roger was here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:374
-msgid "Jungomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:375
-msgid "Just 30 days left!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:376
-msgid "Just ONE week left!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:378
-msgid "Kastor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:379
-msgid "Keep going south"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:380
-msgid "Keep Off The Grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:381
-msgid "Keep Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:382
-msgid "King John"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:383
-msgid "King of Death"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:384
-msgid "Knight's Trail."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:385
-msgid "Knight stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:386
-msgid "Lakeside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:387
-msgid "Land's Edge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:388
-msgid "Land teleporters will get you to your destination sooner."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:389
-msgid "Lankershire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:390
-msgid "Lavalor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:391
-msgid "Like, Stuff And Junk?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:392
-msgid ""
-"Living on the outskirts of the kingdom, you are considered an unwelcome "
-"outcast by the other leaders of the realm, though you always showed your "
-"support for the king.  Now, however, the king is dead, and many of those who "
-"spoke out againt him seek to seize his throne for themselves.  You have a "
-"vast desert at your back, rich with gems, and the advantage that many do not "
-"consider you a threat.  Go, now, and show them how wrong they are!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:393
-msgid "Lladner Dock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:394
-msgid ""
-"Log go up... Log go down... Log go up... Log go down...  OOoohhhhhhhh........"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:395
-msgid "Lombard"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:396
-msgid "Long live Roland the true King!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:397
-msgid "Long live Roland the true King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:398
-msgid "Look before you leap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:399
-msgid "Look out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:400
-msgid "Lord Alberon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:401
-msgid ""
-"Lord Alberon calls you into his war room. He says, \"I am glad you have "
-"chosen to remain loyal to me, but this war is a terrible one for my kingdom. "
-"Already, the sorceress' towns to the Northeast have become unsure about "
-"their loyalties, and will not pledge allegiance to either side. This is hard "
-"on our cities as most of the wood in the land comes from these towns. We "
-"will need to recover their sawmills and take their towns by force.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:402
-msgid "Lord Haart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:404
-msgid "Lord Kreager"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:405
-msgid ""
-"Lord, messages have begun pouring in from our spies in the other island "
-"courts.  They have learned of a new volcanic island with vast amounts of "
-"reasources.  Your Majesty, with these new reasources we could put an end to "
-"a century of war between the islands, and reunite them under your rightful "
-"rule."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:406
-msgid "Lost Continent"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:407
-msgid "Lost Gold- Mine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:408
-msgid "Lost Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:409
-msgid "Lost Relic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:410
-msgid "Maelstrom of Deceit"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:411
-msgid "Maelstrom of Misery"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:412
-msgid "Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:413
-msgid "Magic Three"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:414
-msgid ""
-"Many dust plumes rise from the floor of this small valley. You see various "
-"bands of nomads roaming about, and in the distant, the bright flames of "
-"their camp."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:415
-msgid ""
-"Many guardians stand between you and your enemies, but anybody can sneak "
-"through the back door!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:416
-msgid "Many that have gone through this door have never returned."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:417
-msgid ""
-"Many years ago, a couple of mages had a \"duel\" that forever changed the "
-"lake at the center of this continent.  Hearty adventurers might find "
-"interesting treasure there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:418
-msgid ""
-"Many years ago, a falling star crashed near here.  Only now the area is safe "
-"enough to explore.  Rumor has it a castle exist where the star fell."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:419
-msgid ""
-"Many years ago, your father, the King, died in a freak hunting accident.  "
-"Since then, you and your brother have jointly ruled his kingdom, but both of "
-"you have been seeking a way to seize the throne for yourself.  You got your "
-"wish.  Attackers from across the sea have captured more than half your towns "
-"and castles, effectively dividing the continent in two.  Now is the time to "
-"repel these invaders and do away with your brother once and for all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:420
-msgid "Marco"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:421
-msgid "Marsh Home"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:423
-msgid "Mayland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:424
-msgid "Meramec"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:425
-msgid "Message from Archibald. \" Do not dare to return without my Crown.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:426
-msgid ""
-"Message from Archibald. \" General, thank you for bringing me this lovely "
-"gift. I have decided to participate directly in the capture of my brother "
-"Roland. Since your military advice has taken us this far, I will follow your "
-"orders to the letter.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:427
-msgid "Message from Overlord. \"STILL WAITING FOR MY GOLD!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:428
-msgid "Message from Overlord. \"WHERE'S MY GOLD?\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:429
-msgid ""
-"Message from Roland. \"General, circumstances permit me to take a hand in "
-"the events of this final conflict. I have your spoils of war with me and I "
-"will follow your advice explicitly.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:430
-msgid ""
-"Message from Roland.  \"General, I have sent most of our troops and material "
-"ahead to the region of the final conflict with Archibald.  Unfortunately, "
-"Lord Corlagon has cut us off from the rest of our army.  I will be awaiting "
-"your victory in a castle across the west river.  I should be safe from "
-"attack.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:431
-msgid ""
-"Message from Roland. \" We cannot hope to defeat Archibald without the "
-"Crown, I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:432
-msgid "Middle Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:433
-msgid "Middleton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:434
-msgid "Middletown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:435
-msgid "Might vs. Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:436
-msgid "Mineral Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:437
-msgid "Mirkosov"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:438
-msgid "mirror"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:439
-msgid "Money For Red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:440
-msgid "MONEY, MONEY, MONEY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:441
-msgid "Morale becomes even lower as the endless cliffs move past."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:442
-msgid ""
-"More water than land, you'll still spend lots of time on foot as you search "
-"a literal horde of islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:443
-msgid "Mountain king"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:444
-msgid "Mountainview"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:445
-msgid "Mr Ed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:446
-msgid "Mr. Yellow's Income"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:447
-msgid "Murray's resort Isle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:448
-msgid ""
-"Mutiny!  The crew has dumped off my precious cargo into the sea!  Thank "
-"goodness it floats - when I've rid of them, I'll come back to pick it up!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:449
-msgid ""
-"My leige, our scouts report three other lords are attacking from the south. "
-"They work in conjuction with each other to eliminate us! We must keep this "
-"castle and remove the threat of the enemy. We wish you luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:450
-msgid ""
-"My leige, we have established a foothold (which we cannot afford to lose) "
-"and all of our Heroes have joined us. The king has made us the offer to "
-"purchase this land for 200,000 gold or we may take it by force. The local "
-"lords have been fighting and each wants to be the one that defeats us. Now "
-"all the local armies have arrived on the beach, creating a state of complete "
-"Pandemonium!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:451
-msgid "My Treasure Is Buried Beneath Three Palm Trees"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:452
-msgid "\"Necromancers!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:453
-msgid "New Dawn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:454
-msgid "New Enemies"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:455
-msgid "New Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:456
-msgid "Nightshadow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:457
-msgid "No Description"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:458
-msgid "No Fishing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:459
-msgid "No gems, crystal, or mercury for red."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:460
-msgid ""
-"None of the four leaders like being stuck in a land that has only one season."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:461
-msgid "NO, Not That Way. This Way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:462
-msgid "No one has ever made it out of the deadly swamps alive!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:463
-msgid "Noraston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:464
-msgid "North Road"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:465
-msgid "North vs. South"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:466
-msgid "No stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:467
-msgid "No sulfer fer Yella."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:468
-msgid "No swimming."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:469
-msgid "Notice- Those who put messages in bottles will be tortured."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:470
-msgid "No Trespassing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:471
-msgid "No tresspath...  No tree...  No thresh...  GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:472
-msgid "Now leaving Swamplands of the Eternial"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:473
-msgid "Obsidian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:474
-msgid "Of the necromancers...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:475
-msgid "Ogrehild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:476
-msgid "Olympus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:477
-msgid ""
-"One of the seers in your castle comes to you in the morning with urgent "
-"news. Your one time comrade, the wizard Joseph, and his armies have been "
-"imprisoned in a jail nearby. His power would surely aid you in your quest to "
-"reclaim the library, you think to yourself. Perhaps there is a way to rescue "
-"him..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:478
-msgid ""
-"One of your aides reports that the Castle of Farlien is located on the "
-"northeast spur of this island, and is a stronghold for the enemy. He urges "
-"you to take it out as soon as possible, and then move onto other islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:479
-msgid ""
-"One of your \"allies\" has joined Archibald.  You now face an opponent with "
-"three castles to your one.  Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:480
-msgid ""
-"One of your \"Allies\" has joined Roland. You are now facing three castles, "
-"all belonging to the enemy. Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:481
-msgid "One of your loyal goblins has brought you an armload of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:482
-msgid ""
-"One of your loyal subjects, a fairy tells you where to find a cache of "
-"mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:483
-msgid ""
-"One of your scouts reports a tiny cave nearby. Upon investigating, you "
-"discover a small cache of goods. In the dirt by them is etched 'Ivan'."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:484
-msgid ""
-"One of your troops stubs its paw on something buried here.  After a few "
-"hours of digging you unearth a cache of treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:485
-msgid "Only a month remains in which to find Joseph."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:486
-msgid "On quite days, Nubbie the sea monster can be seen!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:487
-msgid "Orange stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:488
-msgid "Orcville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:489
-msgid "Ostoroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:490
-msgid "Other than the dragons, the elves don't have any enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:491
-msgid "Our ally was greatly weakened when his resources were plundered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:492
-msgid "\"Our Finest Hour\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:493
-msgid "Our reinforcements were lost in a storm, we salvaged all we could!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:494
-msgid ""
-"Our spies have discovered that the barbarian hordes are now receiving "
-"support from kraeger! You must hurry and find the third piece before your "
-"forces here are crushed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:495
-msgid "Overlord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:496
-msgid "Pandemonium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:497
-msgid "Paper can gain you what wood and sail cannot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:498
-msgid "Password found by Crystals to the South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:499
-msgid "Peacekeeper"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:500
-msgid "\"Peasants!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:502
-msgid "Peasantsville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:503
-msgid "Perenor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:504
-msgid "Pet Cemetary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:505
-msgid "Pick one of four Knights in this large and inhospitable land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:506
-msgid "Pig's Eye"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:507
-msgid "Pinehurst"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:508
-msgid "Pirate Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:509
-msgid "Pirate's Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:510
-msgid "Pirate Utopia"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:511
-msgid "Pirites strike and take the gold from you holds."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:512
-msgid "Pixie"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:513
-msgid ""
-"Play the Knight or Barbarian in an alliance in this classic duel against the "
-"four spell casters. (Blue and Green vs Red)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:514
-msgid "Please...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:515
-msgid ""
-"Plenty of resources and lots of ground to cover. Watch out for Orange and "
-"Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:516
-msgid "Portals"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:517
-msgid "Portsmith"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:518
-msgid "POSION - DO NOT DRINK"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:519
-msgid "Powerful magic lies southwest of here in the Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:520
-msgid "Prisoner on...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:522
-msgid "Quick Silver"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:523
-msgid "Raste"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:524
-msgid "Realm of the Undead.  Fresh blood welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:525
-msgid "Red bonus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:526
-msgid "Red player sympathizes with the undead cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:527
-msgid "Red's Connection"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:528
-msgid "Redshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:529
-msgid "Red's Lunch Money"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:530
-msgid "Red's Rubles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:531
-msgid "Red stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:532
-msgid ""
-"Regrettably, you have no castle with which to begin your assault. "
-"Fortunately, however, Kraeger's forces are weak here in the south, and you "
-"have bribed a rebel necromancer to aid you in the beginning of your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:533
-msgid "Reinforcements have arrived, Gold from the homelands!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:534
-msgid ""
-"Remains of a long since dead wizard have attracted an ancient artifact.  "
-"This artifact has now attached itself to you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:535
-msgid ""
-"Remember, you're searching for the Ultimate Artifact... don't get distracted!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:536
-msgid ""
-"Rendall Koski was here. 1997.  Northampton, Massachusetts There is a "
-"powerful artifact in the southeastern corner of the world.  Go for it, "
-"explorer!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:537
-msgid ""
-"Reports from your spies tell of enemies on the march.  As you rush to the "
-"castle courtyard to prepare your armies, you are intercepted by your "
-"Chaplain.  \"My Lord, I have received word that we should send what Heroes "
-"we can to the Isle of Knowledge.   The Scholars there have agreed to teach "
-"them so they will be strong for the battles ahead of us.\"  You thank the "
-"Chaplain for the information and head thoughtfully into the courtyard."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:538
-msgid ""
-"Rescue your crazy Uncle Ivan. Find him within 4 months or it will be no help "
-"to your kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:539
-msgid "Restricted Area, Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:540
-msgid "Rest stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:541
-msgid "Retake the Castle of Ivory Gates."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:542
-msgid "Revolution"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:543
-msgid "Right thinking - he who takes the riskes deserves the rewards."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:544
-msgid "River Crossing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:545
-msgid "Road Ends"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:546
-msgid "Road to Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:547
-msgid "Road to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:548
-msgid "Robbers have looted your treasury and you have lost valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:549
-msgid "Robbers have looted your treasury, stealing valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:550
-msgid "Roc Haven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:551
-msgid "Rogar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:553
-msgid "Roscomon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:554
-msgid "Rotten Birch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:555
-msgid ""
-"Rumors abound and your faithful hero Sandro is now highly regarded by the "
-"masses. Should Sandro desert you, all will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:556
-msgid "Sandcaster"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:558
-msgid "Sands of Time"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:559
-msgid "Sansobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:560
-msgid "\"Save the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:561
-msgid "Scabsdale"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:562
-msgid "Scorched Earth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:563
-msgid ""
-"Scouts have reported a town to the North.  They have also heard some "
-"disturbing news.  Their seems to be a war raging in this area."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:564
-msgid ""
-"Scouts report the enemy's stronghold lies to the Southwest. Our swift "
-"arrival has caught them by surprise. If you move quickly their resistance "
-"will be minimal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:565
-msgid ""
-"Scouts report the notorious necromancer \"Wyrm\" has been sighted to the "
-"northeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:566
-msgid "Scummy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:567
-msgid ""
-"Searching in the dust of this abandoned campsite, you find a magic scroll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:568
-msgid "Seasons Change"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:569
-msgid "Secret Mountain Pass"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:570
-msgid ""
-"Seek out the Ultimate Artifact to be victorious in this strangely shaped "
-"land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:571
-msgid ""
-"Seek the great library, for only with the guidance of the musty tomes therin "
-"will you find the means to reveal and bind the fount to your will."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:572
-msgid "Seven Lakes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:573
-msgid "Sharkania"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:574
-msgid "Sheltemburg"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:575
-msgid "Sherman"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:576
-msgid "Shipwrecked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:577
-msgid ""
-"Should this message ever reach home, please know that this has become a "
-"hostile place since the King's death.  No less than six factions are at war "
-"with each other, each seeking to be the King's successor.  Beware especially "
-"of the Barbarians and the Necromancers who control the north, their regions "
-"are easily defended and they have a wealth of gold and gems.  Do not venture "
-"to this land without a sizeable force.  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:578
-msgid "Sirein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:579
-msgid ""
-"Six factions have established a foothold on a huge, unexplored continent.  "
-"Can you eliminate the other five?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:580
-msgid ""
-"Six heroes with large armies prepare to slug it out for total domination!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:581
-msgid "Skirmish"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:582
-msgid "\"Slay the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:583
-msgid "Slippery when wet."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:584
-msgid "Slugfest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:585
-msgid ""
-"Snagged on a thorny bush, you discover a scrap of cloth. The design on it "
-"looks like the coat of arms of Ivan's house!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:586
-msgid "Snowdrop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:587
-msgid "Somebody has stuffed a pile of gems in the ditch!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:588
-msgid "Some crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:589
-msgid "Some gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:590
-msgid ""
-"Someone has stolen 100 wood and 77 ore from you. Ah, that's nothing. Let's "
-"keep going."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:591
-msgid ""
-"Someone has stolen gold and resources from  the palace treasury!  You "
-"suspect your enemies, but you can't know for certain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:592
-msgid "Someone is playing a pan flute around here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:593
-msgid ""
-"Someone notices a piece of parchment lying behind a clump of grass. You pick "
-"it up. It looks to be a page from a journal, and it reads, \"...made it past "
-"the first guardians. Hopefully will reach the ancient desert city soon. Only "
-"hope my forces are strong enough to survive...\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:594
-msgid "Some ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:595
-msgid "Some sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:596
-msgid ""
-"Some unlucky adventurers have been captured and imprisoned in these lands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:597
-msgid "Sorceress Forest.  Show respect for nature!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:598
-msgid "Sorpigal"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:599
-msgid "South Mill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:600
-msgid "So you think you're smart?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:601
-msgid "Spector"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:602
-msgid "Spell Casters"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:603
-msgid ""
-"Spies report Roland has sent a hero to search for the Crown. If he finds it "
-"first, all is lost!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:604
-msgid "Spirit City"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:605
-msgid "Spy Tower - see what your competition is doing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:606
-msgid "Stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:607
-msgid ""
-"Start with five castles!  How could you lose!?  Oh yeah, everyone else "
-"starts with five, too."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:608
-msgid "Stick to the road!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:609
-msgid "Stromgild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:610
-msgid "Stromhild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:611
-msgid "Stronghold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:612
-msgid "Stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:613
-msgid "Stuff for Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:614
-msgid "Stuff For Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:615
-msgid "Subbaculcha"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:616
-msgid "Sundune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:617
-msgid "Surf and Turf"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:618
-msgid "Swimming near the kelp is a pod of dolphins."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:619
-msgid "Tacma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:620
-msgid "Tchudes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:621
-msgid "Teleporters"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:622
-msgid "Terra Firma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:623
-msgid "Terrain Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:624
-msgid ""
-"The alliance has crumbled and all are at war. Lots of resources but little "
-"time to prepare."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:625
-msgid ""
-"The ancient King Zealot had the artifact of the gods and then hid it in his "
-"old age so that it could not be used by others."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:626
-msgid "The Back Door"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:627
-msgid ""
-"The Barbarian's lands are being invaded. Are you strong enough to resist the "
-"invasion?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:628
-msgid ""
-"The castle of Drakonran in the east has been taken by the barbarians! Two "
-"other towns to the west have also been taken, but the barbarian armies were "
-"fairly decimated in the process."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:629
-msgid "The center island is rumored to harbor great spells."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:630
-msgid "The Citadel"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:631
-msgid "The cities of the plains."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:632
-msgid "The Clearing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:633
-msgid ""
-"The convoy has at long last arrived. Regretably, it has been beset by "
-"bandits on its journey here, and has far less supplies than we had hoped. "
-"Make your way south, for our spies have found rich mines there."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:634
-msgid ""
-"The convoy should have been here by now! Let us hope that it is safe and "
-"still on its way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:635
-msgid ""
-"The country lords have allied and pooled their resources into one command. "
-"Not only have they massed their forces in the north, but they have sent a "
-"knight to the west to steal your supplies. Scouts report a castle to the "
-"east that would be ideal as a base of operations."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:636
-msgid "The crew are unworthy!  I am not going down with the ship! -The Captain"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:637
-msgid "\"The Crown\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:638
-msgid ""
-"The day you have feared has finally arrived.  The king, who you have "
-"faithfully served, has died, leaving no heir to his throne.  As his captain, "
-"you feel that this job should now be yours, but several factions even now "
-"are preparing for conquest.  You are at the center of the trade routes, "
-"having the sea to the south and the great forest to the north.  Go, now, "
-"Commander, and claim what is rightfully yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:639
-msgid ""
-"The diplomats who were sent here ahead of you report that the elves will "
-"only cooperate with you if you will recover the golden bow for them. It was "
-"stolen by their enemies, the Dragons and hidden behind magic barriers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:640
-msgid "The Eastern Town."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:641
-msgid "The edge of the world is your edge.  But prepare to be prepared."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:642
-msgid "The Emerald Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:643
-msgid "The Enchanted Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:644
-msgid "The End of the World is Nigh!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:645
-msgid "The End of the World is Nigh"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:646
-msgid ""
-"The Epic battle against Your Rival! Eliminate everything! Total Warfare! "
-"Don't Lose your first hero!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:647
-msgid ""
-"The Fire King is an ally to the dragons, and will help a friend of theirs."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:648
-msgid "The First One To Take Astircaer Wins!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:649
-msgid ""
-"The first piece of the artifact now lies in the hands of the Unholy Order of "
-"Warlocks. You must annihilate them, and their allies to the north. They will "
-"surely give us what we seek in exchange for their feeble lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:650
-msgid ""
-"The Fortune of Infamous Uae was buried on one of these islands. She died "
-"without ever revealing it.  Find it before the other cutthroats."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:651
-msgid "The four factions race to capture a mystical castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:652
-msgid ""
-"The four spell casters face off with substantial starting armies. Can the "
-"crusaders keep the peace?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:653
-msgid "\"The Gauntlet\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:654
-msgid ""
-"The Gods have given you 6 months to prove yourself. Good or Evil - who shall "
-"prevail? (Blue,Green and Red vs Yellow, Orange and Purple)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:655
-msgid ""
-"The gods have granted this world a great artifact, to find it means victory."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:656
-msgid "The Gods themselves will aid us in this War."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:657
-msgid "The Gold Traveller's Tent is near the Aqua Taveller's Tent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:658
-msgid "The guardians of Dragon Isle reside in the jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:659
-msgid "The Ice Prince stands frozen in some forgotten corner of the world."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:660
-msgid "The island...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:661
-msgid "The Island of Lost Reason"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:662
-msgid "The islands have much wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:663
-msgid "The Isle of Armoria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:664
-msgid "The key to success is rubbing enough lamps."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:665
-msgid ""
-"The King has declared you his hier apparent and champion. You must seek out "
-"and destroy your common enemy, Wilgatus and his Castle, Mirkosov, the source "
-"of his power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:666
-msgid ""
-"The King is dead, his kingdom has been shattered, and six leaders seek to "
-"seize power for themselves."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:667
-msgid "The Kingly Wastes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:668
-msgid "The Kings Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:669
-msgid ""
-"The King will sell you this land for 200,000 gold or you can take it by "
-"force. The choice is yours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:670
-msgid "The land of Heroes II."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:671
-msgid "The Lost Castle of the Ancients"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:672
-msgid ""
-"The mage wars have caused a great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:673
-msgid ""
-"The mage wars have caused great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:674
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trade.  "
-"Plus a little gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:675
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trading.  "
-"Plus a little more gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:676
-msgid ""
-"The Master Merchant arrives at your Castle.  He tells you tall tales of "
-"travel, full of outrageous lies.  He also gives you, your share of the "
-"profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:677
-msgid ""
-"The Master Merchant arrives back at your Castle.  He tells you tall tales of "
-"faraway places full of outrageous lies.  He also gives you, your share of "
-"the profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:678
-msgid "The Medusas have the password and they can be found just to the west."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:679
-msgid "The more there is the less you see."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:680
-msgid "The North Road to Roland's castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:681
-msgid ""
-"The note in this bottle has become mostly indecipherable. All you can make "
-"out are references to deadly pirates, and hidden gold mines."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:682
-msgid "The Other Side"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:683
-msgid ""
-"The Overlord has given you 4 months to conquer this land or deliver to him "
-"the sum of 150,000 gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:684
-msgid ""
-"The people on the Isle of Knowledge are taking up a collection to aid us."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:685
-msgid "The Proving Grounds"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:686
-msgid "The Queen's Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:687
-msgid "The Realm of Air is barred, but you may appeal here for help."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:688
-msgid ""
-"There are remnants of a mighty battle fought here, not too long ago. It "
-"looks as if whoever came this way may have made this their final stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:689
-msgid ""
-"There are three enemy castles to the north. Capture them in the name of "
-"Roland the true king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:690
-msgid ""
-"The Red Tide of War rolls North.  Stopping the flood seems hopeless.  Yet, "
-"Honor demands you and your ally die trying."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:691
-msgid "There is hidden treasure north of the Green Lord's Ore Mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:692
-msgid "There is hidden treasure south of the Blue Lord's Sawmill."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:693
-msgid "There's a warm wind blowing from the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:694
-msgid "There's a Wizard living in the north who is behind this peasant revolt."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:695
-msgid "The Retreat of the Alchemist Doctor Yu"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:696
-msgid ""
-"There used to be a mine here, but it has long since run out of ore.  You are "
-"only able to scavenge 5 units of ore from the old site."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:697
-msgid "There was a shipreck in the far east waters recently."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:698
-msgid "The River Styx"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:699
-msgid "The roars of several dragons echo from the towers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:700
-msgid "The Rock Store."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:701
-msgid "The Royal Gardens."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:702
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:703
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you defend against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:704
-msgid "These doors are a risk the likes of which you do not know."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:705
-msgid "These lands are beholden to Lord Kraeger."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:706
-msgid ""
-"These lands are desolate and for the most part devoid of resources. Not even "
-"the bravest heroes dare to venture into them, and plants are rare and "
-"precious here. Who knows what else awaits?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:707
-msgid ""
-"The Southern Witch is biding her time.  She will strike when your armies are "
-"weak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:708
-msgid "the stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:709
-msgid "The Table in the Great Hall of the Castle is Haunted."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:710
-msgid ""
-"The third piece of the artifact is somewhere to the north, that much we "
-"know. We are still unsure of its exact location, but our spies are out "
-"gathering information. The forces in this area are too strong to be "
-"completely subjugated, so take what you can and hold on to it tightly."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:711
-msgid ""
-"The troops have sworn their allegiance, but should lose a battle they will "
-"lose faith and our cause will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:712
-msgid "The Valley of Aruk."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:713
-msgid ""
-"The Valley of Magic holds many surprises.  You discover an old pair of boots "
-"sticking out of the sand."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:714
-msgid "The Valley of Tresures"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:715
-msgid "The Wasteland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:716
-msgid "The way of magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:717
-msgid "The way of might"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:718
-msgid "The way of numbers"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:719
-msgid "The western town."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:720
-msgid "The winds howl in mourning around the shipwreck."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:721
-msgid "The wizard has an island in the southeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:722
-msgid ""
-"The Wizards who have captured the Necromancers' town have wasted no time in "
-"building defenses designed to stop you, and their last castle has just been "
-"completed. Fortunately only a Captain of the Guard and a small garrison are "
-"currently present.  If you hurry, you should be able to capture the castle "
-"before they have a chance to reinforce it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:723
-msgid "The wood has arrived."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:724
-msgid "The writing on this sign is too faded to read."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:725
-msgid "The Yellow Lord has the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:726
-msgid ""
-"The Yellow Lord is a hothead who will attack before his allies can send him "
-"aid."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:727
-msgid "They say there's mermaids in these waters..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:728
-msgid ""
-"This area is rich in resources. Explore, but beware, a castle left "
-"undefended will quickly fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:729
-msgid ""
-"This area must be secured for the sake of the Empire. Our spies have "
-"reported a discord between The kingdom of the knights to the north, and that "
-"of the oppressive sorceresses to the northeast. Perhaps this feud can be "
-"exploited for our gain..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:730
-msgid "This bottle is empty."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:731
-msgid ""
-"This is the last week you have to find the rebel wizard Joseph! Good Luck in "
-"your quest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:732
-msgid ""
-"This land and all others are now under the sole ownership of Ibn Fadlan, the "
-"Undead King. Any disregard for his magesty's soverign rule is to be punished "
-"by death most horrendous."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:733
-msgid ""
-"This land has been claimed by the nation of Neroli. Interlopers are "
-"UNWELCOME."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:734
-msgid ""
-"This rugged land will have rivals fighting the terrain as well as each other."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:735
-msgid ""
-"This rundown village looks like it was once the epicenter of an enormous, "
-"but now ruined, city. Under a pile of rubble you find an object which looks "
-"like it has lain there for ages."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:736
-msgid ""
-"This spot overlooks an old quarry.  This was one of the only places in the "
-"world where ore could be taken right out of the ground.  Unfortunately the "
-"jungle has reclaimed the quarry and it is unusable.  You collect the last of "
-"the ore and depart."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:737
-msgid ""
-"This twisted maze of sorceress towns has three factions struggling for sole "
-"control.  Use your resources wisely!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:738
-msgid ""
-"This village appears to be in little better shape than the first one you "
-"saw. As you approach the village an old man hands you a slip of paper, with "
-"the following message, \"Joseph lives in the town of IslandHome.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:739
-msgid ""
-"This village is in extremely poor shape. There is no chance of getting more "
-"than some of the lesser creatures here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:740
-msgid "This way to the Necromancer Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:741
-msgid "Those who seek knowledge are welcome to the city of Chronos."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:742
-msgid ""
-"Three Warlocks in the land of Dragons. Lose thy home and all will be lost. "
-"Conquer thy enemies and the land shall forever be yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:743
-msgid "Timberhill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:744
-msgid "Time for a refreshing drink."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:745
-msgid "Time is running out! The enemy's reinforcements are almost here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:746
-msgid "To pass you must pay troll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:747
-msgid "TreeHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:748
-msgid "Trespassers will be EATEN!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:749
-msgid "Trilobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:750
-msgid "Troy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:751
-msgid "Tundara"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:752
-msgid "Turn back, friend, while you still can!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:753
-msgid "Turn Back Now!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:754
-msgid "Turn Back Now or all will be LOST!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:755
-msgid "Turn Back or DIE!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:756
-msgid "Turn Back or else!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:757
-msgid "Turn back, you fool."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:758
-msgid "\"Turning Point\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:759
-msgid ""
-"Uae was the scurviest, pirate ye'd never wanta see. In all her years of "
-"murdering and thieving she amassed so much ill-gotten booty that she "
-"couldn't carry it around in her galleon.  Besides, even the meanest can't "
-"stay awake all the time.  Legend tells that she hid it so well, she was "
-"thinking that she just might forget where it was.  So she left clues around "
-"the islands, carved in stone.  Well, she's dead now.  It's up to you to "
-"recover her legacy."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:761
-msgid "Uncle Leo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:762
-msgid "Uncle Milty"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:763
-msgid "Undead Armies"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:764
-msgid "Unholy Alliance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:765
-msgid "Unite the Tribes. Don't lose your main hero, the first Descendant."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:766
-msgid "Valley of Death"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:767
-msgid "Valley Of The Damned"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:768
-msgid "Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:769
-msgid "Vaultius"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:770
-msgid "Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:771
-msgid "Vikings!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:772
-msgid "Viper's Nest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:773
-msgid "Vulcania"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:774
-msgid "Warrior Knight"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:775
-msgid "Wastelands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:776
-msgid "Watch out for Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:777
-msgid "Waystop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:778
-msgid ""
-"\"We are at the edge of the world!\"  they scream.  \"What are we doing here?"
-"\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:779
-msgid "Weddington"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:780
-msgid "Weed Patch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:781
-msgid ""
-"We found a weakness my lord. Capture castle Black Fang and victory is ours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:782
-msgid ""
-"We have just learned that the artifact is on an island north of this "
-"continent. However, there does not appear to be any means to get there. Stay "
-"very alert for any possible way across the narrow channel."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:783
-msgid ""
-"Welcome back general.  Have you finished the conquest of the northern "
-"lands?  What? you still have not finished your mission!  Get back there and "
-"teach those rebels a lesson!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:784
-msgid "Welcome to Li'l Alctatraz! Vistors NOT welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:785
-msgid ""
-"Welcome to Power Island. He who controls this Isle controls the Seven Lakes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:786
-msgid "Welcome to the Sandbar."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:787
-msgid "Welcome to the sandy Isle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:788
-msgid "Welcome to the sorceress' guild."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:789
-msgid "Welcome to the Spiral Isles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:790
-msgid ""
-"Welcome to the wounderous Kitisland range.  Eruptions each day, beware of "
-"dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:791
-msgid "Welcome to Windfall Island!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:792
-msgid "Welcome to your DOOM!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:793
-msgid "We'll join you - for the right price."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:794
-msgid ""
-"Well placed bribes have won you a stronghold near the warring Barbarians. Be "
-"advised that given their proximity an unguarded castle is an open invitation "
-"to defeat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:795
-msgid "Westfork"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:796
-msgid "Westmoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:797
-msgid "We told you not to drink!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:798
-msgid "What are you doing here?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:799
-msgid "What cannot be seen but only heard, and will not speak until spoken to?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:800
-msgid "What everyday word is most often pronounced incorrectly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:801
-msgid "What goes up and down but never moves?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:802
-msgid ""
-"What good fortune!  You've discovered a long-abandoned settlement.  To your "
-"surprise, you discover that the previous inhabitants left some of their "
-"resources behind when they departed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:803
-msgid "What is always coming but never arrives?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:804
-msgid "What is the Sum of all Numbers from 1 to 200?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:805
-msgid "What is time spent poorly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:806
-msgid "What's another word for pirate treasure?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:807
-msgid "What's behind door number one?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:808
-msgid "What's this? A pile of gems?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:809
-msgid "What's this? Someone has left a pile of wood here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:810
-msgid ""
-"What team won Super Bowl XXI and Super Bowl XXV?  (Hint... a Wizard might "
-"have these troops in his army)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:811
-msgid "What turns everything around but does not move?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:812
-msgid ""
-"What walks in the morning on four legs, two in the afternoon and three in "
-"the evening?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:813
-msgid "What?  What's this?  Something at the bottom of this pool..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:814
-msgid "When you're ready, take the teleport to the Island's Hot Spot!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:815
-msgid ""
-"When you think yourself invincible, walk through this gate.  Even then, "
-"prepare to meet your bitter end."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:816
-msgid "Where am I?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:817
-msgid "While away seeking the Ultimate Artifact, Kastor's kingdom is invaded!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:818
-msgid ""
-"While traveling a mesenger meets you on the road.  His message tells of a "
-"new ally from an island far to the south.  This ally can not offer forces to "
-"your battle but has agreed to send some support in the form of gold and "
-"crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:819
-msgid "Whiteshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:820
-msgid "Whittingham"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:821
-msgid "Who am I?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:822
-msgid ""
-"Who am I?...  Where am I?...  Oh no! My Ship!  Well it's consigned to the "
-"ghosts of my dead crew now, at least I still have my lucky rabbits foot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:823
-msgid "Who is the true King?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:824
-msgid ""
-"\"Why have we come this way?\"  asks the first mate.  You have no answer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:825
-msgid "Wicked Warlock Way"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:826
-msgid "Wilasher"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:827
-msgid "Wildabar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:828
-msgid "Wilgatus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:829
-msgid "Willow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:830
-msgid "Windfall Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:831
-msgid "Winterkill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:832
-msgid "Winterlands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:833
-msgid "Witch Hunt"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:834
-msgid ""
-"With the year long eruption of Mt. Kitisland, your three worst enemies now "
-"have a ground bridge to your eastern contenent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:835
-msgid "Wizardwood.  Magicians welcome!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:836
-msgid "Woodhaven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:837
-msgid "Wood's Lord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:838
-msgid "Woodstock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:839
-msgid "Woodville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:840
-msgid "Wormed Ash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:841
-msgid "Wow, somebody has left a pile of wood here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:842
-msgid "Wyrm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:843
-msgid "Xabran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:844
-msgid "Yellow gets some stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:845
-msgid "Yellow's Steady Cash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:846
-msgid "Yellow stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:847
-msgid "Yellow's Yarbols"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:848
-msgid "Ye old fish liver oil."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:849
-msgid "Yorksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:850
-msgid ""
-"You and your ally's families were given custody of The Isle of Knowledge.  "
-"Other Lords feel the time has come for new guardians..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:851
-msgid "You are a fool to come here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:852
-msgid "You are fighting on the side of your king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:853
-msgid "You are fighting on the side of your sister!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:854
-msgid "You are now entering the domain of Prince Roland. Have a nice day."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:855
-msgid "You are now entering the domain of Prince Roland. Have a pleasant stay."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:856
-msgid ""
-"You bribe the entrance guards of this dingy prison camp. They agree to look "
-"the other way for a little while."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:857
-msgid ""
-"You can only reach your enemies via teleporters, but each jump is a leap of "
-"faith."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:858
-msgid ""
-"You cautiously ride through the trees, looking out for enemy assaults, when "
-"suddenly, the old elf is beside you. \"Your quest is almost at an end, my "
-"friend. All that remains is for you to lay seige to these last few castles. "
-"The fate of my people rests upon your final battles here. May the gods be "
-"with you as well.\"  He turns to leave, but you ask him his name before he "
-"is gone. Over his shoulder, as he is leaving he says \"I am Ilthanis, king "
-"of the elves.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:859
-msgid ""
-"You come across the dead remains of what was appearantly a powerful wizard!  "
-"You wonder if it's safe to continue."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:860
-msgid ""
-"You face three opponents in this scenario. Capture their castles and their "
-"heroes to prove your worthiness to Archibald."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:861
-msgid ""
-"You find a beautiful helm buried in the lava.  As you move to put it on your "
-"head it turns into the Hideous mask and now you realize that no creature "
-"will join you."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:862
-msgid ""
-"You find a gleaming gold medalion buried in the  snow.  As you move to put "
-"it on it changes to the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:863
-msgid ""
-"You find an old signpost in the midst of a thicket that reads \"Warlock "
-"Wood, West.  Barbarian Fields, East.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:864
-msgid ""
-"You find a note in the bottle! It reads, \"My ship has been wrecked by the "
-"notorious pirates in this area! I am stranded on a small and barren island. "
-"Please, I beg you to come and rescue me!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:865
-msgid "You found something!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:866
-msgid "You found Treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:867
-msgid ""
-"You have been ordered here to claim this land in the name of your King and "
-"recover any riches that you might find.  However, five other Kings and "
-"Queens have also sent their heroes to this land, so you must watch out for "
-"them as well as the natives!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:868
-msgid "You have found what someone else has lost..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:869
-msgid ""
-"You have hired a barbarian of great power to aid you in this, your last "
-"quest. His origins are unknown to you, but you sense strong nobility beneath "
-"the furs and dirt that cover him. In addition, the famous explorer, Marco "
-"the wizard, is rumored to have wrecked his ship in this new land. Finding "
-"him would prove to be a much needed boon to your cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:870
-msgid ""
-"You have just 8 weeks  to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:871
-msgid ""
-"You have just 8 weeks to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:872
-msgid ""
-"You have received a message from Archibald. \"General, these peasants "
-"deserve punishment. Put them to the sword and let Corlagon have his way with "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:873
-msgid ""
-"You have received a message from Archibald.  \" HOW DARE YOU BETRAY ME! I "
-"will see your head on the block alongside your new master's once I have won."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:874
-msgid ""
-"You have received a message from Roland. \" I am shocked! I had thought "
-"better of you, but I was terribly wrong. Now you'll have to live with your "
-"dark decision for the rest of your life.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:875
-msgid "You have recieved a shipment of supplies from your kingdom!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:876
-msgid ""
-"You have recieved a shipment of supplies from your kingdom! There is a note "
-"attached, \"These are all we could afford to send you from our treasuries, "
-"as the war with Harondale is taxing us greatly. We will send more in two "
-"weeks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:877
-msgid ""
-"You have six months to destroy the Necromancer Stronghold in the heart of "
-"the valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:878
-msgid ""
-"You have washed up on the beach after being shipwrecked. Your goal is to "
-"find a way home."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:879
-msgid ""
-"You hear a low rumble, look up and see an avalanche!  You dive onto a large "
-"patch of grass to avoid it.  While dusting yourself off, you consider "
-"yourself quite lucky to be alive.  Luckier still to find a Four-Leaf Clover "
-"stuck on your nose."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:880
-msgid ""
-"You hear a rumor from a peasant who lives in the town of Waystop. He says, "
-"\"The pirates control most of the sulfur mines in this area. They use it for "
-"the cannons on their bigger boats. If you want a mine, you'll have to defeat "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:881
-msgid "You hear melodic strains of elvish music as you enter this clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:882
-msgid ""
-"You must, like, forsake your earthly wealth and, like, join us on the island "
-"of the lotus eaters."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:883
-msgid ""
-"You must search the world for your mortal enemy, Wilgatus.  Can you find him "
-"before its too late?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:884
-msgid ""
-"You notice some runes hastily scrawled into a rock by your feet, They look "
-"like the initials of Uncle Ivan!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:885
-msgid ""
-"You notice that mines and resources in the elvish lands are few, and you "
-"send word to your kingdom that you will need extra supplies. They should "
-"respond within a fortnight."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:886
-msgid ""
-"Your advance scouts come riding back to you with the following news. They "
-"believe they have found signs that Uncle Ivan was in this general area, and "
-"that he made his way to the north many months ago. Also they say there is a "
-"town nearby and many resources to the east."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:887
-msgid ""
-"Your advisor approaches you, \"My liege, something must be done about these "
-"peasants! They still refuse to work.  At this rate you won't have anything "
-"to put in your daughter's dowry!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:888
-msgid ""
-"Your advisor approaches you smiling greatly, \"My liege! The peasants are "
-"making money in the market, and are finally paying taxes!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:889
-msgid ""
-"Your advisor approaches you with a long face, \"My liege, the peasant's "
-"numbers are growing steadily.  All they do is take, take, take! We are "
-"beginning to suffer dearly because of them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:890
-msgid ""
-"Your advisor approaches you with some startling information, \"My liege, the "
-"peasants are draining us. They do nothing, and take everything! We must get "
-"them home. Your own citizens are beginning to suffer!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:891
-msgid ""
-"Your arrival here was a surprise to those sworn to guard Dragon Isle, and "
-"you were able to quickly capture one of their castles.  Use caution, though, "
-"for two other guardians remain in this jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:892
-msgid ""
-"Your castle, founded inside the center of a mile wide crater, is besieged by "
-"those who desire your mineral wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:893
-msgid "Your castle is the last outpost in the area, Don't lose it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:894
-msgid "Your crew begins to grumble."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:895
-msgid ""
-"Your crew seriously entertains thoughts of mutiny.  Your nights are "
-"sleepless."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:896
-msgid "You're almost there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:897
-msgid "You, recieve word that you have been robbed."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:898
-msgid "You're getting colder."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:899
-msgid "You're getting warmer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:900
-msgid ""
-"You're here! Oh, thank you thank you thank you! I'm in the jail east of the "
-"castle. Please hurry!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:901
-msgid ""
-"Your expedition has taken a turn for the worse... you now have no way to get "
-"home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:902
-msgid ""
-"Your forces are thinly spread in an effort to defend all the dwarf towns "
-"(which may not be transformed into castles). Consolidate your forces and "
-"smite the enemy before the towns fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:903
-msgid ""
-"Your horse stumbles and throws you from the saddle.  When you awaken you "
-"find that you have hit your head on the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:904
-msgid ""
-"Your isolation from the rest of the kingdom has largely kept you out of the "
-"political struggles, but now with the king's death, and lack of an heir, you "
-"see a golden opportunity to seize the throne for yourself.  Just remember "
-"that you have relied largely on trade for several key resources, especially "
-"sulfur, but with a little planning this land can be yours.  Go, now, and "
-"show these peasants how to rule!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:905
-msgid "Your king has sent supplies to aid the war effort."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:906
-msgid ""
-"Your opponents are allied against you and each is twice as powerful as his "
-"predecessor! Is it possible to win?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:907
-msgid ""
-"Your Queen sent you here to explore this newly discovered territory, but a "
-"freak storm scattered your fleet and left you stranded.  You gather the "
-"survivors and form a small settlement, naming it New Vertigo.  This place is "
-"your home now, and survival is your highest priority, but remember, if you "
-"are captured or killed, it's over!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:908
-msgid ""
-"Your rival, the kingdom of Harondale, is attacking your weak border towns! "
-"Recover from their first strike and crush them completely."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:909
-msgid ""
-"Your Scouts report talking to a young knight, a squire to the two sleeping "
-"heroes.  The squire is trapped by the Aqua Magic Barriers and a group of "
-"fallen Paladins.  He says the two heroes, Dainwin and Ceallach, have "
-"awakened but are still trapped by a Gold Magical Barrier and asks your aid "
-"in freeing them."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:910
-msgid ""
-"Your Scouts report that the Aqua Traveller's Tent is located along The North "
-"Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:911
-msgid ""
-"Your scouts return with grim news.  The natives of this land are currently "
-"at war with each other, and they like outsiders even less than they like "
-"each other!  Congratulations, Commander, you're at war!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:912
-msgid ""
-"Your sister calls you before her altar in the morning. \"I have important "
-"news,\" she says, \"The barbarian kingdoms which border this land have "
-"agreed to lend us some of their castles and warriors in return for a share "
-"of the spoils. I hope victory comes swiftly, but your presence gives me "
-"strength to stand until whatever end awaits.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:913
-msgid "Your subjects contribute to your war effort!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:914
-msgid ""
-"Your town is undefended and your heroes are scattered.  Do you attack or "
-"defend?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:915
-msgid ""
-"Your treasury has been looted by robbers and you have lost valuable "
-"resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:916
-msgid "Your troops begin to wonder about your sanity."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:917
-msgid ""
-"You run aground on the rocks and have to use some wood to fix your boat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:918
-msgid ""
-"You see a family of refugees making their way from the beach. You ask them "
-"about their plight and they tell you that they are from a once great city "
-"called Moss Side. They tell you that the castle was destroyed in a great "
-"conflagration, and they fled for fear of their lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:919
-msgid ""
-"You see an old man bringing water towards the stables. Recognizing him as "
-"the mystic, you attempt to thank him for his gift with some gold. He "
-"refuses, but says to you instead, \"There are riddles guarding the source of "
-"the fount's power, and the dragons know the answers. Make your way through "
-"their lair, and you shall know victory.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:920
-msgid ""
-"You see an old mystic perched on a rock. You walk towards him to see if he "
-"has any words for you on your quest, and he says \"First I see you as a "
-"great conquerer of the lands of men. Secondly, I see you as a mighty ruler "
-"of vast armies, well loved by your troops. Thirdly, I see you as a slayer of "
-"legions of dragons, your body bathed in their fire. Lastly, I see you "
-"standing on the shores of the fount, unable to cross.\" Then the Mystic "
-"fades away."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:921
-msgid "You see something that could just be the elusive Nubbie!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:922
-msgid ""
-"You see the mast of ancient ship here.  On further investigation you find "
-"that the ships holds are full of gems.  The hours pass as your crue "
-"liberates the treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:923
-msgid ""
-"You see the remains of a burned out sawmill here.  All you can salvage is "
-"some ofwood left for scrap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:924
-msgid ""
-"You see the remains of an old sawmill, but it is obvious that you will not "
-"be able to make it work again."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:925
-msgid ""
-"You see the remains of an old sawmill just to realize that it will no longer "
-"produce.  You gather the ramains and move on."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:926
-msgid ""
-"You send this letter back to the king,\"A month has passed and we have not "
-"discovered the wizard Joseph. I only hope that we are able to locate him in "
-"time to aid us in our struggle.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:927
-msgid "You should turn back."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:928
-msgid ""
-"You stumble upon an old man who proclaims you Lord of the Realm, hands you "
-"his boots and wonders into the mountains mumbling something about being late "
-"for an important date."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:929
-msgid ""
-"You stumple across three small rocks piled on top of each other and decide "
-"to dig undernear them.  There you find an old weather-beaten bag of gems."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:930
-msgid "You uncover a compass in the grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:931
-msgid "You've been warned!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:932
-msgid ""
-"You've received a message from Roland. \"In the absence of a strong leader, "
-"the local lords have fallen to fighting. Uniting this area is critical to "
-"our cause, so we must not fail.  Leaving your castle undefended in this "
-"highly contested region will surely lead to defeat. I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:933
-msgid ""
-"You've received a message from the guild. \"Thank God you've arrived! We're "
-"under seige from two enemies from the north and one from across the sea. "
-"Please save us, you're our only hope.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:934
-msgid ""
-"You've ruled with an iron fist (and an army of undead), but now your kingdom "
-"has turned against you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:935
-msgid ""
-"You've saved a group of miners from the dragons.  One of them approaches "
-"you, \"Thank you so much for saving us!  We found this sulfer and sword in "
-"the mine, then those dragons chased us!  I don't know how much longer we "
-"could survive!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:936
-msgid ""
-"You will clash quickly on this small head-to-head map, so stay on your toes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:937
-msgid ""
-"You will need a stronger army than that, mortal, to step through this portal."
-msgstr ""
-
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Wood"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Mercury"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Ore"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Sulfur"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Crystal"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Gems"
 msgstr ""
 
-#: ../fheroes2/spell/spell_book.cpp:61 ../fheroes2/spell/spell_book.cpp:79
-msgid "No spell to cast."
-msgstr ""
-
-#: ../fheroes2/spell/spell_book.cpp:138
-msgid "Your hero has %{point} spell points remaining"
-msgstr ""
-
-#: ../fheroes2/spell/spell.cpp:50
 msgid "Fireball"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:50
 msgid ""
 "Causes a giant fireball to strike the selected area, damaging all nearby "
 "creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid "Fireblast"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid ""
 "An improved version of fireball, fireblast affects two hexes around the "
 "center point of the spell, rather than one."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Lightning Bolt"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Causes a bolt of electrical energy to strike the selected creature."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid "Chain Lightning"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid ""
 "Causes a bolt of electrical energy to strike a selected creature, then "
 "strike the nearest creature with half damage, then strike the NEXT nearest "
@@ -11576,828 +5874,625 @@ msgid ""
 "harmful.  Warning:  This spell can hit your own creatures!"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid "Teleport"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid ""
 "Teleports the creature you select to any open position on the battlefield."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid "Cure"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid ""
-"Removes all negative spells cast upon one of your units, and restores up to %"
-"{count} HP per level of spell power."
+"Removes all negative spells cast upon one of your units, and restores up to "
+"%{count} HP per level of spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid "Mass Cure"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid ""
-"Removes all negative spells cast upon your forces, and restores up to %"
-"{count} HP per level of spell power, per creature."
+"Removes all negative spells cast upon your forces, and restores up to "
+"%{count} HP per level of spell power, per creature."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrect"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrects creatures from a damaged or dead unit until end of combat."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrect True"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrects creatures from a damaged or dead unit permanently."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Haste"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Increases the speed of any creature by %{count}."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Mass Haste"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Increases the speed of all of your creatures by %{count}."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "spell|Slow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "Slows target to half movement rate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Mass Slow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Slows all enemies to half movement rate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:64
-msgid "Blind "
+msgid "spell|Blind"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:64
 msgid "Clouds the affected creatures' eyes, preventing them from moving."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Bless"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Causes the selected creatures to inflict maximum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Mass Bless"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Causes all of your units to inflict maximum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Stoneskin"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Magically increases the defense skill of the selected creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid "Steelskin"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid ""
 "Increases the defense skill of the targeted creatures.  This is an improved "
 "version of Stoneskin."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Curse"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Causes the selected creatures to inflict minimum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Mass Curse"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Causes all enemy troops to inflict minimum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Holy Word"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Damages all undead in the battle."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid "Holy Shout"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid ""
 "Damages all undead in the battle.  This is an improved version of Holy Word."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Anti-Magic"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Prevents harmful magic against the selected creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Dispel Magic"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Removes all magic spells from a single target."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Mass Dispel"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Removes all magic spells from all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Magic Arrow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Causes a magic arrow to strike the selected target."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Berserker"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Causes a creature to attack its nearest neighbor."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid "Armageddon"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid ""
 "Holy terror strikes the battlefield, causing severe damage to all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Elemental Storm"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Magical elements pour down on the battlefield, damaging all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid "Meteor Shower"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid ""
 "A rain of rocks strikes an area of the battlefield, damaging all nearby "
 "creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "Paralyze"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "The targeted creatures are paralyzed, unable to move or retaliate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid "Hypnotize"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid ""
-"Brings a single enemy unit under your control for one combat round if its "
-"hits are less than %{count} times the caster's spell power."
+"Brings a single enemy unit under your control if its hits are less than "
+"%{count} times the caster's spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Cold Ray"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Drains body heat from a single enemy unit."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid "Cold Ring"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid ""
 "Drains body heat from all units surrounding the center point, but not "
 "including the center point."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Disrupting Ray"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Reduces the defense rating of an enemy unit by three."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Death Ripple"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Damages all living (non-undead) units in the battle."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid "Death Wave"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid ""
 "Damages all living (non-undead) units in the battle.  This spell is an "
 "improved version of Death Ripple."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Dragon Slayer"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Greatly increases a unit's attack skill vs. Dragons."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Blood Lust"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Increases a unit's attack skill."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Animate Dead"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Resurrects creatures from a damaged or dead undead unit permanently."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid "Mirror Image"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid ""
 "Creates an illusionary unit that duplicates one of your existing units.  "
 "This illusionary unit does the same damages as the original, but will vanish "
 "if it takes any damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Shield"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Halves damage received from ranged attacks for a single unit."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Mass Shield"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Halves damage received from ranged attacks for all of your units."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summon Earth Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summons Earth Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summon Air Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summons Air Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summon Fire Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summons Fire Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summon Water Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summons Water Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Earthquake"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Damages castle walls."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "View Mines"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "Causes all mines across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "View Resources"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "Causes all resources across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "View Artifacts"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "Causes all artifacts across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "View Towns"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "Causes all towns and castles across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "View Heroes"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "Causes all Heroes across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "View All"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "Causes the entire land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Identify Hero"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Allows the caster to view detailed information on enemy Heroes."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid "Summon Boat"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid ""
 "Summons the nearest unoccupied, friendly boat to an adjacent shore "
 "location.  A friendly boat is one which you just built or were the most "
 "recent player to occupy."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Dimension Door"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Allows the caster to magically transport to a nearby location."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Town Gate"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Returns the caster to any town or castle currently owned."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:109
 msgid ""
 "Returns the hero to the town or castle of choice, provided it is controlled "
 "by you."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid "Visions"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid ""
 "Visions predicts the likely outcome of an encounter with a neutral army camp."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid "Haunt"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid ""
 "Haunts a mine you control with Ghosts.  This mine stops producing "
 "resources.  (If I can't keep it, nobody will!)"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Set Earth Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Sets Earth Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Set Air Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Sets Air Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Set Fire Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Sets Fire Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Set Water Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Sets Water Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:665
-msgid "Necroman"
-msgstr "Necromante:"
-
-#: ../fheroes2/system/players.cpp:691
-msgid ""
-"This lets you change player starting positions and colors. A particular "
-"color will always start in a particular location. Some positions may only be "
-"played by a computer player or only by a human player."
+msgid "No spell to cast."
 msgstr ""
-"Isso permite que você altere o jogador a partir de posições e cores. Uma cor "
-"especial começará sempre em um determinado local. Algumas posições só pode "
-"ser jogado por um computador ou apenas por um jogador humano."
 
-#: ../fheroes2/system/players.cpp:695
-msgid ""
-"This lets you change the class of a player. Classes are not always "
-"changeable. Depending on the scenario, a player may receive additional towns "
-"and/or heroes not of their primary alignment."
+msgid "Your hero has %{point} spell points remaining."
 msgstr ""
-"Isso permite que você alterar a classe de um jogador. Classes não são sempre "
-"alteravel. Dependendo do cenário, um jogador não pode receber cidades "
-"adicionais e / ou heróis do seu alinhamento primário."
 
-#: ../fheroes2/system/players.cpp:734
 #, fuzzy
-msgid "%{color} player"
-msgstr "Turno do jogador %{color}"
+msgid "View Adventure Spells"
+msgstr "Opções de Aventura"
 
-#: ../fheroes2/system/settings.cpp:126
+#, fuzzy
+msgid "View Combat Spells"
+msgstr "Magia"
+
+#, fuzzy
+msgid "View previous page"
+msgstr "Mostrar cidade anterior"
+
+#, fuzzy
+msgid "View next page"
+msgstr "Ver %{name}"
+
+#, fuzzy
+msgid "Close Spellbook"
+msgstr "Magia"
+
+#, fuzzy
+msgid "View %{spell}"
+msgstr "Ver %{name}"
+
 msgid "game: always confirm for rewrite savefile"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:127
-msgid "game: also confirm autosave"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:128
 msgid "game: remember last focus"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:129
-msgid "game: battle show grid"
+msgid "battle: show damage info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:130
-msgid "game: battle mouse shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:131
-msgid "game: battle move shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:132
-msgid "game: battle show damage info"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:133
-msgid "game: castle flash building"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:134
 msgid "world: show visited content from objects"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:135
+msgid "world: show terrain penalty"
+msgstr ""
+
 msgid "world: scouting skill show extended content info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:136
-msgid "world: abandoned mine random resource"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:137
-msgid "world: save count monster after battle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:138
 msgid "world: allow set guardian to objects"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:139
-msgid "world: guardian objects gets +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:140
-msgid "world: no in-built requirements or guardians for placed artifacts"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:141
-msgid "world: only the first monster will attack (H2 bug)."
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:142
 msgid "world: Eagle Eye also works like Scholar in H3."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:143
 msgid "world: ban for WeekOf/MonthOf Monsters"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:144
-msgid "world: new version WeekOf (+growth)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:145
 msgid "world: ban plagues months"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:146
 msgid "world: Months Of Monsters do not place creatures on map"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:147
 msgid "world: Crystal Ball also added Identify Hero and Visions spells"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:148
-msgid "world: Artesian Springs have two separately visitable squares (h3 ver)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:149
 msgid "world: Starting heroes as Loss Conditions for Human Players"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:150
 msgid "world: Only 1 hero can be hired by the one player every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:151
-msgid "world: each castle allows one hero to be recruited every week"
+msgid "world: Each castle allows one hero to be recruited every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:152
-msgid "world: Outer creature dwellings should accumulate units"
+msgid "world: Neutral armies scale with game difficulty"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:153
-msgid "world: use unique artifacts for morale/luck"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:154
 msgid "world: use unique artifacts for resource affecting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:155
 msgid "world: use unique artifacts for primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:156
 msgid "world: use unique artifacts for secondary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:157
 msgid "world: Wind/Water Mills and Magic Garden can be captured"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:158
 msgid "world: disable Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:159
-msgid "castle: allow buy from well"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:160
 msgid "castle: allow guardians"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:161
 msgid ""
 "castle: higher mage guilds regenerate more spell points/turn "
 "(20/40/60/80/100%)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:162
-msgid "castle: allow recruits special/expansion heroes"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:163
 msgid "heroes: allow buy a spellbook from Shrines"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:164
-msgid "heroes: learn new spells with day"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:165
 msgid "heroes: recruit cost to be dependent on hero level"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:166
-msgid "heroes: remember MP/SP for retreat/surrender result"
+msgid "heroes: remember move points for retreat/surrender result"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:167
-msgid "heroes: surrendering gives some experience"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:168
-msgid "heroes: recalculate movement points after creatures movement"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:169
-msgid "heroes: allow pickup objects for patrol"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:170
-msgid "heroes: after battle move to target cell"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:171
 msgid "heroes: allow transcribing scrolls (needs: Eye Eagle skill)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:172
-msgid "heroes: allow banned sec. skills upgrade"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:173
 msgid "heroes: in Arena can choose any of primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:174
 msgid "unions: allow meeting heroes"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:175
 msgid "unions: allow castle visiting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:176
+msgid "battle: show army order"
+msgstr ""
+
 msgid "battle: soft wait troop"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:177
-msgid "battle: high objects are an obstacle for archers"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:178
-msgid "battle: merge armies for hero from castle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:179
-msgid "battle: archmage can resists (20%) bad spells"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:180
-msgid "battle: magical creature resists (20%) the same magic"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:181
-msgid "battle: skip increase +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:182
 msgid "battle: reverse wait order (fast, average, slow)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:183
 msgid "game: show system info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:184
 msgid "game: autosave on"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:185
 msgid "game: autosave will be made at the beginning of the day"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:186
 msgid "game: use fade"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:187
-msgid "game: show SDL logo"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:188
 msgid "game: use evil interface"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:189
-msgid "game: also use dynamic interface for castles"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:190
 msgid "game: hide interface"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:191
 msgid "game: offer to continue the game afer victory condition"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:192
-msgid "pocketpc: hide cursor"
+msgid "The ultimate artifact is really the %{name}."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:193
-msgid "pocketpc: tap mode"
+msgid "The ultimate artifact may be found in the %{name} regions of the world."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:194
-msgid "pocketpc: drag&drop gamearea as scroll"
+msgid "north-west"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:195
-msgid "pocketpc: low memory"
+msgid "north"
 msgstr ""
+
+msgid "north-east"
+msgstr ""
+
+#, fuzzy
+msgid "west"
+msgstr "Ninho"
+
+#, fuzzy
+msgid "center"
+msgstr "Tenda"
+
+#, fuzzy
+msgid "east"
+msgstr "Ninho"
+
+msgid "south-west"
+msgstr ""
+
+#, fuzzy
+msgid "south"
+msgstr "som"
+
+msgid "south-east"
+msgstr ""
+
+msgid "The truth is out there."
+msgstr ""
+
+msgid "The dark side is stronger."
+msgstr ""
+
+msgid "The end of the world is near."
+msgstr ""
+
+msgid "The bones of Lord Slayer are buried in the foundation of the arena."
+msgstr ""
+
+msgid "A Black Dragon will take out a Titan any day of the week."
+msgstr ""
+
+msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
+msgstr ""
+
+msgid "An unknown force is being ressurected..."
+msgstr ""
+
+msgid ""
+"Check the newest version of game at\n"
+"https://github.com/ihhub/\n"
+"fheroes2/releases"
+msgstr ""
+
+#~ msgid "For the QVGA version is not available."
+#~ msgstr "Para a versão QVGA não está disponível."
+
+#~ msgid "sound"
+#~ msgstr "som"
+
+#, fuzzy
+#~ msgid "ai speed"
+#~ msgstr "Veloc."
+
+#~ msgid "Water"
+#~ msgstr "Água"
 
 #~ msgid "New Map"
 #~ msgstr "Novo Mapa"
@@ -12477,9 +6572,6 @@ msgstr ""
 
 #~ msgid "Allows you to draw streams by clicking and dragging."
 #~ msgstr "Permite-lhe desenhar fluxos clicando e arrastando."
-
-#~ msgid "Road Mode"
-#~ msgstr "Modo Estrada"
 
 #~ msgid "Allows you to draw roads by clicking and dragging."
 #~ msgstr "Permite-lhe desenhar estradas, clicando e arrastando."
@@ -12627,12 +6719,6 @@ msgstr ""
 #~ msgid "You may learn either %{level1} %{skill1} or %{level2} %{skill2}."
 #~ msgstr ""
 #~ "Você pode aprender tanto %{level1} %{skill1} ou %{level2} %{skill2}."
-
-#~ msgid "A single player game playing through a series of maps."
-#~ msgstr "Um único jogador jogando em uma série de mapas."
-
-#~ msgid "animation"
-#~ msgstr "animação"
 
 #~ msgid ""
 #~ "Create a map that is 36 squares wide by 36 squares high. (For reference, "

--- a/files/lang/ru.po
+++ b/files/lang/ru.po
@@ -8,51 +8,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-22 09:48+0800\n"
+"POT-Creation-Date: 2021-07-01 15:11+0200\n"
 "PO-Revision-Date: 2013-03-04 05:27+0000\n"
 "Last-Translator: Watervolt <c347228@rmqkr.net>\n"
 "Language-Team: <ru@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: \n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%"
-"10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Launchpad-Export-Date: 2013-10-09 02:01+0000\n"
 "X-Generator: Launchpad (build 16799)\n"
 "X-Poedit-Bookmarks: 63,299,625,629,-1,-1,-1,-1,-1,-1\n"
 
-#: ../fheroes2/ai/ai_action.cpp:157 ../fheroes2/heroes/heroes_action.cpp:248
-msgid "Hero %{name} also got a %{count} experience."
-msgstr "Герой %{name} также получает %{count} опыта."
-
-#: ../fheroes2/army/army_bar.cpp:221 ../fheroes2/resource/artifact.cpp:977
-msgid "View %{name}"
-msgstr "Просмотреть %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:227 ../fheroes2/army/army_bar.cpp:310
-msgid "Move or right click to redistribute %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:233 ../fheroes2/army/army_bar.cpp:301
-msgid "Combine %{name} armies"
-msgstr "Комбинировать %{name} армии"
-
-#: ../fheroes2/army/army_bar.cpp:238 ../fheroes2/army/army_bar.cpp:292
-#: ../fheroes2/resource/artifact.cpp:989
-#: ../fheroes2/resource/artifact.cpp:1011
-msgid "Exchange %{name2} with %{name}"
-msgstr "Обмен %{name2} с %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:246 ../fheroes2/resource/artifact.cpp:997
-msgid "Select %{name}"
-msgstr "Выбрать %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:298 ../fheroes2/army/army_bar.cpp:307
-msgid "Cannot move last troop"
-msgstr ""
-
-#: ../fheroes2/army/army.cpp:85
 msgid ""
 "A few\n"
 "%{monster}"
@@ -60,7 +29,6 @@ msgstr ""
 "Мало\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:86
 msgid ""
 "Several\n"
 "%{monster}"
@@ -68,7 +36,6 @@ msgstr ""
 "Несколько\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:87
 msgid ""
 "A pack of\n"
 "%{monster}"
@@ -76,7 +43,6 @@ msgstr ""
 "Группа\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:88
 msgid ""
 "Lots of\n"
 "%{monster}"
@@ -84,7 +50,6 @@ msgstr ""
 "Много\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:89
 msgid ""
 "A horde of\n"
 "%{monster}"
@@ -92,7 +57,6 @@ msgstr ""
 "Орда\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:90
 msgid ""
 "A throng of\n"
 "%{monster}"
@@ -100,7 +64,6 @@ msgstr ""
 "Толпа\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:91
 msgid ""
 "A swarm of\n"
 "%{monster}"
@@ -108,7 +71,6 @@ msgstr ""
 "Свора\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:92
 msgid ""
 "Zounds of\n"
 "%{monster}"
@@ -116,7 +78,6 @@ msgstr ""
 "Сотни\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:93
 msgid ""
 "A legion of\n"
 "%{monster}"
@@ -124,228 +85,229 @@ msgstr ""
 "Легион\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Few"
 msgstr "Мало"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Several"
 msgstr "Несколько"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Pack"
 msgstr "Группа"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Lots"
 msgstr "Много"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Horde"
 msgstr "Орда"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Throng"
 msgstr "Толпа"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Swarm"
 msgstr "Туча"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Zounds"
 msgstr "Тысячи"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Legion"
 msgstr "Легион"
 
-#: ../fheroes2/army/army.cpp:928
 msgid "All %{race} troops +1"
 msgstr "Все отряды одной расы +1"
 
-#: ../fheroes2/army/army.cpp:939
-msgid "Entire unit is undead, so morale does not apply."
-msgstr "Мораль неприменима к нежити."
-
-#: ../fheroes2/army/army.cpp:949
 msgid "Troops of 3 alignments -1"
 msgstr "Отряды 3-х рас -1"
 
-#: ../fheroes2/army/army.cpp:957
 msgid "Troops of 4 alignments -2"
 msgstr "Отряды 4-х рас -2"
 
-#: ../fheroes2/army/army.cpp:965
 msgid "Troops of 5 alignments -3"
 msgstr "Отряды 5-и рас -3"
 
-#: ../fheroes2/army/army.cpp:979
 msgid "Some undead in groups -1"
 msgstr "В армии нежить -1"
 
-#: ../fheroes2/battle/battle_action.cpp:752
+msgid "View %{name}"
+msgstr "Просмотреть %{name}"
+
+msgid "Move or right click to redistribute %{name}"
+msgstr ""
+
+msgid "Combine %{name} armies"
+msgstr "Комбинировать %{name} армии"
+
+msgid "Exchange %{name2} with %{name}"
+msgstr "Обмен %{name2} с %{name}"
+
+msgid "Select %{name}"
+msgstr "Выбрать %{name}"
+
+msgid "Cannot move last troop"
+msgstr ""
+
+msgid "%{name} half the enemy troops!"
+msgstr "%{name} убивает половину вражеской армии!"
+
 msgid "Set auto battle off"
 msgstr "Выключить Авто-Битву"
 
-#: ../fheroes2/battle/battle_action.cpp:757
 msgid "Set auto battle on"
 msgstr "Включить Авто-Битву"
 
-#: ../fheroes2/battle/battle_action.cpp:864
 msgid "spell failed!"
 msgstr "Неудачный вызов магии!"
 
-#: ../fheroes2/battle/battle_arena.cpp:705
 msgid ""
 "The Sphere of Negation artifact is in effect for this battle, disabling all "
 "combat spells."
 msgstr ""
 "Сфера Отрицания лишила возможности использовать любые заклинания в битве."
 
-#: ../fheroes2/battle/battle_arena.cpp:714
 msgid "You have already cast a spell this round."
 msgstr "Вы уже использовали магию на этом ходу."
 
-#: ../fheroes2/battle/battle_arena.cpp:720
-#: ../fheroes2/battle/battle_arena.cpp:768
 msgid "That spell will affect no one!"
 msgstr "Это заклинание ни на кого не подействует!"
 
-#: ../fheroes2/battle/battle_arena.cpp:739
 msgid "You may only summon one type of elemental per combat."
 msgstr "В сражении Вы можете вызывать только одного типа элементалей."
 
-#: ../fheroes2/battle/battle_arena.cpp:745
 msgid "There is no open space adjacent to your hero to summon an Elemental to."
 msgstr "Для вызова элементалей у  Вас нет свободного пространства возле Героя."
 
-#: ../fheroes2/battle/battle_board.cpp:968
 msgid ""
 "The Moat reduces by -%{count} the defense skill of any unit and slows to "
 "half movement rate."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:50
-msgid "speed: %{speed}"
+msgid "Speed"
+msgstr "Скорость"
+
+#, fuzzy
+msgid "Speed: %{speed}"
 msgstr "скорость: %{speed}"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:165
+#, fuzzy
+msgid "Auto Spell Casting"
+msgstr "Использовать Магию"
+
+msgid "Grid"
+msgstr ""
+
+#, fuzzy
+msgid "Shadow Movement"
+msgstr "Продолжить движение"
+
+msgid "Shadow Cursor"
+msgstr ""
+
+msgid "On"
+msgstr ""
+
+#, fuzzy
+msgid "Off"
+msgstr "Выкл."
+
 msgid "The enemy has surrendered!"
 msgstr "Враг капитулировал!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:168
 msgid "The enemy has fled!"
 msgstr "Враг сбежал!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:170
-#: ../fheroes2/battle/battle_dialogs.cpp:256
 msgid "A glorious victory!"
 msgstr "Блистательная победа!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:175
-msgid "For valor in combat, %{name} receives %{exp} experience"
+#, fuzzy
+msgid "For valor in combat, %{name} receives %{exp} experience."
 msgstr "За доблесть в бою %{name} получает %{exp} опыта"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:184
 msgid "The cowardly %{name} flees from battle."
 msgstr "Трусливый %{name} бежал с поля битвы."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:191
 msgid "%{name} surrenders to the enemy, and departs in shame."
 msgstr "%{name} сдается врагу и уходит с позором."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:197
 msgid "Your force suffer a bitter defeat, and %{name} abandons your cause."
 msgstr "Ваши войска потерпели поражение и %{name} покидает вас."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:249
 msgid "Your force suffer a bitter defeat."
 msgstr "Ваши войска потерпели поражение."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:296
 msgid "Battlefield Casualties"
 msgstr "Потери"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:300
 msgid "Attacker"
 msgstr "Атакующий"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:312
 msgid "Defender"
 msgstr "Защитник"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:394
+msgid "You have captured an enemy artifact!"
+msgstr "Вы захватили вражеский артефакт!"
+
+#, fuzzy
+msgid "Necromancy!"
+msgstr "Некромантия"
+
+#, fuzzy
+msgid ""
+"Practicing the dark arts of necromancy, you are able to raise %{count} of "
+"the enemy's dead to return under your service as %{monster}."
+msgstr ""
+"Успешная практика в искусстве Некроманта, помогла поднять %{count} мертвых "
+"врагов как %{monster} для Вашей армии"
+
 msgid "%{name} the %{race}"
 msgstr "%{name} %{race}"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:401
-#: ../fheroes2/castle/castle_well.cpp:311
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:194
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:834
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Attack"
 msgstr "Атака"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:406
-#: ../fheroes2/castle/castle_well.cpp:317
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:206
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:844
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Defense"
 msgstr "Защита"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:411
-#: ../fheroes2/castle/castle_town.cpp:310
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:854
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:142
-#: ../fheroes2/heroes/heroes_meeting.cpp:292
 msgid "Spell Power"
 msgstr "Сила магии"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:416
-#: ../fheroes2/castle/castle_town.cpp:319
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:864
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:147
-#: ../fheroes2/heroes/heroes_meeting.cpp:296 ../fheroes2/heroes/skill.cpp:151
 msgid "Knowledge"
 msgstr "Знания"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:421
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:276
 msgid "Morale"
 msgstr "Мораль"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:426
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:286 ../fheroes2/heroes/skill.cpp:338
 msgid "Luck"
 msgstr "Удача"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:431
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:874
-#: ../fheroes2/heroes/heroes_indicator.cpp:247
 msgid "Spell Points"
 msgstr "Очки магии"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
-#: ../fheroes2/gui/interface_buttons.cpp:189
+msgid "Hero's Options"
+msgstr "Опции героя"
+
 msgid "Cast Spell"
 msgstr "Произнести заклинание"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
+msgid "Retreat"
+msgstr "Отступить"
+
+msgid "Surrender"
+msgstr "Сдаться"
+
+msgid "Cancel"
+msgstr "Отмена"
+
+msgid "Hero Screen"
+msgstr "Экран героя"
+
+#, fuzzy
 msgid ""
 "Cast a magical spell. You may only cast one spell per combat round. The "
-"round is reset when every creature has had a turn"
+"round is reset when every creature has had a turn."
 msgstr ""
 "Совершает магическое заклинание. Вы можете произносить только одно "
 "заклинание в течение раунда. Новый раунд начинается после того, как каждое "
 "существо сделает ход."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:488
-msgid "Retreat"
-msgstr "Отступить"
-
-#: ../fheroes2/battle/battle_dialogs.cpp:488
 msgid ""
 "Retreat your hero, abandoning your creatures. Your hero will be available "
 "for you to recruit again, however, the hero will have only a novice hero's "
@@ -354,11 +316,6 @@ msgstr ""
 "Отступить героем, бросив ваших существ на произвол судьбы. Вы сможете нанять "
 "этого героя снова, но с войском, соответствующим герою-новичку."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:491
-msgid "Surrender"
-msgstr "Сдаться"
-
-#: ../fheroes2/battle/battle_dialogs.cpp:491
 msgid ""
 "Surrendering costs gold. However if you pay the ransom, the hero and all of "
 "his or her surviving creatures will be available to recruit again."
@@ -366,719 +323,1018 @@ msgstr ""
 "Капитуляция стоит денег. Однако, если вы заплатите выкуп, героя можно будет "
 "нанять вместе со всеми выжившими существами."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:166
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:227
-msgid "Cancel"
-msgstr "Отмена"
+#, fuzzy
+msgid "Open Hero Screen to view full information about the hero."
+msgstr "Позволяет получить подробную информацию о героях противника."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
 msgid "Return to the battle."
 msgstr "Вернутся к сражению."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:549
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:515
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:574
 msgid "Not enough gold (%{gold})"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:564
 msgid "%{name} states:"
 msgstr "Параметры %{name}:"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:569
+#, fuzzy
 msgid ""
-"I will accept your surrender and grant you and your troops safe passage for "
-"the price of %{price} gold."
+"\"I will accept your surrender and grant you and your troops safe passage "
+"for the price of %{price} gold.\""
 msgstr ""
 "Я приму вашу капитуляцию и предоставлю безопасный проход вам и вашим войскам "
 "за %{price} золотом."
 
-#: ../fheroes2/battle/battle_interface.cpp:613
-#: ../fheroes2/battle/battle_interface.cpp:1401
 msgid "View %{monster} info."
 msgstr "Показать информацию для %{monster}."
 
-#: ../fheroes2/battle/battle_interface.cpp:1409
 #, fuzzy
 msgid "Shoot %{monster}"
 msgstr ""
 "Много\n"
 "%{monster}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1431
 msgid "Attack %{monster}"
 msgstr "Атаковать (цель: %{monster})"
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Fly %{monster} here."
 msgstr "Лететь сюда."
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Move %{monster} here."
 msgstr "Идти сюда."
 
-#: ../fheroes2/battle/battle_interface.cpp:1449
-#: ../fheroes2/battle/battle_interface.cpp:1538
 msgid "Turn %{turn}"
 msgstr "Turn %{turn}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1475
 msgid "Teleport Here"
 msgstr "Телепортировать сюда"
 
-#: ../fheroes2/battle/battle_interface.cpp:1479
 msgid "Invalid Teleport Destination"
 msgstr "Неверная цель телепорта"
 
-#: ../fheroes2/battle/battle_interface.cpp:1485
 msgid "Cast %{spell} on %{monster}"
 msgstr "Применить \"%{spell}\" (цель: %{monster})"
 
-#: ../fheroes2/battle/battle_interface.cpp:1495
 msgid "Cast %{spell}"
 msgstr "Произнести \"%{spell}\""
 
-#: ../fheroes2/battle/battle_interface.cpp:1501
 msgid "Select Spell Target"
 msgstr "Выберите цель заклинания"
 
-#: ../fheroes2/battle/battle_interface.cpp:1674
-msgid "Spell cast"
-msgstr "Использовать Магию"
-
-#: ../fheroes2/battle/battle_interface.cpp:1686
 msgid "View Ballista Info"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1699
-#: ../fheroes2/battle/battle_tower.cpp:53
 msgid "Ballista"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1712
 msgid "Auto combat"
 msgstr "Авто-Битва"
 
-#: ../fheroes2/battle/battle_interface.cpp:1719
 msgid "Customize system options."
 msgstr "Изменить настройки"
 
-#: ../fheroes2/battle/battle_interface.cpp:1727
 msgid "Wait this unit"
 msgstr "Подождать"
 
-#: ../fheroes2/battle/battle_interface.cpp:1734
 msgid "Skip this unit"
 msgstr "Пропустить ход"
 
-#: ../fheroes2/battle/battle_interface.cpp:1742
-#: ../fheroes2/battle/battle_interface.cpp:1774
-msgid "Hero's Options"
-msgstr "Опции героя"
-
-#: ../fheroes2/battle/battle_interface.cpp:1753
-#: ../fheroes2/battle/battle_interface.cpp:1785
 msgid "View Opposing Hero"
 msgstr "Просмотреть вражеского героя"
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Hide logs"
 msgstr "Спрятать журнал"
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Show logs"
 msgstr "Показать журнал"
 
-#: ../fheroes2/battle/battle_interface.cpp:1878
 msgid "%{color} cast spell: %{spell}"
 msgstr "%{color} использует магию: %{spell}"
 
-#: ../fheroes2/battle/battle_interface.cpp:2202
 msgid "%{name} skipping turn"
 msgstr "%{name} пропускает ход"
 
-#: ../fheroes2/battle/battle_interface.cpp:2203
-msgid ", and get +2 defense"
-msgstr ", а также получает +2 к защите"
-
-#: ../fheroes2/battle/battle_interface.cpp:2206
 msgid "%{name} waiting turn"
 msgstr "%{name} ждет хода"
 
-#: ../fheroes2/battle/battle_interface.cpp:2343
 msgid "%{attacker} do %{damage} damage."
 msgstr "%{attacker} наносит %{damage} урона."
 
-#: ../fheroes2/battle/battle_interface.cpp:2497
 msgid "Moved %{monster}: %{src}, %{dst}"
 msgstr "Ход %{monster}: %{src}, %{dst}"
 
-#: ../fheroes2/battle/battle_interface.cpp:2612
+#, fuzzy
+msgid "Moved %{monster}"
+msgstr "Идти сюда."
+
 msgid "The %{name} resist the spell!"
 msgstr "%{name} защитился от магии!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2625
 msgid "%{name} casts %{spell} on the %{troop}."
 msgstr "%{name} применяет \"%{spell}\" (цель: %{troop})."
 
-#: ../fheroes2/battle/battle_interface.cpp:2630
 msgid "%{name} casts %{spell}."
 msgstr "%{name} применил \"%{spell}\"."
 
-#: ../fheroes2/battle/battle_interface.cpp:2751
-msgid "The %{spell} spell does %{damage} damage to all undead creatures."
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to one undead creature."
 msgstr "Заклинание \"%{spell}\" наносит %{damage} урона всей нежити."
 
-#: ../fheroes2/battle/battle_interface.cpp:2754
-msgid "The %{spell} spell does %{damage} damage to all living creatures."
-msgstr "Заклинание \"%{spell}\" наносит %{damage} урона всем живым существам."
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to all undead creatures."
+msgstr "Заклинание \"%{spell}\" наносит %{damage} урона всей нежити."
 
-#: ../fheroes2/battle/battle_interface.cpp:2756
+#, fuzzy
+msgid "The %{spell} does %{damage} damage, %{count} creatures perish."
+msgstr "Заклинание \"%{spell}\" наносит %{damage} урона всей нежити."
+
 msgid "The %{spell} does %{damage} damage."
 msgstr "Заклинание \"%{spell}\" наносит %{damage} урона."
 
-#: ../fheroes2/battle/battle_interface.cpp:2797
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to one living creature."
+msgstr "Заклинание \"%{spell}\" наносит %{damage} урона всем живым существам."
+
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to all living creatures."
+msgstr "Заклинание \"%{spell}\" наносит %{damage} урона всем живым существам."
+
 msgid "The Unicorns attack blinds the %{name}!"
 msgstr "%{name} ослеплены Единорогами!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2798
 msgid "The Medusas gaze turns the %{name} to stone!"
 msgstr "%{name} обращены в камень взглядом медузы!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2800
 msgid "The Mummies' curse falls upon the %{name}!"
 msgstr "%{name} прокляты Мумиями!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2801
 msgid "The %{name} are paralyzed by the Cyclopes!"
 msgstr "%{name} парализованы Циклопами!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2802
 msgid "The Archmagi dispel all good spells on your %{name}!"
 msgstr "Архимаги рассеяли хорошую магию с отряда %{name}!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2820
-msgid "Good luck shines on the  %{attacker}"
+#, fuzzy
+msgid "Good luck shines on the %{attacker}"
 msgstr "Удача улыбнулась %{attacker}"
 
-#: ../fheroes2/battle/battle_interface.cpp:2872
 msgid "Bad luck descends on the %{attacker}"
 msgstr "Удача отвернулась от %{attacker}"
 
-#: ../fheroes2/battle/battle_interface.cpp:2884
 msgid "High morale enables the %{monster} to attack again."
 msgstr "Благодаря высокой морали %{monster} атакуют ещё раз."
 
-#: ../fheroes2/battle/battle_interface.cpp:2891
 msgid "Low morale causes the %{monster} to freeze in panic."
 msgstr "Из-за низкой морали %{monster} застыли в панике."
 
-#: ../fheroes2/battle/battle_interface.cpp:2944
-msgid "Tower do %{damage} damage."
+#, fuzzy
+msgid "%{tower} does %{damage} damage."
 msgstr "Башня наносит %{damage} урона."
 
-#: ../fheroes2/battle/battle_interface.cpp:3257
 msgid "MirrorImage created"
 msgstr "MirrorImage создано."
 
-#: ../fheroes2/battle/battle_interface.cpp:3798
-msgid "MirrorImage ended"
-msgstr "MirrorImage закончилась магия."
+msgid "The mirror image is destroyed!"
+msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4089
 #, fuzzy
 msgid "Break auto battle?"
 msgstr "Включить Авто-Битву"
 
-#: ../fheroes2/battle/battle_interface.cpp:4138
 msgid "No spells to cast."
 msgstr "Нет заклинаний."
 
-#: ../fheroes2/battle/battle_interface.cpp:4147
 msgid "Are you sure you want to retreat?"
 msgstr "Вы действительно хотите отступить?"
 
-#: ../fheroes2/battle/battle_interface.cpp:4155
 #, fuzzy
 msgid "Retreat disabled"
 msgstr "Отступить"
 
-#: ../fheroes2/battle/battle_interface.cpp:4169
-msgid "You don't have enough gold!"
-msgstr "Вам не хватает золота!"
-
-#: ../fheroes2/battle/battle_interface.cpp:4180
 #, fuzzy
 msgid "Surrender disabled"
 msgstr "Сдаться"
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{max}"
 msgstr "Ущерб: %{max}"
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{min} - %{max}"
 msgstr "Ущерб: %{min} - %{max}"
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{max}"
 msgstr "Погибнет: %{max}"
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{min} - %{max}"
 msgstr "Погибнет: %{min} - %{max}"
 
-#: ../fheroes2/battle/battle_main.cpp:190
-msgid "You have captured an enemy artifact!"
-msgstr "Вы захватили вражеский артефакт!"
-
-#: ../fheroes2/battle/battle_main.cpp:241
 msgid ""
-"Through eagle-eyed observation, %{name} is able to learn the magic spell %"
-"{spell}."
+"Through eagle-eyed observation, %{name} is able to learn the magic spell "
+"%{spell}."
 msgstr ""
 "Благодаря орлиному взору, %{name} смог выучить заклинание \"%{spell}\"."
 
-#: ../fheroes2/battle/battle_main.cpp:280
-msgid ""
-"Practicing the dark arts of necromancy, you are able to raise %{count} of "
-"the enemy's dead to return under your service as %{monster}"
-msgstr ""
-"Успешная практика в искусстве Некроманта, помогла поднять %{count} мертвых "
-"врагов как %{monster} для Вашей армии"
-
-#: ../fheroes2/battle/battle_tower.cpp:47 ../fheroes2/castle/castle.cpp:466
 msgid "Left Turret"
 msgstr "Левая Башня"
 
-#: ../fheroes2/battle/battle_tower.cpp:48 ../fheroes2/castle/castle.cpp:467
 msgid "Right Turret"
 msgstr "Правая Башня"
 
-#: ../fheroes2/battle/battle_tower.cpp:115
 msgid "The %{name} fires with the strength of %{count} Archers"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:116
 msgid "each with a +%{attack} bonus to their attack skill."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:863
-msgid "%{name} half the enemy troops!"
-msgstr "%{name} убивает половину вражеской армии!"
-
-#: ../fheroes2/battle/battle_troop.cpp:950
 msgid ""
 "The %{artifact} artifact is in effect for this battle, disabling %{spell} "
 "spell."
 msgstr "%{artifact} запрещает использовать \"%{spell}\"."
 
-#: ../fheroes2/battle/battle_troop.cpp:1598
 msgid "%{count} %{name} rise(s) from the dead!"
 msgstr "%{count} %{name} воскресли из мертвых!"
 
-#: ../fheroes2/castle/buildinginfo.cpp:258
+#, fuzzy
+msgid "Sorceress Guild"
+msgstr "Колдунья"
+
+#, fuzzy
+msgid "Necromancer Guild"
+msgstr "Некромант"
+
+#, fuzzy
+msgid "Dragon Alliance"
+msgstr "Разрушенный Союз"
+
+#, fuzzy
+msgid "Elven Alliance"
+msgstr "Разрушенный Союз"
+
+msgid "Wayward Son"
+msgstr ""
+
+msgid "Uncle Ivan"
+msgstr "Дядя Ваня"
+
+#, fuzzy
+msgid "Force of Arms"
+msgstr "\"Сила Оружия\""
+
+#, fuzzy
+msgid "Annexation"
+msgstr "\"Присоединение\""
+
+#, fuzzy
+msgid "Save the Dwarves"
+msgstr "\"Спасите Гномов\""
+
+#, fuzzy
+msgid "Carator Mines"
+msgstr "\"Шахты Каратора\""
+
+#, fuzzy
+msgid "Turning Point"
+msgstr "Базар"
+
+msgid "The Gauntlet"
+msgstr ""
+
+#, fuzzy
+msgid "The Crown"
+msgstr "Западный город"
+
+#, fuzzy
+msgid "Corlagon's Defense"
+msgstr "Корлагон"
+
+msgid "Final Justice"
+msgstr ""
+
+#, fuzzy
+msgid "First Blood"
+msgstr "\"Первая кровь\""
+
+#, fuzzy
+msgid "Barbarian Wars"
+msgstr "\"Война Варваров\""
+
+#, fuzzy
+msgid "Necromancers"
+msgstr "Некромант"
+
+#, fuzzy
+msgid "Slay the Dwarves"
+msgstr "\"Спасите Гномов\""
+
+msgid "Rebellion"
+msgstr ""
+
+#, fuzzy
+msgid "Dragon Master"
+msgstr "\"Повелитель Драконов\""
+
+#, fuzzy
+msgid "Country Lords"
+msgstr "\"Страна Лордов\""
+
+#, fuzzy
+msgid "Greater Glory"
+msgstr "\"Великая Слава\""
+
+#, fuzzy
+msgid "Apocalypse"
+msgstr "Апокалипсис"
+
+msgid "Uprising"
+msgstr ""
+
+#, fuzzy
+msgid "Island of Chaos"
+msgstr "Остров Эльфов"
+
+msgid "Arrow's Flight"
+msgstr ""
+
+msgid "The Abyss"
+msgstr ""
+
+msgid "The Giant's Pass"
+msgstr ""
+
+msgid "Aurora Borealis"
+msgstr ""
+
+#, fuzzy
+msgid "Betrayal's End"
+msgstr "\"Измена!\""
+
+#, fuzzy
+msgid "Corruption's Heart"
+msgstr "Капитанский штаб"
+
+msgid "Conquer and Unify"
+msgstr ""
+
+#, fuzzy
+msgid "Border Towns"
+msgstr "Пограничье"
+
+msgid "The Wayward Son"
+msgstr ""
+
+#, fuzzy
+msgid "Crazy Uncle Ivan"
+msgstr "Дядя Ваня"
+
+msgid "The Southern War"
+msgstr ""
+
+msgid "Ivory Gates"
+msgstr "Ворота Слоновой Кости"
+
+#, fuzzy
+msgid "The Elven Lands"
+msgstr "Семь Озер"
+
+msgid "The Epic Battle"
+msgstr ""
+
+msgid "The Shrouded Isles"
+msgstr ""
+
+msgid "The Eternal Scrolls"
+msgstr ""
+
+#, fuzzy
+msgid "Power's End"
+msgstr "Кольцо Силы"
+
+#, fuzzy
+msgid "Fount of Wizardry"
+msgstr "Волшебный Посох"
+
+msgid "Stranded"
+msgstr ""
+
+#, fuzzy
+msgid "Pirate Isles"
+msgstr "Пиратская Бухта"
+
+msgid "King and Country"
+msgstr ""
+
+msgid "Blood is Thicker"
+msgstr ""
+
+msgid ""
+"Roland needs you to defeat the lords near his castle to begin his war of "
+"rebellion against his brother.  They are not allied with each other, so they "
+"will spend most of their time fighting with one another.  Victory is yours "
+"when you have defeated all of their castles and heroes."
+msgstr ""
+
+msgid ""
+"The local lords refuse to swear allegiance to Roland, and must be subdued. "
+"They are wealthy and powerful, so be prepared for a tough fight. Capture all "
+"enemy castles to win."
+msgstr ""
+
+msgid ""
+"Your task is to defend the Dwarves against Archibald's forces. Capture all "
+"of the enemy towns and castles to win, and be sure not to lose all of the "
+"dwarf towns at once, or the enemy will have won."
+msgstr ""
+
+msgid ""
+"You will face four allied enemies in a straightforward fight for resource "
+"and treasure. Capture all of the enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Your enemies are allied against you and start close by, so be ready to come "
+"out fighting. You will need to own all four castles in this small valley to "
+"win."
+msgstr ""
+
+msgid ""
+"The Sorceress' guild of Noraston has requested Roland's aid against an "
+"attack from Archibald's allies. Capture all of the enemy castles to win, and "
+"don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy "
+"castle on an island in the ocean.)"
+msgstr ""
+
+msgid ""
+"Gather as large an army as possible and capture the enemy castle within 8 "
+"weeks. You are opposed by only one enemy, but must travel a long way to get "
+"to the enemy castle. Any troops you have in your army at the end of this "
+"scenario will be with you in the final battle."
+msgstr ""
+
+msgid ""
+"Find the Crown before Archibald's heroes find it. Roland will need the Crown "
+"for the final battle against Archibald."
+msgstr ""
+
+msgid ""
+"Three allied enemies stand before you and victory, including Lord Corlagon. "
+"Roland is in a castle to the northwest, and you will lose if he falls to the "
+"enemy. Remember that capturing Lord Corlagon will ensure that he will not "
+"fight against you in the final scenario."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Archibald to end the war!"
+msgstr ""
+
+msgid ""
+"King Archibald requires you to defeat the three enemies in this region.  "
+"They are not allied with one another, so they will spend most of their "
+"energy fighting amongst themselves.  You will win when you own all of the "
+"enemy castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"You must unify the barbarian tribes of the north by conquering them. As in "
+"the previous mission, the enemy is not allied against you, but they have "
+"more resources at their disposal. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"Do-gooder wizards have taken the Necromancers' castle. You must retake it to "
+"achieve victory. Remember that while you start with a powerful army, you "
+"have no castle and must take one within 7 days, or lose this battle. (Hint: "
+"The nearest castle is to the southeast.)"
+msgstr ""
+
+msgid ""
+"The dwarves need conquering before they can interfere in King Archibald's "
+"plans. Roland's forces have more than one hero and many towns to start with, "
+"so be ready for attack from multiple directions. You must capture all of the "
+"enemy towns and castles to claim victory."
+msgstr ""
+
+msgid ""
+"You must put down a peasant revolt led by Roland's forces. All are allied "
+"against you, but you have Lord Corlagon, an experienced hero, to help you. "
+"Capture all enemy castles to win."
+msgstr ""
+
+msgid ""
+"There are two enemies allied against you in this mission. Both are well "
+"armed and seek to evict you from their island. Avoid them and capture Dragon "
+"City to win"
+msgstr ""
+
+msgid ""
+"Your orders are to conquer the country lords that have sworn to serve "
+"Roland. All of the enemy castles are unified against you. Since you start "
+"without a castle, you must hurry to capture one before the end of the week. "
+"Capture all enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Find the Crown before Roland's heroes find it. Archibald will need the Crown "
+"for the final battle against Roland."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Roland to win the war, and be sure "
+"not to lose Archibald in the fight!"
+msgstr ""
+
+msgid ""
+"Subdue the unruly local lords in order to provide the Empire with facilities "
+"to operate in this region."
+msgstr ""
+
+msgid ""
+"Eliminate all oposition in this area. Then the first piece of the artifact "
+"will be yours."
+msgstr ""
+
+msgid ""
+"The sorceresses to the northeast are rebelling! For the good of the empire "
+"you must quash their feeble uprising on your way to the mountains."
+msgstr ""
+
+msgid ""
+"Having prepared for your arrival, Kraeger has arranged for a force of "
+"necromancers to thwart your quest. You must capture the castle of Scabsdale "
+"before the first day of the third week, or the Necromancers will be too "
+"strong for you."
+msgstr ""
+
+msgid ""
+"The barbarian despot in this area is, as yet, ignorant of your presence. "
+"Quickly, build up your forces before you are discovered and attacked! Secure "
+"the region by subduing all enemy forces."
+msgstr ""
+
+msgid ""
+"The Empire is weak in this region. You will be unable to completely subdue "
+"all forces in this area, so take what you can before reprisal strikes. "
+"Remember, your true goal is to claim the Helmet of Anduran."
+msgstr ""
+
+msgid "For the good of the Empire, eliminate Kraeger."
+msgstr ""
+
+msgid ""
+"At last, you have the opportunity and the facilities to rid the Empire of "
+"the necromancer's evil. Eradicate them completely, and you will be sung as a "
+"hero for all time."
+msgstr ""
+
+msgid ""
+"Conquer and unite all the enemy tribes. Don't lose the hero Jarkonas, the "
+"forefather of all descendants."
+msgstr ""
+
+msgid ""
+"Your rival, the Kingdom of Harondale, is attacking weak towns on your "
+"border! Recover from their first strike and crush them completely!"
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Find your wayward son Joseph who is rumored to be living in the desolate "
+"lands. Do it before the first day of the third month or it will be of no "
+"help to your family."
+msgstr ""
+"Найдите Вашего Блудного Сына, который, по слухам, живёт в бесплодных землях. "
+"Сделайте это за 8 недель, иначе будет поздно."
+
+msgid ""
+"Rescue your crazy uncle Ivan. Find him before the first day of the fourth "
+"month or it will be no help to your kingdom."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Destroy the barbarians who are attacking the southern border of your "
+"kingdom! Recover your fallen towns, and then invade the jungle kingdom. "
+"Leave no enemy standing."
+msgstr ""
+"Уничтожьте варваров, атакующих южные границы вашего королевства. Верните "
+"свои города, затем завоюйте варварские."
+
+msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Gain the favor of the elves. They will not allow trees to be chopped down, "
+"so they will send you wood every 2 weeks. You must complete your mission "
+"before the first day of the seventh month, or the kingdom will surely fall."
+msgstr ""
+"Получите поддержу эльфов. Они не позволят Вам рубить лес, так что мы будет "
+"отправлять Вам древесину каждые две недели. У Вас есть 7 месяцев!"
+
+msgid ""
+"This is the final battle against your rival kingdom of Harondale. Eliminate "
+"everyone, and don't lose the hero Jarkonas VI."
+msgstr ""
+
+msgid ""
+"Your mission is to vanquish the warring mages in the magical Shrouded Isles. "
+"The completion of this task will give you a fighting chance against your "
+"rivals."
+msgstr ""
+
+msgid ""
+"The location of the great library has been dicovered! You must make your way "
+"to it, and reclaim the city of Chronos in which it lies."
+msgstr ""
+
+msgid ""
+"Find the Orb of negation, which is said to be buried in this land. There are "
+"clues inscribed on stone obelisks which will help lead you to your price. "
+"Find the orb before the first day of the sixth month, or your rivals will "
+"surely have gotten to the fount before you."
+msgstr ""
+
+msgid ""
+"You must take control of the castle of Magic, where the fount of wizardry "
+"lies. Do this and your victory will be supreme."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Capture the town on the island off the southeast shore in order to construct "
+"a boat and travel back towards the mainland. Do not lose the hero Gallavant."
+msgstr ""
+"Захватите город на острове к юго-западу от побережья для того, чтобы "
+"построить лодку, и вернитесь обратно на материк."
+
+msgid ""
+"Find and defeat Martine, the pirate leader, who resides in Pirates Cove. Do "
+"not lose Gallavant or your quest will be over."
+msgstr ""
+
+msgid ""
+"Eliminate all the other forces who oppose the rule of Lord Alberon. "
+"Gallavant must not die."
+msgstr ""
+
+msgid ""
+"Overthrow the entrenched monarchy of Lord Alberon, and claim all the land in "
+"your name. Gallavant must not die."
+msgstr ""
+
+msgid " bane"
+msgstr ""
+
+#, fuzzy
+msgid " alliance"
+msgstr "Разрушенный Союз"
+
+msgid "Carry-over forces"
+msgstr ""
+
+msgid " bonus"
+msgstr ""
+
+msgid " defeated"
+msgstr ""
+
+#, fuzzy
+msgid "Thunder Mace"
+msgstr "Громовая Палица"
+
+#, fuzzy
+msgid "Minor Scroll"
+msgstr "Малый Свиток Знания"
+
+#, fuzzy
+msgid "Dragon Sword"
+msgstr "Убить Дракона"
+
+#, fuzzy
+msgid "Breastplate"
+msgstr "Кираса Андурана"
+
+msgid "Fibzin Medal"
+msgstr ""
+
+#, fuzzy
+msgid "Mage's ring"
+msgstr "Кольцо Мага"
+
+#, fuzzy
+msgid "Defender Helm"
+msgstr "Защитник"
+
+#, fuzzy
+msgid "Power Axe"
+msgstr "Сила магии"
+
+#, fuzzy
+msgid "Summon Earth"
+msgstr "Призвать корабль"
+
 msgid "The %{building} produces %{monster}."
 msgstr "В %{building} можно нанять %{monster}."
 
-#: ../fheroes2/castle/buildinginfo.cpp:505
 msgid "Requires:"
 msgstr "Требует:"
 
-#: ../fheroes2/castle/buildinginfo.cpp:597
 msgid "Cannot build. Already built here this turn."
 msgstr "Нельзя строить. Вы уже строили здесь на этом ходу."
 
-#: ../fheroes2/castle/buildinginfo.cpp:601
 msgid "For this action it is necessary first to build a castle."
 msgstr "Для этого вам нужно сперва построить замок."
 
-#: ../fheroes2/castle/buildinginfo.cpp:623
 msgid "Cannot build %{name} because castle is too far from water."
 msgstr "%{name} невозможно построить, потому что замок слишком далеко от воды."
 
-#: ../fheroes2/castle/buildinginfo.cpp:631
-msgid "Cannot afford %{name}"
+#, fuzzy
+msgid "Cannot afford %{name}."
 msgstr "Нельзя построить %{name}"
 
-#: ../fheroes2/castle/buildinginfo.cpp:636
-msgid "%{name} is already built"
+#, fuzzy
+msgid "%{name} is already built."
 msgstr "Это здание уже построено."
 
-#: ../fheroes2/castle/buildinginfo.cpp:641
-msgid "Cannot build %{name}"
+#, fuzzy
+msgid "Cannot build %{name}."
 msgstr "%{name} построить не получится."
 
-#: ../fheroes2/castle/buildinginfo.cpp:646
-msgid "Build %{name}"
+#, fuzzy
+msgid "Build %{name}."
 msgstr "%{name} построено."
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Thieves' Guild"
 msgstr "Гильдия Воров"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Tavern"
 msgstr "Таверна"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Shipyard"
 msgstr "Верфь"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Well"
 msgstr "Колодец"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Statue"
 msgstr "Статуя"
 
-#: ../fheroes2/castle/castle.cpp:467
-#: ../fheroes2/dialog/dialog_marketplace.cpp:212
 msgid "Marketplace"
 msgstr "Рынок"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Moat"
 msgstr "Ров"
 
-#: ../fheroes2/castle/castle.cpp:467 ../fheroes2/maps/mp2.cpp:391
 msgid "Castle"
 msgstr "Замок"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Tent"
 msgstr "Палатка"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Captain's Quarters"
 msgstr "Капитанский штаб"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Mage Guild, Level 1"
 msgstr "Гильдия Магов 1-го уровня"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 2"
 msgstr "Гильдия Магов 2-го уровня"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 3"
 msgstr "Гильдия Магов 3-го уровня"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 4"
 msgstr "Гильдия Магов 4-го уровня"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 5"
 msgstr "Гильдия Магов 5-го уровня"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Farm"
 msgstr "Ферма"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Garbage Heap"
 msgstr "Свалка"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Crystal Garden"
 msgstr "Хрустальный Сад"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Waterfall"
 msgstr "Водопад"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Orchard"
 msgstr "Цветник"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Skull Pile"
 msgstr "Груда Черепов"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Fortifications"
 msgstr "Укрепления"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Coliseum"
 msgstr "Колизей"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Rainbow"
 msgstr "Радуга"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Dungeon"
 msgstr "Сокровищница"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Library"
 msgstr "Библиотека"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Storm"
 msgstr "Буря"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:498
 msgid "Thatched Hut"
 msgstr "Мазанка"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Hut"
 msgstr "Хижина"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Treehouse"
 msgstr "Дома-на-дереве"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:441
 msgid "Cave"
 msgstr "Пещера"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Habitat"
 msgstr "Нора"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:431
 msgid "Excavation"
 msgstr "Раскопки"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:477
 msgid "Archery Range"
 msgstr "Стрельбище"
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Stick Hut"
 msgstr "Халупа"
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Cottage"
 msgstr "Избушка"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Crypt"
 msgstr "Склеп"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Pen"
 msgstr "Хлев"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/maps/mp2.cpp:371
 msgid "Graveyard"
 msgstr "Кладбище"
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Blacksmith"
 msgstr "Кузница"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Den"
 msgstr "Логово"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Nest"
 msgstr "Гнездо"
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Foundry"
 msgstr "Литейная"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:480
-#: ../fheroes2/castle/castle.cpp:487 ../fheroes2/maps/mp2.cpp:427
-#: ../fheroes2/resource/maps_text.cpp:521
 msgid "Pyramid"
 msgstr "Пирамида"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Armory"
 msgstr "Оружейная"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Adobe"
 msgstr "Глинобитный дом"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Stonehenge"
 msgstr "Стоунхедж"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Maze"
 msgstr "Лабиринт"
 
-#: ../fheroes2/castle/castle.cpp:478 ../fheroes2/castle/castle.cpp:485
 msgid "Cliff Nest"
 msgstr "Гнездовье"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Mansion"
 msgstr "Особняк"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Jousting Arena"
 msgstr "Арена"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Bridge"
 msgstr "Мост"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
 msgid "Fenced Meadow"
 msgstr "Огороженная лужайка"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Swamp"
 msgstr "Болото"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Ivory Tower"
 msgstr "Башня слоновой кости"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Mausoleum"
 msgstr "Мавзолей"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cathedral"
 msgstr "Собор"
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Red Tower"
 msgstr "Красная башня"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Green Tower"
 msgstr "Зеленая башня"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cloud Castle"
 msgstr "Небесный замок"
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Laboratory"
 msgstr "Лаборатория"
 
-#: ../fheroes2/castle/castle.cpp:483 ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Archery Range"
 msgstr "Полигон"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Stick Hut"
 msgstr "Хибара"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Cottage"
 msgstr "Хоромы"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Graveyard"
 msgstr "Погост"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Blacksmith"
 msgstr "Ковальня"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Foundry"
 msgstr "Фабрика"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Pyramid"
 msgstr "Великая пирамида"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Armory"
 msgstr "Арсенал"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Adobe"
 msgstr "Логово огров"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Stonehenge"
 msgstr "Менгиры"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Maze"
 msgstr "Большой лабиринт"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Mansion"
 msgstr "Поместье"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Jousting Arena"
 msgstr "Ресталище"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Bridge"
 msgstr "Царь-мост"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Ivory Tower"
 msgstr "Обитель магов"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Mausoleum"
 msgstr "Некрополь"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cathedral"
 msgstr "Храм"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cloud Castle"
 msgstr "Небесный чертог"
 
-#: ../fheroes2/castle/castle.cpp:488
 msgid "Black Tower"
 msgstr "Черная башня"
 
-#: ../fheroes2/castle/castle.cpp:490
 msgid "Shrine"
 msgstr "Алтарь"
 
-#: ../fheroes2/castle/castle.cpp:552
+#, fuzzy
 msgid ""
 "The Thieves' Guild provides information on enemy players. Thieves' Guilds "
-"can also provide scouting information on enemy towns."
+"can also provide scouting information on enemy towns. Additional Guilds "
+"provide more information."
 msgstr "Гильдия воров предоставляет информацию о вражеских игроках и городах."
 
-#: ../fheroes2/castle/castle.cpp:553
 msgid "The Tavern increases morale for troops defending the castle."
 msgstr "Таверна повышает мораль защитников замка на 1."
 
-#: ../fheroes2/castle/castle.cpp:554
 msgid "The Shipyard allows ships to be built."
 msgstr "Верфь позволяет вам строить корабли."
 
-#: ../fheroes2/castle/castle.cpp:555
 msgid ""
 "The Well increases the growth rate of all dwellings by %{count} creatures "
 "per week."
 msgstr ""
 "Колодец увеличивает прирост всех существ в замке на %{count} каждую неделю."
 
-#: ../fheroes2/castle/castle.cpp:556
 msgid "The Statue increases your town's income by %{count} per day."
 msgstr "Статуя приносит в казну %{count} золотых ежедневно."
 
-#: ../fheroes2/castle/castle.cpp:557
 msgid "The Left Turret provides extra firepower during castle combat."
 msgstr "Левая башня наносит дополнительный урон врагу во время осады замка."
 
-#: ../fheroes2/castle/castle.cpp:558
 msgid "The Right Turret provides extra firepower during castle combat."
 msgstr "Правая башня наносит дополнительный урон врагу во время осады замка."
 
-#: ../fheroes2/castle/castle.cpp:559
 msgid ""
 "The Marketplace can be used to convert one type of resource into another. "
 "The more marketplaces you control, the better the exchange rate."
@@ -1086,7 +1342,6 @@ msgstr ""
 "Рынок используется для обмена одного типа ресурсов на другой. Чем больше "
 "рынков, тем ниже цены."
 
-#: ../fheroes2/castle/castle.cpp:560
 msgid ""
 "The Moat slows attacking units. Any unit entering the moat must end its turn "
 "there and becomes more vulnerable to attack."
@@ -1094,20 +1349,17 @@ msgstr ""
 "Ров замедляет наступление войск. Отряд, желающий пересечь ров, будет "
 "вынужден завершить первый ход внутри рва, став уязвимее к атаке."
 
-#: ../fheroes2/castle/castle.cpp:561
 msgid ""
 "The Castle improves town defense and increases income to %{count} gold per "
 "day."
 msgstr ""
 "Замок улучшает оборону города и приносит в казну %{count} золотых ежедневно."
 
-#: ../fheroes2/castle/castle.cpp:562
 msgid ""
 "The Tent provides workers to build a castle, provided the materials and the "
 "gold are available."
 msgstr "Здесь находятся рабочие, которые могут возвести замок."
 
-#: ../fheroes2/castle/castle.cpp:563
 msgid ""
 "The Captain's Quarters provides a captain to assist in the castle's defense "
 "when no hero is present."
@@ -1115,39 +1367,31 @@ msgstr ""
 "Капитанский штаб позволяет капитану руководить защитой замка, если в нем "
 "отсутствует герой."
 
-#: ../fheroes2/castle/castle.cpp:564
 msgid ""
 "The Mage Guild allows heroes to learn spells and replenish their spell "
 "points."
 msgstr ""
 "Гильдия Магов позволяет героям учить заклинания и восполнять очки магии."
 
-#: ../fheroes2/castle/castle.cpp:567
 msgid "The Farm increases production of Peasants by %{count} per week."
 msgstr "Ферма увеличивает прирост Крестьян на %{count} в неделю."
 
-#: ../fheroes2/castle/castle.cpp:568
 msgid "The Garbage Heap increases production of Goblins by %{count} per week."
 msgstr "Свалка увеличивает прирост Гоблинов на %{count} в неделю."
 
-#: ../fheroes2/castle/castle.cpp:569
 msgid ""
 "The Crystal Garden increases production of Sprites by %{count} per week."
 msgstr "Хрустальный сад увеличивает прирост Фей на %{count} в неделю."
 
-#: ../fheroes2/castle/castle.cpp:570
 msgid "The Waterfall increases production of Centaurs by %{count} per week."
 msgstr "Водопад увеличивает прирост Кентавров на %{count} в неделю."
 
-#: ../fheroes2/castle/castle.cpp:571
 msgid "The Orchard increases production of Halflings by %{count} per week."
 msgstr "Терновник увеличивает прирост Хоббитов на %{count} в неделю."
 
-#: ../fheroes2/castle/castle.cpp:572
 msgid "The Skull Pile increases production of Skeletons by %{count} per week."
 msgstr "Груда черепов увеличивает прирост Скелетов на %{count} в неделю."
 
-#: ../fheroes2/castle/castle.cpp:575
 msgid ""
 "The Fortifications increase the toughness of the walls, increasing the "
 "number of turns it takes to knock them down."
@@ -1155,7 +1399,6 @@ msgstr ""
 "Укрепления увеличивают общую прочность стен, делая их более устойчивыми к "
 "разрушению."
 
-#: ../fheroes2/castle/castle.cpp:576
 msgid ""
 "The Coliseum provides inspiring spectacles to defending troops, raising "
 "their morale by two during combat."
@@ -1163,15 +1406,12 @@ msgstr ""
 "Представления, проводимые в колизее, увеличивают мораль защитников замка на "
 "2."
 
-#: ../fheroes2/castle/castle.cpp:577
 msgid "The Rainbow increases the luck of the defending units by two."
 msgstr "Радуга увеличивает удачу защитников замка на 2."
 
-#: ../fheroes2/castle/castle.cpp:578
 msgid "The Dungeon increases the income of the town by %{count} / day."
 msgstr "Темница приносит в казну %{count} золотых ежедневно."
 
-#: ../fheroes2/castle/castle.cpp:579
 msgid ""
 "The Library increases the number of spells in the Guild by one for each "
 "level of the guild."
@@ -1179,131 +1419,119 @@ msgstr ""
 "Библиотека увеличивает число заклинаний, доступных в гильдии магов, на одно "
 "заклинание для каждого уровня."
 
-#: ../fheroes2/castle/castle.cpp:580
 msgid "The Storm adds +2 to the power of spells of a defending spell caster."
 msgstr "Буря добавляет 2 очка к силе магии заклинателя, обороняющего замок."
 
-#: ../fheroes2/castle/castle.cpp:582
 msgid ""
 "The Shrine increases the necromancy skill of all your necromancers by 10 "
 "percent."
 msgstr "Алтарь увеличивает навык некромантии у всех ваших некромантов на 10%."
 
-#: ../fheroes2/castle/castle.cpp:632
 msgid "Cannot recruit - you already recruit hero in current week."
 msgstr "Найм невозможен. На этой неделе Вы уже нанимали героя."
 
-#: ../fheroes2/castle/castle.cpp:645
 #, fuzzy
 msgid "Cannot recruit - guest to guard automove error."
 msgstr "Найм невозможен. Вы уже имеете максимум героев."
 
-#: ../fheroes2/castle/castle.cpp:651
 msgid "Cannot recruit - you already have a Hero in this town."
 msgstr "Найм невозможен. В замке уже есть герой."
 
-#: ../fheroes2/castle/castle.cpp:659
 msgid "Cannot recruit - you have too many Heroes."
 msgstr "Найм невозможен. Вы уже имеете максимум героев."
 
-#: ../fheroes2/castle/castle.cpp:665
 msgid "Cannot afford a Hero"
 msgstr "Найм невозможен. У Вас не достаточно средств."
 
-#: ../fheroes2/castle/castle.cpp:756
 msgid "There is no room in the garrison for this army."
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:272
+msgid "Recruit %{name}"
+msgstr "Нанять  %{name}"
+
 msgid "Month: %{month}, Week: %{week}, Day: %{day}"
 msgstr "Месяц: %{month}, Неделя: %{week}, День: %{day}"
 
-#: ../fheroes2/castle/castle_dialog.cpp:393
-#: ../fheroes2/castle/castle_dialog.cpp:396
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:388
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:186
-msgid "Income:"
+#, fuzzy
+msgid "Income"
 msgstr "Доход:"
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 #, fuzzy
 msgid "Join Error"
 msgstr "Ошибка"
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 msgid "Army is full"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
+msgid ""
+"You must purchase a spell book to use the mage guild, but you currently have "
+"no room for a spell book. Try giving one of your artifacts to another hero."
+msgstr ""
+"Чтобы Вас пропустили в Гильдию Магов, Вы должны купить книгу заклинаний, но "
+"к сожалению, Ваша сумка и так переполнена артифактами."
+
 msgid "Town"
 msgstr "Город"
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
 msgid "This town may not be upgraded to a castle."
 msgstr "В этом городе нельзя построить замок."
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit castle"
+#, fuzzy
+msgid "Exit Castle"
 msgstr "Покинуть замок"
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit town"
+#, fuzzy
+msgid "Exit Town"
 msgstr "Покинуть город"
 
-#: ../fheroes2/castle/castle_dialog.cpp:730
 #, fuzzy
-msgid "Show income"
+msgid "Show Income"
 msgstr "Показать журнал"
 
-#: ../fheroes2/castle/castle_dialog.cpp:734
 msgid "Show previous town"
 msgstr "Предыдущий город"
 
-#: ../fheroes2/castle/castle_dialog.cpp:738
 msgid "Show next town"
 msgstr "Следующий город"
 
-#: ../fheroes2/castle/castle_dialog.cpp:741
 msgid "Swap Heroes"
 msgstr "Переставить Героев"
 
-#: ../fheroes2/castle/castle_dialog.cpp:744
 msgid "Meeting Heroes"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:749
 msgid "View Hero"
 msgstr "Просмотреть героя"
 
-#: ../fheroes2/castle/castle_mageguild.cpp:150
+#, fuzzy
+msgid "The above spells are available here."
+msgstr "Заклинания добавлены в вашу книгу."
+
 msgid "The above spells have been added to your book."
 msgstr "Заклинания добавлены в вашу книгу."
 
-#: ../fheroes2/castle/castle_tavern.cpp:39
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:748
 msgid "A generous tip for the barkeep yields the following rumor:"
 msgstr "Щедрые чаевые вытянули из уст трактирщика следующий слух:"
 
-#: ../fheroes2/castle/castle_town.cpp:54
 msgid "Recruit Hero"
 msgstr "Нанять героя"
 
-#: ../fheroes2/castle/castle_town.cpp:59
-msgid "%{name} is a level %{value} %{race}"
+#, fuzzy
+msgid "%{name} is a level %{value} %{race} "
 msgstr "%{name} %{race}, %{value} уровня"
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with %{count} artifacts"
+#, fuzzy
+msgid "with %{count} artifacts."
 msgstr " с %{count} артефактами"
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with one artifact"
+#, fuzzy
+msgid "with 1 artifact."
 msgstr " с одним артефактом"
 
-#: ../fheroes2/castle/castle_town.cpp:283
-#: ../fheroes2/heroes/heroes_dialog.cpp:108
+#, fuzzy
+msgid "without artifacts."
+msgstr " с %{count} артефактами"
+
 msgid ""
 "'Spread' combat formation spreads your armies from the top to the bottom of "
 "the battlefield, with at least one empty space between each army."
@@ -1311,108 +1539,86 @@ msgstr ""
 "Разомкнутый боевой порядок (по всей ширине поля с интервалом между отрядами, "
 "минимум, одна клетка)."
 
-#: ../fheroes2/castle/castle_town.cpp:284
 msgid ""
 "'Grouped' combat formation bunches your army toget her in the center of your "
 "side of the battlefield."
 msgstr ""
 "Сомкнутый боевой порядок (концентрируется в центре на вашей стороне поля)."
 
-#: ../fheroes2/castle/castle_town.cpp:292
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:132
-#: ../fheroes2/heroes/heroes_meeting.cpp:284
 msgid "Attack Skill"
 msgstr "Атака"
 
-#: ../fheroes2/castle/castle_town.cpp:301
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:137
-#: ../fheroes2/heroes/heroes_meeting.cpp:288
 msgid "Defense Skill"
 msgstr "Защита"
 
-#: ../fheroes2/castle/castle_town.cpp:487
-#: ../fheroes2/heroes/heroes_dialog.cpp:334
 msgid "Spread Formation"
 msgstr "Разомкнутый строй"
 
-#: ../fheroes2/castle/castle_town.cpp:489
-#: ../fheroes2/heroes/heroes_dialog.cpp:337
 msgid "Grouped Formation"
 msgstr "Сомкнутый строй"
 
-#: ../fheroes2/castle/castle_town.cpp:540
-#: ../fheroes2/castle/castle_town.cpp:553
 msgid "Recruit %{name} the %{race}"
 msgstr "Нанять %{name}, %{race}"
 
-#: ../fheroes2/castle/castle_town.cpp:561
 msgid "Set garrison combat formation to 'Spread'"
 msgstr "Боевой порядок гарнизона - Разомкнутый"
 
-#: ../fheroes2/castle/castle_town.cpp:564
 msgid "Set garrison combat formation to 'Grouped'"
 msgstr "Боевой порядок гарнизона - Сомкнутый"
 
-#: ../fheroes2/castle/castle_town.cpp:567
+#, fuzzy
+msgid "Exit Castle Options"
+msgstr "Настройки замка"
+
 msgid "Castle Options"
 msgstr "Настройки замка"
 
-#: ../fheroes2/castle/castle_well.cpp:158
-msgid "Buy Monsters:"
+msgid "Not enough resources to buy monsters."
+msgstr ""
+
+msgid "No monsters available for purchase."
+msgstr ""
+
+#, fuzzy
+msgid "Buy Monsters"
 msgstr "Покупка Воинов:"
 
-#: ../fheroes2/castle/castle_well.cpp:221
 msgid "Town Population Information and Statistics"
 msgstr "Информация о населении и статистика"
 
-#: ../fheroes2/castle/castle_well.cpp:323
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:231
 msgid "Damage"
 msgstr "Урон"
 
-#: ../fheroes2/castle/castle_well.cpp:329
 msgid "HP"
 msgstr "Здоровье"
 
-#: ../fheroes2/castle/castle_well.cpp:335
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:266
-msgid "Speed"
-msgstr "Скорость"
-
-#: ../fheroes2/castle/castle_well.cpp:351
 msgid "Growth"
 msgstr "Прирост"
 
-#: ../fheroes2/castle/castle_well.cpp:355
 msgid "week"
 msgstr "неделя"
 
-#: ../fheroes2/castle/castle_well.cpp:361
-#: ../fheroes2/kingdom/kingdom_overview.cpp:479
 msgid "Available"
 msgstr "Доступно"
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:89
 msgid "View the entire world."
 msgstr "Обзор мира."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:90
 msgid "View the obelisk puzzle."
 msgstr "Показать мозаику."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:91
 msgid "View information on the scenario you are currently playing."
 msgstr "Описание текущего сценария."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:92
 msgid "Dig for the Ultimate Artifact."
 msgstr "Копать в поисках артефакта."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:93
 msgid "Exit this menu without doing anything."
 msgstr "Выход, без изменений."
 
-#: ../fheroes2/dialog/dialog_arena.cpp:48
+msgid "Arena"
+msgstr "Арена"
+
 msgid ""
 "You enter the arena and face a pack of vicious lions. You handily defeat "
 "them, to the wild cheers of the crowd.  Impressed by your skill, the aged "
@@ -1422,43 +1628,30 @@ msgstr ""
 "побеждаете их под диким вопль толпы. Тренер гладиаторов, впечатленный Вашим "
 "умением, соглашается обучить Вас выбранному навыку."
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:154
-msgid ""
-"Your troops can be upgraded, but it will cost you %{ratio} times the "
-"difference in cost for each troop, rounded up to next highest number. Do you "
-"wish to upgrade them?"
-msgstr ""
-"Ваши воины могут быть улушены, но это будет стоить Вам %{ratio} кратной "
-"разницы в цене за каждого воина, округлённой в большую сторону. Вы всё ещё "
-"желаете улучшить?"
-
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:155
 msgid ""
 "Your troops can be upgraded, but it will cost you dearly. Do you wish to "
 "upgrade them?"
 msgstr "Ваши войска могут быть улучшены, но за высокую цену. Вы согласны?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:166
 msgid "Are you sure you want to dismiss this army?"
 msgstr "Вы действительно хотите уволить армию?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots Left"
 msgstr "Осталось выстрелов"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots"
 msgstr "Выстрелов"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:244
 msgid "Hit Points"
 msgstr "Здоровье"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:255
 msgid "Hit Points Left"
 msgstr "Тек. здоровье"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:376
+#, fuzzy
+msgid "Followers"
+msgstr "Цветы"
+
 msgid ""
 "A group of %{monster} with a desire for greater glory wish to join you.\n"
 "Do you accept?"
@@ -1466,9 +1659,9 @@ msgstr ""
 "Группа %{monster} в поисках славы желает к вам присоедениться.\n"
 "Вы согласны?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:456
+#, fuzzy
 msgid ""
-"The creature is swayed by your diplomatic tongue, and offers to join your "
+"The %{monster} is swayed by your diplomatic tongue, and offers to join your "
 "army for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
@@ -1476,7 +1669,6 @@ msgstr ""
 "армию за %{gold} золотых.\n"
 "Вы согласны?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:459
 msgid ""
 "The creatures are swayed by your diplomatic\n"
 "tongue, and make you an offer:\n"
@@ -1486,7 +1678,6 @@ msgstr ""
 "предложение:\n"
 " \n"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:462
 msgid ""
 "%{offer} of the %{total} %{monster} will join your army, and the rest will "
 "leave you alone, for the sum of %{gold} gold.\n"
@@ -1496,7 +1687,6 @@ msgstr ""
 "остальные оставят вас в покое.\n"
 "Вы согласны?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:464
 msgid ""
 "All %{offer} of the %{monster} will join your army for the sum of %{gold} "
 "gold.\n"
@@ -1506,29 +1696,51 @@ msgstr ""
 "золотых.\n"
 "Вы согласны?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:478
 msgid "(Rate: %{percent})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:528
-msgid ""
-"Not room in\n"
-"the garrison"
+msgid "No room in"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:48
+#, fuzzy
+msgid "the garrison"
+msgstr "Гарнизон"
+
 msgid "Build a new ship:"
 msgstr "Построить новый корабль:"
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:63
 msgid "Resource cost:"
 msgstr "Стоимость:"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:40
-msgid "For the QVGA version is not available."
-msgstr "Для версии QVGA пока недоступно."
+msgid "Load Game"
+msgstr "Загрузка игры"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:62
+#, fuzzy
+msgid "No save files to load."
+msgstr "Нет заклинаний."
+
+msgid "New Game"
+msgstr "Новая игра"
+
+msgid "Start a single or multi-player game."
+msgstr "Начало одиночной или сетевой игры."
+
+msgid "Load a previously saved game."
+msgstr "Загрузка ранее сохраненной игры"
+
+#, fuzzy
+msgid "Save Game"
+msgstr "Новая игра"
+
+msgid "Save the current game."
+msgstr ""
+
+msgid "Quit"
+msgstr "Выход"
+
+msgid "Quit out of Free Heroes of Might and Magic II."
+msgstr ""
+
 msgid ""
 "Map\n"
 "Difficulty"
@@ -1536,7 +1748,6 @@ msgstr ""
 "Сложность\n"
 "карты"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:65
 msgid ""
 "Game\n"
 "Difficulty"
@@ -1544,25 +1755,18 @@ msgstr ""
 "Сложность\n"
 "игры"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:68
 msgid "Rating"
 msgstr "Рейтинг"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:71
 msgid "Map Size"
 msgstr "Размер карты"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:89
-#: ../fheroes2/system/players.cpp:691
 msgid "Opponents"
 msgstr "Оппоненты"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:92
-#: ../fheroes2/system/players.cpp:695
 msgid "Class"
 msgstr "Класс"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:100
 msgid ""
 "Victory\n"
 "Conditions"
@@ -1570,7 +1774,6 @@ msgstr ""
 "Условия\n"
 "победы"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:106
 msgid ""
 "Loss\n"
 "Conditions"
@@ -1578,48 +1781,34 @@ msgstr ""
 "Условия\n"
 "поражения"
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:167
 msgid "You cannot select %{resource}!"
 msgstr "Вы не можете выбрать %{resource}!"
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:173
 msgid "Select count %{resource}:"
 msgstr "Выберите количество %{resource}:"
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:200
 msgid "Set Guardian"
 msgstr "Установить Охрану"
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:236
-#: ../fheroes2/dialog/dialog_guardian.cpp:292
 msgid "Your army too big!"
 msgstr "Ваша армия слишком большая!"
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:34
-#: ../fheroes2/dialog/dialog_levelup.cpp:44
-#: ../fheroes2/dialog/dialog_levelup.cpp:73
 msgid "%{name} has gained a level."
 msgstr "%{name} получил уровень."
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:36
-#: ../fheroes2/dialog/dialog_levelup.cpp:46
-#: ../fheroes2/dialog/dialog_levelup.cpp:75
-msgid "%{skill} Skill +1"
+#, fuzzy
+msgid "%{skill} +1"
 msgstr "Навык %{skill} +1"
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:51
 msgid "You have learned %{skill}."
 msgstr "Вы изучили уровень %{skill}."
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:93
 msgid "You may learn either:"
 msgstr "Вы можете выучить:"
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:96
 msgid "or"
 msgstr "или"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:66
 msgid ""
 "Please inspect our fine wares. If you feel like offering a trade, click on "
 "the items you wish to trade with and for."
@@ -1627,7 +1816,6 @@ msgstr ""
 "Посмотрите на наши товары. Если что-то вас заинтересует, щелкните по нужным "
 "вещам и выберите, на что хотите поменять."
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:104
 msgid ""
 "You have received quite a bargain. I expect to make no profit on the deal. "
 "Can I interest you in any of my other wares?"
@@ -1635,602 +1823,494 @@ msgstr ""
 "Вам предложена достойная сделка. Я не пытаюсь нажиться на ней. Вас "
 "интересует что-нибудь из моих товаров?"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:130
 msgid "I can offer you %{count} for 1 unit of %{resfrom}."
 msgstr "Я дам вам %{count} за одну единицу %{resfrom}."
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:136
 msgid "I can offer you 1 unit of %{resto} for %{count} units of %{resfrom}."
 msgstr ""
 "Я могу дать вам за одну единицу %{resto} %{count} единиц(у) %{resfrom}."
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:164
 msgid "Qty to trade"
 msgstr "Перейти к торговле"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:235
+msgid "Trading Post"
+msgstr "Базар"
+
 msgid "Your Resources"
 msgstr "Ваши ресурсы"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:257
 msgid "Available Trades"
 msgstr "Доступно к обмену"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:573
 msgid "n/a"
 msgstr "n/a"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:77
-msgid "guarded by %{count} of %{monster}"
+#, fuzzy
+msgid "guarded by %{count} %{monster}"
 msgstr "охраняется %{count} %{monster}"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:149
 msgid "(available: %{count})"
 msgstr "(Доступно: %{count})"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:181
 msgid "already learned"
 msgstr "уже выучено"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:205
 msgid "already knows this skill"
 msgstr "уже знаете"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:212
 msgid "already has max skills"
 msgstr "максимум навыков"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:260
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:276
 msgid "(already visited)"
 msgstr "(посещено)"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
 msgid "(not visited)"
 msgstr "(не посещено)"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:296
+#, fuzzy
+msgid "Road"
+msgstr "Дороги"
+
+msgid "(digging ok)"
+msgstr ""
+
+msgid "(no digging)"
+msgstr ""
+
 msgid "penalty: %{cost}"
 msgstr "Штраф проходимости: %{cost}"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:382
-msgid "Unchartered Territory"
+#, fuzzy
+msgid "Uncharted Territory"
 msgstr "Терра инкогнито"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:635
 msgid "Defenders:"
 msgstr "Защитники:"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:674
-#: ../fheroes2/heroes/heroes_indicator.cpp:125
-#: ../fheroes2/heroes/heroes_indicator.cpp:171
 msgid "None"
 msgstr "Ничего"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:756
-msgid "%{name} ( Level %{level} )"
+msgid "Unknown"
+msgstr ""
+
+#, fuzzy
+msgid "%{name} (Level %{level})"
 msgstr "%{name} ( Уровень %{level} )"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:884
 msgid "Move Points"
 msgstr "Очки движ-я"
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:40
-#: ../fheroes2/dialog/dialog_recrut.cpp:579
 msgid "Available: %{count}"
 msgstr "Доступно: %{count}"
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:101
-msgid "Cost per troop:"
-msgstr "Цена за войско:"
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:107
-#: ../fheroes2/dialog/dialog_recrut.cpp:506
-msgid "Recruit %{name}"
-msgstr "Нанять  %{name}"
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:210
 msgid "Number to buy:"
 msgstr "Купить:"
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:314
 msgid "How many troops to move?"
 msgstr "Сколько войнов перенести?"
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:358
 msgid "Fast separation into slots:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:180
 msgid "File to Save:"
 msgstr "Сохранить файл:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:186
 msgid "File to Load:"
 msgstr "Загрузить файл:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:302
 msgid "Are you sure you want to delete file:"
 msgstr "Вы действительно хотите удалить файл:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:305
 msgid "Warning!"
 msgstr "Внимание!"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:144
-msgid "Maps Difficulty:"
+#, fuzzy
+msgid "Map difficulty:"
 msgstr "Сложность игры:"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
+msgid "No maps exist at that size"
+msgstr ""
+
 msgid "Small Maps"
 msgstr "Маленькие карты"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
-msgid "View only maps of size small (36x36)."
+#, fuzzy
+msgid "View only maps of size small (36 x 36)."
 msgstr "Просмотр только маленьких карт (36х36)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
 msgid "Medium Maps"
 msgstr "Средние карты"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
-msgid "View only maps of size medium (72x72)."
+#, fuzzy
+msgid "View only maps of size medium (72 x 72)."
 msgstr "Просмотр только средних карт (72х72)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
 msgid "Large Maps"
 msgstr "Большие карты"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
-msgid "View only maps of size large (108x108)."
+#, fuzzy
+msgid "View only maps of size large (108 x 108)."
 msgstr "Просмотр только больших карт (108х108)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
 msgid "Extra Large Maps"
 msgstr "Огромные карты"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
-msgid "View only maps of size extra large (144x144)."
+#, fuzzy
+msgid "View only maps of size extra large (144 x 144)."
 msgstr "Просмотр только огромных карт (144х144)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "All Maps"
 msgstr "Все карты"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "View all maps, regardless of size."
 msgstr "Просмотр всех карт, независимо от размера."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
 msgid "Players Icon"
 msgstr "Значок игроков"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
+#, fuzzy
 msgid ""
-"Indicates how many players total are in the EditScenario. Any positions not "
+"Indicates how many players total are in the scenario. Any positions not "
 "occupied by humans will be occupied by computer players."
 msgstr ""
 "Обозначает количество игроков в данном сценарии. При отсутствии игроков-"
 "людей их места занимает компьютер."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
 msgid "Size Icon"
 msgstr "Значок размера"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
+#, fuzzy
 msgid ""
-"Indicates whether the maps is small (36x36), medium (72x72), large "
-"(108x108), or extra large (144x144)."
+"Indicates whether the map\n"
+"is small (36 x 36), medium\n"
+"(72 x 72), large (108 x 108),\n"
+"or extra large (144 x 144)."
 msgstr ""
 "Обозначает размер карты: маленькая (36х36), средняя 72х72), большая "
 "(108х108) или огромная (144х144)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "Selected Name"
 msgstr "Название Карты"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "The name of the currently selected map."
 msgstr "Название выбранной карты."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid "Selected Map Difficulty"
 msgstr "Сложность игры"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
+#, fuzzy
 msgid ""
 "The map difficulty of the currently selected map.  The map difficulty is "
-"determined by the EditScenario designer. More difficult maps might include "
-"more or stronger enemies, fewer resources, or other special conditions "
-"making things tougher for the human player."
+"determined by the scenario designer. More difficult maps might include more "
+"or stronger enemies, fewer resources, or other special conditions making "
+"things tougher for the human player."
 msgstr ""
 "Сложность выбранной карты. Этот параметр задается автором (или соавтором) "
 "карты в Редакторе. Более сложные карты могут иметь больше (или более "
 "сильных) врагов, меньше ресурсов или другие особые условия, осложняющие игру "
 "человеку."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "Selected Description"
 msgstr "Описание"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "The description of the currently selected map."
 msgstr "Расширенное описание выбранной карты."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
-msgid "OK"
-msgstr "ОК"
+msgid "Okay"
+msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
 msgid "Accept the choice made."
 msgstr "Принять изменения."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:364
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose all your heroes and towns."
 msgstr "Потерять всех героев и все города."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:365
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific town."
 msgstr "Потерять город."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:366
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific hero."
 msgstr "Потерять героя."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:367
 msgid "Run out of time. Fail to win by a certain point."
 msgstr "Не успеть вовремя."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:370
 msgid "Loss Condition"
 msgstr "Условия поражения"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:379
 msgid "Defeat all enemy heroes and towns."
 msgstr "Победить всех противников и захватить все города."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:380
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Capture a specific town."
 msgstr "Захватить город."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:381
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat a specific hero."
 msgstr "Победить героя."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:382
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Find a specific artifact."
 msgstr "Найти артефакт."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:383
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Your side defeats the opposing side."
 msgstr "Победа вашего союза над вражеским."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:384
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Accumulate a large amount of gold."
 msgstr "Накопить крупные запасы золота."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:387
 msgid "Victory Condition"
 msgstr "Условия победы"
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:48
-#: ../fheroes2/heroes/heroes_action.cpp:134
 msgid "one"
 msgstr "1"
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:51
-#: ../fheroes2/heroes/heroes_action.cpp:135
 msgid "two"
 msgstr "2"
 
-#: ../fheroes2/dialog/dialog_system.cpp:187
-msgid "sound"
-msgstr "Звук"
-
-#: ../fheroes2/dialog/dialog_system.cpp:192
-#: ../fheroes2/dialog/dialog_system.cpp:205
-#: ../fheroes2/dialog/dialog_system.cpp:228
-#: ../fheroes2/dialog/dialog_system.cpp:242
-msgid "off"
-msgstr "Выкл."
-
-#: ../fheroes2/dialog/dialog_system.cpp:200
-msgid "music"
+#, fuzzy
+msgid "Music"
 msgstr "Музыка"
 
-#: ../fheroes2/dialog/dialog_system.cpp:223
-msgid "hero speed"
+msgid "Toggle ambient music level."
+msgstr ""
+
+msgid "Effects"
+msgstr ""
+
+msgid "Toggle foreground sounds level."
+msgstr ""
+
+msgid "Music Type"
+msgstr ""
+
+msgid "Change the type of music."
+msgstr ""
+
+#, fuzzy
+msgid "Hero Speed"
 msgstr "скорость героев"
 
-#: ../fheroes2/dialog/dialog_system.cpp:237
-msgid "ai speed"
-msgstr "скорость AI"
+msgid "Change the speed at which your heroes move on the main screen."
+msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:251
-msgid "scroll speed"
+#, fuzzy
+msgid "Enemy Speed"
+msgstr "Скорость"
+
+msgid ""
+"Sets the speed that A.I. heroes move at.  You can also elect not to view A."
+"I. movement at all."
+msgstr ""
+
+#, fuzzy
+msgid "Scroll Speed"
 msgstr "скорость прокрутки"
 
-#: ../fheroes2/dialog/dialog_system.cpp:262
-#: ../fheroes2/dialog/dialog_system.cpp:276
+msgid "Sets the speed at which you scroll the window."
+msgstr ""
+
+#, fuzzy
+msgid "Interface Type"
+msgstr "Интерфейс"
+
+msgid "Toggle the type of interface you want to use."
+msgstr ""
+
 msgid "Interface"
 msgstr "Интерфейс"
 
-#: ../fheroes2/dialog/dialog_system.cpp:265
+msgid "Toggle interface visibility."
+msgstr ""
+
+#, fuzzy
+msgid "Battles"
+msgstr "Бутылка"
+
+msgid "Toggle instant battle mode."
+msgstr ""
+
+msgid "OK"
+msgstr "ОК"
+
+#, fuzzy
+msgid "Exit this menu."
+msgstr "Подождать"
+
+msgid "off"
+msgstr "Выкл."
+
+msgid "MIDI"
+msgstr ""
+
+#, fuzzy
+msgid "MIDI Expansion"
+msgstr "Особняк"
+
+msgid "CD Stereo"
+msgstr ""
+
+msgid "External"
+msgstr ""
+
+msgid "Jump"
+msgstr ""
+
+msgid "Don't Show"
+msgstr ""
+
 msgid "Evil"
 msgstr "Злой"
 
-#: ../fheroes2/dialog/dialog_system.cpp:267
 msgid "Good"
 msgstr "Добрый"
 
-#: ../fheroes2/dialog/dialog_system.cpp:281
 msgid "Hide"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:287
 msgid "Show"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:286
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:96
+msgid "Auto Resolve"
+msgstr ""
+
+msgid "Auto, No Spells"
+msgstr ""
+
+msgid "Manual"
+msgstr ""
+
+msgid "Att."
+msgstr ""
+
+msgid "Def."
+msgstr ""
+
+msgid "Power"
+msgstr "Сила магии"
+
+#, fuzzy
+msgid "Knowl"
+msgstr "Знания"
+
+msgid "Human"
+msgstr ""
+
 msgid "1st"
 msgstr "1-ый"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:97
 msgid "2nd"
 msgstr "2-ый"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:288
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:98
 msgid "3rd"
 msgstr "3-ий"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:289
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:99
 msgid "4th"
 msgstr "4-ый"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:290
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:100
 msgid "5th"
 msgstr "5-ый"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:291
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:101
 msgid "6th"
 msgstr "6-ой"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:306
-msgid "Thieves' Guild: Player RanKings"
+#, fuzzy
+msgid "Oracle: Player Rankings"
 msgstr "Гильдия воров:  достижения игроков"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:316
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:114
+#, fuzzy
+msgid "Thieves' Guild: Player Rankings"
+msgstr "Гильдия воров:  достижения игроков"
+
 msgid "Number of Towns:"
 msgstr "Городов:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:325
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:123
 msgid "Number of Castles:"
 msgstr "Замков:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:334
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:132
 msgid "Number of Heroes:"
 msgstr "Героев:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:343
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:141
 msgid "Gold in Treasury:"
 msgstr "Золота в казне:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:352
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:150
 msgid "Wood & Ore:"
 msgstr "Дерево и руда:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:361
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:159
 msgid "Gems, Cr, Slf & Mer:"
 msgstr "Прочие ресурсы:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:370
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:168
 msgid "Obelisks Found:"
 msgstr "Найдено обелисков:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:379
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:177
+#, fuzzy
+msgid "Artifacts:"
+msgstr "Артифакты"
+
 msgid "Total Army Strength:"
 msgstr "Общая сила армии:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:409
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:211
+msgid "Income:"
+msgstr "Доход:"
+
 msgid "Best Hero:"
 msgstr "Лучший герой:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:418
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:220
 msgid "Best Hero Stats:"
 msgstr "Параметры героя:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:427
 msgid "Personality:"
 msgstr "Характер:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:436
 msgid "Best Monster:"
 msgstr "Лучший воин:"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Easy"
 msgstr "Простой"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Normal"
 msgstr "Нормальная"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Hard"
 msgstr "Сложный"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Expert"
 msgstr "Эксперт"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Impossible"
 msgstr "Невозможный"
 
-#: ../fheroes2/game/game.cpp:314
-msgid "Maps Loading..."
+#, fuzzy
+msgid "Map is loading..."
 msgstr "Загрузка..."
 
-#: ../fheroes2/game/game_highscores.cpp:239
-#: ../fheroes2/game/game_highscores.cpp:242
+msgid "and more..."
+msgstr ""
+
+msgid "Campaign Scenario loading failure"
+msgstr ""
+
+msgid "Please make sure that campaign files are correct and present."
+msgstr ""
+
 msgid "Unknown Hero"
 msgstr ""
 
-#: ../fheroes2/game/game_highscores.cpp:240
 msgid "Your Name"
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:95
-msgid "Are you sure you want to overwrite the save with this name?"
-msgstr "Вы хотите перезаписать файл игры?"
-
-#: ../fheroes2/game/game_io.cpp:191
 msgid ""
-"This file is saved in the \"Price Loyalty\" version.\n"
+"Invalid file game type. Please ensure that you are running the latest type "
+"of save files."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"This file is saved in the \"The Price of Loyalty\" version.\n"
 "Some items may be unavailable."
 msgstr ""
 "Этот файл сохранен в версии \"Price Loyalty\". \n"
 "Некоторые возможности игры будут недоступны."
 
-#: ../fheroes2/game/game_mainmenu.cpp:157
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:95
-msgid "Quit"
-msgstr "Выход"
-
-#: ../fheroes2/game/game_mainmenu.cpp:157
-msgid "Quit Heroes of Might and Magic and return to the operating system."
-msgstr "Завершить игру Heroes of Might and Magic."
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:79
-msgid "Load Game"
-msgstr "Загрузка игры"
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-msgid "Load a previously saved game."
-msgstr "Загрузка ранее сохраненной игры"
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:91
-msgid "Credits"
-msgstr "Авторы"
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-msgid "View the credits screen."
-msgstr "Просмотр окна авторов"
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:87
-msgid "High Scores"
-msgstr "Счет"
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-msgid "View the high score screen."
-msgstr "Просмотр лучших результатов."
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:75
-msgid "New Game"
-msgstr "Новая игра"
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-msgid "Start a single or multi-player game."
-msgstr "Начало одиночной или сетевой игры."
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid "Host"
-msgstr "Хост"
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid ""
-"The host sets up the game options. There can only be one host per network "
-"game."
-msgstr ""
-"Хост задает параметры игры. В одной сетевой игре может учавствовать только  "
-"один хост."
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid "Guest"
-msgstr "Гость"
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid ""
-"The guest waits for the host to set up the game, then is automatically added "
-"in. There can be multiple guests for TCP/IP games."
-msgstr ""
-"Гость ждет пока хост настроит игру, а затем автоматически присоеденяется к "
-"ней. Возможно множество гостевых клиентов при игре по протоколу TCP/IP."
-
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-msgid "Cancel back to the main menu."
-msgstr "Вернуться в главное меню"
-
-#: ../fheroes2/game/game_newgame.cpp:214
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:154
-msgid "Standard Game"
-msgstr "Стандартная игра"
-
-#: ../fheroes2/game/game_newgame.cpp:214
-msgid "A single player game playing out a single map."
-msgstr "Одиночная игра на одиночной карте."
-
-#: ../fheroes2/game/game_newgame.cpp:216
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:162
-msgid "Multi-Player Game"
-msgstr "Сетевая игра"
-
-#: ../fheroes2/game/game_newgame.cpp:216
-msgid ""
-"A multi-player game, with several human players completing against each "
-"other on a single map."
-msgstr "Сетевая игра с несколькими игроками-людьми на одиночной карте."
-
-#: ../fheroes2/game/game_newgame.cpp:217
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:83
-msgid "Settings"
-msgstr "Настройки"
-
-#: ../fheroes2/game/game_newgame.cpp:217
-msgid "FHeroes2 game settings."
-msgstr "Настройки Игры"
-
-#: ../fheroes2/game/game_newgame.cpp:271
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:219
 msgid "Hot Seat"
 msgstr "За одним ПК"
 
-#: ../fheroes2/game/game_newgame.cpp:271
 msgid ""
 "Play a Hot Seat game, where 2 to 4 players play around the same computer, "
 "switching into the 'Hot Seat' when it is their turn."
@@ -2238,98 +2318,204 @@ msgstr ""
 "Игра за одним ПК, где могут играть 2-4 игрока по кругу как с компьютером, "
 "передавая управление другому, когда наступет его ход."
 
-#: ../fheroes2/game/game_newgame.cpp:279
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:223
+msgid "Cancel back to the main menu."
+msgstr "Вернуться в главное меню"
+
 msgid "Network"
 msgstr "Сеть"
 
-#: ../fheroes2/game/game_newgame.cpp:279
 msgid ""
 "Play a network game, where 2 players use their own computers connected "
 "through a LAN (Local Area Network)."
 msgstr "LAN (Local Area Network), для 2 игроков"
 
-#: ../fheroes2/game/game_newgame.cpp:343
+msgid "Standard Game"
+msgstr "Стандартная игра"
+
+msgid "A single player game playing out a single map."
+msgstr "Одиночная игра на одиночной карте."
+
+msgid "Campaign Game"
+msgstr "Кампания"
+
+#, fuzzy
+msgid "A single player game playing through a series of maps."
+msgstr "Одиночная игра на одиночной карте."
+
+msgid "Multi-Player Game"
+msgstr "Сетевая игра"
+
+msgid ""
+"A multi-player game, with several human players completing against each "
+"other on a single map."
+msgstr "Сетевая игра с несколькими игроками-людьми на одиночной карте."
+
+#, fuzzy
+msgid "Greetings!"
+msgstr "Настройки"
+
+msgid ""
+"Welcome to Free Heroes of Might and Magic II! Before starting the game "
+"please choose game resolution."
+msgstr ""
+
+msgid "Please Remember"
+msgstr ""
+
+msgid "You can always change game resolution by clicking on the "
+msgstr ""
+
+msgid "door"
+msgstr ""
+
+msgid ""
+" on the left side of main menu.\n"
+"\n"
+"To switch between windowed and full screen modes\n"
+"press "
+msgstr ""
+
+msgid "F4"
+msgstr ""
+
+msgid ""
+" key on the keyboard.\n"
+"\n"
+"Enjoy the game!"
+msgstr ""
+
+msgid "Quit Heroes of Might and Magic and return to the operating system."
+msgstr "Завершить игру Heroes of Might and Magic."
+
+msgid "Credits"
+msgstr "Авторы"
+
+msgid "View the credits screen."
+msgstr "Просмотр окна авторов"
+
+msgid "High Scores"
+msgstr "Счет"
+
+msgid "View the high score screen."
+msgstr "Просмотр лучших результатов."
+
+#, fuzzy
+msgid "Select Game Resolution"
+msgstr "Описание"
+
+msgid "Change resolution of the game."
+msgstr ""
+
+msgid "Original Campaign"
+msgstr ""
+
+msgid ""
+"Either Roland's or Archibald's campaign from the original Heroes of Might "
+"and Magic II."
+msgstr ""
+
+msgid "Expansion Campaign"
+msgstr ""
+
+msgid "One of the four new campaigns from the Price of Loyalty expansion set."
+msgstr ""
+
+msgid "Host"
+msgstr "Хост"
+
+msgid ""
+"The host sets up the game options. There can only be one host per network "
+"game."
+msgstr ""
+"Хост задает параметры игры. В одной сетевой игре может учавствовать только  "
+"один хост."
+
+msgid "Guest"
+msgstr "Гость"
+
+msgid ""
+"The guest waits for the host to set up the game, then is automatically added "
+"in. There can be multiple guests for TCP/IP games."
+msgstr ""
+"Гость ждет пока хост настроит игру, а затем автоматически присоеденяется к "
+"ней. Возможно множество гостевых клиентов при игре по протоколу TCP/IP."
+
+#, fuzzy
+msgid "Battle Only"
+msgstr "Боевой Гном"
+
+msgid "Setup and play a battle without loading any map."
+msgstr ""
+
+msgid "Settings"
+msgstr "Настройки"
+
+#, fuzzy
+msgid "Experimental game settings."
+msgstr "Настройки Игры"
+
 msgid "2 Players"
 msgstr "2 игрока"
 
-#: ../fheroes2/game/game_newgame.cpp:343
 msgid ""
 "Play with 2 human players, and optionally, up, to 4 additional computer "
 "players."
 msgstr "2 игрока, остальными управляет компьтер."
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid "3 Players"
 msgstr "3 игрока"
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid ""
 "Play with 3 human players, and optionally, up, to 3 additional computer "
 "players."
 msgstr "3 игрока, остальными управляет компьтер."
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid "4 Players"
 msgstr "4 игрока"
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid ""
 "Play with 4 human players, and optionally, up, to 2 additional computer "
 "players."
 msgstr "4 игрока, остальными управляет компьтер."
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid "5 Players"
 msgstr "5 игроков"
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid ""
 "Play with 5 human players, and optionally, up, to 1 additional computer "
 "players."
 msgstr "5 игроков и 1 компьтер."
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "6 Players"
 msgstr "6 игроков"
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "Play with 6 human players."
 msgstr "Все игроки - люди."
 
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat all enemy heroes and capture all enemy towns and castles."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Run out of time. (Fail to win by a certain point.)"
 msgstr "Не успеть вовремя. (С определенного момента нет возможности победить)"
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the castle '%{name}'"
 msgstr "Захватить замок '%{name}'"
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the town '%{name}'"
 msgstr "Захватить город '%{name}'"
 
-#: ../fheroes2/game/game_over.cpp:83
 msgid "Defeat the hero '%{name}'"
 msgstr "Победить героя '%{name}'"
 
-#: ../fheroes2/game/game_over.cpp:91
 msgid "Find the ultimate artifact"
 msgstr "Найти Уникальный Артефакт"
 
-#: ../fheroes2/game/game_over.cpp:95
 msgid "Find the '%{name}' artifact"
 msgstr "Найти '${name}' артефакт"
 
-#: ../fheroes2/game/game_over.cpp:102
 msgid "Accumulate %{count} gold"
 msgstr "Накопить %{count} золота."
 
-#: ../fheroes2/game/game_over.cpp:106
 msgid ""
 ", or you may win by defeating all enemy heroes and capturing all enemy towns "
 "and castles."
@@ -2337,29 +2523,23 @@ msgstr ""
 ", также Вы выигрываете если победите всех героев или захватите все города "
 "противника."
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the castle '%{name}'."
 msgstr "Потерять замок '%{name}'."
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the town '%{name}'."
 msgstr "Потерять город '%{name}'."
 
-#: ../fheroes2/game/game_over.cpp:126 ../fheroes2/game/game_over.cpp:145
 msgid "Lose the hero: %{name}."
 msgstr "Теряете героя по имени %{name}."
 
-#: ../fheroes2/game/game_over.cpp:133
 msgid "Fail to win by the end of month %{month}, week %{week}, day %{day}."
 msgstr ""
-"Не успели победить до указанной даты: месяц %{month}, неделя %{week}, день %"
-"{day}."
+"Не успели победить до указанной даты: месяц %{month}, неделя %{week}, день "
+"%{day}."
 
-#: ../fheroes2/game/game_over.cpp:145
 msgid "Lose the heroes: %{name}."
 msgstr "Теряете следующих героев: %{name}."
 
-#: ../fheroes2/game/game_over.cpp:167
 msgid ""
 "You captured %{name}!\n"
 "You are victorious."
@@ -2367,7 +2547,6 @@ msgstr ""
 "Вы захватили %{name}!\n"
 "С победой!"
 
-#: ../fheroes2/game/game_over.cpp:175
 msgid ""
 "You have captured the enemy hero %{name}!\n"
 "Your quest is complete."
@@ -2375,7 +2554,6 @@ msgstr ""
 "Вы захватили вражеского героя %{name}!\n"
 "Ваше задание выполнено."
 
-#: ../fheroes2/game/game_over.cpp:183
 msgid ""
 "You have found the %{name}.\n"
 "Your quest is complete."
@@ -2383,7 +2561,6 @@ msgstr ""
 "Вы нашли %{name}.\n"
 "Ваше задание выполнено."
 
-#: ../fheroes2/game/game_over.cpp:195
 msgid ""
 "The enemy is beaten.\n"
 "Your side has triumphed!"
@@ -2391,7 +2568,6 @@ msgstr ""
 "Враг повержен.\n"
 "Ваша сторона победила!"
 
-#: ../fheroes2/game/game_over.cpp:200
 msgid ""
 "You have built up over %{count} gold in your treasury.\n"
 "All enemies bow before your wealth and power."
@@ -2399,7 +2575,6 @@ msgstr ""
 "В вашей сокровищнице накопилось более %{count}  золота.\n"
 "Ваши враги преклоняются перед вашим богатством и могуществом."
 
-#: ../fheroes2/game/game_over.cpp:222
 msgid ""
 "The enemy has found the %{name}.\n"
 "Your quest is a failure."
@@ -2407,7 +2582,6 @@ msgstr ""
 "Враг нашел %{name}.\n"
 "Ваше задание провалено."
 
-#: ../fheroes2/game/game_over.cpp:230
 msgid ""
 "%{color} has fallen!\n"
 "All is lost."
@@ -2415,7 +2589,6 @@ msgstr ""
 "%{color} повержен!\n"
 "Все потеряно..."
 
-#: ../fheroes2/game/game_over.cpp:237
 msgid ""
 "The enemy has built up over %{count} gold in his treasury.\n"
 "You must bow done in defeat before his wealth and power."
@@ -2423,11 +2596,9 @@ msgstr ""
 "В сокровищнице врага накопилось более %{count}  золота.\n"
 "Вы вынуждены преклонится перед его богатством и могуществом."
 
-#: ../fheroes2/game/game_over.cpp:243
 msgid "You have been eliminated from the game!!!"
 msgstr "Вы были исключены из игры!"
 
-#: ../fheroes2/game/game_over.cpp:248
 msgid ""
 "The enemy has captured %{name}!\n"
 "They are triumphant."
@@ -2435,7 +2606,6 @@ msgstr ""
 "Враг захватил %{name}!\n"
 "Он торжествует."
 
-#: ../fheroes2/game/game_over.cpp:257 ../fheroes2/game/game_over.cpp:264
 msgid ""
 "You have lost the hero %{name}.\n"
 "Your quest is over."
@@ -2443,7 +2613,6 @@ msgstr ""
 "Вы потеряли героя %{name}.\n"
 "Ваше приключение окончено."
 
-#: ../fheroes2/game/game_over.cpp:272
 msgid ""
 "You have failed to complete your quest in time.\n"
 "All is lost."
@@ -2451,33 +2620,25 @@ msgstr ""
 "Не не успели вовремя закончить задание.\n"
 "Все потеряно..."
 
-#: ../fheroes2/game/game_over.cpp:320
-msgid "%{color} has been vanquished!"
+#, fuzzy
+msgid "%{color} player has been vanquished!"
 msgstr "%{color} побеждён!"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "Warning"
 msgstr "Внимание"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "No maps available!"
 msgstr "Нет доступных карт."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Scenario"
 msgstr "Сценарий"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Click here to select which scenario to play."
 msgstr "Нажмите сюда чтобы выбрать сценарий."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid "Game Difficulty"
 msgstr "Сложность игры"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid ""
 "This lets you change the starting difficulty at which you will play. Higher "
 "difficulty levels start you of with fewer resources, and at the higher "
@@ -2487,11 +2648,9 @@ msgstr ""
 "уровень сложности, тем с меньшим количеством ресурсов вы начнете игру, и тем "
 "больше ресурсов получают ваши компьютерные противники."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid "Difficulty Rating"
 msgstr "Рейтинг"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid ""
 "The difficulty rating reflects a combination of various settings for your "
 "game. This number will be applied to your final score."
@@ -2499,55 +2658,42 @@ msgstr ""
 "Рейтинг отражает сочетание различных игровых установок. Он используется при "
 "расчете конечного результата достигнутого игроком."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
 msgid "Click to accept these settings and start a new game."
 msgstr "Подтверждает заданные установки и начинает новую игру."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
 msgid "Click to return to the main menu."
 msgstr "Нажмите для возврата в главное меню."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:342
 msgid "Scenario:"
 msgstr "Сценарий:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:350
 msgid "Game Difficulty:"
 msgstr "Сложность игры:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:354
 msgid "Opponents:"
 msgstr "Оппоненты:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:358
 msgid "Class:"
 msgstr "Класс:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:384
 msgid "Rating %{rating}%"
 msgstr "Рейтинг %{rating}%"
 
-#: ../fheroes2/game/game_startgame.cpp:226
 msgid "Astrologers proclaim Month of the %{name}."
 msgstr "Астрологи объявили Месяц %{name}."
 
-#: ../fheroes2/game/game_startgame.cpp:226
 msgid "Astrologers proclaim Week of the %{name}."
 msgstr "Астрологи объявили Неделю %{name}."
 
-#: ../fheroes2/game/game_startgame.cpp:240
 msgid "After regular growth, population of %{monster} is doubled!"
 msgstr "Благодаря постоянному приросту, %{monster} удваивает своё население!"
 
-#: ../fheroes2/game/game_startgame.cpp:252
 msgid " All populations are halved."
 msgstr " Все население уменьшилось вдвое."
 
-#: ../fheroes2/game/game_startgame.cpp:254
 msgid " All dwellings increase population."
 msgstr " Население всех жилищ возросло."
 
-#: ../fheroes2/game/game_startgame.cpp:283
 msgid ""
 "%{color} player, your heroes abandon you, and you are banished from this "
 "land."
@@ -2555,7 +2701,6 @@ msgstr ""
 "%{color} игрок, ваши герои отвернулись от вас, а вы изгоняетесь из этих "
 "земель."
 
-#: ../fheroes2/game/game_startgame.cpp:290
 msgid ""
 "%{color} player, this is your last day to capture a town, or you will be "
 "banished from this land."
@@ -2563,7 +2708,6 @@ msgstr ""
 "%{color} игрок, у вас остался последний день чтобы захватить город, иначе вы "
 "будете изгнаны из этих земель."
 
-#: ../fheroes2/game/game_startgame.cpp:295
 msgid ""
 "%{color} player, you only have %{day} days left to capture a town, or you "
 "will be banished from this land."
@@ -2571,11 +2715,10 @@ msgstr ""
 "%{сolor} игрок, у вас осталось %{day} дня(ей) чтобы захватить город, иначе "
 "вы будете изгнаны из этих земель."
 
-#: ../fheroes2/game/game_startgame.cpp:584
-msgid "%{color} player's turn"
+#, fuzzy
+msgid "%{color} player's turn."
 msgstr "%{color} игрок ходит."
 
-#: ../fheroes2/game/game_startgame.cpp:995
 msgid ""
 "%{color} player, you have lost your last town. If you do not conquer another "
 "town in next week, you will be eliminated."
@@ -2583,136 +2726,113 @@ msgstr ""
 "%{color} игрок, вы потеряли последний город. Если вы не захватите любой "
 "другой в течении 7 дней, то потерпите поражение."
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Next Hero"
 msgstr "Следующий герой"
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Select the next Hero."
 msgstr "Выбрать следующего героя."
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue Movement"
 msgstr "Продолжить движение"
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue the Hero's movement along the current path."
 msgstr "Продолжить движение по намеченному пути."
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "Kingdom Summary"
 msgstr "Обзор королевства"
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "View a Summary of your Kingdom."
 msgstr "Осмотреть ваши владения."
 
-#: ../fheroes2/gui/interface_buttons.cpp:189
 msgid "Cast an adventure spell."
 msgstr "Направить заклинание."
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End Turn"
 msgstr "Окончить ход"
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End your turn and left the computer take its turn."
 msgstr "Окончить ход и передать управление следующему игроку."
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Adventure Options"
 msgstr "Игровые действия"
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Bring up the adventure options menu."
 msgstr "Открыть окно доступных игровы действий."
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "File Options"
 msgstr "Настройки файла карты"
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "Bring up the file options menu, alloving you to load menu, save etc."
 msgstr "Открывает меню, где вы можете загружать или сохранять игры."
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "System Options"
 msgstr "Параметры системы"
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "Bring up the system options menu, alloving you to customize your game."
 msgstr "Открывает окно системных настроек, позволяющих настроить игру."
 
-#: ../fheroes2/gui/interface_events.cpp:175
 msgid ""
 "One or more heroes may still move, are you sure you want to end your turn?"
 msgstr ""
 "Один или несколько героев все еще могут ходить. Вы действительно хотитие "
 "закончить ход?"
 
-#: ../fheroes2/gui/interface_events.cpp:212
-msgid "Are you sure you want to restart? (Your current game will be lost)"
-msgstr "Вы действительно хотите начать сначала? (Текущая игра будет потеряна)"
-
-#: ../fheroes2/gui/interface_events.cpp:276
 msgid "Are you sure you want to quit?"
 msgstr "Вы уверены, что хотите выйти?"
 
-#: ../fheroes2/gui/interface_events.cpp:308
+#, fuzzy
+msgid "Are you sure you want to restart? (Your current game will be lost.)"
+msgstr "Вы действительно хотите начать сначала? (Текущая игра будет потеряна)"
+
+msgid "Are you sure you want to overwrite the save with this name?"
+msgstr "Вы хотите перезаписать файл игры?"
+
 msgid "Game saved successfully."
 msgstr "Игра успешно сохранена."
 
-#: ../fheroes2/gui/interface_events.cpp:314
+msgid "There was an issue during saving."
+msgstr ""
+
+#, fuzzy
 msgid ""
-"Are you sure you want to load a new game? (Your current game will be lost)"
+"Are you sure you want to load a new game? (Your current game will be lost.)"
 msgstr ""
 "Вы действительно хотите загрузить новую игру? (Текущая игра будет потеряна)"
 
-#: ../fheroes2/gui/interface_events.cpp:353
 msgid "Try looking on land!!!"
 msgstr "Попробуйте посмотреть на земле!!!"
 
-#: ../fheroes2/gui/interface_events.cpp:368
+#, fuzzy
 msgid ""
-"After spending many hours digging here, you have uncovered the %{artifact}"
+"After spending many hours digging here, you have uncovered the %{artifact}."
 msgstr ""
 "После множества часов, потраченных на раскопки, вы обнаружили %{artifact}"
 
-#: ../fheroes2/gui/interface_events.cpp:370
 msgid "Congratulations!"
 msgstr "Поздравляем!"
 
-#: ../fheroes2/gui/interface_events.cpp:384
 msgid "Nothing here. Where could it be?"
 msgstr "Здесь ничечго. Где бы это могло быть?"
 
-#: ../fheroes2/gui/interface_events.cpp:395
 msgid "Try searching on clear ground."
 msgstr "Попробуйте копать на нормальной земле."
 
-#: ../fheroes2/gui/interface_events.cpp:399
 msgid "Digging for artifacts requires a whole day, try again tomorrow."
 msgstr "Раскопки артефакта занимают целый день. Попробуйте завтра."
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "World Map"
 msgstr "Карта мира"
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "A miniature view of the known world. Left click to move viewing area."
 msgstr ""
 "Миникарта изученного мира. Нажатием левой кнопки можно управлять просмотром."
 
-#: ../fheroes2/gui/interface_status.cpp:216
 msgid "Month: %{month} Week: %{week}"
 msgstr "Месяц: %{month} Неделя: %{week}"
 
-#: ../fheroes2/gui/interface_status.cpp:222
-#: ../fheroes2/kingdom/kingdom_overview.cpp:569
 msgid "Day: %{day}"
 msgstr "День: %{day}"
 
-#: ../fheroes2/gui/interface_status.cpp:257
 msgid ""
 "You find a small\n"
 "quantity of %{resource}."
@@ -2720,11 +2840,18 @@ msgstr ""
 "Вы нашли немного\n"
 "%{resource}."
 
-#: ../fheroes2/gui/interface_status.cpp:407
 msgid "Status Window"
 msgstr "Окно статуса"
 
-#: ../fheroes2/gui/interface_status.cpp:407
+#, fuzzy
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date."
+msgstr ""
+"Это окно сообщает информацию о состоянии вашего героя или королевства, а так "
+"же показывает календарь. Информация меняется циклично при нажатии левой "
+"кнопки мыши на нем."
+
 msgid ""
 "This window provides information on the status of your hero or kingdom, and "
 "shows the date. Left click here to cycle throungh these windows."
@@ -2733,21 +2860,284 @@ msgstr ""
 "же показывает календарь. Информация меняется циклично при нажатии левой "
 "кнопки мыши на нем."
 
-#: ../fheroes2/heroes/heroes_action.cpp:112
+msgid "Necroman"
+msgstr "Некромант"
+
+msgid ""
+"This lets you change player starting positions and colors. A particular "
+"color will always start in a particular location. Some positions may only be "
+"played by a computer player or only by a human player."
+msgstr ""
+"Эта опция позоваляет вам задать цвет игрока и его стартовую позицию. Каждому "
+"цвету соответсвует определенная стартовая позиция. Некторые цвета жестко "
+"закреплены либо за компьютерными, либо за живыми игроками."
+
+msgid ""
+"This lets you change the class of a player. Classes are not always "
+"changeable. Depending on the scenario, a player may receive additional towns "
+"and/or heroes not of their primary alignment."
+msgstr ""
+"Эта опция позволяет вам задавать класс игрока. Классы не всегда можно "
+"изменять. В зависимости от сценария игрок может получать дополнительные "
+"города и/или героев направленность которых изначально не совпадает с "
+"направленностью игрока."
+
+msgid "%{color} player"
+msgstr "%{color} игрок"
+
+msgid "View %{skill} Info"
+msgstr "Информация об умении %{skill}"
+
+msgid "Lord Kilburn"
+msgstr "Лорд Килбурн"
+
+#, fuzzy
+msgid "Sir Gallant"
+msgstr "Сэр Галлант"
+
+msgid "Ector"
+msgstr "Эктор"
+
+msgid "Gwenneth"
+msgstr "Гвиннет"
+
+msgid "Tyro"
+msgstr "Тиро"
+
+msgid "Ambrose"
+msgstr "Амброс"
+
+msgid "Ruby"
+msgstr "Руби"
+
+msgid "Maximus"
+msgstr "Максимус"
+
+msgid "Dimitry"
+msgstr "Димитрий"
+
+msgid "Thundax"
+msgstr "Тандакс"
+
+msgid "Fineous"
+msgstr "Файнеус"
+
+msgid "Jojosh"
+msgstr "Йойош"
+
+msgid "Crag Hack"
+msgstr "Крэг Хэк"
+
+msgid "Jezebel"
+msgstr "Изабэль"
+
+msgid "Jaclyn"
+msgstr "Йаслин"
+
+msgid "Ergon"
+msgstr "Эргон"
+
+msgid "Tsabu"
+msgstr "Тсабу"
+
+msgid "Atlas"
+msgstr "Атлас"
+
+msgid "Astra"
+msgstr "Астра"
+
+msgid "Natasha"
+msgstr "Наташа"
+
+msgid "Troyan"
+msgstr "Троян"
+
+msgid "Vatawna"
+msgstr "Ватана"
+
+msgid "Rebecca"
+msgstr "Ребекка"
+
+msgid "Gem"
+msgstr "Джем"
+
+msgid "Ariel"
+msgstr "Ариэль"
+
+msgid "Carlawn"
+msgstr "Карлан"
+
+msgid "Luna"
+msgstr "Луна"
+
+msgid "Arie"
+msgstr "Эйри"
+
+msgid "Alamar"
+msgstr "Аламар"
+
+msgid "Vesper"
+msgstr "Веспер"
+
+msgid "Crodo"
+msgstr "Кродо"
+
+msgid "Barok"
+msgstr "Барок"
+
+msgid "Kastore"
+msgstr "Кастор"
+
+msgid "Agar"
+msgstr "Агар"
+
+msgid "Falagar"
+msgstr "Фалагар"
+
+msgid "Wrathmont"
+msgstr "Ратмонд"
+
+msgid "Myra"
+msgstr "Мира"
+
+msgid "Flint"
+msgstr "Флинт"
+
+msgid "Dawn"
+msgstr "Дан"
+
+msgid "Halon"
+msgstr "Хейлон"
+
+msgid "Myrini"
+msgstr "Мурини"
+
+msgid "Wilfrey"
+msgstr "Уилфри"
+
+msgid "Sarakin"
+msgstr "Саракин"
+
+msgid "Kalindra"
+msgstr "Калиндра"
+
+msgid "Mandigal"
+msgstr "Мандигал"
+
+msgid "Zom"
+msgstr "Зом"
+
+msgid "Darlana"
+msgstr "Дарлана"
+
+msgid "Zam"
+msgstr "Зам"
+
+msgid "Ranloo"
+msgstr "Рэнлу"
+
+msgid "Charity"
+msgstr "Чарити"
+
+msgid "Rialdo"
+msgstr "Риалдо"
+
+msgid "Roxana"
+msgstr "Роксана"
+
+msgid "Sandro"
+msgstr "Сандро"
+
+msgid "Celia"
+msgstr "Келия"
+
+msgid "Roland"
+msgstr "Роланд"
+
+msgid "Lord Corlagon"
+msgstr "Лорд Корлагон"
+
+msgid "Sister Eliza"
+msgstr "Сестра Элиза"
+
+msgid "Archibald"
+msgstr "Арчибальд"
+
+msgid "Lord Halton"
+msgstr "Лорд Халтон"
+
+#, fuzzy
+msgid "Brother Brax"
+msgstr "Брат Бэкс"
+
+msgid "Solmyr"
+msgstr "Сольмир"
+
+msgid "Dainwin"
+msgstr "Дейнвин"
+
+msgid "Mog"
+msgstr "Моуг"
+
+msgid "Joseph"
+msgstr "Джозефф"
+
+msgid "Gallavant"
+msgstr "Галлавант"
+
+msgid "Elderian"
+msgstr "Элдериан"
+
+msgid "Ceallach"
+msgstr "Каллах"
+
+msgid "Drakonia"
+msgstr "Драконда"
+
+msgid "Martine"
+msgstr "Мартин"
+
+msgid "Jarkonas"
+msgstr "Ярконас"
+
+msgid "%{object} robber"
+msgstr ""
+
+msgid "%{object} raided"
+msgstr ""
+
+msgid "You cannot pick up this artifact, you already have a full load!"
+msgstr ""
+
+msgid "The three Anduran artifacts magically combine into one."
+msgstr "Три магических артифакта Андурана, объединяются в один."
+
+msgid "To cast spells, you must first buy a spell book for %{gold} gold."
+msgstr ""
+"Чтобы Вас пропустили в Гильдию Магов, Вы должны купить книгу заклинаний за "
+"%{gold} золотых."
+
+msgid "Unfortunately, you seem to be a little short of cash at the moment."
+msgstr "К сожалению, у вас не хватает денег."
+
+msgid "Do you wish to buy one?"
+msgstr "Желаете купить?"
+
 msgid "%{count} / day"
 msgstr "%{count} / в день"
 
-#: ../fheroes2/heroes/heroes_action.cpp:331
-#: ../fheroes2/heroes/heroes_action.cpp:2214
 msgid "You are unable to recruit at this time, your ranks are full."
 msgstr "Для этого отряда нет места."
 
-#: ../fheroes2/heroes/heroes_action.cpp:607
-#: ../fheroes2/heroes/heroes_action.cpp:628
+msgid "A whirlpool engulfs your ship."
+msgstr "Ваш корабль засосало в водоворот."
+
+msgid "Some of your army has fallen overboard."
+msgstr "Часть вашей армии смыло за борт."
+
 msgid "Insulted by your refusal of their offer, the monsters attack!"
 msgstr "Оскорбленные вашим отказом они напали на вас."
 
-#: ../fheroes2/heroes/heroes_action.cpp:636
 msgid ""
 "The %{monster}, awed by the power of your forces, begin to scatter.\n"
 "Do you wish to pursue and engage them?"
@@ -2755,11 +3145,9 @@ msgstr ""
 "%{monster}, страшась мощи вашего воинства, бросилась в рассыпную.\n"
 "Соизволите изловить их и заставить драться?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:939
 msgid "Ransacking an enemy camp, you discover a hidden cache of treasures."
 msgstr "Обыскав вражеский лагерь, вы находите спрятанный клад."
 
-#: ../fheroes2/heroes/heroes_action.cpp:974
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with these resources, "
@@ -2769,7 +3157,6 @@ msgstr ""
 "\"Милорд, я трудился в поте лица и прошу вас принять эти ресурсы. Приходите "
 "на следующей неделе и получите еще столько же.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:975
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there are no resources currently available. Please try "
@@ -2779,7 +3166,6 @@ msgstr ""
 "\"Сожалею, милорд, но сегодня у меня нет ресурсов. Приходите на следующей "
 "неделе.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:980
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with this gold, come "
@@ -2789,7 +3175,6 @@ msgstr ""
 "\"Милорд, я трудился в поте лица и прошу вас принять это золото. Приходите "
 "на следующей неделе и получите еще столько же.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:981
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there is no gold currently available. Please try again "
@@ -2799,7 +3184,6 @@ msgstr ""
 "\"Сожалею, милорд, но сегодня золота у меня нет. Приходите на следующей "
 "неделе.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:987
 msgid ""
 "You've found an abandoned lean-to.\n"
 "Poking about, you discover some resources hidden nearby."
@@ -2807,11 +3191,9 @@ msgstr ""
 "Вы нашли заброшенный навес.\n"
 "Немного поискав вы нашли припрятанные рядом ресурсы."
 
-#: ../fheroes2/heroes/heroes_action.cpp:988
 msgid "The lean-to is long abandoned. There is nothing of value here."
 msgstr "Здесь все давно заброшено, и больше здесь нечего нет."
 
-#: ../fheroes2/heroes/heroes_action.cpp:993
 msgid ""
 "You catch a leprechaun foolishly sleeping amidst a cluster of magic "
 "mushrooms.\n"
@@ -2822,7 +3204,6 @@ msgstr ""
 "В обмен на свою свободу он рассказал вам, где лежит горшочек с волшебными "
 "камешками."
 
-#: ../fheroes2/heroes/heroes_action.cpp:994
 msgid ""
 "You've found a magic garden, the kind of place that leprechauns and faeries "
 "like to cavort in, but there is no one here today.\n"
@@ -2831,23 +3212,18 @@ msgstr ""
 "Вы забрели в волшебный сад. Здесь, обычно, так обожают резвится леприконы с "
 "феями. Но сегодня здесь никого."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1030
 msgid "You come upon the remains of an unfortunate adventurer."
 msgstr "Вы обнаружили останки какого-то несчастного путника."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1041
 msgid "Treasure"
 msgstr "Сокровище"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1048
 msgid "Searching through the tattered clothing, you find %{artifact}."
 msgstr "Покопавшись среди лохмотьев, вы нашли %{artifact}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1059
 msgid "Searching through the tattered clothing, you find nothing."
 msgstr "Покопавшись среди лохмотьев, вы ничего не нашли."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1071
 msgid ""
 "You come across an old wagon left by a trader who didn't quite make it to "
 "safe terrain."
@@ -2855,74 +3231,60 @@ msgstr ""
 "Вы наткнулись на брошеную торговую повозку, что не делает местность "
 "безопасной."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1082
-#: ../fheroes2/heroes/heroes_action.cpp:1110
 msgid "Unfortunately, others have found it first, and the wagon is empty."
 msgstr "К несчастью, другие здесь уже были, в повозке ничего нет."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1089
 msgid "Searching inside, you find the %{artifact}."
 msgstr "Покопавшись внутри, вы нашли %{artifact}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1100
 msgid "Inside, you find some of the wagon's cargo still intact."
 msgstr "Внутри часть груза оказалась нетронутой."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1130
 msgid "You search through the flotsam, and find some wood and some gold."
 msgstr "Вы исследовали плавающие обломки и нашли немного древесины и золота."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1131
 msgid "You search through the flotsam, and find some wood."
 msgstr "Вы исследовали плавающие обломки и нашли немного древесины."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1137
 msgid "You search through the flotsam, but find nothing."
 msgstr "Вы исследовали плавающие обломки и ничего не нашли."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1158
 msgid "Shrine of the 1st Circle"
 msgstr "Святилище 1-го круга"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1159
 msgid ""
 "You come across a small shrine attended by a group of novice acolytes.\n"
-"In exchange for your protection, they agree to teach you a simple spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a simple spell - "
+"'%{spell}'."
 msgstr ""
 "Вы набрели на маленькое святилище, где служат молодые братья веры.\n"
-"В обмен на защиту они согласились научить вас простому заклинанию - '%"
-"{spell}'."
+"В обмен на защиту они согласились научить вас простому заклинанию - "
+"'%{spell}'."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1162
 msgid "Shrine of the 2nd Circle"
 msgstr "Святилище 2-го круга"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1163
 msgid ""
 "You come across an ornate shrine attended by a group of rotund friars.\n"
-"In exchange for your protection, they agree to teach you a spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a spell - "
+"'%{spell}'."
 msgstr ""
 "Вы набрели на богато расписанное святилище, где служат достойные братья "
 "веры.\n"
 "В обмен на защиту они согласились научить вас заклинанию - '%{spell}'."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1166
 msgid "Shrine of the 3rd Circle"
 msgstr "Святилище 3-го круга"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1167
 msgid ""
 "You come across a lavish shrine attended by a group of high priests.\n"
 "In exchange for your protection, they agree to teach you a sophisticated "
 "spell - '%{spell}'."
 msgstr ""
 "Вы набрели на роскошное святилище, где служат верховные жрецы.\n"
-"В обмен на защиту они согласились научить вас премудрому заклинанию - '%"
-"{spell}'."
+"В обмен на защиту они согласились научить вас премудрому заклинанию - "
+"'%{spell}'."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1180
 msgid ""
 "\n"
 "Unfortunately, you have no Magic Book to record the spell with."
@@ -2930,7 +3292,6 @@ msgstr ""
 "\n"
 "К сожалению, у вас нет Волшебной книги, чтобы записать заклинание в нее."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1191
 msgid ""
 "\n"
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
@@ -2940,7 +3301,6 @@ msgstr ""
 "К сожалению, у вас недостаточно мудрости, чтобы понять заклинание, и вы не в "
 "состоянии его изучить."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1199
 msgid ""
 "\n"
 "Unfortunately, you already have knowledge of this spell, so there is nothing "
@@ -2949,17 +3309,15 @@ msgstr ""
 "\n"
 "Вы уже знаете эту магию."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1222
 msgid ""
-"You approach the hut and observe a witch inside studying an ancient tome on %"
-"{skill}.\n"
+"You approach the hut and observe a witch inside studying an ancient tome on "
+"%{skill}.\n"
 " \n"
 msgstr ""
 "Подойдя к хижине и заглянув в окно, вы увидели ведьму, склонивщуюся над "
 "древней книгой под названием %{skill}.\n"
 " \n"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1229
 msgid ""
 "As you approach, she turns and focuses her one glass eye on you.\n"
 "\"You already know everything you deserve to learn!\" the witch screeches. "
@@ -2970,7 +3328,6 @@ msgstr ""
 "\"Вы уже знаете достаточно того, что вам положено знать!\" прогаркала "
 "ведьма. \"А ТЕПЕРЬ ВОН ИЗ МОЕГО ДОМА!\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1236
 msgid ""
 "As you approach, she turns and speaks.\n"
 "\"You already know that which I would teach you. I can help you no further.\""
@@ -2978,7 +3335,6 @@ msgstr ""
 "Подойдя к хижине, ведьма поворачиается и говорит.\n"
 "\"Вы уже знаете то, чему я могу вас научить. Больши ничем помочь не могу.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1243
 msgid ""
 "An ancient and immortal witch living in a hut with bird's legs for stilts "
 "teaches you %{skill} for her own inscrutable purposes."
@@ -2986,19 +3342,15 @@ msgstr ""
 "Дряхлая, но бессмертная ведьма, живущая в этой избушке на курьих ножках, по "
 "каким-то непонятным соображениям решила, что %{skill} вам пригодится."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1262
 msgid "You drink from the enchanted fountain, but nothing happens."
 msgstr "Вы пьете из фонтана, но ничего не происходит."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1263
 msgid "As you drink the sweet water, you gain luck for your next battle."
 msgstr "Выпив свежей водички вы получаете бонус удачи в следующем бою."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1267
 msgid "You enter the faerie ring, but nothing happens."
 msgstr "Вы посетили кольцо фей, но ничего не произошло."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1268
 msgid ""
 "Upon entering the mystical faerie ring, your army gains luck for its next "
 "battle."
@@ -3006,7 +3358,6 @@ msgstr ""
 "Ваше войско вступает в кольцо фей, чары которого принесут вам удачу в "
 "грядущем сражении."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1272
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "It is supposed to grant luck to visitors, but since the stars are already "
@@ -3016,7 +3367,6 @@ msgstr ""
 "но поскольку звезды и так покровительствуют вам, идол ничего новго вам не "
 "дал."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1273
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "Kissing it is supposed to be lucky, so you do. The stone is very cold to the "
@@ -3026,13 +3376,11 @@ msgstr ""
 "Говорят, если его поцеловать, то это принесет удачу - вы так и поступили. "
 "Камень оказался очень холоден для губ."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1277
 msgid "The mermaids silently entice you to return later and be blessed again."
 msgstr ""
 "Руслаки молчаливо дали вам понять, чтобы вы приходили в другой раз, догда "
 "они благословят вас."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1278
 msgid ""
 "The magical, soothing beauty of the Mermaids reaches you and your crew.\n"
 "Just for a moment, you forget your worries and bask in the beauty of the "
@@ -3044,7 +3392,6 @@ msgstr ""
 "красоты.\n"
 "Чары русалок благословили вас на удачу в следующем бою."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1310
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "You are tempted to search it for treasure, but all the old stories warn of "
@@ -3056,7 +3403,6 @@ msgstr ""
 "ужасных проклятиях и неупокоенных стражей.\n"
 "Хотите обследовать примиду?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1311
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "Routine exploration reveals that the pyramid is completely empty."
@@ -3064,18 +3410,15 @@ msgstr ""
 "Вы нашли пирамиду древнего великого царя.\n"
 "Первое же обследование показало, что в ней обсолюно ничего нет."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1336
 msgid "Unfortunately, you have no Magic Book to record the spell with."
 msgstr "К сожалению вы не имеете Волшебной книги чтобы записать заклинание."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1340
 msgid ""
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
 msgstr ""
 "К сожалению, вам не хватает мудрости чтобы понять и выучить заклинание."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1344
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
 "telling the secret of the spell."
@@ -3083,11 +3426,9 @@ msgstr ""
 "Одолев чудовищь, вы расшифровали иероглифы на стене, сообщающие секрет "
 "заклинания."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1382 ../fheroes2/maps/mp2.cpp:469
 msgid "Sign"
 msgstr "Указатель"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1393
 msgid ""
 "A drink at the well is supposed to restore your spell points, but you are "
 "already at maximum."
@@ -3095,15 +3436,12 @@ msgstr ""
 "Глоток из колодца обычно восстанавливает магическую энергию, но сейчас она у "
 "вас и так на пределе."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1400
 msgid "A second drink at the well in one day will not help you."
 msgstr "Второй глоток за день вам не поможет."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1407
 msgid "A drink from the well has restored your spell points to maximum."
 msgstr "Глоток из колодца полностью восстановил вашу магическую энергию."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1432
 msgid ""
 "\"I'm sorry sir,\" The leader of the soldiers says, \"but you already know "
 "everything we have to teach.\""
@@ -3111,11 +3449,9 @@ msgstr ""
 "\"Простите, милорд\" -Сказал предводитель воинов, -\"но вы уже знаете все, "
 "чему мы способны научить.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1433
 msgid "The soldiers living in the fort teach you a few new defensive tricks."
 msgstr "Войны, живущие в этом форте, научили вас паре новых защитных приемов."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1438
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. \"You're too "
 "advanced for us,\" the mercenary captain says. \"We can teach nothing more.\""
@@ -3124,7 +3460,6 @@ msgstr ""
 "слишком умелый боец,\" - сказал капитан наемников. - \"Больше мы ничему вас "
 "научить не можем.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1439
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. The mercenaries "
 "welcome you and your troops and invite you to train with them."
@@ -3132,11 +3467,9 @@ msgstr ""
 "Вы пришли в лагерь наемников, отрабатывающих свою тактику. Наемники "
 "поприветсвовали вас и пригласили позаниматся вместе с ними."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1444
 msgid "\"Go 'way!\", the witch doctor barks, \"you know all I know.\""
 msgstr "\"Убирайся!\" - рявкнула ведьма, \"ты и так знаешь все, что знаю я.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1445
 msgid ""
 "An Orcish witch doctor living in the hut deepens your knowledge of magic by "
 "showing you how to cast stones, read portents, and decipher the intricacies "
@@ -3146,7 +3479,6 @@ msgstr ""
 "показав, как гадать на камнях, читать знамения и извлекать сущность бытия из "
 "сложного переплетения цплячьих потрохов."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1450
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, the Druids turn you away, indicating they have nothing "
@@ -3156,7 +3488,6 @@ msgstr ""
 "сооружений Друиды, не нарушая безмолвия, показали жестами, что им больше "
 "нечему вас учить."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1451
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, they teach you new ways to cast spells."
@@ -3165,7 +3496,6 @@ msgstr ""
 "сооружений. Не нарушая безмолвия, они все же научили вас новым способам "
 "колдовства."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1487
 msgid ""
 "You tentatively approach the burial ground of ancient warriors. Do you want "
 "to search the graves?"
@@ -3173,7 +3503,6 @@ msgstr ""
 "Вы осторожно приближатетесь к захоронению древних войнов. Хотите раскопать "
 "их могилы?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1488
 msgid ""
 "Upon defeating the Zombies you spend several hours searching the graves and "
 "find nothing. Such a despicable act reduces your army's morale."
@@ -3181,11 +3510,10 @@ msgstr ""
 "После победы над зомби, вы проводите несколько часов обыскивая могилы и "
 "ничего не находите. Сей презренный акт снижает мораль вашей армии."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1489
-msgid "Upon defeating the zomies you search the graves and find something!"
+#, fuzzy
+msgid "Upon defeating the Zombies you search the graves and find something!"
 msgstr "После победы над зомби, вы обыскиваете могилы и удаляетесь с находкой."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1492
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the shipwreck?"
@@ -3193,7 +3521,6 @@ msgstr ""
 "Гниющий остов огромного пиратского корабля зловеще поскрипывает, "
 "покачиваемый прибоем на скалах. Желаете обыскать обломки?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1493
 msgid ""
 "Upon defeating the Ghosts you spend several hours sifting through the debris "
 "and find nothing. Such a despicable act reduces your army's morale."
@@ -3201,12 +3528,10 @@ msgstr ""
 "Одолев призраков, вы проводите несколько часов обыскивая останки и ничего не "
 "находите. Сей презренный акт снижает мораль вашей армии."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1494
 msgid ""
 "Upon defeating the Ghosts you sift through the debris and find something!"
 msgstr "Одолев призраков, вы обыскали останки кораблекрушения и кое-что нашли."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1497
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the ship?"
@@ -3214,7 +3539,6 @@ msgstr ""
 "Гниющий остов огромного пиратского корабля зловеще поскрипывает, "
 "покачиваемый прибоем на скалах. Желаете обыскать корабль?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1498
 msgid ""
 "Upon defeating the Skeletons you spend several hours sifting through the "
 "debris and find nothing. Such a despicable act reduces your army's morale."
@@ -3222,16 +3546,13 @@ msgstr ""
 "Совлодав со скелетами, вы проводите несколько часов обыскивая останки и "
 "ничего не находите. Сей презренный акт снижает мораль вашей армии."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1499
 msgid ""
 "Upon defeating the Skeletons you sift through the debris and find something!"
 msgstr "Совлодав со скелетами, вы обыскали останки корабля и кое-что нашли."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1572
 msgid "Your men spot a navigational buoy, confirming that you are on course."
 msgstr "Ваши спутники замечают морской буй. Он указывает верный курс."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1573
 msgid ""
 "Your men spot a navigational buoy, confirming that you are on course and "
 "increasing their morale."
@@ -3239,7 +3560,6 @@ msgstr ""
 "Ваши спутники замечают морской буй. Он указывает верный курс, и это повышает "
 "их боевой дух."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1577
 msgid ""
 "The drink at the oasis is refreshing, but offers no further benefit. The "
 "oasis might help again if you fought a battle first."
@@ -3247,7 +3567,6 @@ msgstr ""
 "Глоток влаги в оазисе освежает, но иной пользы не приносит. Этот оазис, "
 "возможно, снова поможет вам после следующей битвы."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1578
 msgid ""
 "A drink at the oasis fills your troops with strength and lifts their "
 "spirits.  You can travel a bit further today."
@@ -3255,7 +3574,6 @@ msgstr ""
 "Глоток воды из оазиса наполняет ваших войнов силой и поднимает дух. Сегодня "
 "вы сможете пройти чуть больше."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1583
 msgid ""
 "The drink at the watering hole is refreshing, but offers no further benefit. "
 "The watering hole might help again if you fought a battle first."
@@ -3263,7 +3581,6 @@ msgstr ""
 "Выпивка освежает, но инных благ не приносит. Источник снова поможет вам "
 "после следующей битвы."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1584
 msgid ""
 "A drink at the watering hole fills your troops with strength and lifts their "
 "spirits. You can travel a bit further today."
@@ -3271,16 +3588,13 @@ msgstr ""
 "Добрый глоток исполнил ваши войска силы и поднял дух. Сегодня вы сможете "
 "пройти чуть дальше."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1589
 msgid ""
 "It doesn't help to pray twice before a battle. Come back after you've fought."
 msgstr "Двойная молитва войне не подспорье. Заходите после битвы."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1590
 msgid "A visit and a prayer at the temple raises the morale of your troops."
 msgstr "Посещение храма и молитва подняли мораль ваших войск."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1630
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"I am sorry, my liege, I "
 "have taught you all I can.\""
@@ -3288,7 +3602,6 @@ msgstr ""
 "На ступенях беседки появляется старый рыцарь. \"Мне жаль храбрый воин, но я "
 "уже научил тебя всему, что знаю сам.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1631
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"My liege, I will teach "
 "you all that I know to aid you in your travels.\""
@@ -3296,7 +3609,6 @@ msgstr ""
 "На ступенях беседки появляется старый рыцарь. \"О храбрый воин, я научу тебя "
 "всему, что знаю сам: пусть мой опыт поможет тебе в твоих странствиях.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1670
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
 "ocean. Grateful, he says, \"I would give you an artifact as a reward, but "
@@ -3306,36 +3618,27 @@ msgstr ""
 "Матрос сказал, \"За свое спасение, Я хотел отблагодарить артифактом, но я "
 "вижу Ваша сумка и так переполнена ими!.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1677
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
-"ocean. Grateful, he rewards you for your act of kindness by giving you the %"
-"{art}."
+"ocean. Grateful, he rewards you for your act of kindness by giving you the "
+"%{art}."
 msgstr ""
 "Вы спасли жертву караблекрушения от неминуемой смерти в безжалостном океане. "
 "Награда за вашу доброту %{art}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1697 ../fheroes2/heroes/heroes.cpp:944
-msgid "You have no room to carry another artifact!"
-msgstr "В вашей сумке нет места для еще одного артефакта."
-
-#: ../fheroes2/heroes/heroes_action.cpp:1719
 msgid "A leprechaun offers you the %{art} for the small price of %{gold} Gold."
 msgstr "Леприкон предлагает вам %{art} за скромную цену в %{gold} золотых."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1724
 msgid ""
-"A leprechaun offers you the %{art} for the small price of %{gold} Gold and %"
-"{count} %{res}."
+"A leprechaun offers you the %{art} for the small price of %{gold} Gold and "
+"%{count} %{res}."
 msgstr ""
 "Леприкон предлагает вам %{art} за скромную цену в %{gold} золотых и %{count} "
 "%{res}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1733
 msgid "Do you wish to buy this artifact?"
 msgstr "Хотите приобрести этот артефакт?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1746
 msgid ""
 "You try to pay the leprechaun, but realize that you can't afford it. The "
 "leprechaun stamps his foot and ignores you."
@@ -3343,7 +3646,6 @@ msgstr ""
 "Вы хотите заплатить леприкону, но у вас не хватает средств. Леприкон топает "
 "ножкой и игнорирует вас."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1750
 msgid ""
 "Insulted by your refusal of his generous offer, the leprechaun stamps his "
 "foot and ignores you."
@@ -3351,12 +3653,9 @@ msgstr ""
 "Оскорбленный вашим отказом на его щедрое предложение, леприкон топает ножкой "
 "и игнорирует вас."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1761
-#: ../fheroes2/heroes/heroes_action.cpp:1836
 msgid "You've found the artifact: "
 msgstr "Вы нашли артефакт: "
 
-#: ../fheroes2/heroes/heroes_action.cpp:1771
 msgid ""
 "You've found the humble dwelling of a withered hermit. The hermit tells you "
 "that he is willing to give the %{art} to the first wise person he meets."
@@ -3364,7 +3663,6 @@ msgstr ""
 "Вы нашли скромное жилище отшельника. Отшельник говорит вам, что он готов "
 "отдать %{art} первому Мудрецу, которого встретит."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1774
 msgid ""
 "You've come across the spartan quarters of a retired soldier. The soldier "
 "tells you that he is willing to pass on the %{art} to the first true leader "
@@ -3373,7 +3671,6 @@ msgstr ""
 "Вы посетили в квартиру отставного ветерана. Солдат говорит вам, что он готов "
 "отдать %{art} первому Лидеру, которого он встретит."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1795
 msgid ""
 "You come upon an ancient artifact. As you reach for it, a pack of Rogues "
 "leap out of the brush to guard their stolen loot."
@@ -3381,7 +3678,6 @@ msgstr ""
 "Вы нашли древний артефакт. Как только вы наклонились его подобрать, "
 "воспользовавшись моментом, вдруг из засады выпрыгнула шайка разбойников..."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1798
 msgid ""
 "Through a clearing you observe an ancient artifact. Unfortunately, it's "
 "guarded by a nearby %{monster}. Do you want to fight the %{monster} for the "
@@ -3390,11 +3686,9 @@ msgstr ""
 "Вы заметили древний артефакт. К сожалению, рядом бродит %{monster}. Хотите "
 "сразится с %{monster}?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1813
 msgid "Victorious, you take your prize, the %{art}."
 msgstr "Победитель! Вы берете ваш приз %{art}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1825
 msgid ""
 "Discretion is the better part of valor, and you decide to avoid this fight "
 "for today."
@@ -3402,8 +3696,6 @@ msgstr ""
 "Осмотрительность - это лучшая черта доблести, и вы решили избежать сражения "
 "сегодня."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1881
-#: ../fheroes2/heroes/heroes_action.cpp:1896
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold pieces."
@@ -3411,7 +3703,6 @@ msgstr ""
 "Проведя часы, пытаясь выловить сундук из воды, вы наконец открыли его и "
 "нашли внутри %{gold} золотых."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1887
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold and the %{art}."
@@ -3419,7 +3710,6 @@ msgstr ""
 "Проведя часы, пытаясь выловить сундук из воды, вы наконец открыли его и "
 "нашли внутри %{gold} золотых и %{art}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1903
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it, "
 "only to find it empty."
@@ -3427,7 +3717,6 @@ msgstr ""
 "Проведя часы, пытаясь выловить сундук из воды, вы наконец открыли его, но он "
 "оказался пуст."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1913
 msgid ""
 "After scouring the area, you fall upon a hidden treasure cache. You may take "
 "the gold or distribute the gold to the peasants for experience. Do you wish "
@@ -3436,15 +3725,13 @@ msgstr ""
 "Исследуя окрестности, вы наткнулись на древний ларец. Золото можно оставить "
 "себе или раздать крестьянам в обмен на опыт. Оставите золото себе?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1927
 msgid ""
-"After scouring the area, you fall upon a hidden chest, containing the %"
-"{gold} gold pieces."
+"After scouring the area, you fall upon a hidden chest, containing the "
+"%{gold} gold pieces."
 msgstr ""
 "Исследуя окрестности, вы наткнулись на древний ларец в котором лежит %{gold} "
 "золотых."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1933
 msgid ""
 "After scouring the area, you fall upon a hidden chest, containing the "
 "ancient artifact %{art}."
@@ -3452,22 +3739,12 @@ msgstr ""
 "Исследуя окрестности, вы наткнулись на древний ларец в котором лежит древний "
 "артефакт %{art}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1957
 msgid ""
 "You stumble upon a dented and tarnished lamp lodged deep in the earth. Do "
 "you wish to rub the lamp?"
 msgstr ""
 "Вы находите засыпанную землей помятую и закопченую лампу. Хотите ее потереть?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2045
-msgid "A whirlpool engulfs your ship."
-msgstr "Ваш корабль засосало в водоворот."
-
-#: ../fheroes2/heroes/heroes_action.cpp:2045
-msgid "Some of your army has fallen overboard."
-msgstr "Часть вашей армии смыло за борт."
-
-#: ../fheroes2/heroes/heroes_action.cpp:2060
 msgid ""
 "You come upon an abandoned gold mine. The mine appears to be haunted. Do you "
 "wish to enter?"
@@ -3475,15 +3752,13 @@ msgstr ""
 "Вы подошли к заброшенной шахте. Возможно в ней живут привидения. Хотите "
 "войти и проверить это?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2079
 msgid ""
 "You have taken control of the local Alchemist shop. It will provide you with "
 "%{count} unit of Mercury per day."
 msgstr ""
-"Вы стали хозяином лаборатории местного алхимика. Она будет приносить вам по %"
-"{count} единиц ртути в день."
+"Вы стали хозяином лаборатории местного алхимика. Она будет приносить вам по "
+"%{count} единиц ртути в день."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2085
 msgid ""
 "You gain control of a sawmill. It will provide you with %{count} units of "
 "wood per day."
@@ -3491,7 +3766,9 @@ msgstr ""
 "Вы стали хозяином лесопилки. Она будет приносить вам по %{count} единиц "
 "древесины в день."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2096
+msgid "You beat the Ghosts and are able to restore the mine to production."
+msgstr "Вы выгнали призраков из шахты и восстановили ее работу."
+
 msgid ""
 "You gain control of an ore mine. It will provide you with %{count} units of "
 "ore per day."
@@ -3499,7 +3776,6 @@ msgstr ""
 "Вы стали хозяином рудной шахты. Она будет приносить вам по %{count} мер руды "
 "в день."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2098
 msgid ""
 "You gain control of a sulfur mine. It will provide you with %{count} unit of "
 "sulfur per day."
@@ -3507,7 +3783,6 @@ msgstr ""
 "Вы стали хозяином серной шахты. Она будет приносить вам по %{count} единицы "
 "серы в день."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2100
 msgid ""
 "You gain control of a crystal mine. It will provide you with %{count} unit "
 "of crystal per day."
@@ -3515,7 +3790,6 @@ msgstr ""
 "Вы стали хозяином кристальной шахты. Она будет приносить вам по %{count} мер "
 "кристаллов в день."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2102
 msgid ""
 "You gain control of a gem mine. It will provide you with %{count} unit of "
 "gems per day."
@@ -3523,7 +3797,6 @@ msgstr ""
 "Вы стали хозяином самоцветной шахты. Она будет приносить вам по %{count} мер "
 "самоцветов в день."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2104
 msgid ""
 "You gain control of a gold mine. It will provide you with %{count} gold per "
 "day."
@@ -3531,11 +3804,6 @@ msgstr ""
 "Вы стали хозяином золотой шахты. Она будет приносить вам по %{count} золотых "
 "в день."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2111
-msgid "You beat the Ghosts and are able to restore the mine to production."
-msgstr "Вы выгнали призраков из шахты и восстановили ее работу."
-
-#: ../fheroes2/heroes/heroes_action.cpp:2116
 msgid ""
 "The lighthouse is now under your control, and all of your ships will now "
 "move further each turn."
@@ -3543,22 +3811,18 @@ msgstr ""
 "Вы стали хозяином маяка, теперь все ваши корабли будут передвигатся на 5 "
 "пунктов движения дальше каждый ход.."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2120
 msgid "You gain control of a %{name}."
 msgstr "Персонаж %{name} переходит под ваш контроль."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2203
 msgid ""
 "A group of %{monster} with a desire for greater glory wish to join you. Do "
 "you accept?"
 msgstr ""
 "Группа %{monster} в погоне за славой желает к вам присоеденится. Вы согласны?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2230
 msgid "As you approach the dwelling, you notice that there is no one here."
 msgstr "Приближаясь к жилищу, вы замечаете что здесь никого нет."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2247
 msgid ""
 "You search the ruins, but the Medusas that used to live here are gone. "
 "Perhaps there will be more next week."
@@ -3566,7 +3830,6 @@ msgstr ""
 "Вы обыскали руины, но убедились, что жившие тут медузы ушли. Может быть вам "
 "повезет больше на следующей неделе."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2248
 msgid ""
 "You've found some Medusas living in the ruins. They are willing to join your "
 "army for a price. Do you want to recruit Medusas?"
@@ -3574,7 +3837,6 @@ msgstr ""
 "Вы обыскали руины и нашли нескольких медуз, обитающих тут. Они согласны "
 "вступить в вашу армию за вознаграждение. Желаете нанять медуз?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2253
 msgid ""
 "You've found a Sprite Tree City. Unfortunately, none of the Sprites living "
 "there wish to join an army. Maybe next week."
@@ -3582,7 +3844,6 @@ msgstr ""
 "Вы нашли древесный город фей. К сожалению, ни одна фея не захотела "
 "присоеденится к вашей армии. Может быть на следующей неделе они передумают."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2254
 msgid ""
 "Some of the Sprites living in the tree city are willing to join your army "
 "for a price. Do you want to recruit Sprites?"
@@ -3590,7 +3851,6 @@ msgstr ""
 "Несколько фей, из города на деревьях, желают вступить в вашу армию, за "
 "некоторое вознаграждение. Желаете нанять фей?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2259
 msgid ""
 "A colorful Rogues' wagon stands empty here. Perhaps more Rogues will be here "
 "later."
@@ -3598,7 +3858,6 @@ msgstr ""
 "Разноцветная повозка разбойников пуста. Пройдет время, и, быть может, здесь "
 "обоснуется новая шайка."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2260
 msgid ""
 "Distant sounds of music and laughter draw you to a colorful wagon housing "
 "Rogues. Do you wish to have any Rogues join your army?"
@@ -3607,7 +3866,6 @@ msgstr ""
 "повозку, в которой живут разбойники. Вы хотите принять в ваше войско шайку "
 "разбойников?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2265
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. The "
 "tents are unoccupied. Perhaps more Nomads will be here later."
@@ -3616,7 +3874,6 @@ msgstr ""
 "пустыни.  Здесь никого нет.  Пройдет время, и, быть может, сюда придет новый "
 "отряд кочевников."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2266
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. Do you "
 "wish to have any Nomads join you during your travels?"
@@ -3624,11 +3881,9 @@ msgstr ""
 "Ваше внимание привлек шатер, пологи которого трепещут на жарком ветру в "
 "пустыни. Вы хотите принять в ваше войско отряд кочевников?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2271
 msgid "The pit of mud bubbles for a minute and then lies still."
 msgstr "Яма клокочущей грязи всколыхнулась и успокоилась."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2272
 msgid ""
 "As you approach the bubbling pit of mud, creatures begin to climb out and "
 "position themselves around it. In unison they say: \"Mother Earth would like "
@@ -3639,12 +3894,10 @@ msgstr ""
 "желает предложить вам нескольких своих войнов. Желаете нанять земных "
 "элементалов?\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2276
 msgid "You enter the structure of white stone pillars, and find nothing."
 msgstr ""
 "Вы входите в сооружение из белых каменных столбов, и ничего не находите."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2277
 msgid ""
 "White stone pillars support a roof that rises up to the sky. As you enter "
 "the structure, the dead air of the outside gives way to a whirling gust that "
@@ -3659,12 +3912,10 @@ msgstr ""
 "обратилось к вам едва слышимым шепотом: \"Зачем ты явился сюда? Ты пришел "
 "сюда искать помощи сил воздуха?\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2281
 msgid "No Fire Elementals approach you from the lava pool."
 msgstr ""
 "Ни один из огненных элементалов не вышел вам навстречу из огненного бассейна."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2282
 msgid ""
 "Beneath a structure that serves to hold in heat, Fire Elementals move about "
 "in a fiery pool of molten lava. A group of them approach you and offer their "
@@ -3674,11 +3925,9 @@ msgstr ""
 "движущихся в потоках раскаленной лавы. Несколько из них подошли к вам и "
 "предложили вам свою службу. Желаете нанять огненых элементалов?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2286
 msgid "A face forms in the water for a moment, and then is gone."
 msgstr "На мгновние в воде мелькнули черты чьих-то лиц, и исчези."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2287
 msgid ""
 "Crystalline structures cast shadows over a small reflective pool of water. "
 "You peer into the pool, and a face that is not your own peers back. It asks: "
@@ -3688,11 +3937,9 @@ msgstr ""
 "бассейн. В воде появилось лицо, не ваше отражение, которое обратилось к вам "
 "со словами: \"Желаешь обратиться за помошью к силам воды?\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2291
 msgid "This burial site is deathly still."
 msgstr "Это захоронение таит смертельную тишину."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2292
 msgid ""
 "Restless spirits of long dead warriors seeking their final resting place "
 "offer to join you in hopes of finding peace. Do you wish to recruit ghosts?"
@@ -3700,7 +3947,6 @@ msgstr ""
 "Неупокоенные духи давно погибших воинов ищут упокоения и соглашаются "
 "вступить в вашу армию в надежде найти упокоение. Желаете нанять призраков?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2328
 msgid ""
 "The City of the Dead is empty of life, and empty of unlife as well. Perhaps "
 "some undead will move in next week."
@@ -3708,7 +3954,6 @@ msgstr ""
 "В этом городе мертвецов жизни не наблюдается, нежити тоже. Может на "
 "следующей неделе кто-то из нежити забредет сюда."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2329
 msgid ""
 "Some Liches living here are willing to join your army for a price. Do you "
 "want to recruit Liches?"
@@ -3716,7 +3961,6 @@ msgstr ""
 "Кое-кто из личей, обитающих здесь, желает вступить в вашу армию за плату. "
 "Желаете нанять личей?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2330
 msgid ""
 "You've found the ruins of an ancient city, now inhabited solely by the "
 "undead. Will you search?"
@@ -3724,7 +3968,6 @@ msgstr ""
 "Вы нашли руины древнего города, ныне населенного лишь нежитью. Обследовать "
 "город?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2331
 msgid ""
 "Some of the surviving Liches are impressed by your victory over their "
 "fellows, and offer to join you for a price. Do you want to recruit Liches?"
@@ -3732,7 +3975,6 @@ msgstr ""
 "Уцелевшие личи прониклись вашей победой над их собратьями и предложили свои "
 "услуги за плату. Желаете нанять личей?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2335
 msgid ""
 "You've found one of those bridges that Trolls are so fond of living under, "
 "but there are none here. Perhaps there will be some next week."
@@ -3740,7 +3982,6 @@ msgstr ""
 "Вы нашли один из мостов, под которым обычно обитают тролли, но тут никого "
 "нет. Возможно на следующей неделе повится несколько."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2336
 msgid ""
 "Some Trolls living under a bridge are willing to join your army, but for a "
 "price. Do you want to recruit Trolls?"
@@ -3748,11 +3989,9 @@ msgstr ""
 "Несколько троллей, живущих под мостом, желают вступить в пашу армию, но не "
 "за даром. Хотите нанять троллей?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2337
 msgid "Trolls living under the bridge challenge you. Will you fight them?"
 msgstr "Тролли, живущие под мостом, вызывают вас на бой. Вы схватитесь с ними?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2338
 msgid ""
 "A few Trolls remain, cowering under the bridge. They approach you and offer "
 "to join your forces as mercenaries. Do you want to buy any Trolls?"
@@ -3760,7 +3999,6 @@ msgstr ""
 "Несколько троллей успели укрылисься под мостом. Они обратились к вам с "
 "предложением вступить в вашу армию. Вы хотите нанять троллей?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2342
 msgid ""
 "The Dragon city has no Dragons willing to join you this week. Perhaps a "
 "Dragon will become available next week."
@@ -3768,7 +4006,6 @@ msgstr ""
 "На этой неделе в городе нет драконов, желающий примкнуть к вам. На следующей "
 "неделе, возможэно, кто-то появится."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2343
 msgid ""
 "The Dragon city is willing to offer some Dragons for your army for a price. "
 "Do you wish to recruit Dragons?"
@@ -3776,7 +4013,6 @@ msgstr ""
 "Драконий город готов предложить вашему войску драконов, не бесплатно. "
 "Желаете нанять драконов?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2344
 msgid ""
 "You stand before the Dragon City, a place off-limits to mere humans. Do you "
 "wish to violate this rule and challenge the Dragons to a fight?"
@@ -3784,7 +4020,6 @@ msgstr ""
 "Вы стоите перед драконьим городом, местом, запретным для простых смертных. "
 "Соблаговолите ли вы нарушить это правило и бросить вызов драконам?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2345
 msgid ""
 "Having defeated the Dragon champions, the city's leaders agree to supply "
 "some Dragons to your army for a price. Do you wish to recruit Dragons?"
@@ -3792,11 +4027,9 @@ msgstr ""
 "После вашей победы над лучшими драконьими войнами отцы города согласились за "
 "плату предоставить вашему войску драконов. Желаете нанять драконов?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2404
 msgid "From the observation tower, you are able to see distant lands."
 msgstr "С вершины обзорной башни вы смогли разглядеть дальние земли."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2416
 msgid ""
 "The spring only refills once a week, and someone's already been here this "
 "week."
@@ -3804,7 +4037,6 @@ msgstr ""
 "Этот родник восполняется раз в неделю, а кто-то уже прикладывался к нему на "
 "это неделе."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2422
 msgid ""
 "A drink at the spring is supposed to give you twice your normal spell "
 "points, but you are already at that level."
@@ -3812,7 +4044,6 @@ msgstr ""
 "Глоток из родника обычно удваивает магическую энергию выпившего, однако у "
 "вас уже удвоенный уровень."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2433
 msgid ""
 "A drink from the spring fills your blood with magic! You have twice your "
 "normal spell points in reserve."
@@ -3820,7 +4051,6 @@ msgstr ""
 "Глоток из родника наполняет вашу кровь магией! Теперь у вас в запасе вдвое "
 "больше обычного магической энергии."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2452
 msgid ""
 "Recognizing you, the butler refuses to admit you. \"The master,\" he says, "
 "\"will not see the same student twice.\""
@@ -3828,7 +4058,6 @@ msgstr ""
 "Осмотрев как следует, лакей отказывается впустить вас.  \"Хозяин,\" - сказал "
 "он - \"не будет обучать вас дважды.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2472
 msgid ""
 "The butler admits you to see the master of the house. He trains you in the "
 "four skills a hero should know."
@@ -3836,7 +4065,6 @@ msgstr ""
 "Лакей пригласил вас встретится с хозяином. Он обучил вас всем четырем "
 "основным параметрам."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2482
 msgid ""
 "The butler opens the door and looks you up and down. \"You are neither "
 "famous nor diplomatic enough to be admitted to see my master,\" he sniffs. "
@@ -3846,7 +4074,6 @@ msgstr ""
 "такой уж дипломат, чтобы мой хозяин принял вас,\" - фыркнул он. - "
 "\"Возвращайтесь, когда сочтете себя достойным.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2525
 msgid ""
 "All of the %{monsters} you have in your army have been trained by the battle "
 "masters of the fort. Your army now contains %{monsters2}."
@@ -3854,23 +4081,22 @@ msgstr ""
 "Все %{monsters} в вашей армии были обучены мастерами форта. Теперь ваша "
 "армия состоит из %{monsters2}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2528
+#, fuzzy
 msgid ""
-"An unusual alliance of Orcs, Ogres, and Dwarves offer to train (upgrade) any "
+"An unusual alliance of Ogres, Orcs, and Dwarves offer to train (upgrade) any "
 "such troops brought to them. Unfortunately, you have none with you."
 msgstr ""
 "Необычный союз орков, огров и гномов предлагает вам потренеровать (улучшить) "
 "любые подобные им войска. К сожалению у вас при себе таких нет."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2539
 msgid "All of your %{monsters} have been upgraded into %{monsters2}."
 msgstr "Все ваши %{monsters} были улучшены до %{monsters2}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2542
+#, fuzzy
 msgid ""
 "A blacksmith working at the foundry offers to convert all Pikemen and "
 "Swordsmen's weapons brought to him from iron to steel. He also says that he "
-"knows a process that will convert Iron Golems into Steel Golems.  "
+"knows a process that will convert Iron Golems into Steel Golems. "
 "Unfortunately, you have none of these troops in your army, so he can't help "
 "you."
 msgstr ""
@@ -3879,7 +4105,6 @@ msgstr ""
 "железных големов в стальные. К сожалению, никого из них нет в вашей армии, и "
 "он не может вам ничем помочь."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2600
 msgid ""
 "A retired captain living on this refurbished fishing platform offers to sell "
 "you maps of the sea he made in his younger days for 1,000 gold. Do you wish "
@@ -3888,7 +4113,6 @@ msgstr ""
 "Бывший капитан, живущий на этом подновленном рыболовном причале, предлагает "
 "вам карты, составленные в прежние дни, за 1000 золотых. Желаете их купить?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2613
 msgid ""
 "The captain sighs. \"You don't have enough money, eh?  You can't expect me "
 "to give my maps away for free!\""
@@ -3896,11 +4120,9 @@ msgstr ""
 "Капитан вздыхает. \"Вам не хватает денег, да? Вы же не думаете что я отдам "
 "их вам просто так!\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2644
 msgid "You find %{artifact}."
 msgstr "Вы нашли %{artifact}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2670
 msgid ""
 "You come upon an obelisk made from a type of stone you have never seen "
 "before. Staring at it intensely, the smooth surface suddenly changes to an "
@@ -3913,11 +4135,9 @@ msgstr ""
 "торопливо срисовываете его, и знаки исчезают так же внезапно, как и "
 "появились."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2674
 msgid "You have already been to this obelisk."
 msgstr "Вы уже посещали этот обелиск."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2686
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"It is good to see "
 "you, my student. I hope my teachings have helped you.\""
@@ -3925,7 +4145,6 @@ msgstr ""
 "При вашем приближении древесные глаза засветились восторгом. \"Рад снова "
 "тебя видеть, мой ученик. Я надеюсь мои знания тебе помогли.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2698
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"Ahh, an "
 "adventurer! Allow me to teach you a little of what I have learned over the "
@@ -3934,39 +4153,38 @@ msgstr ""
 "При вашем приближении древесные глаза засветились восторгом. \"А, странник! "
 "Позволь преподать тебе малую толику того, что я выучил за годы.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2707
 msgid "Upon your approach, the tree opens its eyes in delight."
 msgstr "При вашем приближении древесные глаза засветились восторгом."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2709
 msgid ""
 "\"Ahh, an adventurer! I will be happy to teach you a little of what I have "
 "learned over the ages for a mere %{count} %{res}.\""
 msgstr ""
 "\"Ahh, an adventurer! I will be happy to teach you a little of what I have "
 "learned over the ages for a mere %{count} %{res}.\"\"Ооо, дорогой путник! Я "
-"буду счастлив научить тебя небольшой части моих знаний всего-лишь за %"
-"{count} %{res}.\""
+"буду счастлив научить тебя небольшой части моих знаний всего-лишь за "
+"%{count} %{res}.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2711
 msgid "(Just bury it around my roots.)"
 msgstr "(Просто зарой их вокруг моих корней.)"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2718
 msgid "Tears brim in the eyes of the tree."
 msgstr "Слезы потекли по краям глаз дерева."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2720
 msgid "\"I need %{count} %{res}.\""
 msgstr "\"Мне нужно %{count} %{res}.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2722
 msgid "it whispers. (sniff) \"Well, come back when you can pay me.\""
 msgstr ""
 "прошептало оно. (втянув воздух) \"Ну, возвращайся когда сможешь мне "
 "заплатить.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2752
+msgid ""
+"Nestled among the trees sits a blind seer. After explaining the intent of "
+"your journey, the seer activates his crystal ball, allowing you to see the "
+"strengths and weaknesses of your opponents."
+msgstr ""
+
 msgid ""
 "The entrance to the cave is dark, and a foul, sulfurous smell issues from "
 "the cave mouth. Will you enter?"
@@ -3974,7 +4192,6 @@ msgstr ""
 "Вход в пещеру сияет черной дырой, из которой тянет тошнотворным сернистым "
 "зловонием. Отважитесь ли вы войти?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2764
 msgid ""
 "You find a powerful and grotesque Demon in the cave. \"Today,\" it rasps, "
 "\"you will fight and surely die. But I will give you a choice of deaths. You "
@@ -3986,7 +4203,6 @@ msgstr ""
 "можешь дратся со мной или же с моими слугами. Предпочитаешь сразиться с "
 "моими слугами?\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2774
 msgid ""
 "Upon defeating the daemon's servants, you find a hidden cache with %{count} "
 "gold."
@@ -3994,7 +4210,6 @@ msgstr ""
 "После победы над слугами демона вы обнаружили тайник с золотом из %{count} "
 "монет."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2789
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and receive %{exp} experience points."
@@ -4002,7 +4217,6 @@ msgstr ""
 "Демон жутко кричит и бросается в атаку! После жестокой, но короткой битвы вы "
 "победили монстра и получили %{exp} очков опыта."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2799
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and find the %{art} in the back of the cave."
@@ -4010,16 +4224,15 @@ msgstr ""
 "Демон выкрикнул свой вызов и бросился в бой! После краткой, но отчаянной "
 "схватки вы прикончили чудовщие и нашли %{art} в глубине пещеры.."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2809
+#, fuzzy
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
-"battle, you slay the monster and receive %{exp) experience points and %"
-"{count} gold."
+"battle, you slay the monster and receive %{exp} experience points and "
+"%{count} gold."
 msgstr ""
 "Демон жутко кричит и бросается в атаку! После жестокой, но короткой битвы вы "
 "победили монстра и получили %{exp} очков опыта и %{count} золота."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2824
 msgid ""
 "The Demon leaps upon you and has its claws at your throat before you can "
 "even draw your sword. \"Your life is mine,\" it says. \"I will sell it back "
@@ -4029,7 +4242,6 @@ msgstr ""
 "в моих рукаххх,\" - шипит он. - \"давай золото, %{count} монет, и убирайся, "
 "пока я добрый.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2825
 msgid ""
 "Seeing that you do not have %{count} gold, the demon slashes you with its "
 "claws, and the last thing you see is a red haze."
@@ -4037,15 +4249,12 @@ msgstr ""
 "Даже %{count} жалких монет не наберется у вас. Демон сжимает когти и перед "
 "глазами встает красная пелена. Больше вы ничего не видите..."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2850
 msgid "Except for evidence of a terrible battle, the cave is empty."
 msgstr "Если не считать следов ужасной битвы, пещера пуста."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2875
 msgid "For %{gold} gold, the alchemist will remove it for you. Do you pay?"
 msgstr "За %{gold} золотом, алхимик поможет Вам. Вы заплатите?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2886
 msgid ""
 "You hear a voice from behind the locked door, \"You don't have enough gold "
 "to pay for my services.\""
@@ -4053,13 +4262,11 @@ msgstr ""
 "Вы слышите голос из-за закрытой двери, \"Проходите мимо... У Вас не "
 "достаточно золота, чтобы заплатить за мои услуги. \""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2889
 msgid ""
 "You hear a voice from high above in the tower, \"Go away! I can't help you!\""
 msgstr ""
 "Вы услышали голос с вершины башни: \"Убирайтесь! Я не могу вам помочь!\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2901
 msgid ""
 "The head groom approaches you and speaks, \"You already have a fine horse, "
 "and have no inexperienced cavalry which might make use of our trained war "
@@ -4069,7 +4276,6 @@ msgstr ""
 "конь под седлом и в вашей армии нет неопытных всадников, кого мы могли бы "
 "обучить искуству езды на боевых скакунах.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2904
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, his "
@@ -4081,7 +4287,6 @@ msgstr ""
 "вам быстрее добратся до нужного места, но его силхватит на 7 дней. К тому "
 "же, мы можем дать новых коней и вашим всадникам, но у вас их нет\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2907
 msgid ""
 "The head groom speaks to you, \"That is a fine looking horse you have. I am "
 "afraid we can give you no better, but the horses your cavalry are riding "
@@ -4092,7 +4297,6 @@ msgstr ""
 "прекрасный конь. Я боюсь у нас не найдется лучше, но зато мы можем дать "
 "новых коней вашим всадникам.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2910
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, he will "
@@ -4103,11 +4307,9 @@ msgstr ""
 "вам быстрее добратся до нужного места, но его сил хватит на 7 дней. К тому "
 "же, мы можем дать новых коней и вашим всадникам.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2937
 msgid "The Arena guards turn you away."
 msgstr "Стража арены преградила вам доргоу и не пропустила внутрь."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2954
 msgid ""
 "As the sirens sing their eerie song, your small, determined army manages to "
 "overcome the urge to dive headlong into the sea."
@@ -4116,7 +4318,6 @@ msgstr ""
 "чтобы послушать их пение, которое запросто может погубить всех в морской "
 "пучине."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2959
 msgid ""
 "You have your crew stop up their ears with wax before the sirens' eerie song "
 "has any chance of luring them to a watery grave. An eerie wailing song "
@@ -4128,7 +4329,6 @@ msgstr ""
 "в воду под действием этих чар и утонули в морской пучине. Для вас это был "
 "хороший урок, давший %{exp} очков опыта."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2979
 msgid ""
 "In a dazzling display of daring, you break into the local jail and free the "
 "hero imprisoned there, who, in return, pledges loyalty to your cause."
@@ -4136,7 +4336,6 @@ msgstr ""
 "С ослепительной отвагой вы ворвались в местную темницу и освободили героя, "
 "томящегося здесь. В благодарность он поклялся служить вам."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2995
 msgid ""
 "You already have %{count} heroes, and regretfully must leave the prisoner in "
 "this jail to languish in agony for untold days."
@@ -4144,7 +4343,6 @@ msgstr ""
 "У вас уже %{count} героев. К сожалению, вам придется оставить томится этого "
 "героя в темнице еще неопределенное время."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3006
 msgid ""
 "You enter a rickety hut and talk to the magician who lives there. He tells "
 "you of places near and far which may aid you in your journeys."
@@ -4153,11 +4351,9 @@ msgstr ""
 "местах, которые ему доводилось видеть. Это может пригодится вам в ваших "
 "путешествиях."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3019
 msgid "This eye seems to be intently studying its surroundings."
 msgstr "Кажется, этот глаз внимательно изучает окрестности."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3031
 msgid ""
 "\"I have a riddle for you,\" the Sphinx says. \"Answer correctly, and you "
 "shall be rewarded. Answer incorrectly, and you shall be eaten. Do you accept "
@@ -4166,11 +4362,15 @@ msgstr ""
 "\"Есть у меня загадка для тебя,\" - сказал Сфинкс. \"Ответишь верно - "
 "получишь награду. Ошибешься - и я тебя съем. Принимаешь ли ты мой вызов?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:3033
-msgid "The Sphinx asks you the following riddle: %{riddle}. Your answer?"
+#, fuzzy
+msgid ""
+"The Sphinx asks you the following riddle:\n"
+" \n"
+"'%{riddle}'\n"
+" \n"
+"Your answer?"
 msgstr "Сфинкс загадал вам следующую загадку: %{riddle}.\\nВаш ответ?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:3041
 msgid ""
 "Looking somewhat disappointed, the Sphinx sighs. You've answered my riddle "
 "so here's your reward. Now begone."
@@ -4178,7 +4378,6 @@ msgstr ""
 "Несколько разочарованно Сфинкс промолвил. \"Ты дал верный ответ, вот твоя "
 "награда. А теперь убирайся.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3068
 msgid ""
 "\"You guessed incorrectly,\" the Sphinx says, smiling. The Sphinx swipes at "
 "you with a paw, knocking you to the ground. Another blow makes the world go "
@@ -4187,11 +4386,9 @@ msgstr ""
 "\"Твоя догадка ошибочна,\" - сказал, улыбаясь, Сфинкс. Ухмыляющийся Сфинкс "
 "повалил вас на землю и мир окутала непроглядная тьма. Ням-ням."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3076
 msgid "You come across a giant Sphinx. The Sphinx remains strangely quiet."
 msgstr "Вы подошли к огромному Сфинксу, но он даже не шелохнулся."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3089
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -4203,7 +4400,6 @@ msgstr ""
 " \"Произнеси волшебное слово и сможешь пройти\"\n"
 " Вы произносите волшебное слово и магический барьер исчезает.."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3099
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -4215,7 +4411,6 @@ msgstr ""
 " \"Произнеси волшебное слово и сможешь пройти\"\n"
 " Вы произносите всякие разные нехорошие слова, но ничего не происходит.."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3109
 msgid ""
 "You enter the tent and see an old woman gazing into a magic gem. She looks "
 "up and says,\n"
@@ -4227,328 +4422,15 @@ msgstr ""
 "тайной магии... Сам БО обучал меня древним хитростям.. Ты неучь.. не знаешь "
 "кто такой БО? .. Ну да ладно, у меня есть ответ, который Вы ищете.\""
 
-#: ../fheroes2/heroes/heroes_base.cpp:401
 msgid ""
 "That spell costs %{mana} mana. You only have %{point} mana, so you can't "
 "cast the spell."
 msgstr "Заклинание требует %{mana} очков магии. У вас только %{point}."
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Lord Kilburn"
-msgstr "Лорд Килбурн"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Sir Gallanth"
-msgstr "Сэр Галлант"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ector"
-msgstr "Эктор"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Gwenneth"
-msgstr "Гвиннет"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Tyro"
-msgstr "Тиро"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ambrose"
-msgstr "Амброс"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ruby"
-msgstr "Руби"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Maximus"
-msgstr "Максимус"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Dimitry"
-msgstr "Димитрий"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Thundax"
-msgstr "Тандакс"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Fineous"
-msgstr "Файнеус"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jojosh"
-msgstr "Йойош"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Crag Hack"
-msgstr "Крэг Хэк"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jezebel"
-msgstr "Изабэль"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jaclyn"
-msgstr "Йаслин"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Ergon"
-msgstr "Эргон"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Tsabu"
-msgstr "Тсабу"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Atlas"
-msgstr "Атлас"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Astra"
-msgstr "Астра"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Natasha"
-msgstr "Наташа"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Troyan"
-msgstr "Троян"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Vatawna"
-msgstr "Ватана"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Rebecca"
-msgstr "Ребекка"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Gem"
-msgstr "Джем"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Ariel"
-msgstr "Ариэль"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Carlawn"
-msgstr "Карлан"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Luna"
-msgstr "Луна"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Arie"
-msgstr "Эйри"
-
-#: ../fheroes2/heroes/heroes.cpp:61 ../fheroes2/resource/maps_text.cpp:59
-msgid "Alamar"
-msgstr "Аламар"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Vesper"
-msgstr "Веспер"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Crodo"
-msgstr "Кродо"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Barok"
-msgstr "Барок"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Kastore"
-msgstr "Кастор"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Agar"
-msgstr "Агар"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Falagar"
-msgstr "Фалагар"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Wrathmont"
-msgstr "Ратмонд"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myra"
-msgstr "Мира"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Flint"
-msgstr "Флинт"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Dawn"
-msgstr "Дан"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Halon"
-msgstr "Хейлон"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myrini"
-msgstr "Мурини"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Wilfrey"
-msgstr "Уилфри"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Sarakin"
-msgstr "Саракин"
-
-#: ../fheroes2/heroes/heroes.cpp:63 ../fheroes2/resource/maps_text.cpp:377
-msgid "Kalindra"
-msgstr "Калиндра"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Mandigal"
-msgstr "Мандигал"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zom"
-msgstr "Зом"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Darlana"
-msgstr "Дарлана"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zam"
-msgstr "Зам"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Ranloo"
-msgstr "Рэнлу"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Charity"
-msgstr "Чарити"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Rialdo"
-msgstr "Риалдо"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Roxana"
-msgstr "Роксана"
-
-#: ../fheroes2/heroes/heroes.cpp:65 ../fheroes2/resource/maps_text.cpp:557
-msgid "Sandro"
-msgstr "Сандро"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Celia"
-msgstr "Келия"
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:552
-msgid "Roland"
-msgstr "Роланд"
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Lord Corlagon"
-msgstr "Лорд Корлагон"
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Sister Eliza"
-msgstr "Сестра Элиза"
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:88
-msgid "Archibald"
-msgstr "Арчибальд"
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:403
-msgid "Lord Halton"
-msgstr "Лорд Халтон"
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Brother Bax"
-msgstr "Брат Бэкс"
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Solmyr"
-msgstr "Сольмир"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:194
-msgid "Dainwin"
-msgstr "Дейнвин"
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Mog"
-msgstr "Моуг"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:760
-msgid "Uncle Ivan"
-msgstr "Дядя Ваня"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:373
-msgid "Joseph"
-msgstr "Джозефф"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:285
-msgid "Gallavant"
-msgstr "Галлавант"
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Elderian"
-msgstr "Элдериан"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:179
-msgid "Ceallach"
-msgstr "Каллах"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:229
-msgid "Drakonia"
-msgstr "Драконда"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:422
-msgid "Martine"
-msgstr "Мартин"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:370
-msgid "Jarkonas"
-msgstr "Ярконас"
-
-#: ../fheroes2/heroes/heroes.cpp:943
-msgid ""
-"You must purchase a spell book to use the mage guild, but you currently have "
-"no room for a spell book. Try giving one of your artifacts to another hero."
-msgstr ""
-"Чтобы Вас пропустили в Гильдию Магов, Вы должны купить книгу заклинаний, но "
-"к сожалению, Ваша сумка и так переполнена артифактами."
-
-#: ../fheroes2/heroes/heroes.cpp:953
-msgid "The three Anduran artifacts magically combine into one."
-msgstr "Три магических артифакта Андурана, объединяются в один."
-
-#: ../fheroes2/heroes/heroes.cpp:1059
-msgid "To cast spells, you must first buy a spell book for %{gold} gold."
-msgstr ""
-"Чтобы Вас пропустили в Гильдию Магов, Вы должны купить книгу заклинаний за %"
-"{gold} золотых."
-
-#: ../fheroes2/heroes/heroes.cpp:1067
-msgid "Unfortunately, you seem to be a little short of cash at the moment."
-msgstr "К сожалению, у вас не хватает денег."
-
-#: ../fheroes2/heroes/heroes.cpp:1081
-msgid "Do you wish to buy one?"
-msgstr "Желаете купить?"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:72
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:55
-msgid "%{name} the %{race} ( Level %{level} )"
+#, fuzzy
+msgid "%{name} the %{race} (Level %{level})"
 msgstr "%{name} %{race} (Уровень %{level})"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:118
 msgid ""
 "'Grouped' combat formation bunches your army together in the center of your "
 "side of the battlefield."
@@ -4556,99 +4438,79 @@ msgstr ""
 "Сомкнутый боевой порядок регламентирует отрядам вашей армии организовать "
 "плотный ряд в центре поля боя."
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:161
 msgid "Are you sure you want to dismiss this Hero?"
 msgstr "Вы действительно хотите уволить героя?"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:341
 #, fuzzy
 msgid "View Stats"
 msgstr "Показать артефакты"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:344
-msgid "View Morale Info"
-msgstr "Мораль"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:347
-msgid "View Luck Info"
-msgstr "Удача"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:350
 msgid "View Experience Info"
 msgstr "Опыт"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:353
 msgid "View Spell Points Info"
 msgstr "Очки магии"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:356
 msgid "Set army combat formation to 'Spread'"
 msgstr "Разомкнутый строй"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:359
 msgid "Set army combat formation to 'Grouped'"
 msgstr "Сомкнутый строй"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:362
-msgid "Exit hero"
-msgstr "Закрыть"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:369
-msgid "Dismiss hero"
-msgstr "Уволить"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:373
-msgid "Show prev heroes"
-msgstr "Предыдущий герой"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:376
-msgid "Show next heroes"
-msgstr "Следующий герой"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:379
-msgid "Hero Screen"
+#, fuzzy
+msgid "Exit Hero Screen"
 msgstr "Экран героя"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:39
-msgid "Bad Morale"
-msgstr "Плохая Мораль"
+msgid "You cannot dismiss a hero in a castle"
+msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:42
-msgid "Neutral Morale"
-msgstr "Нейтральная Мораль"
+msgid "Dismissal of %{name} the %{race} is prohibited by scenario"
+msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:47
-msgid "Good Morale"
+#, fuzzy
+msgid "Dismiss %{name} the %{race}"
+msgstr "%{name} %{race}"
+
+#, fuzzy
+msgid "Show previous hero"
+msgstr "Предыдущий город"
+
+#, fuzzy
+msgid "Show next hero"
+msgstr "Следующий герой"
+
+#, fuzzy
+msgid "Blood Morale"
 msgstr "Хорошая Мораль"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:61
-msgid "Bad Luck"
-msgstr "Плохая Удача"
+#, fuzzy
+msgid "%{morale} Morale"
+msgstr "Нормальная"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:64
-msgid "Neutral Luck"
-msgstr "Нейтральная Удача"
+msgid "%{luck} Luck"
+msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:69
-msgid "Good Luck"
-msgstr "Хорошая Удача"
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:113
-#: ../fheroes2/heroes/heroes_indicator.cpp:159
-#: ../fheroes2/heroes/skill.cpp:197
-msgid "Current Modifiers:"
+#, fuzzy
+msgid "Current Luck Modifiers:"
 msgstr "Текущие Модификаторы:"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:195
-msgid "Current experience %{exp1} Next level %{exp2}."
+#, fuzzy
+msgid "Current Morale Modifiers:"
+msgstr "Текущие Модификаторы:"
+
+#, fuzzy
+msgid "Entire army is undead, so morale does not apply."
+msgstr "Мораль неприменима к нежити."
+
+#, fuzzy
+msgid ""
+"Current experience %{exp1}.\n"
+" Next level %{exp2}."
 msgstr "Текущий опыт %{exp1} . Следующий уровень %{exp2}."
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:215
 msgid "Level %{level}"
 msgstr "Уровень %{level}"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:226
 msgid ""
 "%{name} currently has %{point} spell points out of a maximum of %{max}. The "
 "maximum number of spell points is 10 times your knowledge. It is "
@@ -4659,88 +4521,76 @@ msgstr ""
 "число очков магии является произведением 10 на количество очков Знания. "
 "Допускается иметь очков магии выше максимума после посещения специльных мест."
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:65
 msgid "%{name1} meets %{name2}"
 msgstr "%{name1} встретил %{name2}"
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:396
-#: ../fheroes2/heroes/heroes_meeting.cpp:406
 msgid " and "
 msgstr " и "
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:414
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
 msgstr ""
 "%{teacher}, который %{level} %{scholar} знает много магичиских секретов, "
 "изучает %{spells1} от %{learner}, и обучает %{spells2} для %{learner}."
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:417
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}."
 msgstr ""
 "%{teacher}, который %{level} %{scholar} знает много магичиских секретов, "
 "изучает %{spells1} от %{learner}"
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:420
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches %"
-"{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches "
+"%{spells2} to %{learner}."
 msgstr ""
 "%{teacher}, который %{level} %{scholar} знает много магичиских секретов, "
 "обучает %{spells2} для %{learner}."
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:431
 msgid "Scholar Ability"
 msgstr "Обучение Магии"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:83 ../fheroes2/spell/spell.cpp:109
 msgid "Town Portal"
 msgstr "Портал в город"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:86
 msgid "Select town to port to."
 msgstr "Выберите Город для Телепортации:"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:106
 msgid "Your hero is too tired to cast this spell today. Try again tomorrow."
 msgstr ""
 "Ваш герой очень устал, и не сможет применять магию сегодня. Попробуйте еще "
 "раз завтра."
 
-#: ../fheroes2/heroes/heroes_spell.cpp:187
 #, fuzzy
 msgid "%{spell} failed!!!"
 msgstr "Неудачный вызов магии!"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:236
+msgid "This spell is already in use."
+msgstr ""
+
 msgid "Enemy heroes are now fully identifiable."
 msgstr "Все вражеские Герои опознаны."
 
-#: ../fheroes2/heroes/heroes_spell.cpp:362
-#: ../fheroes2/heroes/heroes_spell.cpp:386
-msgid "No available towns. Spell Failed!!!"
+#, fuzzy
+msgid "This spell cannot be used on a boat."
+msgstr "В этом городе нельзя построить замок."
+
+msgid "This spell can be casted only nearby water."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"No available towns.\n"
+"Spell Failed!!!"
 msgstr "Нет доступных городов для этой магии!!!"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:458
-msgid "I fear these creatures are in the mood for a fight."
-msgstr "Скорей всего, эта армия монстров будет сражаться."
+#, fuzzy
+msgid ""
+"Nearest town occupied.\n"
+"Spell Failed!!!"
+msgstr "Нет доступных городов для этой магии!!!"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:462
-msgid "The creatures are willing to join us!"
-msgstr "Эта армия монстров будет присоединяться!"
-
-#: ../fheroes2/heroes/heroes_spell.cpp:467
-msgid "All the creatures will join us..."
-msgstr "Все монстры присоединяться к вам..."
-
-#: ../fheroes2/heroes/heroes_spell.cpp:479
-msgid "These weak creatures will surely flee before us."
-msgstr "Эта трусливая армия убежит от Вас..."
-
-#: ../fheroes2/heroes/heroes_spell.cpp:488
 msgid ""
 "You must be within %{count} spaces of a monster for the Visions spell to "
 "work."
@@ -4748,403 +4598,330 @@ msgstr ""
 "Вы должны находиться не более %{count} ходов от армии монстров для магии "
 "Видение."
 
-#: ../fheroes2/heroes/heroes_spell.cpp:505
+msgid "I fear these creatures are in the mood for a fight."
+msgstr "Скорей всего, эта армия монстров будет сражаться."
+
+msgid "The creatures are willing to join us!"
+msgstr "Эта армия монстров будет присоединяться!"
+
+msgid "All the creatures will join us..."
+msgstr "Все монстры присоединяться к вам..."
+
+msgid "These weak creatures will surely flee before us."
+msgstr "Эта трусливая армия убежит от Вас..."
+
 msgid ""
 "You must be standing on the entrance to a mine (sawmills and alchemists "
 "don't count) to cast this spell."
 msgstr "Вы должны стать поближе к руднику, для использования этой магии."
 
-#: ../fheroes2/heroes/skill.cpp:151
-msgid "Power"
-msgstr "Сила магии"
-
-#: ../fheroes2/heroes/skill.cpp:172
 msgid "Your attack skill is a bonus added to each creature's attack skill."
 msgstr "Навык Атаки дает бонус к навыку атаки каждого существа в армии героя."
 
-#: ../fheroes2/heroes/skill.cpp:177
 msgid "Your defense skill is a bonus added to each creature's defense skill."
 msgstr ""
 "Навык Защиты дает бонус к навыку защиты каждого существа в армии героя."
 
-#: ../fheroes2/heroes/skill.cpp:182
 msgid "Your spell power determines the length or power of a spell."
 msgstr "Навык Силы магии определяет длительность действия или силу заклинания."
 
-#: ../fheroes2/heroes/skill.cpp:187
+#, fuzzy
 msgid ""
 "Your knowledge determines how many spell points your hero may have. Under "
-"normal cirumstances, a hero is limited to 10 spell points per level of "
+"normal circumstances, a hero is limited to 10 spell points per level of "
 "knowledge."
 msgstr "Уровень Знаний отвечает за количество очков магии героя."
 
-#: ../fheroes2/heroes/skill.cpp:214
+msgid "Current Modifiers:"
+msgstr "Текущие Модификаторы:"
+
 msgid "skill|Basic"
 msgstr "skill|Базовый"
 
-#: ../fheroes2/heroes/skill.cpp:214
 msgid "skill|Advanced"
 msgstr "skill|Продвинутый"
 
-#: ../fheroes2/heroes/skill.cpp:214
 msgid "skill|Expert"
 msgstr "skill|Эксперт"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Pathfinding"
 msgstr "Следопыт"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Archery"
 msgstr "Стрельба"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Logistics"
 msgstr "Логистика"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Scouting"
 msgstr "Разведка"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Diplomacy"
 msgstr "Дипломатия"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Navigation"
 msgstr "Навигация"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Leadership"
 msgstr "Лидерство"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Wisdom"
 msgstr "Мудрость"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Mysticism"
 msgstr "Мистицизм"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Ballistics"
 msgstr "Баллистика"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Eagle Eye"
 msgstr "Орлиный взор"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Necromancy"
 msgstr "Некромантия"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Estates"
 msgstr "Казначей"
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Basic Pathfinding"
 msgstr "Базовый Следопыт"
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Advanced Pathfinding"
 msgstr "Продвинутый Следопыт"
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Expert Pathfinding"
 msgstr "Экспертный Следопыт"
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Basic Archery"
 msgstr "Базовая Стрельба"
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Advanced Archery"
 msgstr "Продвинутая Стрельба"
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Expert Archery"
 msgstr "Экспертная Стрельба"
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Basic Logistics"
 msgstr "Базовая Логистика"
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Advanced Logistics"
 msgstr "Продвинутая Логистика"
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Expert Logistics"
 msgstr "Экспертная Логистика"
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Basic Scouting"
 msgstr "Базовая Разведка"
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Advanced Scouting"
 msgstr "Продвинутая Разведка"
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Expert Scouting"
 msgstr "Экспертная Разведка"
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Basic Diplomacy"
 msgstr "Базовая Дипломатия"
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Advanced Diplomacy"
 msgstr "Продвинутая Дипломатия"
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Expert Diplomacy"
 msgstr "Экспертная Дипломатия"
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Basic Navigation"
 msgstr "Базовая Навигация"
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Advanced Navigation"
 msgstr "Продвинутая Навигация"
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Expert Navigation"
 msgstr "Экспертная Навигация"
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Basic Leadership"
 msgstr "Базовое Лидерство"
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Advanced Leadership"
 msgstr "Продвинутое Лидерство"
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Expert Leadership"
 msgstr "Экспертное Лидерство"
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Basic Wisdom"
 msgstr "Базовая Мудрость"
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Advanced Wisdom"
 msgstr "Продвинутая Мудрость"
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Expert Wisdom"
 msgstr "Экспертная Мудрость"
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Basic Mysticism"
 msgstr "Базовый Мистицизм"
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Advanced Mysticism"
 msgstr "Продвинутый Мистицизм"
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Expert Mysticism"
 msgstr "Экспертный Мистицизм"
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Basic Luck"
 msgstr "Базовая Удача"
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Advanced Luck"
 msgstr "Продвинутая Удача"
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Expert Luck"
 msgstr "Экспертная Удача"
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Basic Ballistics"
 msgstr "Базовая Баллистика"
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Advanced Ballistics"
 msgstr "Продвинутая Баллистика"
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Expert Ballistics"
 msgstr "Экспертная Баллистика"
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Basic Eagle Eye"
 msgstr "Базовый Орлиный Взор"
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Advanced Eagle Eye"
 msgstr "Продвинутый Орлиный Взор"
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Expert Eagle Eye"
 msgstr "Экспертный Орлиный Взор"
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Basic Necromancy"
 msgstr "Базовая Некромантия"
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Advanced Necromancy"
 msgstr "Продвинутая Некромантия"
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Expert Necromancy"
 msgstr "Экспертная Некромантия"
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Basic Estates"
 msgstr "Базовый Казначей"
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Advanced Estates"
 msgstr "Продвинутый Казначей"
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Expert Estates"
 msgstr "Эксперт Казначей"
 
-#: ../fheroes2/heroes/skill.cpp:406
-msgid "Allows you to negotiate with monsters who are weaker than your group."
+#, fuzzy
+msgid " allows you to negotiate with monsters who are weaker than your group."
 msgstr ""
 "Позволяет вести переговоры с армией (которая слабее вашей) об примсоединении."
 
-#: ../fheroes2/heroes/skill.cpp:421
-msgid "Allows your hero to learn third level spells."
+#, fuzzy
+msgid "All of the creatures may offer to join you."
+msgstr ""
+"Позволяет присоединиться к Вашей армии, примерно %{count} процент существ."
+
+#, fuzzy
+msgid " allows your hero to learn third level spells."
 msgstr "Позволяет изучать заклинания 3-го круга."
 
-#: ../fheroes2/heroes/skill.cpp:423
-msgid "Allows your hero to learn fourth level spells."
+#, fuzzy
+msgid " allows your hero to learn fourth level spells."
 msgstr "Позволяет изучать заклинания 4-го круга."
 
-#: ../fheroes2/heroes/skill.cpp:425
-msgid "Allows your hero to learn fifth level spells."
+#, fuzzy
+msgid " allows your hero to learn fifth level spells."
 msgstr "Позволяет изучать все возможные заклинания."
 
-#: ../fheroes2/heroes/skill.cpp:440
+#, fuzzy
 msgid ""
-"Gives your hero's catapult shots a greater chance to hit and do damage to "
+" gives your hero's catapult shots a greater chance to hit and do damage to "
 "castle walls."
 msgstr ""
 "Дает выстрелам катапульты больший шанс поразить и причинить вред стенам "
 "замка."
 
-#: ../fheroes2/heroes/skill.cpp:442
+#, fuzzy
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot has a greater chance "
-"to hit and do damage to castle walls."
+" gives your hero's catapult an extra shot, and each shot has a greater "
+"chance to hit and do damage to castle walls."
 msgstr ""
 "Дает сделать катапульте дополнительный выстрел, а так же каждому выстрелу "
 "придает больший шанс поразить и причинить вред стенам замка."
 
-#: ../fheroes2/heroes/skill.cpp:444
+#, fuzzy
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot automatically "
+" gives your hero's catapult an extra shot, and each shot automatically "
 "destroys any wall, except a fortified wall in a Knight town."
 msgstr ""
 "Дает сделать катапульте дополнительный выстрел, и каждый выстрел "
 "гарантированно разрушит любую стену, за исключением укреплений в рыцарском "
 "замке."
 
-#: ../fheroes2/heroes/skill.cpp:876 ../fheroes2/heroes/skill.cpp:977
-msgid "View %{skill} Info"
-msgstr "Информация об умении %{skill}"
-
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:108
 msgid "Blue"
 msgstr "Синий"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:111
 msgid "Green"
 msgstr "Зеленый"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:114
 msgid "Red"
 msgstr "Красный"
 
-#: ../fheroes2/kingdom/color.cpp:32
 msgid "Yellow"
 msgstr "Желтый"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:112
 msgid "Orange"
 msgstr "Оранжевый"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:113
 msgid "Purple"
 msgstr "Фиолетовый"
 
-#: ../fheroes2/kingdom/color.cpp:107
 msgid "Aqua"
 msgstr "Изумрудный"
 
-#: ../fheroes2/kingdom/color.cpp:109
 msgid "Brown"
 msgstr "Коричневый"
 
-#: ../fheroes2/kingdom/color.cpp:110 ../fheroes2/resource/resource.cpp:283
 msgid "Gold"
 msgstr "Золото"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:238
 msgid "Hero/Stats"
 msgstr "Герой/Характеристика"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:241
 msgid "Skills"
 msgstr "Навыки"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:244
 msgid "Artifacts"
 msgstr "Артифакты"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:473
 msgid "Town/Castle"
 msgstr "Город/Замок"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:476
 msgid "Garrison"
 msgstr "Гарнизон"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:566
 msgid "Gold Per Day:"
 msgstr "Доход золота в день:"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Cursed"
 msgstr "Проклятая"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Awful"
 msgstr "Ужасная"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Bad"
 msgstr "Плохая"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Normal"
 msgstr "Нормальная"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Good"
 msgstr "Хорошая"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Great"
 msgstr "Отличная"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Irish"
 msgstr "Фортуна!"
 
-#: ../fheroes2/kingdom/luck.cpp:48
 msgid ""
 "Bad luck sometimes falls on your armies in combat, causing their attacks to "
 "only do half damage."
@@ -5152,7 +4929,6 @@ msgstr ""
 "Плохая удача иногда посещает ваши войска в бою, неудача вынуждает отряд "
 "атаковать только в полсилы."
 
-#: ../fheroes2/kingdom/luck.cpp:49
 msgid ""
 "Neutral luck means your armies will never get lucky or unlucky attacks on "
 "the enemy."
@@ -5160,7 +4936,6 @@ msgstr ""
 "Нормальная удача подразумевает, что ваши войска не буду получать бонусов "
 "удачи или неудачи."
 
-#: ../fheroes2/kingdom/luck.cpp:50
 msgid ""
 "Good luck sometimes lets your armies get lucky attacks (double strength) in "
 "combat."
@@ -5168,39 +4943,30 @@ msgstr ""
 "Хорошая удача иногда позволяет вашим отрядам проводить удачные, наносящие "
 "двойной урон, атаки в сражении."
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Treason"
 msgstr "В панике!"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Awful"
 msgstr "Ужасная"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Poor"
 msgstr "Плохая"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Normal"
 msgstr "Нормальная"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Good"
 msgstr "Хорошая"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Great"
 msgstr "Отличная"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Blood!"
 msgstr "В Бой!"
 
-#: ../fheroes2/kingdom/morale.cpp:48
 msgid "Bad morale may cause your armies to freeze in combat."
 msgstr "Плохая мораль может заставить отряд застыть на месте от ужаса."
 
-#: ../fheroes2/kingdom/morale.cpp:49
 msgid ""
 "Neutral morale means your armies will never be blessed with extra attacks or "
 "freeze in combat."
@@ -5208,1833 +4974,847 @@ msgstr ""
 "Обычная мораль подразумевает, что ваши отряды не буду получать бонусов "
 "дополнительной атаки или пропуска хода."
 
-#: ../fheroes2/kingdom/morale.cpp:50
 msgid "Good morale may give your armies extra attacks in combat."
 msgstr ""
 "Хорошая мораль может дать вашим войскам возможность дополнительной атаки в "
 "сражении."
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Knight"
 msgstr "Рыцарь"
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Barbarian"
 msgstr "Варвар"
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Sorceress"
 msgstr "Колдунья"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Warlock"
 msgstr "Чернокнижник"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Wizard"
 msgstr "Волшебник"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Necromancer"
 msgstr "Некромант"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Multi"
 msgstr "Мульти"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Standing"
 msgstr "Оч. Низкая -2"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Crawling"
 msgstr "Оч. Низкая -1"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Very Slow"
 msgstr "Оч. Низкая"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Slow"
 msgstr "Низкая"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Average"
 msgstr "Средняя"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Fast"
 msgstr "Быстрая"
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Very Fast"
 msgstr "Оч. Быстрая"
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Ultra Fast"
 msgstr "Ультра"
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Blazing"
 msgstr "Ультра +1"
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Instant"
 msgstr "Ультра +2"
 
-#: ../fheroes2/kingdom/week.cpp:32
 msgid "week|PLAGUE"
 msgstr "ЧУМЫ"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Ant"
 msgstr "Муравья"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Grasshopper"
 msgstr "Кузнечиков"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Dragonfly"
 msgstr "Стрекозы"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Spider"
 msgstr "Паука"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Butterfly"
 msgstr "Бабочки"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Bumblebee"
 msgstr "Гусеницы"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Locust"
 msgstr "Цикад"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Earthworm"
 msgstr "Земляного Червя"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Hornet"
 msgstr "Шершня"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Beetle"
 msgstr "Жука"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Squirrel"
 msgstr "Белки"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Rabbit"
 msgstr "Кролика"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Gopher"
 msgstr "Суслика"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Badger"
 msgstr "Барсука"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Eagle"
 msgstr "Орла"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Weasel"
 msgstr "Хорька"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Raven"
 msgstr "Ворона"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Mongoose"
 msgstr "Мангуста"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Aardvark"
 msgstr "Муравьеда"
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Lizard"
 msgstr "Ящера"
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Tortoise"
 msgstr "Черепахи"
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Hedgehog"
 msgstr "Ёжика"
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Condor"
 msgstr "Кондора"
 
-#: ../fheroes2/kingdom/world_loadmap.cpp:1620
-#, fuzzy
-msgid "The ultimate artifact is really the %{name}"
-msgstr "%{name} прокляты Мумиями!"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1624
-msgid "The ultimate artifact may be found in the %{name} regions of the world."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1629
-msgid "north-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1632
-#, fuzzy
-msgid "north"
-msgstr "Земля"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1634
-msgid "north-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1640
-#, fuzzy
-msgid "west"
-msgstr "Гнездо"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1643
-#, fuzzy
-msgid "center"
-msgstr "Отряд"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1645
-#, fuzzy
-msgid "east"
-msgstr "Гнездо"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1650
-msgid "south-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1653
-#, fuzzy
-msgid "south"
-msgstr "Звук"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1655
-msgid "south-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1659
-msgid "The truth is out there."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1660
-msgid "The dark side is stronger."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1661
-#, fuzzy
-msgid "The end of the world is near."
-msgstr "Остерегайся, здесь край мира!"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1662
-msgid "The bones of Lord Slayer are buried in the foundation of the arena."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1663
-msgid "A Black Dragon will take out a Titan any day of the week."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1664
-msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1666
-msgid ""
-"You can load the newest version of game from a site:\n"
-" http://sf.net/projects/fheroes2"
-msgstr ""
-"Новую версию игры, можно найти, на сайте:\n"
-" http://sf.net/projects/fheroes2"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1667
-msgid "This game is now in beta development version. ;)"
-msgstr "Игра пока все еще разрабатывается... ;)"
-
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Desert"
 msgstr "Пустыня"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Snow"
 msgstr "Снег"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Wasteland"
 msgstr "Пустошь"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Beach"
 msgstr "Побережье"
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Lava"
 msgstr "Лава"
 
-#: ../fheroes2/maps/ground.cpp:31 ../fheroes2/resource/maps_text.cpp:210
 msgid "Dirt"
 msgstr "Грязь"
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Grass"
 msgstr "Трава"
 
-#: ../fheroes2/maps/ground.cpp:31
-msgid "Water"
-msgstr "Вода"
+msgid "Ocean"
+msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Small"
 msgstr "Маленькая"
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Medium"
 msgstr "Средняя"
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Large"
 msgstr "Большая"
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Extra Large"
 msgstr "Очень Большая"
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Custom Size"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:122
 msgid "Ore Mine"
 msgstr "Рудная Шахта"
 
-#: ../fheroes2/maps/maps.cpp:123
 msgid "Sulfur Mine"
 msgstr "Серная Шахта"
 
-#: ../fheroes2/maps/maps.cpp:124
 msgid "Crystal Mine"
 msgstr "Кристальная Шахта"
 
-#: ../fheroes2/maps/maps.cpp:125
 msgid "Gems Mine"
 msgstr "Самоцветная Шахта"
 
-#: ../fheroes2/maps/maps.cpp:126
 msgid "Gold Mine"
 msgstr "Золотая Шахта"
 
-#: ../fheroes2/maps/maps.cpp:130
 msgid "Mine"
 msgstr "Шахта"
 
-#: ../fheroes2/maps/mp2.cpp:365
 msgid "Alchemist Lab"
 msgstr "Лаборатория алхимика"
 
-#: ../fheroes2/maps/mp2.cpp:367
 msgid "Daemon Cave"
 msgstr "Пещера демона"
 
-#: ../fheroes2/maps/mp2.cpp:369
 msgid "Faerie Ring"
 msgstr "Кольцо фей"
 
-#: ../fheroes2/maps/mp2.cpp:373 ../fheroes2/resource/maps_text.cpp:217
 msgid "Dragon City"
 msgstr "Драконий город"
 
-#: ../fheroes2/maps/mp2.cpp:375
-msgid "Light House"
+#, fuzzy
+msgid "Lighthouse"
 msgstr "Маяк"
 
-#: ../fheroes2/maps/mp2.cpp:377
 msgid "Water Wheel"
 msgstr "Водяная мельница"
 
-#: ../fheroes2/maps/mp2.cpp:379
 msgid "Mines"
 msgstr "Шахты"
 
-#: ../fheroes2/maps/mp2.cpp:381
 msgid "Obelisk"
 msgstr "Обелиск"
 
-#: ../fheroes2/maps/mp2.cpp:383
 msgid "Oasis"
 msgstr "Оазис"
 
-#: ../fheroes2/maps/mp2.cpp:385
 msgid "Sawmill"
 msgstr "Лесопилка"
 
-#: ../fheroes2/maps/mp2.cpp:387
 msgid "Oracle"
 msgstr "Оракл"
 
-#: ../fheroes2/maps/mp2.cpp:389
 msgid "Desert Tent"
 msgstr "Шатер"
 
-#: ../fheroes2/maps/mp2.cpp:393
 msgid "Wagon Camp"
 msgstr "Вагоны"
 
-#: ../fheroes2/maps/mp2.cpp:395
 msgid "Windmill"
 msgstr "Ветряная мельница"
 
-#: ../fheroes2/maps/mp2.cpp:397
 msgid "Random Town"
 msgstr "Случайный город"
 
-#: ../fheroes2/maps/mp2.cpp:399
 msgid "Random Castle"
 msgstr "Случайный замок"
 
-#: ../fheroes2/maps/mp2.cpp:401
 msgid "Watch Tower"
 msgstr "Обзорная башня"
 
-#: ../fheroes2/maps/mp2.cpp:403
 msgid "Tree City"
 msgstr "Древо-город"
 
-#: ../fheroes2/maps/mp2.cpp:405
 msgid "Tree House"
 msgstr "Древо-дом"
 
-#: ../fheroes2/maps/mp2.cpp:407
 msgid "Ruins"
 msgstr "Руины"
 
-#: ../fheroes2/maps/mp2.cpp:409
 msgid "Fort"
 msgstr "Форт"
 
-#: ../fheroes2/maps/mp2.cpp:411
-msgid "Trading Post"
-msgstr "Базар"
-
-#: ../fheroes2/maps/mp2.cpp:413
 msgid "Abandoned Mine"
 msgstr "Заброшенная шахта"
 
-#: ../fheroes2/maps/mp2.cpp:415
 msgid "Tree of Knowledge"
 msgstr "Древо знаний"
 
-#: ../fheroes2/maps/mp2.cpp:417
 msgid "Witch Doctor's Hut"
 msgstr "Хижина ведьмы"
 
-#: ../fheroes2/maps/mp2.cpp:419
 msgid "Temple"
 msgstr "Храм"
 
-#: ../fheroes2/maps/mp2.cpp:421
 msgid "Hill Fort"
 msgstr "Форт на холме"
 
-#: ../fheroes2/maps/mp2.cpp:423
 msgid "Halfling Hole"
 msgstr "Нора"
 
-#: ../fheroes2/maps/mp2.cpp:425
 msgid "Mercenary Camp"
 msgstr "Лагерь наемников"
 
-#: ../fheroes2/maps/mp2.cpp:429
 msgid "City of the Dead"
 msgstr "Город мертвых"
 
-#: ../fheroes2/maps/mp2.cpp:433
 msgid "Sphinx"
 msgstr "Сфинкс"
 
-#: ../fheroes2/maps/mp2.cpp:435
 msgid "Troll Bridge"
 msgstr "Мост троллей"
 
-#: ../fheroes2/maps/mp2.cpp:437
 msgid "Witch Hut"
 msgstr "Хижина Ведьмы"
 
-#: ../fheroes2/maps/mp2.cpp:439
 msgid "Xanadu"
 msgstr "Ксанаду"
 
-#: ../fheroes2/maps/mp2.cpp:443
 msgid "Magellan Maps"
 msgstr "Магеллан"
 
-#: ../fheroes2/maps/mp2.cpp:445
 msgid "Derelict Ship"
 msgstr "Заброшенный корабль"
 
-#: ../fheroes2/maps/mp2.cpp:447
-msgid "Ship Wreck"
-msgstr "Кораблекрушение"
+#, fuzzy
+msgid "Shipwreck"
+msgstr "Кораблекрушение!"
 
-#: ../fheroes2/maps/mp2.cpp:449
 msgid "Observation Tower"
 msgstr "Обзорная башня"
 
-#: ../fheroes2/maps/mp2.cpp:451
-msgid "Freeman Foundry"
+#, fuzzy
+msgid "Freeman's Foundry"
 msgstr "Литейный цех"
 
-#: ../fheroes2/maps/mp2.cpp:453
 msgid "Watering Hole"
 msgstr "Промоина"
 
-#: ../fheroes2/maps/mp2.cpp:455
 msgid "Artesian Spring"
 msgstr "Артезианский источник"
 
-#: ../fheroes2/maps/mp2.cpp:457
 msgid "Gazebo"
 msgstr "Беседка"
 
-#: ../fheroes2/maps/mp2.cpp:459
 msgid "Archer's House"
 msgstr "Дом Стрелков"
 
-#: ../fheroes2/maps/mp2.cpp:461
 msgid "Peasant Hut"
 msgstr "Мазанка крестьян"
 
-#: ../fheroes2/maps/mp2.cpp:463
 msgid "Dwarf Cottage"
 msgstr "Избушка Гномов"
 
-#: ../fheroes2/maps/mp2.cpp:465
 msgid "Stone Liths"
 msgstr "Монолиты"
 
-#: ../fheroes2/maps/mp2.cpp:467
 msgid "Magic Well"
 msgstr "Волшебный колодец"
 
-#: ../fheroes2/maps/mp2.cpp:468
 msgid "Heroes"
 msgstr "Герои"
 
-#: ../fheroes2/maps/mp2.cpp:470 ../fheroes2/maps/mp2.cpp:488
-msgid "Shrub"
-msgstr "Кустарник"
-
-#: ../fheroes2/maps/mp2.cpp:471
 msgid "Nothing Special"
 msgstr "Ничего особенного"
 
-#: ../fheroes2/maps/mp2.cpp:472
 msgid "Tar Pit"
 msgstr "Смоляная яма"
 
-#: ../fheroes2/maps/mp2.cpp:473
-msgid "Coast"
-msgstr "Побережье"
-
-#: ../fheroes2/maps/mp2.cpp:474
 msgid "Mound"
 msgstr "Курган"
 
-#: ../fheroes2/maps/mp2.cpp:475
 msgid "Dune"
 msgstr "Дюна"
 
-#: ../fheroes2/maps/mp2.cpp:476
 msgid "Stump"
 msgstr "Пень"
 
-#: ../fheroes2/maps/mp2.cpp:477
 msgid "Cactus"
 msgstr "Кактус"
 
-#: ../fheroes2/maps/mp2.cpp:478
 msgid "Trees"
 msgstr "Деревья"
 
-#: ../fheroes2/maps/mp2.cpp:479
 msgid "Dead Tree"
 msgstr "Сушина"
 
-#: ../fheroes2/maps/mp2.cpp:480
 msgid "Mountains"
 msgstr "Горы"
 
-#: ../fheroes2/maps/mp2.cpp:481
 msgid "Volcano"
 msgstr "Вулкан"
 
-#: ../fheroes2/maps/mp2.cpp:482
 msgid "Rock"
 msgstr "Камень"
 
-#: ../fheroes2/maps/mp2.cpp:483
 msgid "Flowers"
 msgstr "Цветы"
 
-#: ../fheroes2/maps/mp2.cpp:484
 msgid "Water Lake"
 msgstr "Озеро"
 
-#: ../fheroes2/maps/mp2.cpp:485
 msgid "Mandrake"
 msgstr "Мандрагора"
 
-#: ../fheroes2/maps/mp2.cpp:486
 msgid "Crater"
 msgstr "Кратер"
 
-#: ../fheroes2/maps/mp2.cpp:487
 msgid "Lava Pool"
 msgstr "Лавовый бассейн"
 
-#: ../fheroes2/maps/mp2.cpp:489
+msgid "Shrub"
+msgstr "Кустарник"
+
 msgid "Buoy"
 msgstr "Буй"
 
-#: ../fheroes2/maps/mp2.cpp:491 ../fheroes2/monster/monster.cpp:116
 #, fuzzy
 msgid "Skeleton"
 msgstr "Скелет"
 
-#: ../fheroes2/maps/mp2.cpp:492
 msgid "Treasure Chest"
 msgstr "Ларец с сокровищами"
 
-#: ../fheroes2/maps/mp2.cpp:493
 msgid "Sea Chest"
 msgstr "Морской Сундук"
 
-#: ../fheroes2/maps/mp2.cpp:494
 msgid "Campfire"
 msgstr "Костер"
 
-#: ../fheroes2/maps/mp2.cpp:495
 msgid "Fountain"
 msgstr "Фонтан"
 
-#: ../fheroes2/maps/mp2.cpp:496
 msgid "Genie Lamp"
 msgstr "Древняя лампа"
 
-#: ../fheroes2/maps/mp2.cpp:497
 msgid "Goblin Hut"
 msgstr "Хибара гоблина"
 
-#: ../fheroes2/maps/mp2.cpp:499
 msgid "Monster"
 msgstr "Отряд"
 
-#: ../fheroes2/maps/mp2.cpp:500
 msgid "Resource"
 msgstr "Ресурс"
 
-#: ../fheroes2/maps/mp2.cpp:501
 msgid "Whirlpool"
 msgstr "Водоворот"
 
-#: ../fheroes2/maps/mp2.cpp:502
 msgid "Artifact"
 msgstr "Артефакты"
 
-#: ../fheroes2/maps/mp2.cpp:503
 msgid "Boat"
 msgstr "Корабль"
 
-#: ../fheroes2/maps/mp2.cpp:510
 msgid "Standing Stones"
 msgstr "Стоячие камни"
 
-#: ../fheroes2/maps/mp2.cpp:514
 msgid "Idol"
 msgstr "Идол"
 
-#: ../fheroes2/maps/mp2.cpp:515
 msgid "Shrine of the First Circle"
 msgstr "Святилище 1-го круга"
 
-#: ../fheroes2/maps/mp2.cpp:516
 msgid "Shrine of the Second Circle"
 msgstr "Святилище 2-го круга"
 
-#: ../fheroes2/maps/mp2.cpp:517
 msgid "Shrine of the Third Circle"
 msgstr "Святилище 3-го круга"
 
-#: ../fheroes2/maps/mp2.cpp:518
 msgid "Wagon"
 msgstr "Тележка"
 
-#: ../fheroes2/maps/mp2.cpp:519
 msgid "Lean To"
 msgstr "Навес"
 
-#: ../fheroes2/maps/mp2.cpp:520
 msgid "Flotsam"
 msgstr "Обломки"
 
-#: ../fheroes2/maps/mp2.cpp:521
 msgid "Shipwreck Survivor"
 msgstr "Тонущий матрос"
 
-#: ../fheroes2/maps/mp2.cpp:522
 msgid "Bottle"
 msgstr "Бутылка"
 
-#: ../fheroes2/maps/mp2.cpp:523
 msgid "Magic Garden"
 msgstr "Волшебный сад"
 
-#: ../fheroes2/maps/mp2.cpp:529
 msgid "Jail"
 msgstr "Тюрьма"
 
-#: ../fheroes2/maps/mp2.cpp:531
 msgid "Traveller's Tent"
 msgstr "Шатер путника"
 
-#: ../fheroes2/maps/mp2.cpp:532
 msgid "Barrier"
 msgstr "Барьер"
 
-#: ../fheroes2/maps/mp2.cpp:535
 msgid "Fire Summoning Altar"
 msgstr "Алтарь Огня"
 
-#: ../fheroes2/maps/mp2.cpp:537
 msgid "Air Summoning Altar"
 msgstr "Алтарь Воздуха"
 
-#: ../fheroes2/maps/mp2.cpp:539
 msgid "Earth Summoning Altar"
 msgstr "Алтарь Земли"
 
-#: ../fheroes2/maps/mp2.cpp:541
 msgid "Water Summoning Altar"
 msgstr "Алтарь Воды"
 
-#: ../fheroes2/maps/mp2.cpp:543
 msgid "Barrow Mounds"
 msgstr "Могильные курганы"
 
-#: ../fheroes2/maps/mp2.cpp:545
-msgid "Arena"
-msgstr "Арена"
-
-#: ../fheroes2/maps/mp2.cpp:547
 msgid "Stables"
 msgstr "Конюшни"
 
-#: ../fheroes2/maps/mp2.cpp:549
 msgid "Alchemist's Tower"
 msgstr "Башня алхимика"
 
-#: ../fheroes2/maps/mp2.cpp:551
 msgid "Hut of the Magi"
 msgstr "Лачуга волхва"
 
-#: ../fheroes2/maps/mp2.cpp:553
 msgid "Eye of the Magi"
 msgstr "Око волхва"
 
-#: ../fheroes2/maps/mp2.cpp:555
 msgid "Mermaid"
 msgstr "Русалка"
 
-#: ../fheroes2/maps/mp2.cpp:557
 msgid "Sirens"
 msgstr "Сирены"
 
-#: ../fheroes2/maps/mp2.cpp:558
 msgid "Reefs"
 msgstr "Рифы"
 
-#: ../fheroes2/monster/monster.cpp:59
-#, fuzzy
-msgid "Peasant"
-msgstr "Крестьянин"
-
-#: ../fheroes2/monster/monster.cpp:59 ../fheroes2/resource/maps_text.cpp:501
-msgid "Peasants"
-msgstr "Крестьяне"
-
-#: ../fheroes2/monster/monster.cpp:60
-#, fuzzy
-msgid "Archer"
-msgstr "Стрелок"
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Archers"
-msgstr "Стрелков"
-
-#: ../fheroes2/monster/monster.cpp:61
-#, fuzzy
-msgid "Ranger"
-msgstr "Рейнджер"
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Rangers"
-msgstr "Рейнджеров"
-
-#: ../fheroes2/monster/monster.cpp:62
-#, fuzzy
-msgid "Pikeman"
-msgstr "Копейщик"
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Pikemen"
-msgstr "Копейщиков"
-
-#: ../fheroes2/monster/monster.cpp:63
-#, fuzzy
-msgid "Veteran Pikeman"
-msgstr "Опытный Копейщик"
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Veteran Pikemen"
-msgstr "Копейщиков ветеранов"
-
-#: ../fheroes2/monster/monster.cpp:64
-#, fuzzy
-msgid "Swordsman"
-msgstr "Мечник"
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Swordsmen"
-msgstr "Мечников"
-
-#: ../fheroes2/monster/monster.cpp:65
-#, fuzzy
-msgid "Master Swordsman"
-msgstr "Опытный Мечник"
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Master Swordsmen"
-msgstr "Опытные Мечники"
-
-#: ../fheroes2/monster/monster.cpp:66
-#, fuzzy
-msgid "Cavalry"
-msgstr "Всадник"
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Cavalries"
-msgstr "Всадников"
-
-#: ../fheroes2/monster/monster.cpp:67
-#, fuzzy
-msgid "Champion"
-msgstr "Опытный Всадник"
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Champions"
-msgstr "Чемпионов"
-
-#: ../fheroes2/monster/monster.cpp:68
-#, fuzzy
-msgid "Paladin"
-msgstr "Рыцарь"
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Paladins"
-msgstr "Паладинов"
-
-#: ../fheroes2/monster/monster.cpp:69
-#, fuzzy
-msgid "Crusader"
-msgstr "Крестоносец"
-
-#: ../fheroes2/monster/monster.cpp:69
-msgid "Crusaders"
-msgstr "Крестоносцев"
-
-#: ../fheroes2/monster/monster.cpp:72
-#, fuzzy
-msgid "Goblin"
-msgstr "Гоблин"
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Goblins"
-msgstr "Гоблиннов"
-
-#: ../fheroes2/monster/monster.cpp:73
-#, fuzzy
-msgid "Orc"
-msgstr "Орк"
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orcs"
-msgstr "Орков"
-
-#: ../fheroes2/monster/monster.cpp:74
-#, fuzzy
-msgid "Orc Chief"
-msgstr "Вождь Орков"
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chiefs"
-msgstr "Вождей орков"
-
-#: ../fheroes2/monster/monster.cpp:75
-#, fuzzy
-msgid "Wolf"
-msgstr "Волк"
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Wolves"
-msgstr "Волков"
-
-#: ../fheroes2/monster/monster.cpp:76
-#, fuzzy
-msgid "Ogre"
-msgstr "Людоед"
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogres"
-msgstr "Огров"
-
-#: ../fheroes2/monster/monster.cpp:77
-#, fuzzy
-msgid "Ogre Lord"
-msgstr "Великан Людоед"
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Ogre Lords"
-msgstr "Лордов огров"
-
-#: ../fheroes2/monster/monster.cpp:78
-#, fuzzy
-msgid "Troll"
-msgstr "Тролль"
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "Trolls"
-msgstr "Троллей"
-
-#: ../fheroes2/monster/monster.cpp:79
-#, fuzzy
-msgid "War Troll"
-msgstr "Боевой Тролль"
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "War Trolls"
-msgstr "Боевых троллей"
-
-#: ../fheroes2/monster/monster.cpp:80
-#, fuzzy
-msgid "Cyclops"
-msgstr "Циклоп"
-
-#: ../fheroes2/monster/monster.cpp:80
-msgid "Cyclopes"
-msgstr "Циклопов"
-
-#: ../fheroes2/monster/monster.cpp:83
-#, fuzzy
-msgid "Sprite"
-msgstr "Фея"
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Sprites"
-msgstr "Фей"
-
-#: ../fheroes2/monster/monster.cpp:84
-#, fuzzy
-msgid "Dwarf"
-msgstr "Гном"
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Dwarves"
-msgstr "Гномов"
-
-#: ../fheroes2/monster/monster.cpp:85
-#, fuzzy
-msgid "Battle Dwarf"
-msgstr "Боевой Гном"
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Battle Dwarves"
-msgstr "Боевых гномов"
-
-#: ../fheroes2/monster/monster.cpp:86
-#, fuzzy
-msgid "Elf"
-msgstr "Эльф"
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elves"
-msgstr "Эльфов"
-
-#: ../fheroes2/monster/monster.cpp:87
-#, fuzzy
-msgid "Grand Elf"
-msgstr "Эльф Охотник"
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elves"
-msgstr "Высоких эльфов"
-
-#: ../fheroes2/monster/monster.cpp:88
-#, fuzzy
-msgid "Druid"
-msgstr "Друид"
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druids"
-msgstr "Друидов"
-
-#: ../fheroes2/monster/monster.cpp:89
-#, fuzzy
-msgid "Greater Druid"
-msgstr "Старший Друид"
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druids"
-msgstr "Старших друидов"
-
-#: ../fheroes2/monster/monster.cpp:90
-#, fuzzy
-msgid "Unicorn"
-msgstr "Единорог"
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorns"
-msgstr "Единогогов"
-
-#: ../fheroes2/monster/monster.cpp:91
-#, fuzzy
-msgid "Phoenix"
-msgstr "Феникс"
-
-#: ../fheroes2/monster/monster.cpp:91
-#, fuzzy
-msgid "Phoenixes"
-msgstr "Феникс"
-
-#: ../fheroes2/monster/monster.cpp:94
-#, fuzzy
-msgid "Centaur"
-msgstr "Кентавр"
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaurs"
-msgstr "Кентавров"
-
-#: ../fheroes2/monster/monster.cpp:95
-#, fuzzy
-msgid "Gargoyle"
-msgstr "Гаргулья"
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyles"
-msgstr "Гаргулий"
-
-#: ../fheroes2/monster/monster.cpp:96
-#, fuzzy
-msgid "Griffin"
-msgstr "Грифон"
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffins"
-msgstr "Грифонов"
-
-#: ../fheroes2/monster/monster.cpp:97
-#, fuzzy
-msgid "Minotaur"
-msgstr "Минотавр"
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaurs"
-msgstr "Минотавров"
-
-#: ../fheroes2/monster/monster.cpp:98
-#, fuzzy
-msgid "Minotaur King"
-msgstr "Царь Минотавр"
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur Kings"
-msgstr "Царей минотавров"
-
-#: ../fheroes2/monster/monster.cpp:99
-#, fuzzy
-msgid "Hydra"
-msgstr "Гидра"
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydras"
-msgstr "Гидр"
-
-#: ../fheroes2/monster/monster.cpp:100
-#, fuzzy
-msgid "Green Dragon"
-msgstr "Зеленый Дракон"
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragons"
-msgstr "Зеленых драконов"
-
-#: ../fheroes2/monster/monster.cpp:101
-#, fuzzy
-msgid "Red Dragon"
-msgstr "Красный Дракон"
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragons"
-msgstr "Красных драконов"
-
-#: ../fheroes2/monster/monster.cpp:102
-#, fuzzy
-msgid "Black Dragon"
-msgstr "Черный Дракон"
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragons"
-msgstr "Черных драконов"
-
-#: ../fheroes2/monster/monster.cpp:105
-#, fuzzy
-msgid "Halfling"
-msgstr "Хоббит"
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halflings"
-msgstr "Хоббитов"
-
-#: ../fheroes2/monster/monster.cpp:106
-#, fuzzy
-msgid "Boar"
-msgstr "Боров"
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boars"
-msgstr "Боровов"
-
-#: ../fheroes2/monster/monster.cpp:107
-#, fuzzy
-msgid "Iron Golem"
-msgstr "Железный Голем"
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golems"
-msgstr "Железных големов"
-
-#: ../fheroes2/monster/monster.cpp:108
-#, fuzzy
-msgid "Steel Golem"
-msgstr "Стальной Голем"
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golems"
-msgstr "Стальных големов"
-
-#: ../fheroes2/monster/monster.cpp:109
-#, fuzzy
-msgid "Roc"
-msgstr "Рух"
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Rocs"
-msgstr "Рух"
-
-#: ../fheroes2/monster/monster.cpp:110
-#, fuzzy
-msgid "Mage"
-msgstr "Маг"
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Magi"
-msgstr "Маг"
-
-#: ../fheroes2/monster/monster.cpp:111
-#, fuzzy
-msgid "Archmage"
-msgstr "Архимаг"
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmagi"
-msgstr "Архимаг"
-
-#: ../fheroes2/monster/monster.cpp:112
-#, fuzzy
-msgid "Giant"
-msgstr "Гигант"
-
-#: ../fheroes2/monster/monster.cpp:112 ../fheroes2/resource/maps_text.cpp:293
-msgid "Giants"
-msgstr "Гигантов"
-
-#: ../fheroes2/monster/monster.cpp:113
-#, fuzzy
-msgid "Titan"
-msgstr "Титан"
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titans"
-msgstr "Титанов"
-
-#: ../fheroes2/monster/monster.cpp:116
-msgid "Skeletons"
-msgstr "Скелетов"
-
-#: ../fheroes2/monster/monster.cpp:117
-#, fuzzy
-msgid "Zombie"
-msgstr "Зомби"
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombies"
-msgstr "Зомби"
-
-#: ../fheroes2/monster/monster.cpp:118
-#, fuzzy
-msgid "Mutant Zombie"
-msgstr "Зомби Мутант"
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombies"
-msgstr "Зомби мутантов"
-
-#: ../fheroes2/monster/monster.cpp:119
-#, fuzzy
-msgid "Mummy"
-msgstr "Мумия"
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummies"
-msgstr "Мумий"
-
-#: ../fheroes2/monster/monster.cpp:120
-#, fuzzy
-msgid "Royal Mummy"
-msgstr "Королевская Мумия"
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummies"
-msgstr "Королевских мумий"
-
-#: ../fheroes2/monster/monster.cpp:121
-#, fuzzy
-msgid "Vampire"
-msgstr "Вампир"
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampires"
-msgstr "Вампиров"
-
-#: ../fheroes2/monster/monster.cpp:122
-#, fuzzy
-msgid "Vampire Lord"
-msgstr "Лорд Вампир"
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lords"
-msgstr "Лордов вампиров"
-
-#: ../fheroes2/monster/monster.cpp:123
-#, fuzzy
-msgid "Lich"
-msgstr "Лич"
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Liches"
-msgstr "Личей"
-
-#: ../fheroes2/monster/monster.cpp:124
-#, fuzzy
-msgid "Power Lich"
-msgstr "Могучий Лич"
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Liches"
-msgstr "Могучих личей"
-
-#: ../fheroes2/monster/monster.cpp:125
-#, fuzzy
-msgid "Bone Dragon"
-msgstr "Костяной Дракон"
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragons"
-msgstr "Костяных драконов"
-
-#: ../fheroes2/monster/monster.cpp:128
-#, fuzzy
-msgid "Rogue"
-msgstr "Разбойник"
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogues"
-msgstr "Разбойников"
-
-#: ../fheroes2/monster/monster.cpp:129
-#, fuzzy
-msgid "Nomad"
-msgstr "Кочевник"
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomads"
-msgstr "Кочевников"
-
-#: ../fheroes2/monster/monster.cpp:130
-#, fuzzy
-msgid "Ghost"
-msgstr "Призрак"
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghosts"
-msgstr "Призраков"
-
-#: ../fheroes2/monster/monster.cpp:131
-#, fuzzy
-msgid "Genie"
-msgstr "Джин"
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genies"
-msgstr "Джинов"
-
-#: ../fheroes2/monster/monster.cpp:132
-#, fuzzy
-msgid "Medusa"
-msgstr "Медуза"
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusas"
-msgstr "Медуз"
-
-#: ../fheroes2/monster/monster.cpp:133
-#, fuzzy
-msgid "Earth Elemental"
-msgstr "Земной Элементал"
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elementals"
-msgstr "Земных элементалов"
-
-#: ../fheroes2/monster/monster.cpp:134
-#, fuzzy
-msgid "Air Elemental"
-msgstr "Воздушный Элементал"
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elementals"
-msgstr "Воздушных элементалов"
-
-#: ../fheroes2/monster/monster.cpp:135
-#, fuzzy
-msgid "Fire Elemental"
-msgstr "Огненный Элементал"
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elementals"
-msgstr "Огненных элементалов"
-
-#: ../fheroes2/monster/monster.cpp:136
-#, fuzzy
-msgid "Water Elemental"
-msgstr "Водяной Элементал"
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elementals"
-msgstr "Водяных элементалов"
-
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:694
-msgid "buy"
-msgstr "купить"
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:158
-msgid "Campaign Game"
-msgstr "Кампания"
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "Error"
-msgstr "Ошибка"
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "This release is compiled without network support."
-msgstr "Эта версия игры не поддерживает игру по сети."
-
-#: ../fheroes2/resource/artifact.cpp:51
 msgid "Ultimate Book of Knowledge"
 msgstr "Уникальная Книга Знаний"
 
-#: ../fheroes2/resource/artifact.cpp:51 ../fheroes2/resource/artifact.cpp:77
-#: ../fheroes2/resource/artifact.cpp:78 ../fheroes2/resource/artifact.cpp:79
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "The %{name} increases your knowledge by %{count}."
 msgstr "%{name} увеличивает Знания на %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:52
 msgid "Ultimate Sword of Dominion"
 msgstr "Уникальный Меч Власти"
 
-#: ../fheroes2/resource/artifact.cpp:52 ../fheroes2/resource/artifact.cpp:68
-#: ../fheroes2/resource/artifact.cpp:71 ../fheroes2/resource/artifact.cpp:74
-#: ../fheroes2/resource/artifact.cpp:75 ../fheroes2/resource/artifact.cpp:149
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "The %{name} increases your attack skill by %{count}."
 msgstr "%{name} увеличивает атаку на %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:53
 msgid "Ultimate Cloak of Protection"
 msgstr "Уникальная Защитная Накидка"
 
-#: ../fheroes2/resource/artifact.cpp:53 ../fheroes2/resource/artifact.cpp:70
-#: ../fheroes2/resource/artifact.cpp:73 ../fheroes2/resource/artifact.cpp:76
 msgid "The %{name} increases your defense skill by %{count}."
 msgstr "%{name} увеличивает силу защиты на %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:54
 msgid "Ultimate Wand of Magic"
 msgstr "Уникальный Жезл Магии"
 
-#: ../fheroes2/resource/artifact.cpp:54 ../fheroes2/resource/artifact.cpp:59
-#: ../fheroes2/resource/artifact.cpp:60 ../fheroes2/resource/artifact.cpp:61
-#: ../fheroes2/resource/artifact.cpp:62 ../fheroes2/resource/artifact.cpp:148
 msgid "The %{name} increases your spell power by %{count}."
 msgstr "%{name} увеличивает силу магии на %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:55
 msgid "Ultimate Shield"
 msgstr "Всемогущий щит"
 
-#: ../fheroes2/resource/artifact.cpp:55 ../fheroes2/resource/artifact.cpp:128
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "The %{name} increases your attack and defense skills by %{count} each."
 msgstr "%{name} увеличивает вашу Атаку и Защиту на %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:56
 msgid "Ultimate Staff"
 msgstr "Всемогущий посох"
 
-#: ../fheroes2/resource/artifact.cpp:56 ../fheroes2/resource/artifact.cpp:130
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "The %{name} increases your spell power and knowledge by %{count} each."
 msgstr "%{name} увеличивает вашу Силу магии и Знания на %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "Ultimate Crown"
 msgstr "Корона всевластия"
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "The %{name} increases each of your basic skills by %{count} points."
 msgstr "%{name} увеличивает все основные параметры на %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "Golden Goose"
 msgstr "Золотой Гусь"
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "The %{name} brings in an income of %{count} gold per turn."
 msgstr "%{name} приносит каждый день по %{count} золотых."
 
-#: ../fheroes2/resource/artifact.cpp:59
 msgid "Arcane Necklace of Magic"
 msgstr "Ожерелье Тайной Магии"
 
-#: ../fheroes2/resource/artifact.cpp:60
 msgid "Caster's Bracelet of Magic"
 msgstr "Магический Браслет"
 
-#: ../fheroes2/resource/artifact.cpp:61
 msgid "Mage's Ring of Power"
 msgstr "Кольцо Мага"
 
-#: ../fheroes2/resource/artifact.cpp:62
 msgid "Witch's Broach of Magic"
 msgstr "Брошь Ведьмы"
 
-#: ../fheroes2/resource/artifact.cpp:63
 msgid "Medal of Valor"
 msgstr "Медаль за Отвагу"
 
-#: ../fheroes2/resource/artifact.cpp:63 ../fheroes2/resource/artifact.cpp:64
-#: ../fheroes2/resource/artifact.cpp:65 ../fheroes2/resource/artifact.cpp:66
 msgid "The %{name} increases your morale."
 msgstr "%{name} увеличивает вашу мораль."
 
-#: ../fheroes2/resource/artifact.cpp:64
 msgid "Medal of Courage"
 msgstr "Медаль за Мужество"
 
-#: ../fheroes2/resource/artifact.cpp:65
 msgid "Medal of Honor"
 msgstr "Медаль за Честь"
 
-#: ../fheroes2/resource/artifact.cpp:66
 msgid "Medal of Distinction"
 msgstr "Медаль Почета"
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "Fizbin of Misfortune"
 msgstr "Символ Неудачи"
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "The %{name} greatly decreases your morale by %{count}."
 msgstr "%{name} снижает вашу мораль на %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:68
 msgid "Thunder Mace of Dominion"
 msgstr "Громовая Палица"
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "Armored Gauntlets of Protection"
 msgstr "Защитная Перчатка"
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "The %{name} increase your defense skill by %{count}."
 msgstr "%{name} увеличивает силу защиты на %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:70
 msgid "Defender Helm of Protection"
 msgstr "Шлем Защитника"
 
-#: ../fheroes2/resource/artifact.cpp:71
 msgid "Giant Flail of Dominion"
 msgstr "Гигантский Цеп"
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "Ballista of Quickness"
 msgstr "Баллиста"
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "The %{name} lets your catapult fire twice per combat round."
 msgstr "%{name} позволяет дважды произвести выстрел из катапульты за один ход."
 
-#: ../fheroes2/resource/artifact.cpp:73
 msgid "Stealth Shield of Protection"
 msgstr "Незримый Щит"
 
-#: ../fheroes2/resource/artifact.cpp:74
 msgid "Dragon Sword of Dominion"
 msgstr "Драконий Меч"
 
-#: ../fheroes2/resource/artifact.cpp:75
 msgid "Power Axe of Dominion"
 msgstr "Топор Власти"
 
-#: ../fheroes2/resource/artifact.cpp:76
 msgid "Divine Breastplate of Protection"
 msgstr "Божественный Доспех"
 
-#: ../fheroes2/resource/artifact.cpp:77
 msgid "Minor Scroll of Knowledge"
 msgstr "Малый Свиток Знания"
 
-#: ../fheroes2/resource/artifact.cpp:78
 msgid "Major Scroll of Knowledge"
 msgstr "Большой Свиток Знания"
 
-#: ../fheroes2/resource/artifact.cpp:79
 msgid "Superior Scroll of Knowledge"
 msgstr "Могущественный Свиток Знания"
 
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "Foremost Scroll of Knowledge"
 msgstr "Свиток Высшего Знания"
 
-#: ../fheroes2/resource/artifact.cpp:81
 msgid "Endless Sack of Gold"
 msgstr "Бездонный Мешок"
 
-#: ../fheroes2/resource/artifact.cpp:81 ../fheroes2/resource/artifact.cpp:82
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "The %{name} provides you with %{count} gold per day."
 msgstr "%{name} ежедневно приносит Вам %{count} золотых."
 
-#: ../fheroes2/resource/artifact.cpp:82
 msgid "Endless Bag of Gold"
 msgstr "Бездонная Сума"
 
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "Endless Purse of Gold"
 msgstr "Бездонный Кошель"
 
-#: ../fheroes2/resource/artifact.cpp:84
 msgid "Nomad Boots of Mobility"
 msgstr "Бошмаки Кочевника"
 
-#: ../fheroes2/resource/artifact.cpp:84 ../fheroes2/resource/artifact.cpp:85
 msgid "The %{name} increase your movement on land."
 msgstr "%{name} увеличивают ваше передвижение по земле."
 
-#: ../fheroes2/resource/artifact.cpp:85
 msgid "Traveler's Boots of Mobility"
 msgstr "Башмаки Путника"
 
-#: ../fheroes2/resource/artifact.cpp:86
 msgid "Lucky Rabbit's Foot"
 msgstr "Лапка Кролика"
 
-#: ../fheroes2/resource/artifact.cpp:86 ../fheroes2/resource/artifact.cpp:87
-#: ../fheroes2/resource/artifact.cpp:88 ../fheroes2/resource/artifact.cpp:89
 msgid "The %{name} increases your luck in combat."
 msgstr "%{name} увеличивает вашу удачу в бою."
 
-#: ../fheroes2/resource/artifact.cpp:87
 msgid "Golden Horseshoe"
 msgstr "Золотая Подкова"
 
-#: ../fheroes2/resource/artifact.cpp:88
 msgid "Gambler's Lucky Coin"
 msgstr "Счастливая Монета"
 
-#: ../fheroes2/resource/artifact.cpp:89
 msgid "Four-Leaf Clover"
 msgstr "Листик Клевера"
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "True Compass of Mobility"
 msgstr "Компас"
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "The %{name} increases your movement on land and sea."
 msgstr "%{name} ваше передвижение по земле и воде."
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "Sailor's Astrolabe of Mobility"
 msgstr "Астролябия"
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "The %{name} increases your movement on sea."
 msgstr "%{name} увеличивает ваше передвижение по воде."
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "Evil Eye"
 msgstr "Дурной Глаз"
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "The %{name} reduces the casting cost of curse spells by half."
 msgstr "%{name} снижает стоиомсть заклинаний проклятия на половину."
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "Enchanted Hourglass"
 msgstr "Зачарованные Часы"
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "The %{name} extends the duration of all your spells by %{count} turns."
 msgstr "%{name} увеличивает длительность всех заклинаний на %{count} ход."
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "Gold Watch"
 msgstr "Золотые Часы"
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "The %{name} doubles the effectiveness of your hypnotize spells."
 msgstr "%{name} удваивают эффект заклинаний гипноза."
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "Skullcap"
 msgstr "Шапочка из Фольги"
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "The %{name} halves the casting cost of all mind influencing spells."
 msgstr "%{name} снижает вдвое стоимость всех заклинаний основанных на разуме."
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "Ice Cloak"
 msgstr "Ледяная Накидка"
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "The %{name} halves all damage your troops take from cold spells."
 msgstr ""
 "%{name} снижает вдвое весь урон нанесеный вашим отрядам заклинаниями холода."
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "Fire Cloak"
 msgstr "Огненная Накидка"
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "The %{name} halves all damage your troops take from fire spells."
 msgstr ""
 "%{name} снижает вдвое весь урон нанесеный вашим отрядам заклинаниями огня."
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "Lightning Helm"
 msgstr "Громовой Шлем"
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "The %{name} halves all damage your troops take from lightning spells."
 msgstr ""
 "%{name} снижает вдвое весь урон нанесеный вашим отрядам заклинаниями молний."
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid "Evercold Icicle"
 msgstr "Нетающий Лед"
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid ""
 "The %{name} causes your cold spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr "%{name} увеличивает на %{count} процентов урон от заклинаний холода."
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid "Everhot Lava Rock"
 msgstr "Горячий Камень"
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid ""
 "The %{name} causes your fire spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr "%{name} увеличивает на %{count} процентов урон от заклинаний огня."
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid "Lightning Rod"
 msgstr "Жезл Молний"
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid ""
 "The %{name} causes your lightning spells to do %{count} percent more damage "
 "to enemy troops."
 msgstr "%{name} увеличивает на %{count} процентов урон от заклинаний молнии."
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "Snake-Ring"
 msgstr "Кольцо Змеи"
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "The %{name} halves the casting cost of all your bless spells."
 msgstr "%{name} снижает стоимость всех заклинаний благословения."
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid "Ankh"
 msgstr "Символ Жизни"
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid ""
 "The %{name} doubles the effectiveness of all your resurrect and animate "
 "spells."
 msgstr "%{name} удваивает эффективность всех ваших заклинаний оживления."
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "Book of Elements"
 msgstr "Книга Стихий"
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "The %{name} doubles the effectiveness of all your summoning spells."
 msgstr "%{name} удваивает эффективность всех ваших заклинаний призыва."
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "Elemental Ring"
 msgstr "Кольцо Элемента"
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "The %{name} halves the casting cost of all summoning spells."
 msgstr "%{name} снижает наполовину стоимость всех ваших заклинаний призыва."
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "Holy Pendant"
 msgstr "Святой Кулон"
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "The %{name} makes all your troops immune to curse spells."
 msgstr ""
 "%{name} делает все ваши отряды невосприимчивыми к заклинаниям проклятия."
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "Pendant of Free Will"
 msgstr "Подвеска Свободы"
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "The %{name} makes all your troops immune to hypnotize spells."
 msgstr ""
 "%{name} воли делает все ваши отряды невосприимчивыми к заклинаниям гипноза."
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "Pendant of Life"
 msgstr "Кулон Жизни"
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "The %{name} makes all your troops immune to death spells."
 msgstr ""
 "%{name} делает все ваши отряды невосприимчивыми к заклинанию Волна смерти."
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "Serenity Pendant"
 msgstr "Подвеска Покоя"
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "The %{name} makes all your troops immune to berserk spells."
 msgstr "%{name} делает все ваши отряды невосприимчивыми к заклинанию берсерка."
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "Seeing-eye Pendant"
 msgstr "Всевидящий Глаз"
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "The %{name} makes all your troops immune to blindness spells."
 msgstr ""
 "%{name} делает все ваши отряды невосприимчивыми к заклинанию ослепления."
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "Kinetic Pendant"
 msgstr "Кулон Движения"
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "The %{name} makes all your troops immune to paralyze spells."
 msgstr "%{name} делает невосприимчивыми ваши отряды к заклинаниям паралича."
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "Pendant of Death"
 msgstr "Кулон Смерти"
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "The %{name} makes all your troops immune to holy spells."
 msgstr ""
 "%{name} делает невосприимчивыми ваши отряды к заклинаниям изгнания нежити."
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "Wand of Negation"
 msgstr "Посох Отрицания"
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "The %{name} protects your troops from the Dispel Magic spell."
 msgstr "%{name} защищает ваши отряды от заклятий снятия чар."
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid "Golden Bow"
 msgstr "Золотой Лук"
 
-#: ../fheroes2/resource/artifact.cpp:114
+#, fuzzy
 msgid ""
 "The %{name} eliminates the %{count} percent penalty for your troops shooting "
-"past obstacles. (e.g. castle walls)"
+"past obstacles (e.g. castle walls)."
 msgstr ""
 "%{name} уменьшает на %{count} процентов штраф при стрельбе за преграды."
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid "Telescope"
 msgstr "Телескоп"
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid ""
 "The %{name} increases the amount of terrain your hero reveals when "
 "adventuring by %{count} extra square."
 msgstr "%{name} увеличивает радиус обзора героя на %{count} клетку."
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid "Statesman's Quill"
 msgstr "Перо Дипломата"
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid ""
 "The %{name} reduces the cost of surrender to %{count} percent of the total "
 "cost of troops you have in your army."
@@ -7042,138 +5822,106 @@ msgstr ""
 "%{name} снижает стоимость сдачи на %{count} процентов от общей стоимости  "
 "войска."
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "Wizard's Hat"
 msgstr "Шляпа Мага"
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "The %{name} increases the duration of your spells by %{count} turns."
 msgstr ""
 "%{name} увеличивает продолжительность всех ваших заклинаний на %{count} "
 "ходов."
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "Power Ring"
 msgstr "Кольцо Силы"
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "The %{name} returns %{count} extra power points/turn to your hero."
 msgstr "%{name} восстанавливает %{count} очка магии в ход."
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "Ammo Cart"
 msgstr "Обоз Оружия"
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "The %{name} provides endless ammunition for all your troops that shoot."
 msgstr "%{name} обеспечивает бесконечными боеприпасами всех ваших стрелков."
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "Tax Lien"
 msgstr "Долговая Расписка"
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "The %{name} costs you %{count} gold pieces/turn."
 msgstr "%{name} взымает %{count} золотых ежедневно."
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "Hideous Mask"
 msgstr "Ужасная Маска"
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "The %{name} prevents all 'wandering' armies from joining your hero."
 msgstr "%{name} не позволяеткому попало вступить в вашу армию."
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "Endless Pouch of Sulfur"
 msgstr "Мешочек Серы"
 
-#: ../fheroes2/resource/artifact.cpp:122
 #, fuzzy
 msgid "The %{name} provides %{count} unit of sulfur per day."
 msgstr "%{name} ежедневно приносит вам %{count} меру серы."
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "Endless Vial of Mercury"
 msgstr "Колба Ртути"
 
-#: ../fheroes2/resource/artifact.cpp:123
 #, fuzzy
 msgid "The %{name} provides %{count} unit of mercury per day."
 msgstr "%{name} еждневно приносит вам %{count} меру ртути."
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "Endless Pouch of Gems"
 msgstr "Мешочек Самоцветов"
 
-#: ../fheroes2/resource/artifact.cpp:124
 #, fuzzy
 msgid "The %{name} provides %{count} unit of gems per day."
 msgstr "%{name} еждневно приносит вам %{count} меру самоцветов."
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "Endless Cord of Wood"
 msgstr "Вязанка Дров"
 
-#: ../fheroes2/resource/artifact.cpp:125
 #, fuzzy
 msgid "The %{name} provides %{count} unit of wood per day."
 msgstr "%{name} еждневно приносит вам %{count} меру древесины."
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "Endless Cart of Ore"
 msgstr "Вагонетка Руды"
 
-#: ../fheroes2/resource/artifact.cpp:126
 #, fuzzy
 msgid "The %{name} provides %{count} unit of ore per day."
 msgstr "%{name} ежедневно приносит вам %{count} меру руды."
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "Endless Pouch of Crystal"
 msgstr "Мешочек Кристаллов"
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "The %{name} provides %{count} unit of crystal/day."
 msgstr "%{name} ежедневно приносит вам %{count} мер кристаллов."
 
-#: ../fheroes2/resource/artifact.cpp:128
 msgid "Spiked Helm"
 msgstr "Шипованный Шлем"
 
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "Spiked Shield"
 msgstr "Шипованный Щит"
 
-#: ../fheroes2/resource/artifact.cpp:130
 msgid "White Pearl"
 msgstr "Белая Жемчужина"
 
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "Black Pearl"
 msgstr "Черная Жемчужина"
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "Magic Book"
 msgstr "Волшебная Книга"
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "The %{name} enables you to cast spells."
 msgstr "%{name} позволяет использовать заклинания."
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "Spell Scroll"
 msgstr "Свиток Заклинания"
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
 msgstr "%{name} позволяет вашему герою направить заклинание %{spell}."
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid "Arm of the Martyr"
 msgstr "Рука Мученника"
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid ""
 "The %{name} increases your spell power by %{count} but adds the undead "
 "morale penalty."
@@ -7181,19 +5929,15 @@ msgstr ""
 "%{name} увеличивает силу магии на %{count}, но добавляет штраф \"Мертвец в "
 "Отряде\"."
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "Breastplate of Anduran"
 msgstr "Кираса Андурана"
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "The %{name} increases your defense by %{count}."
 msgstr "%{name} увеличивает силу защиты на %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid "Broach of Shielding"
 msgstr "Защитная Брошь"
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid ""
 "The %{name} provides %{count} percent protection from Armageddon and "
 "Elemental Storm, but decreases spell power by 2."
@@ -7201,11 +5945,9 @@ msgstr ""
 "%{name} увеличит защиту от Армагеддона и Элементного Шторма на %{count} "
 "процентов, но также уменьшит силу магии на 2 пункта."
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid "Battle Garb of Anduran"
 msgstr "Боевой Доспех Андурана"
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid ""
 "The %{name} combines the powers of the three Anduran artifacts.  It provides "
 "maximum luck and morale for your troops and gives you the Town Portal spell."
@@ -7213,11 +5955,9 @@ msgstr ""
 "%{name} сочетает в себе силу трех артефактов Андурана. Оно увеличивает удачу "
 "и мораль ваших войск, а так же дает вам заклинание Портала в город."
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid "Crystal Ball"
 msgstr "Кристальный Шар"
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid ""
 "The %{name} lets you get more specific information about monsters, enemy "
 "heroes, and castles nearby the hero who holds it."
@@ -7225,11 +5965,9 @@ msgstr ""
 "%{name} предоставляет подробную информацию о монстрах, вражеских героях и "
 "замках, рядом с которыми стоит герой."
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid "Heart of Fire"
 msgstr "Сердце Огня"
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid ""
 "The %{name} provides %{count} percent protection from fire, but doubles the "
 "damage taken from cold."
@@ -7237,11 +5975,9 @@ msgstr ""
 "%{name} увеличивает защиту от магии огня на %{count} процентов, но также "
 "уменьшает в два раза защиту против магии холода."
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid "Heart of Ice"
 msgstr "Ледяное Сердце"
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid ""
 "The %{name} provides %{count} percent protection from cold, but doubles the "
 "damage taken from fire."
@@ -7249,68 +5985,52 @@ msgstr ""
 "%{name} увеличивает защиту от магии холода на %{count} процентов, но также "
 "уменьшает в два раза защиту против магии огня."
 
-#: ../fheroes2/resource/artifact.cpp:148
 msgid "Helmet of Anduran"
 msgstr "Шлем Андурана"
 
-#: ../fheroes2/resource/artifact.cpp:149
 msgid "Holy Hammer"
 msgstr "Святой Молот"
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "Legendary Scepter"
 msgstr "Легендарный Скипетр"
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "The %{name} adds %{count} points to all attributes."
 msgstr "%{name} увеличивает все основные параметры на %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "Masthead"
 msgstr "Наконечник Мачты"
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "The %{name} boosts your luck and morale by %{count} each in sea combat."
 msgstr ""
 "%{name}, при сражениях на воде, увеличивает ваши удачу и мораль на %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "Sphere of Negation"
 msgstr "Сфера Антимагии"
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "The %{name} disables all spell casting, for both sides, in combat."
 msgstr "%{name} запрещает всем на поле боя использовать магию."
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "Staff of Wizardry"
 msgstr "Волшебный Посох"
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "The %{name} boosts your spell power by %{count}."
 msgstr "%{name} увеличивает силу магии на %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "Sword Breaker"
 msgstr "Мечелом"
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "The %{name} increases your defense by %{count} and attack by 1."
 msgstr "%{name} увеличивает силу защиты на %{count}, и атаки на 1."
 
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "Sword of Anduran"
 msgstr "Меч Андурана"
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "Spade of Necromancy"
 msgstr "Лопатка Могильщика"
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "The %{name} gives you increased necromancy skill."
 msgstr "%{name} увеличивает навык искусства Некромантов."
 
-#: ../fheroes2/resource/artifact.cpp:638
 msgid ""
 "You find an elaborate aontainer which housesan old vellum scroll. The runes "
 "on the container are very old, and the artistry with whitch it was put "
@@ -7318,7 +6038,6 @@ msgid ""
 "magical power."
 msgstr "Вы нашли древний свиток. Эти непонятные руны помогут вам в магии."
 
-#: ../fheroes2/resource/artifact.cpp:639
 msgid ""
 "One of the less intelligent members of your party picks up an arm off of the "
 "ground. Despite its missing a body, it is still moving. Your troops find the "
@@ -7331,7 +6050,6 @@ msgstr ""
 "можете ее выкинуть: Рука имеет магическую силу, что положительно сказывается "
 "на процессе принятия решений."
 
-#: ../fheroes2/resource/artifact.cpp:640
 msgid ""
 "You come upon a sign. It reads: \"Here lies the body of Anduran. Bow and "
 "swear fealty, and you shall be rewarded.\" You decide to do as it says. As "
@@ -7343,7 +6061,6 @@ msgstr ""
 "и чувствуете холод на коже. Осматривая себя вы обнаружили, что вы носите "
 "блестящую броню."
 
-#: ../fheroes2/resource/artifact.cpp:641
 msgid ""
 "A kindly Sorceress thinks that your army's defenses could use a magical "
 "boost. She offers to enchant the Broach that you wear on your cloak, and you "
@@ -7352,7 +6069,6 @@ msgstr ""
 "Колдунья считает, что для защиты Вашей армии можно использовать магическую "
 "поддержку. Она предлагает Вам Брошь Очарования."
 
-#: ../fheroes2/resource/artifact.cpp:642
 msgid ""
 "Out of pity for a poor peasant, you purchase a chest of old junk they are "
 "hawking for too much gold. Later, as you search through it, you find it "
@@ -7361,7 +6077,6 @@ msgstr ""
 "Из жалости к бедным крестьянам, Вы приобретаете груду старья. Позже, Вы "
 "находите в нем 3 части легендарного боевого доспеха Андурана!"
 
-#: ../fheroes2/resource/artifact.cpp:643
 msgid ""
 "You come upon a caravan of gypsies who are feasting and fortifying their "
 "bodies with mead. They call you forward and say \"If you prove that you can "
@@ -7375,7 +6090,6 @@ msgstr ""
 "Вы решаете попробовать... Цыгане смеются над Вашими попытками, но восхищаясь "
 "Вашим мужеством, отдают вам Кристальный Шар."
 
-#: ../fheroes2/resource/artifact.cpp:644
 msgid ""
 "You enter a recently burned glade and come upon a Fire Elemental sitting "
 "atop a rock. It looks up, its flaming face contorted in a look of severe "
@@ -7387,7 +6101,6 @@ msgstr ""
 "Вы делаете жест руками, чтобы заблокировать его, но сгусток проходит через  "
 "Ваши руки и тело."
 
-#: ../fheroes2/resource/artifact.cpp:645
 msgid ""
 "Suddenly, a biting coldness engulfs your body. You seize up, falling from "
 "your horse. The pain subsides, but you still feel as if your chest is "
@@ -7399,7 +6112,6 @@ msgstr ""
 "утихает, Вы поднимаетесь и слышите смех. Вы успеваете обернуться как раз "
 "вовремя, чтобы увидеть Ледяного Гиганта скрывающегося в лесу."
 
-#: ../fheroes2/resource/artifact.cpp:646
 msgid ""
 "You spy a gleaming object poking up out of the ground. You send a member of "
 "your party over to investigate. He comes back with a golden helmet in his "
@@ -7410,7 +6122,6 @@ msgstr ""
 "помощника раскопать его. Он возвращается с золотым шлемом в руках. Вы "
 "узнаете легендарный Шлем Андурана."
 
-#: ../fheroes2/resource/artifact.cpp:647
 msgid ""
 "You come upon a battle where a Paladin has been mortally wounded by a group "
 "of Zombies. He asks you to take his hammer and finish what he started.  As "
@@ -7422,7 +6133,6 @@ msgstr ""
 "начинает издавать мелодичные звуки, и потом все вокруг рушится. Все Зомби "
 "уничтожены. Залитый кровью молот Вы прицепляете к своему ремню."
 
-#: ../fheroes2/resource/artifact.cpp:648
 msgid ""
 "Upon cresting a small hill, you come upon a ridiculous looking sight. A "
 "Sprite is attempting to carry a Scepter that is almost as big as it is. "
@@ -7436,7 +6146,6 @@ msgstr ""
 "Бабочка смотрит на Вас и отвечает: \"Вы думаете, это смешно? Хорошо. "
 "Забирайте его себе, а я улетаю.\""
 
-#: ../fheroes2/resource/artifact.cpp:649
 msgid ""
 "An old seaman tells you a tale of an enchanted masthead that he used in his "
 "youth to rally his crew during times of trouble. He then hands you a faded "
@@ -7447,7 +6156,6 @@ msgstr ""
 "использовал во время штормов. Затем он вручает Вам карту, где он спрятал ее. "
 "После поисков, Вы находите ее."
 
-#: ../fheroes2/resource/artifact.cpp:650
 msgid ""
 "You stop to help a Peasant catch a runaway mare. To show his gratitude, he "
 "hands you a tiny sphere. As soon as you grasp it, you feel the magical "
@@ -7457,7 +6165,6 @@ msgstr ""
 "благодарность, они вручают вам крохотную сферу. Лишь только взяв ее, вы "
 "чувствуете, как магическая энергия высасывается из рук и ног."
 
-#: ../fheroes2/resource/artifact.cpp:651
 msgid ""
 "While out scaring up game, your troops find a mysterious staff levitating "
 "about three feet off of the ground. They hand it to you, and you notice an "
@@ -7468,7 +6175,6 @@ msgstr ""
 "заметили надпись: \"Ум лучше Мускулов и Магия победит Силу. всегда помни это."
 "\""
 
-#: ../fheroes2/resource/artifact.cpp:652
 msgid ""
 "A former Captain of the Guard admires your quest and gives you the enchanted "
 "Sword Breaker that he relied on during his tour of duty."
@@ -7476,7 +6182,6 @@ msgstr ""
 "Бывший Капитан Стражи восхищен вашими приключениями и дарит Вам зачарованный "
 "Крушитель Клинков, на который он полагался во время службы."
 
-#: ../fheroes2/resource/artifact.cpp:653
 msgid ""
 "A Troll stops you and says: \"Pay me 5,000 gold, or the Sword of Anduran "
 "will slay you where you stand.\" You refuse. The troll grabs the sword "
@@ -7490,7 +6195,6 @@ msgstr ""
 "вы благодарите судьбу за то, что полоумные Тролли имеют обыкновение хватать "
 "острые предметы не за тот конец."
 
-#: ../fheroes2/resource/artifact.cpp:654
 msgid ""
 "A dirty shovel has been thrust into a dirt mound nearby. Upon investigation, "
 "you discover it to be the enchanted shovel of the Gravediggers, long thought "
@@ -7500,4783 +6204,60 @@ msgstr ""
 "что это зачарованная лопата Гробокопателей, считавшаяся давным давно "
 "потерянной смертными."
 
-#: ../fheroes2/resource/artifact.cpp:905
+#, fuzzy
 msgid ""
-"Do you want to use your knowledge of magical secrets to transcribe the %"
-"{spell} Scroll into your spell book?\n"
-"The Scroll will be consumed.\n"
-" Spell point: %{sp}"
+"Do you want to use your knowledge of magical secrets to transcribe the "
+"%{spell} Scroll into your Magic Book?\n"
+"The Spell Scroll will be consumed.\n"
+" Cost in spell points: %{sp}"
 msgstr ""
 "Вы желаете использоватаь Ваше знание волшебных секретов, чтобы переписать "
 "Свиток %{spell} в Вашу магическую книгу?\n"
 "Свиток будет уничтожен.\n"
 "Сила магии: %{sp}"
 
-#: ../fheroes2/resource/artifact.cpp:969
-msgid "Open book"
-msgstr ""
+#, fuzzy
+msgid "Transcribe Spell Scroll"
+msgstr "Свиток Заклинания"
 
-#: ../fheroes2/resource/artifact.cpp:974
-msgid "Transcribe scroll"
-msgstr ""
+#, fuzzy
+msgid "View Spells"
+msgstr "Показать все"
 
-#: ../fheroes2/resource/artifact.cpp:984
-#: ../fheroes2/resource/artifact.cpp:1017
+#, fuzzy
+msgid "View %{name} Info"
+msgstr "Просмотреть %{name}"
+
 msgid "Move %{name}"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:1007
 msgid "Cannot move artifact"
 msgstr ""
 
-#: ../fheroes2/resource/maps_text.cpp:15
-msgid ""
-"425 bottles of beer on the wall, 425 bottles of beer! If one of those "
-"bottles should happen to fall, there'll be..."
+msgid "This item can't be traded."
 msgstr ""
-"425 бутылок пива, 425 бутылок пива! Если одна из этих бутылок упадет, там "
-"что то будет ..."
 
-#: ../fheroes2/resource/maps_text.cpp:16
-msgid "A balanced scenario with lots of resources and land to explore."
-msgstr "Сбалансированный сценарий с множеством ресурсов для развития."
-
-#: ../fheroes2/resource/maps_text.cpp:17
-msgid ""
-"A bandit army of gorgons jump you without warning.  they stone your entire "
-"army demand 500 gold before they will release your comrads.  Realizing that "
-"it is much cheeper to pay then rebuild your army you part with the gold."
-msgstr ""
-"Бандитская армия горгон набрасыввается на Вас без предупреждения, они "
-"превращают в камень всю вашу армию  и требуют 500 золотых взамен на "
-"освобождение ваших товарищей. Осознавая, что заплатить будет намного "
-"выгоднее, чем перестраивать всю армию, вы делитесь золотом."
-
-#: ../fheroes2/resource/maps_text.cpp:18
-msgid "Abandon All Hope!"
-msgstr "Безнадёга!!"
-
-#: ../fheroes2/resource/maps_text.cpp:19
-msgid "Abandon All Hope Ye That Enter Here"
-msgstr "Оставь всякую надежду, сюда входящий!"
-
-#: ../fheroes2/resource/maps_text.cpp:20
-msgid "A bit of crystal!"
-msgstr "Немного кристаллов!"
-
-#: ../fheroes2/resource/maps_text.cpp:21
-msgid "A bit of mercury!"
-msgstr "Немного ртути!"
-
-#: ../fheroes2/resource/maps_text.cpp:22
-msgid "A bit of sulfur!"
-msgstr "Немного серы!"
-
-#: ../fheroes2/resource/maps_text.cpp:23
-msgid ""
-"Above you looms the ancient Ice Palace.  Dimly remembered myth speaks of a "
-"Prince who rejected the advances of the Winter Goddess, and thus he and his "
-"domain were cursed to remain shrouded in ice, hidden in a forgotten corner "
-"of the world.  It is said that he can only be rescued by a hero who is both "
-"clever and bold.  Are you that one?  Do you dare enter this frozen domain?"
-msgstr ""
-"Перед Вами - древний Ледяной Дворец. Частично сохранившийся миф повествует о "
-"Принце, который не признал достижений Зимней Богини и  был проклят и обречен "
-"со своими владениями на вечное заточение во льду, затерянный в забытом "
-"уголке мира. Говорится, что только герои, равно обладающий умом и храбростью "
-"может освободить его. Может быть это Вы? Вы отважитесь войти в Ледяные "
-"владения?"
-
-#: ../fheroes2/resource/maps_text.cpp:24
-msgid "A cache of crystal!"
-msgstr "Кошелек с кристаллами!"
-
-#: ../fheroes2/resource/maps_text.cpp:25
-msgid "A cache of gems!"
-msgstr "Кошелек с алмазами!"
-
-#: ../fheroes2/resource/maps_text.cpp:26
-msgid "A cache of gold!"
-msgstr "Кошелек с золотом!"
-
-#: ../fheroes2/resource/maps_text.cpp:27
-msgid "A cache of mercury!"
-msgstr "Банка с ртутью!"
-
-#: ../fheroes2/resource/maps_text.cpp:28
-msgid "A cache of sulfur!"
-msgstr "Мешок с серой!"
-
-#: ../fheroes2/resource/maps_text.cpp:29
-msgid ""
-"A chance to end a bitter war has finally arrived as a new resource-laden "
-"land has been discovered."
-msgstr ""
-"Обнаружена Новая Земля. И наконец, появился шанс положить конец ожесточенной "
-"войне за ресурсы."
-
-#: ../fheroes2/resource/maps_text.cpp:30
-msgid "A chunk of gold!"
-msgstr "Немного золота!"
-
-#: ../fheroes2/resource/maps_text.cpp:31
-msgid "A chunk of ore!"
-msgstr "Немного камня!"
-
-#: ../fheroes2/resource/maps_text.cpp:32
-msgid "A couple of gems!"
-msgstr "Немного драгоценных камней!"
-
-#: ../fheroes2/resource/maps_text.cpp:33
-msgid "\"Act of Desperation\""
-msgstr "\"Акт Отчаянья\""
-
-#: ../fheroes2/resource/maps_text.cpp:34
-msgid ""
-"A desert isle rich in resources rewards the quick.  Just be sure to watch "
-"your back!"
-msgstr ""
-"Пустынные острова богаты ресурсами. Только убедись, что почаще смотришь "
-"назад!"
-
-#: ../fheroes2/resource/maps_text.cpp:35
-msgid "A dolphin playfully jumps into the air."
-msgstr "Дельфин игриво прыгает в воздух."
-
-#: ../fheroes2/resource/maps_text.cpp:36
-msgid ""
-"A Dragon, A Cyclops, or an Undead. King of the Centaurs, His name is ....?"
-msgstr "Дракон, Циклоп, или Мертвец. Король Кентавров - Как Его Зовут....?"
-
-#: ../fheroes2/resource/maps_text.cpp:37
-msgid "A flight of dragons circles overhead."
-msgstr "Пара драконов наворачивает кругами над вами."
-
-#: ../fheroes2/resource/maps_text.cpp:38
-msgid "A flock of seagulls circle overhead."
-msgstr "Стая чаек кружится над головой."
-
-#: ../fheroes2/resource/maps_text.cpp:39
-msgid "A friendly dolphin splashes alongside the ship."
-msgstr "Друзья дельфины плывут рядом с кораблем."
-
-#: ../fheroes2/resource/maps_text.cpp:40
-msgid ""
-"After a long search of the island, I have discovered that there is no way "
-"for me to escape without help.  I can not steal a ship from one of the "
-"coastal castles, and I dare not venture into the desert unless I wish to "
-"become Dragon food.  Should anyone find this, I beg of you, please send a "
-"ship and get me off this cursed island!  -Sir Christian"
-msgstr ""
-"Я обшарил весь остров и понял, у меня нет способа отсюда выбраться без "
-"посторонней помощи. Я не могу украсть лодку с одного из прибрежных замков, и "
-"я не смею идти через пустыню где я стану пищей драконов. Если кто нашел это, "
-"я прошу вас, пожалуйста, отправьте лодку и заберите меня с этого проклятого "
-"острова! Сэр Христиан."
-
-#: ../fheroes2/resource/maps_text.cpp:41
-msgid ""
-"After centuries of friendship, the Wizards have suddenly decided to stop "
-"sharing their Library with the rest of the world.  This can't be good!"
-msgstr ""
-"После столетий мира и дружбы, Волшебники внезапно запретили, для остального "
-"мира, доступ к их Библиотеке. Это плохой знак!"
-
-#: ../fheroes2/resource/maps_text.cpp:42
-msgid ""
-"After many years of peace, you discover that your sworn enemy from across "
-"the sea has chosen to invade your homeland by raising up the ocean floor to "
-"bridge the distance! You must not let them gain a foothold on this "
-"continent, in fact, your King has ordered you to establish a foothold on "
-"theirs!  To make matters worse, two of your OWN towns have thrown in their "
-"lots with the enemy..."
-msgstr ""
-"После многих лет мира, вы обнаружили, что враги решили вторгнуться из за "
-"моря! Вы должны помешать их планам! Плохая новость, два ваших города уже "
-"бросили жребий с врагом..."
-
-#: ../fheroes2/resource/maps_text.cpp:43
-msgid ""
-"After you return from a scouting trip, your Seneschal hurries to greet you.  "
-"\"My Lord, in your absence I signed an agreement in your name with a Master "
-"Merchant.  If we supply him with the resources he needs, through trading, he "
-"can return the resources to us in a week or so, plus some additional ones."
-"\"  The Seneschal eyes you anxiously.  You hesitate, then nod slowly, "
-"\"Good, we can use more resources>\""
-msgstr ""
-"Вы вернулись с дальней разведки, и вас спешит поприветствовать советник: "
-"\"Мой Лорд, во время Вашего отсутствия, я подписал соглашение, на Ваше имя, "
-"с Боссом Торговцев. Если мы предоставим ему ресурсы, он обещает вернуть все "
-"через неделю плюс некоторые проценты....\".\n"
-"Советник посмотрел на Вас с тревогой в глазах... Вы медленно кивнули: "
-"\"Хорошо, мы сможем использовать больше ресурсов\""
-
-#: ../fheroes2/resource/maps_text.cpp:44
-msgid "A ghostly pirate ship appears and sails on by."
-msgstr "Вдруг появляется пиратский корабль призрак, и проплавает мимо."
-
-#: ../fheroes2/resource/maps_text.cpp:45
-msgid ""
-"A Gift from your King, and a note that reads \"Use these resources wisely, "
-"It's all we have left\"."
-msgstr ""
-"Вы получили Подарок от Короля, и записку, в которой написано: \"Используй "
-"это разумно!\"."
-
-#: ../fheroes2/resource/maps_text.cpp:46
-msgid ""
-"A gift of gold, m'lord, from the people of Enroth, to the people of Enroth.  "
-"Good luck, and may God save true King Roland!"
-msgstr ""
-"Золото в подарок, мой Лорд, от народа Enroth, народу Enroth. Желаю удачи, и "
-"пусть Бог сохранит истинного Короля  Роланда!"
-
-#: ../fheroes2/resource/maps_text.cpp:47
-msgid "A glint by a tree catches your eye..."
-msgstr "Блеск по дереву бросается в глаза..."
-
-#: ../fheroes2/resource/maps_text.cpp:48
-msgid "A gold cache!"
-msgstr "Кошелек золота!"
-
-#: ../fheroes2/resource/maps_text.cpp:49
-msgid "A gold chunk!"
-msgstr "Немного золота!"
-
-#: ../fheroes2/resource/maps_text.cpp:50
-msgid "A gold nugget!"
-msgstr "Самородок золота!"
-
-#: ../fheroes2/resource/maps_text.cpp:51
-msgid ""
-"A great Black dragon stands before you. It speaks in a suprisingly soft "
-"voice, saying, \"The elves believe they have sent another hero to reclaim "
-"their prize. I believe they have sent me another meal.\""
-msgstr ""
-"Перед вами стоит Большой Черный Дракон. На удивление вам, он произносит "
-"мягким тихим голосом: \"Эльфы думают, что направили еще одного героя "
-"востребовать свой приз, Но Я Считаю, что они прислали мне еще один ужин!\""
-
-#: ../fheroes2/resource/maps_text.cpp:52
-msgid ""
-"A group of peasant farmers approaches you, \"We are in dire need of your "
-"assistance.  Our castle to the north has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-"Группа крестьян обратилась к тебе: \"Мы нуждаемся в Вашей помощи. Наш замок, "
-"на востоке, был разграблен и Лорда нашего убили. Пожалуйста, помогите нам "
-"вернуть наши дома! Там остались наши женщины и дети, помогите!\""
-
-#: ../fheroes2/resource/maps_text.cpp:53
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance.  Our castle to the east has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-"Группа крестьян обратилась к тебе: \"Мы нуждаемся в Вашей помощи. Наш замок, "
-"на востоке, был разграблен и Лорда нашего убили. Пожалуйста, помогите нам "
-"вернуть наши дома! Там остались наши женщины и дети, помогите!\""
-
-#: ../fheroes2/resource/maps_text.cpp:54
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance. Our castle to the east has been overrun and our Lord killed. "
-"Please help us regain our homes! There are still women and children there! "
-"Take what we have to help!\""
-msgstr ""
-"К Вам подошла группа крестьян, \"Мы нуждается в Вашей помощи. Наш замок, на "
-"востоке, был разграблен, и Хозяина нашего убили. Пожалуйста, помогите нам! "
-"Там осталось много женщин и детей! Мы готовы помоч!\""
-
-#: ../fheroes2/resource/maps_text.cpp:55
-msgid ""
-"A group of peasant farmers approach you, We are in dire need of your "
-"assistance.  Our castle to the northeast has been overrun and our Lord "
-"killed.  Please help us regain our homes!  There are still women and "
-"children there!  Take what we have to help!\""
-msgstr ""
-"К Вам подошла группа крестьян, \"Мы нуждается в Вашей помощи. Наш замок, на "
-"северо востоке, был разграблен, и Хозяина нашего убили. Пожалуйста, помогите "
-"нам! Там осталось много женщин и детей! Мы готовы помоч!\""
-
-#: ../fheroes2/resource/maps_text.cpp:56
-msgid "A handful of gems!"
-msgstr "Горсть алмазов!"
-
-#: ../fheroes2/resource/maps_text.cpp:57
-msgid ""
-"Ah, you stumble across something buried in the sand.  As you dig it up you "
-"discover a small pile of gems and crystal."
-msgstr ""
-"Вау, Вы случайно нашли что-то в песке. Вы начали копать и обнаружили "
-"небольшую груду драгоценных камней и кристаллов."
-
-#: ../fheroes2/resource/maps_text.cpp:58
-msgid ""
-"A Knight and Necromancer team up against the Barbarian and Sorceress. (Blue "
-"and Green vs Red and Yellow)"
-msgstr ""
-"Рыцарь и Некромант в команде против Варвара и Волшебницы. (Синий и Зеленый "
-"vs Красный, Желтый)"
-
-#: ../fheroes2/resource/maps_text.cpp:60
-msgid ""
-"A large contingent of the king's guard approaches you.  \"Ahh, we have "
-"finally caught up to you.  The king requires tribute from all of his vassals "
-"and you have been negligent far too long.\""
-msgstr ""
-"К Вам подошла большая толпа царской охраны. \"Ага подлец, наконец, мы тебя "
-"поймали. Все вассалы должны платить дань, а Вы что то давно забили на это..."
-"\""
-
-#: ../fheroes2/resource/maps_text.cpp:61
-msgid ""
-"A large map with lots of resources and treasure. Exploration and victory "
-"will require many heroes."
-msgstr ""
-"Большая карта где много ресурсов и сокровищ. Для разведки и победы "
-"потребуется много Героев."
-
-#: ../fheroes2/resource/maps_text.cpp:62
-msgid "A legion of peasants stands between you and this unclaimed island."
-msgstr "Легион крестьян стоит между вами и островом."
-
-#: ../fheroes2/resource/maps_text.cpp:63
-msgid "Algary"
-msgstr "Алгари"
-
-#: ../fheroes2/resource/maps_text.cpp:64
-msgid "A little bit closer..."
-msgstr "Немного ближе..."
-
-#: ../fheroes2/resource/maps_text.cpp:65
-msgid "All mines are grouped by type. Trade is your only hope."
-msgstr ""
-"Все шахты сгруппированы по типу. Торговля это Ваша единственная надежда."
-
-#: ../fheroes2/resource/maps_text.cpp:66
-msgid "A lump of crystal!"
-msgstr "Куча кристаллов!"
-
-#: ../fheroes2/resource/maps_text.cpp:67
-msgid "A lump of gold!"
-msgstr "Куча золота!"
-
-#: ../fheroes2/resource/maps_text.cpp:68
-msgid "A lump of mercury!"
-msgstr "Куча ртути!"
-
-#: ../fheroes2/resource/maps_text.cpp:69
-msgid ""
-"A man appears from behind the sand dune. \"At last,\" he says, \"Someone has "
-"come to rescue me! I am forever grateful. Alas all I have to offer you in "
-"return are these souvenirs from my wrecked ship.\""
-msgstr ""
-"Из-за песчаных дюн появился оборванец. \"О! Наконец то\" - говорит он, \"Кто-"
-"то пришел, чтобы спасти меня! Мои благодарности! Увы... все что я могу "
-"предложить Вам .. так это сувениры с моего погибшего корабля...\""
-
-#: ../fheroes2/resource/maps_text.cpp:70
-msgid ""
-"A man is laying on the ground, near death. He looks to you and speaks, "
-"\"Please help my companions! Please... they can't...cough...get away from..."
-"cough...the drag...\" With that, he dies."
-msgstr ""
-"На земле лежит умирающий человек. Он видит Вас и произносит, \"Пожалуйста, "
-"помоги моим товарищам! Пожалуйста... они не могут... кхе...  кхе.. кхе... "
-"ужасный кашель... сопротивление...\", и после этих слов он умерирает."
-
-#: ../fheroes2/resource/maps_text.cpp:71
-msgid ""
-"A merchant caravan arrives, bringing gold and supplies, however, no one can "
-"seem to remember where they came from.  You silently praise this anonymous "
-"benefactor and continue your duties."
-msgstr ""
-"Прибыл караван купцов, никто не знает откуда они, но их золото и товары "
-"пригодятся."
-
-#: ../fheroes2/resource/maps_text.cpp:72
-msgid "a mirror"
-msgstr "зеркало"
-
-#: ../fheroes2/resource/maps_text.cpp:73
-msgid "An albatross flies ahead of the ship for a while"
-msgstr "Альбатрос летит некоторое время перед судном"
-
-#: ../fheroes2/resource/maps_text.cpp:74
-msgid "Anduran"
-msgstr "Андуран"
-
-#: ../fheroes2/resource/maps_text.cpp:75
-msgid ""
-"An enemy from across the sea has seized half your towns.  Can you put aside "
-"your own feud with your brother to fight this common enemy?"
-msgstr ""
-"Враг из за моря захватил половину страны. Вы сможете отложить вражду, с "
-"собственным братом, для борьбы с этим общим врагом?"
-
-#: ../fheroes2/resource/maps_text.cpp:76
-msgid "\"Annexation\""
-msgstr "\"Присоединение\""
-
-#: ../fheroes2/resource/maps_text.cpp:77
-msgid ""
-"An old elf is sitting on a rock in a glen, pounding on the shackles on his "
-"feet with a stone. You help him remove them and ask him his tale. \"I'm a "
-"deserter from Drakonia's army. She has enslaved all the elves to support her "
-"madness. She must be stopped.\" Then he slips into the woods without a "
-"sound, leaving behind just his cloak."
-msgstr ""
-"На скале сидит старый эльф, стуча кандалами по камню. Вы помогаете ему "
-"удалить кандалы, и он рассказал Вам: \"Я дезертир из армии Драконии. Она "
-"безумна, и поработила всех эльфов. Ее нужно остановить\". Он оставил Вам "
-"свой плащ, и скрытно уходит в лес."
-
-#: ../fheroes2/resource/maps_text.cpp:78
-msgid "Antioch"
-msgstr "Антиош"
-
-#: ../fheroes2/resource/maps_text.cpp:79
-msgid "A piece of crystal!"
-msgstr "Кусочек кристалла!"
-
-#: ../fheroes2/resource/maps_text.cpp:80
-msgid "A pile of crystal!"
-msgstr "Куча кристаллов!"
-
-#: ../fheroes2/resource/maps_text.cpp:81
-msgid "A pile of gems!"
-msgstr "Куча драгоценных камней!"
-
-#: ../fheroes2/resource/maps_text.cpp:82
-msgid "A pile of gold!"
-msgstr "Куча золота!"
-
-#: ../fheroes2/resource/maps_text.cpp:83
-msgid ""
-"A plague of undead is upon us. Who will unite the living against the dead?"
-msgstr "Тьма нежити идет на нас. Кто объединит Живых против Мертвых?"
-
-#: ../fheroes2/resource/maps_text.cpp:84
-msgid "\"Apocalypse\""
-msgstr "Апокалипсис"
-
-#: ../fheroes2/resource/maps_text.cpp:85
-msgid "A quantity of crystal!"
-msgstr "Много кристаллов!"
-
-#: ../fheroes2/resource/maps_text.cpp:86
-msgid "A quantity of mercury!"
-msgstr "Много ртути!"
-
-#: ../fheroes2/resource/maps_text.cpp:87
-msgid "A quantity of sulfur!"
-msgstr "Много серы!"
-
-#: ../fheroes2/resource/maps_text.cpp:89
-msgid ""
-"Archibald has also sent an army to find the Crown, you must find it first or "
-"all is lost."
-msgstr ""
-"Арчибальд направил свою армию на поиски Короны. Вы должны найти этот "
-"артефакт первым."
-
-#: ../fheroes2/resource/maps_text.cpp:90
-msgid "Archibald is hiding at the end of the river."
-msgstr "Арчибальд скрывается в конце реки."
-
-#: ../fheroes2/resource/maps_text.cpp:91
-msgid ""
-"A resource rich valley keeps the Wizard and the Necromancer apart. Your "
-"opponent's army will arrive in 3 months so hurry."
-msgstr ""
-"Богатая ресурсами долина разделяет Волшебника и Некроманта друг от друга. У "
-"Вас есть 3 месяца."
-
-#: ../fheroes2/resource/maps_text.cpp:92
-msgid "Arm of the Crusader"
-msgstr "Рука Рыцаря"
-
-#: ../fheroes2/resource/maps_text.cpp:93
-msgid "Arm of the Cyclops"
-msgstr "Рука Циклопа"
-
-#: ../fheroes2/resource/maps_text.cpp:94
-msgid "Arm of the Dragon"
-msgstr "Крыло Дракона"
-
-#: ../fheroes2/resource/maps_text.cpp:95
-msgid "Arm of the Phoenix"
-msgstr "Крыло Феникса"
-
-#: ../fheroes2/resource/maps_text.cpp:96
-msgid "Arm of the Titan"
-msgstr "Рука Титана"
-
-#: ../fheroes2/resource/maps_text.cpp:97
-msgid "Arr' Here be pirates gold buried."
-msgstr "Арр.. Здесь спрятяно золото пиратов!"
-
-#: ../fheroes2/resource/maps_text.cpp:98
-msgid "A shipment of wood has arrived from your kingdom!"
-msgstr "Древесина прибыла от Вашего Королевства!"
-
-#: ../fheroes2/resource/maps_text.cpp:99
-msgid ""
-"A splash in the seaweed alerts you to a mermaid waving in a friendly manner. "
-"\"Oh, I thought you were Ahab.\" She is surprised, but quickly composes "
-"herself. \"Well, if you meet him, give him these treasures I have collected."
-"\""
-msgstr ""
-"Плеск в морских водорослях, предупреждает Вас о русалке. \"О, я думала, что "
-"ты Ахаб\". Она удивилась, но быстро сочиняет сама. \"Хорошо, если ты ним "
-"встретишься, передай эти сокровища...\""
-
-#: ../fheroes2/resource/maps_text.cpp:100
-msgid "Assassins tried to kill our ally."
-msgstr "Убийцы пытались убить нашего союзника."
-
-#: ../fheroes2/resource/maps_text.cpp:101
-msgid "Astircaer"
-msgstr "Астиркаер"
-
-#: ../fheroes2/resource/maps_text.cpp:102
-msgid ""
-"A stranded Wizard with only a small force must conquer an entire continent "
-"of hostile forces."
-msgstr ""
-"Нищий Волшебник с небольшой армией должен покорить весь континент враждебных "
-"сил."
-
-#: ../fheroes2/resource/maps_text.cpp:103
-msgid ""
-"A supply ship has arrived from the homeland!  You send word home that all is "
-"well."
-msgstr ""
-"Прибыл корабль с грузом! Вы отправляете с ним послание, что все хорошо."
-
-#: ../fheroes2/resource/maps_text.cpp:104
-msgid ""
-"As you approach the barrier, you see the old elf you helped free. This time, "
-"however, you see that he is wearing a cape of fine weave, and a wooden crown "
-"is on his head. He sees your forces, and says \"Take this sword, and with "
-"it, strike down Drakonia and help free my people.\" The old elf then strides "
-"regally into the woods."
-msgstr ""
-"Вы видите старого эльфа, в в плаще из тонкой ткани, и с деревянной короной "
-"на голове. Он говорит: \"Возьми этот меч, а вместе с ним победу над "
-"Драконией! Помоги освободить мой Народ\". После этого, он царственно ушел в "
-"лес."
-
-#: ../fheroes2/resource/maps_text.cpp:105
-msgid ""
-"As you approach the gates of the Ice Palace, one of your troops points in "
-"terror.  You watch in awe as great slabs of ice separate from the castle "
-"walls with loud cracking reports and crash to the ground.  Soon the ice is "
-"gone and the sun begins to peak through the gloom.  The deathly silence that "
-"must have ruled these lands for centuries ends as birds begin to sing.  From "
-"inside you hear the sounds of life."
-msgstr ""
-"Вы приближаетесь к воротам Ледового Дворца. Ваши воины застыли в ужасе и Вы "
-"смотрите в страхе, как большие ледовые плиты, отделяются от Дворца и с "
-"громким грохотом и падают на землю. Вскоре весь лед ушел, и солнце начинает "
-"светить во мраке. Гробовое молчание, которое на протяжении веков "
-"присутствовало здесь, прерывается пением неизвестных птиц. Жизнь "
-"возвращается..."
-
-#: ../fheroes2/resource/maps_text.cpp:106
-msgid ""
-"As you approach the tent, the leader of the nomads comes out to greet you. "
-"He says, \"It was prophecied many years ago that a great hero would come to "
-"greet us in our sacred valley, and we would prosper afterwords. Now it has "
-"come to pass, and we offer you these gifts as tokens of our thanks.\""
-msgstr ""
-"Вы приближаетесь к палатке кочевников, из нее выходит Вождь. Он произносит: "
-"\"Много лет назад было пророчество, к нам придет Великий Герой, и мы будем "
-"процветать.. Теперь это свершилось, и мы предлагаем вам эти подарки в знак "
-"благодарности.\""
-
-#: ../fheroes2/resource/maps_text.cpp:107
-msgid ""
-"As you approach,  you hear whispered mentions of \"the wild barbarian who "
-"passed this way months before\". One of the villagers approaches you and "
-"hands you an object, saying \"The wild one dropped this. You must be his "
-"kin. Therefore I give it to you. But beware! Many in the village will not be "
-"as friendly as I.\""
-msgstr ""
-"Приближаясь, Вы слышите таинственные упоминания о \"диком варваре, чей путь "
-"проходил здесь много месяцев назад\". Один из поселенцев приближается к Вам "
-"и вручает предмет со словами - \"Дикарь обронил его. Вы должно быть его "
-"родственник. Поэтому я отдаю его Вам. Но остерегайтесь! Немногие из деревни "
-"будут дружелюбны к Вам так , как Я"
-
-#: ../fheroes2/resource/maps_text.cpp:108
-msgid ""
-"As you break your fast your sage rushes in, \"Good news, my lord!  I have "
-"translated the message.  Two great heroes were imprisoned many years ago.  "
-"They lie sleeping - still guarded by magic barriers and monsters.  My lord, "
-"they lie nearby- in between our ally and us.  If we could free them, they "
-"would surely aid us against our enemies!  The password to the first magic "
-"barrier can be learned at the Aqua Traveller's Tent.\""
-msgstr ""
-"Как только вы входите, к Вам подбегает слуга, \"Хорошие вести, Господин! Я "
-"преревел послание. Двое великих героев были заточены много лет назад. Они "
-"спят, по прежнему охраняемые магическими барьерами и чудовищами. Господин, "
-"они лежат неподалеку, между союзниками и нами. Если бы Мы могли свободить "
-"их, они наверняка поддержали бы нас против наших врагов! Пароль к первому "
-"магическому барьеру можно узнать В Палатке Подводного Странника."
-
-#: ../fheroes2/resource/maps_text.cpp:109
-msgid ""
-"As you enter the small clearing, you see a familiar figure talking to a "
-"group of halflings and soldiers. You stay awhile and listen to his speech. "
-"\"The time to throw off these chains of tyranny is now! We must strike at "
-"the heart of her empire, and destroy the evil that she has brought to our "
-"land.\" As the old elf finishes speaking, he gets up from his mossy seat and "
-"once again, blends into the woods with incredible grace."
-msgstr ""
-"Выходя к пашне, Вы видите знакомую фигуру, разговаривающую с группой "
-"полуросликов и солдат. Вы останавливаетесь и подслушиваете разговор. "
-"\"Настало время сбросить оковы Тирании! Мы должны нанести удар в сердце ее "
-"империи и разгромить зло, которое она принесла в наши земли.\" Заканчивая "
-"речь, старый эльф встает с мшистого пня и скрывается в лесу с невероятной "
-"ловкостью."
-
-#: ../fheroes2/resource/maps_text.cpp:110
-msgid ""
-"As you lay down to nap after a long battle, you notice a lucky four-leaf "
-"clover."
-msgstr ""
-"Вы ложитесь подремать после длинного сражения, и замечаете четырехлистный "
-"клевер, который приносит Удачу."
-
-#: ../fheroes2/resource/maps_text.cpp:111
-msgid ""
-"As you make  your way through the last of the golemn debris, a group of "
-"halflings runs towards you carrying fruit and flowers. \"Thank you so much!"
-"\" Their leader exclaims, \"We've been trapped in here for ever! Come by our "
-"homes, we'll pack up and go with you!\""
-msgstr ""
-"Как только Вы выбираетесь из-под обломков последнего голема, группа "
-"половинчиков бежит к Вам, неся фрукты и цветы. \"Огромное Вам спасибо!\" "
-"восклицает их лидер, \"Мы провели целую вечность в неволе! Заглядывайте в "
-"гости и мы пойдём с Вами!\""
-
-#: ../fheroes2/resource/maps_text.cpp:112
-msgid ""
-"As you make your way to the shrine, some very thin and hollow-eyed men come "
-"out of the flower patch and stare at you.  Seeing that you want the gold, "
-"one of them says to you \"Hey, man, if you're, like, so lusty for earthly "
-"wealth, then, like, have this too.\" You graciously take what they have "
-"offered and back out of the clearing."
-msgstr ""
-"По дороге в склеп Вы встречаете несколько очень худых людей с пустыми "
-"глазами, которые вышли из палисадника и теперь пялятся на Вас. Видя, что Вы "
-"хотите золото, один из них говорит Вам \"Эй, брат, если ты, типа, так "
-"желаешь материальных благ, то тогда, типа, возьми ещё и вот это.\" Вы "
-"элегантно принимаете то, что они Вам предлагают и уносите ноги."
-
-#: ../fheroes2/resource/maps_text.cpp:113
-msgid ""
-"As you prepare your lands to fight the onslaught from the South, a curious "
-"message appears on your table in the Great Hall of your Castle.  Written in "
-"some ancient language, none but your sage can make any sense of it.  She "
-"promises to have the words deciphered by tomorrow..."
-msgstr ""
-"Во время приготовлений Ваших земель к противостоянию бойне с Юга, любопытное "
-"сообщение появляется на Вашем столе в Большой Зале Вашего Замка. Оно "
-"написано на каком-то древнем языке и никто, кроме Вашего мудреца не может "
-"ничего разобрать. Она обещает, что переведёт загадочные слова к утру..."
-
-#: ../fheroes2/resource/maps_text.cpp:114
-msgid "A three hour tour, a three hour tour..."
-msgstr "Трехчасовой тур, трехчасовой тур..."
-
-#: ../fheroes2/resource/maps_text.cpp:115
-msgid ""
-"A tiny gnome points to a chunk of crystal you otherwise would have "
-"overlooked!"
-msgstr ""
-"Маленький гном указывает на кусочек кристалла, который Вы, иначе, пропустили "
-"бы!"
-
-#: ../fheroes2/resource/maps_text.cpp:116
-msgid "Atlantium"
-msgstr "Атлантиум"
-
-#: ../fheroes2/resource/maps_text.cpp:117
-msgid ""
-"At last, the king is dead.  For years you have planned his demise, but now "
-"it is done, and there is no heir to take his place, though the Knights to "
-"the south believe that they are the rightful successors.  A wealth in wood "
-"(to the south) and ore (in the northern mountains) provides you with trade "
-"goods, and your isolation has allowed you to prepare your forces of darkness "
-"for this day.  Go, now, and fulfill your destiny!"
-msgstr ""
-"Наконец-то, король пал. Годами Вы планировали его свержение и вот оно "
-"свершилось, но нет преемника, чтобы занять его место, хотя Рыцари с юга и "
-"считают, что они являются законными наследниками. Богатые леса (на юге) и "
-"залежи руды (в северных горах) откроют Вам путь на рыночную арену, а Ваша "
-"изолированность позволит Вам приготовить силы тьмы к этому дню. Идите же и "
-"исполните своё предназначение!"
-
-#: ../fheroes2/resource/maps_text.cpp:118
-msgid ""
-"At the base of the mountain you see something that glitters.   You discover "
-"an ancient pile of offerings to the gods."
-msgstr ""
-"В основании горы Вы увидели кое-что блестящее. Там Вы обнаруживаете древнюю "
-"груду, посланную вам богами."
-
-#: ../fheroes2/resource/maps_text.cpp:119
-msgid "Avalon"
-msgstr "Авалон"
-
-#: ../fheroes2/resource/maps_text.cpp:120
-msgid "Avone"
-msgstr "Авона"
-
-#: ../fheroes2/resource/maps_text.cpp:121
-msgid ""
-"A wild magic has allowed a bridge to form between two lands...  Your one "
-"hope is to capture castle \"Black Fang\"."
-msgstr ""
-"Необузданная магия сотворила мост между двумя землями... Ваша единственная "
-"надежда - захватить замок \"Чёрный Клык\"."
-
-#: ../fheroes2/resource/maps_text.cpp:122
-msgid "Barbarian's castle lies to the south."
-msgstr "Замок Варваров находится ближе к Югу."
-
-#: ../fheroes2/resource/maps_text.cpp:123
-msgid ""
-"Barbarians from the north threaten all civilization. Can you repel the "
-"hordes?"
-msgstr ""
-"Варвары с Севера угрожают всей цивилизации. Вы сможете отразить эти орды?"
-
-#: ../fheroes2/resource/maps_text.cpp:124
-msgid "\"Barbarian Wars\""
-msgstr "\"Война Варваров\""
-
-#: ../fheroes2/resource/maps_text.cpp:125
-msgid "Barrowton"
-msgstr "Барраутаун"
-
-#: ../fheroes2/resource/maps_text.cpp:126
-msgid "Basenji"
-msgstr "Басенджи"
-
-#: ../fheroes2/resource/maps_text.cpp:127
-msgid "Bayside"
-msgstr "Байсид"
-
-#: ../fheroes2/resource/maps_text.cpp:128
-msgid "Baywatch"
-msgstr "Байватч"
-
-#: ../fheroes2/resource/maps_text.cpp:129
-msgid ""
-"Because the Darkscale Valley is so barren, the Emperor will be sending wood "
-"to you every week. Use it wisely, for it is all you shall have."
-msgstr ""
-"Из-за того, что Долина Тёмной Чешуи так пустынна, Император будет высылать "
-"Вам древесину каждую неделю. Расходуйте её мудро, кроме неё Вы ничего не "
-"получите."
-
-#: ../fheroes2/resource/maps_text.cpp:130
-msgid ""
-"Before questing for the orb of negation, you must first crush the local "
-"opposition. After the Sorceresses are removed from the earth, go east where "
-"legend says the orb lies.  You may expect a convoy of supplies in a week or "
-"so to aid your conquest."
-msgstr ""
-"Перед походом за сферой отрицания, Вам необходимо сокрушить местную "
-"оппозицию. После того, как все Волшебницы будут убиты, отправляйтесь на "
-"восток, где, судя по легенде, находится сфера. Караван ресурсов в помощь "
-"Вашему завоеванию прибудет через неделю или около того."
-
-#: ../fheroes2/resource/maps_text.cpp:131
-msgid ""
-"Before you may pass, the spirit guardian of this valley demands tribute."
-msgstr "Дух-страж требует плату за проход."
-
-#: ../fheroes2/resource/maps_text.cpp:132
-msgid "Being held...."
-msgstr "Проходит..."
-
-#: ../fheroes2/resource/maps_text.cpp:133
-msgid "Beltway"
-msgstr "Кольцевой путь"
-
-#: ../fheroes2/resource/maps_text.cpp:134
-msgid "\"Betrayal!\""
-msgstr "\"Измена!\""
-
-#: ../fheroes2/resource/maps_text.cpp:135
-msgid "Beware -- Entering Hyrda Country"
-msgstr "Осторожно -- Здесь Страна Гидр"
-
-#: ../fheroes2/resource/maps_text.cpp:136
-msgid "Beware for whom the bell trolls."
-msgstr "Осторожно, слышно рычание Троллей."
-
-#: ../fheroes2/resource/maps_text.cpp:137
-msgid "Beware of Pirates!"
-msgstr "Остерегайся Пиратов!"
-
-#: ../fheroes2/resource/maps_text.cpp:138
-msgid "Beware of thieves!"
-msgstr "Остерегайся Воров!"
-
-#: ../fheroes2/resource/maps_text.cpp:139
-msgid "Beware of traps ahead."
-msgstr "Остерегайтесь ловушек"
-
-#: ../fheroes2/resource/maps_text.cpp:140
-msgid "Beware of Warlocks"
-msgstr "Остерегайтесь Волшебников."
-
-#: ../fheroes2/resource/maps_text.cpp:141
-msgid "Beware the deadly swamps!"
-msgstr "Осторожно, зедсь мертвая пустыня!"
-
-#: ../fheroes2/resource/maps_text.cpp:142
-msgid "Beware the Domain of Dragons"
-msgstr "Остерегайтесь Владений Драконов"
-
-#: ../fheroes2/resource/maps_text.cpp:143
-msgid "Beware the Dragon Leader"
-msgstr "Остерегайтесь Лидера Драконов"
-
-#: ../fheroes2/resource/maps_text.cpp:144
-msgid "Beware the edge of the world!"
-msgstr "Остерегайся, здесь край мира!"
-
-#: ../fheroes2/resource/maps_text.cpp:145
-msgid "Beware the moors and stick to the roads."
-msgstr "Остерегайся мавров и дураков на дороге."
-
-#: ../fheroes2/resource/maps_text.cpp:146
-msgid "Beware the rocks"
-msgstr "Остерегайтесь рифов"
-
-#: ../fheroes2/resource/maps_text.cpp:147
-msgid "Beware the sirens!!!"
-msgstr "Остерегайтесь Сирен!!!"
-
-#: ../fheroes2/resource/maps_text.cpp:148
-msgid "Beware the sirens!"
-msgstr "Остерегайтесь Сиррен!!!"
-
-#: ../fheroes2/resource/maps_text.cpp:149
-msgid "Beware the whiporwill..."
-msgstr "Остерегайтесь водоворотов..."
-
-#: ../fheroes2/resource/maps_text.cpp:150
-msgid "Beware, the whirlpool may not take you into a friendly embrace."
-msgstr "Осторожно, здесь очень коварные водовороты."
-
-#: ../fheroes2/resource/maps_text.cpp:151
-msgid "Beyond here be Dragons!"
-msgstr "Здесь обитают Драконы!"
-
-#: ../fheroes2/resource/maps_text.cpp:152
-msgid "Beyond the door, there be Dragons. BEWARE!"
-msgstr "За сей дверью обитают Драконы. БЕРЕГИСЬ!"
-
-#: ../fheroes2/resource/maps_text.cpp:153
-msgid "Big Oak"
-msgstr "Большой Дуб"
-
-#: ../fheroes2/resource/maps_text.cpp:154
-msgid "Blackburn"
-msgstr "Блэкбурн"
-
-#: ../fheroes2/resource/maps_text.cpp:155
-msgid "Blackfang"
-msgstr "Черный Клык"
-
-#: ../fheroes2/resource/maps_text.cpp:156
-msgid "Black Fang"
-msgstr "Черный Клык"
-
-#: ../fheroes2/resource/maps_text.cpp:157
-msgid "Black Oak"
-msgstr "Черный ДУб"
-
-#: ../fheroes2/resource/maps_text.cpp:158
-msgid "Blackridge"
-msgstr "Блэкридж"
-
-#: ../fheroes2/resource/maps_text.cpp:159
-msgid "Blacksford"
-msgstr "Блэкфорд"
-
-#: ../fheroes2/resource/maps_text.cpp:160
-msgid "Black Vein"
-msgstr "Блэквейн"
-
-#: ../fheroes2/resource/maps_text.cpp:161
-msgid "Blackwind"
-msgstr "Черный Ветер"
-
-#: ../fheroes2/resource/maps_text.cpp:162
-msgid "Bloodreign"
-msgstr "Блудрейн"
-
-#: ../fheroes2/resource/maps_text.cpp:163
-msgid "Boats my be needed to access some parts of this peninsula."
-msgstr ""
-"Возможно, потребуется корабль, чтобы достичь некоторых земель этого "
-"полуострова."
-
-#: ../fheroes2/resource/maps_text.cpp:164
-msgid "Boats Sold Here            Inquire Within"
-msgstr "Продажа Кораблей Консультация На Месте"
-
-#: ../fheroes2/resource/maps_text.cpp:165
-msgid "BoneVille"
-msgstr "КостеГрад"
-
-#: ../fheroes2/resource/maps_text.cpp:166
-msgid "Borderlands"
-msgstr "Пограничье"
-
-#: ../fheroes2/resource/maps_text.cpp:167
-msgid "Bridge out!"
-msgstr "За Мост!"
-
-#: ../fheroes2/resource/maps_text.cpp:168
-msgid "Bridge Out!"
-msgstr "За Мост!"
-
-#: ../fheroes2/resource/maps_text.cpp:169
-msgid "Brindamoor"
-msgstr "Бриндамур"
-
-#: ../fheroes2/resource/maps_text.cpp:170
-msgid "Broken Alliance"
-msgstr "Разрушенный Союз"
-
-#: ../fheroes2/resource/maps_text.cpp:171
-msgid "Brownston"
-msgstr "Браунстон"
-
-#: ../fheroes2/resource/maps_text.cpp:172
-msgid "Buried Treasure!"
-msgstr "Клад!"
-
-#: ../fheroes2/resource/maps_text.cpp:173
-msgid "Burlock"
-msgstr "Барлок"
-
-#: ../fheroes2/resource/maps_text.cpp:174
-msgid "Burton"
-msgstr "Бартон"
-
-#: ../fheroes2/resource/maps_text.cpp:175
-msgid ""
-"Capture the necromancer's dreaded castle \"Death Gate\" and free the land "
-"from the undead plague."
-msgstr ""
-"Захватите ужасный замок колдунов \"Мертвые Ворота\" и освободите долину от "
-"мертвой чумы."
-
-#: ../fheroes2/resource/maps_text.cpp:176
-msgid ""
-"Capture the town on the island off the southeast shore in order to construct "
-"a boat and travel back towards the mainland."
-msgstr ""
-"Захватите город на острове к юго-западу от побережья для того, чтобы "
-"построить лодку, и вернитесь обратно на материк."
-
-#: ../fheroes2/resource/maps_text.cpp:177
-msgid "\"Carator Mines\""
-msgstr "\"Шахты Каратора\""
-
-#: ../fheroes2/resource/maps_text.cpp:178
-msgid "Cathcart"
-msgstr "Кечкарт"
-
-#: ../fheroes2/resource/maps_text.cpp:180
-msgid "Chandler"
-msgstr "Чандлер"
-
-#: ../fheroes2/resource/maps_text.cpp:181
-msgid "Chilton"
-msgstr "Чилтон"
-
-#: ../fheroes2/resource/maps_text.cpp:182
-msgid "Chronos"
-msgstr "Хронос"
-
-#: ../fheroes2/resource/maps_text.cpp:183
-msgid "Come and...."
-msgstr "Ну и ..."
-
-#: ../fheroes2/resource/maps_text.cpp:184
-msgid ""
-"Compared to the rest of the villages in this land, this village seems grand, "
-"but in any other land it would seem poor. From here you can see the tall "
-"spires of the Warlock's tower of Dragons."
-msgstr ""
-"По сравнению с остальными деревнями, эта кажется богатой, но в любых других "
-"землях она показалась бы нищей. Отсюда можно увидеть стройные шпили "
-"Драконьей башни Чернокнижника."
-
-#: ../fheroes2/resource/maps_text.cpp:185
-msgid "Complete"
-msgstr "Выполнено"
-
-#: ../fheroes2/resource/maps_text.cpp:186
-msgid "Condemned!"
-msgstr "Осуждены!"
-
-#: ../fheroes2/resource/maps_text.cpp:187
-msgid ""
-"Congratulations! After navigating the treacherous coast, you have "
-"established trade between the north and south."
-msgstr ""
-"Поздравляем! После причаливания на коварное побережье, Вы установили "
-"торговлю между Севером и Югом."
-
-#: ../fheroes2/resource/maps_text.cpp:188
-msgid "Corackston"
-msgstr "Коракстон"
-
-#: ../fheroes2/resource/maps_text.cpp:189
-msgid "Corlagon"
-msgstr "Корлагон"
-
-#: ../fheroes2/resource/maps_text.cpp:190
-msgid "\"Country Lords\""
-msgstr "\"Страна Лордов\""
-
-#: ../fheroes2/resource/maps_text.cpp:191
-msgid "Crossroads"
-msgstr "Перекресток"
-
-#: ../fheroes2/resource/maps_text.cpp:192
-msgid "Crossroads North"
-msgstr "Северное Шоссе"
-
-#: ../fheroes2/resource/maps_text.cpp:193
-msgid "Crossroads South"
-msgstr "Южное Шоссе"
-
-#: ../fheroes2/resource/maps_text.cpp:195
-msgid "Danger a whirlpool destroyed my ship."
-msgstr "Опасный водоворот разрушил мой кораболь."
-
-#: ../fheroes2/resource/maps_text.cpp:196
-msgid "Danger, Dragons abound!"
-msgstr "Опасность! Драконы вокруг.. ё маё!"
-
-#: ../fheroes2/resource/maps_text.cpp:197
-msgid "DANGER!  QUICKSAND!"
-msgstr "Опасность! Зыбучие Пески!"
-
-#: ../fheroes2/resource/maps_text.cpp:198
-msgid "Danger! Troll bridge ahead!"
-msgstr "Опасность! Впереди мост с Троллями!"
-
-#: ../fheroes2/resource/maps_text.cpp:199
-msgid "Danger - Turn Back Now"
-msgstr "Опасность - Немедленно Возвращайся Назад"
-
-#: ../fheroes2/resource/maps_text.cpp:200
-msgid "Dark clouds loom overhead as you enter this valley."
-msgstr ""
-"Как только вы входите в долину, над головой появляется тень от облаков."
-
-#: ../fheroes2/resource/maps_text.cpp:201
-msgid "Dead Pine"
-msgstr "Мертвая Сосна"
-
-#: ../fheroes2/resource/maps_text.cpp:202
-msgid ""
-"Dear Diary,                           I found a mermaid today.  She was "
-"floating in a patch of seaweed next to a rock.  A very friendly sort of "
-"creature too!  Gave me all sorts of lovely gems and jewelry!  She said to "
-"come back again sometime for more of the sea riches.  Wow. Ahab"
-msgstr ""
-"Дорогой дневник, сегодня я встретил русалку. Она плавала в морских "
-"водорослях неподалёку от скал. Она оказалась очень дружелюбной! Подарила мне "
-"драгоценных камней и золотых украшений! А ещё сказала возвращаться когда-"
-"нибудь за добавкой морских сокровищ. Блин."
-
-#: ../fheroes2/resource/maps_text.cpp:203
-msgid "Deathgate"
-msgstr "Ворота Мертвецов"
-
-#: ../fheroes2/resource/maps_text.cpp:204
-msgid "DeathGate"
-msgstr "Ворота Мертвецов"
-
-#: ../fheroes2/resource/maps_text.cpp:205
-msgid "Decisions"
-msgstr "Решения"
-
-#: ../fheroes2/resource/maps_text.cpp:206
-msgid "\"Defender\""
-msgstr "\"Защитник\""
-
-#: ../fheroes2/resource/maps_text.cpp:207
-msgid ""
-"Destroy the Barbarians who are attacking the southern border of your "
-"kingdom! Recover your towns and then invade the jungle kingdom."
-msgstr ""
-"Уничтожьте варваров, атакующих южные границы вашего королевства. Верните "
-"свои города, затем завоюйте варварские."
-
-#: ../fheroes2/resource/maps_text.cpp:208
-msgid ""
-"Detour! Mountain pass to the East has been known to have avalanches! For "
-"your own safety, follow the road South."
-msgstr ""
-"В объезд! Горный проход на Востоке закрыт, опасность лавин! Следуйте дорогой "
-"Юга."
-
-#: ../fheroes2/resource/maps_text.cpp:209
-msgid "Detour! Troll bridge ahead!"
-msgstr "В объезд! Впереди мост троллей!"
-
-#: ../fheroes2/resource/maps_text.cpp:211
-msgid "DirtWater"
-msgstr "Грязная Вода"
-
-#: ../fheroes2/resource/maps_text.cpp:212
-msgid "Dominion"
-msgstr "Власть"
-
-#: ../fheroes2/resource/maps_text.cpp:213
-msgid "Do Not Enter!"
-msgstr "Вход Запрешен!"
-
-#: ../fheroes2/resource/maps_text.cpp:214
-msgid "Do not remove coins from fountain."
-msgstr "Не забирайте монеты из фонтана."
-
-#: ../fheroes2/resource/maps_text.cpp:215
-msgid "Dragadune"
-msgstr "Драгадун"
-
-#: ../fheroes2/resource/maps_text.cpp:216
-msgid "Dragonburg"
-msgstr "Драконье Клеймо"
-
-#: ../fheroes2/resource/maps_text.cpp:218
-msgid "Dragon City lies beyond the Scorpion Hills."
-msgstr "Город Драконов находится за пределами Скорпион Хиллз."
-
-#: ../fheroes2/resource/maps_text.cpp:219
-msgid "Dragon Hill"
-msgstr "Драконья Горка"
-
-#: ../fheroes2/resource/maps_text.cpp:220
-msgid "\"Dragon Master\""
-msgstr "\"Повелитель Драконов\""
-
-#: ../fheroes2/resource/maps_text.cpp:221
-msgid "Dragon Rider"
-msgstr "Драконья Река"
-
-#: ../fheroes2/resource/maps_text.cpp:222
-msgid "Dragons Everywhere!"
-msgstr "Везде Драконы!"
-
-#: ../fheroes2/resource/maps_text.cpp:223
-msgid "Dragon's Eye"
-msgstr "Глаз Дракона"
-
-#: ../fheroes2/resource/maps_text.cpp:224
-msgid "Dragontooth"
-msgstr "Драконий Зуб"
-
-#: ../fheroes2/resource/maps_text.cpp:225
-msgid "Dragon Town"
-msgstr "Город Драконов"
-
-#: ../fheroes2/resource/maps_text.cpp:226
-msgid "Dragonville"
-msgstr "Деревьня Драконов"
-
-#: ../fheroes2/resource/maps_text.cpp:227
-msgid "Dragon Wars"
-msgstr "Битва Драконов"
-
-#: ../fheroes2/resource/maps_text.cpp:228
-msgid "Dragon Watch"
-msgstr "Стража Драконов"
-
-#: ../fheroes2/resource/maps_text.cpp:230
-msgid "Drakoran"
-msgstr "Дракоран"
-
-#: ../fheroes2/resource/maps_text.cpp:231
-msgid "Dwarfhall"
-msgstr "Город Гномов"
-
-#: ../fheroes2/resource/maps_text.cpp:232
-msgid "Dwarfhall, Domain of the dwarf King."
-msgstr "Город Гномов, владения Короля Гномов."
-
-#: ../fheroes2/resource/maps_text.cpp:233
-msgid "Dwarf Hall, domain of the dwarf King."
-msgstr "Город Гномов, владения Короля Гномов."
-
-#: ../fheroes2/resource/maps_text.cpp:234
-msgid "Eatio"
-msgstr "Поедун"
-
-#: ../fheroes2/resource/maps_text.cpp:235
-msgid "Edgewood"
-msgstr "Эджвуд"
-
-#: ../fheroes2/resource/maps_text.cpp:236
-msgid "Elk's Head"
-msgstr "Голова Элка"
-
-#: ../fheroes2/resource/maps_text.cpp:237
-msgid "Elowyn"
-msgstr "Эловин"
-
-#: ../fheroes2/resource/maps_text.cpp:238
-msgid "Enroth"
-msgstr "Земля"
-
-#: ../fheroes2/resource/maps_text.cpp:239
-msgid "Entering high in the desert"
-msgstr "Вступаете в плато в пустыне"
-
-#: ../fheroes2/resource/maps_text.cpp:240
-msgid "Entering Praires of the Middlelands"
-msgstr "Вступаете в Прерии Срединных Земель"
-
-#: ../fheroes2/resource/maps_text.cpp:241
-msgid "Entering the desert high"
-msgstr "Вступаете в пустынное плато"
-
-#: ../fheroes2/resource/maps_text.cpp:242
-msgid "Entering the high desert"
-msgstr "Вступаете в пустыню на плато"
-
-#: ../fheroes2/resource/maps_text.cpp:243
-msgid "Entering the higher desert"
-msgstr "Вступаете в пустыню над плато"
-
-#: ../fheroes2/resource/maps_text.cpp:244
-msgid "Entering the Valley of Magic"
-msgstr "Вступаете в Долину Магии"
-
-#: ../fheroes2/resource/maps_text.cpp:245
-msgid "Erliquin"
-msgstr "Эрликвин"
-
-#: ../fheroes2/resource/maps_text.cpp:246
-msgid "Evil Igor"
-msgstr "Злой Игор"
-
-#: ../fheroes2/resource/maps_text.cpp:247
-msgid "Fadlan"
-msgstr "Фадлан"
-
-#: ../fheroes2/resource/maps_text.cpp:248
-msgid "Fantasy Island."
-msgstr "Остров Фантазии."
-
-#: ../fheroes2/resource/maps_text.cpp:249
-msgid "Farlien"
-msgstr "Фарлин"
-
-#: ../fheroes2/resource/maps_text.cpp:250
-msgid ""
-"Federal express, when it absolutely positively has to be there turn one."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:251
-msgid "fedx comp"
-msgstr "Подачка для АИ"
-
-#: ../fheroes2/resource/maps_text.cpp:252
-msgid "Fedx for comp"
-msgstr "Подачка для АИ"
-
-#: ../fheroes2/resource/maps_text.cpp:253
-msgid "Fenton"
-msgstr "Фентон"
-
-#: ../fheroes2/resource/maps_text.cpp:254
-msgid "Fetid Elm"
-msgstr "Зловонный Вяз"
-
-#: ../fheroes2/resource/maps_text.cpp:255
-msgid ""
-"Final message from Overlord. \"The royal executioners are on their way. My "
-"gold, the land or your head- it's your choice.\""
-msgstr ""
-"Последнее сообщение от Оверлорда. \"Королевские палачи уже выехали. Моё "
-"золота и земля или твоя голова - выбор за тобой.\""
-
-#: ../fheroes2/resource/maps_text.cpp:256
-msgid "Find and defeat the Pirate Leader!"
-msgstr "Найдите и убейте Лидера Пиратов!"
-
-#: ../fheroes2/resource/maps_text.cpp:257
-msgid "Find and destroy the evil beings who rule the wastelands."
-msgstr "Найдите и уничтожьте злых существ, управляющих пустошами."
-
-#: ../fheroes2/resource/maps_text.cpp:258
-msgid "Find the center island."
-msgstr "Найдите центральный остров."
-
-#: ../fheroes2/resource/maps_text.cpp:259
-msgid ""
-"Find the Ultimate Artifact and be proclaimed King, or smash the opposition "
-"and take control."
-msgstr ""
-"Найдите Главную Реликвию и будете провозглашены Королём или же уничтожьте "
-"противников и захватите власть."
-
-#: ../fheroes2/resource/maps_text.cpp:260
-msgid ""
-"Find Your Wayward Son who is rumored to be living in the desolate lands. Do "
-"it within 8 weeks or it will be of no help to your family."
-msgstr ""
-"Найдите Вашего Блудного Сына, который, по слухам, живёт в бесплодных землях. "
-"Сделайте это за 8 недель, иначе будет поздно."
-
-#: ../fheroes2/resource/maps_text.cpp:261
-msgid "Fire King"
-msgstr "Король Огня"
-
-#: ../fheroes2/resource/maps_text.cpp:262
-msgid "\"First Blood\""
-msgstr "\"Первая кровь\""
-
-#: ../fheroes2/resource/maps_text.cpp:263
-msgid "Five heroes vie for control of a familiar land."
-msgstr "Пять героев сошлись в схватке за фамильные земли."
-
-#: ../fheroes2/resource/maps_text.cpp:264
-msgid "Fool's Gold"
-msgstr "Золото дурака"
-
-#: ../fheroes2/resource/maps_text.cpp:265
-msgid ""
-"For a total of 400,000 gold your opponents will become \"loyal\" subjects, "
-"otherwise... let them eat cake!"
-msgstr ""
-"За 400,000 золотых Ваши соперники станут \"верноподданными\", или же... "
-"задайте им жару!"
-
-#: ../fheroes2/resource/maps_text.cpp:266
-msgid ""
-"For centuries, the Wizards of the North have maintained a vast library for "
-"all the world to share.  Now, however, they have closed their doors, and "
-"issued declarations of war to each of the other rulers of the land.  To make "
-"matters worse, rather than ally with you to face the Wizards, each of the "
-"others have decided to go forth on their own in an effort to conquer this "
-"land for themselves!  Prepare your forces, commander, for you now stand "
-"alone."
-msgstr ""
-"Веками, Волшебники Севера содержали огромную библиотеку, которую мог "
-"посетить каждый. Как бы то ни было, сегодня они закрыли свои двери и "
-"объявили войну всем остальным феодалам. Ещё хуже то, что вместо союза против "
-"Волшебников, каждый из лордов решил в одиночку завоевать эти земли! "
-"Готовьтесь к бою, командир, теперь Вы сам за себя."
-
-#: ../fheroes2/resource/maps_text.cpp:267
-msgid "\"Force of Arms\""
-msgstr "\"Сила Оружия\""
-
-#: ../fheroes2/resource/maps_text.cpp:268
-msgid ""
-"For decades you have studied, learned, and allowed yourself to be ruled by "
-"that pitiful excuse for a king, knowing that one day the time would come for "
-"you to sit on the throne.  That time is now, for the king is dead and "
-"without an heir.  You have the advantage of isolation from the rest of the "
-"kingdom, but beware the miles of coastline that could leave you vulnerable "
-"to attack.  Go, now, and wipe your enemies from this land!"
-msgstr ""
-"Десятилетиями ты учился, готовился и позволял помыкать собой этим жалким "
-"подобием короля, зная, что придёт день, когда ты сам займёшь трон. Пришло "
-"время смерти короля и отсутствия наследника. У тебя преимущество "
-"обособленности от остальной части королевства, но будь осторожен с милями "
-"побережья - там ты уязвим к нападению. Иди же и сотри своих врагов с лица "
-"этой земли!"
-
-#: ../fheroes2/resource/maps_text.cpp:269
-msgid "Forder Oaks"
-msgstr "Фордер Окс"
-
-#: ../fheroes2/resource/maps_text.cpp:270
-msgid "Forestria"
-msgstr "Форестия"
-
-#: ../fheroes2/resource/maps_text.cpp:271
-msgid "For Honor"
-msgstr "За Честь"
-
-#: ../fheroes2/resource/maps_text.cpp:272
-msgid ""
-"For information about Ye Rich lands to the south, speak to Alponse at the "
-"Golden Goose Tavern. Excellent views, plentiful water."
-msgstr ""
-"Для получения информации о богатых землях на юге, поговорите с Альпонсом в "
-"таверне Золотой Гусь. Отличная еда и выпивка..."
-
-#: ../fheroes2/resource/maps_text.cpp:273
-msgid "Forsaken Lands"
-msgstr "Покинутые Земли"
-
-#: ../fheroes2/resource/maps_text.cpp:274
-msgid "For sale."
-msgstr "Продается."
-
-#: ../fheroes2/resource/maps_text.cpp:275
-msgid "Fortress Isle"
-msgstr "Остров Крепость"
-
-#: ../fheroes2/resource/maps_text.cpp:276
-msgid ""
-"For years, you have existed peacefully in the Forest of Dreams, knowing that "
-"your king was the kindest and strongest ruler the land had seen in "
-"centuries.  Now, however, his reign is at an end, and there is no heir to "
-"succeed him.  You realize that a power struggle is coming, and that you must "
-"brace yourself for war, and prevent those who would harm this land from "
-"coming into power!"
-msgstr ""
-"Годами Вы мирно жили в Лесу Сновидений, зная, что Ваш король самый сильный и "
-"самый добрый правитель последних веков. Теперь же пришёл его час, а у трона "
-"нет наследника. Вы понимаете, что грядёт междоусобица и Вы должны воевать, "
-"чтобы не дать захватить трон тому, кто принесёт вред королевству, придя к "
-"власти!"
-
-#: ../fheroes2/resource/maps_text.cpp:277
-msgid ""
-"For years, you've been able to keep your subjects \"appeased.\"  Now "
-"however, you discover not only that your entire kingdom has turned against "
-"you, but most of your outer towns have fallen to the different factions.  To "
-"make matters worse, all your gold suddenly seems to be missing from the "
-"treasury!"
-msgstr ""
-"В течение многих лет, Вы спокойно правили королевством. Но сейчас все "
-"царство обернулось против Вас,  большинство ваших городов отделилось. И что "
-"хуже всего, Ваша казна пуста!"
-
-#: ../fheroes2/resource/maps_text.cpp:278
-msgid "Fountainhead"
-msgstr "Фонтан"
-
-#: ../fheroes2/resource/maps_text.cpp:279
-msgid "Four kingdoms race to capture the island of Sharkania."
-msgstr "Четыре королевства для захвата острова Sharkania."
-
-#: ../fheroes2/resource/maps_text.cpp:280
-msgid "Four lakes have castles, three have treasure."
-msgstr "Четыре Замка с озером, три из них с сокровищами.."
-
-#: ../fheroes2/resource/maps_text.cpp:281
-msgid "Four players must work together to assault the Wizards' Stronghold."
-msgstr "Четыре игрока должны сообща осадить цитадель волшебника"
-
-#: ../fheroes2/resource/maps_text.cpp:282
-msgid "Frozenpeak"
-msgstr "Замерзший пик"
-
-#: ../fheroes2/resource/maps_text.cpp:283
-msgid "Full House"
-msgstr "Все Дома"
-
-#: ../fheroes2/resource/maps_text.cpp:284
-msgid ""
-"Gain the aid of the elves. They will not allow trees to be chopped down, so "
-"we will send you wood every 2 weeks. You have 7 months!"
-msgstr ""
-"Получите поддержу эльфов. Они не позволят Вам рубить лес, так что мы будет "
-"отправлять Вам древесину каждые две недели. У Вас есть 7 месяцев!"
-
-#: ../fheroes2/resource/maps_text.cpp:286
-msgid "Galveston"
-msgstr "Гальвестон"
-
-#: ../fheroes2/resource/maps_text.cpp:287
-msgid "Garamok"
-msgstr "Гарамок"
-
-#: ../fheroes2/resource/maps_text.cpp:288
-msgid "Gate"
-msgstr "Ворота"
-
-#: ../fheroes2/resource/maps_text.cpp:289
-msgid "Gate to the Isle of Knowledge"
-msgstr "Врата к Острову Познания"
-
-#: ../fheroes2/resource/maps_text.cpp:290
-msgid "Gate to The Isle of Knowledge"
-msgstr "Врата к Острову Познания"
-
-#: ../fheroes2/resource/maps_text.cpp:291
-msgid "Gaurdian"
-msgstr "Хранитель"
-
-#: ../fheroes2/resource/maps_text.cpp:292
-msgid "Gavonshire"
-msgstr "Гейвоншир"
-
-#: ../fheroes2/resource/maps_text.cpp:294
-msgid "Glastonbury"
-msgstr "Гластонбёри"
-
-#: ../fheroes2/resource/maps_text.cpp:295
-msgid "Go away!"
-msgstr "Уходите!"
-
-#: ../fheroes2/resource/maps_text.cpp:296
-msgid "GO AWAY!"
-msgstr "Пошел Прочь!"
-
-#: ../fheroes2/resource/maps_text.cpp:297
-msgid "Goblin Island"
-msgstr "Гоблинский Остров"
-
-#: ../fheroes2/resource/maps_text.cpp:298
-msgid "Goblin King"
-msgstr "Король Гоблинов"
-
-#: ../fheroes2/resource/maps_text.cpp:299
-msgid "Go Home!"
-msgstr "Домой!"
-
-#: ../fheroes2/resource/maps_text.cpp:300
-msgid "Go north to find the lost gold-mine."
-msgstr "Следуйте на север, чтобы найти потеряную золотую шахту"
-
-#: ../fheroes2/resource/maps_text.cpp:301
-msgid "Good vs. Evil"
-msgstr "Добро против Зла"
-
-#: ../fheroes2/resource/maps_text.cpp:302
-msgid "Gorgomar"
-msgstr "Горгомар"
-
-#: ../fheroes2/resource/maps_text.cpp:303
-msgid "\"Greater Glory\""
-msgstr "\"Великая Слава\""
-
-#: ../fheroes2/resource/maps_text.cpp:304
-msgid "Greed"
-msgstr "Жадность"
-
-#: ../fheroes2/resource/maps_text.cpp:305
-msgid "Green bonus stuff"
-msgstr "хабар для Зеленого"
-
-#: ../fheroes2/resource/maps_text.cpp:306
-msgid "Green gets stuff"
-msgstr "хабар для Зеленого"
-
-#: ../fheroes2/resource/maps_text.cpp:307
-msgid "Greenroot"
-msgstr "Гринрут"
-
-#: ../fheroes2/resource/maps_text.cpp:308
-msgid "Green's Allowance"
-msgstr "Зеленым Разрешено"
-
-#: ../fheroes2/resource/maps_text.cpp:309
-msgid "Green's Groceries"
-msgstr "Зеленая Лавка"
-
-#: ../fheroes2/resource/maps_text.cpp:310
-msgid "green stuff"
-msgstr "хабар для Зеленого"
-
-#: ../fheroes2/resource/maps_text.cpp:311
-msgid "Green stuff"
-msgstr "хабар для Зеленого"
-
-#: ../fheroes2/resource/maps_text.cpp:312
-msgid "Greywind"
-msgstr "Грейвинд"
-
-#: ../fheroes2/resource/maps_text.cpp:313
-msgid "Grim"
-msgstr "Грим"
-
-#: ../fheroes2/resource/maps_text.cpp:314
-msgid "Grrr, Blazzer, Grrupt. Be gone with you!"
-msgstr "Гррр, Блаззер, Гррапт. Мы идём с твоя!"
-
-#: ../fheroes2/resource/maps_text.cpp:315
-msgid "Guardian War"
-msgstr "Война Стражей"
-
-#: ../fheroes2/resource/maps_text.cpp:316
-msgid "Gungtooth"
-msgstr "Гангтус"
-
-#: ../fheroes2/resource/maps_text.cpp:317
-msgid "Hail Unicorns!"
-msgstr "Слава Единорогам!"
-
-#: ../fheroes2/resource/maps_text.cpp:318
-msgid "Hampshire"
-msgstr "Хэмпшир"
-
-#: ../fheroes2/resource/maps_text.cpp:319
-msgid "Have fun storming the castle!"
-msgstr "Веселитесь, осаждая замок!"
-
-#: ../fheroes2/resource/maps_text.cpp:320
-msgid "Havenwood"
-msgstr "Хэйвенвуд"
-
-#: ../fheroes2/resource/maps_text.cpp:321
-msgid "Hawkins"
-msgstr "Хокинс"
-
-#: ../fheroes2/resource/maps_text.cpp:322
-msgid "Help!"
-msgstr "На помощь!"
-
-#: ../fheroes2/resource/maps_text.cpp:323
-msgid "Help me...."
-msgstr "Помогите мне..."
-
-#: ../fheroes2/resource/maps_text.cpp:324
-msgid ""
-"Help peasant farmers regain their castle and land, else they'll take your "
-"crops."
-msgstr ""
-"Помогите крестьянам вернуть свой замок и земли, или они отберут ваш урожай"
-
-#: ../fheroes2/resource/maps_text.cpp:325
-msgid "Hero's Hall"
-msgstr "Зал героев"
-
-#: ../fheroes2/resource/maps_text.cpp:326
-msgid ""
-"High in the snowy crags, you meet an old witch who, in return for a trinket "
-"of yours, gives you a powerful magical object she used to use as a footstool "
-"before she was exiled into the mountains by her own townspeople."
-msgstr ""
-"Высоко в снежных горах, Вы встречаете старую ведьму, которая в обмен на Ваш "
-"медальон даёт Вам могущественный магический объект, который она использовала "
-"в качестве костыля до того, как её изгнали в горы её соотечественники."
-
-#: ../fheroes2/resource/maps_text.cpp:327
-msgid "Hillstone"
-msgstr "Хиллстон"
-
-#: ../fheroes2/resource/maps_text.cpp:328
-msgid "Hilltop"
-msgstr "Холмовершье"
-
-#: ../fheroes2/resource/maps_text.cpp:329
-msgid "Hilltown"
-msgstr "Хилтаун"
-
-#: ../fheroes2/resource/maps_text.cpp:330
-msgid "Horizon"
-msgstr "Горизонт"
-
-#: ../fheroes2/resource/maps_text.cpp:331
-msgid "Hot Spot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:332
-msgid "Hungry dragons await.  Welcome, food."
-msgstr "Голодные драконы ждут. Добро пожаловать, Вы моя еда."
-
-#: ../fheroes2/resource/maps_text.cpp:333
-msgid "Hurry, no time to wait.  This way to the dock."
-msgstr "Скорее, нет времени ждать. Вот дорога к верфи."
-
-#: ../fheroes2/resource/maps_text.cpp:334
-msgid "Hurry up! Few days are left before the enemy's army arrives."
-msgstr "Быстрей же! Осталось несколько дней до прибытия вражеской армии."
-
-#: ../fheroes2/resource/maps_text.cpp:335
-msgid "I am...."
-msgstr "Я..."
-
-#: ../fheroes2/resource/maps_text.cpp:336
-msgid ""
-"I am one of the few remaining survivors of the wrecked pleasure ship, "
-"Exhorbitance. I think we'll all be dead of hunger soon, for we are out of "
-"caviar. We ate the chef yesterday."
-msgstr ""
-"Я - один из выживших после крушения корабля Эксхорбитанс. Я думаю, мы все "
-"умрём голодной смертью в скором времени, так как провиант кончился. Вчера мы "
-"съели кока."
-
-#: ../fheroes2/resource/maps_text.cpp:337
-msgid "Ibn Fadlan"
-msgstr "Ибн Фадлан"
-
-#: ../fheroes2/resource/maps_text.cpp:338
-msgid "Ice Palace"
-msgstr "Ледяной Дворец"
-
-#: ../fheroes2/resource/maps_text.cpp:339
-msgid "Ice Prince"
-msgstr "Ледяной Принц"
-
-#: ../fheroes2/resource/maps_text.cpp:340
-msgid "Icy lands ahead."
-msgstr "Снежные земли впереди."
-
-#: ../fheroes2/resource/maps_text.cpp:341
-msgid "I didn't do it!"
-msgstr "Я не делал этого!"
-
-#: ../fheroes2/resource/maps_text.cpp:342
-msgid ""
-"If three heroes could dig six holes in three days, how long would it take "
-"six heroes to dig twelve holes?"
-msgstr ""
-"Если три героя могут выкопать шесть нор за три дня, за сколько шесть героев "
-"выкопают 12 нор?"
-
-#: ../fheroes2/resource/maps_text.cpp:343
-msgid "If you free a hero, they may help..."
-msgstr "Если вы освободите героя, он может вам помочь..."
-
-#: ../fheroes2/resource/maps_text.cpp:344
-msgid ""
-"If you value your lives, for God's sake, Don't go through this whirlpool!"
-msgstr ""
-"Если вам дороги ваши жизни, то ради всего святого, НЕ плывите через "
-"водоворот!"
-
-#: ../fheroes2/resource/maps_text.cpp:345
-msgid "Income for Yellow."
-msgstr "Доход для Жёлтого."
-
-#: ../fheroes2/resource/maps_text.cpp:346
-msgid "In the hole you find a chunk of ore!"
-msgstr "Вы обнаружили в яме глыбу руды!"
-
-#: ../fheroes2/resource/maps_text.cpp:347
-msgid "In the stream you find an old compass!"
-msgstr "В потоке Вы обнаружили старый компас!"
-
-#: ../fheroes2/resource/maps_text.cpp:348
-msgid "In this glen live some very naughty halflings. Stay Away!"
-msgstr ""
-"В этой узкой горной долине живут непоседливые половинчики. Держись подальше!"
-
-#: ../fheroes2/resource/maps_text.cpp:349
-msgid ""
-"In two more weeks, if you have not located Joseph, your kingdom will surely "
-"lose its current battle with Harondale."
-msgstr ""
-"Если вы не найдете Иосифа за две недели, ваше королевство погибнет в "
-"сражении с Harondale."
-
-#: ../fheroes2/resource/maps_text.cpp:350
-msgid "I see you, you see me."
-msgstr "Я вижу тебя, ты - меня"
-
-#: ../fheroes2/resource/maps_text.cpp:351
-msgid "Is it something I said? Go back and I will forget the whole thing."
-msgstr "Что Я сказал? Вернитесь назад и я забуду все это."
-
-#: ../fheroes2/resource/maps_text.cpp:352
-msgid "IslandHome"
-msgstr "ДомашнийОстров"
-
-#: ../fheroes2/resource/maps_text.cpp:353
-msgid "Island of the Elves"
-msgstr "Остров Эльфов"
-
-#: ../fheroes2/resource/maps_text.cpp:354
-msgid "Island of the meek"
-msgstr "Кроткий Остров"
-
-#: ../fheroes2/resource/maps_text.cpp:355
-msgid "Island of Wolcott"
-msgstr "Остров Вулкут"
-
-#: ../fheroes2/resource/maps_text.cpp:356
-msgid "Isle Maze"
-msgstr "Остров Лабиринт"
-
-#: ../fheroes2/resource/maps_text.cpp:357
-msgid "Isle of Knowledge"
-msgstr "Остров Знания"
-
-#: ../fheroes2/resource/maps_text.cpp:358
-msgid ""
-"It has become apparent that if all your enemies were eliminated, you would "
-"have all the time you need to find the Ultimate Artifact."
-msgstr ""
-"Стало очевидным, что если бы все Ваши враги были устранены, у Вас было полно "
-"времени, необходимого, чтобы найти Реликвию."
-
-#: ../fheroes2/resource/maps_text.cpp:359
-msgid ""
-"It is obvious that the mage that once was here had won many battles!  There, "
-"upon his hand, is a most powerful ring!"
-msgstr ""
-"Очевидно, что маг, побывавший здесь, выиграл множество битв! На его палец "
-"надето могущественное кольцо."
-
-#: ../fheroes2/resource/maps_text.cpp:360
-msgid ""
-"It is rumored that a bridge of land used to exist between the two "
-"continents, but that a wild magic caused it to sink into the sea, taking "
-"with it all those who used to inhabit it.  To try to raise this bridge is to "
-"invite a curse upon the world!  The spirits of the dead will haunt us all!"
-msgstr ""
-"Ходят слухи, что ранее существовал мост между двумя континентами, но "
-"неподвластная магия потопила его на морское дно, забрав с собой всех, кто "
-"его населял... Попытаться вернуть этот мост означает навлечь проклятье на "
-"весь мир! Духи мёртвых будут преследовать всех нас!"
-
-#: ../fheroes2/resource/maps_text.cpp:361
-msgid ""
-"It is said that King Zealot found the gods' artifact once and it let him "
-"rule for 100 years."
-msgstr ""
-"Говорят, что король Zealot нашел Божественный Артифакт и правил в течение "
-"100 лет."
-
-#: ../fheroes2/resource/maps_text.cpp:362
-msgid ""
-"It looks like there used to be an ore mine here but all you see now is a "
-"hole in the ground and some minerals scattered around."
-msgstr ""
-"Похоже здесь когда-то был рудник. Но все, что осталось от него, это "
-"несколько разбросанных вокруг минералов и отверстие в земле."
-
-#: ../fheroes2/resource/maps_text.cpp:363
-msgid ""
-"It's a battle for supremacy as the Blue and Green heroes take on Red and "
-"Orange in team competition!"
-msgstr "Это битва для команды Синих и Зеленых против Красных и Оранжевых!"
-
-#: ../fheroes2/resource/maps_text.cpp:364
-msgid "It's windy at the top.  Defend, Divide, and Conquer."
-msgstr "Защити, Раздели, и Властвуй."
-
-#: ../fheroes2/resource/maps_text.cpp:365
-msgid "IvanHome"
-msgstr "Дом Ивана"
-
-#: ../fheroes2/resource/maps_text.cpp:366
-msgid "Ivan lives in the desert."
-msgstr "Иван живет в пустыне"
-
-#: ../fheroes2/resource/maps_text.cpp:367
-msgid "Ivory Gates"
-msgstr "Ворота Слоновой Кости"
-
-#: ../fheroes2/resource/maps_text.cpp:368
-msgid ""
-"I, Wilgatus, besiege you - do not fight me for I am all powerful and will "
-"destroy you if you persue me.  I will demonstrate my power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:369
-msgid "I Would Go That Way If I Were You."
-msgstr "Я желаю идти с Вами, по по этому пути."
-
-#: ../fheroes2/resource/maps_text.cpp:371
-msgid "Jarkonas VI"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:372
-msgid "Jolly Roger was here"
-msgstr "Здесь был Веселый Роджер"
-
-#: ../fheroes2/resource/maps_text.cpp:374
-msgid "Jungomar"
-msgstr "Джунгомар"
-
-#: ../fheroes2/resource/maps_text.cpp:375
-msgid "Just 30 days left!"
-msgstr "Осталось 30 дней!"
-
-#: ../fheroes2/resource/maps_text.cpp:376
-msgid "Just ONE week left!"
-msgstr "Осталась всего ОДНА неделя!"
-
-#: ../fheroes2/resource/maps_text.cpp:378
-msgid "Kastor"
-msgstr "Кастор"
-
-#: ../fheroes2/resource/maps_text.cpp:379
-msgid "Keep going south"
-msgstr "Продолжайте идти на юг"
-
-#: ../fheroes2/resource/maps_text.cpp:380
-msgid "Keep Off The Grass!"
-msgstr "Не ходите по траве!"
-
-#: ../fheroes2/resource/maps_text.cpp:381
-msgid "Keep Out!"
-msgstr "Держись Подальше!"
-
-#: ../fheroes2/resource/maps_text.cpp:382
-msgid "King John"
-msgstr "Король Джон"
-
-#: ../fheroes2/resource/maps_text.cpp:383
-msgid "King of Death"
-msgstr "Король Мертвых"
-
-#: ../fheroes2/resource/maps_text.cpp:384
-msgid "Knight's Trail."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:385
-msgid "Knight stuff"
-msgstr "Хабар для Рыцаря"
-
-#: ../fheroes2/resource/maps_text.cpp:386
-msgid "Lakeside"
-msgstr "Лейксайд"
-
-#: ../fheroes2/resource/maps_text.cpp:387
-msgid "Land's Edge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:388
-msgid "Land teleporters will get you to your destination sooner."
-msgstr "Телепорт приведет вас к месту назначения намного быстрее."
-
-#: ../fheroes2/resource/maps_text.cpp:389
-msgid "Lankershire"
-msgstr "Ланкашир"
-
-#: ../fheroes2/resource/maps_text.cpp:390
-msgid "Lavalor"
-msgstr "Лавалор"
-
-#: ../fheroes2/resource/maps_text.cpp:391
-msgid "Like, Stuff And Junk?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:392
-msgid ""
-"Living on the outskirts of the kingdom, you are considered an unwelcome "
-"outcast by the other leaders of the realm, though you always showed your "
-"support for the king.  Now, however, the king is dead, and many of those who "
-"spoke out againt him seek to seize his throne for themselves.  You have a "
-"vast desert at your back, rich with gems, and the advantage that many do not "
-"consider you a threat.  Go, now, and show them how wrong they are!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:393
-msgid "Lladner Dock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:394
-msgid ""
-"Log go up... Log go down... Log go up... Log go down...  OOoohhhhhhhh........"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:395
-msgid "Lombard"
-msgstr "Ломбард"
-
-#: ../fheroes2/resource/maps_text.cpp:396
-msgid "Long live Roland the true King!"
-msgstr "Долгой жизни королю Роланду!"
-
-#: ../fheroes2/resource/maps_text.cpp:397
-msgid "Long live Roland the true King."
-msgstr "Долгой жизни королю Роланду!"
-
-#: ../fheroes2/resource/maps_text.cpp:398
-msgid "Look before you leap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:399
-msgid "Look out!"
-msgstr "Берегись!"
-
-#: ../fheroes2/resource/maps_text.cpp:400
-msgid "Lord Alberon"
-msgstr "Лорд Алберон"
-
-#: ../fheroes2/resource/maps_text.cpp:401
-msgid ""
-"Lord Alberon calls you into his war room. He says, \"I am glad you have "
-"chosen to remain loyal to me, but this war is a terrible one for my kingdom. "
-"Already, the sorceress' towns to the Northeast have become unsure about "
-"their loyalties, and will not pledge allegiance to either side. This is hard "
-"on our cities as most of the wood in the land comes from these towns. We "
-"will need to recover their sawmills and take their towns by force.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:402
-msgid "Lord Haart"
-msgstr "Лорд Хаарт"
-
-#: ../fheroes2/resource/maps_text.cpp:404
-msgid "Lord Kreager"
-msgstr "Лорд Крегер"
-
-#: ../fheroes2/resource/maps_text.cpp:405
-msgid ""
-"Lord, messages have begun pouring in from our spies in the other island "
-"courts.  They have learned of a new volcanic island with vast amounts of "
-"reasources.  Your Majesty, with these new reasources we could put an end to "
-"a century of war between the islands, and reunite them under your rightful "
-"rule."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:406
-msgid "Lost Continent"
-msgstr "Потерянный Континент"
-
-#: ../fheroes2/resource/maps_text.cpp:407
-msgid "Lost Gold- Mine"
-msgstr "Затеряная золотая шахта"
-
-#: ../fheroes2/resource/maps_text.cpp:408
-msgid "Lost Island."
-msgstr "Потерянный Остров."
-
-#: ../fheroes2/resource/maps_text.cpp:409
-msgid "Lost Relic"
-msgstr "Утерянная Реликвия"
-
-#: ../fheroes2/resource/maps_text.cpp:410
-msgid "Maelstrom of Deceit"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:411
-msgid "Maelstrom of Misery"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:412
-msgid "Magic"
-msgstr "Магия"
-
-#: ../fheroes2/resource/maps_text.cpp:413
-msgid "Magic Three"
-msgstr "Магическое Дерево"
-
-#: ../fheroes2/resource/maps_text.cpp:414
-msgid ""
-"Many dust plumes rise from the floor of this small valley. You see various "
-"bands of nomads roaming about, and in the distant, the bright flames of "
-"their camp."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:415
-msgid ""
-"Many guardians stand between you and your enemies, but anybody can sneak "
-"through the back door!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:416
-msgid "Many that have gone through this door have never returned."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:417
-msgid ""
-"Many years ago, a couple of mages had a \"duel\" that forever changed the "
-"lake at the center of this continent.  Hearty adventurers might find "
-"interesting treasure there!"
-msgstr ""
-"Много лет назад несколько магов устроили \"дуэль\", навсегда изменившую "
-"озеро в центре этого континента. Старательные путники могут там найти "
-"интересное сокровище!"
-
-#: ../fheroes2/resource/maps_text.cpp:418
-msgid ""
-"Many years ago, a falling star crashed near here.  Only now the area is safe "
-"enough to explore.  Rumor has it a castle exist where the star fell."
-msgstr ""
-"Много лет назад недалеко отсюда упала звезда. Только сейчас эта область "
-"стала достаточно безопасной для поисков. По слухам, там, на месте падающей "
-"звезды, сейчас стоит замок."
-
-#: ../fheroes2/resource/maps_text.cpp:419
-msgid ""
-"Many years ago, your father, the King, died in a freak hunting accident.  "
-"Since then, you and your brother have jointly ruled his kingdom, but both of "
-"you have been seeking a way to seize the throne for yourself.  You got your "
-"wish.  Attackers from across the sea have captured more than half your towns "
-"and castles, effectively dividing the continent in two.  Now is the time to "
-"repel these invaders and do away with your brother once and for all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:420
-msgid "Marco"
-msgstr "Марко"
-
-#: ../fheroes2/resource/maps_text.cpp:421
-msgid "Marsh Home"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:423
-msgid "Mayland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:424
-msgid "Meramec"
-msgstr "Мерамек"
-
-#: ../fheroes2/resource/maps_text.cpp:425
-msgid "Message from Archibald. \" Do not dare to return without my Crown.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:426
-msgid ""
-"Message from Archibald. \" General, thank you for bringing me this lovely "
-"gift. I have decided to participate directly in the capture of my brother "
-"Roland. Since your military advice has taken us this far, I will follow your "
-"orders to the letter.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:427
-msgid "Message from Overlord. \"STILL WAITING FOR MY GOLD!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:428
-msgid "Message from Overlord. \"WHERE'S MY GOLD?\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:429
-msgid ""
-"Message from Roland. \"General, circumstances permit me to take a hand in "
-"the events of this final conflict. I have your spoils of war with me and I "
-"will follow your advice explicitly.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:430
-msgid ""
-"Message from Roland.  \"General, I have sent most of our troops and material "
-"ahead to the region of the final conflict with Archibald.  Unfortunately, "
-"Lord Corlagon has cut us off from the rest of our army.  I will be awaiting "
-"your victory in a castle across the west river.  I should be safe from "
-"attack.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:431
-msgid ""
-"Message from Roland. \" We cannot hope to defeat Archibald without the "
-"Crown, I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:432
-msgid "Middle Gate"
-msgstr "Средние Ворота"
-
-#: ../fheroes2/resource/maps_text.cpp:433
-msgid "Middleton"
-msgstr "Мидлтаун"
-
-#: ../fheroes2/resource/maps_text.cpp:434
-msgid "Middletown"
-msgstr "Миддлтаун"
-
-#: ../fheroes2/resource/maps_text.cpp:435
-msgid "Might vs. Magic"
-msgstr "Сила против Магии"
-
-#: ../fheroes2/resource/maps_text.cpp:436
-msgid "Mineral Wars"
-msgstr "Война за Ресурсы"
-
-#: ../fheroes2/resource/maps_text.cpp:437
-msgid "Mirkosov"
-msgstr "Миркосов"
-
-#: ../fheroes2/resource/maps_text.cpp:438
-msgid "mirror"
-msgstr "зеркало"
-
-#: ../fheroes2/resource/maps_text.cpp:439
-msgid "Money For Red"
-msgstr "Деньги для Красного"
-
-#: ../fheroes2/resource/maps_text.cpp:440
-msgid "MONEY, MONEY, MONEY!"
-msgstr "Деньги, Деньги, Деньги!"
-
-#: ../fheroes2/resource/maps_text.cpp:441
-msgid "Morale becomes even lower as the endless cliffs move past."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:442
-msgid ""
-"More water than land, you'll still spend lots of time on foot as you search "
-"a literal horde of islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:443
-msgid "Mountain king"
-msgstr "Король Горы"
-
-#: ../fheroes2/resource/maps_text.cpp:444
-msgid "Mountainview"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:445
-msgid "Mr Ed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:446
-msgid "Mr. Yellow's Income"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:447
-msgid "Murray's resort Isle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:448
-msgid ""
-"Mutiny!  The crew has dumped off my precious cargo into the sea!  Thank "
-"goodness it floats - when I've rid of them, I'll come back to pick it up!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:449
-msgid ""
-"My leige, our scouts report three other lords are attacking from the south. "
-"They work in conjuction with each other to eliminate us! We must keep this "
-"castle and remove the threat of the enemy. We wish you luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:450
-msgid ""
-"My leige, we have established a foothold (which we cannot afford to lose) "
-"and all of our Heroes have joined us. The king has made us the offer to "
-"purchase this land for 200,000 gold or we may take it by force. The local "
-"lords have been fighting and each wants to be the one that defeats us. Now "
-"all the local armies have arrived on the beach, creating a state of complete "
-"Pandemonium!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:451
-msgid "My Treasure Is Buried Beneath Three Palm Trees"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:452
-msgid "\"Necromancers!\""
-msgstr "\"Колдуны Пердуны!\""
-
-#: ../fheroes2/resource/maps_text.cpp:453
-msgid "New Dawn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:454
-msgid "New Enemies"
-msgstr "Новые Враги"
-
-#: ../fheroes2/resource/maps_text.cpp:455
-msgid "New Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:456
-msgid "Nightshadow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:457
-msgid "No Description"
-msgstr "Нет описания"
-
-#: ../fheroes2/resource/maps_text.cpp:458
-msgid "No Fishing!"
-msgstr "Здесь рыбы нет!"
-
-#: ../fheroes2/resource/maps_text.cpp:459
-msgid "No gems, crystal, or mercury for red."
-msgstr "Нет кристаллов, ртути и драгоценных камней для Красного."
-
-#: ../fheroes2/resource/maps_text.cpp:460
-msgid ""
-"None of the four leaders like being stuck in a land that has only one season."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:461
-msgid "NO, Not That Way. This Way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:462
-msgid "No one has ever made it out of the deadly swamps alive!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:463
-msgid "Noraston"
-msgstr "Норастун"
-
-#: ../fheroes2/resource/maps_text.cpp:464
-msgid "North Road"
-msgstr "Северная Дорога"
-
-#: ../fheroes2/resource/maps_text.cpp:465
-msgid "North vs. South"
-msgstr "Север или Юг"
-
-#: ../fheroes2/resource/maps_text.cpp:466
-msgid "No stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:467
-msgid "No sulfer fer Yella."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:468
-msgid "No swimming."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:469
-msgid "Notice- Those who put messages in bottles will be tortured."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:470
-msgid "No Trespassing"
-msgstr "Не беспокоить."
-
-#: ../fheroes2/resource/maps_text.cpp:471
-msgid "No tresspath...  No tree...  No thresh...  GO AWAY!"
-msgstr "Не беспе.. Не безбо... Небесполе... ИДИТЕ ПРОЧЬ!"
-
-#: ../fheroes2/resource/maps_text.cpp:472
-msgid "Now leaving Swamplands of the Eternial"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:473
-msgid "Obsidian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:474
-msgid "Of the necromancers...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:475
-msgid "Ogrehild"
-msgstr "Огрхилд"
-
-#: ../fheroes2/resource/maps_text.cpp:476
-msgid "Olympus"
-msgstr "Олимп"
-
-#: ../fheroes2/resource/maps_text.cpp:477
-msgid ""
-"One of the seers in your castle comes to you in the morning with urgent "
-"news. Your one time comrade, the wizard Joseph, and his armies have been "
-"imprisoned in a jail nearby. His power would surely aid you in your quest to "
-"reclaim the library, you think to yourself. Perhaps there is a way to rescue "
-"him..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:478
-msgid ""
-"One of your aides reports that the Castle of Farlien is located on the "
-"northeast spur of this island, and is a stronghold for the enemy. He urges "
-"you to take it out as soon as possible, and then move onto other islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:479
-msgid ""
-"One of your \"allies\" has joined Archibald.  You now face an opponent with "
-"three castles to your one.  Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:480
-msgid ""
-"One of your \"Allies\" has joined Roland. You are now facing three castles, "
-"all belonging to the enemy. Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:481
-msgid "One of your loyal goblins has brought you an armload of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:482
-msgid ""
-"One of your loyal subjects, a fairy tells you where to find a cache of "
-"mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:483
-msgid ""
-"One of your scouts reports a tiny cave nearby. Upon investigating, you "
-"discover a small cache of goods. In the dirt by them is etched 'Ivan'."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:484
-msgid ""
-"One of your troops stubs its paw on something buried here.  After a few "
-"hours of digging you unearth a cache of treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:485
-msgid "Only a month remains in which to find Joseph."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:486
-msgid "On quite days, Nubbie the sea monster can be seen!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:487
-msgid "Orange stuff"
-msgstr "хабар для Оранжевого"
-
-#: ../fheroes2/resource/maps_text.cpp:488
-msgid "Orcville"
-msgstr "Орквиль"
-
-#: ../fheroes2/resource/maps_text.cpp:489
-msgid "Ostoroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:490
-msgid "Other than the dragons, the elves don't have any enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:491
-msgid "Our ally was greatly weakened when his resources were plundered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:492
-msgid "\"Our Finest Hour\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:493
-msgid "Our reinforcements were lost in a storm, we salvaged all we could!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:494
-msgid ""
-"Our spies have discovered that the barbarian hordes are now receiving "
-"support from kraeger! You must hurry and find the third piece before your "
-"forces here are crushed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:495
-msgid "Overlord"
-msgstr "Повелитель"
-
-#: ../fheroes2/resource/maps_text.cpp:496
-msgid "Pandemonium"
-msgstr "Столпотворение"
-
-#: ../fheroes2/resource/maps_text.cpp:497
-msgid "Paper can gain you what wood and sail cannot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:498
-msgid "Password found by Crystals to the South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:499
-msgid "Peacekeeper"
-msgstr "Пеаскипер"
-
-#: ../fheroes2/resource/maps_text.cpp:500
-msgid "\"Peasants!\""
-msgstr "\"Крестьяне!\""
-
-#: ../fheroes2/resource/maps_text.cpp:502
-msgid "Peasantsville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:503
-msgid "Perenor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:504
-msgid "Pet Cemetary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:505
-msgid "Pick one of four Knights in this large and inhospitable land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:506
-msgid "Pig's Eye"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:507
-msgid "Pinehurst"
-msgstr "Пайнхурст"
-
-#: ../fheroes2/resource/maps_text.cpp:508
-msgid "Pirate Cove"
-msgstr "Пиратская Бухта"
-
-#: ../fheroes2/resource/maps_text.cpp:509
-msgid "Pirate's Cove"
-msgstr "Пиратская Бухта"
-
-#: ../fheroes2/resource/maps_text.cpp:510
-msgid "Pirate Utopia"
-msgstr "Мечта Пиратов"
-
-#: ../fheroes2/resource/maps_text.cpp:511
-msgid "Pirites strike and take the gold from you holds."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:512
-msgid "Pixie"
-msgstr "Пиксия"
-
-#: ../fheroes2/resource/maps_text.cpp:513
-msgid ""
-"Play the Knight or Barbarian in an alliance in this classic duel against the "
-"four spell casters. (Blue and Green vs Red)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:514
-msgid "Please...."
-msgstr "Пожалуйста..."
-
-#: ../fheroes2/resource/maps_text.cpp:515
-msgid ""
-"Plenty of resources and lots of ground to cover. Watch out for Orange and "
-"Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:516
-msgid "Portals"
-msgstr "Порталы"
-
-#: ../fheroes2/resource/maps_text.cpp:517
-msgid "Portsmith"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:518
-msgid "POSION - DO NOT DRINK"
-msgstr "не пейте - это ЯД"
-
-#: ../fheroes2/resource/maps_text.cpp:519
-msgid "Powerful magic lies southwest of here in the Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:520
-msgid "Prisoner on...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:522
-msgid "Quick Silver"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:523
-msgid "Raste"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:524
-msgid "Realm of the Undead.  Fresh blood welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:525
-msgid "Red bonus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:526
-msgid "Red player sympathizes with the undead cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:527
-msgid "Red's Connection"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:528
-msgid "Redshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:529
-msgid "Red's Lunch Money"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:530
-msgid "Red's Rubles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:531
-msgid "Red stuff"
-msgstr "хабар для Красного"
-
-#: ../fheroes2/resource/maps_text.cpp:532
-msgid ""
-"Regrettably, you have no castle with which to begin your assault. "
-"Fortunately, however, Kraeger's forces are weak here in the south, and you "
-"have bribed a rebel necromancer to aid you in the beginning of your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:533
-msgid "Reinforcements have arrived, Gold from the homelands!"
-msgstr "Прибыло подкрепление, прибыло золото от родины!"
-
-#: ../fheroes2/resource/maps_text.cpp:534
-msgid ""
-"Remains of a long since dead wizard have attracted an ancient artifact.  "
-"This artifact has now attached itself to you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:535
-msgid ""
-"Remember, you're searching for the Ultimate Artifact... don't get distracted!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:536
-msgid ""
-"Rendall Koski was here. 1997.  Northampton, Massachusetts There is a "
-"powerful artifact in the southeastern corner of the world.  Go for it, "
-"explorer!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:537
-msgid ""
-"Reports from your spies tell of enemies on the march.  As you rush to the "
-"castle courtyard to prepare your armies, you are intercepted by your "
-"Chaplain.  \"My Lord, I have received word that we should send what Heroes "
-"we can to the Isle of Knowledge.   The Scholars there have agreed to teach "
-"them so they will be strong for the battles ahead of us.\"  You thank the "
-"Chaplain for the information and head thoughtfully into the courtyard."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:538
-msgid ""
-"Rescue your crazy Uncle Ivan. Find him within 4 months or it will be no help "
-"to your kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:539
-msgid "Restricted Area, Do Not Enter!"
-msgstr "Ограниченный доступ, не входить!"
-
-#: ../fheroes2/resource/maps_text.cpp:540
-msgid "Rest stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:541
-msgid "Retake the Castle of Ivory Gates."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:542
-msgid "Revolution"
-msgstr "Революция"
-
-#: ../fheroes2/resource/maps_text.cpp:543
-msgid "Right thinking - he who takes the riskes deserves the rewards."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:544
-msgid "River Crossing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:545
-msgid "Road Ends"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:546
-msgid "Road to Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:547
-msgid "Road to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:548
-msgid "Robbers have looted your treasury and you have lost valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:549
-msgid "Robbers have looted your treasury, stealing valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:550
-msgid "Roc Haven"
-msgstr "Тайное Убежище"
-
-#: ../fheroes2/resource/maps_text.cpp:551
-msgid "Rogar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:553
-msgid "Roscomon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:554
-msgid "Rotten Birch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:555
-msgid ""
-"Rumors abound and your faithful hero Sandro is now highly regarded by the "
-"masses. Should Sandro desert you, all will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:556
-msgid "Sandcaster"
-msgstr "Сандкастер"
-
-#: ../fheroes2/resource/maps_text.cpp:558
-msgid "Sands of Time"
-msgstr "Пески времени"
-
-#: ../fheroes2/resource/maps_text.cpp:559
-msgid "Sansobar"
-msgstr "Сансобр"
-
-#: ../fheroes2/resource/maps_text.cpp:560
-msgid "\"Save the Dwarves\""
-msgstr "\"Спасите Гномов\""
-
-#: ../fheroes2/resource/maps_text.cpp:561
-msgid "Scabsdale"
-msgstr "Скабсдэл"
-
-#: ../fheroes2/resource/maps_text.cpp:562
-msgid "Scorched Earth"
-msgstr "Выжженная земля"
-
-#: ../fheroes2/resource/maps_text.cpp:563
-msgid ""
-"Scouts have reported a town to the North.  They have also heard some "
-"disturbing news.  Their seems to be a war raging in this area."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:564
-msgid ""
-"Scouts report the enemy's stronghold lies to the Southwest. Our swift "
-"arrival has caught them by surprise. If you move quickly their resistance "
-"will be minimal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:565
-msgid ""
-"Scouts report the notorious necromancer \"Wyrm\" has been sighted to the "
-"northeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:566
-msgid "Scummy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:567
-msgid ""
-"Searching in the dust of this abandoned campsite, you find a magic scroll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:568
-msgid "Seasons Change"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:569
-msgid "Secret Mountain Pass"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:570
-msgid ""
-"Seek out the Ultimate Artifact to be victorious in this strangely shaped "
-"land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:571
-msgid ""
-"Seek the great library, for only with the guidance of the musty tomes therin "
-"will you find the means to reveal and bind the fount to your will."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:572
-msgid "Seven Lakes"
-msgstr "Семь Озер"
-
-#: ../fheroes2/resource/maps_text.cpp:573
-msgid "Sharkania"
-msgstr "Шаркания"
-
-#: ../fheroes2/resource/maps_text.cpp:574
-msgid "Sheltemburg"
-msgstr "Шелтембург"
-
-#: ../fheroes2/resource/maps_text.cpp:575
-msgid "Sherman"
-msgstr "Шерман"
-
-#: ../fheroes2/resource/maps_text.cpp:576
-msgid "Shipwrecked!"
-msgstr "Кораблекрушение!"
-
-#: ../fheroes2/resource/maps_text.cpp:577
-msgid ""
-"Should this message ever reach home, please know that this has become a "
-"hostile place since the King's death.  No less than six factions are at war "
-"with each other, each seeking to be the King's successor.  Beware especially "
-"of the Barbarians and the Necromancers who control the north, their regions "
-"are easily defended and they have a wealth of gold and gems.  Do not venture "
-"to this land without a sizeable force.  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:578
-msgid "Sirein"
-msgstr "Сирены"
-
-#: ../fheroes2/resource/maps_text.cpp:579
-msgid ""
-"Six factions have established a foothold on a huge, unexplored continent.  "
-"Can you eliminate the other five?"
-msgstr ""
-"Шесть конкурентов закрепились на большом, неизведанном континенте. Вы "
-"сможете устранить всех?"
-
-#: ../fheroes2/resource/maps_text.cpp:580
-msgid ""
-"Six heroes with large armies prepare to slug it out for total domination!"
-msgstr "Шесть героев с большими армиями готовы к войне для полного контроля!"
-
-#: ../fheroes2/resource/maps_text.cpp:581
-msgid "Skirmish"
-msgstr "Скирмаш"
-
-#: ../fheroes2/resource/maps_text.cpp:582
-msgid "\"Slay the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:583
-msgid "Slippery when wet."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:584
-msgid "Slugfest"
-msgstr "Слагфест"
-
-#: ../fheroes2/resource/maps_text.cpp:585
-msgid ""
-"Snagged on a thorny bush, you discover a scrap of cloth. The design on it "
-"looks like the coat of arms of Ivan's house!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:586
-msgid "Snowdrop"
-msgstr "Сноудроп"
-
-#: ../fheroes2/resource/maps_text.cpp:587
-msgid "Somebody has stuffed a pile of gems in the ditch!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:588
-msgid "Some crystal!"
-msgstr "Несколько кристаллов!"
-
-#: ../fheroes2/resource/maps_text.cpp:589
-msgid "Some gems!"
-msgstr "Несколько драгоценных камней!"
-
-#: ../fheroes2/resource/maps_text.cpp:590
-msgid ""
-"Someone has stolen 100 wood and 77 ore from you. Ah, that's nothing. Let's "
-"keep going."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:591
-msgid ""
-"Someone has stolen gold and resources from  the palace treasury!  You "
-"suspect your enemies, but you can't know for certain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:592
-msgid "Someone is playing a pan flute around here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:593
-msgid ""
-"Someone notices a piece of parchment lying behind a clump of grass. You pick "
-"it up. It looks to be a page from a journal, and it reads, \"...made it past "
-"the first guardians. Hopefully will reach the ancient desert city soon. Only "
-"hope my forces are strong enough to survive...\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:594
-msgid "Some ore!"
-msgstr "Несколько каменной руды!"
-
-#: ../fheroes2/resource/maps_text.cpp:595
-msgid "Some sulfur!"
-msgstr "Несколько серы!"
-
-#: ../fheroes2/resource/maps_text.cpp:596
-msgid ""
-"Some unlucky adventurers have been captured and imprisoned in these lands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:597
-msgid "Sorceress Forest.  Show respect for nature!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:598
-msgid "Sorpigal"
-msgstr "Сорпигал"
-
-#: ../fheroes2/resource/maps_text.cpp:599
-msgid "South Mill"
-msgstr "Южная Шахта"
-
-#: ../fheroes2/resource/maps_text.cpp:600
-msgid "So you think you're smart?"
-msgstr "Похоже, ты считаешь себя умным?"
-
-#: ../fheroes2/resource/maps_text.cpp:601
-msgid "Spector"
-msgstr "Спектор"
-
-#: ../fheroes2/resource/maps_text.cpp:602
-msgid "Spell Casters"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:603
-msgid ""
-"Spies report Roland has sent a hero to search for the Crown. If he finds it "
-"first, all is lost!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:604
-msgid "Spirit City"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:605
-msgid "Spy Tower - see what your competition is doing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:606
-msgid "Stairs"
-msgstr "Лесенка"
-
-#: ../fheroes2/resource/maps_text.cpp:607
-msgid ""
-"Start with five castles!  How could you lose!?  Oh yeah, everyone else "
-"starts with five, too."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:608
-msgid "Stick to the road!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:609
-msgid "Stromgild"
-msgstr "Стромхилд"
-
-#: ../fheroes2/resource/maps_text.cpp:610
-msgid "Stromhild"
-msgstr "Стромхилд"
-
-#: ../fheroes2/resource/maps_text.cpp:611
-msgid "Stronghold"
-msgstr "Крепость"
-
-#: ../fheroes2/resource/maps_text.cpp:612
-msgid "Stuff for red"
-msgstr "хабар для Красного"
-
-#: ../fheroes2/resource/maps_text.cpp:613
-msgid "Stuff for Yellow"
-msgstr "хабар для Желтого"
-
-#: ../fheroes2/resource/maps_text.cpp:614
-msgid "Stuff For Yellow"
-msgstr "хабар для Желтого"
-
-#: ../fheroes2/resource/maps_text.cpp:615
-msgid "Subbaculcha"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:616
-msgid "Sundune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:617
-msgid "Surf and Turf"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:618
-msgid "Swimming near the kelp is a pod of dolphins."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:619
-msgid "Tacma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:620
-msgid "Tchudes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:621
-msgid "Teleporters"
-msgstr "Телепорты"
-
-#: ../fheroes2/resource/maps_text.cpp:622
-msgid "Terra Firma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:623
-msgid "Terrain Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:624
-msgid ""
-"The alliance has crumbled and all are at war. Lots of resources but little "
-"time to prepare."
-msgstr ""
-"Союз рухнул, и все в состоянии войны. Много ресурсов, но мало времени на "
-"подготовку."
-
-#: ../fheroes2/resource/maps_text.cpp:625
-msgid ""
-"The ancient King Zealot had the artifact of the gods and then hid it in his "
-"old age so that it could not be used by others."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:626
-msgid "The Back Door"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:627
-msgid ""
-"The Barbarian's lands are being invaded. Are you strong enough to resist the "
-"invasion?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:628
-msgid ""
-"The castle of Drakonran in the east has been taken by the barbarians! Two "
-"other towns to the west have also been taken, but the barbarian armies were "
-"fairly decimated in the process."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:629
-msgid "The center island is rumored to harbor great spells."
-msgstr "Говорят что центральный остров таит много заклинаний."
-
-#: ../fheroes2/resource/maps_text.cpp:630
-msgid "The Citadel"
-msgstr "Цитадель"
-
-#: ../fheroes2/resource/maps_text.cpp:631
-msgid "The cities of the plains."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:632
-msgid "The Clearing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:633
-msgid ""
-"The convoy has at long last arrived. Regretably, it has been beset by "
-"bandits on its journey here, and has far less supplies than we had hoped. "
-"Make your way south, for our spies have found rich mines there."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:634
-msgid ""
-"The convoy should have been here by now! Let us hope that it is safe and "
-"still on its way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:635
-msgid ""
-"The country lords have allied and pooled their resources into one command. "
-"Not only have they massed their forces in the north, but they have sent a "
-"knight to the west to steal your supplies. Scouts report a castle to the "
-"east that would be ideal as a base of operations."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:636
-msgid "The crew are unworthy!  I am not going down with the ship! -The Captain"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:637
-msgid "\"The Crown\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:638
-msgid ""
-"The day you have feared has finally arrived.  The king, who you have "
-"faithfully served, has died, leaving no heir to his throne.  As his captain, "
-"you feel that this job should now be yours, but several factions even now "
-"are preparing for conquest.  You are at the center of the trade routes, "
-"having the sea to the south and the great forest to the north.  Go, now, "
-"Commander, and claim what is rightfully yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:639
-msgid ""
-"The diplomats who were sent here ahead of you report that the elves will "
-"only cooperate with you if you will recover the golden bow for them. It was "
-"stolen by their enemies, the Dragons and hidden behind magic barriers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:640
-msgid "The Eastern Town."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:641
-msgid "The edge of the world is your edge.  But prepare to be prepared."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:642
-msgid "The Emerald Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:643
-msgid "The Enchanted Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:644
-msgid "The End of the World is Nigh!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:645
-msgid "The End of the World is Nigh"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:646
-msgid ""
-"The Epic battle against Your Rival! Eliminate everything! Total Warfare! "
-"Don't Lose your first hero!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:647
-msgid ""
-"The Fire King is an ally to the dragons, and will help a friend of theirs."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:648
-msgid "The First One To Take Astircaer Wins!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:649
-msgid ""
-"The first piece of the artifact now lies in the hands of the Unholy Order of "
-"Warlocks. You must annihilate them, and their allies to the north. They will "
-"surely give us what we seek in exchange for their feeble lives."
-msgstr ""
-"Первый кусок от артефакта сейчас у Нечестивого Ордена Чернокнижников. Вы "
-"должны уничтожить их, и их союзников на севере. Они отдадут нам все, к чему "
-"мы стремимся, в обмен на их слабую жизнь."
-
-#: ../fheroes2/resource/maps_text.cpp:650
-msgid ""
-"The Fortune of Infamous Uae was buried on one of these islands. She died "
-"without ever revealing it.  Find it before the other cutthroats."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:651
-msgid "The four factions race to capture a mystical castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:652
-msgid ""
-"The four spell casters face off with substantial starting armies. Can the "
-"crusaders keep the peace?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:653
-msgid "\"The Gauntlet\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:654
-msgid ""
-"The Gods have given you 6 months to prove yourself. Good or Evil - who shall "
-"prevail? (Blue,Green and Red vs Yellow, Orange and Purple)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:655
-msgid ""
-"The gods have granted this world a great artifact, to find it means victory."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:656
-msgid "The Gods themselves will aid us in this War."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:657
-msgid "The Gold Traveller's Tent is near the Aqua Taveller's Tent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:658
-msgid "The guardians of Dragon Isle reside in the jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:659
-msgid "The Ice Prince stands frozen in some forgotten corner of the world."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:660
-msgid "The island...."
-msgstr "Остров..."
-
-#: ../fheroes2/resource/maps_text.cpp:661
-msgid "The Island of Lost Reason"
-msgstr "Остров Потерянных Решений"
-
-#: ../fheroes2/resource/maps_text.cpp:662
-msgid "The islands have much wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:663
-msgid "The Isle of Armoria"
-msgstr "Остров Армория"
-
-#: ../fheroes2/resource/maps_text.cpp:664
-msgid "The key to success is rubbing enough lamps."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:665
-msgid ""
-"The King has declared you his hier apparent and champion. You must seek out "
-"and destroy your common enemy, Wilgatus and his Castle, Mirkosov, the source "
-"of his power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:666
-msgid ""
-"The King is dead, his kingdom has been shattered, and six leaders seek to "
-"seize power for themselves."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:667
-msgid "The Kingly Wastes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:668
-msgid "The Kings Road."
-msgstr "Королевская Дорога."
-
-#: ../fheroes2/resource/maps_text.cpp:669
-msgid ""
-"The King will sell you this land for 200,000 gold or you can take it by "
-"force. The choice is yours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:670
-msgid "The land of Heroes II."
-msgstr "Земля Героев II."
-
-#: ../fheroes2/resource/maps_text.cpp:671
-msgid "The Lost Castle of the Ancients"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:672
-msgid ""
-"The mage wars have caused a great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:673
-msgid ""
-"The mage wars have caused great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:674
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trade.  "
-"Plus a little gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:675
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trading.  "
-"Plus a little more gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:676
-msgid ""
-"The Master Merchant arrives at your Castle.  He tells you tall tales of "
-"travel, full of outrageous lies.  He also gives you, your share of the "
-"profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:677
-msgid ""
-"The Master Merchant arrives back at your Castle.  He tells you tall tales of "
-"faraway places full of outrageous lies.  He also gives you, your share of "
-"the profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:678
-msgid "The Medusas have the password and they can be found just to the west."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:679
-msgid "The more there is the less you see."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:680
-msgid "The North Road to Roland's castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:681
-msgid ""
-"The note in this bottle has become mostly indecipherable. All you can make "
-"out are references to deadly pirates, and hidden gold mines."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:682
-msgid "The Other Side"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:683
-msgid ""
-"The Overlord has given you 4 months to conquer this land or deliver to him "
-"the sum of 150,000 gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:684
-msgid ""
-"The people on the Isle of Knowledge are taking up a collection to aid us."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:685
-msgid "The Proving Grounds"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:686
-msgid "The Queen's Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:687
-msgid "The Realm of Air is barred, but you may appeal here for help."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:688
-msgid ""
-"There are remnants of a mighty battle fought here, not too long ago. It "
-"looks as if whoever came this way may have made this their final stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:689
-msgid ""
-"There are three enemy castles to the north. Capture them in the name of "
-"Roland the true king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:690
-msgid ""
-"The Red Tide of War rolls North.  Stopping the flood seems hopeless.  Yet, "
-"Honor demands you and your ally die trying."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:691
-msgid "There is hidden treasure north of the Green Lord's Ore Mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:692
-msgid "There is hidden treasure south of the Blue Lord's Sawmill."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:693
-msgid "There's a warm wind blowing from the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:694
-msgid "There's a Wizard living in the north who is behind this peasant revolt."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:695
-msgid "The Retreat of the Alchemist Doctor Yu"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:696
-msgid ""
-"There used to be a mine here, but it has long since run out of ore.  You are "
-"only able to scavenge 5 units of ore from the old site."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:697
-msgid "There was a shipreck in the far east waters recently."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:698
-msgid "The River Styx"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:699
-msgid "The roars of several dragons echo from the towers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:700
-msgid "The Rock Store."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:701
-msgid "The Royal Gardens."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:702
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:703
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you defend against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:704
-msgid "These doors are a risk the likes of which you do not know."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:705
-msgid "These lands are beholden to Lord Kraeger."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:706
-msgid ""
-"These lands are desolate and for the most part devoid of resources. Not even "
-"the bravest heroes dare to venture into them, and plants are rare and "
-"precious here. Who knows what else awaits?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:707
-msgid ""
-"The Southern Witch is biding her time.  She will strike when your armies are "
-"weak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:708
-msgid "the stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:709
-msgid "The Table in the Great Hall of the Castle is Haunted."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:710
-msgid ""
-"The third piece of the artifact is somewhere to the north, that much we "
-"know. We are still unsure of its exact location, but our spies are out "
-"gathering information. The forces in this area are too strong to be "
-"completely subjugated, so take what you can and hold on to it tightly."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:711
-msgid ""
-"The troops have sworn their allegiance, but should lose a battle they will "
-"lose faith and our cause will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:712
-msgid "The Valley of Aruk."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:713
-msgid ""
-"The Valley of Magic holds many surprises.  You discover an old pair of boots "
-"sticking out of the sand."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:714
-msgid "The Valley of Tresures"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:715
-msgid "The Wasteland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:716
-msgid "The way of magic"
-msgstr "Дорога магии"
-
-#: ../fheroes2/resource/maps_text.cpp:717
-msgid "The way of might"
-msgstr "Дорога силы"
-
-#: ../fheroes2/resource/maps_text.cpp:718
-msgid "The way of numbers"
-msgstr "Дорога чисел"
-
-#: ../fheroes2/resource/maps_text.cpp:719
-msgid "The western town."
-msgstr "Западный город"
-
-#: ../fheroes2/resource/maps_text.cpp:720
-msgid "The winds howl in mourning around the shipwreck."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:721
-msgid "The wizard has an island in the southeast."
-msgstr "У волшебника есть остров на юго-востоке."
-
-#: ../fheroes2/resource/maps_text.cpp:722
-msgid ""
-"The Wizards who have captured the Necromancers' town have wasted no time in "
-"building defenses designed to stop you, and their last castle has just been "
-"completed. Fortunately only a Captain of the Guard and a small garrison are "
-"currently present.  If you hurry, you should be able to capture the castle "
-"before they have a chance to reinforce it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:723
-msgid "The wood has arrived."
-msgstr "Дерево прибыло."
-
-#: ../fheroes2/resource/maps_text.cpp:724
-msgid "The writing on this sign is too faded to read."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:725
-msgid "The Yellow Lord has the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:726
-msgid ""
-"The Yellow Lord is a hothead who will attack before his allies can send him "
-"aid."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:727
-msgid "They say there's mermaids in these waters..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:728
-msgid ""
-"This area is rich in resources. Explore, but beware, a castle left "
-"undefended will quickly fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:729
-msgid ""
-"This area must be secured for the sake of the Empire. Our spies have "
-"reported a discord between The kingdom of the knights to the north, and that "
-"of the oppressive sorceresses to the northeast. Perhaps this feud can be "
-"exploited for our gain..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:730
-msgid "This bottle is empty."
-msgstr "Бутылка пуста."
-
-#: ../fheroes2/resource/maps_text.cpp:731
-msgid ""
-"This is the last week you have to find the rebel wizard Joseph! Good Luck in "
-"your quest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:732
-msgid ""
-"This land and all others are now under the sole ownership of Ibn Fadlan, the "
-"Undead King. Any disregard for his magesty's soverign rule is to be punished "
-"by death most horrendous."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:733
-msgid ""
-"This land has been claimed by the nation of Neroli. Interlopers are "
-"UNWELCOME."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:734
-msgid ""
-"This rugged land will have rivals fighting the terrain as well as each other."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:735
-msgid ""
-"This rundown village looks like it was once the epicenter of an enormous, "
-"but now ruined, city. Under a pile of rubble you find an object which looks "
-"like it has lain there for ages."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:736
-msgid ""
-"This spot overlooks an old quarry.  This was one of the only places in the "
-"world where ore could be taken right out of the ground.  Unfortunately the "
-"jungle has reclaimed the quarry and it is unusable.  You collect the last of "
-"the ore and depart."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:737
-msgid ""
-"This twisted maze of sorceress towns has three factions struggling for sole "
-"control.  Use your resources wisely!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:738
-msgid ""
-"This village appears to be in little better shape than the first one you "
-"saw. As you approach the village an old man hands you a slip of paper, with "
-"the following message, \"Joseph lives in the town of IslandHome.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:739
-msgid ""
-"This village is in extremely poor shape. There is no chance of getting more "
-"than some of the lesser creatures here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:740
-msgid "This way to the Necromancer Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:741
-msgid "Those who seek knowledge are welcome to the city of Chronos."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:742
-msgid ""
-"Three Warlocks in the land of Dragons. Lose thy home and all will be lost. "
-"Conquer thy enemies and the land shall forever be yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:743
-msgid "Timberhill"
-msgstr "Тимберхилл"
-
-#: ../fheroes2/resource/maps_text.cpp:744
-msgid "Time for a refreshing drink."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:745
-msgid "Time is running out! The enemy's reinforcements are almost here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:746
-msgid "To pass you must pay troll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:747
-msgid "TreeHome"
-msgstr "Дерево Дом"
-
-#: ../fheroes2/resource/maps_text.cpp:748
-msgid "Trespassers will be EATEN!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:749
-msgid "Trilobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:750
-msgid "Troy"
-msgstr "Троя"
-
-#: ../fheroes2/resource/maps_text.cpp:751
-msgid "Tundara"
-msgstr "Тундра"
-
-#: ../fheroes2/resource/maps_text.cpp:752
-msgid "Turn back, friend, while you still can!"
-msgstr "Возвращайся назад, друг,  пока еще можешь!"
-
-#: ../fheroes2/resource/maps_text.cpp:753
-msgid "Turn Back Now!"
-msgstr "Возвращайся назад!"
-
-#: ../fheroes2/resource/maps_text.cpp:754
-msgid "Turn Back Now or all will be LOST!"
-msgstr "Возвращайся назад или ПОГИБНЕШЬ!"
-
-#: ../fheroes2/resource/maps_text.cpp:755
-msgid "Turn Back or DIE!"
-msgstr "Возвращайся назад или УМРЕШЬ!"
-
-#: ../fheroes2/resource/maps_text.cpp:756
-msgid "Turn Back or else!"
-msgstr "Возвращайся назад иначе..."
-
-#: ../fheroes2/resource/maps_text.cpp:757
-msgid "Turn back, you fool."
-msgstr "Возвращайся назад глупец."
-
-#: ../fheroes2/resource/maps_text.cpp:758
-msgid "\"Turning Point\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:759
-msgid ""
-"Uae was the scurviest, pirate ye'd never wanta see. In all her years of "
-"murdering and thieving she amassed so much ill-gotten booty that she "
-"couldn't carry it around in her galleon.  Besides, even the meanest can't "
-"stay awake all the time.  Legend tells that she hid it so well, she was "
-"thinking that she just might forget where it was.  So she left clues around "
-"the islands, carved in stone.  Well, she's dead now.  It's up to you to "
-"recover her legacy."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:761
-msgid "Uncle Leo"
-msgstr "Дядя Ли"
-
-#: ../fheroes2/resource/maps_text.cpp:762
-msgid "Uncle Milty"
-msgstr "Дядя Милти"
-
-#: ../fheroes2/resource/maps_text.cpp:763
-msgid "Undead Armies"
-msgstr "Армии Мертвых"
-
-#: ../fheroes2/resource/maps_text.cpp:764
-msgid "Unholy Alliance"
-msgstr "Нечестный Союз"
-
-#: ../fheroes2/resource/maps_text.cpp:765
-msgid "Unite the Tribes. Don't lose your main hero, the first Descendant."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:766
-msgid "Valley of Death"
-msgstr "Долина Смерти"
-
-#: ../fheroes2/resource/maps_text.cpp:767
-msgid "Valley Of The Damned"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:768
-msgid "Valley of the Kings."
-msgstr "Долина Королей"
-
-#: ../fheroes2/resource/maps_text.cpp:769
-msgid "Vaultius"
-msgstr "Ваултиус"
-
-#: ../fheroes2/resource/maps_text.cpp:770
-msgid "Vertigo"
-msgstr "Вертиго"
-
-#: ../fheroes2/resource/maps_text.cpp:771
-msgid "Vikings!"
-msgstr "Викинги!"
-
-#: ../fheroes2/resource/maps_text.cpp:772
-msgid "Viper's Nest"
-msgstr "Змеиное Гнездо"
-
-#: ../fheroes2/resource/maps_text.cpp:773
-msgid "Vulcania"
-msgstr "Вулкания"
-
-#: ../fheroes2/resource/maps_text.cpp:774
-msgid "Warrior Knight"
-msgstr "Воин Рыцарь"
-
-#: ../fheroes2/resource/maps_text.cpp:775
-msgid "Wastelands"
-msgstr "Опустошенная Земля"
-
-#: ../fheroes2/resource/maps_text.cpp:776
-msgid "Watch out for Purple!"
-msgstr "Следите внимательно за Фиолетовым!"
-
-#: ../fheroes2/resource/maps_text.cpp:777
-msgid "Waystop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:778
-msgid ""
-"\"We are at the edge of the world!\"  they scream.  \"What are we doing here?"
-"\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:779
-msgid "Weddington"
-msgstr "Ведингтон"
-
-#: ../fheroes2/resource/maps_text.cpp:780
-msgid "Weed Patch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:781
-msgid ""
-"We found a weakness my lord. Capture castle Black Fang and victory is ours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:782
-msgid ""
-"We have just learned that the artifact is on an island north of this "
-"continent. However, there does not appear to be any means to get there. Stay "
-"very alert for any possible way across the narrow channel."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:783
-msgid ""
-"Welcome back general.  Have you finished the conquest of the northern "
-"lands?  What? you still have not finished your mission!  Get back there and "
-"teach those rebels a lesson!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:784
-msgid "Welcome to Li'l Alctatraz! Vistors NOT welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:785
-msgid ""
-"Welcome to Power Island. He who controls this Isle controls the Seven Lakes!"
-msgstr ""
-"Добро пожаловать на Остров Власти. Тот, кто контролирует этот Остров - "
-"контролирует Семь Озер!"
-
-#: ../fheroes2/resource/maps_text.cpp:786
-msgid "Welcome to the Sandbar."
-msgstr "Добро пожаловать в Сандбар."
-
-#: ../fheroes2/resource/maps_text.cpp:787
-msgid "Welcome to the sandy Isle."
-msgstr "Добро пожаловать на Оранжевый Остров."
-
-#: ../fheroes2/resource/maps_text.cpp:788
-msgid "Welcome to the sorceress' guild."
-msgstr "Добро пожаловать в башню волшебницы."
-
-#: ../fheroes2/resource/maps_text.cpp:789
-msgid "Welcome to the Spiral Isles"
-msgstr "Добро пожаловать на Спиральный Остров."
-
-#: ../fheroes2/resource/maps_text.cpp:790
-msgid ""
-"Welcome to the wounderous Kitisland range.  Eruptions each day, beware of "
-"dragons."
-msgstr ""
-"Добро пожаловать в Китисленд. Каждый день извержения вулканов, а также "
-"остерегайтесь драконов."
-
-#: ../fheroes2/resource/maps_text.cpp:791
-msgid "Welcome to Windfall Island!"
-msgstr "Добро пожаловать на Остров Буреломов!"
-
-#: ../fheroes2/resource/maps_text.cpp:792
-msgid "Welcome to your DOOM!"
-msgstr "Добро пожаловать, здесь Ваша Погибель!"
-
-#: ../fheroes2/resource/maps_text.cpp:793
-msgid "We'll join you - for the right price."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:794
-msgid ""
-"Well placed bribes have won you a stronghold near the warring Barbarians. Be "
-"advised that given their proximity an unguarded castle is an open invitation "
-"to defeat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:795
-msgid "Westfork"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:796
-msgid "Westmoor"
-msgstr "Восточное Болото"
-
-#: ../fheroes2/resource/maps_text.cpp:797
-msgid "We told you not to drink!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:798
-msgid "What are you doing here?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:799
-msgid "What cannot be seen but only heard, and will not speak until spoken to?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:800
-msgid "What everyday word is most often pronounced incorrectly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:801
-msgid "What goes up and down but never moves?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:802
-msgid ""
-"What good fortune!  You've discovered a long-abandoned settlement.  To your "
-"surprise, you discover that the previous inhabitants left some of their "
-"resources behind when they departed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:803
-msgid "What is always coming but never arrives?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:804
-msgid "What is the Sum of all Numbers from 1 to 200?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:805
-msgid "What is time spent poorly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:806
-msgid "What's another word for pirate treasure?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:807
-msgid "What's behind door number one?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:808
-msgid "What's this? A pile of gems?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:809
-msgid "What's this? Someone has left a pile of wood here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:810
-msgid ""
-"What team won Super Bowl XXI and Super Bowl XXV?  (Hint... a Wizard might "
-"have these troops in his army)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:811
-msgid "What turns everything around but does not move?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:812
-msgid ""
-"What walks in the morning on four legs, two in the afternoon and three in "
-"the evening?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:813
-msgid "What?  What's this?  Something at the bottom of this pool..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:814
-msgid "When you're ready, take the teleport to the Island's Hot Spot!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:815
-msgid ""
-"When you think yourself invincible, walk through this gate.  Even then, "
-"prepare to meet your bitter end."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:816
-msgid "Where am I?"
-msgstr "Где Я?"
-
-#: ../fheroes2/resource/maps_text.cpp:817
-msgid "While away seeking the Ultimate Artifact, Kastor's kingdom is invaded!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:818
-msgid ""
-"While traveling a mesenger meets you on the road.  His message tells of a "
-"new ally from an island far to the south.  This ally can not offer forces to "
-"your battle but has agreed to send some support in the form of gold and "
-"crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:819
-msgid "Whiteshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:820
-msgid "Whittingham"
-msgstr "Витингем"
-
-#: ../fheroes2/resource/maps_text.cpp:821
-msgid "Who am I?"
-msgstr "Кто Я?"
-
-#: ../fheroes2/resource/maps_text.cpp:822
-msgid ""
-"Who am I?...  Where am I?...  Oh no! My Ship!  Well it's consigned to the "
-"ghosts of my dead crew now, at least I still have my lucky rabbits foot."
-msgstr ""
-"Кто Я?!... Где Я?!... Я попал.. мой корабль разбит, и сейчас он под охраной "
-"моего мертвого экипажа. Моя судьба немного удачнее, лишь благодаря кроличей "
-"лапке."
-
-#: ../fheroes2/resource/maps_text.cpp:823
-msgid "Who is the true King?"
-msgstr "Кто из нас, настоящий Король?"
-
-#: ../fheroes2/resource/maps_text.cpp:824
-msgid ""
-"\"Why have we come this way?\"  asks the first mate.  You have no answer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:825
-msgid "Wicked Warlock Way"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:826
-msgid "Wilasher"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:827
-msgid "Wildabar"
-msgstr "Вилдабар"
-
-#: ../fheroes2/resource/maps_text.cpp:828
-msgid "Wilgatus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:829
-msgid "Willow"
-msgstr "Виллоу"
-
-#: ../fheroes2/resource/maps_text.cpp:830
-msgid "Windfall Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:831
-msgid "Winterkill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:832
-msgid "Winterlands"
-msgstr "Северные Страны"
-
-#: ../fheroes2/resource/maps_text.cpp:833
-msgid "Witch Hunt"
-msgstr "Избушка"
-
-#: ../fheroes2/resource/maps_text.cpp:834
-msgid ""
-"With the year long eruption of Mt. Kitisland, your three worst enemies now "
-"have a ground bridge to your eastern contenent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:835
-msgid "Wizardwood.  Magicians welcome!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:836
-msgid "Woodhaven"
-msgstr "Вудхавен"
-
-#: ../fheroes2/resource/maps_text.cpp:837
-msgid "Wood's Lord"
-msgstr "Деревянный Король"
-
-#: ../fheroes2/resource/maps_text.cpp:838
-msgid "Woodstock"
-msgstr "Вудсток"
-
-#: ../fheroes2/resource/maps_text.cpp:839
-msgid "Woodville"
-msgstr "Вудвиль"
-
-#: ../fheroes2/resource/maps_text.cpp:840
-msgid "Wormed Ash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:841
-msgid "Wow, somebody has left a pile of wood here!"
-msgstr "Ого, ктото оставил тут дрова!"
-
-#: ../fheroes2/resource/maps_text.cpp:842
-msgid "Wyrm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:843
-msgid "Xabran"
-msgstr "Ксабран"
-
-#: ../fheroes2/resource/maps_text.cpp:844
-msgid "Yellow gets some stuff"
-msgstr "Желтый получил несколько материалов"
-
-#: ../fheroes2/resource/maps_text.cpp:845
-msgid "Yellow's Steady Cash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:846
-msgid "Yellow stuff"
-msgstr "хабар для Желтого"
-
-#: ../fheroes2/resource/maps_text.cpp:847
-msgid "Yellow's Yarbols"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:848
-msgid "Ye old fish liver oil."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:849
-msgid "Yorksford"
-msgstr "Йорксфорд"
-
-#: ../fheroes2/resource/maps_text.cpp:850
-msgid ""
-"You and your ally's families were given custody of The Isle of Knowledge.  "
-"Other Lords feel the time has come for new guardians..."
-msgstr ""
-"Опека над Островом Знания поручена Вам и семьям вашего союзника. Но другие "
-"Лорды считают, что пришло время для новых хранителей..."
-
-#: ../fheroes2/resource/maps_text.cpp:851
-msgid "You are a fool to come here!"
-msgstr "Ты настолько глуп, что изволил прийти сюда!"
-
-#: ../fheroes2/resource/maps_text.cpp:852
-msgid "You are fighting on the side of your king!"
-msgstr "Вы сражаетесь на стороне вашего Короля!"
-
-#: ../fheroes2/resource/maps_text.cpp:853
-msgid "You are fighting on the side of your sister!"
-msgstr "Вы сражаетесь на стороне своей сестры!"
-
-#: ../fheroes2/resource/maps_text.cpp:854
-msgid "You are now entering the domain of Prince Roland. Have a nice day."
-msgstr "Вы прибываете во владения принца Роланда. Удачного дня!"
-
-#: ../fheroes2/resource/maps_text.cpp:855
-msgid "You are now entering the domain of Prince Roland. Have a pleasant stay."
-msgstr ""
-"Вы прибываете во владения принца Роланда. Надеемся, что вам понравится."
-
-#: ../fheroes2/resource/maps_text.cpp:856
-msgid ""
-"You bribe the entrance guards of this dingy prison camp. They agree to look "
-"the other way for a little while."
-msgstr ""
-"Вы подкупили стражу у входа в этот грязный лагерь. Некоторое время они будут "
-"считать ворон в небе."
-
-#: ../fheroes2/resource/maps_text.cpp:857
-msgid ""
-"You can only reach your enemies via teleporters, but each jump is a leap of "
-"faith."
-msgstr ""
-"Вы можете настигнуть врагов только через монолиты, но с каждым прыжком вера "
-"все крепнет."
-
-#: ../fheroes2/resource/maps_text.cpp:858
-msgid ""
-"You cautiously ride through the trees, looking out for enemy assaults, when "
-"suddenly, the old elf is beside you. \"Your quest is almost at an end, my "
-"friend. All that remains is for you to lay seige to these last few castles. "
-"The fate of my people rests upon your final battles here. May the gods be "
-"with you as well.\"  He turns to leave, but you ask him his name before he "
-"is gone. Over his shoulder, as he is leaving he says \"I am Ilthanis, king "
-"of the elves.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:859
-msgid ""
-"You come across the dead remains of what was appearantly a powerful wizard!  "
-"You wonder if it's safe to continue."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:860
-msgid ""
-"You face three opponents in this scenario. Capture their castles and their "
-"heroes to prove your worthiness to Archibald."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:861
-msgid ""
-"You find a beautiful helm buried in the lava.  As you move to put it on your "
-"head it turns into the Hideous mask and now you realize that no creature "
-"will join you."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:862
-msgid ""
-"You find a gleaming gold medalion buried in the  snow.  As you move to put "
-"it on it changes to the Fizbin of Misfortune."
-msgstr ""
-"Вы увидели блестящий золотой медальон, лежащий в снегу. Вы подобрали его, и "
-"узнаете это Медальон Несчастья."
-
-#: ../fheroes2/resource/maps_text.cpp:863
-msgid ""
-"You find an old signpost in the midst of a thicket that reads \"Warlock "
-"Wood, West.  Barbarian Fields, East.\""
-msgstr ""
-"Среди зарослей, Вы нашли старый указатель, который гласит: \"Колдун Вуд, на "
-"Западе. Варвар Фиелд, на Востоке\"."
-
-#: ../fheroes2/resource/maps_text.cpp:864
-msgid ""
-"You find a note in the bottle! It reads, \"My ship has been wrecked by the "
-"notorious pirates in this area! I am stranded on a small and barren island. "
-"Please, I beg you to come and rescue me!\""
-msgstr ""
-"Вы находите бутылку и в ней записка! Она гласит: \"Мое судно потерпело "
-"крушение, благодаря пиратам! Я нахожусь на маленьком и пустынном острове. "
-"Пожалуйста, спасите меня!\""
-
-#: ../fheroes2/resource/maps_text.cpp:865
-msgid "You found something!"
-msgstr "Вы чтото нашли!"
-
-#: ../fheroes2/resource/maps_text.cpp:866
-msgid "You found Treasure!"
-msgstr "Вы нашли Сокровища!"
-
-#: ../fheroes2/resource/maps_text.cpp:867
-msgid ""
-"You have been ordered here to claim this land in the name of your King and "
-"recover any riches that you might find.  However, five other Kings and "
-"Queens have also sent their heroes to this land, so you must watch out for "
-"them as well as the natives!"
-msgstr ""
-"Вам приказали исследовать и захватить эту землю, именем Короля. Однако, пять "
-"других королевств также оспаривают права на эту землю, так что вы должны "
-"следить и за ними, и за местными туземцами!"
-
-#: ../fheroes2/resource/maps_text.cpp:868
-msgid "You have found what someone else has lost..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:869
-msgid ""
-"You have hired a barbarian of great power to aid you in this, your last "
-"quest. His origins are unknown to you, but you sense strong nobility beneath "
-"the furs and dirt that cover him. In addition, the famous explorer, Marco "
-"the wizard, is rumored to have wrecked his ship in this new land. Finding "
-"him would prove to be a much needed boon to your cause."
-msgstr ""
-"Вы наняли очень сильного Варвара, который согласился помочь в ваших "
-"приключениях. Его происхождение неизвестно, но вы чувствуете под мехами и "
-"грязью благородного человека. Так же в этих землях потерпел крушение "
-"известный мореплаватель Волшебник Марко. его нужно найти, для вашего дела."
-
-#: ../fheroes2/resource/maps_text.cpp:870
-msgid ""
-"You have just 8 weeks  to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-"У вас есть 8 недель, чтобы построить свою армию и завоевать город на другой "
-"стороне далекой реки.\n"
-"Есть три пути выбора, который из них вы выберете?"
-
-#: ../fheroes2/resource/maps_text.cpp:871
-msgid ""
-"You have just 8 weeks to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-"У вас есть 8 недель, чтобы построить свою армию и завоевать город на другой "
-"стороне далекой реки.\n"
-"Есть три пути выбора, который из них вы выберете?"
-
-#: ../fheroes2/resource/maps_text.cpp:872
-msgid ""
-"You have received a message from Archibald. \"General, these peasants "
-"deserve punishment. Put them to the sword and let Corlagon have his way with "
-"them.\""
-msgstr ""
-"Вы получили сообщение от Арчибальда. \"Мой Генерал, эти крестьяне "
-"заслуживают наказания. Пусть Корлагон возьмет меч и поступает с ними по "
-"своему\"."
-
-#: ../fheroes2/resource/maps_text.cpp:873
-msgid ""
-"You have received a message from Archibald.  \" HOW DARE YOU BETRAY ME! I "
-"will see your head on the block alongside your new master's once I have won."
-msgstr ""
-"Вы получили сообщение от Арчибальда. \"Как смеешь ты предать меня! Скоро Я "
-"увижу Вашу голову на плахе.\""
-
-#: ../fheroes2/resource/maps_text.cpp:874
-msgid ""
-"You have received a message from Roland. \" I am shocked! I had thought "
-"better of you, but I was terribly wrong. Now you'll have to live with your "
-"dark decision for the rest of your life.\""
-msgstr ""
-"Вы получили сообщение от Роланда. \"Я в шоке! Я ошибся в Вас. Теперь вы "
-"будете жить с этим решением всю оставшуюся короткую жизнь\"."
-
-#: ../fheroes2/resource/maps_text.cpp:875
-msgid "You have recieved a shipment of supplies from your kingdom!"
-msgstr "Вы получили новый груз из Королевства!"
-
-#: ../fheroes2/resource/maps_text.cpp:876
-msgid ""
-"You have recieved a shipment of supplies from your kingdom! There is a note "
-"attached, \"These are all we could afford to send you from our treasuries, "
-"as the war with Harondale is taxing us greatly. We will send more in two "
-"weeks.\""
-msgstr ""
-"Вы получили новый груз из Королевства!  И письмо: \"Это все, что мы могли "
-"позволить себе послать вам, эта война очень затратна для нас. Следующий груз "
-"мы вышлем через две недели\"."
-
-#: ../fheroes2/resource/maps_text.cpp:877
-msgid ""
-"You have six months to destroy the Necromancer Stronghold in the heart of "
-"the valley."
-msgstr ""
-"У вас есть 6 месцев, чтобы уничтожить Крепость Некроманта, в самом сердце "
-"долины."
-
-#: ../fheroes2/resource/maps_text.cpp:878
-msgid ""
-"You have washed up on the beach after being shipwrecked. Your goal is to "
-"find a way home."
-msgstr ""
-"После кораблекрушения Вас вынесло на пляж. Ваша задача - найти путь домой."
-
-#: ../fheroes2/resource/maps_text.cpp:879
-msgid ""
-"You hear a low rumble, look up and see an avalanche!  You dive onto a large "
-"patch of grass to avoid it.  While dusting yourself off, you consider "
-"yourself quite lucky to be alive.  Luckier still to find a Four-Leaf Clover "
-"stuck on your nose."
-msgstr ""
-"Вы слышите низкий гул, смотрите вверх и видите снежную лавину! Вы прячетесь "
-"на большой лужайке, чтобы избежать ее. Лавина проносится мимо, Вы "
-"счастливчик, у вас в носу застрял Четырехлистный Клевер."
-
-#: ../fheroes2/resource/maps_text.cpp:880
-msgid ""
-"You hear a rumor from a peasant who lives in the town of Waystop. He says, "
-"\"The pirates control most of the sulfur mines in this area. They use it for "
-"the cannons on their bigger boats. If you want a mine, you'll have to defeat "
-"them.\""
-msgstr ""
-"Ты услышал сплетни от крестьянина, который живет в городе Вайстоп. Он "
-"рассказал что пираты контролируют большую часть шахт с серой в этой области. "
-"Они используют его для своих пушек для кораблей. Рано или поздно вам "
-"придется с ними столкнуться\"."
-
-#: ../fheroes2/resource/maps_text.cpp:881
-msgid "You hear melodic strains of elvish music as you enter this clearing."
-msgstr "На поляне Вы слышите мелодичные звуки эльфийской музыки."
-
-#: ../fheroes2/resource/maps_text.cpp:882
-msgid ""
-"You must, like, forsake your earthly wealth and, like, join us on the island "
-"of the lotus eaters."
-msgstr ""
-"Вы должны все бросить и присоединиться к нам на острове Поедателей Лотуса."
-
-#: ../fheroes2/resource/maps_text.cpp:883
-msgid ""
-"You must search the world for your mortal enemy, Wilgatus.  Can you find him "
-"before its too late?"
-msgstr ""
-"Вы должны найти, Вашего смертельного врага, Вилгатуса. Сможете ли вы его "
-"найти пока не поздно?"
-
-#: ../fheroes2/resource/maps_text.cpp:884
-msgid ""
-"You notice some runes hastily scrawled into a rock by your feet, They look "
-"like the initials of Uncle Ivan!"
-msgstr ""
-"Вы заметили несколько наскальных надписей, они выглядят: \"Здесь был Дядя "
-"Ваня!\""
-
-#: ../fheroes2/resource/maps_text.cpp:885
-msgid ""
-"You notice that mines and resources in the elvish lands are few, and you "
-"send word to your kingdom that you will need extra supplies. They should "
-"respond within a fortnight."
-msgstr ""
-"Вы заметили, что ресурсов на этой эльфийской земле осталось очень мало, и вы "
-"отправили соообщение о помощи в кололевство. Вам должен придти ответ в "
-"течении двух недель."
-
-#: ../fheroes2/resource/maps_text.cpp:886
-msgid ""
-"Your advance scouts come riding back to you with the following news. They "
-"believe they have found signs that Uncle Ivan was in this general area, and "
-"that he made his way to the north many months ago. Also they say there is a "
-"town nearby and many resources to the east."
-msgstr ""
-"Ваши разведчики вернулись с новостями. Они считают, что обнаружили признаки "
-"того, что Дядя Ваня было здесь, и что двигался на север, несколько месяцев "
-"назад. Кроме того, они сообщили, что рядом находится город, и много ресусов "
-"на востоке."
-
-#: ../fheroes2/resource/maps_text.cpp:887
-msgid ""
-"Your advisor approaches you, \"My liege, something must be done about these "
-"peasants! They still refuse to work.  At this rate you won't have anything "
-"to put in your daughter's dowry!\""
-msgstr ""
-"Советник подходит вам, \"Мои Сеньер, нужно что то делать! Эти крестьяне по "
-"прежнему отказываются работать. При таком темпе работ, у вад небудет "
-"приданного для вашей дочери!\""
-
-#: ../fheroes2/resource/maps_text.cpp:888
-msgid ""
-"Your advisor approaches you smiling greatly, \"My liege! The peasants are "
-"making money in the market, and are finally paying taxes!\""
-msgstr ""
-"lДовольный советник подходит к Вам, \"Мои Сеньер! Крестьяне начали торговать "
-"на рынке! Налоги текут рекой!\""
-
-#: ../fheroes2/resource/maps_text.cpp:889
-msgid ""
-"Your advisor approaches you with a long face, \"My liege, the peasant's "
-"numbers are growing steadily.  All they do is take, take, take! We are "
-"beginning to suffer dearly because of them.\""
-msgstr ""
-"К Вам подходит советник, с вытянутым лицом, \"Мой Сеньер! Число крестьян "
-"постояннно увеличивается... Они все время просят, просят, и просят! Это нам "
-"выходит очень дорого.\""
-
-#: ../fheroes2/resource/maps_text.cpp:890
-msgid ""
-"Your advisor approaches you with some startling information, \"My liege, the "
-"peasants are draining us. They do nothing, and take everything! We must get "
-"them home. Your own citizens are beginning to suffer!\""
-msgstr ""
-"К вам подошел советник, с шокирующей информацией, \"Мои Сеньер!, крестьяне "
-"занимаются грабежами. Они ничего не делают, и берут все! Мы должны отправить "
-"их всех домой. Ваши граждане начинают страдать!\""
-
-#: ../fheroes2/resource/maps_text.cpp:891
-msgid ""
-"Your arrival here was a surprise to those sworn to guard Dragon Isle, and "
-"you were able to quickly capture one of their castles.  Use caution, though, "
-"for two other guardians remain in this jungle."
-msgstr ""
-"Ваш приезд сюда, был неожиданностью для охраны Острова Драконов, и Вы смогли "
-"быстро захватить один из своих замков. Соблюдайте осторожность, два других "
-"захватчика все еще остаются поблизости."
-
-#: ../fheroes2/resource/maps_text.cpp:892
-msgid ""
-"Your castle, founded inside the center of a mile wide crater, is besieged by "
-"those who desire your mineral wealth."
-msgstr ""
-"Ваш замок, построенный в центре давно потухшего кратер, осаждают враги, "
-"которые желают разграбить все ваше богатство."
-
-#: ../fheroes2/resource/maps_text.cpp:893
-msgid "Your castle is the last outpost in the area, Don't lose it!"
-msgstr ""
-"Ваш замок является последним форпостом в этом районе, Не Потеряйте Его!"
-
-#: ../fheroes2/resource/maps_text.cpp:894
-msgid "Your crew begins to grumble."
-msgstr "Ваша команда начинает ворчать."
-
-#: ../fheroes2/resource/maps_text.cpp:895
-msgid ""
-"Your crew seriously entertains thoughts of mutiny.  Your nights are "
-"sleepless."
-msgstr ""
-"Вашу команду, все чаще и чаще, посещают мысли мысли о мятеже. Это время "
-"бессонных ночей для вас."
-
-#: ../fheroes2/resource/maps_text.cpp:896
-msgid "You're almost there!"
-msgstr "Вы почти у цели!"
-
-#: ../fheroes2/resource/maps_text.cpp:897
-msgid "You, recieve word that you have been robbed."
-msgstr "Вы, получили письмо, в котором говориться, что Вас ограбили!"
-
-#: ../fheroes2/resource/maps_text.cpp:898
-msgid "You're getting colder."
-msgstr "Вам становится холодно"
-
-#: ../fheroes2/resource/maps_text.cpp:899
-msgid "You're getting warmer."
-msgstr "Вам становится теплее."
-
-#: ../fheroes2/resource/maps_text.cpp:900
-msgid ""
-"You're here! Oh, thank you thank you thank you! I'm in the jail east of the "
-"castle. Please hurry!"
-msgstr ""
-"Вы уже здесь! О, благодарю Вас, благодарю Вас! Я нахожусь в тюрьме к востоку "
-"от замка. Пожалуйста, поспешите!"
-
-#: ../fheroes2/resource/maps_text.cpp:901
-msgid ""
-"Your expedition has taken a turn for the worse... you now have no way to get "
-"home!"
-msgstr ""
-"Ваша экспедиция закончилась очень плохо ... Теперь у Вас нет возможности "
-"попасть домой!"
-
-#: ../fheroes2/resource/maps_text.cpp:902
-msgid ""
-"Your forces are thinly spread in an effort to defend all the dwarf towns "
-"(which may not be transformed into castles). Consolidate your forces and "
-"smite the enemy before the towns fall."
-msgstr ""
-"Ваши силы расредоточены, для защиты Гномьих Поселений. Вам нужно "
-"объединиться, и поразить противника, пока он не захватил все."
-
-#: ../fheroes2/resource/maps_text.cpp:903
-msgid ""
-"Your horse stumbles and throws you from the saddle.  When you awaken you "
-"find that you have hit your head on the Fizbin of Misfortune."
-msgstr ""
-"Ваш конь спотыкается и выбросает Вас из седла. Когда Вы пришли в сознание, "
-"Вы обнаружите Мадальон Несчастья."
-
-#: ../fheroes2/resource/maps_text.cpp:904
-msgid ""
-"Your isolation from the rest of the kingdom has largely kept you out of the "
-"political struggles, but now with the king's death, and lack of an heir, you "
-"see a golden opportunity to seize the throne for yourself.  Just remember "
-"that you have relied largely on trade for several key resources, especially "
-"sulfur, but with a little planning this land can be yours.  Go, now, and "
-"show these peasants how to rule!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:905
-msgid "Your king has sent supplies to aid the war effort."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:906
-msgid ""
-"Your opponents are allied against you and each is twice as powerful as his "
-"predecessor! Is it possible to win?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:907
-msgid ""
-"Your Queen sent you here to explore this newly discovered territory, but a "
-"freak storm scattered your fleet and left you stranded.  You gather the "
-"survivors and form a small settlement, naming it New Vertigo.  This place is "
-"your home now, and survival is your highest priority, but remember, if you "
-"are captured or killed, it's over!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:908
-msgid ""
-"Your rival, the kingdom of Harondale, is attacking your weak border towns! "
-"Recover from their first strike and crush them completely."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:909
-msgid ""
-"Your Scouts report talking to a young knight, a squire to the two sleeping "
-"heroes.  The squire is trapped by the Aqua Magic Barriers and a group of "
-"fallen Paladins.  He says the two heroes, Dainwin and Ceallach, have "
-"awakened but are still trapped by a Gold Magical Barrier and asks your aid "
-"in freeing them."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:910
-msgid ""
-"Your Scouts report that the Aqua Traveller's Tent is located along The North "
-"Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:911
-msgid ""
-"Your scouts return with grim news.  The natives of this land are currently "
-"at war with each other, and they like outsiders even less than they like "
-"each other!  Congratulations, Commander, you're at war!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:912
-msgid ""
-"Your sister calls you before her altar in the morning. \"I have important "
-"news,\" she says, \"The barbarian kingdoms which border this land have "
-"agreed to lend us some of their castles and warriors in return for a share "
-"of the spoils. I hope victory comes swiftly, but your presence gives me "
-"strength to stand until whatever end awaits.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:913
-msgid "Your subjects contribute to your war effort!"
-msgstr "Ваши субъекты способствуют военным усилиям!"
-
-#: ../fheroes2/resource/maps_text.cpp:914
-msgid ""
-"Your town is undefended and your heroes are scattered.  Do you attack or "
-"defend?"
-msgstr ""
-"Ваш город незащищен и герои разбросаны по стране. Что вам делать: атаковать "
-"или обороняться?"
-
-#: ../fheroes2/resource/maps_text.cpp:915
-msgid ""
-"Your treasury has been looted by robbers and you have lost valuable "
-"resources."
-msgstr "Ваша казна была разграблена грабителями, и Вы потеряли ценные ресурсы."
-
-#: ../fheroes2/resource/maps_text.cpp:916
-msgid "Your troops begin to wonder about your sanity."
-msgstr "Ваши войска начинают задумываться о Вашей вменяемости."
-
-#: ../fheroes2/resource/maps_text.cpp:917
-msgid ""
-"You run aground on the rocks and have to use some wood to fix your boat."
-msgstr ""
-"Вы попали в кораблекрушение на скалах, и вам нужны дрова, чтобы починить "
-"корабль."
-
-#: ../fheroes2/resource/maps_text.cpp:918
-msgid ""
-"You see a family of refugees making their way from the beach. You ask them "
-"about their plight and they tell you that they are from a once great city "
-"called Moss Side. They tell you that the castle was destroyed in a great "
-"conflagration, and they fled for fear of their lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:919
-msgid ""
-"You see an old man bringing water towards the stables. Recognizing him as "
-"the mystic, you attempt to thank him for his gift with some gold. He "
-"refuses, but says to you instead, \"There are riddles guarding the source of "
-"the fount's power, and the dragons know the answers. Make your way through "
-"their lair, and you shall know victory.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:920
-msgid ""
-"You see an old mystic perched on a rock. You walk towards him to see if he "
-"has any words for you on your quest, and he says \"First I see you as a "
-"great conquerer of the lands of men. Secondly, I see you as a mighty ruler "
-"of vast armies, well loved by your troops. Thirdly, I see you as a slayer of "
-"legions of dragons, your body bathed in their fire. Lastly, I see you "
-"standing on the shores of the fount, unable to cross.\" Then the Mystic "
-"fades away."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:921
-msgid "You see something that could just be the elusive Nubbie!"
-msgstr "Вы видите что-то, это как раз может быть неуловимая Nubbie!"
-
-#: ../fheroes2/resource/maps_text.cpp:922
-msgid ""
-"You see the mast of ancient ship here.  On further investigation you find "
-"that the ships holds are full of gems.  The hours pass as your crue "
-"liberates the treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:923
-msgid ""
-"You see the remains of a burned out sawmill here.  All you can salvage is "
-"some ofwood left for scrap."
-msgstr ""
-"Вы видите остатки сгоревшей лесопики. Все что осталось, вы разобрали на "
-"ресурсы."
-
-#: ../fheroes2/resource/maps_text.cpp:924
-msgid ""
-"You see the remains of an old sawmill, but it is obvious that you will not "
-"be able to make it work again."
-msgstr ""
-"Вы видите остатки старой лесопилки, и очевидно, что вы не сможете ее "
-"отремонтировать."
-
-#: ../fheroes2/resource/maps_text.cpp:925
-msgid ""
-"You see the remains of an old sawmill just to realize that it will no longer "
-"produce.  You gather the ramains and move on."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:926
-msgid ""
-"You send this letter back to the king,\"A month has passed and we have not "
-"discovered the wizard Joseph. I only hope that we are able to locate him in "
-"time to aid us in our struggle.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:927
-msgid "You should turn back."
-msgstr "Вам нужно вернуться назад."
-
-#: ../fheroes2/resource/maps_text.cpp:928
-msgid ""
-"You stumble upon an old man who proclaims you Lord of the Realm, hands you "
-"his boots and wonders into the mountains mumbling something about being late "
-"for an important date."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:929
-msgid ""
-"You stumple across three small rocks piled on top of each other and decide "
-"to dig undernear them.  There you find an old weather-beaten bag of gems."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:930
-msgid "You uncover a compass in the grass!"
-msgstr "Вы обнаружили компас в траве!"
-
-#: ../fheroes2/resource/maps_text.cpp:931
-msgid "You've been warned!"
-msgstr "Мы Вас предупредили!"
-
-#: ../fheroes2/resource/maps_text.cpp:932
-msgid ""
-"You've received a message from Roland. \"In the absence of a strong leader, "
-"the local lords have fallen to fighting. Uniting this area is critical to "
-"our cause, so we must not fail.  Leaving your castle undefended in this "
-"highly contested region will surely lead to defeat. I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:933
-msgid ""
-"You've received a message from the guild. \"Thank God you've arrived! We're "
-"under seige from two enemies from the north and one from across the sea. "
-"Please save us, you're our only hope.\""
-msgstr ""
-"Вы получили сообщение от гильдии. \"Слава Богу, что вы приехали! Сейчас мы в "
-"осаде, один враг с севера, а другой из-за моря. Пожалуйста, помогите нам, Вы "
-"наша единственная надежда!\""
-
-#: ../fheroes2/resource/maps_text.cpp:934
-msgid ""
-"You've ruled with an iron fist (and an army of undead), but now your kingdom "
-"has turned against you!"
-msgstr ""
-"Вы жестко правили королевством и армией из нежити, но теперь ваше "
-"королевство превратилось против вас!"
-
-#: ../fheroes2/resource/maps_text.cpp:935
-msgid ""
-"You've saved a group of miners from the dragons.  One of them approaches "
-"you, \"Thank you so much for saving us!  We found this sulfer and sword in "
-"the mine, then those dragons chased us!  I don't know how much longer we "
-"could survive!\""
-msgstr ""
-"Вы спасли группа шахтеров от драконов. Один из них подходит вам,  "
-"\"Благодярю Вас за наше спасение! Мы обнаружили этот меч в шахте, долго "
-"здесь мы бы не продержались...\""
-
-#: ../fheroes2/resource/maps_text.cpp:936
-msgid ""
-"You will clash quickly on this small head-to-head map, so stay on your toes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:937
-msgid ""
-"You will need a stronger army than that, mortal, to step through this portal."
-msgstr "Вам нужна более сильная армия, чтобы пройти через этот портал."
-
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Wood"
 msgstr "Древесина"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Mercury"
 msgstr "Ртуть"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Ore"
 msgstr "Руда"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Sulfur"
 msgstr "Сера"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Crystal"
 msgstr "Кристаллы"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Gems"
 msgstr "Самоцветы"
 
-#: ../fheroes2/spell/spell_book.cpp:61 ../fheroes2/spell/spell_book.cpp:79
-msgid "No spell to cast."
-msgstr "Нет заклинаний для применения."
-
-#: ../fheroes2/spell/spell_book.cpp:138
-msgid "Your hero has %{point} spell points remaining"
-msgstr "У вашего героя осталось %{point} очков магии."
-
-#: ../fheroes2/spell/spell.cpp:50
 msgid "Fireball"
 msgstr "Огненный Шар"
 
-#: ../fheroes2/spell/spell.cpp:50
 msgid ""
 "Causes a giant fireball to strike the selected area, damaging all nearby "
 "creatures."
@@ -12284,11 +6265,9 @@ msgstr ""
 "Огненный шар действует на выбранную зону, причиняя в радиусе действия урон "
 "врагу. Цель = зона. Урон = 10хСМ. Радиус = 1 клетка."
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid "Fireblast"
 msgstr "Огненный Взрыв"
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid ""
 "An improved version of fireball, fireblast affects two hexes around the "
 "center point of the spell, rather than one."
@@ -12296,21 +6275,17 @@ msgstr ""
 "Огненный взрыв улучшенная версия огненного шара с увеличенным радиусом "
 "поражения. Цель = зона. Урон = 10хСМ. Радиус = 2 клетки."
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Lightning Bolt"
 msgstr "Молния"
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Causes a bolt of electrical energy to strike the selected creature."
 msgstr ""
 "Мощный электрический разряд поражает выбранный отряд противника. Цель = "
 "отряд. Урон = 25хСМ."
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid "Chain Lightning"
 msgstr "Цепь Молний"
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid ""
 "Causes a bolt of electrical energy to strike a selected creature, then "
 "strike the nearest creature with half damage, then strike the NEXT nearest "
@@ -12321,135 +6296,108 @@ msgstr ""
 "только врага, но и ваши. Цель = 4 разряда против часовой стрелки. Урон = "
 "(40хСМ)+(20хСМ)+(10хСМ)+(5хСМ)."
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid "Teleport"
 msgstr "Телепорт"
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid ""
 "Teleports the creature you select to any open position on the battlefield."
 msgstr "Телепортирует выбранное существо в  любую свободную точку на поле."
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid "Cure"
 msgstr "Лечение"
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid ""
-"Removes all negative spells cast upon one of your units, and restores up to %"
-"{count} HP per level of spell power."
+"Removes all negative spells cast upon one of your units, and restores up to "
+"%{count} HP per level of spell power."
 msgstr ""
 "Убирает все негативные заклинания (кроме разрушающего луча) с Вашего отряда "
 "и восстанавливает %{count}*SP здоровья."
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid "Mass Cure"
 msgstr "Массовое Лечение"
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid ""
-"Removes all negative spells cast upon your forces, and restores up to %"
-"{count} HP per level of spell power, per creature."
+"Removes all negative spells cast upon your forces, and restores up to "
+"%{count} HP per level of spell power, per creature."
 msgstr ""
 "Убирает все негативные заклинания (кроме разрушающего луча) с Ваших отрядов, "
 "и восстанавливает %{count}*SP здоровья."
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrect"
 msgstr "Оживление"
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrects creatures from a damaged or dead unit until end of combat."
 msgstr ""
 "До конца боя оживляет войнов в отряде, которому был нанесен урон или который "
 "был уничтожен. Цель = дружественный отряд. Здоровье = 50хСМ."
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrect True"
 msgstr "Воскрешение"
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrects creatures from a damaged or dead unit permanently."
 msgstr ""
 "Полностю оживляет войнов в отряде, которому был нанесен урон или который был "
 "уничтожен. Цель = дружественный отряд. Здоровье = 50хСМ."
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Haste"
 msgstr "Ускорение"
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Increases the speed of any creature by %{count}."
 msgstr "Увеличивает скорость вашего отряда на %{count}."
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Mass Haste"
 msgstr "Массовое Ускорение"
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Increases the speed of all of your creatures by %{count}."
 msgstr "Увеличивает скорость всех ваших отрядов на %{count}."
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "spell|Slow"
 msgstr "Замедление"
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "Slows target to half movement rate."
 msgstr "Замедляет варжеский отряд на 2. Цель = отряд врага. Длит =Раунд*СМ."
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Mass Slow"
 msgstr "Массовое Замедление"
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Slows all enemies to half movement rate."
 msgstr ""
 "Замедляет все варжеские отряды на 2. Цель = отряд врага. Длит =Раунд*СМ."
 
-#: ../fheroes2/spell/spell.cpp:64
-msgid "Blind "
-msgstr "Ослепить "
+#, fuzzy
+msgid "spell|Blind"
+msgstr "Замедление"
 
-#: ../fheroes2/spell/spell.cpp:64
 msgid "Clouds the affected creatures' eyes, preventing them from moving."
 msgstr ""
 "Ослепленный отряд пропускает ходы до тех пор пока не получит урон или не "
 "кончится дейсвтие заклинания. Цель = отряд. Длит =Раунд*СМ."
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Bless"
 msgstr "Благословение"
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Causes the selected creatures to inflict maximum damage."
 msgstr "Выбранный отряд будет наносить максимальный урон. Длит = Раунд*СМ."
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Mass Bless"
 msgstr "Массовое Благословение"
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Causes all of your units to inflict maximum damage."
 msgstr ""
 "Все ваши отряды будут наносить максимальный урон противнику. Цель = "
 "дружественный отряд. Длит = Раунд*СМ."
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Stoneskin"
 msgstr "Каменная Кожа"
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Magically increases the defense skill of the selected creatures."
 msgstr ""
 "Магически увеличивает защиту выбранного отряда на 3. Цель = дружественный "
 "отряд. Длит = Раунд*СМ."
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid "Steelskin"
 msgstr "Стальная Кожа"
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid ""
 "Increases the defense skill of the targeted creatures.  This is an improved "
 "version of Stoneskin."
@@ -12457,123 +6405,99 @@ msgstr ""
 "Увеличивает защиту выбранного существа на 5. Цель = дружественный отряд. "
 "Длит = Раунд*СМ."
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Curse"
 msgstr "Проклятье"
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Causes the selected creatures to inflict minimum damage."
 msgstr ""
 "Заставляет вражеский отряд при атаке наносить минимальный урон. Цель = отряд "
 "врага. Длит = Раунд*СМ."
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Mass Curse"
 msgstr "Массовое Проклятие"
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Causes all enemy troops to inflict minimum damage."
 msgstr ""
 "Заставляет все вражеские отряды при атаке наносить минимальный урон. Цель = "
 "отряд врага. Длит = Раунд*СМ."
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Holy Word"
 msgstr "Святое слово"
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Damages all undead in the battle."
 msgstr ""
 "Причиняет всей нежити, находящейся на поле боя. Цель = все поле. Урон = "
 "10хСМ."
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid "Holy Shout"
 msgstr "Экзорцизм"
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid ""
 "Damages all undead in the battle.  This is an improved version of Holy Word."
 msgstr ""
 "Усиленный вариант святого слова, который причиняет сильные повреждения всей "
 "нежити, находящейся на поле боя. Цель = все поле. Урон = 20хСМ."
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Anti-Magic"
 msgstr "Анти-Магия"
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Prevents harmful magic against the selected creatures."
 msgstr ""
 "Защищает выбранный отряд от действий всех видов магии урона. Цель = любой "
 "отряд."
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Dispel Magic"
 msgstr "Снятие Чар"
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Removes all magic spells from a single target."
 msgstr ""
 "Снимает с выбранного отряда действие всех заклинаний. Как полезных, так и "
 "вредных. Цель = любой отряд."
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Mass Dispel"
 msgstr "Массовое Снятие Чар"
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Removes all magic spells from all creatures."
 msgstr ""
 "Снимает со всех, присутствующих на поле боя отрядов, действия всех "
 "заклинаний. Как полезных, так и вредных. Цель = все поле."
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Magic Arrow"
 msgstr "Волшебная Стрела"
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Causes a magic arrow to strike the selected target."
 msgstr ""
 "Выстреливает волшебную стрелу в существо противника. Цель = отряд врага. "
 "Урон = 10хСМ."
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Berserker"
 msgstr "Берсерк"
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Causes a creature to attack its nearest neighbor."
 msgstr ""
 "Выбранный отряд атакует ближайшее к нему существо, но после атаки действие "
 "заклинания прекращается. Цель = отряд."
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid "Armageddon"
 msgstr "Армагеддон"
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid ""
 "Holy terror strikes the battlefield, causing severe damage to all creatures."
 msgstr ""
 "Хаос обрушивается на боле боя, причиняя всем и вся огромный урон. Цель = все "
 "поле. Урон = 50хСМ."
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Elemental Storm"
 msgstr "Шторм Элементов"
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Magical elements pour down on the battlefield, damaging all creatures."
 msgstr ""
 "Силы стихий обрушиваются на поле боя нанося урон всем участникам сражения. "
 "Цель = все поле. Урон = 25хСМ."
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid "Meteor Shower"
 msgstr "Камнепад"
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid ""
 "A rain of rocks strikes an area of the battlefield, damaging all nearby "
 "creatures."
@@ -12581,44 +6505,37 @@ msgstr ""
 "Призывает дождь из камней, наносящий урон всем существам, находящимся в поле "
 "действия заклинания. Цель = зона. Урон = 25хСМ."
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "Paralyze"
 msgstr "Паралич"
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "The targeted creatures are paralyzed, unable to move or retaliate."
 msgstr ""
 "Отряд, против которого направленно это заклинание, поражает паралич, и он "
 "теряет способность передвигатся и отвечать на удары. Цель = отряд. Длит = "
 "Раунд*СМ."
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid "Hypnotize"
 msgstr "Гипноз"
 
-#: ../fheroes2/spell/spell.cpp:82
+#, fuzzy
 msgid ""
-"Brings a single enemy unit under your control for one combat round if its "
-"hits are less than %{count} times the caster's spell power."
+"Brings a single enemy unit under your control if its hits are less than "
+"%{count} times the caster's spell power."
 msgstr ""
 "Загипнотизированный вражеский отряд, переходит под ваш полный контроль, на "
 "один раунд, если его здоровье меньше %{count} * SP."
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Cold Ray"
 msgstr "Ледяной Луч"
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Drains body heat from a single enemy unit."
 msgstr ""
 "Высасывает жизненное тепло из вражеского отряда. Цель = отряд врага. Урон = "
 "20хСМ."
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid "Cold Ring"
 msgstr "Ледяное Кольцо"
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid ""
 "Drains body heat from all units surrounding the center point, but not "
 "including the center point."
@@ -12626,29 +6543,23 @@ msgstr ""
 "Высасывает жизненное тепло из вражеских отрядов, находящихся в зоне действия "
 "заклинания, за исключением его центра. Цель = зона. Урон = 10хСМ."
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Disrupting Ray"
 msgstr "Разрушающий Луч"
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Reduces the defense rating of an enemy unit by three."
 msgstr "Снижает защиту выбранного отряда на 3."
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Death Ripple"
 msgstr "Дыхание Смерти"
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Damages all living (non-undead) units in the battle."
 msgstr ""
 "Наносит урон всем, в чьих жилах течет кровь, существам на поле боя. Цель = "
 "все поле. Урон = 5хСМ."
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid "Death Wave"
 msgstr "Волна Смерти"
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid ""
 "Damages all living (non-undead) units in the battle.  This spell is an "
 "improved version of Death Ripple."
@@ -12656,39 +6567,31 @@ msgstr ""
 "Наносит урон, еще больший чем Дыхание смерти, живым существам на поле боя. "
 "Цель = все поле. Урон = 10хСМ."
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Dragon Slayer"
 msgstr "Убить Дракона"
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Greatly increases a unit's attack skill vs. Dragons."
 msgstr ""
 "Увеличивает атаку выбранного существа в схватке с драконами на 5. Цель = "
 "дружественный отряд."
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Blood Lust"
 msgstr "Жажда Крови"
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Increases a unit's attack skill."
 msgstr "Увеличивает атаку выбранного отряда на 3. Цель = дружественный отряд."
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Animate Dead"
 msgstr "Поднять Нежить"
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Resurrects creatures from a damaged or dead undead unit permanently."
 msgstr ""
 "Навсегда оживляет существ нежити, которым был нанесен урон или котрые были "
 "уничтожены. Цель = отряд нежити. Здоровье = 50хСМ."
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid "Mirror Image"
 msgstr "Фантом"
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid ""
 "Creates an illusionary unit that duplicates one of your existing units.  "
 "This illusionary unit does the same damages as the original, but will vanish "
@@ -12698,135 +6601,105 @@ msgstr ""
 "уже урон как и оригинал, но будет развеяна от малейшего повреждения. Цель = "
 "отряд."
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Shield"
 msgstr "Щит"
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Halves damage received from ranged attacks for a single unit."
 msgstr ""
 "Принимает на себя половину урона от всех срелковых атак врага, направленных "
 "на выбранный отряд. Цель = дружественный отряд."
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Mass Shield"
 msgstr "Массовый щит"
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Halves damage received from ranged attacks for all of your units."
 msgstr ""
 "Принимает на себя половину урона от всех срелковых атак врага, направленных "
 "на ваших существ. Цель = все дружественные отряды."
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summon Earth Elemental"
 msgstr "Земной элементал"
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summons Earth Elementals to fight for your army."
 msgstr ""
 "Призывает на поле боя земляного элементала сражатся на вашей стороне. Цель = "
 "все поле. Количество = 3хСМ."
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summon Air Elemental"
 msgstr "Воздушный элементал"
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summons Air Elementals to fight for your army."
 msgstr ""
 "Призывает на поле боя воздушного элементала сражатся на вашей стороне. Цель "
 "= все поле. Количество = 3хСМ."
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summon Fire Elemental"
 msgstr "Огненный элементал"
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summons Fire Elementals to fight for your army."
 msgstr ""
 "Призывает на поле боя огненного элементала сражаться на вашей стороне. Цель "
 "= все поле. Количество = 3хСМ."
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summon Water Elemental"
 msgstr "Водяной элементал"
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summons Water Elementals to fight for your army."
 msgstr ""
 "Призывает на поле боя водяного элементала сражаться на вашей стороне. Цель = "
 "все поле. Количество = 3хСМ."
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Earthquake"
 msgstr "Землетрясение"
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Damages castle walls."
 msgstr "Наносит урон стенам замка."
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "View Mines"
 msgstr "Показать шахты"
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "Causes all mines across the land to become visible."
 msgstr "Делает видимыми все шахты, расположенные на карте."
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "View Resources"
 msgstr "Показать ресурсы"
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "Causes all resources across the land to become visible."
 msgstr "Делает видимыми все ресурсы, расположенные на карте."
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "View Artifacts"
 msgstr "Показать артефакты"
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "Causes all artifacts across the land to become visible."
 msgstr "Делает видимыми все артефакты, расположенные на карте."
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "View Towns"
 msgstr "Показать города."
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "Causes all towns and castles across the land to become visible."
 msgstr "Делает видимыми все города и замки, расположенные на карте."
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "View Heroes"
 msgstr "Показать героев"
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "Causes all Heroes across the land to become visible."
 msgstr "Делает видимыми всех героев, расположенных на карте."
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "View All"
 msgstr "Показать все"
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "Causes the entire land to become visible."
 msgstr "Делает видимымой всю карту."
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Identify Hero"
 msgstr "Опознать героя"
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Allows the caster to view detailed information on enemy Heroes."
 msgstr "Позволяет получить подробную информацию о героях противника."
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid "Summon Boat"
 msgstr "Призвать корабль"
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid ""
 "Summons the nearest unoccupied, friendly boat to an adjacent shore "
 "location.  A friendly boat is one which you just built or were the most "
@@ -12836,25 +6709,20 @@ msgstr ""
 "Корабль считается вашим, если вы его только что построили, или тот на ктором "
 "вы плавали в последним."
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Dimension Door"
 msgstr "Портал"
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Allows the caster to magically transport to a nearby location."
 msgstr "Переносит героя в расположенную поблизости точку на карте."
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Town Gate"
 msgstr "Врата в город"
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Returns the caster to any town or castle currently owned."
 msgstr ""
 "Возвращает героя в ближайший город или замок, если там уже не находится "
 "другой герой."
 
-#: ../fheroes2/spell/spell.cpp:109
 msgid ""
 "Returns the hero to the town or castle of choice, provided it is controlled "
 "by you."
@@ -12862,22 +6730,18 @@ msgstr ""
 "Возвращает героя в любой город или замок на выбор, при условии, если там уже "
 "не находится другой герой."
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid "Visions"
 msgstr "Видения"
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid ""
 "Visions predicts the likely outcome of an encounter with a neutral army camp."
 msgstr ""
 "Позволяет видеть герою не дальше 3-х шагов количество существ в нейтральном "
 "войске, а так же их намерения."
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid "Haunt"
 msgstr "Запустение"
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid ""
 "Haunts a mine you control with Ghosts.  This mine stops producing "
 "resources.  (If I can't keep it, nobody will!)"
@@ -12885,233 +6749,147 @@ msgstr ""
 "Наводняет принадлежащую игроку шахту призраками, после чего работа шахты "
 "прекращается. (Не доставайся же ты никому!) Количество = 4хСМ."
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Set Earth Guardian"
 msgstr "Страж земли"
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Sets Earth Elementals to guard a mine against enemy armies."
 msgstr ""
 "Призывает земляных элементалов охранять вашу шахту от врагов. Количество = "
 "4хСМ."
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Set Air Guardian"
 msgstr "Страж воздуха"
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Sets Air Elementals to guard a mine against enemy armies."
 msgstr ""
 "Призывает воздушных элементалов охранять вашу шахту от врагов. Количество = "
 "4хСМ."
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Set Fire Guardian"
 msgstr "Страж огня"
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Sets Fire Elementals to guard a mine against enemy armies."
 msgstr ""
 "Призывает огненых элементалов охранять вашу шахту от врагов. Количество = "
 "4хСМ."
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Set Water Guardian"
 msgstr "Страж воды"
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Sets Water Elementals to guard a mine against enemy armies."
 msgstr ""
 "Призывает водяных элементалов охранять вашу шахту от врагов. Количество = "
 "4хСМ."
 
-#: ../fheroes2/system/players.cpp:665
-msgid "Necroman"
-msgstr "Некромант"
+msgid "No spell to cast."
+msgstr "Нет заклинаний для применения."
 
-#: ../fheroes2/system/players.cpp:691
-msgid ""
-"This lets you change player starting positions and colors. A particular "
-"color will always start in a particular location. Some positions may only be "
-"played by a computer player or only by a human player."
-msgstr ""
-"Эта опция позоваляет вам задать цвет игрока и его стартовую позицию. Каждому "
-"цвету соответсвует определенная стартовая позиция. Некторые цвета жестко "
-"закреплены либо за компьютерными, либо за живыми игроками."
+#, fuzzy
+msgid "Your hero has %{point} spell points remaining."
+msgstr "У вашего героя осталось %{point} очков магии."
 
-#: ../fheroes2/system/players.cpp:695
-msgid ""
-"This lets you change the class of a player. Classes are not always "
-"changeable. Depending on the scenario, a player may receive additional towns "
-"and/or heroes not of their primary alignment."
-msgstr ""
-"Эта опция позволяет вам задавать класс игрока. Классы не всегда можно "
-"изменять. В зависимости от сценария игрок может получать дополнительные "
-"города и/или героев направленность которых изначально не совпадает с "
-"направленностью игрока."
+#, fuzzy
+msgid "View Adventure Spells"
+msgstr "Игровые действия"
 
-#: ../fheroes2/system/players.cpp:734
-msgid "%{color} player"
-msgstr "%{color} игрок"
+#, fuzzy
+msgid "View Combat Spells"
+msgstr "Произнести заклинание"
 
-#: ../fheroes2/system/settings.cpp:126
+#, fuzzy
+msgid "View previous page"
+msgstr "Предыдущий город"
+
+#, fuzzy
+msgid "View next page"
+msgstr "Просмотреть %{name}"
+
+#, fuzzy
+msgid "Close Spellbook"
+msgstr "Произнести заклинание"
+
+#, fuzzy
+msgid "View %{spell}"
+msgstr "Просмотреть %{name}"
+
 msgid "game: always confirm for rewrite savefile"
 msgstr "game: всегда делать запрос на перезапись игры"
 
-#: ../fheroes2/system/settings.cpp:127
-msgid "game: also confirm autosave"
-msgstr "game: так же спрашивать для autosave"
-
-#: ../fheroes2/system/settings.cpp:128
 msgid "game: remember last focus"
 msgstr "game: запомнить последнюю позицию фокуса (героя/замка)"
 
-#: ../fheroes2/system/settings.cpp:129
-msgid "game: battle show grid"
-msgstr "game: показать сетку на поле боя"
-
-#: ../fheroes2/system/settings.cpp:130
-msgid "game: battle mouse shadow"
-msgstr "game: показать тень перемещения курсора на поле боя"
-
-#: ../fheroes2/system/settings.cpp:131
-msgid "game: battle move shadow"
-msgstr "game: показать тень возможных ходов на поле боя"
-
-#: ../fheroes2/system/settings.cpp:132
-msgid "game: battle show damage info"
+#, fuzzy
+msgid "battle: show damage info"
 msgstr "game: показать доп. информацию для убитых на поле боя"
 
-#: ../fheroes2/system/settings.cpp:133
-msgid "game: castle flash building"
-msgstr "game: выделять активные постройки в городах"
-
-#: ../fheroes2/system/settings.cpp:134
 msgid "world: show visited content from objects"
 msgstr "world: показать доп. информацию о объектах (правый клик)"
 
-#: ../fheroes2/system/settings.cpp:135
+msgid "world: show terrain penalty"
+msgstr ""
+
 msgid "world: scouting skill show extended content info"
 msgstr "умение разведчика покажет дополнительную информацию"
 
-#: ../fheroes2/system/settings.cpp:136
-msgid "world: abandoned mine random resource"
-msgstr "world: для заброшенной шахты, возможны все виды ресурсов"
-
-#: ../fheroes2/system/settings.cpp:137
-msgid "world: save count monster after battle"
-msgstr "world: сохранить количество врагов, после поражения"
-
-#: ../fheroes2/system/settings.cpp:138
 msgid "world: allow set guardian to objects"
 msgstr "world: разрешить охранников для дополнительных объектов"
 
-#: ../fheroes2/system/settings.cpp:139
-msgid "world: guardian objects gets +2 defense"
-msgstr "world: защитники объектов всегда будут получать +2 к защите"
-
-#: ../fheroes2/system/settings.cpp:140
-msgid "world: no in-built requirements or guardians for placed artifacts"
-msgstr ""
-"world: запретить встроенные условия (покупка или охрана) для артефактов"
-
-#: ../fheroes2/system/settings.cpp:141
-msgid "world: only the first monster will attack (H2 bug)."
-msgstr ""
-"world: если несколько армий монстров вокруг героя, то одна битва за ход (H2 "
-"bug)"
-
-#: ../fheroes2/system/settings.cpp:142
 msgid "world: Eagle Eye also works like Scholar in H3."
 msgstr "world: Eagle Eye также работает как Scholar (H3)"
 
-#: ../fheroes2/system/settings.cpp:143
 msgid "world: ban for WeekOf/MonthOf Monsters"
 msgstr ""
 "world: отключить дополнительную прибавку существ в начале Недели/Месяца "
 "Монстров"
 
-#: ../fheroes2/system/settings.cpp:144
-msgid "world: new version WeekOf (+growth)"
-msgstr "world: новая версия прироста населения WeekOf (+ базовый прирост)"
-
-#: ../fheroes2/system/settings.cpp:145
 msgid "world: ban plagues months"
 msgstr "world: отключить месяц Чумы"
 
-#: ../fheroes2/system/settings.cpp:146
 msgid "world: Months Of Monsters do not place creatures on map"
 msgstr ""
 "world: отключить добавление дополнительных существ на карту после начала "
 "Месяца Монстров"
 
-#: ../fheroes2/system/settings.cpp:147
 msgid "world: Crystal Ball also added Identify Hero and Visions spells"
 msgstr ""
 "world: артификт Crystal Ball так же дабавляет заклинания Identify Hero и "
 "Visions"
 
-#: ../fheroes2/system/settings.cpp:148
-msgid "world: Artesian Springs have two separately visitable squares (h3 ver)"
-msgstr ""
-"world: объект Artesian Springs имеет два независимых источника (h3 ver)"
-
-#: ../fheroes2/system/settings.cpp:149
 msgid "world: Starting heroes as Loss Conditions for Human Players"
 msgstr "world: потеря начальных героев сценария приводит к поражению"
 
-#: ../fheroes2/system/settings.cpp:150
 msgid "world: Only 1 hero can be hired by the one player every week"
 msgstr "world: возможен найм только 1 героя в неделю"
 
-#: ../fheroes2/system/settings.cpp:151
-msgid "world: each castle allows one hero to be recruited every week"
+#, fuzzy
+msgid "world: Each castle allows one hero to be recruited every week"
 msgstr "world: каждый город разрешает покупку одного героя в неделю"
 
-#: ../fheroes2/system/settings.cpp:152
-msgid "world: Outer creature dwellings should accumulate units"
+msgid "world: Neutral armies scale with game difficulty"
 msgstr ""
-"world: количество монстров, во внешних жилищах, будет увеличиваться каждую "
-"неделю"
 
-#: ../fheroes2/system/settings.cpp:153
-msgid "world: use unique artifacts for morale/luck"
-msgstr ""
-"world: использовать уникальность для артифактов, влияющие на мораль/удачу"
-
-#: ../fheroes2/system/settings.cpp:154
 msgid "world: use unique artifacts for resource affecting"
 msgstr ""
 "world: использовать уникальность для артифактов, влияющие на доход в ресурсах"
 
-#: ../fheroes2/system/settings.cpp:155
 msgid "world: use unique artifacts for primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:156
 msgid "world: use unique artifacts for secondary skills"
 msgstr ""
 "world: использовать уникальность для артифактов, влияющие на вторич. навык"
 
-#: ../fheroes2/system/settings.cpp:157
 msgid "world: Wind/Water Mills and Magic Garden can be captured"
 msgstr ""
 "world: возможность установить флаг на постройках: Водяная/Ветренная "
 "Мельница, Магический Гриб"
 
-#: ../fheroes2/system/settings.cpp:158
 msgid "world: disable Barrow Mounds"
 msgstr "world: заблокировать покупку Привидений"
 
-#: ../fheroes2/system/settings.cpp:159
-msgid "castle: allow buy from well"
-msgstr "castle: разрешить покупку армии через колодец"
-
-#: ../fheroes2/system/settings.cpp:160
 msgid "castle: allow guardians"
 msgstr "castle: рарешить защитников (как в H3)"
 
-#: ../fheroes2/system/settings.cpp:161
 msgid ""
 "castle: higher mage guilds regenerate more spell points/turn "
 "(20/40/60/80/100%)"
@@ -13119,143 +6897,3172 @@ msgstr ""
 "castle: гильдия магов регенерирует SP от количества дней ожидания "
 "(20/40/60/80/100%)"
 
-#: ../fheroes2/system/settings.cpp:162
-msgid "castle: allow recruits special/expansion heroes"
-msgstr "castle: разрешить найм специальных героев из кампаний"
-
-#: ../fheroes2/system/settings.cpp:163
 msgid "heroes: allow buy a spellbook from Shrines"
 msgstr "heroes: разрешить покупку магической книги в Беседках"
 
-#: ../fheroes2/system/settings.cpp:164
-msgid "heroes: learn new spells with day"
-msgstr "heroes: выучить новые заклинания только после ночевки в городе"
-
-#: ../fheroes2/system/settings.cpp:165
 msgid "heroes: recruit cost to be dependent on hero level"
 msgstr "heroes: цена найма зависит от уровня"
 
-#: ../fheroes2/system/settings.cpp:166
-msgid "heroes: remember MP/SP for retreat/surrender result"
+#, fuzzy
+msgid "heroes: remember move points for retreat/surrender result"
 msgstr "heroes: если сбежал с битвы запомнить MP/SP для текущего дня"
 
-#: ../fheroes2/system/settings.cpp:167
-msgid "heroes: surrendering gives some experience"
-msgstr "heroes: сбежавщий также получает опыт"
-
-#: ../fheroes2/system/settings.cpp:168
-msgid "heroes: recalculate movement points after creatures movement"
-msgstr "heroes: пересчитывать MP после изменения армии"
-
-#: ../fheroes2/system/settings.cpp:169
-msgid "heroes: allow pickup objects for patrol"
-msgstr "heroes: разрешить патрулю поднимать объекты в своем радиусе"
-
-#: ../fheroes2/system/settings.cpp:170
-msgid "heroes: after battle move to target cell"
-msgstr "heroes: после битвы автоматически переходить на клетку цели"
-
-#: ../fheroes2/system/settings.cpp:171
 msgid "heroes: allow transcribing scrolls (needs: Eye Eagle skill)"
 msgstr "heroes: возможость выучить свитки (необходимо умение Орлиный Взор)"
 
-#: ../fheroes2/system/settings.cpp:172
-msgid "heroes: allow banned sec. skills upgrade"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:173
 msgid "heroes: in Arena can choose any of primary skills"
 msgstr "heroes: в постройке Арена можно обновить любой первичный навык"
 
-#: ../fheroes2/system/settings.cpp:174
 msgid "unions: allow meeting heroes"
 msgstr "unions: разрешить встречи для дружественных героев"
 
-#: ../fheroes2/system/settings.cpp:175
 msgid "unions: allow castle visiting"
 msgstr "unions: разрешить посещения дружественных замков"
 
-#: ../fheroes2/system/settings.cpp:176
+#, fuzzy
+msgid "battle: show army order"
+msgstr "game: показать сетку на поле боя"
+
 msgid "battle: soft wait troop"
 msgstr "battle: использовать альтернативный пропуск хода (Heroes III)"
 
-#: ../fheroes2/system/settings.cpp:177
-msgid "battle: high objects are an obstacle for archers"
-msgstr "battle: для высоких препятствий применить штраф при стрельбе"
-
-#: ../fheroes2/system/settings.cpp:178
-msgid "battle: merge armies for hero from castle"
-msgstr "battle: объединять армию города и героя при нападении противника"
-
-#: ../fheroes2/system/settings.cpp:179
-msgid "battle: archmage can resists (20%) bad spells"
-msgstr "battle: АрхиМаги имеют защиту (20%) от плохой магии"
-
-#: ../fheroes2/system/settings.cpp:180
-msgid "battle: magical creature resists (20%) the same magic"
-msgstr "battle: магические существа имеют защиту от этой же магии (20%)."
-
-#: ../fheroes2/system/settings.cpp:181
-msgid "battle: skip increase +2 defense"
-msgstr "battle: пропуск хода увеличивает защиту на +2"
-
-#: ../fheroes2/system/settings.cpp:182
 msgid "battle: reverse wait order (fast, average, slow)"
 msgstr "battle: обратный порядок после ожидания (первый быстрый)"
 
-#: ../fheroes2/system/settings.cpp:183
 msgid "game: show system info"
 msgstr "game: показать информационную строку (время, память и т.п.)"
 
-#: ../fheroes2/system/settings.cpp:184
 msgid "game: autosave on"
 msgstr "game: включить автосохранение"
 
-#: ../fheroes2/system/settings.cpp:185
 msgid "game: autosave will be made at the beginning of the day"
 msgstr "game: autosave в начале дня"
 
-#: ../fheroes2/system/settings.cpp:186
 msgid "game: use fade"
 msgstr "game: использовать плавное затухание при смене экрана"
 
-#: ../fheroes2/system/settings.cpp:187
-msgid "game: show SDL logo"
-msgstr "game: показать SDL logo при старте"
-
-#: ../fheroes2/system/settings.cpp:188
 msgid "game: use evil interface"
 msgstr "game: использовать серую тему интерфейса"
 
-#: ../fheroes2/system/settings.cpp:189
-msgid "game: also use dynamic interface for castles"
-msgstr "game: так же использовать динамическую тему для городов"
-
-#: ../fheroes2/system/settings.cpp:190
 msgid "game: hide interface"
 msgstr ""
 "game: выключить интерфейс\n"
 "(весь экран игровое поле)"
 
-#: ../fheroes2/system/settings.cpp:191
 msgid "game: offer to continue the game afer victory condition"
 msgstr "game: после победы возожно продолжить игру"
 
-#: ../fheroes2/system/settings.cpp:192
-msgid "pocketpc: hide cursor"
-msgstr "pocketpc: выключить курсор"
+#, fuzzy
+msgid "The ultimate artifact is really the %{name}."
+msgstr "%{name} прокляты Мумиями!"
 
-#: ../fheroes2/system/settings.cpp:193
-msgid "pocketpc: tap mode"
-msgstr "pocketpc: включить tap режим"
+msgid "The ultimate artifact may be found in the %{name} regions of the world."
+msgstr ""
 
-#: ../fheroes2/system/settings.cpp:194
-msgid "pocketpc: drag&drop gamearea as scroll"
-msgstr "pocketpc: drag&drop gamearea as scroll"
+msgid "north-west"
+msgstr ""
 
-#: ../fheroes2/system/settings.cpp:195
-msgid "pocketpc: low memory"
-msgstr "pocketpc: недостаточно памяти"
+#, fuzzy
+msgid "north"
+msgstr "Земля"
+
+msgid "north-east"
+msgstr ""
+
+#, fuzzy
+msgid "west"
+msgstr "Гнездо"
+
+#, fuzzy
+msgid "center"
+msgstr "Отряд"
+
+#, fuzzy
+msgid "east"
+msgstr "Гнездо"
+
+msgid "south-west"
+msgstr ""
+
+#, fuzzy
+msgid "south"
+msgstr "Звук"
+
+msgid "south-east"
+msgstr ""
+
+msgid "The truth is out there."
+msgstr ""
+
+msgid "The dark side is stronger."
+msgstr ""
+
+#, fuzzy
+msgid "The end of the world is near."
+msgstr "Остерегайся, здесь край мира!"
+
+msgid "The bones of Lord Slayer are buried in the foundation of the arena."
+msgstr ""
+
+msgid "A Black Dragon will take out a Titan any day of the week."
+msgstr ""
+
+msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
+msgstr ""
+
+msgid "An unknown force is being ressurected..."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Check the newest version of game at\n"
+"https://github.com/ihhub/\n"
+"fheroes2/releases"
+msgstr ""
+"Новую версию игры, можно найти, на сайте:\n"
+" http://sf.net/projects/fheroes2"
+
+#~ msgid "Hero %{name} also got a %{count} experience."
+#~ msgstr "Герой %{name} также получает %{count} опыта."
+
+#~ msgid ", and get +2 defense"
+#~ msgstr ", а также получает +2 к защите"
+
+#~ msgid "MirrorImage ended"
+#~ msgstr "MirrorImage закончилась магия."
+
+#~ msgid "You don't have enough gold!"
+#~ msgstr "Вам не хватает золота!"
+
+#~ msgid ""
+#~ "Your troops can be upgraded, but it will cost you %{ratio} times the "
+#~ "difference in cost for each troop, rounded up to next highest number. Do "
+#~ "you wish to upgrade them?"
+#~ msgstr ""
+#~ "Ваши воины могут быть улушены, но это будет стоить Вам %{ratio} кратной "
+#~ "разницы в цене за каждого воина, округлённой в большую сторону. Вы всё "
+#~ "ещё желаете улучшить?"
+
+#~ msgid "For the QVGA version is not available."
+#~ msgstr "Для версии QVGA пока недоступно."
+
+#~ msgid "Cost per troop:"
+#~ msgstr "Цена за войско:"
+
+#~ msgid "sound"
+#~ msgstr "Звук"
+
+#~ msgid "ai speed"
+#~ msgstr "скорость AI"
+
+#~ msgid "You have no room to carry another artifact!"
+#~ msgstr "В вашей сумке нет места для еще одного артефакта."
+
+#~ msgid "View Morale Info"
+#~ msgstr "Мораль"
+
+#~ msgid "View Luck Info"
+#~ msgstr "Удача"
+
+#~ msgid "Exit hero"
+#~ msgstr "Закрыть"
+
+#~ msgid "Dismiss hero"
+#~ msgstr "Уволить"
+
+#~ msgid "Show prev heroes"
+#~ msgstr "Предыдущий герой"
+
+#~ msgid "Bad Morale"
+#~ msgstr "Плохая Мораль"
+
+#~ msgid "Neutral Morale"
+#~ msgstr "Нейтральная Мораль"
+
+#~ msgid "Bad Luck"
+#~ msgstr "Плохая Удача"
+
+#~ msgid "Neutral Luck"
+#~ msgstr "Нейтральная Удача"
+
+#~ msgid "Good Luck"
+#~ msgstr "Хорошая Удача"
+
+#~ msgid "This game is now in beta development version. ;)"
+#~ msgstr "Игра пока все еще разрабатывается... ;)"
+
+#~ msgid "Water"
+#~ msgstr "Вода"
+
+#~ msgid "Ship Wreck"
+#~ msgstr "Кораблекрушение"
+
+#~ msgid "Coast"
+#~ msgstr "Побережье"
+
+#, fuzzy
+#~ msgid "Peasant"
+#~ msgstr "Крестьянин"
+
+#~ msgid "Peasants"
+#~ msgstr "Крестьяне"
+
+#, fuzzy
+#~ msgid "Archer"
+#~ msgstr "Стрелок"
+
+#~ msgid "Archers"
+#~ msgstr "Стрелков"
+
+#, fuzzy
+#~ msgid "Ranger"
+#~ msgstr "Рейнджер"
+
+#~ msgid "Rangers"
+#~ msgstr "Рейнджеров"
+
+#, fuzzy
+#~ msgid "Pikeman"
+#~ msgstr "Копейщик"
+
+#~ msgid "Pikemen"
+#~ msgstr "Копейщиков"
+
+#, fuzzy
+#~ msgid "Veteran Pikeman"
+#~ msgstr "Опытный Копейщик"
+
+#~ msgid "Veteran Pikemen"
+#~ msgstr "Копейщиков ветеранов"
+
+#, fuzzy
+#~ msgid "Swordsman"
+#~ msgstr "Мечник"
+
+#~ msgid "Swordsmen"
+#~ msgstr "Мечников"
+
+#, fuzzy
+#~ msgid "Master Swordsman"
+#~ msgstr "Опытный Мечник"
+
+#~ msgid "Master Swordsmen"
+#~ msgstr "Опытные Мечники"
+
+#, fuzzy
+#~ msgid "Cavalry"
+#~ msgstr "Всадник"
+
+#~ msgid "Cavalries"
+#~ msgstr "Всадников"
+
+#, fuzzy
+#~ msgid "Champion"
+#~ msgstr "Опытный Всадник"
+
+#~ msgid "Champions"
+#~ msgstr "Чемпионов"
+
+#, fuzzy
+#~ msgid "Paladin"
+#~ msgstr "Рыцарь"
+
+#~ msgid "Paladins"
+#~ msgstr "Паладинов"
+
+#, fuzzy
+#~ msgid "Crusader"
+#~ msgstr "Крестоносец"
+
+#~ msgid "Crusaders"
+#~ msgstr "Крестоносцев"
+
+#, fuzzy
+#~ msgid "Goblin"
+#~ msgstr "Гоблин"
+
+#~ msgid "Goblins"
+#~ msgstr "Гоблиннов"
+
+#, fuzzy
+#~ msgid "Orc"
+#~ msgstr "Орк"
+
+#~ msgid "Orcs"
+#~ msgstr "Орков"
+
+#, fuzzy
+#~ msgid "Orc Chief"
+#~ msgstr "Вождь Орков"
+
+#~ msgid "Orc Chiefs"
+#~ msgstr "Вождей орков"
+
+#, fuzzy
+#~ msgid "Wolf"
+#~ msgstr "Волк"
+
+#~ msgid "Wolves"
+#~ msgstr "Волков"
+
+#, fuzzy
+#~ msgid "Ogre"
+#~ msgstr "Людоед"
+
+#~ msgid "Ogres"
+#~ msgstr "Огров"
+
+#, fuzzy
+#~ msgid "Ogre Lord"
+#~ msgstr "Великан Людоед"
+
+#~ msgid "Ogre Lords"
+#~ msgstr "Лордов огров"
+
+#, fuzzy
+#~ msgid "Troll"
+#~ msgstr "Тролль"
+
+#~ msgid "Trolls"
+#~ msgstr "Троллей"
+
+#, fuzzy
+#~ msgid "War Troll"
+#~ msgstr "Боевой Тролль"
+
+#~ msgid "War Trolls"
+#~ msgstr "Боевых троллей"
+
+#, fuzzy
+#~ msgid "Cyclops"
+#~ msgstr "Циклоп"
+
+#~ msgid "Cyclopes"
+#~ msgstr "Циклопов"
+
+#, fuzzy
+#~ msgid "Sprite"
+#~ msgstr "Фея"
+
+#~ msgid "Sprites"
+#~ msgstr "Фей"
+
+#, fuzzy
+#~ msgid "Dwarf"
+#~ msgstr "Гном"
+
+#~ msgid "Dwarves"
+#~ msgstr "Гномов"
+
+#~ msgid "Battle Dwarves"
+#~ msgstr "Боевых гномов"
+
+#, fuzzy
+#~ msgid "Elf"
+#~ msgstr "Эльф"
+
+#~ msgid "Elves"
+#~ msgstr "Эльфов"
+
+#, fuzzy
+#~ msgid "Grand Elf"
+#~ msgstr "Эльф Охотник"
+
+#~ msgid "Grand Elves"
+#~ msgstr "Высоких эльфов"
+
+#, fuzzy
+#~ msgid "Druid"
+#~ msgstr "Друид"
+
+#~ msgid "Druids"
+#~ msgstr "Друидов"
+
+#, fuzzy
+#~ msgid "Greater Druid"
+#~ msgstr "Старший Друид"
+
+#~ msgid "Greater Druids"
+#~ msgstr "Старших друидов"
+
+#, fuzzy
+#~ msgid "Unicorn"
+#~ msgstr "Единорог"
+
+#~ msgid "Unicorns"
+#~ msgstr "Единогогов"
+
+#, fuzzy
+#~ msgid "Phoenix"
+#~ msgstr "Феникс"
+
+#, fuzzy
+#~ msgid "Phoenixes"
+#~ msgstr "Феникс"
+
+#, fuzzy
+#~ msgid "Centaur"
+#~ msgstr "Кентавр"
+
+#~ msgid "Centaurs"
+#~ msgstr "Кентавров"
+
+#, fuzzy
+#~ msgid "Gargoyle"
+#~ msgstr "Гаргулья"
+
+#~ msgid "Gargoyles"
+#~ msgstr "Гаргулий"
+
+#, fuzzy
+#~ msgid "Griffin"
+#~ msgstr "Грифон"
+
+#~ msgid "Griffins"
+#~ msgstr "Грифонов"
+
+#, fuzzy
+#~ msgid "Minotaur"
+#~ msgstr "Минотавр"
+
+#~ msgid "Minotaurs"
+#~ msgstr "Минотавров"
+
+#, fuzzy
+#~ msgid "Minotaur King"
+#~ msgstr "Царь Минотавр"
+
+#~ msgid "Minotaur Kings"
+#~ msgstr "Царей минотавров"
+
+#, fuzzy
+#~ msgid "Hydra"
+#~ msgstr "Гидра"
+
+#~ msgid "Hydras"
+#~ msgstr "Гидр"
+
+#, fuzzy
+#~ msgid "Green Dragon"
+#~ msgstr "Зеленый Дракон"
+
+#~ msgid "Green Dragons"
+#~ msgstr "Зеленых драконов"
+
+#, fuzzy
+#~ msgid "Red Dragon"
+#~ msgstr "Красный Дракон"
+
+#~ msgid "Red Dragons"
+#~ msgstr "Красных драконов"
+
+#, fuzzy
+#~ msgid "Black Dragon"
+#~ msgstr "Черный Дракон"
+
+#~ msgid "Black Dragons"
+#~ msgstr "Черных драконов"
+
+#, fuzzy
+#~ msgid "Halfling"
+#~ msgstr "Хоббит"
+
+#~ msgid "Halflings"
+#~ msgstr "Хоббитов"
+
+#, fuzzy
+#~ msgid "Boar"
+#~ msgstr "Боров"
+
+#~ msgid "Boars"
+#~ msgstr "Боровов"
+
+#, fuzzy
+#~ msgid "Iron Golem"
+#~ msgstr "Железный Голем"
+
+#~ msgid "Iron Golems"
+#~ msgstr "Железных големов"
+
+#, fuzzy
+#~ msgid "Steel Golem"
+#~ msgstr "Стальной Голем"
+
+#~ msgid "Steel Golems"
+#~ msgstr "Стальных големов"
+
+#, fuzzy
+#~ msgid "Roc"
+#~ msgstr "Рух"
+
+#~ msgid "Rocs"
+#~ msgstr "Рух"
+
+#, fuzzy
+#~ msgid "Mage"
+#~ msgstr "Маг"
+
+#~ msgid "Magi"
+#~ msgstr "Маг"
+
+#, fuzzy
+#~ msgid "Archmage"
+#~ msgstr "Архимаг"
+
+#~ msgid "Archmagi"
+#~ msgstr "Архимаг"
+
+#, fuzzy
+#~ msgid "Giant"
+#~ msgstr "Гигант"
+
+#~ msgid "Giants"
+#~ msgstr "Гигантов"
+
+#, fuzzy
+#~ msgid "Titan"
+#~ msgstr "Титан"
+
+#~ msgid "Titans"
+#~ msgstr "Титанов"
+
+#~ msgid "Skeletons"
+#~ msgstr "Скелетов"
+
+#, fuzzy
+#~ msgid "Zombie"
+#~ msgstr "Зомби"
+
+#~ msgid "Zombies"
+#~ msgstr "Зомби"
+
+#, fuzzy
+#~ msgid "Mutant Zombie"
+#~ msgstr "Зомби Мутант"
+
+#~ msgid "Mutant Zombies"
+#~ msgstr "Зомби мутантов"
+
+#, fuzzy
+#~ msgid "Mummy"
+#~ msgstr "Мумия"
+
+#~ msgid "Mummies"
+#~ msgstr "Мумий"
+
+#, fuzzy
+#~ msgid "Royal Mummy"
+#~ msgstr "Королевская Мумия"
+
+#~ msgid "Royal Mummies"
+#~ msgstr "Королевских мумий"
+
+#, fuzzy
+#~ msgid "Vampire"
+#~ msgstr "Вампир"
+
+#~ msgid "Vampires"
+#~ msgstr "Вампиров"
+
+#, fuzzy
+#~ msgid "Vampire Lord"
+#~ msgstr "Лорд Вампир"
+
+#~ msgid "Vampire Lords"
+#~ msgstr "Лордов вампиров"
+
+#, fuzzy
+#~ msgid "Lich"
+#~ msgstr "Лич"
+
+#~ msgid "Liches"
+#~ msgstr "Личей"
+
+#, fuzzy
+#~ msgid "Power Lich"
+#~ msgstr "Могучий Лич"
+
+#~ msgid "Power Liches"
+#~ msgstr "Могучих личей"
+
+#, fuzzy
+#~ msgid "Bone Dragon"
+#~ msgstr "Костяной Дракон"
+
+#~ msgid "Bone Dragons"
+#~ msgstr "Костяных драконов"
+
+#, fuzzy
+#~ msgid "Rogue"
+#~ msgstr "Разбойник"
+
+#~ msgid "Rogues"
+#~ msgstr "Разбойников"
+
+#, fuzzy
+#~ msgid "Nomad"
+#~ msgstr "Кочевник"
+
+#~ msgid "Nomads"
+#~ msgstr "Кочевников"
+
+#, fuzzy
+#~ msgid "Ghost"
+#~ msgstr "Призрак"
+
+#~ msgid "Ghosts"
+#~ msgstr "Призраков"
+
+#, fuzzy
+#~ msgid "Genie"
+#~ msgstr "Джин"
+
+#~ msgid "Genies"
+#~ msgstr "Джинов"
+
+#, fuzzy
+#~ msgid "Medusa"
+#~ msgstr "Медуза"
+
+#~ msgid "Medusas"
+#~ msgstr "Медуз"
+
+#, fuzzy
+#~ msgid "Earth Elemental"
+#~ msgstr "Земной Элементал"
+
+#~ msgid "Earth Elementals"
+#~ msgstr "Земных элементалов"
+
+#, fuzzy
+#~ msgid "Air Elemental"
+#~ msgstr "Воздушный Элементал"
+
+#~ msgid "Air Elementals"
+#~ msgstr "Воздушных элементалов"
+
+#, fuzzy
+#~ msgid "Fire Elemental"
+#~ msgstr "Огненный Элементал"
+
+#~ msgid "Fire Elementals"
+#~ msgstr "Огненных элементалов"
+
+#, fuzzy
+#~ msgid "Water Elemental"
+#~ msgstr "Водяной Элементал"
+
+#~ msgid "Water Elementals"
+#~ msgstr "Водяных элементалов"
+
+#~ msgid "buy"
+#~ msgstr "купить"
+
+#~ msgid "Error"
+#~ msgstr "Ошибка"
+
+#~ msgid "This release is compiled without network support."
+#~ msgstr "Эта версия игры не поддерживает игру по сети."
+
+#~ msgid ""
+#~ "425 bottles of beer on the wall, 425 bottles of beer! If one of those "
+#~ "bottles should happen to fall, there'll be..."
+#~ msgstr ""
+#~ "425 бутылок пива, 425 бутылок пива! Если одна из этих бутылок упадет, там "
+#~ "что то будет ..."
+
+#~ msgid "A balanced scenario with lots of resources and land to explore."
+#~ msgstr "Сбалансированный сценарий с множеством ресурсов для развития."
+
+#~ msgid ""
+#~ "A bandit army of gorgons jump you without warning.  they stone your "
+#~ "entire army demand 500 gold before they will release your comrads.  "
+#~ "Realizing that it is much cheeper to pay then rebuild your army you part "
+#~ "with the gold."
+#~ msgstr ""
+#~ "Бандитская армия горгон набрасыввается на Вас без предупреждения, они "
+#~ "превращают в камень всю вашу армию  и требуют 500 золотых взамен на "
+#~ "освобождение ваших товарищей. Осознавая, что заплатить будет намного "
+#~ "выгоднее, чем перестраивать всю армию, вы делитесь золотом."
+
+#~ msgid "Abandon All Hope!"
+#~ msgstr "Безнадёга!!"
+
+#~ msgid "Abandon All Hope Ye That Enter Here"
+#~ msgstr "Оставь всякую надежду, сюда входящий!"
+
+#~ msgid "A bit of crystal!"
+#~ msgstr "Немного кристаллов!"
+
+#~ msgid "A bit of mercury!"
+#~ msgstr "Немного ртути!"
+
+#~ msgid "A bit of sulfur!"
+#~ msgstr "Немного серы!"
+
+#~ msgid ""
+#~ "Above you looms the ancient Ice Palace.  Dimly remembered myth speaks of "
+#~ "a Prince who rejected the advances of the Winter Goddess, and thus he and "
+#~ "his domain were cursed to remain shrouded in ice, hidden in a forgotten "
+#~ "corner of the world.  It is said that he can only be rescued by a hero "
+#~ "who is both clever and bold.  Are you that one?  Do you dare enter this "
+#~ "frozen domain?"
+#~ msgstr ""
+#~ "Перед Вами - древний Ледяной Дворец. Частично сохранившийся миф "
+#~ "повествует о Принце, который не признал достижений Зимней Богини и  был "
+#~ "проклят и обречен со своими владениями на вечное заточение во льду, "
+#~ "затерянный в забытом уголке мира. Говорится, что только герои, равно "
+#~ "обладающий умом и храбростью может освободить его. Может быть это Вы? Вы "
+#~ "отважитесь войти в Ледяные владения?"
+
+#~ msgid "A cache of crystal!"
+#~ msgstr "Кошелек с кристаллами!"
+
+#~ msgid "A cache of gems!"
+#~ msgstr "Кошелек с алмазами!"
+
+#~ msgid "A cache of gold!"
+#~ msgstr "Кошелек с золотом!"
+
+#~ msgid "A cache of mercury!"
+#~ msgstr "Банка с ртутью!"
+
+#~ msgid "A cache of sulfur!"
+#~ msgstr "Мешок с серой!"
+
+#~ msgid ""
+#~ "A chance to end a bitter war has finally arrived as a new resource-laden "
+#~ "land has been discovered."
+#~ msgstr ""
+#~ "Обнаружена Новая Земля. И наконец, появился шанс положить конец "
+#~ "ожесточенной войне за ресурсы."
+
+#~ msgid "A chunk of gold!"
+#~ msgstr "Немного золота!"
+
+#~ msgid "A chunk of ore!"
+#~ msgstr "Немного камня!"
+
+#~ msgid "A couple of gems!"
+#~ msgstr "Немного драгоценных камней!"
+
+#~ msgid "\"Act of Desperation\""
+#~ msgstr "\"Акт Отчаянья\""
+
+#~ msgid ""
+#~ "A desert isle rich in resources rewards the quick.  Just be sure to watch "
+#~ "your back!"
+#~ msgstr ""
+#~ "Пустынные острова богаты ресурсами. Только убедись, что почаще смотришь "
+#~ "назад!"
+
+#~ msgid "A dolphin playfully jumps into the air."
+#~ msgstr "Дельфин игриво прыгает в воздух."
+
+#~ msgid ""
+#~ "A Dragon, A Cyclops, or an Undead. King of the Centaurs, His name is ....?"
+#~ msgstr "Дракон, Циклоп, или Мертвец. Король Кентавров - Как Его Зовут....?"
+
+#~ msgid "A flight of dragons circles overhead."
+#~ msgstr "Пара драконов наворачивает кругами над вами."
+
+#~ msgid "A flock of seagulls circle overhead."
+#~ msgstr "Стая чаек кружится над головой."
+
+#~ msgid "A friendly dolphin splashes alongside the ship."
+#~ msgstr "Друзья дельфины плывут рядом с кораблем."
+
+#~ msgid ""
+#~ "After a long search of the island, I have discovered that there is no way "
+#~ "for me to escape without help.  I can not steal a ship from one of the "
+#~ "coastal castles, and I dare not venture into the desert unless I wish to "
+#~ "become Dragon food.  Should anyone find this, I beg of you, please send a "
+#~ "ship and get me off this cursed island!  -Sir Christian"
+#~ msgstr ""
+#~ "Я обшарил весь остров и понял, у меня нет способа отсюда выбраться без "
+#~ "посторонней помощи. Я не могу украсть лодку с одного из прибрежных "
+#~ "замков, и я не смею идти через пустыню где я стану пищей драконов. Если "
+#~ "кто нашел это, я прошу вас, пожалуйста, отправьте лодку и заберите меня с "
+#~ "этого проклятого острова! Сэр Христиан."
+
+#~ msgid ""
+#~ "After centuries of friendship, the Wizards have suddenly decided to stop "
+#~ "sharing their Library with the rest of the world.  This can't be good!"
+#~ msgstr ""
+#~ "После столетий мира и дружбы, Волшебники внезапно запретили, для "
+#~ "остального мира, доступ к их Библиотеке. Это плохой знак!"
+
+#~ msgid ""
+#~ "After many years of peace, you discover that your sworn enemy from across "
+#~ "the sea has chosen to invade your homeland by raising up the ocean floor "
+#~ "to bridge the distance! You must not let them gain a foothold on this "
+#~ "continent, in fact, your King has ordered you to establish a foothold on "
+#~ "theirs!  To make matters worse, two of your OWN towns have thrown in "
+#~ "their lots with the enemy..."
+#~ msgstr ""
+#~ "После многих лет мира, вы обнаружили, что враги решили вторгнуться из за "
+#~ "моря! Вы должны помешать их планам! Плохая новость, два ваших города уже "
+#~ "бросили жребий с врагом..."
+
+#~ msgid ""
+#~ "After you return from a scouting trip, your Seneschal hurries to greet "
+#~ "you.  \"My Lord, in your absence I signed an agreement in your name with "
+#~ "a Master Merchant.  If we supply him with the resources he needs, through "
+#~ "trading, he can return the resources to us in a week or so, plus some "
+#~ "additional ones.\"  The Seneschal eyes you anxiously.  You hesitate, then "
+#~ "nod slowly, \"Good, we can use more resources>\""
+#~ msgstr ""
+#~ "Вы вернулись с дальней разведки, и вас спешит поприветствовать советник: "
+#~ "\"Мой Лорд, во время Вашего отсутствия, я подписал соглашение, на Ваше "
+#~ "имя, с Боссом Торговцев. Если мы предоставим ему ресурсы, он обещает "
+#~ "вернуть все через неделю плюс некоторые проценты....\".\n"
+#~ "Советник посмотрел на Вас с тревогой в глазах... Вы медленно кивнули: "
+#~ "\"Хорошо, мы сможем использовать больше ресурсов\""
+
+#~ msgid "A ghostly pirate ship appears and sails on by."
+#~ msgstr "Вдруг появляется пиратский корабль призрак, и проплавает мимо."
+
+#~ msgid ""
+#~ "A Gift from your King, and a note that reads \"Use these resources "
+#~ "wisely, It's all we have left\"."
+#~ msgstr ""
+#~ "Вы получили Подарок от Короля, и записку, в которой написано: \"Используй "
+#~ "это разумно!\"."
+
+#~ msgid ""
+#~ "A gift of gold, m'lord, from the people of Enroth, to the people of "
+#~ "Enroth.  Good luck, and may God save true King Roland!"
+#~ msgstr ""
+#~ "Золото в подарок, мой Лорд, от народа Enroth, народу Enroth. Желаю удачи, "
+#~ "и пусть Бог сохранит истинного Короля  Роланда!"
+
+#~ msgid "A glint by a tree catches your eye..."
+#~ msgstr "Блеск по дереву бросается в глаза..."
+
+#~ msgid "A gold cache!"
+#~ msgstr "Кошелек золота!"
+
+#~ msgid "A gold chunk!"
+#~ msgstr "Немного золота!"
+
+#~ msgid "A gold nugget!"
+#~ msgstr "Самородок золота!"
+
+#~ msgid ""
+#~ "A great Black dragon stands before you. It speaks in a suprisingly soft "
+#~ "voice, saying, \"The elves believe they have sent another hero to reclaim "
+#~ "their prize. I believe they have sent me another meal.\""
+#~ msgstr ""
+#~ "Перед вами стоит Большой Черный Дракон. На удивление вам, он произносит "
+#~ "мягким тихим голосом: \"Эльфы думают, что направили еще одного героя "
+#~ "востребовать свой приз, Но Я Считаю, что они прислали мне еще один ужин!\""
+
+#~ msgid ""
+#~ "A group of peasant farmers approaches you, \"We are in dire need of your "
+#~ "assistance.  Our castle to the north has been overrun and our Lord "
+#~ "killed.  Please help us regain our homes!  There are still women and "
+#~ "children there!  Take what we have to help!\""
+#~ msgstr ""
+#~ "Группа крестьян обратилась к тебе: \"Мы нуждаемся в Вашей помощи. Наш "
+#~ "замок, на востоке, был разграблен и Лорда нашего убили. Пожалуйста, "
+#~ "помогите нам вернуть наши дома! Там остались наши женщины и дети, "
+#~ "помогите!\""
+
+#~ msgid ""
+#~ "A group of peasant farmers approach you, \"We are in dire need of your "
+#~ "assistance.  Our castle to the east has been overrun and our Lord "
+#~ "killed.  Please help us regain our homes!  There are still women and "
+#~ "children there!  Take what we have to help!\""
+#~ msgstr ""
+#~ "Группа крестьян обратилась к тебе: \"Мы нуждаемся в Вашей помощи. Наш "
+#~ "замок, на востоке, был разграблен и Лорда нашего убили. Пожалуйста, "
+#~ "помогите нам вернуть наши дома! Там остались наши женщины и дети, "
+#~ "помогите!\""
+
+#~ msgid ""
+#~ "A group of peasant farmers approach you, \"We are in dire need of your "
+#~ "assistance. Our castle to the east has been overrun and our Lord killed. "
+#~ "Please help us regain our homes! There are still women and children "
+#~ "there! Take what we have to help!\""
+#~ msgstr ""
+#~ "К Вам подошла группа крестьян, \"Мы нуждается в Вашей помощи. Наш замок, "
+#~ "на востоке, был разграблен, и Хозяина нашего убили. Пожалуйста, помогите "
+#~ "нам! Там осталось много женщин и детей! Мы готовы помоч!\""
+
+#~ msgid ""
+#~ "A group of peasant farmers approach you, We are in dire need of your "
+#~ "assistance.  Our castle to the northeast has been overrun and our Lord "
+#~ "killed.  Please help us regain our homes!  There are still women and "
+#~ "children there!  Take what we have to help!\""
+#~ msgstr ""
+#~ "К Вам подошла группа крестьян, \"Мы нуждается в Вашей помощи. Наш замок, "
+#~ "на северо востоке, был разграблен, и Хозяина нашего убили. Пожалуйста, "
+#~ "помогите нам! Там осталось много женщин и детей! Мы готовы помоч!\""
+
+#~ msgid "A handful of gems!"
+#~ msgstr "Горсть алмазов!"
+
+#~ msgid ""
+#~ "Ah, you stumble across something buried in the sand.  As you dig it up "
+#~ "you discover a small pile of gems and crystal."
+#~ msgstr ""
+#~ "Вау, Вы случайно нашли что-то в песке. Вы начали копать и обнаружили "
+#~ "небольшую груду драгоценных камней и кристаллов."
+
+#~ msgid ""
+#~ "A Knight and Necromancer team up against the Barbarian and Sorceress. "
+#~ "(Blue and Green vs Red and Yellow)"
+#~ msgstr ""
+#~ "Рыцарь и Некромант в команде против Варвара и Волшебницы. (Синий и "
+#~ "Зеленый vs Красный, Желтый)"
+
+#~ msgid ""
+#~ "A large contingent of the king's guard approaches you.  \"Ahh, we have "
+#~ "finally caught up to you.  The king requires tribute from all of his "
+#~ "vassals and you have been negligent far too long.\""
+#~ msgstr ""
+#~ "К Вам подошла большая толпа царской охраны. \"Ага подлец, наконец, мы "
+#~ "тебя поймали. Все вассалы должны платить дань, а Вы что то давно забили "
+#~ "на это...\""
+
+#~ msgid ""
+#~ "A large map with lots of resources and treasure. Exploration and victory "
+#~ "will require many heroes."
+#~ msgstr ""
+#~ "Большая карта где много ресурсов и сокровищ. Для разведки и победы "
+#~ "потребуется много Героев."
+
+#~ msgid "A legion of peasants stands between you and this unclaimed island."
+#~ msgstr "Легион крестьян стоит между вами и островом."
+
+#~ msgid "Algary"
+#~ msgstr "Алгари"
+
+#~ msgid "A little bit closer..."
+#~ msgstr "Немного ближе..."
+
+#~ msgid "All mines are grouped by type. Trade is your only hope."
+#~ msgstr ""
+#~ "Все шахты сгруппированы по типу. Торговля это Ваша единственная надежда."
+
+#~ msgid "A lump of crystal!"
+#~ msgstr "Куча кристаллов!"
+
+#~ msgid "A lump of gold!"
+#~ msgstr "Куча золота!"
+
+#~ msgid "A lump of mercury!"
+#~ msgstr "Куча ртути!"
+
+#~ msgid ""
+#~ "A man appears from behind the sand dune. \"At last,\" he says, \"Someone "
+#~ "has come to rescue me! I am forever grateful. Alas all I have to offer "
+#~ "you in return are these souvenirs from my wrecked ship.\""
+#~ msgstr ""
+#~ "Из-за песчаных дюн появился оборванец. \"О! Наконец то\" - говорит он, "
+#~ "\"Кто-то пришел, чтобы спасти меня! Мои благодарности! Увы... все что я "
+#~ "могу предложить Вам .. так это сувениры с моего погибшего корабля...\""
+
+#~ msgid ""
+#~ "A man is laying on the ground, near death. He looks to you and speaks, "
+#~ "\"Please help my companions! Please... they can't...cough...get away "
+#~ "from...cough...the drag...\" With that, he dies."
+#~ msgstr ""
+#~ "На земле лежит умирающий человек. Он видит Вас и произносит, "
+#~ "\"Пожалуйста, помоги моим товарищам! Пожалуйста... они не могут... "
+#~ "кхе...  кхе.. кхе... ужасный кашель... сопротивление...\", и после этих "
+#~ "слов он умерирает."
+
+#~ msgid ""
+#~ "A merchant caravan arrives, bringing gold and supplies, however, no one "
+#~ "can seem to remember where they came from.  You silently praise this "
+#~ "anonymous benefactor and continue your duties."
+#~ msgstr ""
+#~ "Прибыл караван купцов, никто не знает откуда они, но их золото и товары "
+#~ "пригодятся."
+
+#~ msgid "a mirror"
+#~ msgstr "зеркало"
+
+#~ msgid "An albatross flies ahead of the ship for a while"
+#~ msgstr "Альбатрос летит некоторое время перед судном"
+
+#~ msgid "Anduran"
+#~ msgstr "Андуран"
+
+#~ msgid ""
+#~ "An enemy from across the sea has seized half your towns.  Can you put "
+#~ "aside your own feud with your brother to fight this common enemy?"
+#~ msgstr ""
+#~ "Враг из за моря захватил половину страны. Вы сможете отложить вражду, с "
+#~ "собственным братом, для борьбы с этим общим врагом?"
+
+#~ msgid ""
+#~ "An old elf is sitting on a rock in a glen, pounding on the shackles on "
+#~ "his feet with a stone. You help him remove them and ask him his tale. "
+#~ "\"I'm a deserter from Drakonia's army. She has enslaved all the elves to "
+#~ "support her madness. She must be stopped.\" Then he slips into the woods "
+#~ "without a sound, leaving behind just his cloak."
+#~ msgstr ""
+#~ "На скале сидит старый эльф, стуча кандалами по камню. Вы помогаете ему "
+#~ "удалить кандалы, и он рассказал Вам: \"Я дезертир из армии Драконии. Она "
+#~ "безумна, и поработила всех эльфов. Ее нужно остановить\". Он оставил Вам "
+#~ "свой плащ, и скрытно уходит в лес."
+
+#~ msgid "Antioch"
+#~ msgstr "Антиош"
+
+#~ msgid "A piece of crystal!"
+#~ msgstr "Кусочек кристалла!"
+
+#~ msgid "A pile of crystal!"
+#~ msgstr "Куча кристаллов!"
+
+#~ msgid "A pile of gems!"
+#~ msgstr "Куча драгоценных камней!"
+
+#~ msgid "A pile of gold!"
+#~ msgstr "Куча золота!"
+
+#~ msgid ""
+#~ "A plague of undead is upon us. Who will unite the living against the dead?"
+#~ msgstr "Тьма нежити идет на нас. Кто объединит Живых против Мертвых?"
+
+#~ msgid "A quantity of crystal!"
+#~ msgstr "Много кристаллов!"
+
+#~ msgid "A quantity of mercury!"
+#~ msgstr "Много ртути!"
+
+#~ msgid "A quantity of sulfur!"
+#~ msgstr "Много серы!"
+
+#~ msgid ""
+#~ "Archibald has also sent an army to find the Crown, you must find it first "
+#~ "or all is lost."
+#~ msgstr ""
+#~ "Арчибальд направил свою армию на поиски Короны. Вы должны найти этот "
+#~ "артефакт первым."
+
+#~ msgid "Archibald is hiding at the end of the river."
+#~ msgstr "Арчибальд скрывается в конце реки."
+
+#~ msgid ""
+#~ "A resource rich valley keeps the Wizard and the Necromancer apart. Your "
+#~ "opponent's army will arrive in 3 months so hurry."
+#~ msgstr ""
+#~ "Богатая ресурсами долина разделяет Волшебника и Некроманта друг от друга. "
+#~ "У Вас есть 3 месяца."
+
+#~ msgid "Arm of the Crusader"
+#~ msgstr "Рука Рыцаря"
+
+#~ msgid "Arm of the Cyclops"
+#~ msgstr "Рука Циклопа"
+
+#~ msgid "Arm of the Dragon"
+#~ msgstr "Крыло Дракона"
+
+#~ msgid "Arm of the Phoenix"
+#~ msgstr "Крыло Феникса"
+
+#~ msgid "Arm of the Titan"
+#~ msgstr "Рука Титана"
+
+#~ msgid "Arr' Here be pirates gold buried."
+#~ msgstr "Арр.. Здесь спрятяно золото пиратов!"
+
+#~ msgid "A shipment of wood has arrived from your kingdom!"
+#~ msgstr "Древесина прибыла от Вашего Королевства!"
+
+#~ msgid ""
+#~ "A splash in the seaweed alerts you to a mermaid waving in a friendly "
+#~ "manner. \"Oh, I thought you were Ahab.\" She is surprised, but quickly "
+#~ "composes herself. \"Well, if you meet him, give him these treasures I "
+#~ "have collected.\""
+#~ msgstr ""
+#~ "Плеск в морских водорослях, предупреждает Вас о русалке. \"О, я думала, "
+#~ "что ты Ахаб\". Она удивилась, но быстро сочиняет сама. \"Хорошо, если ты "
+#~ "ним встретишься, передай эти сокровища...\""
+
+#~ msgid "Assassins tried to kill our ally."
+#~ msgstr "Убийцы пытались убить нашего союзника."
+
+#~ msgid "Astircaer"
+#~ msgstr "Астиркаер"
+
+#~ msgid ""
+#~ "A stranded Wizard with only a small force must conquer an entire "
+#~ "continent of hostile forces."
+#~ msgstr ""
+#~ "Нищий Волшебник с небольшой армией должен покорить весь континент "
+#~ "враждебных сил."
+
+#~ msgid ""
+#~ "A supply ship has arrived from the homeland!  You send word home that all "
+#~ "is well."
+#~ msgstr ""
+#~ "Прибыл корабль с грузом! Вы отправляете с ним послание, что все хорошо."
+
+#~ msgid ""
+#~ "As you approach the barrier, you see the old elf you helped free. This "
+#~ "time, however, you see that he is wearing a cape of fine weave, and a "
+#~ "wooden crown is on his head. He sees your forces, and says \"Take this "
+#~ "sword, and with it, strike down Drakonia and help free my people.\" The "
+#~ "old elf then strides regally into the woods."
+#~ msgstr ""
+#~ "Вы видите старого эльфа, в в плаще из тонкой ткани, и с деревянной "
+#~ "короной на голове. Он говорит: \"Возьми этот меч, а вместе с ним победу "
+#~ "над Драконией! Помоги освободить мой Народ\". После этого, он царственно "
+#~ "ушел в лес."
+
+#~ msgid ""
+#~ "As you approach the gates of the Ice Palace, one of your troops points in "
+#~ "terror.  You watch in awe as great slabs of ice separate from the castle "
+#~ "walls with loud cracking reports and crash to the ground.  Soon the ice "
+#~ "is gone and the sun begins to peak through the gloom.  The deathly "
+#~ "silence that must have ruled these lands for centuries ends as birds "
+#~ "begin to sing.  From inside you hear the sounds of life."
+#~ msgstr ""
+#~ "Вы приближаетесь к воротам Ледового Дворца. Ваши воины застыли в ужасе и "
+#~ "Вы смотрите в страхе, как большие ледовые плиты, отделяются от Дворца и с "
+#~ "громким грохотом и падают на землю. Вскоре весь лед ушел, и солнце "
+#~ "начинает светить во мраке. Гробовое молчание, которое на протяжении веков "
+#~ "присутствовало здесь, прерывается пением неизвестных птиц. Жизнь "
+#~ "возвращается..."
+
+#~ msgid ""
+#~ "As you approach the tent, the leader of the nomads comes out to greet "
+#~ "you. He says, \"It was prophecied many years ago that a great hero would "
+#~ "come to greet us in our sacred valley, and we would prosper afterwords. "
+#~ "Now it has come to pass, and we offer you these gifts as tokens of our "
+#~ "thanks.\""
+#~ msgstr ""
+#~ "Вы приближаетесь к палатке кочевников, из нее выходит Вождь. Он "
+#~ "произносит: \"Много лет назад было пророчество, к нам придет Великий "
+#~ "Герой, и мы будем процветать.. Теперь это свершилось, и мы предлагаем вам "
+#~ "эти подарки в знак благодарности.\""
+
+#~ msgid ""
+#~ "As you approach,  you hear whispered mentions of \"the wild barbarian who "
+#~ "passed this way months before\". One of the villagers approaches you and "
+#~ "hands you an object, saying \"The wild one dropped this. You must be his "
+#~ "kin. Therefore I give it to you. But beware! Many in the village will not "
+#~ "be as friendly as I.\""
+#~ msgstr ""
+#~ "Приближаясь, Вы слышите таинственные упоминания о \"диком варваре, чей "
+#~ "путь проходил здесь много месяцев назад\". Один из поселенцев "
+#~ "приближается к Вам и вручает предмет со словами - \"Дикарь обронил его. "
+#~ "Вы должно быть его родственник. Поэтому я отдаю его Вам. Но "
+#~ "остерегайтесь! Немногие из деревни будут дружелюбны к Вам так , как Я"
+
+#~ msgid ""
+#~ "As you break your fast your sage rushes in, \"Good news, my lord!  I have "
+#~ "translated the message.  Two great heroes were imprisoned many years "
+#~ "ago.  They lie sleeping - still guarded by magic barriers and monsters.  "
+#~ "My lord, they lie nearby- in between our ally and us.  If we could free "
+#~ "them, they would surely aid us against our enemies!  The password to the "
+#~ "first magic barrier can be learned at the Aqua Traveller's Tent.\""
+#~ msgstr ""
+#~ "Как только вы входите, к Вам подбегает слуга, \"Хорошие вести, Господин! "
+#~ "Я преревел послание. Двое великих героев были заточены много лет назад. "
+#~ "Они спят, по прежнему охраняемые магическими барьерами и чудовищами. "
+#~ "Господин, они лежат неподалеку, между союзниками и нами. Если бы Мы могли "
+#~ "свободить их, они наверняка поддержали бы нас против наших врагов! Пароль "
+#~ "к первому магическому барьеру можно узнать В Палатке Подводного Странника."
+
+#~ msgid ""
+#~ "As you enter the small clearing, you see a familiar figure talking to a "
+#~ "group of halflings and soldiers. You stay awhile and listen to his "
+#~ "speech. \"The time to throw off these chains of tyranny is now! We must "
+#~ "strike at the heart of her empire, and destroy the evil that she has "
+#~ "brought to our land.\" As the old elf finishes speaking, he gets up from "
+#~ "his mossy seat and once again, blends into the woods with incredible "
+#~ "grace."
+#~ msgstr ""
+#~ "Выходя к пашне, Вы видите знакомую фигуру, разговаривающую с группой "
+#~ "полуросликов и солдат. Вы останавливаетесь и подслушиваете разговор. "
+#~ "\"Настало время сбросить оковы Тирании! Мы должны нанести удар в сердце "
+#~ "ее империи и разгромить зло, которое она принесла в наши земли.\" "
+#~ "Заканчивая речь, старый эльф встает с мшистого пня и скрывается в лесу с "
+#~ "невероятной ловкостью."
+
+#~ msgid ""
+#~ "As you lay down to nap after a long battle, you notice a lucky four-leaf "
+#~ "clover."
+#~ msgstr ""
+#~ "Вы ложитесь подремать после длинного сражения, и замечаете четырехлистный "
+#~ "клевер, который приносит Удачу."
+
+#~ msgid ""
+#~ "As you make  your way through the last of the golemn debris, a group of "
+#~ "halflings runs towards you carrying fruit and flowers. \"Thank you so "
+#~ "much!\" Their leader exclaims, \"We've been trapped in here for ever! "
+#~ "Come by our homes, we'll pack up and go with you!\""
+#~ msgstr ""
+#~ "Как только Вы выбираетесь из-под обломков последнего голема, группа "
+#~ "половинчиков бежит к Вам, неся фрукты и цветы. \"Огромное Вам спасибо!\" "
+#~ "восклицает их лидер, \"Мы провели целую вечность в неволе! Заглядывайте в "
+#~ "гости и мы пойдём с Вами!\""
+
+#~ msgid ""
+#~ "As you make your way to the shrine, some very thin and hollow-eyed men "
+#~ "come out of the flower patch and stare at you.  Seeing that you want the "
+#~ "gold, one of them says to you \"Hey, man, if you're, like, so lusty for "
+#~ "earthly wealth, then, like, have this too.\" You graciously take what "
+#~ "they have offered and back out of the clearing."
+#~ msgstr ""
+#~ "По дороге в склеп Вы встречаете несколько очень худых людей с пустыми "
+#~ "глазами, которые вышли из палисадника и теперь пялятся на Вас. Видя, что "
+#~ "Вы хотите золото, один из них говорит Вам \"Эй, брат, если ты, типа, так "
+#~ "желаешь материальных благ, то тогда, типа, возьми ещё и вот это.\" Вы "
+#~ "элегантно принимаете то, что они Вам предлагают и уносите ноги."
+
+#~ msgid ""
+#~ "As you prepare your lands to fight the onslaught from the South, a "
+#~ "curious message appears on your table in the Great Hall of your Castle.  "
+#~ "Written in some ancient language, none but your sage can make any sense "
+#~ "of it.  She promises to have the words deciphered by tomorrow..."
+#~ msgstr ""
+#~ "Во время приготовлений Ваших земель к противостоянию бойне с Юга, "
+#~ "любопытное сообщение появляется на Вашем столе в Большой Зале Вашего "
+#~ "Замка. Оно написано на каком-то древнем языке и никто, кроме Вашего "
+#~ "мудреца не может ничего разобрать. Она обещает, что переведёт загадочные "
+#~ "слова к утру..."
+
+#~ msgid "A three hour tour, a three hour tour..."
+#~ msgstr "Трехчасовой тур, трехчасовой тур..."
+
+#~ msgid ""
+#~ "A tiny gnome points to a chunk of crystal you otherwise would have "
+#~ "overlooked!"
+#~ msgstr ""
+#~ "Маленький гном указывает на кусочек кристалла, который Вы, иначе, "
+#~ "пропустили бы!"
+
+#~ msgid "Atlantium"
+#~ msgstr "Атлантиум"
+
+#~ msgid ""
+#~ "At last, the king is dead.  For years you have planned his demise, but "
+#~ "now it is done, and there is no heir to take his place, though the "
+#~ "Knights to the south believe that they are the rightful successors.  A "
+#~ "wealth in wood (to the south) and ore (in the northern mountains) "
+#~ "provides you with trade goods, and your isolation has allowed you to "
+#~ "prepare your forces of darkness for this day.  Go, now, and fulfill your "
+#~ "destiny!"
+#~ msgstr ""
+#~ "Наконец-то, король пал. Годами Вы планировали его свержение и вот оно "
+#~ "свершилось, но нет преемника, чтобы занять его место, хотя Рыцари с юга и "
+#~ "считают, что они являются законными наследниками. Богатые леса (на юге) и "
+#~ "залежи руды (в северных горах) откроют Вам путь на рыночную арену, а Ваша "
+#~ "изолированность позволит Вам приготовить силы тьмы к этому дню. Идите же "
+#~ "и исполните своё предназначение!"
+
+#~ msgid ""
+#~ "At the base of the mountain you see something that glitters.   You "
+#~ "discover an ancient pile of offerings to the gods."
+#~ msgstr ""
+#~ "В основании горы Вы увидели кое-что блестящее. Там Вы обнаруживаете "
+#~ "древнюю груду, посланную вам богами."
+
+#~ msgid "Avalon"
+#~ msgstr "Авалон"
+
+#~ msgid "Avone"
+#~ msgstr "Авона"
+
+#~ msgid ""
+#~ "A wild magic has allowed a bridge to form between two lands...  Your one "
+#~ "hope is to capture castle \"Black Fang\"."
+#~ msgstr ""
+#~ "Необузданная магия сотворила мост между двумя землями... Ваша "
+#~ "единственная надежда - захватить замок \"Чёрный Клык\"."
+
+#~ msgid "Barbarian's castle lies to the south."
+#~ msgstr "Замок Варваров находится ближе к Югу."
+
+#~ msgid ""
+#~ "Barbarians from the north threaten all civilization. Can you repel the "
+#~ "hordes?"
+#~ msgstr ""
+#~ "Варвары с Севера угрожают всей цивилизации. Вы сможете отразить эти орды?"
+
+#~ msgid "Barrowton"
+#~ msgstr "Барраутаун"
+
+#~ msgid "Basenji"
+#~ msgstr "Басенджи"
+
+#~ msgid "Bayside"
+#~ msgstr "Байсид"
+
+#~ msgid "Baywatch"
+#~ msgstr "Байватч"
+
+#~ msgid ""
+#~ "Because the Darkscale Valley is so barren, the Emperor will be sending "
+#~ "wood to you every week. Use it wisely, for it is all you shall have."
+#~ msgstr ""
+#~ "Из-за того, что Долина Тёмной Чешуи так пустынна, Император будет "
+#~ "высылать Вам древесину каждую неделю. Расходуйте её мудро, кроме неё Вы "
+#~ "ничего не получите."
+
+#~ msgid ""
+#~ "Before questing for the orb of negation, you must first crush the local "
+#~ "opposition. After the Sorceresses are removed from the earth, go east "
+#~ "where legend says the orb lies.  You may expect a convoy of supplies in a "
+#~ "week or so to aid your conquest."
+#~ msgstr ""
+#~ "Перед походом за сферой отрицания, Вам необходимо сокрушить местную "
+#~ "оппозицию. После того, как все Волшебницы будут убиты, отправляйтесь на "
+#~ "восток, где, судя по легенде, находится сфера. Караван ресурсов в помощь "
+#~ "Вашему завоеванию прибудет через неделю или около того."
+
+#~ msgid ""
+#~ "Before you may pass, the spirit guardian of this valley demands tribute."
+#~ msgstr "Дух-страж требует плату за проход."
+
+#~ msgid "Being held...."
+#~ msgstr "Проходит..."
+
+#~ msgid "Beltway"
+#~ msgstr "Кольцевой путь"
+
+#~ msgid "Beware -- Entering Hyrda Country"
+#~ msgstr "Осторожно -- Здесь Страна Гидр"
+
+#~ msgid "Beware for whom the bell trolls."
+#~ msgstr "Осторожно, слышно рычание Троллей."
+
+#~ msgid "Beware of Pirates!"
+#~ msgstr "Остерегайся Пиратов!"
+
+#~ msgid "Beware of thieves!"
+#~ msgstr "Остерегайся Воров!"
+
+#~ msgid "Beware of traps ahead."
+#~ msgstr "Остерегайтесь ловушек"
+
+#~ msgid "Beware of Warlocks"
+#~ msgstr "Остерегайтесь Волшебников."
+
+#~ msgid "Beware the deadly swamps!"
+#~ msgstr "Осторожно, зедсь мертвая пустыня!"
+
+#~ msgid "Beware the Domain of Dragons"
+#~ msgstr "Остерегайтесь Владений Драконов"
+
+#~ msgid "Beware the Dragon Leader"
+#~ msgstr "Остерегайтесь Лидера Драконов"
+
+#~ msgid "Beware the edge of the world!"
+#~ msgstr "Остерегайся, здесь край мира!"
+
+#~ msgid "Beware the moors and stick to the roads."
+#~ msgstr "Остерегайся мавров и дураков на дороге."
+
+#~ msgid "Beware the rocks"
+#~ msgstr "Остерегайтесь рифов"
+
+#~ msgid "Beware the sirens!!!"
+#~ msgstr "Остерегайтесь Сирен!!!"
+
+#~ msgid "Beware the sirens!"
+#~ msgstr "Остерегайтесь Сиррен!!!"
+
+#~ msgid "Beware the whiporwill..."
+#~ msgstr "Остерегайтесь водоворотов..."
+
+#~ msgid "Beware, the whirlpool may not take you into a friendly embrace."
+#~ msgstr "Осторожно, здесь очень коварные водовороты."
+
+#~ msgid "Beyond here be Dragons!"
+#~ msgstr "Здесь обитают Драконы!"
+
+#~ msgid "Beyond the door, there be Dragons. BEWARE!"
+#~ msgstr "За сей дверью обитают Драконы. БЕРЕГИСЬ!"
+
+#~ msgid "Big Oak"
+#~ msgstr "Большой Дуб"
+
+#~ msgid "Blackburn"
+#~ msgstr "Блэкбурн"
+
+#~ msgid "Blackfang"
+#~ msgstr "Черный Клык"
+
+#~ msgid "Black Fang"
+#~ msgstr "Черный Клык"
+
+#~ msgid "Black Oak"
+#~ msgstr "Черный ДУб"
+
+#~ msgid "Blackridge"
+#~ msgstr "Блэкридж"
+
+#~ msgid "Blacksford"
+#~ msgstr "Блэкфорд"
+
+#~ msgid "Black Vein"
+#~ msgstr "Блэквейн"
+
+#~ msgid "Blackwind"
+#~ msgstr "Черный Ветер"
+
+#~ msgid "Bloodreign"
+#~ msgstr "Блудрейн"
+
+#~ msgid "Boats my be needed to access some parts of this peninsula."
+#~ msgstr ""
+#~ "Возможно, потребуется корабль, чтобы достичь некоторых земель этого "
+#~ "полуострова."
+
+#~ msgid "Boats Sold Here            Inquire Within"
+#~ msgstr "Продажа Кораблей Консультация На Месте"
+
+#~ msgid "BoneVille"
+#~ msgstr "КостеГрад"
+
+#~ msgid "Bridge out!"
+#~ msgstr "За Мост!"
+
+#~ msgid "Bridge Out!"
+#~ msgstr "За Мост!"
+
+#~ msgid "Brindamoor"
+#~ msgstr "Бриндамур"
+
+#~ msgid "Brownston"
+#~ msgstr "Браунстон"
+
+#~ msgid "Buried Treasure!"
+#~ msgstr "Клад!"
+
+#~ msgid "Burlock"
+#~ msgstr "Барлок"
+
+#~ msgid "Burton"
+#~ msgstr "Бартон"
+
+#~ msgid ""
+#~ "Capture the necromancer's dreaded castle \"Death Gate\" and free the land "
+#~ "from the undead plague."
+#~ msgstr ""
+#~ "Захватите ужасный замок колдунов \"Мертвые Ворота\" и освободите долину "
+#~ "от мертвой чумы."
+
+#~ msgid "Cathcart"
+#~ msgstr "Кечкарт"
+
+#~ msgid "Chandler"
+#~ msgstr "Чандлер"
+
+#~ msgid "Chilton"
+#~ msgstr "Чилтон"
+
+#~ msgid "Chronos"
+#~ msgstr "Хронос"
+
+#~ msgid "Come and...."
+#~ msgstr "Ну и ..."
+
+#~ msgid ""
+#~ "Compared to the rest of the villages in this land, this village seems "
+#~ "grand, but in any other land it would seem poor. From here you can see "
+#~ "the tall spires of the Warlock's tower of Dragons."
+#~ msgstr ""
+#~ "По сравнению с остальными деревнями, эта кажется богатой, но в любых "
+#~ "других землях она показалась бы нищей. Отсюда можно увидеть стройные "
+#~ "шпили Драконьей башни Чернокнижника."
+
+#~ msgid "Complete"
+#~ msgstr "Выполнено"
+
+#~ msgid "Condemned!"
+#~ msgstr "Осуждены!"
+
+#~ msgid ""
+#~ "Congratulations! After navigating the treacherous coast, you have "
+#~ "established trade between the north and south."
+#~ msgstr ""
+#~ "Поздравляем! После причаливания на коварное побережье, Вы установили "
+#~ "торговлю между Севером и Югом."
+
+#~ msgid "Corackston"
+#~ msgstr "Коракстон"
+
+#~ msgid "Crossroads"
+#~ msgstr "Перекресток"
+
+#~ msgid "Crossroads North"
+#~ msgstr "Северное Шоссе"
+
+#~ msgid "Crossroads South"
+#~ msgstr "Южное Шоссе"
+
+#~ msgid "Danger a whirlpool destroyed my ship."
+#~ msgstr "Опасный водоворот разрушил мой кораболь."
+
+#~ msgid "Danger, Dragons abound!"
+#~ msgstr "Опасность! Драконы вокруг.. ё маё!"
+
+#~ msgid "DANGER!  QUICKSAND!"
+#~ msgstr "Опасность! Зыбучие Пески!"
+
+#~ msgid "Danger! Troll bridge ahead!"
+#~ msgstr "Опасность! Впереди мост с Троллями!"
+
+#~ msgid "Danger - Turn Back Now"
+#~ msgstr "Опасность - Немедленно Возвращайся Назад"
+
+#~ msgid "Dark clouds loom overhead as you enter this valley."
+#~ msgstr ""
+#~ "Как только вы входите в долину, над головой появляется тень от облаков."
+
+#~ msgid "Dead Pine"
+#~ msgstr "Мертвая Сосна"
+
+#~ msgid ""
+#~ "Dear Diary,                           I found a mermaid today.  She was "
+#~ "floating in a patch of seaweed next to a rock.  A very friendly sort of "
+#~ "creature too!  Gave me all sorts of lovely gems and jewelry!  She said to "
+#~ "come back again sometime for more of the sea riches.  Wow. Ahab"
+#~ msgstr ""
+#~ "Дорогой дневник, сегодня я встретил русалку. Она плавала в морских "
+#~ "водорослях неподалёку от скал. Она оказалась очень дружелюбной! Подарила "
+#~ "мне драгоценных камней и золотых украшений! А ещё сказала возвращаться "
+#~ "когда-нибудь за добавкой морских сокровищ. Блин."
+
+#~ msgid "Deathgate"
+#~ msgstr "Ворота Мертвецов"
+
+#~ msgid "DeathGate"
+#~ msgstr "Ворота Мертвецов"
+
+#~ msgid "Decisions"
+#~ msgstr "Решения"
+
+#~ msgid "\"Defender\""
+#~ msgstr "\"Защитник\""
+
+#~ msgid ""
+#~ "Detour! Mountain pass to the East has been known to have avalanches! For "
+#~ "your own safety, follow the road South."
+#~ msgstr ""
+#~ "В объезд! Горный проход на Востоке закрыт, опасность лавин! Следуйте "
+#~ "дорогой Юга."
+
+#~ msgid "Detour! Troll bridge ahead!"
+#~ msgstr "В объезд! Впереди мост троллей!"
+
+#~ msgid "DirtWater"
+#~ msgstr "Грязная Вода"
+
+#~ msgid "Dominion"
+#~ msgstr "Власть"
+
+#~ msgid "Do Not Enter!"
+#~ msgstr "Вход Запрешен!"
+
+#~ msgid "Do not remove coins from fountain."
+#~ msgstr "Не забирайте монеты из фонтана."
+
+#~ msgid "Dragadune"
+#~ msgstr "Драгадун"
+
+#~ msgid "Dragonburg"
+#~ msgstr "Драконье Клеймо"
+
+#~ msgid "Dragon City lies beyond the Scorpion Hills."
+#~ msgstr "Город Драконов находится за пределами Скорпион Хиллз."
+
+#~ msgid "Dragon Hill"
+#~ msgstr "Драконья Горка"
+
+#~ msgid "Dragon Rider"
+#~ msgstr "Драконья Река"
+
+#~ msgid "Dragons Everywhere!"
+#~ msgstr "Везде Драконы!"
+
+#~ msgid "Dragon's Eye"
+#~ msgstr "Глаз Дракона"
+
+#~ msgid "Dragontooth"
+#~ msgstr "Драконий Зуб"
+
+#~ msgid "Dragon Town"
+#~ msgstr "Город Драконов"
+
+#~ msgid "Dragonville"
+#~ msgstr "Деревьня Драконов"
+
+#~ msgid "Dragon Wars"
+#~ msgstr "Битва Драконов"
+
+#~ msgid "Dragon Watch"
+#~ msgstr "Стража Драконов"
+
+#~ msgid "Drakoran"
+#~ msgstr "Дракоран"
+
+#~ msgid "Dwarfhall"
+#~ msgstr "Город Гномов"
+
+#~ msgid "Dwarfhall, Domain of the dwarf King."
+#~ msgstr "Город Гномов, владения Короля Гномов."
+
+#~ msgid "Dwarf Hall, domain of the dwarf King."
+#~ msgstr "Город Гномов, владения Короля Гномов."
+
+#~ msgid "Eatio"
+#~ msgstr "Поедун"
+
+#~ msgid "Edgewood"
+#~ msgstr "Эджвуд"
+
+#~ msgid "Elk's Head"
+#~ msgstr "Голова Элка"
+
+#~ msgid "Elowyn"
+#~ msgstr "Эловин"
+
+#~ msgid "Enroth"
+#~ msgstr "Земля"
+
+#~ msgid "Entering high in the desert"
+#~ msgstr "Вступаете в плато в пустыне"
+
+#~ msgid "Entering Praires of the Middlelands"
+#~ msgstr "Вступаете в Прерии Срединных Земель"
+
+#~ msgid "Entering the desert high"
+#~ msgstr "Вступаете в пустынное плато"
+
+#~ msgid "Entering the high desert"
+#~ msgstr "Вступаете в пустыню на плато"
+
+#~ msgid "Entering the higher desert"
+#~ msgstr "Вступаете в пустыню над плато"
+
+#~ msgid "Entering the Valley of Magic"
+#~ msgstr "Вступаете в Долину Магии"
+
+#~ msgid "Erliquin"
+#~ msgstr "Эрликвин"
+
+#~ msgid "Evil Igor"
+#~ msgstr "Злой Игор"
+
+#~ msgid "Fadlan"
+#~ msgstr "Фадлан"
+
+#~ msgid "Fantasy Island."
+#~ msgstr "Остров Фантазии."
+
+#~ msgid "Farlien"
+#~ msgstr "Фарлин"
+
+#~ msgid "fedx comp"
+#~ msgstr "Подачка для АИ"
+
+#~ msgid "Fedx for comp"
+#~ msgstr "Подачка для АИ"
+
+#~ msgid "Fenton"
+#~ msgstr "Фентон"
+
+#~ msgid "Fetid Elm"
+#~ msgstr "Зловонный Вяз"
+
+#~ msgid ""
+#~ "Final message from Overlord. \"The royal executioners are on their way. "
+#~ "My gold, the land or your head- it's your choice.\""
+#~ msgstr ""
+#~ "Последнее сообщение от Оверлорда. \"Королевские палачи уже выехали. Моё "
+#~ "золота и земля или твоя голова - выбор за тобой.\""
+
+#~ msgid "Find and defeat the Pirate Leader!"
+#~ msgstr "Найдите и убейте Лидера Пиратов!"
+
+#~ msgid "Find and destroy the evil beings who rule the wastelands."
+#~ msgstr "Найдите и уничтожьте злых существ, управляющих пустошами."
+
+#~ msgid "Find the center island."
+#~ msgstr "Найдите центральный остров."
+
+#~ msgid ""
+#~ "Find the Ultimate Artifact and be proclaimed King, or smash the "
+#~ "opposition and take control."
+#~ msgstr ""
+#~ "Найдите Главную Реликвию и будете провозглашены Королём или же уничтожьте "
+#~ "противников и захватите власть."
+
+#~ msgid "Fire King"
+#~ msgstr "Король Огня"
+
+#~ msgid "Five heroes vie for control of a familiar land."
+#~ msgstr "Пять героев сошлись в схватке за фамильные земли."
+
+#~ msgid "Fool's Gold"
+#~ msgstr "Золото дурака"
+
+#~ msgid ""
+#~ "For a total of 400,000 gold your opponents will become \"loyal\" "
+#~ "subjects, otherwise... let them eat cake!"
+#~ msgstr ""
+#~ "За 400,000 золотых Ваши соперники станут \"верноподданными\", или же... "
+#~ "задайте им жару!"
+
+#~ msgid ""
+#~ "For centuries, the Wizards of the North have maintained a vast library "
+#~ "for all the world to share.  Now, however, they have closed their doors, "
+#~ "and issued declarations of war to each of the other rulers of the land.  "
+#~ "To make matters worse, rather than ally with you to face the Wizards, "
+#~ "each of the others have decided to go forth on their own in an effort to "
+#~ "conquer this land for themselves!  Prepare your forces, commander, for "
+#~ "you now stand alone."
+#~ msgstr ""
+#~ "Веками, Волшебники Севера содержали огромную библиотеку, которую мог "
+#~ "посетить каждый. Как бы то ни было, сегодня они закрыли свои двери и "
+#~ "объявили войну всем остальным феодалам. Ещё хуже то, что вместо союза "
+#~ "против Волшебников, каждый из лордов решил в одиночку завоевать эти "
+#~ "земли! Готовьтесь к бою, командир, теперь Вы сам за себя."
+
+#~ msgid ""
+#~ "For decades you have studied, learned, and allowed yourself to be ruled "
+#~ "by that pitiful excuse for a king, knowing that one day the time would "
+#~ "come for you to sit on the throne.  That time is now, for the king is "
+#~ "dead and without an heir.  You have the advantage of isolation from the "
+#~ "rest of the kingdom, but beware the miles of coastline that could leave "
+#~ "you vulnerable to attack.  Go, now, and wipe your enemies from this land!"
+#~ msgstr ""
+#~ "Десятилетиями ты учился, готовился и позволял помыкать собой этим жалким "
+#~ "подобием короля, зная, что придёт день, когда ты сам займёшь трон. Пришло "
+#~ "время смерти короля и отсутствия наследника. У тебя преимущество "
+#~ "обособленности от остальной части королевства, но будь осторожен с милями "
+#~ "побережья - там ты уязвим к нападению. Иди же и сотри своих врагов с лица "
+#~ "этой земли!"
+
+#~ msgid "Forder Oaks"
+#~ msgstr "Фордер Окс"
+
+#~ msgid "Forestria"
+#~ msgstr "Форестия"
+
+#~ msgid "For Honor"
+#~ msgstr "За Честь"
+
+#~ msgid ""
+#~ "For information about Ye Rich lands to the south, speak to Alponse at the "
+#~ "Golden Goose Tavern. Excellent views, plentiful water."
+#~ msgstr ""
+#~ "Для получения информации о богатых землях на юге, поговорите с Альпонсом "
+#~ "в таверне Золотой Гусь. Отличная еда и выпивка..."
+
+#~ msgid "Forsaken Lands"
+#~ msgstr "Покинутые Земли"
+
+#~ msgid "For sale."
+#~ msgstr "Продается."
+
+#~ msgid "Fortress Isle"
+#~ msgstr "Остров Крепость"
+
+#~ msgid ""
+#~ "For years, you have existed peacefully in the Forest of Dreams, knowing "
+#~ "that your king was the kindest and strongest ruler the land had seen in "
+#~ "centuries.  Now, however, his reign is at an end, and there is no heir to "
+#~ "succeed him.  You realize that a power struggle is coming, and that you "
+#~ "must brace yourself for war, and prevent those who would harm this land "
+#~ "from coming into power!"
+#~ msgstr ""
+#~ "Годами Вы мирно жили в Лесу Сновидений, зная, что Ваш король самый "
+#~ "сильный и самый добрый правитель последних веков. Теперь же пришёл его "
+#~ "час, а у трона нет наследника. Вы понимаете, что грядёт междоусобица и Вы "
+#~ "должны воевать, чтобы не дать захватить трон тому, кто принесёт вред "
+#~ "королевству, придя к власти!"
+
+#~ msgid ""
+#~ "For years, you've been able to keep your subjects \"appeased.\"  Now "
+#~ "however, you discover not only that your entire kingdom has turned "
+#~ "against you, but most of your outer towns have fallen to the different "
+#~ "factions.  To make matters worse, all your gold suddenly seems to be "
+#~ "missing from the treasury!"
+#~ msgstr ""
+#~ "В течение многих лет, Вы спокойно правили королевством. Но сейчас все "
+#~ "царство обернулось против Вас,  большинство ваших городов отделилось. И "
+#~ "что хуже всего, Ваша казна пуста!"
+
+#~ msgid "Fountainhead"
+#~ msgstr "Фонтан"
+
+#~ msgid "Four kingdoms race to capture the island of Sharkania."
+#~ msgstr "Четыре королевства для захвата острова Sharkania."
+
+#~ msgid "Four lakes have castles, three have treasure."
+#~ msgstr "Четыре Замка с озером, три из них с сокровищами.."
+
+#~ msgid "Four players must work together to assault the Wizards' Stronghold."
+#~ msgstr "Четыре игрока должны сообща осадить цитадель волшебника"
+
+#~ msgid "Frozenpeak"
+#~ msgstr "Замерзший пик"
+
+#~ msgid "Full House"
+#~ msgstr "Все Дома"
+
+#~ msgid "Galveston"
+#~ msgstr "Гальвестон"
+
+#~ msgid "Garamok"
+#~ msgstr "Гарамок"
+
+#~ msgid "Gate"
+#~ msgstr "Ворота"
+
+#~ msgid "Gate to the Isle of Knowledge"
+#~ msgstr "Врата к Острову Познания"
+
+#~ msgid "Gate to The Isle of Knowledge"
+#~ msgstr "Врата к Острову Познания"
+
+#~ msgid "Gaurdian"
+#~ msgstr "Хранитель"
+
+#~ msgid "Gavonshire"
+#~ msgstr "Гейвоншир"
+
+#~ msgid "Glastonbury"
+#~ msgstr "Гластонбёри"
+
+#~ msgid "Go away!"
+#~ msgstr "Уходите!"
+
+#~ msgid "GO AWAY!"
+#~ msgstr "Пошел Прочь!"
+
+#~ msgid "Goblin Island"
+#~ msgstr "Гоблинский Остров"
+
+#~ msgid "Goblin King"
+#~ msgstr "Король Гоблинов"
+
+#~ msgid "Go Home!"
+#~ msgstr "Домой!"
+
+#~ msgid "Go north to find the lost gold-mine."
+#~ msgstr "Следуйте на север, чтобы найти потеряную золотую шахту"
+
+#~ msgid "Good vs. Evil"
+#~ msgstr "Добро против Зла"
+
+#~ msgid "Gorgomar"
+#~ msgstr "Горгомар"
+
+#~ msgid "Greed"
+#~ msgstr "Жадность"
+
+#~ msgid "Green bonus stuff"
+#~ msgstr "хабар для Зеленого"
+
+#~ msgid "Green gets stuff"
+#~ msgstr "хабар для Зеленого"
+
+#~ msgid "Greenroot"
+#~ msgstr "Гринрут"
+
+#~ msgid "Green's Allowance"
+#~ msgstr "Зеленым Разрешено"
+
+#~ msgid "Green's Groceries"
+#~ msgstr "Зеленая Лавка"
+
+#~ msgid "green stuff"
+#~ msgstr "хабар для Зеленого"
+
+#~ msgid "Green stuff"
+#~ msgstr "хабар для Зеленого"
+
+#~ msgid "Greywind"
+#~ msgstr "Грейвинд"
+
+#~ msgid "Grim"
+#~ msgstr "Грим"
+
+#~ msgid "Grrr, Blazzer, Grrupt. Be gone with you!"
+#~ msgstr "Гррр, Блаззер, Гррапт. Мы идём с твоя!"
+
+#~ msgid "Guardian War"
+#~ msgstr "Война Стражей"
+
+#~ msgid "Gungtooth"
+#~ msgstr "Гангтус"
+
+#~ msgid "Hail Unicorns!"
+#~ msgstr "Слава Единорогам!"
+
+#~ msgid "Hampshire"
+#~ msgstr "Хэмпшир"
+
+#~ msgid "Have fun storming the castle!"
+#~ msgstr "Веселитесь, осаждая замок!"
+
+#~ msgid "Havenwood"
+#~ msgstr "Хэйвенвуд"
+
+#~ msgid "Hawkins"
+#~ msgstr "Хокинс"
+
+#~ msgid "Help!"
+#~ msgstr "На помощь!"
+
+#~ msgid "Help me...."
+#~ msgstr "Помогите мне..."
+
+#~ msgid ""
+#~ "Help peasant farmers regain their castle and land, else they'll take your "
+#~ "crops."
+#~ msgstr ""
+#~ "Помогите крестьянам вернуть свой замок и земли, или они отберут ваш урожай"
+
+#~ msgid "Hero's Hall"
+#~ msgstr "Зал героев"
+
+#~ msgid ""
+#~ "High in the snowy crags, you meet an old witch who, in return for a "
+#~ "trinket of yours, gives you a powerful magical object she used to use as "
+#~ "a footstool before she was exiled into the mountains by her own "
+#~ "townspeople."
+#~ msgstr ""
+#~ "Высоко в снежных горах, Вы встречаете старую ведьму, которая в обмен на "
+#~ "Ваш медальон даёт Вам могущественный магический объект, который она "
+#~ "использовала в качестве костыля до того, как её изгнали в горы её "
+#~ "соотечественники."
+
+#~ msgid "Hillstone"
+#~ msgstr "Хиллстон"
+
+#~ msgid "Hilltop"
+#~ msgstr "Холмовершье"
+
+#~ msgid "Hilltown"
+#~ msgstr "Хилтаун"
+
+#~ msgid "Horizon"
+#~ msgstr "Горизонт"
+
+#~ msgid "Hungry dragons await.  Welcome, food."
+#~ msgstr "Голодные драконы ждут. Добро пожаловать, Вы моя еда."
+
+#~ msgid "Hurry, no time to wait.  This way to the dock."
+#~ msgstr "Скорее, нет времени ждать. Вот дорога к верфи."
+
+#~ msgid "Hurry up! Few days are left before the enemy's army arrives."
+#~ msgstr "Быстрей же! Осталось несколько дней до прибытия вражеской армии."
+
+#~ msgid "I am...."
+#~ msgstr "Я..."
+
+#~ msgid ""
+#~ "I am one of the few remaining survivors of the wrecked pleasure ship, "
+#~ "Exhorbitance. I think we'll all be dead of hunger soon, for we are out of "
+#~ "caviar. We ate the chef yesterday."
+#~ msgstr ""
+#~ "Я - один из выживших после крушения корабля Эксхорбитанс. Я думаю, мы все "
+#~ "умрём голодной смертью в скором времени, так как провиант кончился. Вчера "
+#~ "мы съели кока."
+
+#~ msgid "Ibn Fadlan"
+#~ msgstr "Ибн Фадлан"
+
+#~ msgid "Ice Palace"
+#~ msgstr "Ледяной Дворец"
+
+#~ msgid "Ice Prince"
+#~ msgstr "Ледяной Принц"
+
+#~ msgid "Icy lands ahead."
+#~ msgstr "Снежные земли впереди."
+
+#~ msgid "I didn't do it!"
+#~ msgstr "Я не делал этого!"
+
+#~ msgid ""
+#~ "If three heroes could dig six holes in three days, how long would it take "
+#~ "six heroes to dig twelve holes?"
+#~ msgstr ""
+#~ "Если три героя могут выкопать шесть нор за три дня, за сколько шесть "
+#~ "героев выкопают 12 нор?"
+
+#~ msgid "If you free a hero, they may help..."
+#~ msgstr "Если вы освободите героя, он может вам помочь..."
+
+#~ msgid ""
+#~ "If you value your lives, for God's sake, Don't go through this whirlpool!"
+#~ msgstr ""
+#~ "Если вам дороги ваши жизни, то ради всего святого, НЕ плывите через "
+#~ "водоворот!"
+
+#~ msgid "Income for Yellow."
+#~ msgstr "Доход для Жёлтого."
+
+#~ msgid "In the hole you find a chunk of ore!"
+#~ msgstr "Вы обнаружили в яме глыбу руды!"
+
+#~ msgid "In the stream you find an old compass!"
+#~ msgstr "В потоке Вы обнаружили старый компас!"
+
+#~ msgid "In this glen live some very naughty halflings. Stay Away!"
+#~ msgstr ""
+#~ "В этой узкой горной долине живут непоседливые половинчики. Держись "
+#~ "подальше!"
+
+#~ msgid ""
+#~ "In two more weeks, if you have not located Joseph, your kingdom will "
+#~ "surely lose its current battle with Harondale."
+#~ msgstr ""
+#~ "Если вы не найдете Иосифа за две недели, ваше королевство погибнет в "
+#~ "сражении с Harondale."
+
+#~ msgid "I see you, you see me."
+#~ msgstr "Я вижу тебя, ты - меня"
+
+#~ msgid "Is it something I said? Go back and I will forget the whole thing."
+#~ msgstr "Что Я сказал? Вернитесь назад и я забуду все это."
+
+#~ msgid "IslandHome"
+#~ msgstr "ДомашнийОстров"
+
+#~ msgid "Island of the meek"
+#~ msgstr "Кроткий Остров"
+
+#~ msgid "Island of Wolcott"
+#~ msgstr "Остров Вулкут"
+
+#~ msgid "Isle Maze"
+#~ msgstr "Остров Лабиринт"
+
+#~ msgid "Isle of Knowledge"
+#~ msgstr "Остров Знания"
+
+#~ msgid ""
+#~ "It has become apparent that if all your enemies were eliminated, you "
+#~ "would have all the time you need to find the Ultimate Artifact."
+#~ msgstr ""
+#~ "Стало очевидным, что если бы все Ваши враги были устранены, у Вас было "
+#~ "полно времени, необходимого, чтобы найти Реликвию."
+
+#~ msgid ""
+#~ "It is obvious that the mage that once was here had won many battles!  "
+#~ "There, upon his hand, is a most powerful ring!"
+#~ msgstr ""
+#~ "Очевидно, что маг, побывавший здесь, выиграл множество битв! На его палец "
+#~ "надето могущественное кольцо."
+
+#~ msgid ""
+#~ "It is rumored that a bridge of land used to exist between the two "
+#~ "continents, but that a wild magic caused it to sink into the sea, taking "
+#~ "with it all those who used to inhabit it.  To try to raise this bridge is "
+#~ "to invite a curse upon the world!  The spirits of the dead will haunt us "
+#~ "all!"
+#~ msgstr ""
+#~ "Ходят слухи, что ранее существовал мост между двумя континентами, но "
+#~ "неподвластная магия потопила его на морское дно, забрав с собой всех, кто "
+#~ "его населял... Попытаться вернуть этот мост означает навлечь проклятье на "
+#~ "весь мир! Духи мёртвых будут преследовать всех нас!"
+
+#~ msgid ""
+#~ "It is said that King Zealot found the gods' artifact once and it let him "
+#~ "rule for 100 years."
+#~ msgstr ""
+#~ "Говорят, что король Zealot нашел Божественный Артифакт и правил в течение "
+#~ "100 лет."
+
+#~ msgid ""
+#~ "It looks like there used to be an ore mine here but all you see now is a "
+#~ "hole in the ground and some minerals scattered around."
+#~ msgstr ""
+#~ "Похоже здесь когда-то был рудник. Но все, что осталось от него, это "
+#~ "несколько разбросанных вокруг минералов и отверстие в земле."
+
+#~ msgid ""
+#~ "It's a battle for supremacy as the Blue and Green heroes take on Red and "
+#~ "Orange in team competition!"
+#~ msgstr "Это битва для команды Синих и Зеленых против Красных и Оранжевых!"
+
+#~ msgid "It's windy at the top.  Defend, Divide, and Conquer."
+#~ msgstr "Защити, Раздели, и Властвуй."
+
+#~ msgid "IvanHome"
+#~ msgstr "Дом Ивана"
+
+#~ msgid "Ivan lives in the desert."
+#~ msgstr "Иван живет в пустыне"
+
+#~ msgid "I Would Go That Way If I Were You."
+#~ msgstr "Я желаю идти с Вами, по по этому пути."
+
+#~ msgid "Jolly Roger was here"
+#~ msgstr "Здесь был Веселый Роджер"
+
+#~ msgid "Jungomar"
+#~ msgstr "Джунгомар"
+
+#~ msgid "Just 30 days left!"
+#~ msgstr "Осталось 30 дней!"
+
+#~ msgid "Just ONE week left!"
+#~ msgstr "Осталась всего ОДНА неделя!"
+
+#~ msgid "Kastor"
+#~ msgstr "Кастор"
+
+#~ msgid "Keep going south"
+#~ msgstr "Продолжайте идти на юг"
+
+#~ msgid "Keep Off The Grass!"
+#~ msgstr "Не ходите по траве!"
+
+#~ msgid "Keep Out!"
+#~ msgstr "Держись Подальше!"
+
+#~ msgid "King John"
+#~ msgstr "Король Джон"
+
+#~ msgid "King of Death"
+#~ msgstr "Король Мертвых"
+
+#~ msgid "Knight stuff"
+#~ msgstr "Хабар для Рыцаря"
+
+#~ msgid "Lakeside"
+#~ msgstr "Лейксайд"
+
+#~ msgid "Land teleporters will get you to your destination sooner."
+#~ msgstr "Телепорт приведет вас к месту назначения намного быстрее."
+
+#~ msgid "Lankershire"
+#~ msgstr "Ланкашир"
+
+#~ msgid "Lavalor"
+#~ msgstr "Лавалор"
+
+#~ msgid "Lombard"
+#~ msgstr "Ломбард"
+
+#~ msgid "Long live Roland the true King!"
+#~ msgstr "Долгой жизни королю Роланду!"
+
+#~ msgid "Long live Roland the true King."
+#~ msgstr "Долгой жизни королю Роланду!"
+
+#~ msgid "Look out!"
+#~ msgstr "Берегись!"
+
+#~ msgid "Lord Alberon"
+#~ msgstr "Лорд Алберон"
+
+#~ msgid "Lord Haart"
+#~ msgstr "Лорд Хаарт"
+
+#~ msgid "Lord Kreager"
+#~ msgstr "Лорд Крегер"
+
+#~ msgid "Lost Continent"
+#~ msgstr "Потерянный Континент"
+
+#~ msgid "Lost Gold- Mine"
+#~ msgstr "Затеряная золотая шахта"
+
+#~ msgid "Lost Island."
+#~ msgstr "Потерянный Остров."
+
+#~ msgid "Lost Relic"
+#~ msgstr "Утерянная Реликвия"
+
+#~ msgid "Magic"
+#~ msgstr "Магия"
+
+#~ msgid "Magic Three"
+#~ msgstr "Магическое Дерево"
+
+#~ msgid ""
+#~ "Many years ago, a couple of mages had a \"duel\" that forever changed the "
+#~ "lake at the center of this continent.  Hearty adventurers might find "
+#~ "interesting treasure there!"
+#~ msgstr ""
+#~ "Много лет назад несколько магов устроили \"дуэль\", навсегда изменившую "
+#~ "озеро в центре этого континента. Старательные путники могут там найти "
+#~ "интересное сокровище!"
+
+#~ msgid ""
+#~ "Many years ago, a falling star crashed near here.  Only now the area is "
+#~ "safe enough to explore.  Rumor has it a castle exist where the star fell."
+#~ msgstr ""
+#~ "Много лет назад недалеко отсюда упала звезда. Только сейчас эта область "
+#~ "стала достаточно безопасной для поисков. По слухам, там, на месте "
+#~ "падающей звезды, сейчас стоит замок."
+
+#~ msgid "Marco"
+#~ msgstr "Марко"
+
+#~ msgid "Meramec"
+#~ msgstr "Мерамек"
+
+#~ msgid "Middle Gate"
+#~ msgstr "Средние Ворота"
+
+#~ msgid "Middleton"
+#~ msgstr "Мидлтаун"
+
+#~ msgid "Middletown"
+#~ msgstr "Миддлтаун"
+
+#~ msgid "Might vs. Magic"
+#~ msgstr "Сила против Магии"
+
+#~ msgid "Mineral Wars"
+#~ msgstr "Война за Ресурсы"
+
+#~ msgid "Mirkosov"
+#~ msgstr "Миркосов"
+
+#~ msgid "mirror"
+#~ msgstr "зеркало"
+
+#~ msgid "Money For Red"
+#~ msgstr "Деньги для Красного"
+
+#~ msgid "MONEY, MONEY, MONEY!"
+#~ msgstr "Деньги, Деньги, Деньги!"
+
+#~ msgid "Mountain king"
+#~ msgstr "Король Горы"
+
+#~ msgid "\"Necromancers!\""
+#~ msgstr "\"Колдуны Пердуны!\""
+
+#~ msgid "New Enemies"
+#~ msgstr "Новые Враги"
+
+#~ msgid "No Description"
+#~ msgstr "Нет описания"
+
+#~ msgid "No Fishing!"
+#~ msgstr "Здесь рыбы нет!"
+
+#~ msgid "No gems, crystal, or mercury for red."
+#~ msgstr "Нет кристаллов, ртути и драгоценных камней для Красного."
+
+#~ msgid "Noraston"
+#~ msgstr "Норастун"
+
+#~ msgid "North Road"
+#~ msgstr "Северная Дорога"
+
+#~ msgid "North vs. South"
+#~ msgstr "Север или Юг"
+
+#~ msgid "No Trespassing"
+#~ msgstr "Не беспокоить."
+
+#~ msgid "No tresspath...  No tree...  No thresh...  GO AWAY!"
+#~ msgstr "Не беспе.. Не безбо... Небесполе... ИДИТЕ ПРОЧЬ!"
+
+#~ msgid "Ogrehild"
+#~ msgstr "Огрхилд"
+
+#~ msgid "Olympus"
+#~ msgstr "Олимп"
+
+#~ msgid "Orange stuff"
+#~ msgstr "хабар для Оранжевого"
+
+#~ msgid "Orcville"
+#~ msgstr "Орквиль"
+
+#~ msgid "Overlord"
+#~ msgstr "Повелитель"
+
+#~ msgid "Pandemonium"
+#~ msgstr "Столпотворение"
+
+#~ msgid "Peacekeeper"
+#~ msgstr "Пеаскипер"
+
+#~ msgid "\"Peasants!\""
+#~ msgstr "\"Крестьяне!\""
+
+#~ msgid "Pinehurst"
+#~ msgstr "Пайнхурст"
+
+#~ msgid "Pirate's Cove"
+#~ msgstr "Пиратская Бухта"
+
+#~ msgid "Pirate Utopia"
+#~ msgstr "Мечта Пиратов"
+
+#~ msgid "Pixie"
+#~ msgstr "Пиксия"
+
+#~ msgid "Please...."
+#~ msgstr "Пожалуйста..."
+
+#~ msgid "Portals"
+#~ msgstr "Порталы"
+
+#~ msgid "POSION - DO NOT DRINK"
+#~ msgstr "не пейте - это ЯД"
+
+#~ msgid "Red stuff"
+#~ msgstr "хабар для Красного"
+
+#~ msgid "Reinforcements have arrived, Gold from the homelands!"
+#~ msgstr "Прибыло подкрепление, прибыло золото от родины!"
+
+#~ msgid "Restricted Area, Do Not Enter!"
+#~ msgstr "Ограниченный доступ, не входить!"
+
+#~ msgid "Revolution"
+#~ msgstr "Революция"
+
+#~ msgid "Roc Haven"
+#~ msgstr "Тайное Убежище"
+
+#~ msgid "Sandcaster"
+#~ msgstr "Сандкастер"
+
+#~ msgid "Sands of Time"
+#~ msgstr "Пески времени"
+
+#~ msgid "Sansobar"
+#~ msgstr "Сансобр"
+
+#~ msgid "Scabsdale"
+#~ msgstr "Скабсдэл"
+
+#~ msgid "Scorched Earth"
+#~ msgstr "Выжженная земля"
+
+#~ msgid "Sharkania"
+#~ msgstr "Шаркания"
+
+#~ msgid "Sheltemburg"
+#~ msgstr "Шелтембург"
+
+#~ msgid "Sherman"
+#~ msgstr "Шерман"
+
+#~ msgid "Sirein"
+#~ msgstr "Сирены"
+
+#~ msgid ""
+#~ "Six factions have established a foothold on a huge, unexplored "
+#~ "continent.  Can you eliminate the other five?"
+#~ msgstr ""
+#~ "Шесть конкурентов закрепились на большом, неизведанном континенте. Вы "
+#~ "сможете устранить всех?"
+
+#~ msgid ""
+#~ "Six heroes with large armies prepare to slug it out for total domination!"
+#~ msgstr ""
+#~ "Шесть героев с большими армиями готовы к войне для полного контроля!"
+
+#~ msgid "Skirmish"
+#~ msgstr "Скирмаш"
+
+#~ msgid "Slugfest"
+#~ msgstr "Слагфест"
+
+#~ msgid "Snowdrop"
+#~ msgstr "Сноудроп"
+
+#~ msgid "Some crystal!"
+#~ msgstr "Несколько кристаллов!"
+
+#~ msgid "Some gems!"
+#~ msgstr "Несколько драгоценных камней!"
+
+#~ msgid "Some ore!"
+#~ msgstr "Несколько каменной руды!"
+
+#~ msgid "Some sulfur!"
+#~ msgstr "Несколько серы!"
+
+#~ msgid "Sorpigal"
+#~ msgstr "Сорпигал"
+
+#~ msgid "South Mill"
+#~ msgstr "Южная Шахта"
+
+#~ msgid "So you think you're smart?"
+#~ msgstr "Похоже, ты считаешь себя умным?"
+
+#~ msgid "Spector"
+#~ msgstr "Спектор"
+
+#~ msgid "Stairs"
+#~ msgstr "Лесенка"
+
+#~ msgid "Stromgild"
+#~ msgstr "Стромхилд"
+
+#~ msgid "Stromhild"
+#~ msgstr "Стромхилд"
+
+#~ msgid "Stronghold"
+#~ msgstr "Крепость"
+
+#~ msgid "Stuff for red"
+#~ msgstr "хабар для Красного"
+
+#~ msgid "Stuff for Yellow"
+#~ msgstr "хабар для Желтого"
+
+#~ msgid "Stuff For Yellow"
+#~ msgstr "хабар для Желтого"
+
+#~ msgid "Teleporters"
+#~ msgstr "Телепорты"
+
+#~ msgid ""
+#~ "The alliance has crumbled and all are at war. Lots of resources but "
+#~ "little time to prepare."
+#~ msgstr ""
+#~ "Союз рухнул, и все в состоянии войны. Много ресурсов, но мало времени на "
+#~ "подготовку."
+
+#~ msgid "The center island is rumored to harbor great spells."
+#~ msgstr "Говорят что центральный остров таит много заклинаний."
+
+#~ msgid "The Citadel"
+#~ msgstr "Цитадель"
+
+#~ msgid ""
+#~ "The first piece of the artifact now lies in the hands of the Unholy Order "
+#~ "of Warlocks. You must annihilate them, and their allies to the north. "
+#~ "They will surely give us what we seek in exchange for their feeble lives."
+#~ msgstr ""
+#~ "Первый кусок от артефакта сейчас у Нечестивого Ордена Чернокнижников. Вы "
+#~ "должны уничтожить их, и их союзников на севере. Они отдадут нам все, к "
+#~ "чему мы стремимся, в обмен на их слабую жизнь."
+
+#~ msgid "The island...."
+#~ msgstr "Остров..."
+
+#~ msgid "The Island of Lost Reason"
+#~ msgstr "Остров Потерянных Решений"
+
+#~ msgid "The Isle of Armoria"
+#~ msgstr "Остров Армория"
+
+#~ msgid "The Kings Road."
+#~ msgstr "Королевская Дорога."
+
+#~ msgid "The land of Heroes II."
+#~ msgstr "Земля Героев II."
+
+#~ msgid "The way of magic"
+#~ msgstr "Дорога магии"
+
+#~ msgid "The way of might"
+#~ msgstr "Дорога силы"
+
+#~ msgid "The way of numbers"
+#~ msgstr "Дорога чисел"
+
+#~ msgid "The wizard has an island in the southeast."
+#~ msgstr "У волшебника есть остров на юго-востоке."
+
+#~ msgid "The wood has arrived."
+#~ msgstr "Дерево прибыло."
+
+#~ msgid "This bottle is empty."
+#~ msgstr "Бутылка пуста."
+
+#~ msgid "Timberhill"
+#~ msgstr "Тимберхилл"
+
+#~ msgid "TreeHome"
+#~ msgstr "Дерево Дом"
+
+#~ msgid "Troy"
+#~ msgstr "Троя"
+
+#~ msgid "Tundara"
+#~ msgstr "Тундра"
+
+#~ msgid "Turn back, friend, while you still can!"
+#~ msgstr "Возвращайся назад, друг,  пока еще можешь!"
+
+#~ msgid "Turn Back Now!"
+#~ msgstr "Возвращайся назад!"
+
+#~ msgid "Turn Back Now or all will be LOST!"
+#~ msgstr "Возвращайся назад или ПОГИБНЕШЬ!"
+
+#~ msgid "Turn Back or DIE!"
+#~ msgstr "Возвращайся назад или УМРЕШЬ!"
+
+#~ msgid "Turn Back or else!"
+#~ msgstr "Возвращайся назад иначе..."
+
+#~ msgid "Turn back, you fool."
+#~ msgstr "Возвращайся назад глупец."
+
+#~ msgid "Uncle Leo"
+#~ msgstr "Дядя Ли"
+
+#~ msgid "Uncle Milty"
+#~ msgstr "Дядя Милти"
+
+#~ msgid "Undead Armies"
+#~ msgstr "Армии Мертвых"
+
+#~ msgid "Unholy Alliance"
+#~ msgstr "Нечестный Союз"
+
+#~ msgid "Valley of Death"
+#~ msgstr "Долина Смерти"
+
+#~ msgid "Valley of the Kings."
+#~ msgstr "Долина Королей"
+
+#~ msgid "Vaultius"
+#~ msgstr "Ваултиус"
+
+#~ msgid "Vertigo"
+#~ msgstr "Вертиго"
+
+#~ msgid "Vikings!"
+#~ msgstr "Викинги!"
+
+#~ msgid "Viper's Nest"
+#~ msgstr "Змеиное Гнездо"
+
+#~ msgid "Vulcania"
+#~ msgstr "Вулкания"
+
+#~ msgid "Warrior Knight"
+#~ msgstr "Воин Рыцарь"
+
+#~ msgid "Wastelands"
+#~ msgstr "Опустошенная Земля"
+
+#~ msgid "Watch out for Purple!"
+#~ msgstr "Следите внимательно за Фиолетовым!"
+
+#~ msgid "Weddington"
+#~ msgstr "Ведингтон"
+
+#~ msgid ""
+#~ "Welcome to Power Island. He who controls this Isle controls the Seven "
+#~ "Lakes!"
+#~ msgstr ""
+#~ "Добро пожаловать на Остров Власти. Тот, кто контролирует этот Остров - "
+#~ "контролирует Семь Озер!"
+
+#~ msgid "Welcome to the Sandbar."
+#~ msgstr "Добро пожаловать в Сандбар."
+
+#~ msgid "Welcome to the sandy Isle."
+#~ msgstr "Добро пожаловать на Оранжевый Остров."
+
+#~ msgid "Welcome to the sorceress' guild."
+#~ msgstr "Добро пожаловать в башню волшебницы."
+
+#~ msgid "Welcome to the Spiral Isles"
+#~ msgstr "Добро пожаловать на Спиральный Остров."
+
+#~ msgid ""
+#~ "Welcome to the wounderous Kitisland range.  Eruptions each day, beware of "
+#~ "dragons."
+#~ msgstr ""
+#~ "Добро пожаловать в Китисленд. Каждый день извержения вулканов, а также "
+#~ "остерегайтесь драконов."
+
+#~ msgid "Welcome to Windfall Island!"
+#~ msgstr "Добро пожаловать на Остров Буреломов!"
+
+#~ msgid "Welcome to your DOOM!"
+#~ msgstr "Добро пожаловать, здесь Ваша Погибель!"
+
+#~ msgid "Westmoor"
+#~ msgstr "Восточное Болото"
+
+#~ msgid "Where am I?"
+#~ msgstr "Где Я?"
+
+#~ msgid "Whittingham"
+#~ msgstr "Витингем"
+
+#~ msgid "Who am I?"
+#~ msgstr "Кто Я?"
+
+#~ msgid ""
+#~ "Who am I?...  Where am I?...  Oh no! My Ship!  Well it's consigned to the "
+#~ "ghosts of my dead crew now, at least I still have my lucky rabbits foot."
+#~ msgstr ""
+#~ "Кто Я?!... Где Я?!... Я попал.. мой корабль разбит, и сейчас он под "
+#~ "охраной моего мертвого экипажа. Моя судьба немного удачнее, лишь "
+#~ "благодаря кроличей лапке."
+
+#~ msgid "Who is the true King?"
+#~ msgstr "Кто из нас, настоящий Король?"
+
+#~ msgid "Wildabar"
+#~ msgstr "Вилдабар"
+
+#~ msgid "Willow"
+#~ msgstr "Виллоу"
+
+#~ msgid "Winterlands"
+#~ msgstr "Северные Страны"
+
+#~ msgid "Witch Hunt"
+#~ msgstr "Избушка"
+
+#~ msgid "Woodhaven"
+#~ msgstr "Вудхавен"
+
+#~ msgid "Wood's Lord"
+#~ msgstr "Деревянный Король"
+
+#~ msgid "Woodstock"
+#~ msgstr "Вудсток"
+
+#~ msgid "Woodville"
+#~ msgstr "Вудвиль"
+
+#~ msgid "Wow, somebody has left a pile of wood here!"
+#~ msgstr "Ого, ктото оставил тут дрова!"
+
+#~ msgid "Xabran"
+#~ msgstr "Ксабран"
+
+#~ msgid "Yellow gets some stuff"
+#~ msgstr "Желтый получил несколько материалов"
+
+#~ msgid "Yellow stuff"
+#~ msgstr "хабар для Желтого"
+
+#~ msgid "Yorksford"
+#~ msgstr "Йорксфорд"
+
+#~ msgid ""
+#~ "You and your ally's families were given custody of The Isle of "
+#~ "Knowledge.  Other Lords feel the time has come for new guardians..."
+#~ msgstr ""
+#~ "Опека над Островом Знания поручена Вам и семьям вашего союзника. Но "
+#~ "другие Лорды считают, что пришло время для новых хранителей..."
+
+#~ msgid "You are a fool to come here!"
+#~ msgstr "Ты настолько глуп, что изволил прийти сюда!"
+
+#~ msgid "You are fighting on the side of your king!"
+#~ msgstr "Вы сражаетесь на стороне вашего Короля!"
+
+#~ msgid "You are fighting on the side of your sister!"
+#~ msgstr "Вы сражаетесь на стороне своей сестры!"
+
+#~ msgid "You are now entering the domain of Prince Roland. Have a nice day."
+#~ msgstr "Вы прибываете во владения принца Роланда. Удачного дня!"
+
+#~ msgid ""
+#~ "You are now entering the domain of Prince Roland. Have a pleasant stay."
+#~ msgstr ""
+#~ "Вы прибываете во владения принца Роланда. Надеемся, что вам понравится."
+
+#~ msgid ""
+#~ "You bribe the entrance guards of this dingy prison camp. They agree to "
+#~ "look the other way for a little while."
+#~ msgstr ""
+#~ "Вы подкупили стражу у входа в этот грязный лагерь. Некоторое время они "
+#~ "будут считать ворон в небе."
+
+#~ msgid ""
+#~ "You can only reach your enemies via teleporters, but each jump is a leap "
+#~ "of faith."
+#~ msgstr ""
+#~ "Вы можете настигнуть врагов только через монолиты, но с каждым прыжком "
+#~ "вера все крепнет."
+
+#~ msgid ""
+#~ "You find a gleaming gold medalion buried in the  snow.  As you move to "
+#~ "put it on it changes to the Fizbin of Misfortune."
+#~ msgstr ""
+#~ "Вы увидели блестящий золотой медальон, лежащий в снегу. Вы подобрали его, "
+#~ "и узнаете это Медальон Несчастья."
+
+#~ msgid ""
+#~ "You find an old signpost in the midst of a thicket that reads \"Warlock "
+#~ "Wood, West.  Barbarian Fields, East.\""
+#~ msgstr ""
+#~ "Среди зарослей, Вы нашли старый указатель, который гласит: \"Колдун Вуд, "
+#~ "на Западе. Варвар Фиелд, на Востоке\"."
+
+#~ msgid ""
+#~ "You find a note in the bottle! It reads, \"My ship has been wrecked by "
+#~ "the notorious pirates in this area! I am stranded on a small and barren "
+#~ "island. Please, I beg you to come and rescue me!\""
+#~ msgstr ""
+#~ "Вы находите бутылку и в ней записка! Она гласит: \"Мое судно потерпело "
+#~ "крушение, благодаря пиратам! Я нахожусь на маленьком и пустынном острове. "
+#~ "Пожалуйста, спасите меня!\""
+
+#~ msgid "You found something!"
+#~ msgstr "Вы чтото нашли!"
+
+#~ msgid "You found Treasure!"
+#~ msgstr "Вы нашли Сокровища!"
+
+#~ msgid ""
+#~ "You have been ordered here to claim this land in the name of your King "
+#~ "and recover any riches that you might find.  However, five other Kings "
+#~ "and Queens have also sent their heroes to this land, so you must watch "
+#~ "out for them as well as the natives!"
+#~ msgstr ""
+#~ "Вам приказали исследовать и захватить эту землю, именем Короля. Однако, "
+#~ "пять других королевств также оспаривают права на эту землю, так что вы "
+#~ "должны следить и за ними, и за местными туземцами!"
+
+#~ msgid ""
+#~ "You have hired a barbarian of great power to aid you in this, your last "
+#~ "quest. His origins are unknown to you, but you sense strong nobility "
+#~ "beneath the furs and dirt that cover him. In addition, the famous "
+#~ "explorer, Marco the wizard, is rumored to have wrecked his ship in this "
+#~ "new land. Finding him would prove to be a much needed boon to your cause."
+#~ msgstr ""
+#~ "Вы наняли очень сильного Варвара, который согласился помочь в ваших "
+#~ "приключениях. Его происхождение неизвестно, но вы чувствуете под мехами и "
+#~ "грязью благородного человека. Так же в этих землях потерпел крушение "
+#~ "известный мореплаватель Волшебник Марко. его нужно найти, для вашего дела."
+
+#~ msgid ""
+#~ "You have just 8 weeks  to build your army and conquer a town on the other "
+#~ "side of a distant river.  There are three paths to take, which will you "
+#~ "choose?"
+#~ msgstr ""
+#~ "У вас есть 8 недель, чтобы построить свою армию и завоевать город на "
+#~ "другой стороне далекой реки.\n"
+#~ "Есть три пути выбора, который из них вы выберете?"
+
+#~ msgid ""
+#~ "You have just 8 weeks to build your army and conquer a town on the other "
+#~ "side of a distant river.  There are three paths to take, which will you "
+#~ "choose?"
+#~ msgstr ""
+#~ "У вас есть 8 недель, чтобы построить свою армию и завоевать город на "
+#~ "другой стороне далекой реки.\n"
+#~ "Есть три пути выбора, который из них вы выберете?"
+
+#~ msgid ""
+#~ "You have received a message from Archibald. \"General, these peasants "
+#~ "deserve punishment. Put them to the sword and let Corlagon have his way "
+#~ "with them.\""
+#~ msgstr ""
+#~ "Вы получили сообщение от Арчибальда. \"Мой Генерал, эти крестьяне "
+#~ "заслуживают наказания. Пусть Корлагон возьмет меч и поступает с ними по "
+#~ "своему\"."
+
+#~ msgid ""
+#~ "You have received a message from Archibald.  \" HOW DARE YOU BETRAY ME! I "
+#~ "will see your head on the block alongside your new master's once I have "
+#~ "won."
+#~ msgstr ""
+#~ "Вы получили сообщение от Арчибальда. \"Как смеешь ты предать меня! Скоро "
+#~ "Я увижу Вашу голову на плахе.\""
+
+#~ msgid ""
+#~ "You have received a message from Roland. \" I am shocked! I had thought "
+#~ "better of you, but I was terribly wrong. Now you'll have to live with "
+#~ "your dark decision for the rest of your life.\""
+#~ msgstr ""
+#~ "Вы получили сообщение от Роланда. \"Я в шоке! Я ошибся в Вас. Теперь вы "
+#~ "будете жить с этим решением всю оставшуюся короткую жизнь\"."
+
+#~ msgid "You have recieved a shipment of supplies from your kingdom!"
+#~ msgstr "Вы получили новый груз из Королевства!"
+
+#~ msgid ""
+#~ "You have recieved a shipment of supplies from your kingdom! There is a "
+#~ "note attached, \"These are all we could afford to send you from our "
+#~ "treasuries, as the war with Harondale is taxing us greatly. We will send "
+#~ "more in two weeks.\""
+#~ msgstr ""
+#~ "Вы получили новый груз из Королевства!  И письмо: \"Это все, что мы могли "
+#~ "позволить себе послать вам, эта война очень затратна для нас. Следующий "
+#~ "груз мы вышлем через две недели\"."
+
+#~ msgid ""
+#~ "You have six months to destroy the Necromancer Stronghold in the heart of "
+#~ "the valley."
+#~ msgstr ""
+#~ "У вас есть 6 месцев, чтобы уничтожить Крепость Некроманта, в самом сердце "
+#~ "долины."
+
+#~ msgid ""
+#~ "You have washed up on the beach after being shipwrecked. Your goal is to "
+#~ "find a way home."
+#~ msgstr ""
+#~ "После кораблекрушения Вас вынесло на пляж. Ваша задача - найти путь домой."
+
+#~ msgid ""
+#~ "You hear a low rumble, look up and see an avalanche!  You dive onto a "
+#~ "large patch of grass to avoid it.  While dusting yourself off, you "
+#~ "consider yourself quite lucky to be alive.  Luckier still to find a Four-"
+#~ "Leaf Clover stuck on your nose."
+#~ msgstr ""
+#~ "Вы слышите низкий гул, смотрите вверх и видите снежную лавину! Вы "
+#~ "прячетесь на большой лужайке, чтобы избежать ее. Лавина проносится мимо, "
+#~ "Вы счастливчик, у вас в носу застрял Четырехлистный Клевер."
+
+#~ msgid ""
+#~ "You hear a rumor from a peasant who lives in the town of Waystop. He "
+#~ "says, \"The pirates control most of the sulfur mines in this area. They "
+#~ "use it for the cannons on their bigger boats. If you want a mine, you'll "
+#~ "have to defeat them.\""
+#~ msgstr ""
+#~ "Ты услышал сплетни от крестьянина, который живет в городе Вайстоп. Он "
+#~ "рассказал что пираты контролируют большую часть шахт с серой в этой "
+#~ "области. Они используют его для своих пушек для кораблей. Рано или поздно "
+#~ "вам придется с ними столкнуться\"."
+
+#~ msgid "You hear melodic strains of elvish music as you enter this clearing."
+#~ msgstr "На поляне Вы слышите мелодичные звуки эльфийской музыки."
+
+#~ msgid ""
+#~ "You must, like, forsake your earthly wealth and, like, join us on the "
+#~ "island of the lotus eaters."
+#~ msgstr ""
+#~ "Вы должны все бросить и присоединиться к нам на острове Поедателей Лотуса."
+
+#~ msgid ""
+#~ "You must search the world for your mortal enemy, Wilgatus.  Can you find "
+#~ "him before its too late?"
+#~ msgstr ""
+#~ "Вы должны найти, Вашего смертельного врага, Вилгатуса. Сможете ли вы его "
+#~ "найти пока не поздно?"
+
+#~ msgid ""
+#~ "You notice some runes hastily scrawled into a rock by your feet, They "
+#~ "look like the initials of Uncle Ivan!"
+#~ msgstr ""
+#~ "Вы заметили несколько наскальных надписей, они выглядят: \"Здесь был Дядя "
+#~ "Ваня!\""
+
+#~ msgid ""
+#~ "You notice that mines and resources in the elvish lands are few, and you "
+#~ "send word to your kingdom that you will need extra supplies. They should "
+#~ "respond within a fortnight."
+#~ msgstr ""
+#~ "Вы заметили, что ресурсов на этой эльфийской земле осталось очень мало, и "
+#~ "вы отправили соообщение о помощи в кололевство. Вам должен придти ответ в "
+#~ "течении двух недель."
+
+#~ msgid ""
+#~ "Your advance scouts come riding back to you with the following news. They "
+#~ "believe they have found signs that Uncle Ivan was in this general area, "
+#~ "and that he made his way to the north many months ago. Also they say "
+#~ "there is a town nearby and many resources to the east."
+#~ msgstr ""
+#~ "Ваши разведчики вернулись с новостями. Они считают, что обнаружили "
+#~ "признаки того, что Дядя Ваня было здесь, и что двигался на север, "
+#~ "несколько месяцев назад. Кроме того, они сообщили, что рядом находится "
+#~ "город, и много ресусов на востоке."
+
+#~ msgid ""
+#~ "Your advisor approaches you, \"My liege, something must be done about "
+#~ "these peasants! They still refuse to work.  At this rate you won't have "
+#~ "anything to put in your daughter's dowry!\""
+#~ msgstr ""
+#~ "Советник подходит вам, \"Мои Сеньер, нужно что то делать! Эти крестьяне "
+#~ "по прежнему отказываются работать. При таком темпе работ, у вад небудет "
+#~ "приданного для вашей дочери!\""
+
+#~ msgid ""
+#~ "Your advisor approaches you smiling greatly, \"My liege! The peasants are "
+#~ "making money in the market, and are finally paying taxes!\""
+#~ msgstr ""
+#~ "lДовольный советник подходит к Вам, \"Мои Сеньер! Крестьяне начали "
+#~ "торговать на рынке! Налоги текут рекой!\""
+
+#~ msgid ""
+#~ "Your advisor approaches you with a long face, \"My liege, the peasant's "
+#~ "numbers are growing steadily.  All they do is take, take, take! We are "
+#~ "beginning to suffer dearly because of them.\""
+#~ msgstr ""
+#~ "К Вам подходит советник, с вытянутым лицом, \"Мой Сеньер! Число крестьян "
+#~ "постояннно увеличивается... Они все время просят, просят, и просят! Это "
+#~ "нам выходит очень дорого.\""
+
+#~ msgid ""
+#~ "Your advisor approaches you with some startling information, \"My liege, "
+#~ "the peasants are draining us. They do nothing, and take everything! We "
+#~ "must get them home. Your own citizens are beginning to suffer!\""
+#~ msgstr ""
+#~ "К вам подошел советник, с шокирующей информацией, \"Мои Сеньер!, "
+#~ "крестьяне занимаются грабежами. Они ничего не делают, и берут все! Мы "
+#~ "должны отправить их всех домой. Ваши граждане начинают страдать!\""
+
+#~ msgid ""
+#~ "Your arrival here was a surprise to those sworn to guard Dragon Isle, and "
+#~ "you were able to quickly capture one of their castles.  Use caution, "
+#~ "though, for two other guardians remain in this jungle."
+#~ msgstr ""
+#~ "Ваш приезд сюда, был неожиданностью для охраны Острова Драконов, и Вы "
+#~ "смогли быстро захватить один из своих замков. Соблюдайте осторожность, "
+#~ "два других захватчика все еще остаются поблизости."
+
+#~ msgid ""
+#~ "Your castle, founded inside the center of a mile wide crater, is besieged "
+#~ "by those who desire your mineral wealth."
+#~ msgstr ""
+#~ "Ваш замок, построенный в центре давно потухшего кратер, осаждают враги, "
+#~ "которые желают разграбить все ваше богатство."
+
+#~ msgid "Your castle is the last outpost in the area, Don't lose it!"
+#~ msgstr ""
+#~ "Ваш замок является последним форпостом в этом районе, Не Потеряйте Его!"
+
+#~ msgid "Your crew begins to grumble."
+#~ msgstr "Ваша команда начинает ворчать."
+
+#~ msgid ""
+#~ "Your crew seriously entertains thoughts of mutiny.  Your nights are "
+#~ "sleepless."
+#~ msgstr ""
+#~ "Вашу команду, все чаще и чаще, посещают мысли мысли о мятеже. Это время "
+#~ "бессонных ночей для вас."
+
+#~ msgid "You're almost there!"
+#~ msgstr "Вы почти у цели!"
+
+#~ msgid "You, recieve word that you have been robbed."
+#~ msgstr "Вы, получили письмо, в котором говориться, что Вас ограбили!"
+
+#~ msgid "You're getting colder."
+#~ msgstr "Вам становится холодно"
+
+#~ msgid "You're getting warmer."
+#~ msgstr "Вам становится теплее."
+
+#~ msgid ""
+#~ "You're here! Oh, thank you thank you thank you! I'm in the jail east of "
+#~ "the castle. Please hurry!"
+#~ msgstr ""
+#~ "Вы уже здесь! О, благодарю Вас, благодарю Вас! Я нахожусь в тюрьме к "
+#~ "востоку от замка. Пожалуйста, поспешите!"
+
+#~ msgid ""
+#~ "Your expedition has taken a turn for the worse... you now have no way to "
+#~ "get home!"
+#~ msgstr ""
+#~ "Ваша экспедиция закончилась очень плохо ... Теперь у Вас нет возможности "
+#~ "попасть домой!"
+
+#~ msgid ""
+#~ "Your forces are thinly spread in an effort to defend all the dwarf towns "
+#~ "(which may not be transformed into castles). Consolidate your forces and "
+#~ "smite the enemy before the towns fall."
+#~ msgstr ""
+#~ "Ваши силы расредоточены, для защиты Гномьих Поселений. Вам нужно "
+#~ "объединиться, и поразить противника, пока он не захватил все."
+
+#~ msgid ""
+#~ "Your horse stumbles and throws you from the saddle.  When you awaken you "
+#~ "find that you have hit your head on the Fizbin of Misfortune."
+#~ msgstr ""
+#~ "Ваш конь спотыкается и выбросает Вас из седла. Когда Вы пришли в "
+#~ "сознание, Вы обнаружите Мадальон Несчастья."
+
+#~ msgid "Your subjects contribute to your war effort!"
+#~ msgstr "Ваши субъекты способствуют военным усилиям!"
+
+#~ msgid ""
+#~ "Your town is undefended and your heroes are scattered.  Do you attack or "
+#~ "defend?"
+#~ msgstr ""
+#~ "Ваш город незащищен и герои разбросаны по стране. Что вам делать: "
+#~ "атаковать или обороняться?"
+
+#~ msgid ""
+#~ "Your treasury has been looted by robbers and you have lost valuable "
+#~ "resources."
+#~ msgstr ""
+#~ "Ваша казна была разграблена грабителями, и Вы потеряли ценные ресурсы."
+
+#~ msgid "Your troops begin to wonder about your sanity."
+#~ msgstr "Ваши войска начинают задумываться о Вашей вменяемости."
+
+#~ msgid ""
+#~ "You run aground on the rocks and have to use some wood to fix your boat."
+#~ msgstr ""
+#~ "Вы попали в кораблекрушение на скалах, и вам нужны дрова, чтобы починить "
+#~ "корабль."
+
+#~ msgid "You see something that could just be the elusive Nubbie!"
+#~ msgstr "Вы видите что-то, это как раз может быть неуловимая Nubbie!"
+
+#~ msgid ""
+#~ "You see the remains of a burned out sawmill here.  All you can salvage is "
+#~ "some ofwood left for scrap."
+#~ msgstr ""
+#~ "Вы видите остатки сгоревшей лесопики. Все что осталось, вы разобрали на "
+#~ "ресурсы."
+
+#~ msgid ""
+#~ "You see the remains of an old sawmill, but it is obvious that you will "
+#~ "not be able to make it work again."
+#~ msgstr ""
+#~ "Вы видите остатки старой лесопилки, и очевидно, что вы не сможете ее "
+#~ "отремонтировать."
+
+#~ msgid "You should turn back."
+#~ msgstr "Вам нужно вернуться назад."
+
+#~ msgid "You uncover a compass in the grass!"
+#~ msgstr "Вы обнаружили компас в траве!"
+
+#~ msgid "You've been warned!"
+#~ msgstr "Мы Вас предупредили!"
+
+#~ msgid ""
+#~ "You've received a message from the guild. \"Thank God you've arrived! "
+#~ "We're under seige from two enemies from the north and one from across the "
+#~ "sea. Please save us, you're our only hope.\""
+#~ msgstr ""
+#~ "Вы получили сообщение от гильдии. \"Слава Богу, что вы приехали! Сейчас "
+#~ "мы в осаде, один враг с севера, а другой из-за моря. Пожалуйста, помогите "
+#~ "нам, Вы наша единственная надежда!\""
+
+#~ msgid ""
+#~ "You've ruled with an iron fist (and an army of undead), but now your "
+#~ "kingdom has turned against you!"
+#~ msgstr ""
+#~ "Вы жестко правили королевством и армией из нежити, но теперь ваше "
+#~ "королевство превратилось против вас!"
+
+#~ msgid ""
+#~ "You've saved a group of miners from the dragons.  One of them approaches "
+#~ "you, \"Thank you so much for saving us!  We found this sulfer and sword "
+#~ "in the mine, then those dragons chased us!  I don't know how much longer "
+#~ "we could survive!\""
+#~ msgstr ""
+#~ "Вы спасли группа шахтеров от драконов. Один из них подходит вам,  "
+#~ "\"Благодярю Вас за наше спасение! Мы обнаружили этот меч в шахте, долго "
+#~ "здесь мы бы не продержались...\""
+
+#~ msgid ""
+#~ "You will need a stronger army than that, mortal, to step through this "
+#~ "portal."
+#~ msgstr "Вам нужна более сильная армия, чтобы пройти через этот портал."
+
+#~ msgid "Blind "
+#~ msgstr "Ослепить "
+
+#~ msgid "game: also confirm autosave"
+#~ msgstr "game: так же спрашивать для autosave"
+
+#~ msgid "game: battle mouse shadow"
+#~ msgstr "game: показать тень перемещения курсора на поле боя"
+
+#~ msgid "game: battle move shadow"
+#~ msgstr "game: показать тень возможных ходов на поле боя"
+
+#~ msgid "game: castle flash building"
+#~ msgstr "game: выделять активные постройки в городах"
+
+#~ msgid "world: abandoned mine random resource"
+#~ msgstr "world: для заброшенной шахты, возможны все виды ресурсов"
+
+#~ msgid "world: save count monster after battle"
+#~ msgstr "world: сохранить количество врагов, после поражения"
+
+#~ msgid "world: guardian objects gets +2 defense"
+#~ msgstr "world: защитники объектов всегда будут получать +2 к защите"
+
+#~ msgid "world: no in-built requirements or guardians for placed artifacts"
+#~ msgstr ""
+#~ "world: запретить встроенные условия (покупка или охрана) для артефактов"
+
+#~ msgid "world: only the first monster will attack (H2 bug)."
+#~ msgstr ""
+#~ "world: если несколько армий монстров вокруг героя, то одна битва за ход "
+#~ "(H2 bug)"
+
+#~ msgid "world: new version WeekOf (+growth)"
+#~ msgstr "world: новая версия прироста населения WeekOf (+ базовый прирост)"
+
+#~ msgid ""
+#~ "world: Artesian Springs have two separately visitable squares (h3 ver)"
+#~ msgstr ""
+#~ "world: объект Artesian Springs имеет два независимых источника (h3 ver)"
+
+#~ msgid "world: Outer creature dwellings should accumulate units"
+#~ msgstr ""
+#~ "world: количество монстров, во внешних жилищах, будет увеличиваться "
+#~ "каждую неделю"
+
+#~ msgid "world: use unique artifacts for morale/luck"
+#~ msgstr ""
+#~ "world: использовать уникальность для артифактов, влияющие на мораль/удачу"
+
+#~ msgid "castle: allow buy from well"
+#~ msgstr "castle: разрешить покупку армии через колодец"
+
+#~ msgid "castle: allow recruits special/expansion heroes"
+#~ msgstr "castle: разрешить найм специальных героев из кампаний"
+
+#~ msgid "heroes: learn new spells with day"
+#~ msgstr "heroes: выучить новые заклинания только после ночевки в городе"
+
+#~ msgid "heroes: surrendering gives some experience"
+#~ msgstr "heroes: сбежавщий также получает опыт"
+
+#~ msgid "heroes: recalculate movement points after creatures movement"
+#~ msgstr "heroes: пересчитывать MP после изменения армии"
+
+#~ msgid "heroes: allow pickup objects for patrol"
+#~ msgstr "heroes: разрешить патрулю поднимать объекты в своем радиусе"
+
+#~ msgid "heroes: after battle move to target cell"
+#~ msgstr "heroes: после битвы автоматически переходить на клетку цели"
+
+#~ msgid "battle: high objects are an obstacle for archers"
+#~ msgstr "battle: для высоких препятствий применить штраф при стрельбе"
+
+#~ msgid "battle: merge armies for hero from castle"
+#~ msgstr "battle: объединять армию города и героя при нападении противника"
+
+#~ msgid "battle: archmage can resists (20%) bad spells"
+#~ msgstr "battle: АрхиМаги имеют защиту (20%) от плохой магии"
+
+#~ msgid "battle: magical creature resists (20%) the same magic"
+#~ msgstr "battle: магические существа имеют защиту от этой же магии (20%)."
+
+#~ msgid "battle: skip increase +2 defense"
+#~ msgstr "battle: пропуск хода увеличивает защиту на +2"
+
+#~ msgid "game: show SDL logo"
+#~ msgstr "game: показать SDL logo при старте"
+
+#~ msgid "game: also use dynamic interface for castles"
+#~ msgstr "game: так же использовать динамическую тему для городов"
+
+#~ msgid "pocketpc: hide cursor"
+#~ msgstr "pocketpc: выключить курсор"
+
+#~ msgid "pocketpc: tap mode"
+#~ msgstr "pocketpc: включить tap режим"
+
+#~ msgid "pocketpc: drag&drop gamearea as scroll"
+#~ msgstr "pocketpc: drag&drop gamearea as scroll"
+
+#~ msgid "pocketpc: low memory"
+#~ msgstr "pocketpc: недостаточно памяти"
 
 #~ msgid "Shoot %{monster} (%{count} shot(s) left)"
 #~ msgstr "Стрелять в  %{monster} (осталось %{count} выстрелов)"
@@ -13353,9 +10160,6 @@ msgstr "pocketpc: недостаточно памяти"
 
 #~ msgid "Allows you to draw streams by clicking and dragging."
 #~ msgstr "Позволяет разместить потоки воды и лавы."
-
-#~ msgid "Road Mode"
-#~ msgstr "Дороги"
 
 #~ msgid "Allows you to draw roads by clicking and dragging."
 #~ msgstr "Позволяет проложить дороги."
@@ -13547,19 +10351,6 @@ msgstr "pocketpc: недостаточно памяти"
 #~ msgstr[0] "Увеличивает радиус обзора героя на %{count} квадрат."
 #~ msgstr[1] "Увеличивает радиус обзора героя на %{count} квадрата."
 #~ msgstr[2] "Увеличивает радиус обзора героя на %{count} квадратов."
-
-#~ msgid ""
-#~ "Approximately %{count} percent of the creatures may offer to join you."
-#~ msgid_plural ""
-#~ "Approximately %{count} percent of the creatures may offer to join you."
-#~ msgstr[0] ""
-#~ "Позволяет присоединиться к Вашей армии, примерно %{count} процент существ."
-#~ msgstr[1] ""
-#~ "Позволяет присоединиться к Вашей армии, примерно %{count} процента "
-#~ "существ."
-#~ msgstr[2] ""
-#~ "Позволяет присоединиться к Вашей армии, примерно %{count} процентов "
-#~ "существ."
 
 #~ msgid ""
 #~ "Increases your hero's movement points over water by %{count} percent."

--- a/files/lang/sv.po
+++ b/files/lang/sv.po
@@ -7,49 +7,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-10-23 10:54+0900\n"
+"POT-Creation-Date: 2021-07-01 15:11+0200\n"
 "PO-Revision-Date: 2013-04-25 12:49+0000\n"
 "Last-Translator: Phoenix <Unknown>\n"
 "Language-Team: Swedish <sv@li.org>\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sv\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Launchpad-Export-Date: 2013-10-09 02:01+0000\n"
 "X-Generator: Launchpad (build 16799)\n"
 
-#: ../fheroes2/ai/ai_action.cpp:157 ../fheroes2/heroes/heroes_action.cpp:248
-msgid "Hero %{name} also got a %{count} experience."
-msgstr "Hjälten %{name} fick också %{count} erfarenhet."
-
-#: ../fheroes2/army/army_bar.cpp:221 ../fheroes2/resource/artifact.cpp:968
-msgid "View %{name}"
-msgstr "Visa %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:227 ../fheroes2/army/army_bar.cpp:310
-msgid "Move or right click to redistribute %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:233 ../fheroes2/army/army_bar.cpp:301
-msgid "Combine %{name} armies"
-msgstr "Kombinera %{name} arméer"
-
-#: ../fheroes2/army/army_bar.cpp:238 ../fheroes2/army/army_bar.cpp:292
-#: ../fheroes2/resource/artifact.cpp:980
-#: ../fheroes2/resource/artifact.cpp:1002
-msgid "Exchange %{name2} with %{name}"
-msgstr "Byt ut %{name2} mot %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:246 ../fheroes2/resource/artifact.cpp:988
-msgid "Select %{name}"
-msgstr "Välj %{name}"
-
-#: ../fheroes2/army/army_bar.cpp:298 ../fheroes2/army/army_bar.cpp:307
-msgid "Cannot move last troop"
-msgstr ""
-
-#: ../fheroes2/army/army.cpp:85
 msgid ""
 "A few\n"
 "%{monster}"
@@ -57,7 +26,6 @@ msgstr ""
 "Ett par\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:86
 msgid ""
 "Several\n"
 "%{monster}"
@@ -65,7 +33,6 @@ msgstr ""
 "Några\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:87
 msgid ""
 "A pack of\n"
 "%{monster}"
@@ -73,7 +40,6 @@ msgstr ""
 "En flock\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:88
 msgid ""
 "Lots of\n"
 "%{monster}"
@@ -81,7 +47,6 @@ msgstr ""
 "Mängder av\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:89
 msgid ""
 "A horde of\n"
 "%{monster}"
@@ -89,7 +54,6 @@ msgstr ""
 "En hord av\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:90
 msgid ""
 "A throng of\n"
 "%{monster}"
@@ -97,7 +61,6 @@ msgstr ""
 "Ett myller av\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:91
 msgid ""
 "A swarm of\n"
 "%{monster}"
@@ -105,7 +68,6 @@ msgstr ""
 "En svärm av\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:92
 msgid ""
 "Zounds of\n"
 "%{monster}"
@@ -113,7 +75,6 @@ msgstr ""
 "En skock\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:93
 msgid ""
 "A legion of\n"
 "%{monster}"
@@ -121,79 +82,78 @@ msgstr ""
 "En legion av\n"
 "%{monster}"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Few"
 msgstr "Armé|Några"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Several"
 msgstr "Armé|Flera"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Pack"
 msgstr "Armé|Flock"
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Lots"
 msgstr "Armé|Mängder"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Horde"
 msgstr "Armé|Hord"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Throng"
 msgstr "Armé|Myller"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Swarm"
 msgstr "Armé|Svärm"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Zounds"
 msgstr "Armé|Skock"
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Legion"
 msgstr "Armé|Legion"
 
-#: ../fheroes2/army/army.cpp:925
 msgid "All %{race} troops +1"
 msgstr "Alla %{race} trupper +1"
 
-#: ../fheroes2/army/army.cpp:936
-msgid "Entire unit is undead, so morale does not apply."
-msgstr "Hela gruppen är odöd, så moral gäller inte."
-
-#: ../fheroes2/army/army.cpp:946
 msgid "Troops of 3 alignments -1"
 msgstr "3 uppställningstrupper -1"
 
-#: ../fheroes2/army/army.cpp:954
 msgid "Troops of 4 alignments -2"
 msgstr "4 uppställningstrupper -2"
 
-#: ../fheroes2/army/army.cpp:962
 msgid "Troops of 5 alignments -3"
 msgstr "5 uppställningstrupper -3"
 
-#: ../fheroes2/army/army.cpp:976
 msgid "Some undead in groups -1"
 msgstr "Några odöda i grupper -1"
 
-#: ../fheroes2/battle/battle_action.cpp:752
+msgid "View %{name}"
+msgstr "Visa %{name}"
+
+msgid "Move or right click to redistribute %{name}"
+msgstr ""
+
+msgid "Combine %{name} armies"
+msgstr "Kombinera %{name} arméer"
+
+msgid "Exchange %{name2} with %{name}"
+msgstr "Byt ut %{name2} mot %{name}"
+
+msgid "Select %{name}"
+msgstr "Välj %{name}"
+
+msgid "Cannot move last troop"
+msgstr ""
+
+msgid "%{name} half the enemy troops!"
+msgstr "%{name} halverar fiendetrupperna!"
+
 msgid "Set auto battle off"
 msgstr "Slå av autostrid"
 
-#: ../fheroes2/battle/battle_action.cpp:757
 msgid "Set auto battle on"
 msgstr "Slå på autostrid"
 
-#: ../fheroes2/battle/battle_action.cpp:864
 msgid "spell failed!"
 msgstr "besvärjelse misslyckades!"
 
-#: ../fheroes2/battle/battle_arena.cpp:705
 msgid ""
 "The Sphere of Negation artifact is in effect for this battle, disabling all "
 "combat spells."
@@ -201,151 +161,150 @@ msgstr ""
 "Negationsklotsartefakten är i effn ekt för den här striden och inaktivera "
 "alla stridsbesvärjelser."
 
-#: ../fheroes2/battle/battle_arena.cpp:714
 msgid "You have already cast a spell this round."
 msgstr "Du har redan kastat en besvärjelse denna runda."
 
-#: ../fheroes2/battle/battle_arena.cpp:720
-#: ../fheroes2/battle/battle_arena.cpp:768
 msgid "That spell will affect no one!"
 msgstr "Den besvärjelsen kommer inte att påverka någon!"
 
-#: ../fheroes2/battle/battle_arena.cpp:739
 msgid "You may only summon one type of elemental per combat."
 msgstr "Du kan endast inkalla en elementtyp per strid."
 
-#: ../fheroes2/battle/battle_arena.cpp:745
 msgid "There is no open space adjacent to your hero to summon an Elemental to."
 msgstr ""
 "Det finns ingen öppen plats intill din hjälte för att inkalla ett element."
 
-#: ../fheroes2/battle/battle_board.cpp:968
 msgid ""
 "The Moat reduces by -%{count} the defense skill of any unit and slows to "
 "half movement rate."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:50
-msgid "speed: %{speed}"
+msgid "Speed"
+msgstr "Hastighet"
+
+#, fuzzy
+msgid "Speed: %{speed}"
 msgstr "Hastighet: %{speed}"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:165
+#, fuzzy
+msgid "Auto Spell Casting"
+msgstr "Besvärjelsekastning"
+
+msgid "Grid"
+msgstr ""
+
+#, fuzzy
+msgid "Shadow Movement"
+msgstr "Fortsätt förflyttning"
+
+msgid "Shadow Cursor"
+msgstr ""
+
+msgid "On"
+msgstr ""
+
+#, fuzzy
+msgid "Off"
+msgstr "av"
+
 msgid "The enemy has surrendered!"
 msgstr "Fienden har kapitulerat!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:168
 msgid "The enemy has fled!"
 msgstr "Fienden har flytt!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:170
-#: ../fheroes2/battle/battle_dialogs.cpp:256
 msgid "A glorious victory!"
 msgstr "En ljuvlig seger!"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:175
-msgid "For valor in combat, %{name} receives %{exp} experience"
+#, fuzzy
+msgid "For valor in combat, %{name} receives %{exp} experience."
 msgstr "För sin tapperhet i strid erhåller %{name} %{exp} erfarenhetspoäng"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:184
 msgid "The cowardly %{name} flees from battle."
 msgstr "Fegisen %{name} flyr från striden."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:191
 msgid "%{name} surrenders to the enemy, and departs in shame."
 msgstr "%{name} ger upp till fienden och ger sig av i skam."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:197
 msgid "Your force suffer a bitter defeat, and %{name} abandons your cause."
 msgstr ""
 "Dina trupper lider en bitter förslust och %{name} lämnar dig och dina "
 "trupper."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:249
 msgid "Your force suffer a bitter defeat."
 msgstr "Dina trupper lider en bitter förslust."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:296
 msgid "Battlefield Casualties"
 msgstr "Slagfältsoffer"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:300
 msgid "Attacker"
 msgstr "Angripare"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:312
 msgid "Defender"
 msgstr "Försvarare"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:394
+msgid "You have captured an enemy artifact!"
+msgstr "Du har tillfångatagit fiendens artefakt!"
+
+#, fuzzy
+msgid "Necromancy!"
+msgstr "Svartkonst"
+
+msgid ""
+"Practicing the dark arts of necromancy, you are able to raise %{count} of "
+"the enemy's dead to return under your service as %{monster}."
+msgstr ""
+
 msgid "%{name} the %{race}"
 msgstr "%{name} av %{race}"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:401
-#: ../fheroes2/castle/castle_well.cpp:311
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:194
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:834
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Attack"
 msgstr "Attackera"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:406
-#: ../fheroes2/castle/castle_well.cpp:317
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:206
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:844
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Defense"
 msgstr "Försvar"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:411
-#: ../fheroes2/castle/castle_town.cpp:310
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:854
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:142
-#: ../fheroes2/heroes/heroes_meeting.cpp:292
 msgid "Spell Power"
 msgstr "Besvärjelsestyrka"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:416
-#: ../fheroes2/castle/castle_town.cpp:319
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:864
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:147
-#: ../fheroes2/heroes/heroes_meeting.cpp:296 ../fheroes2/heroes/skill.cpp:151
 msgid "Knowledge"
 msgstr "Kunskap"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:421
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:276
 msgid "Morale"
 msgstr "Moral"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:426
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:286 ../fheroes2/heroes/skill.cpp:338
 msgid "Luck"
 msgstr "Tur"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:431
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:874
-#: ../fheroes2/heroes/heroes_indicator.cpp:247
 msgid "Spell Points"
 msgstr "Besvärjelsepoäng"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
-#: ../fheroes2/gui/interface_buttons.cpp:189
+msgid "Hero's Options"
+msgstr "Hjältealternativ"
+
 msgid "Cast Spell"
 msgstr "Kasta besvärjelse"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
+msgid "Retreat"
+msgstr "Retirera"
+
+msgid "Surrender"
+msgstr "Ge upp"
+
+msgid "Cancel"
+msgstr "Avbryt"
+
+msgid "Hero Screen"
+msgstr "Hjältesskärm"
+
+#, fuzzy
 msgid ""
 "Cast a magical spell. You may only cast one spell per combat round. The "
-"round is reset when every creature has had a turn"
+"round is reset when every creature has had a turn."
 msgstr ""
 "Kasta en besvärjelse. Du kan endast kasta en besvärjelse per runda. Rundan "
 "nollställs när varje varelse har haft sin runda"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:488
-msgid "Retreat"
-msgstr "Retirera"
-
-#: ../fheroes2/battle/battle_dialogs.cpp:488
 msgid ""
 "Retreat your hero, abandoning your creatures. Your hero will be available "
 "for you to recruit again, however, the hero will have only a novice hero's "
@@ -355,11 +314,6 @@ msgstr ""
 "tillgänglig för dig att rekrytera igen, men hjälten kommer endast att ha en "
 "novishjältes styrkor."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:491
-msgid "Surrender"
-msgstr "Ge upp"
-
-#: ../fheroes2/battle/battle_dialogs.cpp:491
 msgid ""
 "Surrendering costs gold. However if you pay the ransom, the hero and all of "
 "his or her surviving creatures will be available to recruit again."
@@ -367,310 +321,227 @@ msgstr ""
 "Att ge upp kostar guld. Men om du betalar lösensumman kommer hjälten och "
 "alla hans eller hennes överlevande kreatur kunna rekryteras igen."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:166
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:227
-msgid "Cancel"
-msgstr "Avbryt"
+#, fuzzy
+msgid "Open Hero Screen to view full information about the hero."
+msgstr "Låter kastaren få detaljerad information om fiendehjältar."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
 msgid "Return to the battle."
 msgstr "Återgå till strid."
 
-#: ../fheroes2/battle/battle_dialogs.cpp:549
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:438
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:497
 msgid "Not enough gold (%{gold})"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:564
 msgid "%{name} states:"
 msgstr "%{name}s status:"
 
-#: ../fheroes2/battle/battle_dialogs.cpp:569
+#, fuzzy
 msgid ""
-"I will accept your surrender and grant you and your troops safe passage for "
-"the price of %{price} gold."
+"\"I will accept your surrender and grant you and your troops safe passage "
+"for the price of %{price} gold.\""
 msgstr ""
 "Jag kommer att acceptera din kapitulation och bevilja dig och dina trupper "
 "en säker passage för ett pris på %{price} guld."
 
-#: ../fheroes2/battle/battle_interface.cpp:613
-#: ../fheroes2/battle/battle_interface.cpp:1401
 msgid "View %{monster} info."
 msgstr "Visa information om %{monster}."
 
-#: ../fheroes2/battle/battle_interface.cpp:1409
 #, fuzzy
 msgid "Shoot %{monster}"
 msgstr ""
 "Mängder av\n"
 "%{monster}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1431
 msgid "Attack %{monster}"
 msgstr "Attackera %{monster}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Fly %{monster} here."
 msgstr "Flyg %{monster} hit."
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Move %{monster} here."
 msgstr "Flytta %{monster} hit."
 
-#: ../fheroes2/battle/battle_interface.cpp:1449
-#: ../fheroes2/battle/battle_interface.cpp:1538
 msgid "Turn %{turn}"
 msgstr "Sväng %{turn}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1475
 msgid "Teleport Here"
 msgstr "Teleportera hit"
 
-#: ../fheroes2/battle/battle_interface.cpp:1479
 msgid "Invalid Teleport Destination"
 msgstr "Ogiltig teleporteringsdestination"
 
-#: ../fheroes2/battle/battle_interface.cpp:1485
 msgid "Cast %{spell} on %{monster}"
 msgstr "Kasta %{spell} på %{monster}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1495
 msgid "Cast %{spell}"
 msgstr "Kasta %{spell}"
 
-#: ../fheroes2/battle/battle_interface.cpp:1501
 msgid "Select Spell Target"
 msgstr "Välj besvärjelsemåltavla"
 
-#: ../fheroes2/battle/battle_interface.cpp:1674
-msgid "Spell cast"
-msgstr "Besvärjelsekastning"
-
-#: ../fheroes2/battle/battle_interface.cpp:1686
 msgid "View Ballista Info"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1699
-#: ../fheroes2/battle/battle_tower.cpp:53
 msgid "Ballista"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1712
 msgid "Auto combat"
 msgstr "Autom. strid"
 
-#: ../fheroes2/battle/battle_interface.cpp:1719
 msgid "Customize system options."
 msgstr "Skräddarsy systeminställningarna."
 
-#: ../fheroes2/battle/battle_interface.cpp:1727
 msgid "Wait this unit"
 msgstr "Vänta denna enhet"
 
-#: ../fheroes2/battle/battle_interface.cpp:1734
 msgid "Skip this unit"
 msgstr "Hoppa över denna enhet"
 
-#: ../fheroes2/battle/battle_interface.cpp:1742
-#: ../fheroes2/battle/battle_interface.cpp:1774
-msgid "Hero's Options"
-msgstr "Hjältealternativ"
-
-#: ../fheroes2/battle/battle_interface.cpp:1753
-#: ../fheroes2/battle/battle_interface.cpp:1785
 msgid "View Opposing Hero"
 msgstr "Visa motstående hjälte"
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Hide logs"
 msgstr "Göm logg"
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Show logs"
 msgstr "Visa logg"
 
-#: ../fheroes2/battle/battle_interface.cpp:1878
 msgid "%{color} cast spell: %{spell}"
 msgstr "%{color} Kastar besvärjelse: %{spell}"
 
-#: ../fheroes2/battle/battle_interface.cpp:2202
 msgid "%{name} skipping turn"
 msgstr "%{name} hoppar över rundan"
 
-#: ../fheroes2/battle/battle_interface.cpp:2203
-msgid ", and get +2 defense"
-msgstr ", och får +2 i försvar"
-
-#: ../fheroes2/battle/battle_interface.cpp:2206
 msgid "%{name} waiting turn"
 msgstr "%{name} inväntar runda"
 
-#: ../fheroes2/battle/battle_interface.cpp:2343
 msgid "%{attacker} do %{damage} damage."
 msgstr "%{attacker} tar %{damage} skada."
 
-#: ../fheroes2/battle/battle_interface.cpp:2497
 msgid "Moved %{monster}: %{src}, %{dst}"
 msgstr "Flyttade %{monster}: %{src}, %{dst}"
 
-#: ../fheroes2/battle/battle_interface.cpp:2612
+#, fuzzy
+msgid "Moved %{monster}"
+msgstr "Flytta %{monster} hit."
+
 msgid "The %{name} resist the spell!"
 msgstr "%{name} motstår besvärjelsen!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2625
 msgid "%{name} casts %{spell} on the %{troop}."
 msgstr "%{name} kastar %{spell} på %{troop}."
 
-#: ../fheroes2/battle/battle_interface.cpp:2630
 msgid "%{name} casts %{spell}."
 msgstr "%{name} kastar %{spell}."
 
-#: ../fheroes2/battle/battle_interface.cpp:2751
-msgid "The %{spell} spell does %{damage} damage to all undead creatures."
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to one undead creature."
 msgstr "Besvärjelsen %{spell} tar %{damage} skada på alla odöda varelser."
 
-#: ../fheroes2/battle/battle_interface.cpp:2754
-msgid "The %{spell} spell does %{damage} damage to all living creatures."
-msgstr "Besvärjelsen %{spell} tar %{damage} skada på alla levande varelser."
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to all undead creatures."
+msgstr "Besvärjelsen %{spell} tar %{damage} skada på alla odöda varelser."
 
-#: ../fheroes2/battle/battle_interface.cpp:2756
+#, fuzzy
+msgid "The %{spell} does %{damage} damage, %{count} creatures perish."
+msgstr "Besvärjelsen %{spell} tar %{damage} skada på alla odöda varelser."
+
 msgid "The %{spell} does %{damage} damage."
 msgstr "Besvärjelsen %{spell} tar %{damage} skada."
 
-#: ../fheroes2/battle/battle_interface.cpp:2797
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to one living creature."
+msgstr "Besvärjelsen %{spell} tar %{damage} skada på alla levande varelser."
+
+#, fuzzy
+msgid "The %{spell} does %{damage} damage to all living creatures."
+msgstr "Besvärjelsen %{spell} tar %{damage} skada på alla levande varelser."
+
 msgid "The Unicorns attack blinds the %{name}!"
 msgstr "Enhörningarna attackerar %{name} i blindo!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2798
 msgid "The Medusas gaze turns the %{name} to stone!"
 msgstr "Medusas blick förvandlar %{name} till sten!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2800
 msgid "The Mummies' curse falls upon the %{name}!"
 msgstr "Mumiens förbannelse har drabbat %{name}!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2801
 msgid "The %{name} are paralyzed by the Cyclopes!"
 msgstr "%{name} blev paralyserad av Cykloperna!"
 
-#: ../fheroes2/battle/battle_interface.cpp:2802
 msgid "The Archmagi dispel all good spells on your %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2820
-msgid "Good luck shines on the  %{attacker}"
+#, fuzzy
+msgid "Good luck shines on the %{attacker}"
 msgstr "God lycka skiner på %{attacker}"
 
-#: ../fheroes2/battle/battle_interface.cpp:2872
 msgid "Bad luck descends on the %{attacker}"
 msgstr "Dålig lycka stiger ned på %{attacker}"
 
-#: ../fheroes2/battle/battle_interface.cpp:2884
 msgid "High morale enables the %{monster} to attack again."
 msgstr "Hög moral låter %{monster} attackera igen."
 
-#: ../fheroes2/battle/battle_interface.cpp:2891
 msgid "Low morale causes the %{monster} to freeze in panic."
 msgstr "Låg moral får %{monster} att stelna i panik."
 
-#: ../fheroes2/battle/battle_interface.cpp:2944
-msgid "Tower do %{damage} damage."
+#, fuzzy
+msgid "%{tower} does %{damage} damage."
 msgstr "Torn tar %{damage} skada."
 
-#: ../fheroes2/battle/battle_interface.cpp:3257
 msgid "MirrorImage created"
 msgstr "Spegelbild skapad"
 
-#: ../fheroes2/battle/battle_interface.cpp:3798
-msgid "MirrorImage ended"
-msgstr "Spegelbild avslutades"
+msgid "The mirror image is destroyed!"
+msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4089
 #, fuzzy
 msgid "Break auto battle?"
 msgstr "Slå på autostrid"
 
-#: ../fheroes2/battle/battle_interface.cpp:4138
 msgid "No spells to cast."
 msgstr "Inga besvärjelser att kasta."
 
-#: ../fheroes2/battle/battle_interface.cpp:4147
 msgid "Are you sure you want to retreat?"
 msgstr "Är du säker på att du vill retirera?"
 
-#: ../fheroes2/battle/battle_interface.cpp:4155
 #, fuzzy
 msgid "Retreat disabled"
 msgstr "Retirera"
 
-#: ../fheroes2/battle/battle_interface.cpp:4169
-msgid "You don't have enough gold!"
-msgstr "Du har inte tillräckligt mycket guld!"
-
-#: ../fheroes2/battle/battle_interface.cpp:4180
 #, fuzzy
 msgid "Surrender disabled"
 msgstr "Ge upp"
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{max}"
 msgstr "Skada: %{max}"
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{min} - %{max}"
 msgstr "Skada: %{min} - %{max}"
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{min} - %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_main.cpp:190
-msgid "You have captured an enemy artifact!"
-msgstr "Du har tillfångatagit fiendens artefakt!"
-
-#: ../fheroes2/battle/battle_main.cpp:241
 msgid ""
-"Through eagle-eyed observation, %{name} is able to learn the magic spell %"
-"{spell}."
+"Through eagle-eyed observation, %{name} is able to learn the magic spell "
+"%{spell}."
 msgstr ""
 "Genom en falkblicksobservation, %{name} kan lära sig besvärjelsen %{spell}."
 
-#: ../fheroes2/battle/battle_main.cpp:280
-msgid ""
-"Practicing the dark arts of necromancy, you are able to raise %{count} of "
-"the enemy's dead to return under your service as %{monster}"
-msgstr ""
-
-#: ../fheroes2/battle/battle_tower.cpp:47 ../fheroes2/castle/castle.cpp:466
 msgid "Left Turret"
 msgstr "Vänster torn"
 
-#: ../fheroes2/battle/battle_tower.cpp:48 ../fheroes2/castle/castle.cpp:467
 msgid "Right Turret"
 msgstr "Höger torn"
 
-#: ../fheroes2/battle/battle_tower.cpp:115
 msgid "The %{name} fires with the strength of %{count} Archers"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:116
 msgid "each with a +%{attack} bonus to their attack skill."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:863
-msgid "%{name} half the enemy troops!"
-msgstr "%{name} halverar fiendetrupperna!"
-
-#: ../fheroes2/battle/battle_troop.cpp:950
 msgid ""
 "The %{artifact} artifact is in effect for this battle, disabling %{spell} "
 "spell."
@@ -678,392 +549,774 @@ msgstr ""
 "%{artifact}-artefakten är i effekt för denna strid och inaktiverar %{spell}-"
 "besvärjelsen."
 
-#: ../fheroes2/battle/battle_troop.cpp:1598
 msgid "%{count} %{name} rise(s) from the dead!"
 msgstr "%{count} %{name} uppstår från de döda!"
 
-#: ../fheroes2/castle/buildinginfo.cpp:258
+#, fuzzy
+msgid "Sorceress Guild"
+msgstr "Häxa"
+
+#, fuzzy
+msgid "Necromancer Guild"
+msgstr "Svartkonstnär"
+
+#, fuzzy
+msgid "Dragon Alliance"
+msgstr "Drakdräpare"
+
+#, fuzzy
+msgid "Elven Alliance"
+msgstr "Ohelig allians"
+
+msgid "Wayward Son"
+msgstr ""
+
+msgid "Uncle Ivan"
+msgstr "Farbror Ivan"
+
+msgid "Force of Arms"
+msgstr ""
+
+#, fuzzy
+msgid "Annexation"
+msgstr "\"Tillägg\""
+
+#, fuzzy
+msgid "Save the Dwarves"
+msgstr "\"Rädda dvärgarna\""
+
+#, fuzzy
+msgid "Carator Mines"
+msgstr "Kristallgruva"
+
+#, fuzzy
+msgid "Turning Point"
+msgstr "\"Vändpunkt\""
+
+#, fuzzy
+msgid "The Gauntlet"
+msgstr "\"Stridshandsken\""
+
+#, fuzzy
+msgid "The Crown"
+msgstr "\"Kronan\""
+
+#, fuzzy
+msgid "Corlagon's Defense"
+msgstr "Draköga"
+
+msgid "Final Justice"
+msgstr ""
+
+msgid "First Blood"
+msgstr ""
+
+#, fuzzy
+msgid "Barbarian Wars"
+msgstr "\"Barbarkrig\""
+
+#, fuzzy
+msgid "Necromancers"
+msgstr "Svartkonstnär"
+
+#, fuzzy
+msgid "Slay the Dwarves"
+msgstr "\"Rädda dvärgarna\""
+
+msgid "Rebellion"
+msgstr ""
+
+#, fuzzy
+msgid "Dragon Master"
+msgstr "\"Drakmästare\""
+
+#, fuzzy
+msgid "Country Lords"
+msgstr "\"Landslordar\""
+
+#, fuzzy
+msgid "Greater Glory"
+msgstr "Stor druid"
+
+#, fuzzy
+msgid "Apocalypse"
+msgstr "\"Apokalyps\""
+
+msgid "Uprising"
+msgstr ""
+
+msgid "Island of Chaos"
+msgstr ""
+
+msgid "Arrow's Flight"
+msgstr ""
+
+msgid "The Abyss"
+msgstr ""
+
+#, fuzzy
+msgid "The Giant's Pass"
+msgstr "Kungligt avfall"
+
+msgid "Aurora Borealis"
+msgstr ""
+
+#, fuzzy
+msgid "Betrayal's End"
+msgstr "\"Förräderi!\""
+
+#, fuzzy
+msgid "Corruption's Heart"
+msgstr "Kaptenens bostad"
+
+msgid "Conquer and Unify"
+msgstr ""
+
+#, fuzzy
+msgid "Border Towns"
+msgstr "Visa Städer"
+
+msgid "The Wayward Son"
+msgstr ""
+
+#, fuzzy
+msgid "Crazy Uncle Ivan"
+msgstr "Farbror Ivan"
+
+#, fuzzy
+msgid "The Southern War"
+msgstr "Den andra sidan"
+
+msgid "Ivory Gates"
+msgstr ""
+
+msgid "The Elven Lands"
+msgstr ""
+
+msgid "The Epic Battle"
+msgstr ""
+
+#, fuzzy
+msgid "The Shrouded Isles"
+msgstr "Smaragdön"
+
+#, fuzzy
+msgid "The Eternal Scrolls"
+msgstr "Smaragdön"
+
+#, fuzzy
+msgid "Power's End"
+msgstr "Effekt"
+
+msgid "Fount of Wizardry"
+msgstr ""
+
+msgid "Stranded"
+msgstr ""
+
+#, fuzzy
+msgid "Pirate Isles"
+msgstr "Piratgrotta"
+
+msgid "King and Country"
+msgstr ""
+
+msgid "Blood is Thicker"
+msgstr ""
+
+msgid ""
+"Roland needs you to defeat the lords near his castle to begin his war of "
+"rebellion against his brother.  They are not allied with each other, so they "
+"will spend most of their time fighting with one another.  Victory is yours "
+"when you have defeated all of their castles and heroes."
+msgstr ""
+
+msgid ""
+"The local lords refuse to swear allegiance to Roland, and must be subdued. "
+"They are wealthy and powerful, so be prepared for a tough fight. Capture all "
+"enemy castles to win."
+msgstr ""
+
+msgid ""
+"Your task is to defend the Dwarves against Archibald's forces. Capture all "
+"of the enemy towns and castles to win, and be sure not to lose all of the "
+"dwarf towns at once, or the enemy will have won."
+msgstr ""
+
+msgid ""
+"You will face four allied enemies in a straightforward fight for resource "
+"and treasure. Capture all of the enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Your enemies are allied against you and start close by, so be ready to come "
+"out fighting. You will need to own all four castles in this small valley to "
+"win."
+msgstr ""
+
+msgid ""
+"The Sorceress' guild of Noraston has requested Roland's aid against an "
+"attack from Archibald's allies. Capture all of the enemy castles to win, and "
+"don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy "
+"castle on an island in the ocean.)"
+msgstr ""
+
+msgid ""
+"Gather as large an army as possible and capture the enemy castle within 8 "
+"weeks. You are opposed by only one enemy, but must travel a long way to get "
+"to the enemy castle. Any troops you have in your army at the end of this "
+"scenario will be with you in the final battle."
+msgstr ""
+
+msgid ""
+"Find the Crown before Archibald's heroes find it. Roland will need the Crown "
+"for the final battle against Archibald."
+msgstr ""
+
+msgid ""
+"Three allied enemies stand before you and victory, including Lord Corlagon. "
+"Roland is in a castle to the northwest, and you will lose if he falls to the "
+"enemy. Remember that capturing Lord Corlagon will ensure that he will not "
+"fight against you in the final scenario."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Archibald to end the war!"
+msgstr ""
+
+msgid ""
+"King Archibald requires you to defeat the three enemies in this region.  "
+"They are not allied with one another, so they will spend most of their "
+"energy fighting amongst themselves.  You will win when you own all of the "
+"enemy castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"You must unify the barbarian tribes of the north by conquering them. As in "
+"the previous mission, the enemy is not allied against you, but they have "
+"more resources at their disposal. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"Do-gooder wizards have taken the Necromancers' castle. You must retake it to "
+"achieve victory. Remember that while you start with a powerful army, you "
+"have no castle and must take one within 7 days, or lose this battle. (Hint: "
+"The nearest castle is to the southeast.)"
+msgstr ""
+
+msgid ""
+"The dwarves need conquering before they can interfere in King Archibald's "
+"plans. Roland's forces have more than one hero and many towns to start with, "
+"so be ready for attack from multiple directions. You must capture all of the "
+"enemy towns and castles to claim victory."
+msgstr ""
+
+msgid ""
+"You must put down a peasant revolt led by Roland's forces. All are allied "
+"against you, but you have Lord Corlagon, an experienced hero, to help you. "
+"Capture all enemy castles to win."
+msgstr ""
+
+msgid ""
+"There are two enemies allied against you in this mission. Both are well "
+"armed and seek to evict you from their island. Avoid them and capture Dragon "
+"City to win"
+msgstr ""
+
+msgid ""
+"Your orders are to conquer the country lords that have sworn to serve "
+"Roland. All of the enemy castles are unified against you. Since you start "
+"without a castle, you must hurry to capture one before the end of the week. "
+"Capture all enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Find the Crown before Roland's heroes find it. Archibald will need the Crown "
+"for the final battle against Roland."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Roland to win the war, and be sure "
+"not to lose Archibald in the fight!"
+msgstr ""
+
+msgid ""
+"Subdue the unruly local lords in order to provide the Empire with facilities "
+"to operate in this region."
+msgstr ""
+
+msgid ""
+"Eliminate all oposition in this area. Then the first piece of the artifact "
+"will be yours."
+msgstr ""
+
+msgid ""
+"The sorceresses to the northeast are rebelling! For the good of the empire "
+"you must quash their feeble uprising on your way to the mountains."
+msgstr ""
+
+msgid ""
+"Having prepared for your arrival, Kraeger has arranged for a force of "
+"necromancers to thwart your quest. You must capture the castle of Scabsdale "
+"before the first day of the third week, or the Necromancers will be too "
+"strong for you."
+msgstr ""
+
+msgid ""
+"The barbarian despot in this area is, as yet, ignorant of your presence. "
+"Quickly, build up your forces before you are discovered and attacked! Secure "
+"the region by subduing all enemy forces."
+msgstr ""
+
+msgid ""
+"The Empire is weak in this region. You will be unable to completely subdue "
+"all forces in this area, so take what you can before reprisal strikes. "
+"Remember, your true goal is to claim the Helmet of Anduran."
+msgstr ""
+
+msgid "For the good of the Empire, eliminate Kraeger."
+msgstr ""
+
+msgid ""
+"At last, you have the opportunity and the facilities to rid the Empire of "
+"the necromancer's evil. Eradicate them completely, and you will be sung as a "
+"hero for all time."
+msgstr ""
+
+msgid ""
+"Conquer and unite all the enemy tribes. Don't lose the hero Jarkonas, the "
+"forefather of all descendants."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Your rival, the Kingdom of Harondale, is attacking weak towns on your "
+"border! Recover from their first strike and crush them completely!"
+msgstr ""
+"Din rival, kungariket Harondale, attackerer din svaga gränsstäder! Återhämta "
+"dig från deras första slag och krossa dem helt."
+
+msgid ""
+"Find your wayward son Joseph who is rumored to be living in the desolate "
+"lands. Do it before the first day of the third month or it will be of no "
+"help to your family."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Rescue your crazy uncle Ivan. Find him before the first day of the fourth "
+"month or it will be no help to your kingdom."
+msgstr ""
+"Rädda din farbror Ivan. Hitta honom inom 4 månader, annars kommer det inte "
+"till någon hjälp för ditt kungarike."
+
+msgid ""
+"Destroy the barbarians who are attacking the southern border of your "
+"kingdom! Recover your fallen towns, and then invade the jungle kingdom. "
+"Leave no enemy standing."
+msgstr ""
+
+msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
+msgstr ""
+
+msgid ""
+"Gain the favor of the elves. They will not allow trees to be chopped down, "
+"so they will send you wood every 2 weeks. You must complete your mission "
+"before the first day of the seventh month, or the kingdom will surely fall."
+msgstr ""
+
+msgid ""
+"This is the final battle against your rival kingdom of Harondale. Eliminate "
+"everyone, and don't lose the hero Jarkonas VI."
+msgstr ""
+
+msgid ""
+"Your mission is to vanquish the warring mages in the magical Shrouded Isles. "
+"The completion of this task will give you a fighting chance against your "
+"rivals."
+msgstr ""
+
+msgid ""
+"The location of the great library has been dicovered! You must make your way "
+"to it, and reclaim the city of Chronos in which it lies."
+msgstr ""
+
+msgid ""
+"Find the Orb of negation, which is said to be buried in this land. There are "
+"clues inscribed on stone obelisks which will help lead you to your price. "
+"Find the orb before the first day of the sixth month, or your rivals will "
+"surely have gotten to the fount before you."
+msgstr ""
+
+msgid ""
+"You must take control of the castle of Magic, where the fount of wizardry "
+"lies. Do this and your victory will be supreme."
+msgstr ""
+
+msgid ""
+"Capture the town on the island off the southeast shore in order to construct "
+"a boat and travel back towards the mainland. Do not lose the hero Gallavant."
+msgstr ""
+
+msgid ""
+"Find and defeat Martine, the pirate leader, who resides in Pirates Cove. Do "
+"not lose Gallavant or your quest will be over."
+msgstr ""
+
+msgid ""
+"Eliminate all the other forces who oppose the rule of Lord Alberon. "
+"Gallavant must not die."
+msgstr ""
+
+msgid ""
+"Overthrow the entrenched monarchy of Lord Alberon, and claim all the land in "
+"your name. Gallavant must not die."
+msgstr ""
+
+msgid " bane"
+msgstr ""
+
+#, fuzzy
+msgid " alliance"
+msgstr "Ohelig allians"
+
+msgid "Carry-over forces"
+msgstr ""
+
+#, fuzzy
+msgid " bonus"
+msgstr "Röd bonus"
+
+msgid " defeated"
+msgstr ""
+
+#, fuzzy
+msgid "Thunder Mace"
+msgstr "Thundax"
+
+#, fuzzy
+msgid "Minor Scroll"
+msgstr "Mindre Kunskapsrulle"
+
+#, fuzzy
+msgid "Dragon Sword"
+msgstr "Drakdräpare"
+
+#, fuzzy
+msgid "Breastplate"
+msgstr "Andurans bröstharnesk"
+
+msgid "Fibzin Medal"
+msgstr ""
+
+msgid "Mage's ring"
+msgstr ""
+
+#, fuzzy
+msgid "Defender Helm"
+msgstr "Försvarare"
+
+#, fuzzy
+msgid "Power Axe"
+msgstr "Effekt"
+
+#, fuzzy
+msgid "Summon Earth"
+msgstr "Inkalla båt"
+
 msgid "The %{building} produces %{monster}."
 msgstr "%{building} skapar %{monster}."
 
-#: ../fheroes2/castle/buildinginfo.cpp:505
 msgid "Requires:"
 msgstr "Kräver:"
 
-#: ../fheroes2/castle/buildinginfo.cpp:597
 msgid "Cannot build. Already built here this turn."
 msgstr "Kan inte byggas. Har redan byggt här denna runda."
 
-#: ../fheroes2/castle/buildinginfo.cpp:601
 msgid "For this action it is necessary first to build a castle."
 msgstr "För denna åtgärd är det nödvändigt att först bygga ett slott."
 
-#: ../fheroes2/castle/buildinginfo.cpp:623
 msgid "Cannot build %{name} because castle is too far from water."
 msgstr ""
 "Kan inte bygga %{name} eftersom slottet är för långt borta från vatten."
 
-#: ../fheroes2/castle/buildinginfo.cpp:631
-msgid "Cannot afford %{name}"
+#, fuzzy
+msgid "Cannot afford %{name}."
 msgstr "Har inte råd med %{name}"
 
-#: ../fheroes2/castle/buildinginfo.cpp:636
-msgid "%{name} is already built"
+#, fuzzy
+msgid "%{name} is already built."
 msgstr "%{name} har redan byggts"
 
-#: ../fheroes2/castle/buildinginfo.cpp:641
-msgid "Cannot build %{name}"
+#, fuzzy
+msgid "Cannot build %{name}."
 msgstr "Kan inte bygga %{name}"
 
-#: ../fheroes2/castle/buildinginfo.cpp:646
-msgid "Build %{name}"
+#, fuzzy
+msgid "Build %{name}."
 msgstr "Bygg %{name}"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Thieves' Guild"
 msgstr "Tjuvarnas förening"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Tavern"
 msgstr "Värdshus"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Shipyard"
 msgstr "Skeppsvarv"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Well"
 msgstr "Brunn"
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Statue"
 msgstr "Staty"
 
-#: ../fheroes2/castle/castle.cpp:467
-#: ../fheroes2/dialog/dialog_marketplace.cpp:212
 msgid "Marketplace"
 msgstr "Marknad"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Moat"
 msgstr "Vall grav"
 
-#: ../fheroes2/castle/castle.cpp:467 ../fheroes2/maps/mp2.cpp:391
 msgid "Castle"
 msgstr "Slott"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Tent"
 msgstr "Telt"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Captain's Quarters"
 msgstr "Kaptenens bostad"
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Mage Guild, Level 1"
 msgstr "Magikerförening, level 1"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 2"
 msgstr "Magikerförening, level 2"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 3"
 msgstr "Magikerförening, level 3"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 4"
 msgstr "Magikerförening, level 4"
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 5"
 msgstr "Magikerförening, level 5"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Farm"
 msgstr "Farm"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Garbage Heap"
 msgstr "Skrot Hög"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Crystal Garden"
 msgstr "Kristallträdgård"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Waterfall"
 msgstr "Vattenfall"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Orchard"
 msgstr "Fruktträdgård"
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Skull Pile"
 msgstr "Benhög"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Fortifications"
 msgstr "Fortifikationer"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Coliseum"
 msgstr "Kolosseum"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Rainbow"
 msgstr "Regnbåge"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Dungeon"
 msgstr "Fängelsehåla"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Library"
 msgstr "Bibliotek"
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Storm"
 msgstr "Storm"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:498
 msgid "Thatched Hut"
 msgstr "Halmtäckt hydda"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Hut"
 msgstr "Hydda"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Treehouse"
 msgstr "Trädhus"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:441
 msgid "Cave"
 msgstr "Grotta"
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Habitat"
 msgstr "Livsmiljö"
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:431
 msgid "Excavation"
 msgstr "Utgrävning"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:477
 msgid "Archery Range"
 msgstr "Bågskyttesräckvidd"
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Stick Hut"
 msgstr "Kvisthydda"
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Cottage"
 msgstr "Stuga"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Crypt"
 msgstr "Krypta"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Pen"
 msgstr "Hägn"
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/maps/mp2.cpp:371
 msgid "Graveyard"
 msgstr "Kyrkogård"
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Blacksmith"
 msgstr "Smed"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Den"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Nest"
 msgstr "Näste"
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Foundry"
 msgstr "Gjuteri"
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:480
-#: ../fheroes2/castle/castle.cpp:487 ../fheroes2/maps/mp2.cpp:427
-#: ../fheroes2/resource/maps_text.cpp:521
 msgid "Pyramid"
 msgstr "Pyramid"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Armory"
 msgstr "Vapensmedja"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Adobe"
 msgstr "Adobe"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Stonehenge"
 msgstr "Stonehenge"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Maze"
 msgstr "Labyrint"
 
-#: ../fheroes2/castle/castle.cpp:478 ../fheroes2/castle/castle.cpp:485
 msgid "Cliff Nest"
 msgstr "Klippnästet"
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Mansion"
 msgstr "Herrgård"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Jousting Arena"
 msgstr "Turneringsarena"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Bridge"
 msgstr "Bro"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
 msgid "Fenced Meadow"
 msgstr "Inhägnad äng"
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Swamp"
 msgstr "Träsk"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Ivory Tower"
 msgstr "Elfenbenstorn"
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Mausoleum"
 msgstr "Mausoleum"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cathedral"
 msgstr "Katedral"
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Red Tower"
 msgstr "Rött torn"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Green Tower"
 msgstr "Grönt torn"
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cloud Castle"
 msgstr "Molnslott"
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Laboratory"
 msgstr "Laboratorium"
 
-#: ../fheroes2/castle/castle.cpp:483 ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Archery Range"
 msgstr "Uppg. Bågskyttesräckvidd"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Stick Hut"
 msgstr "Uppg. Kvisthydda"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Cottage"
 msgstr "Uppg. Stuga"
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Graveyard"
 msgstr "Uppg. Kyrkogård"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Blacksmith"
 msgstr "Uppg. Smed"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Foundry"
 msgstr "Uppg. Gjuteri"
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Pyramid"
 msgstr "Uppg. Pyramid"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Armory"
 msgstr "Uppg. Vapensmedja"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Adobe"
 msgstr "Uppg. Adobe"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Stonehenge"
 msgstr "Uppg. Stonehenge"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Maze"
 msgstr "Uppg. Labyrint"
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Mansion"
 msgstr "Uppg. Herrgård"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Jousting Arena"
 msgstr "Uppg. turneringsarena"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Bridge"
 msgstr "Uppg. Bro"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Ivory Tower"
 msgstr "Uppg. Elfenbenstorn"
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Mausoleum"
 msgstr "Uppg. Mausoleum"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cathedral"
 msgstr "Uppg. Katedral"
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cloud Castle"
 msgstr "Uppg. Molnslott"
 
-#: ../fheroes2/castle/castle.cpp:488
 msgid "Black Tower"
 msgstr "Svart torn"
 
-#: ../fheroes2/castle/castle.cpp:490
 msgid "Shrine"
 msgstr "Tempel"
 
-#: ../fheroes2/castle/castle.cpp:552
+#, fuzzy
 msgid ""
 "The Thieves' Guild provides information on enemy players. Thieves' Guilds "
-"can also provide scouting information on enemy towns."
+"can also provide scouting information on enemy towns. Additional Guilds "
+"provide more information."
 msgstr ""
 "Tjuvarnas förening ger infomation om fiendespelare. Tjuvarnas förening kan "
 "även erbjuda spaningsinformation om fiendetorn."
 
-#: ../fheroes2/castle/castle.cpp:553
 msgid "The Tavern increases morale for troops defending the castle."
 msgstr "Värdshuset höjer moralen för trupperna som försvarar slottet."
 
-#: ../fheroes2/castle/castle.cpp:554
 msgid "The Shipyard allows ships to be built."
 msgstr "Skeppsvarvet låter skepp byggas."
 
-#: ../fheroes2/castle/castle.cpp:555
 msgid ""
 "The Well increases the growth rate of all dwellings by %{count} creatures "
 "per week."
@@ -1071,19 +1324,15 @@ msgstr ""
 "Brunnen höjer tillväxthastigheten för alla bostäder med %{count} varelser "
 "per vecka."
 
-#: ../fheroes2/castle/castle.cpp:556
 msgid "The Statue increases your town's income by %{count} per day."
 msgstr "Statyn höjer din stads inkomst med %{count} per dag."
 
-#: ../fheroes2/castle/castle.cpp:557
 msgid "The Left Turret provides extra firepower during castle combat."
 msgstr "Vänster torn ger extra mycket eldkraft under slottstrid."
 
-#: ../fheroes2/castle/castle.cpp:558
 msgid "The Right Turret provides extra firepower during castle combat."
 msgstr "Höger torn ger extra mycket eldkraft under slottstrid."
 
-#: ../fheroes2/castle/castle.cpp:559
 msgid ""
 "The Marketplace can be used to convert one type of resource into another. "
 "The more marketplaces you control, the better the exchange rate."
@@ -1091,13 +1340,11 @@ msgstr ""
 "Markanden används för att konvertera en ressurs till en annan. Ju mer "
 "marknaded du kontrolerar desto better är växlingskurs."
 
-#: ../fheroes2/castle/castle.cpp:560
 msgid ""
 "The Moat slows attacking units. Any unit entering the moat must end its turn "
 "there and becomes more vulnerable to attack."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:561
 msgid ""
 "The Castle improves town defense and increases income to %{count} gold per "
 "day."
@@ -1105,7 +1352,6 @@ msgstr ""
 "Slottet förbättrar stadens försvar och höjer inkomsten till %{count} guld "
 "per dag."
 
-#: ../fheroes2/castle/castle.cpp:562
 msgid ""
 "The Tent provides workers to build a castle, provided the materials and the "
 "gold are available."
@@ -1113,197 +1359,170 @@ msgstr ""
 "Tältet låter arbetare bygga ett slott, förutsatt att material och guld finns "
 "tillgängligt."
 
-#: ../fheroes2/castle/castle.cpp:563
 msgid ""
 "The Captain's Quarters provides a captain to assist in the castle's defense "
 "when no hero is present."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:564
 msgid ""
 "The Mage Guild allows heroes to learn spells and replenish their spell "
 "points."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:567
 msgid "The Farm increases production of Peasants by %{count} per week."
 msgstr "Farmen höjer produktionen av Bönder med %{count} per vecka."
 
-#: ../fheroes2/castle/castle.cpp:568
 msgid "The Garbage Heap increases production of Goblins by %{count} per week."
 msgstr "Sophögen höjer produktionen av Goblins med %{count} per vecka."
 
-#: ../fheroes2/castle/castle.cpp:569
 msgid ""
 "The Crystal Garden increases production of Sprites by %{count} per week."
 msgstr "Kristallträdgården höjer produktionen av feer med %{count} per vecka."
 
-#: ../fheroes2/castle/castle.cpp:570
 msgid "The Waterfall increases production of Centaurs by %{count} per week."
 msgstr "Vattenfallet höjer produktionen av Kentaurer med %{count} per vecka."
 
-#: ../fheroes2/castle/castle.cpp:571
 msgid "The Orchard increases production of Halflings by %{count} per week."
 msgstr "Fruktträdgården höjer produktionen av hober med %{count} per vecka."
 
-#: ../fheroes2/castle/castle.cpp:572
 msgid "The Skull Pile increases production of Skeletons by %{count} per week."
 msgstr "Benhögen höjer produktionen av skelett med %{count} per vecka."
 
-#: ../fheroes2/castle/castle.cpp:575
 msgid ""
 "The Fortifications increase the toughness of the walls, increasing the "
 "number of turns it takes to knock them down."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:576
 msgid ""
 "The Coliseum provides inspiring spectacles to defending troops, raising "
 "their morale by two during combat."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:577
 msgid "The Rainbow increases the luck of the defending units by two."
 msgstr "Regnbågen höjer turen för försvarsenheterna med två."
 
-#: ../fheroes2/castle/castle.cpp:578
 msgid "The Dungeon increases the income of the town by %{count} / day."
 msgstr "Fängelsehålan höjer stadens inkomst med %{count} per dag."
 
-#: ../fheroes2/castle/castle.cpp:579
 msgid ""
 "The Library increases the number of spells in the Guild by one for each "
 "level of the guild."
 msgstr ""
 "Biblioteket höjer antal besvärjelser i föreningen med en för varje level."
 
-#: ../fheroes2/castle/castle.cpp:580
 msgid "The Storm adds +2 to the power of spells of a defending spell caster."
 msgstr ""
 "Stormen lägger till +2 i besvärjelsernas styrka för en fösvarande "
 "besvärjelsekastare."
 
-#: ../fheroes2/castle/castle.cpp:582
 msgid ""
 "The Shrine increases the necromancy skill of all your necromancers by 10 "
 "percent."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:632
 msgid "Cannot recruit - you already recruit hero in current week."
 msgstr "Kan inte rekrytera - du har redan rekryterat en hjälte denna vecka."
 
-#: ../fheroes2/castle/castle.cpp:645
 #, fuzzy
 msgid "Cannot recruit - guest to guard automove error."
 msgstr "Kan inte rekrytera - du har för många hjältar."
 
-#: ../fheroes2/castle/castle.cpp:651
 msgid "Cannot recruit - you already have a Hero in this town."
 msgstr "Kan inte rekrytera - du har redan en hjälte i denna stad."
 
-#: ../fheroes2/castle/castle.cpp:659
 msgid "Cannot recruit - you have too many Heroes."
 msgstr "Kan inte rekrytera - du har för många hjältar."
 
-#: ../fheroes2/castle/castle.cpp:665
 msgid "Cannot afford a Hero"
 msgstr "Har inte råd med en hjälte"
 
-#: ../fheroes2/castle/castle.cpp:756
 msgid "There is no room in the garrison for this army."
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:272
+msgid "Recruit %{name}"
+msgstr "Rekrytera %{name}"
+
 msgid "Month: %{month}, Week: %{week}, Day: %{day}"
 msgstr "Månad: %{month}, Vecka: %{week}, Dag: %{day}"
 
-#: ../fheroes2/castle/castle_dialog.cpp:393
-#: ../fheroes2/castle/castle_dialog.cpp:396
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:387
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:186
-msgid "Income:"
+#, fuzzy
+msgid "Income"
 msgstr "Inkomst:"
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 #, fuzzy
 msgid "Join Error"
 msgstr "Fel"
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 msgid "Army is full"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
+msgid ""
+"You must purchase a spell book to use the mage guild, but you currently have "
+"no room for a spell book. Try giving one of your artifacts to another hero."
+msgstr ""
+
 msgid "Town"
 msgstr "Stad"
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
 msgid "This town may not be upgraded to a castle."
 msgstr "Denna stad kan inte uppgraderas till ett slott."
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit castle"
+#, fuzzy
+msgid "Exit Castle"
 msgstr "Gå ut från slottet"
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit town"
+#, fuzzy
+msgid "Exit Town"
 msgstr "Gå ut från staden"
 
-#: ../fheroes2/castle/castle_dialog.cpp:730
 #, fuzzy
-msgid "Show income"
+msgid "Show Income"
 msgstr "Visa logg"
 
-#: ../fheroes2/castle/castle_dialog.cpp:734
 msgid "Show previous town"
 msgstr "Visa föregående stad"
 
-#: ../fheroes2/castle/castle_dialog.cpp:738
 msgid "Show next town"
 msgstr "Visa nästa stad"
 
-#: ../fheroes2/castle/castle_dialog.cpp:741
 msgid "Swap Heroes"
 msgstr "Byt hjältar"
 
-#: ../fheroes2/castle/castle_dialog.cpp:744
 msgid "Meeting Heroes"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:749
 msgid "View Hero"
 msgstr "Visa hjälte"
 
-#: ../fheroes2/castle/castle_mageguild.cpp:150
+#, fuzzy
+msgid "The above spells are available here."
+msgstr "Ovanstående besvärjelser har lagts till i din bok."
+
 msgid "The above spells have been added to your book."
 msgstr "Ovanstående besvärjelser har lagts till i din bok."
 
-#: ../fheroes2/castle/castle_tavern.cpp:39
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:748
 msgid "A generous tip for the barkeep yields the following rumor:"
 msgstr "Ett generöst tips från bartendern som uppger detta rykte:"
 
-#: ../fheroes2/castle/castle_town.cpp:54
 msgid "Recruit Hero"
 msgstr "Rekrytera hjälte"
 
-#: ../fheroes2/castle/castle_town.cpp:59
-msgid "%{name} is a level %{value} %{race}"
+#, fuzzy
+msgid "%{name} is a level %{value} %{race} "
 msgstr "%{name} är en level %{value} %{race}"
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with %{count} artifacts"
+#, fuzzy
+msgid "with %{count} artifacts."
 msgstr " med %{count} artefakter"
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with one artifact"
+#, fuzzy
+msgid "with 1 artifact."
 msgstr " med en artefakt"
 
-#: ../fheroes2/castle/castle_town.cpp:283
-#: ../fheroes2/heroes/heroes_dialog.cpp:108
+#, fuzzy
+msgid "without artifacts."
+msgstr " med %{count} artefakter"
+
 msgid ""
 "'Spread' combat formation spreads your armies from the top to the bottom of "
 "the battlefield, with at least one empty space between each army."
@@ -1311,7 +1530,6 @@ msgstr ""
 "'Utspridd' stridsformation sprider ut dina arméer över hela slagfältet med "
 "minst en tomt mellanrum mellan varje armé."
 
-#: ../fheroes2/castle/castle_town.cpp:284
 msgid ""
 "'Grouped' combat formation bunches your army toget her in the center of your "
 "side of the battlefield."
@@ -1319,101 +1537,80 @@ msgstr ""
 "'Grupperad' stridsformation buntar ihop din armé till mitten av din sida av "
 "slagfältet."
 
-#: ../fheroes2/castle/castle_town.cpp:292
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:132
-#: ../fheroes2/heroes/heroes_meeting.cpp:284
 msgid "Attack Skill"
 msgstr "Attackfärdighet"
 
-#: ../fheroes2/castle/castle_town.cpp:301
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:137
-#: ../fheroes2/heroes/heroes_meeting.cpp:288
 msgid "Defense Skill"
 msgstr "Försvarsfärdighet"
 
-#: ../fheroes2/castle/castle_town.cpp:487
-#: ../fheroes2/heroes/heroes_dialog.cpp:334
 msgid "Spread Formation"
 msgstr "Utspridd formation"
 
-#: ../fheroes2/castle/castle_town.cpp:489
-#: ../fheroes2/heroes/heroes_dialog.cpp:337
 msgid "Grouped Formation"
 msgstr "Grupperad formation"
 
-#: ../fheroes2/castle/castle_town.cpp:540
-#: ../fheroes2/castle/castle_town.cpp:553
 msgid "Recruit %{name} the %{race}"
 msgstr "Rekrytera %{name} av %{race}"
 
-#: ../fheroes2/castle/castle_town.cpp:561
 msgid "Set garrison combat formation to 'Spread'"
 msgstr "Ändra besättningens stridsformation till 'Utspridd'"
 
-#: ../fheroes2/castle/castle_town.cpp:564
 msgid "Set garrison combat formation to 'Grouped'"
 msgstr "Ändra besättningens stridsformation till 'Grupperad'"
 
-#: ../fheroes2/castle/castle_town.cpp:567
+#, fuzzy
+msgid "Exit Castle Options"
+msgstr "Slottalternativ"
+
 msgid "Castle Options"
 msgstr "Slottalternativ"
 
-#: ../fheroes2/castle/castle_well.cpp:158
-msgid "Buy Monsters:"
+msgid "Not enough resources to buy monsters."
+msgstr ""
+
+msgid "No monsters available for purchase."
+msgstr ""
+
+#, fuzzy
+msgid "Buy Monsters"
 msgstr "Köp monster:"
 
-#: ../fheroes2/castle/castle_well.cpp:221
 msgid "Town Population Information and Statistics"
 msgstr "Stadsbefolknings- och statistikinfo"
 
-#: ../fheroes2/castle/castle_well.cpp:323
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:231
 msgid "Damage"
 msgstr "Skada"
 
-#: ../fheroes2/castle/castle_well.cpp:329
 msgid "HP"
 msgstr "HP"
 
-#: ../fheroes2/castle/castle_well.cpp:335
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:266
-msgid "Speed"
-msgstr "Hastighet"
-
-#: ../fheroes2/castle/castle_well.cpp:351
 msgid "Growth"
 msgstr "Tillväxt"
 
-#: ../fheroes2/castle/castle_well.cpp:355
 msgid "week"
 msgstr "vecka"
 
-#: ../fheroes2/castle/castle_well.cpp:361
-#: ../fheroes2/kingdom/kingdom_overview.cpp:479
 msgid "Available"
 msgstr "Tillgänglig"
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:89
 msgid "View the entire world."
 msgstr "Visa hela världen."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:90
 msgid "View the obelisk puzzle."
 msgstr "Visa obelisk-pusslet."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:91
 msgid "View information on the scenario you are currently playing."
 msgstr "Visa information om scenariot som du spelar."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:92
 msgid "Dig for the Ultimate Artifact."
 msgstr "Gräv efter den Ultimata artefakten."
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:93
 msgid "Exit this menu without doing anything."
 msgstr "Stäng denna meny utan att spara någonting."
 
-#: ../fheroes2/dialog/dialog_arena.cpp:48
+msgid "Arena"
+msgstr "Arena"
+
 msgid ""
 "You enter the arena and face a pack of vicious lions. You handily defeat "
 "them, to the wild cheers of the crowd.  Impressed by your skill, the aged "
@@ -1423,17 +1620,6 @@ msgstr ""
 "ansträngning och publiken hurrar. Den åldrade gladiatortränaren går med på "
 "att träna dig i en valfri färdighet."
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:154
-msgid ""
-"Your troops can be upgraded, but it will cost you %{ratio} times the "
-"difference in cost for each troop, rounded up to next highest number. Do you "
-"wish to upgrade them?"
-msgstr ""
-"Dina trupper kan uppgraderas, men det kommer att kosta dig %{ratio} gånger "
-"skillnad i kostnad för varje trupp, avrundat uppåt till det nästa högsta "
-"numret. Vill du uppgradera dem?"
-
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:155
 msgid ""
 "Your troops can be upgraded, but it will cost you dearly. Do you wish to "
 "upgrade them?"
@@ -1441,41 +1627,49 @@ msgstr ""
 "Din trupper kan uppgraderas, men det kommer att bli dyrt. Vill du uppgradera "
 "dem?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:166
 msgid "Are you sure you want to dismiss this army?"
 msgstr "Är du säker på att du vill avskeda denna armé?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots Left"
 msgstr "Skott kvar"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots"
 msgstr "Skott"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:244
 msgid "Hit Points"
 msgstr "Hälsopoäng"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:255
 msgid "Hit Points Left"
 msgstr "Hälsopoäng kvar"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:379
+#, fuzzy
+msgid "Followers"
+msgstr "Blommor"
+
 msgid ""
-"The creature is swayed by your diplomatic tongue, and offers to join your "
+"A group of %{monster} with a desire for greater glory wish to join you.\n"
+"Do you accept?"
+msgstr ""
+"En grupp %{monster} med en längtan efter större ära önskar att göra dig "
+"sällskap.\n"
+"Accepterar du?"
+
+#, fuzzy
+msgid ""
+"The %{monster} is swayed by your diplomatic tongue, and offers to join your "
 "army for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
+"Alla %{offer} %{monster} vill förena sig med din armé för en summa på "
+"%{gold} guld.\n"
+"Accepterar du det?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:382
 msgid ""
 "The creatures are swayed by your diplomatic\n"
 "tongue, and make you an offer:\n"
 " \n"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:385
 msgid ""
 "%{offer} of the %{total} %{monster} will join your army, and the rest will "
 "leave you alone, for the sum of %{gold} gold.\n"
@@ -1485,39 +1679,60 @@ msgstr ""
 "ifred, för en summa på %{gold} guld.\n"
 "Accepterar du det?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:387
 msgid ""
 "All %{offer} of the %{monster} will join your army for the sum of %{gold} "
 "gold.\n"
 "Do you accept?"
 msgstr ""
-"Alla %{offer} %{monster} vill förena sig med din armé för en summa på %"
-"{gold} guld.\n"
+"Alla %{offer} %{monster} vill förena sig med din armé för en summa på "
+"%{gold} guld.\n"
 "Accepterar du det?"
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:401
 msgid "(Rate: %{percent})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:451
-msgid ""
-"Not room in\n"
-"the garrison"
+msgid "No room in"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:48
+#, fuzzy
+msgid "the garrison"
+msgstr "trapporna"
+
 msgid "Build a new ship:"
 msgstr "Bygg ett nytt skepp:"
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:63
 msgid "Resource cost:"
 msgstr "Resurskostnad:"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:40
-msgid "For the QVGA version is not available."
-msgstr "Är inte tillgänglig för QVGA-versionen."
+msgid "Load Game"
+msgstr "Ladda spel"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:62
+#, fuzzy
+msgid "No save files to load."
+msgstr "Inga besvärjelser att kasta."
+
+msgid "New Game"
+msgstr "Nytt spel"
+
+msgid "Start a single or multi-player game."
+msgstr "Starta ett spel med en eller flera spelare."
+
+msgid "Load a previously saved game."
+msgstr "Ladda ett tidigare sparat spel."
+
+#, fuzzy
+msgid "Save Game"
+msgstr "Nytt spel"
+
+msgid "Save the current game."
+msgstr ""
+
+msgid "Quit"
+msgstr "Avsluta"
+
+msgid "Quit out of Free Heroes of Might and Magic II."
+msgstr ""
+
 msgid ""
 "Map\n"
 "Difficulty"
@@ -1525,7 +1740,6 @@ msgstr ""
 "Karta\n"
 "Svårighetsgrad"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:65
 msgid ""
 "Game\n"
 "Difficulty"
@@ -1533,25 +1747,18 @@ msgstr ""
 "Spel\n"
 "Svårighetsgrad"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:68
 msgid "Rating"
 msgstr "Betyg"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:71
 msgid "Map Size"
 msgstr "Kartstorlek"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:89
-#: ../fheroes2/system/players.cpp:691
 msgid "Opponents"
 msgstr "Motståndare"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:92
-#: ../fheroes2/system/players.cpp:695
 msgid "Class"
 msgstr "Klass"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:100
 msgid ""
 "Victory\n"
 "Conditions"
@@ -1559,7 +1766,6 @@ msgstr ""
 "Seger\n"
 "Villkor"
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:106
 msgid ""
 "Loss\n"
 "Conditions"
@@ -1567,48 +1773,34 @@ msgstr ""
 "Förlust\n"
 "Villkor"
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:167
 msgid "You cannot select %{resource}!"
 msgstr "Du kan inte välja %{resource}!"
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:173
 msgid "Select count %{resource}:"
 msgstr "Välj antalet %{resource}:"
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:200
 msgid "Set Guardian"
 msgstr "Ange beskyddare"
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:236
-#: ../fheroes2/dialog/dialog_guardian.cpp:292
 msgid "Your army too big!"
 msgstr "Din armé är för stor!"
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:34
-#: ../fheroes2/dialog/dialog_levelup.cpp:44
-#: ../fheroes2/dialog/dialog_levelup.cpp:73
 msgid "%{name} has gained a level."
 msgstr "%{name} har gått upp en level."
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:36
-#: ../fheroes2/dialog/dialog_levelup.cpp:46
-#: ../fheroes2/dialog/dialog_levelup.cpp:75
-msgid "%{skill} Skill +1"
+#, fuzzy
+msgid "%{skill} +1"
 msgstr "Färdighet %{skill} +1"
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:51
 msgid "You have learned %{skill}."
 msgstr "Du har lärt dig %{skill}."
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:93
 msgid "You may learn either:"
 msgstr "Du kan lära dig antingen:"
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:96
 msgid "or"
 msgstr "eller"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:66
 msgid ""
 "Please inspect our fine wares. If you feel like offering a trade, click on "
 "the items you wish to trade with and for."
@@ -1616,7 +1808,6 @@ msgstr ""
 "Var god granska våra fina varor. Om du vill köpa någonting, klickar du på "
 "föremålet du vill köpa med och för."
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:104
 msgid ""
 "You have received quite a bargain. I expect to make no profit on the deal. "
 "Can I interest you in any of my other wares?"
@@ -1624,595 +1815,481 @@ msgstr ""
 "Du har fått ett riktigt fynd. Jag förväntar mig inte att göra någon vinst på "
 "affären. Kan jag intressera dig med några andra varor?"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:130
 msgid "I can offer you %{count} for 1 unit of %{resfrom}."
 msgstr "Jag kan erbjuda dig %{count} för 1 enhet %{resfrom}."
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:136
 msgid "I can offer you 1 unit of %{resto} for %{count} units of %{resfrom}."
 msgstr "Jag kan erbjuda dig 1 enhet %{resto} för %{count} %{resfrom}."
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:164
 msgid "Qty to trade"
 msgstr "Köp antal:"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:235
+msgid "Trading Post"
+msgstr "Handelsstation"
+
 msgid "Your Resources"
 msgstr "Dina resurser"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:257
 msgid "Available Trades"
 msgstr "Tillgänglig handel"
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:573
 msgid "n/a"
 msgstr "Inga"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:77
-msgid "guarded by %{count} of %{monster}"
+#, fuzzy
+msgid "guarded by %{count} %{monster}"
 msgstr "vaktas av %{count} %{monster}"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:149
 msgid "(available: %{count})"
 msgstr "(tillgängligt: %{count})"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:181
 msgid "already learned"
 msgstr "redan inlärt"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:205
 msgid "already knows this skill"
 msgstr "vet redan denna färdighet"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:212
 msgid "already has max skills"
 msgstr "har redan maximala färdigheter"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:260
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:276
 msgid "(already visited)"
 msgstr "(redan besökt)"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
 msgid "(not visited)"
 msgstr "(inte besökt)"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:296
+#, fuzzy
+msgid "Road"
+msgstr "Vägläge"
+
+msgid "(digging ok)"
+msgstr ""
+
+msgid "(no digging)"
+msgstr ""
+
 msgid "penalty: %{cost}"
 msgstr "Straff: %{cost}"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:382
-msgid "Unchartered Territory"
+#, fuzzy
+msgid "Uncharted Territory"
 msgstr "Outforskat område"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:635
 msgid "Defenders:"
 msgstr "Försvarare:"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:674
-#: ../fheroes2/heroes/heroes_indicator.cpp:125
-#: ../fheroes2/heroes/heroes_indicator.cpp:171
 msgid "None"
 msgstr "Inga"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:756
-msgid "%{name} ( Level %{level} )"
+msgid "Unknown"
+msgstr ""
+
+#, fuzzy
+msgid "%{name} (Level %{level})"
 msgstr "%{name} (Level %{level})"
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:884
 msgid "Move Points"
 msgstr "Förflyttningspoäng"
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:40
-#: ../fheroes2/dialog/dialog_recrut.cpp:579
 msgid "Available: %{count}"
 msgstr "Tillgängligt: %{count}"
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:101
-msgid "Cost per troop:"
-msgstr "Kostnad per trupp:"
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:107
-#: ../fheroes2/dialog/dialog_recrut.cpp:506
-msgid "Recruit %{name}"
-msgstr "Rekrytera %{name}"
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:210
 msgid "Number to buy:"
 msgstr "Antal att köpa:"
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:314
 msgid "How many troops to move?"
 msgstr "Hur många trupper ska flyttas?"
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:358
 msgid "Fast separation into slots:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:180
 msgid "File to Save:"
 msgstr "Fil att spara:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:186
 msgid "File to Load:"
 msgstr "Fil att ladda:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:302
 msgid "Are you sure you want to delete file:"
 msgstr "Är du säker på att du vill radera filen:"
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:305
 msgid "Warning!"
 msgstr "Varning!"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:144
-msgid "Maps Difficulty:"
+#, fuzzy
+msgid "Map difficulty:"
 msgstr "Kartornas svårighetsgrad:"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
+msgid "No maps exist at that size"
+msgstr ""
+
 msgid "Small Maps"
 msgstr "Små kartor"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
-msgid "View only maps of size small (36x36)."
+#, fuzzy
+msgid "View only maps of size small (36 x 36)."
 msgstr "Visa bara kartor med storleken (36x36)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
 msgid "Medium Maps"
 msgstr "Mediumstora kartor"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
-msgid "View only maps of size medium (72x72)."
+#, fuzzy
+msgid "View only maps of size medium (72 x 72)."
 msgstr "Visa bara kartor med storleken (72x72)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
 msgid "Large Maps"
 msgstr "Stora kartor"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
-msgid "View only maps of size large (108x108)."
+#, fuzzy
+msgid "View only maps of size large (108 x 108)."
 msgstr "Visa bara kartor med storleken (108x108)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
 msgid "Extra Large Maps"
 msgstr "Extra stora kartor"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
-msgid "View only maps of size extra large (144x144)."
+#, fuzzy
+msgid "View only maps of size extra large (144 x 144)."
 msgstr "Visa bara kartor med storleken (144x144)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "All Maps"
 msgstr "Alla kartor"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "View all maps, regardless of size."
 msgstr "Visa alla kartor, oavsett storlek."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
 msgid "Players Icon"
 msgstr "Spelarikon"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
 msgid ""
-"Indicates how many players total are in the EditScenario. Any positions not "
+"Indicates how many players total are in the scenario. Any positions not "
 "occupied by humans will be occupied by computer players."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
 msgid "Size Icon"
 msgstr "Ikonstorlek"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
+#, fuzzy
 msgid ""
-"Indicates whether the maps is small (36x36), medium (72x72), large "
-"(108x108), or extra large (144x144)."
+"Indicates whether the map\n"
+"is small (36 x 36), medium\n"
+"(72 x 72), large (108 x 108),\n"
+"or extra large (144 x 144)."
 msgstr ""
 "Anger om kartorna är små (36x36), mellan (72x72), stor (108x108), eller "
 "extra stor (144x144)."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "Selected Name"
 msgstr "Välj namn"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "The name of the currently selected map."
 msgstr "Den valda kartans namn."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid "Selected Map Difficulty"
 msgstr "Vald svårighetsgrad för karta"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid ""
 "The map difficulty of the currently selected map.  The map difficulty is "
-"determined by the EditScenario designer. More difficult maps might include "
-"more or stronger enemies, fewer resources, or other special conditions "
-"making things tougher for the human player."
+"determined by the scenario designer. More difficult maps might include more "
+"or stronger enemies, fewer resources, or other special conditions making "
+"things tougher for the human player."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "Selected Description"
 msgstr "Vald beskrivning"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "The description of the currently selected map."
 msgstr "Den valda kartans beskrivning"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
-msgid "OK"
-msgstr "OK"
+msgid "Okay"
+msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
 msgid "Accept the choice made."
 msgstr "Acceptera alla ändringar."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:364
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose all your heroes and towns."
 msgstr "Förlora alla dina hjältar och städer."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:365
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific town."
 msgstr "Förlora en specifik stad."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:366
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific hero."
 msgstr "Förlora en specifik hjälte."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:367
 msgid "Run out of time. Fail to win by a certain point."
 msgstr "Få slut på tid. Misslyckas för att vinna vid en viss punkt."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:370
 msgid "Loss Condition"
 msgstr "Villkor vid förlust"
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:379
 msgid "Defeat all enemy heroes and towns."
 msgstr "Besegra alla fiendehjältar och städer."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:380
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Capture a specific town."
 msgstr "Erövra en specifik stad."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:381
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat a specific hero."
 msgstr "Besegra en specifik hjälte."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:382
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Find a specific artifact."
 msgstr "Hitta en specifik artefakt."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:383
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Your side defeats the opposing side."
 msgstr "Din sida besegrar den moståndarsidan."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:384
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Accumulate a large amount of gold."
 msgstr "Samla ihop en stor summa guld."
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:387
 msgid "Victory Condition"
 msgstr "Villkor vid seger"
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:48
-#: ../fheroes2/heroes/heroes_action.cpp:134
 msgid "one"
 msgstr "ett"
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:51
-#: ../fheroes2/heroes/heroes_action.cpp:135
 msgid "two"
 msgstr "två"
 
-#: ../fheroes2/dialog/dialog_system.cpp:187
-msgid "sound"
-msgstr "ljud"
-
-#: ../fheroes2/dialog/dialog_system.cpp:192
-#: ../fheroes2/dialog/dialog_system.cpp:205
-#: ../fheroes2/dialog/dialog_system.cpp:228
-#: ../fheroes2/dialog/dialog_system.cpp:242
-msgid "off"
-msgstr "av"
-
-#: ../fheroes2/dialog/dialog_system.cpp:200
-msgid "music"
+#, fuzzy
+msgid "Music"
 msgstr "musik"
 
-#: ../fheroes2/dialog/dialog_system.cpp:223
-msgid "hero speed"
+msgid "Toggle ambient music level."
+msgstr ""
+
+msgid "Effects"
+msgstr ""
+
+msgid "Toggle foreground sounds level."
+msgstr ""
+
+msgid "Music Type"
+msgstr ""
+
+msgid "Change the type of music."
+msgstr ""
+
+#, fuzzy
+msgid "Hero Speed"
 msgstr "Hastighet för Hjälte"
 
-#: ../fheroes2/dialog/dialog_system.cpp:237
-msgid "ai speed"
-msgstr "Hastighet för AI"
+msgid "Change the speed at which your heroes move on the main screen."
+msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:251
-msgid "scroll speed"
+#, fuzzy
+msgid "Enemy Speed"
+msgstr "Hastighet"
+
+msgid ""
+"Sets the speed that A.I. heroes move at.  You can also elect not to view A."
+"I. movement at all."
+msgstr ""
+
+#, fuzzy
+msgid "Scroll Speed"
 msgstr "Hastighet för skrollning"
 
-#: ../fheroes2/dialog/dialog_system.cpp:262
-#: ../fheroes2/dialog/dialog_system.cpp:276
+msgid "Sets the speed at which you scroll the window."
+msgstr ""
+
+#, fuzzy
+msgid "Interface Type"
+msgstr "Gränssnitt"
+
+msgid "Toggle the type of interface you want to use."
+msgstr ""
+
 msgid "Interface"
 msgstr "Gränssnitt"
 
-#: ../fheroes2/dialog/dialog_system.cpp:265
+msgid "Toggle interface visibility."
+msgstr ""
+
+#, fuzzy
+msgid "Battles"
+msgstr "Flaska"
+
+msgid "Toggle instant battle mode."
+msgstr ""
+
+msgid "OK"
+msgstr "OK"
+
+#, fuzzy
+msgid "Exit this menu."
+msgstr "Vänta denna enhet"
+
+msgid "off"
+msgstr "av"
+
+msgid "MIDI"
+msgstr ""
+
+#, fuzzy
+msgid "MIDI Expansion"
+msgstr "Herrgård"
+
+msgid "CD Stereo"
+msgstr ""
+
+msgid "External"
+msgstr ""
+
+msgid "Jump"
+msgstr ""
+
+msgid "Don't Show"
+msgstr ""
+
 msgid "Evil"
 msgstr "Ond"
 
-#: ../fheroes2/dialog/dialog_system.cpp:267
 msgid "Good"
 msgstr "God"
 
-#: ../fheroes2/dialog/dialog_system.cpp:281
 msgid "Hide"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:287
 msgid "Show"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:285
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:96
+msgid "Auto Resolve"
+msgstr ""
+
+msgid "Auto, No Spells"
+msgstr ""
+
+msgid "Manual"
+msgstr ""
+
+msgid "Att."
+msgstr ""
+
+msgid "Def."
+msgstr ""
+
+msgid "Power"
+msgstr "Effekt"
+
+#, fuzzy
+msgid "Knowl"
+msgstr "Kunskap"
+
+msgid "Human"
+msgstr ""
+
 msgid "1st"
 msgstr "1:a"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:286
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:97
 msgid "2nd"
 msgstr "2:a"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:98
 msgid "3rd"
 msgstr "3:e"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:288
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:99
 msgid "4th"
 msgstr "4:e"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:289
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:100
 msgid "5th"
 msgstr "5:e"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:290
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:101
 msgid "6th"
 msgstr "6:e"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:305
-msgid "Thieves' Guild: Player RanKings"
+msgid "Oracle: Player Rankings"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:315
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:114
+#, fuzzy
+msgid "Thieves' Guild: Player Rankings"
+msgstr "Tjuvarnas förening"
+
 msgid "Number of Towns:"
 msgstr "Antal städer:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:324
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:123
 msgid "Number of Castles:"
 msgstr "Antal slott:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:333
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:132
 msgid "Number of Heroes:"
 msgstr "Antal hjältar:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:342
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:141
 msgid "Gold in Treasury:"
 msgstr "Guld i skattkammaren:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:351
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:150
 msgid "Wood & Ore:"
 msgstr "Ved & malm:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:360
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:159
 msgid "Gems, Cr, Slf & Mer:"
 msgstr "Andra resurser:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:369
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:168
 msgid "Obelisks Found:"
 msgstr "Hittade obelisker:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:378
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:177
+#, fuzzy
+msgid "Artifacts:"
+msgstr "Artifakter"
+
 msgid "Total Army Strength:"
 msgstr "Total arméstyrka:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:408
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:211
+msgid "Income:"
+msgstr "Inkomst:"
+
 msgid "Best Hero:"
 msgstr "Bästa hjälte:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:417
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:220
 msgid "Best Hero Stats:"
 msgstr "Status för Bästa hjälte:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:426
 msgid "Personality:"
 msgstr "Personlighet:"
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:435
 msgid "Best Monster:"
 msgstr "Bästa monster:"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Easy"
 msgstr "svårighetsgrad|Lätt"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Normal"
 msgstr "Svårighetsgrad|Normalt"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Hard"
 msgstr "Svårighetsgrad|Svårt"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Expert"
 msgstr "Svårighetsgrad|Professionell"
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Impossible"
 msgstr "Svårighetsgrad|Omöjligt"
 
-#: ../fheroes2/game/game.cpp:314
-msgid "Maps Loading..."
+#, fuzzy
+msgid "Map is loading..."
 msgstr "Laddar kartor..."
 
-#: ../fheroes2/game/game_highscores.cpp:239
-#: ../fheroes2/game/game_highscores.cpp:242
+msgid "and more..."
+msgstr ""
+
+msgid "Campaign Scenario loading failure"
+msgstr ""
+
+msgid "Please make sure that campaign files are correct and present."
+msgstr ""
+
 msgid "Unknown Hero"
 msgstr ""
 
-#: ../fheroes2/game/game_highscores.cpp:240
 msgid "Your Name"
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:95
-msgid "Are you sure you want to overwrite the save with this name?"
-msgstr "Är du säker på att du vill skriva över sparningen med detta namn?"
-
-#: ../fheroes2/game/game_io.cpp:191
 msgid ""
-"This file is saved in the \"Price Loyalty\" version.\n"
+"Invalid file game type. Please ensure that you are running the latest type "
+"of save files."
+msgstr ""
+
+msgid ""
+"This file is saved in the \"The Price of Loyalty\" version.\n"
 "Some items may be unavailable."
 msgstr ""
 
-#: ../fheroes2/game/game_mainmenu.cpp:157
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:95
-msgid "Quit"
-msgstr "Avsluta"
-
-#: ../fheroes2/game/game_mainmenu.cpp:157
-msgid "Quit Heroes of Might and Magic and return to the operating system."
-msgstr "Avsluta Heroes of Might and Magic och återgå till operativsystemet."
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:79
-msgid "Load Game"
-msgstr "Ladda spel"
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-msgid "Load a previously saved game."
-msgstr "Ladda ett tidigare sparat spel."
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:91
-msgid "Credits"
-msgstr "Tack till"
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-msgid "View the credits screen."
-msgstr "Visa \"Tack till\"-skärmen."
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:87
-msgid "High Scores"
-msgstr "Poänglistan"
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-msgid "View the high score screen."
-msgstr "Visa Poänglistan."
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:75
-msgid "New Game"
-msgstr "Nytt spel"
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-msgid "Start a single or multi-player game."
-msgstr "Starta ett spel med en eller flera spelare."
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid "Host"
-msgstr "Värd"
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid ""
-"The host sets up the game options. There can only be one host per network "
-"game."
-msgstr ""
-"Värdarna anger spelinställningarna. Det kan endast finnas en värd per "
-"nätverksspel."
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid "Guest"
-msgstr "Gäst"
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid ""
-"The guest waits for the host to set up the game, then is automatically added "
-"in. There can be multiple guests for TCP/IP games."
-msgstr ""
-"Gästen väntar på att värdarna ska sätta igång spelet, sen läggs till "
-"automatiskt. Det kan finnas flera gäster för TCP/IP-spel."
-
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-msgid "Cancel back to the main menu."
-msgstr "Avbryt och gå tillbaka till huvudmenyn."
-
-#: ../fheroes2/game/game_newgame.cpp:214
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:154
-msgid "Standard Game"
-msgstr "Standardspel"
-
-#: ../fheroes2/game/game_newgame.cpp:214
-msgid "A single player game playing out a single map."
-msgstr "En ensam spelare går igenom en karta."
-
-#: ../fheroes2/game/game_newgame.cpp:216
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:162
-msgid "Multi-Player Game"
-msgstr "Flerspelarläge"
-
-#: ../fheroes2/game/game_newgame.cpp:216
-msgid ""
-"A multi-player game, with several human players completing against each "
-"other on a single map."
-msgstr ""
-"Ett spel med flera spelare, där flera mänskliga spelare som tävlar mot "
-"varandra på en karta."
-
-#: ../fheroes2/game/game_newgame.cpp:217
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:83
-msgid "Settings"
-msgstr "Inställningar"
-
-#: ../fheroes2/game/game_newgame.cpp:217
-msgid "FHeroes2 game settings."
-msgstr "Spelinställningar för FHeroes2."
-
-#: ../fheroes2/game/game_newgame.cpp:271
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:219
 msgid "Hot Seat"
 msgstr "Heta stolen"
 
-#: ../fheroes2/game/game_newgame.cpp:271
 msgid ""
 "Play a Hot Seat game, where 2 to 4 players play around the same computer, "
 "switching into the 'Hot Seat' when it is their turn."
@@ -2220,12 +2297,12 @@ msgstr ""
 "Spela Heta stolen, där 2 till 4 spelare spelar på samma dator och sätter sig "
 "i den 'Heta stolen' när det är sin tur."
 
-#: ../fheroes2/game/game_newgame.cpp:279
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:223
+msgid "Cancel back to the main menu."
+msgstr "Avbryt och gå tillbaka till huvudmenyn."
+
 msgid "Network"
 msgstr "Nätverk"
 
-#: ../fheroes2/game/game_newgame.cpp:279
 msgid ""
 "Play a network game, where 2 players use their own computers connected "
 "through a LAN (Local Area Network)."
@@ -2233,11 +2310,136 @@ msgstr ""
 "Spela via nätverk, när 2 spelare spelare på sina egna datorer anslutna genom "
 "LAN (Local Area Network)."
 
-#: ../fheroes2/game/game_newgame.cpp:343
+msgid "Standard Game"
+msgstr "Standardspel"
+
+msgid "A single player game playing out a single map."
+msgstr "En ensam spelare går igenom en karta."
+
+msgid "Campaign Game"
+msgstr "Kampanjspel"
+
+#, fuzzy
+msgid "A single player game playing through a series of maps."
+msgstr "En ensam spelare går igenom en karta."
+
+msgid "Multi-Player Game"
+msgstr "Flerspelarläge"
+
+msgid ""
+"A multi-player game, with several human players completing against each "
+"other on a single map."
+msgstr ""
+"Ett spel med flera spelare, där flera mänskliga spelare som tävlar mot "
+"varandra på en karta."
+
+#, fuzzy
+msgid "Greetings!"
+msgstr "Inställningar"
+
+msgid ""
+"Welcome to Free Heroes of Might and Magic II! Before starting the game "
+"please choose game resolution."
+msgstr ""
+
+msgid "Please Remember"
+msgstr ""
+
+msgid "You can always change game resolution by clicking on the "
+msgstr ""
+
+msgid "door"
+msgstr ""
+
+msgid ""
+" on the left side of main menu.\n"
+"\n"
+"To switch between windowed and full screen modes\n"
+"press "
+msgstr ""
+
+msgid "F4"
+msgstr ""
+
+msgid ""
+" key on the keyboard.\n"
+"\n"
+"Enjoy the game!"
+msgstr ""
+
+msgid "Quit Heroes of Might and Magic and return to the operating system."
+msgstr "Avsluta Heroes of Might and Magic och återgå till operativsystemet."
+
+msgid "Credits"
+msgstr "Tack till"
+
+msgid "View the credits screen."
+msgstr "Visa \"Tack till\"-skärmen."
+
+msgid "High Scores"
+msgstr "Poänglistan"
+
+msgid "View the high score screen."
+msgstr "Visa Poänglistan."
+
+#, fuzzy
+msgid "Select Game Resolution"
+msgstr "Vald beskrivning"
+
+msgid "Change resolution of the game."
+msgstr ""
+
+msgid "Original Campaign"
+msgstr ""
+
+msgid ""
+"Either Roland's or Archibald's campaign from the original Heroes of Might "
+"and Magic II."
+msgstr ""
+
+msgid "Expansion Campaign"
+msgstr ""
+
+msgid "One of the four new campaigns from the Price of Loyalty expansion set."
+msgstr ""
+
+msgid "Host"
+msgstr "Värd"
+
+msgid ""
+"The host sets up the game options. There can only be one host per network "
+"game."
+msgstr ""
+"Värdarna anger spelinställningarna. Det kan endast finnas en värd per "
+"nätverksspel."
+
+msgid "Guest"
+msgstr "Gäst"
+
+msgid ""
+"The guest waits for the host to set up the game, then is automatically added "
+"in. There can be multiple guests for TCP/IP games."
+msgstr ""
+"Gästen väntar på att värdarna ska sätta igång spelet, sen läggs till "
+"automatiskt. Det kan finnas flera gäster för TCP/IP-spel."
+
+#, fuzzy
+msgid "Battle Only"
+msgstr "Stridsdvärg"
+
+msgid "Setup and play a battle without loading any map."
+msgstr ""
+
+msgid "Settings"
+msgstr "Inställningar"
+
+#, fuzzy
+msgid "Experimental game settings."
+msgstr "Spelinställningar för FHeroes2."
+
 msgid "2 Players"
 msgstr "2 Spelare"
 
-#: ../fheroes2/game/game_newgame.cpp:343
 msgid ""
 "Play with 2 human players, and optionally, up, to 4 additional computer "
 "players."
@@ -2245,11 +2447,9 @@ msgstr ""
 "Spela med 2 mänskliga spelare, och eventuellt, med upp till 4 datorstyrda "
 "spelare."
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid "3 Players"
 msgstr "3  Spelare"
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid ""
 "Play with 3 human players, and optionally, up, to 3 additional computer "
 "players."
@@ -2257,11 +2457,9 @@ msgstr ""
 "Spela med 3mänskliga spelare, och eventuellt, med upp till 3 datorstyrda "
 "spelare."
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid "4 Players"
 msgstr "4 Spelare"
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid ""
 "Play with 4 human players, and optionally, up, to 2 additional computer "
 "players."
@@ -2269,58 +2467,45 @@ msgstr ""
 "Spela med 4 mänskliga spelare, och eventuellt, med upp till 2 datorstyrda "
 "spelare."
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid "5 Players"
 msgstr "5  Spelare"
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid ""
 "Play with 5 human players, and optionally, up, to 1 additional computer "
 "players."
 msgstr ""
 "Spela med 4 mänskliga spelare, och eventuellt, med 1 datorstyrd spelare."
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "6 Players"
 msgstr "6  Spelare"
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "Play with 6 human players."
 msgstr "Spela med 6 mänskliga spelare."
 
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat all enemy heroes and capture all enemy towns and castles."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Run out of time. (Fail to win by a certain point.)"
 msgstr "Få slut på tid. (Misslyckas att vinna vid en bestämd punkt.)"
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the castle '%{name}'"
 msgstr "Erövra slottet '%{name}'"
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the town '%{name}'"
 msgstr "Erövra staden '%{name}'"
 
-#: ../fheroes2/game/game_over.cpp:83
 msgid "Defeat the hero '%{name}'"
 msgstr "Besegra hjälten '%{name}'"
 
-#: ../fheroes2/game/game_over.cpp:91
 msgid "Find the ultimate artifact"
 msgstr "Hitta den Ultimata artefakten"
 
-#: ../fheroes2/game/game_over.cpp:95
 msgid "Find the '%{name}' artifact"
 msgstr "Hitta artefakten '%{name}'"
 
-#: ../fheroes2/game/game_over.cpp:102
 msgid "Accumulate %{count} gold"
 msgstr "Samla ihop %{count} guld"
 
-#: ../fheroes2/game/game_over.cpp:106
 msgid ""
 ", or you may win by defeating all enemy heroes and capturing all enemy towns "
 "and castles."
@@ -2328,29 +2513,23 @@ msgstr ""
 ", eller så kan du vinna genom att besegra alla fiendehjältar och tillfångata "
 "alla fiendestäder och slott."
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the castle '%{name}'."
 msgstr "Förlora slottet '%{name}'."
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the town '%{name}'."
 msgstr "Förlora staden '%{name}'."
 
-#: ../fheroes2/game/game_over.cpp:126 ../fheroes2/game/game_over.cpp:145
 msgid "Lose the hero: %{name}."
 msgstr "Förlora hjälten: %{name}."
 
-#: ../fheroes2/game/game_over.cpp:133
 msgid "Fail to win by the end of month %{month}, week %{week}, day %{day}."
 msgstr ""
-"Misslyckas att vinna vid slutet av månaden %{month}, vecka %{week}, dag %"
-"{day}."
+"Misslyckas att vinna vid slutet av månaden %{month}, vecka %{week}, dag "
+"%{day}."
 
-#: ../fheroes2/game/game_over.cpp:145
 msgid "Lose the heroes: %{name}."
 msgstr "Förlora hjältarna: %{name}."
 
-#: ../fheroes2/game/game_over.cpp:167
 msgid ""
 "You captured %{name}!\n"
 "You are victorious."
@@ -2358,7 +2537,6 @@ msgstr ""
 "Du fångade %{name}!\n"
 "Du segrar."
 
-#: ../fheroes2/game/game_over.cpp:175
 msgid ""
 "You have captured the enemy hero %{name}!\n"
 "Your quest is complete."
@@ -2366,7 +2544,6 @@ msgstr ""
 "Du har fångat fiendehjälten %{name}!\n"
 "Ditt uppdrag är slutfört."
 
-#: ../fheroes2/game/game_over.cpp:183
 msgid ""
 "You have found the %{name}.\n"
 "Your quest is complete."
@@ -2374,7 +2551,6 @@ msgstr ""
 "Du har hittat %{name}.\n"
 "Ditt uppdrag är slufört."
 
-#: ../fheroes2/game/game_over.cpp:195
 msgid ""
 "The enemy is beaten.\n"
 "Your side has triumphed!"
@@ -2382,7 +2558,6 @@ msgstr ""
 "Fienden är besegrad.\n"
 "Din sida segrar!"
 
-#: ../fheroes2/game/game_over.cpp:200
 msgid ""
 "You have built up over %{count} gold in your treasury.\n"
 "All enemies bow before your wealth and power."
@@ -2390,7 +2565,6 @@ msgstr ""
 "Du har byggt upp en förmögenhet på över %{count} i din skattkammare.\n"
 "Alla fiender bugar inför din rikedom och makt."
 
-#: ../fheroes2/game/game_over.cpp:222
 msgid ""
 "The enemy has found the %{name}.\n"
 "Your quest is a failure."
@@ -2398,7 +2572,6 @@ msgstr ""
 "Fienden har hittat %{name}.\n"
 "Ditt uppdrag har misslyckats."
 
-#: ../fheroes2/game/game_over.cpp:230
 msgid ""
 "%{color} has fallen!\n"
 "All is lost."
@@ -2406,7 +2579,6 @@ msgstr ""
 "%{color} har fallit!\n"
 "Allt är förlorat."
 
-#: ../fheroes2/game/game_over.cpp:237
 msgid ""
 "The enemy has built up over %{count} gold in his treasury.\n"
 "You must bow done in defeat before his wealth and power."
@@ -2415,11 +2587,9 @@ msgstr ""
 "skattkammare.\n"
 "Du måste buga i förlust inför deras rikedom och makt."
 
-#: ../fheroes2/game/game_over.cpp:243
 msgid "You have been eliminated from the game!!!"
 msgstr "Du har blivit eliminerad från spelet!!!"
 
-#: ../fheroes2/game/game_over.cpp:248
 msgid ""
 "The enemy has captured %{name}!\n"
 "They are triumphant."
@@ -2427,7 +2597,6 @@ msgstr ""
 "Fienden har tillfångatagit %{name}!\n"
 "Dem jublar."
 
-#: ../fheroes2/game/game_over.cpp:257 ../fheroes2/game/game_over.cpp:264
 msgid ""
 "You have lost the hero %{name}.\n"
 "Your quest is over."
@@ -2435,7 +2604,6 @@ msgstr ""
 "Du har förlorat hjälten %{name}.\n"
 "Ditt uppdrag är över."
 
-#: ../fheroes2/game/game_over.cpp:272
 msgid ""
 "You have failed to complete your quest in time.\n"
 "All is lost."
@@ -2443,44 +2611,34 @@ msgstr ""
 "Du har misslyckats att slutföra ditt uppdrag i tid.\n"
 "Allting är förlorat."
 
-#: ../fheroes2/game/game_over.cpp:320
-msgid "%{color} has been vanquished!"
+#, fuzzy
+msgid "%{color} player has been vanquished!"
 msgstr "%{color} har blivit besegrad!"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "Warning"
 msgstr "Varning"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "No maps available!"
 msgstr "Inga kartor tillgängliga!"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Scenario"
 msgstr "Scenario"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Click here to select which scenario to play."
 msgstr "Klicka här för att välja vilket scenario som ska spelas upp."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid "Game Difficulty"
 msgstr "Spelets svårighet"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid ""
 "This lets you change the starting difficulty at which you will play. Higher "
 "difficulty levels start you of with fewer resources, and at the higher "
 "settings, give extra resources to the computer."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid "Difficulty Rating"
 msgstr "Svårighetsgrad"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid ""
 "The difficulty rating reflects a combination of various settings for your "
 "game. This number will be applied to your final score."
@@ -2488,62 +2646,48 @@ msgstr ""
 "Svårighetsgraden reflekterar en kombination av blandande inställningar för "
 "ditt spel. Denna siffra kommer att läggas till i dina slutpoäng."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
 msgid "Click to accept these settings and start a new game."
 msgstr "Klicka för att acceptera dessa inställningar och starta ett nytt spel."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
 msgid "Click to return to the main menu."
 msgstr "Klicka för att gå tillbaka till huvudmenyn."
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:342
 msgid "Scenario:"
 msgstr "Scenario:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:350
 msgid "Game Difficulty:"
 msgstr "Spelets svårighet:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:354
 msgid "Opponents:"
 msgstr "Motståndare:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:358
 msgid "Class:"
 msgstr "Klass:"
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:384
 msgid "Rating %{rating}%"
 msgstr "Ranking %{rating}%"
 
-#: ../fheroes2/game/game_startgame.cpp:226
 msgid "Astrologers proclaim Month of the %{name}."
 msgstr "Astrologerna utropar %{name} månad."
 
-#: ../fheroes2/game/game_startgame.cpp:226
 msgid "Astrologers proclaim Week of the %{name}."
 msgstr "Astrologerna utropar %{name} vecka."
 
-#: ../fheroes2/game/game_startgame.cpp:240
 msgid "After regular growth, population of %{monster} is doubled!"
 msgstr "Efter en vanlig ökning har beståndet av %{monster} fördubblats!"
 
-#: ../fheroes2/game/game_startgame.cpp:252
 msgid " All populations are halved."
 msgstr " All folkmängd är halverad."
 
-#: ../fheroes2/game/game_startgame.cpp:254
 msgid " All dwellings increase population."
 msgstr " Alla bostäder höjer folkmängden."
 
-#: ../fheroes2/game/game_startgame.cpp:283
 msgid ""
 "%{color} player, your heroes abandon you, and you are banished from this "
 "land."
 msgstr ""
 "%{color} spelare, dina hjältar överger dig och du utvisas från detta land."
 
-#: ../fheroes2/game/game_startgame.cpp:290
 msgid ""
 "%{color} player, this is your last day to capture a town, or you will be "
 "banished from this land."
@@ -2551,7 +2695,6 @@ msgstr ""
 "%{color} spelare, detta är din sista dag att erövra en stad, annars kommer "
 "du att bannlysas från detta land."
 
-#: ../fheroes2/game/game_startgame.cpp:295
 msgid ""
 "%{color} player, you only have %{day} days left to capture a town, or you "
 "will be banished from this land."
@@ -2559,11 +2702,10 @@ msgstr ""
 "%{color} spelare, du har %{day} dagar kvar att erövra en stad. Annars kommer "
 "du att bli bannlyst från detta land."
 
-#: ../fheroes2/game/game_startgame.cpp:584
-msgid "%{color} player's turn"
+#, fuzzy
+msgid "%{color} player's turn."
 msgstr "%{color} spelares tur"
 
-#: ../fheroes2/game/game_startgame.cpp:995
 msgid ""
 "%{color} player, you have lost your last town. If you do not conquer another "
 "town in next week, you will be eliminated."
@@ -2571,142 +2713,119 @@ msgstr ""
 "%{color} spelare, du har förlorat din sista stad. Om du inte erövrar en stad "
 "nästa vecka kommer du att bli eliminerad."
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Next Hero"
 msgstr "Nästa hjälte"
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Select the next Hero."
 msgstr "Välj nästa hjälte."
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue Movement"
 msgstr "Fortsätt förflyttning"
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue the Hero's movement along the current path."
 msgstr "Upprepa Hjältens förflyttning längst den aktuella stigen."
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "Kingdom Summary"
 msgstr "Kungarikessammanfattning"
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "View a Summary of your Kingdom."
 msgstr "Visa en sammanfattning av ditt kungarike"
 
-#: ../fheroes2/gui/interface_buttons.cpp:189
 msgid "Cast an adventure spell."
 msgstr "Kasta en avancerad besvärjelse."
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End Turn"
 msgstr "Avsluta runda"
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End your turn and left the computer take its turn."
 msgstr "Avsluta din runda och låt datorn göra sin runda."
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Adventure Options"
 msgstr "Äventyrsinställningar"
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Bring up the adventure options menu."
 msgstr "Tar upp menyn för äventyrinställningar."
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "File Options"
 msgstr "Filalternativ"
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "Bring up the file options menu, alloving you to load menu, save etc."
 msgstr "Tar fram filalternativsmenyn som låter dig ladda, spara etc."
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "System Options"
 msgstr "Systemalternativ"
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "Bring up the system options menu, alloving you to customize your game."
 msgstr ""
 "Tar fram systemalternativsmenyn som låter dig skräddarsy ditt spelande."
 
-#: ../fheroes2/gui/interface_events.cpp:175
 msgid ""
 "One or more heroes may still move, are you sure you want to end your turn?"
 msgstr ""
 "En eller flera hjältar kan fortfarande flytta sig. Är du säker på att du "
 "vill avsluta din runda?"
 
-#: ../fheroes2/gui/interface_events.cpp:212
-msgid "Are you sure you want to restart? (Your current game will be lost)"
+msgid "Are you sure you want to quit?"
+msgstr "Är du säker på att du vill avsluta?"
+
+#, fuzzy
+msgid "Are you sure you want to restart? (Your current game will be lost.)"
 msgstr ""
 "Är du säker på att du vill starta om? (Ditt nuvarande spel kommer att "
 "förloras)"
 
-#: ../fheroes2/gui/interface_events.cpp:276
-msgid "Are you sure you want to quit?"
-msgstr "Är du säker på att du vill avsluta?"
+msgid "Are you sure you want to overwrite the save with this name?"
+msgstr "Är du säker på att du vill skriva över sparningen med detta namn?"
 
-#: ../fheroes2/gui/interface_events.cpp:308
 msgid "Game saved successfully."
 msgstr "Sparning lyckades."
 
-#: ../fheroes2/gui/interface_events.cpp:314
+msgid "There was an issue during saving."
+msgstr ""
+
+#, fuzzy
 msgid ""
-"Are you sure you want to load a new game? (Your current game will be lost)"
+"Are you sure you want to load a new game? (Your current game will be lost.)"
 msgstr ""
 "Är du säker på att du vill ladda ett nytt spel? (Ditt nuvarande spel kommer "
 "att försvinna)"
 
-#: ../fheroes2/gui/interface_events.cpp:353
 msgid "Try looking on land!!!"
 msgstr "Försök att titta på land!!!"
 
-#: ../fheroes2/gui/interface_events.cpp:368
+#, fuzzy
 msgid ""
-"After spending many hours digging here, you have uncovered the %{artifact}"
+"After spending many hours digging here, you have uncovered the %{artifact}."
 msgstr ""
-"Efter att ha spenderat många timmar på att gräva här, har du avtäckt %"
-"{artifact}"
+"Efter att ha spenderat många timmar på att gräva här, har du avtäckt "
+"%{artifact}"
 
-#: ../fheroes2/gui/interface_events.cpp:370
 msgid "Congratulations!"
 msgstr "Gratulerar!"
 
-#: ../fheroes2/gui/interface_events.cpp:384
 msgid "Nothing here. Where could it be?"
 msgstr "Ingenting här. Var kan det vara?"
 
-#: ../fheroes2/gui/interface_events.cpp:395
 msgid "Try searching on clear ground."
 msgstr "Försök att söka på bar mark."
 
-#: ../fheroes2/gui/interface_events.cpp:399
 msgid "Digging for artifacts requires a whole day, try again tomorrow."
 msgstr "Att gräva efter artefakter tar en hel dag. Försök igen imorgon."
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "World Map"
 msgstr "Världskarta"
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "A miniature view of the known world. Left click to move viewing area."
 msgstr ""
 "En miniatyrvy av den kända världen. Vänsterklicka för att flytta "
 "visningsområdet."
 
-#: ../fheroes2/gui/interface_status.cpp:216
 msgid "Month: %{month} Week: %{week}"
 msgstr "Månad: %{month} Vecka: %{week}"
 
-#: ../fheroes2/gui/interface_status.cpp:222
-#: ../fheroes2/kingdom/kingdom_overview.cpp:569
 msgid "Day: %{day}"
 msgstr "Dag: %{day}"
 
-#: ../fheroes2/gui/interface_status.cpp:257
 msgid ""
 "You find a small\n"
 "quantity of %{resource}."
@@ -2714,11 +2833,17 @@ msgstr ""
 "Du hittade en liten\n"
 "summa %{resource}."
 
-#: ../fheroes2/gui/interface_status.cpp:407
 msgid "Status Window"
 msgstr "Statusfönster"
 
-#: ../fheroes2/gui/interface_status.cpp:407
+#, fuzzy
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date."
+msgstr ""
+"Detta fönster ger information om din hjältes eller kungarikes status, och "
+"visar datumet. Vänsterklicka här för att bläddra genom dessa fönster."
+
 msgid ""
 "This window provides information on the status of your hero or kingdom, and "
 "shows the date. Left click here to cycle throungh these windows."
@@ -2726,42 +2851,290 @@ msgstr ""
 "Detta fönster ger information om din hjältes eller kungarikes status, och "
 "visar datumet. Vänsterklicka här för att bläddra genom dessa fönster."
 
-#: ../fheroes2/heroes/heroes_action.cpp:112
+msgid "Necroman"
+msgstr ""
+
+msgid ""
+"This lets you change player starting positions and colors. A particular "
+"color will always start in a particular location. Some positions may only be "
+"played by a computer player or only by a human player."
+msgstr ""
+"Detta låter dig ändra spelarnas startpositioner och färger. En speciell färg "
+"startar alltid vid en speciell plats. Vissa positioner kan endast spelas av "
+"en datorstyrd eller mänsklig spelare."
+
+msgid ""
+"This lets you change the class of a player. Classes are not always "
+"changeable. Depending on the scenario, a player may receive additional towns "
+"and/or heroes not of their primary alignment."
+msgstr ""
+
+msgid "%{color} player"
+msgstr ""
+
+msgid "View %{skill} Info"
+msgstr "Visa info om %{skill}"
+
+msgid "Lord Kilburn"
+msgstr "Lord Kilburn"
+
+#, fuzzy
+msgid "Sir Gallant"
+msgstr "Herr Gallanth"
+
+msgid "Ector"
+msgstr "Ector"
+
+msgid "Gwenneth"
+msgstr "Gwenneth"
+
+msgid "Tyro"
+msgstr "Tyro"
+
+msgid "Ambrose"
+msgstr "Ambrose"
+
+msgid "Ruby"
+msgstr "Ruby"
+
+msgid "Maximus"
+msgstr "Maximus"
+
+msgid "Dimitry"
+msgstr "Dimitry"
+
+msgid "Thundax"
+msgstr "Thundax"
+
+msgid "Fineous"
+msgstr "Fineous"
+
+msgid "Jojosh"
+msgstr "Jojosh"
+
+msgid "Crag Hack"
+msgstr "Crag Hack"
+
+msgid "Jezebel"
+msgstr "Jezebel"
+
+msgid "Jaclyn"
+msgstr "Jaclyn"
+
+msgid "Ergon"
+msgstr "Ergon"
+
+msgid "Tsabu"
+msgstr "Tsabu"
+
+msgid "Atlas"
+msgstr "Atlas"
+
+msgid "Astra"
+msgstr "Astra"
+
+msgid "Natasha"
+msgstr "Natasha"
+
+msgid "Troyan"
+msgstr "Troyan"
+
+msgid "Vatawna"
+msgstr "Vatawna"
+
+msgid "Rebecca"
+msgstr "Rebecca"
+
+msgid "Gem"
+msgstr "Gem"
+
+msgid "Ariel"
+msgstr "Ariel"
+
+msgid "Carlawn"
+msgstr "Carlawn"
+
+msgid "Luna"
+msgstr "Luna"
+
+msgid "Arie"
+msgstr "Arie"
+
+msgid "Alamar"
+msgstr "Alamar"
+
+msgid "Vesper"
+msgstr "Vesper"
+
+msgid "Crodo"
+msgstr "Crodo"
+
+msgid "Barok"
+msgstr "Barok"
+
+msgid "Kastore"
+msgstr "Kastore"
+
+msgid "Agar"
+msgstr "Agar"
+
+msgid "Falagar"
+msgstr "Falagar"
+
+msgid "Wrathmont"
+msgstr "Wrathmont"
+
+msgid "Myra"
+msgstr "Myra"
+
+msgid "Flint"
+msgstr "Flint"
+
+msgid "Dawn"
+msgstr "Dawn"
+
+msgid "Halon"
+msgstr "Halon"
+
+msgid "Myrini"
+msgstr "Myrini"
+
+msgid "Wilfrey"
+msgstr "Wilfrey"
+
+msgid "Sarakin"
+msgstr "Sarakin"
+
+msgid "Kalindra"
+msgstr "Kalindra"
+
+msgid "Mandigal"
+msgstr "Mandigal"
+
+msgid "Zom"
+msgstr "Zom"
+
+msgid "Darlana"
+msgstr "Darlana"
+
+msgid "Zam"
+msgstr "Zam"
+
+msgid "Ranloo"
+msgstr "Ranloo"
+
+msgid "Charity"
+msgstr "Charity"
+
+msgid "Rialdo"
+msgstr "Rialdo"
+
+msgid "Roxana"
+msgstr "Roxana"
+
+msgid "Sandro"
+msgstr "Sandro"
+
+msgid "Celia"
+msgstr "Celia"
+
+msgid "Roland"
+msgstr "Roland"
+
+msgid "Lord Corlagon"
+msgstr "Lord Corlagon"
+
+msgid "Sister Eliza"
+msgstr "Syster Eliza"
+
+msgid "Archibald"
+msgstr "Archibald"
+
+msgid "Lord Halton"
+msgstr "Lord Halton"
+
+#, fuzzy
+msgid "Brother Brax"
+msgstr "Broder Bax"
+
+msgid "Solmyr"
+msgstr "Solmyr"
+
+msgid "Dainwin"
+msgstr "Dainwin"
+
+msgid "Mog"
+msgstr "Mog"
+
+msgid "Joseph"
+msgstr "Joseph"
+
+msgid "Gallavant"
+msgstr "Gallavant"
+
+msgid "Elderian"
+msgstr "Elderian"
+
+msgid "Ceallach"
+msgstr "Ceallach"
+
+msgid "Drakonia"
+msgstr "Drakonia"
+
+msgid "Martine"
+msgstr "Martine"
+
+msgid "Jarkonas"
+msgstr "Jarkonas"
+
+msgid "%{object} robber"
+msgstr ""
+
+msgid "%{object} raided"
+msgstr ""
+
+msgid "You cannot pick up this artifact, you already have a full load!"
+msgstr ""
+
+msgid "The three Anduran artifacts magically combine into one."
+msgstr "De tre Anduranartefakterna kombineras magiskt till en."
+
+msgid "To cast spells, you must first buy a spell book for %{gold} gold."
+msgstr ""
+"För att kasta besvärjelser måste du först och främst köpa en magibok för "
+"%{gold} guld."
+
+msgid "Unfortunately, you seem to be a little short of cash at the moment."
+msgstr "Tyvärr verkar du för tillfället vara på grön kvist."
+
+msgid "Do you wish to buy one?"
+msgstr "Vill du köpa en?"
+
 msgid "%{count} / day"
 msgstr "%{count} / dag"
 
-#: ../fheroes2/heroes/heroes_action.cpp:331
-#: ../fheroes2/heroes/heroes_action.cpp:2199
 msgid "You are unable to recruit at this time, your ranks are full."
 msgstr "Du kan inte rekrytera just nu. Din ranker är fulla."
 
-#: ../fheroes2/heroes/heroes_action.cpp:599
-msgid ""
-"A group of %{monster} with a desire for greater glory wish to join you.\n"
-"Do you accept?"
-msgstr ""
-"En grupp %{monster} med en längtan efter större ära önskar att göra dig "
-"sällskap.\n"
-"Accepterar du?"
+msgid "A whirlpool engulfs your ship."
+msgstr "En strömvirvel uppslukar ditt skepp."
 
-#: ../fheroes2/heroes/heroes_action.cpp:609
-#: ../fheroes2/heroes/heroes_action.cpp:630
+msgid "Some of your army has fallen overboard."
+msgstr "En del av din armé har ramlat överbord."
+
 msgid "Insulted by your refusal of their offer, the monsters attack!"
 msgstr ""
 "Förolämpade av ditt avvisande av deras erbjudande, attackerar monsterna!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:638
 msgid ""
 "The %{monster}, awed by the power of your forces, begin to scatter.\n"
 "Do you wish to pursue and engage them?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:934
 msgid "Ransacking an enemy camp, you discover a hidden cache of treasures."
 msgstr ""
 "När du genomsöker ett fiendeläger hittar du ett gömt förråd av skatter."
 
-#: ../fheroes2/heroes/heroes_action.cpp:966
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with these resources, "
@@ -2771,7 +3144,6 @@ msgstr ""
 "\"Herre, jag har jobbat hårt för att förse dig med dessa resurser, kom "
 "tillbaka nästa vecka för mer.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:967
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there are no resources currently available. Please try "
@@ -2781,7 +3153,6 @@ msgstr ""
 "\"Herre, jag är ledsen, det finns för tillfället inga resurser tillgänliga. "
 "Vänligen försök nästa vecka.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:972
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with this gold, come "
@@ -2791,7 +3162,6 @@ msgstr ""
 "\"Herre, jag har jobbat hårt för att förse dig med detta guld, kom tillbaka "
 "nästa vecka för mer.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:973
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there is no gold currently available. Please try again "
@@ -2801,7 +3171,6 @@ msgstr ""
 "\"Herre, jag är ledsen, det finns för tillfället inget guld tillgänligt. "
 "Vänligen försök nästa vecka.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:979
 msgid ""
 "You've found an abandoned lean-to.\n"
 "Poking about, you discover some resources hidden nearby."
@@ -2809,12 +3178,10 @@ msgstr ""
 "Du har hittat ett övergivet skjul.\n"
 "Efter att ha kikat igenom hittar du några gömda resurser i närheten."
 
-#: ../fheroes2/heroes/heroes_action.cpp:980
 msgid "The lean-to is long abandoned. There is nothing of value here."
 msgstr ""
 "Skjulet är övergivet sedan länge tillbaka. Det finns ingenting av värde här."
 
-#: ../fheroes2/heroes/heroes_action.cpp:985
 msgid ""
 "You catch a leprechaun foolishly sleeping amidst a cluster of magic "
 "mushrooms.\n"
@@ -2822,30 +3189,24 @@ msgid ""
 "precious things."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:986
 msgid ""
 "You've found a magic garden, the kind of place that leprechauns and faeries "
 "like to cavort in, but there is no one here today.\n"
 "Perhaps you should try again next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1023
 msgid "You come upon the remains of an unfortunate adventurer."
 msgstr "Du stöter på kvarlevorna av en olycklig äventyrare."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1034
 msgid "Treasure"
 msgstr "Skatt"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1041
 msgid "Searching through the tattered clothing, you find %{artifact}."
 msgstr "När du söker igenom de trasiga kläderna hittar du %{artifact}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1052
 msgid "Searching through the tattered clothing, you find nothing."
 msgstr "När du söker igenom de trasiga kläderna hittar du ingenting."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1064
 msgid ""
 "You come across an old wagon left by a trader who didn't quite make it to "
 "safe terrain."
@@ -2853,64 +3214,51 @@ msgstr ""
 "Du stöter på en gammal vagn som har övergetts av en försäljare som inte "
 "riktig lyckades komma in på säker terräng."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1075
-#: ../fheroes2/heroes/heroes_action.cpp:1103
 msgid "Unfortunately, others have found it first, and the wagon is empty."
 msgstr "Tyvärr har andra hittat den tidigare, och vagnen är tom."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1082
 msgid "Searching inside, you find the %{artifact}."
 msgstr "När du söker igenom den, hittar du %{artifact}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1093
 msgid "Inside, you find some of the wagon's cargo still intact."
 msgstr "Inuti ser du att några av vagnens packningar fortfarande är orörda."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1123
 msgid "You search through the flotsam, and find some wood and some gold."
 msgstr "Du söker igenom vrakgodset, du hittar lite ved och guld."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1124
 msgid "You search through the flotsam, and find some wood."
 msgstr "Du söker igenom vrakgodset, du hittar lite ved."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1130
 msgid "You search through the flotsam, but find nothing."
 msgstr "Du söker igenom vrakgodset, men du hittar ingenting."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1151
 msgid "Shrine of the 1st Circle"
 msgstr "1:a kretsens tempel"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1152
 msgid ""
 "You come across a small shrine attended by a group of novice acolytes.\n"
-"In exchange for your protection, they agree to teach you a simple spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a simple spell - "
+"'%{spell}'."
 msgstr ""
 "Du hittar ett litet tempel, bevistat av en grupp följeslagare.\n"
 "I utbyte mot ditt beskyddande går de med på att lära dig en komplicerad "
 "besvärjelse - '%{spell}'."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1155
 msgid "Shrine of the 2nd Circle"
 msgstr "2:a kretsens tempel"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1156
 msgid ""
 "You come across an ornate shrine attended by a group of rotund friars.\n"
-"In exchange for your protection, they agree to teach you a spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a spell - "
+"'%{spell}'."
 msgstr ""
 "Du hittar ett utsmyckat tempel, bevistat av en grupp runda munkar.\n"
 "I utbyte mot ditt beskyddande går de med på att lära dig en komplicerad "
 "besvärjelse - '%{spell}'."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1159
 msgid "Shrine of the 3rd Circle"
 msgstr "3:e kretsens tempel"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1160
 msgid ""
 "You come across a lavish shrine attended by a group of high priests.\n"
 "In exchange for your protection, they agree to teach you a sophisticated "
@@ -2920,7 +3268,6 @@ msgstr ""
 "I utbyte mot ditt beskyddande går de med på att lära dig en komplicerad "
 "besvärjelse - '%{spell}'."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1173
 msgid ""
 "\n"
 "Unfortunately, you have no Magic Book to record the spell with."
@@ -2928,7 +3275,6 @@ msgstr ""
 "\n"
 "Tyvärr har du ingen magibok att anteckna besvärjelsen med."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1184
 msgid ""
 "\n"
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
@@ -2937,7 +3283,6 @@ msgstr ""
 "\n"
 "Tyvärr är du inte vis nog att förstå besvärjelsen, så kan inte lära dig den."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1192
 msgid ""
 "\n"
 "Unfortunately, you already have knowledge of this spell, so there is nothing "
@@ -2947,17 +3292,15 @@ msgstr ""
 "Tyvärr har du redan lärt dig denna besvärjelse. De kan inte lära dig "
 "någonting mer."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1215
 msgid ""
-"You approach the hut and observe a witch inside studying an ancient tome on %"
-"{skill}.\n"
+"You approach the hut and observe a witch inside studying an ancient tome on "
+"%{skill}.\n"
 " \n"
 msgstr ""
 "Du närmar dig hyddan och ser en häxa där inne som studerar en uråldrig volym "
 "av %{skill}.\n"
 " \n"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1222
 msgid ""
 "As you approach, she turns and focuses her one glass eye on you.\n"
 "\"You already know everything you deserve to learn!\" the witch screeches. "
@@ -2967,7 +3310,6 @@ msgstr ""
 "\"Du kan redan allting du förtjänar att veta!\" tjuter häxan. \"UT FRÅN MITT "
 "HUS!\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1229
 msgid ""
 "As you approach, she turns and speaks.\n"
 "\"You already know that which I would teach you. I can help you no further.\""
@@ -2976,27 +3318,22 @@ msgstr ""
 "\"Du kan redan allting som jag kan lära dig. Jag kan inte hjälpa dig vidare."
 "\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1236
 msgid ""
 "An ancient and immortal witch living in a hut with bird's legs for stilts "
 "teaches you %{skill} for her own inscrutable purposes."
 msgstr ""
-"En gammal och odödlig häxa bor i en hydda med fågelben som styltor lär dig %"
-"{skill} för hennes egna gåtfulla ändamål."
+"En gammal och odödlig häxa bor i en hydda med fågelben som styltor lär dig "
+"%{skill} för hennes egna gåtfulla ändamål."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1255
 msgid "You drink from the enchanted fountain, but nothing happens."
 msgstr "Du dricker från den förtrollande fontänen, men ingenting händer."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1256
 msgid "As you drink the sweet water, you gain luck for your next battle."
 msgstr "När du dricker det söta vattnet, ökar din tur inför nästa strid."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1260
 msgid "You enter the faerie ring, but nothing happens."
 msgstr "Du kliver in i häxringen, men ingenting händer."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1261
 msgid ""
 "Upon entering the mystical faerie ring, your army gains luck for its next "
 "battle."
@@ -3004,7 +3341,6 @@ msgstr ""
 "När du kliver in i den mystiska häxringen, ökar din armés tur inför nästa "
 "strid."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1265
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "It is supposed to grant luck to visitors, but since the stars are already "
@@ -3014,7 +3350,6 @@ msgstr ""
 "Den är menad för att lyckoönska besökare, men eftersom stjärnorna redan ler "
 "åt dig gör den ingenting."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1266
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "Kissing it is supposed to be lucky, so you do. The stone is very cold to the "
@@ -3023,13 +3358,11 @@ msgstr ""
 "Du har hittat en gammal och vittrad stenuthuggen avgud.\n"
 "Om man kysser den ska den medföra lycka. Stenen är kall vid beröringen."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1270
 msgid "The mermaids silently entice you to return later and be blessed again."
 msgstr ""
 "Sjöjungfrurna lockar dig tyst att komma tillbaka senare och bli välsignad "
 "igen."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1271
 msgid ""
 "The magical, soothing beauty of the Mermaids reaches you and your crew.\n"
 "Just for a moment, you forget your worries and bask in the beauty of the "
@@ -3037,7 +3370,6 @@ msgid ""
 "The mermaids charms bless you with increased luck for your next combat."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1303
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "You are tempted to search it for treasure, but all the old stories warn of "
@@ -3049,7 +3381,6 @@ msgstr ""
 "om hemska förbannelser och odöda väktare.\n"
 "Vill du gå in och söka?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1304
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "Routine exploration reveals that the pyramid is completely empty."
@@ -3057,18 +3388,15 @@ msgstr ""
 "Du stöter på en pyramid av en stor och gammal kung.\n"
 "En rutinerad utforskning avslöjar att pyramiden är helt tom."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1329
 msgid "Unfortunately, you have no Magic Book to record the spell with."
 msgstr "Tyvärr har du ingen magibok att anteckna besvärjelsen med."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1333
 msgid ""
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
 msgstr ""
 "Tyvärr är du inte vis nog att förstå besvärjelsen, så kan inte lära dig den."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1337
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
 "telling the secret of the spell."
@@ -3076,11 +3404,9 @@ msgstr ""
 "Medan du besegrar monstren, dechiffrerar du en uråldrig hieroglyf på väggen "
 "som berättar hemligheten om besvärjelsen."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1374 ../fheroes2/maps/mp2.cpp:469
 msgid "Sign"
 msgstr "Skylt"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1385
 msgid ""
 "A drink at the well is supposed to restore your spell points, but you are "
 "already at maximum."
@@ -3088,15 +3414,12 @@ msgstr ""
 "En klunk från brunnen ska återställa dina magipoäng, men du har redan "
 "maximalt antal magipoäng."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1392
 msgid "A second drink at the well in one day will not help you."
 msgstr "En andra klunk från brunnen på samma dag kommer inte att hjälpa dig."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1399
 msgid "A drink from the well has restored your spell points to maximum."
 msgstr "En klunk från brunnen har återställt dina magipoäng till max."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1424
 msgid ""
 "\"I'm sorry sir,\" The leader of the soldiers says, \"but you already know "
 "everything we have to teach.\""
@@ -3104,11 +3427,9 @@ msgstr ""
 "\"Jag är ledsen herrn,\" säger legosoldatsledaren, \"du vet redan allt vi "
 "kan lära dig\"."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1425
 msgid "The soldiers living in the fort teach you a few new defensive tricks."
 msgstr "Soldaterna som bor i fortet lär dig några nya försvarstricks."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1430
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. \"You're too "
 "advanced for us,\" the mercenary captain says. \"We can teach nothing more.\""
@@ -3117,24 +3438,20 @@ msgstr ""
 "är för avancerade för oss,\" säger legosoldatskaptenen. \"Vi kan inte lära "
 "er någonting mer.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1431
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. The mercenaries "
 "welcome you and your troops and invite you to train with them."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1436
 msgid "\"Go 'way!\", the witch doctor barks, \"you know all I know.\""
 msgstr "\"Ge dig iväg!\", ryter häxdoktorn, \"du vet allt jag vet.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1437
 msgid ""
 "An Orcish witch doctor living in the hut deepens your knowledge of magic by "
 "showing you how to cast stones, read portents, and decipher the intricacies "
 "of chicken entrails."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1442
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, the Druids turn you away, indicating they have nothing "
@@ -3144,7 +3461,6 @@ msgstr ""
 "stenbyggnader. Under tystnad avvisar de dig och påpekar att de inte har "
 "någonting nytt att lära dig."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1443
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, they teach you new ways to cast spells."
@@ -3152,7 +3468,6 @@ msgstr ""
 "Du har hittat en grupp druider som dyrkar en av deras mystiska "
 "stenbyggnader. Under tystnad lär de dig nya sätt att kasta besvärjelser."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1479
 msgid ""
 "You tentatively approach the burial ground of ancient warriors. Do you want "
 "to search the graves?"
@@ -3160,7 +3475,6 @@ msgstr ""
 "Du närmar dig försiktigt gravplatsen som tillhör en uråldrig krigare. Vill "
 "du söka igenom gravarna?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1480
 msgid ""
 "Upon defeating the Zombies you spend several hours searching the graves and "
 "find nothing. Such a despicable act reduces your army's morale."
@@ -3169,18 +3483,16 @@ msgstr ""
 "gravarna och hittar ingenting! En sådan föraktlig handling reducerar din "
 "armés moral."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1481
-msgid "Upon defeating the zomies you search the graves and find something!"
+#, fuzzy
+msgid "Upon defeating the Zombies you search the graves and find something!"
 msgstr ""
 "Medan du besegrar Zombierna söker du igenom gravarna och hittar någonting!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1484
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the shipwreck?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1485
 msgid ""
 "Upon defeating the Ghosts you spend several hours sifting through the debris "
 "and find nothing. Such a despicable act reduces your army's morale."
@@ -3189,19 +3501,16 @@ msgstr ""
 "ruinerna och hittar ingenting! En sådan föraktlig handling reducerar din "
 "armés moral."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1486
 msgid ""
 "Upon defeating the Ghosts you sift through the debris and find something!"
 msgstr ""
 "Medan du besegrar Spökena kikar du igenom ruinerna och hittar någonting!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1489
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the ship?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1490
 msgid ""
 "Upon defeating the Skeletons you spend several hours sifting through the "
 "debris and find nothing. Such a despicable act reduces your army's morale."
@@ -3210,17 +3519,14 @@ msgstr ""
 "ruinerna och hittar ingenting! En sådan föraktlig handling reducerar din "
 "armés moral."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1491
 msgid ""
 "Upon defeating the Skeletons you sift through the debris and find something!"
 msgstr ""
 "Medan du besegrar Skeletten söker du igenom ruinerna och hittar någonting!"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1564
 msgid "Your men spot a navigational buoy, confirming that you are on course."
 msgstr "Dina män hittar en navigeringsboj som bekräftar att du är på rätt väg."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1565
 msgid ""
 "Your men spot a navigational buoy, confirming that you are on course and "
 "increasing their morale."
@@ -3228,7 +3534,6 @@ msgstr ""
 "Dina män hittar en navigeringsboj som bekräftar att du är på rätt väg och "
 "höjer deras moral."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1569
 msgid ""
 "The drink at the oasis is refreshing, but offers no further benefit. The "
 "oasis might help again if you fought a battle first."
@@ -3236,7 +3541,6 @@ msgstr ""
 "En klunk från oasen är uppfriskande, men den erbjuder ingen ytterligare "
 "förmån. Oasen kan hjälpa till igen om du slåss i en strid först."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1570
 msgid ""
 "A drink at the oasis fills your troops with strength and lifts their "
 "spirits.  You can travel a bit further today."
@@ -3244,7 +3548,6 @@ msgstr ""
 "En klunk från oasen fyller din trupper med styrka och lyfter deras stämning. "
 "Du kan resa en bit till idag."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1575
 msgid ""
 "The drink at the watering hole is refreshing, but offers no further benefit. "
 "The watering hole might help again if you fought a battle first."
@@ -3252,7 +3555,6 @@ msgstr ""
 "En klunk från vattenhålet är uppfriskande, men den erbjuder ingen "
 "ytterligare förmån. Oasen kan hjälpa till igen om du slåss i en strid först."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1576
 msgid ""
 "A drink at the watering hole fills your troops with strength and lifts their "
 "spirits. You can travel a bit further today."
@@ -3260,18 +3562,15 @@ msgstr ""
 "En klunk från vattenhålet fyller din trupper med styrka och lyfter deras "
 "stämning. Du kan resa en bit till idag."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1581
 msgid ""
 "It doesn't help to pray twice before a battle. Come back after you've fought."
 msgstr ""
 "Det hjälper inte att be två gånger före en strid. Kom tillbaka när du har "
 "slagits."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1582
 msgid "A visit and a prayer at the temple raises the morale of your troops."
 msgstr "Ett besök och en bön i templet höjer dina truppers moral."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1622
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"I am sorry, my liege, I "
 "have taught you all I can.\""
@@ -3279,7 +3578,6 @@ msgstr ""
 "En gammal riddare dyker upp på lusthusets trapp. \"Jag är ledsen, min herre. "
 "Jag har lärt dig allt jag kan.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1623
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"My liege, I will teach "
 "you all that I know to aid you in your travels.\""
@@ -3287,7 +3585,6 @@ msgstr ""
 "En gammal riddare dyker upp på lusthusets trapp. \"Min herre, jag ska lära "
 "dig allt jag kan för att hjälpa dig på dina resor.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1662
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
 "ocean. Grateful, he says, \"I would give you an artifact as a reward, but "
@@ -3297,36 +3594,27 @@ msgstr ""
 "ocean. Han säger tacksamt, \"Jag skulle ge dig en artefakt som belöning, men "
 "du har ingen plats för den.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1669
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
-"ocean. Grateful, he rewards you for your act of kindness by giving you the %"
-"{art}."
+"ocean. Grateful, he rewards you for your act of kindness by giving you the "
+"%{art}."
 msgstr ""
 "Du har dragit ut en skeppsbruten man från en säker död i en oförlåtande "
 "ocean. Tacksamt ger han dig  %{art} för din vänlighet."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1688 ../fheroes2/heroes/heroes.cpp:941
-msgid "You have no room to carry another artifact!"
-msgstr "Du har inte rum att bära en till artefakt!"
-
-#: ../fheroes2/heroes/heroes_action.cpp:1704
 msgid "A leprechaun offers you the %{art} for the small price of %{gold} Gold."
 msgstr "En pyssling erbjuder dig en %{art} för en lite summa på %{gold} guld."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1709
 msgid ""
-"A leprechaun offers you the %{art} for the small price of %{gold} Gold and %"
-"{count} %{res}."
+"A leprechaun offers you the %{art} for the small price of %{gold} Gold and "
+"%{count} %{res}."
 msgstr ""
-"En pyssling erbjuder dig en %{art} för en lite summa på %{gold} guld och %"
-"{count} %{res}."
+"En pyssling erbjuder dig en %{art} för en lite summa på %{gold} guld och "
+"%{count} %{res}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1718
 msgid "Do you wish to buy this artifact?"
 msgstr "Vill du köpa denna artefakt?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:1731
 msgid ""
 "You try to pay the leprechaun, but realize that you can't afford it. The "
 "leprechaun stamps his foot and ignores you."
@@ -3334,7 +3622,6 @@ msgstr ""
 "Du försöker att betala pysslingen, men du inser att du inte har råd. "
 "Pysslingen stampar med sin fot och ignorerar dig."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1735
 msgid ""
 "Insulted by your refusal of his generous offer, the leprechaun stamps his "
 "foot and ignores you."
@@ -3342,25 +3629,20 @@ msgstr ""
 "Förolämpad av din vägran att neka hans generösa erbjudande, stampar "
 "pysslingen med sin fot och ignorerar dig."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1746
-#: ../fheroes2/heroes/heroes_action.cpp:1821
 msgid "You've found the artifact: "
 msgstr "Du har hittat artefakten: "
 
-#: ../fheroes2/heroes/heroes_action.cpp:1756
 msgid ""
 "You've found the humble dwelling of a withered hermit. The hermit tells you "
 "that he is willing to give the %{art} to the first wise person he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1759
 msgid ""
 "You've come across the spartan quarters of a retired soldier. The soldier "
 "tells you that he is willing to pass on the %{art} to the first true leader "
 "he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1780
 msgid ""
 "You come upon an ancient artifact. As you reach for it, a pack of Rogues "
 "leap out of the brush to guard their stolen loot."
@@ -3368,18 +3650,15 @@ msgstr ""
 "Du stöter på en uråldrig artefakt. När du närmar dig den dyker ett gäng "
 "Skurkar upp från buskarna för att vakta deras stöldgods."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1783
 msgid ""
 "Through a clearing you observe an ancient artifact. Unfortunately, it's "
 "guarded by a nearby %{monster}. Do you want to fight the %{monster} for the "
 "artifact?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1798
 msgid "Victorious, you take your prize, the %{art}."
 msgstr "Segrande tar du ditt pris, %{art}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1810
 msgid ""
 "Discretion is the better part of valor, and you decide to avoid this fight "
 "for today."
@@ -3387,8 +3666,6 @@ msgstr ""
 "Det är bättre att fly än att illa fäkta, så du bestämmer dig för att undvika "
 "denna strid för idag."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1866
-#: ../fheroes2/heroes/heroes_action.cpp:1881
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold pieces."
@@ -3396,7 +3673,6 @@ msgstr ""
 "Efter att ha spenderat flera timmar på att försöka fiska upp kistan ur sjön, "
 "öppnar du den och hittar %{gold} guldmynt."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1872
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold and the %{art}."
@@ -3404,7 +3680,6 @@ msgstr ""
 "Efter att ha spenderat flera timmar på att försöka fiska upp kistan ur sjön, "
 "öppnar du den och hittar %{gold} guld och %{art}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1888
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it, "
 "only to find it empty."
@@ -3412,22 +3687,19 @@ msgstr ""
 "Efter att ha spenderat timmar på att försöka fiska upp skattkistan ur sjön, "
 "öppnar du den, bara för att hitta den tom."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1898
 msgid ""
 "After scouring the area, you fall upon a hidden treasure cache. You may take "
 "the gold or distribute the gold to the peasants for experience. Do you wish "
 "to keep the gold?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1912
 msgid ""
-"After scouring the area, you fall upon a hidden chest, containing the %"
-"{gold} gold pieces."
+"After scouring the area, you fall upon a hidden chest, containing the "
+"%{gold} gold pieces."
 msgstr ""
-"Efter att ha renskrubbat området, finner du en gömd kista som innehåller de %"
-"{gold} guldmynten."
+"Efter att ha renskrubbat området, finner du en gömd kista som innehåller de "
+"%{gold} guldmynten."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1918
 msgid ""
 "After scouring the area, you fall upon a hidden chest, containing the "
 "ancient artifact %{art}."
@@ -3435,7 +3707,6 @@ msgstr ""
 "Efter att ha renskrubbat området, finner du en gömd kista som innehåller den "
 "antika artefakten %{art}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:1942
 msgid ""
 "You stumble upon a dented and tarnished lamp lodged deep in the earth. Do "
 "you wish to rub the lamp?"
@@ -3443,15 +3714,6 @@ msgstr ""
 "Du stöter på en bucklig och matt lampa djupt ner i jorden. Vill du gnida "
 "lampan?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "A whirlpool engulfs your ship."
-msgstr "En strömvirvel uppslukar ditt skepp."
-
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "Some of your army has fallen overboard."
-msgstr "En del av din armé har ramlat överbord."
-
-#: ../fheroes2/heroes/heroes_action.cpp:2045
 msgid ""
 "You come upon an abandoned gold mine. The mine appears to be haunted. Do you "
 "wish to enter?"
@@ -3459,7 +3721,6 @@ msgstr ""
 "Du stöter på en övergiven guldgruva. Gruvan verkar vara hemsökt. Vill du gå "
 "in?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2064
 msgid ""
 "You have taken control of the local Alchemist shop. It will provide you with "
 "%{count} unit of Mercury per day."
@@ -3467,7 +3728,6 @@ msgstr ""
 "Du har tagit kontroll över den lokala Alkemistaffären. Den kommer att förse "
 "dig med %{count} enheter kvicksilver per dag."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2070
 msgid ""
 "You gain control of a sawmill. It will provide you with %{count} units of "
 "wood per day."
@@ -3475,7 +3735,9 @@ msgstr ""
 "Du får kontroll över ett sågverk. Den kommer att förse dig med %{count} "
 "enheter av ved per dag."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2081
+msgid "You beat the Ghosts and are able to restore the mine to production."
+msgstr "Du besegrade spökena och kan återställa gruvans produktion."
+
 msgid ""
 "You gain control of an ore mine. It will provide you with %{count} units of "
 "ore per day."
@@ -3483,7 +3745,6 @@ msgstr ""
 "Du får kontroll över en malmgruva. Den kommer att förse dig med %{count} "
 "enheter av malm per dag."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2083
 msgid ""
 "You gain control of a sulfur mine. It will provide you with %{count} unit of "
 "sulfur per day."
@@ -3491,7 +3752,6 @@ msgstr ""
 "Du får kontroll över en svavelgruva. Den kommer att förse dig med %{count} "
 "enheter av svavel per dag."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2085
 msgid ""
 "You gain control of a crystal mine. It will provide you with %{count} unit "
 "of crystal per day."
@@ -3499,15 +3759,13 @@ msgstr ""
 "Du får kontroll över en kristallgruva. Den kommer att förse dig med %{count} "
 "enheter av kristaller per dag."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2087
 msgid ""
 "You gain control of a gem mine. It will provide you with %{count} unit of "
 "gems per day."
 msgstr ""
-"Du får kontroll över en ädelstensgruva. Den kommer att förse dig med %"
-"{count} enheter av ädelstenar per dag."
+"Du får kontroll över en ädelstensgruva. Den kommer att förse dig med "
+"%{count} enheter av ädelstenar per dag."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2089
 msgid ""
 "You gain control of a gold mine. It will provide you with %{count} gold per "
 "day."
@@ -3515,11 +3773,6 @@ msgstr ""
 "Du får kontroll över en guldgruva. Den kommer att förse dig med %{count} "
 "enheter av guld per dag."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2096
-msgid "You beat the Ghosts and are able to restore the mine to production."
-msgstr "Du besegrade spökena och kan återställa gruvans produktion."
-
-#: ../fheroes2/heroes/heroes_action.cpp:2101
 msgid ""
 "The lighthouse is now under your control, and all of your ships will now "
 "move further each turn."
@@ -3527,11 +3780,9 @@ msgstr ""
 "Fyret är nu under din kontroll och alla dina skepp kommer nu förflytta sig "
 "längre varje runda."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2105
 msgid "You gain control of a %{name}."
 msgstr "Du fick kontroll över en %{name}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2188
 msgid ""
 "A group of %{monster} with a desire for greater glory wish to join you. Do "
 "you accept?"
@@ -3539,11 +3790,9 @@ msgstr ""
 "En grupp %{monster} med en önskan för större ära vill följa med dig. "
 "Accepterar du det?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2215
 msgid "As you approach the dwelling, you notice that there is no one here."
 msgstr "När du närmar dig bostaden upptäcker du att det inte är någon där."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2232
 msgid ""
 "You search the ruins, but the Medusas that used to live here are gone. "
 "Perhaps there will be more next week."
@@ -3551,7 +3800,6 @@ msgstr ""
 "Du söker igenom ruinerna, men Medusorna som brukade bo här är borta. Kanske "
 "det kommer att finnas några där nästa vecka."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2233
 msgid ""
 "You've found some Medusas living in the ruins. They are willing to join your "
 "army for a price. Do you want to recruit Medusas?"
@@ -3559,48 +3807,40 @@ msgstr ""
 "Du har hittat några Medusor som bor i ruinerna. Dem är beredd att förena sig "
 "med din armé för ett pris. Vill du rekrytera Medusorna?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2238
 msgid ""
 "You've found a Sprite Tree City. Unfortunately, none of the Sprites living "
 "there wish to join an army. Maybe next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2239
 msgid ""
 "Some of the Sprites living in the tree city are willing to join your army "
 "for a price. Do you want to recruit Sprites?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2244
 msgid ""
 "A colorful Rogues' wagon stands empty here. Perhaps more Rogues will be here "
 "later."
 msgstr ""
 "En färgglad Skurkvagn står tom här. Kanske det finns fler Skurkar här senare."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2245
 msgid ""
 "Distant sounds of music and laughter draw you to a colorful wagon housing "
 "Rogues. Do you wish to have any Rogues join your army?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2250
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. The "
 "tents are unoccupied. Perhaps more Nomads will be here later."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2251
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. Do you "
 "wish to have any Nomads join you during your travels?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2256
 msgid "The pit of mud bubbles for a minute and then lies still."
 msgstr "Lerpölen bubblar för en stund innan den förblir stilla."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2257
 msgid ""
 "As you approach the bubbling pit of mud, creatures begin to climb out and "
 "position themselves around it. In unison they say: \"Mother Earth would like "
@@ -3610,11 +3850,9 @@ msgstr ""
 "ställa sig runt den. I samklang säger de: \"Moder Jord vill erbjuda dig "
 "några av hennes trupper. Vill du rekrytera Jordelement?\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2261
 msgid "You enter the structure of white stone pillars, and find nothing."
 msgstr "Du kliver in i byggnaden av vita pelare, men du hittar ingenting."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2262
 msgid ""
 "White stone pillars support a roof that rises up to the sky. As you enter "
 "the structure, the dead air of the outside gives way to a whirling gust that "
@@ -3624,24 +3862,20 @@ msgid ""
 "air?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2266
 msgid "No Fire Elementals approach you from the lava pool."
 msgstr "Inga eldelement kommer upp ur lavapölen."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2267
 msgid ""
 "Beneath a structure that serves to hold in heat, Fire Elementals move about "
 "in a fiery pool of molten lava. A group of them approach you and offer their "
 "services. Would you like to recruit Fire Elementals?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2271
 msgid "A face forms in the water for a moment, and then is gone."
 msgstr ""
 "Ett ansikte formar sig i vattnet för ett ögonblick, bara för att försvinna "
 "sen."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2272
 msgid ""
 "Crystalline structures cast shadows over a small reflective pool of water. "
 "You peer into the pool, and a face that is not your own peers back. It asks: "
@@ -3651,29 +3885,24 @@ msgstr ""
 "tittar ned i pölen och ett ansikte som inte är ditt tittar tillbaka. Den "
 "frågar: \"Vill du kalla på vattnets krafter?\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2276
 msgid "This burial site is deathly still."
 msgstr "Denna begravningsplats är dödligt tyst."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2277
 msgid ""
 "Restless spirits of long dead warriors seeking their final resting place "
 "offer to join you in hopes of finding peace. Do you wish to recruit ghosts?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2313
 msgid ""
 "The City of the Dead is empty of life, and empty of unlife as well. Perhaps "
 "some undead will move in next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2314
 msgid ""
 "Some Liches living here are willing to join your army for a price. Do you "
 "want to recruit Liches?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2315
 msgid ""
 "You've found the ruins of an ancient city, now inhabited solely by the "
 "undead. Will you search?"
@@ -3681,13 +3910,11 @@ msgstr ""
 "Du har hittat ruinerna av en antik stad, som nu är endast är bebodd av de "
 "odöda. Vill du söka?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2316
 msgid ""
 "Some of the surviving Liches are impressed by your victory over their "
 "fellows, and offer to join you for a price. Do you want to recruit Liches?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2320
 msgid ""
 "You've found one of those bridges that Trolls are so fond of living under, "
 "but there are none here. Perhaps there will be some next week."
@@ -3695,7 +3922,6 @@ msgstr ""
 "Du har hittat en av dem där broarna som Troll brukar bo under, men det finns "
 "inga där. Kanske det finns några där nästa vecka."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2321
 msgid ""
 "Some Trolls living under a bridge are willing to join your army, but for a "
 "price. Do you want to recruit Trolls?"
@@ -3703,17 +3929,14 @@ msgstr ""
 "Några troll som bor under bron är beredd på att förena sig med din armé mot "
 "ett pris. Vill du rekrytera troll?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2322
 msgid "Trolls living under the bridge challenge you. Will you fight them?"
 msgstr "Trollen som bor under bron utmanar dig. Vill du slåss mot dem?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2323
 msgid ""
 "A few Trolls remain, cowering under the bridge. They approach you and offer "
 "to join your forces as mercenaries. Do you want to buy any Trolls?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2327
 msgid ""
 "The Dragon city has no Dragons willing to join you this week. Perhaps a "
 "Dragon will become available next week."
@@ -3721,7 +3944,6 @@ msgstr ""
 "Drakstaden har inga Drakar som kan förena sig med dig denna vecka. Det "
 "kanske finns en tillgänglig Drake där nästa vecka."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2328
 msgid ""
 "The Dragon city is willing to offer some Dragons for your army for a price. "
 "Do you wish to recruit Dragons?"
@@ -3729,7 +3951,6 @@ msgstr ""
 "Drakstaden är beredd att erbjuda några drakar till din armé för ett pris. "
 "Vill du rekrytera drakar?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2329
 msgid ""
 "You stand before the Dragon City, a place off-limits to mere humans. Do you "
 "wish to violate this rule and challenge the Dragons to a fight?"
@@ -3737,7 +3958,6 @@ msgstr ""
 "Du står inför Drakstaden, en plats på förbjudet område för människor. Vill "
 "du strida mot denna regel och utmana drakarna i en strid?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2330
 msgid ""
 "Having defeated the Dragon champions, the city's leaders agree to supply "
 "some Dragons to your army for a price. Do you wish to recruit Dragons?"
@@ -3745,11 +3965,9 @@ msgstr ""
 "Efter att ha besegrat Drakkrigarna går stadens ledare med på att förse några "
 "Drakar till din armé till ett pris. Vill du rekrytera Drakar?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2389
 msgid "From the observation tower, you are able to see distant lands."
 msgstr "Från observationstornet kan du se avlägsna länder,"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2401
 msgid ""
 "The spring only refills once a week, and someone's already been here this "
 "week."
@@ -3757,7 +3975,6 @@ msgstr ""
 "Källan fylls bara på en gång per vecka och någon har redan varit här denna "
 "vecka."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2407
 msgid ""
 "A drink at the spring is supposed to give you twice your normal spell "
 "points, but you are already at that level."
@@ -3765,7 +3982,6 @@ msgstr ""
 "En klunk från källan ska ge dig dubbelt så många magipoäng, men du är redan "
 "den leveln."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2418
 msgid ""
 "A drink from the spring fills your blood with magic! You have twice your "
 "normal spell points in reserve."
@@ -3773,7 +3989,6 @@ msgstr ""
 "En klunk från källan fyller ditt blod med magi! Du har nu dubbelt så fler "
 "magipoäng."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2437
 msgid ""
 "Recognizing you, the butler refuses to admit you. \"The master,\" he says, "
 "\"will not see the same student twice.\""
@@ -3781,7 +3996,6 @@ msgstr ""
 "Butlern känner igen dig och vägrar släpa in dig. \"Mästaren,\" säger han, "
 "\"vill inte se samma student två gånger.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2457
 msgid ""
 "The butler admits you to see the master of the house. He trains you in the "
 "four skills a hero should know."
@@ -3789,7 +4003,6 @@ msgstr ""
 "Butlern släpper in dig för att få träffa husets mästaren. Han tränar dig i "
 "de fyra färdigheterna som en hjälte borde veta."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2467
 msgid ""
 "The butler opens the door and looks you up and down. \"You are neither "
 "famous nor diplomatic enough to be admitted to see my master,\" he sniffs. "
@@ -3799,7 +4012,6 @@ msgstr ""
 "eller diplomatisk nog för att bli insläppt och för att få se min mästare,\" "
 "han sniffar. \"Kom tillbaka när du tror att du är dig själv värdig.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2510
 msgid ""
 "All of the %{monsters} you have in your army have been trained by the battle "
 "masters of the fort. Your army now contains %{monsters2}."
@@ -3807,21 +4019,19 @@ msgstr ""
 "Alla %{monsters} du har i din armé har tränats av stridsmästarna i fortet. "
 "Din armé innehåller nu %{monsters2}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2513
 msgid ""
-"An unusual alliance of Orcs, Ogres, and Dwarves offer to train (upgrade) any "
+"An unusual alliance of Ogres, Orcs, and Dwarves offer to train (upgrade) any "
 "such troops brought to them. Unfortunately, you have none with you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2524
 msgid "All of your %{monsters} have been upgraded into %{monsters2}."
 msgstr "Alla dina %{monsters} har blivit uppgraderade till %{monsters2}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2527
+#, fuzzy
 msgid ""
 "A blacksmith working at the foundry offers to convert all Pikemen and "
 "Swordsmen's weapons brought to him from iron to steel. He also says that he "
-"knows a process that will convert Iron Golems into Steel Golems.  "
+"knows a process that will convert Iron Golems into Steel Golems. "
 "Unfortunately, you have none of these troops in your army, so he can't help "
 "you."
 msgstr ""
@@ -3830,7 +4040,6 @@ msgstr ""
 "process som konverterar Järngolems till Stålgolems. Olyckligtvis har du inte "
 "någon av dessa i dina arméer, så han kan inte hjälpa dig."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2585
 msgid ""
 "A retired captain living on this refurbished fishing platform offers to sell "
 "you maps of the sea he made in his younger days for 1,000 gold. Do you wish "
@@ -3840,7 +4049,6 @@ msgstr ""
 "dig att köpa hans kartor, som han själv har gjort i hans yngre dagar, för "
 "1,000 guld. Vill du köpa kartorna?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2598
 msgid ""
 "The captain sighs. \"You don't have enough money, eh?  You can't expect me "
 "to give my maps away for free!\""
@@ -3848,11 +4056,9 @@ msgstr ""
 "Kaptenen suckar. \"Du har inte tillräckligt med pengar, va? Du kan inte "
 "förvänta mig att ge bort mina kartor gratis!\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2632
 msgid "You find %{artifact}."
 msgstr "Du hittade %{artifact}."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2655
 msgid ""
 "You come upon an obelisk made from a type of stone you have never seen "
 "before. Staring at it intensely, the smooth surface suddenly changes to an "
@@ -3864,11 +4070,9 @@ msgstr ""
 "Inskriptionen är en del av en förlorad antik karta. Du kopierar snabbt av "
 "den och inskriptionen försvinner lika tvärt som den kom dit."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2659
 msgid "You have already been to this obelisk."
 msgstr "Du har redan varit till denna obelisk."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2671
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"It is good to see "
 "you, my student. I hope my teachings have helped you.\""
@@ -3876,7 +4080,6 @@ msgstr ""
 "När du närmar dig öppnar trädet sina ögon i glädje. \"Vad kul att se dig, "
 "min student. Jag hoppas mina undervisningar har hjälpt dig.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2683
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"Ahh, an "
 "adventurer! Allow me to teach you a little of what I have learned over the "
@@ -3885,11 +4088,9 @@ msgstr ""
 "När du närmar dig öppnar trädet sina ögon i glädje. \"Åh, en äventyrare! Låt "
 "mig lära dig lite grann om vad jag har lärt mig under åren.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2692
 msgid "Upon your approach, the tree opens its eyes in delight."
 msgstr "När du närmar dig öppnar trädet sina ögon i glädje."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2694
 msgid ""
 "\"Ahh, an adventurer! I will be happy to teach you a little of what I have "
 "learned over the ages for a mere %{count} %{res}.\""
@@ -3897,23 +4098,24 @@ msgstr ""
 "\"Aha, en äventyrare! Jag skulle gladeligen lära dig lite om vad jag har "
 "lärt mig under alla år för endast %{count} %{res}.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2696
 msgid "(Just bury it around my roots.)"
 msgstr "(Begrav det bara under mina rötter.)"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2703
 msgid "Tears brim in the eyes of the tree."
 msgstr "Tårar fyller trädets ögon."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2705
 msgid "\"I need %{count} %{res}.\""
 msgstr "\"Jag behöver %{count} %{res}.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2707
 msgid "it whispers. (sniff) \"Well, come back when you can pay me.\""
 msgstr "viskar den. (Sniff) \"Nåja, kom tillbaka när du kan betala mig.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2737
+msgid ""
+"Nestled among the trees sits a blind seer. After explaining the intent of "
+"your journey, the seer activates his crystal ball, allowing you to see the "
+"strengths and weaknesses of your opponents."
+msgstr ""
+
 msgid ""
 "The entrance to the cave is dark, and a foul, sulfurous smell issues from "
 "the cave mouth. Will you enter?"
@@ -3921,7 +4123,6 @@ msgstr ""
 "Ingången till grottan är mörk och en otäck, svavelaktig lukt strömmar från "
 "grottans mynning. Vill du gå in?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2749
 msgid ""
 "You find a powerful and grotesque Demon in the cave. \"Today,\" it rasps, "
 "\"you will fight and surely die. But I will give you a choice of deaths. You "
@@ -3929,57 +4130,48 @@ msgid ""
 "servants?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2759
 msgid ""
 "Upon defeating the daemon's servants, you find a hidden cache with %{count} "
 "gold."
 msgstr ""
-"Medan du besegrar demonens underhuggare hittar du en dolt förråd med %"
-"{count} guld."
+"Medan du besegrar demonens underhuggare hittar du en dolt förråd med "
+"%{count} guld."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2774
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and receive %{exp} experience points."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2784
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and find the %{art} in the back of the cave."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2794
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
-"battle, you slay the monster and receive %{exp) experience points and %"
-"{count} gold."
+"battle, you slay the monster and receive %{exp} experience points and "
+"%{count} gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2809
 msgid ""
 "The Demon leaps upon you and has its claws at your throat before you can "
 "even draw your sword. \"Your life is mine,\" it says. \"I will sell it back "
 "to you for %{count} gold.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2810
 msgid ""
 "Seeing that you do not have %{count} gold, the demon slashes you with its "
 "claws, and the last thing you see is a red haze."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2835
 msgid "Except for evidence of a terrible battle, the cave is empty."
 msgstr ""
 "Förutom bevis på att det har varit ett förskräcklig strid här, är grottan "
 "tom."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2860
 msgid "For %{gold} gold, the alchemist will remove it for you. Do you pay?"
 msgstr "För %{gold} guld kan alkemisten ta bort den åt dig. Vill du betala?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:2871
 msgid ""
 "You hear a voice from behind the locked door, \"You don't have enough gold "
 "to pay for my services.\""
@@ -3987,14 +4179,12 @@ msgstr ""
 "Du hör en röst bakom den låsta dörren, \"Du har inte tillräckligt mycket "
 "guld att betala mina tjänster.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2874
 msgid ""
 "You hear a voice from high above in the tower, \"Go away! I can't help you!\""
 msgstr ""
 "Du hör en röst från högt ovan i tornet, \"Ge dig väg! Jag kan inte hjälpa "
 "dig!\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2886
 msgid ""
 "The head groom approaches you and speaks, \"You already have a fine horse, "
 "and have no inexperienced cavalry which might make use of our trained war "
@@ -4004,7 +4194,6 @@ msgstr ""
 "inget oerfaret kavalleri som kanske skulle kunna ha nytta av våra tränade "
 "stridshästar.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2889
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, his "
@@ -4013,7 +4202,6 @@ msgid ""
 "mounted soldiers, but you have none we can help.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2892
 msgid ""
 "The head groom speaks to you, \"That is a fine looking horse you have. I am "
 "afraid we can give you no better, but the horses your cavalry are riding "
@@ -4021,7 +4209,6 @@ msgid ""
 "would aid your riders greatly. I insist you take them.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2895
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, he will "
@@ -4029,11 +4216,9 @@ msgid ""
 "mounted soldiers, their horses look shoddy and weak.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2922
 msgid "The Arena guards turn you away."
 msgstr "Arenavakterna avvisar dig."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2939
 msgid ""
 "As the sirens sing their eerie song, your small, determined army manages to "
 "overcome the urge to dive headlong into the sea."
@@ -4041,7 +4226,6 @@ msgstr ""
 "När sirenerna sjunger sin spökliga sång lyckas din din lilla beslutsamma "
 "armé överkomma uppmaningen att dyka med huvudet först i havet."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2944
 msgid ""
 "You have your crew stop up their ears with wax before the sirens' eerie song "
 "has any chance of luring them to a watery grave. An eerie wailing song "
@@ -4055,13 +4239,11 @@ msgstr ""
 "faller i trans och dyker i vattnet, där de drunknar. Du är nu klokare för "
 "besöket och tjänar %{exp} erfarenhet."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2964
 msgid ""
 "In a dazzling display of daring, you break into the local jail and free the "
 "hero imprisoned there, who, in return, pledges loyalty to your cause."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2980
 msgid ""
 "You already have %{count} heroes, and regretfully must leave the prisoner in "
 "this jail to languish in agony for untold days."
@@ -4069,17 +4251,14 @@ msgstr ""
 "Du har redan %{count} hjältar och måste ångerfullt lämna fångarna i detta "
 "fängelse för att tvina i smärta för outsägliga dagar."
 
-#: ../fheroes2/heroes/heroes_action.cpp:2991
 msgid ""
 "You enter a rickety hut and talk to the magician who lives there. He tells "
 "you of places near and far which may aid you in your journeys."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3004
 msgid "This eye seems to be intently studying its surroundings."
 msgstr "Detta öga verkar koncentrerat studera sin omgivning."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3015
 msgid ""
 "\"I have a riddle for you,\" the Sphinx says. \"Answer correctly, and you "
 "shall be rewarded. Answer incorrectly, and you shall be eaten. Do you accept "
@@ -4089,11 +4268,15 @@ msgstr ""
 "att bli belönad. Svarar du fel, kommer du att bli uppäten. Accepterar du "
 "utmaningen?\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3017
-msgid "The Sphinx asks you the following riddle: %{riddle}. Your answer?"
+#, fuzzy
+msgid ""
+"The Sphinx asks you the following riddle:\n"
+" \n"
+"'%{riddle}'\n"
+" \n"
+"Your answer?"
 msgstr "Sfinxen frågar dig följande gåta: %{riddle}. Vad är ditt svar?"
 
-#: ../fheroes2/heroes/heroes_action.cpp:3025
 msgid ""
 "Looking somewhat disappointed, the Sphinx sighs. You've answered my riddle "
 "so here's your reward. Now begone."
@@ -4101,7 +4284,6 @@ msgstr ""
 "Något besviken säger sfinxen. \"Du har svarat på min gåta så här är din "
 "belöning. Ge sig av nu.\""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3052
 msgid ""
 "\"You guessed incorrectly,\" the Sphinx says, smiling. The Sphinx swipes at "
 "you with a paw, knocking you to the ground. Another blow makes the world go "
@@ -4111,11 +4293,9 @@ msgstr ""
 "marken med en tass. Ett till slag får världen att slockna och du vet inte av "
 "någonting mer."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3060
 msgid "You come across a giant Sphinx. The Sphinx remains strangely quiet."
 msgstr "Du möter en gigantisk sfinx. Sfinxen kvarstår ovanligt tyst."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3073
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -4127,7 +4307,6 @@ msgstr ""
 "\"Säg nyckeln och du kan passera.\"\n"
 "När du säger det magiska ordet tonar den glöder barriären bort."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3083
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -4139,7 +4318,6 @@ msgstr ""
 "\"Säg nyckeln och du kan passera.\"\n"
 "Du pratar, men ingenting händer."
 
-#: ../fheroes2/heroes/heroes_action.cpp:3093
 msgid ""
 "You enter the tent and see an old woman gazing into a magic gem. She looks "
 "up and says,\n"
@@ -4151,7 +4329,6 @@ msgstr ""
 "\"I mina resor har jag lärt mig mycket om mystisk magi. Ett stor orakel "
 "lärde mig denna färdighet. Jag har svaret du söker.\""
 
-#: ../fheroes2/heroes/heroes_base.cpp:401
 msgid ""
 "That spell costs %{mana} mana. You only have %{point} mana, so you can't "
 "cast the spell."
@@ -4159,320 +4336,10 @@ msgstr ""
 "Den besvärjelsen kostar %{mana} mana. Du har bara %{point} mana, så du kan "
 "inte kasta besvärjelsen."
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Lord Kilburn"
-msgstr "Lord Kilburn"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Sir Gallanth"
-msgstr "Herr Gallanth"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ector"
-msgstr "Ector"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Gwenneth"
-msgstr "Gwenneth"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Tyro"
-msgstr "Tyro"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ambrose"
-msgstr "Ambrose"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ruby"
-msgstr "Ruby"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Maximus"
-msgstr "Maximus"
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Dimitry"
-msgstr "Dimitry"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Thundax"
-msgstr "Thundax"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Fineous"
-msgstr "Fineous"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jojosh"
-msgstr "Jojosh"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Crag Hack"
-msgstr "Crag Hack"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jezebel"
-msgstr "Jezebel"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jaclyn"
-msgstr "Jaclyn"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Ergon"
-msgstr "Ergon"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Tsabu"
-msgstr "Tsabu"
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Atlas"
-msgstr "Atlas"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Astra"
-msgstr "Astra"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Natasha"
-msgstr "Natasha"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Troyan"
-msgstr "Troyan"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Vatawna"
-msgstr "Vatawna"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Rebecca"
-msgstr "Rebecca"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Gem"
-msgstr "Gem"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Ariel"
-msgstr "Ariel"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Carlawn"
-msgstr "Carlawn"
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Luna"
-msgstr "Luna"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Arie"
-msgstr "Arie"
-
-#: ../fheroes2/heroes/heroes.cpp:61 ../fheroes2/resource/maps_text.cpp:59
-msgid "Alamar"
-msgstr "Alamar"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Vesper"
-msgstr "Vesper"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Crodo"
-msgstr "Crodo"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Barok"
-msgstr "Barok"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Kastore"
-msgstr "Kastore"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Agar"
-msgstr "Agar"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Falagar"
-msgstr "Falagar"
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Wrathmont"
-msgstr "Wrathmont"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myra"
-msgstr "Myra"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Flint"
-msgstr "Flint"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Dawn"
-msgstr "Dawn"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Halon"
-msgstr "Halon"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myrini"
-msgstr "Myrini"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Wilfrey"
-msgstr "Wilfrey"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Sarakin"
-msgstr "Sarakin"
-
-#: ../fheroes2/heroes/heroes.cpp:63 ../fheroes2/resource/maps_text.cpp:377
-msgid "Kalindra"
-msgstr "Kalindra"
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Mandigal"
-msgstr "Mandigal"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zom"
-msgstr "Zom"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Darlana"
-msgstr "Darlana"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zam"
-msgstr "Zam"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Ranloo"
-msgstr "Ranloo"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Charity"
-msgstr "Charity"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Rialdo"
-msgstr "Rialdo"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Roxana"
-msgstr "Roxana"
-
-#: ../fheroes2/heroes/heroes.cpp:65 ../fheroes2/resource/maps_text.cpp:557
-msgid "Sandro"
-msgstr "Sandro"
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Celia"
-msgstr "Celia"
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:552
-msgid "Roland"
-msgstr "Roland"
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Lord Corlagon"
-msgstr "Lord Corlagon"
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Sister Eliza"
-msgstr "Syster Eliza"
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:88
-msgid "Archibald"
-msgstr "Archibald"
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:403
-msgid "Lord Halton"
-msgstr "Lord Halton"
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Brother Bax"
-msgstr "Broder Bax"
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Solmyr"
-msgstr "Solmyr"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:194
-msgid "Dainwin"
-msgstr "Dainwin"
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Mog"
-msgstr "Mog"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:760
-msgid "Uncle Ivan"
-msgstr "Farbror Ivan"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:373
-msgid "Joseph"
-msgstr "Joseph"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:285
-msgid "Gallavant"
-msgstr "Gallavant"
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Elderian"
-msgstr "Elderian"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:179
-msgid "Ceallach"
-msgstr "Ceallach"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:229
-msgid "Drakonia"
-msgstr "Drakonia"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:422
-msgid "Martine"
-msgstr "Martine"
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:370
-msgid "Jarkonas"
-msgstr "Jarkonas"
-
-#: ../fheroes2/heroes/heroes.cpp:940
-msgid ""
-"You must purchase a spell book to use the mage guild, but you currently have "
-"no room for a spell book. Try giving one of your artifacts to another hero."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:950
-msgid "The three Anduran artifacts magically combine into one."
-msgstr "De tre Anduranartefakterna kombineras magiskt till en."
-
-#: ../fheroes2/heroes/heroes.cpp:1056
-msgid "To cast spells, you must first buy a spell book for %{gold} gold."
-msgstr ""
-"För att kasta besvärjelser måste du först och främst köpa en magibok för %"
-"{gold} guld."
-
-#: ../fheroes2/heroes/heroes.cpp:1064
-msgid "Unfortunately, you seem to be a little short of cash at the moment."
-msgstr "Tyvärr verkar du för tillfället vara på grön kvist."
-
-#: ../fheroes2/heroes/heroes.cpp:1078
-msgid "Do you wish to buy one?"
-msgstr "Vill du köpa en?"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:72
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:55
-msgid "%{name} the %{race} ( Level %{level} )"
+#, fuzzy
+msgid "%{name} the %{race} (Level %{level})"
 msgstr "%{name} av %{race} ( Level %{level} )"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:118
 msgid ""
 "'Grouped' combat formation bunches your army together in the center of your "
 "side of the battlefield."
@@ -4480,99 +4347,77 @@ msgstr ""
 "'Grupperad' stridsformation samlar ihop din armé tillsammans i mitten på din "
 "sida av stridsfältet."
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:161
 msgid "Are you sure you want to dismiss this Hero?"
 msgstr "Är du säker på att du vill avsätta denna hjälte?"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:341
 #, fuzzy
 msgid "View Stats"
 msgstr "Visa artefakter."
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:344
-msgid "View Morale Info"
-msgstr "Visa information för moral"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:347
-msgid "View Luck Info"
-msgstr "Visa information för tur"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:350
 msgid "View Experience Info"
 msgstr "Visa information för erfarenhet"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:353
 msgid "View Spell Points Info"
 msgstr "Visa information för besvärlejsepoäng"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:356
 msgid "Set army combat formation to 'Spread'"
 msgstr "Ställ in arméns stridsformation på 'Utspridd'"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:359
 msgid "Set army combat formation to 'Grouped'"
 msgstr "Ställ in arméns stridsformation på 'Grupperad'"
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:362
-msgid "Exit hero"
-msgstr "Avsluta hjälte"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:369
-msgid "Dismiss hero"
-msgstr "Avskeda hjälte"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:373
-msgid "Show prev heroes"
-msgstr "Visa föreg. hjälte"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:376
-msgid "Show next heroes"
-msgstr "Visa nästa hjälte"
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:379
-msgid "Hero Screen"
+#, fuzzy
+msgid "Exit Hero Screen"
 msgstr "Hjältesskärm"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:39
-msgid "Bad Morale"
-msgstr "Dålig moral"
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:42
-msgid "Neutral Morale"
-msgstr "Neutral moral"
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:47
-msgid "Good Morale"
-msgstr "Bra moral"
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:61
-msgid "Bad Luck"
-msgstr "Otur"
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:64
-msgid "Neutral Luck"
-msgstr "Neutral tur"
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:69
-msgid "Good Luck"
-msgstr "God tur"
-
-#: ../fheroes2/heroes/heroes_indicator.cpp:113
-#: ../fheroes2/heroes/heroes_indicator.cpp:159
-#: ../fheroes2/heroes/skill.cpp:197
-msgid "Current Modifiers:"
+msgid "You cannot dismiss a hero in a castle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:195
-msgid "Current experience %{exp1} Next level %{exp2}."
+msgid "Dismissal of %{name} the %{race} is prohibited by scenario"
+msgstr ""
+
+#, fuzzy
+msgid "Dismiss %{name} the %{race}"
+msgstr "%{name} av %{race}"
+
+#, fuzzy
+msgid "Show previous hero"
+msgstr "Visa föregående stad"
+
+#, fuzzy
+msgid "Show next hero"
+msgstr "Visa nästa hjälte"
+
+#, fuzzy
+msgid "Blood Morale"
+msgstr "Bra moral"
+
+#, fuzzy
+msgid "%{morale} Morale"
+msgstr "moral|Normal"
+
+msgid "%{luck} Luck"
+msgstr ""
+
+msgid "Current Luck Modifiers:"
+msgstr ""
+
+msgid "Current Morale Modifiers:"
+msgstr ""
+
+#, fuzzy
+msgid "Entire army is undead, so morale does not apply."
+msgstr "Hela gruppen är odöd, så moral gäller inte."
+
+#, fuzzy
+msgid ""
+"Current experience %{exp1}.\n"
+" Next level %{exp2}."
 msgstr "Nuvarande erfarenhet: %{exp1}. Nästa level: %{exp2}."
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:215
 msgid "Level %{level}"
 msgstr "Level %{level}"
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:226
 msgid ""
 "%{name} currently has %{point} spell points out of a maximum of %{max}. The "
 "maximum number of spell points is 10 times your knowledge. It is "
@@ -4580,489 +4425,397 @@ msgid ""
 "special events."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:65
 msgid "%{name1} meets %{name2}"
 msgstr "%{name1} möter %{name2}"
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:396
-#: ../fheroes2/heroes/heroes_meeting.cpp:406
 msgid " and "
 msgstr " och "
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:414
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
 msgstr ""
-"%{teacher}, vars %{level} %{scholar} vet många magiska hemligheter, lär sig %"
-"{spells1} från %{learner}, och lär %{spells2} till %{learner}."
+"%{teacher}, vars %{level} %{scholar} vet många magiska hemligheter, lär sig "
+"%{spells1} från %{learner}, och lär %{spells2} till %{learner}."
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:417
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}."
 msgstr ""
-"%{teacher}, vars %{level} %{scholar} vet många magiska hemligheter, lär sig %"
-"{spells1} från %{learner}."
+"%{teacher}, vars %{level} %{scholar} vet många magiska hemligheter, lär sig "
+"%{spells1} från %{learner}."
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:420
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches %"
-"{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches "
+"%{spells2} to %{learner}."
 msgstr ""
-"%{teacher}, vars %{level} %{scholar} vet många magiska hemligheter, lär sig %"
-"{spells2} till %{learner}."
+"%{teacher}, vars %{level} %{scholar} vet många magiska hemligheter, lär sig "
+"%{spells2} till %{learner}."
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:431
 msgid "Scholar Ability"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:83 ../fheroes2/spell/spell.cpp:109
 msgid "Town Portal"
 msgstr "Stadsportal"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:86
 msgid "Select town to port to."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:106
 msgid "Your hero is too tired to cast this spell today. Try again tomorrow."
 msgstr ""
 "Din hjälte är för trött för att kasta en besvärjelse idag. Försök igen "
 "imorgon."
 
-#: ../fheroes2/heroes/heroes_spell.cpp:187
 #, fuzzy
 msgid "%{spell} failed!!!"
 msgstr "besvärjelse misslyckades!"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:236
+msgid "This spell is already in use."
+msgstr ""
+
 msgid "Enemy heroes are now fully identifiable."
 msgstr "Fiendehjältar är nu fullt identifierade."
 
-#: ../fheroes2/heroes/heroes_spell.cpp:362
-#: ../fheroes2/heroes/heroes_spell.cpp:386
-msgid "No available towns. Spell Failed!!!"
+#, fuzzy
+msgid "This spell cannot be used on a boat."
+msgstr "Denna stad kan inte uppgraderas till ett slott."
+
+msgid "This spell can be casted only nearby water."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"No available towns.\n"
+"Spell Failed!!!"
 msgstr "Ingen stad tillgänlig. Besvärjelsen misslyckades!!!"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:459
-msgid "I fear these creatures are in the mood for a fight."
-msgstr "Jag är rädd för att dessa varelser är på humör för att slåss."
+#, fuzzy
+msgid ""
+"Nearest town occupied.\n"
+"Spell Failed!!!"
+msgstr "Ingen stad tillgänlig. Besvärjelsen misslyckades!!!"
 
-#: ../fheroes2/heroes/heroes_spell.cpp:463
-msgid "The creatures are willing to join us!"
-msgstr "Varelserna är villiga att följa med oss!"
-
-#: ../fheroes2/heroes/heroes_spell.cpp:468
-msgid "All the creatures will join us..."
-msgstr "Alla varelserna vill följa med oss..."
-
-#: ../fheroes2/heroes/heroes_spell.cpp:480
-msgid "These weak creatures will surely flee before us."
-msgstr "Dessa svaga kreaturer kommer säkert att fly före oss."
-
-#: ../fheroes2/heroes/heroes_spell.cpp:489
 msgid ""
 "You must be within %{count} spaces of a monster for the Visions spell to "
 "work."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:506
+msgid "I fear these creatures are in the mood for a fight."
+msgstr "Jag är rädd för att dessa varelser är på humör för att slåss."
+
+msgid "The creatures are willing to join us!"
+msgstr "Varelserna är villiga att följa med oss!"
+
+msgid "All the creatures will join us..."
+msgstr "Alla varelserna vill följa med oss..."
+
+msgid "These weak creatures will surely flee before us."
+msgstr "Dessa svaga kreaturer kommer säkert att fly före oss."
+
 msgid ""
 "You must be standing on the entrance to a mine (sawmills and alchemists "
 "don't count) to cast this spell."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:151
-msgid "Power"
-msgstr "Effekt"
-
-#: ../fheroes2/heroes/skill.cpp:172
 msgid "Your attack skill is a bonus added to each creature's attack skill."
 msgstr ""
 "Din attackfärdighet är en bonus som läggs till på varje varelses "
 "attackfärdighet."
 
-#: ../fheroes2/heroes/skill.cpp:177
 msgid "Your defense skill is a bonus added to each creature's defense skill."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:182
 msgid "Your spell power determines the length or power of a spell."
 msgstr "Din besvärjelsestyrka bestämmer besvärjelsens längd eller styrka."
 
-#: ../fheroes2/heroes/skill.cpp:187
 msgid ""
 "Your knowledge determines how many spell points your hero may have. Under "
-"normal cirumstances, a hero is limited to 10 spell points per level of "
+"normal circumstances, a hero is limited to 10 spell points per level of "
 "knowledge."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
+msgid "Current Modifiers:"
+msgstr ""
+
 msgid "skill|Basic"
 msgstr "färdighet|Grundläggande"
 
-#: ../fheroes2/heroes/skill.cpp:214
 msgid "skill|Advanced"
 msgstr "färdighet|Avancerad"
 
-#: ../fheroes2/heroes/skill.cpp:214
 msgid "skill|Expert"
 msgstr "färdighet|Expert"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Pathfinding"
 msgstr "Vägledning"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Archery"
 msgstr "Bågskytte"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Logistics"
 msgstr "Logistik"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Scouting"
 msgstr "Spaning"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Diplomacy"
 msgstr "Diplomati"
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Navigation"
 msgstr "Navigering"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Leadership"
 msgstr "Ledarskap"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Wisdom"
 msgstr "Visdom"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Mysticism"
 msgstr "Mystik"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Ballistics"
 msgstr "Ballistik"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Eagle Eye"
 msgstr "Falkblick"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Necromancy"
 msgstr "Svartkonst"
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Estates"
 msgstr "Rang"
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Basic Pathfinding"
 msgstr "Grundläggande vägledning"
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Advanced Pathfinding"
 msgstr "Avancerad vägledning"
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Expert Pathfinding"
 msgstr "Professionell vägledning"
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Basic Archery"
 msgstr "Grundläggande bågskytte"
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Advanced Archery"
 msgstr "Avancerat bågskytte"
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Expert Archery"
 msgstr "Professionellt bågskytte"
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Basic Logistics"
 msgstr "Grundläggande logistik"
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Advanced Logistics"
 msgstr "Avancerad logistik"
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Expert Logistics"
 msgstr "Professionell logistik"
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Basic Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Advanced Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Expert Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Basic Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Advanced Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Expert Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Basic Navigation"
 msgstr "Grundläggande navigering"
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Advanced Navigation"
 msgstr "Avancerad navigering"
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Expert Navigation"
 msgstr "Professionell navigering"
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Basic Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Advanced Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Expert Leadership"
 msgstr "Professionellt ledarskap"
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Basic Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Advanced Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Expert Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Basic Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Advanced Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Expert Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Basic Luck"
 msgstr "Grundläggande tur"
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Advanced Luck"
 msgstr "Avancerad tur"
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Expert Luck"
 msgstr "Professionell tur"
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Basic Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Advanced Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Expert Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Basic Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Advanced Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Expert Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Basic Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Advanced Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Expert Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Basic Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Advanced Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Expert Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:406
-msgid "Allows you to negotiate with monsters who are weaker than your group."
+msgid " allows you to negotiate with monsters who are weaker than your group."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:421
-msgid "Allows your hero to learn third level spells."
+#, fuzzy
+msgid "All of the creatures may offer to join you."
+msgstr "Alla varelserna vill följa med oss..."
+
+#, fuzzy
+msgid " allows your hero to learn third level spells."
 msgstr "Låter din hjälte lära sig tredje nivåns besvärjelser."
 
-#: ../fheroes2/heroes/skill.cpp:423
-msgid "Allows your hero to learn fourth level spells."
+#, fuzzy
+msgid " allows your hero to learn fourth level spells."
 msgstr "Låter din hjälte lära sig fjärde nivåns besvärjelser."
 
-#: ../fheroes2/heroes/skill.cpp:425
-msgid "Allows your hero to learn fifth level spells."
+#, fuzzy
+msgid " allows your hero to learn fifth level spells."
 msgstr "Låter din hjälte lära sig femte nivåns besvärjelser."
 
-#: ../fheroes2/heroes/skill.cpp:440
 msgid ""
-"Gives your hero's catapult shots a greater chance to hit and do damage to "
+" gives your hero's catapult shots a greater chance to hit and do damage to "
 "castle walls."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:442
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot has a greater chance "
-"to hit and do damage to castle walls."
+" gives your hero's catapult an extra shot, and each shot has a greater "
+"chance to hit and do damage to castle walls."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:444
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot automatically "
+" gives your hero's catapult an extra shot, and each shot automatically "
 "destroys any wall, except a fortified wall in a Knight town."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:858 ../fheroes2/heroes/skill.cpp:959
-msgid "View %{skill} Info"
-msgstr "Visa info om %{skill}"
-
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:108
 msgid "Blue"
 msgstr "Blå"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:111
 msgid "Green"
 msgstr "Grön"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:114
 msgid "Red"
 msgstr "Röd"
 
-#: ../fheroes2/kingdom/color.cpp:32
 msgid "Yellow"
 msgstr "Gul"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:112
 msgid "Orange"
 msgstr "Orange"
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:113
 msgid "Purple"
 msgstr "Lila"
 
-#: ../fheroes2/kingdom/color.cpp:107
 msgid "Aqua"
 msgstr "Akvamarin"
 
-#: ../fheroes2/kingdom/color.cpp:109
 msgid "Brown"
 msgstr "Brun"
 
-#: ../fheroes2/kingdom/color.cpp:110 ../fheroes2/resource/resource.cpp:283
 msgid "Gold"
 msgstr "Guld"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:238
 msgid "Hero/Stats"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:241
 msgid "Skills"
 msgstr "Färdigheter"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:244
 msgid "Artifacts"
 msgstr "Artifakter"
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:473
 msgid "Town/Castle"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:476
 msgid "Garrison"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:566
 msgid "Gold Per Day:"
 msgstr "Guld per dag!"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Cursed"
 msgstr "tur|Förhäxad"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Awful"
 msgstr "tur|Fruktansvärd"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Bad"
 msgstr "tur|Dålig"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Normal"
 msgstr "tur|Normal"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Good"
 msgstr "tur|Bra"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Great"
 msgstr "tur|Fantastisk"
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Irish"
 msgstr "tur|Irländsk"
 
-#: ../fheroes2/kingdom/luck.cpp:48
 msgid ""
 "Bad luck sometimes falls on your armies in combat, causing their attacks to "
 "only do half damage."
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:49
 msgid ""
 "Neutral luck means your armies will never get lucky or unlucky attacks on "
 "the enemy."
@@ -5070,7 +4823,6 @@ msgstr ""
 "Normal tur inebär att dina arméer kommer varken att få lyckosamma eller "
 "oturliga attacker"
 
-#: ../fheroes2/kingdom/luck.cpp:50
 msgid ""
 "Good luck sometimes lets your armies get lucky attacks (double strength) in "
 "combat."
@@ -5078,39 +4830,30 @@ msgstr ""
 "God tur låter dina ibland dina arméer få tursamma attacker (dubbel styrka) i "
 "strid."
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Treason"
 msgstr "moral|Förräderi"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Awful"
 msgstr "moral|Fruktansvärd"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Poor"
 msgstr "moral|Dålig"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Normal"
 msgstr "moral|Normal"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Good"
 msgstr "moral|Bra"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Great"
 msgstr "moral|Fantastisk"
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Blood!"
 msgstr "moral|Blod!"
 
-#: ../fheroes2/kingdom/morale.cpp:48
 msgid "Bad morale may cause your armies to freeze in combat."
 msgstr "Dålig moral kan få dina arméer att låsa sig i strid."
 
-#: ../fheroes2/kingdom/morale.cpp:49
 msgid ""
 "Neutral morale means your armies will never be blessed with extra attacks or "
 "freeze in combat."
@@ -5118,2073 +4861,1030 @@ msgstr ""
 "Neutral moral innebär att dina arméer aldrig kommer att bli välsignade eller "
 "låsta i strid."
 
-#: ../fheroes2/kingdom/morale.cpp:50
 msgid "Good morale may give your armies extra attacks in combat."
 msgstr "God moral kan ge din arméer extra attacker i strid."
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Knight"
 msgstr "Riddare"
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Barbarian"
 msgstr "Barbar"
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Sorceress"
 msgstr "Häxa"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Warlock"
 msgstr "Krigstrollkarl"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Wizard"
 msgstr "Trollkarl"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Necromancer"
 msgstr "Svartkonstnär"
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Multi"
 msgstr "Flera"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Standing"
 msgstr "hastighet|Stående"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Crawling"
 msgstr "hastighet|Krypande"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Very Slow"
 msgstr "hastighet|Riktigt långsam"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Slow"
 msgstr "hastighet|Långsam"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Average"
 msgstr "hastighet|Vanlig"
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Fast"
 msgstr "hastighet|Snabb"
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Very Fast"
 msgstr "hastighet|Riktigt snabb"
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Ultra Fast"
 msgstr "hastighet|Jättesnabb"
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Blazing"
 msgstr "hastighet|Blixtsnabb"
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Instant"
 msgstr "hastighet|Ögonblicklig"
 
-#: ../fheroes2/kingdom/week.cpp:32
 msgid "week|PLAGUE"
 msgstr "vecka|PLÅGA"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Ant"
 msgstr "vecka|Myra"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Grasshopper"
 msgstr "vecka|Gräshoppa"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Dragonfly"
 msgstr "vecka|Trollslända"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Spider"
 msgstr "vecka|Spindel"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Butterfly"
 msgstr "vecka|Fjäril"
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Bumblebee"
 msgstr "vecka|Humla"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Locust"
 msgstr "vecka|Vandringsgräshoppa"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Earthworm"
 msgstr "vecka|Daggmask"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Hornet"
 msgstr "vecka|Bålgeting"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Beetle"
 msgstr "vecka|Skalbagge"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Squirrel"
 msgstr "vecka|Ekorre"
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Rabbit"
 msgstr "vecka|Hare"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Gopher"
 msgstr "vecka|Sisel"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Badger"
 msgstr "vecka|Grävling"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Eagle"
 msgstr "vecka|Örn"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Weasel"
 msgstr "vecka|Vessla"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Raven"
 msgstr "kartor|Korp"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Mongoose"
 msgstr "vecka|Mungo"
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Aardvark"
 msgstr "vecka|Jordsvin"
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Lizard"
 msgstr "vecka|Ödla"
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Tortoise"
 msgstr "vecka|Sköldpadda"
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Hedgehog"
 msgstr "kartor|Igelkott"
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Condor"
 msgstr "kartor|Kondor"
 
-#: ../fheroes2/kingdom/world_loadmap.cpp:1424
-#, fuzzy
-msgid "The ultimate artifact is really the %{name}"
-msgstr "Mumiens förbannelse har drabbat %{name}!"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1428
-msgid "The ultimate artifact may be found in the %{name} regions of the world."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1433
-msgid "north-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1436
-#, fuzzy
-msgid "north"
-msgstr "Fort"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1438
-msgid "north-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1444
-#, fuzzy
-msgid "west"
-msgstr "Näste"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1447
-#, fuzzy
-msgid "center"
-msgstr "Monster"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1449
-#, fuzzy
-msgid "east"
-msgstr "Näste"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1454
-msgid "south-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1457
-#, fuzzy
-msgid "south"
-msgstr "ljud"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1459
-msgid "south-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1463
-msgid "The truth is out there."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1464
-msgid "The dark side is stronger."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1465
-#, fuzzy
-msgid "The end of the world is near."
-msgstr "Världens undergång är nära"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1466
-msgid "The bones of Lord Slayer are buried in the foundation of the arena."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1467
-msgid "A Black Dragon will take out a Titan any day of the week."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1468
-msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1470
-msgid ""
-"You can load the newest version of game from a site:\n"
-" http://sf.net/projects/fheroes2"
-msgstr ""
-"Du kan ladda ned det nyaste versionen av spelet från sidan:\n"
-" http://sf.net/projects/fheroes2"
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1471
-msgid "This game is now in beta development version. ;)"
-msgstr "Detta spel är nu i betaversion. ;)"
-
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Desert"
 msgstr "Öken"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Snow"
 msgstr "Snö"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Wasteland"
 msgstr "Ödemark"
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Beach"
 msgstr "Strand"
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Lava"
 msgstr "Lava"
 
-#: ../fheroes2/maps/ground.cpp:31 ../fheroes2/resource/maps_text.cpp:210
 msgid "Dirt"
 msgstr "Lera"
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Grass"
 msgstr "Gräs"
 
-#: ../fheroes2/maps/ground.cpp:31
-msgid "Water"
-msgstr "Vatten"
+msgid "Ocean"
+msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Small"
 msgstr "kartor|Liten"
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Medium"
 msgstr "kartor|Medel"
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Large"
 msgstr "kartor|Stor"
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Extra Large"
 msgstr "kartor|Extra stor"
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Custom Size"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:122
 msgid "Ore Mine"
 msgstr "Malmgruva"
 
-#: ../fheroes2/maps/maps.cpp:123
 msgid "Sulfur Mine"
 msgstr "Svavelgruva"
 
-#: ../fheroes2/maps/maps.cpp:124
 msgid "Crystal Mine"
 msgstr "Kristallgruva"
 
-#: ../fheroes2/maps/maps.cpp:125
 msgid "Gems Mine"
 msgstr "Ädelstensgruva"
 
-#: ../fheroes2/maps/maps.cpp:126
 msgid "Gold Mine"
 msgstr "Guldgruva"
 
-#: ../fheroes2/maps/maps.cpp:130
 msgid "Mine"
 msgstr "Gruva"
 
-#: ../fheroes2/maps/mp2.cpp:365
 msgid "Alchemist Lab"
 msgstr "Alkemistlabb"
 
-#: ../fheroes2/maps/mp2.cpp:367
 msgid "Daemon Cave"
 msgstr "Demongrotta"
 
-#: ../fheroes2/maps/mp2.cpp:369
 msgid "Faerie Ring"
 msgstr "Häxring"
 
-#: ../fheroes2/maps/mp2.cpp:373 ../fheroes2/resource/maps_text.cpp:217
 msgid "Dragon City"
 msgstr "Drakstad"
 
-#: ../fheroes2/maps/mp2.cpp:375
-msgid "Light House"
+#, fuzzy
+msgid "Lighthouse"
 msgstr "Fyr"
 
-#: ../fheroes2/maps/mp2.cpp:377
 msgid "Water Wheel"
 msgstr "Vattenhjul"
 
-#: ../fheroes2/maps/mp2.cpp:379
 msgid "Mines"
 msgstr "Gruvor"
 
-#: ../fheroes2/maps/mp2.cpp:381
 msgid "Obelisk"
 msgstr "Obelisk"
 
-#: ../fheroes2/maps/mp2.cpp:383
 msgid "Oasis"
 msgstr "Oas"
 
-#: ../fheroes2/maps/mp2.cpp:385
 msgid "Sawmill"
 msgstr "Sågverk"
 
-#: ../fheroes2/maps/mp2.cpp:387
 msgid "Oracle"
 msgstr "Orakel"
 
-#: ../fheroes2/maps/mp2.cpp:389
 msgid "Desert Tent"
 msgstr "Ökentält"
 
-#: ../fheroes2/maps/mp2.cpp:393
 msgid "Wagon Camp"
 msgstr "Godsvagnläger"
 
-#: ../fheroes2/maps/mp2.cpp:395
 msgid "Windmill"
 msgstr "Väderkvarn"
 
-#: ../fheroes2/maps/mp2.cpp:397
 msgid "Random Town"
 msgstr "Slumpartad stad"
 
-#: ../fheroes2/maps/mp2.cpp:399
 msgid "Random Castle"
 msgstr "Slumpartat slott"
 
-#: ../fheroes2/maps/mp2.cpp:401
 msgid "Watch Tower"
 msgstr "Vakttorn"
 
-#: ../fheroes2/maps/mp2.cpp:403
 msgid "Tree City"
 msgstr "Trädstad"
 
-#: ../fheroes2/maps/mp2.cpp:405
 msgid "Tree House"
 msgstr "Trädhus"
 
-#: ../fheroes2/maps/mp2.cpp:407
 msgid "Ruins"
 msgstr "Ruiner"
 
-#: ../fheroes2/maps/mp2.cpp:409
 msgid "Fort"
 msgstr "Fort"
 
-#: ../fheroes2/maps/mp2.cpp:411
-msgid "Trading Post"
-msgstr "Handelsstation"
-
-#: ../fheroes2/maps/mp2.cpp:413
 msgid "Abandoned Mine"
 msgstr "Övergiven gruva"
 
-#: ../fheroes2/maps/mp2.cpp:415
 msgid "Tree of Knowledge"
 msgstr "Kunskapens träd"
 
-#: ../fheroes2/maps/mp2.cpp:417
 msgid "Witch Doctor's Hut"
 msgstr "Häxdoktorns hydda"
 
-#: ../fheroes2/maps/mp2.cpp:419
 msgid "Temple"
 msgstr "Tempel"
 
-#: ../fheroes2/maps/mp2.cpp:421
 msgid "Hill Fort"
 msgstr "Fornborg"
 
-#: ../fheroes2/maps/mp2.cpp:423
 msgid "Halfling Hole"
 msgstr "Hobhål"
 
-#: ../fheroes2/maps/mp2.cpp:425
 msgid "Mercenary Camp"
 msgstr "Legosoldatsläger"
 
-#: ../fheroes2/maps/mp2.cpp:429
 msgid "City of the Dead"
 msgstr "Dödens stad"
 
-#: ../fheroes2/maps/mp2.cpp:433
 msgid "Sphinx"
 msgstr "Sfinx"
 
-#: ../fheroes2/maps/mp2.cpp:435
 msgid "Troll Bridge"
 msgstr "Trollbro"
 
-#: ../fheroes2/maps/mp2.cpp:437
 msgid "Witch Hut"
 msgstr "Häxhydda"
 
-#: ../fheroes2/maps/mp2.cpp:439
 msgid "Xanadu"
 msgstr "Xanadu"
 
-#: ../fheroes2/maps/mp2.cpp:443
 msgid "Magellan Maps"
 msgstr "Magellan-kartor"
 
-#: ../fheroes2/maps/mp2.cpp:445
 msgid "Derelict Ship"
 msgstr "Övergivet skepp"
 
-#: ../fheroes2/maps/mp2.cpp:447
-msgid "Ship Wreck"
-msgstr "Skeppsvrak"
+#, fuzzy
+msgid "Shipwreck"
+msgstr "Skeppsbruten!"
 
-#: ../fheroes2/maps/mp2.cpp:449
 msgid "Observation Tower"
 msgstr "Observationstorn"
 
-#: ../fheroes2/maps/mp2.cpp:451
-msgid "Freeman Foundry"
+#, fuzzy
+msgid "Freeman's Foundry"
 msgstr "Hedersmedborgarnas gjuteri"
 
-#: ../fheroes2/maps/mp2.cpp:453
 msgid "Watering Hole"
 msgstr "Vattenhål"
 
-#: ../fheroes2/maps/mp2.cpp:455
 msgid "Artesian Spring"
 msgstr "Artesisk källa"
 
-#: ../fheroes2/maps/mp2.cpp:457
 msgid "Gazebo"
 msgstr "Lusthus"
 
-#: ../fheroes2/maps/mp2.cpp:459
 msgid "Archer's House"
 msgstr "Bågskyttens hus"
 
-#: ../fheroes2/maps/mp2.cpp:461
 msgid "Peasant Hut"
 msgstr "Bondehydda"
 
-#: ../fheroes2/maps/mp2.cpp:463
 msgid "Dwarf Cottage"
 msgstr "Dvärgstuga"
 
-#: ../fheroes2/maps/mp2.cpp:465
 msgid "Stone Liths"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:467
 msgid "Magic Well"
 msgstr "Magisk brunn"
 
-#: ../fheroes2/maps/mp2.cpp:468
 msgid "Heroes"
 msgstr "Hjältar"
 
-#: ../fheroes2/maps/mp2.cpp:470 ../fheroes2/maps/mp2.cpp:488
-msgid "Shrub"
-msgstr "Buske"
-
-#: ../fheroes2/maps/mp2.cpp:471
 msgid "Nothing Special"
 msgstr "Ingenting speciellt"
 
-#: ../fheroes2/maps/mp2.cpp:472
 msgid "Tar Pit"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:473
-msgid "Coast"
-msgstr "Kust"
-
-#: ../fheroes2/maps/mp2.cpp:474
 msgid "Mound"
 msgstr "Kulle"
 
-#: ../fheroes2/maps/mp2.cpp:475
 msgid "Dune"
 msgstr "Dyn"
 
-#: ../fheroes2/maps/mp2.cpp:476
 msgid "Stump"
 msgstr "Stubbe"
 
-#: ../fheroes2/maps/mp2.cpp:477
 msgid "Cactus"
 msgstr "Kaktus"
 
-#: ../fheroes2/maps/mp2.cpp:478
 msgid "Trees"
 msgstr "Träd"
 
-#: ../fheroes2/maps/mp2.cpp:479
 msgid "Dead Tree"
 msgstr "Dött träd"
 
-#: ../fheroes2/maps/mp2.cpp:480
 msgid "Mountains"
 msgstr "Berg"
 
-#: ../fheroes2/maps/mp2.cpp:481
 msgid "Volcano"
 msgstr "Vulkan"
 
-#: ../fheroes2/maps/mp2.cpp:482
 msgid "Rock"
 msgstr "Sten"
 
-#: ../fheroes2/maps/mp2.cpp:483
 msgid "Flowers"
 msgstr "Blommor"
 
-#: ../fheroes2/maps/mp2.cpp:484
 msgid "Water Lake"
 msgstr "Sjö"
 
-#: ../fheroes2/maps/mp2.cpp:485
 msgid "Mandrake"
 msgstr "Alruna"
 
-#: ../fheroes2/maps/mp2.cpp:486
 msgid "Crater"
 msgstr "Krater"
 
-#: ../fheroes2/maps/mp2.cpp:487
 msgid "Lava Pool"
 msgstr "Lavapöl"
 
-#: ../fheroes2/maps/mp2.cpp:489
+msgid "Shrub"
+msgstr "Buske"
+
 msgid "Buoy"
 msgstr "Boj"
 
-#: ../fheroes2/maps/mp2.cpp:491 ../fheroes2/monster/monster.cpp:116
 #, fuzzy
 msgid "Skeleton"
 msgstr "Skelett"
 
-#: ../fheroes2/maps/mp2.cpp:492
 msgid "Treasure Chest"
 msgstr "Skattkista"
 
-#: ../fheroes2/maps/mp2.cpp:493
 msgid "Sea Chest"
 msgstr "Sjökista"
 
-#: ../fheroes2/maps/mp2.cpp:494
 msgid "Campfire"
 msgstr "Lägereld"
 
-#: ../fheroes2/maps/mp2.cpp:495
 msgid "Fountain"
 msgstr "Fontän"
 
-#: ../fheroes2/maps/mp2.cpp:496
 msgid "Genie Lamp"
 msgstr "Andens lampa"
 
-#: ../fheroes2/maps/mp2.cpp:497
 msgid "Goblin Hut"
 msgstr "Goblinhydda"
 
-#: ../fheroes2/maps/mp2.cpp:499
 msgid "Monster"
 msgstr "Monster"
 
-#: ../fheroes2/maps/mp2.cpp:500
 msgid "Resource"
 msgstr "Resurs"
 
-#: ../fheroes2/maps/mp2.cpp:501
 msgid "Whirlpool"
 msgstr "Strömvirvel"
 
-#: ../fheroes2/maps/mp2.cpp:502
 msgid "Artifact"
 msgstr "Artefakt"
 
-#: ../fheroes2/maps/mp2.cpp:503
 msgid "Boat"
 msgstr "Båt"
 
-#: ../fheroes2/maps/mp2.cpp:510
 msgid "Standing Stones"
 msgstr "Stenblock"
 
-#: ../fheroes2/maps/mp2.cpp:514
 msgid "Idol"
 msgstr "Avgud"
 
-#: ../fheroes2/maps/mp2.cpp:515
 msgid "Shrine of the First Circle"
 msgstr "Första kretsens tempel"
 
-#: ../fheroes2/maps/mp2.cpp:516
 msgid "Shrine of the Second Circle"
 msgstr "Andra kretsens tempel"
 
-#: ../fheroes2/maps/mp2.cpp:517
 msgid "Shrine of the Third Circle"
 msgstr "Tredje kretsens tempel"
 
-#: ../fheroes2/maps/mp2.cpp:518
 msgid "Wagon"
 msgstr "Godsvagn"
 
-#: ../fheroes2/maps/mp2.cpp:519
 msgid "Lean To"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:520
 msgid "Flotsam"
 msgstr "Vrakgods"
 
-#: ../fheroes2/maps/mp2.cpp:521
 msgid "Shipwreck Survivor"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:522
 msgid "Bottle"
 msgstr "Flaska"
 
-#: ../fheroes2/maps/mp2.cpp:523
 msgid "Magic Garden"
 msgstr "Magisk trädgård"
 
-#: ../fheroes2/maps/mp2.cpp:529
 msgid "Jail"
 msgstr "Fängelse"
 
-#: ../fheroes2/maps/mp2.cpp:531
 msgid "Traveller's Tent"
 msgstr "Resenärstält"
 
-#: ../fheroes2/maps/mp2.cpp:532
 msgid "Barrier"
 msgstr "Barriär"
 
-#: ../fheroes2/maps/mp2.cpp:535
 msgid "Fire Summoning Altar"
 msgstr "Eldinkallnings-altare"
 
-#: ../fheroes2/maps/mp2.cpp:537
 msgid "Air Summoning Altar"
 msgstr "Luftinkallnings-altare"
 
-#: ../fheroes2/maps/mp2.cpp:539
 msgid "Earth Summoning Altar"
 msgstr "Jordinkallnings-altare"
 
-#: ../fheroes2/maps/mp2.cpp:541
 msgid "Water Summoning Altar"
 msgstr "Vatteninkallnings-altare"
 
-#: ../fheroes2/maps/mp2.cpp:543
 msgid "Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:545
-msgid "Arena"
-msgstr "Arena"
-
-#: ../fheroes2/maps/mp2.cpp:547
 msgid "Stables"
 msgstr "Stall"
 
-#: ../fheroes2/maps/mp2.cpp:549
 msgid "Alchemist's Tower"
 msgstr "Alkemistens torn"
 
-#: ../fheroes2/maps/mp2.cpp:551
 msgid "Hut of the Magi"
 msgstr "De vise männens stuga"
 
-#: ../fheroes2/maps/mp2.cpp:553
 msgid "Eye of the Magi"
 msgstr "De vise männens öga"
 
-#: ../fheroes2/maps/mp2.cpp:555
 msgid "Mermaid"
 msgstr "Sjöjungfru"
 
-#: ../fheroes2/maps/mp2.cpp:557
 msgid "Sirens"
 msgstr "Sirener"
 
-#: ../fheroes2/maps/mp2.cpp:558
 msgid "Reefs"
 msgstr "Rev"
 
-#: ../fheroes2/monster/monster.cpp:59
-#, fuzzy
-msgid "Peasant"
-msgstr "Bonde"
-
-#: ../fheroes2/monster/monster.cpp:59 ../fheroes2/resource/maps_text.cpp:501
-msgid "Peasants"
-msgstr "Bönder"
-
-#: ../fheroes2/monster/monster.cpp:60
-#, fuzzy
-msgid "Archer"
-msgstr "Bågskytt"
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Archers"
-msgstr "Bågskyttar"
-
-#: ../fheroes2/monster/monster.cpp:61
-#, fuzzy
-msgid "Ranger"
-msgstr "Vandringsman"
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Rangers"
-msgstr "Vandringsmän"
-
-#: ../fheroes2/monster/monster.cpp:62
-#, fuzzy
-msgid "Pikeman"
-msgstr "Pikenerare"
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Pikemen"
-msgstr "Pikenerare"
-
-#: ../fheroes2/monster/monster.cpp:63
-#, fuzzy
-msgid "Veteran Pikeman"
-msgstr "Veteranpikenerare"
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Veteran Pikemen"
-msgstr "Veteranpikenerare"
-
-#: ../fheroes2/monster/monster.cpp:64
-#, fuzzy
-msgid "Swordsman"
-msgstr "Svärdsman"
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Swordsmen"
-msgstr "Svärdsmän"
-
-#: ../fheroes2/monster/monster.cpp:65
-#, fuzzy
-msgid "Master Swordsman"
-msgstr "Mästersvärdsman"
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Master Swordsmen"
-msgstr "Mästersvärdsmän"
-
-#: ../fheroes2/monster/monster.cpp:66
-#, fuzzy
-msgid "Cavalry"
-msgstr "Kavalleri"
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Cavalries"
-msgstr "Kavallerier"
-
-#: ../fheroes2/monster/monster.cpp:67
-#, fuzzy
-msgid "Champion"
-msgstr "Krigare"
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Champions"
-msgstr "Krigare"
-
-#: ../fheroes2/monster/monster.cpp:68
-#, fuzzy
-msgid "Paladin"
-msgstr "Ryttare"
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Paladins"
-msgstr "Ryttare"
-
-#: ../fheroes2/monster/monster.cpp:69
-#, fuzzy
-msgid "Crusader"
-msgstr "Korsriddare"
-
-#: ../fheroes2/monster/monster.cpp:69
-msgid "Crusaders"
-msgstr "Korsriddare"
-
-#: ../fheroes2/monster/monster.cpp:72
-#, fuzzy
-msgid "Goblin"
-msgstr "Goblin"
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Goblins"
-msgstr "Goblins"
-
-#: ../fheroes2/monster/monster.cpp:73
-#, fuzzy
-msgid "Orc"
-msgstr "Orch"
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orcs"
-msgstr "Orcher"
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chief"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chiefs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:75
-#, fuzzy
-msgid "Wolf"
-msgstr "Varg"
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Wolves"
-msgstr "Vargar"
-
-#: ../fheroes2/monster/monster.cpp:76
-#, fuzzy
-msgid "Ogre"
-msgstr "Jätte"
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogres"
-msgstr "Jättar"
-
-#: ../fheroes2/monster/monster.cpp:77
-#, fuzzy
-msgid "Ogre Lord"
-msgstr "Ogrelord"
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Ogre Lords"
-msgstr "Ogrelorder"
-
-#: ../fheroes2/monster/monster.cpp:78
-#, fuzzy
-msgid "Troll"
-msgstr "Troll"
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "Trolls"
-msgstr "Troll"
-
-#: ../fheroes2/monster/monster.cpp:79
-#, fuzzy
-msgid "War Troll"
-msgstr "Krigstroll"
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "War Trolls"
-msgstr "Krigstroll"
-
-#: ../fheroes2/monster/monster.cpp:80
-#, fuzzy
-msgid "Cyclops"
-msgstr "Cyklop"
-
-#: ../fheroes2/monster/monster.cpp:80
-msgid "Cyclopes"
-msgstr "Cykloper"
-
-#: ../fheroes2/monster/monster.cpp:83
-#, fuzzy
-msgid "Sprite"
-msgstr "Fe"
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Sprites"
-msgstr "Feer"
-
-#: ../fheroes2/monster/monster.cpp:84
-#, fuzzy
-msgid "Dwarf"
-msgstr "Dvärg"
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Dwarves"
-msgstr "Dvärgar"
-
-#: ../fheroes2/monster/monster.cpp:85
-#, fuzzy
-msgid "Battle Dwarf"
-msgstr "Stridsdvärg"
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Battle Dwarves"
-msgstr "Stridsdvärgar"
-
-#: ../fheroes2/monster/monster.cpp:86
-#, fuzzy
-msgid "Elf"
-msgstr "Alv"
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elves"
-msgstr "Alver"
-
-#: ../fheroes2/monster/monster.cpp:87
-#, fuzzy
-msgid "Grand Elf"
-msgstr "Stor alv"
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elves"
-msgstr "Stora alver"
-
-#: ../fheroes2/monster/monster.cpp:88
-#, fuzzy
-msgid "Druid"
-msgstr "Druid"
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druids"
-msgstr "Druider"
-
-#: ../fheroes2/monster/monster.cpp:89
-#, fuzzy
-msgid "Greater Druid"
-msgstr "Stor druid"
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druids"
-msgstr "Stora druider"
-
-#: ../fheroes2/monster/monster.cpp:90
-#, fuzzy
-msgid "Unicorn"
-msgstr "Enhörning"
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorns"
-msgstr "Enhörningar"
-
-#: ../fheroes2/monster/monster.cpp:91
-#, fuzzy
-msgid "Phoenix"
-msgstr "Fenix"
-
-#: ../fheroes2/monster/monster.cpp:91
-#, fuzzy
-msgid "Phoenixes"
-msgstr "Fenix"
-
-#: ../fheroes2/monster/monster.cpp:94
-#, fuzzy
-msgid "Centaur"
-msgstr "Kentaur"
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaurs"
-msgstr "Kentaurer"
-
-#: ../fheroes2/monster/monster.cpp:95
-#, fuzzy
-msgid "Gargoyle"
-msgstr "Stenstaty"
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyles"
-msgstr "Stenstatyer"
-
-#: ../fheroes2/monster/monster.cpp:96
-#, fuzzy
-msgid "Griffin"
-msgstr "Grip"
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffins"
-msgstr "Gripar"
-
-#: ../fheroes2/monster/monster.cpp:97
-#, fuzzy
-msgid "Minotaur"
-msgstr "Minotaur"
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaurs"
-msgstr "Minotaurer"
-
-#: ../fheroes2/monster/monster.cpp:98
-#, fuzzy
-msgid "Minotaur King"
-msgstr "Minotaurkung"
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur Kings"
-msgstr "Minotaurkungar"
-
-#: ../fheroes2/monster/monster.cpp:99
-#, fuzzy
-msgid "Hydra"
-msgstr "Hydra"
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydras"
-msgstr "Hydror"
-
-#: ../fheroes2/monster/monster.cpp:100
-#, fuzzy
-msgid "Green Dragon"
-msgstr "Grön drake"
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragons"
-msgstr "Gröna drakar"
-
-#: ../fheroes2/monster/monster.cpp:101
-#, fuzzy
-msgid "Red Dragon"
-msgstr "Röd drake"
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragons"
-msgstr "Röda drakar"
-
-#: ../fheroes2/monster/monster.cpp:102
-#, fuzzy
-msgid "Black Dragon"
-msgstr "Svart drake"
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragons"
-msgstr "Svarta drakar"
-
-#: ../fheroes2/monster/monster.cpp:105
-#, fuzzy
-msgid "Halfling"
-msgstr "Hob"
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halflings"
-msgstr "Hober"
-
-#: ../fheroes2/monster/monster.cpp:106
-#, fuzzy
-msgid "Boar"
-msgstr "Vildsvin"
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boars"
-msgstr "Vildsvin"
-
-#: ../fheroes2/monster/monster.cpp:107
-#, fuzzy
-msgid "Iron Golem"
-msgstr "Järngolem"
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golems"
-msgstr "Järngolem"
-
-#: ../fheroes2/monster/monster.cpp:108
-#, fuzzy
-msgid "Steel Golem"
-msgstr "Stålgolem"
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golems"
-msgstr "Stålgolem"
-
-#: ../fheroes2/monster/monster.cpp:109
-#, fuzzy
-msgid "Roc"
-msgstr "Fågel rock"
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Rocs"
-msgstr "Fågel rock"
-
-#: ../fheroes2/monster/monster.cpp:110
-#, fuzzy
-msgid "Mage"
-msgstr "Magiker"
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Magi"
-msgstr "Magiker"
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmage"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmagi"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:112
-#, fuzzy
-msgid "Giant"
-msgstr "Koloss"
-
-#: ../fheroes2/monster/monster.cpp:112 ../fheroes2/resource/maps_text.cpp:293
-msgid "Giants"
-msgstr "Kolosser"
-
-#: ../fheroes2/monster/monster.cpp:113
-#, fuzzy
-msgid "Titan"
-msgstr "Titan"
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titans"
-msgstr "Titaner"
-
-#: ../fheroes2/monster/monster.cpp:116
-msgid "Skeletons"
-msgstr "Skelett"
-
-#: ../fheroes2/monster/monster.cpp:117
-#, fuzzy
-msgid "Zombie"
-msgstr "Zombie"
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombies"
-msgstr "Zombies"
-
-#: ../fheroes2/monster/monster.cpp:118
-#, fuzzy
-msgid "Mutant Zombie"
-msgstr "Muterad zombie"
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombies"
-msgstr "Muterade zombies"
-
-#: ../fheroes2/monster/monster.cpp:119
-#, fuzzy
-msgid "Mummy"
-msgstr "Mumie"
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummies"
-msgstr "Mumier"
-
-#: ../fheroes2/monster/monster.cpp:120
-#, fuzzy
-msgid "Royal Mummy"
-msgstr "Kunglig mumie"
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummies"
-msgstr "Kungliga mumier"
-
-#: ../fheroes2/monster/monster.cpp:121
-#, fuzzy
-msgid "Vampire"
-msgstr "Vampyr"
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampires"
-msgstr "Vampyrer"
-
-#: ../fheroes2/monster/monster.cpp:122
-#, fuzzy
-msgid "Vampire Lord"
-msgstr "Vampyrlord"
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lords"
-msgstr "Vampyrlordar"
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Lich"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Liches"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Lich"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Liches"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:125
-#, fuzzy
-msgid "Bone Dragon"
-msgstr "Bendrake"
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragons"
-msgstr "Bendrakar"
-
-#: ../fheroes2/monster/monster.cpp:128
-#, fuzzy
-msgid "Rogue"
-msgstr "Skurk"
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogues"
-msgstr "Skurkar"
-
-#: ../fheroes2/monster/monster.cpp:129
-#, fuzzy
-msgid "Nomad"
-msgstr "Nomad"
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomads"
-msgstr "Nomader"
-
-#: ../fheroes2/monster/monster.cpp:130
-#, fuzzy
-msgid "Ghost"
-msgstr "Spöke"
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghosts"
-msgstr "Spöken"
-
-#: ../fheroes2/monster/monster.cpp:131
-#, fuzzy
-msgid "Genie"
-msgstr "Ande"
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genies"
-msgstr "Andar"
-
-#: ../fheroes2/monster/monster.cpp:132
-#, fuzzy
-msgid "Medusa"
-msgstr "Medusa"
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusas"
-msgstr "Medusor"
-
-#: ../fheroes2/monster/monster.cpp:133
-#, fuzzy
-msgid "Earth Elemental"
-msgstr "Jordelement"
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elementals"
-msgstr "Jordelement"
-
-#: ../fheroes2/monster/monster.cpp:134
-#, fuzzy
-msgid "Air Elemental"
-msgstr "Luftelement"
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elementals"
-msgstr "Luftelement"
-
-#: ../fheroes2/monster/monster.cpp:135
-#, fuzzy
-msgid "Fire Elemental"
-msgstr "Eldelement"
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elementals"
-msgstr "Eldelement"
-
-#: ../fheroes2/monster/monster.cpp:136
-#, fuzzy
-msgid "Water Elemental"
-msgstr "Vattenelement"
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elementals"
-msgstr "Vattenelement"
-
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:694
-msgid "buy"
-msgstr "köp"
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:158
-msgid "Campaign Game"
-msgstr "Kampanjspel"
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "Error"
-msgstr "Fel"
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "This release is compiled without network support."
-msgstr "Denna utgåva är framtagen utan stöd för nätverk."
-
-#: ../fheroes2/resource/artifact.cpp:51
 msgid "Ultimate Book of Knowledge"
 msgstr "Ultimata kunskapsboken"
 
-#: ../fheroes2/resource/artifact.cpp:51 ../fheroes2/resource/artifact.cpp:77
-#: ../fheroes2/resource/artifact.cpp:78 ../fheroes2/resource/artifact.cpp:79
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "The %{name} increases your knowledge by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:52
 msgid "Ultimate Sword of Dominion"
 msgstr "Ultimata Herraväldessvärdet"
 
-#: ../fheroes2/resource/artifact.cpp:52 ../fheroes2/resource/artifact.cpp:68
-#: ../fheroes2/resource/artifact.cpp:71 ../fheroes2/resource/artifact.cpp:74
-#: ../fheroes2/resource/artifact.cpp:75 ../fheroes2/resource/artifact.cpp:149
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "The %{name} increases your attack skill by %{count}."
 msgstr "%{name} höjer din attackförmåga med %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:53
 msgid "Ultimate Cloak of Protection"
 msgstr "Ultimata Skyddsmanteln"
 
-#: ../fheroes2/resource/artifact.cpp:53 ../fheroes2/resource/artifact.cpp:70
-#: ../fheroes2/resource/artifact.cpp:73 ../fheroes2/resource/artifact.cpp:76
 msgid "The %{name} increases your defense skill by %{count}."
 msgstr "%{name} höjer din försvarsfärdighet med %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:54
 msgid "Ultimate Wand of Magic"
 msgstr "Ultimata trollstaven"
 
-#: ../fheroes2/resource/artifact.cpp:54 ../fheroes2/resource/artifact.cpp:59
-#: ../fheroes2/resource/artifact.cpp:60 ../fheroes2/resource/artifact.cpp:61
-#: ../fheroes2/resource/artifact.cpp:62 ../fheroes2/resource/artifact.cpp:148
 msgid "The %{name} increases your spell power by %{count}."
 msgstr "%{name} höjer din besvärjelsestyrka med %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:55
 msgid "Ultimate Shield"
 msgstr "Ultimata skölden"
 
-#: ../fheroes2/resource/artifact.cpp:55 ../fheroes2/resource/artifact.cpp:128
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "The %{name} increases your attack and defense skills by %{count} each."
 msgstr ""
 "%{name} höjer dina attack- och försvarsfärdigheter med %{count} vardera."
 
-#: ../fheroes2/resource/artifact.cpp:56
 msgid "Ultimate Staff"
 msgstr "Ultimata skölden"
 
-#: ../fheroes2/resource/artifact.cpp:56 ../fheroes2/resource/artifact.cpp:130
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "The %{name} increases your spell power and knowledge by %{count} each."
 msgstr "%{name} höjer din besvärjelsestyrka och kunskap med %{count} vardera."
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "Ultimate Crown"
 msgstr "Ultimata Kronan"
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "The %{name} increases each of your basic skills by %{count} points."
 msgstr "%{name} höjer alla dina grundläggande färdigheter med %{count} poäng."
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "Golden Goose"
 msgstr "Gyllene gås"
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "The %{name} brings in an income of %{count} gold per turn."
 msgstr "%{name} medför en inkomst på %{count} guld per runda."
 
-#: ../fheroes2/resource/artifact.cpp:59
 msgid "Arcane Necklace of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:60
 msgid "Caster's Bracelet of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:61
 msgid "Mage's Ring of Power"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:62
 msgid "Witch's Broach of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:63
 msgid "Medal of Valor"
 msgstr "Tapperhetens medalj"
 
-#: ../fheroes2/resource/artifact.cpp:63 ../fheroes2/resource/artifact.cpp:64
-#: ../fheroes2/resource/artifact.cpp:65 ../fheroes2/resource/artifact.cpp:66
 msgid "The %{name} increases your morale."
 msgstr "%{name} höjer din moral."
 
-#: ../fheroes2/resource/artifact.cpp:64
 msgid "Medal of Courage"
 msgstr "Modets medalj"
 
-#: ../fheroes2/resource/artifact.cpp:65
 msgid "Medal of Honor"
 msgstr "Hedersmedalj"
 
-#: ../fheroes2/resource/artifact.cpp:66
 msgid "Medal of Distinction"
 msgstr "Utmärkelsens medalj"
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "Fizbin of Misfortune"
 msgstr "Olycksfizbin"
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "The %{name} greatly decreases your morale by %{count}."
 msgstr "%{name} minskar kraftigt din moral med %{count}."
 
-#: ../fheroes2/resource/artifact.cpp:68
 msgid "Thunder Mace of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "Armored Gauntlets of Protection"
 msgstr "Beskyddande armerade stridshandskar"
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "The %{name} increase your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:70
 msgid "Defender Helm of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:71
 msgid "Giant Flail of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "Ballista of Quickness"
 msgstr "Snabbhetens kastmaskin"
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "The %{name} lets your catapult fire twice per combat round."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:73
 msgid "Stealth Shield of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:74
 msgid "Dragon Sword of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:75
 msgid "Power Axe of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:76
 msgid "Divine Breastplate of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:77
 msgid "Minor Scroll of Knowledge"
 msgstr "Mindre Kunskapsrulle"
 
-#: ../fheroes2/resource/artifact.cpp:78
 msgid "Major Scroll of Knowledge"
 msgstr "Större Kunskapsrulle"
 
-#: ../fheroes2/resource/artifact.cpp:79
 msgid "Superior Scroll of Knowledge"
 msgstr "Överordnad Kunskapsrulle"
 
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "Foremost Scroll of Knowledge"
 msgstr "Särskild Kunskapsrulle"
 
-#: ../fheroes2/resource/artifact.cpp:81
 msgid "Endless Sack of Gold"
 msgstr "Bottenlös säck av guld"
 
-#: ../fheroes2/resource/artifact.cpp:81 ../fheroes2/resource/artifact.cpp:82
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "The %{name} provides you with %{count} gold per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:82
 msgid "Endless Bag of Gold"
 msgstr "Bottenlös väska av guld"
 
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "Endless Purse of Gold"
 msgstr "Bottenlös börs av guld"
 
-#: ../fheroes2/resource/artifact.cpp:84
 msgid "Nomad Boots of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:84 ../fheroes2/resource/artifact.cpp:85
 msgid "The %{name} increase your movement on land."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:85
 msgid "Traveler's Boots of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:86
 msgid "Lucky Rabbit's Foot"
 msgstr "Hartass"
 
-#: ../fheroes2/resource/artifact.cpp:86 ../fheroes2/resource/artifact.cpp:87
-#: ../fheroes2/resource/artifact.cpp:88 ../fheroes2/resource/artifact.cpp:89
 msgid "The %{name} increases your luck in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:87
 msgid "Golden Horseshoe"
 msgstr "Gyllene hästsko"
 
-#: ../fheroes2/resource/artifact.cpp:88
 msgid "Gambler's Lucky Coin"
 msgstr "Spelarens turmynt"
 
-#: ../fheroes2/resource/artifact.cpp:89
 msgid "Four-Leaf Clover"
 msgstr "Fyrklöver"
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "True Compass of Mobility"
 msgstr "Mobilitetens sanna kompass"
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "The %{name} increases your movement on land and sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "Sailor's Astrolabe of Mobility"
 msgstr "Seglarens mobila astrolabium"
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "The %{name} increases your movement on sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "Evil Eye"
 msgstr "Ondskefullt öga"
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "The %{name} reduces the casting cost of curse spells by half."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "Enchanted Hourglass"
 msgstr "Förvandlat timglas"
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "The %{name} extends the duration of all your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "Gold Watch"
 msgstr "Gyllene klocka"
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "The %{name} doubles the effectiveness of your hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "Skullcap"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "The %{name} halves the casting cost of all mind influencing spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "Ice Cloak"
 msgstr "Ismantel"
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "The %{name} halves all damage your troops take from cold spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "Fire Cloak"
 msgstr "Eldmantel"
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "The %{name} halves all damage your troops take from fire spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "Lightning Helm"
 msgstr "Blixthjälm"
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "The %{name} halves all damage your troops take from lightning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid "Evercold Icicle"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid ""
 "The %{name} causes your cold spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid "Everhot Lava Rock"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid ""
 "The %{name} causes your fire spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid "Lightning Rod"
 msgstr "Blixtstav"
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid ""
 "The %{name} causes your lightning spells to do %{count} percent more damage "
 "to enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "Snake-Ring"
 msgstr "Ormring"
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "The %{name} halves the casting cost of all your bless spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid "Ankh"
 msgstr "Ankh"
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid ""
 "The %{name} doubles the effectiveness of all your resurrect and animate "
 "spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "Book of Elements"
 msgstr "Elementbok"
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "The %{name} doubles the effectiveness of all your summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "Elemental Ring"
 msgstr "Elementring"
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "The %{name} halves the casting cost of all summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "Holy Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "The %{name} makes all your troops immune to curse spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "Pendant of Free Will"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "The %{name} makes all your troops immune to hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "Pendant of Life"
 msgstr "Livets hängsmycke"
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "The %{name} makes all your troops immune to death spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "Serenity Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "The %{name} makes all your troops immune to berserk spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "Seeing-eye Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "The %{name} makes all your troops immune to blindness spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "Kinetic Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "The %{name} makes all your troops immune to paralyze spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "Pendant of Death"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "The %{name} makes all your troops immune to holy spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "Wand of Negation"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "The %{name} protects your troops from the Dispel Magic spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid "Golden Bow"
 msgstr "Gyllene båge"
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid ""
 "The %{name} eliminates the %{count} percent penalty for your troops shooting "
-"past obstacles. (e.g. castle walls)"
+"past obstacles (e.g. castle walls)."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid "Telescope"
 msgstr "Teleskop"
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid ""
 "The %{name} increases the amount of terrain your hero reveals when "
 "adventuring by %{count} extra square."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid "Statesman's Quill"
 msgstr "Statsmannens fjäderpenna"
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid ""
 "The %{name} reduces the cost of surrender to %{count} percent of the total "
 "cost of troops you have in your army."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "Wizard's Hat"
 msgstr "Trollkarlshatt"
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "The %{name} increases the duration of your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "Power Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "The %{name} returns %{count} extra power points/turn to your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "Ammo Cart"
 msgstr "Ammunitionsvagn"
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "The %{name} provides endless ammunition for all your troops that shoot."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "Tax Lien"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "The %{name} costs you %{count} gold pieces/turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "Hideous Mask"
 msgstr "Otäck mask"
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "The %{name} prevents all 'wandering' armies from joining your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "Endless Pouch of Sulfur"
 msgstr "Bottenlös påse av svavel"
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "The %{name} provides %{count} unit of sulfur per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "Endless Vial of Mercury"
 msgstr "Bottenlös flaska av kvicksilver"
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "The %{name} provides %{count} unit of mercury per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "Endless Pouch of Gems"
 msgstr "Bottenlös påse av ädelstenar"
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "The %{name} provides %{count} unit of gems per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "Endless Cord of Wood"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "The %{name} provides %{count} unit of wood per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "Endless Cart of Ore"
 msgstr "Bottenlös kärra av malm"
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "The %{name} provides %{count} unit of ore per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "Endless Pouch of Crystal"
 msgstr "Bottenlös påse av kristaller"
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "The %{name} provides %{count} unit of crystal/day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:128
 msgid "Spiked Helm"
 msgstr "Spikad hjälm"
 
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "Spiked Shield"
 msgstr "Spikad sköld"
 
-#: ../fheroes2/resource/artifact.cpp:130
 msgid "White Pearl"
 msgstr "Vit pärla"
 
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "Black Pearl"
 msgstr "Svart pärla"
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "Magic Book"
 msgstr "Magibok"
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "The %{name} enables you to cast spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "Spell Scroll"
 msgstr "Besvärjelserulle"
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid "Arm of the Martyr"
 msgstr "Martyrens arm"
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid ""
 "The %{name} increases your spell power by %{count} but adds the undead "
 "morale penalty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "Breastplate of Anduran"
 msgstr "Andurans bröstharnesk"
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "The %{name} increases your defense by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid "Broach of Shielding"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid ""
 "The %{name} provides %{count} percent protection from Armageddon and "
 "Elemental Storm, but decreases spell power by 2."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid "Battle Garb of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid ""
 "The %{name} combines the powers of the three Anduran artifacts.  It provides "
 "maximum luck and morale for your troops and gives you the Town Portal spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid "Crystal Ball"
 msgstr "Kristallboll"
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid ""
 "The %{name} lets you get more specific information about monsters, enemy "
 "heroes, and castles nearby the hero who holds it."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid "Heart of Fire"
 msgstr "Eldhjärta"
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid ""
 "The %{name} provides %{count} percent protection from fire, but doubles the "
 "damage taken from cold."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid "Heart of Ice"
 msgstr "Ishjärta"
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid ""
 "The %{name} provides %{count} percent protection from cold, but doubles the "
 "damage taken from fire."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:148
 msgid "Helmet of Anduran"
 msgstr "Andurans hjälm"
 
-#: ../fheroes2/resource/artifact.cpp:149
 msgid "Holy Hammer"
 msgstr "Helig hammare"
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "Legendary Scepter"
 msgstr "Legendarisk spira"
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "The %{name} adds %{count} points to all attributes."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "Masthead"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "The %{name} boosts your luck and morale by %{count} each in sea combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "Sphere of Negation"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "The %{name} disables all spell casting, for both sides, in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "Staff of Wizardry"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "The %{name} boosts your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "Sword Breaker"
 msgstr "Svärdsbrytare"
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "The %{name} increases your defense by %{count} and attack by 1."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "Sword of Anduran"
 msgstr "Andurans svärd"
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "Spade of Necromancy"
 msgstr "Svartkonstens spade"
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "The %{name} gives you increased necromancy skill."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:638
 msgid ""
 "You find an elaborate aontainer which housesan old vellum scroll. The runes "
 "on the container are very old, and the artistry with whitch it was put "
@@ -7192,7 +5892,6 @@ msgid ""
 "magical power."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:639
 msgid ""
 "One of the less intelligent members of your party picks up an arm off of the "
 "ground. Despite its missing a body, it is still moving. Your troops find the "
@@ -7201,7 +5900,6 @@ msgid ""
 "making."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:640
 msgid ""
 "You come upon a sign. It reads: \"Here lies the body of Anduran. Bow and "
 "swear fealty, and you shall be rewarded.\" You decide to do as it says. As "
@@ -7213,21 +5911,18 @@ msgstr ""
 "står. När du ställer dig upp känner du kyla mot din hud. Du upptäcker att du "
 "plötsligt bär ett skimrande utsmyckat bröstharnesk."
 
-#: ../fheroes2/resource/artifact.cpp:641
 msgid ""
 "A kindly Sorceress thinks that your army's defenses could use a magical "
 "boost. She offers to enchant the Broach that you wear on your cloak, and you "
 "accept."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:642
 msgid ""
 "Out of pity for a poor peasant, you purchase a chest of old junk they are "
 "hawking for too much gold. Later, as you search through it, you find it "
 "contains the 3 pieces of the legendary battle garb of Anduran!"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:643
 msgid ""
 "You come upon a caravan of gypsies who are feasting and fortifying their "
 "bodies with mead. They call you forward and say \"If you prove that you can "
@@ -7236,7 +5931,6 @@ msgid ""
 "Crystal Ball."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:644
 msgid ""
 "You enter a recently burned glade and come upon a Fire Elemental sitting "
 "atop a rock. It looks up, its flaming face contorted in a look of severe "
@@ -7244,7 +5938,6 @@ msgid ""
 "it, but it passes right through them and sears itself into your chest."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:645
 msgid ""
 "Suddenly, a biting coldness engulfs your body. You seize up, falling from "
 "your horse. The pain subsides, but you still feel as if your chest is "
@@ -7253,7 +5946,6 @@ msgid ""
 "woods and disappear."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:646
 msgid ""
 "You spy a gleaming object poking up out of the ground. You send a member of "
 "your party over to investigate. He comes back with a golden helmet in his "
@@ -7261,7 +5953,6 @@ msgid ""
 "only man who was known to wear solid gold armor."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:647
 msgid ""
 "You come upon a battle where a Paladin has been mortally wounded by a group "
 "of Zombies. He asks you to take his hammer and finish what he started.  As "
@@ -7269,7 +5960,6 @@ msgid ""
 "Zombies lie dead, the hammer dripping with blood. You strap it to your belt."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:648
 msgid ""
 "Upon cresting a small hill, you come upon a ridiculous looking sight. A "
 "Sprite is attempting to carry a Scepter that is almost as big as it is. "
@@ -7283,7 +5973,6 @@ msgstr ""
 "blänger på dig och svarar: \"Tror du att det är roligt? Visst, du kan bära "
 "den själv. Jag föredrar ändå att flyga.\""
 
-#: ../fheroes2/resource/artifact.cpp:649
 msgid ""
 "An old seaman tells you a tale of an enchanted masthead that he used in his "
 "youth to rally his crew during times of trouble. He then hands you a faded "
@@ -7291,14 +5980,12 @@ msgid ""
 "underneath a nearby dock."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:650
 msgid ""
 "You stop to help a Peasant catch a runaway mare. To show his gratitude, he "
 "hands you a tiny sphere. As soon as you grasp it, you feel the magical "
 "energy drain from your limbs..."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:651
 msgid ""
 "While out scaring up game, your troops find a mysterious staff levitating "
 "about three feet off of the ground. They hand it to you, and you notice an "
@@ -7306,13 +5993,11 @@ msgid ""
 "words, and you'll win every fight.\""
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:652
 msgid ""
 "A former Captain of the Guard admires your quest and gives you the enchanted "
 "Sword Breaker that he relied on during his tour of duty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:653
 msgid ""
 "A Troll stops you and says: \"Pay me 5,000 gold, or the Sword of Anduran "
 "will slay you where you stand.\" You refuse. The troll grabs the sword "
@@ -7326,4655 +6011,66 @@ msgstr ""
 "förtäljda svärdet och tackar det sinnessvaga trollets försök att ta tag i "
 "fel ände av det vassa objektet."
 
-#: ../fheroes2/resource/artifact.cpp:654
 msgid ""
 "A dirty shovel has been thrust into a dirt mound nearby. Upon investigation, "
 "you discover it to be the enchanted shovel of the Gravediggers, long thought "
 "lost by mortals."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:896
+#, fuzzy
 msgid ""
-"Do you want to use your knowledge of magical secrets to transcribe the %"
-"{spell} Scroll into your spell book?\n"
-"The Scroll will be consumed.\n"
-" Spell point: %{sp}"
+"Do you want to use your knowledge of magical secrets to transcribe the "
+"%{spell} Scroll into your Magic Book?\n"
+"The Spell Scroll will be consumed.\n"
+" Cost in spell points: %{sp}"
 msgstr ""
 "Vill du använda din kunskap om magiska hemligheter för att överföra %{spell}"
 "rullen till din besvärjelsebok?\n"
 "Rullen kommer att förstöras.\n"
 "Magipoäng: %{sp}"
 
-#: ../fheroes2/resource/artifact.cpp:960
-msgid "Open book"
-msgstr ""
+#, fuzzy
+msgid "Transcribe Spell Scroll"
+msgstr "Besvärjelserulle"
 
-#: ../fheroes2/resource/artifact.cpp:965
-msgid "Transcribe scroll"
-msgstr ""
+#, fuzzy
+msgid "View Spells"
+msgstr "Visa alla"
 
-#: ../fheroes2/resource/artifact.cpp:975
-#: ../fheroes2/resource/artifact.cpp:1008
+#, fuzzy
+msgid "View %{name} Info"
+msgstr "Visa %{name}"
+
 msgid "Move %{name}"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:998
 msgid "Cannot move artifact"
 msgstr ""
 
-#: ../fheroes2/resource/maps_text.cpp:15
-msgid ""
-"425 bottles of beer on the wall, 425 bottles of beer! If one of those "
-"bottles should happen to fall, there'll be..."
+msgid "This item can't be traded."
 msgstr ""
-"425 flaskor öl på väggen, 425 flaskor öl! Om en av flaskorna skulle falla, "
-"skulle det vara..."
 
-#: ../fheroes2/resource/maps_text.cpp:16
-msgid "A balanced scenario with lots of resources and land to explore."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:17
-msgid ""
-"A bandit army of gorgons jump you without warning.  they stone your entire "
-"army demand 500 gold before they will release your comrads.  Realizing that "
-"it is much cheeper to pay then rebuild your army you part with the gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:18
-msgid "Abandon All Hope!"
-msgstr "Ge upp allt hopp!"
-
-#: ../fheroes2/resource/maps_text.cpp:19
-msgid "Abandon All Hope Ye That Enter Here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:20
-msgid "A bit of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:21
-msgid "A bit of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:22
-msgid "A bit of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:23
-msgid ""
-"Above you looms the ancient Ice Palace.  Dimly remembered myth speaks of a "
-"Prince who rejected the advances of the Winter Goddess, and thus he and his "
-"domain were cursed to remain shrouded in ice, hidden in a forgotten corner "
-"of the world.  It is said that he can only be rescued by a hero who is both "
-"clever and bold.  Are you that one?  Do you dare enter this frozen domain?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:24
-msgid "A cache of crystal!"
-msgstr "Ett förråd av kristaller!"
-
-#: ../fheroes2/resource/maps_text.cpp:25
-msgid "A cache of gems!"
-msgstr "Ett förråd av ädelstenar!"
-
-#: ../fheroes2/resource/maps_text.cpp:26
-msgid "A cache of gold!"
-msgstr "Ett förråd av guld!"
-
-#: ../fheroes2/resource/maps_text.cpp:27
-msgid "A cache of mercury!"
-msgstr "Ett förråd av kvicksilver!"
-
-#: ../fheroes2/resource/maps_text.cpp:28
-msgid "A cache of sulfur!"
-msgstr "Ett förråd av svavel!"
-
-#: ../fheroes2/resource/maps_text.cpp:29
-msgid ""
-"A chance to end a bitter war has finally arrived as a new resource-laden "
-"land has been discovered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:30
-msgid "A chunk of gold!"
-msgstr "Ett stycke guld!"
-
-#: ../fheroes2/resource/maps_text.cpp:31
-msgid "A chunk of ore!"
-msgstr "Ett stycke malm!"
-
-#: ../fheroes2/resource/maps_text.cpp:32
-msgid "A couple of gems!"
-msgstr "Några ädelstenar!"
-
-#: ../fheroes2/resource/maps_text.cpp:33
-msgid "\"Act of Desperation\""
-msgstr "\"Desperationens gärning\""
-
-#: ../fheroes2/resource/maps_text.cpp:34
-msgid ""
-"A desert isle rich in resources rewards the quick.  Just be sure to watch "
-"your back!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:35
-msgid "A dolphin playfully jumps into the air."
-msgstr "En delfin hoppar lekfullt upp i luften."
-
-#: ../fheroes2/resource/maps_text.cpp:36
-msgid ""
-"A Dragon, A Cyclops, or an Undead. King of the Centaurs, His name is ....?"
-msgstr "En drake, en cyklop eller en odöd. Kentaurernas kung. Hans namn är...?"
-
-#: ../fheroes2/resource/maps_text.cpp:37
-msgid "A flight of dragons circles overhead."
-msgstr "En grupp drakar cirkulerar ovanför."
-
-#: ../fheroes2/resource/maps_text.cpp:38
-msgid "A flock of seagulls circle overhead."
-msgstr "En flock fiskmåsar cirkulerar ovanför."
-
-#: ../fheroes2/resource/maps_text.cpp:39
-msgid "A friendly dolphin splashes alongside the ship."
-msgstr "En vänlig delfin plaskar vid sidan av  skeppet."
-
-#: ../fheroes2/resource/maps_text.cpp:40
-msgid ""
-"After a long search of the island, I have discovered that there is no way "
-"for me to escape without help.  I can not steal a ship from one of the "
-"coastal castles, and I dare not venture into the desert unless I wish to "
-"become Dragon food.  Should anyone find this, I beg of you, please send a "
-"ship and get me off this cursed island!  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:41
-msgid ""
-"After centuries of friendship, the Wizards have suddenly decided to stop "
-"sharing their Library with the rest of the world.  This can't be good!"
-msgstr ""
-"Efter århundraden av vänskap bästämmer sig trollkarlarna plötsligt för att "
-"sluta dela med sig deras bibliotek med världen. Detta kan inte vara bra!"
-
-#: ../fheroes2/resource/maps_text.cpp:42
-msgid ""
-"After many years of peace, you discover that your sworn enemy from across "
-"the sea has chosen to invade your homeland by raising up the ocean floor to "
-"bridge the distance! You must not let them gain a foothold on this "
-"continent, in fact, your King has ordered you to establish a foothold on "
-"theirs!  To make matters worse, two of your OWN towns have thrown in their "
-"lots with the enemy..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:43
-msgid ""
-"After you return from a scouting trip, your Seneschal hurries to greet you.  "
-"\"My Lord, in your absence I signed an agreement in your name with a Master "
-"Merchant.  If we supply him with the resources he needs, through trading, he "
-"can return the resources to us in a week or so, plus some additional ones."
-"\"  The Seneschal eyes you anxiously.  You hesitate, then nod slowly, "
-"\"Good, we can use more resources>\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:44
-msgid "A ghostly pirate ship appears and sails on by."
-msgstr "En spökligt piratskepp dyker upp och seglar förbi."
-
-#: ../fheroes2/resource/maps_text.cpp:45
-msgid ""
-"A Gift from your King, and a note that reads \"Use these resources wisely, "
-"It's all we have left\"."
-msgstr ""
-"En gåva från din kung. På en medföljande lapp står det, \"Använd dessa "
-"resurser klokt, det är allt vi har kvar\"."
-
-#: ../fheroes2/resource/maps_text.cpp:46
-msgid ""
-"A gift of gold, m'lord, from the people of Enroth, to the people of Enroth.  "
-"Good luck, and may God save true King Roland!"
-msgstr ""
-"En gåva av guld, herre, från Enroths folk till Enroths folk. Lycka till, och "
-"må Gud rädda den sanne Kung Roland!"
-
-#: ../fheroes2/resource/maps_text.cpp:47
-msgid "A glint by a tree catches your eye..."
-msgstr "En glimt av ett träd fångar din blick..."
-
-#: ../fheroes2/resource/maps_text.cpp:48
-msgid "A gold cache!"
-msgstr "Ett förråd av guld!"
-
-#: ../fheroes2/resource/maps_text.cpp:49
-msgid "A gold chunk!"
-msgstr "Ett stycke guld!"
-
-#: ../fheroes2/resource/maps_text.cpp:50
-msgid "A gold nugget!"
-msgstr "En guldklimp!"
-
-#: ../fheroes2/resource/maps_text.cpp:51
-msgid ""
-"A great Black dragon stands before you. It speaks in a suprisingly soft "
-"voice, saying, \"The elves believe they have sent another hero to reclaim "
-"their prize. I believe they have sent me another meal.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:52
-msgid ""
-"A group of peasant farmers approaches you, \"We are in dire need of your "
-"assistance.  Our castle to the north has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:53
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance.  Our castle to the east has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:54
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance. Our castle to the east has been overrun and our Lord killed. "
-"Please help us regain our homes! There are still women and children there! "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:55
-msgid ""
-"A group of peasant farmers approach you, We are in dire need of your "
-"assistance.  Our castle to the northeast has been overrun and our Lord "
-"killed.  Please help us regain our homes!  There are still women and "
-"children there!  Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:56
-msgid "A handful of gems!"
-msgstr "En handfull ädelstenar!"
-
-#: ../fheroes2/resource/maps_text.cpp:57
-msgid ""
-"Ah, you stumble across something buried in the sand.  As you dig it up you "
-"discover a small pile of gems and crystal."
-msgstr ""
-"Åh, du stöter på någonting som är begravt i sanden. När du gräver upp det "
-"upptäcker du att det är en liten hög med ädelstenar och kristaller."
-
-#: ../fheroes2/resource/maps_text.cpp:58
-msgid ""
-"A Knight and Necromancer team up against the Barbarian and Sorceress. (Blue "
-"and Green vs Red and Yellow)"
-msgstr ""
-"En riddare och svartkonstnär slår ihop sig mot barbaren och häxan. (Blå och "
-"Grön mot Röd och Gul)"
-
-#: ../fheroes2/resource/maps_text.cpp:60
-msgid ""
-"A large contingent of the king's guard approaches you.  \"Ahh, we have "
-"finally caught up to you.  The king requires tribute from all of his vassals "
-"and you have been negligent far too long.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:61
-msgid ""
-"A large map with lots of resources and treasure. Exploration and victory "
-"will require many heroes."
-msgstr ""
-"En stor karta med mängder av resurser och skatter. Utforskning och seger "
-"kommer att kräva många hjältar."
-
-#: ../fheroes2/resource/maps_text.cpp:62
-msgid "A legion of peasants stands between you and this unclaimed island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:63
-msgid "Algary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:64
-msgid "A little bit closer..."
-msgstr "Lite närmare..."
-
-#: ../fheroes2/resource/maps_text.cpp:65
-msgid "All mines are grouped by type. Trade is your only hope."
-msgstr "Alla gruvor är grupperade efter typ. Byteshandel är ditt enda hopp."
-
-#: ../fheroes2/resource/maps_text.cpp:66
-msgid "A lump of crystal!"
-msgstr "Ett stycke kristall"
-
-#: ../fheroes2/resource/maps_text.cpp:67
-msgid "A lump of gold!"
-msgstr "Ett stycke guld!"
-
-#: ../fheroes2/resource/maps_text.cpp:68
-msgid "A lump of mercury!"
-msgstr "Ett stycke kvicksilver!"
-
-#: ../fheroes2/resource/maps_text.cpp:69
-msgid ""
-"A man appears from behind the sand dune. \"At last,\" he says, \"Someone has "
-"come to rescue me! I am forever grateful. Alas all I have to offer you in "
-"return are these souvenirs from my wrecked ship.\""
-msgstr ""
-"En man dyker upp bakom en sanddyna. \"Till slut,\" säger han, \"Någon kommer "
-"för att rädda mig! Jag är riktig tacksam. Tyvärr är det enda jag kan erbjuda "
-"dig är dessa souvenirer från mitt förlistna skepp.\""
-
-#: ../fheroes2/resource/maps_text.cpp:70
-msgid ""
-"A man is laying on the ground, near death. He looks to you and speaks, "
-"\"Please help my companions! Please... they can't...cough...get away from..."
-"cough...the drag...\" With that, he dies."
-msgstr ""
-"En döende man ligger på marken. Han tittar på dig och säger, \"Snälla, hjälp "
-"mina kamrater! Snälla... de kan inte... host... komma undan... host... från "
-"drak...\", plötsligt dör han."
-
-#: ../fheroes2/resource/maps_text.cpp:71
-msgid ""
-"A merchant caravan arrives, bringing gold and supplies, however, no one can "
-"seem to remember where they came from.  You silently praise this anonymous "
-"benefactor and continue your duties."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:72
-msgid "a mirror"
-msgstr "En spegel"
-
-#: ../fheroes2/resource/maps_text.cpp:73
-msgid "An albatross flies ahead of the ship for a while"
-msgstr "En albatross flyger vid skeppet för en stund"
-
-#: ../fheroes2/resource/maps_text.cpp:74
-msgid "Anduran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:75
-msgid ""
-"An enemy from across the sea has seized half your towns.  Can you put aside "
-"your own feud with your brother to fight this common enemy?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:76
-msgid "\"Annexation\""
-msgstr "\"Tillägg\""
-
-#: ../fheroes2/resource/maps_text.cpp:77
-msgid ""
-"An old elf is sitting on a rock in a glen, pounding on the shackles on his "
-"feet with a stone. You help him remove them and ask him his tale. \"I'm a "
-"deserter from Drakonia's army. She has enslaved all the elves to support her "
-"madness. She must be stopped.\" Then he slips into the woods without a "
-"sound, leaving behind just his cloak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:78
-msgid "Antioch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:79
-msgid "A piece of crystal!"
-msgstr "En bit av en kristall!"
-
-#: ../fheroes2/resource/maps_text.cpp:80
-msgid "A pile of crystal!"
-msgstr "En hög kristaller!"
-
-#: ../fheroes2/resource/maps_text.cpp:81
-msgid "A pile of gems!"
-msgstr "En hög av ädelstenar!"
-
-#: ../fheroes2/resource/maps_text.cpp:82
-msgid "A pile of gold!"
-msgstr "En hög av guld!"
-
-#: ../fheroes2/resource/maps_text.cpp:83
-msgid ""
-"A plague of undead is upon us. Who will unite the living against the dead?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:84
-msgid "\"Apocalypse\""
-msgstr "\"Apokalyps\""
-
-#: ../fheroes2/resource/maps_text.cpp:85
-msgid "A quantity of crystal!"
-msgstr "En mängd kristaller!"
-
-#: ../fheroes2/resource/maps_text.cpp:86
-msgid "A quantity of mercury!"
-msgstr "En mängd kvicksilver!"
-
-#: ../fheroes2/resource/maps_text.cpp:87
-msgid "A quantity of sulfur!"
-msgstr "En mängd svavel!"
-
-#: ../fheroes2/resource/maps_text.cpp:89
-msgid ""
-"Archibald has also sent an army to find the Crown, you must find it first or "
-"all is lost."
-msgstr ""
-"Archibald har också skickat en armé för att hitta Kronan. Du måste hitta den "
-"först, annars är allt förlorat."
-
-#: ../fheroes2/resource/maps_text.cpp:90
-msgid "Archibald is hiding at the end of the river."
-msgstr "Archibald gömmer sig vid flodens slut."
-
-#: ../fheroes2/resource/maps_text.cpp:91
-msgid ""
-"A resource rich valley keeps the Wizard and the Necromancer apart. Your "
-"opponent's army will arrive in 3 months so hurry."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:92
-msgid "Arm of the Crusader"
-msgstr "Korsriddarens arm"
-
-#: ../fheroes2/resource/maps_text.cpp:93
-msgid "Arm of the Cyclops"
-msgstr "Cyklopens arm"
-
-#: ../fheroes2/resource/maps_text.cpp:94
-msgid "Arm of the Dragon"
-msgstr "Drakens arm"
-
-#: ../fheroes2/resource/maps_text.cpp:95
-msgid "Arm of the Phoenix"
-msgstr "Fenixens arm"
-
-#: ../fheroes2/resource/maps_text.cpp:96
-msgid "Arm of the Titan"
-msgstr "Titanens arm"
-
-#: ../fheroes2/resource/maps_text.cpp:97
-msgid "Arr' Here be pirates gold buried."
-msgstr "Arr' Här är piratguld nedgrävd."
-
-#: ../fheroes2/resource/maps_text.cpp:98
-msgid "A shipment of wood has arrived from your kingdom!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:99
-msgid ""
-"A splash in the seaweed alerts you to a mermaid waving in a friendly manner. "
-"\"Oh, I thought you were Ahab.\" She is surprised, but quickly composes "
-"herself. \"Well, if you meet him, give him these treasures I have collected."
-"\""
-msgstr ""
-"Ett plask i sjögräset förvarnar dig om en sjöjungfru som vänligt vinkar till "
-"dig. \"Åh, jag trodde du var Ahab.\" Hon är överraskad, men hämtar sig "
-"snabbt. \"Nåja, om du träffar honom, ge honom dessa skatter som jag har "
-"samlat på.\""
-
-#: ../fheroes2/resource/maps_text.cpp:100
-msgid "Assassins tried to kill our ally."
-msgstr "Lönnmördare försöker döda våra allierade."
-
-#: ../fheroes2/resource/maps_text.cpp:101
-msgid "Astircaer"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:102
-msgid ""
-"A stranded Wizard with only a small force must conquer an entire continent "
-"of hostile forces."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:103
-msgid ""
-"A supply ship has arrived from the homeland!  You send word home that all is "
-"well."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:104
-msgid ""
-"As you approach the barrier, you see the old elf you helped free. This time, "
-"however, you see that he is wearing a cape of fine weave, and a wooden crown "
-"is on his head. He sees your forces, and says \"Take this sword, and with "
-"it, strike down Drakonia and help free my people.\" The old elf then strides "
-"regally into the woods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:105
-msgid ""
-"As you approach the gates of the Ice Palace, one of your troops points in "
-"terror.  You watch in awe as great slabs of ice separate from the castle "
-"walls with loud cracking reports and crash to the ground.  Soon the ice is "
-"gone and the sun begins to peak through the gloom.  The deathly silence that "
-"must have ruled these lands for centuries ends as birds begin to sing.  From "
-"inside you hear the sounds of life."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:106
-msgid ""
-"As you approach the tent, the leader of the nomads comes out to greet you. "
-"He says, \"It was prophecied many years ago that a great hero would come to "
-"greet us in our sacred valley, and we would prosper afterwords. Now it has "
-"come to pass, and we offer you these gifts as tokens of our thanks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:107
-msgid ""
-"As you approach,  you hear whispered mentions of \"the wild barbarian who "
-"passed this way months before\". One of the villagers approaches you and "
-"hands you an object, saying \"The wild one dropped this. You must be his "
-"kin. Therefore I give it to you. But beware! Many in the village will not be "
-"as friendly as I.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:108
-msgid ""
-"As you break your fast your sage rushes in, \"Good news, my lord!  I have "
-"translated the message.  Two great heroes were imprisoned many years ago.  "
-"They lie sleeping - still guarded by magic barriers and monsters.  My lord, "
-"they lie nearby- in between our ally and us.  If we could free them, they "
-"would surely aid us against our enemies!  The password to the first magic "
-"barrier can be learned at the Aqua Traveller's Tent.\""
-msgstr ""
-"När du hejdar dig kommer din vise man rusande, \"Goda nyheter, min herre! "
-"Jag har översatt meddelandet. Två stora hjältar var tillfångatagen för flera "
-"år sedan. Dem sover, vaktade av magiska barriärer och monster. Min herre, de "
-"ligger i närheten, mellan våra bundsförvanter och oss. Om vi kan frita dem, "
-"skulle dem kunna stödja oss mot fiender! Lösenordet för den första barriären "
-"kan man få hos akvamarins resenärstält.\""
-
-#: ../fheroes2/resource/maps_text.cpp:109
-msgid ""
-"As you enter the small clearing, you see a familiar figure talking to a "
-"group of halflings and soldiers. You stay awhile and listen to his speech. "
-"\"The time to throw off these chains of tyranny is now! We must strike at "
-"the heart of her empire, and destroy the evil that she has brought to our "
-"land.\" As the old elf finishes speaking, he gets up from his mossy seat and "
-"once again, blends into the woods with incredible grace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:110
-msgid ""
-"As you lay down to nap after a long battle, you notice a lucky four-leaf "
-"clover."
-msgstr "När du lägger dig ned efter en lång strid hittar du en fyrklöver."
-
-#: ../fheroes2/resource/maps_text.cpp:111
-msgid ""
-"As you make  your way through the last of the golemn debris, a group of "
-"halflings runs towards you carrying fruit and flowers. \"Thank you so much!"
-"\" Their leader exclaims, \"We've been trapped in here for ever! Come by our "
-"homes, we'll pack up and go with you!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:112
-msgid ""
-"As you make your way to the shrine, some very thin and hollow-eyed men come "
-"out of the flower patch and stare at you.  Seeing that you want the gold, "
-"one of them says to you \"Hey, man, if you're, like, so lusty for earthly "
-"wealth, then, like, have this too.\" You graciously take what they have "
-"offered and back out of the clearing."
-msgstr ""
-"När du går mot templet, kommer några smala hålögda män ut från blomfältet "
-"och stirrar på dig. När de ser att du vill ha guldet säger en av dem "
-"\"Tjena, mannen. Om du är, typ, så stark för jordisk förmögenhet kan du, "
-"typ, ta det här också.\" Du tar nådigt emot vad de erbjöd och går tillbaka "
-"ut från gläntan"
-
-#: ../fheroes2/resource/maps_text.cpp:113
-msgid ""
-"As you prepare your lands to fight the onslaught from the South, a curious "
-"message appears on your table in the Great Hall of your Castle.  Written in "
-"some ancient language, none but your sage can make any sense of it.  She "
-"promises to have the words deciphered by tomorrow..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:114
-msgid "A three hour tour, a three hour tour..."
-msgstr "En tretimmarsresa, en tretimmarsresa..."
-
-#: ../fheroes2/resource/maps_text.cpp:115
-msgid ""
-"A tiny gnome points to a chunk of crystal you otherwise would have "
-"overlooked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:116
-msgid "Atlantium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:117
-msgid ""
-"At last, the king is dead.  For years you have planned his demise, but now "
-"it is done, and there is no heir to take his place, though the Knights to "
-"the south believe that they are the rightful successors.  A wealth in wood "
-"(to the south) and ore (in the northern mountains) provides you with trade "
-"goods, and your isolation has allowed you to prepare your forces of darkness "
-"for this day.  Go, now, and fulfill your destiny!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:118
-msgid ""
-"At the base of the mountain you see something that glitters.   You discover "
-"an ancient pile of offerings to the gods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:119
-msgid "Avalon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:120
-msgid "Avone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:121
-msgid ""
-"A wild magic has allowed a bridge to form between two lands...  Your one "
-"hope is to capture castle \"Black Fang\"."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:122
-msgid "Barbarian's castle lies to the south."
-msgstr "Barbarernas slott ligger söderut."
-
-#: ../fheroes2/resource/maps_text.cpp:123
-msgid ""
-"Barbarians from the north threaten all civilization. Can you repel the "
-"hordes?"
-msgstr "Barbarer från norr hotar all civilisation. Kan du stöta bort hordarna?"
-
-#: ../fheroes2/resource/maps_text.cpp:124
-msgid "\"Barbarian Wars\""
-msgstr "\"Barbarkrig\""
-
-#: ../fheroes2/resource/maps_text.cpp:125
-msgid "Barrowton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:126
-msgid "Basenji"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:127
-msgid "Bayside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:128
-msgid "Baywatch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:129
-msgid ""
-"Because the Darkscale Valley is so barren, the Emperor will be sending wood "
-"to you every week. Use it wisely, for it is all you shall have."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:130
-msgid ""
-"Before questing for the orb of negation, you must first crush the local "
-"opposition. After the Sorceresses are removed from the earth, go east where "
-"legend says the orb lies.  You may expect a convoy of supplies in a week or "
-"so to aid your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:131
-msgid ""
-"Before you may pass, the spirit guardian of this valley demands tribute."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:132
-msgid "Being held...."
-msgstr "Hålls..."
-
-#: ../fheroes2/resource/maps_text.cpp:133
-msgid "Beltway"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:134
-msgid "\"Betrayal!\""
-msgstr "\"Förräderi!\""
-
-#: ../fheroes2/resource/maps_text.cpp:135
-msgid "Beware -- Entering Hyrda Country"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:136
-msgid "Beware for whom the bell trolls."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:137
-msgid "Beware of Pirates!"
-msgstr "Se upp för pirater!"
-
-#: ../fheroes2/resource/maps_text.cpp:138
-msgid "Beware of thieves!"
-msgstr "Se upp för tjuvar!"
-
-#: ../fheroes2/resource/maps_text.cpp:139
-msgid "Beware of traps ahead."
-msgstr "Se upp för fällor framöver."
-
-#: ../fheroes2/resource/maps_text.cpp:140
-msgid "Beware of Warlocks"
-msgstr "Varning för krigstrollkarlar"
-
-#: ../fheroes2/resource/maps_text.cpp:141
-msgid "Beware the deadly swamps!"
-msgstr "Se upp för dödliga träsket!"
-
-#: ../fheroes2/resource/maps_text.cpp:142
-msgid "Beware the Domain of Dragons"
-msgstr "Varning för Drakdomänen"
-
-#: ../fheroes2/resource/maps_text.cpp:143
-msgid "Beware the Dragon Leader"
-msgstr "Varning för Drakledaren"
-
-#: ../fheroes2/resource/maps_text.cpp:144
-msgid "Beware the edge of the world!"
-msgstr "Se upp för världens ende!"
-
-#: ../fheroes2/resource/maps_text.cpp:145
-msgid "Beware the moors and stick to the roads."
-msgstr "Se upp för hedarna och håll dig på vägarna."
-
-#: ../fheroes2/resource/maps_text.cpp:146
-msgid "Beware the rocks"
-msgstr "Se upp för stenar"
-
-#: ../fheroes2/resource/maps_text.cpp:147
-msgid "Beware the sirens!!!"
-msgstr "Se upp för sirenerna!!!"
-
-#: ../fheroes2/resource/maps_text.cpp:148
-msgid "Beware the sirens!"
-msgstr "Se upp för sirenerna!"
-
-#: ../fheroes2/resource/maps_text.cpp:149
-msgid "Beware the whiporwill..."
-msgstr "Se upp för nattskärran..."
-
-#: ../fheroes2/resource/maps_text.cpp:150
-msgid "Beware, the whirlpool may not take you into a friendly embrace."
-msgstr "Varning, strömvirveln kommer nog inte att ge dig en vänlig omfamning."
-
-#: ../fheroes2/resource/maps_text.cpp:151
-msgid "Beyond here be Dragons!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:152
-msgid "Beyond the door, there be Dragons. BEWARE!"
-msgstr "Bortom denna dörr finns det drakar. VARNING!"
-
-#: ../fheroes2/resource/maps_text.cpp:153
-msgid "Big Oak"
-msgstr "Stor Ek"
-
-#: ../fheroes2/resource/maps_text.cpp:154
-msgid "Blackburn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:155
-msgid "Blackfang"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:156
-msgid "Black Fang"
-msgstr "Svart Huggtand"
-
-#: ../fheroes2/resource/maps_text.cpp:157
-msgid "Black Oak"
-msgstr "Svart Ek"
-
-#: ../fheroes2/resource/maps_text.cpp:158
-msgid "Blackridge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:159
-msgid "Blacksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:160
-msgid "Black Vein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:161
-msgid "Blackwind"
-msgstr "Svartvind"
-
-#: ../fheroes2/resource/maps_text.cpp:162
-msgid "Bloodreign"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:163
-msgid "Boats my be needed to access some parts of this peninsula."
-msgstr "Båtar behövs för att nå vissa delar av halvön."
-
-#: ../fheroes2/resource/maps_text.cpp:164
-msgid "Boats Sold Here            Inquire Within"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:165
-msgid "BoneVille"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:166
-msgid "Borderlands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:167
-msgid "Bridge out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:168
-msgid "Bridge Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:169
-msgid "Brindamoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:170
-msgid "Broken Alliance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:171
-msgid "Brownston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:172
-msgid "Buried Treasure!"
-msgstr "Nedgrävd skatt!"
-
-#: ../fheroes2/resource/maps_text.cpp:173
-msgid "Burlock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:174
-msgid "Burton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:175
-msgid ""
-"Capture the necromancer's dreaded castle \"Death Gate\" and free the land "
-"from the undead plague."
-msgstr ""
-"Tillfångata svartkonstnärens fruktade slott \"Dödsporten\" och befria landet "
-"från en odödlig plåga."
-
-#: ../fheroes2/resource/maps_text.cpp:176
-msgid ""
-"Capture the town on the island off the southeast shore in order to construct "
-"a boat and travel back towards the mainland."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:177
-msgid "\"Carator Mines\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:178
-msgid "Cathcart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:180
-msgid "Chandler"
-msgstr "Småhandlare"
-
-#: ../fheroes2/resource/maps_text.cpp:181
-msgid "Chilton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:182
-msgid "Chronos"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:183
-msgid "Come and...."
-msgstr "Kom och..."
-
-#: ../fheroes2/resource/maps_text.cpp:184
-msgid ""
-"Compared to the rest of the villages in this land, this village seems grand, "
-"but in any other land it would seem poor. From here you can see the tall "
-"spires of the Warlock's tower of Dragons."
-msgstr ""
-"Jämfört med resten av byarna i detta land verkar denna by vara ståtlig. Men "
-"i ett annat land skulle det verka fattigt. Härifrån kan du se de höga "
-"spirorna från Krigstrollkarlarnas Draktorn."
-
-#: ../fheroes2/resource/maps_text.cpp:185
-msgid "Complete"
-msgstr "Klar"
-
-#: ../fheroes2/resource/maps_text.cpp:186
-msgid "Condemned!"
-msgstr "Dömd!"
-
-#: ../fheroes2/resource/maps_text.cpp:187
-msgid ""
-"Congratulations! After navigating the treacherous coast, you have "
-"established trade between the north and south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:188
-msgid "Corackston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:189
-msgid "Corlagon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:190
-msgid "\"Country Lords\""
-msgstr "\"Landslordar\""
-
-#: ../fheroes2/resource/maps_text.cpp:191
-msgid "Crossroads"
-msgstr "Vägskäl"
-
-#: ../fheroes2/resource/maps_text.cpp:192
-msgid "Crossroads North"
-msgstr "Vägskäl norr"
-
-#: ../fheroes2/resource/maps_text.cpp:193
-msgid "Crossroads South"
-msgstr "Vägskäl söder"
-
-#: ../fheroes2/resource/maps_text.cpp:195
-msgid "Danger a whirlpool destroyed my ship."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:196
-msgid "Danger, Dragons abound!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:197
-msgid "DANGER!  QUICKSAND!"
-msgstr "FARA! KVICKSAND!"
-
-#: ../fheroes2/resource/maps_text.cpp:198
-msgid "Danger! Troll bridge ahead!"
-msgstr "Fara! Trollbro framöver!"
-
-#: ../fheroes2/resource/maps_text.cpp:199
-msgid "Danger - Turn Back Now"
-msgstr "Fara - Vänd genast om!"
-
-#: ../fheroes2/resource/maps_text.cpp:200
-msgid "Dark clouds loom overhead as you enter this valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:201
-msgid "Dead Pine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:202
-msgid ""
-"Dear Diary,                           I found a mermaid today.  She was "
-"floating in a patch of seaweed next to a rock.  A very friendly sort of "
-"creature too!  Gave me all sorts of lovely gems and jewelry!  She said to "
-"come back again sometime for more of the sea riches.  Wow. Ahab"
-msgstr ""
-"Kära dagbok, idag hittade jag en sjöjungfru. Hon flöt i sjögräset intill en "
-"sten. En riktigt trevlig varelse också! Hon gav mig alla sorters ädelstenar "
-"och smycken! Hon sa åt mig att komma tillbaka igen någon gång för mer "
-"sjöskatter. Wow. Ahab"
-
-#: ../fheroes2/resource/maps_text.cpp:203
-msgid "Deathgate"
-msgstr "Dödsport"
-
-#: ../fheroes2/resource/maps_text.cpp:204
-msgid "DeathGate"
-msgstr "Dödsport"
-
-#: ../fheroes2/resource/maps_text.cpp:205
-msgid "Decisions"
-msgstr "Beslut"
-
-#: ../fheroes2/resource/maps_text.cpp:206
-msgid "\"Defender\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:207
-msgid ""
-"Destroy the Barbarians who are attacking the southern border of your "
-"kingdom! Recover your towns and then invade the jungle kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:208
-msgid ""
-"Detour! Mountain pass to the East has been known to have avalanches! For "
-"your own safety, follow the road South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:209
-msgid "Detour! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:211
-msgid "DirtWater"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:212
-msgid "Dominion"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:213
-msgid "Do Not Enter!"
-msgstr "Gå Inte In!"
-
-#: ../fheroes2/resource/maps_text.cpp:214
-msgid "Do not remove coins from fountain."
-msgstr "Plocka inte upp mynt från fontänen."
-
-#: ../fheroes2/resource/maps_text.cpp:215
-msgid "Dragadune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:216
-msgid "Dragonburg"
-msgstr "Drakborg"
-
-#: ../fheroes2/resource/maps_text.cpp:218
-msgid "Dragon City lies beyond the Scorpion Hills."
-msgstr "Drakstaden ligger bortom Skorpionbergen."
-
-#: ../fheroes2/resource/maps_text.cpp:219
-msgid "Dragon Hill"
-msgstr "Drakberget"
-
-#: ../fheroes2/resource/maps_text.cpp:220
-msgid "\"Dragon Master\""
-msgstr "\"Drakmästare\""
-
-#: ../fheroes2/resource/maps_text.cpp:221
-msgid "Dragon Rider"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:222
-msgid "Dragons Everywhere!"
-msgstr "Drakar överallt"
-
-#: ../fheroes2/resource/maps_text.cpp:223
-msgid "Dragon's Eye"
-msgstr "Draköga"
-
-#: ../fheroes2/resource/maps_text.cpp:224
-msgid "Dragontooth"
-msgstr "Draktand"
-
-#: ../fheroes2/resource/maps_text.cpp:225
-msgid "Dragon Town"
-msgstr "Drakstaden"
-
-#: ../fheroes2/resource/maps_text.cpp:226
-msgid "Dragonville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:227
-msgid "Dragon Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:228
-msgid "Dragon Watch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:230
-msgid "Drakoran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:231
-msgid "Dwarfhall"
-msgstr "Dvärghall"
-
-#: ../fheroes2/resource/maps_text.cpp:232
-msgid "Dwarfhall, Domain of the dwarf King."
-msgstr "Dvärghall, dvärgkungens domän."
-
-#: ../fheroes2/resource/maps_text.cpp:233
-msgid "Dwarf Hall, domain of the dwarf King."
-msgstr "Dvärghall, dvärgkungens domän."
-
-#: ../fheroes2/resource/maps_text.cpp:234
-msgid "Eatio"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:235
-msgid "Edgewood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:236
-msgid "Elk's Head"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:237
-msgid "Elowyn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:238
-msgid "Enroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:239
-msgid "Entering high in the desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:240
-msgid "Entering Praires of the Middlelands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:241
-msgid "Entering the desert high"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:242
-msgid "Entering the high desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:243
-msgid "Entering the higher desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:244
-msgid "Entering the Valley of Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:245
-msgid "Erliquin"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:246
-msgid "Evil Igor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:247
-msgid "Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:248
-msgid "Fantasy Island."
-msgstr "Fantasiön."
-
-#: ../fheroes2/resource/maps_text.cpp:249
-msgid "Farlien"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:250
-msgid ""
-"Federal express, when it absolutely positively has to be there turn one."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:251
-msgid "fedx comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:252
-msgid "Fedx for comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:253
-msgid "Fenton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:254
-msgid "Fetid Elm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:255
-msgid ""
-"Final message from Overlord. \"The royal executioners are on their way. My "
-"gold, the land or your head- it's your choice.\""
-msgstr ""
-"Ett sista meddelande från Överherren. \"Den kungliga bödeln är på väg. Mitt "
-"guld, landet eller ditt huvud - du bestämmer.\""
-
-#: ../fheroes2/resource/maps_text.cpp:256
-msgid "Find and defeat the Pirate Leader!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:257
-msgid "Find and destroy the evil beings who rule the wastelands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:258
-msgid "Find the center island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:259
-msgid ""
-"Find the Ultimate Artifact and be proclaimed King, or smash the opposition "
-"and take control."
-msgstr ""
-"Hitta den Ultimata artefakten och bli utropad till kung, eller krossa "
-"motståndet och ta kontroll."
-
-#: ../fheroes2/resource/maps_text.cpp:260
-msgid ""
-"Find Your Wayward Son who is rumored to be living in the desolate lands. Do "
-"it within 8 weeks or it will be of no help to your family."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:261
-msgid "Fire King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:262
-msgid "\"First Blood\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:263
-msgid "Five heroes vie for control of a familiar land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:264
-msgid "Fool's Gold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:265
-msgid ""
-"For a total of 400,000 gold your opponents will become \"loyal\" subjects, "
-"otherwise... let them eat cake!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:266
-msgid ""
-"For centuries, the Wizards of the North have maintained a vast library for "
-"all the world to share.  Now, however, they have closed their doors, and "
-"issued declarations of war to each of the other rulers of the land.  To make "
-"matters worse, rather than ally with you to face the Wizards, each of the "
-"others have decided to go forth on their own in an effort to conquer this "
-"land for themselves!  Prepare your forces, commander, for you now stand "
-"alone."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:267
-msgid "\"Force of Arms\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:268
-msgid ""
-"For decades you have studied, learned, and allowed yourself to be ruled by "
-"that pitiful excuse for a king, knowing that one day the time would come for "
-"you to sit on the throne.  That time is now, for the king is dead and "
-"without an heir.  You have the advantage of isolation from the rest of the "
-"kingdom, but beware the miles of coastline that could leave you vulnerable "
-"to attack.  Go, now, and wipe your enemies from this land!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:269
-msgid "Forder Oaks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:270
-msgid "Forestria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:271
-msgid "For Honor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:272
-msgid ""
-"For information about Ye Rich lands to the south, speak to Alponse at the "
-"Golden Goose Tavern. Excellent views, plentiful water."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:273
-msgid "Forsaken Lands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:274
-msgid "For sale."
-msgstr "Till salu."
-
-#: ../fheroes2/resource/maps_text.cpp:275
-msgid "Fortress Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:276
-msgid ""
-"For years, you have existed peacefully in the Forest of Dreams, knowing that "
-"your king was the kindest and strongest ruler the land had seen in "
-"centuries.  Now, however, his reign is at an end, and there is no heir to "
-"succeed him.  You realize that a power struggle is coming, and that you must "
-"brace yourself for war, and prevent those who would harm this land from "
-"coming into power!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:277
-msgid ""
-"For years, you've been able to keep your subjects \"appeased.\"  Now "
-"however, you discover not only that your entire kingdom has turned against "
-"you, but most of your outer towns have fallen to the different factions.  To "
-"make matters worse, all your gold suddenly seems to be missing from the "
-"treasury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:278
-msgid "Fountainhead"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:279
-msgid "Four kingdoms race to capture the island of Sharkania."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:280
-msgid "Four lakes have castles, three have treasure."
-msgstr "Fyra sjöar har slott, tre av dem har skatter."
-
-#: ../fheroes2/resource/maps_text.cpp:281
-msgid "Four players must work together to assault the Wizards' Stronghold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:282
-msgid "Frozenpeak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:283
-msgid "Full House"
-msgstr "Fullt hus"
-
-#: ../fheroes2/resource/maps_text.cpp:284
-msgid ""
-"Gain the aid of the elves. They will not allow trees to be chopped down, so "
-"we will send you wood every 2 weeks. You have 7 months!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:286
-msgid "Galveston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:287
-msgid "Garamok"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:288
-msgid "Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:289
-msgid "Gate to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:290
-msgid "Gate to The Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:291
-msgid "Gaurdian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:292
-msgid "Gavonshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:294
-msgid "Glastonbury"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:295
-msgid "Go away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:296
-msgid "GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:297
-msgid "Goblin Island"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:298
-msgid "Goblin King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:299
-msgid "Go Home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:300
-msgid "Go north to find the lost gold-mine."
-msgstr "Gå norrut och hitta den förlorande gulgruvan."
-
-#: ../fheroes2/resource/maps_text.cpp:301
-msgid "Good vs. Evil"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:302
-msgid "Gorgomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:303
-msgid "\"Greater Glory\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:304
-msgid "Greed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:305
-msgid "Green bonus stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:306
-msgid "Green gets stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:307
-msgid "Greenroot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:308
-msgid "Green's Allowance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:309
-msgid "Green's Groceries"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:310
-msgid "green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:311
-msgid "Green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:312
-msgid "Greywind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:313
-msgid "Grim"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:314
-msgid "Grrr, Blazzer, Grrupt. Be gone with you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:315
-msgid "Guardian War"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:316
-msgid "Gungtooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:317
-msgid "Hail Unicorns!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:318
-msgid "Hampshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:319
-msgid "Have fun storming the castle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:320
-msgid "Havenwood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:321
-msgid "Hawkins"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:322
-msgid "Help!"
-msgstr "Hjälp!"
-
-#: ../fheroes2/resource/maps_text.cpp:323
-msgid "Help me...."
-msgstr "Hjälp mig..."
-
-#: ../fheroes2/resource/maps_text.cpp:324
-msgid ""
-"Help peasant farmers regain their castle and land, else they'll take your "
-"crops."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:325
-msgid "Hero's Hall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:326
-msgid ""
-"High in the snowy crags, you meet an old witch who, in return for a trinket "
-"of yours, gives you a powerful magical object she used to use as a footstool "
-"before she was exiled into the mountains by her own townspeople."
-msgstr ""
-"Högt upp bland de snöiga klippor möter du en gammal häxa som, i utbyte mot "
-"en av dina fasader, ger dig ett kraftfullt magiskt objekt som hon brukade "
-"använda som en fotpall innan hon förvisades till bergen av de andra "
-"stadsborna."
-
-#: ../fheroes2/resource/maps_text.cpp:327
-msgid "Hillstone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:328
-msgid "Hilltop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:329
-msgid "Hilltown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:330
-msgid "Horizon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:331
-msgid "Hot Spot"
-msgstr "Hetfläck"
-
-#: ../fheroes2/resource/maps_text.cpp:332
-msgid "Hungry dragons await.  Welcome, food."
-msgstr "Hungriga drakar väntar. Välkommen, mat."
-
-#: ../fheroes2/resource/maps_text.cpp:333
-msgid "Hurry, no time to wait.  This way to the dock."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:334
-msgid "Hurry up! Few days are left before the enemy's army arrives."
-msgstr "Skynda dig! Det är bara några dagar kvar tills fiendens armé kommer."
-
-#: ../fheroes2/resource/maps_text.cpp:335
-msgid "I am...."
-msgstr "Jag..."
-
-#: ../fheroes2/resource/maps_text.cpp:336
-msgid ""
-"I am one of the few remaining survivors of the wrecked pleasure ship, "
-"Exhorbitance. I think we'll all be dead of hunger soon, for we are out of "
-"caviar. We ate the chef yesterday."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:337
-msgid "Ibn Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:338
-msgid "Ice Palace"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:339
-msgid "Ice Prince"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:340
-msgid "Icy lands ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:341
-msgid "I didn't do it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:342
-msgid ""
-"If three heroes could dig six holes in three days, how long would it take "
-"six heroes to dig twelve holes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:343
-msgid "If you free a hero, they may help..."
-msgstr "Om du befriar en hjälte kan den kanske hjälpa till..."
-
-#: ../fheroes2/resource/maps_text.cpp:344
-msgid ""
-"If you value your lives, for God's sake, Don't go through this whirlpool!"
-msgstr ""
-"Om ni värderar era liv, för Guds skull, åk inte igenom denna strömvirvel!"
-
-#: ../fheroes2/resource/maps_text.cpp:345
-msgid "Income for Yellow."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:346
-msgid "In the hole you find a chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:347
-msgid "In the stream you find an old compass!"
-msgstr "I strömmen hittar du en gammal kompass!"
-
-#: ../fheroes2/resource/maps_text.cpp:348
-msgid "In this glen live some very naughty halflings. Stay Away!"
-msgstr "I denna dalgång bor några elaka hober. Håll dig borta!"
-
-#: ../fheroes2/resource/maps_text.cpp:349
-msgid ""
-"In two more weeks, if you have not located Joseph, your kingdom will surely "
-"lose its current battle with Harondale."
-msgstr ""
-"Om två veckor, om du inte har hittat Joseph, kommer ditt kungarike säkert "
-"förlora striden mot Harondale."
-
-#: ../fheroes2/resource/maps_text.cpp:350
-msgid "I see you, you see me."
-msgstr "Jag ser dig, du ser mig."
-
-#: ../fheroes2/resource/maps_text.cpp:351
-msgid "Is it something I said? Go back and I will forget the whole thing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:352
-msgid "IslandHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:353
-msgid "Island of the Elves"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:354
-msgid "Island of the meek"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:355
-msgid "Island of Wolcott"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:356
-msgid "Isle Maze"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:357
-msgid "Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:358
-msgid ""
-"It has become apparent that if all your enemies were eliminated, you would "
-"have all the time you need to find the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:359
-msgid ""
-"It is obvious that the mage that once was here had won many battles!  There, "
-"upon his hand, is a most powerful ring!"
-msgstr ""
-"Det är självklart att magikern en gång har vunnit många strider! På sin hand "
-"har han en mäktig ring!"
-
-#: ../fheroes2/resource/maps_text.cpp:360
-msgid ""
-"It is rumored that a bridge of land used to exist between the two "
-"continents, but that a wild magic caused it to sink into the sea, taking "
-"with it all those who used to inhabit it.  To try to raise this bridge is to "
-"invite a curse upon the world!  The spirits of the dead will haunt us all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:361
-msgid ""
-"It is said that King Zealot found the gods' artifact once and it let him "
-"rule for 100 years."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:362
-msgid ""
-"It looks like there used to be an ore mine here but all you see now is a "
-"hole in the ground and some minerals scattered around."
-msgstr ""
-"Det ser ut som det har funnits en gruva här, men allt du kan se nu är ett "
-"hål i marken och lite mineraler som ligger utspritt omkring."
-
-#: ../fheroes2/resource/maps_text.cpp:363
-msgid ""
-"It's a battle for supremacy as the Blue and Green heroes take on Red and "
-"Orange in team competition!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:364
-msgid "It's windy at the top.  Defend, Divide, and Conquer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:365
-msgid "IvanHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:366
-msgid "Ivan lives in the desert."
-msgstr "Ivan bor i öknen."
-
-#: ../fheroes2/resource/maps_text.cpp:367
-msgid "Ivory Gates"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:368
-msgid ""
-"I, Wilgatus, besiege you - do not fight me for I am all powerful and will "
-"destroy you if you persue me.  I will demonstrate my power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:369
-msgid "I Would Go That Way If I Were You."
-msgstr "Jag Skulle Gå Den Vägen Om Jag Var Du."
-
-#: ../fheroes2/resource/maps_text.cpp:371
-msgid "Jarkonas VI"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:372
-msgid "Jolly Roger was here"
-msgstr "Jolly Roger var här"
-
-#: ../fheroes2/resource/maps_text.cpp:374
-msgid "Jungomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:375
-msgid "Just 30 days left!"
-msgstr "Bara 30 dagar kvar!"
-
-#: ../fheroes2/resource/maps_text.cpp:376
-msgid "Just ONE week left!"
-msgstr "Bara EN vecka kvar!"
-
-#: ../fheroes2/resource/maps_text.cpp:378
-msgid "Kastor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:379
-msgid "Keep going south"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:380
-msgid "Keep Off The Grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:381
-msgid "Keep Out!"
-msgstr "Håll dig undan!"
-
-#: ../fheroes2/resource/maps_text.cpp:382
-msgid "King John"
-msgstr "Kung John"
-
-#: ../fheroes2/resource/maps_text.cpp:383
-msgid "King of Death"
-msgstr "Dödskungen"
-
-#: ../fheroes2/resource/maps_text.cpp:384
-msgid "Knight's Trail."
-msgstr "Riddarens stig."
-
-#: ../fheroes2/resource/maps_text.cpp:385
-msgid "Knight stuff"
-msgstr "Riddarsaker"
-
-#: ../fheroes2/resource/maps_text.cpp:386
-msgid "Lakeside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:387
-msgid "Land's Edge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:388
-msgid "Land teleporters will get you to your destination sooner."
-msgstr "Landteleportörer förflyttar dig till din destination snabbare."
-
-#: ../fheroes2/resource/maps_text.cpp:389
-msgid "Lankershire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:390
-msgid "Lavalor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:391
-msgid "Like, Stuff And Junk?"
-msgstr "Typ, Grejer Och Skräp?"
-
-#: ../fheroes2/resource/maps_text.cpp:392
-msgid ""
-"Living on the outskirts of the kingdom, you are considered an unwelcome "
-"outcast by the other leaders of the realm, though you always showed your "
-"support for the king.  Now, however, the king is dead, and many of those who "
-"spoke out againt him seek to seize his throne for themselves.  You have a "
-"vast desert at your back, rich with gems, and the advantage that many do not "
-"consider you a threat.  Go, now, and show them how wrong they are!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:393
-msgid "Lladner Dock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:394
-msgid ""
-"Log go up... Log go down... Log go up... Log go down...  OOoohhhhhhhh........"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:395
-msgid "Lombard"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:396
-msgid "Long live Roland the true King!"
-msgstr "Länge leve den sanne kungen Roland!"
-
-#: ../fheroes2/resource/maps_text.cpp:397
-msgid "Long live Roland the true King."
-msgstr "Länge leve den sanne kungen Roland."
-
-#: ../fheroes2/resource/maps_text.cpp:398
-msgid "Look before you leap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:399
-msgid "Look out!"
-msgstr "Se upp!"
-
-#: ../fheroes2/resource/maps_text.cpp:400
-msgid "Lord Alberon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:401
-msgid ""
-"Lord Alberon calls you into his war room. He says, \"I am glad you have "
-"chosen to remain loyal to me, but this war is a terrible one for my kingdom. "
-"Already, the sorceress' towns to the Northeast have become unsure about "
-"their loyalties, and will not pledge allegiance to either side. This is hard "
-"on our cities as most of the wood in the land comes from these towns. We "
-"will need to recover their sawmills and take their towns by force.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:402
-msgid "Lord Haart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:404
-msgid "Lord Kreager"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:405
-msgid ""
-"Lord, messages have begun pouring in from our spies in the other island "
-"courts.  They have learned of a new volcanic island with vast amounts of "
-"reasources.  Your Majesty, with these new reasources we could put an end to "
-"a century of war between the islands, and reunite them under your rightful "
-"rule."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:406
-msgid "Lost Continent"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:407
-msgid "Lost Gold- Mine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:408
-msgid "Lost Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:409
-msgid "Lost Relic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:410
-msgid "Maelstrom of Deceit"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:411
-msgid "Maelstrom of Misery"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:412
-msgid "Magic"
-msgstr "Magi"
-
-#: ../fheroes2/resource/maps_text.cpp:413
-msgid "Magic Three"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:414
-msgid ""
-"Many dust plumes rise from the floor of this small valley. You see various "
-"bands of nomads roaming about, and in the distant, the bright flames of "
-"their camp."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:415
-msgid ""
-"Many guardians stand between you and your enemies, but anybody can sneak "
-"through the back door!"
-msgstr ""
-"Många vakter står mellan dig och dina fiender, men vem som helst kan smyga "
-"ut genom bakdörren!"
-
-#: ../fheroes2/resource/maps_text.cpp:416
-msgid "Many that have gone through this door have never returned."
-msgstr "Många som har gått igenom denna dörr har aldrig återvänt."
-
-#: ../fheroes2/resource/maps_text.cpp:417
-msgid ""
-"Many years ago, a couple of mages had a \"duel\" that forever changed the "
-"lake at the center of this continent.  Hearty adventurers might find "
-"interesting treasure there!"
-msgstr ""
-"För många år sedan hade några trollkarlar en \"duell\" som hela tiden "
-"förändrade sjön i mitten av denna kontinent. Helhjärtade äventyrare kanske "
-"kan hitta intressanta skatter här!"
-
-#: ../fheroes2/resource/maps_text.cpp:418
-msgid ""
-"Many years ago, a falling star crashed near here.  Only now the area is safe "
-"enough to explore.  Rumor has it a castle exist where the star fell."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:419
-msgid ""
-"Many years ago, your father, the King, died in a freak hunting accident.  "
-"Since then, you and your brother have jointly ruled his kingdom, but both of "
-"you have been seeking a way to seize the throne for yourself.  You got your "
-"wish.  Attackers from across the sea have captured more than half your towns "
-"and castles, effectively dividing the continent in two.  Now is the time to "
-"repel these invaders and do away with your brother once and for all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:420
-msgid "Marco"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:421
-msgid "Marsh Home"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:423
-msgid "Mayland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:424
-msgid "Meramec"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:425
-msgid "Message from Archibald. \" Do not dare to return without my Crown.\""
-msgstr ""
-"Meddelande från Archibald. \"Våga inte komma tillbaka utan min Krona.\""
-
-#: ../fheroes2/resource/maps_text.cpp:426
-msgid ""
-"Message from Archibald. \" General, thank you for bringing me this lovely "
-"gift. I have decided to participate directly in the capture of my brother "
-"Roland. Since your military advice has taken us this far, I will follow your "
-"orders to the letter.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:427
-msgid "Message from Overlord. \"STILL WAITING FOR MY GOLD!\""
-msgstr "Meddelande från Överherren. \"JAG VÄNTAR FORTFARANDE PÅ MITT GULD!\""
-
-#: ../fheroes2/resource/maps_text.cpp:428
-msgid "Message from Overlord. \"WHERE'S MY GOLD?\""
-msgstr "Meddelande från Överherren. \"VAR ÄR MITT GULD?\""
-
-#: ../fheroes2/resource/maps_text.cpp:429
-msgid ""
-"Message from Roland. \"General, circumstances permit me to take a hand in "
-"the events of this final conflict. I have your spoils of war with me and I "
-"will follow your advice explicitly.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:430
-msgid ""
-"Message from Roland.  \"General, I have sent most of our troops and material "
-"ahead to the region of the final conflict with Archibald.  Unfortunately, "
-"Lord Corlagon has cut us off from the rest of our army.  I will be awaiting "
-"your victory in a castle across the west river.  I should be safe from "
-"attack.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:431
-msgid ""
-"Message from Roland. \" We cannot hope to defeat Archibald without the "
-"Crown, I'm counting on you.\""
-msgstr ""
-"Meddelande från Roland. \"Vi kan inte hoppas på att besegra Archibald utan "
-"Kronan. Jag räknar med dig.\""
-
-#: ../fheroes2/resource/maps_text.cpp:432
-msgid "Middle Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:433
-msgid "Middleton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:434
-msgid "Middletown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:435
-msgid "Might vs. Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:436
-msgid "Mineral Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:437
-msgid "Mirkosov"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:438
-msgid "mirror"
-msgstr "spegel"
-
-#: ../fheroes2/resource/maps_text.cpp:439
-msgid "Money For Red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:440
-msgid "MONEY, MONEY, MONEY!"
-msgstr "PENGAR, PENGAR, PENGAR!"
-
-#: ../fheroes2/resource/maps_text.cpp:441
-msgid "Morale becomes even lower as the endless cliffs move past."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:442
-msgid ""
-"More water than land, you'll still spend lots of time on foot as you search "
-"a literal horde of islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:443
-msgid "Mountain king"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:444
-msgid "Mountainview"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:445
-msgid "Mr Ed"
-msgstr "Mr Ed"
-
-#: ../fheroes2/resource/maps_text.cpp:446
-msgid "Mr. Yellow's Income"
-msgstr "Herr Guls inkomst"
-
-#: ../fheroes2/resource/maps_text.cpp:447
-msgid "Murray's resort Isle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:448
-msgid ""
-"Mutiny!  The crew has dumped off my precious cargo into the sea!  Thank "
-"goodness it floats - when I've rid of them, I'll come back to pick it up!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:449
-msgid ""
-"My leige, our scouts report three other lords are attacking from the south. "
-"They work in conjuction with each other to eliminate us! We must keep this "
-"castle and remove the threat of the enemy. We wish you luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:450
-msgid ""
-"My leige, we have established a foothold (which we cannot afford to lose) "
-"and all of our Heroes have joined us. The king has made us the offer to "
-"purchase this land for 200,000 gold or we may take it by force. The local "
-"lords have been fighting and each wants to be the one that defeats us. Now "
-"all the local armies have arrived on the beach, creating a state of complete "
-"Pandemonium!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:451
-msgid "My Treasure Is Buried Beneath Three Palm Trees"
-msgstr "Min skatt är nedgrävd nedanför tre palmer"
-
-#: ../fheroes2/resource/maps_text.cpp:452
-msgid "\"Necromancers!\""
-msgstr "\"Svartkonstnärer!\""
-
-#: ../fheroes2/resource/maps_text.cpp:453
-msgid "New Dawn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:454
-msgid "New Enemies"
-msgstr "Nya fiender"
-
-#: ../fheroes2/resource/maps_text.cpp:455
-msgid "New Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:456
-msgid "Nightshadow"
-msgstr "Nattskugga"
-
-#: ../fheroes2/resource/maps_text.cpp:457
-msgid "No Description"
-msgstr "Ingen beskrivning"
-
-#: ../fheroes2/resource/maps_text.cpp:458
-msgid "No Fishing!"
-msgstr "Fiske förbjudet!"
-
-#: ../fheroes2/resource/maps_text.cpp:459
-msgid "No gems, crystal, or mercury for red."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:460
-msgid ""
-"None of the four leaders like being stuck in a land that has only one season."
-msgstr ""
-"Ingen av de fyra ledarna gillade att fastna i ett land med endast en årstid."
-
-#: ../fheroes2/resource/maps_text.cpp:461
-msgid "NO, Not That Way. This Way."
-msgstr "NEJ, inte den vägen. Den här vägen."
-
-#: ../fheroes2/resource/maps_text.cpp:462
-msgid "No one has ever made it out of the deadly swamps alive!"
-msgstr "Ingen har någonsin klarat sig ut från dödliga träsket levande!"
-
-#: ../fheroes2/resource/maps_text.cpp:463
-msgid "Noraston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:464
-msgid "North Road"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:465
-msgid "North vs. South"
-msgstr "Nord vs. Syd"
-
-#: ../fheroes2/resource/maps_text.cpp:466
-msgid "No stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:467
-msgid "No sulfer fer Yella."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:468
-msgid "No swimming."
-msgstr "Simning förbjudet."
-
-#: ../fheroes2/resource/maps_text.cpp:469
-msgid "Notice- Those who put messages in bottles will be tortured."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:470
-msgid "No Trespassing"
-msgstr "Ingen överträdelse"
-
-#: ../fheroes2/resource/maps_text.cpp:471
-msgid "No tresspath...  No tree...  No thresh...  GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:472
-msgid "Now leaving Swamplands of the Eternial"
-msgstr "Du lämnar nu Eternials träskländer."
-
-#: ../fheroes2/resource/maps_text.cpp:473
-msgid "Obsidian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:474
-msgid "Of the necromancers...."
-msgstr "Svartkonstnärernas..."
-
-#: ../fheroes2/resource/maps_text.cpp:475
-msgid "Ogrehild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:476
-msgid "Olympus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:477
-msgid ""
-"One of the seers in your castle comes to you in the morning with urgent "
-"news. Your one time comrade, the wizard Joseph, and his armies have been "
-"imprisoned in a jail nearby. His power would surely aid you in your quest to "
-"reclaim the library, you think to yourself. Perhaps there is a way to rescue "
-"him..."
-msgstr ""
-"En av slottets profeter kommer in till dig på morgonen med brådskande "
-"nyheter. Din vän en gång i tiden, trollkarlen Joseph och hans arméer har "
-"tillfångatagits i ett fängelse i närheten. Hans krafter skulle säkert hjälpa "
-"dig på ditt uppdrag att ta tillbaka biblioteket. Du tänker för sig själv. "
-"Det kanske finns ett sätt att rädda honom..."
-
-#: ../fheroes2/resource/maps_text.cpp:478
-msgid ""
-"One of your aides reports that the Castle of Farlien is located on the "
-"northeast spur of this island, and is a stronghold for the enemy. He urges "
-"you to take it out as soon as possible, and then move onto other islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:479
-msgid ""
-"One of your \"allies\" has joined Archibald.  You now face an opponent with "
-"three castles to your one.  Good luck!"
-msgstr ""
-"En av dina \"allierade\" har förenat sig med Arhbald. Du möter nu en "
-"motståndare med tre slott mot ett. Lycka till!"
-
-#: ../fheroes2/resource/maps_text.cpp:480
-msgid ""
-"One of your \"Allies\" has joined Roland. You are now facing three castles, "
-"all belonging to the enemy. Good luck!"
-msgstr ""
-"En av dina \"allierade\" har förenat sig med Roland. Du möter nu tre slott, "
-"och alla tillhör fienden. Lycka till!"
-
-#: ../fheroes2/resource/maps_text.cpp:481
-msgid "One of your loyal goblins has brought you an armload of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:482
-msgid ""
-"One of your loyal subjects, a fairy tells you where to find a cache of "
-"mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:483
-msgid ""
-"One of your scouts reports a tiny cave nearby. Upon investigating, you "
-"discover a small cache of goods. In the dirt by them is etched 'Ivan'."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:484
-msgid ""
-"One of your troops stubs its paw on something buried here.  After a few "
-"hours of digging you unearth a cache of treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:485
-msgid "Only a month remains in which to find Joseph."
-msgstr "Endast en månad återstår att hitta Joseph."
-
-#: ../fheroes2/resource/maps_text.cpp:486
-msgid "On quite days, Nubbie the sea monster can be seen!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:487
-msgid "Orange stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:488
-msgid "Orcville"
-msgstr "Orchville"
-
-#: ../fheroes2/resource/maps_text.cpp:489
-msgid "Ostoroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:490
-msgid "Other than the dragons, the elves don't have any enemies."
-msgstr "Förutom drakarna har alverna inga fiender."
-
-#: ../fheroes2/resource/maps_text.cpp:491
-msgid "Our ally was greatly weakened when his resources were plundered."
-msgstr ""
-"Våra allierade var kraftigt försvagade när hans resurser var plundrade."
-
-#: ../fheroes2/resource/maps_text.cpp:492
-msgid "\"Our Finest Hour\""
-msgstr "\"Vår Finaste Timme\""
-
-#: ../fheroes2/resource/maps_text.cpp:493
-msgid "Our reinforcements were lost in a storm, we salvaged all we could!"
-msgstr "Våra förstärkningar gick åt i en storm, vi räddade allt som kundes!"
-
-#: ../fheroes2/resource/maps_text.cpp:494
-msgid ""
-"Our spies have discovered that the barbarian hordes are now receiving "
-"support from kraeger! You must hurry and find the third piece before your "
-"forces here are crushed!"
-msgstr ""
-"Våra spioner har upptäckt att barbarhordarna har nu fått stöd från Kraeger! "
-"Du måste skynda dig och hitta den tredje delen innan dina trupper blir "
-"krossade!"
-
-#: ../fheroes2/resource/maps_text.cpp:495
-msgid "Overlord"
-msgstr "Överherre"
-
-#: ../fheroes2/resource/maps_text.cpp:496
-msgid "Pandemonium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:497
-msgid "Paper can gain you what wood and sail cannot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:498
-msgid "Password found by Crystals to the South."
-msgstr "Lösenordet hittades vid kristallerna i syd."
-
-#: ../fheroes2/resource/maps_text.cpp:499
-msgid "Peacekeeper"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:500
-msgid "\"Peasants!\""
-msgstr "\"Bönder\"!"
-
-#: ../fheroes2/resource/maps_text.cpp:502
-msgid "Peasantsville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:503
-msgid "Perenor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:504
-msgid "Pet Cemetary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:505
-msgid "Pick one of four Knights in this large and inhospitable land."
-msgstr "Välj en av de fyra riddarna i detta stora ogästvänliga land."
-
-#: ../fheroes2/resource/maps_text.cpp:506
-msgid "Pig's Eye"
-msgstr "Grisöga"
-
-#: ../fheroes2/resource/maps_text.cpp:507
-msgid "Pinehurst"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:508
-msgid "Pirate Cove"
-msgstr "Piratgrotta"
-
-#: ../fheroes2/resource/maps_text.cpp:509
-msgid "Pirate's Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:510
-msgid "Pirate Utopia"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:511
-msgid "Pirites strike and take the gold from you holds."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:512
-msgid "Pixie"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:513
-msgid ""
-"Play the Knight or Barbarian in an alliance in this classic duel against the "
-"four spell casters. (Blue and Green vs Red)"
-msgstr ""
-"Spela riddaren eller barbaren i en allians i denna klassiska duell mot de "
-"fyra besvärjelsekastarna. (Blå och Grön mot Röd)"
-
-#: ../fheroes2/resource/maps_text.cpp:514
-msgid "Please...."
-msgstr "Snälla..."
-
-#: ../fheroes2/resource/maps_text.cpp:515
-msgid ""
-"Plenty of resources and lots of ground to cover. Watch out for Orange and "
-"Purple!"
-msgstr ""
-"Många resurser och mängder av mark att täcka. Se upp för Orange och Lila!"
-
-#: ../fheroes2/resource/maps_text.cpp:516
-msgid "Portals"
-msgstr "Portaler"
-
-#: ../fheroes2/resource/maps_text.cpp:517
-msgid "Portsmith"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:518
-msgid "POSION - DO NOT DRINK"
-msgstr "GIFT - DRICK INTE"
-
-#: ../fheroes2/resource/maps_text.cpp:519
-msgid "Powerful magic lies southwest of here in the Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:520
-msgid "Prisoner on...."
-msgstr "Fånge på..."
-
-#: ../fheroes2/resource/maps_text.cpp:522
-msgid "Quick Silver"
-msgstr "Kvicksilver"
-
-#: ../fheroes2/resource/maps_text.cpp:523
-msgid "Raste"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:524
-msgid "Realm of the Undead.  Fresh blood welcome."
-msgstr "De odödas rike. Färskt blod välkommen."
-
-#: ../fheroes2/resource/maps_text.cpp:525
-msgid "Red bonus"
-msgstr "Röd bonus"
-
-#: ../fheroes2/resource/maps_text.cpp:526
-msgid "Red player sympathizes with the undead cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:527
-msgid "Red's Connection"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:528
-msgid "Redshield"
-msgstr "Rödsköld"
-
-#: ../fheroes2/resource/maps_text.cpp:529
-msgid "Red's Lunch Money"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:530
-msgid "Red's Rubles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:531
-msgid "Red stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:532
-msgid ""
-"Regrettably, you have no castle with which to begin your assault. "
-"Fortunately, however, Kraeger's forces are weak here in the south, and you "
-"have bribed a rebel necromancer to aid you in the beginning of your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:533
-msgid "Reinforcements have arrived, Gold from the homelands!"
-msgstr "Förstärkningar har anländt. Guld från hemländerna!"
-
-#: ../fheroes2/resource/maps_text.cpp:534
-msgid ""
-"Remains of a long since dead wizard have attracted an ancient artifact.  "
-"This artifact has now attached itself to you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:535
-msgid ""
-"Remember, you're searching for the Ultimate Artifact... don't get distracted!"
-msgstr ""
-"Kom ihåg att du letar efter den Ultimata artefakten... bli inte distraherad!"
-
-#: ../fheroes2/resource/maps_text.cpp:536
-msgid ""
-"Rendall Koski was here. 1997.  Northampton, Massachusetts There is a "
-"powerful artifact in the southeastern corner of the world.  Go for it, "
-"explorer!"
-msgstr ""
-"Rendall Koski var här 1997. Northampton, Massachusetts. Det finns en "
-"kraftfull artefakt i världens sydöstra hörn. Vad väntar du på?"
-
-#: ../fheroes2/resource/maps_text.cpp:537
-msgid ""
-"Reports from your spies tell of enemies on the march.  As you rush to the "
-"castle courtyard to prepare your armies, you are intercepted by your "
-"Chaplain.  \"My Lord, I have received word that we should send what Heroes "
-"we can to the Isle of Knowledge.   The Scholars there have agreed to teach "
-"them so they will be strong for the battles ahead of us.\"  You thank the "
-"Chaplain for the information and head thoughtfully into the courtyard."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:538
-msgid ""
-"Rescue your crazy Uncle Ivan. Find him within 4 months or it will be no help "
-"to your kingdom."
-msgstr ""
-"Rädda din farbror Ivan. Hitta honom inom 4 månader, annars kommer det inte "
-"till någon hjälp för ditt kungarike."
-
-#: ../fheroes2/resource/maps_text.cpp:539
-msgid "Restricted Area, Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:540
-msgid "Rest stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:541
-msgid "Retake the Castle of Ivory Gates."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:542
-msgid "Revolution"
-msgstr "Revolution"
-
-#: ../fheroes2/resource/maps_text.cpp:543
-msgid "Right thinking - he who takes the riskes deserves the rewards."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:544
-msgid "River Crossing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:545
-msgid "Road Ends"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:546
-msgid "Road to Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:547
-msgid "Road to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:548
-msgid "Robbers have looted your treasury and you have lost valuable resources."
-msgstr ""
-"Rånare har plundrat din skattkammare och du har förlorat värdefulla resurser."
-
-#: ../fheroes2/resource/maps_text.cpp:549
-msgid "Robbers have looted your treasury, stealing valuable resources."
-msgstr "Rånare har plundrat din skattkammare och stulit värdefulla resurser."
-
-#: ../fheroes2/resource/maps_text.cpp:550
-msgid "Roc Haven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:551
-msgid "Rogar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:553
-msgid "Roscomon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:554
-msgid "Rotten Birch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:555
-msgid ""
-"Rumors abound and your faithful hero Sandro is now highly regarded by the "
-"masses. Should Sandro desert you, all will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:556
-msgid "Sandcaster"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:558
-msgid "Sands of Time"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:559
-msgid "Sansobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:560
-msgid "\"Save the Dwarves\""
-msgstr "\"Rädda dvärgarna\""
-
-#: ../fheroes2/resource/maps_text.cpp:561
-msgid "Scabsdale"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:562
-msgid "Scorched Earth"
-msgstr "Bränd jord"
-
-#: ../fheroes2/resource/maps_text.cpp:563
-msgid ""
-"Scouts have reported a town to the North.  They have also heard some "
-"disturbing news.  Their seems to be a war raging in this area."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:564
-msgid ""
-"Scouts report the enemy's stronghold lies to the Southwest. Our swift "
-"arrival has caught them by surprise. If you move quickly their resistance "
-"will be minimal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:565
-msgid ""
-"Scouts report the notorious necromancer \"Wyrm\" has been sighted to the "
-"northeast."
-msgstr ""
-"Spanare rapporterar att den ökände svartkonstnären \"Wyrm\" har setts till i "
-"nordöst."
-
-#: ../fheroes2/resource/maps_text.cpp:566
-msgid "Scummy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:567
-msgid ""
-"Searching in the dust of this abandoned campsite, you find a magic scroll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:568
-msgid "Seasons Change"
-msgstr "Årstidsskiftning"
-
-#: ../fheroes2/resource/maps_text.cpp:569
-msgid "Secret Mountain Pass"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:570
-msgid ""
-"Seek out the Ultimate Artifact to be victorious in this strangely shaped "
-"land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:571
-msgid ""
-"Seek the great library, for only with the guidance of the musty tomes therin "
-"will you find the means to reveal and bind the fount to your will."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:572
-msgid "Seven Lakes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:573
-msgid "Sharkania"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:574
-msgid "Sheltemburg"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:575
-msgid "Sherman"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:576
-msgid "Shipwrecked!"
-msgstr "Skeppsbruten!"
-
-#: ../fheroes2/resource/maps_text.cpp:577
-msgid ""
-"Should this message ever reach home, please know that this has become a "
-"hostile place since the King's death.  No less than six factions are at war "
-"with each other, each seeking to be the King's successor.  Beware especially "
-"of the Barbarians and the Necromancers who control the north, their regions "
-"are easily defended and they have a wealth of gold and gems.  Do not venture "
-"to this land without a sizeable force.  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:578
-msgid "Sirein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:579
-msgid ""
-"Six factions have established a foothold on a huge, unexplored continent.  "
-"Can you eliminate the other five?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:580
-msgid ""
-"Six heroes with large armies prepare to slug it out for total domination!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:581
-msgid "Skirmish"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:582
-msgid "\"Slay the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:583
-msgid "Slippery when wet."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:584
-msgid "Slugfest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:585
-msgid ""
-"Snagged on a thorny bush, you discover a scrap of cloth. The design on it "
-"looks like the coat of arms of Ivan's house!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:586
-msgid "Snowdrop"
-msgstr "Snödroppe"
-
-#: ../fheroes2/resource/maps_text.cpp:587
-msgid "Somebody has stuffed a pile of gems in the ditch!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:588
-msgid "Some crystal!"
-msgstr "Några kristaller!"
-
-#: ../fheroes2/resource/maps_text.cpp:589
-msgid "Some gems!"
-msgstr "Några ädelstenar!"
-
-#: ../fheroes2/resource/maps_text.cpp:590
-msgid ""
-"Someone has stolen 100 wood and 77 ore from you. Ah, that's nothing. Let's "
-"keep going."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:591
-msgid ""
-"Someone has stolen gold and resources from  the palace treasury!  You "
-"suspect your enemies, but you can't know for certain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:592
-msgid "Someone is playing a pan flute around here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:593
-msgid ""
-"Someone notices a piece of parchment lying behind a clump of grass. You pick "
-"it up. It looks to be a page from a journal, and it reads, \"...made it past "
-"the first guardians. Hopefully will reach the ancient desert city soon. Only "
-"hope my forces are strong enough to survive...\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:594
-msgid "Some ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:595
-msgid "Some sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:596
-msgid ""
-"Some unlucky adventurers have been captured and imprisoned in these lands."
-msgstr ""
-"Några olycksaliga äventyrare har tillfångatagits och fängslats i dessa "
-"länder."
-
-#: ../fheroes2/resource/maps_text.cpp:597
-msgid "Sorceress Forest.  Show respect for nature!"
-msgstr "Häxskogen. Visa respekt för naturen!"
-
-#: ../fheroes2/resource/maps_text.cpp:598
-msgid "Sorpigal"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:599
-msgid "South Mill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:600
-msgid "So you think you're smart?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:601
-msgid "Spector"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:602
-msgid "Spell Casters"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:603
-msgid ""
-"Spies report Roland has sent a hero to search for the Crown. If he finds it "
-"first, all is lost!"
-msgstr ""
-"Spioner rapporterar att Roland har skickat ut en hjälte för att hitta "
-"Kronan. Om han hittar den är allt förlorat!"
-
-#: ../fheroes2/resource/maps_text.cpp:604
-msgid "Spirit City"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:605
-msgid "Spy Tower - see what your competition is doing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:606
-msgid "Stairs"
-msgstr "Trappor"
-
-#: ../fheroes2/resource/maps_text.cpp:607
-msgid ""
-"Start with five castles!  How could you lose!?  Oh yeah, everyone else "
-"starts with five, too."
-msgstr ""
-"Börja med fem slott! Hur kunde du förlora!? Åh visst, alla andra börjar med "
-"fem också."
-
-#: ../fheroes2/resource/maps_text.cpp:608
-msgid "Stick to the road!"
-msgstr "Håll dig på vägen!"
-
-#: ../fheroes2/resource/maps_text.cpp:609
-msgid "Stromgild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:610
-msgid "Stromhild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:611
-msgid "Stronghold"
-msgstr "Fort"
-
-#: ../fheroes2/resource/maps_text.cpp:612
-msgid "Stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:613
-msgid "Stuff for Yellow"
-msgstr "Saker för Gul"
-
-#: ../fheroes2/resource/maps_text.cpp:614
-msgid "Stuff For Yellow"
-msgstr "Saker För Gul"
-
-#: ../fheroes2/resource/maps_text.cpp:615
-msgid "Subbaculcha"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:616
-msgid "Sundune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:617
-msgid "Surf and Turf"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:618
-msgid "Swimming near the kelp is a pod of dolphins."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:619
-msgid "Tacma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:620
-msgid "Tchudes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:621
-msgid "Teleporters"
-msgstr "Teleportörer"
-
-#: ../fheroes2/resource/maps_text.cpp:622
-msgid "Terra Firma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:623
-msgid "Terrain Wars"
-msgstr "Terrängkrig"
-
-#: ../fheroes2/resource/maps_text.cpp:624
-msgid ""
-"The alliance has crumbled and all are at war. Lots of resources but little "
-"time to prepare."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:625
-msgid ""
-"The ancient King Zealot had the artifact of the gods and then hid it in his "
-"old age so that it could not be used by others."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:626
-msgid "The Back Door"
-msgstr "Bakdörren"
-
-#: ../fheroes2/resource/maps_text.cpp:627
-msgid ""
-"The Barbarian's lands are being invaded. Are you strong enough to resist the "
-"invasion?"
-msgstr "Barbarernas länder invaderas. Är du stark nog att stå emot invasionen?"
-
-#: ../fheroes2/resource/maps_text.cpp:628
-msgid ""
-"The castle of Drakonran in the east has been taken by the barbarians! Two "
-"other towns to the west have also been taken, but the barbarian armies were "
-"fairly decimated in the process."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:629
-msgid "The center island is rumored to harbor great spells."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:630
-msgid "The Citadel"
-msgstr "Citadellen"
-
-#: ../fheroes2/resource/maps_text.cpp:631
-msgid "The cities of the plains."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:632
-msgid "The Clearing"
-msgstr "Gläntan"
-
-#: ../fheroes2/resource/maps_text.cpp:633
-msgid ""
-"The convoy has at long last arrived. Regretably, it has been beset by "
-"bandits on its journey here, and has far less supplies than we had hoped. "
-"Make your way south, for our spies have found rich mines there."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:634
-msgid ""
-"The convoy should have been here by now! Let us hope that it is safe and "
-"still on its way."
-msgstr ""
-"Konvojen skulle ha varit här nu! Hoppas bara att den är i säkerhet och "
-"fortfarande på väg."
-
-#: ../fheroes2/resource/maps_text.cpp:635
-msgid ""
-"The country lords have allied and pooled their resources into one command. "
-"Not only have they massed their forces in the north, but they have sent a "
-"knight to the west to steal your supplies. Scouts report a castle to the "
-"east that would be ideal as a base of operations."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:636
-msgid "The crew are unworthy!  I am not going down with the ship! -The Captain"
-msgstr ""
-"Besättningen är värdelös! Jag tänker inte gå under med skeppet! -Kaptenen"
-
-#: ../fheroes2/resource/maps_text.cpp:637
-msgid "\"The Crown\""
-msgstr "\"Kronan\""
-
-#: ../fheroes2/resource/maps_text.cpp:638
-msgid ""
-"The day you have feared has finally arrived.  The king, who you have "
-"faithfully served, has died, leaving no heir to his throne.  As his captain, "
-"you feel that this job should now be yours, but several factions even now "
-"are preparing for conquest.  You are at the center of the trade routes, "
-"having the sea to the south and the great forest to the north.  Go, now, "
-"Commander, and claim what is rightfully yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:639
-msgid ""
-"The diplomats who were sent here ahead of you report that the elves will "
-"only cooperate with you if you will recover the golden bow for them. It was "
-"stolen by their enemies, the Dragons and hidden behind magic barriers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:640
-msgid "The Eastern Town."
-msgstr "Östra tornet"
-
-#: ../fheroes2/resource/maps_text.cpp:641
-msgid "The edge of the world is your edge.  But prepare to be prepared."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:642
-msgid "The Emerald Isle"
-msgstr "Smaragdön"
-
-#: ../fheroes2/resource/maps_text.cpp:643
-msgid "The Enchanted Forest."
-msgstr "Den förvandlade skogen."
-
-#: ../fheroes2/resource/maps_text.cpp:644
-msgid "The End of the World is Nigh!"
-msgstr "Världens undergång är nära!"
-
-#: ../fheroes2/resource/maps_text.cpp:645
-msgid "The End of the World is Nigh"
-msgstr "Världens undergång är nära"
-
-#: ../fheroes2/resource/maps_text.cpp:646
-msgid ""
-"The Epic battle against Your Rival! Eliminate everything! Total Warfare! "
-"Don't Lose your first hero!"
-msgstr ""
-"Episka striden mot Din rival! Eliminera allting! Total krigföring! Förlora "
-"inte din första hjälte!"
-
-#: ../fheroes2/resource/maps_text.cpp:647
-msgid ""
-"The Fire King is an ally to the dragons, and will help a friend of theirs."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:648
-msgid "The First One To Take Astircaer Wins!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:649
-msgid ""
-"The first piece of the artifact now lies in the hands of the Unholy Order of "
-"Warlocks. You must annihilate them, and their allies to the north. They will "
-"surely give us what we seek in exchange for their feeble lives."
-msgstr ""
-"Den första delen av artefakten ligger i händerna på den oheliga "
-"Krigstrollkarlsordern. Du måste förstöra dem och deras allierade i norr. De "
-"skulle säkert ge oss vad vi söker efter i utbyte mot deras kraftlösa liv."
-
-#: ../fheroes2/resource/maps_text.cpp:650
-msgid ""
-"The Fortune of Infamous Uae was buried on one of these islands. She died "
-"without ever revealing it.  Find it before the other cutthroats."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:651
-msgid "The four factions race to capture a mystical castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:652
-msgid ""
-"The four spell casters face off with substantial starting armies. Can the "
-"crusaders keep the peace?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:653
-msgid "\"The Gauntlet\""
-msgstr "\"Stridshandsken\""
-
-#: ../fheroes2/resource/maps_text.cpp:654
-msgid ""
-"The Gods have given you 6 months to prove yourself. Good or Evil - who shall "
-"prevail? (Blue,Green and Red vs Yellow, Orange and Purple)"
-msgstr ""
-"Gudarna har gett dig 6 månader att visa vad du kan. Godhet eller Ondska - "
-"vad ska segra? (Blå, Grön och Röd mot Gul, Orange och Lila)"
-
-#: ../fheroes2/resource/maps_text.cpp:655
-msgid ""
-"The gods have granted this world a great artifact, to find it means victory."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:656
-msgid "The Gods themselves will aid us in this War."
-msgstr "Gudarna själv kommer att stödja oss i detta krig."
-
-#: ../fheroes2/resource/maps_text.cpp:657
-msgid "The Gold Traveller's Tent is near the Aqua Taveller's Tent."
-msgstr "Gulds resenärstält är nära akvamarins resenärstält."
-
-#: ../fheroes2/resource/maps_text.cpp:658
-msgid "The guardians of Dragon Isle reside in the jungle."
-msgstr "Draköns väktare bor i djungeln."
-
-#: ../fheroes2/resource/maps_text.cpp:659
-msgid "The Ice Prince stands frozen in some forgotten corner of the world."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:660
-msgid "The island...."
-msgstr "Ön..."
-
-#: ../fheroes2/resource/maps_text.cpp:661
-msgid "The Island of Lost Reason"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:662
-msgid "The islands have much wealth."
-msgstr "Öarna har mycket rikedomar."
-
-#: ../fheroes2/resource/maps_text.cpp:663
-msgid "The Isle of Armoria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:664
-msgid "The key to success is rubbing enough lamps."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:665
-msgid ""
-"The King has declared you his hier apparent and champion. You must seek out "
-"and destroy your common enemy, Wilgatus and his Castle, Mirkosov, the source "
-"of his power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:666
-msgid ""
-"The King is dead, his kingdom has been shattered, and six leaders seek to "
-"seize power for themselves."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:667
-msgid "The Kingly Wastes"
-msgstr "Kungligt avfall"
-
-#: ../fheroes2/resource/maps_text.cpp:668
-msgid "The Kings Road."
-msgstr "Kungarnas väg."
-
-#: ../fheroes2/resource/maps_text.cpp:669
-msgid ""
-"The King will sell you this land for 200,000 gold or you can take it by "
-"force. The choice is yours."
-msgstr ""
-"Kungen kommer att sälja dig detta land för 200,000 guld eller så kan du "
-"erövra det. Valet är ditt."
-
-#: ../fheroes2/resource/maps_text.cpp:670
-msgid "The land of Heroes II."
-msgstr "Hjältarnas land II."
-
-#: ../fheroes2/resource/maps_text.cpp:671
-msgid "The Lost Castle of the Ancients"
-msgstr "Antikens förlorade slott."
-
-#: ../fheroes2/resource/maps_text.cpp:672
-msgid ""
-"The mage wars have caused a great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:673
-msgid ""
-"The mage wars have caused great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:674
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trade.  "
-"Plus a little gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:675
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trading.  "
-"Plus a little more gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:676
-msgid ""
-"The Master Merchant arrives at your Castle.  He tells you tall tales of "
-"travel, full of outrageous lies.  He also gives you, your share of the "
-"profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:677
-msgid ""
-"The Master Merchant arrives back at your Castle.  He tells you tall tales of "
-"faraway places full of outrageous lies.  He also gives you, your share of "
-"the profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:678
-msgid "The Medusas have the password and they can be found just to the west."
-msgstr "Medusorna har lösenordet och dem kan man hitta i väst."
-
-#: ../fheroes2/resource/maps_text.cpp:679
-msgid "The more there is the less you see."
-msgstr "Ju mer det finns, desto mindre ser du."
-
-#: ../fheroes2/resource/maps_text.cpp:680
-msgid "The North Road to Roland's castle."
-msgstr "Norra vägen till Rolands slott."
-
-#: ../fheroes2/resource/maps_text.cpp:681
-msgid ""
-"The note in this bottle has become mostly indecipherable. All you can make "
-"out are references to deadly pirates, and hidden gold mines."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:682
-msgid "The Other Side"
-msgstr "Den andra sidan"
-
-#: ../fheroes2/resource/maps_text.cpp:683
-msgid ""
-"The Overlord has given you 4 months to conquer this land or deliver to him "
-"the sum of 150,000 gold."
-msgstr ""
-"Överherren har gett dig 4 månader att erövra detta land eller överlämna en "
-"summa på 150,000 guld."
-
-#: ../fheroes2/resource/maps_text.cpp:684
-msgid ""
-"The people on the Isle of Knowledge are taking up a collection to aid us."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:685
-msgid "The Proving Grounds"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:686
-msgid "The Queen's Road."
-msgstr "Drottningens väg."
-
-#: ../fheroes2/resource/maps_text.cpp:687
-msgid "The Realm of Air is barred, but you may appeal here for help."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:688
-msgid ""
-"There are remnants of a mighty battle fought here, not too long ago. It "
-"looks as if whoever came this way may have made this their final stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:689
-msgid ""
-"There are three enemy castles to the north. Capture them in the name of "
-"Roland the true king!"
-msgstr ""
-"Det finns tre fiendeslott norrut. Erövra dem i Roland, den sanne kungens, "
-"namn!"
-
-#: ../fheroes2/resource/maps_text.cpp:690
-msgid ""
-"The Red Tide of War rolls North.  Stopping the flood seems hopeless.  Yet, "
-"Honor demands you and your ally die trying."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:691
-msgid "There is hidden treasure north of the Green Lord's Ore Mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:692
-msgid "There is hidden treasure south of the Blue Lord's Sawmill."
-msgstr "Det finns en gömd skatt söder om Den blå herrens sågverk."
-
-#: ../fheroes2/resource/maps_text.cpp:693
-msgid "There's a warm wind blowing from the south."
-msgstr "En varm vind blåser från söder."
-
-#: ../fheroes2/resource/maps_text.cpp:694
-msgid "There's a Wizard living in the north who is behind this peasant revolt."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:695
-msgid "The Retreat of the Alchemist Doctor Yu"
-msgstr "Alkemisten Doktor Yu's reträtt"
-
-#: ../fheroes2/resource/maps_text.cpp:696
-msgid ""
-"There used to be a mine here, but it has long since run out of ore.  You are "
-"only able to scavenge 5 units of ore from the old site."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:697
-msgid "There was a shipreck in the far east waters recently."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:698
-msgid "The River Styx"
-msgstr "Floden Styx"
-
-#: ../fheroes2/resource/maps_text.cpp:699
-msgid "The roars of several dragons echo from the towers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:700
-msgid "The Rock Store."
-msgstr "Stenaffären."
-
-#: ../fheroes2/resource/maps_text.cpp:701
-msgid "The Royal Gardens."
-msgstr "Kungliga trädgårdarna."
-
-#: ../fheroes2/resource/maps_text.cpp:702
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:703
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you defend against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:704
-msgid "These doors are a risk the likes of which you do not know."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:705
-msgid "These lands are beholden to Lord Kraeger."
-msgstr "Dessa länder tillhör Lord Kraeger."
-
-#: ../fheroes2/resource/maps_text.cpp:706
-msgid ""
-"These lands are desolate and for the most part devoid of resources. Not even "
-"the bravest heroes dare to venture into them, and plants are rare and "
-"precious here. Who knows what else awaits?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:707
-msgid ""
-"The Southern Witch is biding her time.  She will strike when your armies are "
-"weak."
-msgstr "Häxan i söder tar sin tid. Hon attackerar när dina arméer är svaga."
-
-#: ../fheroes2/resource/maps_text.cpp:708
-msgid "the stairs"
-msgstr "trapporna"
-
-#: ../fheroes2/resource/maps_text.cpp:709
-msgid "The Table in the Great Hall of the Castle is Haunted."
-msgstr "Bordet i slottets stora hall är hemsökt."
-
-#: ../fheroes2/resource/maps_text.cpp:710
-msgid ""
-"The third piece of the artifact is somewhere to the north, that much we "
-"know. We are still unsure of its exact location, but our spies are out "
-"gathering information. The forces in this area are too strong to be "
-"completely subjugated, so take what you can and hold on to it tightly."
-msgstr ""
-"Den tredje delen av artefakten är någonstans i norr, det vet vi. Vi är "
-"fortfarande osäkra på dess exakta position, men våra spioner är ute och "
-"samlar på sig information. Trupperna i detta område är för starka för att "
-"bli helt underkuvade, så ta det du kan och håll det dig nära."
-
-#: ../fheroes2/resource/maps_text.cpp:711
-msgid ""
-"The troops have sworn their allegiance, but should lose a battle they will "
-"lose faith and our cause will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:712
-msgid "The Valley of Aruk."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:713
-msgid ""
-"The Valley of Magic holds many surprises.  You discover an old pair of boots "
-"sticking out of the sand."
-msgstr ""
-"Magidalen rymmer många överraskningar. Du hittar ett par gamla stövlar som "
-"sticker upp i sanden."
-
-#: ../fheroes2/resource/maps_text.cpp:714
-msgid "The Valley of Tresures"
-msgstr "Skattdalen"
-
-#: ../fheroes2/resource/maps_text.cpp:715
-msgid "The Wasteland"
-msgstr "Ödemarken"
-
-#: ../fheroes2/resource/maps_text.cpp:716
-msgid "The way of magic"
-msgstr "Magins väg"
-
-#: ../fheroes2/resource/maps_text.cpp:717
-msgid "The way of might"
-msgstr "Maktens väg"
-
-#: ../fheroes2/resource/maps_text.cpp:718
-msgid "The way of numbers"
-msgstr "Siffrornas väg"
-
-#: ../fheroes2/resource/maps_text.cpp:719
-msgid "The western town."
-msgstr "Västra staden"
-
-#: ../fheroes2/resource/maps_text.cpp:720
-msgid "The winds howl in mourning around the shipwreck."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:721
-msgid "The wizard has an island in the southeast."
-msgstr "Trollkarlen har en ö i sydöst."
-
-#: ../fheroes2/resource/maps_text.cpp:722
-msgid ""
-"The Wizards who have captured the Necromancers' town have wasted no time in "
-"building defenses designed to stop you, and their last castle has just been "
-"completed. Fortunately only a Captain of the Guard and a small garrison are "
-"currently present.  If you hurry, you should be able to capture the castle "
-"before they have a chance to reinforce it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:723
-msgid "The wood has arrived."
-msgstr "Veden har anlänt."
-
-#: ../fheroes2/resource/maps_text.cpp:724
-msgid "The writing on this sign is too faded to read."
-msgstr "Texten på denna skylt är för blek för att kunna läsas."
-
-#: ../fheroes2/resource/maps_text.cpp:725
-msgid "The Yellow Lord has the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:726
-msgid ""
-"The Yellow Lord is a hothead who will attack before his allies can send him "
-"aid."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:727
-msgid "They say there's mermaids in these waters..."
-msgstr "Det sägs att det finns sjöjungfrur i dessa vatten..."
-
-#: ../fheroes2/resource/maps_text.cpp:728
-msgid ""
-"This area is rich in resources. Explore, but beware, a castle left "
-"undefended will quickly fall."
-msgstr ""
-"Detta område är rikt på resurser. Utforska, men se upp! Ett oskyddat slott "
-"faller snabbt."
-
-#: ../fheroes2/resource/maps_text.cpp:729
-msgid ""
-"This area must be secured for the sake of the Empire. Our spies have "
-"reported a discord between The kingdom of the knights to the north, and that "
-"of the oppressive sorceresses to the northeast. Perhaps this feud can be "
-"exploited for our gain..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:730
-msgid "This bottle is empty."
-msgstr "Flaskan är tom."
-
-#: ../fheroes2/resource/maps_text.cpp:731
-msgid ""
-"This is the last week you have to find the rebel wizard Joseph! Good Luck in "
-"your quest."
-msgstr ""
-"Det här är den sista veckan du har på dig att hitta trollkarlsrebellen "
-"Joseph! Lycka till på ditt uppdrag."
-
-#: ../fheroes2/resource/maps_text.cpp:732
-msgid ""
-"This land and all others are now under the sole ownership of Ibn Fadlan, the "
-"Undead King. Any disregard for his magesty's soverign rule is to be punished "
-"by death most horrendous."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:733
-msgid ""
-"This land has been claimed by the nation of Neroli. Interlopers are "
-"UNWELCOME."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:734
-msgid ""
-"This rugged land will have rivals fighting the terrain as well as each other."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:735
-msgid ""
-"This rundown village looks like it was once the epicenter of an enormous, "
-"but now ruined, city. Under a pile of rubble you find an object which looks "
-"like it has lain there for ages."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:736
-msgid ""
-"This spot overlooks an old quarry.  This was one of the only places in the "
-"world where ore could be taken right out of the ground.  Unfortunately the "
-"jungle has reclaimed the quarry and it is unusable.  You collect the last of "
-"the ore and depart."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:737
-msgid ""
-"This twisted maze of sorceress towns has three factions struggling for sole "
-"control.  Use your resources wisely!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:738
-msgid ""
-"This village appears to be in little better shape than the first one you "
-"saw. As you approach the village an old man hands you a slip of paper, with "
-"the following message, \"Joseph lives in the town of IslandHome.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:739
-msgid ""
-"This village is in extremely poor shape. There is no chance of getting more "
-"than some of the lesser creatures here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:740
-msgid "This way to the Necromancer Forest."
-msgstr "Denna väg leder till Svartkonstnärsskogen."
-
-#: ../fheroes2/resource/maps_text.cpp:741
-msgid "Those who seek knowledge are welcome to the city of Chronos."
-msgstr "Dem som söker kunskap är välkommen till Chronors stad."
-
-#: ../fheroes2/resource/maps_text.cpp:742
-msgid ""
-"Three Warlocks in the land of Dragons. Lose thy home and all will be lost. "
-"Conquer thy enemies and the land shall forever be yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:743
-msgid "Timberhill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:744
-msgid "Time for a refreshing drink."
-msgstr "Dags för en uppfriskande drink."
-
-#: ../fheroes2/resource/maps_text.cpp:745
-msgid "Time is running out! The enemy's reinforcements are almost here."
-msgstr "Tiden tar slut! Fiendens förstärkningar är nästan här."
-
-#: ../fheroes2/resource/maps_text.cpp:746
-msgid "To pass you must pay troll."
-msgstr "För att passera måste du betala trollet."
-
-#: ../fheroes2/resource/maps_text.cpp:747
-msgid "TreeHome"
-msgstr "Trädhem"
-
-#: ../fheroes2/resource/maps_text.cpp:748
-msgid "Trespassers will be EATEN!"
-msgstr "Passerande kommer att ÄTAS UPP!"
-
-#: ../fheroes2/resource/maps_text.cpp:749
-msgid "Trilobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:750
-msgid "Troy"
-msgstr "Troy"
-
-#: ../fheroes2/resource/maps_text.cpp:751
-msgid "Tundara"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:752
-msgid "Turn back, friend, while you still can!"
-msgstr "Vänd om, vän, medan du fortfarande kan!"
-
-#: ../fheroes2/resource/maps_text.cpp:753
-msgid "Turn Back Now!"
-msgstr "Vänd Om Nu!"
-
-#: ../fheroes2/resource/maps_text.cpp:754
-msgid "Turn Back Now or all will be LOST!"
-msgstr "Vänd Om Nu annars kommer alla att FÖRSVINNA!"
-
-#: ../fheroes2/resource/maps_text.cpp:755
-msgid "Turn Back or DIE!"
-msgstr "Vänd Om eller DÖ!"
-
-#: ../fheroes2/resource/maps_text.cpp:756
-msgid "Turn Back or else!"
-msgstr "Vänd Om eller annars!"
-
-#: ../fheroes2/resource/maps_text.cpp:757
-msgid "Turn back, you fool."
-msgstr "Vänd om, din dåre."
-
-#: ../fheroes2/resource/maps_text.cpp:758
-msgid "\"Turning Point\""
-msgstr "\"Vändpunkt\""
-
-#: ../fheroes2/resource/maps_text.cpp:759
-msgid ""
-"Uae was the scurviest, pirate ye'd never wanta see. In all her years of "
-"murdering and thieving she amassed so much ill-gotten booty that she "
-"couldn't carry it around in her galleon.  Besides, even the meanest can't "
-"stay awake all the time.  Legend tells that she hid it so well, she was "
-"thinking that she just might forget where it was.  So she left clues around "
-"the islands, carved in stone.  Well, she's dead now.  It's up to you to "
-"recover her legacy."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:761
-msgid "Uncle Leo"
-msgstr "Farbror Leo"
-
-#: ../fheroes2/resource/maps_text.cpp:762
-msgid "Uncle Milty"
-msgstr "Morbror Milty"
-
-#: ../fheroes2/resource/maps_text.cpp:763
-msgid "Undead Armies"
-msgstr "Odöda arméer"
-
-#: ../fheroes2/resource/maps_text.cpp:764
-msgid "Unholy Alliance"
-msgstr "Ohelig allians"
-
-#: ../fheroes2/resource/maps_text.cpp:765
-msgid "Unite the Tribes. Don't lose your main hero, the first Descendant."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:766
-msgid "Valley of Death"
-msgstr "Dödsdalen"
-
-#: ../fheroes2/resource/maps_text.cpp:767
-msgid "Valley Of The Damned"
-msgstr "Förbannade dalen"
-
-#: ../fheroes2/resource/maps_text.cpp:768
-msgid "Valley of the Kings."
-msgstr "Kungarnas dal."
-
-#: ../fheroes2/resource/maps_text.cpp:769
-msgid "Vaultius"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:770
-msgid "Vertigo"
-msgstr "Vertigo"
-
-#: ../fheroes2/resource/maps_text.cpp:771
-msgid "Vikings!"
-msgstr "Vikingar!"
-
-#: ../fheroes2/resource/maps_text.cpp:772
-msgid "Viper's Nest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:773
-msgid "Vulcania"
-msgstr "Vulkania"
-
-#: ../fheroes2/resource/maps_text.cpp:774
-msgid "Warrior Knight"
-msgstr "Krigsriddare"
-
-#: ../fheroes2/resource/maps_text.cpp:775
-msgid "Wastelands"
-msgstr "Ödemarker"
-
-#: ../fheroes2/resource/maps_text.cpp:776
-msgid "Watch out for Purple!"
-msgstr "Akta dig för Lila!"
-
-#: ../fheroes2/resource/maps_text.cpp:777
-msgid "Waystop"
-msgstr "Vägstopp"
-
-#: ../fheroes2/resource/maps_text.cpp:778
-msgid ""
-"\"We are at the edge of the world!\"  they scream.  \"What are we doing here?"
-"\""
-msgstr "\"Vi är vid världens ände\", skriker dem. \"Vad gör vi här?\""
-
-#: ../fheroes2/resource/maps_text.cpp:779
-msgid "Weddington"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:780
-msgid "Weed Patch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:781
-msgid ""
-"We found a weakness my lord. Capture castle Black Fang and victory is ours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:782
-msgid ""
-"We have just learned that the artifact is on an island north of this "
-"continent. However, there does not appear to be any means to get there. Stay "
-"very alert for any possible way across the narrow channel."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:783
-msgid ""
-"Welcome back general.  Have you finished the conquest of the northern "
-"lands?  What? you still have not finished your mission!  Get back there and "
-"teach those rebels a lesson!"
-msgstr ""
-"Välkommen tillbaka, general. Har du slutfört erövringingen av alla länder i "
-"norr? Va? Du har inte slutfört ditt uppdrag! Gå tillbaka och lär dem där "
-"rebellerna en läxa!"
-
-#: ../fheroes2/resource/maps_text.cpp:784
-msgid "Welcome to Li'l Alctatraz! Vistors NOT welcome."
-msgstr "Välkommen till Li'l Alctatraz! Besökare är inte välkomna."
-
-#: ../fheroes2/resource/maps_text.cpp:785
-msgid ""
-"Welcome to Power Island. He who controls this Isle controls the Seven Lakes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:786
-msgid "Welcome to the Sandbar."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:787
-msgid "Welcome to the sandy Isle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:788
-msgid "Welcome to the sorceress' guild."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:789
-msgid "Welcome to the Spiral Isles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:790
-msgid ""
-"Welcome to the wounderous Kitisland range.  Eruptions each day, beware of "
-"dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:791
-msgid "Welcome to Windfall Island!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:792
-msgid "Welcome to your DOOM!"
-msgstr "Välkommen till ditt ÖDE!"
-
-#: ../fheroes2/resource/maps_text.cpp:793
-msgid "We'll join you - for the right price."
-msgstr "Vi följer med er, för ett pris."
-
-#: ../fheroes2/resource/maps_text.cpp:794
-msgid ""
-"Well placed bribes have won you a stronghold near the warring Barbarians. Be "
-"advised that given their proximity an unguarded castle is an open invitation "
-"to defeat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:795
-msgid "Westfork"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:796
-msgid "Westmoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:797
-msgid "We told you not to drink!"
-msgstr "Vi sa att du inte skulle dricka det!"
-
-#: ../fheroes2/resource/maps_text.cpp:798
-msgid "What are you doing here?"
-msgstr "Vad gör du här?"
-
-#: ../fheroes2/resource/maps_text.cpp:799
-msgid "What cannot be seen but only heard, and will not speak until spoken to?"
-msgstr ""
-"Vad kan inte synas men endast höras, och pratar inte förrän man pratar till "
-"den?"
-
-#: ../fheroes2/resource/maps_text.cpp:800
-msgid "What everyday word is most often pronounced incorrectly?"
-msgstr "Vilket vardagligt ord uttalas mest ofta felaktigt?"
-
-#: ../fheroes2/resource/maps_text.cpp:801
-msgid "What goes up and down but never moves?"
-msgstr "Vad går upp och ned, men rör sig aldrig?"
-
-#: ../fheroes2/resource/maps_text.cpp:802
-msgid ""
-"What good fortune!  You've discovered a long-abandoned settlement.  To your "
-"surprise, you discover that the previous inhabitants left some of their "
-"resources behind when they departed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:803
-msgid "What is always coming but never arrives?"
-msgstr "Vad är det som alltid kommer men aldrig kommer fram?"
-
-#: ../fheroes2/resource/maps_text.cpp:804
-msgid "What is the Sum of all Numbers from 1 to 200?"
-msgstr "Vad är summan av nummer från 1 till 200?"
-
-#: ../fheroes2/resource/maps_text.cpp:805
-msgid "What is time spent poorly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:806
-msgid "What's another word for pirate treasure?"
-msgstr "Finns det ett annat ord för piratskatt?"
-
-#: ../fheroes2/resource/maps_text.cpp:807
-msgid "What's behind door number one?"
-msgstr "Vad finns bakom dörr nummer ett?"
-
-#: ../fheroes2/resource/maps_text.cpp:808
-msgid "What's this? A pile of gems?"
-msgstr "Vad är detta? En hög ädelstenar?"
-
-#: ../fheroes2/resource/maps_text.cpp:809
-msgid "What's this? Someone has left a pile of wood here!"
-msgstr "Vad är detta? Någon har lämnat en vedhög här!"
-
-#: ../fheroes2/resource/maps_text.cpp:810
-msgid ""
-"What team won Super Bowl XXI and Super Bowl XXV?  (Hint... a Wizard might "
-"have these troops in his army)"
-msgstr ""
-"Vilket lag vann Super Bowl XXI och Super Bowl XXV? (Tips... en trollkarl "
-"kanske har dessa troféer in sin armé)"
-
-#: ../fheroes2/resource/maps_text.cpp:811
-msgid "What turns everything around but does not move?"
-msgstr "Vad är det som vrider allting men rör sig aldrig?"
-
-#: ../fheroes2/resource/maps_text.cpp:812
-msgid ""
-"What walks in the morning on four legs, two in the afternoon and three in "
-"the evening?"
-msgstr ""
-"Vad är det som har fyra ben på morgonen, två ben på dagen och tre ben på "
-"kvällen?"
-
-#: ../fheroes2/resource/maps_text.cpp:813
-msgid "What?  What's this?  Something at the bottom of this pool..."
-msgstr "Vad? Vad är detta? Någonting på botten av denna damm..."
-
-#: ../fheroes2/resource/maps_text.cpp:814
-msgid "When you're ready, take the teleport to the Island's Hot Spot!"
-msgstr "När du är redo, tar du teleportören till öns hetfläck!"
-
-#: ../fheroes2/resource/maps_text.cpp:815
-msgid ""
-"When you think yourself invincible, walk through this gate.  Even then, "
-"prepare to meet your bitter end."
-msgstr ""
-"Gå endast igenom denna port när du tror du är oövervinnelig. Även då bör du "
-"förbereda dig för att möta ditt bittra slut."
-
-#: ../fheroes2/resource/maps_text.cpp:816
-msgid "Where am I?"
-msgstr "Var är jag?"
-
-#: ../fheroes2/resource/maps_text.cpp:817
-msgid "While away seeking the Ultimate Artifact, Kastor's kingdom is invaded!"
-msgstr ""
-"Medan du är iväg och söker efter den Ultimata artefakten invaderas Kastor's "
-"kungarike!"
-
-#: ../fheroes2/resource/maps_text.cpp:818
-msgid ""
-"While traveling a mesenger meets you on the road.  His message tells of a "
-"new ally from an island far to the south.  This ally can not offer forces to "
-"your battle but has agreed to send some support in the form of gold and "
-"crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:819
-msgid "Whiteshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:820
-msgid "Whittingham"
-msgstr "Whittingham"
-
-#: ../fheroes2/resource/maps_text.cpp:821
-msgid "Who am I?"
-msgstr "Vem är jag?"
-
-#: ../fheroes2/resource/maps_text.cpp:822
-msgid ""
-"Who am I?...  Where am I?...  Oh no! My Ship!  Well it's consigned to the "
-"ghosts of my dead crew now, at least I still have my lucky rabbits foot."
-msgstr ""
-"Vem är jag? ... Var är jag? ... Åh nej! Mitt skepp! Nåja, det är nu "
-"överlämnat till min spökena från min döda besättning. Jag har åtminstone "
-"kvar min hartass."
-
-#: ../fheroes2/resource/maps_text.cpp:823
-msgid "Who is the true King?"
-msgstr "Vem är den sanne kungen?"
-
-#: ../fheroes2/resource/maps_text.cpp:824
-msgid ""
-"\"Why have we come this way?\"  asks the first mate.  You have no answer."
-msgstr ""
-"\"Varför har vi kommit denna väg?\", frågar förste styrman. Du har inget "
-"svar på frågan."
-
-#: ../fheroes2/resource/maps_text.cpp:825
-msgid "Wicked Warlock Way"
-msgstr "Onde krigstrollkarlens väg"
-
-#: ../fheroes2/resource/maps_text.cpp:826
-msgid "Wilasher"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:827
-msgid "Wildabar"
-msgstr "Wildabar"
-
-#: ../fheroes2/resource/maps_text.cpp:828
-msgid "Wilgatus"
-msgstr "Wilgatus"
-
-#: ../fheroes2/resource/maps_text.cpp:829
-msgid "Willow"
-msgstr "Pilträd"
-
-#: ../fheroes2/resource/maps_text.cpp:830
-msgid "Windfall Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:831
-msgid "Winterkill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:832
-msgid "Winterlands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:833
-msgid "Witch Hunt"
-msgstr "Häxjakt"
-
-#: ../fheroes2/resource/maps_text.cpp:834
-msgid ""
-"With the year long eruption of Mt. Kitisland, your three worst enemies now "
-"have a ground bridge to your eastern contenent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:835
-msgid "Wizardwood.  Magicians welcome!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:836
-msgid "Woodhaven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:837
-msgid "Wood's Lord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:838
-msgid "Woodstock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:839
-msgid "Woodville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:840
-msgid "Wormed Ash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:841
-msgid "Wow, somebody has left a pile of wood here!"
-msgstr "Oj, någon har lämnat en vedhög här!"
-
-#: ../fheroes2/resource/maps_text.cpp:842
-msgid "Wyrm"
-msgstr "Wyrm"
-
-#: ../fheroes2/resource/maps_text.cpp:843
-msgid "Xabran"
-msgstr "Xabran"
-
-#: ../fheroes2/resource/maps_text.cpp:844
-msgid "Yellow gets some stuff"
-msgstr "Gul får lite saker"
-
-#: ../fheroes2/resource/maps_text.cpp:845
-msgid "Yellow's Steady Cash"
-msgstr "Guls säkra pengar"
-
-#: ../fheroes2/resource/maps_text.cpp:846
-msgid "Yellow stuff"
-msgstr "Gula saker"
-
-#: ../fheroes2/resource/maps_text.cpp:847
-msgid "Yellow's Yarbols"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:848
-msgid "Ye old fish liver oil."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:849
-msgid "Yorksford"
-msgstr "Yorksford"
-
-#: ../fheroes2/resource/maps_text.cpp:850
-msgid ""
-"You and your ally's families were given custody of The Isle of Knowledge.  "
-"Other Lords feel the time has come for new guardians..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:851
-msgid "You are a fool to come here!"
-msgstr "Du är en dåre som kommer hit!"
-
-#: ../fheroes2/resource/maps_text.cpp:852
-msgid "You are fighting on the side of your king!"
-msgstr "Du slåss på din kungs sida!"
-
-#: ../fheroes2/resource/maps_text.cpp:853
-msgid "You are fighting on the side of your sister!"
-msgstr "Du slåss på din systers sida!"
-
-#: ../fheroes2/resource/maps_text.cpp:854
-msgid "You are now entering the domain of Prince Roland. Have a nice day."
-msgstr "Du kliver nu in i prins Rolands domän. Ha en bra dag."
-
-#: ../fheroes2/resource/maps_text.cpp:855
-msgid "You are now entering the domain of Prince Roland. Have a pleasant stay."
-msgstr "Du kliver nu in i prins Rolands domän. Ha en trevlig dag."
-
-#: ../fheroes2/resource/maps_text.cpp:856
-msgid ""
-"You bribe the entrance guards of this dingy prison camp. They agree to look "
-"the other way for a little while."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:857
-msgid ""
-"You can only reach your enemies via teleporters, but each jump is a leap of "
-"faith."
-msgstr ""
-"Du kan endast nå dina fiender via teleportörer, men varje hopp är ett "
-"chansning."
-
-#: ../fheroes2/resource/maps_text.cpp:858
-msgid ""
-"You cautiously ride through the trees, looking out for enemy assaults, when "
-"suddenly, the old elf is beside you. \"Your quest is almost at an end, my "
-"friend. All that remains is for you to lay seige to these last few castles. "
-"The fate of my people rests upon your final battles here. May the gods be "
-"with you as well.\"  He turns to leave, but you ask him his name before he "
-"is gone. Over his shoulder, as he is leaving he says \"I am Ilthanis, king "
-"of the elves.\""
-msgstr ""
-"Du rider försiktigt genom skogen, spanades efter fiendeangrepp, när en "
-"gammal alv plötsligt står bredvid dig. \"Ditt uppdrag lider mot sitt slut, "
-"min vän. Allt som återstår är att belägra dessa sista slott. Mitt folks öde "
-"vilar på dina sista strider här. Må gudarna vara med dig också.\" Han vänder "
-"sig om för att gå iväg, men du frågar vad han heter innan han försvinner. "
-"Över sin axel säger han medan han går iväg, \"Jag är Ilthanis, alvernas kung."
-"\""
-
-#: ../fheroes2/resource/maps_text.cpp:859
-msgid ""
-"You come across the dead remains of what was appearantly a powerful wizard!  "
-"You wonder if it's safe to continue."
-msgstr ""
-"Du stöter på kvarlevor från en kraftfull trollkarl! Du börjar undra om det "
-"är säkert att fortsätta."
-
-#: ../fheroes2/resource/maps_text.cpp:860
-msgid ""
-"You face three opponents in this scenario. Capture their castles and their "
-"heroes to prove your worthiness to Archibald."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:861
-msgid ""
-"You find a beautiful helm buried in the lava.  As you move to put it on your "
-"head it turns into the Hideous mask and now you realize that no creature "
-"will join you."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:862
-msgid ""
-"You find a gleaming gold medalion buried in the  snow.  As you move to put "
-"it on it changes to the Fizbin of Misfortune."
-msgstr ""
-"Du hittar en glimmande guldmedaljong som är begravd i snön. När du sätter på "
-"dig den förvandlas den till en Olycksfizbin."
-
-#: ../fheroes2/resource/maps_text.cpp:863
-msgid ""
-"You find an old signpost in the midst of a thicket that reads \"Warlock "
-"Wood, West.  Barbarian Fields, East.\""
-msgstr ""
-"Du hittar en gammal skylt mitt i buskaget där det står "
-"\"Krigstrollkarlsskogen, väst. Barbarfälten, öst.\""
-
-#: ../fheroes2/resource/maps_text.cpp:864
-msgid ""
-"You find a note in the bottle! It reads, \"My ship has been wrecked by the "
-"notorious pirates in this area! I am stranded on a small and barren island. "
-"Please, I beg you to come and rescue me!\""
-msgstr ""
-"Du hittar en lapp i flaskan! Det står, \"Mitt skepp har förlist av de "
-"beryktade piraterna i detta område! Jag är strandad på en liten öde ö. "
-"Snälla, jag ber dig att komma och rädda mig!\""
-
-#: ../fheroes2/resource/maps_text.cpp:865
-msgid "You found something!"
-msgstr "Du hittade någonting!"
-
-#: ../fheroes2/resource/maps_text.cpp:866
-msgid "You found Treasure!"
-msgstr "Du hittade en skatt!"
-
-#: ../fheroes2/resource/maps_text.cpp:867
-msgid ""
-"You have been ordered here to claim this land in the name of your King and "
-"recover any riches that you might find.  However, five other Kings and "
-"Queens have also sent their heroes to this land, so you must watch out for "
-"them as well as the natives!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:868
-msgid "You have found what someone else has lost..."
-msgstr "Du har hittat någonting som någon annan har förlorat..."
-
-#: ../fheroes2/resource/maps_text.cpp:869
-msgid ""
-"You have hired a barbarian of great power to aid you in this, your last "
-"quest. His origins are unknown to you, but you sense strong nobility beneath "
-"the furs and dirt that cover him. In addition, the famous explorer, Marco "
-"the wizard, is rumored to have wrecked his ship in this new land. Finding "
-"him would prove to be a much needed boon to your cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:870
-msgid ""
-"You have just 8 weeks  to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-"Du har endast 8 veckor på dig att bygga din armé och erövra en stad på andra "
-"sidan av en avlägsen flod. Det finns tre vägar, vilken väljer du?"
-
-#: ../fheroes2/resource/maps_text.cpp:871
-msgid ""
-"You have just 8 weeks to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-"Du har endast 8 veckor på dig att bygga din armé och erövra en stad på andra "
-"sidan av en avlägsen flod. Det finns tre vägar, vilken väljer du?"
-
-#: ../fheroes2/resource/maps_text.cpp:872
-msgid ""
-"You have received a message from Archibald. \"General, these peasants "
-"deserve punishment. Put them to the sword and let Corlagon have his way with "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:873
-msgid ""
-"You have received a message from Archibald.  \" HOW DARE YOU BETRAY ME! I "
-"will see your head on the block alongside your new master's once I have won."
-msgstr ""
-"Du har fått ett meddelande från Archibald. \"HUR VÅGAR DU FÖRRÅDA MIG! Jag "
-"kommer att se ditt huvud på byggnaden bredvid din nye härskares när jag har "
-"vunnit.\""
-
-#: ../fheroes2/resource/maps_text.cpp:874
-msgid ""
-"You have received a message from Roland. \" I am shocked! I had thought "
-"better of you, but I was terribly wrong. Now you'll have to live with your "
-"dark decision for the rest of your life.\""
-msgstr ""
-"Du har fått ett meddelande från Roland. \"Jag är shockad! Jag trodde bättre "
-"om dig, men jag var helt fel. Nu måste du leva med din mörka val för resten "
-"av ditt liv.\""
-
-#: ../fheroes2/resource/maps_text.cpp:875
-msgid "You have recieved a shipment of supplies from your kingdom!"
-msgstr "Du har fått ett skeppslast med proviant från ditt kungarike!"
-
-#: ../fheroes2/resource/maps_text.cpp:876
-msgid ""
-"You have recieved a shipment of supplies from your kingdom! There is a note "
-"attached, \"These are all we could afford to send you from our treasuries, "
-"as the war with Harondale is taxing us greatly. We will send more in two "
-"weeks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:877
-msgid ""
-"You have six months to destroy the Necromancer Stronghold in the heart of "
-"the valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:878
-msgid ""
-"You have washed up on the beach after being shipwrecked. Your goal is to "
-"find a way home."
-msgstr ""
-"Du har spolats upp på en strand efter att blivit skeppsbruten. Ditt mål är "
-"att hitta hem igen."
-
-#: ../fheroes2/resource/maps_text.cpp:879
-msgid ""
-"You hear a low rumble, look up and see an avalanche!  You dive onto a large "
-"patch of grass to avoid it.  While dusting yourself off, you consider "
-"yourself quite lucky to be alive.  Luckier still to find a Four-Leaf Clover "
-"stuck on your nose."
-msgstr ""
-"Du hör ett lågt mullrande, tittar upp och ser en lavin! Du dyker in i en "
-"stor gräsfläck för att undvika den. När du borstar av dig tänker du på att "
-"du är ganska lyckosam för att vara vid liv. Lyckosam nog för att hitta en "
-"fyrklöver som har fastnat på din näsa."
-
-#: ../fheroes2/resource/maps_text.cpp:880
-msgid ""
-"You hear a rumor from a peasant who lives in the town of Waystop. He says, "
-"\"The pirates control most of the sulfur mines in this area. They use it for "
-"the cannons on their bigger boats. If you want a mine, you'll have to defeat "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:881
-msgid "You hear melodic strains of elvish music as you enter this clearing."
-msgstr "Du hör melodiska strängar av älvlik musik när du kliver in i gläntan."
-
-#: ../fheroes2/resource/maps_text.cpp:882
-msgid ""
-"You must, like, forsake your earthly wealth and, like, join us on the island "
-"of the lotus eaters."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:883
-msgid ""
-"You must search the world for your mortal enemy, Wilgatus.  Can you find him "
-"before its too late?"
-msgstr ""
-"Du måste söka överallt för att kunna hitta din dödsbringande fiende, "
-"Wilgatus. Kan du hitta honom innan det är för sent?"
-
-#: ../fheroes2/resource/maps_text.cpp:884
-msgid ""
-"You notice some runes hastily scrawled into a rock by your feet, They look "
-"like the initials of Uncle Ivan!"
-msgstr ""
-"Du hittar några runor som hastigt inristats i en sten vid dina fötter. Det "
-"ser ut som farbror Ivans initialer!"
-
-#: ../fheroes2/resource/maps_text.cpp:885
-msgid ""
-"You notice that mines and resources in the elvish lands are few, and you "
-"send word to your kingdom that you will need extra supplies. They should "
-"respond within a fortnight."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:886
-msgid ""
-"Your advance scouts come riding back to you with the following news. They "
-"believe they have found signs that Uncle Ivan was in this general area, and "
-"that he made his way to the north many months ago. Also they say there is a "
-"town nearby and many resources to the east."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:887
-msgid ""
-"Your advisor approaches you, \"My liege, something must be done about these "
-"peasants! They still refuse to work.  At this rate you won't have anything "
-"to put in your daughter's dowry!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:888
-msgid ""
-"Your advisor approaches you smiling greatly, \"My liege! The peasants are "
-"making money in the market, and are finally paying taxes!\""
-msgstr ""
-"Din rådgivare kommer mot dig med ett stort leende, \"Min herre! Bönderna "
-"tjänar pengar på marknaden, och de betalar äntligen skatt!\""
-
-#: ../fheroes2/resource/maps_text.cpp:889
-msgid ""
-"Your advisor approaches you with a long face, \"My liege, the peasant's "
-"numbers are growing steadily.  All they do is take, take, take! We are "
-"beginning to suffer dearly because of them.\""
-msgstr ""
-"Din rådgivare kommer till dig lång i ansiktet, \"Min herre, böndernas antal "
-"växer stadigt. Allt det dem gör är att ta, ta, ta! Vi börjar att lida på "
-"grund av dem!"
-
-#: ../fheroes2/resource/maps_text.cpp:890
-msgid ""
-"Your advisor approaches you with some startling information, \"My liege, the "
-"peasants are draining us. They do nothing, and take everything! We must get "
-"them home. Your own citizens are beginning to suffer!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:891
-msgid ""
-"Your arrival here was a surprise to those sworn to guard Dragon Isle, and "
-"you were able to quickly capture one of their castles.  Use caution, though, "
-"for two other guardians remain in this jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:892
-msgid ""
-"Your castle, founded inside the center of a mile wide crater, is besieged by "
-"those who desire your mineral wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:893
-msgid "Your castle is the last outpost in the area, Don't lose it!"
-msgstr "Ditt slott är områdets sista utpost. Tappa inte bort den!"
-
-#: ../fheroes2/resource/maps_text.cpp:894
-msgid "Your crew begins to grumble."
-msgstr "Din besättning börjar mumla."
-
-#: ../fheroes2/resource/maps_text.cpp:895
-msgid ""
-"Your crew seriously entertains thoughts of mutiny.  Your nights are "
-"sleepless."
-msgstr ""
-"Din besättning hyser allvarligt tankar om myteri. Dina nätter är sömnlösa."
-
-#: ../fheroes2/resource/maps_text.cpp:896
-msgid "You're almost there!"
-msgstr "Du är nästan där!"
-
-#: ../fheroes2/resource/maps_text.cpp:897
-msgid "You, recieve word that you have been robbed."
-msgstr "Du har fått reda på att du har blivit rånad."
-
-#: ../fheroes2/resource/maps_text.cpp:898
-msgid "You're getting colder."
-msgstr "Du börjar bli kall."
-
-#: ../fheroes2/resource/maps_text.cpp:899
-msgid "You're getting warmer."
-msgstr "Du börjar bli varm."
-
-#: ../fheroes2/resource/maps_text.cpp:900
-msgid ""
-"You're here! Oh, thank you thank you thank you! I'm in the jail east of the "
-"castle. Please hurry!"
-msgstr ""
-"Du är här! Åh, tack så mycket! Jag är i fängelset på den östra sidan av "
-"slottet. Skynda dig!"
-
-#: ../fheroes2/resource/maps_text.cpp:901
-msgid ""
-"Your expedition has taken a turn for the worse... you now have no way to get "
-"home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:902
-msgid ""
-"Your forces are thinly spread in an effort to defend all the dwarf towns "
-"(which may not be transformed into castles). Consolidate your forces and "
-"smite the enemy before the towns fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:903
-msgid ""
-"Your horse stumbles and throws you from the saddle.  When you awaken you "
-"find that you have hit your head on the Fizbin of Misfortune."
-msgstr ""
-"Din häst snubblar och kastar av dig från sadeln. När du vaknar upptäcker du "
-"att du har slagit ditt huvud i en Olycksfizbin."
-
-#: ../fheroes2/resource/maps_text.cpp:904
-msgid ""
-"Your isolation from the rest of the kingdom has largely kept you out of the "
-"political struggles, but now with the king's death, and lack of an heir, you "
-"see a golden opportunity to seize the throne for yourself.  Just remember "
-"that you have relied largely on trade for several key resources, especially "
-"sulfur, but with a little planning this land can be yours.  Go, now, and "
-"show these peasants how to rule!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:905
-msgid "Your king has sent supplies to aid the war effort."
-msgstr "Din kung har skickat proviant för att stödja krigsinsatserna."
-
-#: ../fheroes2/resource/maps_text.cpp:906
-msgid ""
-"Your opponents are allied against you and each is twice as powerful as his "
-"predecessor! Is it possible to win?"
-msgstr ""
-"Dina motståndare har slagit ihop sig mot dig och de är dubbelt så starka som "
-"sina företrädare! Är det möjligt att vinna?"
-
-#: ../fheroes2/resource/maps_text.cpp:907
-msgid ""
-"Your Queen sent you here to explore this newly discovered territory, but a "
-"freak storm scattered your fleet and left you stranded.  You gather the "
-"survivors and form a small settlement, naming it New Vertigo.  This place is "
-"your home now, and survival is your highest priority, but remember, if you "
-"are captured or killed, it's over!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:908
-msgid ""
-"Your rival, the kingdom of Harondale, is attacking your weak border towns! "
-"Recover from their first strike and crush them completely."
-msgstr ""
-"Din rival, kungariket Harondale, attackerer din svaga gränsstäder! Återhämta "
-"dig från deras första slag och krossa dem helt."
-
-#: ../fheroes2/resource/maps_text.cpp:909
-msgid ""
-"Your Scouts report talking to a young knight, a squire to the two sleeping "
-"heroes.  The squire is trapped by the Aqua Magic Barriers and a group of "
-"fallen Paladins.  He says the two heroes, Dainwin and Ceallach, have "
-"awakened but are still trapped by a Gold Magical Barrier and asks your aid "
-"in freeing them."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:910
-msgid ""
-"Your Scouts report that the Aqua Traveller's Tent is located along The North "
-"Road."
-msgstr ""
-"Dina spanare rapporterar att akvamarins resenärstält finns längst norra "
-"vägen."
-
-#: ../fheroes2/resource/maps_text.cpp:911
-msgid ""
-"Your scouts return with grim news.  The natives of this land are currently "
-"at war with each other, and they like outsiders even less than they like "
-"each other!  Congratulations, Commander, you're at war!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:912
-msgid ""
-"Your sister calls you before her altar in the morning. \"I have important "
-"news,\" she says, \"The barbarian kingdoms which border this land have "
-"agreed to lend us some of their castles and warriors in return for a share "
-"of the spoils. I hope victory comes swiftly, but your presence gives me "
-"strength to stand until whatever end awaits.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:913
-msgid "Your subjects contribute to your war effort!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:914
-msgid ""
-"Your town is undefended and your heroes are scattered.  Do you attack or "
-"defend?"
-msgstr ""
-"Din stad är oförsvarad och dina hjältar är splittrade. Vill du attackera "
-"eller försvara?"
-
-#: ../fheroes2/resource/maps_text.cpp:915
-msgid ""
-"Your treasury has been looted by robbers and you have lost valuable "
-"resources."
-msgstr ""
-"Din skattkammare har blivit plundrad av rånare och du har förlorat "
-"värdefulla resurser."
-
-#: ../fheroes2/resource/maps_text.cpp:916
-msgid "Your troops begin to wonder about your sanity."
-msgstr "Dina trupper börjar ifrågasätta din mental hälsa."
-
-#: ../fheroes2/resource/maps_text.cpp:917
-msgid ""
-"You run aground on the rocks and have to use some wood to fix your boat."
-msgstr "Du kör på grund och måste få tag på virke att laga din båt med."
-
-#: ../fheroes2/resource/maps_text.cpp:918
-msgid ""
-"You see a family of refugees making their way from the beach. You ask them "
-"about their plight and they tell you that they are from a once great city "
-"called Moss Side. They tell you that the castle was destroyed in a great "
-"conflagration, and they fled for fear of their lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:919
-msgid ""
-"You see an old man bringing water towards the stables. Recognizing him as "
-"the mystic, you attempt to thank him for his gift with some gold. He "
-"refuses, but says to you instead, \"There are riddles guarding the source of "
-"the fount's power, and the dragons know the answers. Make your way through "
-"their lair, and you shall know victory.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:920
-msgid ""
-"You see an old mystic perched on a rock. You walk towards him to see if he "
-"has any words for you on your quest, and he says \"First I see you as a "
-"great conquerer of the lands of men. Secondly, I see you as a mighty ruler "
-"of vast armies, well loved by your troops. Thirdly, I see you as a slayer of "
-"legions of dragons, your body bathed in their fire. Lastly, I see you "
-"standing on the shores of the fount, unable to cross.\" Then the Mystic "
-"fades away."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:921
-msgid "You see something that could just be the elusive Nubbie!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:922
-msgid ""
-"You see the mast of ancient ship here.  On further investigation you find "
-"that the ships holds are full of gems.  The hours pass as your crue "
-"liberates the treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:923
-msgid ""
-"You see the remains of a burned out sawmill here.  All you can salvage is "
-"some ofwood left for scrap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:924
-msgid ""
-"You see the remains of an old sawmill, but it is obvious that you will not "
-"be able to make it work again."
-msgstr ""
-"Du ser resterna av ett gammalt sågverk, men det är uppenbart att du kan inte "
-"jobba där igen."
-
-#: ../fheroes2/resource/maps_text.cpp:925
-msgid ""
-"You see the remains of an old sawmill just to realize that it will no longer "
-"produce.  You gather the ramains and move on."
-msgstr ""
-"Du ser resterna av ett gammalt sågverk, bara för att inse att det kan inte "
-"producera mer. Du samlar ihop resterna och går vidare."
-
-#: ../fheroes2/resource/maps_text.cpp:926
-msgid ""
-"You send this letter back to the king,\"A month has passed and we have not "
-"discovered the wizard Joseph. I only hope that we are able to locate him in "
-"time to aid us in our struggle.\""
-msgstr ""
-"Du skickade detta brev tillbaka till kungen, \"En månad har gått och vi har "
-"ännu inte hittat trollkarlen Joseph. Jag hoppas bara att vi kan hitta honom "
-"i tid för att hjälpa oss i vår strid.\""
-
-#: ../fheroes2/resource/maps_text.cpp:927
-msgid "You should turn back."
-msgstr "Du bör vända om."
-
-#: ../fheroes2/resource/maps_text.cpp:928
-msgid ""
-"You stumble upon an old man who proclaims you Lord of the Realm, hands you "
-"his boots and wonders into the mountains mumbling something about being late "
-"for an important date."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:929
-msgid ""
-"You stumple across three small rocks piled on top of each other and decide "
-"to dig undernear them.  There you find an old weather-beaten bag of gems."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:930
-msgid "You uncover a compass in the grass!"
-msgstr "Du upptäcker en kompass i gräset!"
-
-#: ../fheroes2/resource/maps_text.cpp:931
-msgid "You've been warned!"
-msgstr "Du har blivit varnad!"
-
-#: ../fheroes2/resource/maps_text.cpp:932
-msgid ""
-"You've received a message from Roland. \"In the absence of a strong leader, "
-"the local lords have fallen to fighting. Uniting this area is critical to "
-"our cause, so we must not fail.  Leaving your castle undefended in this "
-"highly contested region will surely lead to defeat. I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:933
-msgid ""
-"You've received a message from the guild. \"Thank God you've arrived! We're "
-"under seige from two enemies from the north and one from across the sea. "
-"Please save us, you're our only hope.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:934
-msgid ""
-"You've ruled with an iron fist (and an army of undead), but now your kingdom "
-"has turned against you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:935
-msgid ""
-"You've saved a group of miners from the dragons.  One of them approaches "
-"you, \"Thank you so much for saving us!  We found this sulfer and sword in "
-"the mine, then those dragons chased us!  I don't know how much longer we "
-"could survive!\""
-msgstr ""
-"Du har räddat en grupp gruvarbetare från drakarna. En av dem går fram till "
-"dig, \"Tack så mycket för att du har räddat oss! Vi hittade svavel och detta "
-"svärd i gruvan innan dessa drakar jagade oss! Jag vet inte hur mycket längre "
-"vi kunde överleva!\""
-
-#: ../fheroes2/resource/maps_text.cpp:936
-msgid ""
-"You will clash quickly on this small head-to-head map, so stay on your toes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:937
-msgid ""
-"You will need a stronger army than that, mortal, to step through this portal."
-msgstr ""
-"Du behöver en starkare armé än det där för att passera denna portal, du "
-"dödlige."
-
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Wood"
 msgstr "Trä"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Mercury"
 msgstr "Kvicksilver"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Ore"
 msgstr "Malm"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Sulfur"
 msgstr "Svavel"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Crystal"
 msgstr "Kristall"
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Gems"
 msgstr "Ädelstenar"
 
-#: ../fheroes2/spell/spell_book.cpp:61 ../fheroes2/spell/spell_book.cpp:79
-msgid "No spell to cast."
-msgstr "Inga besvärjelser kan kastas."
-
-#: ../fheroes2/spell/spell_book.cpp:138
-msgid "Your hero has %{point} spell points remaining"
-msgstr "Din hjälte har %{point} magipoäng kvar"
-
-#: ../fheroes2/spell/spell.cpp:50
 msgid "Fireball"
 msgstr "Eldboll"
 
-#: ../fheroes2/spell/spell.cpp:50
 msgid ""
 "Causes a giant fireball to strike the selected area, damaging all nearby "
 "creatures."
@@ -11982,11 +6078,9 @@ msgstr ""
 "Skapar en stor eldboll som träffar ett utvalt område, tar skada på alla "
 "varelser i närheten."
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid "Fireblast"
 msgstr "Eldexplosion"
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid ""
 "An improved version of fireball, fireblast affects two hexes around the "
 "center point of the spell, rather than one."
@@ -11994,19 +6088,15 @@ msgstr ""
 "En förbättrad version av Eldboll. Eldexplosion angriper två hexagonaler "
 "runtomkring den centrala punkten, istället för en."
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Lightning Bolt"
 msgstr "Ljusblixt"
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Causes a bolt of electrical energy to strike the selected creature."
 msgstr "Får en blixt att slå ned på en varelse."
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid "Chain Lightning"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid ""
 "Causes a bolt of electrical energy to strike a selected creature, then "
 "strike the nearest creature with half damage, then strike the NEXT nearest "
@@ -12018,224 +6108,173 @@ msgstr ""
 "de NÄST närmaste varelserna med halverad skada, o.s.v., tills den blir för "
 "svag för att skada. Varning: Denna besvärjelse kan träffa dina egna varelser!"
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid "Teleport"
 msgstr "Teleportera"
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid ""
 "Teleports the creature you select to any open position on the battlefield."
 msgstr "Teleporterar vald varelse till valfri position på slagfältet."
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid "Cure"
 msgstr "Hela"
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid ""
-"Removes all negative spells cast upon one of your units, and restores up to %"
-"{count} HP per level of spell power."
+"Removes all negative spells cast upon one of your units, and restores up to "
+"%{count} HP per level of spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid "Mass Cure"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid ""
-"Removes all negative spells cast upon your forces, and restores up to %"
-"{count} HP per level of spell power, per creature."
+"Removes all negative spells cast upon your forces, and restores up to "
+"%{count} HP per level of spell power, per creature."
 msgstr ""
 "Tar bort alla negativa besvärjelser som har kastats på dina trupper och "
 "återställer upp till %{count} HP per besvärjelse-level, per varelse."
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrect"
 msgstr "Återuppliva"
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrects creatures from a damaged or dead unit until end of combat."
 msgstr ""
 "Återupplivar varelser från en skadad eller död enhet tills striden slutar."
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrect True"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrects creatures from a damaged or dead unit permanently."
 msgstr "Återupplivar varelser från en skadad eller död enhet permanent."
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Haste"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Increases the speed of any creature by %{count}."
 msgstr "Höjer en varelses hastighet med %{count}."
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Mass Haste"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Increases the speed of all of your creatures by %{count}."
 msgstr "Höjer alla dina varelsers hastighet med %{count}."
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "spell|Slow"
 msgstr "besvärjelse|Långsam"
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "Slows target to half movement rate."
 msgstr "Saktar ned målet till hälften."
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Mass Slow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Slows all enemies to half movement rate."
 msgstr "Saktar ned alla fiender till hälften."
 
-#: ../fheroes2/spell/spell.cpp:64
-msgid "Blind "
-msgstr "Blind "
+#, fuzzy
+msgid "spell|Blind"
+msgstr "besvärjelse|Långsam"
 
-#: ../fheroes2/spell/spell.cpp:64
 msgid "Clouds the affected creatures' eyes, preventing them from moving."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Bless"
 msgstr "Välsignelse"
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Causes the selected creatures to inflict maximum damage."
 msgstr "Får en varelse att tilldela maximal skada."
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Mass Bless"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Causes all of your units to inflict maximum damage."
 msgstr "Får alla dina enheter att tilldela maximal skada."
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Stoneskin"
 msgstr "Stenskinn"
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Magically increases the defense skill of the selected creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid "Steelskin"
 msgstr "Stålskinn"
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid ""
 "Increases the defense skill of the targeted creatures.  This is an improved "
 "version of Stoneskin."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Curse"
 msgstr "Förbannelse"
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Causes the selected creatures to inflict minimum damage."
 msgstr "Får en varelse att tilldela minimal skada."
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Mass Curse"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Causes all enemy troops to inflict minimum damage."
 msgstr "Får alla fiendetrupper att tilldela minimal skada."
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Holy Word"
 msgstr "Heligt ord"
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Damages all undead in the battle."
 msgstr "Skadar alla odöda i striden."
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid "Holy Shout"
 msgstr "Heligt rop"
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid ""
 "Damages all undead in the battle.  This is an improved version of Holy Word."
 msgstr ""
 "Skadar alla odöda i striden. Det är en förbättrad version av Heligt ord."
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Anti-Magic"
 msgstr "Antimagi"
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Prevents harmful magic against the selected creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Dispel Magic"
 msgstr "Skingra magi"
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Removes all magic spells from a single target."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Mass Dispel"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Removes all magic spells from all creatures."
 msgstr "Tar bort alla magiska besvärjelser från alla varelser."
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Magic Arrow"
 msgstr "Magisk pil"
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Causes a magic arrow to strike the selected target."
 msgstr "Skjuter en magisk pil på valt mål."
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Berserker"
 msgstr "Bärsärk"
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Causes a creature to attack its nearest neighbor."
 msgstr "Får en varelse att attackera sin närmaste granne."
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid "Armageddon"
 msgstr "Harmageddon"
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid ""
 "Holy terror strikes the battlefield, causing severe damage to all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Elemental Storm"
 msgstr "Elementstorm"
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Magical elements pour down on the battlefield, damaging all creatures."
 msgstr "Magiska element vräker ned på slagfältet, skadar alla varelser."
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid "Meteor Shower"
 msgstr "Meteorregn"
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid ""
 "A rain of rocks strikes an area of the battlefield, damaging all nearby "
 "creatures."
@@ -12243,38 +6282,30 @@ msgstr ""
 "Ett stenregn slår ned på en område på slagfältet och skadar alla varelser i "
 "närheten."
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "Paralyze"
 msgstr "Paralysera"
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "The targeted creatures are paralyzed, unable to move or retaliate."
 msgstr ""
 "Inriktade varelser är paralyserade, de kan varken förflytta sig eller hämnas."
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid "Hypnotize"
 msgstr "Hypnotisera"
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid ""
-"Brings a single enemy unit under your control for one combat round if its "
-"hits are less than %{count} times the caster's spell power."
+"Brings a single enemy unit under your control if its hits are less than "
+"%{count} times the caster's spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Cold Ray"
 msgstr "Kall stråle"
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Drains body heat from a single enemy unit."
 msgstr "Tömmer kroppsvärme från en enskild fiendeenhet."
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid "Cold Ring"
 msgstr "Kall ring"
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid ""
 "Drains body heat from all units surrounding the center point, but not "
 "including the center point."
@@ -12282,27 +6313,21 @@ msgstr ""
 "Tömmer kroppsvärme från omgivande enheter runt mittpunkten, exklusive "
 "mittpunkten."
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Disrupting Ray"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Reduces the defense rating of an enemy unit by three."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Death Ripple"
 msgstr "Dödskrusning"
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Damages all living (non-undead) units in the battle."
 msgstr "Skadar alla levande (icke-odöda) enheter i striden."
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid "Death Wave"
 msgstr "Dödsvåg"
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid ""
 "Damages all living (non-undead) units in the battle.  This spell is an "
 "improved version of Death Ripple."
@@ -12310,35 +6335,27 @@ msgstr ""
 "Skadar alla levande (icke-odöda) enheter i striden. Denna besvärjelse är en "
 "förbättrad version av Dödskrusningen."
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Dragon Slayer"
 msgstr "Drakdräpare"
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Greatly increases a unit's attack skill vs. Dragons."
 msgstr "Höjer en enhets attackfärdighet mot Drakar kraftigt."
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Blood Lust"
 msgstr "Blodtörst"
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Increases a unit's attack skill."
 msgstr "Höjer en enhets attackfärdighet."
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Animate Dead"
 msgstr "Ge liv åt död"
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Resurrects creatures from a damaged or dead undead unit permanently."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid "Mirror Image"
 msgstr "Spegelbild"
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid ""
 "Creates an illusionary unit that duplicates one of your existing units.  "
 "This illusionary unit does the same damages as the original, but will vanish "
@@ -12348,166 +6365,127 @@ msgstr ""
 "Denna illusoriska enhet tar lika mycket skada som originalet, men försvinner "
 "om de tar skada."
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Shield"
 msgstr "Sköld"
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Halves damage received from ranged attacks for a single unit."
 msgstr "Halverar skada från avståndsattacker för en enhet."
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Mass Shield"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Halves damage received from ranged attacks for all of your units."
 msgstr ""
 "Halverar skadan som tas emot från avståndsattacker för alla dina enheter."
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summon Earth Elemental"
 msgstr "Inkalla jordelement"
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summons Earth Elementals to fight for your army."
 msgstr "Kallar in Jordelement för att slåss för din armé."
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summon Air Elemental"
 msgstr "Inkalla luftelement"
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summons Air Elementals to fight for your army."
 msgstr "Kallar in Luftelement för att slåss för din armé."
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summon Fire Elemental"
 msgstr "Inkalla eldelement"
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summons Fire Elementals to fight for your army."
 msgstr "Kallar in Eldelement för att slåss för din armé."
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summon Water Elemental"
 msgstr "Inkalla vattenelement"
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summons Water Elementals to fight for your army."
 msgstr "Kallar in Vattenelement för att slåss för din armé."
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Earthquake"
 msgstr "Jordbävning"
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Damages castle walls."
 msgstr "Skadar slottsvägar"
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "View Mines"
 msgstr "Visa Gruvor"
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "Causes all mines across the land to become visible."
 msgstr "Gör alla gruvor synliga över hela landet."
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "View Resources"
 msgstr "Visa resurser"
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "Causes all resources across the land to become visible."
 msgstr "Gör alla resurser synliga över hela landet."
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "View Artifacts"
 msgstr "Visa artefakter."
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "Causes all artifacts across the land to become visible."
 msgstr "Gör alla artefakter synliga över hela landet."
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "View Towns"
 msgstr "Visa Städer"
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "Causes all towns and castles across the land to become visible."
 msgstr "Gör alla städer och slott synliga över hela landet."
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "View Heroes"
 msgstr "Visa hjältar"
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "Causes all Heroes across the land to become visible."
 msgstr "Gör alla hjältar synliga över hela landet."
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "View All"
 msgstr "Visa alla"
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "Causes the entire land to become visible."
 msgstr "Gör hela landet synligt."
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Identify Hero"
 msgstr "Identifiera hjälte"
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Allows the caster to view detailed information on enemy Heroes."
 msgstr "Låter kastaren få detaljerad information om fiendehjältar."
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid "Summon Boat"
 msgstr "Inkalla båt"
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid ""
 "Summons the nearest unoccupied, friendly boat to an adjacent shore "
 "location.  A friendly boat is one which you just built or were the most "
 "recent player to occupy."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Dimension Door"
 msgstr "Dimensionsdörr"
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Allows the caster to magically transport to a nearby location."
 msgstr "Låter kastaren magiskt transportera sig till en närliggande plats."
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Town Gate"
 msgstr "Stadsport"
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Returns the caster to any town or castle currently owned."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:109
 msgid ""
 "Returns the hero to the town or castle of choice, provided it is controlled "
 "by you."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid "Visions"
 msgstr "Visioner"
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid ""
 "Visions predicts the likely outcome of an encounter with a neutral army camp."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid "Haunt"
 msgstr "Hemsök"
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid ""
 "Haunts a mine you control with Ghosts.  This mine stops producing "
 "resources.  (If I can't keep it, nobody will!)"
@@ -12516,344 +6494,2424 @@ msgstr ""
 "producera resurser. (Om inte jag kan behålla den, kommer ingen att kunna "
 "det!)"
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Set Earth Guardian"
 msgstr "Ange jordväktare"
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Sets Earth Elementals to guard a mine against enemy armies."
 msgstr "Låter ett jordelement vakta en gruva mot fiendearméer."
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Set Air Guardian"
 msgstr "Ange luftväktare"
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Sets Air Elementals to guard a mine against enemy armies."
 msgstr "Låter ett luftelement vakta en gruva mot fiendearméer."
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Set Fire Guardian"
 msgstr "Ange eldväktare"
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Sets Fire Elementals to guard a mine against enemy armies."
 msgstr "Låter ett eldelement vakta en gruva mot fiendearméer."
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Set Water Guardian"
 msgstr "Ange vattenväktare"
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Sets Water Elementals to guard a mine against enemy armies."
 msgstr "Låter ett vattenelement vakta en gruva mot fiendearméer."
 
-#: ../fheroes2/system/players.cpp:665
-msgid "Necroman"
-msgstr ""
+msgid "No spell to cast."
+msgstr "Inga besvärjelser kan kastas."
 
-#: ../fheroes2/system/players.cpp:691
-msgid ""
-"This lets you change player starting positions and colors. A particular "
-"color will always start in a particular location. Some positions may only be "
-"played by a computer player or only by a human player."
-msgstr ""
-"Detta låter dig ändra spelarnas startpositioner och färger. En speciell färg "
-"startar alltid vid en speciell plats. Vissa positioner kan endast spelas av "
-"en datorstyrd eller mänsklig spelare."
+#, fuzzy
+msgid "Your hero has %{point} spell points remaining."
+msgstr "Din hjälte har %{point} magipoäng kvar"
 
-#: ../fheroes2/system/players.cpp:695
-msgid ""
-"This lets you change the class of a player. Classes are not always "
-"changeable. Depending on the scenario, a player may receive additional towns "
-"and/or heroes not of their primary alignment."
-msgstr ""
+#, fuzzy
+msgid "View Adventure Spells"
+msgstr "Äventyrsinställningar"
 
-#: ../fheroes2/system/players.cpp:734
-msgid "%{color} player"
-msgstr ""
+#, fuzzy
+msgid "View Combat Spells"
+msgstr "Kasta besvärjelse"
 
-#: ../fheroes2/system/settings.cpp:126
+#, fuzzy
+msgid "View previous page"
+msgstr "Visa föregående stad"
+
+#, fuzzy
+msgid "View next page"
+msgstr "Visa %{name}"
+
+#, fuzzy
+msgid "Close Spellbook"
+msgstr "Kasta besvärjelse"
+
+#, fuzzy
+msgid "View %{spell}"
+msgstr "Visa %{name}"
+
 msgid "game: always confirm for rewrite savefile"
 msgstr "spel: Tillåt alltid överskrivning av sparfil"
 
-#: ../fheroes2/system/settings.cpp:127
-msgid "game: also confirm autosave"
-msgstr "spel: tillåt även autosparning"
-
-#: ../fheroes2/system/settings.cpp:128
 msgid "game: remember last focus"
 msgstr "spel: Kom ihåg senast fokus"
 
-#: ../fheroes2/system/settings.cpp:129
-msgid "game: battle show grid"
-msgstr ""
+#, fuzzy
+msgid "battle: show damage info"
+msgstr "spel: Visa systeminfo"
 
-#: ../fheroes2/system/settings.cpp:130
-msgid "game: battle mouse shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:131
-msgid "game: battle move shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:132
-msgid "game: battle show damage info"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:133
-msgid "game: castle flash building"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:134
 msgid "world: show visited content from objects"
 msgstr "värld: Visa besökt innehåll från objekt"
 
-#: ../fheroes2/system/settings.cpp:135
+msgid "world: show terrain penalty"
+msgstr ""
+
 msgid "world: scouting skill show extended content info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:136
-msgid "world: abandoned mine random resource"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:137
-msgid "world: save count monster after battle"
-msgstr "Värld: Spara antalet monster efter strid"
-
-#: ../fheroes2/system/settings.cpp:138
 msgid "world: allow set guardian to objects"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:139
-msgid "world: guardian objects gets +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:140
-msgid "world: no in-built requirements or guardians for placed artifacts"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:141
-msgid "world: only the first monster will attack (H2 bug)."
-msgstr "Värld: Endast första monstret attackerar (H2 bug)."
-
-#: ../fheroes2/system/settings.cpp:142
 msgid "world: Eagle Eye also works like Scholar in H3."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:143
 msgid "world: ban for WeekOf/MonthOf Monsters"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:144
-msgid "world: new version WeekOf (+growth)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:145
 msgid "world: ban plagues months"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:146
 msgid "world: Months Of Monsters do not place creatures on map"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:147
 msgid "world: Crystal Ball also added Identify Hero and Visions spells"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:148
-msgid "world: Artesian Springs have two separately visitable squares (h3 ver)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:149
 msgid "world: Starting heroes as Loss Conditions for Human Players"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:150
 msgid "world: Only 1 hero can be hired by the one player every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:151
-msgid "world: each castle allows one hero to be recruited every week"
+msgid "world: Each castle allows one hero to be recruited every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:152
-msgid "world: Outer creature dwellings should accumulate units"
+msgid "world: Neutral armies scale with game difficulty"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:153
-msgid "world: use unique artifacts for morale/luck"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:154
 msgid "world: use unique artifacts for resource affecting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:155
 msgid "world: use unique artifacts for primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:156
 msgid "world: use unique artifacts for secondary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:157
 msgid "world: Wind/Water Mills and Magic Garden can be captured"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:158
 msgid "world: disable Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:159
-msgid "castle: allow buy from well"
-msgstr "Slott: Tillåt att köpa från brunnar"
-
-#: ../fheroes2/system/settings.cpp:160
 msgid "castle: allow guardians"
 msgstr "slott: tillåt väktare"
 
-#: ../fheroes2/system/settings.cpp:161
 msgid ""
 "castle: higher mage guilds regenerate more spell points/turn "
 "(20/40/60/80/100%)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:162
-msgid "castle: allow recruits special/expansion heroes"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:163
 msgid "heroes: allow buy a spellbook from Shrines"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:164
-msgid "heroes: learn new spells with day"
-msgstr "hjältar: få nya besvärjelser varje dag"
-
-#: ../fheroes2/system/settings.cpp:165
 msgid "heroes: recruit cost to be dependent on hero level"
 msgstr "Hjältar: Rekryteringskostnad beror på hjältens level"
 
-#: ../fheroes2/system/settings.cpp:166
-msgid "heroes: remember MP/SP for retreat/surrender result"
+msgid "heroes: remember move points for retreat/surrender result"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:167
-msgid "heroes: surrendering gives some experience"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:168
-msgid "heroes: recalculate movement points after creatures movement"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:169
-msgid "heroes: allow pickup objects for patrol"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:170
-msgid "heroes: after battle move to target cell"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:171
 msgid "heroes: allow transcribing scrolls (needs: Eye Eagle skill)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:172
-msgid "heroes: allow banned sec. skills upgrade"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:173
 msgid "heroes: in Arena can choose any of primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:174
 msgid "unions: allow meeting heroes"
 msgstr "unioner: Tillåt att träffa hjältar"
 
-#: ../fheroes2/system/settings.cpp:175
 msgid "unions: allow castle visiting"
 msgstr "unioner: Tillåt att besöka slott"
 
-#: ../fheroes2/system/settings.cpp:176
+msgid "battle: show army order"
+msgstr ""
+
 msgid "battle: soft wait troop"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:177
-msgid "battle: high objects are an obstacle for archers"
-msgstr "strid: höga objekt är ett hinder för bågskyttar"
-
-#: ../fheroes2/system/settings.cpp:178
-msgid "battle: merge armies for hero from castle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:179
-msgid "battle: archmage can resists (20%) bad spells"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:180
-msgid "battle: magical creature resists (20%) the same magic"
-msgstr "strid: Magiska varelser motstår (20%) av sin egen magi"
-
-#: ../fheroes2/system/settings.cpp:181
-msgid "battle: skip increase +2 defense"
-msgstr "Strid: Skippning höjer försvar med 2"
-
-#: ../fheroes2/system/settings.cpp:182
 msgid "battle: reverse wait order (fast, average, slow)"
 msgstr "strid: omvänd väntordning (snabb, medel, långsam)"
 
-#: ../fheroes2/system/settings.cpp:183
 msgid "game: show system info"
 msgstr "spel: Visa systeminfo"
 
-#: ../fheroes2/system/settings.cpp:184
 msgid "game: autosave on"
 msgstr "spel: Autospara på"
 
-#: ../fheroes2/system/settings.cpp:185
 msgid "game: autosave will be made at the beginning of the day"
 msgstr "spel: automatisk sparning kommer att utföras i början på dagen"
 
-#: ../fheroes2/system/settings.cpp:186
 msgid "game: use fade"
 msgstr "spel: Använd toning"
 
-#: ../fheroes2/system/settings.cpp:187
-msgid "game: show SDL logo"
-msgstr "spel: Visa SDL-loggan"
-
-#: ../fheroes2/system/settings.cpp:188
 msgid "game: use evil interface"
 msgstr "spel: Använd ondskefullt gränssnitt"
 
-#: ../fheroes2/system/settings.cpp:189
-msgid "game: also use dynamic interface for castles"
-msgstr "spel: Använd dynamiskt gränssnitt för slott"
-
-#: ../fheroes2/system/settings.cpp:190
 msgid "game: hide interface"
 msgstr "spel: Göm gränssnitt"
 
-#: ../fheroes2/system/settings.cpp:191
 msgid "game: offer to continue the game afer victory condition"
 msgstr "spel: erbjud att fortsätta spelet efter att spelaren har segrat"
 
-#: ../fheroes2/system/settings.cpp:192
-msgid "pocketpc: hide cursor"
-msgstr "pocketpc: Göm pekare"
+#, fuzzy
+msgid "The ultimate artifact is really the %{name}."
+msgstr "Mumiens förbannelse har drabbat %{name}!"
 
-#: ../fheroes2/system/settings.cpp:193
-msgid "pocketpc: tap mode"
-msgstr "pocketpc: Knackläge"
+msgid "The ultimate artifact may be found in the %{name} regions of the world."
+msgstr ""
 
-#: ../fheroes2/system/settings.cpp:194
-msgid "pocketpc: drag&drop gamearea as scroll"
-msgstr "pocketpc: Dra och släpp spelarea vid skroll"
+msgid "north-west"
+msgstr ""
 
-#: ../fheroes2/system/settings.cpp:195
-msgid "pocketpc: low memory"
-msgstr "pocketpc: Lågt minne"
+#, fuzzy
+msgid "north"
+msgstr "Fort"
+
+msgid "north-east"
+msgstr ""
+
+#, fuzzy
+msgid "west"
+msgstr "Näste"
+
+#, fuzzy
+msgid "center"
+msgstr "Monster"
+
+#, fuzzy
+msgid "east"
+msgstr "Näste"
+
+msgid "south-west"
+msgstr ""
+
+#, fuzzy
+msgid "south"
+msgstr "ljud"
+
+msgid "south-east"
+msgstr ""
+
+msgid "The truth is out there."
+msgstr ""
+
+msgid "The dark side is stronger."
+msgstr ""
+
+#, fuzzy
+msgid "The end of the world is near."
+msgstr "Världens undergång är nära"
+
+msgid "The bones of Lord Slayer are buried in the foundation of the arena."
+msgstr ""
+
+msgid "A Black Dragon will take out a Titan any day of the week."
+msgstr ""
+
+msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
+msgstr ""
+
+msgid "An unknown force is being ressurected..."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Check the newest version of game at\n"
+"https://github.com/ihhub/\n"
+"fheroes2/releases"
+msgstr ""
+"Du kan ladda ned det nyaste versionen av spelet från sidan:\n"
+" http://sf.net/projects/fheroes2"
+
+#~ msgid "Hero %{name} also got a %{count} experience."
+#~ msgstr "Hjälten %{name} fick också %{count} erfarenhet."
+
+#~ msgid ", and get +2 defense"
+#~ msgstr ", och får +2 i försvar"
+
+#~ msgid "MirrorImage ended"
+#~ msgstr "Spegelbild avslutades"
+
+#~ msgid "You don't have enough gold!"
+#~ msgstr "Du har inte tillräckligt mycket guld!"
+
+#~ msgid ""
+#~ "Your troops can be upgraded, but it will cost you %{ratio} times the "
+#~ "difference in cost for each troop, rounded up to next highest number. Do "
+#~ "you wish to upgrade them?"
+#~ msgstr ""
+#~ "Dina trupper kan uppgraderas, men det kommer att kosta dig %{ratio} "
+#~ "gånger skillnad i kostnad för varje trupp, avrundat uppåt till det nästa "
+#~ "högsta numret. Vill du uppgradera dem?"
+
+#~ msgid "For the QVGA version is not available."
+#~ msgstr "Är inte tillgänglig för QVGA-versionen."
+
+#~ msgid "Cost per troop:"
+#~ msgstr "Kostnad per trupp:"
+
+#~ msgid "sound"
+#~ msgstr "ljud"
+
+#~ msgid "ai speed"
+#~ msgstr "Hastighet för AI"
+
+#~ msgid "You have no room to carry another artifact!"
+#~ msgstr "Du har inte rum att bära en till artefakt!"
+
+#~ msgid "View Morale Info"
+#~ msgstr "Visa information för moral"
+
+#~ msgid "View Luck Info"
+#~ msgstr "Visa information för tur"
+
+#~ msgid "Exit hero"
+#~ msgstr "Avsluta hjälte"
+
+#~ msgid "Dismiss hero"
+#~ msgstr "Avskeda hjälte"
+
+#~ msgid "Show prev heroes"
+#~ msgstr "Visa föreg. hjälte"
+
+#~ msgid "Bad Morale"
+#~ msgstr "Dålig moral"
+
+#~ msgid "Neutral Morale"
+#~ msgstr "Neutral moral"
+
+#~ msgid "Bad Luck"
+#~ msgstr "Otur"
+
+#~ msgid "Neutral Luck"
+#~ msgstr "Neutral tur"
+
+#~ msgid "Good Luck"
+#~ msgstr "God tur"
+
+#~ msgid "This game is now in beta development version. ;)"
+#~ msgstr "Detta spel är nu i betaversion. ;)"
+
+#~ msgid "Water"
+#~ msgstr "Vatten"
+
+#~ msgid "Ship Wreck"
+#~ msgstr "Skeppsvrak"
+
+#~ msgid "Coast"
+#~ msgstr "Kust"
+
+#, fuzzy
+#~ msgid "Peasant"
+#~ msgstr "Bonde"
+
+#~ msgid "Peasants"
+#~ msgstr "Bönder"
+
+#, fuzzy
+#~ msgid "Archer"
+#~ msgstr "Bågskytt"
+
+#~ msgid "Archers"
+#~ msgstr "Bågskyttar"
+
+#, fuzzy
+#~ msgid "Ranger"
+#~ msgstr "Vandringsman"
+
+#~ msgid "Rangers"
+#~ msgstr "Vandringsmän"
+
+#, fuzzy
+#~ msgid "Pikeman"
+#~ msgstr "Pikenerare"
+
+#~ msgid "Pikemen"
+#~ msgstr "Pikenerare"
+
+#, fuzzy
+#~ msgid "Veteran Pikeman"
+#~ msgstr "Veteranpikenerare"
+
+#~ msgid "Veteran Pikemen"
+#~ msgstr "Veteranpikenerare"
+
+#, fuzzy
+#~ msgid "Swordsman"
+#~ msgstr "Svärdsman"
+
+#~ msgid "Swordsmen"
+#~ msgstr "Svärdsmän"
+
+#, fuzzy
+#~ msgid "Master Swordsman"
+#~ msgstr "Mästersvärdsman"
+
+#~ msgid "Master Swordsmen"
+#~ msgstr "Mästersvärdsmän"
+
+#, fuzzy
+#~ msgid "Cavalry"
+#~ msgstr "Kavalleri"
+
+#~ msgid "Cavalries"
+#~ msgstr "Kavallerier"
+
+#, fuzzy
+#~ msgid "Champion"
+#~ msgstr "Krigare"
+
+#~ msgid "Champions"
+#~ msgstr "Krigare"
+
+#, fuzzy
+#~ msgid "Paladin"
+#~ msgstr "Ryttare"
+
+#~ msgid "Paladins"
+#~ msgstr "Ryttare"
+
+#, fuzzy
+#~ msgid "Crusader"
+#~ msgstr "Korsriddare"
+
+#~ msgid "Crusaders"
+#~ msgstr "Korsriddare"
+
+#, fuzzy
+#~ msgid "Goblin"
+#~ msgstr "Goblin"
+
+#~ msgid "Goblins"
+#~ msgstr "Goblins"
+
+#, fuzzy
+#~ msgid "Orc"
+#~ msgstr "Orch"
+
+#~ msgid "Orcs"
+#~ msgstr "Orcher"
+
+#, fuzzy
+#~ msgid "Wolf"
+#~ msgstr "Varg"
+
+#~ msgid "Wolves"
+#~ msgstr "Vargar"
+
+#, fuzzy
+#~ msgid "Ogre"
+#~ msgstr "Jätte"
+
+#~ msgid "Ogres"
+#~ msgstr "Jättar"
+
+#, fuzzy
+#~ msgid "Ogre Lord"
+#~ msgstr "Ogrelord"
+
+#~ msgid "Ogre Lords"
+#~ msgstr "Ogrelorder"
+
+#, fuzzy
+#~ msgid "Troll"
+#~ msgstr "Troll"
+
+#~ msgid "Trolls"
+#~ msgstr "Troll"
+
+#, fuzzy
+#~ msgid "War Troll"
+#~ msgstr "Krigstroll"
+
+#~ msgid "War Trolls"
+#~ msgstr "Krigstroll"
+
+#, fuzzy
+#~ msgid "Cyclops"
+#~ msgstr "Cyklop"
+
+#~ msgid "Cyclopes"
+#~ msgstr "Cykloper"
+
+#, fuzzy
+#~ msgid "Sprite"
+#~ msgstr "Fe"
+
+#~ msgid "Sprites"
+#~ msgstr "Feer"
+
+#, fuzzy
+#~ msgid "Dwarf"
+#~ msgstr "Dvärg"
+
+#~ msgid "Dwarves"
+#~ msgstr "Dvärgar"
+
+#~ msgid "Battle Dwarves"
+#~ msgstr "Stridsdvärgar"
+
+#, fuzzy
+#~ msgid "Elf"
+#~ msgstr "Alv"
+
+#~ msgid "Elves"
+#~ msgstr "Alver"
+
+#, fuzzy
+#~ msgid "Grand Elf"
+#~ msgstr "Stor alv"
+
+#~ msgid "Grand Elves"
+#~ msgstr "Stora alver"
+
+#, fuzzy
+#~ msgid "Druid"
+#~ msgstr "Druid"
+
+#~ msgid "Druids"
+#~ msgstr "Druider"
+
+#~ msgid "Greater Druids"
+#~ msgstr "Stora druider"
+
+#, fuzzy
+#~ msgid "Unicorn"
+#~ msgstr "Enhörning"
+
+#~ msgid "Unicorns"
+#~ msgstr "Enhörningar"
+
+#, fuzzy
+#~ msgid "Phoenix"
+#~ msgstr "Fenix"
+
+#, fuzzy
+#~ msgid "Phoenixes"
+#~ msgstr "Fenix"
+
+#, fuzzy
+#~ msgid "Centaur"
+#~ msgstr "Kentaur"
+
+#~ msgid "Centaurs"
+#~ msgstr "Kentaurer"
+
+#, fuzzy
+#~ msgid "Gargoyle"
+#~ msgstr "Stenstaty"
+
+#~ msgid "Gargoyles"
+#~ msgstr "Stenstatyer"
+
+#, fuzzy
+#~ msgid "Griffin"
+#~ msgstr "Grip"
+
+#~ msgid "Griffins"
+#~ msgstr "Gripar"
+
+#, fuzzy
+#~ msgid "Minotaur"
+#~ msgstr "Minotaur"
+
+#~ msgid "Minotaurs"
+#~ msgstr "Minotaurer"
+
+#, fuzzy
+#~ msgid "Minotaur King"
+#~ msgstr "Minotaurkung"
+
+#~ msgid "Minotaur Kings"
+#~ msgstr "Minotaurkungar"
+
+#, fuzzy
+#~ msgid "Hydra"
+#~ msgstr "Hydra"
+
+#~ msgid "Hydras"
+#~ msgstr "Hydror"
+
+#, fuzzy
+#~ msgid "Green Dragon"
+#~ msgstr "Grön drake"
+
+#~ msgid "Green Dragons"
+#~ msgstr "Gröna drakar"
+
+#, fuzzy
+#~ msgid "Red Dragon"
+#~ msgstr "Röd drake"
+
+#~ msgid "Red Dragons"
+#~ msgstr "Röda drakar"
+
+#, fuzzy
+#~ msgid "Black Dragon"
+#~ msgstr "Svart drake"
+
+#~ msgid "Black Dragons"
+#~ msgstr "Svarta drakar"
+
+#, fuzzy
+#~ msgid "Halfling"
+#~ msgstr "Hob"
+
+#~ msgid "Halflings"
+#~ msgstr "Hober"
+
+#, fuzzy
+#~ msgid "Boar"
+#~ msgstr "Vildsvin"
+
+#~ msgid "Boars"
+#~ msgstr "Vildsvin"
+
+#, fuzzy
+#~ msgid "Iron Golem"
+#~ msgstr "Järngolem"
+
+#~ msgid "Iron Golems"
+#~ msgstr "Järngolem"
+
+#, fuzzy
+#~ msgid "Steel Golem"
+#~ msgstr "Stålgolem"
+
+#~ msgid "Steel Golems"
+#~ msgstr "Stålgolem"
+
+#, fuzzy
+#~ msgid "Roc"
+#~ msgstr "Fågel rock"
+
+#~ msgid "Rocs"
+#~ msgstr "Fågel rock"
+
+#, fuzzy
+#~ msgid "Mage"
+#~ msgstr "Magiker"
+
+#~ msgid "Magi"
+#~ msgstr "Magiker"
+
+#, fuzzy
+#~ msgid "Giant"
+#~ msgstr "Koloss"
+
+#~ msgid "Giants"
+#~ msgstr "Kolosser"
+
+#, fuzzy
+#~ msgid "Titan"
+#~ msgstr "Titan"
+
+#~ msgid "Titans"
+#~ msgstr "Titaner"
+
+#~ msgid "Skeletons"
+#~ msgstr "Skelett"
+
+#, fuzzy
+#~ msgid "Zombie"
+#~ msgstr "Zombie"
+
+#~ msgid "Zombies"
+#~ msgstr "Zombies"
+
+#, fuzzy
+#~ msgid "Mutant Zombie"
+#~ msgstr "Muterad zombie"
+
+#~ msgid "Mutant Zombies"
+#~ msgstr "Muterade zombies"
+
+#, fuzzy
+#~ msgid "Mummy"
+#~ msgstr "Mumie"
+
+#~ msgid "Mummies"
+#~ msgstr "Mumier"
+
+#, fuzzy
+#~ msgid "Royal Mummy"
+#~ msgstr "Kunglig mumie"
+
+#~ msgid "Royal Mummies"
+#~ msgstr "Kungliga mumier"
+
+#, fuzzy
+#~ msgid "Vampire"
+#~ msgstr "Vampyr"
+
+#~ msgid "Vampires"
+#~ msgstr "Vampyrer"
+
+#, fuzzy
+#~ msgid "Vampire Lord"
+#~ msgstr "Vampyrlord"
+
+#~ msgid "Vampire Lords"
+#~ msgstr "Vampyrlordar"
+
+#, fuzzy
+#~ msgid "Bone Dragon"
+#~ msgstr "Bendrake"
+
+#~ msgid "Bone Dragons"
+#~ msgstr "Bendrakar"
+
+#, fuzzy
+#~ msgid "Rogue"
+#~ msgstr "Skurk"
+
+#~ msgid "Rogues"
+#~ msgstr "Skurkar"
+
+#, fuzzy
+#~ msgid "Nomad"
+#~ msgstr "Nomad"
+
+#~ msgid "Nomads"
+#~ msgstr "Nomader"
+
+#, fuzzy
+#~ msgid "Ghost"
+#~ msgstr "Spöke"
+
+#~ msgid "Ghosts"
+#~ msgstr "Spöken"
+
+#, fuzzy
+#~ msgid "Genie"
+#~ msgstr "Ande"
+
+#~ msgid "Genies"
+#~ msgstr "Andar"
+
+#, fuzzy
+#~ msgid "Medusa"
+#~ msgstr "Medusa"
+
+#~ msgid "Medusas"
+#~ msgstr "Medusor"
+
+#, fuzzy
+#~ msgid "Earth Elemental"
+#~ msgstr "Jordelement"
+
+#~ msgid "Earth Elementals"
+#~ msgstr "Jordelement"
+
+#, fuzzy
+#~ msgid "Air Elemental"
+#~ msgstr "Luftelement"
+
+#~ msgid "Air Elementals"
+#~ msgstr "Luftelement"
+
+#, fuzzy
+#~ msgid "Fire Elemental"
+#~ msgstr "Eldelement"
+
+#~ msgid "Fire Elementals"
+#~ msgstr "Eldelement"
+
+#, fuzzy
+#~ msgid "Water Elemental"
+#~ msgstr "Vattenelement"
+
+#~ msgid "Water Elementals"
+#~ msgstr "Vattenelement"
+
+#~ msgid "buy"
+#~ msgstr "köp"
+
+#~ msgid "Error"
+#~ msgstr "Fel"
+
+#~ msgid "This release is compiled without network support."
+#~ msgstr "Denna utgåva är framtagen utan stöd för nätverk."
+
+#~ msgid ""
+#~ "425 bottles of beer on the wall, 425 bottles of beer! If one of those "
+#~ "bottles should happen to fall, there'll be..."
+#~ msgstr ""
+#~ "425 flaskor öl på väggen, 425 flaskor öl! Om en av flaskorna skulle "
+#~ "falla, skulle det vara..."
+
+#~ msgid "Abandon All Hope!"
+#~ msgstr "Ge upp allt hopp!"
+
+#~ msgid "A cache of crystal!"
+#~ msgstr "Ett förråd av kristaller!"
+
+#~ msgid "A cache of gems!"
+#~ msgstr "Ett förråd av ädelstenar!"
+
+#~ msgid "A cache of gold!"
+#~ msgstr "Ett förråd av guld!"
+
+#~ msgid "A cache of mercury!"
+#~ msgstr "Ett förråd av kvicksilver!"
+
+#~ msgid "A cache of sulfur!"
+#~ msgstr "Ett förråd av svavel!"
+
+#~ msgid "A chunk of gold!"
+#~ msgstr "Ett stycke guld!"
+
+#~ msgid "A chunk of ore!"
+#~ msgstr "Ett stycke malm!"
+
+#~ msgid "A couple of gems!"
+#~ msgstr "Några ädelstenar!"
+
+#~ msgid "\"Act of Desperation\""
+#~ msgstr "\"Desperationens gärning\""
+
+#~ msgid "A dolphin playfully jumps into the air."
+#~ msgstr "En delfin hoppar lekfullt upp i luften."
+
+#~ msgid ""
+#~ "A Dragon, A Cyclops, or an Undead. King of the Centaurs, His name is ....?"
+#~ msgstr ""
+#~ "En drake, en cyklop eller en odöd. Kentaurernas kung. Hans namn är...?"
+
+#~ msgid "A flight of dragons circles overhead."
+#~ msgstr "En grupp drakar cirkulerar ovanför."
+
+#~ msgid "A flock of seagulls circle overhead."
+#~ msgstr "En flock fiskmåsar cirkulerar ovanför."
+
+#~ msgid "A friendly dolphin splashes alongside the ship."
+#~ msgstr "En vänlig delfin plaskar vid sidan av  skeppet."
+
+#~ msgid ""
+#~ "After centuries of friendship, the Wizards have suddenly decided to stop "
+#~ "sharing their Library with the rest of the world.  This can't be good!"
+#~ msgstr ""
+#~ "Efter århundraden av vänskap bästämmer sig trollkarlarna plötsligt för "
+#~ "att sluta dela med sig deras bibliotek med världen. Detta kan inte vara "
+#~ "bra!"
+
+#~ msgid "A ghostly pirate ship appears and sails on by."
+#~ msgstr "En spökligt piratskepp dyker upp och seglar förbi."
+
+#~ msgid ""
+#~ "A Gift from your King, and a note that reads \"Use these resources "
+#~ "wisely, It's all we have left\"."
+#~ msgstr ""
+#~ "En gåva från din kung. På en medföljande lapp står det, \"Använd dessa "
+#~ "resurser klokt, det är allt vi har kvar\"."
+
+#~ msgid ""
+#~ "A gift of gold, m'lord, from the people of Enroth, to the people of "
+#~ "Enroth.  Good luck, and may God save true King Roland!"
+#~ msgstr ""
+#~ "En gåva av guld, herre, från Enroths folk till Enroths folk. Lycka till, "
+#~ "och må Gud rädda den sanne Kung Roland!"
+
+#~ msgid "A glint by a tree catches your eye..."
+#~ msgstr "En glimt av ett träd fångar din blick..."
+
+#~ msgid "A gold cache!"
+#~ msgstr "Ett förråd av guld!"
+
+#~ msgid "A gold chunk!"
+#~ msgstr "Ett stycke guld!"
+
+#~ msgid "A gold nugget!"
+#~ msgstr "En guldklimp!"
+
+#~ msgid "A handful of gems!"
+#~ msgstr "En handfull ädelstenar!"
+
+#~ msgid ""
+#~ "Ah, you stumble across something buried in the sand.  As you dig it up "
+#~ "you discover a small pile of gems and crystal."
+#~ msgstr ""
+#~ "Åh, du stöter på någonting som är begravt i sanden. När du gräver upp det "
+#~ "upptäcker du att det är en liten hög med ädelstenar och kristaller."
+
+#~ msgid ""
+#~ "A Knight and Necromancer team up against the Barbarian and Sorceress. "
+#~ "(Blue and Green vs Red and Yellow)"
+#~ msgstr ""
+#~ "En riddare och svartkonstnär slår ihop sig mot barbaren och häxan. (Blå "
+#~ "och Grön mot Röd och Gul)"
+
+#~ msgid ""
+#~ "A large map with lots of resources and treasure. Exploration and victory "
+#~ "will require many heroes."
+#~ msgstr ""
+#~ "En stor karta med mängder av resurser och skatter. Utforskning och seger "
+#~ "kommer att kräva många hjältar."
+
+#~ msgid "A little bit closer..."
+#~ msgstr "Lite närmare..."
+
+#~ msgid "All mines are grouped by type. Trade is your only hope."
+#~ msgstr "Alla gruvor är grupperade efter typ. Byteshandel är ditt enda hopp."
+
+#~ msgid "A lump of crystal!"
+#~ msgstr "Ett stycke kristall"
+
+#~ msgid "A lump of gold!"
+#~ msgstr "Ett stycke guld!"
+
+#~ msgid "A lump of mercury!"
+#~ msgstr "Ett stycke kvicksilver!"
+
+#~ msgid ""
+#~ "A man appears from behind the sand dune. \"At last,\" he says, \"Someone "
+#~ "has come to rescue me! I am forever grateful. Alas all I have to offer "
+#~ "you in return are these souvenirs from my wrecked ship.\""
+#~ msgstr ""
+#~ "En man dyker upp bakom en sanddyna. \"Till slut,\" säger han, \"Någon "
+#~ "kommer för att rädda mig! Jag är riktig tacksam. Tyvärr är det enda jag "
+#~ "kan erbjuda dig är dessa souvenirer från mitt förlistna skepp.\""
+
+#~ msgid ""
+#~ "A man is laying on the ground, near death. He looks to you and speaks, "
+#~ "\"Please help my companions! Please... they can't...cough...get away "
+#~ "from...cough...the drag...\" With that, he dies."
+#~ msgstr ""
+#~ "En döende man ligger på marken. Han tittar på dig och säger, \"Snälla, "
+#~ "hjälp mina kamrater! Snälla... de kan inte... host... komma undan... "
+#~ "host... från drak...\", plötsligt dör han."
+
+#~ msgid "a mirror"
+#~ msgstr "En spegel"
+
+#~ msgid "An albatross flies ahead of the ship for a while"
+#~ msgstr "En albatross flyger vid skeppet för en stund"
+
+#~ msgid "A piece of crystal!"
+#~ msgstr "En bit av en kristall!"
+
+#~ msgid "A pile of crystal!"
+#~ msgstr "En hög kristaller!"
+
+#~ msgid "A pile of gems!"
+#~ msgstr "En hög av ädelstenar!"
+
+#~ msgid "A pile of gold!"
+#~ msgstr "En hög av guld!"
+
+#~ msgid "A quantity of crystal!"
+#~ msgstr "En mängd kristaller!"
+
+#~ msgid "A quantity of mercury!"
+#~ msgstr "En mängd kvicksilver!"
+
+#~ msgid "A quantity of sulfur!"
+#~ msgstr "En mängd svavel!"
+
+#~ msgid ""
+#~ "Archibald has also sent an army to find the Crown, you must find it first "
+#~ "or all is lost."
+#~ msgstr ""
+#~ "Archibald har också skickat en armé för att hitta Kronan. Du måste hitta "
+#~ "den först, annars är allt förlorat."
+
+#~ msgid "Archibald is hiding at the end of the river."
+#~ msgstr "Archibald gömmer sig vid flodens slut."
+
+#~ msgid "Arm of the Crusader"
+#~ msgstr "Korsriddarens arm"
+
+#~ msgid "Arm of the Cyclops"
+#~ msgstr "Cyklopens arm"
+
+#~ msgid "Arm of the Dragon"
+#~ msgstr "Drakens arm"
+
+#~ msgid "Arm of the Phoenix"
+#~ msgstr "Fenixens arm"
+
+#~ msgid "Arm of the Titan"
+#~ msgstr "Titanens arm"
+
+#~ msgid "Arr' Here be pirates gold buried."
+#~ msgstr "Arr' Här är piratguld nedgrävd."
+
+#~ msgid ""
+#~ "A splash in the seaweed alerts you to a mermaid waving in a friendly "
+#~ "manner. \"Oh, I thought you were Ahab.\" She is surprised, but quickly "
+#~ "composes herself. \"Well, if you meet him, give him these treasures I "
+#~ "have collected.\""
+#~ msgstr ""
+#~ "Ett plask i sjögräset förvarnar dig om en sjöjungfru som vänligt vinkar "
+#~ "till dig. \"Åh, jag trodde du var Ahab.\" Hon är överraskad, men hämtar "
+#~ "sig snabbt. \"Nåja, om du träffar honom, ge honom dessa skatter som jag "
+#~ "har samlat på.\""
+
+#~ msgid "Assassins tried to kill our ally."
+#~ msgstr "Lönnmördare försöker döda våra allierade."
+
+#~ msgid ""
+#~ "As you break your fast your sage rushes in, \"Good news, my lord!  I have "
+#~ "translated the message.  Two great heroes were imprisoned many years "
+#~ "ago.  They lie sleeping - still guarded by magic barriers and monsters.  "
+#~ "My lord, they lie nearby- in between our ally and us.  If we could free "
+#~ "them, they would surely aid us against our enemies!  The password to the "
+#~ "first magic barrier can be learned at the Aqua Traveller's Tent.\""
+#~ msgstr ""
+#~ "När du hejdar dig kommer din vise man rusande, \"Goda nyheter, min herre! "
+#~ "Jag har översatt meddelandet. Två stora hjältar var tillfångatagen för "
+#~ "flera år sedan. Dem sover, vaktade av magiska barriärer och monster. Min "
+#~ "herre, de ligger i närheten, mellan våra bundsförvanter och oss. Om vi "
+#~ "kan frita dem, skulle dem kunna stödja oss mot fiender! Lösenordet för "
+#~ "den första barriären kan man få hos akvamarins resenärstält.\""
+
+#~ msgid ""
+#~ "As you lay down to nap after a long battle, you notice a lucky four-leaf "
+#~ "clover."
+#~ msgstr "När du lägger dig ned efter en lång strid hittar du en fyrklöver."
+
+#~ msgid ""
+#~ "As you make your way to the shrine, some very thin and hollow-eyed men "
+#~ "come out of the flower patch and stare at you.  Seeing that you want the "
+#~ "gold, one of them says to you \"Hey, man, if you're, like, so lusty for "
+#~ "earthly wealth, then, like, have this too.\" You graciously take what "
+#~ "they have offered and back out of the clearing."
+#~ msgstr ""
+#~ "När du går mot templet, kommer några smala hålögda män ut från blomfältet "
+#~ "och stirrar på dig. När de ser att du vill ha guldet säger en av dem "
+#~ "\"Tjena, mannen. Om du är, typ, så stark för jordisk förmögenhet kan du, "
+#~ "typ, ta det här också.\" Du tar nådigt emot vad de erbjöd och går "
+#~ "tillbaka ut från gläntan"
+
+#~ msgid "A three hour tour, a three hour tour..."
+#~ msgstr "En tretimmarsresa, en tretimmarsresa..."
+
+#~ msgid "Barbarian's castle lies to the south."
+#~ msgstr "Barbarernas slott ligger söderut."
+
+#~ msgid ""
+#~ "Barbarians from the north threaten all civilization. Can you repel the "
+#~ "hordes?"
+#~ msgstr ""
+#~ "Barbarer från norr hotar all civilisation. Kan du stöta bort hordarna?"
+
+#~ msgid "Being held...."
+#~ msgstr "Hålls..."
+
+#~ msgid "Beware of Pirates!"
+#~ msgstr "Se upp för pirater!"
+
+#~ msgid "Beware of thieves!"
+#~ msgstr "Se upp för tjuvar!"
+
+#~ msgid "Beware of traps ahead."
+#~ msgstr "Se upp för fällor framöver."
+
+#~ msgid "Beware of Warlocks"
+#~ msgstr "Varning för krigstrollkarlar"
+
+#~ msgid "Beware the deadly swamps!"
+#~ msgstr "Se upp för dödliga träsket!"
+
+#~ msgid "Beware the Domain of Dragons"
+#~ msgstr "Varning för Drakdomänen"
+
+#~ msgid "Beware the Dragon Leader"
+#~ msgstr "Varning för Drakledaren"
+
+#~ msgid "Beware the edge of the world!"
+#~ msgstr "Se upp för världens ende!"
+
+#~ msgid "Beware the moors and stick to the roads."
+#~ msgstr "Se upp för hedarna och håll dig på vägarna."
+
+#~ msgid "Beware the rocks"
+#~ msgstr "Se upp för stenar"
+
+#~ msgid "Beware the sirens!!!"
+#~ msgstr "Se upp för sirenerna!!!"
+
+#~ msgid "Beware the sirens!"
+#~ msgstr "Se upp för sirenerna!"
+
+#~ msgid "Beware the whiporwill..."
+#~ msgstr "Se upp för nattskärran..."
+
+#~ msgid "Beware, the whirlpool may not take you into a friendly embrace."
+#~ msgstr ""
+#~ "Varning, strömvirveln kommer nog inte att ge dig en vänlig omfamning."
+
+#~ msgid "Beyond the door, there be Dragons. BEWARE!"
+#~ msgstr "Bortom denna dörr finns det drakar. VARNING!"
+
+#~ msgid "Big Oak"
+#~ msgstr "Stor Ek"
+
+#~ msgid "Black Fang"
+#~ msgstr "Svart Huggtand"
+
+#~ msgid "Black Oak"
+#~ msgstr "Svart Ek"
+
+#~ msgid "Blackwind"
+#~ msgstr "Svartvind"
+
+#~ msgid "Boats my be needed to access some parts of this peninsula."
+#~ msgstr "Båtar behövs för att nå vissa delar av halvön."
+
+#~ msgid "Buried Treasure!"
+#~ msgstr "Nedgrävd skatt!"
+
+#~ msgid ""
+#~ "Capture the necromancer's dreaded castle \"Death Gate\" and free the land "
+#~ "from the undead plague."
+#~ msgstr ""
+#~ "Tillfångata svartkonstnärens fruktade slott \"Dödsporten\" och befria "
+#~ "landet från en odödlig plåga."
+
+#~ msgid "Chandler"
+#~ msgstr "Småhandlare"
+
+#~ msgid "Come and...."
+#~ msgstr "Kom och..."
+
+#~ msgid ""
+#~ "Compared to the rest of the villages in this land, this village seems "
+#~ "grand, but in any other land it would seem poor. From here you can see "
+#~ "the tall spires of the Warlock's tower of Dragons."
+#~ msgstr ""
+#~ "Jämfört med resten av byarna i detta land verkar denna by vara ståtlig. "
+#~ "Men i ett annat land skulle det verka fattigt. Härifrån kan du se de höga "
+#~ "spirorna från Krigstrollkarlarnas Draktorn."
+
+#~ msgid "Complete"
+#~ msgstr "Klar"
+
+#~ msgid "Condemned!"
+#~ msgstr "Dömd!"
+
+#~ msgid "Crossroads"
+#~ msgstr "Vägskäl"
+
+#~ msgid "Crossroads North"
+#~ msgstr "Vägskäl norr"
+
+#~ msgid "Crossroads South"
+#~ msgstr "Vägskäl söder"
+
+#~ msgid "DANGER!  QUICKSAND!"
+#~ msgstr "FARA! KVICKSAND!"
+
+#~ msgid "Danger! Troll bridge ahead!"
+#~ msgstr "Fara! Trollbro framöver!"
+
+#~ msgid "Danger - Turn Back Now"
+#~ msgstr "Fara - Vänd genast om!"
+
+#~ msgid ""
+#~ "Dear Diary,                           I found a mermaid today.  She was "
+#~ "floating in a patch of seaweed next to a rock.  A very friendly sort of "
+#~ "creature too!  Gave me all sorts of lovely gems and jewelry!  She said to "
+#~ "come back again sometime for more of the sea riches.  Wow. Ahab"
+#~ msgstr ""
+#~ "Kära dagbok, idag hittade jag en sjöjungfru. Hon flöt i sjögräset intill "
+#~ "en sten. En riktigt trevlig varelse också! Hon gav mig alla sorters "
+#~ "ädelstenar och smycken! Hon sa åt mig att komma tillbaka igen någon gång "
+#~ "för mer sjöskatter. Wow. Ahab"
+
+#~ msgid "Deathgate"
+#~ msgstr "Dödsport"
+
+#~ msgid "DeathGate"
+#~ msgstr "Dödsport"
+
+#~ msgid "Decisions"
+#~ msgstr "Beslut"
+
+#~ msgid "Do Not Enter!"
+#~ msgstr "Gå Inte In!"
+
+#~ msgid "Do not remove coins from fountain."
+#~ msgstr "Plocka inte upp mynt från fontänen."
+
+#~ msgid "Dragonburg"
+#~ msgstr "Drakborg"
+
+#~ msgid "Dragon City lies beyond the Scorpion Hills."
+#~ msgstr "Drakstaden ligger bortom Skorpionbergen."
+
+#~ msgid "Dragon Hill"
+#~ msgstr "Drakberget"
+
+#~ msgid "Dragons Everywhere!"
+#~ msgstr "Drakar överallt"
+
+#~ msgid "Dragontooth"
+#~ msgstr "Draktand"
+
+#~ msgid "Dragon Town"
+#~ msgstr "Drakstaden"
+
+#~ msgid "Dwarfhall"
+#~ msgstr "Dvärghall"
+
+#~ msgid "Dwarfhall, Domain of the dwarf King."
+#~ msgstr "Dvärghall, dvärgkungens domän."
+
+#~ msgid "Dwarf Hall, domain of the dwarf King."
+#~ msgstr "Dvärghall, dvärgkungens domän."
+
+#~ msgid "Fantasy Island."
+#~ msgstr "Fantasiön."
+
+#~ msgid ""
+#~ "Final message from Overlord. \"The royal executioners are on their way. "
+#~ "My gold, the land or your head- it's your choice.\""
+#~ msgstr ""
+#~ "Ett sista meddelande från Överherren. \"Den kungliga bödeln är på väg. "
+#~ "Mitt guld, landet eller ditt huvud - du bestämmer.\""
+
+#~ msgid ""
+#~ "Find the Ultimate Artifact and be proclaimed King, or smash the "
+#~ "opposition and take control."
+#~ msgstr ""
+#~ "Hitta den Ultimata artefakten och bli utropad till kung, eller krossa "
+#~ "motståndet och ta kontroll."
+
+#~ msgid "For sale."
+#~ msgstr "Till salu."
+
+#~ msgid "Four lakes have castles, three have treasure."
+#~ msgstr "Fyra sjöar har slott, tre av dem har skatter."
+
+#~ msgid "Full House"
+#~ msgstr "Fullt hus"
+
+#~ msgid "Go north to find the lost gold-mine."
+#~ msgstr "Gå norrut och hitta den förlorande gulgruvan."
+
+#~ msgid "Help!"
+#~ msgstr "Hjälp!"
+
+#~ msgid "Help me...."
+#~ msgstr "Hjälp mig..."
+
+#~ msgid ""
+#~ "High in the snowy crags, you meet an old witch who, in return for a "
+#~ "trinket of yours, gives you a powerful magical object she used to use as "
+#~ "a footstool before she was exiled into the mountains by her own "
+#~ "townspeople."
+#~ msgstr ""
+#~ "Högt upp bland de snöiga klippor möter du en gammal häxa som, i utbyte "
+#~ "mot en av dina fasader, ger dig ett kraftfullt magiskt objekt som hon "
+#~ "brukade använda som en fotpall innan hon förvisades till bergen av de "
+#~ "andra stadsborna."
+
+#~ msgid "Hot Spot"
+#~ msgstr "Hetfläck"
+
+#~ msgid "Hungry dragons await.  Welcome, food."
+#~ msgstr "Hungriga drakar väntar. Välkommen, mat."
+
+#~ msgid "Hurry up! Few days are left before the enemy's army arrives."
+#~ msgstr ""
+#~ "Skynda dig! Det är bara några dagar kvar tills fiendens armé kommer."
+
+#~ msgid "I am...."
+#~ msgstr "Jag..."
+
+#~ msgid "If you free a hero, they may help..."
+#~ msgstr "Om du befriar en hjälte kan den kanske hjälpa till..."
+
+#~ msgid ""
+#~ "If you value your lives, for God's sake, Don't go through this whirlpool!"
+#~ msgstr ""
+#~ "Om ni värderar era liv, för Guds skull, åk inte igenom denna strömvirvel!"
+
+#~ msgid "In the stream you find an old compass!"
+#~ msgstr "I strömmen hittar du en gammal kompass!"
+
+#~ msgid "In this glen live some very naughty halflings. Stay Away!"
+#~ msgstr "I denna dalgång bor några elaka hober. Håll dig borta!"
+
+#~ msgid ""
+#~ "In two more weeks, if you have not located Joseph, your kingdom will "
+#~ "surely lose its current battle with Harondale."
+#~ msgstr ""
+#~ "Om två veckor, om du inte har hittat Joseph, kommer ditt kungarike säkert "
+#~ "förlora striden mot Harondale."
+
+#~ msgid "I see you, you see me."
+#~ msgstr "Jag ser dig, du ser mig."
+
+#~ msgid ""
+#~ "It is obvious that the mage that once was here had won many battles!  "
+#~ "There, upon his hand, is a most powerful ring!"
+#~ msgstr ""
+#~ "Det är självklart att magikern en gång har vunnit många strider! På sin "
+#~ "hand har han en mäktig ring!"
+
+#~ msgid ""
+#~ "It looks like there used to be an ore mine here but all you see now is a "
+#~ "hole in the ground and some minerals scattered around."
+#~ msgstr ""
+#~ "Det ser ut som det har funnits en gruva här, men allt du kan se nu är ett "
+#~ "hål i marken och lite mineraler som ligger utspritt omkring."
+
+#~ msgid "Ivan lives in the desert."
+#~ msgstr "Ivan bor i öknen."
+
+#~ msgid "I Would Go That Way If I Were You."
+#~ msgstr "Jag Skulle Gå Den Vägen Om Jag Var Du."
+
+#~ msgid "Jolly Roger was here"
+#~ msgstr "Jolly Roger var här"
+
+#~ msgid "Just 30 days left!"
+#~ msgstr "Bara 30 dagar kvar!"
+
+#~ msgid "Just ONE week left!"
+#~ msgstr "Bara EN vecka kvar!"
+
+#~ msgid "Keep Out!"
+#~ msgstr "Håll dig undan!"
+
+#~ msgid "King John"
+#~ msgstr "Kung John"
+
+#~ msgid "King of Death"
+#~ msgstr "Dödskungen"
+
+#~ msgid "Knight's Trail."
+#~ msgstr "Riddarens stig."
+
+#~ msgid "Knight stuff"
+#~ msgstr "Riddarsaker"
+
+#~ msgid "Land teleporters will get you to your destination sooner."
+#~ msgstr "Landteleportörer förflyttar dig till din destination snabbare."
+
+#~ msgid "Like, Stuff And Junk?"
+#~ msgstr "Typ, Grejer Och Skräp?"
+
+#~ msgid "Long live Roland the true King!"
+#~ msgstr "Länge leve den sanne kungen Roland!"
+
+#~ msgid "Long live Roland the true King."
+#~ msgstr "Länge leve den sanne kungen Roland."
+
+#~ msgid "Look out!"
+#~ msgstr "Se upp!"
+
+#~ msgid "Magic"
+#~ msgstr "Magi"
+
+#~ msgid ""
+#~ "Many guardians stand between you and your enemies, but anybody can sneak "
+#~ "through the back door!"
+#~ msgstr ""
+#~ "Många vakter står mellan dig och dina fiender, men vem som helst kan "
+#~ "smyga ut genom bakdörren!"
+
+#~ msgid "Many that have gone through this door have never returned."
+#~ msgstr "Många som har gått igenom denna dörr har aldrig återvänt."
+
+#~ msgid ""
+#~ "Many years ago, a couple of mages had a \"duel\" that forever changed the "
+#~ "lake at the center of this continent.  Hearty adventurers might find "
+#~ "interesting treasure there!"
+#~ msgstr ""
+#~ "För många år sedan hade några trollkarlar en \"duell\" som hela tiden "
+#~ "förändrade sjön i mitten av denna kontinent. Helhjärtade äventyrare "
+#~ "kanske kan hitta intressanta skatter här!"
+
+#~ msgid "Message from Archibald. \" Do not dare to return without my Crown.\""
+#~ msgstr ""
+#~ "Meddelande från Archibald. \"Våga inte komma tillbaka utan min Krona.\""
+
+#~ msgid "Message from Overlord. \"STILL WAITING FOR MY GOLD!\""
+#~ msgstr ""
+#~ "Meddelande från Överherren. \"JAG VÄNTAR FORTFARANDE PÅ MITT GULD!\""
+
+#~ msgid "Message from Overlord. \"WHERE'S MY GOLD?\""
+#~ msgstr "Meddelande från Överherren. \"VAR ÄR MITT GULD?\""
+
+#~ msgid ""
+#~ "Message from Roland. \" We cannot hope to defeat Archibald without the "
+#~ "Crown, I'm counting on you.\""
+#~ msgstr ""
+#~ "Meddelande från Roland. \"Vi kan inte hoppas på att besegra Archibald "
+#~ "utan Kronan. Jag räknar med dig.\""
+
+#~ msgid "mirror"
+#~ msgstr "spegel"
+
+#~ msgid "MONEY, MONEY, MONEY!"
+#~ msgstr "PENGAR, PENGAR, PENGAR!"
+
+#~ msgid "Mr Ed"
+#~ msgstr "Mr Ed"
+
+#~ msgid "Mr. Yellow's Income"
+#~ msgstr "Herr Guls inkomst"
+
+#~ msgid "My Treasure Is Buried Beneath Three Palm Trees"
+#~ msgstr "Min skatt är nedgrävd nedanför tre palmer"
+
+#~ msgid "\"Necromancers!\""
+#~ msgstr "\"Svartkonstnärer!\""
+
+#~ msgid "New Enemies"
+#~ msgstr "Nya fiender"
+
+#~ msgid "Nightshadow"
+#~ msgstr "Nattskugga"
+
+#~ msgid "No Description"
+#~ msgstr "Ingen beskrivning"
+
+#~ msgid "No Fishing!"
+#~ msgstr "Fiske förbjudet!"
+
+#~ msgid ""
+#~ "None of the four leaders like being stuck in a land that has only one "
+#~ "season."
+#~ msgstr ""
+#~ "Ingen av de fyra ledarna gillade att fastna i ett land med endast en "
+#~ "årstid."
+
+#~ msgid "NO, Not That Way. This Way."
+#~ msgstr "NEJ, inte den vägen. Den här vägen."
+
+#~ msgid "No one has ever made it out of the deadly swamps alive!"
+#~ msgstr "Ingen har någonsin klarat sig ut från dödliga träsket levande!"
+
+#~ msgid "North vs. South"
+#~ msgstr "Nord vs. Syd"
+
+#~ msgid "No swimming."
+#~ msgstr "Simning förbjudet."
+
+#~ msgid "No Trespassing"
+#~ msgstr "Ingen överträdelse"
+
+#~ msgid "Now leaving Swamplands of the Eternial"
+#~ msgstr "Du lämnar nu Eternials träskländer."
+
+#~ msgid "Of the necromancers...."
+#~ msgstr "Svartkonstnärernas..."
+
+#~ msgid ""
+#~ "One of the seers in your castle comes to you in the morning with urgent "
+#~ "news. Your one time comrade, the wizard Joseph, and his armies have been "
+#~ "imprisoned in a jail nearby. His power would surely aid you in your quest "
+#~ "to reclaim the library, you think to yourself. Perhaps there is a way to "
+#~ "rescue him..."
+#~ msgstr ""
+#~ "En av slottets profeter kommer in till dig på morgonen med brådskande "
+#~ "nyheter. Din vän en gång i tiden, trollkarlen Joseph och hans arméer har "
+#~ "tillfångatagits i ett fängelse i närheten. Hans krafter skulle säkert "
+#~ "hjälpa dig på ditt uppdrag att ta tillbaka biblioteket. Du tänker för sig "
+#~ "själv. Det kanske finns ett sätt att rädda honom..."
+
+#~ msgid ""
+#~ "One of your \"allies\" has joined Archibald.  You now face an opponent "
+#~ "with three castles to your one.  Good luck!"
+#~ msgstr ""
+#~ "En av dina \"allierade\" har förenat sig med Arhbald. Du möter nu en "
+#~ "motståndare med tre slott mot ett. Lycka till!"
+
+#~ msgid ""
+#~ "One of your \"Allies\" has joined Roland. You are now facing three "
+#~ "castles, all belonging to the enemy. Good luck!"
+#~ msgstr ""
+#~ "En av dina \"allierade\" har förenat sig med Roland. Du möter nu tre "
+#~ "slott, och alla tillhör fienden. Lycka till!"
+
+#~ msgid "Only a month remains in which to find Joseph."
+#~ msgstr "Endast en månad återstår att hitta Joseph."
+
+#~ msgid "Orcville"
+#~ msgstr "Orchville"
+
+#~ msgid "Other than the dragons, the elves don't have any enemies."
+#~ msgstr "Förutom drakarna har alverna inga fiender."
+
+#~ msgid "Our ally was greatly weakened when his resources were plundered."
+#~ msgstr ""
+#~ "Våra allierade var kraftigt försvagade när hans resurser var plundrade."
+
+#~ msgid "\"Our Finest Hour\""
+#~ msgstr "\"Vår Finaste Timme\""
+
+#~ msgid "Our reinforcements were lost in a storm, we salvaged all we could!"
+#~ msgstr "Våra förstärkningar gick åt i en storm, vi räddade allt som kundes!"
+
+#~ msgid ""
+#~ "Our spies have discovered that the barbarian hordes are now receiving "
+#~ "support from kraeger! You must hurry and find the third piece before your "
+#~ "forces here are crushed!"
+#~ msgstr ""
+#~ "Våra spioner har upptäckt att barbarhordarna har nu fått stöd från "
+#~ "Kraeger! Du måste skynda dig och hitta den tredje delen innan dina "
+#~ "trupper blir krossade!"
+
+#~ msgid "Overlord"
+#~ msgstr "Överherre"
+
+#~ msgid "Password found by Crystals to the South."
+#~ msgstr "Lösenordet hittades vid kristallerna i syd."
+
+#~ msgid "\"Peasants!\""
+#~ msgstr "\"Bönder\"!"
+
+#~ msgid "Pick one of four Knights in this large and inhospitable land."
+#~ msgstr "Välj en av de fyra riddarna i detta stora ogästvänliga land."
+
+#~ msgid "Pig's Eye"
+#~ msgstr "Grisöga"
+
+#~ msgid ""
+#~ "Play the Knight or Barbarian in an alliance in this classic duel against "
+#~ "the four spell casters. (Blue and Green vs Red)"
+#~ msgstr ""
+#~ "Spela riddaren eller barbaren i en allians i denna klassiska duell mot de "
+#~ "fyra besvärjelsekastarna. (Blå och Grön mot Röd)"
+
+#~ msgid "Please...."
+#~ msgstr "Snälla..."
+
+#~ msgid ""
+#~ "Plenty of resources and lots of ground to cover. Watch out for Orange and "
+#~ "Purple!"
+#~ msgstr ""
+#~ "Många resurser och mängder av mark att täcka. Se upp för Orange och Lila!"
+
+#~ msgid "Portals"
+#~ msgstr "Portaler"
+
+#~ msgid "POSION - DO NOT DRINK"
+#~ msgstr "GIFT - DRICK INTE"
+
+#~ msgid "Prisoner on...."
+#~ msgstr "Fånge på..."
+
+#~ msgid "Quick Silver"
+#~ msgstr "Kvicksilver"
+
+#~ msgid "Realm of the Undead.  Fresh blood welcome."
+#~ msgstr "De odödas rike. Färskt blod välkommen."
+
+#~ msgid "Redshield"
+#~ msgstr "Rödsköld"
+
+#~ msgid "Reinforcements have arrived, Gold from the homelands!"
+#~ msgstr "Förstärkningar har anländt. Guld från hemländerna!"
+
+#~ msgid ""
+#~ "Remember, you're searching for the Ultimate Artifact... don't get "
+#~ "distracted!"
+#~ msgstr ""
+#~ "Kom ihåg att du letar efter den Ultimata artefakten... bli inte "
+#~ "distraherad!"
+
+#~ msgid ""
+#~ "Rendall Koski was here. 1997.  Northampton, Massachusetts There is a "
+#~ "powerful artifact in the southeastern corner of the world.  Go for it, "
+#~ "explorer!"
+#~ msgstr ""
+#~ "Rendall Koski var här 1997. Northampton, Massachusetts. Det finns en "
+#~ "kraftfull artefakt i världens sydöstra hörn. Vad väntar du på?"
+
+#~ msgid "Revolution"
+#~ msgstr "Revolution"
+
+#~ msgid ""
+#~ "Robbers have looted your treasury and you have lost valuable resources."
+#~ msgstr ""
+#~ "Rånare har plundrat din skattkammare och du har förlorat värdefulla "
+#~ "resurser."
+
+#~ msgid "Robbers have looted your treasury, stealing valuable resources."
+#~ msgstr ""
+#~ "Rånare har plundrat din skattkammare och stulit värdefulla resurser."
+
+#~ msgid "Scorched Earth"
+#~ msgstr "Bränd jord"
+
+#~ msgid ""
+#~ "Scouts report the notorious necromancer \"Wyrm\" has been sighted to the "
+#~ "northeast."
+#~ msgstr ""
+#~ "Spanare rapporterar att den ökände svartkonstnären \"Wyrm\" har setts "
+#~ "till i nordöst."
+
+#~ msgid "Seasons Change"
+#~ msgstr "Årstidsskiftning"
+
+#~ msgid "Snowdrop"
+#~ msgstr "Snödroppe"
+
+#~ msgid "Some crystal!"
+#~ msgstr "Några kristaller!"
+
+#~ msgid "Some gems!"
+#~ msgstr "Några ädelstenar!"
+
+#~ msgid ""
+#~ "Some unlucky adventurers have been captured and imprisoned in these lands."
+#~ msgstr ""
+#~ "Några olycksaliga äventyrare har tillfångatagits och fängslats i dessa "
+#~ "länder."
+
+#~ msgid "Sorceress Forest.  Show respect for nature!"
+#~ msgstr "Häxskogen. Visa respekt för naturen!"
+
+#~ msgid ""
+#~ "Spies report Roland has sent a hero to search for the Crown. If he finds "
+#~ "it first, all is lost!"
+#~ msgstr ""
+#~ "Spioner rapporterar att Roland har skickat ut en hjälte för att hitta "
+#~ "Kronan. Om han hittar den är allt förlorat!"
+
+#~ msgid "Stairs"
+#~ msgstr "Trappor"
+
+#~ msgid ""
+#~ "Start with five castles!  How could you lose!?  Oh yeah, everyone else "
+#~ "starts with five, too."
+#~ msgstr ""
+#~ "Börja med fem slott! Hur kunde du förlora!? Åh visst, alla andra börjar "
+#~ "med fem också."
+
+#~ msgid "Stick to the road!"
+#~ msgstr "Håll dig på vägen!"
+
+#~ msgid "Stronghold"
+#~ msgstr "Fort"
+
+#~ msgid "Stuff for Yellow"
+#~ msgstr "Saker för Gul"
+
+#~ msgid "Stuff For Yellow"
+#~ msgstr "Saker För Gul"
+
+#~ msgid "Teleporters"
+#~ msgstr "Teleportörer"
+
+#~ msgid "Terrain Wars"
+#~ msgstr "Terrängkrig"
+
+#~ msgid "The Back Door"
+#~ msgstr "Bakdörren"
+
+#~ msgid ""
+#~ "The Barbarian's lands are being invaded. Are you strong enough to resist "
+#~ "the invasion?"
+#~ msgstr ""
+#~ "Barbarernas länder invaderas. Är du stark nog att stå emot invasionen?"
+
+#~ msgid "The Citadel"
+#~ msgstr "Citadellen"
+
+#~ msgid "The Clearing"
+#~ msgstr "Gläntan"
+
+#~ msgid ""
+#~ "The convoy should have been here by now! Let us hope that it is safe and "
+#~ "still on its way."
+#~ msgstr ""
+#~ "Konvojen skulle ha varit här nu! Hoppas bara att den är i säkerhet och "
+#~ "fortfarande på väg."
+
+#~ msgid ""
+#~ "The crew are unworthy!  I am not going down with the ship! -The Captain"
+#~ msgstr ""
+#~ "Besättningen är värdelös! Jag tänker inte gå under med skeppet! -Kaptenen"
+
+#~ msgid "The Eastern Town."
+#~ msgstr "Östra tornet"
+
+#~ msgid "The Enchanted Forest."
+#~ msgstr "Den förvandlade skogen."
+
+#~ msgid "The End of the World is Nigh!"
+#~ msgstr "Världens undergång är nära!"
+
+#~ msgid "The End of the World is Nigh"
+#~ msgstr "Världens undergång är nära"
+
+#~ msgid ""
+#~ "The Epic battle against Your Rival! Eliminate everything! Total Warfare! "
+#~ "Don't Lose your first hero!"
+#~ msgstr ""
+#~ "Episka striden mot Din rival! Eliminera allting! Total krigföring! "
+#~ "Förlora inte din första hjälte!"
+
+#~ msgid ""
+#~ "The first piece of the artifact now lies in the hands of the Unholy Order "
+#~ "of Warlocks. You must annihilate them, and their allies to the north. "
+#~ "They will surely give us what we seek in exchange for their feeble lives."
+#~ msgstr ""
+#~ "Den första delen av artefakten ligger i händerna på den oheliga "
+#~ "Krigstrollkarlsordern. Du måste förstöra dem och deras allierade i norr. "
+#~ "De skulle säkert ge oss vad vi söker efter i utbyte mot deras kraftlösa "
+#~ "liv."
+
+#~ msgid ""
+#~ "The Gods have given you 6 months to prove yourself. Good or Evil - who "
+#~ "shall prevail? (Blue,Green and Red vs Yellow, Orange and Purple)"
+#~ msgstr ""
+#~ "Gudarna har gett dig 6 månader att visa vad du kan. Godhet eller Ondska - "
+#~ "vad ska segra? (Blå, Grön och Röd mot Gul, Orange och Lila)"
+
+#~ msgid "The Gods themselves will aid us in this War."
+#~ msgstr "Gudarna själv kommer att stödja oss i detta krig."
+
+#~ msgid "The Gold Traveller's Tent is near the Aqua Taveller's Tent."
+#~ msgstr "Gulds resenärstält är nära akvamarins resenärstält."
+
+#~ msgid "The guardians of Dragon Isle reside in the jungle."
+#~ msgstr "Draköns väktare bor i djungeln."
+
+#~ msgid "The island...."
+#~ msgstr "Ön..."
+
+#~ msgid "The islands have much wealth."
+#~ msgstr "Öarna har mycket rikedomar."
+
+#~ msgid "The Kings Road."
+#~ msgstr "Kungarnas väg."
+
+#~ msgid ""
+#~ "The King will sell you this land for 200,000 gold or you can take it by "
+#~ "force. The choice is yours."
+#~ msgstr ""
+#~ "Kungen kommer att sälja dig detta land för 200,000 guld eller så kan du "
+#~ "erövra det. Valet är ditt."
+
+#~ msgid "The land of Heroes II."
+#~ msgstr "Hjältarnas land II."
+
+#~ msgid "The Lost Castle of the Ancients"
+#~ msgstr "Antikens förlorade slott."
+
+#~ msgid ""
+#~ "The Medusas have the password and they can be found just to the west."
+#~ msgstr "Medusorna har lösenordet och dem kan man hitta i väst."
+
+#~ msgid "The more there is the less you see."
+#~ msgstr "Ju mer det finns, desto mindre ser du."
+
+#~ msgid "The North Road to Roland's castle."
+#~ msgstr "Norra vägen till Rolands slott."
+
+#~ msgid ""
+#~ "The Overlord has given you 4 months to conquer this land or deliver to "
+#~ "him the sum of 150,000 gold."
+#~ msgstr ""
+#~ "Överherren har gett dig 4 månader att erövra detta land eller överlämna "
+#~ "en summa på 150,000 guld."
+
+#~ msgid "The Queen's Road."
+#~ msgstr "Drottningens väg."
+
+#~ msgid ""
+#~ "There are three enemy castles to the north. Capture them in the name of "
+#~ "Roland the true king!"
+#~ msgstr ""
+#~ "Det finns tre fiendeslott norrut. Erövra dem i Roland, den sanne kungens, "
+#~ "namn!"
+
+#~ msgid "There is hidden treasure south of the Blue Lord's Sawmill."
+#~ msgstr "Det finns en gömd skatt söder om Den blå herrens sågverk."
+
+#~ msgid "There's a warm wind blowing from the south."
+#~ msgstr "En varm vind blåser från söder."
+
+#~ msgid "The Retreat of the Alchemist Doctor Yu"
+#~ msgstr "Alkemisten Doktor Yu's reträtt"
+
+#~ msgid "The River Styx"
+#~ msgstr "Floden Styx"
+
+#~ msgid "The Rock Store."
+#~ msgstr "Stenaffären."
+
+#~ msgid "The Royal Gardens."
+#~ msgstr "Kungliga trädgårdarna."
+
+#~ msgid "These lands are beholden to Lord Kraeger."
+#~ msgstr "Dessa länder tillhör Lord Kraeger."
+
+#~ msgid ""
+#~ "The Southern Witch is biding her time.  She will strike when your armies "
+#~ "are weak."
+#~ msgstr "Häxan i söder tar sin tid. Hon attackerar när dina arméer är svaga."
+
+#~ msgid "The Table in the Great Hall of the Castle is Haunted."
+#~ msgstr "Bordet i slottets stora hall är hemsökt."
+
+#~ msgid ""
+#~ "The third piece of the artifact is somewhere to the north, that much we "
+#~ "know. We are still unsure of its exact location, but our spies are out "
+#~ "gathering information. The forces in this area are too strong to be "
+#~ "completely subjugated, so take what you can and hold on to it tightly."
+#~ msgstr ""
+#~ "Den tredje delen av artefakten är någonstans i norr, det vet vi. Vi är "
+#~ "fortfarande osäkra på dess exakta position, men våra spioner är ute och "
+#~ "samlar på sig information. Trupperna i detta område är för starka för att "
+#~ "bli helt underkuvade, så ta det du kan och håll det dig nära."
+
+#~ msgid ""
+#~ "The Valley of Magic holds many surprises.  You discover an old pair of "
+#~ "boots sticking out of the sand."
+#~ msgstr ""
+#~ "Magidalen rymmer många överraskningar. Du hittar ett par gamla stövlar "
+#~ "som sticker upp i sanden."
+
+#~ msgid "The Valley of Tresures"
+#~ msgstr "Skattdalen"
+
+#~ msgid "The Wasteland"
+#~ msgstr "Ödemarken"
+
+#~ msgid "The way of magic"
+#~ msgstr "Magins väg"
+
+#~ msgid "The way of might"
+#~ msgstr "Maktens väg"
+
+#~ msgid "The way of numbers"
+#~ msgstr "Siffrornas väg"
+
+#~ msgid "The western town."
+#~ msgstr "Västra staden"
+
+#~ msgid "The wizard has an island in the southeast."
+#~ msgstr "Trollkarlen har en ö i sydöst."
+
+#~ msgid "The wood has arrived."
+#~ msgstr "Veden har anlänt."
+
+#~ msgid "The writing on this sign is too faded to read."
+#~ msgstr "Texten på denna skylt är för blek för att kunna läsas."
+
+#~ msgid "They say there's mermaids in these waters..."
+#~ msgstr "Det sägs att det finns sjöjungfrur i dessa vatten..."
+
+#~ msgid ""
+#~ "This area is rich in resources. Explore, but beware, a castle left "
+#~ "undefended will quickly fall."
+#~ msgstr ""
+#~ "Detta område är rikt på resurser. Utforska, men se upp! Ett oskyddat "
+#~ "slott faller snabbt."
+
+#~ msgid "This bottle is empty."
+#~ msgstr "Flaskan är tom."
+
+#~ msgid ""
+#~ "This is the last week you have to find the rebel wizard Joseph! Good Luck "
+#~ "in your quest."
+#~ msgstr ""
+#~ "Det här är den sista veckan du har på dig att hitta trollkarlsrebellen "
+#~ "Joseph! Lycka till på ditt uppdrag."
+
+#~ msgid "This way to the Necromancer Forest."
+#~ msgstr "Denna väg leder till Svartkonstnärsskogen."
+
+#~ msgid "Those who seek knowledge are welcome to the city of Chronos."
+#~ msgstr "Dem som söker kunskap är välkommen till Chronors stad."
+
+#~ msgid "Time for a refreshing drink."
+#~ msgstr "Dags för en uppfriskande drink."
+
+#~ msgid "Time is running out! The enemy's reinforcements are almost here."
+#~ msgstr "Tiden tar slut! Fiendens förstärkningar är nästan här."
+
+#~ msgid "To pass you must pay troll."
+#~ msgstr "För att passera måste du betala trollet."
+
+#~ msgid "TreeHome"
+#~ msgstr "Trädhem"
+
+#~ msgid "Trespassers will be EATEN!"
+#~ msgstr "Passerande kommer att ÄTAS UPP!"
+
+#~ msgid "Troy"
+#~ msgstr "Troy"
+
+#~ msgid "Turn back, friend, while you still can!"
+#~ msgstr "Vänd om, vän, medan du fortfarande kan!"
+
+#~ msgid "Turn Back Now!"
+#~ msgstr "Vänd Om Nu!"
+
+#~ msgid "Turn Back Now or all will be LOST!"
+#~ msgstr "Vänd Om Nu annars kommer alla att FÖRSVINNA!"
+
+#~ msgid "Turn Back or DIE!"
+#~ msgstr "Vänd Om eller DÖ!"
+
+#~ msgid "Turn Back or else!"
+#~ msgstr "Vänd Om eller annars!"
+
+#~ msgid "Turn back, you fool."
+#~ msgstr "Vänd om, din dåre."
+
+#~ msgid "Uncle Leo"
+#~ msgstr "Farbror Leo"
+
+#~ msgid "Uncle Milty"
+#~ msgstr "Morbror Milty"
+
+#~ msgid "Undead Armies"
+#~ msgstr "Odöda arméer"
+
+#~ msgid "Valley of Death"
+#~ msgstr "Dödsdalen"
+
+#~ msgid "Valley Of The Damned"
+#~ msgstr "Förbannade dalen"
+
+#~ msgid "Valley of the Kings."
+#~ msgstr "Kungarnas dal."
+
+#~ msgid "Vertigo"
+#~ msgstr "Vertigo"
+
+#~ msgid "Vikings!"
+#~ msgstr "Vikingar!"
+
+#~ msgid "Vulcania"
+#~ msgstr "Vulkania"
+
+#~ msgid "Warrior Knight"
+#~ msgstr "Krigsriddare"
+
+#~ msgid "Wastelands"
+#~ msgstr "Ödemarker"
+
+#~ msgid "Watch out for Purple!"
+#~ msgstr "Akta dig för Lila!"
+
+#~ msgid "Waystop"
+#~ msgstr "Vägstopp"
+
+#~ msgid ""
+#~ "\"We are at the edge of the world!\"  they scream.  \"What are we doing "
+#~ "here?\""
+#~ msgstr "\"Vi är vid världens ände\", skriker dem. \"Vad gör vi här?\""
+
+#~ msgid ""
+#~ "Welcome back general.  Have you finished the conquest of the northern "
+#~ "lands?  What? you still have not finished your mission!  Get back there "
+#~ "and teach those rebels a lesson!"
+#~ msgstr ""
+#~ "Välkommen tillbaka, general. Har du slutfört erövringingen av alla länder "
+#~ "i norr? Va? Du har inte slutfört ditt uppdrag! Gå tillbaka och lär dem "
+#~ "där rebellerna en läxa!"
+
+#~ msgid "Welcome to Li'l Alctatraz! Vistors NOT welcome."
+#~ msgstr "Välkommen till Li'l Alctatraz! Besökare är inte välkomna."
+
+#~ msgid "Welcome to your DOOM!"
+#~ msgstr "Välkommen till ditt ÖDE!"
+
+#~ msgid "We'll join you - for the right price."
+#~ msgstr "Vi följer med er, för ett pris."
+
+#~ msgid "We told you not to drink!"
+#~ msgstr "Vi sa att du inte skulle dricka det!"
+
+#~ msgid "What are you doing here?"
+#~ msgstr "Vad gör du här?"
+
+#~ msgid ""
+#~ "What cannot be seen but only heard, and will not speak until spoken to?"
+#~ msgstr ""
+#~ "Vad kan inte synas men endast höras, och pratar inte förrän man pratar "
+#~ "till den?"
+
+#~ msgid "What everyday word is most often pronounced incorrectly?"
+#~ msgstr "Vilket vardagligt ord uttalas mest ofta felaktigt?"
+
+#~ msgid "What goes up and down but never moves?"
+#~ msgstr "Vad går upp och ned, men rör sig aldrig?"
+
+#~ msgid "What is always coming but never arrives?"
+#~ msgstr "Vad är det som alltid kommer men aldrig kommer fram?"
+
+#~ msgid "What is the Sum of all Numbers from 1 to 200?"
+#~ msgstr "Vad är summan av nummer från 1 till 200?"
+
+#~ msgid "What's another word for pirate treasure?"
+#~ msgstr "Finns det ett annat ord för piratskatt?"
+
+#~ msgid "What's behind door number one?"
+#~ msgstr "Vad finns bakom dörr nummer ett?"
+
+#~ msgid "What's this? A pile of gems?"
+#~ msgstr "Vad är detta? En hög ädelstenar?"
+
+#~ msgid "What's this? Someone has left a pile of wood here!"
+#~ msgstr "Vad är detta? Någon har lämnat en vedhög här!"
+
+#~ msgid ""
+#~ "What team won Super Bowl XXI and Super Bowl XXV?  (Hint... a Wizard might "
+#~ "have these troops in his army)"
+#~ msgstr ""
+#~ "Vilket lag vann Super Bowl XXI och Super Bowl XXV? (Tips... en trollkarl "
+#~ "kanske har dessa troféer in sin armé)"
+
+#~ msgid "What turns everything around but does not move?"
+#~ msgstr "Vad är det som vrider allting men rör sig aldrig?"
+
+#~ msgid ""
+#~ "What walks in the morning on four legs, two in the afternoon and three in "
+#~ "the evening?"
+#~ msgstr ""
+#~ "Vad är det som har fyra ben på morgonen, två ben på dagen och tre ben på "
+#~ "kvällen?"
+
+#~ msgid "What?  What's this?  Something at the bottom of this pool..."
+#~ msgstr "Vad? Vad är detta? Någonting på botten av denna damm..."
+
+#~ msgid "When you're ready, take the teleport to the Island's Hot Spot!"
+#~ msgstr "När du är redo, tar du teleportören till öns hetfläck!"
+
+#~ msgid ""
+#~ "When you think yourself invincible, walk through this gate.  Even then, "
+#~ "prepare to meet your bitter end."
+#~ msgstr ""
+#~ "Gå endast igenom denna port när du tror du är oövervinnelig. Även då bör "
+#~ "du förbereda dig för att möta ditt bittra slut."
+
+#~ msgid "Where am I?"
+#~ msgstr "Var är jag?"
+
+#~ msgid ""
+#~ "While away seeking the Ultimate Artifact, Kastor's kingdom is invaded!"
+#~ msgstr ""
+#~ "Medan du är iväg och söker efter den Ultimata artefakten invaderas "
+#~ "Kastor's kungarike!"
+
+#~ msgid "Whittingham"
+#~ msgstr "Whittingham"
+
+#~ msgid "Who am I?"
+#~ msgstr "Vem är jag?"
+
+#~ msgid ""
+#~ "Who am I?...  Where am I?...  Oh no! My Ship!  Well it's consigned to the "
+#~ "ghosts of my dead crew now, at least I still have my lucky rabbits foot."
+#~ msgstr ""
+#~ "Vem är jag? ... Var är jag? ... Åh nej! Mitt skepp! Nåja, det är nu "
+#~ "överlämnat till min spökena från min döda besättning. Jag har åtminstone "
+#~ "kvar min hartass."
+
+#~ msgid "Who is the true King?"
+#~ msgstr "Vem är den sanne kungen?"
+
+#~ msgid ""
+#~ "\"Why have we come this way?\"  asks the first mate.  You have no answer."
+#~ msgstr ""
+#~ "\"Varför har vi kommit denna väg?\", frågar förste styrman. Du har inget "
+#~ "svar på frågan."
+
+#~ msgid "Wicked Warlock Way"
+#~ msgstr "Onde krigstrollkarlens väg"
+
+#~ msgid "Wildabar"
+#~ msgstr "Wildabar"
+
+#~ msgid "Wilgatus"
+#~ msgstr "Wilgatus"
+
+#~ msgid "Willow"
+#~ msgstr "Pilträd"
+
+#~ msgid "Witch Hunt"
+#~ msgstr "Häxjakt"
+
+#~ msgid "Wow, somebody has left a pile of wood here!"
+#~ msgstr "Oj, någon har lämnat en vedhög här!"
+
+#~ msgid "Wyrm"
+#~ msgstr "Wyrm"
+
+#~ msgid "Xabran"
+#~ msgstr "Xabran"
+
+#~ msgid "Yellow gets some stuff"
+#~ msgstr "Gul får lite saker"
+
+#~ msgid "Yellow's Steady Cash"
+#~ msgstr "Guls säkra pengar"
+
+#~ msgid "Yellow stuff"
+#~ msgstr "Gula saker"
+
+#~ msgid "Yorksford"
+#~ msgstr "Yorksford"
+
+#~ msgid "You are a fool to come here!"
+#~ msgstr "Du är en dåre som kommer hit!"
+
+#~ msgid "You are fighting on the side of your king!"
+#~ msgstr "Du slåss på din kungs sida!"
+
+#~ msgid "You are fighting on the side of your sister!"
+#~ msgstr "Du slåss på din systers sida!"
+
+#~ msgid "You are now entering the domain of Prince Roland. Have a nice day."
+#~ msgstr "Du kliver nu in i prins Rolands domän. Ha en bra dag."
+
+#~ msgid ""
+#~ "You are now entering the domain of Prince Roland. Have a pleasant stay."
+#~ msgstr "Du kliver nu in i prins Rolands domän. Ha en trevlig dag."
+
+#~ msgid ""
+#~ "You can only reach your enemies via teleporters, but each jump is a leap "
+#~ "of faith."
+#~ msgstr ""
+#~ "Du kan endast nå dina fiender via teleportörer, men varje hopp är ett "
+#~ "chansning."
+
+#~ msgid ""
+#~ "You cautiously ride through the trees, looking out for enemy assaults, "
+#~ "when suddenly, the old elf is beside you. \"Your quest is almost at an "
+#~ "end, my friend. All that remains is for you to lay seige to these last "
+#~ "few castles. The fate of my people rests upon your final battles here. "
+#~ "May the gods be with you as well.\"  He turns to leave, but you ask him "
+#~ "his name before he is gone. Over his shoulder, as he is leaving he says "
+#~ "\"I am Ilthanis, king of the elves.\""
+#~ msgstr ""
+#~ "Du rider försiktigt genom skogen, spanades efter fiendeangrepp, när en "
+#~ "gammal alv plötsligt står bredvid dig. \"Ditt uppdrag lider mot sitt "
+#~ "slut, min vän. Allt som återstår är att belägra dessa sista slott. Mitt "
+#~ "folks öde vilar på dina sista strider här. Må gudarna vara med dig också."
+#~ "\" Han vänder sig om för att gå iväg, men du frågar vad han heter innan "
+#~ "han försvinner. Över sin axel säger han medan han går iväg, \"Jag är "
+#~ "Ilthanis, alvernas kung.\""
+
+#~ msgid ""
+#~ "You come across the dead remains of what was appearantly a powerful "
+#~ "wizard!  You wonder if it's safe to continue."
+#~ msgstr ""
+#~ "Du stöter på kvarlevor från en kraftfull trollkarl! Du börjar undra om "
+#~ "det är säkert att fortsätta."
+
+#~ msgid ""
+#~ "You find a gleaming gold medalion buried in the  snow.  As you move to "
+#~ "put it on it changes to the Fizbin of Misfortune."
+#~ msgstr ""
+#~ "Du hittar en glimmande guldmedaljong som är begravd i snön. När du sätter "
+#~ "på dig den förvandlas den till en Olycksfizbin."
+
+#~ msgid ""
+#~ "You find an old signpost in the midst of a thicket that reads \"Warlock "
+#~ "Wood, West.  Barbarian Fields, East.\""
+#~ msgstr ""
+#~ "Du hittar en gammal skylt mitt i buskaget där det står "
+#~ "\"Krigstrollkarlsskogen, väst. Barbarfälten, öst.\""
+
+#~ msgid ""
+#~ "You find a note in the bottle! It reads, \"My ship has been wrecked by "
+#~ "the notorious pirates in this area! I am stranded on a small and barren "
+#~ "island. Please, I beg you to come and rescue me!\""
+#~ msgstr ""
+#~ "Du hittar en lapp i flaskan! Det står, \"Mitt skepp har förlist av de "
+#~ "beryktade piraterna i detta område! Jag är strandad på en liten öde ö. "
+#~ "Snälla, jag ber dig att komma och rädda mig!\""
+
+#~ msgid "You found something!"
+#~ msgstr "Du hittade någonting!"
+
+#~ msgid "You found Treasure!"
+#~ msgstr "Du hittade en skatt!"
+
+#~ msgid "You have found what someone else has lost..."
+#~ msgstr "Du har hittat någonting som någon annan har förlorat..."
+
+#~ msgid ""
+#~ "You have just 8 weeks  to build your army and conquer a town on the other "
+#~ "side of a distant river.  There are three paths to take, which will you "
+#~ "choose?"
+#~ msgstr ""
+#~ "Du har endast 8 veckor på dig att bygga din armé och erövra en stad på "
+#~ "andra sidan av en avlägsen flod. Det finns tre vägar, vilken väljer du?"
+
+#~ msgid ""
+#~ "You have just 8 weeks to build your army and conquer a town on the other "
+#~ "side of a distant river.  There are three paths to take, which will you "
+#~ "choose?"
+#~ msgstr ""
+#~ "Du har endast 8 veckor på dig att bygga din armé och erövra en stad på "
+#~ "andra sidan av en avlägsen flod. Det finns tre vägar, vilken väljer du?"
+
+#~ msgid ""
+#~ "You have received a message from Archibald.  \" HOW DARE YOU BETRAY ME! I "
+#~ "will see your head on the block alongside your new master's once I have "
+#~ "won."
+#~ msgstr ""
+#~ "Du har fått ett meddelande från Archibald. \"HUR VÅGAR DU FÖRRÅDA MIG! "
+#~ "Jag kommer att se ditt huvud på byggnaden bredvid din nye härskares när "
+#~ "jag har vunnit.\""
+
+#~ msgid ""
+#~ "You have received a message from Roland. \" I am shocked! I had thought "
+#~ "better of you, but I was terribly wrong. Now you'll have to live with "
+#~ "your dark decision for the rest of your life.\""
+#~ msgstr ""
+#~ "Du har fått ett meddelande från Roland. \"Jag är shockad! Jag trodde "
+#~ "bättre om dig, men jag var helt fel. Nu måste du leva med din mörka val "
+#~ "för resten av ditt liv.\""
+
+#~ msgid "You have recieved a shipment of supplies from your kingdom!"
+#~ msgstr "Du har fått ett skeppslast med proviant från ditt kungarike!"
+
+#~ msgid ""
+#~ "You have washed up on the beach after being shipwrecked. Your goal is to "
+#~ "find a way home."
+#~ msgstr ""
+#~ "Du har spolats upp på en strand efter att blivit skeppsbruten. Ditt mål "
+#~ "är att hitta hem igen."
+
+#~ msgid ""
+#~ "You hear a low rumble, look up and see an avalanche!  You dive onto a "
+#~ "large patch of grass to avoid it.  While dusting yourself off, you "
+#~ "consider yourself quite lucky to be alive.  Luckier still to find a Four-"
+#~ "Leaf Clover stuck on your nose."
+#~ msgstr ""
+#~ "Du hör ett lågt mullrande, tittar upp och ser en lavin! Du dyker in i en "
+#~ "stor gräsfläck för att undvika den. När du borstar av dig tänker du på "
+#~ "att du är ganska lyckosam för att vara vid liv. Lyckosam nog för att "
+#~ "hitta en fyrklöver som har fastnat på din näsa."
+
+#~ msgid "You hear melodic strains of elvish music as you enter this clearing."
+#~ msgstr ""
+#~ "Du hör melodiska strängar av älvlik musik när du kliver in i gläntan."
+
+#~ msgid ""
+#~ "You must search the world for your mortal enemy, Wilgatus.  Can you find "
+#~ "him before its too late?"
+#~ msgstr ""
+#~ "Du måste söka överallt för att kunna hitta din dödsbringande fiende, "
+#~ "Wilgatus. Kan du hitta honom innan det är för sent?"
+
+#~ msgid ""
+#~ "You notice some runes hastily scrawled into a rock by your feet, They "
+#~ "look like the initials of Uncle Ivan!"
+#~ msgstr ""
+#~ "Du hittar några runor som hastigt inristats i en sten vid dina fötter. "
+#~ "Det ser ut som farbror Ivans initialer!"
+
+#~ msgid ""
+#~ "Your advisor approaches you smiling greatly, \"My liege! The peasants are "
+#~ "making money in the market, and are finally paying taxes!\""
+#~ msgstr ""
+#~ "Din rådgivare kommer mot dig med ett stort leende, \"Min herre! Bönderna "
+#~ "tjänar pengar på marknaden, och de betalar äntligen skatt!\""
+
+#~ msgid ""
+#~ "Your advisor approaches you with a long face, \"My liege, the peasant's "
+#~ "numbers are growing steadily.  All they do is take, take, take! We are "
+#~ "beginning to suffer dearly because of them.\""
+#~ msgstr ""
+#~ "Din rådgivare kommer till dig lång i ansiktet, \"Min herre, böndernas "
+#~ "antal växer stadigt. Allt det dem gör är att ta, ta, ta! Vi börjar att "
+#~ "lida på grund av dem!"
+
+#~ msgid "Your castle is the last outpost in the area, Don't lose it!"
+#~ msgstr "Ditt slott är områdets sista utpost. Tappa inte bort den!"
+
+#~ msgid "Your crew begins to grumble."
+#~ msgstr "Din besättning börjar mumla."
+
+#~ msgid ""
+#~ "Your crew seriously entertains thoughts of mutiny.  Your nights are "
+#~ "sleepless."
+#~ msgstr ""
+#~ "Din besättning hyser allvarligt tankar om myteri. Dina nätter är sömnlösa."
+
+#~ msgid "You're almost there!"
+#~ msgstr "Du är nästan där!"
+
+#~ msgid "You, recieve word that you have been robbed."
+#~ msgstr "Du har fått reda på att du har blivit rånad."
+
+#~ msgid "You're getting colder."
+#~ msgstr "Du börjar bli kall."
+
+#~ msgid "You're getting warmer."
+#~ msgstr "Du börjar bli varm."
+
+#~ msgid ""
+#~ "You're here! Oh, thank you thank you thank you! I'm in the jail east of "
+#~ "the castle. Please hurry!"
+#~ msgstr ""
+#~ "Du är här! Åh, tack så mycket! Jag är i fängelset på den östra sidan av "
+#~ "slottet. Skynda dig!"
+
+#~ msgid ""
+#~ "Your horse stumbles and throws you from the saddle.  When you awaken you "
+#~ "find that you have hit your head on the Fizbin of Misfortune."
+#~ msgstr ""
+#~ "Din häst snubblar och kastar av dig från sadeln. När du vaknar upptäcker "
+#~ "du att du har slagit ditt huvud i en Olycksfizbin."
+
+#~ msgid "Your king has sent supplies to aid the war effort."
+#~ msgstr "Din kung har skickat proviant för att stödja krigsinsatserna."
+
+#~ msgid ""
+#~ "Your opponents are allied against you and each is twice as powerful as "
+#~ "his predecessor! Is it possible to win?"
+#~ msgstr ""
+#~ "Dina motståndare har slagit ihop sig mot dig och de är dubbelt så starka "
+#~ "som sina företrädare! Är det möjligt att vinna?"
+
+#~ msgid ""
+#~ "Your Scouts report that the Aqua Traveller's Tent is located along The "
+#~ "North Road."
+#~ msgstr ""
+#~ "Dina spanare rapporterar att akvamarins resenärstält finns längst norra "
+#~ "vägen."
+
+#~ msgid ""
+#~ "Your town is undefended and your heroes are scattered.  Do you attack or "
+#~ "defend?"
+#~ msgstr ""
+#~ "Din stad är oförsvarad och dina hjältar är splittrade. Vill du attackera "
+#~ "eller försvara?"
+
+#~ msgid ""
+#~ "Your treasury has been looted by robbers and you have lost valuable "
+#~ "resources."
+#~ msgstr ""
+#~ "Din skattkammare har blivit plundrad av rånare och du har förlorat "
+#~ "värdefulla resurser."
+
+#~ msgid "Your troops begin to wonder about your sanity."
+#~ msgstr "Dina trupper börjar ifrågasätta din mental hälsa."
+
+#~ msgid ""
+#~ "You run aground on the rocks and have to use some wood to fix your boat."
+#~ msgstr "Du kör på grund och måste få tag på virke att laga din båt med."
+
+#~ msgid ""
+#~ "You see the remains of an old sawmill, but it is obvious that you will "
+#~ "not be able to make it work again."
+#~ msgstr ""
+#~ "Du ser resterna av ett gammalt sågverk, men det är uppenbart att du kan "
+#~ "inte jobba där igen."
+
+#~ msgid ""
+#~ "You see the remains of an old sawmill just to realize that it will no "
+#~ "longer produce.  You gather the ramains and move on."
+#~ msgstr ""
+#~ "Du ser resterna av ett gammalt sågverk, bara för att inse att det kan "
+#~ "inte producera mer. Du samlar ihop resterna och går vidare."
+
+#~ msgid ""
+#~ "You send this letter back to the king,\"A month has passed and we have "
+#~ "not discovered the wizard Joseph. I only hope that we are able to locate "
+#~ "him in time to aid us in our struggle.\""
+#~ msgstr ""
+#~ "Du skickade detta brev tillbaka till kungen, \"En månad har gått och vi "
+#~ "har ännu inte hittat trollkarlen Joseph. Jag hoppas bara att vi kan hitta "
+#~ "honom i tid för att hjälpa oss i vår strid.\""
+
+#~ msgid "You should turn back."
+#~ msgstr "Du bör vända om."
+
+#~ msgid "You uncover a compass in the grass!"
+#~ msgstr "Du upptäcker en kompass i gräset!"
+
+#~ msgid "You've been warned!"
+#~ msgstr "Du har blivit varnad!"
+
+#~ msgid ""
+#~ "You've saved a group of miners from the dragons.  One of them approaches "
+#~ "you, \"Thank you so much for saving us!  We found this sulfer and sword "
+#~ "in the mine, then those dragons chased us!  I don't know how much longer "
+#~ "we could survive!\""
+#~ msgstr ""
+#~ "Du har räddat en grupp gruvarbetare från drakarna. En av dem går fram "
+#~ "till dig, \"Tack så mycket för att du har räddat oss! Vi hittade svavel "
+#~ "och detta svärd i gruvan innan dessa drakar jagade oss! Jag vet inte hur "
+#~ "mycket längre vi kunde överleva!\""
+
+#~ msgid ""
+#~ "You will need a stronger army than that, mortal, to step through this "
+#~ "portal."
+#~ msgstr ""
+#~ "Du behöver en starkare armé än det där för att passera denna portal, du "
+#~ "dödlige."
+
+#~ msgid "Blind "
+#~ msgstr "Blind "
+
+#~ msgid "game: also confirm autosave"
+#~ msgstr "spel: tillåt även autosparning"
+
+#~ msgid "world: save count monster after battle"
+#~ msgstr "Värld: Spara antalet monster efter strid"
+
+#~ msgid "world: only the first monster will attack (H2 bug)."
+#~ msgstr "Värld: Endast första monstret attackerar (H2 bug)."
+
+#~ msgid "castle: allow buy from well"
+#~ msgstr "Slott: Tillåt att köpa från brunnar"
+
+#~ msgid "heroes: learn new spells with day"
+#~ msgstr "hjältar: få nya besvärjelser varje dag"
+
+#~ msgid "battle: high objects are an obstacle for archers"
+#~ msgstr "strid: höga objekt är ett hinder för bågskyttar"
+
+#~ msgid "battle: magical creature resists (20%) the same magic"
+#~ msgstr "strid: Magiska varelser motstår (20%) av sin egen magi"
+
+#~ msgid "battle: skip increase +2 defense"
+#~ msgstr "Strid: Skippning höjer försvar med 2"
+
+#~ msgid "game: show SDL logo"
+#~ msgstr "spel: Visa SDL-loggan"
+
+#~ msgid "game: also use dynamic interface for castles"
+#~ msgstr "spel: Använd dynamiskt gränssnitt för slott"
+
+#~ msgid "pocketpc: hide cursor"
+#~ msgstr "pocketpc: Göm pekare"
+
+#~ msgid "pocketpc: tap mode"
+#~ msgstr "pocketpc: Knackläge"
+
+#~ msgid "pocketpc: drag&drop gamearea as scroll"
+#~ msgstr "pocketpc: Dra och släpp spelarea vid skroll"
+
+#~ msgid "pocketpc: low memory"
+#~ msgstr "pocketpc: Lågt minne"
 
 #~ msgid "Shoot %{monster} (%{count} shot(s) left)"
 #~ msgstr "Skjut %{monster} (%{count} skott kvar)"
@@ -12949,9 +9007,6 @@ msgstr "pocketpc: Lågt minne"
 
 #~ msgid "Allows you to draw streams by clicking and dragging."
 #~ msgstr "Låter dig rita stömmar genom att klicka och dra."
-
-#~ msgid "Road Mode"
-#~ msgstr "Vägläge"
 
 #~ msgid "Allows you to draw roads by clicking and dragging."
 #~ msgstr "Låter dig rita vägar genom att klicka och dra."
@@ -13084,11 +9139,11 @@ msgstr "pocketpc: Lågt minne"
 #~ "After regular growth, population of %{monter} increase on %{count} "
 #~ "percent!"
 #~ msgstr[0] ""
-#~ "Efter en vanlig ökning har beståndet av %{monster} fördubblats med %"
-#~ "{count} procent!"
+#~ "Efter en vanlig ökning har beståndet av %{monster} fördubblats med "
+#~ "%{count} procent!"
 #~ msgstr[1] ""
-#~ "Efter en vanlig ökning har beståndet av %{monster} fördubblats med %"
-#~ "{count} procent!"
+#~ "Efter en vanlig ökning har beståndet av %{monster} fördubblats med "
+#~ "%{count} procent!"
 
 #~ msgid "%{monster} population increases by +%{count}."
 #~ msgid_plural "%{monster} population increases by +%{count}."

--- a/files/lang/tr.po
+++ b/files/lang/tr.po
@@ -7,2636 +7,2880 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-10-23 10:54+0900\n"
+"POT-Creation-Date: 2021-07-01 15:11+0200\n"
 "PO-Revision-Date: 2009-12-08 00:41+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Turkish <tr@li.org>\n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: tr\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Launchpad-Export-Date: 2010-05-27 09:12+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: ../fheroes2/ai/ai_action.cpp:157 ../fheroes2/heroes/heroes_action.cpp:248
-msgid "Hero %{name} also got a %{count} experience."
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:221 ../fheroes2/resource/artifact.cpp:968
-msgid "View %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:227 ../fheroes2/army/army_bar.cpp:310
-msgid "Move or right click to redistribute %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:233 ../fheroes2/army/army_bar.cpp:301
-msgid "Combine %{name} armies"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:238 ../fheroes2/army/army_bar.cpp:292
-#: ../fheroes2/resource/artifact.cpp:980
-#: ../fheroes2/resource/artifact.cpp:1002
-msgid "Exchange %{name2} with %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:246 ../fheroes2/resource/artifact.cpp:988
-msgid "Select %{name}"
-msgstr ""
-
-#: ../fheroes2/army/army_bar.cpp:298 ../fheroes2/army/army_bar.cpp:307
-msgid "Cannot move last troop"
-msgstr ""
-
-#: ../fheroes2/army/army.cpp:85
 msgid ""
 "A few\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:86
 msgid ""
 "Several\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:87
 msgid ""
 "A pack of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:88
 msgid ""
 "Lots of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:89
 msgid ""
 "A horde of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:90
 msgid ""
 "A throng of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:91
 msgid ""
 "A swarm of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:92
 msgid ""
 "Zounds of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:93
 msgid ""
 "A legion of\n"
 "%{monster}"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Few"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Several"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Pack"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:102
 msgid "army|Lots"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Horde"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Throng"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Swarm"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Zounds"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:103
 msgid "army|Legion"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:925
 msgid "All %{race} troops +1"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:936
-msgid "Entire unit is undead, so morale does not apply."
-msgstr ""
-
-#: ../fheroes2/army/army.cpp:946
 msgid "Troops of 3 alignments -1"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:954
 msgid "Troops of 4 alignments -2"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:962
 msgid "Troops of 5 alignments -3"
 msgstr ""
 
-#: ../fheroes2/army/army.cpp:976
 msgid "Some undead in groups -1"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:752
+msgid "View %{name}"
+msgstr ""
+
+msgid "Move or right click to redistribute %{name}"
+msgstr ""
+
+msgid "Combine %{name} armies"
+msgstr ""
+
+msgid "Exchange %{name2} with %{name}"
+msgstr ""
+
+msgid "Select %{name}"
+msgstr ""
+
+msgid "Cannot move last troop"
+msgstr ""
+
+msgid "%{name} half the enemy troops!"
+msgstr ""
+
 msgid "Set auto battle off"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:757
 msgid "Set auto battle on"
 msgstr ""
 
-#: ../fheroes2/battle/battle_action.cpp:864
 msgid "spell failed!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:705
 msgid ""
 "The Sphere of Negation artifact is in effect for this battle, disabling all "
 "combat spells."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:714
 msgid "You have already cast a spell this round."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:720
-#: ../fheroes2/battle/battle_arena.cpp:768
 msgid "That spell will affect no one!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:739
 msgid "You may only summon one type of elemental per combat."
 msgstr ""
 
-#: ../fheroes2/battle/battle_arena.cpp:745
 msgid "There is no open space adjacent to your hero to summon an Elemental to."
 msgstr ""
 
-#: ../fheroes2/battle/battle_board.cpp:968
 msgid ""
 "The Moat reduces by -%{count} the defense skill of any unit and slows to "
 "half movement rate."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:50
-msgid "speed: %{speed}"
+msgid "Speed"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:165
+msgid "Speed: %{speed}"
+msgstr ""
+
+msgid "Auto Spell Casting"
+msgstr ""
+
+msgid "Grid"
+msgstr ""
+
+msgid "Shadow Movement"
+msgstr ""
+
+msgid "Shadow Cursor"
+msgstr ""
+
+msgid "On"
+msgstr ""
+
+msgid "Off"
+msgstr ""
+
 msgid "The enemy has surrendered!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:168
 msgid "The enemy has fled!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:170
-#: ../fheroes2/battle/battle_dialogs.cpp:256
 msgid "A glorious victory!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:175
-msgid "For valor in combat, %{name} receives %{exp} experience"
+msgid "For valor in combat, %{name} receives %{exp} experience."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:184
 msgid "The cowardly %{name} flees from battle."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:191
 msgid "%{name} surrenders to the enemy, and departs in shame."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:197
 msgid "Your force suffer a bitter defeat, and %{name} abandons your cause."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:249
 msgid "Your force suffer a bitter defeat."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:296
 msgid "Battlefield Casualties"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:300
 msgid "Attacker"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:312
 msgid "Defender"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:394
+msgid "You have captured an enemy artifact!"
+msgstr ""
+
+msgid "Necromancy!"
+msgstr ""
+
+msgid ""
+"Practicing the dark arts of necromancy, you are able to raise %{count} of "
+"the enemy's dead to return under your service as %{monster}."
+msgstr ""
+
 msgid "%{name} the %{race}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:401
-#: ../fheroes2/castle/castle_well.cpp:311
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:194
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:834
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Attack"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:406
-#: ../fheroes2/castle/castle_well.cpp:317
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:206
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:844
-#: ../fheroes2/heroes/skill.cpp:151
 msgid "Defense"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:411
-#: ../fheroes2/castle/castle_town.cpp:310
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:854
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:142
-#: ../fheroes2/heroes/heroes_meeting.cpp:292
 msgid "Spell Power"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:416
-#: ../fheroes2/castle/castle_town.cpp:319
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:864
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:147
-#: ../fheroes2/heroes/heroes_meeting.cpp:296 ../fheroes2/heroes/skill.cpp:151
 msgid "Knowledge"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:421
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:276
 msgid "Morale"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:426
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:286 ../fheroes2/heroes/skill.cpp:338
 msgid "Luck"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:431
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:874
-#: ../fheroes2/heroes/heroes_indicator.cpp:247
 msgid "Spell Points"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
-#: ../fheroes2/gui/interface_buttons.cpp:189
+msgid "Hero's Options"
+msgstr ""
+
 msgid "Cast Spell"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:485
-msgid ""
-"Cast a magical spell. You may only cast one spell per combat round. The "
-"round is reset when every creature has had a turn"
-msgstr ""
-
-#: ../fheroes2/battle/battle_dialogs.cpp:488
 msgid "Retreat"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:488
+msgid "Surrender"
+msgstr ""
+
+msgid "Cancel"
+msgstr ""
+
+msgid "Hero Screen"
+msgstr ""
+
+msgid ""
+"Cast a magical spell. You may only cast one spell per combat round. The "
+"round is reset when every creature has had a turn."
+msgstr ""
+
 msgid ""
 "Retreat your hero, abandoning your creatures. Your hero will be available "
 "for you to recruit again, however, the hero will have only a novice hero's "
 "forces."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:491
-msgid "Surrender"
-msgstr ""
-
-#: ../fheroes2/battle/battle_dialogs.cpp:491
 msgid ""
 "Surrendering costs gold. However if you pay the ransom, the hero and all of "
 "his or her surviving creatures will be available to recruit again."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:166
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:227
-msgid "Cancel"
+msgid "Open Hero Screen to view full information about the hero."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:494
 msgid "Return to the battle."
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:549
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:438
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:497
 msgid "Not enough gold (%{gold})"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:564
 msgid "%{name} states:"
 msgstr ""
 
-#: ../fheroes2/battle/battle_dialogs.cpp:569
 msgid ""
-"I will accept your surrender and grant you and your troops safe passage for "
-"the price of %{price} gold."
+"\"I will accept your surrender and grant you and your troops safe passage "
+"for the price of %{price} gold.\""
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:613
-#: ../fheroes2/battle/battle_interface.cpp:1401
 msgid "View %{monster} info."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1409
 msgid "Shoot %{monster}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1431
 msgid "Attack %{monster}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Fly %{monster} here."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1443
 msgid "Move %{monster} here."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1449
-#: ../fheroes2/battle/battle_interface.cpp:1538
 msgid "Turn %{turn}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1475
 msgid "Teleport Here"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1479
 msgid "Invalid Teleport Destination"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1485
 msgid "Cast %{spell} on %{monster}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1495
 msgid "Cast %{spell}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1501
 msgid "Select Spell Target"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1674
-msgid "Spell cast"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:1686
 msgid "View Ballista Info"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1699
-#: ../fheroes2/battle/battle_tower.cpp:53
 msgid "Ballista"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1712
 msgid "Auto combat"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1719
 msgid "Customize system options."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1727
 msgid "Wait this unit"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1734
 msgid "Skip this unit"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1742
-#: ../fheroes2/battle/battle_interface.cpp:1774
-msgid "Hero's Options"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:1753
-#: ../fheroes2/battle/battle_interface.cpp:1785
 msgid "View Opposing Hero"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Hide logs"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1840
 msgid "Show logs"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:1878
 msgid "%{color} cast spell: %{spell}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2202
 msgid "%{name} skipping turn"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2203
-msgid ", and get +2 defense"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:2206
 msgid "%{name} waiting turn"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2343
 msgid "%{attacker} do %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2497
 msgid "Moved %{monster}: %{src}, %{dst}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2612
+msgid "Moved %{monster}"
+msgstr ""
+
 msgid "The %{name} resist the spell!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2625
 msgid "%{name} casts %{spell} on the %{troop}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2630
 msgid "%{name} casts %{spell}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2751
-msgid "The %{spell} spell does %{damage} damage to all undead creatures."
+msgid "The %{spell} does %{damage} damage to one undead creature."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2754
-msgid "The %{spell} spell does %{damage} damage to all living creatures."
+msgid "The %{spell} does %{damage} damage to all undead creatures."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2756
+msgid "The %{spell} does %{damage} damage, %{count} creatures perish."
+msgstr ""
+
 msgid "The %{spell} does %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2797
+msgid "The %{spell} does %{damage} damage to one living creature."
+msgstr ""
+
+msgid "The %{spell} does %{damage} damage to all living creatures."
+msgstr ""
+
 msgid "The Unicorns attack blinds the %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2798
 msgid "The Medusas gaze turns the %{name} to stone!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2800
 msgid "The Mummies' curse falls upon the %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2801
 msgid "The %{name} are paralyzed by the Cyclopes!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2802
 msgid "The Archmagi dispel all good spells on your %{name}!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2820
-msgid "Good luck shines on the  %{attacker}"
+msgid "Good luck shines on the %{attacker}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2872
 msgid "Bad luck descends on the %{attacker}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2884
 msgid "High morale enables the %{monster} to attack again."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2891
 msgid "Low morale causes the %{monster} to freeze in panic."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:2944
-msgid "Tower do %{damage} damage."
+msgid "%{tower} does %{damage} damage."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:3257
 msgid "MirrorImage created"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:3798
-msgid "MirrorImage ended"
+msgid "The mirror image is destroyed!"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4089
 msgid "Break auto battle?"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4138
 msgid "No spells to cast."
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4147
 msgid "Are you sure you want to retreat?"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4155
 msgid "Retreat disabled"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4169
-msgid "You don't have enough gold!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_interface.cpp:4180
 msgid "Surrender disabled"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4235
 msgid "Damage: %{min} - %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_interface.cpp:4248
 msgid "Perish: %{min} - %{max}"
 msgstr ""
 
-#: ../fheroes2/battle/battle_main.cpp:190
-msgid "You have captured an enemy artifact!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_main.cpp:241
 msgid ""
-"Through eagle-eyed observation, %{name} is able to learn the magic spell %"
-"{spell}."
+"Through eagle-eyed observation, %{name} is able to learn the magic spell "
+"%{spell}."
 msgstr ""
 
-#: ../fheroes2/battle/battle_main.cpp:280
-msgid ""
-"Practicing the dark arts of necromancy, you are able to raise %{count} of "
-"the enemy's dead to return under your service as %{monster}"
-msgstr ""
-
-#: ../fheroes2/battle/battle_tower.cpp:47 ../fheroes2/castle/castle.cpp:466
 msgid "Left Turret"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:48 ../fheroes2/castle/castle.cpp:467
 msgid "Right Turret"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:115
 msgid "The %{name} fires with the strength of %{count} Archers"
 msgstr ""
 
-#: ../fheroes2/battle/battle_tower.cpp:116
 msgid "each with a +%{attack} bonus to their attack skill."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:863
-msgid "%{name} half the enemy troops!"
-msgstr ""
-
-#: ../fheroes2/battle/battle_troop.cpp:950
 msgid ""
 "The %{artifact} artifact is in effect for this battle, disabling %{spell} "
 "spell."
 msgstr ""
 
-#: ../fheroes2/battle/battle_troop.cpp:1598
 msgid "%{count} %{name} rise(s) from the dead!"
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:258
+msgid "Sorceress Guild"
+msgstr ""
+
+msgid "Necromancer Guild"
+msgstr ""
+
+msgid "Dragon Alliance"
+msgstr ""
+
+msgid "Elven Alliance"
+msgstr ""
+
+msgid "Wayward Son"
+msgstr ""
+
+msgid "Uncle Ivan"
+msgstr ""
+
+msgid "Force of Arms"
+msgstr ""
+
+msgid "Annexation"
+msgstr ""
+
+msgid "Save the Dwarves"
+msgstr ""
+
+msgid "Carator Mines"
+msgstr ""
+
+msgid "Turning Point"
+msgstr ""
+
+msgid "The Gauntlet"
+msgstr ""
+
+msgid "The Crown"
+msgstr ""
+
+msgid "Corlagon's Defense"
+msgstr ""
+
+msgid "Final Justice"
+msgstr ""
+
+msgid "First Blood"
+msgstr ""
+
+msgid "Barbarian Wars"
+msgstr ""
+
+msgid "Necromancers"
+msgstr ""
+
+msgid "Slay the Dwarves"
+msgstr ""
+
+msgid "Rebellion"
+msgstr ""
+
+msgid "Dragon Master"
+msgstr ""
+
+msgid "Country Lords"
+msgstr ""
+
+msgid "Greater Glory"
+msgstr ""
+
+msgid "Apocalypse"
+msgstr ""
+
+msgid "Uprising"
+msgstr ""
+
+msgid "Island of Chaos"
+msgstr ""
+
+msgid "Arrow's Flight"
+msgstr ""
+
+msgid "The Abyss"
+msgstr ""
+
+msgid "The Giant's Pass"
+msgstr ""
+
+msgid "Aurora Borealis"
+msgstr ""
+
+msgid "Betrayal's End"
+msgstr ""
+
+msgid "Corruption's Heart"
+msgstr ""
+
+msgid "Conquer and Unify"
+msgstr ""
+
+msgid "Border Towns"
+msgstr ""
+
+msgid "The Wayward Son"
+msgstr ""
+
+msgid "Crazy Uncle Ivan"
+msgstr ""
+
+msgid "The Southern War"
+msgstr ""
+
+msgid "Ivory Gates"
+msgstr ""
+
+msgid "The Elven Lands"
+msgstr ""
+
+msgid "The Epic Battle"
+msgstr ""
+
+msgid "The Shrouded Isles"
+msgstr ""
+
+msgid "The Eternal Scrolls"
+msgstr ""
+
+msgid "Power's End"
+msgstr ""
+
+msgid "Fount of Wizardry"
+msgstr ""
+
+msgid "Stranded"
+msgstr ""
+
+msgid "Pirate Isles"
+msgstr ""
+
+msgid "King and Country"
+msgstr ""
+
+msgid "Blood is Thicker"
+msgstr ""
+
+msgid ""
+"Roland needs you to defeat the lords near his castle to begin his war of "
+"rebellion against his brother.  They are not allied with each other, so they "
+"will spend most of their time fighting with one another.  Victory is yours "
+"when you have defeated all of their castles and heroes."
+msgstr ""
+
+msgid ""
+"The local lords refuse to swear allegiance to Roland, and must be subdued. "
+"They are wealthy and powerful, so be prepared for a tough fight. Capture all "
+"enemy castles to win."
+msgstr ""
+
+msgid ""
+"Your task is to defend the Dwarves against Archibald's forces. Capture all "
+"of the enemy towns and castles to win, and be sure not to lose all of the "
+"dwarf towns at once, or the enemy will have won."
+msgstr ""
+
+msgid ""
+"You will face four allied enemies in a straightforward fight for resource "
+"and treasure. Capture all of the enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Your enemies are allied against you and start close by, so be ready to come "
+"out fighting. You will need to own all four castles in this small valley to "
+"win."
+msgstr ""
+
+msgid ""
+"The Sorceress' guild of Noraston has requested Roland's aid against an "
+"attack from Archibald's allies. Capture all of the enemy castles to win, and "
+"don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy "
+"castle on an island in the ocean.)"
+msgstr ""
+
+msgid ""
+"Gather as large an army as possible and capture the enemy castle within 8 "
+"weeks. You are opposed by only one enemy, but must travel a long way to get "
+"to the enemy castle. Any troops you have in your army at the end of this "
+"scenario will be with you in the final battle."
+msgstr ""
+
+msgid ""
+"Find the Crown before Archibald's heroes find it. Roland will need the Crown "
+"for the final battle against Archibald."
+msgstr ""
+
+msgid ""
+"Three allied enemies stand before you and victory, including Lord Corlagon. "
+"Roland is in a castle to the northwest, and you will lose if he falls to the "
+"enemy. Remember that capturing Lord Corlagon will ensure that he will not "
+"fight against you in the final scenario."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Archibald to end the war!"
+msgstr ""
+
+msgid ""
+"King Archibald requires you to defeat the three enemies in this region.  "
+"They are not allied with one another, so they will spend most of their "
+"energy fighting amongst themselves.  You will win when you own all of the "
+"enemy castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"You must unify the barbarian tribes of the north by conquering them. As in "
+"the previous mission, the enemy is not allied against you, but they have "
+"more resources at their disposal. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+
+msgid ""
+"Do-gooder wizards have taken the Necromancers' castle. You must retake it to "
+"achieve victory. Remember that while you start with a powerful army, you "
+"have no castle and must take one within 7 days, or lose this battle. (Hint: "
+"The nearest castle is to the southeast.)"
+msgstr ""
+
+msgid ""
+"The dwarves need conquering before they can interfere in King Archibald's "
+"plans. Roland's forces have more than one hero and many towns to start with, "
+"so be ready for attack from multiple directions. You must capture all of the "
+"enemy towns and castles to claim victory."
+msgstr ""
+
+msgid ""
+"You must put down a peasant revolt led by Roland's forces. All are allied "
+"against you, but you have Lord Corlagon, an experienced hero, to help you. "
+"Capture all enemy castles to win."
+msgstr ""
+
+msgid ""
+"There are two enemies allied against you in this mission. Both are well "
+"armed and seek to evict you from their island. Avoid them and capture Dragon "
+"City to win"
+msgstr ""
+
+msgid ""
+"Your orders are to conquer the country lords that have sworn to serve "
+"Roland. All of the enemy castles are unified against you. Since you start "
+"without a castle, you must hurry to capture one before the end of the week. "
+"Capture all enemy castles for victory."
+msgstr ""
+
+msgid ""
+"Find the Crown before Roland's heroes find it. Archibald will need the Crown "
+"for the final battle against Roland."
+msgstr ""
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Roland to win the war, and be sure "
+"not to lose Archibald in the fight!"
+msgstr ""
+
+msgid ""
+"Subdue the unruly local lords in order to provide the Empire with facilities "
+"to operate in this region."
+msgstr ""
+
+msgid ""
+"Eliminate all oposition in this area. Then the first piece of the artifact "
+"will be yours."
+msgstr ""
+
+msgid ""
+"The sorceresses to the northeast are rebelling! For the good of the empire "
+"you must quash their feeble uprising on your way to the mountains."
+msgstr ""
+
+msgid ""
+"Having prepared for your arrival, Kraeger has arranged for a force of "
+"necromancers to thwart your quest. You must capture the castle of Scabsdale "
+"before the first day of the third week, or the Necromancers will be too "
+"strong for you."
+msgstr ""
+
+msgid ""
+"The barbarian despot in this area is, as yet, ignorant of your presence. "
+"Quickly, build up your forces before you are discovered and attacked! Secure "
+"the region by subduing all enemy forces."
+msgstr ""
+
+msgid ""
+"The Empire is weak in this region. You will be unable to completely subdue "
+"all forces in this area, so take what you can before reprisal strikes. "
+"Remember, your true goal is to claim the Helmet of Anduran."
+msgstr ""
+
+msgid "For the good of the Empire, eliminate Kraeger."
+msgstr ""
+
+msgid ""
+"At last, you have the opportunity and the facilities to rid the Empire of "
+"the necromancer's evil. Eradicate them completely, and you will be sung as a "
+"hero for all time."
+msgstr ""
+
+msgid ""
+"Conquer and unite all the enemy tribes. Don't lose the hero Jarkonas, the "
+"forefather of all descendants."
+msgstr ""
+
+msgid ""
+"Your rival, the Kingdom of Harondale, is attacking weak towns on your "
+"border! Recover from their first strike and crush them completely!"
+msgstr ""
+
+msgid ""
+"Find your wayward son Joseph who is rumored to be living in the desolate "
+"lands. Do it before the first day of the third month or it will be of no "
+"help to your family."
+msgstr ""
+
+msgid ""
+"Rescue your crazy uncle Ivan. Find him before the first day of the fourth "
+"month or it will be no help to your kingdom."
+msgstr ""
+
+msgid ""
+"Destroy the barbarians who are attacking the southern border of your "
+"kingdom! Recover your fallen towns, and then invade the jungle kingdom. "
+"Leave no enemy standing."
+msgstr ""
+
+msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
+msgstr ""
+
+msgid ""
+"Gain the favor of the elves. They will not allow trees to be chopped down, "
+"so they will send you wood every 2 weeks. You must complete your mission "
+"before the first day of the seventh month, or the kingdom will surely fall."
+msgstr ""
+
+msgid ""
+"This is the final battle against your rival kingdom of Harondale. Eliminate "
+"everyone, and don't lose the hero Jarkonas VI."
+msgstr ""
+
+msgid ""
+"Your mission is to vanquish the warring mages in the magical Shrouded Isles. "
+"The completion of this task will give you a fighting chance against your "
+"rivals."
+msgstr ""
+
+msgid ""
+"The location of the great library has been dicovered! You must make your way "
+"to it, and reclaim the city of Chronos in which it lies."
+msgstr ""
+
+msgid ""
+"Find the Orb of negation, which is said to be buried in this land. There are "
+"clues inscribed on stone obelisks which will help lead you to your price. "
+"Find the orb before the first day of the sixth month, or your rivals will "
+"surely have gotten to the fount before you."
+msgstr ""
+
+msgid ""
+"You must take control of the castle of Magic, where the fount of wizardry "
+"lies. Do this and your victory will be supreme."
+msgstr ""
+
+msgid ""
+"Capture the town on the island off the southeast shore in order to construct "
+"a boat and travel back towards the mainland. Do not lose the hero Gallavant."
+msgstr ""
+
+msgid ""
+"Find and defeat Martine, the pirate leader, who resides in Pirates Cove. Do "
+"not lose Gallavant or your quest will be over."
+msgstr ""
+
+msgid ""
+"Eliminate all the other forces who oppose the rule of Lord Alberon. "
+"Gallavant must not die."
+msgstr ""
+
+msgid ""
+"Overthrow the entrenched monarchy of Lord Alberon, and claim all the land in "
+"your name. Gallavant must not die."
+msgstr ""
+
+msgid " bane"
+msgstr ""
+
+msgid " alliance"
+msgstr ""
+
+msgid "Carry-over forces"
+msgstr ""
+
+msgid " bonus"
+msgstr ""
+
+msgid " defeated"
+msgstr ""
+
+msgid "Thunder Mace"
+msgstr ""
+
+msgid "Minor Scroll"
+msgstr ""
+
+msgid "Dragon Sword"
+msgstr ""
+
+msgid "Breastplate"
+msgstr ""
+
+msgid "Fibzin Medal"
+msgstr ""
+
+msgid "Mage's ring"
+msgstr ""
+
+msgid "Defender Helm"
+msgstr ""
+
+msgid "Power Axe"
+msgstr ""
+
+msgid "Summon Earth"
+msgstr ""
+
 msgid "The %{building} produces %{monster}."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:505
 msgid "Requires:"
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:597
 msgid "Cannot build. Already built here this turn."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:601
 msgid "For this action it is necessary first to build a castle."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:623
 msgid "Cannot build %{name} because castle is too far from water."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:631
-msgid "Cannot afford %{name}"
+msgid "Cannot afford %{name}."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:636
-msgid "%{name} is already built"
+msgid "%{name} is already built."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:641
-msgid "Cannot build %{name}"
+msgid "Cannot build %{name}."
 msgstr ""
 
-#: ../fheroes2/castle/buildinginfo.cpp:646
-msgid "Build %{name}"
+msgid "Build %{name}."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Thieves' Guild"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Tavern"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Shipyard"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Well"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:466
 msgid "Statue"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467
-#: ../fheroes2/dialog/dialog_marketplace.cpp:212
 msgid "Marketplace"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Moat"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467 ../fheroes2/maps/mp2.cpp:391
 msgid "Castle"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Tent"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Captain's Quarters"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:467
 msgid "Mage Guild, Level 1"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 2"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 3"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 4"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:468
 msgid "Mage Guild, Level 5"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Farm"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Garbage Heap"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Crystal Garden"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Waterfall"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Orchard"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:470
 msgid "Skull Pile"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Fortifications"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Coliseum"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Rainbow"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Dungeon"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Library"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:472
 msgid "Storm"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:498
 msgid "Thatched Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Treehouse"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:441
 msgid "Cave"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475
 msgid "Habitat"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:475 ../fheroes2/maps/mp2.cpp:431
 msgid "Excavation"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:477
 msgid "Archery Range"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Stick Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476
 msgid "Cottage"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Crypt"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/castle/castle.cpp:483
 msgid "Pen"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:476 ../fheroes2/maps/mp2.cpp:371
 msgid "Graveyard"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Blacksmith"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Den"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:484
 msgid "Nest"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477
 msgid "Foundry"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:477 ../fheroes2/castle/castle.cpp:480
-#: ../fheroes2/castle/castle.cpp:487 ../fheroes2/maps/mp2.cpp:427
-#: ../fheroes2/resource/maps_text.cpp:521
 msgid "Pyramid"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Armory"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Adobe"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Stonehenge"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Maze"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478 ../fheroes2/castle/castle.cpp:485
 msgid "Cliff Nest"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:478
 msgid "Mansion"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Jousting Arena"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Bridge"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
 msgid "Fenced Meadow"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479 ../fheroes2/castle/castle.cpp:486
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Swamp"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Ivory Tower"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:479
 msgid "Mausoleum"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cathedral"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Red Tower"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Green Tower"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480
 msgid "Cloud Castle"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:480 ../fheroes2/castle/castle.cpp:487
 msgid "Laboratory"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:483 ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Archery Range"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Stick Hut"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Cottage"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:483
 msgid "Upg. Graveyard"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Blacksmith"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Foundry"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:484
 msgid "Upg. Pyramid"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Armory"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Adobe"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Stonehenge"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Maze"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:485
 msgid "Upg. Mansion"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Jousting Arena"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Bridge"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Ivory Tower"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:486
 msgid "Upg. Mausoleum"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cathedral"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:487
 msgid "Upg. Cloud Castle"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:488
 msgid "Black Tower"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:490
 msgid "Shrine"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:552
 msgid ""
 "The Thieves' Guild provides information on enemy players. Thieves' Guilds "
-"can also provide scouting information on enemy towns."
+"can also provide scouting information on enemy towns. Additional Guilds "
+"provide more information."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:553
 msgid "The Tavern increases morale for troops defending the castle."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:554
 msgid "The Shipyard allows ships to be built."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:555
 msgid ""
 "The Well increases the growth rate of all dwellings by %{count} creatures "
 "per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:556
 msgid "The Statue increases your town's income by %{count} per day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:557
 msgid "The Left Turret provides extra firepower during castle combat."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:558
 msgid "The Right Turret provides extra firepower during castle combat."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:559
 msgid ""
 "The Marketplace can be used to convert one type of resource into another. "
 "The more marketplaces you control, the better the exchange rate."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:560
 msgid ""
 "The Moat slows attacking units. Any unit entering the moat must end its turn "
 "there and becomes more vulnerable to attack."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:561
 msgid ""
 "The Castle improves town defense and increases income to %{count} gold per "
 "day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:562
 msgid ""
 "The Tent provides workers to build a castle, provided the materials and the "
 "gold are available."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:563
 msgid ""
 "The Captain's Quarters provides a captain to assist in the castle's defense "
 "when no hero is present."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:564
 msgid ""
 "The Mage Guild allows heroes to learn spells and replenish their spell "
 "points."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:567
 msgid "The Farm increases production of Peasants by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:568
 msgid "The Garbage Heap increases production of Goblins by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:569
 msgid ""
 "The Crystal Garden increases production of Sprites by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:570
 msgid "The Waterfall increases production of Centaurs by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:571
 msgid "The Orchard increases production of Halflings by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:572
 msgid "The Skull Pile increases production of Skeletons by %{count} per week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:575
 msgid ""
 "The Fortifications increase the toughness of the walls, increasing the "
 "number of turns it takes to knock them down."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:576
 msgid ""
 "The Coliseum provides inspiring spectacles to defending troops, raising "
 "their morale by two during combat."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:577
 msgid "The Rainbow increases the luck of the defending units by two."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:578
 msgid "The Dungeon increases the income of the town by %{count} / day."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:579
 msgid ""
 "The Library increases the number of spells in the Guild by one for each "
 "level of the guild."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:580
 msgid "The Storm adds +2 to the power of spells of a defending spell caster."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:582
 msgid ""
 "The Shrine increases the necromancy skill of all your necromancers by 10 "
 "percent."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:632
 msgid "Cannot recruit - you already recruit hero in current week."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:645
 msgid "Cannot recruit - guest to guard automove error."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:651
 msgid "Cannot recruit - you already have a Hero in this town."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:659
 msgid "Cannot recruit - you have too many Heroes."
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:665
 msgid "Cannot afford a Hero"
 msgstr ""
 
-#: ../fheroes2/castle/castle.cpp:756
 msgid "There is no room in the garrison for this army."
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:272
+msgid "Recruit %{name}"
+msgstr ""
+
 msgid "Month: %{month}, Week: %{week}, Day: %{day}"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:393
-#: ../fheroes2/castle/castle_dialog.cpp:396
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:387
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:186
-msgid "Income:"
+msgid "Income"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 msgid "Join Error"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:436
 msgid "Army is full"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
+msgid ""
+"You must purchase a spell book to use the mage guild, but you currently have "
+"no room for a spell book. Try giving one of your artifacts to another hero."
+msgstr ""
+
 msgid "Town"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:612
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:270
 msgid "This town may not be upgraded to a castle."
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit castle"
+msgid "Exit Castle"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:727
-msgid "Exit town"
+msgid "Exit Town"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:730
-msgid "Show income"
+msgid "Show Income"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:734
 msgid "Show previous town"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:738
 msgid "Show next town"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:741
 msgid "Swap Heroes"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:744
 msgid "Meeting Heroes"
 msgstr ""
 
-#: ../fheroes2/castle/castle_dialog.cpp:749
 msgid "View Hero"
 msgstr ""
 
-#: ../fheroes2/castle/castle_mageguild.cpp:150
+msgid "The above spells are available here."
+msgstr ""
+
 msgid "The above spells have been added to your book."
 msgstr ""
 
-#: ../fheroes2/castle/castle_tavern.cpp:39
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:748
 msgid "A generous tip for the barkeep yields the following rumor:"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:54
 msgid "Recruit Hero"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:59
-msgid "%{name} is a level %{value} %{race}"
+msgid "%{name} is a level %{value} %{race} "
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with %{count} artifacts"
+msgid "with %{count} artifacts."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:65
-msgid " with one artifact"
+msgid "with 1 artifact."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:283
-#: ../fheroes2/heroes/heroes_dialog.cpp:108
+msgid "without artifacts."
+msgstr ""
+
 msgid ""
 "'Spread' combat formation spreads your armies from the top to the bottom of "
 "the battlefield, with at least one empty space between each army."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:284
 msgid ""
 "'Grouped' combat formation bunches your army toget her in the center of your "
 "side of the battlefield."
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:292
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:132
-#: ../fheroes2/heroes/heroes_meeting.cpp:284
 msgid "Attack Skill"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:301
-#: ../fheroes2/dialog/dialog_skillinfo.cpp:137
-#: ../fheroes2/heroes/heroes_meeting.cpp:288
 msgid "Defense Skill"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:487
-#: ../fheroes2/heroes/heroes_dialog.cpp:334
 msgid "Spread Formation"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:489
-#: ../fheroes2/heroes/heroes_dialog.cpp:337
 msgid "Grouped Formation"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:540
-#: ../fheroes2/castle/castle_town.cpp:553
 msgid "Recruit %{name} the %{race}"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:561
 msgid "Set garrison combat formation to 'Spread'"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:564
 msgid "Set garrison combat formation to 'Grouped'"
 msgstr ""
 
-#: ../fheroes2/castle/castle_town.cpp:567
+msgid "Exit Castle Options"
+msgstr ""
+
 msgid "Castle Options"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:158
-msgid "Buy Monsters:"
+msgid "Not enough resources to buy monsters."
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:221
+msgid "No monsters available for purchase."
+msgstr ""
+
+msgid "Buy Monsters"
+msgstr ""
+
 msgid "Town Population Information and Statistics"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:323
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:231
 msgid "Damage"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:329
 msgid "HP"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:335
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:266
-msgid "Speed"
-msgstr ""
-
-#: ../fheroes2/castle/castle_well.cpp:351
 msgid "Growth"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:355
 msgid "week"
 msgstr ""
 
-#: ../fheroes2/castle/castle_well.cpp:361
-#: ../fheroes2/kingdom/kingdom_overview.cpp:479
 msgid "Available"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:89
 msgid "View the entire world."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:90
 msgid "View the obelisk puzzle."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:91
 msgid "View information on the scenario you are currently playing."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:92
 msgid "Dig for the Ultimate Artifact."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_adventure.cpp:93
 msgid "Exit this menu without doing anything."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_arena.cpp:48
+msgid "Arena"
+msgstr ""
+
 msgid ""
 "You enter the arena and face a pack of vicious lions. You handily defeat "
 "them, to the wild cheers of the crowd.  Impressed by your skill, the aged "
 "trainer of gladiators agrees to train you in a skill of your choice."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:154
-msgid ""
-"Your troops can be upgraded, but it will cost you %{ratio} times the "
-"difference in cost for each troop, rounded up to next highest number. Do you "
-"wish to upgrade them?"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:155
 msgid ""
 "Your troops can be upgraded, but it will cost you dearly. Do you wish to "
 "upgrade them?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:166
 msgid "Are you sure you want to dismiss this army?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots Left"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:218
 msgid "Shots"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:244
 msgid "Hit Points"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:255
 msgid "Hit Points Left"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:379
+msgid "Followers"
+msgstr ""
+
 msgid ""
-"The creature is swayed by your diplomatic tongue, and offers to join your "
+"A group of %{monster} with a desire for greater glory wish to join you.\n"
+"Do you accept?"
+msgstr ""
+
+msgid ""
+"The %{monster} is swayed by your diplomatic tongue, and offers to join your "
 "army for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:382
 msgid ""
 "The creatures are swayed by your diplomatic\n"
 "tongue, and make you an offer:\n"
 " \n"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:385
 msgid ""
 "%{offer} of the %{total} %{monster} will join your army, and the rest will "
 "leave you alone, for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:387
 msgid ""
 "All %{offer} of the %{monster} will join your army for the sum of %{gold} "
 "gold.\n"
 "Do you accept?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:401
 msgid "(Rate: %{percent})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_armyinfo.cpp:451
-msgid ""
-"Not room in\n"
-"the garrison"
+msgid "No room in"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:48
+msgid "the garrison"
+msgstr ""
+
 msgid "Build a new ship:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_buyboat.cpp:63
 msgid "Resource cost:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:40
-msgid "For the QVGA version is not available."
+msgid "Load Game"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:62
+msgid "No save files to load."
+msgstr ""
+
+msgid "New Game"
+msgstr ""
+
+msgid "Start a single or multi-player game."
+msgstr ""
+
+msgid "Load a previously saved game."
+msgstr ""
+
+msgid "Save Game"
+msgstr ""
+
+msgid "Save the current game."
+msgstr ""
+
+msgid "Quit"
+msgstr ""
+
+msgid "Quit out of Free Heroes of Might and Magic II."
+msgstr ""
+
 msgid ""
 "Map\n"
 "Difficulty"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:65
 msgid ""
 "Game\n"
 "Difficulty"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:68
 msgid "Rating"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:71
 msgid "Map Size"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:89
-#: ../fheroes2/system/players.cpp:691
 msgid "Opponents"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:92
-#: ../fheroes2/system/players.cpp:695
 msgid "Class"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:100
 msgid ""
 "Victory\n"
 "Conditions"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_gameinfo.cpp:106
 msgid ""
 "Loss\n"
 "Conditions"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:167
 msgid "You cannot select %{resource}!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_giftresources.cpp:173
 msgid "Select count %{resource}:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:200
 msgid "Set Guardian"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_guardian.cpp:236
-#: ../fheroes2/dialog/dialog_guardian.cpp:292
 msgid "Your army too big!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:34
-#: ../fheroes2/dialog/dialog_levelup.cpp:44
-#: ../fheroes2/dialog/dialog_levelup.cpp:73
 msgid "%{name} has gained a level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:36
-#: ../fheroes2/dialog/dialog_levelup.cpp:46
-#: ../fheroes2/dialog/dialog_levelup.cpp:75
-msgid "%{skill} Skill +1"
+msgid "%{skill} +1"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:51
 msgid "You have learned %{skill}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:93
 msgid "You may learn either:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_levelup.cpp:96
 msgid "or"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:66
 msgid ""
 "Please inspect our fine wares. If you feel like offering a trade, click on "
 "the items you wish to trade with and for."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:104
 msgid ""
 "You have received quite a bargain. I expect to make no profit on the deal. "
 "Can I interest you in any of my other wares?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:130
 msgid "I can offer you %{count} for 1 unit of %{resfrom}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:136
 msgid "I can offer you 1 unit of %{resto} for %{count} units of %{resfrom}."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:164
 msgid "Qty to trade"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:235
+msgid "Trading Post"
+msgstr ""
+
 msgid "Your Resources"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:257
 msgid "Available Trades"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_marketplace.cpp:573
 msgid "n/a"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:77
-msgid "guarded by %{count} of %{monster}"
+msgid "guarded by %{count} %{monster}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:149
 msgid "(available: %{count})"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:181
 msgid "already learned"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:205
 msgid "already knows this skill"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:212
 msgid "already has max skills"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:260
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:276
 msgid "(already visited)"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:227
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:239
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:249
 msgid "(not visited)"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:296
+msgid "Road"
+msgstr ""
+
+msgid "(digging ok)"
+msgstr ""
+
+msgid "(no digging)"
+msgstr ""
+
 msgid "penalty: %{cost}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:382
-msgid "Unchartered Territory"
+msgid "Uncharted Territory"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:635
 msgid "Defenders:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:674
-#: ../fheroes2/heroes/heroes_indicator.cpp:125
-#: ../fheroes2/heroes/heroes_indicator.cpp:171
 msgid "None"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:756
-msgid "%{name} ( Level %{level} )"
+msgid "Unknown"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_quickinfo.cpp:884
+msgid "%{name} (Level %{level})"
+msgstr ""
+
 msgid "Move Points"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:40
-#: ../fheroes2/dialog/dialog_recrut.cpp:579
 msgid "Available: %{count}"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_recrut.cpp:101
-msgid "Cost per troop:"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:107
-#: ../fheroes2/dialog/dialog_recrut.cpp:506
-msgid "Recruit %{name}"
-msgstr ""
-
-#: ../fheroes2/dialog/dialog_recrut.cpp:210
 msgid "Number to buy:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:314
 msgid "How many troops to move?"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectcount.cpp:358
 msgid "Fast separation into slots:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:180
 msgid "File to Save:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:186
 msgid "File to Load:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:302
 msgid "Are you sure you want to delete file:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectfile.cpp:305
 msgid "Warning!"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:144
-msgid "Maps Difficulty:"
+msgid "Map difficulty:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
+msgid "No maps exist at that size"
+msgstr ""
+
 msgid "Small Maps"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:300
-msgid "View only maps of size small (36x36)."
+msgid "View only maps of size small (36 x 36)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
 msgid "Medium Maps"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:302
-msgid "View only maps of size medium (72x72)."
+msgid "View only maps of size medium (72 x 72)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
 msgid "Large Maps"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:304
-msgid "View only maps of size large (108x108)."
+msgid "View only maps of size large (108 x 108)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
 msgid "Extra Large Maps"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:306
-msgid "View only maps of size extra large (144x144)."
+msgid "View only maps of size extra large (144 x 144)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "All Maps"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:308
 msgid "View all maps, regardless of size."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
 msgid "Players Icon"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:310
 msgid ""
-"Indicates how many players total are in the EditScenario. Any positions not "
+"Indicates how many players total are in the scenario. Any positions not "
 "occupied by humans will be occupied by computer players."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
 msgid "Size Icon"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:312
 msgid ""
-"Indicates whether the maps is small (36x36), medium (72x72), large "
-"(108x108), or extra large (144x144)."
+"Indicates whether the map\n"
+"is small (36 x 36), medium\n"
+"(72 x 72), large (108 x 108),\n"
+"or extra large (144 x 144)."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "Selected Name"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:314
 msgid "The name of the currently selected map."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid "Selected Map Difficulty"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:332
 msgid ""
 "The map difficulty of the currently selected map.  The map difficulty is "
-"determined by the EditScenario designer. More difficult maps might include "
-"more or stronger enemies, fewer resources, or other special conditions "
-"making things tougher for the human player."
+"determined by the scenario designer. More difficult maps might include more "
+"or stronger enemies, fewer resources, or other special conditions making "
+"things tougher for the human player."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "Selected Description"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:334
 msgid "The description of the currently selected map."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
-msgid "OK"
+msgid "Okay"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:336
 msgid "Accept the choice made."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:364
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose all your heroes and towns."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:365
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific town."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:366
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Lose a specific hero."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:367
 msgid "Run out of time. Fail to win by a certain point."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:370
 msgid "Loss Condition"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:379
 msgid "Defeat all enemy heroes and towns."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:380
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Capture a specific town."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:381
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat a specific hero."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:382
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Find a specific artifact."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:383
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Your side defeats the opposing side."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:384
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Accumulate a large amount of gold."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_selectscenario.cpp:387
 msgid "Victory Condition"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:48
-#: ../fheroes2/heroes/heroes_action.cpp:134
 msgid "one"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_spellinfo.cpp:51
-#: ../fheroes2/heroes/heroes_action.cpp:135
 msgid "two"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:187
-msgid "sound"
+msgid "Music"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:192
-#: ../fheroes2/dialog/dialog_system.cpp:205
-#: ../fheroes2/dialog/dialog_system.cpp:228
-#: ../fheroes2/dialog/dialog_system.cpp:242
-msgid "off"
+msgid "Toggle ambient music level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:200
-msgid "music"
+msgid "Effects"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:223
-msgid "hero speed"
+msgid "Toggle foreground sounds level."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:237
-msgid "ai speed"
+msgid "Music Type"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:251
-msgid "scroll speed"
+msgid "Change the type of music."
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:262
-#: ../fheroes2/dialog/dialog_system.cpp:276
+msgid "Hero Speed"
+msgstr ""
+
+msgid "Change the speed at which your heroes move on the main screen."
+msgstr ""
+
+msgid "Enemy Speed"
+msgstr ""
+
+msgid ""
+"Sets the speed that A.I. heroes move at.  You can also elect not to view A."
+"I. movement at all."
+msgstr ""
+
+msgid "Scroll Speed"
+msgstr ""
+
+msgid "Sets the speed at which you scroll the window."
+msgstr ""
+
+msgid "Interface Type"
+msgstr ""
+
+msgid "Toggle the type of interface you want to use."
+msgstr ""
+
 msgid "Interface"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:265
+msgid "Toggle interface visibility."
+msgstr ""
+
+msgid "Battles"
+msgstr ""
+
+msgid "Toggle instant battle mode."
+msgstr ""
+
+msgid "OK"
+msgstr ""
+
+msgid "Exit this menu."
+msgstr ""
+
+msgid "off"
+msgstr ""
+
+msgid "MIDI"
+msgstr ""
+
+msgid "MIDI Expansion"
+msgstr ""
+
+msgid "CD Stereo"
+msgstr ""
+
+msgid "External"
+msgstr ""
+
+msgid "Jump"
+msgstr ""
+
+msgid "Don't Show"
+msgstr ""
+
 msgid "Evil"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:267
 msgid "Good"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:281
 msgid "Hide"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_system.cpp:287
 msgid "Show"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:285
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:96
+msgid "Auto Resolve"
+msgstr ""
+
+msgid "Auto, No Spells"
+msgstr ""
+
+msgid "Manual"
+msgstr ""
+
+msgid "Att."
+msgstr ""
+
+msgid "Def."
+msgstr ""
+
+msgid "Power"
+msgstr ""
+
+msgid "Knowl"
+msgstr ""
+
+msgid "Human"
+msgstr ""
+
 msgid "1st"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:286
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:97
 msgid "2nd"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:98
 msgid "3rd"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:288
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:99
 msgid "4th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:289
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:100
 msgid "5th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:290
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:101
 msgid "6th"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:305
-msgid "Thieves' Guild: Player RanKings"
+msgid "Oracle: Player Rankings"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:315
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:114
+msgid "Thieves' Guild: Player Rankings"
+msgstr ""
+
 msgid "Number of Towns:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:324
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:123
 msgid "Number of Castles:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:333
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:132
 msgid "Number of Heroes:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:342
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:141
 msgid "Gold in Treasury:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:351
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:150
 msgid "Wood & Ore:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:360
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:159
 msgid "Gems, Cr, Slf & Mer:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:369
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:168
 msgid "Obelisks Found:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:378
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:177
+msgid "Artifacts:"
+msgstr ""
+
 msgid "Total Army Strength:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:408
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:211
+msgid "Income:"
+msgstr ""
+
 msgid "Best Hero:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:417
-#: ../fheroes2/pocketpc/pocketpc_thievesguild.cpp:220
 msgid "Best Hero Stats:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:426
 msgid "Personality:"
 msgstr ""
 
-#: ../fheroes2/dialog/dialog_thievesguild.cpp:435
 msgid "Best Monster:"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Easy"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Normal"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Hard"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Expert"
 msgstr ""
 
-#: ../fheroes2/game/difficulty.cpp:27
 msgid "difficulty|Impossible"
 msgstr ""
 
-#: ../fheroes2/game/game.cpp:314
-msgid "Maps Loading..."
+msgid "Map is loading..."
 msgstr ""
 
-#: ../fheroes2/game/game_highscores.cpp:239
-#: ../fheroes2/game/game_highscores.cpp:242
+msgid "and more..."
+msgstr ""
+
+msgid "Campaign Scenario loading failure"
+msgstr ""
+
+msgid "Please make sure that campaign files are correct and present."
+msgstr ""
+
 msgid "Unknown Hero"
 msgstr ""
 
-#: ../fheroes2/game/game_highscores.cpp:240
 msgid "Your Name"
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:95
-msgid "Are you sure you want to overwrite the save with this name?"
+msgid ""
+"Invalid file game type. Please ensure that you are running the latest type "
+"of save files."
 msgstr ""
 
-#: ../fheroes2/game/game_io.cpp:191
 msgid ""
-"This file is saved in the \"Price Loyalty\" version.\n"
+"This file is saved in the \"The Price of Loyalty\" version.\n"
 "Some items may be unavailable."
 msgstr ""
 
-#: ../fheroes2/game/game_mainmenu.cpp:157
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:95
-msgid "Quit"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:157
-msgid "Quit Heroes of Might and Magic and return to the operating system."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:79
-msgid "Load Game"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:159
-msgid "Load a previously saved game."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:91
-msgid "Credits"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:161
-msgid "View the credits screen."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:87
-msgid "High Scores"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:163
-msgid "View the high score screen."
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:75
-msgid "New Game"
-msgstr ""
-
-#: ../fheroes2/game/game_mainmenu.cpp:165
-msgid "Start a single or multi-player game."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid "Host"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:127
-msgid ""
-"The host sets up the game options. There can only be one host per network "
-"game."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid "Guest"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:128
-msgid ""
-"The guest waits for the host to set up the game, then is automatically added "
-"in. There can be multiple guests for TCP/IP games."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:129 ../fheroes2/game/game_newgame.cpp:218
-#: ../fheroes2/game/game_newgame.cpp:272 ../fheroes2/game/game_newgame.cpp:348
-msgid "Cancel back to the main menu."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:214
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:154
-msgid "Standard Game"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:214
-msgid "A single player game playing out a single map."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:216
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:162
-msgid "Multi-Player Game"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:216
-msgid ""
-"A multi-player game, with several human players completing against each "
-"other on a single map."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:217
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:83
-msgid "Settings"
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:217
-msgid "FHeroes2 game settings."
-msgstr ""
-
-#: ../fheroes2/game/game_newgame.cpp:271
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:219
 msgid "Hot Seat"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:271
 msgid ""
 "Play a Hot Seat game, where 2 to 4 players play around the same computer, "
 "switching into the 'Hot Seat' when it is their turn."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:279
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:223
+msgid "Cancel back to the main menu."
+msgstr ""
+
 msgid "Network"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:279
 msgid ""
 "Play a network game, where 2 players use their own computers connected "
 "through a LAN (Local Area Network)."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:343
+msgid "Standard Game"
+msgstr ""
+
+msgid "A single player game playing out a single map."
+msgstr ""
+
+msgid "Campaign Game"
+msgstr ""
+
+msgid "A single player game playing through a series of maps."
+msgstr ""
+
+msgid "Multi-Player Game"
+msgstr ""
+
+msgid ""
+"A multi-player game, with several human players completing against each "
+"other on a single map."
+msgstr ""
+
+msgid "Greetings!"
+msgstr ""
+
+msgid ""
+"Welcome to Free Heroes of Might and Magic II! Before starting the game "
+"please choose game resolution."
+msgstr ""
+
+msgid "Please Remember"
+msgstr ""
+
+msgid "You can always change game resolution by clicking on the "
+msgstr ""
+
+msgid "door"
+msgstr ""
+
+msgid ""
+" on the left side of main menu.\n"
+"\n"
+"To switch between windowed and full screen modes\n"
+"press "
+msgstr ""
+
+msgid "F4"
+msgstr ""
+
+msgid ""
+" key on the keyboard.\n"
+"\n"
+"Enjoy the game!"
+msgstr ""
+
+msgid "Quit Heroes of Might and Magic and return to the operating system."
+msgstr ""
+
+msgid "Credits"
+msgstr ""
+
+msgid "View the credits screen."
+msgstr ""
+
+msgid "High Scores"
+msgstr ""
+
+msgid "View the high score screen."
+msgstr ""
+
+msgid "Select Game Resolution"
+msgstr ""
+
+msgid "Change resolution of the game."
+msgstr ""
+
+msgid "Original Campaign"
+msgstr ""
+
+msgid ""
+"Either Roland's or Archibald's campaign from the original Heroes of Might "
+"and Magic II."
+msgstr ""
+
+msgid "Expansion Campaign"
+msgstr ""
+
+msgid "One of the four new campaigns from the Price of Loyalty expansion set."
+msgstr ""
+
+msgid "Host"
+msgstr ""
+
+msgid ""
+"The host sets up the game options. There can only be one host per network "
+"game."
+msgstr ""
+
+msgid "Guest"
+msgstr ""
+
+msgid ""
+"The guest waits for the host to set up the game, then is automatically added "
+"in. There can be multiple guests for TCP/IP games."
+msgstr ""
+
+msgid "Battle Only"
+msgstr ""
+
+msgid "Setup and play a battle without loading any map."
+msgstr ""
+
+msgid "Settings"
+msgstr ""
+
+msgid "Experimental game settings."
+msgstr ""
+
 msgid "2 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:343
 msgid ""
 "Play with 2 human players, and optionally, up, to 4 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid "3 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:344
 msgid ""
 "Play with 3 human players, and optionally, up, to 3 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid "4 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:345
 msgid ""
 "Play with 4 human players, and optionally, up, to 2 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid "5 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:346
 msgid ""
 "Play with 5 human players, and optionally, up, to 1 additional computer "
 "players."
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "6 Players"
 msgstr ""
 
-#: ../fheroes2/game/game_newgame.cpp:347
 msgid "Play with 6 human players."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:37
 msgid "Defeat all enemy heroes and capture all enemy towns and castles."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:38
 msgid "Run out of time. (Fail to win by a certain point.)"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the castle '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:73
 msgid "Capture the town '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:83
 msgid "Defeat the hero '%{name}'"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:91
 msgid "Find the ultimate artifact"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:95
 msgid "Find the '%{name}' artifact"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:102
 msgid "Accumulate %{count} gold"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:106
 msgid ""
 ", or you may win by defeating all enemy heroes and capturing all enemy towns "
 "and castles."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the castle '%{name}'."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:116
 msgid "Lose the town '%{name}'."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:126 ../fheroes2/game/game_over.cpp:145
 msgid "Lose the hero: %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:133
 msgid "Fail to win by the end of month %{month}, week %{week}, day %{day}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:145
 msgid "Lose the heroes: %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:167
 msgid ""
 "You captured %{name}!\n"
 "You are victorious."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:175
 msgid ""
 "You have captured the enemy hero %{name}!\n"
 "Your quest is complete."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:183
 msgid ""
 "You have found the %{name}.\n"
 "Your quest is complete."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:195
 msgid ""
 "The enemy is beaten.\n"
 "Your side has triumphed!"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:200
 msgid ""
 "You have built up over %{count} gold in your treasury.\n"
 "All enemies bow before your wealth and power."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:222
 msgid ""
 "The enemy has found the %{name}.\n"
 "Your quest is a failure."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:230
 msgid ""
 "%{color} has fallen!\n"
 "All is lost."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:237
 msgid ""
 "The enemy has built up over %{count} gold in his treasury.\n"
 "You must bow done in defeat before his wealth and power."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:243
 msgid "You have been eliminated from the game!!!"
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:248
 msgid ""
 "The enemy has captured %{name}!\n"
 "They are triumphant."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:257 ../fheroes2/game/game_over.cpp:264
 msgid ""
 "You have lost the hero %{name}.\n"
 "Your quest is over."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:272
 msgid ""
 "You have failed to complete your quest in time.\n"
 "All is lost."
 msgstr ""
 
-#: ../fheroes2/game/game_over.cpp:320
-msgid "%{color} has been vanquished!"
+msgid "%{color} player has been vanquished!"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "Warning"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:63
-#: ../fheroes2/pocketpc/pocketpc_selectscenario.cpp:54
 msgid "No maps available!"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Scenario"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:263
 msgid "Click here to select which scenario to play."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid "Game Difficulty"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:266
 msgid ""
 "This lets you change the starting difficulty at which you will play. Higher "
 "difficulty levels start you of with fewer resources, and at the higher "
 "settings, give extra resources to the computer."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid "Difficulty Rating"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:269
 msgid ""
 "The difficulty rating reflects a combination of various settings for your "
 "game. This number will be applied to your final score."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:272
 msgid "Click to accept these settings and start a new game."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:275
 msgid "Click to return to the main menu."
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:342
 msgid "Scenario:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:350
 msgid "Game Difficulty:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:354
 msgid "Opponents:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:358
 msgid "Class:"
 msgstr ""
 
-#: ../fheroes2/game/game_scenarioinfo.cpp:384
 msgid "Rating %{rating}%"
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:226
 msgid "Astrologers proclaim Month of the %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:226
 msgid "Astrologers proclaim Week of the %{name}."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:240
 msgid "After regular growth, population of %{monster} is doubled!"
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:252
 msgid " All populations are halved."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:254
 msgid " All dwellings increase population."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:283
 msgid ""
 "%{color} player, your heroes abandon you, and you are banished from this "
 "land."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:290
 msgid ""
 "%{color} player, this is your last day to capture a town, or you will be "
 "banished from this land."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:295
 msgid ""
 "%{color} player, you only have %{day} days left to capture a town, or you "
 "will be banished from this land."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:584
-msgid "%{color} player's turn"
+msgid "%{color} player's turn."
 msgstr ""
 
-#: ../fheroes2/game/game_startgame.cpp:995
 msgid ""
 "%{color} player, you have lost your last town. If you do not conquer another "
 "town in next week, you will be eliminated."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Next Hero"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:183
 msgid "Select the next Hero."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue Movement"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:185
 msgid "Continue the Hero's movement along the current path."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "Kingdom Summary"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:187
 msgid "View a Summary of your Kingdom."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:189
 msgid "Cast an adventure spell."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End Turn"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:191
 msgid "End your turn and left the computer take its turn."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Adventure Options"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:193
 msgid "Bring up the adventure options menu."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "File Options"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:195
 msgid "Bring up the file options menu, alloving you to load menu, save etc."
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "System Options"
 msgstr ""
 
-#: ../fheroes2/gui/interface_buttons.cpp:197
 msgid "Bring up the system options menu, alloving you to customize your game."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:175
 msgid ""
 "One or more heroes may still move, are you sure you want to end your turn?"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:212
-msgid "Are you sure you want to restart? (Your current game will be lost)"
-msgstr ""
-
-#: ../fheroes2/gui/interface_events.cpp:276
 msgid "Are you sure you want to quit?"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:308
+msgid "Are you sure you want to restart? (Your current game will be lost.)"
+msgstr ""
+
+msgid "Are you sure you want to overwrite the save with this name?"
+msgstr ""
+
 msgid "Game saved successfully."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:314
-msgid ""
-"Are you sure you want to load a new game? (Your current game will be lost)"
+msgid "There was an issue during saving."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:353
+msgid ""
+"Are you sure you want to load a new game? (Your current game will be lost.)"
+msgstr ""
+
 msgid "Try looking on land!!!"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:368
 msgid ""
-"After spending many hours digging here, you have uncovered the %{artifact}"
+"After spending many hours digging here, you have uncovered the %{artifact}."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:370
 msgid "Congratulations!"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:384
 msgid "Nothing here. Where could it be?"
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:395
 msgid "Try searching on clear ground."
 msgstr ""
 
-#: ../fheroes2/gui/interface_events.cpp:399
 msgid "Digging for artifacts requires a whole day, try again tomorrow."
 msgstr ""
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "World Map"
 msgstr ""
 
-#: ../fheroes2/gui/interface_radar.cpp:387
 msgid "A miniature view of the known world. Left click to move viewing area."
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:216
 msgid "Month: %{month} Week: %{week}"
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:222
-#: ../fheroes2/kingdom/kingdom_overview.cpp:569
 msgid "Day: %{day}"
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:257
 msgid ""
 "You find a small\n"
 "quantity of %{resource}."
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:407
 msgid "Status Window"
 msgstr ""
 
-#: ../fheroes2/gui/interface_status.cpp:407
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date."
+msgstr ""
+
 msgid ""
 "This window provides information on the status of your hero or kingdom, and "
 "shows the date. Left click here to cycle throungh these windows."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:112
+msgid "Necroman"
+msgstr ""
+
+msgid ""
+"This lets you change player starting positions and colors. A particular "
+"color will always start in a particular location. Some positions may only be "
+"played by a computer player or only by a human player."
+msgstr ""
+
+msgid ""
+"This lets you change the class of a player. Classes are not always "
+"changeable. Depending on the scenario, a player may receive additional towns "
+"and/or heroes not of their primary alignment."
+msgstr ""
+
+msgid "%{color} player"
+msgstr ""
+
+msgid "View %{skill} Info"
+msgstr ""
+
+msgid "Lord Kilburn"
+msgstr ""
+
+msgid "Sir Gallant"
+msgstr ""
+
+msgid "Ector"
+msgstr ""
+
+msgid "Gwenneth"
+msgstr ""
+
+msgid "Tyro"
+msgstr ""
+
+msgid "Ambrose"
+msgstr ""
+
+msgid "Ruby"
+msgstr ""
+
+msgid "Maximus"
+msgstr ""
+
+msgid "Dimitry"
+msgstr ""
+
+msgid "Thundax"
+msgstr ""
+
+msgid "Fineous"
+msgstr ""
+
+msgid "Jojosh"
+msgstr ""
+
+msgid "Crag Hack"
+msgstr ""
+
+msgid "Jezebel"
+msgstr ""
+
+msgid "Jaclyn"
+msgstr ""
+
+msgid "Ergon"
+msgstr ""
+
+msgid "Tsabu"
+msgstr ""
+
+msgid "Atlas"
+msgstr ""
+
+msgid "Astra"
+msgstr ""
+
+msgid "Natasha"
+msgstr ""
+
+msgid "Troyan"
+msgstr ""
+
+msgid "Vatawna"
+msgstr ""
+
+msgid "Rebecca"
+msgstr ""
+
+msgid "Gem"
+msgstr ""
+
+msgid "Ariel"
+msgstr ""
+
+msgid "Carlawn"
+msgstr ""
+
+msgid "Luna"
+msgstr ""
+
+msgid "Arie"
+msgstr ""
+
+msgid "Alamar"
+msgstr ""
+
+msgid "Vesper"
+msgstr ""
+
+msgid "Crodo"
+msgstr ""
+
+msgid "Barok"
+msgstr ""
+
+msgid "Kastore"
+msgstr ""
+
+msgid "Agar"
+msgstr ""
+
+msgid "Falagar"
+msgstr ""
+
+msgid "Wrathmont"
+msgstr ""
+
+msgid "Myra"
+msgstr ""
+
+msgid "Flint"
+msgstr ""
+
+msgid "Dawn"
+msgstr ""
+
+msgid "Halon"
+msgstr ""
+
+msgid "Myrini"
+msgstr ""
+
+msgid "Wilfrey"
+msgstr ""
+
+msgid "Sarakin"
+msgstr ""
+
+msgid "Kalindra"
+msgstr ""
+
+msgid "Mandigal"
+msgstr ""
+
+msgid "Zom"
+msgstr ""
+
+msgid "Darlana"
+msgstr ""
+
+msgid "Zam"
+msgstr ""
+
+msgid "Ranloo"
+msgstr ""
+
+msgid "Charity"
+msgstr ""
+
+msgid "Rialdo"
+msgstr ""
+
+msgid "Roxana"
+msgstr ""
+
+msgid "Sandro"
+msgstr ""
+
+msgid "Celia"
+msgstr ""
+
+msgid "Roland"
+msgstr ""
+
+msgid "Lord Corlagon"
+msgstr ""
+
+msgid "Sister Eliza"
+msgstr ""
+
+msgid "Archibald"
+msgstr ""
+
+msgid "Lord Halton"
+msgstr ""
+
+msgid "Brother Brax"
+msgstr ""
+
+msgid "Solmyr"
+msgstr ""
+
+msgid "Dainwin"
+msgstr ""
+
+msgid "Mog"
+msgstr ""
+
+msgid "Joseph"
+msgstr ""
+
+msgid "Gallavant"
+msgstr ""
+
+msgid "Elderian"
+msgstr ""
+
+msgid "Ceallach"
+msgstr ""
+
+msgid "Drakonia"
+msgstr ""
+
+msgid "Martine"
+msgstr ""
+
+msgid "Jarkonas"
+msgstr ""
+
+msgid "%{object} robber"
+msgstr ""
+
+msgid "%{object} raided"
+msgstr ""
+
+msgid "You cannot pick up this artifact, you already have a full load!"
+msgstr ""
+
+msgid "The three Anduran artifacts magically combine into one."
+msgstr ""
+
+msgid "To cast spells, you must first buy a spell book for %{gold} gold."
+msgstr ""
+
+msgid "Unfortunately, you seem to be a little short of cash at the moment."
+msgstr ""
+
+msgid "Do you wish to buy one?"
+msgstr ""
+
 msgid "%{count} / day"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:331
-#: ../fheroes2/heroes/heroes_action.cpp:2199
 msgid "You are unable to recruit at this time, your ranks are full."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:599
-msgid ""
-"A group of %{monster} with a desire for greater glory wish to join you.\n"
-"Do you accept?"
+msgid "A whirlpool engulfs your ship."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:609
-#: ../fheroes2/heroes/heroes_action.cpp:630
+msgid "Some of your army has fallen overboard."
+msgstr ""
+
 msgid "Insulted by your refusal of their offer, the monsters attack!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:638
 msgid ""
 "The %{monster}, awed by the power of your forces, begin to scatter.\n"
 "Do you wish to pursue and engage them?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:934
 msgid "Ransacking an enemy camp, you discover a hidden cache of treasures."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:966
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with these resources, "
 "come back next week for more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:967
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there are no resources currently available. Please try "
 "again next week.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:972
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with this gold, come "
 "back next week for more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:973
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there is no gold currently available. Please try again "
 "next week.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:979
 msgid ""
 "You've found an abandoned lean-to.\n"
 "Poking about, you discover some resources hidden nearby."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:980
 msgid "The lean-to is long abandoned. There is nothing of value here."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:985
 msgid ""
 "You catch a leprechaun foolishly sleeping amidst a cluster of magic "
 "mushrooms.\n"
@@ -2644,176 +2888,142 @@ msgid ""
 "precious things."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:986
 msgid ""
 "You've found a magic garden, the kind of place that leprechauns and faeries "
 "like to cavort in, but there is no one here today.\n"
 "Perhaps you should try again next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1023
 msgid "You come upon the remains of an unfortunate adventurer."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1034
 msgid "Treasure"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1041
 msgid "Searching through the tattered clothing, you find %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1052
 msgid "Searching through the tattered clothing, you find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1064
 msgid ""
 "You come across an old wagon left by a trader who didn't quite make it to "
 "safe terrain."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1075
-#: ../fheroes2/heroes/heroes_action.cpp:1103
 msgid "Unfortunately, others have found it first, and the wagon is empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1082
 msgid "Searching inside, you find the %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1093
 msgid "Inside, you find some of the wagon's cargo still intact."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1123
 msgid "You search through the flotsam, and find some wood and some gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1124
 msgid "You search through the flotsam, and find some wood."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1130
 msgid "You search through the flotsam, but find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1151
 msgid "Shrine of the 1st Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1152
 msgid ""
 "You come across a small shrine attended by a group of novice acolytes.\n"
-"In exchange for your protection, they agree to teach you a simple spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a simple spell - "
+"'%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1155
 msgid "Shrine of the 2nd Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1156
 msgid ""
 "You come across an ornate shrine attended by a group of rotund friars.\n"
-"In exchange for your protection, they agree to teach you a spell - '%"
-"{spell}'."
+"In exchange for your protection, they agree to teach you a spell - "
+"'%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1159
 msgid "Shrine of the 3rd Circle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1160
 msgid ""
 "You come across a lavish shrine attended by a group of high priests.\n"
 "In exchange for your protection, they agree to teach you a sophisticated "
 "spell - '%{spell}'."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1173
 msgid ""
 "\n"
 "Unfortunately, you have no Magic Book to record the spell with."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1184
 msgid ""
 "\n"
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1192
 msgid ""
 "\n"
 "Unfortunately, you already have knowledge of this spell, so there is nothing "
 "more for them to teach you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1215
 msgid ""
-"You approach the hut and observe a witch inside studying an ancient tome on %"
-"{skill}.\n"
+"You approach the hut and observe a witch inside studying an ancient tome on "
+"%{skill}.\n"
 " \n"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1222
 msgid ""
 "As you approach, she turns and focuses her one glass eye on you.\n"
 "\"You already know everything you deserve to learn!\" the witch screeches. "
 "\"NOW GET OUT OF MY HOUSE!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1229
 msgid ""
 "As you approach, she turns and speaks.\n"
 "\"You already know that which I would teach you. I can help you no further.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1236
 msgid ""
 "An ancient and immortal witch living in a hut with bird's legs for stilts "
 "teaches you %{skill} for her own inscrutable purposes."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1255
 msgid "You drink from the enchanted fountain, but nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1256
 msgid "As you drink the sweet water, you gain luck for your next battle."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1260
 msgid "You enter the faerie ring, but nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1261
 msgid ""
 "Upon entering the mystical faerie ring, your army gains luck for its next "
 "battle."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1265
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "It is supposed to grant luck to visitors, but since the stars are already "
 "smiling upon you, it does nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1266
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "Kissing it is supposed to be lucky, so you do. The stone is very cold to the "
 "touch."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1270
 msgid "The mermaids silently entice you to return later and be blessed again."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1271
 msgid ""
 "The magical, soothing beauty of the Mermaids reaches you and your crew.\n"
 "Just for a moment, you forget your worries and bask in the beauty of the "
@@ -2821,7 +3031,6 @@ msgid ""
 "The mermaids charms bless you with increased luck for your next combat."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1303
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "You are tempted to search it for treasure, but all the old stories warn of "
@@ -2829,470 +3038,375 @@ msgid ""
 "Will you search?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1304
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "Routine exploration reveals that the pyramid is completely empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1329
 msgid "Unfortunately, you have no Magic Book to record the spell with."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1333
 msgid ""
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1337
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
 "telling the secret of the spell."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1374 ../fheroes2/maps/mp2.cpp:469
 msgid "Sign"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1385
 msgid ""
 "A drink at the well is supposed to restore your spell points, but you are "
 "already at maximum."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1392
 msgid "A second drink at the well in one day will not help you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1399
 msgid "A drink from the well has restored your spell points to maximum."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1424
 msgid ""
 "\"I'm sorry sir,\" The leader of the soldiers says, \"but you already know "
 "everything we have to teach.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1425
 msgid "The soldiers living in the fort teach you a few new defensive tricks."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1430
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. \"You're too "
 "advanced for us,\" the mercenary captain says. \"We can teach nothing more.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1431
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. The mercenaries "
 "welcome you and your troops and invite you to train with them."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1436
 msgid "\"Go 'way!\", the witch doctor barks, \"you know all I know.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1437
 msgid ""
 "An Orcish witch doctor living in the hut deepens your knowledge of magic by "
 "showing you how to cast stones, read portents, and decipher the intricacies "
 "of chicken entrails."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1442
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, the Druids turn you away, indicating they have nothing "
 "new to teach you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1443
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, they teach you new ways to cast spells."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1479
 msgid ""
 "You tentatively approach the burial ground of ancient warriors. Do you want "
 "to search the graves?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1480
 msgid ""
 "Upon defeating the Zombies you spend several hours searching the graves and "
 "find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1481
-msgid "Upon defeating the zomies you search the graves and find something!"
+msgid "Upon defeating the Zombies you search the graves and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1484
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the shipwreck?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1485
 msgid ""
 "Upon defeating the Ghosts you spend several hours sifting through the debris "
 "and find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1486
 msgid ""
 "Upon defeating the Ghosts you sift through the debris and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1489
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the ship?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1490
 msgid ""
 "Upon defeating the Skeletons you spend several hours sifting through the "
 "debris and find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1491
 msgid ""
 "Upon defeating the Skeletons you sift through the debris and find something!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1564
 msgid "Your men spot a navigational buoy, confirming that you are on course."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1565
 msgid ""
 "Your men spot a navigational buoy, confirming that you are on course and "
 "increasing their morale."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1569
 msgid ""
 "The drink at the oasis is refreshing, but offers no further benefit. The "
 "oasis might help again if you fought a battle first."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1570
 msgid ""
 "A drink at the oasis fills your troops with strength and lifts their "
 "spirits.  You can travel a bit further today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1575
 msgid ""
 "The drink at the watering hole is refreshing, but offers no further benefit. "
 "The watering hole might help again if you fought a battle first."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1576
 msgid ""
 "A drink at the watering hole fills your troops with strength and lifts their "
 "spirits. You can travel a bit further today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1581
 msgid ""
 "It doesn't help to pray twice before a battle. Come back after you've fought."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1582
 msgid "A visit and a prayer at the temple raises the morale of your troops."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1622
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"I am sorry, my liege, I "
 "have taught you all I can.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1623
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"My liege, I will teach "
 "you all that I know to aid you in your travels.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1662
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
 "ocean. Grateful, he says, \"I would give you an artifact as a reward, but "
 "you're all full.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1669
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
-"ocean. Grateful, he rewards you for your act of kindness by giving you the %"
-"{art}."
+"ocean. Grateful, he rewards you for your act of kindness by giving you the "
+"%{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1688 ../fheroes2/heroes/heroes.cpp:941
-msgid "You have no room to carry another artifact!"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:1704
 msgid "A leprechaun offers you the %{art} for the small price of %{gold} Gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1709
 msgid ""
-"A leprechaun offers you the %{art} for the small price of %{gold} Gold and %"
-"{count} %{res}."
+"A leprechaun offers you the %{art} for the small price of %{gold} Gold and "
+"%{count} %{res}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1718
 msgid "Do you wish to buy this artifact?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1731
 msgid ""
 "You try to pay the leprechaun, but realize that you can't afford it. The "
 "leprechaun stamps his foot and ignores you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1735
 msgid ""
 "Insulted by your refusal of his generous offer, the leprechaun stamps his "
 "foot and ignores you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1746
-#: ../fheroes2/heroes/heroes_action.cpp:1821
 msgid "You've found the artifact: "
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1756
 msgid ""
 "You've found the humble dwelling of a withered hermit. The hermit tells you "
 "that he is willing to give the %{art} to the first wise person he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1759
 msgid ""
 "You've come across the spartan quarters of a retired soldier. The soldier "
 "tells you that he is willing to pass on the %{art} to the first true leader "
 "he meets."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1780
 msgid ""
 "You come upon an ancient artifact. As you reach for it, a pack of Rogues "
 "leap out of the brush to guard their stolen loot."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1783
 msgid ""
 "Through a clearing you observe an ancient artifact. Unfortunately, it's "
 "guarded by a nearby %{monster}. Do you want to fight the %{monster} for the "
 "artifact?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1798
 msgid "Victorious, you take your prize, the %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1810
 msgid ""
 "Discretion is the better part of valor, and you decide to avoid this fight "
 "for today."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1866
-#: ../fheroes2/heroes/heroes_action.cpp:1881
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold pieces."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1872
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold and the %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1888
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it, "
 "only to find it empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1898
 msgid ""
 "After scouring the area, you fall upon a hidden treasure cache. You may take "
 "the gold or distribute the gold to the peasants for experience. Do you wish "
 "to keep the gold?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1912
 msgid ""
-"After scouring the area, you fall upon a hidden chest, containing the %"
-"{gold} gold pieces."
+"After scouring the area, you fall upon a hidden chest, containing the "
+"%{gold} gold pieces."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1918
 msgid ""
 "After scouring the area, you fall upon a hidden chest, containing the "
 "ancient artifact %{art}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:1942
 msgid ""
 "You stumble upon a dented and tarnished lamp lodged deep in the earth. Do "
 "you wish to rub the lamp?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "A whirlpool engulfs your ship."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2030
-msgid "Some of your army has fallen overboard."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2045
 msgid ""
 "You come upon an abandoned gold mine. The mine appears to be haunted. Do you "
 "wish to enter?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2064
 msgid ""
 "You have taken control of the local Alchemist shop. It will provide you with "
 "%{count} unit of Mercury per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2070
 msgid ""
 "You gain control of a sawmill. It will provide you with %{count} units of "
 "wood per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2081
+msgid "You beat the Ghosts and are able to restore the mine to production."
+msgstr ""
+
 msgid ""
 "You gain control of an ore mine. It will provide you with %{count} units of "
 "ore per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2083
 msgid ""
 "You gain control of a sulfur mine. It will provide you with %{count} unit of "
 "sulfur per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2085
 msgid ""
 "You gain control of a crystal mine. It will provide you with %{count} unit "
 "of crystal per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2087
 msgid ""
 "You gain control of a gem mine. It will provide you with %{count} unit of "
 "gems per day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2089
 msgid ""
 "You gain control of a gold mine. It will provide you with %{count} gold per "
 "day."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2096
-msgid "You beat the Ghosts and are able to restore the mine to production."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_action.cpp:2101
 msgid ""
 "The lighthouse is now under your control, and all of your ships will now "
 "move further each turn."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2105
 msgid "You gain control of a %{name}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2188
 msgid ""
 "A group of %{monster} with a desire for greater glory wish to join you. Do "
 "you accept?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2215
 msgid "As you approach the dwelling, you notice that there is no one here."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2232
 msgid ""
 "You search the ruins, but the Medusas that used to live here are gone. "
 "Perhaps there will be more next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2233
 msgid ""
 "You've found some Medusas living in the ruins. They are willing to join your "
 "army for a price. Do you want to recruit Medusas?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2238
 msgid ""
 "You've found a Sprite Tree City. Unfortunately, none of the Sprites living "
 "there wish to join an army. Maybe next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2239
 msgid ""
 "Some of the Sprites living in the tree city are willing to join your army "
 "for a price. Do you want to recruit Sprites?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2244
 msgid ""
 "A colorful Rogues' wagon stands empty here. Perhaps more Rogues will be here "
 "later."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2245
 msgid ""
 "Distant sounds of music and laughter draw you to a colorful wagon housing "
 "Rogues. Do you wish to have any Rogues join your army?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2250
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. The "
 "tents are unoccupied. Perhaps more Nomads will be here later."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2251
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. Do you "
 "wish to have any Nomads join you during your travels?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2256
 msgid "The pit of mud bubbles for a minute and then lies still."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2257
 msgid ""
 "As you approach the bubbling pit of mud, creatures begin to climb out and "
 "position themselves around it. In unison they say: \"Mother Earth would like "
 "to offer you a few of her troops. Do you want to recruit Earth Elementals?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2261
 msgid "You enter the structure of white stone pillars, and find nothing."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2262
 msgid ""
 "White stone pillars support a roof that rises up to the sky. As you enter "
 "the structure, the dead air of the outside gives way to a whirling gust that "
@@ -3302,192 +3416,159 @@ msgid ""
 "air?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2266
 msgid "No Fire Elementals approach you from the lava pool."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2267
 msgid ""
 "Beneath a structure that serves to hold in heat, Fire Elementals move about "
 "in a fiery pool of molten lava. A group of them approach you and offer their "
 "services. Would you like to recruit Fire Elementals?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2271
 msgid "A face forms in the water for a moment, and then is gone."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2272
 msgid ""
 "Crystalline structures cast shadows over a small reflective pool of water. "
 "You peer into the pool, and a face that is not your own peers back. It asks: "
 "\"Would you like to call upon the powers of water?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2276
 msgid "This burial site is deathly still."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2277
 msgid ""
 "Restless spirits of long dead warriors seeking their final resting place "
 "offer to join you in hopes of finding peace. Do you wish to recruit ghosts?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2313
 msgid ""
 "The City of the Dead is empty of life, and empty of unlife as well. Perhaps "
 "some undead will move in next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2314
 msgid ""
 "Some Liches living here are willing to join your army for a price. Do you "
 "want to recruit Liches?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2315
 msgid ""
 "You've found the ruins of an ancient city, now inhabited solely by the "
 "undead. Will you search?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2316
 msgid ""
 "Some of the surviving Liches are impressed by your victory over their "
 "fellows, and offer to join you for a price. Do you want to recruit Liches?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2320
 msgid ""
 "You've found one of those bridges that Trolls are so fond of living under, "
 "but there are none here. Perhaps there will be some next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2321
 msgid ""
 "Some Trolls living under a bridge are willing to join your army, but for a "
 "price. Do you want to recruit Trolls?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2322
 msgid "Trolls living under the bridge challenge you. Will you fight them?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2323
 msgid ""
 "A few Trolls remain, cowering under the bridge. They approach you and offer "
 "to join your forces as mercenaries. Do you want to buy any Trolls?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2327
 msgid ""
 "The Dragon city has no Dragons willing to join you this week. Perhaps a "
 "Dragon will become available next week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2328
 msgid ""
 "The Dragon city is willing to offer some Dragons for your army for a price. "
 "Do you wish to recruit Dragons?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2329
 msgid ""
 "You stand before the Dragon City, a place off-limits to mere humans. Do you "
 "wish to violate this rule and challenge the Dragons to a fight?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2330
 msgid ""
 "Having defeated the Dragon champions, the city's leaders agree to supply "
 "some Dragons to your army for a price. Do you wish to recruit Dragons?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2389
 msgid "From the observation tower, you are able to see distant lands."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2401
 msgid ""
 "The spring only refills once a week, and someone's already been here this "
 "week."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2407
 msgid ""
 "A drink at the spring is supposed to give you twice your normal spell "
 "points, but you are already at that level."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2418
 msgid ""
 "A drink from the spring fills your blood with magic! You have twice your "
 "normal spell points in reserve."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2437
 msgid ""
 "Recognizing you, the butler refuses to admit you. \"The master,\" he says, "
 "\"will not see the same student twice.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2457
 msgid ""
 "The butler admits you to see the master of the house. He trains you in the "
 "four skills a hero should know."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2467
 msgid ""
 "The butler opens the door and looks you up and down. \"You are neither "
 "famous nor diplomatic enough to be admitted to see my master,\" he sniffs. "
 "\"Come back when you think yourself worthy.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2510
 msgid ""
 "All of the %{monsters} you have in your army have been trained by the battle "
 "masters of the fort. Your army now contains %{monsters2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2513
 msgid ""
-"An unusual alliance of Orcs, Ogres, and Dwarves offer to train (upgrade) any "
+"An unusual alliance of Ogres, Orcs, and Dwarves offer to train (upgrade) any "
 "such troops brought to them. Unfortunately, you have none with you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2524
 msgid "All of your %{monsters} have been upgraded into %{monsters2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2527
 msgid ""
 "A blacksmith working at the foundry offers to convert all Pikemen and "
 "Swordsmen's weapons brought to him from iron to steel. He also says that he "
-"knows a process that will convert Iron Golems into Steel Golems.  "
+"knows a process that will convert Iron Golems into Steel Golems. "
 "Unfortunately, you have none of these troops in your army, so he can't help "
 "you."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2585
 msgid ""
 "A retired captain living on this refurbished fishing platform offers to sell "
 "you maps of the sea he made in his younger days for 1,000 gold. Do you wish "
 "to buy the maps?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2598
 msgid ""
 "The captain sighs. \"You don't have enough money, eh?  You can't expect me "
 "to give my maps away for free!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2632
 msgid "You find %{artifact}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2655
 msgid ""
 "You come upon an obelisk made from a type of stone you have never seen "
 "before. Staring at it intensely, the smooth surface suddenly changes to an "
@@ -3495,56 +3576,51 @@ msgid ""
 "copy down the piece and the inscription vanishes as abruptly as it appeared."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2659
 msgid "You have already been to this obelisk."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2671
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"It is good to see "
 "you, my student. I hope my teachings have helped you.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2683
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"Ahh, an "
 "adventurer! Allow me to teach you a little of what I have learned over the "
 "ages.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2692
 msgid "Upon your approach, the tree opens its eyes in delight."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2694
 msgid ""
 "\"Ahh, an adventurer! I will be happy to teach you a little of what I have "
 "learned over the ages for a mere %{count} %{res}.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2696
 msgid "(Just bury it around my roots.)"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2703
 msgid "Tears brim in the eyes of the tree."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2705
 msgid "\"I need %{count} %{res}.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2707
 msgid "it whispers. (sniff) \"Well, come back when you can pay me.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2737
+msgid ""
+"Nestled among the trees sits a blind seer. After explaining the intent of "
+"your journey, the seer activates his crystal ball, allowing you to see the "
+"strengths and weaknesses of your opponents."
+msgstr ""
+
 msgid ""
 "The entrance to the cave is dark, and a foul, sulfurous smell issues from "
 "the cave mouth. Will you enter?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2749
 msgid ""
 "You find a powerful and grotesque Demon in the cave. \"Today,\" it rasps, "
 "\"you will fight and surely die. But I will give you a choice of deaths. You "
@@ -3552,71 +3628,59 @@ msgid ""
 "servants?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2759
 msgid ""
 "Upon defeating the daemon's servants, you find a hidden cache with %{count} "
 "gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2774
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and receive %{exp} experience points."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2784
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and find the %{art} in the back of the cave."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2794
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
-"battle, you slay the monster and receive %{exp) experience points and %"
-"{count} gold."
+"battle, you slay the monster and receive %{exp} experience points and "
+"%{count} gold."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2809
 msgid ""
 "The Demon leaps upon you and has its claws at your throat before you can "
 "even draw your sword. \"Your life is mine,\" it says. \"I will sell it back "
 "to you for %{count} gold.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2810
 msgid ""
 "Seeing that you do not have %{count} gold, the demon slashes you with its "
 "claws, and the last thing you see is a red haze."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2835
 msgid "Except for evidence of a terrible battle, the cave is empty."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2860
 msgid "For %{gold} gold, the alchemist will remove it for you. Do you pay?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2871
 msgid ""
 "You hear a voice from behind the locked door, \"You don't have enough gold "
 "to pay for my services.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2874
 msgid ""
 "You hear a voice from high above in the tower, \"Go away! I can't help you!\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2886
 msgid ""
 "The head groom approaches you and speaks, \"You already have a fine horse, "
 "and have no inexperienced cavalry which might make use of our trained war "
 "horses.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2889
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, his "
@@ -3625,7 +3689,6 @@ msgid ""
 "mounted soldiers, but you have none we can help.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2892
 msgid ""
 "The head groom speaks to you, \"That is a fine looking horse you have. I am "
 "afraid we can give you no better, but the horses your cavalry are riding "
@@ -3633,7 +3696,6 @@ msgid ""
 "would aid your riders greatly. I insist you take them.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2895
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
 "war horse. \"This steed will help speed you in your travels. Alas, he will "
@@ -3641,17 +3703,14 @@ msgid ""
 "mounted soldiers, their horses look shoddy and weak.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2922
 msgid "The Arena guards turn you away."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2939
 msgid ""
 "As the sirens sing their eerie song, your small, determined army manages to "
 "overcome the urge to dive headlong into the sea."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2944
 msgid ""
 "You have your crew stop up their ears with wax before the sirens' eerie song "
 "has any chance of luring them to a watery grave. An eerie wailing song "
@@ -3660,57 +3719,52 @@ msgid ""
 "for the visit, and gain %{exp} experience."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2964
 msgid ""
 "In a dazzling display of daring, you break into the local jail and free the "
 "hero imprisoned there, who, in return, pledges loyalty to your cause."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2980
 msgid ""
 "You already have %{count} heroes, and regretfully must leave the prisoner in "
 "this jail to languish in agony for untold days."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:2991
 msgid ""
 "You enter a rickety hut and talk to the magician who lives there. He tells "
 "you of places near and far which may aid you in your journeys."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3004
 msgid "This eye seems to be intently studying its surroundings."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3015
 msgid ""
 "\"I have a riddle for you,\" the Sphinx says. \"Answer correctly, and you "
 "shall be rewarded. Answer incorrectly, and you shall be eaten. Do you accept "
 "the challenge?\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3017
-msgid "The Sphinx asks you the following riddle: %{riddle}. Your answer?"
+msgid ""
+"The Sphinx asks you the following riddle:\n"
+" \n"
+"'%{riddle}'\n"
+" \n"
+"Your answer?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3025
 msgid ""
 "Looking somewhat disappointed, the Sphinx sighs. You've answered my riddle "
 "so here's your reward. Now begone."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3052
 msgid ""
 "\"You guessed incorrectly,\" the Sphinx says, smiling. The Sphinx swipes at "
 "you with a paw, knocking you to the ground. Another blow makes the world go "
 "black, and you know no more."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3060
 msgid "You come across a giant Sphinx. The Sphinx remains strangely quiet."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3073
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -3718,7 +3772,6 @@ msgid ""
 "As you speak the magic word, the glowing barrier dissolves into nothingness."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3083
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
 "arch read,\n"
@@ -3726,7 +3779,6 @@ msgid ""
 "You speak, and nothing happens."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_action.cpp:3093
 msgid ""
 "You enter the tent and see an old woman gazing into a magic gem. She looks "
 "up and says,\n"
@@ -3734,421 +3786,81 @@ msgid ""
 "oracle taught me his skill. I have the answer you seek.\""
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_base.cpp:401
 msgid ""
 "That spell costs %{mana} mana. You only have %{point} mana, so you can't "
 "cast the spell."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Lord Kilburn"
+msgid "%{name} the %{race} (Level %{level})"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Sir Gallanth"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ector"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Gwenneth"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Tyro"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ambrose"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Ruby"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Maximus"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:55
-msgid "Dimitry"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Thundax"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Fineous"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jojosh"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Crag Hack"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jezebel"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Jaclyn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Ergon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Tsabu"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:57
-msgid "Atlas"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Astra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Natasha"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Troyan"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Vatawna"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Rebecca"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Gem"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Ariel"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Carlawn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:59
-msgid "Luna"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Arie"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61 ../fheroes2/resource/maps_text.cpp:59
-msgid "Alamar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Vesper"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Crodo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Barok"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Kastore"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Agar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Falagar"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:61
-msgid "Wrathmont"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Flint"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Dawn"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Halon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Myrini"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Wilfrey"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Sarakin"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63 ../fheroes2/resource/maps_text.cpp:377
-msgid "Kalindra"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:63
-msgid "Mandigal"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zom"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Darlana"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Zam"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Ranloo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Charity"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Rialdo"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Roxana"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65 ../fheroes2/resource/maps_text.cpp:557
-msgid "Sandro"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:65
-msgid "Celia"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:552
-msgid "Roland"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Lord Corlagon"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Sister Eliza"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:88
-msgid "Archibald"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67 ../fheroes2/resource/maps_text.cpp:403
-msgid "Lord Halton"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:67
-msgid "Brother Bax"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Solmyr"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:194
-msgid "Dainwin"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Mog"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:760
-msgid "Uncle Ivan"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:373
-msgid "Joseph"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:285
-msgid "Gallavant"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69
-msgid "Elderian"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:179
-msgid "Ceallach"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:229
-msgid "Drakonia"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:422
-msgid "Martine"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:69 ../fheroes2/resource/maps_text.cpp:370
-msgid "Jarkonas"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:940
-msgid ""
-"You must purchase a spell book to use the mage guild, but you currently have "
-"no room for a spell book. Try giving one of your artifacts to another hero."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:950
-msgid "The three Anduran artifacts magically combine into one."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1056
-msgid "To cast spells, you must first buy a spell book for %{gold} gold."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1064
-msgid "Unfortunately, you seem to be a little short of cash at the moment."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes.cpp:1078
-msgid "Do you wish to buy one?"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:72
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:55
-msgid "%{name} the %{race} ( Level %{level} )"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:118
 msgid ""
 "'Grouped' combat formation bunches your army together in the center of your "
 "side of the battlefield."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:287
-#: ../fheroes2/pocketpc/pocketpc_heroes.cpp:161
 msgid "Are you sure you want to dismiss this Hero?"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:341
 msgid "View Stats"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:344
-msgid "View Morale Info"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:347
-msgid "View Luck Info"
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_dialog.cpp:350
 msgid "View Experience Info"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:353
 msgid "View Spell Points Info"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:356
 msgid "Set army combat formation to 'Spread'"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:359
 msgid "Set army combat formation to 'Grouped'"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:362
-msgid "Exit hero"
+msgid "Exit Hero Screen"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:369
-msgid "Dismiss hero"
+msgid "You cannot dismiss a hero in a castle"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:373
-msgid "Show prev heroes"
+msgid "Dismissal of %{name} the %{race} is prohibited by scenario"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:376
-msgid "Show next heroes"
+msgid "Dismiss %{name} the %{race}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_dialog.cpp:379
-msgid "Hero Screen"
+msgid "Show previous hero"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:39
-msgid "Bad Morale"
+msgid "Show next hero"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:42
-msgid "Neutral Morale"
+msgid "Blood Morale"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:47
-msgid "Good Morale"
+msgid "%{morale} Morale"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:61
-msgid "Bad Luck"
+msgid "%{luck} Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:64
-msgid "Neutral Luck"
+msgid "Current Luck Modifiers:"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:69
-msgid "Good Luck"
+msgid "Current Morale Modifiers:"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:113
-#: ../fheroes2/heroes/heroes_indicator.cpp:159
-#: ../fheroes2/heroes/skill.cpp:197
-msgid "Current Modifiers:"
+msgid "Entire army is undead, so morale does not apply."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:195
-msgid "Current experience %{exp1} Next level %{exp2}."
+msgid ""
+"Current experience %{exp1}.\n"
+" Next level %{exp2}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:215
 msgid "Level %{level}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_indicator.cpp:226
 msgid ""
 "%{name} currently has %{point} spell points out of a maximum of %{max}. The "
 "maximum number of spell points is 10 times your knowledge. It is "
@@ -4156,2521 +3868,1437 @@ msgid ""
 "special events."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:65
 msgid "%{name1} meets %{name2}"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:396
-#: ../fheroes2/heroes/heroes_meeting.cpp:406
 msgid " and "
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:414
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:417
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns %"
-"{spells1} from %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
+"%{spells1} from %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:420
 msgid ""
-"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches %"
-"{spells2} to %{learner}."
+"%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches "
+"%{spells2} to %{learner}."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_meeting.cpp:431
 msgid "Scholar Ability"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:83 ../fheroes2/spell/spell.cpp:109
 msgid "Town Portal"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:86
 msgid "Select town to port to."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:106
 msgid "Your hero is too tired to cast this spell today. Try again tomorrow."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:187
 msgid "%{spell} failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:236
+msgid "This spell is already in use."
+msgstr ""
+
 msgid "Enemy heroes are now fully identifiable."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:362
-#: ../fheroes2/heroes/heroes_spell.cpp:386
-msgid "No available towns. Spell Failed!!!"
+msgid "This spell cannot be used on a boat."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:459
-msgid "I fear these creatures are in the mood for a fight."
+msgid "This spell can be casted only nearby water."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:463
-msgid "The creatures are willing to join us!"
+msgid ""
+"No available towns.\n"
+"Spell Failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:468
-msgid "All the creatures will join us..."
+msgid ""
+"Nearest town occupied.\n"
+"Spell Failed!!!"
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:480
-msgid "These weak creatures will surely flee before us."
-msgstr ""
-
-#: ../fheroes2/heroes/heroes_spell.cpp:489
 msgid ""
 "You must be within %{count} spaces of a monster for the Visions spell to "
 "work."
 msgstr ""
 
-#: ../fheroes2/heroes/heroes_spell.cpp:506
+msgid "I fear these creatures are in the mood for a fight."
+msgstr ""
+
+msgid "The creatures are willing to join us!"
+msgstr ""
+
+msgid "All the creatures will join us..."
+msgstr ""
+
+msgid "These weak creatures will surely flee before us."
+msgstr ""
+
 msgid ""
 "You must be standing on the entrance to a mine (sawmills and alchemists "
 "don't count) to cast this spell."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:151
-msgid "Power"
-msgstr ""
-
-#: ../fheroes2/heroes/skill.cpp:172
 msgid "Your attack skill is a bonus added to each creature's attack skill."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:177
 msgid "Your defense skill is a bonus added to each creature's defense skill."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:182
 msgid "Your spell power determines the length or power of a spell."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:187
 msgid ""
 "Your knowledge determines how many spell points your hero may have. Under "
-"normal cirumstances, a hero is limited to 10 spell points per level of "
+"normal circumstances, a hero is limited to 10 spell points per level of "
 "knowledge."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
+msgid "Current Modifiers:"
+msgstr ""
+
 msgid "skill|Basic"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
 msgid "skill|Advanced"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:214
 msgid "skill|Expert"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:337
 msgid "Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:338
 msgid "Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Basic Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Advanced Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:367
 msgid "Expert Pathfinding"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Basic Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Advanced Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:368
 msgid "Expert Archery"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Basic Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Advanced Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:369
 msgid "Expert Logistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Basic Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Advanced Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:370
 msgid "Expert Scouting"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Basic Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Advanced Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:371
 msgid "Expert Diplomacy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Basic Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Advanced Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:372
 msgid "Expert Navigation"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Basic Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Advanced Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:373
 msgid "Expert Leadership"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Basic Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Advanced Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:374
 msgid "Expert Wisdom"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Basic Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Advanced Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:375
 msgid "Expert Mysticism"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Basic Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Advanced Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:376
 msgid "Expert Luck"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Basic Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Advanced Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:377
 msgid "Expert Ballistics"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Basic Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Advanced Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:378
 msgid "Expert Eagle Eye"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Basic Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Advanced Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:379
 msgid "Expert Necromancy"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Basic Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Advanced Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:380
 msgid "Expert Estates"
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:406
-msgid "Allows you to negotiate with monsters who are weaker than your group."
+msgid " allows you to negotiate with monsters who are weaker than your group."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:421
-msgid "Allows your hero to learn third level spells."
+msgid "All of the creatures may offer to join you."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:423
-msgid "Allows your hero to learn fourth level spells."
+msgid " allows your hero to learn third level spells."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:425
-msgid "Allows your hero to learn fifth level spells."
+msgid " allows your hero to learn fourth level spells."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:440
+msgid " allows your hero to learn fifth level spells."
+msgstr ""
+
 msgid ""
-"Gives your hero's catapult shots a greater chance to hit and do damage to "
+" gives your hero's catapult shots a greater chance to hit and do damage to "
 "castle walls."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:442
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot has a greater chance "
-"to hit and do damage to castle walls."
+" gives your hero's catapult an extra shot, and each shot has a greater "
+"chance to hit and do damage to castle walls."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:444
 msgid ""
-"Gives your hero's catapult an extra shot, and each shot automatically "
+" gives your hero's catapult an extra shot, and each shot automatically "
 "destroys any wall, except a fortified wall in a Knight town."
 msgstr ""
 
-#: ../fheroes2/heroes/skill.cpp:858 ../fheroes2/heroes/skill.cpp:959
-msgid "View %{skill} Info"
-msgstr ""
-
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:108
 msgid "Blue"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:111
 msgid "Green"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:114
 msgid "Red"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32
 msgid "Yellow"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:112
 msgid "Orange"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:32 ../fheroes2/kingdom/color.cpp:113
 msgid "Purple"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:107
 msgid "Aqua"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:109
 msgid "Brown"
 msgstr ""
 
-#: ../fheroes2/kingdom/color.cpp:110 ../fheroes2/resource/resource.cpp:283
 msgid "Gold"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:238
 msgid "Hero/Stats"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:241
 msgid "Skills"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:244
 msgid "Artifacts"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:473
 msgid "Town/Castle"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:476
 msgid "Garrison"
 msgstr ""
 
-#: ../fheroes2/kingdom/kingdom_overview.cpp:566
 msgid "Gold Per Day:"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Cursed"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Awful"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Bad"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Normal"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Good"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Great"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:28
 msgid "luck|Irish"
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:48
 msgid ""
 "Bad luck sometimes falls on your armies in combat, causing their attacks to "
 "only do half damage."
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:49
 msgid ""
 "Neutral luck means your armies will never get lucky or unlucky attacks on "
 "the enemy."
 msgstr ""
 
-#: ../fheroes2/kingdom/luck.cpp:50
 msgid ""
 "Good luck sometimes lets your armies get lucky attacks (double strength) in "
 "combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Treason"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Awful"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Poor"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Normal"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Good"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Great"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:28
 msgid "morale|Blood!"
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:48
 msgid "Bad morale may cause your armies to freeze in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:49
 msgid ""
 "Neutral morale means your armies will never be blessed with extra attacks or "
 "freeze in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/morale.cpp:50
 msgid "Good morale may give your armies extra attacks in combat."
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Knight"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Barbarian"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:29
 msgid "Sorceress"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Warlock"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Wizard"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Necromancer"
 msgstr ""
 
-#: ../fheroes2/kingdom/race.cpp:30
 msgid "Multi"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Standing"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Crawling"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Very Slow"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Slow"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Average"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:28
 msgid "speed|Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Very Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Ultra Fast"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Blazing"
 msgstr ""
 
-#: ../fheroes2/kingdom/speed.cpp:29
 msgid "speed|Instant"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:32
 msgid "week|PLAGUE"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Ant"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Grasshopper"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Dragonfly"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Spider"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Butterfly"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:33
 msgid "week|Bumblebee"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Locust"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Earthworm"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Hornet"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Beetle"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Squirrel"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:34
 msgid "week|Rabbit"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Gopher"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Badger"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Eagle"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Weasel"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Raven"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Mongoose"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:35
 msgid "week|Aardvark"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Lizard"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Tortoise"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Hedgehog"
 msgstr ""
 
-#: ../fheroes2/kingdom/week.cpp:36
 msgid "week|Condor"
 msgstr ""
 
-#: ../fheroes2/kingdom/world_loadmap.cpp:1424
-msgid "The ultimate artifact is really the %{name}"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1428
-msgid "The ultimate artifact may be found in the %{name} regions of the world."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1433
-msgid "north-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1436
-msgid "north"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1438
-msgid "north-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1444
-msgid "west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1447
-msgid "center"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1449
-msgid "east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1454
-msgid "south-west"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1457
-msgid "south"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1459
-msgid "south-east"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1463
-msgid "The truth is out there."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1464
-msgid "The dark side is stronger."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1465
-msgid "The end of the world is near."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1466
-msgid "The bones of Lord Slayer are buried in the foundation of the arena."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1467
-msgid "A Black Dragon will take out a Titan any day of the week."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1468
-msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1470
-msgid ""
-"You can load the newest version of game from a site:\n"
-" http://sf.net/projects/fheroes2"
-msgstr ""
-
-#: ../fheroes2/kingdom/world_loadmap.cpp:1471
-msgid "This game is now in beta development version. ;)"
-msgstr ""
-
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Desert"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Snow"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Wasteland"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:30
 msgid "Beach"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Lava"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:31 ../fheroes2/resource/maps_text.cpp:210
 msgid "Dirt"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:31
 msgid "Grass"
 msgstr ""
 
-#: ../fheroes2/maps/ground.cpp:31
-msgid "Water"
+msgid "Ocean"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Small"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Medium"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Large"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Extra Large"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:104
 msgid "maps|Custom Size"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:122
 msgid "Ore Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:123
 msgid "Sulfur Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:124
 msgid "Crystal Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:125
 msgid "Gems Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:126
 msgid "Gold Mine"
 msgstr ""
 
-#: ../fheroes2/maps/maps.cpp:130
 msgid "Mine"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:365
 msgid "Alchemist Lab"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:367
 msgid "Daemon Cave"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:369
 msgid "Faerie Ring"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:373 ../fheroes2/resource/maps_text.cpp:217
 msgid "Dragon City"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:375
-msgid "Light House"
+msgid "Lighthouse"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:377
 msgid "Water Wheel"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:379
 msgid "Mines"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:381
 msgid "Obelisk"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:383
 msgid "Oasis"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:385
 msgid "Sawmill"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:387
 msgid "Oracle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:389
 msgid "Desert Tent"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:393
 msgid "Wagon Camp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:395
 msgid "Windmill"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:397
 msgid "Random Town"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:399
 msgid "Random Castle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:401
 msgid "Watch Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:403
 msgid "Tree City"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:405
 msgid "Tree House"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:407
 msgid "Ruins"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:409
 msgid "Fort"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:411
-msgid "Trading Post"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:413
 msgid "Abandoned Mine"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:415
 msgid "Tree of Knowledge"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:417
 msgid "Witch Doctor's Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:419
 msgid "Temple"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:421
 msgid "Hill Fort"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:423
 msgid "Halfling Hole"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:425
 msgid "Mercenary Camp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:429
 msgid "City of the Dead"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:433
 msgid "Sphinx"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:435
 msgid "Troll Bridge"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:437
 msgid "Witch Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:439
 msgid "Xanadu"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:443
 msgid "Magellan Maps"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:445
 msgid "Derelict Ship"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:447
-msgid "Ship Wreck"
+msgid "Shipwreck"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:449
 msgid "Observation Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:451
-msgid "Freeman Foundry"
+msgid "Freeman's Foundry"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:453
 msgid "Watering Hole"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:455
 msgid "Artesian Spring"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:457
 msgid "Gazebo"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:459
 msgid "Archer's House"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:461
 msgid "Peasant Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:463
 msgid "Dwarf Cottage"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:465
 msgid "Stone Liths"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:467
 msgid "Magic Well"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:468
 msgid "Heroes"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:470 ../fheroes2/maps/mp2.cpp:488
-msgid "Shrub"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:471
 msgid "Nothing Special"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:472
 msgid "Tar Pit"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:473
-msgid "Coast"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:474
 msgid "Mound"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:475
 msgid "Dune"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:476
 msgid "Stump"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:477
 msgid "Cactus"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:478
 msgid "Trees"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:479
 msgid "Dead Tree"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:480
 msgid "Mountains"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:481
 msgid "Volcano"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:482
 msgid "Rock"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:483
 msgid "Flowers"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:484
 msgid "Water Lake"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:485
 msgid "Mandrake"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:486
 msgid "Crater"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:487
 msgid "Lava Pool"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:489
+msgid "Shrub"
+msgstr ""
+
 msgid "Buoy"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:491 ../fheroes2/monster/monster.cpp:116
 msgid "Skeleton"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:492
 msgid "Treasure Chest"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:493
 msgid "Sea Chest"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:494
 msgid "Campfire"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:495
 msgid "Fountain"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:496
 msgid "Genie Lamp"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:497
 msgid "Goblin Hut"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:499
 msgid "Monster"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:500
 msgid "Resource"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:501
 msgid "Whirlpool"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:502
 msgid "Artifact"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:503
 msgid "Boat"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:510
 msgid "Standing Stones"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:514
 msgid "Idol"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:515
 msgid "Shrine of the First Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:516
 msgid "Shrine of the Second Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:517
 msgid "Shrine of the Third Circle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:518
 msgid "Wagon"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:519
 msgid "Lean To"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:520
 msgid "Flotsam"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:521
 msgid "Shipwreck Survivor"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:522
 msgid "Bottle"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:523
 msgid "Magic Garden"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:529
 msgid "Jail"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:531
 msgid "Traveller's Tent"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:532
 msgid "Barrier"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:535
 msgid "Fire Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:537
 msgid "Air Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:539
 msgid "Earth Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:541
 msgid "Water Summoning Altar"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:543
 msgid "Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:545
-msgid "Arena"
-msgstr ""
-
-#: ../fheroes2/maps/mp2.cpp:547
 msgid "Stables"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:549
 msgid "Alchemist's Tower"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:551
 msgid "Hut of the Magi"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:553
 msgid "Eye of the Magi"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:555
 msgid "Mermaid"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:557
 msgid "Sirens"
 msgstr ""
 
-#: ../fheroes2/maps/mp2.cpp:558
 msgid "Reefs"
 msgstr ""
 
-#: ../fheroes2/monster/monster.cpp:59
-msgid "Peasant"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:59 ../fheroes2/resource/maps_text.cpp:501
-msgid "Peasants"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Archer"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:60
-msgid "Archers"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Ranger"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:61
-msgid "Rangers"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Pikeman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:62
-msgid "Pikemen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Veteran Pikeman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:63
-msgid "Veteran Pikemen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Swordsman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:64
-msgid "Swordsmen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Master Swordsman"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:65
-msgid "Master Swordsmen"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Cavalry"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:66
-msgid "Cavalries"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Champion"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:67
-msgid "Champions"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Paladin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:68
-msgid "Paladins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:69
-msgid "Crusader"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:69
-msgid "Crusaders"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Goblin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:72
-msgid "Goblins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orc"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:73
-msgid "Orcs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chief"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:74
-msgid "Orc Chiefs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Wolf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:75
-msgid "Wolves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogre"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:76
-msgid "Ogres"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Ogre Lord"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:77
-msgid "Ogre Lords"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "Troll"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:78
-msgid "Trolls"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "War Troll"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:79
-msgid "War Trolls"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:80
-msgid "Cyclops"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:80
-msgid "Cyclopes"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Sprite"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:83
-msgid "Sprites"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Dwarf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:84
-msgid "Dwarves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Battle Dwarf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:85
-msgid "Battle Dwarves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:86
-msgid "Elves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elf"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:87
-msgid "Grand Elves"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druid"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:88
-msgid "Druids"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druid"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:89
-msgid "Greater Druids"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorn"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:90
-msgid "Unicorns"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:91
-msgid "Phoenix"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:91
-msgid "Phoenixes"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaur"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:94
-msgid "Centaurs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyle"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:95
-msgid "Gargoyles"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffin"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:96
-msgid "Griffins"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaur"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:97
-msgid "Minotaurs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur King"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:98
-msgid "Minotaur Kings"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydra"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:99
-msgid "Hydras"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:100
-msgid "Green Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:101
-msgid "Red Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:102
-msgid "Black Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halfling"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:105
-msgid "Halflings"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boar"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:106
-msgid "Boars"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golem"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:107
-msgid "Iron Golems"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golem"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:108
-msgid "Steel Golems"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Roc"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:109
-msgid "Rocs"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Mage"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:110
-msgid "Magi"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmage"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:111
-msgid "Archmagi"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:112
-msgid "Giant"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:112 ../fheroes2/resource/maps_text.cpp:293
-msgid "Giants"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titan"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:113
-msgid "Titans"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:116
-msgid "Skeletons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:117
-msgid "Zombies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:118
-msgid "Mutant Zombies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummy"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:119
-msgid "Mummies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummy"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:120
-msgid "Royal Mummies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampire"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:121
-msgid "Vampires"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lord"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:122
-msgid "Vampire Lords"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Lich"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:123
-msgid "Liches"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Lich"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:124
-msgid "Power Liches"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragon"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:125
-msgid "Bone Dragons"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogue"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:128
-msgid "Rogues"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomad"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:129
-msgid "Nomads"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghost"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:130
-msgid "Ghosts"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genie"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:131
-msgid "Genies"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusa"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:132
-msgid "Medusas"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:133
-msgid "Earth Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:134
-msgid "Air Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:135
-msgid "Fire Elementals"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elemental"
-msgstr ""
-
-#: ../fheroes2/monster/monster.cpp:136
-msgid "Water Elementals"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_castle.cpp:694
-msgid "buy"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:158
-msgid "Campaign Game"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "Error"
-msgstr ""
-
-#: ../fheroes2/pocketpc/pocketpc_mainmenu.cpp:243
-msgid "This release is compiled without network support."
-msgstr ""
-
-#: ../fheroes2/resource/artifact.cpp:51
 msgid "Ultimate Book of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:51 ../fheroes2/resource/artifact.cpp:77
-#: ../fheroes2/resource/artifact.cpp:78 ../fheroes2/resource/artifact.cpp:79
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "The %{name} increases your knowledge by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:52
 msgid "Ultimate Sword of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:52 ../fheroes2/resource/artifact.cpp:68
-#: ../fheroes2/resource/artifact.cpp:71 ../fheroes2/resource/artifact.cpp:74
-#: ../fheroes2/resource/artifact.cpp:75 ../fheroes2/resource/artifact.cpp:149
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "The %{name} increases your attack skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:53
 msgid "Ultimate Cloak of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:53 ../fheroes2/resource/artifact.cpp:70
-#: ../fheroes2/resource/artifact.cpp:73 ../fheroes2/resource/artifact.cpp:76
 msgid "The %{name} increases your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:54
 msgid "Ultimate Wand of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:54 ../fheroes2/resource/artifact.cpp:59
-#: ../fheroes2/resource/artifact.cpp:60 ../fheroes2/resource/artifact.cpp:61
-#: ../fheroes2/resource/artifact.cpp:62 ../fheroes2/resource/artifact.cpp:148
 msgid "The %{name} increases your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:55
 msgid "Ultimate Shield"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:55 ../fheroes2/resource/artifact.cpp:128
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "The %{name} increases your attack and defense skills by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:56
 msgid "Ultimate Staff"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:56 ../fheroes2/resource/artifact.cpp:130
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "The %{name} increases your spell power and knowledge by %{count} each."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "Ultimate Crown"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:57
 msgid "The %{name} increases each of your basic skills by %{count} points."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "Golden Goose"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:58
 msgid "The %{name} brings in an income of %{count} gold per turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:59
 msgid "Arcane Necklace of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:60
 msgid "Caster's Bracelet of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:61
 msgid "Mage's Ring of Power"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:62
 msgid "Witch's Broach of Magic"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:63
 msgid "Medal of Valor"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:63 ../fheroes2/resource/artifact.cpp:64
-#: ../fheroes2/resource/artifact.cpp:65 ../fheroes2/resource/artifact.cpp:66
 msgid "The %{name} increases your morale."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:64
 msgid "Medal of Courage"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:65
 msgid "Medal of Honor"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:66
 msgid "Medal of Distinction"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "Fizbin of Misfortune"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:67
 msgid "The %{name} greatly decreases your morale by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:68
 msgid "Thunder Mace of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "Armored Gauntlets of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:69
 msgid "The %{name} increase your defense skill by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:70
 msgid "Defender Helm of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:71
 msgid "Giant Flail of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "Ballista of Quickness"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:72
 msgid "The %{name} lets your catapult fire twice per combat round."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:73
 msgid "Stealth Shield of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:74
 msgid "Dragon Sword of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:75
 msgid "Power Axe of Dominion"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:76
 msgid "Divine Breastplate of Protection"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:77
 msgid "Minor Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:78
 msgid "Major Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:79
 msgid "Superior Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:80
 msgid "Foremost Scroll of Knowledge"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:81
 msgid "Endless Sack of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:81 ../fheroes2/resource/artifact.cpp:82
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "The %{name} provides you with %{count} gold per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:82
 msgid "Endless Bag of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:83
 msgid "Endless Purse of Gold"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:84
 msgid "Nomad Boots of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:84 ../fheroes2/resource/artifact.cpp:85
 msgid "The %{name} increase your movement on land."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:85
 msgid "Traveler's Boots of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:86
 msgid "Lucky Rabbit's Foot"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:86 ../fheroes2/resource/artifact.cpp:87
-#: ../fheroes2/resource/artifact.cpp:88 ../fheroes2/resource/artifact.cpp:89
 msgid "The %{name} increases your luck in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:87
 msgid "Golden Horseshoe"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:88
 msgid "Gambler's Lucky Coin"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:89
 msgid "Four-Leaf Clover"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "True Compass of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:90
 msgid "The %{name} increases your movement on land and sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "Sailor's Astrolabe of Mobility"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:91
 msgid "The %{name} increases your movement on sea."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "Evil Eye"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:92
 msgid "The %{name} reduces the casting cost of curse spells by half."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "Enchanted Hourglass"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:93
 msgid "The %{name} extends the duration of all your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "Gold Watch"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:94
 msgid "The %{name} doubles the effectiveness of your hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "Skullcap"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:95
 msgid "The %{name} halves the casting cost of all mind influencing spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "Ice Cloak"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:96
 msgid "The %{name} halves all damage your troops take from cold spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "Fire Cloak"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:97
 msgid "The %{name} halves all damage your troops take from fire spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "Lightning Helm"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:98
 msgid "The %{name} halves all damage your troops take from lightning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid "Evercold Icicle"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:99
 msgid ""
 "The %{name} causes your cold spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid "Everhot Lava Rock"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:100
 msgid ""
 "The %{name} causes your fire spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid "Lightning Rod"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:101
 msgid ""
 "The %{name} causes your lightning spells to do %{count} percent more damage "
 "to enemy troops."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "Snake-Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:102
 msgid "The %{name} halves the casting cost of all your bless spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid "Ankh"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:103
 msgid ""
 "The %{name} doubles the effectiveness of all your resurrect and animate "
 "spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "Book of Elements"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:104
 msgid "The %{name} doubles the effectiveness of all your summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "Elemental Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:105
 msgid "The %{name} halves the casting cost of all summoning spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "Holy Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:106
 msgid "The %{name} makes all your troops immune to curse spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "Pendant of Free Will"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:107
 msgid "The %{name} makes all your troops immune to hypnotize spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "Pendant of Life"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:108
 msgid "The %{name} makes all your troops immune to death spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "Serenity Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:109
 msgid "The %{name} makes all your troops immune to berserk spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "Seeing-eye Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:110
 msgid "The %{name} makes all your troops immune to blindness spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "Kinetic Pendant"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:111
 msgid "The %{name} makes all your troops immune to paralyze spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "Pendant of Death"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:112
 msgid "The %{name} makes all your troops immune to holy spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "Wand of Negation"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:113
 msgid "The %{name} protects your troops from the Dispel Magic spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid "Golden Bow"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:114
 msgid ""
 "The %{name} eliminates the %{count} percent penalty for your troops shooting "
-"past obstacles. (e.g. castle walls)"
+"past obstacles (e.g. castle walls)."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid "Telescope"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:115
 msgid ""
 "The %{name} increases the amount of terrain your hero reveals when "
 "adventuring by %{count} extra square."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid "Statesman's Quill"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:116
 msgid ""
 "The %{name} reduces the cost of surrender to %{count} percent of the total "
 "cost of troops you have in your army."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "Wizard's Hat"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:117
 msgid "The %{name} increases the duration of your spells by %{count} turns."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "Power Ring"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:118
 msgid "The %{name} returns %{count} extra power points/turn to your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "Ammo Cart"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:119
 msgid "The %{name} provides endless ammunition for all your troops that shoot."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "Tax Lien"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:120
 msgid "The %{name} costs you %{count} gold pieces/turn."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "Hideous Mask"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:121
 msgid "The %{name} prevents all 'wandering' armies from joining your hero."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "Endless Pouch of Sulfur"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:122
 msgid "The %{name} provides %{count} unit of sulfur per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "Endless Vial of Mercury"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:123
 msgid "The %{name} provides %{count} unit of mercury per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "Endless Pouch of Gems"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:124
 msgid "The %{name} provides %{count} unit of gems per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "Endless Cord of Wood"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:125
 msgid "The %{name} provides %{count} unit of wood per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "Endless Cart of Ore"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:126
 msgid "The %{name} provides %{count} unit of ore per day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "Endless Pouch of Crystal"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:127
 msgid "The %{name} provides %{count} unit of crystal/day."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:128
 msgid "Spiked Helm"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:129
 msgid "Spiked Shield"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:130
 msgid "White Pearl"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:131
 msgid "Black Pearl"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "Magic Book"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:133
 msgid "The %{name} enables you to cast spells."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "Spell Scroll"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:140
 msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid "Arm of the Martyr"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:141
 msgid ""
 "The %{name} increases your spell power by %{count} but adds the undead "
 "morale penalty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "Breastplate of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:142
 msgid "The %{name} increases your defense by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid "Broach of Shielding"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:143
 msgid ""
 "The %{name} provides %{count} percent protection from Armageddon and "
 "Elemental Storm, but decreases spell power by 2."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid "Battle Garb of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:144
 msgid ""
 "The %{name} combines the powers of the three Anduran artifacts.  It provides "
 "maximum luck and morale for your troops and gives you the Town Portal spell."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid "Crystal Ball"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:145
 msgid ""
 "The %{name} lets you get more specific information about monsters, enemy "
 "heroes, and castles nearby the hero who holds it."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid "Heart of Fire"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:146
 msgid ""
 "The %{name} provides %{count} percent protection from fire, but doubles the "
 "damage taken from cold."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid "Heart of Ice"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:147
 msgid ""
 "The %{name} provides %{count} percent protection from cold, but doubles the "
 "damage taken from fire."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:148
 msgid "Helmet of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:149
 msgid "Holy Hammer"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "Legendary Scepter"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:150
 msgid "The %{name} adds %{count} points to all attributes."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "Masthead"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:151
 msgid "The %{name} boosts your luck and morale by %{count} each in sea combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "Sphere of Negation"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:152
 msgid "The %{name} disables all spell casting, for both sides, in combat."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "Staff of Wizardry"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:153
 msgid "The %{name} boosts your spell power by %{count}."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "Sword Breaker"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:154
 msgid "The %{name} increases your defense by %{count} and attack by 1."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:155
 msgid "Sword of Anduran"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "Spade of Necromancy"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:156
 msgid "The %{name} gives you increased necromancy skill."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:638
 msgid ""
 "You find an elaborate aontainer which housesan old vellum scroll. The runes "
 "on the container are very old, and the artistry with whitch it was put "
@@ -6678,7 +5306,6 @@ msgid ""
 "magical power."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:639
 msgid ""
 "One of the less intelligent members of your party picks up an arm off of the "
 "ground. Despite its missing a body, it is still moving. Your troops find the "
@@ -6687,7 +5314,6 @@ msgid ""
 "making."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:640
 msgid ""
 "You come upon a sign. It reads: \"Here lies the body of Anduran. Bow and "
 "swear fealty, and you shall be rewarded.\" You decide to do as it says. As "
@@ -6695,21 +5321,18 @@ msgid ""
 "that you are suddenly wearing a gleaming, ornate breastplate."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:641
 msgid ""
 "A kindly Sorceress thinks that your army's defenses could use a magical "
 "boost. She offers to enchant the Broach that you wear on your cloak, and you "
 "accept."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:642
 msgid ""
 "Out of pity for a poor peasant, you purchase a chest of old junk they are "
 "hawking for too much gold. Later, as you search through it, you find it "
 "contains the 3 pieces of the legendary battle garb of Anduran!"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:643
 msgid ""
 "You come upon a caravan of gypsies who are feasting and fortifying their "
 "bodies with mead. They call you forward and say \"If you prove that you can "
@@ -6718,7 +5341,6 @@ msgid ""
 "Crystal Ball."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:644
 msgid ""
 "You enter a recently burned glade and come upon a Fire Elemental sitting "
 "atop a rock. It looks up, its flaming face contorted in a look of severe "
@@ -6726,7 +5348,6 @@ msgid ""
 "it, but it passes right through them and sears itself into your chest."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:645
 msgid ""
 "Suddenly, a biting coldness engulfs your body. You seize up, falling from "
 "your horse. The pain subsides, but you still feel as if your chest is "
@@ -6735,7 +5356,6 @@ msgid ""
 "woods and disappear."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:646
 msgid ""
 "You spy a gleaming object poking up out of the ground. You send a member of "
 "your party over to investigate. He comes back with a golden helmet in his "
@@ -6743,7 +5363,6 @@ msgid ""
 "only man who was known to wear solid gold armor."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:647
 msgid ""
 "You come upon a battle where a Paladin has been mortally wounded by a group "
 "of Zombies. He asks you to take his hammer and finish what he started.  As "
@@ -6751,7 +5370,6 @@ msgid ""
 "Zombies lie dead, the hammer dripping with blood. You strap it to your belt."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:648
 msgid ""
 "Upon cresting a small hill, you come upon a ridiculous looking sight. A "
 "Sprite is attempting to carry a Scepter that is almost as big as it is. "
@@ -6760,7 +5378,6 @@ msgid ""
 "flying anyway.\""
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:649
 msgid ""
 "An old seaman tells you a tale of an enchanted masthead that he used in his "
 "youth to rally his crew during times of trouble. He then hands you a faded "
@@ -6768,14 +5385,12 @@ msgid ""
 "underneath a nearby dock."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:650
 msgid ""
 "You stop to help a Peasant catch a runaway mare. To show his gratitude, he "
 "hands you a tiny sphere. As soon as you grasp it, you feel the magical "
 "energy drain from your limbs..."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:651
 msgid ""
 "While out scaring up game, your troops find a mysterious staff levitating "
 "about three feet off of the ground. They hand it to you, and you notice an "
@@ -6783,13 +5398,11 @@ msgid ""
 "words, and you'll win every fight.\""
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:652
 msgid ""
 "A former Captain of the Guard admires your quest and gives you the enchanted "
 "Sword Breaker that he relied on during his tour of duty."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:653
 msgid ""
 "A Troll stops you and says: \"Pay me 5,000 gold, or the Sword of Anduran "
 "will slay you where you stand.\" You refuse. The troll grabs the sword "
@@ -6798,4464 +5411,80 @@ msgid ""
 "sharp objects."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:654
 msgid ""
 "A dirty shovel has been thrust into a dirt mound nearby. Upon investigation, "
 "you discover it to be the enchanted shovel of the Gravediggers, long thought "
 "lost by mortals."
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:896
 msgid ""
-"Do you want to use your knowledge of magical secrets to transcribe the %"
-"{spell} Scroll into your spell book?\n"
-"The Scroll will be consumed.\n"
-" Spell point: %{sp}"
+"Do you want to use your knowledge of magical secrets to transcribe the "
+"%{spell} Scroll into your Magic Book?\n"
+"The Spell Scroll will be consumed.\n"
+" Cost in spell points: %{sp}"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:960
-msgid "Open book"
+msgid "Transcribe Spell Scroll"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:965
-msgid "Transcribe scroll"
+msgid "View Spells"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:975
-#: ../fheroes2/resource/artifact.cpp:1008
+msgid "View %{name} Info"
+msgstr ""
+
 msgid "Move %{name}"
 msgstr ""
 
-#: ../fheroes2/resource/artifact.cpp:998
 msgid "Cannot move artifact"
 msgstr ""
 
-#: ../fheroes2/resource/maps_text.cpp:15
-msgid ""
-"425 bottles of beer on the wall, 425 bottles of beer! If one of those "
-"bottles should happen to fall, there'll be..."
+msgid "This item can't be traded."
 msgstr ""
 
-#: ../fheroes2/resource/maps_text.cpp:16
-msgid "A balanced scenario with lots of resources and land to explore."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:17
-msgid ""
-"A bandit army of gorgons jump you without warning.  they stone your entire "
-"army demand 500 gold before they will release your comrads.  Realizing that "
-"it is much cheeper to pay then rebuild your army you part with the gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:18
-msgid "Abandon All Hope!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:19
-msgid "Abandon All Hope Ye That Enter Here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:20
-msgid "A bit of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:21
-msgid "A bit of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:22
-msgid "A bit of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:23
-msgid ""
-"Above you looms the ancient Ice Palace.  Dimly remembered myth speaks of a "
-"Prince who rejected the advances of the Winter Goddess, and thus he and his "
-"domain were cursed to remain shrouded in ice, hidden in a forgotten corner "
-"of the world.  It is said that he can only be rescued by a hero who is both "
-"clever and bold.  Are you that one?  Do you dare enter this frozen domain?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:24
-msgid "A cache of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:25
-msgid "A cache of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:26
-msgid "A cache of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:27
-msgid "A cache of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:28
-msgid "A cache of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:29
-msgid ""
-"A chance to end a bitter war has finally arrived as a new resource-laden "
-"land has been discovered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:30
-msgid "A chunk of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:31
-msgid "A chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:32
-msgid "A couple of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:33
-msgid "\"Act of Desperation\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:34
-msgid ""
-"A desert isle rich in resources rewards the quick.  Just be sure to watch "
-"your back!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:35
-msgid "A dolphin playfully jumps into the air."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:36
-msgid ""
-"A Dragon, A Cyclops, or an Undead. King of the Centaurs, His name is ....?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:37
-msgid "A flight of dragons circles overhead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:38
-msgid "A flock of seagulls circle overhead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:39
-msgid "A friendly dolphin splashes alongside the ship."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:40
-msgid ""
-"After a long search of the island, I have discovered that there is no way "
-"for me to escape without help.  I can not steal a ship from one of the "
-"coastal castles, and I dare not venture into the desert unless I wish to "
-"become Dragon food.  Should anyone find this, I beg of you, please send a "
-"ship and get me off this cursed island!  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:41
-msgid ""
-"After centuries of friendship, the Wizards have suddenly decided to stop "
-"sharing their Library with the rest of the world.  This can't be good!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:42
-msgid ""
-"After many years of peace, you discover that your sworn enemy from across "
-"the sea has chosen to invade your homeland by raising up the ocean floor to "
-"bridge the distance! You must not let them gain a foothold on this "
-"continent, in fact, your King has ordered you to establish a foothold on "
-"theirs!  To make matters worse, two of your OWN towns have thrown in their "
-"lots with the enemy..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:43
-msgid ""
-"After you return from a scouting trip, your Seneschal hurries to greet you.  "
-"\"My Lord, in your absence I signed an agreement in your name with a Master "
-"Merchant.  If we supply him with the resources he needs, through trading, he "
-"can return the resources to us in a week or so, plus some additional ones."
-"\"  The Seneschal eyes you anxiously.  You hesitate, then nod slowly, "
-"\"Good, we can use more resources>\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:44
-msgid "A ghostly pirate ship appears and sails on by."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:45
-msgid ""
-"A Gift from your King, and a note that reads \"Use these resources wisely, "
-"It's all we have left\"."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:46
-msgid ""
-"A gift of gold, m'lord, from the people of Enroth, to the people of Enroth.  "
-"Good luck, and may God save true King Roland!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:47
-msgid "A glint by a tree catches your eye..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:48
-msgid "A gold cache!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:49
-msgid "A gold chunk!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:50
-msgid "A gold nugget!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:51
-msgid ""
-"A great Black dragon stands before you. It speaks in a suprisingly soft "
-"voice, saying, \"The elves believe they have sent another hero to reclaim "
-"their prize. I believe they have sent me another meal.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:52
-msgid ""
-"A group of peasant farmers approaches you, \"We are in dire need of your "
-"assistance.  Our castle to the north has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:53
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance.  Our castle to the east has been overrun and our Lord killed.  "
-"Please help us regain our homes!  There are still women and children there!  "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:54
-msgid ""
-"A group of peasant farmers approach you, \"We are in dire need of your "
-"assistance. Our castle to the east has been overrun and our Lord killed. "
-"Please help us regain our homes! There are still women and children there! "
-"Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:55
-msgid ""
-"A group of peasant farmers approach you, We are in dire need of your "
-"assistance.  Our castle to the northeast has been overrun and our Lord "
-"killed.  Please help us regain our homes!  There are still women and "
-"children there!  Take what we have to help!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:56
-msgid "A handful of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:57
-msgid ""
-"Ah, you stumble across something buried in the sand.  As you dig it up you "
-"discover a small pile of gems and crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:58
-msgid ""
-"A Knight and Necromancer team up against the Barbarian and Sorceress. (Blue "
-"and Green vs Red and Yellow)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:60
-msgid ""
-"A large contingent of the king's guard approaches you.  \"Ahh, we have "
-"finally caught up to you.  The king requires tribute from all of his vassals "
-"and you have been negligent far too long.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:61
-msgid ""
-"A large map with lots of resources and treasure. Exploration and victory "
-"will require many heroes."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:62
-msgid "A legion of peasants stands between you and this unclaimed island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:63
-msgid "Algary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:64
-msgid "A little bit closer..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:65
-msgid "All mines are grouped by type. Trade is your only hope."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:66
-msgid "A lump of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:67
-msgid "A lump of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:68
-msgid "A lump of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:69
-msgid ""
-"A man appears from behind the sand dune. \"At last,\" he says, \"Someone has "
-"come to rescue me! I am forever grateful. Alas all I have to offer you in "
-"return are these souvenirs from my wrecked ship.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:70
-msgid ""
-"A man is laying on the ground, near death. He looks to you and speaks, "
-"\"Please help my companions! Please... they can't...cough...get away from..."
-"cough...the drag...\" With that, he dies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:71
-msgid ""
-"A merchant caravan arrives, bringing gold and supplies, however, no one can "
-"seem to remember where they came from.  You silently praise this anonymous "
-"benefactor and continue your duties."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:72
-msgid "a mirror"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:73
-msgid "An albatross flies ahead of the ship for a while"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:74
-msgid "Anduran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:75
-msgid ""
-"An enemy from across the sea has seized half your towns.  Can you put aside "
-"your own feud with your brother to fight this common enemy?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:76
-msgid "\"Annexation\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:77
-msgid ""
-"An old elf is sitting on a rock in a glen, pounding on the shackles on his "
-"feet with a stone. You help him remove them and ask him his tale. \"I'm a "
-"deserter from Drakonia's army. She has enslaved all the elves to support her "
-"madness. She must be stopped.\" Then he slips into the woods without a "
-"sound, leaving behind just his cloak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:78
-msgid "Antioch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:79
-msgid "A piece of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:80
-msgid "A pile of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:81
-msgid "A pile of gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:82
-msgid "A pile of gold!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:83
-msgid ""
-"A plague of undead is upon us. Who will unite the living against the dead?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:84
-msgid "\"Apocalypse\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:85
-msgid "A quantity of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:86
-msgid "A quantity of mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:87
-msgid "A quantity of sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:89
-msgid ""
-"Archibald has also sent an army to find the Crown, you must find it first or "
-"all is lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:90
-msgid "Archibald is hiding at the end of the river."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:91
-msgid ""
-"A resource rich valley keeps the Wizard and the Necromancer apart. Your "
-"opponent's army will arrive in 3 months so hurry."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:92
-msgid "Arm of the Crusader"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:93
-msgid "Arm of the Cyclops"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:94
-msgid "Arm of the Dragon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:95
-msgid "Arm of the Phoenix"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:96
-msgid "Arm of the Titan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:97
-msgid "Arr' Here be pirates gold buried."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:98
-msgid "A shipment of wood has arrived from your kingdom!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:99
-msgid ""
-"A splash in the seaweed alerts you to a mermaid waving in a friendly manner. "
-"\"Oh, I thought you were Ahab.\" She is surprised, but quickly composes "
-"herself. \"Well, if you meet him, give him these treasures I have collected."
-"\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:100
-msgid "Assassins tried to kill our ally."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:101
-msgid "Astircaer"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:102
-msgid ""
-"A stranded Wizard with only a small force must conquer an entire continent "
-"of hostile forces."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:103
-msgid ""
-"A supply ship has arrived from the homeland!  You send word home that all is "
-"well."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:104
-msgid ""
-"As you approach the barrier, you see the old elf you helped free. This time, "
-"however, you see that he is wearing a cape of fine weave, and a wooden crown "
-"is on his head. He sees your forces, and says \"Take this sword, and with "
-"it, strike down Drakonia and help free my people.\" The old elf then strides "
-"regally into the woods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:105
-msgid ""
-"As you approach the gates of the Ice Palace, one of your troops points in "
-"terror.  You watch in awe as great slabs of ice separate from the castle "
-"walls with loud cracking reports and crash to the ground.  Soon the ice is "
-"gone and the sun begins to peak through the gloom.  The deathly silence that "
-"must have ruled these lands for centuries ends as birds begin to sing.  From "
-"inside you hear the sounds of life."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:106
-msgid ""
-"As you approach the tent, the leader of the nomads comes out to greet you. "
-"He says, \"It was prophecied many years ago that a great hero would come to "
-"greet us in our sacred valley, and we would prosper afterwords. Now it has "
-"come to pass, and we offer you these gifts as tokens of our thanks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:107
-msgid ""
-"As you approach,  you hear whispered mentions of \"the wild barbarian who "
-"passed this way months before\". One of the villagers approaches you and "
-"hands you an object, saying \"The wild one dropped this. You must be his "
-"kin. Therefore I give it to you. But beware! Many in the village will not be "
-"as friendly as I.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:108
-msgid ""
-"As you break your fast your sage rushes in, \"Good news, my lord!  I have "
-"translated the message.  Two great heroes were imprisoned many years ago.  "
-"They lie sleeping - still guarded by magic barriers and monsters.  My lord, "
-"they lie nearby- in between our ally and us.  If we could free them, they "
-"would surely aid us against our enemies!  The password to the first magic "
-"barrier can be learned at the Aqua Traveller's Tent.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:109
-msgid ""
-"As you enter the small clearing, you see a familiar figure talking to a "
-"group of halflings and soldiers. You stay awhile and listen to his speech. "
-"\"The time to throw off these chains of tyranny is now! We must strike at "
-"the heart of her empire, and destroy the evil that she has brought to our "
-"land.\" As the old elf finishes speaking, he gets up from his mossy seat and "
-"once again, blends into the woods with incredible grace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:110
-msgid ""
-"As you lay down to nap after a long battle, you notice a lucky four-leaf "
-"clover."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:111
-msgid ""
-"As you make  your way through the last of the golemn debris, a group of "
-"halflings runs towards you carrying fruit and flowers. \"Thank you so much!"
-"\" Their leader exclaims, \"We've been trapped in here for ever! Come by our "
-"homes, we'll pack up and go with you!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:112
-msgid ""
-"As you make your way to the shrine, some very thin and hollow-eyed men come "
-"out of the flower patch and stare at you.  Seeing that you want the gold, "
-"one of them says to you \"Hey, man, if you're, like, so lusty for earthly "
-"wealth, then, like, have this too.\" You graciously take what they have "
-"offered and back out of the clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:113
-msgid ""
-"As you prepare your lands to fight the onslaught from the South, a curious "
-"message appears on your table in the Great Hall of your Castle.  Written in "
-"some ancient language, none but your sage can make any sense of it.  She "
-"promises to have the words deciphered by tomorrow..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:114
-msgid "A three hour tour, a three hour tour..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:115
-msgid ""
-"A tiny gnome points to a chunk of crystal you otherwise would have "
-"overlooked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:116
-msgid "Atlantium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:117
-msgid ""
-"At last, the king is dead.  For years you have planned his demise, but now "
-"it is done, and there is no heir to take his place, though the Knights to "
-"the south believe that they are the rightful successors.  A wealth in wood "
-"(to the south) and ore (in the northern mountains) provides you with trade "
-"goods, and your isolation has allowed you to prepare your forces of darkness "
-"for this day.  Go, now, and fulfill your destiny!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:118
-msgid ""
-"At the base of the mountain you see something that glitters.   You discover "
-"an ancient pile of offerings to the gods."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:119
-msgid "Avalon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:120
-msgid "Avone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:121
-msgid ""
-"A wild magic has allowed a bridge to form between two lands...  Your one "
-"hope is to capture castle \"Black Fang\"."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:122
-msgid "Barbarian's castle lies to the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:123
-msgid ""
-"Barbarians from the north threaten all civilization. Can you repel the "
-"hordes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:124
-msgid "\"Barbarian Wars\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:125
-msgid "Barrowton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:126
-msgid "Basenji"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:127
-msgid "Bayside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:128
-msgid "Baywatch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:129
-msgid ""
-"Because the Darkscale Valley is so barren, the Emperor will be sending wood "
-"to you every week. Use it wisely, for it is all you shall have."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:130
-msgid ""
-"Before questing for the orb of negation, you must first crush the local "
-"opposition. After the Sorceresses are removed from the earth, go east where "
-"legend says the orb lies.  You may expect a convoy of supplies in a week or "
-"so to aid your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:131
-msgid ""
-"Before you may pass, the spirit guardian of this valley demands tribute."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:132
-msgid "Being held...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:133
-msgid "Beltway"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:134
-msgid "\"Betrayal!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:135
-msgid "Beware -- Entering Hyrda Country"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:136
-msgid "Beware for whom the bell trolls."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:137
-msgid "Beware of Pirates!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:138
-msgid "Beware of thieves!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:139
-msgid "Beware of traps ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:140
-msgid "Beware of Warlocks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:141
-msgid "Beware the deadly swamps!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:142
-msgid "Beware the Domain of Dragons"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:143
-msgid "Beware the Dragon Leader"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:144
-msgid "Beware the edge of the world!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:145
-msgid "Beware the moors and stick to the roads."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:146
-msgid "Beware the rocks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:147
-msgid "Beware the sirens!!!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:148
-msgid "Beware the sirens!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:149
-msgid "Beware the whiporwill..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:150
-msgid "Beware, the whirlpool may not take you into a friendly embrace."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:151
-msgid "Beyond here be Dragons!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:152
-msgid "Beyond the door, there be Dragons. BEWARE!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:153
-msgid "Big Oak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:154
-msgid "Blackburn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:155
-msgid "Blackfang"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:156
-msgid "Black Fang"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:157
-msgid "Black Oak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:158
-msgid "Blackridge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:159
-msgid "Blacksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:160
-msgid "Black Vein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:161
-msgid "Blackwind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:162
-msgid "Bloodreign"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:163
-msgid "Boats my be needed to access some parts of this peninsula."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:164
-msgid "Boats Sold Here            Inquire Within"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:165
-msgid "BoneVille"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:166
-msgid "Borderlands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:167
-msgid "Bridge out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:168
-msgid "Bridge Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:169
-msgid "Brindamoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:170
-msgid "Broken Alliance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:171
-msgid "Brownston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:172
-msgid "Buried Treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:173
-msgid "Burlock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:174
-msgid "Burton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:175
-msgid ""
-"Capture the necromancer's dreaded castle \"Death Gate\" and free the land "
-"from the undead plague."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:176
-msgid ""
-"Capture the town on the island off the southeast shore in order to construct "
-"a boat and travel back towards the mainland."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:177
-msgid "\"Carator Mines\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:178
-msgid "Cathcart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:180
-msgid "Chandler"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:181
-msgid "Chilton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:182
-msgid "Chronos"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:183
-msgid "Come and...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:184
-msgid ""
-"Compared to the rest of the villages in this land, this village seems grand, "
-"but in any other land it would seem poor. From here you can see the tall "
-"spires of the Warlock's tower of Dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:185
-msgid "Complete"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:186
-msgid "Condemned!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:187
-msgid ""
-"Congratulations! After navigating the treacherous coast, you have "
-"established trade between the north and south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:188
-msgid "Corackston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:189
-msgid "Corlagon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:190
-msgid "\"Country Lords\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:191
-msgid "Crossroads"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:192
-msgid "Crossroads North"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:193
-msgid "Crossroads South"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:195
-msgid "Danger a whirlpool destroyed my ship."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:196
-msgid "Danger, Dragons abound!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:197
-msgid "DANGER!  QUICKSAND!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:198
-msgid "Danger! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:199
-msgid "Danger - Turn Back Now"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:200
-msgid "Dark clouds loom overhead as you enter this valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:201
-msgid "Dead Pine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:202
-msgid ""
-"Dear Diary,                           I found a mermaid today.  She was "
-"floating in a patch of seaweed next to a rock.  A very friendly sort of "
-"creature too!  Gave me all sorts of lovely gems and jewelry!  She said to "
-"come back again sometime for more of the sea riches.  Wow. Ahab"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:203
-msgid "Deathgate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:204
-msgid "DeathGate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:205
-msgid "Decisions"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:206
-msgid "\"Defender\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:207
-msgid ""
-"Destroy the Barbarians who are attacking the southern border of your "
-"kingdom! Recover your towns and then invade the jungle kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:208
-msgid ""
-"Detour! Mountain pass to the East has been known to have avalanches! For "
-"your own safety, follow the road South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:209
-msgid "Detour! Troll bridge ahead!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:211
-msgid "DirtWater"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:212
-msgid "Dominion"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:213
-msgid "Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:214
-msgid "Do not remove coins from fountain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:215
-msgid "Dragadune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:216
-msgid "Dragonburg"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:218
-msgid "Dragon City lies beyond the Scorpion Hills."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:219
-msgid "Dragon Hill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:220
-msgid "\"Dragon Master\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:221
-msgid "Dragon Rider"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:222
-msgid "Dragons Everywhere!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:223
-msgid "Dragon's Eye"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:224
-msgid "Dragontooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:225
-msgid "Dragon Town"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:226
-msgid "Dragonville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:227
-msgid "Dragon Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:228
-msgid "Dragon Watch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:230
-msgid "Drakoran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:231
-msgid "Dwarfhall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:232
-msgid "Dwarfhall, Domain of the dwarf King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:233
-msgid "Dwarf Hall, domain of the dwarf King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:234
-msgid "Eatio"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:235
-msgid "Edgewood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:236
-msgid "Elk's Head"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:237
-msgid "Elowyn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:238
-msgid "Enroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:239
-msgid "Entering high in the desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:240
-msgid "Entering Praires of the Middlelands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:241
-msgid "Entering the desert high"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:242
-msgid "Entering the high desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:243
-msgid "Entering the higher desert"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:244
-msgid "Entering the Valley of Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:245
-msgid "Erliquin"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:246
-msgid "Evil Igor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:247
-msgid "Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:248
-msgid "Fantasy Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:249
-msgid "Farlien"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:250
-msgid ""
-"Federal express, when it absolutely positively has to be there turn one."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:251
-msgid "fedx comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:252
-msgid "Fedx for comp"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:253
-msgid "Fenton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:254
-msgid "Fetid Elm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:255
-msgid ""
-"Final message from Overlord. \"The royal executioners are on their way. My "
-"gold, the land or your head- it's your choice.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:256
-msgid "Find and defeat the Pirate Leader!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:257
-msgid "Find and destroy the evil beings who rule the wastelands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:258
-msgid "Find the center island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:259
-msgid ""
-"Find the Ultimate Artifact and be proclaimed King, or smash the opposition "
-"and take control."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:260
-msgid ""
-"Find Your Wayward Son who is rumored to be living in the desolate lands. Do "
-"it within 8 weeks or it will be of no help to your family."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:261
-msgid "Fire King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:262
-msgid "\"First Blood\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:263
-msgid "Five heroes vie for control of a familiar land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:264
-msgid "Fool's Gold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:265
-msgid ""
-"For a total of 400,000 gold your opponents will become \"loyal\" subjects, "
-"otherwise... let them eat cake!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:266
-msgid ""
-"For centuries, the Wizards of the North have maintained a vast library for "
-"all the world to share.  Now, however, they have closed their doors, and "
-"issued declarations of war to each of the other rulers of the land.  To make "
-"matters worse, rather than ally with you to face the Wizards, each of the "
-"others have decided to go forth on their own in an effort to conquer this "
-"land for themselves!  Prepare your forces, commander, for you now stand "
-"alone."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:267
-msgid "\"Force of Arms\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:268
-msgid ""
-"For decades you have studied, learned, and allowed yourself to be ruled by "
-"that pitiful excuse for a king, knowing that one day the time would come for "
-"you to sit on the throne.  That time is now, for the king is dead and "
-"without an heir.  You have the advantage of isolation from the rest of the "
-"kingdom, but beware the miles of coastline that could leave you vulnerable "
-"to attack.  Go, now, and wipe your enemies from this land!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:269
-msgid "Forder Oaks"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:270
-msgid "Forestria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:271
-msgid "For Honor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:272
-msgid ""
-"For information about Ye Rich lands to the south, speak to Alponse at the "
-"Golden Goose Tavern. Excellent views, plentiful water."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:273
-msgid "Forsaken Lands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:274
-msgid "For sale."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:275
-msgid "Fortress Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:276
-msgid ""
-"For years, you have existed peacefully in the Forest of Dreams, knowing that "
-"your king was the kindest and strongest ruler the land had seen in "
-"centuries.  Now, however, his reign is at an end, and there is no heir to "
-"succeed him.  You realize that a power struggle is coming, and that you must "
-"brace yourself for war, and prevent those who would harm this land from "
-"coming into power!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:277
-msgid ""
-"For years, you've been able to keep your subjects \"appeased.\"  Now "
-"however, you discover not only that your entire kingdom has turned against "
-"you, but most of your outer towns have fallen to the different factions.  To "
-"make matters worse, all your gold suddenly seems to be missing from the "
-"treasury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:278
-msgid "Fountainhead"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:279
-msgid "Four kingdoms race to capture the island of Sharkania."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:280
-msgid "Four lakes have castles, three have treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:281
-msgid "Four players must work together to assault the Wizards' Stronghold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:282
-msgid "Frozenpeak"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:283
-msgid "Full House"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:284
-msgid ""
-"Gain the aid of the elves. They will not allow trees to be chopped down, so "
-"we will send you wood every 2 weeks. You have 7 months!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:286
-msgid "Galveston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:287
-msgid "Garamok"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:288
-msgid "Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:289
-msgid "Gate to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:290
-msgid "Gate to The Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:291
-msgid "Gaurdian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:292
-msgid "Gavonshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:294
-msgid "Glastonbury"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:295
-msgid "Go away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:296
-msgid "GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:297
-msgid "Goblin Island"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:298
-msgid "Goblin King"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:299
-msgid "Go Home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:300
-msgid "Go north to find the lost gold-mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:301
-msgid "Good vs. Evil"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:302
-msgid "Gorgomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:303
-msgid "\"Greater Glory\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:304
-msgid "Greed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:305
-msgid "Green bonus stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:306
-msgid "Green gets stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:307
-msgid "Greenroot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:308
-msgid "Green's Allowance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:309
-msgid "Green's Groceries"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:310
-msgid "green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:311
-msgid "Green stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:312
-msgid "Greywind"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:313
-msgid "Grim"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:314
-msgid "Grrr, Blazzer, Grrupt. Be gone with you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:315
-msgid "Guardian War"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:316
-msgid "Gungtooth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:317
-msgid "Hail Unicorns!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:318
-msgid "Hampshire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:319
-msgid "Have fun storming the castle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:320
-msgid "Havenwood"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:321
-msgid "Hawkins"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:322
-msgid "Help!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:323
-msgid "Help me...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:324
-msgid ""
-"Help peasant farmers regain their castle and land, else they'll take your "
-"crops."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:325
-msgid "Hero's Hall"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:326
-msgid ""
-"High in the snowy crags, you meet an old witch who, in return for a trinket "
-"of yours, gives you a powerful magical object she used to use as a footstool "
-"before she was exiled into the mountains by her own townspeople."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:327
-msgid "Hillstone"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:328
-msgid "Hilltop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:329
-msgid "Hilltown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:330
-msgid "Horizon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:331
-msgid "Hot Spot"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:332
-msgid "Hungry dragons await.  Welcome, food."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:333
-msgid "Hurry, no time to wait.  This way to the dock."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:334
-msgid "Hurry up! Few days are left before the enemy's army arrives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:335
-msgid "I am...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:336
-msgid ""
-"I am one of the few remaining survivors of the wrecked pleasure ship, "
-"Exhorbitance. I think we'll all be dead of hunger soon, for we are out of "
-"caviar. We ate the chef yesterday."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:337
-msgid "Ibn Fadlan"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:338
-msgid "Ice Palace"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:339
-msgid "Ice Prince"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:340
-msgid "Icy lands ahead."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:341
-msgid "I didn't do it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:342
-msgid ""
-"If three heroes could dig six holes in three days, how long would it take "
-"six heroes to dig twelve holes?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:343
-msgid "If you free a hero, they may help..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:344
-msgid ""
-"If you value your lives, for God's sake, Don't go through this whirlpool!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:345
-msgid "Income for Yellow."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:346
-msgid "In the hole you find a chunk of ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:347
-msgid "In the stream you find an old compass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:348
-msgid "In this glen live some very naughty halflings. Stay Away!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:349
-msgid ""
-"In two more weeks, if you have not located Joseph, your kingdom will surely "
-"lose its current battle with Harondale."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:350
-msgid "I see you, you see me."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:351
-msgid "Is it something I said? Go back and I will forget the whole thing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:352
-msgid "IslandHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:353
-msgid "Island of the Elves"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:354
-msgid "Island of the meek"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:355
-msgid "Island of Wolcott"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:356
-msgid "Isle Maze"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:357
-msgid "Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:358
-msgid ""
-"It has become apparent that if all your enemies were eliminated, you would "
-"have all the time you need to find the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:359
-msgid ""
-"It is obvious that the mage that once was here had won many battles!  There, "
-"upon his hand, is a most powerful ring!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:360
-msgid ""
-"It is rumored that a bridge of land used to exist between the two "
-"continents, but that a wild magic caused it to sink into the sea, taking "
-"with it all those who used to inhabit it.  To try to raise this bridge is to "
-"invite a curse upon the world!  The spirits of the dead will haunt us all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:361
-msgid ""
-"It is said that King Zealot found the gods' artifact once and it let him "
-"rule for 100 years."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:362
-msgid ""
-"It looks like there used to be an ore mine here but all you see now is a "
-"hole in the ground and some minerals scattered around."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:363
-msgid ""
-"It's a battle for supremacy as the Blue and Green heroes take on Red and "
-"Orange in team competition!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:364
-msgid "It's windy at the top.  Defend, Divide, and Conquer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:365
-msgid "IvanHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:366
-msgid "Ivan lives in the desert."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:367
-msgid "Ivory Gates"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:368
-msgid ""
-"I, Wilgatus, besiege you - do not fight me for I am all powerful and will "
-"destroy you if you persue me.  I will demonstrate my power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:369
-msgid "I Would Go That Way If I Were You."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:371
-msgid "Jarkonas VI"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:372
-msgid "Jolly Roger was here"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:374
-msgid "Jungomar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:375
-msgid "Just 30 days left!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:376
-msgid "Just ONE week left!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:378
-msgid "Kastor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:379
-msgid "Keep going south"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:380
-msgid "Keep Off The Grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:381
-msgid "Keep Out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:382
-msgid "King John"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:383
-msgid "King of Death"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:384
-msgid "Knight's Trail."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:385
-msgid "Knight stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:386
-msgid "Lakeside"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:387
-msgid "Land's Edge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:388
-msgid "Land teleporters will get you to your destination sooner."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:389
-msgid "Lankershire"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:390
-msgid "Lavalor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:391
-msgid "Like, Stuff And Junk?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:392
-msgid ""
-"Living on the outskirts of the kingdom, you are considered an unwelcome "
-"outcast by the other leaders of the realm, though you always showed your "
-"support for the king.  Now, however, the king is dead, and many of those who "
-"spoke out againt him seek to seize his throne for themselves.  You have a "
-"vast desert at your back, rich with gems, and the advantage that many do not "
-"consider you a threat.  Go, now, and show them how wrong they are!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:393
-msgid "Lladner Dock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:394
-msgid ""
-"Log go up... Log go down... Log go up... Log go down...  OOoohhhhhhhh........"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:395
-msgid "Lombard"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:396
-msgid "Long live Roland the true King!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:397
-msgid "Long live Roland the true King."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:398
-msgid "Look before you leap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:399
-msgid "Look out!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:400
-msgid "Lord Alberon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:401
-msgid ""
-"Lord Alberon calls you into his war room. He says, \"I am glad you have "
-"chosen to remain loyal to me, but this war is a terrible one for my kingdom. "
-"Already, the sorceress' towns to the Northeast have become unsure about "
-"their loyalties, and will not pledge allegiance to either side. This is hard "
-"on our cities as most of the wood in the land comes from these towns. We "
-"will need to recover their sawmills and take their towns by force.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:402
-msgid "Lord Haart"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:404
-msgid "Lord Kreager"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:405
-msgid ""
-"Lord, messages have begun pouring in from our spies in the other island "
-"courts.  They have learned of a new volcanic island with vast amounts of "
-"reasources.  Your Majesty, with these new reasources we could put an end to "
-"a century of war between the islands, and reunite them under your rightful "
-"rule."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:406
-msgid "Lost Continent"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:407
-msgid "Lost Gold- Mine"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:408
-msgid "Lost Island."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:409
-msgid "Lost Relic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:410
-msgid "Maelstrom of Deceit"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:411
-msgid "Maelstrom of Misery"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:412
-msgid "Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:413
-msgid "Magic Three"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:414
-msgid ""
-"Many dust plumes rise from the floor of this small valley. You see various "
-"bands of nomads roaming about, and in the distant, the bright flames of "
-"their camp."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:415
-msgid ""
-"Many guardians stand between you and your enemies, but anybody can sneak "
-"through the back door!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:416
-msgid "Many that have gone through this door have never returned."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:417
-msgid ""
-"Many years ago, a couple of mages had a \"duel\" that forever changed the "
-"lake at the center of this continent.  Hearty adventurers might find "
-"interesting treasure there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:418
-msgid ""
-"Many years ago, a falling star crashed near here.  Only now the area is safe "
-"enough to explore.  Rumor has it a castle exist where the star fell."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:419
-msgid ""
-"Many years ago, your father, the King, died in a freak hunting accident.  "
-"Since then, you and your brother have jointly ruled his kingdom, but both of "
-"you have been seeking a way to seize the throne for yourself.  You got your "
-"wish.  Attackers from across the sea have captured more than half your towns "
-"and castles, effectively dividing the continent in two.  Now is the time to "
-"repel these invaders and do away with your brother once and for all!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:420
-msgid "Marco"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:421
-msgid "Marsh Home"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:423
-msgid "Mayland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:424
-msgid "Meramec"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:425
-msgid "Message from Archibald. \" Do not dare to return without my Crown.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:426
-msgid ""
-"Message from Archibald. \" General, thank you for bringing me this lovely "
-"gift. I have decided to participate directly in the capture of my brother "
-"Roland. Since your military advice has taken us this far, I will follow your "
-"orders to the letter.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:427
-msgid "Message from Overlord. \"STILL WAITING FOR MY GOLD!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:428
-msgid "Message from Overlord. \"WHERE'S MY GOLD?\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:429
-msgid ""
-"Message from Roland. \"General, circumstances permit me to take a hand in "
-"the events of this final conflict. I have your spoils of war with me and I "
-"will follow your advice explicitly.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:430
-msgid ""
-"Message from Roland.  \"General, I have sent most of our troops and material "
-"ahead to the region of the final conflict with Archibald.  Unfortunately, "
-"Lord Corlagon has cut us off from the rest of our army.  I will be awaiting "
-"your victory in a castle across the west river.  I should be safe from "
-"attack.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:431
-msgid ""
-"Message from Roland. \" We cannot hope to defeat Archibald without the "
-"Crown, I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:432
-msgid "Middle Gate"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:433
-msgid "Middleton"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:434
-msgid "Middletown"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:435
-msgid "Might vs. Magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:436
-msgid "Mineral Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:437
-msgid "Mirkosov"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:438
-msgid "mirror"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:439
-msgid "Money For Red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:440
-msgid "MONEY, MONEY, MONEY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:441
-msgid "Morale becomes even lower as the endless cliffs move past."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:442
-msgid ""
-"More water than land, you'll still spend lots of time on foot as you search "
-"a literal horde of islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:443
-msgid "Mountain king"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:444
-msgid "Mountainview"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:445
-msgid "Mr Ed"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:446
-msgid "Mr. Yellow's Income"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:447
-msgid "Murray's resort Isle!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:448
-msgid ""
-"Mutiny!  The crew has dumped off my precious cargo into the sea!  Thank "
-"goodness it floats - when I've rid of them, I'll come back to pick it up!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:449
-msgid ""
-"My leige, our scouts report three other lords are attacking from the south. "
-"They work in conjuction with each other to eliminate us! We must keep this "
-"castle and remove the threat of the enemy. We wish you luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:450
-msgid ""
-"My leige, we have established a foothold (which we cannot afford to lose) "
-"and all of our Heroes have joined us. The king has made us the offer to "
-"purchase this land for 200,000 gold or we may take it by force. The local "
-"lords have been fighting and each wants to be the one that defeats us. Now "
-"all the local armies have arrived on the beach, creating a state of complete "
-"Pandemonium!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:451
-msgid "My Treasure Is Buried Beneath Three Palm Trees"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:452
-msgid "\"Necromancers!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:453
-msgid "New Dawn"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:454
-msgid "New Enemies"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:455
-msgid "New Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:456
-msgid "Nightshadow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:457
-msgid "No Description"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:458
-msgid "No Fishing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:459
-msgid "No gems, crystal, or mercury for red."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:460
-msgid ""
-"None of the four leaders like being stuck in a land that has only one season."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:461
-msgid "NO, Not That Way. This Way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:462
-msgid "No one has ever made it out of the deadly swamps alive!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:463
-msgid "Noraston"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:464
-msgid "North Road"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:465
-msgid "North vs. South"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:466
-msgid "No stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:467
-msgid "No sulfer fer Yella."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:468
-msgid "No swimming."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:469
-msgid "Notice- Those who put messages in bottles will be tortured."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:470
-msgid "No Trespassing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:471
-msgid "No tresspath...  No tree...  No thresh...  GO AWAY!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:472
-msgid "Now leaving Swamplands of the Eternial"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:473
-msgid "Obsidian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:474
-msgid "Of the necromancers...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:475
-msgid "Ogrehild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:476
-msgid "Olympus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:477
-msgid ""
-"One of the seers in your castle comes to you in the morning with urgent "
-"news. Your one time comrade, the wizard Joseph, and his armies have been "
-"imprisoned in a jail nearby. His power would surely aid you in your quest to "
-"reclaim the library, you think to yourself. Perhaps there is a way to rescue "
-"him..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:478
-msgid ""
-"One of your aides reports that the Castle of Farlien is located on the "
-"northeast spur of this island, and is a stronghold for the enemy. He urges "
-"you to take it out as soon as possible, and then move onto other islands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:479
-msgid ""
-"One of your \"allies\" has joined Archibald.  You now face an opponent with "
-"three castles to your one.  Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:480
-msgid ""
-"One of your \"Allies\" has joined Roland. You are now facing three castles, "
-"all belonging to the enemy. Good luck!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:481
-msgid "One of your loyal goblins has brought you an armload of crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:482
-msgid ""
-"One of your loyal subjects, a fairy tells you where to find a cache of "
-"mercury!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:483
-msgid ""
-"One of your scouts reports a tiny cave nearby. Upon investigating, you "
-"discover a small cache of goods. In the dirt by them is etched 'Ivan'."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:484
-msgid ""
-"One of your troops stubs its paw on something buried here.  After a few "
-"hours of digging you unearth a cache of treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:485
-msgid "Only a month remains in which to find Joseph."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:486
-msgid "On quite days, Nubbie the sea monster can be seen!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:487
-msgid "Orange stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:488
-msgid "Orcville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:489
-msgid "Ostoroth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:490
-msgid "Other than the dragons, the elves don't have any enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:491
-msgid "Our ally was greatly weakened when his resources were plundered."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:492
-msgid "\"Our Finest Hour\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:493
-msgid "Our reinforcements were lost in a storm, we salvaged all we could!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:494
-msgid ""
-"Our spies have discovered that the barbarian hordes are now receiving "
-"support from kraeger! You must hurry and find the third piece before your "
-"forces here are crushed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:495
-msgid "Overlord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:496
-msgid "Pandemonium"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:497
-msgid "Paper can gain you what wood and sail cannot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:498
-msgid "Password found by Crystals to the South."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:499
-msgid "Peacekeeper"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:500
-msgid "\"Peasants!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:502
-msgid "Peasantsville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:503
-msgid "Perenor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:504
-msgid "Pet Cemetary"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:505
-msgid "Pick one of four Knights in this large and inhospitable land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:506
-msgid "Pig's Eye"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:507
-msgid "Pinehurst"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:508
-msgid "Pirate Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:509
-msgid "Pirate's Cove"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:510
-msgid "Pirate Utopia"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:511
-msgid "Pirites strike and take the gold from you holds."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:512
-msgid "Pixie"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:513
-msgid ""
-"Play the Knight or Barbarian in an alliance in this classic duel against the "
-"four spell casters. (Blue and Green vs Red)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:514
-msgid "Please...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:515
-msgid ""
-"Plenty of resources and lots of ground to cover. Watch out for Orange and "
-"Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:516
-msgid "Portals"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:517
-msgid "Portsmith"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:518
-msgid "POSION - DO NOT DRINK"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:519
-msgid "Powerful magic lies southwest of here in the Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:520
-msgid "Prisoner on...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:522
-msgid "Quick Silver"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:523
-msgid "Raste"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:524
-msgid "Realm of the Undead.  Fresh blood welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:525
-msgid "Red bonus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:526
-msgid "Red player sympathizes with the undead cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:527
-msgid "Red's Connection"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:528
-msgid "Redshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:529
-msgid "Red's Lunch Money"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:530
-msgid "Red's Rubles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:531
-msgid "Red stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:532
-msgid ""
-"Regrettably, you have no castle with which to begin your assault. "
-"Fortunately, however, Kraeger's forces are weak here in the south, and you "
-"have bribed a rebel necromancer to aid you in the beginning of your conquest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:533
-msgid "Reinforcements have arrived, Gold from the homelands!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:534
-msgid ""
-"Remains of a long since dead wizard have attracted an ancient artifact.  "
-"This artifact has now attached itself to you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:535
-msgid ""
-"Remember, you're searching for the Ultimate Artifact... don't get distracted!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:536
-msgid ""
-"Rendall Koski was here. 1997.  Northampton, Massachusetts There is a "
-"powerful artifact in the southeastern corner of the world.  Go for it, "
-"explorer!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:537
-msgid ""
-"Reports from your spies tell of enemies on the march.  As you rush to the "
-"castle courtyard to prepare your armies, you are intercepted by your "
-"Chaplain.  \"My Lord, I have received word that we should send what Heroes "
-"we can to the Isle of Knowledge.   The Scholars there have agreed to teach "
-"them so they will be strong for the battles ahead of us.\"  You thank the "
-"Chaplain for the information and head thoughtfully into the courtyard."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:538
-msgid ""
-"Rescue your crazy Uncle Ivan. Find him within 4 months or it will be no help "
-"to your kingdom."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:539
-msgid "Restricted Area, Do Not Enter!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:540
-msgid "Rest stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:541
-msgid "Retake the Castle of Ivory Gates."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:542
-msgid "Revolution"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:543
-msgid "Right thinking - he who takes the riskes deserves the rewards."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:544
-msgid "River Crossing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:545
-msgid "Road Ends"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:546
-msgid "Road to Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:547
-msgid "Road to the Isle of Knowledge"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:548
-msgid "Robbers have looted your treasury and you have lost valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:549
-msgid "Robbers have looted your treasury, stealing valuable resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:550
-msgid "Roc Haven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:551
-msgid "Rogar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:553
-msgid "Roscomon"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:554
-msgid "Rotten Birch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:555
-msgid ""
-"Rumors abound and your faithful hero Sandro is now highly regarded by the "
-"masses. Should Sandro desert you, all will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:556
-msgid "Sandcaster"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:558
-msgid "Sands of Time"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:559
-msgid "Sansobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:560
-msgid "\"Save the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:561
-msgid "Scabsdale"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:562
-msgid "Scorched Earth"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:563
-msgid ""
-"Scouts have reported a town to the North.  They have also heard some "
-"disturbing news.  Their seems to be a war raging in this area."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:564
-msgid ""
-"Scouts report the enemy's stronghold lies to the Southwest. Our swift "
-"arrival has caught them by surprise. If you move quickly their resistance "
-"will be minimal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:565
-msgid ""
-"Scouts report the notorious necromancer \"Wyrm\" has been sighted to the "
-"northeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:566
-msgid "Scummy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:567
-msgid ""
-"Searching in the dust of this abandoned campsite, you find a magic scroll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:568
-msgid "Seasons Change"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:569
-msgid "Secret Mountain Pass"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:570
-msgid ""
-"Seek out the Ultimate Artifact to be victorious in this strangely shaped "
-"land."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:571
-msgid ""
-"Seek the great library, for only with the guidance of the musty tomes therin "
-"will you find the means to reveal and bind the fount to your will."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:572
-msgid "Seven Lakes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:573
-msgid "Sharkania"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:574
-msgid "Sheltemburg"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:575
-msgid "Sherman"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:576
-msgid "Shipwrecked!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:577
-msgid ""
-"Should this message ever reach home, please know that this has become a "
-"hostile place since the King's death.  No less than six factions are at war "
-"with each other, each seeking to be the King's successor.  Beware especially "
-"of the Barbarians and the Necromancers who control the north, their regions "
-"are easily defended and they have a wealth of gold and gems.  Do not venture "
-"to this land without a sizeable force.  -Sir Christian"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:578
-msgid "Sirein"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:579
-msgid ""
-"Six factions have established a foothold on a huge, unexplored continent.  "
-"Can you eliminate the other five?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:580
-msgid ""
-"Six heroes with large armies prepare to slug it out for total domination!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:581
-msgid "Skirmish"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:582
-msgid "\"Slay the Dwarves\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:583
-msgid "Slippery when wet."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:584
-msgid "Slugfest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:585
-msgid ""
-"Snagged on a thorny bush, you discover a scrap of cloth. The design on it "
-"looks like the coat of arms of Ivan's house!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:586
-msgid "Snowdrop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:587
-msgid "Somebody has stuffed a pile of gems in the ditch!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:588
-msgid "Some crystal!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:589
-msgid "Some gems!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:590
-msgid ""
-"Someone has stolen 100 wood and 77 ore from you. Ah, that's nothing. Let's "
-"keep going."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:591
-msgid ""
-"Someone has stolen gold and resources from  the palace treasury!  You "
-"suspect your enemies, but you can't know for certain."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:592
-msgid "Someone is playing a pan flute around here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:593
-msgid ""
-"Someone notices a piece of parchment lying behind a clump of grass. You pick "
-"it up. It looks to be a page from a journal, and it reads, \"...made it past "
-"the first guardians. Hopefully will reach the ancient desert city soon. Only "
-"hope my forces are strong enough to survive...\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:594
-msgid "Some ore!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:595
-msgid "Some sulfur!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:596
-msgid ""
-"Some unlucky adventurers have been captured and imprisoned in these lands."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:597
-msgid "Sorceress Forest.  Show respect for nature!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:598
-msgid "Sorpigal"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:599
-msgid "South Mill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:600
-msgid "So you think you're smart?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:601
-msgid "Spector"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:602
-msgid "Spell Casters"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:603
-msgid ""
-"Spies report Roland has sent a hero to search for the Crown. If he finds it "
-"first, all is lost!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:604
-msgid "Spirit City"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:605
-msgid "Spy Tower - see what your competition is doing!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:606
-msgid "Stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:607
-msgid ""
-"Start with five castles!  How could you lose!?  Oh yeah, everyone else "
-"starts with five, too."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:608
-msgid "Stick to the road!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:609
-msgid "Stromgild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:610
-msgid "Stromhild"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:611
-msgid "Stronghold"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:612
-msgid "Stuff for red"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:613
-msgid "Stuff for Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:614
-msgid "Stuff For Yellow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:615
-msgid "Subbaculcha"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:616
-msgid "Sundune"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:617
-msgid "Surf and Turf"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:618
-msgid "Swimming near the kelp is a pod of dolphins."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:619
-msgid "Tacma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:620
-msgid "Tchudes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:621
-msgid "Teleporters"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:622
-msgid "Terra Firma"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:623
-msgid "Terrain Wars"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:624
-msgid ""
-"The alliance has crumbled and all are at war. Lots of resources but little "
-"time to prepare."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:625
-msgid ""
-"The ancient King Zealot had the artifact of the gods and then hid it in his "
-"old age so that it could not be used by others."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:626
-msgid "The Back Door"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:627
-msgid ""
-"The Barbarian's lands are being invaded. Are you strong enough to resist the "
-"invasion?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:628
-msgid ""
-"The castle of Drakonran in the east has been taken by the barbarians! Two "
-"other towns to the west have also been taken, but the barbarian armies were "
-"fairly decimated in the process."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:629
-msgid "The center island is rumored to harbor great spells."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:630
-msgid "The Citadel"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:631
-msgid "The cities of the plains."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:632
-msgid "The Clearing"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:633
-msgid ""
-"The convoy has at long last arrived. Regretably, it has been beset by "
-"bandits on its journey here, and has far less supplies than we had hoped. "
-"Make your way south, for our spies have found rich mines there."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:634
-msgid ""
-"The convoy should have been here by now! Let us hope that it is safe and "
-"still on its way."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:635
-msgid ""
-"The country lords have allied and pooled their resources into one command. "
-"Not only have they massed their forces in the north, but they have sent a "
-"knight to the west to steal your supplies. Scouts report a castle to the "
-"east that would be ideal as a base of operations."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:636
-msgid "The crew are unworthy!  I am not going down with the ship! -The Captain"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:637
-msgid "\"The Crown\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:638
-msgid ""
-"The day you have feared has finally arrived.  The king, who you have "
-"faithfully served, has died, leaving no heir to his throne.  As his captain, "
-"you feel that this job should now be yours, but several factions even now "
-"are preparing for conquest.  You are at the center of the trade routes, "
-"having the sea to the south and the great forest to the north.  Go, now, "
-"Commander, and claim what is rightfully yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:639
-msgid ""
-"The diplomats who were sent here ahead of you report that the elves will "
-"only cooperate with you if you will recover the golden bow for them. It was "
-"stolen by their enemies, the Dragons and hidden behind magic barriers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:640
-msgid "The Eastern Town."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:641
-msgid "The edge of the world is your edge.  But prepare to be prepared."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:642
-msgid "The Emerald Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:643
-msgid "The Enchanted Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:644
-msgid "The End of the World is Nigh!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:645
-msgid "The End of the World is Nigh"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:646
-msgid ""
-"The Epic battle against Your Rival! Eliminate everything! Total Warfare! "
-"Don't Lose your first hero!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:647
-msgid ""
-"The Fire King is an ally to the dragons, and will help a friend of theirs."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:648
-msgid "The First One To Take Astircaer Wins!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:649
-msgid ""
-"The first piece of the artifact now lies in the hands of the Unholy Order of "
-"Warlocks. You must annihilate them, and their allies to the north. They will "
-"surely give us what we seek in exchange for their feeble lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:650
-msgid ""
-"The Fortune of Infamous Uae was buried on one of these islands. She died "
-"without ever revealing it.  Find it before the other cutthroats."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:651
-msgid "The four factions race to capture a mystical castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:652
-msgid ""
-"The four spell casters face off with substantial starting armies. Can the "
-"crusaders keep the peace?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:653
-msgid "\"The Gauntlet\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:654
-msgid ""
-"The Gods have given you 6 months to prove yourself. Good or Evil - who shall "
-"prevail? (Blue,Green and Red vs Yellow, Orange and Purple)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:655
-msgid ""
-"The gods have granted this world a great artifact, to find it means victory."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:656
-msgid "The Gods themselves will aid us in this War."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:657
-msgid "The Gold Traveller's Tent is near the Aqua Taveller's Tent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:658
-msgid "The guardians of Dragon Isle reside in the jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:659
-msgid "The Ice Prince stands frozen in some forgotten corner of the world."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:660
-msgid "The island...."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:661
-msgid "The Island of Lost Reason"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:662
-msgid "The islands have much wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:663
-msgid "The Isle of Armoria"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:664
-msgid "The key to success is rubbing enough lamps."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:665
-msgid ""
-"The King has declared you his hier apparent and champion. You must seek out "
-"and destroy your common enemy, Wilgatus and his Castle, Mirkosov, the source "
-"of his power."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:666
-msgid ""
-"The King is dead, his kingdom has been shattered, and six leaders seek to "
-"seize power for themselves."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:667
-msgid "The Kingly Wastes"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:668
-msgid "The Kings Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:669
-msgid ""
-"The King will sell you this land for 200,000 gold or you can take it by "
-"force. The choice is yours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:670
-msgid "The land of Heroes II."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:671
-msgid "The Lost Castle of the Ancients"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:672
-msgid ""
-"The mage wars have caused a great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:673
-msgid ""
-"The mage wars have caused great turmoil.  This island has become a central "
-"flux of magical power.  Be wary all those that enter upon here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:674
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trade.  "
-"Plus a little gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:675
-msgid ""
-"The Master Merchant arrives and takes the resources he needs for trading.  "
-"Plus a little more gold for expenses..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:676
-msgid ""
-"The Master Merchant arrives at your Castle.  He tells you tall tales of "
-"travel, full of outrageous lies.  He also gives you, your share of the "
-"profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:677
-msgid ""
-"The Master Merchant arrives back at your Castle.  He tells you tall tales of "
-"faraway places full of outrageous lies.  He also gives you, your share of "
-"the profits..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:678
-msgid "The Medusas have the password and they can be found just to the west."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:679
-msgid "The more there is the less you see."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:680
-msgid "The North Road to Roland's castle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:681
-msgid ""
-"The note in this bottle has become mostly indecipherable. All you can make "
-"out are references to deadly pirates, and hidden gold mines."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:682
-msgid "The Other Side"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:683
-msgid ""
-"The Overlord has given you 4 months to conquer this land or deliver to him "
-"the sum of 150,000 gold."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:684
-msgid ""
-"The people on the Isle of Knowledge are taking up a collection to aid us."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:685
-msgid "The Proving Grounds"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:686
-msgid "The Queen's Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:687
-msgid "The Realm of Air is barred, but you may appeal here for help."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:688
-msgid ""
-"There are remnants of a mighty battle fought here, not too long ago. It "
-"looks as if whoever came this way may have made this their final stop."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:689
-msgid ""
-"There are three enemy castles to the north. Capture them in the name of "
-"Roland the true king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:690
-msgid ""
-"The Red Tide of War rolls North.  Stopping the flood seems hopeless.  Yet, "
-"Honor demands you and your ally die trying."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:691
-msgid "There is hidden treasure north of the Green Lord's Ore Mine."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:692
-msgid "There is hidden treasure south of the Blue Lord's Sawmill."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:693
-msgid "There's a warm wind blowing from the south."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:694
-msgid "There's a Wizard living in the north who is behind this peasant revolt."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:695
-msgid "The Retreat of the Alchemist Doctor Yu"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:696
-msgid ""
-"There used to be a mine here, but it has long since run out of ore.  You are "
-"only able to scavenge 5 units of ore from the old site."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:697
-msgid "There was a shipreck in the far east waters recently."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:698
-msgid "The River Styx"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:699
-msgid "The roars of several dragons echo from the towers."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:700
-msgid "The Rock Store."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:701
-msgid "The Royal Gardens."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:702
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:703
-msgid ""
-"The Scholars, Priests, and Priestesses of the Isle have given you what they "
-"can to help you defend against your enemies."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:704
-msgid "These doors are a risk the likes of which you do not know."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:705
-msgid "These lands are beholden to Lord Kraeger."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:706
-msgid ""
-"These lands are desolate and for the most part devoid of resources. Not even "
-"the bravest heroes dare to venture into them, and plants are rare and "
-"precious here. Who knows what else awaits?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:707
-msgid ""
-"The Southern Witch is biding her time.  She will strike when your armies are "
-"weak."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:708
-msgid "the stairs"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:709
-msgid "The Table in the Great Hall of the Castle is Haunted."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:710
-msgid ""
-"The third piece of the artifact is somewhere to the north, that much we "
-"know. We are still unsure of its exact location, but our spies are out "
-"gathering information. The forces in this area are too strong to be "
-"completely subjugated, so take what you can and hold on to it tightly."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:711
-msgid ""
-"The troops have sworn their allegiance, but should lose a battle they will "
-"lose faith and our cause will be lost."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:712
-msgid "The Valley of Aruk."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:713
-msgid ""
-"The Valley of Magic holds many surprises.  You discover an old pair of boots "
-"sticking out of the sand."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:714
-msgid "The Valley of Tresures"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:715
-msgid "The Wasteland"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:716
-msgid "The way of magic"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:717
-msgid "The way of might"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:718
-msgid "The way of numbers"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:719
-msgid "The western town."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:720
-msgid "The winds howl in mourning around the shipwreck."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:721
-msgid "The wizard has an island in the southeast."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:722
-msgid ""
-"The Wizards who have captured the Necromancers' town have wasted no time in "
-"building defenses designed to stop you, and their last castle has just been "
-"completed. Fortunately only a Captain of the Guard and a small garrison are "
-"currently present.  If you hurry, you should be able to capture the castle "
-"before they have a chance to reinforce it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:723
-msgid "The wood has arrived."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:724
-msgid "The writing on this sign is too faded to read."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:725
-msgid "The Yellow Lord has the Ultimate Artifact."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:726
-msgid ""
-"The Yellow Lord is a hothead who will attack before his allies can send him "
-"aid."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:727
-msgid "They say there's mermaids in these waters..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:728
-msgid ""
-"This area is rich in resources. Explore, but beware, a castle left "
-"undefended will quickly fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:729
-msgid ""
-"This area must be secured for the sake of the Empire. Our spies have "
-"reported a discord between The kingdom of the knights to the north, and that "
-"of the oppressive sorceresses to the northeast. Perhaps this feud can be "
-"exploited for our gain..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:730
-msgid "This bottle is empty."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:731
-msgid ""
-"This is the last week you have to find the rebel wizard Joseph! Good Luck in "
-"your quest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:732
-msgid ""
-"This land and all others are now under the sole ownership of Ibn Fadlan, the "
-"Undead King. Any disregard for his magesty's soverign rule is to be punished "
-"by death most horrendous."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:733
-msgid ""
-"This land has been claimed by the nation of Neroli. Interlopers are "
-"UNWELCOME."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:734
-msgid ""
-"This rugged land will have rivals fighting the terrain as well as each other."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:735
-msgid ""
-"This rundown village looks like it was once the epicenter of an enormous, "
-"but now ruined, city. Under a pile of rubble you find an object which looks "
-"like it has lain there for ages."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:736
-msgid ""
-"This spot overlooks an old quarry.  This was one of the only places in the "
-"world where ore could be taken right out of the ground.  Unfortunately the "
-"jungle has reclaimed the quarry and it is unusable.  You collect the last of "
-"the ore and depart."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:737
-msgid ""
-"This twisted maze of sorceress towns has three factions struggling for sole "
-"control.  Use your resources wisely!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:738
-msgid ""
-"This village appears to be in little better shape than the first one you "
-"saw. As you approach the village an old man hands you a slip of paper, with "
-"the following message, \"Joseph lives in the town of IslandHome.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:739
-msgid ""
-"This village is in extremely poor shape. There is no chance of getting more "
-"than some of the lesser creatures here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:740
-msgid "This way to the Necromancer Forest."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:741
-msgid "Those who seek knowledge are welcome to the city of Chronos."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:742
-msgid ""
-"Three Warlocks in the land of Dragons. Lose thy home and all will be lost. "
-"Conquer thy enemies and the land shall forever be yours!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:743
-msgid "Timberhill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:744
-msgid "Time for a refreshing drink."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:745
-msgid "Time is running out! The enemy's reinforcements are almost here."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:746
-msgid "To pass you must pay troll."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:747
-msgid "TreeHome"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:748
-msgid "Trespassers will be EATEN!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:749
-msgid "Trilobar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:750
-msgid "Troy"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:751
-msgid "Tundara"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:752
-msgid "Turn back, friend, while you still can!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:753
-msgid "Turn Back Now!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:754
-msgid "Turn Back Now or all will be LOST!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:755
-msgid "Turn Back or DIE!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:756
-msgid "Turn Back or else!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:757
-msgid "Turn back, you fool."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:758
-msgid "\"Turning Point\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:759
-msgid ""
-"Uae was the scurviest, pirate ye'd never wanta see. In all her years of "
-"murdering and thieving she amassed so much ill-gotten booty that she "
-"couldn't carry it around in her galleon.  Besides, even the meanest can't "
-"stay awake all the time.  Legend tells that she hid it so well, she was "
-"thinking that she just might forget where it was.  So she left clues around "
-"the islands, carved in stone.  Well, she's dead now.  It's up to you to "
-"recover her legacy."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:761
-msgid "Uncle Leo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:762
-msgid "Uncle Milty"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:763
-msgid "Undead Armies"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:764
-msgid "Unholy Alliance"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:765
-msgid "Unite the Tribes. Don't lose your main hero, the first Descendant."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:766
-msgid "Valley of Death"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:767
-msgid "Valley Of The Damned"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:768
-msgid "Valley of the Kings."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:769
-msgid "Vaultius"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:770
-msgid "Vertigo"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:771
-msgid "Vikings!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:772
-msgid "Viper's Nest"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:773
-msgid "Vulcania"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:774
-msgid "Warrior Knight"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:775
-msgid "Wastelands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:776
-msgid "Watch out for Purple!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:777
-msgid "Waystop"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:778
-msgid ""
-"\"We are at the edge of the world!\"  they scream.  \"What are we doing here?"
-"\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:779
-msgid "Weddington"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:780
-msgid "Weed Patch"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:781
-msgid ""
-"We found a weakness my lord. Capture castle Black Fang and victory is ours."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:782
-msgid ""
-"We have just learned that the artifact is on an island north of this "
-"continent. However, there does not appear to be any means to get there. Stay "
-"very alert for any possible way across the narrow channel."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:783
-msgid ""
-"Welcome back general.  Have you finished the conquest of the northern "
-"lands?  What? you still have not finished your mission!  Get back there and "
-"teach those rebels a lesson!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:784
-msgid "Welcome to Li'l Alctatraz! Vistors NOT welcome."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:785
-msgid ""
-"Welcome to Power Island. He who controls this Isle controls the Seven Lakes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:786
-msgid "Welcome to the Sandbar."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:787
-msgid "Welcome to the sandy Isle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:788
-msgid "Welcome to the sorceress' guild."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:789
-msgid "Welcome to the Spiral Isles"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:790
-msgid ""
-"Welcome to the wounderous Kitisland range.  Eruptions each day, beware of "
-"dragons."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:791
-msgid "Welcome to Windfall Island!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:792
-msgid "Welcome to your DOOM!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:793
-msgid "We'll join you - for the right price."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:794
-msgid ""
-"Well placed bribes have won you a stronghold near the warring Barbarians. Be "
-"advised that given their proximity an unguarded castle is an open invitation "
-"to defeat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:795
-msgid "Westfork"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:796
-msgid "Westmoor"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:797
-msgid "We told you not to drink!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:798
-msgid "What are you doing here?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:799
-msgid "What cannot be seen but only heard, and will not speak until spoken to?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:800
-msgid "What everyday word is most often pronounced incorrectly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:801
-msgid "What goes up and down but never moves?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:802
-msgid ""
-"What good fortune!  You've discovered a long-abandoned settlement.  To your "
-"surprise, you discover that the previous inhabitants left some of their "
-"resources behind when they departed!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:803
-msgid "What is always coming but never arrives?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:804
-msgid "What is the Sum of all Numbers from 1 to 200?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:805
-msgid "What is time spent poorly?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:806
-msgid "What's another word for pirate treasure?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:807
-msgid "What's behind door number one?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:808
-msgid "What's this? A pile of gems?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:809
-msgid "What's this? Someone has left a pile of wood here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:810
-msgid ""
-"What team won Super Bowl XXI and Super Bowl XXV?  (Hint... a Wizard might "
-"have these troops in his army)"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:811
-msgid "What turns everything around but does not move?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:812
-msgid ""
-"What walks in the morning on four legs, two in the afternoon and three in "
-"the evening?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:813
-msgid "What?  What's this?  Something at the bottom of this pool..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:814
-msgid "When you're ready, take the teleport to the Island's Hot Spot!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:815
-msgid ""
-"When you think yourself invincible, walk through this gate.  Even then, "
-"prepare to meet your bitter end."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:816
-msgid "Where am I?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:817
-msgid "While away seeking the Ultimate Artifact, Kastor's kingdom is invaded!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:818
-msgid ""
-"While traveling a mesenger meets you on the road.  His message tells of a "
-"new ally from an island far to the south.  This ally can not offer forces to "
-"your battle but has agreed to send some support in the form of gold and "
-"crystal."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:819
-msgid "Whiteshield"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:820
-msgid "Whittingham"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:821
-msgid "Who am I?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:822
-msgid ""
-"Who am I?...  Where am I?...  Oh no! My Ship!  Well it's consigned to the "
-"ghosts of my dead crew now, at least I still have my lucky rabbits foot."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:823
-msgid "Who is the true King?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:824
-msgid ""
-"\"Why have we come this way?\"  asks the first mate.  You have no answer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:825
-msgid "Wicked Warlock Way"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:826
-msgid "Wilasher"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:827
-msgid "Wildabar"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:828
-msgid "Wilgatus"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:829
-msgid "Willow"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:830
-msgid "Windfall Isle"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:831
-msgid "Winterkill"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:832
-msgid "Winterlands"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:833
-msgid "Witch Hunt"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:834
-msgid ""
-"With the year long eruption of Mt. Kitisland, your three worst enemies now "
-"have a ground bridge to your eastern contenent."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:835
-msgid "Wizardwood.  Magicians welcome!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:836
-msgid "Woodhaven"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:837
-msgid "Wood's Lord"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:838
-msgid "Woodstock"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:839
-msgid "Woodville"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:840
-msgid "Wormed Ash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:841
-msgid "Wow, somebody has left a pile of wood here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:842
-msgid "Wyrm"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:843
-msgid "Xabran"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:844
-msgid "Yellow gets some stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:845
-msgid "Yellow's Steady Cash"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:846
-msgid "Yellow stuff"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:847
-msgid "Yellow's Yarbols"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:848
-msgid "Ye old fish liver oil."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:849
-msgid "Yorksford"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:850
-msgid ""
-"You and your ally's families were given custody of The Isle of Knowledge.  "
-"Other Lords feel the time has come for new guardians..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:851
-msgid "You are a fool to come here!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:852
-msgid "You are fighting on the side of your king!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:853
-msgid "You are fighting on the side of your sister!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:854
-msgid "You are now entering the domain of Prince Roland. Have a nice day."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:855
-msgid "You are now entering the domain of Prince Roland. Have a pleasant stay."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:856
-msgid ""
-"You bribe the entrance guards of this dingy prison camp. They agree to look "
-"the other way for a little while."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:857
-msgid ""
-"You can only reach your enemies via teleporters, but each jump is a leap of "
-"faith."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:858
-msgid ""
-"You cautiously ride through the trees, looking out for enemy assaults, when "
-"suddenly, the old elf is beside you. \"Your quest is almost at an end, my "
-"friend. All that remains is for you to lay seige to these last few castles. "
-"The fate of my people rests upon your final battles here. May the gods be "
-"with you as well.\"  He turns to leave, but you ask him his name before he "
-"is gone. Over his shoulder, as he is leaving he says \"I am Ilthanis, king "
-"of the elves.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:859
-msgid ""
-"You come across the dead remains of what was appearantly a powerful wizard!  "
-"You wonder if it's safe to continue."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:860
-msgid ""
-"You face three opponents in this scenario. Capture their castles and their "
-"heroes to prove your worthiness to Archibald."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:861
-msgid ""
-"You find a beautiful helm buried in the lava.  As you move to put it on your "
-"head it turns into the Hideous mask and now you realize that no creature "
-"will join you."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:862
-msgid ""
-"You find a gleaming gold medalion buried in the  snow.  As you move to put "
-"it on it changes to the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:863
-msgid ""
-"You find an old signpost in the midst of a thicket that reads \"Warlock "
-"Wood, West.  Barbarian Fields, East.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:864
-msgid ""
-"You find a note in the bottle! It reads, \"My ship has been wrecked by the "
-"notorious pirates in this area! I am stranded on a small and barren island. "
-"Please, I beg you to come and rescue me!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:865
-msgid "You found something!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:866
-msgid "You found Treasure!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:867
-msgid ""
-"You have been ordered here to claim this land in the name of your King and "
-"recover any riches that you might find.  However, five other Kings and "
-"Queens have also sent their heroes to this land, so you must watch out for "
-"them as well as the natives!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:868
-msgid "You have found what someone else has lost..."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:869
-msgid ""
-"You have hired a barbarian of great power to aid you in this, your last "
-"quest. His origins are unknown to you, but you sense strong nobility beneath "
-"the furs and dirt that cover him. In addition, the famous explorer, Marco "
-"the wizard, is rumored to have wrecked his ship in this new land. Finding "
-"him would prove to be a much needed boon to your cause."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:870
-msgid ""
-"You have just 8 weeks  to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:871
-msgid ""
-"You have just 8 weeks to build your army and conquer a town on the other "
-"side of a distant river.  There are three paths to take, which will you "
-"choose?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:872
-msgid ""
-"You have received a message from Archibald. \"General, these peasants "
-"deserve punishment. Put them to the sword and let Corlagon have his way with "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:873
-msgid ""
-"You have received a message from Archibald.  \" HOW DARE YOU BETRAY ME! I "
-"will see your head on the block alongside your new master's once I have won."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:874
-msgid ""
-"You have received a message from Roland. \" I am shocked! I had thought "
-"better of you, but I was terribly wrong. Now you'll have to live with your "
-"dark decision for the rest of your life.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:875
-msgid "You have recieved a shipment of supplies from your kingdom!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:876
-msgid ""
-"You have recieved a shipment of supplies from your kingdom! There is a note "
-"attached, \"These are all we could afford to send you from our treasuries, "
-"as the war with Harondale is taxing us greatly. We will send more in two "
-"weeks.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:877
-msgid ""
-"You have six months to destroy the Necromancer Stronghold in the heart of "
-"the valley."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:878
-msgid ""
-"You have washed up on the beach after being shipwrecked. Your goal is to "
-"find a way home."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:879
-msgid ""
-"You hear a low rumble, look up and see an avalanche!  You dive onto a large "
-"patch of grass to avoid it.  While dusting yourself off, you consider "
-"yourself quite lucky to be alive.  Luckier still to find a Four-Leaf Clover "
-"stuck on your nose."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:880
-msgid ""
-"You hear a rumor from a peasant who lives in the town of Waystop. He says, "
-"\"The pirates control most of the sulfur mines in this area. They use it for "
-"the cannons on their bigger boats. If you want a mine, you'll have to defeat "
-"them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:881
-msgid "You hear melodic strains of elvish music as you enter this clearing."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:882
-msgid ""
-"You must, like, forsake your earthly wealth and, like, join us on the island "
-"of the lotus eaters."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:883
-msgid ""
-"You must search the world for your mortal enemy, Wilgatus.  Can you find him "
-"before its too late?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:884
-msgid ""
-"You notice some runes hastily scrawled into a rock by your feet, They look "
-"like the initials of Uncle Ivan!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:885
-msgid ""
-"You notice that mines and resources in the elvish lands are few, and you "
-"send word to your kingdom that you will need extra supplies. They should "
-"respond within a fortnight."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:886
-msgid ""
-"Your advance scouts come riding back to you with the following news. They "
-"believe they have found signs that Uncle Ivan was in this general area, and "
-"that he made his way to the north many months ago. Also they say there is a "
-"town nearby and many resources to the east."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:887
-msgid ""
-"Your advisor approaches you, \"My liege, something must be done about these "
-"peasants! They still refuse to work.  At this rate you won't have anything "
-"to put in your daughter's dowry!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:888
-msgid ""
-"Your advisor approaches you smiling greatly, \"My liege! The peasants are "
-"making money in the market, and are finally paying taxes!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:889
-msgid ""
-"Your advisor approaches you with a long face, \"My liege, the peasant's "
-"numbers are growing steadily.  All they do is take, take, take! We are "
-"beginning to suffer dearly because of them.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:890
-msgid ""
-"Your advisor approaches you with some startling information, \"My liege, the "
-"peasants are draining us. They do nothing, and take everything! We must get "
-"them home. Your own citizens are beginning to suffer!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:891
-msgid ""
-"Your arrival here was a surprise to those sworn to guard Dragon Isle, and "
-"you were able to quickly capture one of their castles.  Use caution, though, "
-"for two other guardians remain in this jungle."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:892
-msgid ""
-"Your castle, founded inside the center of a mile wide crater, is besieged by "
-"those who desire your mineral wealth."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:893
-msgid "Your castle is the last outpost in the area, Don't lose it!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:894
-msgid "Your crew begins to grumble."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:895
-msgid ""
-"Your crew seriously entertains thoughts of mutiny.  Your nights are "
-"sleepless."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:896
-msgid "You're almost there!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:897
-msgid "You, recieve word that you have been robbed."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:898
-msgid "You're getting colder."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:899
-msgid "You're getting warmer."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:900
-msgid ""
-"You're here! Oh, thank you thank you thank you! I'm in the jail east of the "
-"castle. Please hurry!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:901
-msgid ""
-"Your expedition has taken a turn for the worse... you now have no way to get "
-"home!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:902
-msgid ""
-"Your forces are thinly spread in an effort to defend all the dwarf towns "
-"(which may not be transformed into castles). Consolidate your forces and "
-"smite the enemy before the towns fall."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:903
-msgid ""
-"Your horse stumbles and throws you from the saddle.  When you awaken you "
-"find that you have hit your head on the Fizbin of Misfortune."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:904
-msgid ""
-"Your isolation from the rest of the kingdom has largely kept you out of the "
-"political struggles, but now with the king's death, and lack of an heir, you "
-"see a golden opportunity to seize the throne for yourself.  Just remember "
-"that you have relied largely on trade for several key resources, especially "
-"sulfur, but with a little planning this land can be yours.  Go, now, and "
-"show these peasants how to rule!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:905
-msgid "Your king has sent supplies to aid the war effort."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:906
-msgid ""
-"Your opponents are allied against you and each is twice as powerful as his "
-"predecessor! Is it possible to win?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:907
-msgid ""
-"Your Queen sent you here to explore this newly discovered territory, but a "
-"freak storm scattered your fleet and left you stranded.  You gather the "
-"survivors and form a small settlement, naming it New Vertigo.  This place is "
-"your home now, and survival is your highest priority, but remember, if you "
-"are captured or killed, it's over!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:908
-msgid ""
-"Your rival, the kingdom of Harondale, is attacking your weak border towns! "
-"Recover from their first strike and crush them completely."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:909
-msgid ""
-"Your Scouts report talking to a young knight, a squire to the two sleeping "
-"heroes.  The squire is trapped by the Aqua Magic Barriers and a group of "
-"fallen Paladins.  He says the two heroes, Dainwin and Ceallach, have "
-"awakened but are still trapped by a Gold Magical Barrier and asks your aid "
-"in freeing them."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:910
-msgid ""
-"Your Scouts report that the Aqua Traveller's Tent is located along The North "
-"Road."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:911
-msgid ""
-"Your scouts return with grim news.  The natives of this land are currently "
-"at war with each other, and they like outsiders even less than they like "
-"each other!  Congratulations, Commander, you're at war!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:912
-msgid ""
-"Your sister calls you before her altar in the morning. \"I have important "
-"news,\" she says, \"The barbarian kingdoms which border this land have "
-"agreed to lend us some of their castles and warriors in return for a share "
-"of the spoils. I hope victory comes swiftly, but your presence gives me "
-"strength to stand until whatever end awaits.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:913
-msgid "Your subjects contribute to your war effort!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:914
-msgid ""
-"Your town is undefended and your heroes are scattered.  Do you attack or "
-"defend?"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:915
-msgid ""
-"Your treasury has been looted by robbers and you have lost valuable "
-"resources."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:916
-msgid "Your troops begin to wonder about your sanity."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:917
-msgid ""
-"You run aground on the rocks and have to use some wood to fix your boat."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:918
-msgid ""
-"You see a family of refugees making their way from the beach. You ask them "
-"about their plight and they tell you that they are from a once great city "
-"called Moss Side. They tell you that the castle was destroyed in a great "
-"conflagration, and they fled for fear of their lives."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:919
-msgid ""
-"You see an old man bringing water towards the stables. Recognizing him as "
-"the mystic, you attempt to thank him for his gift with some gold. He "
-"refuses, but says to you instead, \"There are riddles guarding the source of "
-"the fount's power, and the dragons know the answers. Make your way through "
-"their lair, and you shall know victory.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:920
-msgid ""
-"You see an old mystic perched on a rock. You walk towards him to see if he "
-"has any words for you on your quest, and he says \"First I see you as a "
-"great conquerer of the lands of men. Secondly, I see you as a mighty ruler "
-"of vast armies, well loved by your troops. Thirdly, I see you as a slayer of "
-"legions of dragons, your body bathed in their fire. Lastly, I see you "
-"standing on the shores of the fount, unable to cross.\" Then the Mystic "
-"fades away."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:921
-msgid "You see something that could just be the elusive Nubbie!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:922
-msgid ""
-"You see the mast of ancient ship here.  On further investigation you find "
-"that the ships holds are full of gems.  The hours pass as your crue "
-"liberates the treasure."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:923
-msgid ""
-"You see the remains of a burned out sawmill here.  All you can salvage is "
-"some ofwood left for scrap."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:924
-msgid ""
-"You see the remains of an old sawmill, but it is obvious that you will not "
-"be able to make it work again."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:925
-msgid ""
-"You see the remains of an old sawmill just to realize that it will no longer "
-"produce.  You gather the ramains and move on."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:926
-msgid ""
-"You send this letter back to the king,\"A month has passed and we have not "
-"discovered the wizard Joseph. I only hope that we are able to locate him in "
-"time to aid us in our struggle.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:927
-msgid "You should turn back."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:928
-msgid ""
-"You stumble upon an old man who proclaims you Lord of the Realm, hands you "
-"his boots and wonders into the mountains mumbling something about being late "
-"for an important date."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:929
-msgid ""
-"You stumple across three small rocks piled on top of each other and decide "
-"to dig undernear them.  There you find an old weather-beaten bag of gems."
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:930
-msgid "You uncover a compass in the grass!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:931
-msgid "You've been warned!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:932
-msgid ""
-"You've received a message from Roland. \"In the absence of a strong leader, "
-"the local lords have fallen to fighting. Uniting this area is critical to "
-"our cause, so we must not fail.  Leaving your castle undefended in this "
-"highly contested region will surely lead to defeat. I'm counting on you.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:933
-msgid ""
-"You've received a message from the guild. \"Thank God you've arrived! We're "
-"under seige from two enemies from the north and one from across the sea. "
-"Please save us, you're our only hope.\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:934
-msgid ""
-"You've ruled with an iron fist (and an army of undead), but now your kingdom "
-"has turned against you!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:935
-msgid ""
-"You've saved a group of miners from the dragons.  One of them approaches "
-"you, \"Thank you so much for saving us!  We found this sulfer and sword in "
-"the mine, then those dragons chased us!  I don't know how much longer we "
-"could survive!\""
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:936
-msgid ""
-"You will clash quickly on this small head-to-head map, so stay on your toes!"
-msgstr ""
-
-#: ../fheroes2/resource/maps_text.cpp:937
-msgid ""
-"You will need a stronger army than that, mortal, to step through this portal."
-msgstr ""
-
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Wood"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Mercury"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Ore"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Sulfur"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Crystal"
 msgstr ""
 
-#: ../fheroes2/resource/resource.cpp:283
 msgid "Gems"
 msgstr ""
 
-#: ../fheroes2/spell/spell_book.cpp:61 ../fheroes2/spell/spell_book.cpp:79
-msgid "No spell to cast."
-msgstr ""
-
-#: ../fheroes2/spell/spell_book.cpp:138
-msgid "Your hero has %{point} spell points remaining"
-msgstr ""
-
-#: ../fheroes2/spell/spell.cpp:50
 msgid "Fireball"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:50
 msgid ""
 "Causes a giant fireball to strike the selected area, damaging all nearby "
 "creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid "Fireblast"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:51
 msgid ""
 "An improved version of fireball, fireblast affects two hexes around the "
 "center point of the spell, rather than one."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Lightning Bolt"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:52
 msgid "Causes a bolt of electrical energy to strike the selected creature."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid "Chain Lightning"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:53
 msgid ""
 "Causes a bolt of electrical energy to strike a selected creature, then "
 "strike the nearest creature with half damage, then strike the NEXT nearest "
@@ -11263,818 +5492,599 @@ msgid ""
 "harmful.  Warning:  This spell can hit your own creatures!"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid "Teleport"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:54
 msgid ""
 "Teleports the creature you select to any open position on the battlefield."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid "Cure"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:55
 msgid ""
-"Removes all negative spells cast upon one of your units, and restores up to %"
-"{count} HP per level of spell power."
+"Removes all negative spells cast upon one of your units, and restores up to "
+"%{count} HP per level of spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid "Mass Cure"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:56
 msgid ""
-"Removes all negative spells cast upon your forces, and restores up to %"
-"{count} HP per level of spell power, per creature."
+"Removes all negative spells cast upon your forces, and restores up to "
+"%{count} HP per level of spell power, per creature."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrect"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:57
 msgid "Resurrects creatures from a damaged or dead unit until end of combat."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrect True"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:58
 msgid "Resurrects creatures from a damaged or dead unit permanently."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Haste"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:59
 msgid "Increases the speed of any creature by %{count}."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Mass Haste"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:60
 msgid "Increases the speed of all of your creatures by %{count}."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "spell|Slow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:61
 msgid "Slows target to half movement rate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Mass Slow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:62
 msgid "Slows all enemies to half movement rate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:64
-msgid "Blind "
+msgid "spell|Blind"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:64
 msgid "Clouds the affected creatures' eyes, preventing them from moving."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Bless"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:65
 msgid "Causes the selected creatures to inflict maximum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Mass Bless"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:66
 msgid "Causes all of your units to inflict maximum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Stoneskin"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:67
 msgid "Magically increases the defense skill of the selected creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid "Steelskin"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:68
 msgid ""
 "Increases the defense skill of the targeted creatures.  This is an improved "
 "version of Stoneskin."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Curse"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:69
 msgid "Causes the selected creatures to inflict minimum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Mass Curse"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:70
 msgid "Causes all enemy troops to inflict minimum damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Holy Word"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:71
 msgid "Damages all undead in the battle."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid "Holy Shout"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:72
 msgid ""
 "Damages all undead in the battle.  This is an improved version of Holy Word."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Anti-Magic"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:73
 msgid "Prevents harmful magic against the selected creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Dispel Magic"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:74
 msgid "Removes all magic spells from a single target."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Mass Dispel"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:75
 msgid "Removes all magic spells from all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Magic Arrow"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:76
 msgid "Causes a magic arrow to strike the selected target."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Berserker"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:77
 msgid "Causes a creature to attack its nearest neighbor."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid "Armageddon"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:78
 msgid ""
 "Holy terror strikes the battlefield, causing severe damage to all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Elemental Storm"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:79
 msgid "Magical elements pour down on the battlefield, damaging all creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid "Meteor Shower"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:80
 msgid ""
 "A rain of rocks strikes an area of the battlefield, damaging all nearby "
 "creatures."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "Paralyze"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:81
 msgid "The targeted creatures are paralyzed, unable to move or retaliate."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid "Hypnotize"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:82
 msgid ""
-"Brings a single enemy unit under your control for one combat round if its "
-"hits are less than %{count} times the caster's spell power."
+"Brings a single enemy unit under your control if its hits are less than "
+"%{count} times the caster's spell power."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Cold Ray"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:83
 msgid "Drains body heat from a single enemy unit."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid "Cold Ring"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:84
 msgid ""
 "Drains body heat from all units surrounding the center point, but not "
 "including the center point."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Disrupting Ray"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:85
 msgid "Reduces the defense rating of an enemy unit by three."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Death Ripple"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:86
 msgid "Damages all living (non-undead) units in the battle."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid "Death Wave"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:87
 msgid ""
 "Damages all living (non-undead) units in the battle.  This spell is an "
 "improved version of Death Ripple."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Dragon Slayer"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:88
 msgid "Greatly increases a unit's attack skill vs. Dragons."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Blood Lust"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:89
 msgid "Increases a unit's attack skill."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Animate Dead"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:90
 msgid "Resurrects creatures from a damaged or dead undead unit permanently."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid "Mirror Image"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:91
 msgid ""
 "Creates an illusionary unit that duplicates one of your existing units.  "
 "This illusionary unit does the same damages as the original, but will vanish "
 "if it takes any damage."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Shield"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:92
 msgid "Halves damage received from ranged attacks for a single unit."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Mass Shield"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:93
 msgid "Halves damage received from ranged attacks for all of your units."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summon Earth Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:94
 msgid "Summons Earth Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summon Air Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:95
 msgid "Summons Air Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summon Fire Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:96
 msgid "Summons Fire Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summon Water Elemental"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:97
 msgid "Summons Water Elementals to fight for your army."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Earthquake"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:98
 msgid "Damages castle walls."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "View Mines"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:99
 msgid "Causes all mines across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "View Resources"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:100
 msgid "Causes all resources across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "View Artifacts"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:101
 msgid "Causes all artifacts across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "View Towns"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:102
 msgid "Causes all towns and castles across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "View Heroes"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:103
 msgid "Causes all Heroes across the land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "View All"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:104
 msgid "Causes the entire land to become visible."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Identify Hero"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:105
 msgid "Allows the caster to view detailed information on enemy Heroes."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid "Summon Boat"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:106
 msgid ""
 "Summons the nearest unoccupied, friendly boat to an adjacent shore "
 "location.  A friendly boat is one which you just built or were the most "
 "recent player to occupy."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Dimension Door"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:107
 msgid "Allows the caster to magically transport to a nearby location."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Town Gate"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:108
 msgid "Returns the caster to any town or castle currently owned."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:109
 msgid ""
 "Returns the hero to the town or castle of choice, provided it is controlled "
 "by you."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid "Visions"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:110
 msgid ""
 "Visions predicts the likely outcome of an encounter with a neutral army camp."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid "Haunt"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:111
 msgid ""
 "Haunts a mine you control with Ghosts.  This mine stops producing "
 "resources.  (If I can't keep it, nobody will!)"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Set Earth Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:112
 msgid "Sets Earth Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Set Air Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:113
 msgid "Sets Air Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Set Fire Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:114
 msgid "Sets Fire Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Set Water Guardian"
 msgstr ""
 
-#: ../fheroes2/spell/spell.cpp:115
 msgid "Sets Water Elementals to guard a mine against enemy armies."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:665
-msgid "Necroman"
+msgid "No spell to cast."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:691
-msgid ""
-"This lets you change player starting positions and colors. A particular "
-"color will always start in a particular location. Some positions may only be "
-"played by a computer player or only by a human player."
+msgid "Your hero has %{point} spell points remaining."
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:695
-msgid ""
-"This lets you change the class of a player. Classes are not always "
-"changeable. Depending on the scenario, a player may receive additional towns "
-"and/or heroes not of their primary alignment."
+msgid "View Adventure Spells"
 msgstr ""
 
-#: ../fheroes2/system/players.cpp:734
-msgid "%{color} player"
+msgid "View Combat Spells"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:126
+msgid "View previous page"
+msgstr ""
+
+msgid "View next page"
+msgstr ""
+
+msgid "Close Spellbook"
+msgstr ""
+
+msgid "View %{spell}"
+msgstr ""
+
 msgid "game: always confirm for rewrite savefile"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:127
-msgid "game: also confirm autosave"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:128
 msgid "game: remember last focus"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:129
-msgid "game: battle show grid"
+msgid "battle: show damage info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:130
-msgid "game: battle mouse shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:131
-msgid "game: battle move shadow"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:132
-msgid "game: battle show damage info"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:133
-msgid "game: castle flash building"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:134
 msgid "world: show visited content from objects"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:135
+msgid "world: show terrain penalty"
+msgstr ""
+
 msgid "world: scouting skill show extended content info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:136
-msgid "world: abandoned mine random resource"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:137
-msgid "world: save count monster after battle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:138
 msgid "world: allow set guardian to objects"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:139
-msgid "world: guardian objects gets +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:140
-msgid "world: no in-built requirements or guardians for placed artifacts"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:141
-msgid "world: only the first monster will attack (H2 bug)."
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:142
 msgid "world: Eagle Eye also works like Scholar in H3."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:143
 msgid "world: ban for WeekOf/MonthOf Monsters"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:144
-msgid "world: new version WeekOf (+growth)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:145
 msgid "world: ban plagues months"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:146
 msgid "world: Months Of Monsters do not place creatures on map"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:147
 msgid "world: Crystal Ball also added Identify Hero and Visions spells"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:148
-msgid "world: Artesian Springs have two separately visitable squares (h3 ver)"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:149
 msgid "world: Starting heroes as Loss Conditions for Human Players"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:150
 msgid "world: Only 1 hero can be hired by the one player every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:151
-msgid "world: each castle allows one hero to be recruited every week"
+msgid "world: Each castle allows one hero to be recruited every week"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:152
-msgid "world: Outer creature dwellings should accumulate units"
+msgid "world: Neutral armies scale with game difficulty"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:153
-msgid "world: use unique artifacts for morale/luck"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:154
 msgid "world: use unique artifacts for resource affecting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:155
 msgid "world: use unique artifacts for primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:156
 msgid "world: use unique artifacts for secondary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:157
 msgid "world: Wind/Water Mills and Magic Garden can be captured"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:158
 msgid "world: disable Barrow Mounds"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:159
-msgid "castle: allow buy from well"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:160
 msgid "castle: allow guardians"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:161
 msgid ""
 "castle: higher mage guilds regenerate more spell points/turn "
 "(20/40/60/80/100%)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:162
-msgid "castle: allow recruits special/expansion heroes"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:163
 msgid "heroes: allow buy a spellbook from Shrines"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:164
-msgid "heroes: learn new spells with day"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:165
 msgid "heroes: recruit cost to be dependent on hero level"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:166
-msgid "heroes: remember MP/SP for retreat/surrender result"
+msgid "heroes: remember move points for retreat/surrender result"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:167
-msgid "heroes: surrendering gives some experience"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:168
-msgid "heroes: recalculate movement points after creatures movement"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:169
-msgid "heroes: allow pickup objects for patrol"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:170
-msgid "heroes: after battle move to target cell"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:171
 msgid "heroes: allow transcribing scrolls (needs: Eye Eagle skill)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:172
-msgid "heroes: allow banned sec. skills upgrade"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:173
 msgid "heroes: in Arena can choose any of primary skills"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:174
 msgid "unions: allow meeting heroes"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:175
 msgid "unions: allow castle visiting"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:176
+msgid "battle: show army order"
+msgstr ""
+
 msgid "battle: soft wait troop"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:177
-msgid "battle: high objects are an obstacle for archers"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:178
-msgid "battle: merge armies for hero from castle"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:179
-msgid "battle: archmage can resists (20%) bad spells"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:180
-msgid "battle: magical creature resists (20%) the same magic"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:181
-msgid "battle: skip increase +2 defense"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:182
 msgid "battle: reverse wait order (fast, average, slow)"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:183
 msgid "game: show system info"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:184
 msgid "game: autosave on"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:185
 msgid "game: autosave will be made at the beginning of the day"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:186
 msgid "game: use fade"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:187
-msgid "game: show SDL logo"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:188
 msgid "game: use evil interface"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:189
-msgid "game: also use dynamic interface for castles"
-msgstr ""
-
-#: ../fheroes2/system/settings.cpp:190
 msgid "game: hide interface"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:191
 msgid "game: offer to continue the game afer victory condition"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:192
-msgid "pocketpc: hide cursor"
+msgid "The ultimate artifact is really the %{name}."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:193
-msgid "pocketpc: tap mode"
+msgid "The ultimate artifact may be found in the %{name} regions of the world."
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:194
-msgid "pocketpc: drag&drop gamearea as scroll"
+msgid "north-west"
 msgstr ""
 
-#: ../fheroes2/system/settings.cpp:195
-msgid "pocketpc: low memory"
+msgid "north"
+msgstr ""
+
+msgid "north-east"
+msgstr ""
+
+msgid "west"
+msgstr ""
+
+msgid "center"
+msgstr ""
+
+msgid "east"
+msgstr ""
+
+msgid "south-west"
+msgstr ""
+
+msgid "south"
+msgstr ""
+
+msgid "south-east"
+msgstr ""
+
+msgid "The truth is out there."
+msgstr ""
+
+msgid "The dark side is stronger."
+msgstr ""
+
+msgid "The end of the world is near."
+msgstr ""
+
+msgid "The bones of Lord Slayer are buried in the foundation of the arena."
+msgstr ""
+
+msgid "A Black Dragon will take out a Titan any day of the week."
+msgstr ""
+
+msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
+msgstr ""
+
+msgid "An unknown force is being ressurected..."
+msgstr ""
+
+msgid ""
+"Check the newest version of game at\n"
+"https://github.com/ihhub/\n"
+"fheroes2/releases"
 msgstr ""

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -53,8 +53,8 @@ u32 crc32b( const char * msg )
         crc ^= static_cast<u32>( msg[index] );
 
         for ( int bit = 0; bit < 8; ++bit ) {
-            uint32_t mask = ~( crc & 1 );
-            crc = ( crc >> 1 ) ^ ( 0xEDB88320 & mask );
+            uint32_t poly = ( crc & 1 ) ? 0xEDB88320 : 0x0;
+            crc = ( crc >> 1 ) ^ poly;
         }
 
         ++index;


### PR DESCRIPTION
This consists of 3 commits related to #2211:
- update the .pot file and merge .po files with it (fully automated change)
- fix a bug in the crc32b function which makes the calculated CRC independent of the input data
- add a call to `iconv/konwert` to replace language-specific characters with ASCII. `iconv` is pretty standard but doesn't handle Russian. `konwert` is less widespread (it's packaged for Debian though) and handles Russian pretty well. It also has a /1 option which forces a 1-to-1 replacement (so that `ä` is replaced with `a` rather than `ae` or `"a`), which is useful when checking whether translations fit on their respective interface elements.

I'm currently working on FR/RU translations (I own a French GoG HoMM2 version and a Russian edition of HoMM2 from "Buka" which is arguably the most decent Russian translation out there, not just machine-translated junk) for comparison. Here's a screenshot of fheroes2 with `lang=fr` side by side with a French version of HoMM2 from GoG (note - translation changes are not part of this PR, I prefer to submit these separately later):

![homm2_fr](https://user-images.githubusercontent.com/10945319/124096901-52be1480-da5b-11eb-93c6-298c842602fe.png)
