### PR TITLE
Fix passabilities for old saves being resaved

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2460,14 +2460,6 @@ StreamBase & Maps::operator>>( StreamBase & msg, Tiles & tile )
     if ( Game::GetLoadVersion() >= FORMAT_VERSION_095_RELEASE ) {
         msg >> tile._level;
     }
-    else {
-        if ( MP2::isActionObject( tile.quantity1 ) ) {
-            tile._level = 0;
-        }
-        else {
-            tile._level = tile.quantity1 & 0x03;
-        }
-    }
 
     return msg;
 }

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -1121,6 +1121,7 @@ int MP2::getActionObjectDirection( const int objId )
     case OBJ_BOTTLE:
     case OBJ_COAST:
     case OBJ_BOAT:
+    case OBJ_HEROES:
         return DIRECTION_ALL;
 
     case OBJ_SHIPWRECK:

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1137,17 +1137,19 @@ void World::resetPathfinder()
     AI::Get().resetPathfinder();
 }
 
-void World::PostLoad()
+void World::PostLoad( const bool setTilePassabilities )
 {
-    // update tile passable
-    for ( Maps::Tiles & tile : vec_tiles ) {
-        tile.updateEmpty();
-        tile.setInitialPassability();
-    }
+    if ( setTilePassabilities ) {
+        // update tile passable
+        for ( Maps::Tiles & tile : vec_tiles ) {
+            tile.updateEmpty();
+            tile.setInitialPassability();
+        }
 
-    // Once the original passabilities are set we know all neighbours. Now we have to update passabilities based on neighbours.
-    for ( Maps::Tiles & tile : vec_tiles ) {
-        tile.updatePassability();
+        // Once the original passabilities are set we know all neighbours. Now we have to update passabilities based on neighbours.
+        for ( Maps::Tiles & tile : vec_tiles ) {
+            tile.updatePassability();
+        }
     }
 
     // cache data that's accessed often
@@ -1276,7 +1278,7 @@ StreamBase & operator>>( StreamBase & msg, World & w )
     msg >> w.vec_tiles >> w.vec_heroes >> w.vec_castles >> w.vec_kingdoms >> w.vec_rumors >> w.vec_eventsday >> w.map_captureobj >> w.ultimate_artifact >> w.day >> w.week
         >> w.month >> w.week_current >> w.week_next >> w.heroes_cond_wins >> w.heroes_cond_loss >> w.map_actions >> w.map_objects >> w._seed;
 
-    w.PostLoad();
+    w.PostLoad( false );
 
     return msg;
 }

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -290,7 +290,7 @@ private:
     void Reset( void );
     void MonthOfMonstersAction( const Monster & );
     void ProcessNewMap();
-    void PostLoad();
+    void PostLoad( const bool setTilePassabilities );
     void pickRumor();
 
 private:

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -715,7 +715,7 @@ void World::ProcessNewMap()
         ultimate_pos = ( *it ).GetCenter();
     }
 
-    PostLoad();
+    PostLoad( true );
 
     // play with hero
     vec_kingdoms.ApplyPlayWithStartingHero();


### PR DESCRIPTION
Every time when we load saves we recalculate passability rules. This is incorrect as objects on map never being changed (for now). This change fixes old saves as well as new ones if there are any issues.