### PR TITLE
AI heroes don't ever capture empty castles

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -769,7 +769,7 @@ namespace AI
                 const RegionStats & regionStats = _regions[world.GetTiles( node.first ).GetRegion()];
 
                 const Castle * castle = world.GetCastle( Maps::GetPoint( node.first ) );
-                if ( castle && ( castle->GetGarrisonStrength( &hero ) <= 0 || castle->GetColor() == hero.GetColor() ) )
+                if ( castle && ( castle->GetGarrisonStrength( &hero ) <= 0 || castle->GetColor() == hero.GetColor() ) && heroStrength < regionStats.highestThreat )
                     value -= dangerousTaskPenalty / 2;
 
                 else if ( heroStrength < regionStats.highestThreat )

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -768,12 +768,14 @@ namespace AI
                 }
                 const RegionStats & regionStats = _regions[world.GetTiles( node.first ).GetRegion()];
 
-                const Castle * castle = world.GetCastle( Maps::GetPoint( node.first ) );
-                if ( castle && ( castle->GetGarrisonStrength( &hero ) <= 0 || castle->GetColor() == hero.GetColor() ) && heroStrength < regionStats.highestThreat )
-                    value -= dangerousTaskPenalty / 2;
+                if ( heroStrength < regionStats.highestThreat ) {
+                    const Castle * castle = world.GetCastle( Maps::GetPoint( node.first ) );
 
-                else if ( heroStrength < regionStats.highestThreat )
-                    value -= dangerousTaskPenalty;
+                    if ( castle && ( castle->GetGarrisonStrength( &hero ) <= 0 || castle->GetColor() == hero.GetColor() ) )
+                        value -= dangerousTaskPenalty / 2;
+                    else
+                        value -= dangerousTaskPenalty;
+                }
 
                 if ( dist > leftMovePoints ) {
                     // Distant object which is out of reach for the current turn must have lower priority.


### PR DESCRIPTION
fix #3795

The intent of this line was to reduce the threat when a castle was empty. But since I forgot to check if there was actually a threat, it was instead decreasing the value of an empty castle. This PR should fix it.