### PR TITLE
code cleanup: Remove redundant c_str() calls

### DIFF
--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -494,7 +494,7 @@ std::string Game::GetEncodeString( const std::string & str1 )
 
     // encode name
     if ( conf.Unicode() && conf.MapsCharset().size() )
-        return EncodeString( str1.c_str(), conf.MapsCharset().c_str() );
+        return EncodeString( str1, conf.MapsCharset().c_str() );
 
     return str1;
 }

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -203,7 +203,7 @@ fheroes2::GameMode Game::HighScores()
 
     Mixer::Pause();
     AGG::PlayMusic( MUS::MAINMENU, true, true );
-    hgs.Load( stream.str().c_str() );
+    hgs.Load( stream.str() );
 
     const fheroes2::Sprite & back = fheroes2::AGG::GetICN( ICN::HSBKG, 0 );
 
@@ -233,7 +233,7 @@ fheroes2::GameMode Game::HighScores()
         if ( player.empty() )
             player = _( "Unknown Hero" );
         hgs.ScoreRegistry( player, Settings::Get().CurrentFileInfo().name, days, rating );
-        hgs.Save( stream.str().c_str() );
+        hgs.Save( stream.str() );
         hgs.RedrawList( top.x, top.y );
         buttonCampain.draw();
         buttonExit.draw();

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -281,7 +281,7 @@ void Game::HotKeysLoad( const std::string & hotkeys )
 {
     TinyConfig config( '=', '#' );
 
-    if ( config.Load( hotkeys.c_str() ) ) {
+    if ( config.Load( hotkeys ) ) {
         int ival = 0;
 
         for ( int evnt = EVENT_NONE; evnt < EVENT_LAST; ++evnt ) {


### PR DESCRIPTION
Fix clang-tidy [readability-redundant-string-cstr](https://releases.llvm.org/11.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-redundant-string-cstr.html) warnings.