### PR TITLE
If the hero's army does not have any of the original troops left alive at the end of the battle, then the hero should lose

### DIFF
--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -505,14 +505,13 @@ void Battle::Arena::Turns( void )
     // end turn: fix result
     if ( !army1->isValid() || ( result_game.army1 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
         result_game.army1 |= RESULT_LOSS;
-        if ( army2->isValid() )
-            result_game.army2 = RESULT_WINS;
+        // check if any of the original troops in the army2 are still alive
+        result_game.army2 = army2->isValid( false ) ? RESULT_WINS : RESULT_LOSS;
     }
-
-    if ( !army2->isValid() || ( result_game.army2 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
+    else if ( !army2->isValid() || ( result_game.army2 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
         result_game.army2 |= RESULT_LOSS;
-        if ( army1->isValid() )
-            result_game.army1 = RESULT_WINS;
+        // check if any of the original troops in the army1 are still alive
+        result_game.army1 = army1->isValid( false ) ? RESULT_WINS : RESULT_LOSS;
     }
 
     // fix experience and killed

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -186,7 +186,7 @@ bool Battle::Force::isValid( bool considerBattlefieldArmy /* = true */ ) const
         if ( troop && troop->isValid() ) {
             const Unit * unit = FindUID( uids.at( index ) );
 
-            if ( unit && unit->GetDead() < troop->GetCount() ) {
+            if ( unit && unit->GetDead() < unit->GetInitialCount() ) {
                 return true;
             }
         }
@@ -395,10 +395,7 @@ void Battle::Force::SyncArmyCount()
             const Unit * unit = FindUID( uids.at( index ) );
 
             if ( unit ) {
-                if ( unit->GetDead() )
-                    troop->SetCount( unit->GetDead() > troop->GetCount() ? 0 : troop->GetCount() - unit->GetDead() );
-                else if ( unit->GetID() == Monster::GHOST )
-                    troop->SetCount( unit->GetCount() );
+                troop->SetCount( unit->GetDead() > unit->GetInitialCount() ? 0 : unit->GetInitialCount() - unit->GetDead() );
             }
         }
     }

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -368,43 +368,8 @@ u32 Battle::Force::GetDeadHitPoints( void ) const
     return res;
 }
 
-void Battle::Force::SyncArmyCount( bool checkResurrected )
+void Battle::Force::SyncArmyCount()
 {
-    // A special case: when every creature was resurrected by Ressurection
-    // In this case we have to find the weakest troop and set it to 1
-    Troop * restoredTroop = nullptr;
-    if ( checkResurrected ) {
-        bool isAllDead = true;
-        std::vector<Troop *> armyMonsters;
-        for ( u32 index = 0; index < army.Size(); ++index ) {
-            Troop * troop = army.GetTroop( index );
-
-            if ( troop && troop->isValid() ) {
-                const Unit * unit = FindUID( uids.at( index ) );
-                if ( unit ) {
-                    if ( unit->GetDead() > 0 ) {
-                        if ( unit->GetDead() < troop->GetCount() ) {
-                            isAllDead = false;
-                            break;
-                        }
-                    }
-                    else {
-                        isAllDead = false;
-                        break;
-                    }
-                }
-
-                armyMonsters.push_back( troop );
-            }
-        }
-
-        if ( isAllDead && !armyMonsters.empty() ) {
-            std::sort( armyMonsters.begin(), armyMonsters.end(), []( const Troop * one, const Troop * two ) { return one->GetStrength() < two->GetStrength(); } );
-
-            restoredTroop = armyMonsters.front();
-        }
-    }
-
     for ( u32 index = 0; index < army.Size(); ++index ) {
         Troop * troop = army.GetTroop( index );
 
@@ -418,9 +383,5 @@ void Battle::Force::SyncArmyCount( bool checkResurrected )
                     troop->SetCount( unit->GetCount() );
             }
         }
-    }
-
-    if ( restoredTroop != nullptr ) {
-        restoredTroop->SetCount( 1 );
     }
 }

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -112,14 +112,14 @@ void Battle::Units::SortArchers( void )
     std::sort( begin(), end(), []( const Troop * t1, const Troop * t2 ) { return t1->isArchers() && !t2->isArchers(); } );
 }
 
-Battle::Unit * Battle::Units::FindUID( u32 pid ) const
+Battle::Unit * Battle::Units::FindUID( uint32_t pid ) const
 {
     const_iterator it = std::find_if( begin(), end(), [pid]( const Unit * unit ) { return unit->isUID( pid ); } );
 
     return it == end() ? nullptr : *it;
 }
 
-Battle::Unit * Battle::Units::FindMode( u32 mod ) const
+Battle::Unit * Battle::Units::FindMode( uint32_t mod ) const
 {
     const_iterator it = std::find_if( begin(), end(), [mod]( const Unit * unit ) { return unit->Modes( mod ); } );
 

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -172,7 +172,7 @@ int Battle::Force::GetControl( void ) const
     return army.GetControl();
 }
 
-bool Battle::Force::isValid( bool considerBattlefieldArmy /* = true */ ) const
+bool Battle::Force::isValid( const bool considerBattlefieldArmy /* = true */ ) const
 {
     // Consider the state of the army on the battlefield (including resurrected units, summoned units, etc)
     if ( considerBattlefieldArmy ) {
@@ -180,8 +180,8 @@ bool Battle::Force::isValid( bool considerBattlefieldArmy /* = true */ ) const
     }
 
     // Consider only the state of the original army
-    for ( u32 index = 0; index < army.Size(); ++index ) {
-        Troop * troop = army.GetTroop( index );
+    for ( uint32_t index = 0; index < army.Size(); ++index ) {
+        const Troop * troop = army.GetTroop( index );
 
         if ( troop && troop->isValid() ) {
             const Unit * unit = FindUID( uids.at( index ) );

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -39,8 +39,8 @@ namespace Battle
 
         Units & operator=( const Units & ) = delete;
 
-        Unit * FindMode( u32 ) const;
-        Unit * FindUID( u32 ) const;
+        Unit * FindMode( uint32_t mod ) const;
+        Unit * FindUID( uint32_t pid ) const;
 
         void SortSlowest();
         void SortFastest();

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -72,7 +72,7 @@ namespace Battle
         void resetIdleAnimation();
 
         void NewTurn( void );
-        void SyncArmyCount( bool checkResurrected );
+        void SyncArmyCount();
 
         static Unit * GetCurrentUnit( const Force & army1, const Force & army2, bool part1, int preferredColor );
         static void UpdateOrderUnits( const Force & army1, const Force & army2, const Unit * activeUnit, int preferredColor, const Units & orderHistory, Units & orders );

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -39,8 +39,8 @@ namespace Battle
 
         Units & operator=( const Units & ) = delete;
 
-        Unit * FindMode( u32 );
-        Unit * FindUID( u32 );
+        Unit * FindMode( u32 ) const;
+        Unit * FindUID( u32 ) const;
 
         void SortSlowest();
         void SortFastest();
@@ -60,7 +60,7 @@ namespace Battle
         HeroBase * GetCommander( void );
         const HeroBase * GetCommander( void ) const;
 
-        bool isValid( void ) const;
+        bool isValid( bool considerBattlefieldArmy = true ) const;
         bool HasMonster( const Monster & ) const;
         u32 GetDeadHitPoints( void ) const;
         u32 GetDeadCounts( void ) const;

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -60,7 +60,7 @@ namespace Battle
         HeroBase * GetCommander( void );
         const HeroBase * GetCommander( void ) const;
 
-        bool isValid( bool considerBattlefieldArmy = true ) const;
+        bool isValid( const bool considerBattlefieldArmy = true ) const;
         bool HasMonster( const Monster & ) const;
         u32 GetDeadHitPoints( void ) const;
         u32 GetDeadCounts( void ) const;

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -183,8 +183,8 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, s32 mapsindex )
     }
 
     // save count troop
-    arena->GetForce1().SyncArmyCount( ( result.army1 & RESULT_WINS ) != 0 );
-    arena->GetForce2().SyncArmyCount( ( result.army2 & RESULT_WINS ) != 0 );
+    arena->GetForce1().SyncArmyCount();
+    arena->GetForce2().SyncArmyCount();
 
     // after battle army1
     if ( commander1 ) {

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -218,6 +218,11 @@ std::string Battle::Unit::GetSpeedString() const
     return os.str();
 }
 
+uint32_t Battle::Unit::GetInitialCount() const
+{
+    return count0;
+}
+
 u32 Battle::Unit::GetDead( void ) const
 {
     return dead;

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -130,6 +130,7 @@ namespace Battle
         int GetControl() const override;
         u32 GetDamage( const Unit & ) const;
         s32 GetScoreQuality( const Unit & ) const;
+        uint32_t GetInitialCount() const;
         u32 GetDead( void ) const;
         u32 GetHitPoints( void ) const;
         u32 GetShots( void ) const;


### PR DESCRIPTION
fix #3786

Apparently the behavior described in #775 is wrong - if all creatures from the initial army were killed in a battle, then the hero should lose regardless of using Resurrect during the battle.