### PR TITLE
Revert some auxiliary changes introduced in #3576

### DIFF
--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -96,13 +96,13 @@ namespace
     }
 }
 
-struct ComparsionDistance
+struct ComparisonDistance
 {
-    explicit ComparsionDistance( const int32_t index )
+    explicit ComparisonDistance( const int32_t index )
         : centerPoint( Maps::GetPoint( index ) )
     {}
 
-    ComparsionDistance() = delete;
+    ComparisonDistance() = delete;
 
     bool operator()( const int32_t index1, const int32_t index2 ) const
     {
@@ -347,7 +347,7 @@ Maps::Indexes Maps::GetAroundIndexes( const int32_t tileIndex, const int32_t max
     }
 
     if ( sortTiles ) {
-        std::sort( results.begin(), results.end(), ComparsionDistance( tileIndex ) );
+        std::sort( results.begin(), results.end(), ComparisonDistance( tileIndex ) );
     }
 
     return results;
@@ -423,7 +423,7 @@ Maps::Indexes Maps::GetObjectPositions( int obj, bool ignoreHeroes )
 Maps::Indexes Maps::GetObjectPositions( int32_t center, int obj, bool ignoreHeroes )
 {
     Indexes results = MapsIndexesObject( obj, ignoreHeroes );
-    std::sort( results.begin(), results.end(), ComparsionDistance( center ) );
+    std::sort( results.begin(), results.end(), ComparisonDistance( center ) );
     return results;
 }
 

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -71,6 +71,29 @@ namespace
 
         return indicies;
     }
+
+    Maps::Indexes MapsIndexesFilteredObject( const Maps::Indexes & indexes, const int obj, const bool ignoreHeroes = true )
+    {
+        Maps::Indexes result;
+        for ( size_t idx = 0; idx < indexes.size(); ++idx ) {
+            if ( world.GetTiles( indexes[idx] ).GetObject( !ignoreHeroes ) == obj ) {
+                result.push_back( indexes[idx] );
+            }
+        }
+        return result;
+    }
+
+    Maps::Indexes MapsIndexesObject( const int obj, const bool ignoreHeroes = true )
+    {
+        Maps::Indexes result;
+        const int32_t size = static_cast<int32_t>( world.getSize() );
+        for ( int32_t idx = 0; idx < size; ++idx ) {
+            if ( world.GetTiles( idx ).GetObject( !ignoreHeroes ) == obj ) {
+                result.push_back( idx );
+            }
+        }
+        return result;
+    }
 }
 
 struct ComparsionDistance
@@ -96,29 +119,6 @@ struct ComparsionDistance
 
     const fheroes2::Point centerPoint;
 };
-
-Maps::Indexes Maps::MapsIndexesFilteredObject( const Maps::Indexes & indexes, const int obj, const bool ignoreHeroes /* = true */ )
-{
-    Maps::Indexes result;
-    for ( size_t idx = 0; idx < indexes.size(); ++idx ) {
-        if ( world.GetTiles( indexes[idx] ).GetObject( !ignoreHeroes ) == obj ) {
-            result.push_back( indexes[idx] );
-        }
-    }
-    return result;
-}
-
-Maps::Indexes Maps::MapsIndexesObject( const int obj, const bool ignoreHeroes /* = true */ )
-{
-    Maps::Indexes result;
-    const int32_t size = static_cast<int32_t>( world.getSize() );
-    for ( int32_t idx = 0; idx < size; ++idx ) {
-        if ( world.GetTiles( idx ).GetObject( !ignoreHeroes ) == obj ) {
-            result.push_back( idx );
-        }
-    }
-    return result;
-}
 
 const char * Maps::SizeString( int s )
 {

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -45,9 +45,6 @@ namespace Maps
 
     using Indexes = MapsIndexes;
 
-    Indexes MapsIndexesFilteredObject( const Indexes & indexes, const int obj, const bool ignoreHeroes = true );
-    Indexes MapsIndexesObject( const int obj, const bool ignoreHeroes = true );
-
     const char * SizeString( int size );
     const char * GetMinesName( int res );
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2030,9 +2030,7 @@ std::pair<uint32_t, uint32_t> Maps::Tiles::GetMonsterSpriteIndices( const Tiles 
     int attackerIndex = -1;
 
     // scan for a hero around
-    const MapsIndexes aroundIndexes = Maps::GetAroundIndexes( tileIndex );
-
-    for ( const int32_t idx : Maps::MapsIndexesFilteredObject( aroundIndexes, MP2::OBJ_HEROES, false ) ) {
+    for ( const int32_t idx : ScanAroundObject( tileIndex, MP2::OBJ_HEROES, false ) ) {
         const Heroes * hero = world.GetTiles( idx ).GetHeroes();
         assert( hero != nullptr );
 


### PR DESCRIPTION
Related to #3576: since after merging of #3494 there is a variant of `ScanAroundObject()` with `ignoreHeroes` parameter, use it in `Maps::Tiles::GetMonsterSpriteIndices()` instead of replicating its logic, move `Maps::GetAroundIndexes()` and `Maps::MapsIndexesFilteredObject()` back to the anonymous namespace.

Fix a typo in the `ComparsionDistance`, while I'm here.