### PR TITLE
Align text evenly inside secondary skill window

### DIFF
--- a/src/fheroes2/dialog/dialog_skillinfo.cpp
+++ b/src/fheroes2/dialog/dialog_skillinfo.cpp
@@ -30,6 +30,7 @@
 #include "skill.h"
 #include "text.h"
 #include "ui_button.h"
+#include "ui_text.h"
 
 void Dialog::SecondarySkillInfo( const Skill::Secondary & skill, const Heroes & hero, const bool ok_button )
 {
@@ -44,21 +45,22 @@ void Dialog::SecondarySkillInfo( const std::string & header, const std::string &
     // setup cursor
     const CursorRestorer cursorRestorer( ok_button, Cursor::POINTER );
 
-    TextBox box1( header, Font::YELLOW_BIG, BOXAREA_WIDTH );
-    TextBox box2( message, Font::BIG, BOXAREA_WIDTH );
+    fheroes2::Text caption( header, { fheroes2::FontSize::NORMAL, fheroes2::FontColor::YELLOW } );
+    fheroes2::Text messageBody( message, { fheroes2::FontSize::NORMAL, fheroes2::FontColor::WHITE } );
+
     const fheroes2::Sprite & border = fheroes2::AGG::GetICN( ICN::SECSKILL, 15 );
     const int spacer = 10;
 
-    FrameBox box( box1.h() + spacer + box2.h() + spacer + border.height(), ok_button );
+    FrameBox box( caption.height( BOXAREA_WIDTH ) + spacer + messageBody.height( BOXAREA_WIDTH ) + spacer + border.height(), ok_button );
     fheroes2::Rect pos = box.GetArea();
 
     if ( header.size() )
-        box1.Blit( pos.x, pos.y );
-    pos.y += box1.h() + spacer;
+        caption.draw( pos.x, pos.y, BOXAREA_WIDTH, display );
+    pos.y += caption.height( BOXAREA_WIDTH ) + spacer;
 
     if ( message.size() )
-        box2.Blit( pos.x, pos.y );
-    pos.y += box2.h() + spacer;
+        messageBody.draw( pos.x, pos.y, BOXAREA_WIDTH, display );
+    pos.y += messageBody.height( BOXAREA_WIDTH ) + spacer;
 
     // blit sprite
     pos.x = box.GetArea().x + ( pos.width - border.width() ) / 2;

--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -441,8 +441,8 @@ namespace fheroes2
         }
 
         offsets.clear();
-        render( reinterpret_cast<const uint8_t *>( _text.data() ), static_cast<int32_t>( _text.size() ), x + xOffset, y, correctedWidth, output, _fontType,
-                fontHeight, true, offsets );
+        render( reinterpret_cast<const uint8_t *>( _text.data() ), static_cast<int32_t>( _text.size() ), x + xOffset, y, correctedWidth, output, _fontType, fontHeight,
+                true, offsets );
     }
 
     bool Text::empty() const

--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -410,9 +410,39 @@ namespace fheroes2
             return;
         }
 
+        const int32_t fontHeight = getFontHeight( _fontType.size );
+
         std::deque<Point> offsets;
-        render( reinterpret_cast<const uint8_t *>( _text.data() ), static_cast<int32_t>( _text.size() ), x, y, maxWidth, output, _fontType,
-                getFontHeight( _fontType.size ), true, offsets );
+        getMultiRowInfo( reinterpret_cast<const uint8_t *>( _text.data() ), static_cast<int32_t>( _text.size() ), maxWidth, _fontType, fontHeight, offsets );
+
+        int32_t xOffset = 0;
+        int32_t correctedWidth = maxWidth;
+        if ( offsets.size() > 1 ) {
+            // This is a multi-line message. Optimize it to fit the text evenly.
+            // TODO: this optimization doesn't take into account explicit line endings - '\n'.
+            int32_t startWidth = 1;
+            int32_t endWidth = maxWidth;
+            while ( startWidth + 1 < endWidth ) {
+                const int32_t currentWidth = ( endWidth + startWidth ) / 2;
+                std::deque<Point> tempOffsets;
+                getMultiRowInfo( reinterpret_cast<const uint8_t *>( _text.data() ), static_cast<int32_t>( _text.size() ), currentWidth, _fontType, fontHeight,
+                                 tempOffsets );
+
+                if ( tempOffsets.size() > offsets.size() ) {
+                    startWidth = currentWidth;
+                    continue;
+                }
+
+                correctedWidth = currentWidth;
+                endWidth = currentWidth;
+            }
+
+            xOffset = ( maxWidth - correctedWidth ) / 2;
+        }
+
+        offsets.clear();
+        render( reinterpret_cast<const uint8_t *>( _text.data() ), static_cast<int32_t>( _text.size() ), x + xOffset, y, correctedWidth, output, _fontType,
+                fontHeight, true, offsets );
     }
 
     bool Text::empty() const
@@ -523,12 +553,40 @@ namespace fheroes2
                              offsets );
         }
 
+        int32_t xOffset = 0;
+        int32_t correctedWidth = maxWidth;
+        if ( offsets.size() > 1 ) {
+            // This is a multi-line message. Optimize it to fit the text evenly.
+            // TODO: this optimization doesn't take into account explicit line endings - '\n'.
+            int32_t startWidth = 1;
+            int32_t endWidth = maxWidth;
+            while ( startWidth + 1 < endWidth ) {
+                const int32_t currentWidth = ( endWidth + startWidth ) / 2;
+                std::deque<Point> tempOffsets;
+                for ( const Text & text : _texts ) {
+                    getMultiRowInfo( reinterpret_cast<const uint8_t *>( text._text.data() ), static_cast<int32_t>( text._text.size() ), currentWidth, text._fontType,
+                                     maxFontHeight, tempOffsets );
+                }
+
+                if ( tempOffsets.size() > offsets.size() ) {
+                    startWidth = currentWidth;
+                    continue;
+                }
+
+                correctedWidth = currentWidth;
+                endWidth = currentWidth;
+                std::swap( offsets, tempOffsets );
+            }
+
+            xOffset = ( maxWidth - correctedWidth ) / 2;
+        }
+
         for ( Point & point : offsets ) {
-            point.x = ( maxWidth - point.x ) / 2;
+            point.x = ( correctedWidth - point.x ) / 2;
         }
 
         for ( size_t i = 0; i < _texts.size(); ++i ) {
-            render( reinterpret_cast<const uint8_t *>( _texts[i]._text.data() ), static_cast<int32_t>( _texts[i]._text.size() ), x, y, maxWidth, output,
+            render( reinterpret_cast<const uint8_t *>( _texts[i]._text.data() ), static_cast<int32_t>( _texts[i]._text.size() ), x + xOffset, y, correctedWidth, output,
                     _texts[i]._fontType, maxFontHeight, false, offsets );
         }
     }

--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -419,7 +419,6 @@ namespace fheroes2
         int32_t correctedWidth = maxWidth;
         if ( offsets.size() > 1 ) {
             // This is a multi-line message. Optimize it to fit the text evenly.
-            // TODO: this optimization doesn't take into account explicit line endings - '\n'.
             int32_t startWidth = 1;
             int32_t endWidth = maxWidth;
             while ( startWidth + 1 < endWidth ) {
@@ -557,7 +556,6 @@ namespace fheroes2
         int32_t correctedWidth = maxWidth;
         if ( offsets.size() > 1 ) {
             // This is a multi-line message. Optimize it to fit the text evenly.
-            // TODO: this optimization doesn't take into account explicit line endings - '\n'.
             int32_t startWidth = 1;
             int32_t endWidth = maxWidth;
             while ( startWidth + 1 < endWidth ) {


### PR DESCRIPTION
close #3273

We should use this class for any new future texts.

This is how it looks now:
![image](https://user-images.githubusercontent.com/19829520/125307942-15af2780-e363-11eb-9e64-a0c9f8174d13.png)