### PR TITLE
Update ru/fr translations and the Makefile

### DIFF
--- a/files/lang/Makefile
+++ b/files/lang/Makefile
@@ -3,16 +3,31 @@
 #
 
 # TODO: remove the iconv/konwert line once unicode support is there
-# `-iconv -c -f utf-8 -t ascii $< > $<.tmp` simply removes all non-ASCII characters
-# Most non-ASCII characters can be converted to ASCII with `iconv -f utf-8 -t ascii//TRANSLIT -o $<.tmp $<`
-# Russian alphabet can be transliterated on Debian with `konwert UTF8-ascii/1 -o $<.tmp $<`
 
 all: $(patsubst %.po, %.mo, $(wildcard *.po))
 
+# In French, accented characters are mapped to unused ASCII characters
+# Non-mapped characters are replaced by their non-accented equivalents
+fr.mo: fr.po
+	msgmerge -U --no-location $< fheroes2.pot
+	sed -e 'y/àâçéèêîïôùûüÉÊÀ/@*^~ee><#&$$uEEA/' $< > $<.tmp
+	msgfmt $<.tmp -o $@
+
+# Russian versions from "Buka" and "XXI vek" use CP1251 encoding (supported)
+# Russian version from "Fargus" uses Russian keyboard layout as encoding (not supported)
+ru.mo: ru.po
+	msgmerge -U --no-location $< fheroes2.pot
+	iconv -f utf-8 -t CP1251 $< > $<.tmp
+	sed -i 's/UTF-8/CP1251/' $<.tmp
+	msgfmt $<.tmp -o $@
+
+# All other languages: drop accents transliterated with `"` (which breaks translation file format)
+# and transliterate the rest with default iconv rules
 %.mo: %.po
 	msgmerge -U --no-location $< fheroes2.pot
-	-iconv -c -f utf-8 -t ascii $< > $<.tmp
-	msgfmt $<.tmp -o $@
+	sed -e 'y/äëïöőüűÄËÏŐÖÜŰ/aeioouuAEIOOUU/' $< > $<.tmp
+	iconv -f utf-8 -t ascii//TRANSLIT $<.tmp > $<.2.tmp
+	msgfmt $<.2.tmp -o $@
 
 clean:
 	rm -f *.mo *.tmp

--- a/files/lang/fr.po
+++ b/files/lang/fr.po
@@ -1,15 +1,15 @@
 # French translation for fheroes2
 # Copyright (c) 2009 Rosetta Contributors and Canonical Ltd 2009
 # This file is distributed under the same license as the fheroes2 package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2009.
+# dimag0g <dmitry.grigoryev@outlook.com>, 2021.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-07-01 15:11+0200\n"
-"PO-Revision-Date: 2009-11-29 01:03+0000\n"
-"Last-Translator: Sorkin <Unknown>\n"
+"PO-Revision-Date: 2021-07-12 20:50+0200\n"
+"Last-Translator: dimag0g <dmitry.grigoryev@outlook.com>\n"
 "Language-Team: French <fr@li.org>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -17,41 +17,41 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Launchpad-Export-Date: 2010-05-27 09:12+0000\n"
-"X-Generator: Launchpad (build Unknown)\n"
+"X-Generator: Poedit 3.0\n"
 
 msgid ""
 "A few\n"
 "%{monster}"
 msgstr ""
-"Peu\n"
+"Peu de\n"
 "%{monster}"
 
 msgid ""
 "Several\n"
 "%{monster}"
 msgstr ""
-"Beaucoup\n"
+"Quelques\n"
 "%{monster}"
 
 msgid ""
 "A pack of\n"
 "%{monster}"
 msgstr ""
-"un bon paquet\n"
+"Un groupe de\n"
 "%{monster}"
 
 msgid ""
 "Lots of\n"
 "%{monster}"
 msgstr ""
-"Beaucoup de\n"
+"Une troupe de\n"
 "%{monster}"
 
 msgid ""
 "A horde of\n"
 "%{monster}"
 msgstr ""
-"une horde de \n"
+"Une horde de \n"
 "%{monster}"
 
 msgid ""
@@ -65,14 +65,14 @@ msgid ""
 "A swarm of\n"
 "%{monster}"
 msgstr ""
-"un essaim de \n"
+"Un essaim de \n"
 "%{monster}"
 
 msgid ""
 "Zounds of\n"
 "%{monster}"
 msgstr ""
-"Pléthore de \n"
+"Pléoptre de \n"
 "%{monster}"
 
 msgid ""
@@ -83,31 +83,31 @@ msgstr ""
 "%{monster}"
 
 msgid "army|Few"
-msgstr ""
+msgstr "Peu"
 
 msgid "army|Several"
-msgstr ""
+msgstr "Quelques"
 
 msgid "army|Pack"
-msgstr ""
+msgstr "Paquet"
 
 msgid "army|Lots"
-msgstr ""
+msgstr "Troupe"
 
 msgid "army|Horde"
-msgstr ""
+msgstr "Horde"
 
 msgid "army|Throng"
-msgstr ""
+msgstr "Foule"
 
 msgid "army|Swarm"
-msgstr ""
+msgstr "Essaim"
 
 msgid "army|Zounds"
-msgstr ""
+msgstr "Pléoptre"
 
 msgid "army|Legion"
-msgstr ""
+msgstr "Légion"
 
 msgid "All %{race} troops +1"
 msgstr "+1 pour toutes les troupes %{race}"
@@ -125,10 +125,10 @@ msgid "Some undead in groups -1"
 msgstr "Morts vivants dans les groupes -1"
 
 msgid "View %{name}"
-msgstr "voir %{name}"
+msgstr "Voir %{name}"
 
 msgid "Move or right click to redistribute %{name}"
-msgstr ""
+msgstr "Déplacez ou faites un clic droit pour redistribuer %{name}"
 
 msgid "Combine %{name} armies"
 msgstr "Fusionner les armées de %{name}"
@@ -139,74 +139,78 @@ msgstr "Echanger %{name2} avec %{name}"
 msgid "Select %{name}"
 msgstr "Selectionner %{name}"
 
-#, fuzzy
 msgid "Cannot move last troop"
 msgstr "Impossible de déplacer la dernière armée dans la garnison"
 
 msgid "%{name} half the enemy troops!"
-msgstr ""
+msgstr "%{name} décime la troupe ennemi!"
 
 msgid "Set auto battle off"
-msgstr ""
+msgstr "Désactiver combat auto"
 
 msgid "Set auto battle on"
-msgstr ""
+msgstr "Activer combat auto"
 
 msgid "spell failed!"
-msgstr ""
+msgstr "sort échoué!"
 
 msgid ""
 "The Sphere of Negation artifact is in effect for this battle, disabling all "
 "combat spells."
 msgstr ""
+"L’artefact Sphère de négation est en vigueur pour cette bataille, "
+"désactivant tous les sorts de combat."
 
 msgid "You have already cast a spell this round."
-msgstr ""
+msgstr "Vous avez déjà jeté un sort ce tour."
 
 msgid "That spell will affect no one!"
 msgstr "Ce sort n'affectera personne!"
 
 msgid "You may only summon one type of elemental per combat."
-msgstr ""
+msgstr "Vous ne pouvez invoquer qu'un seul type d'élémentaire par combat."
 
 msgid "There is no open space adjacent to your hero to summon an Elemental to."
 msgstr ""
+"Il n'y a pas d'espace ouvert adjacent à votre héros pour y invoquer un "
+"élémentaire."
 
 msgid ""
 "The Moat reduces by -%{count} the defense skill of any unit and slows to "
 "half movement rate."
 msgstr ""
+"Le Fosse réduit de -%{count} la compétence de défense de n’importe quelle "
+"unité et ralentit à la moitié du taux de mouvement."
 
 msgid "Speed"
 msgstr "Vitesse"
 
 msgid "Speed: %{speed}"
-msgstr ""
+msgstr "Vitesse : %{speed}"
 
 msgid "Auto Spell Casting"
-msgstr ""
+msgstr "Lancement de sorts auto"
 
 msgid "Grid"
-msgstr ""
+msgstr "Grille"
 
 msgid "Shadow Movement"
-msgstr ""
+msgstr "Ombre de mouvement"
 
 msgid "Shadow Cursor"
-msgstr ""
+msgstr "Curseur d’ombre"
 
 msgid "On"
-msgstr ""
+msgstr "Activé"
 
-#, fuzzy
 msgid "Off"
-msgstr "coupé"
+msgstr "Eteint"
 
 msgid "The enemy has surrendered!"
-msgstr ""
+msgstr "L'ennemi s'est rendu à vous!"
 
 msgid "The enemy has fled!"
-msgstr ""
+msgstr "L'ennemi a pris la fuite!"
 
 msgid "A glorious victory!"
 msgstr "Une victoire pleine de gloire!"
@@ -217,16 +221,16 @@ msgstr ""
 "d'experience."
 
 msgid "The cowardly %{name} flees from battle."
-msgstr ""
+msgstr "Le lâche %{name} fuit la bataille."
 
 msgid "%{name} surrenders to the enemy, and departs in shame."
 msgstr "%{name} se rend à l'ennemi et part couvert de honte."
 
 msgid "Your force suffer a bitter defeat, and %{name} abandons your cause."
-msgstr ""
+msgstr "Votre force subit une défaite amère, et %{name} abandonne votre cause."
 
 msgid "Your force suffer a bitter defeat."
-msgstr ""
+msgstr "Votre force subit une défaite amère."
 
 msgid "Battlefield Casualties"
 msgstr "Blessures reçues au champ de bataille"
@@ -241,12 +245,15 @@ msgid "You have captured an enemy artifact!"
 msgstr "Vous avez capturé un artéfact ennemi!"
 
 msgid "Necromancy!"
-msgstr ""
+msgstr "Nécromancie!"
 
 msgid ""
 "Practicing the dark arts of necromancy, you are able to raise %{count} of "
 "the enemy's dead to return under your service as %{monster}."
 msgstr ""
+"Pratiquant les arts sombres de la nécromancie, vous êtes capable de soulever "
+"%{count} des morts de l’ennemi pour revenir sous votre service en tant que "
+"%{monster}."
 
 msgid "%{name} the %{race}"
 msgstr "%{name} le %{race}"
@@ -258,25 +265,25 @@ msgid "Defense"
 msgstr "Défense"
 
 msgid "Spell Power"
-msgstr "Pouvoir d'invocation"
+msgstr "Pouvoir"
 
 msgid "Knowledge"
 msgstr "Connaissance"
 
 msgid "Morale"
-msgstr "Morale"
+msgstr "Moral"
 
 msgid "Luck"
 msgstr "Chance"
 
 msgid "Spell Points"
-msgstr "Points de sortilège"
+msgstr "Pts. de magie"
 
 msgid "Hero's Options"
-msgstr "Options du héro"
+msgstr "Options du héros"
 
 msgid "Cast Spell"
-msgstr "Lancer un sortilège"
+msgstr "Lancer un sort"
 
 msgid "Retreat"
 msgstr "Sonner la retraite"
@@ -288,99 +295,96 @@ msgid "Cancel"
 msgstr "Annuler"
 
 msgid "Hero Screen"
-msgstr ""
+msgstr "Écran Héros"
 
-#, fuzzy
 msgid ""
 "Cast a magical spell. You may only cast one spell per combat round. The "
 "round is reset when every creature has had a turn."
 msgstr ""
 "Lance un sortilège. Vous pouvez seulement en lancer un par tour pendant le "
-"combat. Le tour se termine lorsque chauqe créature a effectuée une action"
+"combat. Le tour se termine lorsque chaque créature a effectuée une action."
 
 msgid ""
 "Retreat your hero, abandoning your creatures. Your hero will be available "
 "for you to recruit again, however, the hero will have only a novice hero's "
 "forces."
 msgstr ""
-"Retirer votre héro de la bataille, en abandonnant vos créatures. Votre héro "
+"Retirer votre héros de la bataille, en abandonnant vos créatures. Votre héro "
 "sera ensuite capable de recruter de nouveau, mais ne disposera que des "
-"forces d'un héro novice."
+"forces d'un héros novice."
 
 msgid ""
 "Surrendering costs gold. However if you pay the ransom, the hero and all of "
 "his or her surviving creatures will be available to recruit again."
 msgstr ""
 "Se constituer prisonnier coûte de l'or. Toutefois, si vous payez la rançon, "
-"le héro et toutes les créatures survivantes pourront recruter de nouveau."
+"le héros et toutes les créatures survivantes pourront recruter de nouveau."
 
 msgid "Open Hero Screen to view full information about the hero."
 msgstr ""
+"Ouvrir l’écran héros pour afficher toutes les informations sur le héros."
 
 msgid "Return to the battle."
 msgstr "Retourner a la bataille."
 
 msgid "Not enough gold (%{gold})"
-msgstr ""
+msgstr "Pas assez d'or (%{gold})"
 
 msgid "%{name} states:"
-msgstr ""
+msgstr "%{name} déclare:"
 
 msgid ""
 "\"I will accept your surrender and grant you and your troops safe passage "
 "for the price of %{price} gold.\""
 msgstr ""
+"\" J’accepterai votre reddition et vous accorderai, à vous et à vos troupes, "
+"un passage sûr pour le prix de %{price} pièces 'or. \""
 
 msgid "View %{monster} info."
-msgstr ""
+msgstr "Voir les infos de %{monster}."
 
-#, fuzzy
 msgid "Shoot %{monster}"
-msgstr ""
-"Beaucoup de\n"
-"%{monster}"
+msgstr "Tirer sur %{monster}"
 
 msgid "Attack %{monster}"
-msgstr ""
+msgstr "Attaquer %{monster}"
 
 msgid "Fly %{monster} here."
-msgstr ""
+msgstr "%{monster} vole ici."
 
 msgid "Move %{monster} here."
-msgstr ""
+msgstr "Déplacer %{monster} ici."
 
 msgid "Turn %{turn}"
-msgstr ""
+msgstr "Tour %{turn}"
 
 msgid "Teleport Here"
-msgstr ""
+msgstr "Téléporter ici"
 
 msgid "Invalid Teleport Destination"
-msgstr ""
+msgstr "Destination de téléportation non valide"
 
 msgid "Cast %{spell} on %{monster}"
-msgstr ""
+msgstr "Lancer %{spell} sur %{monster}"
 
 msgid "Cast %{spell}"
-msgstr ""
+msgstr "Lancer %{spell}"
 
 msgid "Select Spell Target"
-msgstr ""
+msgstr "Sélectionner la cible du sort"
 
-#, fuzzy
 msgid "View Ballista Info"
-msgstr "voir les infos de %{name} info."
+msgstr "Voir les infos de baliste"
 
 msgid "Ballista"
-msgstr ""
+msgstr "Baliste"
 
 msgid "Auto combat"
-msgstr ""
+msgstr "Combat auto"
 
 msgid "Customize system options."
-msgstr ""
+msgstr "Modifier les options système."
 
-#, fuzzy
 msgid "Wait this unit"
 msgstr "Passer cette unité"
 
@@ -388,139 +392,128 @@ msgid "Skip this unit"
 msgstr "Passer cette unité"
 
 msgid "View Opposing Hero"
-msgstr "Voir le héro adverse"
+msgstr "Voir le héros adverse"
 
 msgid "Hide logs"
-msgstr ""
+msgstr "Cacher le journal"
 
 msgid "Show logs"
-msgstr ""
+msgstr "Afficher le journal"
 
 msgid "%{color} cast spell: %{spell}"
-msgstr ""
+msgstr "%{color} lance un sort : %{spell}"
 
 msgid "%{name} skipping turn"
-msgstr ""
+msgstr "%{name} passe le tour"
 
 msgid "%{name} waiting turn"
-msgstr ""
+msgstr "%{name} attend"
 
 msgid "%{attacker} do %{damage} damage."
-msgstr ""
+msgstr "%{attacker} effectue %{damage} de dommages."
 
 msgid "Moved %{monster}: %{src}, %{dst}"
-msgstr ""
+msgstr "Déplace %{monster} : %{src}, %{dst}"
 
-#, fuzzy
 msgid "Moved %{monster}"
-msgstr ""
-"Beaucoup de\n"
-"%{monster}"
+msgstr "Déplacé %{monster}"
 
 msgid "The %{name} resist the spell!"
-msgstr ""
+msgstr "%{name} résiste au sort!"
 
 msgid "%{name} casts %{spell} on the %{troop}."
-msgstr ""
+msgstr "%{name} lance %{spell} sur les %{troop}."
 
 msgid "%{name} casts %{spell}."
-msgstr ""
+msgstr "%{name} lance %{spell}."
 
-#, fuzzy
 msgid "The %{spell} does %{damage} damage to one undead creature."
-msgstr "%{spell} fait %{value} dommage(s) à %{name}."
+msgstr "%{spell} fait %{value} dommage(s) à un mort-vivant."
 
-#, fuzzy
 msgid "The %{spell} does %{damage} damage to all undead creatures."
-msgstr "%{spell} fait %{value} dommage(s) à %{name}."
+msgstr "%{spell} fait %{value} dommage(s) à tous les morts-vivants."
 
-#, fuzzy
 msgid "The %{spell} does %{damage} damage, %{count} creatures perish."
-msgstr "%{spell} fait %{value} dommage(s) à %{name}."
+msgstr "%{spell} fait %{value} dommage(s), %{count} créatures meurent."
 
 msgid "The %{spell} does %{damage} damage."
-msgstr ""
+msgstr "%{spell} fait %{damage} dommage(s)."
 
-#, fuzzy
 msgid "The %{spell} does %{damage} damage to one living creature."
-msgstr "%{spell} fait %{value} dommage(s) à %{name}."
+msgstr "%{spell} fait %{value} dommage(s) à une créature vivante."
 
-#, fuzzy
 msgid "The %{spell} does %{damage} damage to all living creatures."
-msgstr "%{spell} fait %{value} dommage(s) à %{name}."
+msgstr "%{spell} fait %{value} dommage(s) à toutes les créatures vivantes."
 
 msgid "The Unicorns attack blinds the %{name}!"
-msgstr ""
+msgstr "L'attaque des licornes aveugle les %{name} !"
 
 msgid "The Medusas gaze turns the %{name} to stone!"
-msgstr ""
+msgstr "Le regard de Meduses transforme les %{name} en pierre !"
 
 msgid "The Mummies' curse falls upon the %{name}!"
-msgstr ""
+msgstr "La malédiction des momies s'abat sur les %{nom} !"
 
 msgid "The %{name} are paralyzed by the Cyclopes!"
-msgstr ""
+msgstr "%{name} sont paralysés par les Cyclops!"
 
 msgid "The Archmagi dispel all good spells on your %{name}!"
-msgstr ""
+msgstr "Les Archmagi dissipent tous les bons sorts sur vos %{nom} !"
 
 msgid "Good luck shines on the %{attacker}"
-msgstr ""
+msgstr "La chance sourit aux %{attacker}"
 
 msgid "Bad luck descends on the %{attacker}"
-msgstr ""
+msgstr "La malchance s'abat sur les %{attacker}."
 
 msgid "High morale enables the %{monster} to attack again."
-msgstr ""
+msgstr "Un moral élevé permet aux %{monster} d’attaquer à nouveau."
 
 msgid "Low morale causes the %{monster} to freeze in panic."
-msgstr ""
+msgstr "Un moral bas fait que les %{monster} gèlent en panique."
 
-#, fuzzy
 msgid "%{tower} does %{damage} damage."
-msgstr "%{tower} a causé %{dmg} dommage(s)."
+msgstr "%{tower} fait %{damage} dommage(s)."
 
 msgid "MirrorImage created"
-msgstr ""
+msgstr "L'image miroir créée"
 
 msgid "The mirror image is destroyed!"
-msgstr ""
+msgstr "L'image miroir est détruite !"
 
 msgid "Break auto battle?"
-msgstr ""
+msgstr "Arrêter le combat auto?"
 
 msgid "No spells to cast."
-msgstr ""
+msgstr "Aucun sort disponible."
 
 msgid "Are you sure you want to retreat?"
 msgstr "Êtes vous sur de vouloir sonner la retraite?"
 
-#, fuzzy
 msgid "Retreat disabled"
-msgstr "Sonner la retraite"
+msgstr "Retraite impossible"
 
-#, fuzzy
 msgid "Surrender disabled"
-msgstr "Prisonnier"
+msgstr "Reddition impossible"
 
-#, fuzzy
 msgid "Damage: %{max}"
-msgstr "Dommage"
+msgstr "Dommages: %{max}"
 
 msgid "Damage: %{min} - %{max}"
-msgstr ""
+msgstr "Dommages: %{min} - %{max}"
 
-#, fuzzy
 msgid "Perish: %{max}"
-msgstr "Dommage"
+msgstr "Perte : %{max}"
 
 msgid "Perish: %{min} - %{max}"
-msgstr ""
+msgstr "Perte : %{min} - %{max}"
 
 msgid ""
 "Through eagle-eyed observation, %{name} is able to learn the magic spell "
 "%{spell}."
 msgstr ""
+"Grâce à l’observation aux yeux d’aigle, %{name} est capable d’apprendre le "
+"sort magique %{spell}."
 
 msgid "Left Turret"
 msgstr "Tourelle gauche"
@@ -529,166 +522,164 @@ msgid "Right Turret"
 msgstr "Tourelle droite"
 
 msgid "The %{name} fires with the strength of %{count} Archers"
-msgstr ""
+msgstr "Le %{name} tire avec la force de %{count} Archers"
 
 msgid "each with a +%{attack} bonus to their attack skill."
-msgstr ""
+msgstr "chacun avec un bonus de +%{attack} à sa compétence d'attaque."
 
 msgid ""
 "The %{artifact} artifact is in effect for this battle, disabling %{spell} "
 "spell."
 msgstr ""
+"L'artefact %{artifact} est en vigueur pour ce combat, désactivant le sort "
+"%{spell}."
 
 msgid "%{count} %{name} rise(s) from the dead!"
-msgstr ""
+msgstr "%{count} %{name} reviennent en vie !"
 
-#, fuzzy
 msgid "Sorceress Guild"
-msgstr "Guilde des voleurs"
+msgstr "Guilde de Sorcières"
 
 msgid "Necromancer Guild"
-msgstr ""
+msgstr "Guilde de Nécromanciens"
 
 msgid "Dragon Alliance"
-msgstr ""
+msgstr "Alliance des Dragons"
 
 msgid "Elven Alliance"
-msgstr ""
+msgstr "Alliance des Elfes"
 
 msgid "Wayward Son"
-msgstr ""
+msgstr "Fils Dévoyé"
 
 msgid "Uncle Ivan"
-msgstr ""
+msgstr "Oncle Ivan"
 
 msgid "Force of Arms"
-msgstr ""
+msgstr "Force des armes"
 
-#, fuzzy
 msgid "Annexation"
-msgstr "animation"
+msgstr "Annexation"
 
 msgid "Save the Dwarves"
-msgstr ""
+msgstr "Sauve les Nains"
 
 msgid "Carator Mines"
-msgstr ""
+msgstr "Mines de Carator"
 
-#, fuzzy
 msgid "Turning Point"
-msgstr "Points de vie"
+msgstr "Moment Décisif"
 
 msgid "The Gauntlet"
-msgstr ""
+msgstr "Le gantelet"
 
 msgid "The Crown"
-msgstr ""
+msgstr "La Couronne"
 
 msgid "Corlagon's Defense"
-msgstr ""
+msgstr "Défense de Corlagon"
 
 msgid "Final Justice"
-msgstr ""
+msgstr "Justice définitive"
 
 msgid "First Blood"
-msgstr ""
+msgstr "Premier sang"
 
 msgid "Barbarian Wars"
-msgstr ""
+msgstr "Guerres Barbares"
 
 msgid "Necromancers"
-msgstr ""
+msgstr "Nécromanciens"
 
 msgid "Slay the Dwarves"
-msgstr ""
+msgstr "Massacre des Nains"
 
 msgid "Rebellion"
-msgstr ""
+msgstr "Rebellion"
 
 msgid "Dragon Master"
-msgstr ""
+msgstr "Maître des Dragons"
 
 msgid "Country Lords"
-msgstr ""
+msgstr "Seigneurs du Pays"
 
 msgid "Greater Glory"
-msgstr ""
+msgstr "Grande Gloire"
 
 msgid "Apocalypse"
-msgstr ""
+msgstr "Apocalypse"
 
 msgid "Uprising"
-msgstr ""
+msgstr "Révolte"
 
 msgid "Island of Chaos"
-msgstr ""
+msgstr "L'île du chaos"
 
 msgid "Arrow's Flight"
-msgstr ""
+msgstr "Vol de la flèche"
 
 msgid "The Abyss"
-msgstr ""
+msgstr "L'abîme"
 
 msgid "The Giant's Pass"
-msgstr ""
+msgstr "Col des Géants"
 
 msgid "Aurora Borealis"
-msgstr ""
+msgstr "Aurore boréale"
 
 msgid "Betrayal's End"
-msgstr ""
+msgstr "Fin de la trahison"
 
-#, fuzzy
 msgid "Corruption's Heart"
-msgstr "Quartiers du capitaine"
+msgstr "Coeur de la corruption"
 
 msgid "Conquer and Unify"
-msgstr ""
+msgstr "Conquérir et unifier"
 
 msgid "Border Towns"
-msgstr ""
+msgstr "Villes Lointaines"
 
 msgid "The Wayward Son"
-msgstr ""
+msgstr "Le Fils Dévoyé"
 
 msgid "Crazy Uncle Ivan"
-msgstr ""
+msgstr "Oncle Fou Ivan"
 
 msgid "The Southern War"
-msgstr ""
+msgstr "La guerre du Sud"
 
 msgid "Ivory Gates"
-msgstr ""
+msgstr "Porte d'Ivoire"
 
 msgid "The Elven Lands"
-msgstr ""
+msgstr "Les Terres Elfiques"
 
 msgid "The Epic Battle"
-msgstr ""
+msgstr "Combat Épique"
 
 msgid "The Shrouded Isles"
-msgstr ""
+msgstr "Les îles du Linceul"
 
 msgid "The Eternal Scrolls"
-msgstr ""
+msgstr "Parchemins Éternels"
 
 msgid "Power's End"
-msgstr ""
+msgstr "Fin du Pouvoir"
 
 msgid "Fount of Wizardry"
-msgstr ""
+msgstr "Source de la Magie"
 
 msgid "Stranded"
-msgstr ""
+msgstr "Échoué"
 
 msgid "Pirate Isles"
-msgstr ""
+msgstr "Iles Pirates"
 
 msgid "King and Country"
-msgstr ""
+msgstr "Roi et Pays"
 
 msgid "Blood is Thicker"
-msgstr ""
+msgstr "Sang Épais"
 
 msgid ""
 "Roland needs you to defeat the lords near his castle to begin his war of "
@@ -696,29 +687,47 @@ msgid ""
 "will spend most of their time fighting with one another.  Victory is yours "
 "when you have defeated all of their castles and heroes."
 msgstr ""
+"Roland a besoin de vous pour vaincre les seigneurs près de son château afin "
+"de commencer sa guerre de rébellion contre son frère.  Ils ne sont pas "
+"alliés entre eux, ils passeront donc la plupart de leur temps à se battre "
+"les uns contre les autres.  La victoire vous reviendra lorsque vous aurez "
+"vaincu tous leurs châteaux et leurs héros."
 
 msgid ""
 "The local lords refuse to swear allegiance to Roland, and must be subdued. "
 "They are wealthy and powerful, so be prepared for a tough fight. Capture all "
 "enemy castles to win."
 msgstr ""
+"Les seigneurs locaux refusent de prêter allégeance à Roland et doivent être "
+"soumis. Ils sont riches et puissants, alors préparez-vous à un combat "
+"difficile. Capturez tous les châteaux ennemis pour gagner."
 
 msgid ""
 "Your task is to defend the Dwarves against Archibald's forces. Capture all "
 "of the enemy towns and castles to win, and be sure not to lose all of the "
 "dwarf towns at once, or the enemy will have won."
 msgstr ""
+"Votre tâche est de défendre les Nains contre les forces d'Archibald. "
+"Capturez tous les villages et tous les châteaux ennemis pour gagner, et "
+"veillez à ne pas perdre toutes les villes naines d'un coup, ou l'ennemi aura "
+"gagné."
 
 msgid ""
 "You will face four allied enemies in a straightforward fight for resource "
 "and treasure. Capture all of the enemy castles for victory."
 msgstr ""
+"Vous affronterez quatre ennemis alliés dans une lutte directe pour les "
+"ressources et les trésors. Capturez tous les châteaux ennemis pour remporter "
+"la victoire."
 
 msgid ""
 "Your enemies are allied against you and start close by, so be ready to come "
 "out fighting. You will need to own all four castles in this small valley to "
 "win."
 msgstr ""
+"Vos ennemis sont alliés contre vous et commencent tout près, alors soyez "
+"prêt à vous battre. Vous devrez posséder les quatre châteaux de cette petite "
+"vallée pour gagner."
 
 msgid ""
 "The Sorceress' guild of Noraston has requested Roland's aid against an "
@@ -726,6 +735,10 @@ msgid ""
 "don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy "
 "castle on an island in the ocean.)"
 msgstr ""
+"La guilde des sorcières de Noraston a demandé l'aide de Roland contre une "
+"attaque des alliés d'Archibald. Capturez tous les châteaux ennemis pour "
+"gagner, et ne perdez pas Noraston, ou vous perdrez le scénario. (Indice : il "
+"y a un château ennemi sur une île dans l'océan)."
 
 msgid ""
 "Gather as large an army as possible and capture the enemy castle within 8 "
@@ -733,11 +746,18 @@ msgid ""
 "to the enemy castle. Any troops you have in your army at the end of this "
 "scenario will be with you in the final battle."
 msgstr ""
+"Rassemblez une armée aussi nombreuse que possible et capturez le château "
+"ennemi en 8 semaines. Vous n'êtes confronté qu'à un seul ennemi, mais vous "
+"devez parcourir un long chemin pour atteindre le château ennemi. Toutes les "
+"troupes que vous avez dans votre armée à la fin de ce scénario seront avec "
+"vous lors de la bataille finale."
 
 msgid ""
 "Find the Crown before Archibald's heroes find it. Roland will need the Crown "
 "for the final battle against Archibald."
 msgstr ""
+"Trouvez la couronne avant que les héros d'Archibald ne la trouvent. Roland "
+"aura besoin de la couronne pour la bataille finale contre Archibald."
 
 msgid ""
 "Three allied enemies stand before you and victory, including Lord Corlagon. "
@@ -745,11 +765,18 @@ msgid ""
 "enemy. Remember that capturing Lord Corlagon will ensure that he will not "
 "fight against you in the final scenario."
 msgstr ""
+"Trois ennemis alliés se dressent devant vous et la victoire, y compris Lord "
+"Corlagon. Roland se trouve dans un château au nord-ouest, et vous perdrez "
+"s'il tombe aux mains de l'ennemi. N'oubliez pas que si vous capturez Lord "
+"Corlagon, il ne se battra pas contre vous dans le scénario final."
 
 msgid ""
 "This is the final battle. Both you and your enemy are armed to the teeth, "
 "and all are allied against you. Capture Archibald to end the war!"
 msgstr ""
+"C'est la bataille finale. Vous et votre ennemi êtes armés jusqu'aux dents, "
+"et tous sont alliés contre vous. Capturez Archibald pour mettre fin à la "
+"guerre !"
 
 msgid ""
 "King Archibald requires you to defeat the three enemies in this region.  "
@@ -757,6 +784,11 @@ msgid ""
 "energy fighting amongst themselves.  You will win when you own all of the "
 "enemy castles and there are no more heroes left to fight."
 msgstr ""
+"Le roi Archibald vous demande de vaincre les trois ennemis de cette région.  "
+"Ils ne sont pas alliés les uns aux autres, ils dépenseront donc la majeure "
+"partie de leur énergie à se battre entre eux.  Vous gagnerez lorsque vous "
+"posséderez tous les châteaux ennemis et qu'il ne restera plus de héros à "
+"combattre."
 
 msgid ""
 "You must unify the barbarian tribes of the north by conquering them. As in "
@@ -764,6 +796,10 @@ msgid ""
 "more resources at their disposal. You will win when you own all of the enemy "
 "castles and there are no more heroes left to fight."
 msgstr ""
+"Vous devez unifier les tribus barbares du nord en les conquérant. Comme dans "
+"la mission précédente, l'ennemi n'est pas allié contre vous, mais il a plus "
+"de ressources à sa disposition. Vous gagnerez lorsque vous posséderez tous "
+"les châteaux ennemis et qu'il n'y aura plus de héros à combattre."
 
 msgid ""
 "Do-gooder wizards have taken the Necromancers' castle. You must retake it to "
@@ -771,6 +807,11 @@ msgid ""
 "have no castle and must take one within 7 days, or lose this battle. (Hint: "
 "The nearest castle is to the southeast.)"
 msgstr ""
+"Des sorciers bienfaisants ont pris le château des Nécromanciens. Vous devez "
+"le reprendre pour remporter la victoire. Rappelez-vous que si vous commencez "
+"avec une puissante armée, vous n'avez pas de château et devez en prendre un "
+"dans les 7 jours, ou perdre cette bataille. (Indice : le château le plus "
+"proche est au sud-est)."
 
 msgid ""
 "The dwarves need conquering before they can interfere in King Archibald's "
@@ -778,18 +819,29 @@ msgid ""
 "so be ready for attack from multiple directions. You must capture all of the "
 "enemy towns and castles to claim victory."
 msgstr ""
+"Les nains doivent être conquis avant de pouvoir interférer dans les plans du "
+"roi Archibald. Les forces de Roland ont plus d'un héros et de nombreuses "
+"villes au départ, alors soyez prêt à être attaqué de plusieurs directions. "
+"Vous devez capturer toutes les villes et tous les châteaux ennemis pour "
+"remporter la victoire."
 
 msgid ""
 "You must put down a peasant revolt led by Roland's forces. All are allied "
 "against you, but you have Lord Corlagon, an experienced hero, to help you. "
 "Capture all enemy castles to win."
 msgstr ""
+"Vous devez réprimer une révolte paysanne menée par les forces de Roland. "
+"Tous sont alliés contre vous, mais vous avez Lord Corlagon, un héros "
+"expérimenté, pour vous aider. Capturez tous les châteaux ennemis pour gagner."
 
 msgid ""
 "There are two enemies allied against you in this mission. Both are well "
 "armed and seek to evict you from their island. Avoid them and capture Dragon "
 "City to win"
 msgstr ""
+"Il y a deux ennemis alliés contre vous dans cette mission. Tous deux sont "
+"bien armés et cherchent à vous expulser de leur île. Évitez-les et capturez "
+"Dragon City pour gagner"
 
 msgid ""
 "Your orders are to conquer the country lords that have sworn to serve "
@@ -797,32 +849,48 @@ msgid ""
 "without a castle, you must hurry to capture one before the end of the week. "
 "Capture all enemy castles for victory."
 msgstr ""
+"Vos ordres sont de conquérir les seigneurs du pays qui ont juré de servir "
+"Roland. Tous les châteaux ennemis sont unis contre vous. Comme vous "
+"commencez sans château, vous devez vous dépêcher d'en capturer un avant la "
+"fin de la semaine. Capturez tous les châteaux ennemis pour remporter la "
+"victoire."
 
 msgid ""
 "Find the Crown before Roland's heroes find it. Archibald will need the Crown "
 "for the final battle against Roland."
 msgstr ""
+"Trouvez la couronne avant que les héros de Roland ne la trouvent. Archibald "
+"aura besoin de la couronne pour la bataille finale contre Roland."
 
 msgid ""
 "This is the final battle. Both you and your enemy are armed to the teeth, "
 "and all are allied against you. Capture Roland to win the war, and be sure "
 "not to lose Archibald in the fight!"
 msgstr ""
+"C'est la bataille finale. Vous et votre ennemi êtes tous deux armés "
+"jusqu'aux dents, et tous sont alliés contre vous. Capturez Roland pour "
+"gagner la guerre, et assurez-vous de ne pas perdre Archibald dans le combat !"
 
 msgid ""
 "Subdue the unruly local lords in order to provide the Empire with facilities "
 "to operate in this region."
 msgstr ""
+"Soumettez les seigneurs locaux indisciplinés afin de fournir à l'Empire des "
+"installations pour opérer dans cette région."
 
 msgid ""
 "Eliminate all oposition in this area. Then the first piece of the artifact "
 "will be yours."
 msgstr ""
+"Éliminez tous les opposants dans cette zone. Ensuite, la première pièce de "
+"l'artefact sera à vous."
 
 msgid ""
 "The sorceresses to the northeast are rebelling! For the good of the empire "
 "you must quash their feeble uprising on your way to the mountains."
 msgstr ""
+"Les sorcières du nord-est se rebellent ! Pour le bien de l'empire, vous "
+"devez réprimer leur faible soulèvement en vous rendant dans les montagnes."
 
 msgid ""
 "Having prepared for your arrival, Kraeger has arranged for a force of "
@@ -830,79 +898,117 @@ msgid ""
 "before the first day of the third week, or the Necromancers will be too "
 "strong for you."
 msgstr ""
+"Ayant préparé votre arrivée, Kraeger a mis en place une force de "
+"nécromanciens pour contrecarrer votre quête. Vous devez capturer le château "
+"de Scabsdale avant le premier jour de la troisième semaine, ou les "
+"nécromanciens seront trop forts pour vous."
 
 msgid ""
 "The barbarian despot in this area is, as yet, ignorant of your presence. "
 "Quickly, build up your forces before you are discovered and attacked! Secure "
 "the region by subduing all enemy forces."
 msgstr ""
+"Le despote barbare de cette région ignore pour l'instant votre présence. "
+"Vite, renforcez vos forces avant d'être découvert et attaqué ! Sécurisez la "
+"région en soumettant toutes les forces ennemies."
 
 msgid ""
 "The Empire is weak in this region. You will be unable to completely subdue "
 "all forces in this area, so take what you can before reprisal strikes. "
 "Remember, your true goal is to claim the Helmet of Anduran."
 msgstr ""
+"L'Empire est faible dans cette région. Vous ne pourrez pas soumettre "
+"complètement toutes les forces dans cette zone, alors prenez ce que vous "
+"pouvez avant que les représailles ne frappent. Rappelez-vous, votre "
+"véritable objectif est de réclamer le casque d'Anduran."
 
 msgid "For the good of the Empire, eliminate Kraeger."
-msgstr ""
+msgstr "Pour le bien de l'Empire, éliminez Kraeger."
 
 msgid ""
 "At last, you have the opportunity and the facilities to rid the Empire of "
 "the necromancer's evil. Eradicate them completely, and you will be sung as a "
 "hero for all time."
 msgstr ""
+"Vous avez enfin l'occasion et les moyens de débarrasser l'Empire du mal des "
+"nécromanciens. Eradiquez-les complètement, et vous serez chanté comme un "
+"héros pour l'éternité."
 
 msgid ""
 "Conquer and unite all the enemy tribes. Don't lose the hero Jarkonas, the "
 "forefather of all descendants."
 msgstr ""
+"Conquérez et unissez toutes les tribus ennemies. Ne perdez pas le héros "
+"Jarkonas, l'ancêtre de tous les descendants."
 
 msgid ""
 "Your rival, the Kingdom of Harondale, is attacking weak towns on your "
 "border! Recover from their first strike and crush them completely!"
 msgstr ""
+"Votre rival, le Royaume d'Harondale, attaque des villes faibles à votre "
+"frontière ! Récupérez leur première frappe et écrasez-les complètement !"
 
 msgid ""
 "Find your wayward son Joseph who is rumored to be living in the desolate "
 "lands. Do it before the first day of the third month or it will be of no "
 "help to your family."
 msgstr ""
+"Trouvez votre fils Joseph qui, selon la rumeur, vit dans les terres "
+"désolées. Faites-le avant le premier jour du troisième mois ou il ne sera "
+"d'aucune aide pour votre famille."
 
 msgid ""
 "Rescue your crazy uncle Ivan. Find him before the first day of the fourth "
 "month or it will be no help to your kingdom."
 msgstr ""
+"Sauvez votre oncle fou Ivan. Trouvez-le avant le premier jour du quatrième "
+"mois ou il ne sera d'aucune aide pour votre royaume."
 
 msgid ""
 "Destroy the barbarians who are attacking the southern border of your "
 "kingdom! Recover your fallen towns, and then invade the jungle kingdom. "
 "Leave no enemy standing."
 msgstr ""
+"Détruisez les barbares qui attaquent la frontière sud de votre royaume ! "
+"Récupérez vos villes perdues, puis envahissez le royaume de la jungle. Ne "
+"laissez aucun ennemi debout."
 
 msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
 msgstr ""
+"Reprendre le château de Ivory Gates, qui est tombé à cause de la trahison."
 
 msgid ""
 "Gain the favor of the elves. They will not allow trees to be chopped down, "
 "so they will send you wood every 2 weeks. You must complete your mission "
 "before the first day of the seventh month, or the kingdom will surely fall."
 msgstr ""
+"Gagnez la faveur des elfes. Ils ne permettront pas aux arbres d’être coupés, "
+"ils vous enverront donc du bois toutes les 2 semaines. Vous devez terminer "
+"votre mission avant le premier jour du septième mois, sinon le royaume "
+"tombera sûrement."
 
 msgid ""
 "This is the final battle against your rival kingdom of Harondale. Eliminate "
 "everyone, and don't lose the hero Jarkonas VI."
 msgstr ""
+"C’est la bataille finale contre votre royaume rival de Harondale. Éliminez "
+"tout le monde et ne perdez pas le héros Jarkonas VI."
 
 msgid ""
 "Your mission is to vanquish the warring mages in the magical Shrouded Isles. "
 "The completion of this task will give you a fighting chance against your "
 "rivals."
 msgstr ""
+"Votre mission est de vaincre les mages en guerre dans les îles magiques "
+"enveloppées. L’achèvement de cette tâche vous donnera une chance de vous "
+"battre contre vos rivaux."
 
 msgid ""
 "The location of the great library has been dicovered! You must make your way "
 "to it, and reclaim the city of Chronos in which it lies."
 msgstr ""
+"L’emplacement de la grande bibliothèque a été dicovered! Vous devez vous y "
+"rendre, et récupérer la ville de Chronos dans laquelle elle se trouve."
 
 msgid ""
 "Find the Orb of negation, which is said to be buried in this land. There are "
@@ -910,75 +1016,88 @@ msgid ""
 "Find the orb before the first day of the sixth month, or your rivals will "
 "surely have gotten to the fount before you."
 msgstr ""
+"Trouvez l’Orbe de la négation, qui serait enterré dans ce pays. Il y a des "
+"indices inscrits sur les obélisques en pierre qui vous aideront à vous "
+"conduire à votre prix. Trouvez l’orbe avant le premier jour du sixième mois, "
+"ou vos rivaux seront sûrement arrivés à la source avant vous."
 
 msgid ""
 "You must take control of the castle of Magic, where the fount of wizardry "
 "lies. Do this and your victory will be supreme."
 msgstr ""
+"Vous devez prendre le contrôle du château de la Magie, où se trouve la "
+"source de la magie. Faites-le et votre victoire sera suprême."
 
 msgid ""
 "Capture the town on the island off the southeast shore in order to construct "
 "a boat and travel back towards the mainland. Do not lose the hero Gallavant."
 msgstr ""
+"Capturez la ville sur l’île au large de la côte sud-est afin de construire "
+"un bateau et de retourner vers le continent. Ne perdez pas le héros "
+"Gallavant."
 
 msgid ""
 "Find and defeat Martine, the pirate leader, who resides in Pirates Cove. Do "
 "not lose Gallavant or your quest will be over."
 msgstr ""
+"Trouvez et battez Martine, le chef pirate, qui réside à Pirates Cove. Ne "
+"perdez pas Gallavant ou votre quête sera terminée."
 
 msgid ""
 "Eliminate all the other forces who oppose the rule of Lord Alberon. "
 "Gallavant must not die."
 msgstr ""
+"Éliminer toutes les autres forces qui s’opposent à la règle de lord Alberon. "
+"Gallavant ne doit pas mourir."
 
 msgid ""
 "Overthrow the entrenched monarchy of Lord Alberon, and claim all the land in "
 "your name. Gallavant must not die."
 msgstr ""
+"Renversez la monarchie enracinée de lord Alberon et revendiquez toutes les "
+"terres en votre nom. Gallavant ne doit pas mourir."
 
 msgid " bane"
-msgstr ""
+msgstr " fléau"
 
 msgid " alliance"
-msgstr ""
+msgstr " alliance"
 
 msgid "Carry-over forces"
-msgstr ""
+msgstr "Forces reportées"
 
 msgid " bonus"
-msgstr ""
+msgstr " bonus"
 
 msgid " defeated"
-msgstr ""
+msgstr " vaincu"
 
 msgid "Thunder Mace"
-msgstr ""
+msgstr "Massue"
 
 msgid "Minor Scroll"
-msgstr ""
+msgstr "Parchemin Mineur"
 
 msgid "Dragon Sword"
-msgstr ""
+msgstr "L'épée du Dragon"
 
-#, fuzzy
 msgid "Breastplate"
-msgstr "Place du marché"
+msgstr "Plastron Divin"
 
-msgid "Fizbin Medal"
-msgstr ""
+msgid "Fibzin Medal"
+msgstr "Médaille de Fibzin"
 
 msgid "Mage's ring"
-msgstr ""
+msgstr "Anneau de Magicien"
 
-#, fuzzy
 msgid "Defender Helm"
-msgstr "Défenseur"
+msgstr "Casque de Protection"
 
 msgid "Power Axe"
-msgstr ""
+msgstr "Puissante Hache"
 
 msgid "Summon Earth"
-msgstr ""
+msgstr "Invoquer Terre"
 
 msgid "The %{building} produces %{monster}."
 msgstr "%{building} produit des %{monster}."
@@ -995,20 +1114,17 @@ msgstr "Pour effectuer cette action il faut d'abord construire un château."
 
 msgid "Cannot build %{name} because castle is too far from water."
 msgstr ""
+"Impossible de construire %{name} parce que le château est trop loin de l’eau."
 
-#, fuzzy
 msgid "Cannot afford %{name}."
 msgstr "Impossible d'acheter %{name}"
 
-#, fuzzy
 msgid "%{name} is already built."
 msgstr "%{name} est déjà construit(e)"
 
-#, fuzzy
 msgid "Cannot build %{name}."
 msgstr "Impossible de construire %{name}"
 
-#, fuzzy
 msgid "Build %{name}."
 msgstr "Construire %{name}"
 
@@ -1019,10 +1135,10 @@ msgid "Tavern"
 msgstr "Taverne"
 
 msgid "Shipyard"
-msgstr "Chantier naval"
+msgstr "Ponton"
 
 msgid "Well"
-msgstr "Puit"
+msgstr "Puits"
 
 msgid "Statue"
 msgstr "Statue"
@@ -1031,10 +1147,10 @@ msgid "Marketplace"
 msgstr "Place du marché"
 
 msgid "Moat"
-msgstr "Douves"
+msgstr "Fossé"
 
 msgid "Castle"
-msgstr "Chateau"
+msgstr "Château"
 
 msgid "Tent"
 msgstr "Tente"
@@ -1043,37 +1159,37 @@ msgid "Captain's Quarters"
 msgstr "Quartiers du capitaine"
 
 msgid "Mage Guild, Level 1"
-msgstr "Guide des Mages, niveau 1"
+msgstr "Guide des mages niv. 1"
 
 msgid "Mage Guild, Level 2"
-msgstr "Guide des Mages, niveau 2"
+msgstr "Guide des mages niv. 2"
 
 msgid "Mage Guild, Level 3"
-msgstr "Guide des Mages, niveau 3"
+msgstr "Guide des mages niv. 3"
 
 msgid "Mage Guild, Level 4"
-msgstr "Guide des Mages, niveau 4"
+msgstr "Guide des mages niv. 4"
 
 msgid "Mage Guild, Level 5"
-msgstr "Guide des Mages, niveau 5"
+msgstr "Guide des mages niv. 5"
 
 msgid "Farm"
 msgstr "Ferme"
 
 msgid "Garbage Heap"
-msgstr "Tas de déchets"
+msgstr "Tas d'Ordures"
 
 msgid "Crystal Garden"
-msgstr "Jardin de Cristal"
+msgstr "Jardin de Cristaux"
 
 msgid "Waterfall"
-msgstr "Chute d'eau"
+msgstr "Chutes"
 
 msgid "Orchard"
 msgstr "Verger"
 
 msgid "Skull Pile"
-msgstr "Tas d'ossements"
+msgstr "Tas d'Ossements"
 
 msgid "Fortifications"
 msgstr "Fortifications"
@@ -1082,7 +1198,7 @@ msgid "Coliseum"
 msgstr "Colisée"
 
 msgid "Rainbow"
-msgstr "Arc en ciel"
+msgstr "Arc-en-ciel"
 
 msgid "Dungeon"
 msgstr "Donjon"
@@ -1094,19 +1210,19 @@ msgid "Storm"
 msgstr "Tempête"
 
 msgid "Thatched Hut"
-msgstr "Chaumière"
+msgstr "Grange"
 
 msgid "Hut"
-msgstr "Hutte"
+msgstr "Paillote"
 
 msgid "Treehouse"
-msgstr "Cabane dans les arbres"
+msgstr "Cabane"
 
 msgid "Cave"
 msgstr "Grotte"
 
 msgid "Habitat"
-msgstr "Habitation"
+msgstr "Repaire"
 
 msgid "Excavation"
 msgstr "Fouille"
@@ -1115,7 +1231,7 @@ msgid "Archery Range"
 msgstr "Archerie"
 
 msgid "Stick Hut"
-msgstr "Cabane de bois"
+msgstr "Hutte"
 
 msgid "Cottage"
 msgstr "Cottage"
@@ -1124,16 +1240,16 @@ msgid "Crypt"
 msgstr "Crypte"
 
 msgid "Pen"
-msgstr "Taule"
+msgstr "Enclos"
 
 msgid "Graveyard"
 msgstr "Cimetière"
 
 msgid "Blacksmith"
-msgstr "Forgeron"
+msgstr "Forge"
 
 msgid "Den"
-msgstr "Antre"
+msgstr "Tanière"
 
 msgid "Nest"
 msgstr "Nid"
@@ -1148,28 +1264,28 @@ msgid "Armory"
 msgstr "Armurerie"
 
 msgid "Adobe"
-msgstr "Pisé"
+msgstr "Cahute"
 
 msgid "Stonehenge"
-msgstr "Stonehenge"
+msgstr "Cromlech"
 
 msgid "Maze"
-msgstr "Dédale"
+msgstr "Labyrinthe"
 
 msgid "Cliff Nest"
-msgstr "Falaise des Rocks"
+msgstr "Nid perché"
 
 msgid "Mansion"
 msgstr "Manoir"
 
 msgid "Jousting Arena"
-msgstr "Arène de joute"
+msgstr "Arène"
 
 msgid "Bridge"
 msgstr "Pont"
 
 msgid "Fenced Meadow"
-msgstr "Prairie clôturée"
+msgstr "Pré"
 
 msgid "Swamp"
 msgstr "Marais"
@@ -1190,72 +1306,71 @@ msgid "Green Tower"
 msgstr "Tour verte"
 
 msgid "Cloud Castle"
-msgstr "Château des Nuages"
+msgstr "Château céleste"
 
 msgid "Laboratory"
 msgstr "Laboratoire"
 
 msgid "Upg. Archery Range"
-msgstr "Améliorer Archerie"
+msgstr "Archerie renforcée"
 
 msgid "Upg. Stick Hut"
-msgstr "Améliorer cabane de bois"
+msgstr "Hutte renforcée"
 
 msgid "Upg. Cottage"
-msgstr "Améliorer cottage"
+msgstr "Cottage renforcé"
 
 msgid "Upg. Graveyard"
-msgstr "Améliorer Cimetière"
+msgstr "Cimetière renforcée"
 
 msgid "Upg. Blacksmith"
-msgstr "Améliorer forge"
+msgstr "Forge renforcée"
 
 msgid "Upg. Foundry"
-msgstr "Améliorer fonderie"
+msgstr "Fonderie renforcée"
 
 msgid "Upg. Pyramid"
-msgstr "Améliorer pyramide"
+msgstr "Pyramide renforcée"
 
 msgid "Upg. Armory"
-msgstr "Améliorer  armuerie"
+msgstr "Armurerie renforcée"
 
 msgid "Upg. Adobe"
-msgstr "Améliorer pisé"
+msgstr "Cahute renforcée"
 
 msgid "Upg. Stonehenge"
-msgstr "Améliorer monument de pierres"
+msgstr "Cromlech renforcé"
 
 msgid "Upg. Maze"
-msgstr "Améliorer dédale"
+msgstr "Labyrinthe renforcé"
 
 msgid "Upg. Mansion"
-msgstr "Améliorer manoir"
+msgstr "Manoir renforcé"
 
 msgid "Upg. Jousting Arena"
-msgstr "Améliorer arène de joutes"
+msgstr "Arène renforcée"
 
 msgid "Upg. Bridge"
-msgstr "Améliorer pont"
+msgstr "Pont renforcé"
 
 msgid "Upg. Ivory Tower"
-msgstr "Améliorer tour d'ivoire"
+msgstr "Tour d'ivoire renforcée"
 
 msgid "Upg. Mausoleum"
-msgstr "Améliorer mausolée"
+msgstr "Mausolée renforcée"
 
 msgid "Upg. Cathedral"
-msgstr "Améliorer cathédrale"
+msgstr "Cathédrale renforcée"
 
 msgid "Upg. Cloud Castle"
-msgstr "Améliorer château des nuages"
+msgstr "Château céleste renforcée"
 
 msgid "Black Tower"
 msgstr "Tour noire"
 
 msgid "Shrine"
-msgstr "Lieu saint"
+msgstr "Sanctuaire"
 
-#, fuzzy
 msgid ""
 "The Thieves' Guild provides information on enemy players. Thieves' Guilds "
 "can also provide scouting information on enemy towns. Additional Guilds "
@@ -1263,10 +1378,10 @@ msgid ""
 msgstr ""
 "La guilde des voleurs fournit des informations sur les joueurs ennemies. Les "
 "guildes de voleurs peuvent aussi effectuer des missions d'infiltrations dans "
-"les villes ennemies"
+"les villes ennemies."
 
 msgid "The Tavern increases morale for troops defending the castle."
-msgstr "La taverne permet d'augmenter le moral des défenseurs du château."
+msgstr "La taverne augmente le moral des défenseurs du château."
 
 msgid "The Shipyard allows ships to be built."
 msgstr "Le chantier naval permet la construction de navires."
@@ -1275,18 +1390,21 @@ msgid ""
 "The Well increases the growth rate of all dwellings by %{count} creatures "
 "per week."
 msgstr ""
+"Le Puits augment le taux de croissance de population de deux créatures par "
+"semaine dans chaque demeure."
 
 msgid "The Statue increases your town's income by %{count} per day."
 msgstr ""
+"La Statue augmente les revenus de votre village de %{count} pièces par jour."
 
 msgid "The Left Turret provides extra firepower during castle combat."
 msgstr ""
-"la tourelle gauche fournit une puissance de feu supplémentaire lors de "
+"La tourelle gauche fournit une puissance de feu supplémentaire lors de "
 "combat de châteaux."
 
 msgid "The Right Turret provides extra firepower during castle combat."
 msgstr ""
-"la tourelle droite fournit une puissance de feu supplémentaire lors de "
+"La tourelle droite fournit une puissance de feu supplémentaire lors de "
 "combat de châteaux."
 
 msgid ""
@@ -1301,13 +1419,15 @@ msgid ""
 "The Moat slows attacking units. Any unit entering the moat must end its turn "
 "there and becomes more vulnerable to attack."
 msgstr ""
-"Les douves ralentissent les attaques d'unités. Chaque unité qui entre dans "
-"les douves y termine son tour et devient plus vulnérable aux attaques."
+"Le Fossé ralentit les attaques des ennemis. Chaque unité qui tente de "
+"franchir le fossé perd son tour et devient plus vulnérable aux attaques."
 
 msgid ""
 "The Castle improves town defense and increases income to %{count} gold per "
 "day."
 msgstr ""
+"Le Château améliore la défense du village et augmente les revenus de "
+"%{count} pièces par jour."
 
 msgid ""
 "The Tent provides workers to build a castle, provided the materials and the "
@@ -1320,34 +1440,40 @@ msgid ""
 "The Captain's Quarters provides a captain to assist in the castle's defense "
 "when no hero is present."
 msgstr ""
-"les quartiers du capitaine permettent au capitaine d'assurer une aide à la "
-"défense du château lorsqu'un héro est absent."
+"Les quartiers du capitaine permettent au capitaine d'assurer une aide à la "
+"défense du château lorsqu'un héros est absent."
 
 msgid ""
 "The Mage Guild allows heroes to learn spells and replenish their spell "
 "points."
 msgstr ""
 "La guilde des Mages permet aux héros d'apprendre des sortilèges et de "
-"restaurer les points de sorts."
+"restaurer les points de magie."
 
 msgid "The Farm increases production of Peasants by %{count} per week."
-msgstr ""
+msgstr "La Ferme augmente la production de Paysans de %{count} par semaine."
 
 msgid "The Garbage Heap increases production of Goblins by %{count} per week."
 msgstr ""
+"Le Tas d'Ordures augmente la production de Gobelins de %{count} par semaine."
 
 msgid ""
 "The Crystal Garden increases production of Sprites by %{count} per week."
 msgstr ""
+"Le Jardin de Cristaux augmente la production de Sprites de %{count} par "
+"semaine."
 
 msgid "The Waterfall increases production of Centaurs by %{count} per week."
 msgstr ""
+"Les Cascades augmentent la production de Centaures de %{count} par semaine."
 
 msgid "The Orchard increases production of Halflings by %{count} per week."
-msgstr ""
+msgstr "Le Verger augmente la production de galopins de %{count} par semaine."
 
 msgid "The Skull Pile increases production of Skeletons by %{count} per week."
 msgstr ""
+"Le Tas de Crânes augmente la production de Squelettes de %{count} par "
+"semaine."
 
 msgid ""
 "The Fortifications increase the toughness of the walls, increasing the "
@@ -1368,6 +1494,7 @@ msgstr "L'arc en ciel augmente la chance des unités de défenses de deux."
 
 msgid "The Dungeon increases the income of the town by %{count} / day."
 msgstr ""
+"Le Donjon augmente les revenus de votre village de %{count} pièces par jour."
 
 msgid ""
 "The Library increases the number of spells in the Guild by one for each "
@@ -1387,108 +1514,101 @@ msgstr ""
 "Le lieu saint augmente la puissance de nécromancie de tous les nécromanciens "
 "de 10 pour cents."
 
-#, fuzzy
 msgid "Cannot recruit - you already recruit hero in current week."
-msgstr "Impossible de recruter - vous avez déjà une héro dans cette ville."
+msgstr ""
+"Impossible de recruter - vous avez déjà recruté un héros cette semaine."
 
-#, fuzzy
 msgid "Cannot recruit - guest to guard automove error."
-msgstr "Impossible de recruter - vous avez trop de héros."
+msgstr "Impossible de recruter - guest to guard automove error."
 
 msgid "Cannot recruit - you already have a Hero in this town."
-msgstr "Impossible de recruter - vous avez déjà une héro dans cette ville."
+msgstr "Impossible de recruter - vous avez déjà un héros dans ce village."
 
 msgid "Cannot recruit - you have too many Heroes."
 msgstr "Impossible de recruter - vous avez trop de héros."
 
 msgid "Cannot afford a Hero"
-msgstr "Imopssible de s'offrir un héro"
+msgstr "Imopssible de s'offrir un héros"
 
 msgid "There is no room in the garrison for this army."
-msgstr ""
+msgstr "Il n'y a pas de place dans la garnison pour cette armée."
 
 msgid "Recruit %{name}"
 msgstr "Recruter %{name}"
 
 msgid "Month: %{month}, Week: %{week}, Day: %{day}"
-msgstr ""
+msgstr "Mois : %{month}, Semaine : %{week}, Jour : %{day}"
 
-#, fuzzy
 msgid "Income"
-msgstr "Rentrées d'argent :"
+msgstr "Revenu"
 
 msgid "Join Error"
-msgstr ""
+msgstr "Join Error"
 
 msgid "Army is full"
-msgstr ""
+msgstr "L'armée est complete"
 
 msgid ""
 "You must purchase a spell book to use the mage guild, but you currently have "
 "no room for a spell book. Try giving one of your artifacts to another hero."
 msgstr ""
+"Vous devez acheter un livre de sorts pour utiliser la guilde des mages, mais "
+"vous n'avez actuellement pas de place pour un livre de sorts. Essayez de "
+"donner un de vos artefacts à un autre héros."
 
 msgid "Town"
-msgstr "Ville"
+msgstr "Village"
 
 msgid "This town may not be upgraded to a castle."
-msgstr "Cette ville ne peut pas être améliorée en château."
+msgstr "Ce village ne peut pas être améliorée en château."
 
-#, fuzzy
 msgid "Exit Castle"
-msgstr "Sortie du château"
+msgstr "Qutter le château"
 
-#, fuzzy
 msgid "Exit Town"
-msgstr "Sortie de la ville"
+msgstr "Quitter le village"
 
-#, fuzzy
 msgid "Show Income"
-msgstr "Rentrées d'argent :"
+msgstr "Afficher le revenu"
 
 msgid "Show previous town"
-msgstr "Montrer la ville précédente"
+msgstr "Montrer le village précédent"
 
 msgid "Show next town"
-msgstr "Montrer la ville suivante"
+msgstr "Montrer le village suivant"
 
-#, fuzzy
 msgid "Swap Heroes"
-msgstr "Héros"
+msgstr "Echanger héros"
 
-#, fuzzy
 msgid "Meeting Heroes"
-msgstr "Héros"
+msgstr "Rencontre"
 
 msgid "View Hero"
-msgstr "Voir le Héro"
+msgstr "Voir le Héros"
 
-#, fuzzy
 msgid "The above spells are available here."
-msgstr "Les sorts ci-dessus ont été ajoutés à votre livre."
+msgstr "Les sorts ci-dessus sond disponibles."
 
 msgid "The above spells have been added to your book."
 msgstr "Les sorts ci-dessus ont été ajoutés à votre livre."
 
 msgid "A generous tip for the barkeep yields the following rumor:"
-msgstr ""
+msgstr "Le tavernier fait courir la rumeur suivante :"
 
 msgid "Recruit Hero"
-msgstr "Recruter un héro"
+msgstr "Recruter un héros"
 
-#, fuzzy
 msgid "%{name} is a level %{value} %{race} "
-msgstr "%{name} est niveau %{value} %{race} avec %{count} artefacts."
+msgstr "%{name} est un %{race} de niveau %{value} "
 
 msgid "with %{count} artifacts."
-msgstr ""
+msgstr "avec %{count} artéfacts."
 
-#, fuzzy
 msgid "with 1 artifact."
-msgstr "Impossible de déplacer la dernière armée dans la garnison"
+msgstr "avec un artéfact."
 
 msgid "without artifacts."
-msgstr ""
+msgstr "sans artéfacts."
 
 msgid ""
 "'Spread' combat formation spreads your armies from the top to the bottom of "
@@ -1505,13 +1625,13 @@ msgstr ""
 "bataille, de votre coté."
 
 msgid "Attack Skill"
-msgstr "Puissance d'attaque"
+msgstr "Attaque"
 
 msgid "Defense Skill"
-msgstr "Puissance de défense"
+msgstr "Défense"
 
 msgid "Spread Formation"
-msgstr "Formation Déploiement"
+msgstr "Formation Dispersée"
 
 msgid "Grouped Formation"
 msgstr "Formation Groupée"
@@ -1525,25 +1645,23 @@ msgstr "Utiliser la formation de combat 'Déploiement' pour la garnison"
 msgid "Set garrison combat formation to 'Grouped'"
 msgstr "Utiliser la formation de combat 'Déploiement' pour la garnison"
 
-#, fuzzy
 msgid "Exit Castle Options"
-msgstr "Options du chateau"
+msgstr "Quitter les options du château"
 
 msgid "Castle Options"
-msgstr "Options du chateau"
+msgstr "Options du château"
 
 msgid "Not enough resources to buy monsters."
-msgstr ""
+msgstr "Pas assez de ressources pour acheter des monstres."
 
 msgid "No monsters available for purchase."
-msgstr ""
+msgstr "Pas de monstres disponibles à l'achat."
 
-#, fuzzy
 msgid "Buy Monsters"
-msgstr "Meilleur monstre :"
+msgstr "Acheter monstres"
 
 msgid "Town Population Information and Statistics"
-msgstr "Information et statistiques sur la population de la ville"
+msgstr "Information et statistiques sur la population du village"
 
 msgid "Damage"
 msgstr "Dommage"
@@ -1570,13 +1688,13 @@ msgid "View information on the scenario you are currently playing."
 msgstr "Voir les informations du scénario de la partie actuelle."
 
 msgid "Dig for the Ultimate Artifact."
-msgstr "Creuser pour l'Artefact Ultime"
+msgstr "Creuser pour l'Artefact Ultime."
 
 msgid "Exit this menu without doing anything."
 msgstr "Sortir de ce menu sans modification."
 
 msgid "Arena"
-msgstr ""
+msgstr "Arène"
 
 msgid ""
 "You enter the arena and face a pack of vicious lions. You handily defeat "
@@ -1592,15 +1710,17 @@ msgid ""
 "Your troops can be upgraded, but it will cost you dearly. Do you wish to "
 "upgrade them?"
 msgstr ""
+"Vos troupes peuvent être améliorées, mais cela vous coûtera cher. Souhaitez-"
+"vous les mettre à niveau ?"
 
 msgid "Are you sure you want to dismiss this army?"
-msgstr ""
+msgstr "Êtes vous sur de vouloir renvoyer cette troupe?"
 
 msgid "Shots Left"
 msgstr "Tirs restants"
 
 msgid "Shots"
-msgstr "Tirs"
+msgstr "Projectiles"
 
 msgid "Hit Points"
 msgstr "Points de vie"
@@ -1608,47 +1728,61 @@ msgstr "Points de vie"
 msgid "Hit Points Left"
 msgstr "Points de vie restants"
 
-#, fuzzy
 msgid "Followers"
-msgstr "Pouvoir d'invocation"
+msgstr "Suiveurs"
 
 msgid ""
 "A group of %{monster} with a desire for greater glory wish to join you.\n"
 "Do you accept?"
 msgstr ""
+"Un groupe de %{monster} avec un désir de plus grande gloire souhaitent se "
+"joindre à vous.\n"
+"Acceptez-vous?"
 
 msgid ""
 "The %{monster} is swayed by your diplomatic tongue, and offers to join your "
 "army for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
+"Le %{monster} est influencé par votre langue diplomatique, et propose de "
+"rejoindre votre armée pour la somme de %{gold} d’or.\n"
+"Acceptez-vous?"
 
 msgid ""
 "The creatures are swayed by your diplomatic\n"
 "tongue, and make you an offer:\n"
 " \n"
 msgstr ""
+"Les créatures sont balayées par votre diplomate\n"
+"langue, et vous faire une offre:\n"
+" \n"
 
 msgid ""
 "%{offer} of the %{total} %{monster} will join your army, and the rest will "
 "leave you alone, for the sum of %{gold} gold.\n"
 "Do you accept?"
 msgstr ""
+"%{offer} des %{total} %{monster} rejoindront votre armée, et le reste vous "
+"laissera tranquille, pour la somme de %{gold} d’or.\n"
+"Acceptez-vous?"
 
 msgid ""
 "All %{offer} of the %{monster} will join your army for the sum of %{gold} "
 "gold.\n"
 "Do you accept?"
 msgstr ""
+"Tous les %{offer} de la %{monster} rejoindront votre armée pour la somme de "
+"%{gold} d’or.\n"
+"Acceptez-vous?"
 
 msgid "(Rate: %{percent})"
-msgstr ""
+msgstr "(Taux: %{percent})"
 
 msgid "No room in"
-msgstr ""
+msgstr "Pas de place dans"
 
 msgid "the garrison"
-msgstr ""
+msgstr "la garnison"
 
 msgid "Build a new ship:"
 msgstr "Construire un nouveau navire :"
@@ -1660,29 +1794,28 @@ msgid "Load Game"
 msgstr "Charger une partie"
 
 msgid "No save files to load."
-msgstr ""
+msgstr "Pas de sauvegarde disponible."
 
 msgid "New Game"
 msgstr "Nouvelle partie"
 
 msgid "Start a single or multi-player game."
-msgstr "Démarrer un jeu solo ou multijoueur"
+msgstr "Démarrer un jeu solo ou multijoueur."
 
 msgid "Load a previously saved game."
-msgstr "CHarger une partie sauvegardée"
+msgstr "Charger une partie sauvegardée."
 
-#, fuzzy
 msgid "Save Game"
-msgstr "Nouvelle partie"
+msgstr "Enregistrer"
 
 msgid "Save the current game."
-msgstr ""
+msgstr "Enregistrer le jeu en cours."
 
 msgid "Quit"
 msgstr "Quitter"
 
 msgid "Quit out of Free Heroes of Might and Magic II."
-msgstr ""
+msgstr "Quittez le jeu Free Heroes of Might and Magic II."
 
 msgid ""
 "Map\n"
@@ -1699,7 +1832,7 @@ msgstr ""
 "Difficulté"
 
 msgid "Rating"
-msgstr "Classement"
+msgstr "Taux"
 
 msgid "Map Size"
 msgstr "Taille de la carte"
@@ -1725,32 +1858,31 @@ msgstr ""
 "Conditions"
 
 msgid "You cannot select %{resource}!"
-msgstr ""
+msgstr "Vous ne pouvez pas sélectionner %{resource} !"
 
 msgid "Select count %{resource}:"
-msgstr ""
+msgstr "Sélectionner %{resource}:"
 
 msgid "Set Guardian"
-msgstr ""
+msgstr "Gardien"
 
 msgid "Your army too big!"
-msgstr ""
+msgstr "Votre armée est trop grande !"
 
 msgid "%{name} has gained a level."
-msgstr ""
+msgstr "%{name} a gagné un niveau."
 
-#, fuzzy
 msgid "%{skill} +1"
-msgstr "voir les infos de %{name} info."
+msgstr "%{skill} +1"
 
 msgid "You have learned %{skill}."
-msgstr ""
+msgstr "Vous avez appris %{skill}."
 
 msgid "You may learn either:"
-msgstr ""
+msgstr "Vous pouvez apprendre soit :"
 
 msgid "or"
-msgstr ""
+msgstr "ou"
 
 msgid ""
 "Please inspect our fine wares. If you feel like offering a trade, click on "
@@ -1763,6 +1895,8 @@ msgid ""
 "You have received quite a bargain. I expect to make no profit on the deal. "
 "Can I interest you in any of my other wares?"
 msgstr ""
+"Vous avez fait une bonne affaire. Je ne compte pas faire de profit sur cette "
+"affaire. Puis-je vous intéresser à d'autres de mes produits ?"
 
 msgid "I can offer you %{count} for 1 unit of %{resfrom}."
 msgstr "Je peux vous offrir %{count} pour une unité de %{resfrom}."
@@ -1775,7 +1909,7 @@ msgid "Qty to trade"
 msgstr "Qté à échanger"
 
 msgid "Trading Post"
-msgstr ""
+msgstr "Comptoir"
 
 msgid "Your Resources"
 msgstr "Vos ressources"
@@ -1787,19 +1921,19 @@ msgid "n/a"
 msgstr "n/a"
 
 msgid "guarded by %{count} %{monster}"
-msgstr ""
+msgstr "gardé par %{count} de %{monster}"
 
 msgid "(available: %{count})"
-msgstr ""
+msgstr "(disponible: %{count})"
 
 msgid "already learned"
-msgstr ""
+msgstr "déjà appris"
 
 msgid "already knows this skill"
-msgstr ""
+msgstr "connaît déjà cette compétence"
 
 msgid "already has max skills"
-msgstr ""
+msgstr "a déjà le maximum des compétences"
 
 msgid "(already visited)"
 msgstr "(déjà visité)"
@@ -1807,21 +1941,20 @@ msgstr "(déjà visité)"
 msgid "(not visited)"
 msgstr "(pas visité)"
 
-#, fuzzy
 msgid "Road"
-msgstr "Mode Routes"
+msgstr "Route"
 
 msgid "(digging ok)"
-msgstr ""
+msgstr "(fouille possible)"
 
 msgid "(no digging)"
-msgstr ""
+msgstr "(pas de fouille)"
 
 msgid "penalty: %{cost}"
-msgstr ""
+msgstr "pénalité : %{cost}"
 
 msgid "Uncharted Territory"
-msgstr ""
+msgstr "Terra Incognita"
 
 msgid "Defenders:"
 msgstr "Defenseurs :"
@@ -1830,15 +1963,13 @@ msgid "None"
 msgstr "Aucun"
 
 msgid "Unknown"
-msgstr ""
+msgstr "Inconnu"
 
-#, fuzzy
 msgid "%{name} (Level %{level})"
-msgstr "%{name} le %{race}"
+msgstr "%{name} (niveau %{level})"
 
-#, fuzzy
 msgid "Move Points"
-msgstr "Points de sortilège"
+msgstr "Pt. de mouvement"
 
 msgid "Available: %{count}"
 msgstr "Disponible: %{count}"
@@ -1847,10 +1978,10 @@ msgid "Number to buy:"
 msgstr "Nombre à acheter :"
 
 msgid "How many troops to move?"
-msgstr ""
+msgstr "Combien de troupes à déplacer ?"
 
 msgid "Fast separation into slots:"
-msgstr ""
+msgstr "Séparation rapide des troupes :"
 
 msgid "File to Save:"
 msgstr "Fichier à sauvegarder :"
@@ -1864,38 +1995,33 @@ msgstr "Êtes vous sur de vouloir effacer le fichier :"
 msgid "Warning!"
 msgstr "Attention!"
 
-#, fuzzy
 msgid "Map difficulty:"
-msgstr "Difficulté des cartes :"
+msgstr "Difficulté de la carte :"
 
 msgid "No maps exist at that size"
-msgstr ""
+msgstr "Aucune carte n'existe à cette taille"
 
 msgid "Small Maps"
 msgstr "Petite cartes"
 
-#, fuzzy
 msgid "View only maps of size small (36 x 36)."
 msgstr "Voir seulement les cartes de petite taille (36x36)"
 
 msgid "Medium Maps"
 msgstr "Cartes moyennes"
 
-#, fuzzy
 msgid "View only maps of size medium (72 x 72)."
 msgstr "Voir seulement les cartes de taille moyenne (72x72)"
 
 msgid "Large Maps"
 msgstr "Grandes cartes"
 
-#, fuzzy
 msgid "View only maps of size large (108 x 108)."
 msgstr "Voir seulement les grandes cartes (108x108)."
 
 msgid "Extra Large Maps"
 msgstr "Très grandes cartes"
 
-#, fuzzy
 msgid "View only maps of size extra large (144 x 144)."
 msgstr "Voir seulement les très grandes cartes (144x144)."
 
@@ -1908,7 +2034,6 @@ msgstr "Voir toutes les cartes, sans tenir compte de leur taille."
 msgid "Players Icon"
 msgstr "Icônes des joueurs"
 
-#, fuzzy
 msgid ""
 "Indicates how many players total are in the scenario. Any positions not "
 "occupied by humans will be occupied by computer players."
@@ -1919,24 +2044,25 @@ msgstr ""
 msgid "Size Icon"
 msgstr "Taille de l'icône"
 
-#, fuzzy
 msgid ""
 "Indicates whether the map\n"
 "is small (36 x 36), medium\n"
 "(72 x 72), large (108 x 108),\n"
 "or extra large (144 x 144)."
 msgstr ""
-"Indique si la map est petite (36x36), moyenne (72x72), large (108x108) ou "
-"extra large (144x144)."
+"Indique si la carte est\n"
+"petite (36x36), moyenne\n"
+"(72x72), large (108x108)\n"
+"ou extra large (144x144)."
 
 msgid "Selected Name"
-msgstr ""
+msgstr "Nom choisi"
 
 msgid "The name of the currently selected map."
-msgstr ""
+msgstr "Le nom de la carte actuellement sélectionnée."
 
 msgid "Selected Map Difficulty"
-msgstr ""
+msgstr "Difficulté de la carte choisie"
 
 msgid ""
 "The map difficulty of the currently selected map.  The map difficulty is "
@@ -1944,149 +2070,151 @@ msgid ""
 "or stronger enemies, fewer resources, or other special conditions making "
 "things tougher for the human player."
 msgstr ""
+"Difficulté de la carte actuellement sélectionnée.  La difficulté de la carte "
+"est déterminée par le concepteur de scénarios. Les cartes plus difficiles "
+"peuvent inclure des ennemis plus nombreux ou plus forts, moins de ressources "
+"ou d’autres conditions spéciales rendant les choses plus difficiles pour le "
+"joueur humain."
 
 msgid "Selected Description"
-msgstr ""
+msgstr "Description sélectionnée"
 
 msgid "The description of the currently selected map."
-msgstr ""
+msgstr "La description de la carte actuellement sélectionnée."
 
 msgid "Okay"
-msgstr ""
+msgstr "OK"
 
 msgid "Accept the choice made."
 msgstr "Confirmez le choix."
 
 msgid "Lose all your heroes and towns."
-msgstr ""
+msgstr "Perdre tous les héros et tous les villages."
 
 msgid "Lose a specific town."
-msgstr ""
+msgstr "Perdre un village spécifique."
 
 msgid "Lose a specific hero."
-msgstr ""
+msgstr "Perdre un héros spécifique."
 
 msgid "Run out of time. Fail to win by a certain point."
-msgstr ""
+msgstr "Manquer de temps. Ne pas gagner avant un certain point."
 
 msgid "Loss Condition"
-msgstr ""
+msgstr "Conditions de Défaite"
 
 msgid "Defeat all enemy heroes and towns."
-msgstr "Détruisez tous les héros et villes ennemis"
+msgstr "Détruisez tous les héros et villages ennemis."
 
 msgid "Capture a specific town."
-msgstr "Capturez une ville spécifique"
+msgstr "Capturez un village spécifique."
 
 msgid "Defeat a specific hero."
-msgstr "Détruisez un héros spécifique"
+msgstr "Détruisez un héros spécifique."
 
 msgid "Find a specific artifact."
-msgstr "Trouvez un artefact spécifique"
+msgstr "Trouvez un artéfact spécifique."
 
 msgid "Your side defeats the opposing side."
-msgstr ""
+msgstr "Votre camp a vaincu le camp adverse."
 
 msgid "Accumulate a large amount of gold."
-msgstr ""
+msgstr "Accumuler une grande quantité d'or."
 
 msgid "Victory Condition"
-msgstr ""
+msgstr "Conditions de Victoire"
 
 msgid "one"
-msgstr ""
+msgstr "1"
 
 msgid "two"
-msgstr ""
+msgstr "2"
 
-#, fuzzy
 msgid "Music"
-msgstr "musique"
+msgstr "Musique"
 
 msgid "Toggle ambient music level."
-msgstr ""
+msgstr "Basculez le niveau de la musique ambiante."
 
 msgid "Effects"
-msgstr ""
+msgstr "Effets"
 
 msgid "Toggle foreground sounds level."
-msgstr ""
+msgstr "Basculer le niveau des sons de premier plan."
 
 msgid "Music Type"
-msgstr ""
+msgstr "Type de Musique"
 
 msgid "Change the type of music."
-msgstr ""
+msgstr "Changer de type de musique."
 
-#, fuzzy
 msgid "Hero Speed"
-msgstr "Vitesse"
+msgstr "Vitesse héros"
 
 msgid "Change the speed at which your heroes move on the main screen."
 msgstr ""
+"Changez la vitesse à laquelle vos héros se déplacent sur l’écran principal."
 
-#, fuzzy
 msgid "Enemy Speed"
-msgstr "Vitesse"
+msgstr "Vitesse ennemi"
 
 msgid ""
 "Sets the speed that A.I. heroes move at.  You can also elect not to view A."
 "I. movement at all."
 msgstr ""
+"Définit la vitesse à laquelle les héros de l’I.A. se déplacent.  Vous pouvez "
+"également choisir de ne pas voir du tout le mouvement de l’AI."
 
 msgid "Scroll Speed"
-msgstr ""
+msgstr "Vitesse de défilée"
 
 msgid "Sets the speed at which you scroll the window."
-msgstr ""
+msgstr "Définit la vitesse à laquelle vous faites défiler la fenêtre."
 
-#, fuzzy
 msgid "Interface Type"
-msgstr "Interface"
+msgstr "Type d'Interface"
 
 msgid "Toggle the type of interface you want to use."
-msgstr ""
+msgstr "Basculer le type d'interface que vous voulez utiliser."
 
 msgid "Interface"
 msgstr "Interface"
 
 msgid "Toggle interface visibility."
-msgstr ""
+msgstr "Visibilité d'Interface."
 
 msgid "Battles"
-msgstr ""
+msgstr "Batailles"
 
 msgid "Toggle instant battle mode."
-msgstr ""
+msgstr "Basculer le mode de combat instantané."
 
 msgid "OK"
 msgstr "OK"
 
-#, fuzzy
 msgid "Exit this menu."
-msgstr "Passer cette unité"
+msgstr "Quitter ce menu."
 
 msgid "off"
 msgstr "coupé"
 
 msgid "MIDI"
-msgstr ""
+msgstr "MIDI"
 
-#, fuzzy
 msgid "MIDI Expansion"
-msgstr "Manoir"
+msgstr "MIDI Expansion"
 
 msgid "CD Stereo"
-msgstr ""
+msgstr "Stéréo CD"
 
 msgid "External"
-msgstr ""
+msgstr "Externe"
 
 msgid "Jump"
-msgstr ""
+msgstr "Immédiat"
 
 msgid "Don't Show"
-msgstr ""
+msgstr "Masquer"
 
 msgid "Evil"
 msgstr "Mal"
@@ -2094,66 +2222,62 @@ msgstr "Mal"
 msgid "Good"
 msgstr "Bien"
 
-#, fuzzy
 msgid "Hide"
-msgstr "Horde"
+msgstr "Cacher"
 
-#, fuzzy
 msgid "Show"
-msgstr "Neige"
+msgstr "Afficher"
 
 msgid "Auto Resolve"
-msgstr ""
+msgstr "Combat auto"
 
 msgid "Auto, No Spells"
-msgstr ""
+msgstr "Combat auto sans magie"
 
 msgid "Manual"
-msgstr ""
+msgstr "Manuel"
 
 msgid "Att."
-msgstr ""
+msgstr "Att."
 
 msgid "Def."
-msgstr ""
+msgstr "Déf."
 
 msgid "Power"
-msgstr ""
+msgstr "Pouvoir d'invocation"
 
-#, fuzzy
 msgid "Knowl"
 msgstr "Connaissance"
 
 msgid "Human"
-msgstr ""
+msgstr "Humain"
 
 msgid "1st"
-msgstr ""
+msgstr "1-er"
 
 msgid "2nd"
-msgstr ""
+msgstr "2-ème"
 
 msgid "3rd"
-msgstr ""
+msgstr "3-ème"
 
 msgid "4th"
-msgstr ""
+msgstr "4-ème"
 
 msgid "5th"
-msgstr ""
+msgstr "5-ème"
 
 msgid "6th"
-msgstr ""
+msgstr "6-ème"
 
 msgid "Oracle: Player Rankings"
-msgstr ""
+msgstr "Oracle : Classement de joueurs"
 
-#, fuzzy
 msgid "Thieves' Guild: Player Rankings"
-msgstr "Guilde des voleurs"
+msgstr "Guilde des voleurs: Classement de joueurs"
 
 msgid "Number of Towns:"
-msgstr "Nombre de villes :"
+msgstr "Nombre de villages :"
 
 msgid "Number of Castles:"
 msgstr "Nombre de châteaux :"
@@ -2168,14 +2292,13 @@ msgid "Wood & Ore:"
 msgstr "Bois et minerais :"
 
 msgid "Gems, Cr, Slf & Mer:"
-msgstr ""
+msgstr "Rubis, Cr, Sfr & Mer:"
 
 msgid "Obelisks Found:"
 msgstr "Obélisques trouvés :"
 
-#, fuzzy
 msgid "Artifacts:"
-msgstr "Artéfact"
+msgstr "Artéfacts :"
 
 msgid "Total Army Strength:"
 msgstr "Force totale de l'armée :"
@@ -2184,10 +2307,10 @@ msgid "Income:"
 msgstr "Rentrées d'argent :"
 
 msgid "Best Hero:"
-msgstr "Meilleur Héro :"
+msgstr "Meilleur Héros :"
 
 msgid "Best Hero Stats:"
-msgstr "Stats du meilleur Héro :"
+msgstr "Stats du meilleur Héros :"
 
 msgid "Personality:"
 msgstr "Personnalité:"
@@ -2196,56 +2319,61 @@ msgid "Best Monster:"
 msgstr "Meilleur monstre :"
 
 msgid "difficulty|Easy"
-msgstr ""
+msgstr "Facile"
 
 msgid "difficulty|Normal"
-msgstr ""
+msgstr "Normal"
 
 msgid "difficulty|Hard"
-msgstr ""
+msgstr "Difficile"
 
 msgid "difficulty|Expert"
-msgstr ""
+msgstr "Expert"
 
 msgid "difficulty|Impossible"
-msgstr ""
+msgstr "Impossible"
 
-#, fuzzy
 msgid "Map is loading..."
-msgstr "Chargement des cartes..."
+msgstr "Chargement de la carte..."
 
 msgid "and more..."
-msgstr ""
+msgstr "et plus encore..."
 
 msgid "Campaign Scenario loading failure"
-msgstr ""
+msgstr "Échec du chargement du scénario de campagne"
 
 msgid "Please make sure that campaign files are correct and present."
-msgstr ""
+msgstr "Assurez-vous que les fichiers de campagne sont corrects et présents."
 
 msgid "Unknown Hero"
-msgstr ""
+msgstr "Héros Inconnu"
 
 msgid "Your Name"
-msgstr ""
+msgstr "Votre Nom"
 
 msgid ""
 "Invalid file game type. Please ensure that you are running the latest type "
 "of save files."
 msgstr ""
+"Type de jeu de fichier non valide. Assurez-vous que vous avez le dernier "
+"type de fichiers de sauvegarde."
 
 msgid ""
 "This file is saved in the \"The Price of Loyalty\" version.\n"
 "Some items may be unavailable."
 msgstr ""
+"Ce fichier est enregistré dans la version « Le prix de la fidélité ».\n"
+"Certains éléments peuvent ne pas être disponibles."
 
 msgid "Hot Seat"
-msgstr ""
+msgstr "Hot Seat"
 
 msgid ""
 "Play a Hot Seat game, where 2 to 4 players play around the same computer, "
 "switching into the 'Hot Seat' when it is their turn."
 msgstr ""
+"Jouez à un jeu Hot Seat, où 2 à 4 joueurs jouent autour du même ordinateur, "
+"passant au « Hot Seat » lorsque c’est leur tour."
 
 msgid "Cancel back to the main menu."
 msgstr "Annuler et revenir au menu principal."
@@ -2257,18 +2385,20 @@ msgid ""
 "Play a network game, where 2 players use their own computers connected "
 "through a LAN (Local Area Network)."
 msgstr ""
+"Jouez à un jeu en réseau, où 2 joueurs utilisent leurs propres ordinateurs "
+"connectés via un réseau local (LAN)."
 
 msgid "Standard Game"
 msgstr "Jeu standard"
 
 msgid "A single player game playing out a single map."
-msgstr ""
+msgstr "Un jeu solo jouant sur une seule carte."
 
 msgid "Campaign Game"
 msgstr "Mode Campagne"
 
 msgid "A single player game playing through a series of maps."
-msgstr ""
+msgstr "Un jeu solo jouant à travers une série de cartes."
 
 msgid "Multi-Player Game"
 msgstr "Jeu Multi-joueur"
@@ -2277,23 +2407,27 @@ msgid ""
 "A multi-player game, with several human players completing against each "
 "other on a single map."
 msgstr ""
+"Un jeu multi-joueurs, avec plusieurs joueurs humains se complétant les uns "
+"contre les autres sur une seule carte."
 
 msgid "Greetings!"
-msgstr ""
+msgstr "Salutations !"
 
 msgid ""
 "Welcome to Free Heroes of Might and Magic II! Before starting the game "
 "please choose game resolution."
 msgstr ""
+"Bienvenue à Free Heroes of Might and Magic II! Avant de commencer le jeu "
+"choissisez la résolution d'écran."
 
 msgid "Please Remember"
-msgstr ""
+msgstr "N'oubliez pas"
 
 msgid "You can always change game resolution by clicking on the "
-msgstr ""
+msgstr "Vous pouvez toujours changer la résolution du jeu en cliquant sur le "
 
 msgid "door"
-msgstr ""
+msgstr "porte"
 
 msgid ""
 " on the left side of main menu.\n"
@@ -2301,15 +2435,22 @@ msgid ""
 "To switch between windowed and full screen modes\n"
 "press "
 msgstr ""
+" sur le côté gauche du menu principal.\n"
+"\n"
+"Pour basculer entre le mode fenêtré et le mode plein écran\n"
+"appuyiez "
 
 msgid "F4"
-msgstr ""
+msgstr "F4"
 
 msgid ""
 " key on the keyboard.\n"
 "\n"
 "Enjoy the game!"
 msgstr ""
+" sur le clavier.\n"
+"\n"
+"Profitez du jeu !"
 
 msgid "Quit Heroes of Might and Magic and return to the operating system."
 msgstr ""
@@ -2319,33 +2460,37 @@ msgid "Credits"
 msgstr "Crédits"
 
 msgid "View the credits screen."
-msgstr "Voir l'écran des crédits"
+msgstr "Voir l'écran des crédits."
 
 msgid "High Scores"
 msgstr "Meilleurs scores"
 
 msgid "View the high score screen."
-msgstr "Voir l'écran des meilleurs scores"
+msgstr "Voir l'écran des meilleurs scores."
 
 msgid "Select Game Resolution"
-msgstr ""
+msgstr "Choisir la résolution d'écran"
 
 msgid "Change resolution of the game."
-msgstr ""
+msgstr "Charger la résolution d'écran."
 
 msgid "Original Campaign"
-msgstr ""
+msgstr "Campagne Originale"
 
 msgid ""
 "Either Roland's or Archibald's campaign from the original Heroes of Might "
 "and Magic II."
 msgstr ""
+"La campagne de Roland ou d’Archibald du jeu original Heros of Might and "
+"Magic II."
 
 msgid "Expansion Campaign"
-msgstr ""
+msgstr "Campagne Expansion"
 
 msgid "One of the four new campaigns from the Price of Loyalty expansion set."
 msgstr ""
+"L’une des quatre nouvelles campagnes de l’ensemble d’extension Price of "
+"Loyalty."
 
 msgid "Host"
 msgstr "Hôte"
@@ -2354,6 +2499,8 @@ msgid ""
 "The host sets up the game options. There can only be one host per network "
 "game."
 msgstr ""
+"L’hôte configure les options de jeu. Il ne peut y avoir qu’un seul hôte par "
+"jeu en réseau."
 
 msgid "Guest"
 msgstr "Invité"
@@ -2362,18 +2509,20 @@ msgid ""
 "The guest waits for the host to set up the game, then is automatically added "
 "in. There can be multiple guests for TCP/IP games."
 msgstr ""
+"L’invité attend que l’hôte configure le jeu, puis est automatiquement "
+"ajouté. Il peut y avoir plusieurs invités pour les jeux TCP/IP."
 
 msgid "Battle Only"
-msgstr ""
+msgstr "Combat unique"
 
 msgid "Setup and play a battle without loading any map."
-msgstr ""
+msgstr "Configurez et jouez une bataille sans charger de carte."
 
 msgid "Settings"
-msgstr ""
+msgstr "Paramètres"
 
 msgid "Experimental game settings."
-msgstr ""
+msgstr "Paramètres du jeu expérimentales."
 
 msgid "2 Players"
 msgstr "2 Joueurs"
@@ -2382,6 +2531,8 @@ msgid ""
 "Play with 2 human players, and optionally, up, to 4 additional computer "
 "players."
 msgstr ""
+"Jouez avec 2 joueurs humains, et éventuellement, jusqu’à 4 joueurs CPU "
+"supplémentaires."
 
 msgid "3 Players"
 msgstr "3 Joueurs"
@@ -2390,6 +2541,8 @@ msgid ""
 "Play with 3 human players, and optionally, up, to 3 additional computer "
 "players."
 msgstr ""
+"Jouez avec 3 joueurs humains, et éventuellement, jusqu’à 3 joueurs CPU "
+"supplémentaires."
 
 msgid "4 Players"
 msgstr "4 Joueurs"
@@ -2398,6 +2551,8 @@ msgid ""
 "Play with 4 human players, and optionally, up, to 2 additional computer "
 "players."
 msgstr ""
+"Jouez avec 4 joueurs humains, et éventuellement, jusqu’à 2 joueurs CPU "
+"supplémentaires."
 
 msgid "5 Players"
 msgstr "5 Joueurs"
@@ -2406,57 +2561,61 @@ msgid ""
 "Play with 5 human players, and optionally, up, to 1 additional computer "
 "players."
 msgstr ""
+"Jouez avec 5 joueurs humains, et éventuellement, jusqu’à 1 joueurs CPU "
+"supplémentaires."
 
 msgid "6 Players"
 msgstr "6 Joueurs"
 
 msgid "Play with 6 human players."
-msgstr ""
+msgstr "Jouer avec 6 joueurs humains."
 
-#, fuzzy
 msgid "Defeat all enemy heroes and capture all enemy towns and castles."
-msgstr "Détruisez tous les héros et villes ennemis"
+msgstr "Détruisez tous les héros et capturez tous les villages ennemis."
 
 msgid "Run out of time. (Fail to win by a certain point.)"
-msgstr ""
+msgstr "Manquer de temps. (Ne pas gagner avant un certain point.)"
 
 msgid "Capture the castle '%{name}'"
-msgstr ""
+msgstr "Capturez le château '%{name}'"
 
 msgid "Capture the town '%{name}'"
-msgstr ""
+msgstr "Capturez le village '%{name}'"
 
 msgid "Defeat the hero '%{name}'"
-msgstr ""
+msgstr "Détruisez le héros '%{name}'"
 
 msgid "Find the ultimate artifact"
-msgstr ""
+msgstr "Trouvez l'Artefact Ultime"
 
 msgid "Find the '%{name}' artifact"
-msgstr ""
+msgstr "Trouvez un artéfact '%{name}'"
 
 msgid "Accumulate %{count} gold"
-msgstr ""
+msgstr "Amassez %{count} d'or"
 
 msgid ""
 ", or you may win by defeating all enemy heroes and capturing all enemy towns "
 "and castles."
 msgstr ""
+", vous pouvez également gagner en battant tous les héros ennemis et en "
+"capturant tous les villages et tous les châteaux ennemis."
 
 msgid "Lose the castle '%{name}'."
-msgstr ""
+msgstr "Perdre le château '%{name}'."
 
 msgid "Lose the town '%{name}'."
-msgstr ""
+msgstr "Perdre le village de '%{name}'."
 
 msgid "Lose the hero: %{name}."
-msgstr ""
+msgstr "Perdre le héros : %{name}."
 
 msgid "Fail to win by the end of month %{month}, week %{week}, day %{day}."
 msgstr ""
+"Ne pas gagner d’ici la fin du mois %{month}, semaine %{week}, jour %{day}."
 
 msgid "Lose the heroes: %{name}."
-msgstr ""
+msgstr "Perdez un village spécifique."
 
 msgid ""
 "You captured %{name}!\n"
@@ -2483,47 +2642,63 @@ msgid ""
 "The enemy is beaten.\n"
 "Your side has triumphed!"
 msgstr ""
+"L’ennemi est battu.\n"
+"Votre camp a triomphé !"
 
 msgid ""
 "You have built up over %{count} gold in your treasury.\n"
 "All enemies bow before your wealth and power."
 msgstr ""
+"Vous avez accumulé plus de %{count} d’or dans votre trésorerie.\n"
+"Tous les ennemis s’inclinent devant votre richesse et votre puissance."
 
 msgid ""
 "The enemy has found the %{name}.\n"
 "Your quest is a failure."
 msgstr ""
+"L’ennemi a trouvé la %{name}.\n"
+"Votre quête est un échec."
 
 msgid ""
 "%{color} has fallen!\n"
 "All is lost."
 msgstr ""
+"%{color} est vaincu !\n"
+"Tout est perdu."
 
 msgid ""
 "The enemy has built up over %{count} gold in his treasury.\n"
 "You must bow done in defeat before his wealth and power."
 msgstr ""
+"L’ennemi a accumulé plus de %{count}'or dans son trésor.\n"
+"Vous devez vous incliner dans la défaite devant sa richesse et son pouvoir."
 
 msgid "You have been eliminated from the game!!!"
-msgstr ""
+msgstr "Vous avez été éliminé du jeu !!!"
 
 msgid ""
 "The enemy has captured %{name}!\n"
 "They are triumphant."
 msgstr ""
+"L'ennemi a capturé %{name} !\n"
+"Ils sont triomphants."
 
 msgid ""
 "You have lost the hero %{name}.\n"
 "Your quest is over."
 msgstr ""
+"Vous avez perdu le héros %{name} .\n"
+"Votre quête est terminée."
 
 msgid ""
 "You have failed to complete your quest in time.\n"
 "All is lost."
 msgstr ""
+"Vous n'avez pas réussi à terminer votre quête à temps.\n"
+"Tout est perdu."
 
 msgid "%{color} player has been vanquished!"
-msgstr ""
+msgstr "Le %{color} a été vaincu !"
 
 msgid "Warning"
 msgstr "Attention"
@@ -2532,513 +2707,577 @@ msgid "No maps available!"
 msgstr "Pas de carte disponible!"
 
 msgid "Scenario"
-msgstr ""
+msgstr "Scénario"
 
 msgid "Click here to select which scenario to play."
-msgstr ""
+msgstr "Cliquez ici pour sélectionner le scénario à jouer."
 
 msgid "Game Difficulty"
-msgstr ""
+msgstr "Difficulté de Jeu"
 
 msgid ""
 "This lets you change the starting difficulty at which you will play. Higher "
 "difficulty levels start you of with fewer resources, and at the higher "
 "settings, give extra resources to the computer."
 msgstr ""
+"Vous permet de modifier la difficulté de départ à laquelle vous allez jouer. "
+"Les niveaux de difficulté plus élevés vous commencent avec moins de "
+"ressources et, aux paramètres plus élevés, donnez des ressources "
+"supplémentaires à l’ordinateur."
 
 msgid "Difficulty Rating"
-msgstr ""
+msgstr "Taux de Difficulté"
 
 msgid ""
 "The difficulty rating reflects a combination of various settings for your "
 "game. This number will be applied to your final score."
 msgstr ""
+"La note de difficulté reflète une combinaison de différents paramètres pour "
+"votre jeu. Cette note sera appliqué à votre score final."
 
 msgid "Click to accept these settings and start a new game."
-msgstr ""
+msgstr "Cliquez pour accepter ces paramètres et démarrer un nouveau jeu."
 
 msgid "Click to return to the main menu."
-msgstr ""
+msgstr "Cliquez pour revenir au menu principal."
 
 msgid "Scenario:"
-msgstr ""
+msgstr "Scénario :"
 
 msgid "Game Difficulty:"
-msgstr ""
+msgstr "Difficulté de jeu:"
 
 msgid "Opponents:"
-msgstr ""
+msgstr "Opposants:"
 
 msgid "Class:"
-msgstr ""
+msgstr "Classe:"
 
 msgid "Rating %{rating}%"
-msgstr ""
+msgstr "Taux %{rating}%"
 
 msgid "Astrologers proclaim Month of the %{name}."
-msgstr ""
+msgstr "Les astrologues proclament le mois de %{name}."
 
 msgid "Astrologers proclaim Week of the %{name}."
-msgstr ""
+msgstr "Les astrologues proclament la Semaine de %{name}."
 
 msgid "After regular growth, population of %{monster} is doubled!"
 msgstr ""
+"Après une croissance régulière, la population de %{monster} est doublée!"
 
 msgid " All populations are halved."
-msgstr ""
+msgstr " Toutes les populations sont réduites de moitié."
 
 msgid " All dwellings increase population."
-msgstr ""
+msgstr " Tous les logements augmentent la population."
 
 msgid ""
 "%{color} player, your heroes abandon you, and you are banished from this "
 "land."
 msgstr ""
+"%{color}, vos héros vous abandonnent et vous êtes banni de cette terre."
 
 msgid ""
 "%{color} player, this is your last day to capture a town, or you will be "
 "banished from this land."
 msgstr ""
+"%{color}, c’est votre dernier jour pour capturer une ville, ou vous serez "
+"banni de cette terre."
 
 msgid ""
 "%{color} player, you only have %{day} days left to capture a town, or you "
 "will be banished from this land."
 msgstr ""
+"%{color} joueur, il ne vous reste que %{day} jours pour capturer un village, "
+"sinon vous serez banni de cette terre."
 
 msgid "%{color} player's turn."
-msgstr ""
+msgstr "tour de %{color}."
 
 msgid ""
 "%{color} player, you have lost your last town. If you do not conquer another "
 "town in next week, you will be eliminated."
 msgstr ""
+"Joueur %{color}, vous venez de perdre votre dernier village. Si vous n'avez "
+"pas de village dans une semaine, vous serez éliminés."
 
 msgid "Next Hero"
-msgstr ""
+msgstr "Héros suivant"
 
 msgid "Select the next Hero."
-msgstr ""
+msgstr "Choisir le héros suivant."
 
 msgid "Continue Movement"
-msgstr ""
+msgstr "Continuer le mouvement"
 
 msgid "Continue the Hero's movement along the current path."
-msgstr ""
+msgstr "Continuez le mouvement du Héros le long du chemin actuel."
 
 msgid "Kingdom Summary"
-msgstr ""
+msgstr "Résumé de Royaume"
 
 msgid "View a Summary of your Kingdom."
-msgstr ""
+msgstr "Voir un résumé de votre Royaume."
 
 msgid "Cast an adventure spell."
-msgstr ""
+msgstr "Lancer un sort d'aventure."
 
 msgid "End Turn"
-msgstr ""
+msgstr "Fin du tour"
 
 msgid "End your turn and left the computer take its turn."
-msgstr ""
+msgstr "Terminez votre tour et laissez l'ordinateur faire son tour."
 
 msgid "Adventure Options"
-msgstr ""
+msgstr "Options d'aventure"
 
 msgid "Bring up the adventure options menu."
-msgstr ""
+msgstr "Faites apparaître le menu des options d’aventure."
 
 msgid "File Options"
 msgstr "Fichier d'options"
 
 msgid "Bring up the file options menu, alloving you to load menu, save etc."
 msgstr ""
+"Affiche le menu des options du fichier, qui vous permet de charger, "
+"sauvegarder, etc."
 
 msgid "System Options"
 msgstr "Options du système"
 
 msgid "Bring up the system options menu, alloving you to customize your game."
 msgstr ""
+"Affiche  le menu des options du système, qui vous permet de personnaliser "
+"votre jeu."
 
 msgid ""
 "One or more heroes may still move, are you sure you want to end your turn?"
 msgstr ""
+"Un ou plusieurs héros peuvent encore bouger, êtes-vous sûr de vouloir "
+"terminer votre tour ?"
 
 msgid "Are you sure you want to quit?"
 msgstr "Êtes vous sur de vouloir quitter?"
 
-#, fuzzy
 msgid "Are you sure you want to restart? (Your current game will be lost.)"
-msgstr "Êtes vous sur de vouloir sonner la retraite?"
+msgstr ""
+"Êtes vous sur de vouloir recommencer (Votre partie en cours sera perdue)?"
 
 msgid "Are you sure you want to overwrite the save with this name?"
-msgstr ""
+msgstr "Voulez-vous vraiment sur de vouloir remplacer cette sauvegarde?"
 
 msgid "Game saved successfully."
-msgstr ""
+msgstr "Sauvegarde réussie."
 
 msgid "There was an issue during saving."
-msgstr ""
+msgstr "Il y a eu un problème lors de la sauvegarde."
 
-#, fuzzy
 msgid ""
 "Are you sure you want to load a new game? (Your current game will be lost.)"
-msgstr "Êtes vous sur de vouloir effacer le fichier :"
+msgstr ""
+"Êtes-vous sûr de vouloir charger une nouvelle partie ? (Votre partie en "
+"cours sera perdue)?"
 
 msgid "Try looking on land!!!"
-msgstr ""
+msgstr "Essayez de chercher sur terre !!!"
 
 msgid ""
 "After spending many hours digging here, you have uncovered the %{artifact}."
 msgstr ""
+"Après avoir passé de nombreuses heures à creuser ici, vous avez découvert le "
+"%{artifact}."
 
 msgid "Congratulations!"
-msgstr ""
+msgstr "Félicitations !"
 
 msgid "Nothing here. Where could it be?"
-msgstr ""
+msgstr "Rien ici. Où cela pourrait-il être ?"
 
 msgid "Try searching on clear ground."
-msgstr ""
+msgstr "Essayez de chercher sur un terrain dégagé."
 
 msgid "Digging for artifacts requires a whole day, try again tomorrow."
 msgstr ""
+"La fouille pour les artefacts nécessite une journée entière, réessayez "
+"demain."
 
 msgid "World Map"
-msgstr ""
+msgstr "Carte du monde"
 
 msgid "A miniature view of the known world. Left click to move viewing area."
 msgstr ""
+"Une vue miniature du monde connu. Cliquez avec le bouton gauche de la souris "
+"pour déplacer la zone d’affichage."
 
 msgid "Month: %{month} Week: %{week}"
-msgstr ""
+msgstr "Mois : %{month} Semaine : %{week}"
 
 msgid "Day: %{day}"
-msgstr ""
+msgstr "Jour : %{day}"
 
 msgid ""
 "You find a small\n"
 "quantity of %{resource}."
 msgstr ""
+"Vous trouvez une petite\n"
+"quantité de %{ressource}."
 
 msgid "Status Window"
-msgstr ""
+msgstr "Fenêtre d'état"
 
 msgid ""
 "This window provides information on the status of your hero or kingdom, and "
 "shows the date."
 msgstr ""
+"Cette fenêtre fournit des informations sur le statut de votre héros ou "
+"royaume, et affiche la date."
 
 msgid ""
 "This window provides information on the status of your hero or kingdom, and "
 "shows the date. Left click here to cycle throungh these windows."
 msgstr ""
+"Cette fenêtre fournit des informations sur le statut de votre héros ou "
+"royaume, et affiche la date. Faites un clic gauche ici pour faire un cycle "
+"throungh ces fenêtres."
 
 msgid "Necroman"
-msgstr ""
+msgstr "Nécromancie"
 
 msgid ""
 "This lets you change player starting positions and colors. A particular "
 "color will always start in a particular location. Some positions may only be "
 "played by a computer player or only by a human player."
 msgstr ""
+"Cela vous permet de changer les positions de départ et les couleurs du "
+"joueur. Une couleur particulière commencera toujours dans un emplacement "
+"particulier. Certaines positions ne peuvent être jouées que par un joueur "
+"d’ordinateur ou uniquement par un joueur humain."
 
 msgid ""
 "This lets you change the class of a player. Classes are not always "
 "changeable. Depending on the scenario, a player may receive additional towns "
 "and/or heroes not of their primary alignment."
 msgstr ""
+"Ceci vous permet de changer la classe d'un joueur. Les classes ne sont pas "
+"toujours modifiables. Selon le scénario, un joueur peut recevoir des "
+"villages et/ou des héros supplémentaires qui ne sont pas de son alignement "
+"principal."
 
 msgid "%{color} player"
-msgstr ""
+msgstr "Joueur %{color}"
 
-#, fuzzy
 msgid "View %{skill} Info"
-msgstr "voir les infos de %{name} info."
+msgstr "Voir les infos de %{skill}"
 
 msgid "Lord Kilburn"
-msgstr ""
+msgstr "Lord Kilburn"
 
 msgid "Sir Gallant"
-msgstr ""
+msgstr "Sir Gallant"
 
 msgid "Ector"
-msgstr ""
+msgstr "Ector"
 
 msgid "Gwenneth"
-msgstr ""
+msgstr "Gwenneth"
 
 msgid "Tyro"
-msgstr ""
+msgstr "Tyro"
 
 msgid "Ambrose"
-msgstr ""
+msgstr "Ambrose"
 
 msgid "Ruby"
-msgstr ""
+msgstr "Ruby"
 
 msgid "Maximus"
-msgstr ""
+msgstr "Maximus"
 
 msgid "Dimitry"
-msgstr ""
+msgstr "Dimitry"
 
 msgid "Thundax"
-msgstr ""
+msgstr "Thundax"
 
 msgid "Fineous"
-msgstr ""
+msgstr "Fineous"
 
 msgid "Jojosh"
-msgstr ""
+msgstr "Jojosh"
 
 msgid "Crag Hack"
-msgstr ""
+msgstr "Crag Hack"
 
 msgid "Jezebel"
-msgstr ""
+msgstr "Jezebel"
 
 msgid "Jaclyn"
-msgstr ""
+msgstr "Jaclyn"
 
 msgid "Ergon"
-msgstr ""
+msgstr "Ergon"
 
 msgid "Tsabu"
-msgstr ""
+msgstr "Tsabu"
 
 msgid "Atlas"
-msgstr ""
+msgstr "Atlas"
 
 msgid "Astra"
-msgstr ""
+msgstr "Astra"
 
 msgid "Natasha"
-msgstr ""
+msgstr "Natasha"
 
 msgid "Troyan"
-msgstr ""
+msgstr "Troyan"
 
 msgid "Vatawna"
-msgstr ""
+msgstr "Vatawna"
 
 msgid "Rebecca"
-msgstr ""
+msgstr "Rebecca"
 
 msgid "Gem"
-msgstr ""
+msgstr "Gem"
 
 msgid "Ariel"
-msgstr ""
+msgstr "Ariel"
 
 msgid "Carlawn"
-msgstr ""
+msgstr "Carlawn"
 
 msgid "Luna"
-msgstr ""
+msgstr "Luna"
 
 msgid "Arie"
-msgstr ""
+msgstr "Arie"
 
 msgid "Alamar"
-msgstr ""
+msgstr "Alamar"
 
 msgid "Vesper"
-msgstr ""
+msgstr "Vesper"
 
 msgid "Crodo"
-msgstr ""
+msgstr "Crodo"
 
 msgid "Barok"
-msgstr ""
+msgstr "Barok"
 
 msgid "Kastore"
-msgstr ""
+msgstr "Kastore"
 
 msgid "Agar"
-msgstr ""
+msgstr "Agar"
 
 msgid "Falagar"
-msgstr ""
+msgstr "Falagar"
 
 msgid "Wrathmont"
-msgstr ""
+msgstr "Wrathmont"
 
 msgid "Myra"
-msgstr ""
+msgstr "Myra"
 
 msgid "Flint"
-msgstr ""
+msgstr "Flint"
 
 msgid "Dawn"
-msgstr ""
+msgstr "Dawn"
 
 msgid "Halon"
-msgstr ""
+msgstr "Halon"
 
 msgid "Myrini"
-msgstr ""
+msgstr "Myrini"
 
 msgid "Wilfrey"
-msgstr ""
+msgstr "Wilfrey"
 
 msgid "Sarakin"
-msgstr ""
+msgstr "Sarakin"
 
 msgid "Kalindra"
-msgstr ""
+msgstr "Kalindra"
 
 msgid "Mandigal"
-msgstr ""
+msgstr "Mandigal"
 
 msgid "Zom"
-msgstr ""
+msgstr "Zom"
 
 msgid "Darlana"
-msgstr ""
+msgstr "Darlana"
 
 msgid "Zam"
-msgstr ""
+msgstr "Zam"
 
 msgid "Ranloo"
-msgstr ""
+msgstr "Ranloo"
 
 msgid "Charity"
-msgstr ""
+msgstr "Charity"
 
 msgid "Rialdo"
-msgstr ""
+msgstr "Rialdo"
 
 msgid "Roxana"
-msgstr ""
+msgstr "Roxana"
 
 msgid "Sandro"
-msgstr ""
+msgstr "Sandro"
 
 msgid "Celia"
-msgstr ""
+msgstr "Celia"
 
 msgid "Roland"
-msgstr ""
+msgstr "Roland"
 
 msgid "Lord Corlagon"
-msgstr ""
+msgstr "Lord Corlagon"
 
 msgid "Sister Eliza"
-msgstr ""
+msgstr "Soeur Eliza"
 
 msgid "Archibald"
-msgstr ""
+msgstr "Archibald"
 
 msgid "Lord Halton"
-msgstr ""
+msgstr "Lord Halton"
 
 msgid "Brother Brax"
-msgstr ""
+msgstr "Frère Brax"
 
 msgid "Solmyr"
-msgstr ""
+msgstr "Solmyr"
 
 msgid "Dainwin"
-msgstr ""
+msgstr "Dainwin"
 
 msgid "Mog"
-msgstr ""
+msgstr "Mog"
 
 msgid "Joseph"
-msgstr ""
+msgstr "Joseph"
 
 msgid "Gallavant"
-msgstr ""
+msgstr "Gallavant"
 
 msgid "Elderian"
-msgstr ""
+msgstr "Elderian"
 
 msgid "Ceallach"
-msgstr ""
+msgstr "Ceallach"
 
 msgid "Drakonia"
-msgstr ""
+msgstr "Drakonia"
 
 msgid "Martine"
-msgstr ""
+msgstr "Martine"
 
 msgid "Jarkonas"
-msgstr ""
+msgstr "Jarkonas"
 
 msgid "%{object} robber"
-msgstr ""
+msgstr "%{objet} voleur"
 
 msgid "%{object} raided"
-msgstr ""
+msgstr "%{objet} attaqué"
 
 msgid "You cannot pick up this artifact, you already have a full load!"
 msgstr ""
+"Vous ne pouvez pas ramasser cet artefact, vous avez déjà une charge complète!"
 
 msgid "The three Anduran artifacts magically combine into one."
-msgstr ""
+msgstr "Les trois artefacts anduriens se combinent magiquement en un seul."
 
 msgid "To cast spells, you must first buy a spell book for %{gold} gold."
 msgstr ""
+"Pour lancer des sorts, vous devez d'abord acheter un livre de sorts pour "
+"%{gold} or."
 
 msgid "Unfortunately, you seem to be a little short of cash at the moment."
 msgstr ""
+"Malheureusement, vous semblez être un peu à court d’argent pour le moment."
 
 msgid "Do you wish to buy one?"
-msgstr ""
+msgstr "Voulez-vous en acheter un ?"
 
 msgid "%{count} / day"
-msgstr ""
+msgstr "%{count} / jour"
 
 msgid "You are unable to recruit at this time, your ranks are full."
 msgstr ""
+"Vous n’êtes pas en mesure de recruter pour le moment, vos rangs sont pleins."
 
 msgid "A whirlpool engulfs your ship."
-msgstr ""
+msgstr "Un tourbillon engloutit votre vaisseau."
 
 msgid "Some of your army has fallen overboard."
-msgstr ""
+msgstr "Une partie de votre armée est tombée par-dessus du bord."
 
 msgid "Insulted by your refusal of their offer, the monsters attack!"
-msgstr ""
+msgstr "Insultés par votre refus de leur offre, les monstres attaquent !"
 
 msgid ""
 "The %{monster}, awed by the power of your forces, begin to scatter.\n"
 "Do you wish to pursue and engage them?"
 msgstr ""
+"Les %{monstres}, impressionnés par la puissance de vos forces, commencent à "
+"se disperser.\n"
+"Voulez-vous les poursuivre et les attaquer ?"
 
 msgid "Ransacking an enemy camp, you discover a hidden cache of treasures."
-msgstr ""
+msgstr "En fouillant le camp, vous découvrez des trésors cachés."
 
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with these resources, "
 "come back next week for more.\""
 msgstr ""
+"Le gardien du moulin annonce :\n"
+"\"Milord, j'ai travaillé très dur pour vous fournir ces ressources, revenez "
+"la semaine prochaine pour en avoir plus.\""
 
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there are no resources currently available. Please try "
 "again next week.\""
 msgstr ""
+"Le gardien du moulin annonce :\n"
+"\"Milord, je suis désolé, il n'y a pas de ressources disponibles "
+"actuellement. Veuillez réessayer la semaine prochaine.\""
 
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I have been working very hard to provide you with this gold, come "
 "back next week for more.\""
 msgstr ""
+"Le gardien du moulin annonce :\n"
+"\"Milord, j'ai travaillé très dur pour vous fournir cet or, revenez la "
+"semaine prochaine pour en avoir plus.\""
 
 msgid ""
 "The keeper of the mill announces:\n"
 "\"Milord, I am sorry, there is no gold currently available. Please try again "
 "next week.\""
 msgstr ""
+"Le gardien du moulin annonce :\n"
+"\"Milord, je suis désolé, il n'y a pas d'or disponible actuellement. "
+"Veuillez réessayer la semaine prochaine.\""
 
 msgid ""
 "You've found an abandoned lean-to.\n"
 "Poking about, you discover some resources hidden nearby."
 msgstr ""
+"Vous avez trouvé un appentis abandonné.\n"
+"En le fouillant, vous découvrez des ressources cachées à proximité."
 
 msgid "The lean-to is long abandoned. There is nothing of value here."
 msgstr ""
+"L'appentis est abandonné depuis longtemps. Il n'y a rien de valeur ici."
 
 msgid ""
 "You catch a leprechaun foolishly sleeping amidst a cluster of magic "
@@ -3046,143 +3285,198 @@ msgid ""
 "In exchange for his freedom, he guides you to a small pot filled with "
 "precious things."
 msgstr ""
+"Vous attrapez un lutin qui dort bêtement au milieu d'un amas de champignons "
+"magiques.\n"
+"En échange de sa liberté, il vous guide vers un petit pot rempli de choses "
+"précieuses."
 
 msgid ""
 "You've found a magic garden, the kind of place that leprechauns and faeries "
 "like to cavort in, but there is no one here today.\n"
 "Perhaps you should try again next week."
 msgstr ""
+"Vous avez trouvé un jardin magique, le genre d'endroit où les lutins et les "
+"fées aiment s'ébattre, mais il n'y a personne aujourd'hui.\n"
+"Vous devriez peut-être réessayer la semaine prochaine."
 
 msgid "You come upon the remains of an unfortunate adventurer."
-msgstr ""
+msgstr "Vous tombez sur les restes d'un malheureux aventurier."
 
-#, fuzzy
 msgid "Treasure"
-msgstr "Trésors"
+msgstr "Trésor"
 
 msgid "Searching through the tattered clothing, you find %{artifact}."
-msgstr ""
+msgstr "En cherchant dans les vêtements en lambeaux, vous trouvez %{artifact}."
 
 msgid "Searching through the tattered clothing, you find nothing."
-msgstr ""
+msgstr "En cherchant dans les vêtements en lambeaux, vous ne trouvez rien."
 
 msgid ""
 "You come across an old wagon left by a trader who didn't quite make it to "
 "safe terrain."
 msgstr ""
+"Vous tombez sur un vieux chariot laissé par un commerçant qui n'a pas réussi "
+"à atteindre un terrain sûr."
 
 msgid "Unfortunately, others have found it first, and the wagon is empty."
 msgstr ""
+"Malheureusement, d'autres l'ont trouvé en premier, et le wagon est vide."
 
 msgid "Searching inside, you find the %{artifact}."
-msgstr ""
+msgstr "En cherchant à l'intérieur, vous trouvez le %{artifact}."
 
 msgid "Inside, you find some of the wagon's cargo still intact."
 msgstr ""
+"A l'intérieur, vous trouvez une partie de la cargaison du wagon encore "
+"intacte."
 
 msgid "You search through the flotsam, and find some wood and some gold."
-msgstr ""
+msgstr "Vous cherchez dans les débris, et vous  trouvez du bois et de l'or."
 
 msgid "You search through the flotsam, and find some wood."
-msgstr ""
+msgstr "Vous cherchez dans les débris et trouvez du bois."
 
 msgid "You search through the flotsam, but find nothing."
-msgstr ""
+msgstr "Vous cherchez parmi les débris, mais ne trouvez rien."
 
 msgid "Shrine of the 1st Circle"
-msgstr ""
+msgstr "Lieu saint du 1-er Cercle"
 
 msgid ""
 "You come across a small shrine attended by a group of novice acolytes.\n"
 "In exchange for your protection, they agree to teach you a simple spell - "
 "'%{spell}'."
 msgstr ""
+"Vous tombez sur un petit sanctuaire fréquenté par un groupe d'acolytes "
+"novices.\n"
+"En échange de votre protection, ils acceptent de vous enseigner un sort "
+"simple - '%{spell}'."
 
 msgid "Shrine of the 2nd Circle"
-msgstr ""
+msgstr "Lieu saint du 2-ème Cercle"
 
 msgid ""
 "You come across an ornate shrine attended by a group of rotund friars.\n"
 "In exchange for your protection, they agree to teach you a spell - "
 "'%{spell}'."
 msgstr ""
+"Vous tombez sur un sanctuaire orné, fréquenté par un groupe de frères "
+"corpulents.\n"
+"En échange de votre protection, ils acceptent de vous enseigner un sort - "
+"'%{spell}'."
 
 msgid "Shrine of the 3rd Circle"
-msgstr ""
+msgstr "Lieu saint du 3-ème Cercle"
 
 msgid ""
 "You come across a lavish shrine attended by a group of high priests.\n"
 "In exchange for your protection, they agree to teach you a sophisticated "
 "spell - '%{spell}'."
 msgstr ""
+"Vous tombez sur un sanctuaire somptueux fréquenté par un groupe de grands "
+"prêtres.\n"
+"En échange de votre protection, ils acceptent de vous enseigner un sort "
+"sophistiqué - '%{spell}'."
 
 msgid ""
 "\n"
 "Unfortunately, you have no Magic Book to record the spell with."
 msgstr ""
+"\n"
+"Malheureusement, vous n'avez pas de livre de magie pour enregistrer le sort."
 
 msgid ""
 "\n"
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
 msgstr ""
+"\n"
+"Malheureusement, vous n'avez pas la sagesse nécessaire pour comprendre ce "
+"sort et vous ne pouvez pas l'apprendre."
 
 msgid ""
 "\n"
 "Unfortunately, you already have knowledge of this spell, so there is nothing "
 "more for them to teach you."
 msgstr ""
+"\n"
+"Malheureusement, vous connaissez déjà ce sort, il n'y a donc rien de plus à "
+"vous apprendre."
 
 msgid ""
 "You approach the hut and observe a witch inside studying an ancient tome on "
 "%{skill}.\n"
 " \n"
 msgstr ""
+"Vous vous approchez de la hutte et observez une sorcière à l'intérieur qui "
+"étudie un tome ancien sur %{skill}.\n"
 
 msgid ""
 "As you approach, she turns and focuses her one glass eye on you.\n"
 "\"You already know everything you deserve to learn!\" the witch screeches. "
 "\"NOW GET OUT OF MY HOUSE!\""
 msgstr ""
+"Quand vous vous approchez, elle se retourne et concentre son unique œil de "
+"verre sur vous.\n"
+"\"Tu sais déjà tout ce que tu mérites d'apprendre !\" hurle la sorcière. "
+"\"MAINTENANT, SORS DE CHEZ MOI !\""
 
 msgid ""
 "As you approach, she turns and speaks.\n"
 "\"You already know that which I would teach you. I can help you no further.\""
 msgstr ""
+"Lorsque vous vous approchez, elle se tourne et parle.\n"
+"\"Tu sais déjà ce que je voudrais t'enseigner. Je ne peux pas t'aider "
+"davantage.\""
 
 msgid ""
 "An ancient and immortal witch living in a hut with bird's legs for stilts "
 "teaches you %{skill} for her own inscrutable purposes."
 msgstr ""
+"Une sorcière ancienne et immortelle vivant dans une hutte avec des pattes "
+"d'oiseau en guise d'échasses vous enseigne %{skill} pour ses propres "
+"objectifs impénétrables."
 
 msgid "You drink from the enchanted fountain, but nothing happens."
-msgstr ""
+msgstr "Tu bois à la fontaine enchantée, mais rien ne se passe."
 
 msgid "As you drink the sweet water, you gain luck for your next battle."
 msgstr ""
+"En buvant l'eau douce, vous gagnez de la chance pour votre prochaine "
+"bataille."
 
 msgid "You enter the faerie ring, but nothing happens."
-msgstr ""
+msgstr "Vous entrez dans l'anneau des fées, mais rien ne se passe."
 
 msgid ""
 "Upon entering the mystical faerie ring, your army gains luck for its next "
 "battle."
 msgstr ""
+"En entrant dans l'anneau mystique des fées, votre armée gagne de la chance "
+"pour sa prochaine bataille."
 
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "It is supposed to grant luck to visitors, but since the stars are already "
 "smiling upon you, it does nothing."
 msgstr ""
+"Vous avez trouvé une ancienne idole de pierre usée par le temps.\n"
+"Elle est censée porter chance aux visiteurs, mais comme les étoiles vous "
+"sourient déjà, elle ne fait rien."
 
 msgid ""
 "You've found an ancient and weathered stone idol.\n"
 "Kissing it is supposed to be lucky, so you do. The stone is very cold to the "
 "touch."
 msgstr ""
+"Vous avez trouvé une idole en pierre ancienne et usée par le temps.\n"
+"L'embrasser est censé porter chance, alors vous le faites. La pierre est "
+"très froide au toucher."
 
 msgid "The mermaids silently entice you to return later and be blessed again."
 msgstr ""
+"Les sirènes vous tiquent silencieusement pour revenir plus tard et être "
+"bénis à nouveau."
 
 msgid ""
 "The magical, soothing beauty of the Mermaids reaches you and your crew.\n"
@@ -3190,6 +3484,12 @@ msgid ""
 "moment.\n"
 "The mermaids charms bless you with increased luck for your next combat."
 msgstr ""
+"La beauté magique et apaisante des sirènes vous atteint, vous et votre "
+"équipage.\n"
+"Pendant un instant, vous oubliez vos soucis et vous vous prélassez dans la "
+"beauté du moment.\n"
+"Les charmes des sirènes vous bénissent avec une chance accrue pour votre "
+"prochain combat."
 
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
@@ -3197,375 +3497,535 @@ msgid ""
 "fearful curses and undead guardians.\n"
 "Will you search?"
 msgstr ""
+"Vous tombez sur la pyramide d’un grand et ancien roi.\n"
+"Vous êtes tenté de le chercher à la recherche d’un trésor, mais toutes les "
+"vieilles histoires mettent en garde contre les malédictions effrayantes et "
+"les gardiens morts-vivants.\n"
+"Allez-vous chercher?"
 
 msgid ""
 "You come upon the pyramid of a great and ancient king.\n"
 "Routine exploration reveals that the pyramid is completely empty."
 msgstr ""
+"Vous tombez sur la pyramide d'un grand et ancien roi.\n"
+"Une exploration de routine révèle que la pyramide est complètement vide."
 
 msgid "Unfortunately, you have no Magic Book to record the spell with."
 msgstr ""
+"Malheureusement, vous n'avez pas de livre de magie pour enregistrer le sort."
 
 msgid ""
 "Unfortunately, you do not have the wisdom to understand the spell, and you "
 "are unable to learn it."
 msgstr ""
+"Malheureusement, vous n'avez pas la sagesse nécessaire pour comprendre ce "
+"sort et vous ne pouvez pas l'apprendre."
 
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
 "telling the secret of the spell."
 msgstr ""
+"Après avoir vaincu les monstres, vous déchiffrez un ancien glyphe sur le "
+"mur, qui révèle le secret du sort."
 
 msgid "Sign"
-msgstr ""
+msgstr "Signe"
 
 msgid ""
 "A drink at the well is supposed to restore your spell points, but you are "
 "already at maximum."
 msgstr ""
+"Un verre au puits est censé restaurer vos points de magie, mais vous êtes "
+"déjà au maximum."
 
 msgid "A second drink at the well in one day will not help you."
-msgstr ""
+msgstr "Un deuxième verre au puits en une journée ne vous aidera pas."
 
 msgid "A drink from the well has restored your spell points to maximum."
-msgstr ""
+msgstr "Une boisson du puits a restauré vos points de magie au maximum."
 
 msgid ""
 "\"I'm sorry sir,\" The leader of the soldiers says, \"but you already know "
 "everything we have to teach.\""
 msgstr ""
+"« Je suis désolé monsieur, dit le chef des soldats, mais vous savez déjà "
+"tout ce que nous avons à enseigner. »"
 
 msgid "The soldiers living in the fort teach you a few new defensive tricks."
 msgstr ""
+"Les soldats vivant dans le fort vous enseignent quelques nouvelles astuces "
+"défensives."
 
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. \"You're too "
 "advanced for us,\" the mercenary captain says. \"We can teach nothing more.\""
 msgstr ""
+"Vous êtes tombé sur un camp de mercenaires qui pratique leurs tactiques. "
+"« Vous êtes trop avancé pour nous », dit le capitaine mercenaire. « Nous ne "
+"pouvons rien apprendre de plus. »"
 
 msgid ""
 "You've come upon a mercenary camp practicing their tactics. The mercenaries "
 "welcome you and your troops and invite you to train with them."
 msgstr ""
+"Vous êtes tombé sur un camp de mercenaires qui pratique leurs tactiques. Les "
+"mercenaires vous accueillent, vous et vos troupes, et vous invitent à vous "
+"entraîner avec eux."
 
 msgid "\"Go 'way!\", the witch doctor barks, \"you know all I know.\""
-msgstr ""
+msgstr "« Partez! », aboie le sorcier, « vous savez tout ce que je sais. »"
 
 msgid ""
 "An Orcish witch doctor living in the hut deepens your knowledge of magic by "
 "showing you how to cast stones, read portents, and decipher the intricacies "
 "of chicken entrails."
 msgstr ""
+"Un sorcier Orc vivant dans la cabane approfondit votre connaissance de la "
+"magie en vous montrant comment jeter des pierres, lire des présages et "
+"déchiffrer les subtilités des entrailles de poulet."
 
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, the Druids turn you away, indicating they have nothing "
 "new to teach you."
 msgstr ""
+"Vous avez trouvé un groupe de druides en train de prier dans l'un de leurs "
+"étranges édifices de pierre. En silence, les druides vous repoussent, "
+"indiquant qu'ils n'ont rien de nouveau à vous apprendre."
 
 msgid ""
 "You've found a group of Druids worshipping at one of their strange stone "
 "edifices. Silently, they teach you new ways to cast spells."
 msgstr ""
+"Vous avez trouvé un groupe de druides en train de célébrer un culte dans "
+"l'un de leurs étranges édifices de pierre. En silence, ils vous enseignent "
+"de nouvelles façons de lancer des sorts."
 
 msgid ""
 "You tentatively approach the burial ground of ancient warriors. Do you want "
 "to search the graves?"
 msgstr ""
+"Vous vous approchez timidement du cimetière des anciens guerriers. Voulez-"
+"vous fouiller les tombes ?"
 
 msgid ""
 "Upon defeating the Zombies you spend several hours searching the graves and "
 "find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
+"Après avoir vaincu les zombies, vous passez plusieurs heures à fouiller les "
+"tombes sans rien trouver. Un tel acte méprisable réduit le moral de votre "
+"armée."
 
 msgid "Upon defeating the Zombies you search the graves and find something!"
 msgstr ""
+"Après avoir vaincu les zombies, fouillez les tombes et trouvez quelque "
+"chose !"
 
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the shipwreck?"
 msgstr ""
+"La coque en décomposition d'un grand bateau pirate grince sinistrement "
+"lorsqu'elle est poussée contre les rochers. Voulez-vous fouiller l'épave ?"
 
 msgid ""
 "Upon defeating the Ghosts you spend several hours sifting through the debris "
 "and find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
+"Après avoir vaincu les fantômes, vous passez plusieurs heures à fouiller les "
+"débris et ne trouvez rien. Un tel acte méprisable réduit le moral de votre "
+"armée."
 
 msgid ""
 "Upon defeating the Ghosts you sift through the debris and find something!"
 msgstr ""
+"Après avoir vaincu les fantômes, vous passez en revue les débris et trouver "
+"quelque chose !"
 
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
 "against the rocks. Do you wish to search the ship?"
 msgstr ""
+"La carcasse pourrie d'un grand bateau pirate grince sinistrement lorsqu'elle "
+"est poussée contre les rochers. Voulez-vous fouiller le navire ?"
 
 msgid ""
 "Upon defeating the Skeletons you spend several hours sifting through the "
 "debris and find nothing. Such a despicable act reduces your army's morale."
 msgstr ""
+"Après avoir vaincu les squelettes, vous passez plusieurs heures à fouiller "
+"les débris et ne trouvez rien. Un tel acte méprisable réduit le moral de "
+"votre armée."
 
 msgid ""
 "Upon defeating the Skeletons you sift through the debris and find something!"
 msgstr ""
+"Après avoir vaincu les squelettes, vous passez en revue les débris et "
+"trouver quelque chose !"
 
 msgid "Your men spot a navigational buoy, confirming that you are on course."
 msgstr ""
+"Vos hommes repèrent une bouée de navigation, confirmant que vous êtes sur la "
+"bonne voie."
 
 msgid ""
 "Your men spot a navigational buoy, confirming that you are on course and "
 "increasing their morale."
 msgstr ""
+"Vos hommes repèrent une bouée de navigation, confirmant que vous êtes sur la "
+"bonne voie et augmentant leur moral."
 
 msgid ""
 "The drink at the oasis is refreshing, but offers no further benefit. The "
 "oasis might help again if you fought a battle first."
 msgstr ""
+"La boisson à l'oasis est rafraîchissante, mais n'offre aucun autre avantage. "
+"L'oasis pourrait vous aider à nouveau si vous livriez d'abord une bataille."
 
 msgid ""
 "A drink at the oasis fills your troops with strength and lifts their "
 "spirits.  You can travel a bit further today."
 msgstr ""
+"Une boisson à l'oasis remplit vos troupes de force et leur remonte le "
+"moral.  Vous pouvez voyager un peu plus loin aujourd'hui."
 
 msgid ""
 "The drink at the watering hole is refreshing, but offers no further benefit. "
 "The watering hole might help again if you fought a battle first."
 msgstr ""
+"La boisson de l'abreuvoir est rafraîchissante, mais n'offre aucun autre "
+"avantage. L'abreuvoir pourrait vous aider à nouveau si vous vous battiez "
+"d'abord."
 
 msgid ""
 "A drink at the watering hole fills your troops with strength and lifts their "
 "spirits. You can travel a bit further today."
 msgstr ""
+"Un verre à l'abreuvoir donne de la force à vos troupes et leur remonte le "
+"moral. Vous pouvez voyager un peu plus loin aujourd'hui."
 
 msgid ""
 "It doesn't help to pray twice before a battle. Come back after you've fought."
 msgstr ""
+"Ça ne sert à rien de prier deux fois avant une bataille. Revenez après avoir "
+"combattu."
 
 msgid "A visit and a prayer at the temple raises the morale of your troops."
-msgstr ""
+msgstr "Une visite et une prière au temple remontent le moral de vos troupes."
 
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"I am sorry, my liege, I "
 "have taught you all I can.\""
 msgstr ""
+"Un vieux chevalier apparaît sur les marches du belvédère. \"Je suis désolé, "
+"mon seigneur, je vous ai appris tout ce que je pouvais.\""
 
 msgid ""
 "An old Knight appears on the steps of the gazebo. \"My liege, I will teach "
 "you all that I know to aid you in your travels.\""
 msgstr ""
+"Un vieux chevalier apparaît sur les marches du belvédère. \"Mon seigneur, je "
+"vais vous apprendre tout ce que je sais pour vous aider dans vos voyages.\""
 
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
 "ocean. Grateful, he says, \"I would give you an artifact as a reward, but "
 "you're all full.\""
 msgstr ""
+"Vous avez tiré un survivant d’un naufrage d’une mort certaine dans un océan "
+"impitoyable. Reconnaissant, dit-il, « Je vous donnerais un artefact en "
+"récompense, mais vous êtes tout plein. »"
 
 msgid ""
 "You've pulled a shipwreck survivor from certain death in an unforgiving "
 "ocean. Grateful, he rewards you for your act of kindness by giving you the "
 "%{art}."
 msgstr ""
+"Vous avez tiré un survivant d’un naufrage d’une mort certaine dans un océan "
+"impitoyable. Reconnaissant, il vous récompense pour votre acte de "
+"gentillesse en vous donnant le %{art}."
 
 msgid "A leprechaun offers you the %{art} for the small price of %{gold} Gold."
-msgstr ""
+msgstr "Un lutin vous offre l'%{art} pour le petit prix de %{gold} d'or."
 
 msgid ""
 "A leprechaun offers you the %{art} for the small price of %{gold} Gold and "
 "%{count} %{res}."
 msgstr ""
+"Un lutin vous offre la %{art} pour le petit prix de %{gold} pièces d'or et "
+"%{count} de %{res}."
 
 msgid "Do you wish to buy this artifact?"
-msgstr ""
+msgstr "Souhaitez-vous acheter cet artefact?"
 
 msgid ""
 "You try to pay the leprechaun, but realize that you can't afford it. The "
 "leprechaun stamps his foot and ignores you."
 msgstr ""
+"Vous essayez de payer le lutin, mais réalisez que vous ne pouvez pas vous le "
+"permettre. Le lutin tamponne son pied et vous ignore."
 
 msgid ""
 "Insulted by your refusal of his generous offer, the leprechaun stamps his "
 "foot and ignores you."
 msgstr ""
+"Insulté par votre refus de son offre généreuse, le lutin tape sur son pied "
+"et vous ignore."
 
 msgid "You've found the artifact: "
-msgstr ""
+msgstr "Vous avez trouvé un artéfact : "
 
 msgid ""
 "You've found the humble dwelling of a withered hermit. The hermit tells you "
 "that he is willing to give the %{art} to the first wise person he meets."
 msgstr ""
+"Vous avez trouvé l’humble demeure d’un ermite desséché. L’ermite vous dit "
+"qu’il est prêt à donner le %{art} à la première personne sage qu’il "
+"rencontre."
 
 msgid ""
 "You've come across the spartan quarters of a retired soldier. The soldier "
 "tells you that he is willing to pass on the %{art} to the first true leader "
 "he meets."
 msgstr ""
+"Vous avez rencontré les quartiers spartiates d’un soldat à la retraite. Le "
+"soldat vous dit qu’il est prêt à transmettre le %{art} au premier vrai chef "
+"qu’il rencontre."
 
 msgid ""
 "You come upon an ancient artifact. As you reach for it, a pack of Rogues "
 "leap out of the brush to guard their stolen loot."
 msgstr ""
+"Vous tombez sur un ancien artefact. Alors que vous vous en emparez, une "
+"bande de Pillards bondit des broussailles pour garder le butin volé."
 
 msgid ""
 "Through a clearing you observe an ancient artifact. Unfortunately, it's "
 "guarded by a nearby %{monster}. Do you want to fight the %{monster} for the "
 "artifact?"
 msgstr ""
+"À travers une clairière, vous observez un ancien artefact. Malheureusement, "
+"il est gardé par un %{monster} à proximité. Voulez-vous combattre le "
+"%{monster} pour l’artefact?"
 
 msgid "Victorious, you take your prize, the %{art}."
-msgstr ""
+msgstr "Victorieux, vous prenez votre prix, le %{art}."
 
 msgid ""
 "Discretion is the better part of valor, and you decide to avoid this fight "
 "for today."
 msgstr ""
+"La discrétion est la meilleure partie de la vaillance, et vous décidez "
+"d’éviter ce combat pour aujourd’hui."
 
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold pieces."
 msgstr ""
+"Après avoir passé des heures à essayer de pêcher le coffre de la mer, vous "
+"l’ouvrez et trouvez %{gold} pièces d’or."
 
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold and the %{art}."
 msgstr ""
+"Après avoir passé des heures à essayer de pêcher le coffre de la mer, vous "
+"l’ouvrez et trouvez %{gold}'or et le %{art}."
 
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it, "
 "only to find it empty."
 msgstr ""
+"Après avoir passé des heures à essayer de pêcher le coffre de la mer, vous "
+"l’ouvrez, seulement pour le trouver vide."
 
 msgid ""
 "After scouring the area, you fall upon a hidden treasure cache. You may take "
 "the gold or distribute the gold to the peasants for experience. Do you wish "
 "to keep the gold?"
 msgstr ""
+"Après avoir parcouru la zone, vous tombez sur une cache au trésor. Vous "
+"pouvez prendre l’or ou distribuer l’or aux paysans pour l’expérience. "
+"Souhaitez-vous garder l’or?"
 
 msgid ""
 "After scouring the area, you fall upon a hidden chest, containing the "
 "%{gold} gold pieces."
 msgstr ""
+"Après avoir parcouru la zone, vous tombez sur un coffre caché, contenant "
+"%{gold} pièces d’or."
 
 msgid ""
 "After scouring the area, you fall upon a hidden chest, containing the "
 "ancient artifact %{art}."
 msgstr ""
+"Après avoir parcouru la zone, vous tombez sur un coffre caché, contenant "
+"l’ancien artefact %{art}."
 
 msgid ""
 "You stumble upon a dented and tarnished lamp lodged deep in the earth. Do "
 "you wish to rub the lamp?"
 msgstr ""
+"Vous tombez sur une lampe cabossée et ternie, enfouie dans la terre. Voulez-"
+"vous frotter la lampe ?"
 
 msgid ""
 "You come upon an abandoned gold mine. The mine appears to be haunted. Do you "
 "wish to enter?"
 msgstr ""
+"Vous tombez sur une mine d’or abandonnée. La mine semble hantée. Souhaitez-"
+"vous entrer?"
 
 msgid ""
 "You have taken control of the local Alchemist shop. It will provide you with "
 "%{count} unit of Mercury per day."
 msgstr ""
+"Vous avez pris le contrôle de la boutique alchimiste locale. Il vous "
+"fournira %{count} unité de mercure par jour."
 
 msgid ""
 "You gain control of a sawmill. It will provide you with %{count} units of "
 "wood per day."
 msgstr ""
+"Vous prenez le contrôle d’une scierie. Il vous fournira %{count} unités de "
+"bois par jour."
 
 msgid "You beat the Ghosts and are able to restore the mine to production."
 msgstr ""
+"Vous battez les Fantômes et êtes capable de remettre la mine en production."
 
 msgid ""
 "You gain control of an ore mine. It will provide you with %{count} units of "
 "ore per day."
 msgstr ""
+"Vous prenez le contrôle d’une mine de fer. Il vous fournira %{count} unités "
+"de fer par jour."
 
 msgid ""
 "You gain control of a sulfur mine. It will provide you with %{count} unit of "
 "sulfur per day."
 msgstr ""
+"Vous prenez le contrôle d’une mine de soufre. Il vous fournira %{count} "
+"unité de soufre par jour."
 
 msgid ""
 "You gain control of a crystal mine. It will provide you with %{count} unit "
 "of crystal per day."
 msgstr ""
+"Vous prenez le contrôle d’une mine de cristal. Il vous fournira %{count} "
+"unité de cristal par jour."
 
 msgid ""
 "You gain control of a gem mine. It will provide you with %{count} unit of "
 "gems per day."
 msgstr ""
+"Vous prenez le contrôle d’une mine de pierres précieuses. Il vous fournira "
+"%{count} unité de pierres précieuses par jour."
 
 msgid ""
 "You gain control of a gold mine. It will provide you with %{count} gold per "
 "day."
 msgstr ""
+"Vous prenez le contrôle d’une mine d’or. Il vous fournira %{count} d’or par "
+"jour."
 
 msgid ""
 "The lighthouse is now under your control, and all of your ships will now "
 "move further each turn."
 msgstr ""
+"Le phare est maintenant sous votre contrôle, et tous vos navires se "
+"déplaceront maintenant plus loin à chaque tour."
 
 msgid "You gain control of a %{name}."
-msgstr ""
+msgstr "Vous avez capturé %{name}."
 
 msgid ""
 "A group of %{monster} with a desire for greater glory wish to join you. Do "
 "you accept?"
 msgstr ""
+"Un groupe de %{monster} avec un désir de plus grande gloire souhaitent se "
+"joindre à vous. Acceptez-vous?"
 
 msgid "As you approach the dwelling, you notice that there is no one here."
 msgstr ""
+"En vous approchant du logement, vous remarquez qu’il n’y a personne ici."
 
 msgid ""
 "You search the ruins, but the Medusas that used to live here are gone. "
 "Perhaps there will be more next week."
 msgstr ""
+"Vous fouillez les ruines, mais les Méduses qui vivaient ici ont disparu. "
+"Peut-être y en aura-t-il d’autres la semaine prochaine."
 
 msgid ""
 "You've found some Medusas living in the ruins. They are willing to join your "
 "army for a price. Do you want to recruit Medusas?"
 msgstr ""
+"Vous avez trouvé des Médusas vivant dans les ruines. Ils sont prêts à "
+"rejoindre votre armée pour un prix. Voulez-vous recruter des Medusas ?"
 
 msgid ""
 "You've found a Sprite Tree City. Unfortunately, none of the Sprites living "
 "there wish to join an army. Maybe next week."
 msgstr ""
+"Vous avez trouvé une Cité des Arbres Sprites. Malheureusement, aucun des "
+"Sprites qui y vivent ne souhaite rejoindre une armée. Peut-être la semaine "
+"prochaine."
 
 msgid ""
 "Some of the Sprites living in the tree city are willing to join your army "
 "for a price. Do you want to recruit Sprites?"
 msgstr ""
+"Certains des Sprites vivant dans la cité des arbres sont prêts à rejoindre "
+"votre armée pour un prix. Voulez-vous recruter des Sprites ?"
 
 msgid ""
 "A colorful Rogues' wagon stands empty here. Perhaps more Rogues will be here "
 "later."
 msgstr ""
+"Un chariot de Pillards coloré est vide ici. Peut-être que d'autres Pillards "
+"seront là plus tard."
 
 msgid ""
 "Distant sounds of music and laughter draw you to a colorful wagon housing "
 "Rogues. Do you wish to have any Rogues join your army?"
 msgstr ""
+"Des sons lointains de musique et de rires vous attirent vers un wagon coloré "
+"abritant des Pillards. Souhaitez-vous que des Pillards rejoignent votre "
+"armée ?"
 
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. The "
 "tents are unoccupied. Perhaps more Nomads will be here later."
 msgstr ""
+"Un groupe de tentes en lambeaux, gonflées par le vent de sable, vous fait "
+"signe. Les tentes sont inoccupées. Peut-être que d'autres Nomades seront là "
+"plus tard."
 
 msgid ""
 "A group of tattered tents, billowing in the sandy wind, beckons you. Do you "
 "wish to have any Nomads join you during your travels?"
 msgstr ""
+"Un groupe de tentes en lambeaux, flottant dans le vent de sable, t'appelle. "
+"Souhaites-tu que des Nomades se joignent à toi durant ton voyage ?"
 
 msgid "The pit of mud bubbles for a minute and then lies still."
-msgstr ""
+msgstr "La fosse de boue bouillonne pendant une minute, puis reste immobile."
 
 msgid ""
 "As you approach the bubbling pit of mud, creatures begin to climb out and "
 "position themselves around it. In unison they say: \"Mother Earth would like "
 "to offer you a few of her troops. Do you want to recruit Earth Elementals?\""
 msgstr ""
+"Lorsque vous vous approchez de la fosse de boue bouillonnante, des créatures "
+"commencent à en sortir et à se positionner autour d'elle. A l'unisson, elles "
+"disent : \"Mère Terre aimerait vous offrir quelques-unes de ses troupes. "
+"Voulez-vous recruter des Élémentaires de la Terre ?\""
 
 msgid "You enter the structure of white stone pillars, and find nothing."
 msgstr ""
+"Vous entrez dans la structure de piliers de pierre blanche, et ne trouvez "
+"rien."
 
 msgid ""
 "White stone pillars support a roof that rises up to the sky. As you enter "
@@ -3575,137 +4035,202 @@ msgid ""
 "whisper: \"Why have you come? Are you here to call upon the forces of the "
 "air?\""
 msgstr ""
+"Des piliers de pierre blanche soutiennent un toit qui s'élève vers le ciel. "
+"En entrant dans la structure, l'air mort de l'extérieur fait place à une "
+"bourrasque tourbillonnante qui vous repousse presque à l'extérieur. Le "
+"courant d'air se matérialise en une forme à peine visible. La créature "
+"demande, dans ce qui ne peut être décrit que comme un fort chuchotement : "
+"\"Pourquoi es-tu venu ? Es-tu ici pour faire appel aux forces de l'air ?\""
 
 msgid "No Fire Elementals approach you from the lava pool."
 msgstr ""
+"Aucun élémentaire de feu ne s'approche de vous depuis le bassin de lave."
 
 msgid ""
 "Beneath a structure that serves to hold in heat, Fire Elementals move about "
 "in a fiery pool of molten lava. A group of them approach you and offer their "
 "services. Would you like to recruit Fire Elementals?"
 msgstr ""
+"Sous une structure qui sert à retenir la chaleur, des élémentaires du feu se "
+"déplacent dans un bassin de lave en fusion. Un groupe d'entre eux s'approche "
+"de vous et vous propose ses services. Voulez-vous recruter des Élémentaires "
+"de feu ?"
 
 msgid "A face forms in the water for a moment, and then is gone."
-msgstr ""
+msgstr "Un visage se forme dans l'eau pendant un instant, puis disparaît."
 
 msgid ""
 "Crystalline structures cast shadows over a small reflective pool of water. "
 "You peer into the pool, and a face that is not your own peers back. It asks: "
 "\"Would you like to call upon the powers of water?\""
 msgstr ""
+"Des structures cristallines projettent des ombres sur un petit bassin d'eau "
+"réfléchissant. Vous regardez dans la piscine, et un visage qui n'est pas le "
+"vôtre vous regarde en retour. Il demande : \"Voulez-vous faire appel aux "
+"pouvoirs de l'eau ?\""
 
 msgid "This burial site is deathly still."
-msgstr ""
+msgstr "Ce site funéraire est mortellement calme."
 
 msgid ""
 "Restless spirits of long dead warriors seeking their final resting place "
 "offer to join you in hopes of finding peace. Do you wish to recruit ghosts?"
 msgstr ""
+"Les esprits agités de guerriers morts depuis longtemps et cherchant leur "
+"dernière demeure vous proposent de vous rejoindre dans l'espoir de trouver "
+"la paix. Voulez-vous recruter des fantômes ?"
 
 msgid ""
 "The City of the Dead is empty of life, and empty of unlife as well. Perhaps "
 "some undead will move in next week."
 msgstr ""
+"La Cité des Morts est vide de vie, et vide de non-vie aussi. Peut-être que "
+"des morts-vivants vont emménager la semaine prochaine."
 
 msgid ""
 "Some Liches living here are willing to join your army for a price. Do you "
 "want to recruit Liches?"
 msgstr ""
+"Certaines Liches vivant ici sont prêtes à rejoindre votre armée pour un "
+"prix. Voulez-vous recruter des Liches?"
 
 msgid ""
 "You've found the ruins of an ancient city, now inhabited solely by the "
 "undead. Will you search?"
 msgstr ""
+"Vous avez trouvé les ruines d'une ancienne cité, désormais habitée "
+"uniquement par des morts-vivants. Allez-vous chercher?"
 
 msgid ""
 "Some of the surviving Liches are impressed by your victory over their "
 "fellows, and offer to join you for a price. Do you want to recruit Liches?"
 msgstr ""
+"Certains des Liches survivants sont impressionnés par votre victoire sur "
+"leurs congénères et proposent de vous rejoindre moyennant un certain prix. "
+"Voulez-vous recruter des Liches ?"
 
 msgid ""
 "You've found one of those bridges that Trolls are so fond of living under, "
 "but there are none here. Perhaps there will be some next week."
 msgstr ""
+"Vous avez trouvé un de ces ponts sous lesquels les Trolls aiment tant vivre, "
+"mais il n'y en a pas ici. Peut-être qu'il y en aura la semaine prochaine."
 
 msgid ""
 "Some Trolls living under a bridge are willing to join your army, but for a "
 "price. Do you want to recruit Trolls?"
 msgstr ""
+"Des Trolls vivant sous un pont sont prêts à rejoindre votre armée, mais à un "
+"prix. Voulez-vous recruter des Trolls ?"
 
 msgid "Trolls living under the bridge challenge you. Will you fight them?"
 msgstr ""
+"Les trolls qui vivent sous le pont vous défient. Allez-vous les combattre ?"
 
 msgid ""
 "A few Trolls remain, cowering under the bridge. They approach you and offer "
 "to join your forces as mercenaries. Do you want to buy any Trolls?"
 msgstr ""
+"Il reste quelques Trolls, qui se cachent sous le pont. Ils s'approchent de "
+"vous et proposent de rejoindre vos forces en tant que mercenaires. Voulez-"
+"vous acheter des Trolls ?"
 
 msgid ""
 "The Dragon city has no Dragons willing to join you this week. Perhaps a "
 "Dragon will become available next week."
 msgstr ""
+"La cité des Dragons n'a pas de Dragons prêts à se joindre à vous cette "
+"semaine. Peut-être un Dragon sera-t-il disponible la semaine prochaine."
 
 msgid ""
 "The Dragon city is willing to offer some Dragons for your army for a price. "
 "Do you wish to recruit Dragons?"
 msgstr ""
+"La cité des Dragons est prête à offrir quelques Dragons pour votre armée "
+"moyennant un certain prix. Souhaitez-vous recruter des Dragons ?"
 
 msgid ""
 "You stand before the Dragon City, a place off-limits to mere humans. Do you "
 "wish to violate this rule and challenge the Dragons to a fight?"
 msgstr ""
+"Vous vous trouvez devant la Cité des Dragons, un lieu interdit aux simples "
+"humains. Voulez-vous enfreindre cette règle et défier les Dragons dans un "
+"combat ?"
 
 msgid ""
 "Having defeated the Dragon champions, the city's leaders agree to supply "
 "some Dragons to your army for a price. Do you wish to recruit Dragons?"
 msgstr ""
+"Après avoir vaincu les champions dragons, les dirigeants de la ville "
+"acceptent de fournir quelques Dragons à votre armée contre un certain prix. "
+"Souhaitez-vous recruter des Dragons ?"
 
 msgid "From the observation tower, you are able to see distant lands."
 msgstr ""
+"Depuis la tour d'observation, vous êtes en mesure de voir des terres "
+"lointaines."
 
 msgid ""
 "The spring only refills once a week, and someone's already been here this "
 "week."
 msgstr ""
+"La source ne se remplit qu'une fois par semaine, et quelqu'un est déjà venu "
+"cette semaine."
 
 msgid ""
 "A drink at the spring is supposed to give you twice your normal spell "
 "points, but you are already at that level."
 msgstr ""
+"Un verre à la source est censé vous donner deux fois vos points de magie "
+"normaux, mais vous avez déjà atteint ce niveau."
 
 msgid ""
 "A drink from the spring fills your blood with magic! You have twice your "
 "normal spell points in reserve."
 msgstr ""
+"Une boisson de la source remplit votre sang de magie ! Vous avez deux fois "
+"vos points de magie normaux en réserve."
 
 msgid ""
 "Recognizing you, the butler refuses to admit you. \"The master,\" he says, "
 "\"will not see the same student twice.\""
 msgstr ""
+"En vous reconnaissant, le majordome refuse de vous admettre. \"Le maître,\" "
+"dit-il, \"ne verra pas deux fois le même élève.\""
 
 msgid ""
 "The butler admits you to see the master of the house. He trains you in the "
 "four skills a hero should know."
 msgstr ""
+"Le majordome vous admet à voir le maître de maison. Il vous forme aux quatre "
+"compétences qu'un héros doit connaître."
 
 msgid ""
 "The butler opens the door and looks you up and down. \"You are neither "
 "famous nor diplomatic enough to be admitted to see my master,\" he sniffs. "
 "\"Come back when you think yourself worthy.\""
 msgstr ""
+"Le majordome ouvre la porte et vous regarde de haut en bas. \"Vous n'êtes ni "
+"assez célèbre ni assez diplomate pour être admis à voir mon maître\", "
+"renifle-t-il. \"Revenez quand vous vous en croirez digne.\""
 
 msgid ""
 "All of the %{monsters} you have in your army have been trained by the battle "
 "masters of the fort. Your army now contains %{monsters2}."
 msgstr ""
+"Tous les %{monsters} que vous avez dans votre armée ont été entraînés par "
+"les maîtres de guerre du fort. Votre armée contient maintenant %{monsters2}."
 
 msgid ""
 "An unusual alliance of Ogres, Orcs, and Dwarves offer to train (upgrade) any "
 "such troops brought to them. Unfortunately, you have none with you."
 msgstr ""
+"Une alliance inhabituelle d'Ogres, d'Orques et de Nains propose de former "
+"(améliorer) toutes les troupes de ce type qui leur sont apportées. "
+"Malheureusement, vous n'en avez aucune avec vous."
 
 msgid "All of your %{monsters} have been upgraded into %{monsters2}."
-msgstr ""
+msgstr "Tous vos %{monsters} ont été transformés en %{monsters2}."
 
 msgid ""
 "A blacksmith working at the foundry offers to convert all Pikemen and "
@@ -3714,20 +4239,30 @@ msgid ""
 "Unfortunately, you have none of these troops in your army, so he can't help "
 "you."
 msgstr ""
+"Un forgeron travaillant à la fonderie propose de convertir en acier toutes "
+"les armes de piquiers et d'épéistes qui lui sont apportées. Il dit également "
+"qu'il connaît un procédé permettant de convertir les Golems de fer en Golems "
+"d'acier. Malheureusement, vous n'avez aucune de ces troupes dans votre "
+"armée, il ne peut donc pas vous aider."
 
 msgid ""
 "A retired captain living on this refurbished fishing platform offers to sell "
 "you maps of the sea he made in his younger days for 1,000 gold. Do you wish "
 "to buy the maps?"
 msgstr ""
+"Un capitaine à la retraite vivant sur cette plate-forme de pêche rénovée "
+"propose de vous vendre des cartes de la mer qu'il a faites dans sa jeunesse "
+"pour 1 000 or. Souhaitez-vous acheter ces cartes ?"
 
 msgid ""
 "The captain sighs. \"You don't have enough money, eh?  You can't expect me "
 "to give my maps away for free!\""
 msgstr ""
+"Le capitaine soupire. \"Tu n'as pas assez d'argent, hein ? Vous ne pouvez "
+"pas attendre de moi que je donne mes cartes gratuitement !\""
 
 msgid "You find %{artifact}."
-msgstr ""
+msgstr "Vous avez trouvé %{artifact}."
 
 msgid ""
 "You come upon an obelisk made from a type of stone you have never seen "
@@ -3735,51 +4270,68 @@ msgid ""
 "inscription. The inscription is a piece of a lost ancient map. Quickly you "
 "copy down the piece and the inscription vanishes as abruptly as it appeared."
 msgstr ""
+"Vous tombez sur un obélisque fait d'un type de pierre que vous n'avez jamais "
+"vu auparavant. En le fixant intensément, la surface lisse se transforme "
+"soudainement en une inscription. L'inscription est un morceau d'une ancienne "
+"carte perdue. Vous copiez rapidement le morceau et l'inscription disparaît "
+"aussi brusquement qu'elle est apparue."
 
 msgid "You have already been to this obelisk."
-msgstr ""
+msgstr "Vous avez déjà visité cet obélisque."
 
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"It is good to see "
 "you, my student. I hope my teachings have helped you.\""
 msgstr ""
+"A votre approche, l'arbre ouvre les yeux avec joie. \"C'est bon de te voir, "
+"mon élève. J'espère que mes enseignements t'ont aidé.\""
 
 msgid ""
 "Upon your approach, the tree opens its eyes in delight. \"Ahh, an "
 "adventurer! Allow me to teach you a little of what I have learned over the "
 "ages.\""
 msgstr ""
+"A votre approche, l'arbre ouvre les yeux avec joie. \"Ahh, un aventurier ! "
+"Permettez-moi de vous enseigner un peu de ce que j'ai appris au cours des "
+"âges.\""
 
 msgid "Upon your approach, the tree opens its eyes in delight."
-msgstr ""
+msgstr "À votre approche, l'arbre ouvre les yeux avec joie."
 
 msgid ""
 "\"Ahh, an adventurer! I will be happy to teach you a little of what I have "
 "learned over the ages for a mere %{count} %{res}.\""
 msgstr ""
+"\"Ahh, un aventurier ! Je serai heureux de vous enseigner un peu de ce que "
+"j'ai appris au cours des âges pour un prix de %{count} %{res}.\""
 
 msgid "(Just bury it around my roots.)"
-msgstr ""
+msgstr "(Enterrez-les juste autour de mes racines.)"
 
 msgid "Tears brim in the eyes of the tree."
-msgstr ""
+msgstr "Des larmes coulent dans les yeux de l'arbre."
 
 msgid "\"I need %{count} %{res}.\""
-msgstr ""
+msgstr "\"J'ai besoin de %{count} %{res}.\""
 
 msgid "it whispers. (sniff) \"Well, come back when you can pay me.\""
-msgstr ""
+msgstr "il chuchote. (sniff) \"Eh bien, reviens quand tu pourras me payer.\""
 
 msgid ""
 "Nestled among the trees sits a blind seer. After explaining the intent of "
 "your journey, the seer activates his crystal ball, allowing you to see the "
 "strengths and weaknesses of your opponents."
 msgstr ""
+"Niché parmi les arbres se trouve un voyant aveugle. Après avoir expliqué "
+"l’intention de votre voyage, le voyant active sa boule de cristal, vous "
+"permettant de voir les forces et les faiblesses de vos adversaires."
 
 msgid ""
 "The entrance to the cave is dark, and a foul, sulfurous smell issues from "
 "the cave mouth. Will you enter?"
 msgstr ""
+"L’entrée de la grotte est sombre et une odeur nauséabonde et sulfureuse "
+"provient de la bouche de la grotte. Allez-vous entrer?"
 
 msgid ""
 "You find a powerful and grotesque Demon in the cave. \"Today,\" it rasps, "
@@ -3787,59 +4339,83 @@ msgid ""
 "may fight me, or you may fight my servants. Do you prefer to fight my "
 "servants?\""
 msgstr ""
+"Vous trouverez un démon puissant et grotesque dans la grotte. « Aujourd’hui, "
+"râpe-t-il, vous allez vous battre et sûrement mourir. Mais je vais vous "
+"donner le choix des décès. Vous pouvez me combattre, ou vous pouvez "
+"combattre mes serviteurs. Préférez-vous combattre mes serviteurs?"
 
 msgid ""
 "Upon defeating the daemon's servants, you find a hidden cache with %{count} "
 "gold."
 msgstr ""
+"En battant les serviteurs du démon, vous trouvez un cache caché avec "
+"%{count} or."
 
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and receive %{exp} experience points."
 msgstr ""
+"Le Démon crie son défi et attaque ! Après une courte bataille désespérée, "
+"vous tuez le monstre et recevez %{exp} points d’expérience."
 
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and find the %{art} in the back of the cave."
 msgstr ""
+"Le Démon crie son défi et attaque ! Après une courte bataille désespérée, "
+"vous tuez le monstre et trouvez le %{art} à l’arrière de la grotte."
 
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and receive %{exp} experience points and "
 "%{count} gold."
 msgstr ""
+"Le Démon crie son défi et attaque ! Après une courte bataille désespérée, "
+"vous tuez le monstre et recevez %{exp} points d’expérience et %{count} or."
 
 msgid ""
 "The Demon leaps upon you and has its claws at your throat before you can "
 "even draw your sword. \"Your life is mine,\" it says. \"I will sell it back "
 "to you for %{count} gold.\""
 msgstr ""
+"Le Démon saute sur vous et a ses griffes à votre gorge avant même que vous "
+"puissiez tirer votre épée. « Votre vie est à moi », dit-il. « Je vous le "
+"reverrai pour %{count}'or. »"
 
 msgid ""
 "Seeing that you do not have %{count} gold, the demon slashes you with its "
 "claws, and the last thing you see is a red haze."
 msgstr ""
+"Voyant que vous n’avez pas %{count} d’or, le démon vous coupe avec ses "
+"griffes, et la dernière chose que vous voyez est une brume rouge."
 
 msgid "Except for evidence of a terrible battle, the cave is empty."
-msgstr ""
+msgstr "A part les preuves d'une terrible bataille, la grotte est vide."
 
 msgid "For %{gold} gold, the alchemist will remove it for you. Do you pay?"
-msgstr ""
+msgstr "Pour %{gold} or, l'alchimiste l'enlèvera pour vous. Vous payez ?"
 
 msgid ""
 "You hear a voice from behind the locked door, \"You don't have enough gold "
 "to pay for my services.\""
 msgstr ""
+"Vous entendez une voix derrière la porte fermée : \"Vous n'avez pas assez "
+"d'or pour payer mes services.\""
 
 msgid ""
 "You hear a voice from high above in the tower, \"Go away! I can't help you!\""
 msgstr ""
+"Vous entendez une voix venant des hauteurs de la tour : \"Va-t'en ! Je ne "
+"peux pas t'aider !\""
 
 msgid ""
 "The head groom approaches you and speaks, \"You already have a fine horse, "
 "and have no inexperienced cavalry which might make use of our trained war "
 "horses.\""
 msgstr ""
+"Le palefrenier en chef s'approche de vous et vous dit : \"Vous avez déjà un "
+"bon cheval, et vous n'avez pas de cavalerie inexpérimentée qui pourrait se "
+"servir de nos chevaux de guerre entraînés.\""
 
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
@@ -3848,6 +4424,13 @@ msgid ""
 "fresh mount in a week. We also have many fine war horses which could benefit "
 "mounted soldiers, but you have none we can help.\""
 msgstr ""
+"Alors que vous approchez des écuries, le palefrenier en chef apparaît, "
+"conduisant un beau cheval de guerre. \"Ce destrier vous aidera à accélérer "
+"vos déplacements. Hélas, son endurance diminuera avec beaucoup de "
+"chevauchées, et vous devrez revenir pour une nouvelle monture dans une "
+"semaine. Nous avons aussi beaucoup de beaux chevaux de guerre qui pourraient "
+"profiter aux soldats montés, mais vous n'en avez aucun que nous puissions "
+"aider.\""
 
 msgid ""
 "The head groom speaks to you, \"That is a fine looking horse you have. I am "
@@ -3855,6 +4438,11 @@ msgid ""
 "look to be of poor breeding stock. We have many trained war horses which "
 "would aid your riders greatly. I insist you take them.\""
 msgstr ""
+"Le palefrenier en chef vous parle : \"C'est un beau cheval que vous avez. Je "
+"crains que nous ne puissions pas vous donner mieux, mais les chevaux que "
+"votre cavalerie monte semblent être de mauvaise race. Nous avons beaucoup de "
+"chevaux de guerre entraînés qui aideraient grandement vos cavaliers. "
+"J'insiste pour que vous les preniez.\""
 
 msgid ""
 "As you approach the stables, the head groom appears, leading a fine looking "
@@ -3862,14 +4450,21 @@ msgid ""
 "grow tired in a week. You must also let me give better horses to your "
 "mounted soldiers, their horses look shoddy and weak.\""
 msgstr ""
+"Alors que vous approchez des écuries, le palefrenier en chef apparaît, "
+"conduisant un beau cheval de guerre. \"Ce coursier vous aidera à accélérer "
+"vos déplacements. Hélas, il sera fatigué dans une semaine. Vous devez "
+"également me permettre de donner de meilleurs chevaux à vos soldats montés, "
+"leurs chevaux sont en mauvais état et faibles.\""
 
 msgid "The Arena guards turn you away."
-msgstr ""
+msgstr "Les gardes de l'arène vous repoussent."
 
 msgid ""
 "As the sirens sing their eerie song, your small, determined army manages to "
 "overcome the urge to dive headlong into the sea."
 msgstr ""
+"Alors que les sirènes chantent leur sinistre chanson, votre petite armée "
+"déterminée parvient à surmonter l'envie de plonger tête baissée dans la mer."
 
 msgid ""
 "You have your crew stop up their ears with wax before the sirens' eerie song "
@@ -3878,30 +4473,48 @@ msgid ""
 "under its spell, and dive into the water where they drown. You are now wiser "
 "for the visit, and gain %{exp} experience."
 msgstr ""
+"Vous demandez à votre équipage de se boucher les oreilles avec de la cire "
+"avant que le chant sinistre des sirènes n'ait la moindre chance de les "
+"attirer vers une tombe aquatique. Un chant sinistre et plaintif émane des "
+"sirènes perchées sur les rochers. Plusieurs membres de votre équipage "
+"tombent sous son charme et plongent dans l'eau où ils se noient. Vous êtes "
+"maintenant plus sage pour cette visite, et gagnez %{exp} d'expérience."
 
 msgid ""
 "In a dazzling display of daring, you break into the local jail and free the "
 "hero imprisoned there, who, in return, pledges loyalty to your cause."
 msgstr ""
+"Dans une démonstration d'audace éblouissante, vous vous introduisez dans la "
+"prison locale et libérez le héros qui y est emprisonné, qui, en retour, "
+"promet d'être loyal à votre cause."
 
 msgid ""
 "You already have %{count} heroes, and regretfully must leave the prisoner in "
 "this jail to languish in agony for untold days."
 msgstr ""
+"Vous avez déjà %{count} héros, et vous devez malheureusement laisser le "
+"prisonnier dans cette prison languir dans l'agonie pendant des jours "
+"indicibles."
 
 msgid ""
 "You enter a rickety hut and talk to the magician who lives there. He tells "
 "you of places near and far which may aid you in your journeys."
 msgstr ""
+"Vous entrez dans une cabane branlante et parlez au magicien qui y vit. Il "
+"vous parle de lieux proches et lointains qui peuvent vous aider dans vos "
+"voyages."
 
 msgid "This eye seems to be intently studying its surroundings."
-msgstr ""
+msgstr "Cet œil semble étudier attentivement son environnement."
 
 msgid ""
 "\"I have a riddle for you,\" the Sphinx says. \"Answer correctly, and you "
 "shall be rewarded. Answer incorrectly, and you shall be eaten. Do you accept "
 "the challenge?\""
 msgstr ""
+"\"J'ai une énigme pour vous\", dit le Sphinx. \"Répondez correctement, et "
+"vous serez récompensé. Répondez incorrectement, et vous serez mangé. "
+"Acceptez-vous de relever le défi ?\""
 
 msgid ""
 "The Sphinx asks you the following riddle:\n"
@@ -3910,20 +4523,31 @@ msgid ""
 " \n"
 "Your answer?"
 msgstr ""
+"Le Sphinx vous pose l'énigme suivante :\n"
+" \n"
+"\"%{riddle}\n"
+" \n"
+"Votre réponse ?"
 
 msgid ""
 "Looking somewhat disappointed, the Sphinx sighs. You've answered my riddle "
 "so here's your reward. Now begone."
 msgstr ""
+"Le Sphinx soupire, l'air un peu déçu. Vous avez répondu à mon énigme, voici "
+"votre récompense. Maintenant, partez."
 
 msgid ""
 "\"You guessed incorrectly,\" the Sphinx says, smiling. The Sphinx swipes at "
 "you with a paw, knocking you to the ground. Another blow makes the world go "
 "black, and you know no more."
 msgstr ""
+"\"Vous avez mal deviné\", dit le Sphinx en souriant. Le Sphinx vous frappe "
+"d'un coup de patte, vous faisant tomber au sol. Un autre coup rend le monde "
+"noir, et vous ne savez plus rien."
 
 msgid "You come across a giant Sphinx. The Sphinx remains strangely quiet."
 msgstr ""
+"Vous tombez sur un Sphinx géant. Le Sphinx reste étrangement silencieux."
 
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
@@ -3931,6 +4555,11 @@ msgid ""
 "\"Speak the key and you may pass.\"\n"
 "As you speak the magic word, the glowing barrier dissolves into nothingness."
 msgstr ""
+"Une barrière magique se dresse devant vous, bloquant votre chemin. Les runes "
+"sur l'arche disent,\n"
+"\"Prononcez la clé et vous pourrez passer.\"\n"
+"Lorsque vous prononcez le mot magique, la barrière lumineuse se dissout dans "
+"le néant."
 
 msgid ""
 "A magical barrier stands tall before you, blocking your way. Runes on the "
@@ -3938,6 +4567,10 @@ msgid ""
 "\"Speak the key and you may pass.\"\n"
 "You speak, and nothing happens."
 msgstr ""
+"Une barrière magique se dresse devant vous, vous bloquant le chemin. Runes "
+"sur l’arche lire,\n"
+"« Prononcez le mot clé et vous pouvez passer. »\n"
+"Vous parlez, et rien ne se passe."
 
 msgid ""
 "You enter the tent and see an old woman gazing into a magic gem. She looks "
@@ -3945,87 +4578,94 @@ msgid ""
 "\"In my travels, I have learned much in the way of arcane magic. A great "
 "oracle taught me his skill. I have the answer you seek.\""
 msgstr ""
+"Vous entrez dans la tente et voyez une vieille femme contempler dans un "
+"joyau magique. Elle lève les y regards et dit:\n"
+"« Au cours de mes voyages, j’ai beaucoup appris sur la voie de la magie "
+"arcane. Un grand oracle m’a appris son talent. J’ai la réponse que vous "
+"cherchez."
 
 msgid ""
 "That spell costs %{mana} mana. You only have %{point} mana, so you can't "
 "cast the spell."
 msgstr ""
+"Ce sort coûte %{mana} mana. Vous n’avez que %{point} mana, vous ne pouvez "
+"donc pas lancer le sort."
 
-#, fuzzy
 msgid "%{name} the %{race} (Level %{level})"
-msgstr "%{name} le %{race}"
+msgstr "%{name} le %{race} (niveau %{level})"
 
 msgid ""
 "'Grouped' combat formation bunches your army together in the center of your "
 "side of the battlefield."
 msgstr ""
+"La formation de combat 'Groupée' regroupe votre armée au centre du champ de "
+"bataille, de votre coté."
 
 msgid "Are you sure you want to dismiss this Hero?"
-msgstr ""
+msgstr "Êtes vous sur de vouloir renvoyer ce héros?"
 
-#, fuzzy
 msgid "View Stats"
-msgstr "Stats du meilleur Héro :"
+msgstr "Voir Stats"
 
 msgid "View Experience Info"
-msgstr ""
+msgstr "Voir les infos de l'expérience"
 
 msgid "View Spell Points Info"
-msgstr ""
+msgstr "Voir les infos sur les points de magie"
 
 msgid "Set army combat formation to 'Spread'"
-msgstr ""
+msgstr "Utiliser la formation de combat 'Dispersée'"
 
 msgid "Set army combat formation to 'Grouped'"
-msgstr ""
+msgstr "Utiliser la formation de combat 'Groupée'"
 
 msgid "Exit Hero Screen"
-msgstr ""
+msgstr "Quitter l'écran Héros"
 
 msgid "You cannot dismiss a hero in a castle"
-msgstr ""
+msgstr "Vous ne pouvez pas renvoyer un héros dans un château"
 
 msgid "Dismissal of %{name} the %{race} is prohibited by scenario"
-msgstr ""
+msgstr "Le renvoi de %{name} le %{race} est interdit par scénario"
 
-#, fuzzy
 msgid "Dismiss %{name} the %{race}"
-msgstr "%{name} le %{race}"
+msgstr "Renvoyer %{name} le %{race}"
 
-#, fuzzy
 msgid "Show previous hero"
-msgstr "Montrer la ville précédente"
+msgstr "Afficher le héros précédent"
 
-#, fuzzy
 msgid "Show next hero"
-msgstr "Montrer la ville suivante"
+msgstr "Afficher le héros suivant"
 
-#, fuzzy
 msgid "Blood Morale"
-msgstr "Morale"
+msgstr "Moral de sang"
 
 msgid "%{morale} Morale"
-msgstr ""
+msgstr "Moral %{morale}"
 
 msgid "%{luck} Luck"
-msgstr ""
+msgstr "Chance %{luck}"
 
 msgid "Current Luck Modifiers:"
-msgstr ""
+msgstr "Modificateurs de chance actuels :"
 
 msgid "Current Morale Modifiers:"
-msgstr ""
+msgstr "Modificateurs de moral actuels :"
 
 msgid "Entire army is undead, so morale does not apply."
 msgstr ""
+"L'armée entière est composée de morts-vivants, donc le moral ne s'applique "
+"pas."
 
 msgid ""
 "Current experience %{exp1}.\n"
 " Next level %{exp2}."
 msgstr ""
+"Expérience actuelle %{exp1}.\n"
+" Niveau suivant %{exp2}."
 
 msgid "Level %{level}"
-msgstr ""
+msgstr "Niveau %{level}"
 
 msgid ""
 "%{name} currently has %{point} spell points out of a maximum of %{max}. The "
@@ -4033,557 +4673,590 @@ msgid ""
 "occasionally possible to have more than your maximum spell points via "
 "special events."
 msgstr ""
+"%{name} dispose actuellement de %{point} points de magie sur un maximum de "
+"%{max}. Le nombre maximum de points de magie est égal à 10 fois votre "
+"connaissance. Il est parfois possible d'avoir plus de points de magie que "
+"votre maximum grâce à des événements spéciaux."
 
 msgid "%{name1} meets %{name2}"
-msgstr ""
+msgstr "Échanger %{name1} avec %{name2}"
 
 msgid " and "
-msgstr ""
+msgstr " et "
 
 msgid ""
 "%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
 "%{spells1} from %{learner}, and teaches %{spells2} to %{learner}."
 msgstr ""
+"%{teacher}, dont le %{niveau} %{scholar} connaît de nombreux secrets "
+"magiques, apprend %{spells1} de %{learner}, et enseigne %{spells2} à "
+"%{learner}."
 
 msgid ""
 "%{teacher}, whose %{level} %{scholar} knows many magical secrets, learns "
 "%{spells1} from %{learner}."
 msgstr ""
+"%{teacher}, dont le %{niveau} %{scholar} connaît de nombreux secrets "
+"magiques, apprend %{spells1} de %{learner}."
 
 msgid ""
 "%{teacher}, whose %{level} %{scholar} knows many magical secrets, teaches "
 "%{spells2} to %{learner}."
 msgstr ""
+"%{teacher}, dont le %{niveau} %{scholar} connaît de nombreux secrets "
+"magiques, enseigne %{spells2} à %{learner}."
 
 msgid "Scholar Ability"
-msgstr ""
+msgstr "Capacité d'érudition"
 
 msgid "Town Portal"
-msgstr ""
+msgstr "Portes du village"
 
 msgid "Select town to port to."
-msgstr ""
+msgstr "Sélectionnez la destination."
 
 msgid "Your hero is too tired to cast this spell today. Try again tomorrow."
 msgstr ""
+"Votre héros est trop fatigué pour lancer ce sort aujourd'hui. Essayez à "
+"nouveau demain."
 
 msgid "%{spell} failed!!!"
-msgstr ""
+msgstr "%{spell} échoué!"
 
 msgid "This spell is already in use."
-msgstr ""
+msgstr "Ce sort est déjà utilisé."
 
 msgid "Enemy heroes are now fully identifiable."
-msgstr ""
+msgstr "Les héros ennemis sont désormais parfaitement identifiables."
 
-#, fuzzy
 msgid "This spell cannot be used on a boat."
-msgstr "Cette ville ne peut pas être améliorée en château."
+msgstr "Ce sort ne peut pas être jeté en mer."
 
 msgid "This spell can be casted only nearby water."
-msgstr ""
+msgstr "Ce sort ne peut être lancé qu'à proximité de l'eau."
 
 msgid ""
 "No available towns.\n"
 "Spell Failed!!!"
 msgstr ""
+"Pas de villages disponibles.\n"
+"Sort échoué!"
 
 msgid ""
 "Nearest town occupied.\n"
 "Spell Failed!!!"
 msgstr ""
+"Le village le plus proche est occupé.\n"
+"Le sort a échoué ! !!"
 
 msgid ""
 "You must be within %{count} spaces of a monster for the Visions spell to "
 "work."
 msgstr ""
+"Vous devez être dans un %{count} d'espaces d'un monstre pour que le sort "
+"Visions fonctionne."
 
 msgid "I fear these creatures are in the mood for a fight."
-msgstr ""
+msgstr "Je crains que ces créatures ne soient d'humeur à se battre."
 
 msgid "The creatures are willing to join us!"
-msgstr ""
+msgstr "Les créatures sont prêtes à se joindre à nous !"
 
 msgid "All the creatures will join us..."
-msgstr ""
+msgstr "Toutes les créatures vont nous rejoindre..."
 
 msgid "These weak creatures will surely flee before us."
-msgstr ""
+msgstr "Ces faibles créatures vont sûrement fuir devant nous."
 
 msgid ""
 "You must be standing on the entrance to a mine (sawmills and alchemists "
 "don't count) to cast this spell."
 msgstr ""
+"Vous devez être à l’entrée d’une mine (les scieries et les alchimistes ne "
+"comptent pas) pour lancer ce sort."
 
 msgid "Your attack skill is a bonus added to each creature's attack skill."
 msgstr ""
+"Votre compétence d’attaque est un bonus ajouté à la compétence d’attaque de "
+"chaque créature."
 
 msgid "Your defense skill is a bonus added to each creature's defense skill."
 msgstr ""
+"Votre compétence de défense est un bonus ajouté à la compétence de défense "
+"de chaque créature."
 
 msgid "Your spell power determines the length or power of a spell."
-msgstr ""
+msgstr "Votre puissance de sort détermine la durée ou la puissance d'un sort."
 
 msgid ""
 "Your knowledge determines how many spell points your hero may have. Under "
 "normal circumstances, a hero is limited to 10 spell points per level of "
 "knowledge."
 msgstr ""
+"Vos connaissances déterminent le nombre de points de sort que votre héros "
+"peut avoir. Dans des circonstances normales, un héros est limité à 10 points "
+"de sort par niveau de connaissance."
 
 msgid "Current Modifiers:"
-msgstr ""
+msgstr "Modificateurs actuels :"
 
 msgid "skill|Basic"
-msgstr ""
+msgstr "Principes"
 
 msgid "skill|Advanced"
-msgstr ""
+msgstr "Avancé"
 
-#, fuzzy
 msgid "skill|Expert"
 msgstr "Expert"
 
 msgid "Pathfinding"
-msgstr ""
+msgstr "Orientation"
 
 msgid "Archery"
-msgstr ""
+msgstr "Tir à l'arc"
 
 msgid "Logistics"
-msgstr ""
+msgstr "Logistique"
 
 msgid "Scouting"
-msgstr ""
+msgstr "Reconnaissance"
 
 msgid "Diplomacy"
-msgstr ""
+msgstr "Diplomatie"
 
 msgid "Navigation"
-msgstr ""
+msgstr "Navigation"
 
 msgid "Leadership"
-msgstr ""
+msgstr "Charisme"
 
 msgid "Wisdom"
-msgstr ""
+msgstr "Sagesse"
 
 msgid "Mysticism"
-msgstr ""
+msgstr "Mysticisme"
 
 msgid "Ballistics"
-msgstr ""
+msgstr "Balistique"
 
 msgid "Eagle Eye"
-msgstr ""
+msgstr "Oeil d'aigle"
 
 msgid "Necromancy"
-msgstr ""
+msgstr "Nécromancie"
 
 msgid "Estates"
-msgstr ""
+msgstr "Finances"
 
 msgid "Basic Pathfinding"
-msgstr ""
+msgstr "Principes d'Orientation"
 
 msgid "Advanced Pathfinding"
-msgstr ""
+msgstr "Orientation avancée"
 
 msgid "Expert Pathfinding"
-msgstr ""
+msgstr "Expert en Orientation"
 
 msgid "Basic Archery"
-msgstr ""
+msgstr "Principes de Tir à l'arc"
 
 msgid "Advanced Archery"
-msgstr ""
+msgstr "Tir à l'arc avancé"
 
-#, fuzzy
 msgid "Expert Archery"
-msgstr "Expert"
+msgstr "Expert en Tir à l'arc"
 
 msgid "Basic Logistics"
-msgstr ""
+msgstr "Principes de Logistique"
 
 msgid "Advanced Logistics"
-msgstr ""
+msgstr "Logistique Avancée"
 
 msgid "Expert Logistics"
-msgstr ""
+msgstr "Expert en Logistique"
 
 msgid "Basic Scouting"
-msgstr ""
+msgstr "Principes de Reconnaissance"
 
 msgid "Advanced Scouting"
-msgstr ""
+msgstr "Reconnaissance Avancée"
 
 msgid "Expert Scouting"
-msgstr ""
+msgstr "Expert en Reconnaissance"
 
 msgid "Basic Diplomacy"
-msgstr ""
+msgstr "Principes de Diplomatie"
 
 msgid "Advanced Diplomacy"
-msgstr ""
+msgstr "Diplomatie Avancée"
 
 msgid "Expert Diplomacy"
-msgstr ""
+msgstr "Expert en Diplomatie"
 
-#, fuzzy
 msgid "Basic Navigation"
-msgstr "Fouille"
+msgstr "Principes de Navigation"
 
 msgid "Advanced Navigation"
-msgstr ""
+msgstr "Navigation Avancée"
 
-#, fuzzy
 msgid "Expert Navigation"
-msgstr "Fouille"
+msgstr "Expert en Navigation"
 
 msgid "Basic Leadership"
-msgstr ""
+msgstr "Principes de Charisme"
 
 msgid "Advanced Leadership"
-msgstr ""
+msgstr "Charisme Avancée"
 
 msgid "Expert Leadership"
-msgstr ""
+msgstr "Expert en Charisme"
 
 msgid "Basic Wisdom"
-msgstr ""
+msgstr "Principes de Sagesse"
 
 msgid "Advanced Wisdom"
-msgstr ""
+msgstr "Sagesse Avancée"
 
-#, fuzzy
 msgid "Expert Wisdom"
-msgstr "Expert"
+msgstr "Expert en Sagesse"
 
 msgid "Basic Mysticism"
-msgstr ""
+msgstr "Principes de Mysticisme"
 
 msgid "Advanced Mysticism"
-msgstr ""
+msgstr "Mysticisme Avancé"
 
 msgid "Expert Mysticism"
-msgstr ""
+msgstr "Expert en Mysticisme"
 
 msgid "Basic Luck"
-msgstr ""
+msgstr "Principes de Chance"
 
 msgid "Advanced Luck"
-msgstr ""
+msgstr "Chance Avancée"
 
-#, fuzzy
 msgid "Expert Luck"
-msgstr "Expert"
+msgstr "Expert en Chance"
 
 msgid "Basic Ballistics"
-msgstr ""
+msgstr "Principes de Balistique"
 
 msgid "Advanced Ballistics"
-msgstr ""
+msgstr "Balistique Avancée"
 
 msgid "Expert Ballistics"
-msgstr ""
+msgstr "Expert en Balistique"
 
 msgid "Basic Eagle Eye"
-msgstr ""
+msgstr "Principes d'Oeil d'aigle"
 
 msgid "Advanced Eagle Eye"
-msgstr ""
+msgstr "Oeil d'aigle Avancé"
 
 msgid "Expert Eagle Eye"
-msgstr ""
+msgstr "Expert en Oeil d'aigle"
 
 msgid "Basic Necromancy"
-msgstr ""
+msgstr "Principes de Nécromancie"
 
 msgid "Advanced Necromancy"
-msgstr ""
+msgstr "Nécromancie Avancée"
 
 msgid "Expert Necromancy"
-msgstr ""
+msgstr "Expert en Nécromancie"
 
 msgid "Basic Estates"
-msgstr ""
+msgstr "Principes de Finances"
 
 msgid "Advanced Estates"
-msgstr ""
+msgstr "Finances Avancés"
 
-#, fuzzy
 msgid "Expert Estates"
-msgstr "Expert"
+msgstr "Expert en Finances"
 
 msgid " allows you to negotiate with monsters who are weaker than your group."
 msgstr ""
+" vous permet de négocier avec les monstres qui sont plus faibles que votre "
+"groupe."
 
 msgid "All of the creatures may offer to join you."
-msgstr ""
+msgstr "Toutes les créatures peuvent proposer de se joindre à vous."
 
 msgid " allows your hero to learn third level spells."
-msgstr ""
+msgstr " permet à votre héros d'apprendre des sorts de troisième niveau."
 
 msgid " allows your hero to learn fourth level spells."
-msgstr ""
+msgstr " permet à votre héros d'apprendre des sorts de quatrième niveau."
 
 msgid " allows your hero to learn fifth level spells."
-msgstr ""
+msgstr " permet à votre héros d'apprendre des sorts de cinquième niveau."
 
 msgid ""
 " gives your hero's catapult shots a greater chance to hit and do damage to "
 "castle walls."
 msgstr ""
+" donne aux coups de catapulte de votre héros une plus grande chance de "
+"frapper et de faire des dégâts aux murs du château."
 
 msgid ""
 " gives your hero's catapult an extra shot, and each shot has a greater "
 "chance to hit and do damage to castle walls."
 msgstr ""
+" donne à la catapulte de votre héros un tir supplémentaire, et chaque tir a "
+"une plus grande chance de toucher et de faire des dégâts aux murs du château."
 
 msgid ""
 " gives your hero's catapult an extra shot, and each shot automatically "
 "destroys any wall, except a fortified wall in a Knight town."
 msgstr ""
+" donne à la catapulte de votre héros un coup supplémentaire, et chaque coup "
+"détruit automatiquement n’importe quel mur, à l’exception d’un mur fortifié "
+"dans un château chevalier."
 
 msgid "Blue"
-msgstr ""
+msgstr "Bleu"
 
 msgid "Green"
-msgstr ""
+msgstr "Vert"
 
 msgid "Red"
-msgstr ""
+msgstr "Rouge"
 
 msgid "Yellow"
-msgstr ""
+msgstr "Jaune"
 
 msgid "Orange"
-msgstr ""
+msgstr "Orange"
 
 msgid "Purple"
-msgstr ""
+msgstr "Violet"
 
 msgid "Aqua"
-msgstr ""
+msgstr "Turquoise"
 
 msgid "Brown"
-msgstr ""
+msgstr "Marron"
 
 msgid "Gold"
-msgstr ""
+msgstr "Or"
 
-#, fuzzy
 msgid "Hero/Stats"
-msgstr "Stats du meilleur Héro :"
+msgstr "Héros/Stats"
 
-#, fuzzy
 msgid "Skills"
-msgstr "Passer"
+msgstr "Compétences"
 
-#, fuzzy
 msgid "Artifacts"
-msgstr "Artéfact"
+msgstr "Artéfacts"
 
-#, fuzzy
 msgid "Town/Castle"
-msgstr "Chateau"
+msgstr "Village/Château"
 
 msgid "Garrison"
-msgstr ""
+msgstr "Garnison"
 
-#, fuzzy
 msgid "Gold Per Day:"
-msgstr "Or disponible dans la trésorerie :"
+msgstr "Or par jour :"
 
 msgid "luck|Cursed"
-msgstr ""
+msgstr "maudite"
 
 msgid "luck|Awful"
-msgstr ""
+msgstr "affreuse"
 
 msgid "luck|Bad"
-msgstr ""
+msgstr "défavorable"
 
 msgid "luck|Normal"
-msgstr ""
+msgstr "normale"
 
 msgid "luck|Good"
-msgstr ""
+msgstr "favorable"
 
 msgid "luck|Great"
-msgstr ""
+msgstr "superbe"
 
 msgid "luck|Irish"
-msgstr ""
+msgstr "maximale"
 
 msgid ""
 "Bad luck sometimes falls on your armies in combat, causing their attacks to "
 "only do half damage."
 msgstr ""
+"La malchance s'abat parfois sur vos armées au combat, leurs attaques ne "
+"faisant que la moitié des dégâts."
 
 msgid ""
 "Neutral luck means your armies will never get lucky or unlucky attacks on "
 "the enemy."
 msgstr ""
+"La chance neutre signifie que vos armées n'auront jamais de chance ou de "
+"malchance en attaquant l'ennemi."
 
 msgid ""
 "Good luck sometimes lets your armies get lucky attacks (double strength) in "
 "combat."
 msgstr ""
+"La bonne chance permet parfois à vos armées d’obtenir des attaques "
+"chanceuses (double force) au combat."
 
 msgid "morale|Treason"
-msgstr ""
+msgstr "de traitre"
 
 msgid "morale|Awful"
-msgstr ""
+msgstr "désastreux"
 
 msgid "morale|Poor"
-msgstr ""
+msgstr "médiocre"
 
 msgid "morale|Normal"
-msgstr ""
+msgstr "normal"
 
 msgid "morale|Good"
-msgstr ""
+msgstr "bon"
 
 msgid "morale|Great"
-msgstr ""
+msgstr "superbe"
 
 msgid "morale|Blood!"
-msgstr ""
+msgstr "de sang!"
 
 msgid "Bad morale may cause your armies to freeze in combat."
-msgstr ""
+msgstr "Un mauvais moral peut entraîner le gel de vos armées au combat."
 
 msgid ""
 "Neutral morale means your armies will never be blessed with extra attacks or "
 "freeze in combat."
 msgstr ""
+"Un moral neutre signifie que vos armées ne seront jamais bénies avec des "
+"attaques supplémentaires ou se figeront au combat."
 
 msgid "Good morale may give your armies extra attacks in combat."
 msgstr ""
+"Un bon moral peut donner à vos armées des attaques supplémentaires en combat."
 
 msgid "Knight"
-msgstr ""
+msgstr "Chevalier"
 
 msgid "Barbarian"
-msgstr ""
+msgstr "Barbare"
 
 msgid "Sorceress"
-msgstr ""
+msgstr "Sorcière"
 
 msgid "Warlock"
-msgstr ""
+msgstr "Mage"
 
 msgid "Wizard"
-msgstr ""
+msgstr "Magicien"
 
 msgid "Necromancer"
-msgstr ""
+msgstr "Nécromancien"
 
 msgid "Multi"
-msgstr ""
+msgstr "Multi"
 
 msgid "speed|Standing"
-msgstr ""
+msgstr "Immobile"
 
 msgid "speed|Crawling"
-msgstr ""
+msgstr "Rampant"
 
 msgid "speed|Very Slow"
-msgstr ""
+msgstr "Très lent"
 
 msgid "speed|Slow"
-msgstr ""
+msgstr "Lent"
 
 msgid "speed|Average"
-msgstr ""
+msgstr "Moyenne"
 
 msgid "speed|Fast"
-msgstr ""
+msgstr "Rapide"
 
 msgid "speed|Very Fast"
-msgstr ""
+msgstr "Très rapide"
 
 msgid "speed|Ultra Fast"
-msgstr ""
+msgstr "Ultra rapide"
 
 msgid "speed|Blazing"
-msgstr ""
+msgstr "Flamboyant"
 
 msgid "speed|Instant"
-msgstr ""
+msgstr "Immédiat"
 
 msgid "week|PLAGUE"
-msgstr ""
+msgstr "PESTE"
 
 msgid "week|Ant"
-msgstr ""
+msgstr "Fourmi"
 
 msgid "week|Grasshopper"
-msgstr ""
+msgstr "Sauterelle"
 
 msgid "week|Dragonfly"
-msgstr ""
+msgstr "Libellule"
 
 msgid "week|Spider"
-msgstr ""
+msgstr "Araignée"
 
 msgid "week|Butterfly"
-msgstr ""
+msgstr "Papillon"
 
 msgid "week|Bumblebee"
-msgstr ""
+msgstr "Bourdon"
 
 msgid "week|Locust"
-msgstr ""
+msgstr "Criquet"
 
 msgid "week|Earthworm"
-msgstr ""
+msgstr "Ver"
 
 msgid "week|Hornet"
-msgstr ""
+msgstr "Guêpe"
 
 msgid "week|Beetle"
-msgstr ""
+msgstr "Coccinelle"
 
 msgid "week|Squirrel"
-msgstr ""
+msgstr "Ecureil"
 
 msgid "week|Rabbit"
-msgstr ""
+msgstr "Lapin"
 
 msgid "week|Gopher"
-msgstr ""
+msgstr "Gourde"
 
 msgid "week|Badger"
-msgstr ""
+msgstr "Blaireau"
 
 msgid "week|Eagle"
-msgstr ""
+msgstr "Aigle"
 
 msgid "week|Weasel"
-msgstr ""
+msgstr "Belette"
 
 msgid "week|Raven"
-msgstr ""
+msgstr "Corbeau"
 
 msgid "week|Mongoose"
-msgstr ""
+msgstr "Mangouste"
 
 msgid "week|Aardvark"
-msgstr ""
+msgstr "Aardvark"
 
 msgid "week|Lizard"
-msgstr ""
+msgstr "Lézard"
 
 msgid "week|Tortoise"
-msgstr ""
+msgstr "Tortue"
 
 msgid "week|Hedgehog"
-msgstr ""
+msgstr "Hérisson"
 
 msgid "week|Condor"
-msgstr ""
+msgstr "Condor"
 
 msgid "Desert"
 msgstr "Désert"
@@ -4607,878 +5280,932 @@ msgid "Grass"
 msgstr "Herbe"
 
 msgid "Ocean"
-msgstr ""
+msgstr "Océan"
 
 msgid "maps|Small"
-msgstr ""
+msgstr "Petites"
 
 msgid "maps|Medium"
-msgstr ""
+msgstr "Moyennes"
 
 msgid "maps|Large"
-msgstr ""
+msgstr "Grandes"
 
 msgid "maps|Extra Large"
-msgstr ""
+msgstr "Très grandes"
 
 msgid "maps|Custom Size"
-msgstr ""
+msgstr "Voir toutes les cartes, sans tenir compte de leur taille."
 
 msgid "Ore Mine"
-msgstr ""
+msgstr "Mine de fer"
 
 msgid "Sulfur Mine"
-msgstr ""
+msgstr "Mine de Soufre"
 
 msgid "Crystal Mine"
-msgstr ""
+msgstr "Mine de Cristal"
 
 msgid "Gems Mine"
-msgstr ""
+msgstr "Mine de Gemmes"
 
 msgid "Gold Mine"
-msgstr ""
+msgstr "Mine d'or"
 
 msgid "Mine"
-msgstr ""
+msgstr "Mine"
 
 msgid "Alchemist Lab"
-msgstr ""
+msgstr "Laboratoire d'alchimiste"
 
 msgid "Daemon Cave"
-msgstr ""
+msgstr "Grotte de démon"
 
 msgid "Faerie Ring"
-msgstr ""
+msgstr "Anneau des fées"
 
 msgid "Dragon City"
-msgstr ""
+msgstr "Cité de Dragons"
 
 msgid "Lighthouse"
-msgstr ""
+msgstr "Phare"
 
 msgid "Water Wheel"
-msgstr ""
+msgstr "Roue hydraulique"
 
 msgid "Mines"
-msgstr ""
+msgstr "Mines"
 
 msgid "Obelisk"
-msgstr ""
+msgstr "Obélisque"
 
 msgid "Oasis"
-msgstr ""
+msgstr "Oasis"
 
 msgid "Sawmill"
-msgstr ""
+msgstr "Scierie"
 
 msgid "Oracle"
-msgstr ""
+msgstr "Oracle"
 
 msgid "Desert Tent"
-msgstr ""
+msgstr "Tente de désert"
 
 msgid "Wagon Camp"
-msgstr ""
+msgstr "Roulotte"
 
 msgid "Windmill"
-msgstr ""
+msgstr "Moulin à vent"
 
 msgid "Random Town"
-msgstr ""
+msgstr "Village aléatoire"
 
 msgid "Random Castle"
-msgstr ""
+msgstr "Château aléatoire"
 
 msgid "Watch Tower"
-msgstr ""
+msgstr "Tour de guet"
 
 msgid "Tree City"
-msgstr ""
+msgstr "Cité des arbres"
 
 msgid "Tree House"
-msgstr ""
+msgstr "Cabane"
 
 msgid "Ruins"
-msgstr ""
+msgstr "Ruines"
 
 msgid "Fort"
-msgstr ""
+msgstr "Fort"
 
 msgid "Abandoned Mine"
-msgstr ""
+msgstr "Mine abandonnée"
 
 msgid "Tree of Knowledge"
-msgstr ""
+msgstr "Arbre de connaissance"
 
 msgid "Witch Doctor's Hut"
-msgstr ""
+msgstr "Chaumière de sorcier"
 
 msgid "Temple"
-msgstr ""
+msgstr "Temple"
 
+#, fuzzy
 msgid "Hill Fort"
-msgstr ""
+msgstr "Fort"
 
 msgid "Halfling Hole"
-msgstr ""
+msgstr "Repaire des galopins"
 
 msgid "Mercenary Camp"
-msgstr ""
+msgstr "Camp de mercenaires"
 
 msgid "City of the Dead"
-msgstr ""
+msgstr "Cité des Morts"
 
 msgid "Sphinx"
-msgstr ""
+msgstr "Sphinx"
 
 msgid "Troll Bridge"
-msgstr ""
+msgstr "Pont"
 
+#, fuzzy
 msgid "Witch Hut"
-msgstr ""
+msgstr "Chaumière de sorcier"
 
 msgid "Xanadu"
-msgstr ""
+msgstr "Xanadu"
 
 msgid "Magellan Maps"
-msgstr ""
+msgstr "Cartes de Magellan"
 
 msgid "Derelict Ship"
-msgstr ""
+msgstr "Navire abandonnée"
 
 msgid "Shipwreck"
-msgstr ""
+msgstr "Épave"
 
 msgid "Observation Tower"
-msgstr ""
+msgstr "Tour d'observation"
 
 msgid "Freeman's Foundry"
-msgstr ""
+msgstr "Fonderie du citoyen"
 
 msgid "Watering Hole"
-msgstr ""
+msgstr "Point d'eau"
 
 msgid "Artesian Spring"
-msgstr ""
+msgstr "Puits artésien"
 
 msgid "Gazebo"
-msgstr ""
+msgstr "Belvédère"
 
 msgid "Archer's House"
-msgstr ""
+msgstr "Demeure des Archers"
 
 msgid "Peasant Hut"
-msgstr ""
+msgstr "Grange"
 
 msgid "Dwarf Cottage"
-msgstr ""
+msgstr "Cottage de Nains"
 
 msgid "Stone Liths"
-msgstr ""
+msgstr "Liths de pierre"
 
 msgid "Magic Well"
-msgstr ""
+msgstr "Puits"
 
 msgid "Heroes"
 msgstr "Héros"
 
 msgid "Nothing Special"
-msgstr ""
+msgstr "Rien de spécial"
 
 msgid "Tar Pit"
-msgstr ""
+msgstr "Fosse de goudron"
 
 msgid "Mound"
-msgstr ""
+msgstr "Monticule"
 
 msgid "Dune"
-msgstr ""
+msgstr "Dune"
 
 msgid "Stump"
-msgstr ""
+msgstr "Souche"
 
 msgid "Cactus"
-msgstr ""
+msgstr "Cactus"
 
 msgid "Trees"
-msgstr ""
+msgstr "Arbres"
 
 msgid "Dead Tree"
-msgstr ""
+msgstr "Arbre Morte"
 
 msgid "Mountains"
-msgstr ""
+msgstr "Montagnes"
 
 msgid "Volcano"
-msgstr ""
+msgstr "Volcan"
 
 msgid "Rock"
-msgstr ""
+msgstr "Caillou"
 
 msgid "Flowers"
-msgstr ""
+msgstr "Fleurs"
 
 msgid "Water Lake"
-msgstr ""
+msgstr "Lac"
 
 msgid "Mandrake"
-msgstr ""
+msgstr "Mandrake"
 
 msgid "Crater"
-msgstr ""
+msgstr "Cratère"
 
 msgid "Lava Pool"
-msgstr ""
+msgstr "Lac de lave"
 
 msgid "Shrub"
-msgstr ""
+msgstr "Arbuste"
 
 msgid "Buoy"
-msgstr ""
+msgstr "Bouée"
 
 msgid "Skeleton"
-msgstr ""
+msgstr "Squelette"
 
 msgid "Treasure Chest"
-msgstr ""
+msgstr "Coffre de trésor"
 
 msgid "Sea Chest"
-msgstr ""
+msgstr "Coffre de trésor"
 
 msgid "Campfire"
-msgstr ""
+msgstr "Feu de camp"
 
 msgid "Fountain"
-msgstr ""
+msgstr "Fontaine"
 
 msgid "Genie Lamp"
-msgstr ""
+msgstr "Lampe ancienne"
 
 msgid "Goblin Hut"
-msgstr ""
+msgstr "Paillote"
 
 msgid "Monster"
-msgstr ""
+msgstr "Monstre"
 
 msgid "Resource"
-msgstr ""
+msgstr "Ressource"
 
 msgid "Whirlpool"
-msgstr ""
+msgstr "Tourbillon"
 
 msgid "Artifact"
 msgstr "Artéfact"
 
 msgid "Boat"
-msgstr ""
+msgstr "Navire"
 
 msgid "Standing Stones"
-msgstr ""
+msgstr "Pierres dressées"
 
 msgid "Idol"
-msgstr ""
+msgstr "Idole"
 
 msgid "Shrine of the First Circle"
-msgstr ""
+msgstr "Lieu saint du 1-er Cercle"
 
 msgid "Shrine of the Second Circle"
-msgstr ""
+msgstr "Lieu saint du 1-er Cercle"
 
 msgid "Shrine of the Third Circle"
-msgstr ""
+msgstr "Lieu saint du 1-er Cercle"
 
 msgid "Wagon"
-msgstr ""
+msgstr "Charette"
 
 msgid "Lean To"
-msgstr ""
+msgstr "Appentis"
 
 msgid "Flotsam"
-msgstr ""
+msgstr "Débris"
 
 msgid "Shipwreck Survivor"
-msgstr ""
+msgstr "Survivant du naufrage"
 
 msgid "Bottle"
-msgstr ""
+msgstr "Bouteille"
 
 msgid "Magic Garden"
-msgstr ""
+msgstr "Jardin magique"
 
 msgid "Jail"
-msgstr ""
+msgstr "Prison"
 
 msgid "Traveller's Tent"
-msgstr ""
+msgstr "Tente de voyageur"
 
 msgid "Barrier"
-msgstr ""
+msgstr "Barrière magique"
 
 msgid "Fire Summoning Altar"
-msgstr ""
+msgstr "Autel d'invocation du Feu"
 
 msgid "Air Summoning Altar"
-msgstr ""
+msgstr "Autel d'invocation de l'Air"
 
 msgid "Earth Summoning Altar"
-msgstr ""
+msgstr "Autel d'invocation de la Terre"
 
 msgid "Water Summoning Altar"
-msgstr ""
+msgstr "Autel d'invocation de l'Eau"
 
 msgid "Barrow Mounds"
-msgstr ""
+msgstr "Tumulus"
 
 msgid "Stables"
-msgstr ""
+msgstr "Ecurie"
 
 msgid "Alchemist's Tower"
-msgstr ""
+msgstr "Tour d'alchimiste"
 
 msgid "Hut of the Magi"
-msgstr ""
+msgstr "Hutte du Mage"
 
 msgid "Eye of the Magi"
-msgstr ""
+msgstr "Oeil du Mage"
 
 msgid "Mermaid"
-msgstr ""
+msgstr "Nymphe"
 
 msgid "Sirens"
-msgstr ""
+msgstr "Sirènes"
 
 msgid "Reefs"
-msgstr ""
+msgstr "Récifs"
 
 msgid "Ultimate Book of Knowledge"
-msgstr ""
+msgstr "Livre de Connaissance Ultime"
 
 msgid "The %{name} increases your knowledge by %{count}."
-msgstr ""
+msgstr "Le %{name} augmente votre connaissance de %{count}."
 
 msgid "Ultimate Sword of Dominion"
-msgstr ""
+msgstr "Épée de la Domination Ultime"
 
 msgid "The %{name} increases your attack skill by %{count}."
-msgstr ""
+msgstr "L'%{name} augmente votre attaque de %{count}."
 
 msgid "Ultimate Cloak of Protection"
-msgstr ""
+msgstr "Voile Ultime de Protection"
 
 msgid "The %{name} increases your defense skill by %{count}."
-msgstr ""
+msgstr "La %{name} augmente votre défense de %{count}."
 
 msgid "Ultimate Wand of Magic"
-msgstr ""
+msgstr "Baguette Magique Ultime"
 
 msgid "The %{name} increases your spell power by %{count}."
-msgstr ""
+msgstr "La %{name} augmente votre puissance de %{count}."
 
 msgid "Ultimate Shield"
-msgstr ""
+msgstr "Bouclier Ultime"
 
 msgid "The %{name} increases your attack and defense skills by %{count} each."
 msgstr ""
+"Le %{name} augmente vos compétences d'attaque et de défense de %{count} "
+"chacune."
 
 msgid "Ultimate Staff"
-msgstr ""
+msgstr "Bâton Magique Ultime"
 
 msgid "The %{name} increases your spell power and knowledge by %{count} each."
 msgstr ""
+"Le %{name} augmente la puissance de vos sorts et vos connaissances de "
+"%{count} chacun."
 
 msgid "Ultimate Crown"
-msgstr ""
+msgstr "Couronne Ultime"
 
 msgid "The %{name} increases each of your basic skills by %{count} points."
 msgstr ""
+"La %{name} augmente chacune de vos compétences de base de %{count} points."
 
 msgid "Golden Goose"
-msgstr ""
+msgstr "L'oie d'or"
 
 msgid "The %{name} brings in an income of %{count} gold per turn."
-msgstr ""
+msgstr "%{nom} apporte un revenu de %{count} or par tour."
 
 msgid "Arcane Necklace of Magic"
-msgstr ""
+msgstr "Obscur Collier"
 
 msgid "Caster's Bracelet of Magic"
-msgstr ""
+msgstr "Bracelet Magique"
 
 msgid "Mage's Ring of Power"
-msgstr ""
+msgstr "Anneau de Puissance"
 
 msgid "Witch's Broach of Magic"
-msgstr ""
+msgstr "Broche Magique"
 
 msgid "Medal of Valor"
-msgstr ""
+msgstr "Médaille de la bravoure"
 
 msgid "The %{name} increases your morale."
-msgstr ""
+msgstr "%{name} augmente votre moral."
 
 msgid "Medal of Courage"
-msgstr ""
+msgstr "Médaille du courage"
 
 msgid "Medal of Honor"
-msgstr ""
+msgstr "Médaille d'honneur"
 
 msgid "Medal of Distinction"
-msgstr ""
+msgstr "Médaille de distinction"
 
 msgid "Fizbin of Misfortune"
-msgstr ""
+msgstr "Fizbin de la malchance"
 
 msgid "The %{name} greatly decreases your morale by %{count}."
-msgstr ""
+msgstr "%{name} diminue fortement votre moral de %{count}."
 
 msgid "Thunder Mace of Dominion"
-msgstr ""
+msgstr "Massue"
 
 msgid "Armored Gauntlets of Protection"
-msgstr ""
+msgstr "Gantelets"
 
 msgid "The %{name} increase your defense skill by %{count}."
-msgstr ""
+msgstr "Le %{name} augmente votre compétence de défense de %{count}."
 
 msgid "Defender Helm of Protection"
-msgstr ""
+msgstr "Casque de Protection"
 
 msgid "Giant Flail of Dominion"
-msgstr ""
+msgstr "Fléau Géant"
 
 msgid "Ballista of Quickness"
-msgstr ""
+msgstr "Baliste"
 
 msgid "The %{name} lets your catapult fire twice per combat round."
 msgstr ""
+"%{name} permet à votre catapulte de tirer deux fois par round de combat."
 
 msgid "Stealth Shield of Protection"
-msgstr ""
+msgstr "Bouclier Furtif"
 
 msgid "Dragon Sword of Dominion"
-msgstr ""
+msgstr "L'épée du Dragon"
 
 msgid "Power Axe of Dominion"
-msgstr ""
+msgstr "Puissante Hache"
 
 msgid "Divine Breastplate of Protection"
-msgstr ""
+msgstr "Plastron Divin"
 
 msgid "Minor Scroll of Knowledge"
-msgstr ""
+msgstr "Parchemin Mineur"
 
 msgid "Major Scroll of Knowledge"
-msgstr ""
+msgstr "Parchemin Majeur"
 
 msgid "Superior Scroll of Knowledge"
-msgstr ""
+msgstr "Parchemin Supérieur"
 
 msgid "Foremost Scroll of Knowledge"
-msgstr ""
+msgstr "Parchemin Ultime"
 
 msgid "Endless Sack of Gold"
-msgstr ""
+msgstr "Bourse d'or"
 
 msgid "The %{name} provides you with %{count} gold per day."
-msgstr ""
+msgstr "Le %{nom} vous fournit %{count} d'or par jour."
 
 msgid "Endless Bag of Gold"
-msgstr ""
+msgstr "Sac d'or"
 
 msgid "Endless Purse of Gold"
-msgstr ""
+msgstr "Besace d'or"
 
 msgid "Nomad Boots of Mobility"
-msgstr ""
+msgstr "Bottes de nomade"
 
 msgid "The %{name} increase your movement on land."
-msgstr ""
+msgstr "Le %{name} augmente votre mouvement sur terre."
 
 msgid "Traveler's Boots of Mobility"
-msgstr ""
+msgstr "Bottes de sept lieues"
 
 msgid "Lucky Rabbit's Foot"
-msgstr ""
+msgstr "Patte de lapin"
 
-#, fuzzy
 msgid "The %{name} increases your luck in combat."
-msgstr "La statue augmente les recettes de votre ville de 250 par jour."
+msgstr "%{name} augmente votre chance dans un combat."
 
 msgid "Golden Horseshoe"
-msgstr ""
+msgstr "Fer à cheval"
 
 msgid "Gambler's Lucky Coin"
-msgstr ""
+msgstr "Pièce"
 
 msgid "Four-Leaf Clover"
-msgstr ""
+msgstr "Trèfle"
 
 msgid "True Compass of Mobility"
-msgstr ""
+msgstr "Boussole"
 
 msgid "The %{name} increases your movement on land and sea."
 msgstr ""
+"%{name} augmente le potentiel de déplacement d'un héros sur terre et en mer."
 
 msgid "Sailor's Astrolabe of Mobility"
-msgstr ""
+msgstr "Sextant"
 
-#, fuzzy
 msgid "The %{name} increases your movement on sea."
-msgstr "La statue augmente les recettes de votre ville de 250 par jour."
+msgstr "%{name} augmente le potentiel de déplacement d'un héros en mer."
 
 msgid "Evil Eye"
-msgstr ""
+msgstr "Oeil Maléfique"
 
 msgid "The %{name} reduces the casting cost of curse spells by half."
 msgstr ""
+"Le %{name} réduit de moitié le coût d'incantation des sorts de malédiction."
 
 msgid "Enchanted Hourglass"
-msgstr ""
+msgstr "Sablier enchanté"
 
 msgid "The %{name} extends the duration of all your spells by %{count} turns."
-msgstr ""
+msgstr "Le %{name} prolonge la durée de tous vos sorts de %{count} tours."
 
 msgid "Gold Watch"
-msgstr ""
+msgstr "Montre Dorée"
 
 msgid "The %{name} doubles the effectiveness of your hypnotize spells."
-msgstr ""
+msgstr "Le %{name} double l’efficacité de vos sorts hypnotiseurs."
 
 msgid "Skullcap"
-msgstr ""
+msgstr "Calotte"
 
 msgid "The %{name} halves the casting cost of all mind influencing spells."
 msgstr ""
+"Le %{name} réduit de moitié le coût de tous les sorts influençant l’esprit."
 
 msgid "Ice Cloak"
-msgstr ""
+msgstr "Voile de glace"
 
 msgid "The %{name} halves all damage your troops take from cold spells."
 msgstr ""
+"Le %{name} réduit de moitié tous les dégâts subis par vos troupes en raison "
+"de sorts de froid."
 
 msgid "Fire Cloak"
-msgstr ""
+msgstr "Voile de feu"
 
 msgid "The %{name} halves all damage your troops take from fire spells."
 msgstr ""
+"Le %{name} réduit de moitié tous les dégâts subis par vos troupes en cas de "
+"sorts de feu."
 
 msgid "Lightning Helm"
-msgstr ""
+msgstr "Casque paratonnerre"
 
 msgid "The %{name} halves all damage your troops take from lightning spells."
 msgstr ""
+"Le %{name} réduit de moitié tous les dégâts subis par vos troupes à cause "
+"des sorts de foudre."
 
 msgid "Evercold Icicle"
-msgstr ""
+msgstr "Glaçon"
 
 msgid ""
 "The %{name} causes your cold spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
+"Le %{name} permet à vos sorts de froid d'infliger %{count} pour cent de "
+"dégâts supplémentaires aux troupes ennemies."
 
 msgid "Everhot Lava Rock"
-msgstr ""
+msgstr "Caillou de lave"
 
 msgid ""
 "The %{name} causes your fire spells to do %{count} percent more damage to "
 "enemy troops."
 msgstr ""
+"Le %{name} permet à vos sorts de feu d'infliger %{count} pour cent de dégâts "
+"supplémentaires aux troupes ennemies."
 
 msgid "Lightning Rod"
-msgstr ""
+msgstr "Baguette éclair"
 
 msgid ""
 "The %{name} causes your lightning spells to do %{count} percent more damage "
 "to enemy troops."
 msgstr ""
+"Le %{name} permet à vos sorts de foudre d'infliger %{count} pour cent de "
+"dégâts supplémentaires aux troupes ennemies."
 
 msgid "Snake-Ring"
-msgstr ""
+msgstr "Anneau du serpent"
 
 msgid "The %{name} halves the casting cost of all your bless spells."
-msgstr ""
+msgstr "L'%{name} réduit de moitié le coût de tous les sorts de bénédiction."
 
 msgid "Ankh"
-msgstr ""
+msgstr "Croix egyptienne"
 
 msgid ""
 "The %{name} doubles the effectiveness of all your resurrect and animate "
 "spells."
 msgstr ""
+"La %{name} double l'efficacité de tous vos sorts de résurrection et "
+"d'animation."
 
 msgid "Book of Elements"
-msgstr ""
+msgstr "Livre des éléments"
 
 msgid "The %{name} doubles the effectiveness of all your summoning spells."
-msgstr ""
+msgstr "Le %{name} double l’efficacité de vos sorts d'invocation."
 
 msgid "Elemental Ring"
-msgstr ""
+msgstr "Anneau élémentaire"
 
 msgid "The %{name} halves the casting cost of all summoning spells."
-msgstr ""
+msgstr "Le %{name} réduit de moitié le coût de vos sorts d'invocation."
 
 msgid "Holy Pendant"
-msgstr ""
+msgstr "Pendentif sacré"
 
 msgid "The %{name} makes all your troops immune to curse spells."
-msgstr ""
+msgstr "La %{name} rend toutes vos troupes immunes aux sorts de malédiction."
 
 msgid "Pendant of Free Will"
-msgstr ""
+msgstr "Pendentif du libre arbitre"
 
 msgid "The %{name} makes all your troops immune to hypnotize spells."
 msgstr ""
+"La %{name} rend toutes vos troupes immunisées contre les sorts de hypnose."
 
 msgid "Pendant of Life"
-msgstr ""
+msgstr "Pendentif de la vie"
 
 msgid "The %{name} makes all your troops immune to death spells."
-msgstr ""
+msgstr "La %{name} rend toutes vos troupes immunes aux sorts de la mort."
 
 msgid "Serenity Pendant"
-msgstr ""
+msgstr "Pendentif de la sérénité"
 
 msgid "The %{name} makes all your troops immune to berserk spells."
-msgstr ""
+msgstr "La %{name} rend toutes vos troupes immunes aux sorts berserk."
 
 msgid "Seeing-eye Pendant"
-msgstr ""
+msgstr "Pendentif du chien aveugle"
 
 msgid "The %{name} makes all your troops immune to blindness spells."
 msgstr ""
+"La %{name} rend toutes vos troupes immunisées contre les sorts de cécité."
 
 msgid "Kinetic Pendant"
-msgstr ""
+msgstr "Pendentif cinétique"
 
 msgid "The %{name} makes all your troops immune to paralyze spells."
 msgstr ""
+"La %{name} rend toutes vos troupes immunisées contre les sorts de paralysie."
 
 msgid "Pendant of Death"
-msgstr ""
+msgstr "Pendentif de la mort"
 
 msgid "The %{name} makes all your troops immune to holy spells."
-msgstr ""
+msgstr "La %{name} rend toutes vos troupes immunisées contre les sorts saints."
 
 msgid "Wand of Negation"
-msgstr ""
+msgstr "Baguette Magique Ultime"
 
 msgid "The %{name} protects your troops from the Dispel Magic spell."
-msgstr ""
+msgstr "Le %{name} protège vos troupes de la Dissipation."
 
 msgid "Golden Bow"
-msgstr ""
+msgstr "Arc doré"
 
 msgid ""
 "The %{name} eliminates the %{count} percent penalty for your troops shooting "
 "past obstacles (e.g. castle walls)."
 msgstr ""
+"L'%{name} élimine la pénalité de %{count} pour vos troupes qui tirent au-"
+"delà des obstacles (par exemple, les murs d'un château)."
 
 msgid "Telescope"
-msgstr ""
+msgstr "Téléscope"
 
 msgid ""
 "The %{name} increases the amount of terrain your hero reveals when "
 "adventuring by %{count} extra square."
 msgstr ""
+"Le %{name} augmente la quantité de terrain que votre héros révèle lorsqu'il "
+"part à l'aventure de %{count} carré supplémentaire."
 
 msgid "Statesman's Quill"
-msgstr ""
+msgstr "Plume de l'homme d'État"
 
 msgid ""
 "The %{name} reduces the cost of surrender to %{count} percent of the total "
 "cost of troops you have in your army."
 msgstr ""
+"La %{name} réduit le coût de la reddition à %{count} pour cent du coût total "
+"des troupes que vous avez dans votre armée."
 
 msgid "Wizard's Hat"
-msgstr ""
+msgstr "Chapeau du sorcier"
 
 msgid "The %{name} increases the duration of your spells by %{count} turns."
-msgstr ""
+msgstr "Le %{name} augmente la durée de vos sorts de %{count} tours."
 
 msgid "Power Ring"
-msgstr ""
+msgstr "Anneau de puissance"
 
 msgid "The %{name} returns %{count} extra power points/turn to your hero."
 msgstr ""
+"L'%{name} rend %{count} points de puissance supplémentaires/tour à votre "
+"héros."
 
 msgid "Ammo Cart"
-msgstr ""
+msgstr "Cartouche de munition"
 
 msgid "The %{name} provides endless ammunition for all your troops that shoot."
 msgstr ""
+"Le %{name} fournit des munitions illimités pour toutes vos troupes qui "
+"tirent."
 
 msgid "Tax Lien"
-msgstr ""
+msgstr "Privilège fiscal"
 
 msgid "The %{name} costs you %{count} gold pieces/turn."
-msgstr ""
+msgstr "Le %{nom} vous coûte %{count} pièces d'or/tour."
 
 msgid "Hideous Mask"
-msgstr ""
+msgstr "Masque sinistre"
 
 msgid "The %{name} prevents all 'wandering' armies from joining your hero."
-msgstr ""
+msgstr "%{name} empêche toutes les armées 'errantes' de rejoindre votre héros."
 
 msgid "Endless Pouch of Sulfur"
-msgstr ""
+msgstr "Sac de souffre sans fin"
 
 msgid "The %{name} provides %{count} unit of sulfur per day."
-msgstr ""
+msgstr "La %{name} fournit %{count} unité de soufre par jour."
 
 msgid "Endless Vial of Mercury"
-msgstr ""
+msgstr "Fiole de mercure sans fin"
 
 msgid "The %{name} provides %{count} unit of mercury per day."
-msgstr ""
+msgstr "La %{name} fournit %{count} unité de mercure par jour."
 
 msgid "Endless Pouch of Gems"
-msgstr ""
+msgstr "Bourse de rubis sans fin"
 
 msgid "The %{name} provides %{count} unit of gems per day."
-msgstr ""
+msgstr "La %{name} fournit %{count} unité de rubis par jour."
 
 msgid "Endless Cord of Wood"
-msgstr ""
+msgstr "Tas de bois sans fin"
 
 msgid "The %{name} provides %{count} unit of wood per day."
-msgstr ""
+msgstr "Le %{name} fournit %{count} unité de bois par jour."
 
 msgid "Endless Cart of Ore"
-msgstr ""
+msgstr "Charrette de fer sans fin"
 
 msgid "The %{name} provides %{count} unit of ore per day."
-msgstr ""
+msgstr "La %{name} fournit %{count} unité de fer par jour."
 
 msgid "Endless Pouch of Crystal"
-msgstr ""
+msgstr "Bourse de cristal sans fin"
 
 msgid "The %{name} provides %{count} unit of crystal/day."
-msgstr ""
+msgstr "La %{name} fournit %{count} unité de cristal par jour."
 
 msgid "Spiked Helm"
-msgstr ""
+msgstr "Casque à Pointes"
 
 msgid "Spiked Shield"
-msgstr ""
+msgstr "Bouclier à Pointes"
 
 msgid "White Pearl"
-msgstr ""
+msgstr "Perle Blanche"
 
 msgid "Black Pearl"
-msgstr ""
+msgstr "Perle Noire"
 
 msgid "Magic Book"
-msgstr ""
+msgstr "Livre de Magie"
 
 msgid "The %{name} enables you to cast spells."
-msgstr ""
+msgstr "Le %{name} vous permet de lancer des sorts."
 
 msgid "Spell Scroll"
-msgstr ""
+msgstr "Parchemin de sort"
 
 msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
-msgstr ""
+msgstr "Ce %{name} donne à votre héros la capacité de lancer le sort %{spell}."
 
 msgid "Arm of the Martyr"
-msgstr ""
+msgstr "Bras du martyr"
 
 msgid ""
 "The %{name} increases your spell power by %{count} but adds the undead "
 "morale penalty."
 msgstr ""
+"Le %{name} augmente votre puissance de sort par %{count} mais ajoute la "
+"pénalité de moral des morts-vivants."
 
 msgid "Breastplate of Anduran"
-msgstr ""
+msgstr "Plastron d'Anduran"
 
 msgid "The %{name} increases your defense by %{count}."
-msgstr ""
+msgstr "Le %{name} increases your defense by %{count}."
 
 msgid "Broach of Shielding"
-msgstr ""
+msgstr "Broche Magique"
 
 msgid ""
 "The %{name} provides %{count} percent protection from Armageddon and "
 "Elemental Storm, but decreases spell power by 2."
 msgstr ""
+"La %{name} fournit %{count} pour cent de protection contre Armageddon et "
+"Elemental Storm, mais diminue la puissance des sorts de 2."
 
 msgid "Battle Garb of Anduran"
-msgstr ""
+msgstr "Costume de bataille d’Anduran"
 
 msgid ""
 "The %{name} combines the powers of the three Anduran artifacts.  It provides "
 "maximum luck and morale for your troops and gives you the Town Portal spell."
 msgstr ""
+"Le %{name} combine les pouvoirs des trois artefacts andurens.  Il offre un "
+"maximum de chance et de moral à vos troupes et vous donne le sort Portes du "
+"village."
 
 msgid "Crystal Ball"
-msgstr ""
+msgstr "Boule de Cristal"
 
 msgid ""
 "The %{name} lets you get more specific information about monsters, enemy "
 "heroes, and castles nearby the hero who holds it."
 msgstr ""
+"La %{name} vous permet d'obtenir des informations plus spécifiques sur les "
+"monstres, les héros ennemis et les châteaux à proximité du héros qui le "
+"détient."
 
 msgid "Heart of Fire"
-msgstr ""
+msgstr "Coeur de feu"
 
 msgid ""
 "The %{name} provides %{count} percent protection from fire, but doubles the "
 "damage taken from cold."
 msgstr ""
+"Le %{name} offre une protection de %{count} pour cent contre le feu, mais "
+"double les dommages causés par le froid."
 
 msgid "Heart of Ice"
-msgstr ""
+msgstr "Coeur de Glace"
 
 msgid ""
 "The %{name} provides %{count} percent protection from cold, but doubles the "
 "damage taken from fire."
 msgstr ""
+"Le %{name} offre une protection de %{count} pour cent contre le froid, mais "
+"double les dommages causés par le feu."
 
 msgid "Helmet of Anduran"
-msgstr ""
+msgstr "Casque d'Anduran"
 
 msgid "Holy Hammer"
-msgstr ""
+msgstr "Marteau sacré"
 
 msgid "Legendary Scepter"
-msgstr ""
+msgstr "Sceptre légendaire"
 
 msgid "The %{name} adds %{count} points to all attributes."
-msgstr ""
+msgstr "Le %{name} ajoute %{count} points à tous les attributs."
 
 msgid "Masthead"
-msgstr ""
+msgstr "Tête de mât"
 
 msgid "The %{name} boosts your luck and morale by %{count} each in sea combat."
 msgstr ""
+"Le %{name} stimule votre chance et votre moral de %{count} chacun dans le "
+"combat en mer."
 
 msgid "Sphere of Negation"
-msgstr ""
+msgstr "Sphère de négation"
 
 msgid "The %{name} disables all spell casting, for both sides, in combat."
 msgstr ""
+"Le %{name} désactive tout lancer de sorts, pour les deux côtés, au combat."
 
 msgid "Staff of Wizardry"
-msgstr ""
+msgstr "Bâton Magique"
 
 msgid "The %{name} boosts your spell power by %{count}."
-msgstr ""
+msgstr "Le %{name} augmente la puissance de vos sorts de %{count}."
 
 msgid "Sword Breaker"
-msgstr ""
+msgstr "Briseur d'épée"
 
 msgid "The %{name} increases your defense by %{count} and attack by 1."
 msgstr ""
+"Le %{name} augmente vos compétences d'attaque et de défense de 1 chacune."
 
 msgid "Sword of Anduran"
-msgstr ""
+msgstr "Épée d'Anduran"
 
 msgid "Spade of Necromancy"
-msgstr ""
+msgstr "Pique de Nécromancie"
 
 msgid "The %{name} gives you increased necromancy skill."
-msgstr ""
+msgstr "Le %{name} vous donne une compétence accrue en nécromancie."
 
 msgid ""
 "You find an elaborate aontainer which housesan old vellum scroll. The runes "
@@ -5486,6 +6213,10 @@ msgid ""
 "together is stunning. As you pull the scroll out, you feel imbued with "
 "magical power."
 msgstr ""
+"Vous trouverez un aontainer élaboré qui abrite un vieux rouleau de vélin. "
+"Les runes sur le conteneur sont très vieilles, et l’art avec whitch il a été "
+"mis en place est magnifique. Lorsque vous retirez le parchemin, vous vous "
+"sentez imprégné d’un pouvoir magique."
 
 msgid ""
 "One of the less intelligent members of your party picks up an arm off of the "
@@ -5494,6 +6225,11 @@ msgid ""
 "seems to hold some sort of magical power that influences your decision "
 "making."
 msgstr ""
+"L’un des membres les moins intelligents de votre parti prend un bras du sol. "
+"Malgré l’absence d’un corps, il est toujours en mouvement. Vos troupes "
+"trouvent le bras démembré répugnant, mais vous ne pouvez pas vous résoudre à "
+"le laisser tomber: il semble détenir une sorte de pouvoir magique qui "
+"influence votre prise de décision."
 
 msgid ""
 "You come upon a sign. It reads: \"Here lies the body of Anduran. Bow and "
@@ -5501,18 +6237,30 @@ msgid ""
 "you stand up, you feel a coldness against your skin. Looking down, you find "
 "that you are suddenly wearing a gleaming, ornate breastplate."
 msgstr ""
+"Vous tombez sur un panneau. On peut y lire : « Ici se trouve le corps "
+"d’Anduran. Inclinez-vous et jurez fidélité, et vous serez récompensés. Vous "
+"décidez de faire ce qu’il dit. En vous leant, vous ressentez une froideur "
+"contre votre peau. En regardant vers le bas, vous constatez que vous portez "
+"soudainement une cuirasse étincelante et ornée."
 
 msgid ""
 "A kindly Sorceress thinks that your army's defenses could use a magical "
 "boost. She offers to enchant the Broach that you wear on your cloak, and you "
 "accept."
 msgstr ""
+"Une sorcière bienveilleux pense que les défenses de votre armée pourraient "
+"utiliser un coup de pouce magique. Elle propose d’enchanter le Broach que "
+"vous portez sur votre manteau, et vous l’acceptez."
 
 msgid ""
 "Out of pity for a poor peasant, you purchase a chest of old junk they are "
 "hawking for too much gold. Later, as you search through it, you find it "
 "contains the 3 pieces of the legendary battle garb of Anduran!"
 msgstr ""
+"Par pitié pour un pauvre paysan, vous achetez un coffre de vieilles ordures "
+"qu’ils colportent pour trop d’or. Plus tard, en le parcourant, vous "
+"constaterez qu’il contient les 3 pièces du légendaire costume de bataille "
+"d’Anduran!"
 
 msgid ""
 "You come upon a caravan of gypsies who are feasting and fortifying their "
@@ -5521,6 +6269,11 @@ msgid ""
 "anyway. They laugh hysterically, but admire your bravery, giving you a "
 "Crystal Ball."
 msgstr ""
+"Vous tombez sur une caravane de gitans qui se régalent et fortifient leurs "
+"corps avec de l’hydromel. Ils vous appellent vers l’avant et disent : « Si "
+"vous prouvez que vous pouvez danser le Rama-Buta, nous vous récompenserons. "
+"» Vous ne le savez pas, mais essayez quand même. Ils rient hystériquement, "
+"mais admirent votre bravoure, vous donnant une boule de cristal."
 
 msgid ""
 "You enter a recently burned glade and come upon a Fire Elemental sitting "
@@ -5528,6 +6281,11 @@ msgid ""
 "pain. It then tosses a glowing object at you. You put up your hands to block "
 "it, but it passes right through them and sears itself into your chest."
 msgstr ""
+"Vous entrez dans une clairière récemment brûlée et tombez sur un Élément de "
+"Feu assis au sommet d’un rocher. Il lève les y regards, son visage "
+"flamboyant toronné dans un regard de douleur intense. Il vous lance alors un "
+"objet lumineux. Vous levez les mains pour le bloquer, mais il passe à "
+"travers eux et se jette dans votre poitrine."
 
 msgid ""
 "Suddenly, a biting coldness engulfs your body. You seize up, falling from "
@@ -5536,6 +6294,11 @@ msgid ""
 "laughter. You turn around just in time to see a Frost Giant run off into the "
 "woods and disappear."
 msgstr ""
+"Soudain, une froideur mordante engloutit votre corps. Vous vous saisissez, "
+"vous tombez de votre cheval. La douleur s’atténue, mais vous avez toujours "
+"l’impression que votre poitrine est gelée.  Lorsque vous vous reprenez du "
+"sol, vous entendez des rires copieux. Vous vous retournez juste à temps pour "
+"voir un Frost Giant s’enfuir dans les bois et disparaître."
 
 msgid ""
 "You spy a gleaming object poking up out of the ground. You send a member of "
@@ -5543,6 +6306,10 @@ msgid ""
 "hands. You realize that it must be the helmet of the legendary Anduran, the "
 "only man who was known to wear solid gold armor."
 msgstr ""
+"Vous espionnez un objet étincelant qui sort du sol. Vous envoyez un membre "
+"de votre parti pour enquêter. Il revient avec un casque d’or à la main. Vous "
+"vous rendez compte que ce doit être le casque du légendaire Anduran, le seul "
+"homme qui était connu pour porter une armure en or massif."
 
 msgid ""
 "You come upon a battle where a Paladin has been mortally wounded by a group "
@@ -5550,6 +6317,11 @@ msgid ""
 "you pick it up, it begins to hum, and then everything becomes a blur. The "
 "Zombies lie dead, the hammer dripping with blood. You strap it to your belt."
 msgstr ""
+"Vous tombez sur une bataille où un Paladin a été mortellement blessé par un "
+"groupe de Zombies. Il vous demande de prendre son marteau et de terminer ce "
+"qu’il a commencé.  Lorsque vous le ramassez, il commence à fredonner, puis "
+"tout devient flou. Les Zombies mentent morts, le marteau dégoulinant de "
+"sang. Vous l’attachez à votre ceinture."
 
 msgid ""
 "Upon cresting a small hill, you come upon a ridiculous looking sight. A "
@@ -5558,6 +6330,11 @@ msgid ""
 "answers: \"You think this is funny? Fine. You can carry it. I much prefer "
 "flying anyway.\""
 msgstr ""
+"En culminant une petite colline, vous tombez sur un spectacle ridicule. Un "
+"Sprite tente de transporter un Sceptre presque aussi grand qu’il l’est. En "
+"essayant de ne pas rire, vous demandez: « Besoin d’aide? » Le Sprite vous "
+"regarde et répond: « Vous pensez que c’est drôle? bien. Vous pouvez le "
+"transporter. Je préfère de loin voler de toute façon."
 
 msgid ""
 "An old seaman tells you a tale of an enchanted masthead that he used in his "
@@ -5565,12 +6342,20 @@ msgid ""
 "map that shows where he hid it. After much exploring, you find it stashed "
 "underneath a nearby dock."
 msgstr ""
+"Un vieux marin vous raconte l’histoire d’une tête de mât enchantée qu’il a "
+"utilisée dans sa jeunesse pour rallier son équipage pendant les moments "
+"difficiles. Il vous remet ensuite une carte fanée qui montre où il l’a "
+"cachée. Après beaucoup d’exploration, vous le trouvez planqué sous un quai à "
+"proximité."
 
 msgid ""
 "You stop to help a Peasant catch a runaway mare. To show his gratitude, he "
 "hands you a tiny sphere. As soon as you grasp it, you feel the magical "
 "energy drain from your limbs..."
 msgstr ""
+"Vous vous arrêtez pour aider un paysan à attraper une jument fugueuse. Pour "
+"montrer sa gratitude, il vous tend une minuscule sphère. Dès que vous le "
+"saisissez, vous sentez l’énergie magique s’écouler de vos membres..."
 
 msgid ""
 "While out scaring up game, your troops find a mysterious staff levitating "
@@ -5578,11 +6363,17 @@ msgid ""
 "inscription. It reads: \"Brains best brawn and magic beats might. Heed my "
 "words, and you'll win every fight.\""
 msgstr ""
+"Tout en effrayant le jeu, vos troupes trouvent un mystérieux bâton en "
+"lévitation à environ trois pieds du sol. Ils vous le remettent et vous "
+"remarquez une inscription. On peut y lire : Brains best brawn and magic "
+"beats might. Essaie mes paroles, et tu gagnerez tous les combats."
 
 msgid ""
 "A former Captain of the Guard admires your quest and gives you the enchanted "
 "Sword Breaker that he relied on during his tour of duty."
 msgstr ""
+"Un ancien capitaine de la garde admire votre quête et vous donne le brise-"
+"épée enchanté sur lequel il s’est appuyé pendant son tour de service."
 
 msgid ""
 "A Troll stops you and says: \"Pay me 5,000 gold, or the Sword of Anduran "
@@ -5591,12 +6382,20 @@ msgid ""
 "sword, you give thanks that half-witted Trolls tend to grab the wrong end of "
 "sharp objects."
 msgstr ""
+"Un Troll vous arrête et dit: « Payez-moi 5,000 or, ou l’épée d’Anduran vous "
+"tuera où vous vous tenez. » Vous refusez. Le troll attrape l’épée suspendue "
+"à sa ceinture, crie de douleur et s’enfuit. Ramassant l’épée légendaire, "
+"vous remerciez que les Trolls à demi-esprit ont tendance à saisir le mauvais "
+"bout des objets tranchants."
 
 msgid ""
 "A dirty shovel has been thrust into a dirt mound nearby. Upon investigation, "
 "you discover it to be the enchanted shovel of the Gravediggers, long thought "
 "lost by mortals."
 msgstr ""
+"Une pelle sale a été enfoncée dans un monticule de terre à proximité. Après "
+"enquête, vous découvrez qu’il s’agit de la pelle enchantée des fossoyeurs, "
+"longtemps pensé perdu par les mortels."
 
 msgid ""
 "Do you want to use your knowledge of magical secrets to transcribe the "
@@ -5604,71 +6403,76 @@ msgid ""
 "The Spell Scroll will be consumed.\n"
 " Cost in spell points: %{sp}"
 msgstr ""
+"Voulez-vous utiliser votre connaissance des secrets magiques pour transcrire "
+"le parchemin %{spell} dans votre livre magique?\n"
+"Le parchemin de sort sera consommé.\n"
+" Coût en points de sort : %{sp}"
 
 msgid "Transcribe Spell Scroll"
-msgstr ""
+msgstr "Transcrire le Parchemin de sort"
 
-#, fuzzy
 msgid "View Spells"
-msgstr "Stats du meilleur Héro :"
+msgstr "Voir les sorts"
 
-#, fuzzy
 msgid "View %{name} Info"
-msgstr "voir %{name}"
+msgstr "Voir les infos de %{name}"
 
-#, fuzzy
 msgid "Move %{name}"
-msgstr "voir %{name}"
+msgstr "Déplacer %{name}"
 
-#, fuzzy
 msgid "Cannot move artifact"
-msgstr "Impossible de déplacer la dernière armée dans la garnison"
+msgstr "Impossible de déplacer l'artefact"
 
 msgid "This item can't be traded."
-msgstr ""
+msgstr "Cet objet ne peut pas être échangé."
 
 msgid "Wood"
-msgstr ""
+msgstr "Bois"
 
 msgid "Mercury"
-msgstr ""
+msgstr "Mercure"
 
 msgid "Ore"
-msgstr ""
+msgstr "Fer"
 
 msgid "Sulfur"
-msgstr ""
+msgstr "Soufre"
 
 msgid "Crystal"
-msgstr ""
+msgstr "Cristal"
 
 msgid "Gems"
-msgstr ""
+msgstr "Rubis"
 
 msgid "Fireball"
-msgstr ""
+msgstr "Boule de feu"
 
 msgid ""
 "Causes a giant fireball to strike the selected area, damaging all nearby "
 "creatures."
 msgstr ""
+"Provoque une boule de feu géante qui frappe la zone sélectionnée, "
+"endommageant toutes les créatures proches."
 
 msgid "Fireblast"
-msgstr ""
+msgstr "Souffle de feu"
 
 msgid ""
 "An improved version of fireball, fireblast affects two hexes around the "
 "center point of the spell, rather than one."
 msgstr ""
+"Une version améliorée de Boule de feu, le Souffle de feu affecte deux "
+"hexagones autour du point central du sort."
 
 msgid "Lightning Bolt"
-msgstr ""
+msgstr "Éclair foudroyant"
 
 msgid "Causes a bolt of electrical energy to strike the selected creature."
 msgstr ""
+"Provoque un éclair d'énergie électrique qui frappe la créature sélectionnée."
 
 msgid "Chain Lightning"
-msgstr ""
+msgstr "Foudre"
 
 msgid ""
 "Causes a bolt of electrical energy to strike a selected creature, then "
@@ -5676,622 +6480,794 @@ msgid ""
 "creature with half again damage, and so on, until it becomes too weak to be "
 "harmful.  Warning:  This spell can hit your own creatures!"
 msgstr ""
+"Provoque un éclair d'énergie électrique qui frappe une créature "
+"sélectionnée, puis la créature la plus proche avec la moitié des dégâts, "
+"puis la créature suivante la plus proche avec la moitié des dégâts, et ainsi "
+"de suite, jusqu'à ce qu'il devienne trop faible pour être nuisible.  "
+"Avertissement :  Ce sort peut toucher vos propres créatures !"
 
 msgid "Teleport"
-msgstr ""
+msgstr "Téléport"
 
 msgid ""
 "Teleports the creature you select to any open position on the battlefield."
 msgstr ""
+"Téléporte la créature que vous sélectionnez vers n'importe quelle position "
+"ouverte sur le champ de bataille."
 
 msgid "Cure"
-msgstr ""
+msgstr "Guérison"
 
 msgid ""
 "Removes all negative spells cast upon one of your units, and restores up to "
 "%{count} HP per level of spell power."
 msgstr ""
+"Annule tous les sorts négatifs lancés sur l'une de vos unités, et restaure "
+"jusqu'à %{count} de PV par niveau de puissance du sort."
 
 msgid "Mass Cure"
-msgstr ""
+msgstr "Grande guérison"
 
 msgid ""
 "Removes all negative spells cast upon your forces, and restores up to "
 "%{count} HP per level of spell power, per creature."
 msgstr ""
+"Supprime tous les sorts négatifs lancés sur vos forces, et restaure jusqu'à "
+"%{count} de HP par niveau de puissance de sort, par créature."
 
 msgid "Resurrect"
-msgstr ""
+msgstr "Résurrection"
 
 msgid "Resurrects creatures from a damaged or dead unit until end of combat."
 msgstr ""
+"Ressuscite les créatures d'une unité endommagée ou morte jusqu'à la fin du "
+"combat."
 
 msgid "Resurrect True"
-msgstr ""
+msgstr "Ultime résurrection"
 
 msgid "Resurrects creatures from a damaged or dead unit permanently."
 msgstr ""
+"Ressuscite définitivement les créatures d'une unité endommagée ou morte."
 
 msgid "Haste"
-msgstr ""
+msgstr "Célérité"
 
 msgid "Increases the speed of any creature by %{count}."
-msgstr ""
+msgstr "Augmente la vitesse d'une créature de %{count}."
 
 msgid "Mass Haste"
-msgstr ""
+msgstr "Célérité collective"
 
 msgid "Increases the speed of all of your creatures by %{count}."
-msgstr ""
+msgstr "Augmente la vitesse de toutes vos créatures de %{count}."
 
 msgid "spell|Slow"
-msgstr ""
+msgstr "Lenteur"
 
 msgid "Slows target to half movement rate."
-msgstr ""
+msgstr "Ralentit la cible à la moitié de sa vitesse de déplacement."
 
 msgid "Mass Slow"
-msgstr ""
+msgstr "Lourdeur collective"
 
 msgid "Slows all enemies to half movement rate."
-msgstr ""
+msgstr "Ralentit tous les ennemis à la moitié de leur vitesse de déplacement."
 
 msgid "spell|Blind"
-msgstr ""
+msgstr "Aveugler"
 
 msgid "Clouds the affected creatures' eyes, preventing them from moving."
-msgstr ""
+msgstr "Obscurcit les yeux des créatures affectées, les empêchant de bouger."
 
 msgid "Bless"
-msgstr ""
+msgstr "Bénédiction"
 
 msgid "Causes the selected creatures to inflict maximum damage."
-msgstr ""
+msgstr "Permet aux créatures sélectionnées d'infliger des dégâts maximums."
 
 msgid "Mass Bless"
-msgstr ""
+msgstr "Grande bénédiction"
 
 msgid "Causes all of your units to inflict maximum damage."
-msgstr ""
+msgstr "Permet à toutes vos unités d'infliger un maximum de dégâts."
 
 msgid "Stoneskin"
-msgstr ""
+msgstr "Chair de pierre"
 
 msgid "Magically increases the defense skill of the selected creatures."
-msgstr ""
+msgstr "Augmente la compétence de défense des créatures sélectionnées."
 
 msgid "Steelskin"
-msgstr ""
+msgstr "Chair d'acier"
 
 msgid ""
 "Increases the defense skill of the targeted creatures.  This is an improved "
 "version of Stoneskin."
 msgstr ""
+"Augmente la compétence de défense des créatures ciblées.  Il s'agit d'une "
+"version améliorée de Chair de pierre."
 
 msgid "Curse"
-msgstr ""
+msgstr "Malédiction"
 
 msgid "Causes the selected creatures to inflict minimum damage."
 msgstr ""
+"Fait en sorte que les créatures sélectionnées infligent des dégâts minimaux."
 
 msgid "Mass Curse"
-msgstr ""
+msgstr "Grande malédiction"
 
 msgid "Causes all enemy troops to inflict minimum damage."
 msgstr ""
+"Fait en sorte que toutes les troupes ennemies infligent des dégâts minimums."
 
 msgid "Holy Word"
-msgstr ""
+msgstr "Sainte parole"
 
 msgid "Damages all undead in the battle."
-msgstr ""
+msgstr "Endommage tous les morts-vivants dans la bataille."
 
 msgid "Holy Shout"
-msgstr ""
+msgstr "Saint cri"
 
 msgid ""
 "Damages all undead in the battle.  This is an improved version of Holy Word."
 msgstr ""
+"Endommage tous les morts-vivants dans la bataille.  Il s'agit d'une version "
+"améliorée de Sainte Parole."
 
 msgid "Anti-Magic"
-msgstr ""
+msgstr "Anti-magie"
 
 msgid "Prevents harmful magic against the selected creatures."
-msgstr ""
+msgstr "Empêche la magie nuisible contre les créatures sélectionnées."
 
 msgid "Dispel Magic"
-msgstr ""
+msgstr "Contre-sorts"
 
 msgid "Removes all magic spells from a single target."
-msgstr ""
+msgstr "Supprime tous les sorts magiques d'une créature."
 
 msgid "Mass Dispel"
-msgstr ""
+msgstr "Ultime contre-sorts"
 
 msgid "Removes all magic spells from all creatures."
-msgstr ""
+msgstr "Supprime tous les sorts magiques de toutes les créatures."
 
 msgid "Magic Arrow"
-msgstr ""
+msgstr "Flèche magique"
 
 msgid "Causes a magic arrow to strike the selected target."
-msgstr ""
+msgstr "Provoque une flèche magique qui frappe la cible sélectionnée."
 
 msgid "Berserker"
-msgstr ""
+msgstr "Furie"
 
 msgid "Causes a creature to attack its nearest neighbor."
-msgstr ""
+msgstr "Fait en sorte qu'une créature attaque son plus proche voisin."
 
 msgid "Armageddon"
-msgstr ""
+msgstr "Apocalypse"
 
 msgid ""
 "Holy terror strikes the battlefield, causing severe damage to all creatures."
 msgstr ""
+"La terreur sacrée frappe le champ de bataille, causant de graves dommages à "
+"toutes les créatures."
 
 msgid "Elemental Storm"
-msgstr ""
+msgstr "Orage"
 
 msgid "Magical elements pour down on the battlefield, damaging all creatures."
 msgstr ""
+"Les éléments magiques se déversent sur le champ de bataille, endommageant "
+"toutes les créatures."
 
 msgid "Meteor Shower"
-msgstr ""
+msgstr "Pluie de météores"
 
 msgid ""
 "A rain of rocks strikes an area of the battlefield, damaging all nearby "
 "creatures."
 msgstr ""
+"Une pluie de pierres frappe une zone du champ de bataille, endommageant "
+"toutes les créatures proches."
 
 msgid "Paralyze"
-msgstr ""
+msgstr "Paralysie"
 
 msgid "The targeted creatures are paralyzed, unable to move or retaliate."
 msgstr ""
+"Les créatures ciblées sont paralysées, incapables de bouger ou de riposter."
 
 msgid "Hypnotize"
-msgstr ""
+msgstr "Hypnose"
 
 msgid ""
 "Brings a single enemy unit under your control if its hits are less than "
 "%{count} times the caster's spell power."
 msgstr ""
+"Ramène une seule unité ennemie sous votre contrôle si ses points de vie sont "
+"inférieurs à %{count} fois la puissance du sort du lanceur."
 
 msgid "Cold Ray"
-msgstr ""
+msgstr "Rayon froid"
 
 msgid "Drains body heat from a single enemy unit."
-msgstr ""
+msgstr "Draine la chaleur corporelle d'une seule unité ennemie."
 
 msgid "Cold Ring"
-msgstr ""
+msgstr "Anneau froid"
 
 msgid ""
 "Drains body heat from all units surrounding the center point, but not "
 "including the center point."
 msgstr ""
+"Draine la chaleur corporelle de toutes les unités entourant le point "
+"central, mais sans le point central."
 
 msgid "Disrupting Ray"
-msgstr ""
+msgstr "Rayon perturbateur"
 
 msgid "Reduces the defense rating of an enemy unit by three."
-msgstr ""
+msgstr "Réduit de trois la valeur de défense d'une unité ennemie."
 
 msgid "Death Ripple"
-msgstr ""
+msgstr "Onde mortelle"
 
 msgid "Damages all living (non-undead) units in the battle."
 msgstr ""
+"Endommage toutes les unités vivantes (non mortes-vivantes) dans la bataille."
 
 msgid "Death Wave"
-msgstr ""
+msgstr "Vague mortelle"
 
 msgid ""
 "Damages all living (non-undead) units in the battle.  This spell is an "
 "improved version of Death Ripple."
 msgstr ""
+"Endommage toutes les unités vivantes (non mortes-vivantes) dans la "
+"bataille.  Ce sort est une version améliorée de Onde mortelle."
 
 msgid "Dragon Slayer"
-msgstr ""
+msgstr "Anti-dragon"
 
 msgid "Greatly increases a unit's attack skill vs. Dragons."
 msgstr ""
+"Augmente considérablement la compétence d'attaque d'une unité contre les "
+"Dragons."
 
 msgid "Blood Lust"
-msgstr ""
+msgstr "Soif de sang"
 
 msgid "Increases a unit's attack skill."
-msgstr ""
+msgstr "Augmente la compétence d'attaque d'une unité."
 
 msgid "Animate Dead"
-msgstr ""
+msgstr "Mort-vivant"
 
 msgid "Resurrects creatures from a damaged or dead undead unit permanently."
 msgstr ""
+"Ressuscite définitivement les créatures d'une unité de morts-vivants "
+"endommagée ou morte."
 
 msgid "Mirror Image"
-msgstr ""
+msgstr "Mirroir"
 
 msgid ""
 "Creates an illusionary unit that duplicates one of your existing units.  "
 "This illusionary unit does the same damages as the original, but will vanish "
 "if it takes any damage."
 msgstr ""
+"Crée une unité illusoire qui duplique l'une de vos unités existantes.  Cette "
+"unité illusoire inflige les mêmes dégâts que l'original, mais disparaît si "
+"elle subit des dégâts."
 
 msgid "Shield"
-msgstr ""
+msgstr "Bouclier"
 
 msgid "Halves damage received from ranged attacks for a single unit."
 msgstr ""
+"Réduit de moitié les dégâts reçus des attaques à distance pour une seule "
+"unité."
 
 msgid "Mass Shield"
-msgstr ""
+msgstr "Grand bouclier"
 
 msgid "Halves damage received from ranged attacks for all of your units."
 msgstr ""
+"Réduit de moitié les dégâts reçus par les attaques à distance pour toutes "
+"vos unités."
 
 msgid "Summon Earth Elemental"
-msgstr ""
+msgstr "Invoquer Terre"
 
 msgid "Summons Earth Elementals to fight for your army."
 msgstr ""
+"Invoquez des Esprits de la Terre pour qu'ils se battent pour votre armée."
 
 msgid "Summon Air Elemental"
-msgstr ""
+msgstr "Invoquer Air"
 
 msgid "Summons Air Elementals to fight for your army."
-msgstr ""
+msgstr "Invoquez des Esprits de l'Air pour qu'ils se battent pour votre armée."
 
 msgid "Summon Fire Elemental"
-msgstr ""
+msgstr "Invoquer Feu"
 
 msgid "Summons Fire Elementals to fight for your army."
-msgstr ""
+msgstr "Invoquez des Esprits du Feu pour qu'ils se battent pour votre armée."
 
 msgid "Summon Water Elemental"
-msgstr ""
+msgstr "Invoquer Eau"
 
 msgid "Summons Water Elementals to fight for your army."
-msgstr ""
+msgstr "Invoquez des Esprits de l'Eau pour qu'ils se battent pour votre armée."
 
 msgid "Earthquake"
-msgstr ""
+msgstr "Séisme"
 
 msgid "Damages castle walls."
-msgstr ""
+msgstr "Endommage les murs des châteaux."
 
 msgid "View Mines"
-msgstr ""
+msgstr "Voir Mines"
 
 msgid "Causes all mines across the land to become visible."
-msgstr ""
+msgstr "Rend visibles toutes les mines du pays."
 
 msgid "View Resources"
-msgstr ""
+msgstr "Voir Ressources"
 
 msgid "Causes all resources across the land to become visible."
-msgstr ""
+msgstr "Rend visibles toutes les ressources du pays."
 
 msgid "View Artifacts"
-msgstr ""
+msgstr "Voir Artéfacts"
 
 msgid "Causes all artifacts across the land to become visible."
-msgstr ""
+msgstr "Rend visibles tous les artéfacts du pays."
 
 msgid "View Towns"
-msgstr ""
+msgstr "Voir Villages"
 
 msgid "Causes all towns and castles across the land to become visible."
-msgstr ""
+msgstr "Rend visibles toutes les villages et tous les châteaux du pays."
 
 msgid "View Heroes"
-msgstr ""
+msgstr "Voir Héros"
 
 msgid "Causes all Heroes across the land to become visible."
-msgstr ""
+msgstr "Rend visibles tous les Héros."
 
 msgid "View All"
-msgstr ""
+msgstr "Tout Voir"
 
 msgid "Causes the entire land to become visible."
-msgstr ""
+msgstr "Rend visibles tout le pays."
 
 msgid "Identify Hero"
-msgstr ""
+msgstr "Identifier Héros"
 
 msgid "Allows the caster to view detailed information on enemy Heroes."
 msgstr ""
+"Permet au lanceur du sort de visualiser des informations détaillées sur les "
+"Héros ennemis."
 
 msgid "Summon Boat"
-msgstr ""
+msgstr "Embarquement"
 
 msgid ""
 "Summons the nearest unoccupied, friendly boat to an adjacent shore "
 "location.  A friendly boat is one which you just built or were the most "
 "recent player to occupy."
 msgstr ""
+"Appelle le bateau ami inoccupé le plus proche sur un emplacement côtier "
+"adjacent.  Un bateau ami est un bateau que vous venez de construire ou que "
+"vous êtes le dernier joueur à avoir occupé."
 
 msgid "Dimension Door"
-msgstr ""
+msgstr "Autre dimension"
 
 msgid "Allows the caster to magically transport to a nearby location."
 msgstr ""
+"Permet au lanceur du sort de se transporter magiquement dans un lieu proche."
 
 msgid "Town Gate"
-msgstr ""
+msgstr "Portes du village"
 
 msgid "Returns the caster to any town or castle currently owned."
 msgstr ""
+"Ramène le lanceur du sort dans n'importe quelle village ou château qu'il "
+"possède actuellement."
 
 msgid ""
 "Returns the hero to the town or castle of choice, provided it is controlled "
 "by you."
 msgstr ""
+"Ramène le héros dans le village ou le château de son choix, à condition "
+"qu'il soit contrôlé par vous."
 
 msgid "Visions"
-msgstr ""
+msgstr "Visions"
 
 msgid ""
 "Visions predicts the likely outcome of an encounter with a neutral army camp."
 msgstr ""
+"Visions prédit l'issue probable d'une rencontre avec un camp d'armée neutre."
 
 msgid "Haunt"
-msgstr ""
+msgstr "Hantise"
 
 msgid ""
 "Haunts a mine you control with Ghosts.  This mine stops producing "
 "resources.  (If I can't keep it, nobody will!)"
 msgstr ""
+"Hante une mine que vous contrôlez avec des fantômes.  Cette mine cesse de "
+"produire des ressources.  (Si je ne peux pas la garder, personne ne l'aura!)"
 
 msgid "Set Earth Guardian"
-msgstr ""
+msgstr "Gardien Terre"
 
 msgid "Sets Earth Elementals to guard a mine against enemy armies."
 msgstr ""
+"Invoque les Esprits de la Terre pour garder une mine contre les armées "
+"ennemies."
 
 msgid "Set Air Guardian"
-msgstr ""
+msgstr "Gardien Air"
 
 msgid "Sets Air Elementals to guard a mine against enemy armies."
 msgstr ""
+"Invoque les Esprits de l'Air pour garder une mine contre les armées ennemies."
 
 msgid "Set Fire Guardian"
-msgstr ""
+msgstr "Gardien Feu"
 
 msgid "Sets Fire Elementals to guard a mine against enemy armies."
 msgstr ""
+"Invoque les Esprits du Feu pour garder une mine contre les armées ennemies."
 
 msgid "Set Water Guardian"
-msgstr ""
+msgstr "Gardien Eau"
 
 msgid "Sets Water Elementals to guard a mine against enemy armies."
 msgstr ""
+"Invoque les Esprits de l'Eau pour garder une mine contre les armées ennemies."
 
 msgid "No spell to cast."
-msgstr ""
+msgstr "Aucun sort à lancer."
 
 msgid "Your hero has %{point} spell points remaining."
-msgstr ""
+msgstr "Votre héros a %{point} points de magie restants."
 
 msgid "View Adventure Spells"
-msgstr ""
+msgstr "Voir les sorts d'aventure"
 
-#, fuzzy
 msgid "View Combat Spells"
-msgstr "Lancer un sortilège"
+msgstr "Voir les sorts de combat"
 
-#, fuzzy
 msgid "View previous page"
-msgstr "Montrer la ville précédente"
+msgstr "Voir la page précédente"
 
-#, fuzzy
 msgid "View next page"
-msgstr "voir %{name}"
+msgstr "Voir la page suivante"
 
-#, fuzzy
 msgid "Close Spellbook"
-msgstr "Lancer un sortilège"
+msgstr "Fermer le livre de sorts"
 
-#, fuzzy
 msgid "View %{spell}"
-msgstr "voir %{name}"
+msgstr "Voir %{spell}"
 
 msgid "game: always confirm for rewrite savefile"
-msgstr ""
+msgstr "jeu : toujours confirmer l'écrasement de la sauvegarde"
 
 msgid "game: remember last focus"
-msgstr ""
+msgstr "jeu : retenir dernier élément choisi"
 
 msgid "battle: show damage info"
-msgstr ""
+msgstr "bataille : afficher les informations sur les dommages"
 
 msgid "world: show visited content from objects"
-msgstr ""
+msgstr "monde: afficher le contenu visité d’objets"
 
 msgid "world: show terrain penalty"
-msgstr ""
+msgstr "monde: afficher la pénalité de terrain"
 
 msgid "world: scouting skill show extended content info"
-msgstr ""
+msgstr "monde: reconnaissance permet d'afficher des infos supplementaires"
 
 msgid "world: allow set guardian to objects"
-msgstr ""
+msgstr "monde : permet de laisser la protection aux objets"
 
 msgid "world: Eagle Eye also works like Scholar in H3."
-msgstr ""
+msgstr "monde : oeil d'aigle fonctionne aussi comme Scholar en HoMM3."
 
 msgid "world: ban for WeekOf/MonthOf Monsters"
-msgstr ""
+msgstr "monde : interdiction les Semaines/Mois de monstres"
 
 msgid "world: ban plagues months"
-msgstr ""
+msgstr "monde : interdire les mois de PESTE"
 
 msgid "world: Months Of Monsters do not place creatures on map"
-msgstr ""
+msgstr "monde : Mois de monsters ne placent pas les créatures sur la carte"
 
 msgid "world: Crystal Ball also added Identify Hero and Visions spells"
 msgstr ""
+"monde : La Boule de Cristal ajoute les sorts Identifier Héros et Visions"
 
 msgid "world: Starting heroes as Loss Conditions for Human Players"
 msgstr ""
+"monde : Les héros de départ comme conditions de perte pour les joueurs "
+"humains"
 
 msgid "world: Only 1 hero can be hired by the one player every week"
 msgstr ""
+"monde : Un seul héros peut être engagé par le même joueur chaque semaine"
 
 msgid "world: Each castle allows one hero to be recruited every week"
-msgstr ""
+msgstr "monde : Chaque château permet de recruter un héros par semaine"
 
 msgid "world: Neutral armies scale with game difficulty"
-msgstr ""
+msgstr "monde : armées neutres adaptées à la difficulté du jeu"
 
 msgid "world: use unique artifacts for resource affecting"
-msgstr ""
+msgstr "monde : utiliser des artefacts uniques pour affecter les ressources"
 
 msgid "world: use unique artifacts for primary skills"
-msgstr ""
+msgstr "monde : utiliser des artefacts uniques pour les compétences primaires"
 
 msgid "world: use unique artifacts for secondary skills"
 msgstr ""
+"monde : utiliser des artefacts uniques pour les compétences secondaires"
 
 msgid "world: Wind/Water Mills and Magic Garden can be captured"
 msgstr ""
+"monde : moulins/roues hydrauliques et jardins magiques peuvent être capturés"
 
 msgid "world: disable Barrow Mounds"
-msgstr ""
+msgstr "monde : désactivation des Tumulus"
 
 msgid "castle: allow guardians"
-msgstr ""
+msgstr "unions: guardiens"
 
 msgid ""
 "castle: higher mage guilds regenerate more spell points/turn "
 "(20/40/60/80/100%)"
 msgstr ""
+"château : les guildes de mages supérieures régénèrent plus de points de "
+"sorts/tour (20/40/60/80/100%)"
 
 msgid "heroes: allow buy a spellbook from Shrines"
-msgstr ""
+msgstr "héros : possibilité d'acheter un livre de sorts dans les sanctuaires"
 
 msgid "heroes: recruit cost to be dependent on hero level"
-msgstr ""
+msgstr "héros : le coût de recrutement dépend du niveau du héros"
 
 msgid "heroes: remember move points for retreat/surrender result"
 msgstr ""
+"héros : se souvenir des points de mouvement pour le résultat de la retraite/"
+"reddition"
 
 msgid "heroes: allow transcribing scrolls (needs: Eye Eagle skill)"
-msgstr ""
+msgstr "héros: transcription des parchemins (avec l'Oeil d'Aigle)"
 
 msgid "heroes: in Arena can choose any of primary skills"
-msgstr ""
+msgstr "héros : l'arène permet de choisir parmi les compétences primaires"
 
 msgid "unions: allow meeting heroes"
-msgstr ""
+msgstr "unions: rencontres des héros"
 
 msgid "unions: allow castle visiting"
-msgstr ""
+msgstr "unions: visites des châteaux"
 
 msgid "battle: show army order"
-msgstr ""
+msgstr "bataille : afficher l'ordre de l'armée"
 
 msgid "battle: soft wait troop"
-msgstr ""
+msgstr "combat: mise en attente"
 
 msgid "battle: reverse wait order (fast, average, slow)"
-msgstr ""
+msgstr "bataille : ordre d'attente inversé (rapide, moyen, lent)"
 
 msgid "game: show system info"
-msgstr ""
+msgstr "jeu : afficher les informations système"
 
 msgid "game: autosave on"
-msgstr ""
+msgstr "jeu: activer sauvegarde auto"
 
 msgid "game: autosave will be made at the beginning of the day"
-msgstr ""
+msgstr "jeu: sauvegarde auto en début de journée"
 
 msgid "game: use fade"
-msgstr ""
+msgstr "jeu: utiliser \"fade\""
 
 msgid "game: use evil interface"
-msgstr ""
+msgstr "jeu: utiliser l'interface maléfique"
 
 msgid "game: hide interface"
-msgstr ""
+msgstr "jeu: cacher l'interface"
 
 msgid "game: offer to continue the game afer victory condition"
-msgstr ""
+msgstr "jeu : offre de continuer le jeu après la victoire"
 
 msgid "The ultimate artifact is really the %{name}."
-msgstr ""
+msgstr "L'artefact ultime est vraiment le %{name}."
 
 msgid "The ultimate artifact may be found in the %{name} regions of the world."
-msgstr ""
+msgstr "L'artefact ultime peut être trouvé dans les régions %{name} du monde."
 
 msgid "north-west"
-msgstr ""
+msgstr "nord-ouest"
 
 msgid "north"
-msgstr ""
+msgstr "nord"
 
 msgid "north-east"
-msgstr ""
+msgstr "nord-est"
 
-#, fuzzy
 msgid "west"
-msgstr "Nid"
+msgstr "ouest"
 
-#, fuzzy
 msgid "center"
-msgstr "Tente"
+msgstr "centre"
 
-#, fuzzy
 msgid "east"
-msgstr "Nid"
+msgstr "est"
 
 msgid "south-west"
-msgstr ""
+msgstr "sud-ouest"
 
-#, fuzzy
 msgid "south"
-msgstr "son"
+msgstr "sud"
 
 msgid "south-east"
-msgstr ""
+msgstr "sud-est"
 
 msgid "The truth is out there."
-msgstr ""
+msgstr "La vérité est là."
 
 msgid "The dark side is stronger."
-msgstr ""
+msgstr "Le côté obscur est plus fort."
 
 msgid "The end of the world is near."
-msgstr ""
+msgstr "La fin du monde est proche."
 
 msgid "The bones of Lord Slayer are buried in the foundation of the arena."
-msgstr ""
+msgstr "Les os du Lord Slayer sont enterrés dans les fondations de l'arène."
 
 msgid "A Black Dragon will take out a Titan any day of the week."
-msgstr ""
+msgstr "Un Dragon Noir éliminera un Titan n'importe quel jour de la semaine."
 
 msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
-msgstr ""
+msgstr "Il lui a dit : Yada yada yada... et puis elle a dit : Bla, bla, bla..."
 
 msgid "An unknown force is being ressurected..."
-msgstr ""
+msgstr "Une force inconnue est ressuscitée..."
 
 msgid ""
 "Check the newest version of game at\n"
 "https://github.com/ihhub/\n"
 "fheroes2/releases"
 msgstr ""
+"Cherchez la dernière version du jeu sur\n"
+"https://github.com/ihhub/\n"
+"fheroes2/releases"
+
+#~ msgid "You don't have enough gold!"
+#~ msgstr "Vous n'avez pas assez d'or!"
 
 #~ msgid "sound"
 #~ msgstr "son"
 
-#, fuzzy
 #~ msgid "ai speed"
-#~ msgstr "Vitesse"
+#~ msgstr "Vitesse CPU"
 
 #~ msgid "Water"
 #~ msgstr "Eau"
+
+#~ msgid "Peasant"
+#~ msgstr "Paysan"
+
+#~ msgid "Peasants"
+#~ msgstr "Paysans"
+
+#~ msgid "Archer"
+#~ msgstr "Archer"
+
+#~ msgid "Archers"
+#~ msgstr "Archers"
+
+#~ msgid "Ranger"
+#~ msgstr "Ranger"
+
+#~ msgid "Rangers"
+#~ msgstr "Rangers"
+
+#~ msgid "Pikeman"
+#~ msgstr "Fantassin"
+
+#~ msgid "Pikemen"
+#~ msgstr "Fantassins"
+
+#~ msgid "Swordsman"
+#~ msgstr "Spadassin"
+
+#~ msgid "Swordsmen"
+#~ msgstr "Spadassins"
+
+#~ msgid "Cavalry"
+#~ msgstr "Cavalier"
+
+#~ msgid "Cavalries"
+#~ msgstr "Cavaliers"
+
+#~ msgid "Champion"
+#~ msgstr "Champion"
+
+#~ msgid "Champions"
+#~ msgstr "Champions"
+
+#~ msgid "Paladin"
+#~ msgstr "Paladin"
+
+#~ msgid "Paladins"
+#~ msgstr "Paladins"
+
+#~ msgid "Halfling"
+#~ msgstr "Galopin"
+
+#~ msgid "Halflings"
+#~ msgstr "Galopins"
+
+#~ msgid "Boar"
+#~ msgstr "Sanglier"
+
+#~ msgid "Boars"
+#~ msgstr "Sangliers"
+
+#~ msgid "Iron Golem"
+#~ msgstr "Golem de fer"
+
+#~ msgid "Iron Golems"
+#~ msgstr "Golems de fer"
+
+#~ msgid "Steel Golem"
+#~ msgstr "Golem d'acier"
+
+#~ msgid "Steel Golems"
+#~ msgstr "Golems d'acier"
+
+#~ msgid "Roc"
+#~ msgstr "Rock"
+
+#~ msgid "Rocs"
+#~ msgstr "Rocks"
+
+#~ msgid "Mage"
+#~ msgstr "Mage"
+
+#~ msgid "Magi"
+#~ msgstr "Mages"
+
+#~ msgid "Archmage"
+#~ msgstr "Archimage"
+
+#~ msgid "Archmagi"
+#~ msgstr "Archimages"
+
+#~ msgid "Giant"
+#~ msgstr "Géant"
+
+#~ msgid "Giants"
+#~ msgstr "Géants"
+
+#~ msgid "Titan"
+#~ msgstr "Titan"
+
+#~ msgid "Titans"
+#~ msgstr "Titans"
 
 #, fuzzy
 #~ msgid "Shoot %{monster} (%{count} shot(s) left)"

--- a/files/lang/fr.po
+++ b/files/lang/fr.po
@@ -1,7 +1,7 @@
 # French translation for fheroes2
 # Copyright (c) 2009 Rosetta Contributors and Canonical Ltd 2009
 # This file is distributed under the same license as the fheroes2 package.
-# dimag0g <dmitry.grigoryev@outlook.com>, 2021.
+# fheroes2 team <fhomm2@gmail.com>, 2021
 #
 msgid ""
 msgstr ""
@@ -9,7 +9,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-07-01 15:11+0200\n"
 "PO-Revision-Date: 2021-07-12 20:50+0200\n"
-"Last-Translator: dimag0g <dmitry.grigoryev@outlook.com>\n"
+"Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
 "Language-Team: French <fr@li.org>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"

--- a/files/lang/ru.po
+++ b/files/lang/ru.po
@@ -1,17 +1,17 @@
 # translation of fheroes2.po to
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-#
+# fheroes2 team <fhomm2@gmail.com>, 2021
 # Igor Orlov <igororlov@inbox.ru>, 2009.
 # Andrey Afletdinov <afletdinov@gmail.com>, 2009.
-# dimag0g <dmitry.grigoryev@outlook.com>, 2021.
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-07-01 15:11+0200\n"
 "PO-Revision-Date: 2021-07-12 20:18+0200\n"
-"Last-Translator: dimag0g <dmitry.grigoryev@outlook.com>\n"
+"Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
 "Language-Team: <ru@li.org> <>\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"

--- a/files/lang/ru.po
+++ b/files/lang/ru.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-07-01 15:11+0200\n"
-"PO-Revision-Date: 2021-07-12 20:18+0200\n"
+"PO-Revision-Date: 2021-07-17 12:55+0200\n"
 "Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
 "Language-Team: <ru@li.org> <>\n"
 "Language: ru\n"
@@ -149,10 +149,10 @@ msgid "%{name} half the enemy troops!"
 msgstr "%{name} убивает половину вражеской армии!"
 
 msgid "Set auto battle off"
-msgstr "Выключить Авто-Битву"
+msgstr "Выключить автобитву"
 
 msgid "Set auto battle on"
-msgstr "Включить Авто-Битву"
+msgstr "Включить автобитву"
 
 msgid "spell failed!"
 msgstr "неудачный вызов магии!"
@@ -189,7 +189,7 @@ msgid "Speed: %{speed}"
 msgstr "Скорость: %{speed}"
 
 msgid "Auto Spell Casting"
-msgstr "Магия в авто-битве"
+msgstr "Магия в автобитве"
 
 msgid "Grid"
 msgstr "Сетка"
@@ -201,10 +201,10 @@ msgid "Shadow Cursor"
 msgstr "Тень-курсор"
 
 msgid "On"
-msgstr "Вкл"
+msgstr "Вкл."
 
 msgid "Off"
-msgstr "Выкл"
+msgstr "Выкл."
 
 msgid "The enemy has surrendered!"
 msgstr "Враг капитулировал!"
@@ -378,7 +378,7 @@ msgid "Ballista"
 msgstr "Баллиста"
 
 msgid "Auto combat"
-msgstr "Авто-Битва"
+msgstr "Автобитва"
 
 msgid "Customize system options."
 msgstr "Изменить настройки системы."
@@ -476,13 +476,13 @@ msgid "%{tower} does %{damage} damage."
 msgstr "Башня \"%{tower}\" наносит %{damage} урона."
 
 msgid "MirrorImage created"
-msgstr "Отражение создано"
+msgstr "Фантомный отряд создан"
 
 msgid "The mirror image is destroyed!"
-msgstr "Фантом уничтожен!"
+msgstr "Фантомный отряд уничтожен!"
 
 msgid "Break auto battle?"
-msgstr "Остановить Авто-Битву?"
+msgstr "Остановить автобитву?"
 
 msgid "No spells to cast."
 msgstr "Нет заклинаний."
@@ -958,7 +958,7 @@ msgstr ""
 "свои города, затем завоюйте варварские."
 
 msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
-msgstr "Верните замок Ivory Gates, который пал из-за предательства."
+msgstr "Верните замок Ворота Слоновой Кости, который пал из-за предательства."
 
 msgid ""
 "Gain the favor of the elves. They will not allow trees to be chopped down, "
@@ -1064,7 +1064,7 @@ msgid "Breastplate"
 msgstr "Божественный Доспех"
 
 msgid "Fibzin Medal"
-msgstr "Медаль за Отвагу"
+msgstr "Символ неудачи"
 
 msgid "Mage's ring"
 msgstr "Кольцо Мага"
@@ -2142,7 +2142,7 @@ msgid "Exit this menu."
 msgstr "Выход из меню."
 
 msgid "off"
-msgstr "Выкл"
+msgstr "выкл."
 
 msgid "MIDI"
 msgstr "MIDI"
@@ -2175,7 +2175,7 @@ msgid "Show"
 msgstr "Показать"
 
 msgid "Auto Resolve"
-msgstr "Авто-Битва"
+msgstr "Автобитва"
 
 msgid "Auto, No Spells"
 msgstr "Авто без Магии"

--- a/files/lang/ru.po
+++ b/files/lang/ru.po
@@ -4,23 +4,23 @@
 #
 # Igor Orlov <igororlov@inbox.ru>, 2009.
 # Andrey Afletdinov <afletdinov@gmail.com>, 2009.
+# dimag0g <dmitry.grigoryev@outlook.com>, 2021.
 msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-07-01 15:11+0200\n"
-"PO-Revision-Date: 2013-03-04 05:27+0000\n"
-"Last-Translator: Watervolt <c347228@rmqkr.net>\n"
-"Language-Team: <ru@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2021-07-12 20:18+0200\n"
+"Last-Translator: dimag0g <dmitry.grigoryev@outlook.com>\n"
+"Language-Team: <ru@li.org> <>\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Launchpad-Export-Date: 2013-10-09 02:01+0000\n"
-"X-Generator: Launchpad (build 16799)\n"
-"X-Poedit-Bookmarks: 63,299,625,629,-1,-1,-1,-1,-1,-1\n"
+"X-Generator: Poedit 3.0\n"
 
 msgid ""
 "A few\n"
@@ -33,14 +33,14 @@ msgid ""
 "Several\n"
 "%{monster}"
 msgstr ""
-"Несколько\n"
+"Немного\n"
 "%{monster}"
 
 msgid ""
 "A pack of\n"
 "%{monster}"
 msgstr ""
-"Группа\n"
+"Стая\n"
 "%{monster}"
 
 msgid ""
@@ -89,10 +89,10 @@ msgid "army|Few"
 msgstr "Мало"
 
 msgid "army|Several"
-msgstr "Несколько"
+msgstr "Немного"
 
 msgid "army|Pack"
-msgstr "Группа"
+msgstr "Стая"
 
 msgid "army|Lots"
 msgstr "Много"
@@ -131,7 +131,7 @@ msgid "View %{name}"
 msgstr "Просмотреть %{name}"
 
 msgid "Move or right click to redistribute %{name}"
-msgstr ""
+msgstr "Перемеcтить или нажать правую кнопку, чтобы перераспределить %{name}"
 
 msgid "Combine %{name} armies"
 msgstr "Комбинировать %{name} армии"
@@ -143,7 +143,7 @@ msgid "Select %{name}"
 msgstr "Выбрать %{name}"
 
 msgid "Cannot move last troop"
-msgstr ""
+msgstr "Невозможно переместить последний отряд"
 
 msgid "%{name} half the enemy troops!"
 msgstr "%{name} убивает половину вражеской армии!"
@@ -155,7 +155,7 @@ msgid "Set auto battle on"
 msgstr "Включить Авто-Битву"
 
 msgid "spell failed!"
-msgstr "Неудачный вызов магии!"
+msgstr "неудачный вызов магии!"
 
 msgid ""
 "The Sphere of Negation artifact is in effect for this battle, disabling all "
@@ -179,34 +179,32 @@ msgid ""
 "The Moat reduces by -%{count} the defense skill of any unit and slows to "
 "half movement rate."
 msgstr ""
+"Ров уменьшает на -%{count} навыки обороны любого подразделения и замедляет "
+"его до половины скорости движения."
 
 msgid "Speed"
 msgstr "Скорость"
 
-#, fuzzy
 msgid "Speed: %{speed}"
-msgstr "скорость: %{speed}"
+msgstr "Скорость: %{speed}"
 
-#, fuzzy
 msgid "Auto Spell Casting"
-msgstr "Использовать Магию"
+msgstr "Магия в авто-битве"
 
 msgid "Grid"
-msgstr ""
+msgstr "Сетка"
 
-#, fuzzy
 msgid "Shadow Movement"
-msgstr "Продолжить движение"
+msgstr "Тень при движении"
 
 msgid "Shadow Cursor"
-msgstr ""
+msgstr "Тень-курсор"
 
 msgid "On"
-msgstr ""
+msgstr "Вкл"
 
-#, fuzzy
 msgid "Off"
-msgstr "Выкл."
+msgstr "Выкл"
 
 msgid "The enemy has surrendered!"
 msgstr "Враг капитулировал!"
@@ -217,9 +215,8 @@ msgstr "Враг сбежал!"
 msgid "A glorious victory!"
 msgstr "Блистательная победа!"
 
-#, fuzzy
 msgid "For valor in combat, %{name} receives %{exp} experience."
-msgstr "За доблесть в бою %{name} получает %{exp} опыта"
+msgstr "За доблесть в бою %{name} получает %{exp} опыта."
 
 msgid "The cowardly %{name} flees from battle."
 msgstr "Трусливый %{name} бежал с поля битвы."
@@ -245,17 +242,15 @@ msgstr "Защитник"
 msgid "You have captured an enemy artifact!"
 msgstr "Вы захватили вражеский артефакт!"
 
-#, fuzzy
 msgid "Necromancy!"
-msgstr "Некромантия"
+msgstr "Некромантия!"
 
-#, fuzzy
 msgid ""
 "Practicing the dark arts of necromancy, you are able to raise %{count} of "
 "the enemy's dead to return under your service as %{monster}."
 msgstr ""
-"Успешная практика в искусстве Некроманта, помогла поднять %{count} мертвых "
-"врагов как %{monster} для Вашей армии"
+"Успешная практика в искусстве Некроманта помогла поднять %{count} мертвых "
+"врагов как %{monster} для Вашей армии."
 
 msgid "%{name} the %{race}"
 msgstr "%{name} %{race}"
@@ -299,14 +294,13 @@ msgstr "Отмена"
 msgid "Hero Screen"
 msgstr "Экран героя"
 
-#, fuzzy
 msgid ""
 "Cast a magical spell. You may only cast one spell per combat round. The "
 "round is reset when every creature has had a turn."
 msgstr ""
-"Совершает магическое заклинание. Вы можете произносить только одно "
-"заклинание в течение раунда. Новый раунд начинается после того, как каждое "
-"существо сделает ход."
+"Магическое заклинание. Вы можете произносить только одно заклинание в "
+"течение раунда. Новый раунд начинается после того, как каждое существо "
+"сделает ход."
 
 msgid ""
 "Retreat your hero, abandoning your creatures. Your hero will be available "
@@ -323,34 +317,31 @@ msgstr ""
 "Капитуляция стоит денег. Однако, если вы заплатите выкуп, героя можно будет "
 "нанять вместе со всеми выжившими существами."
 
-#, fuzzy
 msgid "Open Hero Screen to view full information about the hero."
-msgstr "Позволяет получить подробную информацию о героях противника."
+msgstr "Открыть экран с подробной информацией о герое."
 
 msgid "Return to the battle."
 msgstr "Вернутся к сражению."
 
 msgid "Not enough gold (%{gold})"
-msgstr ""
+msgstr "Недостаточно золота (%{gold})"
 
 msgid "%{name} states:"
 msgstr "Параметры %{name}:"
 
-#, fuzzy
 msgid ""
 "\"I will accept your surrender and grant you and your troops safe passage "
 "for the price of %{price} gold.\""
 msgstr ""
-"Я приму вашу капитуляцию и предоставлю безопасный проход вам и вашим войскам "
-"за %{price} золотом."
+"\"Я приму вашу капитуляцию и предоставлю безопасный проход вам и вашим "
+"войскам за %{price} золотом.\""
 
 msgid "View %{monster} info."
 msgstr "Показать информацию для %{monster}."
 
-#, fuzzy
 msgid "Shoot %{monster}"
 msgstr ""
-"Много\n"
+"Стрелять \n"
 "%{monster}"
 
 msgid "Attack %{monster}"
@@ -381,16 +372,16 @@ msgid "Select Spell Target"
 msgstr "Выберите цель заклинания"
 
 msgid "View Ballista Info"
-msgstr ""
+msgstr "Информация о баллисте"
 
 msgid "Ballista"
-msgstr ""
+msgstr "Баллиста"
 
 msgid "Auto combat"
 msgstr "Авто-Битва"
 
 msgid "Customize system options."
-msgstr "Изменить настройки"
+msgstr "Изменить настройки системы."
 
 msgid "Wait this unit"
 msgstr "Подождать"
@@ -422,9 +413,8 @@ msgstr "%{attacker} наносит %{damage} урона."
 msgid "Moved %{monster}: %{src}, %{dst}"
 msgstr "Ход %{monster}: %{src}, %{dst}"
 
-#, fuzzy
 msgid "Moved %{monster}"
-msgstr "Идти сюда."
+msgstr "Ход %{monster}"
 
 msgid "The %{name} resist the spell!"
 msgstr "%{name} защитился от магии!"
@@ -435,26 +425,23 @@ msgstr "%{name} применяет \"%{spell}\" (цель: %{troop})."
 msgid "%{name} casts %{spell}."
 msgstr "%{name} применил \"%{spell}\"."
 
-#, fuzzy
 msgid "The %{spell} does %{damage} damage to one undead creature."
-msgstr "Заклинание \"%{spell}\" наносит %{damage} урона всей нежити."
+msgstr "Заклинание \"%{spell}\" наносит %{damage} урона одной нежити."
 
-#, fuzzy
 msgid "The %{spell} does %{damage} damage to all undead creatures."
 msgstr "Заклинание \"%{spell}\" наносит %{damage} урона всей нежити."
 
-#, fuzzy
 msgid "The %{spell} does %{damage} damage, %{count} creatures perish."
-msgstr "Заклинание \"%{spell}\" наносит %{damage} урона всей нежити."
+msgstr ""
+"Заклинание \"%{spell}\" наносит %{damage} урона, %{count} существ погибают."
 
 msgid "The %{spell} does %{damage} damage."
 msgstr "Заклинание \"%{spell}\" наносит %{damage} урона."
 
-#, fuzzy
 msgid "The %{spell} does %{damage} damage to one living creature."
-msgstr "Заклинание \"%{spell}\" наносит %{damage} урона всем живым существам."
+msgstr ""
+"Заклинание \"%{spell}\" наносит %{damage} урона одному живому существу."
 
-#, fuzzy
 msgid "The %{spell} does %{damage} damage to all living creatures."
 msgstr "Заклинание \"%{spell}\" наносит %{damage} урона всем живым существам."
 
@@ -473,7 +460,6 @@ msgstr "%{name} парализованы Циклопами!"
 msgid "The Archmagi dispel all good spells on your %{name}!"
 msgstr "Архимаги рассеяли хорошую магию с отряда %{name}!"
 
-#, fuzzy
 msgid "Good luck shines on the %{attacker}"
 msgstr "Удача улыбнулась %{attacker}"
 
@@ -486,19 +472,17 @@ msgstr "Благодаря высокой морали %{monster} атакуют
 msgid "Low morale causes the %{monster} to freeze in panic."
 msgstr "Из-за низкой морали %{monster} застыли в панике."
 
-#, fuzzy
 msgid "%{tower} does %{damage} damage."
-msgstr "Башня наносит %{damage} урона."
+msgstr "Башня \"%{tower}\" наносит %{damage} урона."
 
 msgid "MirrorImage created"
-msgstr "MirrorImage создано."
+msgstr "Отражение создано"
 
 msgid "The mirror image is destroyed!"
-msgstr ""
+msgstr "Фантом уничтожен!"
 
-#, fuzzy
 msgid "Break auto battle?"
-msgstr "Включить Авто-Битву"
+msgstr "Остановить Авто-Битву?"
 
 msgid "No spells to cast."
 msgstr "Нет заклинаний."
@@ -506,13 +490,11 @@ msgstr "Нет заклинаний."
 msgid "Are you sure you want to retreat?"
 msgstr "Вы действительно хотите отступить?"
 
-#, fuzzy
 msgid "Retreat disabled"
-msgstr "Отступить"
+msgstr "Нельзя отступить"
 
-#, fuzzy
 msgid "Surrender disabled"
-msgstr "Сдаться"
+msgstr "Нельзя сдаться"
 
 msgid "Damage: %{max}"
 msgstr "Ущерб: %{max}"
@@ -539,10 +521,10 @@ msgid "Right Turret"
 msgstr "Правая Башня"
 
 msgid "The %{name} fires with the strength of %{count} Archers"
-msgstr ""
+msgstr "%{name} стреляет силой %{count} лучников"
 
 msgid "each with a +%{attack} bonus to their attack skill."
-msgstr ""
+msgstr "каждый с бонусом +%{attack} к своему навыку атаки."
 
 msgid ""
 "The %{artifact} artifact is in effect for this battle, disabling %{spell} "
@@ -552,177 +534,149 @@ msgstr "%{artifact} запрещает использовать \"%{spell}\"."
 msgid "%{count} %{name} rise(s) from the dead!"
 msgstr "%{count} %{name} воскресли из мертвых!"
 
-#, fuzzy
 msgid "Sorceress Guild"
-msgstr "Колдунья"
+msgstr "Гильдия Волшебниц"
 
-#, fuzzy
 msgid "Necromancer Guild"
-msgstr "Некромант"
+msgstr "Гильдия Некромантов"
 
-#, fuzzy
 msgid "Dragon Alliance"
-msgstr "Разрушенный Союз"
+msgstr "Альянс Драконов"
 
-#, fuzzy
 msgid "Elven Alliance"
-msgstr "Разрушенный Союз"
+msgstr "Альянс Эльфов"
 
 msgid "Wayward Son"
-msgstr ""
+msgstr "Блудный Сын"
 
 msgid "Uncle Ivan"
 msgstr "Дядя Ваня"
 
-#, fuzzy
 msgid "Force of Arms"
-msgstr "\"Сила Оружия\""
+msgstr "Сила Оружия"
 
-#, fuzzy
 msgid "Annexation"
-msgstr "\"Присоединение\""
+msgstr "Присоединение"
 
-#, fuzzy
 msgid "Save the Dwarves"
-msgstr "\"Спасите Гномов\""
+msgstr "Спасите Гномов"
 
-#, fuzzy
 msgid "Carator Mines"
-msgstr "\"Шахты Каратора\""
+msgstr "Копи Каратора"
 
-#, fuzzy
 msgid "Turning Point"
-msgstr "Базар"
+msgstr "Переломный Момент"
 
 msgid "The Gauntlet"
-msgstr ""
+msgstr "Защитник"
 
-#, fuzzy
 msgid "The Crown"
-msgstr "Западный город"
+msgstr "Корона"
 
-#, fuzzy
 msgid "Corlagon's Defense"
-msgstr "Корлагон"
+msgstr "Защита Корлагона"
 
 msgid "Final Justice"
-msgstr ""
+msgstr "Акт отчаяния"
 
-#, fuzzy
 msgid "First Blood"
-msgstr "\"Первая кровь\""
+msgstr "Первая Кровь"
 
-#, fuzzy
 msgid "Barbarian Wars"
-msgstr "\"Война Варваров\""
+msgstr "Войны Варваров"
 
-#, fuzzy
 msgid "Necromancers"
-msgstr "Некромант"
+msgstr "Некроманты"
 
-#, fuzzy
 msgid "Slay the Dwarves"
-msgstr "\"Спасите Гномов\""
+msgstr "Уничтожь Гномов"
 
 msgid "Rebellion"
-msgstr ""
+msgstr "Бунт"
 
-#, fuzzy
 msgid "Dragon Master"
-msgstr "\"Повелитель Драконов\""
+msgstr "Драконий Мастер"
 
-#, fuzzy
 msgid "Country Lords"
-msgstr "\"Страна Лордов\""
+msgstr "Лорды Провинций"
 
-#, fuzzy
 msgid "Greater Glory"
-msgstr "\"Великая Слава\""
+msgstr "К Вящей Славе"
 
-#, fuzzy
 msgid "Apocalypse"
 msgstr "Апокалипсис"
 
 msgid "Uprising"
-msgstr ""
+msgstr "Восстание"
 
-#, fuzzy
 msgid "Island of Chaos"
-msgstr "Остров Эльфов"
+msgstr "Остров Хаоса"
 
 msgid "Arrow's Flight"
-msgstr ""
+msgstr "Полёт Стрелы"
 
 msgid "The Abyss"
-msgstr ""
+msgstr "Бездна"
 
 msgid "The Giant's Pass"
-msgstr ""
+msgstr "Перевал Гигантов"
 
 msgid "Aurora Borealis"
-msgstr ""
+msgstr "Северное Сияние"
 
-#, fuzzy
 msgid "Betrayal's End"
-msgstr "\"Измена!\""
+msgstr "Конец Предательства"
 
-#, fuzzy
 msgid "Corruption's Heart"
-msgstr "Капитанский штаб"
+msgstr "Сердце Скверны"
 
 msgid "Conquer and Unify"
-msgstr ""
+msgstr "Завоевать и объединить"
 
-#, fuzzy
 msgid "Border Towns"
-msgstr "Пограничье"
+msgstr "Пограничные Города"
 
 msgid "The Wayward Son"
-msgstr ""
+msgstr "Блудный Сын"
 
-#, fuzzy
 msgid "Crazy Uncle Ivan"
 msgstr "Дядя Ваня"
 
 msgid "The Southern War"
-msgstr ""
+msgstr "Южная война"
 
 msgid "Ivory Gates"
 msgstr "Ворота Слоновой Кости"
 
-#, fuzzy
 msgid "The Elven Lands"
-msgstr "Семь Озер"
+msgstr "Эльфийские Земли"
 
 msgid "The Epic Battle"
-msgstr ""
+msgstr "Эпическая Битва"
 
 msgid "The Shrouded Isles"
-msgstr ""
+msgstr "Острова чародеев"
 
 msgid "The Eternal Scrolls"
-msgstr ""
+msgstr "Вечные свитки"
 
-#, fuzzy
 msgid "Power's End"
-msgstr "Кольцо Силы"
+msgstr "Конец Власти"
 
-#, fuzzy
 msgid "Fount of Wizardry"
-msgstr "Волшебный Посох"
+msgstr "Источник Волшебства"
 
 msgid "Stranded"
-msgstr ""
+msgstr "На мели"
 
-#, fuzzy
 msgid "Pirate Isles"
 msgstr "Пиратская Бухта"
 
 msgid "King and Country"
-msgstr ""
+msgstr "Король и Страна"
 
 msgid "Blood is Thicker"
-msgstr ""
+msgstr "Кровные Узы"
 
 msgid ""
 "Roland needs you to defeat the lords near his castle to begin his war of "
@@ -730,29 +684,44 @@ msgid ""
 "will spend most of their time fighting with one another.  Victory is yours "
 "when you have defeated all of their castles and heroes."
 msgstr ""
+"Роланду нужно, чтобы вы победили лордов возле его замка, чтобы начать войну "
+"восстания против своего брата.  Они не являются союзниками друг друга, "
+"поэтому большую часть времени они будут проводить в борьбе друг с другом.  "
+"Победа будет за вами, когда вы победите все их замки и героев."
 
 msgid ""
 "The local lords refuse to swear allegiance to Roland, and must be subdued. "
 "They are wealthy and powerful, so be prepared for a tough fight. Capture all "
 "enemy castles to win."
 msgstr ""
+"Местные лорды отказываются присягать на верность Роланду и должны быть "
+"покорены. Они богаты и могущественны, поэтому будьте готовы к жесткой "
+"борьбе. Захватите все вражеские замки, чтобы выиграть."
 
 msgid ""
 "Your task is to defend the Dwarves against Archibald's forces. Capture all "
 "of the enemy towns and castles to win, and be sure not to lose all of the "
 "dwarf towns at once, or the enemy will have won."
 msgstr ""
+"Ваша задача защитить гномов от сил Арчибальда. Захват всех вражеских городов "
+"и замков, чтобы выиграть, и не забудьте не потерять все города гномов "
+"одновременно, или враг победит."
 
 msgid ""
 "You will face four allied enemies in a straightforward fight for resource "
 "and treasure. Capture all of the enemy castles for victory."
 msgstr ""
+"Вы столкнетесь с четырьмя врагами союзников в прямой борьбе за ресурс и "
+"сокровища. Захватите все вражеские замки для победы."
 
 msgid ""
 "Your enemies are allied against you and start close by, so be ready to come "
 "out fighting. You will need to own all four castles in this small valley to "
 "win."
 msgstr ""
+"Ваши враги в союзе против вас и находятся рядом, так что будьте готовы к "
+"боевым действиям. Вам нужно будет владеть всеми четырьмя замками в этой "
+"маленькой долине, чтобы выиграть."
 
 msgid ""
 "The Sorceress' guild of Noraston has requested Roland's aid against an "
@@ -760,6 +729,10 @@ msgid ""
 "don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy "
 "castle on an island in the ocean.)"
 msgstr ""
+"Гильдия Волшебниц Норастона обратилась к Роланду с просьбой о помощи в "
+"борьбе с нападением союзников Арчибальда. Захват все вражеские замки, чтобы "
+"выиграть, и не теряйте Норастон, или вы проиграете сценарий. (Подсказка: "
+"Существует вражеский замок на острове в океане.)"
 
 msgid ""
 "Gather as large an army as possible and capture the enemy castle within 8 "
@@ -767,11 +740,17 @@ msgid ""
 "to the enemy castle. Any troops you have in your army at the end of this "
 "scenario will be with you in the final battle."
 msgstr ""
+"Соберите как можно больше армии, и захватите вражеский замок в течение 8 "
+"недель. Вам противостоит только один враг, но вам нужно пройти долгий путь, "
+"чтобы добраться до вражеского замка. Все войска в вашей в армии в конце "
+"этого сценария будут с вами в финальной битве."
 
 msgid ""
 "Find the Crown before Archibald's heroes find it. Roland will need the Crown "
 "for the final battle against Archibald."
 msgstr ""
+"Найдите корону до того, как герои Арчибальда найдут ее. Роланду понадобится "
+"Корона для финальной битвы против Арчибальда."
 
 msgid ""
 "Three allied enemies stand before you and victory, including Lord Corlagon. "
@@ -779,11 +758,17 @@ msgid ""
 "enemy. Remember that capturing Lord Corlagon will ensure that he will not "
 "fight against you in the final scenario."
 msgstr ""
+"Три союзных врага стоят перед вами и победа, в том числе лорд Корлагон. "
+"Роланд находится в замке на северо-западе, и вы проиграете, если потеряете "
+"его. Помните, что захват лорда Корлагона будет гарантировать, что он не "
+"будет бороться против вас в окончательном сценарии."
 
 msgid ""
 "This is the final battle. Both you and your enemy are armed to the teeth, "
 "and all are allied against you. Capture Archibald to end the war!"
 msgstr ""
+"Это последняя битва. И вы, и ваш враг вооружены до зубов, и все враги в "
+"союзе против вас. Захватите Арчибальда, чтобы положить конец войне!"
 
 msgid ""
 "King Archibald requires you to defeat the three enemies in this region.  "
@@ -791,6 +776,10 @@ msgid ""
 "energy fighting amongst themselves.  You will win when you own all of the "
 "enemy castles and there are no more heroes left to fight."
 msgstr ""
+"Король Арчибальд требует, чтобы вы победили трех врагов в этом регионе.  Они "
+"не в союзе друг с другом, поэтому будут тратить большую часть своей энергии "
+"на борьбу между собой.  Вы выиграете, когда захватите все вражеские замки "
+"героев."
 
 msgid ""
 "You must unify the barbarian tribes of the north by conquering them. As in "
@@ -798,6 +787,10 @@ msgid ""
 "more resources at their disposal. You will win when you own all of the enemy "
 "castles and there are no more heroes left to fight."
 msgstr ""
+"Вы должны объединить варварские племена севера, завоевав их. Как и в "
+"предыдущей миссии, враг не является союзником против вас, но они имеют "
+"больше ресурсов в их распоряжении. Вы выиграете, когда захватите все "
+"вражеские замки героев."
 
 msgid ""
 "Do-gooder wizards have taken the Necromancers' castle. You must retake it to "
@@ -805,6 +798,10 @@ msgid ""
 "have no castle and must take one within 7 days, or lose this battle. (Hint: "
 "The nearest castle is to the southeast.)"
 msgstr ""
+"Благодетели-волшебники взяли замок Некромантов. Вы должны вернуть его, чтобы "
+"добиться победы. Помните, что в то время как вы начинаете с мощной армии, у "
+"вас нет замка и должны принять один в течение 7 дней, или проиграть эту "
+"битву. (Подсказка: Ближайший замок находится на юго-востоке.)"
 
 msgid ""
 "The dwarves need conquering before they can interfere in King Archibald's "
@@ -812,18 +809,28 @@ msgid ""
 "so be ready for attack from multiple directions. You must capture all of the "
 "enemy towns and castles to claim victory."
 msgstr ""
+"Гномов нужно победить, прежде чем они посмеют вмешаться в планы короля "
+"Арчибальда. Силы Роланда имеют более одного героя и много городов, так что "
+"будьте готовы к атаке с нескольких направлений. Вы должны захватить все "
+"вражеские города и замки, чтобы претендовать на победу."
 
 msgid ""
 "You must put down a peasant revolt led by Roland's forces. All are allied "
 "against you, but you have Lord Corlagon, an experienced hero, to help you. "
 "Capture all enemy castles to win."
 msgstr ""
+"Вы должны положить конец крестьянскому восстанию во главе с силами Роланда. "
+"Все они объединились против вас, но у вас есть лорд Корлагон, опытный герой, "
+"чтобы помочь вам. Захватите все вражеские замки, чтобы выиграть."
 
 msgid ""
 "There are two enemies allied against you in this mission. Both are well "
 "armed and seek to evict you from their island. Avoid them and capture Dragon "
 "City to win"
 msgstr ""
+"В этой миссии вам противостоят два союзника. Оба хорошо вооружены и "
+"стремятся выселить вас со своего острова. Избегайте их и захватить Город "
+"Драконов, чтобы выиграть"
 
 msgid ""
 "Your orders are to conquer the country lords that have sworn to serve "
@@ -831,32 +838,47 @@ msgid ""
 "without a castle, you must hurry to capture one before the end of the week. "
 "Capture all enemy castles for victory."
 msgstr ""
+"Вам приказано завоевать страну лордов, которые поклялись служить Роланду. "
+"Все вражеские замки объединены против вас. Так как вы начинаете без замка, "
+"вы должны спешить, чтобы захватить один до конца недели. Захватите все "
+"вражеские замки для победы."
 
 msgid ""
 "Find the Crown before Roland's heroes find it. Archibald will need the Crown "
 "for the final battle against Roland."
 msgstr ""
+"Найдите корону до того, как ее найдут герои Роланда. Арчибальду понадобится "
+"Корона для финальной битвы против Роланда."
 
 msgid ""
 "This is the final battle. Both you and your enemy are armed to the teeth, "
 "and all are allied against you. Capture Roland to win the war, and be sure "
 "not to lose Archibald in the fight!"
 msgstr ""
+"Это последняя битва. И вы, и ваш враг вооружены до зубов, и все они связаны "
+"против вас. Захватите Роланда, чтобы выиграть войну, и не забудьте не "
+"потерять Арчибальда в бою!"
 
 msgid ""
 "Subdue the unruly local lords in order to provide the Empire with facilities "
 "to operate in this region."
 msgstr ""
+"Покорите непослушных местных лордов, с тем чтобы обеспечить Империю "
+"средствами для работы в этом регионе."
 
 msgid ""
 "Eliminate all oposition in this area. Then the first piece of the artifact "
 "will be yours."
 msgstr ""
+"Устраните всю опозицию в этой области. Тогда первая часть артефакта будет "
+"твоей."
 
 msgid ""
 "The sorceresses to the northeast are rebelling! For the good of the empire "
 "you must quash their feeble uprising on your way to the mountains."
 msgstr ""
+"Волшебницы на северо-востоке восстают! На благо империи вы должны подавить "
+"их слабое восстание на пути в горы."
 
 msgid ""
 "Having prepared for your arrival, Kraeger has arranged for a force of "
@@ -864,39 +886,54 @@ msgid ""
 "before the first day of the third week, or the Necromancers will be too "
 "strong for you."
 msgstr ""
+"Подготовившись к вашему приезду, Крэгер организовал силу некромантов, чтобы "
+"сорвать ваши поиски. Вы должны захватить замок Скабсдейл до первого дня "
+"третьей недели, или некроманты будут слишком сильны для вас."
 
 msgid ""
 "The barbarian despot in this area is, as yet, ignorant of your presence. "
 "Quickly, build up your forces before you are discovered and attacked! Secure "
 "the region by subduing all enemy forces."
 msgstr ""
+"Варварский деспот в этой области пока не знает о вашем присутствии. Быстро, "
+"нарастите свои силы, прежде чем он обнаружит вас и нападёт! Защитите регион, "
+"покорив все вражеские силы."
 
 msgid ""
 "The Empire is weak in this region. You will be unable to completely subdue "
 "all forces in this area, so take what you can before reprisal strikes. "
 "Remember, your true goal is to claim the Helmet of Anduran."
 msgstr ""
+"Империя слаба в этом регионе. Вы не сможете полностью подавить все силы в "
+"этой области, так что возьмите то, что вы можете до ответных ударов. "
+"Помните, что ваша истинная цель состоит в том, чтобы получить шлем Анурана."
 
 msgid "For the good of the Empire, eliminate Kraeger."
-msgstr ""
+msgstr "На благо Империи уничтожьте Крэгера."
 
 msgid ""
 "At last, you have the opportunity and the facilities to rid the Empire of "
 "the necromancer's evil. Eradicate them completely, and you will be sung as a "
 "hero for all time."
 msgstr ""
+"Наконец, у вас есть возможность и средства, чтобы избавить Империю от зла "
+"некромантов. Искоренить их полностью, и вы будете воспеты, как герой на все "
+"времена."
 
 msgid ""
 "Conquer and unite all the enemy tribes. Don't lose the hero Jarkonas, the "
 "forefather of all descendants."
 msgstr ""
+"Завоюйтеь и объедините все вражеские племена. Не потеряйте героя Жарконаса, "
+"прародителя всех потомков."
 
 msgid ""
 "Your rival, the Kingdom of Harondale, is attacking weak towns on your "
 "border! Recover from their first strike and crush them completely!"
 msgstr ""
+"Ваш соперник, Королевство Харондейл, атакует слабые города на вашей границе! "
+"Оправитесь от их первого удара и сокрушите их полностью!"
 
-#, fuzzy
 msgid ""
 "Find your wayward son Joseph who is rumored to be living in the desolate "
 "lands. Do it before the first day of the third month or it will be of no "
@@ -909,8 +946,9 @@ msgid ""
 "Rescue your crazy uncle Ivan. Find him before the first day of the fourth "
 "month or it will be no help to your kingdom."
 msgstr ""
+"Спасите своего сумасшедшего дядю Ивана. Найдите его до первого дня "
+"четвертого месяца, иначе он не поможет вашему королевству."
 
-#, fuzzy
 msgid ""
 "Destroy the barbarians who are attacking the southern border of your "
 "kingdom! Recover your fallen towns, and then invade the jungle kingdom. "
@@ -920,32 +958,37 @@ msgstr ""
 "свои города, затем завоюйте варварские."
 
 msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
-msgstr ""
+msgstr "Верните замок Ivory Gates, который пал из-за предательства."
 
-#, fuzzy
 msgid ""
 "Gain the favor of the elves. They will not allow trees to be chopped down, "
 "so they will send you wood every 2 weeks. You must complete your mission "
 "before the first day of the seventh month, or the kingdom will surely fall."
 msgstr ""
 "Получите поддержу эльфов. Они не позволят Вам рубить лес, так что мы будет "
-"отправлять Вам древесину каждые две недели. У Вас есть 7 месяцев!"
+"отправлять Вам древесину каждые две недели. У Вас есть 6 месяцев."
 
 msgid ""
 "This is the final battle against your rival kingdom of Harondale. Eliminate "
 "everyone, and don't lose the hero Jarkonas VI."
 msgstr ""
+"Это последняя битва против соперничающего королевства Харондейл. Уничтожьте "
+"всех и не потеряйте героя Джарконаса VI."
 
 msgid ""
 "Your mission is to vanquish the warring mages in the magical Shrouded Isles. "
 "The completion of this task will give you a fighting chance against your "
 "rivals."
 msgstr ""
+"Ваша миссия - победить воинтсвенных магов на волшебных Окутанных островах. "
+"Выполнение этой задачи даст вам шанс побороться с соперниками."
 
 msgid ""
 "The location of the great library has been dicovered! You must make your way "
 "to it, and reclaim the city of Chronos in which it lies."
 msgstr ""
+"Местонахождение великой библиотеки было обнаружено! Вы должны добраться до "
+"нее и вернуть себе город Хронос, в котором она находится."
 
 msgid ""
 "Find the Orb of negation, which is said to be buried in this land. There are "
@@ -953,13 +996,18 @@ msgid ""
 "Find the orb before the first day of the sixth month, or your rivals will "
 "surely have gotten to the fount before you."
 msgstr ""
+"Найдите Сферу отрицания, которая, как говорят, похоронена в этой земле. На "
+"каменных обелисках начертаны подсказки, которые помогут вам найти её. "
+"Найдите сферу до первого дня шестого месяца, иначе ваши соперники наверняка "
+"доберутся до источника раньше вас."
 
 msgid ""
 "You must take control of the castle of Magic, where the fount of wizardry "
 "lies. Do this and your victory will be supreme."
 msgstr ""
+"Вы должны взять под контроль замок Магии, где находится источник волшебства. "
+"Сделайте это, и ваша победа будет окончательной."
 
-#, fuzzy
 msgid ""
 "Capture the town on the island off the southeast shore in order to construct "
 "a boat and travel back towards the mainland. Do not lose the hero Gallavant."
@@ -971,67 +1019,64 @@ msgid ""
 "Find and defeat Martine, the pirate leader, who resides in Pirates Cove. Do "
 "not lose Gallavant or your quest will be over."
 msgstr ""
+"Найдите и победите Мартина, предводителя пиратов, который живет в Бухте "
+"пиратов. Не потеряйте Галаванта, иначе ваши поиски закончатся."
 
 msgid ""
 "Eliminate all the other forces who oppose the rule of Lord Alberon. "
 "Gallavant must not die."
 msgstr ""
+"Уничтожьте все другие силы, выступающие против правления лорда Альберона. "
+"Галавант не должен погибнуть."
 
 msgid ""
 "Overthrow the entrenched monarchy of Lord Alberon, and claim all the land in "
 "your name. Gallavant must not die."
 msgstr ""
+"Свергните укоренившуюся монархию лорда Альберона и объявите все земли своим "
+"именем. Галавант не должен умереть."
 
 msgid " bane"
-msgstr ""
+msgstr " яд"
 
-#, fuzzy
 msgid " alliance"
-msgstr "Разрушенный Союз"
+msgstr " союз"
 
 msgid "Carry-over forces"
-msgstr ""
+msgstr "Перенос войск"
 
 msgid " bonus"
-msgstr ""
+msgstr " бонус"
 
 msgid " defeated"
-msgstr ""
+msgstr " поражение"
 
-#, fuzzy
 msgid "Thunder Mace"
 msgstr "Громовая Палица"
 
-#, fuzzy
 msgid "Minor Scroll"
 msgstr "Малый Свиток Знания"
 
-#, fuzzy
 msgid "Dragon Sword"
-msgstr "Убить Дракона"
+msgstr "Драконий Меч"
 
-#, fuzzy
 msgid "Breastplate"
-msgstr "Кираса Андурана"
+msgstr "Божественный Доспех"
 
-msgid "Fizbin Medal"
-msgstr ""
+msgid "Fibzin Medal"
+msgstr "Медаль за Отвагу"
 
-#, fuzzy
 msgid "Mage's ring"
 msgstr "Кольцо Мага"
 
-#, fuzzy
 msgid "Defender Helm"
-msgstr "Защитник"
+msgstr "Шлем Защитника"
 
-#, fuzzy
 msgid "Power Axe"
-msgstr "Сила магии"
+msgstr "Топор Власти"
 
-#, fuzzy
 msgid "Summon Earth"
-msgstr "Призвать корабль"
+msgstr "Земной элементал"
 
 msgid "The %{building} produces %{monster}."
 msgstr "В %{building} можно нанять %{monster}."
@@ -1048,21 +1093,17 @@ msgstr "Для этого вам нужно сперва построить за
 msgid "Cannot build %{name} because castle is too far from water."
 msgstr "%{name} невозможно построить, потому что замок слишком далеко от воды."
 
-#, fuzzy
 msgid "Cannot afford %{name}."
-msgstr "Нельзя построить %{name}"
+msgstr "Недостаточно золота для найма %{name}."
 
-#, fuzzy
 msgid "%{name} is already built."
 msgstr "Это здание уже построено."
 
-#, fuzzy
 msgid "Cannot build %{name}."
-msgstr "%{name} построить не получится."
+msgstr "Невозможно построить: %{name}."
 
-#, fuzzy
 msgid "Build %{name}."
-msgstr "%{name} построено."
+msgstr "Построить %{name}."
 
 msgid "Thieves' Guild"
 msgstr "Гильдия Воров"
@@ -1095,19 +1136,19 @@ msgid "Captain's Quarters"
 msgstr "Капитанский штаб"
 
 msgid "Mage Guild, Level 1"
-msgstr "Гильдия Магов 1-го уровня"
+msgstr "Гильдия Магов 1 уровня"
 
 msgid "Mage Guild, Level 2"
-msgstr "Гильдия Магов 2-го уровня"
+msgstr "Гильдия Магов 2 уровня"
 
 msgid "Mage Guild, Level 3"
-msgstr "Гильдия Магов 3-го уровня"
+msgstr "Гильдия Магов 3 уровня"
 
 msgid "Mage Guild, Level 4"
-msgstr "Гильдия Магов 4-го уровня"
+msgstr "Гильдия Магов 4 уровня"
 
 msgid "Mage Guild, Level 5"
-msgstr "Гильдия Магов 5-го уровня"
+msgstr "Гильдия Магов 5 уровня"
 
 msgid "Farm"
 msgstr "Ферма"
@@ -1307,12 +1348,13 @@ msgstr "Черная башня"
 msgid "Shrine"
 msgstr "Алтарь"
 
-#, fuzzy
 msgid ""
 "The Thieves' Guild provides information on enemy players. Thieves' Guilds "
 "can also provide scouting information on enemy towns. Additional Guilds "
 "provide more information."
-msgstr "Гильдия воров предоставляет информацию о вражеских игроках и городах."
+msgstr ""
+"Гильдия воров предоставляет информацию о вражеских игроках и городах. "
+"Дополнительные гильдии дают больше информации."
 
 msgid "The Tavern increases morale for troops defending the castle."
 msgstr "Таверна повышает мораль защитников замка на 1."
@@ -1430,9 +1472,8 @@ msgstr "Алтарь увеличивает навык некромантии у
 msgid "Cannot recruit - you already recruit hero in current week."
 msgstr "Найм невозможен. На этой неделе Вы уже нанимали героя."
 
-#, fuzzy
 msgid "Cannot recruit - guest to guard automove error."
-msgstr "Найм невозможен. Вы уже имеете максимум героев."
+msgstr "Найм невозможен - guest to guard automove error."
 
 msgid "Cannot recruit - you already have a Hero in this town."
 msgstr "Найм невозможен. В замке уже есть герой."
@@ -1441,10 +1482,10 @@ msgid "Cannot recruit - you have too many Heroes."
 msgstr "Найм невозможен. Вы уже имеете максимум героев."
 
 msgid "Cannot afford a Hero"
-msgstr "Найм невозможен. У Вас не достаточно средств."
+msgstr "Недостаточно средств для найма"
 
 msgid "There is no room in the garrison for this army."
-msgstr ""
+msgstr "Нет места в гарнизоне."
 
 msgid "Recruit %{name}"
 msgstr "Нанять  %{name}"
@@ -1452,16 +1493,14 @@ msgstr "Нанять  %{name}"
 msgid "Month: %{month}, Week: %{week}, Day: %{day}"
 msgstr "Месяц: %{month}, Неделя: %{week}, День: %{day}"
 
-#, fuzzy
 msgid "Income"
-msgstr "Доход:"
+msgstr "Доход"
 
-#, fuzzy
 msgid "Join Error"
-msgstr "Ошибка"
+msgstr "Ошибка подключения"
 
 msgid "Army is full"
-msgstr ""
+msgstr "Нет места"
 
 msgid ""
 "You must purchase a spell book to use the mage guild, but you currently have "
@@ -1476,17 +1515,14 @@ msgstr "Город"
 msgid "This town may not be upgraded to a castle."
 msgstr "В этом городе нельзя построить замок."
 
-#, fuzzy
 msgid "Exit Castle"
-msgstr "Покинуть замок"
+msgstr "Покинуть Замок"
 
-#, fuzzy
 msgid "Exit Town"
-msgstr "Покинуть город"
+msgstr "Покинуть Город"
 
-#, fuzzy
 msgid "Show Income"
-msgstr "Показать журнал"
+msgstr "Показать Доход"
 
 msgid "Show previous town"
 msgstr "Предыдущий город"
@@ -1498,14 +1534,13 @@ msgid "Swap Heroes"
 msgstr "Переставить Героев"
 
 msgid "Meeting Heroes"
-msgstr ""
+msgstr "Встреча Героев"
 
 msgid "View Hero"
 msgstr "Просмотреть героя"
 
-#, fuzzy
 msgid "The above spells are available here."
-msgstr "Заклинания добавлены в вашу книгу."
+msgstr "Доступные заклинания."
 
 msgid "The above spells have been added to your book."
 msgstr "Заклинания добавлены в вашу книгу."
@@ -1516,21 +1551,17 @@ msgstr "Щедрые чаевые вытянули из уст трактирщ�
 msgid "Recruit Hero"
 msgstr "Нанять героя"
 
-#, fuzzy
 msgid "%{name} is a level %{value} %{race} "
-msgstr "%{name} %{race}, %{value} уровня"
+msgstr "%{name} - %{race} уровня %{value} "
 
-#, fuzzy
 msgid "with %{count} artifacts."
-msgstr " с %{count} артефактами"
+msgstr "с %{count} артефактами."
 
-#, fuzzy
 msgid "with 1 artifact."
-msgstr " с одним артефактом"
+msgstr "с 1 артефактом."
 
-#, fuzzy
 msgid "without artifacts."
-msgstr " с %{count} артефактами"
+msgstr "без артефактов."
 
 msgid ""
 "'Spread' combat formation spreads your armies from the top to the bottom of "
@@ -1566,22 +1597,20 @@ msgstr "Боевой порядок гарнизона - Разомкнутый"
 msgid "Set garrison combat formation to 'Grouped'"
 msgstr "Боевой порядок гарнизона - Сомкнутый"
 
-#, fuzzy
 msgid "Exit Castle Options"
-msgstr "Настройки замка"
+msgstr "Закрыть Настройки Замка"
 
 msgid "Castle Options"
 msgstr "Настройки замка"
 
 msgid "Not enough resources to buy monsters."
-msgstr ""
+msgstr "Недостаточно средств для найма."
 
 msgid "No monsters available for purchase."
-msgstr ""
+msgstr "Нет доступных существ для найма."
 
-#, fuzzy
 msgid "Buy Monsters"
-msgstr "Покупка Воинов:"
+msgstr "Купить Монстров"
 
 msgid "Town Population Information and Statistics"
 msgstr "Информация о населении и статистика"
@@ -1611,7 +1640,7 @@ msgid "View information on the scenario you are currently playing."
 msgstr "Описание текущего сценария."
 
 msgid "Dig for the Ultimate Artifact."
-msgstr "Копать в поисках артефакта."
+msgstr "Копать в поисках  Уникального Артефакта."
 
 msgid "Exit this menu without doing anything."
 msgstr "Выход, без изменений."
@@ -1648,9 +1677,8 @@ msgstr "Здоровье"
 msgid "Hit Points Left"
 msgstr "Тек. здоровье"
 
-#, fuzzy
 msgid "Followers"
-msgstr "Цветы"
+msgstr "Последователи"
 
 msgid ""
 "A group of %{monster} with a desire for greater glory wish to join you.\n"
@@ -1659,7 +1687,6 @@ msgstr ""
 "Группа %{monster} в поисках славы желает к вам присоедениться.\n"
 "Вы согласны?"
 
-#, fuzzy
 msgid ""
 "The %{monster} is swayed by your diplomatic tongue, and offers to join your "
 "army for the sum of %{gold} gold.\n"
@@ -1697,14 +1724,13 @@ msgstr ""
 "Вы согласны?"
 
 msgid "(Rate: %{percent})"
-msgstr ""
+msgstr "(Рейтинг: %{percent})"
 
 msgid "No room in"
-msgstr ""
+msgstr "Нет места в"
 
-#, fuzzy
 msgid "the garrison"
-msgstr "Гарнизон"
+msgstr "гарнизон"
 
 msgid "Build a new ship:"
 msgstr "Построить новый корабль:"
@@ -1715,9 +1741,8 @@ msgstr "Стоимость:"
 msgid "Load Game"
 msgstr "Загрузка игры"
 
-#, fuzzy
 msgid "No save files to load."
-msgstr "Нет заклинаний."
+msgstr "Нет сохранённых игр."
 
 msgid "New Game"
 msgstr "Новая игра"
@@ -1726,20 +1751,19 @@ msgid "Start a single or multi-player game."
 msgstr "Начало одиночной или сетевой игры."
 
 msgid "Load a previously saved game."
-msgstr "Загрузка ранее сохраненной игры"
+msgstr "Загрузка ранее сохраненной игры."
 
-#, fuzzy
 msgid "Save Game"
-msgstr "Новая игра"
+msgstr "Сохранить Игру"
 
 msgid "Save the current game."
-msgstr ""
+msgstr "Сохранить текущую игру."
 
 msgid "Quit"
 msgstr "Выход"
 
 msgid "Quit out of Free Heroes of Might and Magic II."
-msgstr ""
+msgstr "Выйдите из Free Heroes of Might and Magic II."
 
 msgid ""
 "Map\n"
@@ -1796,9 +1820,8 @@ msgstr "Ваша армия слишком большая!"
 msgid "%{name} has gained a level."
 msgstr "%{name} получил уровень."
 
-#, fuzzy
 msgid "%{skill} +1"
-msgstr "Навык %{skill} +1"
+msgstr "%{skill} +1"
 
 msgid "You have learned %{skill}."
 msgstr "Вы изучили уровень %{skill}."
@@ -1845,7 +1868,6 @@ msgstr "Доступно к обмену"
 msgid "n/a"
 msgstr "n/a"
 
-#, fuzzy
 msgid "guarded by %{count} %{monster}"
 msgstr "охраняется %{count} %{monster}"
 
@@ -1867,22 +1889,20 @@ msgstr "(посещено)"
 msgid "(not visited)"
 msgstr "(не посещено)"
 
-#, fuzzy
 msgid "Road"
-msgstr "Дороги"
+msgstr "Дорога"
 
 msgid "(digging ok)"
-msgstr ""
+msgstr "(можно копать)"
 
 msgid "(no digging)"
-msgstr ""
+msgstr "(нельзя копать)"
 
 msgid "penalty: %{cost}"
-msgstr "Штраф проходимости: %{cost}"
+msgstr "Штраф: %{cost}"
 
-#, fuzzy
 msgid "Uncharted Territory"
-msgstr "Терра инкогнито"
+msgstr "Терра Инкогнито"
 
 msgid "Defenders:"
 msgstr "Защитники:"
@@ -1891,11 +1911,10 @@ msgid "None"
 msgstr "Ничего"
 
 msgid "Unknown"
-msgstr ""
+msgstr "Неизвестный"
 
-#, fuzzy
 msgid "%{name} (Level %{level})"
-msgstr "%{name} ( Уровень %{level} )"
+msgstr "%{name} (Уровень%{level})"
 
 msgid "Move Points"
 msgstr "Очки движ-я"
@@ -1910,7 +1929,7 @@ msgid "How many troops to move?"
 msgstr "Сколько войнов перенести?"
 
 msgid "Fast separation into slots:"
-msgstr ""
+msgstr "Быстрое разделение:"
 
 msgid "File to Save:"
 msgstr "Сохранить файл:"
@@ -1924,38 +1943,33 @@ msgstr "Вы действительно хотите удалить файл:"
 msgid "Warning!"
 msgstr "Внимание!"
 
-#, fuzzy
 msgid "Map difficulty:"
-msgstr "Сложность игры:"
+msgstr "Сложность карты:"
 
 msgid "No maps exist at that size"
-msgstr ""
+msgstr "Нет карт такого размера"
 
 msgid "Small Maps"
 msgstr "Маленькие карты"
 
-#, fuzzy
 msgid "View only maps of size small (36 x 36)."
 msgstr "Просмотр только маленьких карт (36х36)."
 
 msgid "Medium Maps"
 msgstr "Средние карты"
 
-#, fuzzy
 msgid "View only maps of size medium (72 x 72)."
 msgstr "Просмотр только средних карт (72х72)."
 
 msgid "Large Maps"
 msgstr "Большие карты"
 
-#, fuzzy
 msgid "View only maps of size large (108 x 108)."
 msgstr "Просмотр только больших карт (108х108)."
 
 msgid "Extra Large Maps"
 msgstr "Огромные карты"
 
-#, fuzzy
 msgid "View only maps of size extra large (144 x 144)."
 msgstr "Просмотр только огромных карт (144х144)."
 
@@ -1968,7 +1982,6 @@ msgstr "Просмотр всех карт, независимо от разме
 msgid "Players Icon"
 msgstr "Значок игроков"
 
-#, fuzzy
 msgid ""
 "Indicates how many players total are in the scenario. Any positions not "
 "occupied by humans will be occupied by computer players."
@@ -1979,15 +1992,16 @@ msgstr ""
 msgid "Size Icon"
 msgstr "Значок размера"
 
-#, fuzzy
 msgid ""
 "Indicates whether the map\n"
 "is small (36 x 36), medium\n"
 "(72 x 72), large (108 x 108),\n"
 "or extra large (144 x 144)."
 msgstr ""
-"Обозначает размер карты: маленькая (36х36), средняя 72х72), большая "
-"(108х108) или огромная (144х144)."
+"Обозначает размер карты:\n"
+"маленькая (36х36), средняя\n"
+"(72х72), большая (108х108)\n"
+"или огромная (144х144)."
 
 msgid "Selected Name"
 msgstr "Название Карты"
@@ -1998,17 +2012,15 @@ msgstr "Название выбранной карты."
 msgid "Selected Map Difficulty"
 msgstr "Сложность игры"
 
-#, fuzzy
 msgid ""
 "The map difficulty of the currently selected map.  The map difficulty is "
 "determined by the scenario designer. More difficult maps might include more "
 "or stronger enemies, fewer resources, or other special conditions making "
 "things tougher for the human player."
 msgstr ""
-"Сложность выбранной карты. Этот параметр задается автором (или соавтором) "
-"карты в Редакторе. Более сложные карты могут иметь больше (или более "
-"сильных) врагов, меньше ресурсов или другие особые условия, осложняющие игру "
-"человеку."
+"Сложность выбранной карты. Этот параметр задается автором карты в Редакторе. "
+"Более сложные карты могут иметь больше (или более сильных) врагов, меньше "
+"ресурсов или другие особые условия, осложняющие игру человеку."
 
 msgid "Selected Description"
 msgstr "Описание"
@@ -2017,7 +2029,7 @@ msgid "The description of the currently selected map."
 msgstr "Расширенное описание выбранной карты."
 
 msgid "Okay"
-msgstr ""
+msgstr "OK"
 
 msgid "Accept the choice made."
 msgstr "Принять изменения."
@@ -2064,96 +2076,91 @@ msgstr "1"
 msgid "two"
 msgstr "2"
 
-#, fuzzy
 msgid "Music"
 msgstr "Музыка"
 
 msgid "Toggle ambient music level."
-msgstr ""
+msgstr "Уровень музыки."
 
 msgid "Effects"
-msgstr ""
+msgstr "Эффекты"
 
 msgid "Toggle foreground sounds level."
-msgstr ""
+msgstr "Уровень звуков."
 
 msgid "Music Type"
-msgstr ""
+msgstr "Тип музыки"
 
 msgid "Change the type of music."
-msgstr ""
+msgstr "Изменить тип музыки."
 
-#, fuzzy
 msgid "Hero Speed"
-msgstr "скорость героев"
+msgstr "Скор. Героев"
 
 msgid "Change the speed at which your heroes move on the main screen."
 msgstr ""
+"Изменить скорость, с которой ваши герои перемещаются по главному экрану."
 
-#, fuzzy
 msgid "Enemy Speed"
-msgstr "Скорость"
+msgstr "Скор. Врагов"
 
 msgid ""
 "Sets the speed that A.I. heroes move at.  You can also elect not to view A."
 "I. movement at all."
 msgstr ""
+"Устанавливает скорость, с которой двигаются герои A.I.  Вы также можете "
+"выбрать не просматривать движение A.I. вовсе."
 
-#, fuzzy
 msgid "Scroll Speed"
-msgstr "скорость прокрутки"
+msgstr "Скор. Прокрутки"
 
 msgid "Sets the speed at which you scroll the window."
-msgstr ""
+msgstr "Устанавливает скорость, с которой вы прокрутите окно."
 
-#, fuzzy
 msgid "Interface Type"
 msgstr "Интерфейс"
 
 msgid "Toggle the type of interface you want to use."
-msgstr ""
+msgstr "Переключить тип интерфейса, который вы хотите использовать."
 
 msgid "Interface"
 msgstr "Интерфейс"
 
 msgid "Toggle interface visibility."
-msgstr ""
+msgstr "Показать/скрыть интерфейс."
 
-#, fuzzy
 msgid "Battles"
-msgstr "Бутылка"
+msgstr "Битвы"
 
 msgid "Toggle instant battle mode."
-msgstr ""
+msgstr "Режим мгновенного боя."
 
 msgid "OK"
 msgstr "ОК"
 
-#, fuzzy
 msgid "Exit this menu."
-msgstr "Подождать"
+msgstr "Выход из меню."
 
 msgid "off"
-msgstr "Выкл."
+msgstr "Выкл"
 
 msgid "MIDI"
-msgstr ""
+msgstr "MIDI"
 
-#, fuzzy
 msgid "MIDI Expansion"
-msgstr "Особняк"
+msgstr "Расширение MIDI"
 
 msgid "CD Stereo"
-msgstr ""
+msgstr "CD Стерео"
 
 msgid "External"
-msgstr ""
+msgstr "Внешний"
 
 msgid "Jump"
-msgstr ""
+msgstr "Н"
 
 msgid "Don't Show"
-msgstr ""
+msgstr "Скрыть"
 
 msgid "Evil"
 msgstr "Злой"
@@ -2162,35 +2169,34 @@ msgid "Good"
 msgstr "Добрый"
 
 msgid "Hide"
-msgstr ""
+msgstr "Скрыть"
 
 msgid "Show"
-msgstr ""
+msgstr "Показать"
 
 msgid "Auto Resolve"
-msgstr ""
+msgstr "Авто-Битва"
 
 msgid "Auto, No Spells"
-msgstr ""
+msgstr "Авто без Магии"
 
 msgid "Manual"
-msgstr ""
+msgstr "Вручную"
 
 msgid "Att."
-msgstr ""
+msgstr "Атк."
 
 msgid "Def."
-msgstr ""
+msgstr "Защ."
 
 msgid "Power"
 msgstr "Сила магии"
 
-#, fuzzy
 msgid "Knowl"
 msgstr "Знания"
 
 msgid "Human"
-msgstr ""
+msgstr "Человек"
 
 msgid "1st"
 msgstr "1-ый"
@@ -2210,13 +2216,11 @@ msgstr "5-ый"
 msgid "6th"
 msgstr "6-ой"
 
-#, fuzzy
 msgid "Oracle: Player Rankings"
-msgstr "Гильдия воров:  достижения игроков"
+msgstr "Оракл: Рейтинг Игроков"
 
-#, fuzzy
 msgid "Thieves' Guild: Player Rankings"
-msgstr "Гильдия воров:  достижения игроков"
+msgstr "Гильдия Воров: Рейтинг Игроков"
 
 msgid "Number of Towns:"
 msgstr "Городов:"
@@ -2239,9 +2243,8 @@ msgstr "Прочие ресурсы:"
 msgid "Obelisks Found:"
 msgstr "Найдено обелисков:"
 
-#, fuzzy
 msgid "Artifacts:"
-msgstr "Артифакты"
+msgstr "Артефакты:"
 
 msgid "Total Army Strength:"
 msgstr "Общая сила армии:"
@@ -2259,53 +2262,53 @@ msgid "Personality:"
 msgstr "Характер:"
 
 msgid "Best Monster:"
-msgstr "Лучший воин:"
+msgstr "Лучший отряд:"
 
 msgid "difficulty|Easy"
-msgstr "Простой"
+msgstr "Простая"
 
 msgid "difficulty|Normal"
 msgstr "Нормальная"
 
 msgid "difficulty|Hard"
-msgstr "Сложный"
+msgstr "Сложная"
 
 msgid "difficulty|Expert"
 msgstr "Эксперт"
 
 msgid "difficulty|Impossible"
-msgstr "Невозможный"
+msgstr "Невозможная"
 
-#, fuzzy
 msgid "Map is loading..."
 msgstr "Загрузка..."
 
 msgid "and more..."
-msgstr ""
+msgstr "и т.д."
 
 msgid "Campaign Scenario loading failure"
-msgstr ""
+msgstr "Сбой загрузки сценария кампании"
 
 msgid "Please make sure that campaign files are correct and present."
-msgstr ""
+msgstr "Пожалуйста, убедитесь, что файлы кампании верны и присутствуют."
 
 msgid "Unknown Hero"
-msgstr ""
+msgstr "Неизвестный Герой"
 
 msgid "Your Name"
-msgstr ""
+msgstr "Ваше Имя"
 
 msgid ""
 "Invalid file game type. Please ensure that you are running the latest type "
 "of save files."
 msgstr ""
+"Недействительный тип файла. Пожалуйста, убедитесь, что вы используете "
+"последнюю версию файлов."
 
-#, fuzzy
 msgid ""
 "This file is saved in the \"The Price of Loyalty\" version.\n"
 "Some items may be unavailable."
 msgstr ""
-"Этот файл сохранен в версии \"Price Loyalty\". \n"
+"Этот файл сохранен в версии \"Price Loyalty\".\n"
 "Некоторые возможности игры будут недоступны."
 
 msgid "Hot Seat"
@@ -2319,7 +2322,7 @@ msgstr ""
 "передавая управление другому, когда наступет его ход."
 
 msgid "Cancel back to the main menu."
-msgstr "Вернуться в главное меню"
+msgstr "Вернуться в главное меню."
 
 msgid "Network"
 msgstr "Сеть"
@@ -2327,7 +2330,9 @@ msgstr "Сеть"
 msgid ""
 "Play a network game, where 2 players use their own computers connected "
 "through a LAN (Local Area Network)."
-msgstr "LAN (Local Area Network), для 2 игроков"
+msgstr ""
+"Сетевая игра, в которой 2 игрока используют свои собственные компьютеры, "
+"соединенные через LAN (локальную сеть)."
 
 msgid "Standard Game"
 msgstr "Стандартная игра"
@@ -2338,9 +2343,8 @@ msgstr "Одиночная игра на одиночной карте."
 msgid "Campaign Game"
 msgstr "Кампания"
 
-#, fuzzy
 msgid "A single player game playing through a series of maps."
-msgstr "Одиночная игра на одиночной карте."
+msgstr "Одиночная игра на серии карт."
 
 msgid "Multi-Player Game"
 msgstr "Сетевая игра"
@@ -2350,23 +2354,24 @@ msgid ""
 "other on a single map."
 msgstr "Сетевая игра с несколькими игроками-людьми на одиночной карте."
 
-#, fuzzy
 msgid "Greetings!"
-msgstr "Настройки"
+msgstr "Добро Пожаловать!"
 
 msgid ""
 "Welcome to Free Heroes of Might and Magic II! Before starting the game "
 "please choose game resolution."
 msgstr ""
+"Добро пожаловать в Free Heroes of Might and Magic II! Перед началом игры, "
+"пожалуйста, выберите разрешение экрана."
 
 msgid "Please Remember"
-msgstr ""
+msgstr "Запомните"
 
 msgid "You can always change game resolution by clicking on the "
-msgstr ""
+msgstr "Вы всегда можете изменить разрешение экрана, нажав на "
 
 msgid "door"
-msgstr ""
+msgstr "портал"
 
 msgid ""
 " on the left side of main menu.\n"
@@ -2374,15 +2379,22 @@ msgid ""
 "To switch between windowed and full screen modes\n"
 "press "
 msgstr ""
+" на левой стороне основного меню.\n"
+"\n"
+"Для переключения между оконными и полноэкранными режимами\n"
+"нажмите клавишу "
 
 msgid "F4"
-msgstr ""
+msgstr "F4"
 
 msgid ""
 " key on the keyboard.\n"
 "\n"
 "Enjoy the game!"
 msgstr ""
+" на клавиатуре.\n"
+"\n"
+"Наслаждайтесь игрой!"
 
 msgid "Quit Heroes of Might and Magic and return to the operating system."
 msgstr "Завершить игру Heroes of Might and Magic."
@@ -2391,7 +2403,7 @@ msgid "Credits"
 msgstr "Авторы"
 
 msgid "View the credits screen."
-msgstr "Просмотр окна авторов"
+msgstr "Просмотр окна авторов."
 
 msgid "High Scores"
 msgstr "Счет"
@@ -2399,26 +2411,25 @@ msgstr "Счет"
 msgid "View the high score screen."
 msgstr "Просмотр лучших результатов."
 
-#, fuzzy
 msgid "Select Game Resolution"
-msgstr "Описание"
+msgstr "Выбор Разрешения Экрана"
 
 msgid "Change resolution of the game."
-msgstr ""
+msgstr "Изменить разрешение экрана."
 
 msgid "Original Campaign"
-msgstr ""
+msgstr "Старая Кампания"
 
 msgid ""
 "Either Roland's or Archibald's campaign from the original Heroes of Might "
 "and Magic II."
-msgstr ""
+msgstr "Кампании Роланда и Арчибальда из оригинальных Героев Меча и Магии II."
 
 msgid "Expansion Campaign"
-msgstr ""
+msgstr "Новая Кампания"
 
 msgid "One of the four new campaigns from the Price of Loyalty expansion set."
-msgstr ""
+msgstr "Одна из четырех новых кампаний из набора дополнений «Цена лояльности»."
 
 msgid "Host"
 msgstr "Хост"
@@ -2440,19 +2451,17 @@ msgstr ""
 "Гость ждет пока хост настроит игру, а затем автоматически присоеденяется к "
 "ней. Возможно множество гостевых клиентов при игре по протоколу TCP/IP."
 
-#, fuzzy
 msgid "Battle Only"
-msgstr "Боевой Гном"
+msgstr "Простая битва"
 
 msgid "Setup and play a battle without loading any map."
-msgstr ""
+msgstr "Настройте и играйте в битву без загрузки карты."
 
 msgid "Settings"
 msgstr "Настройки"
 
-#, fuzzy
 msgid "Experimental game settings."
-msgstr "Настройки Игры"
+msgstr "Экспериментальные настройки игры."
 
 msgid "2 Players"
 msgstr "2 игрока"
@@ -2494,6 +2503,7 @@ msgstr "Все игроки - люди."
 
 msgid "Defeat all enemy heroes and capture all enemy towns and castles."
 msgstr ""
+"Победите всех вражеских героев и захватите все вражеские города и замки."
 
 msgid "Run out of time. (Fail to win by a certain point.)"
 msgstr "Не успеть вовремя. (С определенного момента нет возможности победить)"
@@ -2514,7 +2524,7 @@ msgid "Find the '%{name}' artifact"
 msgstr "Найти '${name}' артефакт"
 
 msgid "Accumulate %{count} gold"
-msgstr "Накопить %{count} золота."
+msgstr "Накопить %{count} золота"
 
 msgid ""
 ", or you may win by defeating all enemy heroes and capturing all enemy towns "
@@ -2545,7 +2555,7 @@ msgid ""
 "You are victorious."
 msgstr ""
 "Вы захватили %{name}!\n"
-"С победой!"
+"Победа за вами."
 
 msgid ""
 "You have captured the enemy hero %{name}!\n"
@@ -2620,7 +2630,6 @@ msgstr ""
 "Не не успели вовремя закончить задание.\n"
 "Все потеряно..."
 
-#, fuzzy
 msgid "%{color} player has been vanquished!"
 msgstr "%{color} побеждён!"
 
@@ -2628,7 +2637,7 @@ msgid "Warning"
 msgstr "Внимание"
 
 msgid "No maps available!"
-msgstr "Нет доступных карт."
+msgstr "Нет доступных карт!"
 
 msgid "Scenario"
 msgstr "Сценарий"
@@ -2715,9 +2724,8 @@ msgstr ""
 "%{сolor} игрок, у вас осталось %{day} дня(ей) чтобы захватить город, иначе "
 "вы будете изгнаны из этих земель."
 
-#, fuzzy
 msgid "%{color} player's turn."
-msgstr "%{color} игрок ходит."
+msgstr "Ход игрока: %{color}"
 
 msgid ""
 "%{color} player, you have lost your last town. If you do not conquer another "
@@ -2780,7 +2788,6 @@ msgstr ""
 msgid "Are you sure you want to quit?"
 msgstr "Вы уверены, что хотите выйти?"
 
-#, fuzzy
 msgid "Are you sure you want to restart? (Your current game will be lost.)"
 msgstr "Вы действительно хотите начать сначала? (Текущая игра будет потеряна)"
 
@@ -2791,9 +2798,8 @@ msgid "Game saved successfully."
 msgstr "Игра успешно сохранена."
 
 msgid "There was an issue during saving."
-msgstr ""
+msgstr "Возникла проблема при сохранении."
 
-#, fuzzy
 msgid ""
 "Are you sure you want to load a new game? (Your current game will be lost.)"
 msgstr ""
@@ -2802,11 +2808,10 @@ msgstr ""
 msgid "Try looking on land!!!"
 msgstr "Попробуйте посмотреть на земле!!!"
 
-#, fuzzy
 msgid ""
 "After spending many hours digging here, you have uncovered the %{artifact}."
 msgstr ""
-"После множества часов, потраченных на раскопки, вы обнаружили %{artifact}"
+"После множества часов, потраченных на раскопки, вы обнаружили %{artifact}."
 
 msgid "Congratulations!"
 msgstr "Поздравляем!"
@@ -2843,14 +2848,12 @@ msgstr ""
 msgid "Status Window"
 msgstr "Окно статуса"
 
-#, fuzzy
 msgid ""
 "This window provides information on the status of your hero or kingdom, and "
 "shows the date."
 msgstr ""
 "Это окно сообщает информацию о состоянии вашего героя или королевства, а так "
-"же показывает календарь. Информация меняется циклично при нажатии левой "
-"кнопки мыши на нем."
+"же показывает календарь."
 
 msgid ""
 "This window provides information on the status of your hero or kingdom, and "
@@ -2891,7 +2894,6 @@ msgstr "Информация об умении %{skill}"
 msgid "Lord Kilburn"
 msgstr "Лорд Килбурн"
 
-#, fuzzy
 msgid "Sir Gallant"
 msgstr "Сэр Галлант"
 
@@ -3066,7 +3068,6 @@ msgstr "Арчибальд"
 msgid "Lord Halton"
 msgstr "Лорд Халтон"
 
-#, fuzzy
 msgid "Brother Brax"
 msgstr "Брат Бэкс"
 
@@ -3101,13 +3102,13 @@ msgid "Jarkonas"
 msgstr "Ярконас"
 
 msgid "%{object} robber"
-msgstr ""
+msgstr "%{object} грабителя"
 
 msgid "%{object} raided"
-msgstr ""
+msgstr "%{object} рейд"
 
 msgid "You cannot pick up this artifact, you already have a full load!"
-msgstr ""
+msgstr "Вы не можете забрать этот артефакт, у вас нет свободного места!"
 
 msgid "The three Anduran artifacts magically combine into one."
 msgstr "Три магических артифакта Андурана, объединяются в один."
@@ -3136,7 +3137,7 @@ msgid "Some of your army has fallen overboard."
 msgstr "Часть вашей армии смыло за борт."
 
 msgid "Insulted by your refusal of their offer, the monsters attack!"
-msgstr "Оскорбленные вашим отказом они напали на вас."
+msgstr "Оскорбленные вашим отказом они напали на вас!"
 
 msgid ""
 "The %{monster}, awed by the power of your forces, begin to scatter.\n"
@@ -3510,9 +3511,8 @@ msgstr ""
 "После победы над зомби, вы проводите несколько часов обыскивая могилы и "
 "ничего не находите. Сей презренный акт снижает мораль вашей армии."
 
-#, fuzzy
 msgid "Upon defeating the Zombies you search the graves and find something!"
-msgstr "После победы над зомби, вы обыскиваете могилы и удаляетесь с находкой."
+msgstr "После победы над зомби, вы обыскиваете могилы и удаляетесь с находкой!"
 
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
@@ -3530,7 +3530,7 @@ msgstr ""
 
 msgid ""
 "Upon defeating the Ghosts you sift through the debris and find something!"
-msgstr "Одолев призраков, вы обыскали останки кораблекрушения и кое-что нашли."
+msgstr "Одолев призраков, вы обыскали останки кораблекрушения и кое-что нашли!"
 
 msgid ""
 "The rotting hulk of a great pirate ship creaks eerily as it is pushed "
@@ -3548,7 +3548,7 @@ msgstr ""
 
 msgid ""
 "Upon defeating the Skeletons you sift through the debris and find something!"
-msgstr "Совлодав со скелетами, вы обыскали останки корабля и кое-что нашли."
+msgstr "Совладав со скелетами, вы обыскали останки корабля и кое-что нашли!"
 
 msgid "Your men spot a navigational buoy, confirming that you are on course."
 msgstr "Ваши спутники замечают морской буй. Он указывает верный курс."
@@ -4081,18 +4081,16 @@ msgstr ""
 "Все %{monsters} в вашей армии были обучены мастерами форта. Теперь ваша "
 "армия состоит из %{monsters2}."
 
-#, fuzzy
 msgid ""
 "An unusual alliance of Ogres, Orcs, and Dwarves offer to train (upgrade) any "
 "such troops brought to them. Unfortunately, you have none with you."
 msgstr ""
-"Необычный союз орков, огров и гномов предлагает вам потренеровать (улучшить) "
-"любые подобные им войска. К сожалению у вас при себе таких нет."
+"Необычный союз орков, огров и гномов предлагает вам потренировать (улучшить) "
+"любые подобные им войска. К сожалению, в вашей армии таких нет."
 
 msgid "All of your %{monsters} have been upgraded into %{monsters2}."
 msgstr "Все ваши %{monsters} были улучшены до %{monsters2}."
 
-#, fuzzy
 msgid ""
 "A blacksmith working at the foundry offers to convert all Pikemen and "
 "Swordsmen's weapons brought to him from iron to steel. He also says that he "
@@ -4184,6 +4182,9 @@ msgid ""
 "your journey, the seer activates his crystal ball, allowing you to see the "
 "strengths and weaknesses of your opponents."
 msgstr ""
+"Среди деревьев сидит слепой провидец. Объяснив цель вашего путешествия, "
+"провидец активирует свой хрустальный шар, позволяя вам увидеть сильные и "
+"слабые стороны ваших противников."
 
 msgid ""
 "The entrance to the cave is dark, and a foul, sulfurous smell issues from "
@@ -4224,7 +4225,6 @@ msgstr ""
 "Демон выкрикнул свой вызов и бросился в бой! После краткой, но отчаянной "
 "схватки вы прикончили чудовщие и нашли %{art} в глубине пещеры.."
 
-#, fuzzy
 msgid ""
 "The Demon screams its challenge and attacks! After a short, desperate "
 "battle, you slay the monster and receive %{exp} experience points and "
@@ -4362,20 +4362,24 @@ msgstr ""
 "\"Есть у меня загадка для тебя,\" - сказал Сфинкс. \"Ответишь верно - "
 "получишь награду. Ошибешься - и я тебя съем. Принимаешь ли ты мой вызов?"
 
-#, fuzzy
 msgid ""
 "The Sphinx asks you the following riddle:\n"
 " \n"
 "'%{riddle}'\n"
 " \n"
 "Your answer?"
-msgstr "Сфинкс загадал вам следующую загадку: %{riddle}.\\nВаш ответ?"
+msgstr ""
+"Сфинкс загадал вам следующую загадку: \n"
+" \n"
+"'%{riddle}'\n"
+" \n"
+"Ваш ответ?"
 
 msgid ""
 "Looking somewhat disappointed, the Sphinx sighs. You've answered my riddle "
 "so here's your reward. Now begone."
 msgstr ""
-"Несколько разочарованно Сфинкс промолвил. \"Ты дал верный ответ, вот твоя "
+"Несколько разочарованно Сфинкс промолвил: \"Ты дал верный ответ, вот твоя "
 "награда. А теперь убирайся.\""
 
 msgid ""
@@ -4406,10 +4410,10 @@ msgid ""
 "\"Speak the key and you may pass.\"\n"
 "You speak, and nothing happens."
 msgstr ""
-"ам преграждает путь магический барьер. Вдруг, на нем, магическими рунами, "
+"Вам преграждает путь магический барьер. Вдруг, на нем, магическими рунами, "
 "высветилась надпись:\n"
 " \"Произнеси волшебное слово и сможешь пройти\"\n"
-" Вы произносите всякие разные нехорошие слова, но ничего не происходит.."
+" Вы произносите всякие разные нехорошие слова, но ничего не происходит."
 
 msgid ""
 "You enter the tent and see an old woman gazing into a magic gem. She looks "
@@ -4427,9 +4431,8 @@ msgid ""
 "cast the spell."
 msgstr "Заклинание требует %{mana} очков магии. У вас только %{point}."
 
-#, fuzzy
 msgid "%{name} the %{race} (Level %{level})"
-msgstr "%{name} %{race} (Уровень %{level})"
+msgstr "%{race} %{name} (уровень %{level})"
 
 msgid ""
 "'Grouped' combat formation bunches your army together in the center of your "
@@ -4441,9 +4444,8 @@ msgstr ""
 msgid "Are you sure you want to dismiss this Hero?"
 msgstr "Вы действительно хотите уволить героя?"
 
-#, fuzzy
 msgid "View Stats"
-msgstr "Показать артефакты"
+msgstr "Герой/Характеристика"
 
 msgid "View Experience Info"
 msgstr "Опыт"
@@ -4457,56 +4459,48 @@ msgstr "Разомкнутый строй"
 msgid "Set army combat formation to 'Grouped'"
 msgstr "Сомкнутый строй"
 
-#, fuzzy
 msgid "Exit Hero Screen"
-msgstr "Экран героя"
+msgstr "Закрыть Экран Героя"
 
 msgid "You cannot dismiss a hero in a castle"
-msgstr ""
+msgstr "Нельзя уволить героя в замке"
 
 msgid "Dismissal of %{name} the %{race} is prohibited by scenario"
-msgstr ""
+msgstr "Увольнение %{name} %{race} запрещено сценарием"
 
-#, fuzzy
 msgid "Dismiss %{name} the %{race}"
-msgstr "%{name} %{race}"
+msgstr "Уволить %{race}а %{name}"
 
-#, fuzzy
 msgid "Show previous hero"
-msgstr "Предыдущий город"
+msgstr "Предыдущий герой"
 
-#, fuzzy
 msgid "Show next hero"
 msgstr "Следующий герой"
 
-#, fuzzy
 msgid "Blood Morale"
-msgstr "Хорошая Мораль"
+msgstr "В Бой!"
 
-#, fuzzy
 msgid "%{morale} Morale"
-msgstr "Нормальная"
+msgstr "Мораль %{morale}"
 
 msgid "%{luck} Luck"
-msgstr ""
+msgstr "Удача %{luck}"
 
-#, fuzzy
 msgid "Current Luck Modifiers:"
-msgstr "Текущие Модификаторы:"
+msgstr "Текущие модификаторы удачи:"
 
-#, fuzzy
 msgid "Current Morale Modifiers:"
-msgstr "Текущие Модификаторы:"
+msgstr "Текущие модификаторы морали:"
 
-#, fuzzy
 msgid "Entire army is undead, so morale does not apply."
 msgstr "Мораль неприменима к нежити."
 
-#, fuzzy
 msgid ""
 "Current experience %{exp1}.\n"
 " Next level %{exp2}."
-msgstr "Текущий опыт %{exp1} . Следующий уровень %{exp2}."
+msgstr ""
+"Текущий опыт %{exp1}.\n"
+"Следующий уровень %{exp2}."
 
 msgid "Level %{level}"
 msgstr "Уровень %{level}"
@@ -4555,37 +4549,35 @@ msgid "Town Portal"
 msgstr "Портал в город"
 
 msgid "Select town to port to."
-msgstr "Выберите Город для Телепортации:"
+msgstr "Выберите Город для Телепортации."
 
 msgid "Your hero is too tired to cast this spell today. Try again tomorrow."
 msgstr ""
 "Ваш герой очень устал, и не сможет применять магию сегодня. Попробуйте еще "
 "раз завтра."
 
-#, fuzzy
 msgid "%{spell} failed!!!"
-msgstr "Неудачный вызов магии!"
+msgstr "Неудачный вызов %{spell}!"
 
 msgid "This spell is already in use."
-msgstr ""
+msgstr "Это заклинание уже используется."
 
 msgid "Enemy heroes are now fully identifiable."
 msgstr "Все вражеские Герои опознаны."
 
-#, fuzzy
 msgid "This spell cannot be used on a boat."
-msgstr "В этом городе нельзя построить замок."
+msgstr "Это заклинание не действует в море."
 
 msgid "This spell can be casted only nearby water."
-msgstr ""
+msgstr "Это заклинание действует только у воды."
 
-#, fuzzy
 msgid ""
 "No available towns.\n"
 "Spell Failed!!!"
-msgstr "Нет доступных городов для этой магии!!!"
+msgstr ""
+"Нет доступных городов.\n"
+"Неудачный вызов магии!"
 
-#, fuzzy
 msgid ""
 "Nearest town occupied.\n"
 "Spell Failed!!!"
@@ -4625,12 +4617,13 @@ msgstr ""
 msgid "Your spell power determines the length or power of a spell."
 msgstr "Навык Силы магии определяет длительность действия или силу заклинания."
 
-#, fuzzy
 msgid ""
 "Your knowledge determines how many spell points your hero may have. Under "
 "normal circumstances, a hero is limited to 10 spell points per level of "
 "knowledge."
-msgstr "Уровень Знаний отвечает за количество очков магии героя."
+msgstr ""
+"Уровень Знаний отвечает за количество очков магии героя. Обычно, герой может "
+"получить 10 очков магии на каждый уровень знаний."
 
 msgid "Current Modifiers:"
 msgstr "Текущие Модификаторы:"
@@ -4809,50 +4802,40 @@ msgstr "Продвинутый Казначей"
 msgid "Expert Estates"
 msgstr "Эксперт Казначей"
 
-#, fuzzy
 msgid " allows you to negotiate with monsters who are weaker than your group."
-msgstr ""
-"Позволяет вести переговоры с армией (которая слабее вашей) об примсоединении."
+msgstr "Позволяет вести переговоры о присоединении с более слабой армией."
 
-#, fuzzy
 msgid "All of the creatures may offer to join you."
-msgstr ""
-"Позволяет присоединиться к Вашей армии, примерно %{count} процент существ."
+msgstr "Позволяет присоединиться к Вашей армии всех существ."
 
-#, fuzzy
 msgid " allows your hero to learn third level spells."
-msgstr "Позволяет изучать заклинания 3-го круга."
+msgstr " позволяет изучать заклинания 3-го круга."
 
-#, fuzzy
 msgid " allows your hero to learn fourth level spells."
-msgstr "Позволяет изучать заклинания 4-го круга."
+msgstr " позволяет изучать заклинания 4-го круга."
 
-#, fuzzy
 msgid " allows your hero to learn fifth level spells."
-msgstr "Позволяет изучать все возможные заклинания."
+msgstr " позволяет изучать все возможные заклинания."
 
-#, fuzzy
 msgid ""
 " gives your hero's catapult shots a greater chance to hit and do damage to "
 "castle walls."
 msgstr ""
-"Дает выстрелам катапульты больший шанс поразить и причинить вред стенам "
+" дает выстрелам катапульты больший шанс поразить и причинить вред стенам "
 "замка."
 
-#, fuzzy
 msgid ""
 " gives your hero's catapult an extra shot, and each shot has a greater "
 "chance to hit and do damage to castle walls."
 msgstr ""
-"Дает сделать катапульте дополнительный выстрел, а так же каждому выстрелу "
+" дает сделать катапульте дополнительный выстрел, а так же каждому выстрелу "
 "придает больший шанс поразить и причинить вред стенам замка."
 
-#, fuzzy
 msgid ""
 " gives your hero's catapult an extra shot, and each shot automatically "
 "destroys any wall, except a fortified wall in a Knight town."
 msgstr ""
-"Дает сделать катапульте дополнительный выстрел, и каждый выстрел "
+" дает сделать катапульте дополнительный выстрел, и каждый выстрел "
 "гарантированно разрушит любую стену, за исключением укреплений в рыцарском "
 "замке."
 
@@ -4989,7 +4972,7 @@ msgid "Sorceress"
 msgstr "Колдунья"
 
 msgid "Warlock"
-msgstr "Чернокнижник"
+msgstr "Чародей"
 
 msgid "Wizard"
 msgstr "Волшебник"
@@ -5097,7 +5080,7 @@ msgid "week|Tortoise"
 msgstr "Черепахи"
 
 msgid "week|Hedgehog"
-msgstr "Ёжика"
+msgstr "Ёжа"
 
 msgid "week|Condor"
 msgstr "Кондора"
@@ -5124,7 +5107,7 @@ msgid "Grass"
 msgstr "Трава"
 
 msgid "Ocean"
-msgstr ""
+msgstr "Океан"
 
 msgid "maps|Small"
 msgstr "Маленькая"
@@ -5139,7 +5122,7 @@ msgid "maps|Extra Large"
 msgstr "Очень Большая"
 
 msgid "maps|Custom Size"
-msgstr ""
+msgstr "Особый Размер"
 
 msgid "Ore Mine"
 msgstr "Рудная Шахта"
@@ -5171,7 +5154,6 @@ msgstr "Кольцо фей"
 msgid "Dragon City"
 msgstr "Драконий город"
 
-#, fuzzy
 msgid "Lighthouse"
 msgstr "Маяк"
 
@@ -5265,16 +5247,14 @@ msgstr "Магеллан"
 msgid "Derelict Ship"
 msgstr "Заброшенный корабль"
 
-#, fuzzy
 msgid "Shipwreck"
-msgstr "Кораблекрушение!"
+msgstr "Кораблекрушение"
 
 msgid "Observation Tower"
 msgstr "Обзорная башня"
 
-#, fuzzy
 msgid "Freeman's Foundry"
-msgstr "Литейный цех"
+msgstr "Литейная"
 
 msgid "Watering Hole"
 msgstr "Промоина"
@@ -5357,7 +5337,6 @@ msgstr "Кустарник"
 msgid "Buoy"
 msgstr "Буй"
 
-#, fuzzy
 msgid "Skeleton"
 msgstr "Скелет"
 
@@ -5611,13 +5590,13 @@ msgid "Endless Purse of Gold"
 msgstr "Бездонный Кошель"
 
 msgid "Nomad Boots of Mobility"
-msgstr "Бошмаки Кочевника"
+msgstr "Сапоги Кочевника"
 
 msgid "The %{name} increase your movement on land."
 msgstr "%{name} увеличивают ваше передвижение по земле."
 
 msgid "Traveler's Boots of Mobility"
-msgstr "Башмаки Путника"
+msgstr "Сапоги Путника"
 
 msgid "Lucky Rabbit's Foot"
 msgstr "Лапка Кролика"
@@ -5632,7 +5611,7 @@ msgid "Gambler's Lucky Coin"
 msgstr "Счастливая Монета"
 
 msgid "Four-Leaf Clover"
-msgstr "Листик Клевера"
+msgstr "Четырёхлистник Клевера"
 
 msgid "True Compass of Mobility"
 msgstr "Компас"
@@ -5665,7 +5644,7 @@ msgid "The %{name} doubles the effectiveness of your hypnotize spells."
 msgstr "%{name} удваивают эффект заклинаний гипноза."
 
 msgid "Skullcap"
-msgstr "Шапочка из Фольги"
+msgstr "Ермолка"
 
 msgid "The %{name} halves the casting cost of all mind influencing spells."
 msgstr "%{name} снижает вдвое стоимость всех заклинаний основанных на разуме."
@@ -5797,7 +5776,6 @@ msgstr "%{name} защищает ваши отряды от заклятий с�
 msgid "Golden Bow"
 msgstr "Золотой Лук"
 
-#, fuzzy
 msgid ""
 "The %{name} eliminates the %{count} percent penalty for your troops shooting "
 "past obstacles (e.g. castle walls)."
@@ -5857,35 +5835,30 @@ msgstr "%{name} не позволяеткому попало вступить в
 msgid "Endless Pouch of Sulfur"
 msgstr "Мешочек Серы"
 
-#, fuzzy
 msgid "The %{name} provides %{count} unit of sulfur per day."
 msgstr "%{name} ежедневно приносит вам %{count} меру серы."
 
 msgid "Endless Vial of Mercury"
 msgstr "Колба Ртути"
 
-#, fuzzy
 msgid "The %{name} provides %{count} unit of mercury per day."
 msgstr "%{name} еждневно приносит вам %{count} меру ртути."
 
 msgid "Endless Pouch of Gems"
 msgstr "Мешочек Самоцветов"
 
-#, fuzzy
 msgid "The %{name} provides %{count} unit of gems per day."
 msgstr "%{name} еждневно приносит вам %{count} меру самоцветов."
 
 msgid "Endless Cord of Wood"
 msgstr "Вязанка Дров"
 
-#, fuzzy
 msgid "The %{name} provides %{count} unit of wood per day."
 msgstr "%{name} еждневно приносит вам %{count} меру древесины."
 
 msgid "Endless Cart of Ore"
 msgstr "Вагонетка Руды"
 
-#, fuzzy
 msgid "The %{name} provides %{count} unit of ore per day."
 msgstr "%{name} ежедневно приносит вам %{count} меру руды."
 
@@ -6204,38 +6177,34 @@ msgstr ""
 "что это зачарованная лопата Гробокопателей, считавшаяся давным давно "
 "потерянной смертными."
 
-#, fuzzy
 msgid ""
 "Do you want to use your knowledge of magical secrets to transcribe the "
 "%{spell} Scroll into your Magic Book?\n"
 "The Spell Scroll will be consumed.\n"
 " Cost in spell points: %{sp}"
 msgstr ""
-"Вы желаете использоватаь Ваше знание волшебных секретов, чтобы переписать "
+"Вы желаете использовать Ваше знание волшебных секретов, чтобы переписать "
 "Свиток %{spell} в Вашу магическую книгу?\n"
 "Свиток будет уничтожен.\n"
-"Сила магии: %{sp}"
+"Цена: %{sp} очков магии"
 
-#, fuzzy
 msgid "Transcribe Spell Scroll"
-msgstr "Свиток Заклинания"
+msgstr "Переписать Свиток Заклинания"
 
-#, fuzzy
 msgid "View Spells"
-msgstr "Показать все"
+msgstr "Просмотреть Заклинания"
 
-#, fuzzy
 msgid "View %{name} Info"
-msgstr "Просмотреть %{name}"
+msgstr "Информация о %{name}"
 
 msgid "Move %{name}"
-msgstr ""
+msgstr "Переместить %{name}"
 
 msgid "Cannot move artifact"
-msgstr ""
+msgstr "Невозможно передать артефакт"
 
 msgid "This item can't be traded."
-msgstr ""
+msgstr "Эту вещь нельзя продать."
 
 msgid "Wood"
 msgstr "Древесина"
@@ -6364,9 +6333,8 @@ msgid "Slows all enemies to half movement rate."
 msgstr ""
 "Замедляет все варжеские отряды на 2. Цель = отряд врага. Длит =Раунд*СМ."
 
-#, fuzzy
 msgid "spell|Blind"
-msgstr "Замедление"
+msgstr "Слепота"
 
 msgid "Clouds the affected creatures' eyes, preventing them from moving."
 msgstr ""
@@ -6517,7 +6485,6 @@ msgstr ""
 msgid "Hypnotize"
 msgstr "Гипноз"
 
-#, fuzzy
 msgid ""
 "Brings a single enemy unit under your control if its hits are less than "
 "%{count} times the caster's spell power."
@@ -6674,7 +6641,7 @@ msgid "Causes all artifacts across the land to become visible."
 msgstr "Делает видимыми все артефакты, расположенные на карте."
 
 msgid "View Towns"
-msgstr "Показать города."
+msgstr "Показать города"
 
 msgid "Causes all towns and castles across the land to become visible."
 msgstr "Делает видимыми все города и замки, расположенные на карте."
@@ -6784,33 +6751,26 @@ msgstr ""
 msgid "No spell to cast."
 msgstr "Нет заклинаний для применения."
 
-#, fuzzy
 msgid "Your hero has %{point} spell points remaining."
 msgstr "У вашего героя осталось %{point} очков магии."
 
-#, fuzzy
 msgid "View Adventure Spells"
-msgstr "Игровые действия"
+msgstr "Просмотр Походных Заклинаний"
 
-#, fuzzy
 msgid "View Combat Spells"
-msgstr "Произнести заклинание"
+msgstr "Просмотр Боевых Заклинаний"
 
-#, fuzzy
 msgid "View previous page"
-msgstr "Предыдущий город"
+msgstr "Предыдущая страница"
 
-#, fuzzy
 msgid "View next page"
-msgstr "Просмотреть %{name}"
+msgstr "Следующая страница"
 
-#, fuzzy
 msgid "Close Spellbook"
-msgstr "Произнести заклинание"
+msgstr "Закрыть Книгу Заклинаний"
 
-#, fuzzy
 msgid "View %{spell}"
-msgstr "Просмотреть %{name}"
+msgstr "Просмотреть %{spell}"
 
 msgid "game: always confirm for rewrite savefile"
 msgstr "game: всегда делать запрос на перезапись игры"
@@ -6818,15 +6778,14 @@ msgstr "game: всегда делать запрос на перезапись �
 msgid "game: remember last focus"
 msgstr "game: запомнить последнюю позицию фокуса (героя/замка)"
 
-#, fuzzy
 msgid "battle: show damage info"
-msgstr "game: показать доп. информацию для убитых на поле боя"
+msgstr "битва: показывать урон"
 
 msgid "world: show visited content from objects"
 msgstr "world: показать доп. информацию о объектах (правый клик)"
 
 msgid "world: show terrain penalty"
-msgstr ""
+msgstr "мир: показывать штраф при перемещении"
 
 msgid "world: scouting skill show extended content info"
 msgstr "умение разведчика покажет дополнительную информацию"
@@ -6861,19 +6820,18 @@ msgstr "world: потеря начальных героев сценария п�
 msgid "world: Only 1 hero can be hired by the one player every week"
 msgstr "world: возможен найм только 1 героя в неделю"
 
-#, fuzzy
 msgid "world: Each castle allows one hero to be recruited every week"
-msgstr "world: каждый город разрешает покупку одного героя в неделю"
+msgstr "мир: каждый город разрешает покупку одного героя в неделю"
 
 msgid "world: Neutral armies scale with game difficulty"
-msgstr ""
+msgstr "мир: размер нейтральных армий зависит от сложности"
 
 msgid "world: use unique artifacts for resource affecting"
 msgstr ""
 "world: использовать уникальность для артифактов, влияющие на доход в ресурсах"
 
 msgid "world: use unique artifacts for primary skills"
-msgstr ""
+msgstr "мир: уникальные артефакты для первичных навыков"
 
 msgid "world: use unique artifacts for secondary skills"
 msgstr ""
@@ -6903,9 +6861,8 @@ msgstr "heroes: разрешить покупку магической книг�
 msgid "heroes: recruit cost to be dependent on hero level"
 msgstr "heroes: цена найма зависит от уровня"
 
-#, fuzzy
 msgid "heroes: remember move points for retreat/surrender result"
-msgstr "heroes: если сбежал с битвы запомнить MP/SP для текущего дня"
+msgstr "герои: при бегстве запомнить MP/SP для текущего дня"
 
 msgid "heroes: allow transcribing scrolls (needs: Eye Eagle skill)"
 msgstr "heroes: возможость выучить свитки (необходимо умение Орлиный Взор)"
@@ -6919,9 +6876,8 @@ msgstr "unions: разрешить встречи для дружественн�
 msgid "unions: allow castle visiting"
 msgstr "unions: разрешить посещения дружественных замков"
 
-#, fuzzy
 msgid "battle: show army order"
-msgstr "game: показать сетку на поле боя"
+msgstr "битва: показывать порядок армии"
 
 msgid "battle: soft wait troop"
 msgstr "battle: использовать альтернативный пропуск хода (Heroes III)"
@@ -6952,76 +6908,70 @@ msgstr ""
 msgid "game: offer to continue the game afer victory condition"
 msgstr "game: после победы возожно продолжить игру"
 
-#, fuzzy
 msgid "The ultimate artifact is really the %{name}."
-msgstr "%{name} прокляты Мумиями!"
+msgstr " Уникальный Артефакт - это %{name}."
 
 msgid "The ultimate artifact may be found in the %{name} regions of the world."
-msgstr ""
+msgstr " Уникальный Артефакт спрятан на %{name}е."
 
 msgid "north-west"
-msgstr ""
+msgstr "северо-запад"
 
-#, fuzzy
 msgid "north"
-msgstr "Земля"
+msgstr "север"
 
 msgid "north-east"
-msgstr ""
+msgstr "северо-восток"
 
-#, fuzzy
 msgid "west"
-msgstr "Гнездо"
+msgstr "запад"
 
-#, fuzzy
 msgid "center"
-msgstr "Отряд"
+msgstr "центр"
 
-#, fuzzy
 msgid "east"
-msgstr "Гнездо"
+msgstr "восток"
 
 msgid "south-west"
-msgstr ""
+msgstr "юго-запад"
 
-#, fuzzy
 msgid "south"
-msgstr "Звук"
+msgstr "юг"
 
 msgid "south-east"
-msgstr ""
+msgstr "юго-восток"
 
 msgid "The truth is out there."
-msgstr ""
+msgstr "Истина где-то рядом."
 
 msgid "The dark side is stronger."
-msgstr ""
+msgstr "Тёмная сторона сильнее."
 
-#, fuzzy
 msgid "The end of the world is near."
-msgstr "Остерегайся, здесь край мира!"
+msgstr "Конец света близок."
 
 msgid "The bones of Lord Slayer are buried in the foundation of the arena."
-msgstr ""
+msgstr "Останки лорда закопаны у основания арены."
 
 msgid "A Black Dragon will take out a Titan any day of the week."
-msgstr ""
+msgstr "Черный Дракон победит Титана в любой день недели."
 
 msgid "He told her: Yada yada yada...  and then she said: Blah, blah, blah..."
-msgstr ""
+msgstr "Он сказал ей: Бе бе бе...  а потом она сказала: Бла, бла, бла..."
 
 msgid "An unknown force is being ressurected..."
-msgstr ""
+msgstr "Возрождается неведомая сила..."
 
-#, fuzzy
 msgid ""
 "Check the newest version of game at\n"
 "https://github.com/ihhub/\n"
 "fheroes2/releases"
 msgstr ""
-"Новую версию игры, можно найти, на сайте:\n"
-" http://sf.net/projects/fheroes2"
+"Новую версию игры можно найти на сайте:\n"
+"https://github.com/ihhub/\n"
+"fheroes2/releases"
 
+#, fuzzy
 #~ msgid "Hero %{name} also got a %{count} experience."
 #~ msgstr "Герой %{name} также получает %{count} опыта."
 
@@ -7100,154 +7050,132 @@ msgstr ""
 #~ msgid "Coast"
 #~ msgstr "Побережье"
 
-#, fuzzy
 #~ msgid "Peasant"
 #~ msgstr "Крестьянин"
 
 #~ msgid "Peasants"
 #~ msgstr "Крестьяне"
 
-#, fuzzy
 #~ msgid "Archer"
 #~ msgstr "Стрелок"
 
 #~ msgid "Archers"
 #~ msgstr "Стрелков"
 
-#, fuzzy
 #~ msgid "Ranger"
 #~ msgstr "Рейнджер"
 
 #~ msgid "Rangers"
 #~ msgstr "Рейнджеров"
 
-#, fuzzy
 #~ msgid "Pikeman"
 #~ msgstr "Копейщик"
 
 #~ msgid "Pikemen"
 #~ msgstr "Копейщиков"
 
-#, fuzzy
 #~ msgid "Veteran Pikeman"
 #~ msgstr "Опытный Копейщик"
 
 #~ msgid "Veteran Pikemen"
 #~ msgstr "Копейщиков ветеранов"
 
-#, fuzzy
 #~ msgid "Swordsman"
 #~ msgstr "Мечник"
 
 #~ msgid "Swordsmen"
 #~ msgstr "Мечников"
 
-#, fuzzy
 #~ msgid "Master Swordsman"
 #~ msgstr "Опытный Мечник"
 
 #~ msgid "Master Swordsmen"
 #~ msgstr "Опытные Мечники"
 
-#, fuzzy
 #~ msgid "Cavalry"
 #~ msgstr "Всадник"
 
 #~ msgid "Cavalries"
 #~ msgstr "Всадников"
 
-#, fuzzy
 #~ msgid "Champion"
 #~ msgstr "Опытный Всадник"
 
 #~ msgid "Champions"
 #~ msgstr "Чемпионов"
 
-#, fuzzy
 #~ msgid "Paladin"
 #~ msgstr "Рыцарь"
 
 #~ msgid "Paladins"
 #~ msgstr "Паладинов"
 
-#, fuzzy
 #~ msgid "Crusader"
 #~ msgstr "Крестоносец"
 
 #~ msgid "Crusaders"
 #~ msgstr "Крестоносцев"
 
-#, fuzzy
 #~ msgid "Goblin"
 #~ msgstr "Гоблин"
 
 #~ msgid "Goblins"
 #~ msgstr "Гоблиннов"
 
-#, fuzzy
 #~ msgid "Orc"
 #~ msgstr "Орк"
 
 #~ msgid "Orcs"
 #~ msgstr "Орков"
 
-#, fuzzy
 #~ msgid "Orc Chief"
 #~ msgstr "Вождь Орков"
 
 #~ msgid "Orc Chiefs"
 #~ msgstr "Вождей орков"
 
-#, fuzzy
 #~ msgid "Wolf"
 #~ msgstr "Волк"
 
 #~ msgid "Wolves"
 #~ msgstr "Волков"
 
-#, fuzzy
 #~ msgid "Ogre"
 #~ msgstr "Людоед"
 
 #~ msgid "Ogres"
 #~ msgstr "Огров"
 
-#, fuzzy
 #~ msgid "Ogre Lord"
 #~ msgstr "Великан Людоед"
 
 #~ msgid "Ogre Lords"
 #~ msgstr "Лордов огров"
 
-#, fuzzy
 #~ msgid "Troll"
 #~ msgstr "Тролль"
 
 #~ msgid "Trolls"
 #~ msgstr "Троллей"
 
-#, fuzzy
 #~ msgid "War Troll"
 #~ msgstr "Боевой Тролль"
 
 #~ msgid "War Trolls"
 #~ msgstr "Боевых троллей"
 
-#, fuzzy
 #~ msgid "Cyclops"
-#~ msgstr "Циклоп"
+#~ msgstr "Циклопы"
 
 #~ msgid "Cyclopes"
 #~ msgstr "Циклопов"
 
-#, fuzzy
 #~ msgid "Sprite"
 #~ msgstr "Фея"
 
 #~ msgid "Sprites"
 #~ msgstr "Фей"
 
-#, fuzzy
 #~ msgid "Dwarf"
 #~ msgstr "Гном"
 
@@ -7257,169 +7185,144 @@ msgstr ""
 #~ msgid "Battle Dwarves"
 #~ msgstr "Боевых гномов"
 
-#, fuzzy
 #~ msgid "Elf"
 #~ msgstr "Эльф"
 
 #~ msgid "Elves"
 #~ msgstr "Эльфов"
 
-#, fuzzy
 #~ msgid "Grand Elf"
 #~ msgstr "Эльф Охотник"
 
 #~ msgid "Grand Elves"
 #~ msgstr "Высоких эльфов"
 
-#, fuzzy
 #~ msgid "Druid"
 #~ msgstr "Друид"
 
 #~ msgid "Druids"
 #~ msgstr "Друидов"
 
-#, fuzzy
 #~ msgid "Greater Druid"
 #~ msgstr "Старший Друид"
 
 #~ msgid "Greater Druids"
 #~ msgstr "Старших друидов"
 
-#, fuzzy
 #~ msgid "Unicorn"
 #~ msgstr "Единорог"
 
 #~ msgid "Unicorns"
 #~ msgstr "Единогогов"
 
-#, fuzzy
 #~ msgid "Phoenix"
 #~ msgstr "Феникс"
 
-#, fuzzy
 #~ msgid "Phoenixes"
-#~ msgstr "Феникс"
+#~ msgstr "Фениксы"
 
-#, fuzzy
 #~ msgid "Centaur"
 #~ msgstr "Кентавр"
 
 #~ msgid "Centaurs"
 #~ msgstr "Кентавров"
 
-#, fuzzy
 #~ msgid "Gargoyle"
 #~ msgstr "Гаргулья"
 
 #~ msgid "Gargoyles"
 #~ msgstr "Гаргулий"
 
-#, fuzzy
 #~ msgid "Griffin"
 #~ msgstr "Грифон"
 
 #~ msgid "Griffins"
 #~ msgstr "Грифонов"
 
-#, fuzzy
 #~ msgid "Minotaur"
 #~ msgstr "Минотавр"
 
 #~ msgid "Minotaurs"
 #~ msgstr "Минотавров"
 
-#, fuzzy
 #~ msgid "Minotaur King"
 #~ msgstr "Царь Минотавр"
 
 #~ msgid "Minotaur Kings"
 #~ msgstr "Царей минотавров"
 
-#, fuzzy
 #~ msgid "Hydra"
 #~ msgstr "Гидра"
 
 #~ msgid "Hydras"
 #~ msgstr "Гидр"
 
-#, fuzzy
 #~ msgid "Green Dragon"
 #~ msgstr "Зеленый Дракон"
 
 #~ msgid "Green Dragons"
 #~ msgstr "Зеленых драконов"
 
-#, fuzzy
 #~ msgid "Red Dragon"
 #~ msgstr "Красный Дракон"
 
 #~ msgid "Red Dragons"
 #~ msgstr "Красных драконов"
 
-#, fuzzy
 #~ msgid "Black Dragon"
 #~ msgstr "Черный Дракон"
 
 #~ msgid "Black Dragons"
 #~ msgstr "Черных драконов"
 
-#, fuzzy
 #~ msgid "Halfling"
 #~ msgstr "Хоббит"
 
 #~ msgid "Halflings"
 #~ msgstr "Хоббитов"
 
-#, fuzzy
 #~ msgid "Boar"
 #~ msgstr "Боров"
 
 #~ msgid "Boars"
 #~ msgstr "Боровов"
 
-#, fuzzy
 #~ msgid "Iron Golem"
 #~ msgstr "Железный Голем"
 
 #~ msgid "Iron Golems"
 #~ msgstr "Железных големов"
 
-#, fuzzy
 #~ msgid "Steel Golem"
 #~ msgstr "Стальной Голем"
 
 #~ msgid "Steel Golems"
 #~ msgstr "Стальных големов"
 
-#, fuzzy
 #~ msgid "Roc"
 #~ msgstr "Рух"
 
 #~ msgid "Rocs"
 #~ msgstr "Рух"
 
-#, fuzzy
 #~ msgid "Mage"
 #~ msgstr "Маг"
 
 #~ msgid "Magi"
 #~ msgstr "Маг"
 
-#, fuzzy
 #~ msgid "Archmage"
 #~ msgstr "Архимаг"
 
 #~ msgid "Archmagi"
 #~ msgstr "Архимаг"
 
-#, fuzzy
 #~ msgid "Giant"
 #~ msgstr "Гигант"
 
 #~ msgid "Giants"
 #~ msgstr "Гигантов"
 
-#, fuzzy
 #~ msgid "Titan"
 #~ msgstr "Титан"
 
@@ -7429,126 +7332,108 @@ msgstr ""
 #~ msgid "Skeletons"
 #~ msgstr "Скелетов"
 
-#, fuzzy
 #~ msgid "Zombie"
 #~ msgstr "Зомби"
 
 #~ msgid "Zombies"
 #~ msgstr "Зомби"
 
-#, fuzzy
 #~ msgid "Mutant Zombie"
 #~ msgstr "Зомби Мутант"
 
 #~ msgid "Mutant Zombies"
 #~ msgstr "Зомби мутантов"
 
-#, fuzzy
 #~ msgid "Mummy"
 #~ msgstr "Мумия"
 
 #~ msgid "Mummies"
 #~ msgstr "Мумий"
 
-#, fuzzy
 #~ msgid "Royal Mummy"
 #~ msgstr "Королевская Мумия"
 
 #~ msgid "Royal Mummies"
 #~ msgstr "Королевских мумий"
 
-#, fuzzy
 #~ msgid "Vampire"
 #~ msgstr "Вампир"
 
 #~ msgid "Vampires"
 #~ msgstr "Вампиров"
 
-#, fuzzy
 #~ msgid "Vampire Lord"
 #~ msgstr "Лорд Вампир"
 
 #~ msgid "Vampire Lords"
 #~ msgstr "Лордов вампиров"
 
-#, fuzzy
 #~ msgid "Lich"
 #~ msgstr "Лич"
 
 #~ msgid "Liches"
 #~ msgstr "Личей"
 
-#, fuzzy
 #~ msgid "Power Lich"
 #~ msgstr "Могучий Лич"
 
 #~ msgid "Power Liches"
 #~ msgstr "Могучих личей"
 
-#, fuzzy
 #~ msgid "Bone Dragon"
 #~ msgstr "Костяной Дракон"
 
 #~ msgid "Bone Dragons"
 #~ msgstr "Костяных драконов"
 
-#, fuzzy
 #~ msgid "Rogue"
 #~ msgstr "Разбойник"
 
 #~ msgid "Rogues"
 #~ msgstr "Разбойников"
 
-#, fuzzy
 #~ msgid "Nomad"
 #~ msgstr "Кочевник"
 
 #~ msgid "Nomads"
 #~ msgstr "Кочевников"
 
-#, fuzzy
 #~ msgid "Ghost"
 #~ msgstr "Призрак"
 
 #~ msgid "Ghosts"
 #~ msgstr "Призраков"
 
-#, fuzzy
 #~ msgid "Genie"
 #~ msgstr "Джин"
 
 #~ msgid "Genies"
 #~ msgstr "Джинов"
 
-#, fuzzy
 #~ msgid "Medusa"
 #~ msgstr "Медуза"
 
 #~ msgid "Medusas"
 #~ msgstr "Медуз"
 
-#, fuzzy
 #~ msgid "Earth Elemental"
 #~ msgstr "Земной Элементал"
 
 #~ msgid "Earth Elementals"
 #~ msgstr "Земных элементалов"
 
-#, fuzzy
 #~ msgid "Air Elemental"
 #~ msgstr "Воздушный Элементал"
 
 #~ msgid "Air Elementals"
 #~ msgstr "Воздушных элементалов"
 
-#, fuzzy
 #~ msgid "Fire Elemental"
 #~ msgstr "Огненный Элементал"
 
 #~ msgid "Fire Elementals"
 #~ msgstr "Огненных элементалов"
 
-#, fuzzy
 #~ msgid "Water Elemental"
 #~ msgstr "Водяной Элементал"
 


### PR DESCRIPTION
I've finished my work on RU/FR translations. It's far from perfect, but at least there are no untranslated strings now. I'll be happy to apply changes affecting many strings, especially concerning rules of thumb listed below. Fixing individual strings should IMO be done by subsequent pull requests which don't modify half of the file and are easily mergeable.

I have tried to follow these rules, at least for new translations:

- specific names (buildings/items/spells/etc.) should be translated exactly as in official games. I used the GoG version for French and the Buka version for Russian.
- Longer sentences should not be copied (to avoid copyright issues). I mostly used Deepl translations with a manual check for gender / plural form issues, especially around variables. Specific names in longer strings should still be consistent with the rest of the translation.
- In languages featuring formal tone (e.g. polite "you" vs. familiar "you"), the game should address the player in formal tone, and so should his in-game subjects. Independent characters (seers, witches, etc.) should use informal tone when implied by context (e.g. "you already know everything, now get out of my house" looks awkward with polite "you").
- In order to fit translated text on in-game controls, re-phrasing should be preferred to shortening.
- The character set of the translation should not be altered to be more compatible with a given game version (e.g replacing `Ä` with `A` because `Ä` is missing in the in-game font should be done via the Makefile). Punctuation should match the target language as well - I would even suggest we use the German `„“` and the French `«»` quotes, and replace them back to English `""` quotes while Unicode font is not yet supported.

Speaking of the Makefile, I made some changes there too, hopefully the comments explain them well enough. It should now be usable on any reasonable build environment with `iconv` and `sed` installed.