### PR TITLE
Don't run clang-tidy workflow for PRs from forks

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     name: Clang-Tidy
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies


### PR DESCRIPTION
Unfortunately, it seems that clang-tidy workflow is not able to perform a PR decoration if PR is made from a fork, because access for pull request to another repo [cannot be higher than read](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token) in this case. So I limit this workflow only to PRs from the same repo for now, just like SonarCloud workflow.