### PR TITLE
Centering fast separation buttons

### DIFF
--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -356,7 +356,7 @@ int Dialog::ArmySplitTroop( uint32_t freeSlots, const uint32_t redistributeMax, 
             ++spriteIconIdx;
 
             const int spriteWidth = sprites[i].width();
-            const int offset = spriteWidth * ( i - freeSlots / 2 ) + spriteWidth / 2;
+            const int offset = spriteWidth * ( 2 * static_cast<int>( i ) + 1 - static_cast<int>( freeSlots ) ) / 2;
             vrts[i] = fheroes2::Rect( center + offset + deltaXStart + i * deltaX, pos.y + 95, spriteWidth, sprites[i].height() );
         }
 


### PR DESCRIPTION
fix #3734
![1](https://user-images.githubusercontent.com/71143197/125538277-9050b090-ad95-45e2-a295-892848c975a3.png)
