### PR TITLE
Clang-Tidy workflow: use pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -1,7 +1,7 @@
 name: Clang-Tidy
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ master ]
     paths: [ '**.cpp', '**.h' ]
 


### PR DESCRIPTION
This should fix an issue when `clang_tidy.yml` fails to perform PR decoration when PR is made from a fork.