### PR TITLE
Clang-Tidy: disable some checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,1 +1,12 @@
-Checks: '-*,bugprone-*,cppcoreguidelines-*,-cppcoreguidelines-init-variables,misc-*,modernize-*,performance-*,readability-*,-readability-avoid-const-params-in-decls'
+Checks: >-
+  -*,
+  bugprone-*,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-init-variables,
+  misc-*,
+  modernize-*,
+  -modernize-use-trailing-return-type,
+  performance-*,
+  readability-*,
+  -readability-avoid-const-params-in-decls,
+  -readability-implicit-bool-conversion


### PR DESCRIPTION
Related to the clang-tidy run in #3769. `modernize-use-trailing-return-type` check is no use and I believe `readability-implicit-bool-conversion` should be turned off too, because in many cases readability is better with implicit bool conversions than without them, but this is debatable. Also I'm not sure about `readability-braces-around-statements` - on the one hand, "no braces for one-liners" is error-prone, but on the other hand this style is very common in this project. Hi @ihhub what do you think?

P.S. Also it seems that "reviewed" line numbers are wrong - however, given that there are quoted pieces of code, it's not that big a deal.