### PR TITLE
Clang-Tidy: fix repo checkout for pull_request_target

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
     - name: Install dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
It seems that issues with wrong line numbers occur because `actions/checkout` in the case of `pull_request_target` checkouts a wrong ref - not the head ref, but the target ref instead. This PR should fix this.