### PR TITLE
Don't run the Clang-Tidy workflow on PRs from forks

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -1,7 +1,7 @@
 name: Clang-Tidy
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ master ]
     paths: [ '**.cpp', '**.h' ]
 
@@ -9,11 +9,9 @@ jobs:
   build:
     name: Clang-Tidy
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
     - uses: actions/checkout@v2
-      with:
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        ref: ${{ github.event.pull_request.head.ref }}
     - name: Install dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
I have concerns regarding security of the Clang-Tidy workflow. This workflow have r/w access to the main repo and access to repo secrets (due to the nature of `pull_request_target` and the need to post code reviews), but it works with untrusted code from forks, so in theory it may run malicious scripts (using specially crafted `CMakeLists.txt`, for example). That's not good. I'll change it to not run in the `pull_request_target` mode but in the regular `pull_request` mode instead (it doesn't have any r/w access or access to secrets) and it will be run only for PRs originated from the main repo, not from forks.