### PR TITLE
Implement the secure way to run clang-tidy checks from forks

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -9,21 +9,30 @@ jobs:
   build:
     name: Clang-Tidy
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
     - uses: actions/checkout@v2
-    - name: Install dependencies
+      with:
+        fetch-depth: 50
+    - name: Install dependencies and clang-tidy
       run: |
         sudo apt-get update
-        sudo apt-get install -y libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev
+        sudo apt-get install -y libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev gettext clang-tidy
     - name: Prepare compile_commands.json
       run: |
         cmake -B build -DCMAKE_BUILD_TYPE=Release -DUSE_SDL_VERSION=SDL2 -DENABLE_IMAGE=ON -DENABLE_UNICODE=ON -DENABLE_TOOLS=ON -DFHEROES2_STRICT_COMPILATION=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-        # We need to fixup paths in the compile_commands.json, because clang-tidy-review doesn't work properly with nested directories in the build_dir
-        sed -i.orig 's@"directory": .*@"directory": "'"$GITHUB_WORKSPACE"'/build",@g' build/compile_commands.json
+    - name: Create results directory
+      run: |
+        mkdir clang-tidy-result
     - name: Analyze
-      uses: ZedThree/clang-tidy-review@v0.7.0
+      run: |
+        git diff -U0 HEAD^ | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
+    - name: Save PR metadata
+      run: |
+        echo ${{ github.event.number }} > clang-tidy-result/pr-id.txt
+        echo ${{ github.event.pull_request.head.repo.full_name }} > clang-tidy-result/pr-head-repo.txt
+        echo ${{ github.event.pull_request.head.ref }} > clang-tidy-result/pr-head-ref.txt
+    - uses: actions/upload-artifact@v2
       with:
-        apt_packages: libsdl2-dev,libsdl2-image-dev,libsdl2-mixer-dev,libsdl2-ttf-dev
-        build_dir: build
-        clang_tidy_checks:
+        name: clang-tidy-result
+        path: clang-tidy-result/

--- a/.github/workflows/clang_tidy_comments.yml
+++ b/.github/workflows/clang_tidy_comments.yml
@@ -1,0 +1,74 @@
+name: Clang-Tidy Comments
+
+on:
+  workflow_run:
+    workflows: [ Clang-Tidy ]
+    types: [ completed ]
+
+jobs:
+  build:
+    name: Clang-Tidy Comments
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    steps:
+    - name: Download analysis results
+      uses: actions/github-script@v3.1.0
+      with:
+        script: |
+          let artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
+          });
+          let matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "clang-tidy-result"
+          })[0];
+          let download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: "zip",
+          });
+          let fs = require("fs");
+          fs.writeFileSync("${{github.workspace}}/clang-tidy-result.zip", Buffer.from(download.data));
+    - name: Set environment variables
+      run: |
+        mkdir clang-tidy-result
+        unzip clang-tidy-result.zip -d clang-tidy-result
+        echo "pr_id=$(cat clang-tidy-result/pr-id.txt)" >> $GITHUB_ENV
+        echo "pr_head_repo=$(cat clang-tidy-result/pr-head-repo.txt)" >> $GITHUB_ENV
+        echo "pr_head_ref=$(cat clang-tidy-result/pr-head-ref.txt)" >> $GITHUB_ENV
+    - uses: actions/checkout@v2
+      with:
+        repository: ${{ env.pr_head_repo }}
+        ref: ${{ env.pr_head_ref }}
+        persist-credentials: false
+    - name: Redownload analysis results
+      uses: actions/github-script@v3.1.0
+      with:
+        script: |
+          let artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
+          });
+          let matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "clang-tidy-result"
+          })[0];
+          let download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: "zip",
+          });
+          let fs = require("fs");
+          fs.writeFileSync("${{github.workspace}}/clang-tidy-result.zip", Buffer.from(download.data));
+    - name: Extract analysis results
+      run: |
+        mkdir clang-tidy-result
+        unzip clang-tidy-result.zip -d clang-tidy-result
+    - uses: oleg-derevenetz/clang-tidy-pr-comments@adapt-to-workflow_run
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        clang_tidy_fixes: clang-tidy-result/fixes.yml
+        pull_request_id: ${{ env.pr_id }}

--- a/.github/workflows/clang_tidy_comments.yml
+++ b/.github/workflows/clang_tidy_comments.yml
@@ -67,7 +67,7 @@ jobs:
       run: |
         mkdir clang-tidy-result
         unzip clang-tidy-result.zip -d clang-tidy-result
-    - uses: oleg-derevenetz/clang-tidy-pr-comments@adapt-to-workflow_run
+    - uses: fheroes2/clang-tidy-pr-comments@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         clang_tidy_fixes: clang-tidy-result/fixes.yml


### PR DESCRIPTION
Run the analysis itself on `pull_request` event with minimal permissions and then run the separate workflow on `workflow_run` event with elevated permissions to perform the PR decoration.

Currently the `clang_tidy_comments.yml` uses my own fork of Action to perform the PR decoration because original Action ([platisd/clang-tidy-pr-comments](https://github.com/platisd/clang-tidy-pr-comments)) is not able to accept the PR id as a parameter, but I made the https://github.com/platisd/clang-tidy-pr-comments/pull/4 PR, and I'll update this workflow once it will be merged. @ihhub or, if you wish, you can make your own fork of this Action (with my changes) to be able to fully control it.