### PR TITLE
clang-tidy: disable cppcoreguidelines-pro-type-union-access

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,7 @@ Checks: >-
   -cppcoreguidelines-init-variables,
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-union-access,
   misc-*,
   -misc-non-private-member-variables-in-classes,
   modernize-*,


### PR DESCRIPTION
Suggested `variant` is C++17 feature. Related to #3887.