### PR TITLE
Fix English phrasing and punctuation

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2405,7 +2405,7 @@ void Battle::Interface::HumanCastSpellTurn( const Unit & /*b*/, Actions & a, std
             }
 
             if ( listlog ) {
-                std::string str = _( "%{color} cast spell: %{spell}" );
+                std::string str = _( "%{color} casts a spell: %{spell}" );
                 const HeroBase * current_commander = arena.GetCurrentCommander();
                 if ( current_commander )
                     StringReplace( str, "%{color}", Color::String( current_commander->GetColor() ) );
@@ -2689,10 +2689,10 @@ void Battle::Interface::RedrawActionSkipStatus( const Unit & attacker )
 {
     std::string msg;
     if ( attacker.Modes( TR_HARDSKIP ) ) {
-        msg = _( "%{name} skipping turn" );
+        msg = _( "%{name} skip the turn" );
     }
     else {
-        msg = _( "%{name} waiting turn" );
+        msg = _( "%{name} wait their turn" );
     }
 
     StringReplace( msg, "%{name}", attacker.GetName() );
@@ -3845,7 +3845,7 @@ void Battle::Interface::RedrawActionMirrorImageSpell( const Unit & target, const
         }
     }
 
-    status.SetMessage( _( "MirrorImage created" ), true );
+    status.SetMessage( _( "The mirror image is created" ), true );
 }
 
 void Battle::Interface::RedrawLightningOnTargets( const std::vector<fheroes2::Point> & points, const fheroes2::Rect & drawRoi )

--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -327,7 +327,7 @@ namespace
         case Artifact::DIVINE_BREASTPLATE:
             return _( "Breastplate" );
         case Artifact::FIZBIN_MISFORTUNE:
-            return _( "Fizbin Medal" );
+            return _( "Fizbin of Misfortune" );
         case Artifact::MAGE_RING:
             return _( "Mage's ring" );
         case Artifact::DEFENDER_HELM:

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -933,7 +933,7 @@ bool Castle::AllowBuyHero( const Heroes & hero, std::string * msg ) const
     const Kingdom & myKingdom = GetKingdom();
     if ( Modes( DISABLEHIRES ) || myKingdom.Modes( Kingdom::DISABLEHIRES ) ) {
         if ( msg )
-            *msg = _( "Cannot recruit - you already recruit hero in current week." );
+            *msg = _( "Cannot recruit - you have already recruited a hero in the current week." );
         return false;
     }
 

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -496,13 +496,13 @@ u32 Game::SelectCountPlayers( void )
 
         // right info
         if ( le.MousePressRight( button2Players.area() ) )
-            Dialog::Message( _( "2 Players" ), _( "Play with 2 human players, and optionally, up, to 4 additional computer players." ), Font::BIG );
+            Dialog::Message( _( "2 Players" ), _( "Play with 2 human players, and optionally, up to 4 additional computer players." ), Font::BIG );
         if ( le.MousePressRight( button3Players.area() ) )
-            Dialog::Message( _( "3 Players" ), _( "Play with 3 human players, and optionally, up, to 3 additional computer players." ), Font::BIG );
+            Dialog::Message( _( "3 Players" ), _( "Play with 3 human players, and optionally, up to 3 additional computer players." ), Font::BIG );
         if ( le.MousePressRight( button4Players.area() ) )
-            Dialog::Message( _( "4 Players" ), _( "Play with 4 human players, and optionally, up, to 2 additional computer players." ), Font::BIG );
+            Dialog::Message( _( "4 Players" ), _( "Play with 4 human players, and optionally, up to 2 additional computer players." ), Font::BIG );
         if ( le.MousePressRight( button5Players.area() ) )
-            Dialog::Message( _( "5 Players" ), _( "Play with 5 human players, and optionally, up, to 1 additional computer players." ), Font::BIG );
+            Dialog::Message( _( "5 Players" ), _( "Play with 5 human players, and optionally, up to 1 additional computer player." ), Font::BIG );
         if ( le.MousePressRight( button6Players.area() ) )
             Dialog::Message( _( "6 Players" ), _( "Play with 6 human players." ), Font::BIG );
         if ( le.MousePressRight( buttonCancel.area() ) )

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -228,28 +228,28 @@ std::string GameOver::GetActualDescription( int cond )
     else if ( WINS_TOWN & cond ) {
         const Castle * town = world.getCastleEntrance( conf.WinsMapsPositionObject() );
         if ( town ) {
-            msg = town->isCastle() ? _( "Capture the castle '%{name}'" ) : _( "Capture the town '%{name}'" );
+            msg = town->isCastle() ? _( "Capture the castle '%{name}'." ) : _( "Capture the town '%{name}'." );
             StringReplace( msg, "%{name}", town->GetName() );
         }
     }
     else if ( WINS_HERO & cond ) {
         const Heroes * hero = world.GetHeroesCondWins();
         if ( hero ) {
-            msg = _( "Defeat the hero '%{name}'" );
+            msg = _( "Defeat the hero '%{name}'." );
             StringReplace( msg, "%{name}", hero->GetName() );
         }
     }
     else if ( WINS_ARTIFACT & cond ) {
         if ( conf.WinsFindUltimateArtifact() )
-            msg = _( "Find the ultimate artifact" );
+            msg = _( "Find the ultimate artifact." );
         else {
             const Artifact art = conf.WinsFindArtifactID();
-            msg = _( "Find the '%{name}' artifact" );
+            msg = _( "Find the '%{name}' artifact." );
             StringReplace( msg, "%{name}", art.GetName() );
         }
     }
     else if ( WINS_GOLD & cond ) {
-        msg = _( "Accumulate %{count} gold" );
+        msg = _( "Accumulate %{count} gold." );
         StringReplace( msg, "%{count}", conf.WinsAccumulateGold() );
     }
 


### PR DESCRIPTION
I found several cases of awkward English phrasing while working on translations, which I would like to fix:

- Replace "Fizbin Medal" with "Fizbin of Misfortune", as in the original game.
- Expand incomplete phrases like "MirrorImage created", "%{name} skipping turn" etc. to proper sentences.
- Replace "up, to" with "up to", finish victory conditions with a dot to match the loss conditions.
- A few other fixes.