### PR TITLE
Add font checksums for Polish / German / alt. Russian (XXI Vek) versions

### DIFF
--- a/src/fheroes2/gui/ui_language.cpp
+++ b/src/fheroes2/gui/ui_language.cpp
@@ -30,8 +30,11 @@
 
 namespace
 {
-    const std::map<uint32_t, fheroes2::SupportedLanguage> languageCRC32
-        = { { 0x406967B9, fheroes2::SupportedLanguage::French }, { 0xD5CF8AF3, fheroes2::SupportedLanguage::Russian } };
+    const std::map<uint32_t, fheroes2::SupportedLanguage> languageCRC32 = { { 0x406967B9, fheroes2::SupportedLanguage::French }, // GoG version
+                                                                            { 0x04745D1D, fheroes2::SupportedLanguage::German }, // GoG version
+                                                                            { 0x88774771, fheroes2::SupportedLanguage::Polish }, // GoG version
+                                                                            { 0xDB10FFD8, fheroes2::SupportedLanguage::Russian }, // XXI Vek version
+                                                                            { 0xD5CF8AF3, fheroes2::SupportedLanguage::Russian } }; // Buka version
 
     class LanguageSwitcher
     {


### PR DESCRIPTION
Sorry I was late for the party when #3897 was being worked on.

I have installed all HoMM versions which are available to me and calculated the font checksums. The alternative Russian version (XXI Vek, "21st Century") uses exactly the same CP1251 encoding as Buka, so there's no added effort to support it. Personally I find XXI Vek interface to be horrible, the font face they used makes me feel dyslexic ([check out for yourself](https://user-images.githubusercontent.com/10945319/126991533-68bc1583-3216-4248-b619-a2e078fe9831.png)), but hey, it's a matter of taste.

FIY, I'm working on a German translation right now, it's about 40% completed.