### PR TITLE
Correct player icon in the Game Info window.

### DIFF
--- a/src/fheroes2/gui/player_info.cpp
+++ b/src/fheroes2/gui/player_info.cpp
@@ -190,7 +190,7 @@ void Interface::PlayersInfo::RedrawInfo( bool show_play_info ) const /* show_pla
             // comp only
             if ( fi.ComputerOnlyColors() & player.GetColor() ) {
             if ( show_play_info ) {
-                index = ( player.isPlay() ? 3 : 15 ) + Color::GetIndex( player.GetColor() );
+                index = ( player.isPlay() ? 15 : 3 ) + Color::GetIndex( player.GetColor() );
             }
             else
                 index = 15 + Color::GetIndex( player.GetColor() );

--- a/src/fheroes2/gui/player_info.cpp
+++ b/src/fheroes2/gui/player_info.cpp
@@ -188,22 +188,11 @@ void Interface::PlayersInfo::RedrawInfo( bool show_play_info ) const /* show_pla
             index = 9 + Color::GetIndex( player.GetColor() );
         else
             // comp only
-            if ( fi.ComputerOnlyColors() & player.GetColor() ) {
-            if ( show_play_info ) {
-                index = ( player.isPlay() ? 15 : 3 ) + Color::GetIndex( player.GetColor() );
-            }
-            else
-                index = 15 + Color::GetIndex( player.GetColor() );
-        }
+            if ( fi.ComputerOnlyColors() & player.GetColor() )
+            index = 15 + Color::GetIndex( player.GetColor() );
         else
-        // comp/human
-        {
-            if ( show_play_info ) {
-                index = ( player.isPlay() ? 3 : 15 ) + Color::GetIndex( player.GetColor() );
-            }
-            else
-                index = 3 + Color::GetIndex( player.GetColor() );
-        }
+            // comp/human
+            index = 3 + Color::GetIndex( player.GetColor() );
 
         // wide sprite offset
         if ( show_name )


### PR DESCRIPTION
I fixed a bug in the game info window that incorrectly displayed the player icon for computer-only players. For more details, please read my comment in the #3475. It fixes #3475.