### PR TITLE
Remove some useless experimental options

### DIFF
--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -525,7 +525,6 @@ u32 * Castle::GetDwelling( u32 dw )
 
 void Castle::ActionNewWeek( void )
 {
-    ResetModes( DISABLEHIRES );
     const bool isNeutral = GetColor() == Color::NONE;
 
     // increase population
@@ -930,13 +929,6 @@ const char * Castle::GetDescriptionBuilding( u32 build, int race )
 
 bool Castle::AllowBuyHero( const Heroes & hero, std::string * msg ) const
 {
-    const Kingdom & myKingdom = GetKingdom();
-    if ( Modes( DISABLEHIRES ) || myKingdom.Modes( Kingdom::DISABLEHIRES ) ) {
-        if ( msg )
-            *msg = _( "Cannot recruit - you have already recruited a hero in the current week." );
-        return false;
-    }
-
     CastleHeroes heroes = world.GetHeroes( *this );
 
     if ( heroes.Guest() ) {
@@ -955,6 +947,7 @@ bool Castle::AllowBuyHero( const Heroes & hero, std::string * msg ) const
         }
     }
 
+    const Kingdom & myKingdom = GetKingdom();
     if ( !myKingdom.AllowRecruitHero( false, hero.GetLevel() ) ) {
         if ( msg )
             *msg = _( "Cannot recruit - you have too many Heroes." );
@@ -1002,12 +995,6 @@ Heroes * Castle::RecruitHero( Heroes * hero )
     // update spell book
     if ( GetLevelMageGuild() )
         MageGuildEducateHero( *hero );
-
-    if ( Settings::Get().ExtWorldOneHeroHiredEveryWeek() )
-        kingdom.SetModes( Kingdom::DISABLEHIRES );
-
-    if ( Settings::Get().ExtCastleOneHeroHiredEveryWeek() )
-        SetModes( DISABLEHIRES );
 
     DEBUG_LOG( DBG_GAME, DBG_INFO, name << ", recruit: " << hero->GetName() );
 

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -110,7 +110,7 @@ public:
         ALLOWCASTLE = 0x0002,
         CUSTOMARMY = 0x0004,
         ALLOWBUILD = 0x0008,
-        DISABLEHIRES = 0x0010,
+        // UNUSED = 0x0010,
         CAPITAL = 0x0020
     };
 

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -193,13 +193,13 @@ std::string ShowDwellingInfo( const Maps::Tiles & tile, bool owned, bool extende
     return str;
 }
 
-std::string ShowShrineInfo( const Maps::Tiles & tile, const Heroes * hero, bool showVisitedOption, bool isVisited, bool extendedScoutingOption, uint32_t scoutingLevel )
+std::string ShowShrineInfo( const Maps::Tiles & tile, const Heroes * hero, bool isVisited, bool extendedScoutingOption, uint32_t scoutingLevel )
 {
     std::string str = MP2::StringObject( tile.GetObject() );
 
     bool showSpellDetails = false;
 
-    if ( showVisitedOption && isVisited ) {
+    if ( isVisited ) {
         showSpellDetails = true;
     }
     else if ( extendedScoutingOption ) {
@@ -233,11 +233,11 @@ std::string ShowShrineInfo( const Maps::Tiles & tile, const Heroes * hero, bool 
     return str;
 }
 
-std::string ShowWitchHutInfo( const Maps::Tiles & tile, const Heroes * hero, bool showVisitedOption, bool isVisited, bool extendedScoutingOption, uint32_t scoutingLevel )
+std::string ShowWitchHutInfo( const Maps::Tiles & tile, const Heroes * hero, bool isVisited, bool extendedScoutingOption, uint32_t scoutingLevel )
 {
     std::string str = MP2::StringObject( tile.GetObject() );
 
-    const bool show = ( showVisitedOption && isVisited ) || ( extendedScoutingOption && scoutingLevel == Skill::Level::EXPERT );
+    const bool show = isVisited || ( extendedScoutingOption && scoutingLevel == Skill::Level::EXPERT );
 
     if ( show ) {
         const Skill::Secondary & skill = tile.QuantitySkill();
@@ -284,14 +284,12 @@ std::string ShowLocalVisitObjectInfo( const Maps::Tiles & tile, const Heroes * h
     return str;
 }
 
-std::string ShowGlobalVisitInfo( const Maps::Tiles & tile, const Kingdom & kingdom, bool showVisitedOption )
+std::string ShowGlobalVisitInfo( const Maps::Tiles & tile, const Kingdom & kingdom )
 {
     std::string str = MP2::StringObject( tile.GetObject() );
 
-    if ( showVisitedOption ) {
-        str.append( "\n \n" );
-        str.append( kingdom.isVisited( tile ) ? _( "(already visited)" ) : _( "(not visited)" ) );
-    }
+    str.append( "\n \n" );
+    str.append( kingdom.isVisited( tile ) ? _( "(already visited)" ) : _( "(not visited)" ) );
 
     return str;
 }
@@ -492,7 +490,6 @@ void Dialog::QuickInfo( const Maps::Tiles & tile )
     // This value is only relevant for the "Extended Scouting" option
     const uint32_t scoutingLevelForTile = isVisibleFromCrystalBall ? static_cast<int>( Skill::Level::EXPERT ) : GetHeroScoutingLevelForTile( from_hero, tile.GetIndex() );
 
-    const bool showVisitedOption = settings.ExtWorldShowVisitedContent();
     const bool showTerrainPenaltyOption = settings.ExtWorldShowTerrainPenalty();
     const bool extendedScoutingOption = settings.ExtWorldScouteExtended();
 
@@ -523,13 +520,13 @@ void Dialog::QuickInfo( const Maps::Tiles & tile )
         case MP2::OBJ_WAGON:
         case MP2::OBJ_SKELETON:
         case MP2::OBJ_LEANTO:
-            name_object = ShowGlobalVisitInfo( tile, kingdom, showVisitedOption );
+            name_object = ShowGlobalVisitInfo( tile, kingdom );
             break;
 
         case MP2::OBJ_WINDMILL:
         case MP2::OBJ_WATERWHEEL:
         case MP2::OBJ_MAGICGARDEN:
-            name_object = Settings::Get().ExtWorldExtObjectsCaptured() ? MP2::StringObject( objectType ) : ShowGlobalVisitInfo( tile, kingdom, showVisitedOption );
+            name_object = Settings::Get().ExtWorldExtObjectsCaptured() ? MP2::StringObject( objectType ) : ShowGlobalVisitInfo( tile, kingdom );
             break;
 
         case MP2::OBJ_CAMPFIRE:
@@ -588,7 +585,7 @@ void Dialog::QuickInfo( const Maps::Tiles & tile )
             break;
 
         case MP2::OBJ_ARTESIANSPRING:
-            name_object = ShowGlobalVisitInfo( tile, kingdom, true );
+            name_object = ShowGlobalVisitInfo( tile, kingdom );
             break;
 
         case MP2::OBJ_MAGICWELL:
@@ -609,15 +606,15 @@ void Dialog::QuickInfo( const Maps::Tiles & tile )
         case MP2::OBJ_SHRINE1:
         case MP2::OBJ_SHRINE2:
         case MP2::OBJ_SHRINE3:
-            name_object = ShowShrineInfo( tile, from_hero, showVisitedOption, kingdom.isVisited( tile ), extendedScoutingOption, scoutingLevelForTile );
+            name_object = ShowShrineInfo( tile, from_hero, kingdom.isVisited( tile ), extendedScoutingOption, scoutingLevelForTile );
             break;
 
         case MP2::OBJ_WITCHSHUT:
-            name_object = ShowWitchHutInfo( tile, from_hero, showVisitedOption, kingdom.isVisited( tile ), extendedScoutingOption, scoutingLevelForTile );
+            name_object = ShowWitchHutInfo( tile, from_hero, kingdom.isVisited( tile ), extendedScoutingOption, scoutingLevelForTile );
             break;
 
         case MP2::OBJ_OBELISK:
-            name_object = ShowGlobalVisitInfo( tile, kingdom, true );
+            name_object = ShowGlobalVisitInfo( tile, kingdom );
             break;
 
         case MP2::OBJ_BARRIER:

--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -110,14 +110,6 @@ void SettingsListBox::ActionListSingleClick( u32 & item )
 
         // depends
         switch ( item ) {
-        case Settings::WORLD_1HERO_HIRED_EVERY_WEEK:
-            conf.ExtResetModes( Settings::CASTLE_1HERO_HIRED_EVERY_WEEK );
-            break;
-
-        case Settings::CASTLE_1HERO_HIRED_EVERY_WEEK:
-            conf.ExtResetModes( Settings::WORLD_1HERO_HIRED_EVERY_WEEK );
-            break;
-
         case Settings::GAME_AUTOSAVE_BEGIN_DAY:
             if ( conf.ExtModes( Settings::GAME_AUTOSAVE_BEGIN_DAY ) ) {
                 conf.ExtSetModes( Settings::GAME_AUTOSAVE_ON );
@@ -159,19 +151,12 @@ void Dialog::ExtSettings( bool readonly )
         states.push_back( Settings::GAME_USE_FADE );
 
     states.push_back( Settings::GAME_CONTINUE_AFTER_VICTORY );
-    states.push_back( Settings::WORLD_SHOW_VISITED_CONTENT );
     states.push_back( Settings::WORLD_SHOW_TERRAIN_PENALTY );
     states.push_back( Settings::WORLD_ALLOW_SET_GUARDIAN );
     states.push_back( Settings::WORLD_EXT_OBJECTS_CAPTURED );
     states.push_back( Settings::WORLD_SCOUTING_EXTENDED );
     states.push_back( Settings::WORLD_ARTIFACT_CRYSTAL_BALL );
     states.push_back( Settings::WORLD_EYE_EAGLE_AS_SCHOLAR );
-    states.push_back( Settings::WORLD_BAN_WEEKOF );
-    states.push_back( Settings::WORLD_BAN_PLAGUES );
-    states.push_back( Settings::WORLD_BAN_MONTHOF_MONSTERS );
-    states.push_back( Settings::WORLD_STARTHERO_LOSSCOND4HUMANS );
-    states.push_back( Settings::WORLD_1HERO_HIRED_EVERY_WEEK );
-    states.push_back( Settings::CASTLE_1HERO_HIRED_EVERY_WEEK );
     states.push_back( Settings::WORLD_SCALE_NEUTRAL_ARMIES );
     states.push_back( Settings::WORLD_USE_UNIQUE_ARTIFACTS_RS );
     states.push_back( Settings::WORLD_USE_UNIQUE_ARTIFACTS_PS );

--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -108,16 +108,8 @@ void SettingsListBox::ActionListSingleClick( u32 & item )
     if ( !readonly || conf.CanChangeInGame( item ) ) {
         conf.ExtModes( item ) ? conf.ExtResetModes( item ) : conf.ExtSetModes( item );
 
-        // depends
-        switch ( item ) {
-        case Settings::GAME_AUTOSAVE_BEGIN_DAY:
-            if ( conf.ExtModes( Settings::GAME_AUTOSAVE_BEGIN_DAY ) ) {
-                conf.ExtSetModes( Settings::GAME_AUTOSAVE_ON );
-            }
-            break;
-
-        default:
-            break;
+        if ( item == Settings::GAME_AUTOSAVE_BEGIN_DAY && conf.ExtModes( Settings::GAME_AUTOSAVE_BEGIN_DAY ) ) {
+            conf.ExtSetModes( Settings::GAME_AUTOSAVE_ON );
         }
     }
 }

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -283,17 +283,6 @@ std::string GameOver::GetActualDescription( uint32_t cond )
         StringReplace( msg, "%{month}", month + 1 );
     }
 
-    if ( ( cond & LOSS ) && conf.ExtWorldStartHeroLossCond4Humans() && conf.isStandardGameType() ) {
-        const std::string names = world.GetKingdom( conf.CurrentColor() ).GetNamesHeroStartCondLoss();
-
-        if ( !names.empty() ) {
-            std::string str = std::string::npos == names.find( ',' ) ? _( "Lose the hero: %{name}." ) : _( "Lose the heroes: %{name}." );
-            StringReplace( str, "%{name}", names );
-            msg.append( "\n" );
-            msg.append( str );
-        }
-    }
-
     return msg;
 }
 

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -435,7 +435,6 @@ fheroes2::GameMode GameOver::Result::LocalCheckGameOver()
 
                 // LOSS_ALL fulfillment is not a reason to end the game, only this player is vanquished
                 // LOSS_TOWN is currently not supported in multiplayer
-                // LOSS_STARTHERO is an extension and apparently is not intended to be used in multiplayer
                 if ( condition == GameOver::LOSS_HERO || condition == GameOver::LOSS_TIME || ( condition & GameOver::LOSS_ENEMY_WINS ) ) {
                     return condition;
                 }

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -254,17 +254,6 @@ const Heroes * Kingdom::GetFirstHeroStartCondLoss( void ) const
     return nullptr;
 }
 
-std::string Kingdom::GetNamesHeroStartCondLoss( void ) const
-{
-    std::string result;
-    for ( KingdomHeroes::const_iterator it = heroes_cond_loss.begin(); it != heroes_cond_loss.end(); ++it ) {
-        result.append( ( *it )->GetName() );
-        if ( it + 1 != heroes_cond_loss.end() )
-            result.append( ", " );
-    }
-    return result;
-}
-
 void Kingdom::RemoveHeroes( const Heroes * hero )
 {
     if ( hero ) {

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -195,8 +195,6 @@ void Kingdom::ActionNewDay( void )
 
 void Kingdom::ActionNewWeek( void )
 {
-    ResetModes( DISABLEHIRES );
-
     // skip first day
     if ( 1 < world.CountDay() ) {
         // castle New Week
@@ -246,12 +244,6 @@ void Kingdom::AddHeroes( Heroes * hero )
 
         AI::Get().HeroesAdd( *hero );
     }
-}
-
-void Kingdom::AddHeroStartCondLoss( Heroes * hero )
-{
-    // see: Settings::ExtWorldStartHeroLossCond4Humans
-    heroes_cond_loss.push_back( hero );
 }
 
 const Heroes * Kingdom::GetFirstHeroStartCondLoss( void ) const
@@ -855,20 +847,6 @@ void Kingdoms::AddHeroes( const AllHeroes & heroes )
         // skip gray color
         if ( ( *it )->GetColor() )
             GetKingdom( ( *it )->GetColor() ).AddHeroes( *it );
-}
-
-void Kingdoms::AddCondLossHeroes( const AllHeroes & heroes )
-{
-    for ( AllHeroes::const_iterator it = heroes.begin(); it != heroes.end(); ++it )
-        // skip gray color
-        if ( ( *it )->GetColor() ) {
-            Kingdom & kingdom = GetKingdom( ( *it )->GetColor() );
-
-            if ( kingdom.isControlHuman() ) {
-                ( *it )->SetModes( Heroes::NOTDISMISS | Heroes::NOTDEFAULTS );
-                kingdom.AddHeroStartCondLoss( *it );
-            }
-        }
 }
 
 void Kingdoms::AddCastles( const AllCastles & castles )

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -82,7 +82,6 @@ public:
 
     void SetLastLostHero( const Heroes & );
     void ResetLastLostHero( void );
-    std::string GetNamesHeroStartCondLoss( void ) const;
 
     void SetLastBattleWinHero( const Heroes & hero );
 

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -62,7 +62,7 @@ public:
     {
         // UNDEF      = 0x0001,
         IDENTIFYHERO = 0x0002,
-        DISABLEHIRES = 0x0004,
+        // UNUSED = 0x0004,
         OVERVIEWCSTL = 0x0008
     };
 
@@ -82,7 +82,6 @@ public:
 
     void SetLastLostHero( const Heroes & );
     void ResetLastLostHero( void );
-    void AddHeroStartCondLoss( Heroes * );
     std::string GetNamesHeroStartCondLoss( void ) const;
 
     void SetLastBattleWinHero( const Heroes & hero );
@@ -224,7 +223,6 @@ public:
     void AddHeroes( const AllHeroes & );
     void AddCastles( const AllCastles & );
 
-    void AddCondLossHeroes( const AllHeroes & );
     void AddTributeEvents( CapturedObjects &, u32 day, int obj );
 
     u32 size( void ) const;

--- a/src/fheroes2/kingdom/week.cpp
+++ b/src/fheroes2/kingdom/week.cpp
@@ -114,14 +114,12 @@ const char * Week::GetName( void ) const
 
 int Week::WeekRand( void )
 {
-    return ( ( 0 == ( world.CountWeek() + 1 ) % 3 ) && ( !Settings::Get().ExtWorldBanWeekOf() ) ) ? static_cast<int>( MONSTERS ) : Rand::Get( ANT, CONDOR );
+    return ( 0 == ( world.CountWeek() + 1 ) % 3 ) ? static_cast<int>( MONSTERS ) : Rand::Get( ANT, CONDOR );
 }
 
 int Week::MonthRand( void )
 {
-    return ( ( 0 == ( world.GetMonth() + 1 ) % 3 ) && ( !Settings::Get().ExtWorldBanWeekOf() ) )
-               ? static_cast<int>( MONSTERS )
-               : Rand::Get( Settings::Get().ExtWorldBanPlagues() ? ANT : PLAGUE, CONDOR );
+    return ( 0 == ( world.GetMonth() + 1 ) % 3 ) ? static_cast<int>( MONSTERS ) : Rand::Get( PLAGUE, CONDOR );
 }
 
 StreamBase & operator>>( StreamBase & sb, Week & st )

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -1053,11 +1053,6 @@ void Settings::SetGameType( int type )
     game_type = type;
 }
 
-bool Settings::isStandardGameType() const
-{
-    return ( game_type & Game::TYPE_STANDARD ) != 0;
-}
-
 bool Settings::isCampaignGameType() const
 {
     return ( game_type & Game::TYPE_CAMPAIGN ) != 0;

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -102,10 +102,6 @@ namespace
             _( "battle: show damage info" ),
         },
         {
-            Settings::WORLD_SHOW_VISITED_CONTENT,
-            _( "world: show visited content from objects" ),
-        },
-        {
             Settings::WORLD_SHOW_TERRAIN_PENALTY,
             _( "world: show terrain penalty" ),
         },
@@ -122,32 +118,8 @@ namespace
             _( "world: Eagle Eye also works like Scholar in H3." ),
         },
         {
-            Settings::WORLD_BAN_WEEKOF,
-            _( "world: ban for WeekOf/MonthOf Monsters" ),
-        },
-        {
-            Settings::WORLD_BAN_PLAGUES,
-            _( "world: ban plagues months" ),
-        },
-        {
-            Settings::WORLD_BAN_MONTHOF_MONSTERS,
-            _( "world: Months Of Monsters do not place creatures on map" ),
-        },
-        {
             Settings::WORLD_ARTIFACT_CRYSTAL_BALL,
             _( "world: Crystal Ball also added Identify Hero and Visions spells" ),
-        },
-        {
-            Settings::WORLD_STARTHERO_LOSSCOND4HUMANS,
-            _( "world: Starting heroes as Loss Conditions for Human Players" ),
-        },
-        {
-            Settings::WORLD_1HERO_HIRED_EVERY_WEEK,
-            _( "world: Only 1 hero can be hired by the one player every week" ),
-        },
-        {
-            Settings::CASTLE_1HERO_HIRED_EVERY_WEEK,
-            _( "world: Each castle allows one hero to be recruited every week" ),
         },
         {
             Settings::WORLD_SCALE_NEUTRAL_ARMIES,
@@ -275,7 +247,6 @@ Settings::Settings()
     , preferably_count_players( 0 )
 {
     ExtSetModes( GAME_AUTOSAVE_ON );
-    ExtSetModes( WORLD_SHOW_VISITED_CONTENT );
 
     opt_global.SetModes( GLOBAL_FIRST_RUN );
     opt_global.SetModes( GLOBAL_SHOW_INTRO );
@@ -1341,11 +1312,6 @@ bool Settings::ExtCastleAllowGuardians() const
     return ExtModes( CASTLE_ALLOW_GUARDIANS );
 }
 
-bool Settings::ExtWorldShowVisitedContent() const
-{
-    return ExtModes( WORLD_SHOW_VISITED_CONTENT );
-}
-
 bool Settings::ExtWorldShowTerrainPenalty() const
 {
     return ExtModes( WORLD_SHOW_TERRAIN_PENALTY );
@@ -1456,39 +1422,9 @@ bool Settings::ExtGameHideInterface() const
     return ExtModes( GAME_HIDE_INTERFACE );
 }
 
-bool Settings::ExtWorldBanWeekOf() const
-{
-    return ExtModes( WORLD_BAN_WEEKOF );
-}
-
-bool Settings::ExtWorldBanMonthOfMonsters() const
-{
-    return ExtModes( WORLD_BAN_MONTHOF_MONSTERS );
-}
-
-bool Settings::ExtWorldBanPlagues() const
-{
-    return ExtModes( WORLD_BAN_PLAGUES );
-}
-
 bool Settings::ExtBattleReverseWaitOrder() const
 {
     return ExtModes( BATTLE_REVERSE_WAIT_ORDER );
-}
-
-bool Settings::ExtWorldStartHeroLossCond4Humans() const
-{
-    return ExtModes( WORLD_STARTHERO_LOSSCOND4HUMANS );
-}
-
-bool Settings::ExtWorldOneHeroHiredEveryWeek() const
-{
-    return ExtModes( WORLD_1HERO_HIRED_EVERY_WEEK );
-}
-
-bool Settings::ExtCastleOneHeroHiredEveryWeek() const
-{
-    return ExtModes( CASTLE_1HERO_HIRED_EVERY_WEEK );
 }
 
 bool Settings::ExtWorldNeutralArmyDifficultyScaling() const

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -241,7 +241,6 @@ public:
     bool IsGameType( int type ) const;
     int GameType() const;
     void SetGameType( int );
-    bool isStandardGameType() const;
     bool isCampaignGameType() const;
 
     Players & GetPlayers();

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -66,7 +66,7 @@ public:
         GAME_CONTINUE_AFTER_VICTORY = 0x10200000,
 
         /* influence on game balance: save to savefile */
-        WORLD_SHOW_VISITED_CONTENT = 0x20000001,
+        // UNUSED = 0x20000001,
         // UNUSED = 0x20000002,
         WORLD_ALLOW_SET_GUARDIAN = 0x20000008,
         WORLD_ARTIFACT_CRYSTAL_BALL = 0x20000020,
@@ -74,13 +74,13 @@ public:
         // UNUSED = 0x20000080,
         WORLD_EYE_EAGLE_AS_SCHOLAR = 0x20000100,
         HEROES_BUY_BOOK_FROM_SHRINES = 0x20000200,
-        WORLD_BAN_WEEKOF = 0x20000400,
-        WORLD_BAN_PLAGUES = 0x20000800,
+        // UNUSED = 0x20000400,
+        // UNUSED = 0x20000800,
         UNIONS_ALLOW_HERO_MEETINGS = 0x20001000,
         UNIONS_ALLOW_CASTLE_VISITING = 0x20002000,
         WORLD_SHOW_TERRAIN_PENALTY = 0x20004000,
         // UNUSED = 0x20008000,
-        WORLD_BAN_MONTHOF_MONSTERS = 0x20010000,
+        // UNUSED = 0x20010000,
         HEROES_TRANSCRIBING_SCROLLS = 0x20020000,
         // UNUSED = 0x20040000,
         CASTLE_ALLOW_GUARDIANS = 0x20080000,
@@ -88,8 +88,8 @@ public:
         HEROES_REMEMBER_POINTS_RETREAT = 0x21000000,
 
         CASTLE_MAGEGUILD_POINTS_TURN = 0x30000001,
-        WORLD_STARTHERO_LOSSCOND4HUMANS = 0x30000008,
-        WORLD_1HERO_HIRED_EVERY_WEEK = 0x30000010,
+        // UNUSED = 0x30000008,
+        // UNUSED = 0x30000010,
         WORLD_SCALE_NEUTRAL_ARMIES = 0x30000020,
         HEROES_ARENA_ANY_SKILLS = 0x30000080,
         // UNUSED = 0x30000100,
@@ -98,7 +98,7 @@ public:
         WORLD_USE_UNIQUE_ARTIFACTS_SS = 0x30000800,
         WORLD_DISABLE_BARROW_MOUNDS = 0x30001000,
         WORLD_EXT_OBJECTS_CAPTURED = 0x30004000,
-        CASTLE_1HERO_HIRED_EVERY_WEEK = 0x30008000,
+        // UNUSED = 0x30008000,
 
         BATTLE_SHOW_ARMY_ORDER = 0x40004000,
         // UNUSED = 0x40008000,
@@ -129,13 +129,8 @@ public:
 
     int GameDifficulty() const;
 
-    const std::string & MapsCharset() const;
     const std::string & getGameLanguage() const;
     const std::string & loadedFileLanguage() const;
-    const std::string & FontsNormal() const;
-    const std::string & FontsSmall() const;
-    int FontsNormalSize() const;
-    int FontsSmallSize() const;
 
     const fheroes2::Point & PosRadar() const;
     const fheroes2::Point & PosButtons() const;
@@ -183,17 +178,11 @@ public:
     bool ExtHeroArenaCanChoiseAnySkills() const;
     bool ExtUnionsAllowCastleVisiting() const;
     bool ExtUnionsAllowHeroesMeetings() const;
-    bool ExtWorldShowVisitedContent() const;
     bool ExtWorldShowTerrainPenalty() const;
     bool ExtWorldScouteExtended() const;
     bool ExtWorldAllowSetGuardian() const;
     bool ExtWorldArtifactCrystalBall() const;
     bool ExtWorldEyeEagleAsScholar() const;
-    bool ExtWorldBanMonthOfMonsters() const;
-    bool ExtWorldBanWeekOf() const;
-    bool ExtWorldBanPlagues() const;
-    bool ExtWorldStartHeroLossCond4Humans() const;
-    bool ExtWorldOneHeroHiredEveryWeek() const;
     bool ExtWorldNeutralArmyDifficultyScaling() const;
     bool ExtWorldUseUniqueArtifactsRS() const;
     bool ExtWorldUseUniqueArtifactsPS() const;
@@ -202,7 +191,6 @@ public:
     bool ExtWorldDisableBarrowMounds() const;
     bool ExtCastleAllowGuardians() const;
     bool ExtCastleGuildRestorePointsTurn() const;
-    bool ExtCastleOneHeroHiredEveryWeek() const;
     bool ExtBattleShowDamage() const;
     bool ExtBattleShowBattleOrder() const;
     bool ExtBattleSoftWait() const;

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -706,7 +706,7 @@ void World::NewWeek( void )
 void World::NewMonth( void )
 {
     // skip first month
-    if ( 1 < week && week_current.GetType() == Week::MONSTERS && !Settings::Get().ExtWorldBanMonthOfMonsters() )
+    if ( 1 < week && week_current.GetType() == Week::MONSTERS )
         MonthOfMonstersAction( Monster( week_current.GetMonster() ) );
 
     // update gray towns
@@ -1289,12 +1289,6 @@ uint32_t World::CheckKingdomLoss( const Kingdom & kingdom ) const
     for ( const uint32_t cond : loss ) {
         if ( ( ( conf.ConditionLoss() & cond ) == cond ) && KingdomIsLoss( kingdom, cond ) ) {
             return cond;
-        }
-    }
-
-    if ( conf.ExtWorldStartHeroLossCond4Humans() && conf.isStandardGameType() ) {
-        if ( kingdom.GetFirstHeroStartCondLoss() ) {
-            return GameOver::LOSS_STARTHERO;
         }
     }
 

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -728,10 +728,6 @@ void World::ProcessNewMap()
     // play with hero
     vec_kingdoms.ApplyPlayWithStartingHero();
 
-    if ( conf.ExtWorldStartHeroLossCond4Humans() && conf.isStandardGameType() ) {
-        vec_kingdoms.AddCondLossHeroes( vec_heroes );
-    }
-
     // play with debug hero
     if ( IS_DEVEL() ) {
         // get first castle position


### PR DESCRIPTION
- world: show visited content from objects (this is enabled by default now)
- world: ban for WeekOf/MonthOf Monsters
- world: ban plagues months
- world: Months Of Monsters do not place creatures on map
- world: Starting heroes as Loss Conditions for Human Players
- world: Only 1 hero can be hired by the one player every week
- world: Each castle allows one hero to be recruited every week

relates to #1272