### PR TITLE
Delete the fixes.yml existence check - it is no longer needed

### DIFF
--- a/.github/workflows/clang_tidy_comments.yml
+++ b/.github/workflows/clang_tidy_comments.yml
@@ -68,7 +68,6 @@ jobs:
         mkdir clang-tidy-result
         unzip clang-tidy-result.zip -d clang-tidy-result
     - uses: fheroes2/clang-tidy-pr-comments@master
-      if: ${{ hashFiles( 'clang-tidy-result/fixes.yml' ) != '' }}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         clang_tidy_fixes: clang-tidy-result/fixes.yml


### PR DESCRIPTION
Need to sync the [fheroes2/clang-tidy-pr-comments](https://github.com/fheroes2/clang-tidy-pr-comments) with the upstream first though.