### PR TITLE
Update skill order for new heroes

### DIFF
--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -584,32 +584,32 @@ Skill::SecSkills::SecSkills( int race )
         if ( ptr ) {
             if ( ptr->initial_secondary.archery )
                 AddSkill( Secondary( Secondary::ARCHERY, ptr->initial_secondary.archery ) );
-            if ( ptr->initial_secondary.ballistics )
-                AddSkill( Secondary( Secondary::BALLISTICS, ptr->initial_secondary.ballistics ) );
             if ( ptr->initial_secondary.diplomacy )
                 AddSkill( Secondary( Secondary::DIPLOMACY, ptr->initial_secondary.diplomacy ) );
             if ( ptr->initial_secondary.eagleeye )
                 AddSkill( Secondary( Secondary::EAGLEEYE, ptr->initial_secondary.eagleeye ) );
             if ( ptr->initial_secondary.estates )
                 AddSkill( Secondary( Secondary::ESTATES, ptr->initial_secondary.estates ) );
-            if ( ptr->initial_secondary.leadership )
-                AddSkill( Secondary( Secondary::LEADERSHIP, ptr->initial_secondary.leadership ) );
             if ( ptr->initial_secondary.logistics )
                 AddSkill( Secondary( Secondary::LOGISTICS, ptr->initial_secondary.logistics ) );
             if ( ptr->initial_secondary.luck )
                 AddSkill( Secondary( Secondary::LUCK, ptr->initial_secondary.luck ) );
             if ( ptr->initial_secondary.mysticism )
                 AddSkill( Secondary( Secondary::MYSTICISM, ptr->initial_secondary.mysticism ) );
-            if ( ptr->initial_secondary.navigation )
-                AddSkill( Secondary( Secondary::NAVIGATION, ptr->initial_secondary.navigation ) );
-            if ( ptr->initial_secondary.necromancy )
-                AddSkill( Secondary( Secondary::NECROMANCY, ptr->initial_secondary.necromancy ) );
             if ( ptr->initial_secondary.pathfinding )
                 AddSkill( Secondary( Secondary::PATHFINDING, ptr->initial_secondary.pathfinding ) );
+            if ( ptr->initial_secondary.leadership )
+                AddSkill( Secondary( Secondary::LEADERSHIP, ptr->initial_secondary.leadership ) );
+            if ( ptr->initial_secondary.ballistics )
+                AddSkill( Secondary( Secondary::BALLISTICS, ptr->initial_secondary.ballistics ) );
+            if ( ptr->initial_secondary.navigation )
+                AddSkill( Secondary( Secondary::NAVIGATION, ptr->initial_secondary.navigation ) );
             if ( ptr->initial_secondary.scouting )
                 AddSkill( Secondary( Secondary::SCOUTING, ptr->initial_secondary.scouting ) );
             if ( ptr->initial_secondary.wisdom )
                 AddSkill( Secondary( Secondary::WISDOM, ptr->initial_secondary.wisdom ) );
+            if ( ptr->initial_secondary.necromancy )
+                AddSkill( Secondary( Secondary::NECROMANCY, ptr->initial_secondary.necromancy ) );
         }
     }
 }

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -606,10 +606,10 @@ Skill::SecSkills::SecSkills( int race )
                 AddSkill( Secondary( Secondary::NAVIGATION, ptr->initial_secondary.navigation ) );
             if ( ptr->initial_secondary.scouting )
                 AddSkill( Secondary( Secondary::SCOUTING, ptr->initial_secondary.scouting ) );
-            if ( ptr->initial_secondary.wisdom )
-                AddSkill( Secondary( Secondary::WISDOM, ptr->initial_secondary.wisdom ) );
             if ( ptr->initial_secondary.necromancy )
                 AddSkill( Secondary( Secondary::NECROMANCY, ptr->initial_secondary.necromancy ) );
+            if ( ptr->initial_secondary.wisdom )
+                AddSkill( Secondary( Secondary::WISDOM, ptr->initial_secondary.wisdom ) );
         }
     }
 }


### PR DESCRIPTION
The secondary skill order is similar to the OG order. Meaning:
- Knight: Leadership->Ballistics
- Sorc: Navigation->Wisdom
- Warlock: Scouting->Wisdom
- Necro: Necro->Wisdom (as per @LeHerosInconnu remark; to be consistent with the Editor but different than the OG)

Fixes #1677.