### PR TITLE
Fix an assertion call during battle shadow rendering

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1647,11 +1647,23 @@ void Battle::Interface::RedrawCover()
 
             if ( _currentUnit->GetTailIndex() != -1 ) {
                 int tailDirection = _currentUnit->isReflect() ? RIGHT : LEFT;
-                const Cell * tailAttackerCell = Board::GetCell( attackerCell->GetIndex(), tailDirection );
+                const Cell * tailAttackerCell = nullptr;
+
+                if ( Board::isValidDirection( attackerCell->GetIndex(), tailDirection ) ) {
+                    tailAttackerCell = Board::GetCell( attackerCell->GetIndex(), tailDirection );
+                    if ( tailAttackerCell != nullptr && ( tailAttackerCell->GetUnit() || !tailAttackerCell->isPassable1( false ) ) ) {
+                        tailAttackerCell = nullptr;
+                    }
+                }
                 if ( tailAttackerCell == nullptr ) {
                     // A monster doesn't move.
                     tailDirection = _currentUnit->isReflect() ? LEFT : RIGHT;
-                    tailAttackerCell = Board::GetCell( attackerCell->GetIndex(), tailDirection );
+                    if ( Board::isValidDirection( attackerCell->GetIndex(), tailDirection ) ) {
+                        tailAttackerCell = Board::GetCell( attackerCell->GetIndex(), tailDirection );
+                        if ( tailAttackerCell != nullptr && ( tailAttackerCell->GetUnit() || !tailAttackerCell->isPassable1( false ) ) ) {
+                            tailAttackerCell = nullptr;
+                        }
+                    }
                 }
                 assert( tailAttackerCell != nullptr );
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1643,31 +1643,23 @@ void Battle::Interface::RedrawCover()
 
             const Cell * attackerCell = Board::GetCell( cell->GetIndex(), direction );
             assert( attackerCell != nullptr );
-            highlightCells.emplace( attackerCell );
 
-            if ( _currentUnit->GetTailIndex() != -1 ) {
-                int tailDirection = _currentUnit->isReflect() ? RIGHT : LEFT;
-                const Cell * tailAttackerCell = nullptr;
+            Position attackerPos;
 
-                if ( Board::isValidDirection( attackerCell->GetIndex(), tailDirection ) ) {
-                    tailAttackerCell = Board::GetCell( attackerCell->GetIndex(), tailDirection );
-                    if ( tailAttackerCell != nullptr && ( tailAttackerCell->GetUnit() || !tailAttackerCell->isPassable1( false ) ) ) {
-                        tailAttackerCell = nullptr;
-                    }
-                }
-                if ( tailAttackerCell == nullptr ) {
-                    // A monster doesn't move.
-                    tailDirection = _currentUnit->isReflect() ? LEFT : RIGHT;
-                    if ( Board::isValidDirection( attackerCell->GetIndex(), tailDirection ) ) {
-                        tailAttackerCell = Board::GetCell( attackerCell->GetIndex(), tailDirection );
-                        if ( tailAttackerCell != nullptr && ( tailAttackerCell->GetUnit() || !tailAttackerCell->isPassable1( false ) ) ) {
-                            tailAttackerCell = nullptr;
-                        }
-                    }
-                }
-                assert( tailAttackerCell != nullptr );
+            if ( attackerCell->GetIndex() == _currentUnit->GetHeadIndex() ) {
+                // The attacking unit is already there and shouldn't move
+                attackerPos = _currentUnit->GetPosition();
+            }
+            else {
+                attackerPos = Position::GetCorrect( *_currentUnit, attackerCell->GetIndex() );
+            }
 
-                highlightCells.emplace( tailAttackerCell );
+            assert( attackerPos.GetHead() != nullptr );
+            highlightCells.emplace( attackerPos.GetHead() );
+
+            if ( _currentUnit->isWide() ) {
+                assert( attackerPos.GetTail() != nullptr );
+                highlightCells.emplace( attackerPos.GetTail() );
             }
         }
         else {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1646,8 +1646,13 @@ void Battle::Interface::RedrawCover()
             highlightCells.emplace( attackerCell );
 
             if ( _currentUnit->GetTailIndex() != -1 ) {
-                const int tailDirection = _currentUnit->isReflect() ? RIGHT : LEFT;
+                int tailDirection = _currentUnit->isReflect() ? RIGHT : LEFT;
                 const Cell * tailAttackerCell = Board::GetCell( attackerCell->GetIndex(), tailDirection );
+                if ( tailAttackerCell == nullptr ) {
+                    // A monster doesn't move.
+                    tailDirection = _currentUnit->isReflect() ? LEFT : RIGHT;
+                    tailAttackerCell = Board::GetCell( attackerCell->GetIndex(), tailDirection );
+                }
                 assert( tailAttackerCell != nullptr );
 
                 highlightCells.emplace( tailAttackerCell );


### PR DESCRIPTION
for wide monsters which are at the end of the battlefield

regression from #3911