### PR TITLE
Fix attacking after turning back in some cases

### DIFF
--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -193,18 +193,10 @@ void Battle::Board::SetScanPassability( const Unit & unit )
         }
     }
     else {
-        Indexes indexes = GetDistanceIndexes( unit.GetHeadIndex(), unit.GetSpeed() );
-        if ( unit.isWide() ) {
-            const Indexes & tailIndexes = GetDistanceIndexes( unit.GetTailIndex(), unit.GetSpeed() );
-            std::set<int32_t> filteredIndexed( indexes.begin(), indexes.end() );
-            filteredIndexed.insert( tailIndexes.begin(), tailIndexes.end() );
-            indexes = std::vector<int32_t>( filteredIndexed.begin(), filteredIndexed.end() );
-        }
-        indexes.erase( std::remove_if( indexes.begin(), indexes.end(), isImpassableIndex ), indexes.end() );
-
         // Set passable cells.
-        for ( Indexes::const_iterator it = indexes.begin(); it != indexes.end(); ++it )
-            GetPath( unit, Position::GetCorrect( unit, *it ), false );
+        for ( const int32_t idx : GetDistanceIndexes( unit.GetHeadIndex(), unit.GetSpeed() ) ) {
+            GetPath( unit, Position::GetCorrect( unit, idx ), false );
+        }
     }
 }
 

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -676,12 +676,6 @@ bool Battle::Board::isOutOfWallsIndex( s32 index )
              || ( 55 <= index && index <= 62 ) || ( 66 <= index && index <= 73 ) || ( 77 <= index && index <= 85 ) || ( 88 <= index && index <= 96 ) );
 }
 
-bool Battle::Board::isImpassableIndex( s32 index )
-{
-    const Cell * cell = Board::GetCell( index );
-    return !cell || !cell->isPassable1( true );
-}
-
 bool Battle::Board::isBridgeIndex( s32 index, const Unit & b )
 {
     const Bridge * bridge = Arena::GetBridge();

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -74,7 +74,6 @@ namespace Battle
         static bool isCastleIndex( s32 );
         static bool isMoatIndex( s32 index, const Unit & b );
         static bool isBridgeIndex( s32 index, const Unit & b );
-        static bool isImpassableIndex( s32 );
         static bool isOutOfWallsIndex( s32 );
         static bool isReflectDirection( int );
         static bool IsLeftDirection( const int32_t startCellId, const int32_t endCellId, const bool prevLeftDirection );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2619,17 +2619,21 @@ void Battle::Interface::MouseLeftClickBoardAction( u32 themes, const Cell & cell
 
     if ( _currentUnit ) {
         auto fixupTargetIndex = []( const Unit * unit, const int32_t dst ) {
-            if ( unit->isWide() ) {
-                Position pos = Position::GetCorrect( *unit, dst );
+            // only wide units may need this fixup
+            if ( !unit->isWide() ) {
+                return dst;
+            }
 
-                // destination cell is on the border of the cell space available to the unit
-                // and it should be the tail cell of the unit, return the head cell instead
-                if ( pos.GetTail()->GetDirection() == UNKNOWN ) {
-                    int headDirection = unit->isReflect() ? LEFT : RIGHT;
+            const Position pos = Position::GetCorrect( *unit, dst );
+            assert( pos.GetTail() != nullptr );
 
-                    if ( Board::isValidDirection( dst, headDirection ) ) {
-                        return Board::GetIndexDirection( dst, headDirection );
-                    }
+            // destination cell is on the border of the cell space available to the unit
+            // and it should be the tail cell of the unit, return the head cell instead
+            if ( pos.GetTail()->GetDirection() == UNKNOWN ) {
+                const int headDirection = unit->isReflect() ? LEFT : RIGHT;
+
+                if ( Board::isValidDirection( dst, headDirection ) ) {
+                    return Board::GetIndexDirection( dst, headDirection );
                 }
             }
 


### PR DESCRIPTION
Found when testing the #3931. In the following situation:

<img width="638" alt="Wide units attack fail" src="https://user-images.githubusercontent.com/32623900/127743047-aa38d5a2-5d17-4a45-8580-54770285bb98.png">

neither of these two wide units will attack each other, they just will do one step forward instead (the same is observed when AI controls them during auto battle). This PR is intended to fix this.