### PR TITLE
Remove sortTiles flag from Maps::GetAroundIndexes

### DIFF
--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -328,7 +328,7 @@ Maps::Indexes Maps::GetAroundIndexes( int32_t center )
     return result;
 }
 
-Maps::Indexes Maps::GetAroundIndexes( const int32_t tileIndex, const int32_t maxDistanceFromTile, bool sortTiles )
+Maps::Indexes Maps::getAroundIndexes( const int32_t tileIndex, const int32_t maxDistanceFromTile )
 {
     Indexes results;
     results.reserve( maxDistanceFromTile * 12 );
@@ -344,10 +344,6 @@ Maps::Indexes Maps::GetAroundIndexes( const int32_t tileIndex, const int32_t max
                 results.push_back( tileId );
             }
         }
-    }
-
-    if ( sortTiles ) {
-        std::sort( results.begin(), results.end(), ComparisonDistance( tileIndex ) );
     }
 
     return results;
@@ -411,7 +407,8 @@ Maps::Indexes Maps::ScanAroundObject( const int32_t center, const int obj )
 
 Maps::Indexes Maps::ScanAroundObjectWithDistance( const int32_t center, const uint32_t dist, const int obj )
 {
-    Indexes results = Maps::GetAroundIndexes( center, dist, true );
+    Indexes results = Maps::getAroundIndexes( center, dist );
+    std::sort( results.begin(), results.end(), ComparisonDistance( center ) );
     return MapsIndexesFilteredObject( results, obj );
 }
 

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -62,7 +62,7 @@ namespace Maps
     int32_t GetIndexFromAbsPoint( const int32_t x, const int32_t y );
 
     Indexes GetAroundIndexes( s32 );
-    Indexes GetAroundIndexes( const int32_t tileIndex, const int32_t maxDistanceFromTile, bool sortTiles = false ); // sorting distance
+    Indexes getAroundIndexes( const int32_t tileIndex, const int32_t maxDistanceFromTile );
 
     Indexes ScanAroundObject( const int32_t center, const int obj );
     Indexes ScanAroundObjectWithDistance( const int32_t center, const uint32_t dist, const int obj );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2441,7 +2441,7 @@ void Maps::Tiles::setAsEmpty()
 
     bool isCoast = false;
 
-    const Indexes tileIndices = Maps::GetAroundIndexes( _index, 1 );
+    const Indexes tileIndices = Maps::getAroundIndexes( _index, 1 );
     for ( const int tileIndex : tileIndices ) {
         if ( tileIndex < 0 ) {
             // Invalid tile index.

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -47,7 +47,7 @@ namespace
 {
     bool isTileBlockedForSettingMonster( const MapsTiles & mapTiles, const int32_t tileId, const int32_t radius, const std::set<int32_t> & excludeTiles )
     {
-        const MapsIndexes & indexes = Maps::GetAroundIndexes( tileId, radius, false );
+        const MapsIndexes & indexes = Maps::getAroundIndexes( tileId, radius );
         for ( const int32_t indexId : indexes ) {
             if ( excludeTiles.count( indexId ) > 0 ) {
                 return true;


### PR DESCRIPTION
Inline sort by distance in only caller.