### PR TITLE
Fix incorrect icons for scenario information dialog

### DIFF
--- a/src/fheroes2/gui/player_info.cpp
+++ b/src/fheroes2/gui/player_info.cpp
@@ -183,28 +183,19 @@ void Interface::PlayersInfo::RedrawInfo( bool show_play_info ) const /* show_pla
 
         // 1. redraw opponents
 
-        // current human
-        if ( humans_colors & player.GetColor() )
+        if ( humans_colors & player.GetColor() ) {
+            // Current human.
             index = 9 + Color::GetIndex( player.GetColor() );
-        else
-            // comp only
-            if ( fi.ComputerOnlyColors() & player.GetColor() ) {
-            if ( show_play_info ) {
-                index = ( player.isPlay() ? 3 : 15 ) + Color::GetIndex( player.GetColor() );
-            }
-            else
-                index = 15 + Color::GetIndex( player.GetColor() );
         }
-        else
-        // comp/human
-        {
-            if ( show_play_info ) {
-                index = ( player.isPlay() ? 3 : 15 ) + Color::GetIndex( player.GetColor() );
-            }
-            else
-                index = 3 + Color::GetIndex( player.GetColor() );
+        else if ( fi.ComputerOnlyColors() & player.GetColor() ) {
+            // Computer only.
+            index = 15 + Color::GetIndex( player.GetColor() );
         }
-
+        else {
+            // Computer or human.
+            index = 3 + Color::GetIndex( player.GetColor() );
+        }
+            
         // wide sprite offset
         if ( show_name )
             index += 24;

--- a/src/fheroes2/gui/player_info.cpp
+++ b/src/fheroes2/gui/player_info.cpp
@@ -195,7 +195,7 @@ void Interface::PlayersInfo::RedrawInfo( bool show_play_info ) const /* show_pla
             // Computer or human.
             index = 3 + Color::GetIndex( player.GetColor() );
         }
-            
+
         // wide sprite offset
         if ( show_name )
             index += 24;


### PR DESCRIPTION
I fixed a bug in the game info window that incorrectly displayed the player icon for computer-only players. For more details, please read my comment in the #3475. It fixes #3475. 
This is a continuation of [the following pull request](https://github.com/ihhub/fheroes2/pull/3912).

Below some screens from my tests:
Before:
![01_before](https://user-images.githubusercontent.com/85434237/127751804-3167a0b6-68ec-43ef-a3b0-024fbc17e9d6.png)
After:
![01_after](https://user-images.githubusercontent.com/85434237/127751803-4570de5c-b244-4672-b2f1-3a2dbd3125a5.png)


Before:
![02 1 game info before](https://user-images.githubusercontent.com/85434237/127751818-66ff171a-e4b5-44a2-9f2c-94a6c96f273f.PNG)
![02 1 yellow vanqiushed](https://user-images.githubusercontent.com/85434237/127751821-e9588184-3910-4865-9662-0daaf6d08448.PNG)
After:
![02 1 game info after](https://user-images.githubusercontent.com/85434237/127751822-f8b5009a-3151-4b07-9577-5a2c40f96a25.PNG)
