### PR TITLE
Provide issue templates for the most common issue types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,9 +7,9 @@ body:
   attributes:
     label: Preliminary checks
     options:
-    - label: I have checked that there aren't [**other open issues**](https://github.com/ihhub/fheroes2/issues?q=is%3Aissue) on the same topic
+    - label: I've checked that there aren't [**other open issues**](https://github.com/ihhub/fheroes2/issues?q=is%3Aissue) on the same topic.
       required: true
-    - label: I have checked that this issue is reproducible on the [**latest snapshot build**](https://ihhub.github.io/fheroes2/INSTALL.html#snapshots-latest-builds)
+    - label: I've checked that this issue is reproducible on the [**latest snapshot build**](https://ihhub.github.io/fheroes2/INSTALL.html#snapshots-latest-builds).
       required: true
 - type: dropdown
   attributes:
@@ -24,38 +24,16 @@ body:
     - Other
   validations:
     required: true
-- type: input
-  attributes:
-    label: Additional platform info
-    placeholder: Describe your platform if you chose "Other" in the previous section.
 - type: textarea
   attributes:
     label: Describe the bug
-    placeholder: Provide a clear and concise description of what the bug is.
-  validations:
-    required: true
-- type: textarea
-  attributes:
-    label: Steps to reproduce
-    placeholder: |
-      Steps to reproduce the bug:
-      1. Go to ...
-      2. Click on ...
-      3. See error ...
-  validations:
-    required: true
-- type: textarea
-  attributes:
-    label: Expected behavior
-    placeholder: Provide a clear and concise description of what you expected to happen.
-  validations:
-    required: true
-- type: textarea
-  attributes:
-    label: Screenshots
     placeholder: >
-      If possible, provide screenshots to illustrate the issue.
-      You can add them by dragging and dropping the image file to this section.
+      Provide a clear and concise description of what the bug is, including
+      the list of steps to reproduce the bug. If possible, provide screenshots
+      to illustrate the issue. You can add screenshots by dragging and dropping
+      the image file to this section.
+  validations:
+    required: true
 - type: textarea
   attributes:
     label: Save file
@@ -63,7 +41,12 @@ body:
       If possible, provide a save file to make it easier for developers to
       reproduce the issue. You can add it by placing your save file into a
       ZIP archive and then dragging and dropping the resulting archive file
-      into this section.
+      into this section. If you do not want to provide a save file (for example,
+      because it is not required to reproduce the issue or is not available),
+      please indicate here the reason why the save file cannot be attached to
+      this bug report.
+  validations:
+    required: true
 - type: textarea
   attributes:
     label: Additional info

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: Something is not working or is going wrong
+labels: [ bug ]
+
+body:
+- type: dropdown
+  attributes:
+    label: Platform
+    description: Choose your platform
+    options:
+    - Windows
+    - macOS
+    - Linux
+    - Other
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Additional platform info
+    placeholder: Describe your platform if you chose "Other" in the previous section.
+- type: textarea
+  attributes:
+    label: Describe the bug
+    placeholder: Provide a clear and concise description of what the bug is.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Steps to reproduce
+    placeholder: |
+      Steps to reproduce the bug:
+      1. Go to ...
+      2. Click on ...
+      3. See error ...
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected behavior
+    placeholder: Provide a clear and concise description of what you expected to happen.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Screenshots
+    placeholder: >
+      If possible, provide screenshots to illustrate the issue.
+      You can add them by dragging and dropping the image file to this section.
+- type: textarea
+  attributes:
+    label: Save file
+    placeholder: >
+      If possible, provide a save file to make it easier for developers to
+      reproduce the issue. You can add it by placing your save file into a
+      ZIP archive and then dragging and dropping the resulting archive file
+      into this section.
+- type: textarea
+  attributes:
+    label: Additional info
+    placeholder: Submit any additional info (game console output, crash logs, etc) in this section.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,12 @@ description: Something is not working or is going wrong
 labels: [ bug ]
 
 body:
+- type: checkboxes
+  attributes:
+    label: Check for duplicates
+    options:
+    - label: I checked that there aren't other open issues on the same topic
+      required: true
 - type: dropdown
   attributes:
     label: Platform

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,9 +5,11 @@ labels: [ bug ]
 body:
 - type: checkboxes
   attributes:
-    label: Check for duplicates
+    label: Preliminary checks
     options:
-    - label: I checked that there aren't other open issues on the same topic
+    - label: I have checked that there aren't [**other open issues**](https://github.com/ihhub/fheroes2/issues?q=is%3Aissue) on the same topic
+      required: true
+    - label: I have checked that this issue is reproducible on the [**latest snapshot build**](https://ihhub.github.io/fheroes2/INSTALL.html#snapshots-latest-builds)
       required: true
 - type: dropdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,6 +17,8 @@ body:
     - Windows
     - macOS
     - Linux
+    - PlayStation Vita
+    - Nintendo Switch
     - Other
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,9 +5,9 @@ labels: [ improvement ]
 body:
 - type: checkboxes
   attributes:
-    label: Check for duplicates
+    label: Preliminary checks
     options:
-    - label: I checked that there aren't other open issues on the same topic
+    - label: I have checked that there aren't [**other open issues**](https://github.com/ihhub/fheroes2/issues?q=is%3Aissue) on the same topic
       required: true
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,6 +3,18 @@ description: New feature, request or improvement
 labels: [ improvement ]
 
 body:
+- type: markdown
+  attributes:
+    value: >
+      ## Please note
+
+      The current project improvement policy is mainly focused on making
+      the gameplay more user-friendly and easier to interact with, while
+      keeping the spirit of the original game intact. Make sure the feature
+      you are about to request will be the most useful for the majority of
+      users. We do not accept feature requests related to the overall game
+      balance (such as creating new monsters or castles) or various
+      "improvements" to the appearance of existing game monsters or objects.
 - type: checkboxes
   attributes:
     label: Preliminary checks

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature request
+description: New feature, request or improvement
+labels: [ improvement ]
+
+body:
+- type: textarea
+  attributes:
+    label: Describe the problem requiring a solution
+    placeholder: >
+      Provide a clear and concise description of what the problem is.
+      For example: "I'm always frustrated when ...".
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Describe the possible solution
+    placeholder: Provide a clear and concise description of what you want to happen.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Screenshots
+    placeholder: >
+      If possible, provide screenshots to illustrate the topic.
+      You can add them by dragging and dropping the image file to this section.
+- type: textarea
+  attributes:
+    label: Additional info
+    placeholder: Submit any additional info (game console output, crash logs, etc) in this section.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,6 +3,12 @@ description: New feature, request or improvement
 labels: [ improvement ]
 
 body:
+- type: checkboxes
+  attributes:
+    label: Check for duplicates
+    options:
+    - label: I checked that there aren't other open issues on the same topic
+      required: true
 - type: textarea
   attributes:
     label: Describe the problem requiring a solution

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,14 +7,16 @@ body:
   attributes:
     label: Preliminary checks
     options:
-    - label: I have checked that there aren't [**other open issues**](https://github.com/ihhub/fheroes2/issues?q=is%3Aissue) on the same topic
+    - label: I've checked that there aren't [**other open issues**](https://github.com/ihhub/fheroes2/issues?q=is%3Aissue) on the same topic.
       required: true
 - type: textarea
   attributes:
     label: Describe the problem requiring a solution
     placeholder: >
       Provide a clear and concise description of what the problem is.
-      For example: "I'm always frustrated when ...".
+      For example: "I'm always frustrated when ...". If possible, provide
+      screenshots to illustrate the topic. You can add them by dragging
+      and dropping the image file to this section.
   validations:
     required: true
 - type: textarea
@@ -23,12 +25,6 @@ body:
     placeholder: Provide a clear and concise description of what you want to happen.
   validations:
     required: true
-- type: textarea
-  attributes:
-    label: Screenshots
-    placeholder: >
-      If possible, provide screenshots to illustrate the topic.
-      You can add them by dragging and dropping the image file to this section.
 - type: textarea
   attributes:
     label: Additional info

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,21 @@
+name: Question
+description: Ask a general question
+labels: [ question ]
+
+body:
+- type: textarea
+  attributes:
+    label: Your question
+    placeholder: Ask your question here.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Screenshots
+    placeholder: >
+      If possible, provide screenshots to illustrate the topic.
+      You can add them by dragging and dropping the image file to this section.
+- type: textarea
+  attributes:
+    label: Additional info
+    placeholder: Submit any additional info (game console output, crash logs, etc) in this section.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -6,15 +6,12 @@ body:
 - type: textarea
   attributes:
     label: Your question
-    placeholder: Ask your question here.
+    placeholder: >
+      Ask your question here. If possible, provide screenshots to
+      illustrate the topic. You can add them by dragging and dropping
+      the image file to this section.
   validations:
     required: true
-- type: textarea
-  attributes:
-    label: Screenshots
-    placeholder: >
-      If possible, provide screenshots to illustrate the topic.
-      You can add them by dragging and dropping the image file to this section.
 - type: textarea
   attributes:
     label: Additional info


### PR DESCRIPTION
People often forget to attach a screenshot or a save file. You can test these templates in my repo:

https://github.com/oleg-derevenetz/fheroes2/issues

Just click on the "New issue" button.