### PR TITLE
Add links to README_switch.md in INSTALL.md and DEVELOPMENT.md, rename "PS Vita" to "PlayStation Vita"

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -18,9 +18,13 @@ Please follow the instructions below to be able to build the project from source
 * Go to the directory `script/demo` and run the file `demo_unix.sh`. This script will download a demo version of the original game, which is the minimum required for development.
 * Run the `make` command in the root directory of the project to build it with **SDL2** or `make FHEROES2_SDL1="ON"` to build it with **SDL1**.
 
-### PS Vita
+### PlayStation Vita
 
-If you would like to build and run this project on PS Vita please follow the instructions on [**this page**](README_PSV.md).
+If you would like to build and run this project on PlayStation Vita please follow the instructions on [**this page**](README_PSV.md).
+
+### Nintendo Switch
+
+If you would like to build and run this project on Nintendo Switch please follow the instructions on [**this page**](README_switch.md).
 
 ### Build with CMake
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -17,6 +17,8 @@ Precompiled binaries of the release version are currently available for the foll
 * [**Linux**](#linux)
   * [**AUR package**](#aur-package)
   * [**Linux ZIP archive**](#linux-zip-archive)
+* [**PlayStation Vita**](README_PSV.md)
+* [**Nintendo Switch**](README_switch.md)
 
 Alternatively, you can download the precompiled binaries of the latest commit (snapshot) [**here**](#snapshots-latest-builds).
 
@@ -149,6 +151,6 @@ You can download the precompiled binaries of the latest commit (snapshot) for
 [**SDL2**](https://github.com/ihhub/fheroes2/releases/tag/fheroes2-linux-sdl2_dev) and
 [**SDL1**](https://github.com/ihhub/fheroes2/releases/tag/fheroes2-linux-sdl1_dev)
 ),
-[**PS Vita**](https://github.com/ihhub/fheroes2/releases/tag/fheroes2-psv-sdl2_dev) and
+[**PlayStation Vita**](https://github.com/ihhub/fheroes2/releases/tag/fheroes2-psv-sdl2_dev) and
 [**Nintendo Switch**](https://github.com/ihhub/fheroes2/releases/tag/fheroes2-switch-sdl2_dev).
 **These binaries incorporate all the latest changes, but also all the latest bugs, and are mainly intended for developers. DON'T EXPECT THEM TO WORK PROPERLY.**


### PR DESCRIPTION
As usual, you can see how it looks like in the website mode here:

https://oleg-derevenetz.github.io/fheroes2/

Also I added links to PSV and Switch-specific READMEs to INSTALL.md (they still contain useful data about which data should be copied to where, although this does not apply to devices with official firmware), if it is better not to do this, I can remove them.