### PR TITLE
Clang-Tidy: disable cppcoreguidelines-pro-bounds-array-to-pointer-decay

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: >-
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-init-variables,
   -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-constant-array-index,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
   -cppcoreguidelines-pro-type-union-access,


### PR DESCRIPTION
Reason: `char *` is widely used in this project to represent null-terminated strings, and `char[]` literals are often passed as arguments to functions that accept `char *`. At the same time we are not going to use GSL yet, so `gsl::span` is not available anyway, and neither `std::span` (from C++20) nor `std::string_view` (from C++17) are available.