### PR TITLE
Clang-Tidy: disable cppcoreguidelines-avoid-non-const-global-variables

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@ Checks: >-
   bugprone-*,
   cppcoreguidelines-*,
   -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-avoid-non-const-global-variables,
   -cppcoreguidelines-init-variables,
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,


### PR DESCRIPTION
Reason: namespace-scope and module-scope variables are routinely used in this project.