### PR TITLE
A not visited obelisk remains not visited after the UA has been found.

### DIFF
--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -363,16 +363,6 @@ fheroes2::GameMode Interface::Basic::EventDigArtifact()
                     std::string msg( _( "After spending many hours digging here, you have uncovered the %{artifact}." ) );
                     StringReplace( msg, "%{artifact}", ultimate.GetName() );
                     Dialog::ArtifactInfo( _( "Congratulations!" ), msg, ultimate.GetID() );
-
-                    // set all obelisks visited
-                    Kingdom & kingdom = world.GetKingdom( hero->GetColor() );
-                    const MapsIndexes obelisks = Maps::GetObjectPositions( MP2::OBJ_OBELISK, false );
-
-                    for ( MapsIndexes::const_iterator it = obelisks.begin(); it != obelisks.end(); ++it )
-                        if ( !hero->isVisited( world.GetTiles( *it ), Visit::GLOBAL ) )
-                            hero->SetVisited( *it, Visit::GLOBAL );
-
-                    kingdom.PuzzleMaps().Update( kingdom.CountVisitedObjects( MP2::OBJ_OBELISK ), world.CountObeliskOnMaps() );
                 }
                 else
                     Dialog::Message( "", _( "Nothing here. Where could it be?" ), Font::BIG, Dialog::OK );


### PR DESCRIPTION
A "not visited" obelisk remains "not visited" after the Ultimate Artifact has been found. Fixes #438.

In this PR, I am fixing a bug when all obelisks become visited when the Ultimate Artifact is found (even if a player never visited any obelisk). For future enhancements, pls visit #438 or create a new issue.