### PR TITLE
Deduplicate settings code

### DIFF
--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -313,7 +313,7 @@ namespace
 
             // set scroll speed
             if ( le.MouseClickLeft( scrollSpeedRoi ) ) {
-                conf.SetScrollSpeed( SCROLL_FAST2 > conf.ScrollSpeed() ? conf.ScrollSpeed() << 1 : SCROLL_SLOW );
+                conf.SetScrollSpeed( SCROLL_FAST2 > conf.ScrollSpeed() ? conf.ScrollSpeed() + 1 : SCROLL_SLOW );
                 redraw = true;
                 saveConfig = true;
             }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -511,7 +511,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
 
 void Interface::GameArea::Scroll( void )
 {
-    const int32_t shift = Settings::Get().ScrollShift();
+    const int32_t shift = 2 << Settings::Get().ScrollSpeed();
     fheroes2::Point offset;
 
     if ( scrollDirection & SCROLL_LEFT ) {

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -511,21 +511,21 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
 
 void Interface::GameArea::Scroll( void )
 {
-    const int32_t speed = Settings::Get().ScrollSpeed();
+    const int32_t shift = Settings::Get().ScrollShift();
     fheroes2::Point offset;
 
     if ( scrollDirection & SCROLL_LEFT ) {
-        offset.x = -speed;
+        offset.x = -shift;
     }
     else if ( scrollDirection & SCROLL_RIGHT ) {
-        offset.x = speed;
+        offset.x = shift;
     }
 
     if ( scrollDirection & SCROLL_TOP ) {
-        offset.y = -speed;
+        offset.y = -shift;
     }
     else if ( scrollDirection & SCROLL_BOTTOM ) {
-        offset.y = speed;
+        offset.y = shift;
     }
 
     ShiftCenter( offset );

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -750,11 +750,6 @@ int Settings::ScrollSpeed() const
     return scroll_speed;
 }
 
-int Settings::ScrollShift() const
-{
-    return 2 << scroll_speed;
-}
-
 /* set ai speed: 1 - 10 */
 void Settings::SetAIMoveSpeed( int speed )
 {

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -122,7 +122,6 @@ public:
     int AIMoveSpeed() const;
     int BattleSpeed() const;
     int ScrollSpeed() const;
-    int ScrollShift() const;
 
     int GameDifficulty() const;
 

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -30,10 +30,10 @@
 
 enum
 {
-    SCROLL_SLOW = 4,
-    SCROLL_NORMAL = 8,
-    SCROLL_FAST1 = 16,
-    SCROLL_FAST2 = 32
+    SCROLL_SLOW = 1,
+    SCROLL_NORMAL = 2,
+    SCROLL_FAST1 = 3,
+    SCROLL_FAST2 = 4
 };
 
 enum MusicSource
@@ -122,6 +122,7 @@ public:
     int AIMoveSpeed() const;
     int BattleSpeed() const;
     int ScrollSpeed() const;
+    int ScrollShift() const;
 
     int GameDifficulty() const;
 


### PR DESCRIPTION
Use setters in `Settings::Read` in instead of copypaste.
Change scroll speed enum values to simplify read/write.
Use `clamp` and `min` instead of manual comparisons.
Also fix `battle_speed` initial value.