### PR TITLE
Battle pathfinding: store passability info separately for the head and tail of wide units, improve AI pathfinding a bit

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -168,7 +168,7 @@ namespace AI
         assert( targetCell != nullptr );
 
         // Target cell is already reachable
-        if ( targetCell->GetHeadDirection() != UNKNOWN ) {
+        if ( targetCell->isReachableForHead() ) {
             return Board::FixupTargetCellForUnit( currentUnit, target );
         }
 
@@ -177,7 +177,7 @@ namespace AI
 
         // Search for the nearest reachable cell
         for ( const Cell & cell : *Arena::GetBoard() ) {
-            if ( cell.GetHeadDirection() != UNKNOWN ) {
+            if ( cell.isReachableForHead() ) {
                 const uint32_t distance = Board::GetDistance( target, cell.GetIndex() );
 
                 if ( distance < nearestDistance ) {
@@ -202,7 +202,7 @@ namespace AI
             if ( Board::isValidDirection( from, tailDirection ) ) {
                 const Cell * tailCell = Board::GetCell( Board::GetIndexDirection( from, tailDirection ) );
 
-                if ( tailCell != nullptr && tailCell->GetTailDirection() != UNKNOWN && ( tailCell->GetUnit() == nullptr || tailCell->GetUnit() == &attacker ) ) {
+                if ( tailCell != nullptr && tailCell->isReachableForTail() && ( tailCell->GetUnit() == nullptr || tailCell->GetUnit() == &attacker ) ) {
                     headIndex = from;
                     tailIndex = tailCell->GetIndex();
                 }
@@ -215,7 +215,7 @@ namespace AI
                 if ( Board::isValidDirection( from, headDirection ) ) {
                     const Cell * headCell = Board::GetCell( Board::GetIndexDirection( from, headDirection ) );
 
-                    if ( headCell != nullptr && headCell->GetHeadDirection() != UNKNOWN && ( headCell->GetUnit() == nullptr || headCell->GetUnit() == &attacker ) ) {
+                    if ( headCell != nullptr && headCell->isReachableForHead() && ( headCell->GetUnit() == nullptr || headCell->GetUnit() == &attacker ) ) {
                         headIndex = headCell->GetIndex();
                         tailIndex = from;
                     }

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -227,7 +227,7 @@ namespace AI
         }
 
         // Check that the attacker is actually capable of attacking the target from this position
-        std::array<int32_t, 2> indexes = { headIndex, tailIndex };
+        const std::array<int32_t, 2> indexes = { headIndex, tailIndex };
 
         for ( const int32_t idx : indexes ) {
             if ( idx == -1 ) {

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -34,6 +34,7 @@
 #include "settings.h"
 #include "speed.h"
 
+#include <array>
 #include <cassert>
 #include <cmath>
 #include <cstdint>
@@ -167,8 +168,8 @@ namespace AI
         assert( targetCell != nullptr );
 
         // Target cell is already reachable
-        if ( targetCell->isPassable3( currentUnit, false ) && targetCell->GetDirection() != UNKNOWN ) {
-            return target;
+        if ( targetCell->GetHeadDirection() != UNKNOWN ) {
+            return Board::FixupTargetCellForUnit( currentUnit, target );
         }
 
         int32_t nearest = -1;
@@ -176,7 +177,7 @@ namespace AI
 
         // Search for the nearest reachable cell
         for ( const Cell & cell : *Arena::GetBoard() ) {
-            if ( cell.isPassable3( currentUnit, false ) && cell.GetDirection() != UNKNOWN ) {
+            if ( cell.GetHeadDirection() != UNKNOWN ) {
                 const uint32_t distance = Board::GetDistance( target, cell.GetIndex() );
 
                 if ( distance < nearestDistance ) {
@@ -186,7 +187,64 @@ namespace AI
             }
         }
 
-        return nearest;
+        return Board::FixupTargetCellForUnit( currentUnit, nearest );
+    }
+
+    bool CanAttackUnitFromCell( const Unit & attacker, const Unit * target, const int32_t from )
+    {
+        int32_t headIndex = -1;
+        int32_t tailIndex = -1;
+
+        // Get the actual position of the attacker before attacking
+        if ( attacker.isWide() ) {
+            const int tailDirection = attacker.isReflect() ? RIGHT : LEFT;
+
+            if ( Board::isValidDirection( from, tailDirection ) ) {
+                const Cell * tailCell = Board::GetCell( Board::GetIndexDirection( from, tailDirection ) );
+
+                if ( tailCell != nullptr && tailCell->GetTailDirection() != UNKNOWN && ( tailCell->GetUnit() == nullptr || tailCell->GetUnit() == &attacker ) ) {
+                    headIndex = from;
+                    tailIndex = tailCell->GetIndex();
+                }
+            }
+
+            if ( headIndex == -1 || tailIndex == -1 ) {
+                // Try opposite direction
+                const int headDirection = attacker.isReflect() ? LEFT : RIGHT;
+
+                if ( Board::isValidDirection( from, headDirection ) ) {
+                    const Cell * headCell = Board::GetCell( Board::GetIndexDirection( from, headDirection ) );
+
+                    if ( headCell != nullptr && headCell->GetHeadDirection() != UNKNOWN && ( headCell->GetUnit() == nullptr || headCell->GetUnit() == &attacker ) ) {
+                        headIndex = headCell->GetIndex();
+                        tailIndex = from;
+                    }
+                }
+            }
+        }
+        else {
+            headIndex = from;
+        }
+
+        // Check that the attacker is actually capable of attacking the target from this position
+        std::array<int32_t, 2> indexes = { headIndex, tailIndex };
+
+        for ( const int32_t idx : indexes ) {
+            if ( idx == -1 ) {
+                continue;
+            }
+
+            for ( const int32_t aroundIdx : Board::GetAroundIndexes( idx ) ) {
+                const Cell * cell = Board::GetCell( aroundIdx );
+                assert( cell != nullptr );
+
+                if ( cell->GetUnit() == target ) {
+                    return Board::CanAttackUnitFromCell( attacker, idx );
+                }
+            }
+        }
+
+        return false;
     }
 
     void Normal::HeroesPreBattle( HeroBase & hero, bool isAttacking )
@@ -291,10 +349,10 @@ namespace AI
                 if ( currentUnit.GetHeadIndex() != reachableCell )
                     actions.emplace_back( MSG_BATTLE_MOVE, currentUnit.GetUID(), reachableCell );
 
-                // Attack only if target unit is reachable and can be attacked from the target cell
-                if ( target.unit && target.cell == reachableCell && Board::CanAttackUnitFromCell( currentUnit, target.cell ) ) {
+                // Attack only if target unit is reachable and can be attacked
+                if ( target.unit && CanAttackUnitFromCell( currentUnit, target.unit, reachableCell ) ) {
                     actions.emplace_back( MSG_BATTLE_ATTACK, currentUnit.GetUID(), target.unit->GetUID(),
-                                          Board::OptimalAttackTarget( currentUnit, *target.unit, target.cell ), 0 );
+                                          Board::OptimalAttackTarget( currentUnit, *target.unit, reachableCell ), 0 );
                     DEBUG_LOG( DBG_BATTLE, DBG_INFO,
                                currentUnit.GetName() << " melee offense, focus enemy " << target.unit->GetName()
                                                      << " threat level: " << target.unit->GetScoreQuality( currentUnit ) );
@@ -478,7 +536,7 @@ namespace AI
                     const int32_t reachableCell = FindNearestReachableCell( target.cell, currentUnit );
 
                     actions.emplace_back( MSG_BATTLE_MOVE, currentUnit.GetUID(), reachableCell );
-                    DEBUG_LOG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " archer kiting enemy, moving to " << target.cell );
+                    DEBUG_LOG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " archer kiting enemy, moving to " << reachableCell );
                 }
             }
             // Worst case scenario - Skip turn
@@ -727,8 +785,8 @@ namespace AI
                         if ( currentUnit.GetHeadIndex() != reachableCell )
                             actions.emplace_back( MSG_BATTLE_MOVE, currentUnitUID, reachableCell );
 
-                        // Attack only if target unit is reachable and can be attacked from the target cell
-                        if ( targetCell == reachableCell && Board::CanAttackUnitFromCell( currentUnit, targetCell ) )
+                        // Attack only if target unit is reachable and can be attacked
+                        if ( CanAttackUnitFromCell( currentUnit, targetUnit, reachableCell ) )
                             actions.emplace_back( MSG_BATTLE_ATTACK, currentUnitUID, targetUnitUID, targetUnitHead, 0 );
 
                         break;

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -93,7 +93,7 @@ void Battle::Board::Reset( void )
         if ( unit && !unit->isValid() ) {
             unit->PostKilledAction();
         }
-        it->ResetReachability();
+        it->resetReachability();
         it->ResetQuality();
     }
 }
@@ -180,12 +180,12 @@ uint32_t Battle::Board::GetDistance( s32 index1, s32 index2 )
 
 void Battle::Board::SetScanPassability( const Unit & unit )
 {
-    std::for_each( begin(), end(), []( Battle::Cell & cell ) { cell.ResetReachability(); } );
+    std::for_each( begin(), end(), []( Battle::Cell & cell ) { cell.resetReachability(); } );
 
-    at( unit.GetHeadIndex() ).SetReachableForHead();
+    at( unit.GetHeadIndex() ).setReachableForHead();
 
     if ( unit.isWide() ) {
-        at( unit.GetTailIndex() ).SetReachableForTail();
+        at( unit.GetTailIndex() ).setReachableForTail();
     }
 
     if ( unit.isFlying() ) {
@@ -194,10 +194,10 @@ void Battle::Board::SetScanPassability( const Unit & unit )
 
         for ( std::size_t i = 0; i < size(); i++ ) {
             if ( at( i ).isPassable3( unit, false ) && ( isPassableBridge || !isBridgeIndex( static_cast<int32_t>( i ), unit ) ) ) {
-                at( i ).SetReachableForHead();
+                at( i ).setReachableForHead();
 
                 if ( unit.isWide() ) {
-                    at( i ).SetReachableForTail();
+                    at( i ).setReachableForTail();
                 }
             }
         }
@@ -436,7 +436,7 @@ Battle::Indexes Battle::Board::GetPath( const Unit & unit, const Position & dest
             Cell * headCell = GetCell( cellId );
             assert( headCell != nullptr );
 
-            headCell->SetReachableForHead();
+            headCell->setReachableForHead();
 
             if ( isWideUnit ) {
                 const int32_t prevCellId = i == 0 ? unit.GetHeadIndex() : result[i - 1];
@@ -444,7 +444,7 @@ Battle::Indexes Battle::Board::GetPath( const Unit & unit, const Position & dest
                 Cell * tailCell = GetCell( cellId, LEFT_SIDE & GetDirection( cellId, prevCellId ) ? LEFT : RIGHT );
                 assert( tailCell != nullptr );
 
-                tailCell->SetReachableForTail();
+                tailCell->setReachableForTail();
             }
         }
     }

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -99,6 +99,10 @@ namespace Battle
 
         static Indexes GetAdjacentEnemies( const Unit & unit );
 
+        // Handles the situation when the destination cell is on the border of the cell
+        // space reachable for the unit and it should be the tail cell of this unit
+        static int32_t FixupTargetCellForUnit( const Unit & unit, const int32_t dst );
+
         enum
         {
             CATAPULT_POS = 77,

--- a/src/fheroes2/battle/battle_cell.cpp
+++ b/src/fheroes2/battle/battle_cell.cpp
@@ -191,12 +191,12 @@ void Battle::Cell::SetObject( int val )
     object = val;
 }
 
-void Battle::Cell::SetReachableForHead()
+void Battle::Cell::setReachableForHead()
 {
     _reachableForHead = true;
 }
 
-void Battle::Cell::SetReachableForTail()
+void Battle::Cell::setReachableForTail()
 {
     _reachableForTail = true;
 }
@@ -300,7 +300,7 @@ void Battle::Cell::ResetQuality( void )
     quality = 0;
 }
 
-void Battle::Cell::ResetReachability()
+void Battle::Cell::resetReachability()
 {
     _reachableForHead = false;
     _reachableForTail = false;

--- a/src/fheroes2/battle/battle_cell.cpp
+++ b/src/fheroes2/battle/battle_cell.cpp
@@ -123,8 +123,8 @@ bool Battle::Position::contains( int cellIndex ) const
 Battle::Cell::Cell( int32_t ii )
     : index( ii )
     , object( 0 )
-    , _headDirection( UNKNOWN )
-    , _tailDirection( UNKNOWN )
+    , _reachableForHead( false )
+    , _reachableForTail( false )
     , quality( 0 )
     , troop( nullptr )
 {
@@ -191,14 +191,14 @@ void Battle::Cell::SetObject( int val )
     object = val;
 }
 
-void Battle::Cell::SetHeadDirection( const int val )
+void Battle::Cell::SetReachableForHead()
 {
-    _headDirection = val;
+    _reachableForHead = true;
 }
 
-void Battle::Cell::SetTailDirection( const int val )
+void Battle::Cell::SetReachableForTail()
 {
-    _tailDirection = val;
+    _reachableForTail = true;
 }
 
 void Battle::Cell::SetQuality( u32 val )
@@ -209,16 +209,6 @@ void Battle::Cell::SetQuality( u32 val )
 int Battle::Cell::GetObject( void ) const
 {
     return object;
-}
-
-int Battle::Cell::GetHeadDirection() const
-{
-    return _headDirection;
-}
-
-int Battle::Cell::GetTailDirection() const
-{
-    return _tailDirection;
 }
 
 const fheroes2::Rect & Battle::Cell::GetPos( void ) const
@@ -239,6 +229,16 @@ Battle::Unit * Battle::Cell::GetUnit( void )
 void Battle::Cell::SetUnit( Unit * val )
 {
     troop = val;
+}
+
+bool Battle::Cell::isReachableForHead() const
+{
+    return _reachableForHead;
+}
+
+bool Battle::Cell::isReachableForTail() const
+{
+    return _reachableForTail;
 }
 
 bool Battle::Cell::isPassable4( const Unit & b, const Cell & from ) const
@@ -300,8 +300,8 @@ void Battle::Cell::ResetQuality( void )
     quality = 0;
 }
 
-void Battle::Cell::ResetDirections()
+void Battle::Cell::ResetReachability()
 {
-    _headDirection = UNKNOWN;
-    _tailDirection = UNKNOWN;
+    _reachableForHead = false;
+    _reachableForTail = false;
 }

--- a/src/fheroes2/battle/battle_cell.cpp
+++ b/src/fheroes2/battle/battle_cell.cpp
@@ -123,7 +123,8 @@ bool Battle::Position::contains( int cellIndex ) const
 Battle::Cell::Cell( int32_t ii )
     : index( ii )
     , object( 0 )
-    , direction( UNKNOWN )
+    , _headDirection( UNKNOWN )
+    , _tailDirection( UNKNOWN )
     , quality( 0 )
     , troop( nullptr )
 {
@@ -190,9 +191,14 @@ void Battle::Cell::SetObject( int val )
     object = val;
 }
 
-void Battle::Cell::SetDirection( int val )
+void Battle::Cell::SetHeadDirection( const int val )
 {
-    direction = val;
+    _headDirection = val;
+}
+
+void Battle::Cell::SetTailDirection( const int val )
+{
+    _tailDirection = val;
 }
 
 void Battle::Cell::SetQuality( u32 val )
@@ -205,9 +211,14 @@ int Battle::Cell::GetObject( void ) const
     return object;
 }
 
-int Battle::Cell::GetDirection( void ) const
+int Battle::Cell::GetHeadDirection() const
 {
-    return direction;
+    return _headDirection;
+}
+
+int Battle::Cell::GetTailDirection() const
+{
+    return _tailDirection;
 }
 
 const fheroes2::Rect & Battle::Cell::GetPos( void ) const
@@ -289,7 +300,8 @@ void Battle::Cell::ResetQuality( void )
     quality = 0;
 }
 
-void Battle::Cell::ResetDirection( void )
+void Battle::Cell::ResetDirections()
 {
-    direction = UNKNOWN;
+    _headDirection = UNKNOWN;
+    _tailDirection = UNKNOWN;
 }

--- a/src/fheroes2/battle/battle_cell.h
+++ b/src/fheroes2/battle/battle_cell.h
@@ -56,10 +56,11 @@ namespace Battle
         explicit Cell( int32_t );
 
         void ResetQuality( void );
-        void ResetDirection( void );
+        void ResetDirections();
 
         void SetObject( int );
-        void SetDirection( int );
+        void SetHeadDirection( const int val );
+        void SetTailDirection( const int val );
         void SetQuality( u32 );
 
         void SetArea( const fheroes2::Rect & );
@@ -72,7 +73,8 @@ namespace Battle
         s32 GetIndex( void ) const;
         const fheroes2::Rect & GetPos( void ) const;
         int GetObject( void ) const;
-        int GetDirection( void ) const;
+        int GetHeadDirection() const;
+        int GetTailDirection() const;
         s32 GetQuality( void ) const;
         direction_t GetTriangleDirection( const fheroes2::Point & ) const;
 
@@ -84,7 +86,8 @@ namespace Battle
         s32 index;
         fheroes2::Rect pos;
         int object;
-        int direction;
+        int _headDirection;
+        int _tailDirection;
         s32 quality;
         Unit * troop;
         fheroes2::Point coord[7];

--- a/src/fheroes2/battle/battle_cell.h
+++ b/src/fheroes2/battle/battle_cell.h
@@ -56,14 +56,18 @@ namespace Battle
         explicit Cell( int32_t );
 
         void ResetQuality( void );
-        void ResetDirections();
+        void ResetReachability();
 
         void SetObject( int );
-        void SetHeadDirection( const int val );
-        void SetTailDirection( const int val );
         void SetQuality( u32 );
 
+        void SetReachableForHead();
+        void SetReachableForTail();
+
         void SetArea( const fheroes2::Rect & );
+
+        bool isReachableForHead() const;
+        bool isReachableForTail() const;
 
         bool isPassable4( const Unit &, const Cell & ) const;
         bool isPassable3( const Unit &, bool check_reflect ) const;
@@ -73,8 +77,6 @@ namespace Battle
         s32 GetIndex( void ) const;
         const fheroes2::Rect & GetPos( void ) const;
         int GetObject( void ) const;
-        int GetHeadDirection() const;
-        int GetTailDirection() const;
         s32 GetQuality( void ) const;
         direction_t GetTriangleDirection( const fheroes2::Point & ) const;
 
@@ -86,8 +88,8 @@ namespace Battle
         s32 index;
         fheroes2::Rect pos;
         int object;
-        int _headDirection;
-        int _tailDirection;
+        bool _reachableForHead;
+        bool _reachableForTail;
         s32 quality;
         Unit * troop;
         fheroes2::Point coord[7];

--- a/src/fheroes2/battle/battle_cell.h
+++ b/src/fheroes2/battle/battle_cell.h
@@ -56,13 +56,13 @@ namespace Battle
         explicit Cell( int32_t );
 
         void ResetQuality( void );
-        void ResetReachability();
+        void resetReachability();
 
         void SetObject( int );
         void SetQuality( u32 );
 
-        void SetReachableForHead();
-        void SetReachableForTail();
+        void setReachableForHead();
+        void setReachableForTail();
 
         void SetArea( const fheroes2::Rect & );
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1610,7 +1610,7 @@ void Battle::Interface::RedrawCover()
             if ( Board::isValidDirection( index_pos, tailDirection ) ) {
                 const Cell * tailCell = Board::GetCell( Board::GetIndexDirection( index_pos, tailDirection ) );
 
-                if ( tailCell != nullptr && tailCell->GetTailDirection() != UNKNOWN && ( tailCell->GetUnit() == nullptr || tailCell->GetUnit() == _currentUnit ) ) {
+                if ( tailCell != nullptr && tailCell->isReachableForTail() && ( tailCell->GetUnit() == nullptr || tailCell->GetUnit() == _currentUnit ) ) {
                     highlightCells.emplace( tailCell );
                 }
             }
@@ -1622,7 +1622,7 @@ void Battle::Interface::RedrawCover()
                 if ( Board::isValidDirection( index_pos, headDirection ) ) {
                     const Cell * headCell = Board::GetCell( Board::GetIndexDirection( index_pos, headDirection ) );
 
-                    if ( headCell != nullptr && headCell->GetHeadDirection() != UNKNOWN && ( headCell->GetUnit() == nullptr || headCell->GetUnit() == _currentUnit ) ) {
+                    if ( headCell != nullptr && headCell->isReachableForHead() && ( headCell->GetUnit() == nullptr || headCell->GetUnit() == _currentUnit ) ) {
                         highlightCells.emplace( headCell );
                     }
                 }
@@ -1675,7 +1675,7 @@ void Battle::Interface::RedrawCover()
                     if ( Board::isValidDirection( attackerCell->GetIndex(), tailDirection ) ) {
                         const Cell * attackerTailCell = Board::GetCell( Board::GetIndexDirection( attackerCell->GetIndex(), tailDirection ) );
 
-                        if ( attackerTailCell != nullptr && attackerTailCell->GetTailDirection() != UNKNOWN
+                        if ( attackerTailCell != nullptr && attackerTailCell->isReachableForTail()
                              && ( attackerTailCell->GetUnit() == nullptr || attackerTailCell->GetUnit() == _currentUnit ) ) {
                             highlightCells.emplace( attackerTailCell );
                         }
@@ -1688,7 +1688,7 @@ void Battle::Interface::RedrawCover()
                         if ( Board::isValidDirection( attackerCell->GetIndex(), headDirection ) ) {
                             const Cell * attackerHeadCell = Board::GetCell( Board::GetIndexDirection( attackerCell->GetIndex(), headDirection ) );
 
-                            if ( attackerHeadCell != nullptr && attackerHeadCell->GetHeadDirection() != UNKNOWN
+                            if ( attackerHeadCell != nullptr && attackerHeadCell->isReachableForHead()
                                  && ( attackerHeadCell->GetUnit() == nullptr || attackerHeadCell->GetUnit() == _currentUnit ) ) {
                                 highlightCells.emplace( attackerHeadCell );
                             }
@@ -1759,7 +1759,7 @@ void Battle::Interface::RedrawCoverBoard( const Settings & conf, const Board & b
 
     if ( !_movingUnit && conf.BattleShowMoveShadow() && _currentUnit && !( _currentUnit->GetCurrentControl() & CONTROL_AI ) ) { // shadow
         for ( const Cell & cell : board ) {
-            if ( cell.GetHeadDirection() != UNKNOWN || cell.GetTailDirection() != UNKNOWN ) {
+            if ( cell.isReachableForHead() || cell.isReachableForTail() ) {
                 fheroes2::Blit( sf_shadow, _mainSurface, cell.GetPos().x, cell.GetPos().y );
             }
         }
@@ -2113,7 +2113,7 @@ int Battle::Interface::GetBattleCursor( std::string & statusMsg ) const
                 }
             }
         }
-        else if ( cell->GetHeadDirection() != UNKNOWN || cell->GetTailDirection() != UNKNOWN ) {
+        else if ( cell->isReachableForHead() || cell->isReachableForTail() ) {
             statusMsg = _currentUnit->isFlying() ? _( "Fly %{monster} here." ) : _( "Move %{monster} here." );
             StringReplace( statusMsg, "%{monster}", _currentUnit->GetName() );
             return _currentUnit->isFlying() ? Cursor::WAR_FLY : Cursor::WAR_MOVE;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1602,24 +1602,28 @@ void Battle::Interface::RedrawCover()
                 }
             }
         }
-        else if ( _currentUnit->GetTailIndex() != -1 && ( cursorType == Cursor::WAR_MOVE || cursorType == Cursor::WAR_FLY ) ) {
+        else if ( _currentUnit->isWide() && ( cursorType == Cursor::WAR_MOVE || cursorType == Cursor::WAR_FLY ) ) {
             highlightCells.emplace( cell );
-            int tailDirection = _currentUnit->isReflect() ? RIGHT : LEFT;
+
+            const int tailDirection = _currentUnit->isReflect() ? RIGHT : LEFT;
 
             if ( Board::isValidDirection( index_pos, tailDirection ) ) {
                 const Cell * tailCell = Board::GetCell( Board::GetIndexDirection( index_pos, tailDirection ) );
-                if ( tailCell != nullptr && tailCell->GetDirection() != UNKNOWN && ( tailCell->GetUnit() == nullptr || tailCell->GetUnit() == _currentUnit ) ) {
+
+                if ( tailCell != nullptr && tailCell->GetTailDirection() != UNKNOWN && ( tailCell->GetUnit() == nullptr || tailCell->GetUnit() == _currentUnit ) ) {
                     highlightCells.emplace( tailCell );
                 }
             }
 
             if ( highlightCells.size() == 1 ) {
                 // Try opposite direction
-                tailDirection = _currentUnit->isReflect() ? LEFT : RIGHT;
-                if ( Board::isValidDirection( index_pos, tailDirection ) ) {
-                    const Cell * tailCell = Board::GetCell( Board::GetIndexDirection( index_pos, tailDirection ) );
-                    if ( tailCell != nullptr && tailCell->GetDirection() != UNKNOWN && ( tailCell->GetUnit() == nullptr || tailCell->GetUnit() == _currentUnit ) ) {
-                        highlightCells.emplace( tailCell );
+                const int headDirection = _currentUnit->isReflect() ? LEFT : RIGHT;
+
+                if ( Board::isValidDirection( index_pos, headDirection ) ) {
+                    const Cell * headCell = Board::GetCell( Board::GetIndexDirection( index_pos, headDirection ) );
+
+                    if ( headCell != nullptr && headCell->GetHeadDirection() != UNKNOWN && ( headCell->GetUnit() == nullptr || headCell->GetUnit() == _currentUnit ) ) {
+                        highlightCells.emplace( headCell );
                     }
                 }
             }
@@ -1666,12 +1670,12 @@ void Battle::Interface::RedrawCover()
                 highlightCells.emplace( attackerCell );
 
                 if ( _currentUnit->isWide() ) {
-                    int tailDirection = _currentUnit->isReflect() ? RIGHT : LEFT;
+                    const int tailDirection = _currentUnit->isReflect() ? RIGHT : LEFT;
 
                     if ( Board::isValidDirection( attackerCell->GetIndex(), tailDirection ) ) {
                         const Cell * attackerTailCell = Board::GetCell( Board::GetIndexDirection( attackerCell->GetIndex(), tailDirection ) );
 
-                        if ( attackerTailCell != nullptr && attackerTailCell->GetDirection() != UNKNOWN
+                        if ( attackerTailCell != nullptr && attackerTailCell->GetTailDirection() != UNKNOWN
                              && ( attackerTailCell->GetUnit() == nullptr || attackerTailCell->GetUnit() == _currentUnit ) ) {
                             highlightCells.emplace( attackerTailCell );
                         }
@@ -1679,14 +1683,14 @@ void Battle::Interface::RedrawCover()
 
                     if ( highlightCells.size() == 2 ) {
                         // Try opposite direction
-                        tailDirection = _currentUnit->isReflect() ? LEFT : RIGHT;
+                        const int headDirection = _currentUnit->isReflect() ? LEFT : RIGHT;
 
-                        if ( Board::isValidDirection( attackerCell->GetIndex(), tailDirection ) ) {
-                            const Cell * attackerTailCell = Board::GetCell( Board::GetIndexDirection( attackerCell->GetIndex(), tailDirection ) );
+                        if ( Board::isValidDirection( attackerCell->GetIndex(), headDirection ) ) {
+                            const Cell * attackerHeadCell = Board::GetCell( Board::GetIndexDirection( attackerCell->GetIndex(), headDirection ) );
 
-                            if ( attackerTailCell != nullptr && attackerTailCell->GetDirection() != UNKNOWN
-                                 && ( attackerTailCell->GetUnit() == nullptr || attackerTailCell->GetUnit() == _currentUnit ) ) {
-                                highlightCells.emplace( attackerTailCell );
+                            if ( attackerHeadCell != nullptr && attackerHeadCell->GetHeadDirection() != UNKNOWN
+                                 && ( attackerHeadCell->GetUnit() == nullptr || attackerHeadCell->GetUnit() == _currentUnit ) ) {
+                                highlightCells.emplace( attackerHeadCell );
                             }
                         }
                     }
@@ -1702,24 +1706,17 @@ void Battle::Interface::RedrawCover()
         const HeroBase * currentCommander = arena.GetCurrentCommander();
         const int spellPower = ( currentCommander == nullptr ) ? 0 : currentCommander->GetPower();
 
-        const bool displayMoveShadow = conf.BattleShowMoveShadow();
-
         for ( const Cell * highlightCell : highlightCells ) {
             bool isApplicable = highlightCell->isPassable1( false );
+
             if ( isApplicable ) {
                 const Unit * highlightedUnit = highlightCell->GetUnit();
+
                 isApplicable = highlightedUnit == nullptr || !humanturn_spell.isValid() || !highlightedUnit->isMagicResist( humanturn_spell, spellPower );
             }
 
             if ( isApplicable ) {
-                if ( displayMoveShadow && ( highlightCell->GetDirection() == UNKNOWN || highlightCell->GetUnit() != nullptr ) ) {
-                    fheroes2::Blit( sf_shadow, _mainSurface, highlightCell->GetPos().x, highlightCell->GetPos().y );
-                }
-
                 fheroes2::Blit( sf_cursor, _mainSurface, highlightCell->GetPos().x, highlightCell->GetPos().y );
-            }
-            else {
-                fheroes2::Blit( sf_shadow, _mainSurface, highlightCell->GetPos().x, highlightCell->GetPos().y );
             }
         }
     }
@@ -1755,15 +1752,15 @@ void Battle::Interface::RedrawCoverStatic()
 void Battle::Interface::RedrawCoverBoard( const Settings & conf, const Board & board )
 {
     if ( conf.BattleShowGrid() ) { // grid
-        for ( Board::const_iterator it = board.begin(); it != board.end(); ++it ) {
-            fheroes2::Blit( sf_hexagon, _mainSurface, ( *it ).GetPos().x, ( *it ).GetPos().y );
+        for ( const Cell & cell : board ) {
+            fheroes2::Blit( sf_hexagon, _mainSurface, cell.GetPos().x, cell.GetPos().y );
         }
     }
 
     if ( !_movingUnit && conf.BattleShowMoveShadow() && _currentUnit && !( _currentUnit->GetCurrentControl() & CONTROL_AI ) ) { // shadow
-        for ( Board::const_iterator it = board.begin(); it != board.end(); ++it ) {
-            if ( ( *it ).isPassable1( true ) && UNKNOWN != ( *it ).GetDirection() ) {
-                fheroes2::Blit( sf_shadow, _mainSurface, ( *it ).GetPos().x, ( *it ).GetPos().y );
+        for ( const Cell & cell : board ) {
+            if ( cell.GetHeadDirection() != UNKNOWN || cell.GetTailDirection() != UNKNOWN ) {
+                fheroes2::Blit( sf_shadow, _mainSurface, cell.GetPos().x, cell.GetPos().y );
             }
         }
     }
@@ -2116,7 +2113,7 @@ int Battle::Interface::GetBattleCursor( std::string & statusMsg ) const
                 }
             }
         }
-        else if ( cell->isPassable3( *_currentUnit, false ) && UNKNOWN != cell->GetDirection() ) {
+        else if ( cell->GetHeadDirection() != UNKNOWN || cell->GetTailDirection() != UNKNOWN ) {
             statusMsg = _currentUnit->isFlying() ? _( "Fly %{monster} here." ) : _( "Move %{monster} here." );
             StringReplace( statusMsg, "%{monster}", _currentUnit->GetName() );
             return _currentUnit->isFlying() ? Cursor::WAR_FLY : Cursor::WAR_MOVE;
@@ -2640,32 +2637,10 @@ void Battle::Interface::MouseLeftClickBoardAction( u32 themes, const Cell & cell
     const Unit * b = cell.GetUnit();
 
     if ( _currentUnit ) {
-        auto fixupTargetIndex = []( const Unit * unit, const int32_t dst ) {
-            // only wide units may need this fixup
-            if ( !unit->isWide() ) {
-                return dst;
-            }
-
-            const Position pos = Position::GetCorrect( *unit, dst );
-            assert( pos.GetTail() != nullptr );
-
-            // destination cell is on the border of the cell space available to the unit
-            // and it should be the tail cell of the unit, return the head cell instead
-            if ( pos.GetTail()->GetDirection() == UNKNOWN ) {
-                const int headDirection = unit->isReflect() ? LEFT : RIGHT;
-
-                if ( Board::isValidDirection( dst, headDirection ) ) {
-                    return Board::GetIndexDirection( dst, headDirection );
-                }
-            }
-
-            return dst;
-        };
-
         switch ( themes ) {
         case Cursor::WAR_FLY:
         case Cursor::WAR_MOVE:
-            a.push_back( Command( MSG_BATTLE_MOVE, _currentUnit->GetUID(), fixupTargetIndex( _currentUnit, index ) ) );
+            a.push_back( Command( MSG_BATTLE_MOVE, _currentUnit->GetUID(), Board::FixupTargetCellForUnit( *_currentUnit, index ) ) );
             a.push_back( Command( MSG_BATTLE_END_TURN, _currentUnit->GetUID() ) );
             humanturn_exit = true;
             break;
@@ -2683,7 +2658,7 @@ void Battle::Interface::MouseLeftClickBoardAction( u32 themes, const Cell & cell
                 const s32 move = Board::GetIndexDirection( index, dir );
 
                 if ( _currentUnit->GetHeadIndex() != move )
-                    a.push_back( Command( MSG_BATTLE_MOVE, _currentUnit->GetUID(), fixupTargetIndex( _currentUnit, move ) ) );
+                    a.push_back( Command( MSG_BATTLE_MOVE, _currentUnit->GetUID(), Board::FixupTargetCellForUnit( *_currentUnit, move ) ) );
                 a.push_back( Command( MSG_BATTLE_ATTACK, _currentUnit->GetUID(), enemy->GetUID(), index, Board::GetReflectDirection( dir ) ) );
                 a.push_back( Command( MSG_BATTLE_END_TURN, _currentUnit->GetUID() ) );
                 humanturn_exit = true;


### PR DESCRIPTION
Today I ran into an interesting problem:

![bug](https://user-images.githubusercontent.com/32623900/129486699-d57eb12f-5f46-4f8c-adfe-b74e0ec49e68.jpg)

Although the Cavalry can occupy each of the highlighted cells separately, it can't occupy them BOTH AT THE SAME TIME. If I press the left mouse button here, Cavalry just skips the turn, and this is completely logical - Cavalry can't reach those cells from inside the castle because of the moat, and it can't reach those cells from outside, because the head cell (the rightmost one) is too far.

This problem apparently cannot be solved within the current pathfinding paradigm, because each of both cells have the valid `direction` field, so I decided to introduce separate info for the head (`_reachableForHead`) and tail (`_reachableForTail`) of units and also replace direction (`int`) by reachability (`bool`) since all that was done with them was a comparison for equality/inequality with `UNKNOWN`, no direction info was ever used anywhere. This approach seems to work just fine:

![1](https://user-images.githubusercontent.com/32623900/129486974-e8b51487-da16-4345-be9f-efc350ace4f5.jpg)
![2](https://user-images.githubusercontent.com/32623900/129486976-59d87690-84a8-44f4-8061-20703201acb2.jpg)

However, it needs an extensive testing with all unit types (regular units, wide units, flying units, wide flying units) in different circumstances (siege, obstacles, etc).

Also I improved AI pathfinding a bit in relation to the attack - since AI may decide to attack a distant unit, it may select the wrong cell (unreachable on the current turn) for this, and attack fails even if attacker is near the target - because he is literally one step away from the desired cell. In this PR I implemented a logic that allows attacker to attack the target if possible, even if desired cell wasn't reached.