### PR TITLE
SonarCloud: fix sonar.links.ci

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,7 +18,7 @@ sonar.cfamily.build-wrapper-output=bw-output
 sonar.cfamily.gcov.reportsPath=.
 
 sonar.links.homepage=https://github.com/ihhub/fheroes2
-sonar.links.ci=https://travis-ci.org/ihhub/fheroes2
+sonar.links.ci=https://github.com/ihhub/fheroes2/actions
 sonar.links.scm=https://github.com/ihhub/fheroes2
 sonar.links.issue=https://github.com/ihhub/fheroes2/issues
 


### PR DESCRIPTION
Travis isn't used anymore.