### PR TITLE
Game::EnvironmentSoundMixer(): remove extra Audio::isValid() check that blocks the main thread

### DIFF
--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -351,10 +351,6 @@ u32 & Game::CastleAnimationFrame( void )
 /* play all sound from focus area game */
 void Game::EnvironmentSoundMixer( void )
 {
-    if ( !Audio::isValid() ) {
-        return;
-    }
-
     const fheroes2::Point abs_pt( Interface::GetFocusCenter() );
     std::fill( reserved_vols.begin(), reserved_vols.end(), 0 );
 


### PR DESCRIPTION
fix #4031

Hi @ihhub I was unable to reproduce this issue on my own hardware (apparently it's too fast), so I borrowed an ancient Lenovo T420, but it was taken back from me recently. Do you have a hardware slow enough to test this patch?