### PR TITLE
Implement CaseInsensitiveCompare for filename sorting

### DIFF
--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -50,9 +50,24 @@ namespace
     const size_t mapDescriptionLength = 143;
 
     template <typename CharType>
-    bool AlphabeticalCompare( const std::basic_string<CharType> & lhs, const std::basic_string<CharType> & rhs )
+    bool CaseInsensitiveCompare( const std::basic_string<CharType> & lhs, const std::basic_string<CharType> & rhs )
     {
-        return std::use_facet<std::collate<CharType> >( std::locale() ).compare( lhs.data(), lhs.data() + lhs.size(), rhs.data(), rhs.data() + rhs.size() ) == -1;
+        typename std::basic_string<CharType>::const_iterator li = lhs.begin();
+        typename std::basic_string<CharType>::const_iterator ri = rhs.begin();
+
+        while ( li != lhs.end() && ri != rhs.end() ) {
+            const CharType lc = std::tolower( *li++, std::locale() );
+            const CharType rc = std::tolower( *ri++, std::locale() );
+            if ( lc < rc ) {
+                return true;
+            } else if ( lc > rc ) {
+                return false;
+            } else {
+                // the chars are "equal", so proceed to check the next pair
+            }
+        }
+        // we came to the end of either (or both) strings, left is "smaller" if it was shorter:
+        return li == lhs.end() && ri != rhs.end();
     }
 
     int ByteToColor( const int byte )
@@ -405,12 +420,12 @@ void Maps::FileInfo::FillUnions( const int side1Colors, const int side2Colors )
 
 bool Maps::FileInfo::FileSorting( const FileInfo & fi1, const FileInfo & fi2 )
 {
-    return AlphabeticalCompare( fi1.file, fi2.file );
+    return CaseInsensitiveCompare( fi1.file, fi2.file );
 }
 
 bool Maps::FileInfo::NameSorting( const FileInfo & fi1, const FileInfo & fi2 )
 {
-    return AlphabeticalCompare( fi1.name, fi2.name );
+    return CaseInsensitiveCompare( fi1.name, fi2.name );
 }
 
 int Maps::FileInfo::KingdomRace( int color ) const

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -56,8 +56,12 @@ namespace
         typename std::basic_string<CharType>::const_iterator ri = rhs.begin();
 
         while ( li != lhs.end() && ri != rhs.end() ) {
-            const CharType lc = std::tolower( *li++, std::locale() );
-            const CharType rc = std::tolower( *ri++, std::locale() );
+            const CharType lc = std::tolower( *li, std::locale() );
+            const CharType rc = std::tolower( *ri, std::locale() );
+
+            ++li;
+            ++ri;
+
             if ( lc < rc ) {
                 return true;
             }

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -60,12 +60,13 @@ namespace
             const CharType rc = std::tolower( *ri++, std::locale() );
             if ( lc < rc ) {
                 return true;
-            } else if ( lc > rc ) {
-                return false;
-            } else {
-                // the chars are "equal", so proceed to check the next pair
             }
+            else if ( lc > rc ) {
+                return false;
+            }
+            // the chars are "equal", so proceed to check the next pair
         }
+
         // we came to the end of either (or both) strings, left is "smaller" if it was shorter:
         return li == lhs.end() && ri != rhs.end();
     }

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -61,7 +61,7 @@ namespace
             if ( lc < rc ) {
                 return true;
             }
-            else if ( lc > rc ) {
+            if ( lc > rc ) {
                 return false;
             }
             // the chars are "equal", so proceed to check the next pair


### PR DESCRIPTION
Fixes #945

Also affects how map names are ordered (e.g. in the "New Game" dialog), but
that should be fine in general.