### PR TITLE
clang-tidy: enable AllowSoleDefaultDtor option for cppcoreguidelines-special-member-functions check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,3 +25,5 @@ Checks: >-
 CheckOptions:
   - key: cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted
     value: true
+  - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value: true


### PR DESCRIPTION
For example, in #4035 we have an abstract class with virtual defaulted destructor, no need to add copy/move constructors and assignment operators in such cases.