### PR TITLE
Don't ignore in<>out mismatch in Image Transpose

### DIFF
--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -2065,10 +2065,12 @@ namespace fheroes2
 
     void Transpose( const Image & in, Image & out )
     {
-        assert( !in.empty() );
         assert( !out.empty() );
-        assert( in.width() == out.height() && in.height() == out.width() );
 
+        if ( in.empty() || in.width() != out.height() || in.height() != out.width() ) {
+            out.reset();
+            return;
+        }
         const int32_t width = in.width();
         const int32_t height = in.height();
 

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -2065,8 +2065,9 @@ namespace fheroes2
 
     void Transpose( const Image & in, Image & out )
     {
-        if ( in.empty() || out.empty() || in.width() != out.height() || in.height() != out.width() )
-            return;
+        assert( !in.empty() );
+        assert( !out.empty() );
+        assert( in.width() == out.height() && in.height() == out.width() );
 
         const int32_t width = in.width();
         const int32_t height = in.height();


### PR DESCRIPTION
Passing unexpected images is a programming error, we should bail out instead
of pretending nothing happened.