### PR TITLE
Eradicate more reinterpret_cast calls

### DIFF
--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -24,7 +24,6 @@
 #include <cstring>
 #include <string>
 
-#include "endian_h2.h"
 #include "logging.h"
 #include "serialize.h"
 

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -323,9 +323,9 @@ namespace fheroes2
 
         T result;
 
-#if BYTE_ORDER == LITTLE_ENDIAN
+#if defined( BYTE_ORDER ) && defined( LITTLE_ENDIAN ) && BYTE_ORDER == LITTLE_ENDIAN
         std::copy( begin, end, reinterpret_cast<char *>( &result ) );
-#elif BYTE_ORDER == BIG_ENDIAN
+#elif defined( BYTE_ORDER ) && defined( BIG_ENDIAN ) && BYTE_ORDER == BIG_ENDIAN
         std::reverse_copy( begin, end, reinterpret_cast<char *>( &result ) );
 #else
         static_assert( false, "Unknown byte order" );

--- a/src/fheroes2/agg/bin_info.cpp
+++ b/src/fheroes2/agg/bin_info.cpp
@@ -18,38 +18,22 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include <algorithm>
 #include <map>
-#include <type_traits>
 
 #include "agg.h"
 #include "battle_animation.h"
 #include "battle_cell.h"
 #include "bin_info.h"
-#include "endian_h2.h"
 #include "logging.h"
 #include "monster.h"
+#include "serialize.h"
 
 namespace
 {
-    template <typename T, typename = typename std::enable_if<std::is_integral<T>::value || std::is_floating_point<T>::value>::type>
+    template <typename T>
     T getValue( const uint8_t * data, const size_t base, const size_t offset = 0 )
     {
-        const char * begin = reinterpret_cast<const char *>( data ) + base + offset * sizeof( T );
-        const char * end = begin + sizeof( T );
-
-        T result;
-
-        // Data is originally stored using the little-endian byte order
-#if BYTE_ORDER == LITTLE_ENDIAN
-        std::copy( begin, end, reinterpret_cast<char *>( &result ) );
-#elif BYTE_ORDER == BIG_ENDIAN
-        std::reverse_copy( begin, end, reinterpret_cast<char *>( &result ) );
-#else
-        static_assert( false, "Unknown byte order" );
-#endif
-
-        return result;
+        return fheroes2::getLEValue<T>( reinterpret_cast<const char *>( data ), base, offset );
     }
 }
 

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -173,9 +173,14 @@ void ArmyBar::SetArmy( Army * ptr )
     _army = ptr;
     items.clear();
 
-    if ( ptr )
-        for ( u32 ii = 0; ii < ptr->Size(); ++ii )
-            items.push_back( reinterpret_cast<ArmyTroop *>( ptr->GetTroop( ii ) ) );
+    if ( ptr ) {
+        for ( u32 ii = 0; ii < ptr->Size(); ++ii ) {
+            ArmyTroop * troop = dynamic_cast<ArmyTroop *>( ptr->GetTroop( ii ) );
+            assert( troop != nullptr );
+
+            items.push_back( troop );
+        }
+    }
 
     SetContentItems();
 }

--- a/src/fheroes2/system/players.cpp
+++ b/src/fheroes2/system/players.cpp
@@ -203,10 +203,10 @@ StreamBase & operator<<( StreamBase & msg, const Focus & focus )
 
     switch ( focus.first ) {
     case FOCUS_HEROES:
-        msg << reinterpret_cast<Heroes *>( focus.second )->GetIndex();
+        msg << static_cast<Heroes *>( focus.second )->GetIndex();
         break;
     case FOCUS_CASTLE:
-        msg << reinterpret_cast<Castle *>( focus.second )->GetIndex();
+        msg << static_cast<Castle *>( focus.second )->GetIndex();
         break;
     default:
         msg << static_cast<s32>( -1 );

--- a/src/fheroes2/system/players.h
+++ b/src/fheroes2/system/players.h
@@ -82,11 +82,11 @@ struct Focus : std::pair<int, void *>
 
     Castle * GetCastle( void )
     {
-        return first == FOCUS_CASTLE && second ? reinterpret_cast<Castle *>( second ) : nullptr;
+        return first == FOCUS_CASTLE && second ? static_cast<Castle *>( second ) : nullptr;
     }
     Heroes * GetHeroes( void )
     {
-        return first == FOCUS_HEROES && second ? reinterpret_cast<Heroes *>( second ) : nullptr;
+        return first == FOCUS_HEROES && second ? static_cast<Heroes *>( second ) : nullptr;
     }
 };
 

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -4,6 +4,9 @@ target_link_libraries(82m2wav
 	)
 
 add_executable(bin2txt bin2txt.cpp)
+target_link_libraries(bin2txt
+	engine
+	)
 
 add_executable(extractor extractor.cpp)
 target_link_libraries(extractor

--- a/src/tools/bin2txt.cpp
+++ b/src/tools/bin2txt.cpp
@@ -1,34 +1,9 @@
-#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <type_traits>
 #include <vector>
 
-#include "endian_h2.h"
-
-namespace
-{
-    template <typename T, typename = typename std::enable_if<std::is_integral<T>::value || std::is_floating_point<T>::value>::type>
-    T getValue( const char * data, const size_t base, const size_t offset = 0 )
-    {
-        const char * begin = data + base + offset * sizeof( T );
-        const char * end = begin + sizeof( T );
-
-        T result;
-
-        // Data is originally stored using the little-endian byte order
-#if BYTE_ORDER == LITTLE_ENDIAN
-        std::copy( begin, end, reinterpret_cast<char *>( &result ) );
-#elif BYTE_ORDER == BIG_ENDIAN
-        std::reverse_copy( begin, end, reinterpret_cast<char *>( &result ) );
-#else
-        static_assert( false, "Unknown byte order" );
-#endif
-
-        return result;
-    }
-}
+#include "serialize.h"
 
 int main( int argc, char ** argv )
 {
@@ -74,7 +49,7 @@ int main( int argc, char ** argv )
         return EXIT_FAILURE;
     }
 
-    file << "Monster eye position: [" << getValue<int16_t>( data.data(), 1 ) << ", " << getValue<int16_t>( data.data(), 3 ) << "]\n\n";
+    file << "Monster eye position: [" << fheroes2::getLEValue<int16_t>( data.data(), 1 ) << ", " << fheroes2::getLEValue<int16_t>( data.data(), 3 ) << "]\n\n";
 
     file << "Animation frame offsets:\n";
     for ( size_t setId = 0u; setId < 7; ++setId ) {
@@ -101,34 +76,35 @@ int main( int argc, char ** argv )
 
     file << "Probabilities of each idle animation:\n";
     for ( int i = 0; i < idleAnimationCount; ++i ) {
-        file << i + 1 << ": " << getValue<float>( data.data(), 118 ) << "\n";
+        file << i + 1 << ": " << fheroes2::getLEValue<float>( data.data(), 118 ) << "\n";
     }
     file << "\n";
 
-    file << "Idle animation delay (?) (ms): " << getValue<uint32_t>( data.data(), 138, 0 ) << " " << getValue<uint32_t>( data.data(), 138, 1 ) << " "
-         << getValue<uint32_t>( data.data(), 138, 2 ) << " " << getValue<uint32_t>( data.data(), 138, 3 ) << " " << getValue<uint32_t>( data.data(), 138, 4 ) << "\n\n";
+    file << "Idle animation delay (?) (ms): " << fheroes2::getLEValue<uint32_t>( data.data(), 138, 0 ) << " " << fheroes2::getLEValue<uint32_t>( data.data(), 138, 1 )
+         << " " << fheroes2::getLEValue<uint32_t>( data.data(), 138, 2 ) << " " << fheroes2::getLEValue<uint32_t>( data.data(), 138, 3 ) << " "
+         << fheroes2::getLEValue<uint32_t>( data.data(), 138, 4 ) << "\n\n";
 
-    file << "Idle animation delay (?) (ms): " << getValue<uint32_t>( data.data(), 158 ) << "\n\n";
+    file << "Idle animation delay (?) (ms): " << fheroes2::getLEValue<uint32_t>( data.data(), 158 ) << "\n\n";
 
-    file << "Walking animation speed (ms): " << getValue<uint32_t>( data.data(), 162 ) << "\n\n";
+    file << "Walking animation speed (ms): " << fheroes2::getLEValue<uint32_t>( data.data(), 162 ) << "\n\n";
 
-    file << "Shooting animation speed (ms): " << getValue<uint32_t>( data.data(), 166 ) << "\n\n";
+    file << "Shooting animation speed (ms): " << fheroes2::getLEValue<uint32_t>( data.data(), 166 ) << "\n\n";
 
-    file << "Flying animation speed (ms): " << getValue<uint32_t>( data.data(), 170 ) << "\n\n";
+    file << "Flying animation speed (ms): " << fheroes2::getLEValue<uint32_t>( data.data(), 170 ) << "\n\n";
 
     file << "Projectile start positions:\n";
-    file << "[" << getValue<int16_t>( data.data(), 174, 0 ) << ", " << getValue<int16_t>( data.data(), 174, 1 ) << "]\n";
-    file << "[" << getValue<int16_t>( data.data(), 174, 2 ) << ", " << getValue<int16_t>( data.data(), 174, 3 ) << "]\n";
-    file << "[" << getValue<int16_t>( data.data(), 174, 4 ) << ", " << getValue<int16_t>( data.data(), 174, 5 ) << "]\n\n";
+    file << "[" << fheroes2::getLEValue<int16_t>( data.data(), 174, 0 ) << ", " << fheroes2::getLEValue<int16_t>( data.data(), 174, 1 ) << "]\n";
+    file << "[" << fheroes2::getLEValue<int16_t>( data.data(), 174, 2 ) << ", " << fheroes2::getLEValue<int16_t>( data.data(), 174, 3 ) << "]\n";
+    file << "[" << fheroes2::getLEValue<int16_t>( data.data(), 174, 4 ) << ", " << fheroes2::getLEValue<int16_t>( data.data(), 174, 5 ) << "]\n\n";
 
     file << "Number of projectile frames is " << static_cast<int>( *( data.data() + 186 ) ) << "\n\n";
 
     file << "Projectile angles:\n";
     for ( size_t angleId = 0; angleId < 12; ++angleId )
-        file << getValue<float>( data.data(), 187, angleId ) << "\n";
+        file << fheroes2::getLEValue<float>( data.data(), 187, angleId ) << "\n";
     file << "\n";
 
-    file << "Troop count offset: [" << getValue<int32_t>( data.data(), 235 ) << ", " << getValue<int32_t>( data.data(), 239 ) << "]\n\n";
+    file << "Troop count offset: [" << fheroes2::getLEValue<int32_t>( data.data(), 235 ) << ", " << fheroes2::getLEValue<int32_t>( data.data(), 239 ) << "]\n\n";
 
     file << "Animation sequence (frame IDs):\n";
     const char invalidFrameId = static_cast<char>( 0xFF );

--- a/src/tools/bin2txt.cpp
+++ b/src/tools/bin2txt.cpp
@@ -92,9 +92,8 @@ int main( int argc, char ** argv )
     }
     file << "\n";
 
-    file << "Idle animation delay (?) (ms): " << getValue<uint32_t>( data.data(), 138, 0 ) << " "
-         << getValue<uint32_t>( data.data(), 138, 1 ) << " " << getValue<uint32_t>( data.data(), 138, 2 ) << " "
-         << getValue<uint32_t>( data.data(), 138, 3 ) << " " << getValue<uint32_t>( data.data(), 138, 4 ) << "\n\n";
+    file << "Idle animation delay (?) (ms): " << getValue<uint32_t>( data.data(), 138, 0 ) << " " << getValue<uint32_t>( data.data(), 138, 1 ) << " "
+         << getValue<uint32_t>( data.data(), 138, 2 ) << " " << getValue<uint32_t>( data.data(), 138, 3 ) << " " << getValue<uint32_t>( data.data(), 138, 4 ) << "\n\n";
 
     file << "Idle animation delay (?) (ms): " << getValue<uint32_t>( data.data(), 158 ) << "\n\n";
 

--- a/src/tools/bin2txt.cpp
+++ b/src/tools/bin2txt.cpp
@@ -1,7 +1,21 @@
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
+
+namespace
+{
+    template <typename T>
+    T getValue( const char * data, const size_t base, const size_t offset = 0 )
+    {
+        T result;
+
+        memcpy( &result, data + base + offset * sizeof( T ), sizeof( T ) );
+
+        return result;
+    }
+}
 
 int main( int argc, char ** argv )
 {
@@ -47,7 +61,7 @@ int main( int argc, char ** argv )
         return EXIT_FAILURE;
     }
 
-    file << "Monster eye position: [" << *( reinterpret_cast<int16_t *>( data.data() + 1 ) ) << ", " << *( reinterpret_cast<int16_t *>( data.data() + 3 ) ) << "]\n\n";
+    file << "Monster eye position: [" << getValue<int16_t>( data.data(), 1 ) << ", " << getValue<int16_t>( data.data(), 3 ) << "]\n\n";
 
     file << "Animation frame offsets:\n";
     for ( size_t setId = 0u; setId < 7; ++setId ) {
@@ -74,35 +88,35 @@ int main( int argc, char ** argv )
 
     file << "Probabilities of each idle animation:\n";
     for ( int i = 0; i < idleAnimationCount; ++i ) {
-        file << i + 1 << ": " << *( reinterpret_cast<float *>( data.data() + 118 ) ) << "\n";
+        file << i + 1 << ": " << getValue<float>( data.data(), 118 ) << "\n";
     }
     file << "\n";
 
-    file << "Idle animation delay (?) (ms): " << *( reinterpret_cast<uint32_t *>( data.data() + 138 ) ) << " "
-         << *( reinterpret_cast<uint32_t *>( data.data() + 138 + 4 ) ) << " " << *( reinterpret_cast<uint32_t *>( data.data() + 138 + 8 ) ) << " "
-         << *( reinterpret_cast<uint32_t *>( data.data() + 138 + 12 ) ) << " " << *( reinterpret_cast<uint32_t *>( data.data() + 138 + 16 ) ) << "\n\n";
+    file << "Idle animation delay (?) (ms): " << getValue<uint32_t>( data.data(), 138, 0 ) << " "
+         << getValue<uint32_t>( data.data(), 138, 1 ) << " " << getValue<uint32_t>( data.data(), 138, 2 ) << " "
+         << getValue<uint32_t>( data.data(), 138, 3 ) << " " << getValue<uint32_t>( data.data(), 138, 4 ) << "\n\n";
 
-    file << "Idle animation delay (?) (ms): " << *( reinterpret_cast<uint32_t *>( data.data() + 158 ) ) << "\n\n";
+    file << "Idle animation delay (?) (ms): " << getValue<uint32_t>( data.data(), 158 ) << "\n\n";
 
-    file << "Walking animation speed (ms): " << *( reinterpret_cast<uint32_t *>( data.data() + 162 ) ) << "\n\n";
+    file << "Walking animation speed (ms): " << getValue<uint32_t>( data.data(), 162 ) << "\n\n";
 
-    file << "Shooting animation speed (ms): " << *( reinterpret_cast<uint32_t *>( data.data() + 166 ) ) << "\n\n";
+    file << "Shooting animation speed (ms): " << getValue<uint32_t>( data.data(), 166 ) << "\n\n";
 
-    file << "Flying animation speed (ms): " << *( reinterpret_cast<uint32_t *>( data.data() + 170 ) ) << "\n\n";
+    file << "Flying animation speed (ms): " << getValue<uint32_t>( data.data(), 170 ) << "\n\n";
 
     file << "Projectile start positions:\n";
-    file << "[" << *( reinterpret_cast<int16_t *>( data.data() + 174 ) ) << ", " << *( reinterpret_cast<int16_t *>( data.data() + 176 ) ) << "]\n";
-    file << "[" << *( reinterpret_cast<int16_t *>( data.data() + 178 ) ) << ", " << *( reinterpret_cast<int16_t *>( data.data() + 180 ) ) << "]\n";
-    file << "[" << *( reinterpret_cast<int16_t *>( data.data() + 182 ) ) << ", " << *( reinterpret_cast<int16_t *>( data.data() + 184 ) ) << "]\n\n";
+    file << "[" << getValue<int16_t>( data.data(), 174, 0 ) << ", " << getValue<int16_t>( data.data(), 174, 1 ) << "]\n";
+    file << "[" << getValue<int16_t>( data.data(), 174, 2 ) << ", " << getValue<int16_t>( data.data(), 174, 3 ) << "]\n";
+    file << "[" << getValue<int16_t>( data.data(), 174, 4 ) << ", " << getValue<int16_t>( data.data(), 174, 5 ) << "]\n\n";
 
     file << "Number of projectile frames is " << static_cast<int>( *( data.data() + 186 ) ) << "\n\n";
 
     file << "Projectile angles:\n";
     for ( size_t angleId = 0; angleId < 12; ++angleId )
-        file << *( reinterpret_cast<float *>( data.data() + 187 + angleId * 4 ) ) << "\n";
+        file << getValue<float>( data.data(), 187, angleId ) << "\n";
     file << "\n";
 
-    file << "Troop count offset: [" << *( reinterpret_cast<int32_t *>( data.data() + 235 ) ) << ", " << *( reinterpret_cast<int32_t *>( data.data() + 239 ) ) << "]\n\n";
+    file << "Troop count offset: [" << getValue<int32_t>( data.data(), 235 ) << ", " << getValue<int32_t>( data.data(), 239 ) << "]\n\n";
 
     file << "Animation sequence (frame IDs):\n";
     const char invalidFrameId = static_cast<char>( 0xFF );


### PR DESCRIPTION
* Replace `reinterpret_cast` by `static_cast` or `dynamic_cast` where appropriate;
* Remove `reinterpret_cast` usage from the `bin2txt` tool - this led to unaligned accesses at least.

I compared the `bin2txt` output from `master` branch and from this branch for some `.bin` files - it seems that nothing has been broken.