### PR TITLE
Quick monster upgrade in towns

### DIFF
--- a/src/fheroes2/army/army_bar.h
+++ b/src/fheroes2/army/army_bar.h
@@ -42,19 +42,24 @@ public:
 
     bool isValid( void ) const;
 
+    static fheroes2::Rect UpgradeButtonPos( const fheroes2::Rect & itemPos );
+    bool CanUpgradeNow( const ArmyTroop & troop ) const;
+    bool CanAffordUpgrade( const ArmyTroop & troop ) const;
+    void UpgradeTroop( ArmyTroop & troop );
+
     void ResetSelected( void );
     void Redraw( fheroes2::Image & dstsf = fheroes2::Display::instance() );
 
-    bool ActionBarLeftMouseSingleClick( ArmyTroop & troop ) override;
+    bool ActionBarLeftMouseSingleClick( const fheroes2::Point & cursor, ArmyTroop & troop, const fheroes2::Rect & ) override;
     bool ActionBarLeftMouseSingleClick( ArmyTroop & destTroop, ArmyTroop & selectedTroop ) override;
-    bool ActionBarLeftMouseDoubleClick( ArmyTroop & troop ) override;
+    bool ActionBarLeftMouseDoubleClick( const fheroes2::Point &, ArmyTroop & troop, const fheroes2::Rect & ) override;
     bool ActionBarLeftMouseRelease( ArmyTroop & troop ) override;
     bool ActionBarLeftMouseRelease( ArmyTroop & destTroop, ArmyTroop & troop ) override;
     bool ActionBarRightMouseHold( ArmyTroop & troop ) override;
     bool ActionBarRightMouseSingleClick( ArmyTroop & troop ) override;
     bool ActionBarRightMouseSingleClick( ArmyTroop & destTroop, ArmyTroop & selectedTroop ) override;
 
-    bool ActionBarCursor( ArmyTroop & ) override;
+    bool ActionBarCursor( const fheroes2::Point &, ArmyTroop &, const fheroes2::Rect & ) override;
     bool ActionBarCursor( ArmyTroop &, ArmyTroop & ) override;
 
     bool QueueEventProcessing( std::string * = nullptr );

--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -724,7 +724,7 @@ void DwellingsBar::RedrawItem( DwellingItem & dwl, const fheroes2::Rect & pos, f
         fheroes2::Blit( fheroes2::AGG::GetICN( ICN::CSLMARKER, 0 ), dstsf, pos.x + pos.width - 10, pos.y + 4 );
 }
 
-bool DwellingsBar::ActionBarLeftMouseSingleClick( DwellingItem & dwl )
+bool DwellingsBar::ActionBarLeftMouseSingleClick( const fheroes2::Point &, DwellingItem & dwl, const fheroes2::Rect & )
 {
     if ( castle.isBuild( dwl.type ) ) {
         castle.RecruitMonster( Dialog::RecruitMonster( dwl.mons, castle.getMonstersInDwelling( dwl.type ), true ) );

--- a/src/fheroes2/castle/buildinginfo.h
+++ b/src/fheroes2/castle/buildinginfo.h
@@ -72,7 +72,7 @@ public:
     void RedrawBackground( const fheroes2::Rect &, fheroes2::Image & ) override;
     void RedrawItem( DwellingItem &, const fheroes2::Rect &, fheroes2::Image & ) override;
 
-    bool ActionBarLeftMouseSingleClick( DwellingItem & dwelling ) override;
+    bool ActionBarLeftMouseSingleClick( const fheroes2::Point &, DwellingItem & dwelling, const fheroes2::Rect & ) override;
     bool ActionBarRightMouseHold( DwellingItem & dwelling ) override;
 
 protected:

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -682,6 +682,12 @@ int Castle::OpenDialog( bool readonly )
                 BuyBuilding( build );
                 if ( BUILD_CAPTAIN == build )
                     RedrawIcons( *this, heroes, cur_pt );
+
+                // may render new quick upgrade possibilities
+                selectArmy1.Redraw();
+                if ( selectArmy2.isValid() && alphaHero >= 255 )
+                    selectArmy2.Redraw();
+
                 CastleRedrawTownName( *this, cur_pt );
                 RedrawResourcePanel( cur_pt );
                 display.render();

--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -107,6 +107,7 @@ namespace Dialog
     Troop RecruitMonster( const Monster &, u32 available, bool );
     void DwellingInfo( const Monster &, u32 available );
     bool SetGuardian( Heroes &, Troop &, CapturedObject &, bool readonly );
+    int TroopUpgrade( const Troop & troop, bool cannotAfford );
     int ArmyInfo( const Troop & troop, int flags, bool isReflected = false );
     int ArmyJoinFree( const Troop &, Heroes & );
     int ArmyJoinWithCost( const Troop &, u32 join, u32 gold, Heroes & );

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -71,6 +71,22 @@ void DrawMonsterInfo( const fheroes2::Point & dst, const Troop & troop );
 void DrawMonster( fheroes2::RandomMonsterAnimation & monsterAnimation, const Troop & troop, const fheroes2::Point & offset, bool isReflected, bool isAnimated,
                   const fheroes2::Rect & roi );
 
+int Dialog::TroopUpgrade( const Troop & troop, bool cannotAfford )
+{
+    std::string msg;
+    int flags;
+
+    if ( cannotAfford ) {
+        msg = _( "You can't afford to upgrade your troops!" );
+        flags = Dialog::OK;
+    }
+    else {
+        msg = _( "Your troops can be upgraded, but it will cost you dearly. Do you wish to upgrade them?" );
+        flags = Dialog::YES | Dialog::NO;
+    }
+    return Dialog::ResourceInfo( "", msg, troop.GetUpgradeCost(), flags );
+}
+
 int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
 {
     // The active size of the window is 520 by 256 pixels
@@ -169,20 +185,9 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
 
             // upgrade
             if ( buttonUpgrade.isEnabled() && ( le.MouseClickLeft( buttonUpgrade.area() ) || Game::HotKeyPressEvent( Game::EVENT_UPGRADE_TROOP ) ) ) {
-                if ( UPGRADE_DISABLE & flags ) {
-                    const std::string msg( "You can't afford to upgrade your troops!" );
-                    if ( Dialog::YES == Dialog::ResourceInfo( "", msg, troop.GetUpgradeCost(), Dialog::OK ) ) {
-                        result = Dialog::UPGRADE;
-                        break;
-                    }
-                }
-                else {
-                    const std::string msg = _( "Your troops can be upgraded, but it will cost you dearly. Do you wish to upgrade them?" );
-
-                    if ( Dialog::YES == Dialog::ResourceInfo( "", msg, troop.GetUpgradeCost(), Dialog::YES | Dialog::NO ) ) {
-                        result = Dialog::UPGRADE;
-                        break;
-                    }
+                if ( Dialog::YES == Dialog::TroopUpgrade( troop, UPGRADE_DISABLE & flags ) ) {
+                    result = Dialog::UPGRADE;
+                    break;
                 }
             }
             // dismiss

--- a/src/fheroes2/gui/interface_itemsbar.h
+++ b/src/fheroes2/gui/interface_itemsbar.h
@@ -55,7 +55,7 @@ namespace Interface
         virtual void RedrawBackground( const fheroes2::Rect &, fheroes2::Image & ) = 0;
         virtual void RedrawItem( Item &, const fheroes2::Rect &, fheroes2::Image & ) = 0;
 
-        virtual bool ActionBarLeftMouseSingleClick( Item & )
+        virtual bool ActionBarLeftMouseSingleClick( const fheroes2::Point &, Item &, const fheroes2::Rect & )
         {
             return false;
         }
@@ -65,7 +65,7 @@ namespace Interface
             return false;
         }
 
-        virtual bool ActionBarCursor( Item & )
+        virtual bool ActionBarCursor( const fheroes2::Point &, Item &, const fheroes2::Rect & )
         {
             return false;
         }
@@ -201,15 +201,15 @@ namespace Interface
             RedrawItem( **it, pos, dstsf );
         }
 
-        virtual bool ActionCursorItemIter( const fheroes2::Point &, ItemIterPos iterPos )
+        virtual bool ActionCursorItemIter( const fheroes2::Point & cursor, ItemIterPos iterPos )
         {
             if ( iterPos.first != GetEndItemIter() ) {
                 LocalEvent & le = LocalEvent::Get();
 
-                if ( ActionBarCursor( **iterPos.first ) )
+                if ( ActionBarCursor( cursor, **iterPos.first, iterPos.second ) )
                     return true;
                 else if ( le.MouseClickLeft( iterPos.second ) )
-                    return ActionBarLeftMouseSingleClick( **iterPos.first );
+                    return ActionBarLeftMouseSingleClick( cursor, **iterPos.first, iterPos.second );
                 else if ( le.MousePressRight( iterPos.second ) )
                     return ActionBarRightMouseHold( **iterPos.first );
             }
@@ -293,7 +293,7 @@ namespace Interface
             // Do nothing.
         }
 
-        bool ActionBarCursor( Item & ) override
+        bool ActionBarCursor( const fheroes2::Point &, Item &, const fheroes2::Rect & ) override
         {
             return false;
         }
@@ -308,14 +308,14 @@ namespace Interface
             return false;
         }
 
-        bool ActionBarLeftMouseSingleClick( Item & ) override
+        bool ActionBarLeftMouseSingleClick( const fheroes2::Point &, Item &, const fheroes2::Rect & ) override
         {
             return false;
         }
 
-        virtual bool ActionBarLeftMouseDoubleClick( Item & item )
+        virtual bool ActionBarLeftMouseDoubleClick( const fheroes2::Point & cursor, Item & item, const fheroes2::Rect & pos )
         {
-            return ActionBarLeftMouseSingleClick( item );
+            return ActionBarLeftMouseSingleClick( cursor, item, pos );
         }
 
         virtual bool ActionBarLeftMouseRelease( Item & )
@@ -463,20 +463,20 @@ namespace Interface
             return false;
         }
 
-        bool ActionCursorItemIter( const fheroes2::Point &, ItemIterPos iterPos ) override
+        bool ActionCursorItemIter( const fheroes2::Point & cursor, ItemIterPos iterPos ) override
         {
             if ( iterPos.first != ItemsBar<Item>::GetEndItemIter() ) {
                 LocalEvent & le = LocalEvent::Get();
 
-                if ( ActionBarCursor( **iterPos.first ) ) {
+                if ( ActionBarCursor( cursor, **iterPos.first, iterPos.second ) ) {
                     return true;
                 }
                 else if ( le.MouseClickLeft( iterPos.second ) ) {
                     if ( iterPos.first == GetCurItemIter() ) {
-                        return ActionBarLeftMouseDoubleClick( **iterPos.first );
+                        return ActionBarLeftMouseDoubleClick( cursor, **iterPos.first, iterPos.second );
                     }
                     else {
-                        if ( ActionBarLeftMouseSingleClick( **iterPos.first ) )
+                        if ( ActionBarLeftMouseSingleClick( cursor, **iterPos.first, iterPos.second ) )
                             curItemPos = iterPos;
                         else
                             ResetSelected();

--- a/src/fheroes2/gui/skill_bar.cpp
+++ b/src/fheroes2/gui/skill_bar.cpp
@@ -145,7 +145,7 @@ void PrimarySkillsBar::RedrawItem( int & skill, const fheroes2::Rect & pos, fher
     }
 }
 
-bool PrimarySkillsBar::ActionBarLeftMouseSingleClick( int & skill )
+bool PrimarySkillsBar::ActionBarLeftMouseSingleClick( const fheroes2::Point &, int & skill, const fheroes2::Rect & )
 {
     if ( Skill::Primary::UNKNOWN != skill ) {
         Dialog::Message( Skill::Primary::String( skill ), Skill::Primary::StringDescription( skill, _hero ), Font::BIG, Dialog::OK );
@@ -165,7 +165,7 @@ bool PrimarySkillsBar::ActionBarRightMouseHold( int & skill )
     return false;
 }
 
-bool PrimarySkillsBar::ActionBarCursor( int & skill )
+bool PrimarySkillsBar::ActionBarCursor( const fheroes2::Point &, int & skill, const fheroes2::Rect & )
 {
     if ( Skill::Primary::UNKNOWN != skill ) {
         msg = _( "View %{skill} Info" );
@@ -228,7 +228,7 @@ void SecondarySkillsBar::RedrawItem( Skill::Secondary & skill, const fheroes2::R
     }
 }
 
-bool SecondarySkillsBar::ActionBarLeftMouseSingleClick( Skill::Secondary & skill )
+bool SecondarySkillsBar::ActionBarLeftMouseSingleClick( const fheroes2::Point &, Skill::Secondary & skill, const fheroes2::Rect & )
 {
     if ( skill.isValid() ) {
         Dialog::SecondarySkillInfo( skill, _hero, true );
@@ -259,7 +259,7 @@ bool SecondarySkillsBar::ActionBarRightMouseHold( Skill::Secondary & skill )
     return false;
 }
 
-bool SecondarySkillsBar::ActionBarCursor( Skill::Secondary & skill )
+bool SecondarySkillsBar::ActionBarCursor( const fheroes2::Point &, Skill::Secondary & skill, const fheroes2::Rect & )
 {
     if ( skill.isValid() ) {
         msg = _( "View %{skill} Info" );

--- a/src/fheroes2/gui/skill_bar.h
+++ b/src/fheroes2/gui/skill_bar.h
@@ -37,9 +37,9 @@ public:
     void RedrawBackground( const fheroes2::Rect &, fheroes2::Image & ) override;
     void RedrawItem( int &, const fheroes2::Rect &, fheroes2::Image & ) override;
 
-    bool ActionBarLeftMouseSingleClick( int & skill ) override;
+    bool ActionBarLeftMouseSingleClick( const fheroes2::Point &, int & skill, const fheroes2::Rect & ) override;
     bool ActionBarRightMouseHold( int & skill ) override;
-    bool ActionBarCursor( int & skill ) override;
+    bool ActionBarCursor( const fheroes2::Point &, int & skill, const fheroes2::Rect & ) override;
 
     bool QueueEventProcessing( std::string * = nullptr );
 
@@ -60,9 +60,9 @@ public:
     void RedrawBackground( const fheroes2::Rect &, fheroes2::Image & ) override;
     void RedrawItem( Skill::Secondary &, const fheroes2::Rect &, fheroes2::Image & ) override;
 
-    bool ActionBarLeftMouseSingleClick( Skill::Secondary & skill ) override;
+    bool ActionBarLeftMouseSingleClick( const fheroes2::Point &, Skill::Secondary & skill, const fheroes2::Rect & ) override;
     bool ActionBarRightMouseHold( Skill::Secondary & skill ) override;
-    bool ActionBarCursor( Skill::Secondary & skill ) override;
+    bool ActionBarCursor( const fheroes2::Point &, Skill::Secondary & skill, const fheroes2::Rect & ) override;
 
     bool QueueEventProcessing( std::string * = nullptr );
 

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -931,7 +931,7 @@ void ArtifactsBar::RedrawItem( Artifact & art, const fheroes2::Rect & pos, bool 
     }
 }
 
-bool ArtifactsBar::ActionBarLeftMouseSingleClick( Artifact & art )
+bool ArtifactsBar::ActionBarLeftMouseSingleClick( const fheroes2::Point &, Artifact & art, const fheroes2::Rect & )
 {
     if ( isMagicBook( art ) ) {
         const bool isMbSelected = ( !isSelected() || isMagicBook( *GetSelectedItem() ) );
@@ -978,7 +978,7 @@ bool ArtifactsBar::ActionBarLeftMouseSingleClick( Artifact & art )
     return true;
 }
 
-bool ArtifactsBar::ActionBarLeftMouseDoubleClick( Artifact & art )
+bool ArtifactsBar::ActionBarLeftMouseDoubleClick( const fheroes2::Point &, Artifact & art, const fheroes2::Rect & )
 {
     if ( art.GetID() == Artifact::SPELL_SCROLL && Settings::Get().ExtHeroAllowTranscribingScroll() && !read_only && _hero->CanTranscribeScroll( art ) ) {
         Spell spell = art.GetSpell();
@@ -1047,7 +1047,7 @@ bool ArtifactsBar::ActionBarLeftMouseSingleClick( Artifact & art1, Artifact & ar
     return false;
 }
 
-bool ArtifactsBar::ActionBarCursor( Artifact & art )
+bool ArtifactsBar::ActionBarCursor( const fheroes2::Point &, Artifact & art, const fheroes2::Rect & )
 {
     if ( isSelected() ) {
         const Artifact * art2 = GetSelectedItem();

--- a/src/fheroes2/resource/artifact.h
+++ b/src/fheroes2/resource/artifact.h
@@ -248,15 +248,15 @@ public:
     void ResetSelected( void );
     void Redraw( fheroes2::Image & dstsf = fheroes2::Display::instance() );
 
-    bool ActionBarLeftMouseSingleClick( Artifact & artifact ) override;
+    bool ActionBarLeftMouseSingleClick( const fheroes2::Point &, Artifact & artifact, const fheroes2::Rect & ) override;
     bool ActionBarLeftMouseSingleClick( Artifact & artifact1, Artifact & artifact2 ) override;
-    bool ActionBarLeftMouseDoubleClick( Artifact & artifact ) override;
+    bool ActionBarLeftMouseDoubleClick( const fheroes2::Point &, Artifact & artifact, const fheroes2::Rect & ) override;
     bool ActionBarRightMouseHold( Artifact & artifact ) override;
 
     bool QueueEventProcessing( std::string * = nullptr );
     bool QueueEventProcessing( ArtifactsBar &, std::string * = nullptr );
 
-    bool ActionBarCursor( Artifact & ) override;
+    bool ActionBarCursor( const fheroes2::Point &, Artifact &, const fheroes2::Rect & ) override;
     bool ActionBarCursor( Artifact &, Artifact & ) override;
 
 protected:


### PR DESCRIPTION
If an army troop is located in a town that provides a possibility to upgrade
them, display a quick upgrade button on the troop sprite.  Clicking the button
invokes the upgrade troop dialog directly.