### PR TITLE
Fix AI behavior during siege

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -88,7 +88,7 @@ namespace AI
             MeleeAttackOutcome current;
             current.positionValue = Board::GetCell( cell )->GetQuality();
             current.attackValue = Board::OptimalAttackValue( attacker, defender, cell );
-            current.canAttackImmediately = Board::CanAttackUnitFromCell( attacker, defender, cell );
+            current.canAttackImmediately = Board::CanAttackUnitFromPosition( attacker, defender, cell );
 
             // Pick target if either position has improved or unit is higher value at the same position quality
             if ( IsOutcomeImproved( current, bestOutcome ) ) {
@@ -262,7 +262,7 @@ namespace AI
                     actions.emplace_back( MSG_BATTLE_MOVE, currentUnit.GetUID(), reachableCell );
 
                 // Attack only if target unit is reachable and can be attacked
-                if ( target.unit && Board::CanAttackUnitFromCell( currentUnit, *target.unit, reachableCell ) ) {
+                if ( target.unit && Board::CanAttackUnitFromPosition( currentUnit, *target.unit, reachableCell ) ) {
                     actions.emplace_back( MSG_BATTLE_ATTACK, currentUnit.GetUID(), target.unit->GetUID(),
                                           Board::OptimalAttackTarget( currentUnit, *target.unit, reachableCell ), 0 );
                     DEBUG_LOG( DBG_BATTLE, DBG_INFO,
@@ -700,7 +700,7 @@ namespace AI
                             actions.emplace_back( MSG_BATTLE_MOVE, currentUnitUID, reachableCell );
 
                         // Attack only if target unit is reachable and can be attacked
-                        if ( Board::CanAttackUnitFromCell( currentUnit, *targetUnit, reachableCell ) )
+                        if ( Board::CanAttackUnitFromPosition( currentUnit, *targetUnit, reachableCell ) )
                             actions.emplace_back( MSG_BATTLE_ATTACK, currentUnitUID, targetUnitUID, targetUnitHead, 0 );
 
                         break;

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -261,8 +261,7 @@ namespace AI
                 if ( currentUnit.GetHeadIndex() != reachableCell )
                     actions.emplace_back( MSG_BATTLE_MOVE, currentUnit.GetUID(), reachableCell );
 
-                // Attack only if target unit is reachable and can be attacked
-                if ( target.unit && Board::CanAttackUnitFromPosition( currentUnit, *target.unit, reachableCell ) ) {
+                if ( target.unit ) {
                     actions.emplace_back( MSG_BATTLE_ATTACK, currentUnit.GetUID(), target.unit->GetUID(),
                                           Board::OptimalAttackTarget( currentUnit, *target.unit, reachableCell ), 0 );
                     DEBUG_LOG( DBG_BATTLE, DBG_INFO,

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -619,7 +619,7 @@ namespace AI
             const uint32_t distanceToUnit = ( move.first != -1 ) ? move.second : Board::GetDistance( myHeadIndex, unitToDefend->GetHeadIndex() );
             const double archerValue = unitToDefend->GetStrength() - distanceToUnit * defenceDistanceModifier;
 
-            DEBUG_LOG( DBG_AI, DBG_TRACE, unitToDefend->GetName() << " archer value " << archerValue << " distance: " << distanceToUnit );
+            DEBUG_LOG( DBG_BATTLE, DBG_TRACE, unitToDefend->GetName() << " archer value " << archerValue << " distance: " << distanceToUnit );
 
             // 3. Search for enemy units blocking our archers within range move
             const Indexes & adjacentEnemies = Board::GetAdjacentEnemies( *unitToDefend );

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -53,7 +53,7 @@ namespace AI
         int32_t fromIndex = -1;
         double attackValue = -INT32_MAX;
         double positionValue = -INT32_MAX;
-        bool canReach = false;
+        bool canAttackImmediately = false;
     };
 
     bool ValueHasImproved( double primary, double primaryMax, double secondary, double secondaryMax )
@@ -67,8 +67,8 @@ namespace AI
         // Primary - Enemy is within move range and can be attacked this turn
         // Secondary - Postion quality (to attack from, or protect friendly unit)
         // Tertiary - Enemy unit threat
-        return ( newOutcome.canReach && !previous.canReach )
-               || ( newOutcome.canReach == previous.canReach
+        return ( newOutcome.canAttackImmediately && !previous.canAttackImmediately )
+               || ( newOutcome.canAttackImmediately == previous.canAttackImmediately
                     && ValueHasImproved( newOutcome.positionValue, previous.positionValue, newOutcome.attackValue, previous.attackValue ) );
     }
 
@@ -88,14 +88,14 @@ namespace AI
             MeleeAttackOutcome current;
             current.positionValue = Board::GetCell( cell )->GetQuality();
             current.attackValue = Board::OptimalAttackValue( attacker, defender, cell );
-            current.canReach = Board::CanAttackUnitFromCell( attacker, defender, cell );
+            current.canAttackImmediately = Board::CanAttackUnitFromCell( attacker, defender, cell );
 
             // Pick target if either position has improved or unit is higher value at the same position quality
             if ( IsOutcomeImproved( current, bestOutcome ) ) {
                 bestOutcome.attackValue = current.attackValue;
                 bestOutcome.positionValue = current.positionValue;
                 bestOutcome.fromIndex = cell;
-                bestOutcome.canReach = current.canReach;
+                bestOutcome.canAttackImmediately = current.canAttackImmediately;
             }
         }
         return bestOutcome;
@@ -512,7 +512,7 @@ namespace AI
         for ( const Unit * enemy : enemies ) {
             const MeleeAttackOutcome & outcome = BestAttackOutcome( arena, currentUnit, *enemy );
 
-            if ( outcome.canReach && ValueHasImproved( outcome.positionValue, attackPositionValue, outcome.attackValue, attackHighestValue ) ) {
+            if ( outcome.canAttackImmediately && ValueHasImproved( outcome.positionValue, attackPositionValue, outcome.attackValue, attackHighestValue ) ) {
                 attackHighestValue = outcome.attackValue;
                 attackPositionValue = outcome.positionValue;
                 target.cell = outcome.fromIndex;
@@ -602,8 +602,8 @@ namespace AI
                 attackOption.positionValue = outcome.positionValue;
                 target.cell = outcome.fromIndex;
 
-                if ( outcome.canReach ) {
-                    attackOption.canReach = true;
+                if ( outcome.canAttackImmediately ) {
+                    attackOption.canAttackImmediately = true;
                     target.unit = enemy;
                 }
             }
@@ -641,8 +641,8 @@ namespace AI
                     protectOption.positionValue = archerValue;
                     target.cell = outcome.fromIndex;
 
-                    if ( outcome.canReach ) {
-                        protectOption.canReach = true;
+                    if ( outcome.canAttackImmediately ) {
+                        protectOption.canAttackImmediately = true;
                         target.unit = enemy;
                     }
                     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, " - Target selected " << enemy->GetName() << " cell " << target.cell << " archer value " << archerValue );

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -599,12 +599,9 @@ namespace AI
             if ( IsOutcomeImproved( outcome, attackOption ) ) {
                 attackOption.attackValue = outcome.attackValue;
                 attackOption.positionValue = outcome.positionValue;
+                attackOption.canAttackImmediately = outcome.canAttackImmediately;
                 target.cell = outcome.fromIndex;
-
-                if ( outcome.canAttackImmediately ) {
-                    attackOption.canAttackImmediately = true;
-                    target.unit = enemy;
-                }
+                target.unit = outcome.canAttackImmediately ? enemy : nullptr;
             }
         }
 
@@ -638,12 +635,10 @@ namespace AI
                 if ( IsOutcomeImproved( outcome, protectOption ) ) {
                     protectOption.attackValue = outcome.attackValue;
                     protectOption.positionValue = archerValue;
+                    protectOption.canAttackImmediately = outcome.canAttackImmediately;
                     target.cell = outcome.fromIndex;
+                    target.unit = outcome.canAttackImmediately ? enemy : nullptr;
 
-                    if ( outcome.canAttackImmediately ) {
-                        protectOption.canAttackImmediately = true;
-                        target.unit = enemy;
-                    }
                     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, " - Target selected " << enemy->GetName() << " cell " << target.cell << " archer value " << archerValue );
                 }
             }

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -34,7 +34,6 @@
 #include "settings.h"
 #include "speed.h"
 
-#include <array>
 #include <cassert>
 #include <cmath>
 #include <cstdint>
@@ -77,8 +76,6 @@ namespace AI
     {
         MeleeAttackOutcome bestOutcome;
 
-        const uint32_t currentUnitMoveRange = attacker.GetMoveRange();
-
         Indexes around = Board::GetAroundIndexes( defender );
         // Shuffle to make equal quality moves a bit unpredictable
         Rand::Shuffle( around );
@@ -91,7 +88,7 @@ namespace AI
             MeleeAttackOutcome current;
             current.positionValue = Board::GetCell( cell )->GetQuality();
             current.attackValue = Board::OptimalAttackValue( attacker, defender, cell );
-            current.canReach = arena.CalculateMoveDistance( cell ) <= currentUnitMoveRange;
+            current.canReach = Board::CanAttackUnitFromCell( attacker, defender, cell );
 
             // Pick target if either position has improved or unit is higher value at the same position quality
             if ( IsOutcomeImproved( current, bestOutcome ) ) {
@@ -160,91 +157,6 @@ namespace AI
             }
         }
         return targetCell;
-    }
-
-    int32_t FindNearestReachableCell( const int32_t target, const Unit & currentUnit )
-    {
-        const Cell * targetCell = Board::GetCell( target );
-        assert( targetCell != nullptr );
-
-        // Target cell is already reachable
-        if ( targetCell->isReachableForHead() ) {
-            return Board::FixupTargetCellForUnit( currentUnit, target );
-        }
-
-        int32_t nearest = -1;
-        uint32_t nearestDistance = UINT32_MAX;
-
-        // Search for the nearest reachable cell
-        for ( const Cell & cell : *Arena::GetBoard() ) {
-            if ( cell.isReachableForHead() ) {
-                const uint32_t distance = Board::GetDistance( target, cell.GetIndex() );
-
-                if ( distance < nearestDistance ) {
-                    nearest = cell.GetIndex();
-                    nearestDistance = distance;
-                }
-            }
-        }
-
-        return Board::FixupTargetCellForUnit( currentUnit, nearest );
-    }
-
-    bool CanAttackUnitFromCell( const Unit & attacker, const Unit * target, const int32_t from )
-    {
-        int32_t headIndex = -1;
-        int32_t tailIndex = -1;
-
-        // Get the actual position of the attacker before attacking
-        if ( attacker.isWide() ) {
-            const int tailDirection = attacker.isReflect() ? RIGHT : LEFT;
-
-            if ( Board::isValidDirection( from, tailDirection ) ) {
-                const Cell * tailCell = Board::GetCell( Board::GetIndexDirection( from, tailDirection ) );
-
-                if ( tailCell != nullptr && tailCell->isReachableForTail() && ( tailCell->GetUnit() == nullptr || tailCell->GetUnit() == &attacker ) ) {
-                    headIndex = from;
-                    tailIndex = tailCell->GetIndex();
-                }
-            }
-
-            if ( headIndex == -1 || tailIndex == -1 ) {
-                // Try opposite direction
-                const int headDirection = attacker.isReflect() ? LEFT : RIGHT;
-
-                if ( Board::isValidDirection( from, headDirection ) ) {
-                    const Cell * headCell = Board::GetCell( Board::GetIndexDirection( from, headDirection ) );
-
-                    if ( headCell != nullptr && headCell->isReachableForHead() && ( headCell->GetUnit() == nullptr || headCell->GetUnit() == &attacker ) ) {
-                        headIndex = headCell->GetIndex();
-                        tailIndex = from;
-                    }
-                }
-            }
-        }
-        else {
-            headIndex = from;
-        }
-
-        // Check that the attacker is actually capable of attacking the target from this position
-        const std::array<int32_t, 2> indexes = { headIndex, tailIndex };
-
-        for ( const int32_t idx : indexes ) {
-            if ( idx == -1 ) {
-                continue;
-            }
-
-            for ( const int32_t aroundIdx : Board::GetAroundIndexes( idx ) ) {
-                const Cell * cell = Board::GetCell( aroundIdx );
-                assert( cell != nullptr );
-
-                if ( cell->GetUnit() == target ) {
-                    return Board::CanAttackUnitFromCell( attacker, idx );
-                }
-            }
-        }
-
-        return false;
     }
 
     void Normal::HeroesPreBattle( HeroBase & hero, bool isAttacking )
@@ -344,13 +256,13 @@ namespace AI
             DEBUG_LOG( DBG_BATTLE, DBG_INFO, "Melee phase end, targetCell is " << target.cell );
 
             if ( target.cell != -1 ) {
-                const int32_t reachableCell = FindNearestReachableCell( target.cell, currentUnit );
+                const int32_t reachableCell = Board::FindNearestReachableCell( target.cell, currentUnit );
 
                 if ( currentUnit.GetHeadIndex() != reachableCell )
                     actions.emplace_back( MSG_BATTLE_MOVE, currentUnit.GetUID(), reachableCell );
 
                 // Attack only if target unit is reachable and can be attacked
-                if ( target.unit && CanAttackUnitFromCell( currentUnit, target.unit, reachableCell ) ) {
+                if ( target.unit && Board::CanAttackUnitFromCell( currentUnit, *target.unit, reachableCell ) ) {
                     actions.emplace_back( MSG_BATTLE_ATTACK, currentUnit.GetUID(), target.unit->GetUID(),
                                           Board::OptimalAttackTarget( currentUnit, *target.unit, reachableCell ), 0 );
                     DEBUG_LOG( DBG_BATTLE, DBG_INFO,
@@ -533,7 +445,7 @@ namespace AI
                 target.cell = FindMoveToRetreat( arena.getAllAvailableMoves( currentUnit.GetMoveRange() ), currentUnit, enemies );
 
                 if ( target.cell != -1 ) {
-                    const int32_t reachableCell = FindNearestReachableCell( target.cell, currentUnit );
+                    const int32_t reachableCell = Board::FindNearestReachableCell( target.cell, currentUnit );
 
                     actions.emplace_back( MSG_BATTLE_MOVE, currentUnit.GetUID(), reachableCell );
                     DEBUG_LOG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " archer kiting enemy, moving to " << reachableCell );
@@ -780,13 +692,13 @@ namespace AI
                     }
 
                     if ( targetCell != -1 ) {
-                        const int32_t reachableCell = FindNearestReachableCell( targetCell, currentUnit );
+                        const int32_t reachableCell = Board::FindNearestReachableCell( targetCell, currentUnit );
 
                         if ( currentUnit.GetHeadIndex() != reachableCell )
                             actions.emplace_back( MSG_BATTLE_MOVE, currentUnitUID, reachableCell );
 
                         // Attack only if target unit is reachable and can be attacked
-                        if ( CanAttackUnitFromCell( currentUnit, targetUnit, reachableCell ) )
+                        if ( Board::CanAttackUnitFromCell( currentUnit, *targetUnit, reachableCell ) )
                             actions.emplace_back( MSG_BATTLE_ATTACK, currentUnitUID, targetUnitUID, targetUnitHead, 0 );
 
                         break;

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -447,7 +447,9 @@ namespace AI
                 if ( target.cell != -1 ) {
                     const int32_t reachableCell = Board::FindNearestReachableCell( target.cell, currentUnit );
 
-                    actions.emplace_back( MSG_BATTLE_MOVE, currentUnit.GetUID(), reachableCell );
+                    if ( currentUnit.GetHeadIndex() != reachableCell )
+                        actions.emplace_back( MSG_BATTLE_MOVE, currentUnit.GetUID(), reachableCell );
+
                     DEBUG_LOG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " archer kiting enemy, moving to " << reachableCell );
                 }
             }

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -227,7 +227,7 @@ void Battle::Arena::ApplyActionSpellCast( Command & cmd )
         usage_spells.Append( spell );
     }
     else {
-        DEBUG_LOG( DBG_BATTLE, DBG_INFO,
+        DEBUG_LOG( DBG_BATTLE, DBG_WARN,
                    spell.GetName() << ", "
                                    << "incorrect param" );
     }
@@ -457,7 +457,7 @@ void Battle::Arena::ApplyActionEnd( Command & cmd )
         }
     }
     else {
-        DEBUG_LOG( DBG_BATTLE, DBG_INFO,
+        DEBUG_LOG( DBG_BATTLE, DBG_WARN,
                    "incorrect param"
                        << ": "
                        << "uid: "

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -1147,7 +1147,7 @@ bool Battle::Board::CanAttackUnitFromCell( const Unit & attacker, const int32_t 
     return false;
 }
 
-bool Battle::Board::CanAttackUnitFromCell( const Unit & attacker, const Unit & target, const int32_t from )
+bool Battle::Board::CanAttackUnitFromPosition( const Unit & attacker, const Unit & target, const int32_t dst )
 {
     int32_t headIndex = -1;
     int32_t tailIndex = -1;
@@ -1156,11 +1156,11 @@ bool Battle::Board::CanAttackUnitFromCell( const Unit & attacker, const Unit & t
     if ( attacker.isWide() ) {
         const int tailDirection = attacker.isReflect() ? RIGHT : LEFT;
 
-        if ( isValidDirection( from, tailDirection ) ) {
-            const Cell * tailCell = GetCell( GetIndexDirection( from, tailDirection ) );
+        if ( isValidDirection( dst, tailDirection ) ) {
+            const Cell * tailCell = GetCell( GetIndexDirection( dst, tailDirection ) );
 
             if ( tailCell != nullptr && tailCell->isReachableForTail() && ( tailCell->GetUnit() == nullptr || tailCell->GetUnit() == &attacker ) ) {
-                headIndex = from;
+                headIndex = dst;
                 tailIndex = tailCell->GetIndex();
             }
         }
@@ -1169,18 +1169,18 @@ bool Battle::Board::CanAttackUnitFromCell( const Unit & attacker, const Unit & t
             // Try opposite direction
             const int headDirection = attacker.isReflect() ? LEFT : RIGHT;
 
-            if ( isValidDirection( from, headDirection ) ) {
-                const Cell * headCell = GetCell( GetIndexDirection( from, headDirection ) );
+            if ( isValidDirection( dst, headDirection ) ) {
+                const Cell * headCell = GetCell( GetIndexDirection( dst, headDirection ) );
 
                 if ( headCell != nullptr && headCell->isReachableForHead() && ( headCell->GetUnit() == nullptr || headCell->GetUnit() == &attacker ) ) {
                     headIndex = headCell->GetIndex();
-                    tailIndex = from;
+                    tailIndex = dst;
                 }
             }
         }
     }
     else {
-        headIndex = from;
+        headIndex = dst;
     }
 
     // Check that the attacker is actually capable of attacking the target from this position

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -1255,14 +1255,14 @@ Battle::Indexes Battle::Board::GetAdjacentEnemies( const Unit & unit )
     return result;
 }
 
-int32_t Battle::Board::FindNearestReachableCell( const int32_t target, const Unit & unit )
+int32_t Battle::Board::FindNearestReachableCell( const int32_t dst, const Unit & unit )
 {
-    const Cell * targetCell = GetCell( target );
-    assert( targetCell != nullptr );
+    const Cell * dstCell = GetCell( dst );
+    assert( dstCell != nullptr );
 
-    // Target cell is already reachable
-    if ( targetCell->isReachableForHead() ) {
-        return FixupTargetCellForUnit( unit, target );
+    // Destination cell is already reachable
+    if ( dstCell->isReachableForHead() ) {
+        return FixupDestinationCellForUnit( unit, dst );
     }
 
     int32_t nearest = -1;
@@ -1271,7 +1271,7 @@ int32_t Battle::Board::FindNearestReachableCell( const int32_t target, const Uni
     // Search for the nearest reachable cell
     for ( const Cell & cell : *Arena::GetBoard() ) {
         if ( cell.isReachableForHead() ) {
-            const uint32_t distance = GetDistance( target, cell.GetIndex() );
+            const uint32_t distance = GetDistance( dst, cell.GetIndex() );
 
             if ( distance < nearestDistance ) {
                 nearest = cell.GetIndex();
@@ -1280,10 +1280,10 @@ int32_t Battle::Board::FindNearestReachableCell( const int32_t target, const Uni
         }
     }
 
-    return FixupTargetCellForUnit( unit, nearest );
+    return FixupDestinationCellForUnit( unit, nearest );
 }
 
-int32_t Battle::Board::FixupTargetCellForUnit( const Unit & unit, const int32_t dst )
+int32_t Battle::Board::FixupDestinationCellForUnit( const Unit & unit, const int32_t dst )
 {
     // Only wide units may need this fixup
     if ( !unit.isWide() ) {

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -98,8 +98,8 @@ namespace Battle
 
         // Checks that the attacker is able (in principle) to attack from the given cell
         static bool CanAttackUnitFromCell( const Unit & attacker, const int32_t from );
-        // Checks that the attacker is able to attack the target from the given cell
-        static bool CanAttackUnitFromCell( const Unit & attacker, const Unit & target, const int32_t from );
+        // Checks that the attacker is able to attack the target from the position corresponding to the given cell
+        static bool CanAttackUnitFromPosition( const Unit & attacker, const Unit & target, const int32_t dst );
 
         static Indexes GetAdjacentEnemies( const Unit & unit );
 

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -95,9 +95,16 @@ namespace Battle
         static Indexes GetAroundIndexes( const Unit & );
         static Indexes GetMoveWideIndexes( s32, bool reflect );
         static bool isValidMirrorImageIndex( s32, const Unit * );
+
+        // Checks that the attacker is able (in principle) to attack from the given cell
         static bool CanAttackUnitFromCell( const Unit & attacker, const int32_t from );
+        // Checks that the attacker is able to attack the target from the given cell
+        static bool CanAttackUnitFromCell( const Unit & attacker, const Unit & target, const int32_t from );
 
         static Indexes GetAdjacentEnemies( const Unit & unit );
+
+        // Finds the cell nearest to the target and reachable for the unit
+        static int32_t FindNearestReachableCell( const int32_t target, const Unit & unit );
 
         // Handles the situation when the destination cell is on the border of the cell
         // space reachable for the unit and it should be the tail cell of this unit

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -103,12 +103,12 @@ namespace Battle
 
         static Indexes GetAdjacentEnemies( const Unit & unit );
 
-        // Finds the cell nearest to the target and reachable for the unit
-        static int32_t FindNearestReachableCell( const int32_t target, const Unit & unit );
+        // Finds the cell nearest to the destination cell and reachable for the unit
+        static int32_t FindNearestReachableCell( const int32_t dst, const Unit & unit );
 
         // Handles the situation when the destination cell is on the border of the cell
         // space reachable for the unit and it should be the tail cell of this unit
-        static int32_t FixupTargetCellForUnit( const Unit & unit, const int32_t dst );
+        static int32_t FixupDestinationCellForUnit( const Unit & unit, const int32_t dst );
 
     private:
         void SetCobjObject( const int icn, const int32_t dst );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2659,7 +2659,7 @@ void Battle::Interface::MouseLeftClickBoardAction( u32 themes, const Cell & cell
         switch ( themes ) {
         case Cursor::WAR_FLY:
         case Cursor::WAR_MOVE:
-            a.push_back( Command( MSG_BATTLE_MOVE, _currentUnit->GetUID(), Board::FixupTargetCellForUnit( *_currentUnit, index ) ) );
+            a.push_back( Command( MSG_BATTLE_MOVE, _currentUnit->GetUID(), Board::FixupDestinationCellForUnit( *_currentUnit, index ) ) );
             a.push_back( Command( MSG_BATTLE_END_TURN, _currentUnit->GetUID() ) );
             humanturn_exit = true;
             break;
@@ -2677,7 +2677,7 @@ void Battle::Interface::MouseLeftClickBoardAction( u32 themes, const Cell & cell
                 const s32 move = Board::GetIndexDirection( index, dir );
 
                 if ( _currentUnit->GetHeadIndex() != move )
-                    a.push_back( Command( MSG_BATTLE_MOVE, _currentUnit->GetUID(), Board::FixupTargetCellForUnit( *_currentUnit, move ) ) );
+                    a.push_back( Command( MSG_BATTLE_MOVE, _currentUnit->GetUID(), Board::FixupDestinationCellForUnit( *_currentUnit, move ) ) );
                 a.push_back( Command( MSG_BATTLE_ATTACK, _currentUnit->GetUID(), enemy->GetUID(), index, Board::GetReflectDirection( dir ) ) );
                 a.push_back( Command( MSG_BATTLE_END_TURN, _currentUnit->GetUID() ) );
                 humanturn_exit = true;

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -104,7 +104,7 @@ bool Game::Save( const std::string & fn )
     fs.setbigendian( true );
 
     if ( !fs.open( fn, "wb" ) ) {
-        DEBUG_LOG( DBG_GAME, DBG_INFO, fn << ", error open" );
+        DEBUG_LOG( DBG_GAME, DBG_WARN, fn << ", error open" );
         return false;
     }
 
@@ -139,7 +139,7 @@ fheroes2::GameMode Game::Load( const std::string & fn )
     fs.setbigendian( true );
 
     if ( !fs.open( fn, "rb" ) ) {
-        DEBUG_LOG( DBG_GAME, DBG_INFO, fn << ", error open" );
+        DEBUG_LOG( DBG_GAME, DBG_WARN, fn << ", error open" );
         return fheroes2::GameMode::CANCEL;
     }
 
@@ -152,7 +152,7 @@ fheroes2::GameMode Game::Load( const std::string & fn )
 
     // check version sav file
     if ( savid != SAV2ID2 && savid != SAV2ID3 ) {
-        DEBUG_LOG( DBG_GAME, DBG_INFO, fn << ", incorrect SAV2ID" );
+        DEBUG_LOG( DBG_GAME, DBG_WARN, fn << ", incorrect SAV2ID" );
         return fheroes2::GameMode::CANCEL;
     }
 
@@ -184,7 +184,7 @@ fheroes2::GameMode Game::Load( const std::string & fn )
     fz.setbigendian( true );
 
     if ( !fz.read( fn, offset ) ) {
-        DEBUG_LOG( DBG_GAME, DBG_INFO, ", uncompress: error" );
+        DEBUG_LOG( DBG_GAME, DBG_WARN, ", uncompress: error" );
         return fheroes2::GameMode::CANCEL;
     }
 
@@ -271,11 +271,13 @@ fheroes2::GameMode Game::Load( const std::string & fn )
 
 bool Game::LoadSAV2FileInfo( const std::string & fn, Maps::FileInfo & finfo )
 {
+    DEBUG_LOG( DBG_GAME, DBG_INFO, fn );
+
     StreamFile fs;
     fs.setbigendian( true );
 
     if ( !fs.open( fn, "rb" ) ) {
-        DEBUG_LOG( DBG_GAME, DBG_INFO, fn << ", error open" );
+        DEBUG_LOG( DBG_GAME, DBG_WARN, fn << ", error open" );
         return false;
     }
 
@@ -285,7 +287,7 @@ bool Game::LoadSAV2FileInfo( const std::string & fn, Maps::FileInfo & finfo )
 
     // check version sav file
     if ( savid != SAV2ID2 && savid != SAV2ID3 ) {
-        DEBUG_LOG( DBG_GAME, DBG_INFO, fn << ", incorrect SAV2ID" );
+        DEBUG_LOG( DBG_GAME, DBG_WARN, fn << ", incorrect SAV2ID" );
         return false;
     }
 

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -70,7 +70,7 @@ void Kingdom::Init( int clr )
         UpdateStartingResource();
     }
     else {
-        DEBUG_LOG( DBG_GAME, DBG_INFO, "Kingdom: unknown player: " << Color::String( color ) << "(" << static_cast<int>( color ) << ")" );
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "Kingdom: unknown player: " << Color::String( color ) << "(" << static_cast<int>( color ) << ")" );
     }
 }
 


### PR DESCRIPTION
I've seen similar AI behavior during a siege many times:

<img width="639" alt="Paladin in the moat" src="https://user-images.githubusercontent.com/32623900/130690992-3687636f-d42a-477a-833f-fdb165a82672.png">

If I press the "AUTO" button now, Paladin does this:

<img width="638" alt="Paladin fail" src="https://user-images.githubusercontent.com/32623900/130691132-8580108e-cb56-446b-a4ca-e1c0332229f3.png">

Utter failure. My initial (not a very thorough) investigation showed that this is not a pathfinding problem, but now I did a proper investigation and it showed that I was wrong - AI pathfinder really believes that Paladin is not able to reach Unicorn here(?!). So I replaced AI pathfinder by my pathfinder from `Battle::Board` (for the purpose of making decisions on the reachability of units for attack), and...

<img width="640" alt="Paladin success" src="https://user-images.githubusercontent.com/32623900/130691696-668a5462-0e96-41ad-a864-20408529c864.png">

The pathetic unicorns were defeated, as they should have been.

Hi @ihhub regarding your sentence from #4064:

> And that's why our AI is weak!

**_That's why it is weak_** - at least, one of the real reasons. Pathfinding issues will ruin even the most sophisticated battle planner.

Also I fixed an issue when archers are trying to "kite" melee attackers by "moving" to the very same position that they currently occupy which is expressed in errors like this:

```
23:57:39: [DBG_ENGINE]	main:  Free Heroes of Might and Magic II, version: 0.9.6
23:57:57: [DBG_BATTLE]	GetPath:  Path is not found for Unit: [ 11 Druids, Red, pos: 54, -1, reflect ], destination: (head cell ID: 54, tail cell ID: -1)
23:57:57: [DBG_BATTLE]	ApplyActionMove:  path empty, Unit: [ 11 Druids, Red, pos: 54, -1, reflect ] to dst: 54
23:57:57: [DBG_BATTLE]	GetPath:  Path is not found for Unit: [ 11 Druids, Red, pos: 54, -1, reflect ], destination: (head cell ID: 54, tail cell ID: -1)
23:57:57: [DBG_BATTLE]	ApplyActionMove:  path empty, Unit: [ 11 Druids, Red, pos: 54, -1, reflect ] to dst: 54
```

P.S. However, I'm not sure about the latter issue with kiting - is it worth to fix it, may be just print warning as it happens now... The thing is, AI battle planner recommends the unit to kite to the definitely unreachable cell - unreachable to such an extent that nearest reachable cell turns out to be the current unit cell (I suppose that recommended cell is very close to the current one and reachable only in such a way that unit should leave the castle first and then return back to the castle via a moat, which is impossible during the same turn, that's why such an effect). In theory, this should not happen at all... On the other hand, of course, AI pathfinder is good at the strategic level (like an owl from a famous joke), but not at the tactical level, so it is natural that pathfinder from `Battle::Board` is used to correct it at the tactical level.