### PR TITLE
Update French translation 

### DIFF
--- a/files/lang/fr.po
+++ b/files/lang/fr.po
@@ -479,7 +479,7 @@ msgid "The %{name} are paralyzed by the Cyclopes!"
 msgstr "%{name} sont paralysés par les Cyclopes !"
 
 msgid "The Archmagi dispel all good spells on your %{name}!"
-msgstr "Les Archi-mages dissipent tous les bons sorts sur vos %{name} !"
+msgstr "Les Grands mages dissipent tous les bons sorts sur vos %{name} !"
 
 msgid "Bad luck descends on the %{attacker}"
 msgstr "La malchance s'abat sur les %{attacker}."
@@ -6095,10 +6095,10 @@ msgid "Magi"
 msgstr "Mages"
 
 msgid "Archmage"
-msgstr "Archimage"
+msgstr "Grand mage"
 
 msgid "Archmagi"
-msgstr "Archimages"
+msgstr "Grands mages"
 
 msgid "Giant"
 msgstr "Géant"


### PR DESCRIPTION
Archi-mage -> Grand mage

---------
The lasts few points to discuss/decide about to finish this translation:
Lasts points to discuss/decide about:

**subis -> infligés**
Do we really replace "subis (taken)" by "infligé (inflicted)" everywhere?
I don't think it's an improvement.

**"Archmagi"** was "Grand mage" in the French original H2. But "Archi-mage" sounds more used in recent years than it was in 1996. :D What name to stick with? (My opinion is to stick with original H2: "Grand mage")

Campaigns texts: full review needed.
1034: "ou vos rivaux seront sûrement arrivés à la source avant vous."
This sentence sounds wrong. (and any sentence translated with "surely" words too.)
"Dwarfbane" -> No better translation in french?
"Iles Pirates" -> "Îles Pirates" (once the replace i -> î in the "makefile" is working)

"Astrologers proclaim Week of the %{name}."
FR: "proclament la Semaine %{name}." -> need to add: "de le/de la/du" depending on which creature it is.


> 3286 msgid "%{object} robbed" (as in "Graveyard robbed", "Shipwreck robbed", etc.) and translated to
> "%{object} cambriolé".

I really want to add "déjà": "déjà cambriolé", as for "already visited" is "déjà visité". Without "déjà", it sounds as an adjective, and thus seems to be the part of the name.