### PR TITLE
Clang-Tidy: disable cppcoreguidelines-owning-memory

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,7 @@ Checks: >-
   -cppcoreguidelines-avoid-non-const-global-variables,
   -cppcoreguidelines-init-variables,
   -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-owning-memory,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-constant-array-index,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,


### PR DESCRIPTION
Upon request from @ihhub in #4072.

Pros: we are not going to use `gsl` in this project;
Cons: this warning at least makes you think about using `unique_ptr` or `shared_ptr`. However, this warning is useless when you touching the old code that uses raw pointers.