### PR TITLE
Simplify passability logic a bit, clarify function descriptions

### DIFF
--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -1116,8 +1116,7 @@ bool Battle::Board::CanAttackUnitFromCell( const Unit & attacker, const int32_t 
     assert( fromCell != nullptr );
 
     // Target unit cannot be attacked if out of reach
-    if ( !fromCell->isReachableForHead() && ( !attacker.isWide() || !fromCell->isReachableForTail() ) && from != attacker.GetHeadIndex()
-         && ( !attacker.isWide() || from != attacker.GetTailIndex() ) ) {
+    if ( !fromCell->isReachableForHead() && ( !attacker.isWide() || !fromCell->isReachableForTail() ) ) {
         return false;
     }
 

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -1110,13 +1110,13 @@ bool Battle::Board::isValidMirrorImageIndex( s32 index, const Unit * troop )
     return true;
 }
 
-bool Battle::Board::CanAttackUnitFromCell( const Unit & attacker, const int32_t from )
+bool Battle::Board::CanAttackUnitFromCell( const Unit & currentUnit, const int32_t from )
 {
     const Cell * fromCell = GetCell( from );
     assert( fromCell != nullptr );
 
     // Target unit cannot be attacked if out of reach
-    if ( !fromCell->isReachableForHead() && ( !attacker.isWide() || !fromCell->isReachableForTail() ) ) {
+    if ( !fromCell->isReachableForHead() && ( !currentUnit.isWide() || !fromCell->isReachableForTail() ) ) {
         return false;
     }
 
@@ -1128,17 +1128,17 @@ bool Battle::Board::CanAttackUnitFromCell( const Unit & attacker, const int32_t 
     }
 
     // Target unit isn't attacked from the moat
-    if ( !isMoatIndex( from, attacker ) ) {
+    if ( !isMoatIndex( from, currentUnit ) ) {
         return true;
     }
 
     // The moat doesn't stop flying units
-    if ( attacker.isFlying() ) {
+    if ( currentUnit.isFlying() ) {
         return true;
     }
 
     // Attacker is already near the target
-    if ( from == attacker.GetHeadIndex() || ( attacker.isWide() && from == attacker.GetTailIndex() ) ) {
+    if ( from == currentUnit.GetHeadIndex() || ( currentUnit.isWide() && from == currentUnit.GetTailIndex() ) ) {
         return true;
     }
 
@@ -1146,10 +1146,10 @@ bool Battle::Board::CanAttackUnitFromCell( const Unit & attacker, const int32_t 
     return false;
 }
 
-bool Battle::Board::CanAttackUnitFromPosition( const Unit & attacker, const Unit & target, const int32_t dst )
+bool Battle::Board::CanAttackUnitFromPosition( const Unit & currentUnit, const Unit & target, const int32_t dst )
 {
     // Get the actual position of the attacker before attacking
-    const Position pos = Position::GetReachable( attacker, dst );
+    const Position pos = Position::GetReachable( currentUnit, dst );
 
     // Check that the attacker is actually capable of attacking the target from this position
     const std::array<const Cell *, 2> cells = { pos.GetHead(), pos.GetTail() };
@@ -1164,7 +1164,7 @@ bool Battle::Board::CanAttackUnitFromPosition( const Unit & attacker, const Unit
             assert( aroundCell != nullptr );
 
             if ( aroundCell->GetUnit() == &target ) {
-                return CanAttackUnitFromCell( attacker, cell->GetIndex() );
+                return CanAttackUnitFromCell( currentUnit, cell->GetIndex() );
             }
         }
     }
@@ -1223,11 +1223,11 @@ Battle::Indexes Battle::Board::GetAdjacentEnemies( const Unit & unit )
     return result;
 }
 
-int32_t Battle::Board::FindNearestReachableCell( const Unit & unit, const int32_t dst )
+int32_t Battle::Board::FindNearestReachableCell( const Unit & currentUnit, const int32_t dst )
 {
-    const Position dstPos = Position::GetReachable( unit, dst );
+    const Position dstPos = Position::GetReachable( currentUnit, dst );
 
-    if ( dstPos.GetHead() != nullptr && ( !unit.isWide() || dstPos.GetTail() != nullptr ) ) {
+    if ( dstPos.GetHead() != nullptr && ( !currentUnit.isWide() || dstPos.GetTail() != nullptr ) ) {
         // Destination cell is already reachable
         return dstPos.GetHead()->GetIndex();
     }
@@ -1237,9 +1237,9 @@ int32_t Battle::Board::FindNearestReachableCell( const Unit & unit, const int32_
 
     // Search for the nearest reachable cell
     for ( const Cell & cell : *Arena::GetBoard() ) {
-        const Position pos = Position::GetReachable( unit, cell.GetIndex() );
+        const Position pos = Position::GetReachable( currentUnit, cell.GetIndex() );
 
-        if ( pos.GetHead() != nullptr && ( !unit.isWide() || pos.GetTail() != nullptr ) ) {
+        if ( pos.GetHead() != nullptr && ( !currentUnit.isWide() || pos.GetTail() != nullptr ) ) {
             const uint32_t distance = GetDistance( dst, cell.GetIndex() );
 
             if ( distance < nearestDistance ) {
@@ -1252,14 +1252,14 @@ int32_t Battle::Board::FindNearestReachableCell( const Unit & unit, const int32_
     return nearestCell ? nearestCell->GetIndex() : -1;
 }
 
-int32_t Battle::Board::FixupDestinationCellForUnit( const Unit & unit, const int32_t dst )
+int32_t Battle::Board::FixupDestinationCell( const Unit & currentUnit, const int32_t dst )
 {
     // Only wide units may need this fixup
-    if ( !unit.isWide() ) {
+    if ( !currentUnit.isWide() ) {
         return dst;
     }
 
-    const Position pos = Position::GetReachable( unit, dst );
+    const Position pos = Position::GetReachable( currentUnit, dst );
 
     assert( pos.GetHead() != nullptr );
     assert( pos.GetTail() != nullptr );

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -96,19 +96,23 @@ namespace Battle
         static Indexes GetMoveWideIndexes( s32, bool reflect );
         static bool isValidMirrorImageIndex( s32, const Unit * );
 
-        // Checks that the attacker is able (in principle) to attack from the cell with the given index
-        static bool CanAttackUnitFromCell( const Unit & attacker, const int32_t from );
-        // Checks that the attacker is able to attack the target from the position which corresponds to the given index
-        static bool CanAttackUnitFromPosition( const Unit & attacker, const Unit & target, const int32_t dst );
+        // Checks that the current unit (to which the current passability information relates) is able (in principle)
+        // to attack from the cell with the given index
+        static bool CanAttackUnitFromCell( const Unit & currentUnit, const int32_t from );
+        // Checks that the current unit (to which the current passability information relates) is able to attack the
+        // target from the position which corresponds to the given index
+        static bool CanAttackUnitFromPosition( const Unit & currentUnit, const Unit & target, const int32_t dst );
 
         static Indexes GetAdjacentEnemies( const Unit & unit );
 
-        // Finds the cell nearest to the cell with the given index and reachable for the unit
-        static int32_t FindNearestReachableCell( const Unit & unit, const int32_t dst );
+        // Finds the cell nearest to the cell with the given index and reachable for the current unit (to which the
+        // current passability information relates)
+        static int32_t FindNearestReachableCell( const Unit & currentUnit, const int32_t dst );
 
-        // Handles the situation when the cell with the given index is specified as the target cell of the unit's movement,
-        // is located on the border of the cell space reachable for the unit and it should be the tail cell of this unit
-        static int32_t FixupDestinationCellForUnit( const Unit & unit, const int32_t dst );
+        // Handles the situation when the cell with the given index is specified as the target cell for the movement of
+        // the current unit (to which the current passability information relates), this cell is located on the border
+        // of the cell space reachable for this unit and it should be the tail cell of this unit
+        static int32_t FixupDestinationCell( const Unit & currentUnit, const int32_t dst );
 
     private:
         void SetCobjObject( const int icn, const int32_t dst );

--- a/src/fheroes2/battle/battle_cell.cpp
+++ b/src/fheroes2/battle/battle_cell.cpp
@@ -110,11 +110,11 @@ Battle::Position Battle::Position::GetCorrect( const Unit & b, s32 head )
     return result;
 }
 
-Battle::Position Battle::Position::GetReachable( const Unit & unit, const int32_t dst )
+Battle::Position Battle::Position::GetReachable( const Unit & currentUnit, const int32_t dst )
 {
     Position result;
 
-    if ( unit.isWide() ) {
+    if ( currentUnit.isWide() ) {
         auto checkCells = []( Cell * headCell, Cell * tailCell ) {
             Position res;
 
@@ -126,7 +126,7 @@ Battle::Position Battle::Position::GetReachable( const Unit & unit, const int32_
             return res;
         };
 
-        const int tailDirection = unit.isReflect() ? RIGHT : LEFT;
+        const int tailDirection = currentUnit.isReflect() ? RIGHT : LEFT;
 
         if ( Board::isValidDirection( dst, tailDirection ) ) {
             Cell * headCell = Board::GetCell( dst );
@@ -137,7 +137,7 @@ Battle::Position Battle::Position::GetReachable( const Unit & unit, const int32_
 
         if ( result.GetHead() == nullptr || result.GetTail() == nullptr ) {
             // Try opposite direction
-            const int headDirection = unit.isReflect() ? LEFT : RIGHT;
+            const int headDirection = currentUnit.isReflect() ? LEFT : RIGHT;
 
             if ( Board::isValidDirection( dst, headDirection ) ) {
                 Cell * headCell = Board::GetCell( Board::GetIndexDirection( dst, headDirection ) );

--- a/src/fheroes2/battle/battle_cell.cpp
+++ b/src/fheroes2/battle/battle_cell.cpp
@@ -115,11 +115,10 @@ Battle::Position Battle::Position::GetReachable( const Unit & unit, const int32_
     Position result;
 
     if ( unit.isWide() ) {
-        auto checkCells = []( const Unit & u, Cell * headCell, Cell * tailCell ) {
+        auto checkCells = []( Cell * headCell, Cell * tailCell ) {
             Position res;
 
-            if ( headCell != nullptr && headCell->isReachableForHead() && ( headCell->GetUnit() == nullptr || headCell->GetUnit() == &u ) && tailCell != nullptr
-                 && tailCell->isReachableForTail() && ( tailCell->GetUnit() == nullptr || tailCell->GetUnit() == &u ) ) {
+            if ( headCell != nullptr && headCell->isReachableForHead() && tailCell != nullptr && tailCell->isReachableForTail() ) {
                 res.first = headCell;
                 res.second = tailCell;
             }
@@ -133,7 +132,7 @@ Battle::Position Battle::Position::GetReachable( const Unit & unit, const int32_
             Cell * headCell = Board::GetCell( dst );
             Cell * tailCell = Board::GetCell( Board::GetIndexDirection( dst, tailDirection ) );
 
-            result = checkCells( unit, headCell, tailCell );
+            result = checkCells( headCell, tailCell );
         }
 
         if ( result.GetHead() == nullptr || result.GetTail() == nullptr ) {
@@ -144,14 +143,14 @@ Battle::Position Battle::Position::GetReachable( const Unit & unit, const int32_
                 Cell * headCell = Board::GetCell( Board::GetIndexDirection( dst, headDirection ) );
                 Cell * tailCell = Board::GetCell( dst );
 
-                result = checkCells( unit, headCell, tailCell );
+                result = checkCells( headCell, tailCell );
             }
         }
     }
     else {
         Cell * headCell = Board::GetCell( dst );
 
-        if ( headCell != nullptr && headCell->isReachableForHead() && ( headCell->GetUnit() == nullptr || headCell->GetUnit() == &unit ) ) {
+        if ( headCell != nullptr && headCell->isReachableForHead() ) {
             result.first = headCell;
         }
     }

--- a/src/fheroes2/battle/battle_cell.h
+++ b/src/fheroes2/battle/battle_cell.h
@@ -109,9 +109,10 @@ namespace Battle
 
         static Position GetCorrect( const Unit &, s32 );
 
-        // Returns the reachable position for the given unit which corresponds to the
-        // given index or an empty Position object if the given index is unreachable
-        static Position GetReachable( const Unit & unit, const int32_t dst );
+        // Returns the reachable position for the current unit (to which the current
+        // passability information relates) which corresponds to the given index or
+        // an empty Position object if the given index is unreachable
+        static Position GetReachable( const Unit & currentUnit, const int32_t dst );
 
         fheroes2::Rect GetRect( void ) const;
         Cell * GetHead( void );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2612,7 +2612,7 @@ void Battle::Interface::MouseLeftClickBoardAction( u32 themes, const Cell & cell
         switch ( themes ) {
         case Cursor::WAR_FLY:
         case Cursor::WAR_MOVE:
-            a.push_back( Command( MSG_BATTLE_MOVE, _currentUnit->GetUID(), Board::FixupDestinationCellForUnit( *_currentUnit, index ) ) );
+            a.push_back( Command( MSG_BATTLE_MOVE, _currentUnit->GetUID(), Board::FixupDestinationCell( *_currentUnit, index ) ) );
             a.push_back( Command( MSG_BATTLE_END_TURN, _currentUnit->GetUID() ) );
             humanturn_exit = true;
             break;
@@ -2627,7 +2627,7 @@ void Battle::Interface::MouseLeftClickBoardAction( u32 themes, const Cell & cell
             const int dir = GetDirectionFromCursorSword( themes );
 
             if ( enemy && Board::isValidDirection( index, dir ) ) {
-                const int32_t move = Board::FixupDestinationCellForUnit( *_currentUnit, Board::GetIndexDirection( index, dir ) );
+                const int32_t move = Board::FixupDestinationCell( *_currentUnit, Board::GetIndexDirection( index, dir ) );
 
                 if ( _currentUnit->GetHeadIndex() != move ) {
                     a.push_back( Command( MSG_BATTLE_MOVE, _currentUnit->GetUID(), move ) );


### PR DESCRIPTION
* Simplify logic a bit: cells occupied by the unit are always reachable for the same unit, if cell is occupied by another unit, it is unreachable anyway;
* Make it clear that passability-related functions will work only with "current unit" - the unit for which cell passability information is currently calculated.