### PR TITLE
Heroes::inCastle(): respect GUARDIAN mode

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -812,7 +812,7 @@ namespace AI
 
     void Normal::HeroesActionComplete( Heroes & hero )
     {
-        Castle * castle = hero.inCastle();
+        Castle * castle = hero.inCastleMutable();
         if ( castle ) {
             ReinforceHeroInCastle( hero, *castle, castle->GetKingdom().GetFunds() );
         }

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -791,13 +791,41 @@ void Heroes::RescanPath( void )
 /* if hero in castle */
 const Castle * Heroes::inCastle( void ) const
 {
-    const Castle * castle = Color::NONE != GetColor() ? world.getCastleEntrance( GetCenter() ) : nullptr;
+    if ( GetColor() == Color::NONE ) {
+        return nullptr;
+    }
+
+    if ( Modes( Heroes::GUARDIAN ) ) {
+        const fheroes2::Point & heroPoint = GetCenter();
+        const fheroes2::Point castlePoint( heroPoint.x, heroPoint.y + 1 );
+
+        const Castle * castle = world.getCastleEntrance( castlePoint );
+
+        return castle && castle->GetHeroes() == this ? castle : nullptr;
+    }
+
+    const Castle * castle = world.getCastleEntrance( GetCenter() );
+
     return castle && castle->GetHeroes() == this ? castle : nullptr;
 }
 
 Castle * Heroes::inCastle( void )
 {
-    Castle * castle = Color::NONE != GetColor() ? world.getCastleEntrance( GetCenter() ) : nullptr;
+    if ( GetColor() == Color::NONE ) {
+        return nullptr;
+    }
+
+    if ( Modes( Heroes::GUARDIAN ) ) {
+        const fheroes2::Point & heroPoint = GetCenter();
+        const fheroes2::Point castlePoint( heroPoint.x, heroPoint.y + 1 );
+
+        Castle * castle = world.getCastleEntrance( castlePoint );
+
+        return castle && castle->GetHeroes() == this ? castle : nullptr;
+    }
+
+    Castle * castle = world.getCastleEntrance( GetCenter() );
+
     return castle && castle->GetHeroes() == this ? castle : nullptr;
 }
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -789,27 +789,12 @@ void Heroes::RescanPath( void )
 }
 
 /* if hero in castle */
-const Castle * Heroes::inCastle( void ) const
+const Castle * Heroes::inCastle() const
 {
-    if ( GetColor() == Color::NONE ) {
-        return nullptr;
-    }
-
-    if ( Modes( Heroes::GUARDIAN ) ) {
-        const fheroes2::Point & heroPoint = GetCenter();
-        const fheroes2::Point castlePoint( heroPoint.x, heroPoint.y + 1 );
-
-        const Castle * castle = world.getCastleEntrance( castlePoint );
-
-        return castle && castle->GetHeroes() == this ? castle : nullptr;
-    }
-
-    const Castle * castle = world.getCastleEntrance( GetCenter() );
-
-    return castle && castle->GetHeroes() == this ? castle : nullptr;
+    return inCastleMutable();
 }
 
-Castle * Heroes::inCastle( void )
+Castle * Heroes::inCastleMutable() const
 {
     if ( GetColor() == Color::NONE ) {
         return nullptr;

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -197,7 +197,7 @@ public:
     void SetFreeman( int reason );
 
     const Castle * inCastle() const override;
-    Castle * inCastle();
+    Castle * inCastleMutable() const;
 
     void LoadFromMP2( s32 map_index, int cl, int rc, StreamBuf );
     void PostLoad( void );


### PR DESCRIPTION
This fixes an ability to upgrade units in castle guardian armies (and, may be, something else).