### PR TITLE
Remove redundant member initializations

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -28,3 +28,5 @@ CheckOptions:
     value: true
   - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
     value: true
+  - key: readability-redundant-member-init.IgnoreBaseInCopyConstructors
+    value: true

--- a/src/fheroes2/campaign/campaign_data.cpp
+++ b/src/fheroes2/campaign/campaign_data.cpp
@@ -493,8 +493,6 @@ namespace Campaign
 {
     CampaignData::CampaignData()
         : _campaignID( 0 )
-        , _campaignDescription()
-        , _scenarios()
     {}
 
     const std::vector<int> & CampaignData::getScenariosAfter( const int scenarioID ) const

--- a/src/fheroes2/campaign/campaign_savedata.cpp
+++ b/src/fheroes2/campaign/campaign_savedata.cpp
@@ -28,12 +28,9 @@
 namespace Campaign
 {
     CampaignSaveData::CampaignSaveData()
-        : _finishedMaps()
-        , _obtainedCampaignAwards()
-        , _currentScenarioID( 0 )
+        : _currentScenarioID( 0 )
         , _campaignID( 0 )
         , _daysPassed( 0 )
-        , _currentScenarioBonus()
     {}
 
     CampaignSaveData & Campaign::CampaignSaveData::Get()

--- a/src/fheroes2/gui/ui_button.cpp
+++ b/src/fheroes2/gui/ui_button.cpp
@@ -205,7 +205,6 @@ namespace fheroes2
 
     ButtonSprite::ButtonSprite( int32_t offsetX, int32_t offsetY )
         : ButtonBase( offsetX, offsetY )
-        , _disabled()
     {}
 
     ButtonSprite::ButtonSprite( int32_t offsetX, int32_t offsetY, const Sprite & released, const Sprite & pressed, const Sprite & disabled )

--- a/src/fheroes2/heroes/heroes_base.cpp
+++ b/src/fheroes2/heroes/heroes_base.cpp
@@ -142,7 +142,6 @@ int ArtifactsModifiersLuck( const HeroBase & base, std::string * strs )
 HeroBase::HeroBase( int type, int race )
     : magic_point( 0 )
     , move_point( 0 )
-    , spell_book()
 {
     bag_artifacts.assign( HEROESMAXARTIFACT, Artifact::UNKNOWN );
     LoadDefaults( type, race );
@@ -184,7 +183,6 @@ void HeroBase::LoadDefaults( int type, int race )
 HeroBase::HeroBase()
     : magic_point( 0 )
     , move_point( 0 )
-    , spell_book()
 {}
 
 bool HeroBase::isCaptain( void ) const


### PR DESCRIPTION
Fix clang-tidy [readability-redundant-member-init](https://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-member-init.html) warnings.
Disable check for unnecessary base class initializations within copy constructors since gcc generates warning if it removed.