### PR TITLE
Cleanup GetKingdomStartingResources

### DIFF
--- a/src/fheroes2/game/game_static.cpp
+++ b/src/fheroes2/game/game_static.cpp
@@ -130,13 +130,6 @@ namespace GameStatic
 
     // kingdom
     u8 kingdom_max_heroes = 8;
-    cost_t kingdom_starting_resource[] = {{10000, 30, 10, 30, 10, 10, 10},
-                                          {7500, 20, 5, 20, 5, 5, 5},
-                                          {5000, 10, 2, 10, 2, 2, 2},
-                                          {2500, 5, 0, 5, 0, 0, 0},
-                                          {0, 0, 0, 0, 0, 0, 0},
-                                          // ai resource
-                                          {10000, 30, 10, 30, 10, 10, 10}};
 
     // castle
     u8 castle_grown_well = 2;

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -69,7 +69,7 @@ void Kingdom::Init( int clr )
     if ( Color::ALL & color ) {
         heroes.reserve( GetMaxHeroes() );
         castles.reserve( 15 );
-        resource = _getKingdomStartingResources( Game::getDifficulty(), isControlAI() );
+        resource = _getKingdomStartingResources( Game::getDifficulty() );
     }
     else {
         DEBUG_LOG( DBG_GAME, DBG_WARN, "Kingdom: unknown player: " << Color::String( color ) << "(" << static_cast<int>( color ) << ")" );
@@ -878,7 +878,7 @@ bool Kingdom::IsTileVisibleFromCrystalBall( const int32_t dest ) const
     return false;
 }
 
-cost_t Kingdom::_getKingdomStartingResources( const int difficulty, const bool isAIKingdom )
+cost_t Kingdom::_getKingdomStartingResources( const int difficulty )
 {
     static cost_t startingResourcesSet[] = {{10000, 30, 10, 30, 10, 10, 10},
                                             {7500, 20, 5, 20, 5, 5, 5},
@@ -888,7 +888,7 @@ cost_t Kingdom::_getKingdomStartingResources( const int difficulty, const bool i
                                             // ai resource
                                             {10000, 30, 10, 30, 10, 10, 10}};
 
-    if ( isAIKingdom )
+    if ( isControlAI() )
         return startingResourcesSet[5];
 
     switch ( difficulty ) {

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -74,7 +74,7 @@ void Kingdom::Init( int clr )
     if ( Color::ALL & color ) {
         heroes.reserve( GetMaxHeroes() );
         castles.reserve( 15 );
-        resource = GetKingdomStartingResources( Game::getDifficulty(), isControlAI() );
+        resource = _getKingdomStartingResources( Game::getDifficulty(), isControlAI() );
     }
     else {
         DEBUG_LOG( DBG_GAME, DBG_WARN, "Kingdom: unknown player: " << Color::String( color ) << "(" << static_cast<int>( color ) << ")" );
@@ -883,7 +883,7 @@ bool Kingdom::IsTileVisibleFromCrystalBall( const int32_t dest ) const
     return false;
 }
 
-cost_t Kingdom::GetKingdomStartingResources( int difficulty, bool isAIKingdom )
+cost_t Kingdom::_getKingdomStartingResources( const int difficulty, const bool isAIKingdom )
 {
     if ( isAIKingdom )
         return GameStatic::kingdom_starting_resource[5];

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -46,6 +46,11 @@
 
 #include <cassert>
 
+namespace GameStatic
+{
+    extern cost_t kingdom_starting_resource[];
+}
+
 bool HeroesStrongestArmy( const Heroes * h1, const Heroes * h2 )
 {
     return h1 && h2 && h2->GetArmy().isStrongerThan( h1->GetArmy() );
@@ -886,33 +891,25 @@ bool Kingdom::IsTileVisibleFromCrystalBall( const int32_t dest ) const
 
 cost_t Kingdom::GetKingdomStartingResources( int difficulty, bool isAIKingdom )
 {
-    static cost_t startingResourcesSet[] = {{10000, 30, 10, 30, 10, 10, 10},
-                                            {7500, 20, 5, 20, 5, 5, 5},
-                                            {5000, 10, 2, 10, 2, 2, 2},
-                                            {2500, 5, 0, 5, 0, 0, 0},
-                                            {0, 0, 0, 0, 0, 0, 0},
-                                            // ai resource
-                                            {10000, 30, 10, 30, 10, 10, 10}};
-
     if ( isAIKingdom )
-        return startingResourcesSet[5];
+        return GameStatic::kingdom_starting_resource[5];
 
     switch ( difficulty ) {
     case Difficulty::EASY:
-        return startingResourcesSet[0];
+        return GameStatic::kingdom_starting_resource[0];
     case Difficulty::NORMAL:
-        return startingResourcesSet[1];
+        return GameStatic::kingdom_starting_resource[1];
     case Difficulty::HARD:
-        return startingResourcesSet[2];
+        return GameStatic::kingdom_starting_resource[2];
     case Difficulty::EXPERT:
-        return startingResourcesSet[3];
+        return GameStatic::kingdom_starting_resource[3];
     case Difficulty::IMPOSSIBLE:
-        return startingResourcesSet[4];
+        return GameStatic::kingdom_starting_resource[4];
     default:
         break;
     }
 
-    return startingResourcesSet[1];
+    return GameStatic::kingdom_starting_resource[1];
 }
 
 StreamBase & operator<<( StreamBase & msg, const Kingdom & kingdom )

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -74,8 +74,7 @@ void Kingdom::Init( int clr )
     if ( Color::ALL & color ) {
         heroes.reserve( GetMaxHeroes() );
         castles.reserve( 15 );
-
-        UpdateStartingResource();
+        resource = GetKingdomStartingResources( Game::getDifficulty(), isControlAI() );
     }
     else {
         DEBUG_LOG( DBG_GAME, DBG_WARN, "Kingdom: unknown player: " << Color::String( color ) << "(" << static_cast<int>( color ) << ")" );
@@ -115,11 +114,6 @@ int Kingdom::GetColor( void ) const
 int Kingdom::GetRace( void ) const
 {
     return Players::GetPlayerRace( GetColor() );
-}
-
-void Kingdom::UpdateStartingResource( void )
-{
-    resource = GetKingdomStartingResources( Game::getDifficulty(), isControlAI() );
 }
 
 bool Kingdom::isLoss( void ) const

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -46,11 +46,6 @@
 
 #include <cassert>
 
-namespace GameStatic
-{
-    extern cost_t kingdom_starting_resource[];
-}
-
 bool HeroesStrongestArmy( const Heroes * h1, const Heroes * h2 )
 {
     return h1 && h2 && h2->GetArmy().isStrongerThan( h1->GetArmy() );
@@ -885,25 +880,33 @@ bool Kingdom::IsTileVisibleFromCrystalBall( const int32_t dest ) const
 
 cost_t Kingdom::_getKingdomStartingResources( const int difficulty, const bool isAIKingdom )
 {
+    static cost_t startingResourcesSet[] = {{10000, 30, 10, 30, 10, 10, 10},
+                                            {7500, 20, 5, 20, 5, 5, 5},
+                                            {5000, 10, 2, 10, 2, 2, 2},
+                                            {2500, 5, 0, 5, 0, 0, 0},
+                                            {0, 0, 0, 0, 0, 0, 0},
+                                            // ai resource
+                                            {10000, 30, 10, 30, 10, 10, 10}};
+
     if ( isAIKingdom )
-        return GameStatic::kingdom_starting_resource[5];
+        return startingResourcesSet[5];
 
     switch ( difficulty ) {
     case Difficulty::EASY:
-        return GameStatic::kingdom_starting_resource[0];
+        return startingResourcesSet[0];
     case Difficulty::NORMAL:
-        return GameStatic::kingdom_starting_resource[1];
+        return startingResourcesSet[1];
     case Difficulty::HARD:
-        return GameStatic::kingdom_starting_resource[2];
+        return startingResourcesSet[2];
     case Difficulty::EXPERT:
-        return GameStatic::kingdom_starting_resource[3];
+        return startingResourcesSet[3];
     case Difficulty::IMPOSSIBLE:
-        return GameStatic::kingdom_starting_resource[4];
+        return startingResourcesSet[4];
     default:
         break;
     }
 
-    return GameStatic::kingdom_starting_resource[1];
+    return startingResourcesSet[1];
 }
 
 StreamBase & operator<<( StreamBase & msg, const Kingdom & kingdom )

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -162,7 +162,7 @@ public:
     static u32 GetMaxHeroes( void );
 
 private:
-    static cost_t _getKingdomStartingResources( const int difficulty, const bool isAIKingdom );
+    cost_t _getKingdomStartingResources( const int difficulty );
 
     friend StreamBase & operator<<( StreamBase &, const Kingdom & );
     friend StreamBase & operator>>( StreamBase &, Kingdom & );

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -160,9 +160,10 @@ public:
     bool IsTileVisibleFromCrystalBall( const int32_t dest ) const;
 
     static u32 GetMaxHeroes( void );
-    static cost_t GetKingdomStartingResources( int difficulty, bool isAIKingdom );
 
 private:
+    static cost_t _getKingdomStartingResources( const int difficulty, const bool isAIKingdom );
+
     friend StreamBase & operator<<( StreamBase &, const Kingdom & );
     friend StreamBase & operator>>( StreamBase &, Kingdom & );
 

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -65,7 +65,6 @@ public:
 
     void openOverviewDialog();
 
-    void UpdateStartingResource( void );
     bool isPlay( void ) const;
     bool isLoss( void ) const;
     bool AllowPayment( const Funds & ) const;


### PR DESCRIPTION
* Remove unused `kingdom_starting_resource` array.
* Remove intermediate redundant `UpdateStartingResource` method.
* Make `GetKingdomStartingResources` private and format according to codestyle.