### PR TITLE
Alignment fix of scenario info window

### DIFF
--- a/src/fheroes2/dialog/dialog_gameinfo.cpp
+++ b/src/fheroes2/dialog/dialog_gameinfo.cpp
@@ -45,7 +45,8 @@ void Dialog::GameInfo( void )
 
     const fheroes2::Sprite & box = fheroes2::AGG::GetICN( ICN::SCENIBKG, 0 );
 
-    fheroes2::Point pt( ( display.width() - box.width() ) / 2, ( display.height() - box.height() ) / 2 );
+    // the visual graphics of the box sprite height is 4 pixels less than given value
+    fheroes2::Point pt( ( display.width() - box.width() - BORDERWIDTH ) / 2, ( ( display.height() - box.height() + 4 ) / 2 ) );
     fheroes2::ImageRestorer back( display, pt.x, pt.y, box.width(), box.height() );
     fheroes2::Blit( box, display, pt.x, pt.y );
 

--- a/src/fheroes2/dialog/dialog_gameinfo.cpp
+++ b/src/fheroes2/dialog/dialog_gameinfo.cpp
@@ -45,7 +45,6 @@ void Dialog::GameInfo( void )
 
     const fheroes2::Sprite & box = fheroes2::AGG::GetICN( ICN::SCENIBKG, 0 );
 
-    // the visual graphics of the box sprite height is 4 pixels less than given value
     fheroes2::Point pt( ( display.width() - box.width() - BORDERWIDTH ) / 2, ( ( display.height() - box.height() + 4 ) / 2 ) );
     fheroes2::ImageRestorer back( display, pt.x, pt.y, box.width(), box.height() );
     fheroes2::Blit( box, display, pt.x, pt.y );

--- a/src/fheroes2/dialog/dialog_gameinfo.cpp
+++ b/src/fheroes2/dialog/dialog_gameinfo.cpp
@@ -45,7 +45,10 @@ void Dialog::GameInfo( void )
 
     const fheroes2::Sprite & box = fheroes2::AGG::GetICN( ICN::SCENIBKG, 0 );
 
-    fheroes2::Point pt( ( display.width() - box.width() - BORDERWIDTH ) / 2, ( ( display.height() - box.height() + 4 ) / 2 ) );
+    // This is a shadow offset from the original ICN::SCENIBKG image.
+    const fheroes2::Point shadowOffset( -16, 4 );
+
+    fheroes2::Point pt( ( display.width() - box.width() + shadowOffset.x ) / 2, ( ( display.height() - box.height() + shadowOffset.y ) / 2 ) );
     fheroes2::ImageRestorer back( display, pt.x, pt.y, box.width(), box.height() );
     fheroes2::Blit( box, display, pt.x, pt.y );
 


### PR DESCRIPTION
Fix for issue #1890 
The horizontal window alignment didn't take the border width into consideration when calculating its position.
The vertical position was misaligned due to sprite reporting a height of 476px when the actual size is 472px

![box-height](https://user-images.githubusercontent.com/8593280/131877285-60c208c5-f1d8-4472-b442-b8c1e2a500e7.png)
![actual-box-height](https://user-images.githubusercontent.com/8593280/131877621-a1a2ca45-a123-43b4-bb31-70199f4878ce.png)