### PR TITLE
Allow hero to traverse Stone Liths and Whirlpools even if he has no movement points left

### DIFF
--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -388,18 +388,12 @@ void Interface::Basic::EventDefaultAction( void )
 
     if ( hero ) {
         // 1. action object
-        if ( MP2::isActionObject( hero->GetMapsObject(), hero->isShipMaster() ) && ( !MP2::isMoveObject( hero->GetMapsObject() ) || hero->CanMove() ) ) {
-            const Maps::Tiles & tile = world.GetTiles( hero->GetIndex() );
-
+        if ( MP2::isActionObject( hero->GetMapsObject(), hero->isShipMaster() ) ) {
             hero->Action( hero->GetIndex(), true );
-            if ( MP2::OBJ_STONELITHS == tile.GetObject( false ) || MP2::OBJ_WHIRLPOOL == tile.GetObject( false ) )
-                SetRedraw( REDRAW_HEROES );
-            SetRedraw( REDRAW_GAMEAREA );
         }
     }
-    else
+    else if ( GetFocusCastle() ) {
         // 2. town dialog
-        if ( GetFocusCastle() ) {
         Game::OpenCastleDialog( *GetFocusCastle() );
     }
 }

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -1209,20 +1209,6 @@ bool MP2::isProtectedObject( const MapObjectType objectType )
     return isCaptureObject( objectType );
 }
 
-bool MP2::isMoveObject( const MapObjectType objectType )
-{
-    switch ( objectType ) {
-    case OBJ_STONELITHS:
-    case OBJ_WHIRLPOOL:
-        return true;
-
-    default:
-        break;
-    }
-
-    return false;
-}
-
 bool MP2::isAbandonedMine( const MapObjectType objectType )
 {
     return objectType == MP2::OBJN_ABANDONEDMINE || objectType == MP2::OBJ_ABANDONEDMINE;

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -587,7 +587,6 @@ namespace MP2
     bool isHeroUpgradeObject( const MapObjectType objectType );
     bool isMonsterDwelling( const MapObjectType objectType );
     bool isRemoveObject( const MapObjectType objectType );
-    bool isMoveObject( const MapObjectType objectType );
     bool isAbandonedMine( const MapObjectType objectType );
     bool isProtectedObject( const MapObjectType objectType );
 


### PR DESCRIPTION
fix #4146

Hi @Branikolog in fact, hero still has 100MP after teleporting to the Snow terrain (you can make sure of this by viewing hero's quick info), so no movement penalty is in fact applied. I suppose that hero still should be able to traverse through teleports if he has non-zero movement points, even if he is not able to make a step over the terrain on which teleport resides due to this terrain's penalty? If yes, then this PR should fix the issue. If no, then there is no issue :)