### PR TITLE
Fix black edges on view world

### DIFF
--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -395,7 +395,9 @@ ViewWorld::ZoomROIs::ZoomROIs( const ViewWorld::ZoomLevel zoomLevel, const fhero
 
 bool ViewWorld::ZoomROIs::ChangeCenter( const fheroes2::Point & centerInPixels )
 {
-    const fheroes2::Point newCenter( clamp( centerInPixels.x, 0, world.w() * TILEWIDTH ), clamp( centerInPixels.y, 0, world.h() * TILEWIDTH ) );
+    const fheroes2::Rect currentRect = GetROIinPixels();
+    const fheroes2::Point newCenter( clamp( centerInPixels.x, currentRect.width / 2, world.w() * TILEWIDTH - currentRect.width / 2 ),
+                                     clamp( centerInPixels.y, currentRect.height / 2, world.h() * TILEWIDTH - currentRect.height / 2 ) );
 
     if ( newCenter == _center ) {
         return false;

--- a/src/fheroes2/kingdom/view_world.h
+++ b/src/fheroes2/kingdom/view_world.h
@@ -70,6 +70,8 @@ public:
         fheroes2::Rect _roiForZoomLevels[4];
 
     private:
+        void updateZoomLevels();
+        bool updateCenter();
         bool changeZoom( const ZoomLevel newLevel );
     };
 };


### PR DESCRIPTION
Fix #3157

This prevents displaying beyond the edges of the map, ~but seems to introduce a problem when changing position by clicking on the world: it might jump around unpredictably.  Not sure why that would be the case.~

In general with big screen resolution and a small map we will display back area around the map anyway, so maybe it's not critical to try to fix it at all.