### PR TITLE
audio_music: log the reason why mixer could not be created

### DIFF
--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -378,7 +378,12 @@ void Music::Play( const std::vector<uint8_t> & v, const bool loop )
 #endif
         SDL_FreeRW( rwops );
 
-        PlayMusic( mix, loop );
+        if ( !mix ) {
+            ERROR_LOG( Mix_GetError() );
+        }
+        else {
+            PlayMusic( mix, loop );
+        }
     }
 }
 


### PR DESCRIPTION
On NixOS SDL2_mixer was not configured fully against timidity,
but it was not immediately clear:
    10:02:38: [ERROR]       PlayMusic:  music parameter was NULL

With the patch error reporting is more straightforward:
    10:03:45: [ERROR]       Play:  Couldn't open /etc/timidity/freepats.cfg

The change makes error handling in
    void Music::Play( const std::vector<uint8_t> & v, const bool loop )
    void Music::Play( const std::string & file, const bool loop )
identical.