### PR TITLE
Troops split logic change

### DIFF
--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -62,6 +62,11 @@ namespace
             troopFrom.SetCount( 1 );
             troopTarget.Set( troopFrom.GetMonster(), 1 );
         }
+        else if ( isSameTroopType && troopFrom.isValid() && troopFrom.GetCount() == 1 && troopTarget.isValid() && troopTarget.GetCount() == 1 ) {
+            // a player splits the same troop type and both count one; move a monster from the source slot to the target slot.
+            troopFrom.Reset();
+            troopTarget.SetCount( 2 );
+        }
         else {
             uint32_t freeSlots = static_cast<uint32_t>( 1 + armyTarget->Size() - armyTarget->GetCount() );
 

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -69,22 +69,9 @@ namespace
                 ++freeSlots;
 
             const uint32_t maxCount = saveLastTroop ? troopFrom.GetCount() - 1 : troopFrom.GetCount();
-            uint32_t redistributeCount = troopFrom.GetCount() / 2;
-            const uint32_t halfOverallCount = overallCount / 2;
+            uint32_t redistributeCount = isSameTroopType ? 1 : troopFrom.GetCount() / 2;
 
-            if ( isSameTroopType ) {
-                // if the same type, then display how many troops should be moved from one slot to another (if redistributeCount > 1 then the Min button is displayed by
-                // default)
-                redistributeCount = halfOverallCount > troopTarget.GetCount() ? halfOverallCount - troopTarget.GetCount() : troopTarget.GetCount() - halfOverallCount;
-
-                // possible when merging two slots of the same unit and there is a count difference, ie. 2 troops + 14 troops
-                if ( redistributeCount > maxCount )
-                    redistributeCount = maxCount;
-            }
-
-            // if splitting to the same troop type, use this bool to turn on fast split option at the beginning of the dialog
-            bool useFastSplit = true;
-
+            bool useFastSplit = !isSameTroopType;
             const uint32_t slots = Dialog::ArmySplitTroop( ( freeSlots > overallCount ? overallCount : freeSlots ), maxCount, redistributeCount, useFastSplit );
 
             if ( slots < 2 || slots > 6 )

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -70,7 +70,7 @@ namespace
             const uint32_t maxCount = saveLastTroop ? troopFrom.GetCount() - 1 : troopFrom.GetCount();
             uint32_t redistributeCount = troopFrom.GetCount() / 2;
 
-            // if same type, then display how amny troops should be moved from one slot to another (if redistributeCount > 1 then the Min button is displayed by default)
+            // if the same type, then display how many troops should be moved from one slot to another (if redistributeCount > 1 then the Min button is displayed by default)
             if ( isSameTroopType ) {
                 redistributeCount
                     = ( overallCount / 2 ) > troopTarget.GetCount() ? ( overallCount / 2 ) - troopTarget.GetCount() : troopTarget.GetCount() - ( overallCount / 2 );

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -70,7 +70,8 @@ namespace
             const uint32_t maxCount = saveLastTroop ? troopFrom.GetCount() - 1 : troopFrom.GetCount();
             uint32_t redistributeCount = troopFrom.GetCount() / 2;
 
-            // if the same type, then display how many troops should be moved from one slot to another (if redistributeCount > 1 then the Min button is displayed by default)
+            // if the same type, then display how many troops should be moved from one slot to another (if redistributeCount > 1 then the Min button is displayed by
+            // default)
             if ( isSameTroopType ) {
                 redistributeCount
                     = ( overallCount / 2 ) > troopTarget.GetCount() ? ( overallCount / 2 ) - troopTarget.GetCount() : troopTarget.GetCount() - ( overallCount / 2 );

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -42,6 +42,7 @@ namespace
         const Army * armyFrom = troopFrom.GetArmy();
         const bool saveLastTroop = armyFrom->SaveLastTroop() && armyFrom != armyTarget;
         const bool isSameTroopType = troopTarget.isValid() && troopFrom.GetID() == troopTarget.GetID();
+        const bool isTargetEmpty = troopTarget.isEmpty();
         const uint32_t overallCount = isSameTroopType ? troopFrom.GetCount() + troopTarget.GetCount() : troopFrom.GetCount();
 
         assert( overallCount > 0 );
@@ -64,10 +65,10 @@ namespace
                 ++freeSlots;
 
             const uint32_t maxCount = saveLastTroop ? troopFrom.GetCount() - 1 : troopFrom.GetCount();
-            uint32_t redistributeCount = isSameTroopType ? 1 : troopFrom.GetCount() / 2;
+            uint32_t redistributeCount = (isSameTroopType || isTargetEmpty) ? 1 : troopFrom.GetCount() / 2;
 
-            // if splitting to the same troop type, use this bool to turn off fast split option at the beginning of the dialog
-            bool useFastSplit = !isSameTroopType;
+            // if splitting to the same troop type, use this bool to turn on fast split option at the beginning of the dialog
+            bool useFastSplit = isSameTroopType && !isTargetEmpty;
             const uint32_t slots = Dialog::ArmySplitTroop( ( freeSlots > overallCount ? overallCount : freeSlots ), maxCount, redistributeCount, useFastSplit );
 
             if ( slots < 2 || slots > 6 )

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -64,11 +64,29 @@ namespace
             if ( isSameTroopType )
                 ++freeSlots;
 
-            const uint32_t maxCount = saveLastTroop ? troopFrom.GetCount() - 1 : troopFrom.GetCount();
-            uint32_t redistributeCount = ( isSameTroopType || isTargetEmpty ) ? 1 : troopFrom.GetCount() / 2;
+            const uint32_t maxCount = saveLastTroop ? troopFrom.GetCount() : troopFrom.GetCount() - 1;
 
-            // if splitting to the same troop type, use this bool to turn on fast split option at the beginning of the dialog
-            bool useFastSplit = isSameTroopType && !isTargetEmpty;
+            // by default, the game proposes the fast split option
+            bool useFastSplit = true;
+
+            // if splitting troops and the destination slot contains the same troop type, then we want to divide the sum of all troops from both slots
+            // the default redistribute value represents how many troops should be moved to achieve equal slots
+            uint32_t redistributeCount = 1;
+
+            if ( useFastSplit ) {
+                if ( isSameTroopType ) {
+                    redistributeCount
+                        = ( overallCount / 2 ) > troopTarget.GetCount() ? ( overallCount / 2 ) - troopTarget.GetCount() : troopTarget.GetCount() - ( overallCount / 2 );
+
+                    // possible when merging two slots of the same unit and there is a count difference, ie. 2 Titan + 14 Titans
+                    if ( redistributeCount > maxCount )
+                        redistributeCount = maxCount;
+                }
+                else {
+                    redistributeCount = troopFrom.GetCount() / 2;
+                }
+            }
+
             const uint32_t slots = Dialog::ArmySplitTroop( ( freeSlots > overallCount ? overallCount : freeSlots ), maxCount, redistributeCount, useFastSplit );
 
             if ( slots < 2 || slots > 6 )

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -57,34 +57,31 @@ namespace
 
             Army::SwapTroops( troopFrom, troopTarget );
         }
+        else if ( !troopTarget.isValid() && troopFrom.GetCount() == 2 ) {
+            troopFrom.SetCount( 1 );
+            troopTarget.Set( troopFrom.GetMonster(), 1 );
+        }
         else {
             uint32_t freeSlots = static_cast<uint32_t>( 1 + armyTarget->Size() - armyTarget->GetCount() );
 
             if ( isSameTroopType )
                 ++freeSlots;
 
-            const uint32_t maxCount = saveLastTroop ? troopFrom.GetCount() : troopFrom.GetCount() - 1;
+            const uint32_t maxCount = saveLastTroop ? troopFrom.GetCount() - 1 : troopFrom.GetCount();
+            uint32_t redistributeCount = troopFrom.GetCount() / 2;
 
-            // by default, the game proposes the fast split option
-            bool useFastSplit = true;
+            // if same type, then display how amny troops should be moved from one slot to another (if redistributeCount > 1 then the Min button is displayed by default)
+            if ( isSameTroopType ) {
+                redistributeCount
+                    = ( overallCount / 2 ) > troopTarget.GetCount() ? ( overallCount / 2 ) - troopTarget.GetCount() : troopTarget.GetCount() - ( overallCount / 2 );
 
-            // if splitting troops and the destination slot contains the same troop type, then we want to divide the sum of all troops from both slots
-            // the default redistribute value represents how many troops should be moved to achieve equal slots
-            uint32_t redistributeCount = 1;
-
-            if ( useFastSplit ) {
-                if ( isSameTroopType ) {
-                    redistributeCount
-                        = ( overallCount / 2 ) > troopTarget.GetCount() ? ( overallCount / 2 ) - troopTarget.GetCount() : troopTarget.GetCount() - ( overallCount / 2 );
-
-                    // possible when merging two slots of the same unit and there is a count difference, ie. 2 Titan + 14 Titans
-                    if ( redistributeCount > maxCount )
-                        redistributeCount = maxCount;
-                }
-                else {
-                    redistributeCount = troopFrom.GetCount() / 2;
-                }
+                // possible when merging two slots of the same unit and there is a count difference, ie. 2 Titan + 14 Titans
+                if ( redistributeCount > maxCount )
+                    redistributeCount = maxCount;
             }
+
+            // if splitting to the same troop type, use this bool to turn on fast split option at the beginning of the dialog
+            bool useFastSplit = true;
 
             const uint32_t slots = Dialog::ArmySplitTroop( ( freeSlots > overallCount ? overallCount : freeSlots ), maxCount, redistributeCount, useFastSplit );
 

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -58,6 +58,7 @@ namespace
             Army::SwapTroops( troopFrom, troopTarget );
         }
         else if ( !troopTarget.isValid() && troopFrom.GetCount() == 2 ) {
+            // a player splits a slot with two monsters into an empty slot; move one monster into the source slot to the target slot.
             troopFrom.SetCount( 1 );
             troopTarget.Set( troopFrom.GetMonster(), 1 );
         }
@@ -69,14 +70,14 @@ namespace
 
             const uint32_t maxCount = saveLastTroop ? troopFrom.GetCount() - 1 : troopFrom.GetCount();
             uint32_t redistributeCount = troopFrom.GetCount() / 2;
+            const uint32_t halfOverallCount = overallCount / 2;
 
-            // if the same type, then display how many troops should be moved from one slot to another (if redistributeCount > 1 then the Min button is displayed by
-            // default)
             if ( isSameTroopType ) {
-                redistributeCount
-                    = ( overallCount / 2 ) > troopTarget.GetCount() ? ( overallCount / 2 ) - troopTarget.GetCount() : troopTarget.GetCount() - ( overallCount / 2 );
+                // if the same type, then display how many troops should be moved from one slot to another (if redistributeCount > 1 then the Min button is displayed by
+                // default)
+                redistributeCount = halfOverallCount > troopTarget.GetCount() ? halfOverallCount - troopTarget.GetCount() : troopTarget.GetCount() - halfOverallCount;
 
-                // possible when merging two slots of the same unit and there is a count difference, ie. 2 Titan + 14 Titans
+                // possible when merging two slots of the same unit and there is a count difference, ie. 2 troops + 14 troops
                 if ( redistributeCount > maxCount )
                     redistributeCount = maxCount;
             }

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -42,7 +42,6 @@ namespace
         const Army * armyFrom = troopFrom.GetArmy();
         const bool saveLastTroop = armyFrom->SaveLastTroop() && armyFrom != armyTarget;
         const bool isSameTroopType = troopTarget.isValid() && troopFrom.GetID() == troopTarget.GetID();
-        const bool isTargetEmpty = troopTarget.isEmpty();
         const uint32_t overallCount = isSameTroopType ? troopFrom.GetCount() + troopTarget.GetCount() : troopFrom.GetCount();
 
         assert( overallCount > 0 );

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -65,7 +65,7 @@ namespace
                 ++freeSlots;
 
             const uint32_t maxCount = saveLastTroop ? troopFrom.GetCount() - 1 : troopFrom.GetCount();
-            uint32_t redistributeCount = (isSameTroopType || isTargetEmpty) ? 1 : troopFrom.GetCount() / 2;
+            uint32_t redistributeCount = ( isSameTroopType || isTargetEmpty ) ? 1 : troopFrom.GetCount() / 2;
 
             // if splitting to the same troop type, use this bool to turn on fast split option at the beginning of the dialog
             bool useFastSplit = isSameTroopType && !isTargetEmpty;

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -434,7 +434,7 @@ int Dialog::ArmySplitTroop( uint32_t freeSlots, const uint32_t redistributeMax, 
             }
 
         if ( redraw_count ) {
-            SwitchMaxMinButtons( buttonMin, buttonMax, redistributeCount, min );
+            SwitchMaxMinButtons( buttonMin, buttonMax, sel.getCur(), min );
             if ( !ssp.empty() )
                 ssp.hide();
             sel.Redraw();

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -38,17 +38,17 @@
 
 namespace
 {
-    void SwitchMaxMinButtons( fheroes2::ButtonBase & minButton, fheroes2::ButtonBase & maxButton, uint32_t currentValue, uint32_t maximumValue )
+    void SwitchMaxMinButtons( fheroes2::ButtonBase & minButton, fheroes2::ButtonBase & maxButton, uint32_t currentValue, uint32_t minimumValue )
     {
-        const bool isMaxValue = ( currentValue >= maximumValue );
+        const bool isMinValue = ( currentValue <= minimumValue );
 
-        if ( isMaxValue ) {
-            minButton.show();
-            maxButton.hide();
-        }
-        else {
+        if ( isMinValue ) {
             minButton.hide();
             maxButton.show();
+        }
+        else {
+            minButton.show();
+            maxButton.hide();
         }
 
         minButton.draw();
@@ -389,7 +389,7 @@ int Dialog::ArmySplitTroop( uint32_t freeSlots, const uint32_t redistributeMax, 
     fheroes2::Button buttonMin( minMaxButtonOffset.x, minMaxButtonOffset.y, isEvilInterface ? ICN::UNIFORM_EVIL_MIN_BUTTON : ICN::UNIFORM_GOOD_MIN_BUTTON, 0, 1 );
 
     const fheroes2::Rect buttonArea( 5, 0, 61, 25 );
-    SwitchMaxMinButtons( buttonMin, buttonMax, redistributeCount, redistributeMax );
+    SwitchMaxMinButtons( buttonMin, buttonMax, redistributeCount, min );
 
     LocalEvent & le = LocalEvent::Get();
 
@@ -434,7 +434,7 @@ int Dialog::ArmySplitTroop( uint32_t freeSlots, const uint32_t redistributeMax, 
             }
 
         if ( redraw_count ) {
-            SwitchMaxMinButtons( buttonMin, buttonMax, redistributeCount, redistributeMax );
+            SwitchMaxMinButtons( buttonMin, buttonMax, redistributeCount, min );
             if ( !ssp.empty() )
                 ssp.hide();
             sel.Redraw();


### PR DESCRIPTION
Edit: the implemented algorithm is described in [the following comment](https://github.com/ihhub/fheroes2/pull/4211#issuecomment-965673032). 

-----
The army split logic after this change:

Case#1 splitting a troop into an empty slot -> the fhereoes2 moves a troop into the destination slot
(no change here)

Case#2 splitting troops into an empty slot -> by default, the fheroes2 proposes to split one troop into the destination slot (the main idea of the issue)
(before the change, the fheroes2 proposed "fast split" (divides troops equally into both slots)

Case#3 splitting troops into the same troop type -> by default system proposes "fast split" (divides troops equally into both slots)
(before the change, the fheroes2 moved one troop from the source slot to the destination slot)

The rest remains unchanged.

My recommendation: the designer should review the whole logic here. I.e. "fast split" is an awesome option, however, it is a bit blurry due to the UI redistribute number is displayed as enabled. (imho when a player uses "fast split", the number of troops to move should be disabled; also, for example, I can see two options here: "fast split troops equally into all available slots"; "fast split one troop into all empty slots").

Fixes #776