### PR TITLE
Fix an empty list of heroes in the Kingdom Overview after the dismissal or loss of a hero

### DIFF
--- a/src/fheroes2/gui/interface_list.h
+++ b/src/fheroes2/gui/interface_list.h
@@ -266,11 +266,6 @@ namespace Interface
         // Move visible area to the position with given element ID being on the top of the list.
         void setTopVisibleItem( const int topId )
         {
-            if ( topId < 0 || static_cast<size_t>( topId ) >= content->size() ) {
-                // Invalid ID.
-                return;
-            }
-
             Verify();
 
             if ( !IsValid() ) {
@@ -278,7 +273,7 @@ namespace Interface
                 return;
             }
 
-            _topId = topId;
+            _topId = std::max( 0, std::min( topId, _size() - maxItems ) );
 
             UpdateScrollbarRange();
             _scrollbar.moveToIndex( _topId );

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -56,7 +56,7 @@ Kingdom::Kingdom()
     , _lastBattleWinHeroID( 0 )
     , lost_town_days( 0 )
     , visited_tents_colors( 0 )
-    , _topItemInKingdomView( 0 )
+    , _topItemInKingdomView( -1 )
 {
     heroes_cond_loss.reserve( 4 );
 }
@@ -926,7 +926,7 @@ StreamBase & operator>>( StreamBase & msg, Kingdom & kingdom )
         msg >> kingdom._topItemInKingdomView;
     }
     else {
-        kingdom._topItemInKingdomView = 0;
+        kingdom._topItemInKingdomView = -1;
     }
 
     return msg;

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -677,7 +677,6 @@ void Kingdom::openOverviewDialog()
         buttonCastle.press();
         buttonHeroes.release();
 
-        assert( _topItemInKingdomView >= 0 );
         listCastles.setTopVisibleItem( _topItemInKingdomView );
 
         listStats = &listCastles;
@@ -687,7 +686,6 @@ void Kingdom::openOverviewDialog()
         buttonHeroes.press();
         buttonCastle.release();
 
-        assert( _topItemInKingdomView >= 0 );
         listHeroes.setTopVisibleItem( _topItemInKingdomView );
 
         listStats = &listHeroes;


### PR DESCRIPTION
fix #4238

Also fix a crash due to a failed assertion when trying to view the Kingdom Overview for the second time after viewing an empty list of heroes or castles.