### PR TITLE
Changed shipwreck message

### DIFF
--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1516,17 +1516,17 @@ void ActionToPoorMoraleObject( Heroes & hero, const MP2::MapObjectType objectTyp
     switch ( objectType ) {
     case MP2::OBJ_GRAVEYARD:
         ask = _( "You tentatively approach the burial ground of ancient warriors. Do you want to search the graves?" );
-        msg = _( "Upon defeating the Zombies you spend several hours searching the graves and find nothing. Such a despicable act reduces your army's morale." );
+        msg = _( "You spend several hours searching the graves and find nothing. Such a despicable act reduces your army's morale." );
         win = _( "Upon defeating the Zombies you search the graves and find something!" );
         break;
     case MP2::OBJ_SHIPWRECK:
         ask = _( "The rotting hulk of a great pirate ship creaks eerily as it is pushed against the rocks. Do you wish to search the shipwreck?" );
-        msg = _( "Upon defeating the Ghosts you spend several hours sifting through the debris and find nothing. Such a despicable act reduces your army's morale." );
+        msg = _( "You spend several hours sifting through the debris and find nothing. Such a despicable act reduces your army's morale." );
         win = _( "Upon defeating the Ghosts you sift through the debris and find something!" );
         break;
     case MP2::OBJ_DERELICTSHIP:
         ask = _( "The rotting hulk of a great pirate ship creaks eerily as it is pushed against the rocks. Do you wish to search the ship?" );
-        msg = _( "Upon defeating the Skeletons you spend several hours sifting through the debris and find nothing. Such a despicable act reduces your army's morale." );
+        msg = _( "You spend several hours sifting through the debris and find nothing. Such a despicable act reduces your army's morale." );
         win = _( "Upon defeating the Skeletons you sift through the debris and find something!" );
         break;
     default:


### PR DESCRIPTION
Fix #4246 

Removed "Upon defeating the ghosts" from the message and also change the other messages that were similar.