### PR TITLE
Fix Resurrection spell regression

### DIFF
--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -64,7 +64,7 @@ namespace Battle
         }
 
     private:
-        uint32_t _id{ 0 };
+        uint32_t _id{ 1 };
     };
 
     class Arena


### PR DESCRIPTION
This is how it looks before the change:
![image](https://user-images.githubusercontent.com/19829520/135467003-2b6600dc-5a18-4ddc-8a6c-7807dd607906.png)


relates to #4208