### PR TITLE
Minor improvements to installation scripts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ skip_commits:
   - .gitignore
   - .github/workflows/*
   - sonar-project.properties
-  - docs/*
+#  - docs/*
 
 skip_tags: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ skip_commits:
   - .gitignore
   - .github/workflows/*
   - sonar-project.properties
-#  - docs/*
+  - docs/*
 
 skip_tags: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,11 +68,9 @@ after_build:
   - cmd: xcopy /Y /s /Q "docs\README.txt" "."
   - cmd: xcopy /Y /s /Q "script\demo\download_demo_version.bat" "."
   - cmd: xcopy /Y /s /Q "script\demo\download_demo_version.ps1" "."
-  - cmd: xcopy /Y /s /Q "script\homm2\extract_homm2_dos_anim.bat" "."
-  - cmd: xcopy /Y /s /Q "script\homm2\extract_homm2_dos_anim.ps1" "."
   - cmd: xcopy /Y /s /Q "script\homm2\extract_homm2_resources.bat" "."
   - cmd: xcopy /Y /s /Q "script\homm2\extract_homm2_resources.ps1" "."
-  - cmd: 7z a build\%platform%\%configuration%\fheroes2_windows_%platform%_%deploy_conf_name%.zip download_demo_version.bat download_demo_version.ps1 extract_homm2_dos_anim.bat extract_homm2_dos_anim.ps1 extract_homm2_resources.bat extract_homm2_resources.ps1 LICENSE fheroes2.key changelog.txt README.txt files\lang\*.mo files\data\*.h2d
+  - cmd: 7z a build\%platform%\%configuration%\fheroes2_windows_%platform%_%deploy_conf_name%.zip download_demo_version.bat download_demo_version.ps1 extract_homm2_resources.bat extract_homm2_resources.ps1 LICENSE fheroes2.key changelog.txt README.txt files\lang\*.mo files\data\*.h2d
   - cmd: iscc script\windows\fheroes2.iss /DAppVersion=%APPVEYOR_BUILD_VERSION% "/DBuildDir=C:\projects\fheroes2\build\%platform%\%configuration%" /DPlatform=%platform% /DDeployConfName=%deploy_conf_name%
 
 artifacts:

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -16,10 +16,15 @@ If you do not have the original Heroes of Might and Magic II game, please run
 OS and macOS. This script will download and install all the necessary files from the
 demo version of the original Heroes of Might and Magic II game.
 
-If you have a legally purchased copy of the original game, copy the subdirectories
-'ANIM', 'DATA', 'MAPS' and 'MUSIC' (some of them may be missing depending on the
-version of the original game) from the original game directory to the fheroes2
-installation directory.
+If you have a legally purchased copy of the original game, and you are using Windows,
+please run the 'extract_homm2_resources.bat' file. This script will try to perform an
+automatic search for an existing installation of the original game and extract all the
+necessary resource files. If it can't find an existing installation, you will be prompted
+to enter the location of the original game manually.
+
+As an alternative to the previous step, you can manually copy the subdirectories 'ANIM',
+'DATA', 'MAPS' and 'MUSIC' (some of them may be missing depending on the version of the
+original game) from the original game directory to the fheroes2 installation directory.
 
 --- License ---
 This project is under GNU General Public License v2.0. Please refer to file

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -11,24 +11,24 @@ using one of the bundled scripts.
 You will need to have a demo version or the full version of Heroes of Might and
 Magic II game to be able to play.
 
-If you do not have the original Heroes of Might and Magic II game, please run
+If you do not have the original Heroes of Might and Magic II game, run the
 'download_demo_version.bat' file for Windows or 'download_demo_version.sh' for Linux
 OS and macOS. This script will download and install all the necessary files from the
 demo version of the original Heroes of Might and Magic II game.
 
 If you have a legally purchased copy of the original game, and you are using Windows,
-please run the 'extract_homm2_resources.bat' file. This script will try to perform an
-automatic search for an existing installation of the original game and extract all the
-necessary resource files. If it can't find an existing installation, you will be prompted
-to enter the location of the original game manually.
+run the 'extract_homm2_resources.bat' file. This script will try to perform an automatic
+search for an existing installation of the original game and extract all the necessary
+resource files. If it can't find an existing installation, you will be prompted to enter
+the location of the original game manually.
 
 As an alternative to the previous step, you can manually copy the subdirectories 'ANIM',
 'DATA', 'MAPS' and 'MUSIC' (some of them may be missing depending on the version of the
 original game) from the original game directory to the fheroes2 installation directory.
 
 --- License ---
-This project is under GNU General Public License v2.0. Please refer to file
-LICENSE for more details.
+This project is under GNU General Public License v2.0. Refer to file LICENSE for more
+details.
 
 --- Donation ---
 Currently we accept donations via Patreon at https://www.patreon.com/fheroes2.


### PR DESCRIPTION
Related to #4307

* Don't pack `extract_homm2_dos_anim.*` files in a ZIP archive - animations can be extracted by the `extract_homm2_resources.bat` alone even if ZIP file will be extracted to the directory with the OG;
* Mention the `extract_homm2_resources.bat` in `README.txt`;
* Rephrase some sentences.
