### PR TITLE
Fix for bonus artifact names in campaign screen

### DIFF
--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -335,6 +335,10 @@ namespace
             return _( "Defender Helm" );
         case Artifact::POWER_AXE:
             return _( "Power Axe" );
+        case Artifact::STEALTH_SHIELD:
+            return _( "Stealth Shield" );
+        case Artifact::NOMAD_BOOTS_MOBILITY:
+            return _( "Nomad Boots" );
         default:
             return Artifact( artifactId ).GetName();
         }


### PR DESCRIPTION
Fixes #4406.  Changes:
* Sets campaign name of the **Stealth Shield of Protection** artifact to "Stealth Shield".
* Sets campaign name of the **Nomad Boots of Mobility** artifact to "Nomad Boots".