### PR TITLE
Handle default exit hotkey in Campaign scenario select / info

### DIFF
--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -685,7 +685,7 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
             }
         }
 
-        if ( le.MouseClickLeft( buttonCancel.area() ) ) {
+        if ( le.MouseClickLeft( buttonCancel.area() ) || HotKeyPressEvent( EVENT_DEFAULT_EXIT ) ) {
             return prevMode;
         }
         else if ( ( buttonOk.isEnabled() && le.MouseClickLeft( buttonOk.area() ) ) || ( buttonRestart.isEnabled() && le.MouseClickLeft( buttonRestart.area() ) ) ) {


### PR DESCRIPTION
Otherwise you have to click the `Cancel` button with the mouse.  The hotkey
saves a lot time when testing changes.