### PR TITLE
Hide the OKAY button in campaign info window

### DIFF
--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -614,13 +614,15 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
 
     if ( allowToRestart ) {
         buttonOk.disable();
+        buttonOk.hide();
         buttonRestart.draw();
     }
     else {
+        buttonRestart.disable();
         buttonRestart.hide();
+        buttonOk.draw();
     }
 
-    buttonOk.draw();
     buttonCancel.draw();
 
     for ( uint32_t i = 0; i < bonusChoiceCount; ++i )


### PR DESCRIPTION
Fix #4377

Also disable the `RESTART` button when it's hidden: otherwise clicking on the
empty area where the button should be leads to the action unexpectedly.