### PR TITLE
Consider the protected tile as an obstacle when recalculating the hero's path

### DIFF
--- a/src/fheroes2/heroes/route.cpp
+++ b/src/fheroes2/heroes/route.cpp
@@ -428,7 +428,7 @@ bool StepIsObstacle( const Route::Step & s )
         break;
     }
 
-    // consider the protected tile is an obstacle because the hero will not be able to step on it without a battle
+    // consider the protected tile as an obstacle because the hero will not be able to step on it without a battle
     if ( Maps::TileIsUnderProtection( index ) ) {
         return true;
     }

--- a/src/fheroes2/heroes/route.cpp
+++ b/src/fheroes2/heroes/route.cpp
@@ -428,6 +428,11 @@ bool StepIsObstacle( const Route::Step & s )
         break;
     }
 
+    // consider the protected tile is an obstacle because the hero will not be able to step on it without a battle
+    if ( Maps::TileIsUnderProtection( index ) ) {
+        return true;
+    }
+
     return false;
 }
 


### PR DESCRIPTION
fix #4430