### PR TITLE
Do not reset music type to MUSIC_MIDI_ORIGINAL too early

### DIFF
--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -211,8 +211,7 @@ bool Settings::Read( const std::string & filename )
         else if ( sval == "expansion" ) {
             opt_global.ResetModes( GLOBAL_MUSIC );
             opt_global.SetModes( GLOBAL_MUSIC_MIDI );
-            if ( isPriceOfLoyaltySupported() )
-                _musicType = MUSIC_MIDI_EXPANSION;
+            _musicType = MUSIC_MIDI_EXPANSION;
         }
         else if ( sval == "external" ) {
             opt_global.ResetModes( GLOBAL_MUSIC );


### PR DESCRIPTION
At the moment when `Settings::Read()` is called, `AGGInitializer` doesn't exist yet, so `isPriceOfLoyaltySupported()` always returns `false` and therefore `music = expansion` setting from the `fheroes2.cfg` is never read correctly.