### PR TITLE
Add buttons in castle construction window

### DIFF
--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -20,6 +20,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <cassert>
+
 #include "buildinginfo.h"
 #include "agg.h"
 #include "agg_image.h"
@@ -56,6 +58,8 @@ namespace
         case Race::NECR:
             return fheroes2::Point( 35, 10 );
         default:
+            // Did you add a new race?
+            assert( 0 );
             return fheroes2::Point();
         }
     }
@@ -258,7 +262,7 @@ int GetIndexBuildingSprite( u32 build )
     return 0;
 }
 
-BuildingInfo::BuildingInfo( const Castle & c, building_t b )
+BuildingInfo::BuildingInfo( const Castle & c, const building_t b )
     : castle( c )
     , building( b )
     , area( 0, 0, 135, 70 )

--- a/src/fheroes2/castle/buildinginfo.h
+++ b/src/fheroes2/castle/buildinginfo.h
@@ -31,7 +31,7 @@ class StatusBar;
 class BuildingInfo
 {
 public:
-    BuildingInfo( const Castle &, building_t );
+    BuildingInfo( const Castle & c, const building_t b );
 
     uint32_t getBuilding( void ) const;
     void SetPos( s32, s32 );

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -112,8 +112,8 @@ public:
         Close, // Close the dialog.
         NextCastle, // Open main dialog of the next castle.
         PreviousCastle, // Open main dialog of the previous castle.
-        NextTown, // Open building purchase dialog of the next castle.
-        PreviousTown // Open building purchase dialog of the previous castle.
+        NextCostructionWindow, // Open construction dialog of the next castle.
+        PreviousCostructionWindow // Open construction dialog of the previous castle.
     };
 
     Castle();
@@ -178,7 +178,7 @@ public:
 
     void DrawImageCastle( const fheroes2::Point & pt ) const;
 
-    CastleDialogReturnValue OpenDialog( const bool readonly );
+    CastleDialogReturnValue OpenDialog( const bool readOnly, const bool openConstructionWindow );
 
     int GetAttackModificator( const std::string * ) const;
     int GetDefenseModificator( const std::string * ) const;
@@ -226,17 +226,20 @@ public:
     void SwapCastleHeroes( CastleHeroes & );
 
 private:
-    enum class TownDialogResult : int
+    enum class ConstructionDialogResult : int
     {
         DoNothing,
-        NextTown, // Open next Town dialog.
-        PrevTown, // Open previous Town dialog.
-        Build // Build something.
+        NextConstructionWindow, // Open construction dialog for the next castle.
+        PrevConstructionWindow, // Open construction dialog for the previous castle.
+        Build, // Build something.
+        RecruitHero // Recruit a hero.
     };
 
     u32 * GetDwelling( u32 dw );
     void EducateHeroes( void );
-    TownDialogResult OpenTown( uint32_t & dwellingTobuild );
+
+    ConstructionDialogResult openConstructionDialog( uint32_t & dwellingTobuild );
+
     void OpenTavern( void ) const;
     void OpenWell( void );
     void OpenMageGuild( const CastleHeroes & heroes ) const;

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -106,6 +106,16 @@ public:
         CAPITAL = 0x0020
     };
 
+    enum class CastleDialogReturnValue : int
+    {
+        DoNothing,
+        Close, // Close the dialog.
+        NextCastle, // Open main dialog of the next castle.
+        PreviousCastle, // Open main dialog of the previous castle.
+        NextTown, // Open building purchase dialog of the next castle.
+        PreviousTown // Open building purchase dialog of the previous castle.
+    };
+
     Castle();
     Castle( s32, s32, int rs );
     ~Castle() override = default;
@@ -168,7 +178,7 @@ public:
 
     void DrawImageCastle( const fheroes2::Point & pt ) const;
 
-    int OpenDialog( bool readonly = false );
+    CastleDialogReturnValue OpenDialog( const bool readonly );
 
     int GetAttackModificator( const std::string * ) const;
     int GetDefenseModificator( const std::string * ) const;
@@ -216,9 +226,17 @@ public:
     void SwapCastleHeroes( CastleHeroes & );
 
 private:
+    enum class TownDialogResult : int
+    {
+        DoNothing,
+        NextTown, // Open next Town dialog.
+        PrevTown, // Open previous Town dialog.
+        Build // Build something.
+    };
+
     u32 * GetDwelling( u32 dw );
     void EducateHeroes( void );
-    u32 OpenTown( void );
+    TownDialogResult OpenTown( uint32_t & dwellingTobuild );
     void OpenTavern( void ) const;
     void OpenWell( void );
     void OpenMageGuild( const CastleHeroes & heroes ) const;
@@ -226,7 +244,6 @@ private:
     void JoinRNDArmy( void );
     void PostLoad( void );
 
-private:
     friend StreamBase & operator<<( StreamBase &, const Castle & );
     friend StreamBase & operator>>( StreamBase &, Castle & );
 

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -145,25 +145,22 @@ namespace
 
         fheroes2::Blit( fheroes2::AGG::GetICN( ICN::STRIP, 0 ), display, pt.x, pt.y + 256 );
 
-        fheroes2::Sprite icon1;
-        fheroes2::Sprite icon2;
+        if ( hero1 ) {
+            fheroes2::Blit( hero1->GetPortrait( PORT_BIG ), display, pt.x + 5, pt.y + 262 );
+        }
+        else if ( castle.isBuild( BUILD_CAPTAIN ) ) {
+            fheroes2::Blit( castle.GetCaptain().GetPortrait( PORT_BIG ), display, pt.x + 5, pt.y + 262 );
+        }
+        else {
+            fheroes2::Blit( fheroes2::AGG::GetICN( ICN::CREST, Color::GetIndex( castle.GetColor() ) ), display, pt.x + 5, pt.y + 262 );
+        }
 
-        if ( hero1 )
-            icon1 = hero1->GetPortrait( PORT_BIG );
-        else if ( castle.isBuild( BUILD_CAPTAIN ) )
-            icon1 = castle.GetCaptain().GetPortrait( PORT_BIG );
-        else
-            icon1 = fheroes2::AGG::GetICN( ICN::CREST, Color::GetIndex( castle.GetColor() ) );
-
-        if ( hero2 )
-            icon2 = hero2->GetPortrait( PORT_BIG );
-        else
-            icon2 = fheroes2::AGG::GetICN( ICN::STRIP, 3 );
-
-        if ( !icon1.empty() )
-            fheroes2::Blit( icon1, display, pt.x + 5, pt.y + 262 );
-        if ( !icon2.empty() )
-            fheroes2::Blit( icon2, display, pt.x + 5, pt.y + 361 );
+        if ( hero2 ) {
+            fheroes2::Blit( hero2->GetPortrait( PORT_BIG ), display, pt.x + 5, pt.y + 361 );
+        }
+        else {
+            fheroes2::Blit( fheroes2::AGG::GetICN( ICN::STRIP, 3 ), display, pt.x + 5, pt.y + 361 );
+        }
 
         if ( !hero2 )
             fheroes2::Blit( fheroes2::AGG::GetICN( ICN::STRIP, 11 ), display, pt.x + 112, pt.y + 361 );
@@ -213,22 +210,43 @@ namespace
         }
     }
 
-    void openHeroDialog( ArmyBar & army1, ArmyBar & army2, Heroes & hero )
+    void openHeroDialog( ArmyBar & topArmyBar, ArmyBar & bottomArmyBar, Heroes & hero )
     {
         Game::SetUpdateSoundsOnFocusUpdate( false );
         Game::OpenHeroesDialog( hero, false, false );
 
-        if ( army2.isValid() && army1.isSelected() )
-            army1.ResetSelected();
-        if ( army2.isValid() && army2.isSelected() )
-            army2.ResetSelected();
+        if ( topArmyBar.isValid() && topArmyBar.isSelected() )
+            topArmyBar.ResetSelected();
+        if ( bottomArmyBar.isValid() && bottomArmyBar.isSelected() )
+            bottomArmyBar.ResetSelected();
+    }
+
+    void generateHeroImage( fheroes2::Image & image, CastleHeroes & heroes )
+    {
+        if ( image.empty() ) {
+            image.resize( 552, 105 );
+            image.reset();
+        }
+
+        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::STRIP, 0 ), 0, 100, image, 0, 0, 552, 107 );
+        const fheroes2::Sprite & port = heroes.Guest()->GetPortrait( PORT_BIG );
+        fheroes2::Blit( port, image, 5, 5 );
+
+        ArmyBar armyBar( &heroes.Guest()->GetArmy(), false, false );
+        armyBar.SetColRows( 5, 1 );
+        armyBar.SetPos( 112, 5 );
+        armyBar.SetHSpace( 6 );
+        armyBar.Redraw( image );
     }
 }
 
-Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readonly )
+Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readOnly, const bool openConstructionWindow )
 {
-    int alphaHero = 255;
-    CastleDialog::FadeBuilding fadeBuilding;
+    // It's not possible to open town window in read only mode.
+    assert( !openConstructionWindow || !readOnly );
+
+    // setup cursor
+    const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
     // Fade screen.
     Settings & conf = Settings::Get();
@@ -237,8 +255,40 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readonly )
 
     const fheroes2::StandardWindow background( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
 
-    // setup cursor
-    const CursorRestorer cursorRestorer( true, Cursor::POINTER );
+    AGG::PlayMusic( MUS::FromRace( race ), true, true );
+
+    int alphaHero = 255;
+    CastleDialog::FadeBuilding fadeBuilding;
+
+    CastleHeroes heroes = world.GetHeroes( *this );
+
+    fheroes2::Image surfaceHero;
+
+    if ( openConstructionWindow && isBuild( BUILD_CASTLE ) ) {
+        uint32_t build = BUILD_NOTHING;
+        const ConstructionDialogResult townResult = openConstructionDialog( build );
+
+        if ( townResult == ConstructionDialogResult::NextConstructionWindow ) {
+            return CastleDialogReturnValue::NextCostructionWindow;
+        }
+        if ( townResult == ConstructionDialogResult::PrevConstructionWindow ) {
+            return CastleDialogReturnValue::PreviousCostructionWindow;
+        }
+
+        if ( build != BUILD_NOTHING ) {
+            AGG::PlaySound( M82::BUILDTWN );
+            fadeBuilding.StartFadeBuilding( build );
+        }
+
+        if ( townResult == ConstructionDialogResult::RecruitHero ) {
+            heroes = world.GetHeroes( *this );
+
+            generateHeroImage( surfaceHero, heroes );
+
+            AGG::PlaySound( M82::BUILDTWN );
+            alphaHero = 0;
+        }
+    }
 
     const fheroes2::Point cur_pt( background.activeArea().x, background.activeArea().y );
     const std::string currentDate = getDateString();
@@ -268,30 +318,34 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readonly )
     const fheroes2::Sprite & crest = fheroes2::AGG::GetICN( ICN::CREST, Color::GetIndex( GetColor() ) );
     const fheroes2::Rect rectSign1( cur_pt.x + 5, cur_pt.y + 262, crest.width(), crest.height() );
 
-    CastleHeroes heroes = world.GetHeroes( *this );
+    
     RedrawIcons( *this, heroes, cur_pt );
 
     // castle troops selector
     // castle army bar
-    ArmyBar selectArmy1( ( heroes.Guard() ? &heroes.Guard()->GetArmy() : &army ), false, readonly );
-    selectArmy1.SetColRows( 5, 1 );
-    selectArmy1.SetPos( cur_pt.x + 112, cur_pt.y + 262 );
-    selectArmy1.SetHSpace( 6 );
-    selectArmy1.Redraw();
+    ArmyBar topArmyBar( ( heroes.Guard() ? &heroes.Guard()->GetArmy() : &army ), false, readOnly );
+    topArmyBar.SetColRows( 5, 1 );
+    topArmyBar.SetPos( cur_pt.x + 112, cur_pt.y + 262 );
+    topArmyBar.SetHSpace( 6 );
+    topArmyBar.Redraw();
 
     // portrait heroes or captain or sign
     const fheroes2::Rect rectSign2( cur_pt.x + 5, cur_pt.y + 361, 100, 92 );
 
     // castle_heroes troops background
-    ArmyBar selectArmy2( nullptr, false, readonly );
-    selectArmy2.SetColRows( 5, 1 );
-    selectArmy2.SetPos( cur_pt.x + 112, cur_pt.y + 361 );
-    selectArmy2.SetHSpace( 6 );
+    ArmyBar bottomArmyBar( nullptr, false, readOnly );
+    bottomArmyBar.SetColRows( 5, 1 );
+    bottomArmyBar.SetPos( cur_pt.x + 112, cur_pt.y + 361 );
+    bottomArmyBar.SetHSpace( 6 );
 
     if ( heroes.Guest() ) {
         heroes.Guest()->MovePointsScaleFixed();
-        selectArmy2.SetArmy( &heroes.Guest()->GetArmy() );
-        selectArmy2.Redraw();
+        bottomArmyBar.SetArmy( &heroes.Guest()->GetArmy() );
+
+        if ( alphaHero != 0 ) {
+            // Draw bottom bar only if no hero fading animation is going.
+            bottomArmyBar.Redraw();
+        }
     }
 
     // button exit
@@ -305,7 +359,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readonly )
     SwapButton buttonSwap( cur_pt.x + 4, cur_pt.y + 348 );
     MeetingButton buttonMeeting( cur_pt.x + 88, cur_pt.y + 346 );
 
-    if ( heroes.Guest() && heroes.Guard() && !readonly ) {
+    if ( heroes.Guest() && heroes.Guard() && !readOnly ) {
         buttonSwap.draw();
         buttonMeeting.draw();
     }
@@ -316,7 +370,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readonly )
     // draw building
     CastleDialog::RedrawAllBuilding( *this, cur_pt, cacheBuildings, fadeBuilding, castleAnimationIndex );
 
-    if ( readonly || GetKingdom().GetCastles().size() < 2 ) {
+    if ( readOnly || GetKingdom().GetCastles().size() < 2 ) {
         buttonPrevCastle.disable();
         buttonNextCastle.disable();
     }
@@ -325,12 +379,8 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readonly )
     buttonNextCastle.draw();
     buttonExit.draw();
 
-    AGG::PlayMusic( MUS::FromRace( race ), true, true );
-
     CastleDialogReturnValue result = CastleDialogReturnValue::DoNothing;
     bool need_redraw = false;
-
-    fheroes2::Image surfaceHero( 552, 105 );
 
     // dialog menu loop
     Game::passAnimationDelay( Game::CASTLE_AROUND_DELAY );
@@ -385,14 +435,14 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readonly )
             }
 
             // selector troops event
-            if ( ( selectArmy2.isValid()
-                   && ( ( le.MouseCursor( selectArmy1.GetArea() ) && selectArmy1.QueueEventProcessing( selectArmy2, &statusMessage ) )
-                        || ( le.MouseCursor( selectArmy2.GetArea() ) && selectArmy2.QueueEventProcessing( selectArmy1, &statusMessage ) ) ) )
-                 || ( !selectArmy2.isValid() && le.MouseCursor( selectArmy1.GetArea() ) && selectArmy1.QueueEventProcessing( &statusMessage ) ) ) {
+            if ( ( bottomArmyBar.isValid()
+                   && ( ( le.MouseCursor( topArmyBar.GetArea() ) && topArmyBar.QueueEventProcessing( bottomArmyBar, &statusMessage ) )
+                        || ( le.MouseCursor( bottomArmyBar.GetArea() ) && bottomArmyBar.QueueEventProcessing( topArmyBar, &statusMessage ) ) ) )
+                 || ( !bottomArmyBar.isValid() && le.MouseCursor( topArmyBar.GetArea() ) && topArmyBar.QueueEventProcessing( &statusMessage ) ) ) {
                 need_redraw = true;
             }
 
-            if ( conf.ExtCastleAllowGuardians() && !readonly ) {
+            if ( conf.ExtCastleAllowGuardians() && !readOnly ) {
                 Army * army1 = nullptr;
                 Army * army2 = nullptr;
 
@@ -408,42 +458,41 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readonly )
                         need_redraw = true;
                     }
                 }
-                else
-                    // move hero to guardian
-                    if ( heroes.Guest() && !heroes.Guard() && le.MouseClickLeft( rectSign1 ) ) {
+                else if ( heroes.Guest() && !heroes.Guard() && le.MouseClickLeft( rectSign1 ) ) {
+                    // Move hero to top army.
                     if ( !heroes.Guest()->GetArmy().CanJoinTroops( army ) ) {
-                        // TODO: correct message
-                        Dialog::Message( _( "Join Error" ), _( "Army is full" ), Font::BIG, Dialog::OK );
+                        Dialog::Message( _( "Army joining" ),
+                                         _( "Unable to merge two armies together. Rearrange monsters manually before moving the hero to the garrison." ),
+                                         Font::BIG, Dialog::OK );
                     }
                     else {
                         SwapCastleHeroes( heroes );
                         army1 = &heroes.Guard()->GetArmy();
                     }
                 }
-                else
-                    // move guardian to hero
-                    if ( !heroes.Guest() && heroes.Guard() && le.MouseClickLeft( rectSign2 ) ) {
+                else if ( !heroes.Guest() && heroes.Guard() && le.MouseClickLeft( rectSign2 ) ) {
+                    // Move hero to bottom army.
                     SwapCastleHeroes( heroes );
                     army2 = &heroes.Guest()->GetArmy();
                 }
 
                 if ( army1 || army2 ) {
-                    if ( selectArmy1.isSelected() )
-                        selectArmy1.ResetSelected();
-                    if ( selectArmy2.isValid() && selectArmy2.isSelected() )
-                        selectArmy2.ResetSelected();
+                    if ( topArmyBar.isSelected() )
+                        topArmyBar.ResetSelected();
+                    if ( bottomArmyBar.isValid() && bottomArmyBar.isSelected() )
+                        bottomArmyBar.ResetSelected();
 
                     if ( army1 && army2 ) {
-                        selectArmy1.SetArmy( army1 );
-                        selectArmy2.SetArmy( army2 );
+                        topArmyBar.SetArmy( army1 );
+                        bottomArmyBar.SetArmy( army2 );
                     }
                     else if ( army1 ) {
-                        selectArmy1.SetArmy( army1 );
-                        selectArmy2.SetArmy( nullptr );
+                        topArmyBar.SetArmy( army1 );
+                        bottomArmyBar.SetArmy( nullptr );
                     }
                     else if ( army2 ) {
-                        selectArmy1.SetArmy( &army );
-                        selectArmy2.SetArmy( army2 );
+                        topArmyBar.SetArmy( &army );
+                        bottomArmyBar.SetArmy( army2 );
                     }
 
                     RedrawIcons( *this, heroes, cur_pt );
@@ -451,14 +500,14 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readonly )
                 }
             }
 
-            if ( !readonly && heroes.Guard() && le.MouseClickLeft( rectSign1 ) ) {
+            if ( !readOnly && heroes.Guard() && le.MouseClickLeft( rectSign1 ) ) {
                 // View guardian.
-                openHeroDialog( selectArmy1, selectArmy2, *heroes.Guard() );
+                openHeroDialog( topArmyBar, bottomArmyBar, *heroes.Guard() );
                 need_redraw = true;
             }
-            else if ( !readonly && heroes.Guest() && le.MouseClickLeft( rectSign2 ) ) {
+            else if ( !readOnly && heroes.Guest() && le.MouseClickLeft( rectSign2 ) ) {
                 // View hero.
-                openHeroDialog( selectArmy1, selectArmy2, *heroes.Guest() );
+                openHeroDialog( topArmyBar, bottomArmyBar, *heroes.Guest() );
                 need_redraw = true;
             }
 
@@ -492,12 +541,12 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readonly )
                 const bool isMagicGuild = ( BUILD_MAGEGUILD & it->id ) != 0;
 
                 if ( le.MouseClickLeft( it->coord ) || hotKeyBuilding == it->id || ( isMagicGuild && hotKeyBuilding == BUILD_MAGEGUILD ) ) {
-                    if ( selectArmy1.isSelected() )
-                        selectArmy1.ResetSelected();
-                    if ( selectArmy2.isValid() && selectArmy2.isSelected() )
-                        selectArmy2.ResetSelected();
+                    if ( topArmyBar.isSelected() )
+                        topArmyBar.ResetSelected();
+                    if ( bottomArmyBar.isValid() && bottomArmyBar.isSelected() )
+                        bottomArmyBar.ResetSelected();
 
-                    if ( readonly && ( it->id & ( BUILD_SHIPYARD | BUILD_MARKETPLACE | BUILD_WELL | BUILD_TENT | BUILD_CASTLE ) ) ) {
+                    if ( readOnly && ( it->id & ( BUILD_SHIPYARD | BUILD_MARKETPLACE | BUILD_WELL | BUILD_TENT | BUILD_CASTLE ) ) ) {
                         Dialog::Message( GetStringBuilding( it->id ), GetDescriptionBuilding( it->id ), Font::BIG, Dialog::OK );
                     }
                     else if ( isMagicGuild ) {
@@ -508,7 +557,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readonly )
                         OpenMageGuild( heroes );
                     }
                     else if ( isMonsterDwelling ) {
-                        if ( !readonly ) {
+                        if ( !readOnly ) {
                             fheroes2::ButtonRestorer exitRestorer( buttonExit );
 
                             const Troop monsterToRecruit = Dialog::RecruitMonster( Monster( race, monsterDwelling ), getMonstersInDwelling( it->id ), true );
@@ -577,17 +626,14 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readonly )
                             const Heroes * prev = heroes.Guest();
 
                             uint32_t build = BUILD_NOTHING;
-                            const TownDialogResult townResult = OpenTown( build );
+                            const ConstructionDialogResult townResult = openConstructionDialog( build );
 
-                            // As of now we do not support switching between town windows for few reasons:
-                            // - what to do if the next / previous town doesn't have a built castle?
-                            // - even if we who castle window for a town without built castle do we need to show town window for the next castle with a built dwelling?
-                            if ( townResult == TownDialogResult::NextTown ) {
-                                result = CastleDialogReturnValue::NextCastle;
+                            if ( townResult == ConstructionDialogResult::NextConstructionWindow ) {
+                                result = CastleDialogReturnValue::NextCostructionWindow;
                                 break;
                             }
-                            if ( townResult == TownDialogResult::PrevTown ) {
-                                result = CastleDialogReturnValue::PreviousCastle;
+                            if ( townResult == ConstructionDialogResult::PrevConstructionWindow ) {
+                                result = CastleDialogReturnValue::PreviousCostructionWindow;
                                 break;
                             }
 
@@ -597,35 +643,22 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readonly )
                             }
 
                             heroes = world.GetHeroes( *this );
-                            const bool buyhero = ( heroes.Guest() && ( heroes.Guest() != prev ) );
 
-                            if ( buyhero ) {
+                            if ( townResult == ConstructionDialogResult::RecruitHero ) {
                                 if ( prev ) {
-                                    selectArmy1.SetArmy( &heroes.Guard()->GetArmy() );
-                                    selectArmy2.SetArmy( nullptr );
+                                    topArmyBar.SetArmy( &heroes.Guard()->GetArmy() );
+                                    bottomArmyBar.SetArmy( nullptr );
+
+                                    topArmyBar.Redraw();
                                     RedrawIcons( *this, CastleHeroes( nullptr, heroes.Guard() ), cur_pt );
-                                    selectArmy1.Redraw();
-                                    if ( selectArmy2.isValid() )
-                                        selectArmy2.Redraw();
-                                    display.render();
                                 }
-                                selectArmy2.SetArmy( &heroes.Guest()->GetArmy() );
                                 AGG::PlaySound( M82::BUILDTWN );
 
-                                // animate fade in for hero army bar
-                                fheroes2::Blit( fheroes2::AGG::GetICN( ICN::STRIP, 0 ), 0, 100, surfaceHero, 0, 0, 552, 107 );
-                                const fheroes2::Sprite & port = heroes.Guest()->GetPortrait( PORT_BIG );
-                                if ( !port.empty() ) {
-                                    fheroes2::Blit( port, surfaceHero, 5, 5 );
-                                }
+                                bottomArmyBar.SetArmy( &heroes.Guest()->GetArmy() );
+                                generateHeroImage( surfaceHero, heroes );
 
-                                const fheroes2::Point savept = selectArmy2.GetPos();
-                                selectArmy2.SetPos( 112, 5 );
-                                selectArmy2.Redraw( surfaceHero );
-                                selectArmy2.SetPos( savept.x, savept.y );
-
-                                fheroes2::drawResourcePanel( GetKingdom().GetFunds(), display, cur_pt );
                                 alphaHero = 0;
+                                need_redraw = true;
                             }
                             break;
                         }
@@ -646,27 +679,39 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readonly )
             break;
         }
 
+        const bool bothHeroesPresent = ( heroes.Guest() != nullptr ) && ( heroes.Guard() != nullptr );
+
         if ( alphaHero < 255 ) {
             if ( Game::validateAnimationDelay( Game::CASTLE_BUYHERO_DELAY ) ) {
                 alphaHero += 10;
-                if ( alphaHero >= 255 )
-                    fheroes2::Blit( surfaceHero, display, cur_pt.x, cur_pt.y + 356 );
-                else
-                    fheroes2::AlphaBlit( surfaceHero, display, cur_pt.x, cur_pt.y + 356, alphaHero );
+                if ( alphaHero >= 255 ) {
+                    alphaHero = 255;
+                }
+
+                fheroes2::AlphaBlit( surfaceHero, display, cur_pt.x, cur_pt.y + 356, static_cast<uint8_t>( alphaHero ) );
+
+                if ( bothHeroesPresent && !readOnly ) {
+                    buttonSwap.draw();
+                    buttonMeeting.draw();
+                }
+
                 if ( !need_redraw )
                     display.render();
             }
         }
+
         if ( need_redraw ) {
-            selectArmy1.Redraw();
-            if ( selectArmy2.isValid() && alphaHero >= 255 )
-                selectArmy2.Redraw();
+            topArmyBar.Redraw();
+            if ( bottomArmyBar.isValid() && alphaHero >= 255 )
+                bottomArmyBar.Redraw();
             fheroes2::drawCastleName( *this, display, cur_pt );
             fheroes2::drawResourcePanel( GetKingdom().GetFunds(), display, cur_pt );
-            if ( heroes.Guest() && heroes.Guard() && !readonly ) {
+
+            if ( bothHeroesPresent && !readOnly ) {
                 buttonSwap.draw();
                 buttonMeeting.draw();
             }
+
             if ( buttonExit.isPressed() )
                 buttonExit.draw();
             display.render();
@@ -694,10 +739,10 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readonly )
         else if ( buttonNextCastle.isEnabled() && le.MouseCursor( buttonNextCastle.area() ) ) {
             statusMessage = _( "Show next town" );
         }
-        else if ( heroes.Guest() && heroes.Guard() && le.MouseCursor( buttonSwap.area() ) ) {
+        else if ( bothHeroesPresent && le.MouseCursor( buttonSwap.area() ) ) {
             statusMessage = _( "Swap Heroes" );
         }
-        else if ( heroes.Guest() && heroes.Guard() && le.MouseCursor( buttonMeeting.area() ) ) {
+        else if ( bothHeroesPresent && le.MouseCursor( buttonMeeting.area() ) ) {
             statusMessage = _( "Meeting Heroes" );
         }
         else if ( ( heroes.Guard() && le.MouseCursor( rectSign1 ) ) || ( heroes.Guest() && le.MouseCursor( rectSign2 ) ) ) {

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -318,7 +318,6 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readOnly, const b
     const fheroes2::Sprite & crest = fheroes2::AGG::GetICN( ICN::CREST, Color::GetIndex( GetColor() ) );
     const fheroes2::Rect rectSign1( cur_pt.x + 5, cur_pt.y + 262, crest.width(), crest.height() );
 
-    
     RedrawIcons( *this, heroes, cur_pt );
 
     // castle troops selector
@@ -462,8 +461,8 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readOnly, const b
                     // Move hero to top army.
                     if ( !heroes.Guest()->GetArmy().CanJoinTroops( army ) ) {
                         Dialog::Message( _( "Army joining" ),
-                                         _( "Unable to merge two armies together. Rearrange monsters manually before moving the hero to the garrison." ),
-                                         Font::BIG, Dialog::OK );
+                                         _( "Unable to merge two armies together. Rearrange monsters manually before moving the hero to the garrison." ), Font::BIG,
+                                         Dialog::OK );
                     }
                     else {
                         SwapCastleHeroes( heroes );

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -463,7 +463,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readonly )
             }
 
             // Get pressed hotkey.
-            const building_t hotKeyBuilding =  getPressedBuildingHotkey();
+            const building_t hotKeyBuilding = getPressedBuildingHotkey();
 
             // Interaction with buildings.
             // Animation queue starts from the lowest by Z-value buildings which means that they draw first and most likely overlap by the top buildings in the queue.

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -512,7 +512,7 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
             dwellingTobuild = ( Race::NECR == race ? BUILD_SHRINE : BUILD_TAVERN );
             return ConstructionDialogResult::Build;
         }
-        else if ( le.MouseCursor( buildingThievesGuild.GetArea() ) && buildingThievesGuild.QueueEventProcessing( buttonExit ) ) {
+        if ( le.MouseCursor( buildingThievesGuild.GetArea() ) && buildingThievesGuild.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_THIEVESGUILD;
             return ConstructionDialogResult::Build;
         }

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -145,12 +145,12 @@ int Castle::DialogBuyCastle( bool buttons ) const
     return info.DialogBuyBuilding( buttons ) ? Dialog::OK : Dialog::CANCEL;
 }
 
-Castle::TownDialogResult Castle::OpenTown( uint32_t & dwellingTobuild )
+Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwellingTobuild )
 {
     if ( !isBuild( BUILD_CASTLE ) ) {
         // It is not possible to open this dialog without a built castle!
         assert( 0 );
-        return TownDialogResult::DoNothing;
+        return ConstructionDialogResult::DoNothing;
     }
 
     dwellingTobuild = BUILD_NOTHING;
@@ -461,11 +461,11 @@ Castle::TownDialogResult Castle::OpenTown( uint32_t & dwellingTobuild )
 
         if ( buttonPrevCastle.isEnabled()
              && ( le.MouseClickLeft( buttonPrevCastle.area() ) || HotKeyPressEvent( Game::EVENT_MOVELEFT ) || timedButtonPrevCastle.isDelayPassed() ) ) {
-            return TownDialogResult::PrevTown;
+            return ConstructionDialogResult::PrevConstructionWindow;
         }
         if ( buttonNextCastle.isEnabled()
              && ( le.MouseClickLeft( buttonNextCastle.area() ) || HotKeyPressEvent( Game::EVENT_MOVERIGHT ) || timedButtonNextCastle.isDelayPassed() ) ) {
-            return TownDialogResult::NextTown;
+            return ConstructionDialogResult::NextConstructionWindow;
         }
 
         if ( le.MouseClickLeft( resActiveArea ) ) {
@@ -482,86 +482,86 @@ Castle::TownDialogResult Castle::OpenTown( uint32_t & dwellingTobuild )
         // click left
         if ( le.MouseCursor( dwelling1.GetArea() ) && dwelling1.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = dwelling1.getBuilding();
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         if ( le.MouseCursor( dwelling2.GetArea() ) && dwelling2.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = dwelling2.getBuilding();
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         if ( le.MouseCursor( dwelling3.GetArea() ) && dwelling3.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = dwelling3.getBuilding();
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         if ( le.MouseCursor( dwelling4.GetArea() ) && dwelling4.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = dwelling4.getBuilding();
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         if ( le.MouseCursor( dwelling5.GetArea() ) && dwelling5.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = dwelling5.getBuilding();
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         if ( le.MouseCursor( dwelling6.GetArea() ) && dwelling6.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = dwelling6.getBuilding();
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         if ( le.MouseCursor( buildingMageGuild.GetArea() ) && buildingMageGuild.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = buildingMageGuild.getBuilding();
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         if ( !isSkipTavernInteraction && le.MouseCursor( buildingTavern.GetArea() ) && buildingTavern.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = ( Race::NECR == race ? BUILD_SHRINE : BUILD_TAVERN );
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         else if ( le.MouseCursor( buildingThievesGuild.GetArea() ) && buildingThievesGuild.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_THIEVESGUILD;
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         if ( le.MouseCursor( buildingShipyard.GetArea() ) && buildingShipyard.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_SHIPYARD;
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         if ( le.MouseCursor( buildingStatue.GetArea() ) && buildingStatue.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_STATUE;
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         if ( le.MouseCursor( buildingMarketplace.GetArea() ) && buildingMarketplace.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_MARKETPLACE;
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         if ( le.MouseCursor( buildingWell.GetArea() ) && buildingWell.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_WELL;
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         if ( le.MouseCursor( buildingWel2.GetArea() ) && buildingWel2.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_WEL2;
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         if ( le.MouseCursor( buildingSpec.GetArea() ) && buildingSpec.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_SPEC;
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         if ( le.MouseCursor( buildingLTurret.GetArea() ) && buildingLTurret.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_LEFTTURRET;
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         if ( le.MouseCursor( buildingRTurret.GetArea() ) && buildingRTurret.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_RIGHTTURRET;
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         if ( le.MouseCursor( buildingMoat.GetArea() ) && buildingMoat.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_MOAT;
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         if ( le.MouseCursor( buildingCaptain.GetArea() ) && buildingCaptain.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_CAPTAIN;
-            return TownDialogResult::Build;
+            return ConstructionDialogResult::Build;
         }
         else if ( hero1 && le.MouseClickLeft( rectHero1 ) ) {
             fheroes2::ButtonRestorer exitRestorer( buttonExit );
             if ( Dialog::OK == DialogBuyHero( hero1 ) ) {
                 RecruitHero( hero1 );
 
-                return TownDialogResult::DoNothing;
+                return ConstructionDialogResult::RecruitHero;
             }
         }
         else if ( hero2 && le.MouseClickLeft( rectHero2 ) ) {
@@ -569,7 +569,7 @@ Castle::TownDialogResult Castle::OpenTown( uint32_t & dwellingTobuild )
             if ( Dialog::OK == DialogBuyHero( hero2 ) ) {
                 RecruitHero( hero2 );
 
-                return TownDialogResult::DoNothing;
+                return ConstructionDialogResult::RecruitHero;
             }
         }
         else if ( isBuild( BUILD_CAPTAIN ) ) {
@@ -588,9 +588,9 @@ Castle::TownDialogResult Castle::OpenTown( uint32_t & dwellingTobuild )
         const bool isCaptainBuilt = isBuild( BUILD_CAPTAIN );
 
         // Right click
-        if ( le.MousePressRight( rectSpreadArmyFormat ) && isCaptainBuilt )
+        if ( isCaptainBuilt && le.MousePressRight( rectSpreadArmyFormat ) )
             Dialog::Message( _( "Spread Formation" ), descriptionSpreadArmyFormat, Font::BIG );
-        else if ( le.MousePressRight( rectGroupedArmyFormat ) && isCaptainBuilt )
+        else if ( isCaptainBuilt && le.MousePressRight( rectGroupedArmyFormat ) )
             Dialog::Message( _( "Grouped Formation" ), descriptionGroupedArmyFormat, Font::BIG );
         else if ( hero1 && le.MousePressRight( rectHero1 ) ) {
             LocalEvent::GetClean();
@@ -681,5 +681,5 @@ Castle::TownDialogResult Castle::OpenTown( uint32_t & dwellingTobuild )
         }
     }
 
-    return TownDialogResult::DoNothing;
+    return ConstructionDialogResult::DoNothing;
 }

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -602,6 +602,12 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
             hero2->OpenDialog( true );
             display.render();
         }
+        else if ( le.MousePressRight( buttonNextCastle.area() ) ) {
+            Dialog::Message( _( "Show next town" ), _( "Click to show next town." ), Font::BIG );
+        }
+        else if ( le.MousePressRight( buttonPrevCastle.area() ) ) {
+            Dialog::Message( _( "Show previous town" ), _( "Click to show previous town." ), Font::BIG );
+        }
 
         // status info
         if ( le.MouseCursor( dwelling1.GetArea() ) )

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -144,13 +144,14 @@ int Castle::DialogBuyCastle( bool buttons ) const
     return info.DialogBuyBuilding( buttons ) ? Dialog::OK : Dialog::CANCEL;
 }
 
-u32 Castle::OpenTown( void )
+Castle::TownDialogResult Castle::OpenTown( uint32_t & dwellingTobuild )
 {
-    fheroes2::Display & display = fheroes2::Display::instance();
+    dwellingTobuild = BUILD_NOTHING;
 
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
+    fheroes2::Display & display = fheroes2::Display::instance();
     const fheroes2::ImageRestorer restorer( display, ( display.width() - fheroes2::Display::DEFAULT_WIDTH ) / 2,
                                             ( display.height() - fheroes2::Display::DEFAULT_HEIGHT ) / 2, fheroes2::Display::DEFAULT_WIDTH,
                                             fheroes2::Display::DEFAULT_HEIGHT );
@@ -180,7 +181,6 @@ u32 Castle::OpenTown( void )
     Text text( GetName(), Font::SMALL );
     text.Blit( cur_pt.x + 536 - text.w() / 2, cur_pt.y + 1 );
 
-    //
     BuildingInfo dwelling1( *this, DWELLING_MONSTER1 );
     dwelling1.SetPos( cur_pt.x + 5, cur_pt.y + 2 );
     dwelling1.Redraw();
@@ -398,19 +398,37 @@ u32 Castle::OpenTown( void )
         fheroes2::Blit( spriteDeny, display, dst_pt.x + 102 - 4 + 1 - spriteDeny.width(), dst_pt.y + 93 - 2 - spriteDeny.height() );
     }
 
-    // bottom bar
-    dst_pt.x = cur_pt.x;
-    dst_pt.y = cur_pt.y + 461;
-    const fheroes2::Sprite & bar = fheroes2::AGG::GetICN( ICN::CASLBAR, 0 );
-    fheroes2::Blit( bar, display, dst_pt.x, dst_pt.y );
+    const int32_t statusBarOffsetY = 480 - 19;
+
+    fheroes2::Button buttonPrevCastle( cur_pt.x, cur_pt.y + statusBarOffsetY, ICN::SMALLBAR, 1, 2 );
+    fheroes2::TimedEventValidator timedButtonPrevCastle( [&buttonPrevCastle]() { return buttonPrevCastle.isPressed(); } );
+    buttonPrevCastle.subscribe( &timedButtonPrevCastle );
+
+    // bottom small bar
+    const fheroes2::Sprite & bar = fheroes2::AGG::GetICN( ICN::SMALLBAR, 0 );
+    fheroes2::Blit( bar, display, cur_pt.x + buttonPrevCastle.area().width, cur_pt.y + statusBarOffsetY );
 
     StatusBar statusBar;
-    statusBar.SetCenter( dst_pt.x + bar.width() / 2, dst_pt.y + 12 );
+    statusBar.SetFont( Font::BIG );
+    statusBar.SetCenter( cur_pt.x + buttonPrevCastle.area().width + bar.width() / 2, cur_pt.y + statusBarOffsetY + 12 );
+
+    // button next castle
+    fheroes2::Button buttonNextCastle( cur_pt.x + buttonPrevCastle.area().width + bar.width(), cur_pt.y + statusBarOffsetY, ICN::SMALLBAR, 3, 4 );
+    fheroes2::TimedEventValidator timedButtonNextCastle( [&buttonNextCastle]() { return buttonNextCastle.isPressed(); } );
+    buttonNextCastle.subscribe( &timedButtonNextCastle );
 
     // button exit
     dst_pt.x = cur_pt.x + 553;
     dst_pt.y = cur_pt.y + 428;
     fheroes2::Button buttonExit( dst_pt.x, dst_pt.y, ICN::TREASURY, 1, 2 );
+
+    if ( GetKingdom().GetCastles().size() < 2 ) {
+        buttonPrevCastle.disable();
+        buttonNextCastle.disable();
+    }
+
+    buttonPrevCastle.draw();
+    buttonNextCastle.draw();
     buttonExit.draw();
 
     // redraw resource panel
@@ -421,12 +439,27 @@ u32 Castle::OpenTown( void )
 
     LocalEvent & le = LocalEvent::Get();
 
-    // message loop
     while ( le.HandleEvents() ) {
         le.MousePressLeft( buttonExit.area() ) ? buttonExit.drawOnPress() : buttonExit.drawOnRelease();
 
+        if ( buttonPrevCastle.isEnabled() ) {
+            le.MousePressLeft( buttonPrevCastle.area() ) ? buttonPrevCastle.drawOnPress() : buttonPrevCastle.drawOnRelease();
+        }
+        if ( buttonNextCastle.isEnabled() ) {
+            le.MousePressLeft( buttonNextCastle.area() ) ? buttonNextCastle.drawOnPress() : buttonNextCastle.drawOnRelease();
+        }
+
         if ( le.MouseClickLeft( buttonExit.area() ) || HotKeyCloseWindow )
             break;
+
+        if ( buttonPrevCastle.isEnabled()
+             && ( le.MouseClickLeft( buttonPrevCastle.area() ) || HotKeyPressEvent( Game::EVENT_MOVELEFT ) || timedButtonPrevCastle.isDelayPassed() ) ) {
+            return TownDialogResult::PrevTown;
+        }
+        if ( buttonNextCastle.isEnabled()
+             && ( le.MouseClickLeft( buttonNextCastle.area() ) || HotKeyPressEvent( Game::EVENT_MOVERIGHT ) || timedButtonNextCastle.isDelayPassed() ) ) {
+            return TownDialogResult::NextTown;
+        }
 
         if ( le.MouseClickLeft( resActiveArea ) ) {
             fheroes2::ButtonRestorer exitRestorer( buttonExit );
@@ -440,50 +473,88 @@ u32 Castle::OpenTown( void )
         }
 
         // click left
-        if ( le.MouseCursor( dwelling1.GetArea() ) && dwelling1.QueueEventProcessing( buttonExit ) )
-            return dwelling1.getBuilding();
-        else if ( le.MouseCursor( dwelling2.GetArea() ) && dwelling2.QueueEventProcessing( buttonExit ) )
-            return dwelling2.getBuilding();
-        else if ( le.MouseCursor( dwelling3.GetArea() ) && dwelling3.QueueEventProcessing( buttonExit ) )
-            return dwelling3.getBuilding();
-        else if ( le.MouseCursor( dwelling4.GetArea() ) && dwelling4.QueueEventProcessing( buttonExit ) )
-            return dwelling4.getBuilding();
-        else if ( le.MouseCursor( dwelling5.GetArea() ) && dwelling5.QueueEventProcessing( buttonExit ) )
-            return dwelling5.getBuilding();
-        else if ( le.MouseCursor( dwelling6.GetArea() ) && dwelling6.QueueEventProcessing( buttonExit ) )
-            return dwelling6.getBuilding();
-        else if ( le.MouseCursor( buildingMageGuild.GetArea() ) && buildingMageGuild.QueueEventProcessing( buttonExit ) )
-            return buildingMageGuild.getBuilding();
-        else if ( !isSkipTavernInteraction && le.MouseCursor( buildingTavern.GetArea() ) && buildingTavern.QueueEventProcessing( buttonExit ) )
-            return ( Race::NECR == race ? BUILD_SHRINE : BUILD_TAVERN );
-        else if ( le.MouseCursor( buildingThievesGuild.GetArea() ) && buildingThievesGuild.QueueEventProcessing( buttonExit ) )
-            return BUILD_THIEVESGUILD;
-        else if ( le.MouseCursor( buildingShipyard.GetArea() ) && buildingShipyard.QueueEventProcessing( buttonExit ) )
-            return BUILD_SHIPYARD;
-        else if ( le.MouseCursor( buildingStatue.GetArea() ) && buildingStatue.QueueEventProcessing( buttonExit ) )
-            return BUILD_STATUE;
-        else if ( le.MouseCursor( buildingMarketplace.GetArea() ) && buildingMarketplace.QueueEventProcessing( buttonExit ) )
-            return BUILD_MARKETPLACE;
-        else if ( le.MouseCursor( buildingWell.GetArea() ) && buildingWell.QueueEventProcessing( buttonExit ) )
-            return BUILD_WELL;
-        else if ( le.MouseCursor( buildingWel2.GetArea() ) && buildingWel2.QueueEventProcessing( buttonExit ) )
-            return BUILD_WEL2;
-        else if ( le.MouseCursor( buildingSpec.GetArea() ) && buildingSpec.QueueEventProcessing( buttonExit ) )
-            return BUILD_SPEC;
-        else if ( le.MouseCursor( buildingLTurret.GetArea() ) && buildingLTurret.QueueEventProcessing( buttonExit ) )
-            return BUILD_LEFTTURRET;
-        else if ( le.MouseCursor( buildingRTurret.GetArea() ) && buildingRTurret.QueueEventProcessing( buttonExit ) )
-            return BUILD_RIGHTTURRET;
-        else if ( le.MouseCursor( buildingMoat.GetArea() ) && buildingMoat.QueueEventProcessing( buttonExit ) )
-            return BUILD_MOAT;
-        else if ( le.MouseCursor( buildingCaptain.GetArea() ) && buildingCaptain.QueueEventProcessing( buttonExit ) )
-            return BUILD_CAPTAIN;
+        if ( le.MouseCursor( dwelling1.GetArea() ) && dwelling1.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = dwelling1.getBuilding();
+            return TownDialogResult::Build;
+        }
+        else if ( le.MouseCursor( dwelling2.GetArea() ) && dwelling2.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = dwelling2.getBuilding();
+            return TownDialogResult::Build;
+        }
+        else if ( le.MouseCursor( dwelling3.GetArea() ) && dwelling3.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = dwelling3.getBuilding();
+            return TownDialogResult::Build;
+        }
+        else if ( le.MouseCursor( dwelling4.GetArea() ) && dwelling4.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = dwelling4.getBuilding();
+            return TownDialogResult::Build;
+        }
+        else if ( le.MouseCursor( dwelling5.GetArea() ) && dwelling5.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = dwelling5.getBuilding();
+            return TownDialogResult::Build;
+        }
+        else if ( le.MouseCursor( dwelling6.GetArea() ) && dwelling6.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = dwelling6.getBuilding();
+            return TownDialogResult::Build;
+        }
+        else if ( le.MouseCursor( buildingMageGuild.GetArea() ) && buildingMageGuild.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = buildingMageGuild.getBuilding();
+            return TownDialogResult::Build;
+        }
+        else if ( !isSkipTavernInteraction && le.MouseCursor( buildingTavern.GetArea() ) && buildingTavern.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = ( Race::NECR == race ? BUILD_SHRINE : BUILD_TAVERN );
+            return TownDialogResult::Build;
+        }
+        else if ( le.MouseCursor( buildingThievesGuild.GetArea() ) && buildingThievesGuild.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = BUILD_THIEVESGUILD;
+            return TownDialogResult::Build;
+        }
+        else if ( le.MouseCursor( buildingShipyard.GetArea() ) && buildingShipyard.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = BUILD_SHIPYARD;
+            return TownDialogResult::Build;
+        }
+        else if ( le.MouseCursor( buildingStatue.GetArea() ) && buildingStatue.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = BUILD_STATUE;
+            return TownDialogResult::Build;
+        }
+        else if ( le.MouseCursor( buildingMarketplace.GetArea() ) && buildingMarketplace.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = BUILD_MARKETPLACE;
+            return TownDialogResult::Build;
+        }
+        else if ( le.MouseCursor( buildingWell.GetArea() ) && buildingWell.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = BUILD_WELL;
+            return TownDialogResult::Build;
+        }
+        else if ( le.MouseCursor( buildingWel2.GetArea() ) && buildingWel2.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = BUILD_WEL2;
+            return TownDialogResult::Build;
+        }
+        else if ( le.MouseCursor( buildingSpec.GetArea() ) && buildingSpec.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = BUILD_SPEC;
+            return TownDialogResult::Build;
+        }
+        else if ( le.MouseCursor( buildingLTurret.GetArea() ) && buildingLTurret.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = BUILD_LEFTTURRET;
+            return TownDialogResult::Build;
+        }
+        else if ( le.MouseCursor( buildingRTurret.GetArea() ) && buildingRTurret.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = BUILD_RIGHTTURRET;
+            return TownDialogResult::Build;
+        }
+        else if ( le.MouseCursor( buildingMoat.GetArea() ) && buildingMoat.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = BUILD_MOAT;
+            return TownDialogResult::Build;
+        }
+        else if ( le.MouseCursor( buildingCaptain.GetArea() ) && buildingCaptain.QueueEventProcessing( buttonExit ) ) {
+            dwellingTobuild = BUILD_CAPTAIN;
+            return TownDialogResult::Build;
+        }
         else if ( hero1 && le.MouseClickLeft( rectHero1 ) ) {
             fheroes2::ButtonRestorer exitRestorer( buttonExit );
             if ( Dialog::OK == DialogBuyHero( hero1 ) ) {
                 RecruitHero( hero1 );
 
-                return BUILD_NOTHING;
+                return TownDialogResult::DoNothing;
             }
         }
         else if ( hero2 && le.MouseClickLeft( rectHero2 ) ) {
@@ -491,7 +562,7 @@ u32 Castle::OpenTown( void )
             if ( Dialog::OK == DialogBuyHero( hero2 ) ) {
                 RecruitHero( hero2 );
 
-                return BUILD_NOTHING;
+                return TownDialogResult::DoNothing;
             }
         }
         else if ( isBuild( BUILD_CAPTAIN ) ) {
@@ -592,10 +663,16 @@ u32 Castle::OpenTown( void )
             statusBar.ShowMessage( _( "Exit Castle Options" ) );
         else if ( le.MouseCursor( resActiveArea ) )
             statusBar.ShowMessage( _( "Show Income" ) );
-        else
-            // clear all
+        else if ( buttonPrevCastle.isEnabled() && le.MouseCursor( buttonPrevCastle.area() ) ) {
+            statusBar.ShowMessage( _( "Show previous town" ) );
+        }
+        else if ( buttonNextCastle.isEnabled() && le.MouseCursor( buttonNextCastle.area() ) ) {
+            statusBar.ShowMessage( _( "Show next town" ) );
+        }
+        else {
             statusBar.ShowMessage( _( "Castle Options" ) );
+        }
     }
 
-    return BUILD_NOTHING;
+    return TownDialogResult::DoNothing;
 }

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -20,6 +20,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <cassert>
 #include <string>
 
 #include "agg_image.h"
@@ -146,6 +147,12 @@ int Castle::DialogBuyCastle( bool buttons ) const
 
 Castle::TownDialogResult Castle::OpenTown( uint32_t & dwellingTobuild )
 {
+    if ( !isBuild( BUILD_CASTLE ) ) {
+        // It is not possible to open this dialog without a built castle!
+        assert( 0 );
+        return TownDialogResult::DoNothing;
+    }
+
     dwellingTobuild = BUILD_NOTHING;
 
     // setup cursor
@@ -477,31 +484,31 @@ Castle::TownDialogResult Castle::OpenTown( uint32_t & dwellingTobuild )
             dwellingTobuild = dwelling1.getBuilding();
             return TownDialogResult::Build;
         }
-        else if ( le.MouseCursor( dwelling2.GetArea() ) && dwelling2.QueueEventProcessing( buttonExit ) ) {
+        if ( le.MouseCursor( dwelling2.GetArea() ) && dwelling2.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = dwelling2.getBuilding();
             return TownDialogResult::Build;
         }
-        else if ( le.MouseCursor( dwelling3.GetArea() ) && dwelling3.QueueEventProcessing( buttonExit ) ) {
+        if ( le.MouseCursor( dwelling3.GetArea() ) && dwelling3.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = dwelling3.getBuilding();
             return TownDialogResult::Build;
         }
-        else if ( le.MouseCursor( dwelling4.GetArea() ) && dwelling4.QueueEventProcessing( buttonExit ) ) {
+        if ( le.MouseCursor( dwelling4.GetArea() ) && dwelling4.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = dwelling4.getBuilding();
             return TownDialogResult::Build;
         }
-        else if ( le.MouseCursor( dwelling5.GetArea() ) && dwelling5.QueueEventProcessing( buttonExit ) ) {
+        if ( le.MouseCursor( dwelling5.GetArea() ) && dwelling5.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = dwelling5.getBuilding();
             return TownDialogResult::Build;
         }
-        else if ( le.MouseCursor( dwelling6.GetArea() ) && dwelling6.QueueEventProcessing( buttonExit ) ) {
+        if ( le.MouseCursor( dwelling6.GetArea() ) && dwelling6.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = dwelling6.getBuilding();
             return TownDialogResult::Build;
         }
-        else if ( le.MouseCursor( buildingMageGuild.GetArea() ) && buildingMageGuild.QueueEventProcessing( buttonExit ) ) {
+        if ( le.MouseCursor( buildingMageGuild.GetArea() ) && buildingMageGuild.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = buildingMageGuild.getBuilding();
             return TownDialogResult::Build;
         }
-        else if ( !isSkipTavernInteraction && le.MouseCursor( buildingTavern.GetArea() ) && buildingTavern.QueueEventProcessing( buttonExit ) ) {
+        if ( !isSkipTavernInteraction && le.MouseCursor( buildingTavern.GetArea() ) && buildingTavern.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = ( Race::NECR == race ? BUILD_SHRINE : BUILD_TAVERN );
             return TownDialogResult::Build;
         }
@@ -509,43 +516,43 @@ Castle::TownDialogResult Castle::OpenTown( uint32_t & dwellingTobuild )
             dwellingTobuild = BUILD_THIEVESGUILD;
             return TownDialogResult::Build;
         }
-        else if ( le.MouseCursor( buildingShipyard.GetArea() ) && buildingShipyard.QueueEventProcessing( buttonExit ) ) {
+        if ( le.MouseCursor( buildingShipyard.GetArea() ) && buildingShipyard.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_SHIPYARD;
             return TownDialogResult::Build;
         }
-        else if ( le.MouseCursor( buildingStatue.GetArea() ) && buildingStatue.QueueEventProcessing( buttonExit ) ) {
+        if ( le.MouseCursor( buildingStatue.GetArea() ) && buildingStatue.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_STATUE;
             return TownDialogResult::Build;
         }
-        else if ( le.MouseCursor( buildingMarketplace.GetArea() ) && buildingMarketplace.QueueEventProcessing( buttonExit ) ) {
+        if ( le.MouseCursor( buildingMarketplace.GetArea() ) && buildingMarketplace.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_MARKETPLACE;
             return TownDialogResult::Build;
         }
-        else if ( le.MouseCursor( buildingWell.GetArea() ) && buildingWell.QueueEventProcessing( buttonExit ) ) {
+        if ( le.MouseCursor( buildingWell.GetArea() ) && buildingWell.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_WELL;
             return TownDialogResult::Build;
         }
-        else if ( le.MouseCursor( buildingWel2.GetArea() ) && buildingWel2.QueueEventProcessing( buttonExit ) ) {
+        if ( le.MouseCursor( buildingWel2.GetArea() ) && buildingWel2.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_WEL2;
             return TownDialogResult::Build;
         }
-        else if ( le.MouseCursor( buildingSpec.GetArea() ) && buildingSpec.QueueEventProcessing( buttonExit ) ) {
+        if ( le.MouseCursor( buildingSpec.GetArea() ) && buildingSpec.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_SPEC;
             return TownDialogResult::Build;
         }
-        else if ( le.MouseCursor( buildingLTurret.GetArea() ) && buildingLTurret.QueueEventProcessing( buttonExit ) ) {
+        if ( le.MouseCursor( buildingLTurret.GetArea() ) && buildingLTurret.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_LEFTTURRET;
             return TownDialogResult::Build;
         }
-        else if ( le.MouseCursor( buildingRTurret.GetArea() ) && buildingRTurret.QueueEventProcessing( buttonExit ) ) {
+        if ( le.MouseCursor( buildingRTurret.GetArea() ) && buildingRTurret.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_RIGHTTURRET;
             return TownDialogResult::Build;
         }
-        else if ( le.MouseCursor( buildingMoat.GetArea() ) && buildingMoat.QueueEventProcessing( buttonExit ) ) {
+        if ( le.MouseCursor( buildingMoat.GetArea() ) && buildingMoat.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_MOAT;
             return TownDialogResult::Build;
         }
-        else if ( le.MouseCursor( buildingCaptain.GetArea() ) && buildingCaptain.QueueEventProcessing( buttonExit ) ) {
+        if ( le.MouseCursor( buildingCaptain.GetArea() ) && buildingCaptain.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = BUILD_CAPTAIN;
             return TownDialogResult::Build;
         }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -144,14 +144,17 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */ )
         while ( result != Castle::CastleDialogReturnValue::Close ) {
             assert( it != myCastles.end() );
 
-            result = ( *it )->OpenDialog( false );
+            const bool openConstructionWindow = ( result == Castle::CastleDialogReturnValue::PreviousCostructionWindow ) ||
+                                                ( result == Castle::CastleDialogReturnValue::NextCostructionWindow );
 
-            if ( result == Castle::CastleDialogReturnValue::PreviousCastle || result == Castle::CastleDialogReturnValue::PreviousTown ) {
+            result = ( *it )->OpenDialog( false, openConstructionWindow );
+
+            if ( result == Castle::CastleDialogReturnValue::PreviousCastle || result == Castle::CastleDialogReturnValue::PreviousCostructionWindow ) {
                 if ( it == myCastles.begin() )
                     it = myCastles.end();
                 --it;
             }
-            else if ( result == Castle::CastleDialogReturnValue::NextCastle || result == Castle::CastleDialogReturnValue::NextTown ) {
+            else if ( result == Castle::CastleDialogReturnValue::NextCastle || result == Castle::CastleDialogReturnValue::NextCostructionWindow ) {
                 ++it;
                 if ( it == myCastles.end() )
                     it = myCastles.begin();
@@ -159,7 +162,7 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */ )
         }
     }
     else if ( castle.isFriends( conf.CurrentColor() ) ) {
-        castle.OpenDialog( true );
+        castle.OpenDialog( true, false );
     }
 
     Interface::Basic & basicInterface = Interface::Basic::Get();

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -144,8 +144,8 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */ )
         while ( result != Castle::CastleDialogReturnValue::Close ) {
             assert( it != myCastles.end() );
 
-            const bool openConstructionWindow = ( result == Castle::CastleDialogReturnValue::PreviousCostructionWindow ) ||
-                                                ( result == Castle::CastleDialogReturnValue::NextCostructionWindow );
+            const bool openConstructionWindow =
+                ( result == Castle::CastleDialogReturnValue::PreviousCostructionWindow ) || ( result == Castle::CastleDialogReturnValue::NextCostructionWindow );
 
             result = ( *it )->OpenDialog( false, openConstructionWindow );
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -144,8 +144,8 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */ )
         while ( result != Castle::CastleDialogReturnValue::Close ) {
             assert( it != myCastles.end() );
 
-            const bool openConstructionWindow =
-                ( result == Castle::CastleDialogReturnValue::PreviousCostructionWindow ) || ( result == Castle::CastleDialogReturnValue::NextCostructionWindow );
+            const bool openConstructionWindow
+                = ( result == Castle::CastleDialogReturnValue::PreviousCostructionWindow ) || ( result == Castle::CastleDialogReturnValue::NextCostructionWindow );
 
             result = ( *it )->OpenDialog( false, openConstructionWindow );
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -139,21 +139,22 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */ )
     const size_t heroCountBefore = myKingdom.GetHeroes().size();
 
     if ( it != myCastles.end() ) {
-        int result = Dialog::ZERO;
-        while ( Dialog::CANCEL != result ) {
+        Castle::CastleDialogReturnValue result = Castle::CastleDialogReturnValue::DoNothing;
+
+        while ( result != Castle::CastleDialogReturnValue::Close ) {
+            assert( it != myCastles.end() );
+
             result = ( *it )->OpenDialog( false );
 
-            if ( it != myCastles.end() ) {
-                if ( Dialog::PREV == result ) {
-                    if ( it == myCastles.begin() )
-                        it = myCastles.end();
-                    --it;
-                }
-                else if ( Dialog::NEXT == result ) {
-                    ++it;
-                    if ( it == myCastles.end() )
-                        it = myCastles.begin();
-                }
+            if ( result == Castle::CastleDialogReturnValue::PreviousCastle || result == Castle::CastleDialogReturnValue::PreviousTown ) {
+                if ( it == myCastles.begin() )
+                    it = myCastles.end();
+                --it;
+            }
+            else if ( result == Castle::CastleDialogReturnValue::NextCastle || result == Castle::CastleDialogReturnValue::NextTown ) {
+                ++it;
+                if ( it == myCastles.end() )
+                    it = myCastles.begin();
             }
         }
     }


### PR DESCRIPTION
close #4335

Also reduce memory usage for castle window and fix swap and meeting buttons during hero fading animation.

This is how it looks:
![image](https://user-images.githubusercontent.com/19829520/139788468-5cb106f3-e16c-4653-8799-503b86041d14.png)
