### PR TITLE
xmi2mid: avoid possible reordering of MIDI commands with the same timestamp

### DIFF
--- a/src/engine/xmi2mid.cpp
+++ b/src/engine/xmi2mid.cpp
@@ -408,7 +408,7 @@ struct MidiEvents : std::vector<MidiChunk>
             }
         }
 
-        std::sort( this->begin(), this->end() );
+        std::stable_sort( this->begin(), this->end() );
 
         // update duration
         delta = 0;

--- a/src/engine/xmi2mid.cpp
+++ b/src/engine/xmi2mid.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <cassert>
 #include <fstream>
 #include <iomanip>
 #include <list>
@@ -498,6 +499,9 @@ struct MidData
         , ppqn( 60 )
         , tracks( t )
     {
+        // MIDI format 0 can contain only one track
+        assert( tracks.count() == 1 );
+
         // XMI files play MIDI at a fixed clock rate of 120 Hz
         if ( !tracks.empty() && tracks.front().events.trackTempo > 0 ) {
             ppqn = ( tracks.front().events.trackTempo * 3 / 25000 );


### PR DESCRIPTION
fix #4232

Credits: @Gerwin2k