### PR TITLE
ResetMixer is async by default

### DIFF
--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -113,8 +113,24 @@ namespace AGG
             }
         }
 
+        void pushStopMusic()
+        {
+            _createThreadIfNeeded();
+
+            std::lock_guard<std::mutex> mutexLock( _mutex );
+
+            while ( !_musicTasks.empty() ) {
+                _musicTasks.pop();
+            }
+
+            _musicTasks.emplace( -1, MUSIC_MIDI_ORIGINAL, true );
+            _runFlag = 1;
+            _workerNotification.notify_all();
+        }
+
         void pushMusic( const int musicId, const MusicSource musicType, const bool isLooped )
         {
+            assert( musicId >= 0 );
             _createThreadIfNeeded();
 
             std::lock_guard<std::mutex> mutexLock( _mutex );
@@ -279,8 +295,12 @@ namespace AGG
                     }
 
                     manager->_mutex.unlock();
-
-                    PlayMusicInternally( musicTask.musicId, musicTask.musicType, musicTask.isLooped );
+                    if ( musicTask.musicId >= 0 ) {
+                        PlayMusicInternally( musicTask.musicId, musicTask.musicType, musicTask.isLooped );
+                    }
+                    else {
+                        Music::Reset();
+                    }
                 }
                 else {
                     manager->_runFlag = 0;
@@ -607,13 +627,19 @@ std::vector<u8> AGG::LoadBINFRM( const char * frm_file )
     return AGG::ReadChunk( frm_file );
 }
 
-void AGG::ResetMixer()
+void AGG::ResetMixer( bool asyncronizedCall /* = true */ )
 {
-    g_asyncSoundManager.sync();
+    if ( asyncronizedCall ) {
+        g_asyncSoundManager.pushStopMusic();
+        Mixer::Stop();
+    }
+    else {
+        g_asyncSoundManager.sync();
 
-    std::lock_guard<std::mutex> mutexLock( g_asyncSoundManager.resourceMutex() );
+        std::lock_guard<std::mutex> mutexLock( g_asyncSoundManager.resourceMutex() );
 
-    Mixer::Reset();
+        Mixer::Reset();
+    }
     loop_sounds.clear();
     loop_sounds.reserve( 7 );
 }

--- a/src/fheroes2/agg/agg.h
+++ b/src/fheroes2/agg/agg.h
@@ -44,7 +44,7 @@ namespace AGG
     void LoadLOOPXXSounds( const std::vector<int> & vols, bool asyncronizedCall = false );
     void PlaySound( int m82, bool asyncronizedCall = false );
     void PlayMusic( int mus, bool loop = true, bool asyncronizedCall = false );
-    void ResetMixer();
+    void ResetMixer( bool asyncronizedCall = true );
 
     std::vector<uint8_t> ReadChunk( const std::string & key, bool ignoreExpansion = false );
 }


### PR DESCRIPTION
ResetMixer is suffering from the same issues with music player:
for MIDI files, it will call SDL that will add a lag of 0.1 sec for every
action on MIDI files. This means that when calling ResetMixer during loading,
we waste 0.1 sec as well.

The fix is simply to have the call to Music::Reset be done in the
dedicated audio thread so it doesn't block the main thread.

We can put the "stop music" task into the stack of existing _musicTasks,
because it behaves the same way, ie the logic has to process in priority
the latest task and can discard all the previous ones.

fixes #4463