### PR TITLE
Allow to use mouse wheel to change system options

### DIFF
--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -254,7 +254,6 @@ namespace
 
         display.render();
 
-        bool redraw = false;
         bool saveConfig = false;
 
         // dialog menu loop
@@ -266,23 +265,45 @@ namespace
                 break;
             }
 
-            // set music volume
-            if ( Audio::isValid() && le.MouseClickLeft( musicVolumeRoi ) ) {
-                conf.SetMusicVolume( 10 > conf.MusicVolume() ? conf.MusicVolume() + 1 : 0 );
-                redraw = true;
-                Music::Volume( static_cast<int16_t>( Mixer::MaxVolume() * conf.MusicVolume() / 10 ) );
-                saveConfig = true;
-            }
+            // set music or sound volume
+            bool saveMusicVolume = false;
+            bool saveSoundVolume = false;
+            if ( Audio::isValid() ) {
+                if ( le.MouseClickLeft( musicVolumeRoi ) ) {
+                    conf.SetMusicVolume( ( conf.MusicVolume() + 1 ) % 10 );
+                    saveMusicVolume = true;
+                }
+                else if ( le.MouseWheelUp( musicVolumeRoi ) ) {
+                    conf.SetMusicVolume( std::min( conf.MusicVolume() + 1, 9 ) );
+                    saveMusicVolume = true;
+                }
+                else if ( le.MouseWheelDn( musicVolumeRoi ) ) {
+                    conf.SetMusicVolume( std::max( 0, conf.MusicVolume() - 1 ) );
+                    saveMusicVolume = true;
+                }
+                if ( saveMusicVolume ) {
+                    Music::Volume( static_cast<int16_t>( Mixer::MaxVolume() * conf.MusicVolume() / 10 ) );
+                }
 
-            // set sound volume
-            if ( Audio::isValid() && le.MouseClickLeft( soundVolumeRoi ) ) {
-                conf.SetSoundVolume( 10 > conf.SoundVolume() ? conf.SoundVolume() + 1 : 0 );
-                redraw = true;
-                Game::EnvironmentSoundMixer();
-                saveConfig = true;
+                if ( le.MouseClickLeft( soundVolumeRoi ) ) {
+                    conf.SetSoundVolume( ( conf.SoundVolume() + 1 ) % 10 );
+                    saveSoundVolume = true;
+                }
+                else if ( le.MouseWheelUp( soundVolumeRoi ) ) {
+                    conf.SetSoundVolume( std::min( conf.SoundVolume() + 1, 9 ) );
+                    saveSoundVolume = true;
+                }
+                else if ( le.MouseWheelDn( soundVolumeRoi ) ) {
+                    conf.SetSoundVolume( std::max( 0, conf.SoundVolume() - 1 ) );
+                    saveSoundVolume = true;
+                }
+                if ( saveSoundVolume ) {
+                    Game::EnvironmentSoundMixer();
+                }
             }
 
             // set music type
+            bool saveMusicType = false;
             if ( le.MouseClickLeft( musicTypeRoi ) ) {
                 int type = conf.MusicType() + 1;
                 // If there's no expansion files we skip this option
@@ -290,32 +311,56 @@ namespace
                     ++type;
 
                 conf.SetMusicType( type > MUSIC_EXTERNAL ? 0 : type );
-                redraw = true;
-                saveConfig = true;
+                saveMusicType = true;
             }
 
             // set hero speed
+            bool saveHeroSpeed = false;
             if ( le.MouseClickLeft( heroSpeedRoi ) ) {
                 conf.SetHeroesMoveSpeed( conf.HeroesMoveSpeed() % 10 + 1 );
-                redraw = true;
-                Game::UpdateGameSpeed();
-                saveConfig = true;
+                saveHeroSpeed = true;
+            }
+            else if ( le.MouseWheelUp( heroSpeedRoi ) ) {
+                conf.SetHeroesMoveSpeed( std::min( conf.HeroesMoveSpeed() + 1, 10 ) );
+                saveHeroSpeed = true;
+            }
+            else if ( le.MouseWheelDn( heroSpeedRoi ) ) {
+                conf.SetHeroesMoveSpeed( std::max( 1, conf.HeroesMoveSpeed() - 1 ) );
+                saveHeroSpeed = true;
             }
 
             // set ai speed
+            bool saveAISpeed = false;
             if ( le.MouseClickLeft( aiSpeedRoi ) ) {
-                const int prevAISpeed = conf.AIMoveSpeed();
-                conf.SetAIMoveSpeed( prevAISpeed >= 10 ? 0 : prevAISpeed + 1 );
-                redraw = true;
+                conf.SetAIMoveSpeed( ( conf.AIMoveSpeed() + 1 ) % 11 );
+                saveAISpeed = true;
+            }
+            else if ( le.MouseWheelUp( aiSpeedRoi ) ) {
+                conf.SetAIMoveSpeed( std::min( conf.AIMoveSpeed() + 1, 10 ) );
+                saveAISpeed = true;
+            }
+            else if ( le.MouseWheelDn( aiSpeedRoi ) ) {
+                conf.SetAIMoveSpeed( std::max( 0, conf.AIMoveSpeed() - 1 ) );
+                saveAISpeed = true;
+            }
+
+            if ( saveHeroSpeed || saveAISpeed ) {
                 Game::UpdateGameSpeed();
-                saveConfig = true;
             }
 
             // set scroll speed
+            bool saveScrollSpeed = false;
             if ( le.MouseClickLeft( scrollSpeedRoi ) ) {
                 conf.SetScrollSpeed( SCROLL_FAST2 > conf.ScrollSpeed() ? conf.ScrollSpeed() + 1 : SCROLL_SLOW );
-                redraw = true;
-                saveConfig = true;
+                saveScrollSpeed = true;
+            }
+            else if ( le.MouseWheelUp( scrollSpeedRoi ) ) {
+                conf.SetScrollSpeed( std::min( static_cast<int>( conf.ScrollSpeed() ) + 1, static_cast<int>( SCROLL_FAST2 ) ) );
+                saveScrollSpeed = true;
+            }
+            else if ( le.MouseWheelDn( scrollSpeedRoi ) ) {
+                conf.SetScrollSpeed( std::max( static_cast<int>( SCROLL_SLOW ), static_cast<int>( conf.ScrollSpeed() ) - 1 ) );
+                saveScrollSpeed = true;
             }
 
             // set interface theme
@@ -329,6 +374,7 @@ namespace
             }
 
             // toggle manual/auto battles
+            bool saveAutoBattle = false;
             if ( le.MouseClickLeft( battleResolveRoi ) ) {
                 if ( conf.BattleAutoResolve() ) {
                     if ( conf.BattleAutoSpellcast() ) {
@@ -342,9 +388,7 @@ namespace
                     conf.setBattleAutoResolve( true );
                     conf.setBattleAutoSpellcast( true );
                 }
-
-                redraw = true;
-                saveConfig = true;
+                saveAutoBattle = true;
             }
 
             if ( le.MousePressRight( musicVolumeRoi ) )
@@ -368,12 +412,14 @@ namespace
             else if ( le.MousePressRight( buttonOkay.area() ) )
                 Dialog::Message( _( "OK" ), _( "Exit this menu." ), Font::BIG );
 
-            if ( redraw ) {
+            if ( saveMusicVolume || saveSoundVolume || saveMusicType || saveHeroSpeed || saveAISpeed || saveScrollSpeed || saveAutoBattle ) {
+                // redraw
                 fheroes2::Blit( dialog, display, dialogArea.x, dialogArea.y );
                 drawDialog( roi );
                 buttonOkay.draw();
                 display.render();
-                redraw = false;
+
+                saveConfig = true;
             }
         }
 


### PR DESCRIPTION
Mouse wheel is enabled on the following options:

- Music
- Effects
- Hero Speed
- AI Speed
- Scroll Speed

Any adjustments made using the wheel do not wrap over max. value, as opposed
to clicking.  Clicking still works as before.

Also unify the value wrapping math.