### PR TITLE
Fix terrain music being played during battle

### DIFF
--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -627,7 +627,7 @@ std::vector<u8> AGG::LoadBINFRM( const char * frm_file )
     return AGG::ReadChunk( frm_file );
 }
 
-void AGG::ResetMixer( bool asyncronizedCall /* = true */ )
+void AGG::ResetMixer( bool asyncronizedCall /* = false */ )
 {
     if ( asyncronizedCall ) {
         g_asyncSoundManager.pushStopMusic();

--- a/src/fheroes2/agg/agg.h
+++ b/src/fheroes2/agg/agg.h
@@ -44,7 +44,7 @@ namespace AGG
     void LoadLOOPXXSounds( const std::vector<int> & vols, bool asyncronizedCall = false );
     void PlaySound( int m82, bool asyncronizedCall = false );
     void PlayMusic( int mus, bool loop = true, bool asyncronizedCall = false );
-    void ResetMixer( bool asyncronizedCall = true );
+    void ResetMixer( bool asyncronizedCall = false );
 
     std::vector<uint8_t> ReadChunk( const std::string & key, bool ignoreExpansion = false );
 }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -81,7 +81,7 @@ fheroes2::GameMode Game::StartGame()
     if ( !conf.LoadedGameVersion() )
         GameOver::Result::Get().Reset();
 
-    AGG::ResetMixer();
+    AGG::ResetMixer( true );
 
     Interface::Basic::Get().Reset();
 


### PR DESCRIPTION
Here's a tentative fix for #4557 which I couldn't reproduce

I think the issue is as follows:
before this PR, we call PlaySound() with aync = false
This forces a call to "sync()", which will remove all pending music tasks. I think at this point it can potentially cancel the "stop music" tasks generated by the call to Agg::ResetMixer that maybe was not dequeued yet

NB : it's unclear to me why AGG::PlaySound in synch mode will erase all pending async music tasks, seems incorrect IMO