### PR TITLE
Don't translate the proper names in Original Team's credits

### DIFF
--- a/src/fheroes2/game/game_credits.cpp
+++ b/src/fheroes2/game/game_credits.cpp
@@ -438,7 +438,7 @@ namespace
         offsetY += title.height( textWidth );
 
         name.set( "Grant Youngblood\n"
-                  "Kareen Meshagan" ,
+                  "Kareen Meshagan",
                   nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
         offsetY += name.height( textWidth ) + titleOffsetY;
@@ -447,15 +447,15 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( "Julia Ulano" , nameFontType );
+        name.set( "Julia Ulano", nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
         offsetY += name.height( textWidth ) + titleOffsetY;
 
-        title.set(  _( "Assistant Art Director" ), titleFontType );
+        title.set( _( "Assistant Art Director" ), titleFontType );
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( "Bonita Long-Hemsath" , nameFontType );
+        name.set( "Bonita Long-Hemsath", nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
         offsetY += name.height( textWidth ) + titleOffsetY;
 

--- a/src/fheroes2/game/game_credits.cpp
+++ b/src/fheroes2/game/game_credits.cpp
@@ -363,7 +363,7 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        fheroes2::Text name( _( "Jon Van Caneghem" ), nameFontType );
+        fheroes2::Text name( "Jon Van Caneghem", nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
         offsetY += name.height( textWidth ) + titleOffsetY;
 
@@ -371,7 +371,7 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( _( "Phil Steinmeyer" ), nameFontType );
+        name.set( "Phil Steinmeyer", nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
         offsetY += name.height( textWidth ) + titleOffsetY;
 
@@ -379,7 +379,7 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( _( "Mark Caldwell" ), nameFontType );
+        name.set( "Mark Caldwell", nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
         offsetY += name.height( textWidth ) + titleOffsetY;
 
@@ -387,7 +387,7 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( _( "Walt Hochbrueckner" ), nameFontType );
+        name.set( "Walt Hochbrueckner", nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
         offsetY += name.height( textWidth ) + titleOffsetY;
 
@@ -395,8 +395,8 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( _( "Paul Rattner\n"
-                     "Debbie Van Caneghem" ),
+        name.set( "Paul Rattner\n"
+                  "Debbie Van Caneghem",
                   nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
         offsetY += name.height( textWidth ) + titleOffsetY;
@@ -405,9 +405,9 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( _( "George Ruof\n"
-                     "Todd Hendrix\n"
-                     "Mark Caldwell" ),
+        name.set( "George Ruof\n"
+                  "Todd Hendrix\n"
+                  "Mark Caldwell",
                   nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
         offsetY += name.height( textWidth ) + titleOffsetY;
@@ -416,7 +416,7 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( _( "Rob King" ), nameFontType );
+        name.set( "Rob King", nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
         offsetY += name.height( textWidth ) + titleOffsetY;
 
@@ -424,9 +424,9 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( _( "Rob King\n"
-                     "Steve Baca\n"
-                     "Paul Romero" ),
+        name.set( "Rob King\n"
+                  "Steve Baca\n"
+                  "Paul Romero",
                   nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
 
@@ -437,8 +437,8 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( _( "Grant Youngblood\n"
-                     "Kareen Meshagan" ),
+        name.set( "Grant Youngblood\n"
+                  "Kareen Meshagan" ,
                   nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
         offsetY += name.height( textWidth ) + titleOffsetY;
@@ -447,15 +447,15 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( _( "Julia Ulano" ), nameFontType );
+        name.set( "Julia Ulano" , nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
         offsetY += name.height( textWidth ) + titleOffsetY;
 
-        title.set( _( "Assistant Art Director" ), titleFontType );
+        title.set(  _( "Assistant Art Director" ), titleFontType );
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( _( "Bonita Long-Hemsath" ), nameFontType );
+        name.set( "Bonita Long-Hemsath" , nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
         offsetY += name.height( textWidth ) + titleOffsetY;
 
@@ -463,18 +463,18 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( _( "Julie Bateman\n"
-                     "Rebecca Christel\n"
-                     "Shelly Garcia\n"
-                     "Sam Hasson\n"
-                     "Louis Henderson\n"
-                     "Tracy Iwata\n"
-                     "Steve Jasper\n"
-                     "April Lee\n"
-                     "Lieu Pham\n"
-                     "Phelan Sykes\n"
-                     "Steve Wasaff\n"
-                     "Scott White" ),
+        name.set( "Julie Bateman\n"
+                  "Rebecca Christel\n"
+                  "Shelly Garcia\n"
+                  "Sam Hasson\n"
+                  "Louis Henderson\n"
+                  "Tracy Iwata\n"
+                  "Steve Jasper\n"
+                  "April Lee\n"
+                  "Lieu Pham\n"
+                  "Phelan Sykes\n"
+                  "Steve Wasaff\n"
+                  "Scott White",
                   nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
 
@@ -504,7 +504,7 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        fheroes2::Text name( _( "Peter Ryu" ), nameFontType );
+        fheroes2::Text name( "Peter Ryu", nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
         offsetY += name.height( textWidth ) + titleOffsetY;
 
@@ -512,13 +512,13 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( _( "David Botan\n"
-                     "David Fernandez\n"
-                     "Bill Nesemeier\n"
-                     "Walter Johnson\n"
-                     "Kate McClelland\n"
-                     "Timothy Lang\n"
-                     "Bryan Farina" ),
+        name.set( "David Botan\n"
+                  "David Fernandez\n"
+                  "Bill Nesemeier\n"
+                  "Walter Johnson\n"
+                  "Kate McClelland\n"
+                  "Timothy Lang\n"
+                  "Bryan Farina",
                   nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
         offsetY += name.height( textWidth ) + titleOffsetY;
@@ -527,7 +527,7 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( _( "Paul Rattner" ), nameFontType );
+        name.set( "Paul Rattner", nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
         offsetY += name.height( textWidth ) + titleOffsetY;
 
@@ -535,9 +535,9 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( _( "Bryan Farina\n"
-                     "Rozita Tolouey\n"
-                     "Bruce Schlickbernd" ),
+        name.set( "Bryan Farina\n"
+                  "Rozita Tolouey\n"
+                  "Bruce Schlickbernd",
                   nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
 
@@ -548,18 +548,18 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( _( "Jon Van Caneghem\n"
-                     "Debbie Van Caneghem\n"
-                     "Clayton Retzer\n"
-                     "Christian Vanover\n"
-                     "Paul Rattner\n"
-                     "Benjamin Bent\n"
-                     "Bryan Farina\n"
-                     "Eric Heffron\n"
-                     "Mark Palczynski\n"
-                     "Walt Hochbrueckner\n"
-                     "Bruce Schlickbernd\n"
-                     "Craig Konas" ),
+        name.set( "Jon Van Caneghem\n"
+                  "Debbie Van Caneghem\n"
+                  "Clayton Retzer\n"
+                  "Christian Vanover\n"
+                  "Paul Rattner\n"
+                  "Benjamin Bent\n"
+                  "Bryan Farina\n"
+                  "Eric Heffron\n"
+                  "Mark Palczynski\n"
+                  "Walt Hochbrueckner\n"
+                  "Bruce Schlickbernd\n"
+                  "Craig Konas",
                   nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
         offsetY += name.height( textWidth ) + titleOffsetY;
@@ -568,10 +568,10 @@ namespace
         title.draw( offsetX, offsetY, textWidth, output );
         offsetY += title.height( textWidth );
 
-        name.set( _( "Scott McDaniel\n"
-                     "Dean Rettig\n"
-                     "Ted Chapman\n"
-                     "Dean Frost" ),
+        name.set( "Scott McDaniel\n"
+                  "Dean Rettig\n"
+                  "Ted Chapman\n"
+                  "Dean Frost",
                   nameFontType );
         name.draw( offsetX, offsetY, textWidth, output );
 


### PR DESCRIPTION
Making this PR now since it makes the work with my other PR less cumbersome with regards to .pot merging.

This removes calls to gettext for the proper names in the NWC credits.