### PR TITLE
Resurect spell updates the board even in no-UI mode

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4812,9 +4812,6 @@ void Battle::Interface::RedrawTroopWithFrameAnimation( Unit & b, int icn, int m8
     }
 
     if ( animation != NONE ) {
-        if ( animation == RESURRECT ) {
-            b.SetPosition( b.GetPosition() );
-        }
         b.SwitchAnimation( Monster_Info::STATIC );
         _currentUnit = nullptr;
     }

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1499,6 +1499,9 @@ void Battle::Unit::SpellRestoreAction( const Spell & spell, u32 spoint, const He
 
         const u32 resurrect = Resurrect( restore, false, ( spell == Spell::RESURRECT ) );
 
+        // Puts back the unit in the board
+        SetPosition( GetPosition() );
+
         if ( Arena::GetInterface() ) {
             std::string str( _( "%{count} %{name} rise(s) from the dead!" ) );
             StringReplace( str, "%{count}", resurrect );


### PR DESCRIPTION
Previously, updating the board state was done only when the animation was playing

this fixes #4568