### PR TITLE
Better heuristic for AI usage of Disrupting Ray

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -97,6 +97,7 @@ namespace AI
         SpellcastOutcome spellSummonValue( const Spell & spell, const Battle::Arena & arena, const int heroColor ) const;
         SpellcastOutcome spellEffectValue( const Spell & spell, const Battle::Units & targets ) const;
         double spellEffectValue( const Spell & spell, const Battle::Unit & target, bool targetIsLast, bool forDispell ) const;
+        double getDisruptingRayRatio( const Battle::Unit & target ) const;
         uint32_t spellDurationMultiplier( const Battle::Unit & target ) const;
 
         // turn variables that wouldn't persist

--- a/src/fheroes2/ai/normal/ai_normal_spell.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_spell.cpp
@@ -204,6 +204,31 @@ namespace AI
         return 1;
     }
 
+    // Compute a heuristic for Disrupting Ray usage by AI
+    double BattlePlanner::getDisruptingRayRatio( const Battle::Unit & target ) const
+    {
+        const double targetDefense = target.GetDefense();
+
+        if ( targetDefense <= 1 ) { // target is already at minimum defense: not useful to cast Disrupting Ray
+            return 0.0;
+        }
+
+        double ratio = 0.2;
+        if ( targetDefense <= Spell( Spell::DISRUPTINGRAY ).ExtraValue() ) { // disrupting ray can't have full effect
+            const double actualDefenseChange = targetDefense - 1.0;
+            ratio *= actualDefenseChange / Spell( Spell::DISRUPTINGRAY ).ExtraValue();
+        }
+
+        const double targetStrength = target.GetStrength();
+
+        // if current army has much lower strength than target unit, we reduce the ratio to prioritize direct damage spells
+        if ( _myArmyStrength < targetStrength ) {
+            ratio *= _myArmyStrength / targetStrength;
+        }
+
+        return ratio;
+    }
+
     double BattlePlanner::spellEffectValue( const Spell & spell, const Battle::Unit & target, bool targetIsLast, bool forDispell ) const
     {
         const int spellID = spell.GetID();
@@ -250,7 +275,7 @@ namespace AI
             break;
         }
         case Spell::DISRUPTINGRAY:
-            ratio = 0.2;
+            ratio = getDisruptingRayRatio( target );
             break;
         case Spell::HASTE:
         case Spell::MASSHASTE:


### PR DESCRIPTION
Relates to #4567

I changed the logic a little:
- if enemy has already defense < 4, we reduce the score of disrupting ray
(really rare corner case)
- if we have a weak army, it means we will do weak direct damage, so
it reduces the usefulness of disrupting ray. In that case I reduce the
score

If I replay the fight of #4567 it will make the AI stop spamming DR
and cast lightning bolt on the titans

NB : in theory the "enemy strength" should take into account the actual
enemy defense, that would also get lower as we cast DR on the enemy.
But the logic change I'm doing is still valid IMO