### PR TITLE
Load palette from AGG file

### DIFF
--- a/fheroes2-vs2015.vcxproj
+++ b/fheroes2-vs2015.vcxproj
@@ -176,6 +176,7 @@
     <ClCompile Include="src\engine\core.cpp" />
     <ClCompile Include="src\engine\dir.cpp" />
     <ClCompile Include="src\engine\image.cpp" />
+    <ClCompile Include="src\engine\image_palette.cpp" />
     <ClCompile Include="src\engine\image_tool.cpp" />
     <ClCompile Include="src\engine\localevent.cpp" />
     <ClCompile Include="src\engine\logging.cpp" />
@@ -390,6 +391,7 @@
     <ClInclude Include="src\engine\core.h" />
     <ClInclude Include="src\engine\dir.h" />
     <ClInclude Include="src\engine\image.h" />
+	<ClInclude Include="src\engine\image_palette.h" />
     <ClInclude Include="src\engine\image_tool.h" />
     <ClInclude Include="src\engine\logging.h" />
     <ClInclude Include="src\engine\localevent.h" />

--- a/fheroes2-vs2019.vcxproj
+++ b/fheroes2-vs2019.vcxproj
@@ -177,6 +177,7 @@
     <ClCompile Include="src\engine\core.cpp" />
     <ClCompile Include="src\engine\dir.cpp" />
     <ClCompile Include="src\engine\image.cpp" />
+    <ClCompile Include="src\engine\image_palette.cpp" />
     <ClCompile Include="src\engine\image_tool.cpp" />
     <ClCompile Include="src\engine\localevent.cpp" />
     <ClCompile Include="src\engine\logging.cpp" />
@@ -391,6 +392,7 @@
     <ClInclude Include="src\engine\core.h" />
     <ClInclude Include="src\engine\dir.h" />
     <ClInclude Include="src\engine\image.h" />
+    <ClInclude Include="src\engine\image_palette.h" />
     <ClInclude Include="src\engine\image_tool.h" />
     <ClInclude Include="src\engine\logging.h" />
     <ClInclude Include="src\engine\localevent.h" />

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -19,7 +19,7 @@
  ***************************************************************************/
 
 #include "image.h"
-#include "palette_h2.h"
+#include "image_palette.h"
 
 #include <cassert>
 #include <cstdlib>
@@ -331,6 +331,8 @@ namespace
             uint32_t g = 0;
             uint32_t b = 0;
 
+            const uint8_t * gamePalette = fheroes2::getGamePalette();
+
             for ( uint32_t id = 0; id < size; ++id ) {
                 r = ( id % 64 );
                 g = ( id >> 6 ) % 64;
@@ -341,7 +343,7 @@ namespace
                 const uint8_t * correctorX = transformTable + 256 * 15;
 
                 for ( uint32_t i = 0; i < 256; ++i, ++correctorX ) {
-                    const uint8_t * palette = kb_pal + *correctorX * 3;
+                    const uint8_t * palette = gamePalette + *correctorX * 3;
 
                     const int32_t offsetRed = static_cast<int32_t>( *palette ) - static_cast<int32_t>( r );
                     ++palette;
@@ -749,6 +751,8 @@ namespace fheroes2
 
         const uint8_t behindValue = 255 - alphaValue;
 
+        const uint8_t * gamePalette = fheroes2::getGamePalette();
+
         if ( flip ) {
             const int32_t offsetInY = inY * widthIn + widthIn - 1 - inX;
             const uint8_t * imageInY = in.image() + offsetInY;
@@ -774,8 +778,8 @@ namespace fheroes2
                         inValue = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
                     }
 
-                    const uint8_t * inPAL = kb_pal + inValue * 3;
-                    const uint8_t * outPAL = kb_pal + ( *imageOutX ) * 3;
+                    const uint8_t * inPAL = gamePalette + inValue * 3;
+                    const uint8_t * outPAL = gamePalette + ( *imageOutX ) * 3;
 
                     const uint32_t red = static_cast<uint32_t>( *inPAL ) * alphaValue + static_cast<uint32_t>( *outPAL ) * behindValue;
                     const uint32_t green = static_cast<uint32_t>( *( inPAL + 1 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 1 ) ) * behindValue;
@@ -808,8 +812,8 @@ namespace fheroes2
                         inValue = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
                     }
 
-                    const uint8_t * inPAL = kb_pal + inValue * 3;
-                    const uint8_t * outPAL = kb_pal + ( *imageOutX ) * 3;
+                    const uint8_t * inPAL = gamePalette + inValue * 3;
+                    const uint8_t * outPAL = gamePalette + ( *imageOutX ) * 3;
 
                     const uint32_t red = static_cast<uint32_t>( *inPAL ) * alphaValue + static_cast<uint32_t>( *outPAL ) * behindValue;
                     const uint32_t green = static_cast<uint32_t>( *( inPAL + 1 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 1 ) ) * behindValue;
@@ -876,7 +880,7 @@ namespace fheroes2
     {
         std::vector<uint8_t> palette( 256 );
 
-        const uint8_t * value = kb_pal;
+        const uint8_t * value = fheroes2::getGamePalette();
 
         for ( uint32_t i = 0; i < 256; ++i ) {
             const uint32_t red = static_cast<uint32_t>( *value ) * alpha / 255;
@@ -1129,6 +1133,8 @@ namespace fheroes2
         uint8_t * imageOutY = out.image();
         const uint8_t * imageIn = in.image();
 
+        const uint8_t * gamePalette = fheroes2::getGamePalette();
+
         for ( int32_t y = 0; y < height; ++y, imageOutY += width ) {
             uint8_t * imageOutX = imageOutY;
 
@@ -1164,7 +1170,7 @@ namespace fheroes2
                     const uint8_t * imageInX = imageInY;
                     const uint8_t * imageInXEnd = imageInX + roiWidth;
                     for ( ; imageInX != imageInXEnd; ++imageInX ) {
-                        const uint8_t * palette = kb_pal + *imageInX * 3;
+                        const uint8_t * palette = gamePalette + *imageInX * 3;
 
                         sumRed += ( *palette );
                         ++palette;
@@ -1834,6 +1840,8 @@ namespace fheroes2
             for ( int32_t y = 0; y < heightRoiOut; ++y )
                 positionY[y] = static_cast<double>( y * heightRoiIn ) / heightRoiOut;
 
+            const uint8_t * gamePalette = fheroes2::getGamePalette();
+
             if ( in.singleLayer() && out.singleLayer() ) {
                 for ( int32_t y = 0; y < heightRoiOut; ++y, imageOutY += widthOut ) {
                     const double posY = positionY[y];
@@ -1856,10 +1864,10 @@ namespace fheroes2
                             const double coeff3 = ( 1 - coeffX ) * coeffY;
                             const double coeff4 = coeffX * coeffY;
 
-                            const uint8_t * id1 = kb_pal + static_cast<uint32_t>( *imageInX ) * 3;
-                            const uint8_t * id2 = kb_pal + static_cast<uint32_t>( *( imageInX + 1 ) ) * 3;
-                            const uint8_t * id3 = kb_pal + static_cast<uint32_t>( *( imageInX + widthIn ) ) * 3;
-                            const uint8_t * id4 = kb_pal + static_cast<uint32_t>( *( imageInX + widthIn + 1 ) ) * 3;
+                            const uint8_t * id1 = gamePalette + static_cast<uint32_t>( *imageInX ) * 3;
+                            const uint8_t * id2 = gamePalette + static_cast<uint32_t>( *( imageInX + 1 ) ) * 3;
+                            const uint8_t * id3 = gamePalette + static_cast<uint32_t>( *( imageInX + widthIn ) ) * 3;
+                            const uint8_t * id4 = gamePalette + static_cast<uint32_t>( *( imageInX + widthIn + 1 ) ) * 3;
 
                             const double red = *id1 * coeff1 + *id2 * coeff2 + *id3 * coeff3 + *id4 * coeff4 + 0.5;
                             const double green = *( id1 + 1 ) * coeff1 + *( id2 + 1 ) * coeff2 + *( id3 + 1 ) * coeff3 + *( id4 + 1 ) * coeff4 + 0.5;
@@ -1901,10 +1909,10 @@ namespace fheroes2
                                 const double coeff3 = ( 1 - coeffX ) * coeffY;
                                 const double coeff4 = coeffX * coeffY;
 
-                                const uint8_t * id1 = kb_pal + static_cast<uint32_t>( *imageInX ) * 3;
-                                const uint8_t * id2 = kb_pal + static_cast<uint32_t>( *( imageInX + 1 ) ) * 3;
-                                const uint8_t * id3 = kb_pal + static_cast<uint32_t>( *( imageInX + widthIn ) ) * 3;
-                                const uint8_t * id4 = kb_pal + static_cast<uint32_t>( *( imageInX + widthIn + 1 ) ) * 3;
+                                const uint8_t * id1 = gamePalette + static_cast<uint32_t>( *imageInX ) * 3;
+                                const uint8_t * id2 = gamePalette + static_cast<uint32_t>( *( imageInX + 1 ) ) * 3;
+                                const uint8_t * id3 = gamePalette + static_cast<uint32_t>( *( imageInX + widthIn ) ) * 3;
+                                const uint8_t * id4 = gamePalette + static_cast<uint32_t>( *( imageInX + widthIn + 1 ) ) * 3;
 
                                 const double red = *id1 * coeff1 + *id2 * coeff2 + *id3 * coeff3 + *id4 * coeff4 + 0.5;
                                 const double green = *( id1 + 1 ) * coeff1 + *( id2 + 1 ) * coeff2 + *( id3 + 1 ) * coeff3 + *( id4 + 1 ) * coeff4 + 0.5;

--- a/src/engine/image_palette.cpp
+++ b/src/engine/image_palette.cpp
@@ -36,7 +36,7 @@ namespace
             std::copy_n( kb_pal, paletteSize, gamePalette.begin() );
         }
 
-        std::array<uint8_t, 768> gamePalette;
+        std::array<uint8_t, paletteSize> gamePalette;
     };
 
     PaletteHolder paletteHolder;

--- a/src/engine/image_palette.cpp
+++ b/src/engine/image_palette.cpp
@@ -1,0 +1,61 @@
+/***************************************************************************
+ *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
+ *   Copyright (C) 2021                                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "image_palette.h"
+#include "palette_h2.h"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+
+namespace
+{
+    const size_t paletteSize = 768;
+
+    struct PaletteHolder
+    {
+        PaletteHolder()
+        {
+            std::copy_n( kb_pal, paletteSize, gamePalette.begin() );
+        }
+
+        std::array<uint8_t, 768> gamePalette;
+    };
+
+    PaletteHolder paletteHolder;
+}
+
+namespace fheroes2
+{
+    const uint8_t * getGamePalette()
+    {
+        return paletteHolder.gamePalette.data();
+    }
+
+    void setGamePalette( const std::vector<uint8_t> & palette )
+    {
+        assert( palette.size() == paletteSize );
+        if ( palette.size() != paletteSize ) {
+            return;
+        }
+
+        std::copy_n( palette.begin(), paletteSize, paletteHolder.gamePalette.begin() );
+    }
+}

--- a/src/engine/image_palette.h
+++ b/src/engine/image_palette.h
@@ -1,0 +1,32 @@
+/***************************************************************************
+ *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
+ *   Copyright (C) 2021                                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace fheroes2
+{
+    const uint8_t * getGamePalette();
+
+    // This function must be called only at the start of the application after loading AGG file content.
+    void setGamePalette( const std::vector<uint8_t> & palette );
+}

--- a/src/engine/image_tool.cpp
+++ b/src/engine/image_tool.cpp
@@ -20,8 +20,8 @@
 
 #include <string>
 
-#include "image_tool.h"
 #include "image_palette.h"
+#include "image_tool.h"
 
 #include <SDL_version.h>
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )

--- a/src/engine/image_tool.cpp
+++ b/src/engine/image_tool.cpp
@@ -21,7 +21,7 @@
 #include <string>
 
 #include "image_tool.h"
-#include "palette_h2.h"
+#include "image_palette.h"
 
 #include <SDL_version.h>
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
@@ -39,11 +39,13 @@
 
 namespace
 {
-    std::vector<uint8_t> PALPAlette()
+    std::vector<uint8_t> PALPalette()
     {
+        const uint8_t * gamePalette = fheroes2::getGamePalette();
+
         std::vector<uint8_t> palette( 256 * 3 );
         for ( size_t i = 0; i < palette.size(); ++i ) {
-            palette[i] = kb_pal[i] << 2;
+            palette[i] = gamePalette[i] << 2;
         }
 
         return palette;
@@ -51,7 +53,7 @@ namespace
 
     bool SaveImage( const fheroes2::Image & image, const std::string & path )
     {
-        const std::vector<uint8_t> & palette = PALPAlette();
+        const std::vector<uint8_t> & palette = PALPalette();
         const uint8_t * currentPalette = palette.data();
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -19,7 +19,7 @@
  ***************************************************************************/
 
 #include "screen.h"
-#include "palette_h2.h"
+#include "image_palette.h"
 #include "tools.h"
 
 #include <SDL_version.h>
@@ -126,13 +126,15 @@ namespace
         return indexes;
     }
 
-    const uint8_t * PALPAlette()
+    const uint8_t * PALPalette()
     {
         static std::vector<uint8_t> palette;
         if ( palette.empty() ) {
+            const uint8_t * gamePalette = fheroes2::getGamePalette();
+
             palette.resize( 256 * 3 );
             for ( size_t i = 0; i < palette.size(); ++i ) {
-                palette[i] = kb_pal[i] << 2;
+                palette[i] = gamePalette[i] << 2;
             }
         }
 
@@ -179,7 +181,7 @@ namespace
         return true;
     }
 
-    const uint8_t * currentPalette = PALPAlette();
+    const uint8_t * currentPalette = PALPalette();
 
 // If SDL library is used
 #if !defined( FHEROES2_VITA )
@@ -1389,10 +1391,10 @@ namespace fheroes2
 
     void Display::changePalette( const uint8_t * palette ) const
     {
-        if ( currentPalette == palette || ( palette == nullptr && currentPalette == PALPAlette() ) )
+        if ( currentPalette == palette || ( palette == nullptr && currentPalette == PALPalette() ) )
             return;
 
-        currentPalette = ( palette == nullptr ) ? PALPAlette() : palette;
+        currentPalette = ( palette == nullptr ) ? PALPalette() : palette;
 
         _engine->updatePalette( StandardPaletteIndexes() );
     }

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -33,6 +33,7 @@
 #include "game.h"
 #include "game_logo.h"
 #include "game_video.h"
+#include "image_palette.h"
 #include "localevent.h"
 #include "logging.h"
 #include "screen.h"
@@ -205,6 +206,9 @@ int main( int argc, char ** argv )
         const DisplayInitializer displayInitializer;
 
         const AGG::AGGInitializer aggInitializer;
+
+        // Load palette.
+        fheroes2::setGamePalette( AGG::ReadChunk( "KB.PAL" ) );
 
         // load BIN data
         Bin_Info::InitBinInfo();

--- a/src/tools/icn2img-vs2015.vcxproj
+++ b/src/tools/icn2img-vs2015.vcxproj
@@ -171,9 +171,10 @@
   <ItemGroup>
     <ClCompile Include="..\engine\agg_file.cpp" />
     <ClCompile Include="..\engine\audio.cpp" />
+    <ClCompile Include="..\engine\core.cpp" />
     <ClCompile Include="..\engine\dir.cpp" />
-    <ClCompile Include="..\engine\engine.cpp" />
     <ClCompile Include="..\engine\image.cpp" />
+    <ClCompile Include="..\engine\image_palette.cpp" />
     <ClCompile Include="..\engine\image_tool.cpp" />
     <ClCompile Include="..\engine\localevent.cpp" />
     <ClCompile Include="..\engine\logging.cpp" />
@@ -183,7 +184,6 @@
     <ClCompile Include="..\engine\serialize.cpp" />
     <ClCompile Include="..\engine\smk_decoder.cpp" />
     <ClCompile Include="..\engine\system.cpp" />
-    <ClCompile Include="..\engine\timer.cpp" />
     <ClCompile Include="..\engine\timing.cpp" />
     <ClCompile Include="..\engine\tinyconfig.cpp" />
     <ClCompile Include="..\engine\tools.cpp" />
@@ -198,9 +198,10 @@
   <ItemGroup>
     <ClInclude Include="..\engine\agg_file.h" />
     <ClInclude Include="..\engine\audio.h" />
+    <ClInclude Include="..\engine\core.h" />
     <ClInclude Include="..\engine\dir.h" />
-    <ClInclude Include="..\engine\engine.h" />
     <ClInclude Include="..\engine\image.h" />
+    <ClInclude Include="..\engine\image_palette.h" />
     <ClInclude Include="..\engine\image_tool.h" />
     <ClInclude Include="..\engine\localevent.h" />
     <ClInclude Include="..\engine\logging.h" />
@@ -213,7 +214,6 @@
     <ClInclude Include="..\engine\serialize.h" />
     <ClInclude Include="..\engine\smk_decoder.h" />
     <ClInclude Include="..\engine\system.h" />
-    <ClInclude Include="..\engine\timer.h" />
     <ClInclude Include="..\engine\timing.h" />
     <ClInclude Include="..\engine\tinyconfig.h" />
     <ClInclude Include="..\engine\tools.h" />

--- a/src/tools/icn2img-vs2019.vcxproj
+++ b/src/tools/icn2img-vs2019.vcxproj
@@ -171,9 +171,10 @@
   <ItemGroup>
     <ClCompile Include="..\engine\agg_file.cpp" />
     <ClCompile Include="..\engine\audio.cpp" />
+    <ClCompile Include="..\engine\core.cpp" />
     <ClCompile Include="..\engine\dir.cpp" />
-    <ClCompile Include="..\engine\engine.cpp" />
     <ClCompile Include="..\engine\image.cpp" />
+    <ClCompile Include="..\engine\image_palette.cpp" />
     <ClCompile Include="..\engine\image_tool.cpp" />
     <ClCompile Include="..\engine\localevent.cpp" />
     <ClCompile Include="..\engine\logging.cpp" />
@@ -183,7 +184,6 @@
     <ClCompile Include="..\engine\serialize.cpp" />
     <ClCompile Include="..\engine\smk_decoder.cpp" />
     <ClCompile Include="..\engine\system.cpp" />
-    <ClCompile Include="..\engine\timer.cpp" />
     <ClCompile Include="..\engine\timing.cpp" />
     <ClCompile Include="..\engine\tinyconfig.cpp" />
     <ClCompile Include="..\engine\tools.cpp" />
@@ -198,9 +198,10 @@
   <ItemGroup>
     <ClInclude Include="..\engine\agg_file.h" />
     <ClInclude Include="..\engine\audio.h" />
+    <ClInclude Include="..\engine\core.h" />
     <ClInclude Include="..\engine\dir.h" />
-    <ClInclude Include="..\engine\engine.h" />
     <ClInclude Include="..\engine\image.h" />
+    <ClInclude Include="..\engine\image_palette.h" />
     <ClInclude Include="..\engine\image_tool.h" />
     <ClInclude Include="..\engine\localevent.h" />
     <ClInclude Include="..\engine\logging.h" />
@@ -213,7 +214,6 @@
     <ClInclude Include="..\engine\serialize.h" />
     <ClInclude Include="..\engine\smk_decoder.h" />
     <ClInclude Include="..\engine\system.h" />
-    <ClInclude Include="..\engine\timer.h" />
     <ClInclude Include="..\engine\timing.h" />
     <ClInclude Include="..\engine\tinyconfig.h" />
     <ClInclude Include="..\engine\tools.h" />

--- a/src/tools/icn2img.cpp
+++ b/src/tools/icn2img.cpp
@@ -33,7 +33,7 @@
 
 int main( int argc, char ** argv )
 {
-    if ( argc < 4 ) {
+    if ( argc != 4 ) {
         std::cout << argv[0] << " inputFile.icn destinationDirectory paletteFileName.pal" << std::endl;
         return EXIT_FAILURE;
     }
@@ -105,6 +105,8 @@ int main( int argc, char ** argv )
             dstfile += ".png";
             shortdstfile += ".png";
 #endif
+            std::cout << "Image " << ii + 1 << " has offset of [" << head.offsetX << ", " << head.offsetY << "]" << std::endl;
+
             fheroes2::Save( image, dstfile, 23 );
         }
     }

--- a/src/tools/icn2img.cpp
+++ b/src/tools/icn2img.cpp
@@ -105,7 +105,8 @@ int main( int argc, char ** argv )
             dstfile += ".png";
             shortdstfile += ".png";
 #endif
-            std::cout << "Image " << ii + 1 << " has offset of [" << head.offsetX << ", " << head.offsetY << "]" << std::endl;
+            std::cout << "Image " << ii + 1 << " has offset of [" << static_cast<int32_t>( head.offsetX ) << ", " << static_cast<int32_t>( head.offsetY ) << "]"
+                      << std::endl;
 
             fheroes2::Save( image, dstfile, 23 );
         }

--- a/src/tools/icn2img.cpp
+++ b/src/tools/icn2img.cpp
@@ -38,7 +38,7 @@ int main( int argc, char ** argv )
         return EXIT_FAILURE;
     }
 
-    std::string intpuFileName( argv[1] );
+    std::string inputFileName( argv[1] );
     std::string prefix( argv[2] );
 
     std::string paletteFileName( argv[3] );
@@ -59,16 +59,16 @@ int main( int argc, char ** argv )
 
     StreamFile sf;
 
-    if ( !sf.open( intpuFileName, "rb" ) ) {
-        std::cout << "Cannot open " << intpuFileName << std::endl;
+    if ( !sf.open( inputFileName, "rb" ) ) {
+        std::cout << "Cannot open " << inputFileName << std::endl;
         return EXIT_FAILURE;
     }
 
     int count_sprite = sf.getLE16();
     int total_size = sf.getLE32();
 
-    intpuFileName.replace( intpuFileName.find( ".icn" ), 4, "" );
-    prefix = System::ConcatePath( prefix, intpuFileName );
+    inputFileName.replace( inputFileName.find( ".icn" ), 4, "" );
+    prefix = System::ConcatePath( prefix, inputFileName );
 
     if ( 0 != System::MakeDirectory( prefix ) ) {
         std::cout << "error mkdir: " << prefix << std::endl;


### PR DESCRIPTION
icn2img tool now requires original kb.pal file.

The solution is not ideal as Display class needs a valid palette at the initialization.