### PR TITLE
Fix heuristic for slow/haste spell in battle

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -97,7 +97,9 @@ namespace AI
         SpellcastOutcome spellSummonValue( const Spell & spell, const Battle::Arena & arena, const int heroColor ) const;
         SpellcastOutcome spellEffectValue( const Spell & spell, const Battle::Units & targets ) const;
         double spellEffectValue( const Spell & spell, const Battle::Unit & target, bool targetIsLast, bool forDispell ) const;
-        double getDisruptingRayRatio( const Battle::Unit & target ) const;
+        double getSpellDisruptingRayRatio( const Battle::Unit & target ) const;
+        double getSpellSlowRatio( const Battle::Unit & target ) const;
+        double getSpellHasteRatio( const Battle::Unit & target ) const;
         uint32_t spellDurationMultiplier( const Battle::Unit & target ) const;
 
         // turn variables that wouldn't persist
@@ -107,6 +109,7 @@ namespace AI
         double _enemyArmyStrength = 0;
         double _myShooterStr = 0;
         double _enemyShooterStr = 0;
+        double _myArmyAverageSpeed = 0;
         double _enemyAverageSpeed = 0;
         double _enemySpellStrength = 0;
         int _highestDamageExpected = 0;

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -466,14 +466,14 @@ void Battle::Unit::NewTurn( void )
     }
 }
 
-u32 Battle::Unit::GetSpeed( bool skip_standing_check, bool skip_moved_check ) const
+u32 Battle::Unit::GetSpeed( bool skipStandingCheck, bool skipMovedCheck ) const
 {
     uint32_t modesToCheck = SP_BLIND | IS_PARALYZE_MAGIC;
-    if ( !skip_moved_check ) {
+    if ( !skipMovedCheck ) {
         modesToCheck |= TR_MOVED;
     }
 
-    if ( !skip_standing_check && ( !GetCount() || Modes( modesToCheck ) ) )
+    if ( !skipStandingCheck && ( !GetCount() || Modes( modesToCheck ) ) )
         return Speed::STANDING;
 
     uint32_t speed = Monster::GetSpeed();

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -221,7 +221,7 @@ std::string Battle::Unit::GetShotString( void ) const
 
 std::string Battle::Unit::GetSpeedString() const
 {
-    const uint32_t speedValue = GetSpeed( true );
+    const uint32_t speedValue = GetSpeed( true, false );
 
     std::string output( Speed::String( speedValue ) );
     output += " (";
@@ -260,7 +260,7 @@ u32 Battle::Unit::GetAffectedDuration( u32 mod ) const
 
 u32 Battle::Unit::GetSpeed( void ) const
 {
-    return GetSpeed( false );
+    return GetSpeed( false, false );
 }
 
 int Battle::Unit::GetMorale() const
@@ -377,7 +377,7 @@ bool Battle::Unit::canReach( int index ) const
 
     const bool isIndirectAttack = isReflect() == Board::isNegativeDistance( GetHeadIndex(), index );
     const int from = ( isWide() && isIndirectAttack ) ? GetTailIndex() : GetHeadIndex();
-    return Board::GetDistance( from, index ) <= GetSpeed( true );
+    return Board::GetDistance( from, index ) <= GetSpeed( true, false );
 }
 
 bool Battle::Unit::canReach( const Unit & unit ) const
@@ -466,21 +466,24 @@ void Battle::Unit::NewTurn( void )
     }
 }
 
-u32 Battle::Unit::GetSpeed( bool skip_standing_check ) const
+u32 Battle::Unit::GetSpeed( bool skip_standing_check, bool skip_moved_check ) const
 {
-    if ( !skip_standing_check && ( !GetCount() || Modes( TR_MOVED | SP_BLIND | IS_PARALYZE_MAGIC ) ) )
+    uint32_t modesToCheck = SP_BLIND | IS_PARALYZE_MAGIC;
+    if ( !skip_moved_check ) {
+        modesToCheck |= TR_MOVED;
+    }
+
+    if ( !skip_standing_check && ( !GetCount() || Modes( modesToCheck ) ) )
         return Speed::STANDING;
 
     uint32_t speed = Monster::GetSpeed();
     Spell spell;
 
     if ( Modes( SP_HASTE ) ) {
-        spell = Spell::HASTE;
-        return spell.ExtraValue() ? speed + spell.ExtraValue() : Speed::GetOriginalFast( speed );
+        return Speed::GetHasteSpeedFromSpell( speed );
     }
     else if ( Modes( SP_SLOW ) ) {
-        spell = Spell::SLOW;
-        return spell.ExtraValue() ? speed - spell.ExtraValue() : Speed::GetOriginalSlow( speed );
+        return Speed::GetSlowSpeedFromSpell( speed );
     }
 
     return speed;
@@ -488,7 +491,7 @@ u32 Battle::Unit::GetSpeed( bool skip_standing_check ) const
 
 uint32_t Battle::Unit::GetMoveRange() const
 {
-    return isFlying() ? ARENASIZE : GetSpeed( false );
+    return isFlying() ? ARENASIZE : GetSpeed( false, false );
 }
 
 uint32_t Battle::Unit::CalculateRetaliationDamage( uint32_t damageTaken ) const

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -132,7 +132,7 @@ namespace Battle
         int GetCurrentOrArmyColor() const; // current unit color (if valid), color of the unit's army otherwise
         int GetCurrentControl() const;
         uint32_t GetMoveRange() const;
-        u32 GetSpeed( bool skip_standing_check ) const;
+        u32 GetSpeed( bool skip_standing_check, bool skip_moved_check ) const;
         int GetControl() const override;
         u32 GetDamage( const Unit & ) const;
         s32 GetScoreQuality( const Unit & ) const;

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -132,7 +132,7 @@ namespace Battle
         int GetCurrentOrArmyColor() const; // current unit color (if valid), color of the unit's army otherwise
         int GetCurrentControl() const;
         uint32_t GetMoveRange() const;
-        u32 GetSpeed( bool skip_standing_check, bool skip_moved_check ) const;
+        u32 GetSpeed( bool skipStandingCheck, bool skipMovedCheck ) const;
         int GetControl() const override;
         u32 GetDamage( const Unit & ) const;
         s32 GetScoreQuality( const Unit & ) const;

--- a/src/fheroes2/kingdom/speed.cpp
+++ b/src/fheroes2/kingdom/speed.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include "speed.h"
+#include "spell.h"
 #include "translations.h"
 
 std::string Speed::String( int speed )
@@ -101,4 +102,16 @@ int Speed::GetOriginalFast( int speed )
     }
 
     return STANDING;
+}
+
+int Speed::GetSlowSpeedFromSpell( const int currentSpeed )
+{
+    Spell spell = Spell::SLOW;
+    return spell.ExtraValue() ? currentSpeed - spell.ExtraValue() : Speed::GetOriginalSlow( currentSpeed );
+}
+
+int Speed::GetHasteSpeedFromSpell( const int currentSpeed )
+{
+    Spell spell = Spell::HASTE;
+    return spell.ExtraValue() ? currentSpeed + spell.ExtraValue() : Speed::GetOriginalFast( currentSpeed );
 }

--- a/src/fheroes2/kingdom/speed.h
+++ b/src/fheroes2/kingdom/speed.h
@@ -40,9 +40,12 @@ namespace Speed
         INSTANT = 9
     };
 
-    std::string String( int );
-    int GetOriginalSlow( int );
-    int GetOriginalFast( int );
+    std::string String( const int speed );
+    int GetOriginalSlow( const int speed );
+    int GetOriginalFast( const int speed );
+
+    int GetSlowSpeedFromSpell( const int currentSpeed );
+    int GetHasteSpeedFromSpell( const int currentSpeed );
 }
 
 #endif


### PR DESCRIPTION
I fixed a few bugs around speed computation, where enemy speed was
incorrectly computed. I also change the "average enemy speed" so it's weighted by monster
strength

I also changed the heuristic a bit so monster that are already slow/fast
don't really benefit that much from the spell

This should somehwat improve issue #4129 even though the problem will still
remain that enemy will cast a slow spell even though it has very low score,
if it's the only spell available