### PR TITLE
Well : Clean up, optimize and make consistent with OG

### DIFF
--- a/src/fheroes2/battle/battle_only.cpp
+++ b/src/fheroes2/battle/battle_only.cpp
@@ -34,6 +34,7 @@
 #include "race.h"
 #include "settings.h"
 #include "skill_bar.h"
+#include "text.h"
 #include "tools.h"
 #include "translations.h"
 #include "ui_text.h"
@@ -181,7 +182,7 @@ bool Battle::Only::ChangeSettings( void )
         if ( allow1 && le.MouseClickLeft( rtPortrait1 ) ) {
             int hid = Dialog::SelectHeroes( hero1 ? hero1->GetID() : Heroes::UNKNOWN );
             if ( hero2 && hid == hero2->GetID() ) {
-                Dialog::Message( _( "Error" ), _( "Please select another hero." ), int( fheroes2::FontSize::LARGE ), Dialog::OK );
+                Dialog::Message( _( "Error" ), _( "Please select another hero." ), Font::BIG, Dialog::OK );
             }
             else if ( Heroes::UNKNOWN != hid ) {
                 hero1 = world.GetHeroes( hid );
@@ -194,7 +195,7 @@ bool Battle::Only::ChangeSettings( void )
         else if ( allow2 && le.MouseClickLeft( rtPortrait2 ) ) {
             int hid = Dialog::SelectHeroes( hero2 ? hero2->GetID() : Heroes::UNKNOWN );
             if ( hero1 && hid == hero1->GetID() ) {
-                Dialog::Message( _( "Error" ), _( "Please select another hero." ), int( fheroes2::FontSize::LARGE ), Dialog::OK );
+                Dialog::Message( _( "Error" ), _( "Please select another hero." ), Font::BIG, Dialog::OK );
             }
             else if ( Heroes::UNKNOWN != hid ) {
                 hero2 = world.GetHeroes( hid );

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -35,8 +35,8 @@
 #include "monster_anim.h"
 #include "resource.h"
 #include "speed.h"
-#include "text.h"
 #include "translations.h"
+#include "ui_text.h"
 
 namespace
 {
@@ -188,10 +188,10 @@ void Castle::OpenWell( void )
                     }
                 }
                 if ( isCreaturePresent ) {
-                    Dialog::Message( "", _( "Not enough resources to buy monsters." ), Font::BIG, Dialog::OK );
+                    Dialog::Message( "", _( "Not enough resources to buy monsters." ), int (fheroes2::FontSize::LARGE), Dialog::OK );
                 }
                 else {
-                    Dialog::Message( "", _( "No monsters available for purchase." ), Font::BIG, Dialog::OK );
+                    Dialog::Message( "", _( "No monsters available for purchase." ), int( fheroes2::FontSize::LARGE ), Dialog::OK );
                 }
             }
             else if ( Dialog::YES == Dialog::ResourceInfo( _( "Buy Monsters" ), str, total, Dialog::YES | Dialog::NO ) ) {
@@ -230,19 +230,21 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
     fheroes2::Display & display = fheroes2::Display::instance();
     fheroes2::Blit( fheroes2::AGG::GetICN( ICN::WELLBKG, 0 ), display, cur_pt.x, cur_pt.y );
 
-    Text text;
+    fheroes2::Text text;
     fheroes2::Point dst_pt;
     fheroes2::Point pt;
+
+    const fheroes2::FontType statsFontType{ fheroes2::FontSize::SMALL, fheroes2::FontColor::WHITE };
 
     const fheroes2::Sprite & button = fheroes2::AGG::GetICN( ICN::BUYMAX, 0 );
     const fheroes2::Rect src_rt( 0, 461, button.width(), 19 );
     fheroes2::Blit( fheroes2::AGG::GetICN( ICN::WELLBKG, 0 ), src_rt.x, src_rt.y, display, cur_pt.x + button.width() + 1, cur_pt.y + 461, src_rt.width, src_rt.height );
     fheroes2::Fill( display, cur_pt.x + button.width(), cur_pt.y + 461, 1, src_rt.height, 0 );
 
-    text.Set( _( "Town Population Information and Statistics" ), Font::BIG );
-    dst_pt.x = cur_pt.x + 315 - text.w() / 2;
-    dst_pt.y = cur_pt.y + 462;
-    text.Blit( dst_pt.x, dst_pt.y );
+    text.set( _( "Town Population Information and Statistics" ), fheroes2::FontType() );
+    dst_pt.x = cur_pt.x + 315 - text.width() / 2;
+    dst_pt.y = cur_pt.y + 464;
+    text.draw( dst_pt.x, dst_pt.y, display );
 
     u32 dw = DWELLING_MONSTER1;
     size_t monsterId = 0u;
@@ -312,29 +314,29 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
         dst_pt.y = pt.y + 35;
         fheroes2::Blit( fheroes2::AGG::GetICN( ICN::Get4Building( race ), icnindex ), display, dst_pt.x, dst_pt.y );
         // text
-        text.Set( GetStringBuilding( dw_orig, race ), Font::SMALL );
-        dst_pt.x = pt.x + 86 - text.w() / 2;
-        dst_pt.y = pt.y + 103;
-        text.Blit( dst_pt.x, dst_pt.y );
+        text.set( GetStringBuilding( dw_orig, race ), statsFontType );
+        dst_pt.x = pt.x + 86 - text.width() / 2;
+        dst_pt.y = pt.y + 104;
+        text.draw( dst_pt.x, dst_pt.y, display );
 
         // name
-        text.Set( monster.GetMultiName() );
-        dst_pt.x = pt.x + 122 - text.w() / 2;
-        dst_pt.y = pt.y + 17;
-        text.Blit( dst_pt.x, dst_pt.y );
+        text.set( monster.GetMultiName(), statsFontType );
+        dst_pt.x = pt.x + 122 - text.width() / 2;
+        dst_pt.y = pt.y + 19;
+        text.draw( dst_pt.x, dst_pt.y, display );
         // attack
         std::string str;
         str = std::string( _( "Attack" ) ) + ": " + std::to_string( monster.GetAttack() );
-        text.Set( str );
-        dst_pt.x = pt.x + 268 - text.w() / 2;
+        text.set( str, statsFontType );
+        dst_pt.x = pt.x + 268 - text.width() / 2;
         dst_pt.y = pt.y + 22;
-        text.Blit( dst_pt.x, dst_pt.y );
+        text.draw( dst_pt.x, dst_pt.y, display );
         // defense
         str = std::string( _( "Defense" ) ) + ": " + std::to_string( monster.GetDefense() );
-        text.Set( str );
-        dst_pt.x = pt.x + 268 - text.w() / 2;
+        text.set( str, statsFontType );
+        dst_pt.x = pt.x + 268 - text.width() / 2;
         dst_pt.y = pt.y + 34;
-        text.Blit( dst_pt.x, dst_pt.y );
+        text.draw( dst_pt.x, dst_pt.y, display );
         // damage
         str = _( "Damg" );
         str += ": ";
@@ -349,26 +351,26 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
             str += std::to_string( monsterMaxDamage );
         }
 
-        text.Set( str );
-        dst_pt.x = pt.x + 268 - text.w() / 2;
+        text.set( str, statsFontType );
+        dst_pt.x = pt.x + 268 - text.width() / 2;
         dst_pt.y = pt.y + 46;
-        text.Blit( dst_pt.x, dst_pt.y );
+        text.draw( dst_pt.x, dst_pt.y, display );
         // hp
         str = std::string( _( "HP" ) ) + ": " + std::to_string( monster.GetHitPoints() );
-        text.Set( str );
-        dst_pt.x = pt.x + 268 - text.w() / 2;
+        text.set( str, statsFontType );
+        dst_pt.x = pt.x + 268 - text.width() / 2;
         dst_pt.y = pt.y + 58;
-        text.Blit( dst_pt.x, dst_pt.y );
+        text.draw( dst_pt.x, dst_pt.y, display );
         // speed
         str = std::string( _( "Speed" ) ) + ": ";
-        text.Set( str );
-        dst_pt.x = pt.x + 268 - text.w() / 2;
+        text.set( str, statsFontType );
+        dst_pt.x = pt.x + 268 - text.width() / 2;
         dst_pt.y = pt.y + 78;
-        text.Blit( dst_pt.x, dst_pt.y );
-        text.Set( Speed::String( monster.GetSpeed() ) );
-        dst_pt.x = pt.x + 268 - text.w() / 2;
+        text.draw( dst_pt.x, dst_pt.y, display );
+        text.set( Speed::String( monster.GetSpeed() ) , statsFontType );
+        dst_pt.x = pt.x + 268 - text.width() / 2;
         dst_pt.y = pt.y + 90;
-        text.Blit( dst_pt.x, dst_pt.y );
+        text.draw( dst_pt.x, dst_pt.y, display );
 
         if ( present ) {
             u32 grown = monster.GetGrown();
@@ -376,25 +378,25 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
             if ( DWELLING_MONSTER1 & dw )
                 grown += building & BUILD_WEL2 ? GetGrownWel2() : 0;
 
-            text.Set( _( "Growth" ) );
-            dst_pt.x = pt.x + 268 - text.w() / 2;
+            text.set( _( "Growth" ), statsFontType );
+            dst_pt.x = pt.x + 268 - text.width() / 2;
             dst_pt.y = pt.y + 110;
-            text.Blit( dst_pt.x, dst_pt.y );
+            text.draw( dst_pt.x, dst_pt.y, display );
             str = std::string( "+ " ) + std::to_string( grown ) + " / " + _( "week" );
-            text.Set( str );
-            dst_pt.x = pt.x + 268 - text.w() / 2;
+            text.set( str, statsFontType );
+            dst_pt.x = pt.x + 268 - text.width() / 2;
             dst_pt.y = pt.y + 122;
-            text.Blit( dst_pt.x, dst_pt.y );
+            text.draw( dst_pt.x, dst_pt.y, display);
 
             str = std::string( _( "Available" ) ) + ": ";
-            text.Set( str );
+            text.set( str, statsFontType );
             dst_pt.x = pt.x + 44;
             dst_pt.y = pt.y + 122;
-            text.Blit( dst_pt.x, dst_pt.y );
-            text.Set( std::to_string( available ), Font::YELLOW_BIG );
-            dst_pt.x = pt.x + 129 - text.w() / 2;
+            text.draw( dst_pt.x, dst_pt.y, display );
+            text.set( std::to_string( available ), { fheroes2::FontSize::NORMAL, fheroes2::FontColor::YELLOW } );
+            dst_pt.x = pt.x + 129 - text.width() / 2;
             dst_pt.y = pt.y + 119;
-            text.Blit( dst_pt.x, dst_pt.y );
+            text.draw( dst_pt.x, dst_pt.y, display );
         }
 
         // monster

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -313,7 +313,7 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
         dst_pt.x = pt.x + 21;
         dst_pt.y = pt.y + 35;
         fheroes2::Blit( fheroes2::AGG::GetICN( ICN::Get4Building( race ), icnindex ), display, dst_pt.x, dst_pt.y );
-       
+
         // texts
         const std::string monsterBuilding = GetStringBuilding( dw_orig, race );
 
@@ -354,7 +354,7 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
         // defense
         str = _( "Defense" );
         str += ": ";
-        
+
         const uint32_t monsterDefense = monster.GetDefense();
 
         str += std::to_string( monsterDefense );
@@ -384,7 +384,7 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
         dst_pt.y = pt.y + statsOffsetY;
         text.draw( dst_pt.x, dst_pt.y, display );
         statsOffsetY += text.height( text.width() );
-       
+
         // hp
         str = _( "HP" );
         str += ": ";
@@ -419,14 +419,12 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
 
         // weekly growth
         if ( present ) {
-
             uint32_t monsterGrown = monster.GetGrown();
             monsterGrown += building & BUILD_WELL ? GetGrownWell() : 0;
 
             if ( DWELLING_MONSTER1 & dw ) {
                 monsterGrown += building & BUILD_WEL2 ? GetGrownWel2() : 0;
             }
-
 
             text.set( _( "Growth" ), statsFontType );
             dst_pt.x = pt.x + statsOffsetX - text.width() / 2;

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -35,6 +35,7 @@
 #include "monster_anim.h"
 #include "resource.h"
 #include "speed.h"
+#include "text.h"
 #include "translations.h"
 #include "ui_text.h"
 
@@ -188,10 +189,10 @@ void Castle::OpenWell( void )
                     }
                 }
                 if ( isCreaturePresent ) {
-                    Dialog::Message( "", _( "Not enough resources to buy monsters." ), int( fheroes2::FontSize::LARGE ), Dialog::OK );
+                    Dialog::Message( "", _( "Not enough resources to buy monsters." ), Font::BIG, Dialog::OK );
                 }
                 else {
-                    Dialog::Message( "", _( "No monsters available for purchase." ), int( fheroes2::FontSize::LARGE ), Dialog::OK );
+                    Dialog::Message( "", _( "No monsters available for purchase." ), Font::BIG, Dialog::OK );
                 }
             }
             else if ( Dialog::YES == Dialog::ResourceInfo( _( "Buy Monsters" ), str, total, Dialog::YES | Dialog::NO ) ) {

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -441,7 +441,6 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
             dst_pt.x = pt.x + statsOffsetX - text.width() / 2;
             dst_pt.y = pt.y + statsOffsetY;
             text.draw( dst_pt.x, dst_pt.y, display );
-            statsOffsetY += text.height( text.width() );
 
             str = _( "Available" );
             str += ':';

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -336,7 +336,7 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
         dst_pt.y = pt.y + 34;
         text.Blit( dst_pt.x, dst_pt.y );
         // damage
-        str = std::string( _( "Damage" ) ) + ": ";
+        str = std::string( _( "Damg" ) ) + ": ";
 
         if ( monster.GetDamageMin() != monster.GetDamageMax() ) {
             str.append( std::to_string( monster.GetDamageMin() ) + "-" + std::to_string( monster.GetDamageMax() ) );

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -188,7 +188,7 @@ void Castle::OpenWell( void )
                     }
                 }
                 if ( isCreaturePresent ) {
-                    Dialog::Message( "", _( "Not enough resources to buy monsters." ), int (fheroes2::FontSize::LARGE), Dialog::OK );
+                    Dialog::Message( "", _( "Not enough resources to buy monsters." ), int( fheroes2::FontSize::LARGE ), Dialog::OK );
                 }
                 else {
                     Dialog::Message( "", _( "No monsters available for purchase." ), int( fheroes2::FontSize::LARGE ), Dialog::OK );
@@ -367,7 +367,7 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
         dst_pt.x = pt.x + 268 - text.width() / 2;
         dst_pt.y = pt.y + 78;
         text.draw( dst_pt.x, dst_pt.y, display );
-        text.set( Speed::String( monster.GetSpeed() ) , statsFontType );
+        text.set( Speed::String( monster.GetSpeed() ), statsFontType );
         dst_pt.x = pt.x + 268 - text.width() / 2;
         dst_pt.y = pt.y + 90;
         text.draw( dst_pt.x, dst_pt.y, display );
@@ -386,7 +386,7 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
             text.set( str, statsFontType );
             dst_pt.x = pt.x + 268 - text.width() / 2;
             dst_pt.y = pt.y + 122;
-            text.draw( dst_pt.x, dst_pt.y, display);
+            text.draw( dst_pt.x, dst_pt.y, display );
 
             str = std::string( _( "Available" ) ) + ": ";
             text.set( str, statsFontType );

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -336,13 +336,17 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
         dst_pt.y = pt.y + 34;
         text.Blit( dst_pt.x, dst_pt.y );
         // damage
-        str = std::string( _( "Damg" ) ) + ": ";
+        str = _( "Damg" );
+        str += ": ";
 
-        if ( monster.GetDamageMin() != monster.GetDamageMax() ) {
-            str.append( std::to_string( monster.GetDamageMin() ) + "-" + std::to_string( monster.GetDamageMax() ) );
-        }
-        else {
-            str.append( std::to_string( monster.GetDamageMin() ) );
+        const uint32_t monsterMinDamage = monster.GetDamageMin();
+        const uint32_t monsterMaxDamage = monster.GetDamageMax();
+
+        str += std::to_string( monsterMinDamage );
+
+        if ( monsterMinDamage != monsterMaxDamage ) {
+            str += '-';
+            str += std::to_string( monsterMaxDamage );
         }
 
         text.Set( str );

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -336,7 +336,15 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
         dst_pt.y = pt.y + 34;
         text.Blit( dst_pt.x, dst_pt.y );
         // damage
-        str = std::string( _( "Damage" ) ) + ": " + std::to_string( monster.GetDamageMin() ) + "-" + std::to_string( monster.GetDamageMax() );
+        str = std::string( _( "Damage" ) ) + ": ";
+
+        if ( monster.GetDamageMin() != monster.GetDamageMax() ) {
+            str.append( std::to_string( monster.GetDamageMin() ) + "-" + std::to_string( monster.GetDamageMax() ) );
+        }
+        else {
+            str.append( std::to_string( monster.GetDamageMin() ) );
+        }
+
         text.Set( str );
         dst_pt.x = pt.x + 268 - text.w() / 2;
         dst_pt.y = pt.y + 46;

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -314,38 +314,30 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
         dst_pt.y = pt.y + 35;
         fheroes2::Blit( fheroes2::AGG::GetICN( ICN::Get4Building( race ), icnindex ), display, dst_pt.x, dst_pt.y );
 
-        // texts
-        const std::string monsterBuilding = GetStringBuilding( dw_orig, race );
-
-        text.set( monsterBuilding, statsFontType );
+        // monster dwelling name
+        text.set( GetStringBuilding( dw_orig, race ), statsFontType );
         dst_pt.x = pt.x + 86 - text.width() / 2;
         dst_pt.y = pt.y + 104;
         text.draw( dst_pt.x, dst_pt.y, display );
 
-        // name
-        const std::string monsterMultiName = monster.GetMultiName();
-
-        text.set( monsterMultiName, statsFontType );
+        // creature name
+        text.set( monster.GetMultiName(), statsFontType );
         dst_pt.x = pt.x + 122 - text.width() / 2;
         dst_pt.y = pt.y + 19;
         text.draw( dst_pt.x, dst_pt.y, display );
 
-        // stats declarations
-
+        // attack
         std::string str;
+        str = _( "Attack" );
+        str += ": ";
+        str += std::to_string( monster.GetAttack() );
+
+        text.set( str, statsFontType );
+
         const int32_t statsOffsetX = 269;
         const int32_t statsInitialOffsetY = 22;
         int32_t statsOffsetY = statsInitialOffsetY;
 
-        // attack
-        str = _( "Attack" );
-        str += ": ";
-
-        const uint32_t monsterAttack = monster.GetAttack();
-
-        str += std::to_string( monsterAttack );
-
-        text.set( str, statsFontType );
         dst_pt.x = pt.x + statsOffsetX - text.width() / 2;
         dst_pt.y = pt.y + statsOffsetY;
         text.draw( dst_pt.x, dst_pt.y, display );
@@ -354,10 +346,7 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
         // defense
         str = _( "Defense" );
         str += ": ";
-
-        const uint32_t monsterDefense = monster.GetDefense();
-
-        str += std::to_string( monsterDefense );
+        str += std::to_string( monster.GetDefense() );
 
         text.set( str, statsFontType );
         dst_pt.x = pt.x + statsOffsetX - text.width() / 2;
@@ -388,10 +377,7 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
         // hp
         str = _( "HP" );
         str += ": ";
-
-        const uint32_t monsterHitPoints = monster.GetHitPoints();
-
-        str += std::to_string( monsterHitPoints );
+        str += std::to_string( monster.GetHitPoints() );
 
         text.set( str, statsFontType );
         dst_pt.x = pt.x + statsOffsetX - text.width() / 2;
@@ -409,15 +395,13 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
         text.draw( dst_pt.x, dst_pt.y, display );
         statsOffsetY += text.height( text.width() );
 
-        const std::string monsterSpeed = Speed::String( monster.GetSpeed() );
-
-        text.set( monsterSpeed, statsFontType );
+        text.set( Speed::String( monster.GetSpeed() ), statsFontType );
         dst_pt.x = pt.x + statsOffsetX - text.width() / 2;
         dst_pt.y = pt.y + statsOffsetY;
         text.draw( dst_pt.x, dst_pt.y, display );
         statsOffsetY += 2 * ( text.height( text.width() ) ); // skip a line
 
-        // weekly growth
+        // growth and number available
         if ( present ) {
             uint32_t monsterGrown = monster.GetGrown();
             monsterGrown += building & BUILD_WELL ? GetGrownWell() : 0;

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -313,30 +313,58 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
         dst_pt.x = pt.x + 21;
         dst_pt.y = pt.y + 35;
         fheroes2::Blit( fheroes2::AGG::GetICN( ICN::Get4Building( race ), icnindex ), display, dst_pt.x, dst_pt.y );
-        // text
-        text.set( GetStringBuilding( dw_orig, race ), statsFontType );
+       
+        // texts
+        const std::string monsterBuilding = GetStringBuilding( dw_orig, race );
+
+        text.set( monsterBuilding, statsFontType );
         dst_pt.x = pt.x + 86 - text.width() / 2;
         dst_pt.y = pt.y + 104;
         text.draw( dst_pt.x, dst_pt.y, display );
 
         // name
-        text.set( monster.GetMultiName(), statsFontType );
+        const std::string monsterMultiName = monster.GetMultiName();
+
+        text.set( monsterMultiName, statsFontType );
         dst_pt.x = pt.x + 122 - text.width() / 2;
         dst_pt.y = pt.y + 19;
         text.draw( dst_pt.x, dst_pt.y, display );
-        // attack
+
+        // stats declarations
+
         std::string str;
-        str = std::string( _( "Attack" ) ) + ": " + std::to_string( monster.GetAttack() );
+        const int32_t statsOffsetX = 269;
+        const int32_t statsInitialOffsetY = 22;
+        int32_t statsOffsetY = statsInitialOffsetY;
+
+        // attack
+        str = _( "Attack" );
+        str += ": ";
+
+        const uint32_t monsterAttack = monster.GetAttack();
+
+        str += std::to_string( monsterAttack );
+
         text.set( str, statsFontType );
-        dst_pt.x = pt.x + 268 - text.width() / 2;
-        dst_pt.y = pt.y + 22;
+        dst_pt.x = pt.x + statsOffsetX - text.width() / 2;
+        dst_pt.y = pt.y + statsOffsetY;
         text.draw( dst_pt.x, dst_pt.y, display );
+        statsOffsetY += text.height( text.width() );
+
         // defense
-        str = std::string( _( "Defense" ) ) + ": " + std::to_string( monster.GetDefense() );
+        str = _( "Defense" );
+        str += ": ";
+        
+        const uint32_t monsterDefense = monster.GetDefense();
+
+        str += std::to_string( monsterDefense );
+
         text.set( str, statsFontType );
-        dst_pt.x = pt.x + 268 - text.width() / 2;
-        dst_pt.y = pt.y + 34;
+        dst_pt.x = pt.x + statsOffsetX - text.width() / 2;
+        dst_pt.y = pt.y + statsOffsetY;
         text.draw( dst_pt.x, dst_pt.y, display );
+        statsOffsetY += text.height( text.width() );
+
         // damage
         str = _( "Damg" );
         str += ": ";
@@ -352,50 +380,82 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
         }
 
         text.set( str, statsFontType );
-        dst_pt.x = pt.x + 268 - text.width() / 2;
-        dst_pt.y = pt.y + 46;
+        dst_pt.x = pt.x + statsOffsetX - text.width() / 2;
+        dst_pt.y = pt.y + statsOffsetY;
         text.draw( dst_pt.x, dst_pt.y, display );
+        statsOffsetY += text.height( text.width() );
+       
         // hp
-        str = std::string( _( "HP" ) ) + ": " + std::to_string( monster.GetHitPoints() );
-        text.set( str, statsFontType );
-        dst_pt.x = pt.x + 268 - text.width() / 2;
-        dst_pt.y = pt.y + 58;
-        text.draw( dst_pt.x, dst_pt.y, display );
-        // speed
-        str = std::string( _( "Speed" ) ) + ": ";
-        text.set( str, statsFontType );
-        dst_pt.x = pt.x + 268 - text.width() / 2;
-        dst_pt.y = pt.y + 78;
-        text.draw( dst_pt.x, dst_pt.y, display );
-        text.set( Speed::String( monster.GetSpeed() ), statsFontType );
-        dst_pt.x = pt.x + 268 - text.width() / 2;
-        dst_pt.y = pt.y + 90;
-        text.draw( dst_pt.x, dst_pt.y, display );
+        str = _( "HP" );
+        str += ": ";
 
+        const uint32_t monsterHitPoints = monster.GetHitPoints();
+
+        str += std::to_string( monsterHitPoints );
+
+        text.set( str, statsFontType );
+        dst_pt.x = pt.x + statsOffsetX - text.width() / 2;
+        dst_pt.y = pt.y + statsOffsetY;
+        text.draw( dst_pt.x, dst_pt.y, display );
+        statsOffsetY += 2 * ( text.height( text.width() ) ); // skip a line
+
+        // speed
+        str = _( "Speed" );
+        str += ':';
+
+        text.set( str, statsFontType );
+        dst_pt.x = pt.x + statsOffsetX - text.width() / 2;
+        dst_pt.y = pt.y + statsOffsetY;
+        text.draw( dst_pt.x, dst_pt.y, display );
+        statsOffsetY += text.height( text.width() );
+
+        const std::string monsterSpeed = Speed::String( monster.GetSpeed() );
+
+        text.set( monsterSpeed, statsFontType );
+        dst_pt.x = pt.x + statsOffsetX - text.width() / 2;
+        dst_pt.y = pt.y + statsOffsetY;
+        text.draw( dst_pt.x, dst_pt.y, display );
+        statsOffsetY += 2 * ( text.height( text.width() ) ); // skip a line
+
+        // weekly growth
         if ( present ) {
-            u32 grown = monster.GetGrown();
-            grown += building & BUILD_WELL ? GetGrownWell() : 0;
-            if ( DWELLING_MONSTER1 & dw )
-                grown += building & BUILD_WEL2 ? GetGrownWel2() : 0;
+
+            uint32_t monsterGrown = monster.GetGrown();
+            monsterGrown += building & BUILD_WELL ? GetGrownWell() : 0;
+
+            if ( DWELLING_MONSTER1 & dw ) {
+                monsterGrown += building & BUILD_WEL2 ? GetGrownWel2() : 0;
+            }
+
 
             text.set( _( "Growth" ), statsFontType );
-            dst_pt.x = pt.x + 268 - text.width() / 2;
-            dst_pt.y = pt.y + 110;
+            dst_pt.x = pt.x + statsOffsetX - text.width() / 2;
+            dst_pt.y = pt.y + statsOffsetY;
             text.draw( dst_pt.x, dst_pt.y, display );
-            str = std::string( "+ " ) + std::to_string( grown ) + " / " + _( "week" );
-            text.set( str, statsFontType );
-            dst_pt.x = pt.x + 268 - text.width() / 2;
-            dst_pt.y = pt.y + 122;
-            text.draw( dst_pt.x, dst_pt.y, display );
+            statsOffsetY += text.height( text.width() );
 
-            str = std::string( _( "Available" ) ) + ": ";
+            str = "+ ";
+            str += std::to_string( monsterGrown );
+            str += " / ";
+            str += _( "week" );
+
+            text.set( str, statsFontType );
+            dst_pt.x = pt.x + statsOffsetX - text.width() / 2;
+            dst_pt.y = pt.y + statsOffsetY;
+            text.draw( dst_pt.x, dst_pt.y, display );
+            statsOffsetY += text.height( text.width() );
+
+            str = _( "Available" );
+            str += ':';
+
             text.set( str, statsFontType );
             dst_pt.x = pt.x + 44;
             dst_pt.y = pt.y + 122;
             text.draw( dst_pt.x, dst_pt.y, display );
+
             text.set( std::to_string( available ), { fheroes2::FontSize::NORMAL, fheroes2::FontColor::YELLOW } );
             dst_pt.x = pt.x + 129 - text.width() / 2;
-            dst_pt.y = pt.y + 119;
+            dst_pt.y = pt.y + 120;
             text.draw( dst_pt.x, dst_pt.y, display );
         }
 


### PR DESCRIPTION
This first part currently only affects peasants since they are the only creatures where min damage is the same as max damage. In the fheroes2 monster info window their damage is already reported as just "1", so this also makes it more consistent.

OG:
![image](https://user-images.githubusercontent.com/12501091/140966724-7729aee6-4a9c-4c47-9c24-fd1cf7dec8fd.png)

fheroes2:
![image](https://user-images.githubusercontent.com/12501091/140966841-694292f5-4759-499b-a93e-dfb94b3858bb.png)

This is most likely why Damage is written "Damg" in OG:
OG:
![image](https://user-images.githubusercontent.com/12501091/140967430-71de11da-5c31-4d6a-b0e0-29bb70104ddb.png)
fheroes2:
![image](https://user-images.githubusercontent.com/12501091/140967182-d6d550bc-e5ba-41b9-87ee-62a806cb7fbc.png)

