### PR TITLE
If a hero on the map has the custom empty army (OG editor bug/feature), give him a minimum army (one unit of level 1)

### DIFF
--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -335,7 +335,7 @@ void Heroes::PostLoad( void )
 
     // fix zero army
     if ( !army.isValid() )
-        army.Reset( true );
+        army.Reset( false );
     else
         SetModes( CUSTOMARMY );
 


### PR DESCRIPTION
fix #4603