### PR TITLE
WorldPathfinder: implement "last move" logic, fix wrong penalty calculation algorithm

### DIFF
--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -480,10 +480,11 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                     const Maps::Tiles & tileFrom = world.GetTiles( currentStep->GetFrom() );
                     const Maps::Tiles & tileTo = world.GetTiles( currentStep->GetIndex() );
 
-                    // Make no mistake: movement penalty depends on tileFrom penalty, BUT route arrow length depends on tileTo penalty
-                    const uint32_t cost = tileFrom.isRoad() && tileTo.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( tileTo, pathfinding );
+                    // Make no mistake: the cost of moving to this tile depends on the penalty of the PREVIOUS tile,
+                    // BUT the length of the route arrow on this tile depends on the penalty of THIS tile
+                    const uint32_t penalty = tileFrom.isRoad() && tileTo.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( tileTo, pathfinding );
 
-                    index = Route::Path::GetIndexSprite( currentStep->GetDirection(), nextStep->GetDirection(), cost );
+                    index = Route::Path::GetIndexSprite( currentStep->GetDirection(), nextStep->GetDirection(), penalty );
                 }
 
                 const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( 0 > green ? ICN::ROUTERED : ICN::ROUTE, index );

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -466,7 +466,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
         Route::Path::const_iterator nextStep = currentStep;
 
         for ( ; currentStep != pathEnd; ++currentStep ) {
-            const int32_t from = ( *currentStep ).GetIndex();
+            const int32_t from = currentStep->GetIndex();
             const fheroes2::Point & mp = Maps::GetPoint( from );
 
             ++nextStep;
@@ -475,14 +475,15 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
             // is visible
             if ( ( tileROI & mp ) && !( currentStep == path.begin() && skipfirst ) ) {
                 uint32_t index = 0;
+
                 if ( pathEnd != nextStep ) {
+                    const Maps::Tiles & tileFrom = world.GetTiles( currentStep->GetFrom() );
                     const Maps::Tiles & tileTo = world.GetTiles( currentStep->GetIndex() );
-                    uint32_t cost = Maps::Ground::GetPenalty( tileTo, pathfinding );
 
-                    if ( world.GetTiles( currentStep->GetFrom() ).isRoad() && tileTo.isRoad() )
-                        cost = Maps::Ground::roadPenalty;
+                    // Movement penalty depends on tileFrom penalty, BUT route arrow length depends on tileTo penalty
+                    const uint32_t cost = tileFrom.isRoad() && tileTo.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( tileTo, pathfinding );
 
-                    index = Route::Path::GetIndexSprite( ( *currentStep ).GetDirection(), ( *nextStep ).GetDirection(), cost );
+                    index = Route::Path::GetIndexSprite( currentStep->GetDirection(), nextStep->GetDirection(), cost );
                 }
 
                 const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( 0 > green ? ICN::ROUTERED : ICN::ROUTE, index );

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -480,7 +480,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                     const Maps::Tiles & tileFrom = world.GetTiles( currentStep->GetFrom() );
                     const Maps::Tiles & tileTo = world.GetTiles( currentStep->GetIndex() );
 
-                    // Movement penalty depends on tileFrom penalty, BUT route arrow length depends on tileTo penalty
+                    // Make no mistake: movement penalty depends on tileFrom penalty, BUT route arrow length depends on tileTo penalty
                     const uint32_t cost = tileFrom.isRoad() && tileTo.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( tileTo, pathfinding );
 
                     index = Route::Path::GetIndexSprite( currentStep->GetDirection(), nextStep->GetDirection(), cost );

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -466,8 +466,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
         Route::Path::const_iterator nextStep = currentStep;
 
         for ( ; currentStep != pathEnd; ++currentStep ) {
-            const int32_t from = currentStep->GetIndex();
-            const fheroes2::Point & mp = Maps::GetPoint( from );
+            const fheroes2::Point & mp = Maps::GetPoint( currentStep->GetIndex() );
 
             ++nextStep;
             --green;
@@ -477,12 +476,11 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                 uint32_t index = 0;
 
                 if ( pathEnd != nextStep ) {
-                    const Maps::Tiles & tileFrom = world.GetTiles( currentStep->GetFrom() );
-                    const Maps::Tiles & tileTo = world.GetTiles( currentStep->GetIndex() );
+                    const Maps::Tiles & tile = world.GetTiles( currentStep->GetIndex() );
 
                     // Make no mistake: the cost of moving to this tile depends on the penalty of the PREVIOUS tile,
                     // BUT the length of the route arrow on this tile depends on the penalty of THIS tile
-                    const uint32_t penalty = tileFrom.isRoad() && tileTo.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( tileTo, pathfinding );
+                    const uint32_t penalty = tile.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( tile, pathfinding );
 
                     index = Route::Path::GetIndexSprite( currentStep->GetDirection(), nextStep->GetDirection(), penalty );
                 }

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1157,7 +1157,7 @@ bool Heroes::BuySpellBook( const Castle * castle, int shrine )
 /* return true is move enable */
 bool Heroes::isMoveEnabled( void ) const
 {
-    return Modes( ENABLEMOVE ) && path.isValid() && path.getLastMovePenalty() <= move_point;
+    return Modes( ENABLEMOVE ) && path.isValid() && path.hasAllowedSteps();
 }
 
 bool Heroes::CanMove( void ) const
@@ -1412,8 +1412,9 @@ bool Heroes::MayStillMove( const bool ignorePath ) const
     }
 
     if ( path.isValid() && !ignorePath ) {
-        return move_point >= path.getLastMovePenalty();
+        return path.hasAllowedSteps();
     }
+
     return CanMove();
 }
 

--- a/src/fheroes2/heroes/route.cpp
+++ b/src/fheroes2/heroes/route.cpp
@@ -20,6 +20,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <cassert>
+
 #include "heroes.h"
 #include "maps.h"
 #include "route.h"
@@ -368,11 +370,16 @@ int Route::Path::GetIndexSprite( int from, int to, int mod )
     return index;
 }
 
-uint32_t Route::Path::getLastMovePenalty() const
+bool Route::Path::hasAllowedSteps() const
 {
-    const Route::Step & firstStep = front();
-    const uint32_t penalty = firstStep.GetPenalty();
-    return Direction::isDiagonal( firstStep.GetDirection() ) ? ( penalty * 2 / 3 ) : penalty;
+    if ( !isValid() ) {
+        return false;
+    }
+
+    assert( hero != nullptr );
+    assert( !empty() );
+
+    return hero->GetMovePoints() >= front().GetPenalty();
 }
 
 int Route::Path::GetAllowedSteps( void ) const
@@ -382,11 +389,6 @@ int Route::Path::GetAllowedSteps( void ) const
 
     for ( const_iterator it = begin(); it != end() && movePoints > 0; ++it ) {
         uint32_t penalty = it->GetPenalty();
-
-        // allow diagonal move at a lower cost if it's a last one
-        if ( movePoints < penalty && Direction::isDiagonal( it->GetDirection() ) ) {
-            penalty = penalty * 2 / 3;
-        }
 
         if ( movePoints >= penalty ) {
             movePoints -= penalty;

--- a/src/fheroes2/heroes/route.h
+++ b/src/fheroes2/heroes/route.h
@@ -86,7 +86,6 @@ namespace Route
         s32 GetDestinedIndex( void ) const;
         int GetFrontDirection( void ) const;
         u32 GetFrontPenalty( void ) const;
-        uint32_t getLastMovePenalty() const;
         void setPath( const std::list<Step> & path, int32_t destIndex );
 
         void Show( void )
@@ -109,6 +108,7 @@ namespace Route
             return !hide;
         }
         bool hasObstacle( void ) const;
+        bool hasAllowedSteps() const;
 
         std::string String( void ) const;
 

--- a/src/fheroes2/maps/ground.cpp
+++ b/src/fheroes2/maps/ground.cpp
@@ -52,19 +52,20 @@ const char * Maps::Ground::String( int ground )
 
 uint32_t Maps::Ground::GetPenalty( const Maps::Tiles & tile, uint32_t level )
 {
-    //            none   basc   advd   expr
-    //    Desert  2.00   1.75   1.50   1.00
-    //    Snow    1.75   1.50   1.25   1.00
-    //    Swamp   1.75   1.50   1.25   1.00
-    //    Cracked 1.25   1.00   1.00   1.00
-    //    Beach   1.25   1.00   1.00   1.00
-    //    Lava    1.00   1.00   1.00   1.00
-    //    Dirt    1.00   1.00   1.00   1.00
-    //    Grass   1.00   1.00   1.00   1.00
-    //    Water   1.00   1.00   1.00   1.00
-    //    Road    0.75   0.75   0.75   0.75
+    //              none   basc   advd   expr
+    //    Desert    2.00   1.75   1.50   1.00
+    //    Swamp     1.75   1.50   1.25   1.00
+    //    Snow      1.50   1.25   1.00   1.00
+    //    Wasteland 1.25   1.00   1.00   1.00
+    //    Beach     1.25   1.00   1.00   1.00
+    //    Lava      1.00   1.00   1.00   1.00
+    //    Dirt      1.00   1.00   1.00   1.00
+    //    Grass     1.00   1.00   1.00   1.00
+    //    Water     1.00   1.00   1.00   1.00
+    //    Road      0.75   0.75   0.75   0.75
 
     uint32_t result = defaultGroundPenalty;
+
     switch ( tile.GetGround() ) {
     case DESERT:
         switch ( level ) {
@@ -82,7 +83,6 @@ uint32_t Maps::Ground::GetPenalty( const Maps::Tiles & tile, uint32_t level )
         }
         break;
 
-    case SNOW:
     case SWAMP:
         switch ( level ) {
         case Skill::Level::EXPERT:
@@ -95,6 +95,20 @@ uint32_t Maps::Ground::GetPenalty( const Maps::Tiles & tile, uint32_t level )
             break;
         default:
             result += 75;
+            break;
+        }
+        break;
+
+    case SNOW:
+        switch ( level ) {
+        case Skill::Level::EXPERT:
+        case Skill::Level::ADVANCED:
+            break;
+        case Skill::Level::BASIC:
+            result += 25;
+            break;
+        default:
+            result += 50;
             break;
         }
         break;

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -155,8 +155,6 @@ uint32_t WorldPathfinder::getMovementPenalty( int src, int dst, int direction ) 
     const Maps::Tiles & srcTile = world.GetTiles( src );
     const Maps::Tiles & dstTile = world.GetTiles( dst );
 
-    const uint32_t srcTilePenalty = srcTile.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( srcTile, _pathfindingSkill );
-
     uint32_t penalty = srcTile.isRoad() && dstTile.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( srcTile, _pathfindingSkill );
 
     // Diagonal movement costs 50% more
@@ -175,6 +173,7 @@ uint32_t WorldPathfinder::getMovementPenalty( int src, int dst, int direction ) 
         assert( src == _pathStart || node._from != -1 );
 
         const uint32_t remainingMovePoints = node._remainingMovePoints;
+        const uint32_t srcTilePenalty = srcTile.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( srcTile, _pathfindingSkill );
 
         // If we still have enough movement points to move over src tile in straight direction,
         // but not enough (or barely enough) to move to the dst tile, then it's the last move

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -202,6 +202,8 @@ uint32_t WorldPathfinder::getMovementPenalty( int src, int dst, int direction ) 
             else {
                 // This movement takes place at the beginning of a new day: start with max
                 // movement points, don't carry leftovers from the previous day
+                assert( _maxMovePoints >= cost );
+
                 movePointsLeft = _maxMovePoints - cost;
             }
         }

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -174,6 +174,8 @@ uint32_t WorldPathfinder::getMovementPenalty( int src, int dst, int direction, u
             movePointsLeft = _maxMovePoints - ( ( consumedMovePoints - _remainingMovePoints ) % _maxMovePoints );
         }
 
+        // If this move is the last one on the current turn, we can move to any adjacent cell (both in straight and diagonal direction)
+        // as long as we have enough move points to move over our current cell in straight direction
         if ( movePointsLeft >= srcTilePenalty && movePointsLeft <= dstTilePenalty ) {
             return movePointsLeft;
         }

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -165,7 +165,7 @@ uint32_t WorldPathfinder::getMovementPenalty( int src, int dst, int direction ) 
     // If we perform pathfinding for a real hero on the map, we have to work out the "last move"
     // logic: if this move is the last one on the current turn, then we can move to any adjacent
     // tile (both in straight and diagonal direction) as long as we have enough movement points
-    // to move over our current tile in straight direction
+    // to move over our current tile in the straight direction
     if ( _maxMovePoints > 0 ) {
         const WorldNode & node = _cache[src];
 
@@ -175,11 +175,11 @@ uint32_t WorldPathfinder::getMovementPenalty( int src, int dst, int direction ) 
         const uint32_t remainingMovePoints = node._remainingMovePoints;
         const uint32_t srcTilePenalty = srcTile.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( srcTile, _pathfindingSkill );
 
-        // If we still have enough movement points to move over src tile in straight direction,
-        // but not enough (or barely enough) to move to the dst tile, then it's the last move
-        // and we can move to the dst tile in any case at the expense of all the remaining
+        // If we still have enough movement points to move over the src tile in the straight
+        // direction, but not enough to move to the dst tile, then the "last move" logic is
+        // applied and we can move to the dst tile anyway at the expense of all the remaining
         // movement points
-        if ( remainingMovePoints >= srcTilePenalty && remainingMovePoints <= penalty ) {
+        if ( remainingMovePoints >= srcTilePenalty && remainingMovePoints < penalty ) {
             return remainingMovePoints;
         }
     }

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -164,8 +164,6 @@ uint32_t WorldPathfinder::getMovementPenalty( int src, int dst, int direction, u
         dstTilePenalty = dstTilePenalty * 3 / 2;
     }
 
-    bool lastMove = false;
-
     if ( _maxMovePoints > 0 ) {
         uint32_t movePointsLeft;
 
@@ -176,11 +174,9 @@ uint32_t WorldPathfinder::getMovementPenalty( int src, int dst, int direction, u
             movePointsLeft = _maxMovePoints - ( ( consumedMovePoints - _remainingMovePoints ) % _maxMovePoints );
         }
 
-        lastMove = movePointsLeft >= srcTilePenalty && movePointsLeft <= dstTilePenalty;
-    }
-
-    if ( lastMove ) {
-        return srcTilePenalty;
+        if ( movePointsLeft >= srcTilePenalty && movePointsLeft <= dstTilePenalty ) {
+            return movePointsLeft;
+        }
     }
 
     return dstTilePenalty;

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -173,7 +173,7 @@ uint32_t WorldPathfinder::getMovementPenalty( int src, int dst, int direction, u
             movePointsLeft = _remainingMovePoints - consumedMovePoints;
         }
         else {
-            movePointsLeft = _maxMovePoints - ( consumedMovePoints - _remainingMovePoints ) % _maxMovePoints;
+            movePointsLeft = _maxMovePoints - ( ( consumedMovePoints - _remainingMovePoints ) % _maxMovePoints );
         }
 
         lastMove = movePointsLeft >= srcTilePenalty && movePointsLeft <= dstTilePenalty;

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -157,11 +157,11 @@ uint32_t WorldPathfinder::getMovementPenalty( int src, int dst, int direction ) 
 
     const uint32_t srcTilePenalty = srcTile.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( srcTile, _pathfindingSkill );
 
-    uint32_t dstTilePenalty = ( srcTile.isRoad() && dstTile.isRoad() ) ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( dstTile, _pathfindingSkill );
+    uint32_t penalty = srcTile.isRoad() && dstTile.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( srcTile, _pathfindingSkill );
 
     // Diagonal movement costs 50% more
     if ( Direction::isDiagonal( direction ) ) {
-        dstTilePenalty = dstTilePenalty * 3 / 2;
+        penalty = penalty * 3 / 2;
     }
 
     // If we perform pathfinding for a real hero on the map, we have to work out the "last move"
@@ -177,15 +177,15 @@ uint32_t WorldPathfinder::getMovementPenalty( int src, int dst, int direction ) 
         const uint32_t remainingMovePoints = node._remainingMovePoints;
 
         // If we still have enough movement points to move over src tile in straight direction,
-        // but not enough to move to the dst tile (or barely enough to move to the dst tile in
-        // straight direction), then it's the last move and we can move to the dst tile in any
-        // case at the expense of all the remaining movement points
-        if ( remainingMovePoints >= srcTilePenalty && remainingMovePoints <= dstTilePenalty ) {
+        // but not enough (or barely enough) to move to the dst tile, then it's the last move
+        // and we can move to the dst tile in any case at the expense of all the remaining
+        // movement points
+        if ( remainingMovePoints >= srcTilePenalty && remainingMovePoints <= penalty ) {
             return remainingMovePoints;
         }
     }
 
-    return dstTilePenalty;
+    return penalty;
 }
 
 uint32_t WorldPathfinder::substractMovePoints( const uint32_t movePoints, const uint32_t substractedMovePoints ) const

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -63,9 +63,10 @@ protected:
     // This method defines pathfinding rules. This has to be implemented by the derived class.
     virtual void processCurrentNode( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx, bool fromWater ) = 0;
 
-    // Calculates the movement penalty when moving from src tile to adjacent dst tile in the specified direction. If "last move"
-    // logic should be taken into account (when performing pathfinding for a real hero on the map), then src tile should be
-    // already accessible for this hero and have valid information about the hero's remaining movement points.
+    // Calculates the movement penalty when moving from the src tile to the adjacent dst tile in the specified direction.
+    // If the "last move" logic should be taken into account (when performing pathfinding for a real hero on the map),
+    // then the src tile should be already accessible for this hero and it should also have a valid information about
+    // the hero's remaining movement points.
     uint32_t getMovementPenalty( int src, int dst, int direction ) const;
 
     // Substracts movement points taking the transition between turns into account

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -37,9 +37,6 @@ public:
     // This method resizes the cache and re-calculates map offsets if values are out of sync with World class
     virtual void checkWorldSize();
 
-    // Shared helper methods
-    uint32_t getMovementPenalty( int start, int target, int direction, uint8_t skill = Skill::Level::EXPERT ) const;
-
 protected:
     void processWorldMap( int pathStart );
     void checkAdjacentNodes( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx, bool fromWater );
@@ -47,8 +44,13 @@ protected:
     // This method defines pathfinding rules. This has to be implemented by the derived class.
     virtual void processCurrentNode( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx, bool fromWater ) = 0;
 
+    // Calculates the movement penalty when moving from src tile to adjacent dst tile in the specified direction.
+    uint32_t getMovementPenalty( int src, int dst, int direction, uint32_t consumedMovePoints ) const;
+
     uint8_t _pathfindingSkill = Skill::Level::EXPERT;
     int _currentColor = Color::NONE;
+    uint32_t _remainingMovePoints = 0;
+    uint32_t _maxMovePoints = 0;
     std::vector<int> _mapOffset;
 };
 

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -44,8 +44,10 @@ protected:
     // This method defines pathfinding rules. This has to be implemented by the derived class.
     virtual void processCurrentNode( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx, bool fromWater ) = 0;
 
-    // Calculates the movement penalty when moving from src tile to adjacent dst tile in the specified direction.
-    uint32_t getMovementPenalty( int src, int dst, int direction, uint32_t consumedMovePoints ) const;
+    // Calculates the movement penalty when moving from src tile to adjacent dst tile in the specified direction. If "last move"
+    // logic should be taken into account (when performing a pathfinding for a real hero on the map), src tile should be already
+    // accessible for this hero (path from the starting tile to src tile should be already in cache).
+    uint32_t getMovementPenalty( int src, int dst, int direction ) const;
 
     uint8_t _pathfindingSkill = Skill::Level::EXPERT;
     int _currentColor = Color::NONE;

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -28,8 +28,27 @@
 
 class IndexObject;
 
+struct WorldNode : public PathfindingNode<MP2::MapObjectType>
+{
+    uint32_t _remainingMovePoints = 0;
+
+    WorldNode() = default;
+
+    WorldNode( const int node, const uint32_t cost, const MP2::MapObjectType object, const uint32_t remainingMovePoints )
+        : PathfindingNode( node, cost, object )
+        , _remainingMovePoints( remainingMovePoints )
+    {}
+
+    void resetNode() override
+    {
+        PathfindingNode::resetNode();
+
+        _remainingMovePoints = 0;
+    }
+};
+
 // Abstract class that provides base functionality to path through World map
-class WorldPathfinder : public Pathfinder<PathfindingNode<MP2::MapObjectType>>
+class WorldPathfinder : public Pathfinder<WorldNode>
 {
 public:
     WorldPathfinder() = default;
@@ -45,9 +64,12 @@ protected:
     virtual void processCurrentNode( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx, bool fromWater ) = 0;
 
     // Calculates the movement penalty when moving from src tile to adjacent dst tile in the specified direction. If "last move"
-    // logic should be taken into account (when performing a pathfinding for a real hero on the map), src tile should be already
-    // accessible for this hero (path from the starting tile to src tile should be already in cache).
+    // logic should be taken into account (when performing pathfinding for a real hero on the map), then src tile should be
+    // already accessible for this hero and have valid information about the hero's remaining movement points.
     uint32_t getMovementPenalty( int src, int dst, int direction ) const;
+
+    // Substracts movement points taking the transition between turns into account
+    uint32_t substractMovePoints( const uint32_t movePoints, const uint32_t substractedMovePoints ) const;
 
     uint8_t _pathfindingSkill = Skill::Level::EXPERT;
     int _currentColor = Color::NONE;


### PR DESCRIPTION
fix #1986
fix #2200
fix #2583
fix #4510

Please note that, while this change applies to AI-controlled heroes too, sometimes AI uses the `AIWorldPathfinder` apart from the some specific hero (for some strategic planning I believe). In this case "last move" logic will not be used - due to natural reasons.