### PR TITLE
Add title for most of dialogs from map's objects

### DIFF
--- a/files/lang/cs.po
+++ b/files/lang/cs.po
@@ -3466,7 +3466,7 @@ msgstr ""
 msgid "Treasure"
 msgstr "Poklady"
 
-msgid "Searching through the tattered clothing, you find %{artifact}."
+msgid "Searching through the tattered clothing, you find the %{artifact}."
 msgstr ""
 
 msgid "Searching through the tattered clothing, you find nothing."

--- a/files/lang/cs.po
+++ b/files/lang/cs.po
@@ -3616,7 +3616,7 @@ msgstr ""
 
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
-"telling the secret of the spell."
+"telling the secret of the spell - '"
 msgstr ""
 
 msgid "Sign"

--- a/files/lang/de.po
+++ b/files/lang/de.po
@@ -3365,7 +3365,7 @@ msgstr ""
 msgid "Treasure"
 msgstr ""
 
-msgid "Searching through the tattered clothing, you find %{artifact}."
+msgid "Searching through the tattered clothing, you find the %{artifact}."
 msgstr ""
 
 msgid "Searching through the tattered clothing, you find nothing."

--- a/files/lang/de.po
+++ b/files/lang/de.po
@@ -3515,7 +3515,7 @@ msgstr ""
 
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
-"telling the secret of the spell."
+"telling the secret of the spell - '"
 msgstr ""
 
 msgid "Sign"

--- a/files/lang/es.po
+++ b/files/lang/es.po
@@ -3825,7 +3825,7 @@ msgstr "Te topas con los restos de un desafortunado aventurero."
 msgid "Treasure"
 msgstr "Tesoro"
 
-msgid "Searching through the tattered clothing, you find %{artifact}."
+msgid "Searching through the tattered clothing, you find the %{artifact}."
 msgstr "Mientras buscabas entre las ropas sucias, encontraste %{artifact}."
 
 msgid "Searching through the tattered clothing, you find nothing."

--- a/files/lang/es.po
+++ b/files/lang/es.po
@@ -4030,10 +4030,10 @@ msgstr ""
 
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
-"telling the secret of the spell."
+"telling the secret of the spell - '"
 msgstr ""
 "Al derrotar a los monstruos, descrifras un antiguo  jeroglífico de la pared "
-"que explica el secreto del hechizo."
+"que explica el secreto del hechizo - '"
 
 msgid "Sign"
 msgstr "Señal"

--- a/files/lang/fr.po
+++ b/files/lang/fr.po
@@ -3847,7 +3847,7 @@ msgstr "Vous tombez sur les restes d'un malheureux aventurier."
 msgid "Treasure"
 msgstr "Trésor"
 
-msgid "Searching through the tattered clothing, you find %{artifact}."
+msgid "Searching through the tattered clothing, you find the %{artifact}."
 msgstr ""
 "En cherchant dans les vêtements en lambeaux, vous trouvez l'artéfact "
 "'%{artifact}'."

--- a/files/lang/fr.po
+++ b/files/lang/fr.po
@@ -4063,10 +4063,10 @@ msgstr ""
 
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
-"telling the secret of the spell."
+"telling the secret of the spell - '"
 msgstr ""
 "Après avoir vaincu les monstres, vous déchiffrez un ancien glyphe sur le "
-"mur, qui révèle le secret du sort."
+"mur, qui révèle le secret du sort - '"
 
 msgid "Sign"
 msgstr "Panneau"

--- a/files/lang/hu.po
+++ b/files/lang/hu.po
@@ -3685,7 +3685,7 @@ msgstr ""
 msgid "Treasure"
 msgstr "Kincsek"
 
-msgid "Searching through the tattered clothing, you find %{artifact}."
+msgid "Searching through the tattered clothing, you find the %{artifact}."
 msgstr ""
 
 #, fuzzy

--- a/files/lang/hu.po
+++ b/files/lang/hu.po
@@ -3871,7 +3871,7 @@ msgstr ""
 
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
-"telling the secret of the spell."
+"telling the secret of the spell - '"
 msgstr ""
 
 msgid "Sign"

--- a/files/lang/it.po
+++ b/files/lang/it.po
@@ -3503,7 +3503,7 @@ msgstr ""
 
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
-"telling the secret of the spell."
+"telling the secret of the spell - '"
 msgstr ""
 
 msgid "Sign"

--- a/files/lang/it.po
+++ b/files/lang/it.po
@@ -3353,7 +3353,7 @@ msgstr ""
 msgid "Treasure"
 msgstr ""
 
-msgid "Searching through the tattered clothing, you find %{artifact}."
+msgid "Searching through the tattered clothing, you find the %{artifact}."
 msgstr ""
 
 msgid "Searching through the tattered clothing, you find nothing."

--- a/files/lang/lt.po
+++ b/files/lang/lt.po
@@ -3461,7 +3461,7 @@ msgstr ""
 msgid "Treasure"
 msgstr ""
 
-msgid "Searching through the tattered clothing, you find %{artifact}."
+msgid "Searching through the tattered clothing, you find the %{artifact}."
 msgstr ""
 
 msgid "Searching through the tattered clothing, you find nothing."

--- a/files/lang/lt.po
+++ b/files/lang/lt.po
@@ -3616,7 +3616,7 @@ msgstr ""
 
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
-"telling the secret of the spell."
+"telling the secret of the spell - '"
 msgstr ""
 
 msgid "Sign"

--- a/files/lang/nb.po
+++ b/files/lang/nb.po
@@ -3799,7 +3799,7 @@ msgstr "Du kommer over levningene til en uheldig reisende."
 msgid "Treasure"
 msgstr "Skatt"
 
-msgid "Searching through the tattered clothing, you find %{artifact}."
+msgid "Searching through the tattered clothing, you find the %{artifact}."
 msgstr "Mens du leter gjennom de fillete klærne finner du %{artifact}."
 
 msgid "Searching through the tattered clothing, you find nothing."

--- a/files/lang/nb.po
+++ b/files/lang/nb.po
@@ -4004,10 +4004,10 @@ msgstr ""
 
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
-"telling the secret of the spell."
+"telling the secret of the spell - '"
 msgstr ""
 "Etter å ha utryddet monstrene tyder du et eldgammelt skrifttegn på veggen, "
-"og det røper hemmeligheten til trolldommen."
+"og det røper hemmeligheten til trolldommen - '"
 
 msgid "Sign"
 msgstr "Skilt"

--- a/files/lang/nl.po
+++ b/files/lang/nl.po
@@ -3359,7 +3359,7 @@ msgstr ""
 msgid "Treasure"
 msgstr ""
 
-msgid "Searching through the tattered clothing, you find %{artifact}."
+msgid "Searching through the tattered clothing, you find the %{artifact}."
 msgstr ""
 
 msgid "Searching through the tattered clothing, you find nothing."

--- a/files/lang/nl.po
+++ b/files/lang/nl.po
@@ -3509,7 +3509,7 @@ msgstr ""
 
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
-"telling the secret of the spell."
+"telling the secret of the spell - '"
 msgstr ""
 
 msgid "Sign"

--- a/files/lang/pl.po
+++ b/files/lang/pl.po
@@ -3716,7 +3716,7 @@ msgstr "Dotarłeś do szczątek pechowego poszukiwacza"
 msgid "Treasure"
 msgstr "Skarb"
 
-msgid "Searching through the tattered clothing, you find %{artifact}."
+msgid "Searching through the tattered clothing, you find the %{artifact}."
 msgstr "Po przeszukaniu rozdartego ubrania, znajdujesz %{artifact}."
 
 msgid "Searching through the tattered clothing, you find nothing."

--- a/files/lang/pl.po
+++ b/files/lang/pl.po
@@ -3918,7 +3918,7 @@ msgstr ""
 
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
-"telling the secret of the spell."
+"telling the secret of the spell - '"
 msgstr ""
 "Pokonawszy potwory, odczytujesz prastary glif na ścianie, dzięki czemu "
 "poznajesz tajemnice zaklęcia."

--- a/files/lang/pt.po
+++ b/files/lang/pt.po
@@ -3878,10 +3878,10 @@ msgstr ""
 
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
-"telling the secret of the spell."
+"telling the secret of the spell - '"
 msgstr ""
 "Após derrotar as criaturas, você decifrar um hieróglifo antigo na parede, "
-"contando o segredo da magia."
+"contando o segredo da magia - '"
 
 msgid "Sign"
 msgstr ""

--- a/files/lang/pt.po
+++ b/files/lang/pt.po
@@ -3664,7 +3664,7 @@ msgid "Treasure"
 msgstr "Tesouros"
 
 #, fuzzy
-msgid "Searching through the tattered clothing, you find %{artifact}."
+msgid "Searching through the tattered clothing, you find the %{artifact}."
 msgstr ""
 "Você vai sobre os restos de um aventureiro infeliz.\n"
 "Olhando através da roupa esfarrapada, você encontra um artefato %{artifact}."

--- a/files/lang/ru.po
+++ b/files/lang/ru.po
@@ -3758,7 +3758,7 @@ msgstr "Вы обнаружили останки какого-то несчас�
 msgid "Treasure"
 msgstr "Сокровище"
 
-msgid "Searching through the tattered clothing, you find %{artifact}."
+msgid "Searching through the tattered clothing, you find the %{artifact}."
 msgstr "Покопавшись среди лохмотьев, вы нашли %{artifact}."
 
 msgid "Searching through the tattered clothing, you find nothing."

--- a/files/lang/ru.po
+++ b/files/lang/ru.po
@@ -3958,10 +3958,10 @@ msgstr ""
 
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
-"telling the secret of the spell."
+"telling the secret of the spell - '"
 msgstr ""
 "Одолев чудовищ, вы расшифровали иероглифы на стене, содержащие секрет "
-"заклинания."
+"заклинания - '"
 
 msgid "Sign"
 msgstr "Указатель"

--- a/files/lang/sv.po
+++ b/files/lang/sv.po
@@ -3660,7 +3660,7 @@ msgstr "Du stöter på kvarlevorna av en olycklig äventyrare."
 msgid "Treasure"
 msgstr "Skatt"
 
-msgid "Searching through the tattered clothing, you find %{artifact}."
+msgid "Searching through the tattered clothing, you find the %{artifact}."
 msgstr "När du söker igenom de trasiga kläderna hittar du %{artifact}."
 
 msgid "Searching through the tattered clothing, you find nothing."

--- a/files/lang/sv.po
+++ b/files/lang/sv.po
@@ -3927,10 +3927,10 @@ msgstr ""
 
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
-"telling the secret of the spell."
+"telling the secret of the spell - '"
 msgstr ""
 "Medan du besegrar monstren, dechiffrerar du en uråldrig hieroglyf på väggen "
-"som berättar hemligheten om besvärjelsen."
+"som berättar hemligheten om besvärjelsen - '"
 
 msgid "Sign"
 msgstr "Skylt"

--- a/files/lang/tr.po
+++ b/files/lang/tr.po
@@ -3503,7 +3503,7 @@ msgstr ""
 
 msgid ""
 "Upon defeating the monsters, you decipher an ancient glyph on the wall, "
-"telling the secret of the spell."
+"telling the secret of the spell - '"
 msgstr ""
 
 msgid "Sign"

--- a/files/lang/tr.po
+++ b/files/lang/tr.po
@@ -3353,7 +3353,7 @@ msgstr ""
 msgid "Treasure"
 msgstr ""
 
-msgid "Searching through the tattered clothing, you find %{artifact}."
+msgid "Searching through the tattered clothing, you find the %{artifact}."
 msgstr ""
 
 msgid "Searching through the tattered clothing, you find nothing."

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1773,8 +1773,8 @@ void ActionToArtifact( Heroes & hero, s32 dst_index )
                     hero.GetKingdom().OddFundsResource( payment );
                 }
                 else {
-                     Dialog::Message( title, _( "You try to pay the leprechaun, but realize that you can't afford it. The leprechaun stamps his foot and ignores you." ),
-                                      Font::BIG, Dialog::OK );
+                    Dialog::Message( title, _( "You try to pay the leprechaun, but realize that you can't afford it. The leprechaun stamps his foot and ignores you." ),
+                                     Font::BIG, Dialog::OK );
                 }
             }
             else {
@@ -2621,8 +2621,8 @@ void ActionToMagellanMaps( Heroes & hero, const MP2::MapObjectType objectType, s
 
     if ( hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) ) {
         Dialog::Message( title,
-                         _( "The captain looks at you with surprise and says:\n\"You already have all the maps I know about. Let me fish in peace now.\"" ), Font::BIG,
-                         Dialog::OK );
+                         _( "The captain looks at you with surprise and says:\n\"You already have all the maps I know about. Let me fish in peace now.\"" ),
+                         Font::BIG, Dialog::OK );
     }
     else if ( kingdom.AllowPayment( payment ) ) {
         if (

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1111,7 +1111,7 @@ void ActionToSkeleton( Heroes & hero, const MP2::MapObjectType objectType, s32 d
         else {
             const Artifact & art = tile.QuantityArtifact();
             message += '\n';
-            message.append( _( "Searching through the tattered clothing, you find %{artifact}." ) );
+            message.append( _( "Searching through the tattered clothing, you find the %{artifact}." ) );
             StringReplace( message, "%{artifact}", art.GetName() );
             AGG::PlaySound( M82::TREASURE );
             Dialog::ArtifactInfo( title, message, art );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1369,7 +1369,7 @@ void ActionToPyramid( Heroes & hero, const MP2::MapObjectType objectType, s32 ds
 
     const std::string title( MP2::StringObject( objectType ) );
 
-    if ( Dialog::YES == Dialog::Message( MP2::StringObject( objectType ), ask, Font::BIG, Dialog::YES | Dialog::NO ) ) {
+    if ( Dialog::YES == Dialog::Message( title, ask, Font::BIG, Dialog::YES | Dialog::NO ) ) {
         if ( spell.isValid() ) {
             // battle
             Army army( tile );
@@ -1553,7 +1553,7 @@ void ActionToPoorMoraleObject( Heroes & hero, const MP2::MapObjectType objectTyp
 
     const std::string title( MP2::StringObject( objectType ) );
 
-    if ( Dialog::YES == Dialog::Message( MP2::StringObject( objectType ), ask, Font::BIG, Dialog::YES | Dialog::NO ) ) {
+    if ( Dialog::YES == Dialog::Message( title, ask, Font::BIG, Dialog::YES | Dialog::NO ) ) {
         bool complete = false;
 
         if ( gold ) {

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1773,14 +1773,13 @@ void ActionToArtifact( Heroes & hero, s32 dst_index )
                     hero.GetKingdom().OddFundsResource( payment );
                 }
                 else {
-                    Dialog::Message( title,
-                                     _( "You try to pay the leprechaun, but realize that you can't afford it. The leprechaun stamps his foot and ignores you." ),
-                                     Font::BIG, Dialog::OK );
+                     Dialog::Message( title, _( "You try to pay the leprechaun, but realize that you can't afford it. The leprechaun stamps his foot and ignores you." ),
+                                      Font::BIG, Dialog::OK );
                 }
             }
-            else
-                Dialog::Message( title,
-                                 _( "Insulted by your refusal of his generous offer, the leprechaun stamps his foot and ignores you." ), Font::BIG, Dialog::OK );
+            else {
+                Dialog::Message( title, _( "Insulted by your refusal of his generous offer, the leprechaun stamps his foot and ignores you." ), Font::BIG, Dialog::OK );
+            }
         }
         else
             // 4,5 - need have skill wisard or leadership,
@@ -1973,8 +1972,9 @@ void ActionToAncientLamp( Heroes & hero, const MP2::MapObjectType objectType, s3
     }
 
     const std::string title( MP2::StringObject( objectType ) );
-    if ( Dialog::YES == Dialog::Message( title,
-            _( "You stumble upon a dented and tarnished lamp lodged deep in the earth. Do you wish to rub the lamp?" ), Font::BIG, Dialog::YES | Dialog::NO ) ) {
+    if ( Dialog::YES
+         == Dialog::Message( title, _( "You stumble upon a dented and tarnished lamp lodged deep in the earth. Do you wish to rub the lamp?" ), Font::BIG,
+                             Dialog::YES | Dialog::NO ) ) {
         RecruitMonsterFromTile( hero, tile, title, troop, true );
     }
 
@@ -2065,8 +2065,7 @@ void ActionToAbandoneMine( Heroes & hero, const MP2::MapObjectType objectType, s
 {
     if ( Dialog::YES
          == Dialog::Message( MP2::StringObject( MP2::OBJ_ABANDONEDMINE ),
-                             _( "You come upon an abandoned gold mine. The mine appears to be haunted. Do you wish to enter?" ), Font::BIG,
-                             Dialog::YES | Dialog::NO ) ) {
+                             _( "You come upon an abandoned gold mine. The mine appears to be haunted. Do you wish to enter?" ), Font::BIG, Dialog::YES | Dialog::NO ) ) {
         ActionToCaptureObject( hero, objectType, dst_index );
     }
 }
@@ -2426,8 +2425,7 @@ void ActionToXanadu( Heroes & hero, const MP2::MapObjectType objectType, s32 dst
     const std::string title( MP2::StringObject( objectType ) );
 
     if ( hero.isVisited( tile ) ) {
-        Dialog::Message( title,
-                         _( "Recognizing you, the butler refuses to admit you. \"The master,\" he says, \"will not see the same student twice.\"" ), Font::BIG,
+        Dialog::Message( title, _( "Recognizing you, the butler refuses to admit you. \"The master,\" he says, \"will not see the same student twice.\"" ), Font::BIG,
                          Dialog::OK );
     }
     else {
@@ -2452,8 +2450,8 @@ void ActionToXanadu( Heroes & hero, const MP2::MapObjectType objectType, s32 dst
         }
 
         if ( access ) {
-            Dialog::Message( title,
-                             _( "The butler admits you to see the master of the house. He trains you in the four skills a hero should know." ), Font::BIG, Dialog::OK );
+            Dialog::Message( title, _( "The butler admits you to see the master of the house. He trains you in the four skills a hero should know." ), Font::BIG,
+                             Dialog::OK );
             hero.IncreasePrimarySkill( Skill::Primary::ATTACK );
             hero.IncreasePrimarySkill( Skill::Primary::DEFENSE );
             hero.IncreasePrimarySkill( Skill::Primary::KNOWLEDGE );
@@ -2643,8 +2641,8 @@ void ActionToMagellanMaps( Heroes & hero, const MP2::MapObjectType objectType, s
         I.RedrawFocus();
     }
     else {
-        Dialog::Message( title,
-                         _( "The captain sighs. \"You don't have enough money, eh?  You can't expect me to give my maps away for free!\"" ), Font::BIG, Dialog::OK );
+        Dialog::Message( title, _( "The captain sighs. \"You don't have enough money, eh?  You can't expect me to give my maps away for free!\"" ), Font::BIG,
+                         Dialog::OK );
     }
 
     DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() );
@@ -2989,9 +2987,8 @@ void ActionToSirens( Heroes & hero, const MP2::MapObjectType objectType, s32 dst
     const std::string title( MP2::StringObject( objectType ) );
 
     if ( hero.isObjectTypeVisited( objectType ) ) {
-        Dialog::Message( title,
-                         _( "As the sirens sing their eerie song, your small, determined army manages to overcome the urge to dive headlong into the sea." ), Font::BIG,
-                         Dialog::OK );
+        Dialog::Message( title, _( "As the sirens sing their eerie song, your small, determined army manages to overcome the urge to dive headlong into the sea." ),
+                         Font::BIG, Dialog::OK );
     }
     else {
         u32 exp = hero.GetArmy().ActionToSirens();

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2620,8 +2620,7 @@ void ActionToMagellanMaps( Heroes & hero, const MP2::MapObjectType objectType, s
     const std::string title( MP2::StringObject( objectType ) );
 
     if ( hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) ) {
-        Dialog::Message( title,
-                         _( "The captain looks at you with surprise and says:\n\"You already have all the maps I know about. Let me fish in peace now.\"" ),
+        Dialog::Message( title, _( "The captain looks at you with surprise and says:\n\"You already have all the maps I know about. Let me fish in peace now.\"" ),
                          Font::BIG, Dialog::OK );
     }
     else if ( kingdom.AllowPayment( payment ) ) {

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1096,6 +1096,7 @@ void ActionToSkeleton( Heroes & hero, const MP2::MapObjectType objectType, s32 d
 {
     Maps::Tiles & tile = world.GetTiles( dst_index );
     std::string message( _( "You come upon the remains of an unfortunate adventurer." ) );
+    const std::string title( MP2::StringObject( objectType ) );
 
     // artifact
     if ( tile.QuantityIsValid() ) {
@@ -1104,7 +1105,7 @@ void ActionToSkeleton( Heroes & hero, const MP2::MapObjectType objectType, s32 d
         if ( hero.IsFullBagArtifacts() ) {
             u32 gold = GoldInsteadArtifact( objectType );
             const Funds funds( Resource::GOLD, gold );
-            Dialog::ResourceInfo( "", _( "Treasure" ), funds, Dialog::OK );
+            Dialog::ResourceInfo( title, _( "Treasure" ), funds, Dialog::OK );
             hero.GetKingdom().AddFundsResource( funds );
         }
         else {
@@ -1113,7 +1114,7 @@ void ActionToSkeleton( Heroes & hero, const MP2::MapObjectType objectType, s32 d
             message.append( _( "Searching through the tattered clothing, you find %{artifact}." ) );
             StringReplace( message, "%{artifact}", art.GetName() );
             AGG::PlaySound( M82::TREASURE );
-            Dialog::ArtifactInfo( "", message, art );
+            Dialog::ArtifactInfo( title, message, art );
             hero.PickupArtifact( art );
         }
 
@@ -1122,7 +1123,7 @@ void ActionToSkeleton( Heroes & hero, const MP2::MapObjectType objectType, s32 d
     else {
         message += '\n';
         message.append( _( "Searching through the tattered clothing, you find nothing." ) );
-        Dialog::Message( "", message, Font::BIG, Dialog::OK );
+        Dialog::Message( title, message, Font::BIG, Dialog::OK );
     }
 
     hero.SetVisitedWideTile( dst_index, objectType, Visit::GLOBAL );
@@ -1134,6 +1135,7 @@ void ActionToWagon( Heroes & hero, s32 dst_index )
 {
     Maps::Tiles & tile = world.GetTiles( dst_index );
     std::string message( _( "You come across an old wagon left by a trader who didn't quite make it to safe terrain." ) );
+    const std::string title( MP2::StringObject( MP2::OBJ_WAGON ) );
 
     if ( tile.QuantityIsValid() ) {
         const Artifact & art = tile.QuantityArtifact();
@@ -1142,14 +1144,14 @@ void ActionToWagon( Heroes & hero, s32 dst_index )
             if ( hero.IsFullBagArtifacts() ) {
                 message += '\n';
                 message.append( _( "Unfortunately, others have found it first, and the wagon is empty." ) );
-                Dialog::Message( "", message, Font::BIG, Dialog::OK );
+                Dialog::Message( title, message, Font::BIG, Dialog::OK );
             }
             else {
                 message += '\n';
                 message.append( _( "Searching inside, you find the %{artifact}." ) );
                 StringReplace( message, "%{artifact}", art.GetName() );
                 AGG::PlaySound( M82::TREASURE );
-                Dialog::ArtifactInfo( "", message, art );
+                Dialog::ArtifactInfo( title, message, art );
                 hero.PickupArtifact( art );
             }
         }
@@ -1158,7 +1160,7 @@ void ActionToWagon( Heroes & hero, s32 dst_index )
             AGG::PlaySound( M82::EXPERNCE );
             message += '\n';
             message.append( _( "Inside, you find some of the wagon's cargo still intact." ) );
-            Dialog::ResourceInfo( "", message, funds );
+            Dialog::ResourceInfo( title, message, funds );
             hero.GetKingdom().AddFundsResource( funds );
         }
 
@@ -1167,7 +1169,7 @@ void ActionToWagon( Heroes & hero, s32 dst_index )
     else {
         message += '\n';
         message.append( _( "Unfortunately, others have found it first, and the wagon is empty." ) );
-        Dialog::Message( "", message, Font::BIG, Dialog::OK );
+        Dialog::Message( title, message, Font::BIG, Dialog::OK );
     }
 
     hero.SetVisited( dst_index, Visit::GLOBAL );
@@ -1179,17 +1181,19 @@ void ActionToFlotSam( const Heroes & hero, const MP2::MapObjectType objectType, 
 {
     Maps::Tiles & tile = world.GetTiles( dst_index );
     std::string msg;
+    const std::string title( MP2::StringObject( objectType ) );
+
     const Funds & funds = tile.QuantityFunds();
 
     if ( 0 < funds.GetValidItemsCount() ) {
         msg = funds.wood && funds.gold ? _( "You search through the flotsam, and find some wood and some gold." )
                                        : _( "You search through the flotsam, and find some wood." );
-        Dialog::ResourceInfo( MP2::StringObject( objectType ), msg, funds );
+        Dialog::ResourceInfo( title, msg, funds );
         hero.GetKingdom().AddFundsResource( funds );
     }
     else {
         msg = _( "You search through the flotsam, but find nothing." );
-        Dialog::Message( MP2::StringObject( objectType ), msg, Font::BIG, Dialog::OK );
+        Dialog::Message( title, msg, Font::BIG, Dialog::OK );
     }
 
     Game::PlayPickupSound();
@@ -1229,6 +1233,8 @@ void ActionToShrine( Heroes & hero, s32 dst_index )
             "You come across a lavish shrine attended by a group of high priests.\nIn exchange for your protection, they agree to teach you a sophisticated spell - '%{spell}'." );
         break;
     default:
+        // Did you add a new level shrine? Add the logic above.
+        assert( 0 );
         return;
     }
 
@@ -1271,29 +1277,34 @@ void ActionToWitchsHut( Heroes & hero, const MP2::MapObjectType objectType, s32 
 
     AGG::PlayMusic( MUS::SKILL, false );
 
+    // If this assertion blows up the object is not set properly.
+    assert( skill.isValid() );
+
     if ( skill.isValid() ) {
         std::string msg = _( "You approach the hut and observe a witch inside studying an ancient tome on %{skill}.\n \n" );
         const std::string & skill_name = Skill::Secondary::String( skill.Skill() );
         StringReplace( msg, "%{skill}", skill_name );
 
+        const std::string title( MP2::StringObject( objectType ) );
+
         // check full
         if ( hero.HasMaxSecondarySkill() ) {
             msg.append( _(
                 "As you approach, she turns and focuses her one glass eye on you.\n\"You already know everything you deserve to learn!\" the witch screeches. \"NOW GET OUT OF MY HOUSE!\"" ) );
-            Dialog::Message( MP2::StringObject( objectType ), msg, Font::BIG, Dialog::OK );
+            Dialog::Message( title, msg, Font::BIG, Dialog::OK );
         }
         else
             // check present skill
             if ( hero.HasSecondarySkill( skill.Skill() ) ) {
             msg.append( _( "As you approach, she turns and speaks.\n\"You already know that which I would teach you. I can help you no further.\"" ) );
-            Dialog::Message( MP2::StringObject( objectType ), msg, Font::BIG, Dialog::OK );
+            Dialog::Message( title, msg, Font::BIG, Dialog::OK );
         }
         else {
             hero.LearnSkill( skill );
 
             msg.append( _( "An ancient and immortal witch living in a hut with bird's legs for stilts teaches you %{skill} for her own inscrutable purposes." ) );
             StringReplace( msg, "%{skill}", skill_name );
-            Dialog::SecondarySkillInfo( MP2::StringObject( objectType ), msg, skill, hero );
+            Dialog::SecondarySkillInfo( title, msg, skill, hero );
         }
     }
 
@@ -1332,15 +1343,17 @@ void ActionToGoodLuckObject( Heroes & hero, const MP2::MapObjectType objectType,
         break;
     }
 
+    const std::string title( MP2::StringObject( objectType ) );
+
     // check already visited
     if ( visited ) {
-        Dialog::Message( MP2::StringObject( objectType ), msg, Font::BIG, Dialog::OK );
+        Dialog::Message( title, msg, Font::BIG, Dialog::OK );
     }
     else {
         // modify luck
         hero.SetVisited( dst_index );
         AGG::PlaySound( M82::GOODLUCK );
-        DialogLuck( MP2::StringObject( objectType ), msg, true, 1 );
+        DialogLuck( title, msg, true, 1 );
     }
 
     DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() );
@@ -1350,48 +1363,47 @@ void ActionToPyramid( Heroes & hero, const MP2::MapObjectType objectType, s32 ds
 {
     Maps::Tiles & tile = world.GetTiles( dst_index );
     const Spell & spell = tile.QuantitySpell();
-    std::string ask;
-    std::string msg;
+    const std::string ask = _(
+        "You come upon the pyramid of a great and ancient king.\nYou are tempted to search it for treasure, but all the old stories warn of fearful curses and undead "
+        "guardians.\nWill you search?" );
 
-    switch ( objectType ) {
-    case MP2::OBJ_PYRAMID:
-        ask = _(
-            "You come upon the pyramid of a great and ancient king.\nYou are tempted to search it for treasure, but all the old stories warn of fearful curses and undead guardians.\nWill you search?" );
-        msg = _( "You come upon the pyramid of a great and ancient king.\nRoutine exploration reveals that the pyramid is completely empty." );
-        break;
+    const std::string title( MP2::StringObject( objectType ) );
 
-    default:
-        break;
-    }
-
-    if ( Dialog::YES == Dialog::Message( "", ask, Font::BIG, Dialog::YES | Dialog::NO ) ) {
+    if ( Dialog::YES == Dialog::Message( MP2::StringObject( objectType ), ask, Font::BIG, Dialog::YES | Dialog::NO ) ) {
         if ( spell.isValid() ) {
             // battle
             Army army( tile );
 
-            Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
+            const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
                 bool valid = false;
 
+                std::string msg = _( "Upon defeating the monsters, you decipher an ancient glyph on the wall, telling the secret of the spell - '" );
+                msg += spell.GetName();
+                msg += "'.";
+
                 // check magick book
-                if ( !hero.HaveSpellBook() )
-                    msg = _( "Unfortunately, you have no Magic Book to record the spell with." );
-                else
+                if ( !hero.HaveSpellBook() ) {
+                    msg += '\n';
+                    msg += _( "Unfortunately, you have no Magic Book to record the spell with." );
+                }
+                else if ( Skill::Level::EXPERT > hero.GetLevelSkill( Skill::Secondary::WISDOM ) ) {
                     // check skill level for wisdom
-                    if ( Skill::Level::EXPERT > hero.GetLevelSkill( Skill::Secondary::WISDOM ) )
-                    msg = _( "Unfortunately, you do not have the wisdom to understand the spell, and you are unable to learn it." );
+                    msg += '\n';
+                    msg += _( "Unfortunately, you do not have the wisdom to understand the spell, and you are unable to learn it." );
+                }
                 else {
                     valid = true;
-                    msg = _( "Upon defeating the monsters, you decipher an ancient glyph on the wall, telling the secret of the spell." );
                 }
 
                 if ( valid ) {
-                    Dialog::SpellInfo( spell.GetName(), msg, spell, true );
+                    Dialog::SpellInfo( title, msg, spell, true );
                     hero.AppendSpellToBook( spell );
                 }
-                else
-                    Dialog::Message( MP2::StringObject( objectType ), msg, Font::BIG, Dialog::OK );
+                else {
+                    Dialog::Message( title, msg, Font::BIG, Dialog::OK );
+                }
 
                 tile.QuantityReset();
                 hero.SetVisited( dst_index, Visit::GLOBAL );
@@ -1403,7 +1415,8 @@ void ActionToPyramid( Heroes & hero, const MP2::MapObjectType objectType, s32 ds
         else {
             // modify luck
             AGG::PlaySound( M82::BADLUCK );
-            DialogLuck( MP2::StringObject( objectType ), msg, false, 2 );
+            const std::string msg = _( "You come upon the pyramid of a great and ancient king.\nRoutine exploration reveals that the pyramid is completely empty." );
+            DialogLuck( title, msg, false, 2 );
 
             hero.SetVisited( dst_index, Visit::LOCAL );
             hero.SetVisited( dst_index, Visit::GLOBAL );
@@ -1416,7 +1429,7 @@ void ActionToPyramid( Heroes & hero, const MP2::MapObjectType objectType, s32 ds
 void ActionToSign( const Heroes & hero, s32 dst_index )
 {
     const MapSign * sign = dynamic_cast<MapSign *>( world.GetMapObject( dst_index ) );
-    Dialog::Message( _( "Sign" ), ( sign ? sign->message : "" ), Font::BIG, Dialog::OK );
+    Dialog::Message( MP2::StringObject( MP2::OBJ_SIGN ), ( sign ? sign->message : "" ), Font::BIG, Dialog::OK );
 
     (void)hero;
     DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() );
@@ -1425,20 +1438,20 @@ void ActionToSign( const Heroes & hero, s32 dst_index )
 void ActionToMagicWell( Heroes & hero, int32_t dst_index )
 {
     const uint32_t max = hero.GetMaxSpellPoints();
+    const std::string title( MP2::StringObject( MP2::OBJ_MAGICWELL ) );
 
     if ( hero.GetSpellPoints() >= max ) {
-        Dialog::Message( MP2::StringObject( MP2::OBJ_MAGICWELL ), _( "A drink at the well is supposed to restore your spell points, but you are already at maximum." ),
-                         Font::BIG, Dialog::OK );
+        Dialog::Message( title, _( "A drink at the well is supposed to restore your spell points, but you are already at maximum." ), Font::BIG, Dialog::OK );
     }
     else
         // check already visited
         if ( hero.isObjectTypeVisited( MP2::OBJ_MAGICWELL ) ) {
-        Dialog::Message( MP2::StringObject( MP2::OBJ_MAGICWELL ), _( "A second drink at the well in one day will not help you." ), Font::BIG, Dialog::OK );
+        Dialog::Message( title, _( "A second drink at the well in one day will not help you." ), Font::BIG, Dialog::OK );
     }
     else {
         hero.SetVisited( dst_index );
         hero.SetSpellPoints( max );
-        Dialog::Message( MP2::StringObject( MP2::OBJ_MAGICWELL ), _( "A drink from the well has restored your spell points to maximum." ), Font::BIG, Dialog::OK );
+        Dialog::Message( title, _( "A drink from the well has restored your spell points to maximum." ), Font::BIG, Dialog::OK );
     }
 
     DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() );
@@ -1492,15 +1505,16 @@ void ActionToPrimarySkillObject( Heroes & hero, const MP2::MapObjectType objectT
         return;
     }
 
+    const std::string title( MP2::StringObject( objectType ) );
     // check already visited
     if ( visited ) {
-        Dialog::Message( MP2::StringObject( objectType ), msg, Font::BIG, Dialog::OK );
+        Dialog::Message( title, msg, Font::BIG, Dialog::OK );
     }
     else {
         // increase skill
         hero.IncreasePrimarySkill( skill );
         hero.SetVisited( dst_index );
-        Dialog::PrimarySkillInfo( MP2::StringObject( objectType ), msg, skill );
+        Dialog::PrimarySkillInfo( title, msg, skill );
 
         // fix double action tile
         hero.SetVisitedWideTile( dst_index, objectType );
@@ -1537,6 +1551,8 @@ void ActionToPoorMoraleObject( Heroes & hero, const MP2::MapObjectType objectTyp
         break;
     }
 
+    const std::string title( MP2::StringObject( objectType ) );
+
     if ( Dialog::YES == Dialog::Message( MP2::StringObject( objectType ), ask, Font::BIG, Dialog::YES | Dialog::NO ) ) {
         bool complete = false;
 
@@ -1552,15 +1568,15 @@ void ActionToPoorMoraleObject( Heroes & hero, const MP2::MapObjectType objectTyp
                 if ( art.isValid() ) {
                     if ( hero.IsFullBagArtifacts() ) {
                         gold = GoldInsteadArtifact( objectType );
-                        DialogWithGold( MP2::StringObject( objectType ), win, gold );
+                        DialogWithGold( title, win, gold );
                     }
                     else {
-                        DialogWithArtifactAndGold( MP2::StringObject( objectType ), win, art, gold );
+                        DialogWithArtifactAndGold( title, win, art, gold );
                         hero.PickupArtifact( art );
                     }
                 }
                 else
-                    DialogWithGold( MP2::StringObject( objectType ), win, gold );
+                    DialogWithGold( title, win, gold );
 
                 hero.GetKingdom().AddFundsResource( Funds( Resource::GOLD, gold ) );
             }
@@ -1578,7 +1594,7 @@ void ActionToPoorMoraleObject( Heroes & hero, const MP2::MapObjectType objectTyp
             hero.SetVisited( dst_index, Visit::LOCAL );
             hero.SetVisited( dst_index, Visit::GLOBAL );
             AGG::PlaySound( M82::BADMRLE );
-            DialogMorale( MP2::StringObject( objectType ), msg, false, 1 );
+            DialogMorale( title, msg, false, 1 );
         }
     }
 
@@ -1619,15 +1635,16 @@ void ActionToGoodMoraleObject( Heroes & hero, const MP2::MapObjectType objectTyp
         return;
     }
 
+    const std::string title( MP2::StringObject( objectType ) );
     // check already visited
     if ( visited ) {
-        Dialog::Message( MP2::StringObject( objectType ), msg, Font::BIG, Dialog::OK );
+        Dialog::Message( title, msg, Font::BIG, Dialog::OK );
     }
     else {
         // modify morale
         hero.SetVisited( dst_index );
         AGG::PlaySound( M82::GOODMRLE );
-        DialogMorale( MP2::StringObject( objectType ), msg, true, ( objectType == MP2::OBJ_TEMPLE ? 2 : 1 ) );
+        DialogMorale( title, msg, true, ( objectType == MP2::OBJ_TEMPLE ? 2 : 1 ) );
         hero.IncreaseMovePoints( move );
 
         // fix double action tile
@@ -1657,9 +1674,10 @@ void ActionToExperienceObject( Heroes & hero, const MP2::MapObjectType objectTyp
         return;
     }
 
+    const std::string title( MP2::StringObject( objectType ) );
     // check already visited
     if ( visited ) {
-        Dialog::Message( MP2::StringObject( objectType ), msg, Font::BIG, Dialog::OK );
+        Dialog::Message( title, msg, Font::BIG, Dialog::OK );
     }
     else {
         if ( Settings::Get().MusicMIDI() ) {
@@ -1668,7 +1686,7 @@ void ActionToExperienceObject( Heroes & hero, const MP2::MapObjectType objectTyp
         else {
             AGG::PlayMusic( MUS::EXPERIENCE, false );
         }
-        DialogWithExp( MP2::StringObject( objectType ), msg, exp );
+        DialogWithExp( title, msg, exp );
 
         // visit
         hero.SetVisited( dst_index );
@@ -1682,10 +1700,12 @@ void ActionToShipwreckSurvivor( Heroes & hero, const MP2::MapObjectType objectTy
 {
     Maps::Tiles & tile = world.GetTiles( dst_index );
 
+    const std::string title( MP2::StringObject( objectType ) );
+
     if ( hero.IsFullBagArtifacts() ) {
         const u32 gold = GoldInsteadArtifact( objectType );
         DialogWithGold(
-            MP2::StringObject( objectType ),
+            title,
             _( "You've pulled a shipwreck survivor from certain death in an unforgiving ocean. Grateful, he says, \"I would give you an artifact as a reward, but you're all full.\"" ),
             gold, Dialog::OK );
         hero.GetKingdom().AddFundsResource( Funds( Resource::GOLD, gold ) );
@@ -1696,7 +1716,7 @@ void ActionToShipwreckSurvivor( Heroes & hero, const MP2::MapObjectType objectTy
             "You've pulled a shipwreck survivor from certain death in an unforgiving ocean. Grateful, he rewards you for your act of kindness by giving you the %{art}." );
         StringReplace( str, "%{art}", art.GetName() );
         AGG::PlaySound( M82::TREASURE );
-        Dialog::ArtifactInfo( "", str, art );
+        Dialog::ArtifactInfo( title, str, art );
         hero.PickupArtifact( art );
     }
 
@@ -1715,9 +1735,10 @@ void ActionToShipwreckSurvivor( Heroes & hero, const MP2::MapObjectType objectTy
 void ActionToArtifact( Heroes & hero, s32 dst_index )
 {
     Maps::Tiles & tile = world.GetTiles( dst_index );
+    const std::string title( MP2::StringObject( MP2::OBJ_ARTIFACT ) );
 
     if ( hero.IsFullBagArtifacts() )
-        Dialog::Message( _( "Artifact" ), _( "You cannot pick up this artifact, you already have a full load!" ), Font::BIG, Dialog::OK );
+        Dialog::Message( title, _( "You cannot pick up this artifact, you already have a full load!" ), Font::BIG, Dialog::OK );
     else {
         u32 cond = tile.QuantityVariant();
         Artifact art = tile.QuantityArtifact();
@@ -1752,14 +1773,14 @@ void ActionToArtifact( Heroes & hero, s32 dst_index )
                     hero.GetKingdom().OddFundsResource( payment );
                 }
                 else {
-                    Dialog::Message( _( "Artifact" ),
+                    Dialog::Message( title,
                                      _( "You try to pay the leprechaun, but realize that you can't afford it. The leprechaun stamps his foot and ignores you." ),
                                      Font::BIG, Dialog::OK );
                 }
             }
             else
-                Dialog::Message( _( "Artifact" ), _( "Insulted by your refusal of his generous offer, the leprechaun stamps his foot and ignores you." ), Font::BIG,
-                                 Dialog::OK );
+                Dialog::Message( title,
+                                 _( "Insulted by your refusal of his generous offer, the leprechaun stamps his foot and ignores you." ), Font::BIG, Dialog::OK );
         }
         else
             // 4,5 - need have skill wisard or leadership,
@@ -1770,7 +1791,7 @@ void ActionToArtifact( Heroes & hero, s32 dst_index )
                 msg = _( "You've found the artifact: " );
                 msg.append( art.GetName() );
                 AGG::PlaySound( M82::TREASURE );
-                Dialog::ArtifactInfo( "", msg, art, Dialog::OK );
+                Dialog::ArtifactInfo( title, msg, art, Dialog::OK );
                 result = true;
             }
             else {
@@ -1790,7 +1811,7 @@ void ActionToArtifact( Heroes & hero, s32 dst_index )
                 }
 
                 StringReplace( msg, "%{art}", art.GetName() );
-                Dialog::Message( _( "Artifact" ), msg, Font::BIG, Dialog::OK );
+                Dialog::Message( title, msg, Font::BIG, Dialog::OK );
             }
         }
         else
@@ -1802,14 +1823,14 @@ void ActionToArtifact( Heroes & hero, s32 dst_index )
 
             if ( troop ) {
                 if ( Monster::ROGUE == troop->GetID() )
-                    Dialog::Message( _( "Artifact" ),
+                    Dialog::Message( title,
                                      _( "You come upon an ancient artifact. As you reach for it, a pack of Rogues leap out of the brush to guard their stolen loot." ),
                                      Font::BIG, Dialog::OK );
                 else {
                     msg = _(
                         "Through a clearing you observe an ancient artifact. Unfortunately, it's guarded by a nearby %{monster}. Do you want to fight the %{monster} for the artifact?" );
                     StringReplace( msg, "%{monster}", troop->GetName() );
-                    battle = ( Dialog::YES == Dialog::Message( _( "Artifact" ), msg, Font::BIG, Dialog::YES | Dialog::NO ) );
+                    battle = ( Dialog::YES == Dialog::Message( title, msg, Font::BIG, Dialog::YES | Dialog::NO ) );
                 }
             }
 
@@ -1822,14 +1843,14 @@ void ActionToArtifact( Heroes & hero, s32 dst_index )
                     msg = _( "Victorious, you take your prize, the %{art}." );
                     StringReplace( msg, "%{art}", art.GetName() );
                     AGG::PlaySound( M82::TREASURE );
-                    Dialog::ArtifactInfo( "", msg, art.GetID() );
+                    Dialog::ArtifactInfo( title, msg, art.GetID() );
                 }
                 else {
                     BattleLose( hero, res, true );
                 }
             }
             else {
-                Dialog::Message( _( "Artifact" ), _( "Discretion is the better part of valor, and you decide to avoid this fight for today." ), Font::BIG, Dialog::OK );
+                Dialog::Message( title, _( "Discretion is the better part of valor, and you decide to avoid this fight for today." ), Font::BIG, Dialog::OK );
             }
         }
         else {
@@ -1841,7 +1862,7 @@ void ActionToArtifact( Heroes & hero, s32 dst_index )
                 msg.append( art.GetName() );
             }
             AGG::PlaySound( M82::TREASURE );
-            Dialog::ArtifactInfo( _( "Artifact" ), msg, art );
+            Dialog::ArtifactInfo( title, msg, art );
             result = true;
         }
 
@@ -1922,7 +1943,7 @@ void ActionToTreasureChest( Heroes & hero, const MP2::MapObjectType objectType, 
                 msg = _( "After scouring the area, you fall upon a hidden chest, containing the ancient artifact %{art}." );
                 StringReplace( msg, "%{art}", art.GetName() );
                 AGG::PlaySound( M82::TREASURE );
-                Dialog::ArtifactInfo( "", msg, art );
+                Dialog::ArtifactInfo( hdr, msg, art );
                 hero.PickupArtifact( art );
             }
         }
@@ -1947,13 +1968,15 @@ void ActionToAncientLamp( Heroes & hero, const MP2::MapObjectType objectType, s3
 {
     Maps::Tiles & tile = world.GetTiles( dst_index );
     const Troop & troop = tile.QuantityTroop();
+    if ( !troop.isValid() ) {
+        return;
+    }
 
-    if ( troop.isValid()
-         && Dialog::YES
-                == Dialog::Message( MP2::StringObject( objectType ),
-                                    _( "You stumble upon a dented and tarnished lamp lodged deep in the earth. Do you wish to rub the lamp?" ), Font::BIG,
-                                    Dialog::YES | Dialog::NO ) )
-        RecruitMonsterFromTile( hero, tile, MP2::StringObject( objectType ), troop, true );
+    const std::string title( MP2::StringObject( objectType ) );
+    if ( Dialog::YES == Dialog::Message( title,
+            _( "You stumble upon a dented and tarnished lamp lodged deep in the earth. Do you wish to rub the lamp?" ), Font::BIG, Dialog::YES | Dialog::NO ) ) {
+        RecruitMonsterFromTile( hero, tile, title, troop, true );
+    }
 
     DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() );
 }
@@ -2041,7 +2064,8 @@ void ActionToWhirlpools( Heroes & hero, s32 index_from )
 void ActionToAbandoneMine( Heroes & hero, const MP2::MapObjectType objectType, s32 dst_index )
 {
     if ( Dialog::YES
-         == Dialog::Message( "", _( "You come upon an abandoned gold mine. The mine appears to be haunted. Do you wish to enter?" ), Font::BIG,
+         == Dialog::Message( MP2::StringObject( MP2::OBJ_ABANDONEDMINE ),
+                             _( "You come upon an abandoned gold mine. The mine appears to be haunted. Do you wish to enter?" ), Font::BIG,
                              Dialog::YES | Dialog::NO ) ) {
         ActionToCaptureObject( hero, objectType, dst_index );
     }
@@ -2174,6 +2198,8 @@ void ActionToDwellingJoinMonster( Heroes & hero, const MP2::MapObjectType object
     Maps::Tiles & tile = world.GetTiles( dst_index );
     const Troop & troop = tile.QuantityTroop();
 
+    const std::string title( MP2::StringObject( objectType ) );
+
     if ( troop.isValid() ) {
         hero.MovePointsScaleFixed();
 
@@ -2185,7 +2211,7 @@ void ActionToDwellingJoinMonster( Heroes & hero, const MP2::MapObjectType object
         else
             AGG::PlaySound( M82::EXPERNCE );
 
-        if ( Dialog::YES == Dialog::Message( MP2::StringObject( objectType ), message, Font::BIG, Dialog::YES | Dialog::NO ) ) {
+        if ( Dialog::YES == Dialog::Message( title, message, Font::BIG, Dialog::YES | Dialog::NO ) ) {
             if ( !hero.GetArmy().CanJoinTroop( troop ) )
                 Dialog::Message( troop.GetName(), _( "You are unable to recruit at this time, your ranks are full." ), Font::BIG, Dialog::OK );
             else {
@@ -2198,12 +2224,12 @@ void ActionToDwellingJoinMonster( Heroes & hero, const MP2::MapObjectType object
         }
     }
     else {
-        Dialog::Message( "", _( "As you approach the dwelling, you notice that there is no one here." ), Font::BIG, Dialog::OK );
+        Dialog::Message( title, _( "As you approach the dwelling, you notice that there is no one here." ), Font::BIG, Dialog::OK );
     }
 
     hero.SetVisited( dst_index, Visit::GLOBAL );
 
-    DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << ", object: " << MP2::StringObject( objectType ) );
+    DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << ", object: " << title.c_str() );
 }
 
 void ActionToDwellingRecruitMonster( Heroes & hero, const MP2::MapObjectType objectType, s32 dst_index )
@@ -2271,14 +2297,16 @@ void ActionToDwellingRecruitMonster( Heroes & hero, const MP2::MapObjectType obj
 
     const Troop & troop = tile.QuantityTroop();
 
+    const std::string title( MP2::StringObject( objectType ) );
+
     if ( !troop.isValid() )
-        Dialog::Message( MP2::StringObject( objectType ), msg_void, Font::BIG, Dialog::OK );
-    else if ( Dialog::YES == Dialog::Message( MP2::StringObject( objectType ), msg_full, Font::BIG, Dialog::YES | Dialog::NO ) )
-        RecruitMonsterFromTile( hero, tile, MP2::StringObject( objectType ), troop, false );
+        Dialog::Message( title, msg_void, Font::BIG, Dialog::OK );
+    else if ( Dialog::YES == Dialog::Message( title, msg_full, Font::BIG, Dialog::YES | Dialog::NO ) )
+        RecruitMonsterFromTile( hero, tile, title, troop, false );
 
     hero.SetVisited( dst_index, Visit::GLOBAL );
 
-    DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << ", object: " << MP2::StringObject( objectType ) );
+    DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << ", object: " << title.c_str() );
 }
 
 void ActionToDwellingBattleMonster( Heroes & hero, const MP2::MapObjectType objectType, s32 dst_index )
@@ -2316,9 +2344,11 @@ void ActionToDwellingBattleMonster( Heroes & hero, const MP2::MapObjectType obje
     Maps::Tiles & tile = world.GetTiles( dst_index );
     const Troop & troop = tile.QuantityTroop();
 
+    const std::string title( MP2::StringObject( objectType ) );
+
     if ( Color::NONE == tile.QuantityColor() ) {
         // Not captured / defeated yet.
-        if ( Dialog::YES == Dialog::Message( MP2::StringObject( objectType ), str_warn, Font::BIG, Dialog::YES | Dialog::NO ) ) {
+        if ( Dialog::YES == Dialog::Message( title, str_warn, Font::BIG, Dialog::YES | Dialog::NO ) ) {
             // new battle
             Army army( tile );
             Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
@@ -2338,25 +2368,26 @@ void ActionToDwellingBattleMonster( Heroes & hero, const MP2::MapObjectType obje
             str_scss = str_recr;
         }
         else {
-            Dialog::Message( MP2::StringObject( objectType ), str_empty, Font::BIG, Dialog::OK );
+            Dialog::Message( title, str_empty, Font::BIG, Dialog::OK );
         }
     }
 
     // recruit monster
     if ( str_scss ) {
-        if ( troop.isValid() && Dialog::YES == Dialog::Message( MP2::StringObject( objectType ), str_scss, Font::BIG, Dialog::YES | Dialog::NO ) ) {
-            RecruitMonsterFromTile( hero, tile, MP2::StringObject( objectType ), troop, false );
+        if ( troop.isValid() && Dialog::YES == Dialog::Message( title, str_scss, Font::BIG, Dialog::YES | Dialog::NO ) ) {
+            RecruitMonsterFromTile( hero, tile, title, troop, false );
         }
 
         hero.SetVisited( dst_index, Visit::GLOBAL );
     }
 
-    DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << ", object: " << MP2::StringObject( objectType ) );
+    DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << ", object: " << title.c_str() );
 }
 
 void ActionToObservationTower( const Heroes & hero, const MP2::MapObjectType objectType, s32 dst_index )
 {
     Dialog::Message( MP2::StringObject( objectType ), _( "From the observation tower, you are able to see distant lands." ), Font::BIG, Dialog::OK );
+
     Maps::ClearFog( dst_index, Game::GetViewDistance( Game::VIEW_OBSERVATION_TOWER ), hero.GetColor() );
 }
 
@@ -2392,9 +2423,10 @@ void ActionToArtesianSpring( Heroes & hero, const MP2::MapObjectType objectType,
 void ActionToXanadu( Heroes & hero, const MP2::MapObjectType objectType, s32 dst_index )
 {
     const Maps::Tiles & tile = world.GetTiles( dst_index );
+    const std::string title( MP2::StringObject( objectType ) );
 
     if ( hero.isVisited( tile ) ) {
-        Dialog::Message( MP2::StringObject( objectType ),
+        Dialog::Message( title,
                          _( "Recognizing you, the butler refuses to admit you. \"The master,\" he says, \"will not see the same student twice.\"" ), Font::BIG,
                          Dialog::OK );
     }
@@ -2420,7 +2452,7 @@ void ActionToXanadu( Heroes & hero, const MP2::MapObjectType objectType, s32 dst
         }
 
         if ( access ) {
-            Dialog::Message( MP2::StringObject( objectType ),
+            Dialog::Message( title,
                              _( "The butler admits you to see the master of the house. He trains you in the four skills a hero should know." ), Font::BIG, Dialog::OK );
             hero.IncreasePrimarySkill( Skill::Primary::ATTACK );
             hero.IncreasePrimarySkill( Skill::Primary::DEFENSE );
@@ -2430,7 +2462,7 @@ void ActionToXanadu( Heroes & hero, const MP2::MapObjectType objectType, s32 dst
         }
         else {
             Dialog::Message(
-                MP2::StringObject( objectType ),
+                title,
                 _( "The butler opens the door and looks you up and down. \"You are neither famous nor diplomatic enough to be admitted to see my master,\" he sniffs. \"Come back when you think yourself worthy.\"" ),
                 Font::BIG, Dialog::OK );
         }
@@ -2511,6 +2543,8 @@ void ActionToUpgradeArmyObject( Heroes & hero, const MP2::MapObjectType objectTy
             mons.emplace_back( &monsToUpgrade[i] );
     }
 
+    const std::string title( MP2::StringObject( objectType ) );
+
     if ( !mons.empty() ) {
         // composite sprite
         uint32_t offsetX = 0;
@@ -2571,10 +2605,10 @@ void ActionToUpgradeArmyObject( Heroes & hero, const MP2::MapObjectType objectTy
             fheroes2::Blit( mon, surface, offsetX + 6 + mon.x(), 6 + mon.y() + offsetY );
             offsetX += border.width() + 4;
         }
-        Dialog::SpriteInfo( MP2::StringObject( objectType ), msg1, surface );
+        Dialog::SpriteInfo( title, msg1, surface );
     }
     else {
-        Dialog::Message( MP2::StringObject( objectType ), msg2, Font::BIG, Dialog::OK );
+        Dialog::Message( title, msg2, Font::BIG, Dialog::OK );
     }
 
     DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() );
@@ -2585,8 +2619,10 @@ void ActionToMagellanMaps( Heroes & hero, const MP2::MapObjectType objectType, s
     const Funds payment( Resource::GOLD, 1000 );
     Kingdom & kingdom = hero.GetKingdom();
 
+    const std::string title( MP2::StringObject( objectType ) );
+
     if ( hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) ) {
-        Dialog::Message( MP2::StringObject( objectType ),
+        Dialog::Message( title,
                          _( "The captain looks at you with surprise and says:\n\"You already have all the maps I know about. Let me fish in peace now.\"" ), Font::BIG,
                          Dialog::OK );
     }
@@ -2594,7 +2630,7 @@ void ActionToMagellanMaps( Heroes & hero, const MP2::MapObjectType objectType, s
         if (
             Dialog::YES
             == Dialog::Message(
-                MP2::StringObject( objectType ),
+                title,
                 _( "A retired captain living on this refurbished fishing platform offers to sell you maps of the sea he made in his younger days for 1,000 gold. Do you wish to buy the maps?" ),
                 Font::BIG, Dialog::YES | Dialog::NO ) ) {
             world.ActionForMagellanMaps( hero.GetColor() );
@@ -2607,7 +2643,7 @@ void ActionToMagellanMaps( Heroes & hero, const MP2::MapObjectType objectType, s
         I.RedrawFocus();
     }
     else {
-        Dialog::Message( MP2::StringObject( objectType ),
+        Dialog::Message( title,
                          _( "The captain sighs. \"You don't have enough money, eh?  You can't expect me to give my maps away for free!\"" ), Font::BIG, Dialog::OK );
     }
 
@@ -2654,18 +2690,21 @@ void ActionToEvent( Heroes & hero, s32 dst_index )
 void ActionToObelisk( Heroes & hero, const MP2::MapObjectType objectType, s32 dst_index )
 {
     Kingdom & kingdom = hero.GetKingdom();
+    const std::string title( MP2::StringObject( objectType ) );
+
     if ( !hero.isVisited( world.GetTiles( dst_index ), Visit::GLOBAL ) ) {
         hero.SetVisited( dst_index, Visit::GLOBAL );
         kingdom.PuzzleMaps().Update( kingdom.CountVisitedObjects( MP2::OBJ_OBELISK ), world.CountObeliskOnMaps() );
         AGG::PlaySound( M82::EXPERNCE );
         Dialog::Message(
-            MP2::StringObject( objectType ),
+            title,
             _( "You come upon an obelisk made from a type of stone you have never seen before. Staring at it intensely, the smooth surface suddenly changes to an inscription. The inscription is a piece of a lost ancient map. Quickly you copy down the piece and the inscription vanishes as abruptly as it appeared." ),
             Font::BIG, Dialog::OK );
         kingdom.PuzzleMaps().ShowMapsDialog();
     }
-    else
-        Dialog::Message( MP2::StringObject( objectType ), _( "You have already been to this obelisk." ), Font::BIG, Dialog::OK );
+    else {
+        Dialog::Message( title, _( "You have already been to this obelisk." ), Font::BIG, Dialog::OK );
+    }
 
     DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() );
 }
@@ -2673,9 +2712,10 @@ void ActionToObelisk( Heroes & hero, const MP2::MapObjectType objectType, s32 ds
 void ActionToTreeKnowledge( Heroes & hero, const MP2::MapObjectType objectType, s32 dst_index )
 {
     const Maps::Tiles & tile = world.GetTiles( dst_index );
+    const std::string title( MP2::StringObject( objectType ) );
 
     if ( hero.isVisited( tile ) ) {
-        Dialog::Message( MP2::StringObject( objectType ),
+        Dialog::Message( title,
                          _( "Upon your approach, the tree opens its eyes in delight. \"It is good to see you, my student. I hope my teachings have helped you.\"" ),
                          Font::BIG, Dialog::OK );
     }
@@ -2689,7 +2729,7 @@ void ActionToTreeKnowledge( Heroes & hero, const MP2::MapObjectType objectType, 
             const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::EXPMRL, 4 );
             msg = _(
                 "Upon your approach, the tree opens its eyes in delight. \"Ahh, an adventurer! Allow me to teach you a little of what I have learned over the ages.\"" );
-            Dialog::SpriteInfo( MP2::StringObject( objectType ), msg, sprite );
+            Dialog::SpriteInfo( title, msg, sprite );
         }
         else {
             const ResourceCount & rc = tile.QuantityResourceCount();
@@ -2702,7 +2742,7 @@ void ActionToTreeKnowledge( Heroes & hero, const MP2::MapObjectType objectType, 
                 msg.append( _( "(Just bury it around my roots.)" ) );
                 StringReplace( msg, "%{res}", Resource::String( rc.first ) );
                 StringReplace( msg, "%{count}", rc.second );
-                conditions = Dialog::YES == Dialog::SpriteInfo( MP2::StringObject( objectType ), msg, fheroes2::AGG::GetICN( ICN::EXPMRL, 4 ), Dialog::YES | Dialog::NO );
+                conditions = Dialog::YES == Dialog::SpriteInfo( title, msg, fheroes2::AGG::GetICN( ICN::EXPMRL, 4 ), Dialog::YES | Dialog::NO );
             }
             else {
                 msg = _( "Tears brim in the eyes of the tree." );
@@ -2712,7 +2752,7 @@ void ActionToTreeKnowledge( Heroes & hero, const MP2::MapObjectType objectType, 
                 msg.append( _( "it whispers. (sniff) \"Well, come back when you can pay me.\"" ) );
                 StringReplace( msg, "%{res}", Resource::String( rc.first ) );
                 StringReplace( msg, "%{count}", rc.second );
-                Dialog::Message( MP2::StringObject( objectType ), msg, Font::BIG, Dialog::OK );
+                Dialog::Message( title, msg, Font::BIG, Dialog::OK );
             }
         }
 
@@ -2732,6 +2772,7 @@ void ActionToOracle( const Heroes & hero, const MP2::MapObjectType objectType )
         MP2::StringObject( objectType ),
         _( "Nestled among the trees sits a blind seer. After explaining the intent of your journey, the seer activates his crystal ball, allowing you to see the strengths and weaknesses of your opponents." ),
         Font::BIG, Dialog::OK );
+
     Dialog::ThievesGuild( true );
 
     (void)hero;
@@ -2945,8 +2986,10 @@ void ActionToArena( Heroes & hero, const MP2::MapObjectType objectType, s32 dst_
 
 void ActionToSirens( Heroes & hero, const MP2::MapObjectType objectType, s32 dst_index )
 {
+    const std::string title( MP2::StringObject( objectType ) );
+
     if ( hero.isObjectTypeVisited( objectType ) ) {
-        Dialog::Message( MP2::StringObject( objectType ),
+        Dialog::Message( title,
                          _( "As the sirens sing their eerie song, your small, determined army manages to overcome the urge to dive headlong into the sea." ), Font::BIG,
                          Dialog::OK );
     }
@@ -2958,7 +3001,7 @@ void ActionToSirens( Heroes & hero, const MP2::MapObjectType objectType, s32 dst
 
         hero.SetVisited( dst_index );
         AGG::PlaySound( M82::EXPERNCE );
-        Dialog::Message( MP2::StringObject( objectType ), str, Font::BIG, Dialog::OK );
+        Dialog::Message( title, str, Font::BIG, Dialog::OK );
         hero.IncreaseExperience( exp );
     }
 
@@ -2968,12 +3011,13 @@ void ActionToSirens( Heroes & hero, const MP2::MapObjectType objectType, s32 dst
 void ActionToJail( const Heroes & hero, const MP2::MapObjectType objectType, s32 dst_index )
 {
     const Kingdom & kingdom = hero.GetKingdom();
+    const std::string title( MP2::StringObject( objectType ) );
 
     if ( kingdom.AllowRecruitHero( false, 0 ) ) {
         Maps::Tiles & tile = world.GetTiles( dst_index );
         AGG::PlaySound( M82::EXPERNCE );
         Dialog::Message(
-            MP2::StringObject( objectType ),
+            title,
             _( "In a dazzling display of daring, you break into the local jail and free the hero imprisoned there, who, in return, pledges loyalty to your cause." ),
             Font::BIG, Dialog::OK );
 
@@ -2994,7 +3038,7 @@ void ActionToJail( const Heroes & hero, const MP2::MapObjectType objectType, s32
     else {
         std::string str = _( "You already have %{count} heroes, and regretfully must leave the prisoner in this jail to languish in agony for untold days." );
         StringReplace( str, "%{count}", Kingdom::GetMaxHeroes() );
-        Dialog::Message( MP2::StringObject( objectType ), str, Font::BIG, Dialog::OK );
+        Dialog::Message( title, str, Font::BIG, Dialog::OK );
     }
 
     DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() );
@@ -3047,6 +3091,7 @@ void ActionToSphinx( Heroes & hero, const MP2::MapObjectType objectType, s32 dst
 {
     MapSphinx * riddle = dynamic_cast<MapSphinx *>( world.GetMapObject( dst_index ) );
     const std::string title = MP2::StringObject( objectType );
+
     if ( riddle && riddle->valid ) {
         if (
             Dialog::YES
@@ -3115,9 +3160,11 @@ void ActionToBarrier( Heroes & hero, const MP2::MapObjectType objectType, s32 ds
     Maps::Tiles & tile = world.GetTiles( dst_index );
     const Kingdom & kingdom = hero.GetKingdom();
 
+    const std::string title = MP2::StringObject( objectType );
+
     if ( kingdom.IsVisitTravelersTent( tile.QuantityColor() ) ) {
         Dialog::Message(
-            MP2::StringObject( objectType ),
+            title,
             _( "A magical barrier stands tall before you, blocking your way. Runes on the arch read,\n\"Speak the key and you may pass.\"\nAs you speak the magic word, the glowing barrier dissolves into nothingness." ),
             Font::BIG, Dialog::OK );
 
@@ -3131,7 +3178,7 @@ void ActionToBarrier( Heroes & hero, const MP2::MapObjectType objectType, s32 ds
     }
     else {
         Dialog::Message(
-            MP2::StringObject( objectType ),
+            title,
             _( "A magical barrier stands tall before you, blocking your way. Runes on the arch read,\n\"Speak the key and you may pass.\"\nYou speak, and nothing happens." ),
             Font::BIG, Dialog::OK );
     }


### PR DESCRIPTION
- added titles and fixed messages for Pyramid dialogs ( close #4615, close #4613 )
- added titles for Skeleton dialogs ( close #4612 )
- added titles for Abandoned Mine dialogs ( close #4614 )
- added titles for Wagon dialogs 