### PR TITLE
Interface::Basic::EventDefaultAction(): the action object can alter the status of the hero, so forcibly redraw the hero icon panel

### DIFF
--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -104,7 +104,7 @@ namespace Interface
         void SetHideInterface( bool );
 
         void EventSwitchHeroSleeping( void );
-        fheroes2::GameMode EventDefaultAction( const fheroes2::GameMode gameMode ) const;
+        fheroes2::GameMode EventDefaultAction( const fheroes2::GameMode gameMode );
         void EventOpenFocus( void ) const;
         fheroes2::GameMode EventSaveGame() const;
         void EventPuzzleMaps( void ) const;

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -391,7 +391,7 @@ fheroes2::GameMode Interface::Basic::EventDigArtifact()
     return fheroes2::GameMode::CANCEL;
 }
 
-fheroes2::GameMode Interface::Basic::EventDefaultAction( const fheroes2::GameMode gameMode ) const
+fheroes2::GameMode Interface::Basic::EventDefaultAction( const fheroes2::GameMode gameMode )
 {
     Heroes * hero = GetFocusHeroes();
 
@@ -399,6 +399,9 @@ fheroes2::GameMode Interface::Basic::EventDefaultAction( const fheroes2::GameMod
         // 1. action object
         if ( MP2::isActionObject( hero->GetMapsObject(), hero->isShipMaster() ) ) {
             hero->Action( hero->GetIndex(), true );
+
+            // The action object (e.g. Stables or Well) can alter the status of the hero
+            iconsPanel.RedrawIcons( ICON_HEROES );
 
             // If a hero completed an action we must verify the condition for the scenario.
             if ( hero->isAction() ) {


### PR DESCRIPTION
fix #4653
fix #4659
fix #4660
fix #4661
fix #4662
