### PR TITLE
Fix crash due to out of memory boundary access during resolution change

### DIFF
--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1287,6 +1287,8 @@ namespace fheroes2
         // deallocate engine resources
         _engine->clear();
 
+        _prevRoi = {};
+
         // allocate engine resources
         if ( !_engine->allocate( width_, height_, isFullScreen ) ) {
             clear();

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1401,6 +1401,8 @@ namespace fheroes2
     {
         _engine->clear();
         clear();
+
+        _prevRoi = {};
     }
 
     void Display::changePalette( const uint8_t * palette ) const


### PR DESCRIPTION
relates to #4762