### PR TITLE
Add hotkey for settings in main menu

### DIFF
--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -219,8 +219,8 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
 
     const double scaleX = static_cast<double>( display.width() ) / fheroes2::Display::DEFAULT_WIDTH;
     const double scaleY = static_cast<double>( display.height() ) / fheroes2::Display::DEFAULT_HEIGHT;
-    const fheroes2::Rect resolutionArea( static_cast<int32_t>( 63 * scaleX ), static_cast<int32_t>( 202 * scaleY ), static_cast<int32_t>( 90 * scaleX ),
-                                         static_cast<int32_t>( 160 * scaleY ) );
+    const fheroes2::Rect settingsArea( static_cast<int32_t>( 63 * scaleX ), static_cast<int32_t>( 202 * scaleY ), static_cast<int32_t>( 90 * scaleX ),
+                                       static_cast<int32_t>( 160 * scaleY ) );
 
     u32 lantern_frame = 0;
 
@@ -298,7 +298,7 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
                 return fheroes2::GameMode::QUIT_GAME;
             }
         }
-        else if ( le.MouseClickLeft( resolutionArea ) ) {
+        else if ( HotKeyPressEvent( EVENT_BUTTON_SETTINGS ) || le.MouseClickLeft( settingsArea ) ) {
             fheroes2::openGameSettings();
 
             // force interface to reset area and positions
@@ -317,14 +317,14 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
             Dialog::Message( _( "High Scores" ), _( "View the high scores screen." ), Font::BIG );
         else if ( le.MousePressRight( buttonNewGame.area() ) )
             Dialog::Message( _( "New Game" ), _( "Start a single or multi-player game." ), Font::BIG );
-        else if ( le.MousePressRight( resolutionArea ) )
+        else if ( le.MousePressRight( settingsArea ) )
             Dialog::Message( _( "Settings" ), _( "Game settings." ), Font::BIG );
 
         if ( validateAnimationDelay( MAIN_MENU_DELAY ) ) {
             const fheroes2::Sprite & lantern12 = fheroes2::AGG::GetICN( ICN::SHNGANIM, ICN::AnimationFrame( ICN::SHNGANIM, 0, lantern_frame ) );
             ++lantern_frame;
             fheroes2::Blit( lantern12, display, lantern12.x(), lantern12.y() );
-            if ( le.MouseCursor( resolutionArea ) ) {
+            if ( le.MouseCursor( settingsArea ) ) {
                 const int32_t offsetY = static_cast<int32_t>( 55 * scaleY );
                 fheroes2::Blit( highlightDoor, 0, offsetY, display, highlightDoor.x(), highlightDoor.y() + offsetY, highlightDoor.width(), highlightDoor.height() );
             }


### PR DESCRIPTION
Use the same hotkey as in "New Game" dialog.

Also rename the variable in the code (used to be called `resolutionArea`, as
this previously opened resolutions dialog).

Not sure why `T` is the default hotkey.  I would find `O` more logical, as:
1. It's already used for "Options" within game and battle.
2. It's the next letter in the word "Config" (`C` already stands for "Credits" or "Campaign", but `O` is not yet taken).