### PR TITLE
Don't reset the hero's path in SLEEPER mode, reset the SLEEPER mode only with the beginning of the hero's movement

### DIFF
--- a/src/fheroes2/ai/ai_base.cpp
+++ b/src/fheroes2/ai/ai_base.cpp
@@ -153,7 +153,7 @@ namespace AI
 
     bool Base::HeroesCanMove( const Heroes & hero )
     {
-        return hero.MayStillMove( false ) && !hero.Modes( Heroes::MOVED );
+        return hero.MayStillMove( false, false ) && !hero.Modes( Heroes::MOVED );
     }
 
     void Base::HeroTurn( Heroes & hero )

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -446,7 +446,7 @@ namespace
         }
 
         hero->ResetModes( Heroes::WAITING | Heroes::MOVED | Heroes::SKIPPED_TURN );
-        if ( !hero->MayStillMove( false ) ) {
+        if ( !hero->MayStillMove( false, false ) ) {
             hero->SetModes( Heroes::MOVED );
         }
         else {
@@ -1249,7 +1249,7 @@ namespace AI
             }
 
             for ( size_t i = 0; i < availableHeroes.size(); ) {
-                if ( !availableHeroes[i].hero->MayStillMove( false ) ) {
+                if ( !availableHeroes[i].hero->MayStillMove( false, false ) ) {
                     availableHeroes[i].hero->SetModes( Heroes::MOVED );
                     availableHeroes.erase( availableHeroes.begin() + i );
                     continue;
@@ -1264,7 +1264,7 @@ namespace AI
         const bool allHeroesMoved = availableHeroes.empty();
 
         for ( HeroToMove & heroInfo : availableHeroes ) {
-            if ( !heroInfo.hero->MayStillMove( false ) ) {
+            if ( !heroInfo.hero->MayStillMove( false, false ) ) {
                 heroInfo.hero->SetModes( Heroes::MOVED );
             }
         }

--- a/src/fheroes2/gui/interface_buttons.cpp
+++ b/src/fheroes2/gui/interface_buttons.cpp
@@ -203,7 +203,7 @@ fheroes2::GameMode Interface::ButtonsArea::QueueEventProcessing( void )
 void Interface::ButtonsArea::SetButtonStatus()
 {
     Heroes * currentHero = GetFocusHeroes();
-    if ( currentHero == nullptr || !currentHero->GetPath().isValid() || !currentHero->MayStillMove( false ) )
+    if ( currentHero == nullptr || !currentHero->GetPath().isValid() || !currentHero->MayStillMove( false, true ) )
         buttonMovement.disable();
     else
         buttonMovement.enable();
@@ -218,7 +218,7 @@ void Interface::ButtonsArea::SetButtonStatus()
 
     bool isMovableHeroPresent = false;
     for ( size_t i = 0; i < heroes.size(); ++i ) {
-        if ( heroes[i]->MayStillMove( false ) ) {
+        if ( heroes[i]->MayStillMove( false, false ) ) {
             isMovableHeroPresent = true;
             break;
         }

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -152,8 +152,9 @@ void Interface::Basic::EventContinueMovement( void ) const
 {
     Heroes * hero = GetFocusHeroes();
 
-    if ( hero && hero->GetPath().isValid() )
+    if ( hero && hero->GetPath().isValid() && hero->MayStillMove( false, true ) ) {
         hero->SetMove( !hero->isMoveEnabled() );
+    }
 }
 
 void Interface::Basic::EventKingdomInfo( void ) const

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -347,6 +347,7 @@ void Interface::Basic::EventSwitchHeroSleeping( void )
         }
 
         SetRedraw( REDRAW_HEROES );
+        buttonsArea.SetRedraw();
     }
 }
 

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -153,7 +153,7 @@ void Interface::Basic::EventContinueMovement( void ) const
     Heroes * hero = GetFocusHeroes();
 
     if ( hero && hero->GetPath().isValid() && hero->MayStillMove( false, true ) ) {
-        hero->SetMove( !hero->isMoveEnabled() );
+        hero->SetMove( true );
     }
 }
 

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -47,7 +47,6 @@ void Interface::Basic::CalculateHeroPath( Heroes * hero, s32 destinationIdx ) co
     if ( ( hero == nullptr ) || hero->Modes( Heroes::GUARDIAN ) )
         return;
 
-    hero->ResetModes( Heroes::SLEEPER );
     hero->SetMove( false );
 
     const Route::Path & path = hero->GetPath();
@@ -78,15 +77,17 @@ void Interface::Basic::ShowPathOrStartMoveHero( Heroes * hero, s32 destinationId
 
     // show path
     if ( path.GetDestinedIndex() != destinationIdx && path.GetDestinationIndex() != destinationIdx ) {
+        hero->ResetModes( Heroes::SLEEPER );
+
         CalculateHeroPath( hero, destinationIdx );
     }
     // start move
     else if ( path.isValid() && hero->MayStillMove( false ) ) {
-        SetFocus( hero );
-        RedrawFocus();
-
         hero->SetMove( true );
     }
+
+    SetFocus( hero );
+    RedrawFocus();
 }
 
 void Interface::Basic::MoveHeroFromArrowKeys( Heroes & hero, int direct )

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -77,17 +77,15 @@ void Interface::Basic::ShowPathOrStartMoveHero( Heroes * hero, s32 destinationId
 
     // show path
     if ( path.GetDestinedIndex() != destinationIdx && path.GetDestinationIndex() != destinationIdx ) {
-        hero->ResetModes( Heroes::SLEEPER );
-
         CalculateHeroPath( hero, destinationIdx );
     }
     // start move
-    else if ( path.isValid() && hero->MayStillMove( false ) ) {
+    else if ( path.isValid() && hero->MayStillMove( false, true ) ) {
+        SetFocus( hero );
+        RedrawFocus();
+
         hero->SetMove( true );
     }
-
-    SetFocus( hero );
-    RedrawFocus();
 }
 
 void Interface::Basic::MoveHeroFromArrowKeys( Heroes & hero, int direct )
@@ -131,7 +129,7 @@ void Interface::Basic::EventNextHero( void )
             ++it;
             if ( it == myHeroes.end() )
                 it = myHeroes.begin();
-            if ( ( *it )->MayStillMove( true ) ) {
+            if ( ( *it )->MayStillMove( true, false ) ) {
                 SetFocus( *it );
                 CalculateHeroPath( *it, -1 );
                 break;
@@ -140,7 +138,7 @@ void Interface::Basic::EventNextHero( void )
     }
     else {
         for ( Heroes * hero : myHeroes ) {
-            if ( hero->MayStillMove( true ) ) {
+            if ( hero->MayStillMove( true, false ) ) {
                 SetFocus( hero );
                 CalculateHeroPath( hero, -1 );
                 break;
@@ -339,12 +337,7 @@ void Interface::Basic::EventSwitchHeroSleeping( void )
     Heroes * hero = GetFocusHeroes();
 
     if ( hero ) {
-        if ( hero->Modes( Heroes::SLEEPER ) )
-            hero->ResetModes( Heroes::SLEEPER );
-        else {
-            hero->SetModes( Heroes::SLEEPER );
-            hero->GetPath().Reset();
-        }
+        hero->Modes( Heroes::SLEEPER ) ? hero->ResetModes( Heroes::SLEEPER ) : hero->SetModes( Heroes::SLEEPER );
 
         SetRedraw( REDRAW_HEROES );
         buttonsArea.SetRedraw();

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1173,6 +1173,8 @@ bool Heroes::CanMove( void ) const
 void Heroes::SetMove( bool f )
 {
     if ( f ) {
+        ResetModes( SLEEPER );
+
         SetModes( ENABLEMOVE );
     }
     else {
@@ -1408,9 +1410,13 @@ void Heroes::ResetMovePoints( void )
     move_point = 0;
 }
 
-bool Heroes::MayStillMove( const bool ignorePath ) const
+bool Heroes::MayStillMove( const bool ignorePath, const bool ignoreSleeper ) const
 {
-    if ( Modes( SLEEPER | GUARDIAN ) || isFreeman() ) {
+    if ( Modes( GUARDIAN ) || isFreeman() ) {
+        return false;
+    }
+
+    if ( !ignoreSleeper && Modes( SLEEPER ) ) {
         return false;
     }
 

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -266,7 +266,7 @@ public:
 
     u32 GetMovePoints( void ) const;
     void IncreaseMovePoints( u32 );
-    bool MayStillMove( const bool ignorePath ) const;
+    bool MayStillMove( const bool ignorePath, const bool ignoreSleeper ) const;
     void ResetMovePoints( void );
     void MovePointsScaleFixed( void );
 

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -414,7 +414,7 @@ bool Kingdom::isValidKingdomObject( const Maps::Tiles & tile, const MP2::MapObje
 
 bool Kingdom::HeroesMayStillMove( void ) const
 {
-    return std::any_of( heroes.begin(), heroes.end(), []( const Heroes * hero ) { return hero->MayStillMove( false ); } );
+    return std::any_of( heroes.begin(), heroes.end(), []( const Heroes * hero ) { return hero->MayStillMove( false, false ); } );
 }
 
 void Kingdom::AddFundsResource( const Funds & funds )


### PR DESCRIPTION
fix #4764

~~I decided not to do this when moving the hero because currently the existing hero path is reset when the hero goes to the SLEEPER mode, so he can't have a paved path and be in the SLEEPER mode at the same time.~~