### PR TITLE
PS Vita updates

### DIFF
--- a/Makefile.vita
+++ b/Makefile.vita
@@ -30,13 +30,21 @@ all: package
 
 package: $(TARGET).vpk
 
-$(TARGET).vpk: eboot.bin param.sfo
+$(TARGET).vpk: eboot.bin param.sfo translations
 	vita-pack-vpk -s param.sfo -b eboot.bin \
 		--add files/images/platform/psv/sce_sys/icon0.png=sce_sys/icon0.png \
 		--add files/images/platform/psv/sce_sys/livearea/contents/bg.png=sce_sys/livearea/contents/bg.png \
 		--add files/images/platform/psv/sce_sys/livearea/contents/startup.png=sce_sys/livearea/contents/startup.png \
 		--add files/images/platform/psv/sce_sys/livearea/contents/template.xml=sce_sys/livearea/contents/template.xml \
+		--add files/data=files/data \
+		--add files/lang/vita_temp=files/lang \
 	$(TARGET).vpk
+	@rm -r files/lang/vita_temp
+
+translations:
+	$(MAKE) -C files/lang
+	mkdir -p files/lang/vita_temp
+	cp files/lang/*.mo files/lang/vita_temp
 
 eboot.bin: $(TARGET).velf
 	vita-make-fself $(TARGET).velf eboot.bin
@@ -54,4 +62,5 @@ $(TARGET).elf:
 
 clean:
 	$(MAKE) -f Makefile -C src clean
+	$(MAKE) -C files/lang clean
 	@rm -rf $(TARGET).velf $(TARGET).elf $(TARGET).vpk eboot.bin param.sfo

--- a/docs/README_PSV.md
+++ b/docs/README_PSV.md
@@ -30,7 +30,7 @@ make -f Makefile.vita
 
 ## Controls
 - Left analog stick - Pointer movement
-- D-Pad / Right analog stick - Map scrolling
+- Right analog stick - Map scrolling
 - × - Left mouse button
 - ○ - Right mouse button
 - □ - End turn
@@ -39,6 +39,7 @@ make -f Makefile.vita
 - R1 - Next castle
 - SELECT - System menu
 - START - Enter
+- D-Pad down - re-visit the field that hero stands on
 
 Text input is done with D-Pad.
 

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1112,22 +1112,7 @@ bool LocalEvent::HandleEvents( bool delay, bool allowExit )
     ResetModes( MOUSE_MOTION );
     ResetModes( MOUSE_RELEASED );
     ResetModes( MOUSE_CLICKED );
-#if SDL_VERSION_ATLEAST( 2, 0, 0 )
-    if ( _gameController != nullptr ) {
-        // fast map scroll with dpad
-#if defined( FHEROES2_VITA )
-        if ( !_dpadScrollActive || dpadInputActive )
-#else
-        if ( !_dpadScrollActive )
-#endif
-            ResetModes( KEY_PRESSED );
-    }
-    else {
-        ResetModes( KEY_PRESSED );
-    }
-#else
     ResetModes( KEY_PRESSED );
-#endif
 
     mouse_wm = fheroes2::Point();
 
@@ -1396,22 +1381,21 @@ void LocalEvent::HandleControllerButtonEvent( const SDL_ControllerButtonEvent & 
         ResetModes( KEY_PRESSED );
     }
     else if ( modes & KEY_PRESSED ) {
-        _dpadScrollActive = true;
-
-        if ( button.button == SDL_CONTROLLER_BUTTON_DPAD_LEFT ) {
-            key_value = KEY_KP4;
-        }
-        else if ( button.button == SDL_CONTROLLER_BUTTON_DPAD_RIGHT ) {
-            key_value = KEY_KP6;
-        }
-        else if ( button.button == SDL_CONTROLLER_BUTTON_DPAD_UP ) {
-            key_value = KEY_KP8;
-        }
-        else if ( button.button == SDL_CONTROLLER_BUTTON_DPAD_DOWN ) {
-            key_value = KEY_KP2;
-        }
-        else {
-            _dpadScrollActive = false;
+        if ( dpadInputActive ) {
+            if ( button.button == SDL_CONTROLLER_BUTTON_DPAD_LEFT ) {
+                key_value = KEY_KP4;
+            }
+            else if ( button.button == SDL_CONTROLLER_BUTTON_DPAD_RIGHT ) {
+                key_value = KEY_KP6;
+            }
+            else if ( button.button == SDL_CONTROLLER_BUTTON_DPAD_UP ) {
+                key_value = KEY_KP8;
+            }
+            else if ( button.button == SDL_CONTROLLER_BUTTON_DPAD_DOWN ) {
+                key_value = KEY_KP2;
+            }
+        } else if ( button.button == SDL_CONTROLLER_BUTTON_DPAD_DOWN ) {
+            key_value = KEY_SPACE;
         }
 
 #if defined( FHEROES2_VITA )

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -321,7 +321,7 @@ private:
 
     enum
     {
-        CONTROLLER_L_DEADZONE = 3000,
+        CONTROLLER_L_DEADZONE = 4000,
         CONTROLLER_R_DEADZONE = 25000
     };
 


### PR DESCRIPTION
Updated `Makefile.vita` to make sure that add-on data files and translations are included in VPK file.
Also removed DPad map scrolling (since it's redundant) and added a gamepad binding for re-visiting current hero location (solves https://github.com/ihhub/fheroes2/issues/4212)