### PR TITLE
Updated Settings description to cover all actions

### DIFF
--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -318,7 +318,7 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
         else if ( le.MousePressRight( buttonNewGame.area() ) )
             Dialog::Message( _( "New Game" ), _( "Start a single or multi-player game." ), Font::BIG );
         else if ( le.MousePressRight( settingsArea ) )
-            Dialog::Message( _( "Settings" ), _( "Game settings." ), Font::BIG );
+            Dialog::Message( _( "Game Settings" ), _( "Change language, resolution and settings of the game." ), Font::BIG );
 
         if ( validateAnimationDelay( MAIN_MENU_DELAY ) ) {
             const fheroes2::Sprite & lantern12 = fheroes2::AGG::GetICN( ICN::SHNGANIM, ICN::AnimationFrame( ICN::SHNGANIM, 0, lantern_frame ) );

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -449,7 +449,7 @@ fheroes2::GameMode Game::NewGame()
         else if ( le.MousePressRight( buttonBattleGame.area() ) )
             Dialog::Message( _( "Battle Only" ), _( "Setup and play a battle without loading any map." ), Font::BIG );
         else if ( le.MousePressRight( buttonSettings.area() ) )
-            Dialog::Message( _( "Settings" ), _( "Game settings." ), Font::BIG );
+            Dialog::Message( _( "Game Settings" ), _( "Change language, resolution and settings of the game." ), Font::BIG );
         else if ( le.MousePressRight( buttonCancelGame.area() ) )
             Dialog::Message( _( "Cancel" ), _( "Cancel back to the main menu." ), Font::BIG );
     }


### PR DESCRIPTION
The title and description of the Settings information window no longer correspond to the change possibilities.

Changed the description when right-clicking game settings to highlight all possibilities (#4788).

New: 
![UI Update](https://user-images.githubusercontent.com/95991495/145913289-ff7c2a6a-895d-4124-801c-771c3f2b92fe.JPG)

Old:
![image](https://user-images.githubusercontent.com/95991495/145913320-112bbb74-041e-4b84-98a8-7857573f1e5c.png)

Project built and ran successfully.
