### PR TITLE
Windows: Try to set the console codepage to the system codepage

### DIFF
--- a/src/engine/logging.cpp
+++ b/src/engine/logging.cpp
@@ -18,12 +18,48 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include "logging.h"
 #include <ctime>
+
+#if defined( __MINGW32__ ) || defined( _MSC_VER )
+#include <windows.h>
+#endif
+
+#include "logging.h"
 
 namespace
 {
     int g_debug = DBG_ALL_WARN + DBG_ALL_INFO;
+
+#if defined( __MINGW32__ ) || defined( _MSC_VER )
+    // Sets the Windows console codepage to the system codepage
+    class ConsoleCPSwitcher
+    {
+    public:
+        ConsoleCPSwitcher()
+            : _consoleOutputCP( GetConsoleOutputCP() )
+        {
+            if ( _consoleOutputCP > 0 ) {
+                SetConsoleOutputCP( GetACP() );
+            }
+        }
+
+        ConsoleCPSwitcher( const ConsoleCPSwitcher & ) = delete;
+
+        ~ConsoleCPSwitcher()
+        {
+            if ( _consoleOutputCP > 0 ) {
+                SetConsoleOutputCP( _consoleOutputCP );
+            }
+        }
+
+        ConsoleCPSwitcher & operator=( const ConsoleCPSwitcher & ) = delete;
+
+    private:
+        const UINT _consoleOutputCP;
+    };
+
+    ConsoleCPSwitcher consoleCPSwitcher;
+#endif
 }
 
 namespace Logging

--- a/src/engine/logging.cpp
+++ b/src/engine/logging.cpp
@@ -58,7 +58,7 @@ namespace
         const UINT _consoleOutputCP;
     };
 
-    ConsoleCPSwitcher consoleCPSwitcher;
+    const ConsoleCPSwitcher consoleCPSwitcher;
 #endif
 }
 


### PR DESCRIPTION
Related to #4755

Before:

![before](https://user-images.githubusercontent.com/32623900/146688650-671c1840-bf73-44dd-901e-d744d911c6e6.jpg)

After:

![after](https://user-images.githubusercontent.com/32623900/146688651-abea0509-128a-426b-b5ee-63e1906eb444.jpg)

Quick and dirty solution.