### PR TITLE
Show languages in vertical order rather than horizonal

### DIFF
--- a/src/fheroes2/dialog/dialog_language_selection.cpp
+++ b/src/fheroes2/dialog/dialog_language_selection.cpp
@@ -53,7 +53,8 @@ namespace fheroes2
             selectionId = static_cast<size_t>( currentLanguageIt - languages.begin() );
         }
 
-        const int32_t languageAreaWidth = 100;
+        const int32_t languageAreaWidth = 200;
+        const int32_t languageAreaHeight = 25;
         const int32_t offsetFromBorders = 10;
 
         const int32_t languageCount = static_cast<int32_t>( languages.size() );
@@ -63,7 +64,7 @@ namespace fheroes2
         const int okIcnId = Settings::Get().ExtGameEvilInterface() ? ICN::NON_UNIFORM_EVIL_OKAY_BUTTON : ICN::NON_UNIFORM_GOOD_OKAY_BUTTON;
         const Sprite & buttonOkayImage = AGG::GetICN( okIcnId, 0 );
 
-        StandardWindow window( languageAreaWidth * languageCount + 2 * offsetFromBorders, 125, display );
+        StandardWindow window( languageAreaWidth + 2 * offsetFromBorders, 90 + languageAreaHeight * languageCount, display );
         const Rect windowRoi = window.activeArea();
 
         ButtonSprite okayButton
@@ -73,13 +74,13 @@ namespace fheroes2
         const Sprite & unselectedButtonSprite = AGG::GetICN( ICN::CELLWIN, 4 );
         const Sprite & selectionSprite = AGG::GetICN( ICN::CELLWIN, 5 );
 
-        Sprite selectedButtonSprite = AGG::GetICN( ICN::CELLWIN, 4 );
-        Blit( selectionSprite, 0, 0, selectedButtonSprite, 3, 3, selectionSprite.width(), selectionSprite.height() );
+        Sprite selectedButtonSprite = unselectedButtonSprite;
+        Blit( selectionSprite, 0, 0, selectedButtonSprite, selectionSprite.x(), selectionSprite.y(), selectionSprite.width(), selectionSprite.height() );
 
         ButtonGroup buttonGroup;
         for ( int32_t i = 0; i < languageCount; ++i ) {
-            buttonGroup.createButton( windowRoi.x + offsetFromBorders + languageAreaWidth * i + languageAreaWidth / 2 - unselectedButtonSprite.width() / 2,
-                                      windowRoi.y + 60, unselectedButtonSprite, selectedButtonSprite, i );
+            buttonGroup.createButton( windowRoi.x + offsetFromBorders + unselectedButtonSprite.width() / 2, windowRoi.y + 40 + languageAreaHeight * i,
+                                      unselectedButtonSprite, selectedButtonSprite, i );
         }
 
         OptionButtonGroup optionButtonGroup;
@@ -99,7 +100,8 @@ namespace fheroes2
         for ( int32_t i = 0; i < languageCount; ++i ) {
             fheroes2::LanguageSwitcher languageSwitcher( languages[i] );
             const Text languageName( getLanguageName( languages[i] ), { FontSize::NORMAL, FontColor::WHITE } );
-            languageName.draw( windowRoi.x + offsetFromBorders + languageAreaWidth * i + languageAreaWidth / 2 - languageName.width() / 2, windowRoi.y + 40, display );
+            languageName.draw( windowRoi.x + offsetFromBorders + selectedButtonSprite.width() + 15,
+                               windowRoi.y + 40 + languageAreaHeight * i + 2 + ( selectedButtonSprite.height() - languageName.height() ) / 2, display );
         }
 
         display.render();


### PR DESCRIPTION
to avoid possible out of window cases.
Now it looks like this:
![image](https://user-images.githubusercontent.com/19829520/147113411-1f7d2051-e63a-4091-82e7-7ea414028e0d.png)
