### PR TITLE
Don't consider the protected tile as an obstacle when recalculating the hero's path if this step is the penultimate and the path ends at the monster

### DIFF
--- a/src/fheroes2/heroes/route.h
+++ b/src/fheroes2/heroes/route.h
@@ -99,7 +99,7 @@ namespace Route
         void Reset( void );
         void PopFront( void );
         void PopBack( void );
-        void RescanObstacle( void );
+        void RescanObstacle();
         void RescanPassable( void );
 
         bool isValid( void ) const;
@@ -107,7 +107,7 @@ namespace Route
         {
             return !hide;
         }
-        bool hasObstacle( void ) const;
+        bool hasObstacle() const;
         bool hasAllowedSteps() const;
 
         std::string String( void ) const;
@@ -116,6 +116,7 @@ namespace Route
         static int GetIndexSprite( int from, int to, int mod );
 
     private:
+        const_iterator findObstacle() const;
 
         friend StreamBase & operator<<( StreamBase &, const Path & );
         friend StreamBase & operator>>( StreamBase &, Path & );


### PR DESCRIPTION
fix #4838

P.S. Honestly, the situation when there are attempts to recalculate the hero's path after each hero's movement looks unhealthy (apparently due to `SetFocus()` calls after each movement from tile to tile), but this is a topic for a separate trial.

P.P.S. There is also an alternative approach #4846.