### PR TITLE
Fallback to `find_library` for smacker when pkgconfig is unable to find it

### DIFF
--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -1,6 +1,10 @@
 if(USE_SYSTEM_LIBSMACKER)
 	include(FindPkgConfig)
-	pkg_check_modules(smacker REQUIRED smacker)
+	pkg_check_modules(smacker smacker)
+	if(NOT smacker_FOUND)
+		find_library(smacker smacker REQUIRED)
+		message(STATUS "Found smacker: ${smacker}")
+	endif(NOT smacker_FOUND)
 else()
 	set(LIBSMACKER_SOURCES
 		libsmacker/smacker.c


### PR DESCRIPTION
Smacker doesn't provides pkgconfig file.
Some distros provide it, but others - doesn't.
