### PR TITLE
Rework the logic of re-calculating the paths of heroes on the adventure map

### DIFF
--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -140,7 +140,7 @@ namespace Interface
         static int GetCursorFocusCastle( const Castle &, const Maps::Tiles & );
         static int GetCursorFocusHeroes( const Heroes &, const Maps::Tiles & );
         static int GetCursorFocusShipmaster( const Heroes &, const Maps::Tiles & );
-        void CalculateHeroPath( Heroes * hero, s32 destinationIdx ) const;
+        void CalculateHeroPath( Heroes * hero, int32_t destinationIdx ) const;
 
         void Reset(); // call this function only when changing the resolution
 

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -256,9 +256,6 @@ fheroes2::GameMode Game::Load( const std::string & fn )
         return returnValue;
     }
 
-    // rescan path passability for all heroes, for this we need actual info about players from Settings
-    World::Get().RescanAllHeroesPathPassable();
-
     return returnValue;
 }
 

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <cassert>
 #include <vector>
 
 #include "agg.h"
@@ -42,30 +43,36 @@
 #include "translations.h"
 #include "world.h"
 
-void Interface::Basic::CalculateHeroPath( Heroes * hero, s32 destinationIdx ) const
+void Interface::Basic::CalculateHeroPath( Heroes * hero, int32_t destinationIdx ) const
 {
-    if ( ( hero == nullptr ) || hero->Modes( Heroes::GUARDIAN ) )
+    if ( ( hero == nullptr ) || hero->Modes( Heroes::GUARDIAN ) ) {
         return;
+    }
 
     hero->SetMove( false );
+    hero->calculatePath( destinationIdx );
 
     const Route::Path & path = hero->GetPath();
-    if ( destinationIdx == -1 )
-        destinationIdx = path.GetDestinedIndex(); // returns -1 at the time of launching new game (because of no path history)
 
-    if ( destinationIdx != -1 ) {
-        hero->GetPath().setPath( world.getPath( *hero, destinationIdx ), destinationIdx );
-        DEBUG_LOG( DBG_GAME, DBG_TRACE, hero->GetName() << ", distance: " << world.getDistance( *hero, destinationIdx ) << ", route: " << path.String() );
-        gameArea.SetRedraw();
-
-        const fheroes2::Point & mousePos = LocalEvent::Get().GetMouseCursor();
-        if ( gameArea.GetROI() & mousePos ) {
-            const int32_t cursorIndex = gameArea.GetValidTileIdFromPoint( mousePos );
-            Cursor::Get().SetThemes( GetCursorTileIndex( cursorIndex ) );
-        }
-
-        Interface::Basic::Get().buttonsArea.Redraw();
+    if ( destinationIdx < 0 ) {
+        destinationIdx = path.GetDestinationIndex();
     }
+
+    if ( destinationIdx < 0 ) {
+        return;
+    }
+
+    DEBUG_LOG( DBG_GAME, DBG_TRACE, hero->GetName() << ", distance: " << world.getDistance( *hero, destinationIdx ) << ", route: " << path.String() );
+
+    gameArea.SetRedraw();
+
+    const fheroes2::Point & mousePos = LocalEvent::Get().GetMouseCursor();
+    if ( gameArea.GetROI() & mousePos ) {
+        const int32_t cursorIndex = gameArea.GetValidTileIdFromPoint( mousePos );
+        Cursor::Get().SetThemes( GetCursorTileIndex( cursorIndex ) );
+    }
+
+    Interface::Basic::Get().buttonsArea.Redraw();
 }
 
 void Interface::Basic::ShowPathOrStartMoveHero( Heroes * hero, s32 destinationIdx )
@@ -76,7 +83,7 @@ void Interface::Basic::ShowPathOrStartMoveHero( Heroes * hero, s32 destinationId
     const Route::Path & path = hero->GetPath();
 
     // show path
-    if ( path.GetDestinedIndex() != destinationIdx && path.GetDestinationIndex() != destinationIdx ) {
+    if ( path.GetDestinationIndex() != destinationIdx ) {
         CalculateHeroPath( hero, destinationIdx );
     }
     // start move

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -44,7 +44,6 @@ void Interface::Basic::SetFocus( Heroes * hero )
             focus.GetHeroes()->ShowPath( false );
         }
 
-        hero->RescanPath();
         hero->ShowPath( true );
         focus.Set( hero );
 

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -305,7 +305,9 @@ public:
     Route::Path & GetPath();
     int GetRangeRouteDays( s32 ) const;
     void ShowPath( bool );
-    // Calculates the hero's path to the tile with the dstIdx index. Recalculates the existing path if dstIdx is negative.
+    // Calculates the hero's path to the tile with the dstIdx index using the pathfinder from the World global object.
+    // Recalculates the existing path if dstIdx is negative. Not applicable if you want to use a pathfinder other than
+    // PlayerWorldPathfinder.
     void calculatePath( int32_t dstIdx );
 
     int GetDirection() const;

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -305,8 +305,8 @@ public:
     Route::Path & GetPath();
     int GetRangeRouteDays( s32 ) const;
     void ShowPath( bool );
-    void RescanPath();
-    void RescanPathPassable();
+    // Calculates the hero's path to the tile with the dstIdx index. Recalculates the existing path if dstIdx is negative.
+    void calculatePath( int32_t dstIdx );
 
     int GetDirection() const;
     void setDirection( int directionToSet );

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -683,7 +683,7 @@ void Heroes::MoveStep( Heroes & hero, s32 indexTo, bool newpos )
 
         // possible that hero loses the battle
         if ( !hero.isFreeman() ) {
-            const bool isDestination = indexTo == hero.GetPath().GetDestinationIndex();
+            const bool isDestination = indexTo == hero.GetPath().GetDestinationIndex( true );
             hero.Action( indexTo, isDestination );
 
             if ( isDestination ) {
@@ -702,7 +702,7 @@ void Heroes::MoveStep( Heroes & hero, s32 indexTo, bool newpos )
 bool Heroes::MoveStep( bool fast )
 {
     const int32_t indexTo = Maps::GetDirectionIndex( GetIndex(), path.GetFrontDirection() );
-    const int32_t indexDest = path.GetDestinationIndex();
+    const int32_t indexDest = path.GetDestinationIndex( true );
     const fheroes2::Point & mp = GetCenter();
 
     if ( fast ) {

--- a/src/fheroes2/heroes/route.h
+++ b/src/fheroes2/heroes/route.h
@@ -99,7 +99,7 @@ namespace Route
         void Reset( void );
         void PopFront( void );
         void PopBack( void );
-        void RescanObstacle( void );
+        void RescanObstacle();
         void RescanPassable( void );
 
         bool isValid( void ) const;
@@ -107,7 +107,7 @@ namespace Route
         {
             return !hide;
         }
-        bool hasObstacle( void ) const;
+        bool hasObstacle() const;
         bool hasAllowedSteps() const;
 
         std::string String( void ) const;
@@ -116,6 +116,7 @@ namespace Route
         static int GetIndexSprite( int from, int to, int mod );
 
     private:
+        const_iterator findObstacle() const;
 
         friend StreamBase & operator<<( StreamBase &, const Path & );
         friend StreamBase & operator>>( StreamBase &, Path & );

--- a/src/fheroes2/heroes/route.h
+++ b/src/fheroes2/heroes/route.h
@@ -81,9 +81,7 @@ namespace Route
 
         Path & operator=( const Path & ) = delete;
 
-        s32 GetDestinationIndex( void ) const;
-        s32 GetLastIndex( void ) const;
-        s32 GetDestinedIndex( void ) const;
+        int32_t GetDestinationIndex( const bool returnLastStep = false ) const;
         int GetFrontDirection( void ) const;
         u32 GetFrontPenalty( void ) const;
         void setPath( const std::list<Step> & path, int32_t destIndex );
@@ -99,15 +97,12 @@ namespace Route
         void Reset( void );
         void PopFront( void );
         void PopBack( void );
-        void RescanObstacle();
-        void RescanPassable( void );
 
         bool isValid( void ) const;
         bool isShow( void ) const
         {
             return !hide;
         }
-        bool hasObstacle() const;
         bool hasAllowedSteps() const;
 
         std::string String( void ) const;
@@ -116,8 +111,6 @@ namespace Route
         static int GetIndexSprite( int from, int to, int mod );
 
     private:
-        const_iterator findObstacle() const;
-
         friend StreamBase & operator<<( StreamBase &, const Path & );
         friend StreamBase & operator>>( StreamBase &, Path & );
 

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -145,10 +145,17 @@ void Kingdom::LossPostActions( void )
     }
 }
 
-void Kingdom::ActionBeforeTurn( void )
+void Kingdom::ActionBeforeTurn()
 {
-    // recalculate the existing paths of heroes
-    std::for_each( heroes.begin(), heroes.end(), []( Heroes * hero ) { hero->calculatePath( -1 ); } );
+    if ( isControlHuman() ) {
+        // Recalculate the existing paths of heroes if the kingdom is controlled by a human
+        std::for_each( heroes.begin(), heroes.end(), []( Heroes * hero ) { hero->calculatePath( -1 ); } );
+    }
+    else {
+        // Reset the paths of heroes if the kingdom is controlled by AI, because it uses a
+        // special pathfinder implementation and revises its goals every turn
+        std::for_each( heroes.begin(), heroes.end(), []( Heroes * hero ) { hero->GetPath().Reset(); } );
+    }
 }
 
 void Kingdom::ActionNewDay( void )

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -147,8 +147,8 @@ void Kingdom::LossPostActions( void )
 
 void Kingdom::ActionBeforeTurn( void )
 {
-    // rescan heroes path
-    std::for_each( heroes.begin(), heroes.end(), []( Heroes * hero ) { hero->RescanPath(); } );
+    // recalculate the existing paths of heroes
+    std::for_each( heroes.begin(), heroes.end(), []( Heroes * hero ) { hero->calculatePath( -1 ); } );
 }
 
 void Kingdom::ActionNewDay( void )

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -134,7 +134,7 @@ public:
     void AddCastle( const Castle * );
     void RemoveCastle( const Castle * );
 
-    void ActionBeforeTurn( void );
+    void ActionBeforeTurn();
     void ActionNewDay( void );
     void ActionNewWeek( void );
     void ActionNewMonth( void );

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -1177,21 +1177,6 @@ bool MP2::isNeedStayFront( const MapObjectType objectType )
     return isPickupObject( objectType );
 }
 
-bool MP2::isAccessibleFromBeach( const MapObjectType objectType )
-{
-    switch ( objectType ) {
-    case OBJ_MONSTER:
-    case OBJ_HEROES:
-    case OBJ_BOAT:
-    case OBJ_SHIPWRECK:
-        return true;
-    default:
-        break;
-    }
-
-    return false;
-}
-
 int MP2::getActionObjectDirection( const MapObjectType objectType )
 {
     switch ( objectType ) {

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -596,8 +596,6 @@ namespace MP2
 
     bool isNeedStayFront( const MapObjectType objectType );
 
-    bool isAccessibleFromBeach( const MapObjectType objectType );
-
     bool isDayLife( const MapObjectType objectType );
     bool isWeekLife( const MapObjectType objectType );
     bool isMonthLife( const MapObjectType objectType );

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -565,11 +565,6 @@ CastleHeroes World::GetHeroes( const Castle & castle ) const
     return CastleHeroes( vec_heroes.GetGuest( castle ), vec_heroes.GetGuard( castle ) );
 }
 
-void World::RescanAllHeroesPathPassable() const
-{
-    std::for_each( vec_heroes.begin(), vec_heroes.end(), []( Heroes * hero ) { hero->RescanPathPassable(); } );
-}
-
 int World::GetDay( void ) const
 {
     return LastDay() ? DAYOFWEEK : day % DAYOFWEEK;

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -212,8 +212,6 @@ public:
 
     CastleHeroes GetHeroes( const Castle & ) const;
 
-    void RescanAllHeroesPathPassable() const;
-
     const UltimateArtifact & GetUltimateArtifact( void ) const;
     bool DiggingForUltimateArtifact( const fheroes2::Point & );
 


### PR DESCRIPTION
fix #4838

Alternative approach to the #4839 (more risky in terms of possible breaking changes). Fixes also the following cases:

---

Before this change:

<img width="639" alt="Obstacle of Heroes Before 1" src="https://user-images.githubusercontent.com/32623900/147392620-d8dc3442-9e97-4f52-91e1-b0c087077893.png">
<img width="637" alt="Obstacle of Heroes Before 2" src="https://user-images.githubusercontent.com/32623900/147392621-bbe6af43-13e3-4fb2-a8e3-89e123442a21.png">

After this change:

<img width="638" alt="Obstacle of Heroes After 1" src="https://user-images.githubusercontent.com/32623900/147392634-9c06312a-728c-4308-a3d6-963904fdd5d0.png">
<img width="638" alt="Obstacle of Heroes After 2" src="https://user-images.githubusercontent.com/32623900/147392637-6632e0b6-9045-4d55-9bae-d94719b544c2.png">

---

Before this change:

<img width="639" alt="Obstacle of Monsters Before 1" src="https://user-images.githubusercontent.com/32623900/147392658-e31a7369-21c5-4c50-a4cf-32ebaa29ee1e.png">
<img width="637" alt="Obstacle of Monsters Before 2" src="https://user-images.githubusercontent.com/32623900/147392659-70ceb5d0-5b80-43d7-bc01-ce4709962fe3.png">

After this change:

<img width="639" alt="Obstacle of Monsters After 1" src="https://user-images.githubusercontent.com/32623900/147392668-8a283756-e4d0-4db2-9dec-897f02c5fe0a.png">
<img width="639" alt="Obstacle of Monsters After 2" src="https://user-images.githubusercontent.com/32623900/147392669-fdaf5305-15bb-4d47-beee-1a068b6dcdc4.png">

