### PR TITLE
The game does not display tooltips and popups for the Cast, Retreat, …

### DIFF
--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -814,19 +814,19 @@ int Battle::Arena::DialogBattleHero( const HeroBase & hero, const bool buttons, 
         le.MousePressLeft( btnClose.area() ) ? btnClose.drawOnPress() : btnClose.drawOnRelease();
 
         if ( buttons ) {
-            if ( le.MouseCursor( btnCast.area() ) ) {
+            if ( le.MouseCursor( btnCast.area() ) && btnCast.isEnabled() ) {
                 statusMessage = _( "Cast Spell" );
             }
-            else if ( le.MouseCursor( btnRetreat.area() ) ) {
+            else if ( le.MouseCursor( btnRetreat.area() ) && btnRetreat.isEnabled() ) {
                 statusMessage = _( "Retreat" );
             }
-            else if ( le.MouseCursor( btnSurrender.area() ) ) {
+            else if ( le.MouseCursor( btnSurrender.area() ) && btnSurrender.isEnabled() ) {
                 statusMessage = _( "Surrender" );
             }
             else if ( le.MouseCursor( btnClose.area() ) ) {
                 statusMessage = _( "Cancel" );
             }
-            else if ( le.MouseCursor( portraitArea ) && actionHero != nullptr ) {
+            else if ( le.MouseCursor( portraitArea ) && actionHero != nullptr && !readonly ) {
                 statusMessage = _( "Hero Screen" );
             }
             else {
@@ -852,24 +852,24 @@ int Battle::Arena::DialogBattleHero( const HeroBase & hero, const bool buttons, 
             const_cast<Heroes *>( actionHero )->OpenDialog( true, false, true, true );
         }
 
-        if ( le.MousePressRight( btnCast.area() ) ) {
+        if ( le.MousePressRight( btnCast.area() ) && btnCast.isEnabled() ) {
             Dialog::Message( _( "Cast Spell" ),
                              _( "Cast a magical spell. You may only cast one spell per combat round. The round is reset when every creature has had a turn." ),
                              Font::BIG );
         }
-        else if ( le.MousePressRight( btnRetreat.area() ) ) {
+        else if ( le.MousePressRight( btnRetreat.area() ) && btnRetreat.isEnabled() ) {
             Dialog::Message(
                 _( "Retreat" ),
                 _( "Retreat your hero, abandoning your creatures. Your hero will be available for you to recruit again, however, the hero will have only a novice hero's forces." ),
                 Font::BIG );
         }
-        else if ( le.MousePressRight( btnSurrender.area() ) ) {
+        else if ( le.MousePressRight( btnSurrender.area() ) && btnSurrender.isEnabled() ) {
             Dialog::Message(
                 _( "Surrender" ),
                 _( "Surrendering costs gold. However if you pay the ransom, the hero and all of his or her surviving creatures will be available to recruit again." ),
                 Font::BIG );
         }
-        else if ( le.MousePressRight( portraitArea ) ) {
+        else if ( le.MousePressRight( portraitArea ) && !readonly ) {
             Dialog::Message( _( "Hero Screen" ), _( "Open Hero Screen to view full information about the hero." ), Font::BIG );
         }
         else if ( le.MousePressRight( btnClose.area() ) ) {

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -814,19 +814,23 @@ int Battle::Arena::DialogBattleHero( const HeroBase & hero, const bool buttons, 
         le.MousePressLeft( btnClose.area() ) ? btnClose.drawOnPress() : btnClose.drawOnRelease();
 
         if ( buttons ) {
-            if ( le.MouseCursor( btnCast.area() ) && btnCast.isEnabled() ) {
+            // The Cast Spell is available for a hero and a captain.
+            if ( le.MouseCursor( btnCast.area() ) && current_color == hero.GetColor() ) {
                 statusMessage = _( "Cast Spell" );
             }
-            else if ( le.MouseCursor( btnRetreat.area() ) && btnRetreat.isEnabled() ) {
+            // The retreat is available during a player's turn only. A captain cannot retreat.
+            else if ( le.MouseCursor( btnRetreat.area() ) && current_color == hero.GetColor() && !hero.isCaptain() ) {
                 statusMessage = _( "Retreat" );
             }
-            else if ( le.MouseCursor( btnSurrender.area() ) && btnSurrender.isEnabled() ) {
+            // The surrender is available during a player's turn only. A captain cannot surrender.
+            else if ( le.MouseCursor( btnSurrender.area() ) && current_color == hero.GetColor() && !hero.isCaptain() ) {
                 statusMessage = _( "Surrender" );
             }
             else if ( le.MouseCursor( btnClose.area() ) ) {
                 statusMessage = _( "Cancel" );
             }
-            else if ( le.MouseCursor( portraitArea ) && actionHero != nullptr && !readonly ) {
+            // The Hero Screen is available for a Hero only (not Captain) and when UI is not read-only.
+            else if ( le.MouseCursor( portraitArea ) && actionHero != nullptr && actionHero->isHeroes() && !readonly ) {
                 statusMessage = _( "Hero Screen" );
             }
             else {
@@ -852,24 +856,24 @@ int Battle::Arena::DialogBattleHero( const HeroBase & hero, const bool buttons, 
             const_cast<Heroes *>( actionHero )->OpenDialog( true, false, true, true );
         }
 
-        if ( le.MousePressRight( btnCast.area() ) && btnCast.isEnabled() ) {
+        if ( le.MousePressRight( btnCast.area() ) && current_color == hero.GetColor() ) {
             Dialog::Message( _( "Cast Spell" ),
                              _( "Cast a magical spell. You may only cast one spell per combat round. The round is reset when every creature has had a turn." ),
                              Font::BIG );
         }
-        else if ( le.MousePressRight( btnRetreat.area() ) && btnRetreat.isEnabled() ) {
+        else if ( le.MousePressRight( btnRetreat.area() ) && current_color == hero.GetColor() && !hero.isCaptain() ) {
             Dialog::Message(
                 _( "Retreat" ),
                 _( "Retreat your hero, abandoning your creatures. Your hero will be available for you to recruit again, however, the hero will have only a novice hero's forces." ),
                 Font::BIG );
         }
-        else if ( le.MousePressRight( btnSurrender.area() ) && btnSurrender.isEnabled() ) {
+        else if ( le.MousePressRight( btnSurrender.area() ) && current_color == hero.GetColor() && !hero.isCaptain() ) {
             Dialog::Message(
                 _( "Surrender" ),
                 _( "Surrendering costs gold. However if you pay the ransom, the hero and all of his or her surviving creatures will be available to recruit again." ),
                 Font::BIG );
         }
-        else if ( le.MousePressRight( portraitArea ) && !readonly ) {
+        else if ( le.MousePressRight( portraitArea ) && actionHero != nullptr ) {
             Dialog::Message( _( "Hero Screen" ), _( "Open Hero Screen to view full information about the hero." ), Font::BIG );
         }
         else if ( le.MousePressRight( btnClose.area() ) ) {


### PR DESCRIPTION
…and Surrender buttons when a button is disabled.

fixes #4775 


I propose the following:
- when the Cast, Retreat, or Surrender button is disabled, a player cannot right-click on it
- when the Cast, Retreat, or Surrender button is disabled, the game does not display any tooltip
- the Hero Screen dialog is not present when a player clicks on the opposing hero

What I did not change:
- when the Cast, Retreat, or Surrender button is enabled, a player can right-click on it and the game displays a tooltip
- I have not touched the current logic that evaluates if whether a button is enabled or not