### PR TITLE
Route::Path::GetFrontDirection(): return Direction::UNKNOWN if path is empty and path destination is not valid

### DIFF
--- a/src/fheroes2/heroes/route.cpp
+++ b/src/fheroes2/heroes/route.cpp
@@ -41,7 +41,7 @@ int Route::Path::GetFrontDirection( void ) const
             return Maps::GetDirection( hero->GetIndex(), dst );
         }
 
-        return Direction::CENTER;
+        return Direction::UNKNOWN;
     }
 
     return front().GetDirection();


### PR DESCRIPTION
Another follow-up after #4846 and #4878