### PR TITLE
fix `make clean` to correctly remove fheroes2.res file

### DIFF
--- a/src/dist/Makefile
+++ b/src/dist/Makefile
@@ -72,4 +72,4 @@ VPATH := $(SOURCEDIR)
 include $(wildcard *.d)
 
 clean:
-	rm -f *.pot *.o *.d *.rc *.res *.exe $(TARGET)
+	rm -f *.pot *.o *.d *.exe $(TARGET) $(RES)


### PR DESCRIPTION
Currently there is an issue with `make clean` command on Windows, which can be reproduced as follows:

- build the game with mingw32
- run `make clean`
- build the game with mingw64

The linker fails in the last step, because `src/resources/fheroes2.res` remains 32-bit and cannot be linked into a 64-bit executable. It is not rebuilt because the input file, `src/resources/fheroes2.rc`, is older, and `src/resources/fheroes2.res` doesn't get removed by `make clean`.

In fact, `make clean` tries to remove `*.rc *res` inside `src/dist`, but no such files exist. What's worse, `*.rc` files are git-tracked and should not be cleaned at all.
