### PR TITLE
Adds missing "pourcent" in description of Golden Bow

### DIFF
--- a/files/lang/fr.po
+++ b/files/lang/fr.po
@@ -7467,7 +7467,7 @@ msgid ""
 "The %{name} eliminates the %{count} percent penalty for your troops shooting "
 "past obstacles (e.g. castle walls)."
 msgstr ""
-"L'%{name} élimine la pénalité de %{count} pour vos troupes qui tirent au-"
+"L'%{name} élimine la pénalité de %{count} pourcent pour vos troupes qui tirent au-"
 "delà des obstacles (par exemple, les murs d'un château)."
 
 msgid "Telescope"


### PR DESCRIPTION
Fixes a small typo in the French translation where the word for "percent" was missing.