### PR TITLE
Update documentation related to MacOS

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -110,7 +110,10 @@ brew install fheroes2
 <a name="macos-zip-archive"></a>
 ### macOS ZIP archive
 
-* Download the [**macOS ZIP archive**](https://github.com/ihhub/fheroes2/releases/latest/download/fheroes2_macos10_15_sdl2_x86-64.zip). Currently only x86-64 binaries are provided. If you use a computer with an Apple Silicon chip, you should choose another installation method (using [**MacPorts**](#macports) or [**Homebrew**](#homebrew-mac)), or [**build the project from source**](https://github.com/ihhub/fheroes2/blob/master/docs/DEVELOPMENT.md#macos-and-linux).
+* Download the [**macOS ZIP archive**](https://github.com/ihhub/fheroes2/releases/latest/download/fheroes2_macos10_15_sdl2_x86-64.zip).
+  Currently only x86-64 binaries are provided. If you use a machine with an Apple Silicon chip, you should choose another installation
+  method (using [**MacPorts**](#macports) or [**Homebrew**](#homebrew-mac)), or
+  [**build the project from source**](https://github.com/ihhub/fheroes2/blob/master/docs/DEVELOPMENT.md#macos-and-linux).
 
 * After downloading the ZIP archive, extract it to a suitable directory of your choice and then run the script `install_sdl_1.sh` or
   `install_sdl_2.sh` (depending on the downloaded build) from the `script/macos` subdirectory. This will install the SDL libraries

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -110,7 +110,7 @@ brew install fheroes2
 <a name="macos-zip-archive"></a>
 ### macOS ZIP archive
 
-* Download the [**macOS ZIP archive**](https://github.com/ihhub/fheroes2/releases/latest/download/fheroes2_macos10_15_sdl2_x86-64.zip).
+* Download the [**macOS ZIP archive**](https://github.com/ihhub/fheroes2/releases/latest/download/fheroes2_macos10_15_sdl2_x86-64.zip). Currently only x86-64 binaries are provided. If you use a computer with an Apple Silicon chip, you should choose another installation method (using [**MacPorts**](#macports) or [**Homebrew**](#homebrew-mac)), or [**build the project from source**](https://github.com/ihhub/fheroes2/blob/master/docs/DEVELOPMENT.md#macos-and-linux).
 
 * After downloading the ZIP archive, extract it to a suitable directory of your choice and then run the script `install_sdl_1.sh` or
   `install_sdl_2.sh` (depending on the downloaded build) from the `script/macos` subdirectory. This will install the SDL libraries


### PR DESCRIPTION
As GitHub does not provide macOS runners on the ARM platform, zip archives are not created for Apple Silicon chips. This patch clarifies that x86-64 binaries on MacOS will not run on ARM64 platform and points affected users to compatible installation methods.