### PR TITLE
Fix sed -i behavior on some systems

### DIFF
--- a/files/lang/Makefile
+++ b/files/lang/Makefile
@@ -42,25 +42,25 @@ ru.mo: ru.po
 # German has locale-specific transliteration rules (ä -> ae, etc)
 de.mo: de.po
 	sed -e 's/ä/ae/g' $< > $<.tmp
-	sed -i -e 's/ö/oe/g' $<.tmp
-	sed -i -e 's/ü/ue/g' $<.tmp
-	sed -i -e 's/Ö/Oe/g' $<.tmp
-	sed -i -e 's/Ü/Ue/g' $<.tmp
+	sed -i~ -e 's/ö/oe/g' $<.tmp
+	sed -i~ -e 's/ü/ue/g' $<.tmp
+	sed -i~ -e 's/Ö/Oe/g' $<.tmp
+	sed -i~ -e 's/Ü/Ue/g' $<.tmp
 	iconv -f utf-8 -t ascii//TRANSLIT $<.tmp > $<.2.tmp
 	msgfmt $<.2.tmp -o $@
-	
+
 # Norwegian has locale-specific transliteration rules (æ -> ae, etc)
 nb.mo: nb.po
 	sed -e 's/æ/ae/g' $< > $<.tmp
-	sed -i -e 's/ø/oe/g' $<.tmp
-	sed -i -e 's/å/aa/g' $<.tmp
-	sed -i -e 's/Æ/Ae/g' $<.tmp
-	sed -i -e 's/Ø/Oe/g' $<.tmp
-	sed -i -e 's/Å/Aa/g' $<.tmp
-	sed -i -e 's/é/e/g' $<.tmp
+	sed -i~ -e 's/ø/oe/g' $<.tmp
+	sed -i~ -e 's/å/aa/g' $<.tmp
+	sed -i~ -e 's/Æ/Ae/g' $<.tmp
+	sed -i~ -e 's/Ø/Oe/g' $<.tmp
+	sed -i~ -e 's/Å/Aa/g' $<.tmp
+	sed -i~ -e 's/é/e/g' $<.tmp
 	iconv -f utf-8 -t ascii//TRANSLIT $<.tmp > $<.2.tmp
 	msgfmt $<.2.tmp -o $@
-	
+
 # Italian
 it.mo: it.po
 	sed -e 'y/àèéìòùÀÈÉÌÒÙ/aeeiouAEEIOU/' $< > $<.tmp
@@ -75,4 +75,4 @@ it.mo: it.po
 	msgfmt $<.2.tmp -o $@
 
 clean:
-	rm -f *.mo *.po~ *.tmp
+	rm -f *.mo *.po~ *.tmp *.tmp~

--- a/src/dist/Makefile
+++ b/src/dist/Makefile
@@ -58,7 +58,8 @@ $(TARGET): $(notdir $(patsubst %.cpp, %.o, $(SEARCH))) $(LIBENGINE) $(RES)
 pot: $(wildcard $(SEARCH))
 	@echo "gen: $(POT)"
 	@xgettext -d $(TARGET) -C -F -k_ -k_n:1,2 -o $(POT) $(sort $(wildcard $(SEARCH)))
-	@sed -i -e 's/, c-format//' $(POT)
+	@sed -i~ -e 's/, c-format//' $(POT)
+	@rm -f $(POT)~
 
 $(RES): $(RC)
 	@echo "gen: $@"


### PR DESCRIPTION
GNU `sed` is incompatible with BSD `sed` in this regard: the GNU `sed` has the `-i[SUFFIX]` syntax, while the BSD `sed` has the `-i extension` syntax, so we have undesirable behavior at least on the latest macOS (files like `fheroes2.pot-e` for example).