### PR TITLE
MusicRestorer: prevent attempts to play the old music by new instances while the music being restored is starting in the background

### DIFF
--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -236,10 +236,18 @@ namespace Game
         {
             if ( _music == MUS::UNUSED || _music == MUS::UNKNOWN ) {
                 SetCurrentMusic( _music );
+
+                return;
             }
-            else {
-                AGG::PlayMusic( _music, true, true );
+
+            // Set current music to MUS::UNKNOWN to prevent attempts to play the old music
+            // by new instances of MusicRestorer while the music being currently restored
+            // is starting in the background
+            if ( _music != CurrentMusic() ) {
+                SetCurrentMusic( MUS::UNKNOWN );
             }
+
+            AGG::PlayMusic( _music, true, true );
         }
 
         MusicRestorer & operator=( const MusicRestorer & ) = delete;


### PR DESCRIPTION
This should fix sound issues like this: [sound-after-battle-bug.zip](https://github.com/ihhub/fheroes2/files/7810935/sound-after-battle-bug.zip). Set the Battles to Auto Resolve and Music Type to External, skip the turn and press OKAY in the battle result window. You will hear the `MUS::BATTLELOSE` instead of `MUS::COMPUTER_TURN` while the AI hero gets into the boat.