### PR TITLE
INSTALL.md: make the link to the section of the DEVELOPMENT.md universal

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,6 +4,7 @@
 
 Please follow the instructions below to be able to build the project from source:
 
+<a name="windows"></a>
 ### Windows
 
 * Go to the directory `script/windows` and run the file `install_packages.bat`. This script will install all the
@@ -16,6 +17,7 @@ Please follow the instructions below to be able to build the project from source
   Studio installed and build the project.
 * Visual Studio will automatically copy game files in the root directory to the build directory.
 
+<a name="macos-and-linux"></a>
 ### macOS and Linux
 
 * Depending on your OS, run the following scripts to install the dependencies required for the build:
@@ -28,14 +30,17 @@ Please follow the instructions below to be able to build the project from source
 * Run the `make` command in the root directory of the project to build it with **SDL2** or `make FHEROES2_SDL1="ON"` to build it
   with **SDL1**.
 
+<a name="playstation-vita"></a>
 ### PlayStation Vita
 
 If you would like to build and run this project on PlayStation Vita please follow the instructions on [**this page**](README_PSV.md).
 
+<a name="nintendo-switch"></a>
 ### Nintendo Switch
 
 If you would like to build and run this project on Nintendo Switch please follow the instructions on [**this page**](README_switch.md).
 
+<a name="build-with-cmake"></a>
 ### Build with CMake
 
 If you would like to build the project using CMake please follow the instructions on [**this page**](README_cmake.md).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -113,7 +113,7 @@ brew install fheroes2
 * Download the [**macOS ZIP archive**](https://github.com/ihhub/fheroes2/releases/latest/download/fheroes2_macos10_15_sdl2_x86-64.zip).
   Currently only x86-64 binaries are provided. If you use a machine with an Apple Silicon chip, you should choose another installation
   method (using [**MacPorts**](#macports) or [**Homebrew**](#homebrew-mac)), or
-  [**build the project from source**](https://github.com/ihhub/fheroes2/blob/master/docs/DEVELOPMENT.md#macos-and-linux).
+  [**build the project from source**](DEVELOPMENT.md#macos-and-linux).
 
 * After downloading the ZIP archive, extract it to a suitable directory of your choice and then run the script `install_sdl_1.sh` or
   `install_sdl_2.sh` (depending on the downloaded build) from the `script/macos` subdirectory. This will install the SDL libraries


### PR DESCRIPTION
Currently the link from the "macOS ZIP archive" section of the `INSTALL.md` to the "macOS and Linux" section of the `DEVELOPMENT.md` always leads to GitHub. This PR fixes this. You can try it out here:

https://github.com/oleg-derevenetz/fheroes2/blob/development-md-link-fix/docs/INSTALL.md#macos-zip-archive
https://oleg-derevenetz.github.io/fheroes2/INSTALL.html#macos-zip-archive
