### PR TITLE
AIWorldPathfinder: add support for paving the way through Whirlpools

### DIFF
--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -117,7 +117,7 @@ namespace AI
     Base & Get( AI_TYPE type = AI_TYPE::NORMAL );
 
     // functionality in ai_hero_action.cpp
-    void HeroesAction( Heroes & hero, s32 dst_index, bool isDestination );
+    void HeroesAction( Heroes & hero, s32 dst_index );
     void HeroesMove( Heroes & hero );
 
     // functionality in ai_common.cpp

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -895,20 +895,12 @@ namespace AI
     {
         assert( hero.GetPath().empty() );
 
-        MapsIndexes teleports = world.GetTeleportEndPoints( startIndex );
-
-        if ( teleports.empty() ) {
+        const int32_t indexTo = world.NextTeleport( startIndex );
+        if ( startIndex == indexTo ) {
             DEBUG_LOG( DBG_AI, DBG_WARN, "AI hero " << hero.GetName() << " has nowhere to go through stone liths." );
             return;
         }
 
-        const int32_t indexTo = Rand::Get( teleports );
-        if ( startIndex == indexTo ) {
-            DEBUG_LOG( DBG_AI, DBG_WARN, "AI hero " << hero.GetName() << " has teleportation tile the same as starting position: " << startIndex );
-            return;
-        }
-
-        // TODO: remove this assertion, this should never happen
         assert( world.GetTiles( indexTo ).GetObject() != MP2::OBJ_HEROES );
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
@@ -932,16 +924,9 @@ namespace AI
     {
         assert( hero.GetPath().empty() );
 
-        MapsIndexes whirlpools = world.GetWhirlpoolEndPoints( startIndex );
-
-        if ( whirlpools.empty() ) {
-            DEBUG_LOG( DBG_AI, DBG_WARN, "AI hero " << hero.GetName() << " has nowhere to go through the whirlpool." );
-            return;
-        }
-
-        const int32_t indexTo = Rand::Get( whirlpools );
+        const int32_t indexTo = world.NextWhirlpool( startIndex );
         if ( startIndex == indexTo ) {
-            DEBUG_LOG( DBG_AI, DBG_WARN, "AI hero " << hero.GetName() << " has teleportation tile the same as starting position: " << startIndex );
+            DEBUG_LOG( DBG_AI, DBG_WARN, "AI hero " << hero.GetName() << " has nowhere to go through the whirlpool." );
             return;
         }
 

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1701,22 +1701,28 @@ namespace AI
 
     void AIWhirlpoolTroopLooseEffect( Heroes & hero )
     {
-        Troop * troop = hero.GetArmy().GetWeakestTroop();
-        assert( troop );
-        if ( !troop )
+        Army & heroArmy = hero.GetArmy();
+
+        // Arrange the hero's army for the passage of the whirlpool first
+        heroArmy.ArrangeForWhirlpool();
+
+        Troop * weakestTroop = heroArmy.GetWeakestTroop();
+        assert( weakestTroop != nullptr );
+        if ( weakestTroop == nullptr ) {
             return;
+        }
 
         // Whirlpool effect affects heroes only with more than one creature in more than one slot
-        if ( hero.GetArmy().GetCount() == 1 && troop->GetCount() == 1 ) {
+        if ( heroArmy.GetCount() == 1 && weakestTroop->GetCount() == 1 ) {
             return;
         }
 
         if ( 1 == Rand::Get( 1, 3 ) ) {
-            if ( troop->GetCount() == 1 ) {
-                troop->Reset();
+            if ( weakestTroop->GetCount() == 1 ) {
+                weakestTroop->Reset();
             }
             else {
-                troop->SetCount( Monster::GetCountFromHitPoints( troop->GetID(), troop->GetHitPoints() - troop->GetHitPoints() * Game::GetWhirlpoolPercent() / 100 ) );
+                weakestTroop->SetCount( Monster::GetCountFromHitPoints( weakestTroop->GetID(), weakestTroop->GetHitPoints() - weakestTroop->GetHitPoints() * Game::GetWhirlpoolPercent() / 100 ) );
             }
         }
     }

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -304,7 +304,7 @@ namespace AI
             AIToAbandoneMine( hero, objectType, dst_index );
             break;
 
-        case MP2::OBJ_SHIPWRECKSURVIROR:
+        case MP2::OBJ_SHIPWRECKSURVIVOR:
             AIToShipwreckSurvivor( hero, objectType, dst_index );
             break;
 

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1722,7 +1722,8 @@ namespace AI
                 weakestTroop->Reset();
             }
             else {
-                weakestTroop->SetCount( Monster::GetCountFromHitPoints( weakestTroop->GetID(), weakestTroop->GetHitPoints() - weakestTroop->GetHitPoints() * Game::GetWhirlpoolPercent() / 100 ) );
+                weakestTroop->SetCount( Monster::GetCountFromHitPoints( weakestTroop->GetID(), weakestTroop->GetHitPoints()
+                                                                                                   - weakestTroop->GetHitPoints() * Game::GetWhirlpoolPercent() / 100 ) );
             }
         }
     }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -34,28 +34,6 @@
 
 namespace
 {
-    bool isHeroAllowedToUseWhirlpool( const Heroes & hero )
-    {
-        if ( hero.GetArmy().getTotalCount() == 1 ) {
-            // No way a hero can loose any army.
-            return true;
-        }
-
-        switch ( hero.getAIRole() ) {
-        case Heroes::Role::HUNTER:
-            break;
-        case Heroes::Role::FIGHTER:
-            // Fighters shouldn't use whirlpools as they can loose an important army.
-            return false;
-        default:
-            // If you set a new type of a hero you must add the logic here.
-            assert( 0 );
-            break;
-        }
-
-        return true;
-    }
-
     bool AIShouldVisitCastle( const Heroes & hero, int castleIndex )
     {
         const Castle * castle = world.getCastleEntrance( Maps::GetPoint( castleIndex ) );
@@ -1076,7 +1054,7 @@ namespace AI
 #endif
 
         // pre-cache the pathfinder
-        _pathfinder.reEvaluateIfNeeded( hero, isHeroAllowedToUseWhirlpool( hero ) );
+        _pathfinder.reEvaluateIfNeeded( hero );
 
         const uint32_t leftMovePoints = hero.GetMovePoints();
 
@@ -1144,7 +1122,7 @@ namespace AI
                        hero.GetName() << ": priority selected: " << priorityTarget << " value is " << maxPriority << " (" << MP2::StringObject( objectType ) << ")" );
         }
         else if ( !heroInPatrolMode ) {
-            priorityTarget = _pathfinder.getFogDiscoveryTile( hero, isHeroAllowedToUseWhirlpool( hero ) );
+            priorityTarget = _pathfinder.getFogDiscoveryTile( hero );
             DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << " can't find an object. Scouting the fog of war at " << priorityTarget );
         }
 
@@ -1222,11 +1200,11 @@ namespace AI
                             continue;
                         }
 
-                        if ( !_pathfinder.isHeroPossiblyBlockingWay( *heroInfo.hero, isHeroAllowedToUseWhirlpool( *heroInfo.hero ) ) ) {
+                        if ( !_pathfinder.isHeroPossiblyBlockingWay( *heroInfo.hero ) ) {
                             continue;
                         }
 
-                        const int targetIndex = _pathfinder.getNearestTileToMove( *heroInfo.hero, isHeroAllowedToUseWhirlpool( *heroInfo.hero ) );
+                        const int targetIndex = _pathfinder.getNearestTileToMove( *heroInfo.hero );
                         if ( targetIndex != -1 ) {
                             bestTargetIndex = targetIndex;
                             bestHero = heroInfo.hero;
@@ -1242,7 +1220,7 @@ namespace AI
                 }
             }
 
-            _pathfinder.reEvaluateIfNeeded( *bestHero, isHeroAllowedToUseWhirlpool( *bestHero ) );
+            _pathfinder.reEvaluateIfNeeded( *bestHero );
             bestHero->GetPath().setPath( _pathfinder.buildPath( bestTargetIndex ), bestTargetIndex );
 
             const size_t heroesBefore = heroes.size();

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -99,8 +99,11 @@ namespace
 
         case MP2::OBJ_MAGELLANMAPS:
             return hero.isShipMaster() && !hero.isObjectTypeVisited( MP2::OBJ_MAGELLANMAPS, Visit::GLOBAL ) && kingdom.AllowPayment( { Resource::GOLD, 1000 } );
+
         case MP2::OBJ_WHIRLPOOL:
-            return hero.isShipMaster() && !hero.isVisited( tile );
+            // Additional checks will follow
+            return true;
+
         case MP2::OBJ_COAST:
             // Coast is not an action object. If this assertion blows up then something wrong with the logic above.
             assert( 0 );
@@ -421,7 +424,7 @@ namespace
             return false;
 
         case MP2::OBJ_STONELITHS:
-            // check later
+            // Additional checks will follow
             return true;
 
         case MP2::OBJ_JAIL:
@@ -703,7 +706,7 @@ namespace AI
                 if ( world.GetTiles( whirlpoolIndex ).isFog( hero.GetColor() ) )
                     return -3000.0;
             }
-            return -dangerousTaskPenalty; // no point to even loose the army for this
+            return valueToIgnore;
         }
         else if ( objectType == MP2::OBJ_BOAT ) {
             // Boat is not considered by AI as an action object. If this assertion blows up something is wrong with the logic.
@@ -940,7 +943,7 @@ namespace AI
                 if ( world.GetTiles( whirlpoolIndex ).isFog( hero.GetColor() ) )
                     return -3000.0;
             }
-            return -dangerousTaskPenalty; // no point to even loose the army for this
+            return valueToIgnore;
         }
         else if ( objectType == MP2::OBJ_BOAT ) {
             // Boat is not considered by AI as an action object. If this assertion blows up something is wrong the the logic.

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -101,8 +101,8 @@ namespace
             return hero.isShipMaster() && !hero.isObjectTypeVisited( MP2::OBJ_MAGELLANMAPS, Visit::GLOBAL ) && kingdom.AllowPayment( { Resource::GOLD, 1000 } );
 
         case MP2::OBJ_WHIRLPOOL:
-            // Additional checks will follow
-            return true;
+            // AI should never consider a whirlpool as a destination point. It uses them only to make a path.
+            return false;
 
         case MP2::OBJ_COAST:
             // Coast is not an action object. If this assertion blows up then something wrong with the logic above.
@@ -424,8 +424,8 @@ namespace
             return false;
 
         case MP2::OBJ_STONELITHS:
-            // Additional checks will follow
-            return true;
+            // AI should never consider a stone lith as a destination point. It uses them only to make a path.
+            return false;
 
         case MP2::OBJ_JAIL:
             return hero.GetKingdom().GetHeroes().size() < Kingdom::GetMaxHeroes();
@@ -676,12 +676,9 @@ namespace AI
             return tile.QuantityTroop().GetStrength();
         }
         else if ( objectType == MP2::OBJ_STONELITHS ) {
-            const MapsIndexes & list = world.GetTeleportEndPoints( index );
-            for ( const int teleportIndex : list ) {
-                if ( world.GetTiles( teleportIndex ).isFog( hero.GetColor() ) )
-                    return 0;
-            }
-            return valueToIgnore;
+            // Stone lith is not considered by AI as an action object. If this assertion blows up something is wrong with the logic.
+            assert( 0 );
+            return -dangerousTaskPenalty;
         }
         else if ( objectType == MP2::OBJ_OBSERVATIONTOWER ) {
             const int fogCountToUncover = Maps::getFogTileCountToBeRevealed( index, Game::GetViewDistance( Game::VIEW_OBSERVATION_TOWER ), hero.GetColor() );
@@ -701,12 +698,9 @@ namespace AI
             return -dangerousTaskPenalty;
         }
         else if ( objectType == MP2::OBJ_WHIRLPOOL ) {
-            const MapsIndexes & list = world.GetWhirlpoolEndPoints( index );
-            for ( const int whirlpoolIndex : list ) {
-                if ( world.GetTiles( whirlpoolIndex ).isFog( hero.GetColor() ) )
-                    return -3000.0;
-            }
-            return valueToIgnore;
+            // Whirlpool is not considered by AI as an action object. If this assertion blows up something is wrong with the logic.
+            assert( 0 );
+            return -dangerousTaskPenalty;
         }
         else if ( objectType == MP2::OBJ_BOAT ) {
             // Boat is not considered by AI as an action object. If this assertion blows up something is wrong with the logic.
@@ -913,12 +907,9 @@ namespace AI
             return tile.QuantityTroop().GetStrength();
         }
         else if ( objectType == MP2::OBJ_STONELITHS ) {
-            const MapsIndexes & list = world.GetTeleportEndPoints( index );
-            for ( const int teleportIndex : list ) {
-                if ( world.GetTiles( teleportIndex ).isFog( hero.GetColor() ) )
-                    return 0;
-            }
-            return valueToIgnore;
+            // Stone lith is not considered by AI as an action object. If this assertion blows up something is wrong with the logic.
+            assert( 0 );
+            return -dangerousTaskPenalty;
         }
         else if ( objectType == MP2::OBJ_OBSERVATIONTOWER ) {
             const int fogCountToUncover = Maps::getFogTileCountToBeRevealed( index, Game::GetViewDistance( Game::VIEW_OBSERVATION_TOWER ), hero.GetColor() );
@@ -938,12 +929,9 @@ namespace AI
             return -dangerousTaskPenalty;
         }
         else if ( objectType == MP2::OBJ_WHIRLPOOL ) {
-            const MapsIndexes & list = world.GetWhirlpoolEndPoints( index );
-            for ( const int whirlpoolIndex : list ) {
-                if ( world.GetTiles( whirlpoolIndex ).isFog( hero.GetColor() ) )
-                    return -3000.0;
-            }
-            return valueToIgnore;
+            // Whirlpool is not considered by AI as an action object. If this assertion blows up something is wrong with the logic.
+            assert( 0 );
+            return -dangerousTaskPenalty;
         }
         else if ( objectType == MP2::OBJ_BOAT ) {
             // Boat is not considered by AI as an action object. If this assertion blows up something is wrong the the logic.

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1238,7 +1238,7 @@ namespace AI
                             continue;
                         }
 
-                        const int targetIndex = _pathfinder.getNeareastTileToMove( *heroInfo.hero, isHeroAllowedToUseWhirlpool( *heroInfo.hero ) );
+                        const int targetIndex = _pathfinder.getNearestTileToMove( *heroInfo.hero, isHeroAllowedToUseWhirlpool( *heroInfo.hero ) );
                         if ( targetIndex != -1 ) {
                             bestTargetIndex = targetIndex;
                             bestHero = heroInfo.hero;

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -82,7 +82,7 @@ namespace
         }
 
         switch ( objectType ) {
-        case MP2::OBJ_SHIPWRECKSURVIROR:
+        case MP2::OBJ_SHIPWRECKSURVIVOR:
         case MP2::OBJ_WATERCHEST:
         case MP2::OBJ_FLOTSAM:
         case MP2::OBJ_BOTTLE:

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1153,7 +1153,7 @@ namespace AI
                        hero.GetName() << ": priority selected: " << priorityTarget << " value is " << maxPriority << " (" << MP2::StringObject( objectType ) << ")" );
         }
         else if ( !heroInPatrolMode ) {
-            priorityTarget = _pathfinder.getFogDiscoveryTile( hero );
+            priorityTarget = _pathfinder.getFogDiscoveryTile( hero, isHeroAllowedToUseWhirlpool( hero ) );
             DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << " can't find an object. Scouting the fog of war at " << priorityTarget );
         }
 
@@ -1231,11 +1231,11 @@ namespace AI
                             continue;
                         }
 
-                        if ( !_pathfinder.isHeroPossiblyBlockingWay( *heroInfo.hero ) ) {
+                        if ( !_pathfinder.isHeroPossiblyBlockingWay( *heroInfo.hero, isHeroAllowedToUseWhirlpool( *heroInfo.hero ) ) ) {
                             continue;
                         }
 
-                        const int targetIndex = _pathfinder.getNeareastTileToMove( *heroInfo.hero );
+                        const int targetIndex = _pathfinder.getNeareastTileToMove( *heroInfo.hero, isHeroAllowedToUseWhirlpool( *heroInfo.hero ) );
                         if ( targetIndex != -1 ) {
                             bestTargetIndex = targetIndex;
                             bestHero = heroInfo.hero;

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -34,6 +34,28 @@
 
 namespace
 {
+    bool isHeroAllowedToUseWhirlpool( const Heroes & hero )
+    {
+        if ( hero.GetArmy().getTotalCount() == 1 ) {
+            // No way a hero can loose any army.
+            return true;
+        }
+
+        switch ( hero.getAIRole() ) {
+        case Heroes::Role::HUNTER:
+            break;
+        case Heroes::Role::FIGHTER:
+            // Fighters shouldn't use whirlpools as they can loose an important army.
+            return false;
+        default:
+            // If you set a new type of a hero you must add the logic here.
+            assert( 0 );
+            break;
+        }
+
+        return true;
+    }
+
     bool AIShouldVisitCastle( const Heroes & hero, int castleIndex )
     {
         const Castle * castle = world.getCastleEntrance( Maps::GetPoint( castleIndex ) );
@@ -1063,7 +1085,7 @@ namespace AI
 #endif
 
         // pre-cache the pathfinder
-        _pathfinder.reEvaluateIfNeeded( hero );
+        _pathfinder.reEvaluateIfNeeded( hero, isHeroAllowedToUseWhirlpool( hero ) );
 
         const uint32_t leftMovePoints = hero.GetMovePoints();
 
@@ -1229,7 +1251,7 @@ namespace AI
                 }
             }
 
-            _pathfinder.reEvaluateIfNeeded( *bestHero );
+            _pathfinder.reEvaluateIfNeeded( *bestHero, isHeroAllowedToUseWhirlpool( *bestHero ) );
             bestHero->GetPath().setPath( _pathfinder.buildPath( bestTargetIndex ), bestTargetIndex );
 
             const size_t heroesBefore = heroes.size();

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <numeric>
 
@@ -582,6 +583,52 @@ void Troops::ArrangeForBattle( bool upgrade )
     else {
         Assign( priority );
     }
+}
+
+void Troops::ArrangeForWhirlpool()
+{
+    // Make an "optimized" version first (each type of monster occupies one slot)
+    const Troops optimizedTroops = GetOptimized();
+    assert( optimizedTroops.size() > 0 && optimizedTroops.size() <= ARMYMAXTROOPS );
+
+    // Already a full house, there is no room for further optimization
+    if ( optimizedTroops.size() == ARMYMAXTROOPS ) {
+        return;
+    }
+
+    Assign( optimizedTroops );
+
+    // Look for a troop consisting of the weakest units
+    Troop * troopOfWeakestUnits = nullptr;
+
+    for ( Troop * troop : *this ) {
+        assert( troop != nullptr );
+
+        if ( !troop->isValid() ) {
+            continue;
+        }
+
+        if ( troopOfWeakestUnits == nullptr || troopOfWeakestUnits->Monster::GetHitPoints() > troop->Monster::GetHitPoints() ) {
+            troopOfWeakestUnits = troop;
+        }
+    }
+
+    assert( troopOfWeakestUnits != nullptr );
+    assert( troopOfWeakestUnits->GetCount() > 0 );
+
+    // There is already just one unit in this troop, let's leave it as it is
+    if ( troopOfWeakestUnits->GetCount() == 1 ) {
+        return;
+    }
+
+    // Move one unit from this troop's slot...
+    troopOfWeakestUnits->SetCount( troopOfWeakestUnits->GetCount() - 1 );
+
+    // To the separate slot
+    auto emptySlot = std::find_if( begin(), end(), []( const Troop * troop ) { return !troop->isValid(); } );
+    assert( emptySlot != end() );
+
+    ( *emptySlot )->Set( Monster( troopOfWeakestUnits->GetID() ), 1 );
 }
 
 void Troops::JoinStrongest( Troops & troops2, bool saveLast )

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -587,7 +587,7 @@ void Troops::ArrangeForBattle( bool upgrade )
 
 void Troops::ArrangeForWhirlpool()
 {
-    // Make an "optimized" version first (each type of monster occupies one slot)
+    // Make an "optimized" version first (each unit type occupies just one slot)
     const Troops optimizedTroops = GetOptimized();
     assert( optimizedTroops.size() > 0 && optimizedTroops.size() <= ARMYMAXTROOPS );
 

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -94,6 +94,9 @@ public:
 
     void SortStrongest();
     void ArrangeForBattle( bool = false );
+    // Optimizes the arrangement of troops to pass through the whirlpool (moves one weakest unit
+    // to a separate slot, if possible)
+    void ArrangeForWhirlpool();
 
     void JoinStrongest( Troops &, bool );
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1991,7 +1991,6 @@ void ActionToTeleports( Heroes & hero, s32 index_from )
         return;
     }
 
-    // TODO: remove this assertion, this should never happen
     assert( world.GetTiles( index_to ).GetObject() != MP2::OBJ_HEROES );
 
     AGG::PlaySound( M82::KILLFADE );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1991,19 +1991,8 @@ void ActionToTeleports( Heroes & hero, s32 index_from )
         return;
     }
 
-    const Heroes * other_hero = world.GetTiles( index_to ).GetHeroes();
-    if ( other_hero ) {
-        ActionToHeroes( hero, index_to );
-
-        // lose battle
-        if ( hero.isFreeman() ) {
-            return;
-        }
-        else if ( !other_hero->isFreeman() ) {
-            DEBUG_LOG( DBG_GAME, DBG_WARN, "is busy..." );
-            return;
-        }
-    }
+    // TODO: remove this assertion, this should never happen
+    assert( world.GetTiles( index_to ).GetObject() != MP2::OBJ_HEROES );
 
     AGG::PlaySound( M82::KILLFADE );
     hero.GetPath().Hide();

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -369,7 +369,7 @@ void Heroes::Action( int tileIndex, bool isDestination )
     const Game::MusicRestorer musicRestorer;
 
     if ( GetKingdom().isControlAI() )
-        return AI::HeroesAction( *this, tileIndex, isDestination );
+        return AI::HeroesAction( *this, tileIndex );
 
     Maps::Tiles & tile = world.GetTiles( tileIndex );
     const MP2::MapObjectType objectType = tile.GetObject( tileIndex != GetIndex() );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -492,7 +492,7 @@ void Heroes::Action( int tileIndex, bool isDestination )
             ActionToFlotSam( *this, objectType, tileIndex );
             break;
 
-        case MP2::OBJ_SHIPWRECKSURVIROR:
+        case MP2::OBJ_SHIPWRECKSURVIVOR:
             ActionToShipwreckSurvivor( *this, objectType, tileIndex );
             break;
         case MP2::OBJ_ARTIFACT:

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1506,6 +1506,29 @@ Maps::TilesAddon * Maps::Tiles::FindAddonLevel2( u32 uniq2 )
 
 std::string Maps::Tiles::String( void ) const
 {
+    Maps::ClearFog( 0, 1024, Color::BLUE );
+    Maps::ClearFog( 0, 1024, Color::GREEN );
+
+    Heroes * debugHero = world.GetHeroes( Heroes::DEBUG_HERO );
+
+    if ( !debugHero->isFreeman() ) {
+        AIWorldPathfinder aiPathfinder( 1.8 );
+
+        aiPathfinder.reset();
+        aiPathfinder.reEvaluateIfNeeded( *debugHero, true );
+
+        auto path = aiPathfinder.buildPath( _index, true );
+
+        printf( "DEBUG: " );
+        for ( const auto & item : path ) {
+            printf( "%d ", item.GetIndex() );
+        }
+        printf( "\n" );
+
+        debugHero->GetPath().setPath( path, _index );
+        debugHero->GetPath().Show();
+    }
+
     std::ostringstream os;
 
     os << "----------------:>>>>>>>>" << std::endl

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1506,29 +1506,6 @@ Maps::TilesAddon * Maps::Tiles::FindAddonLevel2( u32 uniq2 )
 
 std::string Maps::Tiles::String( void ) const
 {
-    Maps::ClearFog( 0, 1024, Color::BLUE );
-    Maps::ClearFog( 0, 1024, Color::GREEN );
-
-    Heroes * debugHero = world.GetHeroes( Heroes::DEBUG_HERO );
-
-    if ( !debugHero->isFreeman() ) {
-        AIWorldPathfinder aiPathfinder( 1.8 );
-
-        aiPathfinder.reset();
-        aiPathfinder.reEvaluateIfNeeded( *debugHero, true );
-
-        auto path = aiPathfinder.buildPath( _index, true );
-
-        printf( "DEBUG: " );
-        for ( const auto & item : path ) {
-            printf( "%d ", item.GetIndex() );
-        }
-        printf( "\n" );
-
-        debugHero->GetPath().setPath( path, _index );
-        debugHero->GetPath().Show();
-    }
-
     std::ostringstream os;
 
     os << "----------------:>>>>>>>>" << std::endl

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -31,7 +31,7 @@ bool Maps::Tiles::QuantityIsValid( void ) const
     case MP2::OBJ_RESOURCE:
     case MP2::OBJ_CAMPFIRE:
     case MP2::OBJ_FLOTSAM:
-    case MP2::OBJ_SHIPWRECKSURVIROR:
+    case MP2::OBJ_SHIPWRECKSURVIVOR:
     case MP2::OBJ_TREASURECHEST:
     case MP2::OBJ_WATERCHEST:
     case MP2::OBJ_ABANDONEDMINE:
@@ -168,7 +168,7 @@ Artifact Maps::Tiles::QuantityArtifact( void ) const
     case MP2::OBJ_DAEMONCAVE:
     case MP2::OBJ_WATERCHEST:
     case MP2::OBJ_TREASURECHEST:
-    case MP2::OBJ_SHIPWRECKSURVIROR:
+    case MP2::OBJ_SHIPWRECKSURVIVOR:
     case MP2::OBJ_SHIPWRECK:
     case MP2::OBJ_GRAVEYARD:
         return Artifact( quantity1 );
@@ -432,7 +432,7 @@ void Maps::Tiles::QuantityReset( void )
     case MP2::OBJ_SKELETON:
     case MP2::OBJ_WAGON:
     case MP2::OBJ_ARTIFACT:
-    case MP2::OBJ_SHIPWRECKSURVIROR:
+    case MP2::OBJ_SHIPWRECKSURVIVOR:
     case MP2::OBJ_WATERCHEST:
     case MP2::OBJ_TREASURECHEST:
     case MP2::OBJ_SHIPWRECK:
@@ -613,7 +613,7 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
         break;
     }
 
-    case MP2::OBJ_SHIPWRECKSURVIROR: {
+    case MP2::OBJ_SHIPWRECKSURVIVOR: {
         Rand::Queue percents( 3 );
         // 55%: artifact 1
         percents.Push( 1, 55 );

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -456,7 +456,7 @@ const char * MP2::StringObject( const MapObjectType objectType, const int count 
         return _( "Lean To" );
     case OBJ_FLOTSAM:
         return _( "Flotsam" );
-    case OBJ_SHIPWRECKSURVIROR:
+    case OBJ_SHIPWRECKSURVIVOR:
         return _( "Shipwreck Survivor" );
     case OBJ_BOTTLE:
         return _( "Bottle" );
@@ -751,7 +751,7 @@ bool MP2::isWaterActionObject( const MapObjectType objectType )
     case OBJ_WHIRLPOOL:
     case OBJ_BUOY:
     case OBJ_BOTTLE:
-    case OBJ_SHIPWRECKSURVIROR:
+    case OBJ_SHIPWRECKSURVIVOR:
     case OBJ_FLOTSAM:
     case OBJ_MAGELLANMAPS:
     case OBJ_COAST:
@@ -965,7 +965,7 @@ bool MP2::isQuantityObject( const MapObjectType objectType )
     case OBJ_LEANTO:
     case OBJ_CAMPFIRE:
     case OBJ_FLOTSAM:
-    case OBJ_SHIPWRECKSURVIROR:
+    case OBJ_SHIPWRECKSURVIVOR:
     case OBJ_WATERCHEST:
     case OBJ_DERELICTSHIP:
     case OBJ_SHIPWRECK:
@@ -1009,7 +1009,7 @@ bool MP2::isPickupObject( const MapObjectType objectType )
 {
     switch ( objectType ) {
     case OBJ_WATERCHEST:
-    case OBJ_SHIPWRECKSURVIROR:
+    case OBJ_SHIPWRECKSURVIVOR:
     case OBJ_FLOTSAM:
     case OBJ_BOTTLE:
     case OBJ_TREASURECHEST:
@@ -1034,7 +1034,7 @@ bool MP2::isArtifactObject( const MapObjectType objectType )
     case OBJ_DAEMONCAVE:
     case OBJ_WATERCHEST:
     case OBJ_TREASURECHEST:
-    case OBJ_SHIPWRECKSURVIROR:
+    case OBJ_SHIPWRECKSURVIVOR:
     case OBJ_SHIPWRECK:
     case OBJ_GRAVEYARD:
         return true;
@@ -1172,7 +1172,7 @@ int MP2::getActionObjectDirection( const MapObjectType objectType )
     case OBJ_MONSTER:
     case OBJ_ANCIENTLAMP:
     case OBJ_CAMPFIRE:
-    case OBJ_SHIPWRECKSURVIROR:
+    case OBJ_SHIPWRECKSURVIVOR:
     case OBJ_FLOTSAM:
     case OBJ_WATERCHEST:
     case OBJ_BUOY:

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -523,7 +523,7 @@ namespace MP2
         OBJ_MAGELLANMAPS = 0xD9,
         OBJ_FLOTSAM = 0xDA,
         OBJ_DERELICTSHIP = 0xDB,
-        OBJ_SHIPWRECKSURVIROR = 0xDC,
+        OBJ_SHIPWRECKSURVIVOR = 0xDC,
         OBJ_BOTTLE = 0xDD,
         OBJ_MAGICWELL = 0xDE,
         OBJ_MAGICGARDEN = 0xDF,

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -788,7 +788,7 @@ u32 GoldInsteadArtifact( const MP2::MapObjectType objectType )
     switch ( objectType ) {
     case MP2::OBJ_SKELETON:
     case MP2::OBJ_TREASURECHEST:
-    case MP2::OBJ_SHIPWRECKSURVIROR:
+    case MP2::OBJ_SHIPWRECKSURVIVOR:
         return 1000;
     case MP2::OBJ_WATERCHEST:
         return 1500;

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -864,40 +864,29 @@ s32 World::NextTeleport( s32 index ) const
     return Rand::Get( teleports );
 }
 
-MapsIndexes World::GetWhirlpoolEndPoints( s32 center ) const
+MapsIndexes World::GetWhirlpoolEndPoints( int32_t index ) const
 {
-    if ( MP2::OBJ_WHIRLPOOL == GetTiles( center ).GetObject( false ) ) {
-        std::map<s32, MapsIndexes> uniq_whirlpools;
+    MapsIndexes result;
 
-        for ( MapsIndexes::const_iterator it = _whirlpoolTiles.begin(); it != _whirlpoolTiles.end(); ++it ) {
-            const Maps::Tiles & tile = GetTiles( *it );
-            if ( tile.GetHeroes() != nullptr ) {
-                continue;
-            }
+    const Maps::Tiles & entranceTile = GetTiles( index );
 
-            uniq_whirlpools[tile.GetObjectUID()].push_back( *it );
-        }
-
-        if ( 2 > uniq_whirlpools.size() ) {
-            DEBUG_LOG( DBG_GAME, DBG_WARN, "is empty" );
-            return MapsIndexes();
-        }
-
-        const uint32_t currentUID = GetTiles( center ).GetObjectUID();
-        MapsIndexes uniqs;
-        uniqs.reserve( uniq_whirlpools.size() );
-
-        for ( std::map<s32, MapsIndexes>::const_iterator it = uniq_whirlpools.begin(); it != uniq_whirlpools.end(); ++it ) {
-            const u32 uniq = ( *it ).first;
-            if ( uniq == currentUID )
-                continue;
-            uniqs.push_back( uniq );
-        }
-
-        return uniq_whirlpools[Rand::Get( uniqs )];
+    if ( entranceTile.GetObject( false ) != MP2::OBJ_WHIRLPOOL ) {
+        return result;
     }
 
-    return MapsIndexes();
+    const uint32_t entranceUID = entranceTile.GetObjectUID();
+
+    for ( const int32_t whirlpoolIndex : _whirlpoolTiles ) {
+        const Maps::Tiles & whirlpoolTile = GetTiles( whirlpoolIndex );
+
+        if ( whirlpoolTile.GetObjectUID() == entranceUID || whirlpoolTile.GetHeroes() != nullptr ) {
+            continue;
+        }
+
+        result.push_back( whirlpoolIndex );
+    }
+
+    return result;
 }
 
 /* return random whirlpools destination */

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -858,8 +858,7 @@ MapsIndexes World::GetTeleportEndPoints( const int32_t index ) const
     return result;
 }
 
-/* return random teleport destination */
-s32 World::NextTeleport( s32 index ) const
+int32_t World::NextTeleport( const int32_t index ) const
 {
     const MapsIndexes teleports = GetTeleportEndPoints( index );
     if ( teleports.empty() ) {
@@ -894,12 +893,11 @@ MapsIndexes World::GetWhirlpoolEndPoints( const int32_t index ) const
     return result;
 }
 
-/* return random whirlpools destination */
-s32 World::NextWhirlpool( s32 index ) const
+int32_t World::NextWhirlpool( const int32_t index ) const
 {
     const MapsIndexes whilrpools = GetWhirlpoolEndPoints( index );
     if ( whilrpools.empty() ) {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, "is full" );
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "not found" );
         return index;
     }
 

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -844,11 +844,11 @@ MapsIndexes World::GetTeleportEndPoints( const int32_t index ) const
         return result;
     }
 
-    for ( const int32_t teleportIndex : _allTeleports ) {
+    // The type of destination stone liths must match the type of the source stone liths.
+    for ( const int32_t teleportIndex : _allTeleports.at( entranceTile.GetObjectSpriteIndex() ) ) {
         const Maps::Tiles & teleportTile = GetTiles( teleportIndex );
 
-        if ( teleportIndex == index || teleportTile.GetObjectSpriteIndex() != entranceTile.GetObjectSpriteIndex() || teleportTile.GetHeroes() != nullptr
-             || teleportTile.isWater() != entranceTile.isWater() ) {
+        if ( teleportIndex == index || teleportTile.GetHeroes() != nullptr || teleportTile.isWater() != entranceTile.isWater() ) {
             continue;
         }
 
@@ -1304,8 +1304,12 @@ void World::PostLoad( const bool setTilePassabilities )
         }
     }
 
-    // Cache all teleport tiles
-    _allTeleports = Maps::GetObjectPositions( MP2::OBJ_STONELITHS, true );
+    // Cache all tiles that that contain stone liths of a certain type (depending on object sprite index).
+    _allTeleports.clear();
+
+    for ( const int32_t index : Maps::GetObjectPositions( MP2::OBJ_STONELITHS, true ) ) {
+        _allTeleports[GetTiles( index ).GetObjectSpriteIndex()].push_back( index );
+    }
 
     // Cache all tiles that contain a certain part of the whirlpool (depending on object sprite index).
     _allWhirlpools.clear();

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -834,19 +834,25 @@ const std::string & World::GetRumors( void )
     return *_rumor;
 }
 
-MapsIndexes World::GetTeleportEndPoints( s32 center ) const
+MapsIndexes World::GetTeleportEndPoints( const int32_t index ) const
 {
     MapsIndexes result;
 
-    const Maps::Tiles & entrance = GetTiles( center );
-    if ( _allTeleporters.size() > 1 && entrance.GetObject( false ) == MP2::OBJ_STONELITHS ) {
-        for ( MapsIndexes::const_iterator it = _allTeleporters.begin(); it != _allTeleporters.end(); ++it ) {
-            const Maps::Tiles & tile = GetTiles( *it );
-            if ( *it != center && tile.GetObjectSpriteIndex() == entrance.GetObjectSpriteIndex() && tile.GetObject() != MP2::OBJ_HEROES
-                 && tile.isWater() == entrance.isWater() ) {
-                result.push_back( *it );
-            }
+    const Maps::Tiles & entranceTile = GetTiles( index );
+
+    if ( entranceTile.GetObject( false ) != MP2::OBJ_STONELITHS ) {
+        return result;
+    }
+
+    for ( const int32_t teleportIndex : _allTeleports ) {
+        const Maps::Tiles & teleportTile = GetTiles( teleportIndex );
+
+        if ( teleportIndex == index || teleportTile.GetObjectSpriteIndex() != entranceTile.GetObjectSpriteIndex() || teleportTile.GetHeroes() != nullptr
+             || teleportTile.isWater() != entranceTile.isWater() ) {
+            continue;
         }
+
+        result.push_back( teleportIndex );
     }
 
     return result;
@@ -864,7 +870,7 @@ s32 World::NextTeleport( s32 index ) const
     return Rand::Get( teleports );
 }
 
-MapsIndexes World::GetWhirlpoolEndPoints( int32_t index ) const
+MapsIndexes World::GetWhirlpoolEndPoints( const int32_t index ) const
 {
     MapsIndexes result;
 
@@ -1301,7 +1307,7 @@ void World::PostLoad( const bool setTilePassabilities )
     }
 
     // Cache all teleport tiles
-    _allTeleporters = Maps::GetObjectPositions( MP2::OBJ_STONELITHS, true );
+    _allTeleports = Maps::GetObjectPositions( MP2::OBJ_STONELITHS, true );
 
     // Cache all tiles that contain a certain part of the whirlpool (depending on object sprite index).
     _allWhirlpools.clear();

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -901,8 +901,6 @@ s32 World::NextWhirlpool( s32 index ) const
     return Rand::Get( whilrpools );
 }
 
-/* return message from sign */
-
 /* return count captured object */
 u32 World::CountCapturedObject( int obj, int col ) const
 {

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -874,12 +874,11 @@ MapsIndexes World::GetWhirlpoolEndPoints( int32_t index ) const
         return result;
     }
 
-    const uint32_t entranceUID = entranceTile.GetObjectUID();
-
-    for ( const int32_t whirlpoolIndex : _whirlpoolTiles ) {
+    // The exit point from the destination whirlpool must match the entry point in the source whirlpool.
+    for ( const int32_t whirlpoolIndex : _allWhirlpools.at( entranceTile.GetObjectSpriteIndex() ) ) {
         const Maps::Tiles & whirlpoolTile = GetTiles( whirlpoolIndex );
 
-        if ( whirlpoolTile.GetObjectUID() == entranceUID || whirlpoolTile.GetHeroes() != nullptr ) {
+        if ( whirlpoolTile.GetObjectUID() == entranceTile.GetObjectUID() || whirlpoolTile.GetHeroes() != nullptr ) {
             continue;
         }
 
@@ -1301,9 +1300,15 @@ void World::PostLoad( const bool setTilePassabilities )
         }
     }
 
-    // cache data that's accessed often
+    // Cache all teleport tiles
     _allTeleporters = Maps::GetObjectPositions( MP2::OBJ_STONELITHS, true );
-    _whirlpoolTiles = Maps::GetObjectPositions( MP2::OBJ_WHIRLPOOL, true );
+
+    // Cache all tiles that contain a certain part of the whirlpool (depending on object sprite index).
+    _allWhirlpools.clear();
+
+    for ( const int32_t index : Maps::GetObjectPositions( MP2::OBJ_WHIRLPOOL, true ) ) {
+        _allWhirlpools[GetTiles( index ).GetObjectSpriteIndex()].push_back( index );
+    }
 
     resetPathfinder();
     ComputeStaticAnalysis();

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -246,7 +246,7 @@ public:
     MapsIndexes GetTeleportEndPoints( s32 ) const;
 
     s32 NextWhirlpool( s32 ) const;
-    MapsIndexes GetWhirlpoolEndPoints( s32 ) const;
+    MapsIndexes GetWhirlpoolEndPoints( int32_t index ) const;
 
     void CaptureObject( s32, int col );
     u32 CountCapturedObject( int obj, int col ) const;

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -22,6 +22,7 @@
 #ifndef H2WORLD_H
 #define H2WORLD_H
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -334,7 +335,7 @@ private:
 
     // This data isn't serialized
     Maps::Indexes _allTeleporters;
-    Maps::Indexes _whirlpoolTiles;
+    std::map<uint8_t, Maps::Indexes> _allWhirlpools; // All indexes of tiles that contain a certain part (sprite index) of the whirlpool
     std::vector<MapRegion> _regions;
     PlayerWorldPathfinder _pathfinder;
 

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -244,10 +244,10 @@ public:
     const std::string & GetRumors( void );
 
     s32 NextTeleport( s32 ) const;
-    MapsIndexes GetTeleportEndPoints( s32 ) const;
+    MapsIndexes GetTeleportEndPoints( const int32_t index ) const;
 
     s32 NextWhirlpool( s32 ) const;
-    MapsIndexes GetWhirlpoolEndPoints( int32_t index ) const;
+    MapsIndexes GetWhirlpoolEndPoints( const int32_t index ) const;
 
     void CaptureObject( s32, int col );
     u32 CountCapturedObject( int obj, int col ) const;
@@ -334,7 +334,7 @@ private:
     MapObjects map_objects;
 
     // This data isn't serialized
-    Maps::Indexes _allTeleporters;
+    Maps::Indexes _allTeleports;
     std::map<uint8_t, Maps::Indexes> _allWhirlpools; // All indexes of tiles that contain a certain part (sprite index) of the whirlpool
     std::vector<MapRegion> _regions;
     PlayerWorldPathfinder _pathfinder;

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -243,10 +243,10 @@ public:
 
     const std::string & GetRumors( void );
 
-    s32 NextTeleport( s32 ) const;
+    int32_t NextTeleport( const int32_t index ) const;
     MapsIndexes GetTeleportEndPoints( const int32_t index ) const;
 
-    s32 NextWhirlpool( s32 ) const;
+    int32_t NextWhirlpool( const int32_t index ) const;
     MapsIndexes GetWhirlpoolEndPoints( const int32_t index ) const;
 
     void CaptureObject( s32, int col );

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -334,7 +334,7 @@ private:
     MapObjects map_objects;
 
     // This data isn't serialized
-    Maps::Indexes _allTeleports;
+    std::map<uint8_t, Maps::Indexes> _allTeleports; // All indexes of tiles that contain stone liths of a certain type (sprite index)
     std::map<uint8_t, Maps::Indexes> _allWhirlpools; // All indexes of tiles that contain a certain part (sprite index) of the whirlpool
     std::vector<MapRegion> _regions;
     PlayerWorldPathfinder _pathfinder;

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -613,7 +613,7 @@ void World::ProcessNewMap()
         case MP2::OBJ_LEANTO:
         case MP2::OBJ_CAMPFIRE:
         case MP2::OBJ_FLOTSAM:
-        case MP2::OBJ_SHIPWRECKSURVIROR:
+        case MP2::OBJ_SHIPWRECKSURVIVOR:
         case MP2::OBJ_DERELICTSHIP:
         case MP2::OBJ_SHIPWRECK:
         case MP2::OBJ_GRAVEYARD:

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -429,31 +429,31 @@ void AIWorldPathfinder::processCurrentNode( std::vector<int> & nodesToExplore, i
         return;
     }
 
-    MapsIndexes teleporters;
+    MapsIndexes teleports;
 
-    // we shouldn't use teleporter at the starting tile
+    // we shouldn't use teleport at the starting tile
     if ( currentNodeIdx != _pathStart ) {
-        teleporters = world.GetTeleportEndPoints( currentNodeIdx );
+        teleports = world.GetTeleportEndPoints( currentNodeIdx );
 
-        if ( teleporters.empty() ) {
-            teleporters = world.GetWhirlpoolEndPoints( currentNodeIdx );
+        if ( teleports.empty() ) {
+            teleports = world.GetWhirlpoolEndPoints( currentNodeIdx );
         }
     }
 
     // do not check adjacent if we're going through the teleport in the middle of the path
-    if ( isFirstNode || teleporters.empty() || std::find( teleporters.begin(), teleporters.end(), currentNode._from ) != teleporters.end() ) {
+    if ( isFirstNode || teleports.empty() || std::find( teleports.begin(), teleports.end(), currentNode._from ) != teleports.end() ) {
         checkAdjacentNodes( nodesToExplore, currentNodeIdx );
     }
 
-    // special case: move through teleporters
-    for ( const int teleportIdx : teleporters ) {
+    // special case: move through teleports
+    for ( const int teleportIdx : teleports ) {
         if ( teleportIdx == _pathStart ) {
             continue;
         }
 
         WorldNode & teleportNode = _cache[teleportIdx];
 
-        // check if move is actually faster through teleporter
+        // check if move is actually faster through teleport
         if ( teleportNode._from == -1 || teleportNode._cost > currentNode._cost ) {
             teleportNode._from = currentNodeIdx;
             teleportNode._cost = currentNode._cost;
@@ -559,14 +559,14 @@ int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero )
 
             nodesToExplore.push_back( newIndex );
 
-            // If there is a teleporter on this tile, we should also consider the endpoints
-            MapsIndexes teleporters = world.GetTeleportEndPoints( newIndex );
+            // If there is a teleport on this tile, we should also consider the endpoints
+            MapsIndexes teleports = world.GetTeleportEndPoints( newIndex );
 
-            if ( teleporters.empty() ) {
-                teleporters = world.GetWhirlpoolEndPoints( newIndex );
+            if ( teleports.empty() ) {
+                teleports = world.GetWhirlpoolEndPoints( newIndex );
             }
 
-            for ( const int teleportIndex : teleporters ) {
+            for ( const int teleportIndex : teleports ) {
                 if ( tilesVisited[teleportIndex] ) {
                     continue;
                 }

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -620,6 +620,7 @@ bool AIWorldPathfinder::isHeroPossiblyBlockingWay( const Heroes & hero )
 {
     // paths have to be pre-calculated to find a spot where we're able to move
     reEvaluateIfNeeded( hero );
+
     const int32_t start = hero.GetIndex();
 
     const bool leftSideUnreachable = !Maps::isValidDirection( start, Direction::LEFT ) || _cache[start - 1]._cost == 0;
@@ -738,6 +739,7 @@ std::list<Route::Step> AIWorldPathfinder::buildPath( int targetIndex, bool isPla
 uint32_t AIWorldPathfinder::getDistance( int start, int targetIndex, int color, double armyStrength, uint8_t skill )
 {
     reEvaluateIfNeeded( start, color, armyStrength, skill );
+
     return _cache[targetIndex]._cost;
 }
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <cmath>
 #include <set>
+#include <tuple>
 
 #include "ground.h"
 #include "logging.h"
@@ -273,19 +274,12 @@ void PlayerWorldPathfinder::reset()
 
 void PlayerWorldPathfinder::reEvaluateIfNeeded( const Heroes & hero )
 {
-    const int startIndex = hero.GetIndex();
-    const int color = hero.GetColor();
-    const uint32_t skill = hero.GetLevelSkill( Skill::Secondary::PATHFINDING );
-    const uint32_t remainingMovePoints = hero.GetMovePoints();
-    const uint32_t maxMovePoints = hero.GetMaxMovePoints();
+    auto currentSettings = std::forward_as_tuple( _pathStart, _pathfindingSkill, _currentColor, _remainingMovePoints, _maxMovePoints );
+    const auto newSettings = std::make_tuple( hero.GetIndex(), static_cast<uint8_t>( hero.GetLevelSkill( Skill::Secondary::PATHFINDING ) ), hero.GetColor(),
+                                              hero.GetMovePoints(), hero.GetMaxMovePoints() );
 
-    if ( _pathStart != startIndex || _currentColor != color || _pathfindingSkill != skill || _remainingMovePoints != remainingMovePoints
-         || _maxMovePoints != maxMovePoints ) {
-        _pathStart = startIndex;
-        _currentColor = color;
-        _pathfindingSkill = skill;
-        _remainingMovePoints = remainingMovePoints;
-        _maxMovePoints = maxMovePoints;
+    if ( currentSettings != newSettings ) {
+        currentSettings = newSettings;
 
         processWorldMap();
     }
@@ -374,22 +368,13 @@ void AIWorldPathfinder::reset()
 
 void AIWorldPathfinder::reEvaluateIfNeeded( const Heroes & hero, const bool considerWhirlpools /* = false */ )
 {
-    const int startIndex = hero.GetIndex();
-    const int color = hero.GetColor();
-    const double armyStrength = hero.GetArmy().GetStrength();
-    const uint32_t skill = hero.GetLevelSkill( Skill::Secondary::PATHFINDING );
-    const uint32_t remainingMovePoints = hero.GetMovePoints();
-    const uint32_t maxMovePoints = hero.GetMaxMovePoints();
+    auto currentSettings
+        = std::forward_as_tuple( _pathStart, _pathfindingSkill, _currentColor, _remainingMovePoints, _maxMovePoints, _considerWhirlpools, _armyStrength );
+    const auto newSettings = std::make_tuple( hero.GetIndex(), static_cast<uint8_t>( hero.GetLevelSkill( Skill::Secondary::PATHFINDING ) ), hero.GetColor(),
+                                              hero.GetMovePoints(), hero.GetMaxMovePoints(), considerWhirlpools, hero.GetArmy().GetStrength() );
 
-    if ( _pathStart != startIndex || _currentColor != color || _considerWhirlpools != considerWhirlpools || std::fabs( _armyStrength - armyStrength ) > 0.001
-         || _pathfindingSkill != skill || _remainingMovePoints != remainingMovePoints || _maxMovePoints != maxMovePoints ) {
-        _pathStart = startIndex;
-        _currentColor = color;
-        _considerWhirlpools = considerWhirlpools;
-        _armyStrength = armyStrength;
-        _pathfindingSkill = skill;
-        _remainingMovePoints = remainingMovePoints;
-        _maxMovePoints = maxMovePoints;
+    if ( currentSettings != newSettings ) {
+        currentSettings = newSettings;
 
         processWorldMap();
     }
@@ -398,15 +383,12 @@ void AIWorldPathfinder::reEvaluateIfNeeded( const Heroes & hero, const bool cons
 void AIWorldPathfinder::reEvaluateIfNeeded( const int start, const int color, const double armyStrength, const uint8_t skill,
                                             const bool considerWhirlpools /* = false */ )
 {
-    if ( _pathStart != start || _currentColor != color || _considerWhirlpools != considerWhirlpools || std::fabs( _armyStrength - armyStrength ) > 0.001
-         || _pathfindingSkill != skill ) {
-        _pathStart = start;
-        _currentColor = color;
-        _considerWhirlpools = considerWhirlpools;
-        _armyStrength = armyStrength;
-        _pathfindingSkill = skill;
-        _remainingMovePoints = 0;
-        _maxMovePoints = 0;
+    auto currentSettings
+        = std::forward_as_tuple( _pathStart, _pathfindingSkill, _currentColor, _remainingMovePoints, _maxMovePoints, _considerWhirlpools, _armyStrength );
+    const auto newSettings = std::make_tuple( start, skill, color, 0U, 0U, considerWhirlpools, armyStrength );
+
+    if ( currentSettings != newSettings ) {
+        currentSettings = newSettings;
 
         processWorldMap();
     }

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -553,7 +553,7 @@ int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero, const bool cons
     return -1;
 }
 
-int AIWorldPathfinder::getNeareastTileToMove( const Heroes & hero, const bool considerWhirlpools )
+int AIWorldPathfinder::getNearestTileToMove( const Heroes & hero, const bool considerWhirlpools )
 {
     // paths have to be pre-calculated to find a spot where we're able to move
     reEvaluateIfNeeded( hero, considerWhirlpools );

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -265,8 +265,9 @@ void PlayerWorldPathfinder::reset()
 
     if ( _pathStart != -1 ) {
         _pathStart = -1;
-        _currentColor = Color::NONE;
+
         _pathfindingSkill = Skill::Level::EXPERT;
+        _currentColor = Color::NONE;
         _remainingMovePoints = 0;
         _maxMovePoints = 0;
     }
@@ -357,12 +358,14 @@ void AIWorldPathfinder::reset()
 
     if ( _pathStart != -1 ) {
         _pathStart = -1;
-        _currentColor = Color::NONE;
-        _considerWhirlpools = false;
-        _armyStrength = -1;
+
         _pathfindingSkill = Skill::Level::EXPERT;
+        _currentColor = Color::NONE;
         _remainingMovePoints = 0;
         _maxMovePoints = 0;
+
+        _considerWhirlpools = false;
+        _armyStrength = -1;
     }
 }
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -363,17 +363,15 @@ void AIWorldPathfinder::reset()
         _remainingMovePoints = 0;
         _maxMovePoints = 0;
 
-        _considerWhirlpools = false;
         _armyStrength = -1;
     }
 }
 
-void AIWorldPathfinder::reEvaluateIfNeeded( const Heroes & hero, const bool considerWhirlpools )
+void AIWorldPathfinder::reEvaluateIfNeeded( const Heroes & hero )
 {
-    auto currentSettings
-        = std::forward_as_tuple( _pathStart, _pathfindingSkill, _currentColor, _remainingMovePoints, _maxMovePoints, _considerWhirlpools, _armyStrength );
+    auto currentSettings = std::forward_as_tuple( _pathStart, _pathfindingSkill, _currentColor, _remainingMovePoints, _maxMovePoints, _armyStrength );
     const auto newSettings = std::make_tuple( hero.GetIndex(), static_cast<uint8_t>( hero.GetLevelSkill( Skill::Secondary::PATHFINDING ) ), hero.GetColor(),
-                                              hero.GetMovePoints(), hero.GetMaxMovePoints(), considerWhirlpools, hero.GetArmy().GetStrength() );
+                                              hero.GetMovePoints(), hero.GetMaxMovePoints(), hero.GetArmy().GetStrength() );
 
     if ( currentSettings != newSettings ) {
         currentSettings = newSettings;
@@ -382,11 +380,10 @@ void AIWorldPathfinder::reEvaluateIfNeeded( const Heroes & hero, const bool cons
     }
 }
 
-void AIWorldPathfinder::reEvaluateIfNeeded( const int start, const int color, const double armyStrength, const uint8_t skill, const bool considerWhirlpools )
+void AIWorldPathfinder::reEvaluateIfNeeded( const int start, const int color, const double armyStrength, const uint8_t skill )
 {
-    auto currentSettings
-        = std::forward_as_tuple( _pathStart, _pathfindingSkill, _currentColor, _remainingMovePoints, _maxMovePoints, _considerWhirlpools, _armyStrength );
-    const auto newSettings = std::make_tuple( start, skill, color, 0U, 0U, considerWhirlpools, armyStrength );
+    auto currentSettings = std::forward_as_tuple( _pathStart, _pathfindingSkill, _currentColor, _remainingMovePoints, _maxMovePoints, _armyStrength );
+    const auto newSettings = std::make_tuple( start, skill, color, 0U, 0U, armyStrength );
 
     if ( currentSettings != newSettings ) {
         currentSettings = newSettings;
@@ -438,7 +435,7 @@ void AIWorldPathfinder::processCurrentNode( std::vector<int> & nodesToExplore, i
     if ( currentNodeIdx != _pathStart ) {
         teleporters = world.GetTeleportEndPoints( currentNodeIdx );
 
-        if ( teleporters.empty() && _considerWhirlpools ) {
+        if ( teleporters.empty() ) {
             teleporters = world.GetWhirlpoolEndPoints( currentNodeIdx );
         }
     }
@@ -498,10 +495,10 @@ uint32_t AIWorldPathfinder::getMovementPenalty( int src, int dst, int direction 
     return defaultPenalty;
 }
 
-int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero, const bool considerWhirlpools )
+int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero )
 {
     // paths have to be pre-calculated to find a spot where we're able to move
-    reEvaluateIfNeeded( hero, considerWhirlpools );
+    reEvaluateIfNeeded( hero );
 
     const int start = hero.GetIndex();
     const int scouteValue = hero.GetScoute();
@@ -565,7 +562,7 @@ int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero, const bool cons
             // If there is a teleporter on this tile, we should also consider the endpoints
             MapsIndexes teleporters = world.GetTeleportEndPoints( newIndex );
 
-            if ( teleporters.empty() && _considerWhirlpools ) {
+            if ( teleporters.empty() ) {
                 teleporters = world.GetWhirlpoolEndPoints( newIndex );
             }
 
@@ -584,10 +581,10 @@ int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero, const bool cons
     return -1;
 }
 
-int AIWorldPathfinder::getNearestTileToMove( const Heroes & hero, const bool considerWhirlpools )
+int AIWorldPathfinder::getNearestTileToMove( const Heroes & hero )
 {
     // paths have to be pre-calculated to find a spot where we're able to move
-    reEvaluateIfNeeded( hero, considerWhirlpools );
+    reEvaluateIfNeeded( hero );
 
     const int start = hero.GetIndex();
 
@@ -619,10 +616,10 @@ int AIWorldPathfinder::getNearestTileToMove( const Heroes & hero, const bool con
     return -1;
 }
 
-bool AIWorldPathfinder::isHeroPossiblyBlockingWay( const Heroes & hero, const bool considerWhirlpools )
+bool AIWorldPathfinder::isHeroPossiblyBlockingWay( const Heroes & hero )
 {
     // paths have to be pre-calculated to find a spot where we're able to move
-    reEvaluateIfNeeded( hero, considerWhirlpools );
+    reEvaluateIfNeeded( hero );
     const int32_t start = hero.GetIndex();
 
     const bool leftSideUnreachable = !Maps::isValidDirection( start, Direction::LEFT ) || _cache[start - 1]._cost == 0;
@@ -740,7 +737,7 @@ std::list<Route::Step> AIWorldPathfinder::buildPath( int targetIndex, bool isPla
 
 uint32_t AIWorldPathfinder::getDistance( int start, int targetIndex, int color, double armyStrength, uint8_t skill )
 {
-    reEvaluateIfNeeded( start, color, armyStrength, skill, false );
+    reEvaluateIfNeeded( start, color, armyStrength, skill );
     return _cache[targetIndex]._cost;
 }
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -690,8 +690,12 @@ std::list<Route::Step> AIWorldPathfinder::buildPath( int targetIndex, bool isPla
         }
     }
 
-    // Cut the path to the last valid tile/obstacle if not in planning mode
-    if ( !isPlanningMode && lastValidNode != targetIndex ) {
+    // Check a corner case when a path is blocked by something else and the destination is not reachable anymore.
+    if ( currentNode == -1 && path.size() == 1 ) {
+        path.clear();
+    }
+    // Cut the path to the last valid tile/obstacle if not in planning mode.
+    else if ( !isPlanningMode && lastValidNode != targetIndex ) {
         path.erase( std::find_if( path.begin(), path.end(), [&lastValidNode]( const Route::Step & step ) { return step.GetFrom() == lastValidNode; } ), path.end() );
     }
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -369,7 +369,7 @@ void AIWorldPathfinder::reset()
     }
 }
 
-void AIWorldPathfinder::reEvaluateIfNeeded( const Heroes & hero, const bool considerWhirlpools /* = false */ )
+void AIWorldPathfinder::reEvaluateIfNeeded( const Heroes & hero, const bool considerWhirlpools )
 {
     auto currentSettings
         = std::forward_as_tuple( _pathStart, _pathfindingSkill, _currentColor, _remainingMovePoints, _maxMovePoints, _considerWhirlpools, _armyStrength );
@@ -383,8 +383,7 @@ void AIWorldPathfinder::reEvaluateIfNeeded( const Heroes & hero, const bool cons
     }
 }
 
-void AIWorldPathfinder::reEvaluateIfNeeded( const int start, const int color, const double armyStrength, const uint8_t skill,
-                                            const bool considerWhirlpools /* = false */ )
+void AIWorldPathfinder::reEvaluateIfNeeded( const int start, const int color, const double armyStrength, const uint8_t skill, const bool considerWhirlpools )
 {
     auto currentSettings
         = std::forward_as_tuple( _pathStart, _pathfindingSkill, _currentColor, _remainingMovePoints, _maxMovePoints, _considerWhirlpools, _armyStrength );
@@ -492,10 +491,10 @@ uint32_t AIWorldPathfinder::getMovementPenalty( int src, int dst, int direction 
     return defaultPenalty;
 }
 
-int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero )
+int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero, const bool considerWhirlpools )
 {
     // paths have to be pre-calculated to find a spot where we're able to move
-    reEvaluateIfNeeded( hero );
+    reEvaluateIfNeeded( hero, considerWhirlpools );
     const int start = hero.GetIndex();
 
     const Directions & directions = Direction::All();
@@ -549,10 +548,10 @@ int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero )
     return -1;
 }
 
-int AIWorldPathfinder::getNeareastTileToMove( const Heroes & hero )
+int AIWorldPathfinder::getNeareastTileToMove( const Heroes & hero, const bool considerWhirlpools )
 {
     // paths have to be pre-calculated to find a spot where we're able to move
-    reEvaluateIfNeeded( hero );
+    reEvaluateIfNeeded( hero, considerWhirlpools );
     const int start = hero.GetIndex();
 
     Directions directions = Direction::All();
@@ -579,10 +578,10 @@ int AIWorldPathfinder::getNeareastTileToMove( const Heroes & hero )
     return -1;
 }
 
-bool AIWorldPathfinder::isHeroPossiblyBlockingWay( const Heroes & hero )
+bool AIWorldPathfinder::isHeroPossiblyBlockingWay( const Heroes & hero, const bool considerWhirlpools )
 {
     // paths have to be pre-calculated to find a spot where we're able to move
-    reEvaluateIfNeeded( hero );
+    reEvaluateIfNeeded( hero, considerWhirlpools );
     const int32_t start = hero.GetIndex();
 
     const bool leftSideUnreachable = !Maps::isValidDirection( start, Direction::LEFT ) || _cache[start - 1]._cost == 0;
@@ -696,7 +695,7 @@ std::list<Route::Step> AIWorldPathfinder::buildPath( int targetIndex, bool isPla
 
 uint32_t AIWorldPathfinder::getDistance( int start, int targetIndex, int color, double armyStrength, uint8_t skill )
 {
-    reEvaluateIfNeeded( start, color, armyStrength, skill );
+    reEvaluateIfNeeded( start, color, armyStrength, skill, false );
     return _cache[targetIndex]._cost;
 }
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -607,8 +607,8 @@ int AIWorldPathfinder::getNearestTileToMove( const Heroes & hero )
             continue;
         }
 
-        const MapsIndexes & monsters = Maps::GetTilesUnderProtection( newIndex );
-        if ( _cache[newIndex]._cost && monsters.empty() ) {
+        // Tile is reachable and not guarded by monsters
+        if ( _cache[newIndex]._cost > 0 && Maps::GetTilesUnderProtection( newIndex ).empty() ) {
             return newIndex;
         }
     }

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -429,10 +429,15 @@ void AIWorldPathfinder::processCurrentNode( std::vector<int> & nodesToExplore, i
 
     // always allow move from the starting spot to cover edge case if got there before tile became blocked/protected
     if ( isFirstNode || ( !isProtected && !isTileBlockedForAIWithArmy( currentNodeIdx, _currentColor, _armyStrength ) ) ) {
-        MapsIndexes teleporters = world.GetTeleportEndPoints( currentNodeIdx );
+        MapsIndexes teleporters;
 
-        if ( teleporters.empty() && _considerWhirlpools ) {
-            teleporters = world.GetWhirlpoolEndPoints( currentNodeIdx );
+        // we shouldn't use teleporter at the starting tile
+        if ( currentNodeIdx != _pathStart ) {
+            teleporters = world.GetTeleportEndPoints( currentNodeIdx );
+
+            if ( teleporters.empty() && _considerWhirlpools ) {
+                teleporters = world.GetWhirlpoolEndPoints( currentNodeIdx );
+            }
         }
 
         // do not check adjacent if we're going through the teleport in the middle of the path

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -102,14 +102,14 @@ public:
 
     void reset() override;
 
-    void reEvaluateIfNeeded( const Heroes & hero, const bool considerWhirlpools = false );
-    void reEvaluateIfNeeded( const int start, const int color, const double armyStrength, const uint8_t skill, const bool considerWhirlpools = false );
-    int getFogDiscoveryTile( const Heroes & hero );
+    void reEvaluateIfNeeded( const Heroes & hero, const bool considerWhirlpools );
+    void reEvaluateIfNeeded( const int start, const int color, const double armyStrength, const uint8_t skill, const bool considerWhirlpools );
+    int getFogDiscoveryTile( const Heroes & hero, const bool considerWhirlpools );
 
     // Used for cases when heroes are stuck because one hero might be blocking the way and we have to move him.
-    int getNeareastTileToMove( const Heroes & hero );
+    int getNeareastTileToMove( const Heroes & hero, const bool considerWhirlpools );
 
-    bool isHeroPossiblyBlockingWay( const Heroes & hero );
+    bool isHeroPossiblyBlockingWay( const Heroes & hero, const bool considerWhirlpools );
 
     std::vector<IndexObject> getObjectsOnTheWay( int targetIndex, bool checkAdjacent = false );
 

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -57,11 +57,11 @@ public:
     virtual void checkWorldSize();
 
 protected:
-    void processWorldMap( int pathStart );
-    void checkAdjacentNodes( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx );
+    void processWorldMap();
+    void checkAdjacentNodes( std::vector<int> & nodesToExplore, int currentNodeIdx );
 
     // This method defines pathfinding rules. This has to be implemented by the derived class.
-    virtual void processCurrentNode( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx ) = 0;
+    virtual void processCurrentNode( std::vector<int> & nodesToExplore, int currentNodeIdx ) = 0;
 
     // Calculates the movement penalty when moving from the src tile to the adjacent dst tile in the specified direction.
     // If the "last move" logic should be taken into account (when performing pathfinding for a real hero on the map),
@@ -90,7 +90,7 @@ public:
     std::list<Route::Step> buildPath( int targetIndex ) const;
 
 private:
-    void processCurrentNode( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx ) override;
+    void processCurrentNode( std::vector<int> & nodesToExplore, int currentNodeIdx ) override;
 };
 
 class AIWorldPathfinder : public WorldPathfinder
@@ -102,8 +102,8 @@ public:
 
     void reset() override;
 
-    void reEvaluateIfNeeded( int start, int color, double armyStrength, uint8_t skill );
-    void reEvaluateIfNeeded( const Heroes & hero );
+    void reEvaluateIfNeeded( const Heroes & hero, const bool considerWhirlpools = false );
+    void reEvaluateIfNeeded( const int start, const int color, const double armyStrength, const uint8_t skill, const bool considerWhirlpools = false );
     int getFogDiscoveryTile( const Heroes & hero );
 
     // Used for cases when heroes are stuck because one hero might be blocking the way and we have to move him.
@@ -130,7 +130,7 @@ public:
     void setArmyStrengthMultplier( const double multiplier );
 
 private:
-    void processCurrentNode( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx ) override;
+    void processCurrentNode( std::vector<int> & nodesToExplore, int currentNodeIdx ) override;
 
     // Adds special logic for AI-controlled heroes to encourage them to overcome water obstacles using boats.
     // If this logic should be taken into account (when performing pathfinding for a real hero on the map),
@@ -138,6 +138,7 @@ private:
     // about the hero's remaining movement points.
     uint32_t getMovementPenalty( int src, int dst, int direction ) const override;
 
+    bool _considerWhirlpools = false;
     double _armyStrength = -1;
     double _advantage = 1.0;
     Army _temporaryArmy; // for internal calculations

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -102,14 +102,14 @@ public:
 
     void reset() override;
 
-    void reEvaluateIfNeeded( const Heroes & hero, const bool considerWhirlpools );
-    void reEvaluateIfNeeded( const int start, const int color, const double armyStrength, const uint8_t skill, const bool considerWhirlpools );
-    int getFogDiscoveryTile( const Heroes & hero, const bool considerWhirlpools );
+    void reEvaluateIfNeeded( const Heroes & hero );
+    void reEvaluateIfNeeded( const int start, const int color, const double armyStrength, const uint8_t skill );
+    int getFogDiscoveryTile( const Heroes & hero );
 
     // Used for cases when heroes are stuck because one hero might be blocking the way and we have to move him.
-    int getNearestTileToMove( const Heroes & hero, const bool considerWhirlpools );
+    int getNearestTileToMove( const Heroes & hero );
 
-    bool isHeroPossiblyBlockingWay( const Heroes & hero, const bool considerWhirlpools );
+    bool isHeroPossiblyBlockingWay( const Heroes & hero );
 
     std::vector<IndexObject> getObjectsOnTheWay( int targetIndex, bool checkAdjacent = false );
 
@@ -138,7 +138,6 @@ private:
     // about the hero's remaining movement points.
     uint32_t getMovementPenalty( int src, int dst, int direction ) const override;
 
-    bool _considerWhirlpools = false;
     double _armyStrength = -1;
     double _advantage = 1.0;
     Army _temporaryArmy; // for internal calculations

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -107,7 +107,7 @@ public:
     int getFogDiscoveryTile( const Heroes & hero, const bool considerWhirlpools );
 
     // Used for cases when heroes are stuck because one hero might be blocking the way and we have to move him.
-    int getNeareastTileToMove( const Heroes & hero, const bool considerWhirlpools );
+    int getNearestTileToMove( const Heroes & hero, const bool considerWhirlpools );
 
     bool isHeroPossiblyBlockingWay( const Heroes & hero, const bool considerWhirlpools );
 

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -337,7 +337,7 @@ void World::ComputeStaticAnalysis()
         for ( const MapRegionNode & node : reg._nodes ) {
             vec_tiles[node.index].UpdateRegion( node.type );
 
-            // connect regions through teleporters
+            // connect regions through teleports
             if ( node.mapObject == MP2::OBJ_STONELITHS ) {
                 const MapsIndexes & exits = GetTeleportEndPoints( node.index );
                 for ( const int exitIndex : exits ) {

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -338,12 +338,18 @@ void World::ComputeStaticAnalysis()
             vec_tiles[node.index].UpdateRegion( node.type );
 
             // connect regions through teleports
+            MapsIndexes exits;
+
             if ( node.mapObject == MP2::OBJ_STONELITHS ) {
-                const MapsIndexes & exits = GetTeleportEndPoints( node.index );
-                for ( const int exitIndex : exits ) {
-                    // neighbours is a set that will force the uniqness
-                    reg._neighbours.insert( vec_tiles[exitIndex].GetRegion() );
-                }
+                exits = GetTeleportEndPoints( node.index );
+            }
+            else if ( node.mapObject == MP2::OBJ_WHIRLPOOL ) {
+                exits = GetWhirlpoolEndPoints( node.index );
+            }
+
+            for ( const int exitIndex : exits ) {
+                // neighbours is a set that will force the uniqness
+                reg._neighbours.insert( vec_tiles[exitIndex].GetRegion() );
             }
         }
     }

--- a/src/fheroes2/world/world_regions.h
+++ b/src/fheroes2/world/world_regions.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <set>
 #include <vector>
 
@@ -51,7 +52,7 @@ struct MapRegion
 public:
     uint32_t _id = REGION_NODE_FOUND;
     bool _isWater = false;
-    std::set<int> _neighbours;
+    std::set<uint32_t> _neighbours;
     std::vector<MapRegionNode> _nodes;
     size_t _lastProcessedNode = 0;
 


### PR DESCRIPTION
related to #4509

Continuation of #4894. That's how it currently works ([WRLTEST.ZIP](https://github.com/ihhub/fheroes2/files/7824054/WRLTEST.ZIP)):

<img width="1247" alt="Path through the whirlpool" src="https://user-images.githubusercontent.com/32623900/148433433-423736c9-7354-424d-892a-2b9a812a8c86.png">

The `AIWorldPathfinder::reEvaluateIfNeeded()` now has optional parameter `considerWhirlpools` (`false` by default).

The debugging principle is just like in #4894 (right-click by the mouse when debug hero is selected).

Please note that `World::GetWhirlpoolEndPoints()` has been rewritten and now it is perfectly deterministic, so it can be used just like `World::GetTeleportEndPoints()` in the AI-related code.

BTW one more funny note: since whirlpools are multi-tile objects, the pathfinder currently chooses the "best tile" of the whirlpool for diving and surfacing from the water.  This leads to the following trick: instead of going around the whirlpool, pathfinder may (and will) choose to dive from the one side of the whirlpool and then emerge from the other side, thus spending 0 move points while traversing the whirlpool :)

Hi @ihhub what do you think?