### PR TITLE
CMake improvements

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,11 +13,11 @@ jobs:
         - name: Linux SDL1
           os: ubuntu-latest
           sdl_version: SDL
-          dependencies: libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev
+          dependencies: libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev gettext
         - name: Linux SDL2
           os: ubuntu-latest
           sdl_version: SDL2
-          dependencies: libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev
+          dependencies: libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev gettext
         - name: macOS SDL1
           os: macos-latest
           sdl_version: SDL

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,12 @@
 *.out
 *.app
 
-# gettext Machine Objects
+# GNU gettext
+*.pot
+*.pot~
+*.po~
+*.po.tmp
+*.po.tmp~
 *.mo
 
 ## Ignore Visual Studio temporary files, build results, and
@@ -68,7 +73,6 @@ files/save
 # Never put 'fheroes2' in this list. It breaks SonarQube analysis
 fheroes2.cfg
 fheroes2.bin
-fheroes2.pot
 
 # demo directory
 script/demo/demo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-# For descent FetchContent()
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.14) # For descent FetchContent()
 
 project(fheroes2 VERSION 0.9.11 LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 11)
@@ -11,22 +10,24 @@ endif()
 include(GNUInstallDirs)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
+#
 # Compile-time options
+#
 set(SDL_VERSIONS SDL SDL2)
 set(USE_SDL_VERSION SDL2 CACHE STRING "SDL version")
 set_property(CACHE USE_SDL_VERSION PROPERTY STRINGS ${SDL_VERSIONS})
 
-option(ENABLE_IMAGE   "Enable SDL/SDL2 Image support (requires libpng)" ON)
-option(ENABLE_TOOLS   "Enable additional tools" OFF)
-option(GET_HOMM2_DEMO "Fetch and install HoMM II demo data" OFF)
-
-option(USE_SYSTEM_LIBSMACKER "Use system libsmacker instead of bundled version" OFF)
-
-option(FHEROES2_STRICT_COMPILATION "Enable -Werror strict compilation" OFF)
-
 set(CONFIGURE_FHEROES2_DATA "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}" CACHE STRING "System fheroes2 game directory")
 
-# Find libraries and enable/disable features
+option(ENABLE_IMAGE "Enable SDL/SDL2 Image support (requires libpng)" ON)
+option(ENABLE_TOOLS "Enable additional tools" OFF)
+option(GET_HOMM2_DEMO "Fetch and install HoMM II demo data" OFF)
+option(USE_SYSTEM_LIBSMACKER "Use system libsmacker instead of bundled version" OFF)
+option(FHEROES2_STRICT_COMPILATION "Enable -Werror strict compilation" OFF)
+
+#
+# Library & feature detection
+#
 find_package(${USE_SDL_VERSION} REQUIRED)
 find_package(${USE_SDL_VERSION}_mixer REQUIRED)
 find_package(ZLIB REQUIRED)
@@ -37,10 +38,43 @@ if(ENABLE_IMAGE)
 	find_package(PNG REQUIRED)
 endif(ENABLE_IMAGE)
 
+#
+# Source files
+#
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_subdirectory(src)
 
+#
+# Translation files
+#
+if(NOT WIN32)
+	find_program(MAKE_EXECUTABLE make)
+	find_program(SED_EXECUTABLE sed)
+	find_program(XGETTEXT_EXECUTABLE xgettext)
+
+	file(GLOB_RECURSE ALL_SOURCES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/src/*.cpp)
+	add_custom_target(
+		${PROJECT_NAME}.pot
+		ALL
+		COMMAND ${XGETTEXT_EXECUTABLE} -d ${PROJECT_NAME} -C -F -k_ -k_n:1,2 -o ${PROJECT_NAME}.pot ${ALL_SOURCES}
+		COMMAND ${SED_EXECUTABLE} -i~ -e "s/, c-format//" ${PROJECT_NAME}.pot
+		DEPENDS fheroes2
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/dist
+		)
+
+	add_custom_target(
+		translations
+		ALL
+		COMMAND ${MAKE_EXECUTABLE}
+		DEPENDS ${PROJECT_NAME}.pot
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/files/lang
+		)
+endif(NOT WIN32)
+
+#
+# Installation of auxiliary files
+#
 file(GLOB H2D_FILES ${CMAKE_SOURCE_DIR}/files/data/*.h2d)
 install(
 	FILES ${H2D_FILES}
@@ -79,6 +113,12 @@ if(WIN32)
 		DESTINATION ${CMAKE_INSTALL_DOCDIR}/homm2
 		)
 else(WIN32)
+	file(GLOB MO_FILES ${CMAKE_SOURCE_DIR}/files/lang/*.mo)
+	install(
+		FILES ${MO_FILES}
+		DESTINATION ${CONFIGURE_FHEROES2_DATA}/files/lang
+		)
+
 	install(
 		FILES script/demo/download_demo_version.sh
 		PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,10 +80,11 @@ install(
 	DESTINATION ${CONFIGURE_FHEROES2_DATA}
 	)
 
-file(GLOB H2D_FILES files/data/*.h2d)
 install(
-	FILES ${H2D_FILES}
+	DIRECTORY files/data/
 	DESTINATION ${CONFIGURE_FHEROES2_DATA}/files/data
+	FILES_MATCHING
+	PATTERN *.h2d
 	)
 
 install(
@@ -119,10 +120,11 @@ if(WIN32)
 		DESTINATION ${CMAKE_INSTALL_DOCDIR}/homm2
 		)
 else(WIN32)
-	file(GLOB MO_FILES files/lang/*.mo)
 	install(
-		FILES ${MO_FILES}
+		DIRECTORY files/lang/
 		DESTINATION ${CONFIGURE_FHEROES2_DATA}/files/lang
+		FILES_MATCHING
+		PATTERN *.mo
 		)
 
 	install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,11 +75,17 @@ endif(NOT WIN32)
 #
 # Installation of auxiliary files
 #
+install(
+	FILES fheroes2.key
+	DESTINATION ${CONFIGURE_FHEROES2_DATA}
+	)
+
 file(GLOB H2D_FILES ${CMAKE_SOURCE_DIR}/files/data/*.h2d)
 install(
 	FILES ${H2D_FILES}
 	DESTINATION ${CONFIGURE_FHEROES2_DATA}/files/data
 	)
+
 install(
 	FILES docs/README.txt LICENSE changelog.txt
 	DESTINATION ${CMAKE_INSTALL_DOCDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,6 @@ if(NOT WIN32)
 	file(GLOB_RECURSE ALL_SOURCES CONFIGURE_DEPENDS src/*.cpp)
 	add_custom_target(
 		${PROJECT_NAME}.pot
-		ALL
 		COMMAND ${XGETTEXT_EXECUTABLE} -d ${PROJECT_NAME} -C -F -k_ -k_n:1,2 -o ${PROJECT_NAME}.pot ${ALL_SOURCES}
 		COMMAND ${SED_EXECUTABLE} -i~ -e "s/, c-format//" ${PROJECT_NAME}.pot
 		DEPENDS fheroes2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ if(NOT WIN32)
 	find_program(SED_EXECUTABLE sed)
 	find_program(XGETTEXT_EXECUTABLE xgettext)
 
-	file(GLOB_RECURSE ALL_SOURCES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/src/*.cpp)
+	file(GLOB_RECURSE ALL_SOURCES CONFIGURE_DEPENDS src/*.cpp)
 	add_custom_target(
 		${PROJECT_NAME}.pot
 		ALL
@@ -80,7 +80,7 @@ install(
 	DESTINATION ${CONFIGURE_FHEROES2_DATA}
 	)
 
-file(GLOB H2D_FILES ${CMAKE_SOURCE_DIR}/files/data/*.h2d)
+file(GLOB H2D_FILES files/data/*.h2d)
 install(
 	FILES ${H2D_FILES}
 	DESTINATION ${CONFIGURE_FHEROES2_DATA}/files/data
@@ -119,7 +119,7 @@ if(WIN32)
 		DESTINATION ${CMAKE_INSTALL_DOCDIR}/homm2
 		)
 else(WIN32)
-	file(GLOB MO_FILES ${CMAKE_SOURCE_DIR}/files/lang/*.mo)
+	file(GLOB MO_FILES files/lang/*.mo)
 	install(
 		FILES ${MO_FILES}
 		DESTINATION ${CONFIGURE_FHEROES2_DATA}/files/lang

--- a/src/dist/Makefile
+++ b/src/dist/Makefile
@@ -59,7 +59,6 @@ pot: $(wildcard $(SEARCH))
 	@echo "gen: $(POT)"
 	@xgettext -d $(TARGET) -C -F -k_ -k_n:1,2 -o $(POT) $(sort $(wildcard $(SEARCH)))
 	@sed -i~ -e 's/, c-format//' $(POT)
-	@rm -f $(POT)~
 
 $(RES): $(RC)
 	@echo "gen: $@"
@@ -73,4 +72,4 @@ VPATH := $(SOURCEDIR)
 include $(wildcard *.d)
 
 clean:
-	rm -f *.pot *.o *.d *.exe $(TARGET) $(RES)
+	rm -f *.pot *.pot~ *.o *.d *.exe $(TARGET) $(RES)


### PR DESCRIPTION
* Now CMake is able to regenerate and install translation files (not the ideal solution I believe, because it uses custom targets to generate the `src/dist/fheroes2.pot` and run `make` in the `files/lang` to update existing `.po` files and generate `.mo` files, and changing anything in the source tree is bad manners for CMake), but it's better than nothing. Not supported on WIN32 though.
* Now CMake is able to install the `fheroes2.key`, what was previously overlooked.