### PR TITLE
experimental option "heroes: random skills on level up"

### DIFF
--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -171,6 +171,7 @@ void Dialog::ExtSettings( bool readonly )
     states.push_back( Settings::HEROES_REMEMBER_POINTS_RETREAT );
     states.push_back( Settings::HEROES_TRANSCRIBING_SCROLLS );
     states.push_back( Settings::HEROES_ARENA_ANY_SKILLS );
+    states.push_back( Settings::HEROES_RANDOM_LEVEL_UP );
 
     states.push_back( Settings::CASTLE_ALLOW_GUARDIANS );
     states.push_back( Settings::CASTLE_MAGEGUILD_POINTS_TURN );

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1950,6 +1950,8 @@ HeroSeedsForLevelUp Heroes::GetSeedsForLevelUp() const
      * */
 
     size_t hash = world.GetMapSeed();
+    if ( Settings::Get().ExtHeroRandomLevelUp() )
+	fheroes2::hashCombine( hash, Rand::Get( std::numeric_limits<uint32_t>::max() ) );
     fheroes2::hashCombine( hash, hid );
     fheroes2::hashCombine( hash, _race );
     fheroes2::hashCombine( hash, attack );

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -981,6 +981,8 @@ std::string Settings::ExtName( const uint32_t settingId )
         return _( "heroes: allow transcribing scrolls (needs: Eye Eagle skill)" );
     case Settings::HEROES_ARENA_ANY_SKILLS:
         return _( "heroes: in Arena can choose any of primary skills" );
+    case Settings::HEROES_RANDOM_LEVEL_UP:
+        return _( "heroes: random skills on level up" );
     case Settings::BATTLE_SHOW_ARMY_ORDER:
         return _( "battle: show army order" );
     case Settings::BATTLE_SOFT_WAITING:
@@ -1103,6 +1105,11 @@ bool Settings::ExtHeroRecruitCostDependedFromLevel() const
 bool Settings::ExtHeroRememberPointsForRetreating() const
 {
     return ExtModes( HEROES_REMEMBER_POINTS_RETREAT );
+}
+
+bool Settings::ExtHeroRandomLevelUp() const
+{
+    return ExtModes( HEROES_RANDOM_LEVEL_UP );
 }
 
 bool Settings::ExtBattleShowDamage() const

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -99,7 +99,8 @@ public:
         BATTLE_SHOW_ARMY_ORDER = 0x40004000,
         BATTLE_DETERMINISTIC_RESULT = 0x40008000,
         BATTLE_SOFT_WAITING = 0x40010000,
-        BATTLE_REVERSE_WAIT_ORDER = 0x40020000
+        BATTLE_REVERSE_WAIT_ORDER = 0x40020000,
+        HEROES_RANDOM_LEVEL_UP = 0x40040000,
     };
 
     Settings( const Settings & ) = delete;
@@ -173,6 +174,7 @@ public:
     bool ExtHeroRememberPointsForRetreating() const;
     bool ExtHeroAllowTranscribingScroll() const;
     bool ExtHeroArenaCanChoiseAnySkills() const;
+    bool ExtHeroRandomLevelUp() const;
     bool ExtWorldShowTerrainPenalty() const;
     bool ExtWorldScouteExtended() const;
     bool ExtWorldAllowSetGuardian() const;


### PR DESCRIPTION
Predetermined hero skills build that appeared in 0.9.1 is no fun. I understand that this is needed to replicate the original game. However I do not like this change that produces non-perfect hero builds. Proposed patch restores old pre-0.9.1 behavior as an experimental option "heroes: random skills on level up"
You may need to fix the value for the HEROES_RANDOM_LEVEL_UP constant in 
+++ b/src/fheroes2/system/settings.h
+        HEROES_RANDOM_LEVEL_UP = 0x40040000,
as I did not get the logic and just chose the next largest one.