### PR TITLE
Migrate clang-tidy to clang 12

### DIFF
--- a/.github/workflows/clang_analyzer.yml
+++ b/.github/workflows/clang_analyzer.yml
@@ -20,7 +20,12 @@ jobs:
       run: |
         sudo update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-10 100
     - name: Analyze
-      run: scan-build --status-bugs -v make -j 2
+      run: scan-build --status-bugs -v -o scan-build-result make -j 2
       env:
         FHEROES2_STRICT_COMPILATION: ON
         WITH_TOOLS: ON
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: scan-build-result
+        path: scan-build-result/

--- a/.github/workflows/clang_analyzer.yml
+++ b/.github/workflows/clang_analyzer.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   clang:
     name: Clang Analyzer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
@@ -15,7 +15,10 @@ jobs:
     - name: Install dependencies and clang-tools
       run: |
         sudo apt-get -y update
-        sudo apt-get -y install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext clang-tools
+        sudo apt-get -y install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext clang-tools-10
+    - name: Setup clang-tools
+      run: |
+        sudo update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-10 100
     - name: Analyze
       run: scan-build --status-bugs -v make -j 2
       env:

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -17,11 +17,11 @@ jobs:
     - name: Install dependencies and clang-tidy
       run: |
         sudo apt-get -y update
-        sudo apt-get -y install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext clang-tidy-11
+        sudo apt-get -y install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext clang-tidy-12
     - name: Setup clang-tidy
       run: |
-        sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-11 100
-        sudo update-alternatives --install /usr/bin/clang-tidy-diff clang-tidy-diff /usr/bin/clang-tidy-diff-11.py 100
+        sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-12 100
+        sudo update-alternatives --install /usr/bin/clang-tidy-diff clang-tidy-diff /usr/bin/clang-tidy-diff-12.py 100
     - name: Prepare compile_commands.json
       run: |
         cmake -B build -DCMAKE_BUILD_TYPE=Release -DUSE_SDL_VERSION=SDL2 -DENABLE_IMAGE=ON -DENABLE_TOOLS=ON -DFHEROES2_STRICT_COMPILATION=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON


### PR DESCRIPTION
Also tie the `scan-build` to clang 10 so far (it gives two false positives(?) in the `engine/image.cpp` on newer clang versions, so I don't want to upgrade it yet) and add the ability to upload analysis results as job artifact.