### PR TITLE
PlayerWorldPathfinder::processCurrentNode(): always check that the candidate tile is not blocked, even if it is guarded by a nearby monster

### DIFF
--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -324,11 +324,6 @@ std::list<Route::Step> PlayerWorldPathfinder::buildPath( int targetIndex ) const
 // Follows regular (for user's interface) passability rules
 void PlayerWorldPathfinder::processCurrentNode( std::vector<int> & nodesToExplore, int pathStart, int currentNodeIdx )
 {
-    // if current tile contains a monster or a barrier, skip it
-    if ( _cache[currentNodeIdx]._objectID == MP2::OBJ_MONSTER || _cache[currentNodeIdx]._objectID == MP2::OBJ_BARRIER ) {
-        return;
-    }
-
     if ( currentNodeIdx == pathStart || !isTileBlocked( currentNodeIdx, world.GetTiles( pathStart ).isWater() ) ) {
         const MapsIndexes & monsters = Maps::GetTilesUnderProtection( currentNodeIdx );
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -329,31 +329,33 @@ void PlayerWorldPathfinder::processCurrentNode( std::vector<int> & nodesToExplor
         return;
     }
 
-    const MapsIndexes & monsters = Maps::GetTilesUnderProtection( currentNodeIdx );
+    if ( currentNodeIdx == pathStart || !isTileBlocked( currentNodeIdx, world.GetTiles( pathStart ).isWater() ) ) {
+        const MapsIndexes & monsters = Maps::GetTilesUnderProtection( currentNodeIdx );
 
-    // check if current tile is protected, can move only to adjacent monster
-    if ( currentNodeIdx != pathStart && !monsters.empty() ) {
-        for ( int monsterIndex : monsters ) {
-            const int direction = Maps::GetDirection( currentNodeIdx, monsterIndex );
+        // check if current tile is protected, can move only to adjacent monster
+        if ( currentNodeIdx != pathStart && !monsters.empty() ) {
+            for ( int monsterIndex : monsters ) {
+                const int direction = Maps::GetDirection( currentNodeIdx, monsterIndex );
 
-            if ( direction != Direction::UNKNOWN && direction != Direction::CENTER && isValidPath( currentNodeIdx, direction, _currentColor ) ) {
-                // add straight to cache, can't move further from the monster
-                const uint32_t movementPenalty = getMovementPenalty( currentNodeIdx, monsterIndex, direction );
-                const uint32_t moveCost = _cache[currentNodeIdx]._cost + movementPenalty;
-                const uint32_t remainingMovePoints = substractMovePoints( _cache[currentNodeIdx]._remainingMovePoints, movementPenalty );
+                if ( direction != Direction::UNKNOWN && direction != Direction::CENTER && isValidPath( currentNodeIdx, direction, _currentColor ) ) {
+                    // add straight to cache, can't move further from the monster
+                    const uint32_t movementPenalty = getMovementPenalty( currentNodeIdx, monsterIndex, direction );
+                    const uint32_t moveCost = _cache[currentNodeIdx]._cost + movementPenalty;
+                    const uint32_t remainingMovePoints = substractMovePoints( _cache[currentNodeIdx]._remainingMovePoints, movementPenalty );
 
-                WorldNode & monsterNode = _cache[monsterIndex];
+                    WorldNode & monsterNode = _cache[monsterIndex];
 
-                if ( monsterNode._from == -1 || monsterNode._cost > moveCost ) {
-                    monsterNode._from = currentNodeIdx;
-                    monsterNode._cost = moveCost;
-                    monsterNode._remainingMovePoints = remainingMovePoints;
+                    if ( monsterNode._from == -1 || monsterNode._cost > moveCost ) {
+                        monsterNode._from = currentNodeIdx;
+                        monsterNode._cost = moveCost;
+                        monsterNode._remainingMovePoints = remainingMovePoints;
+                    }
                 }
             }
         }
-    }
-    else if ( currentNodeIdx == pathStart || !isTileBlocked( currentNodeIdx, world.GetTiles( pathStart ).isWater() ) ) {
-        checkAdjacentNodes( nodesToExplore, pathStart, currentNodeIdx );
+        else {
+            checkAdjacentNodes( nodesToExplore, pathStart, currentNodeIdx );
+        }
     }
 }
 


### PR DESCRIPTION
fix #4916

<img width="637" alt="Bugfix" src="https://user-images.githubusercontent.com/32623900/148986117-7f8c34f9-a9c2-4ef7-bfd3-813fecfcf251.png">
