### PR TITLE
Modify army order setting

### DIFF
--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -274,7 +274,6 @@ void Battle::DialogBattleSettings( void )
         //     Dialog::Message( _( "Monster Info" ), _( "Toggle the monster info window, which shows information on the active and targeted monsters." ), Font::BIG );
         // }
 
-        
         bool saveShowArmyOrder = false;
         if ( le.MouseClickLeft( optionAreas[1] ) ) {
             conf.setBattleShowArmyOrder( !conf.BattleShowArmyOrder() );

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -274,25 +274,26 @@ void Battle::DialogBattleSettings( void )
         //     Dialog::Message( _( "Monster Info" ), _( "Toggle the monster info window, which shows information on the active and targeted monsters." ), Font::BIG );
         // }
 
+        
         bool saveShowArmyOrder = false;
+        if ( le.MouseClickLeft( optionAreas[1] ) ) {
+            conf.setBattleShowArmyOrder( !conf.BattleShowArmyOrder() );
+            saveShowArmyOrder = true;
+        }
+        else if ( le.MousePressRight( optionAreas[1] ) ) {
+            Dialog::Message( _( "Army Order" ), _( "Toggle to display army order during the battle." ), Font::BIG );
+        }
+
+        bool saveAutoSpellCast = false;
         if ( le.MouseClickLeft( optionAreas[2] ) ) {
             conf.setBattleAutoSpellcast( !conf.BattleAutoSpellcast() );
-            saveShowArmyOrder = true;
+            saveAutoSpellCast = true;
         }
         else if ( le.MousePressRight( optionAreas[2] ) ) {
             Dialog::Message(
                 _( "Auto Spell Casting" ),
                 _( "Toggle whether or not the computer will cast spells for you when auto combat is on. (Note: This does not affect spell casting for computer players in any way, nor does it affect quick combat.)" ),
                 Font::BIG );
-        }
-
-        bool saveAutoSpellCast = false;
-        if ( le.MouseClickLeft( optionAreas[1] ) ) {
-            conf.setBattleShowArmyOrder( !conf.BattleShowArmyOrder() );
-            saveAutoSpellCast = true;
-        }
-        else if ( le.MousePressRight( optionAreas[1] ) ) {
-            Dialog::Message( _( "Army Order" ), _( "Toggle to display army order during the battle." ), Font::BIG );
         }
 
         bool saveShowGrid = false;

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -176,6 +176,7 @@ void Battle::RedrawBattleSettings( const std::vector<fheroes2::Rect> & areas )
     Text text( str, Font::SMALL );
     text.Blit( areas[0].x + ( sprite.width() - text.w() ) / 2, areas[0].y + sprite.height() + 3 );
 
+    RedrawOnOffSetting( areas[1], _( "Army Order" ), 3, conf.BattleShowArmyOrder() );
     RedrawOnOffSetting( areas[2], _( "Auto Spell Casting" ), 6, conf.BattleAutoSpellcast() );
     RedrawOnOffSetting( areas[3], _( "Grid" ), 8, conf.BattleShowGrid() );
     RedrawOnOffSetting( areas[4], _( "Shadow Movement" ), 10, conf.BattleShowMoveShadow() );
@@ -273,16 +274,25 @@ void Battle::DialogBattleSettings( void )
         //     Dialog::Message( _( "Monster Info" ), _( "Toggle the monster info window, which shows information on the active and targeted monsters." ), Font::BIG );
         // }
 
-        bool saveAutoSpellCast = false;
+        bool saveShowArmyOrder = false;
         if ( le.MouseClickLeft( optionAreas[2] ) ) {
             conf.setBattleAutoSpellcast( !conf.BattleAutoSpellcast() );
-            saveAutoSpellCast = true;
+            saveShowArmyOrder = true;
         }
         else if ( le.MousePressRight( optionAreas[2] ) ) {
             Dialog::Message(
                 _( "Auto Spell Casting" ),
                 _( "Toggle whether or not the computer will cast spells for you when auto combat is on. (Note: This does not affect spell casting for computer players in any way, nor does it affect quick combat.)" ),
                 Font::BIG );
+        }
+
+        bool saveAutoSpellCast = false;
+        if ( le.MouseClickLeft( optionAreas[1] ) ) {
+            conf.setBattleShowArmyOrder( !conf.BattleShowArmyOrder() );
+            saveAutoSpellCast = true;
+        }
+        else if ( le.MousePressRight( optionAreas[1] ) ) {
+            Dialog::Message( _( "Army Order" ), _( "Toggle to display army order during the battle." ), Font::BIG );
         }
 
         bool saveShowGrid = false;
@@ -319,7 +329,7 @@ void Battle::DialogBattleSettings( void )
             break;
         }
 
-        if ( saveSpeed || saveAutoSpellCast || saveShowGrid || saveShowMoveShadow || saveShowMouseShadow ) {
+        if ( saveSpeed || saveShowArmyOrder || saveAutoSpellCast || saveShowGrid || saveShowMoveShadow || saveShowMouseShadow ) {
             // redraw
             fheroes2::Blit( dialog, display, pos_rt.x, pos_rt.y );
             RedrawBattleSettings( optionAreas );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -880,7 +880,8 @@ void Battle::ArmiesOrder::RedrawUnit( const fheroes2::Rect & pos, const Battle::
         fheroes2::DrawRect( output, { pos.x, pos.y, armyOrderMonsterIconSize, armyOrderMonsterIconSize }, color );
 
         if ( unit.Modes( Battle::TR_MOVED ) ) {
-            fheroes2::ApplyPalette( output, pos.x, pos.y, output, pos.x, pos.y, armyOrderMonsterIconSize, armyOrderMonsterIconSize, PAL::GetPalette( PAL::PaletteType::GRAY ) );
+            fheroes2::ApplyPalette( output, pos.x, pos.y, output, pos.x, pos.y, armyOrderMonsterIconSize, armyOrderMonsterIconSize,
+                                    PAL::GetPalette( PAL::PaletteType::GRAY ) );
             fheroes2::ApplyPalette( output, pos.x, pos.y, output, pos.x, pos.y, armyOrderMonsterIconSize, armyOrderMonsterIconSize, 3 );
         }
     }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -55,11 +55,11 @@
 
 #include <cassert>
 
-#define ARMYORDERW 40
-
 namespace
 {
     const int32_t cellYOffset = -9;
+
+    const int32_t armyOrderMonsterIconSize = 43; // in both directions.
 
     struct LightningPoint
     {
@@ -832,19 +832,20 @@ void Battle::ArmiesOrder::QueueEventProcessing( std::string & msg, const fheroes
 void Battle::ArmiesOrder::RedrawUnit( const fheroes2::Rect & pos, const Battle::Unit & unit, const bool revert, const bool isCurrentUnit, const uint8_t currentUnitColor,
                                       fheroes2::Image & output ) const
 {
-    const fheroes2::Sprite & mons32 = fheroes2::AGG::GetICN( ICN::MONS32, unit.GetSpriteIndex() );
+    // Render background.
+    const fheroes2::Sprite & backgroundOriginal = fheroes2::AGG::GetICN( ICN::SWAPWIN, 0 );
+    fheroes2::Copy( backgroundOriginal, 37, 268, output, pos.x + 1, pos.y + 1, armyOrderMonsterIconSize - 2, armyOrderMonsterIconSize - 2 );
 
-    // background
-    fheroes2::Fill( output, pos.x, pos.y, pos.width, pos.height, fheroes2::GetColorId( 0x33, 0x33, 0x33 ) );
-    // mons32 sprite
+    // Draw a monster's sprite.
+    const fheroes2::Sprite & mons32 = fheroes2::AGG::GetICN( ICN::MONS32, unit.GetSpriteIndex() );
     fheroes2::Blit( mons32, output, pos.x + ( pos.width - mons32.width() ) / 2, pos.y + pos.height - mons32.height() - ( mons32.height() + 3 < pos.height ? 3 : 0 ),
                     revert );
 
-    Text number( std::to_string( unit.GetCount() ), Font::SMALL );
+    Text number( GetStringShort( unit.GetCount() ), Font::SMALL );
     number.Blit( pos.x + 2, pos.y + 2, output );
 
     if ( isCurrentUnit ) {
-        fheroes2::DrawRect( output, { pos.x + 1, pos.y + 1, ARMYORDERW, ARMYORDERW }, currentUnitColor );
+        fheroes2::DrawRect( output, { pos.x, pos.y, armyOrderMonsterIconSize, armyOrderMonsterIconSize }, currentUnitColor );
     }
     else {
         uint8_t color = 0;
@@ -876,38 +877,40 @@ void Battle::ArmiesOrder::RedrawUnit( const fheroes2::Rect & pos, const Battle::
             break;
         }
 
-        fheroes2::DrawRect( output, { pos.x + 1, pos.y + 1, ARMYORDERW, ARMYORDERW }, color );
+        fheroes2::DrawRect( output, { pos.x, pos.y, armyOrderMonsterIconSize, armyOrderMonsterIconSize }, color );
 
         if ( unit.Modes( Battle::TR_MOVED ) ) {
-            fheroes2::ApplyPalette( output, pos.x + 1, pos.y + 1, output, pos.x + 1, pos.y + 1, ARMYORDERW, ARMYORDERW, PAL::GetPalette( PAL::PaletteType::GRAY ) );
-            fheroes2::ApplyPalette( output, pos.x + 1, pos.y + 1, output, pos.x + 1, pos.y + 1, ARMYORDERW, ARMYORDERW, 3 );
+            fheroes2::ApplyPalette( output, pos.x, pos.y, output, pos.x, pos.y, armyOrderMonsterIconSize, armyOrderMonsterIconSize, PAL::GetPalette( PAL::PaletteType::GRAY ) );
+            fheroes2::ApplyPalette( output, pos.x, pos.y, output, pos.x, pos.y, armyOrderMonsterIconSize, armyOrderMonsterIconSize, 3 );
         }
     }
 }
 
 void Battle::ArmiesOrder::Redraw( const Unit * current, const uint8_t currentUnitColor, fheroes2::Image & output )
 {
-    if ( orders ) {
-        const int32_t ow = ARMYORDERW + 2;
+    if ( orders == nullptr ) {
+        // Nothing to show.
+        return;
+    }
 
-        const int32_t validUnitCount = static_cast<int32_t>( std::count_if( orders->begin(), orders->end(), []( const Unit * unit ) { return unit->isValid(); } ) );
+    const int32_t validUnitCount = static_cast<int32_t>( std::count_if( orders->begin(), orders->end(), []( const Unit * unit ) { return unit->isValid(); } ) );
 
-        int32_t ox = area.x + ( area.width - ow * validUnitCount ) / 2;
-        int32_t oy = area.y;
+    int32_t ox = area.x + ( area.width - armyOrderMonsterIconSize * validUnitCount ) / 2;
+    int32_t oy = area.y;
 
-        fheroes2::Rect::x = ox;
-        fheroes2::Rect::y = oy;
-        fheroes2::Rect::height = ow;
+    fheroes2::Rect::x = ox;
+    fheroes2::Rect::y = oy;
+    fheroes2::Rect::height = armyOrderMonsterIconSize;
 
-        rects.clear();
+    rects.clear();
 
-        for ( Units::const_iterator it = orders->begin(); it != orders->end(); ++it )
-            if ( *it && ( *it )->isValid() ) {
-                rects.emplace_back( *it, fheroes2::Rect( ox, oy, ow, ow ) );
-                RedrawUnit( rects.back().second, **it, ( **it ).GetColor() == army_color2, current == *it, currentUnitColor, output );
-                ox += ow;
-                fheroes2::Rect::width += ow;
-            }
+    for ( Units::const_iterator it = orders->begin(); it != orders->end(); ++it ) {
+        if ( *it && ( *it )->isValid() ) {
+            rects.emplace_back( *it, fheroes2::Rect( ox, oy, armyOrderMonsterIconSize, armyOrderMonsterIconSize ) );
+            RedrawUnit( rects.back().second, **it, ( **it ).GetColor() == army_color2, current == *it, currentUnitColor, output );
+            ox += armyOrderMonsterIconSize;
+            fheroes2::Rect::width += armyOrderMonsterIconSize;
+        }
     }
 }
 

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -149,18 +149,29 @@ namespace Battle
         ArmiesOrder();
 
         void Set( const fheroes2::Rect &, const Units *, int );
-        void Redraw( const Unit * current, fheroes2::Image & output );
+        void Redraw( const Unit * current, const uint8_t currentUnitColor, fheroes2::Image & output );
         void QueueEventProcessing( std::string & msg, const fheroes2::Point & offset );
 
     private:
+        enum ArmyColor : uint8_t
+        {
+            ARMY_COLOR_BLUE = 0x47,
+            ARMY_COLOR_GREEN = 0x67,
+            ARMY_COLOR_RED = 0xbd,
+            ARMY_COLOR_YELLOW = 0x70,
+            ARMY_COLOR_ORANGE = 0xcd,
+            ARMY_COLOR_PURPLE = 0x87,
+            ARMY_COLOR_GRAY = 0x10
+        };
+
         using UnitPos = std::pair<const Unit *, fheroes2::Rect>;
 
-        void RedrawUnit( const fheroes2::Rect & pos, const Battle::Unit & unit, bool revert, bool current, fheroes2::Image & output ) const;
+        void RedrawUnit( const fheroes2::Rect & pos, const Battle::Unit & unit, const bool revert, const bool isCurrentUnit, const uint8_t currentUnitColor,
+                         fheroes2::Image & output ) const;
 
         const Units * orders;
         int army_color2;
         fheroes2::Rect area;
-        fheroes2::Image sf_color[3];
         std::vector<UnitPos> rects;
     };
 

--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -175,7 +175,6 @@ void Dialog::ExtSettings( bool readonly )
     states.push_back( Settings::CASTLE_ALLOW_GUARDIANS );
     states.push_back( Settings::CASTLE_MAGEGUILD_POINTS_TURN );
 
-    states.push_back( Settings::BATTLE_SHOW_ARMY_ORDER );
     states.push_back( Settings::BATTLE_SOFT_WAITING );
     states.push_back( Settings::BATTLE_REVERSE_WAIT_ORDER );
     states.push_back( Settings::BATTLE_DETERMINISTIC_RESULT );

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -69,8 +69,8 @@ namespace
         // UNUSED = 0x00080000,
         // UNUSED = 0x00100000,
         // UNUSED = 0x00200000,
-        // UNUSED = 0x00400000,
 
+        GLOBAL_BATTLE_SHOW_ARMY_ORDER = 0x00400000,
         GLOBAL_BATTLE_SHOW_GRID = 0x00800000,
         GLOBAL_BATTLE_SHOW_MOUSE_SHADOW = 0x01000000,
         GLOBAL_BATTLE_SHOW_MOVE_SHADOW = 0x02000000,
@@ -265,6 +265,10 @@ bool Settings::Read( const std::string & filename )
         setBattleAutoSpellcast( config.StrParams( "auto spell casting" ) == "on" );
     }
 
+    if ( config.Exists( "battle army order" ) ) {
+        setBattleShowArmyOrder( config.StrParams( "battle army order" ) == "on" );
+    }
+
     // videomode
     sval = config.StrParams( "videomode" );
     if ( !sval.empty() ) {
@@ -421,6 +425,9 @@ std::string Settings::String() const
 
     os << std::endl << "# auto combat spell casting: on/off" << std::endl;
     os << "auto spell casting = " << ( opt_global.Modes( GLOBAL_BATTLE_AUTO_SPELLCAST ) ? "on" : "off" ) << std::endl;
+
+    os << std::endl << "# show army order during battle: on/off" << std::endl;
+    os << "battle army order = " << ( opt_global.Modes( GLOBAL_BATTLE_SHOW_ARMY_ORDER ) ? "on" : "off" ) << std::endl;
 
     os << std::endl << "# game language (an empty value means English)" << std::endl;
     os << "lang = " << _gameLanguage << std::endl;
@@ -638,6 +645,16 @@ void Settings::setBattleAutoSpellcast( bool enable )
     }
 }
 
+void Settings::setBattleShowArmyOrder( const bool enable )
+{
+    if ( enable ) {
+        opt_global.SetModes( GLOBAL_BATTLE_SHOW_ARMY_ORDER );
+    }
+    else {
+        opt_global.ResetModes( GLOBAL_BATTLE_SHOW_ARMY_ORDER );
+    }
+}
+
 void Settings::setFullScreen( const bool enable )
 {
     if ( enable ) {
@@ -714,6 +731,11 @@ bool Settings::BattleAutoResolve() const
 bool Settings::BattleAutoSpellcast() const
 {
     return opt_global.Modes( GLOBAL_BATTLE_AUTO_SPELLCAST );
+}
+
+bool Settings::BattleShowArmyOrder() const
+{
+    return opt_global.Modes( GLOBAL_BATTLE_SHOW_ARMY_ORDER );
 }
 
 const fheroes2::Size & Settings::VideoMode() const
@@ -981,8 +1003,6 @@ std::string Settings::ExtName( const uint32_t settingId )
         return _( "heroes: allow transcribing scrolls (needs: Eye Eagle skill)" );
     case Settings::HEROES_ARENA_ANY_SKILLS:
         return _( "heroes: in Arena can choose any of primary skills" );
-    case Settings::BATTLE_SHOW_ARMY_ORDER:
-        return _( "battle: show army order" );
     case Settings::BATTLE_SOFT_WAITING:
         return _( "battle: soft wait troop" );
     case Settings::BATTLE_REVERSE_WAIT_ORDER:
@@ -1113,11 +1133,6 @@ bool Settings::ExtBattleShowDamage() const
 bool Settings::ExtHeroAllowTranscribingScroll() const
 {
     return ExtModes( HEROES_TRANSCRIBING_SCROLLS );
-}
-
-bool Settings::ExtBattleShowBattleOrder() const
-{
-    return ExtModes( BATTLE_SHOW_ARMY_ORDER );
 }
 
 bool Settings::ExtBattleSoftWait() const

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -96,7 +96,7 @@ public:
         WORLD_EXT_OBJECTS_CAPTURED = 0x30004000,
         // UNUSED = 0x30008000,
 
-        BATTLE_SHOW_ARMY_ORDER = 0x40004000,
+        // UNUSED = 0x40004000,
         BATTLE_DETERMINISTIC_RESULT = 0x40008000,
         BATTLE_SOFT_WAITING = 0x40010000,
         BATTLE_REVERSE_WAIT_ORDER = 0x40020000
@@ -149,6 +149,7 @@ public:
     bool BattleShowMoveShadow() const;
     bool BattleAutoResolve() const;
     bool BattleAutoSpellcast() const;
+    bool BattleShowArmyOrder() const;
     bool isPriceOfLoyaltySupported() const;
     bool LoadedGameVersion() const;
     bool MusicMIDI() const;
@@ -187,7 +188,6 @@ public:
     bool ExtCastleAllowGuardians() const;
     bool ExtCastleGuildRestorePointsTurn() const;
     bool ExtBattleShowDamage() const;
-    bool ExtBattleShowBattleOrder() const;
     bool ExtBattleSoftWait() const;
     bool ExtBattleDeterministicResult() const;
     bool ExtBattleReverseWaitOrder() const;
@@ -221,6 +221,7 @@ public:
     void SetBattleSpeed( int );
     void setBattleAutoResolve( bool enable );
     void setBattleAutoSpellcast( bool enable );
+    void setBattleShowArmyOrder( const bool enable );
     void setFullScreen( const bool enable );
 
     void SetSoundVolume( int v );


### PR DESCRIPTION
Now it's a part of battle settings window and can be changed anytime during battle. The current unit has the same cycling color as the current monster. Moved creatures have grayed icons. Border of rectangles associates with the color of monsters.

Also drawings now are faster.