### PR TITLE
Fix race condition on initialization of paletteHolder

### DIFF
--- a/src/engine/image_palette.cpp
+++ b/src/engine/image_palette.cpp
@@ -31,22 +31,28 @@ namespace
 
     struct PaletteHolder
     {
+    private:
         PaletteHolder()
         {
             std::copy_n( kb_pal, paletteSize, gamePalette.begin() );
         }
 
+    public:
+        static PaletteHolder & instance()
+        {
+            static PaletteHolder paletteHolder;
+            return paletteHolder;
+        }
+
         std::array<uint8_t, paletteSize> gamePalette;
     };
-
-    PaletteHolder paletteHolder;
 }
 
 namespace fheroes2
 {
     const uint8_t * getGamePalette()
     {
-        return paletteHolder.gamePalette.data();
+        return PaletteHolder::instance().gamePalette.data();
     }
 
     void setGamePalette( const std::vector<uint8_t> & palette )
@@ -56,6 +62,6 @@ namespace fheroes2
             return;
         }
 
-        std::copy_n( palette.begin(), paletteSize, paletteHolder.gamePalette.begin() );
+        std::copy_n( palette.begin(), paletteSize, PaletteHolder::instance().gamePalette.begin() );
     }
 }

--- a/src/engine/image_palette.cpp
+++ b/src/engine/image_palette.cpp
@@ -39,6 +39,7 @@ namespace
         }
 
         std::array<uint8_t, paletteSize> gamePalette;
+
     private:
         PaletteHolder()
         {

--- a/src/engine/image_palette.cpp
+++ b/src/engine/image_palette.cpp
@@ -31,12 +31,6 @@ namespace
 
     struct PaletteHolder
     {
-    private:
-        PaletteHolder()
-        {
-            std::copy_n( kb_pal, paletteSize, gamePalette.begin() );
-        }
-
     public:
         static PaletteHolder & instance()
         {
@@ -45,6 +39,11 @@ namespace
         }
 
         std::array<uint8_t, paletteSize> gamePalette;
+    private:
+        PaletteHolder()
+        {
+            std::copy_n( kb_pal, paletteSize, gamePalette.begin() );
+        }
     };
 }
 


### PR DESCRIPTION
There is a race condition between the initialization of two global variables:

    image_palette.cpp:42    PaletteHolder paletteHolder;
    screen.cpp:184          const uint8_t * currentPalette = PALPalette();

If the compiler choses to initialize `currentPalette` first, it uses data from uninitialized `paletteHolder`, typically resulting in all-black palette. This is what happens e.g. with Mingw64 toolchain.

The proposed solution is to access `paletteHolder` via a singleton.