### PR TITLE
Fix a penetrating attack made by a wide unit from the tail cell, add highlighting of cells attacked by a unit capable of attacking all neighboring cells

### DIFF
--- a/src/fheroes2/battle/battle.h
+++ b/src/fheroes2/battle/battle.h
@@ -82,7 +82,6 @@ namespace Battle
             , resist( false )
         {}
 
-        bool operator==( const TargetInfo & ) const;
         static bool isFinishAnimFrame( const TargetInfo & info );
     };
 

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -585,7 +585,7 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( const Unit & attacker, U
         }
     }
     // attack of all adjacent cells
-    else if ( attacker.isAbilityPresent( fheroes2::MonsterAbilityType::ALL_ADJACENT_CELL_MELEE_ATTACK ) ) {
+    else if ( attacker.isAllAdjacentCellsAttack() ) {
         for ( const int32_t aroundIdx : Board::GetAroundIndexes( attacker ) ) {
             assert( Board::GetCell( aroundIdx ) != nullptr );
 

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <cassert>
 #include <iomanip>
+#include <set>
 
 #include "battle_arena.h"
 #include "battle_army.h"
@@ -572,12 +573,14 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( const Unit & attacker, U
 
     targets.push_back( res );
 
+    std::set<const Unit *> consideredTargets{ &defender };
+
     // long distance attack
     if ( attacker.isDoubleCellAttack() ) {
         Cell * cell = Board::GetCell( dst, dir );
         Unit * enemy = cell ? cell->GetUnit() : nullptr;
 
-        if ( enemy && enemy != &defender ) {
+        if ( enemy && consideredTargets.insert( enemy ).second ) {
             res.defender = enemy;
             res.damage = attacker.GetDamage( *enemy );
 
@@ -591,7 +594,7 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( const Unit & attacker, U
 
             Unit * enemy = Board::GetCell( aroundIdx )->GetUnit();
 
-            if ( enemy && enemy != &defender && enemy->GetColor() != attacker.GetColor() ) {
+            if ( enemy && enemy->GetColor() != attacker.GetColor() && consideredTargets.insert( enemy ).second ) {
                 res.defender = enemy;
                 res.damage = attacker.GetDamage( *enemy );
 
@@ -607,7 +610,7 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( const Unit & attacker, U
 
                 Unit * enemy = Board::GetCell( aroundIdx )->GetUnit();
 
-                if ( enemy && enemy != &defender ) {
+                if ( enemy && consideredTargets.insert( enemy ).second ) {
                     res.defender = enemy;
                     res.damage = attacker.GetDamage( *enemy );
 

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -544,7 +544,7 @@ void Battle::Arena::TargetsApplyDamage( Unit & attacker, const Unit & /*defender
     }
 }
 
-Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( const Unit & attacker, Unit & defender, const int32_t dst, const int dir ) const
+Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( const Unit & attacker, Unit & defender, const int32_t dst, const int dir )
 {
     TargetsInfo targets;
     targets.reserve( 8 );

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -122,11 +122,6 @@ namespace
     }
 }
 
-bool Battle::TargetInfo::operator==( const TargetInfo & ta ) const
-{
-    return defender == ta.defender;
-}
-
 Battle::Arena * Battle::GetArena( void )
 {
     return arena;

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -131,7 +131,7 @@ namespace Battle
 
         void ApplyAction( Command & );
 
-        TargetsInfo GetTargetsForDamage( const Unit &, Unit &, s32 ) const;
+        TargetsInfo GetTargetsForDamage( const Unit & attacker, Unit & defender, const int32_t dst, const int dir ) const;
         void TargetsApplyDamage( Unit &, const Unit &, TargetsInfo & ) const;
         TargetsInfo GetTargetsForSpells( const HeroBase * hero, const Spell & spell, int32_t dest, bool * playResistSound = nullptr );
         void TargetsApplySpell( const HeroBase *, const Spell &, TargetsInfo & ) const;

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -131,7 +131,6 @@ namespace Battle
 
         void ApplyAction( Command & );
 
-        TargetsInfo GetTargetsForDamage( const Unit & attacker, Unit & defender, const int32_t dst, const int dir ) const;
         void TargetsApplyDamage( Unit &, const Unit &, TargetsInfo & ) const;
         TargetsInfo GetTargetsForSpells( const HeroBase * hero, const Spell & spell, int32_t dest, bool * playResistSound = nullptr );
         void TargetsApplySpell( const HeroBase *, const Spell &, TargetsInfo & ) const;
@@ -200,6 +199,8 @@ namespace Battle
 
         void SetCastleTargetValue( int, u32 );
         void CatapultAction( void );
+
+        static TargetsInfo GetTargetsForDamage( const Unit & attacker, Unit & defender, const int32_t dst, const int dir );
 
         std::vector<int> GetCastleTargets( void ) const;
         TargetsInfo TargetsForChainLightning( const HeroBase * hero, int32_t attackedTroopIndex );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1717,7 +1717,7 @@ void Battle::Interface::RedrawCover()
                     highlightCells.emplace( secondAttackedCell );
                 }
             }
-            else if ( _currentUnit->isAbilityPresent( fheroes2::MonsterAbilityType::ALL_ADJACENT_CELL_MELEE_ATTACK ) ) {
+            else if ( _currentUnit->isAllAdjacentCellsAttack() ) {
                 for ( const int32_t aroundIdx : Board::GetAroundIndexes( pos ) ) {
                     // Should already be highlighted
                     if ( aroundIdx == index_pos ) {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1717,6 +1717,23 @@ void Battle::Interface::RedrawCover()
                     highlightCells.emplace( secondAttackedCell );
                 }
             }
+            else if ( _currentUnit->isAbilityPresent( fheroes2::MonsterAbilityType::ALL_ADJACENT_CELL_MELEE_ATTACK ) ) {
+                for ( const int32_t aroundIdx : Board::GetAroundIndexes( pos ) ) {
+                    // Should already be highlighted
+                    if ( aroundIdx == index_pos ) {
+                        continue;
+                    }
+
+                    const Cell * aroundCell = Board::GetCell( aroundIdx );
+                    assert( aroundCell != nullptr );
+
+                    const Unit * aroundUnit = aroundCell->GetUnit();
+
+                    if ( aroundUnit && aroundUnit->GetColor() != _currentUnit->GetColor() ) {
+                        highlightCells.emplace( aroundCell );
+                    }
+                }
+            }
         }
         else {
             highlightCells.emplace( cell );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1711,17 +1711,9 @@ void Battle::Interface::RedrawCover()
             }
 
             if ( _currentUnit->isDoubleCellAttack() ) {
-                // We have to invert the direction.
-                int attackDirection = Board::GetDirection( pos.GetHead()->GetIndex(), index_pos );
-                if ( attackDirection == 0 ) {
-                    // It happens when a creature needs to swap tail and head for an attack move.
-                    attackDirection = Board::GetDirection( pos.GetTail()->GetIndex(), index_pos );
-                }
+                const Cell * secondAttackedCell = Board::GetCell( index_pos, Board::GetReflectDirection( direction ) );
 
-                assert( attackDirection != 0 );
-
-                const Cell * secondAttackedCell = Board::GetCell( index_pos, attackDirection );
-                if ( secondAttackedCell != nullptr ) {
+                if ( secondAttackedCell ) {
                     highlightCells.emplace( secondAttackedCell );
                 }
             }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2960,7 +2960,7 @@ void Battle::Interface::RedrawActionAttackPart1( Unit & attacker, Unit & defende
     }
 }
 
-void Battle::Interface::RedrawActionAttackPart2( Unit & attacker, TargetsInfo & targets )
+void Battle::Interface::RedrawActionAttackPart2( Unit & attacker, const TargetsInfo & targets )
 {
     // post attack animation
     int attackStart = attacker.animation.getCurrentState();
@@ -3019,7 +3019,7 @@ void Battle::Interface::RedrawActionAttackPart2( Unit & attacker, TargetsInfo & 
     _movingUnit = nullptr;
 }
 
-void Battle::Interface::RedrawActionWincesKills( TargetsInfo & targets, Unit * attacker )
+void Battle::Interface::RedrawActionWincesKills( const TargetsInfo & targets, Unit * attacker /* = nullptr */ )
 {
     LocalEvent & le = LocalEvent::Get();
 
@@ -3030,7 +3030,7 @@ void Battle::Interface::RedrawActionWincesKills( TargetsInfo & targets, Unit * a
     std::vector<Unit *> mirrorImages;
     std::set<Unit *> resistantTarget;
 
-    for ( TargetsInfo::iterator it = targets.begin(); it != targets.end(); ++it ) {
+    for ( TargetsInfo::const_iterator it = targets.begin(); it != targets.end(); ++it ) {
         Unit * defender = it->defender;
         if ( defender == nullptr ) {
             continue;
@@ -3097,7 +3097,7 @@ void Battle::Interface::RedrawActionWincesKills( TargetsInfo & targets, Unit * a
                 redrawBattleField = true;
             }
             else {
-                for ( TargetsInfo::iterator it = targets.begin(); it != targets.end(); ++it ) {
+                for ( TargetsInfo::const_iterator it = targets.begin(); it != targets.end(); ++it ) {
                     if ( ( *it ).defender ) {
                         redrawBattleField = true;
                         break;
@@ -3129,7 +3129,7 @@ void Battle::Interface::RedrawActionWincesKills( TargetsInfo & targets, Unit * a
 
             finishedAnimation = ( finish == static_cast<int>( finishedAnimationCount ) );
 
-            for ( TargetsInfo::iterator it = targets.begin(); it != targets.end(); ++it ) {
+            for ( TargetsInfo::const_iterator it = targets.begin(); it != targets.end(); ++it ) {
                 if ( ( *it ).defender ) {
                     if ( it->defender->isFinishAnimFrame() && it->defender->GetAnimationState() == Monster_Info::WNCE ) {
                         it->defender->SwitchAnimation( Monster_Info::STATIC );
@@ -3533,7 +3533,7 @@ void Battle::Interface::RedrawActionSpellCastPart1( const Spell & spell, s32 dst
     }
 }
 
-void Battle::Interface::RedrawActionSpellCastPart2( const Spell & spell, TargetsInfo & targets )
+void Battle::Interface::RedrawActionSpellCastPart2( const Spell & spell, const TargetsInfo & targets )
 {
     if ( spell.isDamage() ) {
         uint32_t killed = 0;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -212,10 +212,10 @@ namespace Battle
 
         void RedrawActionNewTurn() const;
         void RedrawActionAttackPart1( Unit &, Unit &, const TargetsInfo & );
-        void RedrawActionAttackPart2( Unit &, TargetsInfo & );
+        void RedrawActionAttackPart2( Unit & attacker, const TargetsInfo & targets );
         void RedrawActionSpellCastStatus( const Spell & spell, int32_t dst, const std::string & name, const TargetsInfo & targets );
         void RedrawActionSpellCastPart1( const Spell & spell, s32 dst, const HeroBase * caster, const TargetsInfo & targets );
-        void RedrawActionSpellCastPart2( const Spell &, TargetsInfo & );
+        void RedrawActionSpellCastPart2( const Spell & spell, const TargetsInfo & targets );
         void RedrawActionResistSpell( const Unit & target, bool playSound );
         void RedrawActionMonsterSpellCastStatus( const Unit &, const TargetInfo & );
         void RedrawActionMove( Unit &, const Indexes & );
@@ -263,7 +263,7 @@ namespace Battle
 
         void RedrawTroopCount( const Unit & unit );
 
-        void RedrawActionWincesKills( TargetsInfo & targets, Unit * attacker = nullptr );
+        void RedrawActionWincesKills( const TargetsInfo & targets, Unit * attacker = nullptr );
         void RedrawActionArrowSpell( const Unit & );
         void RedrawActionColdRaySpell( Unit & );
         void RedrawActionDisruptingRaySpell( const Unit & );

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -26,6 +26,7 @@
 #include <string>
 
 #include "battle_animation.h"
+#include "battle_board.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "spell.h"
@@ -42,13 +43,16 @@ namespace fheroes2
 
 namespace Battle
 {
+    class Actions;
     class Arena;
+    class Board;
+    class Cell;
+    class Position;
+    class StatusListBox;
+    class Tower;
     class Unit;
     class Units;
-    class Tower;
-    class StatusListBox;
-    class Cell;
-    class Actions;
+
     struct TargetInfo;
     struct TargetsInfo;
 


### PR DESCRIPTION
Companion PR for #4960
Related to #2497

---

Before:

https://user-images.githubusercontent.com/32623900/151677155-20824e6e-3782-434f-a723-0fffb2360396.mp4

After:

https://user-images.githubusercontent.com/32623900/151680628-3d725816-abc3-423a-b8ef-985b43ca4f37.mp4

---

New feature:

https://user-images.githubusercontent.com/32623900/151680722-2923721a-60b5-47a3-90b3-bd077febd635.mp4

Also fixed an issue when the same damage (physical or magical) could be applied to the same wide units twice.