### PR TITLE
Migrate seeds from size_t to uint32_t

### DIFF
--- a/src/engine/rand.cpp
+++ b/src/engine/rand.cpp
@@ -126,16 +126,16 @@ int32_t Rand::Queue::GetWithSeed( uint32_t seed )
     return Rand::Queue::Get( [seed]( uint32_t max ) { return Rand::GetWithSeed( 0, max, seed ); } );
 }
 
-Rand::DeterministicRandomGenerator::DeterministicRandomGenerator( const size_t initialSeed )
+Rand::DeterministicRandomGenerator::DeterministicRandomGenerator( const uint32_t initialSeed )
     : _currentSeed( initialSeed )
 {}
 
-size_t Rand::DeterministicRandomGenerator::GetSeed() const
+uint32_t Rand::DeterministicRandomGenerator::GetSeed() const
 {
     return _currentSeed;
 }
 
-void Rand::DeterministicRandomGenerator::UpdateSeed( const size_t seed )
+void Rand::DeterministicRandomGenerator::UpdateSeed( const uint32_t seed )
 {
     _currentSeed = seed;
 }
@@ -143,5 +143,5 @@ void Rand::DeterministicRandomGenerator::UpdateSeed( const size_t seed )
 uint32_t Rand::DeterministicRandomGenerator::Get( const uint32_t from, const uint32_t to /*= 0*/ ) const
 {
     ++_currentSeed;
-    return Rand::GetWithSeed( from, to, static_cast<uint32_t>( _currentSeed ) );
+    return Rand::GetWithSeed( from, to, _currentSeed );
 }

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -126,14 +126,14 @@ namespace Rand
     class DeterministicRandomGenerator
     {
     public:
-        explicit DeterministicRandomGenerator( const size_t initialSeed );
+        explicit DeterministicRandomGenerator( const uint32_t initialSeed );
 
         // prevent accidental copies
         DeterministicRandomGenerator( const DeterministicRandomGenerator & ) = delete;
         DeterministicRandomGenerator & operator=( const DeterministicRandomGenerator & ) = delete;
 
-        size_t GetSeed() const;
-        void UpdateSeed( const size_t seed );
+        uint32_t GetSeed() const;
+        void UpdateSeed( const uint32_t seed );
 
         uint32_t Get( const uint32_t from, const uint32_t to = 0 ) const;
 
@@ -141,7 +141,7 @@ namespace Rand
         const T & Get( const std::vector<T> & vec ) const
         {
             ++_currentSeed;
-            std::mt19937 seededGen( static_cast<uint32_t>( _currentSeed ) );
+            std::mt19937 seededGen( _currentSeed );
             return Rand::GetWithGen( vec, seededGen );
         }
 
@@ -149,11 +149,11 @@ namespace Rand
         void Shuffle( std::vector<T> & vector ) const
         {
             ++_currentSeed;
-            Rand::ShuffleWithSeed( vector, static_cast<uint32_t>( _currentSeed ) );
+            Rand::ShuffleWithSeed( vector, _currentSeed );
         }
 
     private:
-        mutable size_t _currentSeed; // this is mutable so clients that only call RNG method can receive a const instance
+        mutable uint32_t _currentSeed; // this is mutable so clients that only call RNG method can receive a const instance
     };
 }
 

--- a/src/engine/tools.h
+++ b/src/engine/tools.h
@@ -74,7 +74,7 @@ namespace fheroes2
     uint32_t calculateCRC32( const uint8_t * data, const size_t length );
 
     template <class T>
-    void hashCombine( std::size_t & seed, const T & v )
+    void hashCombine( uint32_t & seed, const T & v )
     {
         std::hash<T> hasher;
         seed ^= hasher( v ) + 0x9e3779b9 + ( seed << 6 ) + ( seed >> 2 );

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -55,9 +55,9 @@ namespace Battle
 namespace
 {
     // compute a new seed from a list of actions, so random actions happen differently depending on user inputs
-    size_t UpdateRandomSeed( const size_t seed, const Battle::Actions & actions )
+    uint32_t UpdateRandomSeed( const uint32_t seed, const Battle::Actions & actions )
     {
-        size_t newSeed = seed;
+        uint32_t newSeed = seed;
 
         for ( const Battle::Command & command : actions ) {
             if ( command.GetType() == Battle::CommandType::MSG_BATTLE_AUTO ) {
@@ -354,7 +354,7 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
             }
         }
 
-        const size_t newSeed = UpdateRandomSeed( _randomGenerator.GetSeed(), actions );
+        const uint32_t newSeed = UpdateRandomSeed( _randomGenerator.GetSeed(), actions );
         _randomGenerator.UpdateSeed( newSeed );
 
         const bool troopHasAlreadySkippedMove = troop->Modes( TR_SKIPMOVE );

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -109,9 +109,9 @@ namespace
         }
     }
 
-    size_t computeBattleSeed( const int32_t mapIndex, const uint32_t mapSeed, const Army & army1, const Army & army2 )
+    uint32_t computeBattleSeed( const int32_t mapIndex, const uint32_t mapSeed, const Army & army1, const Army & army2 )
     {
-        size_t seed = static_cast<size_t>( mapIndex ) + static_cast<size_t>( mapSeed );
+        uint32_t seed = static_cast<uint32_t>( mapIndex ) + mapSeed;
 
         for ( size_t i = 0; i < army1.Size(); ++i ) {
             const Troop * troop = army1.GetTroop( i );
@@ -207,8 +207,8 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, s32 mapsindex )
         showBattle = true;
 #endif
 
-    const size_t battleSeed = Settings::Get().ExtBattleDeterministicResult() ? computeBattleSeed( mapsindex, world.GetMapSeed(), army1, army2 )
-                                                                             : Rand::Get( std::numeric_limits<uint32_t>::max() );
+    const uint32_t battleSeed = Settings::Get().ExtBattleDeterministicResult() ? computeBattleSeed( mapsindex, world.GetMapSeed(), army1, army2 )
+                                                                               : Rand::Get( std::numeric_limits<uint32_t>::max() );
 
     bool isBattleOver = false;
     while ( !isBattleOver ) {

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1954,7 +1954,7 @@ HeroSeedsForLevelUp Heroes::GetSeedsForLevelUp() const
      * skill would always be the same once the 1st one is selected.
      * */
 
-    size_t hash = world.GetMapSeed();
+    uint32_t hash = world.GetMapSeed();
     fheroes2::hashCombine( hash, hid );
     fheroes2::hashCombine( hash, _race );
     fheroes2::hashCombine( hash, attack );
@@ -1966,10 +1966,10 @@ HeroSeedsForLevelUp Heroes::GetSeedsForLevelUp() const
     }
 
     HeroSeedsForLevelUp seeds;
-    seeds.seedPrimarySkill = static_cast<uint32_t>( hash );
-    seeds.seedSecondaySkill1 = seeds.seedPrimarySkill + 1;
-    seeds.seedSecondaySkill2 = seeds.seedPrimarySkill + 2;
-    seeds.seedSecondaySkillRandomChoose = seeds.seedPrimarySkill + 3;
+    seeds.seedPrimarySkill = hash;
+    seeds.seedSecondaySkill1 = hash + 1;
+    seeds.seedSecondaySkill2 = hash + 2;
+    seeds.seedSecondaySkillRandomChoose = hash + 3;
     return seeds;
 }
 

--- a/src/fheroes2/kingdom/week.cpp
+++ b/src/fheroes2/kingdom/week.cpp
@@ -30,20 +30,19 @@
 
 namespace
 {
-    WeekName WeekRand( const World & worldInstance, const size_t seed )
+    WeekName WeekRand( const World & worldInstance, const uint32_t seed )
     {
-        return ( 0 == ( worldInstance.CountWeek() + 1 ) % 3 ) ? WeekName::MONSTERS : Rand::GetWithSeed( WeekName::ANT, WeekName::CONDOR, static_cast<uint32_t>( seed ) );
+        return ( 0 == ( worldInstance.CountWeek() + 1 ) % 3 ) ? WeekName::MONSTERS : Rand::GetWithSeed( WeekName::ANT, WeekName::CONDOR, seed );
     }
 
-    WeekName MonthRand( const World & worldInstance, const size_t seed )
+    WeekName MonthRand( const World & worldInstance, const uint32_t seed )
     {
-        return ( 0 == ( worldInstance.GetMonth() + 1 ) % 3 ) ? WeekName::MONSTERS
-                                                             : Rand::GetWithSeed( WeekName::PLAGUE, WeekName::CONDOR, static_cast<uint32_t>( seed ) );
+        return ( 0 == ( worldInstance.GetMonth() + 1 ) % 3 ) ? WeekName::MONSTERS : Rand::GetWithSeed( WeekName::PLAGUE, WeekName::CONDOR, seed );
     }
 
-    Monster::monster_t RandomMonsterWeekOf( const size_t seed )
+    Monster::monster_t RandomMonsterWeekOf( const uint32_t seed )
     {
-        switch ( Rand::GetWithSeed( 1, 47, static_cast<uint32_t>( seed ) ) ) {
+        switch ( Rand::GetWithSeed( 1, 47, seed ) ) {
         case 1:
             return Monster::PEASANT;
         case 2:
@@ -144,9 +143,9 @@ namespace
         }
     }
 
-    Monster::monster_t RandomMonsterMonthOf( const size_t seed )
+    Monster::monster_t RandomMonsterMonthOf( const uint32_t seed )
     {
-        switch ( Rand::GetWithSeed( 1, 30, static_cast<uint32_t>( seed ) ) ) {
+        switch ( Rand::GetWithSeed( 1, 30, seed ) ) {
         case 1:
             return Monster::PEASANT;
         case 2:
@@ -274,15 +273,15 @@ const char * Week::GetName( void ) const
     return "Unnamed";
 }
 
-Week Week::RandomWeek( const World & worldInstance, const bool isNewMonth, const size_t weekSeed )
+Week Week::RandomWeek( const World & worldInstance, const bool isNewMonth, const uint32_t weekSeed )
 {
-    size_t weekTypeSeed = weekSeed;
+    uint32_t weekTypeSeed = weekSeed;
     fheroes2::hashCombine( weekTypeSeed, 34582445 ); // random value to add salt
 
     const WeekName weekName = isNewMonth ? MonthRand( worldInstance, weekTypeSeed ) : WeekRand( worldInstance, weekTypeSeed );
 
     if ( weekName == WeekName::MONSTERS ) {
-        size_t monsterTypeSeed = weekSeed;
+        uint32_t monsterTypeSeed = weekSeed;
         fheroes2::hashCombine( monsterTypeSeed, 284631 ); // random value to add salt
         if ( isNewMonth ) {
             return { weekName, RandomMonsterMonthOf( monsterTypeSeed ) };

--- a/src/fheroes2/kingdom/week.h
+++ b/src/fheroes2/kingdom/week.h
@@ -76,7 +76,7 @@ struct Week
 
     const char * GetName() const;
 
-    static Week RandomWeek( const World & world, const bool isNewMonth, const size_t weekSeed );
+    static Week RandomWeek( const World & world, const bool isNewMonth, const uint32_t weekSeed );
 
     friend StreamBase & operator>>( StreamBase & stream, Week & week );
 

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1290,11 +1290,11 @@ uint32_t World::GetMapSeed() const
 
 uint32_t World::GetWeekSeed() const
 {
-    size_t weekSeed = _seed;
+    uint32_t weekSeed = _seed;
 
     fheroes2::hashCombine( weekSeed, week );
 
-    return static_cast<uint32_t>( weekSeed );
+    return weekSeed;
 }
 
 StreamBase & operator<<( StreamBase & msg, const CapturedObject & obj )


### PR DESCRIPTION
Currently there is some inconsistency: most of the `namespace Rand` use `uint32_t` seeds, while `DeterministicRandomGenerator` and `hashCombine()` use `size_t` seeds (I suppose that's because `std::hash<...>::operator()` returns `size_t`). This leads to numerous `static_casts` back and forth. I suggest using `uint32_t` everywhere.

Pros of `size_t`:

* ???

Cons of `size_t`:

* `size_t` is implementation-defined (its size can vary from 16 bits to infinity), so we can't reliably save it to the savefiles, we should convert it to some fixed type anyway;
* Most of the existing `Rand` library uses `uint32_t`.
