### PR TITLE
Implement a heuristic for hiring heroes that does not allow to offer the same heroes for hire in several kingdoms at the same time, if there are enough free heroes

### DIFF
--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -652,6 +652,7 @@ bool Heroes::Recruit( const int col, const fheroes2::Point & pt )
         return false;
     }
 
+    ResetModes( RECRUIT );
     ResetModes( JAIL );
 
     SetColor( col );
@@ -1924,6 +1925,19 @@ Heroes * AllHeroes::GetFreeman( const int race, const int heroIDToIgnore ) const
         return nullptr;
     }
 
+    // Try to get a list of freeman heroes who are not yet available for recruitment in any kingdom
+    std::vector<int> freemanHeroesNotRecruits = freeman_heroes;
+
+    freemanHeroesNotRecruits.erase( std::remove_if( freemanHeroesNotRecruits.begin(), freemanHeroesNotRecruits.end(),
+                                                    [this]( const int heroID ) { return at( heroID )->Modes( Heroes::RECRUIT ); } ),
+                                    freemanHeroesNotRecruits.end() );
+
+    if ( !freemanHeroesNotRecruits.empty() ) {
+        return at( Rand::Get( freemanHeroesNotRecruits ) );
+    }
+
+    // There is no freeman heroes who are not yet available for recruitment, allow
+    // heroes to be available for recruitment in several kingdoms at the same time
     return at( Rand::Get( freeman_heroes ) );
 }
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1450,34 +1450,40 @@ bool Heroes::isFreeman( void ) const
 void Heroes::SetFreeman( int reason )
 {
     if ( !isFreeman() ) {
-        bool savepoints = false;
+        // if not surrendering, reset army
+        if ( ( reason & Battle::RESULT_SURRENDER ) == 0 ) {
+            army.Reset( true );
+        }
+
+        const int heroColor = GetColor();
         Kingdom & kingdom = GetKingdom();
+
+        if ( heroColor != Color::NONE ) {
+            kingdom.RemoveHeroes( this );
+        }
+        SetColor( Color::NONE );
+
+        world.GetTiles( GetIndex() ).SetHeroes( nullptr );
+        SetIndex( -1 );
+
+        modes = 0;
+        move_point_scale = -1;
+
+        path.Reset();
+
+        SetMove( false );
+
+        SetModes( ACTION );
 
         if ( ( Battle::RESULT_RETREAT | Battle::RESULT_SURRENDER ) & reason ) {
             if ( Settings::Get().ExtHeroRememberPointsForRetreating() ) {
-                savepoints = true;
+                SetModes( SAVE_MP_POINTS );
             }
 
-            kingdom.appendSurrenderedHero( *this );
+            if ( heroColor != Color::NONE ) {
+                kingdom.appendSurrenderedHero( *this );
+            }
         }
-
-        // if not surrendering, reset army
-        if ( ( reason & Battle::RESULT_SURRENDER ) == 0 )
-            army.Reset( true );
-
-        if ( GetColor() != Color::NONE )
-            kingdom.RemoveHeroes( this );
-
-        SetColor( Color::NONE );
-        world.GetTiles( GetIndex() ).SetHeroes( nullptr );
-        modes = 0;
-        SetIndex( -1 );
-        move_point_scale = -1;
-        path.Reset();
-        SetMove( false );
-        SetModes( ACTION );
-        if ( savepoints )
-            SetModes( SAVE_MP_POINTS );
     }
 }
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1942,7 +1942,7 @@ Heroes * AllHeroes::GetFreeman( const int race, const int heroIDToIgnore ) const
         return at( Rand::Get( freemanHeroesNotRecruits ) );
     }
 
-    // There is no freeman heroes who are not yet available for recruitment, allow
+    // There are no freeman heroes who are not yet available for recruitment, allow
     // heroes to be available for recruitment in several kingdoms at the same time
     return at( Rand::Get( freeman_heroes ) );
 }

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1931,7 +1931,7 @@ Heroes * AllHeroes::GetFreeman( const int race, const int heroIDToIgnore ) const
         return nullptr;
     }
 
-    // Try to get a list of freeman heroes who are not yet available for recruitment in any kingdom
+    // Try to avoid freeman heroes who are already available for recruitment in any kingdom
     std::vector<int> freemanHeroesNotRecruits = freeman_heroes;
 
     freemanHeroesNotRecruits.erase( std::remove_if( freemanHeroesNotRecruits.begin(), freemanHeroesNotRecruits.end(),

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -154,7 +154,7 @@ public:
         ENABLEMOVE = 0x00000008,
         // UNUSED = 0x00000010,
         // UNUSED = 0x00000020,
-        // UNUSED = 0x00000040,
+        RECRUIT = 0x00000040, // Hero is available for recruitment in any kingdom
         JAIL = 0x00000080,
         ACTION = 0x00000100,
         SAVE_MP_POINTS = 0x00000200,

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -146,7 +146,7 @@ public:
     static const fheroes2::Sprite & GetPortrait( int heroid, int type );
     static const char * GetName( int heroid );
 
-    enum flags_t
+    enum flags_t : uint32_t
     {
         SHIPMASTER = 0x00000001,
         // UNUSED = 0x00000002,
@@ -488,6 +488,11 @@ struct AllHeroes : public VecHeroes
     void clear( void );
 
     void Scoute( int ) const;
+
+    void ResetModes( uint32_t modes ) const
+    {
+        std::for_each( begin(), end(), [modes]( Heroes * hero ) { hero->ResetModes( modes ); } );
+    }
 
     void NewDay()
     {

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -489,7 +489,7 @@ struct AllHeroes : public VecHeroes
 
     void Scoute( int ) const;
 
-    void ResetModes( uint32_t modes ) const
+    void ResetModes( const uint32_t modes ) const
     {
         std::for_each( begin(), end(), [modes]( Heroes * hero ) { hero->ResetModes( modes ); } );
     }

--- a/src/fheroes2/heroes/heroes_recruits.cpp
+++ b/src/fheroes2/heroes/heroes_recruits.cpp
@@ -42,16 +42,6 @@ Recruit::Recruit( const Heroes & hero )
     : Recruit( hero, 0 )
 {}
 
-int Recruit::getID() const
-{
-    return _id;
-}
-
-uint32_t Recruit::getSurrenderDay() const
-{
-    return _surrenderDay;
-}
-
 void Recruit::setSurrenderDayTmp( const uint32_t surrenderDay )
 {
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE2_0912_RELEASE, "Remove this method." );

--- a/src/fheroes2/heroes/heroes_recruits.h
+++ b/src/fheroes2/heroes/heroes_recruits.h
@@ -31,24 +31,30 @@
 class Heroes;
 class StreamBase;
 
-struct Recruit
+class Recruit
 {
-    Recruit()
-        : id( Heroes::UNKNOWN )
-        , surrenderDay( 0 )
-    {}
+public:
+    Recruit();
+    Recruit( const Heroes & hero, const uint32_t surrenderDay );
+    explicit Recruit( const Heroes & hero );
+    Recruit( const Recruit & ) = delete;
 
-    Recruit( const Heroes & hero, const uint32_t heroSurrenderDay )
-        : id( hero.GetID() )
-        , surrenderDay( heroSurrenderDay )
-    {}
+    ~Recruit() = default;
 
-    explicit Recruit( const Heroes & hero )
-        : Recruit( hero, 0 )
-    {}
+    Recruit & operator=( const Recruit & ) = delete;
+    Recruit & operator=( Recruit && ) = default;
 
-    int id;
-    uint32_t surrenderDay;
+    int getID() const;
+    uint32_t getSurrenderDay() const;
+
+    void setSurrenderDayTmp( const uint32_t surrenderDay );
+
+private:
+    int _id;
+    uint32_t _surrenderDay;
+
+    friend StreamBase & operator<<( StreamBase & msg, const Recruit & recruit );
+    friend StreamBase & operator>>( StreamBase & msg, Recruit & recruit );
 };
 
 class Recruits : public std::pair<Recruit, Recruit>
@@ -67,12 +73,12 @@ public:
     uint32_t getSurrenderDayOfHero1() const;
     uint32_t getSurrenderDayOfHero2() const;
 
-    void SetHero1( const Heroes * hero );
-    void SetHero2( const Heroes * hero );
+    void SetHero1( Heroes * hero );
+    void SetHero2( Heroes * hero );
 
-    void SetHero2Tmp( const Heroes * hero, const uint32_t heroSurrenderDay );
+    void SetHero2Tmp( Heroes * hero, const uint32_t heroSurrenderDay );
 
-    void appendSurrenderedHero( const Heroes & hero, const uint32_t heroSurrenderDay );
+    void appendSurrenderedHero( Heroes & hero, const uint32_t heroSurrenderDay );
 };
 
 StreamBase & operator<<( StreamBase & msg, const Recruit & recruit );

--- a/src/fheroes2/heroes/heroes_recruits.h
+++ b/src/fheroes2/heroes/heroes_recruits.h
@@ -44,8 +44,15 @@ public:
     Recruit & operator=( const Recruit & ) = delete;
     Recruit & operator=( Recruit && ) = default;
 
-    int getID() const;
-    uint32_t getSurrenderDay() const;
+    int getID() const
+    {
+        return _id;
+    }
+
+    uint32_t getSurrenderDay() const
+    {
+        return _surrenderDay;
+    }
 
     void setSurrenderDayTmp( const uint32_t surrenderDay );
 

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -748,8 +748,9 @@ void Kingdoms::NewWeek( void )
     for ( Kingdom & kingdom : kingdoms ) {
         Recruits & recruits = kingdom.GetCurrentRecruits();
 
-        // Heroes who surrendered on Sunday should still be available for hire next week
-        if ( world.CountDay() - recruits.getSurrenderDayOfHero1() > 1 ) {
+        // Heroes who surrendered on Sunday should still be available for hire next week in the
+        // same kingdom, provided that this kingdom is still playable
+        if ( !kingdom.isPlay() || world.CountDay() - recruits.getSurrenderDayOfHero1() > 1 ) {
             Heroes * hero = recruits.GetHero1();
             if ( hero ) {
                 hero->ResetModes( Heroes::RECRUIT );
@@ -757,7 +758,7 @@ void Kingdoms::NewWeek( void )
 
             recruits.SetHero1( nullptr );
         }
-        if ( world.CountDay() - recruits.getSurrenderDayOfHero2() > 1 ) {
+        if ( !kingdom.isPlay() || world.CountDay() - recruits.getSurrenderDayOfHero2() > 1 ) {
             Heroes * hero = recruits.GetHero2();
             if ( hero ) {
                 hero->ResetModes( Heroes::RECRUIT );

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -63,7 +63,7 @@ public:
     void SetLastBattleWinHero( const Heroes & hero );
     Heroes * GetLastBattleWinHero() const;
 
-    void appendSurrenderedHero( const Heroes & hero );
+    void appendSurrenderedHero( Heroes & hero );
 
     Heroes * GetBestHero();
 
@@ -94,7 +94,12 @@ public:
 
     uint32_t GetCountArtifacts() const;
 
+    // Returns a reference to the pair of heroes available for recruitment,
+    // updating it on the fly if necessary
     const Recruits & GetRecruits();
+    // Returns a reference to the pair of heroes available for recruitment
+    // without making any changes in it
+    Recruits & GetCurrentRecruits();
 
     const KingdomHeroes & GetHeroes( void ) const
     {

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -22,6 +22,8 @@
 #ifndef H2KINGDOM_H
 #define H2KINGDOM_H
 
+#include <set>
+
 #include "castle.h"
 #include "heroes_recruits.h"
 #include "mp2.h"
@@ -204,6 +206,10 @@ public:
     void AddCastles( const AllCastles & );
 
     void AddTributeEvents( CapturedObjects & captureobj, const uint32_t day, const MP2::MapObjectType objectType );
+
+    // Resets recruits in all kingdoms and returns a set of heroes that are still available for recruitment
+    // in the kingdoms
+    std::set<Heroes *> resetRecruits();
 
 private:
     friend StreamBase & operator<<( StreamBase &, const Kingdoms & );

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <set>
 #include <tuple>
 
 #include "ai.h"
@@ -667,6 +668,19 @@ void World::NewWeek( void )
         vec_kingdoms.AddTributeEvents( map_captureobj, day, MP2::OBJ_WATERWHEEL );
         vec_kingdoms.AddTributeEvents( map_captureobj, day, MP2::OBJ_WINDMILL );
         vec_kingdoms.AddTributeEvents( map_captureobj, day, MP2::OBJ_MAGICGARDEN );
+    }
+
+    // Reset RECRUIT mode for all heroes at once
+    vec_heroes.ResetModes( Heroes::RECRUIT );
+
+    // Reset recruits in all kingdoms at once to expand the set of heroes available for recruitment
+    std::set<Heroes *> remainingRecruits = vec_kingdoms.resetRecruits();
+
+    // Restore the RECRUIT mode for the remaining recruits (e.g. heroes who surrendered on Sunday)
+    for ( Heroes * hero : remainingRecruits ) {
+        assert( hero != nullptr );
+
+        hero->SetModes( Heroes::RECRUIT );
     }
 }
 

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -673,10 +673,10 @@ void World::NewWeek( void )
     // Reset RECRUIT mode for all heroes at once
     vec_heroes.ResetModes( Heroes::RECRUIT );
 
-    // Reset recruits in all kingdoms at once to expand the set of heroes available for recruitment
+    // Reset recruits in all kingdoms at once
     std::set<Heroes *> remainingRecruits = vec_kingdoms.resetRecruits();
 
-    // Restore the RECRUIT mode for the remaining recruits (e.g. heroes who surrendered on Sunday)
+    // Restore the RECRUIT mode for the remaining recruits
     for ( Heroes * hero : remainingRecruits ) {
         assert( hero != nullptr );
 


### PR DESCRIPTION
fix #3662