### PR TITLE
Fix the crash on an invalid assertion when the "Army order" setting is turned on and someone casts Berserker spell

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -851,6 +851,9 @@ void Battle::ArmiesOrder::RedrawUnit( const fheroes2::Rect & pos, const Battle::
         uint8_t color = 0;
 
         switch ( unit.GetCurrentColor() ) {
+        case -1: // Berserkers
+            color = ARMY_COLOR_BLACK;
+            break;
         case Color::BLUE:
             color = ARMY_COLOR_BLUE;
             break;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -159,6 +159,7 @@ namespace Battle
     private:
         enum ArmyColor : uint8_t
         {
+            ARMY_COLOR_BLACK = 0x00,
             ARMY_COLOR_BLUE = 0x47,
             ARMY_COLOR_GREEN = 0x67,
             ARMY_COLOR_RED = 0xbd,


### PR DESCRIPTION
I chose black for Berserkers, but it's a matter of taste.