### PR TITLE
Unit with ALL_ADJACENT_CELL_MELEE_ATTACK ability (e.g. Hydra) should be able to attack adjacent units from his own army if he is affected by Berserk or Hypnotize spells

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -718,11 +718,10 @@ namespace AI
                 }
                 else {
                     int targetCell = -1;
-                    const Indexes & around = Board::GetAroundIndexes( *targetUnit );
-                    for ( const int cell : around ) {
-                        if ( arena.hexIsPassable( cell ) ) {
+
+                    for ( const int cell : Board::GetAroundIndexes( *targetUnit ) ) {
+                        if ( arena.hexIsPassable( cell ) && ( targetCell == -1 || arena.CalculateMoveDistance( cell ) < arena.CalculateMoveDistance( targetCell ) ) ) {
                             targetCell = cell;
-                            break;
                         }
                     }
 

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -599,7 +599,7 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( const Unit & attacker, U
 
             Unit * enemy = Board::GetCell( aroundIdx )->GetUnit();
 
-            if ( enemy && enemy->GetColor() != attacker.GetColor() && consideredTargets.insert( enemy ).second ) {
+            if ( enemy && enemy->GetColor() != attacker.GetCurrentColor() && consideredTargets.insert( enemy ).second ) {
                 res.defender = enemy;
                 res.damage = attacker.GetDamage( *enemy );
 

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -532,7 +532,7 @@ int32_t Battle::Board::OptimalAttackValue( const Unit & attacker, const Unit & t
         Board * board = Arena::GetBoard();
         for ( const int32_t index : aroundAttacker ) {
             const Unit * unit = board->at( index ).GetUnit();
-            if ( unit != nullptr && unit->GetColor() != attacker.GetColor() ) {
+            if ( unit != nullptr && unit->GetColor() != attacker.GetCurrentColor() ) {
                 unitsUnderAttack.insert( unit );
             }
         }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1729,7 +1729,7 @@ void Battle::Interface::RedrawCover()
 
                     const Unit * aroundUnit = aroundCell->GetUnit();
 
-                    if ( aroundUnit && aroundUnit->GetColor() != _currentUnit->GetColor() ) {
+                    if ( aroundUnit && aroundUnit->GetColor() != _currentUnit->GetCurrentColor() ) {
                         highlightCells.emplace( aroundCell );
                     }
                 }


### PR DESCRIPTION
Currently his "splash" melee attack always targets only units from the opposing army.

Also, when choosing a cell from which the unit affected by Berserk spell will attack the target unit, always try to choose the nearest one (according to the AI pathfinder).

P.S. What's funny, in this situation:

<img width="639" alt="Hydra Berserk AI Pathfinder" src="https://user-images.githubusercontent.com/32623900/152039852-111ea58a-1197-41c2-b893-80acf9c0a388.png">

AI pathfinder thinks that Hydra (under Berserk spell) can move to the cell 34, and then happens this:

```
22:42:13: [DBG_BATTLE]	berserkTurn:  Hydra is under Berserk spell, moving to 34
22:42:13: [DBG_BATTLE]	berserkTurn:  Nearest reachable cell is -1
22:42:13: [DBG_BATTLE]	ApplyActionMove:  incorrect param: uid: 3, dst: -1
22:42:13: [DBG_BATTLE]	ApplyActionEnd:  uid: 3 moved
```

because cell 34 is the tail cell of Red Dragons, and there is absolutely no possibility for Hydra to move to this cell. But that's a relatively minor issue.