### PR TITLE
Allow a short name for all campaign bonus artifacts and spells

### DIFF
--- a/files/lang/cs.po
+++ b/files/lang/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-27 13:40+0100\n"
+"POT-Creation-Date: 2022-02-17 08:59+0100\n"
 "PO-Revision-Date: 2021-11-07 17:03+0100\n"
 "Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
 "Language-Team: Czech <cs@li.org>\n"
@@ -702,6 +702,12 @@ msgstr ""
 msgid "Save the Dwarves"
 msgstr ""
 
+msgid "The Crown"
+msgstr ""
+
+msgid "The Gauntlet"
+msgstr ""
+
 msgid "Turning Point"
 msgstr ""
 
@@ -709,12 +715,6 @@ msgid "Corlagon's Defense"
 msgstr ""
 
 msgid "Final Justice"
-msgstr ""
-
-msgid "The Crown"
-msgstr ""
-
-msgid "The Gauntlet"
 msgstr ""
 
 msgid ""
@@ -787,19 +787,19 @@ msgstr ""
 msgid "Necromancers"
 msgstr ""
 
-msgid "Rebellion"
-msgstr ""
-
 msgid "Slay the Dwarves"
-msgstr ""
-
-msgid "Apocalypse"
 msgstr ""
 
 msgid "Country Lords"
 msgstr ""
 
 msgid "Dragon Master"
+msgstr ""
+
+msgid "Rebellion"
+msgstr ""
+
+msgid "Apocalypse"
 msgstr ""
 
 msgid "Greater Glory"
@@ -1119,51 +1119,103 @@ msgstr ""
 msgid "\"The Dwarfbane!!!!, run for your lives.\""
 msgstr ""
 
-msgid "Caster's Bracelet"
+msgid "campaignBonus|Ballista"
+msgstr ""
+
+msgid "campaignBonus|Black Pearl"
+msgstr ""
+
+msgid "campaignBonus|Caster's Bracelet"
 msgstr ""
 
 #, fuzzy
-msgid "Defender Helm"
+msgid "campaignBonus|Defender Helm"
 msgstr "Obránce"
 
 #, fuzzy
-msgid "Breastplate"
+msgid "campaignBonus|Breastplate"
 msgstr "Tržiště"
 
-msgid "Dragon Sword"
+msgid "campaignBonus|Dragon Sword"
 msgstr ""
 
-msgid "Fizbin Medal"
+msgid "campaignBonus|Fizbin Medal"
 msgstr ""
 
-msgid "Foremost Scroll"
+msgid "campaignBonus|Foremost Scroll"
 msgstr ""
 
-msgid "Mage's Ring"
+msgid "campaignBonus|Hideous Mask"
 msgstr ""
 
-msgid "Major Scroll"
+msgid "campaignBonus|Mage's Ring"
 msgstr ""
 
-msgid "Minor Scroll"
+msgid "campaignBonus|Major Scroll"
 msgstr ""
 
-msgid "Nomad Boots"
+msgid "campaignBonus|Medal of Honor"
 msgstr ""
 
-msgid "Power Axe"
+msgid "campaignBonus|Medal of Valor"
 msgstr ""
 
-msgid "Stealth Shield"
+msgid "campaignBonus|Minor Scroll"
 msgstr ""
 
-msgid "Thunder Mace"
+msgid "campaignBonus|Nomad Boots"
 msgstr ""
 
-msgid "Traveler's Boots"
+msgid "campaignBonus|Power Axe"
 msgstr ""
 
-msgid "Summon Earth"
+msgid "campaignBonus|Spiked Shield"
+msgstr ""
+
+msgid "campaignBonus|Stealth Shield"
+msgstr ""
+
+msgid "campaignBonus|Tax Lien"
+msgstr ""
+
+msgid "campaignBonus|Thunder Mace"
+msgstr ""
+
+msgid "campaignBonus|Traveler's Boots"
+msgstr ""
+
+msgid "campaignBonus|White Pearl"
+msgstr ""
+
+msgid "campaignBonus|Animate Dead"
+msgstr ""
+
+msgid "campaignBonus|Chain Lightning"
+msgstr ""
+
+msgid "campaignBonus|Fireblast"
+msgstr ""
+
+msgid "campaignBonus|Mass Curse"
+msgstr ""
+
+msgid "campaignBonus|Mass Haste"
+msgstr ""
+
+msgid "campaignBonus|Mirror Image"
+msgstr ""
+
+msgid "campaignBonus|Resurrect"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Steelskin"
+msgstr "Obránce"
+
+msgid "campaignBonus|Summon Earth"
+msgstr ""
+
+msgid "campaignBonus|View Heroes"
 msgstr ""
 
 msgid "The %{building} produces %{monster}."

--- a/files/lang/de.po
+++ b/files/lang/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-27 13:40+0100\n"
+"POT-Creation-Date: 2022-02-17 08:59+0100\n"
 "PO-Revision-Date: 2022-01-22 16:06+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -725,6 +725,12 @@ msgstr "Macht des Schwerts"
 msgid "Save the Dwarves"
 msgstr "Rettet die Zwerge"
 
+msgid "The Crown"
+msgstr "Die Krone"
+
+msgid "The Gauntlet"
+msgstr "Fehdehandschuh"
+
 msgid "Turning Point"
 msgstr "Wendepunkt"
 
@@ -733,12 +739,6 @@ msgstr "Corlagons Kampf"
 
 msgid "Final Justice"
 msgstr "Gerechtigkeit"
-
-msgid "The Crown"
-msgstr "Die Krone"
-
-msgid "The Gauntlet"
-msgstr "Fehdehandschuh"
 
 msgid ""
 "Roland needs you to defeat the lords near his castle to begin his war of "
@@ -848,20 +848,20 @@ msgstr "Erstes Blut"
 msgid "Necromancers"
 msgstr "Totenbeschwörer"
 
-msgid "Rebellion"
-msgstr "Rebellion"
-
 msgid "Slay the Dwarves"
 msgstr "Schlachtet die Zwerge"
-
-msgid "Apocalypse"
-msgstr "Apocalypse"
 
 msgid "Country Lords"
 msgstr "Landesfürsten"
 
 msgid "Dragon Master"
 msgstr "Drachenmeister"
+
+msgid "Rebellion"
+msgstr "Rebellion"
+
+msgid "Apocalypse"
+msgstr "Apocalypse"
 
 msgid "Greater Glory"
 msgstr "Größte Ehre"
@@ -1000,8 +1000,8 @@ msgid ""
 "The sorceresses to the northeast are rebelling! For the good of the empire "
 "you must quash their feeble uprising on your way to the mountains."
 msgstr ""
-"Die Magierinnen im Nordosten rebellieren! Zum Wohle des Reiches müssen "
-"Sie ihren schwachen Aufstand auf Ihren Weg in die Berge niederschlagen."
+"Die Magierinnen im Nordosten rebellieren! Zum Wohle des Reiches müssen Sie "
+"ihren schwachen Aufstand auf Ihren Weg in die Berge niederschlagen."
 
 msgid ""
 "Having prepared for your arrival, Kraeger has arranged for a force of "
@@ -1299,50 +1299,101 @@ msgstr ""
 msgid "\"The Dwarfbane!!!!, run for your lives.\""
 msgstr "\"Zwergenfluch!!!!, rennt um euer Leben.\""
 
-msgid "Caster's Bracelet"
+msgid "campaignBonus|Ballista"
+msgstr "Ballista"
+
+msgid "campaignBonus|Black Pearl"
+msgstr "Schwarze Perle"
+
+msgid "campaignBonus|Caster's Bracelet"
 msgstr "Zauberarmband"
 
-msgid "Defender Helm"
+msgid "campaignBonus|Defender Helm"
 msgstr "Verteidigungshelm"
 
-msgid "Breastplate"
+msgid "campaignBonus|Breastplate"
 msgstr "Brustpanzer"
 
-msgid "Dragon Sword"
+msgid "campaignBonus|Dragon Sword"
 msgstr "Drachenschwert"
 
-msgid "Fizbin Medal"
+msgid "campaignBonus|Fizbin Medal"
 msgstr "Fizbin des Pechs"
 
-msgid "Foremost Scroll"
+msgid "campaignBonus|Foremost Scroll"
 msgstr "Herausragendste Schriftrolle"
 
-msgid "Mage's Ring"
+msgid "campaignBonus|Hideous Mask"
+msgstr "Scheußliche Maske"
+
+msgid "campaignBonus|Mage's Ring"
 msgstr "Ring des Magiers"
 
-msgid "Major Scroll"
+msgid "campaignBonus|Major Scroll"
 msgstr "Grosse Schriftrolle"
 
-msgid "Minor Scroll"
+msgid "campaignBonus|Medal of Honor"
+msgstr "Medaille der Ehre"
+
+msgid "campaignBonus|Medal of Valor"
+msgstr "Medaille der Tapferkeit"
+
+msgid "campaignBonus|Minor Scroll"
 msgstr "Kleine Schriftrolle"
 
-msgid "Nomad Boots"
+msgid "campaignBonus|Nomad Boots"
 msgstr "Nomadenstiefel"
 
-msgid "Power Axe"
+msgid "campaignBonus|Power Axe"
 msgstr "Power-Axt"
 
-msgid "Stealth Shield"
+msgid "campaignBonus|Spiked Shield"
+msgstr "Stachelschild"
+
+msgid "campaignBonus|Stealth Shield"
 msgstr "Tarnkappenschild"
 
-msgid "Thunder Mace"
+msgid "campaignBonus|Tax Lien"
+msgstr "Steuererklärung"
+
+msgid "campaignBonus|Thunder Mace"
 msgstr "Donnerstab"
 
-msgid "Traveler's Boots"
+msgid "campaignBonus|Traveler's Boots"
 msgstr "Reisestiefel"
 
-msgid "Summon Earth"
+msgid "campaignBonus|White Pearl"
+msgstr "Weisse Perle"
+
+msgid "campaignBonus|Animate Dead"
+msgstr "Tote beleben"
+
+msgid "campaignBonus|Chain Lightning"
+msgstr "Kettenblitzstrahl"
+
+msgid "campaignBonus|Fireblast"
+msgstr "Feuerstoß"
+
+msgid "campaignBonus|Mass Curse"
+msgstr "Massenfluch"
+
+msgid "campaignBonus|Mass Haste"
+msgstr "Masseneile"
+
+msgid "campaignBonus|Mirror Image"
+msgstr "Spiegelbild"
+
+msgid "campaignBonus|Resurrect"
+msgstr "Tote beleben"
+
+msgid "campaignBonus|Steelskin"
+msgstr "Stahlhaut"
+
+msgid "campaignBonus|Summon Earth"
 msgstr "Erdwesen beschwören"
+
+msgid "campaignBonus|View Heroes"
+msgstr "Helden anzeigen"
 
 msgid "The %{building} produces %{monster}."
 msgstr "Der %{building} produziert %{monster}."
@@ -8745,6 +8796,9 @@ msgstr ""
 "Die neueste Version des Spiels finden Sie unter\n"
 "https://github.com/ihhub/\n"
 "fheroes2/releases"
+
+#~ msgid "Power Axe"
+#~ msgstr "Power-Axt"
 
 #~ msgid "battle: show army order"
 #~ msgstr "Schlacht: Reihenfolge von Armeen anzeigen"

--- a/files/lang/es.po
+++ b/files/lang/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-27 13:40+0100\n"
+"POT-Creation-Date: 2022-02-17 08:59+0100\n"
 "PO-Revision-Date: 2021-11-07 17:12+0100\n"
 "Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -768,6 +768,14 @@ msgid "Save the Dwarves"
 msgstr "\"Salva a los Enanos\""
 
 #, fuzzy
+msgid "The Crown"
+msgstr "\"La Corona\""
+
+#, fuzzy
+msgid "The Gauntlet"
+msgstr "\"El Guantelete\""
+
+#, fuzzy
 msgid "Turning Point"
 msgstr "\"Punto de retorno\""
 
@@ -777,14 +785,6 @@ msgstr "Corlagon"
 
 msgid "Final Justice"
 msgstr ""
-
-#, fuzzy
-msgid "The Crown"
-msgstr "\"La Corona\""
-
-#, fuzzy
-msgid "The Gauntlet"
-msgstr "\"El Guantelete\""
 
 msgid ""
 "Roland needs you to defeat the lords near his castle to begin his war of "
@@ -859,16 +859,9 @@ msgstr "\"Primera Sangre\""
 msgid "Necromancers"
 msgstr "Nigromante"
 
-msgid "Rebellion"
-msgstr ""
-
 #, fuzzy
 msgid "Slay the Dwarves"
 msgstr "\"Da muerte a los Enanos\""
-
-#, fuzzy
-msgid "Apocalypse"
-msgstr "\"Apocalipsis\""
 
 #, fuzzy
 msgid "Country Lords"
@@ -877,6 +870,13 @@ msgstr "\"Señores del Pais\""
 #, fuzzy
 msgid "Dragon Master"
 msgstr "\"Maestro Dragón\""
+
+msgid "Rebellion"
+msgstr ""
+
+#, fuzzy
+msgid "Apocalypse"
+msgstr "\"Apocalipsis\""
 
 #, fuzzy
 msgid "Greater Glory"
@@ -1230,64 +1230,125 @@ msgstr ""
 msgid "\"The Dwarfbane!!!!, run for your lives.\""
 msgstr ""
 
-#, fuzzy
-msgid "Caster's Bracelet"
-msgstr "Brazalete del Lanzador de la Magia"
-
-#, fuzzy
-msgid "Defender Helm"
-msgstr "Defensor"
-
-#, fuzzy
-msgid "Breastplate"
-msgstr "Peto de Anduran"
-
-#, fuzzy
-msgid "Dragon Sword"
-msgstr "Matadragones"
-
-msgid "Fizbin Medal"
+msgid "campaignBonus|Ballista"
 msgstr ""
 
 #, fuzzy
-msgid "Foremost Scroll"
+msgid "campaignBonus|Black Pearl"
+msgstr "Perla Negra"
+
+#, fuzzy
+msgid "campaignBonus|Caster's Bracelet"
+msgstr "Brazalete del Lanzador de la Magia"
+
+#, fuzzy
+msgid "campaignBonus|Defender Helm"
+msgstr "Defensor"
+
+#, fuzzy
+msgid "campaignBonus|Breastplate"
+msgstr "Peto de Anduran"
+
+#, fuzzy
+msgid "campaignBonus|Dragon Sword"
+msgstr "Matadragones"
+
+msgid "campaignBonus|Fizbin Medal"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Foremost Scroll"
 msgstr "Principal Pergamino de Conocimiento"
 
 #, fuzzy
-msgid "Mage's Ring"
+msgid "campaignBonus|Hideous Mask"
+msgstr "Máscara Horrenda"
+
+#, fuzzy
+msgid "campaignBonus|Mage's Ring"
 msgstr "Anillo del Mago del Poder"
 
 #, fuzzy
-msgid "Major Scroll"
+msgid "campaignBonus|Major Scroll"
 msgstr "Rollo Mayor del Conocimiento"
 
 #, fuzzy
-msgid "Minor Scroll"
+msgid "campaignBonus|Medal of Honor"
+msgstr "La Medalla de Honor"
+
+#, fuzzy
+msgid "campaignBonus|Medal of Valor"
+msgstr "La Medalla de Valor"
+
+#, fuzzy
+msgid "campaignBonus|Minor Scroll"
 msgstr "Pergamino Menor de Conocimiento"
 
 #, fuzzy
-msgid "Nomad Boots"
+msgid "campaignBonus|Nomad Boots"
 msgstr "Nómadas"
 
-#, fuzzy
-msgid "Power Axe"
-msgstr "Poder"
+msgid "campaignBonus|Power Axe"
+msgstr ""
 
 #, fuzzy
-msgid "Stealth Shield"
+msgid "campaignBonus|Spiked Shield"
+msgstr "Escudo Picudo"
+
+#, fuzzy
+msgid "campaignBonus|Stealth Shield"
 msgstr "El Escudo Supremo"
 
+msgid "campaignBonus|Tax Lien"
+msgstr ""
+
 #, fuzzy
-msgid "Thunder Mace"
+msgid "campaignBonus|Thunder Mace"
 msgstr "Maza del Trueno de Dominio"
 
 #, fuzzy
-msgid "Traveler's Boots"
+msgid "campaignBonus|Traveler's Boots"
 msgstr "Botas de Viajero de la Movilidad"
 
 #, fuzzy
-msgid "Summon Earth"
+msgid "campaignBonus|White Pearl"
+msgstr "Perla Blanca"
+
+#, fuzzy
+msgid "campaignBonus|Animate Dead"
+msgstr "Animar Muertos"
+
+#, fuzzy
+msgid "campaignBonus|Chain Lightning"
+msgstr "Cadena de Rayos"
+
+msgid "campaignBonus|Fireblast"
+msgstr ""
+
+msgid "campaignBonus|Mass Curse"
+msgstr ""
+
+msgid "campaignBonus|Mass Haste"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Mirror Image"
+msgstr "Doble Imagen"
+
+msgid "campaignBonus|Resurrect"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Steelskin"
+msgstr "Anillo del Mago del Poder"
+
+#, fuzzy
+msgid "campaignBonus|Summon Earth"
 msgstr "LLamar Barco"
+
+#, fuzzy
+msgid "campaignBonus|View Heroes"
+msgstr "Ver Heroes"
 
 msgid "The %{building} produces %{monster}."
 msgstr "Produce: %{monster}."
@@ -8797,6 +8858,10 @@ msgstr ""
 "Puedes descargar la última versión del juego desde el sítio:\n"
 "https://github.com/ihhub/\n"
 "fheroes2/releases"
+
+#, fuzzy
+#~ msgid "Power Axe"
+#~ msgstr "Poder"
 
 #, fuzzy
 #~ msgid "battle: show army order"

--- a/files/lang/fr.po
+++ b/files/lang/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-27 13:40+0100\n"
+"POT-Creation-Date: 2022-02-17 08:59+0100\n"
 "PO-Revision-Date: 2022-01-22 22:10+0100\n"
 "Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
 "Language-Team: French <fr@li.org>\n"
@@ -722,6 +722,12 @@ msgstr "Force des armes"
 msgid "Save the Dwarves"
 msgstr "Sauve les Nains"
 
+msgid "The Crown"
+msgstr "La Couronne"
+
+msgid "The Gauntlet"
+msgstr "Le gantelet"
+
 msgid "Turning Point"
 msgstr "Moment Décisif"
 
@@ -730,12 +736,6 @@ msgstr "Défense de Corlagon"
 
 msgid "Final Justice"
 msgstr "Justice définitive"
-
-msgid "The Crown"
-msgstr "La Couronne"
-
-msgid "The Gauntlet"
-msgstr "Le gantelet"
 
 msgid ""
 "Roland needs you to defeat the lords near his castle to begin his war of "
@@ -843,20 +843,20 @@ msgstr "Premier sang"
 msgid "Necromancers"
 msgstr "Nécromanciens"
 
-msgid "Rebellion"
-msgstr "Rébellion"
-
 msgid "Slay the Dwarves"
 msgstr "Massacre des Nains"
-
-msgid "Apocalypse"
-msgstr "Apocalypse"
 
 msgid "Country Lords"
 msgstr "Seigneurs du Pays"
 
 msgid "Dragon Master"
 msgstr "Maître des Dragons"
+
+msgid "Rebellion"
+msgstr "Rébellion"
+
+msgid "Apocalypse"
+msgstr "Apocalypse"
 
 msgid "Greater Glory"
 msgstr "Grande Gloire"
@@ -1287,50 +1287,125 @@ msgstr ""
 msgid "\"The Dwarfbane!!!!, run for your lives.\""
 msgstr "\"Le Dwarfbane!!!!, sauve qui peut.\""
 
-msgid "Caster's Bracelet"
+msgid "campaignBonus|Ballista"
+msgstr "Baliste"
+
+#, fuzzy
+msgid "campaignBonus|Black Pearl"
+msgstr "Perle noire"
+
+#, fuzzy
+msgid "campaignBonus|Caster's Bracelet"
 msgstr "Bracelet magique"
 
-msgid "Defender Helm"
+#, fuzzy
+msgid "campaignBonus|Defender Helm"
 msgstr "Casque de Protection"
 
-msgid "Breastplate"
+#, fuzzy
+msgid "campaignBonus|Breastplate"
 msgstr "Plastron Divin"
 
-msgid "Dragon Sword"
+#, fuzzy
+msgid "campaignBonus|Dragon Sword"
 msgstr "L'épée du Dragon"
 
-msgid "Fizbin Medal"
+#, fuzzy
+msgid "campaignBonus|Fizbin Medal"
 msgstr "Fizbin"
 
-msgid "Foremost Scroll"
+#, fuzzy
+msgid "campaignBonus|Foremost Scroll"
 msgstr "Parchemin ultime"
 
-msgid "Mage's Ring"
+#, fuzzy
+msgid "campaignBonus|Hideous Mask"
+msgstr "Masque sinistre"
+
+#, fuzzy
+msgid "campaignBonus|Mage's Ring"
 msgstr "Anneau de Magicien"
 
-msgid "Major Scroll"
+#, fuzzy
+msgid "campaignBonus|Major Scroll"
 msgstr "Parchemin majeur"
 
-msgid "Minor Scroll"
+#, fuzzy
+msgid "campaignBonus|Medal of Honor"
+msgstr "Médaille d'honneur"
+
+#, fuzzy
+msgid "campaignBonus|Medal of Valor"
+msgstr "Médaille de la bravoure"
+
+#, fuzzy
+msgid "campaignBonus|Minor Scroll"
 msgstr "Parchemin Mineur"
 
-msgid "Nomad Boots"
+#, fuzzy
+msgid "campaignBonus|Nomad Boots"
 msgstr "Bottes de Nomade"
 
-msgid "Power Axe"
+msgid "campaignBonus|Power Axe"
 msgstr "Puissante Hache"
 
-msgid "Stealth Shield"
+#, fuzzy
+msgid "campaignBonus|Spiked Shield"
+msgstr "Bouclier à pointes"
+
+#, fuzzy
+msgid "campaignBonus|Stealth Shield"
 msgstr "Bouclier furtif"
 
-msgid "Thunder Mace"
+msgid "campaignBonus|Tax Lien"
+msgstr "Privilège fiscal"
+
+#, fuzzy
+msgid "campaignBonus|Thunder Mace"
 msgstr "Massue du Tonnerre"
 
-msgid "Traveler's Boots"
+#, fuzzy
+msgid "campaignBonus|Traveler's Boots"
 msgstr "Bottes magiques"
 
-msgid "Summon Earth"
+#, fuzzy
+msgid "campaignBonus|White Pearl"
+msgstr "Perle blanche"
+
+#, fuzzy
+msgid "campaignBonus|Animate Dead"
+msgstr "Mort-vivant"
+
+#, fuzzy
+msgid "campaignBonus|Chain Lightning"
+msgstr "Foudre"
+
+msgid "campaignBonus|Fireblast"
+msgstr "Souffle de feu"
+
+msgid "campaignBonus|Mass Curse"
+msgstr "Grande malédiction"
+
+msgid "campaignBonus|Mass Haste"
+msgstr "Célérité collective"
+
+msgid "campaignBonus|Mirror Image"
+msgstr "Miroir"
+
+msgid "campaignBonus|Resurrect"
+msgstr "Mort-vivant"
+
+#, fuzzy
+msgid "campaignBonus|Steelskin"
+msgstr "Chair d'acier"
+
+#, fuzzy
+msgid "campaignBonus|Summon Earth"
 msgstr "Invoquer Terre"
+
+#, fuzzy
+msgid "campaignBonus|View Heroes"
+msgstr "Voir Héros"
 
 msgid "The %{building} produces %{monster}."
 msgstr "Le %{building} produit des %{monster}."
@@ -8713,6 +8788,9 @@ msgstr ""
 "Téléchargez la dernière version du jeu sur\n"
 "https://github.com/ihhub/\n"
 "fheroes2/releases"
+
+#~ msgid "Power Axe"
+#~ msgstr "Puissante Hache"
 
 #~ msgid "battle: show army order"
 #~ msgstr "combat : afficher l'ordre de jeu des créatures"

--- a/files/lang/hu.po
+++ b/files/lang/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-27 13:40+0100\n"
+"POT-Creation-Date: 2022-02-17 08:59+0100\n"
 "PO-Revision-Date: 2021-11-07 17:16+0100\n"
 "Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -753,6 +753,13 @@ msgid "Save the Dwarves"
 msgstr "Törp harcos"
 
 #, fuzzy
+msgid "The Crown"
+msgstr "\"Korona\""
+
+msgid "The Gauntlet"
+msgstr ""
+
+#, fuzzy
 msgid "Turning Point"
 msgstr "Fordulópont"
 
@@ -761,13 +768,6 @@ msgid "Corlagon's Defense"
 msgstr "Sárkány Szem"
 
 msgid "Final Justice"
-msgstr ""
-
-#, fuzzy
-msgid "The Crown"
-msgstr "\"Korona\""
-
-msgid "The Gauntlet"
 msgstr ""
 
 msgid ""
@@ -843,15 +843,9 @@ msgstr "\"Első vérig\""
 msgid "Necromancers"
 msgstr "Hullamágus"
 
-msgid "Rebellion"
-msgstr ""
-
 #, fuzzy
 msgid "Slay the Dwarves"
 msgstr "Törp harcos"
-
-msgid "Apocalypse"
-msgstr ""
 
 #, fuzzy
 msgid "Country Lords"
@@ -860,6 +854,12 @@ msgstr "Ogre Nagyúr"
 #, fuzzy
 msgid "Dragon Master"
 msgstr "\"Sárkánymester\""
+
+msgid "Rebellion"
+msgstr ""
+
+msgid "Apocalypse"
+msgstr ""
 
 #, fuzzy
 msgid "Greater Glory"
@@ -1188,59 +1188,123 @@ msgstr ""
 msgid "\"The Dwarfbane!!!!, run for your lives.\""
 msgstr ""
 
+msgid "campaignBonus|Ballista"
+msgstr ""
+
 #, fuzzy
-msgid "Caster's Bracelet"
+msgid "campaignBonus|Black Pearl"
+msgstr "Fekete Gyöngy"
+
+#, fuzzy
+msgid "campaignBonus|Caster's Bracelet"
 msgstr "Idéző Varázslat Karkötője"
 
 #, fuzzy
-msgid "Defender Helm"
+msgid "campaignBonus|Defender Helm"
 msgstr "Védekező"
 
 #, fuzzy
-msgid "Breastplate"
+msgid "campaignBonus|Breastplate"
 msgstr "Anduran Mellvértje"
 
-msgid "Dragon Sword"
+#, fuzzy
+msgid "campaignBonus|Dragon Sword"
 msgstr "Sárkánykard"
 
-msgid "Fizbin Medal"
+msgid "campaignBonus|Fizbin Medal"
 msgstr ""
 
-msgid "Foremost Scroll"
+msgid "campaignBonus|Foremost Scroll"
 msgstr ""
 
 #, fuzzy
-msgid "Mage's Ring"
+msgid "campaignBonus|Hideous Mask"
+msgstr "Förtelmes Maszk"
+
+#, fuzzy
+msgid "campaignBonus|Mage's Ring"
 msgstr "Varázsgyűrű"
 
-msgid "Major Scroll"
+msgid "campaignBonus|Major Scroll"
 msgstr ""
 
-msgid "Minor Scroll"
+#, fuzzy
+msgid "campaignBonus|Medal of Honor"
+msgstr "Becsület Medál"
+
+#, fuzzy
+msgid "campaignBonus|Medal of Valor"
+msgstr "Vitézség Medál"
+
+#, fuzzy
+msgid "campaignBonus|Minor Scroll"
 msgstr "Kis Pergamentekercs"
 
 #, fuzzy
-msgid "Nomad Boots"
+msgid "campaignBonus|Nomad Boots"
 msgstr "Nomád"
 
-#, fuzzy
-msgid "Power Axe"
-msgstr "Erő"
+msgid "campaignBonus|Power Axe"
+msgstr ""
 
 #, fuzzy
-msgid "Stealth Shield"
+msgid "campaignBonus|Spiked Shield"
+msgstr "Tüskés Pajzs"
+
+#, fuzzy
+msgid "campaignBonus|Stealth Shield"
 msgstr "Szent Pajzs"
 
+msgid "campaignBonus|Tax Lien"
+msgstr ""
+
 #, fuzzy
-msgid "Thunder Mace"
+msgid "campaignBonus|Thunder Mace"
 msgstr "Hatalom Mennydörgő Buzogánya"
 
-msgid "Traveler's Boots"
+#, fuzzy
+msgid "campaignBonus|Traveler's Boots"
 msgstr "Utazócsizma"
 
 #, fuzzy
-msgid "Summon Earth"
+msgid "campaignBonus|White Pearl"
+msgstr "Fehér Gyöngy"
+
+#, fuzzy
+msgid "campaignBonus|Animate Dead"
+msgstr "Feltámasztás"
+
+#, fuzzy
+msgid "campaignBonus|Chain Lightning"
+msgstr "Láncvillám"
+
+msgid "campaignBonus|Fireblast"
+msgstr ""
+
+msgid "campaignBonus|Mass Curse"
+msgstr ""
+
+msgid "campaignBonus|Mass Haste"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Mirror Image"
+msgstr "Tükörkép"
+
+msgid "campaignBonus|Resurrect"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Steelskin"
+msgstr "Varázsgyűrű"
+
+#, fuzzy
+msgid "campaignBonus|Summon Earth"
 msgstr "Hajó idézése"
+
+#, fuzzy
+msgid "campaignBonus|View Heroes"
+msgstr "Hősök mutatása"
 
 msgid "The %{building} produces %{monster}."
 msgstr "A(z) %{building} %{monster}-t termel."
@@ -8410,6 +8474,10 @@ msgstr ""
 "Letöltheted a legújabb verziót az oldalról:\n"
 "https://github.com/ihhub/\n"
 "fheroes2/releases"
+
+#, fuzzy
+#~ msgid "Power Axe"
+#~ msgstr "Erő"
 
 #, fuzzy
 #~ msgid "Buy Monsters"

--- a/files/lang/it.po
+++ b/files/lang/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-27 13:40+0100\n"
+"POT-Creation-Date: 2022-02-17 08:59+0100\n"
 "PO-Revision-Date: 2021-11-23 23:57+0100\n"
 "Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
 "Language-Team: <it@li.org>\n"
@@ -693,6 +693,12 @@ msgstr ""
 msgid "Save the Dwarves"
 msgstr ""
 
+msgid "The Crown"
+msgstr ""
+
+msgid "The Gauntlet"
+msgstr ""
+
 msgid "Turning Point"
 msgstr ""
 
@@ -700,12 +706,6 @@ msgid "Corlagon's Defense"
 msgstr ""
 
 msgid "Final Justice"
-msgstr ""
-
-msgid "The Crown"
-msgstr ""
-
-msgid "The Gauntlet"
 msgstr ""
 
 msgid ""
@@ -778,19 +778,19 @@ msgstr ""
 msgid "Necromancers"
 msgstr ""
 
-msgid "Rebellion"
-msgstr ""
-
 msgid "Slay the Dwarves"
-msgstr ""
-
-msgid "Apocalypse"
 msgstr ""
 
 msgid "Country Lords"
 msgstr ""
 
 msgid "Dragon Master"
+msgstr ""
+
+msgid "Rebellion"
+msgstr ""
+
+msgid "Apocalypse"
 msgstr ""
 
 msgid "Greater Glory"
@@ -1110,50 +1110,111 @@ msgstr ""
 msgid "\"The Dwarfbane!!!!, run for your lives.\""
 msgstr ""
 
-msgid "Caster's Bracelet"
+msgid "campaignBonus|Ballista"
 msgstr ""
 
-msgid "Defender Helm"
+#, fuzzy
+msgid "campaignBonus|Black Pearl"
+msgstr "La Perla Nera"
+
+msgid "campaignBonus|Caster's Bracelet"
 msgstr ""
 
-msgid "Breastplate"
+msgid "campaignBonus|Defender Helm"
 msgstr ""
 
-msgid "Dragon Sword"
+msgid "campaignBonus|Breastplate"
 msgstr ""
 
-msgid "Fizbin Medal"
+msgid "campaignBonus|Dragon Sword"
 msgstr ""
 
-msgid "Foremost Scroll"
+msgid "campaignBonus|Fizbin Medal"
 msgstr ""
 
-msgid "Mage's Ring"
+msgid "campaignBonus|Foremost Scroll"
 msgstr ""
 
-msgid "Major Scroll"
+msgid "campaignBonus|Hideous Mask"
 msgstr ""
 
-msgid "Minor Scroll"
+msgid "campaignBonus|Mage's Ring"
 msgstr ""
 
-msgid "Nomad Boots"
+msgid "campaignBonus|Major Scroll"
 msgstr ""
 
-msgid "Power Axe"
+msgid "campaignBonus|Medal of Honor"
 msgstr ""
 
-msgid "Stealth Shield"
+#, fuzzy
+msgid "campaignBonus|Medal of Valor"
+msgstr "La Medaglia al Valore"
+
+msgid "campaignBonus|Minor Scroll"
+msgstr ""
+
+msgid "campaignBonus|Nomad Boots"
+msgstr ""
+
+msgid "campaignBonus|Power Axe"
+msgstr ""
+
+msgid "campaignBonus|Spiked Shield"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Stealth Shield"
 msgstr "Scudo Segreto"
 
-msgid "Thunder Mace"
+msgid "campaignBonus|Tax Lien"
 msgstr ""
 
-msgid "Traveler's Boots"
+msgid "campaignBonus|Thunder Mace"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Traveler's Boots"
 msgstr "Scarpe del viaggiante"
 
-msgid "Summon Earth"
+#, fuzzy
+msgid "campaignBonus|White Pearl"
+msgstr "La Perla Bianca"
+
+#, fuzzy
+msgid "campaignBonus|Animate Dead"
+msgstr "Anima i Morti"
+
+#, fuzzy
+msgid "campaignBonus|Chain Lightning"
+msgstr "Fulmini in Serie"
+
+msgid "campaignBonus|Fireblast"
 msgstr ""
+
+msgid "campaignBonus|Mass Curse"
+msgstr ""
+
+msgid "campaignBonus|Mass Haste"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Mirror Image"
+msgstr "Rispecchia"
+
+msgid "campaignBonus|Resurrect"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Steelskin"
+msgstr "La Perla Bianca"
+
+msgid "campaignBonus|Summon Earth"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|View Heroes"
+msgstr "Mostra Eroi"
 
 msgid "The %{building} produces %{monster}."
 msgstr "Il/la %{building} produce %{monster}."

--- a/files/lang/lt.po
+++ b/files/lang/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-27 13:40+0100\n"
+"POT-Creation-Date: 2022-02-17 08:59+0100\n"
 "PO-Revision-Date: 2021-11-07 19:44+0100\n"
 "Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
 "Language-Team: Lithuanian <lt@li.org>\n"
@@ -692,6 +692,13 @@ msgstr ""
 msgid "Save the Dwarves"
 msgstr ""
 
+#, fuzzy
+msgid "The Crown"
+msgstr "Rytų miestas."
+
+msgid "The Gauntlet"
+msgstr ""
+
 msgid "Turning Point"
 msgstr ""
 
@@ -699,13 +706,6 @@ msgid "Corlagon's Defense"
 msgstr ""
 
 msgid "Final Justice"
-msgstr ""
-
-#, fuzzy
-msgid "The Crown"
-msgstr "Rytų miestas."
-
-msgid "The Gauntlet"
 msgstr ""
 
 msgid ""
@@ -778,19 +778,19 @@ msgstr ""
 msgid "Necromancers"
 msgstr ""
 
-msgid "Rebellion"
-msgstr ""
-
 msgid "Slay the Dwarves"
-msgstr ""
-
-msgid "Apocalypse"
 msgstr ""
 
 msgid "Country Lords"
 msgstr ""
 
 msgid "Dragon Master"
+msgstr ""
+
+msgid "Rebellion"
+msgstr ""
+
+msgid "Apocalypse"
 msgstr ""
 
 msgid "Greater Glory"
@@ -1112,52 +1112,104 @@ msgstr ""
 msgid "\"The Dwarfbane!!!!, run for your lives.\""
 msgstr ""
 
-msgid "Caster's Bracelet"
+msgid "campaignBonus|Ballista"
+msgstr ""
+
+msgid "campaignBonus|Black Pearl"
+msgstr ""
+
+msgid "campaignBonus|Caster's Bracelet"
 msgstr ""
 
 #, fuzzy
-msgid "Defender Helm"
+msgid "campaignBonus|Defender Helm"
 msgstr "Gynybos įgūdis"
 
 #, fuzzy
-msgid "Breastplate"
+msgid "campaignBonus|Breastplate"
 msgstr "Turgus"
 
 #, fuzzy
-msgid "Dragon Sword"
+msgid "campaignBonus|Dragon Sword"
 msgstr "Drakonų miestas"
 
-msgid "Fizbin Medal"
+msgid "campaignBonus|Fizbin Medal"
 msgstr ""
 
-msgid "Foremost Scroll"
+msgid "campaignBonus|Foremost Scroll"
 msgstr ""
 
-msgid "Mage's Ring"
+msgid "campaignBonus|Hideous Mask"
 msgstr ""
 
-msgid "Major Scroll"
+msgid "campaignBonus|Mage's Ring"
 msgstr ""
 
-msgid "Minor Scroll"
+msgid "campaignBonus|Major Scroll"
 msgstr ""
 
-msgid "Nomad Boots"
+msgid "campaignBonus|Medal of Honor"
 msgstr ""
 
-msgid "Power Axe"
+msgid "campaignBonus|Medal of Valor"
 msgstr ""
 
-msgid "Stealth Shield"
+msgid "campaignBonus|Minor Scroll"
 msgstr ""
 
-msgid "Thunder Mace"
+msgid "campaignBonus|Nomad Boots"
 msgstr ""
 
-msgid "Traveler's Boots"
+msgid "campaignBonus|Power Axe"
 msgstr ""
 
-msgid "Summon Earth"
+msgid "campaignBonus|Spiked Shield"
+msgstr ""
+
+msgid "campaignBonus|Stealth Shield"
+msgstr ""
+
+msgid "campaignBonus|Tax Lien"
+msgstr ""
+
+msgid "campaignBonus|Thunder Mace"
+msgstr ""
+
+msgid "campaignBonus|Traveler's Boots"
+msgstr ""
+
+msgid "campaignBonus|White Pearl"
+msgstr ""
+
+msgid "campaignBonus|Animate Dead"
+msgstr ""
+
+msgid "campaignBonus|Chain Lightning"
+msgstr ""
+
+msgid "campaignBonus|Fireblast"
+msgstr ""
+
+msgid "campaignBonus|Mass Curse"
+msgstr ""
+
+msgid "campaignBonus|Mass Haste"
+msgstr ""
+
+msgid "campaignBonus|Mirror Image"
+msgstr ""
+
+msgid "campaignBonus|Resurrect"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Steelskin"
+msgstr "Gynybos įgūdis"
+
+msgid "campaignBonus|Summon Earth"
+msgstr ""
+
+msgid "campaignBonus|View Heroes"
 msgstr ""
 
 msgid "The %{building} produces %{monster}."

--- a/files/lang/nb.po
+++ b/files/lang/nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-27 13:40+0100\n"
+"POT-Creation-Date: 2022-02-17 08:59+0100\n"
 "PO-Revision-Date: 2021-11-26 03:04+0100\n"
 "Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
 "Language-Team: Norwegian Bokmaal <nb@li.org>\n"
@@ -728,6 +728,12 @@ msgstr "Maktbruk"
 msgid "Save the Dwarves"
 msgstr "Til dvergenes unnsetning"
 
+msgid "The Crown"
+msgstr "Kronen"
+
+msgid "The Gauntlet"
+msgstr "Kappløpet"
+
 msgid "Turning Point"
 msgstr "Vendepunktet"
 
@@ -736,12 +742,6 @@ msgstr "Corlagon sitt forsvar"
 
 msgid "Final Justice"
 msgstr "Den siste rettferd"
-
-msgid "The Crown"
-msgstr "Kronen"
-
-msgid "The Gauntlet"
-msgstr "Kappløpet"
 
 msgid ""
 "Roland needs you to defeat the lords near his castle to begin his war of "
@@ -845,21 +845,21 @@ msgstr "Den første bloddråpen"
 msgid "Necromancers"
 msgstr "Sortekunstnere"
 
-msgid "Rebellion"
-msgstr "Væpnet oppstand"
-
 # Slakt brukes mer om dyr på norsk.
 msgid "Slay the Dwarves"
 msgstr "Drep dvergene"
-
-msgid "Apocalypse"
-msgstr "Dommedag"
 
 msgid "Country Lords"
 msgstr "Landsherrene"
 
 msgid "Dragon Master"
 msgstr "Dragemesteren"
+
+msgid "Rebellion"
+msgstr "Væpnet oppstand"
+
+msgid "Apocalypse"
+msgstr "Dommedag"
 
 msgid "Greater Glory"
 msgstr "Heder og ære"
@@ -1287,50 +1287,128 @@ msgstr ""
 msgid "\"The Dwarfbane!!!!, run for your lives.\""
 msgstr "\"Dvergemorderen!!!! Flykt for livene deres!\""
 
-msgid "Caster's Bracelet"
+msgid "campaignBonus|Ballista"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Black Pearl"
+msgstr "Den sorte perlen"
+
+#, fuzzy
+msgid "campaignBonus|Caster's Bracelet"
 msgstr "Fortryller-armbånd"
 
-msgid "Defender Helm"
+#, fuzzy
+msgid "campaignBonus|Defender Helm"
 msgstr "Forsvarerhjelm"
 
-msgid "Breastplate"
+#, fuzzy
+msgid "campaignBonus|Breastplate"
 msgstr "Brystplate"
 
-msgid "Dragon Sword"
+#, fuzzy
+msgid "campaignBonus|Dragon Sword"
 msgstr "Dragesverdet"
 
-msgid "Fizbin Medal"
+#, fuzzy
+msgid "campaignBonus|Fizbin Medal"
 msgstr "Fizbin-medaljen"
 
-msgid "Foremost Scroll"
+#, fuzzy
+msgid "campaignBonus|Foremost Scroll"
 msgstr "Yprst. kunskpsrull"
 
-msgid "Mage's Ring"
+#, fuzzy
+msgid "campaignBonus|Hideous Mask"
+msgstr "Den forferdelige masken"
+
+#, fuzzy
+msgid "campaignBonus|Mage's Ring"
 msgstr "Magikerens ring"
 
-msgid "Major Scroll"
+#, fuzzy
+msgid "campaignBonus|Major Scroll"
 msgstr "Str. kunskpsrull"
 
-msgid "Minor Scroll"
+#, fuzzy
+msgid "campaignBonus|Medal of Honor"
+msgstr "Æresmedaljen"
+
+#, fuzzy
+msgid "campaignBonus|Medal of Valor"
+msgstr "Medaljen av heltemot"
+
+#, fuzzy
+msgid "campaignBonus|Minor Scroll"
 msgstr "Mindre skriftrull"
 
-msgid "Nomad Boots"
+#, fuzzy
+msgid "campaignBonus|Nomad Boots"
 msgstr "Nomadens sko"
 
-msgid "Power Axe"
-msgstr "Styrkeøks"
+msgid "campaignBonus|Power Axe"
+msgstr ""
 
-msgid "Stealth Shield"
+#, fuzzy
+msgid "campaignBonus|Spiked Shield"
+msgstr "Det piggete skjoldet"
+
+#, fuzzy
+msgid "campaignBonus|Stealth Shield"
 msgstr "Snikeskjoldet"
 
-msgid "Thunder Mace"
+msgid "campaignBonus|Tax Lien"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Thunder Mace"
 msgstr "Tordenklubben"
 
-msgid "Traveler's Boots"
+#, fuzzy
+msgid "campaignBonus|Traveler's Boots"
 msgstr "Vandrerens sko"
 
-msgid "Summon Earth"
+#, fuzzy
+msgid "campaignBonus|White Pearl"
+msgstr "Den hvite perlen"
+
+#, fuzzy
+msgid "campaignBonus|Animate Dead"
+msgstr ""
+"Døde-\n"
+"besjelning"
+
+#, fuzzy
+msgid "campaignBonus|Chain Lightning"
+msgstr "Kjedelyn"
+
+msgid "campaignBonus|Fireblast"
+msgstr ""
+
+msgid "campaignBonus|Mass Curse"
+msgstr ""
+
+msgid "campaignBonus|Mass Haste"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Mirror Image"
+msgstr "Speilbilde"
+
+msgid "campaignBonus|Resurrect"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Steelskin"
+msgstr "Magikerens ring"
+
+#, fuzzy
+msgid "campaignBonus|Summon Earth"
 msgstr "Tilkall jord"
+
+#, fuzzy
+msgid "campaignBonus|View Heroes"
+msgstr "Vis helter"
 
 msgid "The %{building} produces %{monster}."
 msgstr "%{building} gir %{monster}."
@@ -8729,6 +8807,9 @@ msgstr ""
 "Finn den siste oppdateringen av spillet på\n"
 "https://github.com/ihhub/\n"
 "fheroes2/releases"
+
+#~ msgid "Power Axe"
+#~ msgstr "Styrkeøks"
 
 #~ msgid "battle: show army order"
 #~ msgstr "Kamp: Vis rekkefølgen av styrkenes tur."

--- a/files/lang/nl.po
+++ b/files/lang/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-27 13:40+0100\n"
+"POT-Creation-Date: 2022-02-17 08:59+0100\n"
 "PO-Revision-Date: 2009-08-10 12:30+0000\n"
 "Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -666,6 +666,12 @@ msgstr ""
 msgid "Save the Dwarves"
 msgstr ""
 
+msgid "The Crown"
+msgstr ""
+
+msgid "The Gauntlet"
+msgstr ""
+
 msgid "Turning Point"
 msgstr ""
 
@@ -673,12 +679,6 @@ msgid "Corlagon's Defense"
 msgstr ""
 
 msgid "Final Justice"
-msgstr ""
-
-msgid "The Crown"
-msgstr ""
-
-msgid "The Gauntlet"
 msgstr ""
 
 msgid ""
@@ -751,19 +751,19 @@ msgstr ""
 msgid "Necromancers"
 msgstr ""
 
-msgid "Rebellion"
-msgstr ""
-
 msgid "Slay the Dwarves"
-msgstr ""
-
-msgid "Apocalypse"
 msgstr ""
 
 msgid "Country Lords"
 msgstr ""
 
 msgid "Dragon Master"
+msgstr ""
+
+msgid "Rebellion"
+msgstr ""
+
+msgid "Apocalypse"
 msgstr ""
 
 msgid "Greater Glory"
@@ -1083,49 +1083,100 @@ msgstr ""
 msgid "\"The Dwarfbane!!!!, run for your lives.\""
 msgstr ""
 
-msgid "Caster's Bracelet"
+msgid "campaignBonus|Ballista"
 msgstr ""
 
-msgid "Defender Helm"
+msgid "campaignBonus|Black Pearl"
 msgstr ""
 
-msgid "Breastplate"
+msgid "campaignBonus|Caster's Bracelet"
 msgstr ""
 
-msgid "Dragon Sword"
+msgid "campaignBonus|Defender Helm"
 msgstr ""
 
-msgid "Fizbin Medal"
+msgid "campaignBonus|Breastplate"
 msgstr ""
 
-msgid "Foremost Scroll"
+msgid "campaignBonus|Dragon Sword"
 msgstr ""
 
-msgid "Mage's Ring"
+msgid "campaignBonus|Fizbin Medal"
 msgstr ""
 
-msgid "Major Scroll"
+msgid "campaignBonus|Foremost Scroll"
 msgstr ""
 
-msgid "Minor Scroll"
+msgid "campaignBonus|Hideous Mask"
 msgstr ""
 
-msgid "Nomad Boots"
+msgid "campaignBonus|Mage's Ring"
 msgstr ""
 
-msgid "Power Axe"
+msgid "campaignBonus|Major Scroll"
 msgstr ""
 
-msgid "Stealth Shield"
+msgid "campaignBonus|Medal of Honor"
 msgstr ""
 
-msgid "Thunder Mace"
+msgid "campaignBonus|Medal of Valor"
 msgstr ""
 
-msgid "Traveler's Boots"
+msgid "campaignBonus|Minor Scroll"
 msgstr ""
 
-msgid "Summon Earth"
+msgid "campaignBonus|Nomad Boots"
+msgstr ""
+
+msgid "campaignBonus|Power Axe"
+msgstr ""
+
+msgid "campaignBonus|Spiked Shield"
+msgstr ""
+
+msgid "campaignBonus|Stealth Shield"
+msgstr ""
+
+msgid "campaignBonus|Tax Lien"
+msgstr ""
+
+msgid "campaignBonus|Thunder Mace"
+msgstr ""
+
+msgid "campaignBonus|Traveler's Boots"
+msgstr ""
+
+msgid "campaignBonus|White Pearl"
+msgstr ""
+
+msgid "campaignBonus|Animate Dead"
+msgstr ""
+
+msgid "campaignBonus|Chain Lightning"
+msgstr ""
+
+msgid "campaignBonus|Fireblast"
+msgstr ""
+
+msgid "campaignBonus|Mass Curse"
+msgstr ""
+
+msgid "campaignBonus|Mass Haste"
+msgstr ""
+
+msgid "campaignBonus|Mirror Image"
+msgstr ""
+
+msgid "campaignBonus|Resurrect"
+msgstr ""
+
+msgid "campaignBonus|Steelskin"
+msgstr ""
+
+msgid "campaignBonus|Summon Earth"
+msgstr ""
+
+msgid "campaignBonus|View Heroes"
 msgstr ""
 
 msgid "The %{building} produces %{monster}."

--- a/files/lang/pl.po
+++ b/files/lang/pl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-27 13:40+0100\n"
+"POT-Creation-Date: 2022-02-17 08:59+0100\n"
 "PO-Revision-Date: 2013-10-04 21:15+0000\n"
 "Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -738,6 +738,13 @@ msgid "Save the Dwarves"
 msgstr "Uratuj krasnoludy"
 
 #, fuzzy
+msgid "The Crown"
+msgstr "Korona"
+
+msgid "The Gauntlet"
+msgstr ""
+
+#, fuzzy
 msgid "Turning Point"
 msgstr "Punkt zwrotny"
 
@@ -746,13 +753,6 @@ msgid "Corlagon's Defense"
 msgstr "Corlagon"
 
 msgid "Final Justice"
-msgstr ""
-
-#, fuzzy
-msgid "The Crown"
-msgstr "Korona"
-
-msgid "The Gauntlet"
 msgstr ""
 
 msgid ""
@@ -827,16 +827,9 @@ msgstr "Pierwsza krew"
 msgid "Necromancers"
 msgstr "Nekromanci"
 
-msgid "Rebellion"
-msgstr "Bunt"
-
 #, fuzzy
 msgid "Slay the Dwarves"
 msgstr "Krasnoludzcy wojownicy"
-
-#, fuzzy
-msgid "Apocalypse"
-msgstr "Apokalipsa"
 
 #, fuzzy
 msgid "Country Lords"
@@ -845,6 +838,13 @@ msgstr "Kraina Władców"
 #, fuzzy
 msgid "Dragon Master"
 msgstr "Władca Smoków"
+
+msgid "Rebellion"
+msgstr "Bunt"
+
+#, fuzzy
+msgid "Apocalypse"
+msgstr "Apokalipsa"
 
 #, fuzzy
 msgid "Greater Glory"
@@ -1178,50 +1178,126 @@ msgstr ""
 msgid "\"The Dwarfbane!!!!, run for your lives.\""
 msgstr ""
 
-msgid "Caster's Bracelet"
+msgid "campaignBonus|Ballista"
+msgstr "Balista"
+
+#, fuzzy
+msgid "campaignBonus|Black Pearl"
+msgstr "Czarna perła"
+
+#, fuzzy
+msgid "campaignBonus|Caster's Bracelet"
 msgstr "Magiczna bransol"
 
-msgid "Defender Helm"
+#, fuzzy
+msgid "campaignBonus|Defender Helm"
 msgstr "Hełm obrońcy"
 
-msgid "Breastplate"
+#, fuzzy
+msgid "campaignBonus|Breastplate"
 msgstr "Napierśnik"
 
-msgid "Dragon Sword"
+#, fuzzy
+msgid "campaignBonus|Dragon Sword"
 msgstr "Smoczy miecz"
 
-msgid "Fizbin Medal"
+#, fuzzy
+msgid "campaignBonus|Fizbin Medal"
 msgstr "Fizbin"
 
-msgid "Foremost Scroll"
+#, fuzzy
+msgid "campaignBonus|Foremost Scroll"
 msgstr "Doskonały zwój"
 
-msgid "Mage's Ring"
+#, fuzzy
+msgid "campaignBonus|Hideous Mask"
+msgstr "Potworna maska"
+
+#, fuzzy
+msgid "campaignBonus|Mage's Ring"
 msgstr "Pierścień maga"
 
-msgid "Major Scroll"
+#, fuzzy
+msgid "campaignBonus|Major Scroll"
 msgstr "Większy zwój"
 
-msgid "Minor Scroll"
+#, fuzzy
+msgid "campaignBonus|Medal of Honor"
+msgstr "Medal Honoru"
+
+#, fuzzy
+msgid "campaignBonus|Medal of Valor"
+msgstr "Medal Męstwa"
+
+#, fuzzy
+msgid "campaignBonus|Minor Scroll"
 msgstr "Pomniejszy zwój"
 
-msgid "Nomad Boots"
+#, fuzzy
+msgid "campaignBonus|Nomad Boots"
 msgstr "Buty nomada"
 
-msgid "Power Axe"
+msgid "campaignBonus|Power Axe"
 msgstr "Potężny topór"
 
-msgid "Stealth Shield"
+#, fuzzy
+msgid "campaignBonus|Spiked Shield"
+msgstr "Rogata tarcza"
+
+#, fuzzy
+msgid "campaignBonus|Stealth Shield"
 msgstr "Maskuj. tarcza"
 
-msgid "Thunder Mace"
+msgid "campaignBonus|Tax Lien"
+msgstr "Weksel fiskalny"
+
+#, fuzzy
+msgid "campaignBonus|Thunder Mace"
 msgstr "Grzm. maczuga"
 
-msgid "Traveler's Boots"
+#, fuzzy
+msgid "campaignBonus|Traveler's Boots"
 msgstr "Buty podróżnika"
 
-msgid "Summon Earth"
+#, fuzzy
+msgid "campaignBonus|White Pearl"
+msgstr "Biała perła"
+
+#, fuzzy
+msgid "campaignBonus|Animate Dead"
+msgstr "Ożywienie martwych"
+
+#, fuzzy
+msgid "campaignBonus|Chain Lightning"
+msgstr "Łańcuch piorunów"
+
+msgid "campaignBonus|Fireblast"
+msgstr "Eksplozja Ognia"
+
+msgid "campaignBonus|Mass Curse"
+msgstr "Grupowa klątwa"
+
+msgid "campaignBonus|Mass Haste"
+msgstr "Grupowe przyspieszenie"
+
+#, fuzzy
+msgid "campaignBonus|Mirror Image"
+msgstr "Lustrzane odbicie"
+
+msgid "campaignBonus|Resurrect"
+msgstr "Ożywienie"
+
+#, fuzzy
+msgid "campaignBonus|Steelskin"
+msgstr "Stalowa skóra"
+
+#, fuzzy
+msgid "campaignBonus|Summon Earth"
 msgstr "Przyw. ziemi"
+
+#, fuzzy
+msgid "campaignBonus|View Heroes"
+msgstr "Pokaż bohaterów"
 
 msgid "The %{building} produces %{monster}."
 msgstr "%{building} - tu rekrutuje się: %{monster}."
@@ -2941,7 +3017,8 @@ msgstr "Uwaga"
 msgid ""
 "This file is saved in the \"The Price of Loyalty\" version.\n"
 "Some items may be unavailable."
-msgstr "Ten plik jest zapisany w wersji \"Cena Lojalności\".\n"
+msgstr ""
+"Ten plik jest zapisany w wersji \"Cena Lojalności\".\n"
 "Niektóre elementy mogą być niedostępne."
 
 msgid "Usupported save format: "
@@ -8500,6 +8577,9 @@ msgstr ""
 "Możesz pobrać najnowszą wersję gry ze strony:\n"
 "https://github.com/ihhub/\n"
 "fheroes2/releases"
+
+#~ msgid "Power Axe"
+#~ msgstr "Potężny topór"
 
 #~ msgid "battle: show army order"
 #~ msgstr "walka: pokaż kolejność jednostek"

--- a/files/lang/pt.po
+++ b/files/lang/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-27 13:40+0100\n"
+"POT-Creation-Date: 2022-02-17 08:59+0100\n"
 "PO-Revision-Date: 2010-02-09 01:11+0000\n"
 "Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
@@ -726,6 +726,12 @@ msgstr ""
 msgid "Save the Dwarves"
 msgstr ""
 
+msgid "The Crown"
+msgstr ""
+
+msgid "The Gauntlet"
+msgstr ""
+
 #, fuzzy
 msgid "Turning Point"
 msgstr "HP"
@@ -734,12 +740,6 @@ msgid "Corlagon's Defense"
 msgstr ""
 
 msgid "Final Justice"
-msgstr ""
-
-msgid "The Crown"
-msgstr ""
-
-msgid "The Gauntlet"
 msgstr ""
 
 msgid ""
@@ -813,19 +813,19 @@ msgstr ""
 msgid "Necromancers"
 msgstr "Necromante:"
 
-msgid "Rebellion"
-msgstr ""
-
 msgid "Slay the Dwarves"
-msgstr ""
-
-msgid "Apocalypse"
 msgstr ""
 
 msgid "Country Lords"
 msgstr ""
 
 msgid "Dragon Master"
+msgstr ""
+
+msgid "Rebellion"
+msgstr ""
+
+msgid "Apocalypse"
 msgstr ""
 
 msgid "Greater Glory"
@@ -1146,51 +1146,103 @@ msgstr ""
 msgid "\"The Dwarfbane!!!!, run for your lives.\""
 msgstr ""
 
-msgid "Caster's Bracelet"
+msgid "campaignBonus|Ballista"
+msgstr ""
+
+msgid "campaignBonus|Black Pearl"
+msgstr ""
+
+msgid "campaignBonus|Caster's Bracelet"
 msgstr ""
 
 #, fuzzy
-msgid "Defender Helm"
+msgid "campaignBonus|Defender Helm"
 msgstr "Defensor"
 
 #, fuzzy
-msgid "Breastplate"
+msgid "campaignBonus|Breastplate"
 msgstr "Mercado"
 
-msgid "Dragon Sword"
+msgid "campaignBonus|Dragon Sword"
 msgstr ""
 
-msgid "Fizbin Medal"
+msgid "campaignBonus|Fizbin Medal"
 msgstr ""
 
-msgid "Foremost Scroll"
+msgid "campaignBonus|Foremost Scroll"
 msgstr ""
 
-msgid "Mage's Ring"
+msgid "campaignBonus|Hideous Mask"
 msgstr ""
 
-msgid "Major Scroll"
+msgid "campaignBonus|Mage's Ring"
 msgstr ""
 
-msgid "Minor Scroll"
+msgid "campaignBonus|Major Scroll"
 msgstr ""
 
-msgid "Nomad Boots"
+msgid "campaignBonus|Medal of Honor"
 msgstr ""
 
-msgid "Power Axe"
+msgid "campaignBonus|Medal of Valor"
 msgstr ""
 
-msgid "Stealth Shield"
+msgid "campaignBonus|Minor Scroll"
 msgstr ""
 
-msgid "Thunder Mace"
+msgid "campaignBonus|Nomad Boots"
 msgstr ""
 
-msgid "Traveler's Boots"
+msgid "campaignBonus|Power Axe"
 msgstr ""
 
-msgid "Summon Earth"
+msgid "campaignBonus|Spiked Shield"
+msgstr ""
+
+msgid "campaignBonus|Stealth Shield"
+msgstr ""
+
+msgid "campaignBonus|Tax Lien"
+msgstr ""
+
+msgid "campaignBonus|Thunder Mace"
+msgstr ""
+
+msgid "campaignBonus|Traveler's Boots"
+msgstr ""
+
+msgid "campaignBonus|White Pearl"
+msgstr ""
+
+msgid "campaignBonus|Animate Dead"
+msgstr ""
+
+msgid "campaignBonus|Chain Lightning"
+msgstr ""
+
+msgid "campaignBonus|Fireblast"
+msgstr ""
+
+msgid "campaignBonus|Mass Curse"
+msgstr ""
+
+msgid "campaignBonus|Mass Haste"
+msgstr ""
+
+msgid "campaignBonus|Mirror Image"
+msgstr ""
+
+msgid "campaignBonus|Resurrect"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Steelskin"
+msgstr "Defensor"
+
+msgid "campaignBonus|Summon Earth"
+msgstr ""
+
+msgid "campaignBonus|View Heroes"
 msgstr ""
 
 msgid "The %{building} produces %{monster}."

--- a/files/lang/ru.po
+++ b/files/lang/ru.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-27 13:40+0100\n"
+"POT-Creation-Date: 2022-02-17 08:59+0100\n"
 "PO-Revision-Date: 2022-01-25 10:25+0100\n"
 "Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
 "Language-Team: <ru@li.org> <>\n"
@@ -722,6 +722,12 @@ msgstr "Сила оружия"
 msgid "Save the Dwarves"
 msgstr "Спасите гномов"
 
+msgid "The Crown"
+msgstr "Корона"
+
+msgid "The Gauntlet"
+msgstr "Защитник"
+
 msgid "Turning Point"
 msgstr "Переломный момент"
 
@@ -730,12 +736,6 @@ msgstr "Защита Корлагона"
 
 msgid "Final Justice"
 msgstr "Акт отчаяния"
-
-msgid "The Crown"
-msgstr "Корона"
-
-msgid "The Gauntlet"
-msgstr "Защитник"
 
 msgid ""
 "Roland needs you to defeat the lords near his castle to begin his war of "
@@ -839,20 +839,20 @@ msgstr "Первая кровь"
 msgid "Necromancers"
 msgstr "Некроманты"
 
-msgid "Rebellion"
-msgstr "Бунт"
-
 msgid "Slay the Dwarves"
 msgstr "Уничтожь гномов"
-
-msgid "Apocalypse"
-msgstr "Апокалипсис"
 
 msgid "Country Lords"
 msgstr "Лорды провинций"
 
 msgid "Dragon Master"
 msgstr "Повелитель драконов"
+
+msgid "Rebellion"
+msgstr "Бунт"
+
+msgid "Apocalypse"
+msgstr "Апокалипсис"
 
 msgid "Greater Glory"
 msgstr "К вящей славе"
@@ -1268,50 +1268,101 @@ msgstr ""
 msgid "\"The Dwarfbane!!!!, run for your lives.\""
 msgstr "\"Убийца гномов!!!!, спасайтесь кто может!\""
 
-msgid "Caster's Bracelet"
+msgid "campaignBonus|Ballista"
+msgstr "Баллиста"
+
+msgid "campaignBonus|Black Pearl"
+msgstr "Чёр. жемчужина"
+
+msgid "campaignBonus|Caster's Bracelet"
 msgstr "Браслет"
 
-msgid "Defender Helm"
+msgid "campaignBonus|Defender Helm"
 msgstr "Шлем защитника"
 
-msgid "Breastplate"
+msgid "campaignBonus|Breastplate"
 msgstr "Доспех"
 
-msgid "Dragon Sword"
+msgid "campaignBonus|Dragon Sword"
 msgstr "Драконий меч"
 
-msgid "Fizbin Medal"
+msgid "campaignBonus|Fizbin Medal"
 msgstr "Символ неудачи"
 
-msgid "Foremost Scroll"
+msgid "campaignBonus|Foremost Scroll"
 msgstr "Высший свиток"
 
-msgid "Mage's Ring"
+msgid "campaignBonus|Hideous Mask"
+msgstr "Ужасная маска"
+
+msgid "campaignBonus|Mage's Ring"
 msgstr "Кольцо мага"
 
-msgid "Major Scroll"
+msgid "campaignBonus|Major Scroll"
 msgstr "Большой свиток"
 
-msgid "Minor Scroll"
+msgid "campaignBonus|Medal of Honor"
+msgstr "Медаль доблести"
+
+msgid "campaignBonus|Medal of Valor"
+msgstr "Медаль отваги"
+
+msgid "campaignBonus|Minor Scroll"
 msgstr "Малый свиток"
 
-msgid "Nomad Boots"
+msgid "campaignBonus|Nomad Boots"
 msgstr "Сапоги кочевника"
 
-msgid "Power Axe"
+msgid "campaignBonus|Power Axe"
 msgstr "Топор власти"
 
-msgid "Stealth Shield"
-msgstr "Всемогущий щит"
+msgid "campaignBonus|Spiked Shield"
+msgstr "Шипованный щит"
 
-msgid "Thunder Mace"
+msgid "campaignBonus|Stealth Shield"
+msgstr "Незримый щит"
+
+msgid "campaignBonus|Tax Lien"
+msgstr "Податная"
+
+msgid "campaignBonus|Thunder Mace"
 msgstr "Громовая палица"
 
-msgid "Traveler's Boots"
+msgid "campaignBonus|Traveler's Boots"
 msgstr "Сапоги путника"
 
-msgid "Summon Earth"
+msgid "campaignBonus|White Pearl"
+msgstr "Бел. жемчужина"
+
+msgid "campaignBonus|Animate Dead"
+msgstr "Поднять нежить"
+
+msgid "campaignBonus|Chain Lightning"
+msgstr "Цепь молний"
+
+msgid "campaignBonus|Fireblast"
+msgstr "Огненный взрыв"
+
+msgid "campaignBonus|Mass Curse"
+msgstr "Масс. проклятие"
+
+msgid "campaignBonus|Mass Haste"
+msgstr "Масс. ускорение"
+
+msgid "campaignBonus|Mirror Image"
+msgstr "Фантом"
+
+msgid "campaignBonus|Resurrect"
+msgstr "Оживление"
+
+msgid "campaignBonus|Steelskin"
+msgstr "Стальная кожа"
+
+msgid "campaignBonus|Summon Earth"
 msgstr "Элементаль"
+
+msgid "campaignBonus|View Heroes"
+msgstr "Показать героев"
 
 msgid "The %{building} produces %{monster}."
 msgstr "В %{building} можно нанять %{monster}."
@@ -8507,6 +8558,9 @@ msgstr ""
 "Новую версию игры можно найти на сайте:\n"
 "https://github.com/ihhub/\n"
 "fheroes2/releases"
+
+#~ msgid "Power Axe"
+#~ msgstr "Топор власти"
 
 #~ msgid "battle: show army order"
 #~ msgstr "битва: показывать порядок армии"

--- a/files/lang/sv.po
+++ b/files/lang/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-27 13:40+0100\n"
+"POT-Creation-Date: 2022-02-17 08:59+0100\n"
 "PO-Revision-Date: 2021-11-15 17:00+0100\n"
 "Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
 "Language-Team: Swedish <sv@li.org>\n"
@@ -729,6 +729,14 @@ msgstr ""
 msgid "Save the Dwarves"
 msgstr "Rädda dvärgarna"
 
+msgid "The Crown"
+msgstr "Kronan"
+
+# Gauntlet as in race.
+#, fuzzy
+msgid "The Gauntlet"
+msgstr "\"Stridshandsken\""
+
 msgid "Turning Point"
 msgstr "Vändpunkt"
 
@@ -738,14 +746,6 @@ msgstr "Draköga"
 
 msgid "Final Justice"
 msgstr ""
-
-msgid "The Crown"
-msgstr "Kronan"
-
-# Gauntlet as in race.
-#, fuzzy
-msgid "The Gauntlet"
-msgstr "\"Stridshandsken\""
 
 msgid ""
 "Roland needs you to defeat the lords near his castle to begin his war of "
@@ -818,22 +818,22 @@ msgstr ""
 msgid "Necromancers"
 msgstr "Svartkonstnär"
 
-msgid "Rebellion"
-msgstr ""
-
 #, fuzzy
 msgid "Slay the Dwarves"
 msgstr "\"Rädda dvärgarna\""
-
-#, fuzzy
-msgid "Apocalypse"
-msgstr "\"Apokalyps\""
 
 msgid "Country Lords"
 msgstr "Landslordar"
 
 msgid "Dragon Master"
 msgstr "Drakmästare"
+
+msgid "Rebellion"
+msgstr ""
+
+#, fuzzy
+msgid "Apocalypse"
+msgstr "\"Apokalyps\""
 
 #, fuzzy
 msgid "Greater Glory"
@@ -1169,57 +1169,121 @@ msgstr ""
 msgid "\"The Dwarfbane!!!!, run for your lives.\""
 msgstr ""
 
-msgid "Caster's Bracelet"
+msgid "campaignBonus|Ballista"
 msgstr ""
 
 #, fuzzy
-msgid "Defender Helm"
+msgid "campaignBonus|Black Pearl"
+msgstr "Svart pärla"
+
+msgid "campaignBonus|Caster's Bracelet"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Defender Helm"
 msgstr "Försvarare"
 
-msgid "Breastplate"
+#, fuzzy
+msgid "campaignBonus|Breastplate"
 msgstr "Bröstharnesk"
 
 #, fuzzy
-msgid "Dragon Sword"
+msgid "campaignBonus|Dragon Sword"
 msgstr "Drakdräpare"
 
-msgid "Fizbin Medal"
+msgid "campaignBonus|Fizbin Medal"
 msgstr ""
 
-msgid "Foremost Scroll"
+#, fuzzy
+msgid "campaignBonus|Foremost Scroll"
 msgstr "Särskild Kunskapsrulle"
 
-msgid "Mage's Ring"
+#, fuzzy
+msgid "campaignBonus|Hideous Mask"
+msgstr "Otäck mask"
+
+msgid "campaignBonus|Mage's Ring"
 msgstr ""
 
-msgid "Major Scroll"
+#, fuzzy
+msgid "campaignBonus|Major Scroll"
 msgstr "Större Kunskapsrulle"
 
-msgid "Minor Scroll"
+#, fuzzy
+msgid "campaignBonus|Medal of Honor"
+msgstr "Hedersmedalj"
+
+#, fuzzy
+msgid "campaignBonus|Medal of Valor"
+msgstr "Tapperhetens medalj"
+
+#, fuzzy
+msgid "campaignBonus|Minor Scroll"
 msgstr "Mindre Kunskapsrulle"
 
 #, fuzzy
-msgid "Nomad Boots"
+msgid "campaignBonus|Nomad Boots"
 msgstr "Nomader"
 
-#, fuzzy
-msgid "Power Axe"
-msgstr "Effekt"
-
-#, fuzzy
-msgid "Stealth Shield"
-msgstr "Ultimata skölden"
-
-#, fuzzy
-msgid "Thunder Mace"
-msgstr "Thundax"
-
-msgid "Traveler's Boots"
+msgid "campaignBonus|Power Axe"
 msgstr ""
 
 #, fuzzy
-msgid "Summon Earth"
+msgid "campaignBonus|Spiked Shield"
+msgstr "Spikad sköld"
+
+#, fuzzy
+msgid "campaignBonus|Stealth Shield"
+msgstr "Ultimata skölden"
+
+msgid "campaignBonus|Tax Lien"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Thunder Mace"
+msgstr "Thundax"
+
+msgid "campaignBonus|Traveler's Boots"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|White Pearl"
+msgstr "Vit pärla"
+
+#, fuzzy
+msgid "campaignBonus|Animate Dead"
+msgstr "Ge liv åt död"
+
+msgid "campaignBonus|Chain Lightning"
+msgstr ""
+
+msgid "campaignBonus|Fireblast"
+msgstr ""
+
+msgid "campaignBonus|Mass Curse"
+msgstr ""
+
+msgid "campaignBonus|Mass Haste"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Mirror Image"
+msgstr "Spegelbild"
+
+msgid "campaignBonus|Resurrect"
+msgstr ""
+
+#, fuzzy
+msgid "campaignBonus|Steelskin"
+msgstr "Vit pärla"
+
+#, fuzzy
+msgid "campaignBonus|Summon Earth"
 msgstr "Inkalla båt"
+
+#, fuzzy
+msgid "campaignBonus|View Heroes"
+msgstr "Visa hjältar"
 
 msgid "The %{building} produces %{monster}."
 msgstr "%{building} skapar %{monster}."
@@ -8338,6 +8402,10 @@ msgstr ""
 "Du kan ladda ned det nyaste versionen av spelet från sidan:\n"
 "https://github.com/ihhub/\n"
 "fheroes2/releases"
+
+#, fuzzy
+#~ msgid "Power Axe"
+#~ msgstr "Effekt"
 
 #~ msgid "Buy Monsters"
 #~ msgstr "Köp monster"

--- a/files/lang/tr.po
+++ b/files/lang/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fheroes2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-27 13:40+0100\n"
+"POT-Creation-Date: 2022-02-17 08:59+0100\n"
 "PO-Revision-Date: 2009-12-08 00:41+0000\n"
 "Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
 "Language-Team: Turkish <tr@li.org>\n"
@@ -662,6 +662,12 @@ msgstr ""
 msgid "Save the Dwarves"
 msgstr ""
 
+msgid "The Crown"
+msgstr ""
+
+msgid "The Gauntlet"
+msgstr ""
+
 msgid "Turning Point"
 msgstr ""
 
@@ -669,12 +675,6 @@ msgid "Corlagon's Defense"
 msgstr ""
 
 msgid "Final Justice"
-msgstr ""
-
-msgid "The Crown"
-msgstr ""
-
-msgid "The Gauntlet"
 msgstr ""
 
 msgid ""
@@ -747,19 +747,19 @@ msgstr ""
 msgid "Necromancers"
 msgstr ""
 
-msgid "Rebellion"
-msgstr ""
-
 msgid "Slay the Dwarves"
-msgstr ""
-
-msgid "Apocalypse"
 msgstr ""
 
 msgid "Country Lords"
 msgstr ""
 
 msgid "Dragon Master"
+msgstr ""
+
+msgid "Rebellion"
+msgstr ""
+
+msgid "Apocalypse"
 msgstr ""
 
 msgid "Greater Glory"
@@ -1079,49 +1079,100 @@ msgstr ""
 msgid "\"The Dwarfbane!!!!, run for your lives.\""
 msgstr ""
 
-msgid "Caster's Bracelet"
+msgid "campaignBonus|Ballista"
 msgstr ""
 
-msgid "Defender Helm"
+msgid "campaignBonus|Black Pearl"
 msgstr ""
 
-msgid "Breastplate"
+msgid "campaignBonus|Caster's Bracelet"
 msgstr ""
 
-msgid "Dragon Sword"
+msgid "campaignBonus|Defender Helm"
 msgstr ""
 
-msgid "Fizbin Medal"
+msgid "campaignBonus|Breastplate"
 msgstr ""
 
-msgid "Foremost Scroll"
+msgid "campaignBonus|Dragon Sword"
 msgstr ""
 
-msgid "Mage's Ring"
+msgid "campaignBonus|Fizbin Medal"
 msgstr ""
 
-msgid "Major Scroll"
+msgid "campaignBonus|Foremost Scroll"
 msgstr ""
 
-msgid "Minor Scroll"
+msgid "campaignBonus|Hideous Mask"
 msgstr ""
 
-msgid "Nomad Boots"
+msgid "campaignBonus|Mage's Ring"
 msgstr ""
 
-msgid "Power Axe"
+msgid "campaignBonus|Major Scroll"
 msgstr ""
 
-msgid "Stealth Shield"
+msgid "campaignBonus|Medal of Honor"
 msgstr ""
 
-msgid "Thunder Mace"
+msgid "campaignBonus|Medal of Valor"
 msgstr ""
 
-msgid "Traveler's Boots"
+msgid "campaignBonus|Minor Scroll"
 msgstr ""
 
-msgid "Summon Earth"
+msgid "campaignBonus|Nomad Boots"
+msgstr ""
+
+msgid "campaignBonus|Power Axe"
+msgstr ""
+
+msgid "campaignBonus|Spiked Shield"
+msgstr ""
+
+msgid "campaignBonus|Stealth Shield"
+msgstr ""
+
+msgid "campaignBonus|Tax Lien"
+msgstr ""
+
+msgid "campaignBonus|Thunder Mace"
+msgstr ""
+
+msgid "campaignBonus|Traveler's Boots"
+msgstr ""
+
+msgid "campaignBonus|White Pearl"
+msgstr ""
+
+msgid "campaignBonus|Animate Dead"
+msgstr ""
+
+msgid "campaignBonus|Chain Lightning"
+msgstr ""
+
+msgid "campaignBonus|Fireblast"
+msgstr ""
+
+msgid "campaignBonus|Mass Curse"
+msgstr ""
+
+msgid "campaignBonus|Mass Haste"
+msgstr ""
+
+msgid "campaignBonus|Mirror Image"
+msgstr ""
+
+msgid "campaignBonus|Resurrect"
+msgstr ""
+
+msgid "campaignBonus|Steelskin"
+msgstr ""
+
+msgid "campaignBonus|Summon Earth"
+msgstr ""
+
+msgid "campaignBonus|View Heroes"
 msgstr ""
 
 msgid "The %{building} produces %{monster}."

--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -391,10 +391,10 @@ namespace
             return _( "short|Resurrect" );
         case Spell::STEELSKIN:
             return _( "short|Steel Skin" );
-        case Spell::VIEWHEROES:
-            return _( "short|View Heroes" );
         case Spell::SUMMONEELEMENT:
             return _( "Summon Earth" );
+        case Spell::VIEWHEROES:
+            return _( "short|View Heroes" );
         default:
             return Spell( spellId ).GetName();
         }

--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -324,49 +324,49 @@ namespace
     {
         switch ( artifactId ) {
         case Artifact::BALLISTA:
-            return _( "Ballista" );
+            return _( "campaignBonus|Ballista" );
         case Artifact::BLACK_PEARL:
-            return _( "short|Black Pearl" );
+            return _( "campaignBonus|Black Pearl" );
         case Artifact::CASTER_BRACELET:
-            return _( "Caster's Bracelet" );
+            return _( "campaignBonus|Caster's Bracelet" );
         case Artifact::DEFENDER_HELM:
-            return _( "Defender Helm" );
+            return _( "campaignBonus|Defender Helm" );
         case Artifact::DIVINE_BREASTPLATE:
-            return _( "Breastplate" );
+            return _( "campaignBonus|Breastplate" );
         case Artifact::DRAGON_SWORD:
-            return _( "Dragon Sword" );
+            return _( "campaignBonus|Dragon Sword" );
         case Artifact::FIZBIN_MISFORTUNE:
-            return _( "Fizbin Medal" );
+            return _( "campaignBonus|Fizbin Medal" );
         case Artifact::FOREMOST_SCROLL:
-            return _( "Foremost Scroll" );
+            return _( "campaignBonus|Foremost Scroll" );
         case Artifact::HIDEOUS_MASK:
-            return _( "short|Hideous Mask" );
+            return _( "campaignBonus|Hideous Mask" );
         case Artifact::MAGE_RING:
-            return _( "Mage's Ring" );
+            return _( "campaignBonus|Mage's Ring" );
         case Artifact::MAJOR_SCROLL:
-            return _( "Major Scroll" );
+            return _( "campaignBonus|Major Scroll" );
         case Artifact::MEDAL_HONOR:
-            return _( "short|Medal of Honor" );
+            return _( "campaignBonus|Medal of Honor" );
         case Artifact::MEDAL_VALOR:
-            return _( "short|Medal of Valor" );
+            return _( "campaignBonus|Medal of Valor" );
         case Artifact::MINOR_SCROLL:
-            return _( "Minor Scroll" );
+            return _( "campaignBonus|Minor Scroll" );
         case Artifact::NOMAD_BOOTS_MOBILITY:
-            return _( "Nomad Boots" );
+            return _( "campaignBonus|Nomad Boots" );
         case Artifact::POWER_AXE:
-            return _( "Power Axe" );
+            return _( "campaignBonus|Power Axe" );
         case Artifact::SPIKED_SHIELD:
-            return _( "short|Spiked Shield" );
+            return _( "campaignBonus|Spiked Shield" );
         case Artifact::STEALTH_SHIELD:
-            return _( "Stealth Shield" );
+            return _( "campaignBonus|Stealth Shield" );
         case Artifact::TAX_LIEN:
-            return _( "short|Tax Lien" );
+            return _( "campaignBonus|Tax Lien" );
         case Artifact::THUNDER_MACE:
-            return _( "Thunder Mace" );
+            return _( "campaignBonus|Thunder Mace" );
         case Artifact::TRAVELER_BOOTS_MOBILITY:
-            return _( "Traveler's Boots" );
+            return _( "campaignBonus|Traveler's Boots" );
         case Artifact::WHITE_PEARL:
-            return _( "short|White Pearl" );
+            return _( "campaignBonus|White Pearl" );
         default:
             return Artifact( artifactId ).GetName();
         }
@@ -376,25 +376,25 @@ namespace
     {
         switch ( spellId ) {
         case Spell::ANIMATEDEAD:
-            return _( "short|Animate Dead" );
+            return _( "campaignBonus|Animate Dead" );
         case Spell::CHAINLIGHTNING:
-            return _( "short|Chain Lightning" );
+            return _( "campaignBonus|Chain Lightning" );
         case Spell::FIREBLAST:
-            return _( "short|Fireblast" );
+            return _( "campaignBonus|Fireblast" );
         case Spell::MASSCURSE:
-            return _( "short|Mass Curse" );
+            return _( "campaignBonus|Mass Curse" );
         case Spell::MASSHASTE:
-            return _( "short|Mass Haste" );
+            return _( "campaignBonus|Mass Haste" );
         case Spell::MIRRORIMAGE:
-            return _( "short|Mirror Image" );
+            return _( "campaignBonus|Mirror Image" );
         case Spell::RESURRECT:
-            return _( "short|Resurrect" );
+            return _( "campaignBonus|Resurrect" );
         case Spell::STEELSKIN:
-            return _( "short|Steel Skin" );
+            return _( "campaignBonus|Steel Skin" );
         case Spell::SUMMONEELEMENT:
-            return _( "Summon Earth" );
+            return _( "campaignBonus|Summon Earth" );
         case Spell::VIEWHEROES:
-            return _( "short|View Heroes" );
+            return _( "campaignBonus|View Heroes" );
         default:
             return Spell( spellId ).GetName();
         }

--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -390,7 +390,7 @@ namespace
         case Spell::RESURRECT:
             return _( "campaignBonus|Resurrect" );
         case Spell::STEELSKIN:
-            return _( "campaignBonus|Steel Skin" );
+            return _( "campaignBonus|Steelskin" );
         case Spell::SUMMONEELEMENT:
             return _( "campaignBonus|Summon Earth" );
         case Spell::VIEWHEROES:

--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -325,6 +325,8 @@ namespace
         switch ( artifactId ) {
         case Artifact::BALLISTA:
             return _( "Ballista" );
+        case Artifact::BLACK_PEARL:
+            return _( "short|Black Pearl" );
         case Artifact::CASTER_BRACELET:
             return _( "Caster's Bracelet" );
         case Artifact::DEFENDER_HELM:
@@ -337,22 +339,34 @@ namespace
             return _( "Fizbin Medal" );
         case Artifact::FOREMOST_SCROLL:
             return _( "Foremost Scroll" );
+        case Artifact::HIDEOUS_MASK:
+            return _( "short|Hideous Mask" );
         case Artifact::MAGE_RING:
             return _( "Mage's Ring" );
         case Artifact::MAJOR_SCROLL:
             return _( "Major Scroll" );
+        case Artifact::MEDAL_HONOR:
+            return _( "short|Medal of Honor" );
+        case Artifact::MEDAL_VALOR:
+            return _( "short|Medal of Valor" );
         case Artifact::MINOR_SCROLL:
             return _( "Minor Scroll" );
         case Artifact::NOMAD_BOOTS_MOBILITY:
             return _( "Nomad Boots" );
         case Artifact::POWER_AXE:
             return _( "Power Axe" );
+        case Artifact::SPIKED_SHIELD:
+            return _( "short|Spiked Shield" );
         case Artifact::STEALTH_SHIELD:
             return _( "Stealth Shield" );
+        case Artifact::TAX_LIEN:
+            return _( "short|Tax Lien" );
         case Artifact::THUNDER_MACE:
             return _( "Thunder Mace" );
         case Artifact::TRAVELER_BOOTS_MOBILITY:
             return _( "Traveler's Boots" );
+        case Artifact::WHITE_PEARL:
+            return _( "short|White Pearl" );
         default:
             return Artifact( artifactId ).GetName();
         }

--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -375,6 +375,24 @@ namespace
     const char * getSpellCampaignName( const Uint32 spellId )
     {
         switch ( spellId ) {
+        case Spell::ANIMATEDEAD:
+            return _( "short|Animate Dead" );
+        case Spell::CHAINLIGHTNING:
+            return _( "short|Chain Lightning" );
+        case Spell::FIREBLAST:
+            return _( "short|Fireblast" );
+        case Spell::MASSCURSE:
+            return _( "short|Mass Curse" );
+        case Spell::MASSHASTE:
+            return _( "short|Mass Haste" );
+        case Spell::MIRRORIMAGE:
+            return _( "short|Mirror Image" );
+        case Spell::RESURRECT:
+            return _( "short|Resurrect" );
+        case Spell::STEELSKIN:
+            return _( "short|Steel Skin" );
+        case Spell::VIEWHEROES:
+            return _( "short|View Heroes" );
         case Spell::SUMMONEELEMENT:
             return _( "Summon Earth" );
         default:


### PR DESCRIPTION
This is needed to support translations, such as Russian and German.