### PR TITLE
Don't use ESC key as a retreat key during battle, because it conflicts with the hotkey that closes the hero dialog

### DIFF
--- a/fheroes2.key
+++ b/fheroes2.key
@@ -70,7 +70,7 @@
 #
 # 2.5 battle events:
 # battle cast spell	- (default keycode:  99 = 'c')
-# battle retreat	- (default keycode:  27 = 'esc')
+# battle retreat	- (default keycode: 114 = 'r')
 # battle surrender	- (default keycode: 115 = 's')
 # battle auto switch	- (default keycode:  97 = 'a')
 # battle options	- (default keycode: 111 = 'o')

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4996,7 +4996,7 @@ void Battle::Interface::CheckGlobalEvents( LocalEvent & le )
          && ( le.MouseClickLeft( btn_auto.area() )
               || ( le.KeyPress()
                    && ( Game::HotKeyPressEvent( Game::EVENT_BATTLE_AUTOSWITCH )
-                        || ( Game::HotKeyPressEvent( Game::EVENT_BATTLE_RETREAT )
+                        || ( Game::HotKeyPressEvent( Game::EVENT_DEFAULT_EXIT )
                              && Dialog::YES == Dialog::Message( "", _( "Break auto battle?" ), Font::BIG, Dialog::YES | Dialog::NO ) ) ) ) ) ) {
         arena.BreakAutoBattle();
     }

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -231,7 +231,7 @@ void Game::HotKeysDefaults( void )
 
     // battle
     key_events[EVENT_BATTLE_CASTSPELL] = KEY_c;
-    key_events[EVENT_BATTLE_RETREAT] = KEY_ESCAPE;
+    key_events[EVENT_BATTLE_RETREAT] = KEY_r;
     key_events[EVENT_BATTLE_SURRENDER] = KEY_s;
     key_events[EVENT_BATTLE_AUTOSWITCH] = KEY_a;
     key_events[EVENT_BATTLE_OPTIONS] = KEY_o;


### PR DESCRIPTION
That's what happens when I press the `ESC` key to close the hero dialog:

https://user-images.githubusercontent.com/32623900/152235272-91fb71b0-5b6b-47f3-8990-5f4e230de838.mp4

I propose to use the `KEY_r` instead by default.