### PR TITLE
Improve attack handling by AI (and not only AI)

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -267,7 +267,7 @@ namespace AI
 
                 if ( target.unit ) {
                     actions.emplace_back( CommandType::MSG_BATTLE_ATTACK, currentUnit.GetUID(), target.unit->GetUID(),
-                                          Board::OptimalAttackTarget( currentUnit, *target.unit, reachableCell ), 0 );
+                                          Board::OptimalAttackTarget( currentUnit, *target.unit, reachableCell ), -1 );
 
                     DEBUG_LOG( DBG_BATTLE, DBG_INFO,
                                currentUnit.GetName() << " melee offense, focus enemy " << target.unit->GetName()
@@ -474,7 +474,7 @@ namespace AI
             if ( target.unit && target.cell != -1 ) {
                 // Melee attack selected target
                 DEBUG_LOG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " archer deciding to fight back: " << bestOutcome );
-                actions.emplace_back( CommandType::MSG_BATTLE_ATTACK, currentUnit.GetUID(), target.unit->GetUID(), target.cell, 0 );
+                actions.emplace_back( CommandType::MSG_BATTLE_ATTACK, currentUnit.GetUID(), target.unit->GetUID(), target.cell, -1 );
             }
             else {
                 // Kiting enemy: Search for a safe spot unit can move to
@@ -802,7 +802,7 @@ namespace AI
 
         // Attack only if target unit is reachable and can be attacked
         if ( Board::CanAttackUnitFromPosition( currentUnit, *targetUnit, reachableCell ) ) {
-            actions.emplace_back( CommandType::MSG_BATTLE_ATTACK, currentUnitUID, targetUnit->GetUID(), targetUnit->GetHeadIndex(), 0 );
+            actions.emplace_back( CommandType::MSG_BATTLE_ATTACK, currentUnitUID, targetUnit->GetUID(), targetUnit->GetHeadIndex(), -1 );
 
             DEBUG_LOG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " melee offense, focus enemy " << targetUnit->GetName() );
         }

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -529,7 +529,7 @@ namespace AI
             }
 
             if ( target.unit ) {
-                actions.emplace_back( CommandType::MSG_BATTLE_ATTACK, currentUnit.GetUID(), target.unit->GetUID(), target.unit->GetHeadIndex(), 0 );
+                actions.emplace_back( CommandType::MSG_BATTLE_ATTACK, currentUnit.GetUID(), target.unit->GetUID(), -1, 0 );
 
                 DEBUG_LOG( DBG_BATTLE, DBG_INFO,
                            currentUnit.GetName() << " archer focusing enemy " << target.unit->GetName()
@@ -723,7 +723,7 @@ namespace AI
             const Unit * targetUnit = nearestUnits.front();
             assert( targetUnit != nullptr );
 
-            actions.emplace_back( CommandType::MSG_BATTLE_ATTACK, currentUnitUID, targetUnit->GetUID(), targetUnit->GetHeadIndex(), 0 );
+            actions.emplace_back( CommandType::MSG_BATTLE_ATTACK, currentUnitUID, targetUnit->GetUID(), -1, 0 );
 
             DEBUG_LOG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " archer focusing enemy " << targetUnit->GetName() );
 
@@ -802,7 +802,7 @@ namespace AI
 
         // Attack only if target unit is reachable and can be attacked
         if ( Board::CanAttackUnitFromPosition( currentUnit, *targetUnit, reachableCell ) ) {
-            actions.emplace_back( CommandType::MSG_BATTLE_ATTACK, currentUnitUID, targetUnit->GetUID(), targetUnit->GetHeadIndex(), -1 );
+            actions.emplace_back( CommandType::MSG_BATTLE_ATTACK, currentUnitUID, targetUnit->GetUID(), -1, -1 );
 
             DEBUG_LOG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " melee offense, focus enemy " << targetUnit->GetName() );
         }

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -266,8 +266,10 @@ namespace AI
                 }
 
                 if ( target.unit ) {
-                    actions.emplace_back( CommandType::MSG_BATTLE_ATTACK, currentUnit.GetUID(), target.unit->GetUID(),
-                                          Board::OptimalAttackTarget( currentUnit, *target.unit, reachableCell ), -1 );
+                    const int32_t optimalTargetIdx = Board::OptimalAttackTarget( currentUnit, *target.unit, target.cell );
+
+                    actions.emplace_back( CommandType::MSG_BATTLE_ATTACK, currentUnit.GetUID(), target.unit->GetUID(), optimalTargetIdx,
+                                          Board::GetDirection( target.cell, optimalTargetIdx ) );
 
                     DEBUG_LOG( DBG_BATTLE, DBG_INFO,
                                currentUnit.GetName() << " melee offense, focus enemy " << target.unit->GetName()

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -624,10 +624,10 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( const Unit & attacker, U
     }
     // attack of all adjacent cells
     else if ( attacker.isAllAdjacentCellsAttack() ) {
-        for ( const int32_t aroundIdx : Board::GetAroundIndexes( attacker ) ) {
-            assert( Board::GetCell( aroundIdx ) != nullptr );
+        for ( const int32_t nearbyIdx : Board::GetAroundIndexes( attacker ) ) {
+            assert( Board::GetCell( nearbyIdx ) != nullptr );
 
-            Unit * enemy = Board::GetCell( aroundIdx )->GetUnit();
+            Unit * enemy = Board::GetCell( nearbyIdx )->GetUnit();
 
             if ( enemy && enemy->GetColor() != attacker.GetCurrentColor() && consideredTargets.insert( enemy ).second ) {
                 res.defender = enemy;
@@ -639,10 +639,10 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( const Unit & attacker, U
     }
     // lich cloud damage
     else if ( attacker.isAbilityPresent( fheroes2::MonsterAbilityType::AREA_SHOT ) && !attacker.isHandFighting() ) {
-        for ( const int32_t aroundIdx : Board::GetAroundIndexes( dst ) ) {
-            assert( Board::GetCell( aroundIdx ) != nullptr );
+        for ( const int32_t nearbyIdx : Board::GetAroundIndexes( dst ) ) {
+            assert( Board::GetCell( nearbyIdx ) != nullptr );
 
-            Unit * enemy = Board::GetCell( aroundIdx )->GetUnit();
+            Unit * enemy = Board::GetCell( nearbyIdx )->GetUnit();
 
             if ( enemy && consideredTargets.insert( enemy ).second ) {
                 res.defender = enemy;

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -64,10 +64,40 @@ namespace
     }
 }
 
-void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, s32 dst, int dir )
+void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, int32_t dst /* = -1 */, int dir /* = -1 */ )
 {
-    if ( 0 > dst )
-        dst = defender.GetHeadIndex();
+    if ( dst < 0 ) {
+        // The defender's head cell is near the attacker
+        if ( Board::isNearIndexes( attacker.GetHeadIndex(), defender.GetHeadIndex() )
+             || ( attacker.isWide() && Board::isNearIndexes( attacker.GetTailIndex(), defender.GetHeadIndex() ) ) ) {
+            dst = defender.GetHeadIndex();
+        }
+        // The defender's tail cell is near the attacker
+        else if ( defender.isWide()
+                  && ( Board::isNearIndexes( attacker.GetHeadIndex(), defender.GetTailIndex() )
+                       || ( attacker.isWide() && Board::isNearIndexes( attacker.GetTailIndex(), defender.GetTailIndex() ) ) ) ) {
+            dst = defender.GetTailIndex();
+        }
+        // Units don't stand next to each other, this is most likely a shot
+        else {
+            dst = defender.GetHeadIndex();
+        }
+    }
+
+    if ( dir < 0 ) {
+        // The target cell of the attack is near the attacker's head cell
+        if ( Board::isNearIndexes( attacker.GetHeadIndex(), dst ) ) {
+            dir = Board::GetDirection( attacker.GetHeadIndex(), dst );
+        }
+        // The target cell of the attack is near the attacker's tail cell
+        else if ( attacker.isWide() && Board::isNearIndexes( attacker.GetTailIndex(), dst ) ) {
+            dir = Board::GetDirection( attacker.GetTailIndex(), dst );
+        }
+        // Units don't stand next to each other, this is most likely a shot
+        else {
+            dir = UNKNOWN;
+        }
+    }
 
     if ( dir ) {
         if ( attacker.isWide() ) {

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -218,7 +218,12 @@ namespace Battle
         void ApplyActionCatapult( Command & );
         void ApplyActionAutoBattle( Command & );
 
-        void BattleProcess( Unit &, Unit & b2, s32 = -1, int = 0 );
+        // Performs an actual attack of one unit (defender) by another unit (attacker), applying the attacker's
+        // built-in magic, if necessary. If the given index of the target cell of the attack (dst) is negative,
+        // then an attempt will be made to calculate it automatically based on the adjacency of the unit cells.
+        // If the given direction of the attack (dir) is negative, then an attempt will be made to calculate it
+        // automatically. When an attack is made by firing a shot, the dir should be UNKNOWN (zero).
+        void BattleProcess( Unit & attacker, Unit & defender, int32_t dst = -1, int dir = -1 );
 
         Unit * CreateElemental( const Spell & );
         Unit * CreateMirrorImage( Unit &, s32 );

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -1188,11 +1188,11 @@ bool Battle::Board::CanAttackUnitFromPosition( const Unit & currentUnit, const U
             continue;
         }
 
-        for ( const int32_t aroundIdx : GetAroundIndexes( cell->GetIndex() ) ) {
-            const Cell * aroundCell = GetCell( aroundIdx );
-            assert( aroundCell != nullptr );
+        for ( const int32_t nearbyIdx : GetAroundIndexes( cell->GetIndex() ) ) {
+            const Cell * nearbyCell = GetCell( nearbyIdx );
+            assert( nearbyCell != nullptr );
 
-            if ( aroundCell->GetUnit() == &target ) {
+            if ( nearbyCell->GetUnit() == &target ) {
                 return true;
             }
         }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1612,9 +1612,9 @@ void Battle::Interface::RedrawCover()
             case Spell::COLDRING: {
                 const Indexes around = Board::GetAroundIndexes( index_pos );
                 for ( size_t i = 0; i < around.size(); ++i ) {
-                    const Cell * aroundCell = Board::GetCell( around[i] );
-                    if ( aroundCell != nullptr ) {
-                        highlightCells.emplace( aroundCell );
+                    const Cell * nearbyCell = Board::GetCell( around[i] );
+                    if ( nearbyCell != nullptr ) {
+                        highlightCells.emplace( nearbyCell );
                     }
                 }
                 break;
@@ -1624,9 +1624,9 @@ void Battle::Interface::RedrawCover()
                 highlightCells.emplace( cell );
                 const Indexes around = Board::GetAroundIndexes( index_pos );
                 for ( size_t i = 0; i < around.size(); ++i ) {
-                    const Cell * aroundCell = Board::GetCell( around[i] );
-                    if ( aroundCell != nullptr ) {
-                        highlightCells.emplace( aroundCell );
+                    const Cell * nearbyCell = Board::GetCell( around[i] );
+                    if ( nearbyCell != nullptr ) {
+                        highlightCells.emplace( nearbyCell );
                     }
                 }
                 break;
@@ -1635,16 +1635,16 @@ void Battle::Interface::RedrawCover()
                 highlightCells.emplace( cell );
                 const Indexes around = Board::GetAroundIndexes( index_pos );
                 for ( size_t i = 0; i < around.size(); ++i ) {
-                    const Cell * aroundCell = Board::GetCell( around[i] );
-                    if ( aroundCell != nullptr ) {
-                        highlightCells.emplace( aroundCell );
+                    const Cell * nearbyCell = Board::GetCell( around[i] );
+                    if ( nearbyCell != nullptr ) {
+                        highlightCells.emplace( nearbyCell );
                     }
 
                     const Indexes aroundTwice = Board::GetAroundIndexes( around[i] );
                     for ( size_t j = 0; j < aroundTwice.size(); ++j ) {
-                        const Cell * aroundCellTwice = Board::GetCell( aroundTwice[j] );
-                        if ( aroundCellTwice != nullptr ) {
-                            highlightCells.emplace( aroundCellTwice );
+                        const Cell * nearbyCellTwice = Board::GetCell( aroundTwice[j] );
+                        if ( nearbyCellTwice != nullptr ) {
+                            highlightCells.emplace( nearbyCellTwice );
                         }
                     }
                 }
@@ -1659,9 +1659,9 @@ void Battle::Interface::RedrawCover()
             highlightCells.emplace( cell );
             const Indexes around = Board::GetAroundIndexes( index_pos );
             for ( size_t i = 0; i < around.size(); ++i ) {
-                const Cell * aroundCell = Board::GetCell( around[i] );
-                if ( aroundCell != nullptr ) {
-                    highlightCells.emplace( aroundCell );
+                const Cell * nearbyCell = Board::GetCell( around[i] );
+                if ( nearbyCell != nullptr ) {
+                    highlightCells.emplace( nearbyCell );
                 }
             }
         }
@@ -1721,19 +1721,19 @@ void Battle::Interface::RedrawCover()
                 }
             }
             else if ( _currentUnit->isAllAdjacentCellsAttack() ) {
-                for ( const int32_t aroundIdx : Board::GetAroundIndexes( pos ) ) {
+                for ( const int32_t nearbyIdx : Board::GetAroundIndexes( pos ) ) {
                     // Should already be highlighted
-                    if ( aroundIdx == index_pos ) {
+                    if ( nearbyIdx == index_pos ) {
                         continue;
                     }
 
-                    const Cell * aroundCell = Board::GetCell( aroundIdx );
-                    assert( aroundCell != nullptr );
+                    const Cell * nearbyCell = Board::GetCell( nearbyIdx );
+                    assert( nearbyCell != nullptr );
 
-                    const Unit * aroundUnit = aroundCell->GetUnit();
+                    const Unit * nearbyUnit = nearbyCell->GetUnit();
 
-                    if ( aroundUnit && aroundUnit->GetColor() != _currentUnit->GetCurrentColor() ) {
-                        highlightCells.emplace( aroundCell );
+                    if ( nearbyUnit && nearbyUnit->GetColor() != _currentUnit->GetCurrentColor() ) {
+                        highlightCells.emplace( nearbyCell );
                     }
                 }
             }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1633,19 +1633,11 @@ void Battle::Interface::RedrawCover()
             }
             case Spell::FIREBLAST: {
                 highlightCells.emplace( cell );
-                const Indexes around = Board::GetAroundIndexes( index_pos );
+                const Indexes around = Board::GetDistanceIndexes( index_pos, 2 );
                 for ( size_t i = 0; i < around.size(); ++i ) {
                     const Cell * nearbyCell = Board::GetCell( around[i] );
                     if ( nearbyCell != nullptr ) {
                         highlightCells.emplace( nearbyCell );
-                    }
-
-                    const Indexes aroundTwice = Board::GetAroundIndexes( around[i] );
-                    for ( size_t j = 0; j < aroundTwice.size(); ++j ) {
-                        const Cell * nearbyCellTwice = Board::GetCell( aroundTwice[j] );
-                        if ( nearbyCellTwice != nullptr ) {
-                            highlightCells.emplace( nearbyCellTwice );
-                        }
                     }
                 }
                 break;

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -392,15 +392,15 @@ bool Battle::Unit::canReach( const Unit & unit ) const
     return canReach( target );
 }
 
-bool Battle::Unit::isHandFighting( void ) const
+bool Battle::Unit::isHandFighting() const
 {
     if ( GetCount() && !Modes( CAP_TOWER ) ) {
-        const Indexes around = Board::GetAroundIndexes( *this );
+        for ( const int32_t aroundIdx : Board::GetAroundIndexes( *this ) ) {
+            const Unit * nearbyUnit = Board::GetCell( aroundIdx )->GetUnit();
 
-        for ( Indexes::const_iterator it = around.begin(); it != around.end(); ++it ) {
-            const Unit * enemy = Board::GetCell( *it )->GetUnit();
-            if ( enemy && enemy->GetColor() != GetColor() )
+            if ( nearbyUnit && nearbyUnit->GetColor() != GetCurrentColor() ) {
                 return true;
+            }
         }
     }
 

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -395,8 +395,8 @@ bool Battle::Unit::canReach( const Unit & unit ) const
 bool Battle::Unit::isHandFighting() const
 {
     if ( GetCount() && !Modes( CAP_TOWER ) ) {
-        for ( const int32_t aroundIdx : Board::GetAroundIndexes( *this ) ) {
-            const Unit * nearbyUnit = Board::GetCell( aroundIdx )->GetUnit();
+        for ( const int32_t nearbyIdx : Board::GetAroundIndexes( *this ) ) {
+            const Unit * nearbyUnit = Board::GetCell( nearbyIdx )->GetUnit();
 
             if ( nearbyUnit && nearbyUnit->GetColor() != GetCurrentColor() ) {
                 return true;

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -104,7 +104,7 @@ namespace Battle
         bool isTwiceAttack( void ) const;
 
         bool AllowResponse( void ) const;
-        bool isHandFighting( void ) const;
+        bool isHandFighting() const;
         bool isReflect( void ) const;
         bool isHaveDamage( void ) const;
         bool isMagicResist( const Spell &, u32 ) const;

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -411,8 +411,8 @@ bool Heroes::isInDeepOcean() const
     const bool isHeroMovedHalfOfCell = ( sprite_index < 45 && sprite_index % 9 > 4 );
     const int32_t tileIndex
         = ( isHeroMovedHalfOfCell && Maps::isValidDirection( GetIndex(), direction ) ) ? Maps::GetDirectionIndex( GetIndex(), direction ) : GetIndex();
-    for ( const int32_t aroundIndex : Maps::getAroundIndexes( tileIndex ) ) {
-        if ( !world.GetTiles( aroundIndex ).isWater() ) {
+    for ( const int32_t nearbyIndex : Maps::getAroundIndexes( tileIndex ) ) {
+        if ( !world.GetTiles( nearbyIndex ).isWater() ) {
             return false;
         }
     }


### PR DESCRIPTION
fix #4978

https://user-images.githubusercontent.com/32623900/152430675-2cdcb988-20dd-4fe7-a601-53092cdf1429.mp4

---

Also this PR fixes additional issue when long distance attacks were not performed on retaliation. Before (note that the Dragons' retaliation strike does not affect Minotaurs):

https://user-images.githubusercontent.com/32623900/152445048-a750ad87-0e0e-4c06-84d6-ae2207ddb213.mp4

After:

https://user-images.githubusercontent.com/32623900/152445060-d8cccc6e-0e50-4e92-a055-7a720b3a189e.mp4

---

Also this PR fixes issue when units affected by Hypnotize or Berserk spells were able to shoot nearby units from their own army, which may lead to crash or freeze. Before:

https://user-images.githubusercontent.com/32623900/152456112-f8fe7434-7d75-48ce-bcb3-b44c305cbb1d.mp4

https://user-images.githubusercontent.com/32623900/152456131-03840970-9e6a-4045-b535-5ca2edf948a2.mp4

After:

https://user-images.githubusercontent.com/32623900/152456161-261fe4d5-3982-4d64-8c8a-1ebaff74d6d2.mp4

https://user-images.githubusercontent.com/32623900/152456172-e57c56fe-a1f9-4239-9b46-1da5d7f1c369.mp4
