### PR TITLE
Improve the handling of auto battle on/off events and log them properly

### DIFF
--- a/files/lang/cs.po
+++ b/files/lang/cs.po
@@ -140,12 +140,6 @@ msgstr ""
 msgid "%{name} half the enemy troops!"
 msgstr ""
 
-msgid "Set auto battle off"
-msgstr ""
-
-msgid "Set auto battle on"
-msgstr ""
-
 msgid "spell failed!"
 msgstr ""
 

--- a/files/lang/de.po
+++ b/files/lang/de.po
@@ -153,12 +153,6 @@ msgstr "Anzahl festlegen"
 msgid "%{name} half the enemy troops!"
 msgstr "%{name} halbieren die feindlichen Truppen!"
 
-msgid "Set auto battle off"
-msgstr "Autokampf ausschalten"
-
-msgid "Set auto battle on"
-msgstr "Autokampf einschalten"
-
 msgid "spell failed!"
 msgstr "Zauberspruch fehlgeschlagen!"
 

--- a/files/lang/es.po
+++ b/files/lang/es.po
@@ -158,12 +158,6 @@ msgstr ""
 msgid "%{name} half the enemy troops!"
 msgstr "%{name} mitad de las tropas enemigas!"
 
-msgid "Set auto battle off"
-msgstr "Desactivar combate automático"
-
-msgid "Set auto battle on"
-msgstr "Activar combate automático"
-
 msgid "spell failed!"
 msgstr "¡Hechizo fallido!"
 

--- a/files/lang/fr.po
+++ b/files/lang/fr.po
@@ -154,12 +154,6 @@ msgstr "Régler le nombre"
 msgid "%{name} half the enemy troops!"
 msgstr "%{name} décime la troupe ennemie !"
 
-msgid "Set auto battle off"
-msgstr "Désactiver combat auto"
-
-msgid "Set auto battle on"
-msgstr "Activer combat auto"
-
 msgid "spell failed!"
 msgstr "sort échoué !"
 

--- a/files/lang/hu.po
+++ b/files/lang/hu.po
@@ -159,12 +159,6 @@ msgstr ""
 msgid "%{name} half the enemy troops!"
 msgstr ""
 
-msgid "Set auto battle off"
-msgstr "Automata harc kikapcsolása"
-
-msgid "Set auto battle on"
-msgstr "Automata harc bekapcsolása"
-
 msgid "spell failed!"
 msgstr ""
 

--- a/files/lang/it.po
+++ b/files/lang/it.po
@@ -152,12 +152,6 @@ msgstr "Seleziona quanti"
 msgid "%{name} half the enemy troops!"
 msgstr "Le unità nemiche sono state dimezzate da %{name}!"
 
-msgid "Set auto battle off"
-msgstr ""
-
-msgid "Set auto battle on"
-msgstr ""
-
 msgid "spell failed!"
 msgstr "magia fallita!"
 

--- a/files/lang/lt.po
+++ b/files/lang/lt.po
@@ -143,12 +143,6 @@ msgstr ""
 msgid "%{name} half the enemy troops!"
 msgstr ""
 
-msgid "Set auto battle off"
-msgstr ""
-
-msgid "Set auto battle on"
-msgstr ""
-
 msgid "spell failed!"
 msgstr ""
 

--- a/files/lang/nb.po
+++ b/files/lang/nb.po
@@ -154,12 +154,6 @@ msgstr "Velg antall"
 msgid "%{name} half the enemy troops!"
 msgstr "%{name} halverer fiendestyrken!"
 
-msgid "Set auto battle off"
-msgstr "Skru autokamp av"
-
-msgid "Set auto battle on"
-msgstr "Skru autokamp på"
-
 msgid "spell failed!"
 msgstr "trolldom mislykket!"
 

--- a/files/lang/nl.po
+++ b/files/lang/nl.po
@@ -137,12 +137,6 @@ msgstr ""
 msgid "%{name} half the enemy troops!"
 msgstr ""
 
-msgid "Set auto battle off"
-msgstr ""
-
-msgid "Set auto battle on"
-msgstr ""
-
 msgid "spell failed!"
 msgstr ""
 

--- a/files/lang/pl.po
+++ b/files/lang/pl.po
@@ -157,12 +157,6 @@ msgstr "Podaj liczbę"
 msgid "%{name} half the enemy troops!"
 msgstr "%{name} Połowa żołnierzy wroga!"
 
-msgid "Set auto battle off"
-msgstr "Wyłącz automatyczną walkę"
-
-msgid "Set auto battle on"
-msgstr "Włącz automatyczną walkę"
-
 msgid "spell failed!"
 msgstr "czar nie udany!"
 

--- a/files/lang/pt.po
+++ b/files/lang/pt.po
@@ -158,12 +158,6 @@ msgstr ""
 msgid "%{name} half the enemy troops!"
 msgstr "%{name} metade das tropas inimigas!"
 
-msgid "Set auto battle off"
-msgstr "Desligar batalha automática"
-
-msgid "Set auto battle on"
-msgstr "Ligar batalha automática"
-
 msgid "spell failed!"
 msgstr "feitiço falhou!"
 

--- a/files/lang/ru.po
+++ b/files/lang/ru.po
@@ -157,12 +157,6 @@ msgstr "Количество"
 msgid "%{name} half the enemy troops!"
 msgstr "%{name} убивает половину вражеского отряда!"
 
-msgid "Set auto battle off"
-msgstr "Выключить автобитву"
-
-msgid "Set auto battle on"
-msgstr "Включить автобитву"
-
 msgid "spell failed!"
 msgstr "неудачный вызов магии!"
 

--- a/files/lang/sv.po
+++ b/files/lang/sv.po
@@ -156,12 +156,6 @@ msgstr ""
 msgid "%{name} half the enemy troops!"
 msgstr "%{name} halverar fiendetrupperna!"
 
-msgid "Set auto battle off"
-msgstr "Slå av autostrid"
-
-msgid "Set auto battle on"
-msgstr "Slå på autostrid"
-
 msgid "spell failed!"
 msgstr "besvärjelse misslyckades!"
 

--- a/files/lang/tr.po
+++ b/files/lang/tr.po
@@ -136,12 +136,6 @@ msgstr ""
 msgid "%{name} half the enemy troops!"
 msgstr ""
 
-msgid "Set auto battle off"
-msgstr ""
-
-msgid "Set auto battle on"
-msgstr ""
-
 msgid "spell failed!"
 msgstr ""
 

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -910,19 +910,33 @@ void Battle::Arena::ApplyActionCatapult( Command & cmd )
 void Battle::Arena::ApplyActionAutoBattle( Command & cmd )
 {
     const int color = cmd.GetValue();
-    if ( current_color != color ) {
-        DEBUG_LOG( DBG_BATTLE, DBG_WARN, "incorrect param" );
-        return;
-    }
 
     if ( auto_battle & color ) {
-        if ( interface )
-            interface->SetStatus( _( "Set auto battle off" ), true );
+        if ( interface ) {
+            const Player * player = Players::Get( color );
+
+            if ( player ) {
+                std::string msg = _( "%{name} has turned off the auto battle" );
+                StringReplace( msg, "%{name}", player->GetName() );
+
+                interface->SetStatus( msg, true );
+            }
+        }
+
         auto_battle &= ~color;
     }
     else {
-        if ( interface )
-            interface->SetStatus( _( "Set auto battle on" ), true );
+        if ( interface ) {
+            const Player * player = Players::Get( color );
+
+            if ( player ) {
+                std::string msg = _( "%{name} has turned on the auto battle" );
+                StringReplace( msg, "%{name}", player->GetName() );
+
+                interface->SetStatus( msg, true );
+            }
+        }
+
         auto_battle |= color;
     }
 }

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -324,7 +324,15 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
     while ( !end_turn ) {
         Actions actions;
 
-        if ( !troop->isValid() ) { // looks like the unit died
+        if ( interface ) {
+            interface->getPendingActions( actions );
+        }
+
+        if ( !actions.empty() ) {
+            // Pending actions from the user interface (such as toggling auto battle) have a higher priority
+            // and should be handled first, before any other actions
+        }
+        else if ( !troop->isValid() ) { // looks like the unit died
             end_turn = true;
         }
         else if ( troop->Modes( MORALE_BAD ) && !troop->Modes( TR_SKIPMOVE ) ) {
@@ -1273,14 +1281,14 @@ Battle::Result & Battle::Arena::GetResult( void )
     return result_game;
 }
 
-bool Battle::Arena::CanBreakAutoBattle( void ) const
+bool Battle::Arena::AutoBattleInProgress() const
 {
     return ( auto_battle & current_color ) && GetCurrentCommander() && !GetCurrentCommander()->isControlAI();
 }
 
-void Battle::Arena::BreakAutoBattle( void )
+bool Battle::Arena::CanToggleAutoBattle() const
 {
-    auto_battle &= ~current_color;
+    return GetCurrentCommander() && !GetCurrentCommander()->isControlAI();
 }
 
 const Rand::DeterministicRandomGenerator & Battle::Arena::GetRandomGenerator() const

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -329,10 +329,11 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
         }
 
         if ( !actions.empty() ) {
-            // Pending actions from the user interface (such as toggling auto battle) have "already occured"
-            // and therefore should be handled first, before any other actions
+            // Pending actions from the user interface (such as toggling auto battle) have "already occured" and
+            // therefore should be handled first, before any other actions. Just skip the rest of the branches.
         }
-        else if ( !troop->isValid() ) { // looks like the unit died
+        else if ( !troop->isValid() ) {
+            // looks like the unit is dead
             end_turn = true;
         }
         else if ( troop->Modes( MORALE_BAD ) && !troop->Modes( TR_SKIPMOVE ) ) {
@@ -368,11 +369,11 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
             actions.pop_front();
 
             if ( armies_order ) {
-                // some spell could kill someone or affect the speed of some unit, update units order
+                // applied action could kill or resurrect someone, or affect the speed of some unit, update units order
                 Force::UpdateOrderUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
             }
 
-            // check end battle
+            // check for the end of the battle
             if ( !BattleValid() ) {
                 end_turn = true;
                 break;

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -329,8 +329,8 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
         }
 
         if ( !actions.empty() ) {
-            // Pending actions from the user interface (such as toggling auto battle) have a higher priority
-            // and should be handled first, before any other actions
+            // Pending actions from the user interface (such as toggling auto battle) have "already occured"
+            // and therefore should be handled first, before any other actions
         }
         else if ( !troop->isValid() ) { // looks like the unit died
             end_turn = true;

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -78,8 +78,8 @@ namespace Battle
         void Turns( void );
         bool BattleValid( void ) const;
 
-        bool CanBreakAutoBattle( void ) const;
-        void BreakAutoBattle( void );
+        bool AutoBattleInProgress() const;
+        bool CanToggleAutoBattle() const;
 
         u32 GetCurrentTurn( void ) const;
         Result & GetResult( void );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2317,9 +2317,6 @@ void Battle::Interface::HumanTurn( const Unit & b, Actions & a )
         else
             HumanBattleTurn( b, a, msg );
 
-        if ( humanturn_exit )
-            cursor.SetThemes( Cursor::WAIT );
-
         // update status
         if ( msg != status.GetMessage() ) {
             status.SetMessage( msg );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -929,6 +929,7 @@ Battle::Interface::Interface( Arena & a, s32 center )
     , humanturn_redraw( true )
     , animation_flags_frame( 0 )
     , catapult_frame( 0 )
+    , _breakAutoBattleForColor( 0 )
     , _contourColor( 110 )
     , _brightLandType( false )
     , _currentUnit( nullptr )
@@ -2261,6 +2262,15 @@ int Battle::Interface::GetBattleSpellCursor( std::string & statusMsg ) const
     return Cursor::WAR_NONE;
 }
 
+void Battle::Interface::getPendingActions( Actions & actions )
+{
+    if ( _breakAutoBattleForColor ) {
+        actions.push_back( Command( CommandType::MSG_BATTLE_AUTO, _breakAutoBattleForColor ) );
+
+        _breakAutoBattleForColor = 0;
+    }
+}
+
 void Battle::Interface::HumanTurn( const Unit & b, Actions & a )
 {
     Cursor & cursor = Cursor::Get();
@@ -2667,9 +2677,10 @@ void Battle::Interface::EventAutoSwitch( const Unit & b, Actions & a )
 {
     btn_auto.drawOnPress();
 
-    a.push_back( Command( CommandType::MSG_BATTLE_AUTO, b.GetColor() ) );
+    if ( arena.CanToggleAutoBattle() ) {
+        a.push_back( Command( CommandType::MSG_BATTLE_AUTO, b.GetColor() ) );
+    }
 
-    Cursor::Get().SetThemes( Cursor::WAIT );
     humanturn_redraw = true;
     humanturn_exit = true;
 
@@ -4992,13 +5003,13 @@ void Battle::Interface::CheckGlobalEvents( LocalEvent & le )
     }
 
     // break auto battle
-    if ( arena.CanBreakAutoBattle()
+    if ( arena.AutoBattleInProgress() && arena.CanToggleAutoBattle()
          && ( le.MouseClickLeft( btn_auto.area() )
               || ( le.KeyPress()
                    && ( Game::HotKeyPressEvent( Game::EVENT_BATTLE_AUTOSWITCH )
                         || ( Game::HotKeyPressEvent( Game::EVENT_DEFAULT_EXIT )
                              && Dialog::YES == Dialog::Message( "", _( "Break auto battle?" ), Font::BIG, Dialog::YES | Dialog::NO ) ) ) ) ) ) {
-        arena.BreakAutoBattle();
+        _breakAutoBattleForColor = arena.GetCurrentColor();
     }
 }
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2265,7 +2265,7 @@ int Battle::Interface::GetBattleSpellCursor( std::string & statusMsg ) const
 void Battle::Interface::getPendingActions( Actions & actions )
 {
     if ( _breakAutoBattleForColor ) {
-        actions.push_back( Command( CommandType::MSG_BATTLE_AUTO, _breakAutoBattleForColor ) );
+        actions.emplace_back( CommandType::MSG_BATTLE_AUTO, _breakAutoBattleForColor );
 
         _breakAutoBattleForColor = 0;
     }
@@ -2675,7 +2675,7 @@ void Battle::Interface::EventAutoSwitch( const Unit & b, Actions & a )
     btn_auto.drawOnPress();
 
     if ( arena.CanToggleAutoBattle() ) {
-        a.push_back( Command( CommandType::MSG_BATTLE_AUTO, b.GetColor() ) );
+        a.emplace_back( CommandType::MSG_BATTLE_AUTO, b.GetColor() );
     }
 
     humanturn_redraw = true;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -206,6 +206,8 @@ namespace Battle
         void Redraw();
         void RedrawPartialStart();
         void RedrawPartialFinish();
+
+        void getPendingActions( Actions & actions );
         void HumanTurn( const Unit &, Actions & );
 
         const fheroes2::Rect & GetArea( void ) const;
@@ -338,6 +340,8 @@ namespace Battle
         bool humanturn_redraw;
         u32 animation_flags_frame;
         int catapult_frame;
+
+        int _breakAutoBattleForColor;
 
         uint8_t _contourColor;
         bool _brightLandType; // used to determine current monster contour cycling colors


### PR DESCRIPTION
The idea is to throw away that hacky approach with `Arena::BreakAutoBattle()` and use the "regular" approach with `Battle::Command`. Perhaps not the ideal approach, but I think it's less "hacky" and more "general" than the current one.