### PR TITLE
Change the way spell casts are logged

### DIFF
--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -1059,17 +1059,34 @@ void Battle::Arena::ApplyActionSpellMirrorImage( Command & cmd )
         if ( it != distances.end() ) {
             const Position pos = Position::GetPositionWhenMoved( *troop, *it );
             const s32 dst = pos.GetHead()->GetIndex();
+
             DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "set position: " << dst );
-            if ( interface )
+
+            if ( interface ) {
+                const HeroBase * commander = GetCurrentCommander();
+                assert( commander != nullptr );
+
+                TargetInfo targetInfo;
+                targetInfo.defender = troop;
+
+                TargetsInfo targetsInfo;
+                targetsInfo.push_back( targetInfo );
+
+                interface->RedrawActionSpellCastStatus( Spell( Spell::MIRRORIMAGE ), who, commander->GetName(), targetsInfo );
                 interface->RedrawActionMirrorImageSpell( *troop, pos );
+            }
+
             Unit * mirror = CreateMirrorImage( *troop, dst );
-            if ( mirror )
+            if ( mirror ) {
                 mirror->SetPosition( pos );
+            }
         }
         else {
-            if ( interface )
-                interface->SetStatus( _( "spell failed!" ), true );
             DEBUG_LOG( DBG_BATTLE, DBG_WARN, "new position not found!" );
+
+            if ( interface ) {
+                interface->SetStatus( _( "Spell failed!" ), true );
+            }
         }
     }
     else {

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -1017,13 +1017,17 @@ void Battle::Arena::ApplyActionSpellTeleport( Command & cmd )
 
 void Battle::Arena::ApplyActionSpellEarthQuake( const Command & /*cmd*/ )
 {
+    const HeroBase * commander = GetCurrentCommander();
+    assert( commander != nullptr );
+
     std::vector<int> targets = GetCastleTargets();
+
     if ( interface ) {
+        interface->RedrawActionSpellCastStatus( Spell( Spell::EARTHQUAKE ), -1, commander->GetName(), {} );
         interface->RedrawActionEarthQuakeSpell( targets );
     }
 
-    const HeroBase * commander = GetCurrentCommander();
-    const std::pair<int, int> range = commander ? getEarthquakeDamageRange( commander ) : std::make_pair( 0, 0 );
+    const std::pair<int, int> range = getEarthquakeDamageRange( commander );
     const std::vector<int> wallHexPositions = { CASTLE_FIRST_TOP_WALL_POS, CASTLE_SECOND_TOP_WALL_POS, CASTLE_THIRD_TOP_WALL_POS, CASTLE_FOURTH_TOP_WALL_POS };
     for ( int position : wallHexPositions ) {
         if ( 0 != board[position].GetObject() ) {

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -188,12 +188,11 @@ void Battle::Arena::ApplyAction( Command & cmd )
 void Battle::Arena::ApplyActionSpellCast( Command & cmd )
 {
     const Spell spell( cmd.GetValue() );
-    HeroBase * current_commander = GetCurrentForce().GetCommander();
 
-    if ( current_commander && current_commander->HaveSpellBook() && !current_commander->Modes( Heroes::SPELLCASTED ) && current_commander->CanCastSpell( spell )
-         && spell.isCombat() ) {
-        DEBUG_LOG( DBG_BATTLE, DBG_TRACE,
-                   current_commander->GetName() << ", color: " << Color::String( current_commander->GetColor() ) << ", spell: " << spell.GetName() );
+    HeroBase * commander = GetCurrentForce().GetCommander();
+
+    if ( commander && commander->HaveSpellBook() && !commander->Modes( Heroes::SPELLCASTED ) && commander->CanCastSpell( spell ) && spell.isCombat() ) {
+        DEBUG_LOG( DBG_BATTLE, DBG_TRACE, commander->GetName() << ", color: " << Color::String( commander->GetColor() ) << ", spell: " << spell.GetName() );
 
         // uniq spells action
         switch ( spell.GetID() ) {
@@ -221,8 +220,8 @@ void Battle::Arena::ApplyActionSpellCast( Command & cmd )
             break;
         }
 
-        current_commander->SetModes( Heroes::SPELLCASTED );
-        current_commander->SpellCasted( spell );
+        commander->SetModes( Heroes::SPELLCASTED );
+        commander->SpellCasted( spell );
 
         // save spell for "eagle eye" capability
         usage_spells.Append( spell );

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -1028,8 +1028,16 @@ void Battle::Arena::ApplyActionSpellEarthQuake( const Command & /*cmd*/ )
     const std::pair<int, int> range = getEarthquakeDamageRange( commander );
     const std::vector<int> wallHexPositions = { CASTLE_FIRST_TOP_WALL_POS, CASTLE_SECOND_TOP_WALL_POS, CASTLE_THIRD_TOP_WALL_POS, CASTLE_FOURTH_TOP_WALL_POS };
     for ( int position : wallHexPositions ) {
-        if ( 0 != board[position].GetObject() ) {
-            board[position].SetObject( Rand::Get( range.first, range.second ) );
+        const int wallCondition = board[position].GetObject();
+
+        if ( wallCondition > 0 ) {
+            uint32_t wallDamage = Rand::Get( range.first, range.second );
+
+            if ( wallDamage > static_cast<uint32_t>( wallCondition ) ) {
+                wallDamage = wallCondition;
+            }
+
+            board[position].SetObject( wallCondition - wallDamage );
         }
     }
 

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -943,18 +943,17 @@ void Battle::Arena::ApplyActionSpellSummonElemental( const Command & /*cmd*/, co
 
 void Battle::Arena::ApplyActionSpellDefaults( Command & cmd, const Spell & spell )
 {
-    const HeroBase * current_commander = GetCurrentCommander();
-    if ( !current_commander )
-        return;
+    const HeroBase * commander = GetCurrentCommander();
+    assert( commander != nullptr );
 
     const int32_t dst = cmd.GetValue();
 
     bool playResistSound = false;
-    TargetsInfo targets = GetTargetsForSpells( current_commander, spell, dst, &playResistSound );
+    TargetsInfo targets = GetTargetsForSpells( commander, spell, dst, &playResistSound );
     TargetsInfo resistTargets;
 
     if ( interface ) {
-        interface->RedrawActionSpellCastStatus( spell, dst, current_commander->GetName(), targets );
+        interface->RedrawActionSpellCastStatus( spell, dst, commander->GetName(), targets );
 
         for ( const auto & target : targets ) {
             if ( target.resist ) {
@@ -966,13 +965,13 @@ void Battle::Arena::ApplyActionSpellDefaults( Command & cmd, const Spell & spell
     targets.erase( std::remove_if( targets.begin(), targets.end(), []( const TargetInfo & v ) { return v.resist; } ), targets.end() );
 
     if ( interface ) {
-        interface->RedrawActionSpellCastPart1( spell, dst, current_commander, targets );
+        interface->RedrawActionSpellCastPart1( spell, dst, commander, targets );
         for ( const TargetInfo & target : resistTargets ) {
             interface->RedrawActionResistSpell( *target.defender, playResistSound );
         }
     }
 
-    TargetsApplySpell( current_commander, spell, targets );
+    TargetsApplySpell( commander, spell, targets );
 
     if ( interface )
         interface->RedrawActionSpellCastPart2( spell, targets );

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -930,8 +930,13 @@ void Battle::Arena::ApplyActionAutoBattle( Command & cmd )
 void Battle::Arena::ApplyActionSpellSummonElemental( const Command & /*cmd*/, const Spell & spell )
 {
     Unit * elem = CreateElemental( spell );
+    assert( elem != nullptr );
+
     if ( interface ) {
-        assert( elem != nullptr );
+        const HeroBase * commander = GetCurrentCommander();
+        assert( commander != nullptr );
+
+        interface->RedrawActionSpellCastStatus( spell, -1, commander->GetName(), {} );
         interface->RedrawActionSummonElementalSpell( *elem );
     }
 }

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -43,7 +43,7 @@
 
 namespace
 {
-    std::pair<int, int> getEarthquakeDamageRange( const HeroBase * commander )
+    std::pair<uint32_t, uint32_t> getEarthquakeDamageRange( const HeroBase * commander )
     {
         const int spellPower = commander->GetPower();
         if ( ( spellPower > 0 ) && ( spellPower < 3 ) ) {
@@ -1025,7 +1025,7 @@ void Battle::Arena::ApplyActionSpellEarthQuake( const Command & /*cmd*/ )
         interface->RedrawActionEarthQuakeSpell( targets );
     }
 
-    const std::pair<int, int> range = getEarthquakeDamageRange( commander );
+    const std::pair<uint32_t, uint32_t> range = getEarthquakeDamageRange( commander );
     const std::vector<int> wallHexPositions = { CASTLE_FIRST_TOP_WALL_POS, CASTLE_SECOND_TOP_WALL_POS, CASTLE_THIRD_TOP_WALL_POS, CASTLE_FOURTH_TOP_WALL_POS };
     for ( int position : wallHexPositions ) {
         const int wallCondition = board[position].GetObject();

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -986,8 +986,19 @@ void Battle::Arena::ApplyActionSpellTeleport( Command & cmd )
         if ( b->isReflect() != pos.isReflect() )
             pos.Swap();
 
-        if ( interface )
+        if ( interface ) {
+            const HeroBase * commander = GetCurrentCommander();
+            assert( commander != nullptr );
+
+            TargetInfo targetInfo;
+            targetInfo.defender = b;
+
+            TargetsInfo targetsInfo;
+            targetsInfo.push_back( targetInfo );
+
+            interface->RedrawActionSpellCastStatus( spell, src, commander->GetName(), targetsInfo );
             interface->RedrawActionTeleportSpell( *b, pos.GetHead()->GetIndex() );
+        }
 
         b->SetPosition( pos );
         b->UpdateDirection();

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2579,15 +2579,6 @@ void Battle::Interface::HumanCastSpellTurn( const Unit & /*b*/, Actions & a, std
                 return;
             }
 
-            if ( listlog ) {
-                std::string str = _( "%{color} casts a spell: %{spell}" );
-                const HeroBase * current_commander = arena.GetCurrentCommander();
-                if ( current_commander )
-                    StringReplace( str, "%{color}", Color::String( current_commander->GetColor() ) );
-                StringReplace( str, "%{spell}", humanturn_spell.GetName() );
-                listlog->AddMessage( str );
-            }
-
             DEBUG_LOG( DBG_BATTLE, DBG_TRACE, humanturn_spell.GetName() << ", dst: " << index_pos );
 
             if ( Cursor::SP_TELEPORT == cursor.Themes() ) {
@@ -3397,7 +3388,7 @@ void Battle::Interface::RedrawActionSpellCastStatus( const Spell & spell, int32_
         msg = _( "%{name} casts %{spell} on the %{troop}." );
         StringReplace( msg, "%{troop}", target->GetName() );
     }
-    else if ( spell.isApplyWithoutFocusObject() ) {
+    else {
         msg = _( "%{name} casts %{spell}." );
     }
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3384,7 +3384,7 @@ void Battle::Interface::RedrawActionSpellCastStatus( const Spell & spell, int32_
 
     std::string msg;
 
-    if ( target && target->GetHeadIndex() == dst ) {
+    if ( target && ( target->GetHeadIndex() == dst || ( target->isWide() && target->GetTailIndex() == dst ) ) ) {
         msg = _( "%{name} casts %{spell} on the %{troop}." );
         StringReplace( msg, "%{troop}", target->GetName() );
     }


### PR DESCRIPTION
Unifies the spell logging format for all spells. Previously, a number of spells (for example, Summon Elemental, Teleport or Earthquake) were not logged at all.

Also fixes the following issues:

* Earthquake may "heal" castle walls (pay attention to the condition of the wall at the bottom right):

https://user-images.githubusercontent.com/32623900/152602691-8ac7968a-1c79-4c28-915b-b725b9619f2f.mp4

* Spells are incorrectly logged if they are applied to the tail cell of a wide unit:

https://user-images.githubusercontent.com/32623900/152602941-850cd40d-c214-4264-b759-27e77054893c.mp4
