### PR TITLE
Adjusted bottom padding of normal dialogs

### DIFF
--- a/src/fheroes2/dialog/dialog_message.cpp
+++ b/src/fheroes2/dialog/dialog_message.cpp
@@ -38,7 +38,9 @@ int Dialog::Message( const std::string & header, const std::string & message, in
     TextBox textbox2( message, ft, BOXAREA_WIDTH );
 
     const int32_t headerHeight = !header.empty() ? textbox1.h() + 10 : 0;
-    FrameBox box( 10 + headerHeight + textbox2.h(), buttons != 0 );
+    const int32_t bottomPadding = headerHeight * 2 < textbox2.h() ? headerHeight * 2 : 10;
+
+    FrameBox box( 10 + headerHeight + textbox2.h() + bottomPadding, buttons != 0 );
     const fheroes2::Rect & pos = box.GetArea();
 
     if ( !header.empty() )

--- a/src/fheroes2/dialog/dialog_message.cpp
+++ b/src/fheroes2/dialog/dialog_message.cpp
@@ -38,7 +38,7 @@ int Dialog::Message( const std::string & header, const std::string & message, in
     TextBox textbox2( message, ft, BOXAREA_WIDTH );
 
     const int32_t headerHeight = !header.empty() ? textbox1.h() + 10 : 0;
-    const int32_t bottomPadding = headerHeight * 2 < textbox2.h() ? headerHeight * 2 : 10;
+    const int32_t bottomPadding = ( headerHeight * 2 < textbox2.h() ) ? headerHeight * 2 : 10;
 
     FrameBox box( 10 + headerHeight + textbox2.h() + bottomPadding, buttons != 0 );
     const fheroes2::Rect & pos = box.GetArea();


### PR DESCRIPTION
Added a simple rule to adjust the padding at the bottom of the window depending on the relative size of the header and the message height. Some examples of what it looks like in action:

![fheroes2-cancel-bottom-padding](https://user-images.githubusercontent.com/7132795/152648413-281c929c-7e34-4b10-8660-83c3344a9188.png)

![fheroes2-difficulty-bottom-padding](https://user-images.githubusercontent.com/7132795/152648414-5a202ffb-6ab6-4e03-960c-5d3ca9bc84bc.png)

![fheroes2-icon-size-bottom-padding](https://user-images.githubusercontent.com/7132795/152648415-d388593d-3e7a-4505-8a7c-ed9e0b128bde.png)

![fheroes2-ok-bottom-padding](https://user-images.githubusercontent.com/7132795/152648416-bd5496e5-d2b7-4167-a70a-779d519b9c28.png)

Do note that this is not a perfect solution. Specifically, if the header itself is really tall, while the message is also substantially taller, the padding on the bottom of the window will be ridiculous. For instance, if the the header's height is 200px, and the message height is 600px, the resulting bottom padding will be 400px! This is kind of silly, but I assume that it is very unlikely to happen. Obviously this only happens when the header message is long and spans multiple lines, which is not super likely? Let me know if I am way off base here.

relates to #1260