### PR TITLE
Slightly refine the code

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -446,7 +446,7 @@ namespace AI
     Actions BattlePlanner::archerDecision( Arena & arena, const Unit & currentUnit ) const
     {
         Actions actions;
-        const Units enemies( arena.getEnemyForce( _myColor ), true );
+        const Units enemies( arena.getEnemyForce( _myColor ).getUnits(), true );
         BattleTargetPair target;
 
         if ( currentUnit.isHandFighting() ) {
@@ -545,7 +545,7 @@ namespace AI
     BattleTargetPair BattlePlanner::meleeUnitOffense( Arena & arena, const Unit & currentUnit ) const
     {
         BattleTargetPair target;
-        const Units enemies( arena.getEnemyForce( _myColor ), true );
+        const Units enemies( arena.getEnemyForce( _myColor ).getUnits(), true );
 
         double attackHighestValue = -_enemyArmyStrength;
         double attackPositionValue = -_enemyArmyStrength;
@@ -621,8 +621,8 @@ namespace AI
     {
         BattleTargetPair target;
 
-        const Units friendly( arena.getForce( _myColor ), true );
-        const Units enemies( arena.getEnemyForce( _myColor ), true );
+        const Units friendly( arena.getForce( _myColor ).getUnits(), true );
+        const Units enemies( arena.getEnemyForce( _myColor ).getUnits(), true );
 
         const int myHeadIndex = currentUnit.GetHeadIndex();
 

--- a/src/fheroes2/ai/normal/ai_normal_spell.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_spell.cpp
@@ -53,8 +53,8 @@ namespace AI
         }
 
         const std::vector<Spell> allSpells = _commander->GetSpells();
-        const Units friendly( arena.getForce( _myColor ), true );
-        const Units enemies( arena.getEnemyForce( _myColor ), true );
+        const Units friendly( arena.getForce( _myColor ).getUnits(), true );
+        const Units enemies( arena.getEnemyForce( _myColor ).getUnits(), true );
 
         // Hero should conserve spellpoints if already spent more than half or his army is stronger
         // Threshold is 0.04 when armies are equal (= 20% of single unit)

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -361,7 +361,7 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
 
             if ( armies_order ) {
                 // some spell could kill someone or affect the speed of some unit, update units order
-                Force::UpdateOrderUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+                Force::UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
             }
 
             // check end battle
@@ -418,7 +418,7 @@ void Battle::Arena::Turns( void )
         orderHistory.reserve( 25 );
 
         // build initial units order
-        Force::UpdateOrderUnits( *army1, *army2, nullptr, preferredColor, orderHistory, *armies_order );
+        Force::UpdateOrderOfUnits( *army1, *army2, nullptr, preferredColor, orderHistory, *armies_order );
     }
 
     {
@@ -438,7 +438,7 @@ void Battle::Arena::Turns( void )
                 orderHistory.push_back( troop );
 
                 // update units order
-                Force::UpdateOrderUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+                Force::UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
             }
 
             // first turn: castle and catapult action
@@ -454,7 +454,7 @@ void Battle::Arena::Turns( void )
 
                         if ( armies_order ) {
                             // tower could kill someone, update units order
-                            Force::UpdateOrderUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+                            Force::UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
                         }
                     }
                     if ( towers[0] && towers[0]->isValid() ) {
@@ -462,7 +462,7 @@ void Battle::Arena::Turns( void )
 
                         if ( armies_order ) {
                             // tower could kill someone, update units order
-                            Force::UpdateOrderUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+                            Force::UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
                         }
                     }
                     if ( towers[2] && towers[2]->isValid() ) {
@@ -470,7 +470,7 @@ void Battle::Arena::Turns( void )
 
                         if ( armies_order ) {
                             // tower could kill someone, update units order
-                            Force::UpdateOrderUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+                            Force::UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
                         }
                     }
                     tower_moved = true;
@@ -512,7 +512,7 @@ void Battle::Arena::Turns( void )
                 orderHistory.push_back( troop );
 
                 // update units order
-                Force::UpdateOrderUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+                Force::UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
             }
 
             // set bridge passable

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <functional>
 
 #include "ai.h"
 #include "army.h"
@@ -126,11 +127,13 @@ namespace
     {
         Battle::Unit * result = nullptr;
 
-        auto unitFilter = firstStage ? []( const Battle::Unit * unit ) { return !unit->Modes( Battle::TR_SKIPMOVE ) && unit->GetSpeed() > Speed::STANDING; }
-                                     : []( const Battle::Unit * unit ) { return unit->Modes( Battle::TR_SKIPMOVE ) && unit->GetSpeed() > Speed::STANDING; };
+        std::function<bool( const Battle::Unit * )> firstStageFilter
+            = []( const Battle::Unit * unit ) { return !unit->Modes( Battle::TR_SKIPMOVE ) && unit->GetSpeed() > Speed::STANDING; };
+        std::function<bool( const Battle::Unit * )> secondStageFilter
+            = []( const Battle::Unit * unit ) { return unit->Modes( Battle::TR_SKIPMOVE ) && unit->GetSpeed() > Speed::STANDING; };
 
-        Battle::Units::iterator it1 = std::find_if( units1.begin(), units1.end(), unitFilter );
-        Battle::Units::iterator it2 = std::find_if( units2.begin(), units2.end(), unitFilter );
+        Battle::Units::iterator it1 = std::find_if( units1.begin(), units1.end(), firstStage ? firstStageFilter : secondStageFilter );
+        Battle::Units::iterator it2 = std::find_if( units2.begin(), units2.end(), firstStage ? firstStageFilter : secondStageFilter );
 
         if ( it1 != units1.end() && it2 != units2.end() ) {
             if ( ( *it1 )->GetSpeed() == ( *it2 )->GetSpeed() ) {

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -42,6 +42,7 @@
 #include "logging.h"
 #include "race.h"
 #include "settings.h"
+#include "speed.h"
 #include "spell_info.h"
 #include "tools.h"
 #include "translations.h"
@@ -119,6 +120,122 @@ namespace
         }
 
         return covrs.empty() ? ICN::UNKNOWN : Rand::GetWithGen( covrs, gen );
+    }
+
+    Battle::Unit * GetCurrentUnitForBattleStage( Battle::Units & units1, Battle::Units & units2, const bool firstStage, const bool units1GoFirst, const bool ordersMode )
+    {
+        Battle::Unit * result = nullptr;
+
+        auto unitFilter = firstStage ? []( const Battle::Unit * unit ) { return !unit->Modes( Battle::TR_SKIPMOVE ) && unit->GetSpeed() > Speed::STANDING; }
+                                     : []( const Battle::Unit * unit ) { return unit->Modes( Battle::TR_SKIPMOVE ) && unit->GetSpeed() > Speed::STANDING; };
+
+        Battle::Units::iterator it1 = std::find_if( units1.begin(), units1.end(), unitFilter );
+        Battle::Units::iterator it2 = std::find_if( units2.begin(), units2.end(), unitFilter );
+
+        if ( it1 != units1.end() && it2 != units2.end() ) {
+            if ( ( *it1 )->GetSpeed() == ( *it2 )->GetSpeed() ) {
+                result = units1GoFirst ? *it1 : *it2;
+            }
+            else if ( firstStage || Settings::Get().ExtBattleReverseWaitOrder() ) {
+                if ( ( *it1 )->GetSpeed() > ( *it2 )->GetSpeed() )
+                    result = *it1;
+                else if ( ( *it2 )->GetSpeed() > ( *it1 )->GetSpeed() )
+                    result = *it2;
+            }
+            else {
+                if ( ( *it1 )->GetSpeed() < ( *it2 )->GetSpeed() )
+                    result = *it1;
+                else if ( ( *it2 )->GetSpeed() < ( *it1 )->GetSpeed() )
+                    result = *it2;
+            }
+        }
+        else if ( it1 != units1.end() )
+            result = *it1;
+        else if ( it2 != units2.end() )
+            result = *it2;
+
+        if ( result && ordersMode ) {
+            if ( it1 != units1.end() && result == *it1 )
+                units1.erase( it1 );
+            else if ( it2 != units2.end() && result == *it2 )
+                units2.erase( it2 );
+        }
+
+        return result;
+    }
+
+    Battle::Unit * GetCurrentUnit( const Battle::Force & army1, const Battle::Force & army2, const bool firstStage, const int preferredColor )
+    {
+        Battle::Units units1( army1, true );
+        Battle::Units units2( army2, true );
+
+        if ( firstStage || Settings::Get().ExtBattleReverseWaitOrder() ) {
+            units1.SortFastest();
+            units2.SortFastest();
+        }
+        else {
+            std::reverse( units1.begin(), units1.end() );
+            std::reverse( units2.begin(), units2.end() );
+
+            units1.SortSlowest();
+            units2.SortSlowest();
+        }
+
+        Battle::Unit * result = GetCurrentUnitForBattleStage( units1, units2, firstStage, preferredColor != army2.GetColor(), false );
+
+        return result && result->isValid() ? result : nullptr;
+    }
+
+    void UpdateOrderOfUnits( const Battle::Force & army1, const Battle::Force & army2, const Battle::Unit * currentUnit, int preferredColor,
+                             const Battle::Units & orderHistory, Battle::Units & orderOfUnits )
+    {
+        orderOfUnits.clear();
+        orderOfUnits.insert( orderOfUnits.end(), orderHistory.begin(), orderHistory.end() );
+
+        {
+            Battle::Units units1( army1, true );
+            Battle::Units units2( army2, true );
+
+            units1.SortFastest();
+            units2.SortFastest();
+
+            Battle::Unit * unit = nullptr;
+
+            while ( ( unit = GetCurrentUnitForBattleStage( units1, units2, true, preferredColor != army2.GetColor(), true ) ) != nullptr ) {
+                if ( unit != currentUnit && unit->isValid() ) {
+                    preferredColor = unit->GetArmyColor() == army1.GetColor() ? army2.GetColor() : army1.GetColor();
+
+                    orderOfUnits.push_back( unit );
+                }
+            }
+        }
+
+        if ( Settings::Get().ExtBattleSoftWait() ) {
+            Battle::Units units1( army1, true );
+            Battle::Units units2( army2, true );
+
+            if ( Settings::Get().ExtBattleReverseWaitOrder() ) {
+                units1.SortFastest();
+                units2.SortFastest();
+            }
+            else {
+                std::reverse( units1.begin(), units1.end() );
+                std::reverse( units2.begin(), units2.end() );
+
+                units1.SortSlowest();
+                units2.SortSlowest();
+            }
+
+            Battle::Unit * unit = nullptr;
+
+            while ( ( unit = GetCurrentUnitForBattleStage( units1, units2, false, preferredColor != army2.GetColor(), true ) ) != nullptr ) {
+                if ( unit != currentUnit && unit->isValid() ) {
+                    preferredColor = unit->GetArmyColor() == army1.GetColor() ? army2.GetColor() : army1.GetColor();
+
+                    orderOfUnits.push_back( unit );
+                }
+            }
+        }
     }
 }
 
@@ -361,7 +478,7 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
 
             if ( armies_order ) {
                 // some spell could kill someone or affect the speed of some unit, update units order
-                Force::UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+                UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
             }
 
             // check end battle
@@ -418,7 +535,7 @@ void Battle::Arena::Turns( void )
         orderHistory.reserve( 25 );
 
         // build initial units order
-        Force::UpdateOrderOfUnits( *army1, *army2, nullptr, preferredColor, orderHistory, *armies_order );
+        UpdateOrderOfUnits( *army1, *army2, nullptr, preferredColor, orderHistory, *armies_order );
     }
 
     {
@@ -427,7 +544,7 @@ void Battle::Arena::Turns( void )
 
         Unit * troop = nullptr;
 
-        while ( BattleValid() && ( troop = Force::GetCurrentUnit( *army1, *army2, true, preferredColor ) ) != nullptr ) {
+        while ( BattleValid() && ( troop = GetCurrentUnit( *army1, *army2, true, preferredColor ) ) != nullptr ) {
             current_color = troop->GetCurrentOrArmyColor();
 
             // switch preferred color for the next unit
@@ -438,7 +555,7 @@ void Battle::Arena::Turns( void )
                 orderHistory.push_back( troop );
 
                 // update units order
-                Force::UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+                UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
             }
 
             // first turn: castle and catapult action
@@ -454,7 +571,7 @@ void Battle::Arena::Turns( void )
 
                         if ( armies_order ) {
                             // tower could kill someone, update units order
-                            Force::UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+                            UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
                         }
                     }
                     if ( towers[0] && towers[0]->isValid() ) {
@@ -462,7 +579,7 @@ void Battle::Arena::Turns( void )
 
                         if ( armies_order ) {
                             // tower could kill someone, update units order
-                            Force::UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+                            UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
                         }
                     }
                     if ( towers[2] && towers[2]->isValid() ) {
@@ -470,7 +587,7 @@ void Battle::Arena::Turns( void )
 
                         if ( armies_order ) {
                             // tower could kill someone, update units order
-                            Force::UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+                            UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
                         }
                     }
                     tower_moved = true;
@@ -501,7 +618,7 @@ void Battle::Arena::Turns( void )
     if ( conf.ExtBattleSoftWait() ) {
         Unit * troop = nullptr;
 
-        while ( BattleValid() && ( troop = Force::GetCurrentUnit( *army1, *army2, false, preferredColor ) ) != nullptr ) {
+        while ( BattleValid() && ( troop = GetCurrentUnit( *army1, *army2, false, preferredColor ) ) != nullptr ) {
             current_color = troop->GetCurrentOrArmyColor();
 
             // switch preferred color for the next unit
@@ -512,7 +629,7 @@ void Battle::Arena::Turns( void )
                 orderHistory.push_back( troop );
 
                 // update units order
-                Force::UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
+                UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
             }
 
             // set bridge passable

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -169,8 +169,8 @@ namespace
 
     Battle::Unit * GetCurrentUnit( const Battle::Force & army1, const Battle::Force & army2, const bool firstStage, const int preferredColor )
     {
-        Battle::Units units1( army1, true );
-        Battle::Units units2( army2, true );
+        Battle::Units units1( army1.getUnits(), true );
+        Battle::Units units2( army2.getUnits(), true );
 
         if ( firstStage || Settings::Get().ExtBattleReverseWaitOrder() ) {
             units1.SortFastest();
@@ -196,8 +196,8 @@ namespace
         orderOfUnits.insert( orderOfUnits.end(), orderHistory.begin(), orderHistory.end() );
 
         {
-            Battle::Units units1( army1, true );
-            Battle::Units units2( army2, true );
+            Battle::Units units1( army1.getUnits(), true );
+            Battle::Units units2( army2.getUnits(), true );
 
             units1.SortFastest();
             units2.SortFastest();
@@ -214,8 +214,8 @@ namespace
         }
 
         if ( Settings::Get().ExtBattleSoftWait() ) {
-            Battle::Units units1( army1, true );
-            Battle::Units units2( army2, true );
+            Battle::Units units1( army1.getUnits(), true );
+            Battle::Units units2( army2.getUnits(), true );
 
             if ( Settings::Get().ExtBattleReverseWaitOrder() ) {
                 units1.SortFastest();

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -489,7 +489,7 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
             actions.pop_front();
 
             if ( armies_order ) {
-                // applied action could kill or resurrect someone, or affect the speed of some unit, update units order
+                // applied action could kill someone or affect the speed of some unit, update units order
                 UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
             }
 

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -41,13 +41,15 @@ Battle::Units::Units()
     reserve( unitSizeCapacity );
 }
 
-Battle::Units::Units( const Units & units, bool filter )
+Battle::Units::Units( const Units & units, const bool filter )
     : std::vector<Unit *>()
 {
     reserve( unitSizeCapacity < units.size() ? units.size() : unitSizeCapacity );
     assign( units.begin(), units.end() );
-    if ( filter )
+
+    if ( filter ) {
         erase( std::remove_if( begin(), end(), []( const Unit * unit ) { return !unit->isValid(); } ), end() );
+    }
 }
 
 void Battle::Units::SortSlowest()
@@ -113,6 +115,11 @@ const HeroBase * Battle::Force::GetCommander( void ) const
 HeroBase * Battle::Force::GetCommander( void )
 {
     return army.GetCommander();
+}
+
+const Battle::Units & Battle::Force::getUnits() const
+{
+    return *this;
 }
 
 int Battle::Force::GetColor( void ) const

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -80,8 +80,8 @@ namespace Battle
         void NewTurn( void );
         void SyncArmyCount();
 
-        static Unit * GetCurrentUnit( const Force & army1, const Force & army2, bool part1, int preferredColor );
-        static void UpdateOrderUnits( const Force & army1, const Force & army2, const Unit * activeUnit, int preferredColor, const Units & orderHistory, Units & orders );
+        static Unit * GetCurrentUnit( const Force & army1, const Force & army2, const bool firstStage, const int preferredColor );
+        static void UpdateOrderOfUnits( const Force & army1, const Force & army2, const Unit * currentUnit, int preferredColor, const Units & orderHistory, Units & orderOfUnits );
 
     private:
         Army & army;

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -80,9 +80,6 @@ namespace Battle
         void NewTurn( void );
         void SyncArmyCount();
 
-        static Unit * GetCurrentUnit( const Force & army1, const Force & army2, const bool firstStage, const int preferredColor );
-        static void UpdateOrderOfUnits( const Force & army1, const Force & army2, const Unit * currentUnit, int preferredColor, const Units & orderHistory, Units & orderOfUnits );
-
     private:
         Army & army;
         std::vector<u32> uids;

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -40,7 +40,8 @@ namespace Battle
     {
     public:
         Units();
-        Units( const Units &, bool filter = false );
+        Units( const Units & ) = delete;
+        Units( const Units & units, const bool filter );
         virtual ~Units() = default;
 
         Units & operator=( const Units & ) = delete;
@@ -65,6 +66,8 @@ namespace Battle
 
         HeroBase * GetCommander( void );
         const HeroBase * GetCommander( void ) const;
+
+        const Units & getUnits() const;
 
         bool isValid( const bool considerBattlefieldArmy = true ) const;
         bool HasMonster( const Monster & ) const;

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -103,7 +103,7 @@ void Battle::Board::Reset( void )
 void Battle::Board::SetPositionQuality( const Unit & b ) const
 {
     Arena * arena = GetArena();
-    Units enemies( arena->getEnemyForce( b.GetCurrentColor() ), true );
+    Units enemies( arena->getEnemyForce( b.GetCurrentColor() ).getUnits(), true );
 
     // Make sure archers are first here, so melee unit's score won't be double counted
     enemies.SortArchers();
@@ -134,9 +134,9 @@ void Battle::Board::SetPositionQuality( const Unit & b ) const
 void Battle::Board::SetEnemyQuality( const Unit & unit ) const
 {
     Arena * arena = GetArena();
-    Units enemies( arena->getEnemyForce( unit.GetColor() ), true );
+    Units enemies( arena->getEnemyForce( unit.GetColor() ).getUnits(), true );
     if ( unit.Modes( SP_BERSERKER ) ) {
-        Units allies( arena->getForce( unit.GetColor() ), true );
+        Units allies( arena->getForce( unit.GetColor() ).getUnits(), true );
         enemies.insert( enemies.end(), allies.begin(), allies.end() );
     }
 

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -302,7 +302,7 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, s32 mapsindex )
     }
 
     DEBUG_LOG( DBG_BATTLE, DBG_INFO, "army1 " << army1.String() );
-    DEBUG_LOG( DBG_BATTLE, DBG_INFO, "army2 " << army1.String() );
+    DEBUG_LOG( DBG_BATTLE, DBG_INFO, "army2 " << army2.String() );
 
     // update army
     if ( commander1 && commander1->isHeroes() ) {

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -565,7 +565,7 @@ fheroes2::GameMode Interface::Basic::StartGame()
     GameOver::Result & gameResult = GameOver::Result::Get();
     fheroes2::GameMode res = fheroes2::GameMode::END_TURN;
 
-    std::vector<Player *> sortedPlayers = conf.GetPlayers();
+    std::vector<Player *> sortedPlayers = conf.GetPlayers().getVector();
     std::sort( sortedPlayers.begin(), sortedPlayers.end(), SortPlayers );
 
     while ( res == fheroes2::GameMode::END_TURN ) {

--- a/src/fheroes2/system/players.cpp
+++ b/src/fheroes2/system/players.cpp
@@ -376,6 +376,11 @@ int Players::GetActualColors( void ) const
     return res;
 }
 
+const std::vector<Player *> & Players::getVector() const
+{
+    return *this;
+}
+
 Player * Players::GetCurrent( void )
 {
     return Get( current_color );

--- a/src/fheroes2/system/players.h
+++ b/src/fheroes2/system/players.h
@@ -182,6 +182,8 @@ public:
     int GetActualColors( void ) const;
     std::string String( void ) const;
 
+    const std::vector<Player *> & getVector() const;
+
     Player * GetCurrent( void );
     const Player * GetCurrent( void ) const;
 


### PR DESCRIPTION
* Rename variables in the code related to the order of units in battle - for better clarity (all those `part1`, `part2` looks a bit clunky);
* Move this code from `Battle::Force` to the anonymous namespace in the `battle_arena.cpp`, because it doesn't have any dependencies on `Battle::Force`, is not relevant to it and is needed only in one place;
* Fix code smells related to the implicit slicing of `Force` to `Units` (most of remaining "bugs" from SonarCloud);
* Fix code smell related to the implicit slicing of `Players` to `std::vector<Player *>` (another "bug" from SonarCloud);
* Fix typo in debugging output.