### PR TITLE
Use localtime_r() or localtime_s() instead of localtime()

### DIFF
--- a/src/engine/logging.cpp
+++ b/src/engine/logging.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include "logging.h"
+#include "system.h"
 
 namespace
 {
@@ -90,12 +91,10 @@ namespace Logging
 
     std::string GetTimeString()
     {
-        time_t raw;
-        std::time( &raw );
-        const struct tm * tmi = std::localtime( &raw );
+        const tm tmi = System::GetTM( std::time( nullptr ) );
 
         char buf[13] = {0};
-        std::strftime( buf, sizeof( buf ) - 1, "%X", tmi );
+        std::strftime( buf, sizeof( buf ) - 1, "%X", &tmi );
 
         return std::string( buf );
     }

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -486,15 +486,19 @@ tm System::GetTM( const time_t time )
 {
     tm result = {};
 
-#ifdef __STDC_LIB_EXT1__
-    const tm * res = localtime_s( &time, &result );
+#if defined( __MINGW32__ ) || defined( _MSC_VER )
+    errno_t res = localtime_s( &result, &time );
+
+    if ( res != 0 ) {
+        assert( 0 );
+    }
 #else
     const tm * res = localtime_r( &time, &result );
-#endif
 
     if ( res == nullptr ) {
         assert( 0 );
     }
+#endif
 
     return result;
 }

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <cassert>
 #include <cstdlib>
 #include <fstream>
 #include <map>
@@ -479,4 +480,21 @@ std::string System::FileNameToUTF8( const std::string & str )
 #else
     return str;
 #endif
+}
+
+tm System::GetTM( const time_t time )
+{
+    tm result = {};
+
+#ifdef __STDC_LIB_EXT1__
+    const tm * res = localtime_s( &time, &result );
+#else
+    const tm * res = localtime_r( &time, &result );
+#endif
+
+    if ( res == nullptr ) {
+        assert( 0 );
+    }
+
+    return result;
 }

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -23,6 +23,10 @@
 #ifndef H2SYSTEM_H
 #define H2SYSTEM_H
 
+#define __STDC_WANT_LIB_EXT1__ 1
+
+#include <ctime>
+
 #include "dir.h"
 
 namespace System
@@ -51,6 +55,8 @@ namespace System
     bool GetCaseInsensitivePath( const std::string & path, std::string & correctedPath );
 
     std::string FileNameToUTF8( const std::string & str );
+
+    tm GetTM( const time_t time );
 }
 
 #endif

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -23,8 +23,6 @@
 #ifndef H2SYSTEM_H
 #define H2SYSTEM_H
 
-#define __STDC_WANT_LIB_EXT1__ 1
-
 #include <ctime>
 
 #include "dir.h"

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -133,14 +133,15 @@ void FileInfoListBox::RedrawItem( const Maps::FileInfo & info, s32 dstx, s32 dst
     char shortDate[20];
     char shortHours[20];
     char shortTime[20];
-    time_t timeval = info.localtime;
+
+    const tm tmi = System::GetTM( info.localtime );
 
     std::fill( shortDate, std::end( shortDate ), static_cast<char>( 0 ) );
     std::fill( shortHours, std::end( shortHours ), static_cast<char>( 0 ) );
     std::fill( shortTime, std::end( shortTime ), static_cast<char>( 0 ) );
-    std::strftime( shortDate, ARRAY_COUNT( shortDate ) - 1, "%b %d,", std::localtime( &timeval ) );
-    std::strftime( shortHours, ARRAY_COUNT( shortHours ) - 1, "%H", std::localtime( &timeval ) );
-    std::strftime( shortTime, ARRAY_COUNT( shortTime ) - 1, ":%M", std::localtime( &timeval ) );
+    std::strftime( shortDate, ARRAY_COUNT( shortDate ) - 1, "%b %d,", &tmi );
+    std::strftime( shortHours, ARRAY_COUNT( shortHours ) - 1, "%H", &tmi );
+    std::strftime( shortTime, ARRAY_COUNT( shortTime ) - 1, ":%M", &tmi );
     std::string savname( System::GetBasename( info.file ) );
 
     if ( !savname.empty() ) {

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -22,6 +22,7 @@
 #include "localevent.h"
 #include "screen.h"
 #include "settings.h"
+#include "system.h"
 #include "text.h"
 #include "translations.h"
 
@@ -51,9 +52,10 @@ namespace
             const int32_t offsetX = 26;
             const int32_t offsetY = fheroes2::Display::instance().height() - 30;
 
-            std::time_t rawtime = std::time( nullptr );
+            const tm tmi = System::GetTM( std::time( nullptr ) );
+
             char mbstr[10] = { 0 };
-            std::strftime( mbstr, sizeof( mbstr ), "%H:%M:%S", std::localtime( &rawtime ) );
+            std::strftime( mbstr, sizeof( mbstr ), "%H:%M:%S", &tmi );
 
             std::string info( mbstr );
 


### PR DESCRIPTION
At least in one place (`DEBUG_LOG` macro) `localtime()` could be called from the non-main thread (via `AGG::AsyncSoundManager`) - only being built with DEBUG, but nonetheless.