### PR TITLE
Do not count on a specific type of attacking unit when applying built-in dispel

### DIFF
--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -140,19 +140,17 @@ void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, int32_t dst
 
             targets = GetTargetsForSpells( attacker.GetCommander(), spell, defender.GetHeadIndex() );
 
-            bool validSpell = true;
-            if ( attacker == Monster::ARCHMAGE && !defender.Modes( IS_GOOD_MAGIC ) )
-                validSpell = false;
-
-            if ( !targets.empty() && validSpell ) {
+            // The built-in dispel should only remove beneficial spells from the target
+            if ( !targets.empty() && ( spell.GetID() != Spell::DISPEL || defender.Modes( IS_GOOD_MAGIC ) ) ) {
                 if ( interface ) {
                     interface->RedrawActionSpellCastStatus( spell, defender.GetHeadIndex(), name, targets );
                     interface->RedrawActionSpellCastPart1( spell, defender.GetHeadIndex(), nullptr, targets );
                 }
 
-                if ( attacker == Monster::ARCHMAGE ) {
-                    if ( defender.Modes( IS_GOOD_MAGIC ) )
-                        defender.ResetModes( IS_GOOD_MAGIC );
+                if ( spell.GetID() == Spell::DISPEL ) {
+                    assert( targets.size() == 1 );
+
+                    defender.ResetModes( IS_GOOD_MAGIC );
                 }
                 else {
                     // magic attack not depends from hero

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -136,13 +136,13 @@ void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, int32_t dst
 
         // magic attack
         if ( spell.isValid() ) {
-            const std::string name( attacker.GetName() );
-
             targets = GetTargetsForSpells( attacker.GetCommander(), spell, defender.GetHeadIndex() );
 
             // The built-in dispel should only remove beneficial spells from the target
             if ( !targets.empty() && ( spell.GetID() != Spell::DISPEL || defender.Modes( IS_GOOD_MAGIC ) ) ) {
                 if ( interface ) {
+                    const std::string name( attacker.GetName() );
+
                     interface->RedrawActionSpellCastStatus( spell, defender.GetHeadIndex(), name, targets );
                     interface->RedrawActionSpellCastPart1( spell, defender.GetHeadIndex(), nullptr, targets );
                 }


### PR DESCRIPTION
Because in the new ideology, we no longer rely on the type of unit itself, but on unit's capabilities.