### PR TITLE
Fix neutral monster growth formula

### DIFF
--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -1103,7 +1103,7 @@ void Maps::Tiles::UpdateMonsterPopulation( Tiles & tile )
         tile.MonsterSetCount( troop.GetRNDSize( false ) );
     }
     else if ( !tile.MonsterFixedCount() ) {
-        const uint32_t bonusUnit = ( Rand::Get( 1, 7 ) <= troopCount % 7 ) ? 1 : 0;
+        const uint32_t bonusUnit = ( Rand::Get( 1, 7 ) <= ( troopCount % 7 ) ) ? 1 : 0;
         tile.MonsterSetCount( troopCount * 8 / 7 + bonusUnit );
     }
 }

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -1097,9 +1097,13 @@ void Maps::Tiles::UpdateDwellingPopulation( Tiles & tile, bool isFirstLoad )
 void Maps::Tiles::UpdateMonsterPopulation( Tiles & tile )
 {
     const Troop & troop = tile.QuantityTroop();
+    const uint32_t troopCount = troop.GetCount();
 
-    if ( 0 == troop.GetCount() )
+    if ( troopCount == 0 ) {
         tile.MonsterSetCount( troop.GetRNDSize( false ) );
-    else if ( !tile.MonsterFixedCount() )
-        tile.MonsterSetCount( troop.GetCount() * 8 / 7 );
+    }
+    else if ( !tile.MonsterFixedCount() ) {
+        const uint32_t bonusUnit = ( Rand::Get( 1, 7 ) <= troopCount % 7 ) ? 1 : 0;
+        tile.MonsterSetCount( troopCount * 8 / 7 + bonusUnit );
+    }
 }


### PR DESCRIPTION
Fixes #4893 .

Currently if monster stack is smaller than 7 it won't grow at all. Adjusting the logic to follow the original.