### PR TITLE
Archers should not ignore blinded units

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -498,7 +498,7 @@ namespace AI
         }
         else {
             // Normal ranged attack: focus the highest value unit
-            double highestStrength = 0;
+            double highestStrength = -1;
 
             for ( const Unit * enemy : enemies ) {
                 double attackPriority = enemy->GetScoreQuality( currentUnit );
@@ -523,7 +523,7 @@ namespace AI
                     }
                 }
 
-                if ( highestStrength < attackPriority && attackPriority > 0 ) {
+                if ( highestStrength < attackPriority ) {
                     highestStrength = attackPriority;
                     target.unit = enemy;
                     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "- Set priority on " << enemy->GetName() << " value " << attackPriority );


### PR DESCRIPTION
Fixes #4386.

Blinded and paralyzed units are evaluated as strength 0, so AI was ignoring them. Every other enemy stack will be prioritized regardless.