### PR TITLE
Various sound-related fixes

### DIFF
--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -110,7 +110,7 @@ namespace
 
     void PlayMusic( Mix_Music * mix, const bool loop )
     {
-        Music::Reset();
+        Music::Stop();
 
         int res = musicFadeIn ? Mix_FadeInMusic( mix, loop ? -1 : 0, musicFadeIn ) : Mix_PlayMusic( mix, loop ? -1 : 0 );
 
@@ -162,8 +162,8 @@ void Audio::Quit()
     const std::lock_guard<std::recursive_mutex> guard( mutex );
 
     if ( valid && fheroes2::isComponentInitialized( fheroes2::SystemInitializationComponent::Audio ) ) {
-        Music::Reset();
-        Mixer::Reset();
+        Music::Stop();
+        Mixer::Stop();
 
         valid = false;
 
@@ -357,17 +357,6 @@ void Mixer::Stop( const int channel /* = -1 */ )
     }
 }
 
-void Mixer::Reset()
-{
-    const std::lock_guard<std::recursive_mutex> guard( mutex );
-
-    Music::Reset();
-
-    if ( valid ) {
-        Mix_HaltChannel( -1 );
-    }
-}
-
 bool Mixer::isPlaying( const int channel )
 {
     const std::lock_guard<std::recursive_mutex> guard( mutex );
@@ -454,7 +443,7 @@ void Music::Pause()
     }
 }
 
-void Music::Reset()
+void Music::Stop()
 {
     const std::lock_guard<std::recursive_mutex> guard( mutex );
 

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -434,15 +434,6 @@ int Music::Volume( int vol )
     return Mix_VolumeMusic( vol );
 }
 
-void Music::Pause()
-{
-    const std::lock_guard<std::recursive_mutex> guard( mutex );
-
-    if ( music ) {
-        Mix_PauseMusic();
-    }
-}
-
 void Music::Stop()
 {
     const std::lock_guard<std::recursive_mutex> guard( mutex );

--- a/src/engine/audio.h
+++ b/src/engine/audio.h
@@ -53,7 +53,6 @@ namespace Mixer
     void Pause( const int channel = -1 );
     void Resume( const int channel = -1 );
     void Stop( const int channel = -1 );
-    void Reset();
 
     bool isPlaying( const int channel );
 }
@@ -68,7 +67,7 @@ namespace Music
     void SetFadeIn( const int f );
 
     void Pause();
-    void Reset();
+    void Stop();
 
     bool isPlaying();
 

--- a/src/engine/audio.h
+++ b/src/engine/audio.h
@@ -66,7 +66,6 @@ namespace Music
 
     void SetFadeIn( const int f );
 
-    void Pause();
     void Stop();
 
     bool isPlaying();

--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -117,24 +117,8 @@ namespace AGG
 
         AsyncSoundManager & operator=( const AsyncSoundManager & ) = delete;
 
-        void pushStopMusic()
-        {
-            _createThreadIfNeeded();
-
-            std::lock_guard<std::mutex> mutexLock( _mutex );
-
-            while ( !_musicTasks.empty() ) {
-                _musicTasks.pop();
-            }
-
-            _musicTasks.emplace( -1, MUSIC_MIDI_ORIGINAL, true );
-            _runFlag = 1;
-            _workerNotification.notify_all();
-        }
-
         void pushMusic( const int musicId, const MusicSource musicType, const bool isLooped )
         {
-            assert( musicId >= 0 );
             _createThreadIfNeeded();
 
             std::lock_guard<std::mutex> mutexLock( _mutex );
@@ -299,12 +283,8 @@ namespace AGG
                     }
 
                     manager->_mutex.unlock();
-                    if ( musicTask.musicId >= 0 ) {
-                        PlayMusicInternally( musicTask.musicId, musicTask.musicType, musicTask.isLooped );
-                    }
-                    else {
-                        Music::Reset();
-                    }
+
+                    PlayMusicInternally( musicTask.musicId, musicTask.musicType, musicTask.isLooped );
                 }
                 else {
                     manager->_runFlag = 0;
@@ -631,19 +611,14 @@ std::vector<u8> AGG::LoadBINFRM( const char * frm_file )
     return AGG::ReadChunk( frm_file );
 }
 
-void AGG::ResetMixer( bool asyncronizedCall /* = false */ )
+void AGG::ResetMixer()
 {
-    if ( asyncronizedCall ) {
-        g_asyncSoundManager.pushStopMusic();
-        Mixer::Stop();
-    }
-    else {
-        g_asyncSoundManager.sync();
+    g_asyncSoundManager.sync();
 
-        std::lock_guard<std::mutex> mutexLock( g_asyncSoundManager.resourceMutex() );
+    std::lock_guard<std::mutex> mutexLock( g_asyncSoundManager.resourceMutex() );
 
-        Mixer::Reset();
-    }
+    Mixer::Reset();
+
     loop_sounds.clear();
     loop_sounds.reserve( 7 );
 }

--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -617,7 +617,8 @@ void AGG::ResetMixer()
 
     std::lock_guard<std::mutex> mutexLock( g_asyncSoundManager.resourceMutex() );
 
-    Mixer::Reset();
+    Music::Stop();
+    Mixer::Stop();
 
     loop_sounds.clear();
     loop_sounds.reserve( 7 );

--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -611,7 +611,7 @@ std::vector<u8> AGG::LoadBINFRM( const char * frm_file )
     return AGG::ReadChunk( frm_file );
 }
 
-void AGG::ResetMixer()
+void AGG::ResetAudio()
 {
     g_asyncSoundManager.sync();
 

--- a/src/fheroes2/agg/agg.h
+++ b/src/fheroes2/agg/agg.h
@@ -44,7 +44,7 @@ namespace AGG
     void LoadLOOPXXSounds( const std::vector<int> & vols, bool asyncronizedCall = false );
     void PlaySound( int m82, bool asyncronizedCall = false );
     void PlayMusic( int mus, bool loop = true, bool asyncronizedCall = false );
-    void ResetMixer( bool asyncronizedCall = false );
+    void ResetMixer();
 
     std::vector<uint8_t> ReadChunk( const std::string & key );
 }

--- a/src/fheroes2/agg/agg.h
+++ b/src/fheroes2/agg/agg.h
@@ -44,7 +44,7 @@ namespace AGG
     void LoadLOOPXXSounds( const std::vector<int> & vols, bool asyncronizedCall = false );
     void PlaySound( int m82, bool asyncronizedCall = false );
     void PlayMusic( int mus, bool loop = true, bool asyncronizedCall = false );
-    void ResetMixer();
+    void ResetAudio();
 
     std::vector<uint8_t> ReadChunk( const std::string & key );
 }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1047,13 +1047,13 @@ Battle::Interface::Interface( Arena & a, s32 center )
         listlog->SetPosition( area.x, area.y + area.height - status.height );
     status.SetLogs( listlog );
 
-    AGG::ResetMixer();
+    AGG::ResetAudio();
     AGG::PlaySound( M82::PREBATTL );
 }
 
 Battle::Interface::~Interface()
 {
-    AGG::ResetMixer();
+    AGG::ResetAudio();
 
     if ( listlog )
         delete listlog;
@@ -2608,7 +2608,7 @@ void Battle::Interface::HumanCastSpellTurn( const Unit & /*b*/, Actions & a, std
 
 void Battle::Interface::FadeArena( bool clearMessageLog )
 {
-    AGG::ResetMixer();
+    AGG::ResetAudio();
 
     if ( clearMessageLog ) {
         status.clear();

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -402,7 +402,7 @@ void Game::EnvironmentSoundMixer()
 void Game::restoreSoundsForCurrentFocus()
 {
     Game::SetCurrentMusic( MUS::UNKNOWN );
-    AGG::ResetMixer();
+    AGG::ResetAudio();
 
     switch ( Interface::GetFocusType() ) {
     case GameFocus::HEROES: {

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -401,6 +401,7 @@ void Game::EnvironmentSoundMixer()
 
 void Game::restoreSoundsForCurrentFocus()
 {
+    Game::SetCurrentMusic( MUS::UNKNOWN );
     AGG::ResetMixer();
 
     switch ( Interface::GetFocusType() ) {

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -537,13 +537,13 @@ namespace
         const Campaign::ScenarioData & completedScenario = scenarios[lastCompletedScenarioInfoId.scenarioId];
 
         if ( !completedScenario.getEndScenarioVideoPlayback().empty() ) {
-            AGG::ResetMixer();
+            AGG::ResetAudio();
 
             for ( const Campaign::ScenarioIntroVideoInfo & videoInfo : completedScenario.getEndScenarioVideoPlayback() ) {
                 Video::ShowVideo( videoInfo.fileName, videoInfo.action );
             }
 
-            AGG::ResetMixer();
+            AGG::ResetAudio();
         }
     }
 
@@ -560,13 +560,13 @@ namespace
         const Campaign::ScenarioData & scenario = scenarios[currentScenarioInfoId.scenarioId];
 
         if ( !scenario.getStartScenarioVideoPlayback().empty() ) {
-            AGG::ResetMixer();
+            AGG::ResetAudio();
 
             for ( const Campaign::ScenarioIntroVideoInfo & videoInfo : scenario.getStartScenarioVideoPlayback() ) {
                 Video::ShowVideo( videoInfo.fileName, videoInfo.action );
             }
 
-            AGG::ResetMixer();
+            AGG::ResetAudio();
         }
     }
 
@@ -725,7 +725,7 @@ fheroes2::GameMode Game::CompleteCampaignScenario( const bool isLoadingSaveFile 
     if ( campaignData.isLastScenario( lastCompletedScenarioInfo ) ) {
         Game::ShowCredits();
 
-        AGG::ResetMixer();
+        AGG::ResetAudio();
         Video::ShowVideo( "WIN.SMK", Video::VideoAction::WAIT_FOR_USER_INPUT );
         return fheroes2::GameMode::HIGHSCORES;
     }
@@ -966,7 +966,7 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
             return fheroes2::GameMode::START_GAME;
         }
         else if ( le.MouseClickLeft( buttonViewIntro.area() ) ) {
-            AGG::ResetMixer();
+            AGG::ResetAudio();
             fheroes2::ImageRestorer restorer( display, top.x, top.y, backgroundImage.width(), backgroundImage.height() );
             playPreviosScenarioVideo();
             playCurrentScenarioVideo();

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -477,8 +477,11 @@ fheroes2::GameMode Game::HighScores()
 
     const std::string highScoreDataPath = System::ConcatePath( GetSaveDir(), "fheroes2.hgs" );
 
-    Mixer::Pause();
+    // Stop all sounds, but not the music
+    Mixer::Stop();
+
     AGG::PlayMusic( MUS::MAINMENU, true, true );
+
     if ( !hgs.Load( highScoreDataPath ) ) {
         // Unable to load the file. Let's populate with the default values.
         hgs.populateHighScoresStandard();

--- a/src/fheroes2/game/game_loadgame.cpp
+++ b/src/fheroes2/game/game_loadgame.cpp
@@ -115,8 +115,11 @@ fheroes2::GameMode Game::LoadMulti()
 
 fheroes2::GameMode Game::LoadGame()
 {
-    Mixer::Pause();
+    // Stop all sounds, but not the music
+    Mixer::Stop();
+
     AGG::PlayMusic( MUS::MAINMENU, true, true );
+
     fheroes2::Display & display = fheroes2::Display::instance();
 
     // setup cursor
@@ -211,7 +214,9 @@ fheroes2::GameMode Game::LoadStandard()
 
 fheroes2::GameMode Game::DisplayLoadGameDialog()
 {
-    Mixer::Pause();
+    // Stop all sounds, but not the music
+    Mixer::Stop();
+
     AGG::PlayMusic( MUS::MAINMENU, true, true );
 
     // setup cursor

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -148,7 +148,9 @@ void Game::mainGameLoop( bool isFirstGameRun )
 
 fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
 {
-    Mixer::Pause();
+    // Stop all sounds, but not the music
+    Mixer::Stop();
+
     AGG::PlayMusic( MUS::MAINMENU, true, true );
 
     Settings & conf = Settings::Get();

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -174,8 +174,8 @@ fheroes2::GameMode Game::NewSuccessionWarsCampaign()
 {
     Settings::Get().SetGameType( Game::TYPE_CAMPAIGN );
 
-    Mixer::Pause();
-    Music::Pause();
+    // Reset all sound and music before playing videos
+    AGG::ResetMixer();
 
     fheroes2::Display & display = fheroes2::Display::instance();
     const fheroes2::Point roiOffset( ( display.width() - display.DEFAULT_WIDTH ) / 2, ( display.height() - display.DEFAULT_HEIGHT ) / 2 );
@@ -189,9 +189,6 @@ fheroes2::GameMode Game::NewSuccessionWarsCampaign()
     std::vector<fheroes2::Rect> campaignRoi;
     campaignRoi.emplace_back( 382 + roiOffset.x, 58 + roiOffset.y, 222, 298 );
     campaignRoi.emplace_back( 30 + roiOffset.x, 59 + roiOffset.y, 224, 297 );
-
-    // Reset all sound and music before playing videos
-    AGG::ResetMixer();
 
     const CursorRestorer cursorRestorer( false, Cursor::POINTER );
 
@@ -370,8 +367,11 @@ fheroes2::GameMode Game::NewNetwork()
 
 fheroes2::GameMode Game::NewGame()
 {
-    Mixer::Pause();
+    // Stop all sounds, but not the music
+    Mixer::Stop();
+
     AGG::PlayMusic( MUS::MAINMENU, true, true );
+
     Settings & conf = Settings::Get();
 
     // reset last save name

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -175,7 +175,7 @@ fheroes2::GameMode Game::NewSuccessionWarsCampaign()
     Settings::Get().SetGameType( Game::TYPE_CAMPAIGN );
 
     // Reset all sound and music before playing videos
-    AGG::ResetMixer();
+    AGG::ResetAudio();
 
     fheroes2::Display & display = fheroes2::Display::instance();
     const fheroes2::Point roiOffset( ( display.width() - display.DEFAULT_WIDTH ) / 2, ( display.height() - display.DEFAULT_HEIGHT ) / 2 );
@@ -194,7 +194,7 @@ fheroes2::GameMode Game::NewSuccessionWarsCampaign()
 
     Video::ShowVideo( "INTRO.SMK", Video::VideoAction::PLAY_TILL_VIDEO_END );
 
-    AGG::ResetMixer();
+    AGG::ResetAudio();
     Video::ShowVideo( "CHOOSEW.SMK", Video::VideoAction::IGNORE_VIDEO );
     const int chosenCampaign = Video::ShowVideo( "CHOOSE.SMK", Video::VideoAction::LOOP_VIDEO, campaignRoi );
 

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -340,7 +340,7 @@ fheroes2::GameMode GameOver::Result::LocalCheckGameOver()
                     res = fheroes2::GameMode::COMPLETE_CAMPAIGN_SCENARIO;
                 }
                 else {
-                    AGG::ResetMixer();
+                    AGG::ResetAudio();
                     Video::ShowVideo( "WIN.SMK", Video::VideoAction::WAIT_FOR_USER_INPUT );
 
                     res = fheroes2::GameMode::HIGHSCORES;
@@ -384,7 +384,7 @@ fheroes2::GameMode GameOver::Result::LocalCheckGameOver()
                         DialogLoss( result );
                     }
 
-                    AGG::ResetMixer();
+                    AGG::ResetAudio();
                     Video::ShowVideo( "LOSE.SMK", Video::VideoAction::LOOP_VIDEO );
 
                     res = fheroes2::GameMode::MAIN_MENU;
@@ -395,7 +395,7 @@ fheroes2::GameMode GameOver::Result::LocalCheckGameOver()
     else {
         // There are no active human-controlled players left, game over
         if ( activeHumanColors == 0 ) {
-            AGG::ResetMixer();
+            AGG::ResetAudio();
             Video::ShowVideo( "LOSE.SMK", Video::VideoAction::LOOP_VIDEO );
 
             res = fheroes2::GameMode::MAIN_MENU;
@@ -436,7 +436,7 @@ fheroes2::GameMode GameOver::Result::LocalCheckGameOver()
             if ( multiplayerResult & GameOver::WINS ) {
                 DialogWins( multiplayerResult );
 
-                AGG::ResetMixer();
+                AGG::ResetAudio();
                 Video::ShowVideo( "WIN.SMK", Video::VideoAction::WAIT_FOR_USER_INPUT );
 
                 res = fheroes2::GameMode::MAIN_MENU;
@@ -444,7 +444,7 @@ fheroes2::GameMode GameOver::Result::LocalCheckGameOver()
             else if ( multiplayerResult & GameOver::LOSS ) {
                 DialogLoss( multiplayerResult );
 
-                AGG::ResetMixer();
+                AGG::ResetAudio();
                 Video::ShowVideo( "LOSE.SMK", Video::VideoAction::LOOP_VIDEO );
 
                 res = fheroes2::GameMode::MAIN_MENU;

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -602,7 +602,7 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
                 // reset environment sounds and music theme at the beginning of the kingdom's turn
                 Game::SetCurrentMusic( MUS::UNKNOWN );
-                AGG::ResetMixer();
+                AGG::ResetAudio();
 
                 radar.SetHide( true );
                 radar.SetRedraw();
@@ -665,7 +665,7 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
                 // reset environment sounds and music theme at the end of the kingdom's turn
                 Game::SetCurrentMusic( MUS::UNKNOWN );
-                AGG::ResetMixer();
+                AGG::ResetAudio();
 
                 if ( res != fheroes2::GameMode::END_TURN ) {
                     break;

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -603,6 +603,10 @@ fheroes2::GameMode Interface::Basic::StartGame()
                 DEBUG_LOG( DBG_GAME, DBG_INFO,
                            world.DateString() << ", color: " << Color::String( player->GetColor() ) << ", resource: " << kingdom.GetFunds().String() );
 
+                // reset environment sounds and music theme at the beginning of the kingdom's turn
+                Game::SetCurrentMusic( MUS::UNKNOWN );
+                AGG::ResetMixer();
+
                 radar.SetHide( true );
                 radar.SetRedraw();
 
@@ -618,6 +622,11 @@ fheroes2::GameMode Interface::Basic::StartGame()
                         SetRedraw( REDRAW_GAMEAREA | REDRAW_STATUS | REDRAW_ICONS );
                         Redraw();
                         display.render();
+
+                        // reset the music after closing the dialog
+                        const Game::MusicRestorer musicRestorer;
+
+                        AGG::PlayMusic( MUS::NEW_MONTH, false );
 
                         Game::DialogPlayers( player->GetColor(), _( "%{color} player's turn." ) );
                     }
@@ -656,6 +665,10 @@ fheroes2::GameMode Interface::Basic::StartGame()
                     AI::Get().KingdomTurn( kingdom );
                     break;
                 }
+
+                // reset environment sounds and music theme at the end of the kingdom's turn
+                Game::SetCurrentMusic( MUS::UNKNOWN );
+                AGG::ResetMixer();
 
                 if ( res != fheroes2::GameMode::END_TURN ) {
                     break;
@@ -707,11 +720,6 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
 
     Kingdom & myKingdom = world.GetKingdom( conf.CurrentColor() );
     const KingdomCastles & myCastles = myKingdom.GetCastles();
-
-    // current music will be set along with the focus, reset environment sounds
-    // and terrain music theme from the previous turn
-    Game::SetCurrentMusic( MUS::UNKNOWN );
-    AGG::ResetMixer();
 
     // set focus
     if ( conf.ExtGameRememberLastFocus() ) {
@@ -1133,10 +1141,6 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
         if ( !conf.ExtGameAutosaveBeginOfDay() )
             Game::AutoSave();
     }
-
-    // reset environment sounds and terrain music theme at the end of the human turn
-    Game::SetCurrentMusic( MUS::UNKNOWN );
-    AGG::ResetMixer();
 
     return res;
 }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -122,13 +122,13 @@ void Game::DialogPlayers( int color, std::string str )
     Dialog::SpriteInfo( "", str, sign );
 }
 
-/* open castle wrapper */
 void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */ )
 {
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    Mixer::Pause();
+    // Stop all sounds, but not the music - it will be replaced by the music of the castle
+    Mixer::Stop();
 
     const Settings & conf = Settings::Get();
     Kingdom & myKingdom = world.GetKingdom( conf.CurrentColor() );

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -192,7 +192,6 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */ )
     basicInterface.RedrawFocus();
 }
 
-/* open heroes wrapper */
 void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, bool windowIsGameWorld, bool disableDismiss /* = false */ )
 {
     // setup cursor

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -81,8 +81,6 @@ fheroes2::GameMode Game::StartGame()
     if ( !conf.LoadedGameVersion() )
         GameOver::Result::Get().Reset();
 
-    AGG::ResetMixer( true );
-
     Interface::Basic::Get().Reset();
 
     return Interface::Basic::Get().StartGame();

--- a/src/fheroes2/game/game_video.cpp
+++ b/src/fheroes2/game/game_video.cpp
@@ -140,7 +140,7 @@ namespace Video
             if ( roi.empty() ) {
                 if ( le.KeyPress() || le.MouseClickLeft() || le.MouseClickMiddle() || le.MouseClickRight() ) {
                     userMadeAction = true;
-                    Mixer::Reset();
+                    Mixer::Stop();
                     break;
                 }
             }
@@ -155,7 +155,7 @@ namespace Video
                 }
 
                 if ( roiChosen ) {
-                    Mixer::Reset();
+                    Mixer::Stop();
                     break;
                 }
             }

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -321,7 +321,7 @@ fheroes2::GameMode Interface::Basic::EventGameInfo()
         fheroes2::Display & display = fheroes2::Display::instance();
         fheroes2::ImageRestorer saver( display, 0, 0, display.width(), display.height() );
 
-        AGG::ResetMixer();
+        AGG::ResetAudio();
 
         const fheroes2::GameMode returnMode = Game::SelectCampaignScenario( fheroes2::GameMode::CANCEL, true );
         if ( returnMode == fheroes2::GameMode::CANCEL ) {


### PR DESCRIPTION
fix #4511

Also this fixes an issue with `Game::restoreSoundsForCurrentFocus()` in MIDI mode if there is no sound for the current terrain. Before (unmute the sound in this video):

https://user-images.githubusercontent.com/32623900/153728485-729adb0f-d4f3-4898-965b-f2dc9f65eb5b.mp4

After:

https://user-images.githubusercontent.com/32623900/153728488-16dd4c8c-9733-4256-9a46-210b65c98179.mp4

Also this PR removes the only asynchronous `AGG::ResetMixer()` call and reverts the commit that introduced asynchronous `AGG::ResetMixer()` variant because it's unreliable and it did work only because it was followed by the non-async `AGG::ResetMixer()` call in the `Interface::Basic::HumanTurn()` (now `Interface::Basic::StartGame()`).