### PR TITLE
Fix missing sounds for some objects

### DIFF
--- a/src/fheroes2/agg/mus.cpp
+++ b/src/fheroes2/agg/mus.cpp
@@ -202,7 +202,6 @@ int MUS::FromMapObject( const MP2::MapObjectType objectType )
     case MP2::OBJ_ABANDONEDMINE:
     case MP2::OBJ_MAGELLANMAPS:
     case MP2::OBJ_OBSERVATIONTOWER:
-    case MP2::OBJ_WATCHTOWER:
         return MUS::WATCHTOWER;
 
     case MP2::OBJ_XANADU:

--- a/src/fheroes2/agg/mus.cpp
+++ b/src/fheroes2/agg/mus.cpp
@@ -187,13 +187,13 @@ int MUS::FromMapObject( const MP2::MapObjectType objectType )
 
     case MP2::OBJ_GAZEBO:
     case MP2::OBJ_TREEKNOWLEDGE:
-    case MP2::OBJ_WITCHSHUT:
         return MUS::EXPERIENCE;
 
     case MP2::OBJ_FORT:
     case MP2::OBJ_MERCENARYCAMP:
     case MP2::OBJ_DOCTORHUT:
     case MP2::OBJ_STANDINGSTONES:
+    case MP2::OBJ_WITCHSHUT:
         return MUS::SKILL;
 
     case MP2::OBJ_GRAVEYARD:
@@ -201,6 +201,7 @@ int MUS::FromMapObject( const MP2::MapObjectType objectType )
     case MP2::OBJ_DERELICTSHIP:
     case MP2::OBJ_ABANDONEDMINE:
     case MP2::OBJ_MAGELLANMAPS:
+    case MP2::OBJ_OBSERVATIONTOWER:
     case MP2::OBJ_WATCHTOWER:
         return MUS::WATCHTOWER;
 

--- a/src/fheroes2/agg/mus.cpp
+++ b/src/fheroes2/agg/mus.cpp
@@ -174,9 +174,6 @@ int MUS::FromMapObject( const MP2::MapObjectType objectType )
     case MP2::OBJ_ANCIENTLAMP:
         return MUS::ARABIAN;
 
-    case MP2::OBJ_HILLFORT:
-        return MUS::HILLFORT;
-
     case MP2::OBJ_TREEHOUSE:
     case MP2::OBJ_TREECITY:
     case MP2::OBJ_WAGONCAMP:

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2195,10 +2195,7 @@ void ActionToDwellingJoinMonster( Heroes & hero, const MP2::MapObjectType object
         std::string message = _( "A group of %{monster} with a desire for greater glory wish to join you. Do you accept?" );
         StringReplace( message, "%{monster}", troop.GetMultiName() );
 
-        if ( !Settings::Get().MusicMIDI() && objectType == MP2::OBJ_WATCHTOWER )
-            AGG::PlayMusic( MUS::WATCHTOWER, false );
-        else
-            AGG::PlaySound( M82::EXPERNCE );
+        AGG::PlaySound( M82::EXPERNCE );
 
         if ( Dialog::YES == Dialog::Message( title, message, Font::BIG, Dialog::YES | Dialog::NO ) ) {
             if ( !hero.GetArmy().CanJoinTroop( troop ) )

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2509,6 +2509,7 @@ void ActionToUpgradeArmyObject( Heroes & hero, const MP2::MapObjectType objectTy
             "A blacksmith working at the foundry offers to convert all Pikemen and Swordsmen's weapons brought to him from iron to steel. He also says that he knows a process that will convert Iron Golems into Steel Golems. Unfortunately, you have none of these troops in your army, so he can't help you." );
         break;
     }
+
     case MP2::OBJ_STABLES: {
         assert( !defaultMessage.empty() );
         msg1 = defaultMessage;
@@ -2603,6 +2604,12 @@ void ActionToUpgradeArmyObject( Heroes & hero, const MP2::MapObjectType objectTy
             fheroes2::Blit( mon, surface, offsetX + 6 + mon.x(), 6 + mon.y() + offsetY );
             offsetX += border.width() + 4;
         }
+
+        // The Hill Fort has a special sound
+        if ( objectType == MP2::OBJ_HILLFORT ) {
+            AGG::PlayMusic( MUS::HILLFORT, false );
+        }
+
         Dialog::SpriteInfo( title, msg1, surface );
     }
     else {

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1279,8 +1279,6 @@ void ActionToWitchsHut( Heroes & hero, const MP2::MapObjectType objectType, s32 
 {
     const Skill::Secondary & skill = world.GetTiles( dst_index ).QuantitySkill();
 
-    AGG::PlayMusic( MUS::SKILL, false );
-
     // If this assertion blows up the object is not set properly.
     assert( skill.isValid() );
 
@@ -2284,7 +2282,6 @@ void ActionToDwellingRecruitMonster( Heroes & hero, const MP2::MapObjectType obj
     default:
         return;
     }
-    AGG::PlayMusic( MUS::FromMapObject( objectType ), false );
 
     const Troop & troop = tile.QuantityTroop();
 
@@ -2377,10 +2374,6 @@ void ActionToDwellingBattleMonster( Heroes & hero, const MP2::MapObjectType obje
 
 void ActionToObservationTower( const Heroes & hero, const MP2::MapObjectType objectType, s32 dst_index )
 {
-    if ( !Settings::Get().MusicMIDI() ) {
-        AGG::PlayMusic( MUS::WATCHTOWER, true );
-    }
-
     Dialog::Message( MP2::StringObject( objectType ), _( "From the observation tower, you are able to see distant lands." ), Font::BIG, Dialog::OK );
 
     Maps::ClearFog( dst_index, Game::GetViewDistance( Game::VIEW_OBSERVATION_TOWER ), hero.GetColor() );
@@ -2782,8 +2775,6 @@ void ActionToOracle( const Heroes & hero, const MP2::MapObjectType objectType )
 void ActionToDaemonCave( Heroes & hero, const MP2::MapObjectType objectType, int32_t dst_index )
 {
     Maps::Tiles & tile = world.GetTiles( dst_index );
-
-    AGG::PlayMusic( MUS::DEMONCAVE, false );
 
     const std::string header = MP2::StringObject( objectType );
     if ( Dialog::YES

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1074,8 +1074,15 @@ void ActionToObjectResource( Heroes & hero, const MP2::MapObjectType objectType,
     }
 
     if ( rc.isValid() ) {
+        // The Magic Garden has a special sound
+        if ( !Settings::Get().MusicMIDI() && objectType == MP2::OBJ_MAGICGARDEN ) {
+            AGG::PlayMusic( MUS::TREEHOUSE, false );
+        }
+        else {
+            AGG::PlaySound( M82::TREASURE );
+        }
+
         const Funds funds( rc );
-        AGG::PlaySound( M82::TREASURE );
         Dialog::ResourceInfo( caption, msg, funds );
         hero.GetKingdom().AddFundsResource( funds );
 

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -50,6 +50,7 @@ namespace
         GLOBAL_PRICELOYALTY = 0x00000004,
 
         GLOBAL_RENDER_VSYNC = 0x00000008,
+
         // UNUSED = 0x00000010,
         // UNUSED = 0x00000020,
 
@@ -60,12 +61,10 @@ namespace
         GLOBAL_SHOWSTATUS = 0x00000400,
 
         GLOBAL_FULLSCREEN = 0x00008000,
+
         // UNUSED = 0x00010000,
-
-        GLOBAL_MUSIC_EXT = 0x00020000,
-        GLOBAL_MUSIC_MIDI = 0x00040000,
-        GLOBAL_MUSIC = GLOBAL_MUSIC_EXT | GLOBAL_MUSIC_MIDI,
-
+        // UNUSED = 0x00020000,
+        // UNUSED = 0x00040000,
         // UNUSED = 0x00080000,
         // UNUSED = 0x00100000,
         // UNUSED = 0x00200000,
@@ -101,11 +100,11 @@ Settings::Settings()
 {
     opt_global.SetModes( GLOBAL_FIRST_RUN );
     opt_global.SetModes( GLOBAL_SHOW_INTRO );
+
     opt_global.SetModes( GLOBAL_SHOWRADAR );
     opt_global.SetModes( GLOBAL_SHOWICONS );
     opt_global.SetModes( GLOBAL_SHOWBUTTONS );
     opt_global.SetModes( GLOBAL_SHOWSTATUS );
-    opt_global.SetModes( GLOBAL_MUSIC_EXT );
 
     opt_global.SetModes( GLOBAL_BATTLE_SHOW_GRID );
     opt_global.SetModes( GLOBAL_BATTLE_SHOW_MOUSE_SHADOW );
@@ -203,18 +202,12 @@ bool Settings::Read( const std::string & filename )
 
     if ( !sval.empty() ) {
         if ( sval == "original" ) {
-            opt_global.ResetModes( GLOBAL_MUSIC );
-            opt_global.SetModes( GLOBAL_MUSIC_MIDI );
             _musicType = MUSIC_MIDI_ORIGINAL;
         }
         else if ( sval == "expansion" ) {
-            opt_global.ResetModes( GLOBAL_MUSIC );
-            opt_global.SetModes( GLOBAL_MUSIC_MIDI );
             _musicType = MUSIC_MIDI_EXPANSION;
         }
         else if ( sval == "external" ) {
-            opt_global.ResetModes( GLOBAL_MUSIC );
-            opt_global.SetModes( GLOBAL_MUSIC_EXT );
             _musicType = MUSIC_EXTERNAL;
         }
     }
@@ -584,7 +577,7 @@ std::string Settings::GetLastFile( const std::string & prefix, const std::string
 
 bool Settings::MusicMIDI() const
 {
-    return opt_global.Modes( GLOBAL_MUSIC_MIDI );
+    return _musicType == MUSIC_MIDI_ORIGINAL || _musicType == MUSIC_MIDI_EXPANSION;
 }
 
 /* return move speed */


### PR DESCRIPTION
fix #4506

Also fixed an issue where the non-MIDI sounds of objects were not played when switching music from MIDI to external. Before (notice that there is no Wagon Camp sound when switching the music from the MIDI to External):

https://user-images.githubusercontent.com/32623900/153762849-73217ead-94dc-48d1-a14e-6e37e4b67cb1.mp4

After:

https://user-images.githubusercontent.com/32623900/153762813-d83cb770-2997-4e12-b437-b53ad1945d36.mp4

---

> Magic Garden has wrong sound. It should have the same to Wagon Camp.

https://user-images.githubusercontent.com/32623900/153765957-9962f2c2-537c-415f-8f45-727034f5d375.mp4

> Observation Tower is missing any sounds: There should be played sound same to Abandoned mine.

https://user-images.githubusercontent.com/32623900/153765987-5e50e4ff-15ae-45c3-9433-b027130f889b.mp4

> Watch tower has wrong sound: it should have the sound same to halfling gole.

https://user-images.githubusercontent.com/32623900/153766727-7bc7ae40-9484-4f71-b096-a565d0c449e4.mp4

> Sound of visiting Hill Fort should be played only if we succeeded in upgrading any troops. If you don't have any proper troops no sound should be played.

https://user-images.githubusercontent.com/32623900/153766085-ab24927a-6e8e-4df3-91c7-0ae4b54e6f35.mp4
