### PR TITLE
Allow AI fog discovery only for teleport endpoints with reachability information

### DIFF
--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -60,7 +60,7 @@ namespace AI
     };
 
     const double ARMY_STRENGTH_ADVANTAGE_SMALL = 1.3;
-    const double ARMY_STRENGTH_ADVANTAGE_MEDUIM = 1.5;
+    const double ARMY_STRENGTH_ADVANTAGE_MEDIUM = 1.5;
     const double ARMY_STRENGTH_ADVANTAGE_LARGE = 1.8;
 
     class Base

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1207,6 +1207,9 @@ namespace AI
                     if ( targetIndex != -1 ) {
                         bestTargetIndex = targetIndex;
                         bestHero = heroInfo.hero;
+
+                        DEBUG_LOG( DBG_AI, DBG_INFO, bestHero->GetName() << " may be blocking the way. Moving to " << bestTargetIndex );
+
                         break;
                     }
                 }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1150,7 +1150,7 @@ namespace AI
             addHeroToMove( hero, availableHeroes );
         }
 
-        const double originalMonsterStrengthMultipler = _pathfinder.getCurrentArmyStrengthMultiplier();
+        const double originalMonsterStrengthMultiplier = _pathfinder.getCurrentArmyStrengthMultiplier();
 
         const int monsterStrengthMultiplierCount = 2;
         const double monsterStrengthMultipliers[monsterStrengthMultiplierCount] = { ARMY_STRENGTH_ADVANTAGE_MEDUIM, ARMY_STRENGTH_ADVANTAGE_SMALL };
@@ -1176,17 +1176,17 @@ namespace AI
                 }
 
                 // If nowhere to move perhaps it's because of high monster estimation. Let's reduce it.
-                const double currentMonsterStrengthMultipler = _pathfinder.getCurrentArmyStrengthMultiplier();
-                bool setNewMultipler = false;
+                const double currentMonsterStrengthMultiplier = _pathfinder.getCurrentArmyStrengthMultiplier();
+                bool setNewMultiplier = false;
                 for ( int i = 0; i < monsterStrengthMultiplierCount; ++i ) {
-                    if ( currentMonsterStrengthMultipler > monsterStrengthMultipliers[i] ) {
+                    if ( currentMonsterStrengthMultiplier > monsterStrengthMultipliers[i] ) {
                         _pathfinder.setArmyStrengthMultiplier( monsterStrengthMultipliers[i] );
-                        setNewMultipler = true;
+                        setNewMultiplier = true;
                         break;
                     }
                 }
 
-                if ( !setNewMultipler ) {
+                if ( !setNewMultiplier ) {
                     break;
                 }
             }
@@ -1213,7 +1213,7 @@ namespace AI
 
                 if ( bestTargetIndex == -1 ) {
                     // Nothing to do. Stop everything
-                    _pathfinder.setArmyStrengthMultiplier( originalMonsterStrengthMultipler );
+                    _pathfinder.setArmyStrengthMultiplier( originalMonsterStrengthMultiplier );
                     break;
                 }
             }
@@ -1239,7 +1239,7 @@ namespace AI
                 ++i;
             }
 
-            _pathfinder.setArmyStrengthMultiplier( originalMonsterStrengthMultipler );
+            _pathfinder.setArmyStrengthMultiplier( originalMonsterStrengthMultiplier );
         }
 
         const bool allHeroesMoved = availableHeroes.empty();
@@ -1250,7 +1250,7 @@ namespace AI
             }
         }
 
-        _pathfinder.setArmyStrengthMultiplier( originalMonsterStrengthMultipler );
+        _pathfinder.setArmyStrengthMultiplier( originalMonsterStrengthMultiplier );
 
         return allHeroesMoved;
     }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -42,7 +42,7 @@ namespace
                 return castle->GetHeroes().Guest() == nullptr;
             }
             else if ( !hero.isFriends( castle->GetColor() ) ) {
-                return hero.GetArmy().GetStrength() > castle->GetGarrisonStrength( &hero ) * AI::ARMY_STRENGTH_ADVANTAGE_MEDUIM;
+                return hero.GetArmy().GetStrength() > castle->GetGarrisonStrength( &hero ) * AI::ARMY_STRENGTH_ADVANTAGE_MEDIUM;
             }
         }
         return false;
@@ -123,7 +123,7 @@ namespace
             if ( Settings::Get().ExtWorldExtObjectsCaptured() && !hero.isFriends( tile.QuantityColor() ) ) {
                 if ( tile.CaptureObjectIsProtection() ) {
                     const Army enemy( tile );
-                    return army.isStrongerThan( enemy, AI::ARMY_STRENGTH_ADVANTAGE_MEDUIM );
+                    return army.isStrongerThan( enemy, AI::ARMY_STRENGTH_ADVANTAGE_MEDIUM );
                 }
 
                 return true;
@@ -306,7 +306,7 @@ namespace
         case MP2::OBJ_CITYDEAD:
         case MP2::OBJ_TROLLBRIDGE: {
             if ( Color::NONE == tile.QuantityColor() ) {
-                return army.isStrongerThan( Army( tile ), AI::ARMY_STRENGTH_ADVANTAGE_MEDUIM );
+                return army.isStrongerThan( Army( tile ), AI::ARMY_STRENGTH_ADVANTAGE_MEDIUM );
             }
             else {
                 const Troop & troop = tile.QuantityTroop();
@@ -367,11 +367,11 @@ namespace
 
         case MP2::OBJ_DAEMONCAVE:
             if ( tile.QuantityIsValid() && 4 != tile.QuantityVariant() )
-                return army.isStrongerThan( Army( tile ), AI::ARMY_STRENGTH_ADVANTAGE_MEDUIM );
+                return army.isStrongerThan( Army( tile ), AI::ARMY_STRENGTH_ADVANTAGE_MEDIUM );
             break;
 
         case MP2::OBJ_MONSTER:
-            return army.isStrongerThan( Army( tile ), AI::ARMY_STRENGTH_ADVANTAGE_MEDUIM );
+            return army.isStrongerThan( Army( tile ), AI::ARMY_STRENGTH_ADVANTAGE_MEDIUM );
 
         case MP2::OBJ_SIGN:
             // AI has no brains to process anything from sign messages.
@@ -1153,7 +1153,7 @@ namespace AI
         const double originalMonsterStrengthMultiplier = _pathfinder.getCurrentArmyStrengthMultiplier();
 
         const int monsterStrengthMultiplierCount = 2;
-        const double monsterStrengthMultipliers[monsterStrengthMultiplierCount] = { ARMY_STRENGTH_ADVANTAGE_MEDUIM, ARMY_STRENGTH_ADVANTAGE_SMALL };
+        const double monsterStrengthMultipliers[monsterStrengthMultiplierCount] = { ARMY_STRENGTH_ADVANTAGE_MEDIUM, ARMY_STRENGTH_ADVANTAGE_SMALL };
 
         while ( !availableHeroes.empty() ) {
             Heroes * bestHero = availableHeroes.front().hero;

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -31,7 +31,7 @@
 
 namespace
 {
-    const double fighterStrengthMultipler = 3;
+    const double fighterStrengthMultiplier = 3;
 
     void setHeroRoles( KingdomHeroes & heroes )
     {
@@ -58,7 +58,7 @@ namespace
         const double medianStrength = heroStrength[heroStrength.size() / 2].first;
 
         for ( std::pair<double, Heroes *> & hero : heroStrength ) {
-            if ( hero.first > medianStrength * fighterStrengthMultipler ) {
+            if ( hero.first > medianStrength * fighterStrengthMultiplier ) {
                 hero.second->setAIRole( Heroes::Role::FIGHTER );
             }
             else {

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -549,8 +549,8 @@ int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero )
                 continue;
             }
 
-            // Tile is either unreachable or guarded by monsters
-            if ( _cache[newIndex]._cost == 0 || !Maps::GetTilesUnderProtection( newIndex ).empty() ) {
+            // Tile is unreachable (may be because it is guarded by too strong army)
+            if ( _cache[newIndex]._cost == 0 ) {
                 continue;
             }
 
@@ -569,6 +569,11 @@ int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero )
                 }
 
                 tilesVisited[teleportIndex] = true;
+
+                // Teleport endpoint is unreachable (may be because it is guarded by too strong army)
+                if ( _cache[teleportIndex]._cost == 0 ) {
+                    continue;
+                }
 
                 nodesToExplore.push_back( teleportIndex );
             }
@@ -604,8 +609,8 @@ int AIWorldPathfinder::getNearestTileToMove( const Heroes & hero )
             continue;
         }
 
-        // Tile is reachable and not guarded by monsters
-        if ( _cache[newIndex]._cost > 0 && Maps::GetTilesUnderProtection( newIndex ).empty() ) {
+        // Tile is reachable
+        if ( _cache[newIndex]._cost > 0 ) {
             return newIndex;
         }
     }

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -432,7 +432,7 @@ void AIWorldPathfinder::processCurrentNode( std::vector<int> & nodesToExplore, i
     MapsIndexes teleports;
 
     // we shouldn't use teleport at the starting tile
-    if ( currentNodeIdx != _pathStart ) {
+    if ( !isFirstNode ) {
         teleports = world.GetTeleportEndPoints( currentNodeIdx );
 
         if ( teleports.empty() ) {
@@ -441,7 +441,7 @@ void AIWorldPathfinder::processCurrentNode( std::vector<int> & nodesToExplore, i
     }
 
     // do not check adjacent if we're going through the teleport in the middle of the path
-    if ( isFirstNode || teleports.empty() || std::find( teleports.begin(), teleports.end(), currentNode._from ) != teleports.end() ) {
+    if ( teleports.empty() || std::find( teleports.begin(), teleports.end(), currentNode._from ) != teleports.end() ) {
         checkAdjacentNodes( nodesToExplore, currentNodeIdx );
     }
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -611,7 +611,7 @@ int AIWorldPathfinder::getNearestTileToMove( const Heroes & hero )
             continue;
         }
 
-        // Tile is reachable
+        // Tile is reachable and the hero has enough army to defeat potential guards
         if ( _cache[newIndex]._cost > 0 ) {
             return newIndex;
         }

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -319,14 +319,16 @@ std::list<Route::Step> PlayerWorldPathfinder::buildPath( int targetIndex ) const
 // Follows regular (for user's interface) passability rules
 void PlayerWorldPathfinder::processCurrentNode( std::vector<int> & nodesToExplore, int currentNodeIdx )
 {
-    if ( currentNodeIdx != _pathStart && isTileBlocked( currentNodeIdx, world.GetTiles( _pathStart ).isWater() ) ) {
+    const bool isFirstNode = currentNodeIdx == _pathStart;
+
+    if ( !isFirstNode && isTileBlocked( currentNodeIdx, world.GetTiles( _pathStart ).isWater() ) ) {
         return;
     }
 
     const MapsIndexes & monsters = Maps::GetTilesUnderProtection( currentNodeIdx );
 
     // check if current tile is protected, can move only to adjacent monster
-    if ( currentNodeIdx != _pathStart && !monsters.empty() ) {
+    if ( !isFirstNode && !monsters.empty() ) {
         for ( int monsterIndex : monsters ) {
             const int direction = Maps::GetDirection( currentNodeIdx, monsterIndex );
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -551,7 +551,7 @@ int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero )
                 continue;
             }
 
-            // Tile is unreachable (may be because it is guarded by too strong army)
+            // Tile is unreachable (maybe because it is guarded by too strong an army)
             if ( _cache[newIndex]._cost == 0 ) {
                 continue;
             }
@@ -572,7 +572,7 @@ int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero )
 
                 tilesVisited[teleportIndex] = true;
 
-                // Teleport endpoint is unreachable (may be because it is guarded by too strong army)
+                // Teleport endpoint is unreachable (maybe because it is guarded by too strong an army)
                 if ( _cache[teleportIndex]._cost == 0 ) {
                     continue;
                 }


### PR DESCRIPTION
fix #5008

Also fully assign the assessment of the army defending the tile to the `AIWorldPathfinder::processCurrentNode()`.
