### PR TITLE
Run the SonarCloud Analyzer workflow only for the main repo, not for forks

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -10,7 +10,7 @@ jobs:
   sonarcloud:
     name: SonarCloud Analyzer
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) }}
+    if: ${{ github.repository == 'ihhub/fheroes2' && ( github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) ) }}
     env:
       SONAR_SCANNER_VERSION: 4.5.0.2216
     steps:


### PR DESCRIPTION
I'm a bit tired of seeing a workflow failure notification after every fork sync :)