### PR TITLE
Maps::FileInfo validation improvement

### DIFF
--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -538,10 +538,14 @@ namespace Campaign
     {
         std::string matchingFilePath;
 
-        Maps::FileInfo fi;
-        if ( tryGetMatchingFile( _fileName, matchingFilePath ) )
-            fi.ReadMP2( matchingFilePath );
+        if ( tryGetMatchingFile( _fileName, matchingFilePath ) ) {
+            Maps::FileInfo fi;
 
-        return fi;
+            if ( fi.ReadMP2( matchingFilePath ) ) {
+                return fi;
+            }
+        }
+
+        return {};
     }
 }

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -24,7 +24,6 @@
 #include <locale>
 #endif
 #include <algorithm>
-#include <cassert>
 #include <cstring>
 #include <map>
 
@@ -373,8 +372,10 @@ bool Maps::FileInfo::ReadMP2( const std::string & filename )
         int side2 = 0;
 
         const Colors availableColors( kingdom_colors );
-
-        assert( !availableColors.empty() );
+        if ( availableColors.empty() ) {
+            DEBUG_LOG( DBG_GAME, DBG_WARN, "Invalid list of kingdom colors during map load " << filename );
+            return false;
+        }
 
         const int numPlayersSide1 = wins1;
         if ( ( numPlayersSide1 <= 0 ) || ( numPlayersSide1 >= static_cast<int>( availableColors.size() ) ) ) {


### PR DESCRIPTION
Follow-up to #5012

* `Maps::FileInfo::ReadMP2()`: return false if map contains invalid list of kingdom colors instead of an assertion failure;
* `Campaign::ScenarioData::loadMap()`: validate result of the `ReadMP2()`.