### PR TITLE
Fix the logic of protecting tiles by neutral monsters

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -817,7 +817,7 @@ namespace AI
         if ( !hero.isFriends( tile.QuantityColor() ) ) {
             bool capture = true;
 
-            if ( tile.CaptureObjectIsProtection() ) {
+            if ( tile.isCaptureObjectProtected() ) {
                 const Troop & troop = tile.QuantityTroop();
                 Army army;
                 army.JoinTroop( troop );

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -92,7 +92,7 @@ namespace
         case MP2::OBJ_ALCHEMYLAB:
         case MP2::OBJ_LIGHTHOUSE:
             if ( !hero.isFriends( tile.QuantityColor() ) ) {
-                if ( tile.CaptureObjectIsProtection() ) {
+                if ( tile.isCaptureObjectProtected() ) {
                     const Army enemy( tile );
                     return army.isStrongerThan( enemy, AI::ARMY_STRENGTH_ADVANTAGE_SMALL );
                 }
@@ -103,7 +103,7 @@ namespace
 
         case MP2::OBJ_ABANDONEDMINE:
             if ( !hero.isFriends( tile.QuantityColor() ) ) {
-                if ( tile.CaptureObjectIsProtection() ) {
+                if ( tile.isCaptureObjectProtected() ) {
                     const Army enemy( tile );
                     return army.isStrongerThan( enemy, AI::ARMY_STRENGTH_ADVANTAGE_LARGE );
                 }
@@ -121,7 +121,7 @@ namespace
         case MP2::OBJ_WATERWHEEL:
         case MP2::OBJ_WINDMILL:
             if ( Settings::Get().ExtWorldExtObjectsCaptured() && !hero.isFriends( tile.QuantityColor() ) ) {
-                if ( tile.CaptureObjectIsProtection() ) {
+                if ( tile.isCaptureObjectProtected() ) {
                     const Army enemy( tile );
                     return army.isStrongerThan( enemy, AI::ARMY_STRENGTH_ADVANTAGE_MEDIUM );
                 }

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -518,7 +518,7 @@ void Dialog::QuickInfo( const Maps::Tiles & tile, const bool ignoreHeroOnTile )
         name_object = _( "Uncharted Territory" );
     else
         // check guardians mine
-        if ( MP2::OBJ_ABANDONEDMINE == objectType || tile.CaptureObjectIsProtection() ) {
+        if ( MP2::OBJ_ABANDONEDMINE == objectType || tile.isCaptureObjectProtected() ) {
         name_object = ShowGuardiansInfo( tile, settings.CurrentColor() == tile.QuantityColor(), extendedScoutingOption, scoutingLevelForTile );
     }
     else

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -442,7 +442,7 @@ int Interface::Basic::GetCursorFocusHeroes( const Heroes & from_hero, const Maps
                     return ( from_hero.GetColor() == castle->GetColor() ) ? Cursor::CASTLE : Cursor::POINTER;
                 }
                 else {
-                    const bool protection = Maps::TileIsUnderProtection( tile.GetIndex() );
+                    const bool protection = Maps::tileIsUnderProtection( tile.GetIndex() );
 
                     return Cursor::DistanceThemes( ( protection ? Cursor::CURSOR_HERO_FIGHT : Cursor::CURSOR_HERO_MOVE ),
                                                    from_hero.GetRangeRouteDays( tile.GetIndex() ) );
@@ -498,16 +498,16 @@ int Interface::Basic::GetCursorFocusHeroes( const Heroes & from_hero, const Maps
         else if ( MP2::isActionObject( tile.GetObject() ) ) {
             bool protection = false;
             if ( !MP2::isPickupObject( tile.GetObject() ) && !MP2::isAbandonedMine( tile.GetObject() ) ) {
-                protection = ( Maps::TileIsUnderProtection( tile.GetIndex() ) || ( !from_hero.isFriends( tile.QuantityColor() ) && tile.CaptureObjectIsProtection() ) );
+                protection = ( Maps::tileIsUnderProtection( tile.GetIndex() ) || ( !from_hero.isFriends( tile.QuantityColor() ) && tile.CaptureObjectIsProtection() ) );
             }
             else {
-                protection = Maps::TileIsUnderProtection( tile.GetIndex() );
+                protection = Maps::tileIsUnderProtection( tile.GetIndex() );
             }
 
             return Cursor::DistanceThemes( ( protection ? Cursor::CURSOR_HERO_FIGHT : Cursor::CURSOR_HERO_ACTION ), from_hero.GetRangeRouteDays( tile.GetIndex() ) );
         }
         else if ( tile.isPassableFrom( Direction::CENTER, from_hero.isShipMaster(), false, from_hero.GetColor() ) ) {
-            bool protection = Maps::TileIsUnderProtection( tile.GetIndex() );
+            bool protection = Maps::tileIsUnderProtection( tile.GetIndex() );
 
             return Cursor::DistanceThemes( ( protection ? Cursor::CURSOR_HERO_FIGHT : Cursor::CURSOR_HERO_MOVE ), from_hero.GetRangeRouteDays( tile.GetIndex() ) );
         }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -498,7 +498,7 @@ int Interface::Basic::GetCursorFocusHeroes( const Heroes & from_hero, const Maps
         else if ( MP2::isActionObject( tile.GetObject() ) ) {
             bool protection = false;
             if ( !MP2::isPickupObject( tile.GetObject() ) && !MP2::isAbandonedMine( tile.GetObject() ) ) {
-                protection = ( Maps::tileIsUnderProtection( tile.GetIndex() ) || ( !from_hero.isFriends( tile.QuantityColor() ) && tile.CaptureObjectIsProtection() ) );
+                protection = ( Maps::tileIsUnderProtection( tile.GetIndex() ) || ( !from_hero.isFriends( tile.QuantityColor() ) && tile.isCaptureObjectProtected() ) );
             }
             else {
                 protection = Maps::tileIsUnderProtection( tile.GetIndex() );

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -442,7 +442,7 @@ int Interface::Basic::GetCursorFocusHeroes( const Heroes & from_hero, const Maps
                     return ( from_hero.GetColor() == castle->GetColor() ) ? Cursor::CASTLE : Cursor::POINTER;
                 }
                 else {
-                    const bool protection = Maps::tileIsUnderProtection( tile.GetIndex() );
+                    const bool protection = Maps::isTileUnderProtection( tile.GetIndex() );
 
                     return Cursor::DistanceThemes( ( protection ? Cursor::CURSOR_HERO_FIGHT : Cursor::CURSOR_HERO_MOVE ),
                                                    from_hero.GetRangeRouteDays( tile.GetIndex() ) );
@@ -498,16 +498,16 @@ int Interface::Basic::GetCursorFocusHeroes( const Heroes & from_hero, const Maps
         else if ( MP2::isActionObject( tile.GetObject() ) ) {
             bool protection = false;
             if ( !MP2::isPickupObject( tile.GetObject() ) && !MP2::isAbandonedMine( tile.GetObject() ) ) {
-                protection = ( Maps::tileIsUnderProtection( tile.GetIndex() ) || ( !from_hero.isFriends( tile.QuantityColor() ) && tile.isCaptureObjectProtected() ) );
+                protection = ( Maps::isTileUnderProtection( tile.GetIndex() ) || ( !from_hero.isFriends( tile.QuantityColor() ) && tile.isCaptureObjectProtected() ) );
             }
             else {
-                protection = Maps::tileIsUnderProtection( tile.GetIndex() );
+                protection = Maps::isTileUnderProtection( tile.GetIndex() );
             }
 
             return Cursor::DistanceThemes( ( protection ? Cursor::CURSOR_HERO_FIGHT : Cursor::CURSOR_HERO_ACTION ), from_hero.GetRangeRouteDays( tile.GetIndex() ) );
         }
         else if ( tile.isPassableFrom( Direction::CENTER, from_hero.isShipMaster(), false, from_hero.GetColor() ) ) {
-            bool protection = Maps::tileIsUnderProtection( tile.GetIndex() );
+            bool protection = Maps::isTileUnderProtection( tile.GetIndex() );
 
             return Cursor::DistanceThemes( ( protection ? Cursor::CURSOR_HERO_FIGHT : Cursor::CURSOR_HERO_MOVE ), from_hero.GetRangeRouteDays( tile.GetIndex() ) );
         }

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1519,7 +1519,7 @@ void Heroes::ActionNewPosition( const bool allowMonsterAttack )
 {
     if ( allowMonsterAttack ) {
         // scan for monsters around
-        const MapsIndexes targets = Maps::GetTilesUnderProtection( GetIndex() );
+        const MapsIndexes targets = Maps::getMonstersProtectingTile( GetIndex() );
 
         if ( !targets.empty() ) {
             SetMove( false );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2140,7 +2140,7 @@ void ActionToCaptureObject( Heroes & hero, const MP2::MapObjectType objectType, 
         bool capture = true;
 
         // check guardians
-        if ( tile.CaptureObjectIsProtection() ) {
+        if ( tile.isCaptureObjectProtected() ) {
             Army army( tile );
             const Monster & mons = tile.QuantityMonster();
 

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -110,12 +110,13 @@ namespace
         const int directionToMonster = Maps::GetDirection( tileIndex, monsterTileIndex );
         const int directionFromMonster = Direction::Reflect( directionToMonster );
 
-        // The tile is accessible to the monster
+        // The tile is directly accessible to the monster
         if ( ( tile.GetPassable() & directionToMonster ) && ( monsterTile.GetPassable() & directionFromMonster ) ) {
             return true;
         }
 
-        // The tile is not directly accessible to the monster, but he can still attack diagonally in some cases
+        // The tile is not directly accessible to the monster, but he can still attack in the diagonal direction if, when the hero moves away from the tile
+        // in question in the vertical direction and the monster moves away from his tile in the horizontal direction, they would have to meet
         if ( directionFromMonster == Direction::TOP_LEFT && ( tile.GetPassable() & Direction::BOTTOM ) && ( monsterTile.GetPassable() & Direction::LEFT ) ) {
             return true;
         }

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -97,7 +97,7 @@ namespace
         return result;
     }
 
-    bool tileIsUnderMonsterProtection( const int32_t tileIndex, const int32_t monsterTileIndex )
+    bool isTileUnderMonsterProtection( const int32_t tileIndex, const int32_t monsterTileIndex )
     {
         const Maps::Tiles & tile = world.GetTiles( tileIndex );
         const Maps::Tiles & monsterTile = world.GetTiles( monsterTileIndex );
@@ -451,7 +451,7 @@ Maps::Indexes Maps::getMonstersProtectingTile( const int32_t tileIndex )
     const int y = tileIndex / width;
 
     auto validateAndInsert = [&result, tileIndex]( const int monsterTileIndex ) {
-        if ( tileIsUnderMonsterProtection( tileIndex, monsterTileIndex ) ) {
+        if ( isTileUnderMonsterProtection( tileIndex, monsterTileIndex ) ) {
             result.push_back( monsterTileIndex );
         }
     };

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -434,7 +434,7 @@ Maps::Indexes Maps::GetObjectPositions( int32_t center, const MP2::MapObjectType
     return results;
 }
 
-bool Maps::tileIsUnderProtection( const int32_t tileIndex )
+bool Maps::isTileUnderProtection( const int32_t tileIndex )
 {
     return world.GetTiles( tileIndex ).GetObject() == MP2::OBJ_MONSTER ? true : !getMonstersProtectingTile( tileIndex ).empty();
 }

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -69,8 +69,8 @@ namespace Maps
     Indexes ScanAroundObject( const int32_t center, const MP2::MapObjectType objectType, const bool ignoreHeroes );
     Indexes GetFreeIndexesAroundTile( const int32_t center );
 
-    Indexes GetTilesUnderProtection( int32_t center );
-    bool TileIsUnderProtection( int32_t center );
+    bool tileIsUnderProtection( const int32_t tileIndex );
+    Indexes getMonstersProtectingTile( const int32_t tileIndex );
 
     Indexes GetObjectPositions( const MP2::MapObjectType objectType, bool ignoreHeroes );
     Indexes GetObjectPositions( int32_t center, const MP2::MapObjectType objectType, bool ignoreHeroes );

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -70,7 +70,7 @@ namespace Maps
     Indexes GetFreeIndexesAroundTile( const int32_t center );
 
     // Checks if the tile is guarded by a monster
-    bool tileIsUnderProtection( const int32_t tileIndex );
+    bool isTileUnderProtection( const int32_t tileIndex );
     // Returns a list of indexes of tiles with monsters guarding the given tile
     Indexes getMonstersProtectingTile( const int32_t tileIndex );
 

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -69,7 +69,9 @@ namespace Maps
     Indexes ScanAroundObject( const int32_t center, const MP2::MapObjectType objectType, const bool ignoreHeroes );
     Indexes GetFreeIndexesAroundTile( const int32_t center );
 
+    // Checks if the tile is guarded by a monster
     bool tileIsUnderProtection( const int32_t tileIndex );
+    // Returns a list of indexes of tiles with monsters guarding the given tile
     Indexes getMonstersProtectingTile( const int32_t tileIndex );
 
     Indexes GetObjectPositions( const MP2::MapObjectType objectType, bool ignoreHeroes );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1565,7 +1565,7 @@ std::string Maps::Tiles::String( void ) const
     }
 
     default: {
-        const MapsIndexes & v = Maps::GetTilesUnderProtection( _index );
+        const MapsIndexes & v = Maps::getMonstersProtectingTile( _index );
         if ( !v.empty() ) {
             os << "protection      : ";
             for ( MapsIndexes::const_iterator it = v.begin(); it != v.end(); ++it )

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1911,8 +1911,7 @@ void Maps::Tiles::fixTileObjectType( Tiles & tile )
     }
 }
 
-/* true: if protection or has guardians */
-bool Maps::Tiles::CaptureObjectIsProtection( void ) const
+bool Maps::Tiles::isCaptureObjectProtected() const
 {
     const MP2::MapObjectType objectType = GetObject( false );
 

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -253,7 +253,9 @@ namespace Maps
         void MonsterSetCount( u32 count );
         u32 MonsterCount( void ) const;
 
-        bool CaptureObjectIsProtection( void ) const;
+        // Checks whether the object to be captured is guarded by its own forces
+        // (castle has a hero or garrison, dwelling has creatures, etc)
+        bool isCaptureObjectProtected() const;
 
         /* object quantity operation */
         void QuantityUpdate( bool isFirstLoad = true );

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -332,7 +332,7 @@ void PlayerWorldPathfinder::processCurrentNode( std::vector<int> & nodesToExplor
         return;
     }
 
-    const MapsIndexes & monsters = Maps::GetTilesUnderProtection( currentNodeIdx );
+    const MapsIndexes & monsters = Maps::getMonstersProtectingTile( currentNodeIdx );
 
     // check if current tile is protected, can move only to adjacent monster
     if ( !isFirstNode && !monsters.empty() ) {
@@ -419,7 +419,7 @@ void AIWorldPathfinder::processCurrentNode( std::vector<int> & nodesToExplore, i
 
     bool isProtected = protectionCheck( currentNodeIdx );
     if ( !isProtected ) {
-        const MapsIndexes & monsters = Maps::GetTilesUnderProtection( currentNodeIdx );
+        const MapsIndexes & monsters = Maps::getMonstersProtectingTile( currentNodeIdx );
         for ( auto it = monsters.begin(); it != monsters.end(); ++it ) {
             if ( protectionCheck( *it ) ) {
                 isProtected = true;


### PR DESCRIPTION
fix #4324
fix #4899

![Dominion](https://user-images.githubusercontent.com/32623900/154487637-be348988-b20a-40d7-b252-81f2cf9b0a6b.jpg)
![Seven Lakes](https://user-images.githubusercontent.com/32623900/154487692-807c5f82-0218-421a-8bf1-4fcbca1cf4c4.jpg)
