### PR TITLE
World::ComputeStaticAnalysis(): reset the region information for all tiles at the very beginning

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1051,7 +1051,7 @@ void Maps::Tiles::UpdateRegion( uint32_t newRegionID )
         _region = newRegionID;
     }
     else {
-        _region = 0;
+        _region = REGION_NODE_BLOCKED;
     }
 }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1050,6 +1050,9 @@ void Maps::Tiles::UpdateRegion( uint32_t newRegionID )
     if ( tilePassable ) {
         _region = newRegionID;
     }
+    else {
+        _region = 0;
+    }
 }
 
 u32 Maps::Tiles::GetObjectUID() const

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -31,6 +31,7 @@
 #include "mp2.h"
 #include "resource.h"
 #include "skill.h"
+#include "world_regions.h"
 
 class Heroes;
 class Spell;
@@ -367,7 +368,7 @@ namespace Maps
         bool tileIsRoad = false;
 
         // This field does not persist in savegame.
-        uint32_t _region = 0;
+        uint32_t _region = REGION_NODE_BLOCKED;
 
         uint8_t _level = 0;
     };

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -166,6 +166,9 @@ void World::ComputeStaticAnalysis()
     const uint32_t extraRegionSize = 18;
     const uint32_t emptyLineFrequency = 7;
 
+    // Reset the region information for all tiles
+    std::for_each( vec_tiles.begin(), vec_tiles.end(), []( Maps::Tiles & tile ) { tile.UpdateRegion( 0 ); } );
+
     // Step 1. Split map into terrain, water and ground points
     // Initialize the obstacles vector
     TileDataVector obstacles[4];

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -167,7 +167,7 @@ void World::ComputeStaticAnalysis()
     const uint32_t emptyLineFrequency = 7;
 
     // Reset the region information for all tiles
-    std::for_each( vec_tiles.begin(), vec_tiles.end(), []( Maps::Tiles & tile ) { tile.UpdateRegion( 0 ); } );
+    std::for_each( vec_tiles.begin(), vec_tiles.end(), []( Maps::Tiles & tile ) { tile.UpdateRegion( REGION_NODE_BLOCKED ); } );
 
     // Step 1. Split map into terrain, water and ground points
     // Initialize the obstacles vector


### PR DESCRIPTION
This should fix the following crash due to the invalid assertion:

```
Assertion failed: (regionID < _regions.size()), function KingdomTurn, file ai_normal_kingdom.cpp, line 112.
```

How to reproduce:

1. Run fheroes2;
2. Load the following savefile: [!1.zip](https://github.com/ihhub/fheroes2/files/8089177/1.zip);
3. Load the following savefile: [!2.zip](https://github.com/ihhub/fheroes2/files/8089182/2.zip);
4. Skip the turn.

Maybe this can be fixed in some other way, perhaps @idshibanov will advise something.