### PR TITLE
Clang-Tidy: disable readability-function-cognitive-complexity

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,6 +20,7 @@ Checks: >-
   readability-*,
   -readability-avoid-const-params-in-decls,
   -readability-braces-around-statements,
+  -readability-function-cognitive-complexity,
   -readability-implicit-bool-conversion,
   -readability-magic-numbers
 


### PR DESCRIPTION
This diagnostic doesn't work reliably anyway because it will not be reported if function declaration (name/return type/arguments) is not changed as part of PR. It is better to use the SonarCloud for this.