### PR TITLE
Interface::Basic::EventDefaultAction(): reset and redraw the focus after hero's action

### DIFF
--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -402,8 +402,10 @@ fheroes2::GameMode Interface::Basic::EventDefaultAction( const fheroes2::GameMod
         if ( MP2::isActionObject( hero->GetMapsObject(), hero->isShipMaster() ) ) {
             hero->Action( hero->GetIndex(), true );
 
-            // The action object (e.g. Stables or Well) can alter the status of the hero
-            iconsPanel.RedrawIcons( ICON_HEROES );
+            // The action object can alter the status of the hero (e.g. Stables or Well) or
+            // move it to another location (e.g. Stone Liths or Whirlpool)
+            ResetFocus( GameFocus::HEROES );
+            RedrawFocus();
 
             // If a hero completed an action we must verify the condition for the scenario.
             if ( hero->isAction() ) {


### PR DESCRIPTION
This should fix the issue where the sound of the terrain does not change when teleporting using Stone Liths with a space bar. Before:

https://user-images.githubusercontent.com/32623900/154559062-d52317b9-3020-49d3-8f8f-700623884a8b.mp4

After:

https://user-images.githubusercontent.com/32623900/154559089-6136ac21-181c-4526-8907-ef46fa6750a2.mp4
