### PR TITLE
Make AI more aggressive in losing situation

### DIFF
--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -59,6 +59,7 @@ namespace AI
         EXPLORER
     };
 
+    const double ARMY_STRENGTH_ADVANTAGE_DESPERATE = 0.8;
     const double ARMY_STRENGTH_ADVANTAGE_SMALL = 1.3;
     const double ARMY_STRENGTH_ADVANTAGE_MEDIUM = 1.5;
     const double ARMY_STRENGTH_ADVANTAGE_LARGE = 1.8;

--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -59,10 +59,10 @@ namespace AI
         EXPLORER
     };
 
-    const double ARMY_STRENGTH_ADVANTAGE_DESPERATE = 0.8;
-    const double ARMY_STRENGTH_ADVANTAGE_SMALL = 1.3;
-    const double ARMY_STRENGTH_ADVANTAGE_MEDIUM = 1.5;
-    const double ARMY_STRENGTH_ADVANTAGE_LARGE = 1.8;
+    const double ARMY_ADVANTAGE_DESPERATE = 0.8;
+    const double ARMY_ADVANTAGE_SMALL = 1.3;
+    const double ARMY_ADVANTAGE_MEDIUM = 1.5;
+    const double ARMY_ADVANTAGE_LARGE = 1.8;
 
     class Base
     {

--- a/src/fheroes2/ai/normal/ai_normal.cpp
+++ b/src/fheroes2/ai/normal/ai_normal.cpp
@@ -25,7 +25,7 @@
 namespace AI
 {
     Normal::Normal()
-        : _pathfinder( ARMY_STRENGTH_ADVANTAGE_LARGE )
+        : _pathfinder( ARMY_ADVANTAGE_LARGE )
     {
         _personality = Rand::Get( AI::WARRIOR, AI::EXPLORER );
     }

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -184,7 +184,7 @@ namespace AI
         // Retreat if remaining army strength is a fraction of enemy's
         // Consider taking speed/turn order into account in the future
         const double ratio = Difficulty::GetAIRetreatRatio( Game::getDifficulty() );
-        return _considerRetreat && _myArmyStrength * ratio < _enemyArmyStrength && !hero.isControlHuman() && isHeroWorthSaving( hero );
+        return !hero.isLosingGame() && _considerRetreat && _myArmyStrength * ratio < _enemyArmyStrength && !hero.isControlHuman() && isHeroWorthSaving( hero );
     }
 
     bool BattlePlanner::isUnitFaster( const Unit & currentUnit, const Unit & target ) const

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -42,7 +42,7 @@ namespace
                 return castle->GetHeroes().Guest() == nullptr;
             }
             else if ( !hero.isFriends( castle->GetColor() ) ) {
-                const double advantage = hero.isLosingGame() ? AI::ARMY_STRENGTH_ADVANTAGE_DESPERATE : AI::ARMY_STRENGTH_ADVANTAGE_MEDIUM;
+                const double advantage = hero.isLosingGame() ? AI::ARMY_ADVANTAGE_DESPERATE : AI::ARMY_ADVANTAGE_MEDIUM;
                 return hero.GetArmy().GetStrength() > castle->GetGarrisonStrength( &hero ) * advantage;
             }
         }
@@ -95,7 +95,7 @@ namespace
             if ( !hero.isFriends( tile.QuantityColor() ) ) {
                 if ( tile.CaptureObjectIsProtection() ) {
                     const Army enemy( tile );
-                    return army.isStrongerThan( enemy, AI::ARMY_STRENGTH_ADVANTAGE_SMALL );
+                    return army.isStrongerThan( enemy, AI::ARMY_ADVANTAGE_SMALL );
                 }
 
                 return true;
@@ -106,7 +106,7 @@ namespace
             if ( !hero.isFriends( tile.QuantityColor() ) ) {
                 if ( tile.CaptureObjectIsProtection() ) {
                     const Army enemy( tile );
-                    return army.isStrongerThan( enemy, AI::ARMY_STRENGTH_ADVANTAGE_LARGE );
+                    return army.isStrongerThan( enemy, AI::ARMY_ADVANTAGE_LARGE );
                 }
 
                 return true;
@@ -124,7 +124,7 @@ namespace
             if ( Settings::Get().ExtWorldExtObjectsCaptured() && !hero.isFriends( tile.QuantityColor() ) ) {
                 if ( tile.CaptureObjectIsProtection() ) {
                     const Army enemy( tile );
-                    return army.isStrongerThan( enemy, AI::ARMY_STRENGTH_ADVANTAGE_MEDIUM );
+                    return army.isStrongerThan( enemy, AI::ARMY_ADVANTAGE_MEDIUM );
                 }
 
                 return true;
@@ -158,7 +158,7 @@ namespace
             // 6 - 50 rogues, 7 - 1 gin, 8,9,10,11,12,13 - 1 monster level4
             if ( 5 < variants && 14 > variants ) {
                 Army enemy( tile );
-                return army.isStrongerThan( enemy, AI::ARMY_STRENGTH_ADVANTAGE_LARGE );
+                return army.isStrongerThan( enemy, AI::ARMY_ADVANTAGE_LARGE );
             }
 
             // other
@@ -307,7 +307,7 @@ namespace
         case MP2::OBJ_CITYDEAD:
         case MP2::OBJ_TROLLBRIDGE: {
             if ( Color::NONE == tile.QuantityColor() ) {
-                return army.isStrongerThan( Army( tile ), AI::ARMY_STRENGTH_ADVANTAGE_MEDIUM );
+                return army.isStrongerThan( Army( tile ), AI::ARMY_ADVANTAGE_MEDIUM );
             }
             else {
                 const Troop & troop = tile.QuantityTroop();
@@ -362,17 +362,17 @@ namespace
             if ( !hero.isVisited( tile, Visit::GLOBAL ) && tile.QuantityIsValid() ) {
                 Army enemy( tile );
                 return enemy.isValid() && Skill::Level::EXPERT == hero.GetLevelSkill( Skill::Secondary::WISDOM )
-                       && army.isStrongerThan( enemy, AI::ARMY_STRENGTH_ADVANTAGE_LARGE );
+                       && army.isStrongerThan( enemy, AI::ARMY_ADVANTAGE_LARGE );
             }
             break;
 
         case MP2::OBJ_DAEMONCAVE:
             if ( tile.QuantityIsValid() && 4 != tile.QuantityVariant() )
-                return army.isStrongerThan( Army( tile ), AI::ARMY_STRENGTH_ADVANTAGE_MEDIUM );
+                return army.isStrongerThan( Army( tile ), AI::ARMY_ADVANTAGE_MEDIUM );
             break;
 
         case MP2::OBJ_MONSTER:
-            return army.isStrongerThan( Army( tile ), hero.isLosingGame() ? 1.0 : AI::ARMY_STRENGTH_ADVANTAGE_MEDIUM );
+            return army.isStrongerThan( Army( tile ), hero.isLosingGame() ? 1.0 : AI::ARMY_ADVANTAGE_MEDIUM );
 
         case MP2::OBJ_SIGN:
             // AI has no brains to process anything from sign messages.
@@ -389,7 +389,7 @@ namespace
                     return false;
                 else if ( otherHeroInCastle )
                     return AIShouldVisitCastle( hero, index );
-                else if ( army.isStrongerThan( hero2->GetArmy(), hero.isLosingGame() ? AI::ARMY_STRENGTH_ADVANTAGE_DESPERATE : AI::ARMY_STRENGTH_ADVANTAGE_SMALL ) )
+                else if ( army.isStrongerThan( hero2->GetArmy(), hero.isLosingGame() ? AI::ARMY_ADVANTAGE_DESPERATE : AI::ARMY_ADVANTAGE_SMALL ) )
                     return true;
             }
             break;
@@ -821,9 +821,9 @@ namespace AI
             }
             else {
                 double value = castle->getBuildingValue() * 500.0 + 15000;
-                // If the castle is defenseless
                 if ( hero.isLosingGame() )
                     value += 15000;
+                // If the castle is defenseless
                 if ( !castle->GetActualArmy().isValid() )
                     value *= 2.5;
                 return value;
@@ -1158,7 +1158,7 @@ namespace AI
         const double originalMonsterStrengthMultiplier = _pathfinder.getCurrentArmyStrengthMultiplier();
 
         const int monsterStrengthMultiplierCount = 2;
-        const double monsterStrengthMultipliers[monsterStrengthMultiplierCount] = { ARMY_STRENGTH_ADVANTAGE_MEDIUM, ARMY_STRENGTH_ADVANTAGE_SMALL };
+        const double monsterStrengthMultipliers[monsterStrengthMultiplierCount] = { ARMY_ADVANTAGE_MEDIUM, ARMY_ADVANTAGE_SMALL };
 
         while ( !availableHeroes.empty() ) {
             Heroes * bestHero = availableHeroes.front().hero;
@@ -1185,7 +1185,7 @@ namespace AI
                 bool setNewMultiplier = false;
                 for ( int i = 0; i < monsterStrengthMultiplierCount; ++i ) {
                     if ( currentMonsterStrengthMultiplier > monsterStrengthMultipliers[i] ) {
-                        _pathfinder.setArmyStrengthMultiplier( bestHero->isLosingGame() ? ARMY_STRENGTH_ADVANTAGE_DESPERATE : monsterStrengthMultipliers[i] );
+                        _pathfinder.setArmyStrengthMultiplier( bestHero->isLosingGame() ? ARMY_ADVANTAGE_DESPERATE : monsterStrengthMultipliers[i] );
                         setNewMultiplier = true;
                         break;
                     }

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -919,6 +919,11 @@ bool Heroes::hasMetWithHero( int heroID ) const
     return visit_object.end() != std::find( visit_object.begin(), visit_object.end(), IndexObject( heroID, MP2::OBJ_HEROES ) );
 }
 
+bool Heroes::isLosingGame() const
+{
+    return GetKingdom().isLosingGame();
+}
+
 int Heroes::GetSpriteIndex( void ) const
 {
     return sprite_index;

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -212,6 +212,7 @@ public:
     bool isFreeman( void ) const;
     void SetFreeman( int reason );
 
+    bool isLosingGame() const;
     const Castle * inCastle() const override;
     Castle * inCastleMutable() const;
 

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -307,6 +307,11 @@ void Kingdom::RemoveCastle( const Castle * castle )
         LossPostActions();
 }
 
+bool Kingdom::isLosingGame() const
+{
+    return castles.empty();
+}
+
 u32 Kingdom::GetCountCastle( void ) const
 {
     return static_cast<uint32_t>( std::count_if( castles.begin(), castles.end(), Castle::PredicateIsCastle ) );

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -86,6 +86,7 @@ public:
     void AddFundsResource( const Funds & );
     void OddFundsResource( const Funds & );
 
+    bool isLosingGame() const;
     u32 GetCountCastle( void ) const;
     u32 GetCountTown( void ) const;
     u32 GetCountMarketplace( void ) const;


### PR DESCRIPTION
Fixes #4588 . Fixes #3300 .

Essentially if AI is left without castles and currently on timer it will take more risks and should focus on castle capture.