### PR TITLE
Explicitly disable copy (and therefore move) constructor of Battle::Unit and Battle::Tower

### DIFF
--- a/src/fheroes2/battle/battle_tower.cpp
+++ b/src/fheroes2/battle/battle_tower.cpp
@@ -140,7 +140,7 @@ std::string Battle::Tower::GetInfo( const Castle & cstl )
 
     std::string msg;
     for ( std::vector<int>::const_iterator it = towers.begin(); it != towers.end(); ++it ) {
-        Tower twr = Tower( cstl, *it, Rand::DeterministicRandomGenerator( 0 ), 0 );
+        Tower twr( cstl, *it, Rand::DeterministicRandomGenerator( 0 ), 0 );
 
         msg.append( tmpl );
         StringReplace( msg, "%{name}", twr.GetName() );

--- a/src/fheroes2/battle/battle_tower.h
+++ b/src/fheroes2/battle/battle_tower.h
@@ -40,9 +40,7 @@ namespace Battle
     {
     public:
         Tower( const Castle &, int, const Rand::DeterministicRandomGenerator & randomGenerator, const uint32_t );
-
         Tower( const Tower & ) = delete;
-        Tower( Tower && ) = default;
 
         Tower & operator=( const Tower & ) = delete;
 

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -76,7 +76,7 @@ namespace Battle
     {
     public:
         Unit( const Troop &, int32_t pos, bool reflect, const Rand::DeterministicRandomGenerator & randomGenerator, const uint32_t uid );
-        Unit( const Unit & ) = default;
+        Unit( const Unit & ) = delete;
 
         ~Unit() override;
 


### PR DESCRIPTION
In addition to already disabled copy (and therefore move) assignment for these classes. Current battle-related code in many places relies on the fact that all units are in heap and their addresses can be freely compared - so at least such a unit cannot be accidentally passed as a function argument via a copy (or move) instead of pointer or reference.