### PR TITLE
Compile with -pthread, not just link with it

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -43,7 +43,7 @@ jobs:
         brew install ${{ matrix.config.dependencies }}
     - name: Build
       run: |
-        cmake -B build -DCMAKE_BUILD_TYPE=Release -DUSE_SDL_VERSION=${{ matrix.config.sdl_version }} -DENABLE_IMAGE=ON -DENABLE_TOOLS=ON -DFHEROES2_STRICT_COMPILATION=ON
+        cmake -B build -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Release -DUSE_SDL_VERSION=${{ matrix.config.sdl_version }} -DENABLE_IMAGE=ON -DENABLE_TOOLS=ON -DFHEROES2_STRICT_COMPILATION=ON
         cmake --build build -j2
     - name: Install
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,9 @@
-cmake_minimum_required(VERSION 3.14) # For descent FetchContent()
+cmake_minimum_required(VERSION 3.14)
 
 project(fheroes2 VERSION 0.9.12 LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 11)
 
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12")
-    cmake_policy(SET CMP0074 NEW)
-endif()
+cmake_policy(SET CMP0074 NEW)
 
 include(GNUInstallDirs)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,10 +26,10 @@ else
 CFLAGS := -O3 $(CFLAGS)
 endif
 
-CFLAGS := $(CFLAGS) -fsigned-char
+CFLAGS := $(CFLAGS) -fsigned-char -pthread
 CXXFLAGS := -std=c++11 $(CFLAGS)
-LDFLAGS := $(LDFLAGS)
-LIBS := -pthread -lz
+LDFLAGS := $(LDFLAGS) -pthread
+LIBS := -lz
 
 CFLAGS_TP := $(CFLAGS)
 CXXFLAGS_TP := $(CXXFLAGS)

--- a/src/Makefile.vita
+++ b/src/Makefile.vita
@@ -24,7 +24,7 @@ CXX := arm-vita-eabi-g++
 LIBS := -lz
 
 CFLAGS := $(CFLAGS) -DFHEROES2_VITA -I$(VITASDK)/arm-vita-eabi/include -O3 -mcpu=cortex-a9 -mfpu=neon -fgraphite-identity -floop-nest-optimize -fno-lto -fno-tree-slp-vectorize
-LDFLAGS := $(LDFLAGS) -L$(VITASDK)/arm-vita-eabi/lib -L$(VITASDK)/lib $(CFLAGS) -Wl,--sort-common -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -Wl,-q
+LDFLAGS := $(LDFLAGS) -L$(VITASDK)/arm-vita-eabi/lib -L$(VITASDK)/lib $(CFLAGS) -Wl,--sort-common -Wl,--whole-archive -Wl,--no-whole-archive -Wl,-q
 CFLAGS_TP := $(CFLAGS)
 CXXFLAGS_TP := $(CXXFLAGS)
 

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(engine
 	${${USE_SDL_VERSION}_MIXER_LIBRARIES}
 	$<$<BOOL:${ENABLE_IMAGE}>:${${USE_SDL_VERSION}_IMAGE_LIBRARIES}>
 	$<$<BOOL:${ENABLE_IMAGE}>:PNG::PNG>
+	Threads::Threads # To match the build settings of the main app
 	ZLIB::ZLIB
 	)
 export(TARGETS engine FILE EngineConfig.cmake)

--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -12,5 +12,8 @@ else()
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libsmacker>
 		$<INSTALL_INTERFACE:include>
 		)
+	target_link_libraries(smacker
+		Threads::Threads # To match the build settings of the main app
+		)
 	export(TARGETS smacker FILE SmackerConfig.cmake)
 endif(USE_SYSTEM_LIBSMACKER)

--- a/src/tools/Makefile
+++ b/src/tools/Makefile
@@ -36,8 +36,8 @@ CFLAGS := $(SDL_FLAGS) $(CFLAGS) -I../engine
 all: $(TARGETS)
 
 $(TARGETS): $(addsuffix .cpp, $(TARGETS)) $(LIBENGINE)
-	$(CXX) -c $@.cpp $(CFLAGS)
-	$(CXX) -o $@ $@.o $(LIBS)
+	$(CXX) $(CFLAGS) -c $@.cpp
+	$(CXX) $(LDFLAGS) -o $@ $@.o $(LIBS)
 
 clean:
 	rm -f *.o *.exe $(TARGETS)


### PR DESCRIPTION
At least with GCC, `-pthread` implicitly adds `-D_REENTRANT`, which is the compile-time flag:

```
oleg@gentoo ~ $ gcc -dumpspecs | grep pthread
%{posix:-D_POSIX_SOURCE} %{pthread:-D_REENTRANT}
[...]
```

so using it just with linker is not enough (at least in general).

This issue came out when I tried to build fheroes2 as WASM using Emscripten (just out of curiosity). Emscripten was not able to link the final executable with `-pthread` if there were object files that used threads or atomics, but built without `-pthread`.