### PR TITLE
#4298 You can now dig in streams if there is an artifact there

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -589,6 +589,11 @@ bool Maps::TilesAddon::isShadow( const TilesAddon & ta )
     return Tiles::isShadowSprite( ta.object, ta.index );
 }
 
+bool Maps::TilesAddon::isStream( const TilesAddon & ta ) 
+{
+    return MP2::GetICNObject( ta.object ) == ICN::STREAM;
+}
+
 bool Maps::Tiles::isShadowSprite( const int icn, const uint8_t icnIndex )
 {
     return isValidShadowSprite( icn, icnIndex );
@@ -1620,7 +1625,8 @@ bool Maps::Tiles::GoodForUltimateArtifact() const
     }
 
     if ( objectTileset == 0 || isShadowSprite( objectTileset, objectIndex ) ) {
-        return addons_level1.size() == static_cast<size_t>( std::count_if( addons_level1.begin(), addons_level1.end(), TilesAddon::isShadow ) );
+        return ( addons_level1.size() >= static_cast<size_t>( std::count_if( addons_level1.begin(), addons_level1.end(), TilesAddon::isShadow ) ) )
+            || ( addons_level1.size() >= static_cast<size_t>( std::count_if( addons_level1.begin(), addons_level1.end(), TilesAddon::isStream ) ) );
     }
 
     return false;

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -80,6 +80,7 @@ namespace Maps
         std::string String( int level ) const;
 
         static bool isShadow( const TilesAddon & );
+        static bool isStream( const TilesAddon & );
 
         static bool isResource( const TilesAddon & );
         static bool isArtifact( const TilesAddon & );


### PR DESCRIPTION
Adding a check to `Maps::Tiles::GoodForUltimateArtifact()` did the trick.

However, I am not entirely convinced that this is the best way to do it? For one, it is not entirely obvious to me what is meant by `TilesAddon::isShadow`. Conceptually speaking, what is a shadow? I know that `isValidShadowSprite()` ultimately determines this, but it is not clear to me exactly what is considered a shadow. Furthermore, since the original check was `addons_level1.size() == static_cast<size_t>( std::count_if( addons_level1.begin(), addons_level1.end(), TilesAddon::isShadow ) )` there is an assumption here that you can only dig in shadows. This is a little counter-intuitive to me, since you can obviously dig in more spots than shadows. You can dig on most grass tiles etc., so there must be some kind of misconception I have about what a "shadow" is here. If anyone can shed some light this, that would be helpful.

Several things already use `Maps::TilesAddon::isShadow()` so I did not want to change the implementation of that, lest I introduce bugs elsewhere too.

Now, the other thing I am curious about is why the original check - `addons_level1.size() == static_cast<size_t>( std::count_if( addons_level1.begin(), addons_level1.end(), TilesAddon::isShadow ) )` - assumed that `addons_level1` contained only shadow elements? In my testing that is now always the case. When a road intersects a stream, for instance, there are multiple elements in this list. I changed the condition `addons_level1.size() >= ...` to take this into account, which is demonstrated in my screenshots below. With that being said, I am not sure if I violated some core assumption that might have knock-on effects elsewhere.

![stream-digging](https://user-images.githubusercontent.com/7132795/154969372-29e8ae16-b817-48d9-858b-773bf611b167.png)

My original implementation did not account for when a stream intersects with a road. The original game allows this.

*Original game*
![stream-digging-puzzle-original](https://user-images.githubusercontent.com/7132795/154969571-194420aa-0e5e-4dec-ae5f-fea0b7b86e73.png)

If you try to dig in the intersection and there is no artifact it yells at you:

![stream-digging-bad-intersection-original](https://user-images.githubusercontent.com/7132795/154969725-9430e812-8d28-4612-8d7a-22130e70809c.png)

But if there is an artifact there, it will let you dig:

![stream-digging-good-intersection-original](https://user-images.githubusercontent.com/7132795/154969796-8e36ca8d-5c9b-47df-9321-c64b0dce5e9d.png)

*fheroes 2*

![stream-digging-bad-intersection-fheroes](https://user-images.githubusercontent.com/7132795/154969900-a266e61b-0249-4b9f-bd8c-8a71d69be217.png)

![stream-digging-good-intersection-fheroes2](https://user-images.githubusercontent.com/7132795/154969906-17dab465-62d4-47c9-be4b-16d9c0b4bbb2.png)
