### PR TITLE
Update AI hero recruitment logic

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -135,7 +135,7 @@ namespace AI
         void HeroesPreBattle( HeroBase & hero, bool isAttacking ) override;
         void HeroesActionComplete( Heroes & hero ) override;
 
-        bool recruitHero( Castle & castle, bool slowEarlyGame, bool underThreat );
+        bool recruitHero( Castle & castle, bool buyArmy, bool underThreat );
         double getObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         int getPriorityTarget( const Heroes & hero, double & maxPriority, int patrolIndex = -1, uint32_t distanceLimit = 0 );
         void resetPathfinder() override;

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -135,6 +135,7 @@ namespace AI
         void HeroesPreBattle( HeroBase & hero, bool isAttacking ) override;
         void HeroesActionComplete( Heroes & hero ) override;
 
+        bool recruitHero( Castle & castle, bool slowEarlyGame, bool underThreat );
         double getObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         int getPriorityTarget( const Heroes & hero, double & maxPriority, int patrolIndex = -1, uint32_t distanceLimit = 0 );
         void resetPathfinder() override;

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -857,6 +857,11 @@ Army::~Army()
     clear();
 }
 
+const Troops & Army::getTroops() const
+{
+    return *this;
+}
+
 void Army::setFromTile( const Maps::Tiles & tile )
 {
     Reset();

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -153,6 +153,7 @@ public:
     Army & operator=( Army && ) = delete;
     ~Army() override;
 
+    const Troops & getTroops() const;
     void Reset( bool = false ); // reset: soft or hard
     void setFromTile( const Maps::Tiles & tile );
 

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -462,7 +462,7 @@ int Castle::getBuildingValue() const
 
 Troops Castle::getAvailableArmy( Funds potentialBudget ) const
 {
-    Troops reinforcement( army );
+    Troops reinforcement( army.getTroops() );
     for ( uint32_t dw = DWELLING_MONSTER6; dw >= DWELLING_MONSTER1; dw >>= 1 ) {
         if ( isBuild( dw ) ) {
             const Monster monster( race, GetActualDwelling( dw ) );

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -460,6 +460,32 @@ int Castle::getBuildingValue() const
     return value;
 }
 
+Troops Castle::getAvailableArmy( Funds potentialBudget ) const
+{
+    Troops reinforcement( army );
+    for ( uint32_t dw = DWELLING_MONSTER6; dw >= DWELLING_MONSTER1; dw >>= 1 ) {
+        if ( isBuild( dw ) ) {
+            const Monster monster( race, GetActualDwelling( dw ) );
+            const uint32_t available = getMonstersInDwelling( dw );
+
+            uint32_t couldRecruit = potentialBudget.getLowestQuotient( monster.GetCost() );
+            if ( available < couldRecruit )
+                couldRecruit = available;
+
+            if ( couldRecruit > 0 ) {
+                potentialBudget -= ( monster.GetCost() * couldRecruit );
+                reinforcement.PushBack( monster, couldRecruit );
+            }
+        }
+    }
+    return reinforcement;
+}
+
+double Castle::getArmyRecruitmentValue() const
+{
+    return getAvailableArmy( GetKingdom().GetFunds() ).GetStrength();
+}
+
 double Castle::getVisitValue( const Heroes & hero ) const
 {
     double spellValue = 0;
@@ -494,23 +520,7 @@ double Castle::getVisitValue( const Heroes & hero ) const
 
     const double upgradeStrength = futureArmy.GetStrength() - heroArmyStrength;
 
-    Troops reinforcement;
-    for ( uint32_t dw = DWELLING_MONSTER6; dw >= DWELLING_MONSTER1; dw >>= 1 ) {
-        if ( isBuild( dw ) ) {
-            const Monster monster( race, GetActualDwelling( dw ) );
-            const uint32_t available = getMonstersInDwelling( dw );
-
-            uint32_t couldRecruit = potentialFunds.getLowestQuotient( monster.GetCost() );
-            if ( available < couldRecruit )
-                couldRecruit = available;
-
-            potentialFunds -= ( monster.GetCost() * couldRecruit );
-
-            reinforcement.PushBack( monster, couldRecruit );
-        }
-    }
-
-    return spellValue + upgradeStrength + futureArmy.getReinforcementValue( reinforcement );
+    return spellValue + upgradeStrength + futureArmy.getReinforcementValue( getAvailableArmy( potentialFunds ) );
 }
 
 void Castle::ActionNewDay( void )

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -172,6 +172,7 @@ public:
     int getBuildingValue() const;
 
     // Used only for AI.
+    double getArmyRecruitmentValue() const;
     double getVisitValue( const Heroes & hero ) const;
 
     void ChangeColor( int );
@@ -250,6 +251,7 @@ private:
     void OpenWell( void );
     void OpenMageGuild( const CastleHeroes & heroes ) const;
     void WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vector<fheroes2::RandomMonsterAnimation> & monsterAnimInfo ) const;
+    Troops getAvailableArmy( Funds potentialBudget ) const;
     void JoinRNDArmy( void );
     void PostLoad( void );
 

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -85,8 +85,8 @@ namespace
         for ( uint8_t direction = 0; direction < 8; ++direction ) {
             const int newIndex = ConvertExtendedIndex( nodeIndex, rawDataWidth ) + offsets[direction];
             MapRegionNode & newTile = rawData[newIndex];
-            if ( newTile.passable & GetDirectionBitmask( direction, true ) ) {
-                if ( newTile.type == REGION_NODE_OPEN && newTile.isWater == region._isWater ) {
+            if ( newTile.passable & GetDirectionBitmask( direction, true ) && newTile.isWater == region._isWater ) {
+                if ( newTile.type == REGION_NODE_OPEN ) {
                     newTile.type = region._id;
                     region._nodes.push_back( newTile );
                 }


### PR DESCRIPTION
Fixes #4566 .

Refactored recruitment decision logic to cover edge cases when there's more castles than heroes. Excluded patrol heroes from the list. Now AI should select a castle with most the army if multiple available.

Also fixed a minor issue with map region neighbors list.