### PR TITLE
Fix the versioning of toshimaru/auto-author-assign

### DIFF
--- a/.github/workflows/pr_author_auto_assign.yml
+++ b/.github/workflows/pr_author_auto_assign.yml
@@ -9,6 +9,6 @@ jobs:
     name: PR author auto assign
     runs-on: ubuntu-latest
     steps:
-    - uses: toshimaru/auto-author-assign@v1
+    - uses: toshimaru/auto-author-assign@v1.4.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It seems that this Action doesn't follow the [recommended versioning practice](https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-release-management-for-actions), so specifying just a major version is not enough :(