### PR TITLE
Allow selecting options while restarting a campaign scenario

### DIFF
--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -804,7 +804,7 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
     const fheroes2::Point optionButtonOffset( 590, 199 );
     const int32_t optionButtonStep = 22;
 
-    const fheroes2::Sprite & pressedButton = fheroes2::AGG::GetICN( ICN::CAMPXTRG, allowToRestart ? 9 : 8 );
+    const fheroes2::Sprite & pressedButton = fheroes2::AGG::GetICN( ICN::CAMPXTRG, 8 );
     fheroes2::Sprite releaseButton( pressedButton.width(), pressedButton.height(), pressedButton.x(), pressedButton.y() );
     fheroes2::Copy( backgroundImage, optionButtonOffset.x + pressedButton.x(), optionButtonOffset.y + pressedButton.y(), releaseButton, 0, 0, releaseButton.width(),
                     releaseButton.height() );
@@ -891,15 +891,14 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
         if ( allowToRestart ) {
             le.MousePressLeft( buttonRestart.area() ) ? buttonRestart.drawOnPress() : buttonRestart.drawOnRelease();
         }
-        else {
-            for ( uint32_t i = 0; i < bonusChoiceCount; ++i ) {
-                if ( le.MousePressLeft( choiceArea[i] ) ) {
-                    buttonChoices.button( i ).press();
-                    optionButtonGroup.draw();
-                    scenarioBonus = bonusChoices[i];
 
-                    break;
-                }
+        for ( uint32_t i = 0; i < bonusChoiceCount; ++i ) {
+            if ( le.MousePressLeft( choiceArea[i] ) ) {
+                buttonChoices.button( i ).press();
+                optionButtonGroup.draw();
+                scenarioBonus = bonusChoices[i];
+
+                break;
             }
         }
 


### PR DESCRIPTION
close #5052

However, in the original game it is not possible to do so.