### PR TITLE
Fix Sirens logic, AI interaction and UI

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1769,13 +1769,15 @@ namespace AI
 
     void AIToSirens( Heroes & hero, const MP2::MapObjectType objectType, const int32_t objectIndex )
     {
-        if ( !hero.isObjectTypeVisited( objectType ) ) {
-            const uint32_t experience = hero.GetArmy().ActionToSirens();
-            hero.IncreaseExperience( experience );
-
-            hero.SetVisited( objectIndex );
-
-            DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " visited Sirens and got " << experience << " experience." )
+        if ( hero.isObjectTypeVisited( objectType ) ) {
+            return;
         }
+
+        const uint32_t experience = hero.GetArmy().ActionToSirens();
+        hero.IncreaseExperience( experience );
+
+        hero.SetVisited( objectIndex );
+
+        DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " visited Sirens and got " << experience << " experience." )
     }
 }

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -142,6 +142,7 @@ namespace AI
     void AIToJail( const Heroes & hero, const int32_t tileIndex );
     void AIToHutMagi( Heroes & hero, const MP2::MapObjectType objectType, const int32_t tileIndex );
     void AIToAlchemistTower( Heroes & hero );
+    void AIToSirens( Heroes & hero, const MP2::MapObjectType objectType, const int32_t objectIndex );
 
     int AISelectPrimarySkill( const Heroes & hero )
     {
@@ -483,7 +484,10 @@ namespace AI
         case MP2::OBJ_TRADINGPOST:
         case MP2::OBJ_EYEMAGI:
         case MP2::OBJ_SPHINX:
+            break;
         case MP2::OBJ_SIRENS:
+            // AI must have some action even if it goes on this object by mistake.
+            AIToSirens( hero, objectType, dst_index );
             break;
         default:
             assert( !isActionObject ); // AI should know what to do with this type of action object! Please add logic for it.
@@ -1761,5 +1765,17 @@ namespace AI
         }
 
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " visited Alchemist Tower to remove " << cursed << " artifacts." );
+    }
+
+    void AIToSirens( Heroes & hero, const MP2::MapObjectType objectType, const int32_t objectIndex )
+    {
+        if ( !hero.isObjectTypeVisited( objectType ) ) {
+            const uint32_t experience = hero.GetArmy().ActionToSirens();
+            hero.IncreaseExperience( experience );
+
+            hero.SetVisited( objectIndex );
+
+            DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " visited Sirens and got " << experience << " experience." )
+        }
     }
 }

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1250,7 +1250,7 @@ void Army::JoinStrongestFromArmy( Army & army2 )
     JoinStrongest( army2, save_last );
 }
 
-uint32_t Army::ActionToSirens()
+uint32_t Army::ActionToSirens() const
 {
     uint32_t experience = 0;
 

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1250,21 +1250,33 @@ void Army::JoinStrongestFromArmy( Army & army2 )
     JoinStrongest( army2, save_last );
 }
 
-u32 Army::ActionToSirens( void )
+uint32_t Army::ActionToSirens()
 {
-    u32 res = 0;
+    uint32_t experience = 0;
 
-    for ( iterator it = begin(); it != end(); ++it )
-        if ( ( *it )->isValid() ) {
-            const u32 kill = ( *it )->GetCount() * 30 / 100;
+    for ( Troop * troop : *this ) {
+        assert( troop != nullptr );
 
-            if ( kill ) {
-                ( *it )->SetCount( ( *it )->GetCount() - kill );
-                res += kill * static_cast<Monster *>( *it )->GetHitPoints();
+        if ( troop->isValid() ) {
+            const uint32_t troopCount = troop->GetCount();
+            if ( troopCount == 1 ) {
+                // Sirens do not affect 1 troop stack.
+                continue;
             }
-        }
 
-    return res;
+            // 30% of stack troops will be gone.
+            uint32_t troopToRemove = troopCount * 3 / 10;
+            if ( troopToRemove == 0 ) {
+                // At least one unit must go, even if it's more than 30%.
+                troopToRemove = 1;
+            }
+
+            troop->SetCount( troopCount - troopToRemove );
+            experience += troopToRemove * static_cast<Monster *>( troop )->GetHitPoints();
+        }
+    }
+
+    return experience;
 }
 
 bool Army::isStrongerThan( const Army & target, double safetyRatio ) const

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1257,23 +1257,25 @@ uint32_t Army::ActionToSirens() const
     for ( Troop * troop : *this ) {
         assert( troop != nullptr );
 
-        if ( troop->isValid() ) {
-            const uint32_t troopCount = troop->GetCount();
-            if ( troopCount == 1 ) {
-                // Sirens do not affect 1 troop stack.
-                continue;
-            }
-
-            // 30% of stack troops will be gone.
-            uint32_t troopToRemove = troopCount * 3 / 10;
-            if ( troopToRemove == 0 ) {
-                // At least one unit must go, even if it's more than 30%.
-                troopToRemove = 1;
-            }
-
-            troop->SetCount( troopCount - troopToRemove );
-            experience += troopToRemove * static_cast<Monster *>( troop )->GetHitPoints();
+        if ( !troop->isValid() ) {
+            continue;
         }
+
+        const uint32_t troopCount = troop->GetCount();
+        if ( troopCount == 1 ) {
+            // Sirens do not affect 1 troop stack.
+            continue;
+        }
+
+        // 30% of stack troops will be gone.
+        uint32_t troopToRemove = troopCount * 3 / 10;
+        if ( troopToRemove == 0 ) {
+            // At least one unit must go, even if it's more than 30%.
+            troopToRemove = 1;
+        }
+
+        troop->SetCount( troopCount - troopToRemove );
+        experience += troopToRemove * static_cast<Monster *>( troop )->GetHitPoints();
     }
 
     return experience;

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -172,7 +172,7 @@ public:
     int GetLuck( void ) const;
     int GetMoraleModificator( std::string * ) const;
     int GetLuckModificator( const std::string * ) const;
-    uint32_t ActionToSirens();
+    uint32_t ActionToSirens() const;
 
     const HeroBase * GetCommander( void ) const;
     HeroBase * GetCommander( void );

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -172,7 +172,7 @@ public:
     int GetLuck( void ) const;
     int GetMoraleModificator( std::string * ) const;
     int GetLuckModificator( const std::string * ) const;
-    u32 ActionToSirens( void );
+    uint32_t ActionToSirens();
 
     const HeroBase * GetCommander( void ) const;
     HeroBase * GetCommander( void );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3042,19 +3042,24 @@ void ActionToSirens( Heroes & hero, const MP2::MapObjectType objectType, s32 dst
                          Font::BIG, Dialog::OK );
     }
     else {
-        const uint32_t exp = hero.GetArmy().ActionToSirens();
-        if ( hero.GetArmy().getTotalCount() == 1 ) {
+        const uint32_t experience = hero.GetArmy().ActionToSirens();
+        if ( experience == 0 ) {
             Dialog::Message( title, _( "As the sirens sing their eerie song, your small, determined army manages to overcome the urge to dive headlong into the sea." ),
                          Font::BIG, Dialog::OK );
         }
         else {
+            const fheroes2::ExperienceDialogElement experienceUI( static_cast<int32_t>( experience ) );
+
             std::string str = _(
                 "An eerie wailing song emanates from the sirens perched upon the rocks. Many of your crew fall under its spell, and dive into the water where they drown. You are now wiser for the visit, and gain %{exp} experience." );
-            StringReplace( str, "%{exp}", exp );
+            StringReplace( str, "%{exp}", experience );
 
             AGG::PlaySound( M82::EXPERNCE );
-            Dialog::Message( title, str, Font::BIG, Dialog::OK );
-            hero.IncreaseExperience( exp );
+
+            fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( str, fheroes2::FontType::normalWhite() ), Dialog::OK,
+                                   { &experienceUI } );
+
+            hero.IncreaseExperience( experience );
         }
 
         hero.SetVisited( dst_index );


### PR DESCRIPTION
- AI did not have any action while moving onto Sirens object while it should
- sirens must remove at least one unit from a stack which has more than 1 unit
- add experience UI element to Sirens dialog (close #4699 )