### PR TITLE
Increase the fetch-depth for clang_tidy.yml and code_style_check.yml workflows

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -12,6 +12,8 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
     - name: Install dependencies and clang-tidy
       run: |
         sudo apt-get -y update

--- a/.github/workflows/code_style_check.yml
+++ b/.github/workflows/code_style_check.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
     - name: Setup clang-format
       run: |
         sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-12 100

--- a/script/tools/check_copyright_headers.py
+++ b/script/tools/check_copyright_headers.py
@@ -49,8 +49,6 @@ def main():
 
     generic_hdr_re = re.compile("^/\\*.*?\\*/", re.DOTALL)
 
-    retcode = 0
-
     for file_name in sys.argv[1:]:
         with open(file_name, "r", encoding="latin_1") as src_file:
             src = src_file.read()
@@ -68,8 +66,6 @@ def main():
                     src_is_ok = True
 
             if not src_is_ok:
-                retcode = 1
-
                 if year_re_match:
                     hdr = COPYRIGHT_HDR_TMPL.replace("{Y1}", f"{year_re_match.group(1)}") \
                                             .replace("{Y2}", f"{CURRENT_YEAR}")
@@ -89,7 +85,7 @@ def main():
                 with subprocess.Popen(["diff", "-u", file_name, file_name + ".tmp"]) as diff_proc:
                     diff_proc.wait()
 
-    return retcode
+    return 0
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
These workflows access commits other than the current one (such as `HEAD^`) and default `fetch-depth` (1) is not enough for them.

P.S. I recommend to sync existing PRs with `master` after merging this one. 