### PR TITLE
Show missing last frame of wince animation

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3169,7 +3169,11 @@ void Battle::Interface::RedrawActionWincesKills( const TargetsInfo & targets, Un
                 }
 
                 const int animationState = info.defender->GetAnimationState();
-                if ( animationState != Monster_Info::WNCE && animationState != Monster_Info::KILL ) {
+                if ( animationState == Monster_Info::WNCE ) {
+                    return false;
+                }
+
+                if ( animationState != Monster_Info::KILL ) {
                     return true;
                 }
 


### PR DESCRIPTION
relates to #983

Because of this missing frame under normal speed we did not have 120 ms delay.