### PR TITLE
Remove Map loading screen

### DIFF
--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -516,18 +516,6 @@ u32 Game::GetGameOverScores( void )
     return GetRating() * ( 200 - daysScore ) / 100;
 }
 
-void Game::ShowMapLoadingText( void )
-{
-    fheroes2::Display & display = fheroes2::Display::instance();
-    const fheroes2::Rect pos( 0, display.height() / 2, display.width(), display.height() / 2 );
-    TextBox text( _( "Map is loading..." ), Font::BIG, pos.width );
-
-    // blit test
-    display.fill( 0 );
-    text.Blit( pos.x, pos.y );
-    display.render();
-}
-
 u32 Game::GetLostTownDays( void )
 {
     return GameStatic::GetGameOverLostDays();

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -212,7 +212,6 @@ namespace Game
     u32 GetViewDistance( u32 );
     u32 GetWhirlpoolPercent( void );
     u32 SelectCountPlayers( void );
-    void ShowMapLoadingText( void );
     void PlayPickupSound( void );
     bool UpdateSoundsOnFocusUpdate();
     void SetUpdateSoundsOnFocusUpdate( bool update );

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -979,8 +979,6 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
             if ( conf.ExtGameUseFade() )
                 fheroes2::FadeDisplay();
 
-            fheroes2::ImageRestorer restorer( display );
-            Game::ShowMapLoadingText();
             conf.SetGameType( Game::TYPE_CAMPAIGN );
 
             if ( !world.LoadMapMP2( mapInfo.file ) ) {
@@ -988,8 +986,6 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
                 conf.SetCurrentFileInfo( Maps::FileInfo() );
                 continue;
             }
-
-            restorer.reset();
 
             // meanwhile, the others should be called after players.SetStartGame()
             if ( scenarioBonus._type != Campaign::ScenarioBonusData::STARTING_RACE ) {

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2020                                                    *
+ *   Copyright (C) 2020 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -140,8 +140,6 @@ fheroes2::GameMode Game::Load( const std::string & fn )
         return fheroes2::GameMode::CANCEL;
     }
 
-    Game::ShowMapLoadingText();
-
     char major;
     char minor;
     fs >> major >> minor;

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -384,7 +384,6 @@ namespace
             fheroes2::FadeDisplay();
         }
 
-        Game::ShowMapLoadingText();
         // Load maps
         std::string lower = StringLower( conf.MapsFile() );
 


### PR DESCRIPTION
Rendering of such screen sometimes takes more time than just to load a single map or save file.