### PR TITLE
Add popup windows for campaign awards and bonuses

### DIFF
--- a/src/fheroes2/campaign/campaign_data.cpp
+++ b/src/fheroes2/campaign/campaign_data.cpp
@@ -791,7 +791,7 @@ namespace Campaign
                 description += monsters.back().GetMultiName();
             }
 
-            description += _( " will never join your army." );
+            description += _( " will always run away from your army." );
             return description;
         }
         case CampaignAwardData::TYPE_CREATURE_ALLIANCE: {

--- a/src/fheroes2/campaign/campaign_data.cpp
+++ b/src/fheroes2/campaign/campaign_data.cpp
@@ -782,7 +782,7 @@ namespace Campaign
         switch ( _type ) {
         case CampaignAwardData::TYPE_CREATURE_CURSE: {
             std::vector<Monster> monsters;
-            monsters.emplace_back( Monster( _subType ) );
+            monsters.emplace_back( static_cast<int>( _subType ) );
             std::string description( monsters.back().GetMultiName() );
 
             while ( monsters.back() != monsters.back().GetUpgrade() ) {
@@ -796,7 +796,7 @@ namespace Campaign
         }
         case CampaignAwardData::TYPE_CREATURE_ALLIANCE: {
             std::vector<Monster> monsters;
-            monsters.emplace_back( Monster( _subType ) );
+            monsters.emplace_back( static_cast<int>( _subType ) );
             std::string description( monsters.back().GetMultiName() );
 
             while ( monsters.back() != monsters.back().GetUpgrade() ) {
@@ -810,29 +810,29 @@ namespace Campaign
         }
         case CampaignAwardData::TYPE_GET_ARTIFACT: {
             std::string description( _( "\"%{artifact}\" artifact will be carried over the scenario." ) );
-            StringReplace( description, "%{artifact}", Artifact( _subType ).GetName() );
+            StringReplace( description, "%{artifact}", Artifact( static_cast<int>( _subType ) ).GetName() );
             return description;
         }
         case CampaignAwardData::TYPE_CARRY_OVER_FORCES:
             return _( "The army will be carried over the scenario." );
         case CampaignAwardData::TYPE_RESOURCE_BONUS: {
             std::string description( _( "The kingdom will have additional %{resource} at the start of the scenario." ) );
-            StringReplace( description, "%{resource}", Resource::String( _subType ) );
+            StringReplace( description, "%{resource}", Resource::String( static_cast<int>( _subType ) ) );
             return description;
         }
         case CampaignAwardData::TYPE_GET_SPELL: {
             std::string description( _( "\"%{spell}\" spell will be carried over the scenario." ) );
-            StringReplace( description, "%{spell}", Spell( _subType ).GetName() );
+            StringReplace( description, "%{spell}", Spell( static_cast<int>( _subType ) ).GetName() );
             return description;
         }
         case CampaignAwardData::TYPE_HIREABLE_HERO: {
             std::string description( _( "%{hero} hero can be hired in the scenario." ) );
-            StringReplace( description, "%{hero}", Heroes( _subType, 0 ).GetName() );
+            StringReplace( description, "%{hero}", Heroes( static_cast<int>( _subType ), 0 ).GetName() );
             return description;
         }
         case CampaignAwardData::TYPE_DEFEAT_ENEMY_HERO: {
             std::string description( _( "Defeated %{hero} hero will not appear in the subsequent scenarios." ) );
-            StringReplace( description, "%{hero}", Heroes( _subType, 0 ).GetName() );
+            StringReplace( description, "%{hero}", Heroes( static_cast<int>( _subType ), 0 ).GetName() );
             return description;
         }
         default:

--- a/src/fheroes2/campaign/campaign_data.cpp
+++ b/src/fheroes2/campaign/campaign_data.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2021                                                    *
+ *   Copyright (C) 2021 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/campaign/campaign_data.cpp
+++ b/src/fheroes2/campaign/campaign_data.cpp
@@ -24,6 +24,7 @@
 #include "monster.h"
 #include "resource.h"
 #include "spell.h"
+#include "tools.h"
 #include "translations.h"
 
 #include <array>
@@ -39,10 +40,10 @@ namespace
 
         switch ( scenarioID ) {
         case 2:
-            obtainableAwards.emplace_back( 0, Campaign::CampaignAwardData::TYPE_CREATURE_ALLIANCE, Monster::DWARF, _( "Dwarven Alliance" ) );
+            obtainableAwards.emplace_back( 0, Campaign::CampaignAwardData::TYPE_CREATURE_ALLIANCE, Monster::DWARF, gettext_noop( "Dwarven Alliance" ) );
             break;
         case 5:
-            obtainableAwards.emplace_back( 1, Campaign::CampaignAwardData::TYPE_HIREABLE_HERO, Heroes::ELIZA, 0, 0, _( "Sorceress Guild" ) );
+            obtainableAwards.emplace_back( 1, Campaign::CampaignAwardData::TYPE_HIREABLE_HERO, Heroes::ELIZA, 0, 0, gettext_noop( "Sorceress Guild" ) );
             break;
         case 6:
             obtainableAwards.emplace_back( 2, Campaign::CampaignAwardData::TYPE_CARRY_OVER_FORCES, 0, 0, 9 );
@@ -66,14 +67,14 @@ namespace
 
         switch ( scenarioID ) {
         case 2:
-            obtainableAwards.emplace_back( 1, Campaign::CampaignAwardData::TYPE_HIREABLE_HERO, Heroes::BAX, 0, 0, _( "Necromancer Guild" ) );
+            obtainableAwards.emplace_back( 1, Campaign::CampaignAwardData::TYPE_HIREABLE_HERO, Heroes::BAX, 0, 0, gettext_noop( "Necromancer Guild" ) );
             break;
         case 3:
             obtainableAwards.emplace_back( 2, Campaign::CampaignAwardData::TYPE_CREATURE_ALLIANCE, Monster::OGRE );
             obtainableAwards.emplace_back( 3, Campaign::CampaignAwardData::TYPE_CREATURE_CURSE, Monster::DWARF );
             break;
         case 6:
-            obtainableAwards.emplace_back( 4, Campaign::CampaignAwardData::TYPE_CREATURE_ALLIANCE, Monster::GREEN_DRAGON, _( "Dragon Alliance" ) );
+            obtainableAwards.emplace_back( 4, Campaign::CampaignAwardData::TYPE_CREATURE_ALLIANCE, Monster::GREEN_DRAGON, gettext_noop( "Dragon Alliance" ) );
             break;
         case 8:
             obtainableAwards.emplace_back( 5, Campaign::CampaignAwardData::TYPE_GET_ARTIFACT, Artifact::ULTIMATE_CROWN );
@@ -97,7 +98,7 @@ namespace
             obtainableAwards.emplace_back( 0, Campaign::CampaignAwardData::TYPE_GET_ARTIFACT, Artifact::BREASTPLATE_ANDURAN );
             break;
         case 2:
-            obtainableAwards.emplace_back( 1, Campaign::CampaignAwardData::TYPE_CREATURE_ALLIANCE, Monster::ELF, _( "Elven Alliance" ) );
+            obtainableAwards.emplace_back( 1, Campaign::CampaignAwardData::TYPE_CREATURE_ALLIANCE, Monster::ELF, gettext_noop( "Elven Alliance" ) );
             obtainableAwards.emplace_back( 2, Campaign::CampaignAwardData::TYPE_RESOURCE_BONUS, Resource::WOOD, 2 );
             break;
         case 5:
@@ -109,7 +110,7 @@ namespace
             obtainableAwards.emplace_back( 4, Campaign::CampaignAwardData::TYPE_GET_ARTIFACT, Artifact::SWORD_ANDURAN );
 
             // seems that Kraeger is a custom name for Dainwin in this case
-            obtainableAwards.emplace_back( 5, Campaign::CampaignAwardData::TYPE_DEFEAT_ENEMY_HERO, Heroes::DAINWIN, _( "Kraeger defeated" ) );
+            obtainableAwards.emplace_back( 5, Campaign::CampaignAwardData::TYPE_DEFEAT_ENEMY_HERO, Heroes::DAINWIN, gettext_noop( "Kraeger defeated" ) );
             break;
         default:
             break;
@@ -142,16 +143,16 @@ namespace
 
         switch ( scenarioID ) {
         case 2:
-            obtainableAwards.emplace_back( 0, Campaign::CampaignAwardData::TYPE_HIREABLE_HERO, Heroes::JOSEPH, 0, 0, _( "Wayward Son" ) );
+            obtainableAwards.emplace_back( 0, Campaign::CampaignAwardData::TYPE_HIREABLE_HERO, Heroes::JOSEPH, 0, 0, gettext_noop( "Wayward Son" ) );
             break;
         case 3:
-            obtainableAwards.emplace_back( 1, Campaign::CampaignAwardData::TYPE_HIREABLE_HERO, Heroes::UNCLEIVAN, 0, 0, _( "Uncle Ivan" ) );
+            obtainableAwards.emplace_back( 1, Campaign::CampaignAwardData::TYPE_HIREABLE_HERO, Heroes::UNCLEIVAN, 0, 0, gettext_noop( "Uncle Ivan" ) );
             break;
         case 5:
             obtainableAwards.emplace_back( 2, Campaign::CampaignAwardData::TYPE_GET_ARTIFACT, Artifact::LEGENDARY_SCEPTER );
             break;
         case 6:
-            obtainableAwards.emplace_back( 3, Campaign::CampaignAwardData::TYPE_CREATURE_ALLIANCE, Monster::ELF, _( "Elven Alliance" ) );
+            obtainableAwards.emplace_back( 3, Campaign::CampaignAwardData::TYPE_CREATURE_ALLIANCE, Monster::ELF, gettext_noop( "Elven Alliance" ) );
             break;
         default:
             break;
@@ -746,10 +747,10 @@ namespace Campaign
         , _customName( customName )
     {}
 
-    std::string CampaignAwardData::ToString() const
+    std::string CampaignAwardData::getName() const
     {
         if ( !_customName.empty() )
-            return _customName;
+            return _( _customName );
 
         switch ( _type ) {
         case CampaignAwardData::TYPE_CREATURE_CURSE:
@@ -770,8 +771,76 @@ namespace Campaign
             return Heroes( _subType, 0 ).GetName() + std::string( _( " defeated" ) );
         default:
             assert( 0 ); // some new/unhandled award
-            return "";
+            break;
         }
+
+        return {};
+    }
+
+    std::string CampaignAwardData::getDescription() const
+    {
+        switch ( _type ) {
+        case CampaignAwardData::TYPE_CREATURE_CURSE: {
+            std::vector<Monster> monsters;
+            monsters.emplace_back( Monster( _subType ) );
+            std::string description( monsters.back().GetMultiName() );
+
+            while ( monsters.back() != monsters.back().GetUpgrade() ) {
+                monsters.emplace_back( monsters.back().GetUpgrade() );
+                description += ", ";
+                description += monsters.back().GetMultiName();
+            }
+
+            description += _( " will never join your army." );
+            return description;
+        }
+        case CampaignAwardData::TYPE_CREATURE_ALLIANCE: {
+            std::vector<Monster> monsters;
+            monsters.emplace_back( Monster( _subType ) );
+            std::string description( monsters.back().GetMultiName() );
+
+            while ( monsters.back() != monsters.back().GetUpgrade() ) {
+                monsters.emplace_back( monsters.back().GetUpgrade() );
+                description += ", ";
+                description += monsters.back().GetMultiName();
+            }
+
+            description += _( " will be willing to always join your army." );
+            return description;
+        }
+        case CampaignAwardData::TYPE_GET_ARTIFACT: {
+            std::string description( _( "\"%{artifact}\" artifact will be carried over the scenario." ) );
+            StringReplace( description, "%{artifact}", Artifact( _subType ).GetName() );
+            return description;
+        }
+        case CampaignAwardData::TYPE_CARRY_OVER_FORCES:
+            return _( "The army will be carried over the scenario." );
+        case CampaignAwardData::TYPE_RESOURCE_BONUS: {
+            std::string description( _( "The kingdom will have additional %{resource} at the start of the scenario." ) );
+            StringReplace( description, "%{resource}", Resource::String( _subType ) );
+            return description;
+        }
+        case CampaignAwardData::TYPE_GET_SPELL: {
+            std::string description( _( "\"%{spell}\" spell will be carried over the scenario." ) );
+            StringReplace( description, "%{spell}", Spell( _subType ).GetName() );
+            return description;
+        }
+        case CampaignAwardData::TYPE_HIREABLE_HERO: {
+            std::string description( _( "%{hero} hero can be hired in the scenario." ) );
+            StringReplace( description, "%{hero}", Heroes( _subType, 0 ).GetName() );
+            return description;
+        }
+        case CampaignAwardData::TYPE_DEFEAT_ENEMY_HERO: {
+            std::string description( _( "Defeated %{hero} hero will not appear in the subsequent scenarios." ) );
+            StringReplace( description, "%{hero}", Heroes( _subType, 0 ).GetName() );
+            return description;
+        }
+        default:
+            assert( 0 ); // some new/unhandled award
+            break;
+        }
+
+        return {};
     }
 
     std::vector<Campaign::CampaignAwardData> CampaignAwardData::getCampaignAwardData( const ScenarioInfoId & scenarioInfo )

--- a/src/fheroes2/campaign/campaign_data.h
+++ b/src/fheroes2/campaign/campaign_data.h
@@ -90,7 +90,9 @@ namespace Campaign
         CampaignAwardData( int id, uint32_t type, uint32_t subType, const std::string & customName );
         CampaignAwardData( int id, uint32_t type, uint32_t subType, uint32_t amount, int startScenarioID, const std::string & customName = std::string() );
 
-        std::string ToString() const;
+        std::string getName() const;
+
+        std::string getDescription() const;
 
         static std::vector<Campaign::CampaignAwardData> getCampaignAwardData( const ScenarioInfoId & scenarioInfo );
         static std::vector<Campaign::CampaignAwardData> getExtraCampaignAwardData( const int campaignID );

--- a/src/fheroes2/campaign/campaign_data.h
+++ b/src/fheroes2/campaign/campaign_data.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2021                                                    *
+ *   Copyright (C) 2021 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -504,41 +504,41 @@ namespace Campaign
         switch ( _type ) {
         case ScenarioBonusData::ARTIFACT: {
             std::string description( _( "The main hero will have \"%{artifact}\" artifact at the start of the scenario." ) );
-            StringReplace( description, "%{artifact}", Artifact( _subType ).GetName() );
+            StringReplace( description, "%{artifact}", Artifact( static_cast<int>( _subType ) ).GetName() );
             return description;
         }
         case ScenarioBonusData::RESOURCES: {
             std::string description( _( "The kingdom will have additional %{amount} %{resource} at the start of the scenario." ) );
             StringReplace( description, "%{amount}", std::to_string( _amount ) );
-            StringReplace( description, "%{resource}", Resource::String( _subType ) );
+            StringReplace( description, "%{resource}", Resource::String( static_cast<int>( _subType ) ) );
             return description;
         }
         case ScenarioBonusData::TROOP: {
             std::string description( _( "The main hero will have %{count} %{monster} at the start of the scenario." ) );
             StringReplace( description, "%{count}", std::to_string( _amount ) );
-            StringReplace( description, "%{monster}", Monster( _subType ).GetPluralName( _amount ) );
+            StringReplace( description, "%{monster}", Monster( static_cast<int>( _subType ) ).GetPluralName( _amount ) );
             return description;
         }
         case ScenarioBonusData::SPELL: {
             std::string description( _( "The main hero will have \"%{spell}\" spell at the start of the scenario." ) );
-            StringReplace( description, "%{spell}", Spell( _subType ).GetName() );
+            StringReplace( description, "%{spell}", Spell( static_cast<int>( _subType ) ).GetName() );
             return description;
         }
         case ScenarioBonusData::STARTING_RACE:
         case ScenarioBonusData::STARTING_RACE_AND_ARMY: {
             std::string description( _( "The starting race of the scenario will be %{race}." ) );
-            StringReplace( description, "%{race}", Race::String( _subType ) );
+            StringReplace( description, "%{race}", Race::String( static_cast<int>( _subType ) ) );
             return description;
         }
         case ScenarioBonusData::SKILL_PRIMARY: {
             std::string description( _( "The main hero will have additional %{count} %{skill} at the start of the scenario." ) );
             StringReplace( description, "%{count}", std::to_string( _amount ) );
-            StringReplace( description, "%{skill}", Skill::Primary::String( _subType ) );
+            StringReplace( description, "%{skill}", Skill::Primary::String( static_cast<int>( _subType ) ) );
             return description;
         }
         case ScenarioBonusData::SKILL_SECONDARY: {
             std::string description( _( "The main hero will have %{skill} at the start of the scenario." ) );
-            StringReplace( description, "%{skill}", Skill::Secondary( _subType, _amount ).GetName() );
+            StringReplace( description, "%{skill}", Skill::Secondary( static_cast<int>( _subType ), static_cast<int>( _amount ) ).GetName() );
             return description;
         }
         default:

--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2021                                                    *
+ *   Copyright (C) 2021 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -460,11 +460,8 @@ namespace Campaign
         , _amount( amount )
     {}
 
-    std::string ScenarioBonusData::ToString() const
+    std::string ScenarioBonusData::getName() const
     {
-        const std::vector<uint32_t> useAmountTypes
-            = { ScenarioBonusData::ARTIFACT, ScenarioBonusData::RESOURCES, ScenarioBonusData::TROOP, ScenarioBonusData::SKILL_PRIMARY };
-
         std::string objectName;
 
         switch ( _type ) {
@@ -492,10 +489,64 @@ namespace Campaign
             break;
         default:
             assert( 0 ); // some new bonus?
+            break;
         }
 
+        const std::vector<uint32_t> useAmountTypes
+            = { ScenarioBonusData::ARTIFACT, ScenarioBonusData::RESOURCES, ScenarioBonusData::TROOP, ScenarioBonusData::SKILL_PRIMARY };
         const bool useAmount = std::find( useAmountTypes.begin(), useAmountTypes.end(), _type ) != useAmountTypes.end() && _amount > 1;
+
         return useAmount ? std::to_string( _amount ) + " " + objectName : objectName;
+    }
+
+    std::string ScenarioBonusData::getDescription() const
+    {
+        switch ( _type ) {
+        case ScenarioBonusData::ARTIFACT: {
+            std::string description( _( "The main hero will have \"%{artifact}\" artifact at the start of the scenario." ) );
+            StringReplace( description, "%{artifact}", Artifact( _subType ).GetName() );
+            return description;
+        }
+        case ScenarioBonusData::RESOURCES: {
+            std::string description( _( "The kingdom will have additional %{amount} %{resource} at the start of the scenario." ) );
+            StringReplace( description, "%{amount}", std::to_string( _amount ) );
+            StringReplace( description, "%{resource}", Resource::String( _subType ) );
+            return description;
+        }
+        case ScenarioBonusData::TROOP: {
+            std::string description( _( "The main hero will have %{count} %{monster} at the start of the scenario." ) );
+            StringReplace( description, "%{count}", std::to_string( _amount ) );
+            StringReplace( description, "%{monster}", Monster( _subType ).GetPluralName( _amount ) );
+            return description;
+        }
+        case ScenarioBonusData::SPELL: {
+            std::string description( _( "The main hero will have \"%{spell}\" spell at the start of the scenario." ) );
+            StringReplace( description, "%{spell}", Spell( _subType ).GetName() );
+            return description;
+        }
+        case ScenarioBonusData::STARTING_RACE:
+        case ScenarioBonusData::STARTING_RACE_AND_ARMY: {
+            std::string description( _( "The starting race of the scenario will be %{race}." ) );
+            StringReplace( description, "%{race}", Race::String( _subType ) );
+            return description;
+        }
+        case ScenarioBonusData::SKILL_PRIMARY: {
+            std::string description( _( "The main hero will have additional %{count} %{skill} at the start of the scenario." ) );
+            StringReplace( description, "%{count}", std::to_string( _amount ) );
+            StringReplace( description, "%{skill}", Skill::Primary::String( _subType ) );
+            return description;
+        }
+        case ScenarioBonusData::SKILL_SECONDARY: {
+            std::string description( _( "The main hero will have %{skill} at the start of the scenario." ) );
+            StringReplace( description, "%{skill}", Skill::Secondary( _subType, _amount ).GetName() );
+            return description;
+        }
+        default:
+            assert( 0 ); // some new bonus?
+            break;
+        }
+
+        return {};
     }
 
     std::vector<ScenarioBonusData> ScenarioBonusData::getCampaignBonusData( const ScenarioInfoId & scenarioInfo )

--- a/src/fheroes2/campaign/campaign_scenariodata.h
+++ b/src/fheroes2/campaign/campaign_scenariodata.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2021                                                    *
+ *   Copyright (C) 2021 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/campaign/campaign_scenariodata.h
+++ b/src/fheroes2/campaign/campaign_scenariodata.h
@@ -104,7 +104,9 @@ namespace Campaign
         friend StreamBase & operator<<( StreamBase & msg, const ScenarioBonusData & data );
         friend StreamBase & operator>>( StreamBase & msg, ScenarioBonusData & data );
 
-        std::string ToString() const;
+        std::string getName() const;
+
+        std::string getDescription() const;
 
         static std::vector<Campaign::ScenarioBonusData> getCampaignBonusData( const ScenarioInfoId & scenarioInfo );
     };

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1004,9 +1004,7 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
             return prevMode;
         }
 
-        if ( !displayScenarioAwardsPopupWindow( campaignSaveData, top ) ) {
-            displayScenarioBonusPopupWindow( scenario, top );
-        }
+        displayScenarioAwardsPopupWindow( campaignSaveData, top ) || displayScenarioBonusPopupWindow( scenario, top );
 
         const bool restartButtonClicked = ( buttonRestart.isEnabled() && le.MouseClickLeft( buttonRestart.area() ) );
 

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -356,7 +356,7 @@ namespace
             return false;
         }
 
-        LocalEvent & le = LocalEvent::Get();
+        const LocalEvent & le = LocalEvent::Get();
 
         for ( size_t i = 0; i < bonuses.size(); ++i ) {
             if ( le.MousePressRight( { top.x + 414, top.y + 198 + 22 * static_cast<int>( i ), 200, 22 } ) ) {
@@ -415,7 +415,7 @@ namespace
         const size_t indexEnd = awardCount <= 4 ? awardCount : 4;
         const int yOffset = awardCount > 3 ? 16 : 22;
 
-        LocalEvent & le = LocalEvent::Get();
+        const LocalEvent & le = LocalEvent::Get();
 
         for ( size_t i = 0; i < indexEnd; ++i ) {
             if ( le.MousePressRight( { top.x + 414, top.y + 100 - yOffset / 2 + yOffset * static_cast<int>( i ), 200, yOffset } ) ) {

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -38,6 +38,8 @@
 #include "settings.h"
 #include "text.h"
 #include "translations.h"
+#include "ui_dialog.h"
+#include "ui_text.h"
 #include "world.h"
 
 namespace
@@ -339,11 +341,32 @@ namespace
         TextBox mapDescription( scenario.getDescription(), Font::BIG, 356 );
         mapDescription.Blit( top.x + 34, top.y + 132 );
 
-        const int textChoiceWidth = 155;
+        const int textChoiceWidth = 160;
         for ( size_t i = 0; i < bonuses.size(); ++i ) {
-            Text choice( bonuses[i].ToString(), Font::BIG );
+            Text choice( bonuses[i].getName(), Font::BIG );
             choice.Blit( top.x + 425, top.y + 209 + 22 * static_cast<int>( i ) - choice.h() / 2, textChoiceWidth );
         }
+    }
+
+    bool displayScenarioBonusPopupWindow( const Campaign::ScenarioData & scenario, const fheroes2::Point & top )
+    {
+        const std::vector<Campaign::ScenarioBonusData> & bonuses = scenario.getBonuses();
+        if ( bonuses.empty() ) {
+            // Nothing to process.
+            return false;
+        }
+
+        LocalEvent & le = LocalEvent::Get();
+
+        for ( size_t i = 0; i < bonuses.size(); ++i ) {
+            if ( le.MousePressRight( { top.x + 414, top.y + 198 + 22 * static_cast<int>( i ), 200, 22 } ) ) {
+                fheroes2::showMessage( fheroes2::Text( bonuses[i].getName(), fheroes2::FontType::normalYellow() ),
+                                       fheroes2::Text( bonuses[i].getDescription(), fheroes2::FontType::normalWhite() ), Dialog::ZERO );
+                return true;
+            }
+        }
+
+        return false;
     }
 
     void drawObtainedCampaignAwards( const Campaign::CampaignSaveData & campaignSaveData, const fheroes2::Point & top )
@@ -363,9 +386,9 @@ namespace
         Text award;
         for ( size_t i = 0; i < indexEnd; ++i ) {
             if ( i < 3 )
-                award.Set( obtainedAwards[i].ToString(), Font::BIG );
+                award.Set( obtainedAwards[i].getName(), Font::BIG );
             else // if we have exactly 4 obtained awards, display the fourth award, otherwise show "and more..."
-                award.Set( awardCount == 4 ? obtainedAwards[i].ToString() : std::string( _( "and more..." ) ), Font::BIG );
+                award.Set( awardCount == 4 ? obtainedAwards[i].getName() : std::string( _( "and more..." ) ), Font::BIG );
 
             if ( award.w() > textAwardWidth ) {
                 award.Blit( top.x + 425, top.y + 100 + yOffset * static_cast<int>( i ) - award.h() / 2, textAwardWidth );
@@ -374,6 +397,35 @@ namespace
                 award.Blit( top.x + 425 + ( textAwardWidth - award.w() ) / 2, top.y + 100 + yOffset * static_cast<int>( i ) - award.h() / 2 );
             }
         }
+    }
+
+    bool displayScenarioAwardsPopupWindow( const Campaign::CampaignSaveData & campaignSaveData, const fheroes2::Point & top )
+    {
+        if ( isBetrayalScenario( campaignSaveData.getCurrentScenarioInfoId() ) ) {
+            return false;
+        }
+
+        const std::vector<Campaign::CampaignAwardData> obtainedAwards = campaignSaveData.getObtainedCampaignAwards();
+        if ( obtainedAwards.empty() ) {
+            // Nothing to process.
+            return false;
+        }
+
+        const size_t awardCount = obtainedAwards.size();
+        const size_t indexEnd = awardCount <= 4 ? awardCount : 4;
+        const int yOffset = awardCount > 3 ? 16 : 22;
+
+        LocalEvent & le = LocalEvent::Get();
+
+        for ( size_t i = 0; i < indexEnd; ++i ) {
+            if ( le.MousePressRight( { top.x + 414, top.y + 100 - yOffset / 2 + yOffset * static_cast<int>( i ), 200, yOffset } ) ) {
+                fheroes2::showMessage( fheroes2::Text( obtainedAwards[i].getName(), fheroes2::FontType::normalYellow() ),
+                                       fheroes2::Text( obtainedAwards[i].getDescription(), fheroes2::FontType::normalWhite() ), Dialog::ZERO );
+                return true;
+            }
+        }
+
+        return false;
     }
 
     void replaceArmy( Army & army, const std::vector<Troop> & troops )
@@ -658,7 +710,7 @@ namespace
         else {
             COUT( "Awards:" )
             for ( const Campaign::CampaignAwardData & award : obtainedAwards ) {
-                COUT( "- " << award.ToString() )
+                COUT( "- " << award.getName() << " : " << award.getDescription() )
             }
         }
 
@@ -950,6 +1002,10 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
 
         if ( le.MouseClickLeft( buttonCancel.area() ) || HotKeyPressEvent( EVENT_DEFAULT_EXIT ) ) {
             return prevMode;
+        }
+
+        if ( !displayScenarioAwardsPopupWindow( campaignSaveData, top ) ) {
+            displayScenarioBonusPopupWindow( scenario, top );
         }
 
         const bool restartButtonClicked = ( buttonRestart.isEnabled() && le.MouseClickLeft( buttonRestart.area() ) );

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2020                                                    *
+ *   Copyright (C) 2020 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *


### PR DESCRIPTION
- add popup windows for campaign awards and bonuses ( close #4501 )
- increase bonus name area name by 5 pixels to accommodate long names
- fix award name not being translated after language switching