### PR TITLE
Check for the git failures in pipelines

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -30,6 +30,7 @@ jobs:
         mkdir clang-tidy-result
     - name: Analyze
       run: |
+        set -o pipefail
         git diff -U0 HEAD^ | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
     - name: Save PR metadata
       run: |

--- a/script/tools/check_code_format.sh
+++ b/script/tools/check_code_format.sh
@@ -18,7 +18,9 @@
 #
 # This script assumes to be invoked at the project root directory.
 
-FILES_TO_CHECK=$(git diff --name-only HEAD^ | grep -E ".*\.(cpp|cc|c\+\+|cxx|c|h|hpp)$")
+set -e -o pipefail
+
+FILES_TO_CHECK=$(git diff --name-only HEAD^ | (grep -E ".*\.(cpp|cc|c\+\+|cxx|c|h|hpp)$" || true))
 
 if [ -z "${FILES_TO_CHECK}" ]; then
   echo "No source code to check for formatting."

--- a/script/tools/check_copyright_headers.sh
+++ b/script/tools/check_copyright_headers.sh
@@ -5,7 +5,9 @@
 #
 # This script assumes to be invoked at the project root directory.
 
-FILES_TO_CHECK=$(git diff --name-only HEAD^ | grep -E ".*\.(cpp|cc|c\+\+|cxx|c|h|hpp)$")
+set -e -o pipefail
+
+FILES_TO_CHECK=$(git diff --name-only HEAD^ | (grep -E ".*\.(cpp|cc|c\+\+|cxx|c|h|hpp)$" || true))
 
 if [ -z "$FILES_TO_CHECK" ]; then
   echo "No source code to check if the copyright headers are correct."


### PR DESCRIPTION
Related to #5072

Previously, `git` failures in pipelines were not detected and everything went like the `git` output was just empty. Now such failures will be detected like [here](https://github.com/ihhub/fheroes2/runs/5439323484?check_suite_focus=true) and [here](https://github.com/ihhub/fheroes2/runs/5439323619?check_suite_focus=true) - just in case if `fetch-depth: 50` will not be deep enough.