### PR TITLE
Added search for FLAC files if Ogg files aren't found

### DIFF
--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -22,6 +22,11 @@
  ***************************************************************************/
 
 #include <algorithm>
+
+#if !defined( __APPLE__ ) || !defined( __MACH__ )
+#include <cassert>
+#endif
+
 #include <cctype>
 #include <cmath>
 #include <cstdlib>

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -417,6 +417,8 @@ namespace fheroes2
 
     void replaceStringEnding( std::string & output, const char * originalEnding, const char * correctedEnding )
     {
+        assert( originalEnding != nullptr && correctedEnding != nullptr );
+
         const size_t originalEndingSize = strlen( originalEnding );
         const size_t correctedEndingSize = strlen( correctedEnding );
         if ( output.size() < originalEndingSize ) {

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -22,11 +22,7 @@
  ***************************************************************************/
 
 #include <algorithm>
-
-#if !defined( __APPLE__ ) || !defined( __MACH__ )
 #include <cassert>
-#endif
-
 #include <cctype>
 #include <cmath>
 #include <cstdlib>

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -414,4 +414,21 @@ namespace fheroes2
 
         return ~crc;
     }
+
+    void replaceStringEnding( std::string & output, const char * originalEnding, const char * correctedEnding )
+    {
+        const size_t originalEndingSize = strlen( originalEnding );
+        const size_t correctedEndingSize = strlen( correctedEnding );
+        if ( output.size() < originalEndingSize ) {
+            // The original string is smaller than the ending.
+            return;
+        }
+
+        if ( memcmp( output.data() + output.size() - originalEndingSize, originalEnding, originalEndingSize ) != 0 ) {
+            // The string does not have the required ending.
+            return;
+        }
+
+        output.replace( output.size() - originalEndingSize, originalEndingSize, correctedEnding, correctedEndingSize );
+    }
 }

--- a/src/engine/tools.h
+++ b/src/engine/tools.h
@@ -90,6 +90,8 @@ namespace fheroes2
         }
         return result;
     }
+
+    void replaceStringEnding( std::string & output, const char * originalEnding, const char * correctedEnding );
 }
 
 #endif

--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -550,22 +550,35 @@ void AGG::PlayMusicInternally( const int mus, const MusicSource musicType, const
         std::string filename = Settings::GetLastFile( prefix_music, MUS::GetString( mus, MUS::OGG_MUSIC_TYPE::DOS_VERSION ) );
 
         if ( !System::IsFile( filename ) ) {
-            filename = Settings::GetLastFile( prefix_music, MUS::GetString( mus, MUS::OGG_MUSIC_TYPE::WIN_VERSION ) );
+            StringReplace( filename, ".ogg", ".flac" );
+
             if ( !System::IsFile( filename ) ) {
-                filename.clear();
+                filename = Settings::GetLastFile( prefix_music, MUS::GetString( mus, MUS::OGG_MUSIC_TYPE::WIN_VERSION ) );
+                if ( !System::IsFile( filename ) ) {
+                    StringReplace( filename, ".ogg", ".flac" );
+
+                    if ( !System::IsFile( filename ) ) {
+                        filename.clear();
+                    }
+                }
             }
-        }
 
-        if ( filename.empty() ) {
-            filename = Settings::GetLastFile( prefix_music, MUS::GetString( mus, MUS::OGG_MUSIC_TYPE::MAPPED ) );
-
-            if ( !System::IsFile( filename ) ) {
-                StringReplace( filename, ".ogg", ".mp3" );
+            if ( filename.empty() ) {
+                filename = Settings::GetLastFile( prefix_music, MUS::GetString( mus, MUS::OGG_MUSIC_TYPE::MAPPED ) );
 
                 if ( !System::IsFile( filename ) ) {
-                    DEBUG_LOG( DBG_ENGINE, DBG_WARN,
-                               "error read file: " << Settings::GetLastFile( prefix_music, MUS::GetString( mus, MUS::OGG_MUSIC_TYPE::MAPPED ) ) << ", skipping..." );
-                    filename.clear();
+                    StringReplace( filename, ".ogg", ".mp3" );
+
+                    if ( !System::IsFile( filename ) ) {
+                        StringReplace( filename, ".mp3", ".flac" );
+
+                        if ( !System::IsFile( filename ) ) {
+                            DEBUG_LOG( DBG_ENGINE, DBG_WARN,
+                                       "error read file: " << Settings::GetLastFile( prefix_music, MUS::GetString( mus, MUS::OGG_MUSIC_TYPE::MAPPED ) )
+                                                           << ", skipping..." );
+                            filename.clear();
+                        }
+                    }
                 }
             }
         }

--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -550,12 +550,15 @@ void AGG::PlayMusicInternally( const int mus, const MusicSource musicType, const
         std::string filename = Settings::GetLastFile( prefix_music, MUS::GetString( mus, MUS::OGG_MUSIC_TYPE::DOS_VERSION ) );
 
         if ( !System::IsFile( filename ) ) {
-            StringReplace( filename, ".ogg", ".flac" );
+            fheroes2::replaceStringEnding( filename, ".ogg", ".flac" );
+            filename = Settings::GetLastFile( prefix_music, filename );
 
             if ( !System::IsFile( filename ) ) {
                 filename = Settings::GetLastFile( prefix_music, MUS::GetString( mus, MUS::OGG_MUSIC_TYPE::WIN_VERSION ) );
+
                 if ( !System::IsFile( filename ) ) {
-                    StringReplace( filename, ".ogg", ".flac" );
+                    fheroes2::replaceStringEnding( filename, ".ogg", ".flac" );
+                    filename = Settings::GetLastFile( prefix_music, filename );
 
                     if ( !System::IsFile( filename ) ) {
                         filename.clear();
@@ -567,10 +570,12 @@ void AGG::PlayMusicInternally( const int mus, const MusicSource musicType, const
                 filename = Settings::GetLastFile( prefix_music, MUS::GetString( mus, MUS::OGG_MUSIC_TYPE::MAPPED ) );
 
                 if ( !System::IsFile( filename ) ) {
-                    StringReplace( filename, ".ogg", ".mp3" );
+                    fheroes2::replaceStringEnding( filename, ".ogg", ".mp3" );
+                    filename = Settings::GetLastFile( prefix_music, filename );
 
                     if ( !System::IsFile( filename ) ) {
-                        StringReplace( filename, ".mp3", ".flac" );
+                        fheroes2::replaceStringEnding( filename, ".ogg", ".flac" );
+                        filename = Settings::GetLastFile( prefix_music, filename );
 
                         if ( !System::IsFile( filename ) ) {
                             DEBUG_LOG( DBG_ENGINE, DBG_WARN,


### PR DESCRIPTION
This adds a search for FLAC files if Ogg files aren't found.  There don't seem to need to be any other changes, as SDL_mixer takes care of playback, though it does depend on SDL_mixer being compiled with FLAC support.