### PR TITLE
Fix some issues with UI windows

### DIFF
--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -90,7 +90,7 @@ namespace Dialog
     void QuickInfo( const HeroBase & hero, const fheroes2::Rect & activeArea, const fheroes2::Point & position = fheroes2::Point() );
     int Message( const std::string &, const std::string &, int ft, int buttons = 0 /* buttons: OK : CANCEL : OK|CANCEL : YES|NO */ );
     void ExtSettings( bool );
-    int LevelUpSelectSkill( const std::string &, const std::string &, const Skill::Secondary &, const Skill::Secondary &, Heroes & );
+    int LevelUpSelectSkill( const std::string & name, const int primarySkillType, const Skill::Secondary & sec1, const Skill::Secondary & sec2, Heroes & hero );
     bool SelectGoldOrExp( const std::string &, const std::string &, u32 gold, u32 expr, const Heroes & );
     int SelectSkillFromArena( void );
     bool SelectCount( const std::string &, u32 min, u32 max, u32 & res, int step = 1 );

--- a/src/fheroes2/dialog/dialog_levelup.cpp
+++ b/src/fheroes2/dialog/dialog_levelup.cpp
@@ -35,55 +35,45 @@
 #include "ui_dialog.h"
 #include "ui_text.h"
 
-void DialogPrimaryOnly( const std::string & name, const std::string & primary )
+void DialogPrimaryOnly( const std::string & name, const int primarySkillType )
 {
     std::string message = _( "%{name} has gained a level." );
     message.append( "\n \n" );
     message.append( _( "%{skill} +1" ) );
     StringReplace( message, "%{name}", name );
-    StringReplace( message, "%{skill}", primary );
-    Dialog::Message( "", message, Font::BIG, Dialog::OK );
+    StringReplace( message, "%{skill}", Skill::Primary::String( primarySkillType ) );
+
+    const fheroes2::PrimarySkillDialogElement primarySkillUI( primarySkillType, "+1" );
+
+    fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( message, fheroes2::FontType::normalWhite() ), Dialog::OK, { &primarySkillUI } );
 }
 
-int DialogOneSecondary( const std::string & name, const std::string & primary, const Skill::Secondary & sec )
+int DialogOneSecondary( Heroes & hero, const std::string & name, const int primarySkillType, const Skill::Secondary & sec )
 {
     std::string message = _( "%{name} has gained a level." );
     message.append( "\n \n" );
     message.append( _( "%{skill} +1" ) );
     StringReplace( message, "%{name}", name );
-    StringReplace( message, "%{skill}", primary );
+    StringReplace( message, "%{skill}", Skill::Primary::String( primarySkillType ) );
 
     message.append( "\n \n" );
     message.append( _( "You have learned %{skill}." ) );
     StringReplace( message, "%{skill}", sec.GetName() );
 
-    const fheroes2::Sprite & sprite_frame = fheroes2::AGG::GetICN( ICN::SECSKILL, 15 );
+    const fheroes2::SecondarySkillDialogElement secondarySkillUI( sec, hero );
 
-    // Create a surface with no alpha mode to fix SDL 1
-    fheroes2::Sprite drawSurface = sprite_frame;
-
-    // sprite
-    const fheroes2::Sprite & sprite_skill = fheroes2::AGG::GetICN( ICN::SECSKILL, sec.GetIndexSprite1() );
-    fheroes2::Blit( sprite_skill, drawSurface, 3, 3 );
-    // text
-    Text text_skill( Skill::Secondary::String( sec.Skill() ), Font::SMALL );
-    text_skill.Blit( 3 + ( sprite_skill.width() - text_skill.w() ) / 2, 6, drawSurface );
-    Text text_level( Skill::Level::String( sec.Level() ), Font::SMALL );
-    text_level.Blit( 3 + ( sprite_skill.width() - text_level.w() ) / 2, sprite_skill.height() - 12, drawSurface );
-
-    const fheroes2::CustomImageDialogElement imageUI( std::move( drawSurface ) );
-    fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( message, fheroes2::FontType::normalWhite() ), Dialog::OK, { &imageUI } );
+    fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( message, fheroes2::FontType::normalWhite() ), Dialog::OK, { &secondarySkillUI } );
 
     return sec.Skill();
 }
 
-int DialogSelectSecondary( const std::string & name, const std::string & primary, const Skill::Secondary & sec1, const Skill::Secondary & sec2, Heroes & hero )
+int DialogSelectSecondary( const std::string & name, const int primarySkillType, const Skill::Secondary & sec1, const Skill::Secondary & sec2, Heroes & hero )
 {
     std::string header = _( "%{name} has gained a level." );
     header.append( "\n \n" );
     header.append( _( "%{skill} +1" ) );
     StringReplace( header, "%{name}", name );
-    StringReplace( header, "%{skill}", primary );
+    StringReplace( header, "%{skill}", Skill::Primary::String( primarySkillType ) );
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -216,16 +206,16 @@ int DialogSelectSecondary( const std::string & name, const std::string & primary
     return Skill::Secondary::UNKNOWN;
 }
 
-int Dialog::LevelUpSelectSkill( const std::string & name, const std::string & primary, const Skill::Secondary & sec1, const Skill::Secondary & sec2, Heroes & hero )
+int Dialog::LevelUpSelectSkill( const std::string & name, const int primarySkillType, const Skill::Secondary & sec1, const Skill::Secondary & sec2, Heroes & hero )
 {
     int result = Skill::Secondary::UNKNOWN;
 
     if ( Skill::Secondary::UNKNOWN == sec1.Skill() && Skill::Secondary::UNKNOWN == sec2.Skill() )
-        DialogPrimaryOnly( name, primary );
+        DialogPrimaryOnly( name, primarySkillType );
     else if ( Skill::Secondary::UNKNOWN == sec1.Skill() || Skill::Secondary::UNKNOWN == sec2.Skill() )
-        result = DialogOneSecondary( name, primary, ( Skill::Secondary::UNKNOWN == sec2.Skill() ? sec1 : sec2 ) );
+        result = DialogOneSecondary( hero, name, primarySkillType, ( Skill::Secondary::UNKNOWN == sec2.Skill() ? sec1 : sec2 ) );
     else
-        result = DialogSelectSecondary( name, primary, sec1, sec2, hero );
+        result = DialogSelectSecondary( name, primarySkillType, sec1, sec2, hero );
 
     return result;
 }

--- a/src/fheroes2/dialog/dialog_levelup.cpp
+++ b/src/fheroes2/dialog/dialog_levelup.cpp
@@ -48,7 +48,7 @@ void DialogPrimaryOnly( const std::string & name, const int primarySkillType )
     fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( message, fheroes2::FontType::normalWhite() ), Dialog::OK, { &primarySkillUI } );
 }
 
-int DialogOneSecondary( Heroes & hero, const std::string & name, const int primarySkillType, const Skill::Secondary & sec )
+int DialogOneSecondary( const Heroes & hero, const std::string & name, const int primarySkillType, const Skill::Secondary & sec )
 {
     std::string message = _( "%{name} has gained a level." );
     message.append( "\n \n" );

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -991,7 +991,7 @@ bool Heroes::PickupArtifact( const Artifact & art )
     if ( isControlHuman() ) {
         for ( const ArtifactSetData & artifactSetData : assembledArtifacts ) {
             const fheroes2::ArtifactDialogElement artifactUI( artifactSetData._assembledArtifactID );
-            fheroes2::showMessage( fheroes2::Text( Artifact( artifactSetData._assembledArtifactID ).GetName(), fheroes2::FontType::normalYellow() ),
+            fheroes2::showMessage( fheroes2::Text( Artifact( static_cast<int>( artifactSetData._assembledArtifactID ) ).GetName(), fheroes2::FontType::normalYellow() ),
                                    fheroes2::Text( _( artifactSetData._assembleMessage ), fheroes2::FontType::normalWhite() ), Dialog::OK, { &artifactUI } );
         }
     }

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -992,8 +992,7 @@ bool Heroes::PickupArtifact( const Artifact & art )
         for ( const ArtifactSetData & artifactSetData : assembledArtifacts ) {
             const fheroes2::ArtifactDialogElement artifactUI( artifactSetData._assembledArtifactID );
             fheroes2::showMessage( fheroes2::Text( Artifact( artifactSetData._assembledArtifactID ).GetName(), fheroes2::FontType::normalYellow() ),
-                                   fheroes2::Text( _( artifactSetData._assembleMessage ), fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                   { &artifactUI } );
+                                   fheroes2::Text( _( artifactSetData._assembleMessage ), fheroes2::FontType::normalWhite() ), Dialog::OK, { &artifactUI } );
         }
     }
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -991,7 +991,8 @@ bool Heroes::PickupArtifact( const Artifact & art )
     if ( isControlHuman() ) {
         for ( const ArtifactSetData & artifactSetData : assembledArtifacts ) {
             const fheroes2::ArtifactDialogElement artifactUI( artifactSetData._assembledArtifactID );
-            fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( _( artifactSetData._assembleMessage ), fheroes2::FontType::normalWhite() ), Dialog::OK,
+            fheroes2::showMessage( fheroes2::Text( Artifact( artifactSetData._assembledArtifactID ).GetName(), fheroes2::FontType::normalYellow() ),
+                                   fheroes2::Text( _( artifactSetData._assembleMessage ), fheroes2::FontType::normalWhite() ), Dialog::OK,
                                    { &artifactUI } );
         }
     }
@@ -1392,7 +1393,7 @@ void Heroes::LevelUpSecondarySkill( const HeroSeedsForLevelUp & seeds, int prima
     }
     else {
         AGG::PlaySound( M82::NWHEROLV );
-        int result = Dialog::LevelUpSelectSkill( name, Skill::Primary::String( primary ), sec1, sec2, *this );
+        int result = Dialog::LevelUpSelectSkill( name, primary, sec1, sec2, *this );
 
         if ( Skill::Secondary::UNKNOWN != result )
             selected = result == sec2.Skill() ? sec2 : sec1;

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1222,7 +1222,7 @@ void ActionToWitchsHut( Heroes & hero, const MP2::MapObjectType objectType, s32 
             StringReplace( msg, "%{skill}", skill_name );
 
             const fheroes2::SecondarySkillDialogElement secondarySkillUI( skill, hero );
-            fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( title, fheroes2::FontType::normalWhite() ), Dialog::OK,
+            fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK,
                                    { &secondarySkillUI } );
         }
     }
@@ -2765,11 +2765,13 @@ void ActionToTreeKnowledge( Heroes & hero, const MP2::MapObjectType objectType, 
                 StringReplace( msg, "%{res}", Resource::String( rc.first ) );
                 StringReplace( msg, "%{count}", rc.second );
 
-                const fheroes2::CustomImageDialogElement imageUI( fheroes2::AGG::GetICN( ICN::EXPMRL, 4 ) );
+                const uint32_t possibleExperience = Heroes::GetExperienceFromLevel( hero.GetLevel() ) - hero.GetExperience();
+
+                const fheroes2::ExperienceDialogElement experienceUI( possibleExperience );
                 const fheroes2::Text titleUI( title, fheroes2::FontType::normalYellow() );
                 const fheroes2::Text messageUI( msg, fheroes2::FontType::normalWhite() );
 
-                conditions = ( fheroes2::showMessage( titleUI, messageUI, Dialog::YES | Dialog::NO, { &imageUI } ) == Dialog::YES );
+                conditions = ( fheroes2::showMessage( titleUI, messageUI, Dialog::YES | Dialog::NO, { &experienceUI } ) == Dialog::YES );
             }
             else {
                 msg = _( "Tears brim in the eyes of the tree." );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2767,7 +2767,7 @@ void ActionToTreeKnowledge( Heroes & hero, const MP2::MapObjectType objectType, 
 
                 const uint32_t possibleExperience = Heroes::GetExperienceFromLevel( hero.GetLevel() ) - hero.GetExperience();
 
-                const fheroes2::ExperienceDialogElement experienceUI( possibleExperience );
+                const fheroes2::ExperienceDialogElement experienceUI( static_cast<int32_t>( possibleExperience ) );
                 const fheroes2::Text titleUI( title, fheroes2::FontType::normalYellow() );
                 const fheroes2::Text messageUI( msg, fheroes2::FontType::normalWhite() );
 

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -464,7 +464,8 @@ void Heroes::MeetingDialog( Heroes & otherHero )
 
             for ( const ArtifactSetData & artifactSetData : assembledArtifacts ) {
                 const fheroes2::ArtifactDialogElement artifactUI( artifactSetData._assembledArtifactID );
-                fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( _( artifactSetData._assembleMessage ), fheroes2::FontType::normalWhite() ), Dialog::OK,
+                fheroes2::showMessage( fheroes2::Text( Artifact( artifactSetData._assembledArtifactID ).GetName(), fheroes2::FontType::normalYellow() ),
+                                       fheroes2::Text( _( artifactSetData._assembleMessage ), fheroes2::FontType::normalWhite() ), Dialog::OK,
                                        { &artifactUI } );
             }
 

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -464,7 +464,8 @@ void Heroes::MeetingDialog( Heroes & otherHero )
 
             for ( const ArtifactSetData & artifactSetData : assembledArtifacts ) {
                 const fheroes2::ArtifactDialogElement artifactUI( artifactSetData._assembledArtifactID );
-                fheroes2::showMessage( fheroes2::Text( Artifact( artifactSetData._assembledArtifactID ).GetName(), fheroes2::FontType::normalYellow() ),
+                fheroes2::showMessage( fheroes2::Text( Artifact( static_cast<int>( artifactSetData._assembledArtifactID ) ).GetName(),
+                                                       fheroes2::FontType::normalYellow() ),
                                        fheroes2::Text( _( artifactSetData._assembleMessage ), fheroes2::FontType::normalWhite() ), Dialog::OK, { &artifactUI } );
             }
 

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -465,8 +465,7 @@ void Heroes::MeetingDialog( Heroes & otherHero )
             for ( const ArtifactSetData & artifactSetData : assembledArtifacts ) {
                 const fheroes2::ArtifactDialogElement artifactUI( artifactSetData._assembledArtifactID );
                 fheroes2::showMessage( fheroes2::Text( Artifact( artifactSetData._assembledArtifactID ).GetName(), fheroes2::FontType::normalYellow() ),
-                                       fheroes2::Text( _( artifactSetData._assembleMessage ), fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                       { &artifactUI } );
+                                       fheroes2::Text( _( artifactSetData._assembleMessage ), fheroes2::FontType::normalWhite() ), Dialog::OK, { &artifactUI } );
             }
 
             selectArtifacts1.Redraw();


### PR DESCRIPTION
- for hero level up window with no secondary skill display the primary skill icon ( close #5102 )
- for hero level up window with one secondary skill make the skill right clickable ( close #5099 )
- for Anduran assembly window show artifact name as a title ( close #5100 )
- fix Witch's Hut message body ( close #5097 )
- display experience amount for Tree of Knowledge ( close #5092 )