### PR TITLE
Let the hero surrender to the captain during the siege

### DIFF
--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -956,9 +956,9 @@ int32_t Battle::Arena::GetFreePositionNearHero( const int heroColor ) const
 
 bool Battle::Arena::CanSurrenderOpponent( int color ) const
 {
-    const HeroBase * hero1 = getEnemyCommander( color );
-    const HeroBase * hero2 = getCommander( color );
-    return hero1 && hero1->isHeroes() && hero2 && hero2->isHeroes() && !world.GetKingdom( hero2->GetColor() ).GetCastles().empty();
+    const HeroBase * hero = getCommander( color );
+    const HeroBase * enemyHero = getEnemyCommander( color );
+    return hero && hero->isHeroes() && enemyHero && ( enemyHero->isHeroes() || enemyHero->isCaptain() ) && !world.GetKingdom( hero->GetColor() ).GetCastles().empty();
 }
 
 bool Battle::Arena::CanRetreatOpponent( int color ) const

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -967,7 +967,7 @@ bool Battle::DialogBattleSurrender( const HeroBase & hero, u32 cost, Kingdom & k
     fheroes2::Blit( window, display, pos_rt.x + 55, pos_rt.y + 32 );
     hero.PortraitRedraw( pos_rt.x + 60, pos_rt.y + 38, PORT_BIG, display );
 
-    std::string str = _( "%{name} states:" );
+    std::string str = hero.isCaptain() ? _( "Captain of %{name} states:" ) : _( "%{name} states:" );
     StringReplace( str, "%{name}", hero.GetName() );
     Text text( str, Font::BIG );
     text.Blit( pos_rt.x + 320 - text.w() / 2, pos_rt.y + 30 );


### PR DESCRIPTION
fix #5107

Currently the captain has the name of the castle instead of just "Captain". I like it better so I left it as it is.