### PR TITLE
Add MP3 file support

### DIFF
--- a/src/engine/agg_file.cpp
+++ b/src/engine/agg_file.cpp
@@ -24,11 +24,6 @@
 
 namespace fheroes2
 {
-    bool AGGFile::isGood() const
-    {
-        return !_stream.fail() && !_files.empty();
-    }
-
     bool AGGFile::open( const std::string & fileName )
     {
         if ( !_stream.open( fileName, "rb" ) )

--- a/src/engine/agg_file.cpp
+++ b/src/engine/agg_file.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2020                                                    *
+ *   Copyright (C) 2020 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/engine/agg_file.h
+++ b/src/engine/agg_file.h
@@ -37,7 +37,11 @@ namespace fheroes2
             // Avoid C4592 warning in Visual Studio.
         }
 
-        bool isGood() const;
+        bool isGood() const
+        {
+            return !_stream.fail() && !_files.empty();
+        }
+
         bool open( const std::string & fileName );
         std::vector<uint8_t> read( const std::string & fileName );
 

--- a/src/engine/agg_file.h
+++ b/src/engine/agg_file.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2020                                                    *
+ *   Copyright (C) 2020 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -133,8 +133,8 @@ void Audio::Init()
         const int initializationFlags = MIX_INIT_FLAC | MIX_INIT_MOD | MIX_INIT_MP3 | MIX_INIT_OGG;
         const int initializedFlags = Mix_Init( initializationFlags );
         if ( ( initializedFlags & initializationFlags ) != initializationFlags ) {
-            DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "Expected music initialization flags as " << initializationFlags << " but received "
-                       << ( initializedFlags & initializationFlags ) )
+            DEBUG_LOG( DBG_ENGINE, DBG_TRACE,
+                       "Expected music initialization flags as " << initializationFlags << " but received " << ( initializedFlags & initializationFlags ) )
         }
 #endif
         hardware.freq = 22050;

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -133,7 +133,7 @@ void Audio::Init()
         const int initializationFlags = MIX_INIT_FLAC | MIX_INIT_MOD | MIX_INIT_MP3 | MIX_INIT_OGG;
         const int initializedFlags = Mix_Init( initializationFlags );
         if ( ( initializedFlags & initializationFlags ) != initializationFlags ) {
-            DEBUG_LOG( DBG_ENGINE, DBG_TRACE,
+            DEBUG_LOG( DBG_ENGINE, DBG_WARN,
                        "Expected music initialization flags as " << initializationFlags << " but received " << ( initializedFlags & initializationFlags ) )
         }
 #endif

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -130,7 +130,12 @@ void Audio::Init()
 
     if ( fheroes2::isComponentInitialized( fheroes2::SystemInitializationComponent::Audio ) ) {
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
-        Mix_Init( MIX_INIT_OGG | MIX_INIT_MP3 | MIX_INIT_MOD );
+        const int initializationFlags = MIX_INIT_FLAC | MIX_INIT_MOD | MIX_INIT_MP3 | MIX_INIT_OGG;
+        const int initializedFlags = Mix_Init( initializationFlags );
+        if ( ( initializedFlags & initializationFlags ) != initializationFlags ) {
+            DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "Expected music initialization flags as " << initializationFlags << " but received "
+                       << ( initializedFlags & initializationFlags ) )
+        }
 #endif
         hardware.freq = 22050;
         hardware.format = AUDIO_S16;

--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -75,28 +75,28 @@ namespace
         possibleFilenames.reserve( directories.size() );
 
         for ( const std::string & dir : directories ) {
-            possibleFilenames.emplace_back( System::ConcatePath( dir, MUS::getFileName( musicTrackId, musicType, ".ogg" ) ) );
+            possibleFilenames.emplace_back( System::ConcatePath( dir, MUS::getFileName( musicTrackId, musicType, ".flac" ) ) );
         }
 
-        // Search for OGG files.
+        // Search for FLAC files as they have the best audio quality.
         for ( const std::string & filename : possibleFilenames ) {
             if ( System::IsFile( filename ) ) {
                 return filename;
             }
         }
 
-        // None of OGG files found. Try MP3 files.
+        // None of FLAC files found. Try OGG files.
         for ( std::string & filename : possibleFilenames ) {
-            fheroes2::replaceStringEnding( filename, ".ogg", ".mp3" );
+            fheroes2::replaceStringEnding( filename, ".flac", ".ogg" );
 
             if ( System::IsFile( filename ) ) {
                 return filename;
             }
         }
 
-        // No luck with even MP3. Try with FLAC.
+        // No luck with even OGG. Try with MP3.
         for ( std::string & filename : possibleFilenames ) {
-            fheroes2::replaceStringEnding( filename, ".mp3", ".flac" );
+            fheroes2::replaceStringEnding( filename, ".ogg", ".mp3" );
 
             if ( System::IsFile( filename ) ) {
                 return filename;

--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -620,7 +620,7 @@ void AGG::PlayMusicInternally( const int mus, const MusicSource musicType, const
         }
 
         if ( filename.empty() ) {
-            DEBUG_LOG( DBG_ENGINE, DBG_WARN, "Cannot find a file for " << mus << " track." );
+            DEBUG_LOG( DBG_ENGINE, DBG_WARN, "Cannot find a file for " << mus << " track." )
         }
         else {
             Music::Play( filename, loop );
@@ -628,7 +628,7 @@ void AGG::PlayMusicInternally( const int mus, const MusicSource musicType, const
 
             Game::SetCurrentMusic( mus );
 
-            DEBUG_LOG( DBG_ENGINE, DBG_TRACE, MUS::getFileName( mus, MUS::OGG_MUSIC_TYPE::MAPPED, ".ogg" ) );
+            DEBUG_LOG( DBG_ENGINE, DBG_TRACE, MUS::getFileName( mus, MUS::OGG_MUSIC_TYPE::MAPPED, ".ogg" ) )
         }
     }
 

--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -624,7 +624,7 @@ void AGG::PlayMusicInternally( const int mus, const MusicSource musicType, const
 
             Game::SetCurrentMusic( mus );
 
-            DEBUG_LOG( DBG_ENGINE, DBG_TRACE, MUS::getFileName( mus, MUS::EXTERNAL_MUSIC_TYPE::MAPPED, nullptr ) )
+            DEBUG_LOG( DBG_ENGINE, DBG_TRACE, MUS::getFileName( mus, MUS::EXTERNAL_MUSIC_TYPE::MAPPED, " " ) )
 
             return;
         }
@@ -649,13 +649,6 @@ void AGG::PlayMusicInternally( const int mus, const MusicSource musicType, const
         }
     }
     DEBUG_LOG( DBG_ENGINE, DBG_TRACE, XMI::GetString( xmi ) );
-}
-
-// This exists to avoid exposing AGG::ReadChunk
-std::vector<u8> AGG::LoadBINFRM( const char * frm_file )
-{
-    DEBUG_LOG( DBG_ENGINE, DBG_TRACE, frm_file );
-    return AGG::ReadChunk( frm_file );
 }
 
 void AGG::ResetAudio()

--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -46,6 +46,67 @@
 #include "xmi.h"
 #include "zzlib.h"
 
+namespace
+{
+    const std::string externalMusicDirectory( "music" );
+
+    std::vector<std::string> getMusicDirectories()
+    {
+        std::vector<std::string> directories;
+        for ( const std::string & dir : Settings::GetRootDirs() ) {
+            std::string fullDirectoryPath = System::ConcatePath( dir, externalMusicDirectory );
+            if ( System::IsDirectory( fullDirectoryPath ) ) {
+                directories.emplace_back( std::move( fullDirectoryPath ) );
+            }
+        }
+
+        return directories;
+    }
+
+    std::string getExternalMusicFile( const int musicTrackId, const MUS::OGG_MUSIC_TYPE musicType, const std::vector<std::string> & directories )
+    {
+        if ( directories.empty() ) {
+            // Nothing to search.
+            return {};
+        }
+
+        // Instead of relying some generic functions we want to have maximum performance as I/O operations are the slowest.
+        std::vector<std::string> possibleFilenames;
+        possibleFilenames.reserve( directories.size() );
+
+        for ( const std::string & dir : directories ) {
+            possibleFilenames.emplace_back( System::ConcatePath( dir, MUS::getFileName( musicTrackId, musicType, ".ogg" ) ) );
+        }
+
+        // Search for OGG files.
+        for ( const std::string & filename : possibleFilenames ) {
+            if ( System::IsFile( filename ) ) {
+                return filename;
+            }
+        }
+
+        // None of OGG files found. Try MP3 files.
+        for ( std::string & filename : possibleFilenames ) {
+            fheroes2::replaceStringEnding( filename, ".ogg", ".mp3" );
+
+            if ( System::IsFile( filename ) ) {
+                return filename;
+            }
+        }
+
+        // No luck with even MP3. Try with FLAC.
+        for ( std::string & filename : possibleFilenames ) {
+            fheroes2::replaceStringEnding( filename, ".mp3", ".flac" );
+            if ( System::IsFile( filename ) ) {
+                return filename;
+            }
+        }
+
+        // Looks like music file does not exist.
+        return {};
+    }
+}
+
 namespace AGG
 {
     struct loop_sound_t
@@ -547,54 +608,28 @@ void AGG::PlayMusicInternally( const int mus, const MusicSource musicType, const
     bool isSongFound = false;
 
     if ( musicType == MUSIC_EXTERNAL ) {
-        std::string filename = Settings::GetLastFile( prefix_music, MUS::GetString( mus, MUS::OGG_MUSIC_TYPE::DOS_VERSION ) );
+        const std::vector<std::string> & musicDirectories = getMusicDirectories();
 
-        if ( !System::IsFile( filename ) ) {
-            fheroes2::replaceStringEnding( filename, ".ogg", ".flac" );
-            filename = Settings::GetLastFile( prefix_music, filename );
-
-            if ( !System::IsFile( filename ) ) {
-                filename = Settings::GetLastFile( prefix_music, MUS::GetString( mus, MUS::OGG_MUSIC_TYPE::WIN_VERSION ) );
-
-                if ( !System::IsFile( filename ) ) {
-                    fheroes2::replaceStringEnding( filename, ".ogg", ".flac" );
-                    filename = Settings::GetLastFile( prefix_music, filename );
-
-                    if ( !System::IsFile( filename ) ) {
-                        filename.clear();
-                    }
-                }
-            }
-
-            if ( filename.empty() ) {
-                filename = Settings::GetLastFile( prefix_music, MUS::GetString( mus, MUS::OGG_MUSIC_TYPE::MAPPED ) );
-
-                if ( !System::IsFile( filename ) ) {
-                    fheroes2::replaceStringEnding( filename, ".ogg", ".mp3" );
-                    filename = Settings::GetLastFile( prefix_music, filename );
-
-                    if ( !System::IsFile( filename ) ) {
-                        fheroes2::replaceStringEnding( filename, ".ogg", ".flac" );
-                        filename = Settings::GetLastFile( prefix_music, filename );
-
-                        if ( !System::IsFile( filename ) ) {
-                            DEBUG_LOG( DBG_ENGINE, DBG_WARN,
-                                       "error read file: " << Settings::GetLastFile( prefix_music, MUS::GetString( mus, MUS::OGG_MUSIC_TYPE::MAPPED ) )
-                                                           << ", skipping..." );
-                            filename.clear();
-                        }
-                    }
-                }
-            }
+        std::string filename = getExternalMusicFile( mus, MUS::OGG_MUSIC_TYPE::DOS_VERSION, musicDirectories );
+        if ( filename.empty() ) {
+            filename = getExternalMusicFile( mus, MUS::OGG_MUSIC_TYPE::WIN_VERSION, musicDirectories );
         }
 
-        if ( !filename.empty() ) {
+        if ( filename.empty() ) {
+            filename = getExternalMusicFile( mus, MUS::OGG_MUSIC_TYPE::MAPPED, musicDirectories );
+        }
+
+        if ( filename.empty() ) {
+            DEBUG_LOG( DBG_ENGINE, DBG_WARN, "Cannot find a file for " << mus << " track." );
+        }
+        else {
             Music::Play( filename, loop );
             isSongFound = true;
 
             Game::SetCurrentMusic( mus );
+
+            DEBUG_LOG( DBG_ENGINE, DBG_TRACE, MUS::getFileName( mus, MUS::OGG_MUSIC_TYPE::MAPPED, ".ogg" ) );
         }
-        DEBUG_LOG( DBG_ENGINE, DBG_TRACE, MUS::GetString( mus, MUS::OGG_MUSIC_TYPE::MAPPED ) );
     }
 
     if ( !isSongFound ) {

--- a/src/fheroes2/agg/agg.h
+++ b/src/fheroes2/agg/agg.h
@@ -40,8 +40,6 @@ namespace AGG
         ~AGGInitializer();
     };
 
-    std::vector<uint8_t> LoadBINFRM( const char * frm_file );
-
     void LoadLOOPXXSounds( const std::vector<int> & vols, bool asyncronizedCall = false );
     void PlaySound( int m82, bool asyncronizedCall = false );
     void PlayMusic( int mus, bool loop = true, bool asyncronizedCall = false );

--- a/src/fheroes2/agg/bin_info.cpp
+++ b/src/fheroes2/agg/bin_info.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2020                                                    *
+ *   Copyright (C) 2020 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -241,7 +241,7 @@ namespace Bin_Info
             return mapIterator->second;
         }
         else {
-            const MonsterAnimInfo info( monsterID, AGG::LoadBINFRM( Bin_Info::GetFilename( monsterID ) ) );
+            const MonsterAnimInfo info( monsterID, AGG::ReadChunk( Bin_Info::GetFilename( monsterID ) ) );
             if ( info.isValid() ) {
                 _animMap[monsterID] = info;
                 return info;

--- a/src/fheroes2/agg/mus.cpp
+++ b/src/fheroes2/agg/mus.cpp
@@ -95,9 +95,9 @@ namespace
 
 namespace MUS
 {
-    std::string getFileName( const int musicTrackId, const OGG_MUSIC_TYPE musicType, const char * fileExtension )
+    std::string getFileName( const int musicTrackId, const EXTERNAL_MUSIC_TYPE musicType, const char * fileExtension )
     {
-        assert( fileExtension != nullptr );
+        // fileExtension can be nullptr to debug purposes.
 
         if ( musicTrackId <= UNUSED || musicTrackId > UNKNOWN ) {
             // You are passing an invalid music track ID!
@@ -105,7 +105,7 @@ namespace MUS
             return {};
         }
 
-        if ( musicType == OGG_MUSIC_TYPE::MAPPED ) {
+        if ( musicType == EXTERNAL_MUSIC_TYPE::MAPPED ) {
             std::string output;
             addTrackId( output, musicTrackId );
             output += ' ';
@@ -115,7 +115,7 @@ namespace MUS
             return output;
         }
 
-        if ( musicType == OGG_MUSIC_TYPE::DOS_VERSION ) {
+        if ( musicType == EXTERNAL_MUSIC_TYPE::DOS_VERSION ) {
             std::string output( "homm2_" );
 
             // GOG version format, data track was ignored there so 02 becomes 01
@@ -124,7 +124,7 @@ namespace MUS
             return output;
         }
 
-        if ( musicType == OGG_MUSIC_TYPE::WIN_VERSION ) {
+        if ( musicType == EXTERNAL_MUSIC_TYPE::WIN_VERSION ) {
             std::string output( "Track" );
             addTrackId( output, musicTrackId );
             output += fileExtension;

--- a/src/fheroes2/agg/mus.cpp
+++ b/src/fheroes2/agg/mus.cpp
@@ -22,7 +22,6 @@
  ***************************************************************************/
 
 #include <iomanip>
-#include <sstream>
 #include <string>
 
 #include "ground.h"
@@ -32,74 +31,109 @@
 #include "rand.h"
 #include "settings.h"
 
-namespace MUS
+namespace
 {
+    void addTrackId( std::string & output, const int musicTrackId )
+    {
+        if ( musicTrackId < 10 ) {
+            output += '0';
+        }
+
+        output += std::to_string( musicTrackId );
+    }
+
     const struct
     {
         int type;
         const char * string;
-    } musmap[] = { { UNUSED, "" },
-                   { DATATRACK, "" },
-                   { BATTLE1, "Battle 1" },
-                   { BATTLE2, "Battle 2" },
-                   { BATTLE3, "Battle 3" },
-                   { SORCERESS, "Sorceress Castle" },
-                   { WARLOCK, "Warlock Castle" },
-                   { NECROMANCER, "Necromancer Castle" },
-                   { KNIGHT, "Knight Castle" },
-                   { BARBARIAN, "Barbarian Castle" },
-                   { WIZARD, "Wizard Castle" },
-                   { LAVA, "Lava Theme" },
-                   { WASTELAND, "Wasteland Theme" },
-                   { DESERT, "Desert Theme" },
-                   { SNOW, "Snow Theme" },
-                   { SWAMP, "Swamp Theme" },
-                   { OCEAN, "Ocean Theme" },
-                   { DIRT, "Dirt Theme" },
-                   { GRASS, "Grass Theme" },
-                   { LOSTGAME, "Lost Game" },
-                   { NEW_WEEK, "New Week" },
-                   { NEW_MONTH, "New Month" },
-                   { ARCHIBALD_CAMPAIGN_SCREEN, "Archibald Campaign" },
-                   { PUZZLE, "Map Puzzle" },
-                   { ROLAND_CAMPAIGN_SCREEN, "Roland Campaign" },
-                   { CARAVANS, "25" },
-                   { CARAVANS_2, "26" },
-                   { CARAVANS_3, "27" },
-                   { COMPUTER_TURN, "AI Turn" },
-                   { BATTLEWIN, "Battle Won" },
-                   { BATTLELOSE, "Battle Lost" },
-                   { DUNGEON, "Dungeon" },
-                   { WATERSPRING, "Waterspring" },
-                   { ARABIAN, "Arabian" },
-                   { HILLFORT, "Hillfort" },
-                   { TREEHOUSE, "Treehouse" },
-                   { DEMONCAVE, "Demoncave" },
-                   { EXPERIENCE, "Experience" },
-                   { SKILL, "Skill" },
-                   { WATCHTOWER, "Watchtower" },
-                   { XANADU, "Xanadu" },
-                   { ULTIMATE_ARTIFACT, "Ultimate Artifact" },
-                   { MAINMENU, "Main Menu" },
-                   { VICTORY, "Scenario Victory" },
-                   { UNKNOWN, "UNKNOWN" } };
+    } musmap[] = { { MUS::UNUSED, "" },
+                   { MUS::DATATRACK, "" },
+                   { MUS::BATTLE1, "Battle 1" },
+                   { MUS::BATTLE2, "Battle 2" },
+                   { MUS::BATTLE3, "Battle 3" },
+                   { MUS::SORCERESS, "Sorceress Castle" },
+                   { MUS::WARLOCK, "Warlock Castle" },
+                   { MUS::NECROMANCER, "Necromancer Castle" },
+                   { MUS::KNIGHT, "Knight Castle" },
+                   { MUS::BARBARIAN, "Barbarian Castle" },
+                   { MUS::WIZARD, "Wizard Castle" },
+                   { MUS::LAVA, "Lava Theme" },
+                   { MUS::WASTELAND, "Wasteland Theme" },
+                   { MUS::DESERT, "Desert Theme" },
+                   { MUS::SNOW, "Snow Theme" },
+                   { MUS::SWAMP, "Swamp Theme" },
+                   { MUS::OCEAN, "Ocean Theme" },
+                   { MUS::DIRT, "Dirt Theme" },
+                   { MUS::GRASS, "Grass Theme" },
+                   { MUS::LOSTGAME, "Lost Game" },
+                   { MUS::NEW_WEEK, "New Week" },
+                   { MUS::NEW_MONTH, "New Month" },
+                   { MUS::ARCHIBALD_CAMPAIGN_SCREEN, "Archibald Campaign" },
+                   { MUS::PUZZLE, "Map Puzzle" },
+                   { MUS::ROLAND_CAMPAIGN_SCREEN, "Roland Campaign" },
+                   { MUS::CARAVANS, "25" },
+                   { MUS::CARAVANS_2, "26" },
+                   { MUS::CARAVANS_3, "27" },
+                   { MUS::COMPUTER_TURN, "AI Turn" },
+                   { MUS::BATTLEWIN, "Battle Won" },
+                   { MUS::BATTLELOSE, "Battle Lost" },
+                   { MUS::DUNGEON, "Dungeon" },
+                   { MUS::WATERSPRING, "Waterspring" },
+                   { MUS::ARABIAN, "Arabian" },
+                   { MUS::HILLFORT, "Hillfort" },
+                   { MUS::TREEHOUSE, "Treehouse" },
+                   { MUS::DEMONCAVE, "Demoncave" },
+                   { MUS::EXPERIENCE, "Experience" },
+                   { MUS::SKILL, "Skill" },
+                   { MUS::WATCHTOWER, "Watchtower" },
+                   { MUS::XANADU, "Xanadu" },
+                   { MUS::ULTIMATE_ARTIFACT, "Ultimate Artifact" },
+                   { MUS::MAINMENU, "Main Menu" },
+                   { MUS::VICTORY, "Scenario Victory" },
+                   { MUS::UNKNOWN, "UNKNOWN" } };
+}
 
-    std::string GetString( int musicTrack, OGG_MUSIC_TYPE musicType )
+namespace MUS
+{
+    std::string getFileName( const int musicTrackId, const OGG_MUSIC_TYPE musicType, const char * fileExtension )
     {
-        std::stringstream sstream;
-        if ( musicType == OGG_MUSIC_TYPE::MAPPED ) {
-            sstream << std::setw( 2 ) << std::setfill( '0' ) << musicTrack;
-            sstream << " " << ( UNUSED <= musicTrack && UNKNOWN > musicTrack ? musmap[musicTrack].string : musmap[UNKNOWN].string ) << ".ogg";
-        }
-        else if ( musicType == OGG_MUSIC_TYPE::DOS_VERSION ) {
-            // GOG version format, data track was ignored there so 02 becomes 01
-            sstream << "homm2_" << std::setw( 2 ) << std::setfill( '0' ) << musicTrack - 1 << ".ogg";
-        }
-        else if ( musicType == OGG_MUSIC_TYPE::WIN_VERSION ) {
-            sstream << "Track" << std::setw( 2 ) << std::setfill( '0' ) << musicTrack << ".ogg";
+        assert( fileExtension != nullptr );
+
+        if ( musicTrackId <= UNUSED || musicTrackId > UNKNOWN ) {
+            // You are passing an invalid music track ID!
+            assert( 0 );
+            return {};
         }
 
-        return sstream.str();
+        if ( musicType == OGG_MUSIC_TYPE::MAPPED ) {
+            std::string output;
+            addTrackId( output, musicTrackId );
+            output += ' ';
+
+            output += musmap[musicTrackId].string;
+            output += fileExtension;
+            return output;
+        }
+
+        if ( musicType == OGG_MUSIC_TYPE::DOS_VERSION ) {
+            std::string output( "homm2_" );
+
+            // GOG version format, data track was ignored there so 02 becomes 01
+            addTrackId( output, musicTrackId - 1 );
+            output += fileExtension;
+            return output;
+        }
+
+        if ( musicType == OGG_MUSIC_TYPE::WIN_VERSION ) {
+            std::string output( "Track" );
+            addTrackId( output, musicTrackId );
+            output += fileExtension;
+            return output;
+        }
+
+        // Did you add a new type of music?
+        assert( 0 );
+        return {};
     }
 }
 
@@ -211,7 +245,7 @@ int MUS::FromMapObject( const MP2::MapObjectType objectType )
     }
 }
 
-int MUS::GetBattleRandom( void )
+int MUS::GetBattleRandom()
 {
     switch ( Rand::Get( 1, 3 ) ) {
     case 1:
@@ -221,7 +255,10 @@ int MUS::GetBattleRandom( void )
     case 3:
         return BATTLE3;
     default:
+        // How is it even possible?
+        assert( 0 );
         break;
     }
+
     return UNKNOWN;
 }

--- a/src/fheroes2/agg/mus.cpp
+++ b/src/fheroes2/agg/mus.cpp
@@ -97,7 +97,7 @@ namespace MUS
 {
     std::string getFileName( const int musicTrackId, const EXTERNAL_MUSIC_TYPE musicType, const char * fileExtension )
     {
-        // fileExtension can be nullptr to debug purposes.
+        assert( fileExtension != nullptr );
 
         if ( musicTrackId <= UNUSED || musicTrackId > UNKNOWN ) {
             // You are passing an invalid music track ID!

--- a/src/fheroes2/agg/mus.h
+++ b/src/fheroes2/agg/mus.h
@@ -29,7 +29,7 @@
 
 namespace MUS
 {
-    enum
+    enum : int
     {
         UNUSED,
         DATATRACK,
@@ -86,13 +86,13 @@ namespace MUS
         WIN_VERSION
     };
 
-    std::string GetString( int musicTrack, OGG_MUSIC_TYPE musicType );
+    std::string getFileName( const int musicTrackId, const OGG_MUSIC_TYPE musicType, const char * fileExtension );
 
     int FromGround( int );
     int FromRace( int );
     int FromMapObject( const MP2::MapObjectType objectType );
 
-    int GetBattleRandom( void );
+    int GetBattleRandom();
 }
 
 #endif

--- a/src/fheroes2/agg/mus.h
+++ b/src/fheroes2/agg/mus.h
@@ -79,14 +79,14 @@ namespace MUS
         UNKNOWN
     };
 
-    enum class OGG_MUSIC_TYPE : int
+    enum class EXTERNAL_MUSIC_TYPE : int
     {
         MAPPED,
         DOS_VERSION,
         WIN_VERSION
     };
 
-    std::string getFileName( const int musicTrackId, const OGG_MUSIC_TYPE musicType, const char * fileExtension );
+    std::string getFileName( const int musicTrackId, const EXTERNAL_MUSIC_TYPE musicType, const char * fileExtension );
 
     int FromGround( int );
     int FromRace( int );


### PR DESCRIPTION
Reworked the way how we read music files. Previous implementation was slow and incorrect. We were expecting ogg files to be present while searching flac files.

Expanded the support of file types to MP3 ( close #5063 ).