### PR TITLE
Do not render extra frame while playing an audio only video file

### DIFF
--- a/src/fheroes2/game/game_video.cpp
+++ b/src/fheroes2/game/game_video.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2020                                                    *
+ *   Copyright (C) 2020 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -43,7 +43,7 @@ namespace
         fheroes2::DrawRect( image, fheroes2::Rect( roi.x - 1, roi.y - 1, roi.width + 2, roi.height + 2 ), color );
     }
 
-    void playAudio( const std::vector<std::vector<uint8_t> > & audioChannels )
+    void playAudio( const std::vector<std::vector<uint8_t>> & audioChannels )
     {
         for ( const std::vector<uint8_t> & audio : audioChannels ) {
             assert( !audio.empty() );
@@ -86,7 +86,7 @@ namespace Video
         if ( video.frameCount() < 1 ) // nothing to show
             return 0;
 
-        const std::vector<std::vector<uint8_t> > & audioChannels = video.getAudioChannels();
+        const std::vector<std::vector<uint8_t>> & audioChannels = video.getAudioChannels();
         const bool hasAudio = Audio::isValid() && !audioChannels.empty();
         if ( action == VideoAction::IGNORE_VIDEO ) {
             // Since no video is rendered play audio if available.

--- a/src/fheroes2/game/game_video.cpp
+++ b/src/fheroes2/game/game_video.cpp
@@ -30,8 +30,6 @@
 #include "system.h"
 #include "ui_tool.h"
 
-#include <cassert>
-
 namespace
 {
     // Anim2 directory is used in Russian Buka version of the game.
@@ -46,8 +44,9 @@ namespace
     void playAudio( const std::vector<std::vector<uint8_t>> & audioChannels )
     {
         for ( const std::vector<uint8_t> & audio : audioChannels ) {
-            assert( !audio.empty() );
-            Mixer::Play( &audio[0], static_cast<uint32_t>( audio.size() ), -1, false );
+            if ( !audio.empty() ) {
+                Mixer::Play( &audio[0], static_cast<uint32_t>( audio.size() ), -1, false );
+            }
         }
     }
 }

--- a/src/fheroes2/game/game_video.cpp
+++ b/src/fheroes2/game/game_video.cpp
@@ -45,7 +45,7 @@ namespace
     {
         for ( const std::vector<uint8_t> & audio : audioChannels ) {
             if ( !audio.empty() ) {
-                Mixer::Play( &audio[0], static_cast<uint32_t>( audio.size() ), -1, false );
+                Mixer::Play( &audio[0], static_cast<uint32_t>( audio.size() ) );
             }
         }
     }


### PR DESCRIPTION
We should not waste resources to do unnecessary work for rendering.