### PR TITLE
Properly center the first sentence in the battle surrender dialog

### DIFF
--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -969,8 +969,9 @@ bool Battle::DialogBattleSurrender( const HeroBase & hero, u32 cost, Kingdom & k
 
     std::string str = hero.isCaptain() ? _( "Captain of %{name} states:" ) : _( "%{name} states:" );
     StringReplace( str, "%{name}", hero.GetName() );
+
     Text text( str, Font::BIG );
-    text.Blit( pos_rt.x + 320 - text.w() / 2, pos_rt.y + 30 );
+    text.Blit( pos_rt.x + 312 - text.w() / 2, pos_rt.y + 30 );
 
     str = _( "\"I will accept your surrender and grant you and your troops safe passage for the price of %{price} gold.\"" );
     StringReplace( str, "%{price}", cost );


### PR DESCRIPTION
Follow-up to #5108

<img width="639" alt="Screenshot 1" src="https://user-images.githubusercontent.com/32623900/158032420-0c8036d5-dfe3-4ce4-a1f8-ceca6d7c343b.png">
<img width="642" alt="Screenshot 2" src="https://user-images.githubusercontent.com/32623900/158032425-299dfe3b-2f64-4c3c-b69f-226b1ac1ae8f.png">
<img width="640" alt="Screenshot 3" src="https://user-images.githubusercontent.com/32623900/158032429-19227016-f3a1-4a55-b205-d5b4fcb54cdf.png">
