### PR TITLE
Set the direction for attacking and defending units in battle in a more OG-like way

### DIFF
--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -107,6 +107,9 @@ void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, int32_t dst
         }
     }
 
+    // UNKNOWN attack direction is only allowed for archers
+    assert( Unit::isHandFighting( attacker, defender ) ? dir > UNKNOWN : dir == UNKNOWN );
+
     // This is a direct attack, update the direction for both the attacker and the defender
     if ( dir ) {
         if ( !attacker.isWide() || !Board::isNearIndexes( attacker.GetHeadIndex(), dst ) ) {

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -115,7 +115,7 @@ void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, int32_t dst
 
         const int32_t responseDst = calculateDst( defender, attacker );
 
-        if ( defender.AllowResponse() && ( !defender.isWide() || !Board::isNearIndexes( defender.GetHeadIndex(), responseDst ) ) ) {
+        if ( !attacker.ignoreRetaliation() && defender.AllowResponse() && ( !defender.isWide() || !Board::isNearIndexes( defender.GetHeadIndex(), responseDst ) ) ) {
             defender.UpdateDirection( board[responseDst].GetPos() );
         }
     }

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -588,20 +588,6 @@ int Battle::Board::GetReflectDirection( int d )
     return UNKNOWN;
 }
 
-bool Battle::Board::isReflectDirection( int d )
-{
-    switch ( d ) {
-    case TOP_LEFT:
-    case LEFT:
-    case BOTTOM_LEFT:
-        return true;
-    default:
-        break;
-    }
-
-    return false;
-}
-
 bool Battle::Board::IsLeftDirection( const int32_t startCellId, const int32_t endCellId, const bool prevLeftDirection )
 {
     const int startX = startCellId % ARENAW;

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -79,7 +79,6 @@ namespace Battle
         static bool isMoatIndex( s32 index, const Unit & b );
         static bool isBridgeIndex( s32 index, const Unit & b );
         static bool isOutOfWallsIndex( s32 );
-        static bool isReflectDirection( int );
         static bool IsLeftDirection( const int32_t startCellId, const int32_t endCellId, const bool prevLeftDirection );
         static bool isNegativeDistance( s32 index1, s32 index2 );
         static int DistanceFromOriginX( int32_t index, bool reflect );


### PR DESCRIPTION
In OG:

https://user-images.githubusercontent.com/32623900/158616823-455eb4ea-af67-42de-acb2-be3cf1e9f166.mp4

Currently in fheroes2:

https://user-images.githubusercontent.com/32623900/158616907-a7fb812d-a61a-4829-94d9-c9f8ebaa4107.mp4

With this PR:

https://user-images.githubusercontent.com/32623900/158617006-a2fdc1eb-3afd-46c2-bd37-b54dbb7db5ec.mp4

---

Also it seems that in OG defending unit doesn't turn to the attacker who has the "no enemy retaliation" ability:

https://user-images.githubusercontent.com/32623900/158617478-385c3ecf-76a6-4735-83c8-aa8ff0cfc299.mp4

Currently in fheroes2:

https://user-images.githubusercontent.com/32623900/158617557-16b3045b-f1b1-42b4-ace8-6c1641e6c7b5.mp4

With this PR:

https://user-images.githubusercontent.com/32623900/158617606-f14fa725-9490-4f6f-9cfa-2e844bf4de01.mp4

---

fix #2027:

https://user-images.githubusercontent.com/32623900/158674694-1bedee11-d35b-4798-aea2-047801c2c8ad.mp4
