### PR TITLE
Add mandatory requirement of h2d file being present

### DIFF
--- a/VisualStudio/common.props
+++ b/VisualStudio/common.props
@@ -38,6 +38,11 @@ if exist "$(MSBuildThisFileDirectory)..\maps" (
     )
 )
 
+if not exist "$(OutDir)files\data" (
+    mkdir "$(OutDir)files\data"
+)
+xcopy /Y /s /Q "$(MSBuildThisFileDirectory)..\files\data" "$(OutDir)files\data"
+
 xcopy /Y "$(MSBuildThisFileDirectory)..\fheroes2.cfg" "$(OutDir)"
 xcopy /Y "$(MSBuildThisFileDirectory)..\fheroes2.key" "$(OutDir)"
 

--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -670,19 +670,7 @@ AGG::AGGInitializer::AGGInitializer()
         return;
     }
 
-    fheroes2::Display & display = fheroes2::Display::instance();
-    const fheroes2::Image & image = CreateImageFromZlib( 290, 190, errorMessage, sizeof( errorMessage ), false );
-
-    display.fill( 0 );
-    fheroes2::Copy( image, 0, 0, display, ( display.width() - image.width() ) / 2, ( display.height() - image.height() ) / 2, image.width(), image.height() );
-
-    LocalEvent & le = LocalEvent::Get();
-    while ( le.HandleEvents() && !le.KeyPress() && !le.MouseClickLeft() ) {
-        // Do nothing.
-    }
-
-    DEBUG_LOG( DBG_ENGINE, DBG_WARN, "No data files found." );
-    throw std::logic_error( "No data files found." );
+    throw std::logic_error( "No AGG data files found." );
 }
 
 AGG::AGGInitializer::~AGGInitializer()

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -154,8 +154,7 @@ namespace
         {
             const fheroes2::ScreenPaletteRestorer screenRestorer;
 
-            try
-            {
+            try {
                 _aggInitializer.reset( new AGG::AGGInitializer );
 
                 _h2dInitializer.reset( new fheroes2::h2d::H2DInitializer );

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -34,6 +34,7 @@
 #include "game.h"
 #include "game_logo.h"
 #include "game_video.h"
+#include "h2d.h"
 #include "image_palette.h"
 #include "localevent.h"
 #include "logging.h"
@@ -145,6 +146,46 @@ namespace
             fheroes2::Display::instance().release();
         }
     };
+
+    class DataInitializer
+    {
+    public:
+        DataInitializer()
+        {
+            const fheroes2::ScreenPaletteRestorer screenRestorer;
+
+            try
+            {
+                _aggInitializer.reset( new AGG::AGGInitializer );
+
+                _h2dInitializer.reset( new fheroes2::h2d::H2DInitializer );
+            }
+            catch ( ... ) {
+                fheroes2::Display & display = fheroes2::Display::instance();
+                const fheroes2::Image & image = CreateImageFromZlib( 290, 190, errorMessage, sizeof( errorMessage ), false );
+
+                display.fill( 0 );
+                fheroes2::Resize( image, display );
+
+                display.render();
+
+                LocalEvent & le = LocalEvent::Get();
+                while ( le.HandleEvents() && !le.KeyPress() && !le.MouseClickLeft() ) {
+                    // Do nothing.
+                }
+
+                throw;
+            }
+        }
+
+        DataInitializer( const DataInitializer & ) = delete;
+        DataInitializer & operator=( const DataInitializer & ) = delete;
+        ~DataInitializer() = default;
+
+    private:
+        std::unique_ptr<AGG::AGGInitializer> _aggInitializer;
+        std::unique_ptr<fheroes2::h2d::H2DInitializer> _h2dInitializer;
+    };
 }
 
 #if defined( _MSC_VER )
@@ -206,7 +247,7 @@ int main( int argc, char ** argv )
 
         const DisplayInitializer displayInitializer;
 
-        const AGG::AGGInitializer aggInitializer;
+        const DataInitializer dataInitializer;
 
         // Load palette.
         fheroes2::setGamePalette( AGG::ReadChunk( "KB.PAL" ) );

--- a/src/fheroes2/h2d/h2d.cpp
+++ b/src/fheroes2/h2d/h2d.cpp
@@ -59,7 +59,7 @@ namespace fheroes2
                 throw std::logic_error( "No H2D data files found." );
             }
 
-            if ( reader.open( filePath ) ) {
+            if ( !reader.open( filePath ) ) {
                 throw std::logic_error( "Cannot open H2D file." );
             }
         }

--- a/src/fheroes2/h2d/h2d.cpp
+++ b/src/fheroes2/h2d/h2d.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2021                                                    *
+ *   Copyright (C) 2021 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/h2d/h2d.h
+++ b/src/fheroes2/h2d/h2d.h
@@ -28,6 +28,16 @@ namespace fheroes2
 
     namespace h2d
     {
+        class H2DInitializer
+        {
+        public:
+            H2DInitializer();
+            H2DInitializer( const H2DInitializer & ) = delete;
+            H2DInitializer & operator=( const H2DInitializer & ) = delete;
+
+            ~H2DInitializer() = default;
+        };
+
         bool readImage( const std::string & name, Sprite & image );
     }
 }

--- a/src/fheroes2/h2d/h2d.h
+++ b/src/fheroes2/h2d/h2d.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2021                                                    *
+ *   Copyright (C) 2021 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *


### PR DESCRIPTION
Since we want to bring the best experience to players and our h2d file contains some fixes over the original graphics we need to make h2d file presence to be mandatory in order to run the game. This approach will ensure that users will be using not a half-copied product.