### PR TITLE
Makefile: use pkg-config to locate SDL2_mixer and SDL2_image

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,6 +30,7 @@ CFLAGS := $(CFLAGS) -fsigned-char -pthread
 CXXFLAGS := -std=c++11 $(CFLAGS)
 LDFLAGS := $(LDFLAGS) -pthread
 LIBS := -lz
+PKG_CONFIG ?= pkg-config
 
 CFLAGS_TP := $(CFLAGS)
 CXXFLAGS_TP := $(CXXFLAGS)
@@ -52,15 +53,18 @@ endif
 ifdef FHEROES2_SDL1
 SDL_LIBS := $(SDL_LIBS) -lSDL_mixer
 else
-SDL_LIBS := $(SDL_LIBS) -lSDL2_mixer
+SDL_LIBS  := $(SDL_LIBS)  $(shell $(PKG_CONFIG) --libs   SDL2_mixer)
+SDL_FLAGS := $(SDL_FLAGS) $(shell $(PKG_CONFIG) --cflags SDL2_mixer)
 endif
 
 ifdef FHEROES2_IMAGE_SUPPORT
 CFLAGS := $(CFLAGS) -DFHEROES2_IMAGE_SUPPORT $(shell libpng-config --cflags)
+LIBS := $(LIBS) $(shell libpng-config --libs)
 ifdef FHEROES2_SDL1
-SDL_LIBS := $(SDL_LIBS) -lSDL_image $(shell libpng-config --libs)
+SDL_LIBS := $(SDL_LIBS) -lSDL_image
 else
-SDL_LIBS := $(SDL_LIBS) -lSDL2_image $(shell libpng-config --libs)
+SDL_LIBS  := $(SDL_LIBS)  $(shell $(PKG_CONFIG) --libs   SDL2_image)
+SDL_FLAGS := $(SDL_FLAGS) $(shell $(PKG_CONFIG) --cflags SDL2_image)
 endif
 endif
 


### PR DESCRIPTION
On NixOS SDL2, SDL2_mixer and SDL2_image each get installed into their
own directory. As a result sdl2-config does not point to SDL2_mixer
and build fails as:

    fheroes2> g++ -c -MD audio.cpp -I/<<NIX>>/SDL2-2.0.20-dev/include/SDL2 -D_REENTRANT -std=c++11 -O3  -fsigned-char -pthread -Wall -Wextra -Wpedantic -Wfloat-conversion -Wshadow -Wfloat-equal -Wredundant-decls -Wdouble-promotion -Wunused -Wuninitialized -Werror -I../thirdparty/libsmacker
    fheroes2> audio.cpp:30:10: fatal error: SDL_mixer.h: No such file or directory
    fheroes2>    30 | #include <SDL_mixer.h>
    fheroes2>       |          ^~~~~~~~~~~~~
    fheroes2> compilation terminated.

The fix adds `pkg-config --libs/--cflags <lib>` for part discovery.