### PR TITLE
Build player influence map to inform AI kingdom development decisions

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -33,11 +33,16 @@ namespace AI
 {
     struct RegionStats
     {
+        bool evaluated = false;
         double highestThreat = -1;
         double averageMonster = -1;
-        int friendlyHeroCount = 0;
+        int friendlyHeroes = 0;
+        int friendlyCastles = 0;
+        int enemyCastles = 0;
         int monsterCount = 0;
         int fogCount = 0;
+        int safetyFactor = 0;
+        int spellLevel = 2;
         std::vector<IndexObject> validObjects;
     };
 
@@ -136,6 +141,7 @@ namespace AI
         void HeroesActionComplete( Heroes & hero ) override;
 
         bool recruitHero( Castle & castle, bool buyArmy, bool underThreat );
+        void evaluateRegionSafety();
         double getObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         int getPriorityTarget( const Heroes & hero, double & maxPriority, int patrolIndex = -1, uint32_t distanceLimit = 0 );
         void resetPathfinder() override;

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2020                                                    *
+ *   Copyright (C) 2020 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/ai/normal/ai_normal_castle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_castle.cpp
@@ -174,9 +174,6 @@ namespace AI
 
     void Normal::CastleTurn( Castle & castle, bool defensive )
     {
-        const uint32_t regionID = world.GetTiles( castle.GetIndex() ).GetRegion();
-        const RegionStats & stats = _regions[regionID];
-
         if ( defensive ) {
             Build( castle, GetDefensiveStructures() );
 
@@ -184,6 +181,9 @@ namespace AI
             OptimizeTroopsOrder( castle.GetArmy() );
         }
         else {
+            const uint32_t regionID = world.GetTiles( castle.GetIndex() ).GetRegion();
+            const RegionStats & stats = _regions[regionID];
+
             CastleDevelopment( castle, stats.safetyFactor, stats.spellLevel );
         }
     }

--- a/src/fheroes2/ai/normal/ai_normal_castle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_castle.cpp
@@ -134,7 +134,7 @@ namespace AI
         return false;
     }
 
-    bool CastleDevelopment( Castle & castle )
+    bool CastleDevelopment( Castle & castle, int safetyFactor, int spellLevel )
     {
         if ( !castle.isBuild( BUILD_WELL ) && world.LastDay() ) {
             // return right away - if you can't buy Well you can't buy anything else
@@ -157,6 +157,13 @@ namespace AI
             return true;
         }
 
+        if ( castle.GetLevelMageGuild() < spellLevel && safetyFactor > 0 ) {
+            static const std::vector<BuildOrder> magicGuildUpgrades = { { BUILD_MAGEGUILD2, 2 }, { BUILD_MAGEGUILD3, 2 }, { BUILD_MAGEGUILD4, 1 }, { BUILD_MAGEGUILD5, 1 } };
+            if ( Build( castle, magicGuildUpgrades ) ) {
+                return true;
+            }
+        }
+
         // Call internally checks if it's valid (space/resources) to buy one
         if ( castle.GetKingdom().GetFunds() >= PaymentConditions::BuyBoat() * ( islandOrPeninsula ? 2 : 4 ) )
             castle.BuyBoat();
@@ -166,6 +173,9 @@ namespace AI
 
     void Normal::CastleTurn( Castle & castle, bool defensive )
     {
+        const uint32_t regionID = world.GetTiles( castle.GetIndex() ).GetRegion();
+        const RegionStats & stats = _regions[regionID];
+
         if ( defensive ) {
             Build( castle, GetDefensiveStructures() );
 
@@ -173,7 +183,7 @@ namespace AI
             OptimizeTroopsOrder( castle.GetArmy() );
         }
         else {
-            CastleDevelopment( castle );
+            CastleDevelopment( castle, stats.safetyFactor, stats.spellLevel );
         }
     }
 }

--- a/src/fheroes2/ai/normal/ai_normal_castle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_castle.cpp
@@ -158,7 +158,8 @@ namespace AI
         }
 
         if ( castle.GetLevelMageGuild() < spellLevel && safetyFactor > 0 ) {
-            static const std::vector<BuildOrder> magicGuildUpgrades = { { BUILD_MAGEGUILD2, 2 }, { BUILD_MAGEGUILD3, 2 }, { BUILD_MAGEGUILD4, 1 }, { BUILD_MAGEGUILD5, 1 } };
+            static const std::vector<BuildOrder> magicGuildUpgrades
+                = { { BUILD_MAGEGUILD2, 2 }, { BUILD_MAGEGUILD3, 2 }, { BUILD_MAGEGUILD4, 1 }, { BUILD_MAGEGUILD5, 1 } };
             if ( Build( castle, magicGuildUpgrades ) ) {
                 return true;
             }

--- a/src/fheroes2/ai/normal/ai_normal_castle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_castle.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2020                                                    *
+ *   Copyright (C) 2020 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -124,7 +124,8 @@ namespace AI
                 stats.evaluated = false;
             }
         }
-        std::sort( regionsToCheck.begin(), regionsToCheck.end(), []( const auto & x, const auto & y ) { return x.second > y.second; } );
+        std::sort( regionsToCheck.begin(), regionsToCheck.end(),
+                   []( const std::pair<size_t, int> & left, const std::pair<size_t, int> & right ) { return left.second > right.second; } );
 
         size_t currentEntry = 0;
         size_t batchStart = 0;

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2020                                                    *
+ *   Copyright (C) 2020 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -147,7 +147,7 @@ namespace AI
             }
             // no neighbours means it is an island; they are usually safer (or more dangerous to explore) due to boat movement penalties
             if ( region.getNeighboursCount() == 0 )
-                regionsToCheck[currentEntry].second *= 1.5;
+                regionsToCheck[currentEntry].second = regionsToCheck[currentEntry].second * 3 / 2;
 
             if ( currentEntry == batchEnd - 1 ) {
                 // Apply the calculated value in batches

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -355,5 +355,13 @@ void World::ComputeStaticAnalysis()
                 reg._neighbours.insert( vec_tiles[exitIndex].GetRegion() );
             }
         }
+
+        // Fix missing references
+        for ( uint32_t adjacent : reg._neighbours ) {
+            std::set<uint32_t> & otherList = _regions[adjacent]._neighbours;
+            if ( otherList.find( reg._id ) == otherList.end() ) {
+                otherList.insert( reg._id );
+            }
+        }
     }
 }

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -358,10 +358,7 @@ void World::ComputeStaticAnalysis()
 
         // Fix missing references
         for ( uint32_t adjacent : reg._neighbours ) {
-            std::set<uint32_t> & otherList = _regions[adjacent]._neighbours;
-            if ( otherList.find( reg._id ) == otherList.end() ) {
-                otherList.insert( reg._id );
-            }
+            _regions[adjacent]._neighbours.insert( reg._id );
         }
     }
 }

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2020                                                    *
+ *   Copyright (C) 2020 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *


### PR DESCRIPTION
Fixes #5046 .

AI players will upgrade magic guild more often when there's heroes with appropriate Wisdom skill and current map region is considered to be safe.

Also includes bug fixes related to region generation and AI map scan at the beginning of the turn