### PR TITLE
Remove memory copy while reading data from AGG file

### DIFF
--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -392,7 +392,8 @@ bool AGG::ReadDataDir( void )
 std::vector<uint8_t> AGG::ReadChunk( const std::string & key )
 {
     if ( heroes2x_agg.isGood() ) {
-        const std::vector<uint8_t> & buf = heroes2x_agg.read( key );
+        // Make sure that the below container is not const-reference so returning it from the function will invoke a move constructor instead of copy constructor.
+        std::vector<uint8_t> buf = heroes2x_agg.read( key );
         if ( !buf.empty() )
             return buf;
     }
@@ -403,7 +404,8 @@ std::vector<uint8_t> AGG::ReadChunk( const std::string & key )
 std::vector<uint8_t> AGG::ReadMusicChunk( const std::string & key, const bool ignoreExpansion )
 {
     if ( !ignoreExpansion && g_midiHeroes2xAGG.isGood() ) {
-        const std::vector<uint8_t> & buf = g_midiHeroes2xAGG.read( key );
+        // Make sure that the below container is not const-reference so returning it from the function will invoke a move constructor instead of copy constructor.
+        std::vector<uint8_t> buf = g_midiHeroes2xAGG.read( key );
         if ( !buf.empty() )
             return buf;
     }

--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -392,7 +392,8 @@ bool AGG::ReadDataDir( void )
 std::vector<uint8_t> AGG::ReadChunk( const std::string & key )
 {
     if ( heroes2x_agg.isGood() ) {
-        // Make sure that the below container is not const-reference so returning it from the function will invoke a move constructor instead of copy constructor.
+        // Make sure that the below container is not const and not a reference
+        // so returning it from the function will invoke a move constructor instead of copy constructor.
         std::vector<uint8_t> buf = heroes2x_agg.read( key );
         if ( !buf.empty() )
             return buf;
@@ -404,7 +405,8 @@ std::vector<uint8_t> AGG::ReadChunk( const std::string & key )
 std::vector<uint8_t> AGG::ReadMusicChunk( const std::string & key, const bool ignoreExpansion )
 {
     if ( !ignoreExpansion && g_midiHeroes2xAGG.isGood() ) {
-        // Make sure that the below container is not const-reference so returning it from the function will invoke a move constructor instead of copy constructor.
+        // Make sure that the below container is not const and not a reference
+        // so returning it from the function will invoke a move constructor instead of copy constructor.
         std::vector<uint8_t> buf = g_midiHeroes2xAGG.read( key );
         if ( !buf.empty() )
             return buf;


### PR DESCRIPTION
We were wasting memory resources by doing nothing. Now loading of resources on low-profile machines will be even faster.