### PR TITLE
Optimize fighter hero priorities

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -809,6 +809,7 @@ namespace AI
         // 1 tile distance is 100.0 value approximately
         const Maps::Tiles & tile = world.GetTiles( index );
         const MP2::MapObjectType objectType = tile.GetObject();
+        const bool anotherFriendlyHeroPresent = _regions[tile.GetRegion()].friendlyHeroes > 1;
 
         if ( objectType == MP2::OBJ_CASTLE ) {
             const Castle * castle = world.getCastleEntrance( Maps::GetPoint( index ) );
@@ -850,13 +851,13 @@ namespace AI
             return 12000.0;
         }
         else if ( objectType == MP2::OBJ_MONSTER ) {
-            return 8000.0;
+            return anotherFriendlyHeroPresent ? 4000.0 : 1000.0;
         }
         else if ( objectType == MP2::OBJ_MINES || objectType == MP2::OBJ_SAWMILL || objectType == MP2::OBJ_ALCHEMYLAB ) {
             if ( tile.QuantityColor() == hero.GetColor() ) {
                 return -dangerousTaskPenalty; // don't even attempt to go here
             }
-            return ( tile.QuantityResourceCount().first == Resource::GOLD ) ? 2000.0 : 1000.0;
+            return ( tile.QuantityResourceCount().first == Resource::GOLD ) ? 3000.0 : 1500.0;
         }
         else if ( objectType == MP2::OBJ_ABANDONEDMINE ) {
             if ( tile.QuantityColor() == hero.GetColor() ) {
@@ -867,27 +868,31 @@ namespace AI
         else if ( MP2::isArtifactObject( objectType ) && tile.QuantityArtifact().isValid() ) {
             return 1500.0 * tile.QuantityArtifact().getArtifactValue();
         }
+        else if ( objectType == MP2::OBJ_TREASURECHEST ) {
+            // Treasure chest without the artifact
+            return 1250.0;
+        }
         else if ( MP2::isPickupObject( objectType ) ) {
-            return 100.0;
+            return anotherFriendlyHeroPresent ? 100.0 : 500.0;
         }
         else if ( MP2::isCaptureObject( objectType ) && MP2::isQuantityObject( objectType ) ) {
             // Objects like WATERWHEEL, WINDMILL and MAGICGARDEN if capture setting is enabled
             return 100.0;
         }
         else if ( objectType == MP2::OBJ_XANADU ) {
-            return 2000.0;
+            return 3000.0;
         }
         else if ( objectType == MP2::OBJ_SHRINE1 ) {
-            return 100;
+            return 250;
         }
         else if ( objectType == MP2::OBJ_SHRINE2 ) {
-            return 250;
+            return 500;
         }
         else if ( objectType == MP2::OBJ_SHRINE3 ) {
             return 500;
         }
         else if ( MP2::isHeroUpgradeObject( objectType ) ) {
-            return 750.0;
+            return 1250.0;
         }
         else if ( MP2::isMonsterDwelling( objectType ) ) {
             return tile.QuantityTroop().GetStrength();
@@ -932,7 +937,7 @@ namespace AI
             if ( hero.GetSpellPoints() * 2 >= hero.GetMaxSpellPoints() ) {
                 return -2000; // no reason to visit the well with no magic book or with half of points
             }
-            return 0;
+            return 350.0;
         }
         else if ( objectType == MP2::OBJ_TEMPLE ) {
             if ( hero.GetArmy().AllTroopsAreUndead() ) {


### PR DESCRIPTION
Adjust object values for fighter hero as of right now they are simply chasing monsters around the map/not even picking up artifacts at times.