### PR TITLE
Update minimap colors

### DIFF
--- a/src/fheroes2/gui/interface_radar.cpp
+++ b/src/fheroes2/gui/interface_radar.cpp
@@ -65,12 +65,13 @@ namespace
         COLOR_ROAD = 0x7A,
 
         COLOR_BLUE = 0x47,
-        COLOR_GREEN = 0x67,
+        COLOR_GREEN = 0x69,
         COLOR_RED = 0xbd,
         COLOR_YELLOW = 0x70,
         COLOR_ORANGE = 0xcd,
         COLOR_PURPLE = 0x87,
-        COLOR_GRAY = 0x10
+        COLOR_GRAY = 0x10,
+        COLOR_WHITE = 0x0a
     };
 }
 
@@ -121,7 +122,7 @@ uint8_t GetPaletteIndexFromColor( int color )
         break;
     }
 
-    return COLOR_GRAY;
+    return COLOR_WHITE;
 }
 
 Interface::Radar::Radar( Basic & basic )


### PR DESCRIPTION
Fixes #5152 .

Set white and green values to original color shades. Current green was also hard to see on the grassland terrain.

![image](https://user-images.githubusercontent.com/1373638/159598069-19805764-264a-4279-be8b-91d26c9f0c77.png)
![image](https://user-images.githubusercontent.com/1373638/159598174-277f6357-cb82-4f81-82c5-b02d06983d4c.png)

