### PR TITLE
Optimize GitHub Actions workflows

### DIFF
--- a/.github/workflows/clang_analyzer.yml
+++ b/.github/workflows/clang_analyzer.yml
@@ -7,6 +7,7 @@ jobs:
   clang:
     name: Clang Analyzer
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies and clang-tools

--- a/.github/workflows/clang_analyzer.yml
+++ b/.github/workflows/clang_analyzer.yml
@@ -1,8 +1,7 @@
 name: Clang Analyzer
 
 on:
-  pull_request:
-    branches: [ master ]
+  workflow_call:
 
 jobs:
   clang:

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -13,6 +13,7 @@ jobs:
   tidy:
     name: Clang-Tidy
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -5,6 +5,10 @@ on:
     branches: [ master ]
     paths: [ '**.cpp', '**.h' ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tidy:
     name: Clang-Tidy

--- a/.github/workflows/clang_tidy_comments.yml
+++ b/.github/workflows/clang_tidy_comments.yml
@@ -9,6 +9,7 @@ jobs:
   comment:
     name: Clang-Tidy Comments
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Download analysis results

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,7 +6,6 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: false
       matrix:
         config:
         - name: Linux SDL1

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -34,6 +34,7 @@ jobs:
           options: -DUSE_SDL_VERSION=SDL2 -DMACOS_APP_BUNDLE=ON
     name: CMake (${{ matrix.config.name }})
     runs-on: ${{ matrix.config.os }}
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies (Linux)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,8 +1,7 @@
 name: CMake
 
 on:
-  pull_request:
-    branches: [ master ]
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/code_style_check.yml
+++ b/.github/workflows/code_style_check.yml
@@ -1,8 +1,7 @@
 name: Code style check
 
 on:
-  pull_request:
-    branches: [ master ]
+  workflow_call:
 
 jobs:
   check:

--- a/.github/workflows/code_style_check.yml
+++ b/.github/workflows/code_style_check.yml
@@ -7,6 +7,7 @@ jobs:
   check:
     name: Code style check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -6,7 +6,6 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: false
       matrix:
         config:
         - name: Linux SDL1 Release

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,10 +1,7 @@
 name: Make
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -58,6 +58,7 @@ jobs:
           env: { FHEROES2_STRICT_COMPILATION: ON, FHEROES2_WITH_TOOLS: ON, FHEROES2_MACOS_APP_BUNDLE: ON }
     name: Make (${{ matrix.config.name }})
     runs-on: ${{ matrix.config.os }}
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies (Linux)
@@ -102,6 +103,7 @@ jobs:
   build-psv:
     name: Make (PS Vita)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -168,6 +170,7 @@ jobs:
   build-switch:
     name: Make (Nintendo Switch)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container: devkitpro/devkita64:latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -38,6 +38,7 @@ jobs:
           release_tag: fheroes2-windows-x64-SDL2
     name: MSVC (${{ matrix.config.name }})
     runs-on: windows-2019
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -1,10 +1,7 @@
 name: MSVC
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -6,7 +6,6 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: false
       matrix:
         config:
         - name: SDL1 x86

--- a/.github/workflows/pr_author_auto_assign.yml
+++ b/.github/workflows/pr_author_auto_assign.yml
@@ -8,6 +8,7 @@ jobs:
   assign:
     name: PR author auto assign
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - uses: toshimaru/auto-author-assign@v1.4.0
       with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   style:
     name: Code style check

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,17 +13,11 @@ jobs:
     name: Code style check
     uses: ./.github/workflows/code_style_check.yml
 
-  cmake:
-    name: CMake
+  clang:
+    name: Clang Analyzer
     needs:
     - style
-    uses: ./.github/workflows/cmake.yml
-
-  make:
-    name: Make
-    needs:
-    - style
-    uses: ./.github/workflows/make.yml
+    uses: ./.github/workflows/clang_analyzer.yml
 
   msvc:
     name: MSVC
@@ -31,20 +25,22 @@ jobs:
     - style
     uses: ./.github/workflows/msvc.yml
 
-  clang:
-    name: Clang Analyzer
-    needs:
-    - cmake
-    - make
-    - msvc
-    uses: ./.github/workflows/clang_analyzer.yml
-
   sonarcloud:
     name: SonarCloud Analyzer
     needs:
-    - cmake
-    - make
-    - msvc
+    - style
     uses: ./.github/workflows/sonarcloud.yml
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  cmake:
+    name: CMake
+    needs:
+    - msvc
+    uses: ./.github/workflows/cmake.yml
+
+  make:
+    name: Make
+    needs:
+    - msvc
+    uses: ./.github/workflows/make.yml

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,46 @@
+name: Pull Request
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  style:
+    name: Code style check
+    uses: ./.github/workflows/code_style_check.yml
+
+  cmake:
+    name: CMake
+    needs:
+    - style
+    uses: ./.github/workflows/cmake.yml
+
+  make:
+    name: Make
+    needs:
+    - style
+    uses: ./.github/workflows/make.yml
+
+  msvc:
+    name: MSVC
+    needs:
+    - style
+    uses: ./.github/workflows/msvc.yml
+
+  clang:
+    name: Clang Analyzer
+    needs:
+    - cmake
+    - make
+    - msvc
+    uses: ./.github/workflows/clang_analyzer.yml
+
+  sonarcloud:
+    name: SonarCloud Analyzer
+    needs:
+    - cmake
+    - make
+    - msvc
+    uses: ./.github/workflows/sonarcloud.yml
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   make:
     name: Make

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,20 @@
+name: Push
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  make:
+    name: Make
+    uses: ./.github/workflows/make.yml
+
+  msvc:
+    name: MSVC
+    uses: ./.github/workflows/msvc.yml
+
+  sonarcloud:
+    name: SonarCloud Analyzer
+    uses: ./.github/workflows/sonarcloud.yml
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,10 +1,10 @@
 name: SonarCloud Analyzer
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  workflow_call:
+    secrets:
+      SONAR_TOKEN:
+        required: true
 
 jobs:
   sonarcloud:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -10,6 +10,7 @@ jobs:
   sonarcloud:
     name: SonarCloud Analyzer
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: ${{ github.repository == 'ihhub/fheroes2' && ( github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) ) }}
     env:
       SONAR_SCANNER_VERSION: 4.5.0.2216


### PR DESCRIPTION
Now we have a complex set of workflows with a couple dozen of jobs, and there are the following problems with them:

* Slow feedback. Quick but important checks (such as code style check or Clang-Tidy) may be started too late.
* Even if one of the essential checks fails, other workflows still continue to run, which is pointless.
* After updating the PR branch, the checks already running continue to run, which is pointless and slows down checks for the updated PR as well as other PRs.

This PR is designed to try to address these problems using the following techniques:

* Make feedback faster by running fast, but essential checks first, and failing fast the build in case of any issues.
* Automatically cancel already running workflows after updating the branch and before running a new workflow instance.
* Fail fast on matrix jobs.

That's how it looks like:

https://github.com/ihhub/fheroes2/actions/runs/2031938649

If the code style check fails, no other workflows will run. If MSVC build (which is relatively fast) fails, there is no point to run Make or CMake builds. Analyzers are launched first to speed up feedback.