### PR TITLE
Fix the calculation of the cost of surrender

### DIFF
--- a/src/fheroes2/army/army_troop.cpp
+++ b/src/fheroes2/army/army_troop.cpp
@@ -124,12 +124,12 @@ bool Troop::isEmpty( void ) const
     return !isValid();
 }
 
-payment_t Troop::GetCost( void ) const
+payment_t Troop::GetCost() const
 {
     return Monster::GetCost() * count;
 }
 
-payment_t Troop::GetUpgradeCost( void ) const
+payment_t Troop::GetUpgradeCost() const
 {
     return Monster::GetUpgradeCost() * count;
 }

--- a/src/fheroes2/army/army_troop.h
+++ b/src/fheroes2/army/army_troop.h
@@ -53,8 +53,8 @@ public:
     u32 GetDamageMin( void ) const;
     u32 GetDamageMax( void ) const;
 
-    payment_t GetCost( void ) const;
-    payment_t GetUpgradeCost( void ) const;
+    payment_t GetCost() const override;
+    payment_t GetUpgradeCost() const override;
 
     virtual bool isValid( void ) const;
     virtual bool isEmpty( void ) const;

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -141,7 +141,7 @@ bool Battle::Force::isValid( const bool considerBattlefieldArmy /* = true */ ) c
     }
 
     // Consider only the state of the original army
-    for ( uint32_t index = 0; index < army.Size(); ++index ) {
+    for ( size_t index = 0; index < army.Size(); ++index ) {
         const Troop * troop = army.GetTroop( index );
 
         if ( troop && troop->isValid() ) {
@@ -156,17 +156,25 @@ bool Battle::Force::isValid( const bool considerBattlefieldArmy /* = true */ ) c
     return false;
 }
 
-uint32_t Battle::Force::GetSurrenderCost( void ) const
+uint32_t Battle::Force::GetSurrenderCost() const
 {
     double res = 0;
 
-    for ( const_iterator it = begin(); it != end(); ++it )
-        if ( ( *it )->isValid() ) {
-            const payment_t & payment = ( *it )->GetCost();
-            res += payment.gold;
+    // Consider only the units from the original army
+    for ( size_t index = 0; index < army.Size(); ++index ) {
+        const Troop * troop = army.GetTroop( index );
+
+        if ( troop && troop->isValid() ) {
+            const Unit * unit = FindUID( uids.at( index ) );
+
+            if ( unit && unit->isValid() ) {
+                res += unit->GetCost().gold;
+            }
         }
+    }
 
     const HeroBase * commander = GetCommander();
+
     if ( commander ) {
         const Artifact art( Artifact::STATESMAN_QUILL );
         double mod = commander->hasArtifact( art ) ? art.ExtraValue() / 100.0 : 0.5;
@@ -182,8 +190,10 @@ uint32_t Battle::Force::GetSurrenderCost( void ) const
             mod *= 0.4;
             break;
         }
+
         res *= mod;
     }
+
     // Total cost should always be at least 1 gold
     return res >= 1 ? static_cast<uint32_t>( res + 0.5 ) : 1;
 }

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -76,7 +76,7 @@ namespace Battle
         u32 GetDeadCounts( void ) const;
         int GetColor( void ) const;
         int GetControl( void ) const;
-        uint32_t GetSurrenderCost( void ) const;
+        uint32_t GetSurrenderCost() const;
         Troops GetKilledTroops( void ) const;
         bool animateIdleUnits();
         void resetIdleAnimation();

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1119,6 +1119,12 @@ u32 Battle::Unit::GetHitPoints( void ) const
     return hp;
 }
 
+payment_t Battle::Unit::GetCost() const
+{
+    // Resurrected (not truly resurrected) units should not be taken into account when calculating the cost of surrender
+    return Monster::GetCost() * ( GetDead() > GetInitialCount() ? 0 : GetInitialCount() - GetDead() );
+}
+
 int Battle::Unit::GetControl( void ) const
 {
     return !GetArmy() ? CONTROL_AI : GetArmy()->GetControl();

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -170,6 +170,7 @@ namespace Battle
         uint32_t GetInitialCount() const;
         u32 GetDead( void ) const;
         u32 GetHitPoints( void ) const;
+        payment_t GetCost() const override; // used to calculate the cost of the surrender
 
         uint32_t GetShots() const override
         {

--- a/src/fheroes2/monster/monster.cpp
+++ b/src/fheroes2/monster/monster.cpp
@@ -1023,12 +1023,12 @@ int Monster::ICNMonh( void ) const
     return id >= PEASANT && id <= WATER_ELEMENT ? ICN::MONH0000 + id - PEASANT : ICN::UNKNOWN;
 }
 
-payment_t Monster::GetCost( void ) const
+payment_t Monster::GetCost() const
 {
     return payment_t( fheroes2::getMonsterData( id ).generalStats.cost );
 }
 
-payment_t Monster::GetUpgradeCost( void ) const
+payment_t Monster::GetUpgradeCost() const
 {
     const Monster upgr = GetUpgrade();
     const payment_t pay = id != upgr.id ? upgr.GetCost() - GetCost() : GetCost();

--- a/src/fheroes2/monster/monster.h
+++ b/src/fheroes2/monster/monster.h
@@ -190,8 +190,8 @@ public:
     int ICNMonh( void ) const;
 
     u32 GetSpriteIndex( void ) const;
-    payment_t GetCost( void ) const;
-    payment_t GetUpgradeCost( void ) const;
+    virtual payment_t GetCost() const;
+    virtual payment_t GetUpgradeCost() const;
     u32 GetDwelling( void ) const;
 
     int GetMonsterSprite() const;


### PR DESCRIPTION
fix #5168

Also fixed an issue when resurrected (not truly resurrected) units were taken into account when calculating the cost of surrender.