### PR TITLE
Remove unnecessary call to play VICTORY music during Campaign intro

### DIFF
--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -228,8 +228,6 @@ fheroes2::GameMode Game::NewSuccessionWarsCampaign()
     campaignSaveData.reset();
     campaignSaveData.setCurrentScenarioInfoId( { chosenCampaign, 0 } );
 
-    AGG::PlayMusic( MUS::VICTORY, true, true );
-
     return fheroes2::GameMode::SELECT_CAMPAIGN_SCENARIO;
 }
 


### PR DESCRIPTION
I noticed the VICTORY track getting called right after "choosing your lord" in the original campaigns for no apparent reason. You don't hear it getting played and it shouldn't be played here.