### PR TITLE
Fix High Score Music after winning scenario

### DIFF
--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -816,6 +816,9 @@ fheroes2::GameMode Game::CompleteCampaignScenario( const bool isLoadingSaveFile 
 
         AGG::ResetAudio();
         Video::ShowVideo( "WIN.SMK", Video::VideoAction::WAIT_FOR_USER_INPUT );
+        // TODO : Implement function that displays the last frame of win.smk with score
+        // and a dialog for name entry. AGG:PlayMusic is run here in order to start
+        // playing before displaying the high score.
         AGG::PlayMusic( MUS::VICTORY, true, true );
         return fheroes2::GameMode::HIGHSCORES;
     }

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -816,6 +816,7 @@ fheroes2::GameMode Game::CompleteCampaignScenario( const bool isLoadingSaveFile 
 
         AGG::ResetAudio();
         Video::ShowVideo( "WIN.SMK", Video::VideoAction::WAIT_FOR_USER_INPUT );
+        AGG::PlayMusic( MUS::VICTORY, true, true );
         return fheroes2::GameMode::HIGHSCORES;
     }
 

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -478,11 +478,6 @@ fheroes2::GameMode Game::HighScores()
 
     const std::string highScoreDataPath = System::ConcatePath( GetSaveDir(), "fheroes2.hgs" );
 
-    // Stop all sounds, but not the music
-    Mixer::Stop();
-
-    AGG::PlayMusic( MUS::MAINMENU, true, true );
-
     if ( !hgs.Load( highScoreDataPath ) ) {
         // Unable to load the file. Let's populate with the default values.
         hgs.populateHighScoresStandard();

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -29,7 +29,6 @@
 
 #include "agg.h"
 #include "agg_image.h"
-#include "audio.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "game.h"

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -343,7 +343,7 @@ fheroes2::GameMode GameOver::Result::LocalCheckGameOver()
                 else {
                     AGG::ResetAudio();
                     Video::ShowVideo( "WIN.SMK", Video::VideoAction::WAIT_FOR_USER_INPUT );
-                    AGG::PlayMusic( MUS::VICTORY, true, true );
+                    AGG::PlayMusic( MUS::VICTORY, true, false );
 
                     res = fheroes2::GameMode::HIGHSCORES;
 

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -343,7 +343,7 @@ fheroes2::GameMode GameOver::Result::LocalCheckGameOver()
                 else {
                     AGG::ResetAudio();
                     Video::ShowVideo( "WIN.SMK", Video::VideoAction::WAIT_FOR_USER_INPUT );
-                    AGG::PlayMusic( MUS::VICTORY, true, false );
+                    AGG::PlayMusic( MUS::VICTORY, true, true );
 
                     res = fheroes2::GameMode::HIGHSCORES;
 

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -343,6 +343,7 @@ fheroes2::GameMode GameOver::Result::LocalCheckGameOver()
                 else {
                     AGG::ResetAudio();
                     Video::ShowVideo( "WIN.SMK", Video::VideoAction::WAIT_FOR_USER_INPUT );
+                    AGG::PlayMusic( MUS::VICTORY, true, true );
 
                     res = fheroes2::GameMode::HIGHSCORES;
 

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -343,6 +343,9 @@ fheroes2::GameMode GameOver::Result::LocalCheckGameOver()
                 else {
                     AGG::ResetAudio();
                     Video::ShowVideo( "WIN.SMK", Video::VideoAction::WAIT_FOR_USER_INPUT );
+                    // TODO : Implement function that displays the last frame of win.smk and
+                    // a dialog for name entry. AGG:PlayMusic is run here in order to start playing
+                    // before displaying the high score.
                     AGG::PlayMusic( MUS::VICTORY, true, true );
 
                     res = fheroes2::GameMode::HIGHSCORES;

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -646,8 +646,8 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
                     res = HumanTurn( loadedFromSave );
 
-                    // Audio has already been reset if scenario is won and WIN.SMK has played.
-                    if ( Game::CurrentMusic() == MUS::VICTORY ) {
+                    // Skip resetting Audio after winning scenario because MUS::VICTORY should continue playing.
+                    if ( res == fheroes2::GameMode::HIGHSCORES ) {
                         break;
                     }
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -646,7 +646,12 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
                     res = HumanTurn( loadedFromSave );
 
-                    // reset environment sounds and music theme at the end of the human turn
+                    // Audio has already been reset if scenario is won and WIN.SMK has played.
+                    if ( Game::CurrentMusic() == MUS::VICTORY ) {
+                        break;
+                    }
+
+                    // Reset environment sounds and music theme at the end of the human turn.
                     Game::SetCurrentMusic( MUS::UNKNOWN );
                     AGG::ResetAudio();
 


### PR DESCRIPTION
This plays the Victory theme when winning a scenario after the Dragon animation like OG, instead of the Main Menu theme like  it does currently, and it makes sure that the Main Menu theme continues to play if opening the High Score from the Main Menu, like in the original game.

This also future-proofs for when the Victory theme will be played while showing the Congratulations text behind the painting after the Dragon animation, but before the High Score menu is displayed.