### PR TITLE
Fix army order option related crash

### DIFF
--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -1449,8 +1449,8 @@ namespace fheroes2
 
         const bool isValidRoi = roi.width > 0 && roi.height > 0;
 
-        const int32_t minX = isValidRoi ? roi.x : 0;
-        const int32_t minY = isValidRoi ? roi.y : 0;
+        const int32_t minX = isValidRoi ? std::max( roi.x, 0 ) : 0;
+        const int32_t minY = isValidRoi ? std::max( roi.y, 0 ) : 0;
         int32_t maxX = isValidRoi ? roi.x + roi.width : width;
         int32_t maxY = isValidRoi ? roi.y + roi.height : height;
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -910,7 +910,11 @@ void Battle::ArmiesOrder::Redraw( const Unit * current, const uint8_t currentUni
         return;
     }
 
-    const int32_t validUnitCount = static_cast<int32_t>( std::count_if( orders->begin(), orders->end(), []( const Unit * unit ) { return unit->isValid(); } ) );
+    const int32_t validUnitCount = static_cast<int32_t>( std::count_if( orders->begin(), orders->end(), []( const Unit * unit ) {
+        assert( unit != nullptr );
+        return unit->isValid();
+    } ) );
+
     const int32_t maximumUnitsToDraw = area.width / armyOrderMonsterIconSize;
 
     int32_t offsetX = area.x;
@@ -936,7 +940,8 @@ void Battle::ArmiesOrder::Redraw( const Unit * current, const uint8_t currentUni
             break;
         }
 
-        if ( unit == nullptr || !unit->isValid() ) {
+        assert( unit != nullptr );
+        if ( !unit->isValid() ) {
             continue;
         }
 


### PR DESCRIPTION
This fixes #5167 . Also for cases when the number of units to display is more than the screen the order is floating (relates to #5166 ) which means that the bar will show only limited number of units but shifts the order during the progression of the battle.