### PR TITLE
Avoid extra memory reallocations while handling stream buffers

### DIFF
--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <cassert>
 #include <cstring>
 #include <string>
 
@@ -450,6 +451,9 @@ void StreamBuf::putRaw( const char * ptr, size_t sz )
             reallocbuf( capacity() + sz );
         }
     }
+
+    // Make sure that the possible previous memory reallocation was correct.
+    assert( sizep() >= sz );
 
     memcpy( itput, ptr, sz );
     itput = itput + sz;

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -438,8 +438,21 @@ std::vector<u8> StreamBuf::getRaw( size_t sz )
 
 void StreamBuf::putRaw( const char * ptr, size_t sz )
 {
-    for ( size_t it = 0; it < sz; ++it )
-        *this << ptr[it];
+    if ( sz == 0 ) {
+        return;
+    }
+
+    if ( sizep() < sz ) {
+        if ( sz < capacity() / 2 ) {
+            reallocbuf( capacity() + capacity() / 2 );
+        }
+        else {
+            reallocbuf( capacity() + sz );
+        }
+    }
+
+    memcpy( itput, ptr, sz );
+    itput = itput + sz;
 }
 
 std::string StreamBuf::toString( size_t sz )
@@ -615,8 +628,8 @@ void StreamFile::putRaw( const char * ptr, size_t sz )
 
 StreamBuf StreamFile::toStreamBuf( size_t sz )
 {
-    StreamBuf sb;
     std::vector<uint8_t> buf = getRaw( sz );
+    StreamBuf sb( buf.size() );
     sb.putRaw( reinterpret_cast<const char *>( &buf[0] ), buf.size() );
     return sb;
 }


### PR DESCRIPTION
This significantly increases loading of translation files, save files and AGG files.