### PR TITLE
Use move operators for Stream Buffer

### DIFF
--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -595,10 +595,10 @@ namespace fheroes2
     Sprite & Sprite::operator=( Sprite && sprite ) noexcept
     {
         if ( this != &sprite ) {
-            Image::operator=( std::move( sprite ) );
-
             std::swap( _x, sprite._x );
             std::swap( _y, sprite._y );
+
+            Image::operator=( std::move( sprite ) );
         }
 
         return *this;

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -595,10 +595,10 @@ namespace fheroes2
     Sprite & Sprite::operator=( Sprite && sprite ) noexcept
     {
         if ( this != &sprite ) {
+            Image::operator=( std::move( sprite ) );
+
             std::swap( _x, sprite._x );
             std::swap( _y, sprite._y );
-
-            Image::operator=( std::move( sprite ) );
         }
 
         return *this;

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -211,7 +211,8 @@ StreamBuf::~StreamBuf()
 }
 
 StreamBuf::StreamBuf( StreamBuf && st ) noexcept
-    : itbeg( nullptr )
+    : StreamBase( std::move( st ) )
+    , itbeg( nullptr )
     , itget( nullptr )
     , itput( nullptr )
     , itend( nullptr )
@@ -252,6 +253,8 @@ StreamBuf::StreamBuf( const u8 * buf, size_t bufsz )
 
 StreamBuf & StreamBuf::operator=( StreamBuf && st ) noexcept
 {
+    StreamBase::operator=( std::move( st ) );
+
     std::swap( itbeg, st.itbeg );
     std::swap( itget, st.itget );
     std::swap( itput, st.itput );

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -210,15 +210,6 @@ StreamBuf::~StreamBuf()
         delete[] itbeg;
 }
 
-StreamBuf::StreamBuf( const StreamBuf & st )
-    : itbeg( nullptr )
-    , itget( nullptr )
-    , itput( nullptr )
-    , itend( nullptr )
-{
-    copy( st );
-}
-
 StreamBuf::StreamBuf( StreamBuf && st ) noexcept
     : itbeg( nullptr )
     , itget( nullptr )
@@ -257,13 +248,6 @@ StreamBuf::StreamBuf( const u8 * buf, size_t bufsz )
     itput = itend;
     setconstbuf( true );
     setbigendian( IS_BIGENDIAN ); /* default: hardware endian */
-}
-
-StreamBuf & StreamBuf::operator=( const StreamBuf & st )
-{
-    if ( &st != this )
-        copy( st );
-    return *this;
 }
 
 StreamBuf & StreamBuf::operator=( StreamBuf && st ) noexcept

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -334,20 +334,6 @@ void StreamBuf::reallocbuf( size_t sz )
     }
 }
 
-void StreamBuf::copy( const StreamBuf & sb )
-{
-    if ( capacity() < sb.size() )
-        reallocbuf( sb.size() );
-
-    std::copy( sb.itget, sb.itput, itbeg );
-
-    itput = itbeg + sb.tellp();
-    itget = itbeg + sb.tellg();
-    flags = 0;
-
-    setbigendian( sb.bigendian() );
-}
-
 void StreamBuf::put8( const uint8_t v )
 {
     if ( sizep() == 0 )

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -253,12 +253,12 @@ StreamBuf::StreamBuf( const u8 * buf, size_t bufsz )
 
 StreamBuf & StreamBuf::operator=( StreamBuf && st ) noexcept
 {
-    StreamBase::operator=( std::move( st ) );
-
     std::swap( itbeg, st.itbeg );
     std::swap( itget, st.itget );
     std::swap( itput, st.itput );
     std::swap( itend, st.itend );
+
+    StreamBase::operator=( std::move( st ) );
 
     return *this;
 }

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -193,7 +193,7 @@ StreamBase & StreamBase::operator<<( const fheroes2::Point & point_ )
     return *this << point_.x << point_.y;
 }
 
-StreamBuf::StreamBuf( size_t sz )
+StreamBuf::StreamBuf( const size_t sz )
     : itbeg( nullptr )
     , itget( nullptr )
     , itput( nullptr )
@@ -217,6 +217,18 @@ StreamBuf::StreamBuf( const StreamBuf & st )
     , itend( nullptr )
 {
     copy( st );
+}
+
+StreamBuf::StreamBuf( StreamBuf && st ) noexcept
+    : itbeg( nullptr )
+    , itget( nullptr )
+    , itput( nullptr )
+    , itend( nullptr )
+{
+    std::swap( itbeg, st.itbeg );
+    std::swap( itget, st.itget );
+    std::swap( itput, st.itput );
+    std::swap( itend, st.itend );
 }
 
 StreamBuf::StreamBuf( const std::vector<u8> & buf )
@@ -251,6 +263,16 @@ StreamBuf & StreamBuf::operator=( const StreamBuf & st )
 {
     if ( &st != this )
         copy( st );
+    return *this;
+}
+
+StreamBuf & StreamBuf::operator=( StreamBuf && st ) noexcept
+{
+    std::swap( itbeg, st.itbeg );
+    std::swap( itget, st.itget );
+    std::swap( itput, st.itput );
+    std::swap( itend, st.itend );
+
     return *this;
 }
 

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -253,12 +253,14 @@ StreamBuf::StreamBuf( const u8 * buf, size_t bufsz )
 
 StreamBuf & StreamBuf::operator=( StreamBuf && st ) noexcept
 {
-    std::swap( itbeg, st.itbeg );
-    std::swap( itget, st.itget );
-    std::swap( itput, st.itput );
-    std::swap( itend, st.itend );
+    if ( &st != this ) {
+        StreamBase::operator=( std::move( st ) );
 
-    StreamBase::operator=( std::move( st ) );
+        std::swap( itbeg, st.itbeg );
+        std::swap( itget, st.itget );
+        std::swap( itput, st.itput );
+        std::swap( itend, st.itend );
+    }
 
     return *this;
 }

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -42,7 +42,25 @@ public:
     StreamBase()
         : flags( 0 )
     {}
+
+    StreamBase( const StreamBase & ) = delete;
+
+    StreamBase( StreamBase && stream ) noexcept
+        : flags( 0 )
+    {
+        std::swap( flags, stream.flags );
+    }
+
     virtual ~StreamBase() = default;
+
+    StreamBase & operator=( const StreamBase & ) = delete;
+
+    StreamBase & operator=( StreamBase && stream ) noexcept
+    {
+        std::swap( flags, stream.flags );
+
+        return *this;
+    }
 
     void setbigendian( bool );
 
@@ -264,7 +282,10 @@ class StreamFile : public StreamBase
 public:
     StreamFile();
     StreamFile( const StreamFile & ) = delete;
+    StreamFile( StreamFile && ) = delete;
+
     StreamFile & operator=( const StreamFile & ) = delete;
+    StreamFile & operator=( StreamFile && ) = delete;
 
     ~StreamFile() override;
 

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -246,7 +246,6 @@ protected:
     size_t sizeg( void ) const override;
     size_t sizep( void ) const override;
 
-    void copy( const StreamBuf & );
     void reallocbuf( size_t );
 
     u8 get8() override;

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -204,14 +204,17 @@ protected:
 class StreamBuf : public StreamBase
 {
 public:
-    explicit StreamBuf( size_t = 0 );
-    StreamBuf( const StreamBuf & );
+    explicit StreamBuf( const size_t sz = 0 );
+    StreamBuf( const StreamBuf & st );
+    StreamBuf( StreamBuf && st ) noexcept;
+
     explicit StreamBuf( const std::vector<u8> & );
     StreamBuf( const u8 *, size_t );
 
     ~StreamBuf() override;
 
-    StreamBuf & operator=( const StreamBuf & );
+    StreamBuf & operator=( const StreamBuf & st );
+    StreamBuf & operator=( StreamBuf && st ) noexcept;
 
     const u8 * data( void ) const;
     size_t size( void ) const;

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -205,7 +205,7 @@ class StreamBuf : public StreamBase
 {
 public:
     explicit StreamBuf( const size_t sz = 0 );
-    StreamBuf( const StreamBuf & st );
+    StreamBuf( const StreamBuf & st ) = delete;
     StreamBuf( StreamBuf && st ) noexcept;
 
     explicit StreamBuf( const std::vector<u8> & );
@@ -213,7 +213,7 @@ public:
 
     ~StreamBuf() override;
 
-    StreamBuf & operator=( const StreamBuf & st );
+    StreamBuf & operator=( const StreamBuf & st ) = delete;
     StreamBuf & operator=( StreamBuf && st ) noexcept;
 
     const u8 * data( void ) const;


### PR DESCRIPTION
Reduce the amount of memory being used (especially within StreamFile::toStreamBuf method).