### PR TITLE
GitHub Actions: use shallow clone for VDPM, fix broken PSV build, improve Makefiles

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -120,7 +120,7 @@ jobs:
     - name: Setup Vita SDK
       continue-on-error: true
       run: |
-        git clone https://github.com/vitasdk/vdpm
+        git clone --depth 1 https://github.com/vitasdk/vdpm
         cd vdpm
         export PATH="$VITASDK/bin:$PATH"
         ./bootstrap-vitasdk.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,23 @@
+###########################################################################
+#   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
+#   Copyright (C) 2022                                                    #
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+#   This program is distributed in the hope that it will be useful,       #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+#   GNU General Public License for more details.                          #
+#                                                                         #
+#   You should have received a copy of the GNU General Public License     #
+#   along with this program; if not, write to the                         #
+#   Free Software Foundation, Inc.,                                       #
+#   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
+###########################################################################
+
 cmake_minimum_required(VERSION 3.20)
 cmake_policy(SET CMP0074 NEW)
 

--- a/Makefile
+++ b/Makefile
@@ -43,20 +43,20 @@ endif
 
 bundle:
 ifdef FHEROES2_MACOS_APP_BUNDLE
-	@mkdir -p "src/dist/${TARGET}.app/Contents/Resources/translations"
-	@mkdir -p "src/dist/${TARGET}.app/Contents/Resources/h2d"
-	@mkdir -p "src/dist/${TARGET}.app/Contents/MacOS"
-	@cp ./fheroes2.key "src/dist/${TARGET}.app/Contents/Resources"
-	@cp ./src/resources/fheroes2.icns "src/dist/${TARGET}.app/Contents/Resources"
-	@cp ./files/lang/*.mo "src/dist/${TARGET}.app/Contents/Resources/translations"
-	@cp ./files/data/*.h2d "src/dist/${TARGET}.app/Contents/Resources/h2d"
-	@sed -e "s/\$${MACOSX\_BUNDLE\_EXECUTABLE\_NAME}/${TARGET}/" -e "s/\$${MACOSX\_BUNDLE\_ICON\_FILE}/fheroes2.icns/" -e "s/\$${MACOSX\_BUNDLE\_GUI\_IDENTIFIER}/com.fheroes2.${TARGET}/" -e "s/\$${MACOSX\_BUNDLE\_BUNDLE\_NAME}/${TARGET}/" -e "s/\$${MACOSX\_BUNDLE\_BUNDLE\_VERSION}/${PROJECT_VERSION}/" -e "s/\$${MACOSX\_BUNDLE\_SHORT\_VERSION\_STRING}/${PROJECT_VERSION}/" ./src/resources/Info.plist.in > "src/dist/${TARGET}.app/Contents/Info.plist"
-	@mv "src/dist/${TARGET}" "src/dist/${TARGET}.app/Contents/MacOS"
-	@dylibbundler -od -b -x "src/dist/${TARGET}.app/Contents/MacOS/${TARGET}" -d "src/dist/${TARGET}.app/Contents/libs"
-	@cp -R "src/dist/${TARGET}.app" .
+	@mkdir -p "src/dist/$(TARGET).app/Contents/Resources/translations"
+	@mkdir -p "src/dist/$(TARGET).app/Contents/Resources/h2d"
+	@mkdir -p "src/dist/$(TARGET).app/Contents/MacOS"
+	@cp ./fheroes2.key "src/dist/$(TARGET).app/Contents/Resources"
+	@cp ./src/resources/fheroes2.icns "src/dist/$(TARGET).app/Contents/Resources"
+	@cp ./files/lang/*.mo "src/dist/$(TARGET).app/Contents/Resources/translations"
+	@cp ./files/data/*.h2d "src/dist/$(TARGET).app/Contents/Resources/h2d"
+	@sed -e "s/\$${MACOSX_BUNDLE_EXECUTABLE_NAME}/$(TARGET)/" -e "s/\$${MACOSX_BUNDLE_ICON_FILE}/fheroes2.icns/" -e "s/\$${MACOSX_BUNDLE_GUI_IDENTIFIER}/com.fheroes2.$(TARGET)/" -e "s/\$${MACOSX_BUNDLE_BUNDLE_NAME}/$(TARGET)/" -e "s/\$${MACOSX_BUNDLE_BUNDLE_VERSION}/$(PROJECT_VERSION)/" -e "s/\$${MACOSX_BUNDLE_SHORT_VERSION_STRING}/$(PROJECT_VERSION)/" ./src/resources/Info.plist.in > "src/dist/$(TARGET).app/Contents/Info.plist"
+	@mv "src/dist/$(TARGET)" "src/dist/$(TARGET).app/Contents/MacOS"
+	@dylibbundler -od -b -x "src/dist/$(TARGET).app/Contents/MacOS/$(TARGET)" -d "src/dist/$(TARGET).app/Contents/libs"
+	@cp -R "src/dist/$(TARGET).app" .
 endif
 
 clean:
 	$(MAKE) -C src clean
 	@rm -f ./$(TARGET)
-	@rm -rf ./${TARGET}.app
+	@rm -rf ./$(TARGET).app

--- a/files/lang/Makefile
+++ b/files/lang/Makefile
@@ -1,6 +1,22 @@
-#
-# makefile
-#
+###########################################################################
+#   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
+#   Copyright (C) 2022                                                    #
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+#   This program is distributed in the hope that it will be useful,       #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+#   GNU General Public License for more details.                          #
+#                                                                         #
+#   You should have received a copy of the GNU General Public License     #
+#   along with this program; if not, write to the                         #
+#   Free Software Foundation, Inc.,                                       #
+#   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
+###########################################################################
 
 .PHONY: all clean merge
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,23 @@
+###########################################################################
+#   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
+#   Copyright (C) 2022                                                    #
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+#   This program is distributed in the hope that it will be useful,       #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+#   GNU General Public License for more details.                          #
+#                                                                         #
+#   You should have received a copy of the GNU General Public License     #
+#   along with this program; if not, write to the                         #
+#   Free Software Foundation, Inc.,                                       #
+#   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
+###########################################################################
+
 if (MSVC)
 	add_compile_options(/W4)
 else()

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 ###########################################################################
 #   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
-#   Copyright (C) 2021                                                    #
+#   Copyright (C) 2021 - 2022                                             #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #
@@ -20,25 +20,43 @@
 
 TARGET := fheroes2
 
-ifdef FHEROES2_WITH_DEBUG
-CFLAGS := $(CFLAGS) -O0 -g -pedantic -DWITH_DEBUG
-else
-CFLAGS := -O3 $(CFLAGS)
-endif
+#
+# Common build options for fheroes2 and third-party libraries
+#
 
-CFLAGS := $(CFLAGS) -fsigned-char -pthread
-CXXFLAGS := -std=c++11 $(CFLAGS)
+# Common flags for both C and C++ compilers
+CCFLAGS := -fsigned-char -pthread
+# Flags for the C compiler
+CFLAGS := $(CFLAGS)
+# Flags for the C++ compiler
+CXXFLAGS := $(CXXFLAGS) -std=c++11
+# Flags for the linker
 LDFLAGS := $(LDFLAGS) -pthread
 LIBS := -lz
 
+ifdef FHEROES2_WITH_DEBUG
+CCFLAGS := $(CCFLAGS) -O0 -g -DWITH_DEBUG
+else
+CCFLAGS := $(CCFLAGS) -O3
+endif
+
+#
+# Build options for third-party libraries
+#
+
+CCFLAGS_TP := $(CCFLAGS)
 CFLAGS_TP := $(CFLAGS)
 CXXFLAGS_TP := $(CXXFLAGS)
 
+#
+# Build options for fheroes2
+#
+
 # Add -Wconversion -Wsign-conversion -Weffc++ -Woverloaded-virtual -Wextra-semi flags back once we fix all other warnings!
-CFLAGS := $(CXXFLAGS) -Wall -Wextra -Wpedantic -Wfloat-conversion -Wshadow -Wfloat-equal -Wredundant-decls -Wdouble-promotion -Wunused -Wuninitialized
+CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wfloat-conversion -Wshadow -Wfloat-equal -Wredundant-decls -Wdouble-promotion -Wunused -Wuninitialized
 
 ifdef FHEROES2_STRICT_COMPILATION
-CFLAGS := $(CFLAGS) -Werror
+CCFLAGS := $(CCFLAGS) -Werror
 endif
 
 ifdef FHEROES2_WITH_SDL1
@@ -56,7 +74,7 @@ SDL_LIBS := $(SDL_LIBS) -lSDL2_mixer
 endif
 
 ifdef FHEROES2_WITH_IMAGE
-CFLAGS := $(CFLAGS) -DWITH_IMAGE $(shell libpng-config --cflags)
+CCFLAGS := $(CCFLAGS) -DWITH_IMAGE $(shell libpng-config --cflags)
 ifdef FHEROES2_WITH_SDL1
 SDL_LIBS := $(SDL_LIBS) -lSDL_image $(shell libpng-config --libs)
 else
@@ -93,15 +111,15 @@ endif
 
 include Makefile.$(PLATFORM)
 
-CFLAGS := $(SDL_FLAGS) $(CFLAGS)
+CCFLAGS := $(CCFLAGS) $(SDL_FLAGS)
 LIBS := $(SDL_LIBS) $(LIBS)
 
-export CC CXX AR LINK WINDRES LDFLAGS CFLAGS LIBS PLATFORM
+export CC CXX AR LINK WINDRES CCFLAGS CFLAGS CXXFLAGS LDFLAGS LIBS PLATFORM
 
 .PHONY: all clean
 
 all:
-	$(MAKE) -C thirdparty/libsmacker CFLAGS="$(CFLAGS_TP)"
+	$(MAKE) -C thirdparty/libsmacker CCFLAGS="$(CCFLAGS_TP)" CFLAGS="$(CFLAGS_TP)" CXXFLAGS="$(CXXFLAGS_TP)"
 	$(MAKE) -C engine
 	$(MAKE) -C dist
 ifdef FHEROES2_WITH_TOOLS

--- a/src/Makefile.all
+++ b/src/Makefile.all
@@ -1,3 +1,23 @@
+###########################################################################
+#   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
+#   Copyright (C) 2022                                                    #
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+#   This program is distributed in the hope that it will be useful,       #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+#   GNU General Public License for more details.                          #
+#                                                                         #
+#   You should have received a copy of the GNU General Public License     #
+#   along with this program; if not, write to the                         #
+#   Free Software Foundation, Inc.,                                       #
+#   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
+###########################################################################
+
 AR := ar
 
 ifndef CXX

--- a/src/Makefile.bsd
+++ b/src/Makefile.bsd
@@ -1,3 +1,23 @@
+###########################################################################
+#   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
+#   Copyright (C) 2022                                                    #
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+#   This program is distributed in the hope that it will be useful,       #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+#   GNU General Public License for more details.                          #
+#                                                                         #
+#   You should have received a copy of the GNU General Public License     #
+#   along with this program; if not, write to the                         #
+#   Free Software Foundation, Inc.,                                       #
+#   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
+###########################################################################
+
 AR := ar
 CXX := g++
 LIBS := $(LIBS) -L/usr/local/lib

--- a/src/Makefile.mingw
+++ b/src/Makefile.mingw
@@ -1,5 +1,25 @@
+###########################################################################
+#   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
+#   Copyright (C) 2022                                                    #
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+#   This program is distributed in the hope that it will be useful,       #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+#   GNU General Public License for more details.                          #
+#                                                                         #
+#   You should have received a copy of the GNU General Public License     #
+#   along with this program; if not, write to the                         #
+#   Free Software Foundation, Inc.,                                       #
+#   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
+###########################################################################
+
 AR := ar
 CXX := g++
 WINDRES := windres
-LIBS := $(LIBS) -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lwinpthread
 # Static winpthread linking https://stackoverflow.com/a/28001261
+LIBS := $(LIBS) -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lwinpthread

--- a/src/Makefile.mingw32
+++ b/src/Makefile.mingw32
@@ -1,3 +1,23 @@
+###########################################################################
+#   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
+#   Copyright (C) 2022                                                    #
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+#   This program is distributed in the hope that it will be useful,       #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+#   GNU General Public License for more details.                          #
+#                                                                         #
+#   You should have received a copy of the GNU General Public License     #
+#   along with this program; if not, write to the                         #
+#   Free Software Foundation, Inc.,                                       #
+#   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
+###########################################################################
+
 LIBS := $(LIBS) -lSDL -lmad -lvorbisfile -lvorbis -logg
 
 ifndef WITHOUT_IMAGE
@@ -6,12 +26,12 @@ endif
 
 ifdef WITH_ICONS
 IDICON := 1099
-CFLAGS := $(CFLAGS) -DID_ICON=$(IDICON)
+CCFLAGS := $(CCFLAGS) -DID_ICON=$(IDICON)
 export IDICON
 endif
 
 AR := i686-w64-mingw32-ar
 CXX := i686-w64-mingw32-g++
 WINDRES := i686-w64-mingw32-windres
-CFLAGS := $(CFLAGS) -O2 -static
+CCFLAGS := $(CCFLAGS) -static
 LIBS := -static -Wl,-Bstatic $(LIBS) -lwinmm -ldxguid

--- a/src/Makefile.mingw32
+++ b/src/Makefile.mingw32
@@ -20,11 +20,11 @@
 
 LIBS := $(LIBS) -lSDL -lmad -lvorbisfile -lvorbis -logg
 
-ifndef WITHOUT_IMAGE
+ifdef FHEROES2_WITH_IMAGE
 LIBS := $(LIBS) -lSDL -lpng -ljpeg
 endif
 
-ifdef WITH_ICONS
+ifdef FHEROES2_WITH_ICONS
 IDICON := 1099
 CCFLAGS := $(CCFLAGS) -DID_ICON=$(IDICON)
 export IDICON

--- a/src/Makefile.osx
+++ b/src/Makefile.osx
@@ -1,3 +1,23 @@
+###########################################################################
+#   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
+#   Copyright (C) 2022                                                    #
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+#   This program is distributed in the hope that it will be useful,       #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+#   GNU General Public License for more details.                          #
+#                                                                         #
+#   You should have received a copy of the GNU General Public License     #
+#   along with this program; if not, write to the                         #
+#   Free Software Foundation, Inc.,                                       #
+#   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
+###########################################################################
+
 AR := ar
 
 ifndef CXX
@@ -16,6 +36,6 @@ LINK_FLAGS := $(subst $(search_pattern),,$(LIBS))
 LINK_FLAGS := $(subst $(comma_pattern), ,$(LINK_FLAGS)) $(SIMPLE_LINK_FLAGS)
 
 ifdef FHEROES2_MACOS_APP_BUNDLE
-CFLAGS := ${CFLAGS} -DMACOS_APP_BUNDLE
-LDFLAGS := ${LDFLAGS} -framework CoreFoundation
+CCFLAGS := $(CCFLAGS) -DMACOS_APP_BUNDLE
+LDFLAGS := $(LDFLAGS) -framework CoreFoundation
 endif

--- a/src/Makefile.switch
+++ b/src/Makefile.switch
@@ -1,9 +1,28 @@
+###########################################################################
+#   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
+#   Copyright (C) 2022                                                    #
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+#   This program is distributed in the hope that it will be useful,       #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+#   GNU General Public License for more details.                          #
+#                                                                         #
+#   You should have received a copy of the GNU General Public License     #
+#   along with this program; if not, write to the                         #
+#   Free Software Foundation, Inc.,                                       #
+#   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
+###########################################################################
+
 include $(DEVKITPRO)/libnx/switch_rules
 
-ARCH = -march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -fPIE
-CFLAGS := $(CFLAGS) $(ARCH) -D__SWITCH__
-CXXFLAGS := $(CXXFLAGS) $(ARCH) -D__SWITCH__
-CFLAGS_TP := $(CFLAGS_TP) $(ARCH)
-CXXFLAGS_TP := $(CXXFLAGS_TP) $(ARCH)
+ARCH := -march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -fPIE
+CCFLAGS := $(CCFLAGS) $(ARCH) -D__SWITCH__
+
+CCFLAGS_TP := $(CFLAGS_TP) $(ARCH)
 
 LIBS := $(LIBS) -lSDL2 -lpng16 -lbz2 -lvorbisidec -lmodplug -lmpg123 -lm -lopusfile -logg -lopus -ljpeg -lwebp -specs=$(DEVKITPRO)/libnx/switch.specs

--- a/src/Makefile.switch
+++ b/src/Makefile.switch
@@ -23,6 +23,6 @@ include $(DEVKITPRO)/libnx/switch_rules
 ARCH := -march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -fPIE
 CCFLAGS := $(CCFLAGS) $(ARCH) -D__SWITCH__
 
-CCFLAGS_TP := $(CFLAGS_TP) $(ARCH)
+CCFLAGS_TP := $(CCFLAGS_TP) $(ARCH)
 
 LIBS := $(LIBS) -lSDL2 -lpng16 -lbz2 -lvorbisidec -lmodplug -lmpg123 -lm -lopusfile -logg -lopus -ljpeg -lwebp -specs=$(DEVKITPRO)/libnx/switch.specs

--- a/src/Makefile.vita
+++ b/src/Makefile.vita
@@ -1,6 +1,6 @@
 ###########################################################################
 #   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
-#   Copyright (C) 2021                                                    #
+#   Copyright (C) 2021 - 2022                                             #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #
@@ -24,13 +24,14 @@ CXX := arm-vita-eabi-g++
 LIBS := -lz
 
 ifdef FHEROES2_STRICT_COMPILATION
-CFLAGS := $(CFLAGS) -Wno-error=pedantic -Wno-error=float-equal
+CCFLAGS := $(CCFLAGS) -Wno-error=pedantic -Wno-error=float-equal
 endif
 
-CFLAGS := $(CFLAGS) -DFHEROES2_VITA -I$(VITASDK)/arm-vita-eabi/include -O3 -mcpu=cortex-a9 -mfpu=neon -fgraphite-identity -floop-nest-optimize -fno-lto -fno-tree-slp-vectorize
-LDFLAGS := $(LDFLAGS) -L$(VITASDK)/arm-vita-eabi/lib -L$(VITASDK)/lib $(CFLAGS) -Wl,--sort-common -Wl,--whole-archive -Wl,--no-whole-archive -Wl,-q
-CFLAGS_TP := $(CFLAGS)
-CXXFLAGS_TP := $(CXXFLAGS)
+ARCH := -I$(VITASDK)/arm-vita-eabi/include -mcpu=cortex-a9 -mfpu=neon -fgraphite-identity -floop-nest-optimize -fno-lto -fno-tree-slp-vectorize
+CCFLAGS := $(CCFLAGS) -DFHEROES2_VITA $(ARCH)
+LDFLAGS := $(LDFLAGS) -L$(VITASDK)/arm-vita-eabi/lib -L$(VITASDK)/lib -Wl,--sort-common -Wl,--whole-archive -Wl,--no-whole-archive -Wl,-q
+
+CCFLAGS_TP := $(CCFLAGS_TP) $(ARCH)
 
 SDL_LIBS := -L$(VITASDK)/arm-vita-eabi/lib -lSDL2_mixer -lSDL2 -lvita2d -lScePower_stub -lSceAudio_stub -lSceCtrl_stub -lSceHid_stub -lSceTouch_stub -lSceDisplay_stub \
                                            -lSceGxm_stub -lSceAppMgr_stub -lSceSysmodule_stub -lSceCommonDialog_stub -lSceMotion_stub -lFLAC -lmikmod -lmpg123 -lvorbisfile \

--- a/src/Makefile.vita
+++ b/src/Makefile.vita
@@ -38,6 +38,6 @@ SDL_LIBS := -L$(VITASDK)/arm-vita-eabi/lib -lSDL2_mixer -lSDL2 -lvita2d -lScePow
                                            -lvorbis -logg
 SDL_FLAGS := -I$(VITASDK)/arm-vita-eabi/include/SDL2
 
-ifndef WITHOUT_IMAGE
+ifdef FHEROES2_WITH_IMAGE
 SDL_LIBS := $(SDL_LIBS) -lSDL2_image -ljpeg -lpng
 endif

--- a/src/Makefile.vita
+++ b/src/Makefile.vita
@@ -23,6 +23,10 @@ CC := arm-vita-eabi-gcc
 CXX := arm-vita-eabi-g++
 LIBS := -lz
 
+ifdef FHEROES2_STRICT_COMPILATION
+CFLAGS := $(CFLAGS) -Wno-error=pedantic -Wno-error=float-equal
+endif
+
 CFLAGS := $(CFLAGS) -DFHEROES2_VITA -I$(VITASDK)/arm-vita-eabi/include -O3 -mcpu=cortex-a9 -mfpu=neon -fgraphite-identity -floop-nest-optimize -fno-lto -fno-tree-slp-vectorize
 LDFLAGS := $(LDFLAGS) -L$(VITASDK)/arm-vita-eabi/lib -L$(VITASDK)/lib $(CFLAGS) -Wl,--sort-common -Wl,--whole-archive -Wl,--no-whole-archive -Wl,-q
 CFLAGS_TP := $(CFLAGS)

--- a/src/dist/Makefile
+++ b/src/dist/Makefile
@@ -1,6 +1,6 @@
 ###########################################################################
 #   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
-#   Copyright (C) 2021                                                    #
+#   Copyright (C) 2021 - 2022                                             #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #
@@ -24,13 +24,13 @@ endif
 
 TARGET := fheroes2
 LIBENGINE := ../engine/libengine.a
-CFLAGS := $(CFLAGS) -I../engine
+CCFLAGS := $(CCFLAGS) -I../engine
 
 LIBENGINE := $(LIBENGINE) ../thirdparty/libsmacker/libsmacker.a
-CFLAGS := $(CFLAGS) -I../thirdparty/libsmacker
+CCFLAGS := $(CCFLAGS) -I../thirdparty/libsmacker
 
 ifdef PREFIX
-CFLAGS := $(CFLAGS) -I$(PREFIX)/include
+CCFLAGS := $(CCFLAGS) -I$(PREFIX)/include
 endif
 
 ifeq ($(PLATFORM), mingw)
@@ -67,7 +67,7 @@ $(RES): $(RC)
 VPATH := $(SOURCEDIR)
 
 %.o: %.cpp
-	$(CXX) -c -MD $(addprefix -I, $(SOURCEDIR)) $< $(CFLAGS)
+	$(CXX) -c -MD $(addprefix -I, $(SOURCEDIR)) $< $(CCFLAGS) $(CXXFLAGS)
 
 include $(wildcard *.d)
 

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -1,3 +1,23 @@
+###########################################################################
+#   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
+#   Copyright (C) 2022                                                    #
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+#   This program is distributed in the hope that it will be useful,       #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+#   GNU General Public License for more details.                          #
+#                                                                         #
+#   You should have received a copy of the GNU General Public License     #
+#   along with this program; if not, write to the                         #
+#   Free Software Foundation, Inc.,                                       #
+#   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
+###########################################################################
+
 file(GLOB_RECURSE LIBENGINE_SOURCES CONFIGURE_DEPENDS *.cpp)
 
 add_library(engine STATIC ${LIBENGINE_SOURCES})

--- a/src/engine/Makefile
+++ b/src/engine/Makefile
@@ -1,6 +1,6 @@
 ###########################################################################
 #   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
-#   Copyright (C) 2021                                                    #
+#   Copyright (C) 2021 - 2022                                             #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #
@@ -19,7 +19,7 @@
 ###########################################################################
 
 TARGET	:= libengine
-CFLAGS := $(CFLAGS) -I../thirdparty/libsmacker
+CCFLAGS := $(CCFLAGS) -I../thirdparty/libsmacker
 
 .PHONY: all clean
 
@@ -29,7 +29,7 @@ $(TARGET).a: $(patsubst %.cpp, %.o, $(wildcard *.cpp))
 	$(AR) crvs $@ $^
 
 %.o: %.cpp
-	$(CXX) -c -MD $< $(CFLAGS)
+	$(CXX) -c -MD $< $(CCFLAGS) $(CXXFLAGS)
 
 include $(wildcard *.d)
 

--- a/src/fheroes2/CMakeLists.txt
+++ b/src/fheroes2/CMakeLists.txt
@@ -1,3 +1,23 @@
+###########################################################################
+#   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
+#   Copyright (C) 2022                                                    #
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+#   This program is distributed in the hope that it will be useful,       #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+#   GNU General Public License for more details.                          #
+#                                                                         #
+#   You should have received a copy of the GNU General Public License     #
+#   along with this program; if not, write to the                         #
+#   Free Software Foundation, Inc.,                                       #
+#   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
+###########################################################################
+
 file(GLOB_RECURSE FHEROES2_SOURCES CONFIGURE_DEPENDS *.cpp)
 
 if(MINGW)

--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -1,3 +1,23 @@
+###########################################################################
+#   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
+#   Copyright (C) 2022                                                    #
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+#   This program is distributed in the hope that it will be useful,       #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+#   GNU General Public License for more details.                          #
+#                                                                         #
+#   You should have received a copy of the GNU General Public License     #
+#   along with this program; if not, write to the                         #
+#   Free Software Foundation, Inc.,                                       #
+#   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
+###########################################################################
+
 if(USE_SYSTEM_LIBSMACKER)
 	include(FindPkgConfig)
 

--- a/src/thirdparty/libsmacker/Makefile
+++ b/src/thirdparty/libsmacker/Makefile
@@ -1,7 +1,22 @@
-# makefile
-# project: libsmacker
-
-CONLYFLAGS:=$(filter-out -std=c++11,$(CFLAGS))
+###########################################################################
+#   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
+#   Copyright (C) 2022                                                    #
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+#   This program is distributed in the hope that it will be useful,       #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+#   GNU General Public License for more details.                          #
+#                                                                         #
+#   You should have received a copy of the GNU General Public License     #
+#   along with this program; if not, write to the                         #
+#   Free Software Foundation, Inc.,                                       #
+#   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
+###########################################################################
 
 TARGET	:= libsmacker
 
@@ -13,7 +28,7 @@ $(TARGET).a: $(patsubst %.c, %.o, $(wildcard *.c))
 	$(AR) crvs $@ $^
 
 %.o: %.c
-	$(CC) -c -MD $< $(CONLYFLAGS)
+	$(CC) -c -MD $< $(CCFLAGS) $(CFLAGS)
 
 include $(wildcard *.d)
 

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,3 +1,23 @@
+###########################################################################
+#   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
+#   Copyright (C) 2022                                                    #
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+#   This program is distributed in the hope that it will be useful,       #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+#   GNU General Public License for more details.                          #
+#                                                                         #
+#   You should have received a copy of the GNU General Public License     #
+#   along with this program; if not, write to the                         #
+#   Free Software Foundation, Inc.,                                       #
+#   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
+###########################################################################
+
 add_executable(82m2wav 82m2wav.cpp)
 add_executable(bin2txt bin2txt.cpp)
 add_executable(extractor extractor.cpp)

--- a/src/tools/Makefile
+++ b/src/tools/Makefile
@@ -1,6 +1,6 @@
 ###########################################################################
 #   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  #
-#   Copyright (C) 2021                                                    #
+#   Copyright (C) 2021 - 2022                                             #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #
@@ -29,14 +29,14 @@ endif
 TARGETS := extractor 82m2wav til2img icn2img xmi2mid_cli bin2txt
 LIBENGINE := ../engine/libengine.a
 LIBS := $(LIBENGINE) $(SDL_LIBS) $(LIBS)
-CFLAGS := $(SDL_FLAGS) $(CFLAGS) -I../engine
+CCFLAGS := $(CCFLAGS) $(SDL_FLAGS) -I../engine
 
 .PHONY: all clean
 
 all: $(TARGETS)
 
 $(TARGETS): $(addsuffix .cpp, $(TARGETS)) $(LIBENGINE)
-	$(CXX) $(CFLAGS) -c $@.cpp
+	$(CXX) $(CCFLAGS) $(CXXFLAGS) -c $@.cpp
 	$(CXX) $(LDFLAGS) -o $@ $@.o $(LIBS)
 
 clean:


### PR DESCRIPTION
Make the build process a bit faster, disable some warnings specific for PSV and issued for the SDL library code, use `CCFLAGS` (Common CFLAGS) for both C and C++ compilers instead of using just `CFLAGS` and removing the C++ specific options via the `filter-out` construct, add copyright headers to makefiles.

Hi @ihhub could you please remove the Clang-Tidy from the list of required checks? It does not run if there is no changes in source files, like in this PR.