### PR TITLE
Fix the build for PSV, add multiple warning-related compiler flags to the Makefile, remove useless -Weffc++ from the waiting list

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -59,9 +59,8 @@ CCFLAGS := $(CCFLAGS) -DWITH_DEBUG
 endif
 
 # TODO: Add -Wconversion -Wsign-conversion -Wextra-semi -Wswitch-default flags back once we fix all the corresponding code smells!
-CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align=strict -Wctor-dtor-privacy -Wdouble-promotion -Wfloat-conversion \
-           -Wfloat-equal -Winit-self -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wundef -Wuninitialized \
-           -Wunused
+CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align -Wctor-dtor-privacy -Wdouble-promotion -Wfloat-conversion -Wfloat-equal \
+           -Winit-self -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wundef -Wuninitialized -Wunused
 
 ifdef FHEROES2_STRICT_COMPILATION
 CCFLAGS := $(CCFLAGS) -Werror

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,7 +55,7 @@ CXXFLAGS_TP := $(CXXFLAGS)
 # TODO: Add -Wconversion -Wsign-conversion -Wextra-semi flags back once we fix all the corresponding code smells!
 CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align=strict -Wctor-dtor-privacy -Wdouble-promotion -Wfloat-conversion \
            -Wfloat-equal -Wlogical-op -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wstrict-null-sentinel \
-           -Wuninitialized -Wunused
+           -Wswitch-default -Wuninitialized -Wunused
 
 ifdef FHEROES2_STRICT_COMPILATION
 CCFLAGS := $(CCFLAGS) -Werror

--- a/src/Makefile
+++ b/src/Makefile
@@ -52,7 +52,7 @@ CXXFLAGS_TP := $(CXXFLAGS)
 # Build options for fheroes2
 #
 
-# Add -Wconversion -Wsign-conversion -Wextra-semi flags back once we fix all other warnings!
+# TODO: Add -Wconversion -Wsign-conversion -Wextra-semi flags back once we fix all the corresponding code smells!
 CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wdouble-promotion -Wfloat-conversion -Wfloat-equal -Woverloaded-virtual -Wredundant-decls -Wshadow -Wuninitialized -Wunused
 
 ifdef FHEROES2_STRICT_COMPILATION

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,7 +55,7 @@ CXXFLAGS_TP := $(CXXFLAGS)
 # TODO: Add -Wconversion -Wsign-conversion -Wextra-semi flags back once we fix all the corresponding code smells!
 CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align=strict -Wctor-dtor-privacy -Wdouble-promotion -Wfloat-conversion \
            -Wfloat-equal -Wlogical-op -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wstrict-null-sentinel \
-           -Wswitch-default -Wuninitialized -Wunused
+           -Wswitch-default -Wundef -Wuninitialized -Wunused
 
 ifdef FHEROES2_STRICT_COMPILATION
 CCFLAGS := $(CCFLAGS) -Werror

--- a/src/Makefile
+++ b/src/Makefile
@@ -29,13 +29,12 @@ CCFLAGS := -fsigned-char -pthread
 # Flags for the C compiler
 CFLAGS := $(CFLAGS)
 # Flags for the C++ compiler
-CXXFLAGS := $(CXXFLAGS) -std=c++11
+CXXFLAGS := $(CXXFLAGS)
 # Flags for the linker
 LDFLAGS := $(LDFLAGS) -pthread
-LIBS := -lz
 
 ifdef FHEROES2_WITH_DEBUG
-CCFLAGS := $(CCFLAGS) -O0 -g -DWITH_DEBUG
+CCFLAGS := $(CCFLAGS) -O0 -g
 else
 CCFLAGS := $(CCFLAGS) -O3
 endif
@@ -51,6 +50,13 @@ CXXFLAGS_TP := $(CXXFLAGS)
 #
 # Build options for fheroes2
 #
+
+CXXFLAGS := $(CXXFLAGS) -std=c++11
+LIBS := -lz
+
+ifdef FHEROES2_WITH_DEBUG
+CCFLAGS := $(CCFLAGS) -DWITH_DEBUG
+endif
 
 # TODO: Add -Wconversion -Wsign-conversion -Wextra-semi -Wswitch-default flags back once we fix all the corresponding code smells!
 CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align=strict -Wctor-dtor-privacy -Wdouble-promotion -Wfloat-conversion \

--- a/src/Makefile
+++ b/src/Makefile
@@ -54,8 +54,7 @@ CXXFLAGS_TP := $(CXXFLAGS)
 
 # TODO: Add -Wconversion -Wsign-conversion -Wextra-semi -Wswitch-default flags back once we fix all the corresponding code smells!
 CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align=strict -Wctor-dtor-privacy -Wdouble-promotion -Wfloat-conversion \
-           -Wfloat-equal -Wlogical-op -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wstrict-null-sentinel \
-           -Wundef -Wuninitialized -Wunused
+           -Wfloat-equal -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wundef -Wuninitialized -Wunused
 
 ifdef FHEROES2_STRICT_COMPILATION
 CCFLAGS := $(CCFLAGS) -Werror

--- a/src/Makefile
+++ b/src/Makefile
@@ -53,7 +53,7 @@ CXXFLAGS_TP := $(CXXFLAGS)
 #
 
 # TODO: Add -Wconversion -Wsign-conversion -Wextra-semi flags back once we fix all the corresponding code smells!
-CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align=strict -Wdouble-promotion -Wfloat-conversion -Wfloat-equal -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wuninitialized -Wunused
+CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align=strict -Wctor-dtor-privacy -Wdouble-promotion -Wfloat-conversion -Wfloat-equal -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wuninitialized -Wunused
 
 ifdef FHEROES2_STRICT_COMPILATION
 CCFLAGS := $(CCFLAGS) -Werror

--- a/src/Makefile
+++ b/src/Makefile
@@ -54,7 +54,8 @@ CXXFLAGS_TP := $(CXXFLAGS)
 
 # TODO: Add -Wconversion -Wsign-conversion -Wextra-semi -Wswitch-default flags back once we fix all the corresponding code smells!
 CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align=strict -Wctor-dtor-privacy -Wdouble-promotion -Wfloat-conversion \
-           -Wfloat-equal -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wundef -Wuninitialized -Wunused
+           -Wfloat-equal -Winit-self -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wundef -Wuninitialized \
+           -Wunused
 
 ifdef FHEROES2_STRICT_COMPILATION
 CCFLAGS := $(CCFLAGS) -Werror

--- a/src/Makefile
+++ b/src/Makefile
@@ -53,7 +53,7 @@ CXXFLAGS_TP := $(CXXFLAGS)
 #
 
 # TODO: Add -Wconversion -Wsign-conversion -Wextra-semi flags back once we fix all the corresponding code smells!
-CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wdouble-promotion -Wfloat-conversion -Wfloat-equal -Woverloaded-virtual -Wredundant-decls -Wshadow -Wuninitialized -Wunused
+CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align=strict -Wdouble-promotion -Wfloat-conversion -Wfloat-equal -Woverloaded-virtual -Wredundant-decls -Wshadow -Wuninitialized -Wunused
 
 ifdef FHEROES2_STRICT_COMPILATION
 CCFLAGS := $(CCFLAGS) -Werror

--- a/src/Makefile
+++ b/src/Makefile
@@ -54,7 +54,8 @@ CXXFLAGS_TP := $(CXXFLAGS)
 
 # TODO: Add -Wconversion -Wsign-conversion -Wextra-semi flags back once we fix all the corresponding code smells!
 CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align=strict -Wctor-dtor-privacy -Wdouble-promotion -Wfloat-conversion \
-           -Wfloat-equal -Wlogical-op -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wuninitialized -Wunused
+           -Wfloat-equal -Wlogical-op -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wstrict-null-sentinel \
+           -Wuninitialized -Wunused
 
 ifdef FHEROES2_STRICT_COMPILATION
 CCFLAGS := $(CCFLAGS) -Werror

--- a/src/Makefile
+++ b/src/Makefile
@@ -52,10 +52,10 @@ CXXFLAGS_TP := $(CXXFLAGS)
 # Build options for fheroes2
 #
 
-# TODO: Add -Wconversion -Wsign-conversion -Wextra-semi flags back once we fix all the corresponding code smells!
+# TODO: Add -Wconversion -Wsign-conversion -Wextra-semi -Wswitch-default flags back once we fix all the corresponding code smells!
 CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align=strict -Wctor-dtor-privacy -Wdouble-promotion -Wfloat-conversion \
            -Wfloat-equal -Wlogical-op -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wstrict-null-sentinel \
-           -Wswitch-default -Wundef -Wuninitialized -Wunused
+           -Wundef -Wuninitialized -Wunused
 
 ifdef FHEROES2_STRICT_COMPILATION
 CCFLAGS := $(CCFLAGS) -Werror

--- a/src/Makefile
+++ b/src/Makefile
@@ -58,9 +58,10 @@ ifdef FHEROES2_WITH_DEBUG
 CCFLAGS := $(CCFLAGS) -DWITH_DEBUG
 endif
 
-# TODO: Add -Wconversion -Wsign-conversion -Wextra-semi -Wswitch-default flags back once we fix all the corresponding code smells!
+# TODO: Add -Wconversion -Wsign-conversion -Wextra-semi flags once we fix all the corresponding code smells
+# TODO: Add -Wswitch-default -Wold-style-cast flags once SDL headers can be compiled with them
 CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align -Wctor-dtor-privacy -Wdouble-promotion -Wfloat-conversion -Wfloat-equal \
-           -Winit-self -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wundef -Wuninitialized -Wunused
+           -Winit-self -Woverloaded-virtual -Wredundant-decls -Wshadow -Wundef -Wuninitialized -Wunused
 
 ifdef FHEROES2_STRICT_COMPILATION
 CCFLAGS := $(CCFLAGS) -Werror

--- a/src/Makefile
+++ b/src/Makefile
@@ -53,7 +53,7 @@ CXXFLAGS_TP := $(CXXFLAGS)
 #
 
 # TODO: Add -Wconversion -Wsign-conversion -Wextra-semi flags back once we fix all the corresponding code smells!
-CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align=strict -Wdouble-promotion -Wfloat-conversion -Wfloat-equal -Woverloaded-virtual -Wredundant-decls -Wshadow -Wuninitialized -Wunused
+CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align=strict -Wdouble-promotion -Wfloat-conversion -Wfloat-equal -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wuninitialized -Wunused
 
 ifdef FHEROES2_STRICT_COMPILATION
 CCFLAGS := $(CCFLAGS) -Werror

--- a/src/Makefile
+++ b/src/Makefile
@@ -52,7 +52,7 @@ CXXFLAGS_TP := $(CXXFLAGS)
 # Build options for fheroes2
 #
 
-# Add -Wconversion -Wsign-conversion -Weffc++ -Wextra-semi flags back once we fix all other warnings!
+# Add -Wconversion -Wsign-conversion -Wextra-semi flags back once we fix all other warnings!
 CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wdouble-promotion -Wfloat-conversion -Wfloat-equal -Woverloaded-virtual -Wredundant-decls -Wshadow -Wuninitialized -Wunused
 
 ifdef FHEROES2_STRICT_COMPILATION

--- a/src/Makefile
+++ b/src/Makefile
@@ -52,8 +52,8 @@ CXXFLAGS_TP := $(CXXFLAGS)
 # Build options for fheroes2
 #
 
-# Add -Wconversion -Wsign-conversion -Weffc++ -Woverloaded-virtual -Wextra-semi flags back once we fix all other warnings!
-CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wfloat-conversion -Wshadow -Wfloat-equal -Wredundant-decls -Wdouble-promotion -Wunused -Wuninitialized
+# Add -Wconversion -Wsign-conversion -Weffc++ -Wextra-semi flags back once we fix all other warnings!
+CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wdouble-promotion -Wfloat-conversion -Wfloat-equal -Woverloaded-virtual -Wredundant-decls -Wshadow -Wuninitialized -Wunused
 
 ifdef FHEROES2_STRICT_COMPILATION
 CCFLAGS := $(CCFLAGS) -Werror

--- a/src/Makefile
+++ b/src/Makefile
@@ -53,7 +53,7 @@ CXXFLAGS_TP := $(CXXFLAGS)
 #
 
 # TODO: Add -Wconversion -Wsign-conversion -Wextra-semi flags back once we fix all the corresponding code smells!
-CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align=strict -Wctor-dtor-privacy -Wdouble-promotion -Wfloat-conversion -Wfloat-equal -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wuninitialized -Wunused
+CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align=strict -Wctor-dtor-privacy -Wdouble-promotion -Wfloat-conversion -Wfloat-equal -Wlogical-op -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wuninitialized -Wunused
 
 ifdef FHEROES2_STRICT_COMPILATION
 CCFLAGS := $(CCFLAGS) -Werror

--- a/src/Makefile
+++ b/src/Makefile
@@ -53,7 +53,8 @@ CXXFLAGS_TP := $(CXXFLAGS)
 #
 
 # TODO: Add -Wconversion -Wsign-conversion -Wextra-semi flags back once we fix all the corresponding code smells!
-CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align=strict -Wctor-dtor-privacy -Wdouble-promotion -Wfloat-conversion -Wfloat-equal -Wlogical-op -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wuninitialized -Wunused
+CCFLAGS := $(CCFLAGS) -pedantic -Wall -Wextra -Wcast-align=strict -Wctor-dtor-privacy -Wdouble-promotion -Wfloat-conversion \
+           -Wfloat-equal -Wlogical-op -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wuninitialized -Wunused
 
 ifdef FHEROES2_STRICT_COMPILATION
 CCFLAGS := $(CCFLAGS) -Werror

--- a/src/Makefile.vita
+++ b/src/Makefile.vita
@@ -21,7 +21,6 @@
 AR := arm-vita-eabi-gcc-ar
 CC := arm-vita-eabi-gcc
 CXX := arm-vita-eabi-g++
-LIBS := -lz
 
 ifdef FHEROES2_STRICT_COMPILATION
 CCFLAGS := $(CCFLAGS) -Wno-error=pedantic -Wno-error=float-equal

--- a/src/Makefile.vita
+++ b/src/Makefile.vita
@@ -33,9 +33,9 @@ LDFLAGS := $(LDFLAGS) -L$(VITASDK)/arm-vita-eabi/lib -L$(VITASDK)/lib -Wl,--sort
 
 CCFLAGS_TP := $(CCFLAGS_TP) $(ARCH)
 
-SDL_LIBS := -L$(VITASDK)/arm-vita-eabi/lib -lSDL2_mixer -lSDL2 -lvita2d -lScePower_stub -lSceAudio_stub -lSceCtrl_stub -lSceHid_stub -lSceTouch_stub -lSceDisplay_stub \
-                                           -lSceGxm_stub -lSceAppMgr_stub -lSceSysmodule_stub -lSceCommonDialog_stub -lSceMotion_stub -lFLAC -lmikmod -lmpg123 -lvorbisfile \
-                                           -lvorbis -logg
+SDL_LIBS := -L$(VITASDK)/arm-vita-eabi/lib -lSDL2_mixer -lSDL2 -lvita2d -lScePower_stub -lSceAudioIn_stub -lSceAudio_stub -lSceCtrl_stub -lSceHid_stub -lSceTouch_stub \
+                                           -lSceDisplay_stub -lSceGxm_stub -lSceAppMgr_stub -lSceSysmodule_stub -lSceCommonDialog_stub -lSceMotion_stub -lFLAC -lmikmod \
+                                           -lmpg123 -lvorbisfile -lvorbis -logg
 SDL_FLAGS := -I$(VITASDK)/arm-vita-eabi/include/SDL2
 
 ifdef FHEROES2_WITH_IMAGE

--- a/src/fheroes2/army/army_bar.h
+++ b/src/fheroes2/army/army_bar.h
@@ -33,6 +33,9 @@ class ArmyTroop;
 class ArmyBar : public Interface::ItemsActionBar<ArmyTroop>
 {
 public:
+    using Interface::ItemsActionBar<ArmyTroop>::RedrawItem;
+    using Interface::ItemsActionBar<ArmyTroop>::ActionBarRightMouseHold;
+
     ArmyBar( Army *, bool mini, bool ro, bool change = false );
 
     void RedrawBackground( const fheroes2::Rect &, fheroes2::Image & ) override;

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -189,6 +189,8 @@ uint32_t Battle::Force::GetSurrenderCost() const
         case Skill::Level::EXPERT:
             mod *= 0.4;
             break;
+        default:
+            break;
         }
 
         res *= mod;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -223,6 +223,10 @@ namespace Battle
     class StatusListBox : public ::Interface::ListBox<std::string>
     {
     public:
+        using ::Interface::ListBox<std::string>::ActionListDoubleClick;
+        using ::Interface::ListBox<std::string>::ActionListSingleClick;
+        using ::Interface::ListBox<std::string>::ActionListPressRight;
+
         StatusListBox()
             : openlog( false )
         {}

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1081,6 +1081,8 @@ s32 Battle::Unit::GetScoreQuality( const Unit & defender ) const
         // Ghost's ability to increase the numbers
         attackerThreat *= 3;
         break;
+    default:
+        break;
     }
 
     // force big priority on mirror images as they get destroyed in 1 hit

--- a/src/fheroes2/castle/captain.cpp
+++ b/src/fheroes2/castle/captain.cpp
@@ -214,6 +214,8 @@ fheroes2::Sprite Captain::GetPortrait( const PortraitType type ) const
             break;
         }
         break;
+    default:
+        break;
     }
 
     // We shouldn't even reach this code!

--- a/src/fheroes2/dialog/dialog_marketplace.cpp
+++ b/src/fheroes2/dialog/dialog_marketplace.cpp
@@ -766,6 +766,9 @@ u32 GetTradeCosts( const Kingdom & kingdom, int rs_from, int rs_to, bool trading
             else if ( 8 < markets )
                 return COSTLY_COSTLY9;
             break;
+
+        default:
+            break;
         }
         break;
 
@@ -844,6 +847,9 @@ u32 GetTradeCosts( const Kingdom & kingdom, int rs_from, int rs_to, bool trading
                 return COSTLY_UNCOSTLY8;
             else if ( 8 < markets )
                 return COSTLY_UNCOSTLY9;
+            break;
+
+        default:
             break;
         }
         break;

--- a/src/fheroes2/dialog/dialog_resolution.cpp
+++ b/src/fheroes2/dialog/dialog_resolution.cpp
@@ -47,6 +47,10 @@ namespace
     class ResolutionList : public Interface::ListBox<fheroes2::Size>
     {
     public:
+        using Interface::ListBox<fheroes2::Size>::ActionListSingleClick;
+        using Interface::ListBox<fheroes2::Size>::ActionListPressRight;
+        using Interface::ListBox<fheroes2::Size>::ActionListDoubleClick;
+
         explicit ResolutionList( const fheroes2::Point & offset )
             : Interface::ListBox<fheroes2::Size>( offset )
             , _isDoubleClicked( false )

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -87,6 +87,10 @@ bool RedrawExtraInfo( const fheroes2::Point &, const std::string &, const std::s
 class FileInfoListBox : public Interface::ListBox<Maps::FileInfo>
 {
 public:
+    using Interface::ListBox<Maps::FileInfo>::ActionListDoubleClick;
+    using Interface::ListBox<Maps::FileInfo>::ActionListSingleClick;
+    using Interface::ListBox<Maps::FileInfo>::ActionListPressRight;
+
     explicit FileInfoListBox( const fheroes2::Point & pt )
         : Interface::ListBox<Maps::FileInfo>( pt )
         , _isDoubleClicked( false )

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -35,6 +35,10 @@
 class SelectEnum : public Interface::ListBox<int>
 {
 public:
+    using Interface::ListBox<int>::ActionListDoubleClick;
+    using Interface::ListBox<int>::ActionListSingleClick;
+    using Interface::ListBox<int>::ActionListPressRight;
+
     explicit SelectEnum( const fheroes2::Rect & rt )
         : Interface::ListBox<int>( rt.getPosition() )
         , area( rt )
@@ -101,6 +105,8 @@ public:
 class SelectEnumMonster : public SelectEnum
 {
 public:
+    using SelectEnum::ActionListPressRight;
+
     explicit SelectEnumMonster( const fheroes2::Rect & rt )
         : SelectEnum( rt )
     {}

--- a/src/fheroes2/dialog/dialog_selectscenario.h
+++ b/src/fheroes2/dialog/dialog_selectscenario.h
@@ -30,6 +30,10 @@
 class ScenarioListBox : public Interface::ListBox<Maps::FileInfo>
 {
 public:
+    using Interface::ListBox<Maps::FileInfo>::ActionListDoubleClick;
+    using Interface::ListBox<Maps::FileInfo>::ActionListSingleClick;
+    using Interface::ListBox<Maps::FileInfo>::ActionListPressRight;
+
     explicit ScenarioListBox( const fheroes2::Point & pt )
         : Interface::ListBox<Maps::FileInfo>( pt )
         , selectOk( false )

--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -40,6 +40,10 @@
 class SettingsListBox : public Interface::ListBox<u32>
 {
 public:
+    using Interface::ListBox<u32>::ActionListDoubleClick;
+    using Interface::ListBox<u32>::ActionListSingleClick;
+    using Interface::ListBox<u32>::ActionListPressRight;
+
     SettingsListBox( const fheroes2::Point & pt, bool f )
         : Interface::ListBox<u32>( pt )
         , readonly( f )

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -491,6 +491,8 @@ u32 Game::GetGameOverScores( void )
     case Maps::XLARGE:
         mapSizeFactor = 60;
         break;
+    default:
+        break;
     }
 
     const uint32_t daysFactor = world.CountDay() * mapSizeFactor / 100;

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -570,6 +570,8 @@ namespace
             case Campaign::CampaignAwardData::TYPE_CARRY_OVER_FORCES:
                 replaceArmy( humanKingdom.GetBestHero()->GetArmy(), Campaign::CampaignSaveData::Get().getCarryOverTroops() );
                 break;
+            default:
+                break;
             }
         }
     }

--- a/src/fheroes2/gui/interface_icons.h
+++ b/src/fheroes2/gui/interface_icons.h
@@ -95,6 +95,10 @@ namespace Interface
         void SetShow( bool );
 
     protected:
+        using Interface::ListBox<HEROES>::ActionListDoubleClick;
+        using Interface::ListBox<HEROES>::ActionListSingleClick;
+        using Interface::ListBox<HEROES>::ActionListPressRight;
+
         void ActionCurrentUp( void ) override;
         void ActionCurrentDn( void ) override;
         void ActionListDoubleClick( HEROES & ) override;
@@ -118,6 +122,10 @@ namespace Interface
         void SetShow( bool );
 
     protected:
+        using Interface::ListBox<CASTLE>::ActionListDoubleClick;
+        using Interface::ListBox<CASTLE>::ActionListSingleClick;
+        using Interface::ListBox<CASTLE>::ActionListPressRight;
+
         void ActionCurrentUp( void ) override;
         void ActionCurrentDn( void ) override;
         void ActionListDoubleClick( CASTLE & ) override;

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -82,6 +82,8 @@ namespace
 class MeetingArmyBar : public ArmyBar
 {
 public:
+    using ArmyBar::RedrawItem;
+
     explicit MeetingArmyBar( Army * army )
         : ArmyBar( army, true, false, false )
     {}
@@ -142,6 +144,8 @@ private:
 class MeetingArtifactBar : public ArtifactsBar
 {
 public:
+    using ArtifactsBar::RedrawItem;
+
     explicit MeetingArtifactBar( const Heroes * hero )
         : ArtifactsBar( hero, true, false, false, false, nullptr )
     {}

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -285,6 +285,10 @@ const fheroes2::Sprite & SpriteFlag( const Heroes & hero, int index, bool rotate
         case Direction::BOTTOM_LEFT:
             offset = hero.isShipMaster() ? offsetShipBottomSideways[frameId] : offsetBottomSideways[frameId];
             break;
+
+        default:
+            DEBUG_LOG( DBG_GAME, DBG_WARN, "unknown direction" );
+            break;
         }
     }
     return flag;

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -72,6 +72,10 @@ bool ActionSpellSetGuardian( Heroes & hero, const Spell & spell );
 class CastleIndexListBox : public Interface::ListBox<s32>
 {
 public:
+    using Interface::ListBox<s32>::ActionListDoubleClick;
+    using Interface::ListBox<s32>::ActionListSingleClick;
+    using Interface::ListBox<s32>::ActionListPressRight;
+
     CastleIndexListBox( const fheroes2::Rect & area, const fheroes2::Point & offset, int & res, const int townFrameIcnId, const int listBoxIcnId )
         : Interface::ListBox<int32_t>( offset )
         , result( res )

--- a/src/fheroes2/kingdom/color.cpp
+++ b/src/fheroes2/kingdom/color.cpp
@@ -45,6 +45,8 @@ std::string Color::String( int color )
         return _( "Purple" );
     case Color::UNUSED:
         return "Unknown";
+    default:
+        break;
     }
 
     return "None";

--- a/src/fheroes2/kingdom/luck.cpp
+++ b/src/fheroes2/kingdom/luck.cpp
@@ -62,6 +62,8 @@ std::string Luck::Description( int luck )
     case Luck::GREAT:
     case Luck::IRISH:
         return _( "Good luck sometimes lets your armies get lucky attacks (double strength) in combat." );
+    default:
+        break;
     }
 
     return "Unknown";

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -684,6 +684,9 @@ std::pair<int, int> Maps::Tiles::ColorRaceFromHeroSprite( const uint32_t heroSpr
     case 6:
         res.second = Race::RAND;
         break;
+    default:
+        assert( 0 );
+        break;
     }
 
     return res;

--- a/src/fheroes2/monster/monster.cpp
+++ b/src/fheroes2/monster/monster.cpp
@@ -270,6 +270,8 @@ double Monster::GetMonsterStrength( int attack, int defense ) const
         // Ghost's ability to increase the numbers
         monsterSpecial += 2;
         break;
+    default:
+        break;
     }
 
     // Higher speed gives initiative advantage/first attack. Remap speed value to -0.2...+0.15, AVERAGE is 0

--- a/src/fheroes2/objects/objcrck.cpp
+++ b/src/fheroes2/objects/objcrck.cpp
@@ -92,6 +92,8 @@ int ObjCrck::GetActionObject( u32 index )
         return MP2::OBJ_OBELISK;
     case 245:
         return MP2::OBJ_SAWMILL;
+    default:
+        break;
     }
 
     return MP2::OBJ_ZERO;

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -266,6 +266,8 @@ bool Artifact::isAlchemistRemove( void ) const
     case HEART_ICE:
     case BROACH_SHIELDING:
         return true;
+    default:
+        break;
     }
 
     return false;

--- a/src/fheroes2/resource/artifact.h
+++ b/src/fheroes2/resource/artifact.h
@@ -292,6 +292,9 @@ public:
 class ArtifactsBar : public Interface::ItemsActionBar<Artifact>
 {
 public:
+    using Interface::ItemsActionBar<Artifact>::RedrawItem;
+    using Interface::ItemsActionBar<Artifact>::ActionBarRightMouseHold;
+
     ArtifactsBar( const Heroes * hero, const bool mini, const bool ro, const bool change, const bool allowOpeningMagicBook, StatusBar * bar );
 
     void RedrawBackground( const fheroes2::Rect &, fheroes2::Image & ) override;

--- a/src/fheroes2/spell/spell.cpp
+++ b/src/fheroes2/spell/spell.cpp
@@ -495,6 +495,9 @@ bool Spell::isSingleTarget() const
     case MIRRORIMAGE:
     case SHIELD:
         return true;
+
+    default:
+        break;
     }
 
     return false;

--- a/src/tools/82m2wav.cpp
+++ b/src/tools/82m2wav.cpp
@@ -66,7 +66,7 @@ int main( int argc, char ** argv )
         wavHeader.putLE32( 0x61746164 ); // DATA
         wavHeader.putLE32( size ); // size
 
-        fd_body.write( (const char *)wavHeader.data(), wavHeader.size() );
+        fd_body.write( reinterpret_cast<const char *>( wavHeader.data() ), wavHeader.size() );
         fd_body.write( body, size );
         fd_body.close();
     }


### PR DESCRIPTION
Also this PR fixes the build for PSV (once again).

In GCC, `-Weffc++` is broken and useless. For example, even the latest GCC [reports](https://godbolt.org/z/WdKKdsvWz) the following warning:

```
<source>: In constructor 'C::C()':
<source>:6:5: warning: 'C::s' should be initialized in the member initialization list [-Weffc++]
    6 |     C() {};
      |     ^
```

for the following code:

```cpp
#include <string>

class C
{
public:
    C() {};
private:
    std::string s;
};

int main()
{
    C c;
}
```

despite the fact that `std::string` has perfectly safe default constructor.