### PR TITLE
Clang-Tidy: disable the cppcoreguidelines-pro-type-reinterpret-cast check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: >-
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-constant-array-index,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
   -cppcoreguidelines-pro-type-union-access,
   misc-*,
   -misc-non-private-member-variables-in-classes,


### PR DESCRIPTION
Requested by @ihhub

Although `reinterpret_cast` conversion is dangerous in general, it's perfectly legal to use it in certain cases (for example, when accessing a byte representation of an object by casting a pointer to it to the `char *`).