### PR TITLE
Fix regression for AGG file search

### DIFF
--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -706,8 +706,9 @@ bool AGG::AGGInitializer::init()
         }
 
         const std::string tempPath = StringLower( path );
-        if ( tempPath.compare( tempPath.size() - aggLowerCaseFilePath.size(), aggLowerCaseFilePath.size(), aggLowerCaseFilePath ) == 0 ) {
+        if ( tempPath == aggLowerCaseFilePath ) {
             heroes2XAggFilePath = path;
+            break;
         }
     }
 

--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -701,10 +701,6 @@ bool AGG::AGGInitializer::init()
     fheroes2::replaceStringEnding( aggLowerCaseFilePath, ".agg", "x.agg" );
 
     for ( const std::string & path : aggFileNames ) {
-        if ( path.size() < aggLowerCaseFilePath.size() ) {
-            continue;
-        }
-
         const std::string tempPath = StringLower( path );
         if ( tempPath == aggLowerCaseFilePath ) {
             heroes2XAggFilePath = path;

--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -701,7 +701,7 @@ bool AGG::AGGInitializer::init()
     fheroes2::replaceStringEnding( aggLowerCaseFilePath, ".agg", "x.agg" );
 
     for ( const std::string & path : aggFileNames ) {
-        if ( path.size() != aggLowerCaseFilePath.size() ) {
+        if ( path.size() < aggLowerCaseFilePath.size() ) {
             continue;
         }
 


### PR DESCRIPTION
Case-sensitive filesystems do not support the current approach so we have to revert back to the original but with small modifications.

Regression of #5157 

Notes:
- h2d file related logic can remain as it is as we distribute the file and we know the actual name
- the same problem is present for music files but I'll fix it in a separate pull request.