### PR TITLE
Fix the calculation of the cost of upgrading troops

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -657,7 +657,7 @@ namespace AI
             }
         }
         else if ( join.reason == NeutralMonsterJoiningCondition::Reason::ForMoney ) {
-            const int32_t joiningCost = troop.GetCost().gold;
+            const int32_t joiningCost = troop.GetTotalCost().gold;
             if ( hero.GetKingdom().AllowPayment( payment_t( Resource::GOLD, joiningCost ) ) && hero.GetArmy().CanJoinTroop( troop ) ) {
                 DEBUG_LOG( DBG_AI, DBG_INFO, join.monsterCount << " " << troop.GetName() << " join " << hero.GetName() << " for " << joiningCost << " gold." );
                 hero.GetArmy().JoinTroop( troop.GetMonster(), join.monsterCount );
@@ -1334,7 +1334,7 @@ namespace AI
 
         if ( troop.isValid() ) {
             Kingdom & kingdom = hero.GetKingdom();
-            const payment_t paymentCosts = troop.GetCost();
+            const payment_t paymentCosts = troop.GetTotalCost();
 
             if ( kingdom.AllowPayment( paymentCosts ) && hero.GetArmy().JoinTroop( troop ) ) {
                 tile.MonsterSetCount( 0 );

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -299,7 +299,7 @@ namespace
         case MP2::OBJ_EARTHALTAR:
         case MP2::OBJ_BARROWMOUNDS: {
             const Troop & troop = tile.QuantityTroop();
-            const payment_t & paymentCosts = troop.GetCost();
+            const payment_t & paymentCosts = troop.GetTotalCost();
 
             return troop.isValid() && kingdom.AllowPayment( paymentCosts ) && ( army.HasMonster( troop.GetMonster() ) || !army.isFullHouse() );
         }
@@ -313,7 +313,7 @@ namespace
             }
             else {
                 const Troop & troop = tile.QuantityTroop();
-                const payment_t & paymentCosts = troop.GetCost();
+                const payment_t & paymentCosts = troop.GetTotalCost();
 
                 return troop.isValid() && kingdom.AllowPayment( paymentCosts ) && ( army.HasMonster( troop.GetMonster() ) || ( !army.isFullHouse() ) );
             }
@@ -322,7 +322,7 @@ namespace
         // recruit genie
         case MP2::OBJ_ANCIENTLAMP: {
             const Troop & troop = tile.QuantityTroop();
-            const payment_t & paymentCosts = troop.GetCost();
+            const payment_t & paymentCosts = troop.GetTotalCost();
 
             return troop.isValid() && kingdom.AllowPayment( paymentCosts ) && ( army.HasMonster( troop.GetMonster() ) || ( !army.isFullHouse() ) );
         }

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -446,7 +446,7 @@ void Troops::UpgradeTroops( const Castle & castle )
 {
     for ( iterator it = begin(); it != end(); ++it )
         if ( ( *it )->isValid() ) {
-            payment_t payment = ( *it )->GetUpgradeCost();
+            payment_t payment = ( *it )->GetTotalUpgradeCost();
             Kingdom & kingdom = castle.GetKingdom();
 
             if ( castle.GetRace() == ( *it )->GetRace() && castle.isBuild( ( *it )->GetUpgrade().GetDwelling() ) && kingdom.AllowPayment( payment ) ) {

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -535,13 +535,13 @@ bool ArmyBar::ActionBarLeftMouseDoubleClick( ArmyTroop & troop )
              castle && castle->GetRace() == troop.GetRace() && castle->isBuild( troop.GetUpgrade().GetDwelling() ) ) {
             flags |= Dialog::UPGRADE;
 
-            if ( !world.GetKingdom( _army->GetColor() ).AllowPayment( troop.GetUpgradeCost() ) )
+            if ( !world.GetKingdom( _army->GetColor() ).AllowPayment( troop.GetTotalUpgradeCost() ) )
                 flags |= Dialog::UPGRADE_DISABLE;
         }
 
         switch ( Dialog::ArmyInfo( troop, flags ) ) {
         case Dialog::UPGRADE:
-            world.GetKingdom( _army->GetColor() ).OddFundsResource( troop.GetUpgradeCost() );
+            world.GetKingdom( _army->GetColor() ).OddFundsResource( troop.GetTotalUpgradeCost() );
             troop.Upgrade();
             break;
 

--- a/src/fheroes2/army/army_troop.cpp
+++ b/src/fheroes2/army/army_troop.cpp
@@ -124,14 +124,14 @@ bool Troop::isEmpty( void ) const
     return !isValid();
 }
 
-payment_t Troop::GetCost() const
+payment_t Troop::GetTotalCost() const
 {
-    return Monster::GetCost() * count;
+    return GetCost() * count;
 }
 
-payment_t Troop::GetUpgradeCost() const
+payment_t Troop::GetTotalUpgradeCost() const
 {
-    return Monster::GetUpgradeCost() * count;
+    return GetUpgradeCost() * count;
 }
 
 bool Troop::isBattle( void ) const

--- a/src/fheroes2/army/army_troop.h
+++ b/src/fheroes2/army/army_troop.h
@@ -53,8 +53,8 @@ public:
     u32 GetDamageMin( void ) const;
     u32 GetDamageMax( void ) const;
 
-    payment_t GetCost() const override;
-    payment_t GetUpgradeCost() const override;
+    payment_t GetTotalCost() const;
+    payment_t GetTotalUpgradeCost() const;
 
     virtual bool isValid( void ) const;
     virtual bool isEmpty( void ) const;

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -168,7 +168,7 @@ uint32_t Battle::Force::GetSurrenderCost() const
             const Unit * unit = FindUID( uids.at( index ) );
 
             if ( unit && unit->isValid() ) {
-                res += unit->GetCost().gold;
+                res += unit->GetSurrenderCost().gold;
             }
         }
     }

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1118,10 +1118,10 @@ u32 Battle::Unit::GetHitPoints( void ) const
     return hp;
 }
 
-payment_t Battle::Unit::GetCost() const
+payment_t Battle::Unit::GetSurrenderCost() const
 {
     // Resurrected (not truly resurrected) units should not be taken into account when calculating the cost of surrender
-    return Monster::GetCost() * ( GetDead() > GetInitialCount() ? 0 : GetInitialCount() - GetDead() );
+    return GetCost() * ( GetDead() > GetInitialCount() ? 0 : GetInitialCount() - GetDead() );
 }
 
 int Battle::Unit::GetControl( void ) const

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -170,7 +170,7 @@ namespace Battle
         uint32_t GetInitialCount() const;
         u32 GetDead( void ) const;
         u32 GetHitPoints( void ) const;
-        payment_t GetCost() const override; // used to calculate the cost of the surrender
+        payment_t GetSurrenderCost() const;
 
         uint32_t GetShots() const override
         {

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -499,13 +499,13 @@ double Castle::getVisitValue( const Heroes & hero ) const
     Funds potentialFunds = GetKingdom().GetFunds();
 
     for ( size_t i = 0; i < futureArmy.Size(); ++i ) {
-        Troop * monster = futureArmy.GetTroop( i );
-        if ( monster != nullptr && monster->isValid() ) {
-            const payment_t payment = monster->GetUpgradeCost();
+        Troop * troop = futureArmy.GetTroop( i );
+        if ( troop != nullptr && troop->isValid() ) {
+            const payment_t payment = troop->GetTotalUpgradeCost();
 
-            if ( GetRace() == monster->GetRace() && isBuild( monster->GetUpgrade().GetDwelling() ) && potentialFunds >= payment ) {
+            if ( GetRace() == troop->GetRace() && isBuild( troop->GetUpgrade().GetDwelling() ) && potentialFunds >= payment ) {
                 potentialFunds -= payment;
-                monster->Upgrade();
+                troop->Upgrade();
             }
         }
     }
@@ -808,7 +808,7 @@ bool Castle::RecruitMonster( const Troop & troop, bool showDialog )
         count = dwelling[dwellingIndex];
 
     // buy
-    const payment_t paymentCosts = troop.GetCost();
+    const payment_t paymentCosts = troop.GetTotalCost();
     Kingdom & kingdom = GetKingdom();
 
     if ( !kingdom.AllowPayment( paymentCosts ) )

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -220,13 +220,13 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
             if ( buttonUpgrade.isEnabled() && ( le.MouseClickLeft( buttonUpgrade.area() ) || Game::HotKeyPressEvent( Game::EVENT_UPGRADE_TROOP ) ) ) {
                 if ( UPGRADE_DISABLE & flags ) {
                     const fheroes2::Text description( _( "You can't afford to upgrade your troops!" ), fheroes2::FontType::normalWhite() );
-                    fheroes2::showResourceMessage( fheroes2::Text( "", {} ), description, Dialog::OK, troop.GetUpgradeCost() );
+                    fheroes2::showResourceMessage( fheroes2::Text( "", {} ), description, Dialog::OK, troop.GetTotalUpgradeCost() );
                 }
                 else {
                     const fheroes2::Text description( _( "Your troops can be upgraded, but it will cost you dearly. Do you wish to upgrade them?" ),
                                                       fheroes2::FontType::normalWhite() );
 
-                    if ( fheroes2::showResourceMessage( fheroes2::Text( "", {} ), description, Dialog::YES | Dialog::NO, troop.GetUpgradeCost() ) == Dialog::YES ) {
+                    if ( fheroes2::showResourceMessage( fheroes2::Text( "", {} ), description, Dialog::YES | Dialog::NO, troop.GetTotalUpgradeCost() ) == Dialog::YES ) {
                         result = Dialog::UPGRADE;
                         break;
                     }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -623,7 +623,7 @@ void ActionToMonster( Heroes & hero, s32 dst_index )
         }
     }
     else if ( join.reason == NeutralMonsterJoiningCondition::Reason::ForMoney ) {
-        const int32_t joiningCost = troop.GetCost().gold;
+        const int32_t joiningCost = troop.GetTotalCost().gold;
 
         if ( Dialog::YES == Dialog::ArmyJoinWithCost( troop, join.monsterCount, joiningCost, hero ) ) {
             DEBUG_LOG( DBG_GAME, DBG_INFO, join.monsterCount << " " << troop.GetName() << " join " << hero.GetName() << " for " << joiningCost << " gold." );

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -628,7 +628,7 @@ bool ActionSpellVisions( Heroes & hero )
 
             msg += '\n';
             msg.append( _( "\n for a fee of %{gold} gold." ) );
-            StringReplace( msg, "%{gold}", troop.GetCost().gold );
+            StringReplace( msg, "%{gold}", troop.GetTotalCost().gold );
             break;
 
         case NeutralMonsterJoiningCondition::Reason::RunAway:

--- a/src/fheroes2/monster/monster.cpp
+++ b/src/fheroes2/monster/monster.cpp
@@ -1033,7 +1033,7 @@ payment_t Monster::GetCost() const
 payment_t Monster::GetUpgradeCost() const
 {
     const Monster upgr = GetUpgrade();
-    const payment_t pay = id != upgr.id ? upgr.Monster::GetCost() - Monster::GetCost() : Monster::GetCost();
+    const payment_t pay = id != upgr.id ? upgr.GetCost() - GetCost() : GetCost();
 
     return pay;
 }

--- a/src/fheroes2/monster/monster.cpp
+++ b/src/fheroes2/monster/monster.cpp
@@ -1033,7 +1033,7 @@ payment_t Monster::GetCost() const
 payment_t Monster::GetUpgradeCost() const
 {
     const Monster upgr = GetUpgrade();
-    const payment_t pay = id != upgr.id ? upgr.GetCost() - GetCost() : GetCost();
+    const payment_t pay = id != upgr.id ? upgr.Monster::GetCost() - Monster::GetCost() : Monster::GetCost();
 
     return pay;
 }

--- a/src/fheroes2/monster/monster.h
+++ b/src/fheroes2/monster/monster.h
@@ -190,8 +190,8 @@ public:
     int ICNMonh( void ) const;
 
     u32 GetSpriteIndex( void ) const;
-    virtual payment_t GetCost() const;
-    virtual payment_t GetUpgradeCost() const;
+    payment_t GetCost() const;
+    payment_t GetUpgradeCost() const;
     u32 GetDwelling( void ) const;
 
     int GetMonsterSprite() const;


### PR DESCRIPTION
fix #5188

Regression after #5170

The problem is that currently in many relative classes (which inherit from each other) there are non-virtual methods that have the same names, but do different things that are not very compatible with each other. The previous approach was to make the `GetCost()` and `GetUpgradeCost()` `virtual` in related classes (such as `Monster`, `Troop` and `Battle::Unit`), but this may be error-prone in current circumstances, because the wrong method may be called easily (which is what in fact happened). This PR offers the second approach - I have changed the names of these methods to different ones, I hope that this approach is less error-prone.