### PR TITLE
Makefile: add options to build the project with UBSAN, ASAN or TSAN

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -19,7 +19,7 @@ jobs:
         - name: Linux SDL1 Debug
           os: ubuntu-latest
           dependencies: libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev gettext
-          env: { FHEROES2_STRICT_COMPILATION: ON, FHEROES2_WITH_TOOLS: ON, FHEROES2_WITH_SDL1: ON, FHEROES2_WITH_DEBUG: ON }
+          env: { FHEROES2_STRICT_COMPILATION: ON, FHEROES2_WITH_TOOLS: ON, FHEROES2_WITH_SDL1: ON, FHEROES2_WITH_DEBUG: ON, FHEROES2_WITH_ASAN: ON }
         - name: Linux SDL2 Release
           os: ubuntu-latest
           dependencies: libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext
@@ -31,7 +31,7 @@ jobs:
         - name: Linux SDL2 Debug
           os: ubuntu-latest
           dependencies: libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext
-          env: { FHEROES2_STRICT_COMPILATION: ON, FHEROES2_WITH_TOOLS: ON, FHEROES2_WITH_DEBUG: ON }
+          env: { FHEROES2_STRICT_COMPILATION: ON, FHEROES2_WITH_TOOLS: ON, FHEROES2_WITH_DEBUG: ON, FHEROES2_WITH_TSAN: ON }
         - name: macOS SDL1
           os: macos-10.15
           dependencies: sdl sdl_mixer sdl_image

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 #
 option(USE_SYSTEM_LIBSMACKER "Use system libsmacker instead of the bundled version" OFF)
 option(ENABLE_STRICT_COMPILATION "Enable strict compilation mode (turns warnings into errors)" OFF)
-option(ENABLE_IMAGE "Enable SDL Image support (requires libpng)" ON)
+option(ENABLE_IMAGE "Enable SDL2 Image support (requires libpng)" ON)
 option(ENABLE_TOOLS "Enable additional tools" OFF)
 
 # Available only on macOS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 #
 option(USE_SYSTEM_LIBSMACKER "Use system libsmacker instead of the bundled version" OFF)
 option(ENABLE_STRICT_COMPILATION "Enable strict compilation mode (turns warnings into errors)" OFF)
-option(ENABLE_IMAGE "Enable SDL/SDL2 Image support (requires libpng)" ON)
+option(ENABLE_IMAGE "Enable SDL Image support (requires libpng)" ON)
 option(ENABLE_TOOLS "Enable additional tools" OFF)
 
 # Available only on macOS

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@
 # FHEROES2_WITH_DEBUG: build in debug mode
 # FHEROES2_WITH_ASAN: build with UB Sanitizer and Address Sanitizer (small runtime overhead, incompatible with FHEROES2_WITH_TSAN)
 # FHEROES2_WITH_TSAN: build with UB Sanitizer and Thread Sanitizer (large runtime overhead, incompatible with FHEROES2_WITH_ASAN)
-# FHEROES2_WITH_IMAGE: build with SDL Image support (requires libpng)
+# FHEROES2_WITH_IMAGE: build with SDL2 Image support (requires libpng)
 # FHEROES2_WITH_TOOLS: build additional tools
 # FHEROES2_MACOS_APP_BUNDLE: create a Mac app bundle (only valid when building on macOS)
 #

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@
 # FHEROES2_WITH_DEBUG: build in debug mode
 # FHEROES2_WITH_ASAN: build with UB Sanitizer and Address Sanitizer (small runtime overhead, incompatible with FHEROES2_WITH_TSAN)
 # FHEROES2_WITH_TSAN: build with UB Sanitizer and Thread Sanitizer (large runtime overhead, incompatible with FHEROES2_WITH_ASAN)
-# FHEROES2_WITH_IMAGE: build with SDL/SDL2 Image support (requires libpng)
+# FHEROES2_WITH_IMAGE: build with SDL Image support (requires libpng)
 # FHEROES2_WITH_TOOLS: build additional tools
 # FHEROES2_MACOS_APP_BUNDLE: create a Mac app bundle (only valid when building on macOS)
 #

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@
 # FHEROES2_STRICT_COMPILATION: build in strict compilation mode (turns warnings into errors)
 # FHEROES2_WITH_SDL1: build with SDL1 instead of SDL2 (which is used by default)
 # FHEROES2_WITH_DEBUG: build in debug mode
+# FHEROES2_WITH_ASAN: build with UB Sanitizer and Address Sanitizer (small runtime overhead, incompatible with FHEROES2_WITH_TSAN)
+# FHEROES2_WITH_TSAN: build with UB Sanitizer and Thread Sanitizer (large runtime overhead, incompatible with FHEROES2_WITH_ASAN)
 # FHEROES2_WITH_IMAGE: build with SDL/SDL2 Image support (requires libpng)
 # FHEROES2_WITH_TOOLS: build additional tools
 # FHEROES2_MACOS_APP_BUNDLE: create a Mac app bundle (only valid when building on macOS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,6 +39,20 @@ else
 CCFLAGS := $(CCFLAGS) -O3
 endif
 
+ifneq ($(or $(FHEROES2_WITH_ASAN),$(FHEROES2_WITH_TSAN)),)
+SANITIZERS := undefined
+
+ifdef FHEROES2_WITH_ASAN
+SANITIZERS := $(SANITIZERS),address
+endif
+ifdef FHEROES2_WITH_TSAN
+SANITIZERS := $(SANITIZERS),thread
+endif
+
+CCFLAGS := $(CCFLAGS) -fsanitize=$(SANITIZERS)
+LDFLAGS := $(LDFLAGS) -fsanitize=$(SANITIZERS)
+endif
+
 #
 # Build options for third-party libraries
 #


### PR DESCRIPTION
I usually do this by patching the `Makefile`, so I decided to add options instead. [UBSAN](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html)+[ASAN](https://clang.llvm.org/docs/AddressSanitizer.html) introduce relatively small runtime overhead (about 2x), so I use this combination on the everyday basis, while UBSAN+[TSAN](https://clang.llvm.org/docs/ThreadSanitizer.html) introduce significantly larger overhead (5x - 15x).