### PR TITLE
Fix incorrect WITH_IMAGE macro usage

### DIFF
--- a/src/engine/image_tool.cpp
+++ b/src/engine/image_tool.cpp
@@ -300,7 +300,7 @@ namespace fheroes2
     bool isPNGFormatSupported()
     {
 #if defined( FHEROES2_ENABLE_PNG )
-        return true
+        return true;
 #else
         return false;
 #endif

--- a/src/engine/image_tool.cpp
+++ b/src/engine/image_tool.cpp
@@ -28,8 +28,8 @@
 #include <SDL_video.h>
 #endif
 
-#if defined( WITH_IMAGE )
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
+#if defined( WITH_IMAGE )
 #define FHEROES2_ENABLE_PNG 1
 #include <SDL_image.h>
 #endif
@@ -295,5 +295,14 @@ namespace fheroes2
         }
 
         return sprite;
+    }
+
+    bool isPNGFormatSupported()
+    {
+#if defined( FHEROES2_ENABLE_PNG )
+        return true
+#else
+        return false;
+#endif
     }
 }

--- a/src/engine/image_tool.h
+++ b/src/engine/image_tool.h
@@ -34,4 +34,7 @@ namespace fheroes2
     bool Load( const std::string & path, Image & image );
 
     Sprite decodeICNSprite( const uint8_t * data, uint32_t sizeData, const int32_t width, const int32_t height, const int16_t offsetX, const int16_t offsetY );
+
+    // By default only Bitmap (.bmp) format is supported.
+    bool isPNGFormatSupported();
 }

--- a/src/engine/image_tool.h
+++ b/src/engine/image_tool.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2020                                                    *
+ *   Copyright (C) 2020 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/tools/icn2img.cpp
+++ b/src/tools/icn2img.cpp
@@ -97,15 +97,14 @@ int main( int argc, char ** argv )
             os << std::setw( 3 ) << std::setfill( '0' ) << ii;
 
             std::string dstfile = System::ConcatePath( prefix, os.str() );
-            std::string shortdstfile( os.str() ); // the name of destfile without the path
 
-#ifndef WITH_IMAGE
-            dstfile += ".bmp";
-            shortdstfile += ".bmp";
-#else
-            dstfile += ".png";
-            shortdstfile += ".png";
-#endif
+            if ( fheroes2::isPNGFormatSupported() ) {
+                dstfile += ".png";
+            }
+            else {
+                dstfile += ".bmp";
+            }
+
             std::cout << "Image " << ii + 1 << " has offset of [" << static_cast<int32_t>( head.offsetX ) << ", " << static_cast<int32_t>( head.offsetY ) << "]"
                       << std::endl;
 

--- a/src/tools/til2img.cpp
+++ b/src/tools/til2img.cpp
@@ -81,11 +81,13 @@ int main( int argc, char ** argv )
             stream << std::setw( 3 ) << std::setfill( '0' ) << cur;
             std::string dstfile = System::ConcatePath( prefix, stream.str() );
 
-#ifndef WITH_IMAGE
-            dstfile += ".bmp";
-#else
-            dstfile += ".png";
-#endif
+            if ( fheroes2::isPNGFormatSupported() ) {
+                dstfile += ".png";
+            }
+            else {
+                dstfile += ".bmp";
+            }
+
             if ( debugMode ) {
                 std::cout << "Saving " << dstfile << std::endl;
             }


### PR DESCRIPTION
WITH_IMAGE is used only for SDL 2 and it doesn't define the PNG format for SDL 1.