### PR TITLE
Speed up castle and hero icons rendering on adventure map

### DIFF
--- a/src/fheroes2/gui/interface_icons.cpp
+++ b/src/fheroes2/gui/interface_icons.cpp
@@ -69,35 +69,35 @@ void Interface::RedrawHeroesIcon( const Heroes & hero, s32 sx, s32 sy )
     hero.PortraitRedraw( sx, sy, PORT_SMALL, fheroes2::Display::instance() );
 }
 
-void Interface::IconsBar::RedrawBackground( const fheroes2::Point & pos ) const
+void Interface::IconsBar::redrawBackground( fheroes2::Image & output, const fheroes2::Point & offset, const int32_t validItemCount ) const
 {
-    fheroes2::Display & display = fheroes2::Display::instance();
     const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
 
     const fheroes2::Sprite & icnadv = fheroes2::AGG::GetICN( isEvilInterface ? ICN::ADVBORDE : ICN::ADVBORD, 0 );
-    const fheroes2::Sprite & back = fheroes2::AGG::GetICN( isEvilInterface ? ICN::LOCATORE : ICN::LOCATORS, 1 );
     fheroes2::Rect srcrt( icnadv.width() - RADARWIDTH - BORDERWIDTH, RADARWIDTH + 2 * BORDERWIDTH, RADARWIDTH / 2, 32 );
 
-    fheroes2::Point dstpt( pos.x, pos.y );
-    fheroes2::Blit( icnadv, srcrt.x, srcrt.y, display, dstpt.x, dstpt.y, srcrt.width, srcrt.height );
+    fheroes2::Blit( icnadv, srcrt.x, srcrt.y, output, offset.x, offset.y, srcrt.width, srcrt.height );
 
     srcrt.y = srcrt.y + srcrt.height;
-    dstpt.y = dstpt.y + srcrt.height;
+
+    int32_t internalOffsetY = offset.y + srcrt.height;
     srcrt.height = 32;
 
     if ( iconsCount > 2 ) {
         for ( int32_t i = 0; i < iconsCount - 2; ++i ) {
-            fheroes2::Blit( icnadv, srcrt.x, srcrt.y, display, dstpt.x, dstpt.y, srcrt.width, srcrt.height );
-            dstpt.y += srcrt.height;
+            fheroes2::Blit( icnadv, srcrt.x, srcrt.y, output, offset.x, internalOffsetY, srcrt.width, srcrt.height );
+            internalOffsetY += srcrt.height;
         }
     }
 
     srcrt.y = srcrt.y + 64;
     srcrt.height = 32;
-    fheroes2::Blit( icnadv, srcrt.x, srcrt.y, display, dstpt.x, dstpt.y, srcrt.width, srcrt.height );
+    fheroes2::Blit( icnadv, srcrt.x, srcrt.y, output, offset.x, internalOffsetY, srcrt.width, srcrt.height );
 
-    for ( int32_t i = 0; i < iconsCount; ++i )
-        fheroes2::Blit( back, display, pos.x + 5, pos.y + 5 + i * ( IconsBar::GetItemHeight() + 10 ) );
+    for ( int32_t i = validItemCount; i < iconsCount; ++i ) {
+        const fheroes2::Sprite & background = fheroes2::AGG::GetICN( isEvilInterface ? ICN::LOCATORE : ICN::LOCATORS, 1 + i % 8 );
+        fheroes2::Blit( background, output, offset.x + 5, offset.y + 5 + i * ( IconsBar::GetItemHeight() + 10 ) );
+    }
 }
 
 void Interface::CastleIcons::RedrawItem( const CASTLE & item, s32 ox, s32 oy, bool current )
@@ -112,7 +112,7 @@ void Interface::CastleIcons::RedrawItem( const CASTLE & item, s32 ox, s32 oy, bo
 
 void Interface::CastleIcons::RedrawBackground( const fheroes2::Point & pos )
 {
-    IconsBar::RedrawBackground( pos );
+    redrawBackground( fheroes2::Display::instance(), pos, _size() );
 }
 
 void Interface::CastleIcons::ActionCurrentUp()
@@ -200,7 +200,7 @@ void Interface::HeroesIcons::RedrawItem( const HEROES & item, s32 ox, s32 oy, bo
 
 void Interface::HeroesIcons::RedrawBackground( const fheroes2::Point & pos )
 {
-    IconsBar::RedrawBackground( pos );
+    redrawBackground( fheroes2::Display::instance(), pos, _size() );
 }
 
 void Interface::HeroesIcons::ActionCurrentUp( void )

--- a/src/fheroes2/gui/interface_icons.h
+++ b/src/fheroes2/gui/interface_icons.h
@@ -59,7 +59,7 @@ namespace Interface
             show = f;
         }
 
-        void RedrawBackground( const fheroes2::Point & ) const;
+        void redrawBackground( fheroes2::Image & output, const fheroes2::Point & offset, const int32_t validItemCount ) const;
 
         void SetIconsCount( const int32_t c )
         {

--- a/src/fheroes2/gui/interface_list.h
+++ b/src/fheroes2/gui/interface_list.h
@@ -458,6 +458,11 @@ namespace Interface
             return maxItems;
         }
 
+        int _size() const
+        {
+            return content == nullptr ? 0 : static_cast<int>( content->size() );
+        }
+
     private:
         std::vector<Item> * content;
         int maxItems;
@@ -483,11 +488,6 @@ namespace Interface
                 if ( _topId < 0 || _topId >= _size() )
                     _topId = 0;
             }
-        }
-
-        int _size() const
-        {
-            return content == nullptr ? 0 : static_cast<int>( content->size() );
         }
 
         void UpdateScrollbarRange()


### PR DESCRIPTION
We don't need to draw the background for an icon as the icon has the same size as the background image.

Also use a range of background images for the icons. Previously we used only 1 image.