### PR TITLE
Play just the M82::TREASURE sound when we picked up an artifact due to an event

### DIFF
--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2688,7 +2688,6 @@ void ActionToEvent( Heroes & hero, s32 dst_index )
             if ( hero.PickupArtifact( art ) ) {
                 artifactUI.reset( new fheroes2::ArtifactDialogElement( art ) );
                 AGG::PlaySound( M82::TREASURE );
-                Game::PlayPickupSound();
             }
         }
 


### PR DESCRIPTION
fix #5199

I have no idea why we played both `M82::TREASURE` and pickup sound in this case. Let's play just `M82::TREASURE`.