### PR TITLE
Fix switching fullscreen mode in macOS for certain resolutions

### DIFF
--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -709,10 +709,6 @@ namespace
             uint32_t flags = SDL_GetWindowFlags( _window );
             if ( ( flags & SDL_WINDOW_FULLSCREEN ) == SDL_WINDOW_FULLSCREEN || ( flags & SDL_WINDOW_FULLSCREEN_DESKTOP ) == SDL_WINDOW_FULLSCREEN_DESKTOP ) {
                 flags = 0;
-
-                if ( _windowedSize.width != 0 && _windowedSize.height != 0 ) {
-                    SDL_SetWindowSize( _window, _windowedSize.width, _windowedSize.height );
-                }
             }
             else {
 #if defined( __WIN32__ )
@@ -729,6 +725,11 @@ namespace
             }
 
             SDL_SetWindowFullscreen( _window, flags );
+
+            if ( flags == 0 && _windowedSize.width != 0 && _windowedSize.height != 0 ) {
+                SDL_SetWindowSize( _window, _windowedSize.width, _windowedSize.height );
+            }
+
             _retrieveWindowInfo();
 
             _toggleMouseCaptureMode();


### PR DESCRIPTION
If we call `SDL_SetWindowSize()` before turning off the fullscreen mode, the size of the resulting window may be wrong. This issue may be observed not only in macOS, but on other systems where `SDL_WINDOW_FULLSCREEN_DESKTOP` is used (e.g. Linux).

Before:

https://user-images.githubusercontent.com/32623900/161860527-0295a3cc-4dbb-467d-826e-4536b9f5a4ca.mp4

After:

https://user-images.githubusercontent.com/32623900/161860814-1c36bf88-c006-43df-8b03-5120f136b88f.mp4
