### PR TITLE
Remove "battle: reverse wait order (fast, average, slow)" option

### DIFF
--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -140,7 +140,7 @@ namespace
             if ( ( *it1 )->GetSpeed() == ( *it2 )->GetSpeed() ) {
                 result = units1GoFirst ? *it1 : *it2;
             }
-            else if ( firstStage || Settings::Get().ExtBattleReverseWaitOrder() ) {
+            else if ( firstStage ) {
                 if ( ( *it1 )->GetSpeed() > ( *it2 )->GetSpeed() )
                     result = *it1;
                 else if ( ( *it2 )->GetSpeed() > ( *it1 )->GetSpeed() )
@@ -173,7 +173,7 @@ namespace
         Battle::Units units1( army1.getUnits(), true );
         Battle::Units units2( army2.getUnits(), true );
 
-        if ( firstStage || Settings::Get().ExtBattleReverseWaitOrder() ) {
+        if ( firstStage ) {
             units1.SortFastest();
             units2.SortFastest();
         }
@@ -218,17 +218,11 @@ namespace
             Battle::Units units1( army1.getUnits(), true );
             Battle::Units units2( army2.getUnits(), true );
 
-            if ( Settings::Get().ExtBattleReverseWaitOrder() ) {
-                units1.SortFastest();
-                units2.SortFastest();
-            }
-            else {
-                std::reverse( units1.begin(), units1.end() );
-                std::reverse( units2.begin(), units2.end() );
+            std::reverse( units1.begin(), units1.end() );
+            std::reverse( units2.begin(), units2.end() );
 
-                units1.SortSlowest();
-                units2.SortSlowest();
-            }
+            units1.SortSlowest();
+            units2.SortSlowest();
 
             Battle::Unit * unit = nullptr;
 

--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -162,7 +162,6 @@ void Dialog::ExtSettings( bool readonly )
     states.push_back( Settings::HEROES_ARENA_ANY_SKILLS );
     states.push_back( Settings::CASTLE_ALLOW_GUARDIANS );
     states.push_back( Settings::BATTLE_SOFT_WAITING );
-    states.push_back( Settings::BATTLE_REVERSE_WAIT_ORDER );
     states.push_back( Settings::BATTLE_DETERMINISTIC_RESULT );
 
     std::sort( states.begin(), states.end(), []( uint32_t first, uint32_t second ) { return Settings::ExtName( first ) > Settings::ExtName( second ); } );

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -869,8 +869,6 @@ std::string Settings::ExtName( const uint32_t settingId )
         return _( "heroes: allow to choose any primary skill in Arena" );
     case Settings::BATTLE_SOFT_WAITING:
         return _( "battle: allow soft wait for troops" );
-    case Settings::BATTLE_REVERSE_WAIT_ORDER:
-        return _( "battle: reverse wait order (fast, average, slow)" );
     case Settings::BATTLE_DETERMINISTIC_RESULT:
         return _( "battle: deterministic events" );
     case Settings::GAME_SHOW_SYSTEM_INFO:

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -102,7 +102,7 @@ public:
         // UNUSED = 0x40004000,
         BATTLE_DETERMINISTIC_RESULT = 0x40008000,
         BATTLE_SOFT_WAITING = 0x40010000,
-        BATTLE_REVERSE_WAIT_ORDER = 0x40020000
+        // UNUSED = 0x40020000
     };
 
     Settings( const Settings & ) = delete;
@@ -307,11 +307,6 @@ public:
     bool ExtBattleDeterministicResult() const
     {
         return ExtModes( BATTLE_DETERMINISTIC_RESULT );
-    }
-
-    bool ExtBattleReverseWaitOrder() const
-    {
-        return ExtModes( BATTLE_REVERSE_WAIT_ORDER );
     }
 
     bool ExtGameRememberLastFocus() const


### PR DESCRIPTION
It's logical that slowest units after waiting should go first. Also AI has no knowledge of such option.