### PR TITLE
Code cleanup

### DIFF
--- a/src/engine/agg_file.cpp
+++ b/src/engine/agg_file.cpp
@@ -42,11 +42,11 @@ namespace fheroes2
         StreamBuf nameEntries = _stream.toStreamBuf( nameEntriesSize );
 
         for ( size_t i = 0; i < count; ++i ) {
-            const std::string & name = nameEntries.toString( _maxFilenameSize );
+            std::string name = nameEntries.toString( _maxFilenameSize );
             fileEntries.getLE32(); // skip CRC (?) part
             const uint32_t fileOffset = fileEntries.getLE32();
             const uint32_t fileSize = fileEntries.getLE32();
-            _files.emplace( name, std::make_pair( fileSize, fileOffset ) );
+            _files.emplace( std::move( name ), std::make_pair( fileSize, fileOffset ) );
         }
         if ( _files.size() != count ) {
             _files.clear();

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -416,7 +416,9 @@ namespace fheroes2
         : _width( 0 )
         , _height( 0 )
         , _singleLayer( false )
-    {}
+    {
+        // Do nothing.
+    }
 
     Image::Image( int32_t width_, int32_t height_ )
         : _width( 0 )
@@ -551,25 +553,33 @@ namespace fheroes2
         : Image( 0, 0 )
         , _x( 0 )
         , _y( 0 )
-    {}
+    {
+        // Do nothing.
+    }
 
     Sprite::Sprite( int32_t width_, int32_t height_, int32_t x_, int32_t y_ )
         : Image( width_, height_ )
         , _x( x_ )
         , _y( y_ )
-    {}
+    {
+        // Do nothing.
+    }
 
     Sprite::Sprite( const Image & image, int32_t x_, int32_t y_ )
         : Image( image )
         , _x( x_ )
         , _y( y_ )
-    {}
+    {
+        // Do nothing.
+    }
 
     Sprite::Sprite( const Sprite & sprite )
         : Image( sprite )
         , _x( sprite._x )
         , _y( sprite._y )
-    {}
+    {
+        // Do nothing.
+    }
 
     Sprite::Sprite( Sprite && sprite ) noexcept
         : Image( std::move( sprite ) )
@@ -1467,7 +1477,7 @@ namespace fheroes2
         uint8_t * transform = image.transform();
 
         if ( dx > dy ) {
-            int32_t ns = std::div( dx, 2 ).quot;
+            int32_t ns = dx / 2;
 
             for ( int32_t i = 0; i <= dx; ++i ) {
                 if ( x1 >= minX && x1 < maxX && y1 >= minY && y1 < maxY ) {
@@ -1484,7 +1494,7 @@ namespace fheroes2
             }
         }
         else {
-            int32_t ns = std::div( dy, 2 ).quot;
+            int32_t ns = dy / 2;
 
             for ( int32_t i = 0; i <= dy; ++i ) {
                 if ( x1 >= minX && x1 < maxX && y1 >= minY && y1 < maxY ) {

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -34,6 +34,7 @@ namespace fheroes2
     public:
         friend class Cursor;
         friend class Display;
+
         virtual ~BaseRenderEngine() = default;
 
         virtual void toggleFullScreen()
@@ -48,7 +49,7 @@ namespace fheroes2
 
         virtual std::vector<Size> getAvailableResolutions() const
         {
-            return std::vector<Size>();
+            return {};
         }
 
         virtual void setTitle( const std::string & )
@@ -79,7 +80,9 @@ namespace fheroes2
     protected:
         BaseRenderEngine()
             : _isFullScreen( false )
-        {}
+        {
+            // Do nothing.
+        }
 
         virtual void clear()
         {
@@ -128,16 +131,30 @@ namespace fheroes2
 
         ~Display() override = default;
 
-        void render(); // render full image on screen
+        // Render a full frame on screen.
+        void render()
+        {
+            render( { 0, 0, width(), height() } );
+        }
+
         void render( const Rect & roi ); // render a part of image on screen. Prefer this method over full image if you don't draw full screen.
 
         void resize( int32_t width_, int32_t height_ ) override;
-        bool isDefaultSize() const;
+
+        bool isDefaultSize() const
+        {
+            return width() == DEFAULT_WIDTH && height() == DEFAULT_HEIGHT;
+        }
 
         // this function must return true if new palette has been generated
         using PreRenderProcessing = bool ( * )( std::vector<uint8_t> & palette );
         using PostRenderProcessing = void ( * )();
-        void subscribe( PreRenderProcessing preprocessing, PostRenderProcessing postprocessing );
+
+        void subscribe( PreRenderProcessing preprocessing, PostRenderProcessing postprocessing )
+        {
+            _preprocessing = preprocessing;
+            _postprocessing = postprocessing;
+        }
 
         // For 8-bit mode we return a pointer to direct surface which we draw on screen
         uint8_t * image() override;
@@ -163,7 +180,11 @@ namespace fheroes2
         // Previous area drawn on the screen.
         Rect _prevRoi;
 
-        void linkRenderSurface( uint8_t * surface ); // only for cases of direct drawing on rendered 8-bit image
+        // Only for cases of direct drawing on rendered 8-bit image.
+        void linkRenderSurface( uint8_t * surface )
+        {
+            _renderSurface = surface;
+        }
 
         Display();
 

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2020                                                    *
+ *   Copyright (C) 2020 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -166,7 +166,7 @@ public:
         for ( u32 ii = 0; ii < size; ++ii ) {
             std::pair<Type1, Type2> pr;
             *this >> pr;
-            v.insert( pr );
+            v.emplace( std::move( pr ) );
         }
         return *this;
     }

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -35,27 +35,33 @@
 /* trim left right space */
 std::string StringTrim( std::string str )
 {
-    if ( str.empty() )
+    if ( str.empty() ) {
         return str;
-
-    std::string::iterator iter;
+    }
 
     // left
-    iter = str.begin();
-    while ( iter != str.end() && std::isspace( static_cast<unsigned char>( *iter ) ) )
+    std::string::iterator iter = str.begin();
+    while ( iter != str.end() && std::isspace( static_cast<unsigned char>( *iter ) ) ) {
         ++iter;
+    }
+
+    if ( iter == str.end() ) {
+        // Do not erase anything if we reached the end of the string. Just immediately return an empty string.
+        return {};
+    }
+
     if ( iter != str.begin() )
         str.erase( str.begin(), iter );
 
-    if ( str.empty() )
-        return str;
-
     // right
     iter = str.end() - 1;
-    while ( iter != str.begin() && std::isspace( static_cast<unsigned char>( *iter ) ) )
+    while ( iter != str.begin() && std::isspace( static_cast<unsigned char>( *iter ) ) ) {
         --iter;
-    if ( iter != str.end() - 1 )
+    }
+
+    if ( iter != str.end() - 1 ) {
         str.erase( iter + 1, str.end() );
+    }
 
     return str;
 }
@@ -275,12 +281,12 @@ namespace fheroes2
     std::vector<Point> GetLinePoints( const Point & pt1, const Point & pt2, const int32_t step )
     {
         std::vector<Point> res;
-        res.reserve( 10 );
 
         const int32_t dx = std::abs( pt2.x - pt1.x );
         const int32_t dy = std::abs( pt2.y - pt1.y );
 
-        int32_t ns = std::div( ( dx > dy ? dx : dy ), 2 ).quot;
+        int32_t ns = ( dx > dy ? dx : dy ) / 2;
+
         Point pt( pt1 );
 
         for ( int32_t i = 0; i <= ( dx > dy ? dx : dy ); ++i ) {
@@ -315,25 +321,19 @@ namespace fheroes2
     {
         std::vector<Point> res;
 
-        Point pt1( from );
-        Point pt2( from.x + std::abs( max.x - from.x ) / 2, from.y - std::abs( max.y - from.y ) * 3 / 4 );
-        const std::vector<Point> & pts1 = GetLinePoints( pt1, pt2, step );
-        res.insert( res.end(), pts1.begin(), pts1.end() );
+        Point tempPoint( from.x + std::abs( max.x - from.x ) / 2, from.y - std::abs( max.y - from.y ) * 3 / 4 );
+        std::vector<Point> points = GetLinePoints( from, tempPoint, step );
+        res.insert( res.end(), points.begin(), points.end() );
 
-        pt1 = pt2;
-        pt2 = max;
-        const std::vector<Point> & pts2 = GetLinePoints( pt1, pt2, step );
-        res.insert( res.end(), pts2.begin(), pts2.end() );
+        points = GetLinePoints( tempPoint, max, step );
+        res.insert( res.end(), points.begin(), points.end() );
 
-        pt1 = max;
-        pt2 = Point( max.x + std::abs( to.x - max.x ) / 2, to.y - std::abs( to.y - max.y ) * 3 / 4 );
-        const std::vector<Point> & pts3 = GetLinePoints( pt1, pt2, step );
-        res.insert( res.end(), pts3.begin(), pts3.end() );
+        tempPoint = { max.x + std::abs( to.x - max.x ) / 2, to.y - std::abs( to.y - max.y ) * 3 / 4 };
+        points = GetLinePoints( max, tempPoint, step );
+        res.insert( res.end(), points.begin(), points.end() );
 
-        pt1 = pt2;
-        pt2 = to;
-        const std::vector<Point> & pts4 = GetLinePoints( pt1, pt2, step );
-        res.insert( res.end(), pts4.begin(), pts4.end() );
+        points = GetLinePoints( tempPoint, to, step );
+        res.insert( res.end(), points.begin(), points.end() );
 
         return res;
     }
@@ -350,47 +350,47 @@ namespace fheroes2
 
     std::pair<Rect, Point> Fixed4Blit( const Rect & srcrt, const Rect & dstrt )
     {
+        if ( srcrt.width <= 0 || srcrt.height <= 0 || srcrt.x + srcrt.width <= dstrt.x || srcrt.y + srcrt.height <= dstrt.y || srcrt.x >= dstrt.x + dstrt.width
+             || srcrt.y >= dstrt.y + dstrt.height ) {
+            return {};
+        }
+
         std::pair<Rect, Point> res;
         Rect & srcrtfix = res.first;
         Point & dstptfix = res.second;
 
-        if ( srcrt.width && srcrt.height && srcrt.x + srcrt.width > dstrt.x && srcrt.y + srcrt.height > dstrt.y && srcrt.x < dstrt.x + dstrt.width
-             && srcrt.y < dstrt.y + dstrt.height ) {
-            srcrtfix.width = srcrt.width;
-            srcrtfix.height = srcrt.height;
-            dstptfix.x = srcrt.x;
-            dstptfix.y = srcrt.y;
+        srcrtfix.width = srcrt.width;
+        srcrtfix.height = srcrt.height;
+        dstptfix.x = srcrt.x;
+        dstptfix.y = srcrt.y;
 
-            if ( srcrt.x < dstrt.x ) {
-                srcrtfix.x = dstrt.x - srcrt.x;
-                dstptfix.x = dstrt.x;
-            }
-
-            if ( srcrt.y < dstrt.y ) {
-                srcrtfix.y = dstrt.y - srcrt.y;
-                dstptfix.y = dstrt.y;
-            }
-
-            if ( dstptfix.x + srcrtfix.width > dstrt.x + dstrt.width )
-                srcrtfix.width = dstrt.x + dstrt.width - dstptfix.x;
-
-            if ( dstptfix.y + srcrtfix.height > dstrt.y + dstrt.height )
-                srcrtfix.height = dstrt.y + dstrt.height - dstptfix.y;
+        if ( srcrt.x < dstrt.x ) {
+            srcrtfix.x = dstrt.x - srcrt.x;
+            dstptfix.x = dstrt.x;
         }
+
+        if ( srcrt.y < dstrt.y ) {
+            srcrtfix.y = dstrt.y - srcrt.y;
+            dstptfix.y = dstrt.y;
+        }
+
+        if ( dstptfix.x + srcrtfix.width > dstrt.x + dstrt.width )
+            srcrtfix.width = dstrt.x + dstrt.width - dstptfix.x;
+
+        if ( dstptfix.y + srcrtfix.height > dstrt.y + dstrt.height )
+            srcrtfix.height = dstrt.y + dstrt.height - dstptfix.y;
 
         return res;
     }
 
     Rect getBoundaryRect( const Rect & rt1, const Rect & rt2 )
     {
-        Rect rt3;
+        const int32_t x = std::min( rt1.x, rt2.x );
+        const int32_t y = std::min( rt1.y, rt2.y );
+        const int32_t width = std::max( rt1.x + rt1.width, rt2.x + rt2.width ) - x;
+        const int32_t height = std::max( rt1.y + rt1.height, rt2.y + rt2.height ) - y;
 
-        rt3.x = std::min( rt1.x, rt2.x );
-        rt3.y = std::min( rt1.y, rt2.y );
-        rt3.width = std::max( rt1.x + rt1.width, rt2.x + rt2.width ) - rt3.x;
-        rt3.height = std::max( rt1.y + rt1.height, rt2.y + rt2.height ) - rt3.y;
-
-        return rt3;
+        return { x, y, width, height };
     }
 
     uint32_t calculateCRC32( const uint8_t * data, const size_t length )

--- a/src/fheroes2/ai/ai_base.cpp
+++ b/src/fheroes2/ai/ai_base.cpp
@@ -230,7 +230,7 @@ namespace AI
     void Base::BattleTurn( Battle::Arena &, const Battle::Unit & currentUnit, Battle::Actions & actions )
     {
         // end action
-        actions.push_back( Battle::Command( Battle::CommandType::MSG_BATTLE_END_TURN, currentUnit.GetUID() ) );
+        actions.emplace_back( Battle::CommandType::MSG_BATTLE_END_TURN, currentUnit.GetUID() );
     }
 
     StreamBase & operator<<( StreamBase & msg, const AI::Base & instance )

--- a/src/fheroes2/ai/ai_base.cpp
+++ b/src/fheroes2/ai/ai_base.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2020                                                    *
+ *   Copyright (C) 2020 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -48,20 +48,20 @@ namespace
     {
         const int spellPower = commander->GetPower();
         if ( ( spellPower > 0 ) && ( spellPower < 3 ) ) {
-            return std::make_pair( 0, 1 );
+            return { 0, 1 };
         }
         else if ( ( spellPower >= 3 ) && ( spellPower < 6 ) ) {
-            return std::make_pair( 0, 2 );
+            return { 0, 2 };
         }
         else if ( ( spellPower >= 6 ) && ( spellPower < 10 ) ) {
-            return std::make_pair( 0, 3 );
+            return { 0, 3 };
         }
         else if ( spellPower >= 10 ) {
-            return std::make_pair( 1, 3 );
+            return { 1, 3 };
         }
 
         DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "damage_range: unexpected spellPower value: " << spellPower << " for commander " << commander );
-        return std::make_pair( 0, 0 );
+        return { 0, 0 };
     }
 }
 

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -453,7 +453,7 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
         }
         else if ( troop->Modes( MORALE_BAD ) && !troop->Modes( TR_SKIPMOVE ) ) {
             // bad morale, happens only if the unit wasn't waiting for a turn
-            actions.push_back( Command( CommandType::MSG_BATTLE_MORALE, troop->GetUID(), false ) );
+            actions.emplace_back( CommandType::MSG_BATTLE_MORALE, troop->GetUID(), false );
             end_turn = true;
         }
         else {

--- a/src/fheroes2/battle/battle_cell.cpp
+++ b/src/fheroes2/battle/battle_cell.cpp
@@ -227,14 +227,14 @@ void Battle::Cell::SetArea( const fheroes2::Rect & area )
     pos.height = CELLH;
 
     // center
-    coord[0] = fheroes2::Point( infl * pos.x + infl * pos.width / 2, infl * pos.y + infl * pos.height / 2 );
+    coord[0] = { infl * pos.x + infl * pos.width / 2, infl * pos.y + infl * pos.height / 2 };
     // coordinates
-    coord[1] = fheroes2::Point( infl * pos.x, infl * pos.y + infl * ( pos.height - cellHeightVerSide ) / 2 );
-    coord[2] = fheroes2::Point( infl * pos.x + infl * pos.width / 2, infl * pos.y );
-    coord[3] = fheroes2::Point( infl * pos.x + infl * pos.width, infl * pos.y + infl * ( pos.height - cellHeightVerSide ) / 2 );
-    coord[4] = fheroes2::Point( infl * pos.x + infl * pos.width, infl * pos.y + infl * pos.height - infl * ( pos.height - cellHeightVerSide ) / 2 );
-    coord[5] = fheroes2::Point( infl * pos.x + infl * pos.width / 2, infl * pos.y + infl * pos.height );
-    coord[6] = fheroes2::Point( infl * pos.x, infl * pos.y + infl * pos.height - infl * ( pos.height - cellHeightVerSide ) / 2 );
+    coord[1] = { infl * pos.x, infl * pos.y + infl * ( pos.height - cellHeightVerSide ) / 2 };
+    coord[2] = { infl * pos.x + infl * pos.width / 2, infl * pos.y };
+    coord[3] = { infl * pos.x + infl * pos.width, infl * pos.y + infl * ( pos.height - cellHeightVerSide ) / 2 };
+    coord[4] = { infl * pos.x + infl * pos.width, infl * pos.y + infl * pos.height - infl * ( pos.height - cellHeightVerSide ) / 2 };
+    coord[5] = { infl * pos.x + infl * pos.width / 2, infl * pos.y + infl * pos.height };
+    coord[6] = { infl * pos.x, infl * pos.y + infl * pos.height - infl * ( pos.height - cellHeightVerSide ) / 2 };
 }
 
 Battle::direction_t Battle::Cell::GetTriangleDirection( const fheroes2::Point & dst ) const

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -721,7 +721,7 @@ fheroes2::Point Battle::OpponentSprite::GetCastPosition( void ) const
         break;
     }
 
-    return fheroes2::Point( pos.x + ( reflect ? offset.x : pos.width - offset.x ), pos.y + pos.height / 2 + offset.y );
+    return { pos.x + ( reflect ? offset.x : pos.width - offset.x ), pos.y + pos.height / 2 + offset.y };
 }
 
 void Battle::OpponentSprite::Redraw( fheroes2::Image & dst ) const
@@ -1503,7 +1503,7 @@ fheroes2::Point GetTroopPosition( const Battle::Unit & unit, const fheroes2::Spr
 
     const int32_t offsetY = rt.y + rt.height + sprite.y() + cellYOffset;
 
-    return fheroes2::Point( offsetX, offsetY );
+    return { offsetX, offsetY };
 }
 
 void Battle::Interface::RedrawTroopSprite( const Unit & unit )
@@ -2383,13 +2383,13 @@ void Battle::Interface::HumanBattleTurn( const Unit & b, Actions & a, std::strin
     if ( le.KeyPress() ) {
         // skip
         if ( Game::HotKeyPressEvent( Game::EVENT_BATTLE_HARDSKIP ) ) {
-            a.push_back( Command( CommandType::MSG_BATTLE_SKIP, b.GetUID(), true ) );
+            a.emplace_back( CommandType::MSG_BATTLE_SKIP, b.GetUID(), true );
             humanturn_exit = true;
         }
         else
             // soft skip
             if ( Game::HotKeyPressEvent( Game::EVENT_BATTLE_SOFTSKIP ) ) {
-            a.push_back( Command( CommandType::MSG_BATTLE_SKIP, b.GetUID(), !conf.ExtBattleSoftWait() ) );
+            a.emplace_back( CommandType::MSG_BATTLE_SKIP, b.GetUID(), !conf.ExtBattleSoftWait() );
             humanturn_exit = true;
         }
         else
@@ -2421,14 +2421,14 @@ void Battle::Interface::HumanBattleTurn( const Unit & b, Actions & a, std::strin
                 // fast wins game
                 arena.GetResult().army1 = RESULT_WINS;
                 humanturn_exit = true;
-                a.push_back( Command( CommandType::MSG_BATTLE_END_TURN, b.GetUID() ) );
+                a.emplace_back( CommandType::MSG_BATTLE_END_TURN, b.GetUID() );
                 break;
 
             case KEY_l:
                 // fast loss game
                 arena.GetResult().army1 = RESULT_LOSS;
                 humanturn_exit = true;
-                a.push_back( Command( CommandType::MSG_BATTLE_END_TURN, b.GetUID() ) );
+                a.emplace_back( CommandType::MSG_BATTLE_END_TURN, b.GetUID() );
                 break;
 
             default:
@@ -2631,19 +2631,19 @@ void Battle::Interface::HumanCastSpellTurn( const Unit & /*b*/, Actions & a, std
                 if ( 0 > teleport_src )
                     teleport_src = index_pos;
                 else {
-                    a.push_back( Command( CommandType::MSG_BATTLE_CAST, Spell::TELEPORT, teleport_src, index_pos ) );
+                    a.emplace_back( CommandType::MSG_BATTLE_CAST, Spell::TELEPORT, teleport_src, index_pos );
                     humanturn_spell = Spell::NONE;
                     humanturn_exit = true;
                     teleport_src = -1;
                 }
             }
             else if ( Cursor::SP_MIRRORIMAGE == cursor.Themes() ) {
-                a.push_back( Command( CommandType::MSG_BATTLE_CAST, Spell::MIRRORIMAGE, index_pos ) );
+                a.emplace_back( CommandType::MSG_BATTLE_CAST, Spell::MIRRORIMAGE, index_pos );
                 humanturn_spell = Spell::NONE;
                 humanturn_exit = true;
             }
             else {
-                a.push_back( Command( CommandType::MSG_BATTLE_CAST, humanturn_spell.GetID(), index_pos ) );
+                a.emplace_back( CommandType::MSG_BATTLE_CAST, humanturn_spell.GetID(), index_pos );
                 humanturn_spell = Spell::NONE;
                 humanturn_exit = true;
             }
@@ -2743,7 +2743,7 @@ void Battle::Interface::ButtonWaitAction( Actions & a )
     le.MousePressLeft( btn_wait.area() ) ? btn_wait.drawOnPress() : btn_wait.drawOnRelease();
 
     if ( le.MouseClickLeft( btn_wait.area() ) && _currentUnit ) {
-        a.push_back( Command( CommandType::MSG_BATTLE_SKIP, _currentUnit->GetUID(), false ) );
+        a.emplace_back( CommandType::MSG_BATTLE_SKIP, _currentUnit->GetUID(), false );
         humanturn_exit = true;
     }
 }
@@ -2755,7 +2755,7 @@ void Battle::Interface::ButtonSkipAction( Actions & a )
     le.MousePressLeft( btn_skip.area() ) ? btn_skip.drawOnPress() : btn_skip.drawOnRelease();
 
     if ( le.MouseClickLeft( btn_skip.area() ) && _currentUnit ) {
-        a.push_back( Command( CommandType::MSG_BATTLE_SKIP, _currentUnit->GetUID(), true ) );
+        a.emplace_back( CommandType::MSG_BATTLE_SKIP, _currentUnit->GetUID(), true );
         humanturn_exit = true;
     }
 }
@@ -2797,8 +2797,8 @@ void Battle::Interface::MouseLeftClickBoardAction( int themes, const Cell & cell
         switch ( themes ) {
         case Cursor::WAR_FLY:
         case Cursor::WAR_MOVE:
-            a.push_back( Command( CommandType::MSG_BATTLE_MOVE, _currentUnit->GetUID(), fixupDestinationCell( *_currentUnit, index, true ) ) );
-            a.push_back( Command( CommandType::MSG_BATTLE_END_TURN, _currentUnit->GetUID() ) );
+            a.emplace_back( CommandType::MSG_BATTLE_MOVE, _currentUnit->GetUID(), fixupDestinationCell( *_currentUnit, index, true ) );
+            a.emplace_back( CommandType::MSG_BATTLE_END_TURN, _currentUnit->GetUID() );
             humanturn_exit = true;
             break;
 
@@ -2815,10 +2815,10 @@ void Battle::Interface::MouseLeftClickBoardAction( int themes, const Cell & cell
                 const int32_t move = fixupDestinationCell( *_currentUnit, Board::GetIndexDirection( index, dir ), preferAttackFromHead( *_currentUnit, themes ) );
 
                 if ( _currentUnit->GetHeadIndex() != move ) {
-                    a.push_back( Command( CommandType::MSG_BATTLE_MOVE, _currentUnit->GetUID(), move ) );
+                    a.emplace_back( CommandType::MSG_BATTLE_MOVE, _currentUnit->GetUID(), move );
                 }
-                a.push_back( Command( CommandType::MSG_BATTLE_ATTACK, _currentUnit->GetUID(), enemy->GetUID(), index, Board::GetReflectDirection( dir ) ) );
-                a.push_back( Command( CommandType::MSG_BATTLE_END_TURN, _currentUnit->GetUID() ) );
+                a.emplace_back( CommandType::MSG_BATTLE_ATTACK, _currentUnit->GetUID(), enemy->GetUID(), index, Board::GetReflectDirection( dir ) );
+                a.emplace_back( CommandType::MSG_BATTLE_END_TURN, _currentUnit->GetUID() );
                 humanturn_exit = true;
             }
             break;
@@ -2829,8 +2829,8 @@ void Battle::Interface::MouseLeftClickBoardAction( int themes, const Cell & cell
             const Unit * enemy = b;
 
             if ( enemy ) {
-                a.push_back( Command( CommandType::MSG_BATTLE_ATTACK, _currentUnit->GetUID(), enemy->GetUID(), index, 0 ) );
-                a.push_back( Command( CommandType::MSG_BATTLE_END_TURN, _currentUnit->GetUID() ) );
+                a.emplace_back( CommandType::MSG_BATTLE_ATTACK, _currentUnit->GetUID(), enemy->GetUID(), index, 0 );
+                a.emplace_back( CommandType::MSG_BATTLE_END_TURN, _currentUnit->GetUID() );
                 humanturn_exit = true;
             }
             break;
@@ -3026,7 +3026,7 @@ void Battle::Interface::RedrawActionAttackPart1( Unit & attacker, Unit & defende
             AnimateUnitWithDelay( attacker, Game::ApplyBattleSpeed( attacker.animation.getShootingSpeed() ) );
         }
 
-        const fheroes2::Point missileStart = fheroes2::Point( shooterPos.x + ( attacker.isReflect() ? -offset.x : offset.x ), shooterPos.y + offset.y );
+        const fheroes2::Point missileStart( shooterPos.x + ( attacker.isReflect() ? -offset.x : offset.x ), shooterPos.y + offset.y );
 
         // draw missile animation
         RedrawMissileAnimation( missileStart, targetPos, angle, attacker.GetID() );
@@ -4230,7 +4230,7 @@ void Battle::Interface::RedrawActionChainLightningSpell( const TargetsInfo & tar
 
     for ( TargetsInfo::const_iterator it = targets.begin(); it != targets.end(); ++it ) {
         const fheroes2::Rect & pos = it->defender->GetRectPosition();
-        points.push_back( fheroes2::Point( pos.x + pos.width / 2, pos.y ) );
+        points.emplace_back( pos.x + pos.width / 2, pos.y );
     }
 
     RedrawLightningOnTargets( points, _surfaceInnerArea );
@@ -5085,7 +5085,7 @@ void Battle::Interface::ProcessingHeroDialogResult( int res, Actions & a )
                             Dialog::Message( "", msg, Font::BIG, Dialog::OK );
                         else if ( hero->CanCastSpell( spell, &error ) ) {
                             if ( spell.isApplyWithoutFocusObject() ) {
-                                a.push_back( Command( CommandType::MSG_BATTLE_CAST, spell.GetID(), -1 ) );
+                                a.emplace_back( CommandType::MSG_BATTLE_CAST, spell.GetID(), -1 );
                                 humanturn_redraw = true;
                                 humanturn_exit = true;
                             }
@@ -5107,8 +5107,8 @@ void Battle::Interface::ProcessingHeroDialogResult( int res, Actions & a )
     case 2: {
         if ( arena.CanRetreatOpponent( _currentUnit->GetCurrentOrArmyColor() ) ) {
             if ( Dialog::YES == Dialog::Message( "", _( "Are you sure you want to retreat?" ), Font::BIG, Dialog::YES | Dialog::NO ) ) {
-                a.push_back( Command( CommandType::MSG_BATTLE_RETREAT ) );
-                a.push_back( Command( CommandType::MSG_BATTLE_END_TURN, _currentUnit->GetUID() ) );
+                a.emplace_back( CommandType::MSG_BATTLE_RETREAT );
+                a.emplace_back( CommandType::MSG_BATTLE_END_TURN, _currentUnit->GetUID() );
                 humanturn_exit = true;
             }
         }
@@ -5128,8 +5128,8 @@ void Battle::Interface::ProcessingHeroDialogResult( int res, Actions & a )
                 Kingdom & kingdom = world.GetKingdom( arena.GetCurrentColor() );
 
                 if ( DialogBattleSurrender( *enemy, cost, kingdom ) ) {
-                    a.push_back( Command( CommandType::MSG_BATTLE_SURRENDER ) );
-                    a.push_back( Command( CommandType::MSG_BATTLE_END_TURN, _currentUnit->GetUID() ) );
+                    a.emplace_back( CommandType::MSG_BATTLE_SURRENDER );
+                    a.emplace_back( CommandType::MSG_BATTLE_END_TURN, _currentUnit->GetUID() );
                     humanturn_exit = true;
                 }
             }

--- a/src/fheroes2/battle/battle_tower.cpp
+++ b/src/fheroes2/battle/battle_tower.cpp
@@ -97,17 +97,17 @@ fheroes2::Point Battle::Tower::GetPortPosition( void ) const
 {
     switch ( type ) {
     case TWR_LEFT:
-        return fheroes2::Point( 410, 70 );
+        return { 410, 70 };
         break;
     case TWR_RIGHT:
-        return fheroes2::Point( 410, 320 );
+        return { 410, 320 };
     case TWR_CENTER:
-        return fheroes2::Point( 560, 170 );
+        return { 560, 170 };
     default:
         break;
     }
 
-    return fheroes2::Point();
+    return {};
 }
 
 void Battle::Tower::SetDestroy( void )

--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -47,21 +47,21 @@ namespace
     {
         switch ( race ) {
         case Race::KNGT:
-            return fheroes2::Point( 36, 10 );
+            return { 36, 10 };
         case Race::BARB:
-            return fheroes2::Point( 35, 9 );
+            return { 35, 9 };
         case Race::SORC:
-            return fheroes2::Point( 36, 10 );
+            return { 36, 10 };
         case Race::WRLK:
-            return fheroes2::Point( 34, 10 );
+            return { 34, 10 };
         case Race::WZRD:
-            return fheroes2::Point( 35, 9 );
+            return { 35, 9 };
         case Race::NECR:
-            return fheroes2::Point( 35, 10 );
+            return { 35, 10 };
         default:
             // Did you add a new race?
             assert( 0 );
-            return fheroes2::Point();
+            return {};
         }
     }
 }

--- a/src/fheroes2/castle/captain.cpp
+++ b/src/fheroes2/castle/captain.cpp
@@ -58,19 +58,19 @@ namespace
     {
         switch ( race ) {
         case Race::KNGT:
-            return fheroes2::Point( 43, 9 );
+            return { 43, 9 };
         case Race::BARB:
-            return fheroes2::Point( 42, 8 );
+            return { 42, 8 };
         case Race::SORC:
-            return fheroes2::Point( 43, 9 );
+            return { 43, 9 };
         case Race::WRLK:
-            return fheroes2::Point( 41, 9 );
+            return { 41, 9 };
         case Race::WZRD:
-            return fheroes2::Point( 42, 10 );
+            return { 42, 10 };
         case Race::NECR:
-            return fheroes2::Point( 42, 9 );
+            return { 42, 9 };
         default:
-            return fheroes2::Point();
+            return {};
         }
     }
 }

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -479,7 +479,7 @@ void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vect
         fheroes2::Size inSize( smonster.width(), smonster.height() );
 
         if ( fheroes2::FitToRoi( smonster, inPos, display, outPos, inSize,
-                                 fheroes2::Rect( cur_pt.x, cur_pt.y, fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT ) ) ) {
+                                 { cur_pt.x, cur_pt.y, fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT } ) ) {
             fheroes2::Blit( smonster, inPos, display, outPos, inSize, flipMonsterSprite );
         }
 

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -485,7 +485,7 @@ std::vector<std::pair<fheroes2::Rect, Spell>> DrawBattleStats( const fheroes2::P
             const fheroes2::Point imageOffset( ow, dst.y + maxSpriteHeight - sprite.height() );
 
             fheroes2::Blit( sprite, fheroes2::Display::instance(), imageOffset.x, imageOffset.y );
-            output.emplace_back( std::make_pair( fheroes2::Rect( imageOffset.x, imageOffset.y, sprite.width(), sprite.height() ), modeToSpell( spell.mode ) ) );
+            output.emplace_back( fheroes2::Rect( imageOffset.x, imageOffset.y, sprite.width(), sprite.height() ), modeToSpell( spell.mode ) );
 
             if ( spell.duration > 0 ) {
                 text.Set( std::to_string( spell.duration ), Font::SMALL );
@@ -513,7 +513,7 @@ std::vector<std::pair<fheroes2::Rect, Spell>> DrawBattleStats( const fheroes2::P
             const fheroes2::Point imageOffset( ow - sprite.width(), dst.y + maxSpriteHeight - sprite.height() );
 
             fheroes2::Blit( sprite, fheroes2::Display::instance(), imageOffset.x, imageOffset.y );
-            output.emplace_back( std::make_pair( fheroes2::Rect( imageOffset.x, imageOffset.y, sprite.width(), sprite.height() ), modeToSpell( spellIt->mode ) ) );
+            output.emplace_back( fheroes2::Rect( imageOffset.x, imageOffset.y, sprite.width(), sprite.height() ), modeToSpell( spellIt->mode ) );
 
             if ( spellIt->duration > 0 ) {
                 text.Set( std::to_string( spellIt->duration ), Font::SMALL );

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -431,7 +431,7 @@ namespace
     fheroes2::Rect MakeRectQuickInfo( const LocalEvent & le, const fheroes2::Sprite & imageBox, const fheroes2::Point & position = fheroes2::Point() )
     {
         if ( position.x > 0 && position.y > 0 ) {
-            return fheroes2::Rect( position.x - imageBox.width(), position.y, imageBox.width(), imageBox.height() );
+            return { position.x - imageBox.width(), position.y, imageBox.width(), imageBox.height() };
         }
 
         // place box next to mouse cursor
@@ -450,7 +450,7 @@ namespace
         xpos = clamp( xpos, BORDERWIDTH, ( ar.width - imageBox.width() ) + BORDERWIDTH );
         ypos = clamp( ypos, BORDERWIDTH, ( ar.height - imageBox.height() ) + BORDERWIDTH );
 
-        return fheroes2::Rect( xpos, ypos, imageBox.width(), imageBox.height() );
+        return { xpos, ypos, imageBox.width(), imageBox.height() };
     }
 
     uint32_t GetHeroScoutingLevelForTile( const Heroes * hero, uint32_t dst )

--- a/src/fheroes2/dialog/dialog_resolution.cpp
+++ b/src/fheroes2/dialog/dialog_resolution.cpp
@@ -154,7 +154,7 @@ namespace Dialog
         resList.setScrollBarArea( { roi.x + 328, roi.y + 73, 12, 180 } );
         resList.setScrollBarImage( scrollbarSlider );
         resList.SetAreaMaxItems( 11 );
-        resList.SetAreaItems( fheroes2::Rect( roi.x + 41, roi.y + 55 + 3, editBoxLength, 215 ) );
+        resList.SetAreaItems( { roi.x + 41, roi.y + 55 + 3, editBoxLength, 215 } );
 
         resList.SetListContent( resolutions );
 

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -276,7 +276,7 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
     listbox.setScrollBarArea( { rt.x + 328, rt.y + 73, 12, 180 } );
     listbox.setScrollBarImage( scrollbarSlider );
     listbox.SetAreaMaxItems( 11 );
-    listbox.SetAreaItems( fheroes2::Rect( rt.x + 40, rt.y + 55, 265, 215 ) );
+    listbox.SetAreaItems( { rt.x + 40, rt.y + 55, 265, 215 } );
     listbox.SetListContent( lists );
 
     std::string filename;

--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -184,7 +184,7 @@ void Dialog::ExtSettings( bool readonly )
     listbox.setScrollBarArea( { area.x + 298, area.y + 44, 10, ah - 42 } );
     listbox.setScrollBarImage( scrollbarSlider );
     listbox.SetAreaMaxItems( ah / 40 );
-    listbox.SetAreaItems( fheroes2::Rect( area.x + 10, area.y + 30, 290, ah + 5 ) );
+    listbox.SetAreaItems( { area.x + 10, area.y + 30, 290, ah + 5 } );
     listbox.SetListContent( states );
     listbox.Redraw();
 

--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -482,8 +482,8 @@ namespace fheroes2
 
                 const fheroes2::Rect newRoi = gamearea.GetROI();
 
-                gamearea.SetCenterInPixels( prevCenter + fheroes2::Point( newRoi.width / 2, newRoi.height / 2 ) + fheroes2::Point( newRoi.x, newRoi.y )
-                                            - fheroes2::Point( prevRoi.width / 2, prevRoi.height / 2 ) - fheroes2::Point( prevRoi.x, prevRoi.y ) );
+                gamearea.SetCenterInPixels( prevCenter + fheroes2::Point( newRoi.x + newRoi.width / 2, newRoi.y + newRoi.height / 2 )
+                                            - fheroes2::Point( prevRoi.x + prevRoi.width / 2, prevRoi.y + prevRoi.height / 2 ) );
 
                 // We need to redraw radar first due to the nature of restorers. Only then we can redraw everything.
                 basicInterface.Redraw( Interface::REDRAW_RADAR );

--- a/src/fheroes2/gui/cursor.cpp
+++ b/src/fheroes2/gui/cursor.cpp
@@ -67,7 +67,7 @@ bool Cursor::SetThemes( int name, bool force )
             break;
         }
         const fheroes2::Sprite & spr = fheroes2::AGG::GetICN( icnID, 0xFF & name );
-        SetOffset( name, fheroes2::Point( ( spr.width() - spr.x() ) / 2, ( spr.height() - spr.y() ) / 2 ) );
+        SetOffset( name, { ( spr.width() - spr.x() ) / 2, ( spr.height() - spr.y() ) / 2 } );
         fheroes2::cursor().update( spr, -offset_x, -offset_y );
 
         // immediately apply new offset, force
@@ -84,7 +84,7 @@ void Cursor::Redraw( int32_t x, int32_t y )
     if ( fheroes2::cursor().isSoftwareEmulation() ) {
         Cursor::Get().Move( x, y );
         if ( fheroes2::cursor().isVisible() ) {
-            fheroes2::Display::instance().render( fheroes2::Rect( x, y, 1, 1 ) );
+            fheroes2::Display::instance().render( { x, y, 1, 1 } );
         }
     }
 }
@@ -250,7 +250,7 @@ CursorRestorer::~CursorRestorer()
         if ( fheroes2::cursor().isSoftwareEmulation() ) {
             const fheroes2::Point & pos = LocalEvent::Get().GetMouseCursor();
 
-            fheroes2::Display::instance().render( fheroes2::Rect( pos.x, pos.y, 1, 1 ) );
+            fheroes2::Display::instance().render( { pos.x, pos.y, 1, 1 } );
         }
     }
 }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -52,7 +52,7 @@ Interface::GameArea::GameArea( Basic & basic )
 
 fheroes2::Rect Interface::GameArea::GetVisibleTileROI( void ) const
 {
-    return fheroes2::Rect( _getStartTileId(), _visibleTileCount );
+    return { _getStartTileId(), _visibleTileCount };
 }
 
 void Interface::GameArea::ShiftCenter( const fheroes2::Point & offset )
@@ -77,7 +77,7 @@ void Interface::GameArea::generate( const fheroes2::Size & screenSize, const boo
 
 void Interface::GameArea::SetAreaPosition( int32_t x, int32_t y, int32_t w, int32_t h )
 {
-    _windowROI = fheroes2::Rect( x, y, w, h );
+    _windowROI = { x, y, w, h };
     const fheroes2::Size worldSize( world.w() * TILEWIDTH, world.h() * TILEWIDTH );
 
     if ( worldSize.width > w ) {
@@ -674,7 +674,7 @@ void Interface::GameArea::QueueEventProcessing( void )
 
 fheroes2::Point Interface::GameArea::_middlePoint() const
 {
-    return fheroes2::Point( _windowROI.width / 2, _windowROI.height / 2 );
+    return { _windowROI.width / 2, _windowROI.height / 2 };
 }
 
 fheroes2::Point Interface::GameArea::_getStartTileId() const
@@ -682,12 +682,12 @@ fheroes2::Point Interface::GameArea::_getStartTileId() const
     const int32_t x = ( _topLeftTileOffset.x < 0 ? ( _topLeftTileOffset.x - TILEWIDTH - 1 ) / TILEWIDTH : _topLeftTileOffset.x / TILEWIDTH );
     const int32_t y = ( _topLeftTileOffset.y < 0 ? ( _topLeftTileOffset.y - TILEWIDTH - 1 ) / TILEWIDTH : _topLeftTileOffset.y / TILEWIDTH );
 
-    return fheroes2::Point( x, y );
+    return { x, y };
 }
 
 void Interface::GameArea::_setCenterToTile( const fheroes2::Point & tile )
 {
-    SetCenterInPixels( fheroes2::Point( tile.x * TILEWIDTH + TILEWIDTH / 2, tile.y * TILEWIDTH + TILEWIDTH / 2 ) );
+    SetCenterInPixels( { tile.x * TILEWIDTH + TILEWIDTH / 2, tile.y * TILEWIDTH + TILEWIDTH / 2 } );
 }
 
 void Interface::GameArea::SetCenterInPixels( const fheroes2::Point & point )

--- a/src/fheroes2/gui/interface_icons.cpp
+++ b/src/fheroes2/gui/interface_icons.cpp
@@ -61,7 +61,7 @@ int32_t Interface::IconsBar::GetItemHeight()
 
 void Interface::RedrawCastleIcon( const Castle & castle, int32_t sx, int32_t sy )
 {
-    fheroes2::drawCastleIcon( castle, fheroes2::Display::instance(), fheroes2::Point( sx, sy ) );
+    fheroes2::drawCastleIcon( castle, fheroes2::Display::instance(), { sx, sy } );
 }
 
 void Interface::RedrawHeroesIcon( const Heroes & hero, s32 sx, s32 sy )

--- a/src/fheroes2/gui/text.cpp
+++ b/src/fheroes2/gui/text.cpp
@@ -513,5 +513,5 @@ bool TextSprite::isShow( void ) const
 
 fheroes2::Rect TextSprite::GetRect( void ) const
 {
-    return fheroes2::Rect( _restorer.x(), _restorer.y(), _restorer.width(), _restorer.height() );
+    return { _restorer.x(), _restorer.y(), _restorer.width(), _restorer.height() };
 }

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -237,34 +237,22 @@ const fheroes2::Sprite & SpriteFlag( const Heroes & hero, int index, bool rotate
     const int frameId = index % heroFrameCount;
     const fheroes2::Sprite & flag = fheroes2::AGG::GetICN( icn_flag, index_sprite + frameId );
     if ( !hero.isMoveEnabled() ) {
-        static const fheroes2::Point offsetTop[heroFrameCount]
-            = { fheroes2::Point( 0, 0 ), fheroes2::Point( 0, 2 ), fheroes2::Point( 0, 3 ), fheroes2::Point( 0, 2 ), fheroes2::Point( 0, 0 ),
-                fheroes2::Point( 0, 1 ), fheroes2::Point( 0, 3 ), fheroes2::Point( 0, 2 ), fheroes2::Point( 0, 1 ) };
-        static const fheroes2::Point offsetBottom[heroFrameCount]
-            = { fheroes2::Point( 0, 0 ),  fheroes2::Point( 0, -1 ), fheroes2::Point( 0, -2 ), fheroes2::Point( 0, 0 ), fheroes2::Point( 0, -1 ),
-                fheroes2::Point( 0, -2 ), fheroes2::Point( 0, -3 ), fheroes2::Point( 0, 0 ),  fheroes2::Point( 0, -1 ) };
-        static const fheroes2::Point offsetSideways[heroFrameCount]
-            = { fheroes2::Point( 0, 0 ),  fheroes2::Point( -1, 0 ), fheroes2::Point( 0, 0 ), fheroes2::Point( 1, 0 ), fheroes2::Point( 1, -1 ),
-                fheroes2::Point( 2, -1 ), fheroes2::Point( 1, 0 ),  fheroes2::Point( 0, 0 ), fheroes2::Point( 1, 0 ) };
+        static const fheroes2::Point offsetTop[heroFrameCount] = { { 0, 0 }, { 0, 2 }, { 0, 3 }, { 0, 2 }, { 0, 0 }, { 0, 1 }, { 0, 3 }, { 0, 2 }, { 0, 1 } };
+        static const fheroes2::Point offsetBottom[heroFrameCount] = { { 0, 0 },  { 0, -1 }, { 0, -2 }, { 0, 0 }, { 0, -1 }, { 0, -2 }, { 0, -3 }, { 0, 0 },  { 0, -1 } };
+        static const fheroes2::Point offsetSideways[heroFrameCount] = { { 0, 0 },  { -1, 0 }, { 0, 0 }, { 1, 0 }, { 1, -1 }, { 2, -1 }, { 1, 0 },  { 0, 0 }, { 1, 0 } };
         static const fheroes2::Point offsetTopSideways[heroFrameCount]
-            = { fheroes2::Point( 0, 0 ),  fheroes2::Point( -1, 0 ), fheroes2::Point( 0, 0 ), fheroes2::Point( -1, -1 ), fheroes2::Point( -2, -1 ),
-                fheroes2::Point( -2, 0 ), fheroes2::Point( -1, 0 ), fheroes2::Point( 0, 0 ), fheroes2::Point( 1, 0 ) };
+            = { { 0, 0 },  { -1, 0 }, { 0, 0 }, { -1, -1 }, { -2, -1 }, { -2, 0 }, { -1, 0 }, { 0, 0 }, { 1, 0 } };
         static const fheroes2::Point offsetBottomSideways[heroFrameCount]
-            = { fheroes2::Point( 0, 0 ),   fheroes2::Point( -1, 0 ),  fheroes2::Point( 0, -1 ),  fheroes2::Point( 2, -2 ), fheroes2::Point( 0, -2 ),
-                fheroes2::Point( -1, -3 ), fheroes2::Point( -1, -2 ), fheroes2::Point( -1, -1 ), fheroes2::Point( 1, 0 ) };
+            = { { 0, 0 },   { -1, 0 },  { 0, -1 },  { 2, -2 }, { 0, -2 }, { -1, -3 }, { -1, -2 }, { -1, -1 }, { 1, 0 } };
 
         static const fheroes2::Point offsetShipTopBottom[heroFrameCount]
-            = { fheroes2::Point( 0, -1 ), fheroes2::Point( 0, 0 ), fheroes2::Point( 0, 1 ), fheroes2::Point( 0, 1 ), fheroes2::Point( 0, 1 ),
-                fheroes2::Point( 0, 0 ),  fheroes2::Point( 0, 1 ), fheroes2::Point( 0, 1 ), fheroes2::Point( 0, 1 ) };
+            = { { 0, -1 }, { 0, 0 }, { 0, 1 }, { 0, 1 }, { 0, 1 }, { 0, 0 },  { 0, 1 }, { 0, 1 }, { 0, 1 } };
         static const fheroes2::Point offsetShipSideways[heroFrameCount]
-            = { fheroes2::Point( 0, -2 ), fheroes2::Point( 0, -1 ), fheroes2::Point( 0, 0 ),  fheroes2::Point( 0, 1 ), fheroes2::Point( 0, 0 ),
-                fheroes2::Point( 0, -1 ), fheroes2::Point( 0, 0 ),  fheroes2::Point( 0, -1 ), fheroes2::Point( 0, 1 ) };
+            = { { 0, -2 }, { 0, -1 }, { 0, 0 },  { 0, 1 }, { 0, 0 }, { 0, -1 }, { 0, 0 },  { 0, -1 }, { 0, 1 } };
         static const fheroes2::Point offsetShipTopSideways[heroFrameCount]
-            = { fheroes2::Point( 0, 0 ),  fheroes2::Point( 0, -1 ), fheroes2::Point( 0, 0 ),  fheroes2::Point( 0, 1 ), fheroes2::Point( 0, 0 ),
-                fheroes2::Point( 0, -1 ), fheroes2::Point( 0, 0 ),  fheroes2::Point( 0, -1 ), fheroes2::Point( 0, 1 ) };
+            = { { 0, 0 },  { 0, -1 }, { 0, 0 },  { 0, 1 }, { 0, 0 }, { 0, -1 }, { 0, 0 },  { 0, -1 }, { 0, 1 } };
         static const fheroes2::Point offsetShipBottomSideways[heroFrameCount]
-            = { fheroes2::Point( 0, -2 ), fheroes2::Point( 0, 0 ), fheroes2::Point( 0, 0 ), fheroes2::Point( 0, 0 ), fheroes2::Point( 0, 0 ),
-                fheroes2::Point( 0, 0 ),  fheroes2::Point( 0, 0 ), fheroes2::Point( 0, 0 ), fheroes2::Point( 0, 0 ) };
+            = { { 0, -2 }, { 0, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 },  { 0, 0 }, { 0, 0 }, { 0, 0 } };
 
         switch ( hero.GetDirection() ) {
         case Direction::TOP:
@@ -1026,31 +1014,31 @@ fheroes2::Point Heroes::MovementDirection() const
 
     if ( direction == Direction::TOP ) {
         if ( sprite_index > 1 && sprite_index < 9 ) {
-            return fheroes2::Point( 0, -1 );
+            return { 0, -1 };
         }
     }
     else if ( direction == Direction::TOP_RIGHT || direction == Direction::TOP_LEFT ) {
         if ( sprite_index > 9 + 1 && sprite_index < 18 ) {
-            return fheroes2::Point( direction == Direction::TOP_RIGHT ? 1 : -1, -1 );
+            return { direction == Direction::TOP_RIGHT ? 1 : -1, -1 };
         }
     }
     else if ( direction == Direction::RIGHT || direction == Direction::LEFT ) {
         if ( sprite_index > 18 + 1 && sprite_index < 27 ) {
-            return fheroes2::Point( direction == Direction::RIGHT ? 1 : -1, 0 );
+            return { direction == Direction::RIGHT ? 1 : -1, 0 };
         }
     }
     else if ( direction == Direction::BOTTOM_RIGHT || direction == Direction::BOTTOM_LEFT ) {
         if ( sprite_index > 27 + 1 && sprite_index < 36 ) {
-            return fheroes2::Point( direction == Direction::BOTTOM_RIGHT ? 1 : -1, 1 );
+            return { direction == Direction::BOTTOM_RIGHT ? 1 : -1, 1 };
         }
     }
     else if ( direction == Direction::BOTTOM ) {
         if ( sprite_index > 36 + 1 && sprite_index < 45 ) {
-            return fheroes2::Point( 0, 1 );
+            return { 0, 1 };
         }
     }
 
-    return fheroes2::Point();
+    return {};
 }
 
 void Heroes::SetValidDirectionSprite()

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -238,21 +238,20 @@ const fheroes2::Sprite & SpriteFlag( const Heroes & hero, int index, bool rotate
     const fheroes2::Sprite & flag = fheroes2::AGG::GetICN( icn_flag, index_sprite + frameId );
     if ( !hero.isMoveEnabled() ) {
         static const fheroes2::Point offsetTop[heroFrameCount] = { { 0, 0 }, { 0, 2 }, { 0, 3 }, { 0, 2 }, { 0, 0 }, { 0, 1 }, { 0, 3 }, { 0, 2 }, { 0, 1 } };
-        static const fheroes2::Point offsetBottom[heroFrameCount] = { { 0, 0 },  { 0, -1 }, { 0, -2 }, { 0, 0 }, { 0, -1 }, { 0, -2 }, { 0, -3 }, { 0, 0 },  { 0, -1 } };
-        static const fheroes2::Point offsetSideways[heroFrameCount] = { { 0, 0 },  { -1, 0 }, { 0, 0 }, { 1, 0 }, { 1, -1 }, { 2, -1 }, { 1, 0 },  { 0, 0 }, { 1, 0 } };
+        static const fheroes2::Point offsetBottom[heroFrameCount] = { { 0, 0 }, { 0, -1 }, { 0, -2 }, { 0, 0 }, { 0, -1 }, { 0, -2 }, { 0, -3 }, { 0, 0 }, { 0, -1 } };
+        static const fheroes2::Point offsetSideways[heroFrameCount] = { { 0, 0 }, { -1, 0 }, { 0, 0 }, { 1, 0 }, { 1, -1 }, { 2, -1 }, { 1, 0 }, { 0, 0 }, { 1, 0 } };
         static const fheroes2::Point offsetTopSideways[heroFrameCount]
-            = { { 0, 0 },  { -1, 0 }, { 0, 0 }, { -1, -1 }, { -2, -1 }, { -2, 0 }, { -1, 0 }, { 0, 0 }, { 1, 0 } };
+            = { { 0, 0 }, { -1, 0 }, { 0, 0 }, { -1, -1 }, { -2, -1 }, { -2, 0 }, { -1, 0 }, { 0, 0 }, { 1, 0 } };
         static const fheroes2::Point offsetBottomSideways[heroFrameCount]
-            = { { 0, 0 },   { -1, 0 },  { 0, -1 },  { 2, -2 }, { 0, -2 }, { -1, -3 }, { -1, -2 }, { -1, -1 }, { 1, 0 } };
+            = { { 0, 0 }, { -1, 0 }, { 0, -1 }, { 2, -2 }, { 0, -2 }, { -1, -3 }, { -1, -2 }, { -1, -1 }, { 1, 0 } };
 
-        static const fheroes2::Point offsetShipTopBottom[heroFrameCount]
-            = { { 0, -1 }, { 0, 0 }, { 0, 1 }, { 0, 1 }, { 0, 1 }, { 0, 0 },  { 0, 1 }, { 0, 1 }, { 0, 1 } };
+        static const fheroes2::Point offsetShipTopBottom[heroFrameCount] = { { 0, -1 }, { 0, 0 }, { 0, 1 }, { 0, 1 }, { 0, 1 }, { 0, 0 }, { 0, 1 }, { 0, 1 }, { 0, 1 } };
         static const fheroes2::Point offsetShipSideways[heroFrameCount]
-            = { { 0, -2 }, { 0, -1 }, { 0, 0 },  { 0, 1 }, { 0, 0 }, { 0, -1 }, { 0, 0 },  { 0, -1 }, { 0, 1 } };
+            = { { 0, -2 }, { 0, -1 }, { 0, 0 }, { 0, 1 }, { 0, 0 }, { 0, -1 }, { 0, 0 }, { 0, -1 }, { 0, 1 } };
         static const fheroes2::Point offsetShipTopSideways[heroFrameCount]
-            = { { 0, 0 },  { 0, -1 }, { 0, 0 },  { 0, 1 }, { 0, 0 }, { 0, -1 }, { 0, 0 },  { 0, -1 }, { 0, 1 } };
+            = { { 0, 0 }, { 0, -1 }, { 0, 0 }, { 0, 1 }, { 0, 0 }, { 0, -1 }, { 0, 0 }, { 0, -1 }, { 0, 1 } };
         static const fheroes2::Point offsetShipBottomSideways[heroFrameCount]
-            = { { 0, -2 }, { 0, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 },  { 0, 0 }, { 0, 0 }, { 0, 0 } };
+            = { { 0, -2 }, { 0, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 } };
 
         switch ( hero.GetDirection() ) {
         case Direction::TOP:

--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2021                                                    *
+ *   Copyright (C) 2021 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -67,7 +67,7 @@ namespace
         const int x = centerInPixel.x - pixelsW / 2;
         const int y = centerInPixel.y - pixelsH / 2;
 
-        return fheroes2::Rect( x, y, pixelsW, pixelsH );
+        return { x, y, pixelsW, pixelsH };
     }
 
     ViewWorld::ZoomLevel GetNextZoomLevel( const ViewWorld::ZoomLevel level, const bool cycle )

--- a/src/fheroes2/monster/monster.cpp
+++ b/src/fheroes2/monster/monster.cpp
@@ -131,26 +131,6 @@ Monster::Monster( int race, u32 dw )
     id = FromDwelling( race, dw ).id;
 }
 
-bool Monster::isValid( void ) const
-{
-    return id != UNKNOWN;
-}
-
-bool Monster::operator==( const Monster & m ) const
-{
-    return id == m.id;
-}
-
-bool Monster::operator!=( const Monster & m ) const
-{
-    return id != m.id;
-}
-
-void Monster::Upgrade( void )
-{
-    id = GetUpgrade().id;
-}
-
 u32 Monster::GetAttack() const
 {
     return fheroes2::getMonsterData( id ).battleStats.attack;
@@ -181,34 +161,9 @@ int Monster::GetRace() const
     return fheroes2::getMonsterData( id ).generalStats.race;
 }
 
-u32 Monster::GetDamageMin() const
-{
-    return fheroes2::getMonsterData( id ).battleStats.damageMin;
-}
-
-u32 Monster::GetDamageMax() const
-{
-    return fheroes2::getMonsterData( id ).battleStats.damageMax;
-}
-
 uint32_t Monster::GetShots() const
 {
     return fheroes2::getMonsterData( id ).battleStats.shots;
-}
-
-u32 Monster::GetHitPoints() const
-{
-    return fheroes2::getMonsterData( id ).battleStats.hp;
-}
-
-u32 Monster::GetSpeed() const
-{
-    return fheroes2::getMonsterData( id ).battleStats.speed;
-}
-
-u32 Monster::GetGrown() const
-{
-    return fheroes2::getMonsterData( id ).generalStats.baseGrowth;
 }
 
 // Get universal heuristic of Monster type regardless of context; both combat and strategic value
@@ -371,76 +326,11 @@ u32 Monster::GetRNDSize( bool skip_factor ) const
     return ( result > 1 ) ? Rand::Get( result / 2, result ) : 1;
 }
 
-bool Monster::isElemental() const
-{
-    return isAbilityPresent( fheroes2::MonsterAbilityType::ELEMENTAL );
-}
-
-bool Monster::isUndead() const
-{
-    return isAbilityPresent( fheroes2::MonsterAbilityType::UNDEAD );
-}
-
 bool Monster::isAbilityPresent( const fheroes2::MonsterAbilityType abilityType ) const
 {
     const std::vector<fheroes2::MonsterAbility> & abilities = fheroes2::getMonsterData( id ).battleStats.abilities;
 
     return std::find( abilities.begin(), abilities.end(), fheroes2::MonsterAbility( abilityType ) ) != abilities.end();
-}
-
-bool Monster::isFlying() const
-{
-    return isAbilityPresent( fheroes2::MonsterAbilityType::FLYING );
-}
-
-bool Monster::isWide() const
-{
-    return isAbilityPresent( fheroes2::MonsterAbilityType::DOUBLE_HEX_SIZE );
-}
-
-bool Monster::isArchers() const
-{
-    return GetShots() > 0;
-}
-
-bool Monster::isAllowUpgrade() const
-{
-    return id != GetUpgrade().id;
-}
-
-bool Monster::ignoreRetaliation() const
-{
-    return isAbilityPresent( fheroes2::MonsterAbilityType::NO_ENEMY_RETALIATION );
-}
-
-bool Monster::isDragons() const
-{
-    return isAbilityPresent( fheroes2::MonsterAbilityType::DRAGON );
-}
-
-bool Monster::isDoubleAttack() const
-{
-    return isAbilityPresent( fheroes2::MonsterAbilityType::DOUBLE_MELEE_ATTACK ) || isAbilityPresent( fheroes2::MonsterAbilityType::DOUBLE_SHOOTING );
-}
-
-bool Monster::isRegenerating() const
-{
-    return isAbilityPresent( fheroes2::MonsterAbilityType::HP_REGENERATION );
-}
-
-bool Monster::isDoubleCellAttack() const
-{
-    return isAbilityPresent( fheroes2::MonsterAbilityType::TWO_CELL_MELEE_ATTACK );
-}
-
-bool Monster::isAllAdjacentCellsAttack() const
-{
-    return isAbilityPresent( fheroes2::MonsterAbilityType::ALL_ADJACENT_CELL_MELEE_ATTACK );
-}
-
-bool Monster::isAffectedByMorale() const
-{
-    return !( isUndead() || isElemental() );
 }
 
 Monster Monster::GetDowngrade() const
@@ -802,11 +692,6 @@ Monster Monster::Rand( const LevelType type )
     return Rand::Get( monstersVec[static_cast<int>( type ) - 1] );
 }
 
-int Monster::GetMonsterLevel() const
-{
-    return fheroes2::getMonsterData( id ).generalStats.level;
-}
-
 Monster::LevelType Monster::GetRandomUnitLevel() const
 {
     switch ( id ) {
@@ -1015,19 +900,9 @@ const char * Monster::GetPluralName( u32 count ) const
     return count == 1 ? _( generalStats.name ) : _( generalStats.pluralName );
 }
 
-u32 Monster::GetSpriteIndex( void ) const
-{
-    return UNKNOWN < id ? id - 1 : 0;
-}
-
-int Monster::ICNMonh( void ) const
+int Monster::ICNMonh() const
 {
     return id >= PEASANT && id <= WATER_ELEMENT ? ICN::MONH0000 + id - PEASANT : ICN::UNKNOWN;
-}
-
-payment_t Monster::GetCost() const
-{
-    return payment_t( fheroes2::getMonsterData( id ).generalStats.cost );
 }
 
 payment_t Monster::GetUpgradeCost() const
@@ -1047,9 +922,4 @@ u32 Monster::GetCountFromHitPoints( const Monster & mons, u32 hp )
     }
 
     return 0;
-}
-
-int Monster::GetMonsterSprite() const
-{
-    return fheroes2::getMonsterData( id ).icnId;
 }

--- a/src/fheroes2/monster/monster.h
+++ b/src/fheroes2/monster/monster.h
@@ -136,15 +136,26 @@ public:
     Monster( int race, u32 dw );
     virtual ~Monster() = default;
 
-    bool operator==( const Monster & ) const;
-    bool operator!=( const Monster & ) const;
+    bool operator==( const Monster & m ) const
+    {
+        return id == m.id;
+    }
+
+    bool operator!=( const Monster & m ) const
+    {
+        return id != m.id;
+    }
 
     int GetID( void ) const
     {
         return id;
     }
 
-    void Upgrade( void );
+    void Upgrade()
+    {
+        id = GetUpgrade().id;
+    }
+
     Monster GetUpgrade( void ) const;
     Monster GetDowngrade( void ) const;
 
@@ -155,13 +166,38 @@ public:
     virtual int GetLuck( void ) const;
     virtual int GetRace( void ) const;
 
-    u32 GetDamageMin( void ) const;
-    u32 GetDamageMax( void ) const;
+    uint32_t GetDamageMin() const
+    {
+        return fheroes2::getMonsterData( id ).battleStats.damageMin;
+    }
+
+    uint32_t GetDamageMax() const
+    {
+        return fheroes2::getMonsterData( id ).battleStats.damageMax;
+    }
+
     virtual uint32_t GetShots() const;
-    u32 GetHitPoints( void ) const;
-    u32 GetSpeed( void ) const;
-    u32 GetGrown( void ) const;
-    int GetMonsterLevel() const;
+
+    uint32_t GetHitPoints() const
+    {
+        return fheroes2::getMonsterData( id ).battleStats.hp;
+    }
+
+    uint32_t GetSpeed() const
+    {
+        return fheroes2::getMonsterData( id ).battleStats.speed;
+    }
+
+    uint32_t GetGrown() const
+    {
+        return fheroes2::getMonsterData( id ).generalStats.baseGrowth;
+    }
+
+    int GetMonsterLevel() const
+    {
+        return fheroes2::getMonsterData( id ).generalStats.level;
+    }
+
     LevelType GetRandomUnitLevel() const;
     u32 GetRNDSize( bool skip ) const;
 
@@ -169,32 +205,100 @@ public:
     const char * GetMultiName( void ) const;
     const char * GetPluralName( u32 ) const;
 
-    bool isValid( void ) const;
-    bool isElemental( void ) const;
-    bool isUndead( void ) const;
-    bool isFlying( void ) const;
-    bool isWide( void ) const;
-    bool isArchers( void ) const;
-    bool isAllowUpgrade( void ) const;
-    bool isDoubleAttack() const;
-    bool isRegenerating( void ) const;
-    bool isDoubleCellAttack( void ) const;
-    bool isAllAdjacentCellsAttack() const;
-    bool ignoreRetaliation( void ) const;
-    bool isDragons( void ) const;
-    bool isAffectedByMorale( void ) const;
+    bool isValid() const
+    {
+        return id != UNKNOWN;
+    }
+
+    bool isElemental() const
+    {
+        return isAbilityPresent( fheroes2::MonsterAbilityType::ELEMENTAL );
+    }
+
+    bool isUndead() const
+    {
+        return isAbilityPresent( fheroes2::MonsterAbilityType::UNDEAD );
+    }
+
+    bool isFlying() const
+    {
+        return isAbilityPresent( fheroes2::MonsterAbilityType::FLYING );
+    }
+
+    bool isWide() const
+    {
+        return isAbilityPresent( fheroes2::MonsterAbilityType::DOUBLE_HEX_SIZE );
+    }
+
+    bool isArchers() const
+    {
+        return GetShots() > 0;
+    }
+
+    bool isAllowUpgrade() const
+    {
+        return id != GetUpgrade().id;
+    }
+
+    bool isDoubleAttack() const
+    {
+        return isAbilityPresent( fheroes2::MonsterAbilityType::DOUBLE_MELEE_ATTACK ) || isAbilityPresent( fheroes2::MonsterAbilityType::DOUBLE_SHOOTING );
+    }
+
+    bool isRegenerating() const
+    {
+        return isAbilityPresent( fheroes2::MonsterAbilityType::HP_REGENERATION );
+    }
+
+    bool isDoubleCellAttack() const
+    {
+        return isAbilityPresent( fheroes2::MonsterAbilityType::TWO_CELL_MELEE_ATTACK );
+    }
+
+    bool isAllAdjacentCellsAttack() const
+    {
+        return isAbilityPresent( fheroes2::MonsterAbilityType::ALL_ADJACENT_CELL_MELEE_ATTACK );
+    }
+
+    bool ignoreRetaliation() const
+    {
+        return isAbilityPresent( fheroes2::MonsterAbilityType::NO_ENEMY_RETALIATION );
+    }
+
+    bool isDragons() const
+    {
+        return isAbilityPresent( fheroes2::MonsterAbilityType::DRAGON );
+    }
+
+    bool isAffectedByMorale() const
+    {
+        // TODO: possible optimization: run through all abilities once.
+        return !( isUndead() || isElemental() );
+    }
 
     bool isAbilityPresent( const fheroes2::MonsterAbilityType abilityType ) const;
 
     double GetMonsterStrength( int attack = -1, int defense = -1 ) const;
-    int ICNMonh( void ) const;
 
-    u32 GetSpriteIndex( void ) const;
-    payment_t GetCost() const;
+    int ICNMonh() const;
+
+    uint32_t GetSpriteIndex() const
+    {
+        return UNKNOWN < id ? id - 1 : 0;
+    }
+
+    payment_t GetCost() const
+    {
+        return payment_t( fheroes2::getMonsterData( id ).generalStats.cost );
+    }
+
     payment_t GetUpgradeCost() const;
     u32 GetDwelling( void ) const;
 
-    int GetMonsterSprite() const;
+    int GetMonsterSprite() const
+    {
+        return fheroes2::getMonsterData( id ).icnId;
+    }
 
     static Monster Rand( const LevelType type );
 


### PR DESCRIPTION
- do not use `std::div( dy, 2 ).quot;`. It is over-engineering. A simple division operation works perfectly fine
- cache `image()` method result for rendering code as it is not an inlined method
- inline many one line methods
- slightly speed up `StringTrim` method to avoid string resizing in case of all spaces string
- use `emplace_back` where it is useful