### PR TITLE
Fix versioning of MSVC builds

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -54,7 +54,6 @@ jobs:
     - name: Generate version information
       run: |
         echo "FHEROES2_APP_VERSION=$(cat version.txt)" >> "$GITHUB_ENV"
-        echo "FHEROES2_BUILD_NUMBER=$((GITHUB_RUN_ID % 32768))" >> "$GITHUB_ENV"
     - name: Build
       run: |
         MSBuild.exe fheroes2-vs2019.vcxproj /property:Platform=${{ matrix.config.platform }} /property:Configuration=${{ matrix.config.build_config }}

--- a/script/windows/fheroes2.iss
+++ b/script/windows/fheroes2.iss
@@ -20,7 +20,7 @@ ArchitecturesInstallIn64BitMode=x64
 #endif
 
 [Files]
-Source: "{#BuildDir}\{#AppName}.exe"; DestDir: "{app}"
+Source: "{#BuildDir}\{#AppName}.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#BuildDir}\lib*.dll"; DestDir: "{app}"
 Source: "{#BuildDir}\SDL*.dll"; DestDir: "{app}"
 Source: "..\..\docs\README.txt"; DestDir: "{app}"

--- a/script/windows/fheroes2.iss
+++ b/script/windows/fheroes2.iss
@@ -11,7 +11,7 @@ AppUpdatesURL="https://github.com/ihhub/fheroes2/releases"
 AppSupportURL="https://discord.gg/xF85vbZ"
 LicenseFile=..\..\LICENSE
 OutputBaseFilename={#AppName}_windows_{#Platform}_{#DeployConfName}_installer
-DefaultDirName={pf}\{#AppName}
+DefaultDirName={autopf}\{#AppName}
 DefaultGroupName={#AppName}
 UninstallDisplayIcon={app}\{#AppName}.exe
 OutputDir={#BuildDir}
@@ -43,7 +43,7 @@ Name: "{group}\Download demo version files"; Filename: "{app}\download_demo_vers
 Name: "{group}\Extract game resources from the original HoMM2 distribution"; Filename: "{app}\extract_homm2_resources.bat"; WorkingDir: "{app}"
 Name: "{group}\Game data files"; Filename: %WINDIR%\explorer.exe; Parameters: """%APPDATA%\{#AppName}"""
 Name: "{group}\Uninstall"; Filename: "{uninstallexe}"
-Name: "{commondesktop}\Free Heroes of Might & Magic II"; Filename: "{app}\{#AppName}.exe"; WorkingDir: "{app}"; Tasks: desktopicon
+Name: "{autodesktop}\Free Heroes of Might & Magic II"; Filename: "{app}\{#AppName}.exe"; WorkingDir: "{app}"; Tasks: desktopicon
 
 [Run]
 Filename: "{app}\extract_homm2_resources.bat"; Flags: runascurrentuser; Check: UseResourcesFromOriginalGame


### PR DESCRIPTION
Follow-up to #5231

Unfortunately replacing `GITHUB_RUN_NUMBER` with the `GITHUB_RUN_ID` did not bring the desired results, because, although `GITHUB_RUN_ID` is workflow-independent, it seems that there is no requirement for it to increase monotonically, so it is not suitable as the build number. I removed generation of the `FHEROES2_BUILD_NUMBER` from the MSVC workflow for a while and used the `ignoreversion` [flag](https://jrsoftware.org/ishelp/index.php?topic=filessection) in the Inno Setup instead. May be in future I'll come up with a better solution.