### PR TITLE
Reset the mixer volume before playing video soundtracks

### DIFF
--- a/src/fheroes2/game/game_video.cpp
+++ b/src/fheroes2/game/game_video.cpp
@@ -44,6 +44,8 @@ namespace
 
     void playAudio( const std::vector<std::vector<uint8_t>> & audioChannels )
     {
+        Mixer::Volume( -1, Mixer::MaxVolume() * Settings::Get().SoundVolume() / 10 );
+
         for ( const std::vector<uint8_t> & audio : audioChannels ) {
             if ( !audio.empty() ) {
                 Mixer::Play( &audio[0], static_cast<uint32_t>( audio.size() ) );


### PR DESCRIPTION
fix #5282

Mixer is usually used to play ambient sounds, which may have different volume depending on the distance. We should reset the volume of mixer channels to the default one before playing video soundtracks.