### PR TITLE
Improve search for video files

### DIFF
--- a/src/fheroes2/agg/agg.cpp
+++ b/src/fheroes2/agg/agg.cpp
@@ -86,10 +86,11 @@ namespace
             std::string correctFilePath = System::ConcatePath( dir, fileName );
             correctFilePath = StringLower( correctFilePath );
 
-            for ( const std::string & path : musicFilePaths ) {
+            for ( std::string & path : musicFilePaths ) {
                 const std::string temp = StringLower( path );
                 if ( temp == correctFilePath ) {
-                    fullPath = path;
+                    // Avoid string copy.
+                    std::swap( fullPath, path );
                     return true;
                 }
             }

--- a/src/fheroes2/game/game_video.cpp
+++ b/src/fheroes2/game/game_video.cpp
@@ -61,23 +61,18 @@ namespace Video
                 if ( System::IsDirectory( fullDirPath ) ) {
                     ListFiles videoFiles;
                     videoFiles.FindFileInDir( fullDirPath, fileName, false );
-
-                    std::string targetFileName = System::ConcatePath( fullDirPath, fileName );
-                    targetFileName = StringLower( targetFileName );
-
-                    for ( std::string & filePath : videoFiles ) {
-                        if ( StringLower( filePath ) == targetFileName ) {
-                            // Avoid string copy.
-                            std::swap( path, filePath );
-
-                            if ( dirIdx > 0 ) {
-                                // Put the current directory at the first place to increase cache hit chance.
-                                std::swap( videoDir[0], videoDir[dirIdx] );
-                            }
-
-                            return true;
-                        }
+                    if ( videoFiles.empty() ) {
+                        continue;
                     }
+
+                    std::swap( videoFiles.front(), path );
+
+                    if ( dirIdx > 0 ) {
+                        // Put the current directory at the first place to increase cache hit chance.
+                        std::swap( videoDir[0], videoDir[dirIdx] );
+                    }
+
+                    return true;
                 }
             }
         }

--- a/src/fheroes2/game/game_video.cpp
+++ b/src/fheroes2/game/game_video.cpp
@@ -65,9 +65,10 @@ namespace Video
                     std::string targetFileName = System::ConcatePath( fullDirPath, fileName );
                     targetFileName = StringLower( targetFileName );
 
-                    for ( const std::string & filePath : videoFiles ) {
+                    for ( std::string & filePath : videoFiles ) {
                         if ( StringLower( filePath ) == targetFileName ) {
-                            path = filePath;
+                            // Avoid string copy.
+                            std::swap( path, filePath );
 
                             if ( dirIdx > 0 ) {
                                 // Put the current directory at the first place to increase cache hit chance.

--- a/src/fheroes2/game/game_video.cpp
+++ b/src/fheroes2/game/game_video.cpp
@@ -31,10 +31,12 @@
 #include "tools.h"
 #include "ui_tool.h"
 
+#include <array>
+
 namespace
 {
     // Anim2 directory is used in Russian Buka version of the game.
-    const std::vector<std::string> videoDir = { "anim", "anim2", System::ConcatePath( "heroes2", "anim" ), "data" };
+    std::array<std::string, 4> videoDir = { "anim", "anim2", System::ConcatePath( "heroes2", "anim" ), "data" };
 
     void playAudio( const std::vector<std::vector<uint8_t>> & audioChannels )
     {
@@ -53,8 +55,8 @@ namespace Video
     bool getVideoFilePath( const std::string & fileName, std::string & path )
     {
         for ( const std::string & rootDir : Settings::GetRootDirs() ) {
-            for ( const std::string & localDir : videoDir ) {
-                const std::string fullDirPath = System::ConcatePath( rootDir, localDir );
+            for ( size_t dirIdx = 0; dirIdx < videoDir.size(); ++dirIdx ) {
+                const std::string fullDirPath = System::ConcatePath( rootDir, videoDir[dirIdx] );
 
                 if ( System::IsDirectory( fullDirPath ) ) {
                     ListFiles videoFiles;
@@ -66,6 +68,12 @@ namespace Video
                     for ( const std::string & filePath : videoFiles ) {
                         if ( StringLower( filePath ) == targetFileName ) {
                             path = filePath;
+
+                            if ( dirIdx > 0 ) {
+                                // Put the current directory at the first place to increase cache hit chance.
+                                std::swap( videoDir[0], videoDir[dirIdx] );
+                            }
+
                             return true;
                         }
                     }


### PR DESCRIPTION
The same technique as for music files: we put directory where we find a current video file at the first place so for the subsequent runs we will search there.
Also avoid copying of strings where it is not necessary.