### PR TITLE
Fix spacing of player squares in Select Recipients window and horiz. center resource icons for "Your Funds" and "Planned Gift"

### DIFF
--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -34,6 +34,11 @@
 #include "ui_window.h"
 #include "world.h"
 
+namespace
+{
+    const fheroes2::Size giftDialogSize( 320, 234 );
+}
+
 int32_t GetIndexClickRects( const std::vector<fheroes2::Rect> & rects )
 {
     LocalEvent & le = LocalEvent::Get();
@@ -64,16 +69,17 @@ struct SelectRecipientsColors
         , recipients( 0 )
     {
         positions.reserve( colors.size() );
-        const fheroes2::StandardWindow frameborder( 320, 234 );
-        const fheroes2::Rect box( frameborder.activeArea() );
+        const fheroes2::Display & display = fheroes2::Display::instance();
+        const fheroes2::Rect box( ( display.width() - giftDialogSize.width ) / 2, ( display.height() - giftDialogSize.height ) / 2, giftDialogSize.width,
+                                  giftDialogSize.height );
 
         const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::CELLWIN, 43 );
         const int32_t colorCount = static_cast<int32_t>( colors.size() ); // safe to cast as the number of players <= 8.
-        int32_t playerContainerWidth = colorCount * sprite.width() + ( colorCount - 1 ) * 22; // original spacing = 22
-        int32_t startx = box.x + 160 - playerContainerWidth / 2; // fixed half width of brown box = 160
+        const int32_t playerContainerWidth = colorCount * sprite.width() + ( colorCount - 1 ) * 22; // original spacing = 22
+        const int32_t startX = box.x + ( giftDialogSize.width - playerContainerWidth ) / 2;
         for ( int32_t i = 0; i < colorCount; ++i ) {
-            int32_t posx = startx + i * ( 22 + sprite.width() );
-            positions.emplace_back( posx, pos.y, sprite.width(), sprite.height() );
+            const int32_t posX = startX + i * ( 22 + sprite.width() );
+            positions.emplace_back( posX, pos.y, sprite.width(), sprite.height() );
         }
     }
 
@@ -88,6 +94,7 @@ struct SelectRecipientsColors
 
         for ( Colors::const_iterator it = colors.begin(); it != colors.end(); ++it ) {
             const fheroes2::Rect & pos = positions[std::distance( colors.begin(), it )];
+
             fheroes2::Blit( fheroes2::AGG::GetICN( ICN::CELLWIN, 43 + Color::GetIndex( *it ) ), display, pos.x, pos.y );
             if ( recipients & *it )
                 fheroes2::Blit( fheroes2::AGG::GetICN( ICN::CELLWIN, 2 ), display, pos.x + 2, pos.y + 2 );
@@ -138,7 +145,7 @@ struct ResourceBar
         fheroes2::Display & display = fheroes2::Display::instance();
         fheroes2::Text text( std::to_string( count ), fheroes2::FontType::smallWhite() );
         const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::TRADPOST, 7 + Resource::getIconIcnIndex( type ) );
-        fheroes2::Blit( sprite, fheroes2::Display::instance(), posx, posy );
+        fheroes2::Blit( sprite, display, posx, posy );
         text.draw( posx + ( sprite.width() - text.width() ) / 2, posy + sprite.height() - 10, display );
     }
 
@@ -217,7 +224,7 @@ void Dialog::MakeGiftResource( Kingdom & kingdom )
     Funds funds2;
 
     const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::TRADPOST, 7 );
-    int32_t posx = box.x + 160 - ( sprite.width() + 240 ) / 2; // 160 = half width of brown box, fixed
+    const int32_t posX = box.x + ( giftDialogSize.width - ( sprite.width() + 240 ) ) / 2;
 
     const fheroes2::FontType normalWhite = fheroes2::FontType::normalWhite();
     fheroes2::Text text( _( "Select Recipients" ), normalWhite );
@@ -227,13 +234,14 @@ void Dialog::MakeGiftResource( Kingdom & kingdom )
 
     text.set( _( "Your Funds" ), normalWhite );
     text.draw( box.x + ( box.width - text.width() ) / 2, box.y + 57, display );
-    ResourceBar info1( funds1, posx, box.y + 80 );
+    ResourceBar info1( funds1, posX, box.y + 80 );
     info1.Redraw();
 
     text.set( _( "Planned Gift" ), normalWhite );
     text.draw( box.x + ( box.width - text.width() ) / 2, box.y + 127, display );
-    ResourceBar info2( funds2, posx, box.y + 150 );
+    ResourceBar info2( funds2, posX, box.y + 150 );
     info2.Redraw();
+
     const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
     const int okIcnId = isEvilInterface ? ICN::NON_UNIFORM_EVIL_OKAY_BUTTON : ICN::NON_UNIFORM_GOOD_OKAY_BUTTON;
     const int cancelIcnId = isEvilInterface ? ICN::NON_UNIFORM_EVIL_CANCEL_BUTTON : ICN::NON_UNIFORM_GOOD_CANCEL_BUTTON;

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -138,7 +138,6 @@ struct ResourceBar
         fheroes2::Text text( std::to_string( count ), fheroes2::FontType::smallWhite() );
         const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::TRADPOST, 7 + Resource::getIconIcnIndex( type ) );
         fheroes2::Blit( sprite, fheroes2::Display::instance(), posx, posy );
-        // -12 -> -10 for +2 offset using new Text from ui_text.h and others 
         text.draw( posx + ( sprite.width() - text.width() ) / 2, posy + sprite.height() - 10, display );
     }
 
@@ -217,7 +216,7 @@ void Dialog::MakeGiftResource( Kingdom & kingdom )
     Funds funds2;
     fheroes2::Text text;
     const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::TRADPOST, 7 );
-    int32_t posx = ( 320 -  (sprite.width() + 240 ) ) / 2;
+    int32_t posx = ( 320 -  ( sprite.width() + 240 ) ) / 2;
     const fheroes2::FontType normalWhite = fheroes2::FontType::normalWhite();
 
     text.set( _( "Select Recipients" ), normalWhite );

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -30,6 +30,7 @@
 #include "text.h"
 #include "tools.h"
 #include "translations.h"
+#include "ui_text.h"
 #include "ui_window.h"
 #include "world.h"
 
@@ -133,10 +134,12 @@ struct ResourceBar
 
     static void RedrawResource( int type, s32 count, s32 posx, s32 posy )
     {
-        Text text( std::to_string( count ), Font::SMALL );
+        fheroes2::Display & display = fheroes2::Display::instance();
+        fheroes2::Text text( std::to_string( count ), fheroes2::FontType::smallWhite() );
         const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::TRADPOST, 7 + Resource::getIconIcnIndex( type ) );
         fheroes2::Blit( sprite, fheroes2::Display::instance(), posx, posy );
-        text.Blit( posx + ( sprite.width() - text.w() ) / 2, posy + sprite.height() - 12 );
+        // -12 -> -10 for +2 offset using new Text from ui_text.h and others 
+        text.draw( posx + ( sprite.width() - text.width() ) / 2, posy + sprite.height() - 10, display );
     }
 
     void Redraw( const Funds * res = nullptr ) const
@@ -212,23 +215,24 @@ void Dialog::MakeGiftResource( Kingdom & kingdom )
 
     Funds funds1( kingdom.GetFunds() );
     Funds funds2;
-    Text text;
+    fheroes2::Text text;
+    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::TRADPOST, 7 );
+    int32_t posx = ( 320 -  (sprite.width() + 240 ) ) / 2;
 
-    text.Set( _( "Select Recipients" ) );
-    text.Blit( box.x + ( box.width - text.w() ) / 2, box.y + 5 );
+    text.set( _( "Select Recipients" ), fheroes2::FontType::normalWhite() );
+    text.draw( box.x + ( box.width - text.width() ) / 2, box.y + 7, display );
 
     SelectRecipientsColors selector( fheroes2::Point( box.x + 65, box.y + 28 ), kingdom.GetColor() );
     selector.Redraw();
 
-    text.Set( _( "Your Funds" ) );
-    text.Blit( box.x + ( box.width - text.w() ) / 2, box.y + 55 );
-    ResourceBar info1( funds1, box.x + 25, box.y + 80 );
+    text.set( _( "Your Funds" ), fheroes2::FontType::normalWhite() );
+    text.draw( box.x + ( box.width - text.width() ) / 2, box.y + 57, display );
+    ResourceBar info1( funds1, box.x + posx, box.y + 80 );
     info1.Redraw();
 
-    text.Set( _( "Planned Gift" ) );
-    text.Blit( box.x + ( box.width - text.w() ) / 2, box.y + 125 );
-
-    ResourceBar info2( funds2, box.x + 25, box.y + 150 );
+    text.set( _( "Planned Gift" ), fheroes2::FontType::normalWhite() );
+    text.draw( box.x + ( box.width - text.width() ) / 2, box.y + 127, display );
+    ResourceBar info2( funds2, box.x + posx, box.y + 150 );
     info2.Redraw();
 
     const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -67,8 +67,8 @@ struct SelectRecipientsColors
 
         const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::CELLWIN, 43 );
         const int32_t colorCount = static_cast<int32_t>( colors.size() ); // safe to cast as the number of players <= 8.
-        int32_t playerCtnrWidth = 2 * sprite.width() + ( colorCount - 1 ) * 22; // original spacing = 22
-        int32_t startx = 320 - playerCtnrWidth / 2;
+        int32_t playerContainerWidth = colorCount * sprite.width() + ( colorCount - 1 ) * 22; // original spacing = 22
+        int32_t startx = 320 - playerContainerWidth / 2;
 
         for ( int32_t i = 0; i < colorCount; ++i ) {
             int32_t posx = startx + i * ( 22 + sprite.width() );
@@ -214,12 +214,12 @@ void Dialog::MakeGiftResource( Kingdom & kingdom )
 
     Funds funds1( kingdom.GetFunds() );
     Funds funds2;
-    fheroes2::Text text;
+
     const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::TRADPOST, 7 );
     int32_t posx = ( 320 - ( sprite.width() + 240 ) ) / 2;
-    const fheroes2::FontType normalWhite = fheroes2::FontType::normalWhite();
 
-    text.set( _( "Select Recipients" ), normalWhite );
+    const fheroes2::FontType normalWhite = fheroes2::FontType::normalWhite();
+    fheroes2::Text text( _( "Select Recipients" ), normalWhite );
     text.draw( box.x + ( box.width - text.width() ) / 2, box.y + 7, display );
 
     SelectRecipientsColors selector( fheroes2::Point( box.x + 65, box.y + 28 ), kingdom.GetColor() );
@@ -230,7 +230,7 @@ void Dialog::MakeGiftResource( Kingdom & kingdom )
     ResourceBar info1( funds1, box.x + posx, box.y + 80 );
     info1.Redraw();
 
-    text.set( _( "Planned Gift" ), fheroes2::FontType::normalWhite() );
+    text.set( _( "Planned Gift" ), normalWhite );
     text.draw( box.x + ( box.width - text.width() ) / 2, box.y + 127, display );
     ResourceBar info2( funds2, box.x + posx, box.y + 150 );
     info2.Redraw();

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -27,9 +27,9 @@
 #include "game.h"
 #include "icn.h"
 #include "settings.h"
-#include "text.h"
 #include "tools.h"
 #include "translations.h"
+#include "ui_dialog.h"
 #include "ui_text.h"
 #include "ui_window.h"
 #include "world.h"
@@ -176,14 +176,13 @@ struct ResourceBar
             u32 cur = resource.Get( rs );
             u32 sel = cur;
             u32 max = mul > 1 ? ( funds.Get( rs ) + resource.Get( rs ) ) / mul : funds.Get( rs ) + resource.Get( rs );
-
             if ( 0 == mul ) {
-                Dialog::Message( "", _( "First select recipients!" ), Font::BIG, Dialog::OK );
+                fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( _( "First select recipients!" ), fheroes2::FontType::normalWhite() ), Dialog::OK );
             }
             else if ( 0 == max ) {
                 std::string msg = _( "You cannot select %{resource}!" );
                 StringReplace( msg, "%{resource}", Resource::String( rs ) );
-                Dialog::Message( "", msg, Font::BIG, Dialog::OK );
+                fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK );
             }
             else {
                 std::string msg = _( "Select count %{resource}:" );

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -33,6 +33,7 @@
 #include "ui_text.h"
 #include "ui_window.h"
 #include "world.h"
+#include<iostream>
 
 int32_t GetIndexClickRects( const std::vector<fheroes2::Rect> & rects )
 {
@@ -64,11 +65,13 @@ struct SelectRecipientsColors
         , recipients( 0 )
     {
         positions.reserve( colors.size() );
-
+        const fheroes2::StandardWindow frameborder( 320, 234 );
+        const fheroes2::Rect box( frameborder.activeArea() );
+        
         const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::CELLWIN, 43 );
         const int32_t colorCount = static_cast<int32_t>( colors.size() ); // safe to cast as the number of players <= 8.
         int32_t playerContainerWidth = colorCount * sprite.width() + ( colorCount - 1 ) * 22; // original spacing = 22
-        int32_t startx = 320 - playerContainerWidth / 2;
+        int32_t startx = box.x + 160 - playerContainerWidth / 2; // 160 = half, fixed width of brown box 
 
         for ( int32_t i = 0; i < colorCount; ++i ) {
             int32_t posx = startx + i * ( 22 + sprite.width() );
@@ -216,25 +219,23 @@ void Dialog::MakeGiftResource( Kingdom & kingdom )
     Funds funds2;
 
     const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::TRADPOST, 7 );
-    int32_t posx = ( 320 - ( sprite.width() + 240 ) ) / 2;
+    int32_t posx = box.x + 160 - ( sprite.width() + 240 ) / 2; // 160 = half width of brown box, fixed
 
     const fheroes2::FontType normalWhite = fheroes2::FontType::normalWhite();
     fheroes2::Text text( _( "Select Recipients" ), normalWhite );
     text.draw( box.x + ( box.width - text.width() ) / 2, box.y + 7, display );
-
     SelectRecipientsColors selector( fheroes2::Point( box.x + 65, box.y + 28 ), kingdom.GetColor() );
     selector.Redraw();
 
     text.set( _( "Your Funds" ), normalWhite );
     text.draw( box.x + ( box.width - text.width() ) / 2, box.y + 57, display );
-    ResourceBar info1( funds1, box.x + posx, box.y + 80 );
+    ResourceBar info1( funds1, posx, box.y + 80 );
     info1.Redraw();
 
     text.set( _( "Planned Gift" ), normalWhite );
     text.draw( box.x + ( box.width - text.width() ) / 2, box.y + 127, display );
-    ResourceBar info2( funds2, box.x + posx, box.y + 150 );
+    ResourceBar info2( funds2, posx, box.y + 150 );
     info2.Redraw();
-
     const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
     const int okIcnId = isEvilInterface ? ICN::NON_UNIFORM_EVIL_OKAY_BUTTON : ICN::NON_UNIFORM_GOOD_OKAY_BUTTON;
     const int cancelIcnId = isEvilInterface ? ICN::NON_UNIFORM_EVIL_CANCEL_BUTTON : ICN::NON_UNIFORM_GOOD_CANCEL_BUTTON;

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -65,14 +65,14 @@ struct SelectRecipientsColors
     {
         positions.reserve( colors.size() );
 
+        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::CELLWIN, 43 );
         const int32_t colorCount = static_cast<int32_t>( colors.size() ); // safe to cast as the number of players <= 8.
+        int32_t playerCtnrWidth = 2 * sprite.width() + ( colorCount - 1 ) * 22; // original spacing = 22
+        int32_t startx = 320 - playerCtnrWidth / 2;
 
         for ( int32_t i = 0; i < colorCount; ++i ) {
-            const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::CELLWIN, 43 );
-            int32_t temp = i * ( sprite.width() + 15 ) * 6 / colorCount;
-            int32_t ceilCalc = temp + ( ( ( i * ( sprite.width() + 15 ) * 6 ) % colorCount ) > 0 );
-            int32_t posx = ceilCalc + ( ( sprite.width() + 15 ) / ( 2 * colorCount ) );
-            positions.emplace_back( pos.x + posx, pos.y, sprite.width(), sprite.height() );
+            int32_t posx = startx + i * ( 22 + sprite.width() );
+            positions.emplace_back( posx, pos.y, sprite.width(), sprite.height() );
         }
     }
 
@@ -218,14 +218,15 @@ void Dialog::MakeGiftResource( Kingdom & kingdom )
     fheroes2::Text text;
     const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::TRADPOST, 7 );
     int32_t posx = ( 320 -  (sprite.width() + 240 ) ) / 2;
+    const fheroes2::FontType normalWhite = fheroes2::FontType::normalWhite();
 
-    text.set( _( "Select Recipients" ), fheroes2::FontType::normalWhite() );
+    text.set( _( "Select Recipients" ), normalWhite );
     text.draw( box.x + ( box.width - text.width() ) / 2, box.y + 7, display );
 
     SelectRecipientsColors selector( fheroes2::Point( box.x + 65, box.y + 28 ), kingdom.GetColor() );
     selector.Redraw();
 
-    text.set( _( "Your Funds" ), fheroes2::FontType::normalWhite() );
+    text.set( _( "Your Funds" ), normalWhite );
     text.draw( box.x + ( box.width - text.width() ) / 2, box.y + 57, display );
     ResourceBar info1( funds1, box.x + posx, box.y + 80 );
     info1.Redraw();

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -33,7 +33,6 @@
 #include "ui_text.h"
 #include "ui_window.h"
 #include "world.h"
-#include<iostream>
 
 int32_t GetIndexClickRects( const std::vector<fheroes2::Rect> & rects )
 {
@@ -67,12 +66,11 @@ struct SelectRecipientsColors
         positions.reserve( colors.size() );
         const fheroes2::StandardWindow frameborder( 320, 234 );
         const fheroes2::Rect box( frameborder.activeArea() );
-        
+
         const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::CELLWIN, 43 );
         const int32_t colorCount = static_cast<int32_t>( colors.size() ); // safe to cast as the number of players <= 8.
         int32_t playerContainerWidth = colorCount * sprite.width() + ( colorCount - 1 ) * 22; // original spacing = 22
-        int32_t startx = box.x + 160 - playerContainerWidth / 2; // 160 = half, fixed width of brown box 
-
+        int32_t startx = box.x + 160 - playerContainerWidth / 2; // fixed half width of brown box = 160
         for ( int32_t i = 0; i < colorCount; ++i ) {
             int32_t posx = startx + i * ( 22 + sprite.width() );
             positions.emplace_back( posx, pos.y, sprite.width(), sprite.height() );

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -62,16 +62,15 @@ struct SelectRecipientsColors
         : colors( Settings::Get().GetPlayers().GetActualColors() & ~senderColor )
         , recipients( 0 )
     {
-        
         positions.reserve( colors.size() );
 
         const int32_t colorCount = static_cast<int32_t>( colors.size() ); // safe to cast as the number of players <= 8.
 
         for ( int32_t i = 0; i < colorCount; ++i ) {
             const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::CELLWIN, 43 );
-            int32_t temp = i * (sprite.width() + 15) * 6 / colorCount;
-            int32_t ceilCalc = temp + (((i * (sprite.width() + 15) * 6) % colorCount) > 0);
-            int32_t posx = ceilCalc + ( (sprite.width() + 15) / ( 2 * colorCount ) );
+            int32_t temp = i * ( sprite.width() + 15 ) * 6 / colorCount;
+            int32_t ceilCalc = temp + ( ( ( i * ( sprite.width() + 15 ) * 6 ) % colorCount ) > 0 );
+            int32_t posx = ceilCalc + ( ( sprite.width() + 15 ) / ( 2 * colorCount ) );
             positions.emplace_back( pos.x + posx, pos.y, sprite.width(), sprite.height() );
         }
     }
@@ -87,7 +86,6 @@ struct SelectRecipientsColors
 
         for ( Colors::const_iterator it = colors.begin(); it != colors.end(); ++it ) {
             const fheroes2::Rect & pos = positions[std::distance( colors.begin(), it )];
-
             fheroes2::Blit( fheroes2::AGG::GetICN( ICN::CELLWIN, 43 + Color::GetIndex( *it ) ), display, pos.x, pos.y );
             if ( recipients & *it )
                 fheroes2::Blit( fheroes2::AGG::GetICN( ICN::CELLWIN, 2 ), display, pos.x + 2, pos.y + 2 );

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -60,6 +60,7 @@ int32_t GetIndexClickRects( const std::vector<fheroes2::Rect> & rects )
 
 struct SelectRecipientsColors
 {
+    static constexpr int recipientSpacing = 22;
     const Colors colors;
     int recipients;
     std::vector<fheroes2::Rect> positions;
@@ -75,10 +76,10 @@ struct SelectRecipientsColors
 
         const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::CELLWIN, 43 );
         const int32_t colorCount = static_cast<int32_t>( colors.size() ); // safe to cast as the number of players <= 8.
-        const int32_t playerContainerWidth = colorCount * sprite.width() + ( colorCount - 1 ) * 22; // original spacing = 22
+        const int32_t playerContainerWidth = colorCount * sprite.width() + ( colorCount - 1 ) * recipientSpacing;
         const int32_t startX = box.x + ( giftDialogSize.width - playerContainerWidth ) / 2;
         for ( int32_t i = 0; i < colorCount; ++i ) {
-            const int32_t posX = startX + i * ( 22 + sprite.width() );
+            const int32_t posX = startX + i * ( recipientSpacing + sprite.width() );
             positions.emplace_back( posX, pos.y, sprite.width(), sprite.height() );
         }
     }

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -62,14 +62,17 @@ struct SelectRecipientsColors
         : colors( Settings::Get().GetPlayers().GetActualColors() & ~senderColor )
         , recipients( 0 )
     {
+        
         positions.reserve( colors.size() );
 
         const int32_t colorCount = static_cast<int32_t>( colors.size() ); // safe to cast as the number of players <= 8.
 
         for ( int32_t i = 0; i < colorCount; ++i ) {
             const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::CELLWIN, 43 );
-
-            positions.emplace_back( pos.x + Game::GetStep4Player( i, sprite.width() + 15, colorCount ), pos.y, sprite.width(), sprite.height() );
+            int32_t temp = i * (sprite.width() + 15) * 6 / colorCount;
+            int32_t ceilCalc = temp + (((i * (sprite.width() + 15) * 6) % colorCount) > 0);
+            int32_t posx = ceilCalc + ( (sprite.width() + 15) / ( 2 * colorCount ) );
+            positions.emplace_back( pos.x + posx, pos.y, sprite.width(), sprite.height() );
         }
     }
 
@@ -221,7 +224,6 @@ void Dialog::MakeGiftResource( Kingdom & kingdom )
 
     text.Set( _( "Your Funds" ) );
     text.Blit( box.x + ( box.width - text.w() ) / 2, box.y + 55 );
-
     ResourceBar info1( funds1, box.x + 25, box.y + 80 );
     info1.Redraw();
 

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -216,7 +216,7 @@ void Dialog::MakeGiftResource( Kingdom & kingdom )
     Funds funds2;
     fheroes2::Text text;
     const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::TRADPOST, 7 );
-    int32_t posx = ( 320 -  ( sprite.width() + 240 ) ) / 2;
+    int32_t posx = ( 320 - ( sprite.width() + 240 ) ) / 2;
     const fheroes2::FontType normalWhite = fheroes2::FontType::normalWhite();
 
     text.set( _( "Select Recipients" ), normalWhite );


### PR DESCRIPTION
This commit was written for issue #4804. It replaces the call to Game::GetStep4Player(...) with an inlined change that uses integer ceiling arithmetic to replace Game::GetStep4Player(...). The functional requirement was to ensure that the colored squares representing players would be evenly spaced was met. 