### PR TITLE
Reserve half of spell points for dimension door

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1195,6 +1195,7 @@ namespace AI
                 for ( int i = 0; i < monsterStrengthMultiplierCount; ++i ) {
                     if ( currentMonsterStrengthMultiplier > monsterStrengthMultipliers[i] ) {
                         _pathfinder.setArmyStrengthMultiplier( bestHero->isLosingGame() ? ARMY_ADVANTAGE_DESPERATE : monsterStrengthMultipliers[i] );
+                        _pathfinder.setSpellPointReserve( 0 );
                         setNewMultiplier = true;
                         break;
                     }
@@ -1266,6 +1267,7 @@ namespace AI
             }
 
             _pathfinder.setArmyStrengthMultiplier( originalMonsterStrengthMultiplier );
+            _pathfinder.setSpellPointReserve( 0.5 );
         }
 
         const bool allHeroesMoved = availableHeroes.empty();
@@ -1277,6 +1279,7 @@ namespace AI
         }
 
         _pathfinder.setArmyStrengthMultiplier( originalMonsterStrengthMultiplier );
+        _pathfinder.setSpellPointReserve( 0.5 );
 
         return allHeroesMoved;
     }

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -734,7 +734,7 @@ std::list<Route::Step> AIWorldPathfinder::getDimensionDoorPath( const Heroes & h
     if ( currentSpellPoints < hero.GetMaxSpellPoints() * _spellPointsReserved )
         return path;
 
-    currentSpellPoints -= hero.GetMaxSpellPoints() * _spellPointsReserved;
+    currentSpellPoints -= static_cast<uint32_t>( hero.GetMaxSpellPoints() * _spellPointsReserved );
 
     const uint32_t movementCost = std::max( 1U, dimensionDoor.MovePoint() );
     const uint32_t maxCasts = std::min( currentSpellPoints / std::max( 1U, dimensionDoor.SpellPoint( &hero ) ), hero.GetMovePoints() / movementCost );
@@ -865,7 +865,7 @@ void AIWorldPathfinder::setArmyStrengthMultiplier( const double multiplier )
     }
 }
 
-void AIWorldPathfinder::setSpellPointReserve( const double divisor )
+void AIWorldPathfinder::setSpellPointReserve( const double reserve )
 {
-    _spellPointsReserved = divisor;
+    _spellPointsReserved = reserve;
 }

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -730,13 +730,14 @@ std::list<Route::Step> AIWorldPathfinder::getDimensionDoorPath( const Heroes & h
     if ( !hero.HaveSpell( dimensionDoor ) || !Maps::isValidAbsIndex( targetIndex ) )
         return path;
 
-    const uint32_t spCost = std::max( 1U, dimensionDoor.SpellPoint( &hero ) );
-    const uint32_t movementCost = std::max( 1U, dimensionDoor.MovePoint() );
-
-    const uint32_t maxCasts = std::min( hero.GetSpellPoints() / spCost, hero.GetMovePoints() / movementCost );
-    // minimum two casts to make sure there will be movement & spell points left to do the action
-    if ( maxCasts < 2 )
+    uint32_t currentSpellPoints = hero.GetSpellPoints();
+    if ( currentSpellPoints < hero.GetMaxSpellPoints() * _spellPointsReserved )
         return path;
+
+    currentSpellPoints -= hero.GetMaxSpellPoints() * _spellPointsReserved;
+
+    const uint32_t movementCost = std::max( 1U, dimensionDoor.MovePoint() );
+    const uint32_t maxCasts = std::min( currentSpellPoints / std::max( 1U, dimensionDoor.SpellPoint( &hero ) ), hero.GetMovePoints() / movementCost );
 
     if ( world.GetTiles( targetIndex ).GetObject( false ) == MP2::OBJ_CASTLE ) {
         targetIndex = Maps::GetDirectionIndex( targetIndex, Direction::BOTTOM );
@@ -753,7 +754,7 @@ std::list<Route::Step> AIWorldPathfinder::getDimensionDoorPath( const Heroes & h
     const Directions & directions = Direction::All();
     const int32_t distanceLimit = Spell::CalculateDimensionDoorDistance() / 2;
 
-    uint32_t spellsUsed = 1; // start with 1 to avoid spending ALL move/spell points
+    uint32_t spellsUsed = 0;
     while ( maxCasts > spellsUsed ) {
         const int32_t currentNodeIdx = Maps::GetIndexFromAbsPoint( current );
         fheroes2::Point another = current;
@@ -862,4 +863,9 @@ void AIWorldPathfinder::setArmyStrengthMultiplier( const double multiplier )
         _advantage = multiplier;
         reset();
     }
+}
+
+void AIWorldPathfinder::setSpellPointReserve( const double divisor )
+{
+    _spellPointsReserved = divisor;
 }

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -149,6 +149,7 @@ public:
     }
 
     void setArmyStrengthMultiplier( const double multiplier );
+    void setSpellPointReserve( const double reserve );
 
 private:
     void processCurrentNode( std::vector<int> & nodesToExplore, int currentNodeIdx ) override;
@@ -161,5 +162,6 @@ private:
 
     double _armyStrength = -1;
     double _advantage = 1.0;
+    double _spellPointsReserved = 0.5;
     Army _temporaryArmy; // for internal calculations
 };


### PR DESCRIPTION
Added a new variable controlling how much spell points are reserved for adventure spells, half by default. Reset to 0 if there's nothing to do, so "stuck" heroes should teleport out.