### PR TITLE
Do not allow a hero to have multiple spell books in the "Battle Only" mode

### DIFF
--- a/src/fheroes2/battle/battle_only.cpp
+++ b/src/fheroes2/battle/battle_only.cpp
@@ -91,7 +91,7 @@ Battle::Only::Only()
     player2.SetControl( CONTROL_AI );
 }
 
-bool Battle::Only::ChangeSettings( void )
+bool Battle::Only::ChangeSettings()
 {
     fheroes2::Display & display = fheroes2::Display::instance();
     LocalEvent & le = LocalEvent::Get();
@@ -120,6 +120,7 @@ bool Battle::Only::ChangeSettings( void )
 
     hero1 = world.GetHeroes( Heroes::LORDKILBURN );
     hero1->GetSecondarySkills().FillMax( Skill::Secondary() );
+
     army1 = &hero1->GetArmy();
 
     RedrawBaseInfo( cur_pt );
@@ -581,7 +582,7 @@ void Battle::Only::RedrawBaseInfo( const fheroes2::Point & top ) const
     fheroes2::RedrawPrimarySkillInfo( top, primskill_bar1.get(), primskill_bar2.get() );
 }
 
-void Battle::Only::StartBattle( void )
+void Battle::Only::StartBattle()
 {
     Settings & conf = Settings::Get();
 

--- a/src/fheroes2/battle/battle_only.h
+++ b/src/fheroes2/battle/battle_only.h
@@ -64,13 +64,15 @@ namespace Battle
 
         Only & operator=( const Only & ) = delete;
 
-        bool ChangeSettings( void );
-        void RedrawBaseInfo( const fheroes2::Point & ) const;
-        void StartBattle( void );
-        void UpdateHero1( const fheroes2::Point & );
-        void UpdateHero2( const fheroes2::Point & );
+        bool ChangeSettings();
+        void StartBattle();
 
     private:
+        void RedrawBaseInfo( const fheroes2::Point & top ) const;
+
+        void UpdateHero1( const fheroes2::Point & cur_pt );
+        void UpdateHero2( const fheroes2::Point & cur_pt );
+
         Heroes * hero1;
         Heroes * hero2;
 

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <map>
 #include <string>
 

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -935,8 +935,16 @@ bool ArtifactsBar::ActionBarLeftMouseSingleClick( Artifact & art )
         }
     }
     else {
-        if ( can_change )
-            art = Dialog::SelectArtifact();
+        if ( can_change ) {
+            const Artifact newArtifact = Dialog::SelectArtifact();
+
+            if ( isMagicBook( newArtifact ) ) {
+                const_cast<Heroes *>( _hero )->SpellBookActivate();
+            }
+            else {
+                art = newArtifact;
+            }
+        }
 
         return false;
     }

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -683,7 +683,7 @@ bool BagArtifacts::PushArtifact( const Artifact & art )
     }
 
     if ( art.GetID() == Artifact::MAGIC_BOOK && isPresentArtifact( art ) ) {
-        // Wee add a magic book while adding a hero on the map.
+        // We add a magic book while adding a hero on the map.
         // In case if a map creator set Magic Book to be an artifact of the hero we face two Magic Books situation.
         return false;
     }


### PR DESCRIPTION
Currently it is possible:

![Battle Only](https://user-images.githubusercontent.com/32623900/164814122-6c02aa43-21b1-47e8-9f44-1728732e3866.jpg)

This PR fixes this, and also the spell book will always be added to the first slot.