### PR TITLE
GitHub Actions: Automatically generate version information for SonarCloud

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -36,6 +36,9 @@ jobs:
         key: sonarcloud-cfamily-cache-${{ hashFiles( 'src/**/*.c', 'src/**/*.cpp', 'src/**/*.h' ) }}
         restore-keys: |
           sonarcloud-cfamily-cache-
+    - name: Generate version information
+      run: |
+        sed -i~ "s/%{version}/$(cat version.txt)/" sonar-project.properties
     - name: Build
       run: |
         ~/.sonarcloud/build-wrapper-linux-x86/build-wrapper-linux-x86-64 --out-dir bw-output make -j 2

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,11 +3,12 @@ sonar.organization=ihhub
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=fheroes2
-sonar.projectVersion=0.9.14
- 
+# CI will automatically replace this with the contents of the version.txt file.
+sonar.projectVersion=%{version}
+
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=.
- 
+
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
 


### PR DESCRIPTION
Thus, we only need to update the project version in two places: `version.h` and `version.txt`.