### PR TITLE
Generate French 'GIFT' button

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -500,7 +500,7 @@ namespace fheroes2
                     Fill( out, offsetXD + 9 - i, offsetY + i, 1, 1, getButtonFillingColor( i == 0, false ) );
                     // Add 'O'
                     const int32_t offsetXO = 10;
-                    Blit( GetICN( ICN::APANELE, 4 + i ), 50 - ( 1 * i ), 20 + ( 1 * i ), out, offsetXD + offsetXO + 1 - i, offsetY + i , 13 - i, 14 );
+                    Blit( GetICN( ICN::APANELE, 4 + i ), 50 - i, 20 + i, out, offsetXD + offsetXO + 1 - i, offsetY + i, 13 - i, 14 );
                     // Clean up 'DO'
                     Blit( GetICN( ICN::CPANELE, 4 + i ), 51 - i, 34, out, offsetXD + offsetXO - i, offsetY + 5, 2, 2 );
                     Blit( GetICN( ICN::CPANELE, 4 + i ), 51 - i, 34, out, offsetXD + offsetXO - i, offsetY + 7, 1, 1 + i );

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -484,24 +484,8 @@ namespace fheroes2
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::TRADPOSE, 17 + i );
-
                     // clean the button
                     Fill( out, 33, 5, 31, 16, getButtonFillingColor( i == 0, false ) );
-
-                    //// add 'D'
-                    //Blit( GetICN( ICN::CPANEL, 4 + i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
-
-                    //// add 'O'
-                    //Blit( GetICN( ICN::CAMPXTRG, i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
-
-                    //// add 'N'
-                    //Blit( GetICN( ICN::TRADPOST, 17 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
-
-                    //// add 'N'
-                    //Blit( GetICN( ICN::TRADPOST, 17 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
-
-                    //// add 'ER'
-                    //Blit( GetICN( ICN::CAMPXTRG, 2 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
 
                     const int32_t offsetY = 5;
                     // Add 'D'

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -440,9 +440,9 @@ namespace fheroes2
                     // clean the button
                     Fill( out, 33, 5, 31, 16, getButtonFillingColor( i == 0 ) );
 
-                    const int32_t offsetXD = 14;
                     const int32_t offsetY = 5;
                     // Add 'D'
+                    const int32_t offsetXD = 14;
                     Blit( GetICN( ICN::CPANEL, 4 + i ), 48 - i, 28 + i, out, offsetXD - i, offsetY + i, 10, 15 );
                     // Clean up 'D' and restore button ornament
                     Blit( GetICN( ICN::CPANEL, 4 + i ), 48 - i, 36, out, offsetXD - 1 - i, offsetY + 4 + i, 1, 1 );
@@ -471,11 +471,14 @@ namespace fheroes2
                     // Add 'ER'
                     Blit( GetICN( ICN::CAMPXTRG, 2 + i ), 75 - ( 8 * i ), 5, out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN - ( 2 * i ), offsetY, 23, 15 );
                     // Restore button ornament
-                    Blit( GetICN( ICN::TRADPOST, 17 + i ), offsetXD + 10 + 13 + 13 + 13 + 20, offsetY, out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20,
+                    Blit( GetICN( ICN::TRADPOST, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, out,
+                          offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20,
                           offsetY, 1, 1 );
-                    Blit( GetICN( ICN::TRADPOST, 17 + i ), offsetXD + 10 + 13 + 13 + 13 + 21, offsetY + 1, out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21,
+                    Blit( GetICN( ICN::TRADPOST, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21, offsetY + 1, out,
+                          offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21,
                           offsetY + 1, 2, 3 );
-                    Blit( GetICN( ICN::TRADPOST, 17 + i ), offsetXD + 10 + 13 + 13 + 13 + 20, offsetY, out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21,
+                    Blit( GetICN( ICN::TRADPOST, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, out,
+                          offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21,
                           offsetY + 4, 1, 1 );
                 }
                 break;

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -437,25 +437,46 @@ namespace fheroes2
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::TRADPOST, 17 + i );
-
                     // clean the button
                     Fill( out, 33, 5, 31, 16, getButtonFillingColor( i == 0 ) );
-                    /*Blit( GetICN( ICN::SYSTEM, 11 + i ), 10, 6, out, 6, 4, 72, 15 );*/
 
-                    // add 'D'
-                    Blit( GetICN( ICN::CPANEL, 4 + i ), 48 - i, 28, out, 14 - i, 5, 10, 15 );
-
-                    // add 'O'
-                    Blit( GetICN( ICN::CAMPXTRG, i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
-
-                    // add 'N'
-                    Blit( GetICN( ICN::TRADPOST, 17 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
-
-                    // add 'N'
-                    Blit( GetICN( ICN::TRADPOST, 17 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
-
-                    // add 'ER'
-                    Blit( GetICN( ICN::CAMPXTRG, 2 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
+                    const int32_t offsetXD = 14;
+                    const int32_t offsetY = 5;
+                    // Add 'D'
+                    Blit( GetICN( ICN::CPANEL, 4 + i ), 48 - i, 28 + i, out, offsetXD - i, offsetY + i, 10, 15 );
+                    // Clean up 'D' and restore button ornament
+                    Blit( GetICN( ICN::CPANEL, 4 + i ), 48 - i, 36, out, offsetXD - 1 - i, offsetY + 4 + i, 1, 1 );
+                    Blit( GetICN( ICN::CPANEL, 4 + i ), 48 - i, 35, out, offsetXD - i, offsetY + 9 + i, 1, 2 );
+                    Blit( GetICN( ICN::CPANEL, 4 + i ), 48 - i, 35, out, offsetXD - 1 - i, offsetY + 13 + i, 1, 1 );
+                    Fill( out, offsetXD + 9 - i, offsetY + 13 + i, 1, 1, getButtonFillingColor( i == 0 ) );
+                    Blit( GetICN( ICN::TRADPOST, 17 + i ), offsetXD, offsetY, out, offsetXD, offsetY, 1, 1 );
+                    // Add 'O'
+                    const int32_t offsetXO = 10;
+                    Blit( GetICN( ICN::CAMPXTRG, i ), 40 - ( 7 * i ), 5 + ( 1 * i ), out, offsetXD + offsetXO + 1 - i, offsetY + i, 13 - i, 15 );
+                    // Clean up 'DO'
+                    Blit( GetICN( ICN::CPANEL, 4 + i ), 51 - i, 34, out, offsetXD + offsetXO - i, offsetY + 5, 2, 2 );
+                    Blit( GetICN( ICN::CPANEL, 4 + i ), 51 - i, 34, out, offsetXD + offsetXO - i, offsetY + 7, 1, 1 + i );
+                    Blit( GetICN( ICN::CPANEL, 4 + i ), 55 - i, 28 + i, out, offsetXD + 9 - i, offsetY + 2 + i, 3, 3 );
+                    Fill( out, offsetXD + 11 - i, offsetY + i, 2, 2, getButtonFillingColor( i == 0 ) );
+                    // Add 'N'
+                    const int32_t offsetXN = 13;
+                    Blit( GetICN( ICN::TRADPOST, 17 + i ), 50 - i, 5, out, offsetXD + offsetXO + offsetXN - i, offsetY, 14, 15 );
+                    // Clean up 'ON'
+                    Fill( out, offsetXD + offsetXO + offsetXN, offsetY, 1, 1, getButtonFillingColor( i == 0 ) );
+                    Fill( out, offsetXD + offsetXO + offsetXN - i, offsetY + 9, 1, 1, getButtonFillingColor( i == 0 ) );
+                    // Add 'N'
+                    Blit( GetICN( ICN::TRADPOST, 17 + i ), 50 - i, 5, out, offsetXD + 10 + offsetXN + offsetXN - i, offsetY, 14, 15 );
+                    // Clean up 'NN'
+                    Fill( out, offsetXD + offsetXO + offsetXN + offsetXN - i, offsetY + 9, 1, 1, getButtonFillingColor( i == 0 ) );
+                    // Add 'ER'
+                    Blit( GetICN( ICN::CAMPXTRG, 2 + i ), 75 - ( 8 * i ), 5, out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN - ( 2 * i ), offsetY, 23, 15 );
+                    // Restore button ornament
+                    Blit( GetICN( ICN::TRADPOST, 17 + i ), offsetXD + 10 + 13 + 13 + 13 + 20, offsetY, out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20,
+                          offsetY, 1, 1 );
+                    Blit( GetICN( ICN::TRADPOST, 17 + i ), offsetXD + 10 + 13 + 13 + 13 + 21, offsetY + 1, out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21,
+                          offsetY + 1, 2, 3 );
+                    Blit( GetICN( ICN::TRADPOST, 17 + i ), offsetXD + 10 + 13 + 13 + 13 + 20, offsetY, out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21,
+                          offsetY + 4, 1, 1 );
                 }
                 break;
             case ICN::BTNGIFT_EVIL:

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -472,14 +472,11 @@ namespace fheroes2
                     Blit( GetICN( ICN::CAMPXTRG, 2 + i ), 75 - ( 8 * i ), 5, out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN - ( 2 * i ), offsetY, 23, 15 );
                     // Restore button ornament
                     Blit( GetICN( ICN::TRADPOST, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, out,
-                          offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20,
-                          offsetY, 1, 1 );
+                          offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, 1, 1 );
                     Blit( GetICN( ICN::TRADPOST, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21, offsetY + 1, out,
-                          offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21,
-                          offsetY + 1, 2, 3 );
+                          offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21, offsetY + 1, 2, 3 );
                     Blit( GetICN( ICN::TRADPOST, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, out,
-                          offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21,
-                          offsetY + 4, 1, 1 );
+                          offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21, offsetY + 4, 1, 1 );
                 }
                 break;
             case ICN::BTNGIFT_EVIL:
@@ -491,20 +488,58 @@ namespace fheroes2
                     // clean the button
                     Fill( out, 33, 5, 31, 16, getButtonFillingColor( i == 0, false ) );
 
-                    // add 'D'
-                    Blit( GetICN( ICN::CPANEL, 4 + i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
+                    //// add 'D'
+                    //Blit( GetICN( ICN::CPANEL, 4 + i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
 
-                    // add 'O'
-                    Blit( GetICN( ICN::CAMPXTRG, i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
+                    //// add 'O'
+                    //Blit( GetICN( ICN::CAMPXTRG, i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
 
-                    // add 'N'
-                    Blit( GetICN( ICN::TRADPOST, 17 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
+                    //// add 'N'
+                    //Blit( GetICN( ICN::TRADPOST, 17 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
 
-                    // add 'N'
-                    Blit( GetICN( ICN::TRADPOST, 17 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
+                    //// add 'N'
+                    //Blit( GetICN( ICN::TRADPOST, 17 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
 
-                    // add 'ER'
-                    Blit( GetICN( ICN::CAMPXTRG, 2 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
+                    //// add 'ER'
+                    //Blit( GetICN( ICN::CAMPXTRG, 2 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
+
+                    const int32_t offsetY = 5;
+                    // Add 'D'
+                    const int32_t offsetXD = 14;
+                    Blit( GetICN( ICN::CPANELE, 4 + i ), 48 - i, 28 + i, out, offsetXD - i, offsetY + i, 10, 15 );
+                    // Clean up 'D' and restore button ornament
+                    Blit( GetICN( ICN::CPANELE, 4 + i ), 48 - i, 36, out, offsetXD - 1 - i, offsetY + 4 + i, 1, 1 );
+                    Blit( GetICN( ICN::CPANELE, 4 + i ), 48 - i, 35, out, offsetXD - i, offsetY + 9 + i, 1, 2 );
+                    Blit( GetICN( ICN::CPANELE, 4 + i ), 48 - i, 35, out, offsetXD - 1 - i, offsetY + 13 + i, 1, 1 );
+                    Fill( out, offsetXD + 9 - i, offsetY + 13 + i, 1, 1, getButtonFillingColor( i == 0, false ) );
+                    Blit( GetICN( ICN::TRADPOSE, 17 + i ), offsetXD, offsetY, out, offsetXD, offsetY, 1, 1 );
+                    // Add 'O'
+                    const int32_t offsetXO = 10;
+                    Blit( GetICN( ICN::CAMPXTRE, i ), 38 - ( 5 * i ), 5 + ( 1 * i ), out, offsetXD + offsetXO + 1 - i, offsetY + i, 13 - i, 15 );
+                    // Clean up 'DO'
+                    Blit( GetICN( ICN::CPANELE, 4 + i ), 51 - i, 34, out, offsetXD + offsetXO - i, offsetY + 5, 2, 2 );
+                    Blit( GetICN( ICN::CPANELE, 4 + i ), 51 - i, 34, out, offsetXD + offsetXO - i, offsetY + 7, 1, 1 + i );
+                    Blit( GetICN( ICN::CPANELE, 4 + i ), 55 - i, 28 + i, out, offsetXD + 9 - i, offsetY + 2 + i, 3, 3 );
+                    Fill( out, offsetXD + 11 - i, offsetY + i, 2, 2, getButtonFillingColor( i == 0, false ) );
+                    // Add 'N'
+                    const int32_t offsetXN = 13;
+                    Blit( GetICN( ICN::TRADPOSE, 17 + i ), 50 - i, 5, out, offsetXD + offsetXO + offsetXN - i, offsetY, 14, 15 );
+                    // Clean up 'ON'
+                    Fill( out, offsetXD + offsetXO + offsetXN, offsetY, 1, 1, getButtonFillingColor( i == 0, false ) );
+                    Fill( out, offsetXD + offsetXO + offsetXN - i, offsetY + 9, 1, 1, getButtonFillingColor( i == 0, false ) );
+                    // Add 'N'
+                    Blit( GetICN( ICN::TRADPOSE, 17 + i ), 50 - i, 5, out, offsetXD + 10 + offsetXN + offsetXN - i, offsetY, 14, 15 );
+                    // Clean up 'NN'
+                    Fill( out, offsetXD + offsetXO + offsetXN + offsetXN - i, offsetY + 9, 1, 1, getButtonFillingColor( i == 0, false ) );
+                    // Add 'ER'
+                    Blit( GetICN( ICN::CAMPXTRE, 2 + i ), 73 - ( 6 * i ), 5, out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN - ( 2 * i ), offsetY, 23, 15 );
+                    // Restore button ornament
+                    Blit( GetICN( ICN::TRADPOSE, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, out,
+                          offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, 1, 1 );
+                    Blit( GetICN( ICN::TRADPOSE, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21, offsetY + 1, out,
+                          offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21, offsetY + 1, 2, 3 );
+                    Blit( GetICN( ICN::TRADPOSE, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, out,
+                          offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21, offsetY + 4, 1, 1 );
                 }
                 break;
 

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -306,6 +306,50 @@ namespace fheroes2
                     Blit( GetICN( ICN::BTNHOTST, i ), 72 - i, 21, out, 84 - i, 28, 13, 13 );
                 }
                 break;
+            case ICN::BTNGIFT_GOOD:
+                _icnVsSprite[id].resize( 2 );
+                for ( uint32_t i = 0; i < 2; ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
+                    out = GetICN( ICN::TRADPOST, 17 + i );
+
+                    // clean the button
+                    Blit( GetICN( ICN::SYSTEM, 11 + i ), 10, 6, out, 6, 4, 72, 15 );
+
+                    // add 'G'
+                    Blit( GetICN( ICN::CPANEL, i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
+
+                    // add 'I'
+                    Blit( GetICN( ICN::APANEL, 4 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
+
+                    // add 'F'
+                    Blit( GetICN( ICN::APANEL, 4 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
+
+                    // add 'T'
+                    Blit( GetICN( ICN::CPANEL, 6 + i ), 59 - i, 21, out, 60 - i, 5, 14, 14 );
+                }
+                break;
+             case ICN::BTNGIFT_EVIL:
+                _icnVsSprite[id].resize( 2 );
+                for ( uint32_t i = 0; i < 2; ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
+                    out = GetICN( ICN::TRADPOSE, 17 + i );
+
+                    // clean the button
+                    Blit( GetICN( ICN::SYSTEME, 11 + i ), 10, 6, out, 6, 4, 72, 15 );
+
+                    // add 'G'
+                    Blit( GetICN( ICN::CPANELE, i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
+
+                    // add 'I'
+                    Blit( GetICN( ICN::APANELE, 4 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
+
+                    // add 'F'
+                    Blit( GetICN( ICN::APANELE, 4 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
+
+                    // add 'T'
+                    Blit( GetICN( ICN::CPANELE, 6 + i ), 59 - i, 21, out, 60 - i, 5, 14, 14 );
+                }
+                break;
             default:
                 // You're calling this function for non-specified ICN id. Check your logic!
                 assert( 0 );
@@ -653,48 +697,8 @@ namespace fheroes2
                 }
                 return true;
             case ICN::BTNGIFT_GOOD:
-                _icnVsSprite[id].resize( 2 );
-                for ( uint32_t i = 0; i < 2; ++i ) {
-                    Sprite & out = _icnVsSprite[id][i];
-                    out = GetICN( ICN::TRADPOST, 17 + i );
-
-                    // clean the button
-                    Blit( GetICN( ICN::SYSTEM, 11 + i ), 10, 6, out, 6, 4, 72, 15 );
-
-                    // add 'G'
-                    Blit( GetICN( ICN::CPANEL, i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
-
-                    // add 'I'
-                    Blit( GetICN( ICN::APANEL, 4 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
-
-                    // add 'F'
-                    Blit( GetICN( ICN::APANEL, 4 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
-
-                    // add 'T'
-                    Blit( GetICN( ICN::CPANEL, 6 + i ), 59 - i, 21, out, 60 - i, 5, 14, 14 );
-                }
-                return true;
             case ICN::BTNGIFT_EVIL:
-                _icnVsSprite[id].resize( 2 );
-                for ( uint32_t i = 0; i < 2; ++i ) {
-                    Sprite & out = _icnVsSprite[id][i];
-                    out = GetICN( ICN::TRADPOSE, 17 + i );
-
-                    // clean the button
-                    Blit( GetICN( ICN::SYSTEME, 11 + i ), 10, 6, out, 6, 4, 72, 15 );
-
-                    // add 'G'
-                    Blit( GetICN( ICN::CPANELE, i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
-
-                    // add 'I'
-                    Blit( GetICN( ICN::APANELE, 4 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
-
-                    // add 'F'
-                    Blit( GetICN( ICN::APANELE, 4 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
-
-                    // add 'T'
-                    Blit( GetICN( ICN::CPANELE, 6 + i ), 59 - i, 21, out, 60 - i, 5, 14, 14 );
-                }
+                generateLanguageSpecificImages( id );
                 return true;
             case ICN::BTNCONFIG:
                 _icnVsSprite[id].resize( 2 );

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -443,7 +443,7 @@ namespace fheroes2
                     /*Blit( GetICN( ICN::SYSTEM, 11 + i ), 10, 6, out, 6, 4, 72, 15 );*/
 
                     // add 'D'
-                    Blit( GetICN( ICN::CPANEL, 4 + i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
+                    Blit( GetICN( ICN::CPANEL, 4 + i ), 48 - i, 28, out, 14 - i, 5, 10, 15 );
 
                     // add 'O'
                     Blit( GetICN( ICN::CAMPXTRG, i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -452,7 +452,7 @@ namespace fheroes2
                     Blit( GetICN( ICN::TRADPOST, 17 + i ), offsetXD, offsetY, out, offsetXD, offsetY, 1, 1 );
                     // Add 'O'
                     const int32_t offsetXO = 10;
-                    Blit( GetICN( ICN::CAMPXTRG, i ), 40 - ( 7 * i ), 5 + ( 1 * i ), out, offsetXD + offsetXO + 1 - i, offsetY + i, 13 - i, 15 );
+                    Blit( GetICN( ICN::CAMPXTRG, i ), 40 - ( 7 * i ), 5 + i, out, offsetXD + offsetXO + 1 - i, offsetY + i, 13 - i, 15 );
                     // Clean up 'DO'
                     Blit( GetICN( ICN::CPANEL, 4 + i ), 51 - i, 34, out, offsetXD + offsetXO - i, offsetY + 5, 2, 2 );
                     Blit( GetICN( ICN::CPANEL, 4 + i ), 51 - i, 34, out, offsetXD + offsetXO - i, offsetY + 7, 1, 1 + i );
@@ -499,7 +499,7 @@ namespace fheroes2
                     Blit( GetICN( ICN::TRADPOSE, 17 + i ), offsetXD, offsetY, out, offsetXD, offsetY, 1, 1 );
                     // Add 'O'
                     const int32_t offsetXO = 10;
-                    Blit( GetICN( ICN::CAMPXTRE, i ), 38 - ( 5 * i ), 5 + ( 1 * i ), out, offsetXD + offsetXO + 1 - i, offsetY + i, 13 - i, 15 );
+                    Blit( GetICN( ICN::CAMPXTRE, i ), 38 - ( 5 * i ), 5 + ( 2 * i ), out, offsetXD + offsetXO + 1 - i, offsetY + ( 2 * i ), 13 - i, 14 - i );
                     // Clean up 'DO'
                     Blit( GetICN( ICN::CPANELE, 4 + i ), 51 - i, 34, out, offsetXD + offsetXO - i, offsetY + 5, 2, 2 );
                     Blit( GetICN( ICN::CPANELE, 4 + i ), 51 - i, 34, out, offsetXD + offsetXO - i, offsetY + 7, 1, 1 + i );
@@ -516,7 +516,7 @@ namespace fheroes2
                     // Clean up 'NN'
                     Fill( out, offsetXD + offsetXO + offsetXN + offsetXN - i, offsetY + 9, 1, 1, getButtonFillingColor( i == 0, false ) );
                     // Add 'ER'
-                    Blit( GetICN( ICN::CAMPXTRE, 2 + i ), 73 - ( 6 * i ), 5, out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN - ( 2 * i ), offsetY, 23, 15 );
+                    Blit( GetICN( ICN::CAMPXTRE, 2 + i ), 73 - ( 6 * i ), 5 + ( 2 * i ), out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN - ( 2 * i ), offsetY + ( 2 * i ), 23, 14 - i );
                     // Restore button ornament
                     Blit( GetICN( ICN::TRADPOSE, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, out,
                           offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, 1, 1 );

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -516,7 +516,8 @@ namespace fheroes2
                     // Clean up 'NN'
                     Fill( out, offsetXD + offsetXO + offsetXN + offsetXN - i, offsetY + 9, 1, 1, getButtonFillingColor( i == 0, false ) );
                     // Add 'ER'
-                    Blit( GetICN( ICN::CAMPXTRE, 2 + i ), 73 - ( 6 * i ), 5 + ( 2 * i ), out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN - ( 2 * i ), offsetY + ( 2 * i ), 23, 14 - i );
+                    Blit( GetICN( ICN::CAMPXTRE, 2 + i ), 73 - ( 6 * i ), 5 + ( 2 * i ), out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN - ( 2 * i ),
+                          offsetY + ( 2 * i ), 23, 14 - i );
                     // Restore button ornament
                     Blit( GetICN( ICN::TRADPOSE, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, out,
                           offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, 1, 1 );

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -497,27 +497,34 @@ namespace fheroes2
                     Blit( GetICN( ICN::CPANELE, 4 + i ), 48 - i, 35, out, offsetXD - 1 - i, offsetY + 13 + i, 1, 1 );
                     Fill( out, offsetXD + 9 - i, offsetY + 13 + i, 1, 1, getButtonFillingColor( i == 0, false ) );
                     Blit( GetICN( ICN::TRADPOSE, 17 + i ), offsetXD, offsetY, out, offsetXD, offsetY, 1, 1 );
+                    Fill( out, offsetXD + 9 - i, offsetY + i, 1, 1, getButtonFillingColor( i == 0, false ) );
                     // Add 'O'
                     const int32_t offsetXO = 10;
-                    Blit( GetICN( ICN::CAMPXTRE, i ), 38 - ( 5 * i ), 5 + ( 2 * i ), out, offsetXD + offsetXO + 1 - i, offsetY + ( 2 * i ), 13 - i, 14 - i );
+                    Blit( GetICN( ICN::APANELE, 4 + i ), 50 - ( 1 * i ), 20 + ( 1 * i ), out, offsetXD + offsetXO + 1 - i, offsetY + i , 13 - i, 14 );
                     // Clean up 'DO'
                     Blit( GetICN( ICN::CPANELE, 4 + i ), 51 - i, 34, out, offsetXD + offsetXO - i, offsetY + 5, 2, 2 );
                     Blit( GetICN( ICN::CPANELE, 4 + i ), 51 - i, 34, out, offsetXD + offsetXO - i, offsetY + 7, 1, 1 + i );
-                    Blit( GetICN( ICN::CPANELE, 4 + i ), 55 - i, 28 + i, out, offsetXD + 9 - i, offsetY + 2 + i, 3, 3 );
-                    Fill( out, offsetXD + 11 - i, offsetY + i, 2, 2, getButtonFillingColor( i == 0, false ) );
+                    Blit( GetICN( ICN::CPANELE, 4 + i ), 56 - i, 28 + i, out, offsetXD + 10 - i, offsetY + 2 + i, 1, 3 );
+                    Blit( GetICN( ICN::CPANELE, 4 + i ), 56 - i, 28 + i, out, offsetXD + 11 - i, offsetY + 3 + i, 1, 2 );
+                    Fill( out, offsetXD + 11 - i, offsetY + i, 3, 3, getButtonFillingColor( i == 0, false ) );
+                    Fill( out, offsetXD + 12 - i, offsetY + 3 + i, 1, 2, getButtonFillingColor( i == 0, false ) );
                     // Add 'N'
                     const int32_t offsetXN = 13;
                     Blit( GetICN( ICN::TRADPOSE, 17 + i ), 50 - i, 5, out, offsetXD + offsetXO + offsetXN - i, offsetY, 14, 15 );
                     // Clean up 'ON'
-                    Fill( out, offsetXD + offsetXO + offsetXN, offsetY, 1, 1, getButtonFillingColor( i == 0, false ) );
+                    Fill( out, offsetXD + offsetXO + offsetXN - 1 - i, offsetY + 11 + i, 1, 3, getButtonFillingColor( i == 0, false ) );
+                    Fill( out, offsetXD + offsetXO + offsetXN - i, offsetY, 1, 1, getButtonFillingColor( i == 0, false ) );
                     Fill( out, offsetXD + offsetXO + offsetXN - i, offsetY + 9, 1, 1, getButtonFillingColor( i == 0, false ) );
                     // Add 'N'
-                    Blit( GetICN( ICN::TRADPOSE, 17 + i ), 50 - i, 5, out, offsetXD + 10 + offsetXN + offsetXN - i, offsetY, 14, 15 );
+                    Blit( GetICN( ICN::TRADPOSE, 17 + i ), 50 - i, 5, out, offsetXD + offsetXO + offsetXN + offsetXN - i, offsetY, 13, 15 );
                     // Clean up 'NN'
                     Fill( out, offsetXD + offsetXO + offsetXN + offsetXN - i, offsetY + 9, 1, 1, getButtonFillingColor( i == 0, false ) );
                     // Add 'ER'
-                    Blit( GetICN( ICN::CAMPXTRE, 2 + i ), 73 - ( 6 * i ), 5 + ( 2 * i ), out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN - ( 2 * i ),
+                    Blit( GetICN( ICN::APANELE, 8 + i ), 66 - ( 3 * i ), 5 + ( 2 * i ), out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN - ( 2 * i ),
                           offsetY + ( 2 * i ), 23, 14 - i );
+                    // Clean up 'NE'
+                    Blit( GetICN( ICN::TRADPOSE, 17 + i ), 50 - i, 5, out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN - i, offsetY, 2, 10 );
+                    Fill( out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN - ( 2 * i ), offsetY + 9 + i, 1 + i, 2 + i, getButtonFillingColor( i == 0, false ) );
                     // Restore button ornament
                     Blit( GetICN( ICN::TRADPOSE, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, out,
                           offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, 1, 1 );

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -221,9 +221,7 @@ namespace
         if ( isGoodInterface ) {
             return isReleasedState ? fheroes2::GetColorId( 216, 184, 152 ) : fheroes2::GetColorId( 184, 136, 96 );
         }
-        else {
-            return isReleasedState ? fheroes2::GetColorId( 180, 180, 180 ) : fheroes2::GetColorId( 144, 144, 144 );
-        }
+        return isReleasedState ? fheroes2::GetColorId( 180, 180, 180 ) : fheroes2::GetColorId( 144, 144, 144 );
     }
 }
 
@@ -313,7 +311,7 @@ namespace fheroes2
                 break;
             case ICN::BTNGIFT_GOOD:
                 _icnVsSprite[id].resize( 2 );
-                for ( uint32_t i = 0; i < 2; ++i ) {
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::TRADPOST, 17 + i );
 
@@ -335,7 +333,7 @@ namespace fheroes2
                 break;
             case ICN::BTNGIFT_EVIL:
                 _icnVsSprite[id].resize( 2 );
-                for ( uint32_t i = 0; i < 2; ++i ) {
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::TRADPOSE, 17 + i );
 
@@ -462,7 +460,7 @@ namespace fheroes2
                 break;
             case ICN::BTNGIFT_EVIL:
                 _icnVsSprite[id].resize( 2 );
-                for ( uint32_t i = 0; i < 2; ++i ) {
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::TRADPOSE, 17 + i );
 

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -444,17 +444,20 @@ namespace fheroes2
                     Fill( out, 33, 5, 31, 16, getButtonFillingColor( i == 0 ) );
                     /*Blit( GetICN( ICN::SYSTEM, 11 + i ), 10, 6, out, 6, 4, 72, 15 );*/
 
-                    //// add 'G'
-                    // Blit( GetICN( ICN::CPANEL, i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
+                    // add 'D'
+                     Blit( GetICN( ICN::CPANEL, 4 + i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
 
-                    //// add 'I'
-                    // Blit( GetICN( ICN::APANEL, 4 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
+                    // add 'O'
+                     Blit( GetICN( ICN::CAMPXTRG, i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
 
-                    //// add 'F'
-                    // Blit( GetICN( ICN::APANEL, 4 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
+                    // add 'N'
+                     Blit( GetICN( ICN::TRADPOST, 17 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
 
-                    //// add 'T'
-                    // Blit( GetICN( ICN::CPANEL, 6 + i ), 59 - i, 21, out, 60 - i, 5, 14, 14 );
+                    // add 'N'
+                     Blit( GetICN( ICN::TRADPOST, 17 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
+
+                    // add 'ER'
+                     Blit( GetICN( ICN::CAMPXTRG, 2 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
                 }
                 break;
             case ICN::BTNGIFT_EVIL:
@@ -464,20 +467,22 @@ namespace fheroes2
                     out = GetICN( ICN::TRADPOSE, 17 + i );
 
                     // clean the button
-                    /*Blit( GetICN( ICN::SYSTEME, 11 + i ), 10, 6, out, 6, 4, 72, 15 );*/
                     Fill( out, 33, 5, 31, 16, getButtonFillingColor( i == 0, false ) );
 
-                    //// add 'G'
-                    // Blit( GetICN( ICN::CPANELE, i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
+                    // add 'D'
+                    Blit( GetICN( ICN::CPANEL, 4 + i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
 
-                    //// add 'I'
-                    // Blit( GetICN( ICN::APANELE, 4 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
+                    // add 'O'
+                    Blit( GetICN( ICN::CAMPXTRG, i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
 
-                    //// add 'F'
-                    // Blit( GetICN( ICN::APANELE, 4 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
+                    // add 'N'
+                    Blit( GetICN( ICN::TRADPOST, 17 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
 
-                    //// add 'T'
-                    // Blit( GetICN( ICN::CPANELE, 6 + i ), 59 - i, 21, out, 60 - i, 5, 14, 14 );
+                    // add 'N'
+                    Blit( GetICN( ICN::TRADPOST, 17 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
+
+                    // add 'ER'
+                    Blit( GetICN( ICN::CAMPXTRG, 2 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
                 }
                 break;
 

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -216,9 +216,14 @@ namespace
         }
     }
 
-    uint8_t getButtonFillingColor( const bool isReleasedState )
+    uint8_t getButtonFillingColor( const bool isReleasedState, const bool isGoodInterface = true )
     {
-        return isReleasedState ? fheroes2::GetColorId( 216, 184, 152 ) : fheroes2::GetColorId( 184, 136, 96 );
+        if ( isGoodInterface ) {
+            return isReleasedState ? fheroes2::GetColorId( 216, 184, 152 ) : fheroes2::GetColorId( 184, 136, 96 );
+        }
+        else {
+            return isReleasedState ? fheroes2::GetColorId( 180, 180, 180 ) : fheroes2::GetColorId( 144, 144, 144 );
+        }
     }
 }
 
@@ -459,7 +464,8 @@ namespace fheroes2
                     out = GetICN( ICN::TRADPOSE, 17 + i );
 
                     // clean the button
-                    Blit( GetICN( ICN::SYSTEME, 11 + i ), 10, 6, out, 6, 4, 72, 15 );
+                    /*Blit( GetICN( ICN::SYSTEME, 11 + i ), 10, 6, out, 6, 4, 72, 15 );*/
+                    Fill( out, 33, 5, 31, 16, getButtonFillingColor( i == 0, false ) );
 
                     //// add 'G'
                     // Blit( GetICN( ICN::CPANELE, i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -429,6 +429,52 @@ namespace fheroes2
                 }
                 break;
 
+            case ICN::BTNGIFT_GOOD:
+                _icnVsSprite[id].resize( 2 );
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
+                    out = GetICN( ICN::TRADPOST, 17 + i );
+
+                    // clean the button
+                    Fill( out, 33, 5, 31, 16, getButtonFillingColor( i == 0 ) );
+                    /*Blit( GetICN( ICN::SYSTEM, 11 + i ), 10, 6, out, 6, 4, 72, 15 );*/
+
+                    //// add 'G'
+                    // Blit( GetICN( ICN::CPANEL, i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
+
+                    //// add 'I'
+                    // Blit( GetICN( ICN::APANEL, 4 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
+
+                    //// add 'F'
+                    // Blit( GetICN( ICN::APANEL, 4 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
+
+                    //// add 'T'
+                    // Blit( GetICN( ICN::CPANEL, 6 + i ), 59 - i, 21, out, 60 - i, 5, 14, 14 );
+                }
+                break;
+            case ICN::BTNGIFT_EVIL:
+                _icnVsSprite[id].resize( 2 );
+                for ( uint32_t i = 0; i < 2; ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
+                    out = GetICN( ICN::TRADPOSE, 17 + i );
+
+                    // clean the button
+                    Blit( GetICN( ICN::SYSTEME, 11 + i ), 10, 6, out, 6, 4, 72, 15 );
+
+                    //// add 'G'
+                    // Blit( GetICN( ICN::CPANELE, i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
+
+                    //// add 'I'
+                    // Blit( GetICN( ICN::APANELE, 4 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
+
+                    //// add 'F'
+                    // Blit( GetICN( ICN::APANELE, 4 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
+
+                    //// add 'T'
+                    // Blit( GetICN( ICN::CPANELE, 6 + i ), 59 - i, 21, out, 60 - i, 5, 14, 14 );
+                }
+                break;
+
             default:
                 // You're calling this function for non-specified ICN id. Check your logic!
                 assert( 0 );

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -333,7 +333,7 @@ namespace fheroes2
                     Blit( GetICN( ICN::CPANEL, 6 + i ), 59 - i, 21, out, 60 - i, 5, 14, 14 );
                 }
                 break;
-             case ICN::BTNGIFT_EVIL:
+            case ICN::BTNGIFT_EVIL:
                 _icnVsSprite[id].resize( 2 );
                 for ( uint32_t i = 0; i < 2; ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
@@ -445,19 +445,19 @@ namespace fheroes2
                     /*Blit( GetICN( ICN::SYSTEM, 11 + i ), 10, 6, out, 6, 4, 72, 15 );*/
 
                     // add 'D'
-                     Blit( GetICN( ICN::CPANEL, 4 + i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
+                    Blit( GetICN( ICN::CPANEL, 4 + i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
 
                     // add 'O'
-                     Blit( GetICN( ICN::CAMPXTRG, i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
+                    Blit( GetICN( ICN::CAMPXTRG, i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
 
                     // add 'N'
-                     Blit( GetICN( ICN::TRADPOST, 17 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
+                    Blit( GetICN( ICN::TRADPOST, 17 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
 
                     // add 'N'
-                     Blit( GetICN( ICN::TRADPOST, 17 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
+                    Blit( GetICN( ICN::TRADPOST, 17 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
 
                     // add 'ER'
-                     Blit( GetICN( ICN::CAMPXTRG, 2 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
+                    Blit( GetICN( ICN::CAMPXTRG, 2 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
                 }
                 break;
             case ICN::BTNGIFT_EVIL:


### PR DESCRIPTION
This addresses the French part of issue: https://github.com/ihhub/fheroes2/issues/5237

This makes a French 'Gift' button with the text 'Donner'. That's the word that was approved by French-speaking users.

The Gift button generated for English had to be moved to `generateEnglishSpecificImages()`, similar to what was done for the Battle Only button.

Added logic to fill with Evil button color to `getButtonFillingColor()`.

The current state of the generated buttons:
![image](https://user-images.githubusercontent.com/12501091/165041971-ab15abdd-2f91-416f-8c6b-e85468d0a79f.png)

I had to refer to some different ICNs for the Evil button generation than than the Good, because the corresponding ones I used for the Good button didn't have the same background color as other evil ICNs (ex. campxtrg and campxtre).

There could be a reason to go back and make the Good button with the counterpart ICNs as the Evil button if this means you could avoid having one switch case for each button and instead choose the ICN according to which interface type is in use. Not doing this would just mean keeping the implementation like it is, I'm just proposing in order to avoid duplication of code whenever there's need to generate both Good and Evil buttons.