### PR TITLE
Fix 1000 and 100000 short values display

### DIFF
--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -80,8 +80,8 @@ std::string StringUpper( std::string str )
 
 std::string GetStringShort( int value )
 {
-    if ( std::abs( value ) > 1000 ) {
-        if ( std::abs( value ) > 1000000 ) {
+    if ( std::abs( value ) >= 1000 ) {
+        if ( std::abs( value ) >= 1000000 ) {
             return std::to_string( value / 1000000 ) + 'M';
         }
 


### PR DESCRIPTION
We were not applying K and M for 1000 and 100000 values.