### PR TITLE
Add double-lined headers to adventure map options.

### DIFF
--- a/src/fheroes2/dialog/dialog_game_settings.cpp
+++ b/src/fheroes2/dialog/dialog_game_settings.cpp
@@ -89,7 +89,7 @@ namespace
 
     void drawExperimentalOptions( const fheroes2::Rect & optionRoi )
     {
-        drawOption( optionRoi, _( "Experimental" ), _( "Settings" ), ICN::SPANEL, 14 );
+        drawOption( optionRoi, _( "Settings" ), _( "Experimental" ), ICN::SPANEL, 14 );
     }
 
     void drawMusicVolumeOptions( const fheroes2::Rect & optionRoi )

--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -48,8 +48,6 @@ namespace
         Close
     };
 
-
-
     void drawOption( const fheroes2::Rect & optionRoi, const fheroes2::Sprite & icon, const std::string & titleText, const std::string & valueText )
     {
         fheroes2::Display & display = fheroes2::Display::instance();
@@ -411,7 +409,7 @@ namespace
 
                 fheroes2::showMessage( header, body, 0 );
             }
-                
+
             else if ( le.MousePressRight( soundVolumeRoi ) ) {
                 fheroes2::Text header( _( "Effects" ), normalYellow );
                 fheroes2::Text body( _( "Toggle foreground sounds level." ), normalWhite );

--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -30,9 +30,9 @@
 #include "localevent.h"
 #include "screen.h"
 #include "settings.h"
-#include "text.h"
 #include "translations.h"
 #include "ui_button.h"
+#include "ui_dialog.h"
 #include "ui_text.h"
 
 #include <cassert>
@@ -402,26 +402,70 @@ namespace
                 saveAutoBattle = true;
             }
 
-            if ( le.MousePressRight( musicVolumeRoi ) )
-                Dialog::Message( _( "Music" ), _( "Toggle ambient music level." ), Font::BIG );
-            else if ( le.MousePressRight( soundVolumeRoi ) )
-                Dialog::Message( _( "Effects" ), _( "Toggle foreground sounds level." ), Font::BIG );
-            else if ( le.MousePressRight( musicTypeRoi ) )
-                Dialog::Message( _( "Music Type" ), _( "Change the type of music." ), Font::BIG );
-            else if ( le.MousePressRight( heroSpeedRoi ) )
-                Dialog::Message( _( "Hero Speed" ), _( "Change the speed at which your heroes move on the main screen." ), Font::BIG );
-            else if ( le.MousePressRight( aiSpeedRoi ) )
-                Dialog::Message( _( "Enemy Speed" ), _( "Sets the speed that A.I. heroes move at.  You can also elect not to view A.I. movement at all." ), Font::BIG );
-            else if ( le.MousePressRight( scrollSpeedRoi ) )
-                Dialog::Message( _( "Scroll Speed" ), _( "Sets the speed at which you scroll the window." ), Font::BIG );
-            else if ( le.MousePressRight( interfaceTypeRoi ) )
-                Dialog::Message( _( "Interface Type" ), _( "Toggle the type of interface you want to use." ), Font::BIG );
-            else if ( le.MousePressRight( interfaceStateRoi ) )
-                Dialog::Message( _( "Interface" ), _( "Toggle interface visibility." ), Font::BIG );
-            else if ( le.MousePressRight( battleResolveRoi ) )
-                Dialog::Message( _( "Battles" ), _( "Toggle instant battle mode." ), Font::BIG );
-            else if ( le.MousePressRight( buttonOkay.area() ) )
-                Dialog::Message( _( "Okay" ), _( "Exit this menu." ), Font::BIG );
+            const fheroes2::FontType normalYellow = fheroes2::FontType::normalYellow();
+            const fheroes2::FontType normalWhite = fheroes2::FontType::normalWhite();
+
+            if ( le.MousePressRight( musicVolumeRoi ) ) {
+                fheroes2::Text header( _( "Music" ), normalYellow );
+                fheroes2::Text body( _( "Toggle ambient music level." ), normalWhite );
+
+                fheroes2::showMessage( header, body, 0 );
+            }
+                
+            else if ( le.MousePressRight( soundVolumeRoi ) ) {
+                fheroes2::Text header( _( "Effects" ), normalYellow );
+                fheroes2::Text body( _( "Toggle foreground sounds level." ), normalWhite );
+
+                fheroes2::showMessage( header, body, 0 );
+            }
+            else if ( le.MousePressRight( musicTypeRoi ) ) {
+                fheroes2::Text header( _( "Music Type" ), normalYellow );
+                fheroes2::Text body( _( "Change the type of music." ), normalWhite );
+
+                fheroes2::showMessage( header, body, 0 );
+            }
+            else if ( le.MousePressRight( heroSpeedRoi ) ) {
+                fheroes2::Text header( _( "Hero Speed" ), normalYellow );
+                fheroes2::Text body( _( "Change the speed at which your heroes move on the main screen." ), normalWhite );
+
+                fheroes2::showMessage( header, body, 0 );
+            }
+            else if ( le.MousePressRight( aiSpeedRoi ) ) {
+                fheroes2::Text header( _( "Enemy Speed" ), normalYellow );
+                fheroes2::Text body( _( "Sets the speed that A.I. heroes move at.  You can also elect not to view A.I. movement at all." ), normalWhite );
+
+                fheroes2::showMessage( header, body, 0 );
+            }
+            else if ( le.MousePressRight( scrollSpeedRoi ) ) {
+                fheroes2::Text header( _( "Scroll Speed" ), normalYellow );
+                fheroes2::Text body( _( "Sets the speed at which you scroll the window." ), normalWhite );
+
+                fheroes2::showMessage( header, body, 0 );
+            }
+            else if ( le.MousePressRight( interfaceTypeRoi ) ) {
+                fheroes2::Text header( _( "Interface Type" ), normalYellow );
+                fheroes2::Text body( _( "Toggle the type of interface you want to use." ), normalWhite );
+
+                fheroes2::showMessage( header, body, 0 );
+            }
+            else if ( le.MousePressRight( interfaceStateRoi ) ) {
+                fheroes2::Text header( _( "Interface" ), normalYellow );
+                fheroes2::Text body( _( "Toggle interface visibility." ), normalWhite );
+
+                fheroes2::showMessage( header, body, 0 );
+            }
+            else if ( le.MousePressRight( battleResolveRoi ) ) {
+                fheroes2::Text header( _( "Battles" ), normalYellow );
+                fheroes2::Text body( _( "Toggle instant battle mode." ), normalWhite );
+
+                fheroes2::showMessage( header, body, 0 );
+            }
+            else if ( le.MousePressRight( buttonOkay.area() ) ) {
+                fheroes2::Text header( _( "Okay" ), normalYellow );
+                fheroes2::Text body( _( "Exit this menu." ), normalWhite );
+
+                fheroes2::showMessage( header, body, 0 );
+            }
 
             if ( saveMusicVolume || saveSoundVolume || saveMusicType || saveHeroSpeed || saveAISpeed || saveScrollSpeed || saveAutoBattle ) {
                 // redraw

--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -33,6 +33,7 @@
 #include "text.h"
 #include "translations.h"
 #include "ui_button.h"
+#include "ui_text.h"
 
 #include <cassert>
 
@@ -47,18 +48,23 @@ namespace
         Close
     };
 
-    const int textOffset = 2;
 
-    void drawOption( const fheroes2::Rect & optionRoi, const fheroes2::Sprite & icon, const std::string & title, const std::string & value )
+
+    void drawOption( const fheroes2::Rect & optionRoi, const fheroes2::Sprite & icon, const std::string & titleText, const std::string & valueText )
     {
         fheroes2::Display & display = fheroes2::Display::instance();
 
-        fheroes2::Blit( icon, display, optionRoi.x, optionRoi.y );
-        Text text( title, Font::SMALL );
-        text.Blit( optionRoi.x + ( optionRoi.width - text.w() ) / 2, optionRoi.y - text.h() - textOffset );
+        const fheroes2::FontType smallWhite = fheroes2::FontType::smallWhite();
 
-        text.Set( value );
-        text.Blit( optionRoi.x + ( optionRoi.width - text.w() ) / 2, optionRoi.y + optionRoi.height + textOffset );
+        const fheroes2::Text title( titleText, smallWhite );
+        const fheroes2::Text value( valueText, smallWhite );
+
+        const int16_t textMaxWidth = 87;
+
+        title.draw( optionRoi.x - 12, optionRoi.y - title.height( textMaxWidth ), textMaxWidth, display );
+        value.draw( optionRoi.x + ( optionRoi.width - value.width() ) / 2, optionRoi.y + optionRoi.height + 4, display );
+
+        fheroes2::Blit( icon, display, optionRoi.x, optionRoi.y );
     }
 
     void drawDialog( const std::vector<fheroes2::Rect> & rects )


### PR DESCRIPTION
This addresses one part of issue: https://github.com/ihhub/fheroes2/issues/5244

![image](https://user-images.githubusercontent.com/12501091/165954632-c05fe591-3e26-4304-beaa-e179a0ee82da.png)

This also swaps position of "Settings" and "Experimental" in the main menu's system options since that fits in with the other headers: Language and Resolution.

![image](https://user-images.githubusercontent.com/12501091/165955195-37ca696f-ac57-46e5-8eae-3e8da3838c04.png)



Replaced use of `text.h` with `ui_text.h`.