### PR TITLE
Remove Large old Text usage

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -2068,9 +2068,8 @@ namespace fheroes2
                 return GetICN( ICN::FONT, character - 0x20 );
             case Font::SMALL:
                 return GetICN( ICN::SMALFONT, character - 0x20 );
-            case Font::WHITE_LARGE:
-                return GetICN( ICN::WHITE_LARGE_FONT, character - 0x20 );
             default:
+                assert( 0 );
                 break;
             }
 
@@ -2083,13 +2082,13 @@ namespace fheroes2
             case Font::BIG:
             case Font::GRAY_BIG:
             case Font::YELLOW_BIG:
-            case Font::WHITE_LARGE:
                 return static_cast<uint32_t>( GetMaximumICNIndex( ICN::FONT ) ) + 0x20 - 1;
             case Font::SMALL:
             case Font::GRAY_SMALL:
             case Font::YELLOW_SMALL:
                 return static_cast<uint32_t>( GetMaximumICNIndex( ICN::SMALFONT ) ) + 0x20 - 1;
             default:
+                assert( 0 );
                 return 0;
             }
         }

--- a/src/fheroes2/game/game_logo.cpp
+++ b/src/fheroes2/game/game_logo.cpp
@@ -22,8 +22,8 @@
 #include "game_delays.h"
 #include "localevent.h"
 #include "screen.h"
-#include "text.h"
 #include "translations.h"
+#include "ui_text.h"
 
 void fheroes2::showTeamInfo()
 {
@@ -32,12 +32,15 @@ void fheroes2::showTeamInfo()
 
     Display & display = Display::instance();
 
-    TextBox text( _( "fheroes2 Resurrection Team presents" ), Font::WHITE_LARGE, 500 );
-    const Rect roi( ( display.width() - text.w() ) / 2, ( display.height() - text.h() ) / 2, text.w(), text.h() );
+    Text text( _( "fheroes2 Resurrection Team presents" ), FontType{ FontSize::LARGE, FontColor::WHITE } );
+    const int32_t correctedTextWidth = text.width( 500 );
+
+    const Rect roi{ ( display.width() - correctedTextWidth ) / 2, ( display.height() - text.height( correctedTextWidth ) ) / 2, text.width(),
+                    text.height( correctedTextWidth ) };
 
     Image textImage( roi.width, roi.height );
     textImage.fill( 0 );
-    text.Blit( 0, 0, textImage );
+    text.draw( 0, 0, correctedTextWidth, textImage );
 
     // First frame must be fully rendered.
     display.fill( 0 );

--- a/src/fheroes2/gui/text.cpp
+++ b/src/fheroes2/gui/text.cpp
@@ -33,11 +33,6 @@ namespace
     {
         return font == Font::SMALL || font == Font::YELLOW_SMALL || font == Font::GRAY_SMALL;
     }
-
-    bool isLargeFont( int font )
-    {
-        return font == Font::WHITE_LARGE;
-    }
 }
 
 class TextAscii
@@ -96,8 +91,6 @@ int TextAscii::charWidth( const uint8_t character, const int ft )
     if ( character < 0x21 || character > fheroes2::AGG::ASCIILastSupportedCharacter( ft ) ) {
         if ( isSmallFont( ft ) )
             return 4;
-        else if ( isLargeFont( ft ) )
-            return 12;
         else
             return 6;
     }
@@ -110,8 +103,6 @@ int TextAscii::fontHeight( const int f )
 {
     if ( isSmallFont( f ) )
         return 8 + 2 + 1;
-    else if ( isLargeFont( f ) )
-        return 26 + 6 + 1;
     else
         return 13 + 3 + 1;
 }
@@ -359,11 +350,6 @@ void TextBox::Set( const std::string & msg, int ft, uint32_t width_ )
     }
 }
 
-void TextBox::SetAlign( int f )
-{
-    align = f;
-}
-
 void TextBox::Append( const std::string & msg, int ft, u32 width_ )
 {
     uint32_t www = 0;
@@ -494,21 +480,6 @@ void TextSprite::SetFont( int ft )
 void TextSprite::SetPos( s32 ax, s32 ay )
 {
     _restorer.update( ax, ay, gw, gh + 5 );
-}
-
-int TextSprite::w( void ) const
-{
-    return gw;
-}
-
-int TextSprite::h( void ) const
-{
-    return gh + 5;
-}
-
-bool TextSprite::isShow( void ) const
-{
-    return !hide;
 }
 
 fheroes2::Rect TextSprite::GetRect( void ) const

--- a/src/fheroes2/gui/text.h
+++ b/src/fheroes2/gui/text.h
@@ -39,8 +39,7 @@ namespace Font
         YELLOW_BIG = 0x04,
         YELLOW_SMALL = 0x08,
         GRAY_BIG = 0x10,
-        GRAY_SMALL = 0x20,
-        WHITE_LARGE = 0x40
+        GRAY_SMALL = 0x20
     };
 }
 enum
@@ -70,7 +69,8 @@ public:
     void Set( int );
 
     void Clear( void );
-    size_t Size( void ) const;
+
+    size_t Size() const;
 
     int w( void ) const
     {
@@ -110,10 +110,20 @@ public:
     void Show( void );
     void Hide( void );
 
-    bool isShow( void ) const;
+    bool isShow() const
+    {
+        return !hide;
+    }
 
-    int w() const;
-    int h() const;
+    int w() const
+    {
+        return gw;
+    }
+
+    int h() const
+    {
+        return gh + 5;
+    }
 
     fheroes2::Rect GetRect( void ) const;
 
@@ -129,7 +139,11 @@ public:
     TextBox( const std::string &, int, const fheroes2::Rect & );
 
     void Set( const std::string &, int, uint32_t width_ );
-    void SetAlign( int type );
+
+    void SetAlign( int type )
+    {
+        align = type;
+    }
 
     int32_t w() const
     {

--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -400,6 +400,25 @@ namespace fheroes2
         return getFontHeight( _fontType.size );
     }
 
+    int32_t Text::width( const int32_t maxWidth ) const
+    {
+        if ( _text.empty() ) {
+            return 0;
+        }
+
+        const int32_t fontHeight = getFontHeight( _fontType.size );
+
+        std::deque<Point> offsets;
+        getMultiRowInfo( reinterpret_cast<const uint8_t *>( _text.data() ), static_cast<int32_t>( _text.size() ), maxWidth, _fontType, fontHeight, offsets );
+
+        int32_t maxRowWidth = offsets.front().x;
+        for ( const Point & point : offsets ) {
+            maxRowWidth = std::max( maxRowWidth, point.x );
+        }
+
+        return maxRowWidth;
+    }
+
     int32_t Text::height( const int32_t maxWidth ) const
     {
         if ( _text.empty() ) {
@@ -545,6 +564,24 @@ namespace fheroes2
         }
 
         return maxHeight;
+    }
+
+    int32_t MultiFontText::width( const int32_t maxWidth ) const
+    {
+        const int32_t maxFontHeight = height();
+
+        std::deque<Point> offsets;
+        for ( const Text & text : _texts ) {
+            getMultiRowInfo( reinterpret_cast<const uint8_t *>( text._text.data() ), static_cast<int32_t>( text._text.size() ), maxWidth, text._fontType, maxFontHeight,
+                             offsets );
+        }
+
+        int32_t maxRowWidth = offsets.front().x;
+        for ( const Point & point : offsets ) {
+            maxRowWidth = std::max( maxRowWidth, point.x );
+        }
+
+        return maxRowWidth;
     }
 
     int32_t MultiFontText::height( const int32_t maxWidth ) const

--- a/src/fheroes2/gui/ui_text.h
+++ b/src/fheroes2/gui/ui_text.h
@@ -93,6 +93,9 @@ namespace fheroes2
         // Returns height of a text as a single-line text only.
         virtual int32_t height() const = 0;
 
+        // Returns width of a text as a multi-line text limited by maximum width of a line.
+        virtual int32_t width( const int32_t maxWidth ) const = 0;
+
         // Returns height of a text as a multi-line text limited by width of a line.
         virtual int32_t height( const int32_t maxWidth ) const = 0;
 
@@ -130,7 +133,9 @@ namespace fheroes2
         int32_t width() const override;
         int32_t height() const override;
 
+        int32_t width( const int32_t maxWidth ) const override;
         int32_t height( const int32_t maxWidth ) const override;
+
         int32_t rows( const int32_t maxWidth ) const override;
 
         void draw( const int32_t x, const int32_t y, Image & output ) const override;
@@ -161,7 +166,9 @@ namespace fheroes2
         int32_t width() const override;
         int32_t height() const override;
 
+        int32_t width( const int32_t maxWidth ) const override;
         int32_t height( const int32_t maxWidth ) const override;
+
         int32_t rows( const int32_t maxWidth ) const override;
 
         void draw( const int32_t x, const int32_t y, Image & output ) const override;


### PR DESCRIPTION
We need to transit to the new fheroes2::Text classes. Right now we are mixing both old and new text classes which confuses many developers.