### PR TITLE
Properly extract animations from the GOG distribution of HoMM2 for Windows

### DIFF
--- a/script/homm2/extract_homm2_resources.ps1
+++ b/script/homm2/extract_homm2_resources.ps1
@@ -108,12 +108,12 @@ try {
     } else {
         $shell = New-Object -ComObject "Shell.Application"
 
-        foreach ($srcDir in @("ANIM", "DATA", "MAPS", "MUSIC")) {
+        foreach ($srcDir in @("HEROES2\ANIM", "ANIM", "DATA", "MAPS", "MUSIC")) {
             if (-Not (Test-Path -Path "$homm2Path\$srcDir" -PathType Container)) {
                 continue
             }
 
-            $destDir = $srcDir.ToLower()
+            $destDir = (Split-Path $srcDir -Leaf).ToLower()
 
             if (-Not (Test-Path -Path "$destPath\$destDir" -PathType Container)) {
                 [void](New-Item -Path "$destPath\$destDir" -ItemType "directory")

--- a/script/homm2/extract_homm2_resources.sh
+++ b/script/homm2/extract_homm2_resources.sh
@@ -53,7 +53,7 @@ else
     read -e -p "Please enter the full path to the HoMM2 directory (e.g. /home/user/GOG Games/HoMM 2 Gold): " HOMM2_PATH
 fi
 
-if [[ ! -f "$HOMM2_PATH/HEROES2.EXE" || ! -d "$HOMM2_PATH/DATA" || ! -d "$HOMM2_PATH/MAPS" ]]; then
+if [[ ( ! -f "$HOMM2_PATH/HEROES2.EXE" && ! -f "$HOMM2_PATH/HEROES2W.EXE" ) || ! -d "$HOMM2_PATH/DATA" || ! -d "$HOMM2_PATH/MAPS" ]]; then
     echo_red "Unable to find the HoMM2 directory. Installation aborted."
     exit 1
 fi
@@ -71,10 +71,11 @@ cd "$DEST_PATH"
 [[ ! -d maps ]]  && mkdir maps
 [[ ! -d music ]] && mkdir music
 
-[[ -d "$HOMM2_PATH/ANIM" ]]  && cp -r "$HOMM2_PATH/ANIM"/*  anim
-[[ -d "$HOMM2_PATH/DATA" ]]  && cp -r "$HOMM2_PATH/DATA"/*  data
-[[ -d "$HOMM2_PATH/MAPS" ]]  && cp -r "$HOMM2_PATH/MAPS"/*  maps
-[[ -d "$HOMM2_PATH/MUSIC" ]] && cp -r "$HOMM2_PATH/MUSIC"/* music
+[[ -d "$HOMM2_PATH/HEROES2/ANIM" ]] && cp -r "$HOMM2_PATH/HEROES2/ANIM"/* anim
+[[ -d "$HOMM2_PATH/ANIM" ]]         && cp -r "$HOMM2_PATH/ANIM"/*         anim
+[[ -d "$HOMM2_PATH/DATA" ]]         && cp -r "$HOMM2_PATH/DATA"/*         data
+[[ -d "$HOMM2_PATH/MAPS" ]]         && cp -r "$HOMM2_PATH/MAPS"/*         maps
+[[ -d "$HOMM2_PATH/MUSIC" ]]        && cp -r "$HOMM2_PATH/MUSIC"/*        music
 
 if [[ ! -f "$HOMM2_PATH/homm2.gog" ]]; then
     exit 0


### PR DESCRIPTION
They reside not in `ANIM` but (for some reason) in `HEROES2/ANIM`.