### PR TITLE
Fix a bug when a lowest resolution appears twice in a list

### DIFF
--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -104,7 +104,7 @@ namespace
 
         const fheroes2::Size lowestResolution = resolutions.back();
         for ( const fheroes2::Size & resolution : possibleResolutions ) {
-            if ( lowestResolution.width < resolution.width || lowestResolution.height < resolution.height ) {
+            if ( lowestResolution.width < resolution.width || lowestResolution.height < resolution.height || resolution == lowestResolution ) {
                 continue;
             }
             resolutions.emplace_back( resolution );


### PR DESCRIPTION
regression from #5349