### PR TITLE
Battle Only mode: always assign a random spell to the Spell Scroll

### DIFF
--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -944,6 +944,10 @@ bool ArtifactsBar::ActionBarLeftMouseSingleClick( Artifact & art )
             }
             else {
                 art = newArtifact;
+
+                if ( art.GetID() == Artifact::SPELL_SCROLL ) {
+                    art.SetSpell( Spell::RANDOM );
+                }
             }
         }
 

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -255,7 +255,7 @@ int Artifact::getArtifactValue() const
     return 0;
 }
 
-void Artifact::SetSpell( int v )
+void Artifact::SetSpell( const int v )
 {
     if ( id != SPELL_SCROLL ) {
         // This method must be called only for Spell Scroll artifact.

--- a/src/fheroes2/resource/artifact.h
+++ b/src/fheroes2/resource/artifact.h
@@ -209,7 +209,7 @@ public:
 
     int getArtifactValue() const;
 
-    // return index sprite objnarti.icn
+    // return index of the sprite from objnarti.icn
     u32 IndexSprite() const
     {
         return id < UNKNOWN ? id * 2 + 1 : 0;
@@ -221,14 +221,13 @@ public:
         return id;
     }
 
-    // reutrn index from artifact.icn
+    // return index from artifact.icn
     u32 IndexSprite64() const
     {
         return id + 1;
     }
 
-    void SetSpell( int );
-
+    void SetSpell( const int v );
     int32_t getSpellId() const;
 
     const char * GetName( void ) const;


### PR DESCRIPTION
To fix the crash caused by an assertion failure.