### PR TITLE
Tidy up and fix gettext plural forms for languages

### DIFF
--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -440,7 +440,7 @@ namespace Translation
             switch ( current->locale ) {
             case LocaleType::LOCALE_AF:
             case LocaleType::LOCALE_BE:
-                return current->ngettext( str, (n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 12 || n % 100 > 14 ) ? 1 : 2) );
+                return current->ngettext( str, ( n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 12 || n % 100 > 14 ) ? 1 : 2 ) );
             case LocaleType::LOCALE_EU:
             case LocaleType::LOCALE_ID:
             case LocaleType::LOCALE_LA:

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -452,6 +452,7 @@ namespace Translation
                 return current->ngettext( str, ( n != 1 ) );
             case LocaleType::LOCALE_DA:
             case LocaleType::LOCALE_DE:
+                return current->ngettext( str, ( n != 1 ) );
             case LocaleType::LOCALE_ES:
                 return current->ngettext( str, ( n != 1 ) );
             case LocaleType::LOCALE_ET:
@@ -483,7 +484,9 @@ namespace Translation
                 return current->ngettext( str, ( n > 1 ) );
             case LocaleType::LOCALE_HR:
             case LocaleType::LOCALE_RU:
+                return current->ngettext( str, ( n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 ) );
             case LocaleType::LOCALE_LT:
+                return current->ngettext( str, ( n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 ) );
             case LocaleType::LOCALE_LV:
                 return current->ngettext( str, ( n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 ) );
             case LocaleType::LOCALE_MK:

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -439,33 +439,31 @@ namespace Translation
         if ( current )
             switch ( current->locale ) {
             case LocaleType::LOCALE_AF:
-            case LocaleType::LOCALE_BE:
-                return current->ngettext( str, ( n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 12 || n % 100 > 14 ) ? 1 : 2 ) );
-            case LocaleType::LOCALE_EU:
-            case LocaleType::LOCALE_ID:
-            case LocaleType::LOCALE_LA:
-            case LocaleType::LOCALE_TR:
-                return current->ngettext( str, ( n != 1 ) );
-            case LocaleType::LOCALE_AR:
-                return current->ngettext( str, ( n == 0 ? 0 : n == 1 ? 1 : n == 2 ? 2 : n % 100 >= 3 && n % 100 <= 10 ? 3 : n % 100 >= 11 && n % 100 <= 99 ? 4 : 5 ) );
             case LocaleType::LOCALE_BG:
-                return current->ngettext( str, ( n != 1 ) );
             case LocaleType::LOCALE_DA:
             case LocaleType::LOCALE_DE:
-                return current->ngettext( str, ( n != 1 ) );
             case LocaleType::LOCALE_ES:
-                return current->ngettext( str, ( n != 1 ) );
             case LocaleType::LOCALE_ET:
+            case LocaleType::LOCALE_EU:
             case LocaleType::LOCALE_FI:
             case LocaleType::LOCALE_GL:
             case LocaleType::LOCALE_HE:
+            case LocaleType::LOCALE_ID:
             case LocaleType::LOCALE_IT:
-                return current->ngettext( str, ( n != 1 ) );
+            case LocaleType::LOCALE_LA:
+            case LocaleType::LOCALE_NB:
             case LocaleType::LOCALE_NL:
+            case LocaleType::LOCALE_SV:
+            case LocaleType::LOCALE_TR:
+                return current->ngettext( str, ( n != 1 ) );
+            case LocaleType::LOCALE_EL:
+            case LocaleType::LOCALE_FR:
+            case LocaleType::LOCALE_PT:
+                return current->ngettext( str, ( n > 1 ) );
+            case LocaleType::LOCALE_AR:
+                return current->ngettext( str, ( n == 0 ? 0 : n == 1 ? 1 : n == 2 ? 2 : n % 100 >= 3 && n % 100 <= 10 ? 3 : n % 100 >= 11 && n % 100 <= 99 ? 4 : 5 ) );
             case LocaleType::LOCALE_RO:
                 return current->ngettext( str, ( n == 1 ? 0 : n == 0 || ( n != 1 && n % 100 >= 1 && n % 100 <= 19 ) ? 1 : 2 ) );
-            case LocaleType::LOCALE_SV:
-                return current->ngettext( str, ( n != 1 ) );
             case LocaleType::LOCALE_SK:
                 return current->ngettext( str, ( ( n == 1 ) ? 1 : ( n >= 2 && n <= 4 ) ? 2 : 0 ) );
             case LocaleType::LOCALE_SL:
@@ -477,24 +475,17 @@ namespace Translation
                                                                                                                    : 2 ) );
             case LocaleType::LOCALE_CS:
                 return current->ngettext( str, ( ( n == 1 ) ? 0 : ( n >= 2 && n <= 4 ) ? 1 : 2 ) );
-            case LocaleType::LOCALE_EL:
-            case LocaleType::LOCALE_FR:
-                return current->ngettext( str, ( n > 1 ) );
-            case LocaleType::LOCALE_PT:
-                return current->ngettext( str, ( n > 1 ) );
             case LocaleType::LOCALE_HR:
+            case LocaleType::LOCALE_LV:
             case LocaleType::LOCALE_RU:
                 return current->ngettext( str, ( n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 ) );
             case LocaleType::LOCALE_LT:
                 return current->ngettext( str, ( n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 ) );
-            case LocaleType::LOCALE_LV:
-                return current->ngettext( str, ( n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 ) );
             case LocaleType::LOCALE_MK:
                 return current->ngettext( str, ( n == 1 || n % 10 == 1 ? 0 : 1 ) );
-            case LocaleType::LOCALE_NB:
-                return current->ngettext( str, ( n != 1 ) );
             case LocaleType::LOCALE_PL:
                 return current->ngettext( str, ( n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 ) );
+            case LocaleType::LOCALE_BE:
             case LocaleType::LOCALE_UK:
                 return current->ngettext( str, ( n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 12 || n % 100 > 14 ) ? 1 : 2 ) );
             default:

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -440,24 +440,26 @@ namespace Translation
             switch ( current->locale ) {
             case LocaleType::LOCALE_AF:
             case LocaleType::LOCALE_BE:
-                return current->ngettext( str, n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 12 || n % 100 > 14 ) ? 1 : 2 );
+                return current->ngettext( str, (n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 12 || n % 100 > 14 ) ? 1 : 2) );
             case LocaleType::LOCALE_EU:
             case LocaleType::LOCALE_ID:
             case LocaleType::LOCALE_LA:
             case LocaleType::LOCALE_TR:
-                return current->ngettext( str, 0 );
+                return current->ngettext( str, ( n != 1 ) );
             case LocaleType::LOCALE_AR:
                 return current->ngettext( str, ( n == 0 ? 0 : n == 1 ? 1 : n == 2 ? 2 : n % 100 >= 3 && n % 100 <= 10 ? 3 : n % 100 >= 11 && n % 100 <= 99 ? 4 : 5 ) );
             case LocaleType::LOCALE_BG:
+                return current->ngettext( str, ( n != 1 ) );
             case LocaleType::LOCALE_DA:
             case LocaleType::LOCALE_DE:
             case LocaleType::LOCALE_ES:
+                return current->ngettext( str, ( n != 1 ) );
             case LocaleType::LOCALE_ET:
             case LocaleType::LOCALE_FI:
             case LocaleType::LOCALE_GL:
             case LocaleType::LOCALE_HE:
             case LocaleType::LOCALE_IT:
-                return current->ngettext( str, 0 );
+                return current->ngettext( str, ( n != 1 ) );
             case LocaleType::LOCALE_NL:
             case LocaleType::LOCALE_RO:
                 return current->ngettext( str, ( n == 1 ? 0 : n == 0 || ( n != 1 && n % 100 >= 1 && n % 100 <= 19 ) ? 1 : 2 ) );
@@ -476,6 +478,7 @@ namespace Translation
                 return current->ngettext( str, ( ( n == 1 ) ? 0 : ( n >= 2 && n <= 4 ) ? 1 : 2 ) );
             case LocaleType::LOCALE_EL:
             case LocaleType::LOCALE_FR:
+                return current->ngettext( str, ( n > 1 ) );
             case LocaleType::LOCALE_PT:
                 return current->ngettext( str, ( n > 1 ) );
             case LocaleType::LOCALE_HR:


### PR DESCRIPTION
This tidies up the Switch statement for gettext plural forms and reverts some changes to the order of cases. In other words I made the various locales use the same plural form as before, but I only checked the locales we currently have translation files for to see what plural expression they use.

Couldn't find a Locale for Hungarian even though a hungarian .po exists with quite a few translated strings.

These are used in cases like these for Russian so that the correct plural form is used:
![image](https://user-images.githubusercontent.com/12501091/167239419-9ec5d1bf-df0b-4b51-8e2d-96070e8a674b.png)

Before this the Russian translation was using the Lithaunian plural form expression, which is not the same for Russian. Not sure if this was intentional.