### PR TITLE
GitHub Actions: update translation files on push

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -38,9 +38,9 @@ jobs:
         git diff -U0 HEAD^ | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
     - name: Save PR metadata
       run: |
-        echo ${{ github.event.number }} > clang-tidy-result/pr-id.txt
-        echo ${{ github.event.pull_request.head.repo.full_name }} > clang-tidy-result/pr-head-repo.txt
-        echo ${{ github.event.pull_request.head.ref }} > clang-tidy-result/pr-head-ref.txt
+        echo "${{ github.event.number }}" > clang-tidy-result/pr-id.txt
+        echo "${{ github.event.pull_request.head.repo.full_name }}" > clang-tidy-result/pr-head-repo.txt
+        echo "${{ github.event.pull_request.head.ref }}" > clang-tidy-result/pr-head-ref.txt
     - uses: actions/upload-artifact@v2
       with:
         name: clang-tidy-result

--- a/.github/workflows/clang_tidy_comments.yml
+++ b/.github/workflows/clang_tidy_comments.yml
@@ -36,13 +36,13 @@ jobs:
       run: |
         mkdir clang-tidy-result
         unzip clang-tidy-result.zip -d clang-tidy-result
-        echo "pr_id=$(cat clang-tidy-result/pr-id.txt)" >> "$GITHUB_ENV"
-        echo "pr_head_repo=$(cat clang-tidy-result/pr-head-repo.txt)" >> "$GITHUB_ENV"
-        echo "pr_head_ref=$(cat clang-tidy-result/pr-head-ref.txt)" >> "$GITHUB_ENV"
+        echo "PR_ID=$(cat clang-tidy-result/pr-id.txt)" >> "$GITHUB_ENV"
+        echo "PR_HEAD_REPO=$(cat clang-tidy-result/pr-head-repo.txt)" >> "$GITHUB_ENV"
+        echo "PR_HEAD_REF=$(cat clang-tidy-result/pr-head-ref.txt)" >> "$GITHUB_ENV"
     - uses: actions/checkout@v2
       with:
-        repository: ${{ env.pr_head_repo }}
-        ref: ${{ env.pr_head_ref }}
+        repository: ${{ env.PR_HEAD_REPO }}
+        ref: ${{ env.PR_HEAD_REF }}
         persist-credentials: false
     - name: Redownload analysis results
       uses: actions/github-script@v3
@@ -72,4 +72,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         clang_tidy_fixes: clang-tidy-result/fixes.yml
-        pull_request_id: ${{ env.pr_id }}
+        pull_request_id: ${{ env.PR_ID }}

--- a/.github/workflows/clang_tidy_comments.yml
+++ b/.github/workflows/clang_tidy_comments.yml
@@ -1,4 +1,4 @@
-name: Clang-Tidy Comments
+name: Clang-Tidy comments
 
 on:
   workflow_run:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   comment:
-    name: Clang-Tidy Comments
+    name: Clang-Tidy comments
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,3 +22,10 @@ jobs:
     uses: ./.github/workflows/sonarcloud.yml
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  translation:
+    name: Translation update
+    needs:
+    - make
+    - msvc
+    uses: ./.github/workflows/translation_update.yml

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -52,7 +52,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.data.number,
-              assignees: [context.repo.owner],
+              assignees: ["${{ github.actor }}"],
           });
           let labelsPromise = github.rest.issues.addLabels({
               owner: context.repo.owner,

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -21,9 +21,9 @@ jobs:
     - name: Generate POT
       run: |
         make -C src/dist -j 2 pot
-    - name: Generate translations
+    - name: Merge PO with POT
       run: |
-        make -C files/lang -j 2
+        make -C files/lang -j 2 merge
     - name: Commit changes
       run: |
         set -o pipefail

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -26,6 +26,7 @@ jobs:
         make -C files/lang -j 2
     - name: Commit changes
       run: |
+        set -o pipefail
         git diff --name-only -z -- files/lang/*.po \
         | xargs -r0 bash -c 'set -e; for NAME in "$@"; do if [[ "$(git diff "-I^\"POT-Creation-Date:[^\"]*\"$" -- "$NAME")" != "" ]]; then git add -- "$NAME"; fi; done' dummy
         git commit -m "Update translation files" || true

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -8,6 +8,7 @@ jobs:
     name: Translation update
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: ${{ github.repository == 'ihhub/fheroes2' && ( github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) ) }}
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -18,6 +19,11 @@ jobs:
       run: |
         git config user.name "GitHub Actions Bot"
         git config user.email "action@github.com"
+    - name: Create PR branch
+      run: |
+        PR_BRANCH="translation-update-$(uuidgen)"
+        git switch -c "$PR_BRANCH"
+        echo "PR_BRANCH=$PR_BRANCH" >> "$GITHUB_ENV"
     - name: Generate POT
       run: |
         make -C src/dist -j 2 pot
@@ -29,5 +35,28 @@ jobs:
         set -o pipefail
         git diff --name-only -z -- files/lang/*.po \
         | xargs -r0 bash -c 'set -e; for NAME in "$@"; do if [[ "$(git diff "-I^\"POT-Creation-Date:[^\"]*\"$" -- "$NAME")" != "" ]]; then git add -- "$NAME"; fi; done' dummy
-        git commit -m "Update translation files" || true
-        git push origin HEAD
+        if git commit -m "Update translation files"; then git push origin HEAD; echo "CREATE_PR=YES" >> "$GITHUB_ENV"; fi
+    - name: Create PR
+      if: ${{ env.CREATE_PR == 'YES' }}
+      uses: actions/github-script@v6
+      with:
+        script: |
+          let pr = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: "Update translation files",
+              head: "${{ env.PR_BRANCH }}",
+              base: "${{ github.ref }}",
+          });
+          let assignees = await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.data.number,
+              assignees: [context.repo.owner],
+          });
+          let labels = await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.data.number,
+              labels: ["improvement", "translation"],
+          });

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -1,0 +1,31 @@
+name: Translation update
+
+on:
+  workflow_call:
+
+jobs:
+  check:
+    name: Translation update
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        sudo apt-get -y update
+        sudo apt-get -y install gettext
+    - name: Setup Git
+      run: |
+        git config user.name "GitHub Actions Bot"
+        git config user.email "action@github.com"
+    - name: Generate POT
+      run: |
+        make -C src/dist -j 2 pot
+    - name: Generate translations
+      run: |
+        make -C files/lang -j 2
+    - name: Commit changes
+      run: |
+        git add src/dist/fheroes2.pot files/lang/*.po
+        git commit -m "Update translation files" || true
+        git push origin "$GITHUB_REF"

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -48,15 +48,16 @@ jobs:
               head: "${{ env.PR_BRANCH }}",
               base: "${{ github.ref }}",
           });
-          let assignees = await github.rest.issues.addAssignees({
+          let assigneesPromise = github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.data.number,
               assignees: [context.repo.owner],
           });
-          let labels = await github.rest.issues.addLabels({
+          let labelsPromise = github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.data.number,
               labels: ["improvement", "translation"],
           });
+          await Promise.all([assigneesPromise, labelsPromise]);

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -26,6 +26,6 @@ jobs:
         make -C files/lang -j 2
     - name: Commit changes
       run: |
-        git add src/dist/fheroes2.pot files/lang/*.po
+        git add files/lang/*.po
         git commit -m "Update translation files" || true
         git push origin "$GITHUB_REF"

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -26,6 +26,7 @@ jobs:
         make -C files/lang -j 2
     - name: Commit changes
       run: |
-        git add files/lang/*.po
+        git diff --name-only -z -- files/lang/*.po \
+        | xargs -r0 bash -c 'set -e; for NAME in "$@"; do if [[ "$(git diff "-I^\"POT-Creation-Date:[^\"]*\"$" -- "$NAME")" != "" ]]; then git add -- "$NAME"; fi; done' dummy
         git commit -m "Update translation files" || true
-        git push origin "$GITHUB_REF"
+        git push origin HEAD

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 *.app
 
 # GNU gettext
+*.pot
 *.pot~
 *.po~
 *.po.tmp

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@
 *.app
 
 # GNU gettext
-*.pot
 *.pot~
 *.po~
 *.po.tmp


### PR DESCRIPTION
close #5383

Instead of forcing poor Windows developers to install Cygwin and `gettext`, deal with `bash`, `make`, and so on, I suggest just automatically regenerate `fheroes2.pot` and `*.po` on each push event. This will increase number of commits in log, though.