### PR TITLE
Add initial Spanish language support and move German, Norwegian and Italian to CP1252 generation function

### DIFF
--- a/files/lang/Makefile
+++ b/files/lang/Makefile
@@ -31,8 +31,8 @@ merge:
 # Spanish: drop accents transliterated with `"` (which breaks translation file format)
 # and transliterate the rest using the es_ES.UTF-8 locale
 es.mo: es.po
-	sed -e 'y/äëïöőüűÄËÏŐÖÜŰ/aeioouuAEIOOUU/' $< > $<.tmp
-	LANG=es_ES.UTF-8 LC_ALL=es_ES.UTF-8 LC_CTYPE=es_ES.UTF-8 iconv -f utf-8 -t ascii//TRANSLIT $<.tmp > $<.2.tmp
+	iconv -f utf-8 -t CP1252 $< > $<.tmp
+	LANG=es.CP1252 LC_ALL=es.CP1252 LC_CTYPE=es.CP1252 sed -e 's/UTF-8/CP1252/' $<.tmp > $<.2.tmp
 	msgfmt $<.2.tmp -o $@
 
 # In French, accented characters are mapped to unused ASCII characters

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1283,6 +1283,9 @@ namespace
         {
             std::vector<fheroes2::Sprite> & font = icnVsSprite[ICN::FONT];
 
+            // Inverted exclamation mark ?. Replaced with normal for now.
+            font[161 - 32] = font[33 - 32];
+
             // Inverted question mark ?. Replaced with normal for now.
             font[191 - 32] = font[63 - 32];
 
@@ -1529,13 +1532,13 @@ namespace
 
             // i with grave accent `.
             font[236 - 32] = font[73];
-            fheroes2::FillTransform( font[236 - 32], 0, 0, font[236 - 32].width(), 2, 1 );
+            fheroes2::FillTransform( font[236 - 32], 0, 0, font[236 - 32].width(), 3, 1 );
             fheroes2::Copy( font[192 - 32], 7, 0, font[236 - 32], 1, 0, 4, 2 );
             updateNormalFontLetterShadow( font[236 - 32] );
 
             // i with acute accent.
             font[237 - 32] = font[73];
-            fheroes2::FillTransform( font[237 - 32], 0, 0, font[237 - 32].width(), 2, 1 );
+            fheroes2::FillTransform( font[237 - 32], 0, 0, font[237 - 32].width(), 3, 1 );
             fheroes2::Copy( font[193 - 32], 7, 0, font[237 - 32], 1, 0, 4, 2 );
             updateNormalFontLetterShadow( font[237 - 32] );
 

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1463,7 +1463,7 @@ namespace
         {
             std::vector<fheroes2::Sprite> & font = icnVsSprite[ICN::FONT];
 
-            // Upside down question mark ?.
+            // Inverted question mark ?. Replaced with normal for now.
             font[191 - 32] = font[63 - 32];
 
             // A with grave accent ` and generate the grave accent for further use.
@@ -1530,6 +1530,9 @@ namespace
             fheroes2::Copy( font[192 - 32], 7, 0, font[204 - 32], 3, 0, 4, 2 );
             updateNormalFontLetterShadow( font[204 - 32] );
 
+            // I with accute accent.
+            font[205 - 32] = font[41];
+
             // N with tilde ~
             font[209 - 32] = font[46];
 
@@ -1540,6 +1543,9 @@ namespace
             font[210 - 32].setPosition( font[47].x(), font[47].y() - 3 );
             fheroes2::Copy( font[192 - 32], 7, 0, font[210 - 32], 6, 0, 4, 2 );
             updateNormalFontLetterShadow( font[210 - 32] );
+
+            // O with accute accent.
+            font[211 - 32] = font[47];
 
             // O with / inside.
             font[216 - 32].resize( font[47].width() + 2, font[47].height() );
@@ -1561,6 +1567,9 @@ namespace
             fheroes2::Copy( font[192 - 32], 7, 0, font[217 - 32], 5, 0, 4, 2 );
             updateNormalFontLetterShadow( font[217 - 32] );
 
+            // U with accute accent.
+            font[218 - 32] = font[53];
+
             // a with grave accent `.
             font[224 - 32].resize( font[65].width(), font[65].height() + 3 );
             font[224 - 32].reset();
@@ -1568,6 +1577,9 @@ namespace
             font[224 - 32].setPosition( font[65].x(), font[65].y() - 3 );
             fheroes2::Copy( font[192 - 32], 7, 0, font[224 - 32], 3, 0, 4, 2 );
             updateNormalFontLetterShadow( font[224 - 32] );
+
+            // a with accute accent.
+            font[225 - 32] = font[65];
 
             // a with circle on top.
             font[229 - 32].resize( font[65].width(), font[65].height() + 5 );
@@ -1615,6 +1627,9 @@ namespace
             fheroes2::Copy( font[192 - 32], 7, 0, font[236 - 32], 1, 0, 4, 2 );
             updateNormalFontLetterShadow( font[236 - 32] );
 
+            // i with accute accent.
+            font[237 - 32] = font[73];
+
             // n with tilde ~.
             font[241 - 32] = font[110 - 32];
 
@@ -1625,6 +1640,9 @@ namespace
             font[242 - 32].setPosition( font[79].x(), font[79].y() - 3 );
             fheroes2::Copy( font[192 - 32], 7, 0, font[242 - 32], 3, 0, 4, 2 );
             updateNormalFontLetterShadow( font[242 - 32] );
+
+            // o with accute accent.
+            font[243 - 32] = font[79];
 
             // o with / inside.
             font[248 - 32].resize( font[79].width(), font[79].height() );
@@ -1644,6 +1662,9 @@ namespace
             font[249 - 32].setPosition( font[85].x(), font[85].y() - 3 );
             fheroes2::Copy( font[192 - 32], 7, 0, font[249 - 32], 3, 0, 4, 2 );
             updateNormalFontLetterShadow( font[249 - 32] );
+
+            // u with accute accent.
+            font[250 - 32] = font[85];
 
             // Proper lowercase k. Kept at end in case any letters use it for generation.
             fheroes2::FillTransform( font[75], 4, 1, 5, 8, 1 );
@@ -1857,8 +1878,6 @@ namespace fheroes2
             generateCP1251Alphabet( icnVsSprite );
             break;
         case SupportedLanguage::Norwegian:
-            //generateNorwegianAlphabet( icnVsSprite );
-            //break;
         case SupportedLanguage::Spanish:
         case SupportedLanguage::Italian:
             generateCP1252Alphabet( icnVsSprite );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -85,175 +85,6 @@ namespace
         // TODO: modify newly added characters accordingly.
     }
 
-    void generateGermanAlphabet( std::vector<std::vector<fheroes2::Sprite>> & icnVsSprite )
-    {
-        // Resize fonts.
-        for ( const int icnId : { ICN::FONT, ICN::SMALFONT } ) {
-            icnVsSprite[icnId].resize( 96 );
-            icnVsSprite[icnId].insert( icnVsSprite[icnId].end(), 160, icnVsSprite[icnId][0] );
-        }
-
-        // Normal font.
-        {
-            std::vector<fheroes2::Sprite> & font = icnVsSprite[ICN::FONT];
-
-            // A with 2 dots on top.
-            font[196 - 32].resize( font[33].width(), font[33].height() + 3 );
-            font[196 - 32].reset();
-            fheroes2::Copy( font[33], 0, 0, font[196 - 32], 0, 3, font[33].width(), font[33].height() );
-            fheroes2::Copy( font[196 - 32], 3, 1 + 3, font[196 - 32], 4, 0, 1, 1 );
-            fheroes2::Copy( font[196 - 32], 4, 1 + 3, font[196 - 32], 5, 0, 1, 1 );
-            fheroes2::Copy( font[196 - 32], 4, 0, font[196 - 32], 9, 0, 2, 1 );
-            font[196 - 32].setPosition( font[33].x(), font[33].y() - 3 );
-            updateNormalFontLetterShadow( font[196 - 32] );
-
-            // O with 2 dots on top.
-            font[214 - 32].resize( font[47].width(), font[47].height() + 3 );
-            font[214 - 32].reset();
-            fheroes2::Copy( font[47], 0, 0, font[214 - 32], 0, 3, font[47].width(), font[47].height() );
-            fheroes2::Copy( font[214 - 32], 1, 2 + 3, font[214 - 32], 5, 0, 1, 1 );
-            fheroes2::Copy( font[214 - 32], 2, 2 + 3, font[214 - 32], 6, 0, 1, 1 );
-            fheroes2::Copy( font[214 - 32], 5, 0, font[214 - 32], 10, 0, 2, 1 );
-            font[214 - 32].setPosition( font[47].x(), font[47].y() - 3 );
-            updateNormalFontLetterShadow( font[214 - 32] );
-
-            // U with 2 dots on top.
-            font[220 - 32].resize( font[53].width(), font[53].height() + 3 );
-            font[220 - 32].reset();
-            fheroes2::Copy( font[53], 0, 0, font[220 - 32], 0, 3, font[53].width(), font[53].height() );
-            fheroes2::Copy( font[220 - 32], 1, 1 + 3, font[220 - 32], 4, 0, 1, 1 );
-            fheroes2::Copy( font[220 - 32], 2, 1 + 3, font[220 - 32], 5, 0, 1, 1 );
-            fheroes2::Copy( font[220 - 32], 4, 0, font[220 - 32], 9, 0, 2, 1 );
-            font[220 - 32].setPosition( font[53].x(), font[53].y() - 3 );
-            updateNormalFontLetterShadow( font[220 - 32] );
-
-            // a with 2 dots on top.
-            font[228 - 32].resize( font[65].width(), font[65].height() + 3 );
-            font[228 - 32].reset();
-            fheroes2::Copy( font[65], 0, 0, font[228 - 32], 0, 3, font[65].width(), font[65].height() );
-            fheroes2::Copy( font[228 - 32], 3, 0 + 3, font[228 - 32], 3, 0, 1, 1 );
-            fheroes2::Copy( font[228 - 32], 2, 1 + 3, font[228 - 32], 3, 1, 1, 1 );
-            fheroes2::Copy( font[228 - 32], 2, 1 + 3, font[228 - 32], 2, 0, 1, 1 );
-            fheroes2::Copy( font[228 - 32], 1, 0 + 3, font[228 - 32], 2, 1, 1, 1 );
-            fheroes2::Copy( font[228 - 32], 2, 0, font[228 - 32], 5, 0, 2, 2 );
-            font[228 - 32].setPosition( font[65].x(), font[65].y() - 3 );
-            updateNormalFontLetterShadow( font[228 - 32] );
-
-            // o with 2 dots on top.
-            font[246 - 32].resize( font[79].width(), font[79].height() + 3 );
-            font[246 - 32].reset();
-            fheroes2::Copy( font[79], 0, 0, font[246 - 32], 0, 3, font[79].width(), font[79].height() );
-            fheroes2::Copy( font[246 - 32], 4, 0 + 3, font[246 - 32], 3, 0, 1, 1 );
-            fheroes2::Copy( font[246 - 32], 6, 1 + 3, font[246 - 32], 3, 1, 1, 1 );
-            fheroes2::Copy( font[246 - 32], 6, 1 + 3, font[246 - 32], 2, 0, 1, 1 );
-            fheroes2::Copy( font[246 - 32], 4, 1 + 3, font[246 - 32], 2, 1, 1, 1 );
-            fheroes2::Copy( font[246 - 32], 2, 0, font[246 - 32], 6, 0, 2, 2 );
-            font[246 - 32].setPosition( font[79].x(), font[79].y() - 3 );
-            updateNormalFontLetterShadow( font[246 - 32] );
-
-            // u with 2 dots on top.
-            font[252 - 32].resize( font[85].width(), font[85].height() + 3 );
-            font[252 - 32].reset();
-            fheroes2::Copy( font[85], 0, 0, font[252 - 32], 0, 3, font[85].width(), font[85].height() );
-            fheroes2::Copy( font[252 - 32], 2, 0 + 3, font[252 - 32], 3, 0, 1, 1 );
-            fheroes2::Copy( font[252 - 32], 2, 1 + 3, font[252 - 32], 3, 1, 1, 1 );
-            fheroes2::Copy( font[252 - 32], 2, 1 + 3, font[252 - 32], 2, 0, 1, 1 );
-            fheroes2::Copy( font[252 - 32], 3, 6 + 3, font[252 - 32], 2, 1, 1, 1 );
-            fheroes2::Copy( font[252 - 32], 2, 0, font[252 - 32], 6, 0, 2, 2 );
-            font[252 - 32].setPosition( font[85].x(), font[85].y() - 3 );
-            updateNormalFontLetterShadow( font[252 - 32] );
-
-            // Eszett.
-            font[223 - 32].resize( font[34].width(), font[34].height() + 3 );
-            font[223 - 32].reset();
-            fheroes2::Copy( font[34], 1, 0, font[223 - 32], 0, 3, font[34].width() - 1, font[34].height() );
-            fheroes2::FillTransform( font[223 - 32], 0, 0 + 3, 3, 10, 1 );
-            fheroes2::Copy( font[223 - 32], 0, 0 + 3, font[223 - 32], 3, 0 + 3, 1, 1 );
-            fheroes2::Copy( font[223 - 32], 3, 1 + 3, font[223 - 32], 4, 0 + 3, 1, 1 );
-            fheroes2::Copy( font[223 - 32], 4, 3 + 3, font[223 - 32], 3, 7 + 3, 1, 3 );
-            fheroes2::Copy( font[223 - 32], 4, 3 + 3, font[223 - 32], 2, 10 + 3, 1, 1 );
-            fheroes2::Copy( font[223 - 32], 3, 3 + 3, font[223 - 32], 2, 7 + 3, 1, 3 );
-            fheroes2::Copy( font[223 - 32], 3, 6 + 3, font[223 - 32], 1, 10 + 3, 1, 1 );
-            fheroes2::Copy( font[223 - 32], 7, 4 + 3, font[223 - 32], 4, 8 + 3, 1, 1 );
-            fheroes2::Copy( font[223 - 32], 7, 4 + 3, font[223 - 32], 3, 10 + 3, 1, 1 );
-            fheroes2::Copy( font[223 - 32], 8, 5 + 3, font[223 - 32], 4, 9 + 3, 1, 1 );
-            font[223 - 32].setPosition( font[34].x(), font[34].y() - 3 );
-            updateNormalFontLetterShadow( font[223 - 32] );
-        }
-
-        // Small font.
-        {
-            std::vector<fheroes2::Sprite> & font = icnVsSprite[ICN::SMALFONT];
-
-            // A with 2 dots on top.
-            font[196 - 32].resize( font[33].width(), font[33].height() + 2 );
-            font[196 - 32].reset();
-            fheroes2::Copy( font[33], 0, 0, font[196 - 32], 0, 2, font[33].width(), font[33].height() );
-            fheroes2::Copy( font[196 - 32], 3, 0 + 2, font[196 - 32], 4, 0, 1, 1 );
-            fheroes2::Copy( font[196 - 32], 3, 0 + 2, font[196 - 32], 6, 0, 1, 1 );
-            font[196 - 32].setPosition( font[33].x(), font[33].y() - 2 );
-            updateSmallFontLetterShadow( font[196 - 32] );
-
-            // O with 2 dots on top.
-            font[214 - 32].resize( font[47].width(), font[47].height() + 2 );
-            font[214 - 32].reset();
-            fheroes2::Copy( font[47], 0, 0, font[214 - 32], 0, 2, font[47].width(), font[47].height() );
-            fheroes2::Copy( font[214 - 32], 3, 0 + 2, font[214 - 32], 3, 0, 1, 1 );
-            fheroes2::Copy( font[214 - 32], 3, 0 + 2, font[214 - 32], 5, 0, 1, 1 );
-            font[214 - 32].setPosition( font[47].x(), font[47].y() - 2 );
-            updateSmallFontLetterShadow( font[214 - 32] );
-
-            // U with 2 dots on top.
-            font[220 - 32].resize( font[53].width(), font[53].height() + 2 );
-            font[220 - 32].reset();
-            fheroes2::Copy( font[53], 0, 0, font[220 - 32], 0, 2, font[53].width(), font[53].height() );
-            fheroes2::Copy( font[220 - 32], 3, 0 + 2, font[220 - 32], 4, 0, 1, 1 );
-            fheroes2::Copy( font[220 - 32], 3, 0 + 2, font[220 - 32], 6, 0, 1, 1 );
-            font[220 - 32].setPosition( font[53].x(), font[53].y() - 2 );
-            updateSmallFontLetterShadow( font[220 - 32] );
-
-            // a with 2 dots on top.
-            font[228 - 32].resize( font[65].width(), font[65].height() + 2 );
-            font[228 - 32].reset();
-            fheroes2::Copy( font[65], 0, 0, font[228 - 32], 0, 2, font[65].width(), font[65].height() );
-            fheroes2::Copy( font[228 - 32], 3, 0 + 2, font[228 - 32], 2, 0, 1, 1 );
-            fheroes2::Copy( font[228 - 32], 3, 0 + 2, font[228 - 32], 5, 0, 1, 1 );
-            font[228 - 32].setPosition( font[65].x(), font[65].y() - 2 );
-            updateSmallFontLetterShadow( font[228 - 32] );
-
-            // o with 2 dots on top.
-            font[246 - 32].resize( font[79].width(), font[79].height() + 2 );
-            font[246 - 32].reset();
-            fheroes2::Copy( font[79], 0, 0, font[246 - 32], 0, 2, font[79].width(), font[79].height() );
-            fheroes2::Copy( font[246 - 32], 3, 0 + 2, font[246 - 32], 2, 0, 1, 1 );
-            fheroes2::Copy( font[246 - 32], 3, 0 + 2, font[246 - 32], 4, 0, 1, 1 );
-            font[246 - 32].setPosition( font[79].x(), font[79].y() - 2 );
-            updateSmallFontLetterShadow( font[246 - 32] );
-
-            // u with 2 dots on top.
-            font[252 - 32].resize( font[85].width(), font[85].height() + 2 );
-            font[252 - 32].reset();
-            fheroes2::Copy( font[85], 0, 0, font[252 - 32], 0, 2, font[85].width(), font[85].height() );
-            fheroes2::Copy( font[252 - 32], 2, 0 + 2, font[252 - 32], 2, 0, 1, 1 );
-            fheroes2::Copy( font[252 - 32], 2, 0 + 2, font[252 - 32], 6, 0, 1, 1 );
-            font[252 - 32].setPosition( font[85].x(), font[85].y() - 2 );
-            updateSmallFontLetterShadow( font[252 - 32] );
-
-            // Eszett.
-            font[223 - 32].resize( font[34].width(), font[34].height() + 2 );
-            font[223 - 32].reset();
-            fheroes2::Copy( font[34], 0, 0, font[223 - 32], 0, 2, font[34].width(), font[34].height() );
-            fheroes2::FillTransform( font[223 - 32], 0, 0 + 2, 4, 9, 1 );
-            fheroes2::Copy( font[223 - 32], 6, 1 + 2, font[223 - 32], 2, 1 + 2, 1, 5 );
-            fheroes2::Copy( font[223 - 32], 4, 3 + 2, font[223 - 32], 2, 3 + 2, 2, 1 );
-            fheroes2::Copy( font[223 - 32], 5, 0 + 2, font[223 - 32], 1, 6 + 2, 1, 1 );
-            fheroes2::Copy( font[223 - 32], 5, 0 + 2, font[223 - 32], 3, 0 + 2, 1, 1 );
-            fheroes2::Copy( font[223 - 32], 5, 0 + 2, font[223 - 32], 3, 6 + 2, 1, 1 );
-            font[223 - 32].setPosition( font[34].x(), font[34].y() - 2 );
-            updateSmallFontLetterShadow( font[223 - 32] );
-        }
-    }
-
     void generateFrenchAlphabet( std::vector<std::vector<fheroes2::Sprite>> & icnVsSprite )
     {
         // Resize fonts.
@@ -1481,6 +1312,16 @@ namespace
             // A with acute accent.
             font[193 - 32] = font[33];
 
+            // A with 2 dots on top.
+            font[196 - 32].resize( font[33].width(), font[33].height() + 3 );
+            font[196 - 32].reset();
+            fheroes2::Copy( font[33], 0, 0, font[196 - 32], 0, 3, font[33].width(), font[33].height() );
+            fheroes2::Copy( font[196 - 32], 3, 1 + 3, font[196 - 32], 4, 0, 1, 1 );
+            fheroes2::Copy( font[196 - 32], 4, 1 + 3, font[196 - 32], 5, 0, 1, 1 );
+            fheroes2::Copy( font[196 - 32], 4, 0, font[196 - 32], 9, 0, 2, 1 );
+            font[196 - 32].setPosition( font[33].x(), font[33].y() - 3 );
+            updateNormalFontLetterShadow( font[196 - 32] );
+
             // A with circle on top.
             font[197 - 32].resize( font[33].width(), font[33].height() + 2 );
             font[197 - 32].reset();
@@ -1547,6 +1388,16 @@ namespace
             // O with accute accent.
             font[211 - 32] = font[47];
 
+            // O with 2 dots on top.
+            font[214 - 32].resize( font[47].width(), font[47].height() + 3 );
+            font[214 - 32].reset();
+            fheroes2::Copy( font[47], 0, 0, font[214 - 32], 0, 3, font[47].width(), font[47].height() );
+            fheroes2::Copy( font[214 - 32], 1, 2 + 3, font[214 - 32], 5, 0, 1, 1 );
+            fheroes2::Copy( font[214 - 32], 2, 2 + 3, font[214 - 32], 6, 0, 1, 1 );
+            fheroes2::Copy( font[214 - 32], 5, 0, font[214 - 32], 10, 0, 2, 1 );
+            font[214 - 32].setPosition( font[47].x(), font[47].y() - 3 );
+            updateNormalFontLetterShadow( font[214 - 32] );
+
             // O with / inside.
             font[216 - 32].resize( font[47].width() + 2, font[47].height() );
             font[216 - 32].reset();
@@ -1570,6 +1421,33 @@ namespace
             // U with accute accent.
             font[218 - 32] = font[53];
 
+            // U with 2 dots on top.
+            font[220 - 32].resize( font[53].width(), font[53].height() + 3 );
+            font[220 - 32].reset();
+            fheroes2::Copy( font[53], 0, 0, font[220 - 32], 0, 3, font[53].width(), font[53].height() );
+            fheroes2::Copy( font[220 - 32], 1, 1 + 3, font[220 - 32], 4, 0, 1, 1 );
+            fheroes2::Copy( font[220 - 32], 2, 1 + 3, font[220 - 32], 5, 0, 1, 1 );
+            fheroes2::Copy( font[220 - 32], 4, 0, font[220 - 32], 9, 0, 2, 1 );
+            font[220 - 32].setPosition( font[53].x(), font[53].y() - 3 );
+            updateNormalFontLetterShadow( font[220 - 32] );
+
+            // Eszett.
+            font[223 - 32].resize( font[34].width(), font[34].height() + 3 );
+            font[223 - 32].reset();
+            fheroes2::Copy( font[34], 1, 0, font[223 - 32], 0, 3, font[34].width() - 1, font[34].height() );
+            fheroes2::FillTransform( font[223 - 32], 0, 0 + 3, 3, 10, 1 );
+            fheroes2::Copy( font[223 - 32], 0, 0 + 3, font[223 - 32], 3, 0 + 3, 1, 1 );
+            fheroes2::Copy( font[223 - 32], 3, 1 + 3, font[223 - 32], 4, 0 + 3, 1, 1 );
+            fheroes2::Copy( font[223 - 32], 4, 3 + 3, font[223 - 32], 3, 7 + 3, 1, 3 );
+            fheroes2::Copy( font[223 - 32], 4, 3 + 3, font[223 - 32], 2, 10 + 3, 1, 1 );
+            fheroes2::Copy( font[223 - 32], 3, 3 + 3, font[223 - 32], 2, 7 + 3, 1, 3 );
+            fheroes2::Copy( font[223 - 32], 3, 6 + 3, font[223 - 32], 1, 10 + 3, 1, 1 );
+            fheroes2::Copy( font[223 - 32], 7, 4 + 3, font[223 - 32], 4, 8 + 3, 1, 1 );
+            fheroes2::Copy( font[223 - 32], 7, 4 + 3, font[223 - 32], 3, 10 + 3, 1, 1 );
+            fheroes2::Copy( font[223 - 32], 8, 5 + 3, font[223 - 32], 4, 9 + 3, 1, 1 );
+            font[223 - 32].setPosition( font[34].x(), font[34].y() - 3 );
+            updateNormalFontLetterShadow( font[223 - 32] );
+
             // a with grave accent `.
             font[224 - 32].resize( font[65].width(), font[65].height() + 3 );
             font[224 - 32].reset();
@@ -1580,6 +1458,18 @@ namespace
 
             // a with accute accent.
             font[225 - 32] = font[65];
+
+            // a with 2 dots on top.
+            font[228 - 32].resize( font[65].width(), font[65].height() + 3 );
+            font[228 - 32].reset();
+            fheroes2::Copy( font[65], 0, 0, font[228 - 32], 0, 3, font[65].width(), font[65].height() );
+            fheroes2::Copy( font[228 - 32], 3, 0 + 3, font[228 - 32], 3, 0, 1, 1 );
+            fheroes2::Copy( font[228 - 32], 2, 1 + 3, font[228 - 32], 3, 1, 1, 1 );
+            fheroes2::Copy( font[228 - 32], 2, 1 + 3, font[228 - 32], 2, 0, 1, 1 );
+            fheroes2::Copy( font[228 - 32], 1, 0 + 3, font[228 - 32], 2, 1, 1, 1 );
+            fheroes2::Copy( font[228 - 32], 2, 0, font[228 - 32], 5, 0, 2, 2 );
+            font[228 - 32].setPosition( font[65].x(), font[65].y() - 3 );
+            updateNormalFontLetterShadow( font[228 - 32] );
 
             // a with circle on top.
             font[229 - 32].resize( font[65].width(), font[65].height() + 5 );
@@ -1644,6 +1534,18 @@ namespace
             // o with accute accent.
             font[243 - 32] = font[79];
 
+            // o with 2 dots on top.
+            font[246 - 32].resize( font[79].width(), font[79].height() + 3 );
+            font[246 - 32].reset();
+            fheroes2::Copy( font[79], 0, 0, font[246 - 32], 0, 3, font[79].width(), font[79].height() );
+            fheroes2::Copy( font[246 - 32], 4, 0 + 3, font[246 - 32], 3, 0, 1, 1 );
+            fheroes2::Copy( font[246 - 32], 6, 1 + 3, font[246 - 32], 3, 1, 1, 1 );
+            fheroes2::Copy( font[246 - 32], 6, 1 + 3, font[246 - 32], 2, 0, 1, 1 );
+            fheroes2::Copy( font[246 - 32], 4, 1 + 3, font[246 - 32], 2, 1, 1, 1 );
+            fheroes2::Copy( font[246 - 32], 2, 0, font[246 - 32], 6, 0, 2, 2 );
+            font[246 - 32].setPosition( font[79].x(), font[79].y() - 3 );
+            updateNormalFontLetterShadow( font[246 - 32] );
+
             // o with / inside.
             font[248 - 32].resize( font[79].width(), font[79].height() );
             font[248 - 32].reset();
@@ -1665,6 +1567,18 @@ namespace
 
             // u with accute accent.
             font[250 - 32] = font[85];
+
+            // u with 2 dots on top.
+            font[252 - 32].resize( font[85].width(), font[85].height() + 3 );
+            font[252 - 32].reset();
+            fheroes2::Copy( font[85], 0, 0, font[252 - 32], 0, 3, font[85].width(), font[85].height() );
+            fheroes2::Copy( font[252 - 32], 2, 0 + 3, font[252 - 32], 3, 0, 1, 1 );
+            fheroes2::Copy( font[252 - 32], 2, 1 + 3, font[252 - 32], 3, 1, 1, 1 );
+            fheroes2::Copy( font[252 - 32], 2, 1 + 3, font[252 - 32], 2, 0, 1, 1 );
+            fheroes2::Copy( font[252 - 32], 3, 6 + 3, font[252 - 32], 2, 1, 1, 1 );
+            fheroes2::Copy( font[252 - 32], 2, 0, font[252 - 32], 6, 0, 2, 2 );
+            font[252 - 32].setPosition( font[85].x(), font[85].y() - 3 );
+            updateNormalFontLetterShadow( font[252 - 32] );
 
             // Proper lowercase k. Kept at end in case any letters use it for generation.
             fheroes2::FillTransform( font[75], 4, 1, 5, 8, 1 );
@@ -1696,6 +1610,15 @@ namespace
 
             // A with acute accent.
             font[193 - 32] = font[33];
+
+            // A with 2 dots on top.
+            font[196 - 32].resize( font[33].width(), font[33].height() + 2 );
+            font[196 - 32].reset();
+            fheroes2::Copy( font[33], 0, 0, font[196 - 32], 0, 2, font[33].width(), font[33].height() );
+            fheroes2::Copy( font[196 - 32], 3, 0 + 2, font[196 - 32], 4, 0, 1, 1 );
+            fheroes2::Copy( font[196 - 32], 3, 0 + 2, font[196 - 32], 6, 0, 1, 1 );
+            font[196 - 32].setPosition( font[33].x(), font[33].y() - 2 );
+            updateSmallFontLetterShadow( font[196 - 32] );
 
             // A with circle on top.
             font[197 - 32].resize( font[33].width(), font[33].height() + 4 );
@@ -1763,6 +1686,15 @@ namespace
             // O with accute accent.
             font[211 - 32] = font[47];
 
+            // O with 2 dots on top.
+            font[214 - 32].resize( font[47].width(), font[47].height() + 2 );
+            font[214 - 32].reset();
+            fheroes2::Copy( font[47], 0, 0, font[214 - 32], 0, 2, font[47].width(), font[47].height() );
+            fheroes2::Copy( font[214 - 32], 3, 0 + 2, font[214 - 32], 3, 0, 1, 1 );
+            fheroes2::Copy( font[214 - 32], 3, 0 + 2, font[214 - 32], 5, 0, 1, 1 );
+            font[214 - 32].setPosition( font[47].x(), font[47].y() - 2 );
+            updateSmallFontLetterShadow( font[214 - 32] );
+
             // O with / inside.
             font[216 - 32].resize( font[47].width(), font[47].height() );
             font[216 - 32].reset();
@@ -1784,6 +1716,28 @@ namespace
             // U with accute accent.
             font[218 - 32] = font[53];
 
+            // U with 2 dots on top.
+            font[220 - 32].resize( font[53].width(), font[53].height() + 2 );
+            font[220 - 32].reset();
+            fheroes2::Copy( font[53], 0, 0, font[220 - 32], 0, 2, font[53].width(), font[53].height() );
+            fheroes2::Copy( font[220 - 32], 3, 0 + 2, font[220 - 32], 4, 0, 1, 1 );
+            fheroes2::Copy( font[220 - 32], 3, 0 + 2, font[220 - 32], 6, 0, 1, 1 );
+            font[220 - 32].setPosition( font[53].x(), font[53].y() - 2 );
+            updateSmallFontLetterShadow( font[220 - 32] );
+
+            // Eszett.
+            font[223 - 32].resize( font[34].width(), font[34].height() + 2 );
+            font[223 - 32].reset();
+            fheroes2::Copy( font[34], 0, 0, font[223 - 32], 0, 2, font[34].width(), font[34].height() );
+            fheroes2::FillTransform( font[223 - 32], 0, 0 + 2, 4, 9, 1 );
+            fheroes2::Copy( font[223 - 32], 6, 1 + 2, font[223 - 32], 2, 1 + 2, 1, 5 );
+            fheroes2::Copy( font[223 - 32], 4, 3 + 2, font[223 - 32], 2, 3 + 2, 2, 1 );
+            fheroes2::Copy( font[223 - 32], 5, 0 + 2, font[223 - 32], 1, 6 + 2, 1, 1 );
+            fheroes2::Copy( font[223 - 32], 5, 0 + 2, font[223 - 32], 3, 0 + 2, 1, 1 );
+            fheroes2::Copy( font[223 - 32], 5, 0 + 2, font[223 - 32], 3, 6 + 2, 1, 1 );
+            font[223 - 32].setPosition( font[34].x(), font[34].y() - 2 );
+            updateSmallFontLetterShadow( font[223 - 32] );
+
             // a with grave accent `.
             font[224 - 32].resize( font[65].width(), font[65].height() + 3 );
             font[224 - 32].reset();
@@ -1794,6 +1748,15 @@ namespace
 
             // a with accute accent.
             font[225 - 32] = font[65];
+
+            // a with 2 dots on top.
+            font[228 - 32].resize( font[65].width(), font[65].height() + 2 );
+            font[228 - 32].reset();
+            fheroes2::Copy( font[65], 0, 0, font[228 - 32], 0, 2, font[65].width(), font[65].height() );
+            fheroes2::Copy( font[228 - 32], 3, 0 + 2, font[228 - 32], 2, 0, 1, 1 );
+            fheroes2::Copy( font[228 - 32], 3, 0 + 2, font[228 - 32], 5, 0, 1, 1 );
+            font[228 - 32].setPosition( font[65].x(), font[65].y() - 2 );
+            updateSmallFontLetterShadow( font[228 - 32] );
 
             // a with circle on top.
             font[229 - 32].resize( font[65].width(), font[65].height() + 3 );
@@ -1854,6 +1817,15 @@ namespace
             // o with accute accent.
             font[243 - 32] = font[79];
 
+            // o with 2 dots on top.
+            font[246 - 32].resize( font[79].width(), font[79].height() + 2 );
+            font[246 - 32].reset();
+            fheroes2::Copy( font[79], 0, 0, font[246 - 32], 0, 2, font[79].width(), font[79].height() );
+            fheroes2::Copy( font[246 - 32], 3, 0 + 2, font[246 - 32], 2, 0, 1, 1 );
+            fheroes2::Copy( font[246 - 32], 3, 0 + 2, font[246 - 32], 4, 0, 1, 1 );
+            font[246 - 32].setPosition( font[79].x(), font[79].y() - 2 );
+            updateSmallFontLetterShadow( font[246 - 32] );
+
             // o with / inside.
             font[248 - 32].resize( font[79].width(), font[79].height() );
             font[248 - 32].reset();
@@ -1874,6 +1846,15 @@ namespace
 
             // u with accute accent.
             font[250 - 32] = font[85];
+
+            // u with 2 dots on top.
+            font[252 - 32].resize( font[85].width(), font[85].height() + 2 );
+            font[252 - 32].reset();
+            fheroes2::Copy( font[85], 0, 0, font[252 - 32], 0, 2, font[85].width(), font[85].height() );
+            fheroes2::Copy( font[252 - 32], 2, 0 + 2, font[252 - 32], 2, 0, 1, 1 );
+            fheroes2::Copy( font[252 - 32], 2, 0 + 2, font[252 - 32], 6, 0, 1, 1 );
+            font[252 - 32].setPosition( font[85].x(), font[85].y() - 2 );
+            updateSmallFontLetterShadow( font[252 - 32] );
 
             // Proper lowercase k. Kept at end in case any letters use it for generation.
             font[75].resize( 6, 8 );
@@ -1898,9 +1879,6 @@ namespace fheroes2
         case SupportedLanguage::Romanian:
             generateCP1250Alphabet( icnVsSprite );
             break;
-        case SupportedLanguage::German:
-            generateGermanAlphabet( icnVsSprite );
-            break;
         case SupportedLanguage::French:
             generateFrenchAlphabet( icnVsSprite );
             break;
@@ -1910,9 +1888,10 @@ namespace fheroes2
         case SupportedLanguage::Ukrainian:
             generateCP1251Alphabet( icnVsSprite );
             break;
+        case SupportedLanguage::German:
+        case SupportedLanguage::Italian:
         case SupportedLanguage::Norwegian:
         case SupportedLanguage::Spanish:
-        case SupportedLanguage::Italian:
             generateCP1252Alphabet( icnVsSprite );
             break;
 

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1288,7 +1288,6 @@ namespace
             font[161 - 32].reset();
             fheroes2::Copy( font[33 - 32], 1, 0, font[161 - 32], 1, 3, font[33 - 32].width(), font[33 - 32].height() );
             {
-                // TODO: add proper Flip function variant.
                 fheroes2::Sprite temp = fheroes2::Flip( font[161 - 32], false, true );
                 fheroes2::Copy( temp, 0, 2, font[161 - 32], 1, 2, temp.width(), temp.height() );
             }
@@ -1300,7 +1299,6 @@ namespace
             font[191 - 32].reset();
             fheroes2::Copy( font[63 - 32], 1, 0, font[191 - 32], 0, 0, font[63 - 32].width(), 11 );
             {
-                // TODO: add proper Flip function variant.
                 fheroes2::Sprite temp = fheroes2::Flip( font[191 - 32], true, true );
                 fheroes2::Copy( temp, 1, 2, font[191 - 32], 0, 0, temp.width(), temp.height() );
             }
@@ -1672,7 +1670,6 @@ namespace
             font[161 - 32].reset();
             fheroes2::Copy( font[33 - 32], 1, 0, font[161 - 32], 1, 0, font[33 - 32].width(), 7 );
             {
-                // TODO: add proper Flip function variant.
                 fheroes2::Sprite temp = fheroes2::Flip( font[161 - 32], false, true );
                 fheroes2::Copy( temp, 0, 1, font[161 - 32], 0, 0, temp.width(), temp.height() );
             }
@@ -1684,7 +1681,6 @@ namespace
             font[191 - 32].reset();
             fheroes2::Copy( font[63 - 32], 1, 0, font[191 - 32], 0, 0, font[63 - 32].width(), 7 );
             {
-                // TODO: add proper Flip function variant.
                 fheroes2::Sprite temp = fheroes2::Flip( font[191 - 32], true, true );
                 fheroes2::Copy( temp, 0, 1, font[191 - 32], 0, 0, temp.width(), temp.height() );
             }

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1294,7 +1294,7 @@ namespace
             font[161 - 32].setPosition( font[33 - 32].x(), font[33 - 32].y() + 2 );
             updateNormalFontLetterShadow( font[161 - 32] );
 
-            // Inverted question mark ?. Replaced with normal for now.
+            // Inverted question mark ?.
             font[191 - 32].resize( font[63 - 32].width() + 1, font[63 - 32].height() );
             font[191 - 32].reset();
             fheroes2::Copy( font[63 - 32], 1, 0, font[191 - 32], 0, 0, font[63 - 32].width(), 11 );
@@ -1676,7 +1676,7 @@ namespace
             font[161 - 32].setPosition( font[33 - 32].x(), font[33 - 32].y() + 2 );
             updateSmallFontLetterShadow( font[161 - 32] );
 
-            // Inverted question mark ?. Replaced with normal for now.
+            // Inverted question mark ?.
             font[191 - 32].resize( font[63 - 32].width(), font[63 - 32].height() );
             font[191 - 32].reset();
             fheroes2::Copy( font[63 - 32], 1, 0, font[191 - 32], 0, 0, font[63 - 32].width(), 7 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1752,8 +1752,15 @@ namespace
             font[205 - 32].setPosition( font[41].x(), font[41].y() - 4 );
             updateSmallFontLetterShadow( font[205 - 32] );
 
-            // N with tilde ~
-            font[209 - 32] = font[46];
+            // N with tilde ~. Generate tilde accent for further use.
+            // TODO: Move tilde accent generation to A with tilde when adding Portuguese.
+            font[209 - 32].resize( font[46].width(), font[46].height() + 3 );
+            font[209 - 32].reset();
+            fheroes2::Copy( font[46], 0, 0, font[209 - 32], 0, 4, font[46].width(), font[46].height() );
+            fheroes2::Copy( font[37 - 32], 5, 4, font[209 - 32], 4, 0, 3, 2 );
+            fheroes2::Copy( font[37 - 32], 5, 4, font[209 - 32], 7, 1, 2, 2 );
+            font[209 - 32].setPosition( font[46].x(), font[46].y() - 4 );
+            updateSmallFontLetterShadow( font[209 - 32] );
 
             // O with grave accent `.
             font[210 - 32].resize( font[47].width(), font[47].height() + 4 );
@@ -1902,7 +1909,12 @@ namespace
             updateSmallFontLetterShadow( font[237 - 32] );
 
             // n with tilde ~.
-            font[241 - 32] = font[110 - 32];
+            font[241 - 32].resize( font[110 - 32].width(), font[110 - 32].height() + 4 );
+            font[241 - 32].reset();
+            fheroes2::Copy( font[110 - 32], 0, 0, font[241 - 32], 0, 4, font[110 - 32].width(), font[110 - 32].height() );
+            fheroes2::Copy( font[209 - 32], 4, 0, font[241 - 32], 2, 0, 5, 3 );
+            font[241 - 32].setPosition( font[110 - 32].x(), font[110 - 32].y() - 4 );
+            updateSmallFontLetterShadow( font[241 - 32] );
 
             // o with grave accent `.
             font[242 - 32].resize( font[79].width(), font[79].height() + 3 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1385,7 +1385,7 @@ namespace
             fheroes2::Copy( font[192 - 32], 7, 0, font[210 - 32], 6, 0, 4, 2 );
             updateNormalFontLetterShadow( font[210 - 32] );
 
-            // O with accute accent.
+            // O with acute accent.
             font[211 - 32] = font[47];
 
             // O with 2 dots on top.
@@ -1418,7 +1418,7 @@ namespace
             fheroes2::Copy( font[192 - 32], 7, 0, font[217 - 32], 5, 0, 4, 2 );
             updateNormalFontLetterShadow( font[217 - 32] );
 
-            // U with accute accent.
+            // U with acute accent.
             font[218 - 32] = font[53];
 
             // U with 2 dots on top.
@@ -1456,7 +1456,7 @@ namespace
             fheroes2::Copy( font[192 - 32], 7, 0, font[224 - 32], 3, 0, 4, 2 );
             updateNormalFontLetterShadow( font[224 - 32] );
 
-            // a with accute accent.
+            // a with acute accent.
             font[225 - 32] = font[65];
 
             // a with 2 dots on top.
@@ -1517,7 +1517,7 @@ namespace
             fheroes2::Copy( font[192 - 32], 7, 0, font[236 - 32], 1, 0, 4, 2 );
             updateNormalFontLetterShadow( font[236 - 32] );
 
-            // i with accute accent.
+            // i with acute accent.
             font[237 - 32] = font[73];
 
             // n with tilde ~.
@@ -1531,7 +1531,7 @@ namespace
             fheroes2::Copy( font[192 - 32], 7, 0, font[242 - 32], 3, 0, 4, 2 );
             updateNormalFontLetterShadow( font[242 - 32] );
 
-            // o with accute accent.
+            // o with acute accent.
             font[243 - 32] = font[79];
 
             // o with 2 dots on top.
@@ -1565,7 +1565,7 @@ namespace
             fheroes2::Copy( font[192 - 32], 7, 0, font[249 - 32], 3, 0, 4, 2 );
             updateNormalFontLetterShadow( font[249 - 32] );
 
-            // u with accute accent.
+            // u with acute accent.
             font[250 - 32] = font[85];
 
             // u with 2 dots on top.
@@ -1608,8 +1608,15 @@ namespace
             font[192 - 32].setPosition( font[33].x(), font[33].y() - 4 );
             updateSmallFontLetterShadow( font[192 - 32] );
 
-            // A with acute accent.
-            font[193 - 32] = font[33];
+            // A with acute accent. Generate acute accent for further use
+            font[193 - 32].resize( font[33].width(), font[33].height() + 4 );
+            font[193 - 32].reset();
+            fheroes2::Copy( font[33], 0, 0, font[193 - 32], 0, 4, font[33].width(), font[33].height() );
+            fheroes2::Copy( font[33], 4, 0, font[193 - 32], 4, 2, 1, 1 );
+            fheroes2::Copy( font[33], 4, 0, font[193 - 32], 5, 1, 1, 1 );
+            fheroes2::Copy( font[33], 4, 0, font[193 - 32], 6, 0, 1, 1 );
+            font[193 - 32].setPosition( font[33].x(), font[33].y() - 4 );
+            updateSmallFontLetterShadow( font[193 - 32] );
 
             // A with 2 dots on top.
             font[196 - 32].resize( font[33].width(), font[33].height() + 2 );
@@ -1655,9 +1662,7 @@ namespace
             font[201 - 32].resize( font[37].width(), font[37].height() + 4 );
             font[201 - 32].reset();
             fheroes2::Copy( font[37], 0, 0, font[201 - 32], 0, 4, font[37].width(), font[37].height() );
-            fheroes2::Copy( font[201 - 32], 4, 4, font[201 - 32], 3, 2, 1, 1 );
-            fheroes2::Copy( font[201 - 32], 4, 4, font[201 - 32], 4, 1, 1, 1 );
-            fheroes2::Copy( font[201 - 32], 4, 4, font[201 - 32], 5, 0, 1, 1 );
+            fheroes2::Copy( font[193 - 32], 4, 0, font[201 - 32], 3, 0, 3, 3 );
             font[201 - 32].setPosition( font[37].x(), font[37].y() - 4 );
             updateSmallFontLetterShadow( font[201 - 32] );
 
@@ -1669,8 +1674,13 @@ namespace
             font[204 - 32].setPosition( font[41].x(), font[41].y() - 4 );
             updateSmallFontLetterShadow( font[204 - 32] );
 
-            // I with accute accent.
-            font[205 - 32] = font[41];
+            // I with acute accent.
+            font[205 - 32].resize( font[41].width(), font[41].height() + 4 );
+            font[205 - 32].reset();
+            fheroes2::Copy( font[41], 0, 0, font[205 - 32], 0, 4, font[41].width(), font[41].height() );
+            fheroes2::Copy( font[193 - 32], 4, 0, font[205 - 32], 1, 0, 3, 3 );
+            font[205 - 32].setPosition( font[41].x(), font[41].y() - 4 );
+            updateSmallFontLetterShadow( font[205 - 32] );
 
             // N with tilde ~
             font[209 - 32] = font[46];
@@ -1683,8 +1693,13 @@ namespace
             font[210 - 32].setPosition( font[47].x(), font[47].y() - 4 );
             updateSmallFontLetterShadow( font[210 - 32] );
 
-            // O with accute accent.
-            font[211 - 32] = font[47];
+            // O with acute accent.
+            font[211 - 32].resize( font[47].width(), font[47].height() + 4 );
+            font[211 - 32].reset();
+            fheroes2::Copy( font[47], 0, 0, font[211 - 32], 0, 4, font[47].width(), font[47].height() );
+            fheroes2::Copy( font[193 - 32], 4, 0, font[211 - 32], 3, 0, 3, 3 );
+            font[211 - 32].setPosition( font[47].x(), font[47].y() - 4 );
+            updateSmallFontLetterShadow( font[211 - 32] );
 
             // O with 2 dots on top.
             font[214 - 32].resize( font[47].width(), font[47].height() + 2 );
@@ -1713,8 +1728,13 @@ namespace
             font[217 - 32].setPosition( font[53].x(), font[53].y() - 4 );
             updateSmallFontLetterShadow( font[217 - 32] );
 
-            // U with accute accent.
-            font[218 - 32] = font[53];
+            // U with acute accent.
+            font[218 - 32].resize( font[53].width(), font[53].height() + 4 );
+            font[218 - 32].reset();
+            fheroes2::Copy( font[53], 0, 0, font[218 - 32], 0, 4, font[53].width(), font[53].height() );
+            fheroes2::Copy( font[193 - 32], 4, 0, font[218 - 32], 4, 0, 3, 3 );
+            font[218 - 32].setPosition( font[53].x(), font[53].y() - 4 );
+            updateSmallFontLetterShadow( font[218 - 32] );
 
             // U with 2 dots on top.
             font[220 - 32].resize( font[53].width(), font[53].height() + 2 );
@@ -1746,8 +1766,13 @@ namespace
             font[224 - 32].setPosition( font[65].x(), font[65].y() - 3 );
             updateSmallFontLetterShadow( font[224 - 32] );
 
-            // a with accute accent.
-            font[225 - 32] = font[65];
+            // a with acute accent.
+            font[225 - 32].resize( font[65].width(), font[65].height() + 3 );
+            font[225 - 32].reset();
+            fheroes2::Copy( font[65], 0, 0, font[225 - 32], 0, 3, font[65].width(), font[65].height() );
+            fheroes2::Copy( font[193 - 32], 5, 0, font[225 - 32], 3, 0, 2, 2 );
+            font[225 - 32].setPosition( font[65].x(), font[65].y() - 3 );
+            updateSmallFontLetterShadow( font[225 - 32] );
 
             // a with 2 dots on top.
             font[228 - 32].resize( font[65].width(), font[65].height() + 2 );
@@ -1786,22 +1811,25 @@ namespace
             font[233 - 32].resize( font[69].width(), font[69].height() + 3 );
             font[233 - 32].reset();
             fheroes2::Copy( font[69], 0, 0, font[233 - 32], 0, 3, font[69].width(), font[69].height() );
-            fheroes2::Copy( font[201 - 32], 4, 0, font[233 - 32], 3, 0, 3, 2 );
+            fheroes2::Copy( font[193 - 32], 5, 0, font[233 - 32], 3, 0, 2, 2 );
             font[233 - 32].setPosition( font[69].x(), font[69].y() - 3 );
             updateSmallFontLetterShadow( font[233 - 32] );
 
             // i with grave accent `.
             font[236 - 32].resize( font[73].width(), font[73].height() + 1 );
             font[236 - 32].reset();
-            fheroes2::Copy( font[73], 0, 0, font[236 - 32], 0, 1, font[73].width(), font[73].height() );
-            // Generate i without dot on top.
-            fheroes2::FillTransform( font[236 - 32], 0, 0, font[236 - 32].width(), 3, 1 );
+            fheroes2::Copy( font[73], 0, 2, font[236 - 32], 0, 3, font[73].width(), 6 );
             fheroes2::Copy( font[192 - 32], 4, 0, font[236 - 32], 2, 0, 2, 2 );
             font[236 - 32].setPosition( font[73].x(), font[73].y() - 1 );
             updateSmallFontLetterShadow( font[236 - 32] );
 
-            // i with accute accent.
-            font[237 - 32] = font[73];
+            // i with acute accent.
+            font[237 - 32].resize( font[73].width(), font[73].height() + 1 );
+            font[237 - 32].reset();
+            fheroes2::Copy( font[73], 0, 2, font[237 - 32], 0, 3, font[73].width(), 6 );
+            fheroes2::Copy( font[193 - 32], 5, 0, font[237 - 32], 1, 0, 2, 2 );
+            font[237 - 32].setPosition( font[73].x(), font[73].y() - 1 );
+            updateSmallFontLetterShadow( font[237 - 32] );
 
             // n with tilde ~.
             font[241 - 32] = font[110 - 32];
@@ -1814,8 +1842,13 @@ namespace
             font[242 - 32].setPosition( font[79].x(), font[79].y() - 3 );
             updateSmallFontLetterShadow( font[242 - 32] );
 
-            // o with accute accent.
-            font[243 - 32] = font[79];
+            // o with acute accent.
+            font[243 - 32].resize( font[79].width(), font[79].height() + 3 );
+            font[243 - 32].reset();
+            fheroes2::Copy( font[79], 0, 0, font[243 - 32], 0, 3, font[79].width(), font[79].height() );
+            fheroes2::Copy( font[193 - 32], 5, 0, font[243 - 32], 3, 0, 2, 2 );
+            font[243 - 32].setPosition( font[79].x(), font[79].y() - 3 );
+            updateSmallFontLetterShadow( font[243 - 32] );
 
             // o with 2 dots on top.
             font[246 - 32].resize( font[79].width(), font[79].height() + 2 );
@@ -1844,8 +1877,14 @@ namespace
             font[249 - 32].setPosition( font[85].x(), font[85].y() - 3 );
             updateSmallFontLetterShadow( font[249 - 32] );
 
-            // u with accute accent.
+            // u with acute accent.
             font[250 - 32] = font[85];
+            font[250 - 32].resize( font[85].width(), font[85].height() + 3 );
+            font[250 - 32].reset();
+            fheroes2::Copy( font[85], 0, 0, font[250 - 32], 0, 3, font[85].width(), font[85].height() );
+            fheroes2::Copy( font[193 - 32], 5, 0, font[250 - 32], 3, 0, 2, 2 );
+            font[250 - 32].setPosition( font[85].x(), font[85].y() - 3 );
+            updateSmallFontLetterShadow( font[250 - 32] );
 
             // u with 2 dots on top.
             font[252 - 32].resize( font[85].width(), font[85].height() + 2 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1449,7 +1449,7 @@ namespace
             updateSmallFontLetterShadow( font[255 - 32] );
         }
     }
-    // CP1252 supports Italian, Spanish Norwegian, Swedish and Danish (and French but OG has custom encoding)
+    // CP1252 supports German, Italian, Spanish, Norwegian, Swedish and Danish (and French but OG has custom encoding)
     void generateCP1252Alphabet( std::vector<std::vector<fheroes2::Sprite>> & icnVsSprite )
     {
         // Resize fonts.
@@ -1681,6 +1681,9 @@ namespace
         {
             std::vector<fheroes2::Sprite> & font = icnVsSprite[ICN::SMALFONT];
 
+            // Inverted question mark ?. Replaced with normal for now.
+            font[191 - 32] = font[63 - 32];
+
             // A with grave accent `. Generate grave accent for further use.
             font[192 - 32].resize( font[33].width(), font[33].height() + 3 );
             font[192 - 32].reset();
@@ -1690,6 +1693,9 @@ namespace
             fheroes2::Copy( font[192 - 32], 4, 4, font[192 - 32], 6, 2, 1, 1 );
             font[192 - 32].setPosition( font[33].x(), font[33].y() - 4 );
             updateSmallFontLetterShadow( font[192 - 32] );
+
+            // A with acute accent.
+            font[193 - 32] = font[33];
 
             // A with circle on top.
             font[197 - 32].resize( font[33].width(), font[33].height() + 4 );
@@ -1740,6 +1746,12 @@ namespace
             font[204 - 32].setPosition( font[41].x(), font[41].y() - 4 );
             updateSmallFontLetterShadow( font[204 - 32] );
 
+            // I with accute accent.
+            font[205 - 32] = font[41];
+
+            // N with tilde ~
+            font[209 - 32] = font[46];
+
             // O with grave accent `.
             font[210 - 32].resize( font[47].width(), font[47].height() + 4 );
             font[210 - 32].reset();
@@ -1747,6 +1759,9 @@ namespace
             fheroes2::Copy( font[192 - 32], 4, 0, font[210 - 32], 4, 0, 3, 3 );
             font[210 - 32].setPosition( font[47].x(), font[47].y() - 4 );
             updateSmallFontLetterShadow( font[210 - 32] );
+
+            // O with accute accent.
+            font[211 - 32] = font[47];
 
             // O with / inside.
             font[216 - 32].resize( font[47].width(), font[47].height() );
@@ -1766,6 +1781,9 @@ namespace
             font[217 - 32].setPosition( font[53].x(), font[53].y() - 4 );
             updateSmallFontLetterShadow( font[217 - 32] );
 
+            // U with accute accent.
+            font[218 - 32] = font[53];
+
             // a with grave accent `.
             font[224 - 32].resize( font[65].width(), font[65].height() + 3 );
             font[224 - 32].reset();
@@ -1773,6 +1791,9 @@ namespace
             fheroes2::Copy( font[192 - 32], 4, 0, font[224 - 32], 3, 0, 3, 2 );
             font[224 - 32].setPosition( font[65].x(), font[65].y() - 3 );
             updateSmallFontLetterShadow( font[224 - 32] );
+
+            // a with accute accent.
+            font[225 - 32] = font[65];
 
             // a with circle on top.
             font[229 - 32].resize( font[65].width(), font[65].height() + 3 );
@@ -1816,6 +1837,12 @@ namespace
             font[236 - 32].setPosition( font[73].x(), font[73].y() - 1 );
             updateSmallFontLetterShadow( font[236 - 32] );
 
+            // i with accute accent.
+            font[237 - 32] = font[73];
+
+            // n with tilde ~.
+            font[241 - 32] = font[110 - 32];
+
             // o with grave accent `.
             font[242 - 32].resize( font[79].width(), font[79].height() + 3 );
             font[242 - 32].reset();
@@ -1823,6 +1850,9 @@ namespace
             fheroes2::Copy( font[192 - 32], 4, 0, font[242 - 32], 3, 0, 3, 2 );
             font[242 - 32].setPosition( font[79].x(), font[79].y() - 3 );
             updateSmallFontLetterShadow( font[242 - 32] );
+
+            // o with accute accent.
+            font[243 - 32] = font[79];
 
             // o with / inside.
             font[248 - 32].resize( font[79].width(), font[79].height() );
@@ -1841,6 +1871,9 @@ namespace
             fheroes2::Copy( font[192 - 32], 4, 0, font[249 - 32], 3, 0, 3, 2 );
             font[249 - 32].setPosition( font[85].x(), font[85].y() - 3 );
             updateSmallFontLetterShadow( font[249 - 32] );
+
+            // u with accute accent.
+            font[250 - 32] = font[85];
 
             // Proper lowercase k. Kept at end in case any letters use it for generation.
             font[75].resize( 6, 8 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1415,7 +1415,7 @@ namespace
             font[209 - 32].reset();
             fheroes2::Copy( font[46], 0, 0, font[209 - 32], 0, 3, font[46].width(), font[46].height() );
             fheroes2::Copy( font[37 - 32], 7, 5, font[209 - 32], 4, 0, 5, 2 );
-            fheroes2::Copy( font[37 - 32], 8, 8, font[209 - 32], 8, 2, 3, 1);
+            fheroes2::Copy( font[37 - 32], 8, 8, font[209 - 32], 8, 2, 3, 1 );
             fheroes2::Copy( font[37 - 32], 10, 7, font[209 - 32], 10, 1, 2, 1 );
             font[209 - 32].setPosition( font[46].x(), font[46].y() - 3 );
             updateNormalFontLetterShadow( font[209 - 32] );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1283,11 +1283,38 @@ namespace
         {
             std::vector<fheroes2::Sprite> & font = icnVsSprite[ICN::FONT];
 
-            // Inverted exclamation mark ?. Replaced with normal for now.
-            font[161 - 32] = font[33 - 32];
+            // Inverted exclamation mark !.
+            font[161 - 32].resize( font[33 - 32].width() + 1, font[33 - 32].height() + 3 );
+            font[161 - 32].reset();
+            fheroes2::Copy( font[33 - 32], 1, 0, font[161 - 32], 1, 3, font[33 - 32].width(), font[33 - 32].height() );
+            {
+                // TODO: add proper Flip function variant.
+                fheroes2::Sprite temp = font[161 - 32];
+                temp = fheroes2::Flip( temp, false, true );
+                fheroes2::Copy( temp, 0, 2, font[161 - 32], 1, 2, temp.width(), temp.height() );
+            }
+            font[161 - 32].setPosition( font[33 - 32].x(), font[33 - 32].y() + 2 );
+            updateNormalFontLetterShadow( font[161 - 32] );
 
             // Inverted question mark ?. Replaced with normal for now.
-            font[191 - 32] = font[63 - 32];
+            font[191 - 32].resize( font[63 - 32].width() + 1, font[63 - 32].height() );
+            font[191 - 32].reset();
+            fheroes2::Copy( font[63 - 32], 1, 0, font[191 - 32], 0, 0, font[63 - 32].width(), 11 );
+            {
+                // TODO: add proper Flip function variant.
+                fheroes2::Sprite temp = font[191 - 32];
+                temp = fheroes2::Flip( temp, true, true );
+                fheroes2::Copy( temp, 1, 2, font[191 - 32], 0, 0, temp.width(), temp.height() );
+            }
+            // Remove old shadows
+            fheroes2::FillTransform( font[191 - 32], 6, 1, 1, 2, 1 );
+            fheroes2::FillTransform( font[191 - 32], 5, 2, 1, 1, 1 );
+            fheroes2::FillTransform( font[191 - 32], 2, 4, 1, 1, 1 );
+            fheroes2::FillTransform( font[191 - 32], 3, 8, 5, 1, 1 );
+            fheroes2::FillTransform( font[191 - 32], 4, 7, 3, 1, 1 );
+            fheroes2::FillTransform( font[191 - 32], 8, 5, 1, 1, 1 );
+            font[191 - 32].setPosition( font[63 - 32].x(), font[63 - 32].y() + 2 );
+            updateNormalFontLetterShadow( font[191 - 32] );
 
             // A with grave accent ` and generate the grave accent for further use.
             font[192 - 32].resize( font[33].width(), font[33].height() + 3 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1410,7 +1410,6 @@ namespace
 
             // N with tilde ~. Generate accent for further use.
             // TODO: Move tilde generation code to A with tilde when adding Portuguese.
-            font[209 - 32] = font[46];
             font[209 - 32].resize( font[46].width(), font[46].height() + 3 );
             font[209 - 32].reset();
             fheroes2::Copy( font[46], 0, 0, font[209 - 32], 0, 3, font[46].width(), font[46].height() );
@@ -1578,7 +1577,6 @@ namespace
             updateNormalFontLetterShadow( font[237 - 32] );
 
             // n with tilde ~.
-            font[241 - 32] = font[110 - 32];
             font[241 - 32].resize( font[110 - 32].width(), font[110 - 32].height() + 4 );
             font[241 - 32].reset();
             fheroes2::Copy( font[110 - 32], 0, 0, font[241 - 32], 0, 4, font[110 - 32].width(), font[110 - 32].height() );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1308,7 +1308,7 @@ namespace
             fheroes2::Copy( font[192 - 32], 4, 4, font[192 - 32], 9, 1, 1, 1 );
             fheroes2::Copy( font[192 - 32], 3, 3, font[192 - 32], 10, 1, 1, 1 );
             updateNormalFontLetterShadow( font[192 - 32] );
-            
+
             // A with acute accent.
             font[193 - 32] = font[33];
 
@@ -1589,7 +1589,6 @@ namespace
             fheroes2::Copy( font[43], 6, 6, font[75], 4, 8, 4, 1 );
             font[75].setPosition( font[75].x(), font[75].y() );
             updateNormalFontLetterShadow( font[75] );
-
         }
         // Small font.
         {

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1251,17 +1251,6 @@ namespace
             fheroes2::Copy( font[253 - 32], 1, 0, font[231 - 32], 1, 1, 1, 1 );
             updateSmallFontLetterShadow( font[231 - 32] );
 
-            // o with / inside.
-            font[248 - 32].resize( font[79].width(), font[79].height() );
-            font[248 - 32].reset();
-            fheroes2::Copy( font[79], 0, 0, font[248 - 32], 0, 0, font[79].width(), font[79].height() );
-            fheroes2::Copy( font[88], 5, 0, font[248 - 32], 3, 2, 4, 4 );
-            fheroes2::Copy( font[79], 6, 5, font[248 - 32], 6, 5, 1, 1 );
-            fheroes2::Copy( font[88], 1, 6, font[248 - 32], 1, 6, 2, 1 );
-            fheroes2::Copy( font[88], 7, 0, font[248 - 32], 7, 0, 2, 1 );
-            font[248 - 32].setPosition( font[79].x(), font[79].y() );
-            updateNormalFontLetterShadow( font[248 - 32] );
-
             font[254 - 32].resize( font[79].width() + 2, font[79].height() );
             font[254 - 32].reset();
             fheroes2::Copy( font[82], 1, 0, font[254 - 32], 1, 0, 2, 5 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1420,6 +1420,17 @@ namespace
             fheroes2::Copy( font[253 - 32], 1, 0, font[231 - 32], 1, 1, 1, 1 );
             updateSmallFontLetterShadow( font[231 - 32] );
 
+            // o with / inside.
+            font[248 - 32].resize( font[79].width(), font[79].height() );
+            font[248 - 32].reset();
+            fheroes2::Copy( font[79], 0, 0, font[248 - 32], 0, 0, font[79].width(), font[79].height() );
+            fheroes2::Copy( font[88], 5, 0, font[248 - 32], 3, 2, 4, 4 );
+            fheroes2::Copy( font[79], 6, 5, font[248 - 32], 6, 5, 1, 1 );
+            fheroes2::Copy( font[88], 1, 6, font[248 - 32], 1, 6, 2, 1 );
+            fheroes2::Copy( font[88], 7, 0, font[248 - 32], 7, 0, 2, 1 );
+            font[248 - 32].setPosition( font[79].x(), font[79].y() );
+            updateNormalFontLetterShadow( font[248 - 32] );
+
             font[254 - 32].resize( font[79].width() + 2, font[79].height() );
             font[254 - 32].reset();
             fheroes2::Copy( font[82], 1, 0, font[254 - 32], 1, 0, 2, 5 );
@@ -1438,8 +1449,8 @@ namespace
             updateSmallFontLetterShadow( font[255 - 32] );
         }
     }
-
-    void generateItalianAlphabet( std::vector<std::vector<fheroes2::Sprite>> & icnVsSprite )
+    // CP1252 supports Italian, Spanish Norwegian, Swedish and Danish (and French but OG has custom encoding)
+    void generateCP1252Alphabet( std::vector<std::vector<fheroes2::Sprite>> & icnVsSprite )
     {
         // Resize fonts.
         for ( const int icnId : { ICN::FONT, ICN::SMALFONT } ) {
@@ -1452,6 +1463,9 @@ namespace
         {
             std::vector<fheroes2::Sprite> & font = icnVsSprite[ICN::FONT];
 
+            // Upside down question mark ?.
+            font[191 - 32] = font[63 - 32];
+
             // A with grave accent ` and generate the grave accent for further use.
             font[192 - 32].resize( font[33].width(), font[33].height() + 3 );
             font[192 - 32].reset();
@@ -1463,6 +1477,34 @@ namespace
             fheroes2::Copy( font[192 - 32], 4, 4, font[192 - 32], 9, 1, 1, 1 );
             fheroes2::Copy( font[192 - 32], 3, 3, font[192 - 32], 10, 1, 1, 1 );
             updateNormalFontLetterShadow( font[192 - 32] );
+            
+            // A with acute accent.
+            font[193 - 32] = font[33];
+
+            // A with circle on top.
+            font[197 - 32].resize( font[33].width(), font[33].height() + 2 );
+            font[197 - 32].reset();
+            fheroes2::Copy( font[33], 0, 3, font[197 - 32], 0, 5, font[33].width(), font[33].height() );
+            fheroes2::FillTransform( font[197 - 32], 2, 5, 3, 3, 1 );
+            fheroes2::Copy( font[80], 5, 6, font[197 - 32], 7, 4, 4, 1 );
+            fheroes2::Copy( font[80], 5, 6, font[197 - 32], 7, 0, 4, 1 );
+            fheroes2::Copy( font[80], 5, 6, font[197 - 32], 7, 2, 4, 1 );
+            fheroes2::Copy( font[84], 1, 0, font[197 - 32], 7, 1, 1, 1 );
+            fheroes2::Copy( font[84], 1, 0, font[197 - 32], 10, 1, 1, 1 );
+            font[197 - 32].setPosition( font[33].x(), font[33].y() - 2 );
+            updateNormalFontLetterShadow( font[197 - 32] );
+
+            // A attached to E.
+            font[198 - 32].resize( font[33].width() + 3, font[33].height() );
+            font[198 - 32].reset();
+            fheroes2::Copy( font[33], 0, 0, font[198 - 32], 0, 0, font[33].width(), font[33].height() );
+            fheroes2::Copy( font[37], 6, 0, font[198 - 32], 12, 0, 6, 4 );
+            fheroes2::Copy( font[37], 5, 0, font[198 - 32], 10, 0, 2, 2 );
+            fheroes2::Copy( font[37], 6, 4, font[198 - 32], 12, 4, 3, 2 );
+            fheroes2::Copy( font[37], 6, 4, font[198 - 32], 15, 4, 1, 2 );
+            fheroes2::Copy( font[37], 8, 9, font[198 - 32], 14, 9, 3, 2 );
+            font[198 - 32].setPosition( font[33].x(), font[33].y() );
+            updateNormalFontLetterShadow( font[198 - 32] );
 
             // E with grave accent `.
             font[200 - 32].resize( font[37].width(), font[37].height() + 3 );
@@ -1472,6 +1514,14 @@ namespace
             fheroes2::Copy( font[192 - 32], 7, 0, font[200 - 32], 4, 0, 4, 2 );
             updateNormalFontLetterShadow( font[200 - 32] );
 
+            // E with acute accent.
+            font[201 - 32].resize( font[37].width(), font[37].height() + 3 );
+            font[201 - 32].reset();
+            fheroes2::Copy( font[37], 0, 0, font[201 - 32], 0, 3, font[37].width(), font[37].height() );
+            fheroes2::Copy( font[233 - 32], 3, 0, font[201 - 32], 5, 0, 4, 2 );
+            font[201 - 32].setPosition( font[37].x(), font[37].y() - 3 );
+            updateNormalFontLetterShadow( font[201 - 32] );
+
             // I with grave accent `.
             font[204 - 32].resize( font[41].width(), font[41].height() + 3 );
             font[204 - 32].reset();
@@ -1480,6 +1530,9 @@ namespace
             fheroes2::Copy( font[192 - 32], 7, 0, font[204 - 32], 3, 0, 4, 2 );
             updateNormalFontLetterShadow( font[204 - 32] );
 
+            // N with tilde ~
+            font[209 - 32] = font[46];
+
             // O with grave accent `.
             font[210 - 32].resize( font[47].width(), font[47].height() + 3 );
             font[210 - 32].reset();
@@ -1487,6 +1540,18 @@ namespace
             font[210 - 32].setPosition( font[47].x(), font[47].y() - 3 );
             fheroes2::Copy( font[192 - 32], 7, 0, font[210 - 32], 6, 0, 4, 2 );
             updateNormalFontLetterShadow( font[210 - 32] );
+
+            // O with / inside.
+            font[216 - 32].resize( font[47].width() + 2, font[47].height() );
+            font[216 - 32].reset();
+            fheroes2::Copy( font[47], 0, 0, font[216 - 32], 0, 0, font[47].width(), font[47].height() );
+            fheroes2::Copy( font[56], 10, 0, font[216 - 32], 6, 3, 5, 5 );
+            fheroes2::Copy( font[56], 13, 0, font[216 - 32], font[47].width() - 1, 0, 3, 2 );
+            fheroes2::Copy( font[47], font[47].width() - 3, 1, font[216 - 32], font[47].width() - 3, 2, 2, 1 );
+            fheroes2::Copy( font[33], 1, 7, font[216 - 32], 1, 7, 2, 4 );
+            fheroes2::Copy( font[56], 10, 3, font[216 - 32], 3, font[47].height() - 4, 2, 2 );
+            font[216 - 32].setPosition( font[47].x(), font[47].y() );
+            updateNormalFontLetterShadow( font[216 - 32] );
 
             // U with grave accent `.
             font[217 - 32].resize( font[53].width(), font[53].height() + 3 );
@@ -1504,6 +1569,26 @@ namespace
             fheroes2::Copy( font[192 - 32], 7, 0, font[224 - 32], 3, 0, 4, 2 );
             updateNormalFontLetterShadow( font[224 - 32] );
 
+            // a with circle on top.
+            font[229 - 32].resize( font[65].width(), font[65].height() + 5 );
+            font[229 - 32].reset();
+            fheroes2::Copy( font[65], 0, 0, font[229 - 32], 0, 4, font[65].width(), font[65].height() );
+            fheroes2::Copy( font[197 - 32], 7, 0, font[229 - 32], 2, 0, 1, 3 );
+            fheroes2::Copy( font[197 - 32], 10, 0, font[229 - 32], 6, 0, 1, 3 );
+            fheroes2::Copy( font[65], 2, 0, font[229 - 32], 3, 0, 3, 1 );
+            fheroes2::Copy( font[65], 2, 0, font[229 - 32], 3, 2, 3, 1 );
+            fheroes2::Copy( font[69], 3, 2, font[229 - 32], 3, 1, 3, 1 );
+            font[229 - 32].setPosition( font[65].x(), font[65].y() - 4 );
+            updateNormalFontLetterShadow( font[229 - 32] );
+
+            // a attached to e.
+            font[230 - 32].resize( font[65].width() + 4, font[65].height() );
+            font[230 - 32].reset();
+            fheroes2::Copy( font[65], 0, 0, font[230 - 32], 0, 0, font[65].width(), font[65].height() );
+            fheroes2::Copy( font[69], 3, 0, font[230 - 32], 8, 0, 6, 8 );
+            font[230 - 32].setPosition( font[65].x(), font[65].y() );
+            updateNormalFontLetterShadow( font[230 - 32] );
+
             // e with grave accent `.
             font[232 - 32].resize( font[69].width(), font[69].height() + 3 );
             font[232 - 32].reset();
@@ -1511,28 +1596,6 @@ namespace
             font[232 - 32].setPosition( font[69].x(), font[69].y() - 3 );
             fheroes2::Copy( font[192 - 32], 7, 0, font[232 - 32], 3, 0, 4, 2 );
             updateNormalFontLetterShadow( font[232 - 32] );
-
-            // i with grave accent `.
-            font[236 - 32] = font[73];
-            fheroes2::FillTransform( font[236 - 32], 0, 0, font[236 - 32].width(), 2, 1 );
-            fheroes2::Copy( font[192 - 32], 7, 0, font[236 - 32], 1, 0, 4, 2 );
-            updateNormalFontLetterShadow( font[236 - 32] );
-
-            // o with grave accent `.
-            font[242 - 32].resize( font[79].width(), font[79].height() + 3 );
-            font[242 - 32].reset();
-            fheroes2::Copy( font[79], 0, 0, font[242 - 32], 0, 3, font[79].width(), font[79].height() );
-            font[242 - 32].setPosition( font[79].x(), font[79].y() - 3 );
-            fheroes2::Copy( font[192 - 32], 7, 0, font[242 - 32], 3, 0, 4, 2 );
-            updateNormalFontLetterShadow( font[242 - 32] );
-
-            // u with grave accent `.
-            font[249 - 32].resize( font[85].width(), font[85].height() + 3 );
-            font[249 - 32].reset();
-            fheroes2::Copy( font[85], 0, 0, font[249 - 32], 0, 3, font[85].width(), font[85].height() );
-            font[249 - 32].setPosition( font[85].x(), font[85].y() - 3 );
-            fheroes2::Copy( font[192 - 32], 7, 0, font[249 - 32], 3, 0, 4, 2 );
-            updateNormalFontLetterShadow( font[249 - 32] );
 
             // e with acute accent and generate the acute accent for further use.
             font[233 - 32].resize( font[69].width(), font[69].height() + 3 );
@@ -1546,13 +1609,52 @@ namespace
             font[233 - 32].setPosition( font[69].x(), font[69].y() - 3 );
             updateNormalFontLetterShadow( font[233 - 32] );
 
-            // E with acute accent.
-            font[201 - 32].resize( font[37].width(), font[37].height() + 3 );
-            font[201 - 32].reset();
-            fheroes2::Copy( font[37], 0, 0, font[201 - 32], 0, 3, font[37].width(), font[37].height() );
-            fheroes2::Copy( font[233 - 32], 3, 0, font[201 - 32], 5, 0, 4, 2 );
-            font[201 - 32].setPosition( font[37].x(), font[37].y() - 3 );
-            updateNormalFontLetterShadow( font[201 - 32] );
+            // i with grave accent `.
+            font[236 - 32] = font[73];
+            fheroes2::FillTransform( font[236 - 32], 0, 0, font[236 - 32].width(), 2, 1 );
+            fheroes2::Copy( font[192 - 32], 7, 0, font[236 - 32], 1, 0, 4, 2 );
+            updateNormalFontLetterShadow( font[236 - 32] );
+
+            // n with tilde ~.
+            font[241 - 32] = font[110 - 32];
+
+            // o with grave accent `.
+            font[242 - 32].resize( font[79].width(), font[79].height() + 3 );
+            font[242 - 32].reset();
+            fheroes2::Copy( font[79], 0, 0, font[242 - 32], 0, 3, font[79].width(), font[79].height() );
+            font[242 - 32].setPosition( font[79].x(), font[79].y() - 3 );
+            fheroes2::Copy( font[192 - 32], 7, 0, font[242 - 32], 3, 0, 4, 2 );
+            updateNormalFontLetterShadow( font[242 - 32] );
+
+            // o with / inside.
+            font[248 - 32].resize( font[79].width(), font[79].height() );
+            font[248 - 32].reset();
+            fheroes2::Copy( font[79], 0, 0, font[248 - 32], 0, 0, font[79].width(), font[79].height() );
+            fheroes2::Copy( font[88], 5, 0, font[248 - 32], 3, 2, 4, 4 );
+            fheroes2::Copy( font[79], 6, 5, font[248 - 32], 6, 5, 1, 1 );
+            fheroes2::Copy( font[88], 1, 6, font[248 - 32], 1, 6, 2, 1 );
+            fheroes2::Copy( font[88], 7, 0, font[248 - 32], 7, 0, 2, 1 );
+            font[248 - 32].setPosition( font[79].x(), font[79].y() );
+            updateNormalFontLetterShadow( font[248 - 32] );
+
+            // u with grave accent `.
+            font[249 - 32].resize( font[85].width(), font[85].height() + 3 );
+            font[249 - 32].reset();
+            fheroes2::Copy( font[85], 0, 0, font[249 - 32], 0, 3, font[85].width(), font[85].height() );
+            font[249 - 32].setPosition( font[85].x(), font[85].y() - 3 );
+            fheroes2::Copy( font[192 - 32], 7, 0, font[249 - 32], 3, 0, 4, 2 );
+            updateNormalFontLetterShadow( font[249 - 32] );
+
+            // Proper lowercase k. Kept at end in case any letters use it for generation.
+            fheroes2::FillTransform( font[75], 4, 1, 5, 8, 1 );
+            fheroes2::Copy( font[43], 6, 5, font[75], 4, 7, 3, 1 );
+            fheroes2::Copy( font[43], 6, 4, font[75], 4, 6, 4, 1 );
+            fheroes2::Copy( font[43], 7, 4, font[75], 6, 5, 3, 1 );
+            fheroes2::Copy( font[43], 7, 4, font[75], 7, 4, 2, 1 );
+            fheroes2::Copy( font[43], 6, 6, font[75], 4, 8, 4, 1 );
+            font[75].setPosition( font[75].x(), font[75].y() );
+            updateNormalFontLetterShadow( font[75] );
+
         }
         // Small font.
         {
@@ -1568,6 +1670,29 @@ namespace
             font[192 - 32].setPosition( font[33].x(), font[33].y() - 4 );
             updateSmallFontLetterShadow( font[192 - 32] );
 
+            // A with circle on top.
+            font[197 - 32].resize( font[33].width(), font[33].height() + 4 );
+            font[197 - 32].reset();
+            fheroes2::Copy( font[33], 0, 0, font[197 - 32], 0, 2, font[33].width(), font[33].height() );
+            fheroes2::FillTransform( font[197 - 32], 3, 2, 3, 1, 1 );
+            fheroes2::FillTransform( font[197 - 32], 1, 2, 3, 3, 1 );
+            // Generate circle for further use.
+            fheroes2::Copy( font[69], 2, 0, font[197 - 32], 5, 0, 1, 1 );
+            fheroes2::Copy( font[69], 2, 0, font[197 - 32], 6, 1, 1, 1 );
+            fheroes2::Copy( font[69], 2, 0, font[197 - 32], 5, 2, 1, 1 );
+            fheroes2::Copy( font[69], 2, 0, font[197 - 32], 4, 1, 1, 1 );
+            font[197 - 32].setPosition( font[33].x(), font[33].y() - 2 );
+            updateSmallFontLetterShadow( font[197 - 32] );
+
+            // A attached to E.
+            font[198 - 32].resize( font[33].width() + 3, font[33].height() );
+            font[198 - 32].reset();
+            fheroes2::Copy( font[33], 0, 0, font[198 - 32], 0, 0, font[33].width(), font[33].height() );
+            fheroes2::Copy( font[37], 3, 0, font[198 - 32], 6, 0, 5, 4 );
+            fheroes2::Copy( font[37], 1, 0, font[198 - 32], 9, 5, 2, 2 );
+            font[198 - 32].setPosition( font[33].x(), font[33].y() );
+            updateSmallFontLetterShadow( font[198 - 32] );
+
             // E with grave accent `.
             font[200 - 32].resize( font[37].width(), font[37].height() + 4 );
             font[200 - 32].reset();
@@ -1575,6 +1700,16 @@ namespace
             fheroes2::Copy( font[192 - 32], 4, 0, font[200 - 32], 4, 0, 3, 3 );
             font[200 - 32].setPosition( font[37].x(), font[37].y() - 4 );
             updateSmallFontLetterShadow( font[200 - 32] );
+
+            // E with acute accent. Generate the acute accent for further use.
+            font[201 - 32].resize( font[37].width(), font[37].height() + 4 );
+            font[201 - 32].reset();
+            fheroes2::Copy( font[37], 0, 0, font[201 - 32], 0, 4, font[37].width(), font[37].height() );
+            fheroes2::Copy( font[201 - 32], 4, 4, font[201 - 32], 3, 2, 1, 1 );
+            fheroes2::Copy( font[201 - 32], 4, 4, font[201 - 32], 4, 1, 1, 1 );
+            fheroes2::Copy( font[201 - 32], 4, 4, font[201 - 32], 5, 0, 1, 1 );
+            font[201 - 32].setPosition( font[37].x(), font[37].y() - 4 );
+            updateSmallFontLetterShadow( font[201 - 32] );
 
             // I with grave accent `.
             font[204 - 32].resize( font[41].width(), font[41].height() + 4 );
@@ -1592,6 +1727,16 @@ namespace
             font[210 - 32].setPosition( font[47].x(), font[47].y() - 4 );
             updateSmallFontLetterShadow( font[210 - 32] );
 
+            // O with / inside.
+            font[216 - 32].resize( font[47].width(), font[47].height() );
+            font[216 - 32].reset();
+            fheroes2::Copy( font[47], 0, 0, font[216 - 32], 0, 0, font[47].width(), font[47].height() );
+            fheroes2::Copy( font[56], 6, 0, font[216 - 32], 3, 2, 3, 3 );
+            fheroes2::Copy( font[56], 1, 0, font[216 - 32], font[47].width() - 1, 0, 1, 1 );
+            fheroes2::Copy( font[56], 1, 0, font[216 - 32], 1, font[47].height() - 2, 1, 1 );
+            font[216 - 32].setPosition( font[47].x(), font[47].y() );
+            updateSmallFontLetterShadow( font[216 - 32] );
+
             // U with grave accent `.
             font[217 - 32].resize( font[53].width(), font[53].height() + 4 );
             font[217 - 32].reset();
@@ -1608,6 +1753,22 @@ namespace
             font[224 - 32].setPosition( font[65].x(), font[65].y() - 3 );
             updateSmallFontLetterShadow( font[224 - 32] );
 
+            // a with circle on top.
+            font[229 - 32].resize( font[65].width(), font[65].height() + 3 );
+            font[229 - 32].reset();
+            fheroes2::Copy( font[65], 0, 0, font[229 - 32], 0, 3, font[65].width(), font[65].height() );
+            fheroes2::Copy( font[197 - 32], 4, 0, font[229 - 32], 2, 0, 3, 3 );
+            font[229 - 32].setPosition( font[65].x(), font[65].y() - 3 );
+            updateSmallFontLetterShadow( font[229 - 32] );
+
+            // a attached to e.
+            font[230 - 32].resize( font[65].width() + 3, font[65].height() );
+            font[230 - 32].reset();
+            fheroes2::Copy( font[65], 0, 0, font[230 - 32], 0, 0, font[65].width(), font[65].height() );
+            fheroes2::Copy( font[69], 2, 0, font[230 - 32], 6, 0, font[69].width() - 2, font[69].height() );
+            font[230 - 32].setPosition( font[65].x(), font[65].y() );
+            updateSmallFontLetterShadow( font[230 - 32] );
+
             // e with grave accent `.
             font[232 - 32].resize( font[69].width(), font[69].height() + 3 );
             font[232 - 32].reset();
@@ -1615,6 +1776,14 @@ namespace
             fheroes2::Copy( font[192 - 32], 4, 0, font[232 - 32], 3, 0, 3, 2 );
             font[232 - 32].setPosition( font[69].x(), font[69].y() - 3 );
             updateSmallFontLetterShadow( font[232 - 32] );
+
+            // e with acute accent.
+            font[233 - 32].resize( font[69].width(), font[69].height() + 3 );
+            font[233 - 32].reset();
+            fheroes2::Copy( font[69], 0, 0, font[233 - 32], 0, 3, font[69].width(), font[69].height() );
+            fheroes2::Copy( font[201 - 32], 4, 0, font[233 - 32], 3, 0, 3, 2 );
+            font[233 - 32].setPosition( font[69].x(), font[69].y() - 3 );
+            updateSmallFontLetterShadow( font[233 - 32] );
 
             // i with grave accent `.
             font[236 - 32].resize( font[73].width(), font[73].height() + 1 );
@@ -1634,180 +1803,6 @@ namespace
             font[242 - 32].setPosition( font[79].x(), font[79].y() - 3 );
             updateSmallFontLetterShadow( font[242 - 32] );
 
-            // u with grave accent `.
-            font[249 - 32].resize( font[85].width(), font[85].height() + 3 );
-            font[249 - 32].reset();
-            fheroes2::Copy( font[85], 0, 0, font[249 - 32], 0, 3, font[85].width(), font[85].height() );
-            fheroes2::Copy( font[192 - 32], 4, 0, font[249 - 32], 3, 0, 3, 2 );
-            font[249 - 32].setPosition( font[85].x(), font[85].y() - 3 );
-            updateSmallFontLetterShadow( font[249 - 32] );
-
-            // E with acute accent. Generate the acute accent for further use.
-            font[201 - 32].resize( font[37].width(), font[37].height() + 4 );
-            font[201 - 32].reset();
-            fheroes2::Copy( font[37], 0, 0, font[201 - 32], 0, 4, font[37].width(), font[37].height() );
-            fheroes2::Copy( font[201 - 32], 4, 4, font[201 - 32], 3, 2, 1, 1 );
-            fheroes2::Copy( font[201 - 32], 4, 4, font[201 - 32], 4, 1, 1, 1 );
-            fheroes2::Copy( font[201 - 32], 4, 4, font[201 - 32], 5, 0, 1, 1 );
-            font[201 - 32].setPosition( font[37].x(), font[37].y() - 4 );
-            updateSmallFontLetterShadow( font[201 - 32] );
-
-            // e with acute accent.
-            font[233 - 32].resize( font[69].width(), font[69].height() + 3 );
-            font[233 - 32].reset();
-            fheroes2::Copy( font[69], 0, 0, font[233 - 32], 0, 3, font[69].width(), font[69].height() );
-            fheroes2::Copy( font[201 - 32], 4, 0, font[233 - 32], 3, 0, 3, 2 );
-            font[233 - 32].setPosition( font[69].x(), font[69].y() - 3 );
-            updateSmallFontLetterShadow( font[233 - 32] );
-        }
-    }
-
-    void generateNorwegianAlphabet( std::vector<std::vector<fheroes2::Sprite>> & icnVsSprite )
-    {
-        // Resize fonts. Use CP1252 until UTF-8 support.
-        for ( const int icnId : { ICN::FONT, ICN::SMALFONT } ) {
-            icnVsSprite[icnId].resize( 96 );
-            icnVsSprite[icnId].insert( icnVsSprite[icnId].end(), 160, icnVsSprite[icnId][0] );
-        }
-
-        // Normal font.
-        {
-            std::vector<fheroes2::Sprite> & font = icnVsSprite[ICN::FONT];
-
-            // A with circle on top.
-            font[197 - 32].resize( font[33].width(), font[33].height() + 2 );
-            font[197 - 32].reset();
-            fheroes2::Copy( font[33], 0, 3, font[197 - 32], 0, 5, font[33].width(), font[33].height() );
-            fheroes2::FillTransform( font[197 - 32], 2, 5, 3, 3, 1 );
-            fheroes2::Copy( font[80], 5, 6, font[197 - 32], 7, 4, 4, 1 );
-            fheroes2::Copy( font[80], 5, 6, font[197 - 32], 7, 0, 4, 1 );
-            fheroes2::Copy( font[80], 5, 6, font[197 - 32], 7, 2, 4, 1 );
-            fheroes2::Copy( font[84], 1, 0, font[197 - 32], 7, 1, 1, 1 );
-            fheroes2::Copy( font[84], 1, 0, font[197 - 32], 10, 1, 1, 1 );
-            font[197 - 32].setPosition( font[33].x(), font[33].y() - 2 );
-            updateNormalFontLetterShadow( font[197 - 32] );
-
-            // a with circle on top.
-            font[229 - 32].resize( font[65].width(), font[65].height() + 5 );
-            font[229 - 32].reset();
-            fheroes2::Copy( font[65], 0, 0, font[229 - 32], 0, 4, font[65].width(), font[65].height() );
-            fheroes2::Copy( font[197 - 32], 7, 0, font[229 - 32], 2, 0, 1, 3 );
-            fheroes2::Copy( font[197 - 32], 10, 0, font[229 - 32], 6, 0, 1, 3 );
-            fheroes2::Copy( font[65], 2, 0, font[229 - 32], 3, 0, 3, 1 );
-            fheroes2::Copy( font[65], 2, 0, font[229 - 32], 3, 2, 3, 1 );
-            fheroes2::Copy( font[69], 3, 2, font[229 - 32], 3, 1, 3, 1 );
-            font[229 - 32].setPosition( font[65].x(), font[65].y() - 4 );
-            updateNormalFontLetterShadow( font[229 - 32] );
-
-            // O with / inside.
-            font[216 - 32].resize( font[47].width() + 2, font[47].height() );
-            font[216 - 32].reset();
-            fheroes2::Copy( font[47], 0, 0, font[216 - 32], 0, 0, font[47].width(), font[47].height() );
-            fheroes2::Copy( font[56], 10, 0, font[216 - 32], 6, 3, 5, 5 );
-            fheroes2::Copy( font[56], 13, 0, font[216 - 32], font[47].width() - 1, 0, 3, 2 );
-            fheroes2::Copy( font[47], font[47].width() - 3, 1, font[216 - 32], font[47].width() - 3, 2, 2, 1 );
-            fheroes2::Copy( font[33], 1, 7, font[216 - 32], 1, 7, 2, 4 );
-            fheroes2::Copy( font[56], 10, 3, font[216 - 32], 3, font[47].height() - 4, 2, 2 );
-            font[216 - 32].setPosition( font[47].x(), font[47].y() );
-            updateNormalFontLetterShadow( font[216 - 32] );
-
-            // o with / inside.
-            font[248 - 32].resize( font[79].width(), font[79].height() );
-            font[248 - 32].reset();
-            fheroes2::Copy( font[79], 0, 0, font[248 - 32], 0, 0, font[79].width(), font[79].height() );
-            fheroes2::Copy( font[88], 5, 0, font[248 - 32], 3, 2, 4, 4 );
-            fheroes2::Copy( font[79], 6, 5, font[248 - 32], 6, 5, 1, 1 );
-            fheroes2::Copy( font[88], 1, 6, font[248 - 32], 1, 6, 2, 1 );
-            fheroes2::Copy( font[88], 7, 0, font[248 - 32], 7, 0, 2, 1 );
-            font[248 - 32].setPosition( font[79].x(), font[79].y() );
-            updateNormalFontLetterShadow( font[248 - 32] );
-
-            // A attached to E.
-            font[198 - 32].resize( font[33].width() + 3, font[33].height() );
-            font[198 - 32].reset();
-            fheroes2::Copy( font[33], 0, 0, font[198 - 32], 0, 0, font[33].width(), font[33].height() );
-            fheroes2::Copy( font[37], 6, 0, font[198 - 32], 12, 0, 6, 4 );
-            fheroes2::Copy( font[37], 5, 0, font[198 - 32], 10, 0, 2, 2 );
-            fheroes2::Copy( font[37], 6, 4, font[198 - 32], 12, 4, 3, 2 );
-            fheroes2::Copy( font[37], 6, 4, font[198 - 32], 15, 4, 1, 2 );
-            fheroes2::Copy( font[37], 8, 9, font[198 - 32], 14, 9, 3, 2 );
-            font[198 - 32].setPosition( font[33].x(), font[33].y() );
-            updateNormalFontLetterShadow( font[198 - 32] );
-
-            // a attached to e.
-            font[230 - 32].resize( font[65].width() + 4, font[65].height() );
-            font[230 - 32].reset();
-            fheroes2::Copy( font[65], 0, 0, font[230 - 32], 0, 0, font[65].width(), font[65].height() );
-            fheroes2::Copy( font[69], 3, 0, font[230 - 32], 8, 0, 6, 8 );
-            font[230 - 32].setPosition( font[65].x(), font[65].y() );
-            updateNormalFontLetterShadow( font[230 - 32] );
-
-            // e with acute accent and generate the acute accent for further use.
-            font[233 - 32].resize( font[69].width(), font[69].height() + 3 );
-            font[233 - 32].reset();
-            fheroes2::Copy( font[69], 0, 0, font[233 - 32], 0, 3, font[69].width(), font[69].height() );
-            fheroes2::Copy( font[233 - 32], 4, 8, font[233 - 32], 3, 1, 1, 1 );
-            fheroes2::Copy( font[233 - 32], 8, 6, font[233 - 32], 4, 1, 1, 1 );
-            fheroes2::Copy( font[233 - 32], 8, 6, font[233 - 32], 5, 0, 1, 1 );
-            fheroes2::Copy( font[233 - 32], 4, 3, font[233 - 32], 6, 0, 1, 1 );
-            fheroes2::Copy( font[233 - 32], 4, 3, font[233 - 32], 5, 1, 1, 1 );
-            font[233 - 32].setPosition( font[69].x(), font[69].y() - 3 );
-            updateNormalFontLetterShadow( font[233 - 32] );
-
-            // E with acute accent.
-            font[201 - 32].resize( font[37].width(), font[37].height() + 3 );
-            font[201 - 32].reset();
-            fheroes2::Copy( font[37], 0, 0, font[201 - 32], 0, 3, font[37].width(), font[37].height() );
-            fheroes2::Copy( font[233 - 32], 3, 0, font[201 - 32], 5, 0, 4, 2 );
-            font[201 - 32].setPosition( font[37].x(), font[37].y() - 3 );
-            updateNormalFontLetterShadow( font[201 - 32] );
-
-            // Proper lowercase k.
-            fheroes2::FillTransform( font[75], 4, 1, 5, 8, 1 );
-            fheroes2::Copy( font[43], 6, 5, font[75], 4, 7, 3, 1 );
-            fheroes2::Copy( font[43], 6, 4, font[75], 4, 6, 4, 1 );
-            fheroes2::Copy( font[43], 7, 4, font[75], 6, 5, 3, 1 );
-            fheroes2::Copy( font[43], 7, 4, font[75], 7, 4, 2, 1 );
-            fheroes2::Copy( font[43], 6, 6, font[75], 4, 8, 4, 1 );
-            font[75].setPosition( font[75].x(), font[75].y() );
-            updateNormalFontLetterShadow( font[75] );
-        }
-        // Small font.
-        {
-            std::vector<fheroes2::Sprite> & font = icnVsSprite[ICN::SMALFONT];
-
-            // A with circle on top.
-            font[197 - 32].resize( font[33].width(), font[33].height() + 4 );
-            font[197 - 32].reset();
-            fheroes2::Copy( font[33], 0, 0, font[197 - 32], 0, 2, font[33].width(), font[33].height() );
-            fheroes2::FillTransform( font[197 - 32], 3, 2, 3, 1, 1 );
-            fheroes2::FillTransform( font[197 - 32], 1, 2, 3, 3, 1 );
-            // Generate circle for further use.
-            fheroes2::Copy( font[69], 2, 0, font[197 - 32], 5, 0, 1, 1 );
-            fheroes2::Copy( font[69], 2, 0, font[197 - 32], 6, 1, 1, 1 );
-            fheroes2::Copy( font[69], 2, 0, font[197 - 32], 5, 2, 1, 1 );
-            fheroes2::Copy( font[69], 2, 0, font[197 - 32], 4, 1, 1, 1 );
-            font[197 - 32].setPosition( font[33].x(), font[33].y() - 2 );
-            updateSmallFontLetterShadow( font[197 - 32] );
-
-            // a with circle on top.
-            font[229 - 32].resize( font[65].width(), font[65].height() + 3 );
-            font[229 - 32].reset();
-            fheroes2::Copy( font[65], 0, 0, font[229 - 32], 0, 3, font[65].width(), font[65].height() );
-            fheroes2::Copy( font[197 - 32], 4, 0, font[229 - 32], 2, 0, 3, 3 );
-            font[229 - 32].setPosition( font[65].x(), font[65].y() - 3 );
-            updateSmallFontLetterShadow( font[229 - 32] );
-
-            // O with / inside.
-            font[216 - 32].resize( font[47].width(), font[47].height() );
-            font[216 - 32].reset();
-            fheroes2::Copy( font[47], 0, 0, font[216 - 32], 0, 0, font[47].width(), font[47].height() );
-            fheroes2::Copy( font[56], 6, 0, font[216 - 32], 3, 2, 3, 3 );
-            fheroes2::Copy( font[56], 1, 0, font[216 - 32], font[47].width() - 1, 0, 1, 1 );
-            fheroes2::Copy( font[56], 1, 0, font[216 - 32], 1, font[47].height() - 2, 1, 1 );
-            font[216 - 32].setPosition( font[47].x(), font[47].y() );
-            updateSmallFontLetterShadow( font[216 - 32] );
-
             // o with / inside.
             font[248 - 32].resize( font[79].width(), font[79].height() );
             font[248 - 32].reset();
@@ -1818,42 +1813,15 @@ namespace
             font[248 - 32].setPosition( font[79].x(), font[79].y() );
             updateSmallFontLetterShadow( font[248 - 32] );
 
-            // A attached to E.
-            font[198 - 32].resize( font[33].width() + 3, font[33].height() );
-            font[198 - 32].reset();
-            fheroes2::Copy( font[33], 0, 0, font[198 - 32], 0, 0, font[33].width(), font[33].height() );
-            fheroes2::Copy( font[37], 3, 0, font[198 - 32], 6, 0, 5, 4 );
-            fheroes2::Copy( font[37], 1, 0, font[198 - 32], 9, 5, 2, 2 );
-            font[198 - 32].setPosition( font[33].x(), font[33].y() );
-            updateSmallFontLetterShadow( font[198 - 32] );
+            // u with grave accent `.
+            font[249 - 32].resize( font[85].width(), font[85].height() + 3 );
+            font[249 - 32].reset();
+            fheroes2::Copy( font[85], 0, 0, font[249 - 32], 0, 3, font[85].width(), font[85].height() );
+            fheroes2::Copy( font[192 - 32], 4, 0, font[249 - 32], 3, 0, 3, 2 );
+            font[249 - 32].setPosition( font[85].x(), font[85].y() - 3 );
+            updateSmallFontLetterShadow( font[249 - 32] );
 
-            // a attached to e.
-            font[230 - 32].resize( font[65].width() + 3, font[65].height() );
-            font[230 - 32].reset();
-            fheroes2::Copy( font[65], 0, 0, font[230 - 32], 0, 0, font[65].width(), font[65].height() );
-            fheroes2::Copy( font[69], 2, 0, font[230 - 32], 6, 0, font[69].width() - 2, font[69].height() );
-            font[230 - 32].setPosition( font[65].x(), font[65].y() );
-            updateSmallFontLetterShadow( font[230 - 32] );
-
-            // E with acute accent. Generate the acute accent for further use.
-            font[201 - 32].resize( font[37].width(), font[37].height() + 4 );
-            font[201 - 32].reset();
-            fheroes2::Copy( font[37], 0, 0, font[201 - 32], 0, 4, font[37].width(), font[37].height() );
-            fheroes2::Copy( font[201 - 32], 4, 4, font[201 - 32], 3, 2, 1, 1 );
-            fheroes2::Copy( font[201 - 32], 4, 4, font[201 - 32], 4, 1, 1, 1 );
-            fheroes2::Copy( font[201 - 32], 4, 4, font[201 - 32], 5, 0, 1, 1 );
-            font[201 - 32].setPosition( font[37].x(), font[37].y() - 4 );
-            updateSmallFontLetterShadow( font[201 - 32] );
-
-            // e with acute accent.
-            font[233 - 32].resize( font[69].width(), font[69].height() + 3 );
-            font[233 - 32].reset();
-            fheroes2::Copy( font[69], 0, 0, font[233 - 32], 0, 3, font[69].width(), font[69].height() );
-            fheroes2::Copy( font[201 - 32], 4, 0, font[233 - 32], 3, 0, 3, 2 );
-            font[233 - 32].setPosition( font[69].x(), font[69].y() - 3 );
-            updateSmallFontLetterShadow( font[233 - 32] );
-
-            // Proper lowercase k.
+            // Proper lowercase k. Kept at end in case any letters use it for generation.
             font[75].resize( 6, 8 );
             font[75].reset();
             fheroes2::Copy( font[76], 1, 0, font[75], 1, 0, 2, 7 );
@@ -1888,12 +1856,14 @@ namespace fheroes2
         case SupportedLanguage::Ukrainian:
             generateCP1251Alphabet( icnVsSprite );
             break;
-        case SupportedLanguage::Italian:
-            generateItalianAlphabet( icnVsSprite );
-            break;
         case SupportedLanguage::Norwegian:
-            generateNorwegianAlphabet( icnVsSprite );
+            //generateNorwegianAlphabet( icnVsSprite );
+            //break;
+        case SupportedLanguage::Spanish:
+        case SupportedLanguage::Italian:
+            generateCP1252Alphabet( icnVsSprite );
             break;
+
         default:
             // Add new language generation code!
             assert( 0 );
@@ -1918,6 +1888,7 @@ namespace fheroes2
         case SupportedLanguage::Russian:
         case SupportedLanguage::Belarusian:
         case SupportedLanguage::Bulgarian:
+        case SupportedLanguage::Spanish:
         case SupportedLanguage::Ukrainian:
         case SupportedLanguage::Romanian:
             return true;

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1289,8 +1289,7 @@ namespace
             fheroes2::Copy( font[33 - 32], 1, 0, font[161 - 32], 1, 3, font[33 - 32].width(), font[33 - 32].height() );
             {
                 // TODO: add proper Flip function variant.
-                fheroes2::Sprite temp = font[161 - 32];
-                temp = fheroes2::Flip( temp, false, true );
+                fheroes2::Sprite temp = fheroes2::Flip( font[161 - 32], false, true );
                 fheroes2::Copy( temp, 0, 2, font[161 - 32], 1, 2, temp.width(), temp.height() );
             }
             font[161 - 32].setPosition( font[33 - 32].x(), font[33 - 32].y() + 2 );
@@ -1302,8 +1301,7 @@ namespace
             fheroes2::Copy( font[63 - 32], 1, 0, font[191 - 32], 0, 0, font[63 - 32].width(), 11 );
             {
                 // TODO: add proper Flip function variant.
-                fheroes2::Sprite temp = font[191 - 32];
-                temp = fheroes2::Flip( temp, true, true );
+                fheroes2::Sprite temp = fheroes2::Flip( font[191 - 32], true, true );
                 fheroes2::Copy( temp, 1, 2, font[191 - 32], 0, 0, temp.width(), temp.height() );
             }
             // Remove old shadows
@@ -1665,8 +1663,33 @@ namespace
         {
             std::vector<fheroes2::Sprite> & font = icnVsSprite[ICN::SMALFONT];
 
+            // Inverted exclamation mark !.
+            font[161 - 32].resize( font[33 - 32].width(), font[33 - 32].height() );
+            font[161 - 32].reset();
+            fheroes2::Copy( font[33 - 32], 1, 0, font[161 - 32], 1, 0, font[33 - 32].width(), 7 );
+            {
+                // TODO: add proper Flip function variant.
+                fheroes2::Sprite temp = fheroes2::Flip( font[161 - 32], false, true );
+                fheroes2::Copy( temp, 0, 1, font[161 - 32], 0, 0, temp.width(), temp.height() );
+            }
+            font[161 - 32].setPosition( font[33 - 32].x(), font[33 - 32].y() + 2 );
+            updateSmallFontLetterShadow( font[161 - 32] );
+
             // Inverted question mark ?. Replaced with normal for now.
-            font[191 - 32] = font[63 - 32];
+            font[191 - 32].resize( font[63 - 32].width(), font[63 - 32].height() );
+            font[191 - 32].reset();
+            fheroes2::Copy( font[63 - 32], 1, 0, font[191 - 32], 0, 0, font[63 - 32].width(), 7 );
+            {
+                // TODO: add proper Flip function variant.
+                fheroes2::Sprite temp = fheroes2::Flip( font[191 - 32], true, true );
+                fheroes2::Copy( temp, 0, 1, font[191 - 32], 0, 0, temp.width(), temp.height() );
+            }
+            // Remove old shadows
+            fheroes2::FillTransform( font[191 - 32], 4, 1, 1, 1, 1 );
+            fheroes2::FillTransform( font[191 - 32], 3, 5, 2, 1, 1 );
+            fheroes2::FillTransform( font[191 - 32], 2, 4, 1, 1, 1 );
+            font[191 - 32].setPosition( font[63 - 32].x(), font[63 - 32].y() + 2 );
+            updateSmallFontLetterShadow( font[191 - 32] );
 
             // A with grave accent `. Generate grave accent for further use.
             font[192 - 32].resize( font[33].width(), font[33].height() + 3 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1298,8 +1298,18 @@ namespace
             fheroes2::Copy( font[192 - 32], 3, 3, font[192 - 32], 10, 1, 1, 1 );
             updateNormalFontLetterShadow( font[192 - 32] );
 
-            // A with acute accent.
+            // A with acute accent. Generate the accent for further use.
             font[193 - 32] = font[33];
+            font[193 - 32].resize( font[33].width(), font[33].height() + 3 );
+            font[193 - 32].reset();
+            fheroes2::Copy( font[33], 0, 0, font[193 - 32], 0, 3, font[33].width(), font[33].height() );
+            fheroes2::Copy( font[193 - 32], 3, 4, font[193 - 32], 10, 0, 1, 1 );
+            fheroes2::Copy( font[193 - 32], 4, 4, font[193 - 32], 9, 0, 1, 1 );
+            fheroes2::Copy( font[193 - 32], 3, 4, font[193 - 32], 9, 1, 1, 1 );
+            fheroes2::Copy( font[193 - 32], 4, 4, font[193 - 32], 8, 1, 1, 1 );
+            fheroes2::Copy( font[193 - 32], 3, 3, font[193 - 32], 7, 1, 1, 1 );
+            font[193 - 32].setPosition( font[33].x(), font[33].y() - 3 );
+            updateNormalFontLetterShadow( font[193 - 32] );
 
             // A with 2 dots on top.
             font[196 - 32].resize( font[33].width(), font[33].height() + 3 );
@@ -1348,7 +1358,7 @@ namespace
             font[201 - 32].resize( font[37].width(), font[37].height() + 3 );
             font[201 - 32].reset();
             fheroes2::Copy( font[37], 0, 0, font[201 - 32], 0, 3, font[37].width(), font[37].height() );
-            fheroes2::Copy( font[233 - 32], 3, 0, font[201 - 32], 5, 0, 4, 2 );
+            fheroes2::Copy( font[193 - 32], 7, 0, font[201 - 32], 5, 0, 4, 2 );
             font[201 - 32].setPosition( font[37].x(), font[37].y() - 3 );
             updateNormalFontLetterShadow( font[201 - 32] );
 
@@ -1361,8 +1371,13 @@ namespace
             updateNormalFontLetterShadow( font[204 - 32] );
 
             // I with accute accent.
-            font[205 - 32] = font[41];
-
+            font[205 - 32].resize( font[41].width(), font[41].height() + 3 );
+            font[205 - 32].reset();
+            fheroes2::Copy( font[41], 0, 0, font[205 - 32], 0, 3, font[41].width(), font[41].height() );
+            fheroes2::Copy( font[193 - 32], 7, 0, font[205 - 32], 3, 0, 4, 2 );
+            font[205 - 32].setPosition( font[41].x(), font[41].y() - 3 );
+            updateNormalFontLetterShadow( font[205 - 32] );
+            
             // N with tilde ~
             font[209 - 32] = font[46];
 
@@ -1375,7 +1390,12 @@ namespace
             updateNormalFontLetterShadow( font[210 - 32] );
 
             // O with acute accent.
-            font[211 - 32] = font[47];
+            font[211 - 32].resize( font[47].width(), font[47].height() + 3 );
+            font[211 - 32].reset();
+            fheroes2::Copy( font[47], 0, 0, font[211 - 32], 0, 3, font[47].width(), font[47].height() );
+            fheroes2::Copy( font[193 - 32], 7, 0, font[211 - 32], 7, 0, 4, 2 );
+            font[211 - 32].setPosition( font[47].x(), font[47].y() - 3 );
+            updateNormalFontLetterShadow( font[211 - 32] );
 
             // O with 2 dots on top.
             font[214 - 32].resize( font[47].width(), font[47].height() + 3 );
@@ -1408,7 +1428,13 @@ namespace
             updateNormalFontLetterShadow( font[217 - 32] );
 
             // U with acute accent.
-            font[218 - 32] = font[53];
+            font[218 - 32].resize( font[53].width(), font[53].height() + 3 );
+            font[218 - 32].reset();
+            fheroes2::Copy( font[53], 0, 0, font[218 - 32], 0, 3, font[53].width(), font[53].height() );
+            fheroes2::Copy( font[193 - 32], 7, 0, font[218 - 32], 5, 0, 4, 2 );
+            font[218 - 32].setPosition( font[53].x(), font[53].y() - 3 );
+            updateNormalFontLetterShadow( font[218 - 32] );
+
 
             // U with 2 dots on top.
             font[220 - 32].resize( font[53].width(), font[53].height() + 3 );
@@ -1446,7 +1472,12 @@ namespace
             updateNormalFontLetterShadow( font[224 - 32] );
 
             // a with acute accent.
-            font[225 - 32] = font[65];
+            font[225 - 32].resize( font[65].width(), font[65].height() + 3 );
+            font[225 - 32].reset();
+            fheroes2::Copy( font[65], 0, 0, font[225 - 32], 0, 3, font[65].width(), font[65].height() );
+            fheroes2::Copy( font[193 - 32], 7, 0, font[225 - 32], 3, 0, 4, 2 );
+            font[225 - 32].setPosition( font[65].x(), font[65].y() - 3 );
+            updateNormalFontLetterShadow( font[225 - 32] );
 
             // a with 2 dots on top.
             font[228 - 32].resize( font[65].width(), font[65].height() + 3 );
@@ -1492,11 +1523,7 @@ namespace
             font[233 - 32].resize( font[69].width(), font[69].height() + 3 );
             font[233 - 32].reset();
             fheroes2::Copy( font[69], 0, 0, font[233 - 32], 0, 3, font[69].width(), font[69].height() );
-            fheroes2::Copy( font[233 - 32], 4, 8, font[233 - 32], 3, 1, 1, 1 );
-            fheroes2::Copy( font[233 - 32], 8, 6, font[233 - 32], 4, 1, 1, 1 );
-            fheroes2::Copy( font[233 - 32], 8, 6, font[233 - 32], 5, 0, 1, 1 );
-            fheroes2::Copy( font[233 - 32], 4, 3, font[233 - 32], 6, 0, 1, 1 );
-            fheroes2::Copy( font[233 - 32], 4, 3, font[233 - 32], 5, 1, 1, 1 );
+            fheroes2::Copy( font[193 - 32], 7, 0, font[233 - 32], 3, 0, 4, 2 );
             font[233 - 32].setPosition( font[69].x(), font[69].y() - 3 );
             updateNormalFontLetterShadow( font[233 - 32] );
 
@@ -1508,6 +1535,9 @@ namespace
 
             // i with acute accent.
             font[237 - 32] = font[73];
+            fheroes2::FillTransform( font[237 - 32], 0, 0, font[237 - 32].width(), 2, 1 );
+            fheroes2::Copy( font[193 - 32], 7, 0, font[237 - 32], 1, 0, 4, 2 );
+            updateNormalFontLetterShadow( font[237 - 32] );
 
             // n with tilde ~.
             font[241 - 32] = font[110 - 32];
@@ -1521,7 +1551,12 @@ namespace
             updateNormalFontLetterShadow( font[242 - 32] );
 
             // o with acute accent.
-            font[243 - 32] = font[79];
+            font[243 - 32].resize( font[79].width(), font[79].height() + 3 );
+            font[243 - 32].reset();
+            fheroes2::Copy( font[79], 0, 0, font[243 - 32], 0, 3, font[79].width(), font[79].height() );
+            fheroes2::Copy( font[193 - 32], 7, 0, font[243 - 32], 3, 0, 4, 2 );
+            font[243 - 32].setPosition( font[79].x(), font[79].y() - 3 );
+            updateNormalFontLetterShadow( font[243 - 32] );
 
             // o with 2 dots on top.
             font[246 - 32].resize( font[79].width(), font[79].height() + 3 );
@@ -1555,7 +1590,12 @@ namespace
             updateNormalFontLetterShadow( font[249 - 32] );
 
             // u with acute accent.
-            font[250 - 32] = font[85];
+            font[250 - 32].resize( font[85].width(), font[85].height() + 3 );
+            font[250 - 32].reset();
+            fheroes2::Copy( font[85], 0, 0, font[250 - 32], 0, 3, font[85].width(), font[85].height() );
+            fheroes2::Copy( font[193 - 32], 7, 0, font[250 - 32], 3, 0, 4, 2 );
+            font[250 - 32].setPosition( font[85].x(), font[85].y() - 3 );
+            updateNormalFontLetterShadow( font[250 - 32] );
 
             // u with 2 dots on top.
             font[252 - 32].resize( font[85].width(), font[85].height() + 3 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1313,6 +1313,10 @@ namespace
             fheroes2::FillTransform( font[191 - 32], 8, 5, 1, 1, 1 );
             font[191 - 32].setPosition( font[63 - 32].x(), font[63 - 32].y() + 2 );
             updateNormalFontLetterShadow( font[191 - 32] );
+            // Improve generated shadows
+            fheroes2::FillTransform( font[191 - 32], 0, 8, 1, 1, 1 );
+            fheroes2::FillTransform( font[191 - 32], 0, 12, 1, 1, 1 );
+            fheroes2::FillTransform( font[191 - 32], 7, 12, 1, 1, 1 );
 
             // A with grave accent ` and generate the grave accent for further use.
             font[192 - 32].resize( font[33].width(), font[33].height() + 3 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1408,8 +1408,17 @@ namespace
             font[205 - 32].setPosition( font[41].x(), font[41].y() - 3 );
             updateNormalFontLetterShadow( font[205 - 32] );
 
-            // N with tilde ~
+            // N with tilde ~. Generate accent for further use.
+            // TODO: Move tilde generation code to A with tilde when adding Portuguese.
             font[209 - 32] = font[46];
+            font[209 - 32].resize( font[46].width(), font[46].height() + 3 );
+            font[209 - 32].reset();
+            fheroes2::Copy( font[46], 0, 0, font[209 - 32], 0, 3, font[46].width(), font[46].height() );
+            fheroes2::Copy( font[37 - 32], 7, 5, font[209 - 32], 4, 0, 5, 2 );
+            fheroes2::Copy( font[37 - 32], 8, 8, font[209 - 32], 8, 2, 3, 1);
+            fheroes2::Copy( font[37 - 32], 10, 7, font[209 - 32], 10, 1, 2, 1 );
+            font[209 - 32].setPosition( font[46].x(), font[46].y() - 3 );
+            updateNormalFontLetterShadow( font[209 - 32] );
 
             // O with grave accent `.
             font[210 - 32].resize( font[47].width(), font[47].height() + 3 );
@@ -1570,6 +1579,12 @@ namespace
 
             // n with tilde ~.
             font[241 - 32] = font[110 - 32];
+            font[241 - 32].resize( font[110 - 32].width(), font[110 - 32].height() + 4 );
+            font[241 - 32].reset();
+            fheroes2::Copy( font[110 - 32], 0, 0, font[241 - 32], 0, 4, font[110 - 32].width(), font[110 - 32].height() );
+            fheroes2::Copy( font[209 - 32], 4, 0, font[241 - 32], 1, 0, 8, 3 );
+            font[241 - 32].setPosition( font[110 - 32].x(), font[110 - 32].y() - 4 );
+            updateNormalFontLetterShadow( font[241 - 32] );
 
             // o with grave accent `.
             font[242 - 32].resize( font[79].width(), font[79].height() + 3 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1380,7 +1380,7 @@ namespace
             fheroes2::Copy( font[193 - 32], 7, 0, font[205 - 32], 3, 0, 4, 2 );
             font[205 - 32].setPosition( font[41].x(), font[41].y() - 3 );
             updateNormalFontLetterShadow( font[205 - 32] );
-            
+
             // N with tilde ~
             font[209 - 32] = font[46];
 
@@ -1437,7 +1437,6 @@ namespace
             fheroes2::Copy( font[193 - 32], 7, 0, font[218 - 32], 5, 0, 4, 2 );
             font[218 - 32].setPosition( font[53].x(), font[53].y() - 3 );
             updateNormalFontLetterShadow( font[218 - 32] );
-
 
             // U with 2 dots on top.
             font[220 - 32].resize( font[53].width(), font[53].height() + 3 );

--- a/src/fheroes2/gui/ui_language.cpp
+++ b/src/fheroes2/gui/ui_language.cpp
@@ -52,7 +52,8 @@ namespace
             { "nb", fheroes2::SupportedLanguage::Norwegian },  { "norwegian", fheroes2::SupportedLanguage::Norwegian },
             { "be", fheroes2::SupportedLanguage::Belarusian }, { "belarusian", fheroes2::SupportedLanguage::Belarusian },
             { "uk", fheroes2::SupportedLanguage::Ukrainian },  { "ukrainian", fheroes2::SupportedLanguage::Ukrainian },
-            { "bg", fheroes2::SupportedLanguage::Bulgarian },  { "bulgarian", fheroes2::SupportedLanguage::Bulgarian } };
+            { "bg", fheroes2::SupportedLanguage::Bulgarian },  { "bulgarian", fheroes2::SupportedLanguage::Bulgarian },
+            { "es", fheroes2::SupportedLanguage::Spanish },    { "spanish", fheroes2::SupportedLanguage::Spanish } };
 }
 
 namespace fheroes2
@@ -98,7 +99,7 @@ namespace fheroes2
         const std::set<SupportedLanguage> possibleLanguages{ SupportedLanguage::French,     SupportedLanguage::Polish,    SupportedLanguage::German,
                                                              SupportedLanguage::Russian,    SupportedLanguage::Italian,   SupportedLanguage::Norwegian,
                                                              SupportedLanguage::Belarusian, SupportedLanguage::Bulgarian, SupportedLanguage::Ukrainian,
-                                                             SupportedLanguage::Romanian };
+                                                             SupportedLanguage::Romanian,   SupportedLanguage::Spanish };
 
         for ( const SupportedLanguage language : possibleLanguages ) {
             if ( language != resourceLanguage && isAlphabetSupported( language ) ) {
@@ -152,6 +153,8 @@ namespace fheroes2
             return _( "Ukrainian" );
         case SupportedLanguage::Romanian:
             return _( "Romanian" );
+        case SupportedLanguage::Spanish:
+            return _( "Spanish" );
         default:
             // Did you add a new language? Please add the code to handle it.
             assert( 0 );
@@ -186,6 +189,8 @@ namespace fheroes2
             return "uk";
         case SupportedLanguage::Romanian:
             return "ro";
+        case SupportedLanguage::Spanish:
+            return "es";
         default:
             // Did you add a new language? Please add the code to handle it.
             assert( 0 );

--- a/src/fheroes2/gui/ui_language.h
+++ b/src/fheroes2/gui/ui_language.h
@@ -40,6 +40,7 @@ namespace fheroes2
         Bulgarian,
         Norwegian,
         Romanian,
+        Spanish,
         Ukrainian
     };
 


### PR DESCRIPTION
This  adds a Spanish language option to the game and font support.

The existing Spanish translation is 54 % complete.

Spanish uses CP1252 so I added its letters in a new function `generateCP1252Alphabet()`.

Tidied up so that German, Norwegian and Italian all use CP1252 too. French is supported by CP1252 as well, but the OG encoding does not support that. A decision on how to deal with this is necessary.

Some letter generation improvements to existing CP1252 letters like lowercase `ì`.

All Spanish characters have been implemented.

Current progress:
![image](https://user-images.githubusercontent.com/12501091/167275151-3766c6d7-b4b9-4f2d-9fa1-f40cde2ef3f0.png)
![image](https://user-images.githubusercontent.com/12501091/167389735-458a8160-e9ef-4afe-b9b7-9822019b0522.png)
![image](https://user-images.githubusercontent.com/12501091/168318990-684799da-0919-492b-8656-f45b8e986010.png)

![image](https://user-images.githubusercontent.com/12501091/168319081-ac963656-52c1-47e0-901b-14a2510d4a59.png)