### PR TITLE
Add Portuguese language option and initial font generation

### DIFF
--- a/files/lang/Makefile
+++ b/files/lang/Makefile
@@ -28,8 +28,7 @@ merge:
 %.po: ../../src/dist/fheroes2.pot
 	msgmerge -U --no-location $@ $<
 
-# Spanish: drop accents transliterated with `"` (which breaks translation file format)
-# and transliterate the rest using the es_ES.UTF-8 locale
+# Spanish uses CP1252
 es.mo: es.po
 	iconv -f utf-8 -t CP1252 $< > $<.tmp
 	LANG=es.CP1252 LC_ALL=es.CP1252 LC_CTYPE=es.CP1252 sed -e 's/UTF-8/CP1252/' $<.tmp > $<.2.tmp
@@ -41,6 +40,12 @@ fr.mo: fr.po
 	sed -e 'y/àâçéèêîïôùûüÉÊÀ/@*^~`|><#&$$uEEA/' $< > $<.tmp
 	sed -i~ -e 's/œ/oe/g' $<.tmp
 	msgfmt $<.tmp -o $@
+	
+# Portuguese uses CP1252	
+pt.mo: pt.po
+	iconv -f utf-8 -t CP1252 $< > $<.tmp
+	LANG=pt.CP1252 LC_ALL=pt.CP1252 LC_CTYPE=pt.CP1252 sed -e 's/UTF-8/CP1252/' $<.tmp > $<.2.tmp
+	msgfmt $<.2.tmp -o $@
 
 # Polish version uses CP1250
 pl.mo: pl.po

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1381,6 +1381,9 @@ namespace
             font[198 - 32].setPosition( font[33].x(), font[33].y() );
             updateNormalFontLetterShadow( font[198 - 32] );
 
+            // C with cedilla.
+            font[199 - 32] = font[35];
+
             // E with grave accent `.
             font[200 - 32].resize( font[37].width(), font[37].height() + 3 );
             font[200 - 32].reset();
@@ -1567,6 +1570,9 @@ namespace
             fheroes2::Copy( font[69], 3, 0, font[230 - 32], 8, 0, 6, 8 );
             font[230 - 32].setPosition( font[65].x(), font[65].y() );
             updateNormalFontLetterShadow( font[230 - 32] );
+
+            // c with cedilla.
+            font[231 - 32] = font[67];
 
             // e with grave accent `.
             font[232 - 32].resize( font[69].width(), font[69].height() + 3 );
@@ -1778,6 +1784,9 @@ namespace
             font[198 - 32].setPosition( font[33].x(), font[33].y() );
             updateSmallFontLetterShadow( font[198 - 32] );
 
+            // C with cedilla.
+            font[199 - 32] = font[35];
+
             // E with grave accent `.
             font[200 - 32].resize( font[37].width(), font[37].height() + 4 );
             font[200 - 32].reset();
@@ -1948,6 +1957,9 @@ namespace
             fheroes2::Copy( font[69], 2, 0, font[230 - 32], 6, 0, font[69].width() - 2, font[69].height() );
             font[230 - 32].setPosition( font[65].x(), font[65].y() );
             updateSmallFontLetterShadow( font[230 - 32] );
+
+            // c with cedilla.
+            font[231 - 32] = font[67];
 
             // e with grave accent `.
             font[232 - 32].resize( font[69].width(), font[69].height() + 3 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1329,7 +1329,6 @@ namespace
             updateNormalFontLetterShadow( font[192 - 32] );
 
             // A with acute accent. Generate the accent for further use.
-            font[193 - 32] = font[33];
             font[193 - 32].resize( font[33].width(), font[33].height() + 3 );
             font[193 - 32].reset();
             fheroes2::Copy( font[33], 0, 0, font[193 - 32], 0, 3, font[33].width(), font[33].height() );
@@ -1340,6 +1339,12 @@ namespace
             fheroes2::Copy( font[193 - 32], 3, 3, font[193 - 32], 7, 1, 1, 1 );
             font[193 - 32].setPosition( font[33].x(), font[33].y() - 3 );
             updateNormalFontLetterShadow( font[193 - 32] );
+
+            // A with circumflex accent. TODO Move generation of accent for further use here.
+            font[194 - 32] = font[33];
+
+            // A with tilde accent ~. TODO Move generation of accent for further use here.
+            font[195 - 32] = font[33];
 
             // A with 2 dots on top.
             font[196 - 32].resize( font[33].width(), font[33].height() + 3 );
@@ -1392,6 +1397,9 @@ namespace
             font[201 - 32].setPosition( font[37].x(), font[37].y() - 3 );
             updateNormalFontLetterShadow( font[201 - 32] );
 
+            // E with circumflex accent.
+            font[202 - 32] = font[37];
+
             // I with grave accent `.
             font[204 - 32].resize( font[41].width(), font[41].height() + 3 );
             font[204 - 32].reset();
@@ -1434,6 +1442,12 @@ namespace
             fheroes2::Copy( font[193 - 32], 7, 0, font[211 - 32], 7, 0, 4, 2 );
             font[211 - 32].setPosition( font[47].x(), font[47].y() - 3 );
             updateNormalFontLetterShadow( font[211 - 32] );
+
+            // O with circumflex accent.
+            font[212 - 32] = font[47];
+
+            // O with tilde accent ~.
+            font[213 - 32] = font[47];
 
             // O with 2 dots on top.
             font[214 - 32].resize( font[47].width(), font[47].height() + 3 );
@@ -1516,6 +1530,12 @@ namespace
             font[225 - 32].setPosition( font[65].x(), font[65].y() - 3 );
             updateNormalFontLetterShadow( font[225 - 32] );
 
+            // a with circumflex accent.
+            font[226 - 32] = font[65];
+
+            // a with tilde accent ~.
+            font[227 - 32] = font[65];
+
             // a with 2 dots on top.
             font[228 - 32].resize( font[65].width(), font[65].height() + 3 );
             font[228 - 32].reset();
@@ -1564,6 +1584,9 @@ namespace
             font[233 - 32].setPosition( font[69].x(), font[69].y() - 3 );
             updateNormalFontLetterShadow( font[233 - 32] );
 
+            // e with circumflex accent.
+            font[234 - 32] = font[69];
+
             // i with grave accent `.
             font[236 - 32] = font[73];
             fheroes2::FillTransform( font[236 - 32], 0, 0, font[236 - 32].width(), 3, 1 );
@@ -1599,6 +1622,12 @@ namespace
             fheroes2::Copy( font[193 - 32], 7, 0, font[243 - 32], 3, 0, 4, 2 );
             font[243 - 32].setPosition( font[79].x(), font[79].y() - 3 );
             updateNormalFontLetterShadow( font[243 - 32] );
+
+            // o with circumflex accent.
+            font[244 - 32] = font[79];
+
+            // o with tilde accent ~.
+            font[245 - 32] = font[79];
 
             // o with 2 dots on top.
             font[246 - 32].resize( font[79].width(), font[79].height() + 3 );
@@ -1711,6 +1740,12 @@ namespace
             font[193 - 32].setPosition( font[33].x(), font[33].y() - 4 );
             updateSmallFontLetterShadow( font[193 - 32] );
 
+            // A with circumflex accent. TODO Move generation of accent for further use here.
+            font[194 - 32] = font[33];
+
+            // A with tilde accent ~. TODO Move generation of accent for further use here.
+            font[195 - 32] = font[33];
+
             // A with 2 dots on top.
             font[196 - 32].resize( font[33].width(), font[33].height() + 2 );
             font[196 - 32].reset();
@@ -1751,13 +1786,16 @@ namespace
             font[200 - 32].setPosition( font[37].x(), font[37].y() - 4 );
             updateSmallFontLetterShadow( font[200 - 32] );
 
-            // E with acute accent. Generate the acute accent for further use.
+            // E with acute accent.
             font[201 - 32].resize( font[37].width(), font[37].height() + 4 );
             font[201 - 32].reset();
             fheroes2::Copy( font[37], 0, 0, font[201 - 32], 0, 4, font[37].width(), font[37].height() );
             fheroes2::Copy( font[193 - 32], 4, 0, font[201 - 32], 3, 0, 3, 3 );
             font[201 - 32].setPosition( font[37].x(), font[37].y() - 4 );
             updateSmallFontLetterShadow( font[201 - 32] );
+
+            // E with circumflex accent.
+            font[202 - 32] = font[37];
 
             // I with grave accent `.
             font[204 - 32].resize( font[41].width(), font[41].height() + 4 );
@@ -1800,6 +1838,12 @@ namespace
             fheroes2::Copy( font[193 - 32], 4, 0, font[211 - 32], 3, 0, 3, 3 );
             font[211 - 32].setPosition( font[47].x(), font[47].y() - 4 );
             updateSmallFontLetterShadow( font[211 - 32] );
+
+            // O with circumflex accent.
+            font[212 - 32] = font[47];
+
+            // O with tilde accent ~.
+            font[213 - 32] = font[47];
 
             // O with 2 dots on top.
             font[214 - 32].resize( font[47].width(), font[47].height() + 2 );
@@ -1874,6 +1918,12 @@ namespace
             font[225 - 32].setPosition( font[65].x(), font[65].y() - 3 );
             updateSmallFontLetterShadow( font[225 - 32] );
 
+            // a with circumflex accent.
+            font[226 - 32] = font[65];
+
+            // a with tilde accent ~.
+            font[227 - 32] = font[65];
+
             // a with 2 dots on top.
             font[228 - 32].resize( font[65].width(), font[65].height() + 2 );
             font[228 - 32].reset();
@@ -1915,6 +1965,9 @@ namespace
             font[233 - 32].setPosition( font[69].x(), font[69].y() - 3 );
             updateSmallFontLetterShadow( font[233 - 32] );
 
+            // e with circumflex accent.
+            font[234 - 32] = font[69];
+
             // i with grave accent `.
             font[236 - 32].resize( font[73].width(), font[73].height() + 1 );
             font[236 - 32].reset();
@@ -1954,6 +2007,12 @@ namespace
             fheroes2::Copy( font[193 - 32], 5, 0, font[243 - 32], 3, 0, 2, 2 );
             font[243 - 32].setPosition( font[79].x(), font[79].y() - 3 );
             updateSmallFontLetterShadow( font[243 - 32] );
+
+            // o with circumflex accent.
+            font[244 - 32] = font[79];
+
+            // o with tilde accent ~.
+            font[245 - 32] = font[79];
 
             // o with 2 dots on top.
             font[246 - 32].resize( font[79].width(), font[79].height() + 2 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2064,6 +2064,7 @@ namespace fheroes2
         case SupportedLanguage::Russian:
         case SupportedLanguage::Belarusian:
         case SupportedLanguage::Bulgarian:
+        case SupportedLanguage::Portuguese:
         case SupportedLanguage::Spanish:
         case SupportedLanguage::Ukrainian:
         case SupportedLanguage::Romanian:

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2035,6 +2035,7 @@ namespace fheroes2
         case SupportedLanguage::German:
         case SupportedLanguage::Italian:
         case SupportedLanguage::Norwegian:
+        case SupportedLanguage::Portuguese:
         case SupportedLanguage::Spanish:
             generateCP1252Alphabet( icnVsSprite );
             break;

--- a/src/fheroes2/gui/ui_language.cpp
+++ b/src/fheroes2/gui/ui_language.cpp
@@ -53,7 +53,8 @@ namespace
             { "be", fheroes2::SupportedLanguage::Belarusian }, { "belarusian", fheroes2::SupportedLanguage::Belarusian },
             { "uk", fheroes2::SupportedLanguage::Ukrainian },  { "ukrainian", fheroes2::SupportedLanguage::Ukrainian },
             { "bg", fheroes2::SupportedLanguage::Bulgarian },  { "bulgarian", fheroes2::SupportedLanguage::Bulgarian },
-            { "es", fheroes2::SupportedLanguage::Spanish },    { "spanish", fheroes2::SupportedLanguage::Spanish } };
+            { "es", fheroes2::SupportedLanguage::Spanish },    { "spanish", fheroes2::SupportedLanguage::Spanish },
+            { "pt", fheroes2::SupportedLanguage::Portuguese },  { "portuguese", fheroes2::SupportedLanguage::Portuguese } };
 }
 
 namespace fheroes2
@@ -99,7 +100,7 @@ namespace fheroes2
         const std::set<SupportedLanguage> possibleLanguages{ SupportedLanguage::French,     SupportedLanguage::Polish,    SupportedLanguage::German,
                                                              SupportedLanguage::Russian,    SupportedLanguage::Italian,   SupportedLanguage::Norwegian,
                                                              SupportedLanguage::Belarusian, SupportedLanguage::Bulgarian, SupportedLanguage::Ukrainian,
-                                                             SupportedLanguage::Romanian,   SupportedLanguage::Spanish };
+                                                             SupportedLanguage::Romanian,   SupportedLanguage::Spanish, SupportedLanguage::Portuguese };
 
         for ( const SupportedLanguage language : possibleLanguages ) {
             if ( language != resourceLanguage && isAlphabetSupported( language ) ) {
@@ -155,6 +156,8 @@ namespace fheroes2
             return _( "Romanian" );
         case SupportedLanguage::Spanish:
             return _( "Spanish" );
+        case SupportedLanguage::Portuguese:
+            return _( "Portuguese" );
         default:
             // Did you add a new language? Please add the code to handle it.
             assert( 0 );
@@ -191,6 +194,8 @@ namespace fheroes2
             return "ro";
         case SupportedLanguage::Spanish:
             return "es";
+        case SupportedLanguage::Portuguese:
+            return "pt";
         default:
             // Did you add a new language? Please add the code to handle it.
             assert( 0 );

--- a/src/fheroes2/gui/ui_language.cpp
+++ b/src/fheroes2/gui/ui_language.cpp
@@ -54,7 +54,7 @@ namespace
             { "uk", fheroes2::SupportedLanguage::Ukrainian },  { "ukrainian", fheroes2::SupportedLanguage::Ukrainian },
             { "bg", fheroes2::SupportedLanguage::Bulgarian },  { "bulgarian", fheroes2::SupportedLanguage::Bulgarian },
             { "es", fheroes2::SupportedLanguage::Spanish },    { "spanish", fheroes2::SupportedLanguage::Spanish },
-            { "pt", fheroes2::SupportedLanguage::Portuguese },  { "portuguese", fheroes2::SupportedLanguage::Portuguese } };
+            { "pt", fheroes2::SupportedLanguage::Portuguese }, { "portuguese", fheroes2::SupportedLanguage::Portuguese } };
 }
 
 namespace fheroes2
@@ -100,7 +100,7 @@ namespace fheroes2
         const std::set<SupportedLanguage> possibleLanguages{ SupportedLanguage::French,     SupportedLanguage::Polish,    SupportedLanguage::German,
                                                              SupportedLanguage::Russian,    SupportedLanguage::Italian,   SupportedLanguage::Norwegian,
                                                              SupportedLanguage::Belarusian, SupportedLanguage::Bulgarian, SupportedLanguage::Ukrainian,
-                                                             SupportedLanguage::Romanian,   SupportedLanguage::Spanish, SupportedLanguage::Portuguese };
+                                                             SupportedLanguage::Romanian,   SupportedLanguage::Spanish,   SupportedLanguage::Portuguese };
 
         for ( const SupportedLanguage language : possibleLanguages ) {
             if ( language != resourceLanguage && isAlphabetSupported( language ) ) {

--- a/src/fheroes2/gui/ui_language.h
+++ b/src/fheroes2/gui/ui_language.h
@@ -39,6 +39,7 @@ namespace fheroes2
         Belarusian,
         Bulgarian,
         Norwegian,
+        Portuguese,
         Romanian,
         Spanish,
         Ukrainian


### PR DESCRIPTION
This replaces all special characters with their most similar latin counterpart.

These letters were added: `Ã, Â, Ç, Ê, Õ, Ô, ã, â, ç, ê, õ, ô`.