### PR TITLE
fheroes2::getLEValue(): replace static_assert() by #error

### DIFF
--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -360,7 +360,7 @@ namespace fheroes2
 #elif defined( BYTE_ORDER ) && defined( BIG_ENDIAN ) && BYTE_ORDER == BIG_ENDIAN
         std::reverse_copy( begin, end, reinterpret_cast<char *>( &result ) );
 #else
-        static_assert( false, "Unknown byte order" );
+#error "Unknown byte order"
 #endif
 
         return result;


### PR DESCRIPTION
While all modern compilers I aware of fire this `static_assert()` immediately when compiling the template (what is in fact is needed here if there is no valid byte order info present), formally (according to the standard) the template for which no valid specialization can be generated is "ill-formed, no diagnostic required" (and, formally, no valid specialization can be generated for the template with `static_assert( false, ... )`). So let's just replace it with the `#error` preprocessor directive - just in case.