### PR TITLE
Impose a limit of turns for an attacking AI-controlled hero

### DIFF
--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -69,16 +69,12 @@ namespace AI
     class Base
     {
     public:
-        virtual void KingdomTurn( Kingdom & kingdom );
-        virtual void CastleTurn( Castle & castle, bool defensive );
-        virtual void BattleTurn( Battle::Arena & arena, const Battle::Unit & unit, Battle::Actions & actions );
-        virtual void HeroTurn( Heroes & hero );
-        virtual bool HeroesTurn( VecHeroes & )
-        {
-            return true;
-        }
+        virtual void KingdomTurn( Kingdom & kingdom ) = 0;
+        virtual void CastleTurn( Castle & castle, bool defensive ) = 0;
+        virtual void BattleTurn( Battle::Arena & arena, const Battle::Unit & unit, Battle::Actions & actions ) = 0;
+        virtual bool HeroesTurn( VecHeroes & heroes ) = 0;
 
-        virtual void revealFog( const Maps::Tiles & tile );
+        virtual void revealFog( const Maps::Tiles & tile ) = 0;
 
         virtual void HeroesAdd( const Heroes & hero );
         virtual void HeroesRemove( const Heroes & hero );
@@ -98,7 +94,6 @@ namespace AI
         virtual void CastlePreBattle( Castle & castle );
         virtual void CastleAfterBattle( Castle & castle, bool attackerWins );
 
-        virtual const char * Type() const;
         virtual int GetPersonality() const; // To be utilized in future.
         virtual std::string GetPersonalityString() const;
 

--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -105,6 +105,10 @@ namespace AI
         virtual void Reset();
         virtual void resetPathfinder() = 0;
 
+        // Should be called at the beginning of the battle even if no AI-controlled players are
+        // involved in the battle - because of the possibility of using instant or auto battle
+        virtual void battleBegins() = 0;
+
         virtual ~Base() = default;
 
     protected:

--- a/src/fheroes2/ai/ai_base.cpp
+++ b/src/fheroes2/ai/ai_base.cpp
@@ -18,26 +18,13 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include "agg.h"
 #include "ai.h"
-#include "battle_arena.h"
-#include "battle_command.h"
-#include "battle_troop.h"
-#include "game_interface.h"
 #include "heroes.h"
-#include "kingdom.h"
-#include "logging.h"
-#include "mus.h"
 #include "serialize.h"
 #include "translations.h"
 
 namespace AI
 {
-    const char * Base::Type() const
-    {
-        return "base";
-    }
-
     int Base::GetPersonality() const
     {
         return _personality;
@@ -56,7 +43,7 @@ namespace AI
             break;
         }
 
-        return Type();
+        return _( "None" );
     }
 
     void Base::Reset()
@@ -70,11 +57,6 @@ namespace AI
     }
 
     void Base::CastleAfterBattle( Castle &, bool )
-    {
-        // Do nothing.
-    }
-
-    void Base::CastleTurn( Castle &, bool )
     {
         // Do nothing.
     }
@@ -119,11 +101,6 @@ namespace AI
         // Do nothing.
     }
 
-    void Base::revealFog( const Maps::Tiles & )
-    {
-        // Do nothing.
-    }
-
     std::string Base::HeroesString( const Heroes & )
     {
         return std::string();
@@ -154,83 +131,6 @@ namespace AI
     bool Base::HeroesCanMove( const Heroes & hero )
     {
         return hero.MayStillMove( false, false ) && !hero.Modes( Heroes::MOVED );
-    }
-
-    void Base::HeroTurn( Heroes & hero )
-    {
-        Interface::StatusWindow & status = Interface::Basic::Get().GetStatusWindow();
-
-        hero.ResetModes( Heroes::MOVED );
-
-        while ( Base::HeroesCanMove( hero ) ) {
-            // turn indicator
-            status.RedrawTurnProgress( 3 );
-            status.RedrawTurnProgress( 4 );
-
-            // get task for heroes
-            Base::HeroesGetTask( hero );
-
-            // turn indicator
-            status.RedrawTurnProgress( 5 );
-            status.RedrawTurnProgress( 6 );
-
-            // heroes AI turn
-            AI::HeroesMove( hero );
-            hero.SetModes( Heroes::MOVED );
-
-            // turn indicator
-            status.RedrawTurnProgress( 7 );
-            status.RedrawTurnProgress( 8 );
-        }
-
-        DEBUG_LOG( DBG_AI, DBG_TRACE, hero.GetName() << ", end" )
-    }
-
-    void Base::KingdomTurn( Kingdom & kingdom )
-    {
-        KingdomHeroes & heroes = kingdom.GetHeroes();
-        KingdomCastles & castles = kingdom.GetCastles();
-
-        const int color = kingdom.GetColor();
-
-        if ( kingdom.isLoss() || color == Color::NONE ) {
-            kingdom.LossPostActions();
-            return;
-        }
-
-        AGG::PlayMusic( MUS::COMPUTER_TURN, true, true );
-
-        Interface::StatusWindow & status = Interface::Basic::Get().GetStatusWindow();
-
-        // indicator
-        status.RedrawTurnProgress( 0 );
-
-        status.RedrawTurnProgress( 1 );
-
-        // castles AI turn
-        for ( KingdomCastles::iterator it = castles.begin(); it != castles.end(); ++it )
-            if ( *it )
-                CastleTurn( **it, false );
-
-        status.RedrawTurnProgress( 3 );
-
-        // heroes turns
-        for ( KingdomHeroes::iterator it = heroes.begin(); it != heroes.end(); ++it )
-            if ( *it )
-                HeroTurn( **it );
-
-        status.RedrawTurnProgress( 6 );
-        status.RedrawTurnProgress( 7 );
-        status.RedrawTurnProgress( 8 );
-        status.RedrawTurnProgress( 9 );
-
-        DEBUG_LOG( DBG_AI, DBG_INFO, Color::String( color ) << " moved" )
-    }
-
-    void Base::BattleTurn( Battle::Arena &, const Battle::Unit & currentUnit, Battle::Actions & actions )
-    {
-        // Since this is just a basic implementation - just finish the unit's turn
-        actions.emplace_back( Battle::CommandType::MSG_BATTLE_END_TURN, currentUnit.GetUID() );
     }
 
     StreamBase & operator<<( StreamBase & msg, const AI::Base & instance )

--- a/src/fheroes2/ai/ai_base.cpp
+++ b/src/fheroes2/ai/ai_base.cpp
@@ -229,7 +229,7 @@ namespace AI
 
     void Base::BattleTurn( Battle::Arena &, const Battle::Unit & currentUnit, Battle::Actions & actions )
     {
-        // end action
+        // Since this is just a basic implementation - just finish the unit's turn
         actions.emplace_back( Battle::CommandType::MSG_BATTLE_END_TURN, currentUnit.GetUID() );
     }
 

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -107,8 +107,14 @@ namespace AI
     class BattlePlanner
     {
     public:
+        // Should be called at the beginning of the battle
+        void battleBegins();
+
+        // Checks whether the limit of turns is exceeded for the attacking AI-controlled
+        // hero and inserts an appropriate action to the action list if necessary
+        bool isLimitOfTurnsExceeded( const Battle::Arena & arena, Battle::Actions & actions );
+
         Battle::Actions planUnitTurn( Battle::Arena & arena, const Battle::Unit & currentUnit );
-        void analyzeBattleState( const Battle::Arena & arena, const Battle::Unit & currentUnit );
 
         // decision-making helpers
         bool isUnitFaster( const Battle::Unit & currentUnit, const Battle::Unit & target ) const;
@@ -117,24 +123,42 @@ namespace AI
         bool checkRetreatCondition( const Heroes & hero ) const;
 
     private:
-        // to be exposed later once every BattlePlanner will be re-initialized at combat start
+        void analyzeBattleState( const Battle::Arena & arena, const Battle::Unit & currentUnit );
+
         Battle::Actions berserkTurn( const Battle::Arena & arena, const Battle::Unit & currentUnit ) const;
         Battle::Actions archerDecision( const Battle::Arena & arena, const Battle::Unit & currentUnit ) const;
+
         BattleTargetPair meleeUnitOffense( const Battle::Arena & arena, const Battle::Unit & currentUnit ) const;
         BattleTargetPair meleeUnitDefense( const Battle::Arena & arena, const Battle::Unit & currentUnit ) const;
+
         SpellSelection selectBestSpell( Battle::Arena & arena, const Battle::Unit & currentUnit, bool retreating ) const;
+
         SpellcastOutcome spellDamageValue( const Spell & spell, Battle::Arena & arena, const Battle::Unit & currentUnit, const Battle::Units & friendly,
                                            const Battle::Units & enemies, bool retreating ) const;
         SpellcastOutcome spellDispellValue( const Spell & spell, const Battle::Units & friendly, const Battle::Units & enemies ) const;
         SpellcastOutcome spellResurrectValue( const Spell & spell, const Battle::Arena & arena ) const;
         SpellcastOutcome spellSummonValue( const Spell & spell, const Battle::Arena & arena, const int heroColor ) const;
         SpellcastOutcome spellEffectValue( const Spell & spell, const Battle::Units & targets ) const;
+
         double spellEffectValue( const Spell & spell, const Battle::Unit & target, bool targetIsLast, bool forDispell ) const;
         double getSpellDisruptingRayRatio( const Battle::Unit & target ) const;
         double getSpellSlowRatio( const Battle::Unit & target ) const;
         double getSpellHasteRatio( const Battle::Unit & target ) const;
         int32_t spellDurationMultiplier( const Battle::Unit & target ) const;
+
         static double commanderMaximumSpellDamageValue( const HeroBase & commander );
+
+        const Rand::DeterministicRandomGenerator * _randomGenerator = nullptr;
+
+        // When this limit of turns without deaths is exceeded for an attacking AI-controlled hero,
+        // the auto battle should be interrupted (one way or another)
+        const uint32_t MAX_TURNS_WITHOUT_DEATHS = 50;
+
+        // Member variables related to the logic of checking the limit of the number of turns
+        uint32_t _currentTurnNumber = 0;
+        uint32_t _numberOfRemainingTurnsWithoutDeaths = MAX_TURNS_WITHOUT_DEATHS;
+        uint32_t _attackerForceNumberOfDead = 0;
+        uint32_t _defenderForceNumberOfDead = 0;
 
         // turn variables that wouldn't persist
         const HeroBase * _commander = nullptr;
@@ -151,14 +175,13 @@ namespace AI
         bool _defendingCastle = false;
         bool _considerRetreat = false;
         bool _defensiveTactics = false;
-
-        const Rand::DeterministicRandomGenerator * _randomGenerator = nullptr;
     };
 
     class Normal : public Base
     {
     public:
         Normal();
+
         void KingdomTurn( Kingdom & kingdom ) override;
         void CastleTurn( Castle & castle, bool defensive ) override;
         void BattleTurn( Battle::Arena & arena, const Battle::Unit & currentUnit, Battle::Actions & actions ) override;
@@ -177,6 +200,8 @@ namespace AI
         double getObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         int getPriorityTarget( const HeroToMove & heroInfo, double & maxPriority );
         void resetPathfinder() override;
+
+        void battleBegins() override;
 
     private:
         // following data won't be saved/serialized

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -205,8 +205,6 @@ namespace AI
 
     bool BattlePlanner::isLimitOfTurnsExceeded( const Arena & arena, Actions & actions )
     {
-        assert( MAX_TURNS_WITHOUT_DEATHS > 0 );
-
         const int currentColor = arena.GetCurrentColor();
 
         // Not the attacker's turn, no further checks

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -39,6 +39,7 @@
 #include <cstdint>
 #include <map>
 #include <set>
+#include <tuple>
 #include <utility>
 
 using namespace Battle;
@@ -192,6 +193,74 @@ namespace AI
         if ( currentUnit.isFlying() == target.isFlying() )
             return currentUnit.GetSpeed() > target.GetSpeed();
         return currentUnit.isFlying();
+    }
+
+    void BattlePlanner::battleBegins()
+    {
+        _currentTurnNumber = 0;
+        _numberOfRemainingTurnsWithoutDeaths = MAX_TURNS_WITHOUT_DEATHS;
+        _attackerForceNumberOfDead = 0;
+        _defenderForceNumberOfDead = 0;
+    }
+
+    bool BattlePlanner::isLimitOfTurnsExceeded( const Arena & arena, Actions & actions )
+    {
+        assert( MAX_TURNS_WITHOUT_DEATHS > 0 );
+
+        const int currentColor = arena.GetCurrentColor();
+
+        // Not the attacker's turn, no further checks
+        if ( currentColor != arena.GetArmyColor1() ) {
+            return false;
+        }
+
+        const uint32_t currentTurnNumber = arena.GetCurrentTurn();
+        assert( currentTurnNumber > 0 );
+
+        // This is the beginning of a new turn and we still haven't gone beyond the limit on the number of turns without deaths
+        if ( currentTurnNumber > _currentTurnNumber && _numberOfRemainingTurnsWithoutDeaths > 0 ) {
+            auto prevNumbersOfDead = std::forward_as_tuple( _attackerForceNumberOfDead, _defenderForceNumberOfDead );
+            const auto currNumbersOfDead = std::make_tuple( arena.GetForce1().GetDeadCounts(), arena.GetForce2().GetDeadCounts() );
+
+            // Either we don't have numbers of dead units from the previous turn, or there were changes in these numbers compared
+            // to the previous turn, reset the counter
+            if ( _currentTurnNumber == 0 || currentTurnNumber - _currentTurnNumber != 1 || prevNumbersOfDead != currNumbersOfDead ) {
+                prevNumbersOfDead = currNumbersOfDead;
+
+                _numberOfRemainingTurnsWithoutDeaths = MAX_TURNS_WITHOUT_DEATHS;
+            }
+            // No changes in numbers of dead units compared to the previous turn, decrease the counter of the remaining turns
+            else {
+                _numberOfRemainingTurnsWithoutDeaths -= 1;
+            }
+
+            _currentTurnNumber = currentTurnNumber;
+        }
+
+        // We have gone beyond the limit on the number of turns without deaths and have to stop
+        if ( _numberOfRemainingTurnsWithoutDeaths == 0 ) {
+            // If this is an auto battle (and not the instant battle, because the battle UI is present), then turn it off until the end of the battle
+            if ( arena.AutoBattleInProgress() && Arena::GetInterface() != nullptr ) {
+                assert( arena.CanToggleAutoBattle() );
+
+                actions.emplace_back( CommandType::MSG_BATTLE_AUTO, currentColor );
+
+                DEBUG_LOG( DBG_BATTLE, DBG_INFO, Color::String( currentColor ) << " has used up the limit of turns without deaths, auto battle is turned off" )
+            }
+            // Otherwise the attacker's hero should retreat
+            else {
+                assert( arena.CanRetreatOpponent( currentColor ) && arena.GetCurrentCommander() != nullptr );
+
+                actions.emplace_back( CommandType::MSG_BATTLE_RETREAT );
+
+                DEBUG_LOG( DBG_BATTLE, DBG_INFO,
+                           Color::String( currentColor ) << " has used up the limit of turns without deaths, " << arena.GetCurrentCommander()->GetName() << " retreats" )
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     Actions BattlePlanner::planUnitTurn( Arena & arena, const Unit & currentUnit )
@@ -812,6 +881,11 @@ namespace AI
 
     void Normal::BattleTurn( Arena & arena, const Unit & currentUnit, Actions & actions )
     {
+        // Return immediately if our limit of turns has been exceeded
+        if ( _battlePlanner.isLimitOfTurnsExceeded( arena, actions ) ) {
+            return;
+        }
+
         Board * board = Arena::GetBoard();
 
         board->Reset();
@@ -824,5 +898,10 @@ namespace AI
         if ( plannedActions.size() != 1 || !plannedActions.front().isType( CommandType::MSG_BATTLE_CAST ) ) {
             actions.emplace_back( CommandType::MSG_BATTLE_END_TURN, currentUnit.GetUID() );
         }
+    }
+
+    void Normal::battleBegins()
+    {
+        _battlePlanner.battleBegins();
     }
 }

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -394,6 +394,8 @@ Battle::Arena::Arena( Army & a1, Army & a2, s32 index, bool local, Rand::Determi
             board.SetCobjObjects( world.GetTiles( index ), seededGen );
     }
 
+    AI::Get().battleBegins();
+
     if ( interface ) {
         fheroes2::Display & display = fheroes2::Display::instance();
 


### PR DESCRIPTION
fix #5342

Currently the logic is as follows:

* The limit is triggered if the number of dead in both armies does not change within 50 turns;
* The limit is applied only to the **_attacking AI-controlled army_** (the concept of "AI-controlled" in this particular case includes instant or auto battle mode). It is never applied to the defending army (it doesn't matter whether is controlled by AI or not), and also it is not applied to the attacking army if it is **_directly_** controlled by a human player at the moment (neither instant battle or auto battle are currently in effect);
* If the attacking army is controlled by AI player, and the limit of turns is exceeded, then the attacking hero will retreat (and lose his army);
* If the attacking army is controlled by human player, and there is an **_instant battle_** in progress, then the attacking hero will retreat as well;
* If the attacking army is controlled by human player, and there is an **_auto battle_** in progress, the auto battle will be turned off when the limit of turns is exceeded, and the attacker will not be able to turn it on again (it will be turned back off immediately).

That's how it currently works in case of an attacking AI-controlled hero:

https://user-images.githubusercontent.com/32623900/169033796-ff186097-9b0f-46d8-a705-db2f5f401a3f.mp4
