### PR TITLE
Cache AI hero's and neutral monsters' strength during AI turn

### DIFF
--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -25,6 +25,7 @@
 #define H2AI_H
 
 #include "gamedefs.h"
+#include "mp2.h"
 #include "rand.h"
 
 class StreamBase;
@@ -87,7 +88,7 @@ namespace AI
         virtual void HeroesPostLoad( Heroes & hero );
         virtual bool HeroesCanMove( const Heroes & hero );
         virtual bool HeroesGetTask( Heroes & hero );
-        virtual void HeroesActionComplete( Heroes & hero );
+        virtual void HeroesActionComplete( Heroes & hero, const MP2::MapObjectType objectType );
         virtual void HeroesActionNewPosition( Heroes & hero );
         virtual void HeroesClearTask( const Heroes & hero );
         virtual void HeroesLevelUp( Heroes & hero );
@@ -120,7 +121,7 @@ namespace AI
     Base & Get( AI_TYPE type = AI_TYPE::NORMAL );
 
     // functionality in ai_hero_action.cpp
-    void HeroesAction( Heroes & hero, s32 dst_index );
+    void HeroesAction( Heroes & hero, const int32_t dst_index );
     void HeroesMove( Heroes & hero );
     void HeroesCastDimensionDoor( Heroes & hero, const int32_t targetIndex );
     bool HeroesCastAdventureSpell( Heroes & hero, const Spell & spell );

--- a/src/fheroes2/ai/ai_base.cpp
+++ b/src/fheroes2/ai/ai_base.cpp
@@ -129,7 +129,7 @@ namespace AI
         return std::string();
     }
 
-    void Base::HeroesActionComplete( Heroes & )
+    void Base::HeroesActionComplete( Heroes & /*hero*/, const MP2::MapObjectType /*objectType*/ )
     {
         // Do nothing.
     }

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -237,7 +237,7 @@ namespace AI
         hero.SetFreeman( reason );
     }
 
-    void HeroesAction( Heroes & hero, s32 dst_index )
+    void HeroesAction( Heroes & hero, const int32_t dst_index )
     {
         const Maps::Tiles & tile = world.GetTiles( dst_index );
         const MP2::MapObjectType objectType = tile.GetObject( dst_index != hero.GetIndex() );
@@ -501,7 +501,7 @@ namespace AI
 
         // ignore empty tiles
         if ( isAction )
-            AI::Get().HeroesActionComplete( hero );
+            AI::Get().HeroesActionComplete( hero, objectType );
     }
 
     void AIToHeroes( Heroes & hero, s32 dst_index )

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -167,7 +167,7 @@ namespace AI
         void revealFog( const Maps::Tiles & tile ) override;
 
         void HeroesPreBattle( HeroBase & hero, bool isAttacking ) override;
-        void HeroesActionComplete( Heroes & hero ) override;
+        void HeroesActionComplete( Heroes & hero, const MP2::MapObjectType objectType ) override;
 
         bool recruitHero( Castle & castle, bool buyArmy, bool underThreat );
         void evaluateRegionSafety();
@@ -178,6 +178,8 @@ namespace AI
         int getPriorityTarget( const HeroToMove & heroInfo, double & maxPriority );
         void resetPathfinder() override;
 
+        double getTargetArmyStrength( const Maps::Tiles & tile, const MP2::MapObjectType objectType );
+
     private:
         // following data won't be saved/serialized
         double _combinedHeroStrength = 0;
@@ -186,11 +188,20 @@ namespace AI
         AIWorldPathfinder _pathfinder;
         BattlePlanner _battlePlanner;
 
+        // Monster strength is constant over the same turn for AI but its calculation is a heavy operation.
+        // In order to avoid extra computations during AI turn is it important to keep cache of monster strength but update it when an action on a monster is taken.
+        std::map<int32_t, double> _neutralMonsterStrengthCache;
+
         double getHunterObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         double getFighterObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
 
         bool purchaseNewHeroes( const std::vector<AICastle> & sortedCastleList, const std::set<int> & castlesInDanger, int32_t availableHeroCount,
                                 bool moreTasksForHeroes );
+
+        static bool isMonsterStrengthCacheable( const MP2::MapObjectType objectType )
+        {
+            return objectType == MP2::OBJ_MONSTER;
+        }
     };
 }
 

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -189,7 +189,7 @@ namespace AI
         BattlePlanner _battlePlanner;
 
         // Monster strength is constant over the same turn for AI but its calculation is a heavy operation.
-        // In order to avoid extra computations during AI turn is it important to keep cache of monster strength but update it when an action on a monster is taken.
+        // In order to avoid extra computations during AI turn it is important to keep cache of monster strength but update it when an action on a monster is taken.
         std::map<int32_t, double> _neutralMonsterStrengthCache;
 
         double getHunterObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -199,7 +199,7 @@ namespace
             if ( hero.isObjectTypeVisited( objectType, Visit::GLOBAL )
                  && ( spell == Spell::VIEWARTIFACTS || spell == Spell::VIEWHEROES || spell == Spell::VIEWMINES || spell == Spell::VIEWRESOURCES
                       || spell == Spell::VIEWTOWNS || spell == Spell::IDENTIFYHERO || spell == Spell::VISIONS ) ) {
-                // AI never uses View spells.
+                // AI never uses View spells except "View All".
                 return false;
             }
             return true;

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -35,31 +35,42 @@
 
 namespace
 {
-    bool AIShouldVisitCastle( const Heroes & hero, int castleIndex )
+    bool AIShouldVisitCastle( const Heroes & hero, int castleIndex, const double heroArmyStrength )
     {
         const Castle * castle = world.getCastleEntrance( Maps::GetPoint( castleIndex ) );
-        if ( castle ) {
-            if ( hero.GetColor() == castle->GetColor() ) {
-                return castle->GetHeroes().Guest() == nullptr;
-            }
-            else if ( !hero.isFriends( castle->GetColor() ) ) {
-                const double advantage = hero.isLosingGame() ? AI::ARMY_ADVANTAGE_DESPERATE : AI::ARMY_ADVANTAGE_MEDIUM;
-                return hero.GetArmy().GetStrength() > castle->GetGarrisonStrength( &hero ) * advantage;
-            }
+        if ( castle == nullptr ) {
+            return false;
         }
+
+        if ( hero.GetColor() == castle->GetColor() ) {
+            return castle->GetHeroes().Guest() == nullptr;
+        }
+
+        if ( !hero.isFriends( castle->GetColor() ) ) {
+            const double advantage = hero.isLosingGame() ? AI::ARMY_ADVANTAGE_DESPERATE : AI::ARMY_ADVANTAGE_MEDIUM;
+            return heroArmyStrength > castle->GetGarrisonStrength( &hero ) * advantage;
+        }
+
         return false;
     }
 
-    bool HeroesValidObject( const Heroes & hero, const int32_t index, const AIWorldPathfinder & pathfinder )
+    bool isHeroStrongerThan( const Maps::Tiles & tile, const MP2::MapObjectType objectType, AI::Normal & ai, const double heroArmyStrength,
+                             const double targetStrengthMultiplier )
+    {
+        return heroArmyStrength > ai.getTargetArmyStrength( tile, objectType ) * targetStrengthMultiplier;
+    }
+
+    bool HeroesValidObject( const Heroes & hero, const int32_t index, const AIWorldPathfinder & pathfinder, AI::Normal & ai, const double heroArmyStrength )
     {
         const Maps::Tiles & tile = world.GetTiles( index );
         const MP2::MapObjectType objectType = tile.GetObject();
-        const Army & army = hero.GetArmy();
-        const Kingdom & kingdom = hero.GetKingdom();
 
         if ( !MP2::isActionObject( objectType ) ) {
             return false;
         }
+
+        const Army & army = hero.GetArmy();
+        const Kingdom & kingdom = hero.GetKingdom();
 
         switch ( objectType ) {
         case MP2::OBJ_SHIPWRECKSURVIVOR:
@@ -69,7 +80,7 @@ namespace
             return hero.isShipMaster();
 
         case MP2::OBJ_BUOY:
-            return !hero.isObjectTypeVisited( objectType ) && hero.GetMorale() < Morale::BLOOD && !hero.GetArmy().AllTroopsAreUndead();
+            return !hero.isObjectTypeVisited( objectType ) && hero.GetMorale() < Morale::BLOOD && !army.AllTroopsAreUndead();
 
         case MP2::OBJ_MERMAID:
             return !hero.isObjectTypeVisited( objectType ) && hero.GetLuck() < Luck::IRISH;
@@ -95,8 +106,7 @@ namespace
         case MP2::OBJ_LIGHTHOUSE:
             if ( !hero.isFriends( tile.QuantityColor() ) ) {
                 if ( tile.isCaptureObjectProtected() ) {
-                    const Army enemy( tile );
-                    return army.isStrongerThan( enemy, AI::ARMY_ADVANTAGE_SMALL );
+                    return isHeroStrongerThan( tile, objectType, ai, heroArmyStrength, AI::ARMY_ADVANTAGE_SMALL );
                 }
 
                 return true;
@@ -106,8 +116,7 @@ namespace
         case MP2::OBJ_ABANDONEDMINE:
             if ( !hero.isFriends( tile.QuantityColor() ) ) {
                 if ( tile.isCaptureObjectProtected() ) {
-                    const Army enemy( tile );
-                    return army.isStrongerThan( enemy, AI::ARMY_ADVANTAGE_LARGE );
+                    return isHeroStrongerThan( tile, objectType, ai, heroArmyStrength, AI::ARMY_ADVANTAGE_LARGE );
                 }
 
                 return true;
@@ -124,8 +133,7 @@ namespace
         case MP2::OBJ_WINDMILL:
             if ( Settings::Get().ExtWorldExtObjectsCaptured() && !hero.isFriends( tile.QuantityColor() ) ) {
                 if ( tile.isCaptureObjectProtected() ) {
-                    const Army enemy( tile );
-                    return army.isStrongerThan( enemy, AI::ARMY_ADVANTAGE_MEDIUM );
+                    return isHeroStrongerThan( tile, objectType, ai, heroArmyStrength, AI::ARMY_ADVANTAGE_MEDIUM );
                 }
 
                 return true;
@@ -158,8 +166,7 @@ namespace
 
             // 6 - 50 rogues, 7 - 1 gin, 8,9,10,11,12,13 - 1 monster level4
             if ( 5 < variants && 14 > variants ) {
-                Army enemy( tile );
-                return army.isStrongerThan( enemy, AI::ARMY_ADVANTAGE_LARGE );
+                return isHeroStrongerThan( tile, objectType, ai, heroArmyStrength, AI::ARMY_ADVANTAGE_LARGE );
             }
 
             // other
@@ -190,7 +197,7 @@ namespace
             }
 
             if ( hero.isObjectTypeVisited( objectType, Visit::GLOBAL )
-                 && ( spell == Spell::VIEWALL || spell == Spell::VIEWARTIFACTS || spell == Spell::VIEWHEROES || spell == Spell::VIEWMINES || spell == Spell::VIEWRESOURCES
+                 && ( spell == Spell::VIEWARTIFACTS || spell == Spell::VIEWHEROES || spell == Spell::VIEWMINES || spell == Spell::VIEWRESOURCES
                       || spell == Spell::VIEWTOWNS || spell == Spell::IDENTIFYHERO || spell == Spell::VISIONS ) ) {
                 // AI never uses View spells.
                 return false;
@@ -216,7 +223,7 @@ namespace
                 return false;
             }
 
-            if ( hero.GetArmy().AllTroopsAreUndead() && skillType == Skill::Secondary::LEADERSHIP ) {
+            if ( army.AllTroopsAreUndead() && skillType == Skill::Secondary::LEADERSHIP ) {
                 // For undead army it's pointless to have Leadership skill.
                 return false;
             }
@@ -249,7 +256,7 @@ namespace
             return !hero.isObjectTypeVisited( objectType ) && hero.GetMorale() < Morale::BLOOD;
 
         case MP2::OBJ_TEMPLE:
-            return !hero.isObjectTypeVisited( objectType ) && hero.GetMorale() < Morale::BLOOD && !hero.GetArmy().AllTroopsAreUndead();
+            return !hero.isObjectTypeVisited( objectType ) && hero.GetMorale() < Morale::BLOOD && !army.AllTroopsAreUndead();
 
         case MP2::OBJ_MAGICWELL:
             return !hero.isObjectTypeVisited( MP2::OBJ_MAGICWELL ) && hero.HaveSpellBook() && hero.GetSpellPoints() < hero.GetMaxSpellPoints();
@@ -309,7 +316,7 @@ namespace
         case MP2::OBJ_CITYDEAD:
         case MP2::OBJ_TROLLBRIDGE: {
             if ( Color::NONE == tile.QuantityColor() ) {
-                return army.isStrongerThan( Army( tile ), AI::ARMY_ADVANTAGE_MEDIUM );
+                return isHeroStrongerThan( tile, objectType, ai, heroArmyStrength, AI::ARMY_ADVANTAGE_MEDIUM );
             }
             else {
                 const Troop & troop = tile.QuantityTroop();
@@ -356,7 +363,7 @@ namespace
         case MP2::OBJ_DERELICTSHIP:
             if ( !hero.isVisited( tile, Visit::GLOBAL ) && tile.QuantityIsValid() ) {
                 Army enemy( tile );
-                return enemy.isValid() && army.isStrongerThan( enemy, 2 );
+                return enemy.isValid() && isHeroStrongerThan( tile, objectType, ai, heroArmyStrength, 2 );
             }
             break;
 
@@ -364,17 +371,17 @@ namespace
             if ( !hero.isVisited( tile, Visit::GLOBAL ) && tile.QuantityIsValid() ) {
                 Army enemy( tile );
                 return enemy.isValid() && Skill::Level::EXPERT == hero.GetLevelSkill( Skill::Secondary::WISDOM )
-                       && army.isStrongerThan( enemy, AI::ARMY_ADVANTAGE_LARGE );
+                       && isHeroStrongerThan( tile, objectType, ai, heroArmyStrength, AI::ARMY_ADVANTAGE_LARGE );
             }
             break;
 
         case MP2::OBJ_DAEMONCAVE:
             if ( tile.QuantityIsValid() && 4 != tile.QuantityVariant() )
-                return army.isStrongerThan( Army( tile ), AI::ARMY_ADVANTAGE_MEDIUM );
+                return isHeroStrongerThan( tile, objectType, ai, heroArmyStrength, AI::ARMY_ADVANTAGE_MEDIUM );
             break;
 
         case MP2::OBJ_MONSTER:
-            return army.isStrongerThan( Army( tile ), hero.isLosingGame() ? 1.0 : AI::ARMY_ADVANTAGE_MEDIUM );
+            return isHeroStrongerThan( tile, objectType, ai, heroArmyStrength, ( hero.isLosingGame() ? 1.0 : AI::ARMY_ADVANTAGE_MEDIUM ) );
 
         case MP2::OBJ_SIGN:
             // AI has no brains to process anything from sign messages.
@@ -390,7 +397,7 @@ namespace
                 else if ( hero.isFriends( hero2->GetColor() ) )
                     return false;
                 else if ( otherHeroInCastle )
-                    return AIShouldVisitCastle( hero, index );
+                    return AIShouldVisitCastle( hero, index, heroArmyStrength );
                 else if ( army.isStrongerThan( hero2->GetArmy(), hero.isLosingGame() ? AI::ARMY_ADVANTAGE_DESPERATE : AI::ARMY_ADVANTAGE_SMALL ) )
                     return true;
             }
@@ -398,7 +405,7 @@ namespace
         }
 
         case MP2::OBJ_CASTLE:
-            return AIShouldVisitCastle( hero, index );
+            return AIShouldVisitCastle( hero, index, heroArmyStrength );
 
         case MP2::OBJ_BOAT:
             // AI should never consider a boat as a destination point. It uses them only to make a path.
@@ -409,7 +416,7 @@ namespace
             return false;
 
         case MP2::OBJ_JAIL:
-            return hero.GetKingdom().GetHeroes().size() < Kingdom::GetMaxHeroes();
+            return kingdom.GetHeroes().size() < Kingdom::GetMaxHeroes();
         case MP2::OBJ_HUTMAGI:
             return !hero.isObjectTypeVisited( MP2::OBJ_HUTMAGI, Visit::GLOBAL ) && !Maps::GetObjectPositions( MP2::OBJ_EYEMAGI, true ).empty();
         case MP2::OBJ_TRADINGPOST:
@@ -426,7 +433,7 @@ namespace
 
             const payment_t payment = PaymentConditions::ForAlchemist();
 
-            return cursed > 0 && hero.GetKingdom().AllowPayment( payment );
+            return cursed > 0 && kingdom.AllowPayment( payment );
         }
         default:
             // Did you add a new action object but forget to add AI interaction for it?
@@ -467,10 +474,14 @@ namespace
     class ObjectValidator
     {
     public:
-        explicit ObjectValidator( const Heroes & hero, const AIWorldPathfinder & pathfinder )
+        explicit ObjectValidator( const Heroes & hero, const AIWorldPathfinder & pathfinder, AI::Normal & ai )
             : _hero( hero )
             , _pathfinder( pathfinder )
-        {}
+            , _ai( ai )
+            , _heroArmyStrength( hero.GetArmy().GetStrength() )
+        {
+            // Do nothing.
+        }
 
         bool isValid( const int index )
         {
@@ -479,7 +490,7 @@ namespace
                 return iter->second;
             }
 
-            const bool valid = HeroesValidObject( _hero, index, _pathfinder );
+            const bool valid = HeroesValidObject( _hero, index, _pathfinder, _ai, _heroArmyStrength );
             _validObjects[index] = valid;
             return valid;
         }
@@ -487,6 +498,11 @@ namespace
     private:
         const Heroes & _hero;
         const AIWorldPathfinder & _pathfinder;
+        AI::Normal & _ai;
+
+        // Hero's strength value is valid till any action is done.
+        // Since an instance of this class is used only for evaluation of the future movement it is appropriate to cache the strength.
+        const double _heroArmyStrength;
 
         std::map<int, bool> _validObjects;
     };
@@ -1082,7 +1098,7 @@ namespace AI
 
         const uint32_t leftMovePoints = hero.GetMovePoints();
 
-        ObjectValidator objectValidator( hero, _pathfinder );
+        ObjectValidator objectValidator( hero, _pathfinder, *this );
         ObjectValueStorage valueStorage( hero, *this, lowestPossibleValue );
 
         auto getObjectValue = [&objectValidator, &valueStorage, this, heroStrength, &hero, leftMovePoints]( const int destination, uint32_t & distance, double & value ) {
@@ -1176,11 +1192,19 @@ namespace AI
         return priorityTarget;
     }
 
-    void Normal::HeroesActionComplete( Heroes & hero )
+    void Normal::HeroesActionComplete( Heroes & hero, const MP2::MapObjectType objectType )
     {
         Castle * castle = hero.inCastleMutable();
         if ( castle ) {
             ReinforceHeroInCastle( hero, *castle, castle->GetKingdom().GetFunds() );
+        }
+
+        if ( isMonsterStrengthCacheable( objectType ) ) {
+            // An object can be at the same tile at the hero or on a neighbouring tile so erase all tiles around the hero including the tile where the hero is standing.
+            const int32_t heroIndex = hero.GetIndex();
+            for ( int32_t offset : { 0, 1, -1, world.w(), world.w() + 1, world.w() - 1, -world.w(), -world.w() + 1, -world.w() - 1 } ) {
+                _neutralMonsterStrengthCache.erase( heroIndex + offset );
+            }
         }
     }
 

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -318,8 +318,8 @@ namespace AI
                 objectType = tile.GetObject( false );
             }
 
-            const int tileColor = tile.QuantityColor();
             if ( objectType == MP2::OBJ_CASTLE ) {
+                const int tileColor = tile.QuantityColor();
                 if ( myColor == tileColor || Players::isFriends( myColor, tileColor ) ) {
                     ++stats.friendlyCastles;
                 }

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -237,6 +237,9 @@ namespace AI
         KingdomHeroes & heroes = kingdom.GetHeroes();
         const KingdomCastles & castles = kingdom.GetCastles();
 
+        // Clear the cache of neutral monsters as their strength might have changed.
+        _neutralMonsterStrengthCache.clear();
+
         DEBUG_LOG( DBG_AI, DBG_INFO, Color::String( myColor ) << " starts the turn: " << castles.size() << " castles, " << heroes.size() << " heroes" )
         DEBUG_LOG( DBG_AI, DBG_TRACE, "Funds: " << kingdom.GetFunds().String() )
 
@@ -356,7 +359,7 @@ namespace AI
             // Step 2. Do some hero stuff.
             // If a hero is standing in a castle most likely he has nothing to do so let's try to give him more army.
             for ( Heroes * hero : heroes ) {
-                HeroesActionComplete( *hero );
+                HeroesActionComplete( *hero, MP2::OBJ_ZERO );
             }
 
             // Step 3. Reassign heroes roles
@@ -457,5 +460,23 @@ namespace AI
 
         // target found, buy hero
         return recruitmentCastle && recruitHero( *recruitmentCastle, !slowEarlyGame, false );
+    }
+
+    double Normal::getTargetArmyStrength( const Maps::Tiles & tile, const MP2::MapObjectType objectType )
+    {
+        if ( !isMonsterStrengthCacheable( objectType ) ) {
+            return Army( tile ).GetStrength();
+        }
+
+        const int32_t tileId = tile.GetIndex();
+
+        auto iter = _neutralMonsterStrengthCache.find( tileId );
+        if ( iter != _neutralMonsterStrengthCache.end() ) {
+            // Cache hit.
+            return iter->second;
+        }
+
+        auto newEntry = _neutralMonsterStrengthCache.emplace( tileId, Army( tile ).GetStrength() );
+        return newEntry.first->second;
     }
 }

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -308,11 +308,6 @@ void Kingdom::RemoveCastle( const Castle * castle )
         LossPostActions();
 }
 
-bool Kingdom::isLosingGame() const
-{
-    return castles.empty();
-}
-
 u32 Kingdom::GetCountCastle( void ) const
 {
     return static_cast<uint32_t>( std::count_if( castles.begin(), castles.end(), Castle::PredicateIsCastle ) );

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -97,7 +97,11 @@ public:
     void AddFundsResource( const Funds & );
     void OddFundsResource( const Funds & );
 
-    bool isLosingGame() const;
+    bool isLosingGame() const
+    {
+        return castles.empty();
+    }
+
     u32 GetCountCastle( void ) const;
     u32 GetCountTown( void ) const;
     u32 GetCountMarketplace( void ) const;

--- a/src/fheroes2/monster/monster.cpp
+++ b/src/fheroes2/monster/monster.cpp
@@ -170,8 +170,6 @@ uint32_t Monster::GetShots() const
 // Doesn't account for situational special bonuses such as spell immunity
 double Monster::GetMonsterStrength( int attack, int defense ) const
 {
-    const fheroes2::MonsterBattleStats & battleStats = fheroes2::getMonsterData( id ).battleStats;
-
     // If no modified values were provided then re-calculate
     // GetAttack and GetDefense will call overloaded versions accounting for Hero bonuses
     if ( attack == -1 )
@@ -181,61 +179,9 @@ double Monster::GetMonsterStrength( int attack, int defense ) const
         defense = GetDefense();
 
     const double attackDefense = 1.0 + attack * 0.1 + defense * 0.05;
-    const double effectiveHP = battleStats.hp * ( ignoreRetaliation() ? 1.4 : 1 );
-
-    double damagePotential = ( battleStats.damageMin + battleStats.damageMax ) / 2.0;
-
-    if ( isDoubleAttack() ) {
-        // Melee attacker will lose potential on second attack after retaliation
-        damagePotential *= ( isArchers() || ignoreRetaliation() ) ? 2 : 1.75;
-    }
-    if ( isAbilityPresent( fheroes2::MonsterAbilityType::DOUBLE_DAMAGE_TO_UNDEAD ) )
-        damagePotential *= 1.15; // 15% of all Monsters are Undead, deals double dmg
-    if ( isDoubleCellAttack() )
-        damagePotential *= 1.2;
-    if ( isAbilityPresent( fheroes2::MonsterAbilityType::ALWAYS_RETALIATE ) )
-        damagePotential *= 1.25;
-    if ( isAbilityPresent( fheroes2::MonsterAbilityType::ALL_ADJACENT_CELL_MELEE_ATTACK ) || isAbilityPresent( fheroes2::MonsterAbilityType::AREA_SHOT ) )
-        damagePotential *= 1.3;
-
-    double monsterSpecial = 1.0;
-    if ( isArchers() ) {
-        monsterSpecial += isAbilityPresent( fheroes2::MonsterAbilityType::NO_MELEE_PENALTY ) ? 0.5 : 0.4;
-    }
-    if ( isFlying() ) {
-        monsterSpecial += 0.3;
-    }
-
-    switch ( id ) {
-    case Monster::UNICORN:
-    case Monster::CYCLOPS:
-    case Monster::MEDUSA:
-        // 20% to Blind, Paralyze and Petrify
-        monsterSpecial += 0.2;
-        break;
-    case Monster::VAMPIRE_LORD:
-        // Lifesteal
-        monsterSpecial += 0.3;
-        break;
-    case Monster::GENIE:
-        // Genie's ability to half enemy troops
-        monsterSpecial += 1;
-        break;
-    case Monster::GHOST:
-        // Ghost's ability to increase the numbers
-        monsterSpecial += 2;
-        break;
-    default:
-        break;
-    }
-
-    // Higher speed gives initiative advantage/first attack. Remap speed value to -0.2...+0.15, AVERAGE is 0
-    // Punish slow speeds more as unit won't participate in first rounds and slows down strategic army
-    const int speedDiff = battleStats.speed - Speed::AVERAGE;
-    monsterSpecial += ( speedDiff < 0 ) ? speedDiff * 0.1 : speedDiff * 0.05;
 
     // Additonal HP and Damage effectiveness diminishes with every combat round; strictly x4 HP == x2 unit count
-    return sqrt( damagePotential * effectiveHP ) * attackDefense * monsterSpecial;
+    return attackDefense * fheroes2::getMonsterData( id ).battleStats.monsterBaseStrength;
 }
 
 u32 Monster::GetRNDSize( bool skip_factor ) const
@@ -324,13 +270,6 @@ u32 Monster::GetRNDSize( bool skip_factor ) const
     }
 
     return ( result > 1 ) ? Rand::Get( result / 2, result ) : 1;
-}
-
-bool Monster::isAbilityPresent( const fheroes2::MonsterAbilityType abilityType ) const
-{
-    const std::vector<fheroes2::MonsterAbility> & abilities = fheroes2::getMonsterData( id ).battleStats.abilities;
-
-    return std::find( abilities.begin(), abilities.end(), fheroes2::MonsterAbility( abilityType ) ) != abilities.end();
 }
 
 Monster Monster::GetDowngrade() const

--- a/src/fheroes2/monster/monster.cpp
+++ b/src/fheroes2/monster/monster.cpp
@@ -179,8 +179,6 @@ double Monster::GetMonsterStrength( int attack, int defense ) const
         defense = GetDefense();
 
     const double attackDefense = 1.0 + attack * 0.1 + defense * 0.05;
-
-    // Additonal HP and Damage effectiveness diminishes with every combat round; strictly x4 HP == x2 unit count
     return attackDefense * fheroes2::getMonsterData( id ).battleStats.monsterBaseStrength;
 }
 

--- a/src/fheroes2/monster/monster.cpp
+++ b/src/fheroes2/monster/monster.cpp
@@ -272,6 +272,13 @@ u32 Monster::GetRNDSize( bool skip_factor ) const
     return ( result > 1 ) ? Rand::Get( result / 2, result ) : 1;
 }
 
+bool Monster::isAbilityPresent( const fheroes2::MonsterAbilityType abilityType ) const
+{
+    const std::vector<fheroes2::MonsterAbility> & abilities = fheroes2::getMonsterData( id ).battleStats.abilities;
+
+    return std::find( abilities.begin(), abilities.end(), fheroes2::MonsterAbility( abilityType ) ) != abilities.end();
+}
+
 Monster Monster::GetDowngrade() const
 {
     switch ( id ) {

--- a/src/fheroes2/monster/monster.h
+++ b/src/fheroes2/monster/monster.h
@@ -276,7 +276,10 @@ public:
         return !( isUndead() || isElemental() );
     }
 
-    bool isAbilityPresent( const fheroes2::MonsterAbilityType abilityType ) const;
+    bool isAbilityPresent( const fheroes2::MonsterAbilityType abilityType ) const
+    {
+        return fheroes2::isAbilityPresent( id, abilityType );
+    }
 
     double GetMonsterStrength( int attack = -1, int defense = -1 ) const;
 

--- a/src/fheroes2/monster/monster.h
+++ b/src/fheroes2/monster/monster.h
@@ -278,7 +278,9 @@ public:
 
     bool isAbilityPresent( const fheroes2::MonsterAbilityType abilityType ) const
     {
-        return fheroes2::isAbilityPresent( id, abilityType );
+        const std::vector<fheroes2::MonsterAbility> & abilities = fheroes2::getMonsterData( id ).battleStats.abilities;
+
+        return std::find( abilities.begin(), abilities.end(), fheroes2::MonsterAbility( abilityType ) ) != abilities.end();
     }
 
     double GetMonsterStrength( int attack = -1, int defense = -1 ) const;

--- a/src/fheroes2/monster/monster.h
+++ b/src/fheroes2/monster/monster.h
@@ -276,12 +276,7 @@ public:
         return !( isUndead() || isElemental() );
     }
 
-    bool isAbilityPresent( const fheroes2::MonsterAbilityType abilityType ) const
-    {
-        const std::vector<fheroes2::MonsterAbility> & abilities = fheroes2::getMonsterData( id ).battleStats.abilities;
-
-        return std::find( abilities.begin(), abilities.end(), fheroes2::MonsterAbility( abilityType ) ) != abilities.end();
-    }
+    bool isAbilityPresent( const fheroes2::MonsterAbilityType abilityType ) const;
 
     double GetMonsterStrength( int attack = -1, int defense = -1 ) const;
 

--- a/src/fheroes2/monster/monster_info.cpp
+++ b/src/fheroes2/monster/monster_info.cpp
@@ -931,9 +931,4 @@ namespace fheroes2
 
         return spellResistance;
     }
-
-    bool isAbilityPresent( const int monsterId, const MonsterAbilityType abilityType )
-    {
-        return ::isAbilityPresent( getMonsterData( monsterId ).battleStats.abilities, abilityType );
-    }
 }

--- a/src/fheroes2/monster/monster_info.cpp
+++ b/src/fheroes2/monster/monster_info.cpp
@@ -215,9 +215,9 @@ namespace
             { M82::UNKNOWN, M82::UNKNOWN, M82::UNKNOWN, M82::UNKNOWN, M82::UNKNOWN, M82::UNKNOWN, M82::UNKNOWN, M82::UNKNOWN }, // Random Monster 4
         };
 
-        // Monster abilities and weaknesses will be added later.
+        // Monster abilities and weaknesses will be added later. Base strength is calculated based on abilities.
         const fheroes2::MonsterBattleStats monsterBattleStats[Monster::MONSTER_COUNT] = {
-            // attack | defence | damageMin | damageMax | hp | speed | shots | abilities | weaknesses
+            // attack | defence | damageMin | damageMax | hp | speed | shots | baseStrength | abilities | weaknesses
             { 0, 0, 0, 0, 0, Speed::VERYSLOW, 0, 0, {}, {} }, // Unknown Monster
             { 1, 1, 1, 1, 1, Speed::VERYSLOW, 0, 0, {}, {} }, // Peasant
             { 5, 3, 2, 3, 10, Speed::VERYSLOW, 12, 0, {}, {} }, // Archer

--- a/src/fheroes2/monster/monster_info.cpp
+++ b/src/fheroes2/monster/monster_info.cpp
@@ -38,6 +38,79 @@ namespace
 {
     std::vector<fheroes2::MonsterData> monsterData;
 
+    double getMonsterBaseStrength( const int monsterId )
+    {
+        const fheroes2::MonsterBattleStats & battleStats = fheroes2::getMonsterData( monsterId ).battleStats;
+
+        const double effectiveHP = battleStats.hp * ( isAbilityPresent( monsterId, fheroes2::MonsterAbilityType::NO_ENEMY_RETALIATION ) ? 1.4 : 1 );
+        const bool isArchers = ( battleStats.shots > 0 );
+
+        double damagePotential = ( battleStats.damageMin + battleStats.damageMax ) / 2.0;
+
+        if ( isAbilityPresent( monsterId, fheroes2::MonsterAbilityType::TWO_CELL_MELEE_ATTACK ) ) {
+            // Melee attacker will lose potential on second attack after retaliation
+            damagePotential *= ( isArchers || isAbilityPresent( monsterId, fheroes2::MonsterAbilityType::NO_ENEMY_RETALIATION ) ) ? 2 : 1.75;
+        }
+
+        if ( isAbilityPresent( monsterId, fheroes2::MonsterAbilityType::DOUBLE_DAMAGE_TO_UNDEAD ) ) {
+            damagePotential *= 1.15; // 15% of all Monsters are Undead, deals double dmg
+        }
+
+        if ( isAbilityPresent( monsterId, fheroes2::MonsterAbilityType::TWO_CELL_MELEE_ATTACK ) ) {
+            damagePotential *= 1.2;
+        }
+
+        if ( isAbilityPresent( monsterId, fheroes2::MonsterAbilityType::ALWAYS_RETALIATE ) ) {
+            damagePotential *= 1.25;
+        }
+
+        if ( isAbilityPresent( monsterId, fheroes2::MonsterAbilityType::ALL_ADJACENT_CELL_MELEE_ATTACK )
+             || isAbilityPresent( monsterId, fheroes2::MonsterAbilityType::AREA_SHOT ) ) {
+            damagePotential *= 1.3;
+        }
+
+        double monsterSpecial = 1.0;
+
+        if ( isArchers ) {
+            monsterSpecial += isAbilityPresent( monsterId, fheroes2::MonsterAbilityType::NO_MELEE_PENALTY ) ? 0.5 : 0.4;
+        }
+
+        if ( isAbilityPresent( monsterId, fheroes2::MonsterAbilityType::FLYING ) ) {
+            monsterSpecial += 0.3;
+        }
+
+        switch ( monsterId ) {
+        case Monster::UNICORN:
+        case Monster::CYCLOPS:
+        case Monster::MEDUSA:
+            // 20% to Blind, Paralyze and Petrify
+            monsterSpecial += 0.2;
+            break;
+        case Monster::VAMPIRE_LORD:
+            // Lifesteal
+            monsterSpecial += 0.3;
+            break;
+        case Monster::GENIE:
+            // Genie's ability to half enemy troops
+            monsterSpecial += 1;
+            break;
+        case Monster::GHOST:
+            // Ghost's ability to increase the numbers
+            monsterSpecial += 2;
+            break;
+        default:
+            break;
+        }
+
+        // Higher speed gives initiative advantage/first attack. Remap speed value to -0.2...+0.15, AVERAGE is 0
+        // Punish slow speeds more as unit won't participate in first rounds and slows down strategic army
+        const int speedDiff = battleStats.speed - Speed::AVERAGE;
+        monsterSpecial += ( speedDiff < 0 ) ? speedDiff * 0.1 : speedDiff * 0.05;
+
+        // Additonal HP and Damage effectiveness diminishes with every combat round; strictly x4 HP == x2 unit count
+        return sqrt( damagePotential * effectiveHP ) * monsterSpecial;
+    }
+
     void populateMonsterData()
     {
         const int monsterIcnIds[Monster::MONSTER_COUNT]
@@ -139,78 +212,78 @@ namespace
         // Monster abilities and weaknesses will be added later.
         const fheroes2::MonsterBattleStats monsterBattleStats[Monster::MONSTER_COUNT] = {
             // attack | defence | damageMin | damageMax | hp | speed | shots | abilities | weaknesses
-            { 0, 0, 0, 0, 0, Speed::VERYSLOW, 0, {}, {} }, // Unknown Monster
-            { 1, 1, 1, 1, 1, Speed::VERYSLOW, 0, {}, {} }, // Peasant
-            { 5, 3, 2, 3, 10, Speed::VERYSLOW, 12, {}, {} }, // Archer
-            { 5, 3, 2, 3, 10, Speed::AVERAGE, 24, {}, {} }, // Ranger
-            { 5, 9, 3, 4, 15, Speed::AVERAGE, 0, {}, {} }, // Pikeman
-            { 5, 9, 3, 4, 20, Speed::FAST, 0, {}, {} }, // Veteran Pikeman
-            { 7, 9, 4, 6, 25, Speed::AVERAGE, 0, {}, {} }, // Swordsman
-            { 7, 9, 4, 6, 30, Speed::FAST, 0, {}, {} }, // Master Swordsman
-            { 10, 9, 5, 10, 30, Speed::VERYFAST, 0, {}, {} }, // Cavalry
-            { 10, 9, 5, 10, 40, Speed::ULTRAFAST, 0, {}, {} }, // Champion
-            { 11, 12, 10, 20, 50, Speed::FAST, 0, {}, {} }, // Paladin
-            { 11, 12, 10, 20, 65, Speed::VERYFAST, 0, {}, {} }, // Crusader
-            { 3, 1, 1, 2, 3, Speed::AVERAGE, 0, {}, {} }, // Goblin
-            { 3, 4, 2, 3, 10, Speed::VERYSLOW, 8, {}, {} }, // Orc
-            { 3, 4, 3, 4, 15, Speed::SLOW, 16, {}, {} }, // Orc Chief
-            { 6, 2, 3, 5, 20, Speed::VERYFAST, 0, {}, {} }, // Wolf
-            { 9, 5, 4, 6, 40, Speed::VERYSLOW, 0, {}, {} }, // Ogre
-            { 9, 5, 5, 7, 60, Speed::AVERAGE, 0, {}, {} }, // Ogre Lord
-            { 10, 5, 5, 7, 40, Speed::AVERAGE, 8, {}, {} }, // Troll
-            { 10, 5, 7, 9, 40, Speed::FAST, 16, {}, {} }, // War Troll
-            { 12, 9, 12, 24, 80, Speed::FAST, 0, {}, {} }, // Cyclops
-            { 4, 2, 1, 2, 2, Speed::AVERAGE, 0, {}, {} }, // Sprite
-            { 6, 5, 2, 4, 20, Speed::VERYSLOW, 0, {}, {} }, // Dwarf
-            { 6, 6, 2, 4, 20, Speed::AVERAGE, 0, {}, {} }, // Battle Dwarf
-            { 4, 3, 2, 3, 15, Speed::AVERAGE, 24, {}, {} }, // Elf
-            { 5, 5, 2, 3, 15, Speed::VERYFAST, 24, {}, {} }, // Grand Elf
-            { 7, 5, 5, 8, 25, Speed::FAST, 8, {}, {} }, // Druid
-            { 7, 7, 5, 8, 25, Speed::VERYFAST, 16, {}, {} }, // Greater Druid
-            { 10, 9, 7, 14, 40, Speed::FAST, 0, {}, {} }, // Unicorn
-            { 12, 10, 20, 40, 100, Speed::ULTRAFAST, 0, {}, {} }, // Phoenix
-            { 3, 1, 1, 2, 5, Speed::AVERAGE, 8, {}, {} }, // Centaur
-            { 4, 7, 2, 3, 15, Speed::VERYFAST, 0, {}, {} }, // Gargoyle
-            { 6, 6, 3, 5, 25, Speed::AVERAGE, 0, {}, {} }, // Griffin
-            { 9, 8, 5, 10, 35, Speed::AVERAGE, 0, {}, {} }, // Minotaur
-            { 9, 8, 5, 10, 45, Speed::VERYFAST, 0, {}, {} }, // Minotaur King
-            { 8, 9, 6, 12, 75, Speed::VERYSLOW, 0, {}, {} }, // Hydra
-            { 12, 12, 25, 50, 200, Speed::AVERAGE, 0, {}, {} }, // Green Dragon
-            { 13, 13, 25, 50, 250, Speed::FAST, 0, {}, {} }, // Red Dragon
-            { 14, 14, 25, 50, 300, Speed::VERYFAST, 0, {}, {} }, // Black Dragon
-            { 2, 1, 1, 3, 3, Speed::SLOW, 12, {}, {} }, // Halfling
-            { 5, 4, 2, 3, 15, Speed::VERYFAST, 0, {}, {} }, // Boar
-            { 5, 10, 4, 5, 30, Speed::VERYSLOW, 0, {}, {} }, // Iron Golem
-            { 7, 10, 4, 5, 35, Speed::SLOW, 0, {}, {} }, // Steel Golem
-            { 7, 7, 4, 8, 40, Speed::AVERAGE, 0, {}, {} }, // Roc
-            { 11, 7, 7, 9, 30, Speed::FAST, 12, {}, {} }, // Mage
-            { 12, 8, 7, 9, 35, Speed::VERYFAST, 24, {}, {} }, // Archmage
-            { 13, 10, 20, 30, 150, Speed::AVERAGE, 0, {}, {} }, // Giant
-            { 15, 15, 20, 30, 300, Speed::VERYFAST, 24, {}, {} }, // Titan
-            { 4, 3, 2, 3, 4, Speed::AVERAGE, 0, {}, {} }, // Skeleton
-            { 5, 2, 2, 3, 15, Speed::VERYSLOW, 0, {}, {} }, // Zombie
-            { 5, 2, 2, 3, 20, Speed::AVERAGE, 0, {}, {} }, // Mutant Zombie
-            { 6, 6, 3, 4, 25, Speed::AVERAGE, 0, {}, {} }, // Mummy
-            { 6, 6, 3, 4, 30, Speed::FAST, 0, {}, {} }, // Royal Mummy
-            { 8, 6, 5, 7, 30, Speed::AVERAGE, 0, {}, {} }, // Vampire
-            { 8, 6, 5, 7, 40, Speed::FAST, 0, {}, {} }, // Vampire Lord
-            { 7, 12, 8, 10, 25, Speed::FAST, 12, {}, {} }, // Lich
-            { 7, 13, 8, 10, 35, Speed::VERYFAST, 24, {}, {} }, // Power Lich
-            { 11, 9, 25, 45, 150, Speed::AVERAGE, 0, {}, {} }, // Bone Dragon
-            { 6, 1, 1, 2, 4, Speed::FAST, 0, {}, {} }, // Rogue
-            { 7, 6, 2, 5, 20, Speed::VERYFAST, 0, {}, {} }, // Nomad
-            { 8, 7, 4, 6, 20, Speed::FAST, 0, {}, {} }, // Ghost
-            { 10, 9, 20, 30, 50, Speed::VERYFAST, 0, {}, {} }, // Genie
-            { 8, 9, 6, 10, 35, Speed::AVERAGE, 0, {}, {} }, // Medusa
-            { 8, 8, 4, 5, 50, Speed::SLOW, 0, {}, {} }, // Earth Elemental
-            { 7, 7, 2, 8, 35, Speed::VERYFAST, 0, {}, {} }, // Air Elemental
-            { 8, 6, 4, 6, 40, Speed::FAST, 0, {}, {} }, // Fire Elemental
-            { 6, 8, 3, 7, 45, Speed::AVERAGE, 0, {}, {} }, // Water Elemental
-            { 0, 0, 0, 0, 0, Speed::VERYSLOW, 0, {}, {} }, // Random Monster
-            { 0, 0, 0, 0, 0, Speed::VERYSLOW, 0, {}, {} }, // Random Monster 1
-            { 0, 0, 0, 0, 0, Speed::VERYSLOW, 0, {}, {} }, // Random Monster 2
-            { 0, 0, 0, 0, 0, Speed::VERYSLOW, 0, {}, {} }, // Random Monster 3
-            { 0, 0, 0, 0, 0, Speed::VERYSLOW, 0, {}, {} }, // Random Monster 4
+            { 0, 0, 0, 0, 0, Speed::VERYSLOW, 0, 0, {}, {} }, // Unknown Monster
+            { 1, 1, 1, 1, 1, Speed::VERYSLOW, 0, 0, {}, {} }, // Peasant
+            { 5, 3, 2, 3, 10, Speed::VERYSLOW, 12, 0, {}, {} }, // Archer
+            { 5, 3, 2, 3, 10, Speed::AVERAGE, 24, 0, {}, {} }, // Ranger
+            { 5, 9, 3, 4, 15, Speed::AVERAGE, 0, 0, {}, {} }, // Pikeman
+            { 5, 9, 3, 4, 20, Speed::FAST, 0, 0, {}, {} }, // Veteran Pikeman
+            { 7, 9, 4, 6, 25, Speed::AVERAGE, 0, 0, {}, {} }, // Swordsman
+            { 7, 9, 4, 6, 30, Speed::FAST, 0, 0, {}, {} }, // Master Swordsman
+            { 10, 9, 5, 10, 30, Speed::VERYFAST, 0, 0, {}, {} }, // Cavalry
+            { 10, 9, 5, 10, 40, Speed::ULTRAFAST, 0, 0, {}, {} }, // Champion
+            { 11, 12, 10, 20, 50, Speed::FAST, 0, 0, {}, {} }, // Paladin
+            { 11, 12, 10, 20, 65, Speed::VERYFAST, 0, 0, {}, {} }, // Crusader
+            { 3, 1, 1, 2, 3, Speed::AVERAGE, 0, 0, {}, {} }, // Goblin
+            { 3, 4, 2, 3, 10, Speed::VERYSLOW, 8, 0, {}, {} }, // Orc
+            { 3, 4, 3, 4, 15, Speed::SLOW, 16, 0, {}, {} }, // Orc Chief
+            { 6, 2, 3, 5, 20, Speed::VERYFAST, 0, 0, {}, {} }, // Wolf
+            { 9, 5, 4, 6, 40, Speed::VERYSLOW, 0, 0, {}, {} }, // Ogre
+            { 9, 5, 5, 7, 60, Speed::AVERAGE, 0, 0, {}, {} }, // Ogre Lord
+            { 10, 5, 5, 7, 40, Speed::AVERAGE, 8, 0, {}, {} }, // Troll
+            { 10, 5, 7, 9, 40, Speed::FAST, 16, 0, {}, {} }, // War Troll
+            { 12, 9, 12, 24, 80, Speed::FAST, 0, 0, {}, {} }, // Cyclops
+            { 4, 2, 1, 2, 2, Speed::AVERAGE, 0, 0, {}, {} }, // Sprite
+            { 6, 5, 2, 4, 20, Speed::VERYSLOW, 0, 0, {}, {} }, // Dwarf
+            { 6, 6, 2, 4, 20, Speed::AVERAGE, 0, 0, {}, {} }, // Battle Dwarf
+            { 4, 3, 2, 3, 15, Speed::AVERAGE, 24, 0, {}, {} }, // Elf
+            { 5, 5, 2, 3, 15, Speed::VERYFAST, 24, 0, {}, {} }, // Grand Elf
+            { 7, 5, 5, 8, 25, Speed::FAST, 8, 0, {}, {} }, // Druid
+            { 7, 7, 5, 8, 25, Speed::VERYFAST, 16, 0, {}, {} }, // Greater Druid
+            { 10, 9, 7, 14, 40, Speed::FAST, 0, 0, {}, {} }, // Unicorn
+            { 12, 10, 20, 40, 100, Speed::ULTRAFAST, 0, 0, {}, {} }, // Phoenix
+            { 3, 1, 1, 2, 5, Speed::AVERAGE, 8, 0, {}, {} }, // Centaur
+            { 4, 7, 2, 3, 15, Speed::VERYFAST, 0, 0, {}, {} }, // Gargoyle
+            { 6, 6, 3, 5, 25, Speed::AVERAGE, 0, 0, {}, {} }, // Griffin
+            { 9, 8, 5, 10, 35, Speed::AVERAGE, 0, 0, {}, {} }, // Minotaur
+            { 9, 8, 5, 10, 45, Speed::VERYFAST, 0, 0, {}, {} }, // Minotaur King
+            { 8, 9, 6, 12, 75, Speed::VERYSLOW, 0, 0, {}, {} }, // Hydra
+            { 12, 12, 25, 50, 200, Speed::AVERAGE, 0, 0, {}, {} }, // Green Dragon
+            { 13, 13, 25, 50, 250, Speed::FAST, 0, 0, {}, {} }, // Red Dragon
+            { 14, 14, 25, 50, 300, Speed::VERYFAST, 0, 0, {}, {} }, // Black Dragon
+            { 2, 1, 1, 3, 3, Speed::SLOW, 12, 0, {}, {} }, // Halfling
+            { 5, 4, 2, 3, 15, Speed::VERYFAST, 0, 0, {}, {} }, // Boar
+            { 5, 10, 4, 5, 30, Speed::VERYSLOW, 0, 0, {}, {} }, // Iron Golem
+            { 7, 10, 4, 5, 35, Speed::SLOW, 0, 0, {}, {} }, // Steel Golem
+            { 7, 7, 4, 8, 40, Speed::AVERAGE, 0, 0, {}, {} }, // Roc
+            { 11, 7, 7, 9, 30, Speed::FAST, 12, 0, {}, {} }, // Mage
+            { 12, 8, 7, 9, 35, Speed::VERYFAST, 24, 0, {}, {} }, // Archmage
+            { 13, 10, 20, 30, 150, Speed::AVERAGE, 0, 0, {}, {} }, // Giant
+            { 15, 15, 20, 30, 300, Speed::VERYFAST, 24, 0, {}, {} }, // Titan
+            { 4, 3, 2, 3, 4, Speed::AVERAGE, 0, 0, {}, {} }, // Skeleton
+            { 5, 2, 2, 3, 15, Speed::VERYSLOW, 0, 0, {}, {} }, // Zombie
+            { 5, 2, 2, 3, 20, Speed::AVERAGE, 0, 0, {}, {} }, // Mutant Zombie
+            { 6, 6, 3, 4, 25, Speed::AVERAGE, 0, 0, {}, {} }, // Mummy
+            { 6, 6, 3, 4, 30, Speed::FAST, 0, 0, {}, {} }, // Royal Mummy
+            { 8, 6, 5, 7, 30, Speed::AVERAGE, 0, 0, {}, {} }, // Vampire
+            { 8, 6, 5, 7, 40, Speed::FAST, 0, 0, {}, {} }, // Vampire Lord
+            { 7, 12, 8, 10, 25, Speed::FAST, 12, 0, {}, {} }, // Lich
+            { 7, 13, 8, 10, 35, Speed::VERYFAST, 24, 0, {}, {} }, // Power Lich
+            { 11, 9, 25, 45, 150, Speed::AVERAGE, 0, 0, {}, {} }, // Bone Dragon
+            { 6, 1, 1, 2, 4, Speed::FAST, 0, 0, {}, {} }, // Rogue
+            { 7, 6, 2, 5, 20, Speed::VERYFAST, 0, 0, {}, {} }, // Nomad
+            { 8, 7, 4, 6, 20, Speed::FAST, 0, 0, {}, {} }, // Ghost
+            { 10, 9, 20, 30, 50, Speed::VERYFAST, 0, 0, {}, {} }, // Genie
+            { 8, 9, 6, 10, 35, Speed::AVERAGE, 0, 0, {}, {} }, // Medusa
+            { 8, 8, 4, 5, 50, Speed::SLOW, 0, 0, {}, {} }, // Earth Elemental
+            { 7, 7, 2, 8, 35, Speed::VERYFAST, 0, 0, {}, {} }, // Air Elemental
+            { 8, 6, 4, 6, 40, Speed::FAST, 0, 0, {}, {} }, // Fire Elemental
+            { 6, 8, 3, 7, 45, Speed::AVERAGE, 0, 0, {}, {} }, // Water Elemental
+            { 0, 0, 0, 0, 0, Speed::VERYSLOW, 0, 0, {}, {} }, // Random Monster
+            { 0, 0, 0, 0, 0, Speed::VERYSLOW, 0, 0, {}, {} }, // Random Monster 1
+            { 0, 0, 0, 0, 0, Speed::VERYSLOW, 0, 0, {}, {} }, // Random Monster 2
+            { 0, 0, 0, 0, 0, Speed::VERYSLOW, 0, 0, {}, {} }, // Random Monster 3
+            { 0, 0, 0, 0, 0, Speed::VERYSLOW, 0, 0, {}, {} }, // Random Monster 4
         };
 
         const fheroes2::MonsterGeneralStats monsterGeneralStats[Monster::MONSTER_COUNT]
@@ -456,6 +529,11 @@ namespace
         monsterData[Monster::WATER_ELEMENT].battleStats.abilities.emplace_back( fheroes2::MonsterAbilityType::ELEMENTAL );
         monsterData[Monster::WATER_ELEMENT].battleStats.abilities.emplace_back( fheroes2::MonsterAbilityType::COLD_SPELL_IMMUNITY );
         monsterData[Monster::WATER_ELEMENT].battleStats.weaknesses.emplace_back( fheroes2::MonsterWeaknessType::EXTRA_DAMAGE_FROM_FIRE_SPELL );
+
+        // Calculate base value of monster strength.
+        for ( int i = 0; i < Monster::MONSTER_COUNT; ++i ) {
+            monsterData[i].battleStats.monsterBaseStrength = getMonsterBaseStrength( i );
+        }
 
         // TODO: verify that no duplicates of abilities and weaknesses exist.
     }
@@ -846,5 +924,12 @@ namespace fheroes2
         }
 
         return spellResistance;
+    }
+
+    bool isAbilityPresent( const int monsterId, const MonsterAbilityType abilityType )
+    {
+        const std::vector<MonsterAbility> & abilities = getMonsterData( monsterId ).battleStats.abilities;
+
+        return std::find( abilities.begin(), abilities.end(), MonsterAbility( abilityType ) ) != abilities.end();
     }
 }

--- a/src/fheroes2/monster/monster_info.cpp
+++ b/src/fheroes2/monster/monster_info.cpp
@@ -85,24 +85,24 @@ namespace
             monsterSpecial += 0.3;
         }
 
+        if ( isAbilityPresent( abilities, fheroes2::MonsterAbilityType::ENEMY_HALFING ) ) {
+            monsterSpecial += 1;
+        }
+
+        if ( isAbilityPresent( abilities, fheroes2::MonsterAbilityType::SOUL_EATER ) ) {
+            monsterSpecial += 2;
+        }
+
+        if ( isAbilityPresent( abilities, fheroes2::MonsterAbilityType::HP_DRAIN ) ) {
+            monsterSpecial += 0.3;
+        }
+
         switch ( monsterId ) {
         case Monster::UNICORN:
         case Monster::CYCLOPS:
         case Monster::MEDUSA:
             // 20% to Blind, Paralyze and Petrify
             monsterSpecial += 0.2;
-            break;
-        case Monster::VAMPIRE_LORD:
-            // Lifesteal
-            monsterSpecial += 0.3;
-            break;
-        case Monster::GENIE:
-            // Genie's ability to half enemy troops
-            monsterSpecial += 1;
-            break;
-        case Monster::GHOST:
-            // Ghost's ability to increase the numbers
-            monsterSpecial += 2;
             break;
         default:
             break;

--- a/src/fheroes2/monster/monster_info.cpp
+++ b/src/fheroes2/monster/monster_info.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Free Heroes of Might and Magic II: https://github.com/ihhub/fheroes2  *
- *   Copyright (C) 2021                                                    *
+ *   Copyright (C) 2021 - 2022                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/monster/monster_info.h
+++ b/src/fheroes2/monster/monster_info.h
@@ -196,7 +196,5 @@ namespace fheroes2
     std::vector<std::string> getMonsterPropertiesDescription( const int monsterId );
 
     uint32_t getSpellResistance( const int monsterId, const int spellId );
-
-    bool isAbilityPresent( const int monsterId, const MonsterAbilityType abilityType );
 }
 #endif

--- a/src/fheroes2/monster/monster_info.h
+++ b/src/fheroes2/monster/monster_info.h
@@ -134,6 +134,8 @@ namespace fheroes2
         uint32_t speed;
         uint32_t shots;
 
+        double monsterBaseStrength;
+
         std::vector<MonsterAbility> abilities;
         std::vector<MonsterWeakness> weaknesses;
     };
@@ -194,5 +196,7 @@ namespace fheroes2
     std::vector<std::string> getMonsterPropertiesDescription( const int monsterId );
 
     uint32_t getSpellResistance( const int monsterId, const int spellId );
+
+    bool isAbilityPresent( const int monsterId, const MonsterAbilityType abilityType );
 }
 #endif


### PR DESCRIPTION
Calculation of army strength is a heavy operation and we should avoid calling it over and over again. However, caching should be error-prone to avoid incorrect estimations of strength by AI. close #3840 

Also this pull request fixes a case when AI was ignoring shrines with "View All" spell.