### PR TITLE
Speed up AI turn

### DIFF
--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -109,79 +109,82 @@ void Interface::StatusWindow::SetState( const StatusType status )
 void Interface::StatusWindow::Redraw( void ) const
 {
     const Settings & conf = Settings::Get();
+    if ( conf.ExtGameHideInterface() && !conf.ShowStatus() ) {
+        // The window is hidden.
+        return;
+    }
+
     const fheroes2::Rect & pos = GetArea();
 
-    if ( !conf.ExtGameHideInterface() || conf.ShowStatus() ) {
-        if ( conf.ExtGameHideInterface() ) {
-            fheroes2::Fill( fheroes2::Display::instance(), pos.x, pos.y, pos.width, pos.height, fheroes2::GetColorId( 0x51, 0x31, 0x18 ) );
-            BorderWindow::Redraw();
-        }
-        else {
-            DrawBackground();
-        }
+    if ( conf.ExtGameHideInterface() ) {
+        fheroes2::Fill( fheroes2::Display::instance(), pos.x, pos.y, pos.width, pos.height, fheroes2::GetColorId( 0x51, 0x31, 0x18 ) );
+        BorderWindow::Redraw();
+    }
+    else {
+        DrawBackground();
+    }
 
-        // draw info: Day and Funds and Army
-        const fheroes2::Sprite & ston = fheroes2::AGG::GetICN( Settings::Get().ExtGameEvilInterface() ? ICN::STONBAKE : ICN::STONBACK, 0 );
-        const int32_t stonHeight = ston.height();
+    // draw info: Day and Funds and Army
+    const fheroes2::Sprite & ston = fheroes2::AGG::GetICN( conf.ExtGameEvilInterface() ? ICN::STONBAKE : ICN::STONBACK, 0 );
+    const int32_t stonHeight = ston.height();
 
-        if ( StatusType::STATUS_AITURN == _state ) {
-            DrawAITurns();
+    if ( StatusType::STATUS_AITURN == _state ) {
+        DrawAITurns();
+    }
+    else if ( StatusType::STATUS_UNKNOWN != _state && pos.height >= ( stonHeight * 3 + 15 ) ) {
+        DrawDayInfo();
+
+        if ( conf.CurrentColor() & Players::HumanColors() ) {
+            DrawKingdomInfo( stonHeight + 5 );
+
+            if ( _state != StatusType::STATUS_RESOURCE )
+                DrawArmyInfo( 2 * stonHeight + 10 );
+            else
+                DrawResourceInfo( 2 * stonHeight + 10 );
         }
-        else if ( StatusType::STATUS_UNKNOWN != _state && pos.height >= ( stonHeight * 3 + 15 ) ) {
+    }
+    else if ( StatusType::STATUS_UNKNOWN != _state && pos.height >= ( stonHeight * 2 + 15 ) ) {
+        DrawDayInfo();
+
+        switch ( _state ) {
+        case StatusType::STATUS_FUNDS:
+            DrawKingdomInfo( stonHeight + 5 );
+            break;
+        case StatusType::STATUS_DAY:
+        case StatusType::STATUS_ARMY:
+            DrawArmyInfo( stonHeight + 5 );
+            break;
+        case StatusType::STATUS_RESOURCE:
+            DrawResourceInfo( stonHeight + 5 );
+            break;
+        case StatusType::STATUS_UNKNOWN:
+        case StatusType::STATUS_AITURN:
+            assert( 0 ); // we shouldn't even reach this code
+            break;
+        default:
+            break;
+        }
+    }
+    else {
+        switch ( _state ) {
+        case StatusType::STATUS_DAY:
             DrawDayInfo();
-
-            if ( conf.CurrentColor() & Players::HumanColors() ) {
-                DrawKingdomInfo( stonHeight + 5 );
-
-                if ( _state != StatusType::STATUS_RESOURCE )
-                    DrawArmyInfo( 2 * stonHeight + 10 );
-                else
-                    DrawResourceInfo( 2 * stonHeight + 10 );
-            }
-        }
-        else if ( StatusType::STATUS_UNKNOWN != _state && pos.height >= ( stonHeight * 2 + 15 ) ) {
-            DrawDayInfo();
-
-            switch ( _state ) {
-            case StatusType::STATUS_FUNDS:
-                DrawKingdomInfo( stonHeight + 5 );
-                break;
-            case StatusType::STATUS_DAY:
-            case StatusType::STATUS_ARMY:
-                DrawArmyInfo( stonHeight + 5 );
-                break;
-            case StatusType::STATUS_RESOURCE:
-                DrawResourceInfo( stonHeight + 5 );
-                break;
-            case StatusType::STATUS_UNKNOWN:
-            case StatusType::STATUS_AITURN:
-                assert( 0 ); // we shouldn't even reach this code
-                break;
-            default:
-                break;
-            }
-        }
-        else {
-            switch ( _state ) {
-            case StatusType::STATUS_DAY:
-                DrawDayInfo();
-                break;
-            case StatusType::STATUS_FUNDS:
-                DrawKingdomInfo();
-                break;
-            case StatusType::STATUS_ARMY:
-                DrawArmyInfo();
-                break;
-            case StatusType::STATUS_RESOURCE:
-                DrawResourceInfo();
-                break;
-            case StatusType::STATUS_UNKNOWN:
-            case StatusType::STATUS_AITURN:
-                assert( 0 ); // we shouldn't even reach this code
-                break;
-            default:
-                break;
-            }
+            break;
+        case StatusType::STATUS_FUNDS:
+            DrawKingdomInfo();
+            break;
+        case StatusType::STATUS_ARMY:
+            DrawArmyInfo();
+            break;
+        case StatusType::STATUS_RESOURCE:
+            DrawResourceInfo();
+            break;
+        case StatusType::STATUS_UNKNOWN:
+        case StatusType::STATUS_AITURN:
+            assert( 0 ); // we shouldn't even reach this code
+            break;
+        default:
+            break;
         }
     }
 }
@@ -339,61 +342,58 @@ void Interface::StatusWindow::DrawArmyInfo( int oh ) const
 
 void Interface::StatusWindow::DrawAITurns( void ) const
 {
+    // restore background
+    DrawBackground();
+
+    fheroes2::Display & display = fheroes2::Display::instance();
+
+    const fheroes2::Sprite & glass = fheroes2::AGG::GetICN( ICN::HOURGLAS, 0 );
+    const fheroes2::Rect & pos = GetArea();
+
+    s32 dst_x = pos.x + ( pos.width - glass.width() ) / 2;
+    s32 dst_y = pos.y + ( pos.height - glass.height() ) / 2;
+
+    fheroes2::Blit( glass, display, dst_x, dst_y );
+
+    int color_index = 0;
+
     const Settings & conf = Settings::Get();
-
-    if ( !conf.ExtGameHideInterface() || conf.ShowStatus() ) {
-        // restore background
-        DrawBackground();
-
-        fheroes2::Display & display = fheroes2::Display::instance();
-
-        const fheroes2::Sprite & glass = fheroes2::AGG::GetICN( ICN::HOURGLAS, 0 );
-        const fheroes2::Rect & pos = GetArea();
-
-        s32 dst_x = pos.x + ( pos.width - glass.width() ) / 2;
-        s32 dst_y = pos.y + ( pos.height - glass.height() ) / 2;
-
-        fheroes2::Blit( glass, display, dst_x, dst_y );
-
-        int color_index = 0;
-
-        switch ( conf.CurrentColor() ) {
-        case Color::BLUE:
-            color_index = 0;
-            break;
-        case Color::GREEN:
-            color_index = 1;
-            break;
-        case Color::RED:
-            color_index = 2;
-            break;
-        case Color::YELLOW:
-            color_index = 3;
-            break;
-        case Color::ORANGE:
-            color_index = 4;
-            break;
-        case Color::PURPLE:
-            color_index = 5;
-            break;
-        default:
-            return;
-        }
-
-        const fheroes2::Sprite & crest = fheroes2::AGG::GetICN( ICN::BRCREST, color_index );
-
-        dst_x += 2;
-        dst_y += 2;
-
-        fheroes2::Blit( crest, display, dst_x, dst_y );
-
-        const fheroes2::Sprite & sand = fheroes2::AGG::GetICN( ICN::HOURGLAS, 1 + ( turn_progress % 10 ) );
-
-        dst_x += ( glass.width() - sand.width() - sand.x() - 3 );
-        dst_y += sand.y();
-
-        fheroes2::Blit( sand, display, dst_x, dst_y );
+    switch ( conf.CurrentColor() ) {
+    case Color::BLUE:
+        color_index = 0;
+        break;
+    case Color::GREEN:
+        color_index = 1;
+        break;
+    case Color::RED:
+        color_index = 2;
+        break;
+    case Color::YELLOW:
+        color_index = 3;
+        break;
+    case Color::ORANGE:
+        color_index = 4;
+        break;
+    case Color::PURPLE:
+        color_index = 5;
+        break;
+    default:
+        return;
     }
+
+    const fheroes2::Sprite & crest = fheroes2::AGG::GetICN( ICN::BRCREST, color_index );
+
+    dst_x += 2;
+    dst_y += 2;
+
+    fheroes2::Blit( crest, display, dst_x, dst_y );
+
+    const fheroes2::Sprite & sand = fheroes2::AGG::GetICN( ICN::HOURGLAS, 1 + ( turn_progress % 10 ) );
+
+    dst_x += ( glass.width() - sand.width() - sand.x() - 3 );
+    dst_y += sand.y();
+
+    fheroes2::Blit( sand, display, dst_x, dst_y );
 }
 
 void Interface::StatusWindow::DrawBackground( void ) const
@@ -463,6 +463,6 @@ void Interface::StatusWindow::RedrawTurnProgress( u32 v )
     turn_progress = v;
     SetRedraw();
 
-    interface.Redraw();
-    fheroes2::Display::instance().render();
+    Redraw();
+    fheroes2::Display::instance().render( GetArea() );
 }

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -79,9 +79,9 @@ namespace Maps
     Indexes GetObjectPositions( const MP2::MapObjectType objectType, bool ignoreHeroes );
     Indexes GetObjectPositions( int32_t center, const MP2::MapObjectType objectType, bool ignoreHeroes );
 
-    void ClearFog( const int32_t tileIndex, const int scouteValue, const int playerColor );
+    void ClearFog( const int32_t tileIndex, int scouteValue, const int playerColor );
 
-    int32_t getFogTileCountToBeRevealed( const int32_t tileIndex, const int scouteValue, const int playerColor );
+    int32_t getFogTileCountToBeRevealed( const int32_t tileIndex, int scouteValue, const int playerColor );
 
     // This method should be avoided unless high precision is not important.
     uint32_t GetApproximateDistance( const int32_t pos1, const int32_t pos2 );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -865,16 +865,6 @@ void Maps::Tiles::SetTile( u32 sprite_index, u32 shape )
     pack_sprite_index = PackTileSpriteIndex( sprite_index, shape );
 }
 
-u32 Maps::Tiles::TileSpriteIndex( void ) const
-{
-    return pack_sprite_index & 0x3FFF;
-}
-
-u32 Maps::Tiles::TileSpriteShape( void ) const
-{
-    return pack_sprite_index >> 14;
-}
-
 const fheroes2::Image & Maps::Tiles::GetTileSurface( void ) const
 {
     return fheroes2::AGG::GetTIL( TIL::GROUND32, TileSpriteIndex(), TileSpriteShape() );
@@ -1186,11 +1176,6 @@ int Maps::Tiles::GetGround( void ) const
         return Maps::Ground::WASTELAND;
 
     return Maps::Ground::BEACH;
-}
-
-bool Maps::Tiles::isWater( void ) const
-{
-    return 30 > TileSpriteIndex();
 }
 
 void Maps::Tiles::RedrawTile( fheroes2::Image & dst, const fheroes2::Rect & visibleTileROI, const Interface::GameArea & area ) const

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -151,7 +151,6 @@ namespace Maps
             return pack_sprite_index & 0x3FFF;
         }
 
-
         uint32_t TileSpriteShape() const
         {
             return pack_sprite_index >> 14;

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -140,10 +140,22 @@ namespace Maps
 
         uint16_t GetPassable() const;
         int GetGround() const;
-        bool isWater() const;
 
-        u32 TileSpriteIndex( void ) const;
-        u32 TileSpriteShape( void ) const;
+        bool isWater() const
+        {
+            return 30 > TileSpriteIndex();
+        }
+
+        uint32_t TileSpriteIndex() const
+        {
+            return pack_sprite_index & 0x3FFF;
+        }
+
+
+        uint32_t TileSpriteShape() const
+        {
+            return pack_sprite_index >> 14;
+        }
 
         const fheroes2::Image & GetTileSurface( void ) const;
 


### PR DESCRIPTION
With recent changes for the past release AI became slower and it is noticeable on slower machines. Since we are going to add more logic to AI it is important to keep balance between performance and logic complexity. This pull request improves 2 places for AI turn:
- during `RedrawTurnProgress` method call render only status window instead of re-rendering the whole frame. It releases ~10% of overall AI turns
- `ClearFog` and `getFogTileCountToBeRevealed` where relying on an internal function which creates a vector, resize it due to item insertion and frees the memory. In particular `getFogTileCountToBeRevealed` can be called a lot of time during a single AI hero's movement calculation if there are many discovered cells.