### PR TITLE
Add Swedish in-game option and font support

### DIFF
--- a/files/lang/Makefile
+++ b/files/lang/Makefile
@@ -96,6 +96,12 @@ nb.mo: nb.po
 	iconv -f utf-8 -t CP1252 $< > $<.tmp
 	LANG=nb.CP1252 LC_ALL=nb.CP1252 LC_CTYPE=nb.CP1252 sed -e 's/UTF-8/CP1252/' $<.tmp > $<.2.tmp
 	msgfmt $<.2.tmp -o $@
+	
+# Swedish uses CP1252
+sv.mo: sv.po
+	iconv -f utf-8 -t CP1252 $< > $<.tmp
+	LANG=sv.CP1252 LC_ALL=sv.CP1252 LC_CTYPE=sv.CP1252 sed -e 's/UTF-8/CP1252/' $<.tmp > $<.2.tmp
+	msgfmt $<.2.tmp -o $@
 
 # Italian
 it.mo: it.po

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2108,6 +2108,7 @@ namespace fheroes2
         case SupportedLanguage::Norwegian:
         case SupportedLanguage::Portuguese:
         case SupportedLanguage::Spanish:
+        case SupportedLanguage::Swedish:
             generateCP1252Alphabet( icnVsSprite );
             break;
 
@@ -2137,6 +2138,7 @@ namespace fheroes2
         case SupportedLanguage::Bulgarian:
         case SupportedLanguage::Portuguese:
         case SupportedLanguage::Spanish:
+        case SupportedLanguage::Swedish:
         case SupportedLanguage::Ukrainian:
         case SupportedLanguage::Romanian:
             return true;

--- a/src/fheroes2/gui/ui_language.cpp
+++ b/src/fheroes2/gui/ui_language.cpp
@@ -54,7 +54,8 @@ namespace
             { "uk", fheroes2::SupportedLanguage::Ukrainian },  { "ukrainian", fheroes2::SupportedLanguage::Ukrainian },
             { "bg", fheroes2::SupportedLanguage::Bulgarian },  { "bulgarian", fheroes2::SupportedLanguage::Bulgarian },
             { "es", fheroes2::SupportedLanguage::Spanish },    { "spanish", fheroes2::SupportedLanguage::Spanish },
-            { "pt", fheroes2::SupportedLanguage::Portuguese }, { "portuguese", fheroes2::SupportedLanguage::Portuguese } };
+            { "pt", fheroes2::SupportedLanguage::Portuguese }, { "portuguese", fheroes2::SupportedLanguage::Portuguese },
+            { "sv", fheroes2::SupportedLanguage::Swedish },    { "swedish", fheroes2::SupportedLanguage::Swedish } };
 }
 
 namespace fheroes2
@@ -97,10 +98,11 @@ namespace fheroes2
             languages.emplace_back( resourceLanguage );
         }
 
-        const std::set<SupportedLanguage> possibleLanguages{ SupportedLanguage::French,     SupportedLanguage::Polish,    SupportedLanguage::German,
-                                                             SupportedLanguage::Russian,    SupportedLanguage::Italian,   SupportedLanguage::Norwegian,
-                                                             SupportedLanguage::Belarusian, SupportedLanguage::Bulgarian, SupportedLanguage::Ukrainian,
-                                                             SupportedLanguage::Romanian,   SupportedLanguage::Spanish,   SupportedLanguage::Portuguese };
+        const std::set<SupportedLanguage> possibleLanguages{
+            SupportedLanguage::French,    SupportedLanguage::Polish,     SupportedLanguage::German,    SupportedLanguage::Russian,   SupportedLanguage::Italian,
+            SupportedLanguage::Norwegian, SupportedLanguage::Belarusian, SupportedLanguage::Bulgarian, SupportedLanguage::Ukrainian, SupportedLanguage::Romanian,
+            SupportedLanguage::Spanish,   SupportedLanguage::Portuguese, SupportedLanguage::Swedish,
+        };
 
         for ( const SupportedLanguage language : possibleLanguages ) {
             if ( language != resourceLanguage && isAlphabetSupported( language ) ) {
@@ -156,6 +158,8 @@ namespace fheroes2
             return _( "Romanian" );
         case SupportedLanguage::Spanish:
             return _( "Spanish" );
+        case SupportedLanguage::Swedish:
+            return _( "Swedish" );
         case SupportedLanguage::Portuguese:
             return _( "Portuguese" );
         default:
@@ -194,6 +198,8 @@ namespace fheroes2
             return "ro";
         case SupportedLanguage::Spanish:
             return "es";
+        case SupportedLanguage::Swedish:
+            return "sv";
         case SupportedLanguage::Portuguese:
             return "pt";
         default:

--- a/src/fheroes2/gui/ui_language.h
+++ b/src/fheroes2/gui/ui_language.h
@@ -42,6 +42,7 @@ namespace fheroes2
         Portuguese,
         Romanian,
         Spanish,
+        Swedish,
         Ukrainian
     };
 


### PR DESCRIPTION
All necessary fonts were already present in CP1252.

Note that for some reason the person who made the current Swedish PO chose to replace all instances of special characters with similar latin characters. This would have to be fixed by someone competent in the language.