### PR TITLE
Improved error message if hero tries to open spell book and doesn't have one

### DIFF
--- a/files/lang/be.po
+++ b/files/lang/be.po
@@ -8192,6 +8192,9 @@ msgid ""
 "damage from a direct attack."
 msgstr ""
 
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr ""
+
 msgid "No spell to cast."
 msgstr ""
 

--- a/files/lang/be.po
+++ b/files/lang/be.po
@@ -7509,7 +7509,7 @@ msgstr ""
 msgid "Spell Scroll"
 msgstr ""
 
-msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
+msgid "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book."
 msgstr ""
 
 msgid ""
@@ -8191,6 +8191,7 @@ msgid ""
 "Turns the affected creature into stone.  A petrified creature receives half "
 "damage from a direct attack."
 msgstr ""
+
 
 msgid "You have no Magic Book, so you cannot cast a spell."
 msgstr ""

--- a/files/lang/bg.po
+++ b/files/lang/bg.po
@@ -8178,6 +8178,9 @@ msgid ""
 "damage from a direct attack."
 msgstr ""
 
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr ""
+
 msgid "No spell to cast."
 msgstr ""
 

--- a/files/lang/bg.po
+++ b/files/lang/bg.po
@@ -7495,7 +7495,7 @@ msgstr ""
 msgid "Spell Scroll"
 msgstr ""
 
-msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
+msgid "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book."
 msgstr ""
 
 msgid ""

--- a/files/lang/cs.po
+++ b/files/lang/cs.po
@@ -8400,6 +8400,9 @@ msgid ""
 "damage from a direct attack."
 msgstr ""
 
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr ""
+
 msgid "No spell to cast."
 msgstr ""
 

--- a/files/lang/cs.po
+++ b/files/lang/cs.po
@@ -7715,7 +7715,7 @@ msgstr ""
 msgid "Spell Scroll"
 msgstr ""
 
-msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
+msgid "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book."
 msgstr ""
 
 msgid ""

--- a/files/lang/cs.po
+++ b/files/lang/cs.po
@@ -8400,6 +8400,7 @@ msgid ""
 "damage from a direct attack."
 msgstr ""
 
+#, fuzzy
 msgid "You have no Magic Book, so you cannot cast a spell."
 msgstr ""
 

--- a/files/lang/de.po
+++ b/files/lang/de.po
@@ -8769,7 +8769,8 @@ msgstr "Dummy 4"
 msgid "Spell Scroll"
 msgstr "Zauberspruchrolle"
 
-msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
+#, fuzzy
+msgid "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book."
 msgstr ""
 "Diese %{name} verleiht Ihrem Helden die Fähigkeit, den %{spell} Zauber zu "
 "wirken."

--- a/files/lang/de.po
+++ b/files/lang/de.po
@@ -9621,6 +9621,10 @@ msgstr ""
 "Verwandelt die betroffene Kreatur in Stein.  Eine versteinerte Kreatur "
 "erleidet bei einem direkten Angriff die Hälfte des Schadens."
 
+#, fuzzy
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr ""
+
 msgid "No spell to cast."
 msgstr "Kein Zauber zu wirken."
 

--- a/files/lang/es.po
+++ b/files/lang/es.po
@@ -9272,9 +9272,8 @@ msgid ""
 "damage from a direct attack."
 msgstr ""
 
-#, fuzzy
 msgid "You have no Magic Book, so you cannot cast a spell."
-msgstr ""
+msgstr "No tienes un Libro de Hechizos, por lo que no puedes lanzar un hechizo."
 
 msgid "No spell to cast."
 msgstr "No hay hechizo que lanzar."

--- a/files/lang/es.po
+++ b/files/lang/es.po
@@ -8459,8 +8459,9 @@ msgstr "Momia"
 msgid "Spell Scroll"
 msgstr "Pegamino del Hechizo"
 
-msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
-msgstr ""
+#, fuzzy
+msgid "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book."
+msgstr "Este %{name} le da a tu héroe la habilidad de lanzar el hechizo %{spell} si tu héroe tiene un Libro de Hechizos"
 
 msgid ""
 "You find an elaborate container which houses an old vellum scroll. The runes "

--- a/files/lang/es.po
+++ b/files/lang/es.po
@@ -9272,6 +9272,10 @@ msgid ""
 "damage from a direct attack."
 msgstr ""
 
+#, fuzzy
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr ""
+
 msgid "No spell to cast."
 msgstr "No hay hechizo que lanzar."
 

--- a/files/lang/fr.po
+++ b/files/lang/fr.po
@@ -9458,9 +9458,8 @@ msgstr ""
 "Transforme en pierre la créature affectée.  Une créature pétrifiée reçoit la "
 "moitié des dégâts d'une attaque directe."
 
-#, fuzzy
 msgid "You have no Magic Book, so you cannot cast a spell."
-msgstr ""
+msgstr "Vous n'avez pas de grimoire, vous ne pouvez donc pas lancer un sort."
 
 msgid "No spell to cast."
 msgstr "Aucun sort à lancer."

--- a/files/lang/fr.po
+++ b/files/lang/fr.po
@@ -9458,6 +9458,10 @@ msgstr ""
 "Transforme en pierre la créature affectée.  Une créature pétrifiée reçoit la "
 "moitié des dégâts d'une attaque directe."
 
+#, fuzzy
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr ""
+
 msgid "No spell to cast."
 msgstr "Aucun sort à lancer."
 

--- a/files/lang/fr.po
+++ b/files/lang/fr.po
@@ -8613,8 +8613,8 @@ msgstr "Emplacement 4"
 msgid "Spell Scroll"
 msgstr "Parchemin magique"
 
-msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
-msgstr "Ce %{name} donne à votre héros la capacité de lancer le sort %{spell}."
+msgid "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book."
+msgstr "Ce %{name} donne à votre héros la capacité de lancer le sort %{spell} si celui-ci possède un grimoire."
 
 msgid ""
 "You find an elaborate container which houses an old vellum scroll. The runes "

--- a/files/lang/hu.po
+++ b/files/lang/hu.po
@@ -8382,7 +8382,7 @@ msgstr "Scummy"
 msgid "Spell Scroll"
 msgstr "Varázstekercs"
 
-msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
+msgid "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book."
 msgstr ""
 
 msgid ""

--- a/files/lang/hu.po
+++ b/files/lang/hu.po
@@ -9081,6 +9081,10 @@ msgid ""
 "damage from a direct attack."
 msgstr ""
 
+#, fuzzy
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr ""
+
 msgid "No spell to cast."
 msgstr ""
 

--- a/files/lang/it.po
+++ b/files/lang/it.po
@@ -8536,6 +8536,7 @@ msgstr ""
 "Trasforma la creatura colpita in pietra. Una creatura impietrita subisce "
 "metà dei danni da un attacco diretto."
 
+#, fuzzy
 msgid "You have no Magic Book, so you cannot cast a spell."
 msgstr ""
 

--- a/files/lang/it.po
+++ b/files/lang/it.po
@@ -8536,6 +8536,9 @@ msgstr ""
 "Trasforma la creatura colpita in pietra. Una creatura impietrita subisce "
 "metà dei danni da un attacco diretto."
 
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr ""
+
 msgid "No spell to cast."
 msgstr "Nessuna magia disponibile."
 

--- a/files/lang/it.po
+++ b/files/lang/it.po
@@ -7792,7 +7792,7 @@ msgstr "Mummia"
 msgid "Spell Scroll"
 msgstr ""
 
-msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
+msgid "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book."
 msgstr ""
 
 msgid ""

--- a/files/lang/lt.po
+++ b/files/lang/lt.po
@@ -7737,7 +7737,7 @@ msgstr ""
 msgid "Spell Scroll"
 msgstr ""
 
-msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
+msgid "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book."
 msgstr ""
 
 msgid ""

--- a/files/lang/lt.po
+++ b/files/lang/lt.po
@@ -8422,6 +8422,7 @@ msgid ""
 "damage from a direct attack."
 msgstr ""
 
+#, fuzzy
 msgid "You have no Magic Book, so you cannot cast a spell."
 msgstr ""
 

--- a/files/lang/lt.po
+++ b/files/lang/lt.po
@@ -8422,6 +8422,9 @@ msgid ""
 "damage from a direct attack."
 msgstr ""
 
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr ""
+
 msgid "No spell to cast."
 msgstr ""
 

--- a/files/lang/nb.po
+++ b/files/lang/nb.po
@@ -8756,7 +8756,8 @@ msgstr "Plassholder 4"
 msgid "Spell Scroll"
 msgstr "Trolldomsrull"
 
-msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
+#, fuzzy
+msgid "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book."
 msgstr "Denne %{name}en gir helten din evnen til å bruke trolldommen %{spell}."
 
 msgid ""

--- a/files/lang/nb.po
+++ b/files/lang/nb.po
@@ -9613,6 +9613,10 @@ msgstr ""
 "Forvandler den påvirkede skapningen til stein. En forsteinet skapning tar "
 "halv skade fra direkte angrep."
 
+#, fuzzy
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr ""
+
 # Used on adventure map. Plural is right for norwegian.
 msgid "No spell to cast."
 msgstr "Ingen trolldommer tilgjengelige."

--- a/files/lang/nl.po
+++ b/files/lang/nl.po
@@ -8181,6 +8181,7 @@ msgid ""
 "damage from a direct attack."
 msgstr ""
 
+#, fuzzy
 msgid "You have no Magic Book, so you cannot cast a spell."
 msgstr ""
 

--- a/files/lang/nl.po
+++ b/files/lang/nl.po
@@ -8181,6 +8181,9 @@ msgid ""
 "damage from a direct attack."
 msgstr ""
 
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr ""
+
 msgid "No spell to cast."
 msgstr ""
 

--- a/files/lang/nl.po
+++ b/files/lang/nl.po
@@ -7498,7 +7498,7 @@ msgstr ""
 msgid "Spell Scroll"
 msgstr ""
 
-msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
+msgid "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book."
 msgstr ""
 
 msgid ""

--- a/files/lang/pl.po
+++ b/files/lang/pl.po
@@ -9063,6 +9063,10 @@ msgstr ""
 "Zmienia dotknięte stworzenie w kamień. Skamieniała jednostka otrzymuje "
 "połowę obrażeń z ataku wręcz."
 
+#, fuzzy
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr ""
+
 msgid "No spell to cast."
 msgstr "Brak zaklęć."
 

--- a/files/lang/pl.po
+++ b/files/lang/pl.po
@@ -8240,7 +8240,8 @@ msgstr "Mumia"
 msgid "Spell Scroll"
 msgstr "Zwój z zaklęciem"
 
-msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
+#, fuzzy
+msgid "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book."
 msgstr "%{name} daje twojemu bohaterowi mozliwość rzucania czaru %{spell}"
 
 msgid ""

--- a/files/lang/pt.po
+++ b/files/lang/pt.po
@@ -8036,7 +8036,7 @@ msgstr ""
 msgid "Spell Scroll"
 msgstr ""
 
-msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
+msgid "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book."
 msgstr ""
 
 msgid ""

--- a/files/lang/pt.po
+++ b/files/lang/pt.po
@@ -8721,6 +8721,10 @@ msgid ""
 "damage from a direct attack."
 msgstr ""
 
+#, fuzzy
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr ""
+
 msgid "No spell to cast."
 msgstr ""
 

--- a/files/lang/ru.po
+++ b/files/lang/ru.po
@@ -9175,6 +9175,10 @@ msgstr ""
 "Превращает поражённое существо в камень. Окаменевшее существо получает "
 "половину урона от прямой атаки."
 
+#, fuzzy
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr ""
+
 msgid "No spell to cast."
 msgstr "Нет заклинаний для применения."
 

--- a/files/lang/ru.po
+++ b/files/lang/ru.po
@@ -8360,7 +8360,8 @@ msgstr "Мумия"
 msgid "Spell Scroll"
 msgstr "Свиток Заклинания"
 
-msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
+#, fuzzy
+msgid "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book."
 msgstr "%{name} позволяет Вашему герою произносить заклинание %{spell}."
 
 msgid ""

--- a/files/lang/sv.po
+++ b/files/lang/sv.po
@@ -8280,7 +8280,7 @@ msgstr "Mumie"
 msgid "Spell Scroll"
 msgstr "Besvärjelserulle"
 
-msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
+msgid "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book."
 msgstr ""
 
 msgid ""

--- a/files/lang/sv.po
+++ b/files/lang/sv.po
@@ -9006,6 +9006,10 @@ msgid ""
 "damage from a direct attack."
 msgstr ""
 
+#, fuzzy
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr ""
+
 msgid "No spell to cast."
 msgstr "Inga besvärjelser kan kastas."
 

--- a/files/lang/tr.po
+++ b/files/lang/tr.po
@@ -8179,6 +8179,7 @@ msgid ""
 "damage from a direct attack."
 msgstr ""
 
+#, fuzzy
 msgid "You have no Magic Book, so you cannot cast a spell."
 msgstr ""
 

--- a/files/lang/tr.po
+++ b/files/lang/tr.po
@@ -7496,7 +7496,7 @@ msgstr ""
 msgid "Spell Scroll"
 msgstr ""
 
-msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
+msgid "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book."
 msgstr ""
 
 msgid ""

--- a/files/lang/tr.po
+++ b/files/lang/tr.po
@@ -8179,6 +8179,9 @@ msgid ""
 "damage from a direct attack."
 msgstr ""
 
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr ""
+
 msgid "No spell to cast."
 msgstr ""
 

--- a/files/lang/uk.po
+++ b/files/lang/uk.po
@@ -8380,6 +8380,9 @@ msgid ""
 "damage from a direct attack."
 msgstr ""
 
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr ""
+
 msgid "No spell to cast."
 msgstr ""
 

--- a/files/lang/uk.po
+++ b/files/lang/uk.po
@@ -8380,6 +8380,7 @@ msgid ""
 "damage from a direct attack."
 msgstr ""
 
+#, fuzzy
 msgid "You have no Magic Book, so you cannot cast a spell."
 msgstr ""
 

--- a/files/lang/uk.po
+++ b/files/lang/uk.po
@@ -7688,7 +7688,7 @@ msgstr ""
 msgid "Spell Scroll"
 msgstr ""
 
-msgid "This %{name} gives your hero the ability to cast the %{spell} spell."
+msgid "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book."
 msgstr ""
 
 msgid ""

--- a/src/fheroes2/resource/artifact_info.cpp
+++ b/src/fheroes2/resource/artifact_info.cpp
@@ -478,7 +478,7 @@ namespace
             { gettext_noop( "Dummy 4" ), gettext_noop( "The reserved artifact." ), nullptr, {}, {} },
 
             { gettext_noop( "Spell Scroll" ),
-              gettext_noop( "This %{name} gives your hero the ability to cast the %{spell} spell." ),
+              gettext_noop( "This %{name} gives your hero the ability to cast the %{spell} spell if your hero has a Magic Book." ),
               gettext_noop(
                   "You find an elaborate container which houses an old vellum scroll. The runes on the container are very old, and the artistry with which it was put together is stunning. As you pull the scroll out, you feel imbued with magical power." ),
               {},

--- a/src/fheroes2/spell/spell_book.cpp
+++ b/src/fheroes2/spell/spell_book.cpp
@@ -167,7 +167,7 @@ Spell SpellBook::Open( const HeroBase & hero, const Filter displayableSpells, co
                        const std::function<void( const std::string & )> * statusCallback /*= nullptr*/ ) const
 {
     if ( !hero.HaveSpellBook() ) {
-        Dialog::Message( "", _( "No spell to cast." ), Font::BIG, Dialog::OK );
+        Dialog::Message( "", _( "Spell book is not present." ), Font::BIG, Dialog::OK );
         return Spell::NONE;
     }
 

--- a/src/fheroes2/spell/spell_book.cpp
+++ b/src/fheroes2/spell/spell_book.cpp
@@ -167,7 +167,7 @@ Spell SpellBook::Open( const HeroBase & hero, const Filter displayableSpells, co
                        const std::function<void( const std::string & )> * statusCallback /*= nullptr*/ ) const
 {
     if ( !hero.HaveSpellBook() ) {
-        Dialog::Message( "", _( "Spell book is not present." ), Font::BIG, Dialog::OK );
+        Dialog::Message( "", _( "You have no Magic Book, so you cannot cast a spell." ), Font::BIG, Dialog::OK );
         return Spell::NONE;
     }
 


### PR DESCRIPTION
References #5437 

Currently, if the player tries to open his spell book and doesn't have one he will receive the message "No spell to cast.". This is true in most case, but misleading if the heroes has spell artifacts. So I changed the message from "No spell to cast." to "Spell book is not present."
![image](https://user-images.githubusercontent.com/60141446/169702565-29b3053f-e94d-48b2-8f40-1e0bf72d094e.png)

Also, this text is already part of the game so it doesn't require any further work to translate it : 
![image](https://user-images.githubusercontent.com/60141446/169702582-a8fd03e0-6df1-45c8-bce8-ed605f8ab69e.png)
