### PR TITLE
BagArtifacts::String(): do not print names of invalid artifacts

### DIFF
--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -771,8 +771,12 @@ std::string BagArtifacts::String( void ) const
 {
     std::string output;
 
-    for ( const_iterator it = begin(); it != end(); ++it ) {
-        output += it->GetName();
+    for ( const Artifact & art : *this ) {
+        if ( !art.isValid() ) {
+            continue;
+        }
+
+        output += art.GetName();
         output += ", ";
     }
 


### PR DESCRIPTION
Currently in debug mode, the properties of an AI-controlled hero look like this:

```
----------------I--------
name            : Charity
race            : Necromancer
color           : Yellow
experience      : 53
level           : 1
magic point     : 20
position x      : 11
position y      : 14
move point      : 1200
max magic point : 20
max move point  : 1200
direction       : right
index sprite    : 18
in castle       : true
save object     : Castle
flags           : 
skills          : Basic Necromancy, Basic Wisdom, 
artifacts       : Magic Book, Invalid Artifact, Invalid Artifact, Invalid Artifact, Invalid Artifact, Invalid Artifact, Invalid Artifact, Invalid Artifact, Invalid Artifact, Invalid Artifact, Invalid Artifact, Invalid Artifact, Invalid Artifact, Invalid Artifact, 
spell book      : Haste, 
army dump       : color(Yellow), commander(Charity), : 9 Skeletons, 
capture color   : Yellow
----------------:<<<<<<<<
```

Technically this is correct, but looks weird. This PR fixes that:

```
----------------I--------
name            : Gem
race            : Sorceress
color           : Red
experience      : 48
level           : 1
magic point     : 30
position x      : 10
position y      : 82
move point      : 1000
max magic point : 30
max move point  : 1000
direction       : right
index sprite    : 18
in castle       : true
save object     : Castle
flags           : 
skills          : Advanced Navigation, Basic Wisdom, 
artifacts       : Magic Book, 
spell book      : Bless, 
army dump       : color(Red), commander(Gem), : 14 Sprites, 4 Dwarves, 
capture color   : Red
----------------:<<<<<<<<
```