### PR TITLE
Unify code for monsters to avoid hardcoded monster types

### DIFF
--- a/src/fheroes2/agg/m82.cpp
+++ b/src/fheroes2/agg/m82.cpp
@@ -191,7 +191,7 @@ int M82::FromSpell( int spell )
         return ERTHQUAK;
     case Spell::HAUNT:
         return H2MINE;
-    case Spell::STONE:
+    case Spell::PETRIFY:
         return PARALIZE;
     default:
         break;

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -190,7 +190,7 @@ void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, int32_t dst
 
                 if ( interface ) {
                     interface->RedrawActionSpellCastPart2( spell, targets );
-                    interface->RedrawActionMonsterSpellCastStatus( attacker, targets.front() );
+                    interface->RedrawActionMonsterSpellCastStatus( spell, attacker, targets.front() );
                 }
             }
         }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3612,7 +3612,7 @@ void Battle::Interface::RedrawActionSpellCastPart1( const Spell & spell, s32 dst
             case Spell::BLOODLUST:
                 RedrawActionBloodLustSpell( *target );
                 break;
-            case Spell::STONE:
+            case Spell::PETRIFY:
                 RedrawActionStoneSpell( *target );
                 break;
             default:
@@ -3737,38 +3737,39 @@ void Battle::Interface::RedrawActionSpellCastPart2( const Spell & spell, const T
     _movingUnit = nullptr;
 }
 
-void Battle::Interface::RedrawActionMonsterSpellCastStatus( const Unit & attacker, const TargetInfo & target )
+void Battle::Interface::RedrawActionMonsterSpellCastStatus( const Spell & spell, const Unit & attacker, const TargetInfo & target )
 {
-    const char * msg = nullptr;
+    std::string msg;
 
-    switch ( attacker.GetID() ) {
-    case Monster::UNICORN:
-        msg = _( "The Unicorns' attack blinds the %{name}!" );
+    switch ( spell.GetID() ) {
+    case Spell::BLIND:
+        msg = _( "The %{attacker}' attack blinds the %{target}!" );
         break;
-    case Monster::MEDUSA:
-        msg = _( "The Medusas' gaze turns the %{name} to stone!" );
+    case Spell::PETRIFY:
+        msg = _( "The %{attacker}' gaze turns the %{target} to stone!" );
         break;
-    case Monster::ROYAL_MUMMY:
-    case Monster::MUMMY:
-        msg = _( "The Mummies' curse falls upon the %{name}!" );
+    case Spell::CURSE:
+        msg = _( "The %{attacker}' curse falls upon the %{target}!" );
         break;
-    case Monster::CYCLOPS:
-        msg = _( "The %{name} are paralyzed by the Cyclopes!" );
+    case Spell::PARALYZE:
+        msg = _( "The %{target} are paralyzed by the %{attacker}!" );
         break;
-    case Monster::ARCHMAGE:
-        msg = _( "The Archmagi dispel all good spells on your %{name}!" );
+    case Spell::DISPEL:
+        msg = _( "The %{attacker} dispel all good spells on your %{target}!" );
         break;
     default:
+        // Did you add a new monster spell casting ability? Add the logic above!
+        assert( 0 );
+        msg = _( "The %{attacker} cast %{spell} on %{target}!" );
+        StringReplace( msg, "%{spell}", spell.GetName() );
         break;
     }
 
-    if ( msg ) {
-        std::string str( msg );
-        StringReplace( str, "%{name}", target.defender->GetName() );
+    StringReplace( msg, "%{attacker}", attacker.GetMultiName() );
+    StringReplace( msg, "%{target}", target.defender->GetName() );
 
-        status.SetMessage( str, true );
-        status.SetMessage( "", false );
-    }
+    status.SetMessage( msg, true );
+    status.SetMessage( "", false );
 }
 
 void Battle::Interface::RedrawActionLuck( const Unit & unit )

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -267,7 +267,7 @@ namespace Battle
         void RedrawActionSpellCastPart1( const Spell & spell, s32 dst, const HeroBase * caster, const TargetsInfo & targets );
         void RedrawActionSpellCastPart2( const Spell & spell, const TargetsInfo & targets );
         void RedrawActionResistSpell( const Unit & target, bool playSound );
-        void RedrawActionMonsterSpellCastStatus( const Unit &, const TargetInfo & );
+        void RedrawActionMonsterSpellCastStatus( const Spell & spell, const Unit & attacker, const TargetInfo & target );
         void RedrawActionMove( Unit &, const Indexes & );
         void RedrawActionFly( Unit &, const Position & );
         void RedrawActionMorale( Unit &, bool );

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1113,7 +1113,7 @@ s32 Battle::Unit::GetScoreQuality( const Unit & defender ) const
             break;
         case Spell::CURSE:
             attackerThreat += defendersDamage * foundAbility->percentage / 100.0 / 10.0
-                              * ( 100 - defender.GetMagicResist( foundAbility->value, DEFAULT_SPELL_DURATION, nullptr ) ) / 100.0
+                              * ( 100 - defender.GetMagicResist( foundAbility->value, DEFAULT_SPELL_DURATION, nullptr ) ) / 100.0;
             break;
         default:
             // Did you add a new spell casting ability? Add the logic above!

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1112,8 +1112,8 @@ s32 Battle::Unit::GetScoreQuality( const Unit & defender ) const
             // TODO: add the logic to evaluate this spell value.
             break;
         case Spell::CURSE:
-            attackerThreat += defendersDamage * foundAbility->percentage / 100.0 / 10.0 *
-                              ( 100 - defender.GetMagicResist( foundAbility->value, DEFAULT_SPELL_DURATION, nullptr ) ) / 100.0;
+            attackerThreat += defendersDamage * foundAbility->percentage / 100.0 / 10.0
+                              * ( 100 - defender.GetMagicResist( foundAbility->value, DEFAULT_SPELL_DURATION, nullptr ) ) / 100.0
             break;
         default:
             // Did you add a new spell casting ability? Add the logic above!

--- a/src/fheroes2/castle/mageguild.cpp
+++ b/src/fheroes2/castle/mageguild.cpp
@@ -116,7 +116,7 @@ Spell GetUniqueSpellCompatibility( const SpellStorage & spells, const int race, 
     std::vector<Spell> v;
     v.reserve( 15 );
 
-    for ( int sp = Spell::NONE; sp < Spell::STONE; ++sp ) {
+    for ( int sp = Spell::NONE; sp < Spell::PETRIFY; ++sp ) {
         const Spell spell( sp );
 
         if ( spells.isPresentSpell( spell ) )

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -101,7 +101,7 @@ namespace
         case Battle::SP_PARALYZE:
             return Spell::PARALYZE;
         case Battle::SP_STONE:
-            return Spell::STONE;
+            return Spell::PETRIFY;
         default:
             // Did you add another mode? Please add a corresponding spell.
             assert( 0 );

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -335,7 +335,7 @@ Spell Dialog::SelectSpell( int cur )
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    std::vector<int> spells( static_cast<int>( Spell::STONE - 1 ), Spell::NONE );
+    std::vector<int> spells( static_cast<int>( Spell::RANDOM - 1 ), Spell::NONE );
 
     for ( size_t i = 0; i < spells.size(); ++i )
         spells[i] = static_cast<int>( i + 1 ); // safe to do this as the number of spells can't be more than 2 billion

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -218,7 +218,7 @@ Heroes::Heroes( int heroid, int rc )
         magic_point = 120;
 
         // all spell in magic book
-        for ( u32 spell = Spell::FIREBALL; spell < Spell::PETRIFY; ++spell )
+        for ( int32_t spell = Spell::FIREBALL; spell < Spell::RANDOM; ++spell )
             AppendSpellToBook( Spell( spell ), true );
         break;
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -218,7 +218,7 @@ Heroes::Heroes( int heroid, int rc )
         magic_point = 120;
 
         // all spell in magic book
-        for ( u32 spell = Spell::FIREBALL; spell < Spell::STONE; ++spell )
+        for ( u32 spell = Spell::FIREBALL; spell < Spell::PETRIFY; ++spell )
             AppendSpellToBook( Spell( spell ), true );
         break;
 

--- a/src/fheroes2/spell/spell.cpp
+++ b/src/fheroes2/spell/spell.cpp
@@ -422,7 +422,7 @@ Spell Spell::Rand( int lvl, bool adv )
     std::vector<Spell> v;
     v.reserve( 15 );
 
-    for ( u32 sp = NONE; sp < STONE; ++sp ) {
+    for ( int32_t sp = NONE; sp < PETRIFY; ++sp ) {
         const Spell spell( sp );
         if ( ( ( adv && !spell.isCombat() ) || ( !adv && spell.isCombat() ) ) && lvl == spell.Level() )
             v.push_back( spell );

--- a/src/fheroes2/spell/spell.h
+++ b/src/fheroes2/spell/spell.h
@@ -102,6 +102,7 @@ public:
         SETFGUARDIAN,
         SETWGUARDIAN,
 
+        // The spells below should not be present in the real game.
         RANDOM,
         RANDOM1,
         RANDOM2,
@@ -109,14 +110,14 @@ public:
         RANDOM4,
         RANDOM5,
 
-        STONE,
+        PETRIFY,
 
         // IMPORTANT! Put all new spells above this line.
         SPELL_COUNT
     };
 
-    Spell( const int s = NONE )
-        : id( s > STONE ? NONE : s )
+    Spell( const int spellId = NONE )
+        : id( spellId >= SPELL_COUNT ? NONE : spellId )
     {
         // Do nothing.
     }

--- a/src/fheroes2/spell/spell.h
+++ b/src/fheroes2/spell/spell.h
@@ -102,7 +102,7 @@ public:
         SETFGUARDIAN,
         SETWGUARDIAN,
 
-        // The spells below should not be present in the real game.
+        // These constants are placeholders for a random spell of the corresponding level and should not be added to the spell book.
         RANDOM,
         RANDOM1,
         RANDOM2,
@@ -110,14 +110,15 @@ public:
         RANDOM4,
         RANDOM5,
 
+        // This spell is exclusively a built-in monster spell and should not be added to the spell book.
         PETRIFY,
 
         // IMPORTANT! Put all new spells above this line.
         SPELL_COUNT
     };
 
-    Spell( const int spellId = NONE )
-        : id( spellId >= SPELL_COUNT ? NONE : spellId )
+    Spell( const int32_t spellId = NONE )
+        : id( ( spellId < 0 || spellId >= SPELL_COUNT ) ? NONE : spellId )
     {
         // Do nothing.
     }


### PR DESCRIPTION
- return messages during battle should be based on monster's abilities
- monster quality and strength calculation depends purely on abilities
- do not show random spells in battle only mode
- rename Stone spell into Petrify spell to be consistent with its description