### PR TITLE
Fix a few recent code smells

### DIFF
--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -82,7 +82,6 @@ namespace AI
         virtual void HeroesPreBattle( HeroBase & hero, bool isAttacking );
         virtual void HeroesAfterBattle( HeroBase & hero, bool wasAttacking );
         virtual void HeroesPostLoad( Heroes & hero );
-        virtual bool HeroesCanMove( const Heroes & hero );
         virtual bool HeroesGetTask( Heroes & hero );
         virtual void HeroesActionComplete( Heroes & hero, const MP2::MapObjectType objectType );
         virtual void HeroesActionNewPosition( Heroes & hero );

--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -82,7 +82,6 @@ namespace AI
         virtual void HeroesPreBattle( HeroBase & hero, bool isAttacking );
         virtual void HeroesAfterBattle( HeroBase & hero, bool wasAttacking );
         virtual void HeroesPostLoad( Heroes & hero );
-        virtual bool HeroesGetTask( Heroes & hero );
         virtual void HeroesActionComplete( Heroes & hero, const MP2::MapObjectType objectType );
         virtual void HeroesActionNewPosition( Heroes & hero );
         virtual void HeroesClearTask( const Heroes & hero );

--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -71,9 +71,7 @@ namespace AI
     {
     public:
         virtual void KingdomTurn( Kingdom & kingdom ) = 0;
-        virtual void CastleTurn( Castle & castle, bool defensive ) = 0;
         virtual void BattleTurn( Battle::Arena & arena, const Battle::Unit & unit, Battle::Actions & actions ) = 0;
-        virtual bool HeroesTurn( VecHeroes & heroes ) = 0;
 
         virtual void revealFog( const Maps::Tiles & tile ) = 0;
 

--- a/src/fheroes2/ai/ai_base.cpp
+++ b/src/fheroes2/ai/ai_base.cpp
@@ -128,11 +128,6 @@ namespace AI
         return false;
     }
 
-    bool Base::HeroesCanMove( const Heroes & hero )
-    {
-        return hero.MayStillMove( false, false ) && !hero.Modes( Heroes::MOVED );
-    }
-
     StreamBase & operator<<( StreamBase & msg, const AI::Base & instance )
     {
         return msg << instance._personality;

--- a/src/fheroes2/ai/ai_base.cpp
+++ b/src/fheroes2/ai/ai_base.cpp
@@ -121,13 +121,6 @@ namespace AI
         // Do nothing.
     }
 
-    bool Base::HeroesGetTask( Heroes & hero )
-    {
-        // stop hero
-        hero.GetPath().Reset();
-        return false;
-    }
-
     StreamBase & operator<<( StreamBase & msg, const AI::Base & instance )
     {
         return msg << instance._personality;

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -183,9 +183,7 @@ namespace AI
         Normal();
 
         void KingdomTurn( Kingdom & kingdom ) override;
-        void CastleTurn( Castle & castle, bool defensive ) override;
         void BattleTurn( Battle::Arena & arena, const Battle::Unit & currentUnit, Battle::Actions & actions ) override;
-        bool HeroesTurn( VecHeroes & heroes ) override;
 
         void revealFog( const Maps::Tiles & tile ) override;
 
@@ -216,6 +214,9 @@ namespace AI
         // Monster strength is constant over the same turn for AI but its calculation is a heavy operation.
         // In order to avoid extra computations during AI turn it is important to keep cache of monster strength but update it when an action on a monster is taken.
         std::map<int32_t, double> _neutralMonsterStrengthCache;
+
+        void CastleTurn( Castle & castle, bool defensive );
+        bool HeroesTurn( VecHeroes & heroes );
 
         double getHunterObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         double getFighterObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -529,16 +529,11 @@ namespace
         if ( hero->Modes( Heroes::PATROL ) ) {
             if ( hero->GetSquarePatrol() == 0 ) {
                 DEBUG_LOG( DBG_AI, DBG_TRACE, hero->GetName() << " standing still. Skip turn." )
-                hero->SetModes( Heroes::MOVED );
                 return;
             }
         }
 
-        hero->ResetModes( Heroes::MOVED );
-        if ( !hero->MayStillMove( false, false ) ) {
-            hero->SetModes( Heroes::MOVED );
-        }
-        else {
+        if ( hero->MayStillMove( false, false ) ) {
             availableHeroes.emplace_back();
             AI::HeroToMove & heroInfo = availableHeroes.back();
             heroInfo.hero = hero;
@@ -1471,7 +1466,6 @@ namespace AI
 
             for ( size_t i = 0; i < availableHeroes.size(); ) {
                 if ( !availableHeroes[i].hero->MayStillMove( false, false ) ) {
-                    availableHeroes[i].hero->SetModes( Heroes::MOVED );
                     availableHeroes.erase( availableHeroes.begin() + i );
                     continue;
                 }
@@ -1484,12 +1478,6 @@ namespace AI
         }
 
         const bool allHeroesMoved = availableHeroes.empty();
-
-        for ( HeroToMove & heroInfo : availableHeroes ) {
-            if ( !heroInfo.hero->MayStillMove( false, false ) ) {
-                heroInfo.hero->SetModes( Heroes::MOVED );
-            }
-        }
 
         _pathfinder.setArmyStrengthMultiplier( originalMonsterStrengthMultiplier );
         _pathfinder.setSpellPointReserve( 0.5 );

--- a/src/fheroes2/game/highscores.h
+++ b/src/fheroes2/game/highscores.h
@@ -46,7 +46,7 @@ namespace fheroes2
             // Do nothing.
         }
 
-        HighscoreData( HighscoreData & ) = default;
+        HighscoreData( const HighscoreData & ) = default;
         HighscoreData( HighscoreData && ) = default;
 
         ~HighscoreData() = default;

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -174,12 +174,7 @@ public:
 
         // UNUSED = 0x00010000,
 
-        CUSTOMSKILLS = 0x00020000,
-
-        // UNUSED = 0x00040000,
-        // UNUSED = 0x00080000,
-
-        MOVED = 0x00100000
+        CUSTOMSKILLS = 0x00020000
     };
 
     // Types of heroes. Used only for AI as humans are smart enough to manage heroes by themselves.


### PR DESCRIPTION
* Copy constructor of the `HighscoreData`: add `const`;
* Remove `AI::Base::HeroesCanMove()` and `Heroes::MOVED` flag, because it was checked only in the `AI::Base::HeroesCanMove()`, which never has been called;
* Remove `AI::Base::HeroesGetTask()`;
* Make `AI::Normal::CastleTurn()` and `AI::Normal::HeroesTurn()` private and remove corresponding virtual functions from the `AI::Base`, because they never has been called from the outside and therefore they may be considered as an implementation detail.