### PR TITLE
disable merging on every rebuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,18 +77,7 @@ add_subdirectory(src)
 #
 if(NOT WIN32)
 	find_program(MAKE_EXECUTABLE make)
-	find_program(SED_EXECUTABLE sed)
-	find_program(XGETTEXT_EXECUTABLE xgettext)
 
-	file(GLOB_RECURSE ALL_SOURCES CONFIGURE_DEPENDS src/*.cpp)
-
-	add_custom_target(
-		${PROJECT_NAME}.pot
-		COMMAND ${XGETTEXT_EXECUTABLE} -d ${PROJECT_NAME} -C -F -k_ -k_n:1,2 -o ${PROJECT_NAME}.pot ${ALL_SOURCES}
-		COMMAND ${SED_EXECUTABLE} -i~ -e "s/, c-format//" ${PROJECT_NAME}.pot
-		DEPENDS fheroes2
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/dist
-		)
 	add_custom_target(
 		translations
 		ALL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,6 @@ if(NOT WIN32)
 		translations
 		ALL
 		COMMAND ${MAKE_EXECUTABLE}
-		DEPENDS ${PROJECT_NAME}.pot
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/files/lang
 		)
 endif(NOT WIN32)

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -21,7 +21,7 @@ make pot
 Once the POT file has been created, go to `/files/lang` and run the following command to update translatable strings in the PO files:
 
 ```bash
-make *.po clean
+make merge
 ```
 
 ## Editing translations

--- a/files/lang/Makefile
+++ b/files/lang/Makefile
@@ -23,10 +23,7 @@
 all: $(patsubst %.po, %.mo, $(wildcard *.po))
 
 merge:
-	$(MAKE) $(wildcard *.po)
-
-%.po: ../../src/dist/fheroes2.pot
-	msgmerge -U --no-location $@ $<
+	for i in $(wildcard *.po); do msgmerge -U --no-location $$i ../../src/dist/fheroes2.pot; done
 
 # Spanish uses CP1252
 es.mo: es.po


### PR DESCRIPTION
Source code should be unchanged after `make all; make clean`.
Currently .po files are changed on every rebuild. This PR fix it.