### PR TITLE
MP2::OBJ_BOAT is not an action object, but it is not the clear ground either

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1070,6 +1070,8 @@ bool Maps::Tiles::isClearGround() const
     case MP2::OBJ_ZERO:
     case MP2::OBJ_COAST:
         return true;
+    case MP2::OBJ_BOAT:
+        return false;
 
     default:
         break;


### PR DESCRIPTION
fix #5480