### PR TITLE
Update translation guide

### DIFF
--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -13,7 +13,7 @@ _( "Are you sure you want to quit?" )
 ## Adding new translations/localizations
 
 If you want to add a new language localization, you will first need to add this language in the source code as a supported language. Afterwards, a new PO file for that language will need to be added. It will have to be named according to the ISO standard's two-character language abbreviations.
-To have font support for your language, you will have to specify what font encoding/charset your language uses by adding it to the font generation code found in `src/fheroes2/gui/ui_font.cpp`. If a font supporting your language has not currently been implemented then code for that will need to be added.
+To have font support for your language, you will have to specify what font encoding/charset your language uses by adding it to the font generation code found in `/src/fheroes2/gui/ui_font.cpp`. If a font supporting your language has not currently been implemented then code for that will need to be added.
 
 ## Editing translations
 

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -13,7 +13,7 @@ _( "Are you sure you want to quit?" )
 ## Adding new translations/localizations
 
 If you want to add a new language localization, you will first need to add this language in the source code as a supported language. Afterwards, a new PO file for that language will need to be added. It will have to be named according to the ISO standard's two-character language abbreviations.
-To have fonts supported for your language, you will have to specify what font encoding/charset your language uses by adding it to the font generation code found in `src\fheroes2\gui\ui_font.cpp`. If a font supporting your language has not currently been implemented then code for that will need to be added.
+To have font support for your language, you will have to specify what font encoding/charset your language uses by adding it to the font generation code found in `src\fheroes2\gui\ui_font.cpp`. If a font supporting your language has not currently been implemented then code for that will need to be added.
 
 ## Editing translations
 

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -33,7 +33,7 @@ make de.mo
 
 For Windows users that use POEdit or similar, they can compile with that program. However, note that the program will need to be set to compile the MO file in the font encoding/Charset that the language that you are translating to has been set to.
 
-For example, for German you will have to set font encoding to CP1252, and for Russian this would be CP1250. Later when submitting a PR with your changes, you will have to save the PO file in UTF-8 encoding, because this is what Github supports.
+For example, for German you will have to set font encoding to CP1252, while for Russian this would be CP1250. Later when submitting a PR with your changes, you will have to save the PO file in UTF-8 encoding because this is what Github supports.
 
 ## Updating PO templates and translatable strings in PO files
 

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -22,6 +22,7 @@ We encourage you to use [**poedit**](https://poedit.net/) or [**gtranslator**](h
 Currently all implemented languages, except French, adhere to a standardized font encoding/charset.
 
 NB: The fheroes2 team has set a limit of 1000 lines of added lines for any PR for translations. This is because every PR needs to be reviewed and adding too many lines at once will only slow this process down. In addition, Github becomes hard to navigate once too many changes, comments etc. are present within a PR page, further slowing down the process of reviewing it.
+Preferrably a PR should contain a small amount of changes, like 100, all focused on translating a few parts of the game like creature names or castle buildings.
 
 ## Build binary translation files
 

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -38,7 +38,7 @@ This MO file should then be put in the `/files/lang` folder used by the fheroes2
 
 For Windows users that use POEdit or similar, they can compile with that program. However, note that the program will need to be set to compile the MO file in the font encoding/Charset that the language that you are translating to has been set to.
 
-For example, for German you will have to set font encoding to CP1252, while for Russian this would be CP1250. Later when submitting a PR with your changes, you will have to save the PO file in UTF-8 encoding because this is what Github supports.
+For example, for German you will have to set font encoding to CP1252, while for Russian this would be CP1251. Later when submitting a PR with your changes, you will have to save the PO file in UTF-8 encoding because this is what Github supports.
 
 ## Updating PO templates and translatable strings in PO files
 

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -21,6 +21,8 @@ We encourage you to use [**poedit**](https://poedit.net/) or [**gtranslator**](h
 
 Currently all implemented languages, except French, adhere to a standardized font encoding/charset.
 
+NB: The fheroes2 team has set a limit of 1000 lines of added lines for any PR for translations. This is because every PR needs to be reviewed and adding too many lines at once will only slow this process down. In addition, Github becomes hard to navigate once too many changes, comments etc. are present within a PR page, further slowing down the process of reviewing it.
+
 ## Build binary translation files
 
 Once the translation files have been modified, for Linux/MacOS run the `make` command below in `/files/lang` to create machine object (MO) binary files which can be used by the fheroes2 engine.

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -13,7 +13,7 @@ _( "Are you sure you want to quit?" )
 ## Adding new translations/localizations
 
 If you want to add a new language localization, you will first need to add this language in the source code as a supported language. Afterwards, a new PO file for that language will need to be added. It will have to be named according to the ISO standard's two-character language abbreviations.
-To have font support for your language, you will have to specify what font encoding/charset your language uses by adding it to the font generation code found in `/src/fheroes2/gui/ui_font.cpp`. If a font supporting your language has not currently been implemented then code for that will need to be added.
+To have font support for your language, you will have to specify what font encoding/charset your language uses by adding it to the font generation code found in `/src/fheroes2/gui/ui_font.cpp`. If a font supporting your language has not currently been implemented, then code for that will need to be added.
 
 ## Editing translations
 
@@ -23,13 +23,15 @@ Currently all implemented languages, except French, adhere to a standardized fon
 
 ## Build binary translation files
 
-Once the translation files have been modified, for Linux/MacOS run the `make` command below in `/files/lang` to create machine object (MO) binary files which can be used by fheroes2 engine.
+Once the translation files have been modified, for Linux/MacOS run the `make` command below in `/files/lang` to create machine object (MO) binary files which can be used by the fheroes2 engine.
 
 For the German de.po, this would be the command:
 
 ```bash
 make de.mo
 ```
+
+This MO file should then be put in the `/files/lang` folder used by the fheroes2 executable, in other words not the one located in the source directory.
 
 For Windows users that use POEdit or similar, they can compile with that program. However, note that the program will need to be set to compile the MO file in the font encoding/Charset that the language that you are translating to has been set to.
 

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -13,7 +13,7 @@ _( "Are you sure you want to quit?" )
 ## Adding new translations/localizations
 
 If you want to add a new language localization, you will first need to add this language in the source code as a supported language. Afterwards, a new PO file for that language will need to be added. It will have to be named according to the ISO standard's two-character language abbreviations.
-To have font support for your language, you will have to specify what font encoding/charset your language uses by adding it to the font generation code found in `src\fheroes2\gui\ui_font.cpp`. If a font supporting your language has not currently been implemented then code for that will need to be added.
+To have font support for your language, you will have to specify what font encoding/charset your language uses by adding it to the font generation code found in `src/fheroes2/gui/ui_font.cpp`. If a font supporting your language has not currently been implemented then code for that will need to be added.
 
 ## Editing translations
 

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -1,6 +1,6 @@
 # [**fheroes2**](README.md) translation guide
 
-This project uses portable object (PO) files to handle localization in various languages. The current instruction is designed for Linux/MacOS users. Windows users should install [Cygwin](https://www.cygwin.com/) in order to be able to work with translations.
+This project uses portable object (PO) files to handle localization in various languages. The PO files are located in `/files/lang`. The current instruction is designed for Linux, MacOS and Windows users.
 
 ## Finding translatable strings in the codebase
 
@@ -10,24 +10,47 @@ Translatable strings can be found in the source code as arguments to the `_` fun
 _( "Are you sure you want to quit?" )
 ```
 
+## Adding new translations/localizations
+
+If you want to add a new language localization, you will first need to add this language in the source code as a supported language. Afterwards, a new PO file for that language will need to be added. It will have to be named according to the ISO standard's two-character language abbreviations.
+To have fonts supported for your language, you will have to specify what font encoding/charset your language uses by adding it to the font generation code found in `src\fheroes2\gui\ui_font.cpp`. If a font supporting your language has not currently been implemented then code for that will need to be added.
+
+## Editing translations
+
+We encourage you to use [**poedit**](https://poedit.net/) or [**gtranslator**](https://wiki.gnome.org/Apps/Gtranslator) to edit translations.
+
+Currently all implemented languages, except French, adhere to a standardized font encoding/charset.
+
+## Build binary translation files
+
+Once the translation files have been modified, for Linux/MacOS run the `make` command below in `/files/lang` to create machine object (MO) binary files which can be used by fheroes2 engine.
+
+For the German de.po, this would be the command:
+
+```bash
+make de.mo
+```
+
+For Windows users that use POEdit or similar, they can compile with that program. However, note that the program will need to be set to compile the MO file in the font encoding/Charset that the language that you are translating to has been set to.
+
+For example, for German you will have to set font encoding to CP1252, and for Russian this would be CP1250. Later when submitting a PR with your changes, you will have to save the PO file in UTF-8 encoding, because this is what Github supports.
+
 ## Updating PO templates and translatable strings in PO files
 
-If translatable strings have been added to or removed from the code source, run the command below in `/src/dist` to generate a new portable object template (POT) file:
+Currently all PO files are automatically updated with new strings after each commit that brings changes to the ingame text. Should you still need to update strings locally, this can be acheived by running the command below in `/src/dist` to generate a new portable object template (POT) file. Windows users will need to setup an environment that lets them run 'make', like Windows Subsystem for Linux (WSL) or [Cygwin](https://www.cygwin.com/).
 
 ```bash
 make pot
 ```
 
-Once the POT file has been created, go to `/files/lang` and run the following command to update translatable strings in the PO files:
+Once the POT file has been created, go to `/files/lang` and run the command below to update translatable strings in the PO files. If you are using programs mentioned above like POEdit, then they have options to merge new strings from a POT file.
 
 ```bash
 make merge
 ```
 
-## Editing translations
+Alternatively, to update a specific language you can run the following command, using the French PO file `fr.po` as an example:
 
-The PO files are located in `/files/lang`. We encourage you to use [**poedit**](https://poedit.net/) or [**gtranslator**](https://wiki.gnome.org/Apps/Gtranslator) to edit translations.
-
-## Build binary translation files
-
-Once the translation files have been modified, run the `make` command below in `/files/lang` to create machine object (MO) binary files which can be used by fheroes2 engine.
+```bash
+make fr.po
+```


### PR DESCRIPTION
See relevant issue comment https://github.com/ihhub/fheroes2/issues/5477#issuecomment-1141227004

This adds instructions for compiling MO without need to setup an environment to run `make` on Windows.

Added points about length limit of translation related PRs.

I moved the POT related part to the end since now that we are updating them regularly this part is not as relevant anymore.

I'm not sure if the `make merge` command is valid any longer.

More specific info on how to add language support to the code could be added at a later point, like in a separate document to keep things concise.