### PR TITLE
Makefile: respect user flags

### DIFF
--- a/files/lang/Makefile
+++ b/files/lang/Makefile
@@ -22,8 +22,8 @@
 
 all: $(patsubst %.po, %.mo, $(wildcard *.po))
 
-merge:
-	for i in $(wildcard *.po); do msgmerge -U --no-location $$i ../../src/dist/fheroes2.pot; done
+merge: ../../src/dist/fheroes2.pot
+	for i in $(wildcard *.po); do msgmerge -U --no-location $$i $<; done
 
 # Spanish uses CP1252
 es.mo: es.po

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,11 +27,11 @@ TARGET := fheroes2
 # Common flags for both C and C++ compilers
 CCFLAGS := -fsigned-char -pthread
 # Flags for the C compiler
-CFLAGS :=
+CFLAGS := $(CFLAGS)
 # Flags for the C++ compiler
-CXXFLAGS :=
+CXXFLAGS := $(CXXFLAGS)
 # Flags for the linker
-LDFLAGS := -pthread
+LDFLAGS := $(LDFLAGS) -pthread
 
 ifdef FHEROES2_WITH_DEBUG
 CCFLAGS := $(CCFLAGS) -O0 -g


### PR DESCRIPTION
Discussed with @undef21 in the discussion of #5201 to allow the distro-specific build systems to add their own options, such as architecture-dependent options or various "hardening" options.

Also added the dependency on the `fheroes2.pot` for the `merge` target in the `files/lang/Makefile` to file fast if the `fheroes2.pot` doesn't exist. Before:

```
$ make merge
for i in be.po bg.po cs.po de.po es.po fr.po hu.po it.po lt.po nb.po nl.po pl.po pt.po ru.po sv.po tr.po uk.po; do msgmerge -U --no-location $i ../../src/dist/fheroes2.pot; done
msgmerge: error while opening "../../src/dist/fheroes2.pot" for reading: No such file or directory
msgmerge: error while opening "../../src/dist/fheroes2.pot" for reading: No such file or directory
msgmerge: error while opening "../../src/dist/fheroes2.pot" for reading: No such file or directory
msgmerge: error while opening "../../src/dist/fheroes2.pot" for reading: No such file or directory
msgmerge: error while opening "../../src/dist/fheroes2.pot" for reading: No such file or directory
msgmerge: error while opening "../../src/dist/fheroes2.pot" for reading: No such file or directory
msgmerge: error while opening "../../src/dist/fheroes2.pot" for reading: No such file or directory
msgmerge: error while opening "../../src/dist/fheroes2.pot" for reading: No such file or directory
msgmerge: error while opening "../../src/dist/fheroes2.pot" for reading: No such file or directory
msgmerge: error while opening "../../src/dist/fheroes2.pot" for reading: No such file or directory
msgmerge: error while opening "../../src/dist/fheroes2.pot" for reading: No such file or directory
msgmerge: error while opening "../../src/dist/fheroes2.pot" for reading: No such file or directory
msgmerge: error while opening "../../src/dist/fheroes2.pot" for reading: No such file or directory
msgmerge: error while opening "../../src/dist/fheroes2.pot" for reading: No such file or directory
msgmerge: error while opening "../../src/dist/fheroes2.pot" for reading: No such file or directory
msgmerge: error while opening "../../src/dist/fheroes2.pot" for reading: No such file or directory
msgmerge: error while opening "../../src/dist/fheroes2.pot" for reading: No such file or directory
make: *** [Makefile:26: merge] Error 1
```

Now:

```
$ make merge
make: *** No rule to make target '../../src/dist/fheroes2.pot', needed by 'merge'.  Stop.
```
