### PR TITLE
Cleanup of Audio related code

### DIFF
--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -369,7 +369,7 @@ void Mixer::SetChannels( const int num )
 
     const int channelsCount = Mix_AllocateChannels( num );
     if ( num != channelsCount ) {
-        ERROR_LOG( "Failed to the required amount of channels for sound. Required " << num << " but received " << channelsCount )
+        ERROR_LOG( "Failed to allocate the required amount of channels for sound. The required number of channels " << num << " but allocated only " << channelsCount )
     }
 
     if ( channelsCount > 0 ) {

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -362,11 +362,6 @@ void Mixer::SetChannels( const int num )
         return;
     }
 
-    if ( !savedMixerVolumes.empty() ) {
-        // Why are you allocating channels again?
-        assert( 0 );
-    }
-
     const int channelsCount = Mix_AllocateChannels( num );
     if ( num != channelsCount ) {
         ERROR_LOG( "Failed to allocate the required amount of channels for sound. The required number of channels " << num << " but allocated only " << channelsCount )

--- a/src/fheroes2/agg/mus.h
+++ b/src/fheroes2/agg/mus.h
@@ -32,6 +32,7 @@ namespace MUS
     enum : int
     {
         UNUSED,
+
         DATATRACK,
         BATTLE1,
         BATTLE2,

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -238,7 +238,8 @@ int main( int argc, char ** argv )
 
         if ( Audio::isValid() ) {
             Mixer::SetChannels( 32 );
-            Mixer::setVolume( -1, 100 * conf.SoundVolume() / 10 );
+            // Set the volume for all channels to 0. This is required to avoid random volume spikes at the beginning of the game.
+            Mixer::setVolume( -1, 0 );
 
             Music::setVolume( 100 * conf.MusicVolume() / 10 );
             Music::SetFadeInMs( 900 );


### PR DESCRIPTION
- move `Audio::isValid()` checks to the appropriate places
- remove some invalid TODO comments
- remove useless audio related calls to slightly improve the performance