### PR TITLE
Fix Sorceress captain purchase building rendering

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -2033,7 +2033,7 @@ namespace fheroes2
                 if ( !_icnVsSprite[id].empty() && _icnVsSprite[id][0].width() == 84 && _icnVsSprite[id][0].height() == 81 ) {
                     const Sprite & castle = GetICN( ICN::TWNSCSTL, 0 );
                     if ( !castle.empty() ) {
-                        Blit( castle, 238 - 33 + 1, 172 - 67 + 1, _icnVsSprite[id][0], 2, 2, 33, 67 );
+                        Blit( castle, 206, 106, _icnVsSprite[id][0], 2, 2, 33, 67 );
                     }
                 }
                 return true;


### PR DESCRIPTION
Before the building button was:
![image](https://user-images.githubusercontent.com/19829520/171438995-33969229-58f2-4995-981b-ad280c1782a9.png)

And now it looks:
![image](https://user-images.githubusercontent.com/19829520/171438954-47114add-dc36-4a2b-be91-f4d862ec2f18.png)

and this is how it looks after the construction:
![image](https://user-images.githubusercontent.com/19829520/171438803-edc705de-3a98-4d62-a19c-ebd4c5742945.png)
