### PR TITLE
Do not auto-save at the end of a turn if the player has been vanquished on that turn

### DIFF
--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -760,17 +760,15 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
     display.render();
 
     if ( !isload ) {
-        // new week dialog
         if ( 1 < world.CountWeek() && world.BeginWeek() ) {
             ShowNewWeekDialog();
         }
 
-        // show event day
         ShowEventDayDialog();
 
-        // autosave
-        if ( conf.ExtGameAutosaveBeginOfDay() )
+        if ( conf.ExtGameAutosaveBeginOfDay() ) {
             Game::AutoSave();
+        }
     }
 
     GameOver::Result & gameResult = GameOver::Result::Get();
@@ -778,7 +776,6 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
     // check if the game is over at the beginning of each human-controlled player's turn
     res = gameResult.LocalCheckGameOver();
 
-    // warn that all the towns are lost
     if ( res == fheroes2::GameMode::CANCEL && myCastles.empty() ) {
         ShowWarningLostTownsDialog();
     }
@@ -800,8 +797,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
     LocalEvent & le = LocalEvent::Get();
     Cursor & cursor = Cursor::Get();
 
-    // startgame loop
-    while ( fheroes2::GameMode::CANCEL == res ) {
+    while ( res == fheroes2::GameMode::CANCEL ) {
         if ( !le.HandleEvents( Game::isDelayNeeded( delayTypes ), true ) ) {
             if ( EventExit() == fheroes2::GameMode::QUIT_GAME ) {
                 res = fheroes2::GameMode::QUIT_GAME;
@@ -810,12 +806,12 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
             continue;
         }
 
-        // hot keys
+        // hotkeys
         if ( le.KeyPress() ) {
-            // stop moving hero first if needed
+            // if the hero is currently moving, pressing any key should stop him
             if ( isMovingHero )
                 stopHero = true;
-            // exit dialog
+            // adventure map control
             else if ( HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) )
                 res = EventExit();
             else if ( HotKeyPressEvent( Game::HotKeyEvent::END_TURN ) )
@@ -828,9 +824,8 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
                 res = EventNewGame();
             else if ( HotKeyPressEvent( Game::HotKeyEvent::SAVE_GAME ) )
                 EventSaveGame();
-            else if ( HotKeyPressEvent( Game::HotKeyEvent::MAIN_MENU_LOAD_GAME ) ) {
+            else if ( HotKeyPressEvent( Game::HotKeyEvent::MAIN_MENU_LOAD_GAME ) )
                 res = EventLoadGame();
-            }
             else if ( HotKeyPressEvent( Game::HotKeyEvent::FILE_OPTIONS ) )
                 res = EventFileDialog();
             else if ( HotKeyPressEvent( Game::HotKeyEvent::ADVENTURE_OPTIONS ) )
@@ -847,17 +842,14 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
                 EventKingdomInfo();
             else if ( HotKeyPressEvent( Game::HotKeyEvent::VIEW_WORLD ) )
                 EventViewWorld();
-            // show/hide control panel
             else if ( HotKeyPressEvent( Game::HotKeyEvent::CONTROL_PANEL ) )
                 EventSwitchShowControlPanel();
             else if ( HotKeyPressEvent( Game::HotKeyEvent::SHOW_RADAR ) )
                 EventSwitchShowRadar();
             else if ( HotKeyPressEvent( Game::HotKeyEvent::SHOW_BUTTONS ) )
                 EventSwitchShowButtons();
-            // hide/show status window
             else if ( HotKeyPressEvent( Game::HotKeyEvent::SHOW_STATUS ) )
                 EventSwitchShowStatus();
-            // hide/show hero/town icons
             else if ( HotKeyPressEvent( Game::HotKeyEvent::SHOW_ICONS ) )
                 EventSwitchShowIcons();
             else if ( HotKeyPressEvent( Game::HotKeyEvent::CONTINUE_HERO_MOVEMENT ) )
@@ -866,7 +858,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
                 res = EventDigArtifact();
             else if ( HotKeyPressEvent( Game::HotKeyEvent::SLEEP_HERO ) )
                 EventSwitchHeroSleeping();
-            // move hero
+            // hero movement control
             else if ( HotKeyPressEvent( Game::HotKeyEvent::MOVE_LEFT ) )
                 EventKeyArrowPress( Direction::LEFT );
             else if ( HotKeyPressEvent( Game::HotKeyEvent::MOVE_RIGHT ) )
@@ -883,7 +875,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
                 EventKeyArrowPress( Direction::BOTTOM_LEFT );
             else if ( HotKeyPressEvent( Game::HotKeyEvent::MOVE_BOTTOM_RIGHT ) )
                 EventKeyArrowPress( Direction::BOTTOM_RIGHT );
-            // scroll maps
+            // map scrolling control
             else if ( HotKeyPressEvent( Game::HotKeyEvent::SCROLL_LEFT ) )
                 gameArea.SetScroll( SCROLL_LEFT );
             else if ( HotKeyPressEvent( Game::HotKeyEvent::SCROLL_RIGHT ) )
@@ -946,7 +938,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
                 cursor.SetThemes( Cursor::WAIT );
             }
 
-            // stop moving hero if needed
+            // if the hero is currently moving, pressing any mouse button should stop him
             if ( le.MouseClickLeft( displayArea ) || le.MousePressRight( displayArea ) ) {
                 stopHero = true;
             }
@@ -1001,7 +993,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
             break;
         }
 
-        // heroes move animation
+        // animation of the hero's movement
         if ( Game::validateAnimationDelay( Game::CURRENT_HERO_DELAY ) ) {
             Heroes * hero = GetFocusHeroes();
 
@@ -1111,7 +1103,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
             }
         }
 
-        // slow maps objects animation
+        // map objects animation
         if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
             uint32_t & frame = Game::MapsAnimationFrame();
             ++frame;
@@ -1129,27 +1121,30 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
         }
     }
 
-    if ( fheroes2::GameMode::END_TURN == res ) {
-        // these warnings should be shown at the end of the turn
-        if ( myKingdom.isPlay() && myCastles.empty() ) {
-            const uint32_t lostTownDays = myKingdom.GetLostTownDays();
-
-            if ( lostTownDays > Game::GetLostTownDays() ) {
-                Game::DialogPlayers( conf.CurrentColor(),
-                                     _( "%{color} player, you have lost your last town. If you do not conquer another town in next week, you will be eliminated." ) );
-            }
-            else if ( lostTownDays == 1 ) {
-                Game::DialogPlayers( conf.CurrentColor(), _( "%{color} player, your heroes abandon you, and you are banished from this land." ) );
-            }
-        }
-
+    if ( res == fheroes2::GameMode::END_TURN ) {
         if ( GetFocusHeroes() ) {
             GetFocusHeroes()->ShowPath( false );
             RedrawFocus();
         }
 
-        if ( !conf.ExtGameAutosaveBeginOfDay() )
-            Game::AutoSave();
+        if ( myKingdom.isPlay() ) {
+            // these warnings should be shown at the end of the turn
+            if ( myCastles.empty() ) {
+                const uint32_t lostTownDays = myKingdom.GetLostTownDays();
+
+                if ( lostTownDays > Game::GetLostTownDays() ) {
+                    Game::DialogPlayers( conf.CurrentColor(),
+                                         _( "%{color} player, you have lost your last town. If you do not conquer another town in next week, you will be eliminated." ) );
+                }
+                else if ( lostTownDays == 1 ) {
+                    Game::DialogPlayers( conf.CurrentColor(), _( "%{color} player, your heroes abandon you, and you are banished from this land." ) );
+                }
+            }
+
+            if ( !conf.ExtGameAutosaveBeginOfDay() ) {
+                Game::AutoSave();
+            }
+        }
     }
 
     return res;


### PR DESCRIPTION
Currently game may be auto-saved in certain cases - for example, when player dismissed his last hero by hand, however it will not be auto-saved if player attacks by the same last hero and loses the battle. This seems a bit unfair. With this PR game will not be auto-saved at the end of the turn in all cases when player loses/vanquished on that turn. Let's give him another chance.