### PR TITLE
Add music resume ability for MP3, OGG and FLAC formats

### DIFF
--- a/fheroes2-vs2017.vcxproj
+++ b/fheroes2-vs2017.vcxproj
@@ -186,6 +186,7 @@
     <ClCompile Include="src\engine\serialize.cpp" />
     <ClCompile Include="src\engine\smk_decoder.cpp" />
     <ClCompile Include="src\engine\system.cpp" />
+    <ClCompile Include="src\engine\thread.cpp" />
     <ClCompile Include="src\engine\timing.cpp" />
     <ClCompile Include="src\engine\tinyconfig.cpp" />
     <ClCompile Include="src\engine\tools.cpp" />
@@ -409,6 +410,7 @@
     <ClInclude Include="src\engine\serialize.h" />
     <ClInclude Include="src\engine\smk_decoder.h" />
     <ClInclude Include="src\engine\system.h" />
+    <ClInclude Include="src\engine\thread.h" />
     <ClInclude Include="src\engine\timing.h" />
     <ClInclude Include="src\engine\tinyconfig.h" />
     <ClInclude Include="src\engine\tools.h" />

--- a/fheroes2-vs2019.vcxproj
+++ b/fheroes2-vs2019.vcxproj
@@ -187,6 +187,7 @@
     <ClCompile Include="src\engine\serialize.cpp" />
     <ClCompile Include="src\engine\smk_decoder.cpp" />
     <ClCompile Include="src\engine\system.cpp" />
+    <ClCompile Include="src\engine\thread.cpp" />
     <ClCompile Include="src\engine\timing.cpp" />
     <ClCompile Include="src\engine\tinyconfig.cpp" />
     <ClCompile Include="src\engine\tools.cpp" />
@@ -410,6 +411,7 @@
     <ClInclude Include="src\engine\serialize.h" />
     <ClInclude Include="src\engine\smk_decoder.h" />
     <ClInclude Include="src\engine\system.h" />
+    <ClInclude Include="src\engine\thread.h" />
     <ClInclude Include="src\engine\timing.h" />
     <ClInclude Include="src\engine\tinyconfig.h" />
     <ClInclude Include="src\engine\tools.h" />

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -180,23 +180,13 @@ namespace
             return iter->second;
         }
 
-        void setMusicPosition( const uint64_t musicUID, const double position )
-        {
-            auto iter = _musicCache.find( musicUID );
-            if ( iter == _musicCache.end() ) {
-                return;
-            }
-
-            iter->second.position = position;
-        }
-
         void update( const uint64_t musicUID, Mix_Music * mix, const double position )
         {
             assert( mix != nullptr );
 
             auto iter = _musicCache.find( musicUID );
             if ( iter == _musicCache.end() ) {
-                _musicCache.emplace( musicUID, MusicInfo{ mix, position } );
+                _musicCache.try_emplace( musicUID, MusicInfo{ mix, position } );
                 return;
             }
 

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -268,7 +268,7 @@ namespace
 
         const Mix_MusicType musicType = Mix_GetMusicType( mix );
 
-        return ( musicType == Mix_MusicType::MUS_OGG ) || ( musicType == Mix_MusicType::MUS_MP3 );
+        return ( musicType == Mix_MusicType::MUS_OGG ) || ( musicType == Mix_MusicType::MUS_MP3 ) || ( musicType == Mix_MusicType::MUS_FLAC );
     }
 
     void replayCurrentMusic()
@@ -326,7 +326,10 @@ namespace
 
         if ( isResumeSupported && musicInfo.position > 1 ) {
             // Set music position only when at least 1 second of the music has been played.
-            Mix_SetMusicPosition( musicInfo.position );
+            Mix_RewindMusic();
+            if ( Mix_SetMusicPosition( musicInfo.position ) == -1 ) {
+                ERROR_LOG( "The codec does not support music resuming from a custom place." )
+            }
         }
 
         musicSettings.currentTrack = musicInfo;

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -317,10 +317,7 @@ namespace
             loop = false;
             musicSettings.asyncTrackUID = musicUID;
 
-            Mix_HookMusicFinished(
-                []() {
-                    musicSettings.asyncManager.restartPlayback();
-                } );
+            Mix_HookMusicFinished( []() { musicSettings.asyncManager.restartPlayback(); } );
         }
         else {
             musicSettings.asyncTrackUID = 0;
@@ -329,8 +326,8 @@ namespace
         musicSettings.resumeManager.resetTimer();
 
         const int loopCount = loop ? -1 : 0;
-        const int returnCode = ( musicSettings.fadeInMs > 0 ) ? Mix_FadeInMusic( musicInfo.mix, loopCount, musicSettings.fadeInMs )
-                                                              : Mix_PlayMusic( musicInfo.mix, loopCount );
+        const int returnCode
+            = ( musicSettings.fadeInMs > 0 ) ? Mix_FadeInMusic( musicInfo.mix, loopCount, musicSettings.fadeInMs ) : Mix_PlayMusic( musicInfo.mix, loopCount );
         if ( returnCode != 0 ) {
             ERROR_LOG( "Failed to play music mix. The error: " << Mix_GetError() )
             return;

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -306,8 +306,8 @@ namespace
             loop = false;
             musicSettings.asyncTrackUID = musicUID;
 
-            // Mix_HookMusicFinished() function does not allow any SDL calls to be done within the assigned function. In this case the only to trigger restart of the
-            // current song it using multithreading.
+            // Mix_HookMusicFinished() function does not allow any SDL calls to be done within the assigned function. In this case the only way to trigger the restart of
+            // the current song is to use a multithreading approach.
             Mix_HookMusicFinished( []() { musicSettings.asyncManager.restartPlayback(); } );
         }
         else {
@@ -325,7 +325,7 @@ namespace
         }
 
         if ( isResumeSupported && musicInfo.position > 1 ) {
-            // Set music position only when at least 1 second of the music has been played.
+            // Set music position only when at least 1 second of the track has been played.
             Mix_RewindMusic();
             if ( Mix_SetMusicPosition( musicInfo.position ) == -1 ) {
                 ERROR_LOG( "The codec does not support music resuming from a custom place." )

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -276,14 +276,12 @@ namespace
         const std::lock_guard<std::recursive_mutex> guard( mutex );
 
         if ( musicSettings.asyncTrackUID != musicSettings.currentTrackUID ) {
-            // Looks like the track was changed.
+            // Looks like the track has changed.
             return;
         }
 
-        musicSettings.trackManager.resetTimer();
-
         musicSettings.currentTrack.position = 0;
-        musicSettings.trackManager.update( musicSettings.currentTrackUID, musicSettings.currentTrack.mix, 0 );
+        musicSettings.trackManager.update( musicSettings.currentTrackUID, musicSettings.currentTrack.mix, musicSettings.currentTrack.position );
 
         PlayMusic( musicSettings.currentTrackUID, true );
     }

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -282,6 +282,11 @@ namespace
             return;
         }
 
+        if ( musicSettings.currentTrack.mix == nullptr ) {
+            // This can happen only if track UID is 0 and we reset everything while a separate thread was calling this function.
+            return;
+        }
+
         musicSettings.currentTrack.position = 0;
         musicSettings.trackManager.update( musicSettings.currentTrackUID, musicSettings.currentTrack.mix, musicSettings.currentTrack.position );
 
@@ -830,6 +835,7 @@ void Music::Stop()
     }
 
     musicSettings.currentTrack = {};
+    musicSettings.currentTrackUID = 0;
 }
 
 bool Music::isPlaying()

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -309,11 +309,8 @@ namespace
             Music::Stop();
         }
 
-        bool loopAsynchronously = false;
         const bool isResumeSupported = loop && isMusicResumeSupported( musicInfo.mix );
-
         if ( isResumeSupported ) {
-            loopAsynchronously = true;
             loop = false;
             musicSettings.asyncTrackUID = musicUID;
 

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -817,6 +817,11 @@ void Music::Stop()
         return;
     }
 
+    if ( musicSettings.currentTrackUID == musicSettings.asyncTrackUID ) {
+        // SDL2 calls the callback function when the current song is halted. Do not initiate a restart of the current song.
+        Mix_HookMusicFinished( nullptr );
+    }
+
     if ( musicSettings.fadeOutMs > 0 ) {
         while ( !Mix_FadeOutMusic( musicSettings.fadeOutMs ) && Mix_PlayingMusic() ) {
             SDL_Delay( 50 );

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -223,7 +223,7 @@ namespace
 
     void replayCurrentMusic();
 
-    class AsyncMusicManager : fheroes2::AsyncManager
+    class AsyncMusicManager : public fheroes2::AsyncManager
     {
     public:
         void restartPlayback()

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -253,12 +253,14 @@ namespace
             assert( musicLooperThread->joinable() );
 
             musicLooperThread->join();
+            musicLooperThread.reset();
         }
 
         const std::lock_guard<std::recursive_mutex> audioGuard( audioMutex );
 
-        // If audio is not initialized, then this callback function should not be called at all
-        assert( isInitialized );
+        if ( !isInitialized ) {
+            return;
+        }
 
         // Mix_HookMusicFinished() function does not allow any SDL calls to be done within the assigned function.
         // In this case the only way to trigger the restart of the current song is to use a multithreading approach.

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -268,6 +268,16 @@ namespace
             return;
         }
 
+        // Nothing to play
+        if ( musicSettings.currentTrack.mix == nullptr ) {
+            return;
+        }
+
+        // All other cases should be handled by the Mix_PlayMisic() itself
+        if ( musicSettings.currentTrackPlaybackMode != Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE ) {
+            return;
+        }
+
         // Mix_HookMusicFinished() function does not allow any SDL calls to be done within the assigned function.
         // In this case the only way to trigger the restart of the current song is to use a multithreading approach.
         musicLooperThread = std::make_unique<std::thread>(

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -35,8 +35,8 @@
 #include "core.h"
 #include "logging.h"
 #include "system.h"
-#include "timing.h"
 #include "thread.h"
+#include "timing.h"
 
 namespace
 {

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -331,8 +331,7 @@ namespace
         }
 
         const bool resumePlayback = ( playbackMode == Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE && isMusicResumeSupported( musicInfo.mix ) );
-        const bool autoLoop
-            = ( playbackMode == Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE && !resumePlayback ) || ( playbackMode == Music::PlaybackMode::REWIND_AND_PLAY_INFINITE );
+        const bool autoLoop = ( playbackMode != Music::PlaybackMode::PLAY_ONCE && !resumePlayback );
 
         const int loopCount = autoLoop ? -1 : 0;
 

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -191,8 +191,7 @@ namespace
                 return;
             }
 
-            iter->second.mix = mix;
-            iter->second.position = position;
+            iter->second = { mix, position };
         }
 
         void clear()
@@ -237,12 +236,15 @@ namespace
         }
 
     protected:
-        void doStuff() override
+        bool prepareTask() override
+        {
+            // Nothing to prepare and there is no queue.
+            return false;
+        }
+
+        void executeTask() override
         {
             replayCurrentMusic();
-
-            _runFlag = 0;
-            _mutex.unlock();
         }
     };
 

--- a/src/engine/audio.h
+++ b/src/engine/audio.h
@@ -52,13 +52,13 @@ namespace Mixer
     int applySoundEffect( const int channelId, const int16_t angle, uint8_t volumePercentage );
 
     // Returns the previous volume percentage value.
-    int setVolume( const int channel, const int volumePercentage );
+    int setVolume( const int channelId, const int volumePercentage );
 
-    void Pause( const int channel = -1 );
-    void Resume( const int channel = -1 );
-    void Stop( const int channel = -1 );
+    void Pause( const int channelId = -1 );
+    void Resume( const int channelId = -1 );
+    void Stop( const int channelId = -1 );
 
-    bool isPlaying( const int channel );
+    bool isPlaying( const int channelId );
 }
 
 namespace Music

--- a/src/engine/audio.h
+++ b/src/engine/audio.h
@@ -63,8 +63,9 @@ namespace Mixer
 
 namespace Music
 {
-    void Play( const std::vector<uint8_t> & v, const bool loop );
-    void Play( const std::string & file, const bool loop );
+    // Music UID is used to cache existing songs.
+    void Play( const uint64_t musicUID, const std::vector<uint8_t> & v, const bool loop );
+    void Play( const uint64_t musicUID, const std::string & file, const bool loop );
 
     // Returns the previous volume percentage value.
     int setVolume( const int volumePercentage );

--- a/src/engine/audio.h
+++ b/src/engine/audio.h
@@ -63,16 +63,22 @@ namespace Mixer
 
 namespace Music
 {
-    // Music UID is used to cache existing songs. It is caller's responsibility to generate them.
+    enum class PlaybackMode : uint8_t
+    {
+        PLAY_ONCE,
+        CONTINUE_TO_PLAY_INFINITE,
+        REWIND_AND_PLAY_INFINITE
+    };
 
+    // Music UID is used to cache existing songs. It is caller's responsibility to generate them.
     // This function return true in case of music track for corresponding Music UID is cached.
-    bool Play( const uint64_t musicUID, const bool loop, const bool rewindToStart );
+    bool Play( const uint64_t musicUID, const PlaybackMode playbackMode );
 
     // Load a music track from memory and play it.
-    void Play( const uint64_t musicUID, const std::vector<uint8_t> & v, const bool loop, const bool rewindToStart );
+    void Play( const uint64_t musicUID, const std::vector<uint8_t> & v, const PlaybackMode playbackMode );
 
     // Load a music track from a file system location and play it.
-    void Play( const uint64_t musicUID, const std::string & file, const bool loop, const bool rewindToStart );
+    void Play( const uint64_t musicUID, const std::string & file, const PlaybackMode playbackMode );
 
     // Returns the previous volume percentage value.
     int setVolume( const int volumePercentage );

--- a/src/engine/audio.h
+++ b/src/engine/audio.h
@@ -63,9 +63,16 @@ namespace Mixer
 
 namespace Music
 {
-    // Music UID is used to cache existing songs.
-    void Play( const uint64_t musicUID, const std::vector<uint8_t> & v, const bool loop );
-    void Play( const uint64_t musicUID, const std::string & file, const bool loop );
+    // Music UID is used to cache existing songs. It is caller's responsibility to generate them.
+
+    // This function return true in case of music track for corresponding Music UID is cached.
+    bool Play( const uint64_t musicUID, const bool loop, const bool rewindToStart );
+
+    // Load a music track from memory and play it.
+    void Play( const uint64_t musicUID, const std::vector<uint8_t> & v, const bool loop, const bool rewindToStart );
+
+    // Load a music track from a file system location and play it.
+    void Play( const uint64_t musicUID, const std::string & file, const bool loop, const bool rewindToStart );
 
     // Returns the previous volume percentage value.
     int setVolume( const int volumePercentage );

--- a/src/engine/thread.cpp
+++ b/src/engine/thread.cpp
@@ -1,0 +1,84 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2022                                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "thread.h"
+
+#include <cassert>
+#include <memory>
+
+namespace MultiThreading
+{
+    AsyncManager::~AsyncManager()
+    {
+        if ( _worker ) {
+            {
+                std::lock_guard<std::mutex> guard( _mutex );
+
+                _exitFlag = 1;
+                _runFlag = 1;
+                _workerNotification.notify_all();
+            }
+
+            _worker->join();
+            _worker.reset();
+        }
+    }
+
+    void AsyncManager::_createThreadIfNeeded()
+    {
+        if ( !_worker ) {
+            _runFlag = 1;
+            _worker = std::make_unique<std::thread>( AsyncManager::_workerThread, this );
+
+            std::unique_lock<std::mutex> mutexLock( _mutex );
+            _masterNotification.wait( mutexLock, [this] { return _runFlag == 0; } );
+        }
+    }
+
+    void AsyncManager::_workerThread( AsyncManager * manager )
+    {
+        assert( manager != nullptr );
+
+        {
+            std::lock_guard<std::mutex> guard( manager->_mutex );
+            manager->_runFlag = 0;
+            manager->_masterNotification.notify_one();
+        }
+
+        while ( manager->_exitFlag == 0 ) {
+            std::unique_lock<std::mutex> mutexLock( manager->_mutex );
+            manager->_workerNotification.wait( mutexLock, [manager] { return manager->_runFlag == 1; } );
+            mutexLock.unlock();
+
+            if ( manager->_exitFlag )
+                break;
+
+            manager->_mutex.lock();
+
+            manager->doStuff();
+        }
+    }
+
+    void AsyncManager::notifyThread()
+    {
+        _runFlag = 1;
+        _workerNotification.notify_all();
+    }
+}

--- a/src/engine/thread.h
+++ b/src/engine/thread.h
@@ -42,14 +42,16 @@ namespace MultiThreading
 
     protected:
         std::mutex _mutex;
-        uint8_t _runFlag{ 1 };
 
         void _createThreadIfNeeded();
 
         void notifyThread();
 
-        // This is derived class responsibility to handle _runFlag variable and calling unlock() method!
-        virtual void doStuff() = 0;
+        // Prepare a task which requires mutex lock. Returns true if more tasks are available.
+        virtual bool prepareTask() = 0;
+
+        // Task execution is done in non-thread safe mode! No mutex lock for any means of synchronizations are done for this call.
+        virtual void executeTask() = 0;
 
     private:
         std::unique_ptr<std::thread> _worker;
@@ -58,6 +60,7 @@ namespace MultiThreading
         std::condition_variable _workerNotification;
 
         uint8_t _exitFlag{ 0 };
+        uint8_t _runFlag{ 1 };
 
         static void _workerThread( AsyncManager * manager );
     };

--- a/src/engine/thread.h
+++ b/src/engine/thread.h
@@ -1,0 +1,64 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2022                                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#pragma once
+
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+
+namespace MultiThreading
+{
+    class AsyncManager
+    {
+    public:
+        AsyncManager() = default;
+
+        AsyncManager( const AsyncManager & ) = delete;
+        AsyncManager( AsyncManager && ) = delete;
+
+        virtual ~AsyncManager();
+
+        AsyncManager & operator=( const AsyncManager & ) = delete;
+        AsyncManager & operator=( AsyncManager && ) = delete;
+
+    protected:
+        std::mutex _mutex;
+        uint8_t _runFlag{ 1 };
+
+        void _createThreadIfNeeded();
+
+        void notifyThread();
+
+        // This is derived class responsibility to handle _runFlag variable and calling unlock() method!
+        virtual void doStuff() = 0;
+
+    private:
+        std::unique_ptr<std::thread> _worker;
+
+        std::condition_variable _masterNotification;
+        std::condition_variable _workerNotification;
+
+        uint8_t _exitFlag{ 0 };
+
+        static void _workerThread( AsyncManager * manager );
+    };
+}

--- a/src/engine/timing.cpp
+++ b/src/engine/timing.cpp
@@ -21,6 +21,7 @@
 #include "timing.h"
 
 #include <cassert>
+#include <memory>
 #include <thread>
 
 #include <SDL.h>
@@ -150,7 +151,7 @@ namespace fheroes2
     {
         if ( !_worker ) {
             _runFlag = 1;
-            _worker.reset( new std::thread( AsyncManager::_workerThread, this ) );
+            _worker = std::make_unique<std::thread>( AsyncManager::_workerThread, this );
 
             std::unique_lock<std::mutex> mutexLock( _mutex );
             _masterNotification.wait( mutexLock, [this] { return _runFlag == 0; } );

--- a/src/engine/timing.cpp
+++ b/src/engine/timing.cpp
@@ -20,6 +20,7 @@
 
 #include "timing.h"
 
+#include <cassert>
 #include <thread>
 
 #include <SDL.h>
@@ -127,6 +128,63 @@ namespace fheroes2
     void Timer::remove()
     {
         _timer->remove();
+    }
+
+    AsyncManager::~AsyncManager()
+    {
+        if ( _worker ) {
+            {
+                std::lock_guard<std::mutex> guard( _mutex );
+
+                _exitFlag = 1;
+                _runFlag = 1;
+                _workerNotification.notify_all();
+            }
+
+            _worker->join();
+            _worker.reset();
+        }
+    }
+
+    void AsyncManager::_createThreadIfNeeded()
+    {
+        if ( !_worker ) {
+            _runFlag = 1;
+            _worker.reset( new std::thread( AsyncManager::_workerThread, this ) );
+
+            std::unique_lock<std::mutex> mutexLock( _mutex );
+            _masterNotification.wait( mutexLock, [this] { return _runFlag == 0; } );
+        }
+    }
+
+    void AsyncManager::_workerThread( AsyncManager * manager )
+    {
+        assert( manager != nullptr );
+
+        {
+            std::lock_guard<std::mutex> guard( manager->_mutex );
+            manager->_runFlag = 0;
+            manager->_masterNotification.notify_one();
+        }
+
+        while ( manager->_exitFlag == 0 ) {
+            std::unique_lock<std::mutex> mutexLock( manager->_mutex );
+            manager->_workerNotification.wait( mutexLock, [manager] { return manager->_runFlag == 1; } );
+            mutexLock.unlock();
+
+            if ( manager->_exitFlag )
+                break;
+
+            manager->_mutex.lock();
+
+            manager->doStuff();
+        }
+    }
+
+    void AsyncManager::notifyThread()
+    {
+        _runFlag = 1;
+        _workerNotification.notify_all();
     }
 
     void delayforMs( const uint32_t delayMs )

--- a/src/engine/timing.h
+++ b/src/engine/timing.h
@@ -99,7 +99,7 @@ namespace fheroes2
         AsyncManager( const AsyncManager & ) = delete;
         AsyncManager( AsyncManager && ) = delete;
 
-        ~AsyncManager();
+        ~AsyncManager() virtual;
 
         AsyncManager & operator=( const AsyncManager & ) = delete;
         AsyncManager & operator=( AsyncManager && ) = delete;

--- a/src/engine/timing.h
+++ b/src/engine/timing.h
@@ -21,10 +21,7 @@
 #pragma once
 
 #include <chrono>
-#include <condition_variable>
 #include <cstdint>
-#include <mutex>
-#include <thread>
 
 namespace fheroes2
 {
@@ -89,41 +86,6 @@ namespace fheroes2
 
     private:
         TimerImp * _timer;
-    };
-
-    class AsyncManager
-    {
-    public:
-        AsyncManager() = default;
-
-        AsyncManager( const AsyncManager & ) = delete;
-        AsyncManager( AsyncManager && ) = delete;
-
-        virtual ~AsyncManager();
-
-        AsyncManager & operator=( const AsyncManager & ) = delete;
-        AsyncManager & operator=( AsyncManager && ) = delete;
-
-    protected:
-        std::mutex _mutex;
-        uint8_t _runFlag{ 1 };
-
-        void _createThreadIfNeeded();
-
-        void notifyThread();
-
-        // This is derived class responsibility to handle _runFlag variable and calling unlock() method!
-        virtual void doStuff() = 0;
-
-    private:
-        std::unique_ptr<std::thread> _worker;
-
-        std::condition_variable _masterNotification;
-        std::condition_variable _workerNotification;
-
-        uint8_t _exitFlag{ 0 };
-
-        static void _workerThread( AsyncManager * manager );
     };
 
     void delayforMs( const uint32_t delayMs );

--- a/src/engine/timing.h
+++ b/src/engine/timing.h
@@ -99,7 +99,7 @@ namespace fheroes2
         AsyncManager( const AsyncManager & ) = delete;
         AsyncManager( AsyncManager && ) = delete;
 
-        ~AsyncManager() virtual;
+        virtual ~AsyncManager();
 
         AsyncManager & operator=( const AsyncManager & ) = delete;
         AsyncManager & operator=( AsyncManager && ) = delete;

--- a/src/fheroes2/agg/mus.cpp
+++ b/src/fheroes2/agg/mus.cpp
@@ -140,9 +140,9 @@ namespace MUS
     }
 }
 
-int MUS::FromGround( int ground )
+int MUS::FromGround( const int groundType )
 {
-    switch ( ground ) {
+    switch ( groundType ) {
     case Maps::Ground::DESERT:
         return DESERT;
     case Maps::Ground::SNOW:
@@ -168,7 +168,7 @@ int MUS::FromGround( int ground )
     return UNKNOWN;
 }
 
-int MUS::FromRace( int race )
+int MUS::FromRace( const int race )
 {
     switch ( race ) {
     case Race::KNGT:

--- a/src/fheroes2/agg/mus.h
+++ b/src/fheroes2/agg/mus.h
@@ -33,7 +33,7 @@ namespace MUS
     {
         UNUSED,
 
-        DATATRACK,
+        DATATRACK, // not in use
         BATTLE1,
         BATTLE2,
         BATTLE3,
@@ -57,9 +57,9 @@ namespace MUS
         ARCHIBALD_CAMPAIGN_SCREEN,
         PUZZLE,
         ROLAND_CAMPAIGN_SCREEN,
-        CARAVANS,
-        CARAVANS_2,
-        CARAVANS_3,
+        CARAVANS, // not in use
+        CARAVANS_2, // not in use
+        CARAVANS_3, // not in use
         COMPUTER_TURN,
         BATTLEWIN,
         BATTLELOSE,
@@ -73,10 +73,11 @@ namespace MUS
         SKILL,
         WATCHTOWER,
         XANADU,
-        ULTIMATE_ARTIFACT,
+        ULTIMATE_ARTIFACT, // not in use
         MAINMENU,
         VICTORY,
 
+        // IMPORTANT!!! Put all new entries above this line.
         UNKNOWN
     };
 
@@ -89,8 +90,8 @@ namespace MUS
 
     std::string getFileName( const int musicTrackId, const EXTERNAL_MUSIC_TYPE musicType, const char * fileExtension );
 
-    int FromGround( int );
-    int FromRace( int );
+    int FromGround( const int groundType );
+    int FromRace( const int race );
     int FromMapObject( const MP2::MapObjectType objectType );
 
     int GetBattleRandom();

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -272,7 +272,7 @@ namespace AI
         Interface::StatusWindow & status = Interface::Basic::Get().GetStatusWindow();
         status.RedrawTurnProgress( 0 );
 
-        AudioManager::PlayMusicAsync( MUS::COMPUTER_TURN, AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+        AudioManager::PlayMusicAsync( MUS::COMPUTER_TURN, Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
 
         KingdomHeroes & heroes = kingdom.GetHeroes();
         const KingdomCastles & castles = kingdom.GetCastles();

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -272,7 +272,7 @@ namespace AI
         Interface::StatusWindow & status = Interface::Basic::Get().GetStatusWindow();
         status.RedrawTurnProgress( 0 );
 
-        AudioManager::PlayMusic( MUS::COMPUTER_TURN, true, true );
+        AudioManager::PlayMusicAsync( MUS::COMPUTER_TURN, true );
 
         KingdomHeroes & heroes = kingdom.GetHeroes();
         const KingdomCastles & castles = kingdom.GetCastles();

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -272,7 +272,7 @@ namespace AI
         Interface::StatusWindow & status = Interface::Basic::Get().GetStatusWindow();
         status.RedrawTurnProgress( 0 );
 
-        AudioManager::PlayMusicAsync( MUS::COMPUTER_TURN, true );
+        AudioManager::PlayMusicAsync( MUS::COMPUTER_TURN, AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
 
         KingdomHeroes & heroes = kingdom.GetHeroes();
         const KingdomCastles & castles = kingdom.GetCastles();

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -396,7 +396,8 @@ namespace
 
     uint64_t getMusicUID( const int trackId, const MusicSource musicType )
     {
-        assert( trackId != MUS::UNUSED && trackId != MUS::UNKNOWN && trackId >= 0 );
+        static_assert( MUS::UNUSED == 0, "Why are you changing this value?" );
+        assert( trackId != MUS::UNUSED && trackId != MUS::UNKNOWN );
 
         return ( static_cast<uint64_t>( musicType ) << 32 ) + static_cast<uint64_t>( trackId );
     }

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -27,8 +27,8 @@
 #include "mus.h"
 #include "settings.h"
 #include "system.h"
-#include "timing.h"
 #include "tools.h"
+#include "thread.h"
 #include "xmi.h"
 
 #include <algorithm>
@@ -210,7 +210,7 @@ namespace
     // SDL MIDI player is a single threaded library which requires a lot of time to start playing some long midi compositions.
     // This leads to a situation of a short application freeze while a hero crosses terrains or ending a battle.
     // The only way to avoid this is to fire MIDI requests asynchronously and synchronize them if needed.
-    class AsyncSoundManager : public fheroes2::AsyncManager
+    class AsyncSoundManager : public MultiThreading::AsyncManager
     {
     public:
         void pushMusic( const int musicId, const MusicSource musicType, const bool isLooped )

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -20,7 +20,6 @@
 
 #include "audio_manager.h"
 #include "agg_file.h"
-#include "audio.h"
 #include "game.h"
 #include "logging.h"
 #include "m82.h"

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -27,8 +27,8 @@
 #include "mus.h"
 #include "settings.h"
 #include "system.h"
-#include "tools.h"
 #include "thread.h"
+#include "tools.h"
 #include "xmi.h"
 
 #include <algorithm>

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -295,7 +295,7 @@ namespace
 
             int musicId{ 0 };
             MusicSource musicType{ MUSIC_MIDI_ORIGINAL };
-            AudioManager::MusicPlaybackMode playbackMode { AudioManager::MusicPlaybackMode::PLAY_ONCE };
+            AudioManager::MusicPlaybackMode playbackMode{ AudioManager::MusicPlaybackMode::PLAY_ONCE };
         };
 
         struct SoundTask
@@ -465,8 +465,8 @@ namespace
             return;
         }
 
-        const bool loop = ( playbackMode == AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE ) ||
-                          ( playbackMode == AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
+        const bool loop = ( playbackMode == AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE )
+                          || ( playbackMode == AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
 
         const bool rewindToStart = ( playbackMode == AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
 

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -35,7 +35,6 @@
 #include <array>
 #include <cassert>
 #include <queue>
-#include <string>
 #include <utility>
 
 namespace

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -207,7 +207,7 @@ namespace
     }
 
     void PlaySoundInternally( const int m82, const int soundVolume );
-    void PlayMusicInternally( const int trackId, const MusicSource musicType, const AudioManager::MusicPlaybackMode playbackMode );
+    void PlayMusicInternally( const int trackId, const MusicSource musicType, const Music::PlaybackMode playbackMode );
     void playLoopSoundsInternally( std::map<M82::SoundType, std::vector<AudioManager::AudioLoopEffectInfo>> soundEffects, const int soundVolume,
                                    const bool is3DAudioEnabled );
 
@@ -217,7 +217,7 @@ namespace
     class AsyncSoundManager : public MultiThreading::AsyncManager
     {
     public:
-        void pushMusic( const int musicId, const MusicSource musicType, const AudioManager::MusicPlaybackMode playbackMode )
+        void pushMusic( const int musicId, const MusicSource musicType, const Music::PlaybackMode playbackMode )
         {
             _createThreadIfNeeded();
 
@@ -290,7 +290,7 @@ namespace
         {
             MusicTask() = default;
 
-            MusicTask( const int musicId_, const MusicSource musicType_, const AudioManager::MusicPlaybackMode playbackMode_ )
+            MusicTask( const int musicId_, const MusicSource musicType_, const Music::PlaybackMode playbackMode_ )
                 : musicId( musicId_ )
                 , musicType( musicType_ )
                 , playbackMode( playbackMode_ )
@@ -300,7 +300,7 @@ namespace
 
             int musicId{ 0 };
             MusicSource musicType{ MUSIC_MIDI_ORIGINAL };
-            AudioManager::MusicPlaybackMode playbackMode{ AudioManager::MusicPlaybackMode::PLAY_ONCE };
+            Music::PlaybackMode playbackMode{ Music::PlaybackMode::PLAY_ONCE };
         };
 
         struct SoundTask
@@ -457,7 +457,7 @@ namespace
         return ( static_cast<uint64_t>( musicType ) << 32 ) + static_cast<uint64_t>( trackId );
     }
 
-    void PlayMusicInternally( const int trackId, const MusicSource musicType, const AudioManager::MusicPlaybackMode playbackMode )
+    void PlayMusicInternally( const int trackId, const MusicSource musicType, const Music::PlaybackMode playbackMode )
     {
         // Make sure that the music track is valid.
         assert( trackId != MUS::UNUSED && trackId != MUS::UNKNOWN );
@@ -470,13 +470,8 @@ namespace
             return;
         }
 
-        const bool loop = ( playbackMode == AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE )
-                          || ( playbackMode == AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
-
-        const bool rewindToStart = ( playbackMode == AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
-
         // Check if the music track is cached.
-        if ( Music::Play( musicUID, loop, rewindToStart ) ) {
+        if ( Music::Play( musicUID, playbackMode ) ) {
             DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "Play cached music track " << trackId )
             Game::SetCurrentMusicTrack( trackId );
             return;
@@ -507,7 +502,7 @@ namespace
                 DEBUG_LOG( DBG_ENGINE, DBG_WARN, "Cannot find a file for " << trackId << " track." )
             }
             else {
-                Music::Play( musicUID, filename, loop, rewindToStart );
+                Music::Play( musicUID, filename, playbackMode );
 
                 Game::SetCurrentMusicTrack( trackId );
 
@@ -530,7 +525,7 @@ namespace
         if ( XMI::UNKNOWN != xmi ) {
             const std::vector<uint8_t> & v = GetMID( xmi );
             if ( !v.empty() ) {
-                Music::Play( musicUID, v, loop, rewindToStart );
+                Music::Play( musicUID, v, playbackMode );
 
                 Game::SetCurrentMusicTrack( trackId );
             }
@@ -790,7 +785,7 @@ namespace AudioManager
         }
     }
 
-    void PlayMusic( const int trackId, const MusicPlaybackMode playbackMode )
+    void PlayMusic( const int trackId, const Music::PlaybackMode playbackMode )
     {
         if ( MUS::UNUSED == trackId || MUS::UNKNOWN == trackId ) {
             return;
@@ -804,7 +799,7 @@ namespace AudioManager
         PlayMusicInternally( trackId, Settings::Get().MusicType(), playbackMode );
     }
 
-    void PlayMusicAsync( const int trackId, const MusicPlaybackMode playbackMode )
+    void PlayMusicAsync( const int trackId, const Music::PlaybackMode playbackMode )
     {
         if ( MUS::UNUSED == trackId || MUS::UNKNOWN == trackId ) {
             return;

--- a/src/fheroes2/audio/audio_manager.h
+++ b/src/fheroes2/audio/audio_manager.h
@@ -61,6 +61,9 @@ namespace AudioManager
 
     void playLoopSounds( std::map<M82::SoundType, std::vector<AudioLoopEffectInfo>> soundEffects, bool asyncronizedCall );
     void PlaySound( int m82, bool asyncronizedCall = false );
-    void PlayMusic( int mus, bool loop = true, bool asyncronizedCall = false );
+
+    void PlayMusic( const int trackId, const bool loop, bool rewindToStart = false );
+    void PlayMusicAsync( const int trackId, const bool loop, bool rewindToStart = false );
+
     void ResetAudio();
 }

--- a/src/fheroes2/audio/audio_manager.h
+++ b/src/fheroes2/audio/audio_manager.h
@@ -62,8 +62,15 @@ namespace AudioManager
     void playLoopSounds( std::map<M82::SoundType, std::vector<AudioLoopEffectInfo>> soundEffects, bool asyncronizedCall );
     void PlaySound( int m82, bool asyncronizedCall = false );
 
-    void PlayMusic( const int trackId, const bool loop, bool rewindToStart = false );
-    void PlayMusicAsync( const int trackId, const bool loop, bool rewindToStart = false );
+    enum class MusicPlaybackMode : uint8_t
+    {
+        PLAY_ONCE,
+        CONTINUE_TO_PLAY_INFINITE,
+        REWIND_AND_PLAY_INFINITE
+    };
+
+    void PlayMusic( const int trackId, const MusicPlaybackMode playbackMode );
+    void PlayMusicAsync( const int trackId, const MusicPlaybackMode playbackMode );
 
     void ResetAudio();
 }

--- a/src/fheroes2/audio/audio_manager.h
+++ b/src/fheroes2/audio/audio_manager.h
@@ -25,6 +25,8 @@
 #include <string>
 #include <vector>
 
+#include "audio.h"
+
 namespace M82
 {
     enum SoundType : int;
@@ -67,15 +69,8 @@ namespace AudioManager
     void playLoopSounds( std::map<M82::SoundType, std::vector<AudioLoopEffectInfo>> soundEffects, bool asyncronizedCall );
     void PlaySound( int m82, bool asyncronizedCall = false );
 
-    enum class MusicPlaybackMode : uint8_t
-    {
-        PLAY_ONCE,
-        CONTINUE_TO_PLAY_INFINITE,
-        REWIND_AND_PLAY_INFINITE
-    };
-
-    void PlayMusic( const int trackId, const MusicPlaybackMode playbackMode );
-    void PlayMusicAsync( const int trackId, const MusicPlaybackMode playbackMode );
+    void PlayMusic( const int trackId, const Music::PlaybackMode playbackMode );
+    void PlayMusicAsync( const int trackId, const Music::PlaybackMode playbackMode );
 
     void ResetAudio();
 }

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -418,19 +418,19 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
 
     if ( ( res.army1 & RESULT_WINS ) && ( army1->GetControl() & CONTROL_HUMAN ) ) {
         GetSummaryParams( res.army1, res.army2, army1->GetCommander(), res.exp1, sequence, title, msg );
-        AudioManager::PlayMusic( MUS::BATTLEWIN, false );
+        AudioManager::PlayMusic( MUS::BATTLEWIN, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
     }
     else if ( ( res.army2 & RESULT_WINS ) && ( army2->GetControl() & CONTROL_HUMAN ) ) {
         GetSummaryParams( res.army2, res.army1, army2->GetCommander(), res.exp2, sequence, title, msg );
-        AudioManager::PlayMusic( MUS::BATTLEWIN, false );
+        AudioManager::PlayMusic( MUS::BATTLEWIN, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
     }
     else if ( army1->GetControl() & CONTROL_HUMAN ) {
         GetSummaryParams( res.army1, res.army2, army1->GetCommander(), res.exp1, sequence, title, msg );
-        AudioManager::PlayMusic( MUS::BATTLELOSE, false );
+        AudioManager::PlayMusic( MUS::BATTLELOSE, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
     }
     else if ( army2->GetControl() & CONTROL_HUMAN ) {
         GetSummaryParams( res.army2, res.army1, army2->GetCommander(), res.exp2, sequence, title, msg );
-        AudioManager::PlayMusic( MUS::BATTLELOSE, false );
+        AudioManager::PlayMusic( MUS::BATTLELOSE, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
     }
     else {
         // AI vs AI battle, this dialog should not be shown at all

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -418,19 +418,19 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
 
     if ( ( res.army1 & RESULT_WINS ) && ( army1->GetControl() & CONTROL_HUMAN ) ) {
         GetSummaryParams( res.army1, res.army2, army1->GetCommander(), res.exp1, sequence, title, msg );
-        AudioManager::PlayMusic( MUS::BATTLEWIN, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
+        AudioManager::PlayMusic( MUS::BATTLEWIN, AudioManager::MusicPlaybackMode::PLAY_ONCE );
     }
     else if ( ( res.army2 & RESULT_WINS ) && ( army2->GetControl() & CONTROL_HUMAN ) ) {
         GetSummaryParams( res.army2, res.army1, army2->GetCommander(), res.exp2, sequence, title, msg );
-        AudioManager::PlayMusic( MUS::BATTLEWIN, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
+        AudioManager::PlayMusic( MUS::BATTLEWIN, AudioManager::MusicPlaybackMode::PLAY_ONCE );
     }
     else if ( army1->GetControl() & CONTROL_HUMAN ) {
         GetSummaryParams( res.army1, res.army2, army1->GetCommander(), res.exp1, sequence, title, msg );
-        AudioManager::PlayMusic( MUS::BATTLELOSE, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
+        AudioManager::PlayMusic( MUS::BATTLELOSE, AudioManager::MusicPlaybackMode::PLAY_ONCE );
     }
     else if ( army2->GetControl() & CONTROL_HUMAN ) {
         GetSummaryParams( res.army2, res.army1, army2->GetCommander(), res.exp2, sequence, title, msg );
-        AudioManager::PlayMusic( MUS::BATTLELOSE, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
+        AudioManager::PlayMusic( MUS::BATTLELOSE, AudioManager::MusicPlaybackMode::PLAY_ONCE );
     }
     else {
         // AI vs AI battle, this dialog should not be shown at all

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -418,19 +418,19 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
 
     if ( ( res.army1 & RESULT_WINS ) && ( army1->GetControl() & CONTROL_HUMAN ) ) {
         GetSummaryParams( res.army1, res.army2, army1->GetCommander(), res.exp1, sequence, title, msg );
-        AudioManager::PlayMusic( MUS::BATTLEWIN, AudioManager::MusicPlaybackMode::PLAY_ONCE );
+        AudioManager::PlayMusic( MUS::BATTLEWIN, Music::PlaybackMode::PLAY_ONCE );
     }
     else if ( ( res.army2 & RESULT_WINS ) && ( army2->GetControl() & CONTROL_HUMAN ) ) {
         GetSummaryParams( res.army2, res.army1, army2->GetCommander(), res.exp2, sequence, title, msg );
-        AudioManager::PlayMusic( MUS::BATTLEWIN, AudioManager::MusicPlaybackMode::PLAY_ONCE );
+        AudioManager::PlayMusic( MUS::BATTLEWIN, Music::PlaybackMode::PLAY_ONCE );
     }
     else if ( army1->GetControl() & CONTROL_HUMAN ) {
         GetSummaryParams( res.army1, res.army2, army1->GetCommander(), res.exp1, sequence, title, msg );
-        AudioManager::PlayMusic( MUS::BATTLELOSE, AudioManager::MusicPlaybackMode::PLAY_ONCE );
+        AudioManager::PlayMusic( MUS::BATTLELOSE, Music::PlaybackMode::PLAY_ONCE );
     }
     else if ( army2->GetControl() & CONTROL_HUMAN ) {
         GetSummaryParams( res.army2, res.army1, army2->GetCommander(), res.exp2, sequence, title, msg );
-        AudioManager::PlayMusic( MUS::BATTLELOSE, AudioManager::MusicPlaybackMode::PLAY_ONCE );
+        AudioManager::PlayMusic( MUS::BATTLELOSE, Music::PlaybackMode::PLAY_ONCE );
     }
     else {
         // AI vs AI battle, this dialog should not be shown at all

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2958,7 +2958,7 @@ void Battle::Interface::RedrawMissileAnimation( const fheroes2::Point & startPos
 void Battle::Interface::RedrawActionNewTurn() const
 {
     if ( !Music::isPlaying() ) {
-        AudioManager::PlayMusicAsync( MUS::GetBattleRandom(), true, true );
+        AudioManager::PlayMusicAsync( MUS::GetBattleRandom(), AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
     }
 
     if ( listlog == nullptr ) {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2958,7 +2958,7 @@ void Battle::Interface::RedrawMissileAnimation( const fheroes2::Point & startPos
 void Battle::Interface::RedrawActionNewTurn() const
 {
     if ( !Music::isPlaying() ) {
-        AudioManager::PlayMusicAsync( MUS::GetBattleRandom(), AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
+        AudioManager::PlayMusicAsync( MUS::GetBattleRandom(), Music::PlaybackMode::REWIND_AND_PLAY_INFINITE );
     }
 
     if ( listlog == nullptr ) {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2958,7 +2958,7 @@ void Battle::Interface::RedrawMissileAnimation( const fheroes2::Point & startPos
 void Battle::Interface::RedrawActionNewTurn() const
 {
     if ( !Music::isPlaying() ) {
-        AudioManager::PlayMusic( MUS::GetBattleRandom(), true, true );
+        AudioManager::PlayMusicAsync( MUS::GetBattleRandom(), true, true );
     }
 
     if ( listlog == nullptr ) {

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -258,7 +258,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readOnly, const b
 
     const fheroes2::StandardWindow background( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
 
-    AudioManager::PlayMusic( MUS::FromRace( race ), true, true );
+    AudioManager::PlayMusicAsync( MUS::FromRace( race ), true );
 
     int alphaHero = 255;
     CastleDialog::FadeBuilding fadeBuilding;

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -258,7 +258,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readOnly, const b
 
     const fheroes2::StandardWindow background( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
 
-    AudioManager::PlayMusicAsync( MUS::FromRace( race ), AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+    AudioManager::PlayMusicAsync( MUS::FromRace( race ), Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
 
     int alphaHero = 255;
     CastleDialog::FadeBuilding fadeBuilding;

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -258,7 +258,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readOnly, const b
 
     const fheroes2::StandardWindow background( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
 
-    AudioManager::PlayMusicAsync( MUS::FromRace( race ), true );
+    AudioManager::PlayMusicAsync( MUS::FromRace( race ), AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
 
     int alphaHero = 255;
     CastleDialog::FadeBuilding fadeBuilding;

--- a/src/fheroes2/dialog/dialog_game_settings.cpp
+++ b/src/fheroes2/dialog/dialog_game_settings.cpp
@@ -280,7 +280,7 @@ namespace
 
                 conf.SetMusicType( type > MUSIC_EXTERNAL ? 0 : type );
 
-                Game::SetCurrentMusic( MUS::UNKNOWN );
+                Game::SetCurrentMusicTrack( MUS::UNKNOWN );
 
                 return SelectedWindow::UpdateSettings;
             }

--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -319,7 +319,7 @@ namespace
 
                 conf.SetMusicType( type > MUSIC_EXTERNAL ? 0 : type );
 
-                Game::SetCurrentMusic( MUS::UNKNOWN );
+                Game::SetCurrentMusicTrack( MUS::UNKNOWN );
 
                 saveMusicType = true;
             }

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -485,7 +485,7 @@ void Game::restoreSoundsForCurrentFocus()
         const int heroIndexPos = focusedHero->GetIndex();
         if ( heroIndexPos >= 0 ) {
             Game::EnvironmentSoundMixer();
-            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), true );
+            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
         }
         break;
     }
@@ -495,7 +495,8 @@ void Game::restoreSoundsForCurrentFocus()
         assert( focusedCastle != nullptr );
 
         Game::EnvironmentSoundMixer();
-        AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( focusedCastle->GetIndex() ).GetGround() ), true );
+        AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( focusedCastle->GetIndex() ).GetGround() ),
+                                      AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
         break;
     }
 

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -485,7 +485,7 @@ void Game::restoreSoundsForCurrentFocus()
         const int heroIndexPos = focusedHero->GetIndex();
         if ( heroIndexPos >= 0 ) {
             Game::EnvironmentSoundMixer();
-            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
         }
         break;
     }
@@ -495,8 +495,7 @@ void Game::restoreSoundsForCurrentFocus()
         assert( focusedCastle != nullptr );
 
         Game::EnvironmentSoundMixer();
-        AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( focusedCastle->GetIndex() ).GetGround() ),
-                                      AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+        AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( focusedCastle->GetIndex() ).GetGround() ), Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
         break;
     }
 

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -60,7 +60,7 @@ namespace
     std::string last_name;
 
     bool updateSoundsOnFocusUpdate = true;
-    std::atomic<int> currentMusic{ MUS::UNKNOWN };
+    std::atomic<int> currentMusicTrackId{ MUS::UNKNOWN };
 
     uint32_t maps_animation_frame = 0;
 
@@ -222,14 +222,14 @@ void Game::Init()
     Game::HotKeysLoad( Settings::GetLastFile( "", "fheroes2.key" ) );
 }
 
-int Game::CurrentMusic()
+int Game::CurrentMusicTrackId()
 {
-    return currentMusic;
+    return currentMusicTrackId;
 }
 
-void Game::SetCurrentMusic( const int mus )
+void Game::SetCurrentMusicTrack( const int trackId )
 {
-    currentMusic = mus;
+    currentMusicTrackId = trackId;
 }
 
 void Game::ObjectFadeAnimation::PrepareFadeTask( const MP2::MapObjectType objectType, int32_t fromIndex, int32_t toIndex, bool fadeOut, bool fadeIn )
@@ -474,7 +474,7 @@ void Game::EnvironmentSoundMixer()
 
 void Game::restoreSoundsForCurrentFocus()
 {
-    Game::SetCurrentMusic( MUS::UNKNOWN );
+    Game::SetCurrentMusicTrack( MUS::UNKNOWN );
     AudioManager::ResetAudio();
 
     switch ( Interface::GetFocusType() ) {
@@ -485,7 +485,7 @@ void Game::restoreSoundsForCurrentFocus()
         const int heroIndexPos = focusedHero->GetIndex();
         if ( heroIndexPos >= 0 ) {
             Game::EnvironmentSoundMixer();
-            AudioManager::PlayMusic( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), true, true );
+            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), true );
         }
         break;
     }
@@ -495,7 +495,7 @@ void Game::restoreSoundsForCurrentFocus()
         assert( focusedCastle != nullptr );
 
         Game::EnvironmentSoundMixer();
-        AudioManager::PlayMusic( MUS::FromGround( world.GetTiles( focusedCastle->GetIndex() ).GetGround() ), true, true );
+        AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( focusedCastle->GetIndex() ).GetGround() ), true );
         break;
     }
 

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -96,8 +96,8 @@ namespace Game
     int GetKingdomColors();
     int GetActualKingdomColors();
     void DialogPlayers( int color, std::string );
-    void SetCurrentMusic( const int mus );
-    int CurrentMusic();
+    void SetCurrentMusicTrack( const int trackId );
+    int CurrentMusicTrackId();
     uint32_t & MapsAnimationFrame();
     uint32_t GetRating();
     uint32_t GetGameOverScores();
@@ -125,7 +125,7 @@ namespace Game
     {
     public:
         MusicRestorer()
-            : _music( CurrentMusic() )
+            : _music( CurrentMusicTrackId() )
         {}
 
         MusicRestorer( const MusicRestorer & ) = delete;
@@ -133,7 +133,7 @@ namespace Game
         ~MusicRestorer()
         {
             if ( _music == MUS::UNUSED || _music == MUS::UNKNOWN ) {
-                SetCurrentMusic( _music );
+                SetCurrentMusicTrack( _music );
 
                 return;
             }
@@ -141,11 +141,12 @@ namespace Game
             // Set current music to MUS::UNKNOWN to prevent attempts to play the old music
             // by new instances of MusicRestorer while the music being currently restored
             // is starting in the background
-            if ( _music != CurrentMusic() ) {
-                SetCurrentMusic( MUS::UNKNOWN );
+            if ( _music != CurrentMusicTrackId() ) {
+                SetCurrentMusicTrack( MUS::UNKNOWN );
             }
 
-            AudioManager::PlayMusic( _music, true, true );
+            // It is assumed that the previous track was looped and does not require to be played from the beginning.
+            AudioManager::PlayMusicAsync( _music, true );
         }
 
         MusicRestorer & operator=( const MusicRestorer & ) = delete;

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -146,7 +146,7 @@ namespace Game
             }
 
             // It is assumed that the previous track was looped and does not require to be played from the beginning.
-            AudioManager::PlayMusicAsync( _music, true );
+            AudioManager::PlayMusicAsync( _music, AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
         }
 
         MusicRestorer & operator=( const MusicRestorer & ) = delete;

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -146,7 +146,7 @@ namespace Game
             }
 
             // It is assumed that the previous track was looped and does not require to be played from the beginning.
-            AudioManager::PlayMusicAsync( _music, AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+            AudioManager::PlayMusicAsync( _music, Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
         }
 
         MusicRestorer & operator=( const MusicRestorer & ) = delete;

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -692,10 +692,10 @@ namespace
         case Campaign::DESCENDANTS_CAMPAIGN:
         case Campaign::WIZARDS_ISLE_CAMPAIGN:
         case Campaign::VOYAGE_HOME_CAMPAIGN:
-            AudioManager::PlayMusic( MUS::ROLAND_CAMPAIGN_SCREEN, true );
+            AudioManager::PlayMusicAsync( MUS::ROLAND_CAMPAIGN_SCREEN, true, true );
             break;
         case Campaign::ARCHIBALD_CAMPAIGN:
-            AudioManager::PlayMusic( MUS::ARCHIBALD_CAMPAIGN_SCREEN, true );
+            AudioManager::PlayMusicAsync( MUS::ARCHIBALD_CAMPAIGN_SCREEN, true, true );
             break;
         default:
             // Implementing a new campaign? Add a new case!
@@ -856,7 +856,7 @@ fheroes2::GameMode Game::CompleteCampaignScenario( const bool isLoadingSaveFile 
         // TODO : Implement function that displays the last frame of win.smk with score
         // and a dialog for name entry. fheroes::PlayMusic is run here in order to start
         // playing before displaying the high score.
-        AudioManager::PlayMusic( MUS::VICTORY, true, true );
+        AudioManager::PlayMusicAsync( MUS::VICTORY, true, true );
         return fheroes2::GameMode::HIGHSCORES_CAMPAIGN;
     }
 

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -692,10 +692,10 @@ namespace
         case Campaign::DESCENDANTS_CAMPAIGN:
         case Campaign::WIZARDS_ISLE_CAMPAIGN:
         case Campaign::VOYAGE_HOME_CAMPAIGN:
-            AudioManager::PlayMusicAsync( MUS::ROLAND_CAMPAIGN_SCREEN, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
+            AudioManager::PlayMusicAsync( MUS::ROLAND_CAMPAIGN_SCREEN, Music::PlaybackMode::REWIND_AND_PLAY_INFINITE );
             break;
         case Campaign::ARCHIBALD_CAMPAIGN:
-            AudioManager::PlayMusicAsync( MUS::ARCHIBALD_CAMPAIGN_SCREEN, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
+            AudioManager::PlayMusicAsync( MUS::ARCHIBALD_CAMPAIGN_SCREEN, Music::PlaybackMode::REWIND_AND_PLAY_INFINITE );
             break;
         default:
             // Implementing a new campaign? Add a new case!
@@ -856,7 +856,7 @@ fheroes2::GameMode Game::CompleteCampaignScenario( const bool isLoadingSaveFile 
         // TODO : Implement function that displays the last frame of win.smk with score
         // and a dialog for name entry. fheroes::PlayMusic is run here in order to start
         // playing before displaying the high score.
-        AudioManager::PlayMusicAsync( MUS::VICTORY, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
+        AudioManager::PlayMusicAsync( MUS::VICTORY, Music::PlaybackMode::REWIND_AND_PLAY_INFINITE );
         return fheroes2::GameMode::HIGHSCORES_CAMPAIGN;
     }
 

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -692,10 +692,10 @@ namespace
         case Campaign::DESCENDANTS_CAMPAIGN:
         case Campaign::WIZARDS_ISLE_CAMPAIGN:
         case Campaign::VOYAGE_HOME_CAMPAIGN:
-            AudioManager::PlayMusicAsync( MUS::ROLAND_CAMPAIGN_SCREEN, true, true );
+            AudioManager::PlayMusicAsync( MUS::ROLAND_CAMPAIGN_SCREEN, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
             break;
         case Campaign::ARCHIBALD_CAMPAIGN:
-            AudioManager::PlayMusicAsync( MUS::ARCHIBALD_CAMPAIGN_SCREEN, true, true );
+            AudioManager::PlayMusicAsync( MUS::ARCHIBALD_CAMPAIGN_SCREEN, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
             break;
         default:
             // Implementing a new campaign? Add a new case!
@@ -856,7 +856,7 @@ fheroes2::GameMode Game::CompleteCampaignScenario( const bool isLoadingSaveFile 
         // TODO : Implement function that displays the last frame of win.smk with score
         // and a dialog for name entry. fheroes::PlayMusic is run here in order to start
         // playing before displaying the high score.
-        AudioManager::PlayMusicAsync( MUS::VICTORY, true, true );
+        AudioManager::PlayMusicAsync( MUS::VICTORY, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
         return fheroes2::GameMode::HIGHSCORES_CAMPAIGN;
     }
 

--- a/src/fheroes2/game/game_credits.cpp
+++ b/src/fheroes2/game/game_credits.cpp
@@ -597,7 +597,7 @@ void Game::ShowCredits()
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    AudioManager::PlayMusicAsync( MUS::VICTORY, true, true );
+    AudioManager::PlayMusicAsync( MUS::VICTORY, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
 
     fheroes2::Image blackScreen( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
     blackScreen.fill( 0 );

--- a/src/fheroes2/game/game_credits.cpp
+++ b/src/fheroes2/game/game_credits.cpp
@@ -597,7 +597,7 @@ void Game::ShowCredits()
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    AudioManager::PlayMusicAsync( MUS::VICTORY, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
+    AudioManager::PlayMusicAsync( MUS::VICTORY, Music::PlaybackMode::REWIND_AND_PLAY_INFINITE );
 
     fheroes2::Image blackScreen( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
     blackScreen.fill( 0 );

--- a/src/fheroes2/game/game_credits.cpp
+++ b/src/fheroes2/game/game_credits.cpp
@@ -597,7 +597,7 @@ void Game::ShowCredits()
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    AudioManager::PlayMusic( MUS::VICTORY, true, true );
+    AudioManager::PlayMusicAsync( MUS::VICTORY, true, true );
 
     fheroes2::Image blackScreen( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
     blackScreen.fill( 0 );

--- a/src/fheroes2/game/game_loadgame.cpp
+++ b/src/fheroes2/game/game_loadgame.cpp
@@ -138,7 +138,7 @@ fheroes2::GameMode Game::LoadGame()
     // Stop all sounds, but not the music
     Mixer::Stop();
 
-    AudioManager::PlayMusic( MUS::MAINMENU, true, true );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, true );
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -237,7 +237,7 @@ fheroes2::GameMode Game::DisplayLoadGameDialog()
     // Stop all sounds, but not the music
     Mixer::Stop();
 
-    AudioManager::PlayMusic( MUS::MAINMENU, true, true );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, true );
 
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );

--- a/src/fheroes2/game/game_loadgame.cpp
+++ b/src/fheroes2/game/game_loadgame.cpp
@@ -138,7 +138,7 @@ fheroes2::GameMode Game::LoadGame()
     // Stop all sounds, but not the music
     Mixer::Stop();
 
-    AudioManager::PlayMusicAsync( MUS::MAINMENU, AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -237,7 +237,7 @@ fheroes2::GameMode Game::DisplayLoadGameDialog()
     // Stop all sounds, but not the music
     Mixer::Stop();
 
-    AudioManager::PlayMusicAsync( MUS::MAINMENU, AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
 
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );

--- a/src/fheroes2/game/game_loadgame.cpp
+++ b/src/fheroes2/game/game_loadgame.cpp
@@ -138,7 +138,7 @@ fheroes2::GameMode Game::LoadGame()
     // Stop all sounds, but not the music
     Mixer::Stop();
 
-    AudioManager::PlayMusicAsync( MUS::MAINMENU, true );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -237,7 +237,7 @@ fheroes2::GameMode Game::DisplayLoadGameDialog()
     // Stop all sounds, but not the music
     Mixer::Stop();
 
-    AudioManager::PlayMusicAsync( MUS::MAINMENU, true );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
 
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -170,7 +170,7 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
     // Stop all sounds, but not the music
     Mixer::Stop();
 
-    AudioManager::PlayMusicAsync( MUS::MAINMENU, AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
 
     Settings & conf = Settings::Get();
 

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -170,7 +170,7 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
     // Stop all sounds, but not the music
     Mixer::Stop();
 
-    AudioManager::PlayMusic( MUS::MAINMENU, true, true );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, true );
 
     Settings & conf = Settings::Get();
 

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -170,7 +170,7 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
     // Stop all sounds, but not the music
     Mixer::Stop();
 
-    AudioManager::PlayMusicAsync( MUS::MAINMENU, true );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
 
     Settings & conf = Settings::Get();
 

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -479,7 +479,7 @@ fheroes2::GameMode Game::NewGame()
     // Stop all sounds, but not the music
     Mixer::Stop();
 
-    AudioManager::PlayMusicAsync( MUS::MAINMENU, true );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
 
     // reset last save name
     Game::SetLastSavename( "" );

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -479,7 +479,7 @@ fheroes2::GameMode Game::NewGame()
     // Stop all sounds, but not the music
     Mixer::Stop();
 
-    AudioManager::PlayMusicAsync( MUS::MAINMENU, AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
 
     // reset last save name
     Game::SetLastSavename( "" );

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -479,7 +479,7 @@ fheroes2::GameMode Game::NewGame()
     // Stop all sounds, but not the music
     Mixer::Stop();
 
-    AudioManager::PlayMusic( MUS::MAINMENU, true, true );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, true );
 
     // reset last save name
     Game::SetLastSavename( "" );

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -96,7 +96,7 @@ namespace
             }
         }
 
-        AudioManager::PlayMusic( MUS::VICTORY, false );
+        AudioManager::PlayMusic( MUS::VICTORY, AudioManager::MusicPlaybackMode::PLAY_ONCE );
 
         if ( !body.empty() )
             Dialog::Message( "", body, Font::BIG, Dialog::OK );
@@ -152,7 +152,7 @@ namespace
             break;
         }
 
-        AudioManager::PlayMusic( MUS::LOSTGAME, false );
+        AudioManager::PlayMusic( MUS::LOSTGAME, AudioManager::MusicPlaybackMode::PLAY_ONCE );
 
         if ( !body.empty() )
             Dialog::Message( "", body, Font::BIG, Dialog::OK );
@@ -331,7 +331,7 @@ fheroes2::GameMode GameOver::Result::LocalCheckGameOver()
                     // TODO : Implement function that displays the last frame of win.smk and
                     // a dialog for name entry. AudioManager::PlayMusic is run here in order to start playing
                     // before displaying the high score.
-                    AudioManager::PlayMusicAsync( MUS::VICTORY, true, true );
+                    AudioManager::PlayMusicAsync( MUS::VICTORY, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
 
                     res = fheroes2::GameMode::HIGHSCORES_STANDARD;
 

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -331,7 +331,7 @@ fheroes2::GameMode GameOver::Result::LocalCheckGameOver()
                     // TODO : Implement function that displays the last frame of win.smk and
                     // a dialog for name entry. AudioManager::PlayMusic is run here in order to start playing
                     // before displaying the high score.
-                    AudioManager::PlayMusic( MUS::VICTORY, true, true );
+                    AudioManager::PlayMusicAsync( MUS::VICTORY, true, true );
 
                     res = fheroes2::GameMode::HIGHSCORES_STANDARD;
 

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -96,7 +96,7 @@ namespace
             }
         }
 
-        AudioManager::PlayMusic( MUS::VICTORY, AudioManager::MusicPlaybackMode::PLAY_ONCE );
+        AudioManager::PlayMusic( MUS::VICTORY, Music::PlaybackMode::PLAY_ONCE );
 
         if ( !body.empty() )
             Dialog::Message( "", body, Font::BIG, Dialog::OK );
@@ -152,7 +152,7 @@ namespace
             break;
         }
 
-        AudioManager::PlayMusic( MUS::LOSTGAME, AudioManager::MusicPlaybackMode::PLAY_ONCE );
+        AudioManager::PlayMusic( MUS::LOSTGAME, Music::PlaybackMode::PLAY_ONCE );
 
         if ( !body.empty() )
             Dialog::Message( "", body, Font::BIG, Dialog::OK );
@@ -331,7 +331,7 @@ fheroes2::GameMode GameOver::Result::LocalCheckGameOver()
                     // TODO : Implement function that displays the last frame of win.smk and
                     // a dialog for name entry. AudioManager::PlayMusic is run here in order to start playing
                     // before displaying the high score.
-                    AudioManager::PlayMusicAsync( MUS::VICTORY, AudioManager::MusicPlaybackMode::REWIND_AND_PLAY_INFINITE );
+                    AudioManager::PlayMusicAsync( MUS::VICTORY, Music::PlaybackMode::REWIND_AND_PLAY_INFINITE );
 
                     res = fheroes2::GameMode::HIGHSCORES_STANDARD;
 

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -399,7 +399,7 @@ fheroes2::GameMode Game::SelectScenario()
 
 fheroes2::GameMode Game::ScenarioInfo()
 {
-    AudioManager::PlayMusic( MUS::MAINMENU, true, true );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, true );
 
     const MapsFileInfoList lists = Maps::PrepareMapsFileInfoList( Settings::Get().IsGameType( Game::TYPE_MULTI ) );
     if ( lists.empty() ) {

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -399,7 +399,7 @@ fheroes2::GameMode Game::SelectScenario()
 
 fheroes2::GameMode Game::ScenarioInfo()
 {
-    AudioManager::PlayMusicAsync( MUS::MAINMENU, AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
 
     const MapsFileInfoList lists = Maps::PrepareMapsFileInfoList( Settings::Get().IsGameType( Game::TYPE_MULTI ) );
     if ( lists.empty() ) {

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -399,7 +399,7 @@ fheroes2::GameMode Game::SelectScenario()
 
 fheroes2::GameMode Game::ScenarioInfo()
 {
-    AudioManager::PlayMusicAsync( MUS::MAINMENU, true );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
 
     const MapsFileInfoList lists = Maps::PrepareMapsFileInfoList( Settings::Get().IsGameType( Game::TYPE_MULTI ) );
     if ( lists.empty() ) {

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -617,7 +617,7 @@ fheroes2::GameMode Interface::Basic::StartGame()
                 switch ( kingdom.GetControl() ) {
                 case CONTROL_HUMAN:
                     // reset environment sounds and music theme at the beginning of the human turn
-                    Game::SetCurrentMusic( MUS::UNKNOWN );
+                    Game::SetCurrentMusicTrack( MUS::UNKNOWN );
                     AudioManager::ResetAudio();
 
                     if ( conf.IsGameType( Game::TYPE_HOTSEAT ) ) {
@@ -655,7 +655,7 @@ fheroes2::GameMode Interface::Basic::StartGame()
                     }
 
                     // Reset environment sounds and music theme at the end of the human turn.
-                    Game::SetCurrentMusic( MUS::UNKNOWN );
+                    Game::SetCurrentMusicTrack( MUS::UNKNOWN );
                     AudioManager::ResetAudio();
 
                     break;

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -272,7 +272,7 @@ void ShowNewWeekDialog()
     // restore the original music on exit
     const Game::MusicRestorer musicRestorer;
 
-    AudioManager::PlayMusic( world.BeginMonth() ? MUS::NEW_MONTH : MUS::NEW_WEEK, false );
+    AudioManager::PlayMusic( world.BeginMonth() ? MUS::NEW_MONTH : MUS::NEW_WEEK, AudioManager::MusicPlaybackMode::PLAY_ONCE );
 
     const Week & week = world.GetWeekType();
 
@@ -633,7 +633,7 @@ fheroes2::GameMode Interface::Basic::StartGame()
                         // reset the music after closing the dialog
                         const Game::MusicRestorer musicRestorer;
 
-                        AudioManager::PlayMusic( MUS::NEW_MONTH, false );
+                        AudioManager::PlayMusic( MUS::NEW_MONTH, AudioManager::MusicPlaybackMode::PLAY_ONCE );
 
                         Game::DialogPlayers( player->GetColor(), _( "%{color} player's turn." ) );
                     }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -272,7 +272,7 @@ void ShowNewWeekDialog()
     // restore the original music on exit
     const Game::MusicRestorer musicRestorer;
 
-    AudioManager::PlayMusic( world.BeginMonth() ? MUS::NEW_MONTH : MUS::NEW_WEEK, AudioManager::MusicPlaybackMode::PLAY_ONCE );
+    AudioManager::PlayMusic( world.BeginMonth() ? MUS::NEW_MONTH : MUS::NEW_WEEK, Music::PlaybackMode::PLAY_ONCE );
 
     const Week & week = world.GetWeekType();
 
@@ -633,7 +633,7 @@ fheroes2::GameMode Interface::Basic::StartGame()
                         // reset the music after closing the dialog
                         const Game::MusicRestorer musicRestorer;
 
-                        AudioManager::PlayMusic( MUS::NEW_MONTH, AudioManager::MusicPlaybackMode::PLAY_ONCE );
+                        AudioManager::PlayMusic( MUS::NEW_MONTH, Music::PlaybackMode::PLAY_ONCE );
 
                         Game::DialogPlayers( player->GetColor(), _( "%{color} player's turn." ) );
                     }

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -57,7 +57,7 @@ void Interface::Basic::SetFocus( Heroes * hero )
         const int heroIndexPos = hero->GetIndex();
         if ( Game::UpdateSoundsOnFocusUpdate() && heroIndexPos >= 0 ) {
             Game::EnvironmentSoundMixer();
-            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), true );
+            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
         }
     }
 }
@@ -84,7 +84,8 @@ void Interface::Basic::SetFocus( Castle * castle )
 
         if ( Game::UpdateSoundsOnFocusUpdate() ) {
             Game::EnvironmentSoundMixer();
-            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( castle->GetIndex() ).GetGround() ), true );
+            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( castle->GetIndex() ).GetGround() ),
+                                          AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
         }
     }
 }

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -57,7 +57,7 @@ void Interface::Basic::SetFocus( Heroes * hero )
         const int heroIndexPos = hero->GetIndex();
         if ( Game::UpdateSoundsOnFocusUpdate() && heroIndexPos >= 0 ) {
             Game::EnvironmentSoundMixer();
-            AudioManager::PlayMusic( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), true, true );
+            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), true );
         }
     }
 }
@@ -84,7 +84,7 @@ void Interface::Basic::SetFocus( Castle * castle )
 
         if ( Game::UpdateSoundsOnFocusUpdate() ) {
             Game::EnvironmentSoundMixer();
-            AudioManager::PlayMusic( MUS::FromGround( world.GetTiles( castle->GetIndex() ).GetGround() ), true, true );
+            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( castle->GetIndex() ).GetGround() ), true );
         }
     }
 }

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -57,7 +57,7 @@ void Interface::Basic::SetFocus( Heroes * hero )
         const int heroIndexPos = hero->GetIndex();
         if ( Game::UpdateSoundsOnFocusUpdate() && heroIndexPos >= 0 ) {
             Game::EnvironmentSoundMixer();
-            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
         }
     }
 }
@@ -84,8 +84,7 @@ void Interface::Basic::SetFocus( Castle * castle )
 
         if ( Game::UpdateSoundsOnFocusUpdate() ) {
             Game::EnvironmentSoundMixer();
-            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( castle->GetIndex() ).GetGround() ),
-                                          AudioManager::MusicPlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( castle->GetIndex() ).GetGround() ), Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
         }
     }
 }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -256,7 +256,7 @@ void Heroes::Action( int tileIndex, bool isDestination )
     const MP2::MapObjectType objectType = tile.GetObject( tileIndex != GetIndex() );
 
     if ( MUS::FromMapObject( objectType ) != MUS::UNKNOWN )
-        AudioManager::PlayMusic( MUS::FromMapObject( objectType ), false );
+        AudioManager::PlayMusic( MUS::FromMapObject( objectType ), AudioManager::MusicPlaybackMode::PLAY_ONCE );
 
     if ( MP2::isActionObject( objectType, isShipMaster() ) ) {
         Interface::StatusWindow::ResetTimer();
@@ -956,7 +956,7 @@ void ActionToObjectResource( Heroes & hero, const MP2::MapObjectType objectType,
     if ( rc.isValid() ) {
         // The Magic Garden has a special sound
         if ( !Settings::Get().MusicMIDI() && objectType == MP2::OBJ_MAGICGARDEN ) {
-            AudioManager::PlayMusic( MUS::TREEHOUSE, false );
+            AudioManager::PlayMusic( MUS::TREEHOUSE, AudioManager::MusicPlaybackMode::PLAY_ONCE );
         }
         // The Lean-To has a special sound
         else if ( objectType == MP2::OBJ_LEANTO ) {
@@ -1643,7 +1643,7 @@ void ActionToExperienceObject( Heroes & hero, const MP2::MapObjectType objectTyp
             AudioManager::PlaySound( M82::EXPERNCE );
         }
         else {
-            AudioManager::PlayMusic( MUS::EXPERIENCE, false );
+            AudioManager::PlayMusic( MUS::EXPERIENCE, AudioManager::MusicPlaybackMode::PLAY_ONCE );
         }
 
         const fheroes2::ExperienceDialogElement experienceUI( exp );
@@ -2410,7 +2410,7 @@ void ActionToArtesianSpring( Heroes & hero, const MP2::MapObjectType objectType,
             AudioManager::PlaySound( M82::EXPERNCE );
         }
         else {
-            AudioManager::PlayMusic( MUS::WATERSPRING, false );
+            AudioManager::PlayMusic( MUS::WATERSPRING, AudioManager::MusicPlaybackMode::PLAY_ONCE );
         }
         hero.SetSpellPoints( max * 2 );
         Dialog::Message( name, _( "A drink from the spring fills your blood with magic! You have twice your normal spell points in reserve." ), Font::BIG, Dialog::OK );
@@ -2591,7 +2591,7 @@ void ActionToUpgradeArmyObject( Heroes & hero, const MP2::MapObjectType objectTy
 
         // The Hill Fort has a special sound
         if ( objectType == MP2::OBJ_HILLFORT ) {
-            AudioManager::PlayMusic( MUS::HILLFORT, false );
+            AudioManager::PlayMusic( MUS::HILLFORT, AudioManager::MusicPlaybackMode::PLAY_ONCE );
         }
 
         const fheroes2::CustomImageDialogElement imageUI( std::move( surface ) );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -256,7 +256,7 @@ void Heroes::Action( int tileIndex, bool isDestination )
     const MP2::MapObjectType objectType = tile.GetObject( tileIndex != GetIndex() );
 
     if ( MUS::FromMapObject( objectType ) != MUS::UNKNOWN )
-        AudioManager::PlayMusic( MUS::FromMapObject( objectType ), AudioManager::MusicPlaybackMode::PLAY_ONCE );
+        AudioManager::PlayMusic( MUS::FromMapObject( objectType ), Music::PlaybackMode::PLAY_ONCE );
 
     if ( MP2::isActionObject( objectType, isShipMaster() ) ) {
         Interface::StatusWindow::ResetTimer();
@@ -956,7 +956,7 @@ void ActionToObjectResource( Heroes & hero, const MP2::MapObjectType objectType,
     if ( rc.isValid() ) {
         // The Magic Garden has a special sound
         if ( !Settings::Get().MusicMIDI() && objectType == MP2::OBJ_MAGICGARDEN ) {
-            AudioManager::PlayMusic( MUS::TREEHOUSE, AudioManager::MusicPlaybackMode::PLAY_ONCE );
+            AudioManager::PlayMusic( MUS::TREEHOUSE, Music::PlaybackMode::PLAY_ONCE );
         }
         // The Lean-To has a special sound
         else if ( objectType == MP2::OBJ_LEANTO ) {
@@ -1643,7 +1643,7 @@ void ActionToExperienceObject( Heroes & hero, const MP2::MapObjectType objectTyp
             AudioManager::PlaySound( M82::EXPERNCE );
         }
         else {
-            AudioManager::PlayMusic( MUS::EXPERIENCE, AudioManager::MusicPlaybackMode::PLAY_ONCE );
+            AudioManager::PlayMusic( MUS::EXPERIENCE, Music::PlaybackMode::PLAY_ONCE );
         }
 
         const fheroes2::ExperienceDialogElement experienceUI( exp );
@@ -2410,7 +2410,7 @@ void ActionToArtesianSpring( Heroes & hero, const MP2::MapObjectType objectType,
             AudioManager::PlaySound( M82::EXPERNCE );
         }
         else {
-            AudioManager::PlayMusic( MUS::WATERSPRING, AudioManager::MusicPlaybackMode::PLAY_ONCE );
+            AudioManager::PlayMusic( MUS::WATERSPRING, Music::PlaybackMode::PLAY_ONCE );
         }
         hero.SetSpellPoints( max * 2 );
         Dialog::Message( name, _( "A drink from the spring fills your blood with magic! You have twice your normal spell points in reserve." ), Font::BIG, Dialog::OK );
@@ -2591,7 +2591,7 @@ void ActionToUpgradeArmyObject( Heroes & hero, const MP2::MapObjectType objectTy
 
         // The Hill Fort has a special sound
         if ( objectType == MP2::OBJ_HILLFORT ) {
-            AudioManager::PlayMusic( MUS::HILLFORT, AudioManager::MusicPlaybackMode::PLAY_ONCE );
+            AudioManager::PlayMusic( MUS::HILLFORT, Music::PlaybackMode::PLAY_ONCE );
         }
 
         const fheroes2::CustomImageDialogElement imageUI( std::move( surface ) );

--- a/src/fheroes2/kingdom/puzzle.cpp
+++ b/src/fheroes2/kingdom/puzzle.cpp
@@ -104,7 +104,7 @@ void Puzzle::ShowMapsDialog() const
     // restore the original music on exit
     const Game::MusicRestorer musicRestorer;
 
-    AudioManager::PlayMusic( MUS::PUZZLE, false );
+    AudioManager::PlayMusic( MUS::PUZZLE, AudioManager::MusicPlaybackMode::PLAY_ONCE );
 
     if ( display.isDefaultSize() && !Settings::Get().ExtGameHideInterface() )
         ShowStandardDialog( *this, sf );

--- a/src/fheroes2/kingdom/puzzle.cpp
+++ b/src/fheroes2/kingdom/puzzle.cpp
@@ -104,7 +104,7 @@ void Puzzle::ShowMapsDialog() const
     // restore the original music on exit
     const Game::MusicRestorer musicRestorer;
 
-    AudioManager::PlayMusic( MUS::PUZZLE, AudioManager::MusicPlaybackMode::PLAY_ONCE );
+    AudioManager::PlayMusic( MUS::PUZZLE, Music::PlaybackMode::PLAY_ONCE );
 
     if ( display.isDefaultSize() && !Settings::Get().ExtGameHideInterface() )
         ShowStandardDialog( *this, sf );

--- a/src/tools/extractor-vs2017.vcxproj
+++ b/src/tools/extractor-vs2017.vcxproj
@@ -186,6 +186,7 @@
     <ClCompile Include="..\engine\serialize.cpp" />
     <ClCompile Include="..\engine\smk_decoder.cpp" />
     <ClCompile Include="..\engine\system.cpp" />
+    <ClCompile Include="..\engine\thread.cpp" />
     <ClCompile Include="..\engine\timing.cpp" />
     <ClCompile Include="..\engine\tinyconfig.cpp" />
     <ClCompile Include="..\engine\tools.cpp" />
@@ -214,6 +215,7 @@
     <ClInclude Include="..\engine\serialize.h" />
     <ClInclude Include="..\engine\smk_decoder.h" />
     <ClInclude Include="..\engine\system.h" />
+    <ClInclude Include="..\engine\thread.h" />
     <ClInclude Include="..\engine\timing.h" />
     <ClInclude Include="..\engine\tinyconfig.h" />
     <ClInclude Include="..\engine\tools.h" />

--- a/src/tools/extractor-vs2019.vcxproj
+++ b/src/tools/extractor-vs2019.vcxproj
@@ -186,6 +186,7 @@
     <ClCompile Include="..\engine\serialize.cpp" />
     <ClCompile Include="..\engine\smk_decoder.cpp" />
     <ClCompile Include="..\engine\system.cpp" />
+    <ClCompile Include="..\engine\thread.cpp" />
     <ClCompile Include="..\engine\timing.cpp" />
     <ClCompile Include="..\engine\tinyconfig.cpp" />
     <ClCompile Include="..\engine\tools.cpp" />
@@ -214,6 +215,7 @@
     <ClInclude Include="..\engine\serialize.h" />
     <ClInclude Include="..\engine\smk_decoder.h" />
     <ClInclude Include="..\engine\system.h" />
+    <ClInclude Include="..\engine\thread.h" />
     <ClInclude Include="..\engine\timing.h" />
     <ClInclude Include="..\engine\tinyconfig.h" />
     <ClInclude Include="..\engine\tools.h" />

--- a/src/tools/icn2img-vs2017.vcxproj
+++ b/src/tools/icn2img-vs2017.vcxproj
@@ -186,6 +186,7 @@
     <ClCompile Include="..\engine\serialize.cpp" />
     <ClCompile Include="..\engine\smk_decoder.cpp" />
     <ClCompile Include="..\engine\system.cpp" />
+    <ClCompile Include="..\engine\thread.cpp" />
     <ClCompile Include="..\engine\timing.cpp" />
     <ClCompile Include="..\engine\tinyconfig.cpp" />
     <ClCompile Include="..\engine\tools.cpp" />
@@ -214,6 +215,7 @@
     <ClInclude Include="..\engine\serialize.h" />
     <ClInclude Include="..\engine\smk_decoder.h" />
     <ClInclude Include="..\engine\system.h" />
+    <ClInclude Include="..\engine\thread.h" />
     <ClInclude Include="..\engine\timing.h" />
     <ClInclude Include="..\engine\tinyconfig.h" />
     <ClInclude Include="..\engine\tools.h" />

--- a/src/tools/icn2img-vs2019.vcxproj
+++ b/src/tools/icn2img-vs2019.vcxproj
@@ -186,6 +186,7 @@
     <ClCompile Include="..\engine\serialize.cpp" />
     <ClCompile Include="..\engine\smk_decoder.cpp" />
     <ClCompile Include="..\engine\system.cpp" />
+    <ClCompile Include="..\engine\thread.cpp" />
     <ClCompile Include="..\engine\timing.cpp" />
     <ClCompile Include="..\engine\tinyconfig.cpp" />
     <ClCompile Include="..\engine\tools.cpp" />
@@ -214,6 +215,7 @@
     <ClInclude Include="..\engine\serialize.h" />
     <ClInclude Include="..\engine\smk_decoder.h" />
     <ClInclude Include="..\engine\system.h" />
+    <ClInclude Include="..\engine\thread.h" />
     <ClInclude Include="..\engine\timing.h" />
     <ClInclude Include="..\engine\tinyconfig.h" />
     <ClInclude Include="..\engine\tools.h" />


### PR DESCRIPTION
Add Music resume ability for **MP3**, **OGG** and **FLAC** tracks. MIDI tracks are much more complex so I left them untouched but the code is ready for them as well.

relates to #5047 
close #5255 since the only concern not to use SDL was inability to restart tracks from random places.