### PR TITLE
Minor fixes for the music continuation feature

### DIFF
--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -292,7 +292,8 @@ namespace
 
         // We are here because a track in the PLAY_ONCE mode has finished playing
         if ( musicSettings.currentTrackPlaybackMode == Music::PlaybackMode::PLAY_ONCE ) {
-            // Since this track has finished playing, we will not be able to resume it with all our desire
+            // We cannot resume this track, but in future we should be able to play it in the
+            // RESUME_AND_PLAY_INFINITE mode if necessary, so reset its position to zero
             musicSettings.currentTrack.position = 0;
             musicSettings.trackManager.update( musicSettings.currentTrackUID, musicSettings.currentTrack );
             musicSettings.resetCurrentTrack();
@@ -365,6 +366,7 @@ namespace
                 resumePlayback = true;
             }
             else {
+                // It is impossible to resume this track, let's reflect it by changing the playback mode
                 playbackMode = Music::PlaybackMode::REWIND_AND_PLAY_INFINITE;
                 autoLoop = true;
             }
@@ -914,21 +916,14 @@ void Music::Stop()
         return;
     }
 
-    // We can resume this track in the RESUME_AND_PLAY_INFINITE mode if desired
-    if ( musicSettings.currentTrackPlaybackMode == PlaybackMode::PLAY_ONCE ) {
-        musicSettings.currentTrack.position = musicSettings.trackManager.getCurrentTrackPosition();
-    }
-    // We can resume this track as well - that's what it's designed for
-    else if ( musicSettings.currentTrackPlaybackMode == PlaybackMode::RESUME_AND_PLAY_INFINITE ) {
+    // We can resume this track, so let's remember the current position
+    if ( musicSettings.currentTrackPlaybackMode == PlaybackMode::RESUME_AND_PLAY_INFINITE ) {
         musicSettings.currentTrack.position += musicSettings.trackManager.getCurrentTrackPosition();
     }
-    // We cannot reliably resume this track
-    else if ( musicSettings.currentTrackPlaybackMode == PlaybackMode::REWIND_AND_PLAY_INFINITE ) {
-        musicSettings.currentTrack.position = 0;
-    }
-    // Unknown playback mode
+    // We cannot resume this track, but in future we should be able to play it in the
+    // RESUME_AND_PLAY_INFINITE mode if necessary, so reset its position to zero
     else {
-        assert( 0 );
+        musicSettings.currentTrack.position = 0;
     }
 
     musicSettings.trackManager.update( musicSettings.currentTrackUID, musicSettings.currentTrack );

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -236,7 +236,6 @@ namespace
         uint64_t currentTrackChangeCounter{ 0 };
 
         int fadeInMs{ 0 };
-        int fadeOutMs{ 0 };
 
         MusicTrackManager trackManager;
     };
@@ -892,15 +891,8 @@ void Music::Stop()
     musicSettings.currentTrackPlaybackMode = PlaybackMode::PLAY_ONCE;
     musicSettings.currentTrackChangeCounter += 1;
 
-    if ( musicSettings.fadeOutMs > 0 ) {
-        while ( !Mix_FadeOutMusic( musicSettings.fadeOutMs ) && Mix_PlayingMusic() ) {
-            SDL_Delay( 50 );
-        }
-    }
-    else {
-        // According to the documentation (https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer.html#SEC67) this function always returns 0.
-        Mix_HaltMusic();
-    }
+    // According to the documentation (https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer.html#SEC67) this function always returns 0.
+    Mix_HaltMusic();
 }
 
 bool Music::isPlaying()

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -317,7 +317,7 @@ namespace
         return ( musicType == Mix_MusicType::MUS_OGG ) || ( musicType == Mix_MusicType::MUS_MP3 ) || ( musicType == Mix_MusicType::MUS_FLAC );
     }
 
-    void PlayMusic( const uint64_t musicUID, const Music::PlaybackMode playbackMode )
+    void PlayMusic( const uint64_t musicUID, Music::PlaybackMode playbackMode )
     {
         MusicInfo musicInfo = musicSettings.trackManager.getMusicInfoByUID( musicUID );
         if ( musicInfo.mix == nullptr ) {
@@ -330,8 +330,21 @@ namespace
             Music::Stop();
         }
 
-        const bool resumePlayback = ( playbackMode == Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE && isMusicResumeSupported( musicInfo.mix ) );
-        const bool autoLoop = ( playbackMode != Music::PlaybackMode::PLAY_ONCE && !resumePlayback );
+        bool resumePlayback = false;
+        bool autoLoop = false;
+
+        if ( playbackMode == Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE ) {
+            if ( isMusicResumeSupported( musicInfo.mix ) ) {
+                resumePlayback = true;
+            }
+            else {
+                playbackMode = Music::PlaybackMode::REWIND_AND_PLAY_INFINITE;
+                autoLoop = true;
+            }
+        }
+        else if ( playbackMode == Music::PlaybackMode::REWIND_AND_PLAY_INFINITE ) {
+            autoLoop = true;
+        }
 
         const int loopCount = autoLoop ? -1 : 0;
 

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -102,6 +102,9 @@ namespace
     {
         const std::lock_guard<std::recursive_mutex> audioGuard( audioMutex );
 
+        // This callback function should not be called if audio is not initialized
+        assert( isInitialized );
+
         Mix_Chunk * sample = Mix_GetChunk( channelId );
 
         if ( sample ) {
@@ -281,9 +284,8 @@ namespace
 
         const std::lock_guard<std::recursive_mutex> audioGuard( audioMutex );
 
-        if ( !isInitialized ) {
-            return;
-        }
+        // This callback function should not be called if audio is not initialized
+        assert( isInitialized );
 
         // We are here because of the Music::Stop() call
         if ( musicSettings.currentTrack.mix == nullptr ) {
@@ -296,6 +298,7 @@ namespace
             // RESUME_AND_PLAY_INFINITE mode if necessary, so reset its position to zero
             musicSettings.currentTrack.position = 0;
             musicSettings.trackManager.update( musicSettings.currentTrackUID, musicSettings.currentTrack );
+            // We should be able to restart this track right away if necessary
             musicSettings.resetCurrentTrack();
 
             return;
@@ -550,7 +553,6 @@ void Audio::Quit()
     Mixer::Stop();
 
     musicSettings.trackManager.clear();
-    musicSettings.resetCurrentTrack();
 
     Mix_CloseAudio();
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -323,7 +323,6 @@ namespace
                 }
 
                 assert( musicSettings.currentTrackPlaybackMode == Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
-                assert( musicSettings.currentTrack.mix != nullptr );
 
                 musicSettings.currentTrack.position = 0;
                 musicSettings.trackManager.update( musicSettings.currentTrackUID, musicSettings.currentTrack );

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -247,7 +247,7 @@ namespace
     // This mutex protects the musicLooperThread
     std::mutex musicLooperMutex;
 
-    void PlayMusic( const uint64_t musicUID, const Music::PlaybackMode playbackMode );
+    void PlayMusic( const uint64_t musicUID, Music::PlaybackMode playbackMode );
 
     // This is the callback function set by Mix_HookMusicFinished()
     void replayCurrentMusic()

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -297,7 +297,7 @@ namespace
         }
 
         // REWIND_AND_PLAY_INFINITE should be handled by the Mix_PlayMusic() itself
-        assert( musicSettings.currentTrackPlaybackMode == Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+        assert( musicSettings.currentTrackPlaybackMode == Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 
         // Mix_HookMusicFinished() function does not allow any SDL calls to be done within the assigned function.
         // In this case the only way to trigger the restart of the current song is to use a multithreading approach.
@@ -314,7 +314,7 @@ namespace
                     return;
                 }
 
-                assert( musicSettings.currentTrackPlaybackMode == Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+                assert( musicSettings.currentTrackPlaybackMode == Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
                 assert( musicSettings.currentTrack.mix != nullptr );
 
                 musicSettings.currentTrack.position = 0;
@@ -346,7 +346,7 @@ namespace
         bool resumePlayback = false;
         bool autoLoop = false;
 
-        if ( playbackMode == Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE ) {
+        if ( playbackMode == Music::PlaybackMode::RESUME_AND_PLAY_INFINITE ) {
             if ( isMusicResumeSupported( musicInfo.mix ) ) {
                 resumePlayback = true;
             }

--- a/src/engine/audio.h
+++ b/src/engine/audio.h
@@ -66,7 +66,7 @@ namespace Music
     enum class PlaybackMode : uint8_t
     {
         PLAY_ONCE,
-        CONTINUE_TO_PLAY_INFINITE,
+        RESUME_AND_PLAY_INFINITE,
         REWIND_AND_PLAY_INFINITE
     };
 

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -272,7 +272,7 @@ namespace AI
         Interface::StatusWindow & status = Interface::Basic::Get().GetStatusWindow();
         status.RedrawTurnProgress( 0 );
 
-        AudioManager::PlayMusicAsync( MUS::COMPUTER_TURN, Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+        AudioManager::PlayMusicAsync( MUS::COMPUTER_TURN, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 
         KingdomHeroes & heroes = kingdom.GetHeroes();
         const KingdomCastles & castles = kingdom.GetCastles();

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -258,7 +258,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readOnly, const b
 
     const fheroes2::StandardWindow background( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
 
-    AudioManager::PlayMusicAsync( MUS::FromRace( race ), Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+    AudioManager::PlayMusicAsync( MUS::FromRace( race ), Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 
     int alphaHero = 255;
     CastleDialog::FadeBuilding fadeBuilding;

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -481,7 +481,7 @@ void Game::restoreSoundsForCurrentFocus()
         const int heroIndexPos = focusedHero->GetIndex();
         if ( heroIndexPos >= 0 ) {
             Game::EnvironmentSoundMixer();
-            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
         }
         break;
     }
@@ -491,7 +491,7 @@ void Game::restoreSoundsForCurrentFocus()
         assert( focusedCastle != nullptr );
 
         Game::EnvironmentSoundMixer();
-        AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( focusedCastle->GetIndex() ).GetGround() ), Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+        AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( focusedCastle->GetIndex() ).GetGround() ), Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
         break;
     }
 

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -146,7 +146,7 @@ namespace Game
             }
 
             // It is assumed that the previous track was looped and does not require to be played from the beginning.
-            AudioManager::PlayMusicAsync( _music, Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+            AudioManager::PlayMusicAsync( _music, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
         }
 
         MusicRestorer & operator=( const MusicRestorer & ) = delete;

--- a/src/fheroes2/game/game_loadgame.cpp
+++ b/src/fheroes2/game/game_loadgame.cpp
@@ -138,7 +138,7 @@ fheroes2::GameMode Game::LoadGame()
     // Stop all sounds, but not the music
     Mixer::Stop();
 
-    AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -237,7 +237,7 @@ fheroes2::GameMode Game::DisplayLoadGameDialog()
     // Stop all sounds, but not the music
     Mixer::Stop();
 
-    AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -170,7 +170,7 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
     // Stop all sounds, but not the music
     Mixer::Stop();
 
-    AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 
     Settings & conf = Settings::Get();
 

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -479,7 +479,7 @@ fheroes2::GameMode Game::NewGame()
     // Stop all sounds, but not the music
     Mixer::Stop();
 
-    AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 
     // reset last save name
     Game::SetLastSavename( "" );

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -399,7 +399,7 @@ fheroes2::GameMode Game::SelectScenario()
 
 fheroes2::GameMode Game::ScenarioInfo()
 {
-    AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+    AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 
     const MapsFileInfoList lists = Maps::PrepareMapsFileInfoList( Settings::Get().IsGameType( Game::TYPE_MULTI ) );
     if ( lists.empty() ) {

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -57,7 +57,7 @@ void Interface::Basic::SetFocus( Heroes * hero )
         const int heroIndexPos = hero->GetIndex();
         if ( Game::UpdateSoundsOnFocusUpdate() && heroIndexPos >= 0 ) {
             Game::EnvironmentSoundMixer();
-            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
         }
     }
 }
@@ -84,7 +84,7 @@ void Interface::Basic::SetFocus( Castle * castle )
 
         if ( Game::UpdateSoundsOnFocusUpdate() ) {
             Game::EnvironmentSoundMixer();
-            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( castle->GetIndex() ).GetGround() ), Music::PlaybackMode::CONTINUE_TO_PLAY_INFINITE );
+            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( castle->GetIndex() ).GetGround() ), Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
         }
     }
 }


### PR DESCRIPTION
Follow-up to #5505

* If `playbackMode` is `CONTINUE_TO_PLAY_INFINITE`, but track type doesn't support the playback continuation, convert playbackMode to the `REWIND_AND_PLAY_INFINITE` just in case - to avoid the temptation of `replayCurrentMusic()` to restart it even if the track type is not restartable. Currently it shouldn't happen though, but `replayCurrentMusic()` doesn't check the track type, just the playback mode.

* Remove music fadeout support: first of all, it is unused, and also it deadlocks with the current approach by the following scheme:

1. `Music::Stop()` acquires `audioMutex`;
2. `Music::Stop()` calls `Mix_FadeOutMusic()`, which eventually (when the music is finally stopped) leads to the call of the `replayCurrentMusic()` from the different thread (thread started by the `SDL_Mixer` for the music playback);
3. `replayCurrentMusic()` waits on the `audioMutex` in a different thread;
4. Either `Mix_FadeOutMusic()` or `Mix_PlayingMusic()` are not able to return until callback is not finished;
5. Deadlock!

* If music, which was started in the `PLAY_ONCE` mode, finishes without being forcibly stopped, it should be able to start the same music track right away. Before this PR this wasn't the case.

* It should be able to play the same track using the `RESUME_AND_PLAY_INFINITE` -> any other mode -> `RESUME_AND_PLAY_INFINITE` sequence of modes. Before this PR the track was restarted from an improper position during the second playback in the `RESUME_AND_PLAY_INFINITE` mode.