### PR TITLE
Rework the music resume logic, replace std::lock_guard by std::scoped_lock

### DIFF
--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -258,8 +258,8 @@ namespace
 
     void playMusic( const uint64_t musicUID, Music::PlaybackMode playbackMode )
     {
-        // Unregister this callback to ensure that it will not be called while we are
-        // modifying the current track information
+        // Unregister this callback to ensure that it will not be called while we are modifying the
+        // current track information
         Mix_HookMusicFinished( nullptr );
 
         MusicInfo musicInfo = musicSettings.trackManager.getMusicInfoByUID( musicUID );
@@ -289,7 +289,8 @@ namespace
         // Should be updated before the callback set by Mix_HookMusicFinished() will get a chance to be called
         musicSettings.updateCurrentTrack( musicInfo, musicUID, playbackMode );
 
-        // Once we are done with the current track information, let's register this callback back if needed
+        // Once we are done with the current track information, let's register this callback back. We need this
+        // callback only when resuming the music track, because there is no other way to loop such a track.
         if ( playbackMode == Music::PlaybackMode::RESUME_AND_PLAY_INFINITE ) {
             Mix_HookMusicFinished( musicFinished );
         }
@@ -813,12 +814,11 @@ void Music::Stop()
         return;
     }
 
+    // Unregister this callback - there is no need to repeat this track anymore
+    Mix_HookMusicFinished( nullptr );
+
     // Always returns 0
     Mix_HaltMusic();
-
-    // Unregister this callback to ensure that it will not be called while we are
-    // modifying the current track information
-    Mix_HookMusicFinished( nullptr );
 
     // We can resume this track, so let's remember the current position
     if ( musicSettings.currentTrackPlaybackMode == PlaybackMode::RESUME_AND_PLAY_INFINITE ) {

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -262,7 +262,7 @@ namespace
         // current track information
         Mix_HookMusicFinished( nullptr );
 
-        MusicInfo musicInfo = musicSettings.trackManager.getMusicInfoByUID( musicUID );
+        const MusicInfo musicInfo = musicSettings.trackManager.getMusicInfoByUID( musicUID );
         if ( musicInfo.mix == nullptr ) {
             // How is it even possible! Check your logic!
             assert( 0 );

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -451,7 +451,6 @@ void Audio::Quit()
     Mixer::Stop();
 
     Mix_ChannelFinished( nullptr );
-    Mix_HookMusicFinished( nullptr );
 
     musicSettings.trackManager.clear();
 

--- a/src/engine/audio.h
+++ b/src/engine/audio.h
@@ -47,9 +47,9 @@ namespace Mixer
 
     // To play the audio in a new channel set its value to -1. Returns channel ID. A negative value (-1) in case of failure.
     int Play( const uint8_t * ptr, const uint32_t size, const int channelId, const bool loop );
-    int PlayFromDistance( const uint8_t * ptr, const uint32_t size, const int channelId, const bool loop, const int16_t angle, uint8_t volumePercentage );
+    int PlayFromDistance( const uint8_t * ptr, const uint32_t size, const int channelId, const bool loop, const int16_t angle, const uint8_t volumePercentage );
 
-    int applySoundEffect( const int channelId, const int16_t angle, uint8_t volumePercentage );
+    int applySoundEffect( const int channelId, const int16_t angle, const uint8_t volumePercentage );
 
     // Returns the previous volume percentage value.
     int setVolume( const int channelId, const int volumePercentage );
@@ -83,7 +83,7 @@ namespace Music
     // Returns the previous volume percentage value.
     int setVolume( const int volumePercentage );
 
-    void SetFadeInMs( const int timeInMs );
+    void SetFadeInMs( const int timeMs );
 
     void Stop();
 

--- a/src/engine/thread.h
+++ b/src/engine/thread.h
@@ -43,7 +43,7 @@ namespace MultiThreading
     protected:
         std::mutex _mutex;
 
-        void _createThreadIfNeeded();
+        void createThreadIfNeeded();
 
         void notifyThread();
 

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -218,9 +218,9 @@ namespace
     public:
         void pushMusic( const int musicId, const MusicSource musicType, const Music::PlaybackMode playbackMode )
         {
-            _createThreadIfNeeded();
+            createThreadIfNeeded();
 
-            std::lock_guard<std::mutex> mutexLock( _mutex );
+            std::scoped_lock<std::mutex> lock( _mutex );
 
             while ( !_musicTasks.empty() ) {
                 _musicTasks.pop();
@@ -233,9 +233,9 @@ namespace
 
         void pushSound( const int m82Sound, const int soundVolume )
         {
-            _createThreadIfNeeded();
+            createThreadIfNeeded();
 
-            std::lock_guard<std::mutex> mutexLock( _mutex );
+            std::scoped_lock<std::mutex> lock( _mutex );
 
             _soundTasks.emplace( m82Sound, soundVolume );
 
@@ -244,9 +244,9 @@ namespace
 
         void pushLoopSound( std::map<M82::SoundType, std::vector<AudioManager::AudioLoopEffectInfo>> vols, const int soundVolume, const bool is3DAudioEnabled )
         {
-            _createThreadIfNeeded();
+            createThreadIfNeeded();
 
-            std::lock_guard<std::mutex> mutexLock( _mutex );
+            std::scoped_lock<std::mutex> lock( _mutex );
 
             _loopSoundTasks.emplace( std::move( vols ), soundVolume, is3DAudioEnabled );
 
@@ -255,7 +255,7 @@ namespace
 
         void sync()
         {
-            std::lock_guard<std::mutex> mutexLock( _mutex );
+            std::scoped_lock<std::mutex> lock( _mutex );
 
             while ( !_musicTasks.empty() ) {
                 _musicTasks.pop();
@@ -428,7 +428,7 @@ namespace
 
     void PlaySoundInternally( const int m82, const int soundVolume )
     {
-        std::lock_guard<std::mutex> mutexLock( g_asyncSoundManager.resourceMutex() );
+        std::scoped_lock<std::mutex> lock( g_asyncSoundManager.resourceMutex() );
 
         DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "Try to play sound " << M82::GetString( m82 ) )
 
@@ -463,7 +463,7 @@ namespace
 
         const uint64_t musicUID = getMusicUID( trackId, musicType );
 
-        std::lock_guard<std::mutex> mutexLock( g_asyncSoundManager.resourceMutex() );
+        std::scoped_lock<std::mutex> lock( g_asyncSoundManager.resourceMutex() );
 
         if ( Game::CurrentMusicTrackId() == trackId && Music::isPlaying() ) {
             return;
@@ -566,7 +566,7 @@ namespace
     void playLoopSoundsInternally( std::map<M82::SoundType, std::vector<AudioManager::AudioLoopEffectInfo>> soundEffects, const int soundVolume,
                                    const bool is3DAudioEnabled )
     {
-        std::lock_guard<std::mutex> mutexLock( g_asyncSoundManager.resourceMutex() );
+        std::scoped_lock<std::mutex> lock( g_asyncSoundManager.resourceMutex() );
 
         if ( soundVolume == 0 ) {
             // The volume is 0. Remove all existing sound effects.
@@ -842,7 +842,7 @@ namespace AudioManager
 
         g_asyncSoundManager.sync();
 
-        std::lock_guard<std::mutex> mutexLock( g_asyncSoundManager.resourceMutex() );
+        std::scoped_lock<std::mutex> lock( g_asyncSoundManager.resourceMutex() );
 
         Music::Stop();
         Mixer::Stop();

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -270,7 +270,7 @@ namespace
             }
         }
 
-        // This mutex is used to avoid access to global objects and classes related to SDL Mixer.
+        // This mutex protects operations with AudioManager's resources, such as AGG files, data caches, etc
         std::mutex & resourceMutex()
         {
             return _resourceMutex;


### PR DESCRIPTION
I believe that this is much more stable (and also a bit simpler I think) implementation, current implementation in `master` branch is  deadlock-prone because of acquiring audio mutexes in `SDL_Mixer` callbacks. Implementation from this PR doesn't acquire any mutexes in callbacks and, as far as I can tell, works well and is much more suitable for the new release - we don't want our users to suffer. But it still needs to be extensively tested, if possible.

Also I heeded to persistent recommendations from SonarCloud and replaced `std::lock_guard` by `std::scoped_lock` from C++17. Honestly, if there is no need to safely acquire multiple locks at the same time, I'd prefer old `std::lock_guard`, because due to the variadic nature of `scoped_lock`'s constructor you can easily make a mistake and write like this:

```cpp
std::scoped_lock lock;
```

which is no-op. `lock_guard` will not allow this.