### PR TITLE
Nintendo Switch: protect the logfile with mutex

### DIFF
--- a/src/engine/logging.cpp
+++ b/src/engine/logging.cpp
@@ -73,6 +73,8 @@ namespace Logging
 {
 #if defined( TARGET_NINTENDO_SWITCH )
     std::ofstream logFile;
+    // This mutex protects operations with logFile
+    std::mutex logMutex;
 #endif
 
     const char * GetDebugOptionName( const int name )
@@ -108,6 +110,8 @@ namespace Logging
     void InitLog()
     {
 #if defined( TARGET_NINTENDO_SWITCH )
+        const std::scoped_lock<std::mutex> lock( logMutex );
+
         logFile.open( "fheroes2.log", std::ofstream::out );
 #elif defined( MACOS_APP_BUNDLE )
         openlog( "fheroes2", LOG_CONS | LOG_NDELAY, LOG_USER );

--- a/src/engine/logging.h
+++ b/src/engine/logging.h
@@ -84,14 +84,19 @@ namespace Logging
 
 #if defined( TARGET_NINTENDO_SWITCH )
 #include <fstream>
+#include <mutex>
 
 namespace Logging
 {
     extern std::ofstream logFile;
+    // This mutex protects operations with logFile
+    extern std::mutex logMutex;
 }
 
 #define COUT( x )                                                                                                                                                        \
     {                                                                                                                                                                    \
+        const std::scoped_lock<std::mutex> _logfile_lock( Logging::logMutex ); /* The name was chosen on purpose to avoid name collisions with outer code blocks. */     \
+                                                                                                                                                                         \
         Logging::logFile << x << std::endl;                                                                                                                              \
         Logging::logFile.flush();                                                                                                                                        \
     }
@@ -163,10 +168,10 @@ namespace Logging
 }
 
 // Put this macro at the beginning of code block (eg. function) which is responsible for text support mode output.
-#define START_TEXT_SUPPORT_MODE                                                                                                                                         \
-    if ( !Logging::isTextSupportModeEnabled() ) {                                                                                                                       \
-        return;                                                                                                                                                         \
-    }                                                                                                                                                                   \
-    const Logging::TextSupportLogger _temp_logger; // The name is written on purpose to avoid name clashing within a code block.
+#define START_TEXT_SUPPORT_MODE                                                                                                                                          \
+    if ( !Logging::isTextSupportModeEnabled() ) {                                                                                                                        \
+        return;                                                                                                                                                          \
+    }                                                                                                                                                                    \
+    const Logging::TextSupportLogger _temp_logger; // The name was chosen on purpose to avoid collisions with other variable names within a code block.
 
 #endif // H2LOGGING_H


### PR DESCRIPTION
While it is safe to concurrently [call](https://www.man7.org/linux/man-pages/man3/syslog.3.html#ATTRIBUTES) `syslog()` and [access](https://en.cppreference.com/w/cpp/io/cerr) `std::cout`/`std::cerr` from multiple threads simultaneously, it is still not safe to access Switch-specific `logFile` object this way.