### PR TITLE
Rework settings and introduce 3D audio UI option

### DIFF
--- a/fheroes2-vs2017.vcxproj
+++ b/fheroes2-vs2017.vcxproj
@@ -248,6 +248,7 @@
     <ClCompile Include="src\fheroes2\dialog\dialog_adventure.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_arena.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_armyinfo.cpp" />
+    <ClCompile Include="src\fheroes2\dialog\dialog_audio.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_box.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_buyboat.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_chest.cpp" />
@@ -456,6 +457,7 @@
     <ClInclude Include="src\fheroes2\castle\castle_heroes.h" />
     <ClInclude Include="src\fheroes2\castle\mageguild.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog.h" />
+    <ClInclude Include="src\fheroes2\dialog\dialog_audio.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog_game_settings.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog_hotkeys.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog_language_selection.h" />

--- a/fheroes2-vs2019.vcxproj
+++ b/fheroes2-vs2019.vcxproj
@@ -249,6 +249,7 @@
     <ClCompile Include="src\fheroes2\dialog\dialog_adventure.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_arena.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_armyinfo.cpp" />
+    <ClCompile Include="src\fheroes2\dialog\dialog_audio.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_box.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_buyboat.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_chest.cpp" />
@@ -457,6 +458,7 @@
     <ClInclude Include="src\fheroes2\castle\castle_heroes.h" />
     <ClInclude Include="src\fheroes2\castle\mageguild.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog.h" />
+    <ClInclude Include="src\fheroes2\dialog\dialog_audio.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog_game_settings.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog_hotkeys.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog_language_selection.h" />

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -1833,6 +1833,54 @@ namespace fheroes2
         return GetPALColorId( red / 4, green / 4, blue / 4 );
     }
 
+    std::vector<uint8_t> getTransformTable( const fheroes2::Image & in, const fheroes2::Image & out, int32_t x, int32_t y, int32_t width, int32_t height )
+    {
+        std::vector<uint8_t> table( 256 );
+        for ( size_t i = 0; i < table.size(); ++i ) {
+            table[i] = static_cast<uint8_t>( i );
+        }
+
+        if ( !Verify( in, x, y, width, height ) ) {
+            return table;
+        }
+
+        if ( in.width() != out.width() || in.height() != out.height() ) {
+            return table;
+        }
+
+        const int32_t imageWidth = in.width();
+
+        const int32_t offset = y * imageWidth + x;
+
+        const uint8_t * imageInY = in.image() + offset;
+        const uint8_t * imageInYEnd = imageInY + height * imageWidth;
+        const uint8_t * imageOutY = out.image() + offset;
+        const uint8_t * transformInY = in.transform() + offset;
+        const uint8_t * transformOutY = out.transform() + offset;
+
+        for ( ; imageInY != imageInYEnd; imageInY += imageWidth, transformInY += imageWidth, imageOutY += imageWidth, transformOutY += imageWidth ) {
+            const uint8_t * imageInX = imageInY;
+            const uint8_t * transformInX = transformInY;
+            const uint8_t * imageOutX = imageOutY;
+            const uint8_t * transformOutX = transformOutY;
+            const uint8_t * imageInXEnd = imageInX + width;
+
+            for ( ; imageInX != imageInXEnd; ++imageInX, ++transformInX, ++imageOutX, ++transformOutX ) {
+                if ( *transformInX != *transformOutX ) {
+                    continue;
+                }
+
+                if ( *transformInX != 0 ) {
+                    continue;
+                }
+
+                table[*imageInX] = *imageOutX;
+            }
+        }
+
+        return table;
+    }
+
     Sprite makeShadow( const Sprite & in, const Point & shadowOffset, const uint8_t transformId )
     {
         if ( in.empty() || shadowOffset.x > 0 || shadowOffset.y < 0 )

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -257,6 +257,8 @@ namespace fheroes2
     // Returns a closest color ID from the original game's palette
     uint8_t GetColorId( uint8_t red, uint8_t green, uint8_t blue );
 
+    std::vector<uint8_t> getTransformTable( const fheroes2::Image & in, const fheroes2::Image & out, int32_t x, int32_t y, int32_t width, int32_t height );
+
     Sprite makeShadow( const Sprite & in, const Point & shadowOffset, const uint8_t transformId );
 
     // This function does NOT check transform layer. If you intent to replace few colors at the same image please use ApplyPalette to be more efficient.

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -2067,6 +2067,23 @@ namespace fheroes2
                     }
                 }
                 return true;
+            case ICN::ESPANBKG_EVIL: {
+                _icnVsSprite[id].resize( 2 );
+
+                const Rect roi{ 28, 28, 265, 206 };
+
+                Sprite & output = _icnVsSprite[id][0];
+                _icnVsSprite[id][0] = GetICN( ICN::CSPANBKE, 0 );
+                Copy( GetICN( ICN::ESPANBKG, 0 ), roi.x, roi.y, output, roi.x, roi.y, roi.width, roi.height );
+
+                const std::vector<uint8_t> transformTable
+                    = getTransformTable( GetICN( ICN::CSPANBKG, 0 ), GetICN( ICN::CSPANBKE, 0 ), roi.x, roi.y, roi.width, roi.height );
+                ApplyPalette( output, roi.x, roi.y, output, roi.x, roi.y, roi.width, roi.height, transformTable );
+
+                _icnVsSprite[id][1] =  GetICN( ICN::ESPANBKG, 1 );
+
+                return true;
+            }
             default:
                 break;
             }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -2080,7 +2080,7 @@ namespace fheroes2
                     = getTransformTable( GetICN( ICN::CSPANBKG, 0 ), GetICN( ICN::CSPANBKE, 0 ), roi.x, roi.y, roi.width, roi.height );
                 ApplyPalette( output, roi.x, roi.y, output, roi.x, roi.y, roi.width, roi.height, transformTable );
 
-                _icnVsSprite[id][1] =  GetICN( ICN::ESPANBKG, 1 );
+                _icnVsSprite[id][1] = GetICN( ICN::ESPANBKG, 1 );
 
                 return true;
             }

--- a/src/fheroes2/agg/icn.h
+++ b/src/fheroes2/agg/icn.h
@@ -968,6 +968,8 @@ namespace ICN
         MONO_CURSOR_SPELBW,
         MONO_CURSOR_CMSSBW,
 
+        ESPANBKG_EVIL,
+
         // IMPORTANT! Put any new entry just above this one.
         LASTICN
     };

--- a/src/fheroes2/dialog/dialog_audio.cpp
+++ b/src/fheroes2/dialog/dialog_audio.cpp
@@ -20,10 +20,10 @@
 
 #include <cassert>
 
-#include "dialog_audio.h"
-#include "audio.h"
 #include "agg_image.h"
+#include "audio.h"
 #include "cursor.h"
+#include "dialog_audio.h"
 #include "game.h"
 #include "game_hotkeys.h"
 #include "icn.h"
@@ -100,8 +100,7 @@ namespace
 
         // 3D Audio.
         const bool is3DAudioEnabled = conf.is3DAudioEnabled();
-        const fheroes2::Sprite & interfaceStateIcon
-            = is3DAudioEnabled ? fheroes2::AGG::GetICN( ICN::SPANEL, 11 ) : fheroes2::AGG::GetICN( ICN::SPANEL, 10 );
+        const fheroes2::Sprite & interfaceStateIcon = is3DAudioEnabled ? fheroes2::AGG::GetICN( ICN::SPANEL, 11 ) : fheroes2::AGG::GetICN( ICN::SPANEL, 10 );
         if ( is3DAudioEnabled ) {
             value = _( "On" );
         }

--- a/src/fheroes2/dialog/dialog_audio.cpp
+++ b/src/fheroes2/dialog/dialog_audio.cpp
@@ -1,0 +1,285 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2022                                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <cassert>
+
+#include "dialog_audio.h"
+#include "audio.h"
+#include "agg_image.h"
+#include "cursor.h"
+#include "game.h"
+#include "game_hotkeys.h"
+#include "icn.h"
+#include "localevent.h"
+#include "screen.h"
+#include "settings.h"
+#include "translations.h"
+#include "ui_button.h"
+#include "ui_dialog.h"
+#include "ui_text.h"
+
+namespace
+{
+    void drawOption( const fheroes2::Rect & optionRoi, const fheroes2::Sprite & icon, const std::string & titleText, const std::string & valueText )
+    {
+        fheroes2::Display & display = fheroes2::Display::instance();
+
+        const fheroes2::FontType smallWhite = fheroes2::FontType::smallWhite();
+
+        const fheroes2::Text title( titleText, smallWhite );
+        const fheroes2::Text value( valueText, smallWhite );
+
+        const int16_t textMaxWidth = 87;
+
+        title.draw( optionRoi.x - 12, optionRoi.y - title.height( textMaxWidth ), textMaxWidth, display );
+        value.draw( optionRoi.x + ( optionRoi.width - value.width() ) / 2, optionRoi.y + optionRoi.height + 4, display );
+
+        fheroes2::Blit( icon, display, optionRoi.x, optionRoi.y );
+    }
+
+    void drawDialog( const std::vector<fheroes2::Rect> & rects )
+    {
+        assert( rects.size() == 4 );
+
+        const Settings & conf = Settings::Get();
+
+        // Music volume.
+        const fheroes2::Sprite & musicVolumeIcon = fheroes2::AGG::GetICN( ICN::SPANEL, Audio::isValid() ? 1 : 0 );
+        std::string value;
+        if ( Audio::isValid() && conf.MusicVolume() ) {
+            value = std::to_string( conf.MusicVolume() );
+        }
+        else {
+            value = _( "off" );
+        }
+
+        drawOption( rects[0], musicVolumeIcon, _( "Music" ), value );
+
+        // Sound volume.
+        const fheroes2::Sprite & soundVolumeOption = fheroes2::AGG::GetICN( ICN::SPANEL, Audio::isValid() ? 3 : 2 );
+        if ( Audio::isValid() && conf.SoundVolume() ) {
+            value = std::to_string( conf.SoundVolume() );
+        }
+        else {
+            value = _( "off" );
+        }
+
+        drawOption( rects[1], soundVolumeOption, _( "Effects" ), value );
+
+        // Music Type.
+        const MusicSource musicType = conf.MusicType();
+        const fheroes2::Sprite & musicTypeIcon = fheroes2::AGG::GetICN( ICN::SPANEL, musicType == MUSIC_EXTERNAL ? 11 : 10 );
+        if ( musicType == MUSIC_MIDI_ORIGINAL ) {
+            value = _( "MIDI" );
+        }
+        else if ( musicType == MUSIC_MIDI_EXPANSION ) {
+            value = _( "MIDI Expansion" );
+        }
+        else if ( musicType == MUSIC_EXTERNAL ) {
+            value = _( "External" );
+        }
+
+        drawOption( rects[2], musicTypeIcon, _( "Music Type" ), value );
+
+        // 3D Audio.
+        const bool is3DAudioEnabled = conf.is3DAudioEnabled();
+        const fheroes2::Sprite & interfaceStateIcon
+            = is3DAudioEnabled ? fheroes2::AGG::GetICN( ICN::SPANEL, 11 ) : fheroes2::AGG::GetICN( ICN::SPANEL, 10 );
+        if ( is3DAudioEnabled ) {
+            value = _( "On" );
+        }
+        else {
+            value = _( "Off" );
+        }
+
+        drawOption( rects[3], interfaceStateIcon, _( "3D Audio" ), value );
+    }
+}
+
+namespace Dialog
+{
+    void openAudioSettingsDialog()
+    {
+        const CursorRestorer cursorRestorer( true, Cursor::POINTER );
+
+        Settings & conf = Settings::Get();
+        const bool isEvilInterface = conf.ExtGameEvilInterface();
+
+        fheroes2::Display & display = fheroes2::Display::instance();
+
+        const fheroes2::Sprite & dialog = fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::ESPANBKG_EVIL : ICN::ESPANBKG ), 0 );
+        const fheroes2::Sprite & dialogShadow = fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::CSPANBKE : ICN::CSPANBKG ), 1 );
+
+        const fheroes2::Point dialogOffset( ( display.width() - dialog.width() ) / 2, ( display.height() - dialog.height() ) / 2 );
+        const fheroes2::Point shadowOffset( dialogOffset.x - BORDERWIDTH, dialogOffset.y );
+
+        fheroes2::ImageRestorer back( display, shadowOffset.x, shadowOffset.y, dialog.width() + BORDERWIDTH, dialog.height() + BORDERWIDTH );
+        const fheroes2::Rect dialogArea( dialogOffset.x, dialogOffset.y, dialog.width(), dialog.height() );
+
+        fheroes2::Fill( display, dialogArea.x, dialogArea.y, dialogArea.width, dialogArea.height, 0 );
+        fheroes2::Blit( dialogShadow, display, dialogArea.x - BORDERWIDTH, dialogArea.y + BORDERWIDTH );
+        fheroes2::Blit( dialog, display, dialogArea.x, dialogArea.y );
+
+        const fheroes2::Sprite & optionSprite = fheroes2::AGG::GetICN( ICN::SPANEL, 0 );
+        const fheroes2::Point optionOffset( 69 + dialogArea.x, 47 + dialogArea.y );
+        const fheroes2::Point optionStep( 118, 110 );
+
+        std::vector<fheroes2::Rect> roi;
+        roi.reserve( 4 );
+        roi.emplace_back( optionOffset.x, optionOffset.y, optionSprite.width(), optionSprite.height() );
+        roi.emplace_back( optionOffset.x + optionStep.x, optionOffset.y, optionSprite.width(), optionSprite.height() );
+        roi.emplace_back( optionOffset.x, optionOffset.y + optionStep.y, optionSprite.width(), optionSprite.height() );
+        roi.emplace_back( optionOffset.x + optionStep.x, optionOffset.y + optionStep.y, optionSprite.width(), optionSprite.height() );
+
+        const fheroes2::Rect & musicVolumeRoi = roi[0];
+        const fheroes2::Rect & soundVolumeRoi = roi[1];
+        const fheroes2::Rect & musicTypeRoi = roi[2];
+        const fheroes2::Rect & audio3D = roi[3];
+
+        drawDialog( roi );
+
+        const fheroes2::Point buttonOffset( 112 + dialogArea.x, 252 + dialogArea.y );
+        fheroes2::Button buttonOkay( buttonOffset.x, buttonOffset.y, isEvilInterface ? ICN::SPANBTNE : ICN::SPANBTN, 0, 1 );
+        buttonOkay.draw();
+
+        display.render();
+
+        bool saveConfig = false;
+
+        // dialog menu loop
+        LocalEvent & le = LocalEvent::Get();
+        while ( le.HandleEvents() ) {
+            le.MousePressLeft( buttonOkay.area() ) ? buttonOkay.drawOnPress() : buttonOkay.drawOnRelease();
+
+            if ( le.MouseClickLeft( buttonOkay.area() ) || Game::HotKeyCloseWindow() ) {
+                break;
+            }
+
+            // set music or sound volume
+            bool saveMusicVolume = false;
+            bool saveSoundVolume = false;
+            if ( Audio::isValid() ) {
+                if ( le.MouseClickLeft( musicVolumeRoi ) ) {
+                    conf.SetMusicVolume( ( conf.MusicVolume() + 1 ) % 11 );
+                    saveMusicVolume = true;
+                }
+                else if ( le.MouseWheelUp( musicVolumeRoi ) ) {
+                    conf.SetMusicVolume( conf.MusicVolume() + 1 );
+                    saveMusicVolume = true;
+                }
+                else if ( le.MouseWheelDn( musicVolumeRoi ) ) {
+                    conf.SetMusicVolume( conf.MusicVolume() - 1 );
+                    saveMusicVolume = true;
+                }
+
+                if ( saveMusicVolume ) {
+                    Music::setVolume( 100 * conf.MusicVolume() / 10 );
+                }
+
+                if ( le.MouseClickLeft( soundVolumeRoi ) ) {
+                    conf.SetSoundVolume( ( conf.SoundVolume() + 1 ) % 11 );
+                    saveSoundVolume = true;
+                }
+                else if ( le.MouseWheelUp( soundVolumeRoi ) ) {
+                    conf.SetSoundVolume( conf.SoundVolume() + 1 );
+                    saveSoundVolume = true;
+                }
+                else if ( le.MouseWheelDn( soundVolumeRoi ) ) {
+                    conf.SetSoundVolume( conf.SoundVolume() - 1 );
+                    saveSoundVolume = true;
+                }
+                if ( le.MouseClickLeft( audio3D ) ) {
+                    conf.set3DAudio( !conf.is3DAudioEnabled() );
+                    saveSoundVolume = true;
+                }
+
+                if ( saveSoundVolume ) {
+                    Game::EnvironmentSoundMixer();
+                }
+            }
+
+            // set music type
+            bool saveMusicType = false;
+            if ( le.MouseClickLeft( musicTypeRoi ) ) {
+                int type = conf.MusicType() + 1;
+                // If there's no expansion files we skip this option
+                if ( type == MUSIC_MIDI_EXPANSION && !conf.isPriceOfLoyaltySupported() )
+                    ++type;
+
+                const Game::MusicRestorer musicRestorer;
+
+                conf.SetMusicType( type > MUSIC_EXTERNAL ? 0 : type );
+
+                Game::SetCurrentMusicTrack( MUS::UNKNOWN );
+
+                saveMusicType = true;
+            }
+
+            const fheroes2::FontType normalYellow = fheroes2::FontType::normalYellow();
+            const fheroes2::FontType normalWhite = fheroes2::FontType::normalWhite();
+
+            if ( le.MousePressRight( musicVolumeRoi ) ) {
+                fheroes2::Text header( _( "Music" ), normalYellow );
+                fheroes2::Text body( _( "Toggle ambient music level." ), normalWhite );
+
+                fheroes2::showMessage( header, body, 0 );
+            }
+
+            else if ( le.MousePressRight( soundVolumeRoi ) ) {
+                fheroes2::Text header( _( "Effects" ), normalYellow );
+                fheroes2::Text body( _( "Toggle foreground sounds level." ), normalWhite );
+
+                fheroes2::showMessage( header, body, 0 );
+            }
+            else if ( le.MousePressRight( musicTypeRoi ) ) {
+                fheroes2::Text header( _( "Music Type" ), normalYellow );
+                fheroes2::Text body( _( "Change the type of music." ), normalWhite );
+
+                fheroes2::showMessage( header, body, 0 );
+            }
+            else if ( le.MousePressRight( audio3D ) ) {
+                fheroes2::Text header( _( "3D Audio" ), normalYellow );
+                fheroes2::Text body( _( "Toggle 3D effects of foreground sounds." ), normalWhite );
+
+                fheroes2::showMessage( header, body, 0 );
+            }
+            else if ( le.MousePressRight( buttonOkay.area() ) ) {
+                fheroes2::Text header( _( "Okay" ), normalYellow );
+                fheroes2::Text body( _( "Exit this menu." ), normalWhite );
+
+                fheroes2::showMessage( header, body, 0 );
+            }
+
+            if ( saveMusicVolume || saveSoundVolume || saveMusicType ) {
+                // redraw
+                fheroes2::Blit( dialog, display, dialogArea.x, dialogArea.y );
+                drawDialog( roi );
+                buttonOkay.draw();
+                display.render();
+
+                saveConfig = true;
+            }
+        }
+
+        if ( saveConfig ) {
+            Settings::Get().Save( Settings::configFileName );
+        }
+    }
+}

--- a/src/fheroes2/dialog/dialog_audio.h
+++ b/src/fheroes2/dialog/dialog_audio.h
@@ -1,0 +1,25 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2022                                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+#pragma once
+
+namespace Dialog
+{
+    void openAudioSettingsDialog();
+}

--- a/src/fheroes2/dialog/dialog_game_settings.cpp
+++ b/src/fheroes2/dialog/dialog_game_settings.cpp
@@ -59,8 +59,7 @@ namespace
     const fheroes2::Rect optionsRoi{ optionOffset.x, optionOffset.y + offsetBetweenOptions.height, optionWindowSize, optionWindowSize };
     const fheroes2::Rect battleResolveRoi{ optionOffset.x + offsetBetweenOptions.width, optionOffset.y + offsetBetweenOptions.height, optionWindowSize,
                                            optionWindowSize };
-    const fheroes2::Rect hotKeyRoi{ optionOffset.x + offsetBetweenOptions.width * 2, optionOffset.y + offsetBetweenOptions.height, optionWindowSize,
-                                    optionWindowSize };
+    const fheroes2::Rect hotKeyRoi{ optionOffset.x + offsetBetweenOptions.width * 2, optionOffset.y + offsetBetweenOptions.height, optionWindowSize, optionWindowSize };
     const fheroes2::Rect interfaceTypeRoi{ optionOffset.x, optionOffset.y + 2 * offsetBetweenOptions.height, optionWindowSize, optionWindowSize };
     const fheroes2::Rect cursorTypeRoi{ optionOffset.x + offsetBetweenOptions.width, optionOffset.y + 2 * offsetBetweenOptions.height, optionWindowSize,
                                         optionWindowSize };

--- a/src/fheroes2/dialog/dialog_game_settings.cpp
+++ b/src/fheroes2/dialog/dialog_game_settings.cpp
@@ -183,7 +183,7 @@ namespace
     {
         fheroes2::Display & display = fheroes2::Display::instance();
 
-        Settings & conf = Settings::Get();
+        const Settings & conf = Settings::Get();
         const bool isEvilInterface = conf.ExtGameEvilInterface();
         const int dialogIcnId = isEvilInterface ? ICN::SPANBKGE : ICN::SPANBKG;
         const fheroes2::Sprite & dialog = fheroes2::AGG::GetICN( dialogIcnId, 0 );

--- a/src/fheroes2/dialog/dialog_game_settings.cpp
+++ b/src/fheroes2/dialog/dialog_game_settings.cpp
@@ -23,6 +23,7 @@
 #include "audio.h"
 #include "cursor.h"
 #include "dialog.h"
+#include "dialog_audio.h"
 #include "dialog_hotkeys.h"
 #include "dialog_language_selection.h"
 #include "dialog_resolution.h"
@@ -54,12 +55,13 @@ namespace
 
     const fheroes2::Rect languageRoi{ optionOffset.x, optionOffset.y, optionWindowSize, optionWindowSize };
     const fheroes2::Rect resolutionRoi{ optionOffset.x + offsetBetweenOptions.width, optionOffset.y, optionWindowSize, optionWindowSize };
-    const fheroes2::Rect optionsRoi{ optionOffset.x + offsetBetweenOptions.width * 2, optionOffset.y, optionWindowSize, optionWindowSize };
-    const fheroes2::Rect musicVolumeRoi{ optionOffset.x, optionOffset.y + offsetBetweenOptions.height, optionWindowSize, optionWindowSize };
-    const fheroes2::Rect soundVolumeRoi{ optionOffset.x + offsetBetweenOptions.width, optionOffset.y + offsetBetweenOptions.height, optionWindowSize, optionWindowSize };
-    const fheroes2::Rect musicTypeRoi{ optionOffset.x + offsetBetweenOptions.width * 2, optionOffset.y + offsetBetweenOptions.height, optionWindowSize,
-                                       optionWindowSize };
-    const fheroes2::Rect hotKeyRoi{ optionOffset.x, optionOffset.y + 2 * offsetBetweenOptions.height, optionWindowSize, optionWindowSize };
+    const fheroes2::Rect audioRoi{ optionOffset.x + offsetBetweenOptions.width * 2, optionOffset.y, optionWindowSize, optionWindowSize };
+    const fheroes2::Rect optionsRoi{ optionOffset.x, optionOffset.y + offsetBetweenOptions.height, optionWindowSize, optionWindowSize };
+    const fheroes2::Rect battleResolveRoi{ optionOffset.x + offsetBetweenOptions.width, optionOffset.y + offsetBetweenOptions.height, optionWindowSize,
+                                           optionWindowSize };
+    const fheroes2::Rect hotKeyRoi{ optionOffset.x + offsetBetweenOptions.width * 2, optionOffset.y + offsetBetweenOptions.height, optionWindowSize,
+                                    optionWindowSize };
+    const fheroes2::Rect interfaceTypeRoi{ optionOffset.x, optionOffset.y + 2 * offsetBetweenOptions.height, optionWindowSize, optionWindowSize };
     const fheroes2::Rect cursorTypeRoi{ optionOffset.x + offsetBetweenOptions.width, optionOffset.y + 2 * offsetBetweenOptions.height, optionWindowSize,
                                         optionWindowSize };
     const fheroes2::Rect textSupportModeRoi{ optionOffset.x + offsetBetweenOptions.width * 2, optionOffset.y + 2 * offsetBetweenOptions.height, optionWindowSize,
@@ -102,53 +104,9 @@ namespace
         drawOption( optionRoi, _( "Settings" ), _( "Experimental" ), ICN::SPANEL, 14 );
     }
 
-    void drawMusicVolumeOptions( const fheroes2::Rect & optionRoi )
+    void drawAudioOptions( const fheroes2::Rect & optionRoi )
     {
-        const Settings & configuration = Settings::Get();
-
-        std::string value;
-        if ( Audio::isValid() && configuration.MusicVolume() ) {
-            value = std::to_string( configuration.MusicVolume() );
-        }
-        else {
-            value = _( "off" );
-        }
-
-        drawOption( optionRoi, _( "Music" ), value.c_str(), ICN::SPANEL, Audio::isValid() ? 1 : 0 );
-    }
-
-    void drawSoundVolumeOptions( const fheroes2::Rect & optionRoi )
-    {
-        const Settings & configuration = Settings::Get();
-
-        std::string value;
-        if ( Audio::isValid() && configuration.SoundVolume() ) {
-            value = std::to_string( configuration.SoundVolume() );
-        }
-        else {
-            value = _( "off" );
-        }
-
-        drawOption( optionRoi, _( "Effects" ), value.c_str(), ICN::SPANEL, Audio::isValid() ? 3 : 2 );
-    }
-
-    void drawMusicTypeOptions( const fheroes2::Rect & optionRoi )
-    {
-        const Settings & configuration = Settings::Get();
-
-        std::string value;
-        const MusicSource musicType = configuration.MusicType();
-        if ( musicType == MUSIC_MIDI_ORIGINAL ) {
-            value = _( "MIDI" );
-        }
-        else if ( musicType == MUSIC_MIDI_EXPANSION ) {
-            value = _( "MIDI Expansion" );
-        }
-        else if ( musicType == MUSIC_EXTERNAL ) {
-            value = _( "External" );
-        }
-
-        drawOption( optionRoi, _( "Music Type" ), value.c_str(), ICN::SPANEL, Audio::isValid() ? 11 : 10 );
+        drawOption( optionRoi, _( "Audio" ), _( "settings" ), ICN::SPANEL, 1 );
     }
 
     void drawHotKeyOptions( const fheroes2::Rect & optionRoi )
@@ -176,6 +134,36 @@ namespace
         }
     }
 
+    void drawInterfaceOptions( const fheroes2::Rect & optionRoi )
+    {
+        const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+        drawOption( optionRoi, _( "Interface Type" ), isEvilInterface ? _( "Evil" ) : _( "Good" ), ICN::SPANEL, isEvilInterface ? 17 : 16 );
+    }
+
+    void drawBattleResolveOptions( const fheroes2::Rect & optionRoi )
+    {
+        std::string value;
+        int icnId = ICN::UNKNOWN;
+        uint32_t icnIndex = 0;
+
+        const Settings & conf = Settings::Get();
+        if ( conf.BattleAutoResolve() ) {
+            const bool spellcast = conf.BattleAutoSpellcast();
+            value = spellcast ? _( "Auto Resolve" ) : _( "Auto, No Spells" );
+
+            icnId = ICN::CSPANEL;
+            icnIndex = spellcast ? 7 : 6;
+        }
+        else {
+            value = _( "Manual" );
+
+            icnId = ICN::SPANEL;
+            icnIndex = 18;
+        }
+
+        drawOption( optionRoi, _( "Battles" ), value.c_str(), icnId, icnIndex );
+    }
+
     enum class SelectedWindow : int
     {
         Configuration,
@@ -186,6 +174,9 @@ namespace
         CursorType,
         TextSupportMode,
         UpdateSettings,
+        AudioSettings,
+        InterfaceTheme,
+        BattleResolveType,
         Exit
     };
 
@@ -215,22 +206,21 @@ namespace
 
         const fheroes2::Rect windowLanguageRoi( languageRoi + windowRoi.getPosition() );
         const fheroes2::Rect windowResolutionRoi( resolutionRoi + windowRoi.getPosition() );
+        const fheroes2::Rect windowAudioRoi( audioRoi + windowRoi.getPosition() );
         const fheroes2::Rect windowOptionsRoi( optionsRoi + windowRoi.getPosition() );
-        const fheroes2::Rect windowMusicVolumeRoi( musicVolumeRoi + windowRoi.getPosition() );
-        const fheroes2::Rect windowSoundVolumeRoi( soundVolumeRoi + windowRoi.getPosition() );
-        const fheroes2::Rect windowMusicTypeRoi( musicTypeRoi + windowRoi.getPosition() );
-
+        const fheroes2::Rect windowBattleResolveRoi( battleResolveRoi + windowRoi.getPosition() );
         const fheroes2::Rect windowHotKeyRoi( hotKeyRoi + windowRoi.getPosition() );
+        const fheroes2::Rect windowInterfaceTypeRoi( interfaceTypeRoi + windowRoi.getPosition() );
         const fheroes2::Rect windowCursorTypeRoi( cursorTypeRoi + windowRoi.getPosition() );
         const fheroes2::Rect windowTextSupportModeRoi( textSupportModeRoi + windowRoi.getPosition() );
 
         drawLanguage( windowLanguageRoi );
         drawResolution( windowResolutionRoi );
+        drawAudioOptions( windowAudioRoi );
         drawExperimentalOptions( windowOptionsRoi );
-        drawMusicVolumeOptions( windowMusicVolumeRoi );
-        drawSoundVolumeOptions( windowSoundVolumeRoi );
-        drawMusicTypeOptions( windowMusicTypeRoi );
+        drawBattleResolveOptions( windowBattleResolveRoi );
         drawHotKeyOptions( windowHotKeyRoi );
+        drawInterfaceOptions( windowInterfaceTypeRoi );
         drawCursorTypeOptions( windowCursorTypeRoi );
         drawTextSupportModeOptions( windowTextSupportModeRoi );
 
@@ -257,71 +247,26 @@ namespace
             if ( le.MouseClickLeft( windowResolutionRoi ) ) {
                 return SelectedWindow::Resolution;
             }
+            if ( le.MouseClickLeft( windowAudioRoi ) ) {
+                return SelectedWindow::AudioSettings;
+            }
             if ( le.MouseClickLeft( windowOptionsRoi ) ) {
                 return SelectedWindow::Options;
             }
+            if ( le.MouseClickLeft( windowBattleResolveRoi ) ) {
+                return SelectedWindow::BattleResolveType;
+            }
             if ( le.MouseClickLeft( windowHotKeyRoi ) ) {
                 return SelectedWindow::HotKeys;
+            }
+            if ( le.MouseClickLeft( windowInterfaceTypeRoi ) ) {
+                return SelectedWindow::InterfaceTheme;
             }
             if ( le.MouseClickLeft( windowCursorTypeRoi ) ) {
                 return SelectedWindow::CursorType;
             }
             if ( le.MouseClickLeft( windowTextSupportModeRoi ) ) {
                 return SelectedWindow::TextSupportMode;
-            }
-            if ( le.MouseClickLeft( windowMusicTypeRoi ) ) {
-                int type = conf.MusicType() + 1;
-                // If there's no expansion files we skip this option
-                if ( type == MUSIC_MIDI_EXPANSION && !conf.isPriceOfLoyaltySupported() ) {
-                    ++type;
-                }
-
-                const Game::MusicRestorer musicRestorer;
-
-                conf.SetMusicType( type > MUSIC_EXTERNAL ? 0 : type );
-
-                Game::SetCurrentMusicTrack( MUS::UNKNOWN );
-
-                return SelectedWindow::UpdateSettings;
-            }
-
-            // Set music or sound volume.
-            if ( Audio::isValid() ) {
-                bool saveMusicVolume = false;
-                bool saveSoundVolume = false;
-                if ( le.MouseClickLeft( windowMusicVolumeRoi ) ) {
-                    conf.SetMusicVolume( ( conf.MusicVolume() + 1 ) % 11 );
-                    saveMusicVolume = true;
-                }
-                else if ( le.MouseWheelUp( windowMusicVolumeRoi ) ) {
-                    conf.SetMusicVolume( conf.MusicVolume() + 1 );
-                    saveMusicVolume = true;
-                }
-                else if ( le.MouseWheelDn( windowMusicVolumeRoi ) ) {
-                    conf.SetMusicVolume( conf.MusicVolume() - 1 );
-                    saveMusicVolume = true;
-                }
-                if ( saveMusicVolume ) {
-                    Music::setVolume( 100 * conf.MusicVolume() / 10 );
-                    return SelectedWindow::UpdateSettings;
-                }
-
-                if ( le.MouseClickLeft( windowSoundVolumeRoi ) ) {
-                    conf.SetSoundVolume( ( conf.SoundVolume() + 1 ) % 11 );
-                    saveSoundVolume = true;
-                }
-                else if ( le.MouseWheelUp( windowSoundVolumeRoi ) ) {
-                    conf.SetSoundVolume( conf.SoundVolume() + 1 );
-                    saveSoundVolume = true;
-                }
-                else if ( le.MouseWheelDn( windowSoundVolumeRoi ) ) {
-                    conf.SetSoundVolume( conf.SoundVolume() - 1 );
-                    saveSoundVolume = true;
-                }
-                if ( saveSoundVolume ) {
-                    Game::EnvironmentSoundMixer();
-                    return SelectedWindow::UpdateSettings;
-                }
             }
 
             if ( le.MousePressRight( windowLanguageRoi ) ) {
@@ -336,33 +281,33 @@ namespace
 
                 fheroes2::showMessage( header, body, 0 );
             }
+            else if ( le.MousePressRight( windowAudioRoi ) ) {
+                fheroes2::Text header( _( "Audio" ), fheroes2::FontType::normalYellow() );
+                fheroes2::Text body( _( "Change audio settings of the game." ), fheroes2::FontType::normalWhite() );
+
+                fheroes2::showMessage( header, body, 0 );
+            }
             else if ( le.MousePressRight( windowOptionsRoi ) ) {
                 fheroes2::Text header( _( "Settings" ), fheroes2::FontType::normalYellow() );
                 fheroes2::Text body( _( "Experimental game settings." ), fheroes2::FontType::normalWhite() );
 
                 fheroes2::showMessage( header, body, 0 );
             }
-            else if ( le.MousePressRight( windowMusicVolumeRoi ) ) {
-                fheroes2::Text header( _( "Music" ), fheroes2::FontType::normalYellow() );
-                fheroes2::Text body( _( "Toggle ambient music level." ), fheroes2::FontType::normalWhite() );
-
-                fheroes2::showMessage( header, body, 0 );
-            }
-            else if ( le.MousePressRight( windowSoundVolumeRoi ) ) {
-                fheroes2::Text header( _( "Effects" ), fheroes2::FontType::normalYellow() );
-                fheroes2::Text body( _( "Toggle foreground sounds level." ), fheroes2::FontType::normalWhite() );
-
-                fheroes2::showMessage( header, body, 0 );
-            }
-            else if ( le.MousePressRight( windowMusicTypeRoi ) ) {
-                fheroes2::Text header( _( "Music Type" ), fheroes2::FontType::normalYellow() );
-                fheroes2::Text body( _( "Change the type of music." ), fheroes2::FontType::normalWhite() );
+            if ( le.MousePressRight( windowBattleResolveRoi ) ) {
+                fheroes2::Text header( _( "Battles" ), fheroes2::FontType::normalYellow() );
+                fheroes2::Text body( _( "Toggle instant battle mode." ), fheroes2::FontType::normalWhite() );
 
                 fheroes2::showMessage( header, body, 0 );
             }
             else if ( le.MousePressRight( windowHotKeyRoi ) ) {
                 fheroes2::Text header( _( "Hot Keys" ), fheroes2::FontType::normalYellow() );
                 fheroes2::Text body( _( "Check all Hot Keys used in the game." ), fheroes2::FontType::normalWhite() );
+
+                fheroes2::showMessage( header, body, 0 );
+            }
+            if ( le.MousePressRight( windowInterfaceTypeRoi ) ) {
+                fheroes2::Text header( _( "Interface Type" ), fheroes2::FontType::normalYellow() );
+                fheroes2::Text body( _( "Toggle the type of interface you want to use." ), fheroes2::FontType::normalWhite() );
 
                 fheroes2::showMessage( header, body, 0 );
             }
@@ -452,6 +397,30 @@ namespace fheroes2
             case SelectedWindow::UpdateSettings:
                 conf.Save( Settings::configFileName );
                 windowType = SelectedWindow::Configuration;
+                break;
+            case SelectedWindow::AudioSettings:
+                Dialog::openAudioSettingsDialog();
+                windowType = SelectedWindow::Configuration;
+                break;
+            case SelectedWindow::InterfaceTheme:
+                conf.SetEvilInterface( !conf.ExtGameEvilInterface() );
+                windowType = SelectedWindow::UpdateSettings;
+                break;
+            case SelectedWindow::BattleResolveType:
+                if ( conf.BattleAutoResolve() ) {
+                    if ( conf.BattleAutoSpellcast() ) {
+                        conf.setBattleAutoSpellcast( false );
+                    }
+                    else {
+                        conf.setBattleAutoResolve( false );
+                    }
+                }
+                else {
+                    conf.setBattleAutoResolve( true );
+                    conf.setBattleAutoSpellcast( true );
+                }
+
+                windowType = SelectedWindow::UpdateSettings;
                 break;
             default:
                 return;

--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -78,7 +78,7 @@ namespace
 
         // Audio settings.
         const fheroes2::Sprite & audioSettingsIcon = fheroes2::AGG::GetICN( ICN::SPANEL, 1 );
-        drawOption( rects[0], audioSettingsIcon, _( "Music" ), _( "settings" ) );
+        drawOption( rects[0], audioSettingsIcon, _( "Audio" ), _( "settings" ) );
 
         // Hot keys.
         const fheroes2::Sprite & hotkeysIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, 5 );

--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -23,6 +23,8 @@
 #include "audio.h"
 #include "cursor.h"
 #include "dialog.h"
+#include "dialog_audio.h"
+#include "dialog_hotkeys.h"
 #include "game.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
@@ -46,6 +48,9 @@ namespace
         ChangeInterfaceTheme,
         UpdateInterface,
         SaveConfiguration,
+        AudioSettings,
+        HotKeys,
+        CursorType,
         Close
     };
 
@@ -72,43 +77,18 @@ namespace
 
         const Settings & conf = Settings::Get();
 
-        // Music volume.
-        const fheroes2::Sprite & musicVolumeIcon = fheroes2::AGG::GetICN( ICN::SPANEL, Audio::isValid() ? 1 : 0 );
-        std::string value;
-        if ( Audio::isValid() && conf.MusicVolume() ) {
-            value = std::to_string( conf.MusicVolume() );
-        }
-        else {
-            value = _( "off" );
-        }
+        // Audio settings.
+        const fheroes2::Sprite & audioSettingsIcon = fheroes2::AGG::GetICN( ICN::SPANEL, 1 );
+        drawOption( rects[0], audioSettingsIcon, _( "Music" ), _( "settings" ) );
 
-        drawOption( rects[0], musicVolumeIcon, _( "Music" ), value );
+        // Hot keys.
+        const fheroes2::Sprite & hotkeysIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, 5 );
+        drawOption( rects[1], hotkeysIcon, _( "Hot Keys" ), _( "In-game" ) );
 
-        // Sound volume.
-        const fheroes2::Sprite & soundVolumeOption = fheroes2::AGG::GetICN( ICN::SPANEL, Audio::isValid() ? 3 : 2 );
-        if ( Audio::isValid() && conf.SoundVolume() ) {
-            value = std::to_string( conf.SoundVolume() );
-        }
-        else {
-            value = _( "off" );
-        }
-
-        drawOption( rects[1], soundVolumeOption, _( "Effects" ), value );
-
-        // Music Type.
-        const MusicSource musicType = conf.MusicType();
-        const fheroes2::Sprite & musicTypeIcon = fheroes2::AGG::GetICN( ICN::SPANEL, musicType == MUSIC_EXTERNAL ? 11 : 10 );
-        if ( musicType == MUSIC_MIDI_ORIGINAL ) {
-            value = _( "MIDI" );
-        }
-        else if ( musicType == MUSIC_MIDI_EXPANSION ) {
-            value = _( "MIDI Expansion" );
-        }
-        else if ( musicType == MUSIC_EXTERNAL ) {
-            value = _( "External" );
-        }
-
-        drawOption( rects[2], musicTypeIcon, _( "Music Type" ), value );
+        // Cursor Type.
+        const bool isMonoCursor = Settings::Get().isMonochromeCursorEnabled();
+        const fheroes2::Sprite & cursorTypeIcon = fheroes2::AGG::GetICN( ICN::SPANEL, isMonoCursor ? 20 : 21 );
+        drawOption( rects[2], cursorTypeIcon, _( "Mouse Cursor" ), isMonoCursor ? _( "Black & White" ) : _( "Color" ) );
 
         // Hero's movement speed.
         const int heroSpeed = conf.HeroesMoveSpeed();
@@ -121,6 +101,7 @@ namespace
         }
 
         const fheroes2::Sprite & heroSpeedIcon = fheroes2::AGG::GetICN( ICN::SPANEL, heroSpeedIconId );
+        std::string value;
         if ( heroSpeed == 10 ) {
             value = _( "Jump" );
         }
@@ -242,9 +223,9 @@ namespace
             }
         }
 
-        const fheroes2::Rect & musicVolumeRoi = roi[0];
-        const fheroes2::Rect & soundVolumeRoi = roi[1];
-        const fheroes2::Rect & musicTypeRoi = roi[2];
+        const fheroes2::Rect & audioSettingsRoi = roi[0];
+        const fheroes2::Rect & hotkeysRoi = roi[1];
+        const fheroes2::Rect & cursorTypeRoi = roi[2];
         const fheroes2::Rect & heroSpeedRoi = roi[3];
         const fheroes2::Rect & aiSpeedRoi = roi[4];
         const fheroes2::Rect & scrollSpeedRoi = roi[5];
@@ -271,58 +252,19 @@ namespace
                 break;
             }
 
-            // set music or sound volume
-            bool saveMusicVolume = false;
-            bool saveSoundVolume = false;
-            if ( Audio::isValid() ) {
-                if ( le.MouseClickLeft( musicVolumeRoi ) ) {
-                    conf.SetMusicVolume( ( conf.MusicVolume() + 1 ) % 11 );
-                    saveMusicVolume = true;
-                }
-                else if ( le.MouseWheelUp( musicVolumeRoi ) ) {
-                    conf.SetMusicVolume( conf.MusicVolume() + 1 );
-                    saveMusicVolume = true;
-                }
-                else if ( le.MouseWheelDn( musicVolumeRoi ) ) {
-                    conf.SetMusicVolume( conf.MusicVolume() - 1 );
-                    saveMusicVolume = true;
-                }
-                if ( saveMusicVolume ) {
-                    Music::setVolume( 100 * conf.MusicVolume() / 10 );
-                }
-
-                if ( le.MouseClickLeft( soundVolumeRoi ) ) {
-                    conf.SetSoundVolume( ( conf.SoundVolume() + 1 ) % 11 );
-                    saveSoundVolume = true;
-                }
-                else if ( le.MouseWheelUp( soundVolumeRoi ) ) {
-                    conf.SetSoundVolume( conf.SoundVolume() + 1 );
-                    saveSoundVolume = true;
-                }
-                else if ( le.MouseWheelDn( soundVolumeRoi ) ) {
-                    conf.SetSoundVolume( conf.SoundVolume() - 1 );
-                    saveSoundVolume = true;
-                }
-                if ( saveSoundVolume ) {
-                    Game::EnvironmentSoundMixer();
-                }
+            // Open audio settings window.
+            if ( le.MouseClickLeft( audioSettingsRoi ) ) {
+                return DialogAction::AudioSettings;
             }
 
-            // set music type
-            bool saveMusicType = false;
-            if ( le.MouseClickLeft( musicTypeRoi ) ) {
-                int type = conf.MusicType() + 1;
-                // If there's no expansion files we skip this option
-                if ( type == MUSIC_MIDI_EXPANSION && !conf.isPriceOfLoyaltySupported() )
-                    ++type;
+            // Open Hotkeys window.
+            if ( le.MouseClickLeft( hotkeysRoi ) ) {
+                return DialogAction::HotKeys;
+            }
 
-                const Game::MusicRestorer musicRestorer;
-
-                conf.SetMusicType( type > MUSIC_EXTERNAL ? 0 : type );
-
-                Game::SetCurrentMusicTrack( MUS::UNKNOWN );
-
-                saveMusicType = true;
+            // Change Cursor Type.
+            if ( le.MouseClickLeft( cursorTypeRoi ) ) {
+                return DialogAction::CursorType;
             }
 
             // set hero speed
@@ -405,22 +347,23 @@ namespace
             const fheroes2::FontType normalYellow = fheroes2::FontType::normalYellow();
             const fheroes2::FontType normalWhite = fheroes2::FontType::normalWhite();
 
-            if ( le.MousePressRight( musicVolumeRoi ) ) {
-                fheroes2::Text header( _( "Music" ), normalYellow );
-                fheroes2::Text body( _( "Toggle ambient music level." ), normalWhite );
+            if ( le.MousePressRight( audioSettingsRoi ) ) {
+                fheroes2::Text header( _( "Audio" ), normalYellow );
+                fheroes2::Text body( _( "Change audio settings of the game." ), normalWhite );
 
                 fheroes2::showMessage( header, body, 0 );
             }
 
-            else if ( le.MousePressRight( soundVolumeRoi ) ) {
-                fheroes2::Text header( _( "Effects" ), normalYellow );
-                fheroes2::Text body( _( "Toggle foreground sounds level." ), normalWhite );
+            else if ( le.MousePressRight( hotkeysRoi ) ) {
+                fheroes2::Text header( _( "Hot Keys" ), normalYellow );
+                fheroes2::Text body( _( "Check all Hot Keys used in the game." ), normalWhite );
 
                 fheroes2::showMessage( header, body, 0 );
             }
-            else if ( le.MousePressRight( musicTypeRoi ) ) {
-                fheroes2::Text header( _( "Music Type" ), normalYellow );
-                fheroes2::Text body( _( "Change the type of music." ), normalWhite );
+            else if ( le.MousePressRight( cursorTypeRoi ) ) {
+                fheroes2::Text header( _( "Mouse Cursor" ), normalYellow );
+                fheroes2::Text body( _( "Toggle color cursors on/off. Color cursors look nicer, but sometimes don't move as smoothly as black and white ones." ),
+                                     normalWhite );
 
                 fheroes2::showMessage( header, body, 0 );
             }
@@ -467,7 +410,7 @@ namespace
                 fheroes2::showMessage( header, body, 0 );
             }
 
-            if ( saveMusicVolume || saveSoundVolume || saveMusicType || saveHeroSpeed || saveAISpeed || saveScrollSpeed || saveAutoBattle ) {
+            if ( saveHeroSpeed || saveAISpeed || saveScrollSpeed || saveAutoBattle ) {
                 // redraw
                 fheroes2::Blit( dialog, display, dialogArea.x, dialogArea.y );
                 drawDialog( roi );
@@ -530,6 +473,21 @@ namespace fheroes2
             case DialogAction::SaveConfiguration:
                 Settings::Get().Save( Settings::configFileName );
                 return;
+            case DialogAction::AudioSettings:
+                Dialog::openAudioSettingsDialog();
+                action = DialogAction::Open;
+                break;
+            case DialogAction::HotKeys:
+                fheroes2::openHotkeysDialog();
+                action = DialogAction::Open;
+                break;
+            case DialogAction::CursorType: {
+                Settings & conf = Settings::Get();
+                conf.setMonochromeCursor( !conf.isMonochromeCursorEnabled() );
+                saveConfiguration = true;
+                action = DialogAction::Open;
+                break;
+            }
             default:
                 break;
             }

--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -20,7 +20,6 @@
 
 #include "dialog_system_options.h"
 #include "agg_image.h"
-#include "audio.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "dialog_audio.h"


### PR DESCRIPTION
All Audio settings are moved to a separate window because we cannot have more than 9 options in a single window. Since we replaced 3 options by 1 I added Interface type and Battle Resolve options into Main Menu Settings and Cursor Type and HotKeys into Adventure System Options.
![image](https://user-images.githubusercontent.com/19829520/173190117-43e986db-192d-433d-a79b-63c537a98eb5.png)
![image](https://user-images.githubusercontent.com/19829520/173190253-25c0e390-5996-49bc-95fe-a2d52c7f7574.png)

