### PR TITLE
Multiple fixes for the AsyncManager, make it ready for use to restart the music in the RESUME_AND_PLAY_INFINITE mode

### DIFF
--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -222,8 +222,6 @@ namespace
     public:
         void restartCurrentMusicTrack()
         {
-            createWorker();
-
             std::scoped_lock<std::mutex> lock( _mutex );
 
             _trackChangeCounter = musicSettings.currentTrackChangeCounter;
@@ -462,6 +460,8 @@ void Audio::Init()
     audioSpecs.freq = frequency;
     audioSpecs.format = format;
     audioSpecs.channels = static_cast<uint8_t>( channels );
+
+    musicRestartManager.createWorker();
 
     Mix_ChannelFinished( channelFinished );
 

--- a/src/engine/thread.h
+++ b/src/engine/thread.h
@@ -38,6 +38,10 @@ namespace MultiThreading
 
         AsyncManager & operator=( const AsyncManager & ) = delete;
 
+        // Create the worker thread if it doesn't exist yet. Both createWorker() and stopWorker() are not
+        // designed to be executed concurrently.
+        void createWorker();
+
         // Stop and join the worker thread. This cannot be done in the destructor (directly or indirectly) due
         // to the potential race on the vptr since this class has virtual methods that could be called from the
         // worker thread.
@@ -45,9 +49,6 @@ namespace MultiThreading
 
     protected:
         std::mutex _mutex;
-
-        // Create the worker thread if it doesn't exist yet.
-        void createWorker();
 
         // Notify the worker thread about a new task. The _mutex should be acquired while calling this method.
         void notifyWorker();

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -213,12 +213,12 @@ namespace
     // SDL MIDI player is a single threaded library which requires a lot of time to start playing some long midi compositions.
     // This leads to a situation of a short application freeze while a hero crosses terrains or ending a battle.
     // The only way to avoid this is to fire MIDI requests asynchronously and synchronize them if needed.
-    class AsyncSoundManager : public MultiThreading::AsyncManager
+    class AsyncSoundManager final : public MultiThreading::AsyncManager
     {
     public:
         void pushMusic( const int musicId, const MusicSource musicType, const Music::PlaybackMode playbackMode )
         {
-            createThreadIfNeeded();
+            createWorker();
 
             std::scoped_lock<std::mutex> lock( _mutex );
 
@@ -228,29 +228,29 @@ namespace
 
             _musicTasks.emplace( musicId, musicType, playbackMode );
 
-            notifyThread();
+            notifyWorker();
         }
 
         void pushSound( const int m82Sound, const int soundVolume )
         {
-            createThreadIfNeeded();
+            createWorker();
 
             std::scoped_lock<std::mutex> lock( _mutex );
 
             _soundTasks.emplace( m82Sound, soundVolume );
 
-            notifyThread();
+            notifyWorker();
         }
 
         void pushLoopSound( std::map<M82::SoundType, std::vector<AudioManager::AudioLoopEffectInfo>> vols, const int soundVolume, const bool is3DAudioEnabled )
         {
-            createThreadIfNeeded();
+            createWorker();
 
             std::scoped_lock<std::mutex> lock( _mutex );
 
             _loopSoundTasks.emplace( std::move( vols ), soundVolume, is3DAudioEnabled );
 
-            notifyThread();
+            notifyWorker();
         }
 
         void sync()
@@ -764,6 +764,7 @@ namespace AudioManager
     AudioInitializer::~AudioInitializer()
     {
         g_asyncSoundManager.sync();
+        g_asyncSoundManager.stopWorker();
 
         wavDataCache.clear();
         MIDDataCache.clear();


### PR DESCRIPTION
The current approach with detached thread to restart the music is simple and works well enough, but it has one drawback - there is a possibility (although minimal) that eventually the detached thread will outlive the `main()`, which may lead to various issues, because when `main()` is exited, all global objects will be destroyed, and only then, during the process termination, other threads will be terminated, that is, there is always a possibility for a detached thread to access already destroyed object(s). BTW, `AsyncSoundManager` from the `AudioManager` module could suffer from this too, because its worker thread can outlive `main()` as well and can access global objects in other modules that are already destroyed while `g_asyncSoundManager` global object is not destroyed yet - since order of destruction of global objects in different modules is indeterminate. This is not good, we need to perform the proper cleanup. I adapted the `AsyncManager` for this with several changes, because in its current form it doesn't work reliable enough due to various race issues in it. See details below.