### PR TITLE
Fix the inter-thread race with SDL timer in Interface::StatusWindow

### DIFF
--- a/src/engine/timing.cpp
+++ b/src/engine/timing.cpp
@@ -18,11 +18,12 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include "timing.h"
-
 #include <thread>
 
 #include <SDL.h>
+
+#include "timing.h"
+#include "logging.h"
 
 namespace fheroes2
 {
@@ -40,12 +41,16 @@ namespace fheroes2
             remove();
 
             id = SDL_AddTimer( interval, fn, param );
+            if ( id == 0 ) {
+                ERROR_LOG( "Failed to add timer. The error: " << SDL_GetError() )
+            }
         }
 
         void remove()
         {
             if ( valid() ) {
                 SDL_RemoveTimer( id );
+
                 id = 0;
             }
         }
@@ -104,14 +109,14 @@ namespace fheroes2
     }
 
     Timer::Timer()
-        : _timer( new TimerImp )
+        : _timer( std::make_unique<TimerImp>() )
     {
         // Do nothing.
     }
 
     Timer::~Timer()
     {
-        delete _timer;
+        _timer->remove();
     }
 
     bool Timer::valid() const

--- a/src/engine/timing.h
+++ b/src/engine/timing.h
@@ -22,6 +22,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <memory>
 
 namespace fheroes2
 {
@@ -81,11 +82,13 @@ namespace fheroes2
 
         bool valid() const;
 
+        // NOTE WELL: The callback function set by this method will be called from some internal SDL thread.
+        // The inter-thread synchronization is advised.
         void run( uint32_t interval, uint32_t ( *fn )( uint32_t, void * ), void * param = nullptr );
         void remove();
 
     private:
-        TimerImp * _timer;
+        std::unique_ptr<TimerImp> _timer;
     };
 
     void delayforMs( const uint32_t delayMs );

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -137,7 +137,6 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */ )
     Kingdom & myKingdom = world.GetKingdom( conf.CurrentColor() );
     const KingdomCastles & myCastles = myKingdom.GetCastles();
     KingdomCastles::const_iterator it = std::find( myCastles.begin(), myCastles.end(), &castle );
-    Interface::StatusWindow::ResetTimer();
 
     const size_t heroCountBefore = myKingdom.GetHeroes().size();
 
@@ -199,8 +198,6 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, bool windowIsGameW
 {
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
-
-    Interface::StatusWindow::ResetTimer();
 
     bool needFade = Settings::ExtGameUseFade() && fheroes2::Display::instance().isDefaultSize();
 
@@ -799,6 +796,9 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
             }
             continue;
         }
+
+        // pending timer events
+        statusWindow.TimerEventProcessing();
 
         // hotkeys
         if ( le.KeyPress() ) {

--- a/src/fheroes2/gui/interface_status.h
+++ b/src/fheroes2/gui/interface_status.h
@@ -24,6 +24,8 @@
 #ifndef H2INTERFACE_STATUS_H
 #define H2INTERFACE_STATUS_H
 
+#include <atomic>
+
 #include "interface_border.h"
 #include "timing.h"
 
@@ -47,7 +49,7 @@ namespace Interface
         explicit StatusWindow( Basic & basic );
         StatusWindow( const StatusWindow & ) = delete;
 
-        ~StatusWindow() override = default;
+        ~StatusWindow() override;
 
         StatusWindow & operator=( const StatusWindow & ) = delete;
 
@@ -63,8 +65,7 @@ namespace Interface
         void SetResource( int, uint32_t );
         void RedrawTurnProgress( uint32_t );
         void QueueEventProcessing();
-
-        static void ResetTimer();
+        void TimerEventProcessing();
 
     private:
         friend Basic;
@@ -78,7 +79,10 @@ namespace Interface
         void DrawResourceInfo( int oh = 0 ) const;
         void DrawBackground() const;
         void DrawAITurns() const;
-        static uint32_t ResetResourceStatus( uint32_t, void * );
+
+        // This is the callback function set by fheroes2::Timer::run(). As a rule, it
+        // is called from a timer's internal thread.
+        static uint32_t timerShowLastResourceFired( uint32_t tick, void * ptr );
 
         Basic & interface;
 
@@ -88,6 +92,7 @@ namespace Interface
         uint32_t countLastResource;
         uint32_t turn_progress;
 
+        std::atomic<bool> resetStatusResource;
         fheroes2::Timer timerShowLastResource;
     };
 }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -259,7 +259,6 @@ void Heroes::Action( int tileIndex, bool isDestination )
         AudioManager::PlayMusic( MUS::FromMapObject( objectType ), Music::PlaybackMode::PLAY_ONCE );
 
     if ( MP2::isActionObject( objectType, isShipMaster() ) ) {
-        Interface::StatusWindow::ResetTimer();
         SetModes( ACTION );
     }
 


### PR DESCRIPTION
Regularly reported by the ThreadSanitizer. Fortunately, as far as I can see, there are no other places where the `fheroes2::Timer` is currently used.