### PR TITLE
Reset sounds through Audio Manager

### DIFF
--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -378,8 +378,12 @@ namespace
             }
 
             if ( !_loopSoundTasks.empty() ) {
-                std::swap( _currentLoopSoundTask, _loopSoundTasks.front() );
-                _loopSoundTasks.pop();
+                // Pick only the latest loop sound set and discard the rest.
+                std::swap( _currentLoopSoundTask, _loopSoundTasks.back() );
+
+                while ( !_loopSoundTasks.empty() ) {
+                    _loopSoundTasks.pop();
+                }
 
                 _taskToExecute = TaskType::PlayLoopSound;
 

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -247,6 +247,10 @@ namespace
             while ( !_soundTasks.empty() ) {
                 _soundTasks.pop();
             }
+
+            while ( !_loopSoundTasks.empty() ) {
+                _loopSoundTasks.pop();
+            }
         }
 
         void pushLoopSound( std::map<M82::SoundType, std::vector<AudioManager::AudioLoopEffectInfo>> vols, const int soundVolume, const bool is3DAudioEnabled )

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -263,14 +263,9 @@ namespace
                 _loopSoundTasks.pop();
             }
 
-            switch ( _taskToExecute ) {
-            case TaskType::PlaySound:
-            case TaskType::PlayLoopSound:
-                _taskToExecute = TaskType::None;
-                break;
-            default:
-                break;
-            }
+            // TODO: there is a chance that at the time of clearing all tasks executeTask() method would be executing by the worker thread.
+            // The worker thread will proceed with the execution producing incorrect results such as environment sounds being played in castle's windows.
+            // It is not wise to update the type of the task without synchronization.
         }
 
         void sync()
@@ -289,7 +284,9 @@ namespace
                 _loopSoundTasks.pop();
             }
 
-            _taskToExecute = TaskType::None;
+            // TODO: there is a chance that at the time of clearing all tasks executeTask() method would be executing by the worker thread.
+            // The worker thread will proceed with the execution producing incorrect results such as environment sounds being played in castle's windows.
+            // It is not wise to update the type of the task without synchronization.
         }
 
         // This mutex protects operations with AudioManager's resources, such as AGG files, data caches, etc

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -369,7 +369,7 @@ namespace
             }
 
             if ( !_soundTasks.empty() ) {
-                std::swap( _currentSoundTask, _soundTasks.back() );
+                std::swap( _currentSoundTask, _soundTasks.front() );
                 _soundTasks.pop();
 
                 _taskToExecute = TaskType::PlaySound;
@@ -378,7 +378,7 @@ namespace
             }
 
             if ( !_loopSoundTasks.empty() ) {
-                std::swap( _currentLoopSoundTask, _loopSoundTasks.back() );
+                std::swap( _currentLoopSoundTask, _loopSoundTasks.front() );
                 _loopSoundTasks.pop();
 
                 _taskToExecute = TaskType::PlayLoopSound;

--- a/src/fheroes2/audio/audio_manager.h
+++ b/src/fheroes2/audio/audio_manager.h
@@ -72,5 +72,7 @@ namespace AudioManager
     void PlayMusic( const int trackId, const Music::PlaybackMode playbackMode );
     void PlayMusicAsync( const int trackId, const Music::PlaybackMode playbackMode );
 
+    void stopSounds();
+
     void ResetAudio();
 }

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -262,8 +262,6 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readOnly, const b
 
     const fheroes2::StandardWindow background( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
 
-    AudioManager::stopSounds();
-
     AudioManager::PlayMusicAsync( MUS::FromRace( race ), Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 
     int alphaHero = 255;

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -262,6 +262,8 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readOnly, const b
 
     const fheroes2::StandardWindow background( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
 
+    AudioManager::stopSounds();
+
     AudioManager::PlayMusicAsync( MUS::FromRace( race ), Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 
     int alphaHero = 255;

--- a/src/fheroes2/game/game_loadgame.cpp
+++ b/src/fheroes2/game/game_loadgame.cpp
@@ -136,7 +136,7 @@ fheroes2::GameMode Game::LoadGame()
     outputLoadGameInTextSupportMode();
 
     // Stop all sounds, but not the music
-    Mixer::Stop();
+    AudioManager::stopSounds();
 
     AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 
@@ -235,7 +235,7 @@ fheroes2::GameMode Game::LoadStandard()
 fheroes2::GameMode Game::DisplayLoadGameDialog()
 {
     // Stop all sounds, but not the music
-    Mixer::Stop();
+    AudioManager::stopSounds();
 
     AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -168,7 +168,7 @@ void Game::mainGameLoop( bool isFirstGameRun )
 fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
 {
     // Stop all sounds, but not the music
-    Mixer::Stop();
+    AudioManager::stopSounds();
 
     AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -477,7 +477,7 @@ fheroes2::GameMode Game::NewGame()
     outputNewMenuInTextSupportMode();
 
     // Stop all sounds, but not the music
-    Mixer::Stop();
+    AudioManager::stopSounds();
 
     AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -131,7 +131,7 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */ )
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
     // Stop all sounds, but not the music - it will be replaced by the music of the castle
-    Mixer::Stop();
+    AudioManager::stopSounds();
 
     const Settings & conf = Settings::Get();
     Kingdom & myKingdom = world.GetKingdom( conf.CurrentColor() );


### PR DESCRIPTION
- fix cases when ambient sounds are still played while opening a castle's window
- fix incorrect order of music and sounds (pop call of std::queue actually removes front element, not back)

Note: video playback still uses Mixer::Stop() because it plays audio outside Audio Manager.