### PR TITLE
Multiple AudioManager fixes

### DIFF
--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -35,7 +35,6 @@
 #include <cassert>
 #include <deque>
 #include <optional>
-#include <tuple>
 #include <utility>
 
 namespace
@@ -233,11 +232,6 @@ namespace
 
             std::scoped_lock<std::mutex> lock( _mutex );
 
-            // Do not add sound to the queue if the queue already contains exactly the same sound
-            if ( std::find( _soundTasks.begin(), _soundTasks.end(), SoundTask( m82Sound, soundVolume ) ) != _soundTasks.end() ) {
-                return;
-            }
-
             _soundTasks.emplace_back( m82Sound, soundVolume );
 
             notifyWorker();
@@ -323,11 +317,6 @@ namespace
                 , soundVolume( soundVolume_ )
             {
                 // Do nothing.
-            }
-
-            bool operator==( const SoundTask & other ) const
-            {
-                return std::tie( m82Sound, soundVolume ) == std::tie( other.m82Sound, other.soundVolume );
             }
 
             int m82Sound{ 0 };

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -251,7 +251,46 @@ namespace
             notifyWorker();
         }
 
+        void removeMusicTasks()
+        {
+            std::scoped_lock<std::mutex> lock( _mutex );
+
+            while ( !_musicTasks.empty() ) {
+                _musicTasks.pop();
+            }
+
+            if ( _taskToExecute == TaskType::PlayMusic ) {
+                _taskToExecute = TaskType::None;
+            }
+        }
+
         void removeSoundTasks()
+        {
+            std::scoped_lock<std::mutex> lock( _mutex );
+
+            while ( !_soundTasks.empty() ) {
+                _soundTasks.pop();
+            }
+
+            if ( _taskToExecute == TaskType::PlaySound ) {
+                _taskToExecute = TaskType::None;
+            }
+        }
+
+        void removeLoopSoundTasks()
+        {
+            std::scoped_lock<std::mutex> lock( _mutex );
+
+            while ( !_loopSoundTasks.empty() ) {
+                _loopSoundTasks.pop();
+            }
+
+            if ( _taskToExecute == TaskType::PlayLoopSound ) {
+                _taskToExecute = TaskType::None;
+            }
+        }
+
+        void removeAllSoundTasks()
         {
             std::scoped_lock<std::mutex> lock( _mutex );
 
@@ -820,7 +859,7 @@ namespace AudioManager
             g_asyncSoundManager.pushLoopSound( std::move( soundEffects ), conf.SoundVolume(), conf.is3DAudioEnabled() );
         }
         else {
-            g_asyncSoundManager.removeAllTasks();
+            g_asyncSoundManager.removeLoopSoundTasks();
 
             playLoopSoundsInternally( std::move( soundEffects ), conf.SoundVolume(), conf.is3DAudioEnabled() );
         }
@@ -840,7 +879,7 @@ namespace AudioManager
             g_asyncSoundManager.pushSound( m82, Settings::Get().SoundVolume() );
         }
         else {
-            g_asyncSoundManager.removeAllTasks();
+            g_asyncSoundManager.removeSoundTasks();
 
             PlaySoundInternally( m82, Settings::Get().SoundVolume() );
         }
@@ -856,7 +895,7 @@ namespace AudioManager
             return;
         }
 
-        g_asyncSoundManager.removeAllTasks();
+        g_asyncSoundManager.removeMusicTasks();
 
         PlayMusicInternally( trackId, Settings::Get().MusicType(), playbackMode );
     }
@@ -880,7 +919,7 @@ namespace AudioManager
             return;
         }
 
-        g_asyncSoundManager.removeSoundTasks();
+        g_asyncSoundManager.removeAllSoundTasks();
 
         std::scoped_lock<std::recursive_mutex> lock( g_asyncSoundManager.resourceMutex() );
 

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -407,6 +407,7 @@ namespace
 
         std::recursive_mutex _resourceMutex;
 
+        // This method is called by the worker thread and is protected by _mutex
         bool prepareTask() override
         {
             if ( !_musicTasks.empty() ) {
@@ -448,8 +449,12 @@ namespace
             return false;
         }
 
+        // This method is called by the worker thread, but is not protected by _mutex
         void executeTask() override
         {
+            // Do not allow the main thread to acquire this mutex in the interval between the
+            // _taskToExecute was checked and the task was started executing. Release it only
+            // when the task is fully completed.
             std::scoped_lock<std::recursive_mutex> lock( _resourceMutex );
 
             switch ( _taskToExecute ) {

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -254,39 +254,6 @@ namespace
             notifyWorker();
         }
 
-        void removeMusicTasks()
-        {
-            std::scoped_lock<std::mutex> lock( _mutex );
-
-            _musicTask.reset();
-
-            if ( _taskToExecute == TaskType::PlayMusic ) {
-                _taskToExecute = TaskType::None;
-            }
-        }
-
-        void removeSoundTasks()
-        {
-            std::scoped_lock<std::mutex> lock( _mutex );
-
-            _soundTasks.clear();
-
-            if ( _taskToExecute == TaskType::PlaySound ) {
-                _taskToExecute = TaskType::None;
-            }
-        }
-
-        void removeLoopSoundTasks()
-        {
-            std::scoped_lock<std::mutex> lock( _mutex );
-
-            _loopSoundTask.reset();
-
-            if ( _taskToExecute == TaskType::PlayLoopSound ) {
-                _taskToExecute = TaskType::None;
-            }
-        }
-
         void removeAllSoundTasks()
         {
             std::scoped_lock<std::mutex> lock( _mutex );
@@ -847,7 +814,7 @@ namespace AudioManager
             g_asyncSoundManager.pushLoopSound( std::move( soundEffects ), conf.SoundVolume(), conf.is3DAudioEnabled() );
         }
         else {
-            g_asyncSoundManager.removeLoopSoundTasks();
+            g_asyncSoundManager.removeAllTasks();
 
             playLoopSoundsInternally( std::move( soundEffects ), conf.SoundVolume(), conf.is3DAudioEnabled() );
         }
@@ -867,7 +834,7 @@ namespace AudioManager
             g_asyncSoundManager.pushSound( m82, Settings::Get().SoundVolume() );
         }
         else {
-            g_asyncSoundManager.removeSoundTasks();
+            g_asyncSoundManager.removeAllTasks();
 
             PlaySoundInternally( m82, Settings::Get().SoundVolume() );
         }
@@ -883,7 +850,7 @@ namespace AudioManager
             return;
         }
 
-        g_asyncSoundManager.removeMusicTasks();
+        g_asyncSoundManager.removeAllTasks();
 
         PlayMusicInternally( trackId, Settings::Get().MusicType(), playbackMode );
     }

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -822,6 +822,7 @@ namespace AudioManager
             return;
         }
 
+        // TODO: in general, we should not remove all queued tasks here, but only tasks of the same type
         g_asyncSoundManager.removeAllTasks();
 
         PlaySoundInternally( m82, Settings::Get().SoundVolume() );
@@ -850,6 +851,7 @@ namespace AudioManager
             return;
         }
 
+        // TODO: in general, we should not remove all queued tasks here, but only tasks of the same type
         g_asyncSoundManager.removeAllTasks();
 
         PlayMusicInternally( trackId, Settings::Get().MusicType(), playbackMode );

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -802,7 +802,7 @@ namespace AudioManager
         currentAudioLoopEffects.clear();
     }
 
-    void playLoopSounds( std::map<M82::SoundType, std::vector<AudioLoopEffectInfo>> soundEffects, bool asyncronizedCall )
+    void playLoopSoundsAsync( std::map<M82::SoundType, std::vector<AudioLoopEffectInfo>> soundEffects )
     {
         if ( !Audio::isValid() ) {
             return;
@@ -810,17 +810,10 @@ namespace AudioManager
 
         const Settings & conf = Settings::Get();
 
-        if ( asyncronizedCall ) {
-            g_asyncSoundManager.pushLoopSound( std::move( soundEffects ), conf.SoundVolume(), conf.is3DAudioEnabled() );
-        }
-        else {
-            g_asyncSoundManager.removeAllTasks();
-
-            playLoopSoundsInternally( std::move( soundEffects ), conf.SoundVolume(), conf.is3DAudioEnabled() );
-        }
+        g_asyncSoundManager.pushLoopSound( std::move( soundEffects ), conf.SoundVolume(), conf.is3DAudioEnabled() );
     }
 
-    void PlaySound( int m82, bool asyncronizedCall )
+    void PlaySound( const int m82 )
     {
         if ( m82 == M82::UNKNOWN ) {
             return;
@@ -830,14 +823,22 @@ namespace AudioManager
             return;
         }
 
-        if ( asyncronizedCall ) {
-            g_asyncSoundManager.pushSound( m82, Settings::Get().SoundVolume() );
-        }
-        else {
-            g_asyncSoundManager.removeAllTasks();
+        g_asyncSoundManager.removeAllTasks();
 
-            PlaySoundInternally( m82, Settings::Get().SoundVolume() );
+        PlaySoundInternally( m82, Settings::Get().SoundVolume() );
+    }
+
+    void PlaySoundAsync( const int m82 )
+    {
+        if ( m82 == M82::UNKNOWN ) {
+            return;
         }
+
+        if ( !Audio::isValid() ) {
+            return;
+        }
+
+        g_asyncSoundManager.pushSound( m82, Settings::Get().SoundVolume() );
     }
 
     void PlayMusic( const int trackId, const Music::PlaybackMode playbackMode )

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -368,7 +368,6 @@ namespace
         {
             if ( _musicTask ) {
                 std::swap( _currentMusicTask, *_musicTask );
-
                 _musicTask.reset();
 
                 _taskToExecute = TaskType::PlayMusic;
@@ -387,7 +386,6 @@ namespace
 
             if ( _loopSoundTask ) {
                 std::swap( _currentLoopSoundTask, *_loopSoundTask );
-
                 _loopSoundTask.reset();
 
                 _taskToExecute = TaskType::PlayLoopSound;
@@ -396,6 +394,7 @@ namespace
             }
 
             _taskToExecute = TaskType::None;
+
             return false;
         }
 

--- a/src/fheroes2/audio/audio_manager.h
+++ b/src/fheroes2/audio/audio_manager.h
@@ -66,8 +66,10 @@ namespace AudioManager
         uint8_t volumePercentage{ 0 };
     };
 
-    void playLoopSounds( std::map<M82::SoundType, std::vector<AudioLoopEffectInfo>> soundEffects, bool asyncronizedCall );
-    void PlaySound( int m82, bool asyncronizedCall = false );
+    void playLoopSoundsAsync( std::map<M82::SoundType, std::vector<AudioLoopEffectInfo>> soundEffects );
+
+    void PlaySound( const int m82 );
+    void PlaySoundAsync( const int m82 );
 
     void PlayMusic( const int trackId, const Music::PlaybackMode playbackMode );
     void PlayMusicAsync( const int trackId, const Music::PlaybackMode playbackMode );

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -468,7 +468,7 @@ void Game::EnvironmentSoundMixer()
         }
     }
 
-    AudioManager::playLoopSounds( std::move( soundEffects ), true );
+    AudioManager::playLoopSoundsAsync( std::move( soundEffects ) );
 }
 
 void Game::restoreSoundsForCurrentFocus()

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -188,7 +188,11 @@ void Interface::Basic::EventCastSpell()
     const Spell spell = hero->OpenSpellBook( SpellBook::Filter::ADVN, true, nullptr );
     if ( spell.isValid() ) {
         hero->ActionSpellCast( spell );
-        iconsPanel.SetRedraw();
+
+        // The spell will consume the hero's spell points (and perhaps also movement points) and can move the
+        // hero to another location, so we may have to update the terrain music theme and environment sounds
+        ResetFocus( GameFocus::HEROES );
+        RedrawFocus();
     }
 }
 

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -81,7 +81,7 @@ void PlayWalkSound( int ground )
         break;
     }
 
-    AudioManager::PlaySound( wav, true );
+    AudioManager::PlaySoundAsync( wav );
 }
 
 bool ReflectSprite( int from )


### PR DESCRIPTION
First of all, this PR aims to fix the potential failure of `AudioManager` to stop the sound/music. In addition to making the `_taskToExecute` atomic (so it can be safely accessed by different threads without holding the same mutex), `executeTask()` now acquires `_resourceMutex` before checking the `_taskToExecute` (and for the entire duration of its execution) to avoid the scenario when `_taskToExecute` was checked and task is planned, then `_resourceMutex` was acquired by the main thread, which stops the music, but then the worker thread starts the music again.

Possible scenarios (at least essential ones):

* 1\. `stopSounds()`/`ResetAudio()` is called from the main thread (MT) when `prepareTask()` is executing on the worker thread (WT). `prepareTask()` holds the `_mutex`, `_taskToExecute` has been set to something, then `_mutex` has been released. Then `executeTask()` will be eventually called, and it will holds the `_resourceMutex` until its task will be completed. Here we have the following options:

  * 1\.1\. If `_taskToExecute` will be cleared by `removeSoundTasks()`/`removeAllTasks()` on the MT before it will be checked by WT, then we are all set, no task will be performed.

  * 1\.2\. If it will be cleared later, then WT performs the full cycle, while MT is waiting on the `_resourceMutex`, and then, when WT finishes, MT acquires the `_resourceMutex` and calls `Music::Stop()`/`Mixer::Stop()`. All actions just performed by WT has been reset.

* 2\. `stopSounds()`/`ResetAudio()` is called from the MT when `executeTask()` is executing on the WT. The same as 1.1/1.2.

* 3\. `stopSounds()`/`ResetAudio()` is called from the MT between `prepareTask()` and `executeTask()` on the WT. We have the following options:

  * 3\.1\. Only `removeSoundTasks()`/`removeAllTasks()` is managed to be executed on MT before/during the `executeTask()` acquires the `_resourceMutex` on WT. The same as 1.1/1.2.

  * 3\.2\. `stopSounds()`/`ResetAudio()` is fully completed on MT before `executeTask()` acquires the `_resourceMutex` on WT. The `_taskToExecute` has already been cleared, so `executeTask()` has nothing to do.

* 4\. `stopSounds()`/`ResetAudio()` is called from the MT when no task is executed at all on WT. `removeSoundTasks()`/`removeAllTasks()` is called from the MT, it holds the `_mutex`, `_taskToExecute` has been cleared as well as all task queues. Even if WT has been already kicked and `prepareTask()` is a little late and already waiting on the `_mutex`, there will be no tasks when it acquires the `_mutex`.

Hi @ihhub can you come up with a scenario where the sound won't be stopped properly?

Also, I've always wondered why all the task queues are cleared when a certain type of sound should be played in non-asynchronous mode. In my opinion, this is wrong and we need to clear the task queue for sounds only of the type that we want to play in the non-async mode (for example, when we want to play music, then just the `musicTasks` should be cleared).

Also this PR fixes the regression after #5545 - terrain music and environment sounds wasn't updated properly after casting any teleport spells (Dimension Door, Town Gate, Town Portal).