### PR TITLE
Fix the castle well build logic

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_castle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_castle.cpp
@@ -136,7 +136,7 @@ namespace AI
 
     bool CastleDevelopment( Castle & castle, int safetyFactor, int spellLevel )
     {
-        if ( !castle.isBuild( BUILD_WELL ) && world.LastDay() ) {
+        if ( !castle.isBuild( BUILD_WELL ) && world.CountDay() > 6 ) {
             // return right away - if you can't buy Well you can't buy anything else
             return BuildIfAvailable( castle, BUILD_WELL );
         }


### PR DESCRIPTION
Fixes #5162 .

Building wells only on last day of the week is unreliable. Do that only during the first week.