### PR TITLE
AI should keep some creatures in reserve for castle defense

### DIFF
--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -125,7 +125,6 @@ namespace AI
     bool BuildIfAvailable( Castle & castle, int building );
     bool BuildIfEnoughResources( Castle & castle, int building, uint32_t minimumMultiplicator );
     uint32_t GetResourceMultiplier( uint32_t min, uint32_t max );
-    void ReinforceHeroInCastle( Heroes & hero, Castle & castle, const Funds & budget );
     void OptimizeTroopsOrder( Army & hero );
 
     StreamBase & operator<<( StreamBase &, const AI::Base & );

--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -57,26 +57,6 @@ namespace AI
         return Rand::Get( min, max );
     }
 
-    void ReinforceHeroInCastle( Heroes & hero, Castle & castle, const Funds & budget )
-    {
-        if ( !hero.HaveSpellBook() && castle.GetLevelMageGuild() > 0 && !hero.IsFullBagArtifacts() ) {
-            // this call will check if AI kingdom have enough resources to buy book
-            hero.BuySpellBook( &castle );
-        }
-
-        Army & heroArmy = hero.GetArmy();
-        const double armyStrength = heroArmy.GetStrength();
-
-        heroArmy.UpgradeTroops( castle );
-        castle.recruitBestAvailable( budget );
-        heroArmy.JoinStrongestFromArmy( castle.GetArmy() );
-        OptimizeTroopsOrder( heroArmy );
-
-        if ( std::fabs( armyStrength - heroArmy.GetStrength() ) > 0.001 ) {
-            hero.unmarkHeroMeeting();
-        }
-    }
-
     void OptimizeTroopsOrder( Army & army )
     {
         // Optimize troops placement before the battle

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -191,6 +191,7 @@ namespace AI
         void HeroesActionComplete( Heroes & hero, const MP2::MapObjectType objectType ) override;
 
         bool recruitHero( Castle & castle, bool buyArmy, bool underThreat );
+        void reinforceHeroInCastle( Heroes & hero, Castle & castle, const Funds & budget );
         void evaluateRegionSafety();
         std::set<int> findCastlesInDanger( const KingdomCastles & castles, const std::vector<std::pair<int, const Army *>> & enemyArmies, int myColor );
         std::vector<AICastle> getSortedCastleList( const KingdomCastles & castles, const std::set<int> & castlesInDanger );

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1359,7 +1359,7 @@ namespace AI
     {
         Castle * castle = hero.inCastleMutable();
         if ( castle ) {
-            ReinforceHeroInCastle( hero, *castle, castle->GetKingdom().GetFunds() );
+            reinforceHeroInCastle( hero, *castle, castle->GetKingdom().GetFunds() );
         }
 
         if ( isMonsterStrengthCacheable( objectType ) ) {

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -155,8 +155,9 @@ namespace AI
             bool onlyHalf = false;
             Troop * unitToSwap = heroArmy.GetSlowestTroop();
             if ( unitToSwap ) {
-                double significanceRatio = isFigtherHero ? 20.0 : 10.0;
                 // if it's slow and doesn't contribute much to army strength we leave it all in town
+                // 5% of total army for Figthers 10% otherwise
+                const double significanceRatio = isFigtherHero ? 20.0 : 10.0;
                 if ( unitToSwap->GetStrength() > armyStrength / significanceRatio ) {
                     Troop * weakest = heroArmy.GetWeakestTroop();
 

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -148,6 +148,7 @@ namespace AI
 
         const uint32_t regionID = world.GetTiles( castle.GetIndex() ).GetRegion();
         // check if we should leave some troops in the garrison
+        // TODO: amount of troops left could depend on region's safetyFactor
         if ( castle.isCastle() && _regions[regionID].safetyFactor <= 100 && !garrison.isValid() ) {
             const Heroes::Role heroRole = hero.getAIRole();
             const bool isFigtherHero = ( heroRole == Heroes::Role::FIGHTER || heroRole == Heroes::Role::CHAMPION );
@@ -155,8 +156,6 @@ namespace AI
             bool onlyHalf = false;
             Troop * unitToSwap = heroArmy.GetSlowestTroop();
             if ( unitToSwap ) {
-                // if it's slow and doesn't contribute much to army strength we leave it all in town
-                // 5% of total army for Figthers 10% otherwise
                 const double significanceRatio = isFigtherHero ? 20.0 : 10.0;
                 if ( unitToSwap->GetStrength() > armyStrength / significanceRatio ) {
                     Troop * weakest = heroArmy.GetWeakestTroop();

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -125,10 +125,74 @@ namespace AI
 
         if ( recruit && buyArmy ) {
             CastleTurn( castle, underThreat );
-            ReinforceHeroInCastle( *recruit, castle, kingdom.GetFunds() );
+            reinforceHeroInCastle( *recruit, castle, kingdom.GetFunds() );
         }
 
         return recruit != nullptr;
+    }
+
+    void Normal::reinforceHeroInCastle( Heroes & hero, Castle & castle, const Funds & budget )
+    {
+        if ( !hero.HaveSpellBook() && castle.GetLevelMageGuild() > 0 && !hero.IsFullBagArtifacts() ) {
+            // this call will check if AI kingdom have enough resources to buy book
+            hero.BuySpellBook( &castle );
+        }
+
+        Army & heroArmy = hero.GetArmy();
+        Army & garrison = castle.GetArmy();
+        const double armyStrength = heroArmy.GetStrength();
+
+        heroArmy.UpgradeTroops( castle );
+        castle.recruitBestAvailable( budget );
+        heroArmy.JoinStrongestFromArmy( garrison );
+
+        const uint32_t regionID = world.GetTiles( castle.GetIndex() ).GetRegion();
+        // check if we should leave some troops in the garrison
+        if ( castle.isCastle() && _regions[regionID].safetyFactor <= 100 && !garrison.isValid() ) {
+            const Heroes::Role heroRole = hero.getAIRole();
+            const bool isFigtherHero = ( heroRole == Heroes::Role::FIGHTER || heroRole == Heroes::Role::CHAMPION );
+
+            bool onlyHalf = false;
+            Troop * unitToSwap = heroArmy.GetSlowestTroop();
+            if ( unitToSwap ) {
+                double significanceRatio = isFigtherHero ? 20.0 : 10.0;
+                // if it's slow and doesn't contribute much to army strength we leave it all in town
+                if ( unitToSwap->GetStrength() > armyStrength / significanceRatio ) {
+                    Troop * weakest = heroArmy.GetWeakestTroop();
+
+                    assert( weakest != nullptr );
+                    if ( weakest ) {
+                        unitToSwap = weakest;
+                        if ( weakest->GetStrength() > armyStrength / significanceRatio ) {
+                            if ( isFigtherHero ) {
+                                // if it's an important hero and all troops are significant - keep the army
+                                unitToSwap = nullptr;
+                            }
+                            else {
+                                onlyHalf = true;
+                            }
+                        }
+                    }
+                }
+            }
+            if ( unitToSwap ) {
+                const uint32_t count = unitToSwap->GetCount();
+                const uint32_t toMove = onlyHalf ? count / 2 : count;
+                if ( garrison.JoinTroop( unitToSwap->GetMonster(), toMove, true ) ) {
+                    if ( !onlyHalf ) {
+                        unitToSwap->Reset();
+                    }
+                    else {
+                        unitToSwap->SetCount( count - toMove );
+                    }
+                }
+            }
+        }
+
+        OptimizeTroopsOrder( heroArmy );
+        if ( std::fabs( armyStrength - heroArmy.GetStrength() ) > 0.001 ) {
+            hero.unmarkHeroMeeting();
+        }
     }
 
     void Normal::evaluateRegionSafety()

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -486,7 +486,7 @@ Troop * Troops::GetWeakestTroop() const
     return *lowest;
 }
 
-const Troop * Troops::GetSlowestTroop() const
+Troop * Troops::GetSlowestTroop() const
 {
     const_iterator first = begin();
     const_iterator last = end();

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -94,7 +94,7 @@ public:
 
     Troop * GetFirstValid();
     Troop * GetWeakestTroop() const;
-    const Troop * GetSlowestTroop() const;
+    Troop * GetSlowestTroop() const;
 
     void SortStrongest();
     void ArrangeForBattle( bool = false );

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -538,7 +538,7 @@ uint32_t Heroes::GetMaxMovePoints() const
         point += 500 * world.CountCapturedObject( MP2::OBJ_LIGHTHOUSE, GetColor() );
     }
     else {
-        Troop * troop = army.GetSlowestTroop();
+        const Troop * troop = army.GetSlowestTroop();
 
         if ( troop )
             switch ( troop->GetSpeed() ) {

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -538,7 +538,7 @@ uint32_t Heroes::GetMaxMovePoints() const
         point += 500 * world.CountCapturedObject( MP2::OBJ_LIGHTHOUSE, GetColor() );
     }
     else {
-        const Troop * troop = army.GetSlowestTroop();
+        Troop * troop = army.GetSlowestTroop();
 
         if ( troop )
             switch ( troop->GetSpeed() ) {


### PR DESCRIPTION
Fixes #5304 .

Now AI could leave some garrison (preferably slow units) behind when reinforcing the heroes if region is not completely safe.

Fighter heroes should be less likely to leave troops in town than regular ones to avoid players intentionally exploiting the feature by splitting the army on castle recaptures (common OG flaw).