### PR TITLE
Improving AI castle defenses

### DIFF
--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -80,7 +80,7 @@ namespace AI
         virtual void HeroesPreBattle( HeroBase & hero, bool isAttacking );
         virtual void HeroesAfterBattle( HeroBase & hero, bool wasAttacking );
         virtual void HeroesPostLoad( Heroes & hero );
-        virtual void HeroesActionComplete( Heroes & hero, const MP2::MapObjectType objectType );
+        virtual void HeroesActionComplete( Heroes & hero, int32_t tileIndex, const MP2::MapObjectType objectType );
         virtual void HeroesActionNewPosition( Heroes & hero );
         virtual void HeroesClearTask( const Heroes & hero );
         virtual void HeroesLevelUp( Heroes & hero );

--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -62,6 +62,19 @@ namespace AI
         EXPLORER
     };
 
+    // Although AI heroes are capable to find their own tasks we can strategic AI should be able to focus them on most critical tasks
+    enum class PriorityTask : int
+    {
+        // AI will focus on siegeing or chasing the selected enemy castle or hero.
+        ATTACK,
+
+        // Target will usually be a friendly castle. AI will move heroes to defend and garrison it.
+        DEFEND,
+
+        // Target must be a friendly castle or hero. AI with such priority set should focus on bringing more troops to the target.
+        REINFORCE
+    };
+
     const double ARMY_ADVANTAGE_DESPERATE = 0.8;
     const double ARMY_ADVANTAGE_SMALL = 1.3;
     const double ARMY_ADVANTAGE_MEDIUM = 1.5;

--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -62,7 +62,7 @@ namespace AI
         EXPLORER
     };
 
-    // Although AI heroes are capable to find their own tasks we can strategic AI should be able to focus them on most critical tasks
+    // Although AI heroes are capable to find their own tasks strategic AI should be able to focus them on most critical tasks
     enum class PriorityTask : int
     {
         // AI will focus on siegeing or chasing the selected enemy castle or hero.

--- a/src/fheroes2/ai/ai_base.cpp
+++ b/src/fheroes2/ai/ai_base.cpp
@@ -106,7 +106,7 @@ namespace AI
         return std::string();
     }
 
-    void Base::HeroesActionComplete( Heroes & /*hero*/, const MP2::MapObjectType /*objectType*/ )
+    void Base::HeroesActionComplete( Heroes & /*hero*/, int32_t /* tileIndex*/, const MP2::MapObjectType /*objectType*/ )
     {
         // Do nothing.
     }

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -500,7 +500,7 @@ namespace AI
 
         // ignore empty tiles
         if ( isAction )
-            AI::Get().HeroesActionComplete( hero, objectType );
+            AI::Get().HeroesActionComplete( hero, dst_index, objectType );
     }
 
     void AIToHeroes( Heroes & hero, int32_t dst_index )

--- a/src/fheroes2/ai/normal/ai_normal.cpp
+++ b/src/fheroes2/ai/normal/ai_normal.cpp
@@ -41,9 +41,4 @@ namespace AI
         if ( object != MP2::OBJ_ZERO )
             _mapObjects.emplace_back( tile.GetIndex(), object );
     }
-
-    bool Normal::isCriticalTask( const int index ) const
-    {
-        return _priorityTargets.find( index ) != _priorityTargets.end();
-    }
 }

--- a/src/fheroes2/ai/normal/ai_normal.cpp
+++ b/src/fheroes2/ai/normal/ai_normal.cpp
@@ -41,4 +41,9 @@ namespace AI
         if ( object != MP2::OBJ_ZERO )
             _mapObjects.emplace_back( tile.GetIndex(), object );
     }
+
+    bool Normal::isCriticalTask( const int index ) const
+    {
+        return _priorityTargets.find( index ) != _priorityTargets.end();
+    }
 }

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -25,6 +25,7 @@
 #include "kingdom.h"
 #include "world_pathfinding.h"
 
+#include <map>
 #include <set>
 
 struct KingdomCastles;
@@ -188,7 +189,7 @@ namespace AI
         void revealFog( const Maps::Tiles & tile ) override;
 
         void HeroesPreBattle( HeroBase & hero, bool isAttacking ) override;
-        void HeroesActionComplete( Heroes & hero, const MP2::MapObjectType objectType ) override;
+        void HeroesActionComplete( Heroes & hero, int32_t tileIndex, const MP2::MapObjectType objectType ) override;
 
         bool recruitHero( Castle & castle, bool buyArmy, bool underThreat );
         void evaluateRegionSafety();
@@ -197,6 +198,7 @@ namespace AI
 
         double getObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         int getPriorityTarget( const HeroToMove & heroInfo, double & maxPriority );
+        bool isCriticalTask( const int index ) const;
         void resetPathfinder() override;
 
         void battleBegins() override;
@@ -207,6 +209,7 @@ namespace AI
         // following data won't be saved/serialized
         double _combinedHeroStrength = 0;
         std::vector<IndexObject> _mapObjects;
+        std::map<int, int> _priorityTargets;
         std::vector<RegionStats> _regions;
         AIWorldPathfinder _pathfinder;
         BattlePlanner _battlePlanner;

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -209,7 +209,7 @@ namespace AI
         // following data won't be saved/serialized
         double _combinedHeroStrength = 0;
         std::vector<IndexObject> _mapObjects;
-        std::map<int, bool> _priorityTargets;
+        std::map<int, PriorityTask> _priorityTargets;
         std::vector<RegionStats> _regions;
         AIWorldPathfinder _pathfinder;
         BattlePlanner _battlePlanner;

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -198,12 +198,16 @@ namespace AI
 
         double getObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         int getPriorityTarget( const HeroToMove & heroInfo, double & maxPriority );
-        bool isCriticalTask( const int index ) const;
         void resetPathfinder() override;
 
         void battleBegins() override;
 
         double getTargetArmyStrength( const Maps::Tiles & tile, const MP2::MapObjectType objectType );
+
+        bool isCriticalTask( const int index ) const
+        {
+            return _priorityTargets.find( index ) != _priorityTargets.end();
+        }
 
     private:
         // following data won't be saved/serialized

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -209,7 +209,7 @@ namespace AI
         // following data won't be saved/serialized
         double _combinedHeroStrength = 0;
         std::vector<IndexObject> _mapObjects;
-        std::map<int, int> _priorityTargets;
+        std::map<int, bool> _priorityTargets;
         std::vector<RegionStats> _regions;
         AIWorldPathfinder _pathfinder;
         BattlePlanner _battlePlanner;

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -681,8 +681,12 @@ namespace AI
             if ( !castle )
                 return valueToIgnore;
 
+            const bool critical = isCriticalTask( index );
             if ( hero.GetColor() == castle->GetColor() ) {
                 double value = castle->getVisitValue( hero );
+                if ( critical )
+                    return 10000 + value;
+
                 if ( value < 500 )
                     return valueToIgnore;
 
@@ -703,15 +707,14 @@ namespace AI
             }
 
             double value = castle->getBuildingValue() * 150.0 + 3000;
-            if ( hero.isLosingGame() )
+            if ( critical || hero.isLosingGame() )
                 value += 15000;
             // If the castle is defenseless
             if ( !castle->GetActualArmy().isValid() )
                 value *= 1.25;
 
-            if ( isCastleLossConditionForHuman( castle ) ) {
+            if ( isCastleLossConditionForHuman( castle ) )
                 value += 20000;
-            }
 
             return value;
         }
@@ -749,7 +752,8 @@ namespace AI
                 return -dangerousTaskPenalty;
             }
 
-            return 5000.0;
+            // focus on enemy hero if there's priority set (i.e. hero is threatning our castle)
+            return isCriticalTask( index ) ? 15000.0 : 5000.0;
         }
         else if ( objectType == MP2::OBJ_MONSTER ) {
             return 1000.0;
@@ -960,8 +964,12 @@ namespace AI
             if ( !castle )
                 return valueToIgnore;
 
+            const bool critical = isCriticalTask( index );
             if ( hero.GetColor() == castle->GetColor() ) {
                 double value = castle->getVisitValue( hero );
+                if ( critical )
+                    return 10000 + value;
+
                 if ( value < 500 )
                     return valueToIgnore;
 
@@ -982,15 +990,15 @@ namespace AI
             }
 
             double value = castle->getBuildingValue() * 500.0 + 15000;
-            if ( hero.isLosingGame() )
+            if ( critical || hero.isLosingGame() )
                 value += 15000;
             // If the castle is defenseless
+            // This modifier shouldn't be too high to avoid players baiting AI in
             if ( !castle->GetActualArmy().isValid() )
-                value *= 2.5;
+                value *= 1.5;
 
-            if ( isCastleLossConditionForHuman( castle ) ) {
+            if ( isCastleLossConditionForHuman( castle ) )
                 value += 20000;
-            }
 
             return value;
         }
@@ -1028,7 +1036,7 @@ namespace AI
                 return -dangerousTaskPenalty;
             }
 
-            return 12000.0;
+            return isCriticalTask( index ) ? 20000.0 : 12000.0;
         }
         else if ( objectType == MP2::OBJ_MONSTER ) {
             return anotherFriendlyHeroPresent ? 4000.0 : 1000.0;
@@ -1355,7 +1363,7 @@ namespace AI
         return priorityTarget;
     }
 
-    void Normal::HeroesActionComplete( Heroes & hero, const MP2::MapObjectType objectType )
+    void Normal::HeroesActionComplete( Heroes & hero, int32_t tileIndex, const MP2::MapObjectType objectType )
     {
         Castle * castle = hero.inCastleMutable();
         if ( castle ) {
@@ -1363,12 +1371,9 @@ namespace AI
         }
 
         if ( isMonsterStrengthCacheable( objectType ) ) {
-            // An object can be at the same tile at the hero or on a neighbouring tile so erase all tiles around the hero including the tile where the hero is standing.
-            const int32_t heroIndex = hero.GetIndex();
-            for ( int32_t offset : { 0, 1, -1, world.w(), world.w() + 1, world.w() - 1, -world.w(), -world.w() + 1, -world.w() - 1 } ) {
-                _neutralMonsterStrengthCache.erase( heroIndex + offset );
-            }
+            _neutralMonsterStrengthCache.erase( tileIndex );
         }
+        _priorityTargets.erase( tileIndex );
     }
 
     bool Normal::HeroesTurn( VecHeroes & heroes )

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1376,7 +1376,7 @@ namespace AI
         if ( objectType == MP2::OBJ_CASTLE || objectType == MP2::OBJ_HEROES ) {
             const auto it = _priorityTargets.find( tileIndex );
             if ( it != _priorityTargets.end() ) {
-                if ( it->second ) {
+                if ( it->second == PriorityTask::DEFEND ) {
                     hero.SetModes( Heroes::SLEEPER );
                 }
 

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -753,7 +753,7 @@ namespace AI
             }
 
             // focus on enemy hero if there's priority set (i.e. hero is threatning our castle)
-            return isCriticalTask( index ) ? 15000.0 : 5000.0;
+            return isCriticalTask( index ) ? 12000.0 : 5000.0;
         }
         else if ( objectType == MP2::OBJ_MONSTER ) {
             return 1000.0;
@@ -968,7 +968,7 @@ namespace AI
             if ( hero.GetColor() == castle->GetColor() ) {
                 double value = castle->getVisitValue( hero );
                 if ( critical )
-                    return 10000 + value;
+                    return 15000 + value;
 
                 if ( value < 500 )
                     return valueToIgnore;
@@ -1373,7 +1373,16 @@ namespace AI
         if ( isMonsterStrengthCacheable( objectType ) ) {
             _neutralMonsterStrengthCache.erase( tileIndex );
         }
-        _priorityTargets.erase( tileIndex );
+        if ( objectType == MP2::OBJ_CASTLE || objectType == MP2::OBJ_HEROES ) {
+            const auto it = _priorityTargets.find( tileIndex );
+            if ( it != _priorityTargets.end() ) {
+                if ( it->second ) {
+                    hero.SetModes( Heroes::SLEEPER );
+                }
+
+                _priorityTargets.erase( it );
+            }
+        }
     }
 
     bool Normal::HeroesTurn( VecHeroes & heroes )

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -248,13 +248,13 @@ namespace AI
 
                 const double attackerThreat = attackerStrength - defenders;
                 if ( attackerThreat > 0 ) {
-                    _priorityTargets[enemy.first] = attackerStrength;
+                    _priorityTargets[enemy.first] = false;
                     const uint32_t dist = _pathfinder.getDistance( enemy.first, castleIndex, myColor, attackerStrength );
                     if ( dist && dist < threatDistanceLimit ) {
                         // castle is under threat
                         castlesInDanger.insert( castleIndex );
 
-                        _priorityTargets[castleIndex] = defenders;
+                        _priorityTargets[castleIndex] = true;
                     }
                 }
             }
@@ -292,6 +292,8 @@ namespace AI
         Heroes * bestHeroToViewAll = nullptr;
 
         for ( Heroes * hero : heroes ) {
+            hero->ResetModes( Heroes::SLEEPER );
+
             const double strength = hero->GetArmy().GetStrength();
             _combinedHeroStrength += strength;
             if ( !hero->Modes( Heroes::PATROL ) )

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -248,10 +248,13 @@ namespace AI
 
                 const double attackerThreat = attackerStrength - defenders;
                 if ( attackerThreat > 0 ) {
+                    _priorityTargets[enemy.first] = attackerStrength;
                     const uint32_t dist = _pathfinder.getDistance( enemy.first, castleIndex, myColor, attackerStrength );
                     if ( dist && dist < threatDistanceLimit ) {
                         // castle is under threat
                         castlesInDanger.insert( castleIndex );
+
+                        _priorityTargets[castleIndex] = defenders;
                     }
                 }
             }
@@ -306,6 +309,7 @@ namespace AI
         std::vector<std::pair<int, const Army *>> enemyArmies;
 
         const int mapSize = world.w() * world.h();
+        _priorityTargets.clear();
         _mapObjects.clear();
         _regions.clear();
         _regions.resize( world.getRegionCount() );
@@ -399,7 +403,7 @@ namespace AI
             // Step 2. Do some hero stuff.
             // If a hero is standing in a castle most likely he has nothing to do so let's try to give him more army.
             for ( Heroes * hero : heroes ) {
-                HeroesActionComplete( *hero, MP2::OBJ_ZERO );
+                HeroesActionComplete( *hero, hero->GetIndex(), MP2::OBJ_ZERO );
             }
 
             // Step 3. Reassign heroes roles

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -248,13 +248,13 @@ namespace AI
 
                 const double attackerThreat = attackerStrength - defenders;
                 if ( attackerThreat > 0 ) {
-                    _priorityTargets[enemy.first] = false;
+                    _priorityTargets[enemy.first] = PriorityTask::ATTACK;
                     const uint32_t dist = _pathfinder.getDistance( enemy.first, castleIndex, myColor, attackerStrength );
                     if ( dist && dist < threatDistanceLimit ) {
                         // castle is under threat
                         castlesInDanger.insert( castleIndex );
 
-                        _priorityTargets[castleIndex] = true;
+                        _priorityTargets[castleIndex] = PriorityTask::DEFEND;
                     }
                 }
             }


### PR DESCRIPTION
Marking threatening enemy armies and friendly castles under attack as priority targets. AI heroes now have incentives to go to the castle to defend it and switch into sleeper mode to stay there as long as threat persists.