### PR TITLE
Fix AI hero recruiment limit

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -429,6 +429,7 @@ namespace AI
             if ( !purchaseNewHeroes( sortedCastleList, castlesInDanger, availableHeroCount, moreTaskForHeroes ) ) {
                 break;
             }
+            ++availableHeroCount;
         }
 
         status.RedrawTurnProgress( 9 );


### PR DESCRIPTION
`availableHeroCount` wasn't incremented so AI could regularly buy 5 heroes on the first turn on large maps.