### PR TITLE
Fix multiple audio issues

### DIFF
--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -76,8 +76,8 @@ namespace
     // a SDL_Mixer internal thread.
     //
     // TODO: according to SDL_Mixer manual, calls of any SDL_Mixer functions are not allowed in
-    // callbacks. The current code works, but it would be good to find a reliable way to perform
-    // channel cleanup without calling these functions.
+    // TODO: callbacks. The current code works, but it would be good to find a reliable way to
+    // TODO: perform channel cleanup without calling these functions.
     void channelFinished( const int channelId )
     {
         // This callback function should never be called if audio is not initialized

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -746,10 +746,10 @@ namespace
                 // Adjust channel based on given parameters.
 
                 // TODO: this is very hacky way. We should not do this. For example in 3D audio mode when a hero moves alongside beach it is noticeable that ocean sounds
-                //       are 'jumping' in volume. Instead of such approach we need to get free channel ID which will be used for playback. Set volume for it and then
-                //       start playing. Such logic must be implemented within Audio related code.
-                //       As an alternative solution: we can use channel IDs which we freed in the previous step. However, be careful with synchronization for audio
-                //       access.
+                // TODO: are 'jumping' in volume. Instead of such approach we need to get free channel ID which will be used for playback. Set volume for it and then
+                // TODO: start playing. Such logic must be implemented within Audio related code.
+                // TODO: As an alternative solution: we can use channel IDs which we freed in the previous step. However, be careful with synchronization for audio
+                // TODO: access.
                 Mixer::Pause( channelId );
                 Mixer::setVolume( channelId, info.volumePercentage * soundVolume / 10 );
                 Mixer::Resume( channelId );

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -483,7 +483,7 @@ namespace
         // Check if the music track is cached.
         if ( Music::Play( musicUID, playbackMode ) ) {
             DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "Play cached music track " << trackId )
-            Game::SetCurrentMusicTrack( trackId );
+            Game::SetCurrentMusicTrackId( trackId );
             return;
         }
 
@@ -514,7 +514,7 @@ namespace
             else {
                 Music::Play( musicUID, filename, playbackMode );
 
-                Game::SetCurrentMusicTrack( trackId );
+                Game::SetCurrentMusicTrackId( trackId );
 
                 DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "Play music track " << MUS::getFileName( trackId, MUS::EXTERNAL_MUSIC_TYPE::MAPPED, " " ) )
 
@@ -537,7 +537,7 @@ namespace
             if ( !v.empty() ) {
                 Music::Play( musicUID, v, playbackMode );
 
-                Game::SetCurrentMusicTrack( trackId );
+                Game::SetCurrentMusicTrackId( trackId );
             }
         }
         DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "Play MIDI music track " << XMI::GetString( xmi ) )

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -419,6 +419,8 @@ namespace
     std::map<M82::SoundType, std::vector<ChannelAudioLoopEffectInfo>> currentAudioLoopEffects;
     bool is3DAudioLoopEffectsEnabled{ false };
 
+    std::atomic<int> currentMusicTrackId{ MUS::UNKNOWN };
+
     fheroes2::AGGFile g_midiHeroes2AGG;
     fheroes2::AGGFile g_midiHeroes2xAGG;
 
@@ -466,8 +468,6 @@ namespace
 
         return ( static_cast<uint64_t>( musicType ) << 32 ) + static_cast<uint64_t>( trackId );
     }
-
-    std::atomic<int> currentMusicTrackId{ MUS::UNKNOWN };
 
     void PlayMusicInternally( const int trackId, const MusicSource musicType, const Music::PlaybackMode playbackMode )
     {

--- a/src/fheroes2/audio/audio_manager.h
+++ b/src/fheroes2/audio/audio_manager.h
@@ -47,9 +47,12 @@ namespace AudioManager
     };
 
     // Useful for restoring background music after playing short-term music effects.
+    //
     // TODO: Is subject to a (minor) race condition when created while the playback
     // TODO: of a new music track is being started in the AsyncSoundManager's worker
-    // TODO: thread. In this case, the wrong music track may be restored.
+    // TODO: thread. In this case, the wrong music track (the one that is actually
+    // TODO: being played at the moment, and not the one that is being prepared by
+    // TODO: the worker thread for playback) may be restored.
     class MusicRestorer
     {
     public:
@@ -91,10 +94,16 @@ namespace AudioManager
 
     void PlayMusic( const int trackId, const Music::PlaybackMode playbackMode );
     void PlayMusicAsync( const int trackId, const Music::PlaybackMode playbackMode );
-    // Assumes that the current music track is looped and should be resumed
+
+    // Assumes that the current music track is looped and should be resumed.
+    //
+    // TODO: Is subject to a (minor) race condition when called while the playback
+    // TODO: of a new music track is being started in the AsyncSoundManager's worker
+    // TODO: thread. In this case, the wrong music track (the one that is actually
+    // TODO: being played at the moment, and not the one that is being prepared by
+    // TODO: the worker thread for playback) may be played.
     void PlayCurrentMusic();
 
     void stopSounds();
-
     void ResetAudio();
 }

--- a/src/fheroes2/audio/audio_manager.h
+++ b/src/fheroes2/audio/audio_manager.h
@@ -46,6 +46,24 @@ namespace AudioManager
         ~AudioInitializer();
     };
 
+    // Useful for restoring background music after playing short-term music effects.
+    // TODO: Is subject to a (minor) race condition when created while the playback
+    // TODO: of a new music track is being started in the AsyncSoundManager's worker
+    // TODO: thread. In this case, the wrong music track may be restored.
+    class MusicRestorer
+    {
+    public:
+        MusicRestorer();
+        MusicRestorer( const MusicRestorer & ) = delete;
+
+        ~MusicRestorer();
+
+        MusicRestorer & operator=( const MusicRestorer & ) = delete;
+
+    private:
+        const int _music;
+    };
+
     struct AudioLoopEffectInfo
     {
         AudioLoopEffectInfo() = default;
@@ -73,6 +91,8 @@ namespace AudioManager
 
     void PlayMusic( const int trackId, const Music::PlaybackMode playbackMode );
     void PlayMusicAsync( const int trackId, const Music::PlaybackMode playbackMode );
+    // Assumes that the current music track is looped and should be resumed
+    void PlayCurrentMusic();
 
     void stopSounds();
 

--- a/src/fheroes2/dialog/dialog_audio.cpp
+++ b/src/fheroes2/dialog/dialog_audio.cpp
@@ -114,7 +114,7 @@ namespace
 
 namespace Dialog
 {
-    void openAudioSettingsDialog()
+    void openAudioSettingsDialog( const bool fromAdventureMap )
     {
         const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
@@ -209,7 +209,7 @@ namespace Dialog
                     saveSoundVolume = true;
                 }
 
-                if ( saveSoundVolume ) {
+                if ( saveSoundVolume && fromAdventureMap ) {
                     Game::EnvironmentSoundMixer();
                 }
             }

--- a/src/fheroes2/dialog/dialog_audio.cpp
+++ b/src/fheroes2/dialog/dialog_audio.cpp
@@ -219,14 +219,18 @@ namespace Dialog
             if ( le.MouseClickLeft( musicTypeRoi ) ) {
                 int type = conf.MusicType() + 1;
                 // If there's no expansion files we skip this option
-                if ( type == MUSIC_MIDI_EXPANSION && !conf.isPriceOfLoyaltySupported() )
+                if ( type == MUSIC_MIDI_EXPANSION && !conf.isPriceOfLoyaltySupported() ) {
                     ++type;
-
-                const Game::MusicRestorer musicRestorer;
+                }
 
                 conf.SetMusicType( type > MUSIC_EXTERNAL ? 0 : type );
 
+                int music = Game::CurrentMusicTrackId();
+
                 Game::SetCurrentMusicTrack( MUS::UNKNOWN );
+
+                // Use sync mode to avoid issues when the music type changes quickly several times in a row
+                AudioManager::PlayMusic( music, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 
                 saveMusicType = true;
             }

--- a/src/fheroes2/dialog/dialog_audio.cpp
+++ b/src/fheroes2/dialog/dialog_audio.cpp
@@ -22,6 +22,7 @@
 
 #include "agg_image.h"
 #include "audio.h"
+#include "audio_manager.h"
 #include "cursor.h"
 #include "dialog_audio.h"
 #include "game.h"

--- a/src/fheroes2/dialog/dialog_audio.cpp
+++ b/src/fheroes2/dialog/dialog_audio.cpp
@@ -225,15 +225,7 @@ namespace Dialog
 
                 conf.SetMusicType( type > MUSIC_EXTERNAL ? 0 : type );
 
-                // TODO: Is subject to a (minor) race condition when the music type is changed while the
-                // TODO: playback of a new music track is being started in the AsyncSoundManager's worker
-                // TODO: thread. In this case, the wrong music track may be played.
-                int music = Game::CurrentMusicTrackId();
-
-                Game::SetCurrentMusicTrackId( MUS::UNKNOWN );
-
-                // Use sync mode to avoid issues when the music type changes quickly several times in a row
-                AudioManager::PlayMusic( music, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
+                AudioManager::PlayCurrentMusic();
 
                 saveMusicType = true;
             }

--- a/src/fheroes2/dialog/dialog_audio.cpp
+++ b/src/fheroes2/dialog/dialog_audio.cpp
@@ -225,9 +225,12 @@ namespace Dialog
 
                 conf.SetMusicType( type > MUSIC_EXTERNAL ? 0 : type );
 
+                // TODO: Is subject to a (minor) race condition when the music type is changed while the
+                // TODO: playback of a new music track is being started in the AsyncSoundManager's worker
+                // TODO: thread. In this case, the wrong music track may be played.
                 int music = Game::CurrentMusicTrackId();
 
-                Game::SetCurrentMusicTrack( MUS::UNKNOWN );
+                Game::SetCurrentMusicTrackId( MUS::UNKNOWN );
 
                 // Use sync mode to avoid issues when the music type changes quickly several times in a row
                 AudioManager::PlayMusic( music, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );

--- a/src/fheroes2/dialog/dialog_audio.h
+++ b/src/fheroes2/dialog/dialog_audio.h
@@ -21,5 +21,5 @@
 
 namespace Dialog
 {
-    void openAudioSettingsDialog();
+    void openAudioSettingsDialog( const bool fromAdventureMap );
 }

--- a/src/fheroes2/dialog/dialog_game_settings.cpp
+++ b/src/fheroes2/dialog/dialog_game_settings.cpp
@@ -398,7 +398,7 @@ namespace fheroes2
                 windowType = SelectedWindow::Configuration;
                 break;
             case SelectedWindow::AudioSettings:
-                Dialog::openAudioSettingsDialog();
+                Dialog::openAudioSettingsDialog( false );
                 windowType = SelectedWindow::Configuration;
                 break;
             case SelectedWindow::InterfaceTheme:

--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -473,7 +473,7 @@ namespace fheroes2
                 Settings::Get().Save( Settings::configFileName );
                 return;
             case DialogAction::AudioSettings:
-                Dialog::openAudioSettingsDialog();
+                Dialog::openAudioSettingsDialog( true );
                 action = DialogAction::Open;
                 break;
             case DialogAction::HotKeys:

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -205,7 +205,7 @@ bool Game::UpdateSoundsOnFocusUpdate()
     return updateSoundsOnFocusUpdate;
 }
 
-void Game::SetUpdateSoundsOnFocusUpdate( bool update )
+void Game::SetUpdateSoundsOnFocusUpdate( const bool update )
 {
     updateSoundsOnFocusUpdate = update;
 }
@@ -230,7 +230,7 @@ int Game::CurrentMusicTrackId()
     return currentMusicTrackId;
 }
 
-void Game::SetCurrentMusicTrack( const int trackId )
+void Game::SetCurrentMusicTrackId( const int trackId )
 {
     currentMusicTrackId = trackId;
 }
@@ -473,8 +473,10 @@ void Game::EnvironmentSoundMixer()
 
 void Game::restoreSoundsForCurrentFocus()
 {
-    Game::SetCurrentMusicTrack( MUS::UNKNOWN );
     AudioManager::ResetAudio();
+    // AsyncSoundManager's worker thread will not be able to change the current music track
+    // after the ResetAudio() completes, so we can safely reset the current music track here
+    Game::SetCurrentMusicTrackId( MUS::UNKNOWN );
 
     switch ( Interface::GetFocusType() ) {
     case GameFocus::HEROES: {

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -60,7 +60,6 @@ namespace
     std::string last_name;
 
     bool updateSoundsOnFocusUpdate = true;
-    std::atomic<int> currentMusicTrackId{ MUS::UNKNOWN };
 
     uint32_t maps_animation_frame = 0;
 
@@ -223,16 +222,6 @@ void Game::Init()
     Game::AnimateDelaysInitialize();
 
     Game::HotKeysLoad( Settings::GetLastFile( "", "fheroes2.key" ) );
-}
-
-int Game::CurrentMusicTrackId()
-{
-    return currentMusicTrackId;
-}
-
-void Game::SetCurrentMusicTrackId( const int trackId )
-{
-    currentMusicTrackId = trackId;
 }
 
 void Game::ObjectFadeAnimation::PrepareFadeTask( const MP2::MapObjectType objectType, int32_t fromIndex, int32_t toIndex, bool fadeOut, bool fadeIn )
@@ -474,9 +463,6 @@ void Game::EnvironmentSoundMixer()
 void Game::restoreSoundsForCurrentFocus()
 {
     AudioManager::ResetAudio();
-    // AsyncSoundManager's worker thread will not be able to change the current music track
-    // after the ResetAudio() completes, so we can safely reset the current music track here
-    Game::SetCurrentMusicTrackId( MUS::UNKNOWN );
 
     switch ( Interface::GetFocusType() ) {
     case GameFocus::HEROES: {

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -94,9 +94,6 @@ namespace Game
     void EnvironmentSoundMixer();
     void restoreSoundsForCurrentFocus();
 
-    void SetCurrentMusicTrackId( const int trackId );
-    int CurrentMusicTrackId();
-
     bool UpdateSoundsOnFocusUpdate();
     void SetUpdateSoundsOnFocusUpdate( const bool update );
 
@@ -122,44 +119,6 @@ namespace Game
     std::string GetSaveFileBaseName();
     std::string GetSaveFileExtension();
     std::string GetSaveFileExtension( const int gameType );
-
-    // Useful for restoring background music after playing short-term music effects.
-    // TODO: Is subject to a (minor) race condition when created while the playback
-    // TODO: of a new music track is being started in the AsyncSoundManager's worker
-    // TODO: thread. In this case, the wrong music track may be restored.
-    class MusicRestorer
-    {
-    public:
-        MusicRestorer()
-            : _music( CurrentMusicTrackId() )
-        {}
-
-        MusicRestorer( const MusicRestorer & ) = delete;
-
-        ~MusicRestorer()
-        {
-            if ( _music == MUS::UNUSED || _music == MUS::UNKNOWN ) {
-                SetCurrentMusicTrackId( _music );
-
-                return;
-            }
-
-            // Set current music to MUS::UNKNOWN to prevent attempts to play the old music
-            // by new instances of MusicRestorer while the music being currently restored
-            // is starting in the background
-            if ( _music != CurrentMusicTrackId() ) {
-                SetCurrentMusicTrackId( MUS::UNKNOWN );
-            }
-
-            // It is assumed that the previous track was looped and does not require to be played from the beginning.
-            AudioManager::PlayMusicAsync( _music, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
-        }
-
-        MusicRestorer & operator=( const MusicRestorer & ) = delete;
-
-    private:
-        const int _music;
-    };
 
     namespace ObjectFadeAnimation
     {

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -27,7 +27,6 @@
 #include <cstdint>
 #include <string>
 
-#include "audio_manager.h"
 #include "game_mode.h"
 #include "mp2.h"
 #include "mus.h"

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -93,11 +93,16 @@ namespace Game
 
     void EnvironmentSoundMixer();
     void restoreSoundsForCurrentFocus();
+
+    void SetCurrentMusicTrackId( const int trackId );
+    int CurrentMusicTrackId();
+
+    bool UpdateSoundsOnFocusUpdate();
+    void SetUpdateSoundsOnFocusUpdate( const bool update );
+
     int GetKingdomColors();
     int GetActualKingdomColors();
     void DialogPlayers( int color, std::string );
-    void SetCurrentMusicTrack( const int trackId );
-    int CurrentMusicTrackId();
     uint32_t & MapsAnimationFrame();
     uint32_t GetRating();
     uint32_t GetGameOverScores();
@@ -105,8 +110,6 @@ namespace Game
     uint32_t GetWhirlpoolPercent();
     uint32_t SelectCountPlayers();
     void PlayPickupSound();
-    bool UpdateSoundsOnFocusUpdate();
-    void SetUpdateSoundsOnFocusUpdate( bool update );
     void OpenHeroesDialog( Heroes & hero, bool updateFocus, bool windowIsGameWorld, bool disableDismiss = false );
     void OpenCastleDialog( Castle & castle, bool updateFocus = true );
     // Returns the difficulty level based on the type of game.
@@ -120,7 +123,10 @@ namespace Game
     std::string GetSaveFileExtension();
     std::string GetSaveFileExtension( const int gameType );
 
-    // Useful for restoring background music after playing short-term music effects
+    // Useful for restoring background music after playing short-term music effects.
+    // TODO: Is subject to a (minor) race condition when created while the playback
+    // TODO: of a new music track is being started in the AsyncSoundManager's worker
+    // TODO: thread. In this case, the wrong music track may be restored.
     class MusicRestorer
     {
     public:
@@ -133,7 +139,7 @@ namespace Game
         ~MusicRestorer()
         {
             if ( _music == MUS::UNUSED || _music == MUS::UNKNOWN ) {
-                SetCurrentMusicTrack( _music );
+                SetCurrentMusicTrackId( _music );
 
                 return;
             }
@@ -142,7 +148,7 @@ namespace Game
             // by new instances of MusicRestorer while the music being currently restored
             // is starting in the background
             if ( _music != CurrentMusicTrackId() ) {
-                SetCurrentMusicTrack( MUS::UNKNOWN );
+                SetCurrentMusicTrackId( MUS::UNKNOWN );
             }
 
             // It is assumed that the previous track was looped and does not require to be played from the beginning.

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -606,9 +606,11 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
                 switch ( kingdom.GetControl() ) {
                 case CONTROL_HUMAN:
-                    // reset environment sounds and music theme at the beginning of the human turn
-                    Game::SetCurrentMusicTrack( MUS::UNKNOWN );
+                    // Reset environment sounds and music theme at the beginning of the human turn
                     AudioManager::ResetAudio();
+                    // AsyncSoundManager's worker thread will not be able to change the current music track
+                    // after the ResetAudio() completes, so we can safely reset the current music track here
+                    Game::SetCurrentMusicTrackId( MUS::UNKNOWN );
 
                     if ( conf.IsGameType( Game::TYPE_HOTSEAT ) ) {
                         // we need to hide the world map in hot seat mode
@@ -645,8 +647,10 @@ fheroes2::GameMode Interface::Basic::StartGame()
                     }
 
                     // Reset environment sounds and music theme at the end of the human turn.
-                    Game::SetCurrentMusicTrack( MUS::UNKNOWN );
                     AudioManager::ResetAudio();
+                    // AsyncSoundManager's worker thread will not be able to change the current music track
+                    // after the ResetAudio() completes, so we can safely reset the current music track here
+                    Game::SetCurrentMusicTrackId( MUS::UNKNOWN );
 
                     break;
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -743,8 +743,6 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
     gameArea.SetUpdateCursor();
     Redraw( REDRAW_GAMEAREA | REDRAW_RADAR | REDRAW_ICONS | REDRAW_BUTTONS | REDRAW_STATUS | REDRAW_BORDER );
 
-    Game::EnvironmentSoundMixer();
-
     fheroes2::Display & display = fheroes2::Display::instance();
 
     display.render();

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -264,7 +264,7 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, bool windowIsGameW
 void ShowNewWeekDialog()
 {
     // restore the original music on exit
-    const Game::MusicRestorer musicRestorer;
+    const AudioManager::MusicRestorer musicRestorer;
 
     AudioManager::PlayMusic( world.BeginMonth() ? MUS::NEW_MONTH : MUS::NEW_WEEK, Music::PlaybackMode::PLAY_ONCE );
 
@@ -608,9 +608,6 @@ fheroes2::GameMode Interface::Basic::StartGame()
                 case CONTROL_HUMAN:
                     // Reset environment sounds and music theme at the beginning of the human turn
                     AudioManager::ResetAudio();
-                    // AsyncSoundManager's worker thread will not be able to change the current music track
-                    // after the ResetAudio() completes, so we can safely reset the current music track here
-                    Game::SetCurrentMusicTrackId( MUS::UNKNOWN );
 
                     if ( conf.IsGameType( Game::TYPE_HOTSEAT ) ) {
                         // we need to hide the world map in hot seat mode
@@ -623,7 +620,7 @@ fheroes2::GameMode Interface::Basic::StartGame()
                         display.render();
 
                         // reset the music after closing the dialog
-                        const Game::MusicRestorer musicRestorer;
+                        const AudioManager::MusicRestorer musicRestorer;
 
                         AudioManager::PlayMusic( MUS::NEW_MONTH, Music::PlaybackMode::PLAY_ONCE );
 
@@ -648,9 +645,6 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
                     // Reset environment sounds and music theme at the end of the human turn.
                     AudioManager::ResetAudio();
-                    // AsyncSoundManager's worker thread will not be able to change the current music track
-                    // after the ResetAudio() completes, so we can safely reset the current music track here
-                    Game::SetCurrentMusicTrackId( MUS::UNKNOWN );
 
                     break;
 

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -372,7 +372,7 @@ fheroes2::GameMode Interface::Basic::EventDigArtifact()
                 hero->ResetMovePoints();
 
                 if ( world.DiggingForUltimateArtifact( hero->GetCenter() ) ) {
-                    const Game::MusicRestorer musicRestorer;
+                    const AudioManager::MusicRestorer musicRestorer;
 
                     if ( Settings::Get().MusicMIDI() ) {
                         AudioManager::PlaySound( M82::TREASURE );

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -54,10 +54,10 @@ void Interface::Basic::SetFocus( Heroes * hero )
         gameArea.SetCenter( hero->GetCenter() );
         statusWindow.SetState( StatusType::STATUS_ARMY );
 
-        const int heroIndexPos = hero->GetIndex();
-        if ( Game::UpdateSoundsOnFocusUpdate() && heroIndexPos >= 0 ) {
+        const int heroIndex = hero->GetIndex();
+        if ( Game::UpdateSoundsOnFocusUpdate() && heroIndex >= 0 ) {
             Game::EnvironmentSoundMixer();
-            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( heroIndexPos ).GetGround() ), Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
+            AudioManager::PlayMusicAsync( MUS::FromGround( world.GetTiles( heroIndex ).GetGround() ), Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
         }
     }
 }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -248,7 +248,8 @@ void Heroes::Action( int tileIndex, bool isDestination )
 {
     if ( GetKingdom().isControlAI() ) {
         // Restore the original music after the action is completed.
-        const Game::MusicRestorer musicRestorer;
+        const AudioManager::MusicRestorer musicRestorer;
+
         return AI::HeroesAction( *this, tileIndex );
     }
 
@@ -261,7 +262,7 @@ void Heroes::Action( int tileIndex, bool isDestination )
     }
 
     // Restore the original music after the action is completed.
-    const Game::MusicRestorer musicRestorer;
+    const AudioManager::MusicRestorer musicRestorer;
 
     Maps::Tiles & tile = world.GetTiles( tileIndex );
     const MP2::MapObjectType objectType = tile.GetObject( tileIndex != heroPosIndex );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -269,7 +269,6 @@ void Heroes::Action( int tileIndex, bool isDestination )
 
     const int objectMusicTrack = MUS::FromMapObject( objectType );
     if ( objectMusicTrack != MUS::UNKNOWN ) {
-        // Since it is a synchronous call all previous music tracks will be removed from a queue for an asynchronous playback.
         AudioManager::PlayMusic( objectMusicTrack, Music::PlaybackMode::PLAY_ONCE );
     }
 

--- a/src/fheroes2/kingdom/puzzle.cpp
+++ b/src/fheroes2/kingdom/puzzle.cpp
@@ -265,7 +265,7 @@ void Puzzle::ShowMapsDialog() const
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
     // restore the original music on exit
-    const Game::MusicRestorer musicRestorer;
+    const AudioManager::MusicRestorer musicRestorer;
 
     AudioManager::PlayMusic( MUS::PUZZLE, Music::PlaybackMode::PLAY_ONCE );
 


### PR DESCRIPTION
fix #5580
fix #5581

Scenario of the #5581 is as follows:

* The music type is changed for the first time, the current music is set to `MUS::UNKNOWN`, `MusicRestorer` started the preparation for the background music playback in the worker thread, BUT actual music playback is not started yet.
* The music type is quickly changed for the second time, BUT, since the actual music playback is still not started, the current music is still the `MUS::UNKNOWN`, so `MusicRestorer` has nothing to restore, and no music playback is planned for the worker thread.
* The previously planned music playback is actually started by the worker thread.

The proposed solution is to always start music playback in sync mode when changing the music type. There may be some minor delay if we are playing MIDI on Windows (~200ms?), but we will always be sure that the music playback is really started before the music type can be changed once again.