### PR TITLE
Remove unused field move_point_scale from the Heroes class

### DIFF
--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -345,7 +345,6 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readOnly, const b
     bottomArmyBar.SetHSpace( 6 );
 
     if ( heroes.Guest() ) {
-        heroes.Guest()->MovePointsScaleFixed();
         bottomArmyBar.SetArmy( &heroes.Guest()->GetArmy() );
 
         if ( alphaHero != 0 ) {

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -146,7 +146,6 @@ const char * Heroes::GetName( int heroid )
 
 Heroes::Heroes()
     : experience( 0 )
-    , move_point_scale( -1 )
     , army( this )
     , hid( UNKNOWN )
     , portrait( UNKNOWN )
@@ -176,7 +175,6 @@ Heroes::Heroes( int heroid, int rc )
     : HeroBase( HeroBase::HEROES, rc )
     , ColorBase( Color::NONE )
     , experience( GetStartingXp() )
-    , move_point_scale( -1 )
     , secondary_skills( rc )
     , army( this )
     , hid( heroid )
@@ -674,7 +672,6 @@ bool Heroes::Recruit( const int col, const fheroes2::Point & pt )
     if ( !Modes( SAVEMP ) ) {
         move_point = GetMaxMovePoints();
     }
-    MovePointsScaleFixed();
 
     if ( !army.isValid() ) {
         army.Reset( false );
@@ -709,7 +706,6 @@ void Heroes::ActionNewDay()
 {
     // recovery move points
     move_point = GetMaxMovePoints();
-    MovePointsScaleFixed();
 
     // replenish spell points
     ReplenishSpellPoints();
@@ -1433,7 +1429,6 @@ void Heroes::SetFreeman( int reason )
         SetIndex( -1 );
 
         modes = 0;
-        move_point_scale = -1;
 
         path.Reset();
 
@@ -1945,8 +1940,8 @@ StreamBase & operator<<( StreamBase & msg, const Heroes & hero )
     msg << base;
 
     // Heroes
-    msg << hero.name << col << hero.experience << hero.move_point_scale << hero.secondary_skills << hero.army << hero.hid << hero.portrait << hero._race
-        << hero.save_maps_object << hero.path << hero.direction << hero.sprite_index;
+    msg << hero.name << col << hero.experience << hero.secondary_skills << hero.army << hero.hid << hero.portrait << hero._race << hero.save_maps_object << hero.path
+        << hero.direction << hero.sprite_index;
 
     // TODO: before 0.9.4 Point was int16_t type
     const int16_t patrolX = static_cast<int16_t>( hero.patrol_center.x );
@@ -1975,8 +1970,16 @@ StreamBase & operator>>( StreamBase & msg, Heroes & hero )
         msg >> dummyColor;
     }
 
-    msg >> hero.experience >> hero.move_point_scale >> hero.secondary_skills >> hero.army >> hero.hid >> hero.portrait >> hero._race >> hero.save_maps_object >> hero.path
-        >> hero.direction >> hero.sprite_index;
+    msg >> hero.experience;
+
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_0917_RELEASE, "Remove the check below." );
+    if ( Game::GetLoadVersion() < FORMAT_VERSION_0917_RELEASE ) {
+        int32_t dummy;
+
+        msg >> dummy;
+    }
+
+    msg >> hero.secondary_skills >> hero.army >> hero.hid >> hero.portrait >> hero._race >> hero.save_maps_object >> hero.path >> hero.direction >> hero.sprite_index;
 
     // TODO: before 0.9.4 Point was int16_t type
     int16_t patrolX = 0;

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -310,11 +310,6 @@ public:
         move_point = 0;
     }
 
-    void MovePointsScaleFixed()
-    {
-        move_point_scale = move_point * 1000 / GetMaxMovePoints();
-    }
-
     bool HasSecondarySkill( int ) const;
     bool HasMaxSecondarySkill() const;
     int GetLevelSkill( int ) const override;
@@ -529,7 +524,6 @@ private:
 
     std::string name;
     uint32_t experience;
-    int32_t move_point_scale;
 
     Skill::SecSkills secondary_skills;
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -205,7 +205,6 @@ void RecruitMonsterFromTile( Heroes & hero, Maps::Tiles & tile, const std::strin
             hero.GetKingdom().OddFundsResource( paymentCosts );
 
             hero.GetArmy().JoinTroop( troop.GetMonster(), recruit );
-            hero.MovePointsScaleFixed();
 
             Interface::Basic::Get().SetRedraw( Interface::REDRAW_STATUS );
         }
@@ -2221,8 +2220,6 @@ void ActionToDwellingJoinMonster( Heroes & hero, const MP2::MapObjectType object
     const std::string title( MP2::StringObject( objectType ) );
 
     if ( troop.isValid() ) {
-        hero.MovePointsScaleFixed();
-
         std::string message = _( "A group of %{monster} with a desire for greater glory wish to join you. Do you accept?" );
         StringReplace( message, "%{monster}", troop.GetMultiName() );
 
@@ -2234,7 +2231,6 @@ void ActionToDwellingJoinMonster( Heroes & hero, const MP2::MapObjectType object
             else {
                 tile.MonsterSetCount( 0 );
                 hero.GetArmy().JoinTroop( troop );
-                hero.MovePointsScaleFixed();
 
                 Interface::Basic::Get().SetRedraw( Interface::REDRAW_STATUS );
             }
@@ -2511,9 +2507,6 @@ void ActionToUpgradeArmyObject( Heroes & hero, const MP2::MapObjectType objectTy
     std::string msg2;
 
     std::vector<Monster *> mons;
-
-    hero.MovePointsScaleFixed();
-
     std::vector<Monster> monsToUpgrade;
 
     switch ( objectType ) {

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -391,9 +391,6 @@ void Heroes::MeetingDialog( Heroes & otherHero )
 
     display.render();
 
-    MovePointsScaleFixed();
-    otherHero.MovePointsScaleFixed();
-
     LocalEvent & le = LocalEvent::Get();
 
     // message loop

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -25,7 +25,8 @@
 enum SaveFileFormat : uint16_t
 {
     // TODO: if you're adding a new version you must assign it to CURRENT_FORMAT_VERSION located at the bottom.
-    FORMAT_VERSION_0917_RELEASE = 9910,
+    FORMAT_VERSION_0917_RELEASE = 9911,
+    FORMAT_VERSION_PRE_0917_RELEASE = 9910,
     FORMAT_VERSION_0916_RELEASE = 9901,
     FORMAT_VERSION_PRE_0916_RELEASE = 9900,
     FORMAT_VERSION_0912_RELEASE = 9803,

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -1079,8 +1079,8 @@ StreamBase & operator>>( StreamBase & msg, Settings & conf )
 
     msg >> conf.current_maps_file >> conf.game_difficulty >> conf.game_type >> conf.preferably_count_players >> debug;
 
-    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_0917_RELEASE, "Remove the following code." );
-    if ( Game::GetLoadVersion() < FORMAT_VERSION_0917_RELEASE ) {
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE_0917_RELEASE, "Remove the following code." );
+    if ( Game::GetLoadVersion() < FORMAT_VERSION_PRE_0917_RELEASE ) {
         uint32_t dummy;
 
         msg >> dummy;


### PR DESCRIPTION
Apparently this field was once used for some experimental functionality, but it's not the case anymore.