### PR TITLE
Mixer::SetChannels(): don't call the Mix_ReserveChannels()

### DIFF
--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -572,10 +572,6 @@ void Mixer::SetChannels( const int num )
                                                                                                                     << audioChannelCount )
     }
 
-    if ( audioChannelCount > 0 ) {
-        Mix_ReserveChannels( 1 );
-    }
-
     if ( isMuted ) {
         savedMixerVolumes.resize( static_cast<size_t>( audioChannelCount ), 0 );
 


### PR DESCRIPTION
I have no idea why we need to reserve the channel 0.