### PR TITLE
Fix incorrect animation effect for castle's window

### DIFF
--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -166,8 +166,7 @@ namespace
         }
 
         if ( !hero2 ) {
-            const bool isEvilInterace = Settings::Get().ExtGameEvilInterface();
-            const fheroes2::Sprite & backgroundImage = isEvilInterace ? fheroes2::AGG::GetICN( ICN::STRIP_BACKGROUND_EVIL, 0 ) : fheroes2::AGG::GetICN( ICN::STRIP, 11 );
+            const fheroes2::Sprite & backgroundImage = fheroes2::AGG::GetICN( ICN::STRIP, 11 );
 
             fheroes2::Blit( backgroundImage, display, pt.x + 112, pt.y + 361 );
         }


### PR DESCRIPTION
This is a regression from #5546

If you select Evil Interface, open a castle with no hero and then hire a hero you would notice that animation is not great.