### PR TITLE
When scouting, use a straight line distance instead of an approximate distance, rework the neutral monsters counting logic for the extended scouting

### DIFF
--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -78,19 +78,6 @@ std::string StringUpper( std::string str )
     return str;
 }
 
-std::string GetStringShort( int value )
-{
-    if ( std::abs( value ) >= 1000 ) {
-        if ( std::abs( value ) >= 1000000 ) {
-            return std::to_string( value / 1000000 ) + 'M';
-        }
-
-        return std::to_string( value / 1000 ) + 'K';
-    }
-
-    return std::to_string( value );
-}
-
 int CountBits( uint32_t val )
 {
     int res = 0;
@@ -430,5 +417,18 @@ namespace fheroes2
         }
 
         output.replace( output.size() - originalEndingSize, originalEndingSize, correctedEnding, correctedEndingSize );
+    }
+
+    std::string abbreviateNumber( const int num )
+    {
+        if ( std::abs( num ) >= 1000000 ) {
+            return std::to_string( num / 1000000 ) + 'M';
+        }
+
+        if ( std::abs( num ) >= 1000 ) {
+            return std::to_string( num / 1000 ) + 'K';
+        }
+
+        return std::to_string( num );
     }
 }

--- a/src/engine/tools.h
+++ b/src/engine/tools.h
@@ -34,8 +34,6 @@
 
 #include "math_base.h"
 
-std::string GetStringShort( int );
-
 template <typename T, typename = typename std::enable_if<std::is_integral<T>::value>::type>
 std::string GetHexString( T value, int width = 8 )
 {
@@ -99,6 +97,8 @@ namespace fheroes2
     }
 
     void replaceStringEnding( std::string & output, const char * originalEnding, const char * correctedEnding );
+
+    std::string abbreviateNumber( const int num );
 }
 
 #endif

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -186,17 +186,11 @@ std::pair<uint32_t, uint32_t> Army::SizeRange( const uint32_t count )
     if ( count < ARMY_LEGION ) {
         return { ARMY_ZOUNDS, ARMY_LEGION };
     }
-    if ( count < 10000 ) {
-        return { ARMY_LEGION, 10000 };
-    }
-    if ( count < 100000 ) {
-        return { 10000, 100000 };
-    }
-    if ( count < 1000000 ) {
-        return { 100000, 1000000 };
+    if ( count < 5000 ) {
+        return { ARMY_LEGION, 5000 };
     }
 
-    return { 1000000, UINT32_MAX };
+    return { 5000, UINT32_MAX };
 }
 
 Troops::Troops( const Troops & troops )

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -160,6 +160,45 @@ std::string Army::SizeString( uint32_t size )
     return {};
 }
 
+std::pair<uint32_t, uint32_t> Army::SizeRange( const uint32_t count )
+{
+    if ( count < ARMY_SEVERAL ) {
+        return { ARMY_FEW, ARMY_SEVERAL };
+    }
+    if ( count < ARMY_PACK ) {
+        return { ARMY_SEVERAL, ARMY_PACK };
+    }
+    if ( count < ARMY_LOTS ) {
+        return { ARMY_PACK, ARMY_LOTS };
+    }
+    if ( count < ARMY_HORDE ) {
+        return { ARMY_LOTS, ARMY_HORDE };
+    }
+    if ( count < ARMY_THRONG ) {
+        return { ARMY_HORDE, ARMY_THRONG };
+    }
+    if ( count < ARMY_SWARM ) {
+        return { ARMY_THRONG, ARMY_SWARM };
+    }
+    if ( count < ARMY_ZOUNDS ) {
+        return { ARMY_SWARM, ARMY_ZOUNDS };
+    }
+    if ( count < ARMY_LEGION ) {
+        return { ARMY_ZOUNDS, ARMY_LEGION };
+    }
+    if ( count < 10000 ) {
+        return { ARMY_LEGION, 10000 };
+    }
+    if ( count < 100000 ) {
+        return { 10000, 100000 };
+    }
+    if ( count < 1000000 ) {
+        return { 100000, 1000000 };
+    }
+
+    return { 1000000, UINT32_MAX };
+}
+
 Troops::Troops( const Troops & troops )
     : std::vector<Troop *>()
 {

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -25,6 +25,7 @@
 #define H2ARMY_H
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "monster.h"
@@ -134,6 +135,8 @@ class Army : public Troops, public Control
 public:
     static std::string SizeString( uint32_t );
     static std::string TroopSizeString( const Troop & );
+
+    static std::pair<uint32_t, uint32_t> SizeRange( const uint32_t count );
 
     // compare
     static bool WeakestTroop( const Troop *, const Troop * );

--- a/src/fheroes2/army/army_ui_helper.cpp
+++ b/src/fheroes2/army/army_ui_helper.cpp
@@ -53,7 +53,7 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, int32_t cy, 
             continue;
         }
         const fheroes2::Sprite & monster = fheroes2::AGG::GetICN( ICN::MONS32, troop->GetSpriteIndex() );
-        fheroes2::Text text( isScouteView ? Game::CountScoute( troop->GetCount(), drawPower, compact ) : Game::CountThievesGuild( troop->GetCount(), drawPower ),
+        fheroes2::Text text( isScouteView ? Game::formatMonsterCount( troop->GetCount(), drawPower, compact ) : Game::CountThievesGuild( troop->GetCount(), drawPower ),
                              fheroes2::FontType::smallWhite() );
 
         // This is the drawing of army troops in compact form in the small info window beneath resources,

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -857,7 +857,7 @@ void Battle::ArmiesOrder::RedrawUnit( const fheroes2::Rect & pos, const Battle::
     fheroes2::Blit( mons32, output, pos.x + ( pos.width - mons32.width() ) / 2, pos.y + pos.height - mons32.height() - ( mons32.height() + 3 < pos.height ? 3 : 0 ),
                     revert );
 
-    Text number( GetStringShort( unit.GetCount() ), Font::SMALL );
+    Text number( fheroes2::abbreviateNumber( unit.GetCount() ), Font::SMALL );
     number.Blit( pos.x + 2, pos.y + 2, output );
 
     if ( isCurrentUnit ) {
@@ -1625,7 +1625,7 @@ void Battle::Interface::RedrawTroopCount( const Unit & unit )
 
     fheroes2::Blit( bar, _mainSurface, sx, sy );
 
-    Text text( GetStringShort( unit.GetCount() ), Font::SMALL );
+    Text text( fheroes2::abbreviateNumber( unit.GetCount() ), Font::SMALL );
     text.Blit( sx + ( bar.width() - text.w() ) / 2, sy, _mainSurface );
 }
 

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -133,7 +133,7 @@ namespace
         }
         else if ( isAbandonnedMine ) {
             const uint8_t spriteIndex = tile.GetObjectSpriteIndex();
-            if ( spriteIndex == 5 ) { // TODO: remove this hardocded value for real abandoned mine.
+            if ( spriteIndex == 5 ) { // TODO: remove this hardcoded value for real abandoned mine.
                 str = MP2::StringObject( objectType );
             }
             else {
@@ -456,33 +456,23 @@ namespace
         return { xpos, ypos, imageBox.width(), imageBox.height() };
     }
 
-    uint32_t GetHeroScoutingLevelForTile( const Heroes * hero, uint32_t dst )
+    uint32_t GetHeroScoutingLevelForTile( const Heroes * hero, const uint32_t dst )
     {
         if ( hero == nullptr ) {
             return Skill::Level::NONE;
         }
 
-        const uint32_t scoutingLevel = hero->GetSecondaryValues( Skill::Secondary::SCOUTING );
-        const MP2::MapObjectType objectType = world.GetTiles( dst ).GetObject( false );
-
-        const bool monsterInfo = objectType == MP2::OBJ_MONSTER;
-
-        // TODO check that this logic is what is really intended, it's only used for extended scouting anyway
-        if ( monsterInfo ) {
-            if ( Maps::GetStraightLineDistance( hero->GetIndex(), dst ) <= hero->GetVisionsDistance() ) {
-                return scoutingLevel;
-            }
-            else {
-                return Skill::Level::NONE;
-            }
-        }
-        else if ( Settings::Get().ExtWorldScouteExtended() ) {
+        if ( Settings::Get().ExtWorldScouteExtended() ) {
             uint32_t dist = static_cast<uint32_t>( hero->GetScoute() );
-            if ( hero->Modes( Heroes::VISIONS ) && dist < hero->GetVisionsDistance() )
-                dist = hero->GetVisionsDistance();
 
-            if ( Maps::GetStraightLineDistance( hero->GetIndex(), dst ) <= dist )
-                return scoutingLevel;
+            if ( hero->Modes( Heroes::VISIONS ) ) {
+                dist = std::max( dist, hero->GetVisionsDistance() );
+            }
+
+            if ( Maps::GetStraightLineDistance( hero->GetIndex(), dst ) <= dist ) {
+                return hero->GetSecondaryValues( Skill::Secondary::SCOUTING );
+            }
+
             return Skill::Level::NONE;
         }
 

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -469,7 +469,7 @@ namespace
 
         // TODO check that this logic is what is really intended, it's only used for extended scouting anyway
         if ( monsterInfo ) {
-            if ( Maps::GetApproximateDistance( hero->GetIndex(), dst ) <= hero->GetVisionsDistance() ) {
+            if ( Maps::GetStraightLineDistance( hero->GetIndex(), dst ) <= hero->GetVisionsDistance() ) {
                 return scoutingLevel;
             }
             else {
@@ -481,7 +481,7 @@ namespace
             if ( hero->Modes( Heroes::VISIONS ) && dist < hero->GetVisionsDistance() )
                 dist = hero->GetVisionsDistance();
 
-            if ( Maps::GetApproximateDistance( hero->GetIndex(), dst ) <= dist )
+            if ( Maps::GetStraightLineDistance( hero->GetIndex(), dst ) <= dist )
                 return scoutingLevel;
             return Skill::Level::NONE;
         }

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -153,7 +153,7 @@ namespace
             }
             else {
                 str.append( _( "guarded by %{count} %{monster}" ) );
-                StringReplace( str, "%{count}", Translation::StringLower( Game::CountScoute( troop.GetCount(), scoutingLevel ) ) );
+                StringReplace( str, "%{count}", Translation::StringLower( Game::formatMonsterCount( troop.GetCount(), scoutingLevel ) ) );
             }
             if ( troop.GetCount() == 1 && scoutingLevel == Skill::Level::EXPERT ) {
                 StringReplace( str, "%{monster}", Translation::StringLower( troop.GetName() ) );
@@ -173,7 +173,7 @@ namespace
         if ( isVisibleFromCrystalBall || ( extendedScoutingOption && basicScoutingLevel > Skill::Level::NONE ) ) {
             std::string str = "%{count} %{monster}";
             const int scoutingLevel = isVisibleFromCrystalBall ? static_cast<int>( Skill::Level::EXPERT ) : basicScoutingLevel;
-            StringReplace( str, "%{count}", Game::CountScoute( troop.GetCount(), scoutingLevel ) );
+            StringReplace( str, "%{count}", Game::formatMonsterCount( troop.GetCount(), scoutingLevel ) );
             if ( troop.GetCount() == 1 && scoutingLevel == Skill::Level::EXPERT ) {
                 StringReplace( str, "%{monster}", Translation::StringLower( troop.GetName() ) );
             }
@@ -212,7 +212,7 @@ namespace
             if ( extendedScoutingOption && scoutingLevel > Skill::Level::NONE ) {
                 const ResourceCount & rc = tile.QuantityResourceCount();
                 str.append( ": " );
-                str.append( Game::CountScoute( rc.second, scoutingLevel ) );
+                str.append( Game::formatMonsterCount( rc.second, scoutingLevel ) );
             }
         }
         else { // Campfire
@@ -224,14 +224,14 @@ namespace
                 str.append( Resource::String( Resource::GOLD ) );
 
                 str.append( ": " );
-                str.append( Game::CountScoute( funds.gold, scoutingLevel ) );
+                str.append( Game::formatMonsterCount( funds.gold, scoutingLevel ) );
                 str += '\n';
 
                 const ResourceCount & rc = tile.QuantityResourceCount();
                 str.append( Resource::String( rc.first ) );
 
                 str.append( ": " );
-                str.append( Game::CountScoute( rc.second, scoutingLevel ) );
+                str.append( Game::formatMonsterCount( rc.second, scoutingLevel ) );
                 str += ')';
             }
         }
@@ -248,7 +248,7 @@ namespace
             const Troop & troop = tile.QuantityTroop();
             if ( troop.isValid() ) {
                 str.append( _( "(available: %{count})" ) );
-                StringReplace( str, "%{count}", Game::CountScoute( troop.GetCount(), owned ? static_cast<int>( Skill::Level::EXPERT ) : scoutingLevel ) );
+                StringReplace( str, "%{count}", Game::formatMonsterCount( troop.GetCount(), owned ? static_cast<int>( Skill::Level::EXPERT ) : scoutingLevel ) );
             }
             else {
                 str.append( _( "(empty)" ) );

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -472,8 +472,6 @@ namespace
             if ( Maps::GetStraightLineDistance( hero->GetIndex(), dst ) <= dist ) {
                 return hero->GetSecondaryValues( Skill::Secondary::SCOUTING );
             }
-
-            return Skill::Level::NONE;
         }
 
         return Skill::Level::NONE;

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -632,8 +632,8 @@ std::string Game::formatMonsterCount( const uint32_t count, const int scoutingLe
             return formatString( half, max );
         }
 
-        // With basic scouting level, the range is divided into four parts and the part of the range
-        // into which the monster count falls is returned
+        // With advanced scouting level, the range is divided into four parts and the part of the
+        // range into which the monster count falls is returned
         if ( scoutingLevel == Skill::Level::ADVANCED ) {
             const uint32_t firstQuarter = min + ( max - min ) / 4;
 

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -601,15 +601,15 @@ std::string Game::formatMonsterCount( const uint32_t count, const int scoutingLe
     case Skill::Level::BASIC:
     case Skill::Level::ADVANCED: {
         // Always use abbreviated numbers for ranges, otherwise the string might become too long
-        auto formatString = []( uint32_t min, uint32_t max ) {
-            std::string res = fheroes2::abbreviateNumber( min );
+        auto formatString = []( const uint32_t min, const uint32_t max ) {
+            const std::string minStr = fheroes2::abbreviateNumber( min );
+            const std::string maxStr = fheroes2::abbreviateNumber( max );
 
-            if ( min != max ) {
-                res.append( "-" );
-                res.append( fheroes2::abbreviateNumber( max ) );
+            if ( minStr == maxStr ) {
+                return '~' + minStr;
             }
 
-            return res;
+            return minStr + '-' + maxStr;
         };
 
         const auto [min, max] = Army::SizeRange( count );

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -22,9 +22,7 @@
  ***************************************************************************/
 
 #include <algorithm>
-#include <atomic>
 #include <cassert>
-#include <cmath>
 
 #include "audio.h"
 #include "audio_manager.h"
@@ -597,45 +595,36 @@ int Game::GetActualKingdomColors()
     return Settings::Get().GetPlayers().GetActualColors();
 }
 
-std::string Game::CountScoute( uint32_t count, int scoute, bool shorts )
+std::string Game::CountScoute( const uint32_t count, const int scoute, const bool shorts /* = false */ )
 {
-    double infelicity = 0;
-    std::string res;
+    uint32_t inaccuracy = 0;
 
     switch ( scoute ) {
     case Skill::Level::BASIC:
-        infelicity = count * 30 / 100.0;
+        inaccuracy = std::max( count * 30 / 100, 5U );
         break;
 
     case Skill::Level::ADVANCED:
-        infelicity = count * 15 / 100.0;
+        inaccuracy = std::max( count * 15 / 100, 3U );
         break;
 
     case Skill::Level::EXPERT:
-        res = shorts ? GetStringShort( count ) : std::to_string( count );
-        break;
+        return ( shorts ? GetStringShort( count ) : std::to_string( count ) );
 
     default:
         return Army::SizeString( count );
     }
 
-    if ( res.empty() ) {
-        uint32_t min = Rand::Get( static_cast<uint32_t>( std::floor( count - infelicity + 0.5 ) ), static_cast<uint32_t>( std::floor( count + infelicity + 0.5 ) ) );
-        uint32_t max = 0;
+    assert( inaccuracy > 0 );
 
-        if ( min > count ) {
-            max = min;
-            min = static_cast<uint32_t>( std::floor( count - infelicity + 0.5 ) );
-        }
-        else
-            max = static_cast<uint32_t>( std::floor( count + infelicity + 0.5 ) );
+    const uint32_t min = std::max( ( count / inaccuracy ) * inaccuracy, 1U );
+    const uint32_t max = ( count / inaccuracy + 1 ) * inaccuracy;
 
-        res = std::to_string( min );
+    std::string res = std::to_string( min );
 
-        if ( min != max ) {
-            res.append( "-" );
-            res.append( std::to_string( max ) );
-        }
+    if ( min != max ) {
+        res.append( "-" );
+        res.append( std::to_string( max ) );
     }
 
     return res;

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -146,8 +146,11 @@ namespace Game
     }
 
     int32_t GetStep4Player( const int32_t currentId, const int32_t width, const int32_t totalCount );
-    std::string CountScoute( const uint32_t count, const int scoute, const bool shorts = false );
     std::string CountThievesGuild( uint32_t monsterCount, int guildCount );
+
+    // Returns the string representation of the monster count, formatted according to the scouting level (possibly in
+    // abbreviated form), suitable for use with the WORLD_SCOUTING_EXTENDED option. See the implementation for details.
+    std::string formatMonsterCount( const uint32_t count, const int scoutingLevel, const bool abbreviateNumber = false );
 }
 
 #endif

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -146,7 +146,7 @@ namespace Game
     }
 
     int32_t GetStep4Player( const int32_t currentId, const int32_t width, const int32_t totalCount );
-    std::string CountScoute( uint32_t count, int scoute, bool shorts = false );
+    std::string CountScoute( const uint32_t count, const int scoute, const bool shorts = false );
     std::string CountThievesGuild( uint32_t monsterCount, int guildCount );
 }
 

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -230,22 +230,22 @@ void Interface::StatusWindow::DrawKingdomInfo( int oh ) const
     text.Set( std::to_string( myKingdom.GetFunds().Get( Resource::GOLD ) ) );
     text.Blit( pos.x + 122 - text.w() / 2, pos.y + 28 + oh );
     // count wood
-    text.Set( GetStringShort( myKingdom.GetFunds().Get( Resource::WOOD ) ) );
+    text.Set( fheroes2::abbreviateNumber( myKingdom.GetFunds().Get( Resource::WOOD ) ) );
     text.Blit( pos.x + 15 - text.w() / 2, pos.y + 58 + oh );
     // count mercury
-    text.Set( GetStringShort( myKingdom.GetFunds().Get( Resource::MERCURY ) ) );
+    text.Set( fheroes2::abbreviateNumber( myKingdom.GetFunds().Get( Resource::MERCURY ) ) );
     text.Blit( pos.x + 37 - text.w() / 2, pos.y + 58 + oh );
     // count ore
-    text.Set( GetStringShort( myKingdom.GetFunds().Get( Resource::ORE ) ) );
+    text.Set( fheroes2::abbreviateNumber( myKingdom.GetFunds().Get( Resource::ORE ) ) );
     text.Blit( pos.x + 60 - text.w() / 2, pos.y + 58 + oh );
     // count sulfur
-    text.Set( GetStringShort( myKingdom.GetFunds().Get( Resource::SULFUR ) ) );
+    text.Set( fheroes2::abbreviateNumber( myKingdom.GetFunds().Get( Resource::SULFUR ) ) );
     text.Blit( pos.x + 84 - text.w() / 2, pos.y + 58 + oh );
     // count crystal
-    text.Set( GetStringShort( myKingdom.GetFunds().Get( Resource::CRYSTAL ) ) );
+    text.Set( fheroes2::abbreviateNumber( myKingdom.GetFunds().Get( Resource::CRYSTAL ) ) );
     text.Blit( pos.x + 108 - text.w() / 2, pos.y + 58 + oh );
     // count gems
-    text.Set( GetStringShort( myKingdom.GetFunds().Get( Resource::GEMS ) ) );
+    text.Set( fheroes2::abbreviateNumber( myKingdom.GetFunds().Get( Resource::GEMS ) ) );
     text.Blit( pos.x + 130 - text.w() / 2, pos.y + 58 + oh );
 }
 

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -318,7 +318,7 @@ namespace
         for ( const int32_t boatSource : Maps::GetObjectPositions( center, MP2::OBJ_BOAT, false ) ) {
             assert( Maps::isValidAbsIndex( boatSource ) );
 
-            const uint32_t distance = Maps::GetApproximateDistance( boatSource, hero.GetIndex() );
+            const uint32_t distance = Maps::GetStraightLineDistance( boatSource, hero.GetIndex() );
             if ( distance > 1 ) {
                 Game::ObjectFadeAnimation::PrepareFadeTask( MP2::OBJ_BOAT, boatSource, boatDestination, true, true );
                 Game::ObjectFadeAnimation::PerformFadeTask();

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -871,17 +871,20 @@ std::set<Heroes *> Kingdoms::resetRecruits()
     return remainingRecruits;
 }
 
-// Check if tile is visible from any crystal ball of any hero
 bool Kingdom::IsTileVisibleFromCrystalBall( const int32_t dest ) const
 {
     for ( const Heroes * hero : heroes ) {
+        assert( hero != nullptr );
+
         if ( hero->GetBagArtifacts().isArtifactBonusPresent( fheroes2::ArtifactBonusType::VIEW_MONSTER_INFORMATION ) ) {
             const uint32_t crystalBallDistance = hero->GetVisionsDistance();
+
             if ( Maps::GetStraightLineDistance( hero->GetIndex(), dest ) <= crystalBallDistance ) {
                 return true;
             }
         }
     }
+
     return false;
 }
 

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -877,7 +877,7 @@ bool Kingdom::IsTileVisibleFromCrystalBall( const int32_t dest ) const
     for ( const Heroes * hero : heroes ) {
         if ( hero->GetBagArtifacts().isArtifactBonusPresent( fheroes2::ArtifactBonusType::VIEW_MONSTER_INFORMATION ) ) {
             const uint32_t crystalBallDistance = hero->GetVisionsDistance();
-            if ( Maps::GetApproximateDistance( hero->GetIndex(), dest ) <= crystalBallDistance ) {
+            if ( Maps::GetStraightLineDistance( hero->GetIndex(), dest ) <= crystalBallDistance ) {
                 return true;
             }
         }

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -166,6 +166,8 @@ public:
 
     void LossPostActions();
 
+    // Checks whether this tile is visible to any hero who has an artifact with the VIEW_MONSTER_INFORMATION
+    // bonus (for example, a Crystal Ball)
     bool IsTileVisibleFromCrystalBall( const int32_t dest ) const;
 
     static uint32_t GetMaxHeroes();

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 
 #include "ai.h"
 #include "difficulty.h"
@@ -512,9 +513,25 @@ uint32_t Maps::GetApproximateDistance( const int32_t pos1, const int32_t pos2 )
     const fheroes2::Point point1( GetPoint( pos1 ) );
     const fheroes2::Point point2( GetPoint( pos2 ) );
 
-    const fheroes2::Size sz( std::abs( point1.x - point2.x ), std::abs( point1.y - point2.y ) );
-    // diagonal move costs 1.5 as much
-    return std::max( sz.width, sz.height ) + std::min( sz.width, sz.height ) / 2;
+    const uint32_t diffX = std::abs( point1.x - point2.x );
+    const uint32_t diffY = std::abs( point1.y - point2.y );
+
+    assert( diffX < Maps::XLARGE && diffY < Maps::XLARGE );
+
+    return std::max( diffX, diffY ) + std::min( diffX, diffY ) / 2;
+}
+
+uint32_t Maps::GetStraightLineDistance( const int32_t pos1, const int32_t pos2 )
+{
+    const fheroes2::Point point1( GetPoint( pos1 ) );
+    const fheroes2::Point point2( GetPoint( pos2 ) );
+
+    const uint32_t diffX = std::abs( point1.x - point2.x );
+    const uint32_t diffY = std::abs( point1.y - point2.y );
+
+    assert( diffX < Maps::XLARGE && diffY < Maps::XLARGE );
+
+    return static_cast<uint32_t>( std::hypot( diffX, diffY ) );
 }
 
 void Maps::ReplaceRandomCastleObjectId( const fheroes2::Point & center )

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -82,8 +82,28 @@ namespace Maps
 
     int32_t getFogTileCountToBeRevealed( const int32_t tileIndex, int scouteValue, const int playerColor );
 
-    // This method should be avoided unless high precision is not important.
+    // Returns the approximate distance between two tiles with given indexes. This distance is calculated as the number of
+    // tiles (truncated to the nearest smaller integer value) that would need to be traversed in a straight direction to
+    // overcome the distance that corresponds to the distance that the hero would have to cover when moving between tiles
+    // with given indexes using the usual rules and penalties.
+    //
+    // For example, in order to navigate to a tile B, which is located seven tiles below and five to the right of tile A,
+    // the hero should move two tiles down and five tiles right down diagonally (diagonal movement costs 50% more), which
+    // corresponds to 2 + 5 * 1.5 = 9.5 (9 after truncation) tiles traversed in the straight direction.
+    //
+    // This function should be avoided unless high precision is not important.
     uint32_t GetApproximateDistance( const int32_t pos1, const int32_t pos2 );
+
+    // Returns the straight line distance between two tiles with given indexes. This distance is calculated as the number
+    // of tiles (truncated to the nearest smaller integer value) that would need to be traversed in a straight direction
+    // to overcome the distance that corresponds to the straight line distance between the tiles with given indexes.
+    //
+    // For example, in order to navigate to a tile B, which is located seven tiles below and five to the right of tile A,
+    // a straight line distance should be covered, which corresponds to sqrt( 5^2 + 7^2 ) = 8.6 (8 after truncation) tiles
+    // traversed in the straight direction.
+    //
+    // This function is not suitable for accurate calculation of the distance expressed in movement points.
+    uint32_t GetStraightLineDistance( const int32_t pos1, const int32_t pos2 );
 
     void UpdateCastleSprite( const fheroes2::Point & center, int race, bool isCastle = false, bool isRandom = false );
     void ReplaceRandomCastleObjectId( const fheroes2::Point & );

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -69,7 +69,7 @@ namespace
     bool AppendIfFarEnough( std::vector<int> & dataSet, int value, uint32_t distance )
     {
         for ( const int current : dataSet ) {
-            if ( Maps::GetApproximateDistance( current, value ) < distance )
+            if ( Maps::GetStraightLineDistance( current, value ) < distance )
                 return false;
         }
 


### PR DESCRIPTION
fix #1466

In the original game:

https://user-images.githubusercontent.com/32623900/177887700-aa85ac47-4400-4e59-9620-740ed7260736.mp4

With this PR:

https://user-images.githubusercontent.com/32623900/177887727-5a151fc8-63d4-45d7-bdba-bba2248a3451.mp4

---

close #2570

Rework the "extended scouting" algorithm of neutral monster counting by excluding the random from it (a situation where the numbers are constantly changing looks weird). The proposed algorithm is as follows:

1. The range into which a given number of monsters falls (one of standard ranges, i.e. 1 - 5, 5 - 10, 10 - 20, 20 - 50, etc) is taken;
2. With basic scouting level, the range is divided in half and the part of the range into which the monster count falls is returned. For example, for 1 wolf and 2 wolves "1-3 wolves" will be shown, for 3 and 4 wolves "3-5 wolves" will be shown, for 5 wolves "5-7 wolves" will be shown, and for 30 goblins "20-35 goblins" will be shown;
3. With advanced scouting level, the range is divided into four parts and the part of the range into which the monster count falls is returned. For example, for 20 and 25 goblins "20-27 goblins" will be shown, and for 30 goblins "27-35 goblins" will be shown;
4. With expert scouting level, the exact monster count is returned.

This algorithm is a subject to discussion of course.