### PR TITLE
Preparations for Adventure Map rendering

### DIFF
--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -191,6 +191,24 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
         return;
     }
 
+    // Each tile can contain multiple objects parts or sprites. Each object part has its own level or in other words layer of rendering.
+    // We need to use a correct order of levels to render objects. The levels are:
+    // 0 - main and action objects like mines, forest, castle and etc.
+    // 1 - background objects like lake or bushes.
+    // 2 - shadows
+    // 3 - roads, water flaws and cracks. Essentially everything what is a part of terrain.
+    // The correct order of levels is 3 --> 1 --> 2 --> 0.
+    //
+    // There are also two groups of objects: ground objects (bottom layer) and high objects (top layer). High objects are the parts of objects which are taller than
+    // 1 tile. For example, a castle. All ground objects are drawn first.
+    //
+    // However, there are some objects which appears to be more than 1 tile (32 x 32 pixels) size such as heroes, monsters and boats.
+    // To render all these 'special' objects we need to create a copy of object sprite stacks for each tile, add temporary extra sprites and render them.
+    //
+    // TODO: to proceed with this concept we need to put an object info stored in class Tiles into either groud object stack or high object stack. For example, a tile
+    // TODO: which contains only one top castle sprite would have data only in Tiles class but a hero could be at the same tile. To correctly render objects we need to
+    // TODO: render the hero first and only then render castle's sprite. Side note: from the map format Tiles class must contain only objects from level 1.
+
     std::vector<const Maps::Tiles *> drawList;
     std::vector<const Maps::Tiles *> monsterList;
     std::vector<const Maps::Tiles *> topList;

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -191,18 +191,18 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
         return;
     }
 
-    // Each tile can contain multiple objects parts or sprites. Each object part has its own level or in other words layer of rendering.
-    // We need to use a correct order of levels to render objects. The levels are:
+    // Each tile can contain multiple object parts or sprites. Each object part has its own level or in other words layer of rendering.
+    // We need to use a correct order of levels to render objects on tiles. The levels are:
     // 0 - main and action objects like mines, forest, castle and etc.
     // 1 - background objects like lake or bushes.
     // 2 - shadows
     // 3 - roads, water flaws and cracks. Essentially everything what is a part of terrain.
     // The correct order of levels is 3 --> 1 --> 2 --> 0.
     //
-    // There are also two groups of objects: ground objects (bottom layer) and high objects (top layer). High objects are the parts of objects which are taller than
+    // There are also two groups of objects: ground objects (bottom layer) and high objects (top layer). High objects are the parts of the objects which are taller than
     // 1 tile. For example, a castle. All ground objects are drawn first.
     //
-    // However, there are some objects which appears to be more than 1 tile (32 x 32 pixels) size such as heroes, monsters and boats.
+    // However, there are some objects which appear to be more than 1 tile (32 x 32 pixels) size such as heroes, monsters and boats.
     // To render all these 'special' objects we need to create a copy of object sprite stacks for each tile, add temporary extra sprites and render them.
     //
     // TODO: to proceed with this concept we need to put an object info stored in class Tiles into either groud object stack or high object stack. For example, a tile

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1575,8 +1575,7 @@ std::string Maps::Tiles::String() const
 
         os << "capture color   : " << Color::String( co.objcol.second ) << std::endl;
         if ( co.guardians.isValid() ) {
-            os << "capture guard   : " << co.guardians.GetName() << std::endl
-               << "capture count   : " << co.guardians.GetCount() << std::endl;
+            os << "capture guard   : " << co.guardians.GetName() << std::endl << "capture count   : " << co.guardians.GetCount() << std::endl;
         }
     }
 

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -259,10 +259,7 @@ namespace Maps
         /* monster operation */
         bool MonsterJoinConditionSkip() const;
         bool MonsterJoinConditionFree() const;
-        int MonsterJoinCondition() const;
         void MonsterSetJoinCondition( int );
-        void MonsterSetFixedCount();
-        bool MonsterFixedCount() const;
         void MonsterSetCount( uint32_t count );
         uint32_t MonsterCount() const;
 
@@ -347,6 +344,8 @@ namespace Maps
 
         bool isDetachedObject() const;
 
+        int MonsterJoinCondition() const;
+
         static void UpdateMonsterInfo( Tiles & );
         static void UpdateDwellingPopulation( Tiles & tile, bool isFirstLoad );
         static void UpdateMonsterPopulation( Tiles & );
@@ -363,8 +362,8 @@ namespace Maps
             return l.GetIndex() < r.GetIndex();
         }
 
-        Addons addons_level1;
-        Addons addons_level2; // 16
+        Addons addons_level1; // bottom layer
+        Addons addons_level2; // top layer
 
         int32_t _index = 0;
         uint16_t pack_sprite_index = 0;
@@ -377,8 +376,11 @@ namespace Maps
         uint8_t fog_colors = Color::ALL;
 
         uint8_t heroID = 0;
+
+        // TODO: Combine quantity1 and quantity2 into a single 16/32-bit variable except first 2 bits of quantity1 which are used for level type of an object.
         uint8_t quantity1 = 0;
         uint8_t quantity2 = 0;
+
         uint8_t quantity3 = 0;
 
         bool tileIsRoad = false;

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -961,7 +961,7 @@ void Maps::Tiles::PlaceMonsterOnTile( Tiles & tile, const Monster & mons, const 
         tile.MonsterSetJoinCondition( Monster::JOIN_CONDITION_SKIP );
     }
     else if ( setDefinedCount || ( world.GetWeekType().GetType() == WeekName::MONSTERS && world.GetWeekType().GetMonster() == mons.GetID() ) ) {
-        // TODO: why there are neutral monsters whose number was set in the Editor always join for money? Check the logic in the original game.
+        // Wandering monsters with the number of units specified by the map designer are always considered as "hostile" and always join only for money.
 
         // Monsters will be willing to join for some amount of money.
         tile.MonsterSetJoinCondition( Monster::JOIN_CONDITION_MONEY );

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -905,18 +905,9 @@ int Maps::Tiles::MonsterJoinCondition() const
 
 void Maps::Tiles::MonsterSetJoinCondition( int cond )
 {
+    // TODO: why are we doing this? Simplify the logic.
     quantity3 &= 0xFC;
     quantity3 |= ( cond & 0x03 );
-}
-
-void Maps::Tiles::MonsterSetFixedCount()
-{
-    quantity3 |= 0x80;
-}
-
-bool Maps::Tiles::MonsterFixedCount() const
-{
-    return mp2_object == MP2::OBJ_MONSTER ? ( quantity3 & 0x80 ) != 0 : false;
 }
 
 bool Maps::Tiles::MonsterJoinConditionSkip() const
@@ -931,11 +922,13 @@ bool Maps::Tiles::MonsterJoinConditionFree() const
 
 uint32_t Maps::Tiles::MonsterCount() const
 {
+    // TODO: avoid this hacky way of storing data.
     return ( static_cast<uint32_t>( quantity1 ) << 8 ) | quantity2;
 }
 
 void Maps::Tiles::MonsterSetCount( uint32_t count )
 {
+    // TODO: avoid this hacky way of storing data.
     quantity1 = count >> 8;
     quantity2 = 0x00FF & count;
 }
@@ -954,8 +947,9 @@ void Maps::Tiles::PlaceMonsterOnTile( Tiles & tile, const Monster & mons, const 
     tile.objectTileset = 48; // MONS32.ICN
     tile.objectIndex = mons.GetSpriteIndex();
 
-    if ( count ) {
-        tile.MonsterSetFixedCount();
+    const bool setDefinedCount = ( count > 0 );
+
+    if ( setDefinedCount ) {
         tile.MonsterSetCount( count );
     }
     else {
@@ -966,7 +960,9 @@ void Maps::Tiles::PlaceMonsterOnTile( Tiles & tile, const Monster & mons, const 
         // Ghosts and elementals never join hero's army.
         tile.MonsterSetJoinCondition( Monster::JOIN_CONDITION_SKIP );
     }
-    else if ( tile.MonsterFixedCount() || ( world.GetWeekType().GetType() == WeekName::MONSTERS && world.GetWeekType().GetMonster() == mons.GetID() ) ) {
+    else if ( setDefinedCount || ( world.GetWeekType().GetType() == WeekName::MONSTERS && world.GetWeekType().GetMonster() == mons.GetID() ) ) {
+        // TODO: why there are neutral monsters whose number was set in the Editor always join for money? Check the logic in the original game.
+
         // Monsters will be willing to join for some amount of money.
         tile.MonsterSetJoinCondition( Monster::JOIN_CONDITION_MONEY );
     }
@@ -1106,7 +1102,7 @@ void Maps::Tiles::UpdateMonsterPopulation( Tiles & tile )
     if ( troopCount == 0 ) {
         tile.MonsterSetCount( troop.GetRNDSize( false ) );
     }
-    else if ( !tile.MonsterFixedCount() ) {
+    else {
         const uint32_t bonusUnit = ( Rand::Get( 1, 7 ) <= ( troopCount % 7 ) ) ? 1 : 0;
         tile.MonsterSetCount( troopCount * 8 / 7 + bonusUnit );
     }

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -41,7 +41,7 @@ namespace MP2
         SIZEOFMP2RIDDLE = 138
     };
 
-    // origin mp2 tile
+    // Tile structure from the original map format.
     struct mp2tile_t
     {
         uint16_t surfaceType; // Tile index representing a type of surface: ocean, grass, snow, swamp, lava, desert, dirt, wasteland, beach.
@@ -72,7 +72,7 @@ namespace MP2
         uint32_t level2ObjectUID;
     };
 
-    // origin mp2 addons tile
+    // Addon structure from the original map format.
     struct mp2addon_t
     {
         uint16_t nextAddonIndex; // Next add-on index. Zero value means it's the last addon chunk.


### PR DESCRIPTION
Add extra comments for the future Adventure Map rendering to be done in a correct way.

Also fixed invalid logic when neutral monsters whose number was set in the Editor did not grow at all.