### PR TITLE
Fix redrawing of the status window in cases when the hero's army or the castle garrison change without changing focus

### DIFF
--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -185,13 +185,14 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */ )
         else {
             basicInterface.ResetFocus( GameFocus::HEROES );
         }
-
-        basicInterface.RedrawFocus();
     }
     else {
         // If we don't update focus, we still have to restore environment sounds and terrain music theme
         restoreSoundsForCurrentFocus();
     }
+
+    // The castle garrison can change
+    basicInterface.RedrawFocus();
 }
 
 void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, bool windowIsGameWorld, bool disableDismiss /* = false */ )
@@ -256,9 +257,10 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, bool windowIsGameW
         else {
             basicInterface.ResetFocus( GameFocus::HEROES );
         }
-
-        basicInterface.RedrawFocus();
     }
+
+    // The hero's army can change
+    basicInterface.RedrawFocus();
 }
 
 void ShowNewWeekDialog()


### PR DESCRIPTION
fix #5629

Regression after #5545