### PR TITLE
When adding a custom spellbook while loading a hero from MP2, check that the hero does not have it yet

### DIFF
--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -295,6 +295,11 @@ void Heroes::LoadFromMP2( int32_t map_index, int cl, int rc, StreamBuf st )
 
         // Hero's race may not match the custom portrait
         _race = rc;
+
+        // Since we changed the hero's race, we have to update the initial spell as well. Let's remove the
+        // existing spell and the spell book itself for now, the new one will be added later if necessary.
+        spell_book.clear();
+        bag_artifacts.RemoveArtifact( Artifact::MAGIC_BOOK );
     }
     else {
         st.skip( 1 );

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -305,7 +305,7 @@ void Heroes::LoadFromMP2( int32_t map_index, int cl, int rc, StreamBuf st )
         st.skip( 1 );
     }
 
-    auto setInitialArtifact = [this]( const Artifact & art ) {
+    auto addInitialArtifact = [this]( const Artifact & art ) {
         // Perhaps the hero already has a spell book because of his race
         if ( art == Artifact::MAGIC_BOOK && HaveSpellBook() ) {
             return;
@@ -315,9 +315,9 @@ void Heroes::LoadFromMP2( int32_t map_index, int cl, int rc, StreamBuf st )
     };
 
     // 3 artifacts
-    setInitialArtifact( Artifact( st.get() ) );
-    setInitialArtifact( Artifact( st.get() ) );
-    setInitialArtifact( Artifact( st.get() ) );
+    addInitialArtifact( Artifact( st.get() ) );
+    addInitialArtifact( Artifact( st.get() ) );
+    addInitialArtifact( Artifact( st.get() ) );
 
     // Unknown
     st.skip( 1 );


### PR DESCRIPTION
fix #5633

The issue scenario is as follows:

1. The game loads a hero with a specified portrait (Sir Gallant);
2. If this hero is already busy (already hired or jailed), the game tries to get a freeman hero and "remake" it into the right race and set a custom portrait;
3. If this freeman hero already have a spellbook because of his former race, and also he has a "custom" spellbook as an artifact, then the error from #5633 will be observed, because there will be an attempt to add the spellbook twice.

Also this PR fixes an issue when old default spell may remain after changing the hero's race for the custom hero, like here:

<img width="639" alt="Снимок экрана 2022-07-13 в 00 35 58" src="https://user-images.githubusercontent.com/32623900/178602245-8dd6f29f-1aab-4aaa-940d-6c40a2e7bfe1.png">

Custom Knight has the Stoneskin spell, "inherited" from the Wizard.