### PR TITLE
Add auto-calculated resolutions

### DIFF
--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -118,7 +118,7 @@ namespace
 
         // Add resolutions which can be considered as integer downscaling resolutions.
         for ( const fheroes2::Size & resolution : resolutions ) {
-            // Normal desktop / laptop screen always have resolution divisible by 2.
+            // Normal desktop / laptop screen always have resolutions divisible by 2.
             if ( ( resolution.width % 4 ) != 0 || ( resolution.height % 4 ) != 0 ) {
                 continue;
             }

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -100,7 +100,7 @@ namespace
         // Populate missing resolutions into the list.
         const std::vector<fheroes2::Size> possibleResolutions
             = { { 640, 480 },   { 800, 600 },  { 1024, 768 },  { 1152, 864 }, { 1280, 600 }, { 1280, 720 },  { 1280, 768 }, { 1280, 960 },
-                { 1280, 1024 }, { 1360, 768 }, { 1400, 1050 }, { 1440, 900 }, { 1600, 900 }, { 1680, 1050 }, { 1920, 1080 } };
+                { 1360, 768 }, { 1400, 1050 }, { 1440, 900 }, { 1600, 900 }, { 1680, 1050 }, { 1920, 1080 } };
 
         const fheroes2::Size lowestResolution = resolutions.back();
         for ( const fheroes2::Size & resolution : possibleResolutions ) {

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -118,7 +118,8 @@ namespace
 
         // Add resolutions which can be considered as integer downscaling resolutions.
         for ( const fheroes2::Size & resolution : resolutions ) {
-            if ( ( resolution.width & 1 ) != 0 || ( resolution.height & 1 ) != 0 ) {
+            // Normal desktop / laptop screen always have resolution divisible by 2.
+            if ( ( resolution.width % 4 ) != 0 || ( resolution.height % 4 ) != 0 ) {
                 continue;
             }
             const int32_t smallerWidth = resolution.width / 2;

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -100,7 +100,7 @@ namespace
         // Populate missing resolutions into the list.
         const std::vector<fheroes2::Size> possibleResolutions
             = { { 640, 480 },   { 800, 600 },  { 1024, 768 },  { 1152, 864 }, { 1280, 600 }, { 1280, 720 },  { 1280, 768 }, { 1280, 960 },
-                { 1360, 768 }, { 1400, 1050 }, { 1440, 900 }, { 1600, 900 }, { 1680, 1050 }, { 1920, 1080 } };
+                { 1280, 1024 }, { 1360, 768 }, { 1400, 1050 }, { 1440, 900 }, { 1600, 900 }, { 1680, 1050 }, { 1920, 1080 } };
 
         const fheroes2::Size lowestResolution = resolutions.back();
         for ( const fheroes2::Size & resolution : possibleResolutions ) {

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -137,7 +137,6 @@ namespace
         }
 
         resolutions.insert( resolutions.end(), extraResolutions.begin(), extraResolutions.end() );
-        std::sort( resolutions.begin(), resolutions.end(), SortResolutions );
 
         // We can determine an aspect ratio of the screen based on the highest resolution. For now we support only 16 x N resolutions. 4 x 3 resolution is actually
         // 16 x 12.

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -110,7 +110,57 @@ namespace
             resolutions.emplace_back( resolution );
         }
 
+        // To support wide screens without making the in-game elements too tiny there are 2 solutions.
+        // One way is to introduce an in-game scaling while another is to add lower resolutions based on existing resolutions.
+        // The in-game scaling requires more computational power while a low resolution in a full screen mode is usually supported natively by an OS.
+        // Let's go with the second option and add extra resolutions.
+        std::vector<fheroes2::Size> extraResolutions;
+
+        // Add resolutions which can be considered as integer downscaling resolutions.
+        for ( const fheroes2::Size & resolution : resolutions ) {
+            if ( ( resolution.width & 1 ) != 0 || ( resolution.height & 1 ) != 0 ) {
+                continue;
+            }
+            const int32_t smallerWidth = resolution.width / 2;
+            const int32_t smallerHeight = resolution.height / 2;
+
+            if ( smallerWidth < fheroes2::Display::DEFAULT_WIDTH || smallerHeight < fheroes2::Display::DEFAULT_HEIGHT ) {
+                continue;
+            }
+
+            if ( std::find( resolutions.begin(), resolutions.end(), fheroes2::Size( smallerWidth, smallerHeight ) ) != resolutions.end() ) {
+                continue;
+            }
+
+            extraResolutions.emplace_back( smallerWidth, smallerHeight );
+        }
+
+        resolutions.insert( resolutions.end(), extraResolutions.begin(), extraResolutions.end() );
         std::sort( resolutions.begin(), resolutions.end(), SortResolutions );
+
+        // We can determine an aspect ratio of the screen based on the highest resolution. For now we support only 16 x N resolutions. 4 x 3 resolution is actually
+        // 16 x 12.
+        if ( ( resolutions.front().width % 16 ) == 0 ) {
+            const int32_t aspectRatio = resolutions.front().height * 16 / resolutions.front().width;
+            if ( resolutions.front().height * 16 == resolutions.front().width * aspectRatio ) {
+                extraResolutions.clear();
+
+                for ( const fheroes2::Size & resolution : resolutions ) {
+                    if ( ( resolution.width % 16 ) != 0 ) {
+                        continue;
+                    }
+
+                    int32_t newHeight = resolution.width / 16 * aspectRatio;
+                    if ( newHeight >= fheroes2::Display::DEFAULT_HEIGHT && ( newHeight % 16 ) == 0
+                         && std::find( resolutions.begin(), resolutions.end(), fheroes2::Size( resolution.width, newHeight ) ) == resolutions.end() ) {
+                        extraResolutions.emplace_back( resolution.width, newHeight );
+                    }
+                }
+
+                resolutions.insert( resolutions.end(), extraResolutions.begin(), extraResolutions.end() );
+                std::sort( resolutions.begin(), resolutions.end(), SortResolutions );
+            }
+        }
 
         return resolutions;
     }


### PR DESCRIPTION
to support wide screens without making the image too tiny.

![image](https://user-images.githubusercontent.com/19829520/178746570-a4a69c20-66b0-44bc-b9cf-b68bb011285b.png)

The solution is not ideal but at least it gives more options for players without suffering with square or very high resolutions.