### PR TITLE
Remove virtual from Troop::GetCount()

### DIFF
--- a/src/fheroes2/army/army_troop.h
+++ b/src/fheroes2/army/army_troop.h
@@ -46,7 +46,7 @@ public:
 
     bool isMonster( int ) const;
     const char * GetName() const;
-    virtual uint32_t GetCount() const;
+    uint32_t GetCount() const;
     uint32_t GetHitPoints() const;
     Monster GetMonster() const;
 


### PR DESCRIPTION
It is not overridden anywhere and only brings confusion.