### PR TITLE
Update treasure chest AI decision logic

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -716,6 +716,8 @@ namespace AI
         Maps::Tiles & tile = world.GetTiles( dst_index );
         uint32_t gold = tile.QuantityGold();
 
+        Kingdom & kingdom = hero.GetKingdom();
+
         if ( tile.isWater() ) {
             if ( gold ) {
                 const Artifact & art = tile.QuantityArtifact();
@@ -728,27 +730,55 @@ namespace AI
             const Artifact & art = tile.QuantityArtifact();
 
             if ( gold ) {
-                const uint32_t expr = gold > 500 ? gold - 500 : 500;
+                const uint32_t experience = gold > 500 ? gold - 500 : 500;
+                const Heroes::Role role = hero.getAIRole();
+                const int32_t kingdomGold = kingdom.GetFunds().gold;
 
-                if ( hero.getAIRole() == Heroes::Role::HUNTER ) {
-                    // Only 10% chance of choosing experience. Make AI rich!
-                    if ( Rand::Get( 1, 10 ) == 1 ) {
-                        gold = 0;
-                        hero.IncreaseExperience( expr );
+                uint32_t chance = 0;
+                if ( role == Heroes::Role::SCOUT || role == Heroes::Role::COURIER ) {
+                    // These roles usually don't choose experience. Make AI rich!
+                    if ( kingdomGold > 10000 && experience >= 1500 ) {
+                        chance = 10;
                     }
                 }
-                else if ( Rand::Get( 1, 2 ) == 1 ) {
-                    // 50/50 chance.
-                    gold = 0;
-                    hero.IncreaseExperience( expr );
+                else if ( role == Heroes::Role::CHAMPION ) {
+                    // If AI is extremely low on gold consider taking it
+                    if ( kingdomGold < 3000 ) {
+                        // Safeguard the calculation since we're working with unsigned values
+                        chance = ( std::max( experience, 500u ) - 500 ) / 15;
+                    }
+                    else {
+                        // Otherwise Champion always picks experience
+                        chance = 100;
+                    }
+                }
+                else if ( kingdomGold < 3000 ) {
+                    chance = ( role == Heroes::Role::FIGHTER && experience >= 1500 ) ? 10 : 0;
+                }
+                else {
+                    uint32_t value = ( experience > 500 ) ? experience - 500 : 0;
+                    if ( role == Heroes::Role::FIGHTER ) {
+                        value += 500;
+                    }
+                    chance = value / 15; // 33% for every 500 experience
+                }
+
+                if ( chance ) {
+                    const uint32_t randomRoll = Rand::Get( 1, 100 );
+                    if ( randomRoll <= chance ) {
+                        gold = 0;
+                        hero.IncreaseExperience( experience );
+                    }
                 }
             }
-            else if ( art.isValid() && !hero.PickupArtifact( art ) )
+            else if ( art.isValid() && !hero.PickupArtifact( art ) ) {
                 gold = GoldInsteadArtifact( objectType );
+            }
         }
 
-        if ( gold )
-            hero.GetKingdom().AddFundsResource( Funds( Resource::GOLD, gold ) );
+        if ( gold ) {
+            kingdom.AddFundsResource( Funds( Resource::GOLD, gold ) );
+        }
 
         tile.RemoveObjectSprite();
         tile.QuantityReset();

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -745,7 +745,7 @@ namespace AI
                     // If AI is extremely low on gold consider taking it
                     if ( kingdomGold < 3000 ) {
                         // Safeguard the calculation since we're working with unsigned values
-                        chance = ( std::max( experience, 500u ) - 500 ) / 15;
+                        chance = ( std::max( experience, 500U ) - 500 ) / 15;
                     }
                     else {
                         // Otherwise Champion always picks experience

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1063,7 +1063,7 @@ namespace AI
         }
         else if ( objectType == MP2::OBJ_TREASURECHEST ) {
             // Treasure chest without the artifact
-            return 1250.0;
+            return std::max( tile.QuantityGold(), 1000u );
         }
         else if ( MP2::isPickupObject( objectType ) ) {
             return anotherFriendlyHeroPresent ? 100.0 : 500.0;

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1063,7 +1063,7 @@ namespace AI
         }
         else if ( objectType == MP2::OBJ_TREASURECHEST ) {
             // Treasure chest without the artifact
-            return std::max( tile.QuantityGold(), 1000u );
+            return std::max( tile.QuantityGold(), 1000U );
         }
         else if ( MP2::isPickupObject( objectType ) ) {
             return anotherFriendlyHeroPresent ? 100.0 : 500.0;


### PR DESCRIPTION
Now AI should decide between gold or experience more carefully. Increases likelihood of meeting a strong AI hero.