### PR TITLE
Update SDL to 2.0.22 version for Windows

### DIFF
--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -12,7 +12,7 @@ xcopy /Y /Q "..\..\VisualStudio\packages\zlib1.2.11.zip" "%tempPath%\zlib\"
 echo [2/6] Downloading packages
 powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://www.libsdl.org/release/SDL-devel-1.2.15-VC.zip', '%tempPath%\sdl\sdl.zip')"
 echo [3/6] Downloading packages
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://www.libsdl.org/release/SDL2-devel-2.0.12-VC.zip', '%tempPath%\sdl\sdl2.zip')"
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://www.libsdl.org/release/SDL2-devel-2.0.22-VC.zip', '%tempPath%\sdl\sdl2.zip')"
 echo [4/6] Downloading packages
 powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://www.libsdl.org/projects/SDL_mixer/release/SDL_mixer-devel-1.2.12-VC.zip', '%tempPath%\sdl_mixer\sdl_mixer.zip')"
 echo [5/6] Downloading packages

--- a/script/windows/setup_packages.bat
+++ b/script/windows/setup_packages.bat
@@ -11,8 +11,8 @@ if not exist "sdl2\lib"     mkdir "sdl2\lib"
 xcopy /Y /S /Q "temp\sdl\SDL-1.2.15\include"  "sdl\include"
 xcopy /Y /S /Q "temp\sdl\SDL-1.2.15\lib"      "sdl\lib"
 
-xcopy /Y /S /Q "temp\sdl\SDL2-2.0.12\include" "sdl2\include"
-xcopy /Y /S /Q "temp\sdl\SDL2-2.0.12\lib"     "sdl2\lib"
+xcopy /Y /S /Q "temp\sdl\SDL2-2.0.22\include" "sdl2\include"
+xcopy /Y /S /Q "temp\sdl\SDL2-2.0.22\lib"     "sdl2\lib"
 
 xcopy /Y /S /Q "temp\sdl_mixer\SDL_mixer-1.2.12\include"                  "sdl\include"
 xcopy /Y /Q "temp\sdl_mixer\SDL_mixer-1.2.12\lib\x86\SDL_mixer.dll"       "sdl\lib\x86"

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -544,7 +544,9 @@ void Audio::Init()
     }
 
     if ( audioSpecs.freq != frequency ) {
-        ERROR_LOG( "Audio frequency is initialized as " << frequency << " instead of " << audioSpecs.freq )
+        // At least on Windows the standard frequency is 48000 Hz. Sounds in the game are 22500 Hz frequency.
+        // However, resampling is done inside SDL Mixer so this is not exactly an error.
+        DEBUG_LOG( DBG_ENGINE, DBG_WARN, "Audio frequency is initialized as " << frequency << " instead of " << audioSpecs.freq )
     }
 
     if ( audioSpecs.format != format ) {

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -545,7 +545,7 @@ void Audio::Init()
 
     if ( audioSpecs.freq != frequency ) {
         // At least on Windows the standard frequency is 48000 Hz. Sounds in the game are 22500 Hz frequency.
-        // However, resampling is done inside SDL Mixer so this is not exactly an error.
+        // However, resampling is done inside SDL so this is not exactly an error.
         DEBUG_LOG( DBG_ENGINE, DBG_WARN, "Audio frequency is initialized as " << frequency << " instead of " << audioSpecs.freq )
     }
 

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -989,13 +989,6 @@ namespace
                 return false;
             }
 
-            _renderer = SDL_CreateRenderer( _window, -1, renderFlags() );
-            if ( _renderer == nullptr ) {
-                ERROR_LOG( "Failed to create a window renderer of " << width_ << " x " << height_ << " size. The error: " << SDL_GetError() )
-                clear();
-                return false;
-            }
-
             bool isPaletteModeSupported = false;
 
             SDL_RendererInfo rendererInfo;
@@ -1010,6 +1003,18 @@ namespace
                         break;
                     }
                 }
+            }
+
+            const uint32_t renderingFlags = renderFlags();
+            if ( ( renderingFlags & rendererInfo.flags ) != renderingFlags ) {
+                ERROR_LOG( "Chosen rendering driver does not support all rendering flags" )
+            }
+
+            _renderer = SDL_CreateRenderer( _window, -1, renderingFlags );
+            if ( _renderer == nullptr ) {
+                ERROR_LOG( "Failed to create a window renderer of " << width_ << " x " << height_ << " size. The error: " << SDL_GetError() )
+                clear();
+                return false;
             }
 
             _surface = SDL_CreateRGBSurface( 0, width_, height_, isPaletteModeSupported ? 8 : 32, 0, 0, 0, 0 );
@@ -1091,7 +1096,7 @@ namespace
 
         bool _isVSyncEnabled;
 
-        int renderFlags() const
+        uint32_t renderFlags() const
         {
             if ( _isVSyncEnabled ) {
                 return ( SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC );
@@ -1327,7 +1332,7 @@ namespace
         SDL_Surface * _surface;
         int _bitDepth;
 
-        int renderFlags() const
+        uint32_t renderFlags() const
         {
 #if defined( __WIN32__ )
             return SDL_HWSURFACE | SDL_HWPALETTE;

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -905,6 +905,7 @@ namespace
                 if ( _renderer != nullptr )
                     SDL_DestroyRenderer( _renderer );
 
+                // TODO: run throught all drivers and find the one which supports SDL_PIXELFORMAT_INDEX8 and use that driver ID instead of -1.
                 _renderer = SDL_CreateRenderer( _window, -1, renderFlags() );
                 if ( _renderer == nullptr ) {
                     ERROR_LOG( "Failed to create a window renderer. The error: " << SDL_GetError() )
@@ -1010,6 +1011,7 @@ namespace
                 ERROR_LOG( "Chosen rendering driver does not support all rendering flags" )
             }
 
+            // TODO: run throught all drivers and find the one which supports SDL_PIXELFORMAT_INDEX8 and use that driver ID instead of -1.
             _renderer = SDL_CreateRenderer( _window, -1, renderingFlags );
             if ( _renderer == nullptr ) {
                 ERROR_LOG( "Failed to create a window renderer of " << width_ << " x " << height_ << " size. The error: " << SDL_GetError() )

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1029,6 +1029,12 @@ namespace
                 ERROR_LOG( "Failed to set a linear scale hint for rendering." )
             }
 
+            // Setting this hint prevents the window to regain focus after loosing it in fullscreen mode.
+            // It also fixes issues when SDL_UpdateTexture() calls fail because of refocusing.
+            if ( SDL_SetHint( SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0" ) == SDL_FALSE ) {
+                ERROR_LOG( "Failed to set a linear scale hint for rendering." )
+            }
+
             returnCode = SDL_RenderSetLogicalSize( _renderer, width_, height_ );
             if ( returnCode < 0 ) {
                 ERROR_LOG( "Failed to create logical size of " << width_ << " x " << height_ << " size. The error value: " << returnCode


### PR DESCRIPTION
- update SDL library from 2.0.12 to 2.0.22 for Windows
- add more error checks for rendering
- add TODO comments for the future rendering enhancement