### PR TITLE
Fix number of ghosts and splitting for Shipwreck, Haunt and Abandoned Mine cases

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -584,8 +584,7 @@ void Troops::SortStrongest()
     std::sort( begin(), end(), Army::StrongestTroop );
 }
 
-// Pre-battle arrangement for Monster or Neutral troops
-void Troops::ArrangeForBattle( bool upgrade )
+void Troops::ArrangeForBattle( bool upgrade /* = false */ )
 {
     const Troops & priority = GetOptimized();
 
@@ -621,6 +620,36 @@ void Troops::ArrangeForBattle( bool upgrade )
     else {
         Assign( priority );
     }
+}
+
+void Troops::ArrangeForBattle( const Monster & monster, const uint32_t monstersCount, const uint32_t stacksCount )
+{
+    assert( stacksCount > 0 && stacksCount <= size() && size() == ARMYMAXTROOPS );
+    assert( std::all_of( begin(), end(), []( const Troop * troop ) { return troop->isEmpty(); } ) );
+
+    size_t stacks;
+
+    for ( stacks = stacksCount; stacks > 0; --stacks ) {
+        if ( monstersCount / stacks > 0 ) {
+            break;
+        }
+    }
+
+    assert( stacks > 0 );
+
+    const uint32_t quotient = monstersCount / static_cast<uint32_t>( stacks );
+    const uint32_t remainder = monstersCount % static_cast<uint32_t>( stacks );
+
+    assert( quotient > 0 );
+
+    const size_t shift = ( size() - stacks ) / 2;
+
+    for ( size_t i = 0; i < stacks; ++i ) {
+        at( i + shift )->Set( monster, i < remainder ? quotient + 1 : quotient );
+    }
+
+    assert( std::accumulate( begin(), end(), 0U, []( const uint32_t count, const Troop * troop ) { return troop->isValid() ? count + troop->GetCount() : count; } )
+            == monstersCount );
 }
 
 void Troops::ArrangeForWhirlpool()
@@ -880,10 +909,14 @@ void Army::setFromTile( const Maps::Tiles & tile )
         ArrangeForBattle( false );
         break;
 
-    case MP2::OBJ_SHIPWRECK:
-        at( 0 )->Set( Monster::GHOST, tile.GetQuantity2() );
-        ArrangeForBattle( false );
+    case MP2::OBJ_SHIPWRECK: {
+        // The number of stacks is deterministically random and is always the same for a particular tile
+        std::mt19937 seededGen( world.GetMapSeed() + static_cast<uint32_t>( tile.GetIndex() ) );
+
+        ArrangeForBattle( Monster::GHOST, tile.GetQuantity2(), Rand::GetWithGen( 3, 5, seededGen ) );
+
         break;
+    }
 
     case MP2::OBJ_DERELICTSHIP:
         at( 0 )->Set( Monster::SKELETON, 200 );
@@ -961,6 +994,17 @@ void Army::setFromTile( const Maps::Tiles & tile )
         at( 2 )->Set( Monster::EARTH_ELEMENT, 2 );
         at( 3 )->Set( Monster::EARTH_ELEMENT, 2 );
         break;
+
+    case MP2::OBJ_ABANDONEDMINE: {
+        const Troop & troop = world.GetCapturedObject( tile.GetIndex() ).GetTroop();
+
+        // The number of stacks is deterministically random and is always the same for a particular tile
+        std::mt19937 seededGen( world.GetMapSeed() + static_cast<uint32_t>( tile.GetIndex() ) );
+
+        ArrangeForBattle( troop.GetMonster(), troop.GetCount(), Rand::GetWithGen( 3, 5, seededGen ) );
+
+        break;
+    }
 
     default:
         if ( isCaptureObject ) {

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -910,10 +910,30 @@ void Army::setFromTile( const Maps::Tiles & tile )
         break;
 
     case MP2::OBJ_SHIPWRECK: {
+        uint32_t count = 0;
+
+        switch ( tile.QuantityVariant() ) {
+        case 1:
+            count = 10;
+            break;
+        case 2:
+            count = 15;
+            break;
+        case 3:
+            count = 25;
+            break;
+        case 4:
+            count = 50;
+            break;
+        default:
+            assert( 0 );
+            break;
+        }
+
         // The number of stacks is deterministically random and is always the same for a particular tile
         std::mt19937 seededGen( world.GetMapSeed() + static_cast<uint32_t>( tile.GetIndex() ) );
 
-        ArrangeForBattle( Monster::GHOST, tile.GetQuantity2(), Rand::GetWithGen( 3, 5, seededGen ) );
+        ArrangeForBattle( Monster::GHOST, count, Rand::GetWithGen( 3, 5, seededGen ) );
 
         break;
     }

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -98,7 +98,11 @@ public:
     Troop * GetSlowestTroop() const;
 
     void SortStrongest();
-    void ArrangeForBattle( bool = false );
+
+    // Performs the pre-battle arrangement for neutral troops
+    void ArrangeForBattle( bool upgrade = false );
+    // Performs the pre-battle arrangement of given monsters in a given number, dividing them into a given number of stacks if possible
+    void ArrangeForBattle( const Monster & monster, const uint32_t monstersCount, const uint32_t stacksCount );
     // Optimizes the arrangement of troops to pass through the whirlpool (moves one weakest unit
     // to a separate slot, if possible)
     void ArrangeForWhirlpool();


### PR DESCRIPTION
fix #5662
fix #5663

Related to #5651 (this PR does nothing with saving the number of ghosts after a battle, let's postpone it for a while because there is a topic for discussion).

Replaces the #5654.