### PR TITLE
Reveal castle info to AI if it's partially in fog

### DIFF
--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -86,7 +86,7 @@ namespace AI
         virtual void KingdomTurn( Kingdom & kingdom ) = 0;
         virtual void BattleTurn( Battle::Arena & arena, const Battle::Unit & unit, Battle::Actions & actions ) = 0;
 
-        virtual void revealFog( const Maps::Tiles & tile ) = 0;
+        virtual void revealFog( const Maps::Tiles & tile, int playerColor ) = 0;
 
         virtual void HeroesAdd( const Heroes & hero );
         virtual void HeroesRemove( const Heroes & hero );

--- a/src/fheroes2/ai/normal/ai_normal.cpp
+++ b/src/fheroes2/ai/normal/ai_normal.cpp
@@ -21,6 +21,7 @@
 #include "ai_normal.h"
 #include "maps_tiles.h"
 #include "pairs.h"
+#include "world.h"
 
 namespace AI
 {
@@ -35,11 +36,23 @@ namespace AI
         _pathfinder.reset();
     }
 
-    void Normal::revealFog( const Maps::Tiles & tile )
+    void Normal::revealFog( const Maps::Tiles & tile, int playerColor )
     {
         const MP2::MapObjectType object = tile.GetObject();
-        if ( object != MP2::OBJ_ZERO )
-            _mapObjects.emplace_back( tile.GetIndex(), object );
+        if ( object != MP2::OBJ_ZERO ) {
+            const int32_t tileIndex = tile.GetIndex();
+            _mapObjects.emplace_back( tileIndex, object );
+
+            if ( object == MP2::OBJN_CASTLE ) {
+                const Castle * castle = world.getCastle( tile.GetCenter() );
+                if ( castle ) {
+                    // AI should be aware of the castle if sees it partially
+                    int allied = Players::GetPlayerFriends( playerColor );
+                    allied = allied & ~Players::HumanColors(); // exclude human players since they can right click to view info
+                    world.GetTiles( castle->GetIndex() ).ClearFog( allied );
+                }
+            }
+        }
     }
 
     double Normal::getTargetArmyStrength( const Maps::Tiles & tile, const MP2::MapObjectType objectType )

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -186,7 +186,7 @@ namespace AI
         void KingdomTurn( Kingdom & kingdom ) override;
         void BattleTurn( Battle::Arena & arena, const Battle::Unit & currentUnit, Battle::Actions & actions ) override;
 
-        void revealFog( const Maps::Tiles & tile ) override;
+        void revealFog( const Maps::Tiles & tile, int playerColor ) override;
 
         void HeroesPreBattle( HeroBase & hero, bool isAttacking ) override;
         void HeroesActionComplete( Heroes & hero, int32_t tileIndex, const MP2::MapObjectType objectType ) override;

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -360,7 +360,7 @@ void Maps::ClearFog( const int32_t tileIndex, int scouteValue, const int playerC
             if ( revealRadiusSquared >= dx * dx + dy * dy ) {
                 Maps::Tiles & tile = world.GetTiles( x, y );
                 if ( isAIPlayer && tile.isFog( playerColor ) ) {
-                    AI::Get().revealFog( tile );
+                    AI::Get().revealFog( tile, playerColor );
                 }
 
                 tile.ClearFog( alliedColors );


### PR DESCRIPTION
Right now AI is at disadvantage when it can ignore a castle if it's entrance isn't in view. Added a check on new tile revealed to them.