### PR TITLE
Fix an assertion crash for Shipwreck guardians

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -913,6 +913,9 @@ void Army::setFromTile( const Maps::Tiles & tile )
         uint32_t count = 0;
 
         switch ( tile.QuantityVariant() ) {
+        case 0:
+            // Shipwreck guardians were defeated.
+            return;
         case 1:
             count = 10;
             break;


### PR DESCRIPTION
regression from #5668
close  #5681

The issue happens for AI calculating path through Shipwreck.