### PR TITLE
Update comments and logging for XMI conversion

### DIFF
--- a/src/engine/xmi2mid.cpp
+++ b/src/engine/xmi2mid.cpp
@@ -592,7 +592,8 @@ struct MidiEvents : public std::vector<MidiChunk>
                     // It is a drum.
                     const uint32_t drumSoundType = *( ptr + 1 );
                     if ( drumSoundType >= 35 && drumSoundType - 35 < drumSoundDescription.size() ) {
-                        DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "MID: channel " << channelId << ", drum sound : " << drumSoundDescription[drumSoundType - 35] )
+                        DEBUG_LOG( DBG_ENGINE, DBG_TRACE,
+                                   "MID: channel " << channelId << ", drum sound " << drumSoundType << ": " << drumSoundDescription[drumSoundType - 35] )
                     }
                     else {
                         ERROR_LOG( "MIDI track: Unknown drum sound type " << drumSoundType )
@@ -601,8 +602,8 @@ struct MidiEvents : public std::vector<MidiChunk>
                 else {
                     const uint32_t instrumentType = *( ptr + 1 );
                     if ( instrumentType < instrumentDescription.size() ) {
-                        DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "MID: channel " << channelId << ", instrument ID " << instrumentType << ": "
-                                                                          << instrumentDescription[instrumentType] )
+                        DEBUG_LOG( DBG_ENGINE, DBG_TRACE,
+                                   "MID: channel " << channelId << ", instrument ID " << instrumentType << ": " << instrumentDescription[instrumentType] )
                     }
                     else {
                         ERROR_LOG( "MIDI track: Unknown instrument type " << instrumentType )

--- a/src/engine/xmi2mid.cpp
+++ b/src/engine/xmi2mid.cpp
@@ -578,19 +578,21 @@ struct MidiEvents : public std::vector<MidiChunk>
             }
 
             // Program Change: in other words which instrument is going to be played.
-            case 0x0C:
+            case 0x0C: {
                 if ( !checkDataPresence( ptr, end, 2 ) ) {
                     break;
                 }
 
+                const int32_t channelId = *ptr - 0xC0;
+
                 emplace_back( delta, *ptr, *( ptr + 1 ) );
 
                 // Drum sounds are only played in channel 9.
-                if ( *ptr == 0xC9 ) {
+                if ( channelId == 9 ) {
                     // It is a drum.
                     const uint32_t drumSoundType = *( ptr + 1 );
                     if ( drumSoundType >= 35 && drumSoundType - 35 < drumSoundDescription.size() ) {
-                        DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "MID: drum sound used in the track: " << drumSoundDescription[drumSoundType - 35] )
+                        DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "MID: channel " << channelId << ", drum sound : " << drumSoundDescription[drumSoundType - 35] )
                     }
                     else {
                         ERROR_LOG( "MIDI track: Unknown drum sound type " << drumSoundType )
@@ -599,7 +601,8 @@ struct MidiEvents : public std::vector<MidiChunk>
                 else {
                     const uint32_t instrumentType = *( ptr + 1 );
                     if ( instrumentType < instrumentDescription.size() ) {
-                        DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "MID: instrument ID " << instrumentType << " used in the track: " << instrumentDescription[instrumentType] )
+                        DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "MID: channel " << channelId << ", instrument ID " << instrumentType << ": "
+                                                                          << instrumentDescription[instrumentType] )
                     }
                     else {
                         ERROR_LOG( "MIDI track: Unknown instrument type " << instrumentType )
@@ -608,6 +611,7 @@ struct MidiEvents : public std::vector<MidiChunk>
 
                 ptr += 2;
                 break;
+            }
 
             // Channel Pressure (After-touch).
             case 0x0D:

--- a/src/engine/xmi2mid.cpp
+++ b/src/engine/xmi2mid.cpp
@@ -587,7 +587,7 @@ struct MidiEvents : public std::vector<MidiChunk>
 
                 emplace_back( delta, *ptr, *( ptr + 1 ) );
 
-                // Drum sounds are only played in channel 9.
+                // Drum sounds are only played in channel 9 if channel ID starts from 0, or 10 if channel ID starts from 1. In our case it starts from 0.
                 if ( channelId == 9 ) {
                     // It is a drum.
                     const uint32_t drumSoundType = *( ptr + 1 );

--- a/src/engine/xmi2mid.cpp
+++ b/src/engine/xmi2mid.cpp
@@ -585,7 +585,8 @@ struct MidiEvents : public std::vector<MidiChunk>
 
                 emplace_back( delta, *ptr, *( ptr + 1 ) );
 
-                if ( *ptr == 0xCA ) {
+                // Drum sounds are only played in channel 9.
+                if ( *ptr == 0xC9 ) {
                     // It is a drum.
                     const uint32_t drumSoundType = *( ptr + 1 );
                     if ( drumSoundType >= 35 && drumSoundType - 35 < drumSoundDescription.size() ) {

--- a/src/engine/xmi2mid.cpp
+++ b/src/engine/xmi2mid.cpp
@@ -621,8 +621,8 @@ struct MidiEvents : public std::vector<MidiChunk>
             // Unknown command.
             default:
                 emplace_back( 0, static_cast<uint8_t>( 0xFF ), static_cast<uint8_t>( 0x2F ), static_cast<uint8_t>( 0x00 ) );
-                ERROR_LOG( "MIDI track: Unknown command: " << GetHexString( static_cast<int>( *ptr ), 2 ) << ", byte: "
-                           << static_cast<int>( &t.evnt[0] + t.evnt.size() - ptr ) )
+                ERROR_LOG( "MIDI track: Unknown command: " << GetHexString( static_cast<int>( *ptr ), 2 )
+                                                           << ", byte: " << static_cast<int>( &t.evnt[0] + t.evnt.size() - ptr ) )
                 break;
             }
         }

--- a/src/engine/xmi2mid.cpp
+++ b/src/engine/xmi2mid.cpp
@@ -543,11 +543,11 @@ struct MidiEvents : public std::vector<MidiChunk>
             }
 
             switch ( *ptr >> 4 ) {
-            // key pressure
+            // Polyphonic Key Pressure (Aftertouch).
             case 0x0A:
-            // control change
+            // Control Change.
             case 0x0B:
-            // pitch bend
+            // Pitch Wheel Change.
             case 0x0E:
                 if ( !checkDataPresence( ptr, end, 3 ) ) {
                     break;
@@ -558,7 +558,7 @@ struct MidiEvents : public std::vector<MidiChunk>
                 break;
 
             // XMI events do not have note off events.
-            // note on
+            // Note On event.
             case 0x09: {
                 if ( !checkDataPresence( ptr, end, 4 ) ) {
                     break;
@@ -598,7 +598,7 @@ struct MidiEvents : public std::vector<MidiChunk>
                 else {
                     const uint32_t instrumentType = *( ptr + 1 );
                     if ( instrumentType < instrumentDescription.size() ) {
-                        DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "MID: instrument used in the track: " << instrumentDescription[*( ptr + 1 )] )
+                        DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "MID: instrument ID " << instrumentType << " used in the track: " << instrumentDescription[instrumentType] )
                     }
                     else {
                         ERROR_LOG( "MIDI track: Unknown instrument type " << instrumentType )
@@ -608,7 +608,7 @@ struct MidiEvents : public std::vector<MidiChunk>
                 ptr += 2;
                 break;
 
-            // channel aftertouch
+            // Channel Pressure (After-touch).
             case 0x0D:
                 if ( !checkDataPresence( ptr, end, 2 ) ) {
                     break;
@@ -621,7 +621,8 @@ struct MidiEvents : public std::vector<MidiChunk>
             // Unknown command.
             default:
                 emplace_back( 0, static_cast<uint8_t>( 0xFF ), static_cast<uint8_t>( 0x2F ), static_cast<uint8_t>( 0x00 ) );
-                ERROR_LOG( "unknown st: " << GetHexString( static_cast<int>( *ptr ), 2 ) << ", ln: " << static_cast<int>( &t.evnt[0] + t.evnt.size() - ptr ) )
+                ERROR_LOG( "MIDI track: Unknown command: " << GetHexString( static_cast<int>( *ptr ), 2 ) << ", byte: "
+                           << static_cast<int>( &t.evnt[0] + t.evnt.size() - ptr ) )
                 break;
             }
         }


### PR DESCRIPTION
After fixing logs we can identify which instruments are missed. For example:
```bash
15:18:03: [DBG_ENGINE]  `anonymous-namespace'::LoadMID:  MIDI0008.XMI
15:18:03: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 0, instrument ID 0: Acoustic Grand Piano
15:18:03: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 1, instrument ID 72: Slap Bass 1
15:18:03: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 2, instrument ID 71: FX 4 (atmosphere)
15:18:03: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 3, instrument ID 49: Pad 1 (new age Fantasia)
15:18:03: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 4, instrument ID 45: Lead 7 (fifths)
15:18:03: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 5, instrument ID 44: Harmonica
15:18:03: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 8, instrument ID 60: Distortion Guitar
15:18:03: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 9, drum sound 53: G#2 Pedal Hi-Hat
15:18:03: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 10, instrument ID 46: Tango Accordion (Band neon)
15:18:03: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 11, instrument ID 70: Fretless Bass
15:18:03: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 12, instrument ID 68: Electric Bass (picked)
15:18:03: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 13, instrument ID 47: Lead 8 (bass + lead)
15:18:03: [DBG_ENGINE]  `anonymous-namespace'::PlayMusicInternally:  Play MIDI music track MIDI0008.XMI
fluidsynth: warning: Instrument not found on channel 9 [bank=128 prog=53], substituted [bank=128 prog=0]
```
or:
```bash
15:18:25: [DBG_ENGINE]  `anonymous-namespace'::LoadMID:  MIDI0009.XMI
15:18:25: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 0, instrument ID 48: Acoustic Guitar (nylon)
15:18:25: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 1, instrument ID 47: Lead 8 (bass + lead)
15:18:25: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 2, instrument ID 69: FX 3 (crystal)
15:18:25: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 3, instrument ID 73: FX 5 (brightness)
15:18:25: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 5, instrument ID 19: Flute
15:18:25: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 6, instrument ID 0: Acoustic Grand Piano
15:18:25: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 7, instrument ID 45: Lead 7 (fifths)
15:18:25: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 8, instrument ID 44: Harmonica
15:18:25: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 10, instrument ID 46: Tango Accordion (Band neon)
15:18:25: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 11, instrument ID 60: Distortion Guitar
15:18:25: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 12, instrument ID 49: Pad 1 (new age Fantasia)
15:18:25: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 4, instrument ID 52: Electric Guitar (jazz)
15:18:25: [DBG_ENGINE]  MidiEvents::MidiEvents:  MID: channel 9, drum sound 52: G4 High Agogo
15:18:25: [DBG_ENGINE]  `anonymous-namespace'::PlayMusicInternally:  Play MIDI music track MIDI0009.XMI
fluidsynth: warning: Instrument not found on channel 9 [bank=128 prog=52], substituted [bank=128 prog=0]
```
As you can see the error is triggered only when channel ID is 9 which corresponds to Drum Sounds,

According to [this page](http://www.schristiancollins.com/generaluser.php) the soundfont contains only 11 Drum Sounds while MIDI standard expects 47. This is why the error appears and substitution to drum sound 0 is done.

To confirm this play Wizard's castle (MIDI type of music) to hear clear sounds of drums while they are replaced by very weak drum (?) sounds from **fheroes2.sf3** soundfont.

Steps we need to do:
- verify that this soundfont indeed contains 11 drum sounds
- if they are present their IDs should start from 35