### PR TITLE
Fix build with earlier Windows SDKs, copy soundfonts and *.mo files (if they exist) to the $(OutDir)

### DIFF
--- a/VisualStudio/SDL1.props
+++ b/VisualStudio/SDL1.props
@@ -12,8 +12,8 @@
       <AdditionalDependencies>SDL.lib;SDL_mixer.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /Y "$(MSBuildThisFileDirectory)packages\sdl1\lib\$(PlatformTarget)\*.dll" "$(OutDir)"
-xcopy /Y "$(MSBuildThisFileDirectory)packages\sdl1\lib\$(PlatformTarget)\*.pdb" "$(OutDir)"
+      <Command>xcopy /Y /Q "$(MSBuildThisFileDirectory)packages\sdl1\lib\$(PlatformTarget)\*.dll" "$(OutDir)"
+xcopy /Y /Q "$(MSBuildThisFileDirectory)packages\sdl1\lib\$(PlatformTarget)\*.pdb" "$(OutDir)"
 %(Command)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/VisualStudio/SDL2.props
+++ b/VisualStudio/SDL2.props
@@ -13,8 +13,8 @@
       <AdditionalDependencies>SDL2.lib;SDL2_mixer.lib;SDL2_image.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /Y "$(MSBuildThisFileDirectory)packages\sdl2\lib\$(PlatformTarget)\*.dll" "$(OutDir)"
-xcopy /Y "$(MSBuildThisFileDirectory)packages\sdl2\lib\$(PlatformTarget)\*.pdb" "$(OutDir)"
+      <Command>xcopy /Y /Q "$(MSBuildThisFileDirectory)packages\sdl2\lib\$(PlatformTarget)\*.dll" "$(OutDir)"
+xcopy /Y /Q "$(MSBuildThisFileDirectory)packages\sdl2\lib\$(PlatformTarget)\*.pdb" "$(OutDir)"
 %(Command)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/VisualStudio/common.props
+++ b/VisualStudio/common.props
@@ -24,22 +24,19 @@
     <PostBuildEvent>
       <Command>if exist "$(MSBuildThisFileDirectory)..\data" (
     if not exist "$(OutDir)data" (
-        mkdir "$(OutDir)data"
-        xcopy /Y /s /Q "$(MSBuildThisFileDirectory)..\data" "$(OutDir)data"
+        xcopy /Y /S /Q "$(MSBuildThisFileDirectory)..\data" "$(OutDir)data\"
     )
 )
 
 if exist "$(MSBuildThisFileDirectory)..\maps" (
     if not exist "$(OutDir)maps" (
-        mkdir "$(OutDir)maps"
-        xcopy /Y /s /Q "$(MSBuildThisFileDirectory)..\maps" "$(OutDir)maps"
+        xcopy /Y /S /Q "$(MSBuildThisFileDirectory)..\maps" "$(OutDir)maps\"
     )
 )
 
-if not exist "$(OutDir)files\data" (
-    mkdir "$(OutDir)files\data"
-)
-xcopy /Y /s /Q "$(MSBuildThisFileDirectory)..\files\data" "$(OutDir)files\data"
+xcopy /Y /S /Q "$(MSBuildThisFileDirectory)..\files\data" "$(OutDir)files\data\"
+xcopy /Y /Q "$(MSBuildThisFileDirectory)..\files\lang\*.mo" "$(OutDir)files\lang\"
+xcopy /Y /S /Q "$(MSBuildThisFileDirectory)..\files\soundfonts" "$(OutDir)files\soundfonts\"
 
 %(Command)</Command>
     </PostBuildEvent>

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -497,22 +497,26 @@ void Audio::Init()
     }
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
-    const int initializationFlags = MIX_INIT_FLAC | MIX_INIT_MP3 | MIX_INIT_OGG;
+    const int initializationFlags = MIX_INIT_FLAC | MIX_INIT_MP3 | MIX_INIT_OGG | MIX_INIT_MID;
     const int initializedFlags = Mix_Init( initializationFlags );
     if ( ( initializedFlags & initializationFlags ) != initializationFlags ) {
         DEBUG_LOG( DBG_ENGINE, DBG_WARN,
                    "Expected music initialization flags as " << initializationFlags << " but received " << ( initializedFlags & initializationFlags ) )
 
         if ( ( initializedFlags & MIX_INIT_FLAC ) == 0 ) {
-            DEBUG_LOG( DBG_ENGINE, DBG_WARN, "Flac module failed to be initialized" )
+            DEBUG_LOG( DBG_ENGINE, DBG_WARN, "FLAC module failed to be initialized" )
         }
 
         if ( ( initializedFlags & MIX_INIT_MP3 ) == 0 ) {
-            DEBUG_LOG( DBG_ENGINE, DBG_WARN, "Mp3 module failed to be initialized" )
+            DEBUG_LOG( DBG_ENGINE, DBG_WARN, "MP3 module failed to be initialized" )
         }
 
         if ( ( initializedFlags & MIX_INIT_OGG ) == 0 ) {
-            DEBUG_LOG( DBG_ENGINE, DBG_WARN, "Ogg module failed to be initialized" )
+            DEBUG_LOG( DBG_ENGINE, DBG_WARN, "OGG module failed to be initialized" )
+        }
+
+        if ( ( initializedFlags & MIX_INIT_MID ) == 0 ) {
+            DEBUG_LOG( DBG_ENGINE, DBG_WARN, "MID module failed to be initialized" )
         }
     }
 #endif

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -497,7 +497,7 @@ void Audio::Init()
     }
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
-    const int initializationFlags = MIX_INIT_FLAC | MIX_INIT_MOD | MIX_INIT_MP3 | MIX_INIT_OGG;
+    const int initializationFlags = MIX_INIT_FLAC | MIX_INIT_MP3 | MIX_INIT_OGG;
     const int initializedFlags = Mix_Init( initializationFlags );
     if ( ( initializedFlags & initializationFlags ) != initializationFlags ) {
         DEBUG_LOG( DBG_ENGINE, DBG_WARN,
@@ -505,10 +505,6 @@ void Audio::Init()
 
         if ( ( initializedFlags & MIX_INIT_FLAC ) == 0 ) {
             DEBUG_LOG( DBG_ENGINE, DBG_WARN, "Flac module failed to be initialized" )
-        }
-
-        if ( ( initializedFlags & MIX_INIT_MOD ) == 0 ) {
-            DEBUG_LOG( DBG_ENGINE, DBG_WARN, "Mod module failed to be initialized" )
         }
 
         if ( ( initializedFlags & MIX_INIT_MP3 ) == 0 ) {

--- a/src/engine/dir.cpp
+++ b/src/engine/dir.cpp
@@ -21,6 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 #if defined( _MSC_VER ) || defined( __MINGW32__ )
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #elif defined( TARGET_PS_VITA )
 #include <psp2/io/dirent.h>

--- a/src/engine/logging.cpp
+++ b/src/engine/logging.cpp
@@ -21,6 +21,7 @@
 #include <ctime>
 
 #if defined( __MINGW32__ ) || defined( _MSC_VER )
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -39,6 +39,7 @@
 #include <SDL.h>
 
 #if defined( __MINGW32__ ) || defined( _MSC_VER )
+#define WIN32_LEAN_AND_MEAN
 // clang-format off
 // shellapi.h must be included after windows.h
 #include <windows.h>


### PR DESCRIPTION
With earlier Windows 8.1 SDK, `combaseapi.h` failed the build because it missed the `typename` in one place, so I used `WIN32_LEAN_AND_MEAN` to exclude COM from the `windows.h`.

Also I removed the MOD playback support. Are we really needed it for something? AFAIK there was no MOD music in any distributions of the original game.

Also I added an explicit initialization of `MID` module (MIDI) using the `MIX_INIT_MID`. Previously, it seemed to work without this, but this is necessary according to the documentation.