### PR TITLE
Fix issues with SDL_Mixer 1.x, as well as MIDI instrument and drum descriptions

### DIFF
--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -1069,8 +1069,8 @@ void Music::Stop()
     // callback will not be called while we are modifying the current track information.
     Mix_HaltMusic();
 #if !SDL_VERSION_ATLEAST( 2, 0, 0 )
-    // Ancient SDL_Mixer 1.x doesn't call the Mix_HookMusicFinished()'s callback on Mix_HaltMusic(),
-    // so we need to call it manually
+    // SDL_Mixer 1.x doesn't call the Mix_HookMusicFinished()'s callback on Mix_HaltMusic(), so
+    // we need to call it manually
     musicFinished();
 #endif
 

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -199,15 +199,16 @@ namespace
 
         const int channel = Mix_PlayChannel( channelId, sample, loop ? -1 : 0 );
         if ( channel < 0 ) {
-            ERROR_LOG( "Failed to play an audio chunk for channel " << channel << ". The error: " << Mix_GetError() )
+            ERROR_LOG( "Failed to play an audio chunk for channel " << channelId << ". The error: " << Mix_GetError() )
 
             Mix_FreeChunk( sample );
+
+            return channel;
         }
-        else {
-            // There can be a maximum of two items in the sample queue for a channel:
-            // the previous sample (if it hasn't been freed yet) and the current one
-            soundSampleManager.channelStarted( channel, sample );
-        }
+
+        // There can be a maximum of two items in the sample queue for a channel:
+        // the previous sample (if it hasn't been freed yet) and the current one
+        soundSampleManager.channelStarted( channel, sample );
 
         return channel;
     }
@@ -591,15 +592,16 @@ namespace
             // Since the music playback failed, the Mix_HookMusicFinished()'s callback cannot be called
             // here, so we can safely reset the current track information
             musicTrackManager.resetCurrentTrack();
-        }
-        else {
-            // For better accuracy reset the timer right after the actual playback starts
-            musicTrackManager.resetTimer();
 
-            // There can be no more than one element in the music queue - the current track, the previous
-            // one should already be freed
-            musicTrackManager.musicStarted( mus );
+            return;
         }
+
+        // For better accuracy reset the timer right after the actual playback starts
+        musicTrackManager.resetTimer();
+
+        // There can be no more than one element in the music queue - the current track, the previous
+        // one should already be freed
+        musicTrackManager.musicStarted( mus );
     }
 
     int normalizeToSDLVolume( const int volumePercentage )

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -974,9 +974,7 @@ void Music::Play( const uint64_t musicUID, const std::vector<uint8_t> & v, const
         return;
     }
 
-    if ( !musicTrackManager.isTrackInMusicDB( musicUID ) ) {
-        musicTrackManager.addTrackToMusicDB( musicUID, std::make_shared<MusicInfo>( v ) );
-    }
+    musicTrackManager.addTrackToMusicDB( musicUID, std::make_shared<MusicInfo>( v ) );
 
     Stop();
 
@@ -986,7 +984,7 @@ void Music::Play( const uint64_t musicUID, const std::vector<uint8_t> & v, const
 void Music::Play( const uint64_t musicUID, const std::string & file, const PlaybackMode playbackMode )
 {
     if ( file.empty() ) {
-        // Nothing to play. It is an empty file.
+        // Nothing to play, the file name is empty.
         return;
     }
 
@@ -996,9 +994,7 @@ void Music::Play( const uint64_t musicUID, const std::string & file, const Playb
         return;
     }
 
-    if ( !musicTrackManager.isTrackInMusicDB( musicUID ) ) {
-        musicTrackManager.addTrackToMusicDB( musicUID, std::make_shared<MusicInfo>( file ) );
-    }
+    musicTrackManager.addTrackToMusicDB( musicUID, std::make_shared<MusicInfo>( file ) );
 
     Stop();
 

--- a/src/engine/audio.h
+++ b/src/engine/audio.h
@@ -82,14 +82,18 @@ namespace Music
         REWIND_AND_PLAY_INFINITE
     };
 
-    // Music UID is used to cache existing tracks. It is caller's responsibility to generate them.
-    // This function return true in case of music track for corresponding Music UID is cached.
+    // Music UID is used to store metadata of music tracks in the music database. It is caller's
+    // responsibility to generate them. This function searches for a music track with the specified
+    // UID in the database and starts playback if it is found. Returns true if the music track was
+    // found in the database, otherwise returns false.
     bool Play( const uint64_t musicUID, const PlaybackMode playbackMode );
 
-    // Load a music track from memory and play it.
+    // Adds a music track from the memory buffer to the music database and starts playback. A music
+    // track with the specified UID should not already be present in the database.
     void Play( const uint64_t musicUID, const std::vector<uint8_t> & v, const PlaybackMode playbackMode );
 
-    // Load a music track from a file system location and play it.
+    // Adds the music track available in the specified file to the music database and starts playback.
+    // A music track with the specified UID should not already be present in the database.
     void Play( const uint64_t musicUID, const std::string & file, const PlaybackMode playbackMode );
 
     // Returns the previous volume percentage value.

--- a/src/engine/xmi2mid.cpp
+++ b/src/engine/xmi2mid.cpp
@@ -42,134 +42,76 @@
 
 namespace
 {
-    const std::array<const char *, 128> instrumentDescription = { "Acoustic Grand Piano",
-                                                                  "Soprano Sax",
-                                                                  "Bright Acoustic Piano",
-                                                                  "Alto Sax",
-                                                                  "Electric Grand Piano",
-                                                                  "Tenor Sax",
-                                                                  "Honky-tonk Piano",
-                                                                  "Baritone Sax",
-                                                                  "Electric Piano 1 (Rhodes Piano)",
-                                                                  "Oboe",
-                                                                  "Electric Piano 2 (Chorused Piano)",
-                                                                  "English Horn",
-                                                                  "Harpsichord",
-                                                                  "Bassoon",
-                                                                  "Clavinet",
-                                                                  "Clarinet",
-                                                                  "Celesta",
-                                                                  "Piccolo",
-                                                                  "Glockenspiel",
-                                                                  "Flute",
-                                                                  "Music Box",
-                                                                  "Recorder",
-                                                                  "Vibraphone",
-                                                                  "Pan Flute",
-                                                                  "Marimba",
-                                                                  "Blown Bottle",
-                                                                  "Xylophone",
-                                                                  "Shakuhachi",
-                                                                  "Tubular Bells",
-                                                                  "Whistle",
-                                                                  "Dulcimer (Santur)",
-                                                                  "Ocarina",
-                                                                  "Drawbar Organ (Hammond)",
-                                                                  "Lead 1 (square wave)",
-                                                                  "Percussive Organ",
-                                                                  "Lead 2 (sawtooth wave)",
-                                                                  "Rock Organ",
-                                                                  "Lead 3 (calliope)",
-                                                                  "Church Organ",
-                                                                  "Lead 4 (chiffer)",
-                                                                  "Reed Organ",
-                                                                  "Lead 5 (charang)",
-                                                                  "Accordion (French)",
-                                                                  "Lead 6 (voice solo)",
-                                                                  "Harmonica",
-                                                                  "Lead 7 (fifths)",
-                                                                  "Tango Accordion (Band neon)",
-                                                                  "Lead 8 (bass + lead)",
-                                                                  "Acoustic Guitar (nylon)",
-                                                                  "Pad 1 (new age Fantasia)",
-                                                                  "Acoustic Guitar (steel)",
-                                                                  "Pad 2 (warm)",
-                                                                  "Electric Guitar (jazz)",
-                                                                  "Pad 3 (polysynth)",
-                                                                  "Electric Guitar (clean)",
-                                                                  "Pad 4 (choir space voice)",
-                                                                  "Electric Guitar (muted)",
-                                                                  "Pad 5 (bowed glass)",
-                                                                  "Overdriven Guitar",
-                                                                  "Pad 6 (metallic pro)",
-                                                                  "Distortion Guitar",
-                                                                  "Pad 7 (halo)",
-                                                                  "Guitar harmonics",
-                                                                  "Pad 8 (sweep)",
-                                                                  "Acoustic Bass",
-                                                                  "FX 1 (rain)",
-                                                                  "Electric Bass (fingered)",
-                                                                  "FX 2 (soundtrack)",
-                                                                  "Electric Bass (picked)",
-                                                                  "FX 3 (crystal)",
-                                                                  "Fretless Bass",
-                                                                  "FX 4 (atmosphere)",
-                                                                  "Slap Bass 1",
-                                                                  "FX 5 (brightness)",
-                                                                  "Slap Bass 2",
-                                                                  "FX 6 (goblins)",
-                                                                  "Synth Bass 1",
-                                                                  "FX 7 (echoes, drops)",
-                                                                  "Synth Bass 2",
-                                                                  "FX 8 (sci-fi, star theme)",
-                                                                  "Violin",
-                                                                  "Sitar",
-                                                                  "Viola",
-                                                                  "Banjo",
-                                                                  "Cello",
-                                                                  "Shamisen",
-                                                                  "Contrabass",
-                                                                  "Koto",
-                                                                  "Tremolo Strings",
-                                                                  "Kalimba",
-                                                                  "Pizzicato Strings",
-                                                                  "Bag pipe",
-                                                                  "Orchestral Harp",
-                                                                  "Fiddle",
-                                                                  "Timpani",
-                                                                  "Shanai",
-                                                                  "String Ensemble 1 (strings)",
-                                                                  "Tinkle Bell",
-                                                                  "String Ensemble 2 (slow strings)",
-                                                                  "Agogo",
-                                                                  "SynthStrings 1",
-                                                                  "Steel Drums",
-                                                                  "SynthStrings 2",
-                                                                  "Woodblock",
-                                                                  "Choir Aahs",
-                                                                  "Taiko Drum",
-                                                                  "Voice Oohs",
-                                                                  "Melodic Tom",
-                                                                  "Synth Voice",
-                                                                  "Synth Drum",
-                                                                  "Orchestra Hit",
-                                                                  "Reverse Cymbal",
-                                                                  "Trumpet",
-                                                                  "Guitar Fret Noise",
-                                                                  "Trombone",
-                                                                  "Breath Noise",
-                                                                  "Tuba",
-                                                                  "Seashore",
-                                                                  "Muted Trumpet",
-                                                                  "Bird Tweet",
-                                                                  "French Horn",
-                                                                  "Telephone Ring",
-                                                                  "Brass Section",
-                                                                  "Helicopter",
-                                                                  "SynthBrass 1",
-                                                                  "Applause",
-                                                                  "SynthBrass 2",
-                                                                  "Gunshot" };
+    const std::array<const char *, 128> instrumentDescription = {
+        //
+        // Piano ( 0 - 7 )
+        //
+        "Acoustic Grand Piano", "Bright Acoustic Piano", "Electric Grand Piano", "Honky-tonk Piano", "Electric Piano 1 (Rhodes Piano)",
+        "Electric Piano 2 (Chorused Piano)", "Harpsichord", "Clavinet",
+        //
+        // Chromatic Percussion ( 8 - 15 )
+        //
+        "Celesta", "Glockenspiel", "Music Box", "Vibraphone", "Marimba", "Xylophone", "Tubular Bells", "Dulcimer (Santur)",
+        //
+        // Organ ( 16 - 23 )
+        //
+        "Drawbar Organ (Hammond)", "Percussive Organ", "Rock Organ", "Church Organ", "Reed Organ", "Accordion (French)", "Harmonica", "Tango Accordion (Band neon)",
+        //
+        // Guitar ( 24 - 31 )
+        //
+        "Acoustic Guitar (nylon)", "Acoustic Guitar (steel)", "Electric Guitar (jazz)", "Electric Guitar (clean)", "Electric Guitar (muted)", "Overdriven Guitar",
+        "Distortion Guitar", "Guitar harmonics",
+        //
+        // Bass ( 32 - 39 )
+        //
+        "Acoustic Bass", "Electric Bass (fingered)", "Electric Bass (picked)", "Fretless Bass", "Slap Bass 1", "Slap Bass 2", "Synth Bass 1", "Synth Bass 2",
+        //
+        // Strings ( 40 - 47 )
+        //
+        "Violin", "Viola", "Cello", "Contrabass", "Tremolo Strings", "Pizzicato Strings", "Orchestral Harp", "Timpani",
+        //
+        // Strings ( 48 - 55 )
+        //
+        "String Ensemble 1 (strings)", "String Ensemble 2 (slow strings)", "SynthStrings 1", "SynthStrings 2", "Choir Aahs", "Voice Oohs", "Synth Voice", "Orchestra Hit",
+        //
+        // Brass ( 56 - 63 )
+        //
+        "Trumpet", "Trombone", "Tuba", "Muted Trumpet", "French Horn", "Brass Section", "SynthBrass 1", "SynthBrass 2",
+        //
+        // Reed ( 64 - 71 )
+        //
+        "Soprano Sax", "Alto Sax", "Tenor Sax", "Baritone Sax", "Oboe", "English Horn", "Bassoon", "Clarinet",
+        //
+        // Pipe ( 72 - 79 )
+        //
+        "Piccolo", "Flute", "Recorder", "Pan Flute", "Blown Bottle", "Shakuhachi", "Whistle", "Ocarina",
+        //
+        // Synth Lead ( 80 - 87 )
+        //
+        "Lead 1 (square wave)", "Lead 2 (sawtooth wave)", "Lead 3 (calliope)", "Lead 4 (chiffer)", "Lead 5 (charang)", "Lead 6 (voice solo)", "Lead 7 (fifths)",
+        "Lead 8 (bass + lead)",
+        //
+        // Synth Pad ( 88 - 95 )
+        //
+        "Pad 1 (new age Fantasia)", "Pad 2 (warm)", "Pad 3 (polysynth)", "Pad 4 (choir space voice)", "Pad 5 (bowed glass)", "Pad 6 (metallic pro)", "Pad 7 (halo)",
+        "Pad 8 (sweep)",
+        //
+        // Synth Effects ( 96 - 103 )
+        //
+        "FX 1 (rain)", "FX 2 (soundtrack)", "FX 3 (crystal)", "FX 4 (atmosphere)", "FX 5 (brightness)", "FX 6 (goblins)", "FX 7 (echoes, drops)",
+        "FX 8 (sci-fi, star theme)",
+        //
+        // Ethnic ( 104 - 111 )
+        //
+        "Sitar", "Banjo", "Shamisen", "Koto", "Kalimba", "Bag pipe", "Fiddle", "Shanai",
+        //
+        // Percussive ( 112 - 119 )
+        //
+        "Tinkle Bell", "Agogo", "Steel Drums", "Woodblock", "Taiko Drum", "Melodic Tom", "Synth Drum", "Reverse Cymbal",
+        //
+        // Sound effects ( 120 - 127 )
+        //
+        "Guitar Fret Noise", "Breath Noise", "Seashore", "Bird Tweet", "Telephone Ring", "Helicopter", "Applause", "Gunshot" };
 
     const std::array<const char *, 47> drumSoundDescription
         = { "B1 Acoustic Bass Drum", "B3 Ride Cymbal 2",  "C2 Bass Drum 1",    "C4 Hi Bongo",       "C#2 Side Stick",     "C#4 Low Bongo",

--- a/src/engine/xmi2mid.cpp
+++ b/src/engine/xmi2mid.cpp
@@ -113,15 +113,15 @@ namespace
         //
         "Guitar Fret Noise", "Breath Noise", "Seashore", "Bird Tweet", "Telephone Ring", "Helicopter", "Applause", "Gunshot" };
 
+    // MIDI keys 35 - 81
     const std::array<const char *, 47> drumSoundDescription
-        = { "B1 Acoustic Bass Drum", "B3 Ride Cymbal 2",  "C2 Bass Drum 1",    "C4 Hi Bongo",       "C#2 Side Stick",     "C#4 Low Bongo",
-            "D2 Acoustic Snare",     "D4 Mute Hi Conga",  "D#2 Hand Clap",     "D#4 Open Hi Conga", "E2 Electric Snare",  "E4 Low Conga",
-            "F2 Low Floor Tom",      "F4 High Timbale",   "F#2 Closed Hi Hat", "F#4 Low Timbale",   "G2 High Floor Tom",  "G4 High Agogo",
-            "G#2 Pedal Hi-Hat",      "G#4 Low Agogo",     "A2 Low Tom",        "A4 Cabasa",         "A#2 Open Hi-Hat",    "A#4 Maracas",
-            "B2 Low-Mid Tom",        "B4 Short Whistle",  "C3 Hi Mid Tom",     "C5 Long Whistle",   "C#3 Crash Cymbal 1", "C#5 Short Guiro",
-            "D3 High Tom",           "D5 Long Guiro",     "D#3 Ride Cymbal 1", "D#5 Claves",        "E3 Chinese Cymbal",  "E5 Hi Wood Block",
-            "F3 Ride Bell",          "F5 Low Wood Block", "F#3 Tambourine",    "F#5 Mute Cuica",    "G3 Splash Cymbal",   "G5 Open Cuica",
-            "G#3 Cowbell",           "G#5 Mute Triangle", "A3 Crash Cymbal 2", "A5 Open Triangle",  "A#3 Vibraslap" };
+        = { "B1 Acoustic Bass Drum", "C2 Bass Drum 1",    "C#2 Side Stick",    "D2 Acoustic Snare", "D#2 Hand Clap",   "E2 Electric Snare", "F2 Low Floor Tom",
+            "F#2 Closed Hi Hat",     "G2 High Floor Tom", "G#2 Pedal Hi-Hat",  "A2 Low Tom",        "A#2 Open Hi-Hat", "B2 Low-Mid Tom",    "C3 Hi Mid Tom",
+            "C#3 Crash Cymbal 1",    "D3 High Tom",       "D#3 Ride Cymbal 1", "E3 Chinese Cymbal", "F3 Ride Bell",    "F#3 Tambourine",    "G3 Splash Cymbal",
+            "G#3 Cowbell",           "A3 Crash Cymbal 2", "A#3 Vibraslap",     "B3 Ride Cymbal 2",  "C4 Hi Bongo",     "C#4 Low Bongo",     "D4 Mute Hi Conga",
+            "D#4 Open Hi Conga",     "E4 Low Conga",      "F4 High Timbale",   "F#4 Low Timbale",   "G4 High Agogo",   "G#4 Low Agogo",     "A4 Cabasa",
+            "A#4 Maracas",           "B4 Short Whistle",  "C5 Long Whistle",   "C#5 Short Guiro",   "D5 Long Guiro",   "D#5 Claves",        "E5 Hi Wood Block",
+            "F5 Low Wood Block",     "F#5 Mute Cuica",    "G5 Open Cuica",     "G#5 Mute Triangle", "A5 Open Triangle" };
 
     enum
     {

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -482,9 +482,9 @@ namespace
             return;
         }
 
-        // Check if the music track is cached.
+        // Check if the music track is already available in the music database.
         if ( Music::Play( musicUID, playbackMode ) ) {
-            DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "Play cached music track " << trackId )
+            DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "Play music track " << trackId )
 
             currentMusicTrackId = trackId;
 
@@ -526,8 +526,9 @@ namespace
             }
         }
 
-        // Check if music needs to be pulled from HEROES2X
         int xmi = XMI::UNKNOWN;
+
+        // Check if music needs to be pulled from HEROES2X
         if ( musicType == MUSIC_MIDI_EXPANSION ) {
             xmi = XMI::FromMUS( trackId, g_midiHeroes2xAGG.isGood() );
         }


### PR DESCRIPTION
Fix the regressions after #5694

* It turns out that with ancient SDL_Mixer 1.x (used for SDL1 builds) `Mix_HookMusicFinished()`'s callback is not called if music is stopped using `Mix_HaltMusic()`, which causes the music cleanup process to fail;
* SDL_Mixer 1.x (at least 1.2.12) crashes somewhere inside its own music thread if `Mix_FreeMusic()` is called for an already inactive `Mix_Music` while playing another music track;
* Also this PR fixes MIDI instrument and drum descriptions which are currently messed up.