### PR TITLE
Fix Ultimate Artifact digging conditions

### DIFF
--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -411,7 +411,8 @@ namespace
 
         str.append( "\n \n" );
 
-        if ( tile.GoodForUltimateArtifact() ) {
+        // Original Editor allows to put an Ultimate Artifact on an invalid tile. So checking tile index solves this issue.
+        if ( tile.GoodForUltimateArtifact() || world.GetUltimateArtifact().getPosition() == tile.GetIndex() ) {
             str.append( _( "(digging ok)" ) );
         }
         else {

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -364,7 +364,8 @@ fheroes2::GameMode Interface::Basic::EventDigArtifact()
         if ( hero->isShipMaster() )
             Dialog::Message( "", _( "Try looking on land!!!" ), Font::BIG, Dialog::OK );
         else if ( hero->GetMaxMovePoints() <= hero->GetMovePoints() ) {
-            if ( world.GetTiles( hero->GetIndex() ).GoodForUltimateArtifact() ) {
+            // Original Editor allows to put an Ultimate Artifact on an invalid tile. So checking tile index solves this issue.
+            if ( world.GetTiles( hero->GetIndex() ).GoodForUltimateArtifact() || world.GetUltimateArtifact().getPosition() == hero->GetIndex() ) {
                 AudioManager::PlaySound( M82::DIGSOUND );
 
                 hero->ResetMovePoints();


### PR DESCRIPTION
The original Map Editor allows to place an Ultimate Artifact where it shouldn't be.

close #4298