### PR TITLE
Fix typo in Army::ArrangeForBattle()

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1474,7 +1474,7 @@ void Army::ArrangeForBattle( const Monster & monster, const uint32_t monstersCou
             std::mt19937 seededGen( world.GetMapSeed() + static_cast<uint32_t>( tileIndex ) + static_cast<uint32_t>( monster.GetID() ) );
 
             // 50% chance to get an upgraded stack
-            if ( Rand::Get( 0, 1 ) == 1 ) {
+            if ( Rand::GetWithGen( 0, 1, seededGen ) == 1 ) {
                 troopToUpgrade->Upgrade();
             }
         }


### PR DESCRIPTION
fix #5726

Regression after #5703.

The crash due to an assertion failure was in the AI pathfinder because, due to this typo, the same AI-controlled hero with the same army on the same tile with the same guardians sometimes was able to defeat those guardians and sometimes (when guardians get the upgraded stack due to the non-deterministic random) he couldn't do it. This breaks the AI pathfinder logic because it always expects the same results of the `Army::GetStrength()` for the same army on the same tile.