### PR TITLE
Fix the battle order after bad morale events

### DIFF
--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -530,7 +530,7 @@ void Battle::Arena::ApplyActionEnd( Command & cmd )
             DEBUG_LOG( DBG_BATTLE, DBG_TRACE, unit->String() )
         }
         else {
-            DEBUG_LOG( DBG_BATTLE, DBG_INFO, "uid: " << GetHexString( uid ) << " moved" )
+            DEBUG_LOG( DBG_BATTLE, DBG_INFO, "unit has already completed its turn: " << unit->String() )
         }
     }
     else {

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -564,7 +564,6 @@ void Battle::Arena::ApplyActionMorale( Command & cmd )
         }
 
         unit->ResetModes( TR_MOVED | MORALE_GOOD );
-        end_turn = false;
     }
     // Bad morale
     else {
@@ -577,7 +576,6 @@ void Battle::Arena::ApplyActionMorale( Command & cmd )
 
         unit->ResetModes( MORALE_BAD );
         unit->SetModes( TR_MOVED );
-        end_turn = true;
     }
 
     if ( interface ) {

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -578,14 +578,6 @@ void Battle::Arena::ApplyActionMorale( Command & cmd )
         unit->ResetModes( MORALE_BAD );
         unit->SetModes( TR_MOVED );
         end_turn = true;
-
-        // HoMM2-specific quirk: if unit skips a turn due to bad morale, then the "fastest unit of the opposite
-        // army goes first" logic does not apply if and only if there is another unit in the queue from the same
-        // army and with exactly the same speed
-        const Unit * nextUnit = GetCurrentUnit( true, unit->GetArmyColor() );
-        if ( nextUnit && nextUnit->GetArmyColor() == unit->GetArmyColor() && nextUnit->GetSpeed() == unit->GetSpeed( false, true ) ) {
-            _preferredColor = unit->GetArmyColor();
-        }
     }
 
     if ( interface ) {

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -504,9 +504,7 @@ void Battle::Arena::ApplyActionSkip( Command & cmd )
             DEBUG_LOG( DBG_BATTLE, DBG_TRACE, unit->String() )
         }
         else {
-            DEBUG_LOG( DBG_BATTLE, DBG_WARN,
-                       "unit has already completed its turn: "
-                           << "uid: " << GetHexString( uid ) )
+            DEBUG_LOG( DBG_BATTLE, DBG_WARN, "unit has already completed its turn: " << unit->String() )
         }
     }
     else {
@@ -560,9 +558,7 @@ void Battle::Arena::ApplyActionMorale( Command & cmd )
     // Good morale
     if ( morale ) {
         if ( !unit->AllModes( TR_MOVED | MORALE_GOOD ) ) {
-            DEBUG_LOG( DBG_BATTLE, DBG_WARN,
-                       "unit is in an invalid state: "
-                           << "uid: " << GetHexString( uid ) )
+            DEBUG_LOG( DBG_BATTLE, DBG_WARN, "unit is in an invalid state: " << unit->String( true ) )
 
             return;
         }
@@ -574,9 +570,7 @@ void Battle::Arena::ApplyActionMorale( Command & cmd )
     else {
         // A bad morale event cannot happen when a waiting unit gets its turn
         if ( !unit->Modes( MORALE_BAD ) || unit->Modes( TR_MOVED | TR_SKIPMOVE ) ) {
-            DEBUG_LOG( DBG_BATTLE, DBG_WARN,
-                       "unit is in an invalid state: "
-                           << "uid: " << GetHexString( uid ) )
+            DEBUG_LOG( DBG_BATTLE, DBG_WARN, "unit is in an invalid state: " << unit->String( true ) )
 
             return;
         }

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -471,7 +471,7 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
             end_turn = true;
         }
         else if ( troop->Modes( MORALE_BAD ) && !troop->Modes( TR_SKIPMOVE ) ) {
-            // Bad morale, happens only if the unit wasn't waiting for a turn
+            // Bad morale, happens only if the unit was not in the waiting state
             actions.emplace_back( CommandType::MSG_BATTLE_MORALE, troop->GetUID(), false );
             end_turn = true;
 
@@ -503,7 +503,7 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
             actions.pop_front();
 
             if ( armies_order ) {
-                // Applied action could kill someone or affect the speed of some unit, update units order
+                // Applied action could kill someone or affect the speed of some unit, update the order of units
                 UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
             }
 
@@ -554,13 +554,13 @@ void Battle::Arena::Turns()
     army1->NewTurn();
     army2->NewTurn();
 
-    // Order history on the current turn
+    // History of unit order on the current turn
     Units orderHistory;
 
     if ( armies_order ) {
         orderHistory.reserve( 25 );
 
-        // Build initial units order
+        // Build the initial order of units
         UpdateOrderOfUnits( *army1, *army2, nullptr, preferredColor, orderHistory, *armies_order );
     }
 
@@ -584,10 +584,10 @@ void Battle::Arena::Turns()
             preferredColor = ( troop->GetArmyColor() == army1->GetColor() ) ? army2->GetColor() : army1->GetColor();
 
             if ( armies_order ) {
-                // Add unit to the order history
+                // Add unit to the history
                 orderHistory.push_back( troop );
 
-                // Update units order
+                // Update the order of units
                 UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
             }
 
@@ -603,7 +603,7 @@ void Battle::Arena::Turns()
                         TowerAction( *towers[1] );
 
                         if ( armies_order ) {
-                            // Tower could kill someone, update units order
+                            // Tower could kill someone, update the order of units
                             UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
                         }
                     }
@@ -611,7 +611,7 @@ void Battle::Arena::Turns()
                         TowerAction( *towers[0] );
 
                         if ( armies_order ) {
-                            // Tower could kill someone, update units order
+                            // Tower could kill someone, update the order of units
                             UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
                         }
                     }
@@ -619,7 +619,7 @@ void Battle::Arena::Turns()
                         TowerAction( *towers[2] );
 
                         if ( armies_order ) {
-                            // Tower could kill someone, update units order
+                            // Tower could kill someone, update the order of units
                             UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
                         }
                     }
@@ -639,7 +639,7 @@ void Battle::Arena::Turns()
             TurnTroop( troop, orderHistory );
 
             if ( armies_order ) {
-                // If unit hasn't finished its turn yet, then remove it from the order history
+                // If unit hasn't finished its turn yet, then remove it from the history
                 if ( troop->Modes( TR_SKIPMOVE ) && !troop->Modes( TR_MOVED ) ) {
                     orderHistory.pop_back();
                 }
@@ -667,10 +667,10 @@ void Battle::Arena::Turns()
             preferredColor = ( troop->GetArmyColor() == army1->GetColor() ) ? army2->GetColor() : army1->GetColor();
 
             if ( armies_order ) {
-                // Add unit to the order history
+                // Add unit to the history
                 orderHistory.push_back( troop );
 
-                // Update units order
+                // Update the order of units
                 UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
             }
 

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -456,7 +456,8 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
             actions.emplace_back( CommandType::MSG_BATTLE_MORALE, troop->GetUID(), false );
             end_turn = true;
 
-            // If the unit skips a turn due to bad morale, then the next preferred unit should be from the same army
+            // If unit skips a turn due to bad morale, then the "fastest unit of the opposite army goes first"
+            // logic does not apply, do not switch the preferred color for the next unit
             preferredColor = troop->GetArmyColor();
         }
         else {
@@ -626,8 +627,8 @@ void Battle::Arena::Turns()
             }
         }
 
-        // The last unit in queue is "special": even if it skips his turn due to bad morale, the preferred color
-        // should be switched anyway
+        // The last unit in queue is "special": even if it skips his turn due to bad morale, the "fastest unit of
+        // the opposite army goes first" logic is still applicable
         if ( troop ) {
             preferredColor = ( troop->GetArmyColor() == army1->GetColor() ) ? army2->GetColor() : army1->GetColor();
         }

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -700,7 +700,7 @@ void Battle::Arena::Turns()
 
 void Battle::Arena::RemoteTurn( const Unit & b, Actions & a )
 {
-    DEBUG_LOG( DBG_BATTLE, DBG_WARN, "switch to AI turn" )
+    DEBUG_LOG( DBG_BATTLE, DBG_WARN, "switching control to AI" )
     AI::Get().BattleTurn( *this, b, a );
 }
 

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -545,8 +545,8 @@ void Battle::Arena::Turns()
     }
 
     {
-        bool towerMoved = false;
-        bool catapultMoved = false;
+        bool towersActed = false;
+        bool catapultActed = false;
 
         Unit * troop = nullptr;
 
@@ -571,14 +571,14 @@ void Battle::Arena::Turns()
                 UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
             }
 
-            // First turn: castle and catapult action
+            // Castle towers and catapult are acting during the turn of the first unit from the corresponding army
             if ( castle ) {
-                if ( !catapultMoved && troop->GetColor() == army1->GetColor() ) {
+                if ( !catapultActed && troop->GetColor() == army1->GetColor() ) {
                     CatapultAction();
-                    catapultMoved = true;
+                    catapultActed = true;
                 }
 
-                if ( !towerMoved && troop->GetColor() == army2->GetColor() ) {
+                if ( !towersActed && troop->GetColor() == army2->GetColor() ) {
                     if ( towers[1] && towers[1]->isValid() ) {
                         TowerAction( *towers[1] );
 
@@ -603,7 +603,7 @@ void Battle::Arena::Turns()
                             UpdateOrderOfUnits( *army1, *army2, troop, preferredColor, orderHistory, *armies_order );
                         }
                     }
-                    towerMoved = true;
+                    towersActed = true;
 
                     // If the towers have killed the last enemy unit, the battle is over
                     if ( !BattleValid() ) {

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -588,34 +588,30 @@ void Battle::Arena::Turns()
             if ( castle ) {
                 if ( !catapultActed && troop->GetColor() == army1->GetColor() ) {
                     CatapultAction();
+
                     catapultActed = true;
                 }
 
                 if ( !towersActed && troop->GetColor() == army2->GetColor() ) {
-                    if ( towers[1] && towers[1]->isValid() ) {
-                        TowerAction( *towers[1] );
+                    auto towerAction = [this, &orderHistory, troop]( const size_t idx ) {
+                        assert( idx < std::size( towers ) );
+
+                        if ( towers[idx] == nullptr || !towers[idx]->isValid() ) {
+                            return;
+                        }
+
+                        TowerAction( *towers[idx] );
 
                         if ( armies_order ) {
                             // Tower could kill someone, update the order of units
                             UpdateOrderOfUnits( *army1, *army2, troop, GetOppositeColor( troop->GetArmyColor() ), orderHistory, *armies_order );
                         }
-                    }
-                    if ( towers[0] && towers[0]->isValid() ) {
-                        TowerAction( *towers[0] );
+                    };
 
-                        if ( armies_order ) {
-                            // Tower could kill someone, update the order of units
-                            UpdateOrderOfUnits( *army1, *army2, troop, GetOppositeColor( troop->GetArmyColor() ), orderHistory, *armies_order );
-                        }
-                    }
-                    if ( towers[2] && towers[2]->isValid() ) {
-                        TowerAction( *towers[2] );
+                    towerAction( 1 );
+                    towerAction( 0 );
+                    towerAction( 2 );
 
-                        if ( armies_order ) {
-                            // Tower could kill someone, update the order of units
-                            UpdateOrderOfUnits( *army1, *army2, troop, GetOppositeColor( troop->GetArmyColor() ), orderHistory, *armies_order );
-                        }
-                    }
                     towersActed = true;
 
                     // If the towers have killed the last enemy unit, the battle is over

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -185,8 +185,13 @@ namespace
         }
 
         Battle::Unit * result = GetCurrentUnitForBattleStage( units1, units2, firstStage, preferredColor != army2.GetColor(), false );
+        if ( result == nullptr ) {
+            return result;
+        }
 
-        return result && result->isValid() ? result : nullptr;
+        assert( result->isValid() );
+
+        return result;
     }
 
     void UpdateOrderOfUnits( const Battle::Force & army1, const Battle::Force & army2, const Battle::Unit * currentUnit, int preferredColor,
@@ -202,14 +207,21 @@ namespace
             units1.SortFastest();
             units2.SortFastest();
 
-            Battle::Unit * unit = nullptr;
-
-            while ( ( unit = GetCurrentUnitForBattleStage( units1, units2, true, preferredColor != army2.GetColor(), true ) ) != nullptr ) {
-                if ( unit != currentUnit && unit->isValid() ) {
-                    preferredColor = ( unit->GetArmyColor() == army1.GetColor() ) ? army2.GetColor() : army1.GetColor();
-
-                    orderOfUnits.push_back( unit );
+            while ( true ) {
+                Battle::Unit * unit = GetCurrentUnitForBattleStage( units1, units2, true, preferredColor != army2.GetColor(), true );
+                if ( unit == nullptr ) {
+                    break;
                 }
+
+                assert( unit->isValid() );
+
+                if ( unit == currentUnit ) {
+                    continue;
+                }
+
+                preferredColor = ( unit->GetArmyColor() == army1.GetColor() ) ? army2.GetColor() : army1.GetColor();
+
+                orderOfUnits.push_back( unit );
             }
         }
 
@@ -223,14 +235,21 @@ namespace
             units1.SortSlowest();
             units2.SortSlowest();
 
-            Battle::Unit * unit = nullptr;
-
-            while ( ( unit = GetCurrentUnitForBattleStage( units1, units2, false, preferredColor != army2.GetColor(), true ) ) != nullptr ) {
-                if ( unit != currentUnit && unit->isValid() ) {
-                    preferredColor = ( unit->GetArmyColor() == army1.GetColor() ) ? army2.GetColor() : army1.GetColor();
-
-                    orderOfUnits.push_back( unit );
+            while ( true ) {
+                Battle::Unit * unit = GetCurrentUnitForBattleStage( units1, units2, false, preferredColor != army2.GetColor(), true );
+                if ( unit == nullptr ) {
+                    break;
                 }
+
+                assert( unit->isValid() );
+
+                if ( unit == currentUnit ) {
+                    continue;
+                }
+
+                preferredColor = ( unit->GetArmyColor() == army1.GetColor() ) ? army2.GetColor() : army1.GetColor();
+
+                orderOfUnits.push_back( unit );
             }
         }
     }

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -194,6 +194,12 @@ namespace Battle
         void RemoteTurn( const Unit &, Actions & );
         void HumanTurn( const Unit &, Actions & );
 
+        // Returns the current unit (whose turn has come) from the turn queue (or nullptr, if there is no such
+        // unit), taking into account the current stage (the first stage is when the usual turns are made, the
+        // second stage is when the waiting units get their turn), as well as the preferred color (all other
+        // things being equal, a unit of this color is returned).
+        Unit * GetCurrentUnit( const bool firstStage, const int preferredColor ) const;
+
         void TurnTroop( Unit * troop, const Units & orderHistory );
         void TowerAction( const Tower & );
 
@@ -241,7 +247,7 @@ namespace Battle
         Units * armies_order;
 
         int current_color;
-        int preferredColor; // preferred color for the next unit in the battle queue
+        int _preferredColor; // Preferred color for the next unit in the battle queue
 
         const Castle * castle;
         const bool _isTown; // If the battle is in town (village or castle).

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -107,7 +107,9 @@ namespace Battle
         int GetArmyColor1() const;
         int GetArmyColor2() const;
         int GetCurrentColor() const;
-        int GetOppositeColor( int ) const;
+        // Returns the color of the army opposite to the army of the given color. If there is no army of the given color,
+        // returns the color of the attacking army.
+        int GetOppositeColor( const int col ) const;
 
         Unit * GetTroopBoard( int32_t );
         const Unit * GetTroopBoard( int32_t ) const;
@@ -133,8 +135,8 @@ namespace Battle
         Indexes GetPath( const Unit &, const Position & ) const;
 
         // Returns the cell nearest to the end of the path to the cell with the given index (according to the AIBattlePathfinder)
-        // and reachable for the current unit (to which the current board passability information relates) or -1 if the cell
-        // with the given index is unreachable in principle
+        // and reachable for the current unit (to which the current board passability information relates) or -1 if the cell with
+        // the given index is unreachable in principle
         int32_t GetNearestReachableCell( const Unit & currentUnit, const int32_t dst ) const;
 
         void ApplyAction( Command & );
@@ -194,13 +196,6 @@ namespace Battle
         void RemoteTurn( const Unit &, Actions & );
         void HumanTurn( const Unit &, Actions & );
 
-        // Returns the current unit from the turn queue (or nullptr, if the queue is empty), taking into account the
-        // current stage (the first stage is when units get a turn for the first time, the second (optional) stage is
-        // when the units that decided to wait in the first stage get their turn once again), as well as the preferred
-        // color (all other conditions being equal, a unit of this color is returned if possible, otherwise a unit from
-        // the attacking army is returned).
-        Unit * GetCurrentUnit( const bool firstStage, const int preferredColor ) const;
-
         void TurnTroop( Unit * troop, const Units & orderHistory );
         void TowerAction( const Tower & );
 
@@ -248,7 +243,9 @@ namespace Battle
         Units * armies_order;
 
         int current_color;
-        int _preferredColor; // Preferred color for the next unit in the battle queue
+        // The color of the army of the last unit that performed a full-fledged action (skipping a turn due to
+        // bad morale is not considered as such)
+        int _lastActiveUnitArmyColor;
 
         const Castle * castle;
         const bool _isTown; // If the battle is in town (village or castle).

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -194,10 +194,10 @@ namespace Battle
         void RemoteTurn( const Unit &, Actions & );
         void HumanTurn( const Unit &, Actions & );
 
-        // Returns the current unit (whose turn has come) from the turn queue (or nullptr, if there is no such
-        // unit), taking into account the current stage (the first stage is when the usual turns are made, the
-        // second stage is when the waiting units get their turn), as well as the preferred color (all other
-        // things being equal, a unit of this color is returned).
+        // Returns the current unit from the turn queue (or nullptr, if there is no such unit), taking into account the
+        // current stage (the first stage is when the usual unit turns are made, the second stage is when units that chose
+        // to wait in the first stage get their turn), as well as the preferred color (all other conditions being equal, a
+        // unit of this color is returned).
         Unit * GetCurrentUnit( const bool firstStage, const int preferredColor ) const;
 
         void TurnTroop( Unit * troop, const Units & orderHistory );

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -194,10 +194,10 @@ namespace Battle
         void RemoteTurn( const Unit &, Actions & );
         void HumanTurn( const Unit &, Actions & );
 
-        // Returns the current unit from the turn queue (or nullptr, if there is no such unit), taking into account the
-        // current stage (the first stage is when the usual unit turns are made, the second stage is when units that chose
-        // to wait in the first stage get their turn), as well as the preferred color (all other conditions being equal, a
-        // unit of this color is returned).
+        // Returns the current unit from the turn queue (or nullptr, if the queue is empty), taking into account the
+        // current stage (the first stage is when units get a turn for the first time, the second (optional) stage is
+        // when the units that decided to wait in the first stage get their turn once again), as well as the preferred
+        // color (all other conditions being equal, a unit of this color is returned).
         Unit * GetCurrentUnit( const bool firstStage, const int preferredColor ) const;
 
         void TurnTroop( Unit * troop, const Units & orderHistory );

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -197,7 +197,8 @@ namespace Battle
         // Returns the current unit from the turn queue (or nullptr, if the queue is empty), taking into account the
         // current stage (the first stage is when units get a turn for the first time, the second (optional) stage is
         // when the units that decided to wait in the first stage get their turn once again), as well as the preferred
-        // color (all other conditions being equal, a unit of this color is returned).
+        // color (all other conditions being equal, a unit of this color is returned if possible, otherwise a unit from
+        // the attacking army is returned).
         Unit * GetCurrentUnit( const bool firstStage, const int preferredColor ) const;
 
         void TurnTroop( Unit * troop, const Units & orderHistory );

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -267,8 +267,6 @@ namespace Battle
         uint32_t current_turn;
         int auto_battle;
 
-        bool end_turn;
-
         Rand::DeterministicRandomGenerator & _randomGenerator;
 
         TroopsUidGenerator _uidGenerator;

--- a/src/fheroes2/system/bitmodes.h
+++ b/src/fheroes2/system/bitmodes.h
@@ -45,9 +45,16 @@ public:
         modes &= ~f;
     }
 
+    // Returns true if any of the requested modes is set, otherwise returns false
     bool Modes( uint32_t f ) const
     {
         return ( modes & f ) != 0;
+    }
+
+    // Returns true if all the requested modes are set, otherwise returns false
+    bool AllModes( uint32_t f ) const
+    {
+        return ( modes & f ) == f;
     }
 
 protected:

--- a/src/fheroes2/system/bitmodes.h
+++ b/src/fheroes2/system/bitmodes.h
@@ -35,26 +35,26 @@ public:
         : modes( 0 )
     {}
 
-    void SetModes( uint32_t f )
+    void SetModes( const uint32_t f )
     {
         modes |= f;
     }
 
-    void ResetModes( uint32_t f )
+    void ResetModes( const uint32_t f )
     {
         modes &= ~f;
     }
 
     // Returns true if any of the requested modes is set, otherwise returns false
-    bool Modes( uint32_t f ) const
+    bool Modes( const uint32_t f ) const
     {
         return ( modes & f ) != 0;
     }
 
     // Returns true if all the requested modes are set, otherwise returns false
-    bool AllModes( uint32_t f ) const
+    bool AllModes( const uint32_t f ) const
     {
-        return ( modes & f ) == f;
+        return ( modes & f ) == f && f != 0;
     }
 
 protected:


### PR DESCRIPTION
fix #5745

Also minor style nits (curly braces added, some comments paraphrased), some checks are replaced by assertions, because what is being checked for should never happen.