### PR TITLE
Remove older save formats before 0.9.16

### DIFF
--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1996,16 +1996,7 @@ StreamBase & operator>>( StreamBase & msg, Heroes & hero )
     msg >> base;
 
     // Heroes
-    msg >> hero.name >> col;
-
-    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE_0916_RELEASE, "Remove the check below." );
-    if ( Game::GetLoadVersion() < FORMAT_VERSION_PRE_0916_RELEASE ) {
-        ColorBase dummyColor;
-
-        msg >> dummyColor;
-    }
-
-    msg >> hero.experience;
+    msg >> hero.name >> col >> hero.experience;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_0917_RELEASE, "Remove the check below." );
     if ( Game::GetLoadVersion() < FORMAT_VERSION_0917_RELEASE ) {

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -922,16 +922,7 @@ StreamBase & operator<<( StreamBase & msg, const Kingdom & kingdom )
 StreamBase & operator>>( StreamBase & msg, Kingdom & kingdom )
 {
     msg >> kingdom.modes >> kingdom.color >> kingdom.resource >> kingdom.lost_town_days >> kingdom.castles >> kingdom.heroes >> kingdom.recruits >> kingdom.visit_object
-        >> kingdom.puzzle_maps >> kingdom.visited_tents_colors;
-
-    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_0916_RELEASE, "Remove the check below." );
-    if ( Game::GetLoadVersion() < FORMAT_VERSION_0916_RELEASE ) {
-        KingdomHeroes temp;
-
-        msg >> temp;
-    }
-
-    msg >> kingdom._lastBattleWinHeroID >> kingdom._topItemInKingdomView;
+        >> kingdom.puzzle_maps >> kingdom.visited_tents_colors >> kingdom._lastBattleWinHeroID >> kingdom._topItemInKingdomView;
 
     return msg;
 }

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -27,15 +27,15 @@ enum SaveFileFormat : uint16_t
     // !!! IMPORTANT !!!
     // If you're adding a new version you must assign it to CURRENT_FORMAT_VERSION located at the bottom.
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
+
+    // 10000 value must be used for 1.0 release so all version before it should have lower than this value.
     FORMAT_VERSION_0918_RELEASE = 9921,
     FORMAT_VERSION_PRE_0918_RELEASE = 9920,
     FORMAT_VERSION_0917_RELEASE = 9911,
     FORMAT_VERSION_PRE_0917_RELEASE = 9910,
     FORMAT_VERSION_0916_RELEASE = 9901,
-    FORMAT_VERSION_PRE_0916_RELEASE = 9900,
-    FORMAT_VERSION_0912_RELEASE = 9803,
 
-    LAST_SUPPORTED_FORMAT_VERSION = FORMAT_VERSION_0912_RELEASE,
+    LAST_SUPPORTED_FORMAT_VERSION = FORMAT_VERSION_0916_RELEASE,
 
     CURRENT_FORMAT_VERSION = FORMAT_VERSION_0918_RELEASE
 };

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -1018,21 +1018,6 @@ void Settings::BinaryLoad()
         uint16_t version = 0;
 
         fs >> version >> _optExtGame >> _optExtBalance2 >> _optExtBalance4 >> _optExtBalance3 >> pos_radr >> pos_bttn >> pos_icon >> pos_stat;
-
-        static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_0916_RELEASE, "Remove the following code." );
-        if ( version < FORMAT_VERSION_0916_RELEASE ) {
-            // In previous versions, the default values for panel coordinates were {0, 0}, so if all read coordinates
-            // are {0, 0}, then they most likely need to be replaced with the new default coordinates {-1, -1}
-            std::apply(
-                []( auto &... pos ) {
-                    const fheroes2::Point nullPoint{ 0, 0 };
-
-                    if ( ( ( pos == nullPoint ) && ... ) ) {
-                        ( ( pos = { -1, -1 } ), ... );
-                    }
-                },
-                std::tie( pos_radr, pos_bttn, pos_icon, pos_stat ) );
-        }
     }
 }
 


### PR DESCRIPTION
We are reaching 1.0 release so we need to slowly kill support for older save file versions.