### PR TITLE
Makefile: build translations by default

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -75,9 +75,6 @@ jobs:
       run: |
         make -j 2
       env: ${{ matrix.config.env }}
-    - name: Generate translations
-      run: |
-        make -C files/lang -j 2
     - name: Create app bundle
       if: ${{ matrix.config.os == 'macos-11' }}
       run: |

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ PROJECT_VERSION := $(file < version.txt)
 
 all:
 	$(MAKE) -C src
+	$(MAKE) -C files/lang
 ifndef FHEROES2_MACOS_APP_BUNDLE
 	@cp src/dist/$(TARGET) .
 endif
@@ -57,5 +58,6 @@ endif
 
 clean:
 	$(MAKE) -C src clean
+	$(MAKE) -C files/lang clean
 	@rm -f ./$(TARGET)
 	@rm -rf ./$(TARGET).app

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -116,7 +116,6 @@ brew install fheroes2
 
 ```sh
 make FHEROES2_MACOS_APP_BUNDLE=ON
-make -C files/lang
 make FHEROES2_MACOS_APP_BUNDLE=ON bundle
 ```
 

--- a/script/packaging/debian/rules
+++ b/script/packaging/debian/rules
@@ -10,4 +10,3 @@ export DEB_CFLAGS_MAINT_APPEND = -DFHEROES2_DATA=/usr/share/games/fheroes2
 
 override_dh_auto_build:
 	dh_auto_build
-	make -C files/lang


### PR DESCRIPTION
Building translations by default allows running inplace fheroes2 with
languages enabled:

    $ make
    $ ./fheroes2