### PR TITLE
Always use the current color of a unit when toggling the auto battle (take the Hypnotize spell into account)

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2709,7 +2709,7 @@ void Battle::Interface::EventShowOptions()
 void Battle::Interface::EventAutoSwitch( const Unit & b, Actions & a )
 {
     if ( arena.CanToggleAutoBattle() ) {
-        a.emplace_back( CommandType::MSG_BATTLE_AUTO, b.GetColor() );
+        a.emplace_back( CommandType::MSG_BATTLE_AUTO, b.GetCurrentOrArmyColor() );
     }
 
     humanturn_redraw = true;


### PR DESCRIPTION
At the moment, when trying to toggle the auto battle when the hypnotized unit is active, the auto battle can be toggled for the wrong color.