### PR TITLE
Fix doubling incoming for ExtWorldExtObjectsCaptured

### DIFF
--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -811,8 +811,6 @@ void Kingdoms::AddTributeEvents( CapturedObjects & captureobj, const uint32_t da
                 continue;
             }
 
-            kingdom.AddFundsResource( funds );
-
             // for show dialogs
             if ( funds.GetValidItemsCount() && kingdom.isControlHuman() ) {
                 EventDate event;
@@ -832,6 +830,8 @@ void Kingdoms::AddTributeEvents( CapturedObjects & captureobj, const uint32_t da
                 }
 
                 world.AddEventDate( event );
+            } else {
+                kingdom.AddFundsResource( funds );
             }
         }
     }

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -830,7 +830,8 @@ void Kingdoms::AddTributeEvents( CapturedObjects & captureobj, const uint32_t da
                 }
 
                 world.AddEventDate( event );
-            } else {
+            }
+            else {
                 kingdom.AddFundsResource( funds );
             }
         }

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -305,7 +305,7 @@ void CapturedObjects::ResetColor( int color )
     }
 }
 
-void CapturedObjects::tributeCapturedObjects( const int playerColorId, const int objectType, Funds & funds, int & objectCount )
+void CapturedObjects::tributeCapturedObjects( const int playerColorId, const MP2::MapObjectType objectType, Funds & funds, int & objectCount )
 {
     funds = Funds();
     objectCount = 0;

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -120,7 +120,7 @@ struct CapturedObjects : std::map<int32_t, CapturedObject>
 
     CapturedObject & Get( int32_t );
 
-    void tributeCapturedObjects( const int playerColorId, const int objectType, Funds & funds, int & objectCount );
+    void tributeCapturedObjects( const int playerColorId, const MP2::MapObjectType objectType, Funds & funds, int & objectCount );
 
     uint32_t GetCount( int, int ) const;
     uint32_t GetCountMines( int, int ) const;


### PR DESCRIPTION
The problem discussed in a discord chat
Incoming of a kingdom is doubled for human players if option `ExtWorldExtObjectsCaptured` enabled for `ExtObjects`
Save file: [Magic_Garden_Bug.zip](https://github.com/ihhub/fheroes2/files/9377255/Magic_Garden_Bug.zip)
to reproduce just memorize amount of resources then press end of the day and compare what messages write to you and how much you really get.