### PR TITLE
Fix the distribution of Mutant Zombies in the Graveyard

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -791,7 +791,11 @@ void Army::setFromTile( const Maps::Tiles & tile )
         break;
 
     case MP2::OBJ_GRAVEYARD:
-        ArrangeForBattle( Monster::MUTANT_ZOMBIE, 100, tile.GetIndex(), false );
+        at( 0 )->Set( Monster::MUTANT_ZOMBIE, 20 );
+        at( 1 )->Set( Monster::MUTANT_ZOMBIE, 20 );
+        at( 2 )->Set( Monster::MUTANT_ZOMBIE, 20 );
+        at( 3 )->Set( Monster::MUTANT_ZOMBIE, 20 );
+        at( 4 )->Set( Monster::MUTANT_ZOMBIE, 20 );
         break;
 
     case MP2::OBJ_SHIPWRECK: {


### PR DESCRIPTION
fix #5763

Regression after #5703 - before that PR, `Troops::ArrangeForBattle()` always divided 100 units of any kind into 5 stacks, so it worked in the Graveyard by coincidence. Now the number of stacks is pseudo-random, so `ArrangeForBattle()` cannot be used for the Graveyard (where there should always be 5 stacks) anymore.