### PR TITLE
Remove "Remember last focus" option

### DIFF
--- a/files/lang/be.po
+++ b/files/lang/be.po
@@ -8354,9 +8354,6 @@ msgid ""
 "%{hp} HP."
 msgstr ""
 
-msgid "game: remember last focus"
-msgstr ""
-
 msgid "battle: show damage info"
 msgstr ""
 

--- a/files/lang/bg.po
+++ b/files/lang/bg.po
@@ -8420,9 +8420,6 @@ msgid ""
 "%{hp} HP."
 msgstr ""
 
-msgid "game: remember last focus"
-msgstr ""
-
 msgid "battle: show damage info"
 msgstr ""
 

--- a/files/lang/cs.po
+++ b/files/lang/cs.po
@@ -8557,9 +8557,6 @@ msgid ""
 "%{hp} HP."
 msgstr ""
 
-msgid "game: remember last focus"
-msgstr ""
-
 msgid "battle: show damage info"
 msgstr ""
 

--- a/files/lang/de.po
+++ b/files/lang/de.po
@@ -9790,9 +9790,6 @@ msgstr ""
 "Dieser Zauberspruch kontrolliert bis zu\n"
 "%{hp} TP."
 
-msgid "game: remember last focus"
-msgstr "Spiel: den letzten Fokus merken"
-
 msgid "battle: show damage info"
 msgstr "Kampf: Schadensinformationen anzeigen"
 

--- a/files/lang/es.po
+++ b/files/lang/es.po
@@ -9440,9 +9440,6 @@ msgid ""
 "%{hp} HP."
 msgstr ""
 
-msgid "game: remember last focus"
-msgstr "juego: recordar el último foco"
-
 #, fuzzy
 msgid "battle: show damage info"
 msgstr "juego: mostrar información del sistema"

--- a/files/lang/fr.po
+++ b/files/lang/fr.po
@@ -9611,9 +9611,6 @@ msgstr ""
 "Ce sort contrôle jusqu'à\n"
 "%{hp} PV."
 
-msgid "game: remember last focus"
-msgstr "jeu : retenir dernier élément choisi"
-
 msgid "battle: show damage info"
 msgstr "bataille : afficher les informations sur les dégâts"
 

--- a/files/lang/hu.po
+++ b/files/lang/hu.po
@@ -9244,9 +9244,6 @@ msgid ""
 "%{hp} HP."
 msgstr ""
 
-msgid "game: remember last focus"
-msgstr ""
-
 msgid "battle: show damage info"
 msgstr ""
 

--- a/files/lang/it.po
+++ b/files/lang/it.po
@@ -8696,9 +8696,6 @@ msgid ""
 "%{hp} HP."
 msgstr ""
 
-msgid "game: remember last focus"
-msgstr ""
-
 msgid "battle: show damage info"
 msgstr ""
 

--- a/files/lang/lt.po
+++ b/files/lang/lt.po
@@ -8573,9 +8573,6 @@ msgid ""
 "%{hp} HP."
 msgstr ""
 
-msgid "game: remember last focus"
-msgstr ""
-
 msgid "battle: show damage info"
 msgstr ""
 

--- a/files/lang/nb.po
+++ b/files/lang/nb.po
@@ -9756,9 +9756,6 @@ msgstr ""
 "Denne trolldommen gir deg kontroll over\n"
 "opptil %{hp} liv."
 
-msgid "game: remember last focus"
-msgstr "Parti: Husk hvor du var sist"
-
 msgid "battle: show damage info"
 msgstr "Kamp: Vis skadeinfo"
 

--- a/files/lang/nl.po
+++ b/files/lang/nl.po
@@ -8322,9 +8322,6 @@ msgid ""
 "%{hp} HP."
 msgstr ""
 
-msgid "game: remember last focus"
-msgstr ""
-
 msgid "battle: show damage info"
 msgstr ""
 

--- a/files/lang/pl.po
+++ b/files/lang/pl.po
@@ -9317,9 +9317,6 @@ msgstr ""
 "Zaklęcie kontroluje do\n"
 "%{hp} punktów życia."
 
-msgid "game: remember last focus"
-msgstr "gra: pamiętaj ostatni ekran"
-
 msgid "battle: show damage info"
 msgstr "walka: pokaż informacje o obrażeniach"
 

--- a/files/lang/pt.po
+++ b/files/lang/pt.po
@@ -8877,9 +8877,6 @@ msgid ""
 "%{hp} HP."
 msgstr ""
 
-msgid "game: remember last focus"
-msgstr ""
-
 msgid "battle: show damage info"
 msgstr ""
 

--- a/files/lang/ro.po
+++ b/files/lang/ro.po
@@ -8335,9 +8335,6 @@ msgid ""
 "%{hp} HP."
 msgstr ""
 
-msgid "game: remember last focus"
-msgstr ""
-
 msgid "battle: show damage info"
 msgstr ""
 

--- a/files/lang/ru.po
+++ b/files/lang/ru.po
@@ -9343,9 +9343,6 @@ msgstr ""
 "суммарное здоровье которого не превышает\n"
 "%{hp} здоровья."
 
-msgid "game: remember last focus"
-msgstr "игра: запомнить последнюю позицию фокуса (героя/замка)"
-
 msgid "battle: show damage info"
 msgstr "битва: показывать урон"
 

--- a/files/lang/sv.po
+++ b/files/lang/sv.po
@@ -9171,9 +9171,6 @@ msgid ""
 "%{hp} HP."
 msgstr ""
 
-msgid "game: remember last focus"
-msgstr "spel: Kom ihåg senast fokus"
-
 #, fuzzy
 msgid "battle: show damage info"
 msgstr "spel: Visa systeminfo"

--- a/files/lang/tr.po
+++ b/files/lang/tr.po
@@ -8320,9 +8320,6 @@ msgid ""
 "%{hp} HP."
 msgstr ""
 
-msgid "game: remember last focus"
-msgstr ""
-
 msgid "battle: show damage info"
 msgstr ""
 

--- a/files/lang/uk.po
+++ b/files/lang/uk.po
@@ -9211,9 +9211,6 @@ msgid ""
 "%{hp} HP."
 msgstr ""
 
-msgid "game: remember last focus"
-msgstr ""
-
 msgid "battle: show damage info"
 msgstr ""
 

--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -144,9 +144,8 @@ void Dialog::ExtSettings( bool readonly )
     text.Blit( area.x + ( area.width - text.w() ) / 2, area.y + 6 );
 
     std::vector<uint32_t> states;
-    states.reserve( 32 );
+    states.reserve( 16 );
 
-    states.push_back( Settings::GAME_REMEMBER_LAST_FOCUS );
     states.push_back( Settings::GAME_SHOW_SYSTEM_INFO );
     states.push_back( Settings::GAME_BATTLE_SHOW_DAMAGE );
     states.push_back( Settings::GAME_AUTOSAVE_BEGIN_DAY );

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -725,18 +725,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
     Kingdom & myKingdom = world.GetKingdom( conf.CurrentColor() );
     const KingdomCastles & myCastles = myKingdom.GetCastles();
 
-    // set focus
-    if ( conf.ExtGameRememberLastFocus() ) {
-        if ( GetFocusHeroes() != nullptr )
-            ResetFocus( GameFocus::HEROES );
-        else if ( GetFocusCastle() != nullptr )
-            ResetFocus( GameFocus::CASTLE );
-        else
-            ResetFocus( GameFocus::FIRSTHERO );
-    }
-    else {
-        ResetFocus( GameFocus::FIRSTHERO );
-    }
+    ResetFocus( GameFocus::FIRSTHERO );
 
     radar.SetHide( false );
     statusWindow.Reset();

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -900,8 +900,6 @@ bool Settings::ExtModes( uint32_t f ) const
 std::string Settings::ExtName( const uint32_t settingId )
 {
     switch ( settingId ) {
-    case Settings::GAME_REMEMBER_LAST_FOCUS:
-        return _( "game: remember last focus" );
     case Settings::GAME_BATTLE_SHOW_DAMAGE:
         return _( "battle: show damage info" );
     case Settings::WORLD_SCOUTING_EXTENDED:

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -55,7 +55,7 @@ public:
         // game balance and are saved in the binary config file
         //
         GAME_AUTOSAVE_BEGIN_DAY = 0x10000010,
-        GAME_REMEMBER_LAST_FOCUS = 0x10000020,
+        // UNUSED = 0x10000020,
         // UNUSED = 0x10000040,
         GAME_SHOW_SYSTEM_INFO = 0x10000100,
         // UNUSED = 0x10000200,
@@ -309,11 +309,6 @@ public:
     bool ExtBattleDeterministicResult() const
     {
         return ExtModes( BATTLE_DETERMINISTIC_RESULT );
-    }
-
-    bool ExtGameRememberLastFocus() const
-    {
-        return ExtModes( GAME_REMEMBER_LAST_FOCUS );
     }
 
     bool ExtGameContinueAfterVictory() const


### PR DESCRIPTION
This option might actually lead to thinking that the engine is buggy for players who enable this option without checking it. We need to make the logic of focusing identical for every player.

As argument towards removing this option:
- focusing on a castle on a next turn is usually illogical as most of players start doing actions by heroes
- we allow player to put heroes asleep

close #3147