### PR TITLE
Apply PSV paches only if the cached version has not been used

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -131,14 +131,9 @@ jobs:
         rm -rf ~/.vitasdk-cache
       env:
         VITASDK: /usr/local/vitasdk
-    - name: Restore Vita SDK from cache
-      run: |
-        if [[ -d ~/.vitasdk-cache ]]; then
-            sudo rm -rf /usr/local/vitasdk
-            sudo mv ~/.vitasdk-cache /usr/local/vitasdk
-        fi
     - name: Apply temporary patches
       run: |
+        [[ -d ~/.vitasdk-cache ]] && exit 0
         cd /usr/local/vitasdk
         patch --force -p0 << EOF
         --- arm-vita-eabi/include/SDL2/SDL_atomic.h.orig        2022-08-19 23:51:15.143690708 +0300
@@ -153,6 +148,12 @@ jobs:
          #elif (defined(__powerpc__) || defined(__powerpc64__))
              #define SDL_CPUPauseInstruction() __asm__ __volatile__("or 27,27,27");
         EOF
+    - name: Restore Vita SDK from cache
+      run: |
+        if [[ -d ~/.vitasdk-cache ]]; then
+            sudo rm -rf /usr/local/vitasdk
+            sudo mv ~/.vitasdk-cache /usr/local/vitasdk
+        fi
     - name: Build
       run: |
         export PATH="$VITASDK/bin:$PATH"


### PR DESCRIPTION
Cached version already contains all necessary fixes, so there is no need to apply them once again.