### PR TITLE
Added small offset to price of loyalty icons

### DIFF
--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -164,6 +164,21 @@ namespace
         offset.x *= deltaX;
         offset.y *= deltaY;
 
+        // Price of loyalty's track doesn't respect the standard offset between icons.
+        if ( scenarioInfo.campaignId == Campaign::CampaignID::PRICE_OF_LOYALTY_CAMPAIGN && scenarioInfo.scenarioId >= 5 ) {
+            switch ( scenarioInfo.scenarioId ) {
+            case 5:
+                offset.x -= 2;
+                break;
+            case 6:
+                offset.x -= 1;
+                break;
+            case 7:
+                offset.x -= 4;
+                break;
+            }
+        }
+
         offset.x -= 2;
         offset.y -= 2;
 

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -176,6 +176,8 @@ namespace
             case 7:
                 offset.x -= 4;
                 break;
+            default:
+                break;
             }
         }
 


### PR DESCRIPTION
closes #5620 

For some reasons the price of loyalty's icons do not follow the standard offset for the last 3 items. 
When comparing with any other menu we can clearly see that the icons are at the wrong location.

The workaround I found is to add a few pixels to the offset of those specific scenarios. 

![image](https://user-images.githubusercontent.com/60141446/185767070-6dec2865-8a29-42f6-9103-543d4ce9c7af.png)

