### PR TITLE
Implement the instant finish of the battle

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -241,7 +241,7 @@ namespace AI
             if ( arena.AutoBattleInProgress() && Arena::GetInterface() != nullptr ) {
                 assert( arena.CanToggleAutoBattle() );
 
-                actions.emplace_back( CommandType::MSG_BATTLE_AUTO, currentColor );
+                actions.emplace_back( CommandType::MSG_BATTLE_AUTO_SWITCH, currentColor );
 
                 DEBUG_LOG( DBG_BATTLE, DBG_INFO, Color::String( currentColor ) << " has used up the limit of turns without deaths, auto battle is turned off" )
             }

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -208,7 +208,7 @@ namespace AI
         const int currentColor = arena.GetCurrentColor();
 
         // Not the attacker's turn, no further checks
-        if ( currentColor != arena.GetArmyColor1() ) {
+        if ( currentColor != arena.GetArmy1Color() ) {
             return false;
         }
 

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -1001,34 +1001,27 @@ void Battle::Arena::ApplyActionAutoBattle( Command & cmd )
 {
     const int color = cmd.GetValue();
 
-    if ( auto_battle & color ) {
-        if ( interface ) {
-            const Player * player = Players::Get( color );
+    if ( ( color != GetArmyColor1() && color != GetArmyColor2() ) || ( getForce( color ).GetControl() & CONTROL_AI ) ) {
+        DEBUG_LOG( DBG_BATTLE, DBG_WARN,
+                   "incorrect param: "
+                       << "color: " << Color::String( color ) << " (" << color << ")" )
 
-            if ( player ) {
-                std::string msg = _( "%{name} has turned off the auto battle" );
-                StringReplace( msg, "%{name}", player->GetName() );
-
-                interface->SetStatus( msg, true );
-            }
-        }
-
-        auto_battle &= ~color;
+        return;
     }
-    else {
-        if ( interface ) {
-            const Player * player = Players::Get( color );
 
-            if ( player ) {
-                std::string msg = _( "%{name} has turned on the auto battle" );
-                StringReplace( msg, "%{name}", player->GetName() );
+    auto_battle ^= color;
 
-                interface->SetStatus( msg, true );
-            }
-        }
+    if ( interface ) {
+        const Player * player = Players::Get( color );
+        assert( player );
 
-        auto_battle |= color;
+        std::string msg = ( auto_battle & color ) ? _( "%{name} has turned on the auto battle" ) : _( "%{name} has turned off the auto battle" );
+        StringReplace( msg, "%{name}", player->GetName() );
+
+        interface->SetStatus( msg, true );
     }
+
+    DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "color: " << Color::String( color ) << ", status: " << ( ( auto_battle & color ) ? "on" : "off" ) )
 }
 
 void Battle::Arena::ApplyActionSpellSummonElemental( const Command & /*cmd*/, const Spell & spell )

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -1004,7 +1004,7 @@ void Battle::Arena::ApplyActionAutoSwitch( Command & cmd )
 {
     const int color = cmd.GetValue();
 
-    if ( ( color != GetArmyColor1() && color != GetArmyColor2() ) || ( getForce( color ).GetControl() & CONTROL_AI ) ) {
+    if ( ( color != GetArmy1Color() && color != GetArmy2Color() ) || ( getForce( color ).GetControl() & CONTROL_AI ) ) {
         DEBUG_LOG( DBG_BATTLE, DBG_WARN,
                    "incorrect param: "
                        << "color: " << Color::String( color ) << " (" << color << ")" )
@@ -1032,8 +1032,8 @@ void Battle::Arena::ApplyActionAutoFinish( const Command & /* cmd */ )
     const int army1Control = GetForce1().GetControl();
     const int army2Control = GetForce2().GetControl();
 
-    const int army1Color = GetArmyColor1();
-    const int army2Color = GetArmyColor2();
+    const int army1Color = GetArmy1Color();
+    const int army2Color = GetArmy2Color();
 
     if ( army1Control & CONTROL_REMOTE ) {
         DEBUG_LOG( DBG_BATTLE, DBG_WARN, "remote player: " << Color::String( army1Color ) << ", auto finish disabled" )

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -270,8 +270,11 @@ void Battle::Arena::ApplyAction( Command & cmd )
         ApplyActionSurrender( cmd );
         break;
 
-    case CommandType::MSG_BATTLE_AUTO:
-        ApplyActionAutoBattle( cmd );
+    case CommandType::MSG_BATTLE_AUTO_SWITCH:
+        ApplyActionAutoSwitch( cmd );
+        break;
+    case CommandType::MSG_BATTLE_AUTO_FINISH:
+        ApplyActionAutoFinish( cmd );
         break;
 
     default:
@@ -997,7 +1000,7 @@ void Battle::Arena::ApplyActionCatapult( Command & cmd )
     }
 }
 
-void Battle::Arena::ApplyActionAutoBattle( Command & cmd )
+void Battle::Arena::ApplyActionAutoSwitch( Command & cmd )
 {
     const int color = cmd.GetValue();
 
@@ -1022,6 +1025,20 @@ void Battle::Arena::ApplyActionAutoBattle( Command & cmd )
     }
 
     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "color: " << Color::String( color ) << ", status: " << ( ( _autoBattleColors & color ) ? "on" : "off" ) )
+}
+
+void Battle::Arena::ApplyActionAutoFinish( const Command & /* cmd */ )
+{
+    if ( !( GetForce1().GetControl() & CONTROL_AI ) ) {
+        _autoBattleColors |= GetForce1().GetColor();
+    }
+    if ( !( GetForce2().GetControl() & CONTROL_AI ) ) {
+        _autoBattleColors |= GetForce2().GetColor();
+    }
+
+    _interface.reset();
+
+    DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "" )
 }
 
 void Battle::Arena::ApplyActionSpellSummonElemental( const Command & /*cmd*/, const Spell & spell )

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -1009,19 +1009,19 @@ void Battle::Arena::ApplyActionAutoBattle( Command & cmd )
         return;
     }
 
-    auto_battle ^= color;
+    _autoBattleColors ^= color;
 
     if ( interface ) {
         const Player * player = Players::Get( color );
         assert( player );
 
-        std::string msg = ( auto_battle & color ) ? _( "%{name} has turned on the auto battle" ) : _( "%{name} has turned off the auto battle" );
+        std::string msg = ( _autoBattleColors & color ) ? _( "%{name} has turned on the auto battle" ) : _( "%{name} has turned off the auto battle" );
         StringReplace( msg, "%{name}", player->GetName() );
 
         interface->SetStatus( msg, true );
     }
 
-    DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "color: " << Color::String( color ) << ", status: " << ( ( auto_battle & color ) ? "on" : "off" ) )
+    DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "color: " << Color::String( color ) << ", status: " << ( ( _autoBattleColors & color ) ? "on" : "off" ) )
 }
 
 void Battle::Arena::ApplyActionSpellSummonElemental( const Command & /*cmd*/, const Spell & spell )

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -158,14 +158,14 @@ void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, int32_t dst
     // Do damage first
     TargetsInfo attackTargets = GetTargetsForDamage( attacker, defender, dst, dir );
 
-    if ( interface ) {
-        interface->RedrawActionAttackPart1( attacker, defender, attackTargets );
+    if ( _interface ) {
+        _interface->RedrawActionAttackPart1( attacker, defender, attackTargets );
     }
 
     TargetsApplyDamage( attacker, attackTargets );
 
-    if ( interface ) {
-        interface->RedrawActionAttackPart2( attacker, attackTargets );
+    if ( _interface ) {
+        _interface->RedrawActionAttackPart2( attacker, attackTargets );
     }
 
     // Then apply the attacker's built-in spell
@@ -210,9 +210,9 @@ void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, int32_t dst
 
             // The built-in dispel should only remove beneficial spells from the target unit
             if ( spell.GetID() != Spell::DISPEL || spellTargetUnit->Modes( IS_GOOD_MAGIC ) ) {
-                if ( interface ) {
-                    interface->RedrawActionSpellCastStatus( spell, spellTargetUnit->GetHeadIndex(), attacker.GetName(), spellTargets );
-                    interface->RedrawActionSpellCastPart1( spell, spellTargetUnit->GetHeadIndex(), nullptr, spellTargets );
+                if ( _interface ) {
+                    _interface->RedrawActionSpellCastStatus( spell, spellTargetUnit->GetHeadIndex(), attacker.GetName(), spellTargets );
+                    _interface->RedrawActionSpellCastPart1( spell, spellTargetUnit->GetHeadIndex(), nullptr, spellTargets );
                 }
 
                 if ( spell.GetID() == Spell::DISPEL ) {
@@ -223,9 +223,9 @@ void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, int32_t dst
                     TargetsApplySpell( nullptr, spell, spellTargets );
                 }
 
-                if ( interface ) {
-                    interface->RedrawActionSpellCastPart2( spell, spellTargets );
-                    interface->RedrawActionMonsterSpellCastStatus( spell, attacker, spellTargets.front() );
+                if ( _interface ) {
+                    _interface->RedrawActionSpellCastPart2( spell, spellTargets );
+                    _interface->RedrawActionMonsterSpellCastStatus( spell, attacker, spellTargets.front() );
                 }
             }
         }
@@ -398,8 +398,8 @@ void Battle::Arena::ApplyActionMove( Command & cmd )
             if ( unit->isReflect() != pos.isReflect() )
                 pos.Swap();
 
-            if ( interface ) {
-                interface->RedrawActionFly( *unit, pos );
+            if ( _interface ) {
+                _interface->RedrawActionFly( *unit, pos );
             }
             else if ( bridge ) {
                 const int32_t dstHead = pos.GetHead()->GetIndex();
@@ -433,8 +433,8 @@ void Battle::Arena::ApplyActionMove( Command & cmd )
                 return;
             }
 
-            if ( interface )
-                interface->RedrawActionMove( *unit, path );
+            if ( _interface )
+                _interface->RedrawActionMove( *unit, path );
             else if ( bridge ) {
                 for ( Indexes::const_iterator pathIt = path.begin(); pathIt != path.end(); ++pathIt ) {
                     bool doMovement = false;
@@ -498,8 +498,8 @@ void Battle::Arena::ApplyActionSkip( Command & cmd )
 
             unit->SetModes( TR_SKIPMOVE );
 
-            if ( interface )
-                interface->RedrawActionSkipStatus( *unit );
+            if ( _interface )
+                _interface->RedrawActionSkipStatus( *unit );
 
             DEBUG_LOG( DBG_BATTLE, DBG_TRACE, unit->String() )
         }
@@ -524,8 +524,8 @@ void Battle::Arena::ApplyActionEnd( Command & cmd )
         if ( !unit->Modes( TR_MOVED ) ) {
             unit->SetModes( TR_MOVED );
 
-            if ( unit->Modes( TR_SKIPMOVE ) && interface )
-                interface->RedrawActionSkipStatus( *unit );
+            if ( unit->Modes( TR_SKIPMOVE ) && _interface )
+                _interface->RedrawActionSkipStatus( *unit );
 
             DEBUG_LOG( DBG_BATTLE, DBG_TRACE, unit->String() )
         }
@@ -578,8 +578,8 @@ void Battle::Arena::ApplyActionMorale( Command & cmd )
         unit->SetModes( TR_MOVED );
     }
 
-    if ( interface ) {
-        interface->RedrawActionMorale( *unit, morale != 0 );
+    if ( _interface ) {
+        _interface->RedrawActionMorale( *unit, morale != 0 );
     }
 
     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, ( morale ? "good" : "bad" ) << " to " << unit->String() )
@@ -956,11 +956,11 @@ void Battle::Arena::ApplyActionTower( Command & cmd )
         target.defender = unit;
         target.damage = tower->GetDamage( *unit );
 
-        if ( interface )
-            interface->RedrawActionTowerPart1( *tower, *unit );
+        if ( _interface )
+            _interface->RedrawActionTowerPart1( *tower, *unit );
         target.killed = unit->ApplyDamage( *tower, target.damage );
-        if ( interface )
-            interface->RedrawActionTowerPart2( *tower, target );
+        if ( _interface )
+            _interface->RedrawActionTowerPart2( *tower, target );
     }
     else {
         DEBUG_LOG( DBG_BATTLE, DBG_WARN,
@@ -980,8 +980,8 @@ void Battle::Arena::ApplyActionCatapult( Command & cmd )
             const bool hit = cmd.GetValue() != 0;
 
             if ( target ) {
-                if ( interface ) {
-                    interface->RedrawActionCatapult( target, hit );
+                if ( _interface ) {
+                    _interface->RedrawActionCatapult( target, hit );
                 }
 
                 if ( hit ) {
@@ -1011,14 +1011,14 @@ void Battle::Arena::ApplyActionAutoBattle( Command & cmd )
 
     _autoBattleColors ^= color;
 
-    if ( interface ) {
+    if ( _interface ) {
         const Player * player = Players::Get( color );
         assert( player );
 
         std::string msg = ( _autoBattleColors & color ) ? _( "%{name} has turned on the auto battle" ) : _( "%{name} has turned off the auto battle" );
         StringReplace( msg, "%{name}", player->GetName() );
 
-        interface->SetStatus( msg, true );
+        _interface->SetStatus( msg, true );
     }
 
     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "color: " << Color::String( color ) << ", status: " << ( ( _autoBattleColors & color ) ? "on" : "off" ) )
@@ -1029,12 +1029,12 @@ void Battle::Arena::ApplyActionSpellSummonElemental( const Command & /*cmd*/, co
     Unit * elem = CreateElemental( spell );
     assert( elem != nullptr );
 
-    if ( interface ) {
+    if ( _interface ) {
         const HeroBase * commander = GetCurrentCommander();
         assert( commander != nullptr );
 
-        interface->RedrawActionSpellCastStatus( spell, -1, commander->GetName(), {} );
-        interface->RedrawActionSummonElementalSpell( *elem );
+        _interface->RedrawActionSpellCastStatus( spell, -1, commander->GetName(), {} );
+        _interface->RedrawActionSummonElementalSpell( *elem );
     }
 }
 
@@ -1049,8 +1049,8 @@ void Battle::Arena::ApplyActionSpellDefaults( Command & cmd, const Spell & spell
     TargetsInfo targets = GetTargetsForSpells( commander, spell, dst, &playResistSound );
     TargetsInfo resistTargets;
 
-    if ( interface ) {
-        interface->RedrawActionSpellCastStatus( spell, dst, commander->GetName(), targets );
+    if ( _interface ) {
+        _interface->RedrawActionSpellCastStatus( spell, dst, commander->GetName(), targets );
 
         for ( const auto & target : targets ) {
             if ( target.resist ) {
@@ -1061,17 +1061,17 @@ void Battle::Arena::ApplyActionSpellDefaults( Command & cmd, const Spell & spell
 
     targets.erase( std::remove_if( targets.begin(), targets.end(), []( const TargetInfo & v ) { return v.resist; } ), targets.end() );
 
-    if ( interface ) {
-        interface->RedrawActionSpellCastPart1( spell, dst, commander, targets );
+    if ( _interface ) {
+        _interface->RedrawActionSpellCastPart1( spell, dst, commander, targets );
         for ( const TargetInfo & target : resistTargets ) {
-            interface->RedrawActionResistSpell( *target.defender, playResistSound );
+            _interface->RedrawActionResistSpell( *target.defender, playResistSound );
         }
     }
 
     TargetsApplySpell( commander, spell, targets );
 
-    if ( interface )
-        interface->RedrawActionSpellCastPart2( spell, targets );
+    if ( _interface )
+        _interface->RedrawActionSpellCastPart2( spell, targets );
 }
 
 void Battle::Arena::ApplyActionSpellTeleport( Command & cmd )
@@ -1086,7 +1086,7 @@ void Battle::Arena::ApplyActionSpellTeleport( Command & cmd )
         const Position pos = Position::GetPosition( *unit, dst );
         assert( pos.GetHead() != nullptr && ( !unit->isWide() || pos.GetTail() != nullptr ) );
 
-        if ( interface ) {
+        if ( _interface ) {
             const HeroBase * commander = GetCurrentCommander();
             assert( commander != nullptr );
 
@@ -1096,8 +1096,8 @@ void Battle::Arena::ApplyActionSpellTeleport( Command & cmd )
             TargetsInfo targetsInfo;
             targetsInfo.push_back( targetInfo );
 
-            interface->RedrawActionSpellCastStatus( Spell( Spell::TELEPORT ), src, commander->GetName(), targetsInfo );
-            interface->RedrawActionTeleportSpell( *unit, pos.GetHead()->GetIndex() );
+            _interface->RedrawActionSpellCastStatus( Spell( Spell::TELEPORT ), src, commander->GetName(), targetsInfo );
+            _interface->RedrawActionTeleportSpell( *unit, pos.GetHead()->GetIndex() );
         }
 
         unit->SetPosition( pos );
@@ -1118,9 +1118,9 @@ void Battle::Arena::ApplyActionSpellEarthQuake( const Command & /*cmd*/ )
 
     std::vector<int> targets = GetCastleTargets();
 
-    if ( interface ) {
-        interface->RedrawActionSpellCastStatus( Spell( Spell::EARTHQUAKE ), -1, commander->GetName(), {} );
-        interface->RedrawActionEarthQuakeSpell( targets );
+    if ( _interface ) {
+        _interface->RedrawActionSpellCastStatus( Spell( Spell::EARTHQUAKE ), -1, commander->GetName(), {} );
+        _interface->RedrawActionEarthQuakeSpell( targets );
     }
 
     const std::pair<uint32_t, uint32_t> range = getEarthquakeDamageRange( commander );
@@ -1170,7 +1170,7 @@ void Battle::Arena::ApplyActionSpellMirrorImage( Command & cmd )
 
             DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "set position: " << pos.GetHead()->GetIndex() )
 
-            if ( interface ) {
+            if ( _interface ) {
                 const HeroBase * commander = GetCurrentCommander();
                 assert( commander != nullptr );
 
@@ -1180,8 +1180,8 @@ void Battle::Arena::ApplyActionSpellMirrorImage( Command & cmd )
                 TargetsInfo targetsInfo;
                 targetsInfo.push_back( targetInfo );
 
-                interface->RedrawActionSpellCastStatus( Spell( Spell::MIRRORIMAGE ), who, commander->GetName(), targetsInfo );
-                interface->RedrawActionMirrorImageSpell( *unit, pos );
+                _interface->RedrawActionSpellCastStatus( Spell( Spell::MIRRORIMAGE ), who, commander->GetName(), targetsInfo );
+                _interface->RedrawActionMirrorImageSpell( *unit, pos );
             }
 
             mirrorUnit->SetPosition( pos );
@@ -1189,8 +1189,8 @@ void Battle::Arena::ApplyActionSpellMirrorImage( Command & cmd )
         else {
             DEBUG_LOG( DBG_BATTLE, DBG_WARN, "no suitable position found" )
 
-            if ( interface ) {
-                interface->SetStatus( _( "Spell failed!" ), true );
+            if ( _interface ) {
+                _interface->SetStatus( _( "Spell failed!" ), true );
             }
         }
     }

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -1029,16 +1029,39 @@ void Battle::Arena::ApplyActionAutoSwitch( Command & cmd )
 
 void Battle::Arena::ApplyActionAutoFinish( const Command & /* cmd */ )
 {
-    if ( !( GetForce1().GetControl() & CONTROL_AI ) ) {
-        _autoBattleColors |= GetForce1().GetColor();
+    const int army1Control = GetForce1().GetControl();
+    const int army2Control = GetForce2().GetControl();
+
+    const int army1Color = GetArmyColor1();
+    const int army2Color = GetArmyColor2();
+
+    if ( army1Control & CONTROL_REMOTE ) {
+        DEBUG_LOG( DBG_BATTLE, DBG_WARN, "remote player: " << Color::String( army1Color ) << ", auto finish disabled" )
+
+        return;
     }
-    if ( !( GetForce2().GetControl() & CONTROL_AI ) ) {
-        _autoBattleColors |= GetForce2().GetColor();
+    if ( army2Control & CONTROL_REMOTE ) {
+        DEBUG_LOG( DBG_BATTLE, DBG_WARN, "remote player: " << Color::String( army2Color ) << ", auto finish disabled" )
+
+        return;
+    }
+
+    if ( !( army1Control & CONTROL_HUMAN ) && !( army2Control & CONTROL_HUMAN ) ) {
+        DEBUG_LOG( DBG_BATTLE, DBG_WARN, "no local human-controlled player participates in the battle, auto finish disabled" )
+
+        return;
+    }
+
+    if ( army1Control & CONTROL_HUMAN ) {
+        _autoBattleColors |= army1Color;
+    }
+    if ( army2Control & CONTROL_HUMAN ) {
+        _autoBattleColors |= army2Color;
     }
 
     _interface.reset();
 
-    DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "" )
+    DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "finishing the battle" )
 }
 
 void Battle::Arena::ApplyActionSpellSummonElemental( const Command & /*cmd*/, const Spell & spell )

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -58,14 +58,14 @@ namespace Battle
 
 namespace
 {
-    // compute a new seed from a list of actions, so random actions happen differently depending on user inputs
+    // Compute a new seed from a list of actions, so random actions happen differently depending on user inputs
     uint32_t UpdateRandomSeed( const uint32_t seed, const Battle::Actions & actions )
     {
         uint32_t newSeed = seed;
 
         for ( const Battle::Command & command : actions ) {
-            if ( command.GetType() == Battle::CommandType::MSG_BATTLE_AUTO ) {
-                continue; // "auto battle" button event is ignored for the purpose of this hash
+            if ( command.GetType() == Battle::CommandType::MSG_BATTLE_AUTO_SWITCH || command.GetType() == Battle::CommandType::MSG_BATTLE_AUTO_FINISH ) {
+                continue; // Events related to the auto battle are ignored for the purpose of this hash
             }
 
             fheroes2::hashCombine( newSeed, command.GetType() );

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -262,31 +262,43 @@ Battle::Arena * Battle::GetArena()
 
 const Castle * Battle::Arena::GetCastle()
 {
+    assert( arena != nullptr );
+
     return arena->castle;
 }
 
 Battle::Bridge * Battle::Arena::GetBridge()
 {
+    assert( arena != nullptr );
+
     return arena->_bridge.get();
 }
 
 Battle::Board * Battle::Arena::GetBoard()
 {
+    assert( arena != nullptr );
+
     return &arena->board;
 }
 
 Battle::Graveyard * Battle::Arena::GetGraveyard()
 {
+    assert( arena != nullptr );
+
     return &arena->graveyard;
 }
 
 Battle::Interface * Battle::Arena::GetInterface()
 {
+    assert( arena != nullptr );
+
     return arena->_interface.get();
 }
 
 Battle::Tower * Battle::Arena::GetTower( int type )
 {
+    assert( arena != nullptr );
+
     switch ( type ) {
     case TWR_LEFT:
         return arena->_towers[0].get();
@@ -427,20 +439,6 @@ Battle::Arena::Arena( Army & a1, Army & a2, int32_t index, bool local, Rand::Det
 
 Battle::Arena::~Arena()
 {
-    // All members should be destroyed before clearing the global pointer to this Arena object
-    _interface.reset();
-
-    _bridge.reset();
-    _catapult.reset();
-
-    for ( auto & tower : _towers ) {
-        tower.reset();
-    }
-
-    _orderOfUnits.reset();
-    _army2.reset();
-    _army1.reset();
-
     assert( arena == this );
     arena = nullptr;
 }

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -267,7 +267,7 @@ const Castle * Battle::Arena::GetCastle()
 
 Battle::Bridge * Battle::Arena::GetBridge()
 {
-    return arena->bridge;
+    return arena->_bridge.get();
 }
 
 Battle::Board * Battle::Arena::GetBoard()
@@ -289,11 +289,11 @@ Battle::Tower * Battle::Arena::GetTower( int type )
 {
     switch ( type ) {
     case TWR_LEFT:
-        return arena->towers[0];
+        return arena->_towers[0].get();
     case TWR_CENTER:
-        return arena->towers[1];
+        return arena->_towers[1].get();
     case TWR_RIGHT:
-        return arena->towers[2];
+        return arena->_towers[2].get();
     default:
         break;
     }
@@ -304,20 +304,20 @@ bool Battle::Arena::isAnyTowerPresent()
 {
     assert( arena != nullptr );
 
-    return ( arena->towers[0] != nullptr && arena->towers[0]->isValid() ) || ( arena->towers[1] != nullptr && arena->towers[1]->isValid() )
-           || ( arena->towers[2] != nullptr && arena->towers[2]->isValid() );
+    for ( const auto & tower : arena->_towers ) {
+        if ( tower && tower->isValid() ) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 Battle::Arena::Arena( Army & a1, Army & a2, int32_t index, bool local, Rand::DeterministicRandomGenerator & randomGenerator )
-    : army1( nullptr )
-    , army2( nullptr )
-    , armies_order( nullptr )
-    , current_color( Color::NONE )
+    : current_color( Color::NONE )
     , _lastActiveUnitArmyColor( -1 ) // Be aware of unknown color
     , castle( world.getCastleEntrance( Maps::GetPoint( index ) ) )
     , _isTown( castle != nullptr )
-    , catapult( nullptr )
-    , bridge( nullptr )
     , icn_covr( ICN::UNKNOWN )
     , current_turn( 0 )
     , _autoBattleColors( 0 )
@@ -328,8 +328,8 @@ Battle::Arena::Arena( Army & a1, Army & a2, int32_t index, bool local, Rand::Det
     assert( arena == nullptr );
     arena = this;
 
-    army1 = new Force( a1, false, _randomGenerator, _uidGenerator );
-    army2 = new Force( a2, true, _randomGenerator, _uidGenerator );
+    _army1 = std::make_unique<Force>( a1, false, _randomGenerator, _uidGenerator );
+    _army2 = std::make_unique<Force>( a2, true, _randomGenerator, _uidGenerator );
 
     // init castle (interface ahead)
     if ( castle ) {
@@ -349,9 +349,9 @@ Battle::Arena::Arena( Army & a1, Army & a2, int32_t index, bool local, Rand::Det
         _interface = std::make_unique<Interface>( *this, index );
         board.SetArea( _interface->GetArea() );
 
-        armies_order = new Units();
-        armies_order->reserve( 25 );
-        _interface->SetArmiesOrder( armies_order );
+        _orderOfUnits = std::make_shared<Units>();
+        _orderOfUnits->reserve( 25 );
+        _interface->SetOrderOfUnits( _orderOfUnits );
     }
     else {
         // no interface - force auto battle mode for human player
@@ -363,18 +363,22 @@ Battle::Arena::Arena( Army & a1, Army & a2, int32_t index, bool local, Rand::Det
         }
     }
 
-    towers[0] = nullptr;
-    towers[1] = nullptr;
-    towers[2] = nullptr;
-
     if ( castle ) {
-        // init
-        towers[0] = castle->isBuild( BUILD_LEFTTURRET ) ? new Tower( *castle, TWR_LEFT, _randomGenerator, _uidGenerator.GetUnique() ) : nullptr;
-        towers[1] = new Tower( *castle, TWR_CENTER, _randomGenerator, _uidGenerator.GetUnique() );
-        towers[2] = castle->isBuild( BUILD_RIGHTTURRET ) ? new Tower( *castle, TWR_RIGHT, _randomGenerator, _uidGenerator.GetUnique() ) : nullptr;
+        if ( castle->isBuild( BUILD_LEFTTURRET ) ) {
+            _towers[0] = std::make_unique<Tower>( *castle, TWR_LEFT, _randomGenerator, _uidGenerator.GetUnique() );
+        }
 
-        catapult = army1->GetCommander() ? new Catapult( *army1->GetCommander(), _randomGenerator ) : nullptr;
-        bridge = new Bridge();
+        _towers[1] = std::make_unique<Tower>( *castle, TWR_CENTER, _randomGenerator, _uidGenerator.GetUnique() );
+
+        if ( castle->isBuild( BUILD_RIGHTTURRET ) ) {
+            _towers[2] = std::make_unique<Tower>( *castle, TWR_RIGHT, _randomGenerator, _uidGenerator.GetUnique() );
+        }
+
+        if ( _army1->GetCommander() ) {
+            _catapult = std::make_unique<Catapult>( *_army1->GetCommander(), _randomGenerator );
+        }
+
+        _bridge = std::make_unique<Bridge>();
 
         // catapult cell
         board[CATAPULT_POS].SetObject( 1 );
@@ -430,15 +434,18 @@ Battle::Arena::Arena( Army & a1, Army & a2, int32_t index, bool local, Rand::Det
 Battle::Arena::~Arena()
 {
     // All members should be destroyed before clearing the global pointer to this Arena object
-    delete army1;
-    delete army2;
-    delete towers[0];
-    delete towers[1];
-    delete towers[2];
-    delete catapult;
     _interface.reset();
-    delete armies_order;
-    delete bridge;
+
+    _bridge.reset();
+    _catapult.reset();
+
+    for ( auto & tower : _towers ) {
+        tower.reset();
+    }
+
+    _orderOfUnits.reset();
+    _army2.reset();
+    _army1.reset();
 
     assert( arena == this );
     arena = nullptr;
@@ -501,9 +508,9 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
             ApplyAction( actions.front() );
             actions.pop_front();
 
-            if ( armies_order ) {
+            if ( _orderOfUnits ) {
                 // Applied action could kill someone or affect the speed of some unit, update the order of units
-                UpdateOrderOfUnits( *army1, *army2, troop, GetOppositeColor( troop->GetArmyColor() ), orderHistory, *armies_order );
+                UpdateOrderOfUnits( *_army1, *_army2, troop, GetOppositeColor( troop->GetArmyColor() ), orderHistory, *_orderOfUnits );
             }
 
             // Check if the battle is over
@@ -531,7 +538,7 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
 
 bool Battle::Arena::BattleValid() const
 {
-    return army1->isValid() && army2->isValid() && 0 == result_game.army1 && 0 == result_game.army2;
+    return _army1->isValid() && _army2->isValid() && 0 == result_game.army1 && 0 == result_game.army2;
 }
 
 void Battle::Arena::Turns()
@@ -546,17 +553,17 @@ void Battle::Arena::Turns()
         _interface->RedrawActionNewTurn();
     }
 
-    army1->NewTurn();
-    army2->NewTurn();
+    _army1->NewTurn();
+    _army2->NewTurn();
 
     // History of unit order on the current turn
     Units orderHistory;
 
-    if ( armies_order ) {
+    if ( _orderOfUnits ) {
         orderHistory.reserve( 25 );
 
         // Build the initial order of units
-        UpdateOrderOfUnits( *army1, *army2, nullptr, GetOppositeColor( _lastActiveUnitArmyColor ), orderHistory, *armies_order );
+        UpdateOrderOfUnits( *_army1, *_army2, nullptr, GetOppositeColor( _lastActiveUnitArmyColor ), orderHistory, *_orderOfUnits );
     }
 
     {
@@ -564,7 +571,7 @@ void Battle::Arena::Turns()
         bool catapultActed = false;
 
         while ( BattleValid() ) {
-            Unit * troop = GetCurrentUnit( *army1, *army2, true, GetOppositeColor( _lastActiveUnitArmyColor ) );
+            Unit * troop = GetCurrentUnit( *_army1, *_army2, true, GetOppositeColor( _lastActiveUnitArmyColor ) );
             if ( troop == nullptr ) {
                 // All units either finished their turns or decided to wait (if supported)
                 break;
@@ -572,35 +579,35 @@ void Battle::Arena::Turns()
 
             current_color = troop->GetCurrentOrArmyColor();
 
-            if ( armies_order ) {
+            if ( _orderOfUnits ) {
                 // Add unit to the history
                 orderHistory.push_back( troop );
 
                 // Update the order of units
-                UpdateOrderOfUnits( *army1, *army2, troop, GetOppositeColor( troop->GetArmyColor() ), orderHistory, *armies_order );
+                UpdateOrderOfUnits( *_army1, *_army2, troop, GetOppositeColor( troop->GetArmyColor() ), orderHistory, *_orderOfUnits );
             }
 
             // Castle towers and catapult are acting during the turn of the first unit from the corresponding army
             if ( castle ) {
-                if ( !catapultActed && troop->GetColor() == army1->GetColor() ) {
+                if ( !catapultActed && troop->GetColor() == _army1->GetColor() ) {
                     CatapultAction();
 
                     catapultActed = true;
                 }
 
-                if ( !towersActed && troop->GetColor() == army2->GetColor() ) {
+                if ( !towersActed && troop->GetColor() == _army2->GetColor() ) {
                     auto towerAction = [this, &orderHistory, troop]( const size_t idx ) {
-                        assert( idx < std::size( towers ) );
+                        assert( idx < std::size( _towers ) );
 
-                        if ( towers[idx] == nullptr || !towers[idx]->isValid() ) {
+                        if ( _towers[idx] == nullptr || !_towers[idx]->isValid() ) {
                             return;
                         }
 
-                        TowerAction( *towers[idx] );
+                        TowerAction( *_towers[idx] );
 
-                        if ( armies_order ) {
+                        if ( _orderOfUnits ) {
                             // Tower could kill someone, update the order of units
-                            UpdateOrderOfUnits( *army1, *army2, troop, GetOppositeColor( troop->GetArmyColor() ), orderHistory, *armies_order );
+                            UpdateOrderOfUnits( *_army1, *_army2, troop, GetOppositeColor( troop->GetArmyColor() ), orderHistory, *_orderOfUnits );
                         }
                     };
 
@@ -617,13 +624,13 @@ void Battle::Arena::Turns()
                 }
             }
 
-            if ( bridge ) {
-                bridge->SetPassable( *troop );
+            if ( _bridge ) {
+                _bridge->SetPassable( *troop );
             }
 
             TurnTroop( troop, orderHistory );
 
-            if ( armies_order ) {
+            if ( _orderOfUnits ) {
                 // If unit hasn't finished its turn yet, then remove it from the history
                 if ( troop->Modes( TR_SKIPMOVE ) && !troop->Modes( TR_MOVED ) ) {
                     orderHistory.pop_back();
@@ -634,7 +641,7 @@ void Battle::Arena::Turns()
 
     if ( conf.ExtBattleSoftWait() ) {
         while ( BattleValid() ) {
-            Unit * troop = GetCurrentUnit( *army1, *army2, false, GetOppositeColor( _lastActiveUnitArmyColor ) );
+            Unit * troop = GetCurrentUnit( *_army1, *_army2, false, GetOppositeColor( _lastActiveUnitArmyColor ) );
             if ( troop == nullptr ) {
                 // All units have finished their turns
                 break;
@@ -642,16 +649,16 @@ void Battle::Arena::Turns()
 
             current_color = troop->GetCurrentOrArmyColor();
 
-            if ( armies_order ) {
+            if ( _orderOfUnits ) {
                 // Add unit to the history
                 orderHistory.push_back( troop );
 
                 // Update the order of units
-                UpdateOrderOfUnits( *army1, *army2, troop, GetOppositeColor( troop->GetArmyColor() ), orderHistory, *armies_order );
+                UpdateOrderOfUnits( *_army1, *_army2, troop, GetOppositeColor( troop->GetArmyColor() ), orderHistory, *_orderOfUnits );
             }
 
-            if ( bridge ) {
-                bridge->SetPassable( *troop );
+            if ( _bridge ) {
+                _bridge->SetPassable( *troop );
             }
 
             TurnTroop( troop, orderHistory );
@@ -659,30 +666,30 @@ void Battle::Arena::Turns()
     }
 
     // Check if the battle is over
-    if ( !army1->isValid() || ( result_game.army1 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
+    if ( !_army1->isValid() || ( result_game.army1 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
         result_game.army1 |= RESULT_LOSS;
         // Check if any of the original troops in the army2 are still alive
-        result_game.army2 = army2->isValid( false ) ? RESULT_WINS : RESULT_LOSS;
+        result_game.army2 = _army2->isValid( false ) ? RESULT_WINS : RESULT_LOSS;
     }
-    else if ( !army2->isValid() || ( result_game.army2 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
+    else if ( !_army2->isValid() || ( result_game.army2 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
         result_game.army2 |= RESULT_LOSS;
         // Check if any of the original troops in the army1 are still alive
-        result_game.army1 = army1->isValid( false ) ? RESULT_WINS : RESULT_LOSS;
+        result_game.army1 = _army1->isValid( false ) ? RESULT_WINS : RESULT_LOSS;
     }
 
     // If the battle is over, calculate the experience and the number of units killed
     if ( result_game.army1 || result_game.army2 ) {
-        result_game.exp1 = army2->GetDeadHitPoints();
-        result_game.exp2 = army1->GetDeadHitPoints();
+        result_game.exp1 = _army2->GetDeadHitPoints();
+        result_game.exp2 = _army1->GetDeadHitPoints();
 
-        if ( army1->GetCommander() && !( result_game.army1 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
+        if ( _army1->GetCommander() && !( result_game.army1 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
             result_game.exp2 += 500;
         }
-        if ( ( _isTown || army2->GetCommander() ) && !( result_game.army2 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
+        if ( ( _isTown || _army2->GetCommander() ) && !( result_game.army2 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
             result_game.exp1 += 500;
         }
 
-        const Force * army_loss = ( result_game.army1 & RESULT_LOSS ? army1 : ( result_game.army2 & RESULT_LOSS ? army2 : nullptr ) );
+        const Force * army_loss = ( result_game.army1 & RESULT_LOSS ? _army1.get() : ( result_game.army2 & RESULT_LOSS ? _army2.get() : nullptr ) );
         result_game.killed = army_loss ? army_loss->GetDeadCounts() : 0;
     }
 }
@@ -732,8 +739,8 @@ void Battle::Arena::TowerAction( const Tower & twr )
 
 void Battle::Arena::CatapultAction()
 {
-    if ( catapult ) {
-        uint32_t shots = catapult->GetShots();
+    if ( _catapult ) {
+        uint32_t shots = _catapult->GetShots();
         std::vector<uint32_t> values( CAT_CENTRAL_TOWER + 1, 0 );
 
         values[CAT_WALL1] = GetCastleTargetValue( CAT_WALL1 );
@@ -750,9 +757,9 @@ void Battle::Arena::CatapultAction()
         cmd << shots;
 
         while ( shots-- ) {
-            const int target = catapult->GetTarget( values );
-            const uint32_t damage = std::min( catapult->GetDamage(), values[target] );
-            const bool hit = catapult->IsNextShotHit();
+            const int target = _catapult->GetTarget( values );
+            const uint32_t damage = std::min( _catapult->GetDamage(), values[target] );
+            const bool hit = _catapult->IsNextShotHit();
 
             cmd << target << damage << ( hit ? 1 : 0 );
 
@@ -869,22 +876,22 @@ const Battle::Unit * Battle::Arena::GetTroopBoard( int32_t index ) const
 
 const HeroBase * Battle::Arena::GetCommander1() const
 {
-    return army1->GetCommander();
+    return _army1->GetCommander();
 }
 
 const HeroBase * Battle::Arena::GetCommander2() const
 {
-    return army2->GetCommander();
+    return _army2->GetCommander();
 }
 
 int Battle::Arena::GetArmyColor1() const
 {
-    return army1->GetColor();
+    return _army1->GetColor();
 }
 
 int Battle::Arena::GetArmyColor2() const
 {
-    return army2->GetColor();
+    return _army2->GetColor();
 }
 
 int Battle::Arena::GetCurrentColor() const
@@ -899,26 +906,26 @@ int Battle::Arena::GetOppositeColor( const int col ) const
 
 Battle::Unit * Battle::Arena::GetTroopUID( uint32_t uid )
 {
-    Units::iterator it = std::find_if( army1->begin(), army1->end(), [uid]( const Unit * unit ) { return unit->isUID( uid ); } );
+    Units::iterator it = std::find_if( _army1->begin(), _army1->end(), [uid]( const Unit * unit ) { return unit->isUID( uid ); } );
 
-    if ( it != army1->end() )
+    if ( it != _army1->end() )
         return *it;
 
-    it = std::find_if( army2->begin(), army2->end(), [uid]( const Unit * unit ) { return unit->isUID( uid ); } );
+    it = std::find_if( _army2->begin(), _army2->end(), [uid]( const Unit * unit ) { return unit->isUID( uid ); } );
 
-    return it != army2->end() ? *it : nullptr;
+    return it != _army2->end() ? *it : nullptr;
 }
 
 const Battle::Unit * Battle::Arena::GetTroopUID( uint32_t uid ) const
 {
-    Units::const_iterator it = std::find_if( army1->begin(), army1->end(), [uid]( const Unit * unit ) { return unit->isUID( uid ); } );
+    Units::const_iterator it = std::find_if( _army1->begin(), _army1->end(), [uid]( const Unit * unit ) { return unit->isUID( uid ); } );
 
-    if ( it != army1->end() )
+    if ( it != _army1->end() )
         return *it;
 
-    it = std::find_if( army2->begin(), army2->end(), [uid]( const Unit * unit ) { return unit->isUID( uid ); } );
+    it = std::find_if( _army2->begin(), _army2->end(), [uid]( const Unit * unit ) { return unit->isUID( uid ); } );
 
-    return it != army2->end() ? *it : nullptr;
+    return it != _army2->end() ? *it : nullptr;
 }
 
 void Battle::Arena::FadeArena( bool clearMessageLog ) const
@@ -935,10 +942,10 @@ const SpellStorage & Battle::Arena::GetUsageSpells() const
 int32_t Battle::Arena::GetFreePositionNearHero( const int heroColor ) const
 {
     std::vector<int> cellIds;
-    if ( army1->GetColor() == heroColor ) {
+    if ( _army1->GetColor() == heroColor ) {
         cellIds = { 11, 22, 33 };
     }
-    else if ( army2->GetColor() == heroColor ) {
+    else if ( _army2->GetColor() == heroColor ) {
         cellIds = { 21, 32, 43 };
     }
     else {
@@ -970,17 +977,17 @@ bool Battle::Arena::CanSurrenderOpponent( int color ) const
 bool Battle::Arena::CanRetreatOpponent( int color ) const
 {
     const HeroBase * hero = getCommander( color );
-    return hero && hero->isHeroes() && ( color == army1->GetColor() || hero->inCastle() == nullptr );
+    return hero && hero->isHeroes() && ( color == _army1->GetColor() || hero->inCastle() == nullptr );
 }
 
 bool Battle::Arena::isSpellcastDisabled() const
 {
-    const HeroBase * hero1 = army1->GetCommander();
+    const HeroBase * hero1 = _army1->GetCommander();
     if ( hero1 != nullptr && hero1->GetBagArtifacts().isArtifactBonusPresent( fheroes2::ArtifactBonusType::DISABLE_ALL_SPELL_COMBAT_CASTING ) ) {
         return true;
     }
 
-    const HeroBase * hero2 = army2->GetCommander();
+    const HeroBase * hero2 = _army2->GetCommander();
     if ( hero2 != nullptr && hero2->GetBagArtifacts().isArtifactBonusPresent( fheroes2::ArtifactBonusType::DISABLE_ALL_SPELL_COMBAT_CASTING ) ) {
         return true;
     }
@@ -1133,29 +1140,29 @@ void Battle::Arena::SetCastleTargetValue( int target, uint32_t value )
         break;
 
     case CAT_TOWER1:
-        if ( towers[0] && towers[0]->isValid() )
-            towers[0]->SetDestroy();
+        if ( _towers[0] && _towers[0]->isValid() )
+            _towers[0]->SetDestroy();
         break;
     case CAT_TOWER2:
-        if ( towers[2] && towers[2]->isValid() )
-            towers[2]->SetDestroy();
+        if ( _towers[2] && _towers[2]->isValid() )
+            _towers[2]->SetDestroy();
         break;
     case CAT_CENTRAL_TOWER:
-        if ( towers[1] && towers[1]->isValid() )
-            towers[1]->SetDestroy();
+        if ( _towers[1] && _towers[1]->isValid() )
+            _towers[1]->SetDestroy();
         break;
 
     case CAT_BRIDGE:
-        if ( bridge->isValid() ) {
-            if ( !bridge->isDown() ) {
+        if ( _bridge->isValid() ) {
+            if ( !_bridge->isDown() ) {
                 if ( _interface ) {
                     _interface->RedrawBridgeAnimation( true );
                 }
 
-                bridge->SetDown( true );
+                _bridge->SetDown( true );
             }
 
-            bridge->SetDestroy();
+            _bridge->SetDestroy();
         }
         break;
 
@@ -1177,14 +1184,14 @@ uint32_t Battle::Arena::GetCastleTargetValue( int target ) const
         return board[CASTLE_FOURTH_TOP_WALL_POS].GetObject();
 
     case CAT_TOWER1:
-        return towers[0] && towers[0]->isValid();
+        return _towers[0] && _towers[0]->isValid() ? 1 : 0;
     case CAT_TOWER2:
-        return towers[2] && towers[2]->isValid();
+        return _towers[2] && _towers[2]->isValid() ? 1 : 0;
     case CAT_CENTRAL_TOWER:
-        return towers[1] && towers[1]->isValid();
+        return _towers[1] && _towers[1]->isValid() ? 1 : 0;
 
     case CAT_BRIDGE:
-        return bridge->isValid();
+        return _bridge->isValid() ? 1 : 0;
 
     default:
         break;
@@ -1208,9 +1215,9 @@ std::vector<int> Battle::Arena::GetCastleTargets() const
         targets.push_back( CAT_WALL4 );
 
     // check right/left towers
-    if ( towers[0] && towers[0]->isValid() )
+    if ( _towers[0] && _towers[0]->isValid() )
         targets.push_back( CAT_TOWER1 );
-    if ( towers[2] && towers[2]->isValid() )
+    if ( _towers[2] && _towers[2]->isValid() )
         targets.push_back( CAT_TOWER2 );
 
     return targets;
@@ -1218,12 +1225,12 @@ std::vector<int> Battle::Arena::GetCastleTargets() const
 
 const HeroBase * Battle::Arena::getCommander( const int color ) const
 {
-    return ( army1->GetColor() == color ) ? army1->GetCommander() : army2->GetCommander();
+    return ( _army1->GetColor() == color ) ? _army1->GetCommander() : _army2->GetCommander();
 }
 
 const HeroBase * Battle::Arena::getEnemyCommander( const int color ) const
 {
-    return ( army1->GetColor() == color ) ? army2->GetCommander() : army1->GetCommander();
+    return ( _army1->GetColor() == color ) ? _army2->GetCommander() : _army1->GetCommander();
 }
 
 const HeroBase * Battle::Arena::GetCurrentCommander() const
@@ -1247,7 +1254,7 @@ Battle::Unit * Battle::Arena::CreateElemental( const Spell & spell )
 
     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, mons.GetName() << ", position: " << idx )
 
-    const bool reflect = ( hero == army2->GetCommander() );
+    const bool reflect = ( hero == _army2->GetCommander() );
     const uint32_t count = fheroes2::getSummonMonsterCount( spell, hero->GetPower(), hero );
 
     Position pos;
@@ -1331,22 +1338,22 @@ bool Battle::Arena::IsShootingPenalty( const Unit & attacker, const Unit & defen
 
 Battle::Force & Battle::Arena::GetForce1() const
 {
-    return *army1;
+    return *_army1;
 }
 
 Battle::Force & Battle::Arena::GetForce2() const
 {
-    return *army2;
+    return *_army2;
 }
 
 Battle::Force & Battle::Arena::getForce( const int color ) const
 {
-    return ( army1->GetColor() == color ) ? *army1 : *army2;
+    return ( _army1->GetColor() == color ) ? *_army1 : *_army2;
 }
 
 Battle::Force & Battle::Arena::getEnemyForce( const int color ) const
 {
-    return ( army1->GetColor() == color ) ? *army2 : *army1;
+    return ( _army1->GetColor() == color ) ? *_army2 : *_army1;
 }
 
 Battle::Force & Battle::Arena::GetCurrentForce() const

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -321,7 +321,7 @@ Battle::Arena::Arena( Army & a1, Army & a2, int32_t index, bool local, Rand::Det
     , interface( nullptr )
     , icn_covr( ICN::UNKNOWN )
     , current_turn( 0 )
-    , auto_battle( 0 )
+    , _autoBattleColors( 0 )
     , _randomGenerator( randomGenerator )
 {
     usage_spells.reserve( 20 );
@@ -357,10 +357,10 @@ Battle::Arena::Arena( Army & a1, Army & a2, int32_t index, bool local, Rand::Det
     else {
         // no interface - force auto battle mode for human player
         if ( a1.isControlHuman() ) {
-            auto_battle |= a1.GetColor();
+            _autoBattleColors |= a1.GetColor();
         }
         if ( a2.isControlHuman() ) {
-            auto_battle |= a2.GetColor();
+            _autoBattleColors |= a2.GetColor();
         }
     }
 
@@ -484,7 +484,7 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
             if ( troop->isControlRemote() ) {
                 RemoteTurn( *troop, actions );
             }
-            else if ( ( troop->GetCurrentControl() & CONTROL_AI ) || ( troop->GetCurrentColor() & auto_battle ) ) {
+            else if ( ( troop->GetCurrentControl() & CONTROL_AI ) || ( troop->GetCurrentColor() & _autoBattleColors ) ) {
                 AI::Get().BattleTurn( *this, *troop, actions );
             }
             else {
@@ -1375,7 +1375,7 @@ Battle::Result & Battle::Arena::GetResult()
 
 bool Battle::Arena::AutoBattleInProgress() const
 {
-    return ( auto_battle & current_color ) && !( GetCurrentForce().GetControl() & CONTROL_AI );
+    return ( _autoBattleColors & current_color ) && !( GetCurrentForce().GetControl() & CONTROL_AI );
 }
 
 bool Battle::Arena::CanToggleAutoBattle() const

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -304,13 +304,7 @@ bool Battle::Arena::isAnyTowerPresent()
 {
     assert( arena != nullptr );
 
-    for ( const auto & tower : arena->_towers ) {
-        if ( tower && tower->isValid() ) {
-            return true;
-        }
-    }
-
-    return false;
+    return std::any_of( arena->_towers.begin(), arena->_towers.end(), []( const auto & twr ) { return twr && twr->isValid(); } );
 }
 
 Battle::Arena::Arena( Army & a1, Army & a2, int32_t index, bool local, Rand::DeterministicRandomGenerator & randomGenerator )

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -878,12 +878,12 @@ const HeroBase * Battle::Arena::GetCommander2() const
     return _army2->GetCommander();
 }
 
-int Battle::Arena::GetArmyColor1() const
+int Battle::Arena::GetArmy1Color() const
 {
     return _army1->GetColor();
 }
 
-int Battle::Arena::GetArmyColor2() const
+int Battle::Arena::GetArmy2Color() const
 {
     return _army2->GetColor();
 }
@@ -895,7 +895,7 @@ int Battle::Arena::GetCurrentColor() const
 
 int Battle::Arena::GetOppositeColor( const int col ) const
 {
-    return col == GetArmyColor1() ? GetArmyColor2() : GetArmyColor1();
+    return col == GetArmy1Color() ? GetArmy2Color() : GetArmy1Color();
 }
 
 Battle::Unit * Battle::Arena::GetTroopUID( uint32_t uid )

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -1372,7 +1372,14 @@ Battle::Result & Battle::Arena::GetResult()
 
 bool Battle::Arena::AutoBattleInProgress() const
 {
-    return ( _autoBattleColors & current_color ) && !( GetCurrentForce().GetControl() & CONTROL_AI );
+    if ( _autoBattleColors & current_color ) {
+        // Auto battle mode cannot be enabled for a player controlled by AI
+        assert( !( GetCurrentForce().GetControl() & CONTROL_AI ) );
+
+        return true;
+    }
+
+    return false;
 }
 
 bool Battle::Arena::CanToggleAutoBattle() const

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -203,7 +203,7 @@ namespace Battle
         void SetCastleTargetValue( int, uint32_t );
         void CatapultAction();
 
-        static TargetsInfo GetTargetsForDamage( const Unit & attacker, Unit & defender, const int32_t dst, const int dir );
+        TargetsInfo GetTargetsForDamage( const Unit & attacker, Unit & defender, const int32_t dst, const int dir ) const;
 
         static void TargetsApplyDamage( Unit & attacker, TargetsInfo & targets );
         static void TargetsApplySpell( const HeroBase * hero, const Spell & spell, TargetsInfo & targets );
@@ -240,9 +240,9 @@ namespace Battle
         // position, which should be updated separately.
         Unit * CreateMirrorImage( Unit & unit );
 
-        Force * army1;
-        Force * army2;
-        Units * armies_order;
+        std::unique_ptr<Force> _army1;
+        std::unique_ptr<Force> _army2;
+        std::shared_ptr<Units> _orderOfUnits;
 
         int current_color;
         // The color of the army of the last unit that performed a full-fledged action (skipping a turn due to
@@ -252,9 +252,9 @@ namespace Battle
         const Castle * castle;
         const bool _isTown; // If the battle is in town (village or castle).
 
-        Tower * towers[3];
-        Catapult * catapult;
-        Bridge * bridge;
+        std::unique_ptr<Tower> _towers[3];
+        std::unique_ptr<Catapult> _catapult;
+        std::unique_ptr<Bridge> _bridge;
 
         std::unique_ptr<Interface> _interface;
         Result result_game;

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -106,8 +106,8 @@ namespace Battle
         Force & getEnemyForce( const int color ) const;
         Force & GetCurrentForce() const;
 
-        int GetArmyColor1() const;
-        int GetArmyColor2() const;
+        int GetArmy1Color() const;
+        int GetArmy2Color() const;
         int GetCurrentColor() const;
         // Returns the color of the army opposite to the army of the given color. If there is no army of the given color,
         // returns the color of the attacking army.

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -222,7 +222,8 @@ namespace Battle
         void ApplyActionSpellCast( Command & );
         void ApplyActionTower( Command & );
         void ApplyActionCatapult( Command & );
-        void ApplyActionAutoBattle( Command & );
+        void ApplyActionAutoSwitch( Command & cmd );
+        void ApplyActionAutoFinish( const Command & cmd );
 
         // Performs an actual attack of one unit (defender) by another unit (attacker), applying the attacker's
         // built-in magic, if necessary. If the given index of the target cell of the attack (dst) is negative,

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -24,6 +24,7 @@
 #ifndef H2BATTLE_ARENA_H
 #define H2BATTLE_ARENA_H
 
+#include <array>
 #include <cstdint>
 #include <list>
 #include <memory>
@@ -252,7 +253,7 @@ namespace Battle
         const Castle * castle;
         const bool _isTown; // If the battle is in town (village or castle).
 
-        std::unique_ptr<Tower> _towers[3];
+        std::array<std::unique_ptr<Tower>, 3> _towers;
         std::unique_ptr<Catapult> _catapult;
         std::unique_ptr<Bridge> _bridge;
 

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 #include <list>
+#include <memory>
 #include <utility>
 
 #include "battle.h"
@@ -254,7 +255,7 @@ namespace Battle
         Catapult * catapult;
         Bridge * bridge;
 
-        Interface * interface;
+        std::unique_ptr<Interface> _interface;
         Result result_game;
 
         Graveyard graveyard;

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -265,7 +265,8 @@ namespace Battle
         int icn_covr;
 
         uint32_t current_turn;
-        int auto_battle;
+        // A set of colors of players for whom the auto-battle mode is enabled
+        int _autoBattleColors;
 
         Rand::DeterministicRandomGenerator & _randomGenerator;
 

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -104,6 +104,8 @@ void Battle::Board::Reset()
 void Battle::Board::SetPositionQuality( const Unit & b ) const
 {
     const Arena * arena = GetArena();
+    assert( arena != nullptr );
+
     Units enemies( arena->getEnemyForce( b.GetCurrentColor() ).getUnits(), true );
 
     // Make sure archers are first here, so melee unit's score won't be double counted
@@ -135,6 +137,8 @@ void Battle::Board::SetPositionQuality( const Unit & b ) const
 void Battle::Board::SetEnemyQuality( const Unit & unit ) const
 {
     const Arena * arena = GetArena();
+    assert( arena != nullptr );
+
     Units enemies( arena->getEnemyForce( unit.GetColor() ).getUnits(), true );
     if ( unit.Modes( SP_BERSERKER ) ) {
         Units allies( arena->getForce( unit.GetColor() ).getUnits(), true );

--- a/src/fheroes2/battle/battle_command.cpp
+++ b/src/fheroes2/battle/battle_command.cpp
@@ -54,12 +54,13 @@ Battle::Command::Command( const CommandType cmd, const int param1, const int par
     : _type( cmd )
 {
     switch ( _type ) {
-    case CommandType::MSG_BATTLE_AUTO:
+    case CommandType::MSG_BATTLE_AUTO_SWITCH:
         *this << param1; // color
         break;
 
     case CommandType::MSG_BATTLE_SURRENDER:
     case CommandType::MSG_BATTLE_RETREAT:
+    case CommandType::MSG_BATTLE_AUTO_FINISH:
         break;
 
     case CommandType::MSG_BATTLE_TOWER:

--- a/src/fheroes2/battle/battle_command.h
+++ b/src/fheroes2/battle/battle_command.h
@@ -43,7 +43,8 @@ namespace Battle
         MSG_BATTLE_SURRENDER,
         MSG_BATTLE_SKIP,
         MSG_BATTLE_END_TURN,
-        MSG_BATTLE_AUTO
+        MSG_BATTLE_AUTO_SWITCH,
+        MSG_BATTLE_AUTO_FINISH
     };
 
     class Command : public std::vector<int>

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -406,8 +406,8 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     LocalEvent & le = LocalEvent::Get();
     const Settings & conf = Settings::Get();
 
-    const Troops killed1 = army1->GetKilledTroops();
-    const Troops killed2 = army2->GetKilledTroops();
+    const Troops killed1 = _army1->GetKilledTroops();
+    const Troops killed2 = _army2->GetKilledTroops();
 
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
@@ -416,20 +416,20 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     std::string title;
     LoopedAnimationSequence sequence;
 
-    if ( ( res.army1 & RESULT_WINS ) && ( army1->GetControl() & CONTROL_HUMAN ) ) {
-        GetSummaryParams( res.army1, res.army2, army1->GetCommander(), res.exp1, sequence, title, msg );
+    if ( ( res.army1 & RESULT_WINS ) && ( _army1->GetControl() & CONTROL_HUMAN ) ) {
+        GetSummaryParams( res.army1, res.army2, _army1->GetCommander(), res.exp1, sequence, title, msg );
         AudioManager::PlayMusic( MUS::BATTLEWIN, Music::PlaybackMode::PLAY_ONCE );
     }
-    else if ( ( res.army2 & RESULT_WINS ) && ( army2->GetControl() & CONTROL_HUMAN ) ) {
-        GetSummaryParams( res.army2, res.army1, army2->GetCommander(), res.exp2, sequence, title, msg );
+    else if ( ( res.army2 & RESULT_WINS ) && ( _army2->GetControl() & CONTROL_HUMAN ) ) {
+        GetSummaryParams( res.army2, res.army1, _army2->GetCommander(), res.exp2, sequence, title, msg );
         AudioManager::PlayMusic( MUS::BATTLEWIN, Music::PlaybackMode::PLAY_ONCE );
     }
-    else if ( army1->GetControl() & CONTROL_HUMAN ) {
-        GetSummaryParams( res.army1, res.army2, army1->GetCommander(), res.exp1, sequence, title, msg );
+    else if ( _army1->GetControl() & CONTROL_HUMAN ) {
+        GetSummaryParams( res.army1, res.army2, _army1->GetCommander(), res.exp1, sequence, title, msg );
         AudioManager::PlayMusic( MUS::BATTLELOSE, Music::PlaybackMode::PLAY_ONCE );
     }
-    else if ( army2->GetControl() & CONTROL_HUMAN ) {
-        GetSummaryParams( res.army2, res.army1, army2->GetCommander(), res.exp2, sequence, title, msg );
+    else if ( _army2->GetControl() & CONTROL_HUMAN ) {
+        GetSummaryParams( res.army2, res.army1, _army2->GetCommander(), res.exp2, sequence, title, msg );
         AudioManager::PlayMusic( MUS::BATTLELOSE, Music::PlaybackMode::PLAY_ONCE );
     }
     else {
@@ -559,8 +559,8 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     }
 
     if ( !artifacts.empty() ) {
-        const HeroBase * winner = ( res.army1 & RESULT_WINS ? army1->GetCommander() : ( res.army2 & RESULT_WINS ? army2->GetCommander() : nullptr ) );
-        const HeroBase * loser = ( res.army1 & RESULT_LOSS ? army1->GetCommander() : ( res.army2 & RESULT_LOSS ? army2->GetCommander() : nullptr ) );
+        const HeroBase * winner = ( res.army1 & RESULT_WINS ? _army1->GetCommander() : ( res.army2 & RESULT_WINS ? _army2->GetCommander() : nullptr ) );
+        const HeroBase * loser = ( res.army1 & RESULT_LOSS ? _army1->GetCommander() : ( res.army2 & RESULT_LOSS ? _army2->GetCommander() : nullptr ) );
 
         // Can't transfer artifacts
         if ( winner == nullptr || loser == nullptr )

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2408,11 +2408,11 @@ void Battle::Interface::HumanBattleTurn( const Unit & b, Actions & a, std::strin
             EventShowOptions();
         }
         // Switch the auto battle mode on/off
-        else if ( Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_AUTOSWITCH ) ) {
+        else if ( Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_AUTO_SWITCH ) ) {
             EventAutoSwitch( b, a );
         }
         // Finish the battle in auto mode
-        else if ( Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_AUTOFINISH ) ) {
+        else if ( Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_AUTO_FINISH ) ) {
             EventAutoFinish( a );
         }
         // Cast the spell
@@ -5082,7 +5082,7 @@ void Battle::Interface::CheckGlobalEvents( LocalEvent & le )
     if ( arena.AutoBattleInProgress() && arena.CanToggleAutoBattle()
          && ( le.MouseClickLeft( btn_auto.area() )
               || ( le.KeyPress()
-                   && ( Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_AUTOSWITCH )
+                   && ( Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_AUTO_SWITCH )
                         || ( Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL )
                              && Dialog::YES == Dialog::Message( "", _( "Break auto battle?" ), Font::BIG, Dialog::YES | Dialog::NO ) ) ) ) ) ) {
         _breakAutoBattleForColor = arena.GetCurrentColor();

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2728,7 +2728,10 @@ void Battle::Interface::EventAutoSwitch( const Unit & b, Actions & a )
 
 void Battle::Interface::EventAutoFinish( Actions & a )
 {
-    if ( Dialog::Message( "", _( "Are you sure you want to finish the battle in auto mode?" ), Font::BIG, Dialog::YES | Dialog::NO ) != Dialog::YES ) {
+    if ( fheroes2::showMessage( fheroes2::Text( "", {} ),
+                                fheroes2::Text( _( "Are you sure you want to finish the battle in auto mode?" ), fheroes2::FontType::normalWhite() ),
+                                Dialog::YES | Dialog::NO )
+         != Dialog::YES ) {
         return;
     }
 
@@ -5088,7 +5091,9 @@ void Battle::Interface::CheckGlobalEvents( LocalEvent & le )
               || ( le.KeyPress()
                    && ( Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_AUTO_SWITCH )
                         || ( Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL )
-                             && Dialog::Message( "", _( "Are you sure you want to interrupt the auto battle?" ), Font::BIG, Dialog::YES | Dialog::NO )
+                             && fheroes2::showMessage( fheroes2::Text( "", {} ),
+                                                       fheroes2::Text( _( "Are you sure you want to interrupt the auto battle?" ), fheroes2::FontType::normalWhite() ),
+                                                       Dialog::YES | Dialog::NO )
                                     == Dialog::YES ) ) ) ) ) {
         _interruptAutoBattleForColor = arena.GetCurrentColor();
     }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -829,21 +829,24 @@ void Battle::ArmiesOrder::QueueEventProcessing( std::string & msg, const fheroes
 {
     LocalEvent & le = LocalEvent::Get();
 
-    for ( std::vector<UnitPos>::const_iterator it = _rects.begin(); it != _rects.end(); ++it )
-        if ( ( *it ).first ) {
-            const fheroes2::Rect unitRoi = ( *it ).second + offset;
-            if ( le.MouseCursor( unitRoi ) ) {
-                msg = _( "View %{monster} info" );
-                StringReplace( msg, "%{monster}", ( *it ).first->GetName() );
-            }
+    for ( const UnitPos & unitPos : _rects ) {
+        assert( unitPos.first != nullptr );
 
-            const Unit & unit = *( *it ).first;
-
-            if ( le.MouseClickLeft( unitRoi ) )
-                Dialog::ArmyInfo( unit, Dialog::READONLY | Dialog::BUTTONS, unit.isReflect() );
-            else if ( le.MousePressRight( unitRoi ) )
-                Dialog::ArmyInfo( unit, Dialog::READONLY, unit.isReflect() );
+        const fheroes2::Rect unitRoi = unitPos.second + offset;
+        if ( le.MouseCursor( unitRoi ) ) {
+            msg = _( "View %{monster} info" );
+            StringReplace( msg, "%{monster}", unitPos.first->GetName() );
         }
+
+        const Unit & unit = *( unitPos.first );
+
+        if ( le.MouseClickLeft( unitRoi ) ) {
+            Dialog::ArmyInfo( unit, Dialog::READONLY | Dialog::BUTTONS, unit.isReflect() );
+        }
+        else if ( le.MousePressRight( unitRoi ) ) {
+            Dialog::ArmyInfo( unit, Dialog::READONLY, unit.isReflect() );
+        }
+    }
 }
 
 void Battle::ArmiesOrder::RedrawUnit( const fheroes2::Rect & pos, const Battle::Unit & unit, const bool revert, const bool isCurrentUnit, const uint8_t currentUnitColor,

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2432,14 +2432,14 @@ void Battle::Interface::HumanBattleTurn( const Unit & b, Actions & a, std::strin
         if ( IS_DEVEL() )
             switch ( le.KeyValue() ) {
             case fheroes2::Key::KEY_W:
-                // Win the game instantly
+                // The attacker wins the battle instantly
                 arena.GetResult().army1 = RESULT_WINS;
                 humanturn_exit = true;
                 a.emplace_back( CommandType::MSG_BATTLE_END_TURN, b.GetUID() );
                 break;
 
             case fheroes2::Key::KEY_L:
-                // Lose the game instantly
+                // The attacker loses the battle instantly
                 arena.GetResult().army1 = RESULT_LOSS;
                 humanturn_exit = true;
                 a.emplace_back( CommandType::MSG_BATTLE_END_TURN, b.GetUID() );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1123,7 +1123,7 @@ Battle::Interface::~Interface()
 
 void Battle::Interface::SetOrderOfUnits( const std::shared_ptr<const Units> & units )
 {
-    armies_order.Set( GetArea(), units, arena.GetArmyColor2() );
+    armies_order.Set( GetArea(), units, arena.GetArmy2Color() );
 }
 
 fheroes2::Point Battle::Interface::GetMouseCursor() const
@@ -1428,7 +1428,7 @@ void Battle::Interface::RedrawOpponentsFlags()
     if ( opponent1 ) {
         int icn = ICN::UNKNOWN;
 
-        switch ( arena.GetArmyColor1() ) {
+        switch ( arena.GetArmy1Color() ) {
         case Color::BLUE:
             icn = ICN::HEROFL00;
             break;
@@ -2514,7 +2514,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & b, Actions & a, std::strin
     }
     else if ( opponent1 && le.MouseCursor( opponent1->GetArea() + _interfacePosition.getPosition() ) ) {
         const fheroes2::Rect opponent1Area = opponent1->GetArea() + _interfacePosition.getPosition();
-        if ( arena.GetCurrentColor() == arena.GetArmyColor1() ) {
+        if ( arena.GetCurrentColor() == arena.GetArmy1Color() ) {
             msg = _( "View Hero's options" );
             cursor.SetThemes( Cursor::WAR_HERO );
 
@@ -3181,7 +3181,7 @@ void Battle::Interface::RedrawActionWincesKills( const TargetsInfo & targets, Un
     }
 
     if ( deathColor != Color::UNUSED ) {
-        const bool attackersTurn = deathColor == arena.GetArmyColor2();
+        const bool attackersTurn = deathColor == arena.GetArmy2Color();
         OpponentSprite * attackingHero = attackersTurn ? opponent1 : opponent2;
         OpponentSprite * defendingHero = attackersTurn ? opponent2 : opponent1;
         // 60% of joyful animation
@@ -3502,7 +3502,7 @@ void Battle::Interface::RedrawActionSpellCastPart1( const Spell & spell, int32_t
 
     // set spell cast animation
     if ( caster ) {
-        OpponentSprite * opponent = caster->GetColor() == arena.GetArmyColor1() ? opponent1 : opponent2;
+        OpponentSprite * opponent = caster->GetColor() == arena.GetArmy1Color() ? opponent1 : opponent2;
         if ( opponent ) {
             opponent->SetAnimation( spell.isApplyWithoutFocusObject() ? OP_CAST_MASS : OP_CAST_UP );
             AnimateOpponents( opponent );
@@ -3652,7 +3652,7 @@ void Battle::Interface::RedrawActionSpellCastPart1( const Spell & spell, int32_t
     }
 
     if ( caster ) {
-        OpponentSprite * opponent = caster->GetColor() == arena.GetArmyColor1() ? opponent1 : opponent2;
+        OpponentSprite * opponent = caster->GetColor() == arena.GetArmy1Color() ? opponent1 : opponent2;
         if ( opponent ) {
             opponent->SetAnimation( ( target != nullptr ) ? OP_CAST_UP_RETURN : OP_CAST_MASS_RETURN );
             AnimateOpponents( opponent );

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -344,6 +344,7 @@ namespace Battle
         void ProcessingHeroDialogResult( int, Actions & );
 
         void EventAutoSwitch( const Unit &, Actions & );
+        void EventAutoFinish( Actions & a );
         void EventShowOptions();
         void ButtonAutoAction( const Unit &, Actions & );
         void ButtonSettingsAction();

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -24,6 +24,7 @@
 #ifndef H2BATTLE_INTERFACE_H
 #define H2BATTLE_INTERFACE_H
 
+#include <memory>
 #include <string>
 
 #include "battle_animation.h"
@@ -182,7 +183,7 @@ namespace Battle
 
         ArmiesOrder & operator=( const ArmiesOrder & ) = delete;
 
-        void Set( const fheroes2::Rect &, const Units *, int );
+        void Set( const fheroes2::Rect & rt, const std::shared_ptr<const Units> & units, const int army2Color );
         void Redraw( const Unit * current, const uint8_t currentUnitColor, fheroes2::Image & output );
         void QueueEventProcessing( std::string & msg, const fheroes2::Point & offset );
 
@@ -204,10 +205,10 @@ namespace Battle
         void RedrawUnit( const fheroes2::Rect & pos, const Battle::Unit & unit, const bool revert, const bool isCurrentUnit, const uint8_t currentUnitColor,
                          fheroes2::Image & output ) const;
 
-        const Units * orders;
-        int army_color2;
-        fheroes2::Rect area;
-        std::vector<UnitPos> rects;
+        std::weak_ptr<const Units> _orders;
+        int _army2Color;
+        fheroes2::Rect _area;
+        std::vector<UnitPos> _rects;
     };
 
     class PopupDamageInfo : public Dialog::FrameBorder
@@ -257,7 +258,7 @@ namespace Battle
         fheroes2::Point GetMouseCursor() const;
 
         void SetStatus( const std::string &, bool = false );
-        void SetArmiesOrder( const Units * );
+        void SetOrderOfUnits( const std::shared_ptr<const Units> & units );
         void FadeArena( bool clearMessageLog );
 
         void RedrawActionNewTurn() const;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -385,7 +385,7 @@ namespace Battle
         uint32_t animation_flags_frame;
         int catapult_frame;
 
-        int _breakAutoBattleForColor;
+        int _interruptAutoBattleForColor;
 
         uint8_t _contourColor;
         bool _brightLandType; // used to determine current monster contour cycling colors

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -177,7 +177,7 @@ void Battle::Unit::SetReflection( bool r )
 void Battle::Unit::UpdateDirection()
 {
     // set auto reflect
-    SetReflection( GetArena()->GetArmyColor1() != GetArmyColor() );
+    SetReflection( GetArena()->GetArmy1Color() != GetArmyColor() );
 }
 
 bool Battle::Unit::UpdateDirection( const fheroes2::Rect & pos )

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -176,8 +176,10 @@ void Battle::Unit::SetReflection( bool r )
 
 void Battle::Unit::UpdateDirection()
 {
-    // set auto reflect
-    SetReflection( GetArena()->GetArmy1Color() != GetArmyColor() );
+    const Arena * arena = GetArena();
+    assert( arena != nullptr );
+
+    SetReflection( arena->GetArmy1Color() != GetArmyColor() );
 }
 
 bool Battle::Unit::UpdateDirection( const fheroes2::Rect & pos )
@@ -260,11 +262,15 @@ uint32_t Battle::Unit::GetSpeed() const
 
 int Battle::Unit::GetMorale() const
 {
+    const Arena * arena = GetArena();
+    assert( arena != nullptr );
+
     int armyTroopMorale = ArmyTroop::GetMorale();
 
     // enemy Bone dragons affect morale
-    if ( isAffectedByMorale() && GetArena()->getEnemyForce( GetArmyColor() ).HasMonster( Monster::BONE_DRAGON ) && armyTroopMorale > Morale::TREASON )
+    if ( isAffectedByMorale() && arena->getEnemyForce( GetArmyColor() ).HasMonster( Monster::BONE_DRAGON ) && armyTroopMorale > Morale::TREASON ) {
         --armyTroopMorale;
+    }
 
     return armyTroopMorale;
 }
@@ -505,13 +511,18 @@ uint32_t Battle::Unit::CalculateDamageUnit( const Unit & enemy, double dmg ) con
                 dmg += ( dmg * GetCommander()->GetSecondaryValues( Skill::Secondary::ARCHERY ) / 100 );
             }
 
+            const Arena * arena = GetArena();
+            assert( arena != nullptr );
+
             // check castle defense
-            if ( GetArena()->IsShootingPenalty( *this, enemy ) )
+            if ( arena->IsShootingPenalty( *this, enemy ) ) {
                 dmg /= 2;
+            }
 
             // check spell shield
-            if ( enemy.Modes( SP_SHIELD ) )
+            if ( enemy.Modes( SP_SHIELD ) ) {
                 dmg /= Spell( Spell::SHIELD ).ExtraValue();
+            }
         }
         else if ( !isAbilityPresent( fheroes2::MonsterAbilityType::NO_MELEE_PENALTY ) ) {
             dmg /= 2;
@@ -1679,12 +1690,16 @@ int Battle::Unit::GetColor() const
 
 int Battle::Unit::GetCurrentColor() const
 {
-    if ( Modes( SP_BERSERKER ) )
+    if ( Modes( SP_BERSERKER ) ) {
         return -1; // be aware of unknown color
-    else if ( Modes( SP_HYPNOTIZE ) )
-        return GetArena()->GetOppositeColor( GetArmyColor() );
+    }
+    else if ( Modes( SP_HYPNOTIZE ) ) {
+        const Arena * arena = GetArena();
+        assert( arena != nullptr );
 
-    // default
+        return arena->GetOppositeColor( GetArmyColor() );
+    }
+
     return GetColor();
 }
 
@@ -1701,15 +1716,15 @@ int Battle::Unit::GetCurrentOrArmyColor() const
 
 int Battle::Unit::GetCurrentControl() const
 {
-    if ( Modes( SP_BERSERKER ) )
+    if ( Modes( SP_BERSERKER ) ) {
         return CONTROL_AI; // let's say that it belongs to AI which is not present in the battle
+    }
 
     if ( Modes( SP_HYPNOTIZE ) ) {
-        const int color = GetCurrentColor();
-        if ( color == GetArena()->GetForce1().GetColor() )
-            return GetArena()->GetForce1().GetControl();
-        else
-            return GetArena()->GetForce2().GetControl();
+        const Arena * arena = GetArena();
+        assert( arena != nullptr );
+
+        return arena->getForce( GetCurrentColor() ).GetControl();
     }
 
     return GetControl();
@@ -1722,5 +1737,8 @@ const HeroBase * Battle::Unit::GetCommander() const
 
 const HeroBase * Battle::Unit::GetCurrentOrArmyCommander() const
 {
-    return GetArena()->getCommander( GetCurrentOrArmyColor() );
+    const Arena * arena = GetArena();
+    assert( arena != nullptr );
+
+    return arena->getCommander( GetCurrentOrArmyColor() );
 }

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1693,7 +1693,8 @@ int Battle::Unit::GetCurrentColor() const
     if ( Modes( SP_BERSERKER ) ) {
         return -1; // be aware of unknown color
     }
-    else if ( Modes( SP_HYPNOTIZE ) ) {
+
+    if ( Modes( SP_HYPNOTIZE ) ) {
         const Arena * arena = GetArena();
         assert( arena != nullptr );
 

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -160,6 +160,7 @@ namespace
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::BATTLE_RETREAT )] = { HotKeyCategory::BATTLE, "retreat from battle", fheroes2::Key::KEY_R };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::BATTLE_SURRENDER )] = { HotKeyCategory::BATTLE, "surrender during battle", fheroes2::Key::KEY_S };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::BATTLE_AUTOSWITCH )] = { HotKeyCategory::BATTLE, "toggle battle auto mode", fheroes2::Key::KEY_A };
+        hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::BATTLE_AUTOFINISH )] = { HotKeyCategory::BATTLE, "finish the battle in auto mode", fheroes2::Key::KEY_Q };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::BATTLE_OPTIONS )] = { HotKeyCategory::BATTLE, "battle options", fheroes2::Key::KEY_O };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::BATTLE_SKIP )] = { HotKeyCategory::BATTLE, "skip turn in battle", fheroes2::Key::KEY_SPACE };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::BATTLE_WAIT )] = { HotKeyCategory::BATTLE, "wait in battle", fheroes2::Key::KEY_W };

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -159,8 +159,8 @@ namespace
 
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::BATTLE_RETREAT )] = { HotKeyCategory::BATTLE, "retreat from battle", fheroes2::Key::KEY_R };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::BATTLE_SURRENDER )] = { HotKeyCategory::BATTLE, "surrender during battle", fheroes2::Key::KEY_S };
-        hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::BATTLE_AUTOSWITCH )] = { HotKeyCategory::BATTLE, "toggle battle auto mode", fheroes2::Key::KEY_A };
-        hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::BATTLE_AUTOFINISH )] = { HotKeyCategory::BATTLE, "finish the battle in auto mode", fheroes2::Key::KEY_Q };
+        hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::BATTLE_AUTO_SWITCH )] = { HotKeyCategory::BATTLE, "toggle battle auto mode", fheroes2::Key::KEY_A };
+        hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::BATTLE_AUTO_FINISH )] = { HotKeyCategory::BATTLE, "finish the battle in auto mode", fheroes2::Key::KEY_Q };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::BATTLE_OPTIONS )] = { HotKeyCategory::BATTLE, "battle options", fheroes2::Key::KEY_O };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::BATTLE_SKIP )] = { HotKeyCategory::BATTLE, "skip turn in battle", fheroes2::Key::KEY_SPACE };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::BATTLE_WAIT )] = { HotKeyCategory::BATTLE, "wait in battle", fheroes2::Key::KEY_W };

--- a/src/fheroes2/game/game_hotkeys.h
+++ b/src/fheroes2/game/game_hotkeys.h
@@ -105,6 +105,7 @@ namespace Game
         BATTLE_RETREAT,
         BATTLE_SURRENDER,
         BATTLE_AUTOSWITCH,
+        BATTLE_AUTOFINISH,
         BATTLE_OPTIONS,
         BATTLE_SKIP,
         BATTLE_WAIT,

--- a/src/fheroes2/game/game_hotkeys.h
+++ b/src/fheroes2/game/game_hotkeys.h
@@ -104,8 +104,8 @@ namespace Game
 
         BATTLE_RETREAT,
         BATTLE_SURRENDER,
-        BATTLE_AUTOSWITCH,
-        BATTLE_AUTOFINISH,
+        BATTLE_AUTO_SWITCH,
+        BATTLE_AUTO_FINISH,
         BATTLE_OPTIONS,
         BATTLE_SKIP,
         BATTLE_WAIT,


### PR DESCRIPTION
close #5626

Currently, only the hotkey can be used (`Q` by default - yes, just like in HoTA). There is no graphical button for this.

https://user-images.githubusercontent.com/32623900/185990658-f3099b04-7db1-4e0b-af83-760fa9d26b35.mp4

Currently, this works both in single-player and in hotseat mode, because, since now both human players are able to use the instant battle and auto combat, I do not see a reason to disable the instant finish in hotseat (and yes, it is convenient for debugging as well).

Also this PR fixes potential issues with non-deterministic random generator for Genie attack, Chain Lighting troop resistance and Earth Quake damage.