### PR TITLE
View Puzzle screen, wandering creatures and campfires should not be displayed

### DIFF
--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -464,7 +464,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
             }
 
             case MP2::OBJ_MONSTER: {
-                if ( isPuzzleDraw && !drawHeroes ) {
+                if ( isPuzzleDraw ) {
                     continue;
                 }
 

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -464,6 +464,10 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
             }
 
             case MP2::OBJ_MONSTER: {
+                if ( !drawHeroes ) {
+                    continue;
+                }
+
                 const uint8_t alphaValue = getObjectAlphaValue( tile.GetIndex(), MP2::OBJ_MONSTER );
 
                 auto spriteInfo = tile.getMonsterSpritesPerTile();

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -464,7 +464,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
             }
 
             case MP2::OBJ_MONSTER: {
-                if ( !drawHeroes ) {
+                if ( isPuzzleDraw && !drawHeroes ) {
                     continue;
                 }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1291,9 +1291,7 @@ void Maps::Tiles::redrawBottomLayerObjects( fheroes2::Image & dst, bool isPuzzle
     }
 
     if ( objectTileset != 0 && ( _level & 0x03 ) == level && ( !isPuzzleDraw || !MP2::isHiddenForPuzzle( GetGround(), objectTileset, objectIndex ) ) ) {
-        if ( !isPuzzleDraw && mp2_object == MP2::OBJ_CAMPFIRE ) {
-            renderMainObject( dst, area, mp );
-        }
+        renderMainObject( dst, area, mp );
     }
 
     for ( const TilesAddon * addon : postRenderingAddon ) {

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1291,7 +1291,9 @@ void Maps::Tiles::redrawBottomLayerObjects( fheroes2::Image & dst, bool isPuzzle
     }
 
     if ( objectTileset != 0 && ( _level & 0x03 ) == level && ( !isPuzzleDraw || !MP2::isHiddenForPuzzle( GetGround(), objectTileset, objectIndex ) ) ) {
-        renderMainObject( dst, area, mp );
+        if ( !isPuzzleDraw && mp2_object == MP2::OBJ_CAMPFIRE ){
+            renderMainObject( dst, area, mp );
+        }
     }
 
     for ( const TilesAddon * addon : postRenderingAddon ) {

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1291,7 +1291,7 @@ void Maps::Tiles::redrawBottomLayerObjects( fheroes2::Image & dst, bool isPuzzle
     }
 
     if ( objectTileset != 0 && ( _level & 0x03 ) == level && ( !isPuzzleDraw || !MP2::isHiddenForPuzzle( GetGround(), objectTileset, objectIndex ) ) ) {
-        if ( !isPuzzleDraw && mp2_object == MP2::OBJ_CAMPFIRE ){
+        if ( !isPuzzleDraw && mp2_object == MP2::OBJ_CAMPFIRE ) {
             renderMainObject( dst, area, mp );
         }
     }

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -191,7 +191,7 @@ int MP2::GetICNObject( const uint8_t tileset )
 bool MP2::isHiddenForPuzzle( const int terrainType, uint8_t tileset, uint8_t index )
 {
     const int icnID = tileset >> 2;
-    if ( icnID < 22 || icnID == 46 || ( icnID == 56 && index == 140 ) ) {
+    if ( icnID < 22 || icnID == 46 || ( icnID == 56 && index == 140 ) || ( icnID == 59 && index >= 124 && index <= 137 ) ) {
         return true;
     }
 


### PR DESCRIPTION
fix for #5780

@oleg-derevenetz @ihhub @idshibanov, how do you see, guys, the proper way to move this condition:
```
if ( !isPuzzleDraw && mp2_object == MP2::OBJ_CAMPFIRE ) {
            renderMainObject( dst, area, mp );
}
```
inside `isHiddenForPuzzle` function?