### PR TITLE
gcc-13: add missing '#include <cstdint>'

### DIFF
--- a/src/fheroes2/game/game_over.h
+++ b/src/fheroes2/game/game_over.h
@@ -24,6 +24,7 @@
 #ifndef H2GAMEOVER_H
 #define H2GAMEOVER_H
 
+#include <cstdint>
 #include <string>
 
 #include "game_mode.h"

--- a/src/fheroes2/kingdom/color.h
+++ b/src/fheroes2/kingdom/color.h
@@ -23,6 +23,7 @@
 #ifndef H2COLOR_H
 #define H2COLOR_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/fheroes2/spell/spell_info.h
+++ b/src/fheroes2/spell/spell_info.h
@@ -21,6 +21,7 @@
 #ifndef H2_SPELL_INFO_H
 #define H2_SPELL_INFO_H
 
+#include <cstdint>
 #include <string>
 
 class Castle;


### PR DESCRIPTION
Without the change build fails on weekly `gcc-13` snapshot as:

    ../fheroes2/spell/spell_info.h:33:5: error: 'uint32_t' does not name a type
       33 |     uint32_t getSpellDamage( const Spell & spell, const uint32_t spellPower, const HeroBase * hero );
          |     ^~~~~~~~
    ../fheroes2/spell/spell_info.h:25:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
       24 | #include <string>
      +++ |+#include <cstdint>