### PR TITLE
Implement some improvements when exchanging an army between heroes

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -415,7 +415,7 @@ void Troops::JoinTroops( Troops & troops2 )
         }
 }
 
-void Troops::MoveTroops( Troops & from, const int monsterToKeep /* = Monster::UNKNOWN */, const bool keepInSrc /* = true */ )
+void Troops::MoveTroops( Troops & from, const int monsterToKeep )
 {
     assert( this != &from );
 
@@ -425,15 +425,13 @@ void Troops::MoveTroops( Troops & from, const int monsterToKeep /* = Monster::UN
 
     assert( isValid() && from.isValid() );
 
-    // The monster to keep is chosen from the destination stack set
-    if ( monsterToKeep != Monster::UNKNOWN && !keepInSrc ) {
+    if ( monsterToKeep != Monster::UNKNOWN ) {
         // Find a troop stack in the destination stack set consisting of monsters we need to keep
         const auto keepIter = std::find_if( begin(), end(), [monsterToKeep]( const Troop * troop ) {
             assert( troop != nullptr );
 
             return troop->isValid() && troop->GetMonster() == monsterToKeep;
         } );
-        assert( keepIter != end() );
 
         // Find a troop stack in the source stack set consisting of monsters of a different type than the monster we need to keep
         const auto destIter = std::find_if( from.begin(), from.end(), [monsterToKeep]( const Troop * troop ) {
@@ -442,10 +440,9 @@ void Troops::MoveTroops( Troops & from, const int monsterToKeep /* = Monster::UN
             return troop->isValid() && troop->GetMonster() != monsterToKeep;
         } );
 
-        // If we found one, then exchange the monster to keep in the destination stack set with this troop stack. If we didn't find
-        // one, then this means that the source stack set after optimization consists of a single troop stack of monsters to keep
-        // and no additional actions are needed.
-        if ( destIter != from.end() ) {
+        // If we found both, then exchange the monster to keep in the destination stack set with the found troop stack in the
+        // source stack set to concentrate all the monsters to keep in the source stack set
+        if ( keepIter != end() && destIter != from.end() ) {
             Troop * keep = *keepIter;
             Troop * dest = *destIter;
 

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -490,14 +490,13 @@ void Troops::MoveTroops( Troops & from, const int monsterToKeep /* = Monster::UN
 
             break;
         }
-        else {
-            assert( remaining > 1 );
 
-            if ( JoinTroop( *troop ) ) {
-                troop->Reset();
+        assert( remaining > 1 );
 
-                --remaining;
-            }
+        if ( JoinTroop( *troop ) ) {
+            troop->Reset();
+
+            --remaining;
         }
     }
 

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -415,7 +415,7 @@ void Troops::JoinTroops( Troops & troops2 )
         }
 }
 
-void Troops::MoveTroops( Troops & from, const int monsterToKeep )
+void Troops::MoveTroops( Troops & from, const int monsterIdToKeep )
 {
     assert( this != &from );
 
@@ -425,19 +425,19 @@ void Troops::MoveTroops( Troops & from, const int monsterToKeep )
 
     assert( isValid() && from.isValid() );
 
-    if ( monsterToKeep != Monster::UNKNOWN ) {
+    if ( monsterIdToKeep != Monster::UNKNOWN ) {
         // Find a troop stack in the destination stack set consisting of monsters we need to keep
-        const auto keepIter = std::find_if( begin(), end(), [monsterToKeep]( const Troop * troop ) {
+        const auto keepIter = std::find_if( begin(), end(), [monsterIdToKeep]( const Troop * troop ) {
             assert( troop != nullptr );
 
-            return troop->isValid() && troop->GetID() == monsterToKeep;
+            return troop->isValid() && troop->GetID() == monsterIdToKeep;
         } );
 
         // Find a troop stack in the source stack set consisting of monsters of a different type than the monster we need to keep
-        const auto destIter = std::find_if( from.begin(), from.end(), [monsterToKeep]( const Troop * troop ) {
+        const auto destIter = std::find_if( from.begin(), from.end(), [monsterIdToKeep]( const Troop * troop ) {
             assert( troop != nullptr );
 
-            return troop->isValid() && troop->GetID() != monsterToKeep;
+            return troop->isValid() && troop->GetID() != monsterIdToKeep;
         } );
 
         // If we found both, then exchange the monster to keep in the destination stack set with the found troop stack in the
@@ -456,7 +456,7 @@ void Troops::MoveTroops( Troops & from, const int monsterToKeep )
 
             dest->Reset();
 
-            if ( !from.JoinTroop( Monster( monsterToKeep ), count ) ) {
+            if ( !from.JoinTroop( Monster( monsterIdToKeep ), count ) ) {
                 assert( 0 );
             }
         }
@@ -472,7 +472,7 @@ void Troops::MoveTroops( Troops & from, const int monsterToKeep )
             continue;
         }
 
-        if ( troop->GetID() == monsterToKeep ) {
+        if ( troop->GetID() == monsterIdToKeep ) {
             keep = troop;
 
             continue;

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -430,14 +430,14 @@ void Troops::MoveTroops( Troops & from, const int monsterToKeep )
         const auto keepIter = std::find_if( begin(), end(), [monsterToKeep]( const Troop * troop ) {
             assert( troop != nullptr );
 
-            return troop->isValid() && troop->GetMonster() == monsterToKeep;
+            return troop->isValid() && troop->GetID() == monsterToKeep;
         } );
 
         // Find a troop stack in the source stack set consisting of monsters of a different type than the monster we need to keep
         const auto destIter = std::find_if( from.begin(), from.end(), [monsterToKeep]( const Troop * troop ) {
             assert( troop != nullptr );
 
-            return troop->isValid() && troop->GetMonster() != monsterToKeep;
+            return troop->isValid() && troop->GetID() != monsterToKeep;
         } );
 
         // If we found both, then exchange the monster to keep in the destination stack set with the found troop stack in the
@@ -456,7 +456,7 @@ void Troops::MoveTroops( Troops & from, const int monsterToKeep )
 
             dest->Reset();
 
-            if ( !from.JoinTroop( monsterToKeep, count ) ) {
+            if ( !from.JoinTroop( Monster( monsterToKeep ), count ) ) {
                 assert( 0 );
             }
         }
@@ -472,7 +472,7 @@ void Troops::MoveTroops( Troops & from, const int monsterToKeep )
             continue;
         }
 
-        if ( troop->GetMonster() == monsterToKeep ) {
+        if ( troop->GetID() == monsterToKeep ) {
             keep = troop;
 
             continue;

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -415,7 +415,7 @@ void Troops::JoinTroops( Troops & troops2 )
         }
 }
 
-void Troops::MoveTroops( Troops & from, const int monsterToKeep /* = Monster::UNKNOWN */, const bool keepFrom /* = true */ )
+void Troops::MoveTroops( Troops & from, const int monsterToKeep /* = Monster::UNKNOWN */, const bool keepInSrc /* = true */ )
 {
     assert( this != &from );
 
@@ -426,7 +426,7 @@ void Troops::MoveTroops( Troops & from, const int monsterToKeep /* = Monster::UN
     assert( isValid() && from.isValid() );
 
     // The monster to keep is chosen from the destination stack set
-    if ( monsterToKeep != Monster::UNKNOWN && !keepFrom ) {
+    if ( monsterToKeep != Monster::UNKNOWN && !keepInSrc ) {
         // Find a troop stack in the destination stack set consisting of monsters we need to keep
         const auto keepIter = std::find_if( begin(), end(), [monsterToKeep]( const Troop * troop ) {
             assert( troop != nullptr );

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -427,7 +427,7 @@ void Troops::MoveTroops( Troops & from, const int monsterToKeep /* = Monster::UN
 
     // The monster to keep is chosen from the destination stack set
     if ( monsterToKeep != Monster::UNKNOWN && !keepFrom ) {
-        // Find a troop stack in the source stack set consisting of monsters we need to keep
+        // Find a troop stack in the destination stack set consisting of monsters we need to keep
         const auto keepIter = std::find_if( begin(), end(), [monsterToKeep]( const Troop * troop ) {
             assert( troop != nullptr );
 
@@ -442,9 +442,9 @@ void Troops::MoveTroops( Troops & from, const int monsterToKeep /* = Monster::UN
             return troop->isValid() && troop->GetMonster() != monsterToKeep;
         } );
 
-        // If we found one, then exchange the monster to keep in the source stack set with this troop stack. If we didn't find one,
-        // then this means that the source stack set after optimization consists of a single troop stack of monsters to keep and no
-        // additional actions are needed.
+        // If we found one, then exchange the monster to keep in the destination stack set with this troop stack. If we didn't find
+        // one, then this means that the source stack set after optimization consists of a single troop stack of monsters to keep
+        // and no additional actions are needed.
         if ( destIter != from.end() ) {
             Troop * keep = *keepIter;
             Troop * dest = *destIter;

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -462,7 +462,7 @@ void Troops::MoveTroops( Troops & from, const int monsterToKeep )
         }
     }
 
-    uint32_t remaining = from.GetCount();
+    uint32_t stacksLeft = from.GetCount();
     Troop * keep = nullptr;
 
     for ( Troop * troop : from ) {
@@ -478,7 +478,7 @@ void Troops::MoveTroops( Troops & from, const int monsterToKeep )
             continue;
         }
 
-        if ( remaining == 1 ) {
+        if ( stacksLeft == 1 ) {
             // This is the last valid troop stack in the source stack set, try to join all but one monsters from this stack and
             // then stop in any case
             if ( JoinTroop( troop->GetMonster(), troop->GetCount() - 1 ) ) {
@@ -488,12 +488,12 @@ void Troops::MoveTroops( Troops & from, const int monsterToKeep )
             break;
         }
 
-        assert( remaining > 1 );
+        assert( stacksLeft > 1 );
 
         if ( JoinTroop( *troop ) ) {
             troop->Reset();
 
-            --remaining;
+            --stacksLeft;
         }
     }
 

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -434,7 +434,7 @@ void Troops::MoveTroops( Troops & from, const int monsterIdToKeep )
         } );
 
         // Find a troop stack in the source stack set consisting of monsters of a different type than the monster we need to keep
-        const auto destIter = std::find_if( from.begin(), from.end(), [monsterIdToKeep]( const Troop * troop ) {
+        const auto xchgIter = std::find_if( from.begin(), from.end(), [monsterIdToKeep]( const Troop * troop ) {
             assert( troop != nullptr );
 
             return troop->isValid() && troop->GetID() != monsterIdToKeep;
@@ -442,19 +442,19 @@ void Troops::MoveTroops( Troops & from, const int monsterIdToKeep )
 
         // If we found both, then exchange the monster to keep in the destination stack set with the found troop stack in the
         // source stack set to concentrate all the monsters to keep in the source stack set
-        if ( keepIter != end() && destIter != from.end() ) {
+        if ( keepIter != end() && xchgIter != from.end() ) {
             Troop * keep = *keepIter;
-            Troop * dest = *destIter;
+            Troop * xchg = *xchgIter;
 
             const uint32_t count = keep->GetCount();
 
             keep->Reset();
 
-            if ( !JoinTroop( *dest ) ) {
+            if ( !JoinTroop( *xchg ) ) {
                 assert( 0 );
             }
 
-            dest->Reset();
+            xchg->Reset();
 
             if ( !from.JoinTroop( Monster( monsterIdToKeep ), count ) ) {
                 assert( 0 );

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -73,6 +73,7 @@ public:
     bool HasMonster( const Monster & ) const;
 
     bool AllTroopsAreUndead() const;
+    // Returns true if all valid troops have the same ID or if there are no troops, otherwise returns false
     bool AllTroopsAreTheSame() const;
 
     bool JoinTroop( const Troop & );
@@ -82,8 +83,9 @@ public:
     void JoinTroops( Troops & );
     bool CanJoinTroops( const Troops & ) const;
 
-    // Used only for moving full army in hero's meeting dialog.
-    void MoveTroops( const Troops & from );
+    // Implements the necessary logic to move unit stacks from army to army using the arrow buttons in the
+    // hero's meeting dialog
+    void MoveTroops( Troops & from, const int monsterToKeep = Monster::UNKNOWN, const bool keepFrom = true );
 
     void MergeTroops();
     Troops GetOptimized() const;

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -85,7 +85,7 @@ public:
 
     // Implements the necessary logic to move unit stacks from army to army using the arrow buttons in the
     // hero's meeting dialog
-    void MoveTroops( Troops & from, const int monsterToKeep );
+    void MoveTroops( Troops & from, const int monsterIdToKeep );
 
     void MergeTroops();
     Troops GetOptimized() const;

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -85,7 +85,7 @@ public:
 
     // Implements the necessary logic to move unit stacks from army to army using the arrow buttons in the
     // hero's meeting dialog
-    void MoveTroops( Troops & from, const int monsterToKeep = Monster::UNKNOWN, const bool keepInSrc = true );
+    void MoveTroops( Troops & from, const int monsterToKeep );
 
     void MergeTroops();
     Troops GetOptimized() const;

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -85,7 +85,7 @@ public:
 
     // Implements the necessary logic to move unit stacks from army to army using the arrow buttons in the
     // hero's meeting dialog
-    void MoveTroops( Troops & from, const int monsterToKeep = Monster::UNKNOWN, const bool keepFrom = true );
+    void MoveTroops( Troops & from, const int monsterToKeep = Monster::UNKNOWN, const bool keepInSrc = true );
 
     void MergeTroops();
     Troops GetOptimized() const;

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <cassert>
 #include <string>
 
 #include "agg_image.h"
@@ -545,7 +546,21 @@ void Heroes::MeetingDialog( Heroes & otherHero )
             display.render();
         }
         else if ( le.MouseClickLeft( moveArmyToHero2.area() ) ) {
-            otherHero.GetArmy().MoveTroops( GetArmy() );
+            if ( selectArmy1.isSelected() ) {
+                const ArmyTroop * troop = selectArmy1.GetSelectedItem();
+                assert( troop != nullptr );
+
+                otherHero.GetArmy().MoveTroops( GetArmy(), troop->GetMonster().GetID(), true );
+            }
+            else if ( selectArmy2.isSelected() ) {
+                const ArmyTroop * troop = selectArmy2.GetSelectedItem();
+                assert( troop != nullptr );
+
+                otherHero.GetArmy().MoveTroops( GetArmy(), troop->GetMonster().GetID(), false );
+            }
+            else {
+                otherHero.GetArmy().MoveTroops( GetArmy() );
+            }
 
             armyCountBackgroundRestorerLeft.restore();
             armyCountBackgroundRestorerRight.restore();
@@ -561,7 +576,21 @@ void Heroes::MeetingDialog( Heroes & otherHero )
             display.render();
         }
         else if ( le.MouseClickLeft( moveArmyToHero1.area() ) ) {
-            GetArmy().MoveTroops( otherHero.GetArmy() );
+            if ( selectArmy1.isSelected() ) {
+                const ArmyTroop * troop = selectArmy1.GetSelectedItem();
+                assert( troop != nullptr );
+
+                GetArmy().MoveTroops( otherHero.GetArmy(), troop->GetMonster().GetID(), false );
+            }
+            else if ( selectArmy2.isSelected() ) {
+                const ArmyTroop * troop = selectArmy2.GetSelectedItem();
+                assert( troop != nullptr );
+
+                GetArmy().MoveTroops( otherHero.GetArmy(), troop->GetMonster().GetID(), true );
+            }
+            else {
+                GetArmy().MoveTroops( otherHero.GetArmy() );
+            }
 
             armyCountBackgroundRestorerLeft.restore();
             armyCountBackgroundRestorerRight.restore();

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -554,7 +554,7 @@ void Heroes::MeetingDialog( Heroes & otherHero )
                 keep = selectArmy2.GetSelectedItem();
             }
 
-            otherHero.GetArmy().MoveTroops( GetArmy(), keep ? keep->GetMonster().GetID() : Monster::UNKNOWN );
+            otherHero.GetArmy().MoveTroops( GetArmy(), keep ? keep->GetID() : Monster::UNKNOWN );
 
             armyCountBackgroundRestorerLeft.restore();
             armyCountBackgroundRestorerRight.restore();
@@ -579,7 +579,7 @@ void Heroes::MeetingDialog( Heroes & otherHero )
                 keep = selectArmy2.GetSelectedItem();
             }
 
-            GetArmy().MoveTroops( otherHero.GetArmy(), keep ? keep->GetMonster().GetID() : Monster::UNKNOWN );
+            GetArmy().MoveTroops( otherHero.GetArmy(), keep ? keep->GetID() : Monster::UNKNOWN );
 
             armyCountBackgroundRestorerLeft.restore();
             armyCountBackgroundRestorerRight.restore();

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -546,21 +546,16 @@ void Heroes::MeetingDialog( Heroes & otherHero )
             display.render();
         }
         else if ( le.MouseClickLeft( moveArmyToHero2.area() ) ) {
-            if ( selectArmy1.isSelected() ) {
-                const ArmyTroop * troop = selectArmy1.GetSelectedItem();
-                assert( troop != nullptr );
+            const ArmyTroop * keep = nullptr;
 
-                otherHero.GetArmy().MoveTroops( GetArmy(), troop->GetMonster().GetID(), true );
+            if ( selectArmy1.isSelected() ) {
+                keep = selectArmy1.GetSelectedItem();
             }
             else if ( selectArmy2.isSelected() ) {
-                const ArmyTroop * troop = selectArmy2.GetSelectedItem();
-                assert( troop != nullptr );
+                keep = selectArmy2.GetSelectedItem();
+            }
 
-                otherHero.GetArmy().MoveTroops( GetArmy(), troop->GetMonster().GetID(), false );
-            }
-            else {
-                otherHero.GetArmy().MoveTroops( GetArmy() );
-            }
+            otherHero.GetArmy().MoveTroops( GetArmy(), keep ? keep->GetMonster().GetID() : Monster::UNKNOWN );
 
             armyCountBackgroundRestorerLeft.restore();
             armyCountBackgroundRestorerRight.restore();
@@ -576,21 +571,16 @@ void Heroes::MeetingDialog( Heroes & otherHero )
             display.render();
         }
         else if ( le.MouseClickLeft( moveArmyToHero1.area() ) ) {
-            if ( selectArmy1.isSelected() ) {
-                const ArmyTroop * troop = selectArmy1.GetSelectedItem();
-                assert( troop != nullptr );
+            const ArmyTroop * keep = nullptr;
 
-                GetArmy().MoveTroops( otherHero.GetArmy(), troop->GetMonster().GetID(), false );
+            if ( selectArmy1.isSelected() ) {
+                keep = selectArmy1.GetSelectedItem();
             }
             else if ( selectArmy2.isSelected() ) {
-                const ArmyTroop * troop = selectArmy2.GetSelectedItem();
-                assert( troop != nullptr );
+                keep = selectArmy2.GetSelectedItem();
+            }
 
-                GetArmy().MoveTroops( otherHero.GetArmy(), troop->GetMonster().GetID(), true );
-            }
-            else {
-                GetArmy().MoveTroops( otherHero.GetArmy() );
-            }
+            GetArmy().MoveTroops( otherHero.GetArmy(), keep ? keep->GetMonster().GetID() : Monster::UNKNOWN );
 
             armyCountBackgroundRestorerLeft.restore();
             armyCountBackgroundRestorerRight.restore();

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -22,7 +22,6 @@
  ***************************************************************************/
 
 #include <algorithm>
-#include <cassert>
 #include <string>
 
 #include "agg_image.h"


### PR DESCRIPTION
While watching [this](https://youtu.be/XckUhRMi3V0), I decided to propose this (debatable of course) PR, which is intended to make it easier for a player to exchange troops between heroes when performing typical PROgamer's 😎 tasks, such as:

* Creating hero chains in which you need to leave fast but relatively weak units to intermediate heroes:

https://user-images.githubusercontent.com/32623900/187012272-a2c47abd-2238-4454-af12-bf60f633462f.mp4

* Speeding heroes up, for which you need to leave just one fastest unit in hero's army:

https://user-images.githubusercontent.com/32623900/187012426-5e686413-232b-4fa3-8a02-a2f5f5c4115b.mp4

https://user-images.githubusercontent.com/32623900/187012432-f910fce7-eb39-4dc9-a9f2-ef3d74f27491.mp4

Hi @ihhub @Branikolog @LeHerosInconnu @zenseii thoughts are welcome. Please note that this solution doesn't assume any modification of original hero meeting screen (there is much less controls on it compared with the similar screen from HoMM3).