### PR TITLE
allow allies attack

### DIFF
--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -482,9 +482,6 @@ int Interface::Basic::GetCursorFocusHeroes( const Heroes & from_hero, const Maps
                 int newcur = Cursor::DistanceThemes( Cursor::CURSOR_HERO_MEET, from_hero.getNumOfTravelDays( tile.GetIndex() ) );
                 return newcur != Cursor::POINTER ? newcur : Cursor::HEROES;
             }
-            else if ( from_hero.isFriends( to_hero->GetColor() ) ) {
-                return Cursor::POINTER;
-            }
             else
                 return Cursor::DistanceThemes( Cursor::CURSOR_HERO_FIGHT, from_hero.getNumOfTravelDays( tile.GetIndex() ) );
         }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -741,12 +741,12 @@ void ActionToHeroes( Heroes & hero, int32_t dst_index )
 
         at_exit = std::shared_ptr<void>( nullptr,
                                          std::bind(
-                                             []( Player * p1, Player * p2 ) {
+                                             []( Player * lp1, Player * lp2 ) {
                                                  fheroes2::showMessage( fheroes2::Text{ _( "You've made yourself another enemy" ), fheroes2::FontType::normalWhite() },
                                                                         fheroes2::Text{ "", fheroes2::FontType::normalWhite() }, Dialog::OK );
 
-                                                 p1->SetFriends( p2->GetColor() );
-                                                 p2->SetFriends( p1->GetColor() );
+                                                 lp1->SetFriends( lp2->GetColor() );
+                                                 lp2->SetFriends( lp1->GetColor() );
                                              },
                                              p1, p2 ) );
     }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -729,15 +729,15 @@ void ActionToHeroes( Heroes & hero, int32_t dst_index )
     else if ( hero.isFriends( other_hero->GetColor() ) ) {
         if ( fheroes2::showMessage( fheroes2::Text{ _( "Are you sure you want to attack your ally?" ), fheroes2::FontType::normalWhite() },
                                     fheroes2::Text{ "", fheroes2::FontType::normalWhite() }, Dialog::YES | Dialog::NO )
-                                        == Dialog::NO ) {
+             == Dialog::NO ) {
             DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " declined attack ally hero " << other_hero->GetName() )
             return;
         }
 
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " confirmed attack ally hero " << other_hero->GetName() )
 
-        auto *p1 = Players::Get( hero.GetColor() );
-        auto *p2 = Players::Get( other_hero->GetColor() );
+        auto * p1 = Players::Get( hero.GetColor() );
+        auto * p2 = Players::Get( other_hero->GetColor() );
 
         at_exit = std::shared_ptr<void>( nullptr,
                                          std::bind(
@@ -749,7 +749,6 @@ void ActionToHeroes( Heroes & hero, int32_t dst_index )
                                                  p2->SetFriends( p1->GetColor() );
                                              },
                                              p1, p2 ) );
-
     }
 
     const Castle * other_hero_castle = other_hero->inCastle();

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -755,7 +755,7 @@ void ActionToHeroes( Heroes & hero, int32_t dst_index )
         auto * p2 = Players::Get( other_hero->GetColor() );
 
         fheroes2::showMessage( fheroes2::Text{ _( "You've made yourself another enemy" ), fheroes2::FontType::normalWhite() },
-                            fheroes2::Text{ "", fheroes2::FontType::normalWhite() }, Dialog::OK );
+                               fheroes2::Text{ "", fheroes2::FontType::normalWhite() }, Dialog::OK );
 
         p1->SetFriends( p2->GetColor() );
         p2->SetFriends( p1->GetColor() );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -715,8 +715,8 @@ void ActionToMonster( Heroes & hero, int32_t dst_index )
 
 void ActionToHeroes( Heroes & hero, int32_t dst_index )
 {
-    std::shared_ptr<void> at_exit;
     Heroes * other_hero = world.GetTiles( dst_index ).GetHeroes();
+    bool makeAllyEnemy = false;
 
     if ( !other_hero )
         return;
@@ -736,19 +736,7 @@ void ActionToHeroes( Heroes & hero, int32_t dst_index )
 
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " confirmed attack ally hero " << other_hero->GetName() )
 
-        auto * p1 = Players::Get( hero.GetColor() );
-        auto * p2 = Players::Get( other_hero->GetColor() );
-
-        at_exit = std::shared_ptr<void>( nullptr,
-                                         std::bind(
-                                             []( Player * lp1, Player * lp2 ) {
-                                                 fheroes2::showMessage( fheroes2::Text{ _( "You've made yourself another enemy" ), fheroes2::FontType::normalWhite() },
-                                                                        fheroes2::Text{ "", fheroes2::FontType::normalWhite() }, Dialog::OK );
-
-                                                 lp1->SetFriends( lp2->GetColor() );
-                                                 lp2->SetFriends( lp1->GetColor() );
-                                             },
-                                             p1, p2 ) );
+        makeAllyEnemy = true;
     }
 
     const Castle * other_hero_castle = other_hero->inCastle();
@@ -761,6 +749,17 @@ void ActionToHeroes( Heroes & hero, int32_t dst_index )
 
     // new battle
     Battle::Result res = Battle::Loader( hero.GetArmy(), other_hero->GetArmy(), dst_index );
+
+    if ( makeAllyEnemy ) {
+        auto * p1 = Players::Get( hero.GetColor() );
+        auto * p2 = Players::Get( other_hero->GetColor() );
+
+        fheroes2::showMessage( fheroes2::Text{ _( "You've made yourself another enemy" ), fheroes2::FontType::normalWhite() },
+                            fheroes2::Text{ "", fheroes2::FontType::normalWhite() }, Dialog::OK );
+
+        p1->SetFriends( p2->GetColor() );
+        p2->SetFriends( p1->GetColor() );
+    }
 
     // TODO: make fading animation of both heroes together.
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -725,20 +725,25 @@ void ActionToHeroes( Heroes & hero, int32_t dst_index )
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " meeting " << other_hero->GetName() )
         hero.MeetingDialog( *other_hero );
     }
-    else if ( hero.isFriends( other_hero->GetColor() ) && fheroes2::showMessage( fheroes2::Text{ _ ( "Are you sure you want to attack your teammate?" ), fheroes2::FontType::normalWhite() },
-        fheroes2::Text{ "", fheroes2::FontType::normalWhite() }, Dialog::YES | Dialog::NO ) == Dialog::YES ) {
+    else if ( hero.isFriends( other_hero->GetColor() )
+              && fheroes2::showMessage( fheroes2::Text{ _ ( "Are you sure you want to attack your teammate?" ), fheroes2::FontType::normalWhite() },
+                 fheroes2::Text{ "", fheroes2::FontType::normalWhite() }, Dialog::YES | Dialog::NO )
+                     == Dialog::YES ) {
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " attack ally hero " << other_hero->GetName() )
 
         auto p1 = Players::Get( hero.GetColor() );
         auto p2 = Players::Get( other_hero->GetColor() );
 
-        at_exit = std::shared_ptr<void>(nullptr, std::bind([]( Player *p1, Player *p2 ){
-            fheroes2::showMessage( fheroes2::Text{ _ ( "You've made yourself another enemy" ), fheroes2::FontType::normalWhite() },
-                fheroes2::Text{ "", fheroes2::FontType::normalWhite() }, Dialog::OK );
+        at_exit = std::shared_ptr<void>( nullptr,
+                                         std::bind(
+                                             []( Player *p1, Player *p2 ) {
+                                                 fheroes2::showMessage( fheroes2::Text{ _ ( "You've made yourself another enemy" ), fheroes2::FontType::normalWhite() },
+                                                                        fheroes2::Text{ "", fheroes2::FontType::normalWhite() }, Dialog::OK );
 
-            p1->SetFriends( p2->GetColor() );
-            p2->SetFriends( p1->GetColor() );
-        }, p1, p2 ) );
+                                                 p1->SetFriends( p2->GetColor() );
+                                                 p2->SetFriends( p1->GetColor() );
+                                             },
+                                             p1, p2 ) );
 
         goto lbattle;
     }

--- a/src/fheroes2/system/players.cpp
+++ b/src/fheroes2/system/players.cpp
@@ -149,7 +149,7 @@ bool Player::isPlay() const
 
 void Player::SetFriends( int f )
 {
-    friends = f;
+    friends &= f; // TODO: may be this is dangerous?
 }
 
 void Player::SetName( const std::string & newName )


### PR DESCRIPTION
question from chat:
```
Thanks, hello. I have a question about computer allies. In fheroes2 I can't attack them but it's possible in the original game. The map Ghost Planet becomes unplayable if I can't attack allies. Maybe this is an oversight? Or is there a way to force attack anyway?
```
tested with suggested map `Ghost Planet`