### PR TITLE
Include rating calculation for Campaign's high score

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -2316,6 +2316,17 @@ namespace fheroes2
 
                 return true;
             }
+            case ICN::HISCORE: {
+                LoadOriginalICN( id );
+                if ( _icnVsSprite[id].size() > 7 ) {
+                    // Campaign title bar needs to include rating.
+                    Sprite temp = _icnVsSprite[id][7];
+
+                    Copy( temp, 215, 0, _icnVsSprite[id][7], 215 - 57, 0, 300, temp.height() );
+                    Copy( _icnVsSprite[id][6], 324, 0, _icnVsSprite[id][7], 324, 0, _icnVsSprite[id][6].width() - 324, temp.height() );
+                }
+                return true;
+            }
             default:
                 break;
             }

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -62,7 +62,8 @@ namespace
     const int32_t ratingOffset = 484;
 
     void redrawHighScoreScreen( int32_t offsetX, int32_t offsetY, uint32_t & monsterAnimationFrameId, const int32_t selectedScoreIndex,
-                                const std::vector<fheroes2::HighscoreData> & highScores, const uint32_t titleImageIndex, std::function<Monster( size_t )> getMonster )
+                                const std::vector<fheroes2::HighscoreData> & highScores, const uint32_t titleImageIndex,
+                                const std::function<Monster( size_t )> & getMonster )
     {
         ++monsterAnimationFrameId;
 

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -62,7 +62,7 @@ namespace
     const int32_t ratingOffset = 484;
 
     void redrawHighScoreScreen( int32_t offsetX, int32_t offsetY, uint32_t & monsterAnimationFrameId, const int32_t selectedScoreIndex,
-                                const std::vector<fheroes2::HighscoreData> & highScores, const uint32_t titleImageIndex, std::function<Monster(size_t)> getMonster )
+                                const std::vector<fheroes2::HighscoreData> & highScores, const uint32_t titleImageIndex, std::function<Monster( size_t )> getMonster )
     {
         ++monsterAnimationFrameId;
 

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -56,20 +56,25 @@ namespace
     const int32_t initialHighScoreEntryOffsetY = 72;
     const int32_t highScoreEntryStepY = 40;
 
-    void RedrawHighScoresStandard( int32_t ox, int32_t oy, uint32_t & monsterAnimationFrameId, const int32_t selectedScoreIndex )
+    const int32_t playerNameOffset = 88;
+    const int32_t scenarioNameOffset = 244;
+    const int32_t dayCountOffset = 403;
+    const int32_t ratingOffset = 484;
+
+    void redrawHighScoreScreen( int32_t offsetX, int32_t offsetY, uint32_t & monsterAnimationFrameId, const int32_t selectedScoreIndex,
+                                const std::vector<fheroes2::HighscoreData> & highScores, const uint32_t titleImageIndex, std::function<Monster(size_t)> getMonster )
     {
         ++monsterAnimationFrameId;
 
         fheroes2::Display & display = fheroes2::Display::instance();
 
         // Draw background.
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::HSBKG, 0 ), display, ox, oy );
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::HISCORE, 6 ), display, ox + 50, oy + 31 );
+        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::HSBKG, 0 ), display, offsetX, offsetY );
+        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::HISCORE, titleImageIndex ), display, offsetX + 50, offsetY + 31 );
 
         fheroes2::Text text( "", fheroes2::FontType::normalWhite() );
 
         const std::array<uint8_t, 15> & monsterAnimationSequence = fheroes2::getMonsterAnimationSequence();
-        const std::vector<fheroes2::HighscoreData> & highScores = highScoreDataContainer.getHighScoresStandard();
 
         int32_t scoreIndex = 0;
 
@@ -77,76 +82,44 @@ namespace
             const fheroes2::FontType font = ( scoreIndex == selectedScoreIndex ) ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite();
 
             text.set( data.playerName, font );
-            text.draw( ox + 88, oy + initialHighScoreEntryOffsetY, display );
+            text.draw( offsetX + playerNameOffset, offsetY + initialHighScoreEntryOffsetY, display );
 
             text.set( data.scenarioName, font );
-            text.draw( ox + 244, oy + initialHighScoreEntryOffsetY, display );
+            text.draw( offsetX + scenarioNameOffset, offsetY + initialHighScoreEntryOffsetY, display );
 
             text.set( std::to_string( data.dayCount ), font );
-            text.draw( ox + 403, oy + initialHighScoreEntryOffsetY, display );
+            text.draw( offsetX + dayCountOffset, offsetY + initialHighScoreEntryOffsetY, display );
 
             text.set( std::to_string( data.rating ), font );
-            text.draw( ox + 484, oy + initialHighScoreEntryOffsetY, display );
+            text.draw( offsetX + ratingOffset, offsetY + initialHighScoreEntryOffsetY, display );
 
-            const Monster monster = fheroes2::HighScoreDataContainer::getMonsterByRating( data.rating );
+            const Monster monster = getMonster( data.rating );
             const uint32_t baseMonsterAnimationIndex = monster.GetSpriteIndex() * 9;
             const fheroes2::Sprite & baseMonsterSprite = fheroes2::AGG::GetICN( ICN::MINIMON, baseMonsterAnimationIndex );
-            fheroes2::Blit( baseMonsterSprite, display, baseMonsterSprite.x() + ox + 554, baseMonsterSprite.y() + oy + 91 );
+            fheroes2::Blit( baseMonsterSprite, display, baseMonsterSprite.x() + offsetX + 554, baseMonsterSprite.y() + offsetY + 91 );
 
             // Animation frame of a creature is based on its position on screen and common animation frame ID.
-            const uint32_t monsterAnimationId = monsterAnimationSequence[( ox + oy + data.dayCount + monsterAnimationFrameId ) % monsterAnimationSequence.size()];
+            const uint32_t monsterAnimationId
+                = monsterAnimationSequence[( offsetX + offsetY + data.dayCount + monsterAnimationFrameId ) % monsterAnimationSequence.size()];
             const uint32_t secondaryMonsterAnimationIndex = baseMonsterAnimationIndex + 1 + monsterAnimationId;
             const fheroes2::Sprite & secondaryMonsterSprite = fheroes2::AGG::GetICN( ICN::MINIMON, secondaryMonsterAnimationIndex );
-            fheroes2::Blit( secondaryMonsterSprite, display, secondaryMonsterSprite.x() + ox + 554, secondaryMonsterSprite.y() + oy + 91 );
+            fheroes2::Blit( secondaryMonsterSprite, display, secondaryMonsterSprite.x() + offsetX + 554, secondaryMonsterSprite.y() + offsetY + 91 );
 
-            oy += highScoreEntryStepY;
+            offsetY += highScoreEntryStepY;
             ++scoreIndex;
         }
     }
 
+    void RedrawHighScoresStandard( int32_t ox, int32_t oy, uint32_t & monsterAnimationFrameId, const int32_t selectedScoreIndex )
+    {
+        redrawHighScoreScreen( ox, oy, monsterAnimationFrameId, selectedScoreIndex, highScoreDataContainer.getHighScoresStandard(), 6,
+                               fheroes2::HighScoreDataContainer::getMonsterByRating );
+    }
+
     void RedrawHighScoresCampaign( int32_t ox, int32_t oy, uint32_t & monsterAnimationFrameId, const int32_t selectedScoreIndex )
     {
-        ++monsterAnimationFrameId;
-
-        fheroes2::Display & display = fheroes2::Display::instance();
-
-        // Draw background.
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::HSBKG, 0 ), display, ox, oy );
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::HISCORE, 7 ), display, ox + 50, oy + 31 );
-
-        fheroes2::Text text( "", fheroes2::FontType::normalWhite() );
-
-        const std::array<uint8_t, 15> & monsterAnimationSequence = fheroes2::getMonsterAnimationSequence();
-        const std::vector<fheroes2::HighscoreData> & highScores = highScoreDataContainer.getHighScoresCampaign();
-
-        int32_t scoreIndex = 0;
-
-        for ( const fheroes2::HighscoreData & data : highScores ) {
-            const fheroes2::FontType font = ( scoreIndex == selectedScoreIndex ) ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite();
-
-            text.set( data.playerName, font );
-            text.draw( ox + 88, oy + initialHighScoreEntryOffsetY, display );
-
-            text.set( data.scenarioName, font );
-            text.draw( ox + 280, oy + initialHighScoreEntryOffsetY, display );
-
-            text.set( std::to_string( data.dayCount ), font );
-            text.draw( ox + 455, oy + initialHighScoreEntryOffsetY, display );
-
-            const Monster monster = fheroes2::HighScoreDataContainer::getMonsterByDay( data.dayCount );
-            const uint32_t baseMonsterAnimationIndex = monster.GetSpriteIndex() * 9;
-            const fheroes2::Sprite & baseMonsterSprite = fheroes2::AGG::GetICN( ICN::MINIMON, baseMonsterAnimationIndex );
-            fheroes2::Blit( baseMonsterSprite, display, baseMonsterSprite.x() + ox + 554, baseMonsterSprite.y() + oy + 91 );
-
-            // Animation frame of a creature is based on its position on screen and common animation frame ID.
-            uint32_t monsterAnimationId = monsterAnimationSequence[( ox + oy + data.dayCount + monsterAnimationFrameId ) % monsterAnimationSequence.size()];
-            const uint32_t secondaryMonsterAnimationIndex = baseMonsterAnimationIndex + 1 + monsterAnimationId;
-            const fheroes2::Sprite & secondaryMonsterSprite = fheroes2::AGG::GetICN( ICN::MINIMON, secondaryMonsterAnimationIndex );
-            fheroes2::Blit( secondaryMonsterSprite, display, secondaryMonsterSprite.x() + ox + 554, secondaryMonsterSprite.y() + oy + 91 );
-
-            oy += highScoreEntryStepY;
-            ++scoreIndex;
-        }
+        redrawHighScoreScreen( ox, oy, monsterAnimationFrameId, selectedScoreIndex, highScoreDataContainer.getHighScoresCampaign(), 7,
+                               fheroes2::HighScoreDataContainer::getMonsterByDay );
     }
 }
 
@@ -218,8 +191,28 @@ fheroes2::GameMode Game::DisplayHighScores( const bool isCampaign )
 
         if ( isCampaign ) {
             const Campaign::CampaignSaveData & campaignSaveData = Campaign::CampaignSaveData::Get();
+            // Rating is calculated based on difficulty of campaign.
+            uint32_t rating = campaignSaveData.getDaysPassed();
+
+            const int32_t difficulty = campaignSaveData.getDifficulty();
+            switch ( difficulty ) {
+            case Campaign::CampaignDifficulty::Easy:
+                rating = rating * 125 / 100;
+                break;
+            case Campaign::CampaignDifficulty::Normal:
+                // Nothing we need to do here.
+                break;
+            case Campaign::CampaignDifficulty::Hard:
+                rating = rating * 75 / 100;
+                break;
+            default:
+                // Did you add a new campaign difficulty? Add the logic above!
+                assert( 0 );
+                break;
+            }
+
             selectedEntryIndex = highScoreDataContainer.registerScoreCampaign(
-                { player, Campaign::getCampaignName( campaignSaveData.getCampaignID() ), completionTime, campaignSaveData.getDaysPassed(), 0, world.GetMapSeed() } );
+                { player, Campaign::getCampaignName( campaignSaveData.getCampaignID() ), completionTime, campaignSaveData.getDaysPassed(), rating, world.GetMapSeed() } );
         }
         else {
             const uint32_t rating = GetGameOverScores();

--- a/src/fheroes2/game/highscores.cpp
+++ b/src/fheroes2/game/highscores.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <ctime>
 
 #include "highscores.h"
@@ -75,11 +76,6 @@ namespace
 
         entries.emplace_back( data );
         std::sort( entries.begin(), entries.end(), []( const fheroes2::HighscoreData & first, const fheroes2::HighscoreData & second ) {
-            if ( first.rating == 0 && second.rating == 0 ) {
-                // Ratings are 0 only for campaigns.
-                return first.dayCount < second.dayCount;
-            }
-
             return first.rating > second.rating;
         } );
 
@@ -131,6 +127,14 @@ namespace fheroes2
         }
 
         hdata >> _highScoresStandard >> _highScoresCampaign;
+
+        // Since the introduction of campaign difficulty we need to calculate rating of a campaign completion.
+        // Before the change rating for campaigns was always 0. We need to set it to the number of days.
+        for ( fheroes2::HighscoreData & data : _highScoresCampaign ) {
+            if ( data.rating == 0 ) {
+                data.rating = data.dayCount;
+            }
+        }
 
         return !hdata.fail();
     }
@@ -279,15 +283,15 @@ namespace fheroes2
     {
         const uint32_t currentTime = HighscoreData::generateCompletionTime();
 
-        registerScoreCampaign( { "Antoine", "Roland", currentTime, 600, 0, 0 } );
-        registerScoreCampaign( { "Astra", "Archibald", currentTime, 650, 0, 0 } );
-        registerScoreCampaign( { "Agar", "Roland", currentTime, 700, 0, 0 } );
-        registerScoreCampaign( { "Vatawna", "Archibald", currentTime, 750, 0, 0 } );
-        registerScoreCampaign( { "Vesper", "Roland", currentTime, 800, 0, 0 } );
-        registerScoreCampaign( { "Ambrose", "Archibald", currentTime, 850, 0, 0 } );
-        registerScoreCampaign( { "Troyan", "Roland", currentTime, 900, 0, 0 } );
-        registerScoreCampaign( { "Jojosh", "Archibald", currentTime, 1000, 0, 0 } );
-        registerScoreCampaign( { "Wrathmont", "Roland", currentTime, 2000, 0, 0 } );
-        registerScoreCampaign( { "Maximus", "Archibald", currentTime, 3000, 0, 0 } );
+        registerScoreCampaign( { "Antoine", "Roland", currentTime, 600, 600, 0 } );
+        registerScoreCampaign( { "Astra", "Archibald", currentTime, 650, 650, 0 } );
+        registerScoreCampaign( { "Agar", "Roland", currentTime, 700, 700, 0 } );
+        registerScoreCampaign( { "Vatawna", "Archibald", currentTime, 750, 750, 0 } );
+        registerScoreCampaign( { "Vesper", "Roland", currentTime, 800, 800, 0 } );
+        registerScoreCampaign( { "Ambrose", "Archibald", currentTime, 850, 850, 0 } );
+        registerScoreCampaign( { "Troyan", "Roland", currentTime, 900, 900, 0 } );
+        registerScoreCampaign( { "Jojosh", "Archibald", currentTime, 1000, 1000, 0 } );
+        registerScoreCampaign( { "Wrathmont", "Roland", currentTime, 2000, 2000, 0 } );
+        registerScoreCampaign( { "Maximus", "Archibald", currentTime, 3000, 3000, 0 } );
     }
 }

--- a/src/fheroes2/game/highscores.cpp
+++ b/src/fheroes2/game/highscores.cpp
@@ -20,7 +20,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cassert>
 #include <ctime>
 
 #include "highscores.h"

--- a/src/fheroes2/game/highscores.h
+++ b/src/fheroes2/game/highscores.h
@@ -68,7 +68,7 @@ namespace fheroes2
         // Rating is used only for standalone scenarios. Campaigns do not use this member.
         uint32_t rating{ 0 };
 
-        // Map seed is used to identify the same game compeltion to avoid duplicates in highscores.
+        // Map seed is used to identify the same game completion to avoid duplicates in highscores.
         uint32_t mapSeed{ 0 };
 
         static uint32_t generateCompletionTime();


### PR DESCRIPTION
We added difficulty level for campaigns and we need to differentiate scores for them. The easiest way is to introduce rating like for single maps.