### PR TITLE
Generate new default Gift button, move Difficulty button generation, fix pressed evil buttons

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -364,7 +364,7 @@ namespace fheroes2
 
                 break;
             }
-            case ICN::BTNGIFT_EVIL: 
+            case ICN::BTNGIFT_EVIL:
                 _icnVsSprite[id].resize( 2 );
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -415,19 +415,19 @@ namespace fheroes2
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::EVIL_CAMPAIGN_BUTTONS, 0 + i );
-                    // clean the button
-                    Fill( out, 13 - i, 3 + i, 125, 16, getButtonFillingColor( i == 0, false ) );
+                    // clean the button. Needs to use different color to fill pressed state.
+                    Fill( out, 13 - 2 * i, 3 + 2 * i, 129 + 2 * i, 16, getButtonFillingColor( i == 0, false ) );
                 }
-                //const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
-                //const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
+                const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
+                const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
 
-                //const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
+                const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
 
-                //fheroes2::Text releasedText( text, releasedFont );
-                //fheroes2::Text pressedText( text, pressedFont );
+                fheroes2::Text releasedText( text, releasedFont );
+                fheroes2::Text pressedText( text, pressedFont );
 
-                //releasedText.draw( 10 /*+ ( 50 - releasedText.width() ) / 2*/, 5, _icnVsSprite[id][0] );
-                //pressedText.draw( 11 /*+ ( 50 - pressedText.width() ) / 2*/, 6, _icnVsSprite[id][1] );
+                releasedText.draw( 10 + ( 132 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
+                pressedText.draw( 10 + ( 132 - pressedText.width() ) / 2, 6, _icnVsSprite[id][1] );
 
                 break;
             }
@@ -436,19 +436,19 @@ namespace fheroes2
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::X_CMPBTN, 0 + i );
-                    // clean the button
-                    Fill( out, 13 - i, 3 + i, 125, 16, getButtonFillingColor( i == 0, false ) );
+                    // clean the button. Needs to use different color to fill pressed state.
+                    Fill( out, 4 - i, 3 + i, 132, 16, getButtonFillingColor( i == 0, false ) );
                 }
-                // const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
-                // const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
+                 const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
+                 const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
 
-                // const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
+                 const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
 
-                // fheroes2::Text releasedText( text, releasedFont );
-                // fheroes2::Text pressedText( text, pressedFont );
+                 fheroes2::Text releasedText( text, releasedFont );
+                 fheroes2::Text pressedText( text, pressedFont );
 
-                // releasedText.draw( 10 /*+ ( 50 - releasedText.width() ) / 2*/, 5, _icnVsSprite[id][0] );
-                // pressedText.draw( 11 /*+ ( 50 - pressedText.width() ) / 2*/, 6, _icnVsSprite[id][1] );
+                 releasedText.draw( 4 + ( 132 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
+                 pressedText.draw( 4 + ( 132 - pressedText.width() ) / 2, 5, _icnVsSprite[id][1] );
 
                 break;
             }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -458,18 +458,18 @@ namespace fheroes2
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::GOOD_CAMPAIGN_BUTTONS, 0 + i );
                     // clean the button
-                    Fill( out, 13 - i, 3 + i, 125, 16, getButtonFillingColor( i == 0, false ) );
+                    Fill( out, 13, 4 + i, 127, 15, getButtonFillingColor( i == 0 ) );
                 }
-                // const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
-                // const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
+                 const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::WHITE };
+                 const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::WHITE };
 
-                // const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
+                 const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
 
-                // fheroes2::Text releasedText( text, releasedFont );
-                // fheroes2::Text pressedText( text, pressedFont );
+                 fheroes2::Text releasedText( text, releasedFont );
+                 fheroes2::Text pressedText( text, pressedFont );
 
-                // releasedText.draw( 10 /*+ ( 50 - releasedText.width() ) / 2*/, 5, _icnVsSprite[id][0] );
-                // pressedText.draw( 11 /*+ ( 50 - pressedText.width() ) / 2*/, 6, _icnVsSprite[id][1] );
+                 releasedText.draw( 10 + ( 132 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
+                 pressedText.draw( 9 + ( 132 - pressedText.width() ) / 2, 6, _icnVsSprite[id][1] );
 
                 break;
             }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -414,20 +414,64 @@ namespace fheroes2
                 _icnVsSprite[id].resize( 2 );
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
-                    out = GetICN( ICN::EVIL_CAMPAIGN_BUTTONS, 4 + i );
+                    out = GetICN( ICN::EVIL_CAMPAIGN_BUTTONS, 0 + i );
                     // clean the button
-                    Fill( out, 13 - i, 4 + i, 128, 14, getButtonFillingColor( i == 0, false ) );
+                    Fill( out, 13 - i, 3 + i, 125, 16, getButtonFillingColor( i == 0, false ) );
                 }
-                const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
-                const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
+                //const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
+                //const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
 
-                const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
+                //const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
 
-                fheroes2::Text releasedText( text, releasedFont );
-                fheroes2::Text pressedText( text, pressedFont );
+                //fheroes2::Text releasedText( text, releasedFont );
+                //fheroes2::Text pressedText( text, pressedFont );
 
-                releasedText.draw( 10 + ( 50 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
-                pressedText.draw( 11 + ( 50 - pressedText.width() ) / 2, 6, _icnVsSprite[id][1] );
+                //releasedText.draw( 10 /*+ ( 50 - releasedText.width() ) / 2*/, 5, _icnVsSprite[id][0] );
+                //pressedText.draw( 11 /*+ ( 50 - pressedText.width() ) / 2*/, 6, _icnVsSprite[id][1] );
+
+                break;
+            }
+            case ICN::BUTTON_DIFFICULTY_POL: {
+                _icnVsSprite[id].resize( 2 );
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
+                    out = GetICN( ICN::EVIL_CAMPAIGN_BUTTONS, 0 + i );
+                    // clean the button
+                    Fill( out, 13 - i, 3 + i, 125, 16, getButtonFillingColor( i == 0, false ) );
+                }
+                // const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
+                // const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
+
+                // const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
+
+                // fheroes2::Text releasedText( text, releasedFont );
+                // fheroes2::Text pressedText( text, pressedFont );
+
+                // releasedText.draw( 10 /*+ ( 50 - releasedText.width() ) / 2*/, 5, _icnVsSprite[id][0] );
+                // pressedText.draw( 11 /*+ ( 50 - pressedText.width() ) / 2*/, 6, _icnVsSprite[id][1] );
+
+                break;
+            }
+            case ICN::BUTTON_DIFFICULTY_ROLAND: {
+                _icnVsSprite[id].resize( 2 );
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
+                    out = GetICN( ICN::GOOD_CAMPAIGN_BUTTONS, 0 + i );
+                    // clean the button
+                    Fill( out, 13 - i, 3 + i, 125, 16, getButtonFillingColor( i == 0, false ) );
+                }
+                // const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
+                // const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
+
+                // const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
+
+                // fheroes2::Text releasedText( text, releasedFont );
+                // fheroes2::Text pressedText( text, pressedFont );
+
+                // releasedText.draw( 10 /*+ ( 50 - releasedText.width() ) / 2*/, 5, _icnVsSprite[id][0] );
+                // pressedText.draw( 11 /*+ ( 50 - pressedText.width() ) / 2*/, 6, _icnVsSprite[id][1] );
+
+                break;
             }
             default:
                 // You're calling this function for non-specified ICN id. Check your logic!
@@ -959,6 +1003,9 @@ namespace fheroes2
             case ICN::BTNGIFT_GOOD:
             case ICN::BTNGIFT_EVIL:
             case ICN::NON_UNIFORM_GOOD_MIN_BUTTON:
+            case ICN::BUTTON_DIFFICULTY_ARCHIBALD:
+            case ICN::BUTTON_DIFFICULTY_POL:
+            case ICN::BUTTON_DIFFICULTY_ROLAND:
                 generateLanguageSpecificImages( id );
                 return true;
             case ICN::BTNCONFIG:

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -239,6 +239,12 @@ namespace
         return isReleasedState ? fheroes2::GetColorId( 180, 180, 180 ) : fheroes2::GetColorId( 144, 144, 144 );
     }
 
+    const char * getSupportedText( const char * text, const fheroes2::FontType & font )
+    {
+        const char * translatedText = _( text );
+        return fheroes2::isFontAvailable( translatedText, font ) ? translatedText : text;
+    }
+
     void convertToEvilInterface( fheroes2::Sprite & image, const fheroes2::Rect & roi )
     {
         fheroes2::ApplyPalette( image, roi.x, roi.y, image, roi.x, roi.y, roi.width, roi.height, PAL::GetPalette( PAL::PaletteType::GOOD_TO_EVIL_INTERFACE ) );
@@ -353,8 +359,8 @@ namespace fheroes2
                 const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::WHITE };
                 const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::WHITE };
 
-                const char * translatedText = _( "GIFT" );
-                const char * text = fheroes2::isFontAvailable( translatedText, releasedFont ) ? translatedText : "GIFT";
+
+                const char * text = getSupportedText( gettext_noop( "GIFT" ), releasedFont );
 
                 fheroes2::Text releasedText( text, releasedFont );
                 fheroes2::Text presesedText( text, pressedFont );
@@ -373,8 +379,7 @@ namespace fheroes2
                 const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
                 const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
 
-                const char * translatedText = _( "GIFT" );
-                const char * text = fheroes2::isFontAvailable( translatedText, releasedFont ) ? translatedText : "GIFT";
+                const char * text = getSupportedText( gettext_noop( "GIFT" ), releasedFont );
 
                 fheroes2::Text releasedText( text, releasedFont );
                 fheroes2::Text presesedText( text, pressedFont );
@@ -396,8 +401,7 @@ namespace fheroes2
                 const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::WHITE };
                 const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::WHITE };
 
-                const char * translatedText = _( "MIN" );
-                const char * text = fheroes2::isFontAvailable( translatedText, releasedFont ) ? translatedText : "MIN";
+                const char * text = getSupportedText( gettext_noop( "MIN" ), releasedFont );
 
                 fheroes2::Text releasedText( text, releasedFont );
                 fheroes2::Text presesedText( text, pressedFont );

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -415,7 +415,7 @@ namespace fheroes2
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::EVIL_CAMPAIGN_BUTTONS, 0 + i );
-                    // clean the button. Needs to use different evil color for pressed state.
+                    // clean the button. Needs different color for pressed state so can't use getButtonFillingColor().
                     Fill( out, 13 - 2 * i, 3 + 2 * i, 129 + 2 * i, 16, out.image()[13 + 5 * 145] );
                 }
                 const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
@@ -436,7 +436,7 @@ namespace fheroes2
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::X_CMPBTN, 0 + i );
-                    // clean the button. Needs to use different evil color for pressed state.
+                    // clean the button. Needs different color for pressed state so can't use getButtonFillingColor().
                     Fill( out, 4, 3 + i, 132 - i, 16, out.image()[5 * 132] );
                 }
                 const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -416,7 +416,7 @@ namespace fheroes2
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::EVIL_CAMPAIGN_BUTTONS, 0 + i );
                     // clean the button. Needs different color for pressed state so can't use getButtonFillingColor().
-                    Fill( out, 13 - 2 * i, 3 + 2 * i, 129 + 2 * i, 16, out.image()[13 + 5 * 145] );
+                    Fill( out, 13 - 2 * i, 3 + 2 * i, 129 + 2 * i, 16, out.image()[ 13 - 7 * i  +  ( 5 + i ) * ( 145 - ( 4 * i ) )] );
                 }
                 const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
                 const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
@@ -2257,16 +2257,24 @@ namespace fheroes2
 
                 const int originalIcnId = ( id == ICN::GOOD_CAMPAIGN_BUTTONS ) ? ICN::CAMPXTRG : ICN::CAMPXTRE;
 
+                // The evil buttons' pressed state need to be 2 pixels wider.
+                const int offsetEvilX = ( id == ICN::GOOD_CAMPAIGN_BUTTONS ) ? 0 : 2;
+
                 for ( int32_t i = 0; i < 4; ++i ) {
+                    // The released state image.
                     image[2 * i] = GetICN( originalIcnId, 2 * i );
 
+                    // The pressed state image.
                     const Sprite & original = GetICN( originalIcnId, 2 * i + 1 );
 
+                    // Edit the pressed state image.
                     Sprite & resized = image[2 * i + 1];
-                    resized.resize( image[2 * i].width(), image[2 * i].height() );
+                    // Change pressed state image to have same width and hight as released image
+                    resized.resize( image[2 * i].width() + offsetEvilX, image[2 * i].height() );
                     resized.reset();
 
-                    Copy( original, 0, 0, resized, original.x(), original.y(), original.width(), original.height() );
+                    // Restore content of the pressed state image.
+                    Copy( original, 0, 0, resized, original.x(), original.y(), original.width() + offsetEvilX, original.height() );
                 }
 
                 return true;

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -386,7 +386,7 @@ namespace fheroes2
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::RECRUIT, 4 + i );
-                    // clean the button
+                    // clean the button.
                     Blit( GetICN( ICN::SYSTEM, 11 + i ), 10 - i, 4 + i, out, 11 - i, 4 + i, 50, 16 );
                 }
 
@@ -394,57 +394,43 @@ namespace fheroes2
 
                 break;
             }
-            case ICN::BUTTON_DIFFICULTY_POL:
-            case ICN::BUTTON_DIFFICULTY_ROLAND:
             case ICN::BUTTON_DIFFICULTY_ARCHIBALD: {
-                std::array<fheroes2::Rect, 2> clearArea;
-                int baseIcnId = ICN::UNKNOWN;
-                fheroes2::Point textOffsetReleased;
-                fheroes2::Point textOffsetPressed;
-                std::array<int, 2> buttonColorFilling{};
-
-                switch ( id ) {
-                case ICN::BUTTON_DIFFICULTY_ARCHIBALD:
-                    baseIcnId = ICN::EVIL_CAMPAIGN_BUTTONS;
-                    clearArea[0] = { 13, 3, 129, 16 };
-                    clearArea[1] = { 15, 5, 127, 16 };
-                    textOffsetReleased = { 10, 5 };
-                    textOffsetPressed = { 10, 6 };
-                    buttonColorFilling[0] = 13 + 5 * 145;
-                    buttonColorFilling[1] = 13 - 7 + 6 * 141;
-                    break;
-                case ICN::BUTTON_DIFFICULTY_ROLAND:
-                    baseIcnId = ICN::GOOD_CAMPAIGN_BUTTONS;
-                    clearArea[0] = { 13, 4, 127, 15 };
-                    clearArea[1] = { 13, 5, 127, 15 };
-                    textOffsetReleased = { 11, 5 };
-                    textOffsetPressed = { 10, 6 };
-                    buttonColorFilling[0] = 13 + 5 * 147;
-                    buttonColorFilling[1] = 18 - 7 + 6 * 147;
-                    break;
-                case ICN::BUTTON_DIFFICULTY_POL:
-                    baseIcnId = ICN::X_CMPBTN;
-                    clearArea[0] = { 4, 3, 132, 16 };
-                    clearArea[1] = { 4, 4, 131, 16 };
-                    textOffsetReleased = { 3, 5 };
-                    textOffsetPressed = { 3, 5 };
-                    buttonColorFilling[0] = 5 * 132;
-                    buttonColorFilling[1] = 5 * 132;
-                    break;
-                default:
-                    assert( 0 );
-                    break;
-                }
                 _icnVsSprite[id].resize( 2 );
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
-                    out = GetICN( baseIcnId, 0 + i );
-                    Fill( out, clearArea[i].x, clearArea[i].y, clearArea[i].width, clearArea[i].height, out.image()[buttonColorFilling[i]] );
+                    out = GetICN( ICN::EVIL_CAMPAIGN_BUTTONS, 0 + i );
+                    // clean the button.
+                    Fill( out, 13 + 2 * i, 3 + 2 * i, 129 - 2 * i, 16, out.image()[13 - 7 * i + ( 5 + i ) * ( 145 - ( 4 * i ) )] );
                 }
-
-                const fheroes2::FontColor buttonFontColor = ( baseIcnId == ICN::GOOD_CAMPAIGN_BUTTONS ) ? fheroes2::FontColor::WHITE : fheroes2::FontColor::GRAY;
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), textOffsetReleased, textOffsetPressed, 132, buttonFontColor );
-
+                
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 10, 5 }, { 10, 6 }, 132, fheroes2::FontColor::GRAY );
+                
+                break;
+            }
+            case ICN::BUTTON_DIFFICULTY_ROLAND: {
+                _icnVsSprite[id].resize( 2 );
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
+                    out = GetICN( ICN::GOOD_CAMPAIGN_BUTTONS, 0 + i );
+                    // clean the button.
+                    Fill( out, 13, 4 + i, 127, 15, getButtonFillingColor( i == 0 ) );
+                }
+                
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 11, 5 }, { 10, 6 }, 132, fheroes2::FontColor::WHITE );
+                
+                break;
+            }
+            case ICN::BUTTON_DIFFICULTY_POL: {
+                _icnVsSprite[id].resize( 2 );
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
+                    out = GetICN( ICN::X_CMPBTN, 0 + i );
+                    // clean the button.
+                    Fill( out, 4, 3 + i, 132 - i, 16, out.image()[5 * 132] );
+                }
+                
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 3, 5 }, { 3, 5 }, 132, fheroes2::FontColor::GRAY );
+                
                 break;
             }
             default:

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -410,6 +410,25 @@ namespace fheroes2
 
                 break;
             }
+            case ICN::BUTTON_DIFFICULTY_ARCHIBALD: {
+                _icnVsSprite[id].resize( 2 );
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
+                    out = GetICN( ICN::EVIL_CAMPAIGN_BUTTONS, 4 + i );
+                    // clean the button
+                    Fill( out, 13 - i, 4 + i, 128, 14, getButtonFillingColor( i == 0, false ) );
+                }
+                const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
+                const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
+
+                const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
+
+                fheroes2::Text releasedText( text, releasedFont );
+                fheroes2::Text pressedText( text, pressedFont );
+
+                releasedText.draw( 10 + ( 50 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
+                pressedText.draw( 11 + ( 50 - pressedText.width() ) / 2, 6, _icnVsSprite[id][1] );
+            }
             default:
                 // You're calling this function for non-specified ICN id. Check your logic!
                 // Did you add a new image for one language without generating a default

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -343,14 +343,28 @@ namespace fheroes2
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
                 break;
-            case ICN::BTNGIFT_GOOD:
+            case ICN::BTNGIFT_GOOD: {
                 _icnVsSprite[id].resize( 2 );
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::SYSTEM, 11 + i );
                 }
+
+                const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::WHITE };
+                const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::WHITE };
+
+                const char * translatedText = _( "GIFT" );
+                const char * text = fheroes2::isFontAvailable( translatedText, releasedFont ) ? translatedText : "GIFT";
+
+                fheroes2::Text releasedText( text, releasedFont );
+                fheroes2::Text presesedText( text, pressedFont );
+
+                releasedText.draw( 21 + ( 50 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
+                presesedText.draw( 20 + ( 50 - presesedText.width() ) / 2, 6, _icnVsSprite[id][1] );
+
                 break;
-            case ICN::BTNGIFT_EVIL:
+            }
+            case ICN::BTNGIFT_EVIL: 
                 _icnVsSprite[id].resize( 2 );
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
@@ -412,28 +426,6 @@ namespace fheroes2
                     // Add 'ly'
                     Blit( GetICN( ICN::BTNHOTST, i ), 47 - i, 21, out, 71 - i, 28, 12, 13 );
                     Blit( GetICN( ICN::BTNHOTST, i ), 72 - i, 21, out, 84 - i, 28, 13, 13 );
-                }
-                return true;
-            case ICN::BTNGIFT_GOOD:
-                _icnVsSprite[id].resize( 2 );
-                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = _icnVsSprite[id][i];
-                    out = GetICN( ICN::TRADPOST, 17 + i );
-
-                    // clean the button
-                    Blit( GetICN( ICN::SYSTEM, 11 + i ), 10, 6, out, 6, 4, 72, 15 );
-
-                    // add 'G'
-                    Blit( GetICN( ICN::CPANEL, i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
-
-                    // add 'I'
-                    Blit( GetICN( ICN::APANEL, 4 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
-
-                    // add 'F'
-                    Blit( GetICN( ICN::APANEL, 4 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
-
-                    // add 'T'
-                    Blit( GetICN( ICN::CPANEL, 6 + i ), 59 - i, 21, out, 60 - i, 5, 14, 14 );
                 }
                 return true;
             case ICN::BTNGIFT_EVIL:

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -459,8 +459,7 @@ namespace fheroes2
                 }
 
                 const fheroes2::FontColor fontColor = ( baseIcnId == ICN::GOOD_CAMPAIGN_BUTTONS ) ? fheroes2::FontColor::WHITE : fheroes2::FontColor::GRAY;
-                const int textSpaceWidth = 132;
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), textOffsetReleased, textOffsetPressed, textSpaceWidth, fontColor );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), textOffsetReleased, textOffsetPressed, 132, fontColor );
 
                 break;
             }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -359,8 +359,8 @@ namespace fheroes2
                 fheroes2::Text releasedText( text, releasedFont );
                 fheroes2::Text presesedText( text, pressedFont );
 
-                releasedText.draw( 21 + ( 50 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
-                presesedText.draw( 20 + ( 50 - presesedText.width() ) / 2, 6, _icnVsSprite[id][1] );
+                releasedText.draw( 23 + ( 50 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
+                presesedText.draw( 22 + ( 50 - presesedText.width() ) / 2, 6, _icnVsSprite[id][1] );
 
                 break;
             }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -416,7 +416,7 @@ namespace fheroes2
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::EVIL_CAMPAIGN_BUTTONS, 0 + i );
                     // clean the button. Needs different color for pressed state so can't use getButtonFillingColor().
-                    Fill( out, 13 - 2 * i, 3 + 2 * i, 129 + 2 * i, 16, out.image()[ 13 - 7 * i  +  ( 5 + i ) * ( 145 - ( 4 * i ) )] );
+                    Fill( out, 13 - 2 * i, 3 + 2 * i, 129 + 2 * i, 16, out.image()[13 - 7 * i + ( 5 + i ) * ( 145 - ( 4 * i ) )] );
                 }
                 const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
                 const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -417,7 +417,7 @@ namespace fheroes2
                 int baseIcnId = ICN::UNKNOWN;
                 fheroes2::Point textOffsetReleased;
                 fheroes2::Point textOffsetPressed;
-                std::array<int, 2> buttonColorFilling;
+                std::array<int, 2> buttonColorFilling{};
 
                 switch ( id ) {
                 case ICN::BUTTON_DIFFICULTY_ARCHIBALD:

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -402,9 +402,9 @@ namespace fheroes2
                     // clean the button.
                     Fill( out, 13 + 2 * i, 3 + 2 * i, 129 - 2 * i, 16, out.image()[13 - 7 * i + ( 5 + i ) * ( 145 - ( 4 * i ) )] );
                 }
-                
+
                 renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 10, 5 }, { 10, 6 }, 132, fheroes2::FontColor::GRAY );
-                
+
                 break;
             }
             case ICN::BUTTON_DIFFICULTY_ROLAND: {
@@ -415,9 +415,9 @@ namespace fheroes2
                     // clean the button.
                     Fill( out, 13, 4 + i, 127, 15, getButtonFillingColor( i == 0 ) );
                 }
-                
+
                 renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 11, 5 }, { 10, 6 }, 132, fheroes2::FontColor::WHITE );
-                
+
                 break;
             }
             case ICN::BUTTON_DIFFICULTY_POL: {
@@ -428,9 +428,9 @@ namespace fheroes2
                     // clean the button.
                     Fill( out, 4, 3 + i, 132 - i, 16, out.image()[5 * 132] );
                 }
-                
+
                 renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 3, 5 }, { 3, 5 }, 132, fheroes2::FontColor::GRAY );
-                
+
                 break;
             }
             default:

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -251,8 +251,10 @@ namespace
         const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fontColor };
         const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fontColor };
 
-        fheroes2::Text releasedText( text, releasedFont );
-        fheroes2::Text pressedText( text, pressedFont );
+        const char * textSupported = getSupportedText( text, releasedFont );
+
+        fheroes2::Text releasedText( textSupported, releasedFont );
+        fheroes2::Text pressedText( textSupported, pressedFont );
 
         releasedText.draw( releasedTextOffset.x + ( maxTextWidth - releasedText.width() ) / 2, releasedTextOffset.y, releasedState );
         pressedText.draw( pressedTextOffset.x + ( maxTextWidth - pressedText.width() ) / 2, pressedTextOffset.y, pressedState );

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -415,8 +415,8 @@ namespace fheroes2
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::EVIL_CAMPAIGN_BUTTONS, 0 + i );
-                    // clean the button. Needs to use different color to fill pressed state.
-                    Fill( out, 13 - 2 * i, 3 + 2 * i, 129 + 2 * i, 16, getButtonFillingColor( i == 0, false ) );
+                    // clean the button. Needs to use different evil color for pressed state.
+                    Fill( out, 13 - 2 * i, 3 + 2 * i, 129 + 2 * i, 16, out.image()[13 + 5 * 145] );
                 }
                 const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
                 const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
@@ -436,8 +436,8 @@ namespace fheroes2
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::X_CMPBTN, 0 + i );
-                    // clean the button. Needs to use different color to fill pressed state.
-                    Fill( out, 4 - i, 3 + i, 132, 16, getButtonFillingColor( i == 0, false ) );
+                    // clean the button. Needs to use different evil color for pressed state.
+                    Fill( out, 4, 3 + i, 132 - i, 16, out.image()[5 * 132] );
                 }
                 const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
                 const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -435,7 +435,7 @@ namespace fheroes2
                 _icnVsSprite[id].resize( 2 );
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
-                    out = GetICN( ICN::EVIL_CAMPAIGN_BUTTONS, 0 + i );
+                    out = GetICN( ICN::X_CMPBTN, 0 + i );
                     // clean the button
                     Fill( out, 13 - i, 3 + i, 125, 16, getButtonFillingColor( i == 0, false ) );
                 }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -368,23 +368,14 @@ namespace fheroes2
 
                 const bool isGoodInterface = ( id == ICN::BTNGIFT_GOOD );
                 const int baseIcnId = isGoodInterface ? ICN::SYSTEM : ICN::SYSTEME;
-                const fheroes2::FontColor releasedFontColor = ( isGoodInterface ) ? fheroes2::FontColor::WHITE : fheroes2::FontColor::GRAY;
+                const fheroes2::FontColor buttonFontColor = isGoodInterface ? fheroes2::FontColor::WHITE : fheroes2::FontColor::GRAY;
 
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( baseIcnId, 11 + i );
                 }
 
-                const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, releasedFontColor };
-                const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, releasedFontColor };
-
-                const char * text = getSupportedText( gettext_noop( "GIFT" ), releasedFont );
-
-                fheroes2::Text releasedText( text, releasedFont );
-                fheroes2::Text presesedText( text, pressedFont );
-
-                releasedText.draw( 23 + ( 50 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
-                presesedText.draw( 22 + ( 50 - presesedText.width() ) / 2, 6, _icnVsSprite[id][1] );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "GIFT" ), { 23, 5 }, { 22, 6 }, 50, buttonFontColor );
 
                 break;
             }
@@ -397,16 +388,7 @@ namespace fheroes2
                     Blit( GetICN( ICN::SYSTEM, 11 + i ), 10 - i, 4 + i, out, 11 - i, 4 + i, 50, 16 );
                 }
 
-                const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::WHITE };
-                const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::WHITE };
-
-                const char * text = getSupportedText( gettext_noop( "MIN" ), releasedFont );
-
-                fheroes2::Text releasedText( text, releasedFont );
-                fheroes2::Text presesedText( text, pressedFont );
-
-                releasedText.draw( 11 + ( 50 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
-                presesedText.draw( 10 + ( 50 - presesedText.width() ) / 2, 6, _icnVsSprite[id][1] );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "MIN" ), { 11, 5 }, { 10, 6 }, 50, fheroes2::FontColor::WHITE );
 
                 break;
             }
@@ -458,8 +440,8 @@ namespace fheroes2
                     Fill( out, clearArea[i].x, clearArea[i].y, clearArea[i].width, clearArea[i].height, out.image()[buttonColorFilling[i]] );
                 }
 
-                const fheroes2::FontColor fontColor = ( baseIcnId == ICN::GOOD_CAMPAIGN_BUTTONS ) ? fheroes2::FontColor::WHITE : fheroes2::FontColor::GRAY;
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), textOffsetReleased, textOffsetPressed, 132, fontColor );
+                const fheroes2::FontColor buttonFontColor = ( baseIcnId == ICN::GOOD_CAMPAIGN_BUTTONS ) ? fheroes2::FontColor::WHITE : fheroes2::FontColor::GRAY;
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), textOffsetReleased, textOffsetPressed, 132, buttonFontColor );
 
                 break;
             }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -364,13 +364,26 @@ namespace fheroes2
 
                 break;
             }
-            case ICN::BTNGIFT_EVIL:
+            case ICN::BTNGIFT_EVIL: {
                 _icnVsSprite[id].resize( 2 );
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::SYSTEME, 11 + i );
                 }
+                const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
+                const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
+
+                const char * translatedText = _( "GIFT" );
+                const char * text = fheroes2::isFontAvailable( translatedText, releasedFont ) ? translatedText : "GIFT";
+
+                fheroes2::Text releasedText( text, releasedFont );
+                fheroes2::Text presesedText( text, pressedFont );
+
+                releasedText.draw( 23 + ( 50 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
+                presesedText.draw( 22 + ( 50 - presesedText.width() ) / 2, 6, _icnVsSprite[id][1] );
+
                 break;
+            }
             case ICN::NON_UNIFORM_GOOD_MIN_BUTTON: {
                 _icnVsSprite[id].resize( 2 );
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
@@ -426,28 +439,6 @@ namespace fheroes2
                     // Add 'ly'
                     Blit( GetICN( ICN::BTNHOTST, i ), 47 - i, 21, out, 71 - i, 28, 12, 13 );
                     Blit( GetICN( ICN::BTNHOTST, i ), 72 - i, 21, out, 84 - i, 28, 13, 13 );
-                }
-                return true;
-            case ICN::BTNGIFT_EVIL:
-                _icnVsSprite[id].resize( 2 );
-                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = _icnVsSprite[id][i];
-                    out = GetICN( ICN::TRADPOSE, 17 + i );
-
-                    // clean the button
-                    Blit( GetICN( ICN::SYSTEME, 11 + i ), 10, 6, out, 6, 4, 72, 15 );
-
-                    // add 'G'
-                    Blit( GetICN( ICN::CPANELE, i ), 18 - i, 27, out, 20 - i, 4, 15, 15 );
-
-                    // add 'I'
-                    Blit( GetICN( ICN::APANELE, 4 + i ), 22 - i, 20, out, 36 - i, 4, 9, 15 );
-
-                    // add 'F'
-                    Blit( GetICN( ICN::APANELE, 4 + i ), 48 - i, 20, out, 46 - i, 4, 13, 15 );
-
-                    // add 'T'
-                    Blit( GetICN( ICN::CPANELE, 6 + i ), 59 - i, 21, out, 60 - i, 5, 14, 14 );
                 }
                 return true;
             default:

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -245,6 +245,19 @@ namespace
         return fheroes2::isFontAvailable( translatedText, font ) ? translatedText : text;
     }
 
+    void renderTextOnButton( fheroes2::Image & releasedState, fheroes2::Image & pressedState, const char * text, const fheroes2::Point & releasedTextOffset,
+                             const fheroes2::Point & pressedTextOffset, const int32_t maxTextWidth, const fheroes2::FontColor fontColor )
+    {
+        const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fontColor };
+        const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fontColor };
+
+        fheroes2::Text releasedText( text, releasedFont );
+        fheroes2::Text pressedText( text, pressedFont );
+
+        releasedText.draw( releasedTextOffset.x + ( maxTextWidth - releasedText.width() ) / 2, releasedTextOffset.y, releasedState );
+        pressedText.draw( pressedTextOffset.x + ( maxTextWidth - pressedText.width() ) / 2, pressedTextOffset.y, pressedState );
+    }
+
     void convertToEvilInterface( fheroes2::Sprite & image, const fheroes2::Rect & roi )
     {
         fheroes2::ApplyPalette( image, roi.x, roi.y, image, roi.x, roi.y, roi.width, roi.height, PAL::GetPalette( PAL::PaletteType::GOOD_TO_EVIL_INTERFACE ) );
@@ -349,34 +362,21 @@ namespace fheroes2
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
                 break;
-            case ICN::BTNGIFT_GOOD: {
-                _icnVsSprite[id].resize( 2 );
-                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = _icnVsSprite[id][i];
-                    out = GetICN( ICN::SYSTEM, 11 + i );
-                }
-
-                const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::WHITE };
-                const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::WHITE };
-
-                const char * text = getSupportedText( gettext_noop( "GIFT" ), releasedFont );
-
-                fheroes2::Text releasedText( text, releasedFont );
-                fheroes2::Text presesedText( text, pressedFont );
-
-                releasedText.draw( 23 + ( 50 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
-                presesedText.draw( 22 + ( 50 - presesedText.width() ) / 2, 6, _icnVsSprite[id][1] );
-
-                break;
-            }
+            case ICN::BTNGIFT_GOOD:
             case ICN::BTNGIFT_EVIL: {
                 _icnVsSprite[id].resize( 2 );
+
+                const bool isGoodInterface = ( id == ICN::BTNGIFT_GOOD );
+                const int baseIcnId = isGoodInterface ? ICN::SYSTEM : ICN::SYSTEME;
+                const fheroes2::FontColor releasedFontColor = ( isGoodInterface ) ? fheroes2::FontColor::WHITE : fheroes2::FontColor::GRAY;
+
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
-                    out = GetICN( ICN::SYSTEME, 11 + i );
+                    out = GetICN( baseIcnId, 11 + i );
                 }
-                const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
-                const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
+
+                const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, releasedFontColor };
+                const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, releasedFontColor };
 
                 const char * text = getSupportedText( gettext_noop( "GIFT" ), releasedFont );
 
@@ -410,66 +410,57 @@ namespace fheroes2
 
                 break;
             }
+            case ICN::BUTTON_DIFFICULTY_POL:
+            case ICN::BUTTON_DIFFICULTY_ROLAND:
             case ICN::BUTTON_DIFFICULTY_ARCHIBALD: {
+                std::array<fheroes2::Rect, 2> clearArea;
+                int baseIcnId = ICN::UNKNOWN;
+                fheroes2::Point textOffsetReleased;
+                fheroes2::Point textOffsetPressed;
+                std::array<int, 2> buttonColorFilling;
+
+                switch ( id ) {
+                case ICN::BUTTON_DIFFICULTY_ARCHIBALD:
+                    baseIcnId = ICN::EVIL_CAMPAIGN_BUTTONS;
+                    clearArea[0] = { 13, 3, 129, 16 };
+                    clearArea[1] = { 15, 5, 127, 16 };
+                    textOffsetReleased = { 10, 5 };
+                    textOffsetPressed = { 10, 6 };
+                    buttonColorFilling[0] = 13 + 5 * 145;
+                    buttonColorFilling[1] = 13 - 7 + 6 * 141;
+                    break;
+                case ICN::BUTTON_DIFFICULTY_ROLAND:
+                    baseIcnId = ICN::GOOD_CAMPAIGN_BUTTONS;
+                    clearArea[0] = { 13, 4, 127, 15 };
+                    clearArea[1] = { 13, 5, 127, 15 };
+                    textOffsetReleased = { 11, 5 };
+                    textOffsetPressed = { 10, 6 };
+                    buttonColorFilling[0] = 13 + 5 * 147;
+                    buttonColorFilling[1] = 18 - 7 + 6 * 147;
+                    break;
+                case ICN::BUTTON_DIFFICULTY_POL:
+                    baseIcnId = ICN::X_CMPBTN;
+                    clearArea[0] = { 4, 3, 132, 16 };
+                    clearArea[1] = { 4, 4, 131, 16 };
+                    textOffsetReleased = { 4, 5 };
+                    textOffsetPressed = { 4, 5 };
+                    buttonColorFilling[0] = 5 * 132;
+                    buttonColorFilling[1] = 5 * 132;
+                    break;
+                default:
+                    assert( 0 );
+                    break;
+                }
                 _icnVsSprite[id].resize( 2 );
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
-                    out = GetICN( ICN::EVIL_CAMPAIGN_BUTTONS, 0 + i );
-                    // clean the button. Needs different color for pressed state so can't use getButtonFillingColor().
-                    Fill( out, 13 - 2 * i, 3 + 2 * i, 129 + 2 * i, 16, out.image()[13 - 7 * i + ( 5 + i ) * ( 145 - ( 4 * i ) )] );
+                    out = GetICN( baseIcnId, 0 + i );
+                    Fill( out, clearArea[i].x, clearArea[i].y, clearArea[i].width, clearArea[i].height, out.image()[buttonColorFilling[i]] );
                 }
-                const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
-                const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
 
-                const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
-
-                fheroes2::Text releasedText( text, releasedFont );
-                fheroes2::Text pressedText( text, pressedFont );
-
-                releasedText.draw( 10 + ( 132 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
-                pressedText.draw( 10 + ( 132 - pressedText.width() ) / 2, 6, _icnVsSprite[id][1] );
-
-                break;
-            }
-            case ICN::BUTTON_DIFFICULTY_POL: {
-                _icnVsSprite[id].resize( 2 );
-                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = _icnVsSprite[id][i];
-                    out = GetICN( ICN::X_CMPBTN, 0 + i );
-                    // clean the button. Needs different color for pressed state so can't use getButtonFillingColor().
-                    Fill( out, 4, 3 + i, 132 - i, 16, out.image()[5 * 132] );
-                }
-                const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
-                const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
-
-                const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
-
-                fheroes2::Text releasedText( text, releasedFont );
-                fheroes2::Text pressedText( text, pressedFont );
-
-                releasedText.draw( 4 + ( 132 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
-                pressedText.draw( 4 + ( 132 - pressedText.width() ) / 2, 5, _icnVsSprite[id][1] );
-
-                break;
-            }
-            case ICN::BUTTON_DIFFICULTY_ROLAND: {
-                _icnVsSprite[id].resize( 2 );
-                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = _icnVsSprite[id][i];
-                    out = GetICN( ICN::GOOD_CAMPAIGN_BUTTONS, 0 + i );
-                    // clean the button
-                    Fill( out, 13, 4 + i, 127, 15, getButtonFillingColor( i == 0 ) );
-                }
-                const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::WHITE };
-                const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::WHITE };
-
-                const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
-
-                fheroes2::Text releasedText( text, releasedFont );
-                fheroes2::Text pressedText( text, pressedFont );
-
-                releasedText.draw( 10 + ( 132 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
-                pressedText.draw( 9 + ( 132 - pressedText.width() ) / 2, 6, _icnVsSprite[id][1] );
+                const fheroes2::FontColor fontColor = ( baseIcnId == ICN::GOOD_CAMPAIGN_BUTTONS ) ? fheroes2::FontColor::WHITE : fheroes2::FontColor::GRAY;
+                const int textSpaceWidth = 132;
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), textOffsetReleased, textOffsetPressed, textSpaceWidth, fontColor );
 
                 break;
             }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -439,16 +439,16 @@ namespace fheroes2
                     // clean the button. Needs to use different color to fill pressed state.
                     Fill( out, 4 - i, 3 + i, 132, 16, getButtonFillingColor( i == 0, false ) );
                 }
-                 const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
-                 const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
+                const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::GRAY };
+                const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::GRAY };
 
-                 const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
+                const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
 
-                 fheroes2::Text releasedText( text, releasedFont );
-                 fheroes2::Text pressedText( text, pressedFont );
+                fheroes2::Text releasedText( text, releasedFont );
+                fheroes2::Text pressedText( text, pressedFont );
 
-                 releasedText.draw( 4 + ( 132 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
-                 pressedText.draw( 4 + ( 132 - pressedText.width() ) / 2, 5, _icnVsSprite[id][1] );
+                releasedText.draw( 4 + ( 132 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
+                pressedText.draw( 4 + ( 132 - pressedText.width() ) / 2, 5, _icnVsSprite[id][1] );
 
                 break;
             }
@@ -460,16 +460,16 @@ namespace fheroes2
                     // clean the button
                     Fill( out, 13, 4 + i, 127, 15, getButtonFillingColor( i == 0 ) );
                 }
-                 const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::WHITE };
-                 const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::WHITE };
+                const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::WHITE };
+                const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::WHITE };
 
-                 const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
+                const char * text = getSupportedText( gettext_noop( "DIFFICULTY" ), releasedFont );
 
-                 fheroes2::Text releasedText( text, releasedFont );
-                 fheroes2::Text pressedText( text, pressedFont );
+                fheroes2::Text releasedText( text, releasedFont );
+                fheroes2::Text pressedText( text, pressedFont );
 
-                 releasedText.draw( 10 + ( 132 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
-                 pressedText.draw( 9 + ( 132 - pressedText.width() ) / 2, 6, _icnVsSprite[id][1] );
+                releasedText.draw( 10 + ( 132 - releasedText.width() ) / 2, 5, _icnVsSprite[id][0] );
+                pressedText.draw( 9 + ( 132 - pressedText.width() ) / 2, 6, _icnVsSprite[id][1] );
 
                 break;
             }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -2267,9 +2267,8 @@ namespace fheroes2
                     // The pressed state image.
                     const Sprite & original = GetICN( originalIcnId, 2 * i + 1 );
 
-                    // Edit the pressed state image.
                     Sprite & resized = image[2 * i + 1];
-                    // Change pressed state image to have same width and hight as released image
+                    // Change pressed state image to have same width and height as released image
                     resized.resize( image[2 * i].width() + offsetEvilX, image[2 * i].height() );
                     resized.reset();
 

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -359,7 +359,6 @@ namespace fheroes2
                 const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fheroes2::FontColor::WHITE };
                 const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fheroes2::FontColor::WHITE };
 
-
                 const char * text = getSupportedText( gettext_noop( "GIFT" ), releasedFont );
 
                 fheroes2::Text releasedText( text, releasedFont );

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -442,8 +442,8 @@ namespace fheroes2
                     baseIcnId = ICN::X_CMPBTN;
                     clearArea[0] = { 4, 3, 132, 16 };
                     clearArea[1] = { 4, 4, 131, 16 };
-                    textOffsetReleased = { 4, 5 };
-                    textOffsetPressed = { 4, 5 };
+                    textOffsetReleased = { 3, 5 };
+                    textOffsetPressed = { 3, 5 };
                     buttonColorFilling[0] = 5 * 132;
                     buttonColorFilling[1] = 5 * 132;
                     break;

--- a/src/fheroes2/agg/icn.h
+++ b/src/fheroes2/agg/icn.h
@@ -988,6 +988,10 @@ namespace ICN
         BUTTON_EVIL_FONT_RELEASED,
         BUTTON_EVIL_FONT_PRESSED,
 
+        BUTTON_DIFFICULTY_ARCHIBALD,
+        BUTTON_DIFFICULTY_ROLAND,
+        BUTTON_DIFFICULTY_POL,
+
         // IMPORTANT! Put any new entry just above this one.
         LASTICN
     };

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1152,7 +1152,7 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
     fheroes2::Button buttonOk( top.x + 367, top.y + 431, buttonIconID, 4, 5 );
     fheroes2::Button buttonCancel( top.x + 511, top.y + 431, buttonIconID, 6, 7 );
 
-    // Difficulty button does not present in the original assets so we need to generate it.
+    // Difficulty button is not present in the original assets so we need to generate it.
     fheroes2::ButtonSprite buttonDifficulty = getDifficultyButton( chosenCampaignID, top + fheroes2::Point( 195, 431 ) );
 
     // create scenario bonus choice buttons

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -741,8 +741,8 @@ namespace
         case Campaign::DESCENDANTS_CAMPAIGN:
         case Campaign::WIZARDS_ISLE_CAMPAIGN:
         case Campaign::VOYAGE_HOME_CAMPAIGN:
-            releasedImage = fheroes2::AGG::GetICN( ICN::BUTTON_DIFFICULTY_ARCHIBALD, 0 );
-            pressedImage = fheroes2::AGG::GetICN( ICN::BUTTON_DIFFICULTY_ARCHIBALD, 1 );
+            releasedImage = fheroes2::AGG::GetICN( ICN::BUTTON_DIFFICULTY_POL, 0 );
+            pressedImage = fheroes2::AGG::GetICN( ICN::BUTTON_DIFFICULTY_POL, 1 );
             break;
         default:
             // Implementing a new campaign? Add a new case!

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -723,61 +723,32 @@ namespace
         }
     }
 
-    fheroes2::ButtonSprite getDifficultyButton( const int campaignId, const int buttonIconID, const fheroes2::Point & offset )
+    fheroes2::ButtonSprite getDifficultyButton( const int campaignId, const fheroes2::Point & offset )
     {
-        fheroes2::FontColor fontColor{ fheroes2::FontColor::WHITE };
-        fheroes2::Rect fillingReleasedArea;
-        fheroes2::Rect fillingPressedArea;
-        fheroes2::Point releasedTextPosition;
-        fheroes2::Point pressedTextPosition;
+        fheroes2::Sprite releasedImage;
+        fheroes2::Sprite pressedImage;
 
         switch ( campaignId ) {
         case Campaign::ROLAND_CAMPAIGN:
-            fontColor = fheroes2::FontColor::WHITE;
-            fillingReleasedArea = { 13, 4, 128, 16 };
-            fillingPressedArea = { 13, 5, 128, 16 };
-            releasedTextPosition = { 12, 5 };
-            pressedTextPosition = { 11, 6 };
+            releasedImage = fheroes2::AGG::GetICN( ICN::BUTTON_DIFFICULTY_ROLAND, 0 );
+            pressedImage = fheroes2::AGG::GetICN( ICN::BUTTON_DIFFICULTY_ROLAND, 1 );
             break;
         case Campaign::ARCHIBALD_CAMPAIGN:
-            fontColor = fheroes2::FontColor::GRAY;
-            fillingReleasedArea = { 13, 4, 128, 14 };
-            fillingPressedArea = { 13, 6, 128, 14 };
-            releasedTextPosition = { 10, 5 };
-            pressedTextPosition = { 11, 6 };
+            releasedImage = fheroes2::AGG::GetICN( ICN::BUTTON_DIFFICULTY_ARCHIBALD, 0 );
+            pressedImage = fheroes2::AGG::GetICN( ICN::BUTTON_DIFFICULTY_ARCHIBALD, 1 );
             break;
         case Campaign::PRICE_OF_LOYALTY_CAMPAIGN:
         case Campaign::DESCENDANTS_CAMPAIGN:
         case Campaign::WIZARDS_ISLE_CAMPAIGN:
         case Campaign::VOYAGE_HOME_CAMPAIGN:
-            fontColor = fheroes2::FontColor::GRAY;
-            fillingReleasedArea = { 7, 5, 125, 14 };
-            fillingPressedArea = { 6, 6, 128, 14 };
-            releasedTextPosition = { 4, 5 };
-            pressedTextPosition = { 4, 5 };
+            releasedImage = fheroes2::AGG::GetICN( ICN::BUTTON_DIFFICULTY_ARCHIBALD, 0 );
+            pressedImage = fheroes2::AGG::GetICN( ICN::BUTTON_DIFFICULTY_ARCHIBALD, 1 );
             break;
         default:
             // Implementing a new campaign? Add a new case!
             assert( 0 );
             break;
         }
-
-        fheroes2::Sprite releasedImage = fheroes2::AGG::GetICN( buttonIconID, 0 );
-        fheroes2::Sprite pressedImage = fheroes2::AGG::GetICN( buttonIconID, 1 );
-
-        fheroes2::Fill( releasedImage, fillingReleasedArea.x, fillingReleasedArea.y, fillingReleasedArea.width, fillingReleasedArea.height,
-                        releasedImage.image()[fillingReleasedArea.x + fillingReleasedArea.y * releasedImage.width()] );
-        fheroes2::Fill( pressedImage, fillingPressedArea.x, fillingPressedArea.y, fillingPressedArea.width, fillingPressedArea.height,
-                        pressedImage.image()[fillingPressedArea.x + fillingPressedArea.y * pressedImage.width()] );
-
-        const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fontColor };
-        const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fontColor };
-
-        const char * translatedText = _( "DIFFICULTY" );
-        const char * text = fheroes2::isFontAvailable( translatedText, releasedFont ) ? translatedText : "DIFFICULTY";
-
-        fheroes2::Text( text, releasedFont ).draw( releasedTextPosition.x, releasedTextPosition.y, releasedImage );
-        fheroes2::Text( text, pressedFont ).draw( pressedTextPosition.x, pressedTextPosition.y, pressedImage );
 
         return fheroes2::ButtonSprite( offset.x, offset.y, releasedImage, pressedImage );
     }
@@ -1182,7 +1153,7 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
     fheroes2::Button buttonCancel( top.x + 511, top.y + 431, buttonIconID, 6, 7 );
 
     // Difficulty button does not present in the original assets so we need to generate it.
-    fheroes2::ButtonSprite buttonDifficulty = getDifficultyButton( chosenCampaignID, buttonIconID, top + fheroes2::Point( 195, 431 ) );
+    fheroes2::ButtonSprite buttonDifficulty = getDifficultyButton( chosenCampaignID, top + fheroes2::Point( 195, 431 ) );
 
     // create scenario bonus choice buttons
     fheroes2::ButtonGroup buttonChoices;

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -725,32 +725,27 @@ namespace
 
     fheroes2::ButtonSprite getDifficultyButton( const int campaignId, const fheroes2::Point & offset )
     {
-        fheroes2::Sprite releasedImage;
-        fheroes2::Sprite pressedImage;
+        int icnId = ICN::UNKNOWN;
 
         switch ( campaignId ) {
         case Campaign::ROLAND_CAMPAIGN:
-            releasedImage = fheroes2::AGG::GetICN( ICN::BUTTON_DIFFICULTY_ROLAND, 0 );
-            pressedImage = fheroes2::AGG::GetICN( ICN::BUTTON_DIFFICULTY_ROLAND, 1 );
+            icnId = ICN::BUTTON_DIFFICULTY_ROLAND;
             break;
         case Campaign::ARCHIBALD_CAMPAIGN:
-            releasedImage = fheroes2::AGG::GetICN( ICN::BUTTON_DIFFICULTY_ARCHIBALD, 0 );
-            pressedImage = fheroes2::AGG::GetICN( ICN::BUTTON_DIFFICULTY_ARCHIBALD, 1 );
+            icnId = ICN::BUTTON_DIFFICULTY_ARCHIBALD;
             break;
         case Campaign::PRICE_OF_LOYALTY_CAMPAIGN:
         case Campaign::DESCENDANTS_CAMPAIGN:
         case Campaign::WIZARDS_ISLE_CAMPAIGN:
         case Campaign::VOYAGE_HOME_CAMPAIGN:
-            releasedImage = fheroes2::AGG::GetICN( ICN::BUTTON_DIFFICULTY_POL, 0 );
-            pressedImage = fheroes2::AGG::GetICN( ICN::BUTTON_DIFFICULTY_POL, 1 );
+            icnId = ICN::BUTTON_DIFFICULTY_POL;
             break;
         default:
             // Implementing a new campaign? Add a new case!
             assert( 0 );
             break;
         }
-
-        return fheroes2::ButtonSprite( offset.x, offset.y, releasedImage, pressedImage );
+        return fheroes2::ButtonSprite( offset.x, offset.y, fheroes2::AGG::GetICN( icnId, 0 ), fheroes2::AGG::GetICN( icnId, 1 ) );
     }
 
     int32_t setCampaignDifficulty( int32_t currentDifficulty, const bool isSelectionAllowed )

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2255,7 +2255,7 @@ namespace fheroes2
         SetPixel( released[38], offset + 6, offset + 5, releasedFontColor );
 
         // G
-        released[39].resize( 10 + offset * 2, 10 + offset * 2 );
+        released[39].resize( 11 + offset * 2, 10 + offset * 2 );
         released[39].reset();
         DrawLine( released[39], { offset + 2, offset + 0 }, { offset + 7, offset + 0 }, releasedFontColor );
         DrawLine( released[39], { offset + 2, offset + 9 }, { offset + 7, offset + 9 }, releasedFontColor );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2254,6 +2254,20 @@ namespace fheroes2
         SetPixel( released[38], offset + 6, offset + 3, releasedFontColor );
         SetPixel( released[38], offset + 6, offset + 5, releasedFontColor );
 
+        // G
+        released[39].resize( 10 + offset * 2, 10 + offset * 2 );
+        released[39].reset();
+        DrawLine( released[39], { offset + 2, offset + 0 }, { offset + 7, offset + 0 }, releasedFontColor );
+        DrawLine( released[39], { offset + 2, offset + 9 }, { offset + 7, offset + 9 }, releasedFontColor );
+        DrawLine( released[39], { offset + 0, offset + 2 }, { offset + 0, offset + 7 }, releasedFontColor );
+        DrawLine( released[39], { offset + 7, offset + 5 }, { offset + 10, offset + 5 }, releasedFontColor );
+        DrawLine( released[39], { offset + 9, offset + 0 }, { offset + 9, offset + 2 }, releasedFontColor );
+        DrawLine( released[39], { offset + 9, offset + 6 }, { offset + 9, offset + 7 }, releasedFontColor );
+        SetPixel( released[39], offset + 1, offset + 1, releasedFontColor );
+        SetPixel( released[39], offset + 1, offset + 8, releasedFontColor );
+        SetPixel( released[39], offset + 8, offset + 1, releasedFontColor );
+        SetPixel( released[39], offset + 8, offset + 8, releasedFontColor );
+
         // I
         released[41].resize( 5 + offset * 2, 10 + offset * 2 );
         released[41].reset();

--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -781,12 +781,6 @@ namespace fheroes2
             return true;
         }
 
-        // Check that the font exists.
-        const Sprite & commaCharacter = AGG::getChar( ',', fontType );
-        if ( commaCharacter.empty() ) {
-            return false;
-        }
-
         const CharValidator validator( fontType.size );
 
         for ( const char letter : text ) {


### PR DESCRIPTION
This generates a default Gift button that is available for all languages and makes the letter G available for button generation.

Close https://github.com/ihhub/fheroes2/issues/5237


![image](https://user-images.githubusercontent.com/12501091/190394272-c16bd616-a675-483d-9a2b-e65af28a8646.png)

![image](https://user-images.githubusercontent.com/12501091/190404238-e14d02b8-d45d-4924-90b3-fb12e8b6fc36.png)


The generation of the Difficulty button was moved to image_agg.cpp.


An issue with two rows of missing pixels of the right side of the evil campaign screen's pressed buttons was addressed also:

![image](https://user-images.githubusercontent.com/12501091/190676797-4aa9d0e3-747c-43a0-bd5f-52ac4437331a.png)

