### PR TITLE
Fix crosshair rendering on Mini-map and missing selection in Marketplace

### DIFF
--- a/src/fheroes2/dialog/dialog_marketplace.cpp
+++ b/src/fheroes2/dialog/dialog_marketplace.cpp
@@ -470,6 +470,7 @@ void Dialog::Marketplace( Kingdom & kingdom, bool fromTradingPost )
                 count_sell = 0;
                 count_buy = 0;
 
+                cursorFrom.show();
                 cursorFrom.setPosition( rect_from.x - 2, rect_from.y - 2 );
 
                 if ( resourceTo ) {
@@ -503,6 +504,7 @@ void Dialog::Marketplace( Kingdom & kingdom, bool fromTradingPost )
                 count_sell = 0;
                 count_buy = 0;
 
+                cursorTo.show();
                 cursorTo.setPosition( rect_to.x - 2, rect_to.y - 2 );
 
                 if ( resourceFrom ) {

--- a/src/fheroes2/gui/interface_radar.cpp
+++ b/src/fheroes2/gui/interface_radar.cpp
@@ -245,6 +245,7 @@ void Interface::Radar::Redraw()
             cursorArea.hide();
             fheroes2::Blit( spriteArea, display, rect.x + offset.x, rect.y + offset.y );
             RedrawObjects( Players::FriendColors(), ViewWorldMode::OnlyVisible );
+            cursorArea.show();
             RedrawCursor();
         }
     }
@@ -258,6 +259,7 @@ void Interface::Radar::RedrawForViewWorld( const ViewWorld::ZoomROIs & roi, cons
     fheroes2::Blit( spriteArea, display, rect.x + offset.x, rect.y + offset.y );
     RedrawObjects( Players::FriendColors(), mode );
     const fheroes2::Rect roiInTiles = roi.GetROIinTiles();
+    cursorArea.show();
     RedrawCursor( &roiInTiles );
 }
 


### PR DESCRIPTION
close #5843

This is because we were abusing the logic behind hide() and show() methods.