### PR TITLE
Generate button letters A, B, E, H, P, R, S and new Battle Only button

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -259,10 +259,8 @@ namespace
         const fheroes2::Size releasedTextSize( releasedText.width( buttonSize.width ), releasedText.height( buttonSize.width ) );
         const fheroes2::Size pressedTextSize( pressedText.width( buttonSize.width ), pressedText.height( buttonSize.width ) );
 
-        releasedText.draw( releasedTextOffset.x,
-                           releasedTextOffset.y + ( buttonSize.height - releasedTextSize.height ) / 2, buttonSize.width, releasedState );
-        pressedText.draw( pressedTextOffset.x,
-                          pressedTextOffset.y + ( buttonSize.height - pressedTextSize.height ) / 2, buttonSize.width, pressedState );
+        releasedText.draw( releasedTextOffset.x, releasedTextOffset.y + ( buttonSize.height - releasedTextSize.height ) / 2, buttonSize.width, releasedState );
+        pressedText.draw( pressedTextOffset.x, pressedTextOffset.y + ( buttonSize.height - pressedTextSize.height ) / 2, buttonSize.width, pressedState );
     }
 
     void convertToEvilInterface( fheroes2::Sprite & image, const fheroes2::Rect & roi )

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -259,8 +259,10 @@ namespace
         const fheroes2::Size releaseTextSize( releasedText.width( buttonSize.width ), releasedText.height( buttonSize.width ) );
         const fheroes2::Size pressedTextSize( pressedText.width( buttonSize.width ), pressedText.height( buttonSize.width ) );
 
-        releasedText.draw( releasedTextOffset.x + ( buttonSize.width - releaseTextSize.width ) / 2, releasedTextOffset.y + ( buttonSize.height - releaseTextSize.height ) / 2, buttonSize.width, releasedState );
-        pressedText.draw( pressedTextOffset.x + (buttonSize.width - pressedTextSize.width ) / 2, pressedTextOffset.y + ( buttonSize.height - pressedTextSize.height ) / 2 , buttonSize.width, pressedState );
+        releasedText.draw( releasedTextOffset.x + ( buttonSize.width - releaseTextSize.width ) / 2,
+                           releasedTextOffset.y + ( buttonSize.height - releaseTextSize.height ) / 2, buttonSize.width, releasedState );
+        pressedText.draw( pressedTextOffset.x + ( buttonSize.width - pressedTextSize.width ) / 2,
+                          pressedTextOffset.y + ( buttonSize.height - pressedTextSize.height ) / 2, buttonSize.width, pressedState );
     }
 
     void convertToEvilInterface( fheroes2::Sprite & image, const fheroes2::Rect & roi )

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -255,9 +255,8 @@ namespace
 
         fheroes2::Text releasedText( textSupported, releasedFont );
         fheroes2::Text pressedText( textSupported, pressedFont );
-
-        releasedText.draw( releasedTextOffset.x, releasedTextOffset.y, maxTextWidth, releasedState );
-        pressedText.draw( pressedTextOffset.x, pressedTextOffset.y, maxTextWidth, pressedState );
+        releasedText.draw( releasedTextOffset.x, releasedTextOffset.y - ( releasedText.height( maxTextWidth ) / 2 ), maxTextWidth, releasedState );
+        pressedText.draw( pressedTextOffset.x, pressedTextOffset.y - ( pressedText.height( maxTextWidth ) / 2 ), maxTextWidth, pressedState );
     }
 
     void convertToEvilInterface( fheroes2::Sprite & image, const fheroes2::Rect & roi )
@@ -364,7 +363,7 @@ namespace fheroes2
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "BATTLE\nMODE" ), { 14, 13 }, { 13, 14 }, 110, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "BATTLE\nONLY" ), { 14, 29 }, { 13, 30 }, 110, fheroes2::FontColor::WHITE );
 
                 break;
             }
@@ -381,7 +380,7 @@ namespace fheroes2
                     out = GetICN( baseIcnId, 11 + i );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "GIFT" ), { 6, 5 }, { 4, 6 }, 86, buttonFontColor );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "GIFT" ), { 6, 13 }, { 4, 14 }, 86, buttonFontColor );
 
                 break;
             }
@@ -394,7 +393,7 @@ namespace fheroes2
                     Blit( GetICN( ICN::SYSTEM, 11 + i ), 10 - i, 4 + i, out, 11 - i, 4 + i, 50, 16 );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "MIN" ), { 11, 5 }, { 10, 6 }, 50, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "MIN" ), { 11, 13 }, { 10, 14 }, 50, fheroes2::FontColor::WHITE );
 
                 break;
             }
@@ -407,7 +406,7 @@ namespace fheroes2
                     Fill( out, 13 + 2 * i, 3 + 2 * i, 129 - 2 * i, 16, out.image()[13 - 7 * i + ( 5 + i ) * ( 145 - ( 4 * i ) )] );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 4, 5 }, { 4, 6 }, 145, fheroes2::FontColor::GRAY );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 4, 13 }, { 4, 14 }, 145, fheroes2::FontColor::GRAY );
 
                 break;
             }
@@ -420,7 +419,7 @@ namespace fheroes2
                     Fill( out, 13, 4 + i, 127, 15, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 5, 5 }, { 4, 6 }, 145, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 5, 13 }, { 4, 14 }, 145, fheroes2::FontColor::WHITE );
 
                 break;
             }
@@ -433,7 +432,7 @@ namespace fheroes2
                     Fill( out, 4, 3 + i, 132 - i, 16, out.image()[5 * 132] );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 0, 5 }, { 0, 5 }, 142, fheroes2::FontColor::GRAY );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 0, 13 }, { 0, 13 }, 142, fheroes2::FontColor::GRAY );
 
                 break;
             }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -355,7 +355,7 @@ namespace fheroes2
         void generateDefaultImages( const int id )
         {
             switch ( id ) {
-            case ICN::BTNBATTLEONLY:
+            case ICN::BTNBATTLEONLY: {
                 _icnVsSprite[id].resize( 2 );
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
@@ -363,7 +363,11 @@ namespace fheroes2
                     // Clean button
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
+
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "BATTLE MODE" ), { 11, 20 }, { 10, 21 }, 117, fheroes2::FontColor::WHITE );
+
                 break;
+            }
             case ICN::BTNGIFT_GOOD:
             case ICN::BTNGIFT_EVIL: {
                 _icnVsSprite[id].resize( 2 );
@@ -440,37 +444,6 @@ namespace fheroes2
                 assert( 0 );
                 break;
             }
-        }
-
-        bool generateEnglishSpecificImages( const int id )
-        {
-            switch ( id ) {
-            case ICN::BTNBATTLEONLY:
-                _icnVsSprite[id].resize( 2 );
-                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = _icnVsSprite[id][i];
-                    out = GetICN( ICN::BTNNEWGM, 6 + i );
-                    // Clean the button
-                    Fill( out, 25, 18, 88, 23, getButtonFillingColor( i == 0 ) );
-                    // Add 'ba'
-                    Blit( GetICN( ICN::BTNCMPGN, i ), 41 - i, 28, out, 30 - i, 13, 28, 14 );
-                    // Add 'tt'
-                    Blit( GetICN( ICN::BTNNEWGM, i ), 25 - i, 13, out, 57 - i, 13, 13, 14 );
-                    Blit( GetICN( ICN::BTNNEWGM, i ), 25 - i, 13, out, 70 - i, 13, 13, 14 );
-                    // Add 'le'
-                    Blit( GetICN( ICN::BTNNEWGM, 6 + i ), 97 - i, 21, out, 83 - i, 13, 13, 14 );
-                    Blit( GetICN( ICN::BTNNEWGM, 6 + i ), 86 - i, 21, out, 96 - i, 13, 13, 14 );
-                    // Add 'on'
-                    Blit( GetICN( ICN::BTNDCCFG, 4 + i ), 44 - i, 21, out, 40 - i, 28, 31, 14 );
-                    // Add 'ly'
-                    Blit( GetICN( ICN::BTNHOTST, i ), 47 - i, 21, out, 71 - i, 28, 12, 13 );
-                    Blit( GetICN( ICN::BTNHOTST, i ), 72 - i, 21, out, 84 - i, 28, 13, 13 );
-                }
-                return true;
-            default:
-                break;
-            }
-            return false;
         }
 
         bool generateGermanSpecificImages( const int id )
@@ -787,11 +760,6 @@ namespace fheroes2
                 break;
             case fheroes2::SupportedLanguage::Italian:
                 if ( generateItalianSpecificImages( id ) ) {
-                    return;
-                }
-                break;
-            case fheroes2::SupportedLanguage::English:
-                if ( generateEnglishSpecificImages( id ) ) {
                     return;
                 }
                 break;

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -367,7 +367,7 @@ namespace fheroes2
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "BATTLE\nONLY" ), { 11, 4 }, { 10, 5 }, { 117, 47 },
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "BATTLE\nONLY" ), { 12, 5 }, { 10, 5 }, { 117, 47 },
                                     fheroes2::FontColor::WHITE );
 
                 break;
@@ -385,7 +385,7 @@ namespace fheroes2
                     out = GetICN( baseIcnId, 11 + i );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "GIFT" ), { 6, 13 }, { 4, 14 }, { 86, 10 }, buttonFontColor );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "GIFT" ), { 7, 5 }, { 6, 6 }, { 86, 16 }, buttonFontColor );
 
                 break;
             }
@@ -398,7 +398,7 @@ namespace fheroes2
                     Blit( GetICN( ICN::SYSTEM, 11 + i ), 10 - i, 4 + i, out, 11 - i, 4 + i, 50, 16 );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "MIN" ), { 11, 13 }, { 10, 14 }, { 50, 17 }, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "MIN" ), { 12, 5 }, { 11, 6 }, { 50, 16 }, fheroes2::FontColor::WHITE );
 
                 break;
             }
@@ -411,7 +411,7 @@ namespace fheroes2
                     Fill( out, 13 + 2 * i, 3 + 2 * i, 129 - 2 * i, 16, out.image()[13 - 7 * i + ( 5 + i ) * ( 145 - ( 4 * i ) )] );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 4, 13 }, { 4, 14 }, { 145, 10 },
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 11, 5 }, { 11, 6 }, { 131, 17 },
                                     fheroes2::FontColor::GRAY );
 
                 break;
@@ -425,7 +425,7 @@ namespace fheroes2
                     Fill( out, 13, 4 + i, 127, 15, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 5, 13 }, { 4, 14 }, { 145, 10 },
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 13, 5 }, { 12, 6 }, { 131, 16 },
                                     fheroes2::FontColor::WHITE );
 
                 break;
@@ -439,7 +439,7 @@ namespace fheroes2
                     Fill( out, 4, 3 + i, 132 - i, 16, out.image()[5 * 132] );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 0, 13 }, { 0, 13 }, { 142, 10 },
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 5, 5 }, { 5, 5 }, { 132, 17 },
                                     fheroes2::FontColor::GRAY );
 
                 break;

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -259,9 +259,9 @@ namespace
         const fheroes2::Size releasedTextSize( releasedText.width( buttonSize.width ), releasedText.height( buttonSize.width ) );
         const fheroes2::Size pressedTextSize( pressedText.width( buttonSize.width ), pressedText.height( buttonSize.width ) );
 
-        releasedText.draw( releasedTextOffset.x + ( buttonSize.width - releasedTextSize.width ) / 2,
+        releasedText.draw( releasedTextOffset.x,
                            releasedTextOffset.y + ( buttonSize.height - releasedTextSize.height ) / 2, buttonSize.width, releasedState );
-        pressedText.draw( pressedTextOffset.x + ( buttonSize.width - pressedTextSize.width ) / 2,
+        pressedText.draw( pressedTextOffset.x,
                           pressedTextOffset.y + ( buttonSize.height - pressedTextSize.height ) / 2, buttonSize.width, pressedState );
     }
 

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -433,7 +433,7 @@ namespace fheroes2
                     Fill( out, 4, 3 + i, 132 - i, 16, out.image()[5 * 132] );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { -2, 5 }, { -2, 5 }, 145, fheroes2::FontColor::GRAY );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { -1, 5 }, { -1, 5 }, 142, fheroes2::FontColor::GRAY );
 
                 break;
             }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -439,8 +439,7 @@ namespace fheroes2
                     Fill( out, 4, 3 + i, 132 - i, 16, out.image()[5 * 132] );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 5, 5 }, { 5, 5 }, { 132, 17 },
-                                    fheroes2::FontColor::GRAY );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 5, 5 }, { 5, 5 }, { 132, 17 }, fheroes2::FontColor::GRAY );
 
                 break;
             }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -360,7 +360,7 @@ namespace fheroes2
                 for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                     Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNCOM, i );
-                    // Clean button
+                    // clean button.
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -256,11 +256,11 @@ namespace
         fheroes2::Text releasedText( textSupported, releasedFont );
         fheroes2::Text pressedText( textSupported, pressedFont );
 
-        const fheroes2::Size releaseTextSize( releasedText.width( buttonSize.width ), releasedText.height( buttonSize.width ) );
+        const fheroes2::Size releasedTextSize( releasedText.width( buttonSize.width ), releasedText.height( buttonSize.width ) );
         const fheroes2::Size pressedTextSize( pressedText.width( buttonSize.width ), pressedText.height( buttonSize.width ) );
 
-        releasedText.draw( releasedTextOffset.x + ( buttonSize.width - releaseTextSize.width ) / 2,
-                           releasedTextOffset.y + ( buttonSize.height - releaseTextSize.height ) / 2, buttonSize.width, releasedState );
+        releasedText.draw( releasedTextOffset.x + ( buttonSize.width - releasedTextSize.width ) / 2,
+                           releasedTextOffset.y + ( buttonSize.height - releasedTextSize.height ) / 2, buttonSize.width, releasedState );
         pressedText.draw( pressedTextOffset.x + ( buttonSize.width - pressedTextSize.width ) / 2,
                           pressedTextOffset.y + ( buttonSize.height - pressedTextSize.height ) / 2, buttonSize.width, pressedState );
     }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -255,6 +255,7 @@ namespace
 
         fheroes2::Text releasedText( textSupported, releasedFont );
         fheroes2::Text pressedText( textSupported, pressedFont );
+
         releasedText.draw( releasedTextOffset.x, releasedTextOffset.y - ( releasedText.height( maxTextWidth ) / 2 ), maxTextWidth, releasedState );
         pressedText.draw( pressedTextOffset.x, pressedTextOffset.y - ( pressedText.height( maxTextWidth ) / 2 ), maxTextWidth, pressedState );
     }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -246,7 +246,7 @@ namespace
     }
 
     void renderTextOnButton( fheroes2::Image & releasedState, fheroes2::Image & pressedState, const char * text, const fheroes2::Point & releasedTextOffset,
-                             const fheroes2::Point & pressedTextOffset, const int32_t maxTextWidth, const fheroes2::FontColor fontColor )
+                             const fheroes2::Point & pressedTextOffset, const fheroes2::Size buttonSize, const fheroes2::FontColor fontColor )
     {
         const fheroes2::FontType releasedFont{ fheroes2::FontSize::BUTTON_RELEASED, fontColor };
         const fheroes2::FontType pressedFont{ fheroes2::FontSize::BUTTON_PRESSED, fontColor };
@@ -256,8 +256,11 @@ namespace
         fheroes2::Text releasedText( textSupported, releasedFont );
         fheroes2::Text pressedText( textSupported, pressedFont );
 
-        releasedText.draw( releasedTextOffset.x, releasedTextOffset.y - ( releasedText.height( maxTextWidth ) / 2 ), maxTextWidth, releasedState );
-        pressedText.draw( pressedTextOffset.x, pressedTextOffset.y - ( pressedText.height( maxTextWidth ) / 2 ), maxTextWidth, pressedState );
+        const fheroes2::Size releaseTextSize( releasedText.width( buttonSize.width ), releasedText.height( buttonSize.width ) );
+        const fheroes2::Size pressedTextSize( pressedText.width( buttonSize.width ), pressedText.height( buttonSize.width ) );
+
+        releasedText.draw( releasedTextOffset.x + ( buttonSize.width - releaseTextSize.width ) / 2, releasedTextOffset.y + ( buttonSize.height - releaseTextSize.height ) / 2, buttonSize.width, releasedState );
+        pressedText.draw( pressedTextOffset.x + (buttonSize.width - pressedTextSize.width ) / 2, pressedTextOffset.y + ( buttonSize.height - pressedTextSize.height ) / 2 , buttonSize.width, pressedState );
     }
 
     void convertToEvilInterface( fheroes2::Sprite & image, const fheroes2::Rect & roi )
@@ -364,7 +367,8 @@ namespace fheroes2
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "BATTLE\nONLY" ), { 14, 29 }, { 13, 30 }, 110, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "BATTLE\nONLY" ), { 11, 4 }, { 10, 5 }, { 117, 47 },
+                                    fheroes2::FontColor::WHITE );
 
                 break;
             }
@@ -381,7 +385,7 @@ namespace fheroes2
                     out = GetICN( baseIcnId, 11 + i );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "GIFT" ), { 6, 13 }, { 4, 14 }, 86, buttonFontColor );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "GIFT" ), { 6, 13 }, { 4, 14 }, { 86, 10 }, buttonFontColor );
 
                 break;
             }
@@ -394,7 +398,7 @@ namespace fheroes2
                     Blit( GetICN( ICN::SYSTEM, 11 + i ), 10 - i, 4 + i, out, 11 - i, 4 + i, 50, 16 );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "MIN" ), { 11, 13 }, { 10, 14 }, 50, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "MIN" ), { 11, 13 }, { 10, 14 }, { 50, 17 }, fheroes2::FontColor::WHITE );
 
                 break;
             }
@@ -407,7 +411,8 @@ namespace fheroes2
                     Fill( out, 13 + 2 * i, 3 + 2 * i, 129 - 2 * i, 16, out.image()[13 - 7 * i + ( 5 + i ) * ( 145 - ( 4 * i ) )] );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 4, 13 }, { 4, 14 }, 145, fheroes2::FontColor::GRAY );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 4, 13 }, { 4, 14 }, { 145, 10 },
+                                    fheroes2::FontColor::GRAY );
 
                 break;
             }
@@ -420,7 +425,8 @@ namespace fheroes2
                     Fill( out, 13, 4 + i, 127, 15, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 5, 13 }, { 4, 14 }, 145, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 5, 13 }, { 4, 14 }, { 145, 10 },
+                                    fheroes2::FontColor::WHITE );
 
                 break;
             }
@@ -433,7 +439,8 @@ namespace fheroes2
                     Fill( out, 4, 3 + i, 132 - i, 16, out.image()[5 * 132] );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 0, 13 }, { 0, 13 }, 142, fheroes2::FontColor::GRAY );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 0, 13 }, { 0, 13 }, { 142, 10 },
+                                    fheroes2::FontColor::GRAY );
 
                 break;
             }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -433,7 +433,7 @@ namespace fheroes2
                     Fill( out, 4, 3 + i, 132 - i, 16, out.image()[5 * 132] );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { -1, 5 }, { -1, 5 }, 142, fheroes2::FontColor::GRAY );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 0, 5 }, { 0, 5 }, 142, fheroes2::FontColor::GRAY );
 
                 break;
             }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -256,9 +256,8 @@ namespace
         fheroes2::Text releasedText( textSupported, releasedFont );
         fheroes2::Text pressedText( textSupported, pressedFont );
 
-        releasedText.draw( releasedTextOffset.x /*+ ( maxTextWidth - releasedText.width() ) / 2*/, releasedTextOffset.y, maxTextWidth , releasedState );
-        pressedText.draw( pressedTextOffset.x /*+ ( maxTextWidth - pressedText.width() ) / 2*/,
-                          pressedTextOffset.y /*- 6 + ( ( 48 - pressedText.height( pressedText.width() ) ) / 2 )*/, maxTextWidth, pressedState );
+        releasedText.draw( releasedTextOffset.x, releasedTextOffset.y, maxTextWidth, releasedState );
+        pressedText.draw( pressedTextOffset.x, pressedTextOffset.y, maxTextWidth, pressedState );
     }
 
     void convertToEvilInterface( fheroes2::Sprite & image, const fheroes2::Rect & roi )
@@ -365,8 +364,7 @@ namespace fheroes2
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "BATTLE\nMODE" ), { 14, 13 }, { 13, 14 }, 110,
-                                    fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "BATTLE\nMODE" ), { 14, 13 }, { 13, 14 }, 110, fheroes2::FontColor::WHITE );
 
                 break;
             }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -256,8 +256,9 @@ namespace
         fheroes2::Text releasedText( textSupported, releasedFont );
         fheroes2::Text pressedText( textSupported, pressedFont );
 
-        releasedText.draw( releasedTextOffset.x + ( maxTextWidth - releasedText.width() ) / 2, releasedTextOffset.y, releasedState );
-        pressedText.draw( pressedTextOffset.x + ( maxTextWidth - pressedText.width() ) / 2, pressedTextOffset.y, pressedState );
+        releasedText.draw( releasedTextOffset.x /*+ ( maxTextWidth - releasedText.width() ) / 2*/, releasedTextOffset.y, maxTextWidth , releasedState );
+        pressedText.draw( pressedTextOffset.x /*+ ( maxTextWidth - pressedText.width() ) / 2*/,
+                          pressedTextOffset.y /*- 6 + ( ( 48 - pressedText.height( pressedText.width() ) ) / 2 )*/, maxTextWidth, pressedState );
     }
 
     void convertToEvilInterface( fheroes2::Sprite & image, const fheroes2::Rect & roi )
@@ -364,7 +365,8 @@ namespace fheroes2
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "BATTLE MODE" ), { 11, 20 }, { 10, 21 }, 117, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "BATTLE\nMODE" ), { 14, 13 }, { 13, 14 }, 110,
+                                    fheroes2::FontColor::WHITE );
 
                 break;
             }
@@ -381,7 +383,7 @@ namespace fheroes2
                     out = GetICN( baseIcnId, 11 + i );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "GIFT" ), { 23, 5 }, { 22, 6 }, 50, buttonFontColor );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "GIFT" ), { 6, 5 }, { 4, 6 }, 86, buttonFontColor );
 
                 break;
             }
@@ -407,7 +409,7 @@ namespace fheroes2
                     Fill( out, 13 + 2 * i, 3 + 2 * i, 129 - 2 * i, 16, out.image()[13 - 7 * i + ( 5 + i ) * ( 145 - ( 4 * i ) )] );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 10, 5 }, { 10, 6 }, 132, fheroes2::FontColor::GRAY );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 4, 5 }, { 4, 6 }, 145, fheroes2::FontColor::GRAY );
 
                 break;
             }
@@ -420,7 +422,7 @@ namespace fheroes2
                     Fill( out, 13, 4 + i, 127, 15, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 11, 5 }, { 10, 6 }, 132, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 5, 5 }, { 4, 6 }, 145, fheroes2::FontColor::WHITE );
 
                 break;
             }
@@ -433,7 +435,7 @@ namespace fheroes2
                     Fill( out, 4, 3 + i, 132 - i, 16, out.image()[5 * 132] );
                 }
 
-                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 3, 5 }, { 3, 5 }, 132, fheroes2::FontColor::GRAY );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { -2, 5 }, { -2, 5 }, 145, fheroes2::FontColor::GRAY );
 
                 break;
             }

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2456,5 +2456,13 @@ namespace fheroes2
             fheroes2::updateShadow( letter, { -1, 1 }, 7 );
             fheroes2::updateShadow( letter, { -2, 2 }, 8 );
         }
+
+        for ( Sprite & letter : released ) {
+            letter.setPosition( -1, 0 );
+        }
+
+        for ( Sprite & letter : pressed ) {
+            letter.setPosition( -1, 0 );
+        }
     }
 }

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2387,6 +2387,17 @@ namespace fheroes2
         DrawLine( released[50], { offset + 10, offset + 1 }, { offset + 10, offset + 4 }, releasedFontColor );
         DrawLine( released[50], { offset + 7, offset + 6 }, { offset + 9, offset + 8 }, releasedFontColor );
 
+        // S
+        released[51].resize( 10 + offset * 2, 10 + offset * 2 );
+        released[51].reset();
+        DrawLine( released[51], { offset + 1, offset + 0 }, { offset + 7, offset + 0 }, releasedFontColor );
+        DrawLine( released[51], { offset + 0, offset + 1 }, { offset + 0, offset + 3 }, releasedFontColor );
+        DrawLine( released[51], { offset + 1, offset + 4 }, { offset + 7, offset + 4 }, releasedFontColor );
+        DrawLine( released[51], { offset + 8, offset + 5 }, { offset + 8, offset + 8 }, releasedFontColor );
+        DrawLine( released[51], { offset + 1, offset + 9 }, { offset + 7, offset + 9 }, releasedFontColor );
+        DrawLine( released[51], { offset + 0, offset + 8 }, { offset + 1, offset + 8 }, releasedFontColor );
+        SetPixel( released[51], offset + 8, offset + 1, releasedFontColor );
+
         // T
         released[52].resize( 11 + offset * 2, 10 + offset * 2 );
         released[52].reset();

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2306,6 +2306,17 @@ namespace fheroes2
         SetPixel( released[39], offset + 8, offset + 1, releasedFontColor );
         SetPixel( released[39], offset + 8, offset + 8, releasedFontColor );
 
+        // H
+        released[40].resize( 14 + offset * 2, 10 + offset * 2 );
+        released[40].reset();
+        DrawLine( released[40], { offset + 0, offset + 0 }, { offset + 4, offset + 0 }, releasedFontColor );
+        DrawLine( released[40], { offset + 0, offset + 9 }, { offset + 4, offset + 9 }, releasedFontColor );
+        DrawLine( released[40], { offset + 2, offset + 1 }, { offset + 2, offset + 8 }, releasedFontColor );
+        DrawLine( released[40], { offset + 8, offset + 0 }, { offset + 12, offset + 0 }, releasedFontColor );
+        DrawLine( released[40], { offset + 8, offset + 9 }, { offset + 12, offset + 9 }, releasedFontColor );
+        DrawLine( released[40], { offset + 10, offset + 1 }, { offset + 10, offset + 8 }, releasedFontColor );
+        DrawLine( released[40], { offset + 3, offset + 5 }, { offset + 9, offset + 5 }, releasedFontColor );
+
         // I
         released[41].resize( 5 + offset * 2, 10 + offset * 2 );
         released[41].reset();

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2220,6 +2220,20 @@ namespace fheroes2
         SetPixel( released[17], offset + 1, offset + 1, releasedFontColor );
         SetPixel( released[17], offset + 0, offset + 2, releasedFontColor );
 
+        // A
+        released[33].resize( 13 + offset * 2, 10 + offset * 2 );
+        released[33].reset();
+        DrawLine( released[33], { offset + 0, offset + 9 }, { offset + 4, offset + 9 }, releasedFontColor );
+        DrawLine( released[33], { offset + 8, offset + 9 }, { offset + 12, offset + 9 }, releasedFontColor );
+        DrawLine( released[33], { offset + 5, offset + 5 }, { offset + 8, offset + 5 }, releasedFontColor );
+        DrawLine( released[33], { offset + 2, offset + 8 }, { offset + 4, offset + 5 }, releasedFontColor );
+        DrawLine( released[33], { offset + 7, offset + 1 }, { offset + 10, offset + 8 }, releasedFontColor );
+        SetPixel( released[33], offset + 4, offset + 4, releasedFontColor );
+        SetPixel( released[33], offset + 5, offset + 3, releasedFontColor );
+        SetPixel( released[33], offset + 5, offset + 2, releasedFontColor );
+        SetPixel( released[33], offset + 6, offset + 1, releasedFontColor );
+        SetPixel( released[33], offset + 6, offset + 0, releasedFontColor );
+        
         // C
         released[35].resize( 10 + offset * 2, 10 + offset * 2 );
         released[35].reset();
@@ -2253,6 +2267,20 @@ namespace fheroes2
         SetPixel( released[38], offset + 8, offset + 1, releasedFontColor );
         SetPixel( released[38], offset + 6, offset + 3, releasedFontColor );
         SetPixel( released[38], offset + 6, offset + 5, releasedFontColor );
+
+         // G
+        released[39].resize( 11 + offset * 2, 10 + offset * 2 );
+        released[39].reset();
+        DrawLine( released[39], { offset + 2, offset + 0 }, { offset + 7, offset + 0 }, releasedFontColor );
+        DrawLine( released[39], { offset + 2, offset + 9 }, { offset + 7, offset + 9 }, releasedFontColor );
+        DrawLine( released[39], { offset + 0, offset + 2 }, { offset + 0, offset + 7 }, releasedFontColor );
+        DrawLine( released[39], { offset + 7, offset + 5 }, { offset + 10, offset + 5 }, releasedFontColor );
+        DrawLine( released[39], { offset + 9, offset + 0 }, { offset + 9, offset + 2 }, releasedFontColor );
+        DrawLine( released[39], { offset + 9, offset + 6 }, { offset + 9, offset + 7 }, releasedFontColor );
+        SetPixel( released[39], offset + 1, offset + 1, releasedFontColor );
+        SetPixel( released[39], offset + 1, offset + 8, releasedFontColor );
+        SetPixel( released[39], offset + 8, offset + 1, releasedFontColor );
+        SetPixel( released[39], offset + 8, offset + 8, releasedFontColor );
 
         // I
         released[41].resize( 5 + offset * 2, 10 + offset * 2 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2238,14 +2238,14 @@ namespace fheroes2
         released[34].resize( 11 + offset * 2, 10 + offset * 2 );
         released[34].reset();
         DrawLine( released[34], { offset + 0, offset + 0 }, { offset + 8, offset + 0 }, releasedFontColor );
-        SetPixel( released[34], offset + 9, offset + 1, releasedFontColor );
-        DrawLine( released[34], { offset + 10, offset + 2 }, { offset + 10, offset + 4 }, releasedFontColor );
-        DrawLine( released[34], { offset + 2, offset + 5 }, { offset + 9, offset + 5 }, releasedFontColor );
-        DrawLine( released[34], { offset + 2, offset + 1 }, { offset + 2, offset + 4 }, releasedFontColor );
-        DrawLine( released[34], { offset + 2, offset + 6 }, { offset + 2, offset + 8 }, releasedFontColor );
         DrawLine( released[34], { offset + 0, offset + 9 }, { offset + 8, offset + 9 }, releasedFontColor );
-        SetPixel( released[34], offset + 9, offset + 8, releasedFontColor );
+        DrawLine( released[34], { offset + 3, offset + 5 }, { offset + 9, offset + 5 }, releasedFontColor );
+        DrawLine( released[34], { offset + 2, offset + 1 }, { offset + 2, offset + 8 }, releasedFontColor );
+        DrawLine( released[34], { offset + 10, offset + 2 }, { offset + 10, offset + 4 }, releasedFontColor );
         DrawLine( released[34], { offset + 10, offset + 6 }, { offset + 10, offset + 7 }, releasedFontColor );
+        SetPixel( released[34], offset + 9, offset + 8, releasedFontColor );
+        SetPixel( released[34], offset + 9, offset + 1, releasedFontColor );
+        
 
         // C
         released[35].resize( 10 + offset * 2, 10 + offset * 2 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2235,7 +2235,7 @@ namespace fheroes2
         SetPixel( released[33], offset + 6, offset + 0, releasedFontColor );
         
         // B
-        released[34].resize( 13 + offset * 2, 10 + offset * 2 );
+        released[34].resize( 11 + offset * 2, 10 + offset * 2 );
         released[34].reset();
         DrawLine( released[34], { offset + 0, offset + 0 }, { offset + 8, offset + 0 }, releasedFontColor );
         SetPixel( released[34], offset + 9, offset + 1, releasedFontColor );
@@ -2270,6 +2270,18 @@ namespace fheroes2
         SetPixel( released[36], offset + 9, offset + 1, releasedFontColor );
         SetPixel( released[36], offset + 9, offset + 8, releasedFontColor );
 
+        // E
+        released[37].resize( 9 + offset * 2, 10 + offset * 2 );
+        released[37].reset();
+        DrawLine( released[37], { offset + 0, offset + 0 }, { offset + 8, offset + 0 }, releasedFontColor );
+        DrawLine( released[37], { offset + 0, offset + 9 }, { offset + 8, offset + 9 }, releasedFontColor );
+        DrawLine( released[37], { offset + 2, offset + 1 }, { offset + 2, offset + 8 }, releasedFontColor );
+        DrawLine( released[37], { offset + 3, offset + 4 }, { offset + 6, offset + 4 }, releasedFontColor );
+        SetPixel( released[37], offset + 8, offset + 1, releasedFontColor );
+        SetPixel( released[37], offset + 8, offset + 8, releasedFontColor );
+        SetPixel( released[37], offset + 6, offset + 3, releasedFontColor );
+        SetPixel( released[37], offset + 6, offset + 5, releasedFontColor );
+        
         // F
         released[38].resize( 9 + offset * 2, 10 + offset * 2 );
         released[38].reset();

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2233,7 +2233,7 @@ namespace fheroes2
         SetPixel( released[33], offset + 5, offset + 2, releasedFontColor );
         SetPixel( released[33], offset + 6, offset + 1, releasedFontColor );
         SetPixel( released[33], offset + 6, offset + 0, releasedFontColor );
-        
+
         // B
         released[34].resize( 11 + offset * 2, 10 + offset * 2 );
         released[34].reset();
@@ -2245,7 +2245,6 @@ namespace fheroes2
         DrawLine( released[34], { offset + 10, offset + 6 }, { offset + 10, offset + 7 }, releasedFontColor );
         SetPixel( released[34], offset + 9, offset + 8, releasedFontColor );
         SetPixel( released[34], offset + 9, offset + 1, releasedFontColor );
-        
 
         // C
         released[35].resize( 10 + offset * 2, 10 + offset * 2 );
@@ -2281,7 +2280,7 @@ namespace fheroes2
         SetPixel( released[37], offset + 8, offset + 8, releasedFontColor );
         SetPixel( released[37], offset + 6, offset + 3, releasedFontColor );
         SetPixel( released[37], offset + 6, offset + 5, releasedFontColor );
-        
+
         // F
         released[38].resize( 9 + offset * 2, 10 + offset * 2 );
         released[38].reset();

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2234,6 +2234,19 @@ namespace fheroes2
         SetPixel( released[33], offset + 6, offset + 1, releasedFontColor );
         SetPixel( released[33], offset + 6, offset + 0, releasedFontColor );
         
+        // B
+        released[34].resize( 13 + offset * 2, 10 + offset * 2 );
+        released[34].reset();
+        DrawLine( released[34], { offset + 0, offset + 0 }, { offset + 8, offset + 0 }, releasedFontColor );
+        SetPixel( released[34], offset + 9, offset + 1, releasedFontColor );
+        DrawLine( released[34], { offset + 10, offset + 2 }, { offset + 10, offset + 4 }, releasedFontColor );
+        DrawLine( released[34], { offset + 2, offset + 5 }, { offset + 9, offset + 5 }, releasedFontColor );
+        DrawLine( released[34], { offset + 2, offset + 1 }, { offset + 2, offset + 4 }, releasedFontColor );
+        DrawLine( released[34], { offset + 2, offset + 6 }, { offset + 2, offset + 8 }, releasedFontColor );
+        DrawLine( released[34], { offset + 0, offset + 9 }, { offset + 8, offset + 9 }, releasedFontColor );
+        SetPixel( released[34], offset + 9, offset + 8, releasedFontColor );
+        DrawLine( released[34], { offset + 10, offset + 6 }, { offset + 10, offset + 7 }, releasedFontColor );
+
         // C
         released[35].resize( 10 + offset * 2, 10 + offset * 2 );
         released[35].reset();

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2367,6 +2367,15 @@ namespace fheroes2
         SetPixel( released[47], offset + 1, offset + 8, releasedFontColor );
         SetPixel( released[47], offset + 8, offset + 8, releasedFontColor );
 
+        // P
+        released[48].resize( 11 + offset * 2, 10 + offset * 2 );
+        released[48].reset();
+        DrawLine( released[48], { offset + 0, offset + 0 }, { offset + 9, offset + 0 }, releasedFontColor );
+        DrawLine( released[48], { offset + 0, offset + 9 }, { offset + 4, offset + 9 }, releasedFontColor );
+        DrawLine( released[48], { offset + 3, offset + 5 }, { offset + 9, offset + 5 }, releasedFontColor );
+        DrawLine( released[48], { offset + 2, offset + 1 }, { offset + 2, offset + 8 }, releasedFontColor );
+        DrawLine( released[48], { offset + 10, offset + 1 }, { offset + 10, offset + 4 }, releasedFontColor );
+
         // T
         released[52].resize( 11 + offset * 2, 10 + offset * 2 );
         released[52].reset();

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2376,6 +2376,17 @@ namespace fheroes2
         DrawLine( released[48], { offset + 2, offset + 1 }, { offset + 2, offset + 8 }, releasedFontColor );
         DrawLine( released[48], { offset + 10, offset + 1 }, { offset + 10, offset + 4 }, releasedFontColor );
 
+        // R
+        released[50].resize( 12 + offset * 2, 10 + offset * 2 );
+        released[50].reset();
+        DrawLine( released[50], { offset + 0, offset + 0 }, { offset + 9, offset + 0 }, releasedFontColor );
+        DrawLine( released[50], { offset + 0, offset + 9 }, { offset + 4, offset + 9 }, releasedFontColor );
+        DrawLine( released[50], { offset + 8, offset + 9 }, { offset + 11, offset + 9 }, releasedFontColor );
+        DrawLine( released[50], { offset + 3, offset + 5 }, { offset + 9, offset + 5 }, releasedFontColor );
+        DrawLine( released[50], { offset + 2, offset + 1 }, { offset + 2, offset + 8 }, releasedFontColor );
+        DrawLine( released[50], { offset + 10, offset + 1 }, { offset + 10, offset + 4 }, releasedFontColor );
+        DrawLine( released[50], { offset + 7, offset + 6 }, { offset + 9, offset + 8 }, releasedFontColor );
+
         // T
         released[52].resize( 11 + offset * 2, 10 + offset * 2 );
         released[52].reset();

--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -90,6 +90,13 @@ namespace
         return 0;
     }
 
+    int32_t getCharWidth( const uint8_t character, const fheroes2::FontType & fontType )
+    {
+        const fheroes2::Sprite & image = fheroes2::AGG::getChar( character, fontType );
+        assert( ( fontType.size != fheroes2::FontSize::BUTTON_RELEASED && fontType.size != fheroes2::FontSize::BUTTON_PRESSED && image.x() >= 0 ) || image.x() < 0 );
+        return image.x() + image.width();
+    }
+
     int32_t getLineWidth( const uint8_t * data, const int32_t size, const fheroes2::FontType & fontType )
     {
         assert( data != nullptr && size > 0 );
@@ -101,13 +108,13 @@ namespace
         const uint8_t * dataEnd = data + size;
         while ( data != dataEnd ) {
             if ( validator.isValid( *data ) ) {
-                width += fheroes2::AGG::getChar( *data, fontType ).width();
+                width += getCharWidth( *data, fontType );
             }
             else if ( isSpaceChar( *data ) ) {
                 width += getSpaceCharWidth( fontType.size );
             }
             else {
-                width += fheroes2::AGG::getChar( invalidChar, fontType ).width();
+                width += getCharWidth( invalidChar, fontType );
             }
             ++data;
         }
@@ -128,13 +135,13 @@ namespace
         const uint8_t * dataEnd = data + size;
         while ( data != dataEnd ) {
             if ( validator.isValid( *data ) ) {
-                width += fheroes2::AGG::getChar( *data, fontType ).width();
+                width += getCharWidth( *data, fontType );
             }
             else if ( isSpaceChar( *data ) ) {
                 width += getSpaceCharWidth( fontType.size );
             }
             else {
-                width += fheroes2::AGG::getChar( invalidChar, fontType ).width();
+                width += getCharWidth( invalidChar, fontType );
             }
 
             if ( width > maxWidth ) {
@@ -169,10 +176,10 @@ namespace
                 spaceWidth = 0;
 
                 if ( validator.isValid( *data ) ) {
-                    width += fheroes2::AGG::getChar( *data, fontType ).width();
+                    width += getCharWidth( *data, fontType );
                 }
                 else {
-                    width += fheroes2::AGG::getChar( invalidChar, fontType ).width();
+                    width += getCharWidth( invalidChar, fontType );
                 }
             }
             ++data;
@@ -222,7 +229,7 @@ namespace
                 ++lineLength;
                 if ( validator.isValid( *character ) ) {
                     ++lastWordLength;
-                    lineWidth += fheroes2::AGG::getChar( *character, fontType ).width();
+                    lineWidth += getCharWidth( *character, fontType );
                 }
                 else if ( isSpaceChar( *character ) ) {
                     lastWordLength = 0;
@@ -230,7 +237,7 @@ namespace
                 }
                 else {
                     ++lastWordLength;
-                    lineWidth += fheroes2::AGG::getChar( invalidChar, fontType ).width();
+                    lineWidth += getCharWidth( invalidChar, fontType );
                 }
 
                 if ( offset->x + lineWidth > maxWidth ) {
@@ -356,7 +363,7 @@ namespace
                 ++lineLength;
                 if ( validator.isValid( *character ) ) {
                     ++lastWordLength;
-                    lineWidth += fheroes2::AGG::getChar( *character, fontType ).width();
+                    lineWidth += getCharWidth( *character, fontType );
                 }
                 else if ( isSpaceChar( *character ) ) {
                     lastWordLength = 0;
@@ -364,7 +371,7 @@ namespace
                 }
                 else {
                     ++lastWordLength;
-                    lineWidth += fheroes2::AGG::getChar( invalidChar, fontType ).width();
+                    lineWidth += getCharWidth( invalidChar, fontType );
                 }
 
                 if ( offset->x + lineWidth > maxWidth ) {


### PR DESCRIPTION
Close https://github.com/ihhub/fheroes2/issues/5234

With letter spacing fixed we can
close https://github.com/ihhub/fheroes2/issues/5858

The 'A' is different from the OG since the automatic shadowing etc is different and I had to add a pair of pixels to fill some gaps.
![image](https://user-images.githubusercontent.com/12501091/191496517-ea26b750-a1e9-4f14-a0be-89ddcedd1040.png)

~~In the future it should be made possible to have the letter spacing be 2px smaller (i.e. 1px on each side of a letter) so that the buttons matche the OG main menu buttons:~~ This has been achieved in this PR.

![image](https://user-images.githubusercontent.com/12501091/190917035-50248796-8d45-4c1c-a1a3-4fef9c37eb5d.png)

![image](https://user-images.githubusercontent.com/12501091/191034384-94629b0a-fcab-4d3b-8da0-c3975c90ec76.png)


Aligned and tighter Difficulty button:
![image](https://user-images.githubusercontent.com/12501091/191497006-84e94551-b91a-4af8-8d49-9f47c7ef37b2.png)
