### PR TITLE
Before setting a handicap for a player, make sure that this player cannot be controlled by AI

### DIFF
--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -115,13 +115,18 @@ void Game::LoadPlayers( const std::string & mapFileName, Players & players )
     }
 
     players.clear();
+
     for ( const Player & p : savedPlayers ) {
         Player * player = new Player( p.GetColor() );
+
         player->SetRace( p.GetRace() );
         player->SetControl( p.GetControl() );
         player->SetFriends( p.GetFriends() );
         player->SetName( p.GetName() );
+        player->setHandicapStatus( p.getHandicapStatus() );
+
         players.push_back( player );
+
         Players::Set( Color::GetIndex( p.GetColor() ), player );
     }
 }
@@ -134,13 +139,20 @@ void Game::saveDifficulty( const int difficulty )
 void Game::SavePlayers( const std::string & mapFileName, const Players & players )
 {
     lastMapFileName = mapFileName;
+
     savedPlayers.clear();
+
     for ( const Player * p : players ) {
+        assert( p != nullptr );
+
         Player player( p->GetColor() );
+
         player.SetRace( p->GetRace() );
         player.SetControl( p->GetControl() );
         player.SetFriends( p->GetFriends() );
         player.SetName( p->GetName() );
+        player.setHandicapStatus( p->getHandicapStatus() );
+
         savedPlayers.push_back( player );
     }
 }

--- a/src/fheroes2/gui/player_info.cpp
+++ b/src/fheroes2/gui/player_info.cpp
@@ -494,7 +494,7 @@ bool Interface::PlayersInfo::QueueEventProcessing()
 
     player = getPlayerFromHandicapRoi( le.GetMouseCursor() );
     if ( player != nullptr ) {
-        if ( player->GetControl() & CONTROL_HUMAN ) {
+        if ( !( player->GetControl() & CONTROL_AI ) ) {
             switch ( player->getHandicapStatus() ) {
             case Player::HandicapStatus::NONE:
                 player->setHandicapStatus( Player::HandicapStatus::MILD );

--- a/src/fheroes2/system/players.cpp
+++ b/src/fheroes2/system/players.cpp
@@ -164,7 +164,7 @@ void Player::setHandicapStatus( const uint8_t status )
         return;
     }
 
-    assert( control & CONTROL_HUMAN );
+    assert( !( control & CONTROL_AI ) );
 
     _handicapStatus = status;
 }


### PR DESCRIPTION
Fix crash due to failed assertion when clicking on the handicap field for a player that can be controlled both by AI and a human player:

![handicap](https://user-images.githubusercontent.com/32623900/190923259-a27b49ee-8e42-4a8c-a3bf-92a222d96b9a.jpg)

Such players have both the `CONTROL_HUMAN` and `CONTROL_AI` flags at the same time.

Also, this PR adds functionality to remember handicap settings when restarting the same map in the same circumstances, as it has already been done for other player settings.