### PR TITLE
Make creature names lowercased

### DIFF
--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -293,7 +293,7 @@ bool ArmyBar::ActionBarCursor( ArmyTroop & troop )
 
         if ( &troop == troop2 ) {
             msg = _( "View %{name}" );
-            StringReplace( msg, "%{name}", troop.GetName() );
+            StringReplace( msg, "%{name}", Translation::StringLower( troop.GetName() ) );
         }
         else if ( !troop.isValid() ) {
             if ( !read_only ) {
@@ -304,24 +304,24 @@ bool ArmyBar::ActionBarCursor( ArmyTroop & troop )
                     msg = _( "Move or right click to redistribute %{name}" );
                 }
 
-                StringReplace( msg, "%{name}", troop2->GetName() );
+                StringReplace( msg, "%{name}", Translation::StringLower( troop2->GetName() ) );
             }
         }
         else if ( troop.GetID() == troop2->GetID() ) {
             if ( !read_only ) {
                 msg = _( "Combine %{name} armies" );
-                StringReplace( msg, "%{name}", troop.GetName() );
+                StringReplace( msg, "%{name}", Translation::StringLower( troop.GetName() ) );
             }
         }
         else if ( !read_only ) {
             msg = _( "Exchange %{name2} with %{name}" );
-            StringReplace( msg, "%{name}", troop.GetName() );
-            StringReplace( msg, "%{name2}", troop2->GetName() );
+            StringReplace( msg, "%{name}", Translation::StringLower( troop.GetName() ) );
+            StringReplace( msg, "%{name2}", Translation::StringLower( troop2->GetName() ) );
         }
     }
     else if ( troop.isValid() ) {
         msg = _( "Select %{name}" );
-        StringReplace( msg, "%{name}", troop.GetName() );
+        StringReplace( msg, "%{name}", Translation::StringLower( troop.GetName() ) );
     }
 
     return false;
@@ -334,14 +334,14 @@ bool ArmyBar::ActionBarCursor( ArmyTroop & destTroop, ArmyTroop & selectedTroop 
     if ( destTroop.isValid() ) {
         if ( destTroop.GetID() != selectedTroop.GetID() ) {
             msg = _( "Exchange %{name2} with %{name}" );
-            StringReplace( msg, "%{name}", destTroop.GetName() );
-            StringReplace( msg, "%{name2}", selectedTroop.GetName() );
+            StringReplace( msg, "%{name}", Translation::StringLower( destTroop.GetName() ) );
+            StringReplace( msg, "%{name2}", Translation::StringLower( selectedTroop.GetName() ) );
         }
         else if ( save_last_troop )
             msg = _( "Cannot move last troop" );
         else {
             msg = _( "Combine %{name} armies" );
-            StringReplace( msg, "%{name}", destTroop.GetName() );
+            StringReplace( msg, "%{name}", Translation::StringLower( destTroop.GetName() ) );
         }
     }
     else if ( save_last_troop )
@@ -354,7 +354,7 @@ bool ArmyBar::ActionBarCursor( ArmyTroop & destTroop, ArmyTroop & selectedTroop 
             msg = _( "Move or right click to redistribute %{name}" );
         }
 
-        StringReplace( msg, "%{name}", selectedTroop.GetName() );
+        StringReplace( msg, "%{name}", Translation::StringLower( selectedTroop.GetName() ) );
     }
 
     return false;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3320,7 +3320,7 @@ void Battle::Interface::RedrawActionMove( Unit & unit, const Indexes & path )
 
 #ifdef DEBUG_LOG
     std::string msg = _( "Moved %{monster}: %{src}, %{dst}" );
-    StringReplace( msg, "%{monster}", unit.GetName() );
+    StringReplace( msg, "%{monster}", Translation::StringLower( unit.GetName() ) );
     StringReplace( msg, "%{src}", unit.GetHeadIndex() );
 #else
     std::string msg = _( "Moved %{monster}" );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -842,7 +842,7 @@ void Battle::ArmiesOrder::QueueEventProcessing( std::string & msg, const fheroes
         const fheroes2::Rect unitRoi = unitPos.second + offset;
         if ( le.MouseCursor( unitRoi ) ) {
             msg = _( "View %{monster} info" );
-            StringReplace( msg, "%{monster}", unitPos.first->GetName() );
+            StringReplace( msg, "%{monster}", Translation::StringLower( unitPos.first->GetName() ) );
         }
 
         const Unit & unit = *( unitPos.first );
@@ -2180,7 +2180,7 @@ int Battle::Interface::GetBattleCursor( std::string & statusMsg ) const
         if ( b_enemy ) {
             if ( _currentUnit->GetCurrentColor() == b_enemy->GetColor() || ( _currentUnit == b_enemy ) ) {
                 statusMsg = _( "View %{monster} info" );
-                StringReplace( statusMsg, "%{monster}", b_enemy->GetMultiName() );
+                StringReplace( statusMsg, "%{monster}", Translation::StringLower( b_enemy->GetMultiName() ) );
                 return Cursor::WAR_INFO;
             }
             else {
@@ -2188,7 +2188,7 @@ int Battle::Interface::GetBattleCursor( std::string & statusMsg ) const
                     statusMsg = _( "Shoot %{monster}" );
                     statusMsg.append( " " );
                     statusMsg.append( _n( "(1 shot left)", "(%{count} shots left)", _currentUnit->GetShots() ) );
-                    StringReplace( statusMsg, "%{monster}", b_enemy->GetMultiName() );
+                    StringReplace( statusMsg, "%{monster}", Translation::StringLower( b_enemy->GetMultiName() ) );
                     StringReplace( statusMsg, "%{count}", _currentUnit->GetShots() );
 
                     return arena.IsShootingPenalty( *_currentUnit, *b_enemy ) ? Cursor::WAR_BROKENARROW : Cursor::WAR_ARROW;
@@ -2240,7 +2240,7 @@ int Battle::Interface::GetBattleCursor( std::string & statusMsg ) const
                         const int cursor = GetSwordCursorDirection( currentDirection );
 
                         statusMsg = _( "Attack %{monster}" );
-                        StringReplace( statusMsg, "%{monster}", b_enemy->GetName() );
+                        StringReplace( statusMsg, "%{monster}", Translation::StringLower( b_enemy->GetName() ) );
 
                         return cursor;
                     }
@@ -2249,7 +2249,7 @@ int Battle::Interface::GetBattleCursor( std::string & statusMsg ) const
         }
         else if ( cell->isReachableForHead() || cell->isReachableForTail() ) {
             statusMsg = _currentUnit->isFlying() ? _( "Fly %{monster} here" ) : _( "Move %{monster} here" );
-            StringReplace( statusMsg, "%{monster}", _currentUnit->GetName() );
+            StringReplace( statusMsg, "%{monster}", Translation::StringLower( _currentUnit->GetName() ) );
             return _currentUnit->isFlying() ? Cursor::WAR_FLY : Cursor::WAR_MOVE;
         }
     }
@@ -2298,7 +2298,7 @@ int Battle::Interface::GetBattleSpellCursor( std::string & statusMsg ) const
         else if ( b_stats && b_stats->AllowApplySpell( spell, _currentUnit->GetCurrentOrArmyCommander() ) ) {
             statusMsg = _( "Cast %{spell} on %{monster}" );
             StringReplace( statusMsg, "%{spell}", spell.GetName() );
-            StringReplace( statusMsg, "%{monster}", b_stats->GetName() );
+            StringReplace( statusMsg, "%{monster}", Translation::StringLower( b_stats->GetName() ) );
             return GetCursorFromSpell( spell.GetID() );
         }
         else if ( !spell.isApplyToFriends() && !spell.isApplyToEnemies() && !spell.isApplyToAnyTroops() ) {
@@ -3155,7 +3155,7 @@ void Battle::Interface::RedrawActionAttackPart2( Unit & attacker, const TargetsI
                 msg.append( " " );
                 msg.append( _n( "1 %{defender} perishes.", "%{count} %{defender} perish.", target.killed ) );
                 StringReplace( msg, "%{count}", target.killed );
-                StringReplace( msg, "%{defender}", target.defender->GetPluralName( target.killed ) );
+                StringReplace( msg, "%{defender}", Translation::StringLower( target.defender->GetPluralName( target.killed ) ) );
             }
         }
 
@@ -3324,7 +3324,7 @@ void Battle::Interface::RedrawActionMove( Unit & unit, const Indexes & path )
     StringReplace( msg, "%{src}", unit.GetHeadIndex() );
 #else
     std::string msg = _( "Moved %{monster}" );
-    StringReplace( msg, "%{monster}", unit.GetName() );
+    StringReplace( msg, "%{monster}", Translation::StringLower( unit.GetName() ) );
 #endif
 
     _currentUnit = nullptr;
@@ -3403,7 +3403,7 @@ void Battle::Interface::RedrawActionFly( Unit & unit, const Position & pos )
     }
 
     std::string msg = _( "Moved %{monster}: %{src}, %{dst}" );
-    StringReplace( msg, "%{monster}", unit.GetName() );
+    StringReplace( msg, "%{monster}", Translation::StringLower( unit.GetName() ) );
     StringReplace( msg, "%{src}", unit.GetHeadIndex() );
 
     Cursor::Get().SetThemes( Cursor::WAR_POINTER );
@@ -3499,7 +3499,7 @@ void Battle::Interface::RedrawActionResistSpell( const Unit & target, bool playS
         AudioManager::PlaySound( M82::RSBRYFZL );
     }
     std::string str( _( "The %{name} resist the spell!" ) );
-    StringReplace( str, "%{name}", target.GetName() );
+    StringReplace( str, "%{name}", Translation::StringLower( target.GetName() ) );
     status.SetMessage( str, true );
     status.SetMessage( "", false );
 }
@@ -3512,7 +3512,7 @@ void Battle::Interface::RedrawActionSpellCastStatus( const Spell & spell, int32_
 
     if ( target && ( target->GetHeadIndex() == dst || ( target->isWide() && target->GetTailIndex() == dst ) ) ) {
         msg = _( "%{name} casts %{spell} on the %{troop}." );
-        StringReplace( msg, "%{troop}", target->GetName() );
+        StringReplace( msg, "%{troop}", Translation::StringLower( target->GetName() ) );
     }
     else {
         msg = _( "%{name} casts %{spell}." );
@@ -3827,8 +3827,8 @@ void Battle::Interface::RedrawActionMonsterSpellCastStatus( const Spell & spell,
         break;
     }
 
-    StringReplace( msg, "%{attacker}", attacker.GetMultiName() );
-    StringReplace( msg, "%{target}", target.defender->GetName() );
+    StringReplace( msg, "%{attacker}", Translation::StringLower( attacker.GetMultiName() ) );
+    StringReplace( msg, "%{target}", Translation::StringLower( target.defender->GetName() ) );
 
     status.SetMessage( msg, true );
     status.SetMessage( "", false );
@@ -3842,7 +3842,7 @@ void Battle::Interface::RedrawActionLuck( const Unit & unit )
     const fheroes2::Rect & pos = unit.GetRectPosition();
 
     std::string msg = isGoodLuck ? _( "Good luck shines on the %{attacker}." ) : _( "Bad luck descends on the %{attacker}." );
-    StringReplace( msg, "%{attacker}", unit.GetName() );
+    StringReplace( msg, "%{attacker}", Translation::StringLower( unit.GetName() ) );
     status.SetMessage( msg, true );
 
     Cursor::Get().SetThemes( Cursor::WAR_POINTER );
@@ -3910,13 +3910,13 @@ void Battle::Interface::RedrawActionMorale( Unit & b, bool good )
 
     if ( good ) {
         msg = _( "High morale enables the %{monster} to attack again." );
-        StringReplace( msg, "%{monster}", b.GetName() );
+        StringReplace( msg, "%{monster}", Translation::StringLower( b.GetName() ) );
         status.SetMessage( msg, true );
         RedrawTroopWithFrameAnimation( b, ICN::MORALEG, M82::GOODMRLE, NONE );
     }
     else {
         msg = _( "Low morale causes the %{monster} to freeze in panic." );
-        StringReplace( msg, "%{monster}", b.GetName() );
+        StringReplace( msg, "%{monster}", Translation::StringLower( b.GetName() ) );
         status.SetMessage( msg, true );
         RedrawTroopWithFrameAnimation( b, ICN::MORALEB, M82::BADMRLE, WINCE );
     }
@@ -3954,7 +3954,7 @@ void Battle::Interface::RedrawActionTowerPart2( const Tower & tower, const Targe
         msg += ' ';
         msg.append( _n( "1 %{defender} perishes.", "%{count} %{defender} perish.", target.killed ) );
         StringReplace( msg, "%{count}", target.killed );
-        StringReplace( msg, "%{defender}", target.defender->GetPluralName( target.killed ) );
+        StringReplace( msg, "%{defender}", Translation::StringLower( target.defender->GetPluralName( target.killed ) ) );
     }
 
     if ( !isMirror ) {

--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -709,7 +709,7 @@ namespace Campaign
         case ScenarioBonusData::TROOP: {
             std::string description( _( "The main hero will have %{count} %{monster} at the start of the scenario." ) );
             StringReplace( description, "%{count}", std::to_string( _amount ) );
-            StringReplace( description, "%{monster}", Monster( _subType ).GetPluralName( _amount ) );
+            StringReplace( description, "%{monster}", Translation::StringLower( Monster( _subType ).GetPluralName( _amount ) ) );
             return description;
         }
         case ScenarioBonusData::SPELL: {

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -110,7 +110,7 @@ namespace
 
         const Monster monster( race, buildingId );
         std::string msgStatus = _( "Recruit %{name}" );
-        StringReplace( msgStatus, "%{name}", monster.GetMultiName() );
+        StringReplace( msgStatus, "%{name}", Translation::StringLower( monster.GetMultiName() ) );
         return msgStatus;
     }
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1865,7 +1865,7 @@ void ActionToArtifact( Heroes & hero, int32_t dst_index )
                 else {
                     msg = _(
                         "Through a clearing you observe an ancient artifact. Unfortunately, it's guarded by a nearby %{monster}. Do you want to fight the %{monster} for the artifact?" );
-                    StringReplace( msg, "%{monster}", troop->GetName() );
+                    StringReplace( msg, "%{monster}", Translation::StringLower( troop->GetName() ) );
                     battle = ( Dialog::YES == Dialog::Message( title, msg, Font::BIG, Dialog::YES | Dialog::NO ) );
                 }
             }
@@ -2257,7 +2257,7 @@ void ActionToDwellingJoinMonster( Heroes & hero, const MP2::MapObjectType object
 
     if ( troop.isValid() ) {
         std::string message = _( "A group of %{monster} with a desire for greater glory wish to join you. Do you accept?" );
-        StringReplace( message, "%{monster}", troop.GetMultiName() );
+        StringReplace( message, "%{monster}", Translation::StringLower( troop.GetMultiName() ) );
 
         AudioManager::PlaySound( M82::EXPERNCE );
 


### PR DESCRIPTION
This puts creature names in lowercase in the same situations as the OG, which are:
* Army bar (Move, info, redistribute, recruit)
* Battle log
* Artifact creature encounters

In addition this adds lowercase to this:
* Campaign bonus right-click description

This does **not** lowercase creature names if they're in the header of a dialog.

Relates to:
Closed PR:https://github.com/ihhub/fheroes2/pull/5321
Issue: https://github.com/ihhub/fheroes2/issues/5246