### PR TITLE
install_packages.bat: return nonzero value on error, update package hash

### DIFF
--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -7,13 +7,16 @@ set PKG_FILE_SHA256=290F84E793A120E8B555CF7A98D32232BC6E8B4C648EB05A50AD22C32966
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/windows-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-call :install_packages
+set EXIT_CODE=0
+
+call :install_packages || ^
+set EXIT_CODE=1
 
 if not "%CI%" == "true" (
     pause
 )
 
-exit /B
+exit /B %EXIT_CODE%
 
 :install_packages
 

--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -3,7 +3,7 @@
 set DST_DIR=%~dp0\..\..\VisualStudio\packages
 
 set PKG_FILE=windows.zip
-set PKG_FILE_SHA256=290F84E793A120E8B555CF7A98D32232BC6E8B4C648EB05A50AD22C329662D0B
+set PKG_FILE_SHA256=599DF9AE1C7A325EEE45A2B27F6DDC8179362CFF57699F87361E9E55A4B618B0
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/windows-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 


### PR DESCRIPTION
Currently, this bat file always returns zero, which is inconvenient in scripts. Also, update the package hash due to the inclusion of `SDL*main.lib`.