### PR TITLE
Add check for SDL2MAIN_FOUND to prevent linking to library that was not found 

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -54,7 +54,8 @@ target_include_directories(
 target_link_libraries(
 	engine
 	smacker
-	$<$<BOOL:${SDL2MAIN_FOUND}>:${${USE_SDL_VERSION}MAIN_LIBRARY}>
+	# In the case of SDL1, SDL_LIBRARY containts both SDLmain and SDL libraries
+	$<$<BOOL:${SDL2MAIN_FOUND}>:${${SDL2MAIN_LIBRARY}>
 	${${USE_SDL_VERSION}_LIBRARY}
 	${${USE_SDL_VERSION}_MIXER_LIBRARIES}
 	$<$<BOOL:${ENABLE_IMAGE}>:${${USE_SDL_VERSION}_IMAGE_LIBRARIES}>

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -54,7 +54,7 @@ target_include_directories(
 target_link_libraries(
 	engine
 	smacker
-	# In the case of SDL1, SDL_LIBRARY containts both SDLmain and SDL libraries
+	# In the case of SDL1, SDL_LIBRARY contains both SDLmain and SDL libraries
 	$<$<BOOL:${SDL2MAIN_FOUND}>:${${SDL2MAIN_LIBRARY}>
 	${${USE_SDL_VERSION}_LIBRARY}
 	${${USE_SDL_VERSION}_MIXER_LIBRARIES}

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -54,7 +54,7 @@ target_include_directories(
 target_link_libraries(
 	engine
 	smacker
-	${${USE_SDL_VERSION}MAIN_LIBRARY}
+	$<$<BOOL:${SDL2MAIN_FOUND}>:${${USE_SDL_VERSION}MAIN_LIBRARY}>
 	${${USE_SDL_VERSION}_LIBRARY}
 	${${USE_SDL_VERSION}_MIXER_LIBRARIES}
 	$<$<BOOL:${ENABLE_IMAGE}>:${${USE_SDL_VERSION}_IMAGE_LIBRARIES}>

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -55,7 +55,7 @@ target_link_libraries(
 	engine
 	smacker
 	# In the case of SDL1, SDL_LIBRARY contains both SDLmain and SDL libraries
-	$<$<BOOL:${SDL2MAIN_FOUND}>:${${SDL2MAIN_LIBRARY}>
+	$<$<BOOL:${SDL2MAIN_FOUND}>:${SDL2MAIN_LIBRARY}>
 	${${USE_SDL_VERSION}_LIBRARY}
 	${${USE_SDL_VERSION}_MIXER_LIBRARIES}
 	$<$<BOOL:${ENABLE_IMAGE}>:${${USE_SDL_VERSION}_IMAGE_LIBRARIES}>


### PR DESCRIPTION

Fixes cmake error mensioned in :https://github.com/ihhub/fheroes2/pull/5139:  
```
-- The C compiler identification is GNU 12.1.0
-- The CXX compiler identification is GNU 12.1.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /worktmp/yaraslau/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /worktmp/yaraslau/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found SDL2: /usr/lib64/libSDL2.so (found version "2.0.10") 
-- Found SDL2_mixer: /worktmp/yaraslau/lib/libSDL2_mixer.so (found version "2.6.2") 
-- Found ZLIB: /usr/lib64/libz.so (found version "1.2.11") 
-- Found Threads: TRUE  
-- Found SDL2_image: /worktmp/yaraslau/lib/libSDL2_image.so (found version "2.6.2") 
-- Found PNG: /usr/lib64/libpng.so (found version "1.6.34") 
-- Configuring done
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
SDL2MAIN_LIBRARY (ADVANCED)
    linked by target "engine" in directory /worktmp/yaraslau/repository/fheroes2/src/engine

-- Generating done
CMake Generate step failed.  Build files cannot be regenerated correctly.
```
