### PR TITLE
Implement Army Swap

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -207,6 +207,13 @@ Troops & Troops::operator=( const Troops & rhs )
     return *this;
 }
 
+Troops & Troops::operator=( Troops && troops )
+{
+    static_cast<std::vector<Troop *> &>( *this ) = std::move( troops );
+
+    return *this;
+}
+
 Troops::~Troops()
 {
     for ( iterator it = begin(); it != end(); ++it )
@@ -500,6 +507,15 @@ void Troops::MoveTroops( Troops & from, const int monsterIdToKeep )
 
     // Then, try to move as much of monsters to keep as we can (except the last one), if there is still a place for them
     moveTroops( false );
+}
+
+void Troops::swap( Troops & troops )
+{
+    if ( !isValid() || !troops.isValid() ) {
+        return;
+    }
+
+    std::swap( static_cast<std::vector<Troop *> &>( *this ), static_cast<std::vector<Troop *> &>( troops ) );
 }
 
 bool Troops::AllTroopsAreTheSame() const

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -48,6 +48,7 @@ public:
     Troops( const Troops & troops );
     virtual ~Troops();
     Troops & operator=( const Troops & rhs );
+    Troops & operator=( Troops && troops );
 
     void Assign( const Troop *, const Troop * );
     void Assign( const Troops & );
@@ -86,6 +87,7 @@ public:
     // Implements the necessary logic to move unit stacks from army to army using the arrow buttons in the
     // hero's meeting dialog
     void MoveTroops( Troops & from, const int monsterIdToKeep );
+    void swap( Troops & troops );
 
     void MergeTroops();
     Troops GetOptimized() const;

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -446,6 +446,19 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readOnly, const b
                 need_redraw = true;
             }
 
+            if ( HotKeyPressEvent( Game::HotKeyEvent::SWAP_ARMIES ) || ( !heroes.Guard() && le.MouseClickLeft( rectSign1 ) )
+                 || ( heroes.Guard() && le.MouseClickLeft( buttonSwap.area() ) ) ) {
+                GetArmy().swap( heroes.Guest()->GetArmy() );
+
+                if ( topArmyBar.isSelected() )
+                    topArmyBar.ResetSelected();
+                if ( bottomArmyBar.isSelected() )
+                    bottomArmyBar.ResetSelected();
+                topArmyBar.Redraw(display);
+                bottomArmyBar.Redraw(display);
+                need_redraw = true;
+            }
+
             if ( conf.ExtCastleAllowGuardians() && !readOnly ) {
                 Army * army1 = nullptr;
                 Army * army2 = nullptr;

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -203,6 +203,7 @@ namespace
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::JOIN_STACKS )] = { HotKeyCategory::MONSTER, "join stacks", fheroes2::Key::KEY_ALT };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::UPGRADE_TROOP )] = { HotKeyCategory::MONSTER, "upgrade troop", fheroes2::Key::KEY_U };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::DISMISS_TROOP )] = { HotKeyCategory::MONSTER, "dismiss troop", fheroes2::Key::KEY_D };
+        hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::SWAP_ARMIES )] = { HotKeyCategory::MONSTER, "swap troops", fheroes2::Key::KEY_SPACE };
 
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::TOWN_DWELLING_LEVEL_1 )] = { HotKeyCategory::CASTLE, "town dwelling level 1", fheroes2::Key::KEY_1 };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::TOWN_DWELLING_LEVEL_2 )] = { HotKeyCategory::CASTLE, "town dwelling level 2", fheroes2::Key::KEY_2 };

--- a/src/fheroes2/game/game_hotkeys.h
+++ b/src/fheroes2/game/game_hotkeys.h
@@ -121,6 +121,7 @@ namespace Game
         JOIN_STACKS,
         UPGRADE_TROOP,
         DISMISS_TROOP,
+        SWAP_ARMIES,
 
         TOWN_DWELLING_LEVEL_1,
         TOWN_DWELLING_LEVEL_2,

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -403,6 +403,10 @@ void Heroes::MeetingDialog( Heroes & otherHero )
             moveArmyToHero1.drawOnPress();
             moveArmyToHero2.drawOnRelease();
         }
+        else if ( le.MousePressRight( moveArmyToHero2.area() ) || le.MousePressRight( moveArmyToHero1.area() ) || HotKeyHoldEvent( Game::HotKeyEvent::SWAP_ARMIES ) ) {
+            moveArmyToHero1.drawOnPress();
+            moveArmyToHero2.drawOnPress();
+        }
         else {
             moveArmyToHero1.drawOnRelease();
             moveArmyToHero2.drawOnRelease();
@@ -578,6 +582,23 @@ void Heroes::MeetingDialog( Heroes & otherHero )
             }
 
             GetArmy().MoveTroops( otherHero.GetArmy(), keep ? keep->GetID() : Monster::UNKNOWN );
+
+            armyCountBackgroundRestorerLeft.restore();
+            armyCountBackgroundRestorerRight.restore();
+
+            selectArmy1.ResetSelected();
+            selectArmy2.ResetSelected();
+            selectArmy1.Redraw( display );
+            selectArmy2.Redraw( display );
+
+            moraleIndicator1.Redraw();
+            moraleIndicator2.Redraw();
+
+            display.render();
+        }
+        else if ( le.MouseClickRight( moveArmyToHero1.area() ) || le.MouseClickRight( moveArmyToHero2.area() ) || HotKeyPressEvent( Game::HotKeyEvent::SWAP_ARMIES )
+                  || HotKeyPressEvent( Game::HotKeyEvent::SWAP_ARMIES ) ) {
+            GetArmy().swap( otherHero.GetArmy() );
 
             armyCountBackgroundRestorerLeft.restore();
             armyCountBackgroundRestorerRight.restore();


### PR DESCRIPTION
A new attempt at the army swapping in this PR https://github.com/ihhub/fheroes2/pull/5456 after help from @ihhub and @oleg-derevenetz's explanations in that PR.
The move operator has been implemented, but the previous team's assignment/copy operator is still left as is. I've attempted to fix it several times up until now, but to no avail.

I'm marking it as draft since there's still one issue I need to figure out with the army bars not visually updating after the swap.
It can be seen here:
<details>
<summary>Click to show.</summary>

https://user-images.githubusercontent.com/12501091/194065756-eec9778a-6eef-4752-a175-931f715fd9cf.mp4
</details>


Also I'll implement a better UI solution for how to do the swap then the current right-click as commented in the previous PR.

Relates to https://github.com/ihhub/fheroes2/issues/4084.
