### PR TITLE
Display detailed information about the composition of alliances in the scenario info window

### DIFF
--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -21,25 +21,29 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include "game_over.h"
+#include <cassert>
+#include <cstddef>
+#include <utility>
+
 #include "audio_manager.h"
 #include "campaign_savedata.h"
 #include "castle.h"
+#include "color.h"
 #include "dialog.h"
 #include "game.h"
 #include "game_interface.h"
+#include "game_over.h"
 #include "game_video.h"
 #include "gamedefs.h"
 #include "kingdom.h"
 #include "mus.h"
+#include "players.h"
 #include "serialize.h"
 #include "settings.h"
 #include "text.h"
 #include "tools.h"
 #include "translations.h"
 #include "world.h"
-
-#include <cassert>
 
 namespace
 {
@@ -194,8 +198,51 @@ std::string GameOver::GetActualDescription( uint32_t cond )
     const Settings & conf = Settings::Get();
     std::string msg;
 
-    if ( WINS_ALL == cond || WINS_SIDE == cond )
+    if ( WINS_ALL == cond ) {
         msg = GetString( WINS_ALL );
+    }
+    else if ( cond == WINS_SIDE ) {
+        const Player * currentPlayer = Settings::Get().GetPlayers().GetCurrent();
+        assert( currentPlayer != nullptr );
+
+        const int currentColor = currentPlayer->GetColor();
+        const int friendColors = currentPlayer->GetFriends();
+
+        auto makeListOfPlayers = []( const int colors ) {
+            std::pair<std::string, size_t> result{ {}, 0 };
+
+            for ( const int col : Colors( colors ) ) {
+                const Player * player = Players::Get( col );
+                assert( player != nullptr );
+
+                ++result.second;
+
+                if ( result.second > 1 ) {
+                    result.first += ", ";
+                }
+
+                result.first += player->GetName();
+            }
+
+            return result;
+        };
+
+        const auto [alliesList, alliesCount] = makeListOfPlayers( friendColors & ~currentColor );
+        const auto [enemiesList, enemiesCount] = makeListOfPlayers( Game::GetKingdomColors() & ~friendColors );
+
+        assert( enemiesCount > 0 );
+
+        if ( alliesCount == 0 ) {
+            msg = Translation::ngettext( "You must defeat the enemy %{enemies}.", "You must defeat the enemy alliance of %{enemies}.", enemiesCount );
+            StringReplace( msg, "%{enemies}", enemiesList );
+        }
+        else {
+            msg = Translation::ngettext( "You and %{allies}, who is in alliance with you, must defeat the enemy %{enemies}.",
+                                         "You and %{allies}, who is in alliance with you, must defeat the enemy alliance of %{enemies}.", enemiesCount );
+            StringReplace( msg, "%{allies}", alliesList );
+            StringReplace( msg, "%{enemies}", enemiesList );
+        }
+    }
     else if ( WINS_TOWN & cond ) {
         const Castle * town = world.getCastleEntrance( conf.WinsMapsPositionObject() );
         if ( town ) {

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -235,8 +235,8 @@ std::string GameOver::GetActualDescription( uint32_t cond )
             StringReplace( msg, "%{enemies}", enemiesList );
         }
         else {
-            msg = Translation::ngettext( "You and %{allies}, who is in alliance with you, must defeat the enemy %{enemies}.",
-                                         "You and %{allies}, who is in alliance with you, must defeat the enemy alliance of %{enemies}.", enemiesCount );
+            msg = Translation::ngettext( "The alliance consisting of you, %{allies} must defeat the enemy %{enemies}.",
+                                         "The alliance consisting of you, %{allies} must defeat the enemy alliance of %{enemies}.", enemiesCount );
             StringReplace( msg, "%{allies}", alliesList );
             StringReplace( msg, "%{enemies}", enemiesList );
         }

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -235,8 +235,8 @@ std::string GameOver::GetActualDescription( uint32_t cond )
             StringReplace( msg, "%{enemies}", enemiesList );
         }
         else {
-            msg = Translation::ngettext( "The alliance consisting of you, %{allies} must defeat the enemy %{enemies}.",
-                                         "The alliance consisting of you, %{allies} must defeat the enemy alliance of %{enemies}.", enemiesCount );
+            msg = Translation::ngettext( "The alliance consisting of %{allies} and you must defeat the enemy %{enemies}.",
+                                         "The alliance consisting of %{allies} and you must defeat the enemy alliance of %{enemies}.", enemiesCount );
             StringReplace( msg, "%{allies}", alliesList );
             StringReplace( msg, "%{enemies}", enemiesList );
         }

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -215,7 +215,9 @@ std::string GameOver::GetActualDescription( uint32_t cond )
                 const Player * player = Players::Get( col );
                 assert( player != nullptr );
 
-                if ( ++result.second > 1 ) {
+                ++result.second;
+
+                if ( result.second > 1 ) {
                     result.first += ", ";
                 }
 

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -215,9 +215,7 @@ std::string GameOver::GetActualDescription( uint32_t cond )
                 const Player * player = Players::Get( col );
                 assert( player != nullptr );
 
-                ++result.second;
-
-                if ( result.second > 1 ) {
+                if ( ++result.second > 1 ) {
                     result.first += ", ";
                 }
 


### PR DESCRIPTION
fix #5793

The wording was deliberately changed to look better with different composition of alliances.

<img width="641" alt="Screenshot 2022-10-06 в 01 47 08" src="https://user-images.githubusercontent.com/32623900/194177737-db63a8bb-9efc-4519-9f2c-bf47436edec3.png">

<img width="641" alt="Screenshot 2022-10-06 в 01 50 46" src="https://user-images.githubusercontent.com/32623900/194178067-c0f1eb19-ea41-4485-a377-bb926e8ab9de.png">

<img width="641" alt="Screenshot 2022-10-06 в 01 48 00" src="https://user-images.githubusercontent.com/32623900/194177753-080420e4-d622-4af5-830e-2f22ef4bd6c6.png">

<img width="641" alt="Screenshot 2022-10-06 в 01 48 33" src="https://user-images.githubusercontent.com/32623900/194177764-99446c03-d0d6-48dd-b7ca-d90323393197.png">
