### PR TITLE
Fix neutral town unit growth

### DIFF
--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -564,8 +564,9 @@ void Castle::ActionNewWeek()
                 if ( ( dwellings1[ii] == DWELLING_MONSTER1 ) && ( building & BUILD_WEL2 ) )
                     growth += GetGrownWel2();
 
-                if ( isControlAI() )
+                if ( isControlAI() && !isNeutral ) {
                     growth = static_cast<uint32_t>( growth * Difficulty::GetUnitGrowthBonusForAI( Game::getDifficulty() ) );
+                }
 
                 // neutral town: half population (normal for begin month)
                 if ( isNeutral && !world.BeginMonth() )

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -568,9 +568,10 @@ void Castle::ActionNewWeek()
                     growth = static_cast<uint32_t>( growth * Difficulty::GetUnitGrowthBonusForAI( Game::getDifficulty() ) );
                 }
 
-                // neutral town: half population (normal for begin month)
-                if ( isNeutral && !world.BeginMonth() )
+                // Neutral towns always have half population growth.
+                if ( isNeutral ) {
                     growth /= 2;
+                }
 
                 *dw += growth;
             }


### PR DESCRIPTION
The growth should not be affected by game's difficulty. close #5905