### PR TITLE
Fix incorrect AI pathfinding for objects with artifacts

### DIFF
--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -91,16 +91,19 @@ namespace
             return otherHero->GetArmy().GetStrength() > armyStrength;
         }
 
-        // WINS_ARTIFACT victory condition does not apply to AI-controlled players, we should leave this artifact untouched for the human player
+        
         if ( MP2::isArtifactObject( objectType ) ) {
-            if ( isArtifactBagFull ) {
-                return true;
-            }
-
             const Artifact art = tile.QuantityArtifact();
+            if ( art.isValid() ) {
+                if ( isFindArtifactVictoryConditionForHuman( art ) ) {
+                    // WINS_ARTIFACT victory condition does not apply to AI-controlled players, we should leave this artifact untouched for the human player.
+                    return true;
+                }
 
-            if ( art.isValid() && isFindArtifactVictoryConditionForHuman( art ) ) {
-                return true;
+                if ( isArtifactBagFull && MP2::isPickupObject( objectType ) ) {
+                    // A hero cannot pickup this object on his way since his artifact bag is full.
+                    return true;
+                }
             }
         }
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -91,7 +91,6 @@ namespace
             return otherHero->GetArmy().GetStrength() > armyStrength;
         }
 
-        
         if ( MP2::isArtifactObject( objectType ) ) {
             const Artifact art = tile.QuantityArtifact();
             if ( art.isValid() ) {


### PR DESCRIPTION
An artifact should be valid and this object must be pickup, otherwise a hero is not blocked while going through the object.

close #5920