### PR TITLE
Update workflows with latest versions of the actions which runs on Node 16

### DIFF
--- a/.github/workflows/clang_analyzer.yml
+++ b/.github/workflows/clang_analyzer.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install dependencies and clang-tools
       run: |
         sudo apt-get -y update
@@ -25,7 +25,7 @@ jobs:
         FHEROES2_WITH_DEBUG: ON
         FHEROES2_WITH_IMAGE: ON
         FHEROES2_WITH_TOOLS: ON
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:
         name: scan-build-result

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 50
     - name: Install dependencies and clang-tidy
@@ -41,7 +41,7 @@ jobs:
         echo "${{ github.event.number }}" > clang-tidy-result/pr-id.txt
         echo "${{ github.event.pull_request.head.repo.full_name }}" > clang-tidy-result/pr-head-repo.txt
         echo "${{ github.event.pull_request.head.ref }}" > clang-tidy-result/pr-head-ref.txt
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: clang-tidy-result
         path: clang-tidy-result/

--- a/.github/workflows/clang_tidy_comments.yml
+++ b/.github/workflows/clang_tidy_comments.yml
@@ -39,7 +39,7 @@ jobs:
         echo "PR_ID=$(cat clang-tidy-result/pr-id.txt)" >> "$GITHUB_ENV"
         echo "PR_HEAD_REPO=$(cat clang-tidy-result/pr-head-repo.txt)" >> "$GITHUB_ENV"
         echo "PR_HEAD_REF=$(cat clang-tidy-result/pr-head-ref.txt)" >> "$GITHUB_ENV"
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: ${{ env.PR_HEAD_REPO }}
         ref: ${{ env.PR_HEAD_REF }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install dependencies (Linux)
       if: ${{ matrix.config.os == 'ubuntu-latest' }}
       run: |
@@ -62,7 +62,7 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Prepare vcpkg cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/code_style_check.yml
+++ b/.github/workflows/code_style_check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 50
     - name: Setup clang-format

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install dependencies (Linux)
       if: ${{ matrix.config.os == 'ubuntu-latest' }}
       run: |
@@ -85,7 +85,7 @@ jobs:
       run: |
         cp docs/README.txt script/demo/download_demo_version.sh script/homm2/extract_homm2_resources.sh .
         zip ${{ matrix.config.package_name }} ${{ matrix.config.package_files }}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ github.event_name == 'pull_request' && matrix.config.package_name != '' }}
       with:
         name: ${{ matrix.config.package_name }}
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
         sudo apt-get -y update
@@ -172,7 +172,7 @@ jobs:
         cp docs/README.txt docs/README_PSV.md .
         # Translations and H2D files are already included in fheroes2.vpk
         zip fheroes2_psv_sdl2.zip fheroes2.vpk LICENSE changelog.txt README.txt README_PSV.md
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ github.event_name == 'pull_request' }}
       with:
         name: fheroes2_psv_sdl2.zip
@@ -196,7 +196,7 @@ jobs:
     timeout-minutes: 30
     container: devkitpro/devkita64:latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
         sudo apt-get -y update
@@ -215,7 +215,7 @@ jobs:
       run: |
         cp docs/README.txt docs/README_switch.md .
         zip fheroes2_switch_sdl2.zip fheroes2.nro LICENSE changelog.txt README.txt README_switch.md files/lang/*.mo files/data/*.h2d
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ github.event_name == 'pull_request' }}
       with:
         name: fheroes2_switch_sdl2.zip

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -43,7 +43,7 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install dependencies and cygwin
       run: |
         script/windows/install_packages.bat
@@ -82,13 +82,13 @@ jobs:
         fi
       env:
         BUILD_DIR: build\${{ matrix.config.platform }}\${{ matrix.config.build_config }}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ github.event_name == 'pull_request' }}
       with:
         name: ${{ matrix.config.package_name }}_installer.exe
         path: build/${{ matrix.config.platform }}/${{ matrix.config.build_config }}/${{ matrix.config.package_name }}_installer.exe
         if-no-files-found: error
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ github.event_name == 'pull_request' }}
       with:
         name: ${{ matrix.config.package_name }}.zip

--- a/.github/workflows/pr_author_auto_assign.yml
+++ b/.github/workflows/pr_author_auto_assign.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: toshimaru/auto-author-assign@v1.4.0
+    - uses: toshimaru/auto-author-assign@v1.6.1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       SONAR_SCANNER_VERSION: 4.5.0.2216
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Install dependencies

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 10
     if: ${{ github.repository == 'ihhub/fheroes2' && ( github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) ) }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
         sudo apt-get -y update


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

~The latest version of `microsoft/setup-msbuild` action still uses Node 12, hopefully Micro$oft will fix it in the foreseeable future.~ Already fixed.