### PR TITLE
Use Clang 14 in Clang Analyzer, Clang-Tidy and Code style check workflows

### DIFF
--- a/.github/workflows/clang_analyzer.yml
+++ b/.github/workflows/clang_analyzer.yml
@@ -6,17 +6,17 @@ on:
 jobs:
   clang:
     name: Clang Analyzer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies and clang-tools
       run: |
         sudo apt-get -y update
-        sudo apt-get -y install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext clang-tools-12
+        sudo apt-get -y install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext clang-tools-14
     - name: Setup clang-tools
       run: |
-        sudo update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-12 100
+        sudo update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-14 100
     - name: Analyze
       run: |
         scan-build --status-bugs -v -o scan-build-result make -j 2

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   tidy:
     name: Clang-Tidy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
@@ -21,11 +21,11 @@ jobs:
     - name: Install dependencies and clang-tidy
       run: |
         sudo apt-get -y update
-        sudo apt-get -y install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext clang-tidy-12
+        sudo apt-get -y install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext clang-tidy-14
     - name: Setup clang-tidy
       run: |
-        sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-12 100
-        sudo update-alternatives --install /usr/bin/clang-tidy-diff clang-tidy-diff /usr/bin/clang-tidy-diff-12.py 100
+        sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-14 100
+        sudo update-alternatives --install /usr/bin/clang-tidy-diff clang-tidy-diff /usr/bin/clang-tidy-diff-14.py 100
     - name: Prepare compile_commands.json
       run: |
         cmake -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT_COMPILATION=ON -DENABLE_IMAGE=ON -DENABLE_TOOLS=ON -DUSE_SDL_VERSION=SDL2 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON

--- a/.github/workflows/code_style_check.yml
+++ b/.github/workflows/code_style_check.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   style:
     name: Code style check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v3
@@ -14,8 +14,8 @@ jobs:
         fetch-depth: 50
     - name: Setup clang-format
       run: |
-        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-12 100
-        sudo update-alternatives --install /usr/bin/clang-format-diff clang-format-diff /usr/bin/clang-format-diff-12 100
+        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-14 100
+        sudo update-alternatives --install /usr/bin/clang-format-diff clang-format-diff /usr/bin/clang-format-diff-14 100
     - name: Check code format
       run: |
         bash script/tools/check_code_format.sh


### PR DESCRIPTION
To better perform code diagnostics.