### PR TITLE
Fixed issue where soundfonts are not found in the files directory

### DIFF
--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -772,7 +772,11 @@ namespace AudioManager
             // Set the volume for all channels to 0. This is required to avoid random volume spikes at the beginning of the game.
             Mixer::setVolume( -1, 0 );
 
-            Music::SetMidiSoundFonts( midiSoundFonts );
+            // Some platforms (e.g. Linux) may have their own predefined soundfonts, don't overwrite them if we don't have our own
+            if ( !midiSoundFonts.empty() ) {
+                Music::SetMidiSoundFonts( midiSoundFonts );
+            }
+
             Music::setVolume( 100 * Settings::Get().MusicVolume() / 10 );
             Music::SetFadeInMs( 900 );
         }


### PR DESCRIPTION
closes #5986

If for some reason someone deleted the files/soundfont directory (or does not have it). The music will fail to play because the SDL_Mixer won't be able to find any sound fonts. 

The SDL_Mixer libs seem to be using default paths that we don't want to overwrite when no sound fonts have been found. 

This PR adds a condition before calling the Mix_SetSoundFonts function to make sure that we don't overwrite the paths with an empty string.