### PR TITLE
Update extract_homm2_resources.ps1

### DIFF
--- a/script/homm2/extract_homm2_resources.ps1
+++ b/script/homm2/extract_homm2_resources.ps1
@@ -69,7 +69,7 @@ try {
                        "HKEY_CURRENT_USER\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
                        "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
                        "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
-		       "HKEY_LOCAL_MACHINE\SOFTWARE\New World Computing\Heroes of Might and Magic 2")) {
+                       "HKEY_LOCAL_MACHINE\SOFTWARE\New World Computing\Heroes of Might and Magic 2")) {
         if (-Not (Test-Path -Path "Microsoft.PowerShell.Core\Registry::$key" -PathType Container)) {
             continue
         }
@@ -77,19 +77,19 @@ try {
         foreach ($subkey in (Get-ChildItem -Path "Microsoft.PowerShell.Core\Registry::$key")) {
             $path = $subkey.GetValue("InstallLocation")
             
-	    # Legacy installed path detection
+            # Legacy installed path detection
             if ($null -Eq $path) {
             	$path = $subkey.GetValue("AppPath")
             }
 	    
             if ($null -Ne $path) {
                 $path = $path.TrimEnd("\")
-            	# Legacy installed drive path detection
-            	$DrivePath = $subkey.GetValue("CDDrive")
+
 				
                 if (Test-HoMM2DirectoryPath -Path $path) {
                     $homm2Path = $path
-                    $homm2DrivePath = $DrivePath
+                    # Legacy installed drive path detection
+                    $homm2DrivePath = $subkey.GetValue("CDDrive")
 
                     break
                 }
@@ -119,7 +119,10 @@ try {
         $shell = New-Object -ComObject "Shell.Application"
 
         foreach ($homm2Dir in @($homm2Path, $homm2DrivePath )) {
-		
+            if ($null -Eq $homm2Dir) {
+                continue
+            }
+			
             foreach ($srcDir in @("HEROES2\ANIM", "ANIM", "DATA", "MAPS", "MUSIC")) {
                 if (-Not (Test-Path -Path "$homm2Dir\$srcDir" -PathType Container)) {
                     continue
@@ -136,7 +139,7 @@ try {
                 foreach ($item in $content.Items()) {
                     $shell.Namespace((Resolve-Path "$destPath\$destDir").Path).CopyHere($item, 0x14)
 
-		}
+                }
             }
         }
     }

--- a/script/homm2/extract_homm2_resources.ps1
+++ b/script/homm2/extract_homm2_resources.ps1
@@ -64,28 +64,28 @@ try {
 
     $homm2Path = $null
     $homm2DrivePath = $null
-	
+
     foreach ($key in @("HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
                        "HKEY_CURRENT_USER\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
-                       "HKEY_LOCAL_MACHINE\SOFTWARE\New World Computing\Heroes of Might and Magic 2",
                        "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
-                       "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall")) {
+                       "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
+		       "HKEY_LOCAL_MACHINE\SOFTWARE\New World Computing\Heroes of Might and Magic 2")) {
         if (-Not (Test-Path -Path "Microsoft.PowerShell.Core\Registry::$key" -PathType Container)) {
             continue
         }
 
         foreach ($subkey in (Get-ChildItem -Path "Microsoft.PowerShell.Core\Registry::$key")) {
             $path = $subkey.GetValue("InstallLocation")
-			
-			# Legacy installed path detection
-			if ($null -Eq $path) {
-				$path = $subkey.GetValue("AppPath")
-			}
-			
+            
+	    # Legacy installed path detection
+            if ($null -Eq $path) {
+            	$path = $subkey.GetValue("AppPath")
+            }
+	    
             if ($null -Ne $path) {
                 $path = $path.TrimEnd("\")
-				# Legacy installed drive path detection
-				$DrivePath = $subkey.GetValue("CDDrive")
+            	# Legacy installed drive path detection
+            	$DrivePath = $subkey.GetValue("CDDrive")
 				
                 if (Test-HoMM2DirectoryPath -Path $path) {
                     $homm2Path = $path
@@ -117,29 +117,28 @@ try {
         Write-Host -ForegroundColor Green "Apparently fheroes2 was installed to the directory of the original game, there is no need to copy anything"
     } else {
         $shell = New-Object -ComObject "Shell.Application"
-	
+
         foreach ($homm2Dir in @($homm2Path, $homm2DrivePath )) {
 		
-			foreach ($srcDir in @("HEROES2\ANIM", "ANIM", "DATA", "MAPS", "MUSIC")) {
-				if (-Not (Test-Path -Path "$homm2Dir\$srcDir" -PathType Container)) {
-					continue
-				}
+            foreach ($srcDir in @("HEROES2\ANIM", "ANIM", "DATA", "MAPS", "MUSIC")) {
+                if (-Not (Test-Path -Path "$homm2Dir\$srcDir" -PathType Container)) {
+                    continue
+                }
 
-				$destDir = (Split-Path $srcDir -Leaf).ToLower()
+                $destDir = (Split-Path $srcDir -Leaf).ToLower()
 
-				if (-Not (Test-Path -Path "$destPath\$destDir" -PathType Container)) {
-					[void](New-Item -Path "$destPath\$destDir" -ItemType "directory")
-				}
+                if (-Not (Test-Path -Path "$destPath\$destDir" -PathType Container)) {
+                    [void](New-Item -Path "$destPath\$destDir" -ItemType "directory")
+                }
 
-				$content = $shell.NameSpace((Resolve-Path "$homm2Dir\$srcDir").Path)
+                $content = $shell.NameSpace((Resolve-Path "$homm2Dir\$srcDir").Path)
 
-				foreach ($item in $content.Items()) {
-					$shell.Namespace((Resolve-Path "$destPath\$destDir").Path).CopyHere($item, 0x14)
+                foreach ($item in $content.Items()) {
+                    $shell.Namespace((Resolve-Path "$destPath\$destDir").Path).CopyHere($item, 0x14)
 
-				}
-
-			}
 		}
+            }
+        }
     }
 
     # Special case - CD image from GOG

--- a/script/homm2/extract_homm2_resources.ps1
+++ b/script/homm2/extract_homm2_resources.ps1
@@ -77,19 +77,24 @@ try {
 
         foreach ($subkey in (Get-ChildItem -Path "Microsoft.PowerShell.Core\Registry::$key")) {
             $path = $subkey.GetValue("InstallLocation")
+            $cdDrive = $null
 
             if ($null -Eq $path) {
                 # From HKLM\SOFTWARE\New World Computing\Heroes of Might and Magic 2
             	$path = $subkey.GetValue("AppPath")
+                $cdDrive = $subkey.GetValue("CDDrive")
             }
 
             if ($null -Ne $path) {
                 $path = $path.TrimEnd("\")
 
+                if ($null -Ne $cdDrive) {
+                    $cdDrive = $cdDrive.TrimEnd("\")
+                }
+
                 if (Test-HoMM2DirectoryPath -Path $path) {
                     $homm2Path = $path
-                    # From HKLM\SOFTWARE\New World Computing\Heroes of Might and Magic 2
-                    $homm2CD = $subkey.GetValue("CDDrive")
+                    $homm2CD = $cdDrive
 
                     break
                 }
@@ -112,7 +117,7 @@ try {
     Write-Host -ForegroundColor Green (-Join("HoMM2 directory: ", (Resolve-Path $homm2Path).Path))
 
     if ($null -Ne $homm2CD) {
-        Write-Host -ForegroundColor Green (-Join("HoMM2 CD drive: ", (Resolve-Path $homm2CD).Path))
+        Write-Host -ForegroundColor Green "HoMM2 CD drive: $homm2CD"
     }
 
     Write-Host "[3/3] copying game resources"

--- a/script/homm2/extract_homm2_resources.ps1
+++ b/script/homm2/extract_homm2_resources.ps1
@@ -122,7 +122,7 @@ try {
     } else {
         $shell = New-Object -ComObject "Shell.Application"
 
-        foreach ($homm2Dir in @($homm2Path, $homm2CD )) {
+        foreach ($homm2Dir in @($homm2Path, $homm2CD)) {
             if ($null -Eq $homm2Dir) {
                 continue
             }

--- a/script/homm2/extract_homm2_resources.ps1
+++ b/script/homm2/extract_homm2_resources.ps1
@@ -76,16 +76,15 @@ try {
 
         foreach ($subkey in (Get-ChildItem -Path "Microsoft.PowerShell.Core\Registry::$key")) {
             $path = $subkey.GetValue("InstallLocation")
-            
+
             # Legacy installed path detection
             if ($null -Eq $path) {
             	$path = $subkey.GetValue("AppPath")
             }
-	    
+
             if ($null -Ne $path) {
                 $path = $path.TrimEnd("\")
 
-				
                 if (Test-HoMM2DirectoryPath -Path $path) {
                     $homm2Path = $path
                     # Legacy installed drive path detection
@@ -122,7 +121,7 @@ try {
             if ($null -Eq $homm2Dir) {
                 continue
             }
-			
+
             foreach ($srcDir in @("HEROES2\ANIM", "ANIM", "DATA", "MAPS", "MUSIC")) {
                 if (-Not (Test-Path -Path "$homm2Dir\$srcDir" -PathType Container)) {
                     continue
@@ -138,7 +137,6 @@ try {
 
                 foreach ($item in $content.Items()) {
                     $shell.Namespace((Resolve-Path "$destPath\$destDir").Path).CopyHere($item, 0x14)
-
                 }
             }
         }

--- a/script/homm2/extract_homm2_resources.ps1
+++ b/script/homm2/extract_homm2_resources.ps1
@@ -63,6 +63,7 @@ try {
     Write-Host "[2/3] determining the HoMM2 directory"
 
     $homm2Path = $null
+    # Some legacy HoMM2 installation use a CD drive
     $homm2CD = $null
 
     foreach ($key in @("HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",


### PR DESCRIPTION
Added support for extracting resources from orignal game released in Gold Edition by CDPROJEKT in Czech Republic in 2002. All needed files are automatically grabbed from installed game path + drive path too. In my original release is needed CD to play as it also have some of game files.

With this modification is not needed manual input and everything is done automatically. In my tests was mounted game ISO, then installed game, ISO keep mounted and then launch grabbing script. No issues detected. Test was done under Windows XP SP3