### PR TITLE
Update the dependency package hash for Windows

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,19 +12,16 @@ jobs:
   style:
     name: Code style check
     uses: ./.github/workflows/code_style_check.yml
-
   clang:
     name: Clang Analyzer
     needs:
     - style
     uses: ./.github/workflows/clang_analyzer.yml
-
   msvc:
     name: MSVC
     needs:
     - style
     uses: ./.github/workflows/msvc.yml
-
   sonarcloud:
     name: SonarCloud Analyzer
     needs:
@@ -32,13 +29,11 @@ jobs:
     uses: ./.github/workflows/sonarcloud.yml
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
   cmake:
     name: CMake
     needs:
     - msvc
     uses: ./.github/workflows/cmake.yml
-
   make:
     name: Make
     needs:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,17 +12,14 @@ jobs:
   make:
     name: Make
     uses: ./.github/workflows/make.yml
-
   msvc:
     name: MSVC
     uses: ./.github/workflows/msvc.yml
-
   sonarcloud:
     name: SonarCloud Analyzer
     uses: ./.github/workflows/sonarcloud.yml
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
   translation:
     name: Translation update
     needs:

--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -3,7 +3,7 @@
 set DST_DIR=%~dp0\..\..\VisualStudio\packages
 
 set PKG_FILE=windows.zip
-set PKG_FILE_SHA256=599DF9AE1C7A325EEE45A2B27F6DDC8179362CFF57699F87361E9E55A4B618B0
+set PKG_FILE_SHA256=139382B653B2C38A7D523184ADA2C651AE79D6D692A2673FDBFCF1D4098FBF54
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/windows-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 


### PR DESCRIPTION
Downgrade SDL2 to 2.0.22 due to #5984, plus minor style nits.