### PR TITLE
Clang-Tidy: disable the readability-identifier-length check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,6 +23,7 @@ Checks: >-
   -readability-avoid-const-params-in-decls,
   -readability-braces-around-statements,
   -readability-function-cognitive-complexity,
+  -readability-identifier-length,
   -readability-implicit-bool-conversion,
   -readability-magic-numbers
 


### PR DESCRIPTION
There are lots of valid and clear identifier names like `x`/`y`, `px`/`py`, `pt`, etc, etc.