### PR TITLE
Fix the GitHub Actions status badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This repository is a place for everyone. If you want to contribute, please read 
 
 To build the project from source, please follow [**this guide**](docs/DEVELOPMENT.md).
 
-[![Build Status](https://github.com/ihhub/fheroes2/workflows/GitHub%20Actions/badge.svg)](https://github.com/ihhub/fheroes2/actions)
+[![Build Status](https://github.com/ihhub/fheroes2/actions/workflows/push.yml/badge.svg)](https://github.com/ihhub/fheroes2/actions)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=ihhub_fheroes2&metric=bugs)](https://sonarcloud.io/dashboard?id=ihhub_fheroes2)
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=ihhub_fheroes2&metric=code_smells)](https://sonarcloud.io/dashboard?id=ihhub_fheroes2)
 [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=ihhub_fheroes2&metric=duplicated_lines_density)](https://sonarcloud.io/dashboard?id=ihhub_fheroes2)

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@ This repository is a place for everyone. If you want to contribute, please read 
 
 To build the project from source, please follow [**this guide**](DEVELOPMENT.md).
 
-[![Build Status](https://github.com/ihhub/fheroes2/workflows/GitHub%20Actions/badge.svg)](https://github.com/ihhub/fheroes2/actions)
+[![Build Status](https://github.com/ihhub/fheroes2/actions/workflows/push.yml/badge.svg)](https://github.com/ihhub/fheroes2/actions)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=ihhub_fheroes2&metric=bugs)](https://sonarcloud.io/dashboard?id=ihhub_fheroes2)
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=ihhub_fheroes2&metric=code_smells)](https://sonarcloud.io/dashboard?id=ihhub_fheroes2)
 [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=ihhub_fheroes2&metric=duplicated_lines_density)](https://sonarcloud.io/dashboard?id=ihhub_fheroes2)


### PR DESCRIPTION
I don't know where exactly the previous badge URL came from, because I was not able to find it in the documentation. The documented badge URL syntax is as follows:

https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge

And the former URL doesn't work anymore (404 not found):

https://github.com/ihhub/fheroes2/workflows/GitHub%20Actions/badge.svg

Maybe it was a some legacy URL.