### PR TITLE
Add scripts for Windows, Linux and macOS to install Android pre-built packages

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,9 +3,6 @@ name: Android
 on:
   workflow_call:
 
-env:
-  ANDROID_DEPS_URL: https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/android.zip
-
 jobs:
   android:
     name: Android
@@ -15,8 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
-        wget "$ANDROID_DEPS_URL"
-        unzip -d android android.zip
+        bash script/android/install_packages.sh
     - name: Build
       run: |
         cd android

--- a/.gitignore
+++ b/.gitignore
@@ -82,5 +82,10 @@ script/demo/demo
 # Installed packages for Visual Studio
 VisualStudio/packages
 
+# Third-party packages for Android Studio
+android/app/jni/SDL2/
+android/app/jni/SDL2_mixer/
+android/sdl2/
+
 # Mac magic folders
 .DS_Store

--- a/script/android/README.md
+++ b/script/android/README.md
@@ -1,0 +1,4 @@
+Package installation for Android Studio
+======
+
+Run "install_packages.bat" file and it would try to install everything in one shot.

--- a/script/android/README.md
+++ b/script/android/README.md
@@ -1,4 +1,4 @@
 Package installation for Android Studio
 ======
 
-Run "install_packages.bat" file and it would try to install everything in one shot.
+Run the `install_packages.bat` or `install_packages.sh` and it will try to install everything at once.

--- a/script/android/install_packages.bat
+++ b/script/android/install_packages.bat
@@ -1,0 +1,60 @@
+@echo off
+
+set DST_DIR=%~dp0\..\..\android
+
+set PKG_FILE=android.zip
+set PKG_FILE_SHA256=E45DEC4D0A15DD4E159F6021D0BC52A7DA0326E74625571A9AFBAA8833207886
+set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/%PKG_FILE%
+set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+set EXIT_CODE=0
+
+call :install_packages || ^
+set EXIT_CODE=1
+
+if not "%CI%" == "true" (
+    pause
+)
+
+exit /B %EXIT_CODE%
+
+:install_packages
+
+if not exist "%DST_DIR%" ( mkdir "%DST_DIR%" || exit /B 1 )
+
+echo Downloading %PKG_URL%                                                                                        && ^
+powershell -Command "%PKG_TLS%; (New-Object System.Net.WebClient).DownloadFile('%PKG_URL%', '%TEMP%\%PKG_FILE%')" || ^
+exit /B 1
+
+set HASH_CALCULATED=false
+
+for /F "usebackq delims=" %%H in (`powershell -Command "(certutil.exe -hashfile '%TEMP%\%PKG_FILE%' sha256 | Select-String -Pattern '^[0-9A-Fa-f]{64}$').Line.ToUpper()"`) do (
+    set HASH_CALCULATED=true
+
+    if not "%%H" == "%PKG_FILE_SHA256%" (
+        echo Invalid hash for %PKG_FILE%: expected %PKG_FILE_SHA256%, got %%H
+        exit /B 1
+    )
+)
+
+if not "%HASH_CALCULATED%" == "true" (
+    echo Failed to calculate hash for %PKG_FILE%
+    exit /B 1
+)
+
+call :unpack_archive "%TEMP%\%PKG_FILE%" "%DST_DIR%" || ^
+exit /B 1
+
+exit /B
+
+:unpack_archive
+
+echo Unpacking %~n1%~x1
+
+if "%CI%" == "true" (
+    powershell -Command "Expand-Archive -LiteralPath '%~1' -DestinationPath '%~2' -Force" || exit /B 1
+) else (
+    powershell -Command "$shell = New-Object -ComObject 'Shell.Application'; $zip = $shell.NameSpace((Resolve-Path '%~1').Path); foreach ($item in $zip.items()) { $shell.Namespace((Resolve-Path '%~2').Path).CopyHere($item, 0x14) }" || exit /B 1
+)
+
+exit /B

--- a/script/android/install_packages.sh
+++ b/script/android/install_packages.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+PKG_FILE="android.zip"
+PKG_FILE_SHA256="e45dec4d0a15dd4e159f6021d0bc52a7da0326e74625571a9afbaa8833207886"
+PKG_URL="https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/$PKG_FILE"
+
+TMP_DIR="$(mktemp -d)"
+
+if [[ "$(command -v wget)" != "" ]]; then
+    wget -O "$TMP_DIR/$PKG_FILE" "$PKG_URL"
+elif [[ "$(command -v curl)" != "" ]]; then
+    curl -o "$TMP_DIR/$PKG_FILE" -L "$PKG_URL"
+else
+    echo "Neither wget nor curl were found in your system. Unable to download the package archive. Installation aborted."
+    exit 1
+fi
+
+echo "$PKG_FILE_SHA256 *$PKG_FILE" > "$TMP_DIR/checksums"
+
+if [[ "$(command -v shasum)" != "" ]]; then
+    (cd "$TMP_DIR" && shasum --check --algorithm 256 checksums)
+elif [[ "$(command -v sha256sum)" != "" ]]; then
+    (cd "$TMP_DIR" && sha256sum --check --strict checksums)
+else
+    echo "Neither shasum nor sha256sum were found in your system. Unable to verify the downloaded file. Installation aborted."
+    exit 1
+fi
+
+unzip -d "$(dirname "$0")/../../android" "$TMP_DIR/$PKG_FILE"

--- a/script/demo/download_demo_version.sh
+++ b/script/demo/download_demo_version.sh
@@ -54,7 +54,7 @@ cd "$DEST_PATH/demo"
 if [[ "$(command -v wget)" != "" ]]; then
     wget -O h2demo.zip "$H2DEMO_URL"
 elif [[ "$(command -v curl)" != "" ]]; then
-    curl -O -L "$H2DEMO_URL" > h2demo.zip
+    curl -o h2demo.zip -L "$H2DEMO_URL"
 else
     echo_red "Neither wget nor curl were found in your system. Unable to download the demo version. Installation aborted."
     exit 1

--- a/script/windows/README.md
+++ b/script/windows/README.md
@@ -1,4 +1,4 @@
 Package installation for Visual Studio
 ======
 
-Run "install_packages.bat" file and it would try to install everything in one shot.
+Run the `install_packages.bat` and it will try to install everything at once.


### PR DESCRIPTION
Related to #6008

Also make `curl` call in the `download_demo_version.sh` a bit more sane.