### PR TITLE
Take Magic Book into account while visiting a castle by an AI hero

### DIFF
--- a/src/fheroes2/resource/resource.h
+++ b/src/fheroes2/resource/resource.h
@@ -83,10 +83,14 @@ public:
     Funds & operator-=( const Funds & );
     Funds & operator=( const cost_t & );
 
+    bool operator>=( const Funds & ) const;
+    bool operator<( const Funds & funds ) const
+    {
+        return !operator>=( funds );
+    }
+
     int32_t Get( int rs ) const;
     int32_t * GetPtr( int rs );
-
-    bool operator>=( const Funds & ) const;
 
     int getLowestQuotient( const Funds & ) const;
     int GetValidItems() const;


### PR DESCRIPTION
Spells are valuable but they are useless if a hero does not have a magic book or cannot get one.

Also this pull request fixes incorrect evaluable of monsters to hire when a hero has no magic book. In `void Normal::reinforceHeroInCastle()` method we first buy a magic book and then buy monsters.