### PR TITLE
Fix various audio distortions on Android

### DIFF
--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -53,7 +53,12 @@ namespace
             format = AUDIO_S16;
             channels = 2; // Support stereo audio.
             silence = 0;
+#if defined( ANDROID )
+            // TODO: a value greater than 1024 causes audio distortion on Android
+            samples = 1024;
+#else
             samples = 2048;
+#endif
             size = 0;
             // TODO: research if we need to utilize these 2 paremeters in the future.
             callback = nullptr;


### PR DESCRIPTION
I believe the root of the issue lies in SDL2 itself, but here's a workaround.

P.S. I just noticed that with `samples = 2048` there were excessive messages in the logcat like this:

```
D/AAudio: AAudioStream_requestPause(s#1) called
D/: PlayerBase::pause() from IPlayer
D/AAudio: AAudioStream_requestStart(s#1) called --------------
D/: PlayerBase::start() from IPlayer
D/AAudio: AAudioStream_requestStart(s#1) returned 0 ---------
D/AAudio: AAudioStream_requestPause(s#1) called
D/: PlayerBase::pause() from IPlayer
D/AAudio: AAudioStream_requestStart(s#1) called --------------
D/: PlayerBase::start() from IPlayer
D/AAudio: AAudioStream_requestStart(s#1) returned 0 ---------
D/AAudio: AAudioStream_requestPause(s#1) called
D/: PlayerBase::pause() from IPlayer
D/AAudio: AAudioStream_requestStart(s#1) called --------------
D/: PlayerBase::start() from IPlayer
D/AAudio: AAudioStream_requestStart(s#1) returned 0 ---------
```

and with `samples = 1024` they are gone.