### PR TITLE
Modify and fix base font characters

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -826,7 +826,7 @@ namespace fheroes2
                             letter.setPosition( letter.x(), letter.y() - 1 );
                         }
                     }
-                    editOriginalFont( _icnVsSprite[id], false );
+                    modifyBaseSmallFont( _icnVsSprite[id] );
                 }
 
                 if ( id == ICN::FONT ) {
@@ -834,7 +834,7 @@ namespace fheroes2
                     for ( size_t i = 0; i < imageArray.size(); ++i ) {
                         ReplaceColorIdByTransformId( imageArray[i], 50, 2 );
                     }
-                    editOriginalFont( _icnVsSprite[id], true );
+                    modifyBaseNormalFont( _icnVsSprite[id] );
                 }
 
                 // Some checks that we really have CP1251 font

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -826,6 +826,7 @@ namespace fheroes2
                             letter.setPosition( letter.x(), letter.y() - 1 );
                         }
                     }
+                    editOriginalFont( _icnVsSprite[id], false );
                 }
 
                 if ( id == ICN::FONT ) {
@@ -833,6 +834,7 @@ namespace fheroes2
                     for ( size_t i = 0; i < imageArray.size(); ++i ) {
                         ReplaceColorIdByTransformId( imageArray[i], 50, 2 );
                     }
+                    editOriginalFont( _icnVsSprite[id], true );
                 }
 
                 // Some checks that we really have CP1251 font

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -4203,7 +4203,7 @@ namespace fheroes2
         updateButtonFont( icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED], icnVsSprite[ICN::BUTTON_GOOD_FONT_PRESSED], icnVsSprite[ICN::BUTTON_EVIL_FONT_RELEASED],
                           icnVsSprite[ICN::BUTTON_EVIL_FONT_PRESSED] );
     }
-    void editOriginalFont( std::vector<fheroes2::Sprite> & icnVsSprite, const bool normalFont ) 
+    void editOriginalFont( std::vector<fheroes2::Sprite> & icnVsSprite, const bool normalFont )
     {
         if ( normalFont ) {
             // Proper lowercase k. Kept at end in case any letters use it for generation.

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -4219,7 +4219,7 @@ namespace fheroes2
         updateNormalFontLetterShadow( icnVsSprite[75] );
     }
 
-    void modifyBaseSmallFont(std::vector<fheroes2::Sprite>& icnVsSprite)
+    void modifyBaseSmallFont( std::vector<fheroes2::Sprite> & icnVsSprite )
     {
         assert( icnVsSprite.size() > 0 );
 

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -4148,6 +4148,11 @@ namespace fheroes2
     {
         assert( !icnVsSprite.empty() );
 
+        // Remove white line from % symbol
+        fheroes2::FillTransform( icnVsSprite[5], 3, 0, 4, 1, 1 );
+        fheroes2::FillTransform( icnVsSprite[5], 4, 1, 2, 1, 1 );
+        updateNormalFontLetterShadow( icnVsSprite[5] );
+
         // Proper lowercase k.
         icnVsSprite[75].resize( 6, 8 );
         icnVsSprite[75].reset();

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -4124,6 +4124,11 @@ namespace fheroes2
     {
         assert( !icnVsSprite.empty() );
 
+        // Remove white line from % symbol
+        fheroes2::FillTransform( icnVsSprite[5], 5, 0, 5, 1, 1 );
+        fheroes2::FillTransform( icnVsSprite[5], 6, 2, 2, 1, 1 );
+        updateNormalFontLetterShadow( icnVsSprite[5] );
+
         // Proper lowercase k.
         fheroes2::FillTransform( icnVsSprite[75], 4, 1, 5, 8, 1 );
         fheroes2::Copy( icnVsSprite[43], 6, 5, icnVsSprite[75], 4, 7, 3, 1 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -4203,6 +4203,7 @@ namespace fheroes2
         updateButtonFont( icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED], icnVsSprite[ICN::BUTTON_GOOD_FONT_PRESSED], icnVsSprite[ICN::BUTTON_EVIL_FONT_RELEASED],
                           icnVsSprite[ICN::BUTTON_EVIL_FONT_PRESSED] );
     }
+
     void editOriginalFont( std::vector<fheroes2::Sprite> & icnVsSprite, const bool normalFont )
     {
         if ( normalFont ) {

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -4120,7 +4120,9 @@ namespace fheroes2
 
     void modifyBaseNormalFont( std::vector<fheroes2::Sprite> & icnVsSprite )
     {
-        assert( !icnVsSprite.empty() );
+        if ( icnVsSprite.size() < 96 ) {
+            return;
+        }
 
         // Remove white line from % symbol
         fheroes2::FillTransform( icnVsSprite[5], 5, 0, 5, 1, 1 );
@@ -4144,7 +4146,9 @@ namespace fheroes2
 
     void modifyBaseSmallFont( std::vector<fheroes2::Sprite> & icnVsSprite )
     {
-        assert( !icnVsSprite.empty() );
+        if ( icnVsSprite.size() < 96 ) {
+            return;
+        }
 
         // Remove white line from % symbol
         fheroes2::FillTransform( icnVsSprite[5], 3, 0, 4, 1, 1 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -4204,30 +4204,34 @@ namespace fheroes2
                           icnVsSprite[ICN::BUTTON_EVIL_FONT_PRESSED] );
     }
 
-    void editOriginalFont( std::vector<fheroes2::Sprite> & icnVsSprite, const bool normalFont )
+    void modifyBaseNormalFont( std::vector<fheroes2::Sprite> & icnVsSprite )
     {
-        if ( normalFont ) {
-            // Proper lowercase k. Kept at end in case any letters use it for generation.
-            fheroes2::FillTransform( icnVsSprite[75], 4, 1, 5, 8, 1 );
-            fheroes2::Copy( icnVsSprite[43], 6, 5, icnVsSprite[75], 4, 7, 3, 1 );
-            fheroes2::Copy( icnVsSprite[43], 6, 4, icnVsSprite[75], 4, 6, 4, 1 );
-            fheroes2::Copy( icnVsSprite[43], 7, 4, icnVsSprite[75], 6, 5, 3, 1 );
-            fheroes2::Copy( icnVsSprite[43], 7, 4, icnVsSprite[75], 7, 4, 2, 1 );
-            fheroes2::Copy( icnVsSprite[43], 6, 6, icnVsSprite[75], 4, 8, 4, 1 );
-            icnVsSprite[75].setPosition( icnVsSprite[75].x(), icnVsSprite[75].y() );
-            updateNormalFontLetterShadow( icnVsSprite[75] );
-        }
-        else {
-            // Proper lowercase k. Kept at end in case any letters use it for generation.
-            icnVsSprite[75].resize( 6, 8 );
-            icnVsSprite[75].reset();
-            fheroes2::Copy( icnVsSprite[76], 1, 0, icnVsSprite[75], 1, 0, 2, 7 );
-            fheroes2::Copy( icnVsSprite[76], 1, 0, icnVsSprite[75], 1, 6, 1, 1 );
-            fheroes2::Copy( icnVsSprite[56], 6, 0, icnVsSprite[75], 3, 2, 3, 3 );
-            fheroes2::Copy( icnVsSprite[65], 2, icnVsSprite[65].height() - 2, icnVsSprite[75], 5, 6, 2, 1 );
-            fheroes2::Copy( icnVsSprite[65], 2, 0, icnVsSprite[75], 4, 5, 1, 1 );
-            icnVsSprite[75].setPosition( icnVsSprite[75].x(), icnVsSprite[75].y() );
-            updateSmallFontLetterShadow( icnVsSprite[75] );
-        }
+        assert( icnVsSprite.size() > 0 );
+
+        // Proper lowercase k.
+        fheroes2::FillTransform( icnVsSprite[75], 4, 1, 5, 8, 1 );
+        fheroes2::Copy( icnVsSprite[43], 6, 5, icnVsSprite[75], 4, 7, 3, 1 );
+        fheroes2::Copy( icnVsSprite[43], 6, 4, icnVsSprite[75], 4, 6, 4, 1 );
+        fheroes2::Copy( icnVsSprite[43], 7, 4, icnVsSprite[75], 6, 5, 3, 1 );
+        fheroes2::Copy( icnVsSprite[43], 7, 4, icnVsSprite[75], 7, 4, 2, 1 );
+        fheroes2::Copy( icnVsSprite[43], 6, 6, icnVsSprite[75], 4, 8, 4, 1 );
+        icnVsSprite[75].setPosition( icnVsSprite[75].x(), icnVsSprite[75].y() );
+        updateNormalFontLetterShadow( icnVsSprite[75] );
+    }
+
+    void modifyBaseSmallFont(std::vector<fheroes2::Sprite>& icnVsSprite)
+    {
+        assert( icnVsSprite.size() > 0 );
+
+        // Proper lowercase k.
+        icnVsSprite[75].resize( 6, 8 );
+        icnVsSprite[75].reset();
+        fheroes2::Copy( icnVsSprite[76], 1, 0, icnVsSprite[75], 1, 0, 2, 7 );
+        fheroes2::Copy( icnVsSprite[76], 1, 0, icnVsSprite[75], 1, 6, 1, 1 );
+        fheroes2::Copy( icnVsSprite[56], 6, 0, icnVsSprite[75], 3, 2, 3, 3 );
+        fheroes2::Copy( icnVsSprite[65], 2, icnVsSprite[65].height() - 2, icnVsSprite[75], 5, 6, 2, 1 );
+        fheroes2::Copy( icnVsSprite[65], 2, 0, icnVsSprite[75], 4, 5, 1, 1 );
+        icnVsSprite[75].setPosition( icnVsSprite[75].x(), icnVsSprite[75].y() );
+        updateSmallFontLetterShadow( icnVsSprite[75] );
     }
 }

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1472,9 +1472,8 @@ namespace
             // Shorter k.
             font[234 - 32].resize( font[75].width() - 1, font[75].height() - 4 );
             font[234 - 32].reset();
-            fheroes2::Copy( font[75], 2, 2, font[234 - 32], 2, 0, 7, 4 );
-            fheroes2::Copy( font[75], 1, 0, font[234 - 32], 1, 0, 3, 1 );
-            fheroes2::Copy( font[75], 0, 7, font[234 - 32], 0, 4, font[75].width(), 2 );
+            fheroes2::Copy( font[75], 0, 0, font[234 - 32], 0, 0, 4, 6 );
+            fheroes2::Copy( font[75], 4, 4, font[234 - 32], 4, 0, 5, 6 );
             fheroes2::Copy( font[75], 0, 10, font[234 - 32], 0, 6, 4, 1 );
             fheroes2::Copy( font[75], 7, 10, font[234 - 32], 6, 6, 3, 1 );
             font[234 - 32].setPosition( font[75].x(), font[75].y() + 4 );
@@ -1911,11 +1910,10 @@ namespace
             font[233 - 32].setPosition( font[232 - 32].x(), font[232 - 32].y() - 2 );
             updateSmallFontLetterShadow( font[233 - 32] );
 
-            font[234 - 32].resize( font[75].width() - 2, font[75].height() - 2 );
+            font[234 - 32].resize( font[75].width(), font[75].height() - 2 );
             font[234 - 32].reset();
             fheroes2::Copy( font[75], 1, 0, font[234 - 32], 1, 0, 2, 5 );
-            fheroes2::Copy( font[75], 4, 1, font[234 - 32], 3, 0, 3, 3 );
-            fheroes2::Copy( font[75], 5, 4, font[234 - 32], 4, 3, 2, 2 );
+            fheroes2::Copy( font[75], 3, 2, font[234 - 32], 3, 0, 3, 5 );
             font[234 - 32].setPosition( font[75].x(), font[75].y() + 2 );
             updateSmallFontLetterShadow( font[234 - 32] );
 

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -4203,4 +4203,31 @@ namespace fheroes2
         updateButtonFont( icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED], icnVsSprite[ICN::BUTTON_GOOD_FONT_PRESSED], icnVsSprite[ICN::BUTTON_EVIL_FONT_RELEASED],
                           icnVsSprite[ICN::BUTTON_EVIL_FONT_PRESSED] );
     }
+    void editOriginalFont( std::vector<fheroes2::Sprite> & icnVsSprite, const bool normalFont ) 
+    {
+        if ( normalFont ) {
+            // Proper lowercase k. Kept at end in case any letters use it for generation.
+            fheroes2::FillTransform( icnVsSprite[75], 4, 1, 5, 8, 1 );
+            fheroes2::Copy( icnVsSprite[43], 6, 5, icnVsSprite[75], 4, 7, 3, 1 );
+            fheroes2::Copy( icnVsSprite[43], 6, 4, icnVsSprite[75], 4, 6, 4, 1 );
+            fheroes2::Copy( icnVsSprite[43], 7, 4, icnVsSprite[75], 6, 5, 3, 1 );
+            fheroes2::Copy( icnVsSprite[43], 7, 4, icnVsSprite[75], 7, 4, 2, 1 );
+            fheroes2::Copy( icnVsSprite[43], 6, 6, icnVsSprite[75], 4, 8, 4, 1 );
+            icnVsSprite[75].setPosition( icnVsSprite[75].x(), icnVsSprite[75].y() );
+            updateNormalFontLetterShadow( icnVsSprite[75] );
+        }
+        else {
+            // Proper lowercase k. Kept at end in case any letters use it for generation.
+            icnVsSprite[75].resize( 6, 8 );
+            icnVsSprite[75].reset();
+            fheroes2::Copy( icnVsSprite[76], 1, 0, icnVsSprite[75], 1, 0, 2, 7 );
+            fheroes2::Copy( icnVsSprite[76], 1, 0, icnVsSprite[75], 1, 6, 1, 1 );
+            fheroes2::Copy( icnVsSprite[56], 6, 0, icnVsSprite[75], 3, 2, 3, 3 );
+            fheroes2::Copy( icnVsSprite[65], 2, icnVsSprite[65].height() - 2, icnVsSprite[75], 5, 6, 2, 1 );
+            fheroes2::Copy( icnVsSprite[65], 2, 0, icnVsSprite[75], 4, 5, 1, 1 );
+            icnVsSprite[75].setPosition( icnVsSprite[75].x(), icnVsSprite[75].y() );
+            updateSmallFontLetterShadow( icnVsSprite[75] );
+        }
+        return;
+    }
 }

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -4129,6 +4129,10 @@ namespace fheroes2
         fheroes2::FillTransform( icnVsSprite[5], 6, 2, 2, 1, 1 );
         updateNormalFontLetterShadow( icnVsSprite[5] );
 
+        // Move "-" further down
+        icnVsSprite[13].setPosition( icnVsSprite[13].x(), icnVsSprite[13].y() + 1 );
+        updateNormalFontLetterShadow( icnVsSprite[13] );
+
         // Proper lowercase k.
         fheroes2::FillTransform( icnVsSprite[75], 4, 1, 5, 8, 1 );
         fheroes2::Copy( icnVsSprite[43], 6, 5, icnVsSprite[75], 4, 7, 3, 1 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -4228,6 +4228,5 @@ namespace fheroes2
             icnVsSprite[75].setPosition( icnVsSprite[75].x(), icnVsSprite[75].y() );
             updateSmallFontLetterShadow( icnVsSprite[75] );
         }
-        return;
     }
 }

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -523,16 +523,6 @@ namespace
             fheroes2::Copy( font[140 - 32], 4, 0, font[253 - 32], 5, 0, 3, 2 );
             font[253 - 32].setPosition( font[121 - 32].x(), font[121 - 32].y() - 3 );
             updateNormalFontLetterShadow( font[253 - 32] );
-
-            // Proper lowercase k. Kept at end in case any letters use it for generation.
-            fheroes2::FillTransform( font[75], 4, 1, 5, 8, 1 );
-            fheroes2::Copy( font[43], 6, 5, font[75], 4, 7, 3, 1 );
-            fheroes2::Copy( font[43], 6, 4, font[75], 4, 6, 4, 1 );
-            fheroes2::Copy( font[43], 7, 4, font[75], 6, 5, 3, 1 );
-            fheroes2::Copy( font[43], 7, 4, font[75], 7, 4, 2, 1 );
-            fheroes2::Copy( font[43], 6, 6, font[75], 4, 8, 4, 1 );
-            font[75].setPosition( font[75].x(), font[75].y() );
-            updateNormalFontLetterShadow( font[75] );
         }
         // Small font.
         {
@@ -889,17 +879,6 @@ namespace
             fheroes2::Copy( font[122 - 32], 2, 2, font[253 - 32], 4, 0, 2, 2 );
             font[253 - 32].setPosition( font[121 - 32].x(), font[121 - 32].y() - 3 );
             updateSmallFontLetterShadow( font[253 - 32] );
-
-            // Proper lowercase k. Kept at end in case any letters use it for generation.
-            font[75].resize( 6, 8 );
-            font[75].reset();
-            fheroes2::Copy( font[76], 1, 0, font[75], 1, 0, 2, 7 );
-            fheroes2::Copy( font[76], 1, 0, font[75], 1, 6, 1, 1 );
-            fheroes2::Copy( font[56], 6, 0, font[75], 3, 2, 3, 3 );
-            fheroes2::Copy( font[65], 2, font[65].height() - 2, font[75], 5, 6, 2, 1 );
-            fheroes2::Copy( font[65], 2, 0, font[75], 4, 5, 1, 1 );
-            font[75].setPosition( font[75].x(), font[75].y() );
-            updateSmallFontLetterShadow( font[75] );
         }
     }
 
@@ -2497,16 +2476,6 @@ namespace
             fheroes2::Copy( font[252 - 32], 2, 0, font[252 - 32], 6, 0, 2, 2 );
             font[252 - 32].setPosition( font[85].x(), font[85].y() - 3 );
             updateNormalFontLetterShadow( font[252 - 32] );
-
-            // Proper lowercase k. Kept at end in case any letters use it for generation.
-            fheroes2::FillTransform( font[75], 4, 1, 5, 8, 1 );
-            fheroes2::Copy( font[43], 6, 5, font[75], 4, 7, 3, 1 );
-            fheroes2::Copy( font[43], 6, 4, font[75], 4, 6, 4, 1 );
-            fheroes2::Copy( font[43], 7, 4, font[75], 6, 5, 3, 1 );
-            fheroes2::Copy( font[43], 7, 4, font[75], 7, 4, 2, 1 );
-            fheroes2::Copy( font[43], 6, 6, font[75], 4, 8, 4, 1 );
-            font[75].setPosition( font[75].x(), font[75].y() );
-            updateNormalFontLetterShadow( font[75] );
         }
         // Small font.
         {
@@ -2882,17 +2851,6 @@ namespace
             fheroes2::Copy( font[252 - 32], 2, 0 + 2, font[252 - 32], 6, 0, 1, 1 );
             font[252 - 32].setPosition( font[85].x(), font[85].y() - 2 );
             updateSmallFontLetterShadow( font[252 - 32] );
-
-            // Proper lowercase k. Kept at end in case any letters use it for generation.
-            font[75].resize( 6, 8 );
-            font[75].reset();
-            fheroes2::Copy( font[76], 1, 0, font[75], 1, 0, 2, 7 );
-            fheroes2::Copy( font[76], 1, 0, font[75], 1, 6, 1, 1 );
-            fheroes2::Copy( font[56], 6, 0, font[75], 3, 2, 3, 3 );
-            fheroes2::Copy( font[65], 2, font[65].height() - 2, font[75], 5, 6, 2, 1 );
-            fheroes2::Copy( font[65], 2, 0, font[75], 4, 5, 1, 1 );
-            font[75].setPosition( font[75].x(), font[75].y() );
-            updateSmallFontLetterShadow( font[75] );
         }
     }
 
@@ -3022,16 +2980,6 @@ namespace
             fheroes2::Copy( font[199 - 32], 7, 11, font[254 - 32], 4, 7, 3, 3 );
             font[254 - 32].setPosition( font[83].x(), font[83].y() );
             updateNormalFontLetterShadow( font[254 - 32] );
-
-            // Proper lowercase k. Kept at end in case any letters use it for generation.
-            fheroes2::FillTransform( font[75], 4, 1, 5, 8, 1 );
-            fheroes2::Copy( font[43], 6, 5, font[75], 4, 7, 3, 1 );
-            fheroes2::Copy( font[43], 6, 4, font[75], 4, 6, 4, 1 );
-            fheroes2::Copy( font[43], 7, 4, font[75], 6, 5, 3, 1 );
-            fheroes2::Copy( font[43], 7, 4, font[75], 7, 4, 2, 1 );
-            fheroes2::Copy( font[43], 6, 6, font[75], 4, 8, 4, 1 );
-            font[75].setPosition( font[75].x(), font[75].y() );
-            updateNormalFontLetterShadow( font[75] );
         }
         // Small font.
         {
@@ -3139,17 +3087,6 @@ namespace
             fheroes2::Copy( font[35], 1, 1, font[254 - 32], 2, 5, 2, 2 );
             font[254 - 32].setPosition( font[83].x(), font[83].y() );
             updateSmallFontLetterShadow( font[254 - 32] );
-
-            // Proper lowercase k. Kept at end in case any letters use it for generation.
-            font[75].resize( 6, 8 );
-            font[75].reset();
-            fheroes2::Copy( font[76], 1, 0, font[75], 1, 0, 2, 7 );
-            fheroes2::Copy( font[76], 1, 0, font[75], 1, 6, 1, 1 );
-            fheroes2::Copy( font[56], 6, 0, font[75], 3, 2, 3, 3 );
-            fheroes2::Copy( font[65], 2, font[65].height() - 2, font[75], 5, 6, 2, 1 );
-            fheroes2::Copy( font[65], 2, 0, font[75], 4, 5, 1, 1 );
-            font[75].setPosition( font[75].x(), font[75].y() );
-            updateSmallFontLetterShadow( font[75] );
         }
     }
 
@@ -3241,16 +3178,6 @@ namespace
             fheroes2::Copy( font[12], 0, 0, font[254 - 32], 1, 12, font[12].width(), font[12].height() );
             font[254 - 32].setPosition( font[84].x(), font[84].y() );
             updateNormalFontLetterShadow( font[254 - 32] );
-
-            // Proper lowercase k. Kept at end in case any letters use it for generation.
-            fheroes2::FillTransform( font[75], 4, 1, 5, 8, 1 );
-            fheroes2::Copy( font[43], 6, 5, font[75], 4, 7, 3, 1 );
-            fheroes2::Copy( font[43], 6, 4, font[75], 4, 6, 4, 1 );
-            fheroes2::Copy( font[43], 7, 4, font[75], 6, 5, 3, 1 );
-            fheroes2::Copy( font[43], 7, 4, font[75], 7, 4, 2, 1 );
-            fheroes2::Copy( font[43], 6, 6, font[75], 4, 8, 4, 1 );
-            font[75].setPosition( font[75].x(), font[75].y() );
-            updateNormalFontLetterShadow( font[75] );
         }
         // Small font.
         {
@@ -3323,17 +3250,6 @@ namespace
             fheroes2::Copy( font[12], 0, 0, font[254 - 32], 1, 8, font[12].width(), font[12].height() );
             font[254 - 32].setPosition( font[84].x(), font[84].y() );
             updateSmallFontLetterShadow( font[254 - 32] );
-
-            // Proper lowercase k. Kept at end in case any letters use it for generation.
-            font[75].resize( 6, 8 );
-            font[75].reset();
-            fheroes2::Copy( font[76], 1, 0, font[75], 1, 0, 2, 7 );
-            fheroes2::Copy( font[76], 1, 0, font[75], 1, 6, 1, 1 );
-            fheroes2::Copy( font[56], 6, 0, font[75], 3, 2, 3, 3 );
-            fheroes2::Copy( font[65], 2, font[65].height() - 2, font[75], 5, 6, 2, 1 );
-            fheroes2::Copy( font[65], 2, 0, font[75], 4, 5, 1, 1 );
-            font[75].setPosition( font[75].x(), font[75].y() );
-            updateSmallFontLetterShadow( font[75] );
         }
     }
 

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -4206,7 +4206,7 @@ namespace fheroes2
 
     void modifyBaseNormalFont( std::vector<fheroes2::Sprite> & icnVsSprite )
     {
-        assert( icnVsSprite.size() > 0 );
+        assert( !icnVsSprite.empty() );
 
         // Proper lowercase k.
         fheroes2::FillTransform( icnVsSprite[75], 4, 1, 5, 8, 1 );
@@ -4221,7 +4221,7 @@ namespace fheroes2
 
     void modifyBaseSmallFont( std::vector<fheroes2::Sprite> & icnVsSprite )
     {
-        assert( icnVsSprite.size() > 0 );
+        assert( !icnVsSprite.empty() );
 
         // Proper lowercase k.
         icnVsSprite[75].resize( 6, 8 );

--- a/src/fheroes2/gui/ui_font.h
+++ b/src/fheroes2/gui/ui_font.h
@@ -33,4 +33,6 @@ namespace fheroes2
                                  std::vector<Sprite> & evilPressed );
 
     void generateButtonAlphabet( const SupportedLanguage language, std::vector<std::vector<Sprite>> & icnVsSprite );
+
+    void editOriginalFont( std::vector<fheroes2::Sprite> & icnVsSprite, const bool normalFont );
 }

--- a/src/fheroes2/gui/ui_font.h
+++ b/src/fheroes2/gui/ui_font.h
@@ -34,5 +34,7 @@ namespace fheroes2
 
     void generateButtonAlphabet( const SupportedLanguage language, std::vector<std::vector<Sprite>> & icnVsSprite );
 
-    void editOriginalFont( std::vector<fheroes2::Sprite> & icnVsSprite, const bool normalFont );
+    void modifyBaseNormalFont( std::vector<fheroes2::Sprite> & icnVsSprite );
+
+    void modifyBaseSmallFont( std::vector<fheroes2::Sprite> & icnVsSprite );
 }


### PR DESCRIPTION
This adds logic that will modify the base fonts on the fly.

The modifying logic was placed in `ui_font.cpp` to maintain current structure and because the function updating the font shadow is local to that file.

Lowercase k for both normal and small font have been edited as an example and these were also requested by many users.
This PR fixes other font issues like the `%` and `-`.

New `k`:
![image](https://user-images.githubusercontent.com/12501091/197849520-91cd86a6-4cfb-4fec-be76-3cf6ad9cdd83.png)
![image](https://user-images.githubusercontent.com/12501091/197849597-0dc90b3c-4416-4d68-a341-276a0f4fbecc.png)

Fixed `%` sign:
![image](https://user-images.githubusercontent.com/12501091/198538334-34e9df3a-a960-4fb9-a086-c31109d1d5bb.png)
![image](https://user-images.githubusercontent.com/12501091/198538380-a5a7ac09-026d-4972-846b-d1e160153da6.png)


Fixed hyphen `-` (only normal font has issues):
![image](https://user-images.githubusercontent.com/12501091/198538467-eb174460-579c-451d-b6a5-50cc0f05d99d.png)

The Cyrillic `к` in CP1251 has been readjusted because it uses lowercase k for its generation.

Close #5514 
Close #4799