### PR TITLE
Android: setup the backup rules

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
 
     <application
         android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/full_backup_content"
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
 
     <application
         android:allowBackup="true"
+        android:fullBackupContent="@xml/full_backup_content"
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
 <resources>
     <string name="app_name">fheroes2</string>
 </resources>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<data-extraction-rules>
+    <!-- Backup game data files only when using local device-to-device transfer -->
+    <device-transfer>
+        <include
+            domain="external"
+            path="." />
+    </device-transfer>
+    <!-- Otherwise, backup only the save files and game settings -->
+    <cloud-backup>
+        <include
+            domain="external"
+            path="files/save" />
+        <include
+            domain="external"
+            path="fheroes2.bin" />
+        <include
+            domain="external"
+            path="fheroes2.cfg" />
+        <include
+            domain="external"
+            path="fheroes2.key" />
+    </cloud-backup>
+</data-extraction-rules>

--- a/android/app/src/main/res/xml/full_backup_content.xml
+++ b/android/app/src/main/res/xml/full_backup_content.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<full-backup-content>
+    <!-- Backup game data files only when using local device-to-device transfer -->
+    <include
+        domain="external"
+        path="."
+        requireFlags="deviceToDeviceTransfer" />
+    <!-- Otherwise, backup only the save files and game settings -->
+    <include
+        domain="external"
+        path="files/save" />
+    <include
+        domain="external"
+        path="fheroes2.bin" />
+    <include
+        domain="external"
+        path="fheroes2.cfg" />
+    <include
+        domain="external"
+        path="fheroes2.key" />
+</full-backup-content>


### PR DESCRIPTION
Related to #6008

Without special configuration, Android will attempt to backup almost all files both from private and external app data directories (except caches), which is not desirable, because per-app backup storage is very limited (up to 25MB per app) and we shouldn't backup OG data files, maps, music, etc, etc. This PR configures backup rules for Android 11 and lower devices, as well as for Android 12+ devices.