### PR TITLE
MSVC workflow: use cyg-get instead of broken "choco.exe install ... --source cygwin"

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -47,7 +47,8 @@ jobs:
     - name: Install dependencies and cygwin
       run: |
         script/windows/install_packages.bat
-        choco.exe install make gettext-devel -y --source cygwin
+        choco.exe install cygwin cyg-get -y
+        cyg-get.bat make gettext-devel
     - uses: microsoft/setup-msbuild@v1
     - name: Generate version information
       run: |


### PR DESCRIPTION
Fix current issues with MSVC build.