### PR TITLE
Don't overwrite focus on game load

### DIFF
--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -148,6 +148,7 @@ namespace Interface
         void SetFocus( Castle * );
         void ResetFocus( int );
         void RedrawFocus();
+        void updateFocus();
 
         void EventSwitchHeroSleeping();
         fheroes2::GameMode EventDefaultAction( const fheroes2::GameMode gameMode );

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -730,7 +730,12 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
     Kingdom & myKingdom = world.GetKingdom( conf.CurrentColor() );
     const KingdomCastles & myCastles = myKingdom.GetCastles();
 
-    ResetFocus( GameFocus::FIRSTHERO );
+    if ( isload ) {
+        updateFocus();
+    }
+    else {
+        ResetFocus( GameFocus::FIRSTHERO );
+    }
 
     radar.SetHide( false );
     statusWindow.Reset();

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -101,17 +101,13 @@ void Interface::Basic::updateFocus()
     if ( focus.first == FOCUS_CASTLE ) {
         Castle * castle = GetFocusCastle();
         if ( castle != nullptr ) {
-            iconsPanel.Select( castle );
-            gameArea.SetCenter( castle->GetCenter() );
-            statusWindow.SetState( StatusType::STATUS_FUNDS );
+            SetFocus( castle );
         }
     }
     else if ( focus.first == FOCUS_HEROES ) {
         Heroes * hero = GetFocusHeroes();
         if ( hero != nullptr ) {
-            iconsPanel.Select( hero );
-            gameArea.SetCenter( hero->GetCenter() );
-            statusWindow.SetState( StatusType::STATUS_ARMY );
+            SetFocus( hero );
         }
     }
 }

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -100,15 +100,19 @@ void Interface::Basic::updateFocus()
     Focus & focus = player->GetFocus();
     if ( focus.first == FOCUS_CASTLE ) {
         Castle * castle = GetFocusCastle();
-        iconsPanel.Select( castle );
-        gameArea.SetCenter( castle->GetCenter() );
-        statusWindow.SetState( StatusType::STATUS_FUNDS );
+        if ( castle != nullptr ) {
+            iconsPanel.Select( castle );
+            gameArea.SetCenter( castle->GetCenter() );
+            statusWindow.SetState( StatusType::STATUS_FUNDS );
+        }
     }
     else if ( focus.first == FOCUS_HEROES ) {
         Heroes * hero = GetFocusHeroes();
-        iconsPanel.Select( hero );
-        gameArea.SetCenter( hero->GetCenter() );
-        statusWindow.SetState( StatusType::STATUS_ARMY );
+        if ( hero != nullptr ) {
+            iconsPanel.Select( hero );
+            gameArea.SetCenter( hero->GetCenter() );
+            statusWindow.SetState( StatusType::STATUS_ARMY );
+        }
     }
 }
 

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -89,6 +89,29 @@ void Interface::Basic::SetFocus( Castle * castle )
     }
 }
 
+void Interface::Basic::updateFocus()
+{
+    Player * player = Settings::Get().GetPlayers().GetCurrent();
+
+    if ( !player ) {
+        return;
+    }
+
+    Focus & focus = player->GetFocus();
+    if ( focus.first == FOCUS_CASTLE ) {
+        Castle * castle = GetFocusCastle();
+        iconsPanel.Select( castle );
+        gameArea.SetCenter( castle->GetCenter() );
+        statusWindow.SetState( StatusType::STATUS_FUNDS );
+    }
+    else if ( focus.first == FOCUS_HEROES ) {
+        Heroes * hero = GetFocusHeroes();
+        iconsPanel.Select( hero );
+        gameArea.SetCenter( hero->GetCenter() );
+        statusWindow.SetState( StatusType::STATUS_ARMY );
+    }
+}
+
 void Interface::Basic::ResetFocus( int priority )
 {
     Player * player = Settings::Get().GetPlayers().GetCurrent();


### PR DESCRIPTION
When loading a save file, the current focus was being overwritten by the first hero. This PR changes this default behavior.

closes #5898 