### PR TITLE
Add Cyrillic TSE to button font

### DIFF
--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -4211,6 +4211,14 @@ namespace
         released[191].resize( released[50].width(), released[50].height() );
         released[191].reset();
         fheroes2::Flip( released[50], 0, 0, released[191], 0, 0, released[50].width(), released[50].height(), true, false );
+
+        // Cyrillic TSE
+        released[182].resize( 12 + offset * 2, 12 + offset * 2 );
+        released[182].reset();
+        fheroes2::Copy( released[41], 0, 0, released[182], 0, 0, released[41].width(), released[41].height() );
+        fheroes2::Copy( released[41], 0, 0, released[182], 7, 0, released[41].width(), released[41].height() );
+        fheroes2::DrawLine( released[182], { offset + 5, offset + 9 }, { offset + 6, offset + 9 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[182], { offset + 11, offset + 10 }, { offset + 11, offset + 11 }, buttonGoodReleasedColor );
     }
 
     void generateCP1252GoodButtonFont( std::vector<fheroes2::Sprite> & released )


### PR DESCRIPTION
This adds the character Ц to the CP1251 button font as requested here: https://github.com/ihhub/fheroes2/issues/5969#issuecomment-1293376397

How does this look @Branikolog?
![image](https://user-images.githubusercontent.com/12501091/198522270-6e1c6d63-0ce8-4b44-92d9-468671548e41.png)
