### PR TITLE
Consolidate French and CP1252 font generation

### DIFF
--- a/files/lang/Makefile
+++ b/files/lang/Makefile
@@ -28,11 +28,6 @@ all: $(patsubst %.po, %.mo, $(wildcard *.po))
 merge: ../../src/dist/fheroes2.pot
 	for i in $(wildcard *.po); do msgmerge -U --no-location $$i $<; done
 
-# In French, accented characters are mapped to unused ASCII characters
-# Non-mapped characters are replaced by their non-accented equivalents
-fr.mo: fr.po
-	sed -e 'y/àâçéèêîïôùûüÇÉÊÀ/@*^~`|><#&$$uCEEA/; s/œ/oe/g' $< | msgfmt - -o $@
-
 # Czech, Hungarian and Polish versions use CP1250
 cs.mo hu.mo pl.mo: %.mo: %.po
 	$(call MSGFMT,CP1250)
@@ -43,8 +38,8 @@ cs.mo hu.mo pl.mo: %.mo: %.po
 be.mo bg.mo ru.mo uk.mo: %.mo: %.po
 	$(call MSGFMT,CP1251)
 
-# German, Italian, Dutch, Norwegian, Portuguese, Spanish, Swedish versions use CP1252
-de.mo es.mo it.mo nb.mo pt.mo sv.mo nl.mo: %.mo: %.po
+# German, French, Italian, Dutch, Norwegian, Portuguese, Spanish and Swedish translations use CP1252
+de.mo es.mo fr.mo it.mo nb.mo pt.mo sv.mo nl.mo: %.mo: %.po
 	$(call MSGFMT,CP1252)
 
 # Turkish uses CP1254

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2741,7 +2741,6 @@ namespace
             fheroes2::Copy( font[37 - 32], 5, 4, font[195 - 32], 6, 1, 2, 2 );
             font[195 - 32].setPosition( font[65 - 32].x(), font[65 - 32].y() - 3 );
             updateSmallFontLetterShadow( font[195 - 32] );
-            
 
             // A with 2 dots on top.
             font[196 - 32].resize( font[33].width(), font[33].height() + 2 );
@@ -2870,7 +2869,6 @@ namespace
             fheroes2::Copy( font[195 - 32], 3, 0, font[213 - 32], 2, 0, 5, 3 );
             font[213 - 32].setPosition( font[79 - 32].x(), font[79 - 32].y() - 3 );
             updateSmallFontLetterShadow( font[213 - 32] );
-            
 
             // O with 2 dots on top.
             font[214 - 32].resize( font[47].width(), font[47].height() + 2 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1110,7 +1110,7 @@ namespace
             font[42 - 32] = font[226 - 32];
             // Lowercase i with diaeresis
             font[60 - 32] = font[239 - 32];
-            // Lowercase i with circumflex <- Confirmed used in the OG.
+            // Lowercase i with circumflex <- Confirmed used in the OG Succession wars.
             font[62 - 32] = font[238 - 32];
             // Lowercase a with grave accent
             font[64 - 32] = font[224 - 32];

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -4289,44 +4289,51 @@ namespace
         const int32_t offset = 2;
 
         // Offset letters with diacritics above them.
-        released[165].setPosition( buttonFontOffset.x, -2 );
+        released[197 - 32].setPosition( buttonFontOffset.x, -2 );
+        released[201 - 32].setPosition( buttonFontOffset.x, -3 );
 
         // A with circle on top
-        released[165].resize( 13 + offset * 2, 12 + offset * 2 );
-        released[165].reset();
-        fheroes2::DrawLine( released[165], { offset + 0, offset + 11 }, { offset + 4, offset + 11 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[165], { offset + 8, offset + 11 }, { offset + 12, offset + 11 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[165], { offset + 5, offset + 7 }, { offset + 8, offset + 7 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[165], { offset + 2, offset + 10 }, { offset + 4, offset + 7 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[165], { offset + 7, offset + 3 }, { offset + 10, offset + 10 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[165], { offset + 5, offset + 1 }, { offset + 5, offset + 2 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[165], { offset + 8, offset + 1 }, { offset + 8, offset + 2 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[165], { offset + 6, offset + 0 }, { offset + 7, offset + 0 }, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[165], offset + 4, offset + 6, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[165], offset + 5, offset + 5, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[165], offset + 5, offset + 4, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[165], offset + 6, offset + 3, buttonGoodReleasedColor );
+        released[197 - 32].resize( 13 + offset * 2, 12 + offset * 2 );
+        released[197 - 32].reset();
+        fheroes2::DrawLine( released[197 - 32], { offset + 0, offset + 11 }, { offset + 4, offset + 11 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[197 - 32], { offset + 8, offset + 11 }, { offset + 12, offset + 11 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[197 - 32], { offset + 5, offset + 7 }, { offset + 8, offset + 7 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[197 - 32], { offset + 2, offset + 10 }, { offset + 4, offset + 7 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[197 - 32], { offset + 7, offset + 3 }, { offset + 10, offset + 10 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[197 - 32], { offset + 5, offset + 1 }, { offset + 5, offset + 2 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[197 - 32], { offset + 8, offset + 1 }, { offset + 8, offset + 2 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[197 - 32], { offset + 6, offset + 0 }, { offset + 7, offset + 0 }, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[197 - 32], offset + 4, offset + 6, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[197 - 32], offset + 5, offset + 5, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[197 - 32], offset + 5, offset + 4, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[197 - 32], offset + 6, offset + 3, buttonGoodReleasedColor );
 
         // A attached to E.
-        released[166].resize( 18 + offset * 2, 12 + offset * 2 );
-        released[166].reset();
-        fheroes2::DrawLine( released[166], { offset + 0, offset + 9 }, { offset + 4, offset + 9 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[166], { offset + 8, offset + 9 }, { offset + 12, offset + 9 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[166], { offset + 5, offset + 5 }, { offset + 8, offset + 5 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[166], { offset + 2, offset + 8 }, { offset + 4, offset + 5 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[166], { offset + 7, offset + 1 }, { offset + 10, offset + 8 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[166], { offset + 7, offset + 0 }, { offset + 14, offset + 0 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[166], { offset + 13, offset + 9 }, { offset + 14, offset + 9 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[166], { offset + 9, offset + 4 }, { offset + 12, offset + 4 }, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[166], offset + 4, offset + 4, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[166], offset + 5, offset + 3, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[166], offset + 5, offset + 2, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[166], offset + 6, offset + 1, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[166], offset + 6, offset + 0, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[166], offset + 14, offset + 1, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[166], offset + 14, offset + 8, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[166], offset + 12, offset + 3, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[166], offset + 12, offset + 5, buttonGoodReleasedColor );
+        released[198 - 32].resize( 18 + offset * 2, 12 + offset * 2 );
+        released[198 - 32].reset();
+        fheroes2::DrawLine( released[198 - 32], { offset + 0, offset + 9 }, { offset + 4, offset + 9 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[198 - 32], { offset + 8, offset + 9 }, { offset + 12, offset + 9 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[198 - 32], { offset + 5, offset + 5 }, { offset + 8, offset + 5 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[198 - 32], { offset + 2, offset + 8 }, { offset + 4, offset + 5 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[198 - 32], { offset + 7, offset + 1 }, { offset + 10, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[198 - 32], { offset + 7, offset + 0 }, { offset + 14, offset + 0 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[198 - 32], { offset + 13, offset + 9 }, { offset + 14, offset + 9 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[198 - 32], { offset + 9, offset + 4 }, { offset + 12, offset + 4 }, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[198 - 32], offset + 4, offset + 4, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[198 - 32], offset + 5, offset + 3, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[198 - 32], offset + 5, offset + 2, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[198 - 32], offset + 6, offset + 1, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[198 - 32], offset + 6, offset + 0, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[198 - 32], offset + 14, offset + 1, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[198 - 32], offset + 14, offset + 8, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[198 - 32], offset + 12, offset + 3, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[198 - 32], offset + 12, offset + 5, buttonGoodReleasedColor );
+
+        // E with acute.
+        released[201 - 32].resize( released[69 - 32].width(), released[69 - 32].height() + 3 );
+        released[201 - 32].reset();
+        fheroes2::Copy( released[69 - 32], 0, 0, released[201 - 32], 0, 3, released[69 - 32].width(), released[69 - 32].height() );
+        fheroes2::DrawLine( released[201 - 32], { offset + 5, offset + 1 }, { offset + 6, offset + 0 }, buttonGoodReleasedColor );
     }
 }
 
@@ -4419,7 +4426,6 @@ namespace fheroes2
     {
         generateGoodButtonFontBaseShape( icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED] );
 
-        // NOTE: As soon as code structure is agreed on functions for all Code Pages will be added.
         switch ( language ) {
         case SupportedLanguage::English:
             generateBaseButtonFont( icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED], icnVsSprite[ICN::BUTTON_GOOD_FONT_PRESSED], icnVsSprite[ICN::BUTTON_EVIL_FONT_RELEASED],
@@ -4430,12 +4436,6 @@ namespace fheroes2
         case SupportedLanguage::Polish:
             generateCP1250GoodButtonFont( icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED] );
             break;
-        case SupportedLanguage::French:
-            // TODO: Adjust French to use CP1252 button font.
-            // Currently all French capital letters are replaced with the Latin counterpart during .mo compilation.
-            // Therefore, there is no need to generate a French specific button alphabet.
-            // generateFrenchGoodButtonFont( icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED] );
-            break;
         case SupportedLanguage::Belarusian:
         case SupportedLanguage::Bulgarian:
         case SupportedLanguage::Russian:
@@ -4443,6 +4443,7 @@ namespace fheroes2
             generateCP1251GoodButtonFont( icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED] );
             break;
         case SupportedLanguage::Dutch:
+        case SupportedLanguage::French:
         case SupportedLanguage::German:
         case SupportedLanguage::Italian:
         case SupportedLanguage::Norwegian:

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -4364,7 +4364,7 @@ namespace fheroes2
             break;
         case SupportedLanguage::French:
             generateCP1252Alphabet( icnVsSprite );
-            // Make compatible with original French custom encoding.
+            // This serves to make the font compatible with the original French custom encoding.
             generateFrenchAlphabet( icnVsSprite );
             break;
         case SupportedLanguage::Turkish:

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1096,227 +1096,72 @@ namespace
 
     void generateFrenchAlphabet( std::vector<std::vector<fheroes2::Sprite>> & icnVsSprite )
     {
-        // Resize fonts.
-        for ( const int icnId : { ICN::FONT, ICN::SMALFONT } ) {
-            icnVsSprite[icnId].resize( baseFontSize );
-        }
-
         // Normal font.
         {
             std::vector<fheroes2::Sprite> & font = icnVsSprite[ICN::FONT];
 
-            font[3].resize( font[79].width(), font[79].height() + 3 );
-            font[3].reset();
-            fheroes2::Copy( font[79], 0, 0, font[3], 0, 3, font[79].width(), font[79].height() );
-            // generate ^ on the top.
-            fheroes2::Copy( font[3], 2, 3, font[3], 3, 0, 1, 1 );
-            fheroes2::Copy( font[3], 4, 3, font[3], 4, 0, 1, 1 );
-            fheroes2::Copy( font[3], 2, 3, font[3], 5, 0, 1, 1 );
-            fheroes2::Copy( font[3], 2, 3, font[3], 2, 1, 1, 1 );
-            fheroes2::Copy( font[3], 4, 3, font[3], 3, 1, 1, 1 );
-            fheroes2::Copy( font[3], 4, 3, font[3], 5, 1, 1, 1 );
-            fheroes2::Copy( font[3], 2, 3, font[3], 6, 1, 1, 1 );
-            font[3].setPosition( font[79].x(), font[79].y() - 3 );
-            updateNormalFontLetterShadow( font[3] );
-
-            font[4].resize( font[85].width(), font[85].height() + 3 );
-            font[4].reset();
-            fheroes2::Copy( font[85], 0, 0, font[4], 0, 3, font[85].width(), font[85].height() );
-            fheroes2::Copy( font[3], 2, 0, font[4], 3, 0, 5, 2 );
-            font[4].setPosition( font[85].x(), font[85].y() - 3 );
-            updateNormalFontLetterShadow( font[4] );
-
-            font[6].resize( font[85].width(), font[85].height() + 3 );
-            font[6].reset();
-            // generate -_ on the top.
-            fheroes2::Copy( font[85], 0, 0, font[6], 0, 3, font[85].width(), font[85].height() );
-            fheroes2::Copy( font[6], 2, 3, font[6], 4, 0, 1, 1 );
-            fheroes2::Copy( font[6], 2, 4, font[6], 5, 0, 1, 1 );
-            fheroes2::Copy( font[6], 2, 3, font[6], 5, 1, 1, 1 );
-            fheroes2::Copy( font[6], 2, 4, font[6], 6, 1, 1, 1 );
-            fheroes2::Copy( font[6], 3, 3, font[6], 7, 1, 1, 1 );
-            font[6].setPosition( font[85].x(), font[85].y() - 3 );
-            updateNormalFontLetterShadow( font[6] );
-
-            font[10].resize( font[65].width(), font[65].height() + 3 );
-            font[10].reset();
-            fheroes2::Copy( font[65], 0, 0, font[10], 0, 3, font[65].width(), font[65].height() );
-            fheroes2::Copy( font[3], 2, 0, font[10], 2, 0, 5, 2 );
-            font[10].setPosition( font[65].x(), font[65].y() - 3 );
-            updateNormalFontLetterShadow( font[10] );
-
-            font[28] = font[73];
-            // Just to be safe and not to write something out of buffer.
-            if ( font[28].width() > 2 && font[28].height() > 1 ) {
-                font[28].image()[2] = 0;
-                font[28].transform()[2] = 1;
-                font[28].image()[2 + font[28].width()] = 0;
-                font[28].transform()[2 + font[28].width()] = 1;
-            }
-            fheroes2::Copy( font[28], 3, 0, font[28], 1, 0, 1, 2 );
-            updateNormalFontLetterShadow( font[28] );
-
-            font[30] = font[73];
-            // Just to be safe and not to write something out of buffer.
-            if ( font[30].width() > 4 && font[30].height() > 1 ) {
-                font[30].image()[1] = 0;
-                font[30].transform()[1] = 1;
-                font[30].image()[3] = 0;
-                font[30].transform()[3] = 1;
-                font[30].image()[2 + font[30].width()] = 0;
-                font[30].transform()[2 + font[30].width()] = 1;
-            }
-            fheroes2::Copy( font[30], 2, 0, font[30], 1, 1, 1, 1 );
-            fheroes2::Copy( font[30], 2, 0, font[30], 3, 1, 1, 1 );
-            updateNormalFontLetterShadow( font[30] );
-
-            font[32].resize( font[65].width(), font[65].height() + 3 );
-            font[32].reset();
-            fheroes2::Copy( font[65], 0, 0, font[32], 0, 3, font[65].width(), font[65].height() );
-            font[32].setPosition( font[65].x(), font[65].y() - 3 );
-            fheroes2::Copy( font[6], 4, 0, font[32], 3, 0, 4, 2 );
-            updateNormalFontLetterShadow( font[32] );
-
-            font[62].resize( font[67].width(), font[67].height() + 2 );
-            font[62].reset();
-            fheroes2::Copy( font[67], 0, 0, font[62], 0, 0, font[67].width(), font[67].height() );
-            fheroes2::Copy( font[67], 2, 1, font[62], 4, 7, 1, 1 );
-            fheroes2::Copy( font[67], 5, 6, font[62], 5, 7, 1, 1 );
-            fheroes2::Copy( font[67], 2, 6, font[62], 6, 7, 1, 1 );
-            fheroes2::Copy( font[67], 2, 1, font[62], 5, 8, 1, 1 );
-            fheroes2::Copy( font[67], 5, 6, font[62], 6, 8, 1, 1 );
-            fheroes2::Copy( font[67], 2, 1, font[62], 4, 9, 1, 1 );
-            fheroes2::Copy( font[67], 5, 6, font[62], 5, 9, 1, 1 );
-            fheroes2::Copy( font[67], 3, 0, font[62], 6, 9, 1, 1 );
-            font[62].setPosition( font[67].x(), font[67].y() );
-            updateNormalFontLetterShadow( font[62] );
-
-            font[64].resize( font[69].width(), font[69].height() + 3 );
-            font[64].reset();
-            fheroes2::Copy( font[69], 0, 0, font[64], 0, 3, font[69].width(), font[69].height() );
-            fheroes2::Copy( font[64], 4, 3, font[64], 4, 0, 1, 1 );
-            fheroes2::Copy( font[64], 4, 3, font[64], 5, 1, 1, 1 );
-            fheroes2::Copy( font[64], 8, 6, font[64], 5, 0, 1, 1 );
-            fheroes2::Copy( font[64], 8, 6, font[64], 6, 1, 1, 1 );
-            fheroes2::Copy( font[64], 4, 8, font[64], 6, 2, 1, 1 );
-            font[64].setPosition( font[69].x(), font[69].y() - 3 );
-            updateNormalFontLetterShadow( font[64] );
-
-            font[91] = font[28];
-
-            font[92].resize( font[69].width(), font[69].height() + 3 );
-            font[92].reset();
-            fheroes2::Copy( font[69], 0, 0, font[92], 0, 3, font[69].width(), font[69].height() );
-            fheroes2::Copy( font[3], 2, 0, font[92], 3, 0, 5, 2 );
-            font[92].setPosition( font[69].x(), font[69].y() - 3 );
-            updateNormalFontLetterShadow( font[92] );
-
-            font[93] = font[30];
-
-            font[94].resize( font[69].width(), font[69].height() + 3 );
-            font[94].reset();
-            fheroes2::Copy( font[69], 0, 0, font[94], 0, 3, font[69].width(), font[69].height() );
-            fheroes2::Copy( font[94], 4, 8, font[94], 3, 1, 1, 1 );
-            fheroes2::Copy( font[94], 8, 6, font[94], 4, 1, 1, 1 );
-            fheroes2::Copy( font[94], 8, 6, font[94], 5, 0, 1, 1 );
-            fheroes2::Copy( font[94], 4, 3, font[94], 6, 0, 1, 1 );
-            fheroes2::Copy( font[94], 4, 3, font[94], 5, 1, 1, 1 );
-            font[94].setPosition( font[69].x(), font[69].y() - 3 );
-            updateNormalFontLetterShadow( font[94] );
-
-            font[95] = font[30];
+            // Lowercase o with circumflex
+            font[35 - 32] = font[244 - 32];
+            // Lowercase u with circumflex
+            font[36 - 32] = font[251 - 32];
+            // Lowercase u with grave accent
+            font[38 - 32] = font[249 - 32];
+            // Lowercase a with circumflex
+            font[42 - 32] = font[226 - 32];
+            // Lowercase i with diaeresis
+            font[60 - 32] = font[239 - 32];
+            // Lowercase i with circumflex
+            font[62 - 32] = font[238 - 32];
+            // Lowercase a with grave accent
+            font[64 - 32] = font[224 - 32];
+            // Lowercase c with cedilla
+            font[94 - 32] = font[231 - 32];
+            // Lowercase e with grave accent
+            font[96 - 32] = font[232 - 32];
+            // Lowercase i with diaeresis
+            font[123 - 32] = font[239 - 32];
+            // Lowercase e with circumflex
+            font[124 - 32] = font[234 - 32];
+            // Lowercase i with circumflex
+            font[125 - 32] = font[239 - 32];
+            // Lowercase e with acute
+            font[126 - 32] = font[233 - 32];
+            // Lowercase i with circumflex
+            font[127 - 32] = font[239 - 32];
         }
 
         // Small font.
         {
             std::vector<fheroes2::Sprite> & font = icnVsSprite[ICN::SMALFONT];
 
-            font[3].resize( font[79].width(), font[79].height() + 2 );
-            font[3].reset();
-            fheroes2::Copy( font[79], 0, 0, font[3], 0, 2, font[79].width(), font[79].height() );
-            font[3].setPosition( font[79].x(), font[79].y() - 2 );
-            fheroes2::Copy( font[3], 2, 2, font[3], 2, 0, 1, 1 );
-            fheroes2::Copy( font[3], 2, 2, font[3], 4, 0, 1, 1 );
-            updateSmallFontLetterShadow( font[3] );
-
-            font[4].resize( font[85].width(), font[85].height() + 2 );
-            font[4].reset();
-            fheroes2::Copy( font[85], 0, 0, font[4], 0, 2, font[85].width(), font[85].height() );
-            font[4].setPosition( font[85].x(), font[85].y() - 2 );
-            fheroes2::Copy( font[4], 1, 2, font[4], 3, 0, 1, 1 );
-            fheroes2::Copy( font[4], 1, 2, font[4], 5, 0, 1, 1 );
-            updateSmallFontLetterShadow( font[4] );
-
-            font[6].resize( font[85].width(), font[85].height() + 2 );
-            font[6].reset();
-            fheroes2::Copy( font[85], 0, 0, font[6], 0, 2, font[85].width(), font[85].height() );
-            font[6].setPosition( font[85].x(), font[85].y() - 2 );
-            fheroes2::Copy( font[6], 1, 2, font[6], 4, 0, 1, 1 );
-            updateSmallFontLetterShadow( font[6] );
-
-            font[10].resize( font[65].width(), font[65].height() + 2 );
-            font[10].reset();
-            fheroes2::Copy( font[65], 0, 0, font[10], 0, 2, font[65].width(), font[65].height() );
-            font[10].setPosition( font[65].x(), font[65].y() - 2 );
-            fheroes2::Copy( font[10], 2, 2, font[10], 2, 1, 1, 1 );
-            fheroes2::Copy( font[10], 2, 2, font[10], 4, 1, 1, 1 );
-            fheroes2::Copy( font[10], 2, 2, font[10], 3, 0, 1, 1 );
-            updateSmallFontLetterShadow( font[10] );
-
-            font[28] = font[73];
-            fheroes2::FillTransform( font[28], 0, 0, font[28].width(), 2, 1 );
-            fheroes2::Copy( font[28], 1, 2, font[28], 1, 0, 1, 1 );
-            fheroes2::Copy( font[28], 1, 2, font[28], 3, 0, 1, 1 );
-            updateSmallFontLetterShadow( font[28] );
-
-            font[30] = font[28];
-
-            font[32].resize( font[65].width(), font[65].height() + 2 );
-            font[32].reset();
-            fheroes2::Copy( font[65], 0, 0, font[32], 0, 2, font[65].width(), font[65].height() );
-            font[32].setPosition( font[65].x(), font[65].y() - 2 );
-            fheroes2::Copy( font[32], 2, 2, font[32], 3, 0, 1, 1 );
-            fheroes2::Copy( font[32], 2, 2, font[32], 4, 1, 1, 1 );
-            updateSmallFontLetterShadow( font[32] );
-
-            font[62].resize( font[67].width(), font[67].height() + 2 );
-            font[62].reset();
-            fheroes2::Copy( font[67], 0, 0, font[62], 0, 0, font[67].width(), font[67].height() );
-            fheroes2::Copy( font[62], 3, 4, font[62], 3, 5, 1, 1 );
-            fheroes2::Copy( font[62], 3, 4, font[62], 2, 6, 1, 1 );
-            font[62].setPosition( font[67].x(), font[67].y() );
-            updateSmallFontLetterShadow( font[62] );
-
-            font[64].resize( font[69].width(), font[69].height() + 2 );
-            font[64].reset();
-            fheroes2::Copy( font[69], 0, 0, font[64], 0, 2, font[69].width(), font[69].height() );
-            font[64].setPosition( font[69].x(), font[69].y() - 2 );
-            fheroes2::Copy( font[64], 2, 2, font[64], 2, 0, 1, 1 );
-            fheroes2::Copy( font[64], 2, 2, font[64], 3, 1, 1, 1 );
-            updateSmallFontLetterShadow( font[64] );
-
-            font[91] = font[28];
-
-            font[92].resize( font[69].width(), font[69].height() + 2 );
-            font[92].reset();
-            fheroes2::Copy( font[69], 0, 0, font[92], 0, 2, font[69].width(), font[69].height() );
-            font[92].setPosition( font[69].x(), font[69].y() - 2 );
-            fheroes2::Copy( font[92], 2, 2, font[92], 3, 0, 1, 1 );
-            fheroes2::Copy( font[92], 2, 2, font[92], 2, 1, 1, 1 );
-            fheroes2::Copy( font[92], 2, 2, font[92], 4, 1, 1, 1 );
-            updateSmallFontLetterShadow( font[92] );
-
-            font[93] = font[28];
-
-            font[94].resize( font[69].width(), font[69].height() + 2 );
-            font[94].reset();
-            fheroes2::Copy( font[69], 0, 0, font[94], 0, 2, font[69].width(), font[69].height() );
-            font[94].setPosition( font[69].x(), font[69].y() - 2 );
-            fheroes2::Copy( font[94], 2, 2, font[94], 4, 0, 1, 1 );
-            fheroes2::Copy( font[94], 2, 2, font[94], 3, 1, 1, 1 );
-            updateSmallFontLetterShadow( font[94] );
-
-            font[95] = font[28];
+            // Lowercase o with circumflex
+            font[35 - 32] = font[244 - 32];
+            // Lowercase u with circumflex
+            font[36 - 32] = font[251 - 32];
+            // Lowercase u with grave accent
+            font[38 - 32] = font[249 - 32];
+            // Lowercase a with circumflex
+            font[42 - 32] = font[226 - 32];
+            // Lowercase i with diaeresis
+            font[60 - 32] = font[239 - 32];
+            // Lowercase i with circumflex
+            font[62 - 32] = font[238 - 32];
+            // Lowercase a with grave accent
+            font[64 - 32] = font[224 - 32];
+            // Lowercase c with cedilla
+            font[94 - 32] = font[231 - 32];
+            // Lowercase e with grave accent
+            font[96 - 32] = font[232 - 32];
+            // Lowercase i with diaeresis
+            font[123 - 32] = font[239 - 32];
+            // Lowercase e with circumflex
+            font[124 - 32] = font[234 - 32];
+            // Lowercase i with circumflex
+            font[125 - 32] = font[239 - 32];
+            // Lowercase e with acute
+            font[126 - 32] = font[233 - 32];
+            // Lowercase i with circumflex
+            font[127 - 32] = font[239 - 32];
         }
     }
 
@@ -2385,7 +2230,19 @@ namespace
             updateNormalFontLetterShadow( font[198 - 32] );
 
             // C with cedilla.
-            font[199 - 32] = font[35];
+            font[199 - 32].resize( font[35].width(), font[35].height() + 3 );
+            font[199 - 32].reset();
+            fheroes2::Copy( font[35], 0, 0, font[199 - 32], 0, 0, font[35].width(), font[35].height() );
+            fheroes2::Copy( font[67], 2, 1, font[199 - 32], 7, 11, 1, 1 );
+            fheroes2::Copy( font[67], 5, 6, font[199 - 32], 8, 11, 1, 1 );
+            fheroes2::Copy( font[67], 2, 6, font[199 - 32], 9, 11, 1, 1 );
+            fheroes2::Copy( font[67], 2, 1, font[199 - 32], 8, 12, 1, 1 );
+            fheroes2::Copy( font[67], 5, 6, font[199 - 32], 9, 12, 1, 1 );
+            fheroes2::Copy( font[67], 2, 1, font[199 - 32], 7, 13, 1, 1 );
+            fheroes2::Copy( font[67], 5, 6, font[199 - 32], 8, 13, 1, 1 );
+            fheroes2::Copy( font[67], 3, 0, font[199 - 32], 9, 13, 1, 1 );
+            font[199 - 32].setPosition( font[35].x(), font[35].y() );
+            updateNormalFontLetterShadow( font[199 - 32] );
 
             // E with grave accent `.
             font[200 - 32].resize( font[37].width(), font[37].height() + 3 );
@@ -2575,7 +2432,12 @@ namespace
             updateNormalFontLetterShadow( font[230 - 32] );
 
             // c with cedilla.
-            font[231 - 32] = font[67];
+            font[231 - 32].resize( font[67].width(), font[67].height() + 3 );
+            font[231 - 32].reset();
+            fheroes2::Copy( font[67], 0, 0, font[231 - 32], 0, 0, font[67].width(), font[67].height() );
+            fheroes2::Copy( font[199 - 32], 7, 11, font[231 - 32], 4, 7, 3, 3 );
+            font[231 - 32].setPosition( font[67].x(), font[67].y() );
+            updateNormalFontLetterShadow( font[231 - 32] );
 
             // e with grave accent `.
             font[232 - 32].resize( font[69].width(), font[69].height() + 3 );
@@ -2788,7 +2650,12 @@ namespace
             updateSmallFontLetterShadow( font[198 - 32] );
 
             // C with cedilla.
-            font[199 - 32] = font[35];
+            font[199 - 32].resize( font[35].width(), font[35].height() + 3 );
+            font[199 - 32].reset();
+            fheroes2::Copy( font[35], 0, 0, font[199 - 32], 0, 0, font[35].width(), font[35].height() );
+            fheroes2::Copy( font[35], 1, 1, font[199 - 32], 3, 7, 2, 2 );
+            font[199 - 32].setPosition( font[35].x(), font[35].y() );
+            updateSmallFontLetterShadow( font[199 - 32] );
 
             // E with grave accent `.
             font[200 - 32].resize( font[37].width(), font[37].height() + 4 );
@@ -2962,7 +2829,12 @@ namespace
             updateSmallFontLetterShadow( font[230 - 32] );
 
             // c with cedilla.
-            font[231 - 32] = font[67];
+            font[231 - 32].resize( font[67].width(), font[67].height() + 3 );
+            font[231 - 32].reset();
+            fheroes2::Copy( font[67], 0, 0, font[231 - 32], 0, 0, font[67].width(), font[67].height() );
+            fheroes2::Copy( font[199 - 32], 1, 1, font[231 - 32], 2, 5, 2, 2 );
+            font[231 - 32].setPosition( font[67].x(), font[67].y() );
+            updateSmallFontLetterShadow( font[231 - 32] );
 
             // e with grave accent `.
             font[232 - 32].resize( font[69].width(), font[69].height() + 3 );
@@ -4273,9 +4145,6 @@ namespace fheroes2
         case SupportedLanguage::Polish:
             generateCP1250Alphabet( icnVsSprite );
             break;
-        case SupportedLanguage::French:
-            generateFrenchAlphabet( icnVsSprite );
-            break;
         case SupportedLanguage::Belarusian:
         case SupportedLanguage::Bulgarian:
         case SupportedLanguage::Russian:
@@ -4290,6 +4159,11 @@ namespace fheroes2
         case SupportedLanguage::Spanish:
         case SupportedLanguage::Swedish:
             generateCP1252Alphabet( icnVsSprite );
+            break;
+        case SupportedLanguage::French:
+            generateCP1252Alphabet( icnVsSprite );
+            // Make compatible with original French custom encoding.
+            generateFrenchAlphabet( icnVsSprite );
             break;
         case SupportedLanguage::Turkish:
             generateCP1254Alphabet( icnVsSprite );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2200,8 +2200,15 @@ namespace
             font[194 - 32].setPosition( font[65 - 32].x(), font[65 - 32].y() - 3 );
             updateNormalFontLetterShadow( font[194 - 32] );
 
-            // A with tilde accent ~. TODO Move generation of accent for further use here.
-            font[195 - 32] = font[33];
+            // A with tilde accent ~. Generate accent for further use.
+            font[195 - 32].resize( font[65 - 32].width(), font[65 - 32].height() + 4 );
+            font[195 - 32].reset();
+            fheroes2::Copy( font[65 - 32], 0, 0, font[195 - 32], 0, 4, font[65 - 32].width(), font[65 - 32].height() );
+            fheroes2::Copy( font[37 - 32], 7, 5, font[195 - 32], 4, 0, 5, 2 );
+            fheroes2::Copy( font[37 - 32], 8, 8, font[195 - 32], 8, 2, 3, 1 );
+            fheroes2::Copy( font[37 - 32], 10, 7, font[195 - 32], 10, 1, 2, 1 );
+            font[195 - 32].setPosition( font[65 - 32].x(), font[65 - 32].y() - 4 );
+            updateNormalFontLetterShadow( font[195 - 32] );
 
             // A with 2 dots on top.
             font[196 - 32].resize( font[33].width(), font[33].height() + 3 );
@@ -2317,14 +2324,11 @@ namespace
             font[207 - 32].setPosition( font[41].x(), font[41].y() - 3 );
             updateNormalFontLetterShadow( font[207 - 32] );
 
-            // N with tilde ~. Generate accent for further use.
-            // TODO: Move tilde generation code to A with tilde when adding Portuguese.
+            // N with tilde ~.
             font[209 - 32].resize( font[46].width(), font[46].height() + 3 );
             font[209 - 32].reset();
             fheroes2::Copy( font[46], 0, 0, font[209 - 32], 0, 3, font[46].width(), font[46].height() );
-            fheroes2::Copy( font[37 - 32], 7, 5, font[209 - 32], 4, 0, 5, 2 );
-            fheroes2::Copy( font[37 - 32], 8, 8, font[209 - 32], 8, 2, 3, 1 );
-            fheroes2::Copy( font[37 - 32], 10, 7, font[209 - 32], 10, 1, 2, 1 );
+            fheroes2::Copy( font[195 - 32], 4, 0, font[209 - 32], 4, 0, 8, 3 );
             font[209 - 32].setPosition( font[46].x(), font[46].y() - 3 );
             updateNormalFontLetterShadow( font[209 - 32] );
 
@@ -2353,7 +2357,12 @@ namespace
             updateNormalFontLetterShadow( font[212 - 32] );
 
             // O with tilde accent ~.
-            font[213 - 32] = font[47];
+            font[213 - 32].resize( font[79 - 32].width(), font[79 - 32].height() + 4 );
+            font[213 - 32].reset();
+            fheroes2::Copy( font[79 - 32], 0, 0, font[213 - 32], 0, 4, font[79 - 32].width(), font[79 - 32].height() );
+            fheroes2::Copy( font[195 - 32], 4, 0, font[213 - 32], 4, 0, 8, 3 );
+            font[213 - 32].setPosition( font[79 - 32].x(), font[79 - 32].y() - 4 );
+            updateNormalFontLetterShadow( font[213 - 32] );
 
             // O with 2 dots on top. TODO replace with previous accent generation in A.
             font[214 - 32].resize( font[47].width(), font[47].height() + 3 );
@@ -2453,7 +2462,12 @@ namespace
             updateNormalFontLetterShadow( font[226 - 32] );
 
             // a with tilde accent ~.
-            font[227 - 32] = font[65];
+            font[227 - 32].resize( font[97 - 32].width(), font[97 - 32].height() + 4 );
+            font[227 - 32].reset();
+            fheroes2::Copy( font[97 - 32], 0, 0, font[227 - 32], 0, 4, font[97 - 32].width(), font[97 - 32].height() );
+            fheroes2::Copy( font[195 - 32], 4, 0, font[227 - 32], 1, 0, 8, 3 );
+            font[227 - 32].setPosition( font[97 - 32].x(), font[97 - 32].y() - 4 );
+            updateNormalFontLetterShadow( font[227 - 32] );
 
             // a with 2 dots on top.
             font[228 - 32].resize( font[65].width(), font[65].height() + 3 );
@@ -2554,7 +2568,7 @@ namespace
             font[241 - 32].resize( font[110 - 32].width(), font[110 - 32].height() + 4 );
             font[241 - 32].reset();
             fheroes2::Copy( font[110 - 32], 0, 0, font[241 - 32], 0, 4, font[110 - 32].width(), font[110 - 32].height() );
-            fheroes2::Copy( font[209 - 32], 4, 0, font[241 - 32], 1, 0, 8, 3 );
+            fheroes2::Copy( font[195 - 32], 4, 0, font[241 - 32], 1, 0, 8, 3 );
             font[241 - 32].setPosition( font[110 - 32].x(), font[110 - 32].y() - 4 );
             updateNormalFontLetterShadow( font[241 - 32] );
 
@@ -2583,7 +2597,12 @@ namespace
             updateNormalFontLetterShadow( font[244 - 32] );
 
             // o with tilde accent ~.
-            font[245 - 32] = font[79];
+            font[245 - 32].resize( font[111 - 32].width(), font[111 - 32].height() + 4 );
+            font[245 - 32].reset();
+            fheroes2::Copy( font[111 - 32], 0, 0, font[245 - 32], 0, 4, font[111 - 32].width(), font[111 - 32].height() );
+            fheroes2::Copy( font[195 - 32], 4, 0, font[245 - 32], 1, 0, 8, 3 );
+            font[245 - 32].setPosition( font[111 - 32].x(), font[111 - 32].y() - 4 );
+            updateNormalFontLetterShadow( font[245 - 32] );
 
             // o with 2 dots on top.
             font[246 - 32].resize( font[79].width(), font[79].height() + 3 );
@@ -2714,8 +2733,15 @@ namespace
             font[194 - 32].setPosition( font[33].x(), font[33].y() - 3 );
             updateSmallFontLetterShadow( font[194 - 32] );
 
-            // A with tilde accent ~. TODO Move generation of accent for further use here.
-            font[195 - 32] = font[33];
+            // A with tilde accent ~. Generate for further use.
+            font[195 - 32].resize( font[65 - 32].width(), font[65 - 32].height() + 3 );
+            font[195 - 32].reset();
+            fheroes2::Copy( font[65 - 32], 0, 0, font[195 - 32], 0, 3, font[65 - 32].width(), font[65 - 32].height() );
+            fheroes2::Copy( font[37 - 32], 5, 4, font[195 - 32], 3, 0, 3, 2 );
+            fheroes2::Copy( font[37 - 32], 5, 4, font[195 - 32], 6, 1, 2, 2 );
+            font[195 - 32].setPosition( font[65 - 32].x(), font[65 - 32].y() - 3 );
+            updateSmallFontLetterShadow( font[195 - 32] );
+            
 
             // A with 2 dots on top.
             font[196 - 32].resize( font[33].width(), font[33].height() + 2 );
@@ -2805,13 +2831,11 @@ namespace
             font[206 - 32].setPosition( font[73 - 32].x(), font[73 - 32].y() - 3 );
             updateSmallFontLetterShadow( font[206 - 32] );
 
-            // N with tilde ~. Generate tilde accent for further use.
-            // TODO: Move tilde accent generation to A with tilde when adding Portuguese.
+            // N with tilde ~.
             font[209 - 32].resize( font[46].width(), font[46].height() + 3 );
             font[209 - 32].reset();
             fheroes2::Copy( font[46], 0, 0, font[209 - 32], 0, 4, font[46].width(), font[46].height() );
-            fheroes2::Copy( font[37 - 32], 5, 4, font[209 - 32], 4, 0, 3, 2 );
-            fheroes2::Copy( font[37 - 32], 5, 4, font[209 - 32], 7, 1, 2, 2 );
+            fheroes2::Copy( font[195 - 32], 3, 0, font[209 - 32], 4, 0, 5, 3 );
             font[209 - 32].setPosition( font[46].x(), font[46].y() - 4 );
             updateSmallFontLetterShadow( font[209 - 32] );
 
@@ -2840,7 +2864,13 @@ namespace
             updateSmallFontLetterShadow( font[212 - 32] );
 
             // O with tilde accent ~.
-            font[213 - 32] = font[47];
+            font[213 - 32].resize( font[79 - 32].width(), font[79 - 32].height() + 3 );
+            font[213 - 32].reset();
+            fheroes2::Copy( font[79 - 32], 0, 0, font[213 - 32], 0, 3, font[79 - 32].width(), font[79 - 32].height() );
+            fheroes2::Copy( font[195 - 32], 3, 0, font[213 - 32], 2, 0, 5, 3 );
+            font[213 - 32].setPosition( font[79 - 32].x(), font[79 - 32].y() - 3 );
+            updateSmallFontLetterShadow( font[213 - 32] );
+            
 
             // O with 2 dots on top.
             font[214 - 32].resize( font[47].width(), font[47].height() + 2 );
@@ -2932,7 +2962,12 @@ namespace
             updateSmallFontLetterShadow( font[226 - 32] );
 
             // a with tilde accent ~.
-            font[227 - 32] = font[65];
+            font[227 - 32].resize( font[97 - 32].width(), font[97 - 32].height() + 4 );
+            font[227 - 32].reset();
+            fheroes2::Copy( font[97 - 32], 0, 0, font[227 - 32], 0, 4, font[97 - 32].width(), font[97 - 32].height() );
+            fheroes2::Copy( font[195 - 32], 3, 0, font[227 - 32], 1, 0, 5, 3 );
+            font[227 - 32].setPosition( font[97 - 32].x(), font[97 - 32].y() - 4 );
+            updateSmallFontLetterShadow( font[227 - 32] );
 
             // a with 2 dots on top.
             font[228 - 32].resize( font[65].width(), font[65].height() + 2 );
@@ -3019,7 +3054,7 @@ namespace
             font[241 - 32].resize( font[110 - 32].width(), font[110 - 32].height() + 4 );
             font[241 - 32].reset();
             fheroes2::Copy( font[110 - 32], 0, 0, font[241 - 32], 0, 4, font[110 - 32].width(), font[110 - 32].height() );
-            fheroes2::Copy( font[209 - 32], 4, 0, font[241 - 32], 2, 0, 5, 3 );
+            fheroes2::Copy( font[195 - 32], 3, 0, font[241 - 32], 2, 0, 5, 3 );
             font[241 - 32].setPosition( font[110 - 32].x(), font[110 - 32].y() - 4 );
             updateSmallFontLetterShadow( font[241 - 32] );
 
@@ -3048,7 +3083,12 @@ namespace
             updateSmallFontLetterShadow( font[244 - 32] );
 
             // o with tilde accent ~.
-            font[245 - 32] = font[79];
+            font[245 - 32].resize( font[111 - 32].width(), font[111 - 32].height() + 4 );
+            font[245 - 32].reset();
+            fheroes2::Copy( font[111 - 32], 0, 0, font[245 - 32], 0, 4, font[111 - 32].width(), font[111 - 32].height() );
+            fheroes2::Copy( font[195 - 32], 3, 0, font[245 - 32], 1, 0, 5, 3 );
+            font[245 - 32].setPosition( font[111 - 32].x(), font[111 - 32].y() - 4 );
+            updateSmallFontLetterShadow( font[245 - 32] );
 
             // o with 2 dots on top.
             font[246 - 32].resize( font[79].width(), font[79].height() + 2 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2263,6 +2263,14 @@ namespace
             // E with circumflex accent.
             font[202 - 32] = font[37];
 
+            // E with diaeresis.
+            font[203 - 32].resize( font[37].width(), font[37].height() + 3 );
+            font[203 - 32].reset();
+            fheroes2::Copy( font[37], 0, 0, font[203 - 32], 0, 3, font[37].width(), font[37].height() );
+            fheroes2::Copy( font[193 - 32], 7, 0, font[203 - 32], 5, 0, 4, 2 );
+            font[203 - 32].setPosition( font[37].x(), font[37].y() - 3 );
+            updateNormalFontLetterShadow( font[203 - 32] );
+
             // I with grave accent `.
             font[204 - 32].resize( font[41].width(), font[41].height() + 3 );
             font[204 - 32].reset();
@@ -2278,6 +2286,22 @@ namespace
             fheroes2::Copy( font[193 - 32], 7, 0, font[205 - 32], 3, 0, 4, 2 );
             font[205 - 32].setPosition( font[41].x(), font[41].y() - 3 );
             updateNormalFontLetterShadow( font[205 - 32] );
+
+            // I with circumflex.
+            font[206 - 32].resize( font[41].width(), font[41].height() + 3 );
+            font[206 - 32].reset();
+            fheroes2::Copy( font[41], 0, 0, font[206 - 32], 0, 3, font[41].width(), font[41].height() );
+            fheroes2::Copy( font[193 - 32], 7, 0, font[206 - 32], 3, 0, 4, 2 );
+            font[206 - 32].setPosition( font[41].x(), font[41].y() - 3 );
+            updateNormalFontLetterShadow( font[206 - 32] );
+
+            // I with diaeresis.
+            font[207 - 32].resize( font[41].width(), font[41].height() + 3 );
+            font[207 - 32].reset();
+            fheroes2::Copy( font[41], 0, 0, font[207 - 32], 0, 3, font[41].width(), font[41].height() );
+            fheroes2::Copy( font[193 - 32], 7, 0, font[207 - 32], 3, 0, 4, 2 );
+            font[207 - 32].setPosition( font[41].x(), font[41].y() - 3 );
+            updateNormalFontLetterShadow( font[207 - 32] );
 
             // N with tilde ~. Generate accent for further use.
             // TODO: Move tilde generation code to A with tilde when adding Portuguese.
@@ -2312,7 +2336,7 @@ namespace
             // O with tilde accent ~.
             font[213 - 32] = font[47];
 
-            // O with 2 dots on top.
+            // O with 2 dots on top. TODO replace with previous accent generation in A.
             font[214 - 32].resize( font[47].width(), font[47].height() + 3 );
             font[214 - 32].reset();
             fheroes2::Copy( font[47], 0, 0, font[214 - 32], 0, 3, font[47].width(), font[47].height() );
@@ -2349,6 +2373,13 @@ namespace
             fheroes2::Copy( font[193 - 32], 7, 0, font[218 - 32], 5, 0, 4, 2 );
             font[218 - 32].setPosition( font[53].x(), font[53].y() - 3 );
             updateNormalFontLetterShadow( font[218 - 32] );
+
+            // U with circumflex.
+            font[219 - 32].resize( font[53].width(), font[53].height() + 3 );
+            font[219 - 32].reset();
+            fheroes2::Copy( font[53], 0, 0, font[219 - 32], 0, 3, font[53].width(), font[53].height() );
+            font[219 - 32].setPosition( font[53].x(), font[53].y() - 3 );
+            updateNormalFontLetterShadow( font[219 - 32] );
 
             // U with 2 dots on top.
             font[220 - 32].resize( font[53].width(), font[53].height() + 3 );
@@ -2447,7 +2478,7 @@ namespace
             fheroes2::Copy( font[192 - 32], 7, 0, font[232 - 32], 3, 0, 4, 2 );
             updateNormalFontLetterShadow( font[232 - 32] );
 
-            // e with acute accent and generate the acute accent for further use.
+            // e with acute accent.
             font[233 - 32].resize( font[69].width(), font[69].height() + 3 );
             font[233 - 32].reset();
             fheroes2::Copy( font[69], 0, 0, font[233 - 32], 0, 3, font[69].width(), font[69].height() );
@@ -2457,6 +2488,13 @@ namespace
 
             // e with circumflex accent.
             font[234 - 32] = font[69];
+
+            // e with diaeresis.
+            font[235 - 32].resize( font[69].width(), font[69].height() + 3 );
+            font[235 - 32].reset();
+            fheroes2::Copy( font[69], 0, 0, font[235 - 32], 0, 3, font[69].width(), font[69].height() );
+            font[235 - 32].setPosition( font[69].x(), font[69].y() - 3 );
+            updateNormalFontLetterShadow( font[235 - 32] );
 
             // i with grave accent `.
             font[236 - 32] = font[73];
@@ -2469,6 +2507,18 @@ namespace
             fheroes2::FillTransform( font[237 - 32], 0, 0, font[237 - 32].width(), 3, 1 );
             fheroes2::Copy( font[193 - 32], 7, 0, font[237 - 32], 1, 0, 4, 2 );
             updateNormalFontLetterShadow( font[237 - 32] );
+
+            // i with circumflex.
+            font[238 - 32] = font[73];
+            fheroes2::FillTransform( font[238 - 32], 0, 0, font[238 - 32].width(), 3, 1 );
+            fheroes2::Copy( font[193 - 32], 7, 0, font[238 - 32], 1, 0, 4, 2 );
+            updateNormalFontLetterShadow( font[238 - 32] );
+
+            // i with diaeresis.
+            font[239 - 32] = font[73];
+            fheroes2::FillTransform( font[239 - 32], 0, 0, font[239 - 32].width(), 3, 1 );
+            fheroes2::Copy( font[193 - 32], 7, 0, font[239 - 32], 1, 0, 4, 2 );
+            updateNormalFontLetterShadow( font[239 - 32] );
 
             // n with tilde ~.
             font[241 - 32].resize( font[110 - 32].width(), font[110 - 32].height() + 4 );
@@ -2538,6 +2588,13 @@ namespace
             fheroes2::Copy( font[193 - 32], 7, 0, font[250 - 32], 3, 0, 4, 2 );
             font[250 - 32].setPosition( font[85].x(), font[85].y() - 3 );
             updateNormalFontLetterShadow( font[250 - 32] );
+
+            // u with circumflex.
+            font[251 - 32].resize( font[85].width(), font[85].height() + 3 );
+            font[251 - 32].reset();
+            fheroes2::Copy( font[85], 0, 0, font[251 - 32], 0, 3, font[85].width(), font[85].height() );
+            font[251 - 32].setPosition( font[85].x(), font[85].y() - 3 );
+            updateNormalFontLetterShadow( font[251 - 32] );
 
             // u with 2 dots on top.
             font[252 - 32].resize( font[85].width(), font[85].height() + 3 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1110,7 +1110,7 @@ namespace
             font[42 - 32] = font[226 - 32];
             // Lowercase i with diaeresis
             font[60 - 32] = font[239 - 32];
-            // Lowercase i with circumflex
+            // Lowercase i with circumflex <- Confirmed used in the OG.
             font[62 - 32] = font[238 - 32];
             // Lowercase a with grave accent
             font[64 - 32] = font[224 - 32];
@@ -2188,8 +2188,17 @@ namespace
             font[193 - 32].setPosition( font[33].x(), font[33].y() - 3 );
             updateNormalFontLetterShadow( font[193 - 32] );
 
-            // A with circumflex accent. TODO Move generation of accent for further use here.
-            font[194 - 32] = font[33];
+            // A with circumflex accent. Generation of accent for further use.
+            font[194 - 32].resize( font[65 - 32].width(), font[65 - 32].height() + 3 );
+            font[194 - 32].reset();
+            fheroes2::Copy( font[65 - 32], 0, 0, font[194 - 32], 0, 3, font[65 - 32].width(), font[65 - 32].height() );
+            fheroes2::Copy( font[97 - 32], 7, 1, font[194 - 32], 7, 1, 1, 1 );
+            fheroes2::Copy( font[97 - 32], 7, 1, font[194 - 32], 8, 0, 1, 1 );
+            fheroes2::Copy( font[97 - 32], 7, 1, font[194 - 32], 9, 1, 1, 1 );
+            fheroes2::Copy( font[97 - 32], 1, 0, font[194 - 32], 7, 0, 1, 1 );
+            fheroes2::Copy( font[97 - 32], 1, 0, font[194 - 32], 9, 0, 1, 1 );
+            font[194 - 32].setPosition( font[65 - 32].x(), font[65 - 32].y() - 3 );
+            updateNormalFontLetterShadow( font[194 - 32] );
 
             // A with tilde accent ~. TODO Move generation of accent for further use here.
             font[195 - 32] = font[33];
@@ -2261,7 +2270,12 @@ namespace
             updateNormalFontLetterShadow( font[201 - 32] );
 
             // E with circumflex accent.
-            font[202 - 32] = font[37];
+            font[202 - 32].resize( font[69 - 32].width(), font[69 - 32].height() + 3 );
+            font[202 - 32].reset();
+            fheroes2::Copy( font[69 - 32], 0, 0, font[202 - 32], 0, 3, font[69 - 32].width(), font[69 - 32].height() );
+            fheroes2::Copy( font[194 - 32], 7, 0, font[202 - 32], 5, 0, 3, 2 );
+            font[202 - 32].setPosition( font[69 - 32].x(), font[69 - 32].y() - 3 );
+            updateNormalFontLetterShadow( font[202 - 32] );
 
             // E with diaeresis.
             font[203 - 32].resize( font[37].width(), font[37].height() + 3 );
@@ -2291,7 +2305,7 @@ namespace
             font[206 - 32].resize( font[41].width(), font[41].height() + 3 );
             font[206 - 32].reset();
             fheroes2::Copy( font[41], 0, 0, font[206 - 32], 0, 3, font[41].width(), font[41].height() );
-            fheroes2::Copy( font[193 - 32], 7, 0, font[206 - 32], 3, 0, 4, 2 );
+            fheroes2::Copy( font[194 - 32], 7, 0, font[206 - 32], 3, 0, 3, 2 );
             font[206 - 32].setPosition( font[41].x(), font[41].y() - 3 );
             updateNormalFontLetterShadow( font[206 - 32] );
 
@@ -2331,7 +2345,12 @@ namespace
             updateNormalFontLetterShadow( font[211 - 32] );
 
             // O with circumflex accent.
-            font[212 - 32] = font[47];
+            font[212 - 32].resize( font[79 - 32].width(), font[79 - 32].height() + 3 );
+            font[212 - 32].reset();
+            fheroes2::Copy( font[79 - 32], 0, 0, font[212 - 32], 0, 3, font[79 - 32].width(), font[79 - 32].height() );
+            fheroes2::Copy( font[194 - 32], 7, 0, font[212 - 32], 7, 0, 3, 2 );
+            font[212 - 32].setPosition( font[79 - 32].x(), font[79 - 32].y() - 3 );
+            updateNormalFontLetterShadow( font[212 - 32] );
 
             // O with tilde accent ~.
             font[213 - 32] = font[47];
@@ -2378,6 +2397,7 @@ namespace
             font[219 - 32].resize( font[53].width(), font[53].height() + 3 );
             font[219 - 32].reset();
             fheroes2::Copy( font[53], 0, 0, font[219 - 32], 0, 3, font[53].width(), font[53].height() );
+            fheroes2::Copy( font[194 - 32], 7, 0, font[219 - 32], 6, 0, 3, 2 );
             font[219 - 32].setPosition( font[53].x(), font[53].y() - 3 );
             updateNormalFontLetterShadow( font[219 - 32] );
 
@@ -2425,7 +2445,12 @@ namespace
             updateNormalFontLetterShadow( font[225 - 32] );
 
             // a with circumflex accent.
-            font[226 - 32] = font[65];
+            font[226 - 32].resize( font[97 - 32].width(), font[97 - 32].height() + 3 );
+            font[226 - 32].reset();
+            fheroes2::Copy( font[97 - 32], 0, 0, font[226 - 32], 0, 3, font[97 - 32].width(), font[97 - 32].height() );
+            fheroes2::Copy( font[194 - 32], 7, 0, font[226 - 32], 3, 0, 3, 2 );
+            font[226 - 32].setPosition( font[97 - 32].x(), font[97 - 32].y() - 3 );
+            updateNormalFontLetterShadow( font[226 - 32] );
 
             // a with tilde accent ~.
             font[227 - 32] = font[65];
@@ -2487,7 +2512,12 @@ namespace
             updateNormalFontLetterShadow( font[233 - 32] );
 
             // e with circumflex accent.
-            font[234 - 32] = font[69];
+            font[234 - 32].resize( font[101 - 32].width(), font[101 - 32].height() + 3 );
+            font[234 - 32].reset();
+            fheroes2::Copy( font[101 - 32], 0, 0, font[234 - 32], 0, 3, font[101 - 32].width(), font[101 - 32].height() );
+            fheroes2::Copy( font[194 - 32], 7, 0, font[234 - 32], 4, 0, 3, 2 );
+            font[234 - 32].setPosition( font[101 - 32].x(), font[101 - 32].y() - 3 );
+            updateNormalFontLetterShadow( font[234 - 32] );
 
             // e with diaeresis.
             font[235 - 32].resize( font[69].width(), font[69].height() + 3 );
@@ -2511,7 +2541,7 @@ namespace
             // i with circumflex.
             font[238 - 32] = font[73];
             fheroes2::FillTransform( font[238 - 32], 0, 0, font[238 - 32].width(), 3, 1 );
-            fheroes2::Copy( font[193 - 32], 7, 0, font[238 - 32], 1, 0, 4, 2 );
+            fheroes2::Copy( font[194 - 32], 7, 0, font[238 - 32], 1, 0, 3, 2 );
             updateNormalFontLetterShadow( font[238 - 32] );
 
             // i with diaeresis.
@@ -2545,7 +2575,12 @@ namespace
             updateNormalFontLetterShadow( font[243 - 32] );
 
             // o with circumflex accent.
-            font[244 - 32] = font[79];
+            font[244 - 32].resize( font[111 - 32].width(), font[111 - 32].height() + 3 );
+            font[244 - 32].reset();
+            fheroes2::Copy( font[111 - 32], 0, 0, font[244 - 32], 0, 3, font[111 - 32].width(), font[111 - 32].height() );
+            fheroes2::Copy( font[194 - 32], 7, 0, font[244 - 32], 4, 0, 3, 2 );
+            font[244 - 32].setPosition( font[111 - 32].x(), font[111 - 32].y() - 3 );
+            updateNormalFontLetterShadow( font[244 - 32] );
 
             // o with tilde accent ~.
             font[245 - 32] = font[79];
@@ -2593,6 +2628,7 @@ namespace
             font[251 - 32].resize( font[85].width(), font[85].height() + 3 );
             font[251 - 32].reset();
             fheroes2::Copy( font[85], 0, 0, font[251 - 32], 0, 3, font[85].width(), font[85].height() );
+            fheroes2::Copy( font[194 - 32], 7, 0, font[251 - 32], 4, 0, 3, 2 );
             font[251 - 32].setPosition( font[85].x(), font[85].y() - 3 );
             updateNormalFontLetterShadow( font[251 - 32] );
 
@@ -2668,8 +2704,15 @@ namespace
             font[193 - 32].setPosition( font[33].x(), font[33].y() - 4 );
             updateSmallFontLetterShadow( font[193 - 32] );
 
-            // A with circumflex accent. TODO Move generation of accent for further use here.
-            font[194 - 32] = font[33];
+            // A with circumflex accent. Generate accent for further use.
+            font[194 - 32].resize( font[33].width(), font[33].height() + 3 );
+            font[194 - 32].reset();
+            fheroes2::Copy( font[33], 0, 0, font[194 - 32], 0, 3, font[33].width(), font[33].height() );
+            fheroes2::Copy( font[33], 4, 0, font[194 - 32], 4, 1, 1, 1 );
+            fheroes2::Copy( font[33], 4, 0, font[194 - 32], 5, 0, 1, 1 );
+            fheroes2::Copy( font[33], 4, 0, font[194 - 32], 6, 1, 1, 1 );
+            font[194 - 32].setPosition( font[33].x(), font[33].y() - 3 );
+            updateSmallFontLetterShadow( font[194 - 32] );
 
             // A with tilde accent ~. TODO Move generation of accent for further use here.
             font[195 - 32] = font[33];
@@ -2731,7 +2774,12 @@ namespace
             updateSmallFontLetterShadow( font[201 - 32] );
 
             // E with circumflex accent.
-            font[202 - 32] = font[37];
+            font[202 - 32].resize( font[69 - 32].width(), font[69 - 32].height() + 3 );
+            font[202 - 32].reset();
+            fheroes2::Copy( font[69 - 32], 0, 0, font[202 - 32], 0, 3, font[69 - 32].width(), font[69 - 32].height() );
+            fheroes2::Copy( font[194 - 32], 4, 0, font[202 - 32], 3, 0, 3, 2 );
+            font[202 - 32].setPosition( font[69 - 32].x(), font[69 - 32].y() - 3 );
+            updateSmallFontLetterShadow( font[202 - 32] );
 
             // I with grave accent `.
             font[204 - 32].resize( font[41].width(), font[41].height() + 4 );
@@ -2748,6 +2796,14 @@ namespace
             fheroes2::Copy( font[193 - 32], 4, 0, font[205 - 32], 1, 0, 3, 3 );
             font[205 - 32].setPosition( font[41].x(), font[41].y() - 4 );
             updateSmallFontLetterShadow( font[205 - 32] );
+
+            // I with circumflex
+            font[206 - 32].resize( font[73 - 32].width() + 1, font[73 - 32].height() + 3 );
+            font[206 - 32].reset();
+            fheroes2::Copy( font[73 - 32], 0, 0, font[206 - 32], 0, 3, font[73 - 32].width(), font[73 - 32].height() );
+            fheroes2::Copy( font[194 - 32], 4, 0, font[206 - 32], 2, 0, 3, 2 );
+            font[206 - 32].setPosition( font[73 - 32].x(), font[73 - 32].y() - 3 );
+            updateSmallFontLetterShadow( font[206 - 32] );
 
             // N with tilde ~. Generate tilde accent for further use.
             // TODO: Move tilde accent generation to A with tilde when adding Portuguese.
@@ -2776,7 +2832,12 @@ namespace
             updateSmallFontLetterShadow( font[211 - 32] );
 
             // O with circumflex accent.
-            font[212 - 32] = font[47];
+            font[212 - 32].resize( font[79 - 32].width(), font[79 - 32].height() + 3 );
+            font[212 - 32].reset();
+            fheroes2::Copy( font[79 - 32], 0, 0, font[212 - 32], 0, 3, font[79 - 32].width(), font[79 - 32].height() );
+            fheroes2::Copy( font[194 - 32], 4, 0, font[212 - 32], 3, 0, 3, 2 );
+            font[212 - 32].setPosition( font[79 - 32].x(), font[79 - 32].y() - 3 );
+            updateSmallFontLetterShadow( font[212 - 32] );
 
             // O with tilde accent ~.
             font[213 - 32] = font[47];
@@ -2815,6 +2876,14 @@ namespace
             fheroes2::Copy( font[193 - 32], 4, 0, font[218 - 32], 4, 0, 3, 3 );
             font[218 - 32].setPosition( font[53].x(), font[53].y() - 4 );
             updateSmallFontLetterShadow( font[218 - 32] );
+
+            // U with circumflex.
+            font[219 - 32].resize( font[85 - 32].width(), font[85 - 32].height() + 3 );
+            font[219 - 32].reset();
+            fheroes2::Copy( font[85 - 32], 0, 0, font[219 - 32], 0, 3, font[85 - 32].width(), font[85 - 32].height() );
+            fheroes2::Copy( font[194 - 32], 4, 0, font[219 - 32], 4, 0, 3, 2 );
+            font[219 - 32].setPosition( font[85 - 32].x(), font[85 - 32].y() - 3 );
+            updateSmallFontLetterShadow( font[219 - 32] );
 
             // U with 2 dots on top.
             font[220 - 32].resize( font[53].width(), font[53].height() + 2 );
@@ -2855,7 +2924,12 @@ namespace
             updateSmallFontLetterShadow( font[225 - 32] );
 
             // a with circumflex accent.
-            font[226 - 32] = font[65];
+            font[226 - 32].resize( font[97 - 32].width(), font[97 - 32].height() + 3 );
+            font[226 - 32].reset();
+            fheroes2::Copy( font[97 - 32], 0, 0, font[226 - 32], 0, 3, font[97 - 32].width(), font[97 - 32].height() );
+            fheroes2::Copy( font[194 - 32], 4, 0, font[226 - 32], 2, 0, 3, 2 );
+            font[226 - 32].setPosition( font[97 - 32].x(), font[97 - 32].y() - 3 );
+            updateSmallFontLetterShadow( font[226 - 32] );
 
             // a with tilde accent ~.
             font[227 - 32] = font[65];
@@ -2910,7 +2984,12 @@ namespace
             updateSmallFontLetterShadow( font[233 - 32] );
 
             // e with circumflex accent.
-            font[234 - 32] = font[69];
+            font[234 - 32].resize( font[101 - 32].width(), font[101 - 32].height() + 3 );
+            font[234 - 32].reset();
+            fheroes2::Copy( font[101 - 32], 0, 0, font[234 - 32], 0, 3, font[101 - 32].width(), font[101 - 32].height() );
+            fheroes2::Copy( font[194 - 32], 4, 0, font[234 - 32], 2, 0, 3, 2 );
+            font[234 - 32].setPosition( font[101 - 32].x(), font[101 - 32].y() - 3 );
+            updateSmallFontLetterShadow( font[234 - 32] );
 
             // i with grave accent `.
             font[236 - 32].resize( font[73].width(), font[73].height() + 1 );
@@ -2927,6 +3006,14 @@ namespace
             fheroes2::Copy( font[193 - 32], 5, 0, font[237 - 32], 1, 0, 2, 2 );
             font[237 - 32].setPosition( font[73].x(), font[73].y() - 1 );
             updateSmallFontLetterShadow( font[237 - 32] );
+
+            // i with circumflex.
+            font[238 - 32].resize( font[105 - 32].width(), font[105 - 32].height() + 1 );
+            font[238 - 32].reset();
+            fheroes2::Copy( font[105 - 32], 0, 2, font[238 - 32], 0, 3, font[105 - 32].width(), font[105 - 32].height() );
+            fheroes2::Copy( font[194 - 32], 4, 0, font[238 - 32], 1, 0, 3, 2 );
+            font[238 - 32].setPosition( font[105 - 32].x(), font[105 - 32].y() - 1 );
+            updateSmallFontLetterShadow( font[238 - 32] );
 
             // n with tilde ~.
             font[241 - 32].resize( font[110 - 32].width(), font[110 - 32].height() + 4 );
@@ -2953,7 +3040,12 @@ namespace
             updateSmallFontLetterShadow( font[243 - 32] );
 
             // o with circumflex accent.
-            font[244 - 32] = font[79];
+            font[244 - 32].resize( font[111 - 32].width(), font[111 - 32].height() + 3 );
+            font[244 - 32].reset();
+            fheroes2::Copy( font[111 - 32], 0, 0, font[244 - 32], 0, 3, font[111 - 32].width(), font[111 - 32].height() );
+            fheroes2::Copy( font[194 - 32], 4, 0, font[244 - 32], 2, 0, 3, 2 );
+            font[244 - 32].setPosition( font[111 - 32].x(), font[111 - 32].y() - 3 );
+            updateSmallFontLetterShadow( font[244 - 32] );
 
             // o with tilde accent ~.
             font[245 - 32] = font[79];
@@ -2993,6 +3085,14 @@ namespace
             fheroes2::Copy( font[193 - 32], 5, 0, font[250 - 32], 3, 0, 2, 2 );
             font[250 - 32].setPosition( font[85].x(), font[85].y() - 3 );
             updateSmallFontLetterShadow( font[250 - 32] );
+
+            // u with circumflex accent.
+            font[251 - 32].resize( font[117 - 32].width(), font[117 - 32].height() + 3 );
+            font[251 - 32].reset();
+            fheroes2::Copy( font[117 - 32], 0, 0, font[251 - 32], 0, 3, font[117 - 32].width(), font[117 - 32].height() );
+            fheroes2::Copy( font[194 - 32], 4, 0, font[251 - 32], 3, 0, 3, 2 );
+            font[251 - 32].setPosition( font[117 - 32].x(), font[117 - 32].y() - 3 );
+            updateSmallFontLetterShadow( font[251 - 32] );
 
             // u with 2 dots on top.
             font[252 - 32].resize( font[85].width(), font[85].height() + 2 );


### PR DESCRIPTION
This PR makes the French font generation use the CP1252 font generation and maintains compatibility with the original French custom encoding.

All French specific letters have been added as well as all characters with the tilde `~` accent for Portuguese support.

The MO makefile has been changed to use CP1252 encoding for French.

French has been set to use CP1252 for button font.

This PR will also add French quotation marks since they are part of CP1252.
Close #4882