### PR TITLE
Update AI logic for monster distribution and recruitment

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -96,6 +96,25 @@ namespace
 
         return false;
     }
+
+    bool canMonsterJoinHero( const Troop & troop, Heroes & hero )
+    {
+        if ( hero.GetArmy().HasMonster( troop.GetID() ) ) {
+            return true;
+        }
+
+        if ( troop.GetStrength() < hero.getAIMininumJoiningArmyStrength() ) {
+            // No use to hire such a weak troop.
+            return false;
+        }
+
+        if ( !hero.GetArmy().mergeWeakestTroopsIfNeeded() ) {
+            // The army has no slots and we cannot rearrange it.
+            return false;
+        }
+
+        return true;
+    }
 }
 
 namespace AI
@@ -667,7 +686,7 @@ namespace AI
             assert( hero.GetArmy().CanJoinTroop( troop ) && hero.GetKingdom().AllowPayment( payment_t( Resource::GOLD, joiningCost ) ) );
 
             DEBUG_LOG( DBG_AI, DBG_INFO, join.monsterCount << " " << troop.GetName() << " join " << hero.GetName() << " for " << joiningCost << " gold." )
-            hero.GetArmy().JoinTroop( troop.GetMonster(), join.monsterCount );
+            hero.GetArmy().JoinTroop( troop.GetMonster(), join.monsterCount, false );
             hero.GetKingdom().OddFundsResource( Funds( Resource::GOLD, joiningCost ) );
             destroy = true;
         }
@@ -1360,11 +1379,22 @@ namespace AI
     {
         Maps::Tiles & tile = world.GetTiles( dst_index );
         const Troop & troop = tile.QuantityTroop();
-
-        if ( troop.isValid() && hero.GetArmy().JoinTroop( troop ) ) {
-            tile.MonsterSetCount( 0 );
-            hero.unmarkHeroMeeting();
+        if ( !troop.isValid() ) {
+            return;
         }
+
+        if ( !canMonsterJoinHero( troop, hero ) ) {
+            return;
+        }
+
+        if ( !hero.GetArmy().JoinTroop( troop ) ) {
+            // How is it possible that an army has free slots but monsters cannot join it?
+            assert( 0 );
+            return;
+        }
+
+        tile.MonsterSetCount( 0 );
+        hero.unmarkHeroMeeting();
 
         DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() )
     }
@@ -1373,25 +1403,46 @@ namespace AI
     {
         Maps::Tiles & tile = world.GetTiles( dst_index );
         const Troop & troop = tile.QuantityTroop();
-
-        if ( troop.isValid() ) {
-            Kingdom & kingdom = hero.GetKingdom();
-            const payment_t paymentCosts = troop.GetTotalCost();
-
-            // TODO: add logic for buying a part of monsters when the AI does not have enough resources.
-            if ( kingdom.AllowPayment( paymentCosts ) && hero.GetArmy().JoinTroop( troop ) ) {
-                tile.MonsterSetCount( 0 );
-                kingdom.OddFundsResource( paymentCosts );
-
-                // remove ancient lamp sprite
-                if ( MP2::OBJ_ANCIENTLAMP == objectType ) {
-                    tile.RemoveObjectSprite();
-                    tile.setAsEmpty();
-                }
-
-                hero.unmarkHeroMeeting();
-            }
+        if ( !troop.isValid() ) {
+            return;
         }
+
+        Kingdom & kingdom = hero.GetKingdom();
+        const payment_t singleMonsterCost = troop.GetCost();
+
+        const uint32_t availableTroopCount = troop.GetCount();
+        uint32_t recruitTroopCount = kingdom.GetFunds().getLowestQuotient( singleMonsterCost );
+        if ( recruitTroopCount <= 0 ) {
+            // We do not have resources to hire even a single creature.
+            return;
+        }
+
+        if ( recruitTroopCount > troop.GetCount() ) {
+            recruitTroopCount = troop.GetCount();
+        }
+
+        const Troop troopToHire{ troop.GetID(), recruitTroopCount };
+
+        if ( !canMonsterJoinHero( troopToHire, hero ) ) {
+            return;
+        }
+
+        if ( !hero.GetArmy().JoinTroop( troopToHire ) ) {
+            // How is it possible that an army has free slots but monsters cannot join it?
+            assert( 0 );
+            return;
+        }
+
+        tile.MonsterSetCount( availableTroopCount - recruitTroopCount );
+        kingdom.OddFundsResource( troopToHire.GetTotalCost() );
+
+        // Remove ancient lamp sprite if no genies are available to hire.
+        if ( MP2::OBJ_ANCIENTLAMP == objectType && ( availableTroopCount == recruitTroopCount ) ) {
+            tile.RemoveObjectSprite();
+            tile.setAsEmpty();
+        }
+
+        hero.unmarkHeroMeeting();
 
         DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() )
     }
@@ -1625,7 +1676,7 @@ namespace AI
 
         // TODO: do not transfer the whole army from one hero to another. Add logic to leave a fast unit for Scout and Courier. Also 3-5 monsters are better than
         // having 1 Peasant in one stack which leads to an instant death if the hero is attacked by an opponent.
-        taker.GetArmy().JoinStrongestFromArmy( giver.GetArmy() );
+        taker.GetArmy().JoinStrongestFromArmy( giver.GetArmy(), false );
 
         taker.GetBagArtifacts().exchangeArtifacts( giver.GetBagArtifacts(), taker, giver );
     }

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1410,15 +1410,15 @@ namespace AI
         Kingdom & kingdom = hero.GetKingdom();
         const payment_t singleMonsterCost = troop.GetCost();
 
-        const uint32_t availableTroopCount = troop.GetCount();
         uint32_t recruitTroopCount = kingdom.GetFunds().getLowestQuotient( singleMonsterCost );
         if ( recruitTroopCount <= 0 ) {
             // We do not have resources to hire even a single creature.
             return;
         }
 
-        if ( recruitTroopCount > troop.GetCount() ) {
-            recruitTroopCount = troop.GetCount();
+        const uint32_t availableTroopCount = troop.GetCount();
+        if ( recruitTroopCount > availableTroopCount ) {
+            recruitTroopCount = availableTroopCount;
         }
 
         const Troop troopToHire{ troop.GetID(), recruitTroopCount };

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -401,15 +401,15 @@ namespace
 
             const payment_t singleMonsterCost = troop.GetCost();
 
-            const uint32_t availableTroopCount = troop.GetCount();
             uint32_t recruitTroopCount = kingdom.GetFunds().getLowestQuotient( singleMonsterCost );
             if ( recruitTroopCount <= 0 ) {
                 // We do not have resources to hire even a single creature.
                 return false;
             }
 
-            if ( recruitTroopCount > troop.GetCount() ) {
-                recruitTroopCount = troop.GetCount();
+            const uint32_t availableTroopCount = troop.GetCount();
+            if ( recruitTroopCount > availableTroopCount ) {
+                recruitTroopCount = availableTroopCount;
             }
 
             const Troop troopToHire{ troop.GetID(), recruitTroopCount };

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -179,11 +179,12 @@ namespace AI
 
         Army & heroArmy = hero.GetArmy();
         Army & garrison = castle.GetArmy();
-        const double armyStrength = heroArmy.GetStrength();
+        // We need to compare a strength of troops excluding hero's stats.
+        const double armyStrength = heroArmy.getTroops().GetStrength();
 
         heroArmy.UpgradeTroops( castle );
         castle.recruitBestAvailable( budget );
-        heroArmy.JoinStrongestFromArmy( garrison );
+        heroArmy.JoinStrongestFromArmy( garrison, false );
 
         const uint32_t regionID = world.GetTiles( castle.GetIndex() ).GetRegion();
         // check if we should leave some troops in the garrison

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -900,7 +900,7 @@ bool Troops::mergeWeakestTroopsIfNeeded()
     assert( !sortedMultiSlotMonsterIdVsStrength.empty() );
 
     std::sort( sortedMultiSlotMonsterIdVsStrength.begin(), sortedMultiSlotMonsterIdVsStrength.end(),
-               []( const auto & left, const auto & right ){ return left.second < right.second; } );
+               []( const auto & left, const auto & right ) { return left.second < right.second; } );
 
     const int weakestMonsterToMerge = sortedMultiSlotMonsterIdVsStrength.front().first;
 

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -900,7 +900,7 @@ bool Troops::mergeWeakestTroopsIfNeeded()
     assert( !sortedMultiSlotMonsterIdVsStrength.empty() );
 
     std::sort( sortedMultiSlotMonsterIdVsStrength.begin(), sortedMultiSlotMonsterIdVsStrength.end(),
-        []( const auto & left, const auto & right ){ return left.second < right.second; } );
+               []( const auto & left, const auto & right ){ return left.second < right.second; } );
 
     const int weakestMonsterToMerge = sortedMultiSlotMonsterIdVsStrength.front().first;
 

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -340,7 +340,7 @@ bool Troops::areAllTroopsUnique() const
 
         auto [it, inserted] = monsterId.emplace( troop->GetID() );
         if ( !inserted ) {
-          return false;
+            return false;
         }
     }
 

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -868,7 +868,7 @@ bool Troops::mergeWeakestTroopsIfNeeded()
     std::map<int, uint32_t> monsterIdVsSlotCount;
     std::map<int, double> monsterIdVsStrength;
 
-    for ( Troop * troop : *this ) {
+    for ( const Troop * troop : *this ) {
         assert( troop != nullptr );
         if ( !troop->isValid() ) {
             continue;

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -864,7 +864,7 @@ bool Troops::mergeWeakestTroopsIfNeeded()
         return true;
     }
 
-    std::map<int, double> monsterIdVsSlotCount;
+    std::map<int, uint32_t> monsterIdVsSlotCount;
     std::map<int, double> monsterIdVsStrength;
 
     for ( Troop * troop : *this ) {

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -103,7 +103,7 @@ public:
 
     void SortStrongest();
 
-    void JoinStrongest( Troops & giverArmy, const bool keepAtLeastOneSlotForGiver, const bool priotirizeEmptySlots );
+    void JoinStrongest( Troops & giverArmy, const bool keepAtLeastOneSlotForGiver, const bool prioritizeEmptySlots );
 
     void SplitTroopIntoFreeSlots( const Troop & troop, const Troop & selectedSlot, const uint32_t slots );
     void AssignToFirstFreeSlot( const Troop &, const uint32_t splitCount );
@@ -208,7 +208,7 @@ public:
 
     std::string String() const;
 
-    void JoinStrongestFromArmy( Army & giver, const bool priotirizeEmptySlots );
+    void JoinStrongestFromArmy( Army & giver, const bool prioritizeEmptySlots );
 
     void SetSpreadFormat( bool f )
     {

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -72,12 +72,14 @@ public:
     bool isValid() const;
     bool HasMonster( const Monster & ) const;
 
+    bool areAllTroopsUnique() const;
+
     bool AllTroopsAreUndead() const;
     // Returns true if all valid troops have the same ID or if there are no troops, otherwise returns false
     bool AllTroopsAreTheSame() const;
 
-    bool JoinTroop( const Troop & );
-    bool JoinTroop( const Monster & mons, uint32_t count, bool emptySlotFirst = false );
+    bool JoinTroop( const Troop & troop );
+    bool JoinTroop( const Monster & mons, uint32_t count, bool emptySlotFirst );
     bool CanJoinTroop( const Monster & ) const;
 
     void JoinTroops( Troops & );
@@ -101,13 +103,21 @@ public:
 
     void SortStrongest();
 
-    void JoinStrongest( Troops & giverArmy, const bool keepAtLeastOneSlotForGiver );
+    void JoinStrongest( Troops & giverArmy, const bool keepAtLeastOneSlotForGiver, const bool priotirizeEmptySlots );
 
     void SplitTroopIntoFreeSlots( const Troop & troop, const Troop & selectedSlot, const uint32_t slots );
     void AssignToFirstFreeSlot( const Troop &, const uint32_t splitCount );
     void JoinAllTroopsOfType( const Troop & targetTroop );
 
     void addNewTroopsToFreeSlots( const Troop & troop, uint32_t maxSlots );
+
+    bool isFullHouse() const
+    {
+        return GetOccupiedSlotCount() == size();
+    }
+
+    // If the army has no slot find 2 or more slots of the same monster which is the weakest and merge them releasing one slot in troops.
+    bool mergeWeakestTroopsIfNeeded();
 };
 
 struct NeutralMonsterJoiningCondition
@@ -198,7 +208,7 @@ public:
 
     std::string String() const;
 
-    void JoinStrongestFromArmy( Army & );
+    void JoinStrongestFromArmy( Army & giver, const bool priotirizeEmptySlots );
 
     void SetSpreadFormat( bool f )
     {
@@ -208,11 +218,6 @@ public:
     bool isSpreadFormat() const
     {
         return combat_format;
-    }
-
-    bool isFullHouse() const
-    {
-        return GetOccupiedSlotCount() == size();
     }
 
     bool SaveLastTroop() const;

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -401,7 +401,7 @@ void Battle::NecromancySkillAction( HeroBase & hero, const uint32_t enemyTroopsK
     uint32_t raiseCount = Monster::GetCountFromHitPoints( raisedMonsterType, mons.GetHitPoints() * enemyTroopsKilled * necromancyPercent / 100 );
     if ( raiseCount == 0u )
         raiseCount = 1;
-    army.JoinTroop( mons, raiseCount );
+    army.JoinTroop( mons, raiseCount, false );
 
     if ( isControlHuman )
         arena.DialogBattleNecromancy( raiseCount, raisedMonsterType );

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -2488,7 +2488,7 @@ void Castle::JoinRNDArmy()
         count += Rand::Get( 8, 15 );
     }
 
-    army.JoinTroop( Monster( race, dwellingType ), count );
+    army.JoinTroop( Monster( race, dwellingType ), count, false );
 }
 
 void Castle::ActionPreBattle()
@@ -2496,7 +2496,7 @@ void Castle::ActionPreBattle()
     CastleHeroes heroes = world.GetHeroes( *this );
     Heroes * hero = heroes.GuardFirst();
     if ( hero && army.isValid() )
-        hero->GetArmy().JoinStrongestFromArmy( army );
+        hero->GetArmy().JoinStrongestFromArmy( army, true );
 
     if ( isControlAI() )
         AI::Get().CastlePreBattle( *this );

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -67,9 +67,9 @@ namespace
 
         if ( count > 0 ) {
             if ( tempCastleArmy.CanJoinTroop( monsters ) )
-                tempCastleArmy.JoinTroop( monsters, count );
+                tempCastleArmy.JoinTroop( monsters, count, false );
             else if ( tempHeroArmy.CanJoinTroop( monsters ) )
-                tempHeroArmy.JoinTroop( monsters, count );
+                tempHeroArmy.JoinTroop( monsters, count, false );
         }
 
         return count;

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -220,8 +220,8 @@ Heroes::Heroes( int heroid, int rc )
     switch ( hid ) {
     case DEBUG_HERO:
         army.Clean();
-        army.JoinTroop( Monster::BLACK_DRAGON, 2 );
-        army.JoinTroop( Monster::RED_DRAGON, 3 );
+        army.JoinTroop( Monster::BLACK_DRAGON, 2, false );
+        army.JoinTroop( Monster::RED_DRAGON, 3, false );
 
         secondary_skills = Skill::SecSkills();
         secondary_skills.AddSkill( Skill::Secondary( Skill::Secondary::PATHFINDING, Skill::Level::ADVANCED ) );
@@ -1938,6 +1938,38 @@ HeroSeedsForLevelUp Heroes::GetSeedsForLevelUp() const
     seeds.seedSecondaySkill2 = hash + 2;
     seeds.seedSecondaySkillRandomChoose = hash + 3;
     return seeds;
+}
+
+double Heroes::getAIMininumJoiningArmyStrength() const
+{
+    // Ideally we need to assert here that the hero is under AI control.
+    // But in cases when we regain a temporary control from the AI then the hero becomes non-AI.
+
+    double strengthThreshold = 0.05;
+
+    switch ( getAIRole() ) {
+    case Heroes::Role::SCOUT:
+        strengthThreshold = 0.01;
+        break;
+    case Heroes::Role::COURIER:
+        strengthThreshold = 0.015;
+        break;
+    case Heroes::Role::HUNTER:
+        strengthThreshold = 0.02;
+        break;
+    case Heroes::Role::FIGHTER:
+        strengthThreshold = 0.025;
+        break;
+    case Heroes::Role::CHAMPION:
+        strengthThreshold = 0.03;
+        break;
+    default:
+        // Did you add a new AI hero role? Add the logic above!
+        assert( 0 );
+        break;
+    }
+
+    return strengthThreshold * GetArmy().getTroops().GetStrength();
 }
 
 StreamBase & operator<<( StreamBase & msg, const VecHeroes & heroes )

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -480,6 +480,8 @@ public:
         return static_cast<uint8_t>( _alphaValue );
     }
 
+    double getAIMininumJoiningArmyStrength() const;
+
 private:
     friend StreamBase & operator<<( StreamBase &, const Heroes & );
     friend StreamBase & operator>>( StreamBase &, Heroes & );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -198,7 +198,7 @@ void RecruitMonsterFromTile( Heroes & hero, Maps::Tiles & tile, const std::strin
             const payment_t paymentCosts = troop.GetMonster().GetCost() * recruit;
             hero.GetKingdom().OddFundsResource( paymentCosts );
 
-            hero.GetArmy().JoinTroop( troop.GetMonster(), recruit );
+            hero.GetArmy().JoinTroop( troop.GetMonster(), recruit, false );
 
             Interface::Basic::Get().SetRedraw( Interface::REDRAW_STATUS );
         }
@@ -690,7 +690,7 @@ void ActionToMonster( Heroes & hero, int32_t dst_index )
         DEBUG_LOG( DBG_GAME, DBG_INFO, join.monsterCount << " " << troop.GetName() << " want to join " << hero.GetName() << " for " << joiningCost << " gold" )
 
         if ( Dialog::YES == Dialog::ArmyJoinWithCost( troop, join.monsterCount, joiningCost ) ) {
-            hero.GetArmy().JoinTroop( troop.GetMonster(), join.monsterCount );
+            hero.GetArmy().JoinTroop( troop.GetMonster(), join.monsterCount, false );
             hero.GetKingdom().OddFundsResource( Funds( Resource::GOLD, joiningCost ) );
 
             I.SetRedraw( Interface::REDRAW_STATUS );


### PR DESCRIPTION
- while hiring monsters in a castle put monsters to the slots with the same type of monsters
- while attending dwellings on map try to redistribute army before joining monsters
- add logic to hire some monsters from dwellings if they are payable