### PR TITLE
Fix the translation generation for MSVC workflow

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         script/windows/install_packages.bat
         choco.exe install cygwin cyg-get -y
-        cyg-get.bat make libiconv gettext-devel=0.21-1
+        cyg-get.bat make libiconv libunistring5 gettext-devel
     - uses: microsoft/setup-msbuild@v1
     - name: Generate version information
       run: |

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         script/windows/install_packages.bat
         choco.exe install cygwin cyg-get -y
-        cyg-get.bat make gettext-devel
+        cyg-get.bat make libiconv gettext-devel=0.21-1
     - uses: microsoft/setup-msbuild@v1
     - name: Generate version information
       run: |


### PR DESCRIPTION
Recent version of `gettext-devel` (0.21.1-1) is linked against `cygunistring-5.dll`, while Cygwin has just `cygunistring-2.dll` (?), so let's ~~stick with older version of this package (0.21-1) for a while~~ install the `libunistring5` package to fix the broken dependency.