### PR TITLE
Rework the troops arrangement mechanics for the castle defense

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1676,7 +1676,7 @@ namespace AI
 
         // TODO: do not transfer the whole army from one hero to another. Add logic to leave a fast unit for Scout and Courier. Also 3-5 monsters are better than
         // having 1 Peasant in one stack which leads to an instant death if the hero is attacked by an opponent.
-        taker.GetArmy().JoinStrongestFromArmy( giver.GetArmy(), false );
+        taker.GetArmy().JoinStrongestFromArmy( giver.GetArmy() );
 
         taker.GetBagArtifacts().exchangeArtifacts( giver.GetBagArtifacts(), taker, giver );
     }

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -184,7 +184,7 @@ namespace AI
 
         heroArmy.UpgradeTroops( castle );
         castle.recruitBestAvailable( budget );
-        heroArmy.JoinStrongestFromArmy( garrison, false );
+        heroArmy.JoinStrongestFromArmy( garrison );
 
         const uint32_t regionID = world.GetTiles( castle.GetIndex() ).GetRegion();
         // check if we should leave some troops in the garrison

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -658,7 +658,7 @@ void Troops::SortStrongest()
     std::sort( begin(), end(), Army::StrongestTroop );
 }
 
-void Troops::JoinStrongest( Troops & giverArmy, const bool keepAtLeastOneSlotForGiver, const bool prioritizeEmptySlots )
+void Troops::JoinStrongest( Troops & giverArmy, const bool keepAtLeastOneSlotForGiver )
 {
     if ( this == &giverArmy )
         return;
@@ -690,7 +690,7 @@ void Troops::JoinStrongest( Troops & giverArmy, const bool keepAtLeastOneSlotFor
     // there's still unmerged units left and there's empty room for them
     for ( size_t slot = 0; slot < giverArmy.size(); ++slot ) {
         Troop * rightTroop = giverArmy[slot];
-        if ( rightTroop && JoinTroop( rightTroop->GetMonster(), rightTroop->GetCount(), prioritizeEmptySlots ) ) {
+        if ( rightTroop && JoinTroop( rightTroop->GetMonster(), rightTroop->GetCount(), false ) ) {
             rightTroop->Reset();
         }
     }
@@ -1363,10 +1363,10 @@ std::string Army::String() const
     return os.str();
 }
 
-void Army::JoinStrongestFromArmy( Army & giver, const bool prioritizeEmptySlots )
+void Army::JoinStrongestFromArmy( Army & giver )
 {
     const bool saveLast = ( giver.commander != nullptr ) && giver.commander->isHeroes();
-    JoinStrongest( giver, saveLast, prioritizeEmptySlots );
+    JoinStrongest( giver, saveLast );
 }
 
 uint32_t Army::ActionToSirens() const

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1586,7 +1586,7 @@ void Army::resetInvalidMonsters() const
 void Army::ArrangeForCastleDefense( Army & garrison )
 {
     assert( this != &garrison );
-    // This method is not designed to take reinforcements from a hero's army, because
+    // This method is designed to take reinforcements only from the garrison, because
     // it can leave the garrison empty
     assert( garrison.commander == nullptr || garrison.commander->isCaptain() );
 

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1614,15 +1614,9 @@ void Army::ArrangeForCastleDefense( Army & garrison )
 
     // Try to reinforce this army with garrison troops (most powerful stacks first)
     for ( Troop * troop : garrisonTroops ) {
-        if ( !CanJoinTroop( troop->GetMonster() ) ) {
-            continue;
+        if ( JoinTroop( *troop ) ) {
+            troop->Reset();
         }
-
-        if ( !JoinTroop( *troop ) ) {
-            assert( 0 );
-        }
-
-        troop->Reset();
     }
 }
 

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -24,7 +24,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <iterator>
 #include <numeric>
 
 #include "agg_image.h"
@@ -591,7 +590,7 @@ Troop * Troops::getBestMatchToCondition( const std::function<bool( const Troop *
         return nullptr;
     }
 
-    const_iterator iter = std::next( bestMatch );
+    const_iterator iter = bestMatch + 1;
 
     while ( iter != end() ) {
         assert( *iter != nullptr );

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1642,7 +1642,7 @@ void Army::ArrangeForWhirlpool()
             continue;
         }
 
-        if ( troopOfWeakestUnits == nullptr || troopOfWeakestUnits->Monster::GetHitPoints() > troop->Monster::GetHitPoints() ) {
+        if ( troopOfWeakestUnits == nullptr || troopOfWeakestUnits->GetMonsterStrength() > troop->GetMonsterStrength() ) {
             troopOfWeakestUnits = troop;
         }
     }

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1583,37 +1583,37 @@ void Army::resetInvalidMonsters() const
     }
 }
 
-void Army::ArrangeForTownDefense( Army & townArmy )
+void Army::ArrangeForCastleDefense( Army & garrison )
 {
-    assert( this != &townArmy );
+    assert( this != &garrison );
     // This method is not designed to take reinforcements from a hero's army, because
-    // it can leave the townArmy empty
-    assert( townArmy.commander == nullptr || townArmy.commander->isCaptain() );
+    // it can leave the garrison empty
+    assert( garrison.commander == nullptr || garrison.commander->isCaptain() );
 
-    // There is no garrison in the town
-    if ( !townArmy.isValid() ) {
+    // There are no troops in the garrison
+    if ( !garrison.isValid() ) {
         return;
     }
 
     // Create and fill a temporary container for convenient sorting of garrison troops
-    std::vector<Troop *> townTroops;
+    std::vector<Troop *> garrisonTroops;
 
-    townTroops.reserve( townArmy.Size() );
+    garrisonTroops.reserve( garrison.Size() );
 
-    for ( size_t i = 0; i < townArmy.Size(); ++i ) {
-        Troop * troop = townArmy.GetTroop( i );
+    for ( size_t i = 0; i < garrison.Size(); ++i ) {
+        Troop * troop = garrison.GetTroop( i );
         assert( troop != nullptr );
 
         if ( troop->isValid() ) {
-            townTroops.push_back( troop );
+            garrisonTroops.push_back( troop );
         }
     }
 
     // Sort the garrison troops by their strength (strongest first)
-    std::sort( townTroops.begin(), townTroops.end(), StrongestTroop );
+    std::sort( garrisonTroops.begin(), garrisonTroops.end(), StrongestTroop );
 
     // Try to reinforce this army with garrison troops (strongest troops first)
-    for ( Troop * troop : townTroops ) {
+    for ( Troop * troop : garrisonTroops ) {
         if ( !CanJoinTroop( troop->GetMonster() ) ) {
             continue;
         }

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1586,6 +1586,9 @@ void Army::resetInvalidMonsters() const
 void Army::ArrangeForTownDefense( Army & townArmy )
 {
     assert( this != &townArmy );
+    // This method is not designed to take reinforcements from a hero's army, because
+    // it can leave the townArmy empty
+    assert( townArmy.commander == nullptr || townArmy.commander->isCaptain() );
 
     // There is no garrison in the town
     if ( !townArmy.isValid() ) {

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1609,10 +1609,10 @@ void Army::ArrangeForCastleDefense( Army & garrison )
         }
     }
 
-    // Sort the garrison troops by their strength (strongest first)
+    // Sort the garrison troops by their strength (most powerful stacks first)
     std::sort( garrisonTroops.begin(), garrisonTroops.end(), StrongestTroop );
 
-    // Try to reinforce this army with garrison troops (strongest troops first)
+    // Try to reinforce this army with garrison troops (most powerful stacks first)
     for ( Troop * troop : garrisonTroops ) {
         if ( !CanJoinTroop( troop->GetMonster() ) ) {
             continue;

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -103,7 +103,7 @@ public:
 
     void SortStrongest();
 
-    void JoinStrongest( Troops & giverArmy, const bool keepAtLeastOneSlotForGiver, const bool prioritizeEmptySlots );
+    void JoinStrongest( Troops & giverArmy, const bool keepAtLeastOneSlotForGiver );
 
     void SplitTroopIntoFreeSlots( const Troop & troop, const Troop & selectedSlot, const uint32_t slots );
     void AssignToFirstFreeSlot( const Troop &, const uint32_t splitCount );
@@ -213,7 +213,7 @@ public:
 
     std::string String() const;
 
-    void JoinStrongestFromArmy( Army & giver, const bool prioritizeEmptySlots );
+    void JoinStrongestFromArmy( Army & giver );
 
     void SetSpreadFormat( bool f )
     {

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -118,6 +118,10 @@ public:
 
     // If the army has no slot find 2 or more slots of the same monster which is the weakest and merge them releasing one slot in troops.
     bool mergeWeakestTroopsIfNeeded();
+
+private:
+    // Returns the stack that best matches the specified condition or nullptr if there are no valid stacks
+    Troop * getBestMatchToCondition( const std::function<bool( const Troop *, const Troop * )> & condition ) const;
 };
 
 struct NeutralMonsterJoiningCondition
@@ -150,11 +154,12 @@ public:
 
     static std::pair<uint32_t, uint32_t> SizeRange( const uint32_t count );
 
-    // compare
+    // Comparison functions
     static bool WeakestTroop( const Troop *, const Troop * );
     static bool StrongestTroop( const Troop *, const Troop * );
     static bool SlowestTroop( const Troop *, const Troop * );
     static bool FastestTroop( const Troop *, const Troop * );
+
     static void SwapTroops( Troop &, Troop & );
 
     static NeutralMonsterJoiningCondition GetJoinSolution( const Heroes &, const Maps::Tiles &, const Troop & );
@@ -226,6 +231,9 @@ public:
 
     void resetInvalidMonsters() const;
 
+    // Performs the pre-battle arrangement for the town defense, trying to add reinforcements from the city garrison (most powerful
+    // stacks first), by adding them either to free slots or to slots that already contain troops of the same type
+    void ArrangeForTownDefense( Army & townArmy );
     // Optimizes the arrangement of troops to pass through the whirlpool (moves one weakest unit to a separate slot, if possible)
     void ArrangeForWhirlpool();
 

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -104,8 +104,6 @@ public:
 
     void SortStrongest();
 
-    void JoinStrongest( Troops & giverArmy, const bool keepAtLeastOneSlotForGiver );
-
     void SplitTroopIntoFreeSlots( const Troop & troop, const Troop & selectedSlot, const uint32_t slots );
     void AssignToFirstFreeSlot( const Troop &, const uint32_t splitCount );
     void JoinAllTroopsOfType( const Troop & targetTroop );
@@ -119,6 +117,9 @@ public:
 
     // If the army has no slot find 2 or more slots of the same monster which is the weakest and merge them releasing one slot in troops.
     bool mergeWeakestTroopsIfNeeded();
+
+protected:
+    void JoinStrongest( Troops & giverArmy, const bool keepAtLeastOneSlotForGiver );
 
 private:
     // Returns the stack that best matches the specified condition or nullptr if there are no valid stacks

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -232,9 +232,9 @@ public:
 
     void resetInvalidMonsters() const;
 
-    // Performs the pre-battle arrangement for the town defense, trying to add reinforcements from the city garrison (most powerful
-    // stacks first), by adding them either to free slots or to slots that already contain troops of the same type
-    void ArrangeForTownDefense( Army & townArmy );
+    // Performs the pre-battle arrangement for the castle (or town) defense, trying to add reinforcements from the garrison (most
+    // powerful stacks first), by adding them either to free slots or to slots that already contain troops of the same type
+    void ArrangeForCastleDefense( Army & garrison );
     // Optimizes the arrangement of troops to pass through the whirlpool (moves one weakest unit to a separate slot, if possible)
     void ArrangeForWhirlpool();
 

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -24,6 +24,7 @@
 #ifndef H2ARMY_H
 #define H2ARMY_H
 
+#include <functional>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -2471,11 +2471,14 @@ void Castle::ActionPreBattle()
 {
     CastleHeroes heroes = world.GetHeroes( *this );
     Heroes * hero = heroes.GuardFirst();
-    if ( hero && army.isValid() )
-        hero->GetArmy().JoinStrongestFromArmy( army, true );
 
-    if ( isControlAI() )
+    if ( hero ) {
+        hero->GetArmy().ArrangeForTownDefense( army );
+    }
+
+    if ( isControlAI() ) {
         AI::Get().CastlePreBattle( *this );
+    }
 }
 
 void Castle::ActionAfterBattle( bool attacker_wins )

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -2473,7 +2473,7 @@ void Castle::ActionPreBattle()
     Heroes * hero = heroes.GuardFirst();
 
     if ( hero ) {
-        hero->GetArmy().ArrangeForTownDefense( army );
+        hero->GetArmy().ArrangeForCastleDefense( army );
     }
 
     if ( isControlAI() ) {


### PR DESCRIPTION
close #6076

Also fix the `Army::ArrangeForWhirlpool()`: it seems that "weakest stack" for whirlpool should be selected based on the unit's battle value, not HP.