### PR TITLE
Draw the correct arrows for the paths on the adventure map

### DIFF
--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -705,16 +705,8 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
 
             uint32_t routeSpriteIndex = 0;
             if ( nextStep != path.end() ) {
-                const Maps::Tiles & tileFrom = world.GetTiles( from );
-                const Maps::Tiles & tileTo = world.GetTiles( nextStep->GetIndex() );
-                uint32_t cost = 0;
-
-                if ( tileFrom.isRoad() && tileTo.isRoad() ) {
-                    cost = Maps::Ground::roadPenalty;
-                }
-                else {
-                    cost = Maps::Ground::GetPenalty( tileTo, pathfinding );
-                }
+                const Maps::Tiles & tile = world.GetTiles( from );
+                const uint32_t cost = tile.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( tile, pathfinding );
 
                 routeSpriteIndex = Route::Path::GetIndexSprite( currentStep->GetDirection(), nextStep->GetDirection(), cost );
             }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -692,8 +692,8 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
         const fheroes2::Rect extendedVisibleRoi{ tileROI.x - 1, tileROI.y - 1, tileROI.width + 2, tileROI.height + 2 };
 
         for ( ; currentStep != path.end(); ++currentStep ) {
-            const int32_t from = currentStep->GetIndex();
-            const fheroes2::Point & mp = Maps::GetPoint( from );
+            const int32_t tileIndex = currentStep->GetIndex();
+            const fheroes2::Point & mp = Maps::GetPoint( tileIndex );
 
             ++nextStep;
             --greenColorSteps;
@@ -705,7 +705,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
 
             uint32_t routeSpriteIndex = 0;
             if ( nextStep != path.end() ) {
-                const Maps::Tiles & tile = world.GetTiles( from );
+                const Maps::Tiles & tile = world.GetTiles( tileIndex );
                 const uint32_t cost = tile.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( tile, pathfinding );
 
                 routeSpriteIndex = Route::Path::GetIndexSprite( currentStep->GetDirection(), nextStep->GetDirection(), cost );


### PR DESCRIPTION
fix #6085

<img width="752" alt="Screenshot 1" src="https://user-images.githubusercontent.com/32623900/199963713-f77d0d25-080e-4ecb-84d2-7842fbe636f7.png">

<img width="752" alt="Screenshot 2" src="https://user-images.githubusercontent.com/32623900/199963765-5d69ba50-9f22-489d-9ceb-f4376714cb19.png">

This was the regression after the #5692 - while reviewing, I forgot that when leaving the road, we still need to show a short "road arrow" even though the road penalty is not actually applied (it is applied only when moving from a road tile to a road tile), and I didn't notice that `tileTo` should be replaced by `tileFrom` in one more place (in fact, due to the "road issue" mentioned earlier, we don't need to use the `tileTo` at all).