### PR TITLE
Add right click quick info in more dialogs for hero and castle captain

### DIFF
--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -512,14 +512,16 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readOnly, const b
                 need_redraw = true;
             }
 
-            if ( heroes.Guard() && le.MousePressRight( rectSign1 ) ) {
-                Dialog::QuickInfo( *heroes.Guard() );
+            if ( le.MousePressRight( rectSign1 ) ) {
+                if ( heroes.Guard() ) {
+                    Dialog::QuickInfo( *heroes.Guard() );
+                }
+                else if ( isBuild( BUILD_CAPTAIN ) ) {
+                    Dialog::QuickInfo( GetCaptain() );
+                }
             }
             else if ( heroes.Guest() && le.MousePressRight( rectSign2 ) ) {
                 Dialog::QuickInfo( *heroes.Guest() );
-            }
-            else if ( !heroes.Guard() && isBuild( BUILD_CAPTAIN ) && le.MousePressRight( rectSign1 ) ) {
-                Dialog::QuickInfo( GetCaptain() );
             }
 
             // Get pressed hotkey.

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -512,6 +512,16 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readOnly, const b
                 need_redraw = true;
             }
 
+            if ( heroes.Guard() && le.MousePressRight( rectSign1 ) ) {
+                Dialog::QuickInfo( *heroes.Guard() );
+            }
+            else if ( heroes.Guest() && le.MousePressRight( rectSign2 ) ) {
+                Dialog::QuickInfo( *heroes.Guest() );
+            }
+            else if ( !heroes.Guard() && isBuild( BUILD_CAPTAIN ) && le.MousePressRight( rectSign1 ) ) {
+                Dialog::QuickInfo( GetCaptain() );
+            }
+
             // Get pressed hotkey.
             const building_t hotKeyBuilding = getPressedBuildingHotkey();
 

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -98,6 +98,7 @@ int Castle::DialogBuyHero( const Heroes * hero ) const
     dst_pt.y = dst_pt.y + recruitHeroText.h() + spacer;
     fheroes2::Blit( portrait_frame, display, dst_pt.x, dst_pt.y );
 
+    fheroes2::Rect heroPortraitArea( dst_pt.x, dst_pt.y, portrait_frame.width(), portrait_frame.height() );
     dst_pt.x = dst_pt.x + 5;
     dst_pt.y = dst_pt.y + 6;
     hero->PortraitRedraw( dst_pt.x, dst_pt.y, PORT_BIG, display );
@@ -136,6 +137,10 @@ int Castle::DialogBuyHero( const Heroes * hero ) const
 
         if ( le.MouseClickLeft( button2.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) )
             break;
+
+        if ( le.MousePressRight( heroPortraitArea ) ) {
+            Dialog::QuickInfo( *hero );
+        }
     }
 
     return Dialog::CANCEL;

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -98,7 +98,7 @@ int Castle::DialogBuyHero( const Heroes * hero ) const
     dst_pt.y = dst_pt.y + recruitHeroText.h() + spacer;
     fheroes2::Blit( portrait_frame, display, dst_pt.x, dst_pt.y );
 
-    fheroes2::Rect heroPortraitArea( dst_pt.x, dst_pt.y, portrait_frame.width(), portrait_frame.height() );
+    const fheroes2::Rect heroPortraitArea( dst_pt.x, dst_pt.y, portrait_frame.width(), portrait_frame.height() );
     dst_pt.x = dst_pt.x + 5;
     dst_pt.y = dst_pt.y + 6;
     hero->PortraitRedraw( dst_pt.x, dst_pt.y, PORT_BIG, display );

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -861,7 +861,8 @@ void Dialog::QuickInfo( const HeroBase & hero, const fheroes2::Point & position 
     const Kingdom & kingdom = world.GetKingdom( conf.CurrentColor() );
     const bool isFriend = ColorBase( hero.GetColor() ).isFriends( conf.CurrentColor() );
     const bool isUnderIdentifyHeroSpell = kingdom.Modes( Kingdom::IDENTIFYHERO );
-    const bool showFullInfo = hero.GetColor() == 0 || isFriend || isUnderIdentifyHeroSpell || kingdom.IsTileVisibleFromCrystalBall( hero.GetIndex() );
+    const bool isNeutralHero = ( hero.GetColor() == Color::NONE );
+    const bool showFullInfo = isNeutralHero || isFriend || isUnderIdentifyHeroSpell || kingdom.IsTileVisibleFromCrystalBall( hero.GetIndex() );
 
     const Heroes * activeHero = dynamic_cast<const Heroes *>( &hero );
     const Captain * activeCaptain = dynamic_cast<const Captain *>( &hero );

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -861,7 +861,7 @@ void Dialog::QuickInfo( const HeroBase & hero, const fheroes2::Point & position 
     const Kingdom & kingdom = world.GetKingdom( conf.CurrentColor() );
     const bool isFriend = ColorBase( hero.GetColor() ).isFriends( conf.CurrentColor() );
     const bool isUnderIdentifyHeroSpell = kingdom.Modes( Kingdom::IDENTIFYHERO );
-    const bool showFullInfo = isFriend || isUnderIdentifyHeroSpell || kingdom.IsTileVisibleFromCrystalBall( hero.GetIndex() );
+    const bool showFullInfo = hero.GetColor() == 0 || isFriend || isUnderIdentifyHeroSpell || kingdom.IsTileVisibleFromCrystalBall( hero.GetIndex() );
 
     const Heroes * activeHero = dynamic_cast<const Heroes *>( &hero );
     const Captain * activeCaptain = dynamic_cast<const Captain *>( &hero );

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -923,44 +923,43 @@ void Dialog::QuickInfo( const HeroBase & hero, const fheroes2::Point & position 
         }
     }
 
-    // color flags
-    uint32_t index = 0;
+    // color flags, except for neutral heroes
+    if ( !isNeutralHero ) {
+        uint32_t index = 0;
 
-    switch ( hero.GetColor() ) {
-    case Color::BLUE:
-        index = 0;
-        break;
-    case Color::GREEN:
-        index = 2;
-        break;
-    case Color::RED:
-        index = 4;
-        break;
-    case Color::YELLOW:
-        index = 6;
-        break;
-    case Color::ORANGE:
-        index = 8;
-        break;
-    case Color::PURPLE:
-        index = 10;
-        break;
-    case Color::NONE:
-        index = 12;
-        break;
-    default:
-        break;
+        switch ( hero.GetColor() ) {
+        case Color::BLUE:
+            index = 0;
+            break;
+        case Color::GREEN:
+            index = 2;
+            break;
+        case Color::RED:
+            index = 4;
+            break;
+        case Color::YELLOW:
+            index = 6;
+            break;
+        case Color::ORANGE:
+            index = 8;
+            break;
+        case Color::PURPLE:
+            index = 10;
+            break;
+        default:
+            break;
+        }
+
+        dst_pt.y = cur_rt.y + 13;
+
+        const fheroes2::Sprite & l_flag = fheroes2::AGG::GetICN( ICN::FLAG32, index );
+        dst_pt.x = cur_rt.x + ( cur_rt.width - 40 ) / 2 - l_flag.width();
+        fheroes2::Blit( l_flag, display, dst_pt.x, dst_pt.y );
+
+        const fheroes2::Sprite & r_flag = fheroes2::AGG::GetICN( ICN::FLAG32, index + 1 );
+        dst_pt.x = cur_rt.x + ( cur_rt.width + 40 ) / 2;
+        fheroes2::Blit( r_flag, display, dst_pt.x, dst_pt.y );
     }
-
-    dst_pt.y = cur_rt.y + 13;
-
-    const fheroes2::Sprite & l_flag = fheroes2::AGG::GetICN( ICN::FLAG32, index );
-    dst_pt.x = cur_rt.x + ( cur_rt.width - 40 ) / 2 - l_flag.width();
-    fheroes2::Blit( l_flag, display, dst_pt.x, dst_pt.y );
-
-    const fheroes2::Sprite & r_flag = fheroes2::AGG::GetICN( ICN::FLAG32, index + 1 );
-    dst_pt.x = cur_rt.x + ( cur_rt.width + 40 ) / 2;
-    fheroes2::Blit( r_flag, display, dst_pt.x, dst_pt.y );
 
     const uint16_t statNumberColumn = 89;
     const uint16_t statRow = 12;

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -332,7 +332,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
         }
 
         // right info
-        if ( !readonly && le.MousePressRight( portPos ) ) {
+        if ( le.MousePressRight( portPos ) ) {
             Dialog::QuickInfo( *this );
         }
         else if ( le.MousePressRight( rectSpreadArmyFormat ) ) {

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -626,6 +626,13 @@ void Heroes::MeetingDialog( Heroes & otherHero )
 
             display.render();
         }
+
+        if ( le.MousePressRight( hero1Area ) ) {
+            Dialog::QuickInfo( *this );
+        }
+        else if ( le.MousePressRight( hero2Area ) ) {
+            Dialog::QuickInfo( otherHero );
+        }
     }
 
     selectArmy1.ResetSelected();


### PR DESCRIPTION
close #5298 & fix #1724

Added the ability to view quick info about the castle captain in the castle and quick info about the hero for the hero meeting dialog, hero recruit dialog, castle dilaog.
![изображение](https://user-images.githubusercontent.com/113276641/200175077-bfa2d94c-cbbe-4c58-9ced-6eaf24554b07.png)
![изображение](https://user-images.githubusercontent.com/113276641/200175128-74151a75-73bd-4919-b9f9-a78dd8d38c50.png) ![изображение](https://user-images.githubusercontent.com/113276641/200175227-3d0bc36d-d6aa-493e-8ad9-ef0c490d1372.png)

Have not made quick info for heroes in Thieves guid and in Oasis.

upd.:
Quick info for Recruit hero dialog is now without flags:
![picture](https://user-images.githubusercontent.com/113276641/200361443-49ad36f9-9976-442f-9706-ad063ddf9bf2.png)