### PR TITLE
Add a separate graphics options window

### DIFF
--- a/fheroes2-vs2017.vcxproj
+++ b/fheroes2-vs2017.vcxproj
@@ -265,6 +265,7 @@
     <ClCompile Include="src\fheroes2\dialog\dialog_frameborder.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_gameinfo.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_giftresources.cpp" />
+    <ClCompile Include="src\fheroes2\dialog\dialog_graphics_settings.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_guardian.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_hotkeys.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_language_selection.cpp" />
@@ -326,6 +327,7 @@
     <ClCompile Include="src\fheroes2\gui\ui_language.cpp" />
     <ClCompile Include="src\fheroes2\gui\ui_monster.cpp" />
     <ClCompile Include="src\fheroes2\gui\ui_scrollbar.cpp" />
+    <ClCompile Include="src\fheroes2\gui\ui_option_item.cpp" />
     <ClCompile Include="src\fheroes2\gui\ui_text.cpp" />
     <ClCompile Include="src\fheroes2\gui\ui_tool.cpp" />
     <ClCompile Include="src\fheroes2\gui\ui_window.cpp" />
@@ -467,6 +469,7 @@
     <ClInclude Include="src\fheroes2\dialog\dialog.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog_audio.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog_game_settings.h" />
+    <ClInclude Include="src\fheroes2\dialog\dialog_graphics_settings.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog_hotkeys.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog_language_selection.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog_resolution.h" />
@@ -512,6 +515,7 @@
     <ClInclude Include="src\fheroes2\gui\ui_language.h" />
     <ClInclude Include="src\fheroes2\gui\ui_monster.h" />
     <ClInclude Include="src\fheroes2\gui\ui_scrollbar.h" />
+    <ClInclude Include="src\fheroes2\gui\ui_option_item.h" />
     <ClInclude Include="src\fheroes2\gui\ui_text.h" />
     <ClInclude Include="src\fheroes2\gui\ui_tool.h" />
     <ClInclude Include="src\fheroes2\gui\ui_window.h" />

--- a/fheroes2-vs2019.vcxproj
+++ b/fheroes2-vs2019.vcxproj
@@ -266,6 +266,7 @@
     <ClCompile Include="src\fheroes2\dialog\dialog_frameborder.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_gameinfo.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_giftresources.cpp" />
+    <ClCompile Include="src\fheroes2\dialog\dialog_graphics_settings.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_guardian.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_hotkeys.cpp" />
     <ClCompile Include="src\fheroes2\dialog\dialog_language_selection.cpp" />
@@ -327,6 +328,7 @@
     <ClCompile Include="src\fheroes2\gui\ui_language.cpp" />
     <ClCompile Include="src\fheroes2\gui\ui_monster.cpp" />
     <ClCompile Include="src\fheroes2\gui\ui_scrollbar.cpp" />
+    <ClCompile Include="src\fheroes2\gui\ui_option_item.cpp" />
     <ClCompile Include="src\fheroes2\gui\ui_text.cpp" />
     <ClCompile Include="src\fheroes2\gui\ui_tool.cpp" />
     <ClCompile Include="src\fheroes2\gui\ui_window.cpp" />
@@ -468,6 +470,7 @@
     <ClInclude Include="src\fheroes2\dialog\dialog.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog_audio.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog_game_settings.h" />
+    <ClInclude Include="src\fheroes2\dialog\dialog_graphics_settings.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog_hotkeys.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog_language_selection.h" />
     <ClInclude Include="src\fheroes2\dialog\dialog_resolution.h" />
@@ -513,6 +516,7 @@
     <ClInclude Include="src\fheroes2\gui\ui_language.h" />
     <ClInclude Include="src\fheroes2\gui\ui_monster.h" />
     <ClInclude Include="src\fheroes2\gui\ui_scrollbar.h" />
+    <ClInclude Include="src\fheroes2\gui\ui_option_item.h" />
     <ClInclude Include="src\fheroes2\gui\ui_text.h" />
     <ClInclude Include="src\fheroes2\gui\ui_tool.h" />
     <ClInclude Include="src\fheroes2\gui\ui_window.h" />

--- a/src/fheroes2/dialog/dialog_audio.cpp
+++ b/src/fheroes2/dialog/dialog_audio.cpp
@@ -34,27 +34,10 @@
 #include "translations.h"
 #include "ui_button.h"
 #include "ui_dialog.h"
-#include "ui_text.h"
+#include "ui_option_item.h"
 
 namespace
 {
-    void drawOption( const fheroes2::Rect & optionRoi, const fheroes2::Sprite & icon, const std::string & titleText, const std::string & valueText )
-    {
-        fheroes2::Display & display = fheroes2::Display::instance();
-
-        const fheroes2::FontType smallWhite = fheroes2::FontType::smallWhite();
-
-        const fheroes2::Text title( titleText, smallWhite );
-        const fheroes2::Text value( valueText, smallWhite );
-
-        const int16_t textMaxWidth = 87;
-
-        title.draw( optionRoi.x - 12, optionRoi.y - title.height( textMaxWidth ), textMaxWidth, display );
-        value.draw( optionRoi.x + ( optionRoi.width - value.width() ) / 2, optionRoi.y + optionRoi.height + 4, display );
-
-        fheroes2::Blit( icon, display, optionRoi.x, optionRoi.y );
-    }
-
     void drawDialog( const std::vector<fheroes2::Rect> & rects )
     {
         assert( rects.size() == 4 );
@@ -71,7 +54,7 @@ namespace
             value = _( "off" );
         }
 
-        drawOption( rects[0], musicVolumeIcon, _( "Music" ), value );
+        fheroes2::drawOption( rects[0], musicVolumeIcon, _( "Music" ), value );
 
         // Sound volume.
         const fheroes2::Sprite & soundVolumeOption = fheroes2::AGG::GetICN( ICN::SPANEL, Audio::isValid() ? 3 : 2 );
@@ -82,7 +65,7 @@ namespace
             value = _( "off" );
         }
 
-        drawOption( rects[1], soundVolumeOption, _( "Effects" ), value );
+        fheroes2::drawOption( rects[1], soundVolumeOption, _( "Effects" ), value );
 
         // Music Type.
         const MusicSource musicType = conf.MusicType();
@@ -97,7 +80,7 @@ namespace
             value = _( "External" );
         }
 
-        drawOption( rects[2], musicTypeIcon, _( "Music Type" ), value );
+        fheroes2::drawOption( rects[2], musicTypeIcon, _( "Music Type" ), value );
 
         // 3D Audio.
         const bool is3DAudioEnabled = conf.is3DAudioEnabled();
@@ -109,7 +92,7 @@ namespace
             value = _( "Off" );
         }
 
-        drawOption( rects[3], interfaceStateIcon, _( "3D Audio" ), value );
+        fheroes2::drawOption( rects[3], interfaceStateIcon, _( "3D Audio" ), value );
     }
 }
 
@@ -231,39 +214,21 @@ namespace Dialog
                 saveMusicType = true;
             }
 
-            const fheroes2::FontType normalYellow = fheroes2::FontType::normalYellow();
-            const fheroes2::FontType normalWhite = fheroes2::FontType::normalWhite();
-
             if ( le.MousePressRight( musicVolumeRoi ) ) {
-                fheroes2::Text header( _( "Music" ), normalYellow );
-                fheroes2::Text body( _( "Toggle ambient music level." ), normalWhite );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Music" ), _( "Toggle ambient music level." ), 0 );
             }
 
             else if ( le.MousePressRight( soundVolumeRoi ) ) {
-                fheroes2::Text header( _( "Effects" ), normalYellow );
-                fheroes2::Text body( _( "Toggle foreground sounds level." ), normalWhite );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Effects" ), _( "Toggle foreground sounds level." ), 0 );
             }
             else if ( le.MousePressRight( musicTypeRoi ) ) {
-                fheroes2::Text header( _( "Music Type" ), normalYellow );
-                fheroes2::Text body( _( "Change the type of music." ), normalWhite );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Music Type" ), _( "Change the type of music." ), 0 );
             }
             else if ( le.MousePressRight( audio3D ) ) {
-                fheroes2::Text header( _( "3D Audio" ), normalYellow );
-                fheroes2::Text body( _( "Toggle 3D effects of foreground sounds." ), normalWhite );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "3D Audio" ), _( "Toggle 3D effects of foreground sounds." ), 0 );
             }
             else if ( le.MousePressRight( buttonOkay.area() ) ) {
-                fheroes2::Text header( _( "Okay" ), normalYellow );
-                fheroes2::Text body( _( "Exit this menu." ), normalWhite );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Okay" ), _( "Exit this menu." ), 0 );
             }
 
             if ( saveMusicVolume || saveSoundVolume || saveMusicType ) {

--- a/src/fheroes2/dialog/dialog_game_settings.cpp
+++ b/src/fheroes2/dialog/dialog_game_settings.cpp
@@ -24,9 +24,9 @@
 #include "cursor.h"
 #include "dialog.h"
 #include "dialog_audio.h"
+#include "dialog_graphics_settings.h"
 #include "dialog_hotkeys.h"
 #include "dialog_language_selection.h"
-#include "dialog_resolution.h"
 #include "game.h"
 #include "game_hotkeys.h"
 #include "game_interface.h"
@@ -39,7 +39,7 @@
 #include "ui_button.h"
 #include "ui_dialog.h"
 #include "ui_language.h"
-#include "ui_text.h"
+#include "ui_option_item.h"
 #include "ui_window.h"
 
 #include <cassert>
@@ -48,13 +48,11 @@ namespace
 {
     const fheroes2::Size offsetBetweenOptions{ 92, 110 };
 
-    const fheroes2::Point textOffset{ 11, 12 };
-    const int32_t nameOffset = 6;
     const fheroes2::Point optionOffset{ 36, 47 };
     const int32_t optionWindowSize{ 65 };
 
     const fheroes2::Rect languageRoi{ optionOffset.x, optionOffset.y, optionWindowSize, optionWindowSize };
-    const fheroes2::Rect resolutionRoi{ optionOffset.x + offsetBetweenOptions.width, optionOffset.y, optionWindowSize, optionWindowSize };
+    const fheroes2::Rect graphicsRoi{ optionOffset.x + offsetBetweenOptions.width, optionOffset.y, optionWindowSize, optionWindowSize };
     const fheroes2::Rect audioRoi{ optionOffset.x + offsetBetweenOptions.width * 2, optionOffset.y, optionWindowSize, optionWindowSize };
     const fheroes2::Rect optionsRoi{ optionOffset.x, optionOffset.y + offsetBetweenOptions.height, optionWindowSize, optionWindowSize };
     const fheroes2::Rect battleResolveRoi{ optionOffset.x + offsetBetweenOptions.width, optionOffset.y + offsetBetweenOptions.height, optionWindowSize,
@@ -66,79 +64,59 @@ namespace
     const fheroes2::Rect textSupportModeRoi{ optionOffset.x + offsetBetweenOptions.width * 2, optionOffset.y + 2 * offsetBetweenOptions.height, optionWindowSize,
                                              optionWindowSize };
 
-    void drawOption( const fheroes2::Rect & optionRoi, const char * titleText, const char * nameText, const int icnId, const uint32_t icnIndex )
-    {
-        fheroes2::Display & display = fheroes2::Display::instance();
-
-        const fheroes2::Text title( titleText, fheroes2::FontType::smallWhite() );
-        const fheroes2::Text name( nameText, fheroes2::FontType::smallWhite() );
-
-        const int32_t textMaxWidth = 87;
-
-        title.draw( optionRoi.x - textOffset.x, optionRoi.y - textOffset.y + title.height() - title.height( textMaxWidth ), textMaxWidth, display );
-        name.draw( optionRoi.x - textOffset.x, optionRoi.y + languageRoi.height + nameOffset, textMaxWidth, display );
-
-        const fheroes2::Sprite & icon = fheroes2::AGG::GetICN( icnId, icnIndex );
-        fheroes2::Blit( icon, 0, 0, display, optionRoi.x, optionRoi.y, icon.width(), icon.height() );
-    }
-
     void drawLanguage( const fheroes2::Rect & optionRoi )
     {
         const fheroes2::SupportedLanguage currentLanguage = fheroes2::getLanguageFromAbbreviation( Settings::Get().getGameLanguage() );
         fheroes2::LanguageSwitcher languageSwitcher( currentLanguage );
 
-        drawOption( optionRoi, _( "Language" ), fheroes2::getLanguageName( currentLanguage ), ICN::SPANEL, 18 );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 18 ), _( "Language" ), fheroes2::getLanguageName( currentLanguage ) );
     }
 
-    void drawResolution( const fheroes2::Rect & optionRoi )
+    void drawGraphics( const fheroes2::Rect & optionRoi )
     {
-        const fheroes2::Display & display = fheroes2::Display::instance();
-        const std::string resolutionName = std::to_string( display.width() ) + 'x' + std::to_string( display.height() );
-
-        const Settings & configuration = Settings::Get();
-
-        drawOption( optionRoi, _( "Resolution" ), resolutionName.c_str(), ICN::SPANEL, configuration.ExtGameEvilInterface() ? 17 : 16 );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 15 ), _( "Graphics" ), _( "Settings" ) );
     }
 
     void drawExperimentalOptions( const fheroes2::Rect & optionRoi )
     {
-        drawOption( optionRoi, _( "Settings" ), _( "Experimental" ), ICN::SPANEL, 14 );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 14 ), _( "Settings" ), _( "Experimental" ) );
     }
 
     void drawAudioOptions( const fheroes2::Rect & optionRoi )
     {
-        drawOption( optionRoi, _( "Audio" ), _( "Settings" ), ICN::SPANEL, 1 );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 1 ), _( "Audio" ), _( "Settings" ) );
     }
 
     void drawHotKeyOptions( const fheroes2::Rect & optionRoi )
     {
-        drawOption( optionRoi, _( "Hot Keys" ), _( "Configure" ), ICN::CSPANEL, 5 );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::CSPANEL, 5 ), _( "Hot Keys" ), _( "Configure" ) );
     }
 
     void drawCursorTypeOptions( const fheroes2::Rect & optionRoi )
     {
         if ( Settings::Get().isMonochromeCursorEnabled() ) {
-            drawOption( optionRoi, _( "Mouse Cursor" ), _( "Black & White" ), ICN::SPANEL, 20 );
+            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 20 ), _( "Mouse Cursor" ), _( "Black & White" ) );
         }
         else {
-            drawOption( optionRoi, _( "Mouse Cursor" ), _( "Color" ), ICN::SPANEL, 21 );
+            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 21 ), _( "Mouse Cursor" ), _( "Color" ) );
         }
     }
 
     void drawTextSupportModeOptions( const fheroes2::Rect & optionRoi )
     {
         if ( Settings::Get().isTextSupportModeEnabled() ) {
-            drawOption( optionRoi, _( "Text Support" ), _( "On" ), ICN::CSPANEL, 4 );
+            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::CSPANEL, 4 ), _( "Text Support" ), _( "On" ) );
         }
         else {
-            drawOption( optionRoi, _( "Text Support" ), _( "Off" ), ICN::SPANEL, 9 );
+            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 9 ), _( "Text Support" ), _( "Off" ) );
         }
     }
 
     void drawInterfaceOptions( const fheroes2::Rect & optionRoi )
     {
         const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
-        drawOption( optionRoi, _( "Interface Type" ), isEvilInterface ? _( "Evil" ) : _( "Good" ), ICN::SPANEL, isEvilInterface ? 17 : 16 );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, isEvilInterface ? 17 : 16 ), _( "Interface Type" ),
+                              isEvilInterface ? _( "Evil" ) : _( "Good" ) );
     }
 
     void drawBattleResolveOptions( const fheroes2::Rect & optionRoi )
@@ -162,13 +140,13 @@ namespace
             icnIndex = 18;
         }
 
-        drawOption( optionRoi, _( "Battles" ), value.c_str(), icnId, icnIndex );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( icnId, icnIndex ), _( "Battles" ), std::move( value ) );
     }
 
     enum class SelectedWindow : int
     {
         Configuration,
-        Resolution,
+        Graphics,
         Language,
         Options,
         HotKeys,
@@ -206,7 +184,7 @@ namespace
         const fheroes2::Sprite & buttonOkayPressed = fheroes2::AGG::GetICN( buttonIcnId, 1 );
 
         const fheroes2::Rect windowLanguageRoi( languageRoi + windowRoi.getPosition() );
-        const fheroes2::Rect windowResolutionRoi( resolutionRoi + windowRoi.getPosition() );
+        const fheroes2::Rect windowGraphicsRoi( graphicsRoi + windowRoi.getPosition() );
         const fheroes2::Rect windowAudioRoi( audioRoi + windowRoi.getPosition() );
         const fheroes2::Rect windowOptionsRoi( optionsRoi + windowRoi.getPosition() );
         const fheroes2::Rect windowBattleResolveRoi( battleResolveRoi + windowRoi.getPosition() );
@@ -216,7 +194,7 @@ namespace
         const fheroes2::Rect windowTextSupportModeRoi( textSupportModeRoi + windowRoi.getPosition() );
 
         drawLanguage( windowLanguageRoi );
-        drawResolution( windowResolutionRoi );
+        drawGraphics( windowGraphicsRoi );
         drawAudioOptions( windowAudioRoi );
         drawExperimentalOptions( windowOptionsRoi );
         drawBattleResolveOptions( windowBattleResolveRoi );
@@ -245,8 +223,8 @@ namespace
             if ( le.MouseClickLeft( windowLanguageRoi ) ) {
                 return SelectedWindow::Language;
             }
-            if ( le.MouseClickLeft( windowResolutionRoi ) ) {
-                return SelectedWindow::Resolution;
+            if ( le.MouseClickLeft( windowGraphicsRoi ) ) {
+                return SelectedWindow::Graphics;
             }
             if ( le.MouseClickLeft( windowAudioRoi ) ) {
                 return SelectedWindow::AudioSettings;
@@ -271,65 +249,35 @@ namespace
             }
 
             if ( le.MousePressRight( windowLanguageRoi ) ) {
-                fheroes2::Text header( _( "Select Game Language" ), fheroes2::FontType::normalYellow() );
-                fheroes2::Text body( _( "Change the language of the game." ), fheroes2::FontType::normalWhite() );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Select Game Language" ), _( "Change the language of the game." ), 0 );
             }
-            else if ( le.MousePressRight( windowResolutionRoi ) ) {
-                fheroes2::Text header( _( "Select Game Resolution" ), fheroes2::FontType::normalYellow() );
-                fheroes2::Text body( _( "Change the resolution of the game." ), fheroes2::FontType::normalWhite() );
-
-                fheroes2::showMessage( header, body, 0 );
+            else if ( le.MousePressRight( windowGraphicsRoi ) ) {
+                fheroes2::showStandardTextMessage( _( "Graphics" ), _( "Change the graphics settings of the game." ), 0 );
             }
             else if ( le.MousePressRight( windowAudioRoi ) ) {
-                fheroes2::Text header( _( "Audio" ), fheroes2::FontType::normalYellow() );
-                fheroes2::Text body( _( "Change the audio settings of the game." ), fheroes2::FontType::normalWhite() );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Audio" ), _( "Change the audio settings of the game." ), 0 );
             }
             else if ( le.MousePressRight( windowOptionsRoi ) ) {
-                fheroes2::Text header( _( "Settings" ), fheroes2::FontType::normalYellow() );
-                fheroes2::Text body( _( "Experimental game settings." ), fheroes2::FontType::normalWhite() );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Settings" ), _( "Experimental game settings." ), 0 );
             }
             if ( le.MousePressRight( windowBattleResolveRoi ) ) {
-                fheroes2::Text header( _( "Battles" ), fheroes2::FontType::normalYellow() );
-                fheroes2::Text body( _( "Toggle instant battle mode." ), fheroes2::FontType::normalWhite() );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Battles" ), _( "Toggle instant battle mode." ), 0 );
             }
             else if ( le.MousePressRight( windowHotKeyRoi ) ) {
-                fheroes2::Text header( _( "Hot Keys" ), fheroes2::FontType::normalYellow() );
-                fheroes2::Text body( _( "Check and configure all the hot keys present in the game." ), fheroes2::FontType::normalWhite() );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Hot Keys" ), _( "Check and configure all the hot keys present in the game." ), 0 );
             }
             if ( le.MousePressRight( windowInterfaceTypeRoi ) ) {
-                fheroes2::Text header( _( "Interface Type" ), fheroes2::FontType::normalYellow() );
-                fheroes2::Text body( _( "Toggle the type of interface you want to use." ), fheroes2::FontType::normalWhite() );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Interface Type" ), _( "Toggle the type of interface you want to use." ), 0 );
             }
             else if ( le.MousePressRight( windowCursorTypeRoi ) ) {
-                fheroes2::Text header( _( "Mouse Cursor" ), fheroes2::FontType::normalYellow() );
-                fheroes2::Text body( _( "Toggle colored cursor on or off. This is only an esthetic choice." ), fheroes2::FontType::normalWhite() );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Mouse Cursor" ), _( "Toggle colored cursor on or off. This is only an esthetic choice." ), 0 );
             }
             else if ( le.MousePressRight( windowTextSupportModeRoi ) ) {
-                fheroes2::Text header( _( "Text Support" ), fheroes2::FontType::normalYellow() );
-                fheroes2::Text body( _( "Toggle text support mode to output extra information about windows and events in the game." ),
-                                     fheroes2::FontType::normalWhite() );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Text Support" ),
+                                                   _( "Toggle text support mode to output extra information about windows and events in the game." ), 0 );
             }
             else if ( le.MousePressRight( okayButton.area() ) ) {
-                fheroes2::Text header( _( "Okay" ), fheroes2::FontType::normalYellow() );
-                fheroes2::Text body( _( "Exit this menu." ), fheroes2::FontType::normalWhite() );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Okay" ), _( "Exit this menu." ), 0 );
             }
         }
 
@@ -351,11 +299,8 @@ namespace fheroes2
             case SelectedWindow::Configuration:
                 windowType = showConfigurationWindow();
                 break;
-            case SelectedWindow::Resolution:
-                if ( Dialog::SelectResolution() ) {
-                    conf.Save( Settings::configFileName );
-                }
-                drawMainMenuScreen();
+            case SelectedWindow::Graphics:
+                fheroes2::openGraphicsSettingsDialog();
                 windowType = SelectedWindow::Configuration;
                 break;
             case SelectedWindow::Language: {
@@ -369,10 +314,9 @@ namespace fheroes2
 
                     conf.setGameLanguage( getLanguageAbbreviation( SupportedLanguage::English ) );
 
-                    Text header( _( "Attention" ), FontType::normalYellow() );
-                    Text body( _( "Your version of Heroes of Might and Magic II does not support any other languages than English." ), FontType::normalWhite() );
-
-                    showMessage( header, body, Dialog::OK );
+                    fheroes2::showStandardTextMessage( _( "Attention" ),
+                                                       _( "Your version of Heroes of Might and Magic II does not support any other languages than English." ),
+                                                       Dialog::OK );
                 }
 
                 windowType = SelectedWindow::UpdateSettings;

--- a/src/fheroes2/dialog/dialog_game_settings.cpp
+++ b/src/fheroes2/dialog/dialog_game_settings.cpp
@@ -273,8 +273,8 @@ namespace
                 fheroes2::showStandardTextMessage( _( "Mouse Cursor" ), _( "Toggle colored cursor on or off. This is only an esthetic choice." ), 0 );
             }
             else if ( le.MousePressRight( windowTextSupportModeRoi ) ) {
-                fheroes2::showStandardTextMessage( _( "Text Support" ),
-                                                   _( "Toggle text support mode to output extra information about windows and events in the game." ), 0 );
+                fheroes2::showStandardTextMessage( _( "Text Support" ), _( "Toggle text support mode to output extra information about windows and events in the game." ),
+                                                   0 );
             }
             else if ( le.MousePressRight( okayButton.area() ) ) {
                 fheroes2::showStandardTextMessage( _( "Okay" ), _( "Exit this menu." ), 0 );

--- a/src/fheroes2/dialog/dialog_graphics_settings.cpp
+++ b/src/fheroes2/dialog/dialog_graphics_settings.cpp
@@ -172,7 +172,7 @@ namespace
                 fheroes2::showStandardTextMessage( _( "V-Sync" ), _( "Enabled V-Sync option is useful for some monitors to resolve flickering issues." ), 0 );
             }
             if ( le.MousePressRight( windowSystemInfoRoi ) ) {
-                fheroes2::showStandardTextMessage( _( "System Info" ), _( "Show extra information such as FPS and current date and time." ), 0 );
+                fheroes2::showStandardTextMessage( _( "System Info" ), _( "Show extra information such as FPS and current time." ), 0 );
             }
         }
 

--- a/src/fheroes2/dialog/dialog_graphics_settings.cpp
+++ b/src/fheroes2/dialog/dialog_graphics_settings.cpp
@@ -18,8 +18,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include "agg_image.h"
 #include "dialog_graphics_settings.h"
+#include "agg_image.h"
 #include "dialog_resolution.h"
 #include "game_hotkeys.h"
 #include "game_mainmenu_ui.h"

--- a/src/fheroes2/dialog/dialog_graphics_settings.cpp
+++ b/src/fheroes2/dialog/dialog_graphics_settings.cpp
@@ -82,8 +82,7 @@ namespace
     {
         const bool isVSyncEnabled = Settings::Get().isVSyncEnabled();
 
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, isVSyncEnabled ? 18 : 19 ), _( "V-Sync" ),
-                              isVSyncEnabled ? _( "on") : _( "off" ) );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, isVSyncEnabled ? 18 : 19 ), _( "V-Sync" ), isVSyncEnabled ? _( "on") : _( "off" ) );
     }
 
     void drawSystemInfo( const fheroes2::Rect & optionRoi )
@@ -100,7 +99,7 @@ namespace
         }
         info.draw( ( image.width() - info.width() ) / 2, ( image.height() - info.height() ) / 2, image );
 
-        fheroes2::drawOption( optionRoi, image, _( "System Info" ), isSystemInfoDisplayed ? _( "on") : _( "off" ) );
+        fheroes2::drawOption( optionRoi, image, _( "System Info" ), isSystemInfoDisplayed ? _( "on" ) : _( "off" ) );
     }
 
     SelectedWindow showConfigurationWindow()

--- a/src/fheroes2/dialog/dialog_graphics_settings.cpp
+++ b/src/fheroes2/dialog/dialog_graphics_settings.cpp
@@ -82,7 +82,7 @@ namespace
     {
         const bool isVSyncEnabled = Settings::Get().isVSyncEnabled();
 
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, isVSyncEnabled ? 18 : 19 ), _( "V-Sync" ), isVSyncEnabled ? _( "on") : _( "off" ) );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, isVSyncEnabled ? 18 : 19 ), _( "V-Sync" ), isVSyncEnabled ? _( "on" ) : _( "off" ) );
     }
 
     void drawSystemInfo( const fheroes2::Rect & optionRoi )
@@ -120,8 +120,6 @@ namespace
 
         fheroes2::Blit( dialogShadow, display, windowRoi.x - BORDERWIDTH, windowRoi.y + BORDERWIDTH );
         fheroes2::Blit( dialog, display, windowRoi.x, windowRoi.y );
-
-        const int buttonIcnId = isEvilInterface ? ICN::NON_UNIFORM_EVIL_OKAY_BUTTON : ICN::NON_UNIFORM_GOOD_OKAY_BUTTON;
 
         const fheroes2::Rect windowResolutionRoi( resolutionRoi + windowRoi.getPosition() );
         const fheroes2::Rect windowModeRoi( modeRoi + windowRoi.getPosition() );

--- a/src/fheroes2/dialog/dialog_graphics_settings.cpp
+++ b/src/fheroes2/dialog/dialog_graphics_settings.cpp
@@ -1,0 +1,227 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2022                                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "agg_image.h"
+#include "dialog_graphics_settings.h"
+#include "dialog_resolution.h"
+#include "game_hotkeys.h"
+#include "game_mainmenu_ui.h"
+#include "icn.h"
+#include "localevent.h"
+#include "screen.h"
+#include "settings.h"
+#include "translations.h"
+#include "ui_button.h"
+#include "ui_dialog.h"
+#include "ui_option_item.h"
+#include "ui_text.h"
+
+namespace
+{
+    enum class SelectedWindow : int
+    {
+        Configuration,
+        Resolution,
+        Mode,
+        VSync,
+        SystemInfo,
+        Exit
+    };
+
+    const fheroes2::Size offsetBetweenOptions{ 118, 110 };
+    const fheroes2::Point optionOffset{ 69, 47 };
+    const int32_t optionWindowSize{ 65 };
+
+    const fheroes2::Rect resolutionRoi{ optionOffset.x, optionOffset.y, optionWindowSize, optionWindowSize };
+    const fheroes2::Rect modeRoi{ optionOffset.x + offsetBetweenOptions.width, optionOffset.y, optionWindowSize, optionWindowSize };
+    const fheroes2::Rect vSyncRoi{ optionOffset.x, optionOffset.y + offsetBetweenOptions.height, optionWindowSize, optionWindowSize };
+    const fheroes2::Rect systemInfoRoi{ optionOffset.x + offsetBetweenOptions.width, optionOffset.y + offsetBetweenOptions.height, optionWindowSize, optionWindowSize };
+
+    void drawResolution( const fheroes2::Rect & optionRoi )
+    {
+        const fheroes2::Display & display = fheroes2::Display::instance();
+        std::string resolutionName = std::to_string( display.width() ) + 'x' + std::to_string( display.height() );
+
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, Settings::Get().ExtGameEvilInterface() ? 17 : 16 ), _( "Resolution" ),
+                              std::move( resolutionName ) );
+    }
+
+    void drawMode( const fheroes2::Rect & optionRoi )
+    {
+        const fheroes2::Sprite & originalIcon = fheroes2::AGG::GetICN( ICN::SPANEL, Settings::Get().ExtGameEvilInterface() ? 17 : 16 );
+
+        if ( fheroes2::engine().isFullScreen() ) {
+            fheroes2::Sprite icon = originalIcon;
+            fheroes2::Resize( originalIcon, 6, 6, 53, 53, icon, 2, 2, 61, 61 );
+
+            fheroes2::drawOption( optionRoi, icon, _( "window|Mode" ), _( "Fullscreen" ) );
+        }
+        else {
+            fheroes2::drawOption( optionRoi, originalIcon, _( "window|Mode" ), _( "Windowed" ) );
+        }
+    }
+
+    void drawVSync( const fheroes2::Rect & optionRoi )
+    {
+        const bool isVSyncEnabled = Settings::Get().isVSyncEnabled();
+
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, isVSyncEnabled ? 18 : 19 ), _( "V-Sync" ),
+                              isVSyncEnabled ? _( "on") : _( "off" ) );
+    }
+
+    void drawSystemInfo( const fheroes2::Rect & optionRoi )
+    {
+        const bool isSystemInfoDisplayed = Settings::Get().isSystemInfoEnabled();
+
+        fheroes2::Sprite image = fheroes2::Crop( fheroes2::AGG::GetICN( ICN::ESPANBKG, 0 ), 69, 47, 65, 65 );
+        fheroes2::Text info;
+        if ( isSystemInfoDisplayed ) {
+            info.set( _( "FPS" ), fheroes2::FontType( fheroes2::FontSize::NORMAL, fheroes2::FontColor::YELLOW ) );
+        }
+        else {
+            info.set( _( "N/A" ), fheroes2::FontType( fheroes2::FontSize::NORMAL, fheroes2::FontColor::GRAY ) );
+        }
+        info.draw( ( image.width() - info.width() ) / 2, ( image.height() - info.height() ) / 2, image );
+
+        fheroes2::drawOption( optionRoi, image, _( "System Info" ), isSystemInfoDisplayed ? _( "on") : _( "off" ) );
+    }
+
+    SelectedWindow showConfigurationWindow()
+    {
+        fheroes2::Display & display = fheroes2::Display::instance();
+
+        const Settings & conf = Settings::Get();
+        const bool isEvilInterface = conf.ExtGameEvilInterface();
+        const fheroes2::Sprite & dialog = fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::ESPANBKG_EVIL : ICN::ESPANBKG ), 0 );
+        const fheroes2::Sprite & dialogShadow = fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::CSPANBKE : ICN::CSPANBKG ), 1 );
+
+        const fheroes2::Point dialogOffset( ( display.width() - dialog.width() ) / 2, ( display.height() - dialog.height() ) / 2 );
+        const fheroes2::Point shadowOffset( dialogOffset.x - BORDERWIDTH, dialogOffset.y );
+
+        const fheroes2::Rect windowRoi{ dialogOffset.x, dialogOffset.y, dialog.width(), dialog.height() };
+
+        const fheroes2::ImageRestorer restorer( display, shadowOffset.x, shadowOffset.y, dialog.width() + BORDERWIDTH, dialog.height() + BORDERWIDTH );
+
+        fheroes2::Blit( dialogShadow, display, windowRoi.x - BORDERWIDTH, windowRoi.y + BORDERWIDTH );
+        fheroes2::Blit( dialog, display, windowRoi.x, windowRoi.y );
+
+        const int buttonIcnId = isEvilInterface ? ICN::NON_UNIFORM_EVIL_OKAY_BUTTON : ICN::NON_UNIFORM_GOOD_OKAY_BUTTON;
+
+        const fheroes2::Rect windowResolutionRoi( resolutionRoi + windowRoi.getPosition() );
+        const fheroes2::Rect windowModeRoi( modeRoi + windowRoi.getPosition() );
+        const fheroes2::Rect windowVSyncRoi( vSyncRoi + windowRoi.getPosition() );
+        const fheroes2::Rect windowSystemInfoRoi( systemInfoRoi + windowRoi.getPosition() );
+
+        drawResolution( windowResolutionRoi );
+        drawMode( windowModeRoi );
+        drawVSync( windowVSyncRoi );
+        drawSystemInfo( windowSystemInfoRoi );
+
+        const fheroes2::Point buttonOffset( 112 + windowRoi.x, 252 + windowRoi.y );
+        fheroes2::Button okayButton( buttonOffset.x, buttonOffset.y, isEvilInterface ? ICN::SPANBTNE : ICN::SPANBTN, 0, 1 );
+        okayButton.draw();
+
+        display.render();
+
+        LocalEvent & le = LocalEvent::Get();
+        while ( le.HandleEvents() ) {
+            if ( le.MousePressLeft( okayButton.area() ) ) {
+                okayButton.drawOnPress();
+            }
+            else {
+                okayButton.drawOnRelease();
+            }
+
+            if ( le.MouseClickLeft( okayButton.area() ) || Game::HotKeyCloseWindow() ) {
+                break;
+            }
+            if ( le.MouseClickLeft( windowResolutionRoi ) ) {
+                return SelectedWindow::Resolution;
+            }
+            if ( le.MouseClickLeft( windowModeRoi ) ) {
+                return SelectedWindow::Mode;
+            }
+            if ( le.MouseClickLeft( windowVSyncRoi ) ) {
+                return SelectedWindow::VSync;
+            }
+            if ( le.MouseClickLeft( windowSystemInfoRoi ) ) {
+                return SelectedWindow::SystemInfo;
+            }
+
+            if ( le.MousePressRight( windowResolutionRoi ) ) {
+                fheroes2::showStandardTextMessage( _( "Select Game Resolution" ), _( "Change the resolution of the game." ), 0 );
+            }
+            else if ( le.MousePressRight( windowModeRoi ) ) {
+                fheroes2::showStandardTextMessage( _( "window|Mode" ), _( "Toggle between fullscreen and windowed modes." ), 0 );
+            }
+            else if ( le.MousePressRight( windowVSyncRoi ) ) {
+                fheroes2::showStandardTextMessage( _( "V-Sync" ), _( "Enabled V-Sync option is useful for some monitors to resolve flickering issues." ), 0 );
+            }
+            if ( le.MousePressRight( windowSystemInfoRoi ) ) {
+                fheroes2::showStandardTextMessage( _( "System Info" ), _( "Show extra information such as FPS and current date and time." ), 0 );
+            }
+        }
+
+        return SelectedWindow::Exit;
+    }
+}
+
+namespace fheroes2
+{
+    void openGraphicsSettingsDialog()
+    {
+        drawMainMenuScreen();
+
+        Settings & conf = Settings::Get();
+
+        SelectedWindow windowType = SelectedWindow::Configuration;
+        while ( windowType != SelectedWindow::Exit ) {
+            switch ( windowType ) {
+            case SelectedWindow::Configuration:
+                windowType = showConfigurationWindow();
+                break;
+            case SelectedWindow::Resolution:
+                if ( Dialog::SelectResolution() ) {
+                    conf.Save( Settings::configFileName );
+                }
+                drawMainMenuScreen();
+                windowType = SelectedWindow::Configuration;
+                break;
+            case SelectedWindow::Mode:
+                conf.setFullScreen( !conf.FullScreen() );
+                conf.Save( Settings::configFileName );
+                windowType = SelectedWindow::Configuration;
+                break;
+            case SelectedWindow::VSync:
+                conf.setVSync( !conf.isVSyncEnabled() );
+                conf.Save( Settings::configFileName );
+                windowType = SelectedWindow::Configuration;
+                break;
+            case SelectedWindow::SystemInfo:
+                conf.setSystemInfo( !conf.isSystemInfoEnabled() );
+                conf.Save( Settings::configFileName );
+                windowType = SelectedWindow::Configuration;
+                break;
+            default:
+                return;
+            }
+        }
+    }
+}

--- a/src/fheroes2/dialog/dialog_graphics_settings.cpp
+++ b/src/fheroes2/dialog/dialog_graphics_settings.cpp
@@ -169,10 +169,13 @@ namespace
                 fheroes2::showStandardTextMessage( _( "window|Mode" ), _( "Toggle between fullscreen and windowed modes." ), 0 );
             }
             else if ( le.MousePressRight( windowVSyncRoi ) ) {
-                fheroes2::showStandardTextMessage( _( "V-Sync" ), _( "Enabled V-Sync option is useful for some monitors to resolve flickering issues." ), 0 );
+                fheroes2::showStandardTextMessage( _( "V-Sync" ), _( "The V-Sync option can be enabled to resolve flickering issues on some monitors." ), 0 );
             }
             if ( le.MousePressRight( windowSystemInfoRoi ) ) {
                 fheroes2::showStandardTextMessage( _( "System Info" ), _( "Show extra information such as FPS and current time." ), 0 );
+            }
+            else if ( le.MousePressRight( okayButton.area() ) ) {
+                fheroes2::showStandardTextMessage( _( "Okay" ), _( "Exit this menu." ), 0 );
             }
         }
 

--- a/src/fheroes2/dialog/dialog_graphics_settings.h
+++ b/src/fheroes2/dialog/dialog_graphics_settings.h
@@ -1,0 +1,25 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2022                                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+#pragma once
+
+namespace fheroes2
+{
+    void openGraphicsSettingsDialog();
+}

--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -146,7 +146,6 @@ void Dialog::ExtSettings( bool readonly )
     std::vector<uint32_t> states;
     states.reserve( 16 );
 
-    states.push_back( Settings::GAME_SHOW_SYSTEM_INFO );
     states.push_back( Settings::GAME_BATTLE_SHOW_DAMAGE );
     states.push_back( Settings::GAME_AUTOSAVE_BEGIN_DAY );
     states.push_back( Settings::GAME_CONTINUE_AFTER_VICTORY );

--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -35,6 +35,7 @@
 #include "translations.h"
 #include "ui_button.h"
 #include "ui_dialog.h"
+#include "ui_option_item.h"
 #include "ui_text.h"
 
 #include <cassert>
@@ -53,23 +54,6 @@ namespace
         Close
     };
 
-    void drawOption( const fheroes2::Rect & optionRoi, const fheroes2::Sprite & icon, const std::string & titleText, const std::string & valueText )
-    {
-        fheroes2::Display & display = fheroes2::Display::instance();
-
-        const fheroes2::FontType smallWhite = fheroes2::FontType::smallWhite();
-
-        const fheroes2::Text title( titleText, smallWhite );
-        const fheroes2::Text value( valueText, smallWhite );
-
-        const int16_t textMaxWidth = 87;
-
-        title.draw( optionRoi.x - 12, optionRoi.y - title.height( textMaxWidth ), textMaxWidth, display );
-        value.draw( optionRoi.x + ( optionRoi.width - value.width() ) / 2, optionRoi.y + optionRoi.height + 4, display );
-
-        fheroes2::Blit( icon, display, optionRoi.x, optionRoi.y );
-    }
-
     void drawDialog( const std::vector<fheroes2::Rect> & rects )
     {
         assert( rects.size() == 9 );
@@ -78,16 +62,16 @@ namespace
 
         // Audio settings.
         const fheroes2::Sprite & audioSettingsIcon = fheroes2::AGG::GetICN( ICN::SPANEL, 1 );
-        drawOption( rects[0], audioSettingsIcon, _( "Audio" ), _( "Settings" ) );
+        fheroes2::drawOption( rects[0], audioSettingsIcon, _( "Audio" ), _( "Settings" ) );
 
         // Hot keys.
         const fheroes2::Sprite & hotkeysIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, 5 );
-        drawOption( rects[1], hotkeysIcon, _( "Hot Keys" ), _( "Configure" ) );
+        fheroes2::drawOption( rects[1], hotkeysIcon, _( "Hot Keys" ), _( "Configure" ) );
 
         // Cursor Type.
         const bool isMonoCursor = Settings::Get().isMonochromeCursorEnabled();
         const fheroes2::Sprite & cursorTypeIcon = fheroes2::AGG::GetICN( ICN::SPANEL, isMonoCursor ? 20 : 21 );
-        drawOption( rects[2], cursorTypeIcon, _( "Mouse Cursor" ), isMonoCursor ? _( "Black & White" ) : _( "Color" ) );
+        fheroes2::drawOption( rects[2], cursorTypeIcon, _( "Mouse Cursor" ), isMonoCursor ? _( "Black & White" ) : _( "Color" ) );
 
         // Hero's movement speed.
         const int heroSpeed = conf.HeroesMoveSpeed();
@@ -108,7 +92,7 @@ namespace
             value = std::to_string( heroSpeed );
         }
 
-        drawOption( rects[3], heroSpeedIcon, _( "Hero Speed" ), value );
+        fheroes2::drawOption( rects[3], heroSpeedIcon, _( "Hero Speed" ), value );
 
         // AI's movement speed.
         const int aiSpeed = conf.AIMoveSpeed();
@@ -131,7 +115,7 @@ namespace
             value = std::to_string( aiSpeed );
         }
 
-        drawOption( rects[4], aiSpeedIcon, _( "Enemy Speed" ), value );
+        fheroes2::drawOption( rects[4], aiSpeedIcon, _( "Enemy Speed" ), value );
 
         // Scrolling speed.
         const int scrollSpeed = conf.ScrollSpeed();
@@ -147,7 +131,7 @@ namespace
         }
 
         const fheroes2::Sprite & scrollSpeedIcon = fheroes2::AGG::GetICN( ICN::SPANEL, scrollSpeedIconId );
-        drawOption( rects[5], scrollSpeedIcon, _( "Scroll Speed" ), std::to_string( scrollSpeed ) );
+        fheroes2::drawOption( rects[5], scrollSpeedIcon, _( "Scroll Speed" ), std::to_string( scrollSpeed ) );
 
         // Interface theme.
         const bool isEvilInterface = conf.ExtGameEvilInterface();
@@ -159,7 +143,7 @@ namespace
             value = _( "Good" );
         }
 
-        drawOption( rects[6], interfaceThemeIcon, _( "Interface Type" ), value );
+        fheroes2::drawOption( rects[6], interfaceThemeIcon, _( "Interface Type" ), value );
 
         // Interface show/hide state.
         const bool isHiddenInterface = conf.ExtGameHideInterface();
@@ -172,7 +156,7 @@ namespace
             value = _( "Show" );
         }
 
-        drawOption( rects[7], interfaceStateIcon, _( "Interface" ), value );
+        fheroes2::drawOption( rects[7], interfaceStateIcon, _( "Interface" ), value );
 
         // Auto-battles.
         if ( conf.BattleAutoResolve() ) {
@@ -180,11 +164,11 @@ namespace
             value = spellcast ? _( "Auto Resolve" ) : _( "Auto, No Spells" );
 
             const fheroes2::Sprite & autoBattleIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, spellcast ? 7 : 6 );
-            drawOption( rects[8], autoBattleIcon, _( "Battles" ), value );
+            fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), value );
         }
         else {
             const fheroes2::Sprite & autoBattleIcon = fheroes2::AGG::GetICN( ICN::SPANEL, 18 );
-            drawOption( rects[8], autoBattleIcon, _( "Battles" ), _( "Manual" ) );
+            fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), _( "Manual" ) );
         }
     }
 
@@ -343,69 +327,37 @@ namespace
                 saveAutoBattle = true;
             }
 
-            const fheroes2::FontType normalYellow = fheroes2::FontType::normalYellow();
-            const fheroes2::FontType normalWhite = fheroes2::FontType::normalWhite();
-
             if ( le.MousePressRight( audioSettingsRoi ) ) {
-                fheroes2::Text header( _( "Audio" ), normalYellow );
-                fheroes2::Text body( _( "Change the audio settings of the game." ), normalWhite );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Audio" ), _( "Change the audio settings of the game." ), 0 );
             }
 
             else if ( le.MousePressRight( hotkeysRoi ) ) {
-                fheroes2::Text header( _( "Hot Keys" ), normalYellow );
-                fheroes2::Text body( _( "Check and configure all the hot keys present in the game." ), normalWhite );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Hot Keys" ), _( "Check and configure all the hot keys present in the game." ), 0 );
             }
             else if ( le.MousePressRight( cursorTypeRoi ) ) {
-                fheroes2::Text header( _( "Mouse Cursor" ), normalYellow );
-                fheroes2::Text body( _( "Toggle colored cursor on or off. This is only an esthetic choice." ), normalWhite );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Mouse Cursor" ), _( "Toggle colored cursor on or off. This is only an esthetic choice." ), 0 );
             }
             else if ( le.MousePressRight( heroSpeedRoi ) ) {
-                fheroes2::Text header( _( "Hero Speed" ), normalYellow );
-                fheroes2::Text body( _( "Change the speed at which your heroes move on the main screen." ), normalWhite );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Hero Speed" ), _( "Change the speed at which your heroes move on the main screen." ), 0 );
             }
             else if ( le.MousePressRight( aiSpeedRoi ) ) {
-                fheroes2::Text header( _( "Enemy Speed" ), normalYellow );
-                fheroes2::Text body( _( "Sets the speed that A.I. heroes move at.  You can also elect not to view A.I. movement at all." ), normalWhite );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Enemy Speed" ),
+                                                   _( "Sets the speed that A.I. heroes move at.  You can also elect not to view A.I. movement at all." ), 0 );
             }
             else if ( le.MousePressRight( scrollSpeedRoi ) ) {
-                fheroes2::Text header( _( "Scroll Speed" ), normalYellow );
-                fheroes2::Text body( _( "Sets the speed at which you scroll the window." ), normalWhite );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Scroll Speed" ), _( "Sets the speed at which you scroll the window." ), 0 );
             }
             else if ( le.MousePressRight( interfaceTypeRoi ) ) {
-                fheroes2::Text header( _( "Interface Type" ), normalYellow );
-                fheroes2::Text body( _( "Toggle the type of interface you want to use." ), normalWhite );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Interface Type" ), _( "Toggle the type of interface you want to use." ), 0 );
             }
             else if ( le.MousePressRight( interfaceStateRoi ) ) {
-                fheroes2::Text header( _( "Interface" ), normalYellow );
-                fheroes2::Text body( _( "Toggle interface visibility." ), normalWhite );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Interface" ), _( "Toggle interface visibility." ), 0 );
             }
             else if ( le.MousePressRight( battleResolveRoi ) ) {
-                fheroes2::Text header( _( "Battles" ), normalYellow );
-                fheroes2::Text body( _( "Toggle instant battle mode." ), normalWhite );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Battles" ), _( "Toggle instant battle mode." ), 0 );
             }
             else if ( le.MousePressRight( buttonOkay.area() ) ) {
-                fheroes2::Text header( _( "Okay" ), normalYellow );
-                fheroes2::Text body( _( "Exit this menu." ), normalWhite );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Okay" ), _( "Exit this menu." ), 0 );
             }
 
             if ( saveHeroSpeed || saveAISpeed || saveScrollSpeed || saveAutoBattle ) {

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -124,8 +124,6 @@ namespace
         {
             const Settings & conf = Settings::Get();
 
-            fheroes2::engine().setVSync( conf.isVSyncEnabled() );
-
             fheroes2::Display & display = fheroes2::Display::instance();
             if ( conf.FullScreen() != fheroes2::engine().isFullScreen() )
                 fheroes2::engine().toggleFullScreen();

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -357,11 +357,8 @@ void Game::KeyboardGlobalFilter( int sdlKey, int mod )
 {
     if ( fheroes2::getKeyFromSDL( sdlKey ) == hotKeyEventInfo[hotKeyEventToInt( HotKeyEvent::SYSTEM_FULLSCREEN )].key
          && !( ( mod & KMOD_ALT ) || ( mod & KMOD_CTRL ) ) ) {
-        fheroes2::engine().toggleFullScreen();
-        fheroes2::Display::instance().render();
-
         Settings & conf = Settings::Get();
-        conf.setFullScreen( fheroes2::engine().isFullScreen() );
+        conf.setFullScreen( !fheroes2::engine().isFullScreen() );
         conf.Save( Settings::configFileName );
     }
 }

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -200,9 +200,7 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
         fheroes2::MultiFontText body;
         body.add( { _( "You can always change game resolution by clicking on the " ), fheroes2::FontType::normalWhite() } );
         body.add( { _( "door" ), fheroes2::FontType::normalYellow() } );
-        body.add( { _( " on the left side of main menu.\n\nTo switch between windowed and full screen modes\npress " ), fheroes2::FontType::normalWhite() } );
-        body.add( { _( "F4" ), fheroes2::FontType::normalYellow() } );
-        body.add( { _( " key on the keyboard.\n\nEnjoy the game!" ), fheroes2::FontType::normalWhite() } );
+        body.add( { _( " on the left side of main menu or by clicking on the configuration button. \n\nEnjoy the game!" ), fheroes2::FontType::normalWhite() } );
 
         fheroes2::showMessage( header, body, Dialog::OK );
 

--- a/src/fheroes2/gui/ui_option_item.cpp
+++ b/src/fheroes2/gui/ui_option_item.cpp
@@ -1,0 +1,47 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2022                                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "ui_option_item.h"
+#include "screen.h"
+#include "ui_text.h"
+
+namespace
+{
+    const fheroes2::Point textOffset{ 11, 12 };
+    const int32_t nameOffset = 6;
+}
+
+namespace fheroes2
+{
+    void drawOption( const Rect & optionRoi, const Sprite & icon, std::string titleText, std::string valueText )
+    {
+        Display & display = Display::instance();
+
+        const Text title( std::move( titleText ), FontType::smallWhite() );
+        const Text name( std::move( valueText ), FontType::smallWhite() );
+
+        const int32_t textMaxWidth = 87;
+
+        title.draw( optionRoi.x - textOffset.x, optionRoi.y - textOffset.y + title.height() - title.height( textMaxWidth ), textMaxWidth, display );
+        name.draw( optionRoi.x - textOffset.x, optionRoi.y + optionRoi.height + nameOffset, textMaxWidth, display );
+
+        Blit( icon, 0, 0, display, optionRoi.x, optionRoi.y, icon.width(), icon.height() );
+    }
+}

--- a/src/fheroes2/gui/ui_option_item.h
+++ b/src/fheroes2/gui/ui_option_item.h
@@ -1,0 +1,30 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2022                                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#pragma once
+
+#include "image.h"
+
+#include <string>
+
+namespace fheroes2
+{
+    void drawOption( const Rect & optionRoi, const Sprite & icon, std::string titleText, std::string valueText );
+}

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -46,7 +46,7 @@ namespace
 
         void preRender()
         {
-            if ( !Settings::Get().ExtGameShowSystemInfo() )
+            if ( !Settings::Get().isSystemInfoEnabled() )
                 return;
 
             const int32_t offsetX = 26;

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -65,7 +65,7 @@ namespace
         GLOBAL_SHOWSTATUS = 0x00000400,
         GLOBAL_FULLSCREEN = 0x00008000,
         GLOBAL_3D_AUDIO = 0x00010000,
-        // UNUSED = 0x00020000,
+        GLOBAL_SYSTEM_INFO = 0x00020000,
         // UNUSED = 0x00040000,
         // UNUSED = 0x00080000,
         // UNUSED = 0x00100000,
@@ -307,41 +307,23 @@ bool Settings::Read( const std::string & filename )
     }
 
     if ( config.Exists( "v-sync" ) ) {
-        if ( config.StrParams( "v-sync" ) == "on" ) {
-            _optGlobal.SetModes( GLOBAL_RENDER_VSYNC );
-        }
-        else {
-            _optGlobal.ResetModes( GLOBAL_RENDER_VSYNC );
-        }
+        setVSync( config.StrParams( "v-sync" ) == "on" );
     }
 
     if ( config.Exists( "text support mode" ) ) {
-        if ( config.StrParams( "text support mode" ) == "on" ) {
-            _optGlobal.SetModes( GLOBAL_TEXT_SUPPORT_MODE );
-            Logging::setTextSupportMode( true );
-        }
-        else {
-            _optGlobal.ResetModes( GLOBAL_TEXT_SUPPORT_MODE );
-        }
+        setTextSupportMode( config.StrParams( "text support mode" ) == "on" );
     }
 
     if ( config.Exists( "monochrome cursor" ) ) {
-        if ( config.StrParams( "monochrome cursor" ) == "on" ) {
-            _optGlobal.SetModes( GLOBAL_MONOCHROME_CURSOR );
-            Cursor::Get().setMonochromeCursor( true );
-        }
-        else {
-            _optGlobal.ResetModes( GLOBAL_MONOCHROME_CURSOR );
-        }
+        setMonochromeCursor( config.StrParams( "monochrome cursor" ) == "on" );
     }
 
     if ( config.Exists( "3d audio" ) ) {
-        if ( config.StrParams( "3d audio" ) == "on" ) {
-            _optGlobal.SetModes( GLOBAL_3D_AUDIO );
-        }
-        else {
-            _optGlobal.ResetModes( GLOBAL_3D_AUDIO );
-        }
+        set3DAudio( config.StrParams( "3d audio" ) == "on" );
+    }
+
+    if ( config.Exists( "system info" ) ) {
+        setSystemInfo( config.StrParams( "system info" ) == "on" );
     }
 
     BinaryLoad();
@@ -451,14 +433,17 @@ std::string Settings::String() const
     os << std::endl << "# enable V-Sync (Vertical Synchronization) for rendering" << std::endl;
     os << "v-sync = " << ( _optGlobal.Modes( GLOBAL_RENDER_VSYNC ) ? "on" : "off" ) << std::endl;
 
-    os << std::endl << "# enable text support mode to output extra information in console window" << std::endl;
+    os << std::endl << "# enable text support mode to output extra information in console window: on/off" << std::endl;
     os << "text support mode = " << ( _optGlobal.Modes( GLOBAL_TEXT_SUPPORT_MODE ) ? "on" : "off" ) << std::endl;
 
-    os << std::endl << "# enable monochrome (black and white) cursors in the game" << std::endl;
+    os << std::endl << "# enable monochrome (black and white) cursors in the game: on/off" << std::endl;
     os << "monochrome cursor = " << ( _optGlobal.Modes( GLOBAL_MONOCHROME_CURSOR ) ? "on" : "off" ) << std::endl;
 
-    os << std::endl << "# enable 3D audio for objects on Adventure Map" << std::endl;
+    os << std::endl << "# enable 3D audio for objects on Adventure Map: on/off" << std::endl;
     os << "3d audio = " << ( _optGlobal.Modes( GLOBAL_3D_AUDIO ) ? "on" : "off" ) << std::endl;
+
+    os << std::endl << "# display system information: on/off" << std::endl;
+    os << "system info = " << ( _optGlobal.Modes( GLOBAL_SYSTEM_INFO ) ? "on" : "off" ) << std::endl;
 
     return os.str();
 }
@@ -663,6 +648,9 @@ void Settings::setFullScreen( const bool enable )
     else {
         _optGlobal.ResetModes( GLOBAL_FULLSCREEN );
     }
+
+    fheroes2::engine().toggleFullScreen();
+    fheroes2::Display::instance().render();
 }
 
 void Settings::setMonochromeCursor( const bool enable )
@@ -701,6 +689,28 @@ void Settings::set3DAudio( const bool enable )
     }
 }
 
+void Settings::setVSync( const bool enable )
+{
+    if ( enable ) {
+        _optGlobal.SetModes( GLOBAL_RENDER_VSYNC );
+        fheroes2::engine().setVSync( true );
+    }
+    else {
+        _optGlobal.ResetModes( GLOBAL_RENDER_VSYNC );
+        fheroes2::engine().setVSync( false );
+    }
+}
+
+void Settings::setSystemInfo( const bool enable )
+{
+    if ( enable ) {
+        _optGlobal.SetModes( GLOBAL_SYSTEM_INFO );
+    }
+    else {
+        _optGlobal.ResetModes( GLOBAL_SYSTEM_INFO );
+    }
+}
+
 /* set scroll speed: 1 - 4 */
 void Settings::SetScrollSpeed( int speed )
 {
@@ -725,6 +735,11 @@ bool Settings::isTextSupportModeEnabled() const
 bool Settings::is3DAudioEnabled() const
 {
     return _optGlobal.Modes( GLOBAL_3D_AUDIO );
+}
+
+bool Settings::isSystemInfoEnabled() const
+{
+    return _optGlobal.Modes( GLOBAL_SYSTEM_INFO );
 }
 
 bool Settings::ShowControlPanel() const
@@ -918,8 +933,6 @@ std::string Settings::ExtName( const uint32_t settingId )
         return _( "battle: allow soft wait for troops" );
     case Settings::BATTLE_DETERMINISTIC_RESULT:
         return _( "battle: deterministic events" );
-    case Settings::GAME_SHOW_SYSTEM_INFO:
-        return _( "game: show system info" );
     case Settings::GAME_AUTOSAVE_BEGIN_DAY:
         return _( "game: autosave will be made at the beginning of the day" );
     case Settings::GAME_EVIL_INTERFACE:

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -57,7 +57,7 @@ public:
         GAME_AUTOSAVE_BEGIN_DAY = 0x10000010,
         // UNUSED = 0x10000020,
         // UNUSED = 0x10000040,
-        GAME_SHOW_SYSTEM_INFO = 0x10000100,
+        // UNUSED = 0x10000100,
         // UNUSED = 0x10000200,
         // UNUSED = 0x10000400,
         GAME_EVIL_INTERFACE = 0x10001000,
@@ -230,6 +230,7 @@ public:
     bool isMonochromeCursorEnabled() const;
     bool isTextSupportModeEnabled() const;
     bool is3DAudioEnabled() const;
+    bool isSystemInfoEnabled() const;
 
     bool LoadedGameVersion() const
     {
@@ -311,11 +312,6 @@ public:
         return ExtModes( GAME_CONTINUE_AFTER_VICTORY );
     }
 
-    bool ExtGameShowSystemInfo() const
-    {
-        return ExtModes( GAME_SHOW_SYSTEM_INFO );
-    }
-
     bool ExtGameAutosaveBeginOfDay() const
     {
         return ExtModes( GAME_AUTOSAVE_BEGIN_DAY );
@@ -372,6 +368,8 @@ public:
     void setMonochromeCursor( const bool enable );
     void setTextSupportMode( const bool enable );
     void set3DAudio( const bool enable );
+    void setVSync( const bool enable );
+    void setSystemInfo( const bool enable );
 
     void SetSoundVolume( int v );
     void SetMusicVolume( int v );


### PR DESCRIPTION
The new window includes resolution, fullscreen / windowed modes (very useful for devices with no keyboard support, relates to #6008), v-sync option and system information. Besides this this pull request does:
- update fresh start window text: the settings can be changed by pressing a button and remove F4 mentioning as it is not true for all devices
- standartize all options within every dialog: we were rendering text differently for some dialogs
- simplify code for popup windows

**Note**: names and sentences are subject of changes so feel free to proposed better ones.

![image](https://user-images.githubusercontent.com/19829520/200181560-4bbc59c6-74f9-4668-a39a-558ef55b2b30.png)