### PR TITLE
Reset hero meeting flag every time if hero's strength has changed

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -261,6 +261,8 @@ namespace AI
 
     void HeroesAction( Heroes & hero, const int32_t dst_index )
     {
+        const Heroes::AIHeroMeetingUpdater heroMeetingUpdater( hero );
+
         const Maps::Tiles & tile = world.GetTiles( dst_index );
         const MP2::MapObjectType objectType = tile.GetObject( dst_index != hero.GetIndex() );
         bool isAction = true;
@@ -720,8 +722,6 @@ namespace AI
             tile.MonsterSetCount( 0 );
             tile.setAsEmpty();
         }
-
-        hero.unmarkHeroMeeting();
     }
 
     void AIToPickupResource( Heroes & hero, const MP2::MapObjectType objectType, int32_t dst_index )
@@ -1394,7 +1394,6 @@ namespace AI
         }
 
         tile.MonsterSetCount( 0 );
-        hero.unmarkHeroMeeting();
 
         DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() )
     }
@@ -1442,8 +1441,6 @@ namespace AI
             tile.setAsEmpty();
         }
 
-        hero.unmarkHeroMeeting();
-
         DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() )
     }
 
@@ -1461,8 +1458,6 @@ namespace AI
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
                 tile.QuantitySetColor( hero.GetColor() );
                 tile.SetObjectPassable( true );
-
-                hero.unmarkHeroMeeting();
             }
             else {
                 AIBattleLose( hero, res, true );

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -172,6 +172,8 @@ namespace AI
 
     void Normal::reinforceHeroInCastle( Heroes & hero, Castle & castle, const Funds & budget )
     {
+        const Heroes::AIHeroMeetingUpdater heroMeetingUpdater( hero );
+
         if ( !hero.HaveSpellBook() && castle.GetLevelMageGuild() > 0 && !hero.IsFullBagArtifacts() ) {
             // this call will check if AI kingdom have enough resources to buy book
             hero.BuySpellBook( &castle );
@@ -230,9 +232,6 @@ namespace AI
         }
 
         OptimizeTroopsOrder( heroArmy );
-        if ( std::fabs( armyStrength - heroArmy.GetStrength() ) > 0.001 ) {
-            hero.unmarkHeroMeeting();
-        }
     }
 
     void Normal::evaluateRegionSafety()

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -21,9 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include <algorithm>
 #include <array>
-#include <cassert>
 #include <cmath>
 #include <functional>
 

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -144,9 +144,6 @@ public:
         UNKNOWN
     };
 
-    static const fheroes2::Sprite & GetPortrait( int heroid, int type );
-    static const char * GetName( int heroid );
-
     enum flags_t : uint32_t
     {
         SHIPMASTER = 0x00000001,
@@ -203,6 +200,32 @@ public:
         CHAMPION
     };
 
+    // This class is used to update a flag for an AI hero to make him available to meet other heroes.
+    // Such cases happen after battles, reinforcements or collecting artifacts.
+    class AIHeroMeetingUpdater
+    {
+    public:
+        explicit AIHeroMeetingUpdater( Heroes & hero )
+            : _hero( hero )
+            , _initialArmyStrength( hero.GetArmy().GetStrength() )
+        {
+            // Do nothing.
+        }
+
+        ~AIHeroMeetingUpdater()
+        {
+            const double currentArmyStrength = _hero.GetArmy().GetStrength();
+
+            if ( std::fabs( _initialArmyStrength - currentArmyStrength ) > 0.001 ) {
+                _hero.unmarkHeroMeeting();
+            }
+        }
+
+    private:
+        Heroes & _hero;
+        const double _initialArmyStrength;
+    };
+
     Heroes();
     Heroes( int heroid, int rc );
     Heroes( int heroID, int race, int initialLevel );
@@ -211,6 +234,9 @@ public:
     ~Heroes() override = default;
 
     Heroes & operator=( const Heroes & ) = delete;
+
+    static const fheroes2::Sprite & GetPortrait( int heroid, int type );
+    static const char * GetName( int heroid );
 
     bool isValid() const override;
     bool isFreeman() const;
@@ -382,6 +408,8 @@ public:
     // These methods are used only for AI.
     bool hasMetWithHero( int heroID ) const;
     void markHeroMeeting( int heroID );
+
+    // Do not call this method directly. It is used by AIHeroMeetingUpdater class.
     void unmarkHeroMeeting();
 
     bool Move( bool fast = false );

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -212,6 +212,12 @@ public:
             // Do nothing.
         }
 
+        AIHeroMeetingUpdater( const AIHeroMeetingUpdater & ) = delete;
+        AIHeroMeetingUpdater( AIHeroMeetingUpdater && ) = delete;
+
+        AIHeroMeetingUpdater & operator=( const AIHeroMeetingUpdater & ) = delete;
+        AIHeroMeetingUpdater & operator=( AIHeroMeetingUpdater && ) = delete;
+
         ~AIHeroMeetingUpdater()
         {
             const double currentArmyStrength = _hero.GetArmy().GetStrength();

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -220,7 +220,15 @@ public:
 
         ~AIHeroMeetingUpdater()
         {
-            const double currentArmyStrength = _hero.GetArmy().GetStrength();
+            double currentArmyStrength = 0;
+
+            try {
+                // SonarQube complains about this place to throw an exception so we had to add exception handling code.
+                currentArmyStrength = _hero.GetArmy().GetStrength();
+            }
+            catch ( ... ) {
+                return;
+            }
 
             if ( std::fabs( _initialArmyStrength - currentArmyStrength ) > 0.001 ) {
                 _hero.unmarkHeroMeeting();

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -226,8 +226,7 @@ public:
                 // SonarQube complains about this place to throw an exception so we had to add exception handling code.
                 currentArmyStrength = _hero.GetArmy().GetStrength();
             }
-            catch(...)
-            {
+            catch ( ... ) {
                 return;
             }
 

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -25,6 +25,8 @@
 #define H2HEROES_H
 
 #include <algorithm>
+#include <cassert>
+#include <exception>
 #include <list>
 #include <string>
 #include <vector>
@@ -223,11 +225,14 @@ public:
             double currentArmyStrength = 0;
 
             try {
-                // SonarQube complains about this place to throw an exception so we had to add exception handling code.
+                // Army::GetStrength() could potentially throw an exception, and SonarQube complains about a potentially uncaught exception
+                // in the destructor. This is not a problem per se, because calling std::terminate() is OK, so let's just do this ourselves.
                 currentArmyStrength = _hero.GetArmy().GetStrength();
             }
             catch ( ... ) {
-                return;
+                // This should never happen
+                assert( 0 );
+                std::terminate();
             }
 
             if ( std::fabs( _initialArmyStrength - currentArmyStrength ) > 0.001 ) {

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -220,15 +220,7 @@ public:
 
         ~AIHeroMeetingUpdater()
         {
-            double currentArmyStrength = 0;
-
-            try {
-                // SonarQube complains about this place to throw an exception so we had to add exception handling code.
-                currentArmyStrength = _hero.GetArmy().GetStrength();
-            }
-            catch ( ... ) {
-                return;
-            }
+            const double currentArmyStrength = _hero.GetArmy().GetStrength();
 
             if ( std::fabs( _initialArmyStrength - currentArmyStrength ) > 0.001 ) {
                 _hero.unmarkHeroMeeting();

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -220,7 +220,16 @@ public:
 
         ~AIHeroMeetingUpdater()
         {
-            const double currentArmyStrength = _hero.GetArmy().GetStrength();
+            double currentArmyStrength = 0;
+
+            try {
+                // SonarQube complains about this place to throw an exception so we had to add exception handling code.
+                currentArmyStrength = _hero.GetArmy().GetStrength();
+            }
+            catch(...)
+            {
+                return;
+            }
 
             if ( std::fabs( _initialArmyStrength - currentArmyStrength ) > 0.001 ) {
                 _hero.unmarkHeroMeeting();


### PR DESCRIPTION
Previously the hero meeting flag was reset for cases when it was needed or it wasn't reset at all like after levelling up.