### PR TITLE
Removing an accidentally duplicated line in UI

### DIFF
--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -169,7 +169,6 @@ namespace
         else {
             const fheroes2::Sprite & autoBattleIcon = fheroes2::AGG::GetICN( ICN::SPANEL, 18 );
             fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), _( "autoBattle|Manual" ) );
-            fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), _( "Manual" ) );
         }
     }
 


### PR DESCRIPTION
In my last PR ("Changed 'Manual' string ...") after last commit "Merge branch 'master' into different_translation_for_Manual_string" I did not notice that line "fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), _( "Manual" ) );" was not deleted, so now it duplicates  the line "fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), _( "autoBattle|Manual" ) );"

@ihhub, I'm sorry for this mistake and ask you to apply this quick fix.