### PR TITLE
IWYU: add <cmath> as another alias for std::abs()'s internal header

### DIFF
--- a/iwyu.map
+++ b/iwyu.map
@@ -1,5 +1,6 @@
 [
     { include: [ "<bits/getopt_core.h>",     private, "<unistd.h>", public ] },
+    { include: [ "<bits/std_abs.h>",         private, "<cmath>",    public ] },
     { include: [ "<bits/std_abs.h>",         private, "<cstdlib>",  public ] },
     { include: [ "<bits/types/struct_tm.h>", private, "<ctime>",    public ] },
     { include: [ "<ext/alloc_traits.h>",     private, "<memory>",   public ] }


### PR DESCRIPTION
Both `#include <cmath>` and `#include <cstdlib>` [should be fine](https://en.cppreference.com/w/cpp/numeric/math/abs) for the `std::abs()`. Before this PR, there was only alias for the `<cstdlib>`.