### PR TITLE
Update captain's mana on map load and when building the Captain's Quarters

### DIFF
--- a/src/fheroes2/castle/captain.cpp
+++ b/src/fheroes2/castle/captain.cpp
@@ -188,8 +188,6 @@ void Captain::ActionAfterBattle()
 
 void Captain::ActionPreBattle()
 {
-    SetSpellPoints( GetMaxSpellPoints() );
-
     spell_book.resetState();
 }
 

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -354,8 +354,10 @@ void Castle::PostLoad()
     army.SetColor( GetColor() );
 
     // fix captain
-    if ( building & BUILD_CAPTAIN )
+    if ( building & BUILD_CAPTAIN ) {
         captain.LoadDefaults( HeroBase::CAPTAIN, race );
+        captain.SetSpellPoints( captain.GetMaxSpellPoints() );
+}
 
     // MageGuild
     mageguild.initialize( race, HaveLibraryCapability() );
@@ -1462,6 +1464,7 @@ bool Castle::BuyBuilding( uint32_t build )
 
     case BUILD_CAPTAIN:
         captain.LoadDefaults( HeroBase::CAPTAIN, race );
+        captain.SetSpellPoints( captain.GetMaxSpellPoints() );
         if ( GetLevelMageGuild() )
             MageGuildEducateHero( captain );
         break;

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -357,7 +357,7 @@ void Castle::PostLoad()
     if ( building & BUILD_CAPTAIN ) {
         captain.LoadDefaults( HeroBase::CAPTAIN, race );
         captain.SetSpellPoints( captain.GetMaxSpellPoints() );
-}
+    }
 
     // MageGuild
     mageguild.initialize( race, HaveLibraryCapability() );


### PR DESCRIPTION
Close #6132 

This PR adds setting captain's Spell Points to max on map load for castles where the Captain's Quarters is already built and when building the Captain's Quarters in a castle. It also removes the pre-battle setting max Spell Points setting.

Since the intialization of 'captain' is different for random and non-random races, this operation cannot be performed in 'captain' class constructor and in the 'LoadDefaults' function.