### PR TITLE
Use parabolic catapult projectile flight trajectory

### DIFF
--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -310,7 +310,7 @@ namespace fheroes2
         return res;
     }
 
-    std::vector<Point> GetArcPoints( const Point & from, const Point & to, const double arcHeight, const int32_t step )
+    std::vector<Point> GetArcPoints( const Point & from, const Point & to, const int32_t arcHeight, const int32_t step )
     {
         std::vector<Point> res;
         Point pt( from );

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -316,19 +316,20 @@ namespace fheroes2
         Point pt( from );
         res.push_back( pt );
 
+        const int32_t steps = ( to.x - from.x ) / step;
         const double x1 = from.x;
         const double y1 = from.y;
         const double dx = to.x - x1;
         const double dy = to.y - y1;
-        const double maxy = maxHeight - y1;
+        const double dh = maxHeight - y1;
 
-        const double a = -4 * maxy / dx / dx;
-        const double b = 4 * maxy * ( dx + 2 * x1 ) / dx / dx;
-        const double c = y1 - 4 * maxy * x1 * x1 / dx / dx - 4 * maxy * x1 / dx;
+        const double a = -4 * dh / dx / dx;
+        const double b = dy / dx - a  * ( dx + 2 * x1 );
+        const double c = y1 + a * x1 * ( dx + x1 )  - x1 * dy / dx;
 
-        for ( int32_t i = 1; i <= ( dx / step ); i++ ) {
+        for ( int32_t i = 1; i <= steps; i++ ) {
             pt.x = pt.x + step;
-            pt.y = static_cast<int32_t>( std::lround( a * pt.x * pt.x + b * pt.x + c + ( pt.x - x1 ) * dy / dx ) );
+            pt.y = static_cast<int32_t>( std::lround( a * pt.x * pt.x + b * pt.x + c ) );
             res.push_back( pt );
         }
 

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -310,23 +310,27 @@ namespace fheroes2
         return res;
     }
 
-    std::vector<Point> GetArcPoints( const Point & from, const Point & to, const Point & max, const int32_t step )
+    std::vector<Point> GetArcPoints( const Point & from, const Point & to, const int32_t maxHeight, const int32_t step )
     {
         std::vector<Point> res;
+        Point pt( from );
+        res.push_back( pt );
 
-        Point tempPoint( from.x + std::abs( max.x - from.x ) / 2, from.y - std::abs( max.y - from.y ) * 3 / 4 );
-        std::vector<Point> points = GetLinePoints( from, tempPoint, step );
-        res.insert( res.end(), points.begin(), points.end() );
+        const double x1 = from.x;
+        const double y1 = from.y;
+        const double dx = to.x - x1;
+        const double dy = to.y - y1;
+        const double maxy = maxHeight - y1;
 
-        points = GetLinePoints( tempPoint, max, step );
-        res.insert( res.end(), points.begin(), points.end() );
+        const double a = - 4 * maxy / dx / dx;
+        const double b = 4 * maxy * ( dx + 2 * x1 ) / dx / dx;
+        const double c = y1 - 4 * maxy * x1 * x1 / dx / dx - 4 * maxy * x1 / dx;
 
-        tempPoint = { max.x + std::abs( to.x - max.x ) / 2, to.y - std::abs( to.y - max.y ) * 3 / 4 };
-        points = GetLinePoints( max, tempPoint, step );
-        res.insert( res.end(), points.begin(), points.end() );
-
-        points = GetLinePoints( tempPoint, to, step );
-        res.insert( res.end(), points.begin(), points.end() );
+        for ( int32_t i = 1; i <= ( dx / step ); i++ ) {
+            pt.x = pt.x + step;
+            pt.y = int32_t( a * pt.x * pt.x + b * pt.x + c + ( pt.x - x1) * dy / dx + 0.5 );
+            res.push_back( pt );
+        }
 
         return res;
     }

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -324,8 +324,8 @@ namespace fheroes2
         const double dh = maxHeight - y1;
 
         const double a = -4 * dh / dx / dx;
-        const double b = dy / dx - a  * ( dx + 2 * x1 );
-        const double c = y1 + a * x1 * ( dx + x1 )  - x1 * dy / dx;
+        const double b = dy / dx - a * ( dx + 2 * x1 );
+        const double c = y1 + a * x1 * ( dx + x1 ) - x1 * dy / dx;
 
         for ( int32_t i = 1; i <= steps; i++ ) {
             pt.x = pt.x + step;

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -323,7 +323,7 @@ namespace fheroes2
         // Trajectory start point coordinates
         const double x1 = from.x;
         const double y1 = from.y;
-        
+
         // Distance to the destination point along the axes
         const double dx = to.x - x1;
         const double dy = to.y - y1;

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -322,13 +322,13 @@ namespace fheroes2
         const double dy = to.y - y1;
         const double maxy = maxHeight - y1;
 
-        const double a = - 4 * maxy / dx / dx;
+        const double a = -4 * maxy / dx / dx;
         const double b = 4 * maxy * ( dx + 2 * x1 ) / dx / dx;
         const double c = y1 - 4 * maxy * x1 * x1 / dx / dx - 4 * maxy * x1 / dx;
 
         for ( int32_t i = 1; i <= ( dx / step ); i++ ) {
             pt.x = pt.x + step;
-            pt.y = int32_t( a * pt.x * pt.x + b * pt.x + c + ( pt.x - x1) * dy / dx + 0.5 );
+            pt.y = static_cast<int32_t>( std::lround( a * pt.x * pt.x + b * pt.x + c + ( pt.x - x1 ) * dy / dx ) );
             res.push_back( pt );
         }
 

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -310,7 +310,7 @@ namespace fheroes2
         return res;
     }
 
-    std::vector<Point> GetArcPoints( const Point & from, const Point & to, const int32_t arcHeight, const int32_t step )
+    std::vector<Point> GetArcPoints( const Point & from, const Point & to, const double arcHeight, const int32_t step )
     {
         std::vector<Point> res;
         Point pt( from );
@@ -343,12 +343,12 @@ namespace fheroes2
         // parabola ('dy/dx' in 'b' constant and '-x1*dy/dx' in 'c' constant).
 
         // Calculation of the parabola equation coefficients
-        const double a = 4 * static_cast<double>( arcHeight ) / dx / dx;
+        const double a = 4 * arcHeight / dx / dx;
         const double b = dy / dx - a * ( dx + 2 * x1 );
         const double c = y1 + a * x1 * ( dx + x1 ) - x1 * dy / dx;
 
         for ( int32_t i = 1; i <= steps; ++i ) {
-            pt.x = pt.x + step;
+            pt.x += step;
             pt.y = static_cast<int32_t>( std::lround( a * pt.x * pt.x + b * pt.x + c ) );
             res.push_back( pt );
         }

--- a/src/engine/tools.h
+++ b/src/engine/tools.h
@@ -70,7 +70,7 @@ namespace fheroes2
     double GetAngle( const Point & start, const Point & target );
     std::vector<Point> GetEuclideanLine( const Point & pt1, const Point & pt2, const uint32_t step );
     std::vector<Point> GetLinePoints( const Point & pt1, const Point & pt2, const int32_t step );
-    std::vector<Point> GetArcPoints( const Point & from, const Point & to, const int32_t arcHeight, const int32_t step );
+    std::vector<Point> GetArcPoints( const Point & from, const Point & to, const double arcHeight, const int32_t step );
 
     int32_t GetRectIndex( const std::vector<Rect> & rects, const Point & pt );
 

--- a/src/engine/tools.h
+++ b/src/engine/tools.h
@@ -70,7 +70,7 @@ namespace fheroes2
     double GetAngle( const Point & start, const Point & target );
     std::vector<Point> GetEuclideanLine( const Point & pt1, const Point & pt2, const uint32_t step );
     std::vector<Point> GetLinePoints( const Point & pt1, const Point & pt2, const int32_t step );
-    std::vector<Point> GetArcPoints( const Point & from, const Point & to, const double arcHeight, const int32_t step );
+    std::vector<Point> GetArcPoints( const Point & from, const Point & to, const int32_t arcHeight, const int32_t step );
 
     int32_t GetRectIndex( const std::vector<Rect> & rects, const Point & pt );
 

--- a/src/engine/tools.h
+++ b/src/engine/tools.h
@@ -70,7 +70,7 @@ namespace fheroes2
     double GetAngle( const Point & start, const Point & target );
     std::vector<Point> GetEuclideanLine( const Point & pt1, const Point & pt2, const uint32_t step );
     std::vector<Point> GetLinePoints( const Point & pt1, const Point & pt2, const int32_t step );
-    std::vector<Point> GetArcPoints( const Point & from, const Point & to, const Point & max, const int32_t step );
+    std::vector<Point> GetArcPoints( const Point & from, const Point & to, const int32_t maxHeight, const int32_t step );
 
     int32_t GetRectIndex( const std::vector<Rect> & rects, const Point & pt );
 

--- a/src/engine/tools.h
+++ b/src/engine/tools.h
@@ -70,7 +70,7 @@ namespace fheroes2
     double GetAngle( const Point & start, const Point & target );
     std::vector<Point> GetEuclideanLine( const Point & pt1, const Point & pt2, const uint32_t step );
     std::vector<Point> GetLinePoints( const Point & pt1, const Point & pt2, const int32_t step );
-    std::vector<Point> GetArcPoints( const Point & from, const Point & to, const int32_t maxHeight, const int32_t step );
+    std::vector<Point> GetArcPoints( const Point & from, const Point & to, const int32_t arcHeight, const int32_t step );
 
     int32_t GetRectIndex( const std::vector<Rect> & rects, const Point & pt );
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4010,7 +4010,7 @@ void Battle::Interface::RedrawActionCatapult( int target, bool hit )
     // boulder animation
     fheroes2::Point pt1( 40, 290 );
     fheroes2::Point pt2 = Catapult::GetTargetPosition( target, hit );
-    const int32_t boulderArcHeight = 205;
+    const double boulderArcHeight = 0.55 * getDistance( pt1, pt2 );
     const int32_t boulderArcStep = ( pt2.x - pt1.x ) / 30;
 
     pt1.x += area.x;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4008,9 +4008,9 @@ void Battle::Interface::RedrawActionCatapult( int target, bool hit )
     }
 
     // boulder animation
-    fheroes2::Point pt1( 40, 290 );
+    fheroes2::Point pt1( 30, 290 );
     fheroes2::Point pt2 = Catapult::GetTargetPosition( target, hit );
-    const double boulderArcHeight = 0.55 * getDistance( pt1, pt2 );
+    const int32_t boulderArcHeight = ( target == 8 ) ? 300 : 210;
     const int32_t boulderArcStep = ( pt2.x - pt1.x ) / 30;
 
     pt1.x += area.x;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3998,7 +3998,7 @@ void Battle::Interface::RedrawActionCatapult( int target, bool hit )
     AudioManager::PlaySound( M82::CATSND00 );
 
     // catapult animation
-    while ( le.HandleEvents( false ) && catapult_frame < 6 ) {
+    while ( le.HandleEvents( false ) && catapult_frame < 5 ) {
         CheckGlobalEvents( le );
 
         if ( Game::validateAnimationDelay( Game::BATTLE_CATAPULT_DELAY ) ) {
@@ -4008,19 +4008,17 @@ void Battle::Interface::RedrawActionCatapult( int target, bool hit )
     }
 
     // boulder animation
-    fheroes2::Point pt1( 90, 220 );
+    fheroes2::Point pt1( 40, 290 );
     fheroes2::Point pt2 = Catapult::GetTargetPosition( target, hit );
-    fheroes2::Point max( 300, 20 );
+    const int32_t maxHeight = 120;
 
     pt1.x += area.x;
     pt2.x += area.x;
-    max.x += area.x;
     pt1.y += area.y;
     pt2.y += area.y;
-    max.y += area.y;
 
     const fheroes2::Sprite & boulderFirstFrame = fheroes2::AGG::GetICN( ICN::BOULDER, 0 );
-    const std::vector<fheroes2::Point> points = GetArcPoints( pt1, pt2, max, boulderFirstFrame.width() );
+    const std::vector<fheroes2::Point> points = GetArcPoints( pt1, pt2, maxHeight, boulderFirstFrame.width() );
     std::vector<fheroes2::Point>::const_iterator pnt = points.begin();
 
     uint32_t boulderFrameId = 0;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4011,7 +4011,7 @@ void Battle::Interface::RedrawActionCatapult( int target, bool hit )
     fheroes2::Point pt1( 40, 290 );
     fheroes2::Point pt2 = Catapult::GetTargetPosition( target, hit );
     const int32_t boulderArcHeight = 205;
-    const int32_t boulderArcStep = 12;
+    const int32_t boulderArcStep = ( pt2.x - pt1.x ) / 30;
 
     pt1.x += area.x;
     pt2.x += area.x;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4010,7 +4010,7 @@ void Battle::Interface::RedrawActionCatapult( int target, bool hit )
     // boulder animation
     fheroes2::Point pt1( 40, 290 );
     fheroes2::Point pt2 = Catapult::GetTargetPosition( target, hit );
-    const int32_t maxHeight = 120;
+    const int32_t trajectoryHeight = 205;
 
     pt1.x += area.x;
     pt2.x += area.x;
@@ -4018,7 +4018,7 @@ void Battle::Interface::RedrawActionCatapult( int target, bool hit )
     pt2.y += area.y;
 
     const fheroes2::Sprite & boulderFirstFrame = fheroes2::AGG::GetICN( ICN::BOULDER, 0 );
-    const std::vector<fheroes2::Point> points = GetArcPoints( pt1, pt2, maxHeight, boulderFirstFrame.width() );
+    const std::vector<fheroes2::Point> points = GetArcPoints( pt1, pt2, trajectoryHeight, boulderFirstFrame.width() );
     std::vector<fheroes2::Point>::const_iterator pnt = points.begin();
 
     uint32_t boulderFrameId = 0;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4010,8 +4010,38 @@ void Battle::Interface::RedrawActionCatapult( int target, bool hit )
     // boulder animation
     fheroes2::Point pt1( 30, 290 );
     fheroes2::Point pt2 = Catapult::GetTargetPosition( target, hit );
-    const int32_t boulderArcHeight = ( target == 8 ) ? 300 : 210;
     const int32_t boulderArcStep = ( pt2.x - pt1.x ) / 30;
+
+    // set the projectile arc height for each castle target and a formula for an unknown target
+    int32_t boulderArcHeight;
+    switch ( target ) {
+    case Battle::CAT_WALL1:
+        boulderArcHeight = 220;
+        break;
+    case Battle::CAT_WALL2:
+        boulderArcHeight = 216;
+        break;
+    case Battle::CAT_WALL3:
+        boulderArcHeight = 204;
+        break;
+    case Battle::CAT_WALL4:
+        boulderArcHeight = 208;
+        break;
+    case Battle::CAT_TOWER1:
+        boulderArcHeight = 206;
+        break;
+    case Battle::CAT_TOWER2:
+        boulderArcHeight = 206;
+        break;
+    case Battle::CAT_BRIDGE:
+        boulderArcHeight = 216;
+        break;
+    case Battle::CAT_CENTRAL_TOWER:
+        boulderArcHeight = 290;
+        break;
+    default:
+        boulderArcHeight = static_cast<int32_t>( std::lround( 0.55 * getDistance( pt1, pt2 ) ) );
+    }
 
     pt1.x += area.x;
     pt2.x += area.x;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4010,15 +4010,15 @@ void Battle::Interface::RedrawActionCatapult( int target, bool hit )
     // boulder animation
     fheroes2::Point pt1( 40, 290 );
     fheroes2::Point pt2 = Catapult::GetTargetPosition( target, hit );
-    const int32_t trajectoryHeight = 205;
+    const int32_t boulderArcHeight = 205;
+    const int32_t boulderArcStep = 12;
 
     pt1.x += area.x;
     pt2.x += area.x;
     pt1.y += area.y;
     pt2.y += area.y;
 
-    const fheroes2::Sprite & boulderFirstFrame = fheroes2::AGG::GetICN( ICN::BOULDER, 0 );
-    const std::vector<fheroes2::Point> points = GetArcPoints( pt1, pt2, trajectoryHeight, boulderFirstFrame.width() );
+    const std::vector<fheroes2::Point> points = GetArcPoints( pt1, pt2, boulderArcHeight, boulderArcStep );
     std::vector<fheroes2::Point>::const_iterator pnt = points.begin();
 
     uint32_t boulderFrameId = 0;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4019,6 +4019,7 @@ void Battle::Interface::RedrawActionCatapult( int target, bool hit )
         boulderArcHeight = 220;
         break;
     case Battle::CAT_WALL2:
+    case Battle::CAT_BRIDGE:
         boulderArcHeight = 216;
         break;
     case Battle::CAT_WALL3:
@@ -4028,13 +4029,8 @@ void Battle::Interface::RedrawActionCatapult( int target, bool hit )
         boulderArcHeight = 208;
         break;
     case Battle::CAT_TOWER1:
-        boulderArcHeight = 206;
-        break;
     case Battle::CAT_TOWER2:
         boulderArcHeight = 206;
-        break;
-    case Battle::CAT_BRIDGE:
-        boulderArcHeight = 216;
         break;
     case Battle::CAT_CENTRAL_TOWER:
         boulderArcHeight = 290;


### PR DESCRIPTION
close #6079 

I changed the catapult stone trajectory calculation function to calculate a ballistic parabolic trajectory:

https://user-images.githubusercontent.com/113276641/201529496-6eb15855-f046-44c3-97c7-4de6194c04b6.mp4

It calculates the porabolic trajectory for the same target height as the height of the catapult. And for aiming at a specific target, a linear trajectory has been added.

PS
There is one more issue left (not fixed in this PR): the wall (or tower) disappears (destroys) only after the smoke animation, and should disapper in the middle of this animation.
I can call `break;` in the middle of the smoke cloud animation and call a new function to end the smoke animation after the wall is set to destroyed state. But this will duplicate the smoke animation code and I don't think it's a good solution.