### PR TITLE
Make the castle: allow guardians option by default

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1748,6 +1748,7 @@ namespace AI
             const auto it = _priorityTargets.find( tileIndex );
             if ( it != _priorityTargets.end() ) {
                 if ( it->second == PriorityTask::DEFEND ) {
+                    // TODO: consider making this hero a castle guardian if possible
                     hero.SetModes( Heroes::SLEEPER );
                 }
 

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -217,7 +217,7 @@ namespace AI
 
         const uint32_t regionID = world.GetTiles( castle.GetIndex() ).GetRegion();
         // check if we should leave some troops in the garrison
-        // TODO: amount of troops left could depend on region's safetyFactor
+        // TODO: amount of troops left could depend on region's safetyFactor as well as on the presence of a guardian hero (if supported)
         if ( castle.isCastle() && _regions[regionID].safetyFactor <= 100 && !garrison.isValid() ) {
             const Heroes::Role heroRole = hero.getAIRole();
             const bool isFigtherHero = ( heroRole == Heroes::Role::FIGHTER || heroRole == Heroes::Role::CHAMPION );
@@ -616,6 +616,7 @@ namespace AI
                 const int mapIndex = castle->GetIndex();
 
                 // Make sure there is no hero in castle already and we're not under threat while having other heroes.
+                // TODO: consider the ability to have both a guest and a guardian hero in the same castle.
                 if ( hero != nullptr || ( availableHeroCount > 0 && castlesInDanger.find( mapIndex ) != castlesInDanger.end() ) )
                     continue;
 

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -826,11 +826,11 @@ bool Castle::AllowBuyHero( std::string * msg ) const
     CastleHeroes heroes = world.GetHeroes( *this );
 
     if ( heroes.Guest() ) {
-        // allow recruit with auto move guest to guard
-        if ( Settings::Get().ExtCastleAllowGuardians() && !heroes.Guard() ) {
+        // If we already have a guest hero, we still can hire a new hero if we can merge the garrison troops with the army of the guest hero
+        if ( heroes.Guard() == nullptr ) {
             if ( !heroes.Guest()->GetArmy().CanJoinTroops( army ) ) {
                 if ( msg )
-                    *msg = _( "Cannot recruit - guest to guard automove error." );
+                    *msg = _( "Cannot recruit - unable to combine the garrison troops with the army of the guest hero." );
                 return false;
             }
         }
@@ -864,8 +864,8 @@ Heroes * Castle::RecruitHero( Heroes * hero )
 
     CastleHeroes heroes = world.GetHeroes( *this );
     if ( heroes.Guest() ) {
-        if ( Settings::Get().ExtCastleAllowGuardians() && !heroes.Guard() ) {
-            // move guest to guard
+        if ( heroes.Guard() == nullptr ) {
+            // Make the guest hero a castle guardian
             SwapCastleHeroes( heroes );
         }
         else
@@ -2326,7 +2326,7 @@ double Castle::GetGarrisonStrength( const Heroes * attackingHero ) const
     if ( heroes.Guest() ) {
         totalStrength += heroes.Guest()->GetArmy().GetStrength();
     }
-    if ( Settings::Get().ExtCastleAllowGuardians() && heroes.Guard() ) {
+    if ( heroes.Guard() ) {
         totalStrength += heroes.Guard()->GetArmy().GetStrength();
     }
     else {

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -195,8 +195,13 @@ public:
     Army & GetArmy();
     const Army & GetActualArmy() const;
     Army & GetActualArmy();
-    double GetGarrisonStrength( const Heroes * attackingHero ) const;
     uint32_t getMonstersInDwelling( uint32_t ) const;
+
+    // Returns the garrison strength estimation calculated as if the attacking hero really attacked this castle
+    // - including estimation of garrison / guardian hero's army strength, as well as guest hero army strength,
+    // castle-specific bonuses from moat and towers and so on, relative to the attacking hero's abilities. See
+    // the implementation for details.
+    double GetGarrisonStrength( const Heroes * attackingHero ) const;
 
     // Returns the correct dwelling type available in the castle. BUILD_NOTHING is returned if this is not a dwelling.
     uint32_t GetActualDwelling( const uint32_t buildId ) const;

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -265,9 +265,9 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readOnly, const b
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
     // Fade screen.
-    const Settings & conf = Settings::Get();
-    if ( Settings::ExtGameUseFade() )
+    if ( Settings::ExtGameUseFade() ) {
         fheroes2::FadeDisplay();
+    }
 
     const fheroes2::StandardWindow background( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
 
@@ -457,7 +457,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readOnly, const b
                 need_redraw = true;
             }
 
-            if ( conf.ExtCastleAllowGuardians() && !readOnly ) {
+            if ( !readOnly ) {
                 Army * army1 = nullptr;
                 Army * army2 = nullptr;
 

--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -162,7 +162,6 @@ void Dialog::ExtSettings( bool readonly )
     states.push_back( Settings::HEROES_BUY_BOOK_FROM_SHRINES );
     states.push_back( Settings::HEROES_REMEMBER_MP_WHEN_RETREATING );
     states.push_back( Settings::HEROES_ARENA_ANY_SKILLS );
-    states.push_back( Settings::CASTLE_ALLOW_GUARDIANS );
     states.push_back( Settings::BATTLE_SOFT_WAITING );
 
     std::sort( states.begin(), states.end(), []( uint32_t first, uint32_t second ) { return Settings::ExtName( first ) > Settings::ExtName( second ); } );

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1814,13 +1814,13 @@ Heroes * AllHeroes::GetGuest( const Castle & castle ) const
 
 Heroes * AllHeroes::GetGuard( const Castle & castle ) const
 {
-    const_iterator it = Settings::Get().ExtCastleAllowGuardians() ? std::find_if( begin(), end(),
-                                                                                  [&castle]( const Heroes * hero ) {
-                                                                                      const fheroes2::Point & cpt = castle.GetCenter();
-                                                                                      const fheroes2::Point & hpt = hero->GetCenter();
-                                                                                      return cpt.x == hpt.x && cpt.y == hpt.y + 1 && hero->Modes( Heroes::GUARDIAN );
-                                                                                  } )
-                                                                  : end();
+    const_iterator it = std::find_if( begin(), end(), [&castle]( const Heroes * hero ) {
+        const fheroes2::Point & cpt = castle.GetCenter();
+        const fheroes2::Point & hpt = hero->GetCenter();
+
+        return cpt.x == hpt.x && cpt.y == hpt.y + 1 && hero->Modes( Heroes::GUARDIAN );
+    } );
+
     return end() != it ? *it : nullptr;
 }
 

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -29,11 +29,12 @@ enum SaveFileFormat : uint16_t
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
 
     // 10000 value must be used for 1.0 release so all version before it should have lower than this value.
+    FORMAT_VERSION_PRE_1000_RELEASE = 9960,
     FORMAT_VERSION_0921_RELEASE = 9950,
     FORMAT_VERSION_0920_RELEASE = 9940,
     FORMAT_VERSION_0919_RELEASE = 9930,
 
     LAST_SUPPORTED_FORMAT_VERSION = FORMAT_VERSION_0919_RELEASE,
 
-    CURRENT_FORMAT_VERSION = FORMAT_VERSION_0921_RELEASE
+    CURRENT_FORMAT_VERSION = FORMAT_VERSION_PRE_1000_RELEASE
 };

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -923,8 +923,6 @@ std::string Settings::ExtName( const uint32_t settingId )
         return _( "world: allow to set guardian to objects" );
     case Settings::WORLD_EXT_OBJECTS_CAPTURED:
         return _( "world: Windmills, Water Wheels and Magic Gardens can be captured" );
-    case Settings::CASTLE_ALLOW_GUARDIANS:
-        return _( "castle: allow guardians" );
     case Settings::HEROES_BUY_BOOK_FROM_SHRINES:
         return _( "heroes: allow buy a spellbook from Shrines" );
     case Settings::HEROES_REMEMBER_MP_WHEN_RETREATING:

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -96,7 +96,7 @@ public:
         // UNUSED = 0x20010000,
         // UNUSED = 0x20020000,
         // UNUSED = 0x20040000,
-        CASTLE_ALLOW_GUARDIANS = 0x20080000,
+        // UNUSED = 0x20080000,
         // UNUSED = 0x20800000,
         HEROES_REMEMBER_MP_WHEN_RETREATING = 0x21000000,
 
@@ -292,11 +292,6 @@ public:
     bool ExtWorldExtObjectsCaptured() const
     {
         return ExtModes( WORLD_EXT_OBJECTS_CAPTURED );
-    }
-
-    bool ExtCastleAllowGuardians() const
-    {
-        return ExtModes( CASTLE_ALLOW_GUARDIANS );
     }
 
     bool ExtBattleShowDamage() const


### PR DESCRIPTION
Alternative approach to #6190
Related to #6161

This option is supported well enough both in the game logic and game UI, some efforts have been made to polish it and it would be a pity to throw it all away. AI doesn't know how to perceive its benefits for now, but at least it doesn't conflict with this feature.

After all, we already have changes in the core that affect the overall game balance even more - for example, the ability to hire non-upgraded units in the upgraded dwellings.