### PR TITLE
Remove the world: Scouting skill shows extended content info option

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -30,6 +30,7 @@
 #include <ostream>
 #include <random>
 #include <set>
+#include <utility>
 
 #include "army.h"
 #include "army_troop.h"

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -173,39 +173,6 @@ std::string Army::SizeString( uint32_t size )
     return {};
 }
 
-std::pair<uint32_t, uint32_t> Army::SizeRange( const uint32_t count )
-{
-    if ( count < ARMY_SEVERAL ) {
-        return { ARMY_FEW, ARMY_SEVERAL };
-    }
-    if ( count < ARMY_PACK ) {
-        return { ARMY_SEVERAL, ARMY_PACK };
-    }
-    if ( count < ARMY_LOTS ) {
-        return { ARMY_PACK, ARMY_LOTS };
-    }
-    if ( count < ARMY_HORDE ) {
-        return { ARMY_LOTS, ARMY_HORDE };
-    }
-    if ( count < ARMY_THRONG ) {
-        return { ARMY_HORDE, ARMY_THRONG };
-    }
-    if ( count < ARMY_SWARM ) {
-        return { ARMY_THRONG, ARMY_SWARM };
-    }
-    if ( count < ARMY_ZOUNDS ) {
-        return { ARMY_SWARM, ARMY_ZOUNDS };
-    }
-    if ( count < ARMY_LEGION ) {
-        return { ARMY_ZOUNDS, ARMY_LEGION };
-    }
-    if ( count < 5000 ) {
-        return { ARMY_LEGION, 5000 };
-    }
-
-    return { 5000, UINT32_MAX };
-}
-
 Troops::Troops( const Troops & troops )
     : std::vector<Troop *>()
 {
@@ -1443,30 +1410,33 @@ bool Army::isMeleeDominantArmy() const
     return meleeInfantry > other;
 }
 
-// draw MONS32 sprite in line, first valid = 0, count = 0
-void Army::drawMiniMonsLine( const Troops & troops, int32_t cx, int32_t cy, uint32_t width, uint32_t first, uint32_t count )
+void Army::drawSingleDetailedMonsterLine( const Troops & troops, int32_t cx, int32_t cy, uint32_t width )
 {
-    fheroes2::drawMiniMonsters( troops, cx, cy, width, first, count, Skill::Level::EXPERT, false, true, fheroes2::Display::instance() );
+    fheroes2::drawMiniMonsters( troops, cx, cy, width, 0, 0, false, true, false, 0, fheroes2::Display::instance() );
 }
 
-void Army::DrawMonsterLines( const Troops & troops, int32_t posX, int32_t posY, uint32_t lineWidth, uint32_t drawType, bool compact, bool isScouteView )
+void Army::drawMultipleMonsterLines( const Troops & troops, int32_t posX, int32_t posY, uint32_t lineWidth, bool isCompact, const bool isDetailedView,
+                                     const bool isGarrisonView /* = false */, const uint32_t thievesGuildsCount /* = 0 */ )
 {
     const uint32_t count = troops.GetOccupiedSlotCount();
     const int offsetX = lineWidth / 6;
-    const int offsetY = compact ? 31 : 49;
+    const int offsetY = isCompact ? 31 : 49;
 
     fheroes2::Image & output = fheroes2::Display::instance();
 
     if ( count < 3 ) {
-        fheroes2::drawMiniMonsters( troops, posX + offsetX, posY + offsetY / 2 + 1, lineWidth * 2 / 3, 0, 0, drawType, compact, isScouteView, output );
+        fheroes2::drawMiniMonsters( troops, posX + offsetX, posY + offsetY / 2 + 1, lineWidth * 2 / 3, 0, 0, isCompact, isDetailedView, isGarrisonView,
+                                    thievesGuildsCount, output );
     }
     else {
         const int firstLineTroopCount = 2;
         const int secondLineTroopCount = count - firstLineTroopCount;
         const int secondLineWidth = secondLineTroopCount == 2 ? lineWidth * 2 / 3 : lineWidth;
 
-        fheroes2::drawMiniMonsters( troops, posX + offsetX, posY, lineWidth * 2 / 3, 0, firstLineTroopCount, drawType, compact, isScouteView, output );
-        fheroes2::drawMiniMonsters( troops, posX, posY + offsetY, secondLineWidth, firstLineTroopCount, secondLineTroopCount, drawType, compact, isScouteView, output );
+        fheroes2::drawMiniMonsters( troops, posX + offsetX, posY, lineWidth * 2 / 3, 0, firstLineTroopCount, isCompact, isDetailedView, isGarrisonView,
+                                    thievesGuildsCount, output );
+        fheroes2::drawMiniMonsters( troops, posX, posY + offsetY, secondLineWidth, firstLineTroopCount, secondLineTroopCount, isCompact, isDetailedView, isGarrisonView,
+                                    thievesGuildsCount, output );
     }
 }
 

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -158,8 +158,6 @@ public:
     static std::string SizeString( uint32_t );
     static std::string TroopSizeString( const Troop & );
 
-    static std::pair<uint32_t, uint32_t> SizeRange( const uint32_t count );
-
     // Comparison functions
     static bool WeakestTroop( const Troop *, const Troop * );
     static bool StrongestTroop( const Troop *, const Troop * );
@@ -170,9 +168,9 @@ public:
 
     static NeutralMonsterJoiningCondition GetJoinSolution( const Heroes &, const Maps::Tiles &, const Troop & );
 
-    static void drawMiniMonsLine( const Troops & troops, int32_t cx, int32_t cy, uint32_t width, uint32_t first = 0, uint32_t count = 0 );
-    static void DrawMonsterLines( const Troops & troops, int32_t posX, int32_t posY, uint32_t lineWidth, uint32_t drawType, bool compact = true,
-                                  bool isScouteView = true );
+    static void drawSingleDetailedMonsterLine( const Troops & troops, int32_t cx, int32_t cy, uint32_t width );
+    static void drawMultipleMonsterLines( const Troops & troops, int32_t posX, int32_t posY, uint32_t lineWidth, bool isCompact, const bool isDetailedView,
+                                          const bool isGarrisonView = false, const uint32_t thievesGuildsCount = 0 );
 
     explicit Army( HeroBase * s = nullptr );
     explicit Army( const Maps::Tiles & );

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -28,7 +28,6 @@
 #include <cstdint>
 #include <functional>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "monster.h"

--- a/src/fheroes2/army/army_ui_helper.cpp
+++ b/src/fheroes2/army/army_ui_helper.cpp
@@ -18,6 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <cassert>
 #include <cstddef>
 
 #include "agg_image.h"
@@ -29,8 +30,8 @@
 #include "image.h"
 #include "ui_text.h"
 
-void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, int32_t cy, uint32_t width, uint32_t first, uint32_t count, uint32_t drawPower, bool compact,
-                                 bool isScouteView, Image & output )
+void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_t cy, const uint32_t width, uint32_t first, uint32_t count, const bool isCompact,
+                                 const bool isDetailedView, const bool isGarrisonView, const uint32_t thievesGuildsCount, Image & output )
 {
     if ( !troops.isValid() ) {
         return;
@@ -41,7 +42,8 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, int32_t cy, 
     }
 
     const int chunk = width / count;
-    if ( !compact ) {
+
+    if ( !isCompact ) {
         cx += chunk / 2;
     }
 
@@ -54,13 +56,28 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, int32_t cy, 
             --first;
             continue;
         }
-        const fheroes2::Sprite & monster = fheroes2::AGG::GetICN( ICN::MONS32, troop->GetSpriteIndex() );
-        fheroes2::Text text( isScouteView ? Game::formatMonsterCount( troop->GetCount(), drawPower, compact ) : Game::CountThievesGuild( troop->GetCount(), drawPower ),
-                             fheroes2::FontType::smallWhite() );
 
-        // This is the drawing of army troops in compact form in the small info window beneath resources,
-        // as well as for castle troops when a hero is set as guardian (:experimental option).
-        if ( compact ) {
+        std::string monstersCountRepresentation;
+
+        if ( isDetailedView || !isGarrisonView ) {
+            monstersCountRepresentation = Game::formatMonsterCount( troop->GetCount(), isDetailedView, isCompact );
+        }
+        else {
+            assert( thievesGuildsCount > 0 );
+
+            if ( thievesGuildsCount == 1 ) {
+                monstersCountRepresentation = "???";
+            }
+            else {
+                monstersCountRepresentation = Army::SizeString( troop->GetCount() );
+            }
+        }
+
+        const fheroes2::Sprite & monster = fheroes2::AGG::GetICN( ICN::MONS32, troop->GetSpriteIndex() );
+        fheroes2::Text text( monstersCountRepresentation, fheroes2::FontType::smallWhite() );
+
+        // This is the drawing of army troops in compact form in the small info window beneath resources
+        if ( isCompact ) {
             const int offsetY = ( monster.height() < 37 ) ? 37 - monster.height() : 0;
             int offset = ( chunk - monster.width() - text.width() ) / 2;
             if ( offset < 0 )

--- a/src/fheroes2/army/army_ui_helper.cpp
+++ b/src/fheroes2/army/army_ui_helper.cpp
@@ -20,6 +20,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <string>
 
 #include "agg_image.h"
 #include "army.h"

--- a/src/fheroes2/army/army_ui_helper.h
+++ b/src/fheroes2/army/army_ui_helper.h
@@ -28,6 +28,6 @@ namespace fheroes2
 {
     class Image;
 
-    void drawMiniMonsters( const Troops & troops, int32_t cx, int32_t cy, uint32_t width, uint32_t first, uint32_t count, uint32_t drawPower, bool compact,
-                           bool isScouteView, Image & output );
+    void drawMiniMonsters( const Troops & troops, int32_t cx, const int32_t cy, const uint32_t width, uint32_t first, uint32_t count, const bool isCompact,
+                           const bool isDetailedView, const bool isGarrisonView, const uint32_t thievesGuildsCount, Image & output );
 }

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -509,7 +509,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     text.Blit( pos_rt.x + ( pos_rt.width - text.w() ) / 2, pos_rt.y + 285 );
 
     if ( killed1.isValid() )
-        Army::drawMiniMonsLine( killed1, pos_rt.x + 25, pos_rt.y + 303, 270 );
+        Army::drawSingleDetailedMonsterLine( killed1, pos_rt.x + 25, pos_rt.y + 303, 270 );
     else {
         text.Set( _( "None" ), Font::SMALL );
         text.Blit( pos_rt.x + ( pos_rt.width - text.w() ) / 2, pos_rt.y + 300 );
@@ -520,7 +520,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     text.Blit( pos_rt.x + ( pos_rt.width - text.w() ) / 2, pos_rt.y + 345 );
 
     if ( killed2.isValid() )
-        Army::drawMiniMonsLine( killed2, pos_rt.x + 25, pos_rt.y + 363, 270 );
+        Army::drawSingleDetailedMonsterLine( killed2, pos_rt.x + 25, pos_rt.y + 363, 270 );
     else {
         text.Set( _( "None" ), Font::SMALL );
         text.Blit( pos_rt.x + ( pos_rt.width - text.w() ) / 2, pos_rt.y + 360 );

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -31,7 +31,6 @@
 #include "agg_image.h"
 #include "army.h"
 #include "army_troop.h"
-#include "artifact.h"
 #include "artifact_ultimate.h"
 #include "captain.h"
 #include "castle.h"

--- a/src/fheroes2/dialog/dialog_settings.cpp
+++ b/src/fheroes2/dialog/dialog_settings.cpp
@@ -157,7 +157,6 @@ void Dialog::ExtSettings( bool readonly )
     states.push_back( Settings::GAME_AUTOSAVE_BEGIN_DAY );
     states.push_back( Settings::WORLD_ALLOW_SET_GUARDIAN );
     states.push_back( Settings::WORLD_EXT_OBJECTS_CAPTURED );
-    states.push_back( Settings::WORLD_SCOUTING_EXTENDED );
     states.push_back( Settings::HEROES_BUY_BOOK_FROM_SHRINES );
     states.push_back( Settings::HEROES_ARENA_ANY_SKILLS );
     states.push_back( Settings::BATTLE_SOFT_WAITING );

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -491,89 +491,13 @@ int Game::GetActualKingdomColors()
     return Settings::Get().GetPlayers().GetActualColors();
 }
 
-std::string Game::formatMonsterCount( const uint32_t count, const int scoutingLevel, const bool abbreviateNumber /* = false */ )
+std::string Game::formatMonsterCount( const uint32_t count, const bool isDetailedView, const bool abbreviateNumber /* = false */ )
 {
-    switch ( scoutingLevel ) {
-    case Skill::Level::BASIC:
-    case Skill::Level::ADVANCED: {
-        // Always use abbreviated numbers for ranges, otherwise the string might become too long
-        auto formatString = []( const uint32_t min, const uint32_t max ) {
-            const std::string minStr = fheroes2::abbreviateNumber( min );
-            const std::string maxStr = fheroes2::abbreviateNumber( max );
-
-            if ( minStr == maxStr ) {
-                return '~' + minStr;
-            }
-
-            return minStr + '-' + maxStr;
-        };
-
-        const auto [min, max] = Army::SizeRange( count );
-        assert( min <= max );
-
-        // Open range without upper bound
-        if ( max == UINT32_MAX ) {
-            return fheroes2::abbreviateNumber( min ) + '+';
-        }
-
-        // With basic scouting level, the range is divided in half and the part of the range into
-        // which the monster count falls is returned
-        if ( scoutingLevel == Skill::Level::BASIC ) {
-            const uint32_t half = min + ( max - min ) / 2;
-
-            if ( count < half ) {
-                return formatString( min, half );
-            }
-
-            return formatString( half, max );
-        }
-
-        // With advanced scouting level, the range is divided into four parts and the part of the
-        // range into which the monster count falls is returned
-        if ( scoutingLevel == Skill::Level::ADVANCED ) {
-            const uint32_t firstQuarter = min + ( max - min ) / 4;
-
-            if ( count < firstQuarter ) {
-                return formatString( min, firstQuarter );
-            }
-
-            const uint32_t secondQuarter = min + ( max - min ) / 2;
-
-            if ( count < secondQuarter ) {
-                return formatString( firstQuarter, secondQuarter );
-            }
-
-            const uint32_t thirdQuarter = min + ( max - min ) / 2 + ( max - min ) / 4;
-
-            if ( count < thirdQuarter ) {
-                return formatString( secondQuarter, thirdQuarter );
-            }
-
-            return formatString( thirdQuarter, max );
-        }
-
-        // We shouldn't be here
-        assert( 0 );
-
-        break;
-    }
-
-    // With expert scouting level, the exact monster count is returned (possibly in abbreviated form)
-    case Skill::Level::EXPERT:
+    if ( isDetailedView ) {
         return ( abbreviateNumber ? fheroes2::abbreviateNumber( count ) : std::to_string( count ) );
-
-    default:
-        break;
     }
 
-    // Otherwise we just return the approximate string representation (Few, Several, Pack, ...)
     return Army::SizeString( count );
-}
-
-std::string Game::CountThievesGuild( uint32_t monsterCount, int guildCount )
-{
-    assert( guildCount > 0 );
-    return guildCount == 1 ? "???" : Army::SizeString( monsterCount );
 }
 
 void Game::PlayPickupSound()

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -54,7 +54,6 @@
 #include "rand.h"
 #include "save_format_version.h"
 #include "settings.h"
-#include "skill.h"
 #include "tools.h"
 #include "world.h"
 

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -118,11 +118,10 @@ namespace Game
     std::string GetSaveFileExtension( const int gameType );
 
     int32_t GetStep4Player( const int32_t currentId, const int32_t width, const int32_t totalCount );
-    std::string CountThievesGuild( uint32_t monsterCount, int guildCount );
 
-    // Returns the string representation of the monster count, formatted according to the scouting level (possibly in
-    // abbreviated form), suitable for use with the WORLD_SCOUTING_EXTENDED option. See the implementation for details.
-    std::string formatMonsterCount( const uint32_t count, const int scoutingLevel, const bool abbreviateNumber = false );
+    // Returns the string representation of the monster count. If a detailed view is requested, the exact number is returned
+    // (unless the abbreviated number is requested), otherwise, a qualitative estimate is returned (Few, Several, etc).
+    std::string formatMonsterCount( const uint32_t count, const bool isDetailedView, const bool abbreviateNumber = false );
 }
 
 #endif

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -42,7 +42,6 @@
 #include "resource.h"
 #include "screen.h"
 #include "settings.h"
-#include "skill.h"
 #include "text.h"
 #include "tools.h"
 #include "translations.h"

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -324,7 +324,7 @@ void Interface::StatusWindow::DrawArmyInfo( int oh ) const
 
     if ( armies ) {
         const fheroes2::Rect & pos = GetArea();
-        Army::DrawMonsterLines( *armies, pos.x + 4, pos.y + 1 + oh, 138, Skill::Level::EXPERT );
+        Army::drawMultipleMonsterLines( *armies, pos.x + 4, pos.y + 1 + oh, 138, true, true );
     }
 }
 

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -917,8 +917,6 @@ std::string Settings::ExtName( const uint32_t settingId )
     switch ( settingId ) {
     case Settings::GAME_BATTLE_SHOW_DAMAGE:
         return _( "battle: show damage info" );
-    case Settings::WORLD_SCOUTING_EXTENDED:
-        return _( "world: Scouting skill shows extended content info" );
     case Settings::WORLD_ALLOW_SET_GUARDIAN:
         return _( "world: allow to set guardian to objects" );
     case Settings::WORLD_EXT_OBJECTS_CAPTURED:

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -83,7 +83,7 @@ public:
         // UNUSED = 0x20000002,
         WORLD_ALLOW_SET_GUARDIAN = 0x20000008,
         // UNUSED = 0x20000020,
-        WORLD_SCOUTING_EXTENDED = 0x20000040,
+        // UNUSED = 0x20000040,
         // UNUSED = 0x20000080,
         // UNUSED = 0x20000100,
         HEROES_BUY_BOOK_FROM_SHRINES = 0x20000200,
@@ -272,11 +272,6 @@ public:
     bool ExtHeroArenaCanChoiseAnySkills() const
     {
         return ExtModes( HEROES_ARENA_ANY_SKILLS );
-    }
-
-    bool ExtWorldScouteExtended() const
-    {
-        return ExtModes( WORLD_SCOUTING_EXTENDED );
     }
 
     bool ExtWorldAllowSetGuardian() const


### PR DESCRIPTION
Related to #6161

The previous logic was somewhat overcomplicated and confusing due to the need to focus on the scouting skill level in lots of places, I hope I didn't miss anything. It would be good to additionally test the new logic in different situations with artifacts that affect object info visibility (Crystal Ball?) to ensure that I didn't miss something in the mechanics.