### PR TITLE
Add SDLCALL to callbacks used by SDL, remove the SDL_SetEventFilter()

### DIFF
--- a/iwyu.map
+++ b/iwyu.map
@@ -1,7 +1,9 @@
 [
-    { include: [ "<bits/getopt_core.h>",     private, "<unistd.h>", public ] },
-    { include: [ "<bits/std_abs.h>",         private, "<cmath>",    public ] },
-    { include: [ "<bits/std_abs.h>",         private, "<cstdlib>",  public ] },
-    { include: [ "<bits/types/struct_tm.h>", private, "<ctime>",    public ] },
-    { include: [ "<ext/alloc_traits.h>",     private, "<memory>",   public ] }
+    { include: [ "<bits/getopt_core.h>",     private, "<unistd.h>",     public ] },
+    { include: [ "<bits/std_abs.h>",         private, "<cmath>",        public ] },
+    { include: [ "<bits/std_abs.h>",         private, "<cstdlib>",      public ] },
+    { include: [ "<bits/types/struct_tm.h>", private, "<ctime>",        public ] },
+    { include: [ "<ext/alloc_traits.h>",     private, "<memory>",       public ] },
+
+    { include: [ "\"begin_code.h\"",         private, "<SDL_stdinc.h>", public ] }
 ]

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -184,7 +184,11 @@ namespace
 
     // This is the callback function set by Mix_ChannelFinished(). As a rule, it is called from
     // a SDL_Mixer internal thread. Calls of any SDL_Mixer functions are not allowed in callbacks.
+#if SDL_VERSION_ATLEAST( 2, 0, 0 )
+    void SDLCALL channelFinished( const int channelId )
+#else
     void channelFinished( const int channelId )
+#endif
     {
         // This callback function should never be called if audio is not initialized
         assert( isInitialized );
@@ -506,7 +510,11 @@ namespace
 
     // This is the callback function set by Mix_HookMusicFinished(). As a rule, it is called from
     // a SDL_Mixer internal thread. Calls of any SDL_Mixer functions are not allowed in callbacks.
+#if SDL_VERSION_ATLEAST( 2, 0, 0 )
+    void SDLCALL musicFinished()
+#else
     void musicFinished()
+#endif
     {
         // This callback function should never be called if audio is not initialized
         assert( isInitialized );

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -39,6 +39,7 @@
 #include <SDL_error.h>
 #include <SDL_mixer.h>
 #include <SDL_rwops.h>
+#include <SDL_stdinc.h>
 #include <SDL_version.h>
 
 #include "audio.h"

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -935,8 +935,8 @@ LocalEvent::LocalEvent()
     : modes( 0 )
     , key_value( fheroes2::Key::NONE )
     , mouse_button( 0 )
-    , redraw_cursor_func( nullptr )
-    , keyboard_filter_func( nullptr )
+    , mouse_motion_hook_func( nullptr )
+    , key_down_hook_func( nullptr )
     , loop_delay( 1 )
 {}
 
@@ -1327,8 +1327,8 @@ void LocalEvent::HandleTouchEvent( const SDL_TouchFingerEvent & event )
         mouse_cu.x = static_cast<int32_t>( _emulatedPointerPosX );
         mouse_cu.y = static_cast<int32_t>( _emulatedPointerPosY );
 
-        if ( ( modes & MOUSE_MOTION ) && redraw_cursor_func ) {
-            ( *redraw_cursor_func )( mouse_cu.x, mouse_cu.y );
+        if ( ( modes & MOUSE_MOTION ) && mouse_motion_hook_func ) {
+            ( *mouse_motion_hook_func )( mouse_cu.x, mouse_cu.y );
         }
 
         if ( event.type == SDL_FINGERDOWN ) {
@@ -1511,8 +1511,8 @@ void LocalEvent::ProcessControllerAxisMotion()
         mouse_cu.x = static_cast<int32_t>( _emulatedPointerPosX );
         mouse_cu.y = static_cast<int32_t>( _emulatedPointerPosY );
 
-        if ( ( modes & MOUSE_MOTION ) && redraw_cursor_func ) {
-            ( *redraw_cursor_func )( mouse_cu.x, mouse_cu.y );
+        if ( ( modes & MOUSE_MOTION ) && mouse_motion_hook_func ) {
+            ( *mouse_motion_hook_func )( mouse_cu.x, mouse_cu.y );
         }
     }
 
@@ -1562,6 +1562,10 @@ void LocalEvent::HandleKeyboardEvent( const SDL_KeyboardEvent & event )
     if ( event.type == SDL_KEYDOWN ) {
         SetModes( KEY_PRESSED );
         SetModes( KEY_HOLD );
+
+        if ( key_down_hook_func ) {
+            ( *( key_down_hook_func ) )( event.keysym.sym, event.keysym.mod );
+        }
     }
     else if ( event.type == SDL_KEYUP ) {
         ResetModes( KEY_PRESSED );
@@ -1578,6 +1582,10 @@ void LocalEvent::HandleMouseMotionEvent( const SDL_MouseMotionEvent & motion )
     mouse_cu.y = motion.y;
     _emulatedPointerPosX = mouse_cu.x;
     _emulatedPointerPosY = mouse_cu.y;
+
+    if ( mouse_motion_hook_func ) {
+        ( *( mouse_motion_hook_func ) )( motion.x, motion.y );
+    }
 }
 
 void LocalEvent::HandleMouseButtonEvent( const SDL_MouseButtonEvent & button )
@@ -1742,30 +1750,6 @@ int LocalEvent::KeyMod() const
     return SDL_GetModState();
 }
 
-#if SDL_VERSION_ATLEAST( 2, 0, 0 )
-int SDLCALL LocalEvent::GlobalFilterEvents( void * /*userdata*/, SDL_Event * event )
-#else
-int SDLCALL LocalEvent::GlobalFilterEvents( const SDL_Event * event )
-#endif
-{
-    const LocalEvent & le = LocalEvent::Get();
-
-    if ( SDL_MOUSEMOTION == event->type ) {
-        // Redraw cursor.
-        if ( le.redraw_cursor_func ) {
-            ( *( le.redraw_cursor_func ) )( event->motion.x, event->motion.y );
-        }
-    }
-    else if ( SDL_KEYDOWN == event->type ) {
-        // Process key press event.
-        if ( le.keyboard_filter_func ) {
-            ( *( le.keyboard_filter_func ) )( event->key.keysym.sym, event->key.keysym.mod );
-        }
-    }
-
-    return 1;
-}
-
 void LocalEvent::SetState( const uint32_t type, const bool enable )
 {
     // SDL 1 and SDL 2 have different input argument types for event state.
@@ -1808,15 +1792,11 @@ void LocalEvent::SetStateDefaults()
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
     SetState( SDL_WINDOWEVENT, true );
-
-    SDL_SetEventFilter( GlobalFilterEvents, nullptr );
 #else
     SetState( SDL_ACTIVEEVENT, true );
 
     SetState( SDL_SYSWMEVENT, false );
     SetState( SDL_VIDEORESIZE, false );
     SetState( SDL_VIDEOEXPOSE, false );
-
-    SDL_SetEventFilter( GlobalFilterEvents );
 #endif
 }

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1743,9 +1743,9 @@ int LocalEvent::KeyMod() const
 }
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
-int LocalEvent::GlobalFilterEvents( void * /*userdata*/, SDL_Event * event )
+int SDLCALL LocalEvent::GlobalFilterEvents( void * /*userdata*/, SDL_Event * event )
 #else
-int LocalEvent::GlobalFilterEvents( const SDL_Event * event )
+int SDLCALL LocalEvent::GlobalFilterEvents( const SDL_Event * event )
 #endif
 {
     const LocalEvent & le = LocalEvent::Get();

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -29,6 +29,7 @@
 #include <string>
 
 #include <SDL_events.h>
+#include <SDL_stdinc.h>
 #include <SDL_version.h>
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -29,7 +29,6 @@
 #include <string>
 
 #include <SDL_events.h>
-#include <SDL_stdinc.h>
 #include <SDL_version.h>
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
@@ -174,14 +173,14 @@ public:
     static LocalEvent & Get();
     static LocalEvent & GetClean(); // reset all previous event statuses and return a reference for events
 
-    void SetGlobalFilterMouseEvents( void ( *pf )( int32_t, int32_t ) )
+    void SetMouseMotionGlobalHook( void ( *pf )( int32_t, int32_t ) )
     {
-        redraw_cursor_func = pf;
+        mouse_motion_hook_func = pf;
     }
 
-    void SetGlobalFilterKeysEvents( void ( *pf )( int, int ) )
+    void SetKeyDownGlobalHook( void ( *pf )( int, int ) )
     {
-        keyboard_filter_func = pf;
+        key_down_hook_func = pf;
     }
 
     static void SetStateDefaults();
@@ -313,8 +312,6 @@ private:
     static void ResumeSounds();
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
-    static int SDLCALL GlobalFilterEvents( void *, SDL_Event * );
-
     void HandleMouseWheelEvent( const SDL_MouseWheelEvent & );
     void HandleControllerAxisEvent( const SDL_ControllerAxisEvent & motion );
     void HandleControllerButtonEvent( const SDL_ControllerButtonEvent & button );
@@ -323,8 +320,6 @@ private:
 
     static void OnSdl2WindowEvent( const SDL_Event & event );
 #else
-    static int SDLCALL GlobalFilterEvents( const SDL_Event * );
-
     void OnActiveEvent( const SDL_Event & event );
 #endif
 
@@ -365,8 +360,8 @@ private:
 
     fheroes2::Point mouse_wm; // wheel movement
 
-    void ( *redraw_cursor_func )( int32_t, int32_t );
-    void ( *keyboard_filter_func )( int, int );
+    void ( *mouse_motion_hook_func )( int32_t, int32_t );
+    void ( *key_down_hook_func )( int, int );
 
     uint32_t loop_delay;
 

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -312,7 +312,7 @@ private:
     static void ResumeSounds();
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
-    static int GlobalFilterEvents( void *, SDL_Event * );
+    static int SDLCALL GlobalFilterEvents( void *, SDL_Event * );
 
     void HandleMouseWheelEvent( const SDL_MouseWheelEvent & );
     void HandleControllerAxisEvent( const SDL_ControllerAxisEvent & motion );
@@ -322,7 +322,7 @@ private:
 
     static void OnSdl2WindowEvent( const SDL_Event & event );
 #else
-    static int GlobalFilterEvents( const SDL_Event * );
+    static int SDLCALL GlobalFilterEvents( const SDL_Event * );
 
     void OnActiveEvent( const SDL_Event & event );
 #endif

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -211,8 +211,8 @@ void Game::Init()
 
     // set global events
     LocalEvent & le = LocalEvent::Get();
-    le.SetGlobalFilterMouseEvents( Cursor::Redraw );
-    le.SetGlobalFilterKeysEvents( Game::KeyboardGlobalFilter );
+    le.SetMouseMotionGlobalHook( Cursor::Redraw );
+    le.SetKeyDownGlobalHook( Game::KeyDownGlobalHook );
 
     Game::AnimateDelaysInitialize();
 

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -365,7 +365,7 @@ void Game::HotKeySave()
     file.write( data.data(), data.size() );
 }
 
-void Game::KeyboardGlobalFilter( int sdlKey, int mod )
+void Game::KeyDownGlobalHook( int sdlKey, int mod )
 {
     if ( fheroes2::getKeyFromSDL( sdlKey ) == hotKeyEventInfo[hotKeyEventToInt( HotKeyEvent::SYSTEM_FULLSCREEN )].key
          && !( ( mod & KMOD_ALT ) || ( mod & KMOD_CTRL ) ) ) {

--- a/src/fheroes2/game/game_hotkeys.h
+++ b/src/fheroes2/game/game_hotkeys.h
@@ -161,7 +161,7 @@ namespace Game
 
     std::vector<Game::HotKeyEvent> getAllHotKeyEvents();
 
-    void KeyboardGlobalFilter( int sdlKey, int mod );
+    void KeyDownGlobalHook( int sdlKey, int mod );
 
     void HotKeysLoad( const std::string & filename );
 


### PR DESCRIPTION
Technically `SDLCALL` usually expands either to `__cdecl` or to an empty string, but not always. Also SDL_mixer 1.x doesn't require its callbacks to be `SDLCALL`, while SDL_mixer 2.x does.

Also I noticed that `SDL_SetEventFilter()` is used. Please do not ever use it - as rightly [stated in the documentation](https://wiki.libsdl.org/SDL_SetEventFilter), the callback function set by `SDL_SetEventFilter()` has the same issues as any other SDL callbacks - it might be called from an internal SDL thread! (remember SDL_mixer callbacks). So we can't reliably use it to redraw software cursor or switch the fullscreen mode. The only thing you can do safely in it is filter an event out from the event queue by returning 0, that's what this function is designed for. You can't access or alter any external data in the callback without the proper synchronization.

P.S. Hi @ihhub do we use any SDL callbacks anywhere else?