### PR TITLE
Rework SDL events handling

### DIFF
--- a/src/engine/core.cpp
+++ b/src/engine/core.cpp
@@ -124,6 +124,8 @@ namespace
         SDL_EnableKeyRepeat( SDL_DEFAULT_REPEAT_DELAY, SDL_DEFAULT_REPEAT_INTERVAL );
 #endif
 
+        LocalEvent::setEventProcessingStates();
+
         return true;
     }
 

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -25,6 +25,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <map>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -678,19 +679,19 @@ namespace
 #endif
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
-    std::map<uint32_t, bool> eventTypeStatus;
+    std::set<uint32_t> eventTypeStatus;
 
     void setEventProcessingState( const uint32_t eventType, const bool enable )
     {
-        eventTypeStatus[eventType] = enable;
+        eventTypeStatus.emplace( eventType );
         SDL_EventState( eventType, ( enable ? SDL_ENABLE : SDL_IGNORE ) );
     }
 #else
-    std::map<uint8_t, bool> eventTypeStatus;
+    std::set<uint8_t> eventTypeStatus;
 
     void setEventProcessingState( const uint8_t eventType, const bool enable )
     {
-        eventTypeStatus[eventType] = enable;
+        eventTypeStatus.emplace( eventType );
         SDL_EventState( eventType, ( enable ? SDL_ENABLE : SDL_IGNORE ) );
     }
 #endif

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1289,14 +1289,9 @@ bool LocalEvent::HandleEvents( bool delay, bool allowExit )
             }
             break;
         default:
-            if ( allowedEventTypes.count( event.type ) > 0 ) {
-                // If this assertion blows up then we included an event type but we didn't add logic for it.
-                assert( 0 );
-            }
-            else {
-                // If this assertion blows up then SDL might be broken as we disabled this event type.
-                assert( disabledEventTypes.count( event.type ) == 0 );
-            }
+            // If this assertion blows up then we included an event type but we didn't add logic for it.
+            assert( eventTypeStatus.count( event.type ) == 0 );
+
             // This is a new event type which we do not handle. It might have been added in a newer version of SDL.
             break;
         }

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -51,7 +51,6 @@
 
 #include "audio.h"
 #include "localevent.h"
-#include "logging.h"
 #include "pal.h"
 #include "screen.h"
 
@@ -1031,6 +1030,8 @@ void LocalEvent::OpenVirtualKeyboard()
 {
 #if defined( TARGET_PS_VITA )
     dpadInputActive = true;
+#elif defined( ANDROID )
+    // Here we should use SDL_StartTextInput() call to open a keyboard.
 #endif
 }
 
@@ -1038,6 +1039,8 @@ void LocalEvent::CloseVirtualKeyboard()
 {
 #if defined( TARGET_PS_VITA )
     dpadInputActive = false;
+#elif defined( ANDROID )
+    // Here we should use SDL_StopTextInput() call to close a keyboard.
 #endif
 }
 
@@ -1268,6 +1271,12 @@ bool LocalEvent::HandleEvents( bool delay, bool allowExit )
 
             break;
         }
+        case SDL_TEXTINPUT:
+            // Keyboard events on Android should be processed here. Use event.text.text to extract text input.
+            break;
+        case SDL_TEXTEDITING:
+            // An event when a user pressed a button on a keyboard. Not all buttons are supported. This event should be used mainly on Android devices.
+            break;
         case SDL_QUIT:
             if ( allowExit ) {
                 // Try to perform clear exit to catch all memory leaks, for example.
@@ -1305,8 +1314,10 @@ bool LocalEvent::HandleEvents( bool delay, bool allowExit )
             HandleMouseButtonEvent( event.button );
             break;
         case SDL_QUIT:
-            if ( allowExit )
-                return false; // try to perform clear exit to catch all memory leaks, for example
+            if ( allowExit ) {
+                // Try to perform clear exit to catch all memory leaks, for example.
+                return false;
+            }
             break;
         default:
             if ( allowedEventTypes.count( event.type ) > 0 ) {
@@ -1866,9 +1877,9 @@ void LocalEvent::setEventProcessingStates()
     setEventProcessingState( SDL_SYSWMEVENT, false );
     setEventProcessingState( SDL_KEYDOWN, true );
     setEventProcessingState( SDL_KEYUP, true );
-    // TODO: we don't process this event. Add the logic.
+    // SDL_TEXTINPUT and SDL_TEXTEDITING are enabled and disabled by SDL_StartTextInput() and SDL_StopTextInput() functions.
+    // Do not enable them here.
     setEventProcessingState( SDL_TEXTEDITING, false );
-    // TODO: we don't process this event. Add the logic.
     setEventProcessingState( SDL_TEXTINPUT, false );
     setEventProcessingState( SDL_KEYMAPCHANGED, false ); // supported from SDL 2.0.4
     // SDL_TEXTEDITING_EXT is supported only from SDL 2.0.22

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1823,6 +1823,11 @@ int LocalEvent::KeyMod() const
 void LocalEvent::setEventProcessingStates()
 {
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
+// The list below is based on event types which require >= SDL 2.0.5. Is there a reason why you want to compile with an older SDL version?
+#if !SDL_VERSION_ATLEAST( 2, 0, 5 )
+#error Minimal suppported SDL version is 2.0.5.
+#endif
+
     // Full list of events and their requirements can be found at https://wiki.libsdl.org/SDL_EventType
     setEventProcessingState( SDL_QUIT, true );
     // TODO: we don't process this event. Add the logic.

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1248,6 +1248,10 @@ bool LocalEvent::HandleEvents( bool delay, bool allowExit )
             HandleTouchEvent( event.tfinger );
 #endif
             break;
+        case SDL_RENDER_TARGETS_RESET:
+            // We need to just update the screen. This event usually happens when we switch between fullscreen and windowed modes.
+            fheroes2::Display::instance().render();
+            break;
         case SDL_QUIT:
             if ( allowExit ) {
                 // Try to perform clear exit to catch all memory leaks, for example.
@@ -1819,6 +1823,7 @@ int LocalEvent::KeyMod() const
 void LocalEvent::setEventProcessingStates()
 {
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
+    // Full list of events and their requirements can be found at https://wiki.libsdl.org/SDL_EventType
     setEventProcessingState( SDL_QUIT, true );
     // TODO: we don't process this event. Add the logic.
     setEventProcessingState( SDL_APP_TERMINATING, false );
@@ -1832,6 +1837,7 @@ void LocalEvent::setEventProcessingStates()
     setEventProcessingState( SDL_APP_WILLENTERFOREGROUND, false );
     // TODO: we don't process this event. Add the logic.
     setEventProcessingState( SDL_APP_DIDENTERFOREGROUND, false );
+    // SDL_LOCALECHANGED is supported from SDL 2.0.14
     // TODO: we don't process this event. Add the logic.
     setEventProcessingState( SDL_LOCALECHANGED, false );
     // TODO: we don't process this event. Add the logic.
@@ -1872,14 +1878,10 @@ void LocalEvent::setEventProcessingStates()
     setEventProcessingState( SDL_CONTROLLERDEVICEREMOVED, true );
     // TODO: verify why disabled processing of this event.
     setEventProcessingState( SDL_CONTROLLERDEVICEREMAPPED, false );
-    // TODO: verify why disabled processing of this event.
-    setEventProcessingState( SDL_CONTROLLERTOUCHPADDOWN, false );
-    // TODO: verify why disabled processing of this event.
-    setEventProcessingState( SDL_CONTROLLERTOUCHPADMOTION, false );
-    // TODO: verify why disabled processing of this event.
-    setEventProcessingState( SDL_CONTROLLERTOUCHPADUP, false );
-    // TODO: verify why disabled processing of this event.
-    setEventProcessingState( SDL_CONTROLLERSENSORUPDATE, false );
+    // SDL_CONTROLLERTOUCHPADDOWN is supported from SDL 2.0.14
+    // SDL_CONTROLLERTOUCHPADMOTION is supported from SDL 2.0.14
+    // SDL_CONTROLLERTOUCHPADUP is supported from SDL 2.0.14
+    // SDL_CONTROLLERSENSORUPDATE is supported from SDL 2.0.14
     setEventProcessingState( SDL_FINGERDOWN, true );
     setEventProcessingState( SDL_FINGERUP, true );
     setEventProcessingState( SDL_FINGERMOTION, true );
@@ -1902,12 +1904,10 @@ void LocalEvent::setEventProcessingStates()
     setEventProcessingState( SDL_AUDIODEVICEREMOVED, false ); // supported from SDL 2.0.4
     // TODO: verify why disabled processing of this event.
     setEventProcessingState( SDL_SENSORUPDATE, false );
-    // TODO: handle this event in order to avoid possible crashes when a render device has been changed.
-    setEventProcessingState( SDL_RENDER_TARGETS_RESET, false ); // supported from SDL 2.0.2
+    setEventProcessingState( SDL_RENDER_TARGETS_RESET, true ); // supported from SDL 2.0.2
     // TODO: handle this event in order to avoid possible crashes when a render device has been changed.
     setEventProcessingState( SDL_RENDER_DEVICE_RESET, false ); // supported from SDL 2.0.4
-    // TODO: verify why disabled processing of this event.
-    setEventProcessingState( SDL_POLLSENTINEL, false );
+    // SDL_POLLSENTINEL is supported from SDL 2.0.?
     // TODO: verify why disabled processing of this event.
     setEventProcessingState( SDL_USEREVENT, false );
 #else

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1846,7 +1846,7 @@ void LocalEvent::setEventProcessingStates()
     // TODO: we don't process this event. Add the logic.
     setEventProcessingState( SDL_TEXTINPUT, false );
     setEventProcessingState( SDL_KEYMAPCHANGED, false );
-    setEventProcessingState( SDL_TEXTEDITING_EXT, false );
+    // SDL_TEXTEDITING_EXT is supported only from SDL 2.0.22
     setEventProcessingState( SDL_MOUSEMOTION, true );
     setEventProcessingState( SDL_MOUSEBUTTONDOWN, true );
     setEventProcessingState( SDL_MOUSEBUTTONUP, true );

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1839,8 +1839,6 @@ void LocalEvent::setEventProcessingStates()
     setEventProcessingState( SDL_APP_DIDENTERFOREGROUND, false );
     // SDL_LOCALECHANGED is supported from SDL 2.0.14
     // TODO: we don't process this event. Add the logic.
-    setEventProcessingState( SDL_LOCALECHANGED, false );
-    // TODO: we don't process this event. Add the logic.
     setEventProcessingState( SDL_DISPLAYEVENT, false );
     setEventProcessingState( SDL_WINDOWEVENT, true );
     // TODO: verify why disabled processing of this event.

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -691,7 +691,7 @@ namespace
     void setEventProcessingState( const uint8_t eventType, const bool enable )
     {
         eventTypeStatus[eventType] = enable;
-        SDL_EventState( eventType, ( enable ? SDL_ENABLE : SDL_IGNORE ));
+        SDL_EventState( eventType, ( enable ? SDL_ENABLE : SDL_IGNORE ) );
     }
 #endif
 }

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1845,7 +1845,7 @@ void LocalEvent::setEventProcessingStates()
     setEventProcessingState( SDL_TEXTEDITING, false );
     // TODO: we don't process this event. Add the logic.
     setEventProcessingState( SDL_TEXTINPUT, false );
-    setEventProcessingState( SDL_KEYMAPCHANGED, false );
+    setEventProcessingState( SDL_KEYMAPCHANGED, false ); // supported from SDL 2.0.4
     // SDL_TEXTEDITING_EXT is supported only from SDL 2.0.22
     setEventProcessingState( SDL_MOUSEMOTION, true );
     setEventProcessingState( SDL_MOUSEBUTTONDOWN, true );
@@ -1894,18 +1894,18 @@ void LocalEvent::setEventProcessingStates()
     // We do not support drag and drop capability for the application.
     setEventProcessingState( SDL_DROPFILE, false );
     setEventProcessingState( SDL_DROPTEXT, false );
-    setEventProcessingState( SDL_DROPBEGIN, false );
-    setEventProcessingState( SDL_DROPCOMPLETE, false );
+    setEventProcessingState( SDL_DROPBEGIN, false ); // supported from SDL 2.0.5
+    setEventProcessingState( SDL_DROPCOMPLETE, false ); // supported from SDL 2.0.5
     // TODO: verify why disabled processing of this event.
-    setEventProcessingState( SDL_AUDIODEVICEADDED, false );
+    setEventProcessingState( SDL_AUDIODEVICEADDED, false ); // supported from SDL 2.0.4
     // TODO: verify why disabled processing of this event.
-    setEventProcessingState( SDL_AUDIODEVICEREMOVED, false );
+    setEventProcessingState( SDL_AUDIODEVICEREMOVED, false ); // supported from SDL 2.0.4
     // TODO: verify why disabled processing of this event.
     setEventProcessingState( SDL_SENSORUPDATE, false );
-    // TODO: verify why disabled processing of this event.
-    setEventProcessingState( SDL_RENDER_TARGETS_RESET, false );
-    // TODO: verify why disabled processing of this event.
-    setEventProcessingState( SDL_RENDER_DEVICE_RESET, false );
+    // TODO: handle this event in order to avoid possible crashes when a render device has been changed.
+    setEventProcessingState( SDL_RENDER_TARGETS_RESET, false ); // supported from SDL 2.0.2
+    // TODO: handle this event in order to avoid possible crashes when a render device has been changed.
+    setEventProcessingState( SDL_RENDER_DEVICE_RESET, false ); // supported from SDL 2.0.4
     // TODO: verify why disabled processing of this event.
     setEventProcessingState( SDL_POLLSENTINEL, false );
     // TODO: verify why disabled processing of this event.

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -51,7 +51,6 @@
 
 #include "audio.h"
 #include "localevent.h"
-#include "logging.h"
 #include "pal.h"
 #include "screen.h"
 
@@ -1188,7 +1187,7 @@ bool LocalEvent::HandleEvents( bool delay, bool allowExit )
     ResetModes( MOUSE_WHEEL );
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
-        while ( SDL_PollEvent( &event ) ) {
+    while ( SDL_PollEvent( &event ) ) {
         switch ( event.type ) {
         case SDL_WINDOWEVENT:
             if ( event.window.event == SDL_WINDOWEVENT_CLOSE ) {
@@ -1269,7 +1268,7 @@ bool LocalEvent::HandleEvents( bool delay, bool allowExit )
         }
     }
 #else
-        while ( SDL_PollEvent( &event ) ) {
+    while ( SDL_PollEvent( &event ) ) {
         switch ( event.type ) {
         case SDL_ACTIVEEVENT:
             OnActiveEvent( event.active );

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1911,7 +1911,7 @@ void LocalEvent::setEventProcessingStates()
     // TODO: handle this event in order to avoid possible crashes when a render device has been changed.
     setEventProcessingState( SDL_RENDER_DEVICE_RESET, false ); // supported from SDL 2.0.4
     // SDL_POLLSENTINEL is supported from SDL 2.0.?
-    // TODO: verify why disabled processing of this event.
+    // We do not support custom user events as of now.
     setEventProcessingState( SDL_USEREVENT, false );
 #else
     setEventProcessingState( SDL_ACTIVEEVENT, true );
@@ -1933,19 +1933,14 @@ void LocalEvent::setEventProcessingStates()
     setEventProcessingState( SDL_QUIT, true );
     // TODO: verify why disabled processing of this event.
     setEventProcessingState( SDL_SYSWMEVENT, false );
-    // SDL_EVENT_RESERVEDA
-    // SDL_EVENT_RESERVEDB
+    // SDL_EVENT_RESERVEDA is not in use.
+    // SDL_EVENT_RESERVEDB is not in use.
     // TODO: verify why disabled processing of this event.
     setEventProcessingState( SDL_VIDEORESIZE, false );
     // TODO: verify why disabled processing of this event.
     setEventProcessingState( SDL_VIDEOEXPOSE, false );
-    // SDL_EVENT_RESERVED2
-    // SDL_EVENT_RESERVED3
-    // SDL_EVENT_RESERVED4
-    // SDL_EVENT_RESERVED5
-    // SDL_EVENT_RESERVED6
-    // SDL_EVENT_RESERVED7
-    // TODO: verify why disabled processing of this event.
+    // SDL_EVENT_RESERVED2 - SDL_EVENT_RESERVED7 are not in use.
+    // We do not support custom user events as of now.
     setEventProcessingState( SDL_USEREVENT, false );
 #endif
 }

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -50,6 +50,7 @@
 #endif
 
 #include "audio.h"
+#include "image.h"
 #include "localevent.h"
 #include "pal.h"
 #include "screen.h"

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -183,7 +183,7 @@ public:
         key_down_hook_func = pf;
     }
 
-    static void SetStateDefaults();
+    static void setEventProcessingStates();
 
     bool HandleEvents( bool delay = true, bool allowExit = false );
 
@@ -302,8 +302,6 @@ public:
 private:
     LocalEvent();
 
-    static void SetState( const uint32_t type, const bool enable );
-
     void HandleMouseMotionEvent( const SDL_MouseMotionEvent & );
     void HandleMouseButtonEvent( const SDL_MouseButtonEvent & );
     void HandleKeyboardEvent( const SDL_KeyboardEvent & );
@@ -318,9 +316,9 @@ private:
     void ProcessControllerAxisMotion();
     void HandleTouchEvent( const SDL_TouchFingerEvent & event );
 
-    static void OnSdl2WindowEvent( const SDL_Event & event );
+    static void OnSdl2WindowEvent( const SDL_WindowEvent & event );
 #else
-    void OnActiveEvent( const SDL_Event & event );
+    void OnActiveEvent( const SDL_ActiveEvent & event );
 #endif
 
     enum flag_t

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -317,6 +317,8 @@ private:
     void HandleTouchEvent( const SDL_TouchFingerEvent & event );
 
     static void OnSdl2WindowEvent( const SDL_WindowEvent & event );
+
+    static void HandleRenderDeviceResetEvent();
 #else
     void OnActiveEvent( const SDL_ActiveEvent & event );
 #endif

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -389,9 +389,14 @@ namespace
 
         void update( const fheroes2::Image & image, int32_t offsetX, int32_t offsetY ) override
         {
-            fheroes2::Cursor::update( image, offsetX, offsetY );
+            if ( image.empty() ) {
+                // What are you trying to do? Set an invisible cursor? Use hide() method!
+                assert( 0 );
+                return;
+            }
 
             if ( _emulation ) {
+                fheroes2::Cursor::update( image, offsetX, offsetY );
                 return;
             }
 
@@ -435,6 +440,9 @@ namespace
             }
 
             SDL_Cursor * tempCursor = SDL_CreateColorCursor( surface, offsetX, offsetY );
+            if ( tempCursor == nullptr ) {
+                ERROR_LOG( "Failed to create a cursor. The error description: " << SDL_GetError() )
+            }
             SDL_SetCursor( tempCursor );
 
             const int returnCode = SDL_ShowCursor( _show ? SDL_ENABLE : SDL_DISABLE );
@@ -496,7 +504,7 @@ namespace
     private:
         SDL_Cursor * _cursor;
 
-        void clear() override
+        void clear()
         {
             if ( _cursor != nullptr ) {
                 SDL_FreeCursor( _cursor );
@@ -1414,7 +1422,6 @@ namespace fheroes2
 
         // deallocate engine resources
         _engine->clear();
-        _cursor->clear();
 
         _prevRoi = {};
 
@@ -1422,8 +1429,6 @@ namespace fheroes2
         if ( !_engine->allocate( width_, height_, isFullScreen ) ) {
             clear();
         }
-
-        _cursor->refresh();
 
         Image::resize( width_, height_ );
 
@@ -1513,7 +1518,7 @@ namespace fheroes2
     void Display::release()
     {
         _engine->clear();
-        _cursor->clear();
+        _cursor.reset();
         clear();
 
         _prevRoi = {};

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -443,7 +443,9 @@ namespace
             if ( tempCursor == nullptr ) {
                 ERROR_LOG( "Failed to create a cursor. The error description: " << SDL_GetError() )
             }
-            SDL_SetCursor( tempCursor );
+            else {
+                SDL_SetCursor( tempCursor );
+            }
 
             const int returnCode = SDL_ShowCursor( _show ? SDL_ENABLE : SDL_DISABLE );
             if ( returnCode < 0 ) {

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -453,8 +453,10 @@ namespace
             }
             SDL_FreeSurface( surface );
 
-            clear();
-            std::swap( _cursor, tempCursor );
+            if ( tempCursor != nullptr ) {
+                clear();
+                std::swap( _cursor, tempCursor );
+            }
         }
 
         void enableSoftwareEmulation( const bool enable ) override

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -389,8 +389,9 @@ namespace
 
         void update( const fheroes2::Image & image, int32_t offsetX, int32_t offsetY ) override
         {
+            fheroes2::Cursor::update( image, offsetX, offsetY );
+
             if ( _emulation ) {
-                fheroes2::Cursor::update( image, offsetX, offsetY );
                 return;
             }
 
@@ -495,7 +496,7 @@ namespace
     private:
         SDL_Cursor * _cursor;
 
-        void clear()
+        void clear() override
         {
             if ( _cursor != nullptr ) {
                 SDL_FreeCursor( _cursor );
@@ -1413,6 +1414,7 @@ namespace fheroes2
 
         // deallocate engine resources
         _engine->clear();
+        _cursor->clear();
 
         _prevRoi = {};
 
@@ -1420,6 +1422,8 @@ namespace fheroes2
         if ( !_engine->allocate( width_, height_, isFullScreen ) ) {
             clear();
         }
+
+        _cursor->refresh();
 
         Image::resize( width_, height_ );
 
@@ -1509,7 +1513,7 @@ namespace fheroes2
     void Display::release()
     {
         _engine->clear();
-        _cursor.reset();
+        _cursor->clear();
         clear();
 
         _prevRoi = {};

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -250,16 +250,6 @@ namespace fheroes2
             , _show( false )
             , _cursorUpdater( nullptr )
         {}
-
-        virtual void clear()
-        {
-            // Do nothin;
-        }
-
-        void refresh()
-        {
-            update( _image, _image.x(), _image.y() );
-        }
     };
 
     BaseRenderEngine & engine();

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -250,6 +250,16 @@ namespace fheroes2
             , _show( false )
             , _cursorUpdater( nullptr )
         {}
+
+        virtual void clear()
+        {
+            // Do nothin;
+        }
+
+        void refresh()
+        {
+            update( _image, _image.x(), _image.y() );
+        }
     };
 
     BaseRenderEngine & engine();

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -319,7 +319,11 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
     buttonCancel.draw();
 
     display.render();
-    le.OpenVirtualKeyboard();
+
+    if ( isEditing ) {
+        // Show keyboard only when editing file name.
+        le.OpenVirtualKeyboard();
+    }
 
     std::string result;
     bool is_limit = false;
@@ -423,7 +427,9 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
         display.render();
     }
 
-    le.CloseVirtualKeyboard();
+    if ( isEditing ) {
+        le.CloseVirtualKeyboard();
+    }
 
     return result;
 }

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -205,9 +205,6 @@ void Game::SetUpdateSoundsOnFocusUpdate( const bool update )
 
 void Game::Init()
 {
-    // default events
-    LocalEvent::SetStateDefaults();
-
     // set global events
     LocalEvent & le = LocalEvent::Get();
     le.SetMouseMotionGlobalHook( Cursor::Redraw );

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -317,7 +317,15 @@ bool Settings::Read( const std::string & filename )
     }
 
     if ( config.Exists( "monochrome cursor" ) ) {
-        setMonochromeCursor( config.StrParams( "monochrome cursor" ) == "on" );
+        // We cannot set cursor before initializing the system since we read a configuration file before initialization.
+        if ( config.StrParams( "monochrome cursor" ) == "on" ) {
+            _optGlobal.SetModes( GLOBAL_MONOCHROME_CURSOR );
+            Cursor::Get().setMonochromeCursor( true );
+        }
+        else {
+            _optGlobal.ResetModes( GLOBAL_MONOCHROME_CURSOR );
+            Cursor::Get().setMonochromeCursor( false );
+        }
     }
 
     if ( config.Exists( "3d audio" ) ) {


### PR DESCRIPTION
The current implementation of SDL events is a complete mess. We do not even handle most of events and these should be disabled to avoid extra processing. Proper separation of SDL1 and SDL 2 allows us to support the code without mind-bending hacks. The place where initialization of event types is initiated should be within core initialization code as it belongs there.

Moreover, I fixed the place where we update cursor before we even initialize the system.