### PR TITLE
Disable Adventure Map scrolling for handheld devices by default

### DIFF
--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -123,19 +123,40 @@ namespace
 
         // Scrolling speed.
         const int scrollSpeed = conf.ScrollSpeed();
-        uint32_t scrollSpeedIconId = 7;
-        if ( scrollSpeed < SCROLL_NORMAL ) {
-            scrollSpeedIconId = 4;
+        int32_t scrollSpeedIconIcn = ICN::UNKNOWN;
+        uint32_t scrollSpeedIconId = 0;
+        std::string scrollSpeedName;
+
+        if ( scrollSpeed == SCROLL_SPEED_NONE ) {
+            scrollSpeedName = _( "Off" );
+            scrollSpeedIconIcn = ICN::SPANEL;
+            scrollSpeedIconId = 9;
         }
-        else if ( scrollSpeed < SCROLL_FAST1 ) {
-            scrollSpeedIconId = 5;
+        else if ( scrollSpeed == SCROLL_SPEED_SLOW ) {
+            scrollSpeedName = _( "Slow" );
+            scrollSpeedIconIcn = ICN::CSPANEL;
+            scrollSpeedIconId = 0;
         }
-        else if ( scrollSpeed < SCROLL_FAST2 ) {
-            scrollSpeedIconId = 6;
+        else if ( scrollSpeed == SCROLL_SPEED_NORMAL ) {
+            scrollSpeedName = _( "Normal" );
+            scrollSpeedIconIcn = ICN::CSPANEL;
+            scrollSpeedIconId = 0;
+        }
+        else if ( scrollSpeed == SCROLL_SPEED_FAST ) {
+            scrollSpeedName = _( "Fast" );
+            scrollSpeedIconIcn = ICN::CSPANEL;
+            scrollSpeedIconId = 1;
+        }
+        else if ( scrollSpeed == SCROLL_SPEED_VERY_FAST ) {
+            scrollSpeedName = _( "Very Fast" );
+            scrollSpeedIconIcn = ICN::CSPANEL;
+            scrollSpeedIconId = 2;
         }
 
-        const fheroes2::Sprite & scrollSpeedIcon = fheroes2::AGG::GetICN( ICN::SPANEL, scrollSpeedIconId );
-        fheroes2::drawOption( rects[5], scrollSpeedIcon, _( "Scroll Speed" ), std::to_string( scrollSpeed ) );
+        assert( scrollSpeedIconIcn != ICN::UNKNOWN );
+
+        const fheroes2::Sprite & scrollSpeedIcon = fheroes2::AGG::GetICN( scrollSpeedIconIcn, scrollSpeedIconId );
+        fheroes2::drawOption( rects[5], scrollSpeedIcon, _( "Scroll Speed" ), scrollSpeedName );
 
         // Interface theme.
         const bool isEvilInterface = conf.ExtGameEvilInterface();
@@ -291,7 +312,7 @@ namespace
             // set scroll speed
             bool saveScrollSpeed = false;
             if ( le.MouseClickLeft( scrollSpeedRoi ) ) {
-                conf.SetScrollSpeed( conf.ScrollSpeed() % SCROLL_FAST2 + 1 );
+                conf.SetScrollSpeed( ( conf.ScrollSpeed() + 1 ) % ( SCROLL_SPEED_VERY_FAST + 1 ) );
                 saveScrollSpeed = true;
             }
             else if ( le.MouseWheelUp( scrollSpeedRoi ) ) {

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -924,7 +924,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
             break;
         }
 
-        if ( fheroes2::cursor().isFocusActive() && !gameArea.isDragScroll() && !radar.isDragRadar() ) {
+        if ( fheroes2::cursor().isFocusActive() && !gameArea.isDragScroll() && !radar.isDragRadar() && ( conf.ScrollSpeed() != SCROLL_SPEED_NONE ) ) {
             int scrollPosition = SCROLL_NONE;
 
             if ( isScrollLeft( le.GetMouseCursor() ) )

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -773,7 +773,14 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
 
 void Interface::GameArea::Scroll()
 {
-    const int32_t shift = 2 << Settings::Get().ScrollSpeed();
+    const int32_t scrollSpeed = Settings::Get().ScrollSpeed();
+    if ( scrollSpeed == SCROLL_SPEED_NONE ) {
+        // No scrolling.
+        scrollDirection = SCROLL_NONE;
+        return;
+    }
+
+    const int32_t shift = 2 << scrollSpeed;
     fheroes2::Point offset;
 
     if ( scrollDirection & SCROLL_LEFT ) {
@@ -792,7 +799,7 @@ void Interface::GameArea::Scroll()
 
     ShiftCenter( offset );
 
-    scrollDirection = 0;
+    scrollDirection = SCROLL_NONE;
 }
 
 void Interface::GameArea::SetRedraw() const

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -97,7 +97,7 @@ Settings::Settings()
     , _controllerPointerSpeed( 10 )
     , heroes_speed( DEFAULT_SPEED_DELAY )
     , ai_speed( DEFAULT_SPEED_DELAY )
-    , scroll_speed( SCROLL_NORMAL )
+    , scroll_speed( SCROLL_SPEED_NORMAL )
     , battle_speed( DEFAULT_BATTLE_SPEED )
     , game_type( 0 )
     , preferably_count_players( 0 )
@@ -118,6 +118,9 @@ Settings::Settings()
     if ( fheroes2::isHandheldDevice() ) {
         // Due to the nature of handheld devices having small screens in general it is good to make fullscreen option by default.
         _optGlobal.SetModes( GLOBAL_FULLSCREEN );
+
+        // Adventure Map scrolling is disabled by default for handheld devices as it is very hard to navigate on small screens. Use drag and move logic.
+        scroll_speed = SCROLL_SPEED_NONE;
     }
 
     // The Price of Loyalty is not supported by default.
@@ -405,7 +408,7 @@ std::string Settings::String() const
     os << std::endl << "# battle speed: 1 - 10" << std::endl;
     os << "battle speed = " << battle_speed << std::endl;
 
-    os << std::endl << "# scroll speed: 1 - 4" << std::endl;
+    os << std::endl << "# Adventure Map scrolling speed: 0 - 4. 0 means no scrolling" << std::endl;
     os << "scroll speed = " << scroll_speed << std::endl;
 
     os << std::endl << "# show battle grid: on/off" << std::endl;
@@ -719,10 +722,9 @@ void Settings::setSystemInfo( const bool enable )
     }
 }
 
-/* set scroll speed: 1 - 4 */
 void Settings::SetScrollSpeed( int speed )
 {
-    scroll_speed = std::clamp( speed, static_cast<int>( SCROLL_SLOW ), static_cast<int>( SCROLL_FAST2 ) );
+    scroll_speed = std::clamp( speed, static_cast<int>( SCROLL_SPEED_NONE ), static_cast<int>( SCROLL_SPEED_VERY_FAST ) );
 }
 
 bool Settings::isPriceOfLoyaltySupported() const

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -36,12 +36,13 @@
 
 class StreamBase;
 
-enum : int
+enum AdventureMapScrollSpeed : int
 {
-    SCROLL_SLOW = 1,
-    SCROLL_NORMAL = 2,
-    SCROLL_FAST1 = 3,
-    SCROLL_FAST2 = 4
+    SCROLL_SPEED_NONE = 0,
+    SCROLL_SPEED_SLOW = 1,
+    SCROLL_SPEED_NORMAL = 2,
+    SCROLL_SPEED_FAST = 3,
+    SCROLL_SPEED_VERY_FAST = 4
 };
 
 enum MusicSource


### PR DESCRIPTION
Make it as an option. Also change magic values of scrolling into more human readable strings.