### PR TITLE
Fix multiple issues with auxiliary functions from the engine

### DIFF
--- a/src/engine/dir.cpp
+++ b/src/engine/dir.cpp
@@ -81,7 +81,7 @@ namespace
                 continue;
             }
 
-            std::string fullname = System::ConcatePath( path, data.cFileName );
+            std::string fullname = System::concatPath( path, data.cFileName );
 
             // FindFirstFile() searches for both long and short variants of names, so we need additional filtering
             if ( filterByName( data.cFileName, nameAsFilter, name, _stricmp ) )
@@ -103,7 +103,7 @@ namespace
         // this means you use strlen() to get length of file name
         SceIoDirent dir;
         while ( sceIoDread( uid, &dir ) > 0 ) {
-            std::string fullname = System::ConcatePath( path, dir.d_name );
+            std::string fullname = System::concatPath( path, dir.d_name );
 
             // if not regular file
             if ( !SCE_S_ISREG( dir.d_stat.st_mode ) )
@@ -132,7 +132,7 @@ namespace
 
         const struct dirent * ep;
         while ( nullptr != ( ep = readdir( dp ) ) ) {
-            std::string fullname = System::ConcatePath( correctedPath, ep->d_name );
+            std::string fullname = System::concatPath( correctedPath, ep->d_name );
 
             // if not regular file
             if ( !System::IsFile( fullname ) )

--- a/src/engine/logging.cpp
+++ b/src/engine/logging.cpp
@@ -36,8 +36,7 @@
 
 namespace
 {
-    int g_debug = DBG_ALL_WARN + DBG_ALL_INFO;
-
+    int debugLevel = DBG_NONE;
     bool textSupportMode = false;
 
 #if defined( _WIN32 )
@@ -134,9 +133,14 @@ namespace Logging
 #endif
     }
 
-    void SetDebugLevel( const int debugLevel )
+    void setDebugLevel( const int level )
     {
-        g_debug = debugLevel;
+        debugLevel = level;
+    }
+
+    int getDebugLevel()
+    {
+        return debugLevel;
     }
 
     void setTextSupportMode( const bool enableTextSupportMode )
@@ -152,7 +156,7 @@ namespace Logging
 
 bool IS_DEBUG( const int name, const int level )
 {
-    return ( ( DBG_ENGINE & name ) && ( ( DBG_ENGINE & g_debug ) >> 2 ) >= level ) || ( ( DBG_GAME & name ) && ( ( DBG_GAME & g_debug ) >> 4 ) >= level )
-           || ( ( DBG_BATTLE & name ) && ( ( DBG_BATTLE & g_debug ) >> 6 ) >= level ) || ( ( DBG_AI & name ) && ( ( DBG_AI & g_debug ) >> 8 ) >= level )
-           || ( ( DBG_NETWORK & name ) && ( ( DBG_NETWORK & g_debug ) >> 10 ) >= level ) || ( ( DBG_DEVEL & name ) && ( ( DBG_DEVEL & g_debug ) >> 12 ) >= level );
+    return ( ( DBG_ENGINE & name ) && ( ( DBG_ENGINE & debugLevel ) >> 2 ) >= level ) || ( ( DBG_GAME & name ) && ( ( DBG_GAME & debugLevel ) >> 4 ) >= level )
+           || ( ( DBG_BATTLE & name ) && ( ( DBG_BATTLE & debugLevel ) >> 6 ) >= level ) || ( ( DBG_AI & name ) && ( ( DBG_AI & debugLevel ) >> 8 ) >= level )
+           || ( ( DBG_NETWORK & name ) && ( ( DBG_NETWORK & debugLevel ) >> 10 ) >= level ) || ( ( DBG_DEVEL & name ) && ( ( DBG_DEVEL & debugLevel ) >> 12 ) >= level );
 }

--- a/src/engine/logging.cpp
+++ b/src/engine/logging.cpp
@@ -125,6 +125,8 @@ namespace Logging
         const std::scoped_lock<std::mutex> lock( logMutex );
         const std::string logPath( System::concatPath( System::GetConfigDirectory( "fheroes2" ), "fheroes2.log" ) );
 
+        System::MakeDirectory( System::GetDirname( logPath ) );
+
         logFile.open( logPath, std::ofstream::out );
 #elif defined( MACOS_APP_BUNDLE )
         openlog( "fheroes2", LOG_CONS | LOG_NDELAY, LOG_USER );

--- a/src/engine/logging.cpp
+++ b/src/engine/logging.cpp
@@ -36,7 +36,7 @@
 
 namespace
 {
-    int debugLevel = DBG_NONE;
+    int debugLevel = DBG_ALL_WARN;
     bool textSupportMode = false;
 
 #if defined( _WIN32 )

--- a/src/engine/logging.cpp
+++ b/src/engine/logging.cpp
@@ -123,7 +123,7 @@ namespace Logging
         logFile.open( "fheroes2.log", std::ofstream::out );
 #elif defined( _WIN32 )
         const std::scoped_lock<std::mutex> lock( logMutex );
-        const std::string logPath( System::ConcatePath( System::GetConfigDirectory( "fheroes2" ), "fheroes2.log" ) );
+        const std::string logPath( System::concatPath( System::GetConfigDirectory( "fheroes2" ), "fheroes2.log" ) );
 
         logFile.open( logPath, std::ofstream::out );
 #elif defined( MACOS_APP_BUNDLE )

--- a/src/engine/logging.h
+++ b/src/engine/logging.h
@@ -27,8 +27,6 @@
 
 enum
 {
-    DBG_NONE = 0x0000,
-
     DBG_WARN = 0x0001,
     DBG_INFO = 0x0002,
     DBG_TRACE = 0x0003,

--- a/src/engine/logging.h
+++ b/src/engine/logging.h
@@ -27,6 +27,8 @@
 
 enum
 {
+    DBG_NONE = 0x0000,
+
     DBG_WARN = 0x0001,
     DBG_INFO = 0x0002,
     DBG_TRACE = 0x0003,
@@ -88,10 +90,10 @@ namespace Logging
     // Initialize logging. Some systems require writing logging information into a file.
     void InitLog();
 
-    void SetDebugLevel( const int debugLevel );
+    void setDebugLevel( const int level );
+    int getDebugLevel();
 
     void setTextSupportMode( const bool enableTextSupportMode );
-
     bool isTextSupportModeEnabled();
 }
 

--- a/src/engine/rand.cpp
+++ b/src/engine/rand.cpp
@@ -28,8 +28,8 @@
 
 std::mt19937 & Rand::CurrentThreadRandomDevice()
 {
-    thread_local static std::random_device s_rd;
-    thread_local static std::mt19937 s_gen( s_rd() );
+    thread_local std::random_device s_rd;
+    thread_local std::mt19937 s_gen( s_rd() );
     return s_gen;
 }
 

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -30,9 +30,21 @@
 #if defined( _WIN32 )
 #include <clocale>
 #include <map>
-#endif
 
-#include "system.h"
+#include <direct.h>
+#include <io.h>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
+#include <dirent.h>
+#include <unistd.h>
+
+#if defined( TARGET_PS_VITA )
+#include <psp2/io/stat.h>
+#else
+#include <sys/stat.h>
+#endif
+#endif
 
 #if defined( _WIN32 ) || defined( ANDROID )
 #include "logging.h"
@@ -52,30 +64,7 @@
 #include <SDL_stdinc.h>
 #endif
 
-#if defined( _WIN32 )
-#define WIN32_LEAN_AND_MEAN
-// clang-format off
-// shellapi.h must be included after windows.h
-#include <windows.h>
-#include <shellapi.h>
-// clang-format on
-#else
-#include <dirent.h>
-#endif
-
-#if defined( _WIN32 )
-#include <direct.h>
-#include <io.h>
-#else
-
-#if defined( TARGET_PS_VITA )
-#include <psp2/io/stat.h>
-#else
-#include <sys/stat.h>
-#endif
-
-#include <unistd.h>
-#endif
+#include "system.h"
 
 #if defined( _WIN32 )
 #define SEPARATOR '\\'

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
+#include <initializer_list>
 #include <utility>
 
 #if defined( _WIN32 )

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -314,27 +314,6 @@ std::string System::GetBasename( std::string_view path )
     return std::string{ path.substr( pos + 1 ) };
 }
 
-int System::GetCommandOptions( int argc, char * const argv[], const char * optstring )
-{
-#if defined( _WIN32 )
-    (void)argc;
-    (void)argv;
-    (void)optstring;
-    return -1;
-#else
-    return getopt( argc, argv, optstring );
-#endif
-}
-
-char * System::GetOptionsArgument()
-{
-#if defined( _WIN32 )
-    return nullptr;
-#else
-    return optarg;
-#endif
-}
-
 bool System::IsFile( const std::string & path, bool writable )
 {
     if ( path.empty() ) {

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -484,7 +484,7 @@ std::string System::FileNameToUTF8( const std::string & name )
         return name;
     }
 
-    static std::map<std::string, std::string> acpToUtf8;
+    thread_local std::map<std::string, std::string> acpToUtf8;
 
     const auto iter = acpToUtf8.find( name );
     if ( iter != acpToUtf8.end() ) {

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -63,6 +63,7 @@
 #endif
 
 #if defined( _WIN32 )
+#include <direct.h>
 #include <io.h>
 #else
 
@@ -81,15 +82,15 @@
 #define SEPARATOR '/'
 #endif
 
-#if !defined( __linux__ ) || defined( ANDROID )
 namespace
 {
+#if !defined( __linux__ ) || defined( ANDROID )
     std::string GetHomeDirectory( const std::string & prog )
     {
 #if defined( TARGET_PS_VITA )
-        return System::ConcatePath( "ux0:data", prog );
+        return System::concatPath( "ux0:data", prog );
 #elif defined( TARGET_NINTENDO_SWITCH )
-        return System::ConcatePath( "/switch", prog );
+        return System::concatPath( "/switch", prog );
 #elif defined( ANDROID )
         (void)prog;
 
@@ -107,19 +108,19 @@ namespace
 
 #if defined( MACOS_APP_BUNDLE )
         if ( homeEnvPath != nullptr ) {
-            return System::ConcatePath( System::ConcatePath( homeEnvPath, "Library/Preferences" ), prog );
+            return System::concatPath( System::concatPath( homeEnvPath, "Library/Preferences" ), prog );
         }
 
         return {};
 #endif
 
         if ( homeEnvPath != nullptr ) {
-            return System::ConcatePath( homeEnvPath, std::string( "." ).append( prog ) );
+            return System::concatPath( homeEnvPath, std::string( "." ).append( prog ) );
         }
 
         const char * dataEnvPath = getenv( "APPDATA" );
         if ( dataEnvPath != nullptr ) {
-            return System::ConcatePath( dataEnvPath, prog );
+            return System::concatPath( dataEnvPath, prog );
         }
 
         std::string res;
@@ -132,8 +133,43 @@ namespace
 #endif
         return res;
     }
-}
 #endif
+
+#if !defined( _WIN32 ) && !defined( ANDROID )
+    std::vector<std::string> splitUnixPath( const std::string & path, const std::string & delimiter )
+    {
+        std::vector<std::string> result;
+
+        if ( path.empty() ) {
+            return result;
+        }
+
+        size_t pos = path.find( delimiter, 0 );
+        while ( pos != std::string::npos ) { // while found delimiter
+            const size_t nextPos = path.find( delimiter, pos + 1 );
+            if ( nextPos != std::string::npos ) { // if found next delimiter
+                if ( pos + 1 < nextPos ) { // have what to append
+                    result.push_back( path.substr( pos + 1, nextPos - pos - 1 ) );
+                }
+            }
+            else { // if no more delimiter present
+                if ( pos + 1 < path.length() ) { // if not a postfix delimiter
+                    result.push_back( path.substr( pos + 1 ) );
+                }
+                break;
+            }
+
+            pos = path.find( delimiter, pos + 1 );
+        }
+
+        if ( result.empty() ) { // if delimiter not present
+            result.push_back( path );
+        }
+
+        return result;
+    }
+#endif
+}
 
 bool System::isHandheldDevice()
 {
@@ -144,26 +180,26 @@ bool System::isHandheldDevice()
 #endif
 }
 
-int System::MakeDirectory( const std::string & path )
+bool System::MakeDirectory( const std::string & path )
 {
 #if defined( _WIN32 )
-    return CreateDirectoryA( path.c_str(), nullptr );
+    return _mkdir( path.c_str() ) == 0;
 #elif defined( TARGET_PS_VITA )
-    return sceIoMkdir( path.c_str(), 0777 );
+    return sceIoMkdir( path.c_str(), 0777 ) == 0;
 #else
-    return mkdir( path.c_str(), S_IRWXU );
+    return mkdir( path.c_str(), S_IRWXU ) == 0;
 #endif
 }
 
-std::string System::ConcatePath( const std::string & str1, const std::string & str2 )
+std::string System::concatPath( const std::string & left, const std::string & right )
 {
     // Avoid memory allocation while concatenating string. Allocate needed size at once.
     std::string temp;
-    temp.reserve( str1.size() + 1 + str2.size() );
+    temp.reserve( left.size() + 1 + right.size() );
 
-    temp += str1;
+    temp += left;
     temp += SEPARATOR;
-    temp += str2;
+    temp += right;
 
     return temp;
 }
@@ -185,12 +221,12 @@ std::string System::GetConfigDirectory( const std::string & prog )
 #if defined( __linux__ ) && !defined( ANDROID )
     const char * configEnv = getenv( "XDG_CONFIG_HOME" );
     if ( configEnv ) {
-        return System::ConcatePath( configEnv, prog );
+        return System::concatPath( configEnv, prog );
     }
 
     const char * homeEnv = getenv( "HOME" );
     if ( homeEnv ) {
-        return System::ConcatePath( System::ConcatePath( homeEnv, ".config" ), prog );
+        return System::concatPath( System::concatPath( homeEnv, ".config" ), prog );
     }
 
     return std::string();
@@ -204,19 +240,19 @@ std::string System::GetDataDirectory( const std::string & prog )
 #if defined( __linux__ ) && !defined( ANDROID )
     const char * dataEnv = getenv( "XDG_DATA_HOME" );
     if ( dataEnv ) {
-        return System::ConcatePath( dataEnv, prog );
+        return System::concatPath( dataEnv, prog );
     }
 
     const char * homeEnv = getenv( "HOME" );
     if ( homeEnv ) {
-        return System::ConcatePath( System::ConcatePath( homeEnv, ".local/share" ), prog );
+        return System::concatPath( System::concatPath( homeEnv, ".local/share" ), prog );
     }
 
     return {};
 #elif defined( MACOS_APP_BUNDLE )
     const char * homeEnv = getenv( "HOME" );
     if ( homeEnv ) {
-        return System::ConcatePath( System::ConcatePath( homeEnv, "Library/Application Support" ), prog );
+        return System::concatPath( System::concatPath( homeEnv, "Library/Application Support" ), prog );
     }
 
     return {};
@@ -225,38 +261,41 @@ std::string System::GetDataDirectory( const std::string & prog )
 #endif
 }
 
-std::string System::GetDirname( const std::string & str )
+std::string System::GetDirname( const std::string & path )
 {
-    if ( !str.empty() ) {
-        size_t pos = str.rfind( SEPARATOR );
-
-        if ( std::string::npos == pos )
-            return std::string( "." );
-        else if ( pos == 0 )
-            return std::string( "./" );
-        else if ( pos == str.size() - 1 )
-            return GetDirname( str.substr( 0, str.size() - 1 ) );
-        else
-            return str.substr( 0, pos );
+    if ( path.empty() ) {
+        return path;
     }
 
-    return str;
+    size_t pos = path.rfind( SEPARATOR );
+
+    if ( pos == std::string::npos ) {
+        return std::string( "." );
+    }
+    if ( pos == 0 ) {
+        return std::string( "./" );
+    }
+    if ( pos == path.size() - 1 ) {
+        return GetDirname( path.substr( 0, path.size() - 1 ) );
+    }
+    return path.substr( 0, pos );
 }
 
-std::string System::GetBasename( const std::string & str )
+std::string System::GetBasename( const std::string & path )
 {
-    if ( !str.empty() ) {
-        size_t pos = str.rfind( SEPARATOR );
-
-        if ( std::string::npos == pos || pos == 0 )
-            return str;
-        else if ( pos == str.size() - 1 )
-            return GetBasename( str.substr( 0, str.size() - 1 ) );
-        else
-            return str.substr( pos + 1 );
+    if ( path.empty() ) {
+        return path;
     }
 
-    return str;
+    size_t pos = path.rfind( SEPARATOR );
+
+    if ( pos == std::string::npos || pos == 0 ) {
+        return path;
+    }
+    if ( pos == path.size() - 1 ) {
+        return GetBasename( path.substr( 0, path.size() - 1 ) );
+    }
+    return path.substr( pos + 1 );
 }
 
 int System::GetCommandOptions( int argc, char * const argv[], const char * optstring )
@@ -280,15 +319,15 @@ char * System::GetOptionsArgument()
 #endif
 }
 
-bool System::IsFile( const std::string & name, bool writable )
+bool System::IsFile( const std::string & path, bool writable )
 {
-    if ( name.empty() ) {
+    if ( path.empty() ) {
         // An empty path cannot be a file.
         return false;
     }
 
 #if defined( _WIN32 )
-    const DWORD fileAttributes = GetFileAttributes( name.c_str() );
+    const DWORD fileAttributes = GetFileAttributes( path.c_str() );
     if ( fileAttributes == INVALID_FILE_ATTRIBUTES ) {
         // This path doesn't exist.
         return false;
@@ -299,13 +338,13 @@ bool System::IsFile( const std::string & name, bool writable )
         return false;
     }
 
-    return writable ? ( 0 == _access( name.c_str(), 06 ) ) : ( 0 == _access( name.c_str(), 04 ) );
+    return writable ? ( 0 == _access( path.c_str(), 06 ) ) : ( 0 == _access( path.c_str(), 04 ) );
 #elif defined( TARGET_PS_VITA ) || defined( ANDROID )
     // TODO: check if it is really a file.
-    return writable ? 0 == access( name.c_str(), W_OK ) : 0 == access( name.c_str(), R_OK );
+    return writable ? 0 == access( path.c_str(), W_OK ) : 0 == access( path.c_str(), R_OK );
 #else
     std::string correctedPath;
-    if ( !GetCaseInsensitivePath( name, correctedPath ) )
+    if ( !GetCaseInsensitivePath( path, correctedPath ) )
         return false;
 
     struct stat fs;
@@ -317,15 +356,15 @@ bool System::IsFile( const std::string & name, bool writable )
 #endif
 }
 
-bool System::IsDirectory( const std::string & name, bool writable )
+bool System::IsDirectory( const std::string & path, bool writable )
 {
-    if ( name.empty() ) {
+    if ( path.empty() ) {
         // An empty path cannot be a directory.
         return false;
     }
 
 #if defined( _WIN32 )
-    const DWORD fileAttributes = GetFileAttributes( name.c_str() );
+    const DWORD fileAttributes = GetFileAttributes( path.c_str() );
     if ( fileAttributes == INVALID_FILE_ATTRIBUTES ) {
         // This path doesn't exist.
         return false;
@@ -336,13 +375,13 @@ bool System::IsDirectory( const std::string & name, bool writable )
         return false;
     }
 
-    return writable ? ( 0 == _access( name.c_str(), 06 ) ) : ( 0 == _access( name.c_str(), 00 ) );
+    return writable ? ( 0 == _access( path.c_str(), 06 ) ) : ( 0 == _access( path.c_str(), 00 ) );
 #elif defined( TARGET_PS_VITA ) || defined( ANDROID )
     // TODO: check if it is really a directory.
-    return writable ? 0 == access( name.c_str(), W_OK ) : 0 == access( name.c_str(), R_OK );
+    return writable ? 0 == access( path.c_str(), W_OK ) : 0 == access( path.c_str(), R_OK );
 #else
     std::string correctedPath;
-    if ( !GetCaseInsensitivePath( name, correctedPath ) )
+    if ( !GetCaseInsensitivePath( path, correctedPath ) )
         return false;
 
     struct stat fs;
@@ -354,52 +393,18 @@ bool System::IsDirectory( const std::string & name, bool writable )
 #endif
 }
 
-int System::Unlink( const std::string & file )
+bool System::Unlink( const std::string & path )
 {
 #if defined( _WIN32 )
-    return _unlink( file.c_str() );
+    return _unlink( path.c_str() ) == 0;
 #else
-    return unlink( file.c_str() );
+    return unlink( path.c_str() ) == 0;
 #endif
 }
 
 #if !defined( _WIN32 ) && !defined( ANDROID )
 // TODO: Android filesystem is case-sensitive so it should use the code below.
 //       However, in Android an application has access only to a specific path on the system.
-
-// splitUnixPath - function for splitting strings by delimiter
-std::vector<std::string> splitUnixPath( const std::string & path, const std::string & delimiter )
-{
-    std::vector<std::string> result;
-
-    if ( path.empty() ) {
-        return result;
-    }
-
-    size_t pos = path.find( delimiter, 0 );
-    while ( pos != std::string::npos ) { // while found delimiter
-        const size_t nextPos = path.find( delimiter, pos + 1 );
-        if ( nextPos != std::string::npos ) { // if found next delimiter
-            if ( pos + 1 < nextPos ) { // have what to append
-                result.push_back( path.substr( pos + 1, nextPos - pos - 1 ) );
-            }
-        }
-        else { // if no more delimiter present
-            if ( pos + 1 < path.length() ) { // if not a postfix delimiter
-                result.push_back( path.substr( pos + 1 ) );
-            }
-            break;
-        }
-
-        pos = path.find( delimiter, pos + 1 );
-    }
-
-    if ( result.empty() ) { // if delimiter not present
-        result.push_back( path );
-    }
-
-    return result;
-}
 
 // based on: https://github.com/OneSadCookie/fcaseopen
 bool System::GetCaseInsensitivePath( const std::string & path, std::string & correctedPath )
@@ -493,22 +498,22 @@ bool System::GetCaseInsensitivePath( const std::string & path, std::string & cor
 }
 #endif
 
-std::string System::FileNameToUTF8( const std::string & str )
+std::string System::FileNameToUTF8( const std::string & name )
 {
 #if defined( _WIN32 )
-    if ( str.empty() ) {
-        return str;
+    if ( name.empty() ) {
+        return name;
     }
 
     static std::map<std::string, std::string> acpToUtf8;
 
-    const auto iter = acpToUtf8.find( str );
+    const auto iter = acpToUtf8.find( name );
     if ( iter != acpToUtf8.end() ) {
         return iter->second;
     }
 
     // In case of any issues, the original string will be returned, so let's put it to the cache right away
-    acpToUtf8[str] = str;
+    acpToUtf8[name] = name;
 
     auto getLastErrorStr = []() {
         LPTSTR msgBuf;
@@ -526,26 +531,26 @@ std::string System::FileNameToUTF8( const std::string & str )
         return std::string( "FormatMessage() failed: " ) + std::to_string( GetLastError() );
     };
 
-    const int wLen = MultiByteToWideChar( CP_ACP, MB_ERR_INVALID_CHARS, str.c_str(), -1, nullptr, 0 );
+    const int wLen = MultiByteToWideChar( CP_ACP, MB_ERR_INVALID_CHARS, name.c_str(), -1, nullptr, 0 );
     if ( wLen <= 0 ) {
         ERROR_LOG( getLastErrorStr() )
 
-        return str;
+        return name;
     }
 
     const std::unique_ptr<wchar_t[]> wStr( new wchar_t[wLen] );
 
-    if ( MultiByteToWideChar( CP_ACP, MB_ERR_INVALID_CHARS, str.c_str(), -1, wStr.get(), wLen ) != wLen ) {
+    if ( MultiByteToWideChar( CP_ACP, MB_ERR_INVALID_CHARS, name.c_str(), -1, wStr.get(), wLen ) != wLen ) {
         ERROR_LOG( getLastErrorStr() )
 
-        return str;
+        return name;
     }
 
     const int uLen = WideCharToMultiByte( CP_UTF8, WC_ERR_INVALID_CHARS | WC_NO_BEST_FIT_CHARS, wStr.get(), -1, nullptr, 0, nullptr, nullptr );
     if ( uLen <= 0 ) {
         ERROR_LOG( getLastErrorStr() )
 
-        return str;
+        return name;
     }
 
     const std::unique_ptr<char[]> uStr( new char[uLen] );
@@ -553,17 +558,17 @@ std::string System::FileNameToUTF8( const std::string & str )
     if ( WideCharToMultiByte( CP_UTF8, WC_ERR_INVALID_CHARS | WC_NO_BEST_FIT_CHARS, wStr.get(), -1, uStr.get(), uLen, nullptr, nullptr ) != uLen ) {
         ERROR_LOG( getLastErrorStr() )
 
-        return str;
+        return name;
     }
 
     const std::string result( uStr.get() );
 
     // Put the final result to the cache
-    acpToUtf8[str] = result;
+    acpToUtf8[name] = result;
 
     return result;
 #else
-    return str;
+    return name;
 #endif
 }
 

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -171,7 +171,7 @@ namespace
     }
 #endif
 
-    std::string_view trimSeparator( std::string_view path )
+    std::string_view trimTrailingSeparators( std::string_view path )
     {
         while ( path.size() > 1 && path.back() == SEPARATOR ) {
             path.remove_suffix( 1 );
@@ -277,7 +277,7 @@ std::string System::GetDirname( std::string_view path )
         return { "." };
     }
 
-    path = trimSeparator( path );
+    path = trimTrailingSeparators( path );
 
     const size_t pos = path.rfind( SEPARATOR );
 
@@ -288,10 +288,10 @@ std::string System::GetDirname( std::string_view path )
         return { std::initializer_list<char>{ SEPARATOR } };
     }
 
-    // Path separators should already be trimmed from the end
+    // Trailing separators should already be trimmed
     assert( pos != path.size() - 1 );
 
-    return std::string{ trimSeparator( path.substr( 0, pos ) ) };
+    return std::string{ trimTrailingSeparators( path.substr( 0, pos ) ) };
 }
 
 std::string System::GetBasename( std::string_view path )
@@ -300,7 +300,7 @@ std::string System::GetBasename( std::string_view path )
         return { "." };
     }
 
-    path = trimSeparator( path );
+    path = trimTrailingSeparators( path );
 
     const size_t pos = path.rfind( SEPARATOR );
 
@@ -308,7 +308,7 @@ std::string System::GetBasename( std::string_view path )
         return std::string{ path };
     }
 
-    // Path separators should already be trimmed from the end
+    // Trailing separators should already be trimmed
     assert( pos != path.size() - 1 );
 
     return std::string{ path.substr( pos + 1 ) };

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -382,9 +382,6 @@ bool System::Unlink( const std::string & path )
 }
 
 #if !defined( _WIN32 ) && !defined( ANDROID )
-// TODO: Android filesystem is case-sensitive so it should use the code below.
-//       However, in Android an application has access only to a specific path on the system.
-
 // based on: https://github.com/OneSadCookie/fcaseopen
 bool System::GetCaseInsensitivePath( const std::string & path, std::string & correctedPath )
 {

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -170,6 +170,15 @@ namespace
         return result;
     }
 #endif
+
+    std::string_view trimSeparator( std::string_view path )
+    {
+        while ( path.size() > 1 && path.back() == SEPARATOR ) {
+            path.remove_suffix( 1 );
+        }
+
+        return path;
+    }
 }
 
 bool System::isHandheldDevice()
@@ -262,11 +271,13 @@ std::string System::GetDataDirectory( const std::string & prog )
 #endif
 }
 
-std::string System::GetDirname( const std::string & path )
+std::string System::GetDirname( std::string_view path )
 {
     if ( path.empty() ) {
         return { "." };
     }
+
+    path = trimSeparator( path );
 
     const size_t pos = path.rfind( SEPARATOR );
 
@@ -276,27 +287,29 @@ std::string System::GetDirname( const std::string & path )
     if ( pos == 0 ) {
         return { std::initializer_list<char>{ SEPARATOR } };
     }
-    if ( pos == path.size() - 1 ) {
-        return GetDirname( path.substr( 0, path.size() - 1 ) );
-    }
-    return path.substr( 0, pos );
+
+    assert( pos != path.size() - 1 );
+
+    return std::string{ trimSeparator( path.substr( 0, pos ) ) };
 }
 
-std::string System::GetBasename( const std::string & path )
+std::string System::GetBasename( std::string_view path )
 {
     if ( path.empty() ) {
         return { "." };
     }
 
+    path = trimSeparator( path );
+
     const size_t pos = path.rfind( SEPARATOR );
 
     if ( pos == std::string::npos || ( pos == 0 && path.size() == 1 ) ) {
-        return path;
+        return std::string{ path };
     }
-    if ( pos == path.size() - 1 ) {
-        return GetBasename( path.substr( 0, path.size() - 1 ) );
-    }
-    return path.substr( pos + 1 );
+
+    assert( pos != path.size() - 1 );
+
+    return std::string{ path.substr( pos + 1 ) };
 }
 
 int System::GetCommandOptions( int argc, char * const argv[], const char * optstring )

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -134,26 +134,21 @@ namespace
             return result;
         }
 
-        size_t pos = path.find( delimiter, 0 );
-        while ( pos != std::string::npos ) { // while found delimiter
-            const size_t nextPos = path.find( delimiter, pos + 1 );
-            if ( nextPos != std::string::npos ) { // if found next delimiter
-                if ( pos + 1 < nextPos ) { // have what to append
-                    result.push_back( path.substr( pos + 1, nextPos - pos - 1 ) );
-                }
-            }
-            else { // if no more delimiter present
-                if ( pos + 1 < path.length() ) { // if not a postfix delimiter
-                    result.push_back( path.substr( pos + 1 ) );
-                }
+        size_t pos = 0;
+
+        while ( pos < path.size() ) {
+            const size_t nextPos = path.find( delimiter, pos );
+
+            if ( nextPos == std::string::npos ) {
+                result.push_back( path.substr( pos ) );
+
                 break;
             }
+            if ( pos < nextPos ) {
+                result.push_back( path.substr( pos, nextPos - pos ) );
+            }
 
-            pos = path.find( delimiter, pos + 1 );
-        }
-
-        if ( result.empty() ) { // if delimiter not present
-            result.push_back( path );
+            pos = nextPos + delimiter.size();
         }
 
         return result;

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -264,16 +264,16 @@ std::string System::GetDataDirectory( const std::string & prog )
 std::string System::GetDirname( const std::string & path )
 {
     if ( path.empty() ) {
-        return path;
+        return { "." };
     }
 
-    size_t pos = path.rfind( SEPARATOR );
+    const size_t pos = path.rfind( SEPARATOR );
 
     if ( pos == std::string::npos ) {
-        return std::string( "." );
+        return { "." };
     }
     if ( pos == 0 ) {
-        return std::string( "./" );
+        return { std::initializer_list<char>{ SEPARATOR } };
     }
     if ( pos == path.size() - 1 ) {
         return GetDirname( path.substr( 0, path.size() - 1 ) );
@@ -284,12 +284,12 @@ std::string System::GetDirname( const std::string & path )
 std::string System::GetBasename( const std::string & path )
 {
     if ( path.empty() ) {
-        return path;
+        return { "." };
     }
 
-    size_t pos = path.rfind( SEPARATOR );
+    const size_t pos = path.rfind( SEPARATOR );
 
-    if ( pos == std::string::npos || pos == 0 ) {
+    if ( pos == std::string::npos || ( pos == 0 && path.size() == 1 ) ) {
         return path;
     }
     if ( pos == path.size() - 1 ) {

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -87,7 +87,7 @@ namespace
         const char * storagePath = SDL_AndroidGetExternalStoragePath();
         if ( storagePath == nullptr ) {
             ERROR_LOG( "Failed to obtain the path to external storage. The error: " << SDL_GetError() )
-            return {};
+            return { "." };
         }
 
         VERBOSE_LOG( "Application storage path is " << storagePath )
@@ -101,7 +101,7 @@ namespace
             return System::concatPath( System::concatPath( homeEnvPath, "Library/Preferences" ), prog );
         }
 
-        return {};
+        return { "." };
 #endif
 
         if ( homeEnvPath != nullptr ) {
@@ -113,15 +113,18 @@ namespace
             return System::concatPath( dataEnvPath, prog );
         }
 
-        std::string res;
 #if SDL_VERSION_ATLEAST( 2, 0, 1 )
         char * path = SDL_GetPrefPath( "", prog.c_str() );
         if ( path ) {
-            res = path;
+            const std::string result{ path };
+
             SDL_free( path );
+
+            return result;
         }
 #endif
-        return res;
+
+        return { "." };
     }
 #endif
 
@@ -223,7 +226,7 @@ std::string System::GetConfigDirectory( const std::string & prog )
         return System::concatPath( System::concatPath( homeEnv, ".config" ), prog );
     }
 
-    return std::string();
+    return { "." };
 #else
     return GetHomeDirectory( prog );
 #endif
@@ -242,14 +245,14 @@ std::string System::GetDataDirectory( const std::string & prog )
         return System::concatPath( System::concatPath( homeEnv, ".local/share" ), prog );
     }
 
-    return {};
+    return { "." };
 #elif defined( MACOS_APP_BUNDLE )
     const char * homeEnv = getenv( "HOME" );
     if ( homeEnv ) {
         return System::concatPath( System::concatPath( homeEnv, "Library/Application Support" ), prog );
     }
 
-    return {};
+    return { "." };
 #else
     return GetHomeDirectory( prog );
 #endif

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -288,6 +288,7 @@ std::string System::GetDirname( std::string_view path )
         return { std::initializer_list<char>{ SEPARATOR } };
     }
 
+    // Path separators should already be trimmed from the end
     assert( pos != path.size() - 1 );
 
     return std::string{ trimSeparator( path.substr( 0, pos ) ) };
@@ -307,6 +308,7 @@ std::string System::GetBasename( std::string_view path )
         return std::string{ path };
     }
 
+    // Path separators should already be trimmed from the end
     assert( pos != path.size() - 1 );
 
     return std::string{ path.substr( pos + 1 ) };

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -43,9 +43,6 @@ namespace System
     std::string GetDirname( std::string_view path );
     std::string GetBasename( std::string_view path );
 
-    int GetCommandOptions( int argc, char * const argv[], const char * optstring );
-    char * GetOptionsArgument();
-
     bool IsFile( const std::string & path, bool writable = false );
     bool IsDirectory( const std::string & path, bool writable = false );
     bool Unlink( const std::string & path );

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -39,8 +39,8 @@ namespace System
     std::string GetConfigDirectory( const std::string & prog );
     std::string GetDataDirectory( const std::string & prog );
 
-    std::string GetDirname( const std::string & path );
-    std::string GetBasename( const std::string & path );
+    std::string GetDirname( std::string_view path );
+    std::string GetBasename( std::string_view path );
 
     int GetCommandOptions( int argc, char * const argv[], const char * optstring );
     char * GetOptionsArgument();

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -26,6 +26,7 @@
 
 #include <ctime>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace System

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -32,26 +32,26 @@ namespace System
 {
     bool isHandheldDevice();
 
-    int MakeDirectory( const std::string & );
-    std::string ConcatePath( const std::string &, const std::string & );
+    bool MakeDirectory( const std::string & path );
+    std::string concatPath( const std::string & left, const std::string & right );
 
     void appendOSSpecificDirectories( std::vector<std::string> & directories );
     std::string GetConfigDirectory( const std::string & prog );
     std::string GetDataDirectory( const std::string & prog );
 
-    std::string GetDirname( const std::string & );
-    std::string GetBasename( const std::string & );
+    std::string GetDirname( const std::string & path );
+    std::string GetBasename( const std::string & path );
 
     int GetCommandOptions( int argc, char * const argv[], const char * optstring );
     char * GetOptionsArgument();
 
-    bool IsFile( const std::string & name, bool writable = false );
-    bool IsDirectory( const std::string & name, bool writable = false );
-    int Unlink( const std::string & );
+    bool IsFile( const std::string & path, bool writable = false );
+    bool IsDirectory( const std::string & path, bool writable = false );
+    bool Unlink( const std::string & path );
 
     bool GetCaseInsensitivePath( const std::string & path, std::string & correctedPath );
 
-    std::string FileNameToUTF8( const std::string & str );
+    std::string FileNameToUTF8( const std::string & name );
 
     tm GetTM( const time_t time );
 }

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -66,7 +66,7 @@ namespace
     {
         std::vector<std::string> directories;
         for ( const std::string & dir : Settings::GetRootDirs() ) {
-            std::string fullDirectoryPath = System::ConcatePath( dir, externalMusicDirectory );
+            std::string fullDirectoryPath = System::concatPath( dir, externalMusicDirectory );
             if ( System::IsDirectory( fullDirectoryPath ) ) {
                 directories.emplace_back( std::move( fullDirectoryPath ) );
             }
@@ -84,7 +84,7 @@ namespace
                 continue;
             }
 
-            std::string correctFilePath = System::ConcatePath( dir, fileName );
+            std::string correctFilePath = System::concatPath( dir, fileName );
             correctFilePath = StringLower( correctFilePath );
 
             for ( std::string & path : musicFilePaths ) {

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -227,7 +227,7 @@ std::string Dialog::SelectFileSave()
 {
     std::ostringstream os;
 
-    os << System::ConcatePath( Game::GetSaveDir(), Game::GetSaveFileBaseName() ) << '_' << std::setw( 4 ) << std::setfill( '0' ) << world.CountDay()
+    os << System::concatPath( Game::GetSaveDir(), Game::GetSaveFileBaseName() ) << '_' << std::setw( 4 ) << std::setfill( '0' ) << world.CountDay()
        << Game::GetSaveFileExtension();
 
     return SelectFileListSimple( _( "File to Save:" ), os.str(), true );
@@ -341,7 +341,7 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
         if ( ( buttonOk.isEnabled() && le.MouseClickLeft( buttonOk.area() ) ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY )
              || listbox.isDoubleClicked() ) {
             if ( !filename.empty() )
-                result = System::ConcatePath( Game::GetSaveDir(), filename + Game::GetSaveFileExtension() );
+                result = System::concatPath( Game::GetSaveDir(), filename + Game::GetSaveFileExtension() );
             else if ( isListboxSelected )
                 result = listbox.GetCurrent().file;
         }

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -119,8 +119,8 @@ namespace
         if ( dataDir.empty() )
             return;
 
-        const std::string dataFiles = System::ConcatePath( dataDir, "files" );
-        const std::string dataFilesSave = System::ConcatePath( dataFiles, "save" );
+        const std::string dataFiles = System::concatPath( dataDir, "files" );
+        const std::string dataFilesSave = System::concatPath( dataFiles, "save" );
 
         if ( !System::IsDirectory( dataDir ) )
             System::MakeDirectory( dataDir );
@@ -292,8 +292,8 @@ int main( int argc, char ** argv )
 
         ListFiles midiSoundFonts;
 
-        midiSoundFonts.Append( Settings::FindFiles( System::ConcatePath( "files", "soundfonts" ), ".sf2", false ) );
-        midiSoundFonts.Append( Settings::FindFiles( System::ConcatePath( "files", "soundfonts" ), ".sf3", false ) );
+        midiSoundFonts.Append( Settings::FindFiles( System::concatPath( "files", "soundfonts" ), ".sf2", false ) );
+        midiSoundFonts.Append( Settings::FindFiles( System::concatPath( "files", "soundfonts" ), ".sf3", false ) );
 
 #ifdef WITH_DEBUG
         for ( const std::string & file : midiSoundFonts ) {

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -65,9 +65,6 @@
 #include "screen.h"
 #include "settings.h"
 #include "system.h"
-#ifdef WITH_DEBUG
-#include "tools.h"
-#endif
 #include "ui_tool.h"
 #include "zzlib.h"
 

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -287,7 +287,6 @@ int main( int argc, char ** argv )
         DEBUG_LOG( DBG_GAME, DBG_INFO, conf.String() )
 
         const DisplayInitializer displayInitializer;
-
         const DataInitializer dataInitializer;
 
         ListFiles midiSoundFonts;

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -78,17 +78,6 @@ namespace
         return std::string( "fheroes2 engine, version: " + Settings::GetVersion() );
     }
 
-    int PrintHelp( const char * basename )
-    {
-        COUT( "Usage: " << basename << " [OPTIONS]" )
-#ifdef WITH_DEBUG
-        COUT( "  -d <level>\tprint debug messages, see src/engine/logging.h for possible values of <level> argument" )
-#endif
-        COUT( "  -h\t\tprint this help message and exit" )
-
-        return EXIT_SUCCESS;
-    }
-
     void ReadConfigs()
     {
         const std::string configurationFileName( Settings::configFileName );
@@ -240,6 +229,8 @@ int main( int argc, char ** argv )
     assert( argc == __argc );
 
     argv = __argv;
+#else
+    (void)argc;
 #endif
 
     try {
@@ -254,26 +245,6 @@ int main( int argc, char ** argv )
         InitConfigDir();
         InitDataDir();
         ReadConfigs();
-
-        // getopt
-        {
-            int opt;
-
-            while ( ( opt = System::GetCommandOptions( argc, argv, "hd:" ) ) != -1 )
-                switch ( opt ) {
-#ifdef WITH_DEBUG
-                case 'd':
-                    conf.SetDebug( System::GetOptionsArgument() ? GetInt( System::GetOptionsArgument() ) : 0 );
-                    break;
-#endif
-                case '?':
-                case 'h':
-                    return PrintHelp( argv[0] );
-
-                default:
-                    break;
-                }
-        }
 
         std::set<fheroes2::SystemInitializationComponent> coreComponents{ fheroes2::SystemInitializationComponent::Audio,
                                                                           fheroes2::SystemInitializationComponent::Video };

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -183,7 +183,7 @@ fheroes2::GameMode Game::DisplayHighScores( const bool isCampaign )
     }
 #endif
 
-    const std::string highScoreDataPath = System::ConcatePath( GetSaveDir(), highScoreFileName );
+    const std::string highScoreDataPath = System::concatPath( GetSaveDir(), highScoreFileName );
 
     if ( !highScoreDataContainer.load( highScoreDataPath ) ) {
         // Unable to load the file. Let's populate with the default values.

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -345,7 +345,7 @@ void Game::HotKeysLoad( const std::string & filename )
 void Game::HotKeySave()
 {
     // Save the latest information into the file.
-    const std::string filename = System::ConcatePath( System::GetConfigDirectory( "fheroes2" ), "fheroes2.key" );
+    const std::string filename = System::concatPath( System::GetConfigDirectory( "fheroes2" ), "fheroes2.key" );
 
     std::fstream file( filename.data(), std::fstream::out | std::fstream::trunc );
     if ( !file ) {

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -94,7 +94,7 @@ namespace
 
 bool Game::AutoSave()
 {
-    return Game::Save( System::ConcatePath( GetSaveDir(), "AUTOSAVE" + GetSaveFileExtension() ) );
+    return Game::Save( System::concatPath( GetSaveDir(), "AUTOSAVE" + GetSaveFileExtension() ) );
 }
 
 bool Game::Save( const std::string & fn )
@@ -317,7 +317,7 @@ bool Game::LoadSAV2FileInfo( const std::string & fn, Maps::FileInfo & finfo )
 
 std::string Game::GetSaveDir()
 {
-    return System::ConcatePath( System::ConcatePath( System::GetDataDirectory( "fheroes2" ), "files" ), "save" );
+    return System::concatPath( System::concatPath( System::GetDataDirectory( "fheroes2" ), "files" ), "save" );
 }
 
 std::string Game::GetSaveFileBaseName()
@@ -359,5 +359,5 @@ std::string Game::GetSaveFileExtension( const int gameType )
 
 bool Game::SaveCompletedCampaignScenario()
 {
-    return Save( System::ConcatePath( GetSaveDir(), GetSaveFileBaseName() ) + "_Complete" + GetSaveFileExtension() );
+    return Save( System::concatPath( GetSaveDir(), GetSaveFileBaseName() ) + "_Complete" + GetSaveFileExtension() );
 }

--- a/src/fheroes2/game/game_video.cpp
+++ b/src/fheroes2/game/game_video.cpp
@@ -42,7 +42,7 @@
 namespace
 {
     // Anim2 directory is used in Russian Buka version of the game.
-    std::array<std::string, 4> videoDir = { "anim", "anim2", System::ConcatePath( "heroes2", "anim" ), "data" };
+    std::array<std::string, 4> videoDir = { "anim", "anim2", System::concatPath( "heroes2", "anim" ), "data" };
 
     void playAudio( const std::vector<std::vector<uint8_t>> & audioChannels )
     {
@@ -62,7 +62,7 @@ namespace Video
     {
         for ( const std::string & rootDir : Settings::GetRootDirs() ) {
             for ( size_t dirIdx = 0; dirIdx < videoDir.size(); ++dirIdx ) {
-                const std::string fullDirPath = System::ConcatePath( rootDir, videoDir[dirIdx] );
+                const std::string fullDirPath = System::concatPath( rootDir, videoDir[dirIdx] );
 
                 if ( System::IsDirectory( fullDirPath ) ) {
                     ListFiles videoFiles;

--- a/src/fheroes2/h2d/h2d.cpp
+++ b/src/fheroes2/h2d/h2d.cpp
@@ -37,7 +37,7 @@ namespace
 #if defined( MACOS_APP_BUNDLE )
         return Settings::findFile( "h2d", fileName, path );
 #else
-        return Settings::findFile( System::ConcatePath( "files", "data" ), fileName, path );
+        return Settings::findFile( System::concatPath( "files", "data" ), fileName, path );
 #endif
     }
 }

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -29,12 +29,13 @@ enum SaveFileFormat : uint16_t
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
 
     // 10000 value must be used for 1.0 release so all version before it should have lower than this value.
-    FORMAT_VERSION_PRE_1000_RELEASE = 9960,
+    FORMAT_VERSION_PRE2_1000_RELEASE = 9961,
+    FORMAT_VERSION_PRE1_1000_RELEASE = 9960,
     FORMAT_VERSION_0921_RELEASE = 9950,
     FORMAT_VERSION_0920_RELEASE = 9940,
     FORMAT_VERSION_0919_RELEASE = 9930,
 
     LAST_SUPPORTED_FORMAT_VERSION = FORMAT_VERSION_0919_RELEASE,
 
-    CURRENT_FORMAT_VERSION = FORMAT_VERSION_PRE_1000_RELEASE
+    CURRENT_FORMAT_VERSION = FORMAT_VERSION_PRE2_1000_RELEASE
 };

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -149,7 +149,7 @@ bool Settings::Read( const std::string & filename )
 
     // debug
     if ( config.Exists( "debug" ) ) {
-        SetDebug( config.IntParams( "debug" ) );
+        setDebug( config.IntParams( "debug" ) );
     }
 
     // game language
@@ -801,7 +801,7 @@ bool Settings::BattleShowArmyOrder() const
     return _optGlobal.Modes( GLOBAL_BATTLE_SHOW_ARMY_ORDER );
 }
 
-void Settings::SetDebug( int debug )
+void Settings::setDebug( int debug )
 {
     switch ( debug ) {
     case 0:

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -612,7 +612,7 @@ bool Settings::findFile( const std::string & internalDirectory, const std::strin
 {
     std::string tempPath;
 
-    for ( const std::string & rootDir : Settings::GetRootDirs() ) {
+    for ( const std::string & rootDir : GetRootDirs() ) {
         tempPath = System::concatPath( rootDir, internalDirectory );
         tempPath = System::concatPath( tempPath, fileName );
         if ( System::IsFile( tempPath ) ) {

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -369,7 +369,7 @@ bool Settings::Save( const std::string & filename ) const
         return false;
     }
 
-    const std::string cfgFilename = System::ConcatePath( System::GetConfigDirectory( "fheroes2" ), filename );
+    const std::string cfgFilename = System::concatPath( System::GetConfigDirectory( "fheroes2" ), filename );
 
     std::fstream file;
     file.open( cfgFilename.data(), std::fstream::out | std::fstream::trunc );
@@ -511,7 +511,7 @@ bool Settings::setGameLanguage( const std::string & language )
 #if defined( MACOS_APP_BUNDLE )
     const ListFiles translations = Settings::FindFiles( "translations", fileName, false );
 #else
-    const ListFiles translations = Settings::FindFiles( System::ConcatePath( "files", "lang" ), fileName, false );
+    const ListFiles translations = Settings::FindFiles( System::concatPath( "files", "lang" ), fileName, false );
 #endif
 
     if ( !translations.empty() ) {
@@ -593,7 +593,7 @@ ListFiles Settings::FindFiles( const std::string & prefixDir, const std::string 
     ListFiles res;
 
     for ( const std::string & dir : GetRootDirs() ) {
-        const std::string path = !prefixDir.empty() ? System::ConcatePath( dir, prefixDir ) : dir;
+        const std::string path = !prefixDir.empty() ? System::concatPath( dir, prefixDir ) : dir;
 
         if ( System::IsDirectory( path ) ) {
             if ( exactMatch ) {
@@ -613,8 +613,8 @@ bool Settings::findFile( const std::string & internalDirectory, const std::strin
     std::string tempPath;
 
     for ( const std::string & rootDir : Settings::GetRootDirs() ) {
-        tempPath = System::ConcatePath( rootDir, internalDirectory );
-        tempPath = System::ConcatePath( tempPath, fileName );
+        tempPath = System::concatPath( rootDir, internalDirectory );
+        tempPath = System::concatPath( tempPath, fileName );
         if ( System::IsFile( tempPath ) ) {
             fullPath.swap( tempPath );
             return true;
@@ -1028,7 +1028,7 @@ void Settings::ExtResetModes( uint32_t f )
 
 void Settings::BinarySave() const
 {
-    const std::string fname = System::ConcatePath( System::GetConfigDirectory( "fheroes2" ), "fheroes2.bin" );
+    const std::string fname = System::concatPath( System::GetConfigDirectory( "fheroes2" ), "fheroes2.bin" );
 
     StreamFile fs;
     fs.setbigendian( true );
@@ -1041,7 +1041,7 @@ void Settings::BinarySave() const
 
 void Settings::BinaryLoad()
 {
-    std::string fname = System::ConcatePath( System::GetConfigDirectory( "fheroes2" ), "fheroes2.bin" );
+    std::string fname = System::concatPath( System::GetConfigDirectory( "fheroes2" ), "fheroes2.bin" );
 
     if ( !System::IsFile( fname ) ) {
         fname = GetLastFile( "", "fheroes2.bin" );

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -142,11 +142,6 @@ public:
         return current_maps_file._version == GameVersion::PRICE_OF_LOYALTY;
     }
 
-    int Debug() const
-    {
-        return debug;
-    }
-
     int HeroesMoveSpeed() const
     {
         return heroes_speed;
@@ -303,7 +298,8 @@ public:
         return video_mode;
     }
 
-    void SetDebug( int );
+    static void SetDebug( int debug );
+
     void EnablePriceOfLoyaltySupport( const bool set );
 
     void SetGameDifficulty( const int difficulty )
@@ -361,7 +357,6 @@ public:
         return _musicType;
     }
 
-    /* check game type */
     bool IsGameType( int type ) const
     {
         return ( game_type & type ) != 0;
@@ -504,9 +499,7 @@ public:
     static const std::vector<std::string> & GetRootDirs();
 
     static ListFiles FindFiles( const std::string & prefixDir, const std::string & fileNameFilter, const bool exactMatch );
-
     static bool findFile( const std::string & internalDirectory, const std::string & fileName, std::string & fullPath );
-
     static std::string GetLastFile( const std::string & prefix, const std::string & name );
 
 private:
@@ -530,7 +523,6 @@ private:
     BitModes _optExtBalance3; // Options with codes starting with 0x3
     BitModes _optExtBalance4; // Options with codes starting with 0x4
 
-    int debug;
     fheroes2::Size video_mode;
     int game_difficulty;
 

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -298,8 +298,6 @@ public:
         return video_mode;
     }
 
-    static void SetDebug( int debug );
-
     void EnablePriceOfLoyaltySupport( const bool set );
 
     void SetGameDifficulty( const int difficulty )
@@ -511,6 +509,8 @@ private:
 
     void BinarySave() const;
     void BinaryLoad();
+
+    static void setDebug( int debug );
 
     // Global game options (GLOBAL_), they are saved in the text config file
     BitModes _optGlobal;

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1312,8 +1312,8 @@ StreamBase & operator>>( StreamBase & msg, CapturedObject & obj )
 {
     msg >> obj.objcol >> obj.guardians;
 
-    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE_1000_RELEASE, "Remove the check below." );
-    if ( Game::GetLoadVersion() < FORMAT_VERSION_PRE_1000_RELEASE ) {
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE1_1000_RELEASE, "Remove the check below." );
+    if ( Game::GetLoadVersion() < FORMAT_VERSION_PRE1_1000_RELEASE ) {
         int dummy;
 
         msg >> dummy;

--- a/src/tools/extractor.cpp
+++ b/src/tools/extractor.cpp
@@ -84,7 +84,7 @@ int main( int argc, char ** argv )
 
     for ( std::map<std::string, aggfat_t>::const_iterator it = maps.begin(); it != maps.end(); ++it ) {
         const aggfat_t & fat = ( *it ).second;
-        const std::string & fn = System::ConcatePath( argv[2], ( *it ).first );
+        const std::string & fn = System::concatPath( argv[2], ( *it ).first );
         sf1.seek( fat.offset );
         std::vector<uint8_t> buf = sf1.getRaw( fat.size );
 

--- a/src/tools/icn2img.cpp
+++ b/src/tools/icn2img.cpp
@@ -74,7 +74,7 @@ int main( int argc, char ** argv )
     int total_size = sf.getLE32();
 
     inputFileName.replace( inputFileName.find( ".icn" ), 4, "" );
-    prefix = System::ConcatePath( prefix, inputFileName );
+    prefix = System::concatPath( prefix, inputFileName );
 
     if ( 0 != System::MakeDirectory( prefix ) ) {
         std::cout << "error mkdir: " << prefix << std::endl;
@@ -101,7 +101,7 @@ int main( int argc, char ** argv )
             std::ostringstream os;
             os << std::setw( 3 ) << std::setfill( '0' ) << ii;
 
-            std::string dstfile = System::ConcatePath( prefix, os.str() );
+            std::string dstfile = System::concatPath( prefix, os.str() );
 
             if ( fheroes2::isPNGFormatSupported() ) {
                 dstfile += ".png";

--- a/src/tools/til2img.cpp
+++ b/src/tools/til2img.cpp
@@ -59,7 +59,7 @@ int main( int argc, char ** argv )
     }
 
     shortname.replace( shortname.find( "." ), 4, "" );
-    prefix = System::ConcatePath( prefix, shortname );
+    prefix = System::concatPath( prefix, shortname );
 
     if ( 0 != System::MakeDirectory( prefix ) ) {
         std::cout << "error mkdir: " << prefix << std::endl;
@@ -85,7 +85,7 @@ int main( int argc, char ** argv )
 
             std::ostringstream stream;
             stream << std::setw( 3 ) << std::setfill( '0' ) << cur;
-            std::string dstfile = System::ConcatePath( prefix, stream.str() );
+            std::string dstfile = System::concatPath( prefix, stream.str() );
 
             if ( fheroes2::isPNGFormatSupported() ) {
                 dstfile += ".png";


### PR DESCRIPTION
While I'm here:

1. `System::MakeDirectory()` returned 1 (`true`) on Windows, but 0 (`false`) on other systems upon successful directory creation;
2. `System::Unlink()` returned 0 upon successful file/directory removal, which was counterintuitive;
3. Renamed `ConcatePath()` to `concatPath()` (I've been dreaming of doing this for a long time);
4. Fixed an issue that caused `fheroes2.log` not to be created when the game was started for the first time;
5. `System::GetConfigDirectory()`, `System::GetDataDirectory()`: use the current directory as a fallback instead of an empty string. The previous behavior leads to attempts to create a log file, config file, etc. in the root directory, which is hopeless.
6. `GetDirname()` was not quite POSIX-compliant:

| Argument | Old `GetDirname()` | POSIX `dirname()` / new `GetDirname()` |
| - | - | - |
| (empty) | (empty) | `.` |
| `/usr/` | `./` | `/` |
| `/` | `./` | `/` |

7. `GetBasename()` was not quite POSIX-compliant:

| Argument | Old `GetBasename()` | POSIX `basename()` / new `GetBasename()` |
| - | - | - |
| (empty) | (empty) | `.` |
| `/usr/` | `/usr` | `usr` |

8. Removed command-line switches;
9. Fixed a bug on *NIX when game was unable to locate data files if it was started using the relative path (say, `game/fheroes2`). That's because previous version of `splitUnitPath()` was not able to handle the relative paths properly:

| Argument | Before | Now |
| - | - | - |
| `/foo/bar` | `foo`, `bar` | `foo`, `bar` |
| `foo/bar` | `bar` | `foo`, `bar` |

10. Various style nits.