### PR TITLE
iwyu.map: add new private header mappings for newer Ubuntu image version, speed up IWYU workflow a bit

### DIFF
--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -10,16 +10,18 @@ jobs:
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
-    - name: Install dependencies
+    - name: Install dependencies and iwyu
       run: |
         sudo apt-get -y update
-        sudo apt-get -y install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext ninja-build iwyu
+        sudo apt-get -y install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext iwyu
+    - name: Prepare compile_commands.json
+      run: |
+        cmake -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT_COMPILATION=ON -DENABLE_IMAGE=ON -DENABLE_TOOLS=ON -DUSE_SDL_VERSION=SDL2 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     - name: Analyze
       run: |
-        cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DENABLE_IMAGE=ON -DENABLE_TOOLS=ON -DUSE_SDL_VERSION=SDL2 \
-                                -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE="include-what-you-use;-Xiwyu;--cxx17ns;-Xiwyu;--mapping_file=$GITHUB_WORKSPACE/iwyu.map"
-        cmake --build build | tee iwyu-result.txt
-        ! grep "Warning: include-what-you-use reported diagnostics:" iwyu-result.txt > /dev/null
+        set -o pipefail
+        iwyu_tool -p build -j 2 -- -Xiwyu --cxx17ns -Xiwyu --mapping_file="$GITHUB_WORKSPACE/iwyu.map" | (grep -E -v "^$|has correct #includes/fwd-decls" || true) \
+                                                                                                       | tee iwyu-result.txt
     - uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:

--- a/iwyu.map
+++ b/iwyu.map
@@ -1,8 +1,12 @@
 [
+    { include: [ "<bits/chrono.h>",          private, "<chrono>",       public ] },
     { include: [ "<bits/getopt_core.h>",     private, "<unistd.h>",     public ] },
     { include: [ "<bits/std_abs.h>",         private, "<cmath>",        public ] },
     { include: [ "<bits/std_abs.h>",         private, "<cstdlib>",      public ] },
+    { include: [ "<bits/utility.h>",         private, "<utility>",      public ] },
+
     { include: [ "<bits/types/struct_tm.h>", private, "<ctime>",        public ] },
+
     { include: [ "<ext/alloc_traits.h>",     private, "<memory>",       public ] },
 
     { include: [ "\"begin_code.h\"",         private, "<SDL_stdinc.h>", public ] }

--- a/src/fheroes2/agg/bin_info.h
+++ b/src/fheroes2/agg/bin_info.h
@@ -21,7 +21,8 @@
 #ifndef H2BIN_FRM_H
 #define H2BIN_FRM_H
 
-#include <algorithm>
+// TODO: this header is redundant here, but detected as required by IWYU with older compilers
+// IWYU pragma: no_include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <vector>

--- a/src/fheroes2/monster/monster_info.h
+++ b/src/fheroes2/monster/monster_info.h
@@ -21,7 +21,8 @@
 #ifndef H2MONSTER_INFO_H
 #define H2MONSTER_INFO_H
 
-#include <algorithm>
+// TODO: this header is redundant here, but detected as required by IWYU with older compilers
+// IWYU pragma: no_include <algorithm>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/src/fheroes2/resource/artifact_info.cpp
+++ b/src/fheroes2/resource/artifact_info.cpp
@@ -18,6 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <memory>

--- a/src/fheroes2/resource/artifact_info.h
+++ b/src/fheroes2/resource/artifact_info.h
@@ -20,7 +20,8 @@
 
 #pragma once
 
-#include <algorithm>
+// TODO: this header is redundant here, but detected as required by IWYU with older compilers
+// IWYU pragma: no_include <algorithm>
 #include <cstdint>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Fix migration of Ubuntu 22.04 image from 20221027.1 to 20221119.2 with the newer compiler.

See [this run](https://github.com/ihhub/fheroes2/actions/runs/3525606072/jobs/5912534513) and [this comment](https://github.com/ihhub/fheroes2/pull/5983#issuecomment-1324094001) for details.