### PR TITLE
Fix French and Italian characters not being shown with their assets

### DIFF
--- a/files/lang/Makefile
+++ b/files/lang/Makefile
@@ -28,6 +28,11 @@ all: $(patsubst %.po, %.mo, $(wildcard *.po))
 merge: ../../src/dist/fheroes2.pot
 	for i in $(wildcard *.po); do msgmerge -U --no-location $$i $<; done
 
+# In French, accented characters are mapped to unused ASCII characters
+# Non-mapped characters are replaced by their non-accented equivalents
+fr.mo: fr.po
+	sed -e 'y/àâçéèêîïôùûüÇÉÊÀ/@*^~`|><#&$$uCEEA/; s/œ/oe/g' $< | msgfmt - -o $@
+
 # Czech, Hungarian and Polish versions use CP1250
 cs.mo hu.mo pl.mo: %.mo: %.po
 	$(call MSGFMT,CP1250)
@@ -39,7 +44,7 @@ be.mo bg.mo ru.mo uk.mo: %.mo: %.po
 	$(call MSGFMT,CP1251)
 
 # German, French, Italian, Dutch, Norwegian, Portuguese, Spanish and Swedish translations use CP1252
-de.mo es.mo fr.mo it.mo nb.mo pt.mo sv.mo nl.mo: %.mo: %.po
+de.mo es.mo it.mo nb.mo pt.mo sv.mo nl.mo: %.mo: %.po
 	$(call MSGFMT,CP1252)
 
 # Turkish uses CP1254

--- a/files/lang/Makefile
+++ b/files/lang/Makefile
@@ -28,11 +28,6 @@ all: $(patsubst %.po, %.mo, $(wildcard *.po))
 merge: ../../src/dist/fheroes2.pot
 	for i in $(wildcard *.po); do msgmerge -U --no-location $$i $<; done
 
-# In French, accented characters are mapped to unused ASCII characters
-# Non-mapped characters are replaced by their non-accented equivalents
-fr.mo: fr.po
-	sed -e 'y/àâçéèêîïôùûüÇÉÊÀ/@*^~`|><#&$$uCEEA/; s/œ/oe/g' $< | msgfmt - -o $@
-
 # Czech, Hungarian and Polish versions use CP1250
 cs.mo hu.mo pl.mo: %.mo: %.po
 	$(call MSGFMT,CP1250)
@@ -44,7 +39,7 @@ be.mo bg.mo ru.mo uk.mo: %.mo: %.po
 	$(call MSGFMT,CP1251)
 
 # German, French, Italian, Dutch, Norwegian, Portuguese, Spanish and Swedish translations use CP1252
-de.mo es.mo it.mo nb.mo pt.mo sv.mo nl.mo: %.mo: %.po
+de.mo es.mo fr.mo it.mo nb.mo pt.mo sv.mo nl.mo: %.mo: %.po
 	$(call MSGFMT,CP1252)
 
 # Turkish uses CP1254

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -881,7 +881,7 @@ namespace fheroes2
                 }
 
                 // Polish version uses CP1251
-                if ( crc32 == ( 0xE9EC7A63 || 0x88774771 ) ) {
+                if ( crc32 == 0xE9EC7A63 || crc32 == 0x88774771 ) {
                     // Engine expects that letter indexes correspond to charcode - 0x20.
                     // In case CP1251 font.icn contains sprites for chars 0x20-0x7F, 0xC0-0xDF, 0xA8, 0xE0-0xFF, 0xB8 (in that order).
                     // We rearrange sprites array for corresponding sprite indexes to charcode - 0x20.
@@ -892,7 +892,7 @@ namespace fheroes2
                     imageArray.erase( imageArray.begin() + 192 );
                 }
                 // German version uses CP1252
-                if ( crc32 == ( 0x04745D1D || 0xD0F0D852 ) ) {
+                if ( crc32 == 0x04745D1D || crc32 == 0xD0F0D852 ) {
                     imageArray.insert( imageArray.begin() + 96, 124, imageArray[0] );
                     std::swap( imageArray[164], imageArray[224] );
                     std::swap( imageArray[182], imageArray[225] );
@@ -904,7 +904,7 @@ namespace fheroes2
                     imageArray.erase( imageArray.begin() + 221, imageArray.end() );
                 }
                 // French version has its own special encoding but should conform to CP1252 too
-                if ( crc32 == ( 0xD9556567 || 0x406967B9 ) ) {
+                if ( crc32 == 0xD9556567 || crc32 == 0x406967B9 ) {
                     imageArray.insert( imageArray.begin() + 96, 160 - 32, imageArray[0] );
                     imageArray[192 - 32] = imageArray[33];
                     imageArray[199 - 32] = imageArray[35];

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -863,7 +863,7 @@ namespace fheroes2
                 const uint32_t crc32 = fheroes2::calculateCRC32( body.data(), body.size() );
 
                 if ( id == ICN::SMALFONT ) {
-                    // Small font in official Polish GoG version has all letters to be shifted by 1 pixel lower.
+                    // Small font in official Polish GoG version has all letters shifted 1 pixel down.
                     if ( crc32 == 0xE9EC7A63 ) {
                         for ( Sprite & letter : imageArray ) {
                             letter.setPosition( letter.x(), letter.y() - 1 );
@@ -881,8 +881,7 @@ namespace fheroes2
                 }
 
                 // Some checks that we really have CP1251 font
-                int32_t verifiedFontWidth = ( id == ICN::FONT ) ? 19 : 12;
-                if ( imageArray.size() == 162 && imageArray[121].width() == verifiedFontWidth ) {
+                if ( crc32 == 0xE9EC7A63 ) {
                     // Engine expects that letter indexes correspond to charcode - 0x20.
                     // In case CP1251 font.icn contains sprites for chars 0x20-0x7F, 0xC0-0xDF, 0xA8, 0xE0-0xFF, 0xB8 (in that order).
                     // We rearrange sprites array for corresponding sprite indexes to charcode - 0x20.
@@ -893,8 +892,7 @@ namespace fheroes2
                     imageArray.erase( imageArray.begin() + 192 );
                 }
                 // German version uses CP1252
-                verifiedFontWidth = ( id == ICN::FONT ) ? 10 : 7;
-                if ( imageArray.size() == 103 && imageArray[99].width() == verifiedFontWidth ) {
+                if ( crc32 == 0x4C758F2F ) {
                     imageArray.insert( imageArray.begin() + 96, 124, imageArray[0] );
                     std::swap( imageArray[164], imageArray[224] );
                     std::swap( imageArray[182], imageArray[225] );

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -924,7 +924,7 @@ namespace fheroes2
                     imageArray[238 - 32] = imageArray[93];
                     imageArray[233 - 32] = imageArray[94];
                     imageArray[238 - 32] = imageArray[95];
-                    imageArray.erase( imageArray.begin() + 251 - 32, imageArray.end() );
+                    imageArray.erase( imageArray.begin() + 252 - 32, imageArray.end() );
                 }
                 return true;
             }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -904,6 +904,26 @@ namespace fheroes2
                     std::swap( imageArray[220], imageArray[222] );
                     imageArray.erase( imageArray.begin() + 221, imageArray.end() );
                 }
+                // French version has its own special encoding but should conform to CP1252 too
+                verifiedFontWidth = ( id == ICN::FONT ) ? 9 : 5;
+                if ( imageArray.size() == 96 && imageArray[3].width() == verifiedFontWidth ) {
+                    imageArray.insert( imageArray.begin() + 96, 160 - 32, imageArray[0] );
+                    imageArray[244 - 32] = imageArray[3];
+                    imageArray[251 - 32] = imageArray[4];
+                    imageArray[249 - 32] = imageArray[6];
+                    imageArray[226 - 32] = imageArray[10];
+                    imageArray[239 - 32] = imageArray[28];
+                    imageArray[238 - 32] = imageArray[30];
+                    imageArray[224 - 32] = imageArray[32];
+                    imageArray[231 - 32] = imageArray[62];
+                    imageArray[232 - 32] = imageArray[64];
+                    imageArray[239 - 32] = imageArray[91];
+                    imageArray[234 - 32] = imageArray[92];
+                    imageArray[238 - 32] = imageArray[93];
+                    imageArray[233 - 32] = imageArray[94];
+                    imageArray[238 - 32] = imageArray[95];
+                    imageArray.erase( imageArray.begin() + 251 - 32, imageArray.end() );
+                }
                 return true;
             }
             case ICN::YELLOW_FONT:

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -880,8 +880,8 @@ namespace fheroes2
                     modifyBaseNormalFont( _icnVsSprite[id] );
                 }
 
-                // Some checks that we really have CP1251 font
-                if ( crc32 == 0xE9EC7A63 ) {
+                // Polish version uses CP1251
+                if ( crc32 == ( 0xE9EC7A63 || 0x88774771 ) ) {
                     // Engine expects that letter indexes correspond to charcode - 0x20.
                     // In case CP1251 font.icn contains sprites for chars 0x20-0x7F, 0xC0-0xDF, 0xA8, 0xE0-0xFF, 0xB8 (in that order).
                     // We rearrange sprites array for corresponding sprite indexes to charcode - 0x20.
@@ -892,7 +892,7 @@ namespace fheroes2
                     imageArray.erase( imageArray.begin() + 192 );
                 }
                 // German version uses CP1252
-                if ( crc32 == 0x4C758F2F ) {
+                if ( crc32 == ( 0x04745D1D || 0xD0F0D852 ) ) {
                     imageArray.insert( imageArray.begin() + 96, 124, imageArray[0] );
                     std::swap( imageArray[164], imageArray[224] );
                     std::swap( imageArray[182], imageArray[225] );
@@ -904,7 +904,7 @@ namespace fheroes2
                     imageArray.erase( imageArray.begin() + 221, imageArray.end() );
                 }
                 // French version has its own special encoding but should conform to CP1252 too
-                if ( crc32 == 0x0B0AAE3E ) {
+                if ( crc32 == ( 0xD9556567 || 0x406967B9 ) ) {
                     imageArray.insert( imageArray.begin() + 96, 160 - 32, imageArray[0] );
                     imageArray[192 - 32] = imageArray[33];
                     imageArray[199 - 32] = imageArray[35];

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -880,8 +880,9 @@ namespace fheroes2
                     modifyBaseNormalFont( _icnVsSprite[id] );
                 }
 
-                // Polish version uses CP1251
-                if ( crc32 == 0xE9EC7A63 || crc32 == 0x88774771 ) {
+                // Some checks that we really have CP1251 font
+                int32_t verifiedFontWidth = ( id == ICN::FONT ) ? 19 : 12;
+                if ( imageArray.size() == 162 && imageArray[121].width() == verifiedFontWidth ) {
                     // Engine expects that letter indexes correspond to charcode - 0x20.
                     // In case CP1251 font.icn contains sprites for chars 0x20-0x7F, 0xC0-0xDF, 0xA8, 0xE0-0xFF, 0xB8 (in that order).
                     // We rearrange sprites array for corresponding sprite indexes to charcode - 0x20.

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -929,7 +929,7 @@ namespace fheroes2
                 }
                 // Italian version uses CP1252
                 if ( crc32 == 0x219B3124 || crc32 == 0x1F3C3C74 ) {
-                    imageArray.insert( imageArray.begin() + 96, 160 - 32, imageArray[0] );
+                    imageArray.insert( imageArray.begin() + 101, 155 - 32, imageArray[0] );
                     imageArray[192 - 32] = imageArray[33];
                     imageArray[200 - 32] = imageArray[37];
                     imageArray[201 - 32] = imageArray[37];

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -926,6 +926,23 @@ namespace fheroes2
                     imageArray[238 - 32] = imageArray[95];
                     imageArray.erase( imageArray.begin() + 252 - 32, imageArray.end() );
                 }
+                // Italian version uses CP1252
+                if ( crc32 == 0x219B3124 || crc32 == 0x1F3C3C74 ) {
+                    imageArray.insert( imageArray.begin() + 96, 160 - 32, imageArray[0] );
+                    imageArray[192 - 32] = imageArray[33];
+                    imageArray[200 - 32] = imageArray[37];
+                    imageArray[201 - 32] = imageArray[37];
+                    imageArray[204 - 32] = imageArray[41];
+                    imageArray[210 - 32] = imageArray[47];
+                    imageArray[217 - 32] = imageArray[53];
+                    imageArray[224 - 32] = imageArray[96];
+                    imageArray[232 - 32] = imageArray[97];
+                    imageArray[233 - 32] = imageArray[69];
+                    imageArray[236 - 32] = imageArray[98];
+                    imageArray[242 - 32] = imageArray[99];
+                    imageArray[249 - 32] = imageArray[100];
+                    imageArray.erase( imageArray.begin() + 250 - 32, imageArray.end() );
+                }
                 return true;
             }
             case ICN::YELLOW_FONT:

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -859,10 +859,11 @@ namespace fheroes2
 
                 auto & imageArray = _icnVsSprite[id];
 
+                const std::vector<uint8_t> & body = ::AGG::getDataFromAggFile( ICN::GetString( id ) );
+                const uint32_t crc32 = fheroes2::calculateCRC32( body.data(), body.size() );
+
                 if ( id == ICN::SMALFONT ) {
                     // Small font in official Polish GoG version has all letters to be shifted by 1 pixel lower.
-                    const std::vector<uint8_t> & body = ::AGG::getDataFromAggFile( ICN::GetString( id ) );
-                    const uint32_t crc32 = fheroes2::calculateCRC32( body.data(), body.size() );
                     if ( crc32 == 0xE9EC7A63 ) {
                         for ( Sprite & letter : imageArray ) {
                             letter.setPosition( letter.x(), letter.y() - 1 );
@@ -905,8 +906,7 @@ namespace fheroes2
                     imageArray.erase( imageArray.begin() + 221, imageArray.end() );
                 }
                 // French version has its own special encoding but should conform to CP1252 too
-                verifiedFontWidth = ( id == ICN::FONT ) ? 9 : 5;
-                if ( imageArray.size() == 96 && imageArray[3].width() == verifiedFontWidth ) {
+                if ( crc32 == 0x0B0AAE3E  ) {
                     imageArray.insert( imageArray.begin() + 96, 160 - 32, imageArray[0] );
                     imageArray[244 - 32] = imageArray[3];
                     imageArray[251 - 32] = imageArray[4];

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -906,8 +906,12 @@ namespace fheroes2
                     imageArray.erase( imageArray.begin() + 221, imageArray.end() );
                 }
                 // French version has its own special encoding but should conform to CP1252 too
-                if ( crc32 == 0x0B0AAE3E  ) {
+                if ( crc32 == 0x0B0AAE3E ) {
                     imageArray.insert( imageArray.begin() + 96, 160 - 32, imageArray[0] );
+                    imageArray[192 - 32] = imageArray[33];
+                    imageArray[199 - 32] = imageArray[35];
+                    imageArray[201 - 32] = imageArray[37];
+                    imageArray[202 - 32] = imageArray[37];
                     imageArray[244 - 32] = imageArray[3];
                     imageArray[251 - 32] = imageArray[4];
                     imageArray[249 - 32] = imageArray[6];

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -881,7 +881,7 @@ namespace fheroes2
                 }
 
                 // Some checks that we really have CP1251 font
-                int32_t verifiedFontWidth = ( id == ICN::FONT ) ? 19 : 12;
+                const int32_t verifiedFontWidth = ( id == ICN::FONT ) ? 19 : 12;
                 if ( imageArray.size() == 162 && imageArray[121].width() == verifiedFontWidth ) {
                     // Engine expects that letter indexes correspond to charcode - 0x20.
                     // In case CP1251 font.icn contains sprites for chars 0x20-0x7F, 0xC0-0xDF, 0xA8, 0xE0-0xFF, 0xB8 (in that order).


### PR DESCRIPTION
Due to changes from this PR https://github.com/ihhub/fheroes2/pull/6056 when you have the French original assets you will not get the French special characters.

In addition while I was at it I added support for Italian characters too.