### PR TITLE
Store everything in the fheroes2.cfg, remove the binary config file support

### DIFF
--- a/src/engine/tinyconfig.cpp
+++ b/src/engine/tinyconfig.cpp
@@ -28,6 +28,7 @@
 #include <cstddef>
 #include <regex>
 #include <system_error>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -126,6 +127,9 @@ fheroes2::Point TinyConfig::PointParams( const std::string & key, const fheroes2
     };
 
     fheroes2::Point result;
+
+    static_assert( std::is_integral<decltype( result.x )>::value && std::is_integral<decltype( result.y )>::value,
+                   "The type of result fields is not integer, check the logic of this method" );
 
     if ( !convertToInt( pointRegexMatch[1].str(), result.x ) ) {
         return fallbackValue;

--- a/src/engine/tinyconfig.cpp
+++ b/src/engine/tinyconfig.cpp
@@ -109,12 +109,11 @@ fheroes2::Point TinyConfig::PointParams( const std::string & key, const fheroes2
         return fallbackValue;
     }
 
-    const std::string & value = it->second;
     const std::regex pointRegex( "^\\[ *(-?[0-9]+) *, *(-?[0-9]+) *]$", std::regex_constants::extended );
 
     std::smatch pointRegexMatch;
 
-    if ( !std::regex_match( value, pointRegexMatch, pointRegex ) ) {
+    if ( !std::regex_match( it->second, pointRegexMatch, pointRegex ) ) {
         return fallbackValue;
     }
 

--- a/src/engine/tinyconfig.cpp
+++ b/src/engine/tinyconfig.cpp
@@ -120,7 +120,7 @@ fheroes2::Point TinyConfig::PointParams( const std::string & key, const fheroes2
     assert( pointRegexMatch.size() == 3 );
 
     auto convertToInt = []( const std::string & str, auto & intValue ) {
-        auto [ptr, ec] = std::from_chars( str.data(), str.data() + str.size(), intValue );
+        const auto [ptr, ec] = std::from_chars( str.data(), str.data() + str.size(), intValue );
 
         return ec == std::errc();
     };

--- a/src/engine/tinyconfig.cpp
+++ b/src/engine/tinyconfig.cpp
@@ -27,6 +27,7 @@
 #include <charconv>
 #include <cstddef>
 #include <regex>
+#include <system_error>
 #include <utility>
 #include <vector>
 

--- a/src/engine/tinyconfig.cpp
+++ b/src/engine/tinyconfig.cpp
@@ -116,8 +116,8 @@ fheroes2::Point TinyConfig::PointParams( const std::string & key, const fheroes2
 
     assert( pointRegexMatch.size() == 3 );
 
-    auto convertToInt = []( const std::string & str, auto & value ) {
-        auto [ptr, ec] = std::from_chars( str.data(), str.data() + str.size(), value );
+    auto convertToInt = []( const std::string & str, auto & intValue ) {
+        auto [ptr, ec] = std::from_chars( str.data(), str.data() + str.size(), intValue );
 
         return ec == std::errc();
     };

--- a/src/engine/tinyconfig.cpp
+++ b/src/engine/tinyconfig.cpp
@@ -109,7 +109,7 @@ fheroes2::Point TinyConfig::PointParams( const std::string & key, const fheroes2
         return fallbackValue;
     }
 
-    const std::regex pointRegex( "^\\[ *(-?[0-9]+) *, *(-?[0-9]+) *]$", std::regex_constants::extended );
+    static const std::regex pointRegex( "^\\[ *(-?[0-9]+) *, *(-?[0-9]+) *]$", std::regex_constants::extended );
 
     std::smatch pointRegexMatch;
 

--- a/src/engine/tinyconfig.cpp
+++ b/src/engine/tinyconfig.cpp
@@ -35,22 +35,25 @@
 #include "tinyconfig.h"
 #include "tools.h"
 
-bool SpaceCompare( char a, char b )
+namespace
 {
-    return std::isspace( a ) && std::isspace( b );
-}
+    bool SpaceCompare( char a, char b )
+    {
+        return std::isspace( a ) && std::isspace( b );
+    }
 
-std::string ModifyKey( const std::string & str )
-{
-    std::string key = StringTrim( StringLower( str ) );
+    std::string ModifyKey( const std::string & str )
+    {
+        std::string key = StringTrim( StringLower( str ) );
 
-    // remove multiple space
-    key.erase( std::unique( key.begin(), key.end(), SpaceCompare ), key.end() );
+        // remove multiple space
+        key.erase( std::unique( key.begin(), key.end(), SpaceCompare ), key.end() );
 
-    // change space
-    std::replace_if( key.begin(), key.end(), ::isspace, '\x20' );
+        // change space
+        std::replace_if( key.begin(), key.end(), ::isspace, '\x20' );
 
-    return key;
+        return key;
+    }
 }
 
 TinyConfig::TinyConfig( char sep, char com )

--- a/src/engine/tinyconfig.cpp
+++ b/src/engine/tinyconfig.cpp
@@ -104,7 +104,7 @@ std::string TinyConfig::StrParams( const std::string & key ) const
 
 fheroes2::Point TinyConfig::PointParams( const std::string & key, const fheroes2::Point & fallbackValue ) const
 {
-    const_iterator it = find( ModifyKey( key ) );
+    const const_iterator it = find( ModifyKey( key ) );
     if ( it == end() ) {
         return fallbackValue;
     }

--- a/src/engine/tinyconfig.h
+++ b/src/engine/tinyconfig.h
@@ -29,7 +29,7 @@
 
 #include "math_base.h"
 
-class TinyConfig : protected std::multimap<std::string, std::string>
+class TinyConfig : private std::multimap<std::string, std::string>
 {
 public:
     TinyConfig( char sep = '=', char com = ';' );
@@ -44,7 +44,7 @@ public:
     // In case of any error, the fallback value is returned.
     fheroes2::Point PointParams( const std::string & key, const fheroes2::Point & fallbackValue ) const;
 
-protected:
+private:
     char separator;
     char comment;
 };

--- a/src/engine/tinyconfig.h
+++ b/src/engine/tinyconfig.h
@@ -27,6 +27,8 @@
 #include <map>
 #include <string>
 
+#include "math_base.h"
+
 class TinyConfig : protected std::multimap<std::string, std::string>
 {
 public:
@@ -38,6 +40,9 @@ public:
 
     int IntParams( const std::string & key ) const;
     std::string StrParams( const std::string & key ) const;
+    // Tries to find and return a Point-type struct stored as a string "[ x, y ]" for a given key.
+    // In case of any error, the fallback value is returned.
+    fheroes2::Point PointParams( const std::string & key, const fheroes2::Point & fallbackValue ) const;
 
 protected:
     char separator;

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -390,7 +390,7 @@ Battle::Arena::Arena( Army & army1, Army & army2, const int32_t tileIndex, const
     if ( _interface ) {
         fheroes2::Display & display = fheroes2::Display::instance();
 
-        if ( Settings::ExtGameUseFade() )
+        if ( Settings::isFadeEffectEnabled() )
             fheroes2::FadeDisplay();
 
         _interface->fullRedraw();

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -245,7 +245,7 @@ namespace
         // setup cursor
         const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-        const bool isEvilInterface = conf.ExtGameEvilInterface();
+        const bool isEvilInterface = conf.isEvilInterfaceEnabled();
 
         const fheroes2::Sprite & dialog = fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::SPANBKGE : ICN::SPANBKG ), 0 );
         const fheroes2::Sprite & dialogShadow = fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::SPANBKGE : ICN::SPANBKG ), 1 );
@@ -528,7 +528,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
         sequence.push( ICN::UNKNOWN, false );
     }
 
-    const bool isEvilInterface = conf.ExtGameEvilInterface();
+    const bool isEvilInterface = conf.isEvilInterfaceEnabled();
     const fheroes2::Sprite & dialog = fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::WINLOSEE : ICN::WINLOSE ), 0 );
     const fheroes2::Sprite & dialogShadow = fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::WINLOSEE : ICN::WINLOSE ), 1 );
 
@@ -724,7 +724,7 @@ void Battle::Arena::DialogBattleNecromancy( const uint32_t raiseCount, const uin
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+    const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
     const fheroes2::Sprite & dialog = fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::WINLOSEE : ICN::WINLOSE ), 0 );
     const fheroes2::Sprite & dialogShadow = fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::WINLOSEE : ICN::WINLOSE ), 1 );
 
@@ -813,7 +813,7 @@ int Battle::Arena::DialogBattleHero( const HeroBase & hero, const bool buttons, 
     cursor.SetThemes( Cursor::POINTER );
 
     const bool readonly = current_color != hero.GetColor() || !buttons;
-    const fheroes2::Sprite & dialog = fheroes2::AGG::GetICN( ( conf.ExtGameEvilInterface() ? ICN::VGENBKGE : ICN::VGENBKG ), 0 );
+    const fheroes2::Sprite & dialog = fheroes2::AGG::GetICN( ( conf.isEvilInterfaceEnabled() ? ICN::VGENBKGE : ICN::VGENBKG ), 0 );
 
     const fheroes2::Point dialogShadow( 15, 15 );
 
@@ -1011,7 +1011,7 @@ bool Battle::DialogBattleSurrender( const HeroBase & hero, uint32_t cost, Kingdo
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    const bool isEvilInterface = conf.ExtGameEvilInterface();
+    const bool isEvilInterface = conf.isEvilInterfaceEnabled();
 
     const fheroes2::Sprite & dialog = fheroes2::AGG::GetICN( isEvilInterface ? ICN::SURDRBKE : ICN::SURDRBKG, 0 );
 

--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -406,7 +406,7 @@ void BuildingInfo::Redraw() const
 
         // build image
         if ( BUILD_NOTHING == building ) {
-            const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+            const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
             fheroes2::Blit( fheroes2::AGG::GetICN( isEvilInterface ? ICN::CASLXTRA_EVIL : ICN::CASLXTRA, 0 ), display, area.x, area.y );
             return;
         }
@@ -476,7 +476,7 @@ bool BuildingInfo::DialogBuyBuilding( bool buttons ) const
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
-    const int system = ( Settings::Get().ExtGameEvilInterface() ? ICN::SYSTEME : ICN::SYSTEM );
+    const int system = ( Settings::Get().isEvilInterfaceEnabled() ? ICN::SYSTEME : ICN::SYSTEM );
 
     // setup cursor
     const CursorRestorer cursorRestorer( buttons, Cursor::POINTER );

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -223,7 +223,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool readOnly, const b
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
     // Fade screen.
-    if ( Settings::ExtGameUseFade() )
+    if ( Settings::isFadeEffectEnabled() )
         fheroes2::FadeDisplay();
 
     const fheroes2::StandardWindow background( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );

--- a/src/fheroes2/castle/castle_mageguild.cpp
+++ b/src/fheroes2/castle/castle_mageguild.cpp
@@ -165,7 +165,7 @@ void Castle::OpenMageGuild( const Heroes * hero ) const
     const fheroes2::Point cur_pt( restorer.x(), restorer.y() );
     fheroes2::Point dst_pt( cur_pt.x, cur_pt.y );
 
-    const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+    const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
     fheroes2::Blit( fheroes2::AGG::GetICN( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 ), display, cur_pt.x, cur_pt.y );
 

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -64,7 +64,7 @@ int Castle::DialogBuyHero( const Heroes * hero ) const
     if ( !hero )
         return Dialog::CANCEL;
 
-    const int system = ( Settings::Get().ExtGameEvilInterface() ? ICN::SYSTEME : ICN::SYSTEM );
+    const int system = ( Settings::Get().isEvilInterfaceEnabled() ? ICN::SYSTEME : ICN::SYSTEM );
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -187,7 +187,7 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
     const fheroes2::Point cur_pt( restorer.x(), restorer.y() );
     fheroes2::Point dst_pt( cur_pt );
 
-    const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+    const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
     fheroes2::Blit( fheroes2::AGG::GetICN( isEvilInterface ? ICN::CASLWIND_EVIL : ICN::CASLWIND, 0 ), display, dst_pt.x, dst_pt.y );
 

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -306,7 +306,7 @@ void Castle::OpenWell()
 void Castle::WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vector<fheroes2::RandomMonsterAnimation> & monsterAnimInfo ) const
 {
     fheroes2::Display & display = fheroes2::Display::instance();
-    const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+    const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
     fheroes2::Blit( fheroes2::AGG::GetICN( isEvilInterface ? ICN::WELLBKG_EVIL : ICN::WELLBKG, 0 ), display, cur_pt.x, cur_pt.y );
 

--- a/src/fheroes2/dialog/dialog_adventure.cpp
+++ b/src/fheroes2/dialog/dialog_adventure.cpp
@@ -39,7 +39,7 @@
 int Dialog::AdventureOptions( bool enabledig )
 {
     // preload
-    const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+    const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
     const int apanbkg = isEvilInterface ? ICN::APANBKGE : ICN::APANBKG;
     const int apanel = isEvilInterface ? ICN::APANELE : ICN::APANEL;
 

--- a/src/fheroes2/dialog/dialog_arena.cpp
+++ b/src/fheroes2/dialog/dialog_arena.cpp
@@ -101,7 +101,7 @@ namespace
 int Dialog::SelectSkillFromArena()
 {
     fheroes2::Display & display = fheroes2::Display::instance();
-    const int system = Settings::Get().ExtGameEvilInterface() ? ICN::SYSTEME : ICN::SYSTEM;
+    const int system = Settings::Get().isEvilInterfaceEnabled() ? ICN::SYSTEME : ICN::SYSTEM;
 
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -134,7 +134,7 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
 {
     // The active size of the window is 520 by 256 pixels
     fheroes2::Display & display = fheroes2::Display::instance();
-    const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+    const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
     const int viewarmy = isEvilInterface ? ICN::VIEWARME : ICN::VIEWARMY;
     const fheroes2::Sprite & sprite_dialog = fheroes2::AGG::GetICN( viewarmy, 0 );

--- a/src/fheroes2/dialog/dialog_audio.cpp
+++ b/src/fheroes2/dialog/dialog_audio.cpp
@@ -109,7 +109,7 @@ namespace Dialog
         const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
         Settings & conf = Settings::Get();
-        const bool isEvilInterface = conf.ExtGameEvilInterface();
+        const bool isEvilInterface = conf.isEvilInterfaceEnabled();
 
         fheroes2::Display & display = fheroes2::Display::instance();
 

--- a/src/fheroes2/dialog/dialog_box.cpp
+++ b/src/fheroes2/dialog/dialog_box.cpp
@@ -99,7 +99,7 @@ Dialog::NonFixedFrameBox::NonFixedFrameBox( int height, int startYPos, bool show
     if ( showButtons )
         height += buttonHeight;
 
-    const bool evil = Settings::Get().ExtGameEvilInterface();
+    const bool evil = Settings::Get().isEvilInterfaceEnabled();
     _middleFragmentCount = ( height <= 2 * activeAreaHeight ? 0 : 1 + ( height - 2 * activeAreaHeight ) / activeAreaHeight );
     _middleFragmentHeight = height <= 2 * activeAreaHeight ? 0 : height - 2 * activeAreaHeight;
     const int32_t height_top_bottom = topHeight( evil ) + bottomHeight( evil );
@@ -127,7 +127,7 @@ Dialog::NonFixedFrameBox::NonFixedFrameBox( int height, int startYPos, bool show
 
 void Dialog::NonFixedFrameBox::redraw()
 {
-    const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+    const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
     const int buybuild = isEvilInterface ? ICN::BUYBUILE : ICN::BUYBUILD;
 
     const int32_t overallLeftWidth = leftWidth( isEvilInterface );

--- a/src/fheroes2/dialog/dialog_buyboat.cpp
+++ b/src/fheroes2/dialog/dialog_buyboat.cpp
@@ -41,7 +41,7 @@ int Dialog::BuyBoat( bool enable )
 {
     fheroes2::Display & display = fheroes2::Display::instance();
 
-    const int system = Settings::Get().ExtGameEvilInterface() ? ICN::SYSTEME : ICN::SYSTEM;
+    const int system = Settings::Get().isEvilInterfaceEnabled() ? ICN::SYSTEME : ICN::SYSTEM;
 
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );

--- a/src/fheroes2/dialog/dialog_chest.cpp
+++ b/src/fheroes2/dialog/dialog_chest.cpp
@@ -45,7 +45,7 @@
 bool Dialog::SelectGoldOrExp( const std::string & header, const std::string & message, uint32_t gold, uint32_t expr, const Heroes & hero )
 {
     fheroes2::Display & display = fheroes2::Display::instance();
-    const int system = Settings::Get().ExtGameEvilInterface() ? ICN::SYSTEME : ICN::SYSTEM;
+    const int system = Settings::Get().isEvilInterfaceEnabled() ? ICN::SYSTEME : ICN::SYSTEM;
 
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );

--- a/src/fheroes2/dialog/dialog_file.cpp
+++ b/src/fheroes2/dialog/dialog_file.cpp
@@ -44,7 +44,7 @@
 fheroes2::GameMode Dialog::FileOptions()
 {
     // preload
-    const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+    const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
     const int cpanbkg = isEvilInterface ? ICN::CPANBKGE : ICN::CPANBKG;
     const int cpanel = isEvilInterface ? ICN::CPANELE : ICN::CPANEL;
 

--- a/src/fheroes2/dialog/dialog_frameborder.cpp
+++ b/src/fheroes2/dialog/dialog_frameborder.cpp
@@ -114,7 +114,7 @@ const fheroes2::Rect & Dialog::FrameBorder::GetArea() const
 
 void Dialog::FrameBorder::RenderRegular( const fheroes2::Rect & dstrt )
 {
-    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ( Settings::Get().ExtGameEvilInterface() ? ICN::SURDRBKE : ICN::SURDRBKG ), 0 );
+    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ( Settings::Get().isEvilInterfaceEnabled() ? ICN::SURDRBKE : ICN::SURDRBKG ), 0 );
     const fheroes2::Image renderedImage
         = fheroes2::Stretch( sprite, SHADOWWIDTH, 0, sprite.width() - SHADOWWIDTH, sprite.height() - SHADOWWIDTH, dstrt.width, dstrt.height );
     fheroes2::Blit( renderedImage, fheroes2::Display::instance(), dstrt.x, dstrt.y );

--- a/src/fheroes2/dialog/dialog_game_settings.cpp
+++ b/src/fheroes2/dialog/dialog_game_settings.cpp
@@ -120,7 +120,7 @@ namespace
         fheroes2::Display & display = fheroes2::Display::instance();
 
         const Settings & conf = Settings::Get();
-        const bool isEvilInterface = conf.ExtGameEvilInterface();
+        const bool isEvilInterface = conf.isEvilInterfaceEnabled();
         const int dialogIcnId = isEvilInterface ? ICN::CSPANBKE : ICN::CSPANBKG;
         const fheroes2::Sprite & dialog = fheroes2::AGG::GetICN( dialogIcnId, 0 );
         const fheroes2::Sprite & dialogShadow = fheroes2::AGG::GetICN( dialogIcnId, 1 );

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -258,7 +258,7 @@ void Dialog::MakeGiftResource( Kingdom & kingdom )
     ResourceBar info2( funds2, posX, box.y + 150 );
     info2.Redraw();
 
-    const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+    const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
     const int okIcnId = isEvilInterface ? ICN::NON_UNIFORM_EVIL_OKAY_BUTTON : ICN::NON_UNIFORM_GOOD_OKAY_BUTTON;
     const int cancelIcnId = isEvilInterface ? ICN::NON_UNIFORM_EVIL_CANCEL_BUTTON : ICN::NON_UNIFORM_GOOD_CANCEL_BUTTON;
     const fheroes2::Sprite & buttonOkSprite = fheroes2::AGG::GetICN( okIcnId, 0 );

--- a/src/fheroes2/dialog/dialog_graphics_settings.cpp
+++ b/src/fheroes2/dialog/dialog_graphics_settings.cpp
@@ -66,13 +66,13 @@ namespace
         const fheroes2::Display & display = fheroes2::Display::instance();
         std::string resolutionName = std::to_string( display.width() ) + 'x' + std::to_string( display.height() );
 
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, Settings::Get().ExtGameEvilInterface() ? 17 : 16 ), _( "Resolution" ),
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, Settings::Get().isEvilInterfaceEnabled() ? 17 : 16 ), _( "Resolution" ),
                               std::move( resolutionName ) );
     }
 
     void drawMode( const fheroes2::Rect & optionRoi )
     {
-        const fheroes2::Sprite & originalIcon = fheroes2::AGG::GetICN( ICN::SPANEL, Settings::Get().ExtGameEvilInterface() ? 17 : 16 );
+        const fheroes2::Sprite & originalIcon = fheroes2::AGG::GetICN( ICN::SPANEL, Settings::Get().isEvilInterfaceEnabled() ? 17 : 16 );
 
         if ( fheroes2::engine().isFullScreen() ) {
             fheroes2::Sprite icon = originalIcon;
@@ -114,7 +114,7 @@ namespace
         fheroes2::Display & display = fheroes2::Display::instance();
 
         const Settings & conf = Settings::Get();
-        const bool isEvilInterface = conf.ExtGameEvilInterface();
+        const bool isEvilInterface = conf.isEvilInterfaceEnabled();
         const fheroes2::Sprite & dialog = fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::ESPANBKG_EVIL : ICN::ESPANBKG ), 0 );
         const fheroes2::Sprite & dialogShadow = fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::CSPANBKE : ICN::CSPANBKG ), 1 );
 

--- a/src/fheroes2/dialog/dialog_levelup.cpp
+++ b/src/fheroes2/dialog/dialog_levelup.cpp
@@ -85,7 +85,7 @@ int DialogSelectSecondary( const std::string & name, const int primarySkillType,
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
-    const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+    const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
     const int system = isEvilInterface ? ICN::SYSTEME : ICN::SYSTEM;
 
     // setup cursor

--- a/src/fheroes2/dialog/dialog_marketplace.cpp
+++ b/src/fheroes2/dialog/dialog_marketplace.cpp
@@ -143,14 +143,14 @@ public:
     explicit TradeWindowGUI( const fheroes2::Rect & rt )
         : pos_rt( rt )
         , back( fheroes2::Display::instance() )
-        , tradpostIcnId( Settings::Get().ExtGameEvilInterface() ? ICN::TRADPOSE : ICN::TRADPOST )
+        , tradpostIcnId( Settings::Get().isEvilInterfaceEnabled() ? ICN::TRADPOSE : ICN::TRADPOST )
         , _singlePlayer( false )
     {
         Settings & conf = Settings::Get();
 
         back.update( rt.x - 5, rt.y + 15, rt.width + 10, 160 );
 
-        buttonGift.setICNInfo( conf.ExtGameEvilInterface() ? ICN::BTNGIFT_EVIL : ICN::BTNGIFT_GOOD, 0, 1 );
+        buttonGift.setICNInfo( conf.isEvilInterfaceEnabled() ? ICN::BTNGIFT_EVIL : ICN::BTNGIFT_GOOD, 0, 1 );
         buttonTrade.setICNInfo( tradpostIcnId, 15, 16 );
         buttonLeft.setICNInfo( tradpostIcnId, 3, 4 );
         buttonRight.setICNInfo( tradpostIcnId, 5, 6 );
@@ -331,7 +331,7 @@ void TradeWindowGUI::RedrawInfoBuySell( uint32_t count_sell, uint32_t count_buy,
 void Dialog::Marketplace( Kingdom & kingdom, bool fromTradingPost )
 {
     fheroes2::Display & display = fheroes2::Display::instance();
-    const int tradpost = Settings::Get().ExtGameEvilInterface() ? ICN::TRADPOSE : ICN::TRADPOST;
+    const int tradpost = Settings::Get().isEvilInterfaceEnabled() ? ICN::TRADPOSE : ICN::TRADPOST;
     const std::string & header = fromTradingPost ? _( "Trading Post" ) : _( "Marketplace" );
 
     // setup cursor
@@ -627,7 +627,7 @@ void RedrawResourceSprite( const fheroes2::Image & sf, int32_t px, int32_t py, i
 
 void RedrawFromResource( const fheroes2::Point & pt, const Funds & rs )
 {
-    const int tradpost = Settings::Get().ExtGameEvilInterface() ? ICN::TRADPOSE : ICN::TRADPOST;
+    const int tradpost = Settings::Get().isEvilInterfaceEnabled() ? ICN::TRADPOSE : ICN::TRADPOST;
 
     // wood
     RedrawResourceSprite( fheroes2::AGG::GetICN( tradpost, 7 ), pt.x, pt.y, rs.wood );
@@ -661,7 +661,7 @@ void RedrawResourceSprite2( const fheroes2::Image & sf, int32_t px, int32_t py, 
 
 void RedrawToResource( const fheroes2::Point & pt, bool showcost, const Kingdom & kingdom, bool tradingPost, int from_resource )
 {
-    const int tradpost = Settings::Get().ExtGameEvilInterface() ? ICN::TRADPOSE : ICN::TRADPOST;
+    const int tradpost = Settings::Get().isEvilInterfaceEnabled() ? ICN::TRADPOSE : ICN::TRADPOST;
 
     // wood
     RedrawResourceSprite2( fheroes2::AGG::GetICN( tradpost, 7 ), pt.x, pt.y, showcost, kingdom, from_resource, Resource::WOOD, tradingPost );

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -653,7 +653,7 @@ void Dialog::QuickInfo( const Castle & castle, const fheroes2::Point & position 
 
     // castle icon
     const Settings & conf = Settings::Get();
-    const fheroes2::Sprite & castleIcon = fheroes2::AGG::GetICN( conf.ExtGameEvilInterface() ? ICN::LOCATORE : ICN::LOCATORS, 23 );
+    const fheroes2::Sprite & castleIcon = fheroes2::AGG::GetICN( conf.isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS, 23 );
 
     dst_pt.x = cur_rt.x + ( cur_rt.width - castleIcon.width() ) / 2;
     dst_pt.y += 10;

--- a/src/fheroes2/dialog/dialog_recruit.cpp
+++ b/src/fheroes2/dialog/dialog_recruit.cpp
@@ -538,7 +538,7 @@ void Dialog::DwellingInfo( const Monster & monster, uint32_t available )
     // setup cursor
     const CursorRestorer cursorRestorer( false, Cursor::POINTER );
 
-    const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+    const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
     const int icnId = isEvilInterface ? ICN::RECR2BKG_EVIL : ICN::RECR2BKG;
 
     const fheroes2::Sprite & box = fheroes2::AGG::GetICN( icnId, 0 );

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -225,7 +225,7 @@ bool Dialog::SelectCount( const std::string & header, uint32_t min, uint32_t max
 
 bool Dialog::InputString( const std::string & header, std::string & res, const std::string & title, const size_t charLimit )
 {
-    const int system = Settings::Get().ExtGameEvilInterface() ? ICN::SYSTEME : ICN::SYSTEM;
+    const int system = Settings::Get().isEvilInterfaceEnabled() ? ICN::SYSTEME : ICN::SYSTEM;
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -238,7 +238,7 @@ bool Dialog::InputString( const std::string & header, std::string & res, const s
 
     TextBox titlebox( title, Font::YELLOW_BIG, BOXAREA_WIDTH );
     TextBox textbox( header, Font::BIG, BOXAREA_WIDTH );
-    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ( Settings::Get().ExtGameEvilInterface() ? ICN::BUYBUILD : ICN::BUYBUILE ), 3 );
+    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ( Settings::Get().isEvilInterfaceEnabled() ? ICN::BUYBUILD : ICN::BUYBUILE ), 3 );
 
     const uint32_t titleHeight = title.empty() ? 0 : titlebox.h() + 10;
     FrameBox box( 10 + titleHeight + textbox.h() + 10 + sprite.height(), true );
@@ -397,7 +397,7 @@ int Dialog::ArmySplitTroop( uint32_t freeSlots, const uint32_t redistributeMax, 
     btnGroups.draw();
 
     const fheroes2::Point minMaxButtonOffset( pos.x + 165, pos.y + 30 );
-    const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+    const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
     fheroes2::Button buttonMax( minMaxButtonOffset.x, minMaxButtonOffset.y, isEvilInterface ? ICN::UNIFORM_EVIL_MAX_BUTTON : ICN::UNIFORM_GOOD_MAX_BUTTON, 0, 1 );
     fheroes2::Button buttonMin( minMaxButtonOffset.x, minMaxButtonOffset.y, isEvilInterface ? ICN::UNIFORM_EVIL_MIN_BUTTON : ICN::UNIFORM_GOOD_MIN_BUTTON, 0, 1 );
 

--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -158,7 +158,7 @@ namespace
         fheroes2::drawOption( rects[5], scrollSpeedIcon, _( "Scroll Speed" ), scrollSpeedName );
 
         // Interface theme.
-        const bool isEvilInterface = conf.ExtGameEvilInterface();
+        const bool isEvilInterface = conf.isEvilInterfaceEnabled();
         const fheroes2::Sprite & interfaceThemeIcon = fheroes2::AGG::GetICN( ICN::SPANEL, isEvilInterface ? 17 : 16 );
         if ( isEvilInterface ) {
             value = _( "Evil" );
@@ -170,7 +170,7 @@ namespace
         fheroes2::drawOption( rects[6], interfaceThemeIcon, _( "Interface Type" ), value );
 
         // Interface show/hide state.
-        const bool isHiddenInterface = conf.ExtGameHideInterface();
+        const bool isHiddenInterface = conf.isHideInterfaceEnabled();
         const fheroes2::Sprite & interfaceStateIcon
             = isHiddenInterface ? fheroes2::AGG::GetICN( ICN::ESPANEL, 4 ) : fheroes2::AGG::GetICN( ICN::SPANEL, isEvilInterface ? 17 : 16 );
         if ( isHiddenInterface ) {
@@ -201,7 +201,7 @@ namespace
         const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
         Settings & conf = Settings::Get();
-        const bool isEvilInterface = conf.ExtGameEvilInterface();
+        const bool isEvilInterface = conf.isEvilInterfaceEnabled();
 
         fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -412,7 +412,7 @@ namespace fheroes2
                 action = openSystemOptionsDialog( saveConfiguration );
                 break;
             case DialogAction::ChangeInterfaceTheme: {
-                conf.SetEvilInterface( !conf.ExtGameEvilInterface() );
+                conf.setEvilInterface( !conf.isEvilInterfaceEnabled() );
                 saveConfiguration = true;
 
                 Interface::Basic & basicInterface = Interface::Basic::Get();
@@ -423,7 +423,7 @@ namespace fheroes2
                 break;
             }
             case DialogAction::UpdateInterface: {
-                conf.SetHideInterface( !conf.ExtGameHideInterface() );
+                conf.setHideInterface( !conf.isHideInterfaceEnabled() );
                 saveConfiguration = true;
 
                 Interface::Basic & basicInterface = Interface::Basic::Get();

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1368,7 +1368,7 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
 
             Players & players = conf.GetPlayers();
             players.SetStartGame();
-            if ( Settings::ExtGameUseFade() )
+            if ( Settings::isFadeEffectEnabled() )
                 fheroes2::FadeDisplay();
 
             conf.SetGameType( Game::TYPE_CAMPAIGN );

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -782,7 +782,7 @@ namespace
         const fheroes2::StandardWindow frameborder( 234, 270 );
         const fheroes2::Rect & windowRoi = frameborder.activeArea();
 
-        const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+        const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
         const int buttonIcnId = isEvilInterface ? ICN::SPANBTNE : ICN::SPANBTN;
         const fheroes2::Sprite & buttonSprite = fheroes2::AGG::GetICN( buttonIcnId, 0 );
 

--- a/src/fheroes2/game/game_interface.cpp
+++ b/src/fheroes2/game/game_interface.cpp
@@ -79,9 +79,9 @@ void Interface::Basic::Reset()
         else {
             radar.SetPos( 0, 0 );
             // It's OK to use display.width() for the X coordinate here, panel will be docked to the right edge
-            iconsPanel.SetPos( display.width(), radar.GetArea().y + radar.GetArea().height + BORDERWIDTH );
-            buttonsArea.SetPos( display.width(), iconsPanel.GetArea().y + iconsPanel.GetArea().height + BORDERWIDTH );
-            statusWindow.SetPos( display.width(), buttonsArea.GetArea().y + buttonsArea.GetArea().height );
+            iconsPanel.SetPos( display.width(), radar.GetRect().y + radar.GetRect().height );
+            buttonsArea.SetPos( display.width(), iconsPanel.GetRect().y + iconsPanel.GetRect().height );
+            statusWindow.SetPos( display.width(), buttonsArea.GetRect().y + buttonsArea.GetRect().height );
         }
     }
     else {

--- a/src/fheroes2/game/game_interface.cpp
+++ b/src/fheroes2/game/game_interface.cpp
@@ -56,7 +56,7 @@ void Interface::Basic::Reset()
     const fheroes2::Display & display = fheroes2::Display::instance();
 
     Settings & conf = Settings::Get();
-    const bool isHideInterface = conf.ExtGameHideInterface();
+    const bool isHideInterface = conf.isHideInterfaceEnabled();
 
     if ( isHideInterface ) {
         conf.SetShowPanel( true );
@@ -115,7 +115,7 @@ void Interface::Basic::Redraw( const uint32_t force /* = 0 */ )
     const Settings & conf = Settings::Get();
 
     const uint32_t combinedRedraw = redraw | force;
-    const bool hideInterface = conf.ExtGameHideInterface();
+    const bool hideInterface = conf.isHideInterfaceEnabled();
 
     if ( combinedRedraw & REDRAW_GAMEAREA ) {
         gameArea.Redraw( fheroes2::Display::instance(), LEVEL_ALL );
@@ -159,8 +159,8 @@ int32_t Interface::Basic::GetDimensionDoorDestination( const int32_t from, const
     fheroes2::Display & display = fheroes2::Display::instance();
 
     const Settings & conf = Settings::Get();
-    const bool isEvilInterface = conf.ExtGameEvilInterface();
-    const bool isHideInterface = conf.ExtGameHideInterface();
+    const bool isEvilInterface = conf.isEvilInterfaceEnabled();
+    const bool isHideInterface = conf.isHideInterfaceEnabled();
 
     const fheroes2::Rect & radarRect = radar.GetRect();
     const fheroes2::Rect & radarArea = radar.GetArea();

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -257,7 +257,7 @@ namespace
         while ( true ) {
             if ( !le.HandleEvents( true, true ) ) {
                 if ( Interface::Basic::EventExit() == fheroes2::GameMode::QUIT_GAME ) {
-                    if ( Settings::ExtGameUseFade() ) {
+                    if ( Settings::isFadeEffectEnabled() ) {
                         fheroes2::FadeDisplay();
                     }
                     return fheroes2::GameMode::QUIT_GAME;
@@ -376,7 +376,7 @@ namespace
         Settings & conf = Settings::Get();
 
         conf.GetPlayers().SetStartGame();
-        if ( Settings::ExtGameUseFade() ) {
+        if ( Settings::isFadeEffectEnabled() ) {
             fheroes2::FadeDisplay();
         }
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -229,7 +229,7 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, bool windowIsGameW
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    bool needFade = Settings::ExtGameUseFade() && fheroes2::Display::instance().isDefaultSize();
+    bool needFade = Settings::isFadeEffectEnabled() && fheroes2::Display::instance().isDefaultSize();
 
     Interface::Basic & basicInterface = Interface::Basic::Get();
 
@@ -737,7 +737,7 @@ fheroes2::GameMode Interface::Basic::StartGame()
     // if we are here, the res value should never be fheroes2::GameMode::END_TURN
     assert( res != fheroes2::GameMode::END_TURN );
 
-    if ( Settings::ExtGameUseFade() )
+    if ( Settings::isFadeEffectEnabled() )
         fheroes2::FadeDisplay();
 
     return res;
@@ -775,7 +775,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
 
         ShowEventDayDialog();
 
-        if ( conf.isAutoSaveAtBeginingOfTurnEnabled() ) {
+        if ( conf.isAutoSaveAtBeginningOfTurnEnabled() ) {
             Game::AutoSave();
         }
     }
@@ -1181,7 +1181,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
                 }
             }
 
-            if ( !conf.isAutoSaveAtBeginingOfTurnEnabled() ) {
+            if ( !conf.isAutoSaveAtBeginningOfTurnEnabled() ) {
                 Game::AutoSave();
             }
         }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -956,7 +956,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
         }
 
         const fheroes2::Rect displayArea( 0, 0, display.width(), display.height() );
-        const bool isHiddenInterface = conf.ExtGameHideInterface();
+        const bool isHiddenInterface = conf.isHideInterfaceEnabled();
         const bool prevIsCursorOverButtons = isCursorOverButtons;
         isCursorOverButtons = false;
         isCursorOverGamearea = false;

--- a/src/fheroes2/gui/interface_border.cpp
+++ b/src/fheroes2/gui/interface_border.cpp
@@ -69,10 +69,10 @@ namespace
 void Interface::GameBorderRedraw( const bool viewWorldMode )
 {
     const Settings & conf = Settings::Get();
-    if ( conf.ExtGameHideInterface() && !viewWorldMode )
+    if ( conf.isHideInterfaceEnabled() && !viewWorldMode )
         return;
 
-    const bool isEvilInterface = conf.ExtGameEvilInterface();
+    const bool isEvilInterface = conf.isEvilInterfaceEnabled();
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -422,7 +422,7 @@ Interface::BorderWindow::BorderWindow( const fheroes2::Rect & rt )
 
 const fheroes2::Rect & Interface::BorderWindow::GetRect() const
 {
-    return Settings::Get().ExtGameHideInterface() && border.isValid() ? border.GetRect() : GetArea();
+    return Settings::Get().isHideInterfaceEnabled() && border.isValid() ? border.GetRect() : GetArea();
 }
 
 void Interface::BorderWindow::Redraw() const
@@ -440,7 +440,7 @@ void Interface::BorderWindow::SetPosition( int32_t px, int32_t py, uint32_t pw, 
 
 void Interface::BorderWindow::SetPosition( int32_t px, int32_t py )
 {
-    if ( Settings::Get().ExtGameHideInterface() ) {
+    if ( Settings::Get().isHideInterfaceEnabled() ) {
         const fheroes2::Display & display = fheroes2::Display::instance();
 
         px = std::max( 0, std::min( px, display.width() - ( area.width + border.BorderWidth() * 2 ) ) );
@@ -463,7 +463,7 @@ bool Interface::BorderWindow::QueueEventProcessing()
     const Settings & conf = Settings::Get();
     LocalEvent & le = LocalEvent::Get();
 
-    if ( conf.ExtGameHideInterface() && le.MousePressLeft( border.GetTop() ) ) {
+    if ( conf.isHideInterfaceEnabled() && le.MousePressLeft( border.GetTop() ) ) {
         fheroes2::Display & display = fheroes2::Display::instance();
 
         const fheroes2::Point & mp = le.GetMouseCursor();

--- a/src/fheroes2/gui/interface_buttons.cpp
+++ b/src/fheroes2/gui/interface_buttons.cpp
@@ -57,7 +57,7 @@ void Interface::ButtonsArea::SetPos( int32_t ox, int32_t oy )
 {
     BorderWindow::SetPosition( ox, oy );
 
-    const int icnbtn = Settings::Get().ExtGameEvilInterface() ? ICN::ADVEBTNS : ICN::ADVBTNS;
+    const int icnbtn = Settings::Get().isEvilInterfaceEnabled() ? ICN::ADVEBTNS : ICN::ADVBTNS;
 
     buttonNextHero.setICNInfo( icnbtn, 0, 1 );
     buttonMovement.setICNInfo( icnbtn, 2, 3 );
@@ -106,8 +106,8 @@ void Interface::ButtonsArea::Redraw()
 {
     const Settings & conf = Settings::Get();
 
-    if ( !conf.ExtGameHideInterface() || conf.ShowButtons() ) {
-        if ( conf.ExtGameHideInterface() )
+    if ( !conf.isHideInterfaceEnabled() || conf.ShowButtons() ) {
+        if ( conf.isHideInterfaceEnabled() )
             BorderWindow::Redraw();
 
         SetButtonStatus();

--- a/src/fheroes2/gui/interface_buttons.cpp
+++ b/src/fheroes2/gui/interface_buttons.cpp
@@ -45,7 +45,10 @@ Interface::ButtonsArea::ButtonsArea( Basic & basic )
 
 void Interface::ButtonsArea::SavePosition()
 {
-    Settings::Get().SetPosButtons( GetRect().getPosition() );
+    Settings & conf = Settings::Get();
+
+    conf.SetPosButtons( GetRect().getPosition() );
+    conf.Save( Settings::configFileName );
 }
 
 void Interface::ButtonsArea::SetRedraw() const

--- a/src/fheroes2/gui/interface_cpanel.cpp
+++ b/src/fheroes2/gui/interface_cpanel.cpp
@@ -54,7 +54,7 @@ Interface::ControlPanel::ControlPanel( Basic & basic )
 
 void Interface::ControlPanel::ResetTheme()
 {
-    const int icn = Settings::Get().ExtGameEvilInterface() ? ICN::ADVEBTNS : ICN::ADVBTNS;
+    const int icn = Settings::Get().isEvilInterfaceEnabled() ? ICN::ADVEBTNS : ICN::ADVBTNS;
 
     _buttons.reset( new Buttons( fheroes2::AGG::GetICN( icn, 4 ), fheroes2::AGG::GetICN( icn, 0 ), fheroes2::AGG::GetICN( icn, 12 ), fheroes2::AGG::GetICN( icn, 10 ),
                                  fheroes2::AGG::GetICN( icn, 8 ) ) );

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -491,7 +491,7 @@ void Interface::Basic::EventSwitchShowRadar() const
 {
     Settings & conf = Settings::Get();
 
-    if ( conf.ExtGameHideInterface() ) {
+    if ( conf.isHideInterfaceEnabled() ) {
         if ( conf.ShowRadar() ) {
             conf.SetShowRadar( false );
             gameArea.SetRedraw();
@@ -507,7 +507,7 @@ void Interface::Basic::EventSwitchShowButtons() const
 {
     Settings & conf = Settings::Get();
 
-    if ( conf.ExtGameHideInterface() ) {
+    if ( conf.isHideInterfaceEnabled() ) {
         if ( conf.ShowButtons() ) {
             conf.SetShowButtons( false );
             gameArea.SetRedraw();
@@ -523,7 +523,7 @@ void Interface::Basic::EventSwitchShowStatus() const
 {
     Settings & conf = Settings::Get();
 
-    if ( conf.ExtGameHideInterface() ) {
+    if ( conf.isHideInterfaceEnabled() ) {
         if ( conf.ShowStatus() ) {
             conf.SetShowStatus( false );
             gameArea.SetRedraw();
@@ -539,7 +539,7 @@ void Interface::Basic::EventSwitchShowIcons() const
 {
     Settings & conf = Settings::Get();
 
-    if ( conf.ExtGameHideInterface() ) {
+    if ( conf.isHideInterfaceEnabled() ) {
         if ( conf.ShowIcons() ) {
             conf.SetShowIcons( false );
             gameArea.SetRedraw();
@@ -555,7 +555,7 @@ void Interface::Basic::EventSwitchShowControlPanel() const
 {
     Settings & conf = Settings::Get();
 
-    if ( conf.ExtGameHideInterface() ) {
+    if ( conf.isHideInterfaceEnabled() ) {
         conf.SetShowPanel( !conf.ShowControlPanel() );
         gameArea.SetRedraw();
     }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -934,7 +934,7 @@ void Interface::GameArea::QueueEventProcessing( bool isCursorOverGamearea )
         return;
 
     const Settings & conf = Settings::Get();
-    if ( conf.ExtGameHideInterface() && conf.ShowControlPanel() && le.MouseCursor( interface.GetControlPanel().GetArea() ) )
+    if ( conf.isHideInterfaceEnabled() && conf.ShowControlPanel() && le.MouseCursor( interface.GetControlPanel().GetArea() ) )
         return;
 
     const fheroes2::Point tileOffset = _topLeftTileOffset + mp - _windowROI.getPosition();

--- a/src/fheroes2/gui/interface_icons.cpp
+++ b/src/fheroes2/gui/interface_icons.cpp
@@ -309,7 +309,10 @@ Interface::IconsPanel::IconsPanel( Basic & basic )
 
 void Interface::IconsPanel::SavePosition()
 {
-    Settings::Get().SetPosIcons( GetRect().getPosition() );
+    Settings & conf = Settings::Get();
+
+    conf.SetPosIcons( GetRect().getPosition() );
+    conf.Save( Settings::configFileName );
 }
 
 void Interface::IconsPanel::SetRedraw( const icons_t type ) const

--- a/src/fheroes2/gui/interface_icons.cpp
+++ b/src/fheroes2/gui/interface_icons.cpp
@@ -55,7 +55,7 @@ namespace
 bool Interface::IconsBar::IsVisible()
 {
     const Settings & conf = Settings::Get();
-    return !conf.ExtGameHideInterface() || conf.ShowIcons();
+    return !conf.isHideInterfaceEnabled() || conf.ShowIcons();
 }
 
 int32_t Interface::IconsBar::GetItemWidth()
@@ -80,7 +80,7 @@ void Interface::RedrawHeroesIcon( const Heroes & hero, int32_t sx, int32_t sy )
 
 void Interface::IconsBar::redrawBackground( fheroes2::Image & output, const fheroes2::Point & offset, const int32_t validItemCount ) const
 {
-    const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+    const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
     const fheroes2::Sprite & icnadv = fheroes2::AGG::GetICN( isEvilInterface ? ICN::ADVBORDE : ICN::ADVBORD, 0 );
     fheroes2::Rect srcrt( icnadv.width() - RADARWIDTH - BORDERWIDTH, RADARWIDTH + 2 * BORDERWIDTH, RADARWIDTH / 2, 32 );
@@ -174,7 +174,7 @@ void Interface::CastleIcons::SetPos( int32_t px, int32_t py )
 {
     Castle * selectedCastle = isSelected() ? GetCurrent() : nullptr;
 
-    const int icnscroll = Settings::Get().ExtGameEvilInterface() ? ICN::SCROLLE : ICN::SCROLL;
+    const int icnscroll = Settings::Get().isEvilInterfaceEnabled() ? ICN::SCROLLE : ICN::SCROLL;
 
     _topLeftCorner = fheroes2::Point( px, py );
     SetTopLeft( _topLeftCorner );
@@ -268,7 +268,7 @@ void Interface::HeroesIcons::SetPos( int32_t px, int32_t py )
 {
     Heroes * selectedHero = isSelected() ? GetCurrent() : nullptr;
 
-    const int icnscroll = Settings::Get().ExtGameEvilInterface() ? ICN::SCROLLE : ICN::SCROLL;
+    const int icnscroll = Settings::Get().isEvilInterfaceEnabled() ? ICN::SCROLLE : ICN::SCROLL;
 
     _topLeftCorner = fheroes2::Point( px, py );
     SetTopLeft( _topLeftCorner );
@@ -340,7 +340,7 @@ void Interface::IconsPanel::SetPos( int32_t ox, int32_t oy )
 {
     int32_t iconsCount = 0;
 
-    if ( Settings::Get().ExtGameHideInterface() ) {
+    if ( Settings::Get().isHideInterfaceEnabled() ) {
         iconsCount = 2;
     }
     else {
@@ -364,7 +364,7 @@ void Interface::IconsPanel::Redraw()
     // is visible
     if ( IconsBar::IsVisible() ) {
         // redraw border
-        if ( Settings::Get().ExtGameHideInterface() )
+        if ( Settings::Get().isHideInterfaceEnabled() )
             BorderWindow::Redraw();
 
         heroesIcons.Redraw();
@@ -411,7 +411,7 @@ void Interface::IconsPanel::ResetIcons( const icons_t type )
     Kingdom & kingdom = world.GetKingdom( Settings::Get().CurrentColor() );
 
     if ( !kingdom.isControlAI() ) {
-        const int icnscroll = Settings::Get().ExtGameEvilInterface() ? ICN::SCROLLE : ICN::SCROLL;
+        const int icnscroll = Settings::Get().isEvilInterfaceEnabled() ? ICN::SCROLLE : ICN::SCROLL;
 
         const fheroes2::Sprite & originalSlider = fheroes2::AGG::GetICN( icnscroll, 4 );
 

--- a/src/fheroes2/gui/interface_radar.cpp
+++ b/src/fheroes2/gui/interface_radar.cpp
@@ -245,7 +245,7 @@ void Interface::Radar::SetRedraw() const
 void Interface::Radar::Redraw()
 {
     const Settings & conf = Settings::Get();
-    const bool hideInterface = conf.ExtGameHideInterface();
+    const bool hideInterface = conf.isHideInterfaceEnabled();
 
     if ( hideInterface && conf.ShowRadar() ) {
         BorderWindow::Redraw();
@@ -255,7 +255,7 @@ void Interface::Radar::Redraw()
         fheroes2::Display & display = fheroes2::Display::instance();
         const fheroes2::Rect & rect = GetArea();
         if ( hide ) {
-            fheroes2::Blit( fheroes2::AGG::GetICN( ( conf.ExtGameEvilInterface() ? ICN::HEROLOGE : ICN::HEROLOGO ), 0 ), display, rect.x, rect.y );
+            fheroes2::Blit( fheroes2::AGG::GetICN( ( conf.isEvilInterfaceEnabled() ? ICN::HEROLOGE : ICN::HEROLOGO ), 0 ), display, rect.x, rect.y );
         }
         else {
             cursorArea.hide();
@@ -401,7 +401,7 @@ void Interface::Radar::RedrawObjects( int color, ViewWorldMode flags ) const
 void Interface::Radar::RedrawCursor( const fheroes2::Rect * roiRectangle /* =nullptr */ )
 {
     const Settings & conf = Settings::Get();
-    if ( conf.ExtGameHideInterface() && !conf.ShowRadar() && radarType != RadarType::ViewWorld ) {
+    if ( conf.isHideInterfaceEnabled() && !conf.ShowRadar() && radarType != RadarType::ViewWorld ) {
         return;
     }
 

--- a/src/fheroes2/gui/interface_radar.cpp
+++ b/src/fheroes2/gui/interface_radar.cpp
@@ -169,7 +169,10 @@ Interface::Radar::Radar( const Radar & radar, const fheroes2::Display & display 
 
 void Interface::Radar::SavePosition()
 {
-    Settings::Get().SetPosRadar( GetRect().getPosition() );
+    Settings & conf = Settings::Get();
+
+    conf.SetPosRadar( GetRect().getPosition() );
+    conf.Save( Settings::configFileName );
 }
 
 void Interface::Radar::SetPos( int32_t ox, int32_t oy )

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -71,7 +71,10 @@ void Interface::StatusWindow::Reset()
 
 void Interface::StatusWindow::SavePosition()
 {
-    Settings::Get().SetPosStatus( GetRect().getPosition() );
+    Settings & conf = Settings::Get();
+
+    conf.SetPosStatus( GetRect().getPosition() );
+    conf.Save( Settings::configFileName );
 }
 
 void Interface::StatusWindow::SetRedraw() const

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -84,7 +84,7 @@ void Interface::StatusWindow::SetPos( int32_t ox, int32_t oy )
     uint32_t ow = 144;
     uint32_t oh = 72;
 
-    if ( !Settings::Get().ExtGameHideInterface() ) {
+    if ( !Settings::Get().isHideInterfaceEnabled() ) {
         oh = fheroes2::Display::instance().height() - oy - BORDERWIDTH;
     }
 
@@ -104,14 +104,14 @@ void Interface::StatusWindow::SetState( const StatusType status )
 void Interface::StatusWindow::Redraw() const
 {
     const Settings & conf = Settings::Get();
-    if ( conf.ExtGameHideInterface() && !conf.ShowStatus() ) {
+    if ( conf.isHideInterfaceEnabled() && !conf.ShowStatus() ) {
         // The window is hidden.
         return;
     }
 
     const fheroes2::Rect & pos = GetArea();
 
-    if ( conf.ExtGameHideInterface() ) {
+    if ( conf.isHideInterfaceEnabled() ) {
         fheroes2::Fill( fheroes2::Display::instance(), pos.x, pos.y, pos.width, pos.height, fheroes2::GetColorId( 0x51, 0x31, 0x18 ) );
         BorderWindow::Redraw();
     }
@@ -125,7 +125,7 @@ void Interface::StatusWindow::Redraw() const
     }
 
     // draw info: Day and Funds and Army
-    const fheroes2::Sprite & ston = fheroes2::AGG::GetICN( conf.ExtGameEvilInterface() ? ICN::STONBAKE : ICN::STONBACK, 0 );
+    const fheroes2::Sprite & ston = fheroes2::AGG::GetICN( conf.isEvilInterfaceEnabled() ? ICN::STONBAKE : ICN::STONBACK, 0 );
     const int32_t stonHeight = ston.height();
 
     if ( StatusType::STATUS_AITURN == _state ) {
@@ -192,7 +192,7 @@ void Interface::StatusWindow::Redraw() const
 void Interface::StatusWindow::NextState()
 {
     const int32_t areaHeight = GetArea().height;
-    const fheroes2::Sprite & ston = fheroes2::AGG::GetICN( Settings::Get().ExtGameEvilInterface() ? ICN::STONBAKE : ICN::STONBACK, 0 );
+    const fheroes2::Sprite & ston = fheroes2::AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::STONBAKE : ICN::STONBACK, 0 );
     const int32_t stonHeight = ston.height();
 
     const bool skipDayStatus = areaHeight >= ( stonHeight * 2 + 15 ) && areaHeight < ( stonHeight * 3 + 15 );
@@ -265,7 +265,7 @@ void Interface::StatusWindow::DrawDayInfo( int oh ) const
     const int dayOfWeek = world.GetDay();
     const int weekOfMonth = world.GetWeek();
     const uint32_t month = world.GetMonth();
-    const int icnType = Settings::Get().ExtGameEvilInterface() ? ICN::SUNMOONE : ICN::SUNMOON;
+    const int icnType = Settings::Get().isEvilInterfaceEnabled() ? ICN::SUNMOONE : ICN::SUNMOON;
 
     uint32_t icnId = dayOfWeek > 1 ? 0 : ( ( weekOfMonth - 1 ) % 4 ) + 1;
     // Special case
@@ -386,10 +386,10 @@ void Interface::StatusWindow::DrawAITurns() const
 void Interface::StatusWindow::DrawBackground() const
 {
     fheroes2::Display & display = fheroes2::Display::instance();
-    const fheroes2::Sprite & icnston = fheroes2::AGG::GetICN( Settings::Get().ExtGameEvilInterface() ? ICN::STONBAKE : ICN::STONBACK, 0 );
+    const fheroes2::Sprite & icnston = fheroes2::AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::STONBAKE : ICN::STONBACK, 0 );
     const fheroes2::Rect & pos = GetArea();
 
-    if ( !Settings::Get().ExtGameHideInterface() && display.height() - BORDERWIDTH - icnston.height() > pos.y ) {
+    if ( !Settings::Get().isHideInterfaceEnabled() && display.height() - BORDERWIDTH - icnston.height() > pos.y ) {
         // top
         const int32_t startY = 11;
         const int32_t copyHeight = 46;
@@ -431,7 +431,7 @@ void Interface::StatusWindow::QueueEventProcessing()
         SetRedraw();
     }
     if ( le.MousePressRight( GetRect() ) ) {
-        const fheroes2::Sprite & ston = fheroes2::AGG::GetICN( Settings::Get().ExtGameEvilInterface() ? ICN::STONBAKE : ICN::STONBACK, 0 );
+        const fheroes2::Sprite & ston = fheroes2::AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::STONBAKE : ICN::STONBACK, 0 );
         const fheroes2::Rect & pos = GetArea();
         const bool isFullInfo = StatusType::STATUS_UNKNOWN != _state && pos.height >= ( ston.height() * 3 + 15 );
         if ( isFullInfo ) {

--- a/src/fheroes2/gui/ui_button.cpp
+++ b/src/fheroes2/gui/ui_button.cpp
@@ -232,7 +232,7 @@ namespace fheroes2
 
     ButtonGroup::ButtonGroup( const Rect & area, int buttonTypes )
     {
-        const int icnId = Settings::Get().ExtGameEvilInterface() ? ICN::SYSTEME : ICN::SYSTEM;
+        const int icnId = Settings::Get().isEvilInterfaceEnabled() ? ICN::SYSTEME : ICN::SYSTEM;
 
         Point offset;
 

--- a/src/fheroes2/gui/ui_castle.cpp
+++ b/src/fheroes2/gui/ui_castle.cpp
@@ -194,7 +194,7 @@ namespace fheroes2
             DEBUG_LOG( DBG_ENGINE, DBG_WARN, "unknown race" )
         }
 
-        const Sprite & castleImage = fheroes2::AGG::GetICN( Settings::Get().ExtGameEvilInterface() ? ICN::LOCATORE : ICN::LOCATORS, icnIndex );
+        const Sprite & castleImage = fheroes2::AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS, icnIndex );
         fheroes2::Blit( castleImage, output, offset.x, offset.y );
 
         // Draw castle's marker.

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -209,17 +209,17 @@ namespace fheroes2
 
     GameInterfaceTypeRestorer::GameInterfaceTypeRestorer( const bool isEvilInterface_ )
         : isEvilInterface( isEvilInterface_ )
-        , isOriginalEvilInterface( Settings::Get().ExtGameEvilInterface() )
+        , isOriginalEvilInterface( Settings::Get().isEvilInterfaceEnabled() )
     {
         if ( isEvilInterface != isOriginalEvilInterface ) {
-            Settings::Get().SetEvilInterface( isEvilInterface );
+            Settings::Get().setEvilInterface( isEvilInterface );
         }
     }
 
     GameInterfaceTypeRestorer::~GameInterfaceTypeRestorer()
     {
         if ( isEvilInterface != isOriginalEvilInterface ) {
-            Settings::Get().SetEvilInterface( isOriginalEvilInterface );
+            Settings::Get().setEvilInterface( isOriginalEvilInterface );
         }
     }
 

--- a/src/fheroes2/gui/ui_window.cpp
+++ b/src/fheroes2/gui/ui_window.cpp
@@ -50,7 +50,7 @@ namespace fheroes2
 
     void StandardWindow::render()
     {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ( Settings::Get().ExtGameEvilInterface() ? ICN::SURDRBKE : ICN::SURDRBKG ), 0 );
+        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ( Settings::Get().isEvilInterfaceEnabled() ? ICN::SURDRBKE : ICN::SURDRBKG ), 0 );
         const fheroes2::Image renderedImage
             = fheroes2::Stretch( sprite, borderSize, 0, sprite.width() - borderSize, sprite.height() - borderSize, _windowArea.width, _windowArea.height );
         fheroes2::Blit( renderedImage, _output, _windowArea.x, _windowArea.y );

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -60,7 +60,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
     // fade
-    if ( fade && Settings::ExtGameUseFade() )
+    if ( fade && Settings::isFadeEffectEnabled() )
         fheroes2::FadeDisplay();
 
     fheroes2::Display & display = fheroes2::Display::instance();

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -80,7 +80,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
     fheroes2::Point dst_pt( cur_pt );
 
     fheroes2::Blit( fheroes2::AGG::GetICN( ICN::HEROBKG, 0 ), display, dst_pt.x, dst_pt.y );
-    fheroes2::Blit( fheroes2::AGG::GetICN( Settings::Get().ExtGameEvilInterface() ? ICN::HEROEXTE : ICN::HEROEXTG, 0 ), display, dst_pt.x, dst_pt.y );
+    fheroes2::Blit( fheroes2::AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::HEROEXTE : ICN::HEROEXTG, 0 ), display, dst_pt.x, dst_pt.y );
 
     // portrait
     dst_pt.x = cur_pt.x + 49;

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -427,7 +427,7 @@ namespace
         // setup cursor
         const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-        const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+        const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
         LocalEvent & le = LocalEvent::Get();
 
         for ( const Castle * castle : kingdom.GetCastles() ) {

--- a/src/fheroes2/kingdom/puzzle.cpp
+++ b/src/fheroes2/kingdom/puzzle.cpp
@@ -130,7 +130,7 @@ namespace
     {
         fheroes2::Display & display = fheroes2::Display::instance();
 
-        const bool isEvilInterface = Settings::Get().ExtGameEvilInterface();
+        const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
         const Interface::Radar & radar = Interface::Basic::Get().GetRadar();
         const fheroes2::Rect & radarArea = radar.GetArea();
@@ -172,8 +172,8 @@ namespace
         fheroes2::Image background( blitArea.width, blitArea.height );
 
         const Settings & conf = Settings::Get();
-        const bool isEvilInterface = conf.ExtGameEvilInterface();
-        const bool isHideInterface = conf.ExtGameHideInterface();
+        const bool isEvilInterface = conf.isEvilInterfaceEnabled();
+        const bool isHideInterface = conf.isHideInterfaceEnabled();
 
         if ( isEvilInterface ) {
             background.fill( fheroes2::GetColorId( 80, 80, 80 ) );
@@ -280,7 +280,7 @@ void Puzzle::ShowMapsDialog() const
 
     AudioManager::PlayMusic( MUS::PUZZLE, Music::PlaybackMode::PLAY_ONCE );
 
-    if ( display.isDefaultSize() && !Settings::Get().ExtGameHideInterface() )
+    if ( display.isDefaultSize() && !Settings::Get().isHideInterfaceEnabled() )
         ShowStandardDialog( *this, sf );
     else
         ShowExtendedDialog( *this, sf );

--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -541,13 +541,13 @@ void ViewWorld::ViewWorldWindow( const int color, const ViewWorldMode mode, Inte
     LocalEvent::PauseCycling();
 
     Settings & conf = Settings::Get();
-    const bool isEvilInterface = conf.ExtGameEvilInterface();
-    const bool isHideInterface = conf.ExtGameHideInterface();
+    const bool isEvilInterface = conf.isEvilInterfaceEnabled();
+    const bool isHideInterface = conf.isHideInterfaceEnabled();
 
     // If the interface is currently hidden, we have to temporarily bring it back, because
     // the map generation in the World View mode heavily depends on the existing game area
     if ( isHideInterface ) {
-        conf.SetHideInterface( false );
+        conf.setHideInterface( false );
         interface.Reset();
     }
 
@@ -654,7 +654,7 @@ void ViewWorld::ViewWorldWindow( const int color, const ViewWorldMode mode, Inte
 
     // Don't forget to reset the interface settings back if necessary
     if ( isHideInterface ) {
-        conf.SetHideInterface( true );
+        conf.setHideInterface( true );
         interface.Reset();
     }
 

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -29,6 +29,7 @@ enum SaveFileFormat : uint16_t
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
 
     // 10000 value must be used for 1.0 release so all version before it should have lower than this value.
+    FORMAT_VERSION_PRE3_1000_RELEASE = 9962,
     FORMAT_VERSION_PRE2_1000_RELEASE = 9961,
     FORMAT_VERSION_PRE1_1000_RELEASE = 9960,
     FORMAT_VERSION_0921_RELEASE = 9950,
@@ -37,5 +38,5 @@ enum SaveFileFormat : uint16_t
 
     LAST_SUPPORTED_FORMAT_VERSION = FORMAT_VERSION_0919_RELEASE,
 
-    CURRENT_FORMAT_VERSION = FORMAT_VERSION_PRE2_1000_RELEASE
+    CURRENT_FORMAT_VERSION = FORMAT_VERSION_PRE3_1000_RELEASE
 };

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -60,11 +60,11 @@ namespace
         GLOBAL_RENDER_VSYNC = 0x00000008,
         GLOBAL_TEXT_SUPPORT_MODE = 0x00000010,
         GLOBAL_MONOCHROME_CURSOR = 0x00000020,
-        GLOBAL_SHOWCPANEL = 0x00000040,
-        GLOBAL_SHOWRADAR = 0x00000080,
-        GLOBAL_SHOWICONS = 0x00000100,
-        GLOBAL_SHOWBUTTONS = 0x00000200,
-        GLOBAL_SHOWSTATUS = 0x00000400,
+        GLOBAL_SHOW_CPANEL = 0x00000040,
+        GLOBAL_SHOW_RADAR = 0x00000080,
+        GLOBAL_SHOW_ICONS = 0x00000100,
+        GLOBAL_SHOW_BUTTONS = 0x00000200,
+        GLOBAL_SHOW_STATUS = 0x00000400,
         GLOBAL_FULLSCREEN = 0x00008000,
         GLOBAL_3D_AUDIO = 0x00010000,
         GLOBAL_SYSTEM_INFO = 0x00020000,
@@ -103,10 +103,10 @@ Settings::Settings()
     _optGlobal.SetModes( GLOBAL_FIRST_RUN );
     _optGlobal.SetModes( GLOBAL_SHOW_INTRO );
 
-    _optGlobal.SetModes( GLOBAL_SHOWRADAR );
-    _optGlobal.SetModes( GLOBAL_SHOWICONS );
-    _optGlobal.SetModes( GLOBAL_SHOWBUTTONS );
-    _optGlobal.SetModes( GLOBAL_SHOWSTATUS );
+    _optGlobal.SetModes( GLOBAL_SHOW_RADAR );
+    _optGlobal.SetModes( GLOBAL_SHOW_ICONS );
+    _optGlobal.SetModes( GLOBAL_SHOW_BUTTONS );
+    _optGlobal.SetModes( GLOBAL_SHOW_STATUS );
 
     _optGlobal.SetModes( GLOBAL_BATTLE_SHOW_GRID );
     _optGlobal.SetModes( GLOBAL_BATTLE_SHOW_MOUSE_SHADOW );
@@ -748,27 +748,27 @@ bool Settings::isBattleShowDamageInfoEnabled() const
 
 bool Settings::ShowControlPanel() const
 {
-    return _optGlobal.Modes( GLOBAL_SHOWCPANEL );
+    return _optGlobal.Modes( GLOBAL_SHOW_CPANEL );
 }
 
 bool Settings::ShowRadar() const
 {
-    return _optGlobal.Modes( GLOBAL_SHOWRADAR );
+    return _optGlobal.Modes( GLOBAL_SHOW_RADAR );
 }
 
 bool Settings::ShowIcons() const
 {
-    return _optGlobal.Modes( GLOBAL_SHOWICONS );
+    return _optGlobal.Modes( GLOBAL_SHOW_ICONS );
 }
 
 bool Settings::ShowButtons() const
 {
-    return _optGlobal.Modes( GLOBAL_SHOWBUTTONS );
+    return _optGlobal.Modes( GLOBAL_SHOW_BUTTONS );
 }
 
 bool Settings::ShowStatus() const
 {
-    return _optGlobal.Modes( GLOBAL_SHOWSTATUS );
+    return _optGlobal.Modes( GLOBAL_SHOW_STATUS );
 }
 
 bool Settings::BattleShowGrid() const
@@ -910,27 +910,27 @@ void Settings::SetBattleMouseShaded( bool f )
 
 void Settings::SetShowPanel( bool f )
 {
-    f ? _optGlobal.SetModes( GLOBAL_SHOWCPANEL ) : _optGlobal.ResetModes( GLOBAL_SHOWCPANEL );
+    f ? _optGlobal.SetModes( GLOBAL_SHOW_CPANEL ) : _optGlobal.ResetModes( GLOBAL_SHOW_CPANEL );
 }
 
 void Settings::SetShowRadar( bool f )
 {
-    f ? _optGlobal.SetModes( GLOBAL_SHOWRADAR ) : _optGlobal.ResetModes( GLOBAL_SHOWRADAR );
+    f ? _optGlobal.SetModes( GLOBAL_SHOW_RADAR ) : _optGlobal.ResetModes( GLOBAL_SHOW_RADAR );
 }
 
 void Settings::SetShowIcons( bool f )
 {
-    f ? _optGlobal.SetModes( GLOBAL_SHOWICONS ) : _optGlobal.ResetModes( GLOBAL_SHOWICONS );
+    f ? _optGlobal.SetModes( GLOBAL_SHOW_ICONS ) : _optGlobal.ResetModes( GLOBAL_SHOW_ICONS );
 }
 
 void Settings::SetShowButtons( bool f )
 {
-    f ? _optGlobal.SetModes( GLOBAL_SHOWBUTTONS ) : _optGlobal.ResetModes( GLOBAL_SHOWBUTTONS );
+    f ? _optGlobal.SetModes( GLOBAL_SHOW_BUTTONS ) : _optGlobal.ResetModes( GLOBAL_SHOW_BUTTONS );
 }
 
 void Settings::SetShowStatus( bool f )
 {
-    f ? _optGlobal.SetModes( GLOBAL_SHOWSTATUS ) : _optGlobal.ResetModes( GLOBAL_SHOWSTATUS );
+    f ? _optGlobal.SetModes( GLOBAL_SHOW_STATUS ) : _optGlobal.ResetModes( GLOBAL_SHOW_STATUS );
 }
 
 bool Settings::CanChangeInGame( uint32_t f ) const

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -426,16 +426,16 @@ std::string Settings::String() const
     os << std::endl << "# hide interface elements on the adventure map: on/off" << std::endl;
     os << "hide interface = " << ( _optGlobal.Modes( GLOBAL_HIDE_INTERFACE ) ? "on" : "off" ) << std::endl;
 
-    os << std::endl << "# position of the radar window on the adventure map when the interface is hidden" << std::endl;
+    os << std::endl << "# position of the radar window on the adventure map when interface elements are hidden" << std::endl;
     os << "radar window position = [ " << pos_radr.x << ", " << pos_radr.y << " ]" << std::endl;
 
-    os << std::endl << "# position of the buttons window on the adventure map when the interface is hidden" << std::endl;
+    os << std::endl << "# position of the buttons window on the adventure map when interface elements are hidden" << std::endl;
     os << "buttons window position = [ " << pos_bttn.x << ", " << pos_bttn.y << " ]" << std::endl;
 
-    os << std::endl << "# position of the icons window on the adventure map when the interface is hidden" << std::endl;
+    os << std::endl << "# position of the icons window on the adventure map when interface elements are hidden" << std::endl;
     os << "icons window position = [ " << pos_icon.x << ", " << pos_icon.y << " ]" << std::endl;
 
-    os << std::endl << "# position of the status window on the adventure map when the interface is hidden" << std::endl;
+    os << std::endl << "# position of the status window on the adventure map when interface elements are hidden" << std::endl;
     os << "status window position = [ " << pos_stat.x << ", " << pos_stat.y << " ]" << std::endl;
 
     os << std::endl << "# game language (an empty value means English)" << std::endl;

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -132,13 +132,13 @@ Settings & Settings::Get()
     return conf;
 }
 
-bool Settings::Read( const std::string & filename )
+bool Settings::Read( const std::string & filePath )
 {
     TinyConfig config( '=', '#' );
 
     std::string sval;
 
-    if ( !config.Load( filename ) ) {
+    if ( !config.Load( filePath ) ) {
         return false;
     }
 
@@ -332,13 +332,13 @@ bool Settings::Read( const std::string & filename )
     return true;
 }
 
-bool Settings::Save( const std::string & filename ) const
+bool Settings::Save( const std::string_view fileName ) const
 {
-    if ( filename.empty() ) {
+    if ( fileName.empty() ) {
         return false;
     }
 
-    const std::string cfgFilename = System::concatPath( System::GetConfigDirectory( "fheroes2" ), filename );
+    const std::string cfgFilename = System::concatPath( System::GetConfigDirectory( "fheroes2" ), fileName );
 
     std::fstream file;
     file.open( cfgFilename.data(), std::fstream::out | std::fstream::trunc );

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -125,11 +125,6 @@ Settings::Settings()
     EnablePriceOfLoyaltySupport( false );
 }
 
-Settings::~Settings()
-{
-    BinarySave();
-}
-
 Settings & Settings::Get()
 {
     static Settings conf;
@@ -236,6 +231,22 @@ bool Settings::Read( const std::string & filename )
         setHideInterface( config.StrParams( "hide interface" ) == "on" );
     }
 
+    if ( config.Exists( "radar window position" ) ) {
+        pos_radr = config.PointParams( "radar window position", { -1, -1 } );
+    }
+
+    if ( config.Exists( "buttons window position" ) ) {
+        pos_bttn = config.PointParams( "buttons window position", { -1, -1 } );
+    }
+
+    if ( config.Exists( "icons window position" ) ) {
+        pos_icon = config.PointParams( "icons window position", { -1, -1 } );
+    }
+
+    if ( config.Exists( "status window position" ) ) {
+        pos_stat = config.PointParams( "status window position", { -1, -1 } );
+    }
+
     // videomode
     sval = config.StrParams( "videomode" );
     if ( !sval.empty() ) {
@@ -318,8 +329,6 @@ bool Settings::Read( const std::string & filename )
         }
     }
 
-    BinaryLoad();
-
     return true;
 }
 
@@ -339,8 +348,6 @@ bool Settings::Save( const std::string & filename ) const
 
     const std::string & data = String();
     file.write( data.data(), data.size() );
-
-    BinarySave();
 
     return true;
 }
@@ -419,6 +426,18 @@ std::string Settings::String() const
     os << std::endl << "# hide interface elements on the adventure map: on/off" << std::endl;
     os << "hide interface = " << ( _optGlobal.Modes( GLOBAL_HIDE_INTERFACE ) ? "on" : "off" ) << std::endl;
 
+    os << std::endl << "# position of the radar window on the adventure map" << std::endl;
+    os << "radar window position = [ " << pos_radr.x << ", " << pos_radr.y << " ]" << std::endl;
+
+    os << std::endl << "# position of the buttons window on the adventure map" << std::endl;
+    os << "buttons window position = [ " << pos_bttn.x << ", " << pos_bttn.y << " ]" << std::endl;
+
+    os << std::endl << "# position of the icons window on the adventure map" << std::endl;
+    os << "icons window position = [ " << pos_icon.x << ", " << pos_icon.y << " ]" << std::endl;
+
+    os << std::endl << "# position of the status window on the adventure map" << std::endl;
+    os << "status window position = [ " << pos_stat.x << ", " << pos_stat.y << " ]" << std::endl;
+
     os << std::endl << "# game language (an empty value means English)" << std::endl;
     os << "lang = " << _gameLanguage << std::endl;
 
@@ -452,7 +471,6 @@ std::string Settings::String() const
     return os.str();
 }
 
-/* read maps info */
 void Settings::SetCurrentFileInfo( const Maps::FileInfo & fi )
 {
     current_maps_file = fi;
@@ -596,19 +614,16 @@ std::string Settings::GetLastFile( const std::string & prefix, const std::string
     return files.empty() ? name : files.back();
 }
 
-/* set ai speed: 0 (don't show) - 10 */
 void Settings::SetAIMoveSpeed( int speed )
 {
     ai_speed = std::clamp( speed, 0, 10 );
 }
 
-/* set hero speed: 1 - 10 */
 void Settings::SetHeroesMoveSpeed( int speed )
 {
     heroes_speed = std::clamp( speed, 1, 10 );
 }
 
-/* set battle speed: 1 - 10 */
 void Settings::SetBattleSpeed( int speed )
 {
     battle_speed = std::clamp( speed, 1, 10 );
@@ -1033,40 +1048,6 @@ void Settings::ExtResetModes( uint32_t f )
         break;
     default:
         break;
-    }
-}
-
-void Settings::BinarySave() const
-{
-    const std::string fname = System::concatPath( System::GetConfigDirectory( "fheroes2" ), "fheroes2.bin" );
-
-    StreamFile fs;
-    fs.setbigendian( true );
-
-    if ( fs.open( fname, "wb" ) ) {
-        fs << static_cast<uint16_t>( CURRENT_FORMAT_VERSION ) << _optExtGame << _optExtBalance2 << _optExtBalance4 << _optExtBalance3 << pos_radr << pos_bttn << pos_icon
-           << pos_stat;
-    }
-}
-
-void Settings::BinaryLoad()
-{
-    std::string fname = System::concatPath( System::GetConfigDirectory( "fheroes2" ), "fheroes2.bin" );
-
-    if ( !System::IsFile( fname ) ) {
-        fname = GetLastFile( "", "fheroes2.bin" );
-    }
-    if ( !System::IsFile( fname ) ) {
-        return;
-    }
-
-    StreamFile fs;
-    fs.setbigendian( true );
-
-    if ( fs.open( fname, "rb" ) ) {
-        uint16_t version = 0;
-
-        fs >> version >> _optExtGame >> _optExtBalance2 >> _optExtBalance4 >> _optExtBalance3 >> pos_radr >> pos_bttn >> pos_icon >> pos_stat;
     }
 }
 

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -426,16 +426,16 @@ std::string Settings::String() const
     os << std::endl << "# hide interface elements on the adventure map: on/off" << std::endl;
     os << "hide interface = " << ( _optGlobal.Modes( GLOBAL_HIDE_INTERFACE ) ? "on" : "off" ) << std::endl;
 
-    os << std::endl << "# position of the radar window on the adventure map" << std::endl;
+    os << std::endl << "# position of the radar window on the adventure map when the interface is hidden" << std::endl;
     os << "radar window position = [ " << pos_radr.x << ", " << pos_radr.y << " ]" << std::endl;
 
-    os << std::endl << "# position of the buttons window on the adventure map" << std::endl;
+    os << std::endl << "# position of the buttons window on the adventure map when the interface is hidden" << std::endl;
     os << "buttons window position = [ " << pos_bttn.x << ", " << pos_bttn.y << " ]" << std::endl;
 
-    os << std::endl << "# position of the icons window on the adventure map" << std::endl;
+    os << std::endl << "# position of the icons window on the adventure map when the interface is hidden" << std::endl;
     os << "icons window position = [ " << pos_icon.x << ", " << pos_icon.y << " ]" << std::endl;
 
-    os << std::endl << "# position of the status window on the adventure map" << std::endl;
+    os << std::endl << "# position of the status window on the adventure map when the interface is hidden" << std::endl;
     os << "status window position = [ " << pos_stat.x << ", " << pos_stat.y << " ]" << std::endl;
 
     os << std::endl << "# game language (an empty value means English)" << std::endl;

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -69,8 +69,8 @@ namespace
         GLOBAL_3D_AUDIO = 0x00010000,
         GLOBAL_SYSTEM_INFO = 0x00020000,
         GLOBAL_CURSOR_SOFT_EMULATION = 0x00040000,
-        // UNUSED = 0x00080000,
-        // UNUSED = 0x00100000,
+        GLOBAL_EVIL_INTERFACE = 0x00080000,
+        GLOBAL_HIDE_INTERFACE = 0x00100000,
         GLOBAL_BATTLE_SHOW_DAMAGE = 0x00200000,
         GLOBAL_BATTLE_SHOW_ARMY_ORDER = 0x00400000,
         GLOBAL_BATTLE_SHOW_GRID = 0x00800000,
@@ -226,6 +226,14 @@ bool Settings::Read( const std::string & filename )
 
     if ( config.Exists( "battle army order" ) ) {
         setBattleShowArmyOrder( config.StrParams( "battle army order" ) == "on" );
+    }
+
+    if ( config.Exists( "use evil interface" ) ) {
+        setEvilInterface( config.StrParams( "use evil interface" ) == "on" );
+    }
+
+    if ( config.Exists( "hide interface" ) ) {
+        setHideInterface( config.StrParams( "hide interface" ) == "on" );
     }
 
     // videomode
@@ -404,6 +412,12 @@ std::string Settings::String() const
 
     os << std::endl << "# show army order during battle: on/off" << std::endl;
     os << "battle army order = " << ( _optGlobal.Modes( GLOBAL_BATTLE_SHOW_ARMY_ORDER ) ? "on" : "off" ) << std::endl;
+
+    os << std::endl << "# use evil interface style: on/off" << std::endl;
+    os << "use evil interface = " << ( _optGlobal.Modes( GLOBAL_EVIL_INTERFACE ) ? "on" : "off" ) << std::endl;
+
+    os << std::endl << "# hide interface elements on the adventure map: on/off" << std::endl;
+    os << "hide interface = " << ( _optGlobal.Modes( GLOBAL_HIDE_INTERFACE ) ? "on" : "off" ) << std::endl;
 
     os << std::endl << "# game language (an empty value means English)" << std::endl;
     os << "lang = " << _gameLanguage << std::endl;
@@ -711,6 +725,26 @@ void Settings::setBattleDamageInfo( const bool enable )
     }
 }
 
+void Settings::setHideInterface( const bool enable )
+{
+    if ( enable ) {
+        _optGlobal.SetModes( GLOBAL_HIDE_INTERFACE );
+    }
+    else {
+        _optGlobal.ResetModes( GLOBAL_HIDE_INTERFACE );
+    }
+}
+
+void Settings::setEvilInterface( const bool enable )
+{
+    if ( enable ) {
+        _optGlobal.SetModes( GLOBAL_EVIL_INTERFACE );
+    }
+    else {
+        _optGlobal.ResetModes( GLOBAL_EVIL_INTERFACE );
+    }
+}
+
 void Settings::SetScrollSpeed( int speed )
 {
     scroll_speed = std::clamp( speed, static_cast<int>( SCROLL_SPEED_NONE ), static_cast<int>( SCROLL_SPEED_VERY_FAST ) );
@@ -744,6 +778,16 @@ bool Settings::isSystemInfoEnabled() const
 bool Settings::isBattleShowDamageInfoEnabled() const
 {
     return _optGlobal.Modes( GLOBAL_BATTLE_SHOW_DAMAGE );
+}
+
+bool Settings::isHideInterfaceEnabled() const
+{
+    return _optGlobal.Modes( GLOBAL_HIDE_INTERFACE );
+}
+
+bool Settings::isEvilInterfaceEnabled() const
+{
+    return _optGlobal.Modes( GLOBAL_EVIL_INTERFACE );
 }
 
 bool Settings::ShowControlPanel() const
@@ -881,16 +925,6 @@ void Settings::EnablePriceOfLoyaltySupport( const bool set )
         if ( _musicType == MUSIC_MIDI_EXPANSION )
             _musicType = MUSIC_MIDI_ORIGINAL;
     }
-}
-
-void Settings::SetEvilInterface( bool f )
-{
-    f ? ExtSetModes( GAME_EVIL_INTERFACE ) : ExtResetModes( GAME_EVIL_INTERFACE );
-}
-
-void Settings::SetHideInterface( bool f )
-{
-    f ? ExtSetModes( GAME_HIDE_INTERFACE ) : ExtResetModes( GAME_HIDE_INTERFACE );
 }
 
 void Settings::SetBattleGrid( bool f )

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "bitmodes.h"
@@ -128,8 +129,8 @@ public:
 
     static Settings & Get();
 
-    bool Read( const std::string & );
-    bool Save( const std::string & ) const;
+    bool Read( const std::string & filePath );
+    bool Save( const std::string_view fileName ) const;
 
     std::string String() const;
     void SetCurrentFileInfo( const Maps::FileInfo & );

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -307,7 +307,7 @@ public:
     void SetScrollSpeed( int );
     // Sets the speed of human-controlled heroes in the range 1 - 10
     void SetHeroesMoveSpeed( int );
-    // Sets the animation speed of units during combat in the range 1 - 10
+    // Sets the animation speed during combat in the range 1 - 10
     void SetBattleSpeed( int );
     void setBattleAutoResolve( bool enable );
     void setBattleAutoSpellcast( bool enable );

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -124,6 +124,8 @@ public:
 
     Settings & operator=( const Settings & ) = delete;
 
+    ~Settings() = default;
+
     static Settings & Get();
 
     bool Read( const std::string & );
@@ -299,9 +301,12 @@ public:
     void SetShowIcons( bool );
     void SetShowButtons( bool );
     void SetShowStatus( bool );
+    // Sets the speed of AI-controlled heroes in the range 0 - 10, 0 means "don't show"
     void SetAIMoveSpeed( int );
     void SetScrollSpeed( int );
+    // Sets the speed of human-controlled heroes in the range 1 - 10
     void SetHeroesMoveSpeed( int );
+    // Sets the animation speed of units during combat in the range 1 - 10
     void SetBattleSpeed( int );
     void setBattleAutoResolve( bool enable );
     void setBattleAutoSpellcast( bool enable );
@@ -491,10 +496,6 @@ private:
     friend StreamBase & operator>>( StreamBase &, Settings & );
 
     Settings();
-    ~Settings();
-
-    void BinarySave() const;
-    void BinaryLoad();
 
     static void setDebug( int debug );
 

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -68,8 +68,8 @@ public:
         // UNUSED = 0x10000100,
         // UNUSED = 0x10000200,
         // UNUSED = 0x10000400,
-        GAME_EVIL_INTERFACE = 0x10001000,
-        GAME_HIDE_INTERFACE = 0x10002000,
+        // UNUSED = 0x10001000,
+        // UNUSED = 0x10002000,
         // UNUSED = 0x10008000,
         // UNUSED = 0x10010000,
         // UNUSED = 0x10100000,
@@ -235,6 +235,8 @@ public:
     bool is3DAudioEnabled() const;
     bool isSystemInfoEnabled() const;
     bool isBattleShowDamageInfoEnabled() const;
+    bool isHideInterfaceEnabled() const;
+    bool isEvilInterfaceEnabled() const;
 
     bool LoadedGameVersion() const
     {
@@ -277,16 +279,6 @@ public:
         return false;
     }
 
-    bool ExtGameEvilInterface() const
-    {
-        return ExtModes( GAME_EVIL_INTERFACE );
-    }
-
-    bool ExtGameHideInterface() const
-    {
-        return ExtModes( GAME_HIDE_INTERFACE );
-    }
-
     const fheroes2::Size & VideoMode() const
     {
         return video_mode;
@@ -299,8 +291,6 @@ public:
         game_difficulty = difficulty;
     }
 
-    void SetEvilInterface( bool );
-    void SetHideInterface( bool );
     void SetBattleGrid( bool );
     void SetBattleMovementShaded( bool );
     void SetBattleMouseShaded( bool );
@@ -323,6 +313,8 @@ public:
     void setVSync( const bool enable );
     void setSystemInfo( const bool enable );
     void setBattleDamageInfo( const bool enable );
+    void setHideInterface( const bool enable );
+    void setEvilInterface( const bool enable );
 
     void SetSoundVolume( int v );
     void SetMusicVolume( int v );

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -58,69 +58,6 @@ class Settings
 public:
     static constexpr const char * configFileName = "fheroes2.cfg";
 
-    enum : uint32_t
-    {
-        // The following extended options do not affect the overall
-        // game balance and are saved in the binary config file
-        //
-        // UNUSED = 0x10000010,
-        // UNUSED = 0x10000020,
-        // UNUSED = 0x10000040,
-        // UNUSED = 0x10000100,
-        // UNUSED = 0x10000200,
-        // UNUSED = 0x10000400,
-        // UNUSED = 0x10001000,
-        // UNUSED = 0x10002000,
-        // UNUSED = 0x10008000,
-        // UNUSED = 0x10010000,
-        // UNUSED = 0x10100000,
-        // UNUSED = 0x10200000,
-
-        // The following extended options affect the overall game balance and
-        // are saved both in the binary config file and in the savefile
-        //
-        // TODO: combine them all into one bitset
-        //
-        // UNUSED = 0x20000001,
-        // UNUSED = 0x20000002,
-        // UNUSED = 0x20000008,
-        // UNUSED = 0x20000020,
-        // UNUSED = 0x20000040,
-        // UNUSED = 0x20000080,
-        // UNUSED = 0x20000100,
-        // UNUSED = 0x20000200,
-        // UNUSED = 0x20000400,
-        // UNUSED = 0x20000800,
-        // UNUSED = 0x20001000,
-        // UNUSED = 0x20002000,
-        // UNUSED = 0x20004000,
-        // UNUSED = 0x20008000,
-        // UNUSED = 0x20010000,
-        // UNUSED = 0x20020000,
-        // UNUSED = 0x20040000,
-        // UNUSED = 0x20080000,
-        // UNUSED = 0x20800000,
-        // UNUSED = 0x21000000,
-
-        // UNUSED = 0x30000001,
-        // UNUSED = 0x30000008,
-        // UNUSED = 0x30000010,
-        // UNUSED = 0x30000020,
-        // UNUSED = 0x30000080,
-        // UNUSED = 0x30000100,
-        // UNUSED = 0x30000200,
-        // UNUSED = 0x30000400,
-        // UNUSED = 0x30000800,
-        // UNUSED = 0x30001000,
-        // UNUSED = 0x30004000,
-        // UNUSED = 0x30008000,
-
-        // UNUSED = 0x40004000,
-        // UNUSED = 0x40008000,
-        // UNUSED = 0x40010000,
-        // UNUSED = 0x40020000
-    };
-
     Settings( const Settings & ) = delete;
 
     Settings & operator=( const Settings & ) = delete;
@@ -237,10 +174,17 @@ public:
     bool isTextSupportModeEnabled() const;
     bool is3DAudioEnabled() const;
     bool isSystemInfoEnabled() const;
-    bool isAutoSaveAtBeginingOfTurnEnabled() const;
+    bool isAutoSaveAtBeginningOfTurnEnabled() const;
     bool isBattleShowDamageInfoEnabled() const;
     bool isHideInterfaceEnabled() const;
     bool isEvilInterfaceEnabled() const;
+
+    static bool isFadeEffectEnabled()
+    {
+        // TODO: fix fading effect for the original resolution (640 x 480) and enable back this option.
+        // return video_mode == fheroes2::Size( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
+        return false;
+    }
 
     bool LoadedGameVersion() const
     {
@@ -260,18 +204,6 @@ public:
 
     bool isFirstGameRun() const;
     void resetFirstGameRun();
-
-    bool CanChangeInGame( uint32_t ) const;
-    bool ExtModes( uint32_t ) const;
-    void ExtSetModes( uint32_t );
-    void ExtResetModes( uint32_t );
-
-    static bool ExtGameUseFade()
-    {
-        // TODO: fix fading effect for the original resolution (640 x 480) and enable back this option.
-        // return video_mode == fheroes2::Size( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
-        return false;
-    }
 
     const fheroes2::Size & VideoMode() const
     {
@@ -492,16 +424,8 @@ private:
 
     static void setDebug( int debug );
 
-    // Global game options (GLOBAL_), they are saved in the text config file
+    // Global game options (GLOBAL_)
     BitModes _optGlobal;
-    // Extended options that do not affect the overall game balance (GAME_),
-    // they are saved in the binary config file
-    BitModes _optExtGame;
-    // Extended options that affect the overall game balance, they are saved
-    // both in the binary config file and in the savefile
-    BitModes _optExtBalance2; // Options with codes starting with 0x2
-    BitModes _optExtBalance3; // Options with codes starting with 0x3
-    BitModes _optExtBalance4; // Options with codes starting with 0x4
 
     fheroes2::Size video_mode;
     int game_difficulty;


### PR DESCRIPTION
close #6161

This should be merged after #6239 and #6192/#6195, so we need to make a decision regarding the last two :)

This PR also adds a mechanism for storing window coordinates in "no interface" mode in `fheroes2.cfg`. `fheroes2.bin` is not needed anymore and may be removed.