### PR TITLE
Set the minimum supported version to Android 6.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -23,6 +23,13 @@ android {
         }
     }
 
+    compileOptions {
+        coreLibraryDesugaringEnabled true
+
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     externalNativeBuild {
         ndkBuild {
             path 'jni/Android.mk'
@@ -73,9 +80,10 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.0'
+
     implementation project(':sdl2')
-    // Versions 2.9.0+ do not work on devices with API level 23 (Android 6.0)
-    implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
 }
 
 task copyH2D(type: Copy) {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,7 +8,7 @@ android {
     defaultConfig {
         applicationId 'org.fheroes2'
 
-        minSdkVersion 19
+        minSdkVersion 23
         targetSdkVersion 31
 
         // These paths are set relative to the android project directory

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -74,6 +74,7 @@ android {
 
 dependencies {
     implementation project(':sdl2')
+    // Versions 2.9.0+ do not work on devices with API level 23 (Android 6.0)
     implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
 }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -74,7 +74,7 @@ android {
 
 dependencies {
     implementation project(':sdl2')
-    implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
 }
 
 task copyH2D(type: Copy) {


### PR DESCRIPTION
Related to #6008

* Apache commons-io 2.11.0 did not work with Android 6 due to the following error:

```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: org.fheroes2, PID: 8710
    java.lang.NoClassDefFoundError: org.apache.commons.io.IOUtils$$ExternalSyntheticLambda2
        at org.apache.commons.io.IOUtils.<clinit>(IOUtils.java:183)
        at org.fheroes2.MainActivity.extractAssets(MainActivity.java:86)
        at org.fheroes2.MainActivity.onCreate(MainActivity.java:40)
        at android.app.Activity.performCreate(Activity.java:6309)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1113)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2530)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2665)
        at android.app.ActivityThread.-wrap11(ActivityThread.java)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1499)
        at android.os.Handler.dispatchMessage(Handler.java:111)
        at android.os.Looper.loop(Looper.java:207)
        at android.app.ActivityThread.main(ActivityThread.java:5765)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:789)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:679)
```

The [proper desugaring](https://developer.android.com/studio/write/java8-support) was implemented to fix this issue.

* Set `minSdkVersion` to the lowest API level on which the application has been tested and 100% works - 23 (Android 6.0). Maybe it will work even on older versions, but I don't have such devices.

Native libraries are still built with minimum API level set to 19 (Android 4.4), it's the minimum API level supported by the latest NDK at the moment.
