### PR TITLE
Hexagon shading improvement (Battlefield)

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -499,7 +499,7 @@ fheroes2::Image DrawHexagon( const uint8_t colorId )
     return sf;
 }
 
-fheroes2::Image DrawHexagonShadow( const uint8_t alphaValue )
+fheroes2::Image DrawHexagonShadow( const uint8_t alphaValue, const uint8_t horizSpace )
 {
     const int l = 13;
     const int w = CELLW;
@@ -507,7 +507,7 @@ fheroes2::Image DrawHexagonShadow( const uint8_t alphaValue )
 
     fheroes2::Image sf( w, h );
     sf.reset();
-    fheroes2::Rect rt( 2, l - 1, w - 3, 2 * l + 4 );
+    fheroes2::Rect rt( horizSpace, l - 1, w + 1 - horizSpace * 2, h - l * 2 + 4 );
     for ( int i = 0; i < w / 2; i += 2 ) {
         for ( int x = 0; x < rt.width; ++x ) {
             for ( int y = 0; y < rt.height; ++y ) {
@@ -1098,8 +1098,12 @@ Battle::Interface::Interface( Arena & battleArena, const int32_t tileIndex )
 
     // hexagon
     sf_hexagon = DrawHexagon( fheroes2::GetColorId( 0x68, 0x8C, 0x04 ) );
-    sf_cursor = DrawHexagonShadow( 2 );
-    sf_shadow = DrawHexagonShadow( 4 );
+    // Shadow under the cursor: the first parameter is the shadow strength (smaller is stronger), the second is the distance between the hexagonal shadows.
+    sf_cursor = DrawHexagonShadow( 2, 1 );
+    // Hexagon shadow for the case when grid is disabled.
+    sf_shadow = DrawHexagonShadow( 4, 2 );
+    // Shadow that fits the hexagon grid.
+    sf_shadow_grid = DrawHexagonShadow( 4, 1 );
 
     btn_auto.setICNInfo( ICN::TEXTBAR, 4, 5 );
     btn_settings.setICNInfo( ICN::TEXTBAR, 6, 7 );
@@ -1908,7 +1912,12 @@ void Battle::Interface::RedrawCoverStatic( const Settings & conf, const Board & 
     if ( !_movingUnit && conf.BattleShowMoveShadow() && _currentUnit && !( _currentUnit->GetCurrentControl() & CONTROL_AI ) ) { // shadow
         for ( const Cell & cell : board ) {
             if ( cell.isReachableForHead() || cell.isReachableForTail() ) {
-                fheroes2::Blit( sf_shadow, _mainSurface, cell.GetPos().x, cell.GetPos().y );
+                if ( conf.BattleShowGrid() ) { // shadow for 'grid on'
+                    fheroes2::Blit( sf_shadow_grid, _mainSurface, cell.GetPos().x, cell.GetPos().y );
+                }
+                else {
+                    fheroes2::Blit( sf_shadow, _mainSurface, cell.GetPos().x, cell.GetPos().y );
+                }
             }
         }
     }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1912,7 +1912,8 @@ void Battle::Interface::RedrawCoverStatic( const Settings & conf, const Board & 
     if ( !_movingUnit && conf.BattleShowMoveShadow() && _currentUnit && !( _currentUnit->GetCurrentControl() & CONTROL_AI ) ) { // shadow
         for ( const Cell & cell : board ) {
             if ( cell.isReachableForHead() || cell.isReachableForTail() ) {
-                if ( conf.BattleShowGrid() ) { // shadow for 'grid on'
+                if ( conf.BattleShowGrid() ) {
+                    // When the grid is enabled in the settings - use the shadow that suits it.
                     fheroes2::Blit( sf_shadow_grid, _mainSurface, cell.GetPos().x, cell.GetPos().y );
                 }
                 else {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -499,7 +499,7 @@ fheroes2::Image DrawHexagon( const uint8_t colorId )
     return sf;
 }
 
-fheroes2::Image DrawHexagonShadow( const uint8_t alphaValue, const uint8_t horizSpace )
+fheroes2::Image DrawHexagonShadow( const uint8_t alphaValue, const int32_t horizSpace )
 {
     const int l = 13;
     const int w = CELLW;
@@ -1097,13 +1097,13 @@ Battle::Interface::Interface( Arena & battleArena, const int32_t tileIndex )
     }
 
     // hexagon
-    sf_hexagon = DrawHexagon( fheroes2::GetColorId( 0x68, 0x8C, 0x04 ) );
+    _hexagonGrid = DrawHexagon( fheroes2::GetColorId( 0x68, 0x8C, 0x04 ) );
     // Shadow under the cursor: the first parameter is the shadow strength (smaller is stronger), the second is the distance between the hexagonal shadows.
-    sf_cursor = DrawHexagonShadow( 2, 1 );
+    _hexagonCursorShadow = DrawHexagonShadow( 2, 1 );
     // Hexagon shadow for the case when grid is disabled.
-    sf_shadow = DrawHexagonShadow( 4, 2 );
+    _hexagonShadow = DrawHexagonShadow( 4, 2 );
     // Shadow that fits the hexagon grid.
-    sf_shadow_grid = DrawHexagonShadow( 4, 1 );
+    _hexagonGridShadow = DrawHexagonShadow( 4, 1 );
 
     btn_auto.setICNInfo( ICN::TEXTBAR, 4, 5 );
     btn_settings.setICNInfo( ICN::TEXTBAR, 6, 7 );
@@ -1830,7 +1830,7 @@ void Battle::Interface::RedrawCover()
             }
 
             if ( isApplicable ) {
-                fheroes2::Blit( sf_cursor, _mainSurface, highlightCell->GetPos().x, highlightCell->GetPos().y );
+                fheroes2::Blit( _hexagonCursorShadow, _mainSurface, highlightCell->GetPos().x, highlightCell->GetPos().y );
             }
         }
     }
@@ -1892,9 +1892,11 @@ void Battle::Interface::RedrawCoverStatic( const Settings & conf, const Board & 
         }
     }
 
-    if ( conf.BattleShowGrid() ) { // grid
+    const bool isGridEnabled = conf.BattleShowGrid();
+
+    if ( isGridEnabled ) { // grid
         for ( const Cell & cell : board ) {
-            fheroes2::Blit( sf_hexagon, _mainSurface, cell.GetPos().x, cell.GetPos().y );
+            fheroes2::Blit( _hexagonGrid, _mainSurface, cell.GetPos().x, cell.GetPos().y );
         }
     }
 
@@ -1910,15 +1912,10 @@ void Battle::Interface::RedrawCoverStatic( const Settings & conf, const Board & 
     }
 
     if ( !_movingUnit && conf.BattleShowMoveShadow() && _currentUnit && !( _currentUnit->GetCurrentControl() & CONTROL_AI ) ) { // shadow
+        const fheroes2::Image & shadowImage = isGridEnabled ? _hexagonGridShadow : _hexagonShadow;
         for ( const Cell & cell : board ) {
             if ( cell.isReachableForHead() || cell.isReachableForTail() ) {
-                if ( conf.BattleShowGrid() ) {
-                    // When the grid is enabled in the settings - use the shadow that suits it.
-                    fheroes2::Blit( sf_shadow_grid, _mainSurface, cell.GetPos().x, cell.GetPos().y );
-                }
-                else {
-                    fheroes2::Blit( sf_shadow, _mainSurface, cell.GetPos().x, cell.GetPos().y );
-                }
+                fheroes2::Blit( shadowImage, _mainSurface, cell.GetPos().x, cell.GetPos().y );
             }
         }
     }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -507,7 +507,7 @@ fheroes2::Image DrawHexagonShadow( const uint8_t alphaValue, const uint8_t horiz
 
     fheroes2::Image sf( w, h );
     sf.reset();
-    fheroes2::Rect rt( horizSpace, l - 1, w + 1 - horizSpace * 2, h - l * 2 + 4 );
+    fheroes2::Rect rt( horizSpace, l - 1, w + 1 - horizSpace * 2, 2 * l + 4 );
     for ( int i = 0; i < w / 2; i += 2 ) {
         for ( int x = 0; x < rt.width; ++x ) {
             for ( int y = 0; y < rt.height; ++y ) {

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -371,10 +371,10 @@ namespace Battle
         fheroes2::Rect _interfacePosition;
         fheroes2::Rect _surfaceInnerArea;
         fheroes2::Image _mainSurface;
-        fheroes2::Image sf_hexagon;
-        fheroes2::Image sf_shadow;
-        fheroes2::Image sf_shadow_grid;
-        fheroes2::Image sf_cursor;
+        fheroes2::Image _hexagonGrid;
+        fheroes2::Image _hexagonShadow;
+        fheroes2::Image _hexagonGridShadow;
+        fheroes2::Image _hexagonCursorShadow;
 
         int icn_cbkg;
         int icn_frng;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -373,6 +373,7 @@ namespace Battle
         fheroes2::Image _mainSurface;
         fheroes2::Image sf_hexagon;
         fheroes2::Image sf_shadow;
+        fheroes2::Image sf_shadow_grid;
         fheroes2::Image sf_cursor;
 
         int icn_cbkg;


### PR DESCRIPTION
In addition to #6216: made generation of two hexagon shadows.
- shadow that fits the grid
![изображение](https://user-images.githubusercontent.com/113276641/204610466-e0c601a7-1b4a-422a-8236-565815f65f3a.png)

-  shadow with 3px space between hexagons for use without grid
![изображение](https://user-images.githubusercontent.com/113276641/204610599-6fcc40f8-cedc-44a2-819f-2d36fac9e88c.png)

(Cursor shadow size is set to fit the grid.)