### PR TITLE
Use explicit shell: bash in GitHub Actions scripts

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,6 +18,9 @@ jobs:
     name: Android
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies

--- a/.github/workflows/clang_analyzer.yml
+++ b/.github/workflows/clang_analyzer.yml
@@ -8,6 +8,9 @@ jobs:
     name: Clang Analyzer
     runs-on: ubuntu-22.04
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies and clang-tools

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -14,6 +14,9 @@ jobs:
     name: Clang-Tidy
     runs-on: ubuntu-22.04
     timeout-minutes: 60
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -37,7 +37,6 @@ jobs:
         mkdir clang-tidy-result
     - name: Analyze
       run: |
-        set -o pipefail
         git diff -U0 HEAD^ | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
     - name: Save PR metadata
       run: |

--- a/.github/workflows/clang_tidy_comments.yml
+++ b/.github/workflows/clang_tidy_comments.yml
@@ -8,12 +8,12 @@ on:
 jobs:
   comment:
     name: Clang-Tidy comments
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
       run:
         shell: bash
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Download analysis results
       uses: actions/github-script@v6

--- a/.github/workflows/clang_tidy_comments.yml
+++ b/.github/workflows/clang_tidy_comments.yml
@@ -10,6 +10,9 @@ jobs:
     name: Clang-Tidy comments
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Download analysis results

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,6 +35,9 @@ jobs:
     name: CMake (${{ matrix.config.name }})
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies (Linux)

--- a/.github/workflows/code_style_check.yml
+++ b/.github/workflows/code_style_check.yml
@@ -8,6 +8,9 @@ jobs:
     name: Code style check
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -8,6 +8,9 @@ jobs:
     name: IWYU
     runs-on: ubuntu-22.04
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies and iwyu

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -22,7 +22,6 @@ jobs:
         cmake -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT_COMPILATION=ON -DENABLE_IMAGE=ON -DENABLE_TOOLS=ON -DUSE_SDL_VERSION=SDL2 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     - name: Analyze
       run: |
-        set -o pipefail
         iwyu_tool -p build -j 2 -- -Xiwyu --cxx17ns -Xiwyu --mapping_file="$GITHUB_WORKSPACE/iwyu.map" | (grep -E -v "^$|has correct #includes/fwd-decls" || true) \
                                                                                                        | tee iwyu-result.txt
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -59,6 +59,9 @@ jobs:
     name: Make (${{ matrix.config.name }})
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies (Linux)
@@ -107,6 +110,9 @@ jobs:
     name: Make (PS Vita)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies
@@ -176,8 +182,11 @@ jobs:
   make-switch:
     name: Make (Nintendo Switch)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     container: devkitpro/devkita64:latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -64,7 +64,7 @@ jobs:
         MSBuild.exe bin2txt-vs2019.vcxproj /property:Platform=${{ matrix.config.platform }} /property:Configuration=${{ matrix.config.build_config }}
     - name: Generate translations
       run: |
-        C:\tools\cygwin\bin\bash.exe -l -c ^"cd ""$GITHUB_WORKSPACE"" ^&^& make -C files/lang -j 2^"
+        C:\tools\cygwin\bin\bash.exe -l -eo pipefail -c ^"cd ""$GITHUB_WORKSPACE""; make -C files/lang -j 2^"
       shell: cmd
     - name: Create Inno Setup package
       run: |

--- a/.github/workflows/pr_author_auto_assign.yml
+++ b/.github/workflows/pr_author_auto_assign.yml
@@ -9,6 +9,9 @@ jobs:
     name: PR author auto assign
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: toshimaru/auto-author-assign@v1.6.1
       with:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,12 +12,12 @@ env:
 jobs:
   sonarcloud:
     name: SonarCloud Analyzer
+    if: ${{ github.repository == 'ihhub/fheroes2' && ( github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) ) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
       run:
         shell: bash
-    if: ${{ github.repository == 'ihhub/fheroes2' && ( github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) ) }}
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -14,6 +14,9 @@ jobs:
     name: SonarCloud Analyzer
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
     if: ${{ github.repository == 'ihhub/fheroes2' && ( github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) ) }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -6,12 +6,12 @@ on:
 jobs:
   translation:
     name: Translation update
+    if: ${{ github.repository == 'ihhub/fheroes2' && ( github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) ) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
       run:
         shell: bash
-    if: ${{ github.repository == 'ihhub/fheroes2' && ( github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) ) }}
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -35,7 +35,6 @@ jobs:
         make -C files/lang -j 2 merge
     - name: Commit changes
       run: |
-        set -o pipefail
         git diff --name-only -z -- files/lang/*.po \
         | xargs -r0 bash -c 'set -e; for NAME in "$@"; do if [[ "$(git diff "-I^\"POT-Creation-Date:[^\"]*\"$" -- "$NAME")" != "" ]]; then git add -- "$NAME"; fi; done' dummy
         if git commit -m "Update translation files"; then git push origin HEAD; echo "CREATE_PR=YES" >> "$GITHUB_ENV"; fi

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -8,6 +8,9 @@ jobs:
     name: Translation update
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
     if: ${{ github.repository == 'ihhub/fheroes2' && ( github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) ) }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The reason for this change is as follows: while `bash` is in fact used on *nix OS images if shell is not specified, it is [used with relaxed parameters ](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell)that doesn't include `-o pipefail`. I was forced to add `set -o pipefail` in place, which is actually unreliable and may be overlooked or forgotten.