### PR TITLE
Improve rendering speed with software cursor rendering

### DIFF
--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -382,7 +382,7 @@ namespace
 
         double getCurrentTrackPosition() const
         {
-            return _currentTrackTimer.get();
+            return _currentTrackTimer.getS();
         }
 
         void updateCurrentTrack( const uint64_t musicUID, const Music::PlaybackMode trackPlaybackMode )

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1257,6 +1257,7 @@ bool LocalEvent::HandleEvents( const bool sleepAfterEventProcessing, bool allowE
             break;
         case SDL_RENDER_DEVICE_RESET:
             HandleRenderDeviceResetEvent();
+            renderRoi = { 0, 0, display.width(), display.height() };
             break;
         case SDL_TEXTINPUT:
             // Keyboard events on Android should be processed here. Use event.text.text to extract text input.

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1658,11 +1658,7 @@ bool LocalEvent::HandleWindowEvent( const SDL_WindowEvent & event )
         return true;
     }
 
-    if ( event.event == SDL_WINDOWEVENT_RESIZED ) {
-        return true;
-    }
-
-    return false;
+    return ( event.event == SDL_WINDOWEVENT_RESIZED );
 }
 
 void LocalEvent::HandleRenderDeviceResetEvent()

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1165,11 +1165,13 @@ LocalEvent & LocalEvent::GetClean()
 bool LocalEvent::HandleEvents( const bool sleepAfterEventProcessing, bool allowExit )
 {
     // Event processing might be computationally heavy.
-    // We want to make sure that we do not slow down the same by going into sleep mode when it is not needed.
+    // We want to make sure that we do not slow down by going into sleep mode when it is not needed.
     const fheroes2::Time eventProcessingTimer;
 
-    // We can have more than one event which requires rendering. We must render only once.
+    // We can have more than one event which requires rendering. We must render only once and only when sleeping is excepted.
     fheroes2::Rect renderRoi;
+
+    // Mouse area must be updated only once so we will use only the latest area for rendering.
     _mouseCursorRenderArea = {};
 
     fheroes2::Display & display = fheroes2::Display::instance();

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1594,7 +1594,7 @@ void LocalEvent::HandleControllerButtonEvent( const SDL_ControllerButtonEvent & 
 
 void LocalEvent::ProcessControllerAxisMotion()
 {
-    const double deltaTime = _controllerTimer.get() * 1000.0;
+    const double deltaTime = _controllerTimer.getS() * 1000.0;
     _controllerTimer.reset();
 
     if ( _controllerLeftXAxis != 0 || _controllerLeftYAxis != 0 ) {

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -55,8 +55,6 @@
 #include "pal.h"
 #include "screen.h"
 
-#include "logging.h"
-
 namespace
 {
     const uint32_t globalLoopSleepTime{ 1 };

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1162,7 +1162,7 @@ LocalEvent & LocalEvent::GetClean()
     return le;
 }
 
-bool LocalEvent::HandleEvents( const bool sleepAfterEventProcessing, bool allowExit )
+bool LocalEvent::HandleEvents( const bool sleepAfterEventProcessing, const bool allowExit /* = false */ )
 {
     // Event processing might be computationally heavy.
     // We want to make sure that we do not slow down by going into sleep mode when it is not needed.
@@ -1332,6 +1332,7 @@ bool LocalEvent::HandleEvents( const bool sleepAfterEventProcessing, bool allowE
 
         // Make sure not to delay any further if the processing time within this function was more than the expected waiting time.
         if ( eventProcessingTimer.getMs() < globalLoopSleepTime ) {
+            static_assert( globalLoopSleepTime == 1, "Make sure that you sleep for the difference between times since you change the sleep time." );
             SDL_Delay( globalLoopSleepTime );
         }
     }
@@ -1654,7 +1655,6 @@ bool LocalEvent::HandleWindowEvent( const SDL_WindowEvent & event )
 
     if ( event.event == SDL_WINDOWEVENT_FOCUS_GAINED ) {
         ResumeSounds();
-
         return true;
     }
 

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -196,7 +196,7 @@ public:
 
     static void setEventProcessingStates();
 
-    bool HandleEvents( const bool sleepAfterEventProcessing = true, bool allowExit = false );
+    bool HandleEvents( const bool sleepAfterEventProcessing = true, const bool allowExit = false );
 
     bool MouseMotion() const
     {
@@ -380,7 +380,6 @@ private:
     fheroes2::Point mouse_wm; // wheel movement
 
     std::function<fheroes2::Rect( const int32_t, const int32_t )> _globalMouseMotionEventHook;
-
     std::function<void( const fheroes2::Key, const int32_t )> _globalKeyDownEventHook;
 
     fheroes2::Rect _mouseCursorRenderArea;

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -196,7 +196,7 @@ public:
 
     static void setEventProcessingStates();
 
-    bool HandleEvents( bool delay = true, bool allowExit = false );
+    bool HandleEvents( bool sleepAfterEventProcessing = true, bool allowExit = false );
 
     bool MouseMotion() const
     {
@@ -374,8 +374,6 @@ private:
     void ( *mouse_motion_hook_func )( int32_t, int32_t );
 
     std::function<void( const fheroes2::Key, const int32_t )> _globalKeyDownEventHook;
-
-    uint32_t loop_delay;
 
     enum
     {

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -184,9 +184,9 @@ public:
     static LocalEvent & Get();
     static LocalEvent & GetClean(); // reset all previous event statuses and return a reference for events
 
-    void SetMouseMotionGlobalHook( void ( *pf )( int32_t, int32_t ) )
+    void setGlobalMouseMotionEventHook( std::function<fheroes2::Rect( const int32_t, const int32_t )> hook )
     {
-        mouse_motion_hook_func = pf;
+        _globalMouseMotionEventHook = std::move( hook );
     }
 
     void setGlobalKeyDownEventHook( std::function<void( const fheroes2::Key, const int32_t )> hook )
@@ -196,7 +196,7 @@ public:
 
     static void setEventProcessingStates();
 
-    bool HandleEvents( bool sleepAfterEventProcessing = true, bool allowExit = false );
+    bool HandleEvents( const bool sleepAfterEventProcessing = true, bool allowExit = false );
 
     bool MouseMotion() const
     {
@@ -326,12 +326,14 @@ private:
     void HandleControllerButtonEvent( const SDL_ControllerButtonEvent & button );
     void HandleTouchEvent( const SDL_TouchFingerEvent & event );
 
-    static void HandleWindowEvent( const SDL_WindowEvent & event );
+    // Returns true if frame rendering is required.
+    static bool HandleWindowEvent( const SDL_WindowEvent & event );
     static void HandleRenderDeviceResetEvent();
 
     void ProcessControllerAxisMotion();
 #else
-    static void HandleActiveEvent( const SDL_ActiveEvent & event );
+    // Returns true if frame rendering is required.
+    static bool HandleActiveEvent( const SDL_ActiveEvent & event );
 #endif
 
     enum flag_t
@@ -343,6 +345,12 @@ private:
         MOUSE_CLICKED = 0x0010, // mouse button has been clicked
         MOUSE_WHEEL = 0x0020, // mouse wheel has been rotated
         KEY_HOLD = 0x0040 // key on the keyboard is currently being held down
+    };
+
+    enum
+    {
+        CONTROLLER_L_DEADZONE = 4000,
+        CONTROLLER_R_DEADZONE = 25000
     };
 
     void SetModes( flag_t f )
@@ -371,15 +379,11 @@ private:
 
     fheroes2::Point mouse_wm; // wheel movement
 
-    void ( *mouse_motion_hook_func )( int32_t, int32_t );
+    std::function<fheroes2::Rect( const int32_t, const int32_t )> _globalMouseMotionEventHook;
 
     std::function<void( const fheroes2::Key, const int32_t )> _globalKeyDownEventHook;
 
-    enum
-    {
-        CONTROLLER_L_DEADZONE = 4000,
-        CONTROLLER_R_DEADZONE = 25000
-    };
+    fheroes2::Rect _mouseCursorRenderArea;
 
     // used to convert user-friendly pointer speed values into more useable ones
     const double CONTROLLER_SPEED_MOD = 2000000.0;

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1522,6 +1522,11 @@ namespace fheroes2
         _prevRoi = temp;
     }
 
+    void Display::updateNextRenderRoi( const Rect & roi )
+    {
+        _prevRoi = getBoundaryRect( _prevRoi, roi );
+    }
+
     void Display::_renderFrame( const Rect & roi ) const
     {
         bool updateImage = true;

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -143,6 +143,8 @@ namespace fheroes2
 
         void render( const Rect & roi ); // render a part of image on screen. Prefer this method over full image if you don't draw full screen.
 
+        void updateNextRenderRoi( const Rect & roi );
+
         void resize( int32_t width_, int32_t height_ ) override;
 
         bool isDefaultSize() const

--- a/src/engine/timing.cpp
+++ b/src/engine/timing.cpp
@@ -33,7 +33,7 @@ namespace fheroes2
         _startTime = std::chrono::steady_clock::now();
     }
 
-    double Time::get() const
+    double Time::getS() const
     {
         const std::chrono::duration<double> time = std::chrono::steady_clock::now() - _startTime;
         return time.count();
@@ -41,7 +41,8 @@ namespace fheroes2
 
     uint64_t Time::getMs() const
     {
-        return static_cast<uint64_t>( get() * 1000 + 0.5 );
+        const auto time = std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::steady_clock::now() - _startTime );
+        return time.count();
     }
 
     TimeDelay::TimeDelay( const uint64_t delayMs )

--- a/src/engine/timing.h
+++ b/src/engine/timing.h
@@ -36,7 +36,7 @@ namespace fheroes2
         void reset();
 
         // Returns time in seconds.
-        double get() const;
+        double getS() const;
 
         // Returns rounded time in milliseconds.
         uint64_t getMs() const;

--- a/src/engine/timing.h
+++ b/src/engine/timing.h
@@ -34,8 +34,12 @@ namespace fheroes2
         Time();
 
         void reset();
-        double get() const; // returns time in seconds
-        uint64_t getMs() const; // returns rounded time in milliseconds
+
+        // Returns time in seconds.
+        double get() const;
+
+        // Returns rounded time in milliseconds.
+        uint64_t getMs() const;
 
     private:
         std::chrono::time_point<std::chrono::steady_clock> _startTime;

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -368,6 +368,14 @@ namespace fheroes2
 
     Rect getBoundaryRect( const Rect & rt1, const Rect & rt2 )
     {
+        if ( rt2.width == 0 && rt2.height == 0 ) {
+            return rt1;
+        }
+
+        if ( rt1.width == 0 && rt1.height == 0 ) {
+            return rt2;
+        }
+
         const int32_t x = std::min( rt1.x, rt2.x );
         const int32_t y = std::min( rt1.y, rt2.y );
         const int32_t width = std::max( rt1.x + rt1.width, rt2.x + rt2.width ) - x;

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -207,7 +207,7 @@ void Game::Init()
 {
     // set global events
     LocalEvent & le = LocalEvent::Get();
-    le.SetMouseMotionGlobalHook( Cursor::Redraw );
+    le.setGlobalMouseMotionEventHook( Cursor::updateCursorPosition );
     le.setGlobalKeyDownEventHook( Game::globalKeyDownEvent );
 
     Game::AnimateDelaysInitialize();

--- a/src/fheroes2/gui/cursor.cpp
+++ b/src/fheroes2/gui/cursor.cpp
@@ -95,14 +95,16 @@ void Cursor::setCustomImage( const fheroes2::Image & image, const fheroes2::Poin
     Move( currentPos.x, currentPos.y );
 }
 
-void Cursor::Redraw( int32_t x, int32_t y )
+fheroes2::Rect Cursor::updateCursorPosition( const int32_t x, const int32_t y )
 {
     if ( fheroes2::cursor().isSoftwareEmulation() ) {
         Cursor::Get().Move( x, y );
         if ( fheroes2::cursor().isVisible() ) {
-            fheroes2::Display::instance().render( { x, y, 1, 1 } );
+            return { x, y, 1, 1 };
         }
     }
+
+    return {};
 }
 
 void Cursor::Move( int32_t x, int32_t y ) const

--- a/src/fheroes2/gui/cursor.h
+++ b/src/fheroes2/gui/cursor.h
@@ -178,7 +178,9 @@ public:
 
     static Cursor & Get();
 
-    static void Redraw( int32_t, int32_t );
+    // Returns a non-empty area if it should be updated while rendering.
+    static fheroes2::Rect updateCursorPosition( const int32_t x, const int32_t y );
+
     static int DistanceThemes( const int theme, uint32_t distance );
     static int WithoutDistanceThemes( const int theme );
     static void Refresh();


### PR DESCRIPTION
In the global event loop we have 2 sources of performance drops:
- sleep event which is executed if no immediate return from events is required and no color cycling event occurs
- call of rendering when mouse or touchscreen position changes with cursor software rendering option being on. Mouse and touchscreen events can occur multiple times per single global event loop function call.

These 2 places connect to each other leading to obvious slowdowns with enabled V-Sync option. The correct way is to check whether sleeping is allowed. If it is not then we shouldn't render within the global event loop but only update rendering area for the upcoming rendering event outside the loop. If there is a time to sleep we should render only once.

close #6252