### PR TITLE
Update the dependency package hashes for Android & Windows

### DIFF
--- a/script/android/install_packages.bat
+++ b/script/android/install_packages.bat
@@ -3,7 +3,7 @@
 set DST_DIR=%~dp0\..\..\android
 
 set PKG_FILE=android.zip
-set PKG_FILE_SHA256=F33350ACC50D23D4C7A7D8C34ED57FB0198F27861E1F7FCC70542868A92EEE6F
+set PKG_FILE_SHA256=7FDFBFFBE6F97F0ADCE25DBFD638D43BE672B6811BDD289D33DDCE412D45971F
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 

--- a/script/android/install_packages.sh
+++ b/script/android/install_packages.sh
@@ -3,7 +3,7 @@
 set -e
 
 PKG_FILE="android.zip"
-PKG_FILE_SHA256="f33350acc50d23d4c7a7d8c34ed57fb0198f27861e1f7fcc70542868a92eee6f"
+PKG_FILE_SHA256="7fdfbffbe6f97f0adce25dbfd638d43be672b6811bdd289d33ddce412d45971f"
 PKG_URL="https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/$PKG_FILE"
 
 TMP_DIR="$(mktemp -d)"

--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -3,7 +3,7 @@
 set DST_DIR=%~dp0\..\..\VisualStudio\packages
 
 set PKG_FILE=windows.zip
-set PKG_FILE_SHA256=139382B653B2C38A7D523184ADA2C651AE79D6D692A2673FDBFCF1D4098FBF54
+set PKG_FILE_SHA256=D51FB5385E03254E33DCC09CB9AC02ED68DE370994EF3B76F3615923B5381480
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/windows-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 


### PR DESCRIPTION
Update details: https://github.com/fheroes2/fheroes2-prebuilt-deps/pull/23. Nothing critical, no updates for libs - I'll delay them until the 1.0 will be released.