### PR TITLE
Add Danish language option and font

### DIFF
--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -4306,6 +4306,7 @@ namespace fheroes2
         case SupportedLanguage::Ukrainian:
             generateCP1251Alphabet( icnVsSprite );
             break;
+        case SupportedLanguage::Danish:
         case SupportedLanguage::Dutch:
         case SupportedLanguage::German:
         case SupportedLanguage::Italian:
@@ -4359,6 +4360,7 @@ namespace fheroes2
         case SupportedLanguage::Dutch:
         case SupportedLanguage::Hungarian:
         case SupportedLanguage::Czech:
+        case SupportedLanguage::Danish:
             return true;
         default:
             break;
@@ -4395,6 +4397,7 @@ namespace fheroes2
         case SupportedLanguage::Ukrainian:
             generateCP1251GoodButtonFont( icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED] );
             break;
+        case SupportedLanguage::Danish:
         case SupportedLanguage::Dutch:
         case SupportedLanguage::French:
         case SupportedLanguage::German:

--- a/src/fheroes2/gui/ui_language.cpp
+++ b/src/fheroes2/gui/ui_language.cpp
@@ -63,7 +63,8 @@ namespace
             { "tr", fheroes2::SupportedLanguage::Turkish },    { "turkish", fheroes2::SupportedLanguage::Turkish },
             { "ro", fheroes2::SupportedLanguage::Romanian },   { "romanian", fheroes2::SupportedLanguage::Romanian },
             { "nl", fheroes2::SupportedLanguage::Dutch },      { "dutch", fheroes2::SupportedLanguage::Dutch },
-            { "hu", fheroes2::SupportedLanguage::Hungarian },  { "hungarian", fheroes2::SupportedLanguage::Hungarian } };
+            { "hu", fheroes2::SupportedLanguage::Hungarian },  { "hungarian", fheroes2::SupportedLanguage::Hungarian },
+            { "da", fheroes2::SupportedLanguage::Danish },     { "danish", fheroes2::SupportedLanguage::Danish } };
 }
 
 namespace fheroes2
@@ -111,7 +112,7 @@ namespace fheroes2
                                                              SupportedLanguage::Belarusian, SupportedLanguage::Bulgarian, SupportedLanguage::Ukrainian,
                                                              SupportedLanguage::Romanian,   SupportedLanguage::Spanish,   SupportedLanguage::Portuguese,
                                                              SupportedLanguage::Swedish,    SupportedLanguage::Turkish,   SupportedLanguage::Dutch,
-                                                             SupportedLanguage::Hungarian,  SupportedLanguage::Czech };
+                                                             SupportedLanguage::Hungarian,  SupportedLanguage::Czech,     SupportedLanguage::Danish };
 
         for ( const SupportedLanguage language : possibleLanguages ) {
             if ( language != resourceLanguage && isAlphabetSupported( language ) ) {
@@ -177,6 +178,8 @@ namespace fheroes2
             return _( "Dutch" );
         case SupportedLanguage::Hungarian:
             return _( "Hungarian" );
+        case SupportedLanguage::Danish:
+            return _( "Hungarian" );
         default:
             // Did you add a new language? Please add the code to handle it.
             assert( 0 );
@@ -223,6 +226,8 @@ namespace fheroes2
             return "nl";
         case SupportedLanguage::Hungarian:
             return "hu";
+        case SupportedLanguage::Danish:
+            return "da";
         default:
             // Did you add a new language? Please add the code to handle it.
             assert( 0 );

--- a/src/fheroes2/gui/ui_language.cpp
+++ b/src/fheroes2/gui/ui_language.cpp
@@ -179,7 +179,7 @@ namespace fheroes2
         case SupportedLanguage::Hungarian:
             return _( "Hungarian" );
         case SupportedLanguage::Danish:
-            return _( "Hungarian" );
+            return _( "Danish" );
         default:
             // Did you add a new language? Please add the code to handle it.
             assert( 0 );

--- a/src/fheroes2/gui/ui_language.h
+++ b/src/fheroes2/gui/ui_language.h
@@ -38,6 +38,7 @@ namespace fheroes2
         // All languages listed below are original to fheroes2.
         Belarusian,
         Bulgarian,
+        Danish,
         Dutch,
         Hungarian,
         Norwegian,


### PR DESCRIPTION
This adds Danish as an option and includes it in the CP1252 font.

Relates to https://github.com/ihhub/fheroes2/pull/6237