### PR TITLE
MSVC: do not define _DEBUG by hand

### DIFF
--- a/VisualStudio/Debug.props
+++ b/VisualStudio/Debug.props
@@ -7,7 +7,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
-      <PreprocessorDefinitions>WITH_DEBUG;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WITH_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
Follow-up to #6267

There is no need to define `_DEBUG` by hand because it's [automatically defined](https://learn.microsoft.com/en-us/cpp/c-runtime-library/debug?view=msvc-170) when we set the `RuntimeLibrary` to any of the debug versions, which is what we are doing one line above.